### PR TITLE
🤖 fix: preserve cost history across message compaction

### DIFF
--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -2,6 +2,7 @@ import type { UIMessage } from "ai";
 import type { LanguageModelV2Usage } from "@ai-sdk/provider";
 import type { StreamErrorType } from "./errors";
 import type { ToolPolicy } from "@/utils/tools/toolPolicy";
+import type { ChatUsageDisplay } from "@/utils/tokens/usageAggregator";
 
 // Parsed compaction request data (shared type for consistency)
 export interface CompactionRequestData {
@@ -44,6 +45,7 @@ export interface MuxMetadata {
   toolPolicy?: ToolPolicy; // Tool policy active when this message was sent (user messages only)
   mode?: string; // The mode (plan/exec/etc) active when this message was sent (assistant messages only)
   cmuxMetadata?: MuxFrontendMetadata; // Frontend-defined metadata, backend treats as black-box
+  historicalUsage?: ChatUsageDisplay; // Cumulative usage from all messages before this compaction (only present on compaction summaries)
 }
 
 // Extended tool part type that supports interrupted tool calls (input-available state)


### PR DESCRIPTION
## Problem

Message compaction ( command) was destroying all historical cost data, causing displayed costs to be dramatically lower than actual API spend. This was especially noticeable in long chats with multiple compactions.

### Root Cause

When compaction runs:
1. It creates a single summary message
2. Calls `replaceChatHistory()` which deletes all previous messages
3. Cost calculation only reads from current messages
4. Result: All accumulated costs from deleted messages are lost forever

**Example:**
```
Chat with 3 messages → bash.53 accumulated
Run /compact → Summary costs bash.05
Displayed total: bash.05 ❌ (lost bash.48!)
```

Multiple compactions = multiple cost resets, making long chats appear nearly free.

## Solution

Store cumulative historical costs in the summary message metadata, creating a self-documenting chain that preserves costs across compactions.

### Implementation

1. **Added `historicalUsage` field** to `MuxMetadata`
   - Stores cumulative `ChatUsageDisplay` from all pre-compaction messages
   - Only present on compaction summary messages

2. **Updated `performCompaction()`** to calculate and store totals
   - Calls `getWorkspaceUsage()` before replacing history
   - Sums all current costs with `sumUsageHistory()`
   - Stores in summary message metadata

3. **Updated `getWorkspaceUsage()`** to include historical costs
   - Checks each message for `historicalUsage` field
   - Prepends historical costs to current usage array
   - Totals now include both historical and current costs

### Cost Chain Example

```
Before 1st compact:
  [Msg A: bash.15] [Msg B: bash.20] [Msg C: bash.18]
  Total: bash.53

After 1st compact:
  [Summary with historicalUsage=bash.53]
  Displayed: bash.53 + bash.05 (summary) = bash.58 ✅

Continue chatting:
  [Summary: historical=bash.53, own=bash.05] [Msg D: bash.10] [Msg E: bash.12]
  Total: bash.80

After 2nd compact:
  [Summary2 with historicalUsage=bash.80]
  Displayed: bash.80 + bash.04 (summary) = bash.84 ✅
```

## Testing

Manually tested:
- ✅ Fresh workspace → compact → costs preserved
- ✅ Multiple compactions → costs chain correctly
- ✅ Old sessions without `historicalUsage` → backwards compatible
- ✅ Typechecks pass

## Changes

- `src/types/message.ts`: Add `historicalUsage` field (+1 line)
- `src/stores/WorkspaceStore.ts`: Calculate and include historical costs (+36 lines)
- **Total: 37 LoC**

_Generated with `mux`_