### PR TITLE
🤖 ci: skip bun install on cache hit

### DIFF
--- a/.github/actions/setup-mux/action.yml
+++ b/.github/actions/setup-mux/action.yml
@@ -14,6 +14,7 @@ runs:
       run: echo "version=$(bun --version)" >> $GITHUB_OUTPUT
 
     - name: Cache node_modules
+      id: cache-node-modules
       uses: actions/cache@v4
       with:
         path: node_modules
@@ -22,6 +23,7 @@ runs:
           ${{ runner.os }}-${{ runner.arch }}-bun-${{ steps.bun-version.outputs.version }}-node-modules-
 
     - name: Cache bun install cache
+      id: cache-bun-install
       uses: actions/cache@v4
       with:
         path: ~/.bun/install/cache
@@ -30,6 +32,7 @@ runs:
           ${{ runner.os }}-bun-cache-
 
     - name: Install dependencies
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
       shell: bash
       run: bun install --frozen-lockfile
 


### PR DESCRIPTION
## Summary
- add cache step ids to setup-mux action so cache hits can be referenced later
- skip bun install when node_modules cache restores cleanly to avoid ~2m redundant installs on warm runs

## Testing
- Not run (CI-only change)

_Generated with _
