### PR TITLE
🤖 Fix bash elapsed timer to use tool-call timestamp

### DIFF
--- a/src/components/Messages/ToolMessage.tsx
+++ b/src/components/Messages/ToolMessage.tsx
@@ -61,6 +61,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({ message, className, wo
           args={message.args}
           result={message.result as BashToolResult | undefined}
           status={message.status}
+          startedAt={message.timestamp}
         />
       </div>
     );

--- a/src/components/tools/BashToolCall.tsx
+++ b/src/components/tools/BashToolCall.tsx
@@ -79,6 +79,7 @@ interface BashToolCallProps {
   args: BashToolArgs;
   result?: BashToolResult;
   status?: ToolStatus;
+  startedAt?: number;
 }
 
 function formatDuration(ms: number): string {
@@ -88,16 +89,22 @@ function formatDuration(ms: number): string {
   return `${Math.round(ms / 1000)}s`;
 }
 
-export const BashToolCall: React.FC<BashToolCallProps> = ({ args, result, status = "pending" }) => {
+export const BashToolCall: React.FC<BashToolCallProps> = ({
+  args,
+  result,
+  status = "pending",
+  startedAt,
+}) => {
   const { expanded, toggleExpanded } = useToolExpansion();
   const [elapsedTime, setElapsedTime] = useState(0);
-  const startTimeRef = useRef<number>(Date.now());
+  const startTimeRef = useRef<number>(startedAt ?? Date.now());
 
   // Track elapsed time for pending/executing status
   useEffect(() => {
     if (status === "executing" || status === "pending") {
-      startTimeRef.current = Date.now();
-      setElapsedTime(0);
+      const baseStart = startedAt ?? Date.now();
+      startTimeRef.current = baseStart;
+      setElapsedTime(Date.now() - baseStart);
 
       const timer = setInterval(() => {
         setElapsedTime(Date.now() - startTimeRef.current);
@@ -105,7 +112,10 @@ export const BashToolCall: React.FC<BashToolCallProps> = ({ args, result, status
 
       return () => clearInterval(timer);
     }
-  }, [status]);
+
+    setElapsedTime(0);
+    return undefined;
+  }, [status, startedAt]);
 
   const isPending = status === "executing" || status === "pending";
 

--- a/src/types/toolParts.ts
+++ b/src/types/toolParts.ts
@@ -9,6 +9,7 @@ export interface DynamicToolPartAvailable {
   state: "output-available";
   input: unknown;
   output: unknown;
+  timestamp?: number;
 }
 
 export interface DynamicToolPartPending {
@@ -17,6 +18,7 @@ export interface DynamicToolPartPending {
   toolName: string;
   state: "input-available";
   input: unknown;
+  timestamp?: number;
 }
 
 export type DynamicToolPart = DynamicToolPartAvailable | DynamicToolPartPending;

--- a/src/utils/messages/StreamingMessageAggregator.ts
+++ b/src/utils/messages/StreamingMessageAggregator.ts
@@ -330,6 +330,7 @@ export class StreamingMessageAggregator {
       toolName: data.toolName,
       state: "input-available",
       input: data.args,
+      timestamp: data.timestamp,
     };
     message.parts.push(toolPart as never);
 
@@ -569,7 +570,7 @@ export class StreamingMessageAggregator {
               historySequence,
               streamSequence: streamSeq++,
               isLastPartOfMessage: isLastPart,
-              timestamp: baseTimestamp,
+              timestamp: part.timestamp ?? baseTimestamp,
             });
           }
         });


### PR DESCRIPTION
## Summary
- propagate tool-call start timestamps through StreamingMessageAggregator
- pass timestamp into the BashToolCall component so elapsed time reflects real tool start
- display timer using backend timestamp to stay accurate after reconnects or navigation

## Testing
- make lint
- bun test src/utils/messages/StreamingMessageAggregator.test.ts --runInBand

_Generated with `cmux`_
