### PR TITLE
🤖 feat: use effort parameter for Claude thinking

### DIFF
--- a/src/common/types/thinking.ts
+++ b/src/common/types/thinking.ts
@@ -14,19 +14,23 @@ export type ThinkingLevel = "off" | "low" | "medium" | "high";
 export type ThinkingLevelOn = Exclude<ThinkingLevel, "off">;
 
 /**
- * Anthropic thinking token budget mapping
+ * Anthropic effort level mapping
  *
- * These heuristics balance thinking depth with response time and cost:
- * - off: No extended thinking
- * - low: Quick thinking for straightforward tasks (4K tokens)
- * - medium: Standard thinking for moderate complexity (10K tokens)
- * - high: Deep thinking for complex problems (20K tokens)
+ * Maps our unified thinking levels to Anthropic's effort parameter:
+ * - off: No effort specified (undefined)
+ * - low: Most efficient - significant token savings
+ * - medium: Balanced approach with moderate token savings
+ * - high: Maximum capability (default behavior)
+ *
+ * The effort parameter controls all token spend including thinking,
+ * text responses, and tool calls. Unlike budget_tokens, it doesn't require
+ * thinking to be explicitly enabled.
  */
-export const ANTHROPIC_THINKING_BUDGETS: Record<ThinkingLevel, number> = {
-  off: 0,
-  low: 4000,
-  medium: 10000,
-  high: 20000,
+export const ANTHROPIC_EFFORT: Record<ThinkingLevel, "low" | "medium" | "high" | undefined> = {
+  off: undefined,
+  low: "low",
+  medium: "medium",
+  high: "high",
 };
 
 /**

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -33,10 +33,7 @@ import type { HistoryService } from "./historyService";
 import type { PartialService } from "./partialService";
 import { buildSystemMessage, readToolInstructions } from "./systemMessage";
 import { getTokenizerForModel } from "@/node/utils/main/tokenizer";
-import {
-  buildProviderOptions,
-  calculateEffectiveMaxOutputTokens,
-} from "@/common/utils/ai/providerOptions";
+import { buildProviderOptions } from "@/common/utils/ai/providerOptions";
 import type { ThinkingLevel } from "@/common/types/thinking";
 import type {
   StreamAbortEvent,
@@ -929,15 +926,6 @@ export class AIService extends EventEmitter {
         effectiveMuxProviderOptions
       );
 
-      // Calculate effective maxOutputTokens that accounts for thinking budget
-      // For Anthropic models with extended thinking, the SDK adds thinkingBudget to maxOutputTokens
-      // so we need to ensure the sum doesn't exceed the model's max_output_tokens limit
-      const effectiveMaxOutputTokens = calculateEffectiveMaxOutputTokens(
-        effectiveModelString,
-        thinkingLevel ?? "off",
-        maxOutputTokens
-      );
-
       // Delegate to StreamManager with model instance, system message, tools, historySequence, and initial metadata
       const streamResult = await this.streamManager.startStream(
         workspaceId,
@@ -955,7 +943,7 @@ export class AIService extends EventEmitter {
           mode, // Pass mode so it persists in final history entry
         },
         providerOptions,
-        effectiveMaxOutputTokens,
+        maxOutputTokens,
         toolPolicy,
         streamToken // Pass the pre-generated stream token
       );


### PR DESCRIPTION
Replace budget_tokens approach with new effort parameter:

- `ANTHROPIC_EFFORT` maps thinking levels to `'low' | 'medium' | 'high'`
- SDK auto-adds `effort-2025-11-24` beta header when effort is set
- Remove `calculateEffectiveMaxOutputTokens` (no longer needed with effort)
- Effort controls all token spend: thinking, text, and tool calls

Net: **-86 lines** of workaround code removed.

_Generated with `mux`_