### PR TITLE
🤖 feat: add Vercel AI Gateway support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,10 +1,12 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@coder/cmux",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.44",
+        "@ai-sdk/gateway": "^2.0.11",
         "@ai-sdk/google": "^2.0.38",
         "@ai-sdk/openai": "^2.0.66",
         "@openrouter/ai-sdk-provider": "^1.2.2",
@@ -135,7 +137,7 @@
 
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@2.0.44", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-o8TfNXRzO/KZkBrcx+CL9LQsPhx7PHyqzUGjza3TJaF9WxfH1S5UQLAmEw8F7lQoHNLU0IX03WT8o8R/4JbUxQ=="],
 
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@vercel/oidc": "3.0.3" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-c++qOKfjKokTPAJ+vP9UXXNuTQ819yEDCZVXBhpZbgRly1P4fHTJbIAwuh+Qxxe9Bmtu8PEta0JGYZxc+hm7/Q=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.11", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@vercel/oidc": "3.0.3" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-B0Vt2Xv88Lo9rg861Oyzq/SdTmT4LiqdjkpOxpSPpNk8Ih5TXTgyDAsV/qW14N6asPdK1YI5PosFLnVzfK5LrA=="],
 
     "@ai-sdk/google": ["@ai-sdk/google@2.0.38", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-z+RFCxRA/dSd3eCkGBlnk79nz3jv8vwaW42gVc+qDuMofNfvjRz19rjnkFNuYQ6cEUcPKCo0P1rD/JLeTN2Z5A=="],
 
@@ -3212,6 +3214,8 @@
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "ai/@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@vercel/oidc": "3.0.3" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-c++qOKfjKokTPAJ+vP9UXXNuTQ819yEDCZVXBhpZbgRly1P4fHTJbIAwuh+Qxxe9Bmtu8PEta0JGYZxc+hm7/Q=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -49,6 +49,52 @@ Access Gemini models directly via Google's generative AI API:
 
 TODO: add issue link here.
 
+#### Vercel AI Gateway (Cloud)
+
+Access hundreds of AI models through Vercel's unified gateway with automatic failover and monitoring:
+
+- `gateway:openai/gpt-5`
+- `gateway:anthropic/claude-sonnet-4-5`
+- `gateway:xai/grok-4`
+- `gateway:google/gemini-3-pro-preview`
+- Any model from [Vercel AI Gateway Models](https://vercel.com/docs/ai-gateway/models-and-providers)
+
+**Setup:**
+
+1. Get your API key from [Vercel AI Gateway](https://vercel.com/ai-gateway)
+2. Add to `~/.mux/providers.jsonc`:
+
+```jsonc
+{
+  "gateway": {
+    "apiKey": "vai_...",
+  },
+}
+```
+
+**Features:**
+
+- **Unified API**: Access 100+ models from OpenAI, Anthropic, xAI, Google, and more
+- **High Reliability**: Automatic failover to other providers if one fails
+- **No Markup**: Tokens cost the same as directly from providers (0% markup with BYOK)
+- **Spend Monitoring**: Track usage across providers
+- **Provider Routing**: Configure fallback chains and model preferences
+
+**Bring Your Own Key (BYOK):**
+
+You can configure your own provider credentials through the Vercel dashboard to use existing provider accounts:
+
+```jsonc
+{
+  "gateway": {
+    "apiKey": "vai_...",
+    // BYOK credentials configured through Vercel dashboard
+  },
+}
+```
+
+See [Vercel AI Gateway Documentation](https://vercel.com/docs/ai-gateway) for details.
+
 #### OpenRouter (Cloud)
 
 Access 300+ models from multiple providers through a single API:
@@ -166,6 +212,10 @@ All providers are configured in `~/.mux/providers.jsonc`. Example configurations
   // Required for Google models
   "google": {
     "apiKey": "AIza...",
+  },
+  // Required for Vercel AI Gateway models
+  "gateway": {
+    "apiKey": "vai_...",
   },
   // Required for OpenRouter models
   "openrouter": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^2.0.44",
+    "@ai-sdk/gateway": "^2.0.11",
     "@ai-sdk/google": "^2.0.38",
     "@ai-sdk/openai": "^2.0.66",
     "@openrouter/ai-sdk-provider": "^1.2.2",

--- a/src/common/constants/providers.test.ts
+++ b/src/common/constants/providers.test.ts
@@ -28,4 +28,16 @@ describe("Provider Registry", () => {
     expect(isValidProvider("")).toBe(false);
     expect(isValidProvider("gpt-4")).toBe(false);
   });
+
+  test("gateway provider is registered", () => {
+    expect(SUPPORTED_PROVIDERS).toContain("gateway");
+    expect(isValidProvider("gateway")).toBe(true);
+  });
+
+  test("gateway provider can be imported", async () => {
+    const gatewayModule = await PROVIDER_REGISTRY.gateway();
+    expect(gatewayModule).toBeDefined();
+    expect(gatewayModule.createGateway).toBeDefined();
+    expect(typeof gatewayModule.createGateway).toBe("function");
+  });
 });

--- a/src/common/constants/providers.ts
+++ b/src/common/constants/providers.ts
@@ -42,6 +42,13 @@ export async function importOpenRouter() {
 }
 
 /**
+ * Dynamically import the Vercel AI Gateway provider package
+ */
+export async function importGateway() {
+  return await import("@ai-sdk/gateway");
+}
+
+/**
  * Centralized provider registry mapping provider names to their import functions
  *
  * This is the single source of truth for supported providers. By mapping to import
@@ -60,6 +67,7 @@ export const PROVIDER_REGISTRY = {
   google: importGoogle,
   ollama: importOllama,
   openrouter: importOpenRouter,
+  gateway: importGateway,
 } as const;
 
 /**

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -499,6 +499,27 @@ export class AIService extends EventEmitter {
         return Ok(provider(modelId));
       }
 
+      // Handle Vercel AI Gateway provider
+      if (providerName === "gateway") {
+        if (!providerConfig.apiKey) {
+          return Err({
+            type: "api_key_not_found",
+            provider: providerName,
+          });
+        }
+        const baseFetch = getProviderFetch(providerConfig);
+
+        // Lazy-load Gateway provider to reduce startup time
+        const { createGateway } = await PROVIDER_REGISTRY.gateway();
+        const provider = createGateway({
+          apiKey: providerConfig.apiKey,
+          baseURL: providerConfig.baseUrl,
+          headers: providerConfig.headers as Record<string, string> | undefined,
+          fetch: baseFetch,
+        });
+        return Ok(provider(modelId));
+      }
+
       return Err({
         type: "provider_not_supported",
         provider: providerName,


### PR DESCRIPTION
Adds support for Vercel AI Gateway, enabling access to 100+ models from multiple providers through a unified interface.

## Changes

- **Provider Integration**: Added `gateway` provider to the registry with full aiService support
- **Package Dependency**: Installed `@ai-sdk/gateway@2.0.11` package
- **Documentation**: Comprehensive setup guide and feature documentation in `docs/models.md`
- **Testing**: Unit tests for provider registration and import functionality

## Usage

Users can now access models through Vercel AI Gateway by:

1. Getting an API key from [Vercel AI Gateway](https://vercel.com/ai-gateway)
2. Adding configuration to `~/.mux/providers.jsonc`:
   ```jsonc
   {
     "gateway": {
       "apiKey": "vai_..."
     }
   }
   ```
3. Using models with format: `gateway:provider/model`
   - Example: `gateway:openai/gpt-5`
   - Example: `gateway:anthropic/claude-sonnet-4-5`
   - Example: `gateway:xai/grok-4`

## Benefits

- **Unified API**: Single interface for 100+ models from OpenAI, Anthropic, xAI, Google, and more
- **High Reliability**: Automatic failover if a provider fails
- **No Markup**: 0% markup on token costs with BYOK (Bring Your Own Key)
- **Monitoring**: Built-in spend tracking across providers
- **Provider Routing**: Configure fallback chains and model preferences

_Generated with `mux`_