### PR TITLE
🤖 docs: update AGENTS.md with merge guidelines

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -22,6 +22,7 @@ gh pr view <number> --json mergeable,mergeStateStatus | jq '.'
 - Status decoding: `mergeable=MERGEABLE` clean; `CONFLICTING` needs resolution. `mergeStateStatus=CLEAN` ready, `BLOCKED` waiting for CI, `BEHIND` rebase, `DIRTY` conflicts.
 - If behind: `git fetch origin && git rebase origin/main && git push --force-with-lease`.
 - Never enable auto-merge or merge at all unless the user explicitly says "merge it".
+- Do not enable auto-squash or auto-merge on Pull Requests unless explicit permission is given.
 - PR descriptions: include only information a busy reviewer cannot infer; focus on implementation nuances or validation steps.
 - Title prefixes: `perf|refactor|fix|feat|ci|bench`, e.g., `🤖 fix: handle workspace rename edge cases`.
 


### PR DESCRIPTION
Explicitly forbid auto-squash/auto-merge without user permission.