### PR TITLE
🤖 Fix: Display workspace removal errors and auto-focus chat input

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -452,6 +452,15 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       window.removeEventListener(CUSTOM_EVENTS.THINKING_LEVEL_TOAST, handler as EventListener);
   }, [workspaceId, setToast]);
 
+  // Auto-focus chat input when workspace changes (e.g., new workspace created or switched)
+  useEffect(() => {
+    // Small delay to ensure DOM is ready and other components have settled
+    const timer = setTimeout(() => {
+      focusMessageInput();
+    }, 100);
+    return () => clearTimeout(timer);
+  }, [workspaceId, focusMessageInput]);
+
   // Handle paste events to extract images
   const handlePaste = useCallback((e: React.ClipboardEvent<HTMLTextAreaElement>) => {
     const items = e.clipboardData?.items;


### PR DESCRIPTION
## Issues Fixed

### 1. Workspace removal errors not visible ❌ → ✅

**Problem**: When workspace removal fails (e.g., due to uncommitted changes), error was logged to console but not shown in UI.

**Root Cause**: `ProjectsList` has `overflow-y: auto` which clips absolutely positioned children. The error container was positioned absolutely below the workspace item, but the scroll container cut it off.

**Example error that was hidden:**
```
Failed to remove workspace: fatal: '/path/to/workspace' contains modified or untracked files, use --force to delete it
```

**Solution**: 
- Use React Portal (`createPortal()`) to render error outside the scrolling container
- New `RemoveErrorToast` component with fixed positioning at bottom center of viewport
- Toast automatically dismisses after 5 seconds
- High z-index (10000) ensures visibility over all other content

**Visual:**
- Fixed position at bottom center of screen
- Red background with border matching error color scheme
- Monospace font for technical error messages
- Word-wrapping for long git error messages

### 2. Chat input not auto-focusing on new workspace 🔍 → ✅

**Problem**: When creating a new workspace, the chat input didn't auto-focus, requiring user to manually click before typing.

**Why it worked for workspace switching**: When using command palette to switch workspaces, focus already in document from typing in palette, so worked by coincidence.

**Solution**: 
- Add `useEffect` that focuses input whenever `workspaceId` changes
- Small 100ms delay ensures:
  - DOM is fully rendered
  - Other components have settled
  - React lifecycle is complete
- Uses existing `focusMessageInput()` helper which:
  - Checks if element is disabled before focusing
  - Positions cursor at end of text
  - Auto-resizes textarea

## Testing

### Manual Testing Checklist:

**Workspace Removal Errors:**
- [ ] Try to remove workspace with uncommitted changes → error toast appears
- [ ] Error toast is visible (not clipped by scroll container)
- [ ] Error auto-dismisses after 5 seconds
- [ ] Error message shows full git error text
- [ ] Can remove clean workspace successfully (no error)

**Chat Input Focus:**
- [ ] Create new workspace → chat input auto-focuses
- [ ] Switch workspace via command palette → chat input auto-focuses  
- [ ] Switch workspace via sidebar click → chat input auto-focuses
- [ ] Type immediately after workspace change (no manual click needed)

### Static Checks:
- ✅ TypeScript compilation
- ✅ ESLint
- ✅ Formatting

## Technical Details

**New Components:**
```typescript
const RemoveErrorToast = styled.div`
  position: fixed;
  bottom: 20px;
  left: 50%;
  transform: translateX(-50%);
  max-width: 600px;
  z-index: 10000;
  // ... error styling
`;
```

**Portal Rendering:**
```typescript
{removeError && createPortal(
  <RemoveErrorToast>
    Failed to remove workspace: {removeError.error}
  </RemoveErrorToast>,
  document.body
)}
```

**Auto-Focus:**
```typescript
useEffect(() => {
  const timer = setTimeout(() => {
    focusMessageInput();
  }, 100);
  return () => clearTimeout(timer);
}, [workspaceId, focusMessageInput]);
```

## Impact

- **Better UX**: Users now see clear error messages when operations fail
- **Less confusion**: No more silent failures that appear successful
- **Faster workflow**: No manual clicking needed to start typing in new workspaces
- **Better error messages**: Full git error text visible (including suggestions like "use --force")

_Generated with `cmux`_