### PR TITLE
🤖 fix: cursor visibility in light theme

### DIFF
--- a/src/browser/components/VimTextArea.tsx
+++ b/src/browser/components/VimTextArea.tsx
@@ -234,8 +234,8 @@ export const VimTextArea = React.forwardRef<HTMLTextAreaElement, VimTextAreaProp
                 : "bg-dark border-border-light",
               !isEditing && (mode === "plan" ? "focus:border-plan-mode" : "focus:border-exec-mode"),
               vimMode === "normal"
-                ? "caret-transparent selection:bg-white/50"
-                : "caret-white selection:bg-selection"
+                ? "caret-transparent selection:bg-caret/50"
+                : "caret-caret selection:bg-selection"
             )}
           />
           {trailingAction && (
@@ -244,7 +244,7 @@ export const VimTextArea = React.forwardRef<HTMLTextAreaElement, VimTextAreaProp
             </div>
           )}
           {vimEnabled && vimMode === "normal" && value.length === 0 && (
-            <div className="pointer-events-none absolute top-1.5 left-2 h-4 w-2 bg-white/50" />
+            <div className="bg-caret/50 pointer-events-none absolute top-1.5 left-2 h-4 w-2" />
           )}
         </div>
       </div>

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -235,6 +235,9 @@
     --color-selection: hsl(204 100% 60% / 0.5); /* selection blue with 50% opacity */
     --color-vim-status: hsl(0 0% 83% / 0.6); /* status text with 60% opacity */
     --color-code-keyword-overlay-light: hsl(210 100% 70% / 0.05); /* code keyword with 5% opacity */
+
+    /* Caret */
+    --color-caret: hsl(0 0% 100%);
     --color-code-keyword-overlay: hsl(210 100% 70% / 0.2); /* code keyword with 20% opacity */
 
     /* Info/status colors */
@@ -453,6 +456,9 @@
   --color-selection: hsl(204 100% 45% / 0.3);
   --color-vim-status: hsl(210 18% 32% / 0.6);
   --color-code-keyword-overlay-light: hsl(210 88% 28% / 0.16);
+
+  /* Caret */
+  --color-caret: hsl(210 18% 16%);
   --color-code-keyword-overlay: hsl(210 88% 28% / 0.32);
 
   --color-info-light: hsl(5 90% 70%);


### PR DESCRIPTION
Closes #730

Fixes cursor invisibility in the prompt box when using light theme.

**Changes:**
- Added `--color-caret` CSS variable with theme-specific values (white for dark, dark gray for light)
- Updated VimTextArea to use semantic `caret-caret` and `bg-caret/50` utilities instead of arbitrary value syntax
- Fixes apply to insert mode cursor, vim normal mode block cursor, and empty-buffer cursor indicator

**Implementation notes:**
- `--color-caret` defined inside `@theme` block for automatic utility generation
- Light theme override in `:root[data-theme="light"]` 
- Follows existing pattern of semantic utilities like `text-light`, `bg-dark`

_Generated with `mux`_