### PR TITLE
🤖 Update bash sleep error to permit <10s sleeps in busy loops

### DIFF
--- a/src/services/tools/bash.test.ts
+++ b/src/services/tools/bash.test.ts
@@ -894,8 +894,8 @@ describe("bash tool", () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error).toContain("sleep commands are blocked");
-      expect(result.error).toContain("polling loops");
+      expect(result.error).toContain("do not start commands with sleep");
+      expect(result.error).toContain("prefer <10s sleeps in busy loops");
       expect(result.error).toContain("while ! condition");
       expect(result.exitCode).toBe(-1);
       expect(result.wall_duration_ms).toBe(0);

--- a/src/services/tools/bash.ts
+++ b/src/services/tools/bash.ts
@@ -79,7 +79,7 @@ export const createBashTool: ToolFactory = (config: ToolConfiguration) => {
         return {
           success: false,
           error:
-            "sleep commands are blocked to minimize waiting time. Instead, use polling loops to check conditions repeatedly (e.g., 'while ! condition; do sleep 1; done' or 'until condition; do sleep 1; done').",
+            "do not start commands with sleep; prefer <10s sleeps in busy loops (e.g., 'while ! condition; do sleep 1; done' or 'until condition; do sleep 1; done').",
           exitCode: -1,
           wall_duration_ms: 0,
         };


### PR DESCRIPTION
Observed many agents polling without sleep, draining resources. The error message now explicitly encourages the use of short sleeps in busy loops while discouraging standalone sleep commands.

**Changes:**
- Updated error message from "sleep commands are blocked" to "do not start commands with sleep; prefer <10s sleeps in busy loops"
- More permissive framing that validates sleep when used properly in polling loops
- Maintains blocking of standalone sleep commands at script start

_Generated with `cmux`_