### PR TITLE
🤖 feat: VS Code Marketplace release infrastructure

### DIFF
--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -1,0 +1,61 @@
+name: Publish VS Code Extension
+
+on:
+  push:
+    tags:
+      - 'vscode-v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.1.42
+
+      - name: Install dependencies
+        working-directory: vscode
+        run: bun install
+
+      - name: Compile extension
+        working-directory: vscode
+        run: bun run compile
+
+      - name: Publish to Marketplace
+        working-directory: vscode
+        run: npx @vscode/vsce publish -p $VSCE_PAT
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Package extension
+        working-directory: vscode
+        run: bun run package
+
+      - name: Extract version
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/vscode-v}" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: "🤖 VS Code Extension v${{ steps.version.outputs.version }}"
+          body: |
+            _Generated with `cmux`_
+            
+            ## Installation
+            
+            **From VS Code Marketplace:**
+            ```bash
+            code --install-extension coder.cmux
+            ```
+            
+            **From .vsix file:**
+            ```bash
+            code --install-extension cmux-${{ steps.version.outputs.version }}.vsix
+            ```
+          files: vscode/cmux-*.vsix


### PR DESCRIPTION
_Generated with `cmux`_

## Overview

Establishes complete infrastructure for publishing the cmux VS Code extension to the official VS Code Marketplace.

## What's Included

### Documentation
- **MARKETPLACE_RELEASE.md**: Comprehensive publishing guide covering Azure DevOps setup, PAT management, publishing procedures, troubleshooting, and maintenance
- **RELEASE_CHECKLIST.md**: Quick reference for release workflow
- **README.md**: Updated with marketplace installation as primary method

### Automation
- **GitHub Actions workflow** (`.github/workflows/publish-vscode-extension.yml`)
  - Triggers on tags matching `vscode-v*`
  - Builds, packages, and publishes to marketplace
  - Creates GitHub release with .vsix attached
  - Requires `VSCE_PAT` repository secret

### Verification
- **verify-marketplace-setup.sh**: Pre-publish verification script

## Release Process

### One-Time Setup (Required)
1. Create Azure DevOps account
2. Generate PAT with Marketplace: Acquire + Publish scopes
3. Add `VSCE_PAT` to GitHub repository secrets
4. Verify/create "coder" publisher: `npx @vscode/vsce login coder`

### Publishing (Automated)
```bash
git tag vscode-v0.1.0
git push origin vscode-v0.1.0
```

GitHub Actions handles the rest:
- Builds extension
- Publishes to marketplace
- Creates GitHub release

### Future Releases
```bash
cd vscode
npm version patch
git add package.json CHANGELOG.md
git commit -m "🤖 release: VS Code extension v0.1.1"
git push origin marketplace-release
git tag vscode-v0.1.1
git push origin vscode-v0.1.1
```

## Ready to Ship

Extension code is production-ready (already merged in #553). This PR only adds release infrastructure.

**No code changes** - purely documentation and CI/CD setup.

## Next Steps After Merge

1. Complete Azure DevOps setup (PAT + publisher)
2. Add `VSCE_PAT` secret to repository
3. Tag and push `vscode-v0.1.0` to trigger first publish
4. Verify on marketplace: https://marketplace.visualstudio.com/items?itemName=coder.cmux

## Questions

- Publisher name "coder" correct?
- Ready to publish 0.1.0 immediately after merge?
- Want pre-release flag for initial launch?