### PR TITLE
🤖 fix: prevent unbound variable errors from system bashrc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ SHELL := bash
 else
 SHELL := /usr/bin/env bash
 endif
-.SHELLFLAGS := -eu -o pipefail -c
+.SHELLFLAGS := --norc -eu -o pipefail -c
 
 # Enable parallel execution by default (only if user didn't specify -j)
 ifeq (,$(filter -j%,$(MAKEFLAGS)))


### PR DESCRIPTION
Prevents `make` commands from sourcing system `/etc/bash.bashrc` or `~/.bashrc` by adding `--norc` to `.SHELLFLAGS`.

This resolves issues where system bash configurations reference unbound variables (like `PS1`) which cause failures when running under `make`'s strict `set -u` (nounset) mode.

Fixes: /etc/bash.bashrc: line 7: PS1: unbound variable