### PR TITLE
🤖 Add image attachment button for mobile

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -56,15 +56,12 @@ const InputControls = styled.div`
   display: flex;
   gap: 10px;
   align-items: flex-end;
-  position: relative;
 `;
 
 const AttachButton = styled.button`
-  position: absolute;
-  right: 8px;
-  bottom: 8px;
   width: 32px;
   height: 32px;
+  flex-shrink: 0;
   border-radius: 4px;
   background: #3e3e42;
   color: #cccccc;


### PR DESCRIPTION
Adds a file picker button for attaching images on mobile devices.

## Changes

- Added attach button (📎) positioned in bottom-right of input area
- Hidden file input with `accept='image/*'` and multiple selection support
- Clicking button opens native file picker (works on mobile and desktop)
- Reuses existing `processImageFiles` logic for consistent image handling
- Button properly disabled when chat input is disabled

## Why

Desktop users can paste images, but mobile devices need a button to open the file picker. This provides a consistent cross-platform experience for image attachments.

The button is always visible (on mobile and desktop) since it provides a convenient alternative to paste/drag-and-drop.

---

_Generated with `cmux`_