### PR TITLE
🤖 fix: compaction prompt focuses entirely on summary

### DIFF
--- a/src/browser/utils/chatCommands.test.ts
+++ b/src/browser/utils/chatCommands.test.ts
@@ -120,4 +120,16 @@ describe("prepareCompactionMessage", () => {
 
     expect(metadata.parsed.resumeModel).toBe(sendMessageOptions.model);
   });
+
+  test("generates correct prompt text with strict summary instructions", () => {
+    const sendMessageOptions = createBaseOptions();
+    const { messageText } = prepareCompactionMessage({
+      workspaceId: "ws-1",
+      maxOutputTokens: 4096,
+      sendMessageOptions,
+    });
+
+    expect(messageText).toContain("Focus entirely on the summary");
+    expect(messageText).toContain("Do not suggest next steps or future actions");
+  });
 });

--- a/src/browser/utils/chatCommands.ts
+++ b/src/browser/utils/chatCommands.ts
@@ -200,7 +200,7 @@ export function prepareCompactionMessage(options: CompactionOptions): {
   const targetWords = options.maxOutputTokens ? Math.round(options.maxOutputTokens / 1.3) : 2000;
 
   // Build compaction message with optional continue context
-  let messageText = `Summarize this conversation into a compact form for a new Assistant to continue helping the user. Use approximately ${targetWords} words.`;
+  let messageText = `Summarize this conversation into a compact form for a new Assistant to continue helping the user. Focus entirely on the summary of what has happened. Do not suggest next steps or future actions. Use approximately ${targetWords} words.`;
 
   if (options.continueMessage) {
     messageText += `\n\nThe user wants to continue with: ${options.continueMessage}`;

--- a/src/node/services/mock/scenarios/slashCommands.ts
+++ b/src/node/services/mock/scenarios/slashCommands.ts
@@ -7,7 +7,7 @@ export const SLASH_COMMAND_PROMPTS = {
 } as const;
 
 export const COMPACTION_MESSAGE =
-  "Summarize this conversation into a compact form for a new Assistant to continue helping the user. Use approximately 385 words.";
+  "Summarize this conversation into a compact form for a new Assistant to continue helping the user. Focus entirely on the summary of what has happened. Do not suggest next steps or future actions. Use approximately 385 words.";
 
 export const COMPACT_SUMMARY_TEXT =
   "Compact summary: The assistant read project files, listed directory contents, created and inspected test.txt, then confirmed the contents remained 'hello'. Technical details preserved.";


### PR DESCRIPTION
_Generated with `mux`_

Updated compaction prompt to explicitly instruct the model to focus entirely on summarizing what has happened, rather than suggesting next steps or future actions.