### PR TITLE
🤖 docs: require static-check before pushing to PRs

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -156,6 +156,7 @@ Avoid mock-heavy tests that verify implementation details rather than behavior. 
 ## Mode: Exec
 
 - Treat as a standing order: keep running checks and addressing failures until they pass or a blocker outside your control arises.
+- **Before pushing to a PR**, run `make static-check` locally and ensure all checks pass. Fix issues with `make fmt` or manual edits. Never push until local checks are green.
 - Reproduce remote static-check failures locally with `make static-check`; fix formatting with `make fmt` before rerunning CI.
 - When CI fails, reproduce locally with the smallest relevant command; log approximate runtimes to optimize future loops.
 


### PR DESCRIPTION
Add explicit instruction in Mode: Exec to run `make static-check` locally before pushing changes. This makes the requirement proactive rather than only reactive to CI failures.

_Generated with `mux`_