### PR TITLE
🤖 fix: use correct model for post-compaction continue messages

### DIFF
--- a/mobile/src/utils/slashCommandHelpers.test.ts
+++ b/mobile/src/utils/slashCommandHelpers.test.ts
@@ -56,6 +56,7 @@ describe("buildMobileCompactionPayload", () => {
       model: "anthropic:claude-opus-4-1",
       maxOutputTokens: 800,
       continueMessage: parsed.continueMessage,
+      resumeModel: baseOptions.model,
     });
     expect(payload.sendOptions.model).toBe("anthropic:claude-opus-4-1");
     expect(payload.sendOptions.mode).toBe("compact");

--- a/mobile/src/utils/slashCommandHelpers.ts
+++ b/mobile/src/utils/slashCommandHelpers.ts
@@ -57,6 +57,7 @@ export function buildMobileCompactionPayload(
       model: parsed.model,
       maxOutputTokens: parsed.maxOutputTokens,
       continueMessage: parsed.continueMessage,
+      resumeModel: baseOptions.model,
     },
   };
 

--- a/src/browser/utils/chatCommands.ts
+++ b/src/browser/utils/chatCommands.ts
@@ -214,6 +214,7 @@ export function prepareCompactionMessage(options: CompactionOptions): {
     model: effectiveModel,
     maxOutputTokens: options.maxOutputTokens,
     continueMessage: options.continueMessage,
+    resumeModel: options.sendMessageOptions.model,
   };
 
   const metadata: MuxFrontendMetadata = {

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -10,6 +10,7 @@ export interface CompactionRequestData {
   model?: string; // Custom model override for compaction
   maxOutputTokens?: number;
   continueMessage?: string;
+  resumeModel?: string; // Original workspace model to use after compaction continues
 }
 
 // Frontend-specific metadata stored in muxMetadata field
@@ -103,6 +104,7 @@ export type DisplayedMessage =
         parsed: {
           maxOutputTokens?: number;
           continueMessage?: string;
+          resumeModel?: string;
         };
       };
     }

--- a/src/node/services/compactionContinueOptions.test.ts
+++ b/src/node/services/compactionContinueOptions.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import type { SendMessageOptions } from "@/common/types/ipc";
+import { buildContinueMessageOptions } from "./compactionContinueOptions";
+
+const baseOptions = (): SendMessageOptions => ({
+  model: "anthropic:claude-3-5-sonnet",
+  thinkingLevel: "medium",
+  toolPolicy: [],
+  additionalSystemInstructions: "be helpful",
+  mode: "compact",
+  maxOutputTokens: 2048,
+});
+
+describe("buildContinueMessageOptions", () => {
+  it("uses resumeModel when provided and drops compact overrides", () => {
+    const options = baseOptions();
+    const result = buildContinueMessageOptions(options, "anthropic:claude-3-5-haiku");
+
+    expect(result).not.toBe(options);
+    expect(result.model).toBe("anthropic:claude-3-5-haiku");
+    expect(result.mode).toBeUndefined();
+    expect(result.maxOutputTokens).toBeUndefined();
+    expect(result.thinkingLevel).toBe("medium");
+    expect(result.toolPolicy).toEqual([]);
+    // Ensure original options untouched
+    expect(options.model).toBe("anthropic:claude-3-5-sonnet");
+    expect(options.mode).toBe("compact");
+    expect(options.maxOutputTokens).toBe(2048);
+  });
+
+  it("falls back to compaction model when resumeModel is missing", () => {
+    const options = baseOptions();
+    const result = buildContinueMessageOptions(options);
+
+    expect(result.model).toBe(options.model);
+  });
+});

--- a/src/node/services/compactionContinueOptions.ts
+++ b/src/node/services/compactionContinueOptions.ts
@@ -1,0 +1,27 @@
+import type { SendMessageOptions } from "@/common/types/ipc";
+
+/**
+ * Build sanitized SendMessageOptions for auto-continue messages after compaction.
+ *
+ * - Drops compaction-specific overrides (mode="compact", maxOutputTokens)
+ * - Removes frontend metadata (muxMetadata)
+ * - Restores the original workspace model when provided
+ */
+export function buildContinueMessageOptions(
+  options: SendMessageOptions,
+  resumeModel?: string
+): SendMessageOptions {
+  const {
+    muxMetadata: _ignoredMetadata,
+    maxOutputTokens: _ignoredMaxOutputTokens,
+    mode: _ignoredMode,
+    ...rest
+  } = options;
+
+  const nextModel = resumeModel ?? options.model;
+
+  return {
+    ...rest,
+    model: nextModel,
+  };
+}


### PR DESCRIPTION
## Summary

Fixes a regression where the `/compact` model (often a cheaper/faster model) was incorrectly used for the follow-up continue message instead of the user's selected workspace model.

## Regression

Introduced in a31a2e0e67814fe86fc7eb7f2acf0b461463bcfd which moved continue message logic to the backend message queue but failed to sanitize the options.

## Changes

- Extended `CompactionRequestData` to carry `resumeModel`
- Updated frontend/mobile command parsers to capture the current model before switching to compaction mode
- Added `buildContinueMessageOptions` helper in backend to:
  - Strip compaction flags (`mode: 'compact'`, `maxOutputTokens`)
  - Restore the original `resumeModel`
- Added tests for options sanitization and metadata round-tripping

_Generated with `mux`_