### PR TITLE
🤖 fix: bump usageStore when MuxMessage is stored

### DIFF
--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -816,6 +816,7 @@ export class WorkspaceStore {
         // Process live events immediately (after history loaded)
         aggregator.handleMessage(data);
         this.states.bump(workspaceId);
+        this.usageStore.bump(workspaceId);
         this.checkAndBumpRecencyIfChanged();
       }
       return;


### PR DESCRIPTION
When compaction is interrupted, we don't receive usage metadata from the interruption event itself. However, we do have historical usage data from messages stored in the aggregator. Without bumping usageStore when MuxMessages are received, the UI doesn't re-render to display this historical usage, making it appear as if costs have reset.

This single-line addition ensures the usage store stays in sync with message arrivals, so historical usage data is properly reflected in the UI.

## Changes
- Added `this.usageStore.bump(workspaceId)` after live MuxMessage storage in WorkspaceStore

## Testing
- Verified typecheck passes
- Change follows existing pattern from stream-end/stream-abort handlers

Relates to #695

_Generated with `mux`_