### PR TITLE
🤖 Extend TPS calculation window to 60s

### DIFF
--- a/src/utils/messages/StreamingTPSCalculator.test.ts
+++ b/src/utils/messages/StreamingTPSCalculator.test.ts
@@ -23,9 +23,9 @@ describe("StreamingTPSCalculator", () => {
     });
 
     test("returns 0 when all deltas are outside window", () => {
-      const now = 20000;
+      const now = 70000;
       const deltas: DeltaRecord[] = [
-        { tokens: 100, timestamp: 1000, type: "text" }, // 19s ago, outside 10s window
+        { tokens: 100, timestamp: 1000, type: "text" }, // 69s ago, outside 60s window
       ];
       expect(calculateTPS(deltas, now)).toBe(0);
     });
@@ -40,11 +40,11 @@ describe("StreamingTPSCalculator", () => {
       expect(calculateTPS(deltas, now)).toBe(20);
     });
 
-    test("filters out deltas outside 10s window", () => {
-      const now = 15000;
+    test("filters out deltas outside 60s window", () => {
+      const now = 70000;
       const deltas: DeltaRecord[] = [
-        { tokens: 100, timestamp: 1000, type: "text" }, // 14s ago, excluded
-        { tokens: 50, timestamp: 10000, type: "text" }, // 5s ago, included
+        { tokens: 100, timestamp: 1000, type: "text" }, // 69s ago, excluded
+        { tokens: 50, timestamp: 65000, type: "text" }, // 5s ago, included
       ];
       // Only 50 tokens over 5 seconds = 10 t/s
       expect(calculateTPS(deltas, now)).toBe(10);

--- a/src/utils/messages/StreamingTPSCalculator.ts
+++ b/src/utils/messages/StreamingTPSCalculator.ts
@@ -11,11 +11,11 @@ export interface DeltaRecord {
   type: "text" | "reasoning" | "tool-args";
 }
 
-const TPS_WINDOW_MS = 10000; // 10 second trailing window
+const TPS_WINDOW_MS = 60000; // 60 second trailing window
 
 /**
  * Calculate tokens-per-second from a history of delta records
- * Uses a 10-second trailing window
+ * Uses a 60-second trailing window
  */
 export function calculateTPS(deltas: DeltaRecord[], now: number = Date.now()): number {
   if (deltas.length === 0) return 0;


### PR DESCRIPTION
Extends the TPS (tokens-per-second) calculation window from 10 seconds to 60 seconds to reduce jitter and provide more stable readings during streaming.

## Changes

- **TPS window:** 10s → 60s
- Updated test expectations to match the new window size

## Rationale

A longer trailing window smooths out short-term fluctuations in token generation rate, giving users a more stable and useful TPS metric. The 60-second window provides a better average without being too stale.

## Testing

- ✅ All unit tests pass (updated tests to reflect 60s window)
- ✅ Type checking passes
- ✅ Lint passes

_Generated with `cmux`_