### PR TITLE
🤖 Optimize integration test parallelization (maxWorkers 200% → 100%)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,8 @@ jobs:
       - uses: ./.github/actions/setup-cmux
 
       - name: Run integration tests with coverage
-        run: TEST_INTEGRATION=1 bun x jest --coverage --maxWorkers=200% --silent ${{ github.event.inputs.test_filter || 'tests' }}
+        # --silent suppresses per-test output (17 test files × 32 workers = overwhelming logs)
+        run: TEST_INTEGRATION=1 bun x jest --coverage --maxWorkers=100% --silent ${{ github.event.inputs.test_filter || 'tests' }}
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

Optimize integration test parallelization by reducing Jest workers from 200% to 100%, resulting in **~15 second speedup** (7.8% faster).

## Problem

Running with `maxWorkers=200%` on 32-core runners creates 64 parallel workers. Each test spawns child processes, performs I/O operations, and runs git commands. This over-parallelization causes resource contention and context switching overhead.

## Solution

Reduce to `maxWorkers=100%` (32 workers) for better resource utilization.

## Results

Tested across 3 CI runs:
- **Baseline:** 193s test execution
- **Optimized:** 173-183s test execution  
- **Average improvement:** ~15s (7.8% faster)

## Note

The `--silent` flag is intentionally retained to prevent overwhelming log output from 32 parallel workers across 17 test files. Silent mode still shows test suite status, timing, coverage summary, and full failure details.

---

_Generated with `cmux`_