### PR TITLE
🤖 ci: remove push trigger on main to avoid duplicate runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: Build
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
     branches: ["**"]
   merge_group:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
     branches: ["**"]
   merge_group:

--- a/src/utils/tools/toolDefinitions.ts
+++ b/src/utils/tools/toolDefinitions.ts
@@ -143,6 +143,7 @@ export const TOOL_DEFINITIONS = {
             "Scale the detail to match the task complexity: for straightforward changes, briefly state what and why; " +
             "for complex changes, explain approach, key decisions, risks/tradeoffs; " +
             "for uncertain changes, clarify options and what needs user input. " +
+            "When presenting options, always provide your recommendation for the overall best option for the user. " +
             "For highly complex concepts, use mermaid diagrams where they'd clarify better than text. " +
             "Cover what's necessary to understand and approve the approach. Omit obvious details or ceremony."
         ),


### PR DESCRIPTION
## Changes

- Remove `push: branches: [main]` from CI and Build workflows
- Keep only `merge_group` and `pull_request` triggers
- Docs workflow keeps push trigger (has path filters, only deploys)

## Why

Currently, workflows run twice for every merge:
1. Once when PR enters merge queue (`merge_group` event)
2. Again after merging to main (`push` event)

This change eliminates the redundant post-merge runs, reducing CI costs and execution time.

## Testing

After merge, verify that:
- ✅ Workflows run on PR creation/updates
- ✅ Workflows run when PR enters merge queue
- ❌ Workflows do NOT run after merge to main (except Docs when docs change)

---

## Bonus: propose_plan tool improvement

Also updated the `propose_plan` tool description to instruct the agent to always provide a recommendation when presenting options to the user.

_Generated with `cmux`_