### PR TITLE
🤖 Fix service worker cache errors for POST requests

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -33,6 +33,13 @@ self.addEventListener('activate', (event) => {
 
 // Fetch event - network first, fallback to cache
 self.addEventListener('fetch', (event) => {
+  // Skip caching for non-GET requests (POST, PUT, DELETE, etc.)
+  // The Cache API only supports GET requests
+  if (event.request.method !== 'GET') {
+    event.respondWith(fetch(event.request));
+    return;
+  }
+
   event.respondWith(
     fetch(event.request)
       .then((response) => {


### PR DESCRIPTION
Service worker was attempting to cache all requests including POST requests (from browser mode IPC calls and AI streaming). The Cache API only supports caching GET requests.

Added check to skip caching for non-GET requests, preventing the error:
`Failed to execute 'put' on 'Cache': Request method 'POST' is unsupported`

This fix maintains PWA caching for browser mode while avoiding errors during development and when using POST-based features.

_Generated with `cmux`_