### PR TITLE
🤖 fix: focus Review panel when switching with Cmd+2

### DIFF
--- a/src/components/RightSidebar.tsx
+++ b/src/components/RightSidebar.tsx
@@ -114,12 +114,8 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
         setSelectedTab("costs");
       } else if (matchesKeybind(e, KEYBINDS.REVIEW_TAB)) {
         e.preventDefault();
-        // If already on Review tab, focus the panel
-        if (selectedTab === "review") {
-          setFocusTrigger((prev) => prev + 1);
-        } else {
-          setSelectedTab("review");
-        }
+        setSelectedTab("review");
+        setFocusTrigger((prev) => prev + 1);
       }
     };
 


### PR DESCRIPTION
When pressing Cmd+2 to switch to the Review tab, focus now immediately moves to the ReviewPanel, allowing j/k keyboard navigation to work right away.

## Problem

Previously when pressing Cmd+2:
- If not already on Review tab: Focus remained in chat input box
- j/k keys would type text instead of navigating hunks
- User had to manually click in the review panel to enable keyboard navigation

## Solution

Simplified the keyboard shortcut handler to always trigger focus on the ReviewPanel when Cmd+2 is pressed, regardless of current tab state.

## Testing

Manually verified:
- ✅ Cmd+2 from Costs tab → focuses review panel, j/k navigate hunks
- ✅ Cmd+2 while already on Review → maintains focus, no disruption
- ✅ Cmd+1 → Cmd+2 cycle works correctly

_Generated with `cmux`_