### PR TITLE
🤖 Fix iOS PWA keyboard not appearing on input focus

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-content"
+    />
     <meta name="description" content="Parallel agentic development with Electron + React" />
     <meta name="theme-color" content="#1e1e1e" />
     <link rel="manifest" href="/manifest.json" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,8 +64,6 @@ const globalStyles = css`
     html {
       /* Prevent text size adjustment on orientation change */
       -webkit-text-size-adjust: 100%;
-      /* Improve tap responsiveness */
-      touch-action: manipulation;
     }
 
     body {
@@ -79,6 +77,15 @@ const globalStyles = css`
     [role="button"] {
       min-height: 44px;
       min-width: 44px;
+      /* Improve tap responsiveness on buttons only */
+      touch-action: manipulation;
+    }
+
+    /* Ensure input elements allow default touch behavior for iOS keyboard */
+    input,
+    textarea,
+    select {
+      touch-action: auto;
     }
   }
 


### PR DESCRIPTION
Fixes the iOS keyboard not appearing when tapping input fields in the installed PWA.

## Problem
In PWA mode on iOS Safari, the keyboard wasn't appearing when tapping input/textarea elements, even though it worked fine in the browser.

## Solution
The issue was `touch-action: manipulation` applied globally to the `html` element, which interferes with iOS native input behavior.

**Changes:**
- Moved `touch-action: manipulation` from `html` to buttons/interactive elements only
- Added explicit `touch-action: auto` for input/textarea/select elements
- Enhanced viewport meta with `interactive-widget=resizes-content` for better keyboard handling

## Testing
Test on iOS Safari by:
1. Installing the PWA to home screen
2. Opening from home screen
3. Tapping any input field
4. Verify keyboard appears

_Generated with `cmux`_