### PR TITLE
🤖 Fix: Use tilde path in SSH runtime to avoid process.env in renderer

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -392,6 +392,42 @@ export default defineConfig([
     },
   },
   {
+    // Renderer process (frontend) architectural boundary - prevent Node.js API usage
+    files: ["src/**/*.ts", "src/**/*.tsx"],
+    ignores: [
+      "src/main*.ts",
+      "src/preload.ts",
+      "src/services/**",
+      "src/runtime/**",
+      "src/utils/main/**",
+      "src/utils/providers/**",
+      "src/telemetry/**",
+      "src/git.ts",
+      "src/config.ts",
+      "src/debug/**",
+      "**/*.test.ts",
+      "**/*.test.tsx",
+    ],
+    rules: {
+      "no-restricted-globals": [
+        "error",
+        {
+          name: "process",
+          message:
+            "Renderer code cannot access 'process' global (not available in renderer). Use IPC to communicate with main process or use constants for environment-agnostic values.",
+        },
+      ],
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "MemberExpression[object.name='process'][property.name='env']",
+          message:
+            "Renderer code cannot access process.env (not available in renderer). Use IPC to get environment variables from main process or use constants.",
+        },
+      ],
+    },
+  },
+  {
     // Test file configuration
     files: ["**/*.test.ts", "**/*.test.tsx"],
     languageOptions: {

--- a/src/utils/chatCommands.test.ts
+++ b/src/utils/chatCommands.test.ts
@@ -18,7 +18,7 @@ describe("parseRuntimeString", () => {
     expect(result).toEqual({
       type: "ssh",
       host: "user@host",
-      srcBaseDir: "/home/user/cmux",
+      srcBaseDir: "~/cmux",
     });
   });
 
@@ -27,7 +27,7 @@ describe("parseRuntimeString", () => {
     expect(result).toEqual({
       type: "ssh",
       host: "User@Host.Example.Com",
-      srcBaseDir: "/home/User/cmux",
+      srcBaseDir: "~/cmux",
     });
   });
 
@@ -36,7 +36,7 @@ describe("parseRuntimeString", () => {
     expect(result).toEqual({
       type: "ssh",
       host: "user@host",
-      srcBaseDir: "/home/user/cmux",
+      srcBaseDir: "~/cmux",
     });
   });
 
@@ -47,34 +47,31 @@ describe("parseRuntimeString", () => {
 
   test("accepts SSH with hostname only (user will be inferred)", () => {
     const result = parseRuntimeString("ssh hostname", workspaceName);
-    // When no user is specified, uses current user (process.env.USER)
-    const expectedUser = process.env.USER ?? "user";
-    const expectedHomeDir = expectedUser === "root" ? "/root" : `/home/${expectedUser}`;
+    // Uses tilde path - backend will resolve it via runtime.resolvePath()
     expect(result).toEqual({
       type: "ssh",
       host: "hostname",
-      srcBaseDir: `${expectedHomeDir}/cmux`,
+      srcBaseDir: "~/cmux",
     });
   });
 
   test("accepts SSH with hostname.domain only", () => {
     const result = parseRuntimeString("ssh dev.example.com", workspaceName);
-    // When no user is specified, uses current user (process.env.USER)
-    const expectedUser = process.env.USER ?? "user";
-    const expectedHomeDir = expectedUser === "root" ? "/root" : `/home/${expectedUser}`;
+    // Uses tilde path - backend will resolve it via runtime.resolvePath()
     expect(result).toEqual({
       type: "ssh",
       host: "dev.example.com",
-      srcBaseDir: `${expectedHomeDir}/cmux`,
+      srcBaseDir: "~/cmux",
     });
   });
 
-  test("uses /root for root user", () => {
+  test("uses tilde path for root user too", () => {
     const result = parseRuntimeString("ssh root@hostname", workspaceName);
+    // Backend will resolve ~ to /root for root user
     expect(result).toEqual({
       type: "ssh",
       host: "root@hostname",
-      srcBaseDir: "/root/cmux",
+      srcBaseDir: "~/cmux",
     });
   });
 

--- a/src/utils/chatCommands.ts
+++ b/src/utils/chatCommands.ts
@@ -51,20 +51,13 @@ export function parseRuntimeString(
       throw new Error("SSH runtime requires host (e.g., 'ssh hostname' or 'ssh user@host')");
     }
 
-    // Extract username from user@host format, or default to current user
-    const atIndex = hostPart.indexOf("@");
-    const user = atIndex > 0 ? hostPart.substring(0, atIndex) : (process.env.USER ?? "user");
-
-    // Determine home directory path based on user
-    // root user's home is /root, all others are /home/<user>
-    const homeDir = user === "root" ? "/root" : `/home/${user}`;
-
     // Accept both "hostname" and "user@hostname" formats
     // SSH will use current user or ~/.ssh/config if user not specified
+    // Use tilde path - backend will resolve it via runtime.resolvePath()
     return {
       type: RUNTIME_MODE.SSH,
       host: hostPart,
-      srcBaseDir: `${homeDir}/cmux`, // Default remote base directory (NOT including workspace name)
+      srcBaseDir: "~/cmux", // Default remote base directory (tilde will be resolved by backend)
     };
   }
 


### PR DESCRIPTION
Fixes regression from #451 where  was using `process.env.USER` in renderer code, causing "process is not defined" error during workspace creation.

## Problem

After merging #451, workspace creation fails with:
```
ReferenceError: process is not defined
  at parseRuntimeString (chatCommands.ts:56:66)
```

The issue: `chatCommands.ts` is renderer code that was trying to access `process.env.USER` to construct SSH default paths. The `process` global is not available in Electron renderer processes.

## Solution

**Use tilde paths instead** - Now that we have tilde resolution from #451, we can simply use `~/cmux` as the default SSH `srcBaseDir`. The backend will resolve it via `runtime.resolvePath()`.

Before:
```typescript
const user = atIndex > 0 ? hostPart.substring(0, atIndex) : (process.env.USER ?? "user");
const homeDir = user === "root" ? "/root" : `/home/${user}`;
return {
  type: "ssh",
  host: hostPart,
  srcBaseDir: `${homeDir}/cmux`,
};
```

After:
```typescript
return {
  type: "ssh",
  host: hostPart,
  srcBaseDir: "~/cmux", // Backend resolves via runtime.resolvePath()
};
```

## ESLint Rule

Added `no-restricted-globals` and `no-restricted-syntax` rules to prevent future `process.env` usage in renderer code:
- Applies to: `src/**/*.ts(x)`
- Excludes: main, preload, services, runtime, telemetry, utils/main, utils/providers, tests
- Error message guides developers to use IPC or constants instead

This catches the issue at development time rather than runtime.

## Testing

- Unit tests updated to expect `~/cmux` instead of computed paths
- ESLint passes with new rules
- Workspace creation now works without process.env

_Generated with `cmux`_