### PR TITLE
🤖 fix: Ctrl+C no longer interrupts stream when text is selected

### DIFF
--- a/src/hooks/useAIViewKeybinds.ts
+++ b/src/hooks/useAIViewKeybinds.ts
@@ -67,12 +67,11 @@ export function useAIViewKeybinds({
         }
 
         // Normal stream interrupt (non-compaction)
-        // Allow interrupt in editable elements if there's no text selection
+        // Check for text selection anywhere - only interrupt if nothing is selected
         // This way Ctrl+C works for both copy (when text is selected) and interrupt (when not)
-        const inEditableElement = isEditableElement(e.target);
         let hasSelection = false;
 
-        if (inEditableElement) {
+        if (isEditableElement(e.target)) {
           // For input/textarea elements, check selectionStart/selectionEnd
           // (window.getSelection() doesn't work for form elements)
           const target = e.target as HTMLInputElement | HTMLTextAreaElement;
@@ -85,7 +84,8 @@ export function useAIViewKeybinds({
           hasSelection = (window.getSelection()?.toString().length ?? 0) > 0;
         }
 
-        if ((canInterrupt || showRetryBarrier) && (!inEditableElement || !hasSelection)) {
+        // Only interrupt if there's no selection (allow Ctrl+C to copy when text is selected)
+        if ((canInterrupt || showRetryBarrier) && !hasSelection) {
           e.preventDefault();
           setAutoRetry(false); // User explicitly stopped - don't auto-retry
           void window.api.workspace.interruptStream(workspaceId);


### PR DESCRIPTION
Previously, Ctrl+C would interrupt the stream if the user was not in an editable element, even if they had text selected elsewhere in the chat (e.g., in message content).

## Problem

The condition `(!inEditableElement || !hasSelection)` would interrupt when:
- NOT in editable element (regardless of selection) ← **the bug**
- In editable element but no selection

This meant selecting text in chat messages and pressing Ctrl+C to copy would incorrectly interrupt the stream.

## Solution

Simplified the logic to `!hasSelection` - now it always checks for text selection anywhere on the page, regardless of whether the user is in an editable element.

## Verification

```typescript
// Before: Interrupted even with selection outside editable elements
if ((canInterrupt || showRetryBarrier) && (!inEditableElement || !hasSelection)) {
  // interrupt
}

// After: Only interrupts when nothing is selected
if ((canInterrupt || showRetryBarrier) && !hasSelection) {
  // interrupt
}
```

**Behavior now:**
- User selects text in chat messages → Press Ctrl+C → Text is copied (stream continues) ✅
- No text selected → Press Ctrl+C → Stream is interrupted ✅

_Generated with `cmux`_