### PR TITLE
🤖 fix: stabilize vision image fixtures

### DIFF
--- a/src/common/types/ipc.ts
+++ b/src/common/types/ipc.ts
@@ -360,6 +360,11 @@ export interface IPCApi {
 }
 
 // Update status type (matches updater service)
+
+export interface ImagePart {
+  url: string; // Data URL (e.g., "data:image/png;base64,...")
+  mediaType: string; // MIME type (e.g., "image/png", "image/jpeg")
+}
 export type UpdateStatus =
   | { type: "idle" } // Initial state, no check performed yet
   | { type: "checking" }

--- a/tests/ipcMain/helpers.ts
+++ b/tests/ipcMain/helpers.ts
@@ -651,15 +651,16 @@ export async function readChatHistory(
 }
 
 /**
- * Test image fixtures (1x1 pixel PNGs)
+ * Test image fixtures (32x32 solid color PNGs)
  */
 export const TEST_IMAGES: Record<string, ImagePart> = {
+  // 32x32 solid color PNGs provide clearer features than the old 1x1 pixels
   RED_PIXEL: {
-    url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==",
+    url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKElEQVR4nO3NsQ0AAAzCMP5/un0CNkuZ41wybXsHAAAAAAAAAAAAxR4yw/wuPL6QkAAAAABJRU5ErkJggg==",
     mediaType: "image/png",
   },
   BLUE_PIXEL: {
-    url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAEBgIApD5fRAAAAABJRU5ErkJggg==",
+    url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAJklEQVR4nO3NsQkAAAjAsP7/tF7hIASyp5pjAoFAIBAIBAKB4EmwOkv8Lm7+zY4AAAAASUVORK5CYII=",
     mediaType: "image/png",
   },
 };


### PR DESCRIPTION
Replaces the brittle 1×1 pixel fixtures with 32×32 solid-color PNG data URIs so the vision integration test reliably mentions red/blue.

Adapts to main's new `ImagePart` structure (url + mediaType object) and adds the missing `ImagePart` export to `src/common/types/ipc.ts`.

_Generated with `mux`_