### PR TITLE
🤖 ci: optimize Playwright installation with caching

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,0 +1,36 @@
+name: "Setup Playwright"
+description: "Install Playwright browsers and dependencies with caching"
+inputs:
+  browsers:
+    description: "Space-separated list of browsers to install (e.g., 'chromium', 'chromium webkit')"
+    required: false
+    default: "chromium"
+runs:
+  using: "composite"
+  steps:
+    - name: Get Playwright version
+      id: playwright-version
+      shell: bash
+      run: |
+        # Extract Playwright version from bun.lock
+        VERSION=$(grep -A1 '"playwright":' bun.lock | grep -oP '"\K[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Playwright version: $VERSION"
+
+    - name: Cache Playwright browsers
+      id: cache-playwright
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-${{ inputs.browsers }}
+        restore-keys: |
+          ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-
+
+    - name: Install Playwright browsers
+      if: steps.cache-playwright.outputs.cache-hit != 'true'
+      shell: bash
+      run: bun x playwright install ${{ inputs.browsers }}
+
+    - name: Install Playwright system dependencies
+      shell: bash
+      run: bun x playwright install-deps ${{ inputs.browsers }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,8 +134,7 @@ jobs:
 
       - uses: ./.github/actions/setup-mux
 
-      - name: Install Playwright browsers
-        run: bun x playwright install --with-deps
+      - uses: ./.github/actions/setup-playwright
 
       - name: Build Storybook
         run: make storybook-build
@@ -160,16 +159,12 @@ jobs:
 
       - uses: ./.github/actions/setup-mux
 
-      - name: Install system dependencies
+      - name: Install xvfb
         run: |
           sudo apt-get update
           sudo apt-get install -y xvfb
 
-      - name: Install Playwright runtime dependencies
-        run: bun x playwright install-deps
-
-      - name: Install Playwright browsers
-        run: bun x playwright install --with-deps
+      - uses: ./.github/actions/setup-playwright
 
       - name: Run e2e tests
         run: xvfb-run -a make test-e2e


### PR DESCRIPTION
## Summary

Optimizes Playwright installation in CI by caching browser binaries and installing only chromium.

## Changes

### New `.github/actions/setup-playwright` composite action
- Caches `~/.cache/ms-playwright` keyed by Playwright version from bun.lock
- On cache hit: skips browser download, only runs `install-deps`
- Installs only **chromium** (sufficient for E2E and Storybook, ~3x smaller than all browsers)

### Updated CI jobs
- `storybook-test`: uses new composite action (was: `playwright install --with-deps`)
- `e2e-test`: uses new composite action (replaces 3 separate steps)

## Expected Impact

| Scenario | Before | After |
|----------|--------|-------|
| Cache hit | Download all browsers | Skip download (save ~90s) |
| Cache miss | Download all browsers | Download chromium only |

The cache hit path is the common case after the first run per Playwright version.

---

_Generated with `mux`_