### PR TITLE
ci: set integration test timeout to 10m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
 
   integration-test:
     name: Integration Tests
+    timeout-minutes: 10
     runs-on: ${{ github.repository_owner == 'coder' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Checkout code

--- a/jest.config.js
+++ b/jest.config.js
@@ -35,6 +35,8 @@ module.exports = {
   maxWorkers: "50%",
   // Force exit after tests complete to avoid hanging on lingering handles
   forceExit: true,
+  // 10 minute timeout for integration tests, 10s for unit tests
+  testTimeout: process.env.TEST_INTEGRATION === "1" ? 600000 : 10000,
   // Detect open handles in development (disabled by default for speed)
   // detectOpenHandles: true,
 };


### PR DESCRIPTION
Sets the integration test timeout to 10 minutes in both Jest configuration and GitHub Actions workflow to prevent premature failures on slower runners.

_Generated with mux_