### PR TITLE
🤖 Fix timer leak in StreamManager and type errors in renameWorkspace tests

### DIFF
--- a/src/services/streamManager.ts
+++ b/src/services/streamManager.ts
@@ -692,6 +692,11 @@ export class StreamManager extends EventEmitter {
       } as ErrorEvent);
     } finally {
       // Guaranteed cleanup in all code paths
+      // Clear any pending timers to prevent keeping process alive
+      if (streamInfo.partialWriteTimer) {
+        clearTimeout(streamInfo.partialWriteTimer);
+        streamInfo.partialWriteTimer = undefined;
+      }
       this.workspaceStreams.delete(workspaceId);
     }
   }

--- a/tests/ipcMain/renameWorkspace.test.ts
+++ b/tests/ipcMain/renameWorkspace.test.ts
@@ -1,6 +1,7 @@
 import { setupWorkspace, shouldRunIntegrationTests, validateApiKeys } from "./setup";
 import { sendMessageWithModel, createEventCollector } from "./helpers";
 import { IPC_CHANNELS } from "../../src/constants/ipc-constants";
+import type { CmuxMessage } from "../../src/types/message";
 import * as fs from "fs/promises";
 
 // Skip all tests if TEST_INTEGRATION is not set
@@ -368,11 +369,17 @@ describeIntegration("IpcMain rename workspace integration tests", () => {
 
       // Get the user message from chat events for later editing
       const chatMessages = env.sentEvents.filter(
-        (e) => e.channel === `workspace:chat:${workspaceId}` && "role" in e.data
+        (e) =>
+          e.channel === `workspace:chat:${workspaceId}` &&
+          typeof e.data === "object" &&
+          e.data !== null &&
+          "role" in e.data
       );
-      const userMessage = chatMessages.find((e) => e.data.role === "user");
+      const userMessage = chatMessages.find(
+        (e) => (e.data as CmuxMessage).role === "user"
+      );
       expect(userMessage).toBeTruthy();
-      const userMessageId = userMessage!.data.id;
+      const userMessageId = (userMessage!.data as CmuxMessage).id;
 
       // Clear events before rename
       env.sentEvents.length = 0;


### PR DESCRIPTION
Fixes a resource leak where `partialWriteTimer` was not being cleared during stream cleanup in `StreamManager.processStreamWithCleanup()`, and fixes TypeScript errors in `renameWorkspace.test.ts`.

## Problems Fixed

### 1. Timer Leak in StreamManager
Integration tests were hanging for ~500ms after completion because the partial write timer wasn't being cleared when streams ended. This kept the Node.js event loop active unnecessarily.

### 2. TypeScript Errors in renameWorkspace.test.ts
The test had type errors when accessing `e.data` properties due to `unknown` typing:
- Missing type guards for event data filtering
- Incorrect type assertions when accessing message properties

## Solutions

### StreamManager Timer Leak
Added timer cleanup in the `finally` block to ensure `partialWriteTimer` is cleared in all code paths (success, error, or cancellation).

### renameWorkspace Test Types
- Added proper type guards (`typeof e.data === 'object'` and null check) before checking for 'role' property
- Used `CmuxMessage` type for proper typing when accessing `role` and `id` properties

## Testing

StreamManager fix:
```bash
TEST_INTEGRATION=1 bun x jest tests/ipcMain/sendMessage.test.ts --runInBand -t "anthropic.*should handle reconnection"
```

renameWorkspace fix:
```bash
TEST_INTEGRATION=1 bun x jest tests/ipcMain/renameWorkspace.test.ts --runInBand --forceExit
```

All 8 tests in renameWorkspace suite now pass.

## Note
Integration tests may still show a ~15s delay after completion due to HTTP keep-alive connections in the Anthropic SDK. This is expected behavior and not a resource leak - the connections close automatically after their timeout period.

_Generated with `cmux`_