### PR TITLE
🤖 Fix: macOS code signing certificate import

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,34 +26,9 @@ jobs:
       - name: Build application
         run: bun run build
 
-      - name: Import Code Signing Certificate
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && env.MACOS_CERTIFICATE != ''
-        env:
-          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
-        run: |
-          # Create temporary keychain
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
-          
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          
-          # Import certificate
-          echo "$MACOS_CERTIFICATE" | base64 --decode > certificate.p12
-          security import certificate.p12 -k "$KEYCHAIN_PATH" -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          
-          # Add keychain to search list
-          security list-keychain -d user -s "$KEYCHAIN_PATH"
-          
-          # Clean up certificate file
-          rm certificate.p12
-
       - name: Package for macOS
         env:
-          CSC_LINK: base64:${{ secrets.MACOS_CERTIFICATE }}
+          CSC_LINK: ${{ secrets.MACOS_CERTIFICATE }}
           CSC_KEY_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
         run: bun run dist:mac
 


### PR DESCRIPTION
Fixes the certificate import error in the macOS build.

## Problem

The previous implementation had a conflict:
1. Manual keychain creation + certificate import in a workflow step
2. Passing the certificate to electron-builder via `CSC_LINK`

This caused electron-builder to try importing the certificate again, resulting in:
```
security: SecKeychainItemImport: Unknown format in import.
```

## Solution

Simplified the approach - let electron-builder handle everything:
- Removed manual keychain creation and certificate import
- Pass the raw base64 certificate string directly to electron-builder
- Electron-builder automatically detects base64 format and handles the import

## Testing

This will be tested when merged to main.

_Generated with `cmux`_