### PR TITLE
🤖 fix: use git show-branch for clearer SSH workspace force delete errors

### DIFF
--- a/src/runtime/SSHRuntime.ts
+++ b/src/runtime/SSHRuntime.ts
@@ -985,46 +985,34 @@ export class SSHRuntime implements Runtime {
             cd ${shescape.quote(deletedPath)} || exit 1
             git diff --quiet --exit-code && git diff --quiet --cached --exit-code || exit 1
             if git remote | grep -q .; then
-              # Get current branch
-              BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-              
-              # Get default branch (try origin/HEAD, fallback to main, then master)
-              DEFAULT=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-              if [ -z "$DEFAULT" ]; then
-                if git rev-parse --verify origin/main >/dev/null 2>&1; then
-                  DEFAULT="main"
-                elif git rev-parse --verify origin/master >/dev/null 2>&1; then
-                  DEFAULT="master"
-                fi
-              fi
-              
-              # If we have both branch and default, use show-branch for better output
-              if [ -n "$BRANCH" ] && [ -n "$DEFAULT" ]; then
-                if git show-branch "$BRANCH" "origin/$DEFAULT" >/dev/null 2>&1; then
-                  # Check if there are commits not in the default branch
-                  if ! git merge-base --is-ancestor "$BRANCH" "origin/$DEFAULT" 2>/dev/null; then
-                    echo "Branch status compared to origin/$DEFAULT:" >&2
-                    echo "" >&2
-                    git show-branch "$BRANCH" "origin/$DEFAULT" 2>&1 | head -20 >&2
-                    echo "" >&2
-                    echo "Note: If your PR was squash-merged, these commits are already in origin/$DEFAULT and safe to delete." >&2
-                    exit 2
+              # First, check the original condition: any commits not in any remote
+              unpushed=$(git log --branches --not --remotes --oneline)
+              if [ -n "$unpushed" ]; then
+                # Get current branch for better error messaging
+                BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+                
+                # Get default branch (try origin/HEAD, fallback to main, then master)
+                DEFAULT=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+                if [ -z "$DEFAULT" ]; then
+                  if git rev-parse --verify origin/main >/dev/null 2>&1; then
+                    DEFAULT="main"
+                  elif git rev-parse --verify origin/master >/dev/null 2>&1; then
+                    DEFAULT="master"
                   fi
+                fi
+                
+                # If we have both branch and default, use show-branch for better output
+                if [ -n "$BRANCH" ] && [ -n "$DEFAULT" ] && git show-branch "$BRANCH" "origin/$DEFAULT" >/dev/null 2>&1; then
+                  echo "Branch status compared to origin/$DEFAULT:" >&2
+                  echo "" >&2
+                  git show-branch "$BRANCH" "origin/$DEFAULT" 2>&1 | head -20 >&2
+                  echo "" >&2
+                  echo "Note: If your PR was squash-merged, these commits are already in origin/$DEFAULT and safe to delete." >&2
                 else
-                  # Fallback to git log if show-branch fails
-                  unpushed=$(git log --branches --not --remotes --oneline)
-                  if [ -n "$unpushed" ]; then
-                    echo "$unpushed" | head -10 >&2
-                    exit 2
-                  fi
-                fi
-              else
-                # Fallback to git log if we can't determine branches
-                unpushed=$(git log --branches --not --remotes --oneline)
-                if [ -n "$unpushed" ]; then
+                  # Fallback to just showing the commit list
                   echo "$unpushed" | head -10 >&2
-                  exit 2
                 fi
+                exit 2
               fi
             fi
             exit 0


### PR DESCRIPTION
## Problem

When attempting to delete SSH workspaces with unpushed commits, the current error message uses `git log --branches --not --remotes` which just lists commits without context. This is especially confusing in squash-merge workflows where feature branch commits never appear in main, so they always show as "unpushed" even after the PR is merged.

## Solution

Replace the git log command with `git show-branch <current-branch> origin/<default-branch>` to show the relationship between branches visually.

**Before:**
```
5d307e9 feat: add feature work 2
5e195dd feat: add feature work 1
```

**After:**
```
Branch status compared to origin/main:

* [feature-branch] feat: add feature work 2
 ! [origin/main] feat: add all feature work (squashed)
--
 * [origin/main] feat: add all feature work (squashed)
+  [feature-branch] feat: add feature work 2
+  [feature-branch^] feat: add feature work 1
+* [origin/main^] Initial commit

Note: If your PR was squash-merged, these commits are already
in origin/main and safe to delete.
```

The `+`, `*`, and `+*` markers clearly show which commits are in which branch, making it immediately obvious when dealing with a squash-merge scenario.

## Implementation

- Detects default branch using `git symbolic-ref refs/remotes/origin/HEAD` with fallbacks to main/master
- Uses `git show-branch` to display branch relationships
- Falls back to original `git log` command when:
  - No remote branches exist
  - Default branch cannot be determined  
  - show-branch fails for any reason

This ensures backward compatibility while providing better UX in the common case.

## Testing

All existing integration tests pass, including the test that validates error messages contain commit information.

_Generated with `cmux`_