### PR TITLE
test: allow e2e suite to run against dist bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,8 @@ test-coverage: ## Run tests with coverage
 	@./scripts/test.sh --coverage
 
 test-e2e: ## Run end-to-end tests
-	@PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 bun x playwright test --project=electron
+	@$(MAKE) build
+	@CMUX_E2E_LOAD_DIST=1 CMUX_E2E_SKIP_BUILD=1 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 bun x playwright test --project=electron
 
 ## Distribution
 dist: build ## Build distributable packages

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,14 +8,13 @@ export default defineConfig({
   expect: {
     timeout: 5_000,
   },
-  fullyParallel: false,
+  fullyParallel: true,
   forbidOnly: isCI,
   retries: isCI ? 1 : 0,
   reporter: [
     ["list"],
     ["html", { outputFolder: "artifacts/playwright-report", open: "never" }],
   ],
-  workers: 1,
   use: {
     trace: isCI ? "on-first-retry" : "retain-on-failure",
     screenshot: "only-on-failure",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,8 @@ import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const disableMermaid = process.env.VITE_DISABLE_MERMAID === "1";
+const devServerPort = Number(process.env.CMUX_VITE_PORT ?? "5173");
+const previewPort = Number(process.env.CMUX_VITE_PREVIEW_PORT ?? "4173");
 
 const alias: Record<string, string> = {
   "@": path.resolve(__dirname, "./src"),
@@ -29,8 +31,6 @@ export default defineConfig(({ mode }) => ({
     sourcemap: true,
     minify: "esbuild",
     rollupOptions: {
-      // Exclude ai-tokenizer from renderer bundle - it's never used there (only in main process)
-      external: ["ai-tokenizer"],
       output: {
         format: "es",
         inlineDynamicImports: false,
@@ -46,13 +46,13 @@ export default defineConfig(({ mode }) => ({
   },
   server: {
     host: "127.0.0.1",
-    port: 5173,
+    port: devServerPort,
     strictPort: true,
     allowedHosts: ["localhost", "127.0.0.1"],
   },
   preview: {
     host: "127.0.0.1",
-    port: 4173,
+    port: previewPort,
     strictPort: true,
     allowedHosts: ["localhost", "127.0.0.1"],
   },


### PR DESCRIPTION
Run make build before playwright to provide dist artifacts when needed.
Gate dist mode behind CMUX_E2E_LOAD_DIST and assert required files.
Skip the dev server and launch electron with production env when set.
Enable parallel playwright workers to keep runtimes acceptable.
