### PR TITLE
🤖 fix: require Control for cancel edit on mac

### DIFF
--- a/src/utils/ui/keybinds.ts
+++ b/src/utils/ui/keybinds.ts
@@ -190,7 +190,7 @@ export const KEYBINDS = {
   CANCEL: { key: "Escape" },
 
   /** Cancel editing message (exit edit mode) */
-  CANCEL_EDIT: { key: "q", ctrl: true },
+  CANCEL_EDIT: { key: "q", ctrl: true, macCtrlBehavior: "control" },
 
   /** Interrupt active stream (destructive - stops AI generation) */
   INTERRUPT_STREAM: { key: "c", ctrl: true, macCtrlBehavior: "control" },


### PR DESCRIPTION
## Summary
- require Control on mac for the cancel-edit shortcut so we no longer intercept ⌘+Q

## Testing
- make typecheck (fails: existing JSX intrinsic element/type resolution errors)

_Generated with `cmux`_