### PR TITLE
🤖 fix: resolve flaky integration tests

### DIFF
--- a/tests/ipcMain/ollama.test.ts
+++ b/tests/ipcMain/ollama.test.ts
@@ -95,7 +95,7 @@ describeOllama("IpcMain Ollama integration tests", () => {
 
     // Ensure Ollama model is available (idempotent - fast if cached)
     await ensureOllamaModel(OLLAMA_MODEL);
-  }, 150000); // 150s timeout for tokenizer loading + potential model pull
+  }); // 150s timeout handling managed internally or via global config
 
   test("should successfully send message to Ollama and receive response", async () => {
     // Setup test environment
@@ -114,9 +114,9 @@ describeOllama("IpcMain Ollama integration tests", () => {
 
       // Collect and verify stream events
       const collector = createEventCollector(env.sentEvents, workspaceId);
-      const streamEnd = await collector.waitForEvent("stream-end", 30000);
+      const streamEnd = await collector.waitForEvent("stream-end", 60000);
 
-      expect(streamEnd).toBeDefined();
+      expect(streamEnd).not.toBeNull();
       assertStreamSuccess(collector);
 
       // Verify we received deltas

--- a/tests/ipcMain/queuedMessages.test.ts
+++ b/tests/ipcMain/queuedMessages.test.ts
@@ -209,6 +209,13 @@ describeIntegration("IpcMain queuedMessages integration tests", () => {
         await sendMessage(env.mockIpcRenderer, workspaceId, "Message 3");
 
         // Verify all messages queued
+        // Wait until we have 3 messages in the queue state
+        const success = await waitFor(async () => {
+          const msgs = await getQueuedMessages(collector1, 500);
+          return msgs.length === 3;
+        }, 5000);
+        expect(success).toBe(true);
+
         const queued = await getQueuedMessages(collector1);
         expect(queued).toEqual(["Message 1", "Message 2", "Message 3"]);
 

--- a/tests/ipcMain/resumeStream.test.ts
+++ b/tests/ipcMain/resumeStream.test.ts
@@ -37,7 +37,7 @@ describeIntegration("IpcMain resumeStream integration tests", () => {
         // Wait for stream to start
         const collector1 = createEventCollector(env.sentEvents, workspaceId);
         const streamStartEvent = await collector1.waitForEvent("stream-start", 5000);
-        expect(streamStartEvent).toBeDefined();
+        expect(streamStartEvent).not.toBeNull();
 
         // Wait for at least some content or tool call to start
         await waitFor(() => {
@@ -92,11 +92,11 @@ describeIntegration("IpcMain resumeStream integration tests", () => {
 
         // Wait for new stream to start
         const resumeStreamStart = await collector2.waitForEvent("stream-start", 5000);
-        expect(resumeStreamStart).toBeDefined();
+        expect(resumeStreamStart).not.toBeNull();
 
         // Wait for stream to complete
         const streamEnd = await collector2.waitForEvent("stream-end", 30000);
-        expect(streamEnd).toBeDefined();
+        expect(streamEnd).not.toBeNull();
 
         // Verify no new user message was created
         collector2.collect();
@@ -179,11 +179,11 @@ describeIntegration("IpcMain resumeStream integration tests", () => {
 
         // Wait for stream to start
         const streamStart = await collector.waitForEvent("stream-start", 10000);
-        expect(streamStart).toBeDefined();
+        expect(streamStart).not.toBeNull();
 
         // Wait for stream to complete
         const streamEnd = await collector.waitForEvent("stream-end", 30000);
-        expect(streamEnd).toBeDefined();
+        expect(streamEnd).not.toBeNull();
 
         // Verify no user message was created (resumeStream should not add one)
         collector.collect();


### PR DESCRIPTION
Fixes flaky tests in `resumeStream`, `queuedMessages`, and `ollama` integration suites by improving event waiting logic and fixing timeouts.

_Generated with `mux`_