### PR TITLE
🤖 fix: improve typography defaults

### DIFF
--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -30,6 +30,10 @@
 :root {
   color-scheme: dark;
 
+  font-kerning: normal;
+  font-optical-sizing: auto;
+  font-synthesis: style;
+
   @theme {
     /* Mode Colors */
     --color-plan-mode: hsl(210 70% 40%);
@@ -250,6 +254,19 @@
   /* Theme override hook: redeclare tokens inside this block to swap palettes */
 }
 
+
+h1,
+h2,
+h3 {
+  font-variant-ligatures: common-ligatures contextual;
+}
+
+@supports (text-rendering: optimizeLegibility) {
+  h1,
+  h2 {
+    text-rendering: optimizeLegibility;
+  }
+}
 
 body {
   background-color: var(--color-background);


### PR DESCRIPTION
_Generated with _

## Summary
- enable standards-based font smoothing defaults (kerning, optical sizing)
- avoid synthetic bold while preserving synthetic italics with font-synthesis: style
- add heading ligature defaults and gate text-rendering hints behind supports

## Testing
- make typecheck