### PR TITLE
feat: enable per-workspace model selection

### DIFF
--- a/src/constants/ipc-constants.ts
+++ b/src/constants/ipc-constants.ts
@@ -24,6 +24,7 @@ export const IPC_CHANNELS = {
   WORKSPACE_CLEAR_HISTORY: "workspace:clearHistory",
   WORKSPACE_STREAM_HISTORY: "workspace:streamHistory",
   WORKSPACE_GET_INFO: "workspace:getInfo",
+  WORKSPACE_SET_MODEL: "workspace:setModel",
 
   // Dynamic channel prefixes
   WORKSPACE_CHAT_PREFIX: "workspace:chat:",

--- a/src/constants/models.ts
+++ b/src/constants/models.ts
@@ -1,0 +1,20 @@
+export const DEFAULT_MODEL = "anthropic:claude-opus-4-1" as const;
+
+export const MODEL_ALIAS_MAP = {
+  opus: DEFAULT_MODEL,
+  sonnet: "anthropic:claude-sonnet-4",
+} as const;
+
+export type ModelAlias = keyof typeof MODEL_ALIAS_MAP;
+
+export function resolveModelAlias(input: string): string | undefined {
+  const normalized = input.trim().toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  return MODEL_ALIAS_MAP[normalized as ModelAlias];
+}
+
+export function getModelAliasEntries(): Array<{ alias: string; model: string }> {
+  return Object.entries(MODEL_ALIAS_MAP).map(([alias, model]) => ({ alias, model }));
+}

--- a/src/debug/costs.ts
+++ b/src/debug/costs.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import { getSessionDir } from "../config";
 import { CmuxMessage } from "../types/message";
 import { calculateTokenStats } from "../utils/tokenStatsCalculator";
+import { DEFAULT_MODEL } from "../constants/models";
 
 /**
  * Debug command to display cost/token statistics for a workspace
@@ -34,7 +35,7 @@ export async function costsCommand(workspaceId: string) {
 
   // Detect model from first assistant message
   const firstAssistantMessage = messages.find((msg) => msg.role === "assistant");
-  const model = firstAssistantMessage?.metadata?.model || "anthropic:claude-opus-4-1";
+  const model = firstAssistantMessage?.metadata?.model || DEFAULT_MODEL;
 
   // Calculate stats using shared logic
   const stats = await calculateTokenStats(messages, model);

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -53,6 +53,8 @@ const api: IPCApi = {
     clearHistory: (workspaceId) =>
       ipcRenderer.invoke(IPC_CHANNELS.WORKSPACE_CLEAR_HISTORY, workspaceId),
     getInfo: (workspaceId) => ipcRenderer.invoke(IPC_CHANNELS.WORKSPACE_GET_INFO, workspaceId),
+    setModel: (workspaceId, model) =>
+      ipcRenderer.invoke(IPC_CHANNELS.WORKSPACE_SET_MODEL, workspaceId, model),
 
     onChat: (workspaceId, callback) => {
       const channel = getChatChannel(workspaceId);

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -2,7 +2,8 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { EventEmitter } from "events";
 import { convertToModelMessages, type LanguageModel } from "ai";
-import { createAnthropic } from "@ai-sdk/anthropic";
+import { createOpenAI } from "@ai-sdk/openai";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { Result, Ok, Err } from "../types/result";
 import { WorkspaceMetadata, WorkspaceMetadataSchema } from "../types/workspace";
 import { CmuxMessage, createCmuxMessage } from "../types/message";
@@ -22,13 +23,15 @@ import { buildSystemMessage } from "./systemMessage";
 import { getTokenizerForModel } from "../utils/tokenizer";
 import { buildProviderOptions } from "../utils/providerOptions";
 import { ThinkingLevel } from "../types/thinking";
+import { DEFAULT_MODEL } from "../constants/models";
+import { getProviderAdapter } from "./providerAdapters";
 
 // Export a standalone version of getToolsForModel for use in backend
 
 export class AIService extends EventEmitter {
   private readonly METADATA_FILE = "metadata.json";
   private streamManager = new StreamManager();
-  private defaultModel = "anthropic:claude-opus-4-1"; // Default model string
+  private readonly defaultModel = DEFAULT_MODEL; // Default model string
   private historyService: HistoryService;
 
   constructor(historyService: HistoryService) {
@@ -36,6 +39,10 @@ export class AIService extends EventEmitter {
     this.historyService = historyService;
     this.ensureSessionsDir();
     this.setupStreamEventForwarding();
+  }
+
+  getDefaultModel(): string {
+    return this.defaultModel;
   }
 
   /**
@@ -106,6 +113,25 @@ export class AIService extends EventEmitter {
     }
   }
 
+  async setWorkspaceModel(workspaceId: string, model: string): Promise<Result<void>> {
+    const metadataResult = await this.getWorkspaceMetadata(workspaceId);
+    if (!metadataResult.success) {
+      return Err(metadataResult.error);
+    }
+
+    const normalizedModel = model.trim();
+    if (!normalizedModel) {
+      return Err("Model cannot be empty");
+    }
+
+    const updatedMetadata: WorkspaceMetadata = {
+      ...metadataResult.data,
+      model: normalizedModel,
+    };
+
+    return this.saveWorkspaceMetadata(workspaceId, updatedMetadata);
+  }
+
   /**
    * Split assistant messages that have text after tool calls with results.
 
@@ -134,37 +160,23 @@ export class AIService extends EventEmitter {
 
       // Load providers configuration - the ONLY source of truth
       const providersConfig = loadProvidersConfig();
-      const providerConfig = providersConfig?.[providerName];
+      const adapter = getProviderAdapter(providerName);
 
-      if (!providerConfig) {
+      if (!adapter) {
         return Err({
           type: "provider_not_configured",
           provider: providerName,
         });
       }
 
-      // Handle Anthropic provider
-      if (providerName === "anthropic") {
-        // Check for API key in config
-        if (!providerConfig.apiKey) {
-          return Err({
-            type: "api_key_not_found",
-            provider: providerName,
-          });
-        }
-
-        // Pass configuration verbatim to the provider, ensuring parity with Vercel AI SDK
-        const provider = createAnthropic(providerConfig);
-        return Ok(provider(modelId));
+      const validation = adapter.validate(providerName, providersConfig?.[providerName]);
+      if (!validation.success) {
+        return Err(validation.error);
       }
 
-      // Add support for other providers here in the future
-      // if (providerName === "openai") { ... }
-
-      return Err({
-        type: "provider_not_configured",
-        provider: providerName,
-      });
+      const providerConfig = validation.data;
+      const provider = adapter.instantiate(providerConfig, modelId);
+      return Ok(provider);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       return Err({ type: "unknown", raw: `Failed to create model: ${errorMessage}` });
@@ -186,8 +198,17 @@ export class AIService extends EventEmitter {
     abortSignal?: AbortSignal
   ): Promise<Result<void, SendMessageError>> {
     try {
+      const metadataResult = await this.getWorkspaceMetadata(workspaceId);
+      if (!metadataResult.success) {
+        return Err({ type: "unknown", raw: metadataResult.error });
+      }
+
+      const workspaceMetadata = metadataResult.data;
+      const configuredModel = workspaceMetadata.model?.trim();
+      const modelString = configuredModel && configuredModel.length > 0 ? configuredModel : this.defaultModel;
+
       // Create model instance with early API key validation
-      const modelResult = await this.createModel(this.defaultModel);
+      const modelResult = await this.createModel(modelString);
       if (!modelResult.success) {
         return Err(modelResult.error);
       }
@@ -204,7 +225,7 @@ export class AIService extends EventEmitter {
       const transformedMessages = transformModelMessages(modelMessages);
 
       // Apply cache control for Anthropic models AFTER transformation
-      const finalMessages = applyCacheControl(transformedMessages, this.defaultModel);
+      const finalMessages = applyCacheControl(transformedMessages, modelString);
 
       log.debug_obj(`${workspaceId}/3_final_messages.json`, finalMessages);
 
@@ -215,29 +236,23 @@ export class AIService extends EventEmitter {
         // Continue anyway, as the API might be more lenient
       }
 
-      // Get workspace metadata to retrieve workspace path
-      const metadataResult = await this.getWorkspaceMetadata(workspaceId);
-      if (!metadataResult.success) {
-        return Err({ type: "unknown", raw: metadataResult.error });
-      }
-
       // Build system message from workspace metadata
-      const systemMessage = await buildSystemMessage(metadataResult.data);
+      const systemMessage = await buildSystemMessage(workspaceMetadata);
 
       // Count system message tokens for cost tracking
-      const tokenizer = getTokenizerForModel(this.defaultModel);
+      const tokenizer = getTokenizerForModel(modelString);
       const systemMessageTokens = await tokenizer.countTokens(systemMessage);
 
-      const workspacePath = metadataResult.data.workspacePath;
+      const workspacePath = workspaceMetadata.workspacePath;
 
       // Get model-specific tools with workspace path configuration
-      const tools = getToolsForModel(this.defaultModel, { cwd: workspacePath });
+      const tools = getToolsForModel(modelString, { cwd: workspacePath });
 
       // Create assistant message placeholder with historySequence from backend
       const assistantMessageId = `assistant-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
       const assistantMessage = createCmuxMessage(assistantMessageId, "assistant", "", {
         timestamp: Date.now(),
-        model: this.defaultModel,
+        model: modelString,
         systemMessageTokens,
       });
 
@@ -251,14 +266,14 @@ export class AIService extends EventEmitter {
       const historySequence = assistantMessage.metadata?.historySequence ?? 0;
 
       // Build provider options based on thinking level
-      const providerOptions = buildProviderOptions(this.defaultModel, thinkingLevel || "off");
+      const providerOptions = buildProviderOptions(modelString, thinkingLevel || "off");
 
       // Delegate to StreamManager with model instance, system message, tools, historySequence, and initial metadata
       const streamResult = await this.streamManager.startStream(
         workspaceId,
         finalMessages,
         modelResult.data,
-        this.defaultModel,
+        modelString,
         historySequence,
         systemMessage,
         abortSignal,

--- a/src/services/providerAdapters.ts
+++ b/src/services/providerAdapters.ts
@@ -1,0 +1,70 @@
+import type { LanguageModel } from "ai";
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createOpenAI } from "@ai-sdk/openai";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import type { ProviderConfig } from "../config";
+import { Err, Ok, type Result } from "../types/result";
+import type { SendMessageError } from "../types/errors";
+
+interface ProviderAdapter {
+  validate: (
+    providerName: string,
+    config: ProviderConfig | undefined
+  ) => Result<ProviderConfig, SendMessageError>;
+  instantiate: (config: ProviderConfig, modelId: string) => LanguageModel;
+}
+
+interface ProviderAdapterOptions {
+  requiredKeys?: string[];
+}
+
+type ProviderFactory = (config: ProviderConfig) => (modelId: string) => LanguageModel;
+
+function createProviderAdapter(
+  factory: ProviderFactory,
+  options: ProviderAdapterOptions = {}
+): ProviderAdapter {
+  const { requiredKeys = [] } = options;
+
+  return {
+    validate(providerName, config) {
+      if (!config) {
+        return Err({ type: "provider_not_configured", provider: providerName });
+      }
+
+      for (const key of requiredKeys) {
+        const value = config[key];
+        if (value === undefined || value === null || value === "") {
+          if (key === "apiKey") {
+            return Err({ type: "api_key_not_found", provider: providerName });
+          }
+
+          return Err({
+            type: "unknown",
+            raw: `Missing required configuration '${key}' for provider '${providerName}'`,
+          });
+        }
+      }
+
+      return Ok(config);
+    },
+    instantiate(config, modelId) {
+      const provider = factory(config);
+      return provider(modelId);
+    },
+  };
+}
+
+const PROVIDER_ADAPTERS: Record<string, ProviderAdapter> = {
+  anthropic: createProviderAdapter(createAnthropic, { requiredKeys: ["apiKey"] }),
+  openai: createProviderAdapter(createOpenAI, { requiredKeys: ["apiKey"] }),
+  google: createProviderAdapter(createGoogleGenerativeAI, { requiredKeys: ["apiKey"] }),
+};
+
+export function getProviderAdapter(providerName: string): ProviderAdapter | undefined {
+  return PROVIDER_ADAPTERS[providerName];
+}
+
+export function registerProviderAdapter(providerName: string, adapter: ProviderAdapter): void {
+  PROVIDER_ADAPTERS[providerName] = adapter;
+}

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -132,6 +132,7 @@ export interface IPCApi {
     ): Promise<Result<void, SendMessageError>>;
     clearHistory(workspaceId: string): Promise<Result<void, string>>;
     getInfo(workspaceId: string): Promise<WorkspaceMetadata | null>;
+    setModel(workspaceId: string, model: string): Promise<Result<void, string>>;
 
     // Event subscriptions (renderer-only)
     // These methods are designed to send current state immediately upon subscription,

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -7,6 +7,7 @@ export const WorkspaceMetadataSchema = z.object({
   id: z.string().min(1, "Workspace ID is required"),
   projectName: z.string().min(1, "Project name is required"),
   workspacePath: z.string().min(1, "Workspace path is required"),
+  model: z.string().min(1).optional(),
 });
 
 /**
@@ -22,6 +23,9 @@ export interface WorkspaceMetadata {
 
   /** Absolute path to the workspace worktree directory */
   workspacePath: string;
+
+  /** Selected model string in provider:model format */
+  model?: string;
 }
 
 /**

--- a/src/utils/commandParser.test.ts
+++ b/src/utils/commandParser.test.ts
@@ -91,6 +91,49 @@ describe("commandParser", () => {
       });
     });
 
+    it("should show help for /model with no arguments", () => {
+      const result = parseCommand("/model");
+      expect(result).toEqual({ type: "model-help" });
+    });
+
+    it("should resolve model aliases", () => {
+      const result = parseCommand("/model opus");
+      expect(result).toEqual({
+        type: "model-set",
+        model: "anthropic:claude-opus-4-1",
+        requested: "opus",
+        source: "alias",
+      });
+    });
+
+    it("should parse explicit provider and model arguments", () => {
+      const result = parseCommand("/model anthropic claude-sonnet-4");
+      expect(result).toEqual({
+        type: "model-set",
+        model: "anthropic:claude-sonnet-4",
+        requested: "anthropic claude-sonnet-4",
+        source: "provider-model",
+      });
+    });
+
+    it("should parse provider:model syntax", () => {
+      const result = parseCommand("/model anthropic:claude-sonnet-4");
+      expect(result).toEqual({
+        type: "model-set",
+        model: "anthropic:claude-sonnet-4",
+        requested: "anthropic:claude-sonnet-4",
+        source: "explicit",
+      });
+    });
+
+    it("should handle invalid model input", () => {
+      const result = parseCommand("/model anthropic");
+      expect(result).toEqual({
+        type: "model-invalid-input",
+        input: "anthropic",
+      });
+    });
+
     it("should parse unknown commands", () => {
       expect(parseCommand("/foo")).toEqual({
         type: "unknown-command",

--- a/src/utils/modelCatalog.ts
+++ b/src/utils/modelCatalog.ts
@@ -1,0 +1,105 @@
+import modelsData from "./models.json";
+
+interface RawModelData {
+  litellm_provider?: string;
+  mode?: string;
+  [key: string]: unknown;
+}
+
+const PROVIDER_ALIASES: Record<string, string[]> = {
+  anthropic: ["anthropic"],
+  openai: ["openai"],
+  google: [
+    "google",
+    "google_ai_studio",
+    "vertex_ai-chat-models",
+    "vertex_ai-language-models",
+    "vertex_ai-code-chat-models",
+    "vertex_ai-code-text-models",
+    "vertex_ai-text-models",
+  ],
+};
+
+const TEXTUAL_MODE_KEYWORDS = ["chat", "completion", "text", "responses"];
+const EXCLUDED_MODE_KEYWORDS = ["audio", "image", "video", "embedding", "moderation", "rerank"];
+
+function isTextualMode(mode: unknown): boolean {
+  if (typeof mode !== "string" || mode.length === 0) {
+    return true;
+  }
+
+  const normalized = mode.toLowerCase();
+
+  if (EXCLUDED_MODE_KEYWORDS.some((keyword) => normalized.includes(keyword))) {
+    return false;
+  }
+
+  return TEXTUAL_MODE_KEYWORDS.some((keyword) => normalized.includes(keyword));
+}
+
+function shouldIncludeModelName(name: string): boolean {
+  if (!name || typeof name !== "string") {
+    return false;
+  }
+
+  if (name.includes("/")) {
+    return false;
+  }
+
+  if (name.includes("@")) {
+    return false;
+  }
+
+  if (name.startsWith("ft:")) {
+    return false;
+  }
+
+  return true;
+}
+
+function normalizeProvider(provider: string): string {
+  return provider.trim().toLowerCase();
+}
+
+const providerModelCache = new Map<string, string[]>();
+
+export function getModelsForProvider(provider: string): string[] {
+  const normalizedProvider = normalizeProvider(provider);
+  if (!normalizedProvider) {
+    return [];
+  }
+
+  const cached = providerModelCache.get(normalizedProvider);
+  if (cached) {
+    return cached;
+  }
+
+  const aliases = PROVIDER_ALIASES[normalizedProvider] ?? [normalizedProvider];
+  const aliasSet = new Set(aliases.map((alias) => alias.toLowerCase()));
+
+  const results = new Set<string>();
+  const data = modelsData as Record<string, RawModelData>;
+
+  for (const [name, info] of Object.entries(data)) {
+    if (!shouldIncludeModelName(name)) {
+      continue;
+    }
+
+    const providerId = info.litellm_provider?.toLowerCase();
+    if (!providerId || !aliasSet.has(providerId)) {
+      continue;
+    }
+
+    if (!isTextualMode(info.mode)) {
+      continue;
+    }
+
+    // Remove regional prefixes like "us." or "eu." when they mirror the same model name
+    const normalizedName = name.startsWith("us.") || name.startsWith("eu.") ? name.split(".").slice(1).join(".") : name;
+    results.add(normalizedName);
+  }
+
+  const sorted = Array.from(results).sort((a, b) => a.localeCompare(b));
+  providerModelCache.set(normalizedProvider, sorted);
+  return sorted;
+}

--- a/src/utils/slashCommands.test.ts
+++ b/src/utils/slashCommands.test.ts
@@ -13,6 +13,7 @@ describe("getSlashCommandSuggestions", () => {
 
     expect(labels).toContain("/clear");
     expect(labels).toContain("/providers");
+    expect(labels).toContain("/model");
   });
 
   it("filters top level commands by partial input", () => {
@@ -50,5 +51,34 @@ describe("getSlashCommandSuggestions", () => {
 
     expect(suggestions).toHaveLength(1);
     expect(suggestions[0].display).toBe("apiKey");
+  });
+
+  it("suggests model aliases and providers after /model", () => {
+    const suggestions = getSlashCommandSuggestions("/model ", {
+      providerNames: ["anthropic"],
+    });
+
+    const labels = suggestions.map((s) => s.display);
+    expect(labels).toContain("opus");
+    expect(labels).toContain("sonnet");
+    expect(labels).toContain("anthropic");
+  });
+
+  it("filters model alias suggestions by partial input", () => {
+    const suggestions = getSlashCommandSuggestions("/model op");
+    expect(suggestions.map((s) => s.display)).toContain("opus");
+    expect(suggestions.map((s) => s.display)).not.toContain("sonnet");
+  });
+
+  it("suggests provider models after selecting a provider", () => {
+    const suggestions = getSlashCommandSuggestions("/model anthropic ");
+    const labels = suggestions.map((s) => s.display);
+    expect(labels).toContain("claude-opus-4-1");
+  });
+
+  it("filters provider model suggestions by partial input", () => {
+    const suggestions = getSlashCommandSuggestions("/model openai gpt-4");
+    const labels = suggestions.map((s) => s.display);
+    expect(labels.some((label) => label.startsWith("gpt-4"))).toBe(true);
   });
 });


### PR DESCRIPTION
Implement workspace model persistence and command handling.
Load metadata on mount, watch for updates, and save model changes.
Route model updates through new IPC channel and AI service logic.
Provide provider adapters, model catalog helpers, and UI feedback.
Extend slash command parsing, suggestions, and tests for /model flow.
