### PR TITLE
🤖 Fix window title to show branch name correctly

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -183,7 +183,9 @@ function AppInner() {
   // Update window title when workspace changes
   useEffect(() => {
     if (selectedWorkspace) {
-      const title = `${selectedWorkspace.workspaceId} - ${selectedWorkspace.projectName} - cmux`;
+      // Extract branch name from workspace path (last path component)
+      const branch = selectedWorkspace.workspacePath.split("/").pop() ?? "unknown";
+      const title = `${branch} - ${selectedWorkspace.projectName} - cmux`;
       void window.api.window.setTitle(title);
     } else {
       void window.api.window.setTitle("cmux");


### PR DESCRIPTION
Window title was showing the full workspaceId (e.g., `cmux-duplicate-titles`) which duplicated the project name.

Now extracts the branch name from the workspace path (last path component), matching the sidebar's display logic.

**Result:** `duplicate-titles - cmux - cmux` instead of `cmux-duplicate-titles - cmux - cmux`

_Generated with `cmux`_