### PR TITLE
fix: prevent double dist substitution in worker path resolution

### DIFF
--- a/src/utils/main/workerPool.ts
+++ b/src/utils/main/workerPool.ts
@@ -33,11 +33,12 @@ const pendingPromises = new Map<
 // During tests: workerPool.ts is in src/utils/main/ but worker is in dist/utils/main/
 const currentDir = dirname(__filename);
 const pathParts = currentDir.split(sep);
+const hasDist = pathParts.includes("dist");
 const srcIndex = pathParts.lastIndexOf("src");
 
 let workerDir: string;
-if (srcIndex !== -1) {
-  // Replace 'src' with 'dist' in the path
+if (srcIndex !== -1 && !hasDist) {
+  // Replace 'src' with 'dist' in the path (only if not already in dist)
   pathParts[srcIndex] = "dist";
   workerDir = pathParts.join(sep);
 } else {


### PR DESCRIPTION
When workerPool.ts runs from dist/, the existing logic would
incorrectly try to replace 'src' with 'dist' again, leading to
malformed paths like dist/utils/main/dist/utils/main/worker.js.

Now checks if 'dist' already exists in the path before performing
the src->dist replacement, ensuring correct worker resolution in
both development (src/) and production (dist/) contexts.
