### PR TITLE
🤖 Fix PWA manifest 404 in NPM package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ build-static: ## Copy static assets to dist
 	@echo "Copying static assets..."
 	@mkdir -p dist
 	@cp static/splash.html dist/splash.html
+	@cp -r public/* dist/
 
 # Always regenerate version file (marked as .PHONY above)
 version: ## Generate version file

--- a/package.json
+++ b/package.json
@@ -141,6 +141,8 @@
     "dist/**/*.wasm",
     "dist/**/*.html",
     "dist/**/*.css",
+    "dist/**/*.json",
+    "dist/**/*.png",
     "dist/assets/**/*",
     "README.md",
     "LICENSE"


### PR DESCRIPTION
The PWA files (manifest.json, icons, service-worker.js) were not being included in the published NPM package, causing 404 errors when the app tries to load them.

## Problem

When PWA support was added in #359, the `public/` directory files were correctly set up for local development and Electron builds, but they weren't being included in the NPM package distribution. This caused 404 errors for users installing via npm.

## Solution

1. **Updated build-static target** - Added `cp -r public/* dist/` to copy PWA assets during build
2. **Updated package.json files field** - Added `dist/**/*.json` and `dist/**/*.png` patterns to include the PWA files in the published package

## Verification

Confirmed with `npm pack --dry-run`:
- ✓ dist/manifest.json (790B)
- ✓ dist/icon-192.png (7.8kB)  
- ✓ dist/icon-512.png (24.0kB)
- ✓ dist/service-worker.js (1.3kB)

_Generated with `cmux`_