### PR TITLE
🤖 Normalize provider base URL overrides

### DIFF
--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -28,6 +28,7 @@ import type { HistoryService } from "./historyService";
 import type { PartialService } from "./partialService";
 import { buildSystemMessage } from "./systemMessage";
 import { getTokenizerForModel } from "@/utils/main/tokenizer";
+import { normalizeProviderBaseUrl } from "@/utils/providers/normalizeProviderBaseUrl";
 import { buildProviderOptions } from "@/utils/ai/providerOptions";
 import type { ThinkingLevel } from "@/types/thinking";
 import type {
@@ -228,7 +229,7 @@ export class AIService extends EventEmitter {
 
       // Load providers configuration - the ONLY source of truth
       const providersConfig = this.config.loadProvidersConfig();
-      const providerConfig = providersConfig?.[providerName] ?? {};
+      const providerConfig = normalizeProviderBaseUrl(providersConfig?.[providerName]);
 
       // Handle Anthropic provider
       if (providerName === "anthropic") {

--- a/src/utils/providers/normalizeProviderBaseUrl.test.ts
+++ b/src/utils/providers/normalizeProviderBaseUrl.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import type { ProviderConfig } from "@/config";
+import { normalizeProviderBaseUrl } from "./normalizeProviderBaseUrl";
+
+describe("normalizeProviderBaseUrl", () => {
+  it("returns an empty object when config is undefined", () => {
+    expect(normalizeProviderBaseUrl(undefined)).toEqual({});
+  });
+
+  it("synchronizes baseUrl and baseURL when baseUrl is provided", () => {
+    const original: ProviderConfig = {
+      baseUrl: " https://example.com ",
+      apiKey: "test-key",
+    };
+
+    const result = normalizeProviderBaseUrl(original);
+    const record = result as Record<string, unknown>;
+
+    expect(result.baseUrl).toBe("https://example.com");
+    expect(record.baseURL).toBe("https://example.com");
+    expect(original.baseUrl).toBe(" https://example.com ");
+  });
+
+  it("synchronizes baseUrl when only baseURL is provided", () => {
+    const original = {
+      apiKey: "test-key",
+      baseURL: "https://upper.example.com",
+    } as unknown as ProviderConfig;
+
+    const result = normalizeProviderBaseUrl(original);
+    const record = result as Record<string, unknown>;
+
+    expect(result.baseUrl).toBe("https://upper.example.com");
+    expect(record.baseURL).toBe("https://upper.example.com");
+  });
+
+  it("does not mutate the original object", () => {
+    const original: ProviderConfig = {
+      baseUrl: " https://mutate.example.com/ ",
+    };
+
+    const copy = { ...original };
+    const result = normalizeProviderBaseUrl(original);
+
+    expect(original).toEqual(copy);
+    expect(result.baseUrl).toBe("https://mutate.example.com/");
+  });
+});
+

--- a/src/utils/providers/normalizeProviderBaseUrl.ts
+++ b/src/utils/providers/normalizeProviderBaseUrl.ts
@@ -1,0 +1,40 @@
+import type { ProviderConfig } from "@/config";
+
+const trimCandidate = (value: unknown): string | undefined => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+/**
+ * Normalize provider configuration so that both `baseUrl` and `baseURL` variants
+ * are synchronized.
+ *
+ * The user configuration (providers.jsonc) stores `baseUrl` using lower camel case
+ * for readability, but the Vercel AI SDK expects `baseURL`. This helper bridges the
+ * gap without mutating the original configuration.
+ */
+export function normalizeProviderBaseUrl(config: ProviderConfig | undefined): ProviderConfig {
+  if (!config) {
+    return {};
+  }
+
+  const normalized: ProviderConfig = { ...config };
+  const record = normalized as Record<string, unknown>;
+
+  const baseUrl = trimCandidate(config.baseUrl) ?? trimCandidate(record.baseURL);
+
+  if (baseUrl) {
+    normalized.baseUrl = baseUrl;
+    record.baseURL = baseUrl;
+  } else {
+    delete normalized.baseUrl;
+    delete record.baseURL;
+  }
+
+  return normalized;
+}
+


### PR DESCRIPTION
## Summary
- add helper to keep baseUrl/baseURL fields in sync for provider configs
- ensure AIService passes normalized base URLs to OpenAI and Anthropic constructors
- add unit coverage for the normalization helper

## Testing
- make typecheck
- bun test src/utils/providers/normalizeProviderBaseUrl.test.ts

_Generated with _