### PR TITLE
🤖 Make 1M context setting global instead of per-workspace

### DIFF
--- a/src/components/AIView.tsx
+++ b/src/components/AIView.tsx
@@ -324,7 +324,6 @@ const AIViewInner: React.FC<AIViewProps> = ({
       messages={messages}
       cmuxMessages={cmuxMessages}
       model={currentModel}
-      workspaceId={workspaceId}
     >
       <ViewContainer className={className}>
         <ChatArea>

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -306,7 +306,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   const modelSelectorRef = useRef<ModelSelectorRef>(null);
   const [thinkingLevel] = useThinkingLevel();
   const [mode, setMode] = useMode();
-  const [use1M] = use1MContext(workspaceId);
+  const [use1M] = use1MContext();
   const { recentModels } = useModelLRU();
 
   const focusMessageInput = useCallback(() => {

--- a/src/components/ChatMetaSidebar/CostsTab.tsx
+++ b/src/components/ChatMetaSidebar/CostsTab.tsx
@@ -280,9 +280,9 @@ const VIEW_MODE_OPTIONS: Array<ToggleOption<ViewMode>> = [
 ];
 
 export const CostsTab: React.FC = () => {
-  const { stats, isCalculating, workspaceId } = useChatContext();
+  const { stats, isCalculating } = useChatContext();
   const [viewMode, setViewMode] = usePersistedState<ViewMode>("costsTab:viewMode", "last-request");
-  const [use1M] = use1MContext(workspaceId);
+  const [use1M] = use1MContext();
 
   // Only show loading if we don't have any stats yet
   if (isCalculating && !stats) {

--- a/src/components/Context1MCheckbox.tsx
+++ b/src/components/Context1MCheckbox.tsx
@@ -67,7 +67,7 @@ export const Context1MCheckbox: React.FC<Context1MCheckboxProps> = ({
   workspaceId,
   modelString,
 }) => {
-  const [use1M, setUse1M] = use1MContext(workspaceId);
+  const [use1M, setUse1M] = use1MContext();
   const isSupported = supports1MContext(modelString);
 
   if (!isSupported) {

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -8,7 +8,6 @@ interface ChatContextType {
   messages: DisplayedMessage[];
   stats: ChatStats | null;
   isCalculating: boolean;
-  workspaceId: string;
 }
 
 const ChatContext = createContext<ChatContextType | undefined>(undefined);
@@ -18,7 +17,6 @@ interface ChatProviderProps {
   messages: DisplayedMessage[];
   cmuxMessages: CmuxMessage[];
   model: string;
-  workspaceId: string;
 }
 
 export const ChatProvider: React.FC<ChatProviderProps> = ({
@@ -26,7 +24,6 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   messages,
   cmuxMessages,
   model,
-  workspaceId,
 }) => {
   const [stats, setStats] = useState<ChatStats | null>(null);
   const [isCalculating, setIsCalculating] = useState(false);
@@ -91,7 +88,7 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   }, [cmuxMessages, model]);
 
   return (
-    <ChatContext.Provider value={{ messages, stats, isCalculating, workspaceId }}>
+    <ChatContext.Provider value={{ messages, stats, isCalculating }}>
       {children}
     </ChatContext.Provider>
   );

--- a/src/hooks/use1MContext.ts
+++ b/src/hooks/use1MContext.ts
@@ -2,11 +2,10 @@ import { usePersistedState } from "@/hooks/usePersistedState";
 
 /**
  * Custom hook for 1M context state.
- * Persists state per workspace in localStorage.
+ * Persists state globally in localStorage (applies to all workspaces).
  *
- * @param workspaceId - Unique identifier for the workspace
  * @returns [use1MContext, setUse1MContext] tuple
  */
-export function use1MContext(workspaceId: string): [boolean, (value: boolean) => void] {
-  return usePersistedState<boolean>(`use1MContext:${workspaceId}`, false);
+export function use1MContext(): [boolean, (value: boolean) => void] {
+  return usePersistedState<boolean>("use1MContext", false);
 }


### PR DESCRIPTION
## Summary

Make the 1M context checkbox setting global instead of per-workspace.

## Changes

- Updated `use1MContext` hook to use global localStorage key
- Removed `workspaceId` parameter from hook signature
- Updated all call sites: Context1MCheckbox, CostsTab, ChatInput
- Removed `workspaceId` from ChatContext (no longer needed)

## Rationale

Users typically want 1M context either on or off everywhere. Per-workspace state caused confusion when switching between workspaces.

## Testing

- ✅ make typecheck
- ✅ make test (273 tests passing)

_Generated with `cmux`_