### PR TITLE
🤖 Fix Ctrl+J/K workspace navigation to use sorted order

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -577,7 +577,6 @@ function AppInner() {
             onToggleCollapsed={() => setSidebarCollapsed((prev) => !prev)}
             onGetSecrets={handleGetSecrets}
             onUpdateSecrets={handleUpdateSecrets}
-            workspaceRecency={workspaceRecency}
             sortedWorkspacesByProject={sortedWorkspacesByProject}
           />
           <MainContent>

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -43,7 +43,6 @@ interface LeftSidebarProps {
   onToggleCollapsed: () => void;
   onGetSecrets: (projectPath: string) => Promise<Secret[]>;
   onUpdateSecrets: (projectPath: string, secrets: Secret[]) => Promise<void>;
-  workspaceRecency: Record<string, number>;
   sortedWorkspacesByProject: Map<string, ProjectConfig["workspaces"]>;
 }
 

--- a/src/components/ProjectSidebar.tsx
+++ b/src/components/ProjectSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import { createPortal } from "react-dom";
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
@@ -585,7 +585,6 @@ interface ProjectSidebarProps {
   onToggleCollapsed: () => void;
   onGetSecrets: (projectPath: string) => Promise<Secret[]>;
   onUpdateSecrets: (projectPath: string, secrets: Secret[]) => Promise<void>;
-  workspaceRecency: Record<string, number>;
   sortedWorkspacesByProject: Map<string, Workspace[]>;
 }
 
@@ -606,7 +605,6 @@ const ProjectSidebar: React.FC<ProjectSidebarProps> = ({
   onToggleCollapsed,
   onGetSecrets,
   onUpdateSecrets,
-  workspaceRecency,
   sortedWorkspacesByProject,
 }) => {
   // Subscribe to git status updates (causes this component to re-render every 10s)


### PR DESCRIPTION
Workspace navigation (Ctrl+J/K) now follows the visual order displayed in the sidebar.

## Problem

PR #205 added recency-based sorting to the workspace display, but Ctrl+J/K navigation still used the unsorted config order. This caused confusion where pressing "next workspace" wouldn't select the next visible workspace in the sidebar.

## Solution

Moved the sorting logic from ProjectSidebar to App.tsx so both navigation and display use the same recency-sorted workspace list. This ensures Ctrl+J/K navigation matches the visual order users see.

## Changes

- Added `sortedWorkspacesByProject` memo in App.tsx that sorts workspaces by recency
- Updated `handleNavigateWorkspace` to use the sorted list instead of raw config order
- Pass sorted list through LeftSidebar → ProjectSidebar props chain
- Removed duplicate sorting logic from ProjectSidebar (now uses parent's sorted list)

## Testing

- ✅ All 379 unit tests pass
- ✅ Type checking passes
- Manual verification: Ctrl+J/K now navigates in the same order as displayed in sidebar

_Generated with `cmux`_