### PR TITLE
🤖 Fix generate-version.sh shebang for Nix compatibility

### DIFF
--- a/scripts/generate-version.sh
+++ b/scripts/generate-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Generate version.ts with git information
 
 GIT_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")


### PR DESCRIPTION
_Generated with `cmux`_

Use `#!/usr/bin/env bash` instead of `#!/bin/bash` to work on systems where bash is not in /bin (e.g., NixOS where bash is in /nix/store).

This makes the script portable across different Unix-like systems.