### PR TITLE
🤖 Fix type guards for file edit tools (remove lease checks)

### DIFF
--- a/src/components/Messages/ToolMessage.tsx
+++ b/src/components/Messages/ToolMessage.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { TOOL_DEFINITIONS } from "@/utils/tools/toolDefinitions";
 import type { DisplayedMessage } from "@/types/message";
 import { GenericToolCall } from "../tools/GenericToolCall";
 import { BashToolCall } from "../tools/BashToolCall";
@@ -24,52 +25,31 @@ interface ToolMessageProps {
   workspaceId?: string;
 }
 
-// Type guard for bash tool
+// Type guards using Zod schemas for single source of truth
+// This ensures type guards stay in sync with tool definitions
 function isBashTool(toolName: string, args: unknown): args is BashToolArgs {
-  return (
-    toolName === "bash" &&
-    typeof args === "object" &&
-    args !== null &&
-    "script" in args &&
-    "timeout_secs" in args
-  );
+  if (toolName !== "bash") return false;
+  return TOOL_DEFINITIONS.bash.schema.safeParse(args).success;
 }
 
-// Type guard for file_read tool
 function isFileReadTool(toolName: string, args: unknown): args is FileReadToolArgs {
-  return (
-    toolName === "file_read" && typeof args === "object" && args !== null && "filePath" in args
-  );
+  if (toolName !== "file_read") return false;
+  return TOOL_DEFINITIONS.file_read.schema.safeParse(args).success;
 }
 
-// Type guard for file_edit_replace tool
 function isFileEditReplaceTool(toolName: string, args: unknown): args is FileEditReplaceToolArgs {
-  return (
-    toolName === "file_edit_replace" &&
-    typeof args === "object" &&
-    args !== null &&
-    "file_path" in args &&
-    "edits" in args &&
-    "lease" in args
-  );
+  if (toolName !== "file_edit_replace") return false;
+  return TOOL_DEFINITIONS.file_edit_replace.schema.safeParse(args).success;
 }
 
-// Type guard for file_edit_insert tool
 function isFileEditInsertTool(toolName: string, args: unknown): args is FileEditInsertToolArgs {
-  return (
-    toolName === "file_edit_insert" &&
-    typeof args === "object" &&
-    args !== null &&
-    "file_path" in args &&
-    "line_offset" in args &&
-    "content" in args &&
-    "lease" in args
-  );
+  if (toolName !== "file_edit_insert") return false;
+  return TOOL_DEFINITIONS.file_edit_insert.schema.safeParse(args).success;
 }
 
-// Type guard for propose_plan tool
 function isProposePlanTool(toolName: string, args: unknown): args is ProposePlanToolArgs {
-  return toolName === "propose_plan" && typeof args === "object" && args !== null && "plan" in args;
+  if (toolName !== "propose_plan") return false;
+  return TOOL_DEFINITIONS.propose_plan.schema.safeParse(args).success;
 }
 
 export const ToolMessage: React.FC<ToolMessageProps> = ({ message, className, workspaceId }) => {


### PR DESCRIPTION
## Problem

After removing the lease concept from file operations in #136, the type guards in `ToolMessage.tsx` were still checking for the presence of `lease` in the tool arguments. This exposed a deeper architectural issue: **hand-written type guards can drift from type definitions**.

## Root Cause

Type guards used manual property checks that TypeScript can't verify match the actual types:

```typescript
// ❌ Problem: Can get out of sync with type definition
function isFileEditReplaceTool(toolName: string, args: unknown): args is FileEditReplaceToolArgs {
  return (
    toolName === "file_edit_replace" &&
    typeof args === "object" &&
    args !== null &&
    "file_path" in args &&
    "edits" in args &&
    "lease" in args  // ← TypeScript doesn't verify this matches FileEditReplaceToolArgs!
  );
}
```

## Solution: Schema-Driven Type Guards

Use the existing Zod schemas from `toolDefinitions.ts` as the single source of truth:

```typescript
// ✅ Solution: Uses schema validation - always in sync
import { TOOL_DEFINITIONS } from "@/utils/tools/toolDefinitions";

function isFileEditReplaceTool(toolName: string, args: unknown): args is FileEditReplaceToolArgs {
  if (toolName !== "file_edit_replace") return false;
  return TOOL_DEFINITIONS.file_edit_replace.schema.safeParse(args).success;
}
```

## Benefits

1. **Single source of truth**: Zod schemas define both runtime validation and TypeScript types
2. **Automatic sync**: Schema changes automatically propagate to type guards
3. **More robust**: Validates full structure, not just key presence
4. **Future-proof**: Prevents entire category of drift bugs

## Changes

- Import `TOOL_DEFINITIONS` from `toolDefinitions.ts`
- Replace all manual type guards with schema-based validation
- Apply to all tools: `bash`, `file_read`, `file_edit_replace`, `file_edit_insert`, `propose_plan`
- Net result: -33 lines of manual validation code, +13 lines of schema-driven validation

## Related

- Depends on #136 (Remove lease concept from file operations)

_Generated with `cmux`_