### PR TITLE
🤖 fix: use smaller gpt-oss:12b for ollama tests

### DIFF
--- a/tests/ipcMain/ollama.test.ts
+++ b/tests/ipcMain/ollama.test.ts
@@ -16,7 +16,7 @@ const describeOllama = shouldRunOllamaTests ? describe : describe.skip;
 // Tests require Ollama to be running and will pull models idempotently
 // Set TEST_OLLAMA=1 to enable these tests
 
-const OLLAMA_MODEL = "gpt-oss:20b";
+const OLLAMA_MODEL = "gpt-oss:12b";
 
 /**
  * Ensure Ollama model is available (idempotent).


### PR DESCRIPTION
Use gpt-oss:12b instead of gpt-oss:20b for Ollama integration tests to reduce download size and test execution time.

_Generated with `mux`_