### PR TITLE
🤖 Fix thinking slider memory and auto-resume for slow models

### DIFF
--- a/src/components/ThinkingSlider.tsx
+++ b/src/components/ThinkingSlider.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useId } from "react";
 import styled from "@emotion/styled";
-import type { ThinkingLevel } from "@/types/thinking";
+import type { ThinkingLevel, ThinkingLevelOn } from "@/types/thinking";
 import { useThinkingLevel } from "@/hooks/useThinkingLevel";
 import { TooltipWrapper, Tooltip } from "./Tooltip";
 import { formatKeybind, KEYBINDS } from "@/utils/ui/keybinds";
 import { getThinkingPolicyForModel } from "@/utils/thinking/policy";
+import { updatePersistedState } from "@/hooks/usePersistedState";
+import { getLastThinkingByModelKey } from "@/constants/storage";
 
 const ThinkingSliderContainer = styled.div`
   display: flex;
@@ -193,6 +195,16 @@ export const ThinkingSliderComponent: React.FC<ThinkingControlProps> = ({ modelS
 
   const value = thinkingLevelToValue(thinkingLevel);
 
+  const handleThinkingLevelChange = (newLevel: ThinkingLevel) => {
+    setThinkingLevel(newLevel);
+    // Also save to lastThinkingByModel for Ctrl+Shift+T toggle memory
+    // Only save active levels (not "off") - matches useAIViewKeybinds logic
+    if (newLevel !== "off") {
+      const lastThinkingKey = getLastThinkingByModelKey(modelString);
+      updatePersistedState(lastThinkingKey, newLevel as ThinkingLevelOn);
+    }
+  };
+
   return (
     <TooltipWrapper>
       <ThinkingSliderContainer>
@@ -203,7 +215,9 @@ export const ThinkingSliderComponent: React.FC<ThinkingControlProps> = ({ modelS
           max="3"
           step="1"
           value={value}
-          onChange={(e) => setThinkingLevel(valueToThinkingLevel(parseInt(e.target.value)))}
+          onChange={(e) =>
+            handleThinkingLevelChange(valueToThinkingLevel(parseInt(e.target.value)))
+          }
           id={sliderId}
           role="slider"
           aria-valuemin={0}

--- a/src/utils/messages/retryEligibility.test.ts
+++ b/src/utils/messages/retryEligibility.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "@jest/globals";
+import { hasInterruptedStream } from "./retryEligibility";
+import type { DisplayedMessage } from "@/types/message";
+
+describe("hasInterruptedStream", () => {
+  it("returns false for empty messages", () => {
+    expect(hasInterruptedStream([])).toBe(false);
+  });
+
+  it("returns true for stream-error message", () => {
+    const messages: DisplayedMessage[] = [
+      {
+        type: "user",
+        id: "user-1",
+        historyId: "user-1",
+        content: "Hello",
+        historySequence: 1,
+      },
+      {
+        type: "stream-error",
+        id: "error-1",
+        historyId: "assistant-1",
+        error: "Connection failed",
+        errorType: "network",
+        historySequence: 2,
+      },
+    ];
+    expect(hasInterruptedStream(messages)).toBe(true);
+  });
+
+  it("returns true for partial assistant message", () => {
+    const messages: DisplayedMessage[] = [
+      {
+        type: "user",
+        id: "user-1",
+        historyId: "user-1",
+        content: "Hello",
+        historySequence: 1,
+      },
+      {
+        type: "assistant",
+        id: "assistant-1",
+        historyId: "assistant-1",
+        content: "Incomplete response",
+        historySequence: 2,
+        streamSequence: 0,
+        isStreaming: false,
+        isPartial: true,
+        isLastPartOfMessage: true,
+        isCompacted: false,
+      },
+    ];
+    expect(hasInterruptedStream(messages)).toBe(true);
+  });
+
+  it("returns true for partial tool message", () => {
+    const messages: DisplayedMessage[] = [
+      {
+        type: "user",
+        id: "user-1",
+        historyId: "user-1",
+        content: "Hello",
+        historySequence: 1,
+      },
+      {
+        type: "tool",
+        id: "tool-1",
+        historyId: "assistant-1",
+        toolName: "bash",
+        toolCallId: "call-1",
+        args: { script: "echo test" },
+        status: "interrupted",
+        isPartial: true,
+        historySequence: 2,
+        streamSequence: 0,
+        isLastPartOfMessage: true,
+      },
+    ];
+    expect(hasInterruptedStream(messages)).toBe(true);
+  });
+
+  it("returns true for partial reasoning message", () => {
+    const messages: DisplayedMessage[] = [
+      {
+        type: "user",
+        id: "user-1",
+        historyId: "user-1",
+        content: "Hello",
+        historySequence: 1,
+      },
+      {
+        type: "reasoning",
+        id: "reasoning-1",
+        historyId: "assistant-1",
+        content: "Let me think...",
+        historySequence: 2,
+        streamSequence: 0,
+        isStreaming: false,
+        isPartial: true,
+        isLastPartOfMessage: true,
+      },
+    ];
+    expect(hasInterruptedStream(messages)).toBe(true);
+  });
+
+  it("returns false for completed messages", () => {
+    const messages: DisplayedMessage[] = [
+      {
+        type: "user",
+        id: "user-1",
+        historyId: "user-1",
+        content: "Hello",
+        historySequence: 1,
+      },
+      {
+        type: "assistant",
+        id: "assistant-1",
+        historyId: "assistant-1",
+        content: "Complete response",
+        historySequence: 2,
+        streamSequence: 0,
+        isStreaming: false,
+        isPartial: false,
+        isLastPartOfMessage: true,
+        isCompacted: false,
+      },
+    ];
+    expect(hasInterruptedStream(messages)).toBe(false);
+  });
+
+  it("returns true when last message is user message (app restarted during slow model)", () => {
+    const messages: DisplayedMessage[] = [
+      {
+        type: "user",
+        id: "user-1",
+        historyId: "user-1",
+        content: "Hello",
+        historySequence: 1,
+      },
+      {
+        type: "assistant",
+        id: "assistant-1",
+        historyId: "assistant-1",
+        content: "Complete response",
+        historySequence: 2,
+        streamSequence: 0,
+        isStreaming: false,
+        isPartial: false,
+        isLastPartOfMessage: true,
+        isCompacted: false,
+      },
+      {
+        type: "user",
+        id: "user-2",
+        historyId: "user-2",
+        content: "Another question",
+        historySequence: 3,
+      },
+    ];
+    expect(hasInterruptedStream(messages)).toBe(true);
+  });
+
+  it("returns true when user message has no response (slow model scenario)", () => {
+    const messages: DisplayedMessage[] = [
+      {
+        type: "user",
+        id: "user-1",
+        historyId: "user-1",
+        content: "Hello",
+        historySequence: 1,
+      },
+    ];
+    expect(hasInterruptedStream(messages)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Two bugs fixed:

### 1. Thinking slider didn't remember for Ctrl+Shift+T

**Root Cause:**
- Slider only updated `thinkingLevel:{workspaceId}` storage
- Ctrl+Shift+T toggle reads/writes `lastThinkingByModel:{modelName}`
- Slider changes weren't visible to the toggle

**Fix:**
- Added `handleThinkingLevelChange` that updates both storage locations
- Only saves active levels ("low"/"medium"/"high"), not "off"
- Matches the logic in `useAIViewKeybinds.ts`

### 2. Auto-resume didn't work after app restart during slow models

**Root Cause:**
- Models can take 30-60 seconds before first token
- If app restarts during this time:
  - History has user message but no assistant response
  - `hasInterruptedStream()` returned false (no partial/error messages)
  - Auto-resume didn't trigger

**Fix:**
- Updated `hasInterruptedStream()` to return `true` when last message is a user message
- Rationale: History never ends with user message in normal flow
  - Either assistant is responding (active stream, checked separately)
  - Or assistant has responded (completed message in history)
- If history ends with user message → incomplete conversation → needs resume
- **Respects user preference:** `autoRetry` flag is checked separately and persists across restarts

## Changes

```
src/components/ThinkingSlider.tsx           |  16 ++- (thinking slider fix)
src/utils/messages/retryEligibility.test.ts | 176 +++ (comprehensive tests)
src/utils/messages/retryEligibility.ts      |   8 +++ (auto-resume fix)
3 files changed, 198 insertions(+), 2 deletions(-)
```

## Testing

- ✅ 669 unit tests pass
- ✅ 8 new tests for retry eligibility logic
- ✅ Type checking clean
- ✅ Integration tests pass

_Generated with `cmux`_