### PR TITLE
🤖 Improve loading workspace UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -768,36 +768,6 @@ function AppInner() {
       );
   }, [projects, setSelectedWorkspace, setWorkspaceMetadata]);
 
-  // Debug: Register window function to show loading workspace state
-  useEffect(() => {
-    (window as any).__showLoadingWorkspace = () => {
-      if (!selectedWorkspace) {
-        console.warn("No workspace selected");
-        return;
-      }
-
-      const workspaceId = selectedWorkspace.workspaceId;
-      const metadata = workspaceMetadata.get(workspaceId);
-
-      if (!metadata) {
-        console.warn("No metadata for workspace", workspaceId);
-        return;
-      }
-
-      // Temporarily remove workspace from store to show loading state
-      workspaceStore.removeWorkspace(workspaceId);
-
-      // Re-add after 2 seconds to restore state
-      setTimeout(() => {
-        workspaceStore.addWorkspace(metadata);
-      }, 2000);
-    };
-
-    return () => {
-      delete (window as any).__showLoadingWorkspace;
-    };
-  }, [selectedWorkspace, workspaceMetadata, workspaceStore]);
-
   return (
     <>
       <GlobalColors />

--- a/src/components/AIView.tsx
+++ b/src/components/AIView.tsx
@@ -110,6 +110,7 @@ const OutputContent = styled.div`
 `;
 
 const EmptyState = styled.div`
+  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
Loading workspace state now uses the same centered, styled EmptyState component as 'No Messages Yet' for visual consistency.

Fixed EmptyState to properly center by adding `flex: 1` so it fills the ViewContainer.

_Generated with `cmux`_