### PR TITLE
🤖 Show full file paths in file_read display

### DIFF
--- a/src/components/tools/FileReadToolCall.tsx
+++ b/src/components/tools/FileReadToolCall.tsx
@@ -155,8 +155,8 @@ export const FileReadToolCall: React.FC<FileReadToolCallProps> = ({
 }) => {
   const { expanded, toggleExpanded } = useToolExpansion();
 
-  // Extract just the filename from the path for compact display
-  const fileName = args.filePath.split("/").pop() ?? args.filePath;
+  // Use full file path for consistency with file_edit display
+  const filePath = args.filePath;
 
   // Parse the file content to extract line numbers and actual content
   const parsedContent = result?.success && result.content ? parseFileContent(result.content) : null;
@@ -169,7 +169,7 @@ export const FileReadToolCall: React.FC<FileReadToolCallProps> = ({
           <span>📖</span>
           <Tooltip>file_read</Tooltip>
         </TooltipWrapper>
-        <FilePathText>{fileName}</FilePathText>
+        <FilePathText>{filePath}</FilePathText>
         {result && result.success && parsedContent && (
           <MetadataText>
             read {formatBytes(parsedContent.actualBytes)} of {formatBytes(result.file_size)}


### PR DESCRIPTION
FileReadToolCall was displaying only the filename while FileEditToolCall showed the full path, creating an inconsistent user experience when viewing file operations.

## Problem

**Before:**
- FileRead: `📖 filename.ts`
- FileEdit: `✏️ src/path/to/filename.ts`

Users saw different levels of detail for the same files across different tool types, making it harder to track which files were being operated on.

## Solution

Changed FileReadToolCall to display full paths like FileEditToolCall.

**After:**
- FileRead: `📖 src/path/to/filename.ts`
- FileEdit: `✏️ src/path/to/filename.ts`

## Changes

- Removed filename extraction logic (`.split("/").pop()`)
- Updated comment to reflect consistency goal
- Renamed `fileName` to `filePath` for clarity

## Benefits

- ✅ Consistent file path display across all file tools
- ✅ Better context - users know exactly which file is being read
- ✅ Matches file_edit behavior users already expect
- ✅ Simpler code - no extraction logic needed

_Generated with `cmux`_