### PR TITLE
🤖 feat: add MUX_AGENT=1 env var to all command execution

### DIFF
--- a/src/common/constants/env.test.ts
+++ b/src/common/constants/env.test.ts
@@ -1,0 +1,18 @@
+import { NON_INTERACTIVE_ENV_VARS } from "./env";
+
+describe("NON_INTERACTIVE_ENV_VARS", () => {
+  it("should include MUX_AGENT=1", () => {
+    expect(NON_INTERACTIVE_ENV_VARS.MUX_AGENT).toBe("1");
+  });
+
+  it("should include all expected env vars", () => {
+    expect(NON_INTERACTIVE_ENV_VARS).toMatchObject({
+      MUX_AGENT: "1",
+      GIT_EDITOR: "true",
+      GIT_SEQUENCE_EDITOR: "true",
+      EDITOR: "true",
+      VISUAL: "true",
+      GIT_TERMINAL_PROMPT: "0",
+    });
+  });
+});

--- a/src/common/constants/env.ts
+++ b/src/common/constants/env.ts
@@ -3,6 +3,8 @@
  * These prevent tools from blocking on editor/credential prompts.
  */
 export const NON_INTERACTIVE_ENV_VARS = {
+  // Sentinel variable to indicate commands are running under Mux AI agent
+  MUX_AGENT: "1",
   // Prevent interactive editors from blocking execution
   // Critical for git operations like rebase/commit that try to open editors
   GIT_EDITOR: "true", // Git-specific editor (highest priority)


### PR DESCRIPTION
_Generated with `mux`_

Commands executed by the Mux AI agent can now detect they're running in an agent context via the `MUX_AGENT=1` environment variable.

## Changes

- Add `MUX_AGENT=1` to `NON_INTERACTIVE_ENV_VARS` constant
- `LocalRuntime` already spreads `NON_INTERACTIVE_ENV_VARS` (no change needed)
- Update `SSHRuntime` to merge `NON_INTERACTIVE_ENV_VARS` with user-provided env
- Add unit test for env constant
- Add integration test verifying `MUX_AGENT` is set in both local and SSH runtimes

## Testing

```bash
# Unit test
bun test src/common/constants/env.test.ts

# Integration test
TEST_INTEGRATION=1 bun x jest tests/runtime/runtime.test.ts -t "automatically sets MUX_AGENT=1"
```