### PR TITLE
🤖 fix: make Review tab toggles global instead of per-workspace

### DIFF
--- a/src/components/RightSidebar/CodeReview/ReviewPanel.tsx
+++ b/src/components/RightSidebar/CodeReview/ReviewPanel.tsx
@@ -154,17 +154,14 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
   // Persist diff base per workspace (falls back to global default)
   const [diffBase, setDiffBase] = usePersistedState(`review-diff-base:${workspaceId}`, defaultBase);
 
-  // Persist includeUncommitted flag per workspace
+  // Persist includeUncommitted flag globally
   const [includeUncommitted, setIncludeUncommitted] = usePersistedState(
-    `review-include-uncommitted:${workspaceId}`,
+    "review-include-uncommitted",
     false
   );
 
-  // Persist showReadHunks flag per workspace
-  const [showReadHunks, setShowReadHunks] = usePersistedState(
-    `review-show-read:${workspaceId}`,
-    true
-  );
+  // Persist showReadHunks flag globally
+  const [showReadHunks, setShowReadHunks] = usePersistedState("review-show-read", true);
 
   // Initialize review state hook
   const { isRead, toggleRead } = useReviewState(workspaceId);


### PR DESCRIPTION
The 'Show Read' and 'Uncommitted' toggles in the Review tab were stored per-workspace, requiring users to configure them separately for each workspace. This changes them to global settings that apply across all workspaces.

**Changes:**
- Storage key `review-include-uncommitted:${workspaceId}` → `review-include-uncommitted`
- Storage key `review-show-read:${workspaceId}` → `review-show-read`

Users' preferences for these toggles will now persist when switching between workspaces.

_Generated with `cmux`_