### PR TITLE
🤖 fix: reconnect New Workspace button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useEffect, useCallback, useRef } from "react";
 import "./styles/globals.css";
 import { useWorkspaceContext } from "./contexts/WorkspaceContext";
 import { useProjectContext } from "./contexts/ProjectContext";
@@ -44,6 +44,9 @@ function AppInner() {
     renameWorkspace,
     selectedWorkspace,
     setSelectedWorkspace,
+    pendingNewWorkspaceProject,
+    beginWorkspaceCreation,
+    clearPendingWorkspaceCreation,
   } = useWorkspaceContext();
   const {
     projects,
@@ -53,9 +56,6 @@ function AppInner() {
     closeProjectCreateModal,
     addProject,
   } = useProjectContext();
-
-  // Track when we're in "new workspace creation" mode (show FirstMessageInput)
-  const [pendingNewWorkspaceProject, setPendingNewWorkspaceProject] = useState<string | null>(null);
 
   // Auto-collapse sidebar on mobile by default
   const isMobile = typeof window !== "undefined" && window.innerWidth <= 768;
@@ -72,7 +72,7 @@ function AppInner() {
 
   const startWorkspaceCreation = useStartWorkspaceCreation({
     projects,
-    setPendingNewWorkspaceProject,
+    beginWorkspaceCreation,
     setSelectedWorkspace,
   });
 
@@ -569,13 +569,13 @@ function AppInner() {
                           telemetry.workspaceCreated(metadata.id);
 
                           // Clear pending state
-                          setPendingNewWorkspaceProject(null);
+                          clearPendingWorkspaceCreation();
                         }}
                         onCancel={
                           pendingNewWorkspaceProject
                             ? () => {
                                 // User cancelled workspace creation - clear pending state
-                                setPendingNewWorkspaceProject(null);
+                                clearPendingWorkspaceCreation();
                               }
                             : undefined
                         }

--- a/src/contexts/WorkspaceContext.test.tsx
+++ b/src/contexts/WorkspaceContext.test.tsx
@@ -417,7 +417,7 @@ describe("WorkspaceContext", () => {
     expect(info).toEqual(workspace);
   });
 
-  test("tracks pending workspace creation state", async () => {
+  test("beginWorkspaceCreation clears selection and tracks pending state", async () => {
     createMockAPI({
       workspace: {
         list: () => Promise.resolve([]),
@@ -434,9 +434,20 @@ describe("WorkspaceContext", () => {
     expect(ctx().pendingNewWorkspaceProject).toBeNull();
 
     act(() => {
+      ctx().setSelectedWorkspace({
+        workspaceId: "ws-123",
+        projectPath: "/alpha",
+        projectName: "alpha",
+        namedWorkspacePath: "alpha/ws-123",
+      });
+    });
+    expect(ctx().selectedWorkspace?.workspaceId).toBe("ws-123");
+
+    act(() => {
       ctx().beginWorkspaceCreation("/alpha");
     });
     expect(ctx().pendingNewWorkspaceProject).toBe("/alpha");
+    expect(ctx().selectedWorkspace).toBeNull();
 
     act(() => {
       ctx().clearPendingWorkspaceCreation();

--- a/src/contexts/WorkspaceContext.tsx
+++ b/src/contexts/WorkspaceContext.tsx
@@ -350,9 +350,13 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
     return metadata;
   }, []);
 
-  const beginWorkspaceCreation = useCallback((projectPath: string) => {
-    setPendingNewWorkspaceProject(projectPath);
-  }, []);
+  const beginWorkspaceCreation = useCallback(
+    (projectPath: string) => {
+      setPendingNewWorkspaceProject(projectPath);
+      setSelectedWorkspace(null);
+    },
+    [setSelectedWorkspace]
+  );
 
   const clearPendingWorkspaceCreation = useCallback(() => {
     setPendingNewWorkspaceProject(null);

--- a/src/hooks/useStartWorkspaceCreation.ts
+++ b/src/hooks/useStartWorkspaceCreation.ts
@@ -83,7 +83,7 @@ export function persistWorkspaceCreationPrefill(
 
 interface UseStartWorkspaceCreationOptions {
   projects: Map<string, ProjectConfig>;
-  setPendingNewWorkspaceProject: (projectPath: string | null) => void;
+  beginWorkspaceCreation: (projectPath: string) => void;
   setSelectedWorkspace: (selection: WorkspaceSelection | null) => void;
 }
 
@@ -100,7 +100,7 @@ function resolveProjectPath(
 
 export function useStartWorkspaceCreation({
   projects,
-  setPendingNewWorkspaceProject,
+  beginWorkspaceCreation,
   setSelectedWorkspace,
 }: UseStartWorkspaceCreationOptions) {
   const startWorkspaceCreation = useCallback(
@@ -113,10 +113,10 @@ export function useStartWorkspaceCreation({
       }
 
       persistWorkspaceCreationPrefill(resolvedProjectPath, detail);
-      setPendingNewWorkspaceProject(resolvedProjectPath);
+      beginWorkspaceCreation(resolvedProjectPath);
       setSelectedWorkspace(null);
     },
-    [projects, setPendingNewWorkspaceProject, setSelectedWorkspace]
+    [projects, beginWorkspaceCreation, setSelectedWorkspace]
   );
 
   useEffect(() => {


### PR DESCRIPTION
WorkspaceContext owns the "pending new workspace" state, but App was still tracking its own copy. The sidebar button (and other entry points) mutate the context value, so the creation view never appeared.

- Read pendingNewWorkspaceProject/begin/clear from WorkspaceContext in App
- Clear the shared state after creation cancel/success
- Update useStartWorkspaceCreation to call beginWorkspaceCreation directly

Tests: bun test src/hooks/useStartWorkspaceCreation.test.ts

_Generated with `mux`_
