### PR TITLE
🤖 Fix broken symlinks for AGENTS.md and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,1 @@
-docs/src/AGENTS.md
+docs/AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-docs/src/AGENTS.md
+docs/AGENTS.md


### PR DESCRIPTION
Both `AGENTS.md` and `CLAUDE.md` symlinks in the root were pointing to `docs/src/AGENTS.md` which doesn't exist. This caused the symlinks to be broken.

This PR updates both symlinks to correctly point to `docs/AGENTS.md` where the actual agent instructions file is located.

**Changes:**
- Fixed `AGENTS.md` symlink: `docs/src/AGENTS.md` → `docs/AGENTS.md`
- Fixed `CLAUDE.md` symlink: `docs/src/AGENTS.md` → `docs/AGENTS.md`

_Generated with `cmux`_