### PR TITLE
🤖 Track usage in stream abort events

### DIFF
--- a/src/services/ipcMain.ts
+++ b/src/services/ipcMain.ts
@@ -21,6 +21,7 @@ import type {
   StreamStartEvent,
   StreamDeltaEvent,
   StreamEndEvent,
+  StreamAbortEvent,
   ToolCallStartEvent,
   ToolCallDeltaEvent,
   ToolCallEndEvent,
@@ -1156,19 +1157,12 @@ export class IpcMain {
     });
 
     // Handle stream abort events
-    this.aiService.on(
-      "stream-abort",
-      (data: { type: string; workspaceId: string; messageId?: string }) => {
-        if (this.mainWindow) {
-          // Send the stream-abort event to frontend
-          this.mainWindow.webContents.send(getChatChannel(data.workspaceId), {
-            type: "stream-abort",
-            workspaceId: data.workspaceId,
-            messageId: data.messageId,
-          });
-        }
+    this.aiService.on("stream-abort", (data: StreamAbortEvent) => {
+      if (this.mainWindow) {
+        // Forward complete abort event including metadata (usage, duration)
+        this.mainWindow.webContents.send(getChatChannel(data.workspaceId), data);
       }
-    );
+    });
   }
 
   /**

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -47,6 +47,11 @@ export interface StreamAbortEvent {
   type: "stream-abort";
   workspaceId: string;
   messageId: string;
+  // Metadata may contain usage if abort occurred after stream completed processing
+  metadata?: {
+    usage?: LanguageModelV2Usage;
+    duration?: number;
+  };
 }
 
 export interface ErrorEvent {

--- a/src/utils/messages/StreamingMessageAggregator.ts
+++ b/src/utils/messages/StreamingMessageAggregator.ts
@@ -265,10 +265,14 @@ export class StreamingMessageAggregator {
     const activeStream = this.activeStreams.get(data.messageId);
 
     if (activeStream) {
-      // Mark the message as interrupted
+      // Mark the message as interrupted and merge metadata (consistent with handleStreamEnd)
       const message = this.messages.get(data.messageId);
       if (message?.metadata) {
-        message.metadata.partial = true;
+        message.metadata = {
+          ...message.metadata,
+          partial: true,
+          ...data.metadata, // Spread abort metadata (usage, duration)
+        };
       }
 
       // Clean up active stream - direct delete by messageId


### PR DESCRIPTION
## Overview

Capture token usage and duration when streams are interrupted. The AI SDK provides usage data even when streams are aborted, so we should track it for accurate cost accounting.

## Changes

### Backend Changes
- **StreamAbortEvent type**: Added optional `metadata` with `usage` and `duration` fields
- **streamManager.ts**: 
  - Extracted `getStreamMetadata()` helper to eliminate duplication
  - Used in both `cancelStreamSafely()` (abort case) and stream completion
  - Single source of truth for usage/duration extraction
- **StreamingMessageAggregator**: Store usage from abort events using spread operator (consistent with stream-end handling)

### Testing
- Added integration test: "should include usage data in stream-abort events"
- Verifies abort events contain usage metadata with token counts
- Tests both OpenAI and Anthropic providers

## Why This Matters

- **Accurate cost tracking**: Even interrupted work consumes tokens and costs money
- **Budget transparency**: Users can see what they paid for, even for partial results
- **DRY code**: Single helper method eliminates duplication between abort and completion paths

## No UI Changes

This PR focuses solely on backend tracking. Usage data is now available in abort events for future UI consumption.

_Generated with `cmux`_
