### PR TITLE
🤖 ci: use native GitHub 8-core runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: depot-ubuntu-22.04-8
+    runs-on: ubuntu-latest-8-cores
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
 
   fmt-check:
     name: Format Check
-    runs-on: depot-ubuntu-22.04-8
+    runs-on: ubuntu-latest-8-cores
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: depot-ubuntu-22.04-8
+    runs-on: ubuntu-latest-8-cores
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -63,7 +63,7 @@ jobs:
 
   integration-test:
     name: Integration Tests
-    runs-on: depot-ubuntu-22.04-8
+    runs-on: ubuntu-latest-8-cores
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Switch from Depot runners (`depot-ubuntu-22.04-8`) to GitHub's native larger runners (`ubuntu-latest-8-cores`) to avoid queuing issues with Depot.

This should provide better availability and consistent performance for CI jobs.

**Changes:**
- Updated all 4 CI jobs (lint, fmt-check, test, integration-test) to use `ubuntu-latest-8-cores`

_Generated with `cmux`_