### PR TITLE
🤖 Disable mobile zoom/pinch gestures

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="description" content="Parallel agentic development with Electron + React" />
     <meta name="theme-color" content="#1e1e1e" />
     <link rel="manifest" href="/manifest.json" />


### PR DESCRIPTION
Prevents unwanted zooming behavior on mobile devices by setting `maximum-scale=1.0` and `user-scalable=no` in the viewport meta tag.

This ensures a consistent, app-like experience on mobile without accidental zoom triggers.

_Generated with `cmux`_