### PR TITLE
Fix integration test coverage upload to Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -33,7 +33,7 @@ flags:
     carryforward: false
   integration-tests:
     paths:
-      - tests/**
+      - src/**
     carryforward: false
 
 # Ignore common non-source paths


### PR DESCRIPTION
## Problem

The integration-tests flag in `codecov.yml` was incorrectly configured to look for coverage in `tests/**` paths, but Jest collects coverage from `src/**` files (as specified in `jest.config.js`). This caused integration test coverage to not be properly tracked by Codecov.

## Root Cause

- Jest's `collectCoverageFrom` config specifies `src/**` 
- Integration tests in `tests/**` exercise application code in `src/**`
- Test files (`**/*.test.ts`) are explicitly ignored in codecov config
- The mismatch meant coverage data wasn't associated with the `integration-tests` flag

## Solution

Updated the `integration-tests` flag to cover `src/**` paths, matching the actual coverage data generated by Jest.

Both unit tests and integration tests now correctly point to `src/**` since both generate coverage for source code, just through different test suites.

## Testing

This PR will verify that integration test coverage is properly uploaded to Codecov when CI runs.