### PR TITLE
🤖 Fix toast auto-dismiss by memoizing onDismiss callback

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -326,6 +326,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   const [commandSuggestions, setCommandSuggestions] = useState<SlashSuggestion[]>([]);
   const [providerNames, setProviderNames] = useState<string[]>([]);
   const [toast, setToast] = useState<Toast | null>(null);
+  const handleToastDismiss = useCallback(() => {
+    setToast(null);
+  }, []);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const modelSelectorRef = useRef<ModelSelectorRef>(null);
   const [thinkingLevel] = useThinkingLevel();
@@ -696,7 +699,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
 
   return (
     <InputSection>
-      <ChatInputToast toast={toast} onDismiss={() => setToast(null)} />
+      <ChatInputToast toast={toast} onDismiss={handleToastDismiss} />
       <CommandSuggestions
         suggestions={commandSuggestions}
         onSelectSuggestion={handleCommandSelect}


### PR DESCRIPTION
## Problem

Toasts were staying visible forever, even though success toasts should auto-dismiss after 3 seconds.

The issue was in `ChatInput.tsx`:
```tsx
<ChatInputToast toast={toast} onDismiss={() => setToast(null)} />
```

The inline arrow function created a new function reference on every render, causing:
1. `handleDismiss` (which depends on `onDismiss`) to be recreated constantly
2. The `useEffect` timer to restart before completing
3. Toast never auto-dismissing

## Solution

Wrapped the callback in `useCallback` to create a stable function reference:
```typescript
const handleToastDismiss = useCallback(() => {
  setToast(null);
}, []);
```

Now success toasts properly auto-dismiss after 3 seconds, while error toasts stay visible until manually dismissed.

## Testing

- Success toasts (e.g., "Compaction started") now disappear after 3 seconds
- Error toasts still require manual dismissal

---

_Generated with `cmux`_