### PR TITLE
🤖 Fix vertical cost tab animation flash on workspace switch

### DIFF
--- a/src/components/AIView.tsx
+++ b/src/components/AIView.tsx
@@ -559,7 +559,7 @@ const AIViewInner: React.FC<AIViewProps> = ({
         />
       </ChatArea>
 
-      <ChatMetaSidebar workspaceId={workspaceId} chatAreaRef={chatAreaRef} />
+      <ChatMetaSidebar key={workspaceId} workspaceId={workspaceId} chatAreaRef={chatAreaRef} />
     </ViewContainer>
   );
 };

--- a/src/components/ChatMetaSidebar.tsx
+++ b/src/components/ChatMetaSidebar.tsx
@@ -125,7 +125,12 @@ const ChatMetaSidebarComponent: React.FC<ChatMetaSidebarProps> = ({ workspaceId,
   const EXPAND_THRESHOLD = 1100; // Expand above this
   const chatAreaWidth = chatAreaSize?.width ?? 1000; // Default to large to avoid flash
 
-  const [showCollapsed, setShowCollapsed] = React.useState(false);
+  // Persist collapsed state globally (not per-workspace) since chat area width is shared
+  // This prevents animation flash when switching workspaces - sidebar maintains its state
+  const [showCollapsed, setShowCollapsed] = usePersistedState<boolean>(
+    "chat-meta-sidebar:collapsed",
+    false
+  );
 
   React.useEffect(() => {
     if (chatAreaWidth <= COLLAPSE_THRESHOLD) {


### PR DESCRIPTION
## Problem

When switching workspaces, the vertical cost tab would briefly animate from expanded to contracted (or vice versa), creating a jarring visual experience.

## Root Cause

The sidebar's collapsed state was local (`useState`) and reset on each workspace switch. This created a race condition:

1. Component mounted with default state (expanded)
2. ResizeObserver measured actual width after mount  
3. If width required collapse, state updated
4. CSS transition animated the change → visible flash

## Solution

Two-part fix:

### 1. Add `key={workspaceId}` to ChatMetaSidebar

Forces React to remount the component on workspace switch, ensuring clean state boundaries for workspace-specific state (like `selectedTab`).

### 2. Persist `showCollapsed` globally

Changed from `useState` to `usePersistedState("chat-meta-sidebar:collapsed", false)`.

**Key insight:** The chat area is shared across workspaces - its width doesn't change when switching workspaces. Therefore, the sidebar's collapsed state should also persist globally, not reset per workspace.

## Benefits

- ✅ Sidebar starts with correct state immediately (no race condition)
- ✅ No animation flash on workspace switch
- ✅ Window-size-dependent state persists across workspaces
- ✅ Workspace-specific state (selectedTab) remains isolated per workspace
- ✅ State persists across app restarts

## Changes

- `src/components/AIView.tsx`: Add `key` prop to ChatMetaSidebar
- `src/components/ChatMetaSidebar.tsx`: Use `usePersistedState` for `showCollapsed`

## Testing

- [x] Typecheck passes
- [x] Linter passes
- [x] Manually tested: No animation flash when switching workspaces
- [ ] CI checks

_Generated with `cmux`_