### PR TITLE
🤖 Add global placeholder text styling

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -798,6 +798,19 @@ input[type="checkbox"] {
   @apply checked:after:border-solid checked:after:border-white checked:after:content-[''];
 }
 
+/* Global placeholder styling */
+input::placeholder,
+textarea::placeholder {
+  color: var(--color-placeholder);
+  opacity: 0.6;
+}
+
+input:focus::placeholder,
+textarea:focus::placeholder {
+  opacity: 0.4;
+}
+
+
 .text-dim {
   color: var(--color-dim);
 }


### PR DESCRIPTION
Placeholder text now appears visually distinct from regular input text across the app.

**Changes:**
- Added global CSS rules for `input::placeholder` and `textarea::placeholder`
- Set color to `--color-placeholder` with 60% opacity
- Reduced opacity to 40% on focus for better visual feedback

Fixes input fields where placeholder text looked like normal text (e.g., new workspace modal).

_Generated with `cmux`_