### PR TITLE
🤖 Make file lease error message more obvious with WRITE DENIED prefix

### DIFF
--- a/src/services/tools/file_edit_insert.ts
+++ b/src/services/tools/file_edit_insert.ts
@@ -51,7 +51,7 @@ export const createFileEditInsertTool: ToolFactory = (config: ToolConfiguration)
         if (currentLease !== lease) {
           return {
             success: false,
-            error: `File lease mismatch. The file has been modified since it was read. Please read the file again.`,
+            error: `WRITE DENIED: File lease mismatch. The file has been modified since it was read. Please read the file again.`,
           };
         }
 

--- a/src/services/tools/file_edit_replace.ts
+++ b/src/services/tools/file_edit_replace.ts
@@ -50,7 +50,7 @@ export const createFileEditReplaceTool: ToolFactory = (config: ToolConfiguration
         if (currentLease !== lease) {
           return {
             success: false,
-            error: `File lease mismatch. The file has been modified since it was read. Please read the file again.`,
+            error: `WRITE DENIED: File lease mismatch. The file has been modified since it was read. Please read the file again.`,
           };
         }
 


### PR DESCRIPTION
The 'File lease mismatch' error message now starts with 'WRITE DENIED:' to make it immediately clear that the write operation was not applied. This helps avoid confusion about whether the file was modified or not.

_Generated with `cmux`_