### PR TITLE
🤖 Fix BodyTimeoutError by removing artificial timeout limits

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "rehype-katex": "^7.0.1",
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
+        "undici": "^7.16.0",
         "write-file-atomic": "^6.0.0",
         "zod": "^4.1.11",
         "zod-to-json-schema": "^3.24.6",
@@ -1980,6 +1981,8 @@
     "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
+
+    "undici": ["undici@7.16.0", "", {}, "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g=="],
 
     "undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "rehype-katex": "^7.0.1",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
+    "undici": "^7.16.0",
     "write-file-atomic": "^6.0.0",
     "zod": "^4.1.11",
     "zod-to-json-schema": "^3.24.6"


### PR DESCRIPTION
## Problem

New OpenAI models (especially reasoning models like o1/o3) can pause for longer than 5 minutes between tokens while thinking, causing `BodyTimeoutError` from Node's undici HTTP client:

```
BodyTimeoutError: Body Timeout Error
    at Fetch.onAborted (node:internal/deps/undici/undici:11132:53)
    ...
```

The error occurs **client-side** in Node's built-in HTTP client (undici), not from OpenAI's servers. The default `bodyTimeout` is 300 seconds (5 minutes), which is too short for:
- Reasoning models with extended thinking time
- Large context windows  
- Complex multi-tool workflows

## Solution

Set `bodyTimeout: 0` and `headersTimeout: 0` (unlimited) for OpenAI requests by creating a custom undici Agent and passing it via a custom fetch function.

## Why This Is Safe

✅ **User controls cancellation** - Users can stop streams via the UI stop button, which triggers the `AbortController`  
✅ **Network errors still throw** - Actual network issues are detected immediately  
✅ **No artificial limits** - Legitimate long-running operations can complete  
✅ **AbortSignal properly wired** - Already flows through: UI → streamManager → streamText → fetch  

## Testing

- [x] Code compiles and typechecks
- [x] Integration tests pass
- [x] Long-running streams no longer timeout
- [x] User cancellation still works via UI

## Alternative Considered

We could have set a very large timeout (e.g., 1 hour) instead of unlimited, but since users have full cancellation control via the UI, truly unlimited is cleaner and more correct.

_Generated with `cmux`_