### PR TITLE
🤖 Make 'cmux' text link to documentation

### DIFF
--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -18,6 +18,9 @@ const TitleBarContainer = styled.div`
 `;
 
 const TitleText = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
   font-weight: normal;
   letter-spacing: 0.5px;
 `;
@@ -71,12 +74,12 @@ export function TitleBar() {
   return (
     <TitleBarContainer>
       <TitleText>
-        <TooltipWrapper>
+        <TooltipWrapper inline>
           <CmuxLink href="https://cmux.io" target="_blank" rel="noopener noreferrer">
             cmux
           </CmuxLink>
           <Tooltip align="left">Documentation (cmux.io)</Tooltip>
-        </TooltipWrapper>{" "}
+        </TooltipWrapper>
         <VersionText>{VERSION.git_describe}</VersionText>
       </TitleText>
       <TooltipWrapper>


### PR DESCRIPTION
Makes the "cmux" text in the title bar a clickable link to cmux.io documentation.

## Changes
- "cmux" text now links to https://cmux.io
- Opens in default browser via Electron's configured `shell.openExternal`

## Design
- **Clean appearance**: Looks like regular text
- **Hover effect**: Underline appears only on hover
- **Tooltip**: Shows "Documentation (cmux.io)" on hover
- **Color**: Inherits existing title bar color (#858585)
- **No extra space**: Uses existing text, no additional icons

## User Experience
Provides quick access to documentation without adding visual clutter. The hover underline makes it clear the text is clickable. Version text remains selectable for copying.

_Generated with `cmux`_