### PR TITLE
🤖 fix: add module preloading to fix flaky stream error tests

### DIFF
--- a/tests/ipcMain/sendMessage.errors.test.ts
+++ b/tests/ipcMain/sendMessage.errors.test.ts
@@ -15,6 +15,7 @@ import {
   configureTestRetries,
 } from "./helpers";
 import { createSharedRepo, cleanupSharedRepo, withSharedWorkspace } from "./sendMessageTestHelpers";
+import { preloadTestModules } from "./setup";
 import type { StreamDeltaEvent } from "../../src/common/types/stream";
 import { IPC_CHANNELS } from "../../src/common/constants/ipc-constants";
 
@@ -40,9 +41,13 @@ const PROVIDER_CONFIGS: Array<[string, string]> = [
 // - Longer running tests (tool calls, multiple edits) can take up to 30s
 // - Test timeout values (in describe/test) should be 2-3x the expected duration
 
-beforeAll(createSharedRepo);
-afterAll(cleanupSharedRepo);
 describeIntegration("IpcMain sendMessage integration tests", () => {
+  beforeAll(async () => {
+    await preloadTestModules();
+    await createSharedRepo();
+  });
+  afterAll(cleanupSharedRepo);
+
   configureTestRetries(3);
 
   // Run tests for each provider concurrently

--- a/tests/ipcMain/streamErrorRecovery.test.ts
+++ b/tests/ipcMain/streamErrorRecovery.test.ts
@@ -16,7 +16,12 @@
  * test the recovery path without relying on actual network failures.
  */
 
-import { setupWorkspace, shouldRunIntegrationTests, validateApiKeys } from "./setup";
+import {
+  setupWorkspace,
+  shouldRunIntegrationTests,
+  validateApiKeys,
+  preloadTestModules,
+} from "./setup";
 import {
   sendMessageWithModel,
   createEventCollector,
@@ -220,6 +225,8 @@ async function collectStreamUntil(
 }
 
 describeIntegration("Stream Error Recovery (No Amnesia)", () => {
+  beforeAll(preloadTestModules);
+
   test.concurrent(
     "should preserve exact prefix and continue from exact point after stream error",
     async () => {


### PR DESCRIPTION
Generated with `mux`

Fixes intermittent failures in:
- `tests/ipcMain/streamErrorRecovery.test.ts`
- `tests/ipcMain/sendMessage.errors.test.ts`

**Root cause**: Concurrent tests were racing on dynamic module imports (tokenizer, AI SDK providers) which could cause intermittent failures when modules weren't fully loaded before test execution.

**Fix**: Add `preloadTestModules()` call to `beforeAll` hooks inside the `describeIntegration` blocks, ensuring modules are loaded before any concurrent tests start.

Also moved `beforeAll`/`afterAll` hooks inside the `describeIntegration` blocks so they only run when integration tests are enabled.