### PR TITLE
🤖 fix: unblock nightly terminal bench import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -362,7 +362,7 @@ benchmark-terminal: ## Run Terminal-Bench with the mux agent (use TB_DATASET/TB_
 	export MUX_TIMEOUT_MS=$$((TB_TIMEOUT * 1000)); \
 	uvx terminal-bench run \
 		--dataset "$$TB_DATASET" \
-		--agent-import-path benchmarks.terminal_bench.mux_agent:CmuxAgent \
+		--agent-import-path benchmarks.terminal_bench.mux_agent:MuxAgent \
 		--global-agent-timeout-sec $$TB_TIMEOUT \
 		$$CONCURRENCY_FLAG \
 		$$LIVESTREAM_FLAG \

--- a/benchmarks/terminal_bench/README.md
+++ b/benchmarks/terminal_bench/README.md
@@ -101,8 +101,8 @@ Based on analysis of the Oct 30 nightly run (15-minute timeout):
 
 ## Files
 
-- `cmux_agent.py`: Main agent adapter implementing Terminal-Bench's agent interface
-- `cmux-run.sh`: Shell script that sets up environment and invokes cmux CLI
-- `cmux_payload.py`: Helper to package cmux app for containerized execution
-- `cmux_setup.sh.j2`: Jinja2 template for agent installation script
+- `mux_agent.py`: Main agent adapter implementing Terminal-Bench's agent interface
+- `mux-run.sh`: Shell script that sets up environment and invokes mux CLI
+- `mux_payload.py`: Helper to package the mux app for containerized execution
+- `mux_setup.sh.j2`: Jinja2 template for agent installation script
 - `sample_tasks.py`: Utility to randomly sample tasks from dataset

--- a/benchmarks/terminal_bench/__init__.py
+++ b/benchmarks/terminal_bench/__init__.py
@@ -1,3 +1,3 @@
-from .cmux_agent import CmuxAgent
+from .mux_agent import MuxAgent
 
-__all__ = ["CmuxAgent"]
+__all__ = ["MuxAgent"]


### PR DESCRIPTION
## Summary
- point the terminal_bench package export at mux_agent so the renamed class loads again
- update the benchmark-terminal Makefile target to reference MuxAgent consistently
- refresh the README filenames so contributor docs match the new mux nomenclature

## Testing
- Not run (not requested)

_Generated with `mux`_