### PR TITLE
🤖 feat: Add native desktop notifications

### DIFF
--- a/src/services/notificationService.test.ts
+++ b/src/services/notificationService.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "bun:test";
+import { NotificationService } from "@/services/notificationService";
+import type { CompletedMessagePart } from "@/types/stream";
+import type { NotificationPreferences } from "@/types/notifications";
+
+class MockPrefsService {
+  constructor(private prefs: NotificationPreferences) {}
+  load() { return this.prefs; }
+  save() {}
+}
+
+class TestableNotificationService extends NotificationService {
+  public shown: Array<{ title: string; body: string }> = [];
+  protected createNotification(options: any) {
+    const self = this;
+    return {
+      on: () => {},
+      show: () => { self.shown.push({ title: options.title, body: options.body }); },
+    } as any;
+  }
+}
+
+describe("NotificationService helpers", () => {
+  const parts: CompletedMessagePart[] = [
+    { type: "text", text: "Here is some output.\n\n```ts\nconst x = 1;\n```\nAnd more." },
+  ];
+
+  it("builds a preview and strips code blocks", () => {
+    const svc = new TestableNotificationService(() => null, new MockPrefsService({
+      enabled: true,
+      kinds: { complete: true, question: true, error: true },
+      onlyWhenUnfocused: false,
+      includePreview: true,
+    }) as any);
+
+    const preview = svc.buildPreviewFromParts(parts, 200);
+    expect(preview).toContain("Here is some output.");
+    expect(preview).not.toContain("const x = 1");
+  });
+
+  it("detects questions heuristically", () => {
+    const svc = new TestableNotificationService(() => null, new MockPrefsService({
+      enabled: true,
+      kinds: { complete: true, question: true, error: true },
+      onlyWhenUnfocused: false,
+      includePreview: true,
+    }) as any);
+
+    expect(svc.isQuestion("What do you think? ")).toBe(true);
+    expect(svc.isQuestion("Please run the tests.")).toBe(false);
+  });
+});
+

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -1,0 +1,134 @@
+import type { BrowserWindow, NotificationConstructorOptions } from "electron";
+// IMPORTANT: Avoid importing electron Notification at module scope.
+// In tests (non-Electron), requiring 'electron' would throw.
+// We'll require it lazily in createNotification().
+import type { CompletedMessagePart } from "@/types/stream";
+import type { NotificationPreferences, NotificationKind } from "@/types/notifications";
+import { PreferencesService } from "@/services/preferencesService";
+
+/**
+ * NotificationService - desktop-native notifications gated by user preferences
+ *
+ * Platform support:
+ * - macOS: Notification Center
+ * - Windows: Action Center (requires AUMID set by app.setAppUserModelId)
+ * - Linux: a notification daemon must be running
+ */
+export class NotificationService {
+  constructor(
+    private readonly mainWindowProvider: () => BrowserWindow | null,
+    private readonly prefsService: PreferencesService
+  ) {}
+
+  // Public helpers for consumers
+  notifyComplete(parts: CompletedMessagePart[]): void {
+    const prefs = this.prefsService.load();
+    if (!this.shouldNotify(prefs, "complete")) return;
+
+    const preview = prefs.includePreview ? this.buildPreviewFromParts(parts) : undefined;
+    const body = preview ? preview : "Assistant response completed";
+
+    this.notify("Assistant completed", body);
+  }
+
+  notifyQuestion(parts: CompletedMessagePart[]): void {
+    const prefs = this.prefsService.load();
+    if (!this.shouldNotify(prefs, "question")) return;
+
+    const preview = prefs.includePreview ? this.buildPreviewFromParts(parts) : undefined;
+    const body = preview ? preview : "Assistant asked a question";
+
+    this.notify("Assistant has a question", body);
+  }
+
+  notifyError(errorType: string | undefined, message: string): void {
+    const prefs = this.prefsService.load();
+    if (!this.shouldNotify(prefs, "error")) return;
+
+    const body = message || "An error occurred during streaming";
+    const title = errorType ? `Stream error: ${errorType}` : "Stream error";
+    this.notify(title, body);
+  }
+
+  // Core notify method with gating
+  private notify(title: string, body: string): void {
+    const prefs = this.prefsService.load();
+    if (!prefs.enabled) return;
+
+    const win = this.mainWindowProvider();
+    if (prefs.onlyWhenUnfocused && win?.isFocused()) return;
+
+    const options: NotificationConstructorOptions = {
+      title: title,
+      body: body,
+      silent: false,
+    };
+
+    const notification = this.createNotification(options);
+    // Guard against test overrides that don't implement on()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (notification as any).on?.("click", () => {
+      const w = this.mainWindowProvider();
+      if (!w) return;
+      if (w.isMinimized()) w.restore();
+      // show() ensures window comes to front on all platforms
+      w.show();
+      w.focus();
+    });
+    notification.show();
+  }
+
+  // Build a short preview string from message parts
+  buildPreviewFromParts(parts: CompletedMessagePart[], max = 180): string | undefined {
+    if (!parts || parts.length === 0) return undefined;
+
+    // Concatenate text parts only; ignore tools/images
+    const text = parts
+      .filter((p) => p && typeof p === "object" && "type" in p && p.type === "text")
+      .map((p) => (p as { text: string }).text)
+      .join(" ");
+
+    const normalized = text
+      .replace(/```[\s\S]*?```/g, " ") // remove code blocks
+      .replace(/\s+/g, " ") // collapse whitespace
+      .trim();
+
+    if (!normalized) return undefined;
+
+    return normalized.length > max ? `${normalized.slice(0, max - 1)}…` : normalized;
+  }
+
+  // Simple heuristic to detect if preview ends with a question
+  isQuestion(text: string | undefined): boolean {
+    if (!text) return false;
+    const trimmed = text.trim();
+    if (trimmed.endsWith("?")) return true;
+
+    // Also consider interrogatives within the last sentence
+    const lastSentence = trimmed.split(/[.!?]/).pop() ?? trimmed;
+    const lower = lastSentence.toLowerCase();
+    return /\b(what|how|why|should|could|would|do you|can you|is it|are you)\b/.test(lower);
+  }
+
+  private shouldNotify(prefs: NotificationPreferences, kind: NotificationKind): boolean {
+    if (!prefs.enabled) return false;
+    if (kind === "complete" && !prefs.kinds.complete) return false;
+    if (kind === "question" && !prefs.kinds.question) return false;
+    if (kind === "error" && !prefs.kinds.error) return false;
+
+    const win = this.mainWindowProvider();
+    if (prefs.onlyWhenUnfocused && win?.isFocused()) return false;
+
+    return true;
+  }
+
+  // Factory method for Notification (overridable in tests)
+  // eslint-disable-next-line class-methods-use-this
+  protected createNotification(options: NotificationConstructorOptions) {
+    // Lazy require to avoid loading 'electron' in non-Electron environments (tests)
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { Notification } = require("electron") as typeof import("electron");
+    return new Notification(options);
+  }
+}
+

--- a/src/services/preferencesService.test.ts
+++ b/src/services/preferencesService.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { Config } from "@/config";
+import { PreferencesService } from "@/services/preferencesService";
+import { DEFAULT_NOTIFICATION_PREFERENCES } from "@/types/notifications";
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "cmux-prefs-test-"));
+  return dir;
+}
+
+describe("PreferencesService", () => {
+  let root: string;
+  let config: Config;
+
+  beforeEach(() => {
+    root = makeTempDir();
+    config = new Config(root);
+  });
+
+  it("loads defaults when file missing", () => {
+    const svc = new PreferencesService(config);
+    const prefs = svc.load();
+    expect(prefs).toEqual(DEFAULT_NOTIFICATION_PREFERENCES);
+  });
+
+  it("saves and loads preferences", () => {
+    const svc = new PreferencesService(config);
+    const initial = svc.load();
+    const next = {
+      ...initial,
+      enabled: true,
+      kinds: { ...initial.kinds, question: false },
+      onlyWhenUnfocused: false,
+      includePreview: false,
+    };
+    svc.save(next);
+
+    const reloaded = svc.load();
+    expect(reloaded.enabled).toBe(true);
+    expect(reloaded.kinds.question).toBe(false);
+    expect(reloaded.onlyWhenUnfocused).toBe(false);
+    expect(reloaded.includePreview).toBe(false);
+  });
+});
+

--- a/src/services/preferencesService.ts
+++ b/src/services/preferencesService.ts
@@ -1,0 +1,69 @@
+import * as fs from "fs";
+import * as path from "path";
+import writeFileAtomic from "write-file-atomic";
+import type { Config } from "@/config";
+import {
+  DEFAULT_NOTIFICATION_PREFERENCES,
+  type NotificationPreferences,
+} from "@/types/notifications";
+
+/**
+ * PreferencesService - loads and saves user preferences under ~/.cmux
+ *
+ * Currently only manages desktop notification preferences. Designed so we can
+ * add additional preference namespaces later without changing callers.
+ */
+export class PreferencesService {
+  private readonly prefsFile: string;
+
+  constructor(private readonly config: Config) {
+    this.prefsFile = path.join(this.config.rootDir, "preferences.json");
+  }
+
+  /** Load preferences from disk, returning defaults if missing or invalid */
+  load(): NotificationPreferences {
+    try {
+      if (fs.existsSync(this.prefsFile)) {
+        const raw = fs.readFileSync(this.prefsFile, "utf-8");
+        const parsed = JSON.parse(raw) as Partial<NotificationPreferences>;
+        return PreferencesService.mergeWithDefaults(parsed);
+      }
+    } catch (error) {
+      // Don't throw - fall back to defaults on parse or IO error
+      console.warn("Failed to load preferences.json, using defaults:", error);
+    }
+    return { ...DEFAULT_NOTIFICATION_PREFERENCES };
+  }
+
+  /** Persist preferences atomically */
+  save(next: NotificationPreferences): void {
+    try {
+      const dir = path.dirname(this.prefsFile);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+      const toWrite = PreferencesService.mergeWithDefaults(next);
+      writeFileAtomic.sync(this.prefsFile, JSON.stringify(toWrite, null, 2));
+    } catch (error) {
+      console.error("Error saving preferences:", error);
+    }
+  }
+
+  private static mergeWithDefaults(
+    partial?: Partial<NotificationPreferences>
+  ): NotificationPreferences {
+    const base = { ...DEFAULT_NOTIFICATION_PREFERENCES };
+    if (!partial) return base;
+    return {
+      enabled: partial.enabled ?? base.enabled,
+      kinds: {
+        complete: partial.kinds?.complete ?? base.kinds.complete,
+        question: partial.kinds?.question ?? base.kinds.question,
+        error: partial.kinds?.error ?? base.kinds.error,
+      },
+      onlyWhenUnfocused: partial.onlyWhenUnfocused ?? base.onlyWhenUnfocused,
+      includePreview: partial.includePreview ?? base.includePreview,
+    };
+  }
+}
+

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -1,0 +1,25 @@
+// Desktop notification types and preferences
+// Keep small and serializable; persisted under ~/.cmux/preferences.json
+
+export type NotificationKind = "complete" | "question" | "error";
+
+export interface NotificationPreferences {
+  enabled: boolean;
+  kinds: {
+    complete: boolean;
+    question: boolean;
+    error: boolean;
+  };
+  // If true, only show notifications when the app window is not focused
+  onlyWhenUnfocused: boolean;
+  // If true, include a short preview of assistant text when available
+  includePreview: boolean;
+}
+
+export const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = {
+  enabled: true,
+  kinds: { complete: true, question: true, error: true },
+  onlyWhenUnfocused: true,
+  includePreview: true,
+};
+


### PR DESCRIPTION
## Summary

Adds desktop-native notifications for stream completion, questions, and errors. Notifications appear only when the app window is unfocused (configurable via menu).

## Implementation

**Core services:**
- `types/notifications.ts`: Type definitions + defaults
- `services/preferencesService.ts`: Persist to `~/.cmux/preferences.json`
- `services/notificationService.ts`: Preview generation, question heuristic, notification dispatch
- `services/ipcMain.ts`: Wire AIService stream-end/error events → NotificationService
- `main-desktop.ts`: Windows AUMID (toasts), Cmux → Notifications menu

**Event flow:**
```
StreamManager → AIService → IpcMain → NotificationService → electron.Notification
```

**Notification types:**
- **Complete**: Assistant finished response (shows preview)
- **Question**: Assistant asked a question (uses heuristic: ends with `?` or contains interrogatives)
- **Error**: Stream error occurred (shows error type + message)

**Menu (Cmux → Notifications):**
- Enable Notifications (master toggle)
- On Complete / On Question / On Error (individual toggles)
- Changes persist immediately to `preferences.json`
- Menu rebuilds on toggle to reflect new state

## Defaults

```ts
{
  enabled: true,
  kinds: { complete: true, question: true, error: true },
  onlyWhenUnfocused: true,  // Only notify when app not focused
  includePreview: true,     // Show snippet of response
}
```

## Platform support

- **macOS**: Notification Center (native)
- **Windows**: Action Center (AUMID set via `app.setAppUserModelId`)
- **Linux**: Requires notification daemon (standard on modern distros)

## Testing

- Unit tests: `preferencesService.test.ts`, `notificationService.test.ts`
- Verified preview generation strips code blocks, collapses whitespace
- Question detection heuristic tested with common patterns

## Notes

- Notifications are fire-and-forget; errors logged but don't crash app
- Click handler focuses main window (restores if minimized)
- Preview truncates at 180 chars to fit notification constraints
- Question heuristic checks for `?` suffix or interrogative keywords

_Generated with `cmux`_