### PR TITLE
🤖 Disable iOS keyboard autocomplete and suggestions

### DIFF
--- a/src/components/VimTextArea.tsx
+++ b/src/components/VimTextArea.tsx
@@ -285,6 +285,9 @@ export const VimTextArea = React.forwardRef<HTMLTextAreaElement, VimTextAreaProp
             mode={mode}
             vimMode={vimMode}
             spellCheck={false}
+            autoCorrect="off"
+            autoCapitalize="none"
+            autoComplete="off"
             {...rest}
           />
           {vimMode === "normal" && value.length === 0 && <EmptyCursor />}


### PR DESCRIPTION
Fixes iOS keyboard showing autocomplete suggestions and navigation carets that take up unnecessary space.

## Problem
On iOS Safari, the chat input shows:
- Autocomplete suggestions above the keyboard
- Up/down/done navigation carets (accessory bar)
- Auto-capitalization interfering with typing

These features take up screen space and aren't helpful for code/chat input.

## Solution
<cite index="1-3,1-23,6-5,6-7">Added HTML attributes to the textarea to disable iOS autocomplete features: `autoCorrect="off"`, `spellCheck="false"`, and `autoCapitalize="none"`</cite>.

## Testing
Test on iOS device or Safari simulator:
1. Open chat input
2. Verify keyboard doesn't show autocomplete suggestions bar
3. Verify no up/down/done navigation carets appear
4. Verify input doesn't auto-capitalize

_Generated with `cmux`_