### PR TITLE
🤖 Hide menu bar on Linux by default

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -177,6 +177,9 @@ function createWindow() {
       preload: path.join(__dirname, "preload.js"),
     },
     title: "cmux - coder multiplexer",
+    // Hide menu bar on Linux by default (like VS Code)
+    // User can press Alt to toggle it
+    autoHideMenuBar: process.platform === "linux",
   });
 
   // Register IPC handlers with the main window


### PR DESCRIPTION
Hides the menu bar on Linux by default (similar to VS Code UX). Users can press Alt to toggle visibility.

**Why:**
The traditional menu bar looks outdated on Linux. VS Code and other modern apps hide it by default for a cleaner look.

**Changes:**
- Set `autoHideMenuBar: true` for Linux platform in BrowserWindow options
- Menu remains accessible via Alt key toggle
- macOS and Windows behavior unchanged

**Testing:**
- [ ] Verify menu bar is hidden on Linux launch
- [ ] Verify Alt key toggles menu visibility
- [ ] Verify macOS/Windows show menu bar normally

_Generated with `cmux`_