### PR TITLE
🤖 Include tool names in mode switch sentinel

### DIFF
--- a/src/utils/messages/modelMessageTransform.ts
+++ b/src/utils/messages/modelMessageTransform.ts
@@ -113,9 +113,14 @@ export function addInterruptedSentinel(messages: CmuxMessage[]): CmuxMessage[] {
  *
  * @param messages The conversation history
  * @param currentMode The mode for the upcoming assistant response (e.g., "plan", "exec")
+ * @param toolNames Optional list of available tool names to include in transition message
  * @returns Messages with mode transition context injected if needed
  */
-export function injectModeTransition(messages: CmuxMessage[], currentMode?: string): CmuxMessage[] {
+export function injectModeTransition(
+  messages: CmuxMessage[],
+  currentMode?: string,
+  toolNames?: string[]
+): CmuxMessage[] {
   // No mode specified, nothing to do
   if (!currentMode) {
     return messages;
@@ -160,13 +165,22 @@ export function injectModeTransition(messages: CmuxMessage[], currentMode?: stri
   }
 
   // Inject mode transition message right before the last user message
+  let transitionText = `[Mode switched from ${lastMode} to ${currentMode}. Follow ${currentMode} mode instructions.`;
+
+  // Append tool availability if provided
+  if (toolNames && toolNames.length > 0) {
+    transitionText += ` Available tools: ${toolNames.join(", ")}.]`;
+  } else {
+    transitionText += "]";
+  }
+
   const transitionMessage: CmuxMessage = {
     id: `mode-transition-${Date.now()}`,
     role: "user",
     parts: [
       {
         type: "text",
-        text: `[Mode switched from ${lastMode} to ${currentMode}. Follow ${currentMode} mode instructions.]`,
+        text: transitionText,
       },
     ],
     metadata: {


### PR DESCRIPTION
## Summary

When mode switches mid-conversation, the AI now receives information about which tools are available in the new mode. This helps models make better decisions about how to proceed after a mode transition.

## Changes

**Extended mode transition sentinel to include tool availability:**
- Added optional `toolNames` parameter to `injectModeTransition()`
- Reorganized `aiService.ts` to determine tools before message transformations
- Mode transition messages now include tool names when available

**Example transition message:**
```
[Mode switched from plan to exec. Follow exec mode instructions. Available tools: file_read, bash, propose_plan, web_search.]
```

**Benefits:**
- Models understand what tools are newly available/unavailable after mode switch
- Handles model-specific tools (e.g., `web_search` only for some models)
- Respects tool policy filters automatically
- Backward compatible (tools parameter is optional)

## Testing

Added comprehensive test coverage:
- Mode switch with tools - verifies tool names appear in sentinel
- Mode switch without tools parameter - ensures backward compatibility
- Mode switch with empty tool list - graceful handling
- Existing mode transition tests still pass

All 489 tests pass including new test cases.

_Generated with `cmux`_