### PR TITLE
🤖 fix: prevent ForceDeleteModal overflow with long error logs

### DIFF
--- a/src/components/ForceDeleteModal.tsx
+++ b/src/components/ForceDeleteModal.tsx
@@ -50,6 +50,7 @@ export const ForceDeleteModal: React.FC<ForceDeleteModalProps> = ({
       subtitle="The workspace could not be removed normally"
       onClose={onClose}
       maxWidth="600px"
+      maxHeight="90vh"
       isLoading={isDeleting}
     >
       <ErrorSection>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -30,6 +30,7 @@ export const ModalContent: React.FC<
     className={cn(
       "bg-dark rounded-lg p-6 w-[90%] flex flex-col shadow-lg border border-border",
       "[&_h2]:mt-0 [&_h2]:mb-2 [&_h2]:text-white",
+      maxHeight && "overflow-y-auto",
       className
     )}
     style={{ maxWidth, ...(maxHeight && { maxHeight }) }}
@@ -96,7 +97,8 @@ export const ErrorCodeBlock: React.FC<{ children: React.ReactNode; className?: s
   <pre
     className={cn(
       "bg-background-secondary border border-border rounded p-3",
-      "text-xs font-mono text-foreground overflow-x-auto whitespace-pre-wrap break-words leading-relaxed",
+      "text-xs font-mono text-foreground overflow-auto whitespace-pre-wrap break-words leading-relaxed",
+      "max-h-[400px]",
       className
     )}
   >


### PR DESCRIPTION
ErrorCodeBlock now has a 400px max-height with scrolling, and the modal itself is constrained to 90vh to ensure the Force Delete button always remains visible.

_Generated with `cmux`_