### PR TITLE
🤖 refactor: rename CMUX_TEST_ROOT to CMUX_ROOT

### DIFF
--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 
 /**
  * Get the root directory for all cmux configuration and data.
- * Can be overridden with CMUX_TEST_ROOT environment variable.
+ * Can be overridden with CMUX_ROOT environment variable.
  * Appends '-dev' suffix when NODE_ENV=development (explicit dev mode).
  *
  * This is a getter function to support test mocking of os.homedir().
@@ -13,9 +13,9 @@ import { join } from "path";
  */
 export function getCmuxHome(): string {
   // eslint-disable-next-line no-restricted-syntax, no-restricted-globals
-  if (process.env.CMUX_TEST_ROOT) {
+  if (process.env.CMUX_ROOT) {
     // eslint-disable-next-line no-restricted-syntax, no-restricted-globals
-    return process.env.CMUX_TEST_ROOT;
+    return process.env.CMUX_ROOT;
   }
 
   const baseName = ".cmux";

--- a/src/main-desktop.ts
+++ b/src/main-desktop.ts
@@ -75,7 +75,7 @@ const forceDistLoad = process.env.CMUX_E2E_LOAD_DIST === "1";
 
 if (isE2ETest) {
   // For e2e tests, use a test-specific userData directory
-  // Note: getCmuxHome() already respects CMUX_TEST_ROOT for test isolation
+  // Note: getCmuxHome() already respects CMUX_ROOT for test isolation
   const e2eUserData = path.join(getCmuxHome(), "user-data");
   try {
     fs.mkdirSync(e2eUserData, { recursive: true });

--- a/tests/e2e/electronTest.ts
+++ b/tests/e2e/electronTest.ts
@@ -88,7 +88,7 @@ function buildTarget(target: string): void {
 
 export const electronTest = base.extend<ElectronFixtures>({
   workspace: async ({}, use, testInfo) => {
-    const envRoot = process.env.CMUX_TEST_ROOT ?? "";
+    const envRoot = process.env.CMUX_ROOT ?? "";
     const baseRoot = envRoot || defaultTestRoot;
     const uniqueTestId = testInfo.testId || testInfo.title || `test-${Date.now()}`;
     const testRoot = envRoot ? baseRoot : path.join(baseRoot, sanitizeForPath(uniqueTestId));
@@ -195,7 +195,7 @@ export const electronTest = base.extend<ElectronFixtures>({
       }
       electronEnv.ELECTRON_DISABLE_SECURITY_WARNINGS = "true";
       electronEnv.CMUX_MOCK_AI = electronEnv.CMUX_MOCK_AI ?? "1";
-      electronEnv.CMUX_TEST_ROOT = configRoot;
+      electronEnv.CMUX_ROOT = configRoot;
       electronEnv.CMUX_E2E = "1";
       electronEnv.CMUX_E2E_LOAD_DIST = shouldLoadDist ? "1" : "0";
       electronEnv.VITE_DISABLE_MERMAID = "1";


### PR DESCRIPTION
Renames `CMUX_TEST_ROOT` to `CMUX_ROOT` for clearer intent. This environment variable overrides the default cmux data directory and is useful beyond just testing scenarios (e.g., when developers want to run with a clean slate or isolate different development environments).

## Changes

- `CMUX_TEST_ROOT` → `CMUX_ROOT` in all references (`paths.ts`, `main-desktop.ts`, `electronTest.ts`)
- Updated comments to match the new name

## Behavior

No behavior changes - this is purely a rename:
- `make start` still uses `~/.cmux-dev` (via `NODE_ENV=development`, behavior from #573)
- Packaged apps still use `~/.cmux`
- `CMUX_ROOT=/custom/path` still overrides everything

The rename clarifies that this variable isn't just for tests - developers can use it anytime they want explicit control over the data directory.

_Generated with `cmux`_