### PR TITLE
🤖 Add download badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![CI](https://github.com/coder/cmux/actions/workflows/ci.yml/badge.svg)](https://github.com/coder/cmux/actions/workflows/ci.yml)
 [![Build](https://github.com/coder/cmux/actions/workflows/build.yml/badge.svg)](https://github.com/coder/cmux/actions/workflows/build.yml)
+[![Download](https://img.shields.io/badge/Download-Releases-purple)](https://github.com/coder/cmux/releases)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL%203.0-blue.svg)](LICENSE)
 
 </div>


### PR DESCRIPTION
Add a download badge to the README header that links to the releases page, matching the style of existing status badges (CI, Build, License).

_Generated with `cmux`_