### PR TITLE
🤖 Add workflow_dispatch test_filter to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: ./.github/actions/setup-cmux
 
       - name: Run tests with coverage
-        run: bun test --coverage --coverage-reporter=lcov ${{ inputs.test_filter || 'src' }}
+        run: bun test --coverage --coverage-reporter=lcov ${{ github.event.inputs.test_filter || 'src' }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
@@ -95,7 +95,7 @@ jobs:
       - uses: ./.github/actions/setup-cmux
 
       - name: Run integration tests with coverage
-        run: TEST_INTEGRATION=1 bun x jest --coverage ${{ inputs.test_filter || 'tests' }}
+        run: TEST_INTEGRATION=1 bun x jest --coverage ${{ github.event.inputs.test_filter || 'tests' }}
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
_Generated with `cmux`_

Allow manual CI workflow triggers to specify an optional test_filter input that gets passed to both unit and integration test jobs. This enables running specific tests via GitHub Actions UI without requiring a full CI run.

## Usage

When manually triggering the CI workflow through GitHub Actions UI, you can now specify a `test_filter` input:
- **Leave empty**: Run all tests (default behavior)
- **File path pattern**: `workspace` or `tests/specific.test.ts` - matches file paths
- **Test name pattern**: `-t "pattern"` - filters by test description

## Compatibility

Both `bun test` and `jest` support:
- File path patterns as positional arguments
- `-t` flag for test name pattern matching

The filter is applied identically to both unit tests (`bun test`) and integration tests (`jest`).