### PR TITLE
🤖 Ensure lint job generates version metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Generate version file
+        run: ./scripts/generate-version.sh
+
       - name: Run lint
         run: bun lint
 


### PR DESCRIPTION
## Summary
- generate src/version.ts before running lint in CI
- ensures TypeScript resolves VERSION import during lint

_Generated with _