### PR TITLE
🤖 fix: use shell script for artifact name instead of replace()

### DIFF
--- a/.github/workflows/terminal-bench.yml
+++ b/.github/workflows/terminal-bench.yml
@@ -126,12 +126,24 @@ jobs:
             ls -la runs/
           fi
 
+      - name: Set artifact name
+        if: always()
+        id: artifact-name
+        run: |
+          if [ -n "${{ inputs.model_name }}" ]; then
+            # Replace colons with hyphens for filesystem compatibility
+            ARTIFACT_NAME="terminal-bench-results-$(echo "${{ inputs.model_name }}-${{ github.run_id }}" | tr ':' '-')"
+          else
+            ARTIFACT_NAME="terminal-bench-results-${{ github.run_id }}"
+          fi
+          echo "name=$ARTIFACT_NAME" >> $GITHUB_OUTPUT
+          echo "Artifact name: $ARTIFACT_NAME"
+
       - name: Upload benchmark results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          # Replace colons with hyphens to avoid GitHub artifact name restrictions
-          name: terminal-bench-results-${{ inputs.model_name && replace(format('{0}-{1}', inputs.model_name, github.run_id), ':', '-') || format('{0}', github.run_id) }}
+          name: ${{ steps.artifact-name.outputs.name }}
           path: |
             runs/
           if-no-files-found: warn


### PR DESCRIPTION
## Problem

PR #488 introduced a syntax error by using the `replace()` function in a GitHub Actions workflow expression:

```yaml
name: terminal-bench-results-${{ inputs.model_name && replace(format('{0}-{1}', inputs.model_name, github.run_id), ':', '-') || format('{0}', github.run_id) }}
```

**GitHub Actions does not support `replace()` as a function in workflow expressions.**

This caused the nightly workflow to fail with a syntax error.

## Solution

Use a shell script step to compute the artifact name using the `tr` command:

```yaml
- name: Set artifact name
  id: artifact-name
  run: |
    if [ -n "${{ inputs.model_name }}" ]; then
      ARTIFACT_NAME="terminal-bench-results-$(echo "${{ inputs.model_name }}-${{ github.run_id }}" | tr ':' '-')"
    else
      ARTIFACT_NAME="terminal-bench-results-${{ github.run_id }}"
    fi
    echo "name=$ARTIFACT_NAME" >> $GITHUB_OUTPUT

- name: Upload benchmark results
  uses: actions/upload-artifact@v4
  with:
    name: ${{ steps.artifact-name.outputs.name }}
```

This uses standard shell string manipulation which is fully supported.

## Testing

The workflow syntax now validates correctly. The next nightly run should:
- ✅ Parse successfully without syntax errors
- ✅ Replace colons with hyphens: `anthropic-claude-sonnet-4-5`
- ✅ Upload artifacts with valid names

---

_Generated with `cmux`_