### PR TITLE
🤖 Fix recency update after compaction

### DIFF
--- a/src/stores/WorkspaceStore.ts
+++ b/src/stores/WorkspaceStore.ts
@@ -440,6 +440,7 @@ export class WorkspaceStore {
                   console.error("[WorkspaceStore] Failed to replace history:", error);
                 } finally {
                   this.states.bump(workspaceId);
+                  this.checkAndBumpRecencyIfChanged();
                 }
               })();
               return;


### PR DESCRIPTION
## Problem

After compaction completes, the workspace doesn't jump to the top of the sidebar (sorted by recency). User has to click into the workspace again to trigger the recency update.

## Root Cause

The compaction path in `WorkspaceStore.ts` returns early after starting the async `replaceChatHistory` operation:

```typescript
void (async () => {
  try {
    await window.api.workspace.replaceChatHistory(workspaceId, summaryMessage);
  } catch (error) {
    console.error("[WorkspaceStore] Failed to replace history:", error);
  } finally {
    this.states.bump(workspaceId);
  }
})();
return;  // ❌ Returns immediately - skips checkAndBumpRecencyIfChanged()!
```

This means:
1. Stream ends with `compact_summary` tool
2. Async IIFE fires and returns immediately
3. Lines 452-453 never execute (bump + checkAndBumpRecency)
4. Recency is never updated

Additionally, there was a race condition where the summary message could arrive before delete messages were processed, causing `computeRecencyTimestamp()` to find old user messages instead of the new compacted summary.

## Solution

Add explicit `checkAndBumpRecencyIfChanged()` in the finally block:

```typescript
finally {
  this.states.bump(workspaceId);
  this.checkAndBumpRecencyIfChanged(); // ✅ Added
}
```

This ensures recency is recalculated after:
- `replaceChatHistory` IPC completes
- Frontend processes both DeleteMessage and summary message  
- Aggregator is in correct state (old messages deleted, new summary added)

At this point, `computeRecencyTimestamp()` will correctly find the compacted summary message (since all user messages were deleted).

## Result

Workspace now immediately jumps to top of sidebar after compaction completes, without requiring user to click into it.

## Testing

Manual test:
1. Send `/compact` in a workspace
2. Wait for compaction to complete
3. Verify workspace immediately jumps to top of sidebar

All 489 tests pass.

_Generated with `cmux`_