### PR TITLE
🤖 feat: add file icons to tool call headers

### DIFF
--- a/src/browser/components/tools/FileEditToolCall.tsx
+++ b/src/browser/components/tools/FileEditToolCall.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { FileIcon } from "@/browser/components/FileIcon";
 import { parsePatch } from "diff";
 import type {
   FileEditInsertToolArgs,
@@ -138,7 +139,10 @@ export const FileEditToolCall: React.FC<FileEditToolCallProps> = ({
             <span>✏️</span>
             <Tooltip>{toolName}</Tooltip>
           </TooltipWrapper>
-          <span className="text-text font-monospace max-w-96 truncate">{filePath}</span>
+          <div className="text-text flex max-w-96 min-w-0 items-center gap-1.5">
+            <FileIcon filePath={filePath} className="text-[15px] leading-none" />
+            <span className="font-monospace truncate">{filePath}</span>
+          </div>
         </div>
         {!(result && result.success && result.diff) && (
           <StatusIndicator status={status}>{getStatusDisplay(status)}</StatusIndicator>

--- a/src/browser/components/tools/FileReadToolCall.tsx
+++ b/src/browser/components/tools/FileReadToolCall.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { FileIcon } from "@/browser/components/FileIcon";
 import type { FileReadToolArgs, FileReadToolResult } from "@/common/types/tools";
 import {
   ToolContainer,
@@ -82,7 +83,10 @@ export const FileReadToolCall: React.FC<FileReadToolCallProps> = ({
           <span>📖</span>
           <Tooltip>file_read</Tooltip>
         </TooltipWrapper>
-        <span className="text-text font-monospace max-w-96 truncate">{filePath}</span>
+        <div className="text-text flex max-w-96 min-w-0 items-center gap-1.5">
+          <FileIcon filePath={filePath} className="text-[15px] leading-none" />
+          <span className="font-monospace truncate">{filePath}</span>
+        </div>
         {result && result.success && parsedContent && (
           <span className="text-secondary ml-2 text-[10px] whitespace-nowrap">
             <span className="hidden @sm:inline">read </span>


### PR DESCRIPTION
## Summary
- render FileIcon in file_read tool call headers
- render FileIcon in file_edit tool call headers for consistent visuals

## Testing
- make typecheck

_Generated with mux_