### PR TITLE
refactor: Remove YOLO permission mode references

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ When writing user-facing documentation, follow these principles:
 ## Features
 
 - 🔀 Git worktree integration for multi-branch workflows
-- 🤖 Multiple AI permission modes (plan/edit/yolo)
+- 🤖 Multiple AI permission modes (plan/edit)
 - 📦 Multi-project management
 - 💬 Persistent session history
 - ⌨️ Keyboard-first interface

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -249,7 +249,6 @@ This project uses **Make** as the primary build orchestrator. See `Makefile` for
   const MODE_COLORS: Record<UIPermissionMode, string> = {
     plan: "var(--color-plan-mode)",
     edit: "var(--color-edit-mode)",
-    yolo: "var(--color-yolo-mode)",
   };
 
   // ❌ Avoid - Can miss cases, typos won't be caught

--- a/docs/theme/custom.css
+++ b/docs/theme/custom.css
@@ -20,7 +20,6 @@
   --color-plan-mode-hover: color-mix(in srgb, var(--color-plan-mode), white 20%);
   --color-exec-mode: hsl(268.56 94.04% 55.19%);
   --color-edit-mode: hsl(120 50% 35%);
-  --color-yolo-mode: hsl(0 70% 45%);
   --color-interrupted: hsl(38 92% 50%);
 
   /* Docs-specific tokens */

--- a/src/styles/colors.tsx
+++ b/src/styles/colors.tsx
@@ -36,13 +36,6 @@ export const GlobalColors = () => (
         --color-edit-mode-alpha: hsl(from var(--color-edit-mode) h s l / 0.1);
         --color-edit-mode-alpha-hover: hsl(from var(--color-edit-mode) h s l / 0.15);
 
-        /* YOLO Mode Colors */
-        --color-yolo-mode: hsl(0 70% 45%);
-        --color-yolo-mode-hover: color-mix(in srgb, var(--color-yolo-mode), white 20%);
-        --color-yolo-mode-light: color-mix(in srgb, var(--color-yolo-mode) 60%, white);
-        --color-yolo-mode-alpha: hsl(from var(--color-yolo-mode) h s l / 0.1);
-        --color-yolo-mode-alpha-hover: hsl(from var(--color-yolo-mode) h s l / 0.15);
-
         /* Editing Mode Colors */
         --color-editing-mode: hsl(30 100% 50%);
         --color-editing-mode-alpha: hsl(from var(--color-editing-mode) h s l / 0.1);

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,7 +1,7 @@
 import type { IPCApi } from "./ipc";
 
 // Our simplified permission modes for UI
-export type UIPermissionMode = "plan" | "edit" | "yolo";
+export type UIPermissionMode = "plan" | "edit";
 
 // Claude SDK permission modes
 export type SDKPermissionMode = "default" | "acceptEdits" | "bypassPermissions" | "plan";


### PR DESCRIPTION
Drop residual YOLO mode mentions from docs, styles, and UI types to match current plan/edit permission set and avoid dead enum values.