### PR TITLE
🤖 Fix: Auto-retry stream-error messages + add debug logging

### DIFF
--- a/src/hooks/useResumeManager.ts
+++ b/src/hooks/useResumeManager.ts
@@ -69,7 +69,7 @@ export function useResumeManager(workspaceStates: Map<string, WorkspaceState>) {
     if (!state) {
       // Debug: Log why workspace not found
       const allWorkspaceIds = Array.from(workspaceStatesRef.current.keys());
-      console.log(
+      console.debug(
         `[useResumeManager] Workspace ${workspaceId} not in Map. Available:`,
         allWorkspaceIds
       );
@@ -89,7 +89,7 @@ export function useResumeManager(workspaceStates: Map<string, WorkspaceState>) {
       (lastMessage.type === "reasoning" && lastMessage.isPartial);
 
     if (!hasInterruptedStream) {
-      console.log(
+      console.debug(
         `[useResumeManager] ${workspaceId} not eligible: last message type=${lastMessage.type} isPartial=${"isPartial" in lastMessage ? lastMessage.isPartial : "N/A"}`
       );
       return false;


### PR DESCRIPTION
## Problem

Workspaces with stream errors were stuck showing "Retrying... (attempt 1)" forever without actually retrying.

**Root cause:** `useResumeManager` only checked for partial assistant/tool/reasoning messages when determining eligibility for resume. When a stream errors, the UI adds a `stream-error` message instead, which wasn't being recognized as an interrupted stream.

## Diagnosis

Added debug logging that revealed:
```
[useResumeManager] cmux-pm-bugs not eligible: last message type=stream-error isPartial=N/A
```

The workspace had `autoRetry=true` and no retry state (immediately eligible), but failed the interrupted stream check because the last message was type `stream-error`.

## Fix

Check for `stream-error` messages in addition to partial messages:

```typescript
const hasInterruptedStream =
  lastMessage.type === "stream-error" || // NEW: Stream errored out
  (lastMessage.type === "assistant" && lastMessage.isPartial) ||
  (lastMessage.type === "tool" && lastMessage.isPartial) ||
  (lastMessage.type === "reasoning" && lastMessage.isPartial);
```

## Debug Logging Added

Added helpful debug logs to diagnose future issues:
- When workspace not found in Map, shows available workspaces
- When no interrupted stream found, shows last message type and isPartial status

These logs help quickly identify why retry isn't happening.

## Testing

- ✅ Type checking passes
- ✅ Tested on `cmux-pm-bugs` workspace that was stuck
- ✅ Should now auto-retry on stream errors

## Impact

Fixes the stuck retry issue while maintaining all existing behavior for partial message retries.

_Generated with `cmux`_
