### PR TITLE
🤖 ci: speed up mac build job

### DIFF
--- a/.github/actions/setup-mux/action.yml
+++ b/.github/actions/setup-mux/action.yml
@@ -1,10 +1,5 @@
 name: "Setup Mux"
 description: "Setup Bun and install dependencies with caching"
-inputs:
-  install-imagemagick:
-    description: "Install ImageMagick (needed for electron-builder icon generation)"
-    required: false
-    default: "false"
 runs:
   using: "composite"
   steps:
@@ -38,38 +33,3 @@ runs:
       shell: bash
       run: bun install --frozen-lockfile
 
-    - name: Install ImageMagick (macOS)
-      if: inputs.install-imagemagick == 'true' && runner.os == 'macOS'
-      shell: bash
-      run: |
-        if command -v magick &>/dev/null; then
-          echo "✅ ImageMagick already available"
-        else
-          echo "📦 Installing ImageMagick..."
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install imagemagick
-        fi
-        magick --version | head -1
-
-    - name: Install ImageMagick (Linux)
-      if: inputs.install-imagemagick == 'true' && runner.os == 'Linux'
-      shell: bash
-      run: |
-        if command -v convert &>/dev/null; then
-          echo "✅ ImageMagick already available"
-        else
-          echo "📦 Installing ImageMagick..."
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends imagemagick
-        fi
-        convert --version | head -1
-    - name: Install ImageMagick (Windows)
-      if: inputs.install-imagemagick == 'true' && runner.os == 'Windows'
-      shell: powershell
-      run: |
-        if (Get-Command magick -ErrorAction SilentlyContinue) {
-          Write-Host "✅ ImageMagick already available"
-        } else {
-          Write-Host "📦 Installing ImageMagick..."
-          choco install -y imagemagick
-        }
-        magick --version | Select-Object -First 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,6 @@ jobs:
           fetch-depth: 0 # Required for git describe to find tags
 
       - uses: ./.github/actions/setup-mux
-        with:
-          install-imagemagick: true
 
       - name: Setup code signing
         run: ./scripts/setup-macos-signing.sh
@@ -70,8 +68,6 @@ jobs:
           fetch-depth: 0 # Required for git describe to find tags
 
       - uses: ./.github/actions/setup-mux
-        with:
-          install-imagemagick: true
 
       - name: Build application
         run: bun run build

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -23,8 +23,6 @@ jobs:
           fetch-depth: 0 # Required for git describe to find tags
 
       - uses: ./.github/actions/setup-mux
-        with:
-          install-imagemagick: "true"
 
       # Sets up .npmrc with the auth token
       - uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,6 @@ jobs:
           fetch-depth: 0 # Required for git describe to find tags
 
       - uses: ./.github/actions/setup-mux
-        with:
-          install-imagemagick: true
 
       - name: Build application
         run: bun run build
@@ -48,8 +46,6 @@ jobs:
           fetch-depth: 0 # Required for git describe to find tags
 
       - uses: ./.github/actions/setup-mux
-        with:
-          install-imagemagick: true
 
       - name: Build application
         run: bun run build
@@ -98,8 +94,6 @@ jobs:
           fetch-depth: 0 # Required for git describe to find tags
 
       - uses: ./.github/actions/setup-cmux
-        with:
-          install-imagemagick: true
 
       - name: Install GNU Make (for build)
         run: choco install -y make

--- a/Makefile
+++ b/Makefile
@@ -186,30 +186,17 @@ src/version.ts: version
 # Platform-specific icon targets
 ifeq ($(shell uname), Darwin)
 build-icons: build/icon.icns build/icon.png ## Generate Electron app icons from logo (macOS builds both)
+
+build/icon.icns: docs/img/logo.webp scripts/generate-icons.ts
+	@echo "Generating macOS ICNS icon..."
+	@bun scripts/generate-icons.ts icns
 else
 build-icons: build/icon.png ## Generate Electron app icons from logo (Linux builds PNG only)
 endif
 
-# Detect ImageMagick command (magick on v7+, convert on older versions)
-MAGICK_CMD := $(shell command -v magick 2>/dev/null || command -v convert 2>/dev/null || echo "magick")
-
-build/icon.png: docs/img/logo.webp
-	@echo "Generating Linux icon..."
-	@mkdir -p build
-	@"$(MAGICK_CMD)" docs/img/logo.webp -resize 512x512 build/icon.png
-
-build/icon.icns: docs/img/logo.webp
-	@echo "Generating macOS icon..."
-	@mkdir -p build/icon.iconset
-	@for size in 16 32 64 128 256 512; do \
-		"$(MAGICK_CMD)" docs/img/logo.webp -resize $${size}x$${size} build/icon.iconset/icon_$${size}x$${size}.png; \
-		if [ $$size -le 256 ]; then \
-			double=$$((size * 2)); \
-			"$(MAGICK_CMD)" docs/img/logo.webp -resize $${double}x$${double} build/icon.iconset/icon_$${size}x$${size}@2x.png; \
-		fi; \
-	done
-	@iconutil -c icns build/icon.iconset -o build/icon.icns
-	@rm -rf build/icon.iconset
+build/icon.png: docs/img/logo.webp scripts/generate-icons.ts
+	@echo "Generating PNG icon..."
+	@bun scripts/generate-icons.ts png
 
 ## Quality checks (can run in parallel)
 static-check: lint typecheck fmt-check check-eager-imports ## Run all static checks (includes startup performance checks)

--- a/bun.lock
+++ b/bun.lock
@@ -103,6 +103,7 @@
         "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
+        "sharp": "^0.34.5",
         "shiki": "^3.13.0",
         "storybook": "^10.0.0",
         "tailwind-merge": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
+    "sharp": "^0.34.5",
     "shiki": "^3.13.0",
     "storybook": "^10.0.0",
     "tailwind-merge": "^3.3.1",

--- a/scripts/generate-icons.ts
+++ b/scripts/generate-icons.ts
@@ -1,0 +1,89 @@
+#!/usr/bin/env bun
+import { mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import sharp from "sharp";
+
+const SIZES = [16, 32, 64, 128, 256, 512];
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, "..");
+const SOURCE = path.join(ROOT, "docs", "img", "logo.webp");
+const BUILD_DIR = path.join(ROOT, "build");
+const ICONSET_DIR = path.join(BUILD_DIR, "icon.iconset");
+const PNG_OUTPUT = path.join(BUILD_DIR, "icon.png");
+const ICNS_OUTPUT = path.join(BUILD_DIR, "icon.icns");
+
+const args = new Set(process.argv.slice(2));
+if (args.size === 0) {
+  args.add("png");
+  args.add("icns");
+}
+const needsPng = args.has("png") || args.has("icns");
+const needsIcns = args.has("icns");
+
+async function generateIconPng() {
+  await sharp(SOURCE).resize(512, 512).toFile(PNG_OUTPUT);
+}
+
+async function generateIconsetPngs() {
+  await mkdir(ICONSET_DIR, { recursive: true });
+
+  const tasks = SIZES.flatMap((size) => {
+    const outputs = [
+      {
+        file: path.join(ICONSET_DIR, `icon_${size}x${size}.png`),
+        dimension: size,
+      },
+    ];
+
+    if (size <= 256) {
+      const retina = size * 2;
+      outputs.push({
+        file: path.join(ICONSET_DIR, `icon_${size}x${size}@2x.png`),
+        dimension: retina,
+      });
+    }
+
+    return outputs.map(({ file, dimension }) =>
+      sharp(SOURCE)
+        .resize(dimension, dimension, { fit: "cover" })
+        .toFile(file),
+    );
+  });
+
+  await Promise.all(tasks);
+}
+
+async function generateIcns() {
+  if (process.platform !== "darwin") {
+    throw new Error("ICNS generation requires macOS (iconutil)");
+  }
+
+  const proc = Bun.spawn([
+    "iconutil",
+    "-c",
+    "icns",
+    ICONSET_DIR,
+    "-o",
+    ICNS_OUTPUT,
+  ]);
+  const status = await proc.exited;
+  if (status !== 0) {
+    throw new Error("iconutil failed to generate .icns file");
+  }
+}
+
+await mkdir(BUILD_DIR, { recursive: true });
+
+if (needsPng) {
+  await generateIconPng();
+}
+
+if (needsIcns) {
+  await generateIconsetPngs();
+  await generateIcns();
+}
+
+await rm(ICONSET_DIR, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- drop the standalone `bun run build` invocation from the macOS workflow so `make dist-mac` is the only target that compiles everything
- replace the ImageMagick dependency with `scripts/generate-icons.ts` (Bun + Sharp) and delete the `install-imagemagick` plumbing from setup-mux plus every workflow that used it
- setup now restores caches + runs `bun install` only, cutting the macOS job from ~19m to ~9m (setup step alone shrank from 13m30s ➜ 2m03s)

| Run | Workflow version | Setup mux duration | Build macOS job |
| --- | --- | --- | --- |
| [19375324780](https://github.com/coder/mux/actions/runs/19375324780/job/55441174656) | before | 13m31s | 19m05s |
| [19376083893](https://github.com/coder/mux/actions/runs/19376083893/job/55443762040) | after | 2m03s | 8m43s |

## Testing
- make build-icons
- ./scripts/wait_pr_checks.sh 599

_Generated with `mux`_
