### PR TITLE
feat: add global focus shortcut for chat input

### DIFF
--- a/docs/keybinds.md
+++ b/docs/keybinds.md
@@ -24,6 +24,7 @@ When documentation shows `Ctrl`, it means:
 
 | Action                 | Shortcut      |
 | ---------------------- | ------------- |
+| Focus chat input       | `a` or `i`    |
 | Send message           | `Enter`       |
 | New line in message    | `Shift+Enter` |
 | Jump to bottom of chat | `Shift+G`     |

--- a/src/utils/ui/keybinds.ts
+++ b/src/utils/ui/keybinds.ts
@@ -124,6 +124,12 @@ export const KEYBINDS = {
   /** Cancel current action / Close modal / Interrupt streaming */
   CANCEL: { key: "Escape" },
 
+  /** Focus chat input */
+  FOCUS_INPUT_I: { key: "i" },
+
+  /** Focus chat input (alternate) */
+  FOCUS_INPUT_A: { key: "a" },
+
   /** Create new workspace for current project */
   NEW_WORKSPACE: { key: "n", ctrl: true },
 


### PR DESCRIPTION
Introduce global `a` and `i` keybinds that focus the chat input when no editable element is active.
Move focus to the textarea with caret at the end and resize height to match content.
Update escape handling to blur the input when interrupting or editing does not consume the shortcut, and document the new shortcuts in the keybinds reference.