### PR TITLE
🤖 ci: improve extract_pr_logs to show in-progress job steps

### DIFF
--- a/scripts/extract_pr_logs.sh
+++ b/scripts/extract_pr_logs.sh
@@ -179,8 +179,18 @@ for JOB_ID in $JOB_IDS; do
       echo "" >&2
     fi
   else
-    # In-progress/pending/queued job - logs not yet available
-    echo "ℹ️  Job is $JOB_STATUS - logs will be available when job completes" >&2
+    # In-progress/pending/queued job - GitHub API doesn't provide logs until completion
+    echo "ℹ️  Job is $JOB_STATUS - logs not available via API until completion" >&2
+    echo "" >&2
+    
+    # Show which step is currently running
+    CURRENT_STEP=$(gh api "/repos/coder/cmux/actions/jobs/$JOB_ID" 2>/dev/null | jq -r '.steps[] | select(.status == "in_progress") | .name' | head -1)
+    if [[ -n "$CURRENT_STEP" ]]; then
+      echo "🔄 Currently running: $CURRENT_STEP" >&2
+    fi
+    
+    # Construct GitHub URL for viewing live logs in browser
+    echo "👁️  View live logs: https://github.com/coder/cmux/actions/runs/$RUN_ID/job/$JOB_ID" >&2
     echo "" >&2
   fi
 done


### PR DESCRIPTION
Shows step-by-step status for in-progress and pending jobs, making it much easier to debug CI runs that haven't completed yet.

**Key improvements:**
- Shows detailed step status (COMPLETED, IN_PROGRESS, PENDING) for jobs that are still running
- Highlights which step is currently running
- Provides direct link to view live logs in browser (GitHub API doesn't expose logs for in-progress jobs)
- Automatically detects in-progress jobs when no failures exist
- Simplified UX: removed --wait flag, pending jobs work automatically
- New --all flag to show all jobs regardless of status
- Better filtering logic to prioritize failed jobs, then in-progress jobs

**Example output for in-progress job:**
```
📊 Step-by-step status:
  [COMPLETED] Set up job (success)
  [COMPLETED] Checkout code (success)
  [IN_PROGRESS] Run /./.github/actions/setup-cmux
  [PENDING] Build application

🔄 Currently running: Run /./.github/actions/setup-cmux
👁️  View live logs: https://github.com/coder/cmux/actions/runs/.../job/...
```

**Limitation:** GitHub's API doesn't provide actual log content for in-progress jobs - logs are only available once a job completes. The script now provides a direct link to view live logs in the browser instead.

_Generated with `cmux`_