### PR TITLE
🤖 Make title bar version text selectable

### DIFF
--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -20,6 +20,8 @@ const TitleBarContainer = styled.div`
 const TitleText = styled.div`
   font-weight: normal;
   letter-spacing: 0.5px;
+  user-select: text;
+  cursor: text;
 `;
 
 const BuildInfo = styled.div`


### PR DESCRIPTION
Fixes an issue where users cannot select/copy the git version text in the title bar.

## Problem
The title bar has `user-select: none` on the container, preventing users from selecting the version string to copy it for bug reports or reference.

## Solution
Added `user-select: text` and `cursor: text` to the `TitleText` component specifically, while keeping `user-select: none` on the container for other UI elements (like the date).

## Result
Users can now click and drag to select the git version text (e.g., `c354df64-dirty`) and copy it.

_Generated with `cmux`_