### PR TITLE
🤖 refactor: update VS Code extension branding and marketplace publishing

### DIFF
--- a/.github/actions/build-vscode-extension/action.yml
+++ b/.github/actions/build-vscode-extension/action.yml
@@ -1,5 +1,5 @@
 name: "Build VS Code Extension"
-description: "Build the cmux VS Code extension"
+description: "Build the mux VS Code extension"
 
 runs:
   using: "composite"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: vscode-extension
-          path: vscode/cmux-*.vsix
+          path: vscode/mux-*.vsix
           retention-days: 30
           if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ github.event.release.tag_name }} \
-            vscode/cmux-*.vsix \
+            vscode/mux-*.vsix \
             --clobber
+
+      - name: Publish to VS Code Marketplace
+        if: secrets.VSCE_PAT != ''
+        working-directory: vscode
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          bunx vsce publish -p $VSCE_PAT
 
   build-windows:
     name: Build and Release Windows

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Change Log
 
-All notable changes to the "cmux" extension will be documented in this file.
+All notable changes to the "mux" extension will be documented in this file.
 
 ## [0.1.0] - 2024-11-11
 
 ### Added
 - Initial release
-- Command to open cmux workspaces from VS Code and Cursor
+- Command to open mux workspaces from VS Code and Cursor
 - Support for local workspaces
 - Support for SSH workspaces via Remote-SSH extension
   - Automatically detects VS Code Remote-SSH (`ms-vscode-remote.remote-ssh`)

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,18 +1,18 @@
-# cmux VS Code Extension
+# mux VS Code Extension
 
-Open [cmux](https://cmux.io) workspaces from VS Code or Cursor.
+Open [mux](https://cmux.io) workspaces from VS Code or Cursor.
 
 ## Installation
 
-Download the latest `.vsix` from [cmux releases](https://github.com/coder/cmux/releases) and install:
+Download the latest `.vsix` from [mux releases](https://github.com/coder/mux/releases) and install:
 
 ```bash
-code --install-extension cmux-0.1.0.vsix
+code --install-extension mux-0.1.0.vsix
 ```
 
 ## Usage
 
-`Cmd+Shift+P` → "cmux: Open Workspace" → Select workspace
+`Cmd+Shift+P` → "mux: Open Workspace" → Select workspace
 
 ## Requirements
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "cmux",
-  "displayName": "cmux",
-  "description": "Open cmux workspaces directly from VS Code",
+  "name": "mux",
+  "displayName": "mux",
+  "description": "Open mux workspaces directly from VS Code",
   "version": "0.1.0",
   "publisher": "coder",
   "icon": "icon.png",
@@ -15,21 +15,21 @@
     "Other"
   ],
   "keywords": [
-    "cmux",
+    "mux",
     "workspace",
     "remote",
     "ssh",
     "development"
   ],
   "activationEvents": [
-    "onCommand:cmux.openWorkspace"
+    "onCommand:mux.openWorkspace"
   ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
       {
-        "command": "cmux.openWorkspace",
-        "title": "cmux: Open Workspace"
+        "command": "mux.openWorkspace",
+        "title": "mux: Open Workspace"
       }
     ]
   },
@@ -48,7 +48,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/coder/cmux.git",
+    "url": "https://github.com/coder/mux.git",
     "directory": "vscode"
   },
   "license": "AGPL-3.0-only",

--- a/vscode/src/cmuxConfig.ts
+++ b/vscode/src/cmuxConfig.ts
@@ -25,13 +25,13 @@ export async function getAllWorkspaces(): Promise<WorkspaceWithContext[]> {
   const workspaces = await config.getAllWorkspaceMetadata();
   const extensionMeta = readExtensionMetadata();
 
-  console.log(`[cmux] Read ${extensionMeta.size} entries from extension metadata`);
+  console.log(`[mux] Read ${extensionMeta.size} entries from extension metadata`);
 
   // Enrich with extension metadata
   const enriched: WorkspaceWithContext[] = workspaces.map((ws) => {
     const meta = extensionMeta.get(ws.id);
     if (meta) {
-      console.log(`[cmux]   ${ws.id}: recency=${meta.recency}, streaming=${meta.streaming}`);
+      console.log(`[mux]   ${ws.id}: recency=${meta.recency}, streaming=${meta.streaming}`);
     }
     return {
       ...ws,

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -47,7 +47,7 @@ function createWorkspaceQuickPickItem(
 }
 
 /**
- * Command: Open a cmux workspace
+ * Command: Open a mux workspace
  */
 async function openWorkspaceCommand() {
   // Get all workspaces, this is intentionally not cached.
@@ -55,14 +55,14 @@ async function openWorkspaceCommand() {
 
   if (workspaces.length === 0) {
     const selection = await vscode.window.showInformationMessage(
-      "No cmux workspaces found. Create a workspace in cmux first.",
-      "Open cmux"
+      "No mux workspaces found. Create a workspace in mux first.",
+      "Open mux"
     );
 
-    // User can't easily open cmux from VS Code, so just inform them
-    if (selection === "Open cmux") {
+    // User can't easily open mux from VS Code, so just inform them
+    if (selection === "Open mux") {
       vscode.window.showInformationMessage(
-        "Please open the cmux application to create workspaces."
+        "Please open the mux application to create workspaces."
       );
     }
     return;
@@ -75,7 +75,7 @@ async function openWorkspaceCommand() {
   const quickPick = vscode.window.createQuickPick<
     vscode.QuickPickItem & { workspace: WorkspaceWithContext }
   >();
-  quickPick.placeholder = "Select a cmux workspace to open";
+  quickPick.placeholder = "Select a mux workspace to open";
   quickPick.matchOnDescription = true;
   quickPick.matchOnDetail = false;
   quickPick.items = allItems;
@@ -126,7 +126,7 @@ async function openWorkspaceCommand() {
  */
 export function activate(context: vscode.ExtensionContext) {
   // Register the openWorkspace command
-  const disposable = vscode.commands.registerCommand("cmux.openWorkspace", openWorkspaceCommand);
+  const disposable = vscode.commands.registerCommand("mux.openWorkspace", openWorkspaceCommand);
 
   context.subscriptions.push(disposable);
 }

--- a/vscode/src/workspaceOpener.ts
+++ b/vscode/src/workspaceOpener.ts
@@ -29,7 +29,7 @@ export async function openWorkspace(workspace: WorkspaceWithContext) {
   // Check if Remote-SSH is installed
   if (!isRemoteSshInstalled()) {
     const selection = await vscode.window.showErrorMessage(
-      'cmux: The "Remote - SSH" extension is required to open SSH workspaces. ' +
+      'mux: The "Remote - SSH" extension is required to open SSH workspaces. ' +
         "Please install it from the Extensions marketplace.",
       "Open Extensions"
     );
@@ -45,7 +45,7 @@ export async function openWorkspace(workspace: WorkspaceWithContext) {
   }
 
   if (workspace.runtimeConfig.type !== "ssh") {
-    vscode.window.showErrorMessage("cmux: Workspace is not configured for SSH.");
+    vscode.window.showErrorMessage("mux: Workspace is not configured for SSH.");
     return;
   }
 
@@ -63,7 +63,7 @@ export async function openWorkspace(workspace: WorkspaceWithContext) {
     });
   } catch (error) {
     const selection = await vscode.window.showErrorMessage(
-      `cmux: Failed to open SSH workspace on host "${host}". ` +
+      `mux: Failed to open SSH workspace on host "${host}". ` +
         `Make sure the host is configured in your ~/.ssh/config or in the Remote-SSH extension. ` +
         `Error: ${error instanceof Error ? error.message : String(error)}`,
       "Open SSH Config"


### PR DESCRIPTION
## Summary

Updates the VS Code extension branding from "cmux" to "mux" and adds automated marketplace publishing to the release workflow.

## Changes

### Branding Updates
- **Extension metadata**: Updated `name`, `displayName`, and `description` in `package.json`
- **Command IDs**: Changed from `cmux.*` to `mux.*` (e.g., `mux.openWorkspace`)
- **User-facing strings**: Updated error messages, UI text, and console logs
- **Domain reference**: Fixed to use correct live domain `cmux.io`
- **Keywords**: Updated marketplace keywords from "cmux" to "mux"

### GitHub Workflows
- **Artifact naming**: Changed from `cmux-*.vsix` to `mux-*.vsix` in build and release workflows
- **Marketplace publishing**: Added automatic publishing to VS Code marketplace on release
  - Requires `VSCE_PAT` secret to be set in repository settings
  - Only publishes if token is available (graceful degradation)
- **Workflow descriptions**: Updated composite action descriptions

## Marketplace Setup

To enable marketplace publishing, add the `VSCE_PAT` secret to repository settings:

1. Create a Personal Access Token in Azure DevOps:
   - Go to https://dev.azure.com → Profile → Personal access tokens
   - Create token with **Marketplace (Manage)** scope
   - Set expiration (90 days recommended)

2. Add to GitHub repository:
   - Go to repository Settings → Secrets and variables → Actions
   - Create new secret: `VSCE_PAT` with your token value

The extension will automatically publish to the marketplace when a new release is created.

## Testing

- ✅ Extension builds successfully with new naming
- ✅ GitHub workflows updated for new artifact names
- ✅ All user-facing text updated to "mux" branding
- ✅ Domain reference points to correct `cmux.io`

_Generated with `mux`_