### PR TITLE
🤖 Add command palette control for thinking effort

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -5,6 +5,7 @@ import { useCommandRegistry } from "@/contexts/CommandRegistryContext";
 import type { CommandAction } from "@/contexts/CommandRegistryContext";
 import { formatKeybind, KEYBINDS, isEditableElement, matchesKeybind } from "@/utils/ui/keybinds";
 import { getSlashCommandSuggestions } from "@/utils/slashCommands/suggestions";
+import { CUSTOM_EVENTS } from "@/constants/events";
 
 const Overlay = styled.div`
   position: fixed;
@@ -254,7 +255,9 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ getSlashContext 
             shortcutHint: `${formatKeybind(KEYBINDS.SEND_MESSAGE)} to insert`,
             run: () => {
               const text = s.replacement;
-              window.dispatchEvent(new CustomEvent("cmux:insertToChatInput", { detail: { text } }));
+              window.dispatchEvent(
+                new CustomEvent(CUSTOM_EVENTS.INSERT_TO_CHAT_INPUT, { detail: { text } })
+              );
             },
           })),
         },

--- a/src/constants/events.ts
+++ b/src/constants/events.ts
@@ -1,0 +1,30 @@
+/**
+ * Custom Event Constants
+ * These are window-level custom events used for cross-component communication
+ */
+
+export const CUSTOM_EVENTS = {
+  /**
+   * Event to show a toast notification when thinking level changes
+   * Detail: { workspaceId: string, level: ThinkingLevel }
+   */
+  THINKING_LEVEL_TOAST: "cmux:thinkingLevelToast",
+
+  /**
+   * Event to insert text into the chat input
+   * Detail: { text: string }
+   */
+  INSERT_TO_CHAT_INPUT: "cmux:insertToChatInput",
+
+  /**
+   * Event to open the model selector
+   * No detail
+   */
+  OPEN_MODEL_SELECTOR: "cmux:openModelSelector",
+} as const;
+
+/**
+ * Helper to create a storage change event name for a specific key
+ * Used by usePersistedState for same-tab synchronization
+ */
+export const getStorageChangeEvent = (key: string): string => `storage-change:${key}`;

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -1,0 +1,10 @@
+/**
+ * LocalStorage Key Constants and Helpers
+ * These keys are used for persisting state in localStorage
+ */
+
+/**
+ * Helper to create a thinking level storage key for a workspace
+ * Format: "thinkingLevel:{workspaceId}"
+ */
+export const getThinkingLevelKey = (workspaceId: string): string => `thinkingLevel:${workspaceId}`;

--- a/src/contexts/ThinkingContext.tsx
+++ b/src/contexts/ThinkingContext.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import React, { createContext, useContext } from "react";
 import type { ThinkingLevel } from "@/types/thinking";
 import { usePersistedState } from "@/hooks/usePersistedState";
+import { getThinkingLevelKey } from "@/constants/storage";
 
 interface ThinkingContextType {
   thinkingLevel: ThinkingLevel;
@@ -16,9 +17,11 @@ interface ThinkingProviderProps {
 }
 
 export const ThinkingProvider: React.FC<ThinkingProviderProps> = ({ workspaceId, children }) => {
+  const key = getThinkingLevelKey(workspaceId);
   const [thinkingLevel, setThinkingLevel] = usePersistedState<ThinkingLevel>(
-    `thinkingLevel:${workspaceId}`,
-    "off"
+    key,
+    "off",
+    { listener: true } // Listen for changes from command palette and other sources
   );
 
   return (


### PR DESCRIPTION
## Summary
- add a "Set Thinking Effort…" command palette action that offers off/low/medium/high options
- persist and broadcast the selected thinking level so chat input stays in sync
- confirm the behavior with unit coverage for the new command source

## Testing
- bun typecheck

_Generated with `cmux`_
