### PR TITLE
🤖 feat: add in-place local runtime mode

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -9,7 +9,8 @@
 # Features
 
 - [Workspaces](./workspaces.md)
-  - [Local](./local.md)
+  - [Worktree](./worktree.md)
+  - [Local (In-Place)](./local-in-place.md)
   - [SSH](./ssh.md)
   - [Forking](./fork.md)
   - [Init Hooks](./init-hooks.md)

--- a/docs/init-hooks.md
+++ b/docs/init-hooks.md
@@ -34,8 +34,8 @@ Init hooks receive the following environment variables:
 - `MUX_PROJECT_PATH` - Absolute path to the project root on the **local machine**
   - Always refers to your local project path, even on SSH workspaces
   - Useful for logging, debugging, or runtime-specific logic
-- `MUX_RUNTIME` - Runtime type: `"local"` or `"ssh"`
-  - Use this to detect whether the hook is running locally or remotely
+- `MUX_RUNTIME` - Runtime type: `"worktree"`, `"local"`, or `"ssh"`
+  - Use this to detect whether the hook is running in a worktree, directly in your project directory, or on a remote machine
 
 **Note for SSH workspaces:** Since the project is synced to the remote machine, files exist in both locations. The init hook runs in the workspace directory (`$PWD`), so use relative paths to reference project files:
 
@@ -54,11 +54,17 @@ if [ -f "../.env" ]; then
 fi
 
 # Runtime-specific behavior
-if [ "$MUX_RUNTIME" = "local" ]; then
-  echo "Running on local machine"
-else
-  echo "Running on SSH remote"
-fi
+case "$MUX_RUNTIME" in
+  worktree)
+    echo "Running in local worktree"
+    ;;
+  local)
+    echo "Running directly in project directory"
+    ;;
+  ssh)
+    echo "Running on SSH remote"
+    ;;
+esac
 
 bun install
 ```

--- a/docs/local-in-place.md
+++ b/docs/local-in-place.md
@@ -1,0 +1,28 @@
+# Local (In-Place) Workspaces
+
+Local (in-place) workspaces operate directly inside your project directory. Unlike [worktree workspaces](./worktree.md), they do **not** create a separate checkout. The agent works with the branch, index, and working tree that you already have checked out.
+
+## When to Use
+
+- You want zero-copy workflows (benchmarks, quick experiments, or short-lived agents)
+- You need the agent to see files that are too large to duplicate efficiently
+- You plan to drive the session from another terminal that is already inside the project directory
+
+## Key Behavior
+
+- **Single workspace per project**: mux enforces one in-place workspace per project to avoid conflicting agent sessions.
+- **Current branch only**: the agent starts on whatever branch is currently checked out in your repository. Branch switches affect your main working tree immediately.
+- **Shared Git state**: any uncommitted changes are visible to both you and the agent. The agent can stage, commit, and push directly from your checkout.
+- **No automatic cleanup**: deleting the workspace inside mux only removes it from the workspace list—your project directory remains untouched.
+- **Init hooks**: `.mux/init` still runs in the project directory. Use `MUX_RUNTIME=local` to special-case logic if needed.
+
+## Recommended Safeguards
+
+- Commit or stash important work before starting an in-place session.
+- Consider creating a temporary branch manually before opening the workspace if you want to isolate commits.
+- Use descriptive workspace names so it is clear what the agent is attempting.
+- Review the agent's Git operations carefully—there is no isolation layer to fall back on.
+
+## Switching Between Modes
+
+You can select **Local (in-place)** from the workspace creation dialog or via the `/new` command (`/new -r local`). Switch back to **Worktree** or **SSH** at any time for isolated workspaces.

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -4,25 +4,26 @@ Workspaces in mux provide isolated development environments for parallel agent w
 
 ## Workspace Types
 
-mux supports two workspace backends:
+mux supports three workspace backends:
 
-- **[Local Workspaces](./local.md)**: Use [git worktrees](https://git-scm.com/docs/git-worktree) on your local machine. Worktrees share the `.git` directory with your main repository while maintaining independent working changes.
-
+- **[Worktree Workspaces](./worktree.md)**: Use [git worktrees](https://git-scm.com/docs/git-worktree) on your local machine. Worktrees share the `.git` directory with your main repository while maintaining independent working changes.
+- **[Local (In-Place) Workspaces](./local-in-place.md)**: Reuse your existing project directory with no additional checkout. The agent operates on the branch and working tree you already have checked out.
 - **[SSH Workspaces](./ssh.md)**: Regular git clones on a remote server accessed via SSH. These are completely independent repositories stored on the remote machine.
 
 ## Choosing a Backend
 
 The workspace backend is selected when you create a workspace:
 
-- **Local**: Best for fast iteration, local testing, and when you want to leverage your local machine's resources
-- **SSH**: Ideal for heavy workloads, long-running tasks, or when you need access to remote infrastructure
+- **Worktree**: Best for fast iteration, local testing, and when you want an isolated checkout that still lives on your machine.
+- **Local (in-place)**: Ideal for zero-copy workflows or when you need the agent to operate on your existing working tree without creating a new worktree.
+- **SSH**: Ideal for heavy workloads, long-running tasks, or when you need access to remote infrastructure.
 
 ## Key Concepts
 
 - **Isolation**: Each workspace has independent working changes and Git state
 - **Branch flexibility**: Workspaces can switch branches, enter detached HEAD state, or create new branches as needed
 - **Parallel execution**: Run multiple workspaces simultaneously on different tasks
-- **Shared commits**: Local workspaces (using worktrees) share commits with the main repository immediately
+- **Shared commits**: Worktree and local (in-place) workspaces share commits with the main repository immediately; SSH workspaces require pushing to sync
 
 ## Reviewing Code
 
@@ -39,9 +40,9 @@ Here are a few practical approaches to reviewing changes from workspaces, depend
 Some changes (especially UI ones) require the Human to determine acceptability. An effective approach for this is:
 
 1. Ask agent to commit WIP when it's ready for Human review
-2. Human, in main repository, checks out the workspace branch in a detached HEAD state: `git checkout --detach <workspace-branch>` (for local workspaces)
+2. Human, in main repository, checks out the workspace branch in a detached HEAD state: `git checkout --detach <workspace-branch>` (for worktree workspaces)
 
-**Note**: For local workspaces, this workflow uses the detached HEAD state because the branch is already checked out in the workspace and you cannot check out the same branch multiple times across worktrees.
+**Note**: For worktree workspaces, this workflow uses the detached HEAD state because the branch is already checked out in the workspace and you cannot check out the same branch multiple times across worktrees. For local (in-place) workspaces, the agent and human are literally sharing the same checkout—coordinate commits carefully.
 
 If you want faster iteration in between commits, you can hop into the workspace directory and run a dev server (e.g. `bun dev`) there directly and observe the agent's work in real-time.
 

--- a/docs/worktree.md
+++ b/docs/worktree.md
@@ -1,6 +1,6 @@
-# Local Workspaces
+# Worktree Workspaces
 
-Local workspaces use [git worktrees](https://git-scm.com/docs/git-worktree) on your local machine. Worktrees share the `.git` directory with your main repository while maintaining independent working changes and checkout state.
+Worktree workspaces use [git worktrees](https://git-scm.com/docs/git-worktree) on your local machine. Worktrees share the `.git` directory with your main repository while maintaining independent working changes and checkout state.
 
 ## How Worktrees Work
 
@@ -10,7 +10,7 @@ It's important to note that a **worktree is not locked to a branch**. The agent 
 
 ## Filesystem Layout
 
-Local workspaces are stored in `~/.mux/src/<project-name>/<workspace-name>`.
+Worktree workspaces are stored in `~/.mux/src/<project-name>/<workspace-name>`.
 
 Example layout:
 

--- a/src/browser/components/ChatInput/CreationControls.tsx
+++ b/src/browser/components/ChatInput/CreationControls.tsx
@@ -22,7 +22,7 @@ export function CreationControls(props: CreationControlsProps) {
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
       {/* Trunk Branch Selector */}
-      {props.branches.length > 0 && (
+      {props.branches.length > 0 && props.runtimeMode !== RUNTIME_MODE.LOCAL && (
         <div className="flex items-center gap-1" data-component="TrunkBranchGroup">
           <label htmlFor="trunk-branch" className="text-muted text-xs">
             From:
@@ -44,12 +44,14 @@ export function CreationControls(props: CreationControlsProps) {
         <Select
           value={props.runtimeMode}
           options={[
-            { value: RUNTIME_MODE.LOCAL, label: "Local" },
+            { value: RUNTIME_MODE.WORKTREE, label: "Worktree" },
+            { value: RUNTIME_MODE.LOCAL, label: "Local (in-place)" },
             { value: RUNTIME_MODE.SSH, label: "SSH" },
           ]}
           onChange={(newMode) => {
             const mode = newMode as RuntimeMode;
-            props.onRuntimeChange(mode, mode === RUNTIME_MODE.LOCAL ? "" : props.sshHost);
+            const nextHost = mode === RUNTIME_MODE.SSH ? props.sshHost : "";
+            props.onRuntimeChange(mode, nextHost);
           }}
           disabled={props.disabled}
           aria-label="Runtime mode"
@@ -69,7 +71,8 @@ export function CreationControls(props: CreationControlsProps) {
           <Tooltip className="tooltip" align="center" width="wide">
             <strong>Runtime:</strong>
             <br />
-            • Local: git worktree in ~/.mux/src
+            • Worktree: git worktree in ~/.mux/src
+            <br />• Local (in-place): work directly in the project directory
             <br />• SSH: remote clone in ~/mux on SSH host
           </Tooltip>
         </TooltipWrapper>

--- a/src/browser/contexts/WorkspaceContext.test.tsx
+++ b/src/browser/contexts/WorkspaceContext.test.tsx
@@ -18,7 +18,7 @@ const createWorkspaceMetadata = (
   name: "main",
   namedWorkspacePath: "/test-main",
   createdAt: "2025-01-01T00:00:00.000Z",
-  runtimeConfig: { type: "local", srcBaseDir: "/home/user/.mux/src" },
+  runtimeConfig: { type: "worktree", srcBaseDir: "/home/user/.mux/src" },
   ...overrides,
 });
 

--- a/src/browser/hooks/useStartWorkspaceCreation.test.ts
+++ b/src/browser/hooks/useStartWorkspaceCreation.test.ts
@@ -21,11 +21,17 @@ type PersistFn = typeof updatePersistedState;
 type PersistCall = [string, unknown, unknown?];
 
 describe("normalizeRuntimePreference", () => {
-  test("returns undefined for local or empty runtime", () => {
+  test("returns undefined for empty or worktree runtime", () => {
     expect(normalizeRuntimePreference(undefined)).toBeUndefined();
     expect(normalizeRuntimePreference(" ")).toBeUndefined();
-    expect(normalizeRuntimePreference("local")).toBeUndefined();
-    expect(normalizeRuntimePreference("LOCAL")).toBeUndefined();
+    expect(normalizeRuntimePreference("worktree")).toBeUndefined();
+    expect(normalizeRuntimePreference("WORKTREE")).toBeUndefined();
+  });
+
+  test("normalizes local runtime tokens", () => {
+    expect(normalizeRuntimePreference("local")).toBe("local");
+    expect(normalizeRuntimePreference("LOCAL")).toBe("local");
+    expect(normalizeRuntimePreference(" local-in-place ")).toBe("local");
   });
 
   test("normalizes ssh runtimes", () => {

--- a/src/browser/hooks/useStartWorkspaceCreation.ts
+++ b/src/browser/hooks/useStartWorkspaceCreation.ts
@@ -27,8 +27,13 @@ export function normalizeRuntimePreference(runtime: string | undefined): string 
   }
 
   const lower = trimmed.toLowerCase();
-  if (lower === RUNTIME_MODE.LOCAL) {
+  const normalized = lower.replace(/[\s_()-]/g, "");
+  if (normalized === RUNTIME_MODE.WORKTREE) {
     return undefined;
+  }
+
+  if (normalized === RUNTIME_MODE.LOCAL || normalized === "localinplace") {
+    return RUNTIME_MODE.LOCAL;
   }
 
   if (lower === RUNTIME_MODE.SSH) {

--- a/src/browser/utils/chatCommands.test.ts
+++ b/src/browser/utils/chatCommands.test.ts
@@ -3,14 +3,19 @@ import { parseRuntimeString } from "./chatCommands";
 describe("parseRuntimeString", () => {
   const workspaceName = "test-workspace";
 
-  test("returns undefined for undefined runtime (default to local)", () => {
+  test("returns undefined for undefined runtime (default to worktree)", () => {
     expect(parseRuntimeString(undefined, workspaceName)).toBeUndefined();
   });
 
-  test("returns undefined for explicit 'local' runtime", () => {
-    expect(parseRuntimeString("local", workspaceName)).toBeUndefined();
-    expect(parseRuntimeString("LOCAL", workspaceName)).toBeUndefined();
-    expect(parseRuntimeString(" local ", workspaceName)).toBeUndefined();
+  test("returns undefined for explicit 'worktree' runtime", () => {
+    expect(parseRuntimeString("worktree", workspaceName)).toBeUndefined();
+    expect(parseRuntimeString(" WORKTREE ", workspaceName)).toBeUndefined();
+  });
+
+  test("parses local runtime token", () => {
+    expect(parseRuntimeString("local", workspaceName)).toEqual({ type: "local" });
+    expect(parseRuntimeString("LOCAL", workspaceName)).toEqual({ type: "local" });
+    expect(parseRuntimeString(" local-in-place ", workspaceName)).toEqual({ type: "local" });
   });
 
   test("parses valid SSH runtime", () => {
@@ -77,10 +82,10 @@ describe("parseRuntimeString", () => {
 
   test("throws error for unknown runtime type", () => {
     expect(() => parseRuntimeString("docker", workspaceName)).toThrow(
-      "Unknown runtime type: 'docker'"
+      "Unknown runtime type: 'docker'. Use 'worktree', 'local', or 'ssh <host>'"
     );
     expect(() => parseRuntimeString("remote", workspaceName)).toThrow(
-      "Unknown runtime type: 'remote'"
+      "Unknown runtime type: 'remote'. Use 'worktree', 'local', or 'ssh <host>'"
     );
   });
 });

--- a/src/browser/utils/ui/runtimeBadge.test.ts
+++ b/src/browser/utils/ui/runtimeBadge.test.ts
@@ -7,10 +7,17 @@ describe("extractSshHostname", () => {
     expect(extractSshHostname(undefined)).toBeNull();
   });
 
+  it("should return null for worktree runtime", () => {
+    const config: RuntimeConfig = {
+      type: "worktree",
+      srcBaseDir: "/home/user/.mux/src",
+    };
+    expect(extractSshHostname(config)).toBeNull();
+  });
+
   it("should return null for local runtime", () => {
     const config: RuntimeConfig = {
       type: "local",
-      srcBaseDir: "/home/user/.mux/src",
     };
     expect(extractSshHostname(config)).toBeNull();
   });

--- a/src/common/constants/workspace.ts
+++ b/src/common/constants/workspace.ts
@@ -5,6 +5,6 @@ import type { RuntimeConfig } from "@/common/types/runtime";
  * Used when no runtime config is specified
  */
 export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
-  type: "local",
+  type: "worktree",
   srcBaseDir: "~/.mux/src",
 } as const;

--- a/src/common/types/runtime.test.ts
+++ b/src/common/types/runtime.test.ts
@@ -16,6 +16,13 @@ describe("parseRuntimeModeAndHost", () => {
     });
   });
 
+  it("parses worktree mode", () => {
+    expect(parseRuntimeModeAndHost("worktree")).toEqual({
+      mode: "worktree",
+      host: "",
+    });
+  });
+
   it("parses local mode", () => {
     expect(parseRuntimeModeAndHost("local")).toEqual({
       mode: "local",
@@ -23,16 +30,16 @@ describe("parseRuntimeModeAndHost", () => {
     });
   });
 
-  it("defaults to local for undefined", () => {
+  it("defaults to worktree for undefined", () => {
     expect(parseRuntimeModeAndHost(undefined)).toEqual({
-      mode: "local",
+      mode: "worktree",
       host: "",
     });
   });
 
-  it("defaults to local for null", () => {
+  it("defaults to worktree for null", () => {
     expect(parseRuntimeModeAndHost(null)).toEqual({
-      mode: "local",
+      mode: "worktree",
       host: "",
     });
   });
@@ -47,8 +54,12 @@ describe("buildRuntimeString", () => {
     expect(buildRuntimeString("ssh", "")).toBe("ssh");
   });
 
-  it("returns undefined for local mode", () => {
-    expect(buildRuntimeString("local", "")).toBeUndefined();
+  it("returns string token for local mode", () => {
+    expect(buildRuntimeString("local", "")).toBe("local");
+  });
+
+  it("returns undefined for worktree mode", () => {
+    expect(buildRuntimeString("worktree", "")).toBeUndefined();
   });
 
   it("trims whitespace from host", () => {
@@ -61,6 +72,19 @@ describe("round-trip parsing and building", () => {
     const built = buildRuntimeString("ssh", "");
     const parsed = parseRuntimeModeAndHost(built);
     expect(parsed.mode).toBe("ssh");
+    expect(parsed.host).toBe("");
+  });
+  it("preserves local mode token", () => {
+    const built = buildRuntimeString("local", "");
+    const parsed = parseRuntimeModeAndHost(built);
+    expect(parsed.mode).toBe("local");
+    expect(parsed.host).toBe("");
+  });
+
+  it("defaults to worktree when build omits token", () => {
+    const built = buildRuntimeString("worktree", "");
+    const parsed = parseRuntimeModeAndHost(built);
+    expect(parsed.mode).toBe("worktree");
     expect(parsed.host).toBe("");
   });
 

--- a/src/node/git.ts
+++ b/src/node/git.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import type { Config } from "@/node/config";
+import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
 import type { RuntimeConfig } from "@/common/types/runtime";
 import { execAsync } from "@/node/utils/disposableExec";
 import { createRuntime } from "./runtime/runtimeFactory";
@@ -83,9 +84,8 @@ export async function createWorktree(
     // Use directoryName if provided, otherwise fall back to branchName (legacy)
     const dirName = options.directoryName ?? branchName;
     // Compute workspace path using Runtime (single source of truth)
-    const runtime = createRuntime(
-      options.runtimeConfig ?? { type: "local", srcBaseDir: config.srcDir }
-    );
+    const runtimeConfig = options.runtimeConfig ?? DEFAULT_RUNTIME_CONFIG;
+    const runtime = createRuntime(runtimeConfig);
     const workspacePath = runtime.getWorkspacePath(projectPath, dirName);
     const { trunkBranch } = options;
     const normalizedTrunkBranch = typeof trunkBranch === "string" ? trunkBranch.trim() : "";

--- a/src/node/runtime/LocalRuntime.test.ts
+++ b/src/node/runtime/LocalRuntime.test.ts
@@ -5,7 +5,7 @@ import { LocalRuntime } from "./LocalRuntime";
 
 describe("LocalRuntime constructor", () => {
   it("should expand tilde in srcBaseDir", () => {
-    const runtime = new LocalRuntime("~/workspace");
+    const runtime = new LocalRuntime({ type: "worktree", srcBaseDir: "~/workspace" });
     const workspacePath = runtime.getWorkspacePath("/home/user/project", "branch");
 
     // The workspace path should use the expanded home directory
@@ -14,7 +14,7 @@ describe("LocalRuntime constructor", () => {
   });
 
   it("should handle absolute paths without expansion", () => {
-    const runtime = new LocalRuntime("/absolute/path");
+    const runtime = new LocalRuntime({ type: "worktree", srcBaseDir: "/absolute/path" });
     const workspacePath = runtime.getWorkspacePath("/home/user/project", "branch");
 
     const expected = path.join("/absolute/path", "project", "branch");
@@ -22,7 +22,7 @@ describe("LocalRuntime constructor", () => {
   });
 
   it("should handle bare tilde", () => {
-    const runtime = new LocalRuntime("~");
+    const runtime = new LocalRuntime({ type: "worktree", srcBaseDir: "~" });
     const workspacePath = runtime.getWorkspacePath("/home/user/project", "branch");
 
     const expected = path.join(os.homedir(), "project", "branch");
@@ -32,13 +32,13 @@ describe("LocalRuntime constructor", () => {
 
 describe("LocalRuntime.resolvePath", () => {
   it("should expand tilde to home directory", async () => {
-    const runtime = new LocalRuntime("/tmp");
+    const runtime = new LocalRuntime({ type: "worktree", srcBaseDir: "/tmp" });
     const resolved = await runtime.resolvePath("~");
     expect(resolved).toBe(os.homedir());
   });
 
   it("should expand tilde with path", async () => {
-    const runtime = new LocalRuntime("/tmp");
+    const runtime = new LocalRuntime({ type: "worktree", srcBaseDir: "/tmp" });
     // Use a path that likely exists (or use /tmp if ~ doesn't have subdirs)
     const resolved = await runtime.resolvePath("~/..");
     const expected = path.dirname(os.homedir());
@@ -46,20 +46,20 @@ describe("LocalRuntime.resolvePath", () => {
   });
 
   it("should resolve absolute paths", async () => {
-    const runtime = new LocalRuntime("/tmp");
+    const runtime = new LocalRuntime({ type: "worktree", srcBaseDir: "/tmp" });
     const resolved = await runtime.resolvePath("/tmp");
     expect(resolved).toBe("/tmp");
   });
 
   it("should resolve non-existent paths without checking existence", async () => {
-    const runtime = new LocalRuntime("/tmp");
+    const runtime = new LocalRuntime({ type: "worktree", srcBaseDir: "/tmp" });
     const resolved = await runtime.resolvePath("/this/path/does/not/exist/12345");
     // Should resolve to absolute path without checking if it exists
     expect(resolved).toBe("/this/path/does/not/exist/12345");
   });
 
   it("should resolve relative paths from cwd", async () => {
-    const runtime = new LocalRuntime("/tmp");
+    const runtime = new LocalRuntime({ type: "worktree", srcBaseDir: "/tmp" });
     const resolved = await runtime.resolvePath(".");
     // Should resolve to absolute path
     expect(path.isAbsolute(resolved)).toBe(true);

--- a/src/node/runtime/initHook.ts
+++ b/src/node/runtime/initHook.ts
@@ -30,11 +30,11 @@ export function getInitHookPath(projectPath: string): string {
  * Get environment variables for init hook execution
  * Centralizes env var injection to avoid duplication across runtimes
  * @param projectPath - Path to project root (local path for LocalRuntime, remote path for SSHRuntime)
- * @param runtime - Runtime type: "local" or "ssh"
+ * @param runtime - Runtime type: "worktree", "local", or "ssh"
  */
 export function getInitHookEnv(
   projectPath: string,
-  runtime: "local" | "ssh"
+  runtime: "worktree" | "local" | "ssh"
 ): Record<string, string> {
   return {
     MUX_PROJECT_PATH: projectPath,

--- a/src/node/runtime/runtimeFactory.ts
+++ b/src/node/runtime/runtimeFactory.ts
@@ -8,8 +8,9 @@ import type { RuntimeConfig } from "@/common/types/runtime";
  */
 export function createRuntime(config: RuntimeConfig): Runtime {
   switch (config.type) {
+    case "worktree":
     case "local":
-      return new LocalRuntime(config.srcBaseDir);
+      return new LocalRuntime(config);
 
     case "ssh":
       return new SSHRuntime({

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -9,6 +9,7 @@ import type { HistoryService } from "@/node/services/historyService";
 import type { PartialService } from "@/node/services/partialService";
 import type { InitStateManager } from "@/node/services/initStateManager";
 import type { WorkspaceMetadata } from "@/common/types/workspace";
+import type { RuntimeConfig } from "@/common/types/runtime";
 import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
 import type {
   WorkspaceChatMessage,
@@ -189,9 +190,7 @@ export class AgentSession {
       const expectedPath = isInPlace
         ? metadata.projectPath
         : (() => {
-            const runtime = createRuntime(
-              metadata.runtimeConfig ?? { type: "local", srcBaseDir: this.config.srcDir }
-            );
+            const runtime = createRuntime(metadata.runtimeConfig ?? DEFAULT_RUNTIME_CONFIG);
             return runtime.getWorkspacePath(metadata.projectPath, metadata.name);
           })();
       assert(
@@ -230,12 +229,16 @@ export class AgentSession {
           : PlatformPaths.basename(normalizedWorkspacePath) || "unknown";
     }
 
+    const runtimeConfig: RuntimeConfig = isUnderSrcBaseDir
+      ? DEFAULT_RUNTIME_CONFIG
+      : { type: "local" };
+
     const metadata: WorkspaceMetadata = {
       id: this.workspaceId,
       name: workspaceName,
       projectName: derivedProjectName,
       projectPath: derivedProjectPath,
-      runtimeConfig: DEFAULT_RUNTIME_CONFIG,
+      runtimeConfig,
     };
 
     // Write metadata directly to config.json (single source of truth)

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -7,6 +7,7 @@ import { sanitizeToolInputs } from "@/browser/utils/messages/sanitizeToolInput";
 import type { Result } from "@/common/types/result";
 import { Ok, Err } from "@/common/types/result";
 import type { WorkspaceMetadata } from "@/common/types/workspace";
+import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
 import { PROVIDER_REGISTRY } from "@/common/constants/providers";
 
 import type { MuxMessage, MuxTextPart } from "@/common/types/message";
@@ -545,7 +546,7 @@ export class AIService extends EventEmitter {
       const [providerName] = parseModelString(modelString);
 
       // Get tool names early for mode transition sentinel (stub config, no workspace context needed)
-      const earlyRuntime = createRuntime({ type: "local", srcBaseDir: process.cwd() });
+      const earlyRuntime = createRuntime({ type: "worktree", srcBaseDir: process.cwd() });
       const earlyAllTools = await getToolsForModel(
         modelString,
         {
@@ -639,9 +640,7 @@ export class AIService extends EventEmitter {
       }
 
       // Get workspace path - handle both worktree and in-place modes
-      const runtime = createRuntime(
-        metadata.runtimeConfig ?? { type: "local", srcBaseDir: this.config.srcDir }
-      );
+      const runtime = createRuntime(metadata.runtimeConfig ?? DEFAULT_RUNTIME_CONFIG);
       // In-place workspaces (CLI/benchmarks) have projectPath === name
       // Use path directly instead of reconstructing via getWorkspacePath
       const isInPlace = metadata.projectPath === metadata.name;

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -41,7 +41,7 @@ describe("StreamManager - Concurrent Stream Prevention", () => {
   let streamManager: StreamManager;
   let mockHistoryService: HistoryService;
   let mockPartialService: PartialService;
-  const runtime = createRuntime({ type: "local", srcBaseDir: "/tmp" });
+  const runtime = createRuntime({ type: "worktree", srcBaseDir: "/tmp" });
 
   beforeEach(() => {
     mockHistoryService = createMockHistoryService();

--- a/src/node/services/systemMessage.test.ts
+++ b/src/node/services/systemMessage.test.ts
@@ -30,7 +30,7 @@ describe("buildSystemMessage", () => {
     mockHomedir.mockReturnValue(tempDir);
 
     // Create a local runtime for tests
-    runtime = new LocalRuntime(tempDir);
+    runtime = new LocalRuntime({ type: "worktree", srcBaseDir: tempDir });
   });
 
   afterEach(async () => {

--- a/src/node/services/tools/bash.test.ts
+++ b/src/node/services/tools/bash.test.ts
@@ -198,7 +198,7 @@ describe("bash tool", () => {
     const tool = createBashTool({
       ...getTestDeps(),
       cwd: process.cwd(),
-      runtime: new LocalRuntime(process.cwd()),
+      runtime: new LocalRuntime({ type: "worktree", srcBaseDir: process.cwd() }),
       runtimeTempDir: tempDir.path,
       overflow_policy: "truncate",
     });
@@ -231,7 +231,7 @@ describe("bash tool", () => {
     const tool = createBashTool({
       ...getTestDeps(),
       cwd: process.cwd(),
-      runtime: new LocalRuntime(process.cwd()),
+      runtime: new LocalRuntime({ type: "worktree", srcBaseDir: process.cwd() }),
       runtimeTempDir: tempDir.path,
       overflow_policy: "truncate",
     });
@@ -268,7 +268,7 @@ describe("bash tool", () => {
     const tool = createBashTool({
       ...getTestDeps(),
       cwd: process.cwd(),
-      runtime: new LocalRuntime(process.cwd()),
+      runtime: new LocalRuntime({ type: "worktree", srcBaseDir: process.cwd() }),
       runtimeTempDir: tempDir.path,
       // overflow_policy not specified - should default to tmpfile
     });
@@ -302,7 +302,7 @@ describe("bash tool", () => {
     const tool = createBashTool({
       ...getTestDeps(),
       cwd: process.cwd(),
-      runtime: new LocalRuntime(process.cwd()),
+      runtime: new LocalRuntime({ type: "worktree", srcBaseDir: process.cwd() }),
       runtimeTempDir: tempDir.path,
     });
 
@@ -355,7 +355,7 @@ describe("bash tool", () => {
     const tool = createBashTool({
       ...getTestDeps(),
       cwd: process.cwd(),
-      runtime: new LocalRuntime(process.cwd()),
+      runtime: new LocalRuntime({ type: "worktree", srcBaseDir: process.cwd() }),
       runtimeTempDir: tempDir.path,
     });
 
@@ -399,7 +399,7 @@ describe("bash tool", () => {
     const tool = createBashTool({
       ...getTestDeps(),
       cwd: process.cwd(),
-      runtime: new LocalRuntime(process.cwd()),
+      runtime: new LocalRuntime({ type: "worktree", srcBaseDir: process.cwd() }),
       runtimeTempDir: tempDir.path,
     });
 
@@ -442,7 +442,7 @@ describe("bash tool", () => {
     const tool = createBashTool({
       ...getTestDeps(),
       cwd: process.cwd(),
-      runtime: new LocalRuntime(process.cwd()),
+      runtime: new LocalRuntime({ type: "worktree", srcBaseDir: process.cwd() }),
       runtimeTempDir: tempDir.path,
     });
 
@@ -483,7 +483,7 @@ describe("bash tool", () => {
     const tool = createBashTool({
       ...getTestDeps(),
       cwd: process.cwd(),
-      runtime: new LocalRuntime(process.cwd()),
+      runtime: new LocalRuntime({ type: "worktree", srcBaseDir: process.cwd() }),
       runtimeTempDir: tempDir.path,
     });
 
@@ -514,7 +514,7 @@ describe("bash tool", () => {
     const tool = createBashTool({
       ...getTestDeps(),
       cwd: process.cwd(),
-      runtime: new LocalRuntime(process.cwd()),
+      runtime: new LocalRuntime({ type: "worktree", srcBaseDir: process.cwd() }),
       runtimeTempDir: tempDir.path,
     });
 

--- a/src/node/services/tools/fileCommon.test.ts
+++ b/src/node/services/tools/fileCommon.test.ts
@@ -70,7 +70,7 @@ describe("fileCommon", () => {
 
   describe("validatePathInCwd", () => {
     const cwd = "/workspace/project";
-    const runtime = createRuntime({ type: "local", srcBaseDir: cwd });
+    const runtime = createRuntime({ type: "worktree", srcBaseDir: cwd });
 
     it("should allow relative paths within cwd", () => {
       expect(validatePathInCwd("src/file.ts", cwd, runtime)).toBeNull();
@@ -139,7 +139,7 @@ describe("fileCommon", () => {
 
   describe("validateNoRedundantPrefix", () => {
     const cwd = "/workspace/project";
-    const runtime = createRuntime({ type: "local", srcBaseDir: cwd });
+    const runtime = createRuntime({ type: "worktree", srcBaseDir: cwd });
 
     it("should allow relative paths", () => {
       expect(validateNoRedundantPrefix("src/file.ts", cwd, runtime)).toBeNull();

--- a/src/node/services/tools/file_edit_insert.test.ts
+++ b/src/node/services/tools/file_edit_insert.test.ts
@@ -17,7 +17,7 @@ function createTestTool(cwd: string) {
   return createFileEditInsertTool({
     ...getTestDeps(),
     cwd,
-    runtime: createRuntime({ type: "local", srcBaseDir: cwd }),
+    runtime: createRuntime({ type: "worktree", srcBaseDir: cwd }),
     runtimeTempDir: cwd,
   });
 }

--- a/src/node/services/tools/file_edit_replace.test.ts
+++ b/src/node/services/tools/file_edit_replace.test.ts
@@ -61,7 +61,7 @@ describe("file_edit_replace_string tool", () => {
     const tool = createFileEditReplaceStringTool({
       ...getTestDeps(),
       cwd: testDir,
-      runtime: createRuntime({ type: "local", srcBaseDir: "/tmp" }),
+      runtime: createRuntime({ type: "worktree", srcBaseDir: "/tmp" }),
       runtimeTempDir: "/tmp",
     });
 
@@ -100,7 +100,7 @@ describe("file_edit_replace_lines tool", () => {
     const tool = createFileEditReplaceLinesTool({
       ...getTestDeps(),
       cwd: testDir,
-      runtime: createRuntime({ type: "local", srcBaseDir: "/tmp" }),
+      runtime: createRuntime({ type: "worktree", srcBaseDir: "/tmp" }),
       runtimeTempDir: "/tmp",
     });
 

--- a/src/node/services/tools/file_read.test.ts
+++ b/src/node/services/tools/file_read.test.ts
@@ -354,7 +354,7 @@ describe("file_read tool", () => {
     const tool = createFileReadTool({
       ...getTestDeps(),
       cwd: subDir,
-      runtime: new LocalRuntime(process.cwd()),
+      runtime: new LocalRuntime({ type: "worktree", srcBaseDir: process.cwd() }),
       runtimeTempDir: "/tmp",
     });
     const args: FileReadToolArgs = {

--- a/src/node/services/tools/status_set.test.ts
+++ b/src/node/services/tools/status_set.test.ts
@@ -8,7 +8,7 @@ import { STATUS_MESSAGE_MAX_LENGTH } from "@/common/constants/toolLimits";
 describe("status_set tool validation", () => {
   const mockConfig: ToolConfiguration = {
     cwd: "/test",
-    runtime: createRuntime({ type: "local", srcBaseDir: "/tmp" }),
+    runtime: createRuntime({ type: "worktree", srcBaseDir: "/tmp" }),
     runtimeTempDir: "/tmp",
   };
 

--- a/src/node/services/tools/testHelpers.ts
+++ b/src/node/services/tools/testHelpers.ts
@@ -54,7 +54,7 @@ export function createTestToolConfig(
 ): ToolConfiguration {
   return {
     cwd: tempDir,
-    runtime: new LocalRuntime(tempDir),
+    runtime: new LocalRuntime({ type: "worktree", srcBaseDir: tempDir }),
     runtimeTempDir: tempDir,
     niceness: options?.niceness,
   };

--- a/src/node/services/tools/todo.test.ts
+++ b/src/node/services/tools/todo.test.ts
@@ -14,8 +14,8 @@ describe("Todo Storage", () => {
   beforeEach(async () => {
     // Create a temporary directory for each test
     runtimeTempDir = await fs.mkdtemp(path.join(os.tmpdir(), "todo-test-"));
-    // Create a local runtime for testing
-    runtime = createRuntime({ type: "local", srcBaseDir: "/tmp" });
+    // Create a worktree runtime for testing
+    runtime = createRuntime({ type: "worktree", srcBaseDir: "/tmp" });
   });
 
   afterEach(async () => {

--- a/tests/ipcMain/initWorkspace.test.ts
+++ b/tests/ipcMain/initWorkspace.test.ts
@@ -477,7 +477,7 @@ describeIntegration("Init Queue - Runtime Matrix", () => {
   }, 30000);
 
   // Test matrix: Run tests for both local and SSH runtimes
-  describe.each<{ type: "local" | "ssh" }>([{ type: "local" }, { type: "ssh" }])(
+  describe.each<{ type: "worktree" | "ssh" }>([{ type: "worktree" }, { type: "ssh" }])(
     "Runtime: $type",
     ({ type }) => {
       // Helper to build runtime config

--- a/tests/ipcMain/removeWorkspace.test.ts
+++ b/tests/ipcMain/removeWorkspace.test.ts
@@ -124,7 +124,7 @@ describeIntegration("Workspace deletion integration tests", () => {
   }, 30000);
 
   // Test matrix: Run tests for both local and SSH runtimes
-  describe.each<{ type: "local" | "ssh" }>([{ type: "local" }, { type: "ssh" }])(
+  describe.each<{ type: "worktree" | "ssh" }>([{ type: "worktree" }, { type: "ssh" }])(
     "Runtime: $type",
     ({ type }) => {
       const TEST_TIMEOUT = type === "ssh" ? TEST_TIMEOUT_SSH_MS : TEST_TIMEOUT_LOCAL_MS;
@@ -354,7 +354,7 @@ describeIntegration("Workspace deletion integration tests", () => {
       );
 
       // Submodule tests only apply to local runtime (SSH doesn't use git worktrees)
-      if (type === "local") {
+      if (type === "worktree") {
         test.concurrent(
           "should successfully delete clean workspace with submodule",
           async () => {

--- a/tests/ipcMain/renameWorkspace.test.ts
+++ b/tests/ipcMain/renameWorkspace.test.ts
@@ -72,7 +72,7 @@ describeIntegration("WORKSPACE_RENAME with both runtimes", () => {
   }, 30000);
 
   // Test matrix: Run tests for both local and SSH runtimes
-  describe.each<{ type: "local" | "ssh" }>([{ type: "local" }, { type: "ssh" }])(
+  describe.each<{ type: "worktree" | "ssh" }>([{ type: "worktree" }, { type: "ssh" }])(
     "Runtime: $type",
     ({ type }) => {
       // Helper to build runtime config

--- a/tests/ipcMain/runtimeExecuteBash.test.ts
+++ b/tests/ipcMain/runtimeExecuteBash.test.ts
@@ -86,7 +86,7 @@ describeIntegration("Runtime Bash Execution", () => {
   }, 30000);
 
   // Test matrix: Run tests for both local and SSH runtimes
-  describe.each<{ type: "local" | "ssh" }>([{ type: "local" }, { type: "ssh" }])(
+  describe.each<{ type: "worktree" | "ssh" }>([{ type: "worktree" }, { type: "ssh" }])(
     "Runtime: $type",
     ({ type }) => {
       // Helper to build runtime config

--- a/tests/ipcMain/runtimeFileEditing.test.ts
+++ b/tests/ipcMain/runtimeFileEditing.test.ts
@@ -84,8 +84,8 @@ describeIntegration("Runtime File Editing Tools", () => {
     }
   }, 30000);
 
-  // Test matrix: Run tests for both local and SSH runtimes
-  describe.each<{ type: "local" | "ssh" }>([{ type: "local" }, { type: "ssh" }])(
+  // Test matrix: Run tests for both worktree and SSH runtimes
+  describe.each<{ type: "worktree" | "ssh" }>([{ type: "worktree" }, { type: "ssh" }])(
     "Runtime: $type",
     ({ type }) => {
       // Helper to build runtime config

--- a/tests/runtime/test-helpers.ts
+++ b/tests/runtime/test-helpers.ts
@@ -14,7 +14,7 @@ import type { SSHServerConfig } from "./ssh-fixture";
 /**
  * Runtime type for test matrix
  */
-export type RuntimeType = "local" | "ssh";
+export type RuntimeType = "worktree" | "ssh";
 
 /**
  * Create runtime instance based on type
@@ -25,10 +25,11 @@ export function createTestRuntime(
   sshConfig?: SSHServerConfig
 ): Runtime {
   switch (type) {
-    case "local":
+    case "worktree": {
       // Resolve symlinks (e.g., /tmp -> /private/tmp on macOS) to match git worktree paths
       const resolvedWorkdir = realpathSync(workdir);
-      return new LocalRuntime(resolvedWorkdir);
+      return new LocalRuntime({ type: "worktree", srcBaseDir: resolvedWorkdir });
+    }
     case "ssh":
       if (!sshConfig) {
         throw new Error("SSH config required for SSH runtime");

--- a/vscode/src/workspaceOpener.ts
+++ b/vscode/src/workspaceOpener.ts
@@ -16,7 +16,7 @@ function isRemoteSshInstalled(): boolean {
  * Open an SSH workspace in a new VS Code window
  */
 export async function openWorkspace(workspace: WorkspaceWithContext) {
-  if (workspace.runtimeConfig.type === "local") {
+  if (workspace.runtimeConfig.type !== "ssh") {
     const workspacePath = getWorkspacePath(workspace);
     const uri = vscode.Uri.file(workspacePath);
 


### PR DESCRIPTION
## Summary
- add a discriminated runtime config for worktree vs local in-place flows
- implement in-place creation path, single-workspace guard, and updated UI selection
- document new workspace modes and extend runtime/IPС tests for regressions

## Testing
- make typecheck
- bun test src/common/types/runtime.test.ts src/browser/utils/chatCommands.test.ts src/browser/hooks/useStartWorkspaceCreation.test.ts src/browser/utils/ui/runtimeBadge.test.ts
- bun test ./tests/ipcMain/createWorkspace.test.ts

_Generated with _