### PR TITLE
🤖 ci: add self-hosted ollama suite

### DIFF
--- a/tests/ipcMain/runtimeFileEditing.test.ts
+++ b/tests/ipcMain/runtimeFileEditing.test.ts
@@ -68,16 +68,9 @@ let sshConfig: SSHServerConfig | undefined;
 // ============================================================================
 
 describeIntegration("Runtime File Editing Tools", () => {
-<<<<<<< HEAD
   // Enable retries in CI for flaky API tests
   configureTestRetries(3);
 
-||||||| parent of 846841cd (🤖 fix: add retries to flaky integration tests)
-=======
-  // Add retries to handle potential AI flakiness (e.g. failing to call tools)
-  configureTestRetries(3);
-
->>>>>>> 846841cd (🤖 fix: add retries to flaky integration tests)
   beforeAll(async () => {
     // Check if Docker is available (required for SSH tests)
     if (!(await isDockerAvailable())) {


### PR DESCRIPTION
## Summary
- add a dedicated integration-test-ollama job pinned to the self-hosted runner
- reuse the ollama setup/verification flow and run only the targeted suite by default

## Testing
- not run (workflow-only change)

_Generated with `mux`_
