### PR TITLE
🤖 fix: suppress filename in make help output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ help: ## Show this help message
 	@echo 'Usage: make [target]'
 	@echo ''
 	@echo 'Available targets:'
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 ## Development
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
Generated with mux. Fixes #719 by adding `-h` to grep in make help target to suppress filename prefixes.