### PR TITLE
Fix CI double-run on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: ["main"]
   pull_request:
     branches: ["**"]
 


### PR DESCRIPTION
## Problem
When a branch has an open PR, pushing to it triggers both the `push` and `pull_request` events, causing CI to run twice.

## Solution
Limit `push` triggers to only the `main` branch, while keeping `pull_request` triggers for all branches. This is the standard GitHub Actions pattern to prevent duplicate runs.

## Testing
- CI will still run on all PRs
- CI will still run on pushes to main
- CI will no longer double-run when pushing to PR branches