### PR TITLE
🤖 feat: allow cmux server port override

### DIFF
--- a/src/main-server.ts
+++ b/src/main-server.ts
@@ -232,6 +232,26 @@ wss.on("connection", (ws) => {
   });
 });
 
-server.listen(3000, () => {
-  console.log("Server is running on port 3000");
+const DEFAULT_PORT = 3000;
+
+const resolvePort = (value?: string): number => {
+  if (!value) {
+    return DEFAULT_PORT;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) {
+    console.warn(
+      `Invalid CMUX_SERVER_PORT "${value}". Falling back to default port ${DEFAULT_PORT}.`
+    );
+    return DEFAULT_PORT;
+  }
+
+  return parsed;
+};
+
+const port = resolvePort(process.env.CMUX_SERVER_PORT);
+
+server.listen(port, () => {
+  console.log(`Server is running on port ${port}`);
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,32 @@
 #!/usr/bin/env node
 
+import { parsePortOption } from "./utils/cli/serverPort";
+
+const args = process.argv.slice(2);
 const isServer = process.argv.length > 2 && process.argv[2] === "server";
 
-if (isServer) {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  require("./main-server");
-} else {
+const run = (): void => {
+  if (isServer) {
+    const result = parsePortOption(args);
+
+    if (result.kind === "error") {
+      console.error(result.message);
+      process.exit(1);
+    }
+
+    if (result.kind === "ok") {
+      process.env.CMUX_SERVER_PORT = String(result.port);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("./main-server");
+    return;
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   require("./main-desktop");
+};
+
+if (typeof require !== "undefined" && require.main === module) {
+  run();
 }

--- a/src/utils/cli/serverPort.test.ts
+++ b/src/utils/cli/serverPort.test.ts
@@ -1,0 +1,38 @@
+import { parsePortOption } from "./serverPort";
+
+describe("parsePortOption", () => {
+  const withArgs = (...rest: string[]) => parsePortOption(["server", ...rest]);
+
+  it("returns none when flag is absent", () => {
+    expect(withArgs()).toEqual({ kind: "none" });
+  });
+
+  it("parses a port specified as a separate argument", () => {
+    expect(withArgs("--port", "4500")).toEqual({ kind: "ok", port: 4500 });
+  });
+
+  it("parses a port specified with an equals sign", () => {
+    expect(withArgs("--port=5500")).toEqual({ kind: "ok", port: 5500 });
+  });
+
+  it("returns an error when the flag is missing a value", () => {
+    expect(withArgs("--port")).toEqual({
+      kind: "error",
+      message: "Missing value for --port option. Provide a number, e.g. --port 3000.",
+    });
+  });
+
+  it("returns an error when the value is not an integer", () => {
+    expect(withArgs("--port", "abc")).toEqual({
+      kind: "error",
+      message: 'Invalid port "abc". Use an integer between 1 and 65535.',
+    });
+  });
+
+  it("returns an error when the value is out of range", () => {
+    expect(withArgs("--port", "70000")).toEqual({
+      kind: "error",
+      message: 'Invalid port "70000". Use an integer between 1 and 65535.',
+    });
+  });
+});

--- a/src/utils/cli/serverPort.ts
+++ b/src/utils/cli/serverPort.ts
@@ -1,0 +1,47 @@
+export const PORT_FLAG = "--port";
+
+export type PortOptionResult =
+  | { kind: "none" }
+  | { kind: "ok"; port: number }
+  | { kind: "error"; message: string };
+
+const PORT_PREFIX = `${PORT_FLAG}=`;
+
+export const parsePortOption = (values: string[]): PortOptionResult => {
+  let portValue: string | undefined;
+
+  for (let i = 1; i < values.length; i += 1) {
+    const current = values[i];
+
+    if (current === PORT_FLAG) {
+      const next = values[i + 1];
+      if (!next || next.startsWith("-")) {
+        return {
+          kind: "error",
+          message: "Missing value for --port option. Provide a number, e.g. --port 3000.",
+        };
+      }
+      portValue = next;
+      break;
+    }
+
+    if (current.startsWith(PORT_PREFIX)) {
+      portValue = current.slice(PORT_PREFIX.length);
+      break;
+    }
+  }
+
+  if (portValue === undefined) {
+    return { kind: "none" };
+  }
+
+  const parsedPort = Number.parseInt(portValue, 10);
+  if (!Number.isInteger(parsedPort) || parsedPort <= 0 || parsedPort > 65535) {
+    return {
+      kind: "error",
+      message: `Invalid port "${portValue}". Use an integer between 1 and 65535.`,
+    };
+  }
+
+  return { kind: "ok", port: parsedPort };
+};


### PR DESCRIPTION
## Summary
- allow the CLI `cmux server` command to accept an optional --port flag
- reuse shared parsing logic and use the resolved value when starting the server
- cover the port parsing helper with unit tests

## Testing
- make typecheck
- bun test src/utils/cli/serverPort.test.ts

_Generated with `cmux`_
