### PR TITLE
🤖 Cmd+2 returns focus to Review tab

### DIFF
--- a/src/components/RightSidebar.tsx
+++ b/src/components/RightSidebar.tsx
@@ -179,7 +179,7 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
   // Global tab preference (not per-workspace)
   const [selectedTab, setSelectedTab] = usePersistedState<TabType>("right-sidebar-tab", "costs");
 
-  // Trigger for focusing first hunk in Review panel
+  // Trigger for focusing Review panel (preserves hunk selection)
   const [focusTrigger, setFocusTrigger] = React.useState(0);
 
   // Notify parent (AIView) of tab changes so it can enable/disable resize functionality
@@ -195,7 +195,7 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
         setSelectedTab("costs");
       } else if (matchesKeybind(e, KEYBINDS.REVIEW_TAB)) {
         e.preventDefault();
-        // If already on Review tab, focus the first hunk
+        // If already on Review tab, focus the panel
         if (selectedTab === "review") {
           setFocusTrigger((prev) => prev + 1);
         } else {

--- a/src/components/RightSidebar/CodeReview/ReviewPanel.tsx
+++ b/src/components/RightSidebar/CodeReview/ReviewPanel.tsx
@@ -25,7 +25,7 @@ interface ReviewPanelProps {
   workspaceId: string;
   workspacePath: string;
   onReviewNote?: (note: string) => void;
-  /** Trigger to focus first hunk (increment to trigger) */
+  /** Trigger to focus panel (increment to trigger) */
   focusTrigger?: number;
 }
 
@@ -326,13 +326,12 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
     includeUncommitted: includeUncommitted,
   });
 
-  // Focus first hunk when focusTrigger changes
+  // Focus panel when focusTrigger changes (preserves current hunk selection)
   useEffect(() => {
-    if (focusTrigger && focusTrigger > 0 && hunks.length > 0) {
+    if (focusTrigger && focusTrigger > 0) {
       panelRef.current?.focus();
-      setSelectedHunkId(hunks[0].id);
     }
-  }, [focusTrigger, hunks]);
+  }, [focusTrigger]);
 
   // Load file tree - when workspace, diffBase, or refreshTrigger changes
   useEffect(() => {


### PR DESCRIPTION
## Summary

Pressing Cmd+2 (Ctrl+2 on Windows/Linux) while already on the Code Review tab now returns keyboard focus to the panel, enabling immediate keyboard navigation without clicking.

## Implementation

Uses a simple prop trigger pattern:
- `RightSidebar` increments `focusTrigger` counter when Cmd+2 is pressed on active Review tab
- `ReviewPanel` watches trigger and calls `.focus()` on panel ref
- Hunk selection is preserved (doesn't jump to first hunk)

## Behavior

- **Cmd+1**: Switch to Costs tab
- **Cmd+2**: Switch to Review tab (or refocus if already active)
- **j/k/↑/↓**: Navigate between hunks (after panel has focus)
- **m**: Toggle hunk read/unread
- **Space**: Expand/collapse hunk

## Why This Matters

Code review with keyboard is faster when you can instantly return focus from chat input to the review panel. Previously, you had to click on the panel or tab through UI elements.

_Generated with `cmux`_