### PR TITLE
🤖 Fix version display in release builds by fetching git tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for git describe to find tags
 
       - uses: ./.github/actions/setup-cmux
 
@@ -65,6 +67,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for git describe to find tags
 
       - uses: ./.github/actions/setup-cmux
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for git describe to find tags
 
       - uses: ./.github/actions/setup-cmux
 
@@ -52,6 +54,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for git describe to find tags
 
       - uses: ./.github/actions/setup-cmux
 
@@ -64,6 +68,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for git describe to find tags
 
       - uses: ./.github/actions/setup-cmux
 
@@ -79,6 +85,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for git describe to find tags
 
       - uses: ./.github/actions/setup-cmux
 
@@ -105,6 +113,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for git describe to find tags
 
       - name: Check for unresolved Codex comments
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for git describe to find tags
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for git describe to find tags
 
       - uses: ./.github/actions/setup-cmux
 
@@ -40,6 +42,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for git describe to find tags
 
       - uses: ./.github/actions/setup-cmux
 


### PR DESCRIPTION
## Problem

Release builds show only commit hashes (e.g., `a1b2c3d`) instead of version tags (e.g., `v1.2.3`) in the title bar.

## Root Cause

GitHub Actions' `actions/checkout@v4` uses a shallow clone by default, which doesn't fetch git tags. When `git describe --tags --always --dirty` runs without tags, it falls back to showing the short commit hash.

## Solution

Add `fetch-depth: 0` to all `actions/checkout` steps, ensuring full git history and tags are available for `scripts/generate-version.sh`.

## Files Changed

- `.github/workflows/release.yml` - macOS and Linux release builds
- `.github/workflows/build.yml` - PR build artifacts  
- `.github/workflows/ci.yml` - All CI jobs
- `.github/workflows/docs.yml` - Documentation builds

_Generated with `cmux`_