### PR TITLE
🤖 feat: add mux-gateway provider

### DIFF
--- a/src/browser/components/Settings/sections/ProvidersSection.tsx
+++ b/src/browser/components/Settings/sections/ProvidersSection.tsx
@@ -44,6 +44,13 @@ function getProviderFields(provider: ProviderName): FieldConfig[] {
     ];
   }
 
+  // Mux Gateway only needs couponCode
+  if (provider === "mux-gateway") {
+    return [
+      { key: "couponCode", label: "Coupon Code", placeholder: "Enter coupon code", type: "secret" },
+    ];
+  }
+
   // Default for most providers
   return [
     { key: "apiKey", label: "API Key", placeholder: "Enter API key", type: "secret" },
@@ -138,6 +145,11 @@ export function ProvidersSection() {
       );
     }
 
+    // For Mux Gateway, check couponCodeSet
+    if (provider === "mux-gateway") {
+      return providerConfig.couponCodeSet ?? false;
+    }
+
     // For other providers, check apiKeySet
     return providerConfig.apiKeySet ?? false;
   };
@@ -153,6 +165,8 @@ export function ProvidersSection() {
     if (fieldConfig.type === "secret") {
       // For apiKey, we have apiKeySet from the sanitized config
       if (field === "apiKey") return config[provider]?.apiKeySet ?? false;
+      // For couponCode (mux-gateway), check couponCodeSet
+      if (field === "couponCode") return config[provider]?.couponCodeSet ?? false;
       // For other secrets, check if the field exists in the raw config
       // Since we don't expose secret values, we assume they're not set if undefined
       const providerConfig = config[provider] as Record<string, unknown> | undefined;

--- a/src/browser/components/Settings/types.ts
+++ b/src/browser/components/Settings/types.ts
@@ -16,6 +16,8 @@ export interface ProviderConfigDisplay {
   bearerTokenSet?: boolean;
   accessKeyIdSet?: boolean;
   secretAccessKeySet?: boolean;
+  // Mux Gateway-specific fields
+  couponCodeSet?: boolean;
   // Allow additional fields for extensibility
   [key: string]: unknown;
 }

--- a/src/common/constants/providers.ts
+++ b/src/common/constants/providers.ts
@@ -56,6 +56,13 @@ export async function importBedrock() {
 }
 
 /**
+ * Dynamically import the Gateway provider from the AI SDK
+ */
+export async function importMuxGateway() {
+  return import("ai");
+}
+
+/**
  * Centralized provider registry mapping provider names to their import functions
  *
  * This is the single source of truth for supported providers. By mapping to import
@@ -76,6 +83,7 @@ export const PROVIDER_REGISTRY = {
   ollama: importOllama,
   openrouter: importOpenRouter,
   bedrock: importBedrock,
+  "mux-gateway": importMuxGateway,
 } as const;
 
 /**
@@ -99,6 +107,7 @@ export const PROVIDER_DISPLAY_NAMES: Record<ProviderName, string> = {
   ollama: "Ollama",
   openrouter: "OpenRouter",
   bedrock: "Amazon Bedrock",
+  "mux-gateway": "Mux Gateway",
 };
 
 /**

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -656,6 +656,25 @@ export class AIService extends EventEmitter {
         return Ok(provider(modelId));
       }
 
+      // Handle Mux Gateway provider
+      if (providerName === "mux-gateway") {
+        // Mux Gateway uses couponCode as the API key
+        const couponCode = providerConfig.couponCode;
+        if (typeof couponCode !== "string" || !couponCode) {
+          return Err({
+            type: "api_key_not_found",
+            provider: providerName,
+          });
+        }
+
+        const { createGateway } = await PROVIDER_REGISTRY["mux-gateway"]();
+        const gateway = createGateway({
+          apiKey: couponCode,
+          baseURL: "https://gateway.mux.coder.com/api/v1/ai-gateway/v1/ai",
+        });
+        return Ok(gateway(modelId));
+      }
+
       return Err({
         type: "provider_not_supported",
         provider: providerName,


### PR DESCRIPTION
Add new `mux-gateway` provider that uses `createGateway` from the AI SDK.

## Configuration

In `~/.mux/providers.jsonc`:
```jsonc
{
  "mux-gateway": {
    "couponCode": "your-coupon-code-here"
  }
}
```

Then use models like `mux-gateway:claude-3-5-sonnet-20241022`.

## Changes

- Add `importMuxGateway()` and registry entry in `providers.ts`
- Add `mux-gateway` handler in `aiService.ts` using hardcoded baseURL
- Add `couponCodeSet` field to settings UI (no baseUrl field exposed)
- Update schemas and types for the new provider

_Generated with `mux`_