### PR TITLE
🤖 fix: untracked popup overflow

### DIFF
--- a/src/browser/components/RightSidebar/CodeReview/UntrackedStatus.tsx
+++ b/src/browser/components/RightSidebar/CodeReview/UntrackedStatus.tsx
@@ -168,7 +168,9 @@ export const UntrackedStatus: React.FC<UntrackedStatusProps> = ({
         {isLoading ? "..." : `${count} Untracked`}
       </div>
 
-      {showTooltip && hasUntracked && popupPosition &&
+      {showTooltip &&
+        hasUntracked &&
+        popupPosition &&
         createPortal(
           <div
             ref={popupRef}


### PR DESCRIPTION
_Generated with `mux`_

The UntrackedStatus popup was being clipped by parent containers with `overflow:hidden`. 

**Fix:** Use `createPortal` with fixed positioning and dynamic coordinates calculated from the trigger element's bounding rect. Also updated click-outside handler to account for the portal element.