### PR TITLE
🤖 Add models-extra.ts for gpt-5-pro pricing

### DIFF
--- a/src/utils/tokens/modelStats.ts
+++ b/src/utils/tokens/modelStats.ts
@@ -1,4 +1,5 @@
 import modelsData from "./models.json";
+import { modelsExtra } from "./models-extra";
 
 export interface ModelStats {
   max_input_tokens: number;
@@ -34,7 +35,14 @@ function extractModelName(modelString: string): string {
  */
 export function getModelStats(modelString: string): ModelStats | null {
   const modelName = extractModelName(modelString);
-  const data = (modelsData as Record<string, RawModelData>)[modelName];
+
+  // Check main models.json first
+  let data = (modelsData as Record<string, RawModelData>)[modelName];
+
+  // Fall back to models-extra.ts if not found
+  if (!data) {
+    data = (modelsExtra as Record<string, RawModelData>)[modelName];
+  }
 
   if (!data) {
     return null;

--- a/src/utils/tokens/models-extra.ts
+++ b/src/utils/tokens/models-extra.ts
@@ -1,0 +1,42 @@
+/**
+ * Extra models not yet in LiteLLM's official models.json
+ * This file is consulted as a fallback when a model is not found in the main file.
+ * Models should be removed from here once they appear in the upstream LiteLLM repository.
+ */
+
+interface ModelData {
+  max_input_tokens: number;
+  max_output_tokens?: number;
+  input_cost_per_token: number;
+  output_cost_per_token: number;
+  cache_creation_input_token_cost?: number;
+  cache_read_input_token_cost?: number;
+  litellm_provider?: string;
+  mode?: string;
+  supports_function_calling?: boolean;
+  supports_vision?: boolean;
+  supports_reasoning?: boolean;
+  supports_response_schema?: boolean;
+  knowledge_cutoff?: string;
+  supported_endpoints?: string[];
+}
+
+export const modelsExtra: Record<string, ModelData> = {
+  // GPT-5 Pro - Released October 6, 2025 at DevDay
+  // $15/M input, $120/M output
+  // Only available via OpenAI's Responses API
+  "gpt-5-pro": {
+    max_input_tokens: 400000,
+    max_output_tokens: 272000,
+    input_cost_per_token: 0.000015, // $15 per million input tokens
+    output_cost_per_token: 0.00012, // $120 per million output tokens
+    litellm_provider: "openai",
+    mode: "chat",
+    supports_function_calling: true,
+    supports_vision: true,
+    supports_reasoning: true,
+    supports_response_schema: true,
+    knowledge_cutoff: "2024-09-30",
+    supported_endpoints: ["/v1/responses"],
+  },
+};


### PR DESCRIPTION
## Summary

Added support for gpt-5-pro model pricing which was released today (October 6, 2025) at OpenAI's DevDay but is not yet in LiteLLM's official models list.

## Changes

- **Created `src/utils/tokens/models-extra.ts`**: TypeScript file to maintain models not yet in LiteLLM
- **Added gpt-5-pro pricing**: $15/M input tokens, $120/M output tokens
- **Updated `modelStats.ts`**: Falls back to models-extra.ts when model not found in main models.json
- Full type safety with inline comments for maintainability

## Details

- 400K context window
- 272K max output tokens
- September 30, 2024 knowledge cutoff
- Only available via OpenAI's Responses API
- Supports function calling, vision, reasoning, and response schema

## Testing

Verified that:
- ✅ gpt-5-pro is found and returns correct pricing
- ✅ Regular models from models.json still work (gpt-4, gpt-5)
- ✅ Type checking passes with no errors

Models can be removed from models-extra.ts once they appear in the upstream LiteLLM repository.

---
_Generated with `cmux`_