### PR TITLE
🤖 fix: display queued messages inline with other messages

### DIFF
--- a/src/browser/components/AIView.tsx
+++ b/src/browser/components/AIView.tsx
@@ -478,13 +478,13 @@ const AIViewInner: React.FC<AIViewProps> = ({
                   }
                 />
               )}
+              {workspaceState?.queuedMessage && (
+                <QueuedMessage
+                  message={workspaceState.queuedMessage}
+                  onEdit={() => void handleEditQueuedMessage()}
+                />
+              )}
             </div>
-            {workspaceState?.queuedMessage && (
-              <QueuedMessage
-                message={workspaceState.queuedMessage}
-                onEdit={() => void handleEditQueuedMessage()}
-              />
-            )}
           </div>
           {!autoScroll && (
             <button


### PR DESCRIPTION
_Generated with `mux`_

Fixes queued messages appearing as a separate floating element instead of inline with the rest of the message flow.

## Changes
- Moved QueuedMessage component inside the scrollable message container
- Positioned after streaming barrier for consistent flow
- No functional changes, purely visual improvement

## Before
Queued message appeared below the scrollable area as a separate element

## After  
Queued message appears inline with other messages in the chat flow