### PR TITLE
🤖 fix: improve web_fetch HTTP error reporting with body parsing

### DIFF
--- a/src/browser/components/tools/WebFetchToolCall.tsx
+++ b/src/browser/components/tools/WebFetchToolCall.tsx
@@ -102,9 +102,10 @@ export const WebFetchToolCall: React.FC<WebFetchToolCallProps> = ({
                 </DetailSection>
               )}
 
-              {result.success && result.content && (
+              {/* Show content for both success and error responses (error pages may have parsed content) */}
+              {result.content && (
                 <DetailSection>
-                  <DetailLabel>Content</DetailLabel>
+                  <DetailLabel>{result.success ? "Content" : "Error Page Content"}</DetailLabel>
                   <div className="bg-code-bg max-h-[300px] overflow-y-auto rounded px-3 py-2 text-[12px]">
                     <MarkdownRenderer content={result.content} />
                   </div>

--- a/src/common/types/tools.ts
+++ b/src/common/types/tools.ts
@@ -219,4 +219,6 @@ export type WebFetchToolResult =
   | {
       success: false;
       error: string;
+      /** Parsed error response body (e.g., from HTTP 4xx/5xx pages) */
+      content?: string;
     };


### PR DESCRIPTION
## Summary

Improves error messages when `web_fetch` encounters HTTP 4xx/5xx responses:

1. **HTTP status code in error**: Shows actual status code (e.g., `HTTP 404`) instead of generic `HTTP error (4xx/5xx)`

2. **Parsed error body**: When the server returns an error page (like a 404), we now parse and include its content so the AI can understand what went wrong

3. **Cloudflare detection**: Detects Cloudflare JS challenge pages and shows a clear error: `Cloudflare security challenge (page requires JavaScript)`

## Example Outputs

Before:
```
Failed to fetch URL: HTTP error (4xx/5xx)
```

After:
```
HTTP 404
[parsed 404 page content shown]
```

Or for Cloudflare-protected sites:
```
HTTP 403: Cloudflare security challenge (page requires JavaScript)
```

## Testing

- Added test for HTTP 404 status code parsing
- Added test for Cloudflare challenge detection

_Generated with `mux`_