### PR TITLE
🤖 fix: use correct event parameter syntax for build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # cmux - coding agent multiplexer
 
 [![CI](https://github.com/coder/cmux/actions/workflows/ci.yml/badge.svg)](https://github.com/coder/cmux/actions/workflows/ci.yml)
-[![Build](https://github.com/coder/cmux/actions/workflows/build.yml/badge.svg)](https://github.com/coder/cmux/actions/workflows/build.yml?query=event:merge_group)
+[![Build](https://github.com/coder/cmux/actions/workflows/build.yml/badge.svg?event=merge_group)](https://github.com/coder/cmux/actions/workflows/build.yml?query=event:merge_group)
 [![Download](https://img.shields.io/badge/Download-Releases-purple)](https://github.com/coder/cmux/releases)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL%203.0-blue.svg)](LICENSE)
 


### PR DESCRIPTION
The badge was showing as failed because it used the GitHub Actions UI filter syntax (`?query=event:merge_group`) instead of the badge API parameter syntax (`?event=merge_group`).

According to GitHub's documentation, the `badge.svg` endpoint supports `?event=<event_type>` to filter by event type, not the `?query=` syntax.

This keeps the badge filtered to only merge_group events (as desired) but uses the correct API syntax so it actually works.

_Generated with `cmux`_