### PR TITLE
🤖 fix: skip splash screen in E2E tests

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -378,7 +378,11 @@ if (gotTheLock) {
     // 2. Load services while splash visible (fast - ~100ms)
     // 3. Create window and start loading content (splash stays visible)
     // 4. When window ready-to-show: close splash, show main window
-    await showSplashScreen(); // Wait for splash to actually load
+    //
+    // Skip splash in E2E tests to avoid app.firstWindow() grabbing the wrong window
+    if (!isE2ETest) {
+      await showSplashScreen(); // Wait for splash to actually load
+    }
     await loadServices();
     createWindow();
     // Note: splash closes in ready-to-show event handler


### PR DESCRIPTION
## Problem

E2E tests are flaky because `app.firstWindow()` grabs the splash screen instead of the main window. The test expects the "Projects" navigation to be visible, but that only exists in the main window.

## Solution

Skip splash screen when `CMUX_E2E=1`. E2E tests don't need startup feedback and need deterministic window ordering.

## Testing

E2E tests should now pass consistently.

_Generated with `cmux`_