### PR TITLE
🤖 Disable file_edit_replace_lines tool

### DIFF
--- a/src/utils/tools/toolDefinitions.ts
+++ b/src/utils/tools/toolDefinitions.ts
@@ -186,7 +186,7 @@ export function getAvailableTools(modelString: string): string[] {
     "bash",
     "file_read",
     "file_edit_replace_string",
-    "file_edit_replace_lines",
+    // "file_edit_replace_lines", // DISABLED: causes models to break repo state
     "file_edit_insert",
     "propose_plan",
     "compact_summary",

--- a/src/utils/tools/tools.ts
+++ b/src/utils/tools/tools.ts
@@ -5,7 +5,7 @@ import { google } from "@ai-sdk/google";
 import { createFileReadTool } from "@/services/tools/file_read";
 import { createBashTool } from "@/services/tools/bash";
 import { createFileEditReplaceStringTool } from "@/services/tools/file_edit_replace_string";
-import { createFileEditReplaceLinesTool } from "@/services/tools/file_edit_replace_lines";
+// DISABLED: import { createFileEditReplaceLinesTool } from "@/services/tools/file_edit_replace_lines";
 import { createFileEditInsertTool } from "@/services/tools/file_edit_insert";
 import { createProposePlanTool } from "@/services/tools/propose_plan";
 import { createCompactSummaryTool } from "@/services/tools/compact_summary";
@@ -45,7 +45,10 @@ export function getToolsForModel(
     // Use snake_case for tool names to match what seems to be the convention.
     file_read: createFileReadTool(config),
     file_edit_replace_string: createFileEditReplaceStringTool(config),
-    file_edit_replace_lines: createFileEditReplaceLinesTool(config),
+    // DISABLED: file_edit_replace_lines - causes models (particularly GPT-5-Codex)
+    // to leave repository in broken state due to issues with concurrent file modifications
+    // and line number miscalculations. Use file_edit_replace_string or file_edit_insert instead.
+    // file_edit_replace_lines: createFileEditReplaceLinesTool(config),
     file_edit_insert: createFileEditInsertTool(config),
     bash: createBashTool(config),
     propose_plan: createProposePlanTool(config),


### PR DESCRIPTION
Disables the `file_edit_replace_lines` tool by removing it from the available tools list.

## Why

This tool frequently causes models (particularly GPT-5-Codex) to leave the repository in a broken state. Models struggle with line-based edits when:
- Files are modified concurrently
- Line numbers are miscalculated  
- They don't account for previous edits in the same session

## Changes

- Commented out tool creation in `getToolsForModel()` baseTools
- Commented out tool name in `getAvailableTools()` list
- Commented out import (no longer used)

## Backwards Compatibility

Tool definition and implementation remain intact so old history messages continue to render correctly. The tool simply won't be available for new messages.

## Alternatives

Models should use:
- `file_edit_replace_string` - More reliable, based on exact text matching
- `file_edit_insert` - Simpler for adding new content

_Generated with `cmux`_