### PR TITLE
🤖 fix: increase SSH resolvePath timeout to 10s

### DIFF
--- a/src/runtime/SSHRuntime.ts
+++ b/src/runtime/SSHRuntime.ts
@@ -377,8 +377,8 @@ export class SSHRuntime implements Runtime {
     // Bash will expand ~ automatically when we echo the unquoted variable
     // This works with BusyBox (doesn't require GNU coreutils)
     const command = `bash -c 'p=${shescape.quote(filePath)}; echo $p'`;
-    // Use 5 second timeout for path resolution (should be near-instant)
-    return this.execSSHCommand(command, 5000);
+    // Use 10 second timeout for path resolution to allow for slower SSH connections
+    return this.execSSHCommand(command, 10000);
   }
 
   /**


### PR DESCRIPTION
SSH workspace creation was timing out after 5s on slower connections. The connection would have succeeded with more time.

Increased timeout from 5s to 10s in `resolvePath()` to accommodate slower networks or hosts under load.

ProxyCommand `coder ssh` is quite slow for me right now & I was hitting this timeout semi frequently. (I like Coder Desktop because it's nowhere near this slow for new ssh connections)


_Generated with `cmux`_