### PR TITLE
🤖 Fix React DOM warning and EventEmitter max listeners warning

### DIFF
--- a/src/assets/icons/anthropic.svg
+++ b/src/assets/icons/anthropic.svg
@@ -2,14 +2,7 @@
  <style type="text/css">
   .st0{fill:#181818;}
  </style>
- <metadata>
-  <sfw xmlns="ns_sfw;">
-   <slices>
-   </slices>
-   <sliceSourceBounds bottomLeftOrigin="true" height="65" width="92.2" x="-43.7" y="-98">
-   </sliceSourceBounds>
-  </sfw>
- </metadata>
+
  <path class="st0" d="M66.5,0H52.4l25.7,65h14.1L66.5,0z M25.7,0L0,65h14.4l5.3-13.6h26.9L51.8,65h14.4L40.5,0C40.5,0,25.7,0,25.7,0z
 	 M24.3,39.3l8.8-22.8l8.8,22.8H24.3z">
  </path>

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -101,6 +101,9 @@ export class AIService extends EventEmitter {
 
   constructor(config: Config, historyService: HistoryService, partialService: PartialService) {
     super();
+    // Increase max listeners to accommodate multiple concurrent workspace listeners
+    // Each workspace subscribes to stream events, and we expect >10 concurrent workspaces
+    this.setMaxListeners(50);
     this.config = config;
     this.historyService = historyService;
     this.partialService = partialService;


### PR DESCRIPTION
Resolves two console warnings during development:

**React DOM warning**: Removed  attribute from Anthropic SVG metadata that React doesn't recognize as a valid DOM attribute.

**EventEmitter max listeners**: Increased AIService max listeners from default 10 to 50 to accommodate multiple concurrent workspace subscriptions to stream events.

_Generated with `cmux`_