### PR TITLE
test: add slash command mock scenarios and e2e coverage

### DIFF
--- a/src/services/mock/scenarios.ts
+++ b/src/services/mock/scenarios.ts
@@ -1,10 +1,12 @@
 import * as basicChat from "./scenarios/basicChat";
 import * as review from "./scenarios/review";
 import * as toolFlows from "./scenarios/toolFlows";
+import * as slashCommands from "./scenarios/slashCommands";
 import type { ScenarioTurn } from "./scenarioTypes";
 
 export const allScenarios: ScenarioTurn[] = [
   ...basicChat.scenarios,
   ...review.scenarios,
   ...toolFlows.scenarios,
+  ...slashCommands.scenarios,
 ];

--- a/src/services/mock/scenarios/slashCommands.ts
+++ b/src/services/mock/scenarios/slashCommands.ts
@@ -1,0 +1,133 @@
+import type { ScenarioTurn } from "../scenarioTypes";
+import { STREAM_BASE_DELAY } from "../scenarioTypes";
+
+export const SLASH_COMMAND_PROMPTS = {
+  MODEL_STATUS: "Please confirm which model is currently active for this conversation.",
+} as const;
+
+export const COMPACTION_MESSAGE =
+  "Summarize this conversation into a compact form for a new Assistant to continue helping the user. Use approximately 385 words. Keep technical details";
+
+export const COMPACT_SUMMARY_TEXT =
+  "Compact summary: The assistant read project files, listed directory contents, created and inspected test.txt, then confirmed the contents remained 'hello'. Technical details preserved.";
+
+const compactConversationTurn: ScenarioTurn = {
+  user: {
+    text: COMPACTION_MESSAGE,
+    thinkingLevel: "medium",
+    mode: "plan",
+  },
+  assistant: {
+    messageId: "msg-slash-compact-1",
+    events: [
+      {
+        kind: "stream-start",
+        delay: 0,
+        messageId: "msg-slash-compact-1",
+        model: "anthropic:claude-sonnet-4-5",
+      },
+      {
+        kind: "stream-delta",
+        delay: STREAM_BASE_DELAY,
+        text: "Preparing a compact technical summary based on prior tool results…\n",
+      },
+      {
+        kind: "tool-start",
+        delay: STREAM_BASE_DELAY * 2,
+        toolCallId: "tool-compact-summary",
+        toolName: "compact_summary",
+        args: {
+          targetWords: 385,
+          instructions: "Keep technical details",
+        },
+      },
+      {
+        kind: "tool-end",
+        delay: STREAM_BASE_DELAY * 3,
+        toolCallId: "tool-compact-summary",
+        toolName: "compact_summary",
+        result: {
+          success: true,
+          summary: COMPACT_SUMMARY_TEXT,
+          message: "Summary generated successfully.",
+        },
+      },
+      {
+        kind: "stream-delta",
+        delay: STREAM_BASE_DELAY * 3 + 100,
+        text: "Summary ready. Replacing history with the compacted version now.",
+      },
+      {
+        kind: "stream-end",
+        delay: STREAM_BASE_DELAY * 4,
+        metadata: {
+          model: "anthropic:claude-sonnet-4-5",
+          inputTokens: 220,
+          outputTokens: 96,
+          systemMessageTokens: 18,
+        },
+        parts: [
+          {
+            type: "text",
+            text: "Summary ready. Replacing history with the compacted version now.",
+          },
+          {
+            type: "dynamic-tool",
+            toolCallId: "tool-compact-summary",
+            toolName: "compact_summary",
+            state: "output-available",
+            input: {
+              targetWords: 385,
+              instructions: "Keep technical details",
+            },
+            output: {
+              summary: COMPACT_SUMMARY_TEXT,
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const modelStatusTurn: ScenarioTurn = {
+  user: {
+    text: SLASH_COMMAND_PROMPTS.MODEL_STATUS,
+    thinkingLevel: "low",
+    mode: "plan",
+  },
+  assistant: {
+    messageId: "msg-slash-model-status",
+    events: [
+      {
+        kind: "stream-start",
+        delay: 0,
+        messageId: "msg-slash-model-status",
+        model: "anthropic:claude-opus-4-1",
+      },
+      {
+        kind: "stream-delta",
+        delay: STREAM_BASE_DELAY,
+        text: "Claude Opus 4.1 is now responding with enhanced reasoning capacity.",
+      },
+      {
+        kind: "stream-end",
+        delay: STREAM_BASE_DELAY * 2,
+        metadata: {
+          model: "anthropic:claude-opus-4-1",
+          inputTokens: 70,
+          outputTokens: 54,
+          systemMessageTokens: 12,
+        },
+        parts: [
+          {
+            type: "text",
+            text: "I'm responding as Claude Opus 4.1, which you selected via /model opus. Let me know how to proceed.",
+          },
+        ],
+      },
+    ],
+  },
+};
+
+export const scenarios: ScenarioTurn[] = [compactConversationTurn, modelStatusTurn];

--- a/tests/e2e/scenarios/slashCommands.spec.ts
+++ b/tests/e2e/scenarios/slashCommands.spec.ts
@@ -1,0 +1,153 @@
+import fs from "fs/promises";
+import path from "path";
+import { parse } from "jsonc-parser";
+import { electronTest as test, electronExpect as expect } from "../electronTest";
+import { TOOL_FLOW_PROMPTS } from "@/services/mock/scenarios/toolFlows";
+import {
+  COMPACT_SUMMARY_TEXT,
+  SLASH_COMMAND_PROMPTS,
+} from "@/services/mock/scenarios/slashCommands";
+
+test.skip(
+  ({ browserName }) => browserName !== "chromium",
+  "Electron scenario runs on chromium only"
+);
+
+test.describe("slash command flows", () => {
+  test("slash command /clear resets conversation history", async ({ ui, page }) => {
+    await ui.projects.openFirstWorkspace();
+
+    await ui.chat.captureStreamTimeline(async () => {
+      await ui.chat.sendMessage(TOOL_FLOW_PROMPTS.FILE_READ);
+    });
+    await ui.chat.expectTranscriptContains("Mock README content");
+
+    await ui.chat.captureStreamTimeline(async () => {
+      await ui.chat.sendMessage(TOOL_FLOW_PROMPTS.LIST_DIRECTORY);
+    });
+    await ui.chat.expectTranscriptContains("Directory listing:");
+
+    await ui.chat.sendMessage("/clear");
+    await ui.chat.expectStatusMessageContains("Chat history cleared");
+
+    const transcript = page.getByRole("log", { name: "Conversation transcript" });
+    await expect(transcript.getByText("No Messages Yet")).toBeVisible();
+    await expect(transcript).not.toContainText("Mock README content");
+    await expect(transcript).not.toContainText("Directory listing:");
+  });
+
+  test("slash command /truncate 50 removes earlier context", async ({ ui, page }) => {
+    await ui.projects.openFirstWorkspace();
+
+    // Build a conversation with five distinct turns
+    const prompts = [
+      TOOL_FLOW_PROMPTS.FILE_READ,
+      TOOL_FLOW_PROMPTS.LIST_DIRECTORY,
+      TOOL_FLOW_PROMPTS.CREATE_TEST_FILE,
+      TOOL_FLOW_PROMPTS.READ_TEST_FILE,
+      TOOL_FLOW_PROMPTS.RECALL_TEST_FILE,
+    ];
+
+    for (const prompt of prompts) {
+      await ui.chat.captureStreamTimeline(async () => {
+        await ui.chat.sendMessage(prompt);
+      });
+    }
+
+    const transcript = page.getByRole("log", { name: "Conversation transcript" });
+    await expect(transcript).toContainText("Mock README content");
+    await expect(transcript).toContainText("hello");
+
+    await ui.chat.sendMessage("/truncate 50");
+    await ui.chat.expectStatusMessageContains("Chat history truncated by 50%");
+
+    await expect(transcript).not.toContainText("Mock README content");
+    await expect(transcript).toContainText("hello");
+  });
+
+  test("slash command /compact produces compacted summary", async ({ ui, page }) => {
+    await ui.projects.openFirstWorkspace();
+
+    const setupPrompts = [
+      TOOL_FLOW_PROMPTS.FILE_READ,
+      TOOL_FLOW_PROMPTS.LIST_DIRECTORY,
+      TOOL_FLOW_PROMPTS.CREATE_TEST_FILE,
+      TOOL_FLOW_PROMPTS.READ_TEST_FILE,
+    ];
+
+    for (const prompt of setupPrompts) {
+      await ui.chat.captureStreamTimeline(async () => {
+        await ui.chat.sendMessage(prompt);
+      });
+    }
+
+    const timeline = await ui.chat.captureStreamTimeline(
+      async () => {
+        await ui.chat.sendMessage("/compact 500 Keep technical details");
+      },
+      { timeoutMs: 20_000 }
+    );
+
+    await ui.chat.expectStatusMessageContains("Compaction started");
+    const compactToolStart = timeline.events.find(
+      (event) => event.type === "tool-call-start" && event.toolName === "compact_summary"
+    );
+    expect(compactToolStart).toBeDefined();
+
+    const transcript = page.getByRole("log", { name: "Conversation transcript" });
+    await ui.chat.expectTranscriptContains(COMPACT_SUMMARY_TEXT);
+    await expect(transcript).toContainText(COMPACT_SUMMARY_TEXT);
+    await expect(transcript.getByText("📦 compacted")).toBeVisible();
+    await expect(transcript).not.toContainText("Mock README content");
+    await expect(transcript).not.toContainText("Directory listing:");
+  });
+
+  test("slash command /model opus switches models for subsequent turns", async ({ ui, page }) => {
+    await ui.projects.openFirstWorkspace();
+
+    const modeToggles = page.locator('[data-component="ChatModeToggles"]');
+    await expect(
+      modeToggles.getByText("anthropic:claude-sonnet-4-5", { exact: true })
+    ).toBeVisible();
+
+    await ui.chat.sendMessage("/model opus");
+    await ui.chat.expectStatusMessageContains("Model changed to anthropic:claude-opus-4-1");
+    await expect(modeToggles.getByText("anthropic:claude-opus-4-1", { exact: true })).toBeVisible();
+
+    const timeline = await ui.chat.captureStreamTimeline(async () => {
+      await ui.chat.sendMessage(SLASH_COMMAND_PROMPTS.MODEL_STATUS);
+    });
+
+    const streamStart = timeline.events.find((event) => event.type === "stream-start");
+    expect(streamStart?.model).toBe("anthropic:claude-opus-4-1");
+    await ui.chat.expectTranscriptContains(
+      "Claude Opus 4.1 is now responding with enhanced reasoning capacity."
+    );
+  });
+
+  test("slash command /providers set anthropic baseUrl updates provider config", async ({
+    ui,
+    workspace,
+  }) => {
+    await ui.projects.openFirstWorkspace();
+
+    await ui.chat.sendMessage("/providers set anthropic baseUrl https://custom.endpoint");
+    await ui.chat.expectStatusMessageContains("Provider anthropic updated");
+
+    const providersPath = path.join(workspace.configRoot, "providers.jsonc");
+    await expect
+      .poll(async () => {
+        try {
+          await fs.access(providersPath);
+          return true;
+        } catch {
+          return false;
+        }
+      })
+      .toBeTruthy();
+    const content = await fs.readFile(providersPath, "utf-8");
+    const parsed = parse(content) as Record<string, unknown>;
+    const anthropicConfig = parsed?.anthropic as Record<string, unknown> | undefined;
+    expect(anthropicConfig?.baseUrl).toBe("https://custom.endpoint");
+  });
+});

--- a/tests/e2e/utils/ui.ts
+++ b/tests/e2e/utils/ui.ts
@@ -1,7 +1,7 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 import type { DemoProjectConfig } from "./demoProject";
 
-type ChatMode = "Plan" | "Exec" | "Yolo";
+type ChatMode = "Plan" | "Exec";
 
 export interface StreamTimelineEvent {
   type: string;
@@ -51,8 +51,6 @@ function sanitizeMode(mode: ChatMode): ChatMode {
       return "Plan";
     case "exec":
       return "Exec";
-    case "yolo":
-      return "Yolo";
     default:
       throw new Error(`Unsupported chat mode: ${mode as string}`);
   }


### PR DESCRIPTION
Add mock slash command turns so UI can replay compaction and model status flows without hitting real providers.
Exercise slash command behaviors end to end, covering `/clear`, `/truncate`, `/compact`, `/model`, and provider overrides.
Assert provider baseUrl writes by inspecting providers.jsonc.