### PR TITLE
chore: add nix formatting support to build tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,12 @@ jobs:
           curl -sS https://webinstall.dev/shfmt | bash
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
       - name: Run static checks
         run: make -j3 static-check
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 
 .PHONY: all build dev start clean help
 .PHONY: build-renderer
-.PHONY: lint lint-fix fmt fmt-check fmt-shell fmt-shell-check typecheck static-check
+.PHONY: lint lint-fix fmt fmt-check fmt-shell fmt-nix fmt-nix-check fmt-shell-check typecheck static-check
 .PHONY: test test-unit test-integration test-watch test-coverage test-e2e
 .PHONY: dist dist-mac dist-win dist-linux
 .PHONY: docs docs-build docs-watch
@@ -46,7 +46,7 @@ dev: build-main ## Start development server (Vite + TypeScript watcher)
 		"vite"
 
 start: build-main build-preload ## Build and start Electron app
-	@electron .
+	@bun x electron --remote-debugging-port=9222 .
 
 ## Build targets (can run in parallel)
 build: src/version.ts build-renderer build-main build-preload ## Build all targets
@@ -90,11 +90,17 @@ fmt: ## Format code with Prettier
 	@bun x prettier --write $(PRETTIER_PATTERNS)
 
 fmt-check: ## Check code formatting
-	@echo "Checking TypeScript/JSON/Markdown formatting..."
-	@bun x prettier --check $(PRETTIER_PATTERNS)
+	@./scripts/fmt.sh --check
+	@./scripts/fmt.sh --nix-check
 
 fmt-shell: ## Format shell scripts with shfmt
 	@./scripts/fmt.sh --shell
+
+fmt-nix: ## Format flake.nix with nix fmt
+	@./scripts/fmt.sh --nix
+
+fmt-nix-check: ## Check flake.nix formatting
+	@./scripts/fmt.sh --nix-check
 
 typecheck: src/version.ts ## Run TypeScript type checking
 	@./scripts/typecheck.sh

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -16,14 +16,68 @@ PRETTIER_PATTERNS=(
 
 run_prettier() {
   local mode="$1"
+  local prettier_cmd
+  if command -v prettier &>/dev/null; then
+    prettier_cmd=(prettier)
+  elif command -v bun &>/dev/null; then
+    prettier_cmd=(bun x prettier)
+  else
+    echo "Error: prettier not found. Install Prettier or Bun to run formatting."
+    exit 1
+  fi
+
   if [ "$mode" = "--check" ]; then
     echo "Checking TypeScript/JSON/Markdown formatting..."
-    prettier --check "${PRETTIER_PATTERNS[@]}"
+    "${prettier_cmd[@]}" --check "${PRETTIER_PATTERNS[@]}"
   else
     echo "Formatting TypeScript/JSON/Markdown files..."
-    prettier --write "${PRETTIER_PATTERNS[@]}"
+    "${prettier_cmd[@]}" --write "${PRETTIER_PATTERNS[@]}"
   fi
 }
+
+format_nix() {
+  if ! command -v nix &>/dev/null; then
+    echo "Error: nix command not found. Install Nix to format flake.nix."
+    exit 1
+  fi
+
+  local flake_path="$PROJECT_ROOT/flake.nix"
+  if [ ! -f "$flake_path" ]; then
+    echo "flake.nix not found at $flake_path; skipping Nix formatting."
+    return
+  fi
+
+  echo "Formatting Nix flake..."
+  nix fmt -- flake.nix
+}
+
+check_nix_format() (
+  if ! command -v nix &>/dev/null; then
+    echo "Error: nix command not found. Install Nix to check flake.nix formatting."
+    exit 1
+  fi
+
+  local flake_path="$PROJECT_ROOT/flake.nix"
+  if [ ! -f "$flake_path" ]; then
+    echo "flake.nix not found at $flake_path; skipping Nix format check."
+    exit 0
+  fi
+
+  local tmp_dir
+  tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/fmt-nix-check.XXXXXX")"
+  trap 'rm -rf "$tmp_dir"' EXIT
+  cp "$flake_path" "$tmp_dir/flake.nix"
+  (
+    cd "$tmp_dir"
+    nix fmt -- flake.nix
+  )
+
+  if ! cmp -s "$flake_path" "$tmp_dir/flake.nix"; then
+    echo "flake.nix is not formatted correctly. Run ./scripts/fmt.sh --nix or make fmt-nix."
+    diff -u "$flake_path" "$tmp_dir/flake.nix" || true
+    exit 1
+  fi
+)
 
 format_shell() {
   if ! command -v shfmt &>/dev/null; then
@@ -46,8 +100,13 @@ if [ "$1" = "--check" ]; then
   run_prettier --check
 elif [ "$1" = "--shell" ]; then
   format_shell
+elif [ "$1" = "--nix" ]; then
+  format_nix
+elif [ "$1" = "--nix-check" ]; then
+  check_nix_format
 elif [ "$1" = "--all" ]; then
   run_prettier
+  format_nix
   format_shell
 else
   run_prettier


### PR DESCRIPTION
Install Nix in CI to enable nixfmt and ensure flake formatting checks.
Add fmt-nix targets and script support for nix fmt plus prettier.
Run Electron via bun x to expose remote debugging port by default.
