### PR TITLE
🤖 Fix macOS unsigned app installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,25 @@ To download:
 
 **macOS:**
 
+⚠️ **Note**: The app is unsigned, so you'll need to bypass Gatekeeper security.
+
 1. Download and open the DMG file
 2. Drag Cmux to Applications folder
-3. Right-click and select "Open" (first time only, since the app is unsigned)
+3. **First time opening**:
+   - Don't double-click the app (macOS will block it)
+   - Right-click (or Control+click) on Cmux.app
+   - Select "Open" from the menu
+   - Click "Open" in the security dialog
+   - The app will now be allowed to run
+
+**Alternative method if the above doesn't work:**
+
+1. After step 2, open Terminal
+2. Run: `xattr -cr /Applications/Cmux.app`
+3. Run: `codesign --force --deep --sign - /Applications/Cmux.app`
+4. Now you can open the app normally
+
+These steps are only needed once. After that, you can open the app normally.
 
 **Linux:**
 

--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
         }
       ],
       "icon": "build/icon.icns",
-      "artifactName": "${productName}-${version}-${arch}.${ext}"
+      "artifactName": "${productName}-${version}-${arch}.${ext}",
+      "identity": null
     },
     "linux": {
       "target": "AppImage",


### PR DESCRIPTION
Fixes the "app has been modified" error when opening the macOS DMG on macOS.

## Problem

Users were getting this error when trying to open the app:
> The app has been modified, and its code does not match the original signed code.

This happens because the app is completely unsigned, and macOS Gatekeeper is blocking it.

## Solution

### 1. Documentation Updates

Added comprehensive instructions to the README for opening unsigned apps on macOS:

**Primary method (right-click to open):**
- Don't double-click the app
- Right-click (or Control+click) on Cmux.app
- Select "Open" from the menu
- Click "Open" in the security dialog

**Alternative method (command line):**
```bash
xattr -cr /Applications/Cmux.app
codesign --force --deep --sign - /Applications/Cmux.app
```

The `xattr -cr` command removes the quarantine attribute that macOS adds to downloaded files.
The `codesign --force --deep --sign -` command applies ad-hoc signing to make the app internally consistent.

### 2. Configuration Changes

Set `identity: null` in electron-builder config to explicitly disable code signing attempts and avoid any signing conflicts.

## Testing

These instructions should resolve the issue. The alternative method with `xattr` and `codesign` is particularly effective for stubborn cases.

## Future Enhancement

For a production release, we should add proper code signing with an Apple Developer certificate and notarization. This would require:
- Apple Developer account
- Developer ID Application certificate
- Storing credentials in GitHub secrets
- Adding notarization step to the build workflow

But for development builds, the documented workarounds are sufficient.

## Notes

- ⚠️ Added clear warning in README that app is unsigned
- These steps only need to be done once per app installation
- After initial bypass, the app opens normally

_Generated with `cmux`_
