### PR TITLE
fix: harden cmux agent payload setup

### DIFF
--- a/benchmarks/terminal_bench/cmux_agent_test.py
+++ b/benchmarks/terminal_bench/cmux_agent_test.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from .cmux_agent import CmuxAgent
+
+
+@pytest.fixture(autouse=True)
+def _clear_cmux_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    keys = [
+        "CMUX_AGENT_GIT_URL",
+        "CMUX_BUN_INSTALL_URL",
+        "CMUX_PROJECT_PATH",
+        "CMUX_PROJECT_CANDIDATES",
+        "CMUX_TRUNK",
+        "CMUX_MODEL",
+        "CMUX_TIMEOUT_MS",
+        "CMUX_THINKING_LEVEL",
+        "CMUX_CONFIG_ROOT",
+        "CMUX_APP_ROOT",
+        "CMUX_WORKSPACE_ID",
+        "CMUX_MODE",
+    ]
+    for key in keys:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def test_env_defaults_are_normalized(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CMUX_AGENT_REPO_ROOT", str(_repo_root()))
+    agent = CmuxAgent(model_name="anthropic/claude-sonnet-4-5")
+
+    env = agent._env
+
+    assert env["CMUX_MODEL"] == "anthropic:claude-sonnet-4-5"
+    assert env["CMUX_THINKING_LEVEL"] == "high"
+    assert env["CMUX_MODE"] == "exec"
+    assert env["CMUX_PROJECT_CANDIDATES"] == agent._DEFAULT_PROJECT_CANDIDATES
+
+
+def test_timeout_must_be_numeric(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CMUX_AGENT_REPO_ROOT", str(_repo_root()))
+    monkeypatch.setenv("CMUX_TIMEOUT_MS", "not-a-number")
+
+    agent = CmuxAgent()
+    with pytest.raises(ValueError):
+        _ = agent._env

--- a/benchmarks/terminal_bench/cmux_payload.py
+++ b/benchmarks/terminal_bench/cmux_payload.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import io
+import tarfile
+import tempfile
+from pathlib import Path
+from typing import Iterable
+
+from terminal_bench.terminal.tmux_session import TmuxSession
+
+
+def build_app_archive(repo_root: Path, include_paths: Iterable[str]) -> bytes:
+    """Pack the cmux workspace into a gzipped tarball."""
+
+    if not repo_root or not repo_root.exists():
+        raise FileNotFoundError(f"cmux repo root {repo_root} not found")
+
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        for relative_path in include_paths:
+            source = repo_root / relative_path
+            if not source.exists():
+                raise FileNotFoundError(f"Required file {source} missing")
+            archive.add(source, arcname=relative_path, recursive=True)
+
+    buffer.seek(0)
+    return buffer.getvalue()
+
+
+def stage_payload(
+    session: TmuxSession,
+    archive_bytes: bytes,
+    archive_name: str,
+    runner_path: Path,
+) -> None:
+    """Copy the cmux bundle and runner into the task container."""
+
+    if not archive_bytes:
+        raise ValueError("archive_bytes must be non-empty")
+    if not runner_path or not runner_path.is_file():
+        raise FileNotFoundError(f"cmux runner missing at {runner_path}")
+
+    with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as temp_file:
+        temp_file.write(archive_bytes)
+        temp_path = Path(temp_file.name)
+
+    try:
+        session.copy_to_container(
+            paths=temp_path,
+            container_dir="/installed-agent",
+            container_filename=archive_name,
+        )
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+    session.copy_to_container(
+        paths=runner_path,
+        container_dir="/installed-agent",
+        container_filename=runner_path.name,
+    )


### PR DESCRIPTION
Extract payload packaging into `cmux_payload` to reuse staging logic.
Normalize env defaults, validate required fields, support colon models.
Add tests covering env normalization and timeout validation.
