### PR TITLE
🤖 fix: make compact-continue reliable and unify send options

### DIFF
--- a/src/hooks/useAutoCompactContinue.ts
+++ b/src/hooks/useAutoCompactContinue.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useRef, useEffect } from "react";
 import type { WorkspaceState } from "@/hooks/useWorkspaceAggregators";
 import { getCompactContinueMessageKey } from "@/constants/storage";
 import { buildSendMessageOptions } from "@/hooks/useSendMessageOptions";
@@ -18,27 +18,44 @@ import { buildSendMessageOptions } from "@/hooks/useSendMessageOptions";
  * metadata - frontend must pass complete options.
  */
 export function useAutoCompactContinue(workspaceStates: Map<string, WorkspaceState>) {
+  // Prevent duplicate auto-sends if effect runs more than once while the same
+  // compacted summary is visible (e.g., rapid state updates after replaceHistory)
+  const firedForWorkspace = useRef<Set<string>>(new Set());
+
   useEffect(() => {
     // Check all workspaces for completed compaction
     for (const [workspaceId, state] of workspaceStates) {
-      // Check if this workspace just compacted (single message marked as compacted)
-      if (
+      // Reset guard when compaction is no longer in the single-compacted-message state
+      const isSingleCompacted =
         state.messages.length === 1 &&
         state.messages[0].type === "assistant" &&
-        state.messages[0].isCompacted === true
-      ) {
-        const continueMessage = localStorage.getItem(getCompactContinueMessageKey(workspaceId));
+        state.messages[0].isCompacted === true;
 
-        if (continueMessage) {
-          // Clean up first to prevent duplicate sends
-          localStorage.removeItem(getCompactContinueMessageKey(workspaceId));
+      if (!isSingleCompacted) {
+        // Allow future auto-continue for this workspace when next compaction completes
+        firedForWorkspace.current.delete(workspaceId);
+        continue;
+      }
 
-          // Build options and send message directly
-          const options = buildSendMessageOptions(workspaceId);
-          window.api.workspace.sendMessage(workspaceId, continueMessage, options).catch((error) => {
-            console.error("Failed to send continue message:", error);
-          });
-        }
+      // Only proceed once per compaction completion
+      if (firedForWorkspace.current.has(workspaceId)) continue;
+
+      const continueMessage = localStorage.getItem(getCompactContinueMessageKey(workspaceId));
+
+      if (continueMessage) {
+        // Mark as fired immediately to avoid re-entry on rapid renders
+        firedForWorkspace.current.add(workspaceId);
+
+        // Clean up first to prevent duplicate sends (source of truth becomes history)
+        localStorage.removeItem(getCompactContinueMessageKey(workspaceId));
+
+        // Build options and send message directly
+        const options = buildSendMessageOptions(workspaceId);
+        window.api.workspace.sendMessage(workspaceId, continueMessage, options).catch((error) => {
+          console.error("Failed to send continue message:", error);
+          // If sending failed, allow another attempt on next render by clearing the guard
+          firedForWorkspace.current.delete(workspaceId);
+        });
       }
     }
   }, [workspaceStates]);

--- a/src/hooks/useSendMessageOptions.ts
+++ b/src/hooks/useSendMessageOptions.ts
@@ -4,15 +4,11 @@ import { useMode } from "@/contexts/ModeContext";
 import { usePersistedState } from "./usePersistedState";
 import { modeToToolPolicy, PLAN_MODE_INSTRUCTION } from "@/utils/ui/modeUtils";
 import { defaultModel } from "@/utils/ai/models";
-import {
-  getModelKey,
-  getThinkingLevelKey,
-  getModeKey,
-  USE_1M_CONTEXT_KEY,
-} from "@/constants/storage";
+import { getModelKey } from "@/constants/storage";
 import type { SendMessageOptions } from "@/types/ipc";
 import type { UIMode } from "@/types/mode";
 import type { ThinkingLevel } from "@/types/thinking";
+import { getSendOptionsFromStorage } from "@/utils/messages/sendOptions";
 
 /**
  * Construct SendMessageOptions from raw values
@@ -67,21 +63,9 @@ export function useSendMessageOptions(workspaceId: string): SendMessageOptions {
 }
 
 /**
- * Build SendMessageOptions from localStorage (non-hook version)
- *
- * CRITICAL: Frontend is responsible for managing ALL sendMessage options.
- * Backend does NOT fall back to workspace metadata - all options must be passed explicitly.
- *
- * This function mirrors useSendMessageOptions logic but reads from localStorage directly,
- * allowing it to be called outside React component lifecycle (e.g., in callbacks).
+ * Build SendMessageOptions outside React using the shared storage reader.
+ * Single source of truth with getSendOptionsFromStorage to avoid JSON parsing bugs.
  */
 export function buildSendMessageOptions(workspaceId: string): SendMessageOptions {
-  // Read from localStorage matching the keys used by useSendMessageOptions
-  const use1M = localStorage.getItem(USE_1M_CONTEXT_KEY) === "true";
-  const thinkingLevel =
-    (localStorage.getItem(getThinkingLevelKey(workspaceId)) as ThinkingLevel) || "medium";
-  const mode = (localStorage.getItem(getModeKey(workspaceId)) as UIMode) || "edit";
-  const preferredModel = localStorage.getItem(getModelKey(workspaceId));
-
-  return constructSendMessageOptions(mode, thinkingLevel, preferredModel, use1M);
+  return getSendOptionsFromStorage(workspaceId);
 }


### PR DESCRIPTION
Surface bug: After `/compact -c`, user message appeared but no stream started and no error artifacts were visible in AIView.

## Root causes

1. **Options mismatch**: `buildSendMessageOptions` read raw localStorage strings instead of using JSON parser, sometimes producing invalid/missing model. When model was invalid, backend added user message then returned error without throwing, causing silent failure (no stream, no UI error).

2. **Racy re-triggering**: `useAutoCompactContinue` effect could fire multiple times during state settlement after `replaceHistory`, causing flaky behavior and occasional duplicate sends.

## Fix

- **Unified options building**: `buildSendMessageOptions` now delegates to `getSendOptionsFromStorage` (single source of truth with proper JSON parsing) ensuring valid model/toolPolicy/thinking options always supplied.

- **Made auto-continue idempotent**: Added per-workspace guard that fires once per compaction completion and resets when state clears, preventing races.

## Files changed

- `src/hooks/useSendMessageOptions.ts`: Use `getSendOptionsFromStorage`
- `src/hooks/useAutoCompactContinue.ts`: Add idempotency guard

## Testing

1. Create history in any workspace
2. Run: `/compact -c "Keep going"`
3. When summary appears, auto-continue should:
   - Send your continue message with correct model/mode/thinking
   - Start streaming assistant reply
4. Verify with different models/thinking levels

_Generated with `cmux`_