### PR TITLE
🤖 fix: restore LRU model default for new workspaces

### DIFF
--- a/src/browser/hooks/useSendMessageOptions.ts
+++ b/src/browser/hooks/useSendMessageOptions.ts
@@ -1,6 +1,7 @@
 import { useThinkingLevel } from "./useThinkingLevel";
 import { useMode } from "@/browser/contexts/ModeContext";
 import { usePersistedState } from "./usePersistedState";
+import { getDefaultModelFromLRU } from "./useModelLRU";
 import { modeToToolPolicy, PLAN_MODE_INSTRUCTION } from "@/common/utils/ui/modeUtils";
 import { getModelKey } from "@/common/constants/storage";
 import type { SendMessageOptions } from "@/common/types/ipc";
@@ -10,7 +11,6 @@ import type { MuxProviderOptions } from "@/common/types/providerOptions";
 import { getSendOptionsFromStorage } from "@/browser/utils/messages/sendOptions";
 import { enforceThinkingPolicy } from "@/browser/utils/thinking/policy";
 import { useProviderOptions } from "./useProviderOptions";
-import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 
 /**
  * Construct SendMessageOptions from raw values
@@ -56,9 +56,10 @@ export function useSendMessageOptions(workspaceId: string): SendMessageOptions {
   const [thinkingLevel] = useThinkingLevel();
   const [mode] = useMode();
   const { options: providerOptions } = useProviderOptions();
+  const defaultModel = getDefaultModelFromLRU();
   const [preferredModel] = usePersistedState<string>(
     getModelKey(workspaceId),
-    WORKSPACE_DEFAULTS.model, // Hard-coded default (LRU is UI convenience)
+    defaultModel, // Default to most recently used model
     { listener: true } // Listen for changes from ModelSelector and other sources
   );
 
@@ -67,7 +68,7 @@ export function useSendMessageOptions(workspaceId: string): SendMessageOptions {
     thinkingLevel,
     preferredModel,
     providerOptions,
-    WORKSPACE_DEFAULTS.model
+    defaultModel
   );
 }
 

--- a/src/browser/utils/messages/sendOptions.ts
+++ b/src/browser/utils/messages/sendOptions.ts
@@ -1,6 +1,7 @@
 import { getModelKey, getThinkingLevelKey, getModeKey } from "@/common/constants/storage";
 import { modeToToolPolicy, PLAN_MODE_INSTRUCTION } from "@/common/utils/ui/modeUtils";
 import { readPersistedState } from "@/browser/hooks/usePersistedState";
+import { getDefaultModelFromLRU } from "@/browser/hooks/useModelLRU";
 import type { SendMessageOptions } from "@/common/types/ipc";
 import type { UIMode } from "@/common/types/mode";
 import type { ThinkingLevel } from "@/common/types/thinking";
@@ -36,8 +37,8 @@ function getProviderOptions(): MuxProviderOptions {
  * This ensures DRY - single source of truth for option extraction.
  */
 export function getSendOptionsFromStorage(workspaceId: string): SendMessageOptions {
-  // Read model preference (workspace-specific), fallback to immutable defaults
-  const model = readPersistedState<string>(getModelKey(workspaceId), WORKSPACE_DEFAULTS.model);
+  // Read model preference (workspace-specific), fallback to LRU default
+  const model = readPersistedState<string>(getModelKey(workspaceId), getDefaultModelFromLRU());
 
   // Read thinking level (workspace-specific)
   const thinkingLevel = readPersistedState<ThinkingLevel>(


### PR DESCRIPTION
Reverts a regression introduced in 2c700b84 where the default model was hardcoded to Sonnet 4.5.
Now defaults to the most recently used model (LRU) as expected.

_Generated with `mux`_