### PR TITLE
🤖 Reduce git status console spam for output overflow

### DIFF
--- a/src/stores/GitStatusStore.ts
+++ b/src/stores/GitStatusStore.ts
@@ -219,7 +219,13 @@ export class GitStatusStore {
       }
 
       if (!result.data.success) {
-        console.debug(`[gitStatus] Script failed for ${metadata.id}:`, result.data.error);
+        // Don't log output overflow errors at all (common in large repos, handled gracefully)
+        if (
+          !result.data.error?.includes("OUTPUT TRUNCATED") &&
+          !result.data.error?.includes("OUTPUT OVERFLOW")
+        ) {
+          console.debug(`[gitStatus] Script failed for ${metadata.id}:`, result.data.error);
+        }
         return [metadata.id, null];
       }
 


### PR DESCRIPTION
## Problem

GitStatusStore logs every OUTPUT TRUNCATED and OUTPUT OVERFLOW error with `console.debug`, creating console spam in large repositories. These errors are common and handled gracefully by the system.

## Solution

Filter out these specific error messages from logging. The git status script already has proper overflow handling via `overflow_policy`, so these messages provide no actionable information.

## Changes

- Skip logging for errors containing "OUTPUT TRUNCATED" or "OUTPUT OVERFLOW"
- Other git status errors still logged normally for debugging
- No behavior change, just reduces log noise

## Testing

- ✅ `make static-check` passes
- Same error handling, just quieter logs