### PR TITLE
🤖 fix: refresh usage and consumer breakdown on message deletion

### DIFF
--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -795,6 +795,8 @@ export class WorkspaceStore {
       aggregator.handleDeleteMessage(data);
       this.states.bump(workspaceId);
       this.checkAndBumpRecencyIfChanged();
+      this.usageStore.bump(workspaceId);
+      this.consumerManager.scheduleCalculation(workspaceId, aggregator);
       return;
     }
 


### PR DESCRIPTION
## Problem

When messages are deleted (via `/clear` command or manual deletion), the **Context Usage** section and **Breakdown by Consumer** chart showed stale data until the next API response.

## Root Cause

The delete message handler only bumped the main `states` store but not:
1. `usageStore` - which powers the Context Usage section
2. Consumer calculation - which powers the Breakdown by Consumer chart

The system uses a two-store architecture:
- **Usage Store** (fast, metadata-only) - Context Usage UI
- **Consumer Store** (slow, tokenization-based) - Consumer breakdown UI

Both need to update when message structure changes.

## Solution

Added two lines to the delete message handler:

```typescript
if (isDeleteMessage(data)) {
  aggregator.handleDeleteMessage(data);
  this.states.bump(workspaceId);
  this.checkAndBumpRecencyIfChanged();
  this.usageStore.bump(workspaceId);                            // ← NEW
  this.consumerManager.scheduleCalculation(workspaceId, aggregator); // ← NEW
  return;
}
```

This follows the same pattern used in `tool-call-end` and caught-up handlers for structural changes that require recalculation.

## Testing

1. Send messages to see usage and consumer breakdown populate
2. Run `/clear` command (or delete messages manually)
3. Verify both Context Usage and Breakdown by Consumer update immediately
4. Both sections should show zeros or empty state

## Changes

- **Files modified**: 1 (`src/browser/stores/WorkspaceStore.ts`)
- **Lines changed**: +3
- **Pattern**: Mirrors existing structural change handlers

_Generated with `mux`_