### PR TITLE
🤖 Reduce vertical spacing in Projects sidebar

### DIFF
--- a/src/components/ProjectSidebar.tsx
+++ b/src/components/ProjectSidebar.tsx
@@ -126,7 +126,7 @@ const ProjectGroup = styled.div`
 `;
 
 const ProjectItem = styled.div<{ selected?: boolean; isDragging?: boolean; isOver?: boolean }>`
-  padding: 6px 12px;
+  padding: 4px 12px;
   cursor: ${(props) => (props.isDragging ? "grabbing" : "grab")};
   display: flex;
   align-items: center;
@@ -232,7 +232,7 @@ const ProjectName = styled.div`
 const ProjectPath = styled.div`
   color: #6e6e6e;
   font-size: 11px;
-  margin-top: 2px;
+  margin-top: 1px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
Reduces vertical size of project items in the sidebar while preserving all information and clarity.

## Changes

- Reduce ProjectItem padding from 6px to 4px (saves 4px per project)
- Reduce margin between project name and path from 2px to 1px

**Total: ~5px saved per project**

All information remains visible (project name, path, buttons) with maintained visual hierarchy and interaction states.

_Generated with `cmux`_