### PR TITLE
🤖 Fix setState-during-render warning in CostsTab

### DIFF
--- a/src/stores/WorkspaceStore.ts
+++ b/src/stores/WorkspaceStore.ts
@@ -378,7 +378,11 @@ export class WorkspaceStore {
 
     if (!cached && !isPending && isCaughtUp) {
       if (aggregator && aggregator.getAllMessages().length > 0) {
-        this.consumerManager.scheduleCalculation(workspaceId, aggregator);
+        // Defer scheduling to avoid setState-during-render warning
+        // queueMicrotask ensures this runs after current render completes
+        queueMicrotask(() => {
+          this.consumerManager.scheduleCalculation(workspaceId, aggregator);
+        });
       }
     }
 


### PR DESCRIPTION
Fixes React warning: `Cannot update a component while rendering a different component`

## Problem

CostsTab triggered React warning at MapStore.ts:131:
- `getWorkspaceConsumers()` called during render via `useSyncExternalStore`
- Lazy trigger called `scheduleCalculation()` synchronously  
- `scheduleCalculation()` bumped `consumersStore` immediately (WorkspaceConsumerManager.ts:120)
- Store bump triggered re-render while still rendering original component

## Solution

Defer lazy trigger scheduling with `queueMicrotask()`:
```typescript
queueMicrotask(() => {
  this.consumerManager.scheduleCalculation(workspaceId, aggregator);
});
```

This ensures scheduling happens after current render completes.

## Impact

- ✅ Eliminates React warning
- ✅ No behavioral change - calculation still triggered on first access
- ✅ All 578 tests pass
- ✅ Type checking passes

_Generated with `cmux`_