### PR TITLE
🤖 Add viewport expansion hint to vertical token meter tooltip

### DIFF
--- a/src/components/ChatMetaSidebar/VerticalTokenMeter.tsx
+++ b/src/components/ChatMetaSidebar/VerticalTokenMeter.tsx
@@ -154,6 +154,11 @@ const VerticalTokenMeterComponent: React.FC<{ data: TokenMeterData }> = ({ data 
                     {data.maxTokens && ` / ${formatTokens(data.maxTokens)}`}
                     {data.maxTokens && ` (${data.totalPercentage.toFixed(1)}%)`}
                   </div>
+                  <div
+                    style={{ color: "#666666", fontSize: 10, marginTop: 8, fontStyle: "italic" }}
+                  >
+                    💡 Expand your viewport to see full details
+                  </div>
                 </Content>
               </Tooltip>
             </TooltipWrapper>


### PR DESCRIPTION
## What

Add a subtle hint at the bottom of the vertical token meter tooltip suggesting users expand their viewport to see full sidebar details.

## Why

When the sidebar is collapsed to the 20px vertical bar (on smaller viewports), users may not realize they can expand their window to see the full Costs/Tools tabs with detailed breakdowns. This hint guides discovery.

## How

Added italic text below the token totals: "💡 Expand your viewport to see full details"

Styling:
- Subdued gray color (#666)
- Smaller font (10px)
- 8px top margin for spacing

## Testing

Visual inspection: hover over vertical token meter bar and verify hint appears at bottom of tooltip.

_Generated with `cmux`_
