### PR TITLE
🤖 fix: increase stream timeouts in CI to handle rate limits

### DIFF
--- a/tests/ipcMain/helpers.ts
+++ b/tests/ipcMain/helpers.ts
@@ -30,6 +30,10 @@ const isCI = process.env.CI === "true" || process.env.CI === "1";
 export const STREAM_TIMEOUT_LOCAL_MS = isCI ? 37500 : 15000; // 37.5s in CI, 15s locally
 export const STREAM_TIMEOUT_SSH_MS = isCI ? 62500 : 25000; // 62.5s in CI, 25s locally
 
+// Additional stream timeout constants for tests (also CI-aware)
+export const STREAM_TIMEOUT_SHORT_MS = isCI ? 25000 : 10000; // For quick operations
+export const STREAM_TIMEOUT_MEDIUM_MS = isCI ? 75000 : 30000; // For standard operations
+
 /**
  * Generate a unique branch name
  * Uses high-resolution time (nanosecond precision) to prevent collisions
@@ -618,7 +622,7 @@ export async function waitForInitEnd(
 export async function waitForStreamSuccess(
   sentEvents: Array<{ channel: string; data: unknown }>,
   workspaceId: string,
-  timeoutMs = isCI ? 75000 : 30000 // Use longer timeout in CI (75s vs 30s)
+  timeoutMs = STREAM_TIMEOUT_MEDIUM_MS // Use CI-aware timeout (75s in CI, 30s locally)
 ): Promise<EventCollector> {
   const collector = createEventCollector(sentEvents, workspaceId);
   await collector.waitForEvent("stream-end", timeoutMs);

--- a/tests/ipcMain/sendMessage.test.ts
+++ b/tests/ipcMain/sendMessage.test.ts
@@ -18,6 +18,8 @@ import {
   readChatHistory,
   TEST_IMAGES,
   modelString,
+  STREAM_TIMEOUT_SHORT_MS,
+  STREAM_TIMEOUT_MEDIUM_MS,
 } from "./helpers";
 import type { StreamDeltaEvent } from "../../src/types/stream";
 import { IPC_CHANNELS } from "../../src/constants/ipc-constants";
@@ -611,7 +613,7 @@ describeIntegration("IpcMain sendMessage integration tests", () => {
           const collector = await waitForStreamSuccess(
             env.sentEvents,
             workspaceId,
-            provider === "openai" ? 30000 : 10000
+            provider === "openai" ? STREAM_TIMEOUT_MEDIUM_MS : STREAM_TIMEOUT_SHORT_MS
           );
 
           // Get the final assistant message
@@ -858,7 +860,11 @@ These are general instructions that apply to all modes.
           );
 
           // Collect response
-          const collector = await waitForStreamSuccess(env.sentEvents, workspaceId, 10000);
+          const collector = await waitForStreamSuccess(
+            env.sentEvents,
+            workspaceId,
+            STREAM_TIMEOUT_SHORT_MS
+          );
 
           results[provider] = {
             success: result.success,
@@ -1257,7 +1263,11 @@ These are general instructions that apply to all modes.
           expect(result.success).toBe(true);
 
           // Wait for stream to complete
-          const collector = await waitForStreamSuccess(env.sentEvents, workspaceId, 10000);
+          const collector = await waitForStreamSuccess(
+            env.sentEvents,
+            workspaceId,
+            STREAM_TIMEOUT_SHORT_MS
+          );
 
           // Get the final assistant message
           const finalMessage = collector.getFinalMessage();
@@ -1531,7 +1541,11 @@ describe.each(PROVIDER_CONFIGS)("%s:%s image support", (provider, model) => {
         expect(result.success).toBe(true);
 
         // Wait for stream to complete
-        const collector = await waitForStreamSuccess(env.sentEvents, workspaceId, 30000);
+        const collector = await waitForStreamSuccess(
+          env.sentEvents,
+          workspaceId,
+          STREAM_TIMEOUT_MEDIUM_MS
+        );
 
         // Verify we got a response about the image
         const deltas = collector.getDeltas();
@@ -1568,7 +1582,7 @@ describe.each(PROVIDER_CONFIGS)("%s:%s image support", (provider, model) => {
         expect(result.success).toBe(true);
 
         // Wait for stream to complete
-        await waitForStreamSuccess(env.sentEvents, workspaceId, 30000);
+        await waitForStreamSuccess(env.sentEvents, workspaceId, STREAM_TIMEOUT_MEDIUM_MS);
 
         // Read history from disk
         const messages = await readChatHistory(env.tempDir, workspaceId);


### PR DESCRIPTION
## Problem

Integration tests from PR #513 were flaking in CI due to stream timeouts:

- `tests/ipcMain/runtimeFileEditing.test.ts` - File creation timed out after 15s
- `tests/ipcMain/sendMessage.test.ts` - Multiple Anthropic provider tests timed out after 30s
- `tests/ipcMain/sendMessage.test.ts` - Image support test timed out

CI logs show tests that passed took 10-258 seconds total, while failing tests hit the 15-30s stream timeouts. The issue is exacerbated by:
- API rate limiting in CI (shared across parallel test runs)
- CI environment overhead
- Jest retry logic (3 retries) multiplying timeout impact

## Solution

Make stream timeouts CI-aware with 2.5x multiplier for CI environments:

- `STREAM_TIMEOUT_LOCAL_MS`: 15s → **37.5s in CI**
- `STREAM_TIMEOUT_SSH_MS`: 25s → **62.5s in CI**  
- `waitForStreamSuccess` default: 30s → **75s in CI**

CI detection uses standard `process.env.CI` check. Local development keeps existing faster timeouts for quick feedback.

## Testing

The failing tests already have Jest retry logic (`jest.retryTimes(2-3)`) which will validate the fix across multiple attempts if needed. Extended timeouts give API calls breathing room without slowing down successful runs (streams still end immediately on completion).

_Generated with `cmux`_