### PR TITLE
Strip reasoning parts from message history (OpenAI fix)

### DIFF
--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -19,6 +19,7 @@ import {
   validateAnthropicCompliance,
   addInterruptedSentinel,
   filterEmptyAssistantMessages,
+  stripReasoningForOpenAI,
 } from "@/utils/messages/modelMessageTransform";
 import { applyCacheControl } from "@/utils/ai/cacheStrategy";
 import type { HistoryService } from "./historyService";
@@ -278,10 +279,22 @@ export class AIService extends EventEmitter {
       // Dump original messages for debugging
       log.debug_obj(`${workspaceId}/1_original_messages.json`, messages);
 
+      // Extract provider name from modelString (e.g., "anthropic:claude-opus-4-1" -> "anthropic")
+      const [providerName] = modelString.split(":");
+
       // Filter out assistant messages with only reasoning (no text/tools)
-      const filteredMessages = filterEmptyAssistantMessages(messages);
+      let filteredMessages = filterEmptyAssistantMessages(messages);
       log.debug(`Filtered ${messages.length - filteredMessages.length} empty assistant messages`);
       log.debug_obj(`${workspaceId}/1a_filtered_messages.json`, filteredMessages);
+
+      // OpenAI-specific: Strip reasoning parts from history
+      // OpenAI manages reasoning via previousResponseId; sending Anthropic-style reasoning
+      // parts creates orphaned reasoning items that cause API errors
+      if (providerName === "openai") {
+        filteredMessages = stripReasoningForOpenAI(filteredMessages);
+        log.debug("Stripped reasoning parts for OpenAI");
+        log.debug_obj(`${workspaceId}/1b_openai_stripped.json`, filteredMessages);
+      }
 
       // Add [INTERRUPTED] sentinel to partial messages (for model context)
       const messagesWithSentinel = addInterruptedSentinel(filteredMessages);
@@ -292,9 +305,6 @@ export class AIService extends EventEmitter {
       const modelMessages = convertToModelMessages(messagesWithSentinel as any);
 
       log.debug_obj(`${workspaceId}/2_model_messages.json`, modelMessages);
-
-      // Extract provider name from modelString (e.g., "anthropic:claude-opus-4-1" -> "anthropic")
-      const [providerName] = modelString.split(":");
 
       // Apply ModelMessage transforms based on provider requirements
       const transformedMessages = transformModelMessages(modelMessages, providerName);

--- a/src/utils/messages/modelMessageTransform.ts
+++ b/src/utils/messages/modelMessageTransform.ts
@@ -10,41 +10,55 @@ import type { CmuxMessage } from "@/types/message";
  * Filter out assistant messages that only contain reasoning parts (no text or tool parts).
  * These messages are invalid for the API and provide no value to the model.
  * This happens when a message is interrupted during thinking before producing any text.
- * 
- * Also strips reasoning parts from OpenAI messages to prevent orphaned reasoning items.
- * OpenAI's Responses API creates separate reasoning items with IDs that must be properly
- * linked. When reasoning parts come from history, they cause "reasoning without following item" errors.
+ *
+ * Note: This function filters out reasoning-only messages but does NOT strip reasoning
+ * parts from messages that have other content. Reasoning parts are handled differently
+ * per provider (see stripReasoningForOpenAI).
  */
 export function filterEmptyAssistantMessages(messages: CmuxMessage[]): CmuxMessage[] {
-  return messages
-    .map((msg) => {
-      // Only process assistant messages
-      if (msg.role !== "assistant") {
-        return msg;
-      }
+  return messages.filter((msg) => {
+    // Keep all non-assistant messages
+    if (msg.role !== "assistant") {
+      return true;
+    }
 
-      // Strip reasoning parts - they should never be sent back to the API
-      // Reasoning is only for display/debugging, not for model context
-      const filteredParts = msg.parts.filter((part) => part.type !== "reasoning");
+    // Keep assistant messages that have at least one text or tool part
+    const hasContent = msg.parts.some(
+      (part) => (part.type === "text" && part.text) || part.type === "dynamic-tool"
+    );
 
-      return {
-        ...msg,
-        parts: filteredParts,
-      };
-    })
-    .filter((msg) => {
-      // Keep all non-assistant messages
-      if (msg.role !== "assistant") {
-        return true;
-      }
+    return hasContent;
+  });
+}
 
-      // Keep assistant messages that have at least one text or tool part
-      const hasContent = msg.parts.some(
-        (part) => (part.type === "text" && part.text) || part.type === "dynamic-tool"
-      );
+/**
+ * Strip reasoning parts from messages for OpenAI.
+ *
+ * OpenAI's Responses API uses encrypted reasoning items (with IDs like rs_*) that are
+ * managed automatically via previous_response_id. When reasoning parts from history
+ * (which are Anthropic-style text-based reasoning) are sent to OpenAI, they create
+ * orphaned reasoning items that cause "reasoning without following item" errors.
+ *
+ * Anthropic's reasoning (text-based) is different and SHOULD be sent back via sendReasoning.
+ *
+ * @param messages - Messages that may contain reasoning parts
+ * @returns Messages with reasoning parts stripped (for OpenAI only)
+ */
+export function stripReasoningForOpenAI(messages: CmuxMessage[]): CmuxMessage[] {
+  return messages.map((msg) => {
+    // Only process assistant messages
+    if (msg.role !== "assistant") {
+      return msg;
+    }
 
-      return hasContent;
-    });
+    // Strip reasoning parts - OpenAI manages reasoning via previousResponseId
+    const filteredParts = msg.parts.filter((part) => part.type !== "reasoning");
+
+    return {
+      ...msg,
+      parts: filteredParts,
+    };
+  });
 }
 
 /**


### PR DESCRIPTION
## Problem

After merging PR #59, the OpenAI reasoning error still occurred:
```
Item 'rs_01e84f5b161f6bce0068e480e7778481a3a2c3b6234d6bb7c6' of type 'reasoning' was provided without its required following item.
```

## Root Cause Analysis

**The issue was OpenAI-specific.** Anthropic reasoning and OpenAI reasoning work differently:

### Anthropic
- Uses **text-based reasoning parts** in message content
- These **SHOULD be sent back** to the API (via `sendReasoning: true` option, which defaults to true)
- The model uses historical reasoning context to improve responses

### OpenAI  
- Uses **encrypted reasoning items** with IDs (e.g., `rs_*`)
- These are managed automatically via `previous_response_id` 
- Sending Anthropic-style text reasoning parts creates **orphaned reasoning items** that cause API errors
- Per OpenAI docs: "In typical multi-turn conversations, you don't need to include reasoning items or tokens—the model is trained to produce the best output without them"

## Solution

**Strip reasoning parts ONLY for OpenAI**, before converting CmuxMessages to ModelMessages.

- Added `stripReasoningForOpenAI()` function for OpenAI-specific processing
- Apply it conditionally based on provider in `aiService.ts`
- Keeps Anthropic behavior intact (reasoning sent via `sendReasoning`)

## Changes

1. **New function**: `stripReasoningForOpenAI()` in `modelMessageTransform.ts`
2. **Updated `aiService.ts`**: Apply reasoning stripping only for OpenAI provider
3. **Reverted previous change**: `filterEmptyAssistantMessages()` no longer strips all reasoning
4. **Added detailed comments** explaining provider-specific differences

This ensures:
- ✅ OpenAI doesn't get orphaned reasoning items
- ✅ Anthropic still receives reasoning context
- ✅ Provider-specific behavior is clearly documented