### PR TITLE
🤖 feat: add Cmd+, / Ctrl+, keybinding to open settings

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -462,6 +462,9 @@ function AppInner() {
       } else if (matchesKeybind(e, KEYBINDS.TOGGLE_SIDEBAR)) {
         e.preventDefault();
         setSidebarCollapsed((prev) => !prev);
+      } else if (matchesKeybind(e, KEYBINDS.OPEN_SETTINGS)) {
+        e.preventDefault();
+        openSettings();
       }
     };
 
@@ -473,6 +476,7 @@ function AppInner() {
     isCommandPaletteOpen,
     closeCommandPalette,
     openCommandPalette,
+    openSettings,
   ]);
 
   // Handle workspace fork switch event

--- a/src/browser/components/SettingsButton.tsx
+++ b/src/browser/components/SettingsButton.tsx
@@ -1,6 +1,7 @@
 import { Settings } from "lucide-react";
 import { useSettings } from "@/browser/contexts/SettingsContext";
 import { TooltipWrapper, Tooltip } from "./Tooltip";
+import { formatKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
 
 export function SettingsButton() {
   const { open } = useSettings();
@@ -16,7 +17,7 @@ export function SettingsButton() {
       >
         <Settings className="h-3.5 w-3.5" aria-hidden />
       </button>
-      <Tooltip align="right">Settings</Tooltip>
+      <Tooltip align="right">Settings ({formatKeybind(KEYBINDS.OPEN_SETTINGS)})</Tooltip>
     </TooltipWrapper>
   );
 }

--- a/src/browser/utils/ui/keybinds.ts
+++ b/src/browser/utils/ui/keybinds.ts
@@ -281,4 +281,8 @@ export const KEYBINDS = {
 
   /** Toggle hunk expand/collapse in Code Review panel */
   TOGGLE_HUNK_COLLAPSE: { key: " " },
+
+  /** Open settings modal */
+  // macOS: Cmd+, Win/Linux: Ctrl+,
+  OPEN_SETTINGS: { key: ",", ctrl: true },
 } as const;


### PR DESCRIPTION
_Generated with `mux`_

Adds keyboard shortcut to open the settings modal:
- macOS: ⌘,
- Windows/Linux: Ctrl+,

Also updates the settings button tooltip to show the shortcut.