### PR TITLE
🤖 ci: fix fmt:check markdown coverage

### DIFF
--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -4,16 +4,16 @@ Commands for managing conversation history length and token usage.
 
 ## Comparison
 
-| Feature | `/clear` | `/truncate` | `/compact` |
-|---------|----------|------------|------------|
-| **Speed** | Instant | Instant | Slower (uses AI) |
-| **Context Preservation** | None | Temporal | Intelligent |
-| **Cost** | Free | Free | Uses API tokens |
-| **Reversible** | No | No | No |
+| Feature                  | `/clear` | `/truncate` | `/compact`       |
+| ------------------------ | -------- | ----------- | ---------------- |
+| **Speed**                | Instant  | Instant     | Slower (uses AI) |
+| **Context Preservation** | None     | Temporal    | Intelligent      |
+| **Cost**                 | Free     | Free        | Uses API tokens  |
+| **Reversible**           | No       | No          | No               |
 
 ## `/clear` - Clear All History
 
-Remove all messages from conversation history. 
+Remove all messages from conversation history.
 
 ### Syntax
 
@@ -59,7 +59,7 @@ Basic compaction with default settings.
 Limit summary to 1000 output tokens.
 
 ```
-/compact 2000 next up, we're adding a dark theme 
+/compact 2000 next up, we're adding a dark theme
 ```
 
 Compact with token limit and custom instructions.
@@ -101,5 +101,3 @@ Remove oldest 50% of messages.
 - About as fast as `/clear`
 - `/truncate 100` is equivalent to `/clear`
 - **Irreversible** - messages are permanently removed
-
-

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -7,9 +7,14 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 cd "$PROJECT_ROOT"
 
-PRETTIER_PATTERNS=("src/**/*.{ts,tsx,js,jsx,json}" "*.{json,md}")
+PRETTIER_PATTERNS=(
+  "src/**/*.{ts,tsx,js,jsx,json}"
+  "tests/**/*.{ts,tsx,js,jsx,json}"
+  "docs/**/*.{md,mdx}"
+  "*.{json,md}"
+)
 
-format_typescript() {
+run_prettier() {
   local mode="$1"
   if [ "$mode" = "--check" ]; then
     echo "Checking TypeScript/JSON/Markdown formatting..."
@@ -38,12 +43,12 @@ format_shell() {
 }
 
 if [ "$1" = "--check" ]; then
-  format_typescript --check
+  run_prettier --check
 elif [ "$1" = "--shell" ]; then
   format_shell
 elif [ "$1" = "--all" ]; then
-  format_typescript
+  run_prettier
   format_shell
 else
-  format_typescript
+  run_prettier
 fi


### PR DESCRIPTION
## Summary
- ensure Prettier globs cover docs and test sources so `fmt` and `fmt:check` see the same files
- rename the helper to `run_prettier` for clarity
- commit the resulting doc formatting from the expanded glob

## Testing
- bun run fmt
- bun run fmt:check
