### PR TITLE
🤖 Fix hidden tooltip on Add Project button

### DIFF
--- a/src/components/ProjectSidebar.tsx
+++ b/src/components/ProjectSidebar.tsx
@@ -783,9 +783,14 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
             <>
               <SidebarHeader>
                 <h2>Projects</h2>
-                <AddProjectBtn onClick={onAddProject} title="Add Project" aria-label="Add project">
-                  +
-                </AddProjectBtn>
+                <TooltipWrapper inline>
+                  <AddProjectBtn onClick={onAddProject} aria-label="Add project">
+                    +
+                  </AddProjectBtn>
+                  <Tooltip className="tooltip" align="right">
+                    Add Project
+                  </Tooltip>
+                </TooltipWrapper>
               </SidebarHeader>
               <ProjectsList>
                 {projects.size === 0 ? (


### PR DESCRIPTION
Wrap AddProjectBtn in TooltipWrapper component to display styled tooltip on hover, consistent with other UI elements in the sidebar.