### PR TITLE
🤖 fix: enable queued messages during compaction

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -449,7 +449,7 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
 
   const handleSend = async () => {
     // Allow sending if there's text or images
-    if ((!input.trim() && imageAttachments.length === 0) || disabled || isSending || isCompacting) {
+    if ((!input.trim() && imageAttachments.length === 0) || disabled || isSending) {
       return;
     }
 
@@ -849,7 +849,7 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
       const interruptKeybind = vimEnabled
         ? KEYBINDS.INTERRUPT_STREAM_VIM
         : KEYBINDS.INTERRUPT_STREAM_NORMAL;
-      return `Compacting... (${formatKeybind(interruptKeybind)} cancel | ${formatKeybind(KEYBINDS.ACCEPT_EARLY_COMPACTION)} accept early)`;
+      return `Compacting... (${formatKeybind(interruptKeybind)} cancel | ${formatKeybind(KEYBINDS.ACCEPT_EARLY_COMPACTION)} accept early | ${formatKeybind(KEYBINDS.SEND_MESSAGE)} to queue)`;
     }
 
     // Build hints for normal input
@@ -924,7 +924,7 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
               onDrop={variant === "workspace" ? handleDrop : undefined}
               suppressKeys={showCommandSuggestions ? COMMAND_SUGGESTION_KEYS : undefined}
               placeholder={placeholder}
-              disabled={!editingMessage && (disabled || isSending || isCompacting)}
+              disabled={!editingMessage && (disabled || isSending)}
               aria-label={editingMessage ? "Edit your last message" : "Message Claude"}
               aria-autocomplete="list"
               aria-controls={


### PR DESCRIPTION
## Problem

Messages could not be queued during compaction because the text input was disabled when `isCompacting` was true. The backend was already ready to queue messages during any streaming operation (including compaction), but the frontend blocked users from typing.

## Solution

- Remove `isCompacting` check from textarea disabled condition
- Remove `isCompacting` check from `handleSend` early return
- Update placeholder text to indicate queuing is possible: "Compacting... (Ctrl+C cancel | Ctrl+A accept early | Enter to queue)"

## Testing

- [x] Users can type messages during compaction
- [x] Messages are queued (shown with blue indicator)
- [x] Queued messages are sent after compaction completes
- [x] Typecheck passes

_Generated with `mux`_