### PR TITLE
🤖 fix: use ResultSchema for sendMessage output to prevent field stripping

### DIFF
--- a/src/browser/components/ChatInput/useCreationWorkspace.test.tsx
+++ b/src/browser/components/ChatInput/useCreationWorkspace.test.tsx
@@ -138,14 +138,16 @@ const setupWindow = ({ listBranches, sendMessage }: SetupWindowOptions = {}) => 
       if (!args.workspaceId) {
         return Promise.resolve({
           success: true,
-          workspaceId: TEST_WORKSPACE_ID,
-          metadata: TEST_METADATA,
+          data: {
+            workspaceId: TEST_WORKSPACE_ID,
+            metadata: TEST_METADATA,
+          },
         } satisfies WorkspaceSendMessageResult);
       }
 
       const existingWorkspaceResult: WorkspaceSendMessageResult = {
         success: true,
-        data: undefined,
+        data: {},
       };
       return Promise.resolve(existingWorkspaceResult);
     });
@@ -357,8 +359,10 @@ describe("useCreationWorkspace", () => {
       (_args: WorkspaceSendMessageArgs): Promise<WorkspaceSendMessageResult> =>
         Promise.resolve({
           success: true as const,
-          workspaceId: TEST_WORKSPACE_ID,
-          metadata: TEST_METADATA,
+          data: {
+            workspaceId: TEST_WORKSPACE_ID,
+            metadata: TEST_METADATA,
+          },
         })
     );
     const { workspaceApi } = setupWindow({

--- a/src/browser/components/ChatInput/useCreationWorkspace.ts
+++ b/src/browser/components/ChatInput/useCreationWorkspace.ts
@@ -128,16 +128,17 @@ export function useCreationWorkspace({
           return false;
         }
 
-        // Check if this is a workspace creation result (has metadata field)
-        if ("metadata" in result && result.metadata) {
-          syncCreationPreferences(projectPath, result.metadata.id);
+        // Check if this is a workspace creation result (has metadata in data)
+        const { metadata } = result.data;
+        if (metadata) {
+          syncCreationPreferences(projectPath, metadata.id);
           if (projectPath) {
             const pendingInputKey = getInputKey(getPendingScopeId(projectPath));
             updatePersistedState(pendingInputKey, "");
           }
           // Settings are already persisted via useDraftWorkspaceSettings
           // Notify parent to switch workspace (clears input via parent unmount)
-          onWorkspaceCreated(result.metadata);
+          onWorkspaceCreated(metadata);
           setIsSending(false);
           return true;
         } else {

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -167,14 +167,13 @@ export const workspace = {
         trunkBranch: z.string().optional(),
       }).optional(),
     }),
-    output: z.union([
-      ResultSchema(z.void(), SendMessageErrorSchema),
+    output: ResultSchema(
       z.object({
-        success: z.literal(true),
-        workspaceId: z.string(),
-        metadata: FrontendWorkspaceMetadataSchema,
+        workspaceId: z.string().optional(),
+        metadata: FrontendWorkspaceMetadataSchema.optional(),
       }),
-    ]),
+      SendMessageErrorSchema
+    ),
   },
   resumeStream: {
     input: z.object({

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -453,6 +453,7 @@ export class WorkspaceService extends EventEmitter {
 
       const allMetadata = await this.config.getAllWorkspaceMetadata();
       const completeMetadata = allMetadata.find((m) => m.id === workspaceId);
+
       if (!completeMetadata) {
         return { success: false, error: "Failed to retrieve workspace metadata" };
       }

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -132,12 +132,12 @@ export async function sendMessage(
     return { success: false, error: { type: "unknown", raw } };
   }
 
-  if (result.success && "workspaceId" in result) {
-    // Lazy workspace creation path returns metadata/workspaceId; normalize to void success for callers
+  // Normalize to Result<void> for callers - they just care about success/failure
+  if (result.success) {
     return { success: true, data: undefined };
   }
 
-  return result;
+  return { success: false, error: result.error };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix workspace creation failing with "Unexpected response from server" due to Zod schema union ordering
- `z.union()` was matching `ResultSchema(z.void())` first, which stripped `workspaceId`/`metadata` as "extra keys"
- Replaced with single `ResultSchema` using optional fields for consistent response shape

## Test plan
- [x] `make typecheck` passes
- [x] `useCreationWorkspace.test.tsx` tests pass
- [x] Manual test: create new workspace from scratch - should navigate to workspace instead of showing error toast

_Generated with `mux`_