### PR TITLE
🤖 feat: add mux version subcommand

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,12 +1,18 @@
 #!/usr/bin/env node
 
-const isServer = process.argv.length > 2 && process.argv[2] === "server";
+const subcommand = process.argv.length > 2 ? process.argv[2] : null;
 
-if (isServer) {
+if (subcommand === "server") {
   // Remove 'server' from args since main-server doesn't expect it as a positional argument.
   process.argv.splice(2, 1);
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   require("./server");
+} else if (subcommand === "version") {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { VERSION } = require("../version") as {
+    VERSION: { git_describe: string; git_commit: string };
+  };
+  console.log(`mux ${VERSION.git_describe} (${VERSION.git_commit})`);
 } else {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   require("../desktop/main");


### PR DESCRIPTION
Adds `mux version` subcommand that prints version info.

```
$ mux version
mux v0.7.2-3-g8f176aa2-dirty (8f176aa2)
```

Fixes #586

_Generated with `mux`_