### PR TITLE
🤖 Fix: Remove unnecessary DMG signing and split artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,11 +36,19 @@ jobs:
           fi
           bun run dist:mac
 
-      - name: Upload macOS DMG
+      - name: Upload macOS DMG (x64)
         uses: actions/upload-artifact@v4
         with:
-          name: macos-dmg
-          path: release/*.dmg
+          name: macos-dmg-x64
+          path: release/*-x64.dmg
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Upload macOS DMG (arm64)
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-dmg-arm64
+          path: release/*-arm64.dmg
           retention-days: 30
           if-no-files-found: error
 

--- a/package.json
+++ b/package.json
@@ -118,9 +118,6 @@
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist"
     },
-    "dmg": {
-      "sign": true
-    },
     "linux": {
       "target": "AppImage",
       "category": "Development",


### PR DESCRIPTION
## Problem
1. PR #83 added `dmg.sign: true` which is actually **unnecessary and discouraged** by electron-builder
2. Both DMG files (x64 and arm64) are being uploaded as a single artifact, making it confusing for users

## Solution
1. **Removed `dmg.sign: true`** - DMG signing is not needed and can cause issues. What matters is the .app bundle signing (which works perfectly)
2. **Split artifacts** - Now uploading as separate `macos-dmg-x64` and `macos-dmg-arm64` artifacts for clarity

## Why DMG signing is unnecessary
According to electron-builder documentation: "Signing is not required and will lead to unwanted errors in combination with notarization requirements."

The .app bundle inside the DMG is properly signed with:
- Developer ID Application certificate
- Hardened Runtime enabled
- All frameworks and helpers signed
- Valid certificate chain through Apple Root CA

✅ Verified on local machine: `codesign --verify --deep --strict` passes

## Changes
```yaml
# .github/workflows/build.yml
- name: Upload macOS DMG (x64)
  path: release/*-x64.dmg
  
- name: Upload macOS DMG (arm64)
  path: release/*-arm64.dmg
```

```json
// package.json - removed dmg section entirely
"mac": {
  "target": [
    { "target": "dmg", "arch": "x64" },
    { "target": "dmg", "arch": "arm64" }
  ],
  ...
}
```

_Generated with `cmux`_