### PR TITLE
🤖 feat: mid-stream token usage updates

### DIFF
--- a/src/browser/components/ChatMetaSidebar.tsx
+++ b/src/browser/components/ChatMetaSidebar.tsx
@@ -19,7 +19,7 @@ const ChatMetaSidebarComponent: React.FC<ChatMetaSidebarProps> = ({ workspaceId,
   const use1M = options.anthropic?.use1MContext ?? false;
   const chatAreaSize = useResizeObserver(chatAreaRef);
 
-  const lastUsage = usage?.usageHistory[usage.usageHistory.length - 1];
+  const lastUsage = usage?.liveUsage ?? usage?.usageHistory[usage.usageHistory.length - 1];
 
   // Memoize vertical meter data calculation to prevent unnecessary re-renders
   const verticalMeterData = React.useMemo(() => {

--- a/src/browser/components/RightSidebar.tsx
+++ b/src/browser/components/RightSidebar.tsx
@@ -134,7 +134,7 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
   const costsPanelId = `${baseId}-panel-costs`;
   const reviewPanelId = `${baseId}-panel-review`;
 
-  const lastUsage = usage?.usageHistory[usage.usageHistory.length - 1];
+  const lastUsage = usage?.liveUsage ?? usage?.usageHistory[usage.usageHistory.length - 1];
 
   // Memoize vertical meter data calculation to prevent unnecessary re-renders
   const verticalMeterData = React.useMemo(() => {

--- a/src/common/types/ipc.ts
+++ b/src/common/types/ipc.ts
@@ -21,6 +21,7 @@ import type {
   StreamDeltaEvent,
   StreamEndEvent,
   StreamAbortEvent,
+  UsageDeltaEvent,
   ToolCallStartEvent,
   ToolCallDeltaEvent,
   ToolCallEndEvent,
@@ -103,6 +104,7 @@ export type WorkspaceChatMessage =
   | DeleteMessage
   | StreamStartEvent
   | StreamDeltaEvent
+  | UsageDeltaEvent
   | StreamEndEvent
   | StreamAbortEvent
   | ToolCallStartEvent
@@ -147,6 +149,11 @@ export function isStreamEnd(msg: WorkspaceChatMessage): msg is StreamEndEvent {
 // Type guard for stream abort events
 export function isStreamAbort(msg: WorkspaceChatMessage): msg is StreamAbortEvent {
   return "type" in msg && msg.type === "stream-abort";
+}
+
+// Type guard for usage delta events
+export function isUsageDelta(msg: WorkspaceChatMessage): msg is UsageDeltaEvent {
+  return "type" in msg && msg.type === "usage-delta";
 }
 
 // Type guard for tool call start events

--- a/src/common/types/stream.ts
+++ b/src/common/types/stream.ts
@@ -121,6 +121,17 @@ export interface ReasoningEndEvent {
   messageId: string;
 }
 
+/**
+ * Emitted on each AI SDK finish-step event, providing incremental usage updates.
+ * Allows UI to update token display as steps complete (after each tool call or at stream end).
+ */
+export interface UsageDeltaEvent {
+  type: "usage-delta";
+  workspaceId: string;
+  messageId: string;
+  usage: LanguageModelV2Usage; // This step's usage (inputTokens = full context)
+}
+
 export type AIServiceEvent =
   | StreamStartEvent
   | StreamDeltaEvent
@@ -132,4 +143,5 @@ export type AIServiceEvent =
   | ToolCallEndEvent
   | ReasoningStartEvent
   | ReasoningDeltaEvent
-  | ReasoningEndEvent;
+  | ReasoningEndEvent
+  | UsageDeltaEvent;

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -464,6 +464,7 @@ export class AgentSession {
     });
     forward("reasoning-delta", (payload) => this.emitChatEvent(payload));
     forward("reasoning-end", (payload) => this.emitChatEvent(payload));
+    forward("usage-delta", (payload) => this.emitChatEvent(payload));
 
     forward("stream-end", async (payload) => {
       const handled = await this.compactionHandler.handleCompletion(payload as StreamEndEvent);

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -203,6 +203,7 @@ export class AIService extends EventEmitter {
     // Forward reasoning events
     this.streamManager.on("reasoning-delta", (data) => this.emit("reasoning-delta", data));
     this.streamManager.on("reasoning-end", (data) => this.emit("reasoning-end", data));
+    this.streamManager.on("usage-delta", (data) => this.emit("usage-delta", data));
   }
 
   private async ensureSessionsDir(): Promise<void> {


### PR DESCRIPTION
Emit `usage-delta` events on AI SDK `finish-step`, allowing the UI to display live token counts as the AI generates multi-step responses.


https://github.com/user-attachments/assets/80cd3a98-e7fa-415f-9ac6-7b7a241a7a5a

## Changes

**Backend:**
- Add `UsageDeltaEvent` type emitted on each `finish-step`
- `StreamManager` emits usage after each tool call step completes
- Forward events through `AIService` → `AgentSession` → IPC

**Frontend:**
- `StreamingMessageAggregator` stores active stream usage per messageId
- `WorkspaceStore` exposes `liveUsage` in `WorkspaceUsageState`
- `CostsTab`, `RightSidebar`, `ChatMetaSidebar` consume `liveUsage` for real-time context window display

**Tests:**
- Unit tests for usage-delta handling in `StreamingMessageAggregator`
- Integration test for usage-delta events during multi-step streams

## Testing

This feature has been tested with OpenAI, Anthropic & Google.

---
_Generated with `mux`_