### PR TITLE
Docs: add word wrapping to code blocks

### DIFF
--- a/docs/theme/custom.css
+++ b/docs/theme/custom.css
@@ -251,6 +251,7 @@ pre > code {
   display: block;
   padding: 0.9rem 1rem;
   font-family: var(--font-monospace);
+  white-space: pre-wrap;
 }
 
 /* Code blocks inside lists */

--- a/docs/vscode-extension.md
+++ b/docs/vscode-extension.md
@@ -67,7 +67,7 @@ If you haven't configured the SSH host yet:
 
 1. Open `~/.ssh/config` and add:
 
-   ```ssh
+   ```bash
    Host myserver
      HostName 192.168.1.100
      User username


### PR DESCRIPTION
Removes horizontal scroll bar from long code lines.

See System Prompt page for an example:

<img width="737" height="466" alt="Horizontal scrolling in System Prompt page" src="https://github.com/user-attachments/assets/6cce96b1-9153-4446-9270-3ab4b7eab992" />


This also includes a small change in VS Code extensions page, that removes `[mdbook-shiki] Language 'ssh' not available, skipping` error message.