### PR TITLE
test: add permission mode mock scenarios

### DIFF
--- a/src/services/mock/scenarios.ts
+++ b/src/services/mock/scenarios.ts
@@ -2,6 +2,7 @@ import * as basicChat from "./scenarios/basicChat";
 import * as review from "./scenarios/review";
 import * as toolFlows from "./scenarios/toolFlows";
 import * as slashCommands from "./scenarios/slashCommands";
+import * as permissionModes from "./scenarios/permissionModes";
 import type { ScenarioTurn } from "./scenarioTypes";
 
 export const allScenarios: ScenarioTurn[] = [
@@ -9,4 +10,5 @@ export const allScenarios: ScenarioTurn[] = [
   ...review.scenarios,
   ...toolFlows.scenarios,
   ...slashCommands.scenarios,
+  ...permissionModes.scenarios,
 ];

--- a/src/services/mock/scenarios/permissionModes.ts
+++ b/src/services/mock/scenarios/permissionModes.ts
@@ -1,0 +1,137 @@
+import type { ScenarioTurn } from "../scenarioTypes";
+import { STREAM_BASE_DELAY } from "../scenarioTypes";
+
+export const PERMISSION_MODE_PROMPTS = {
+  PLAN_REFACTOR: "How should I refactor this function?",
+  EXECUTE_PLAN: "Do it",
+} as const;
+
+const planRefactorTurn: ScenarioTurn = {
+  user: {
+    text: PERMISSION_MODE_PROMPTS.PLAN_REFACTOR,
+    thinkingLevel: "medium",
+    mode: "plan",
+  },
+  assistant: {
+    messageId: "msg-plan-refactor",
+    events: [
+      {
+        kind: "stream-start",
+        delay: 0,
+        messageId: "msg-plan-refactor",
+        model: "mock:planner",
+      },
+      {
+        kind: "stream-delta",
+        delay: STREAM_BASE_DELAY,
+        text: "Plan summary:\n",
+      },
+      {
+        kind: "stream-delta",
+        delay: STREAM_BASE_DELAY * 2,
+        text: "1. Extract validation into verifyInputs().\n",
+      },
+      {
+        kind: "stream-delta",
+        delay: STREAM_BASE_DELAY * 3,
+        text: "2. Move formatting logic into buildResponse().\n",
+      },
+      {
+        kind: "stream-delta",
+        delay: STREAM_BASE_DELAY * 4,
+        text: "3. Keep handleRequest lean by delegating to helpers.",
+      },
+      {
+        kind: "stream-end",
+        delay: STREAM_BASE_DELAY * 5,
+        metadata: {
+          model: "mock:planner",
+          inputTokens: 180,
+          outputTokens: 130,
+          systemMessageTokens: 24,
+        },
+        parts: [
+          { type: "text", text: "Plan summary:\n" },
+          { type: "text", text: "1. Extract validation into verifyInputs().\n" },
+          { type: "text", text: "2. Move formatting logic into buildResponse().\n" },
+          { type: "text", text: "3. Keep handleRequest lean by delegating to helpers." },
+        ],
+      },
+    ],
+  },
+};
+
+const executePlanTurn: ScenarioTurn = {
+  user: {
+    text: PERMISSION_MODE_PROMPTS.EXECUTE_PLAN,
+    thinkingLevel: "low",
+    mode: "exec",
+  },
+  assistant: {
+    messageId: "msg-exec-refactor",
+    events: [
+      {
+        kind: "stream-start",
+        delay: 0,
+        messageId: "msg-exec-refactor",
+        model: "mock:executor",
+      },
+      {
+        kind: "tool-start",
+        delay: STREAM_BASE_DELAY,
+        toolCallId: "tool-apply-refactor",
+        toolName: "bash",
+        args: {
+          script:
+            'apply_patch <<\'PATCH\'\n*** Begin Patch\n*** Update File: src/utils/legacyFunction.ts\n@@\n-export function handleRequest(input: Request) {\n-  if (!input.userId || !input.payload) {\n-    throw new Error("Missing fields");\n-  }\n-\n-  const result = heavyFormatter(input.payload);\n-  return {\n-    id: input.userId,\n-    details: result,\n-  };\n-}\n+function verifyInputs(input: Request) {\n+  if (!input.userId || !input.payload) {\n+    throw new Error("Missing fields");\n+  }\n+}\n+\n+function buildResponse(input: Request) {\n+  const result = heavyFormatter(input.payload);\n+  return { id: input.userId, details: result };\n+}\n+\n+export function handleRequest(input: Request) {\n+  verifyInputs(input);\n+  return buildResponse(input);\n+}\n*** End Patch\nPATCH',
+          timeout_secs: 10,
+          max_lines: 200,
+        },
+      },
+      {
+        kind: "tool-end",
+        delay: STREAM_BASE_DELAY * 2,
+        toolCallId: "tool-apply-refactor",
+        toolName: "bash",
+        result: {
+          success: true,
+          output: "patch applied\n",
+          exitCode: 0,
+          wall_duration_ms: 180,
+        },
+      },
+      {
+        kind: "stream-delta",
+        delay: STREAM_BASE_DELAY * 2 + 100,
+        text: "Applied refactor plan:\n",
+      },
+      {
+        kind: "stream-delta",
+        delay: STREAM_BASE_DELAY * 2 + 200,
+        text: "- Updated src/utils/legacyFunction.ts\n",
+      },
+      {
+        kind: "stream-delta",
+        delay: STREAM_BASE_DELAY * 2 + 300,
+        text: "- Extracted verifyInputs and buildResponse helpers.",
+      },
+      {
+        kind: "stream-end",
+        delay: STREAM_BASE_DELAY * 3,
+        metadata: {
+          model: "mock:executor",
+          inputTokens: 220,
+          outputTokens: 110,
+          systemMessageTokens: 18,
+        },
+        parts: [
+          { type: "text", text: "Applied refactor plan:\n" },
+          { type: "text", text: "- Updated src/utils/legacyFunction.ts\n" },
+          { type: "text", text: "- Extracted verifyInputs and buildResponse helpers." },
+        ],
+      },
+    ],
+  },
+};
+
+export const scenarios: ScenarioTurn[] = [planRefactorTurn, executePlanTurn];

--- a/tests/e2e/scenarios/permissionModes.spec.ts
+++ b/tests/e2e/scenarios/permissionModes.spec.ts
@@ -1,0 +1,66 @@
+import { electronTest as test, electronExpect as expect } from "../electronTest";
+import { PERMISSION_MODE_PROMPTS } from "@/services/mock/scenarios/permissionModes";
+
+test.skip(
+  ({ browserName }) => browserName !== "chromium",
+  "Electron scenario runs on chromium only"
+);
+
+test.describe("permission mode behavior", () => {
+  test("plan mode streams plan-only response", async ({ ui }) => {
+    await ui.projects.openFirstWorkspace();
+    await ui.chat.setMode("Plan");
+
+    const timeline = await ui.chat.captureStreamTimeline(async () => {
+      await ui.chat.sendMessage(PERMISSION_MODE_PROMPTS.PLAN_REFACTOR);
+    });
+
+    if (timeline.events.length === 0) {
+      throw new Error("Plan mode timeline must contain events");
+    }
+
+    const eventTypes = timeline.events.map((event) => event.type);
+    expect(eventTypes[0]).toBe("stream-start");
+    expect(eventTypes[eventTypes.length - 1]).toBe("stream-end");
+    expect(eventTypes.includes("tool-call-start")).toBe(false);
+    expect(eventTypes.includes("tool-call-end")).toBe(false);
+
+    await ui.chat.expectTranscriptContains("Plan summary:");
+    await ui.chat.expectTranscriptContains("Extract validation into verifyInputs().");
+  });
+
+  test("exec mode performs tool call and reports results", async ({ ui }) => {
+    await ui.projects.openFirstWorkspace();
+    await ui.chat.setMode("Exec");
+
+    const timeline = await ui.chat.captureStreamTimeline(async () => {
+      await ui.chat.sendMessage(PERMISSION_MODE_PROMPTS.EXECUTE_PLAN);
+    });
+
+    if (timeline.events.length === 0) {
+      throw new Error("Exec mode timeline must contain events");
+    }
+
+    const eventTypes = timeline.events.map((event) => event.type);
+    const toolStartIndex = eventTypes.indexOf("tool-call-start");
+    const toolEndIndex = eventTypes.indexOf("tool-call-end");
+    expect(toolStartIndex).toBeGreaterThanOrEqual(0);
+    expect(toolEndIndex).toBeGreaterThan(toolStartIndex);
+
+    const toolStart = timeline.events[toolStartIndex];
+    if (!toolStart) {
+      throw new Error("Missing tool-call-start event in exec mode timeline");
+    }
+    expect(toolStart.toolName).toBe("bash");
+
+    const toolEnd = timeline.events[toolEndIndex];
+    if (!toolEnd) {
+      throw new Error("Missing tool-call-end event in exec mode timeline");
+    }
+    expect(toolEnd.toolName).toBe("bash");
+    expect(toolEnd.result).toMatchObject({ success: true });
+
+    await ui.chat.expectTranscriptContains("Applied refactor plan:");
+    await ui.chat.expectTranscriptContains("Updated src/utils/legacyFunction.ts");
+  });
+});


### PR DESCRIPTION
Introduce mock plan/exec turns to validate permission workflows. Add chromium-only e2e coverage for streaming and tool invocation.