### PR TITLE
🤖 Fix /compact not respecting centralized sendMessageOptions

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -559,8 +559,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
             // so disable thinking for Anthropic models during compaction
             const isAnthropic = sendMessageOptions.model.startsWith("anthropic:");
             const result = await window.api.workspace.sendMessage(workspaceId, compactionMessage, {
+              ...sendMessageOptions,
               thinkingLevel: isAnthropic ? "off" : sendMessageOptions.thinkingLevel,
-              model: sendMessageOptions.model,
               toolPolicy: [{ regex_match: "compact_summary", action: "require" }],
               maxOutputTokens: parsed.maxOutputTokens, // Pass to model directly
             });


### PR DESCRIPTION
## Problem

The `/compact` slash command was not respecting centralized `sendMessageOptions`, specifically:
- ❌ Missing `providerOptions.anthropic.use1MContext` (1M context flag)
- ❌ Missing `additionalSystemInstructions` (plan mode instructions)

This meant that when users had the 1M context toggle enabled, compact operations would still use the default 200k context limit, potentially failing on large conversations.

## Solution

Changed the compact handler to spread `sendMessageOptions` first, then override only the specific fields needed for compaction:

```typescript
// Before - manual construction missing providerOptions
const result = await window.api.workspace.sendMessage(workspaceId, compactionMessage, {
  thinkingLevel: isAnthropic ? "off" : sendMessageOptions.thinkingLevel,
  model: sendMessageOptions.model,
  toolPolicy: [{ regex_match: "compact_summary", action: "require" }],
  maxOutputTokens: parsed.maxOutputTokens,
});

// After - spread first, preserves all centralized options
const result = await window.api.workspace.sendMessage(workspaceId, compactionMessage, {
  ...sendMessageOptions,
  thinkingLevel: isAnthropic ? "off" : sendMessageOptions.thinkingLevel,
  toolPolicy: [{ regex_match: "compact_summary", action: "require" }],
  maxOutputTokens: parsed.maxOutputTokens,
});
```

This matches the pattern used in the regular message send path (ChatInput.tsx:610).

## Impact

- ✅ Compact operations now respect the 1M context toggle
- ✅ Compact operations respect plan mode instructions
- ✅ Consistent with other message send paths

## Verification

Audited all `window.api.workspace.sendMessage` calls:
- ✅ Regular message send - already using spread pattern
- ✅ Resume/retry - uses `getSendOptionsFromStorage()` which includes providerOptions
- ✅ Interrupt calls - empty message, no options needed

_Generated with `cmux`_