### PR TITLE
🤖 fix: include fonts in mux server package

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,6 +167,8 @@
     "dist/**/*.wasm",
     "dist/**/*.html",
     "dist/**/*.css",
+    "dist/**/*.woff",
+    "dist/**/*.woff2",
     "dist/**/*.json",
     "dist/**/*.png",
     "dist/assets/**/*",


### PR DESCRIPTION
## Summary
- include woff/woff2 patterns in package files so mux-server distributes icon fonts

## Testing
- make typecheck
- npm pack --dry-run

_Generated with _