### PR TITLE
🤖 feat: add Google Analytics support to docs site

### DIFF
--- a/docs/theme/head.hbs
+++ b/docs/theme/head.hbs
@@ -1,8 +1,8 @@
 <!-- Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-D1HL4PBRSY"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-  gtag('config', 'G-XXXXXXXXXX');
+  gtag('config', 'G-D1HL4PBRSY');
 </script>


### PR DESCRIPTION
Add head.hbs template file to inject GA4 tracking code into mdBook-generated documentation.

Generated with `cmux`