### PR TITLE
🤖 fix: guard VSCE publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
             --clobber
 
       - name: Publish to VS Code Marketplace
-        if: secrets.VSCE_PAT != ''
+        if: ${{ secrets.VSCE_PAT != '' }}
         working-directory: vscode
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
## Summary
- wrap the VS Code Marketplace publish step condition in a GitHub Actions expression so the parser can resolve the secrets context

## Testing
- make typecheck

_Generated with _