### PR TITLE
🤖 perf: fix streaming content delay from ORPC schema validation

### DIFF
--- a/src/common/orpc/schemas/stream.ts
+++ b/src/common/orpc/schemas/stream.ts
@@ -225,8 +225,11 @@ export const RestoreToInputEventSchema = z.object({
   imageParts: z.array(ImagePartSchema).optional(),
 });
 
+// Order matters: z.union() tries schemas in order until one passes.
+// Put discriminatedUnion first since streaming events (stream-delta, etc.)
+// are most frequent and have a `type` field for O(1) lookup.
+// MuxMessageSchema lacks `type`, so trying it first caused validation overhead.
 export const WorkspaceChatMessageSchema = z.union([
-  MuxMessageSchema,
   z.discriminatedUnion("type", [
     CaughtUpMessageSchema,
     StreamErrorMessageSchema,
@@ -241,9 +244,11 @@ export const WorkspaceChatMessageSchema = z.union([
     ReasoningDeltaEventSchema,
     ReasoningEndEventSchema,
     UsageDeltaEventSchema,
+    QueuedMessageChangedEventSchema,
+    RestoreToInputEventSchema,
   ]),
   WorkspaceInitEventSchema,
-  z.discriminatedUnion("type", [QueuedMessageChangedEventSchema, RestoreToInputEventSchema]),
+  MuxMessageSchema,
 ]);
 
 // Update Status


### PR DESCRIPTION
## Problem

After the ORPC migration (commit `3ee72886`), streaming message content appeared delayed:
- ✅ Token count & speed updates live
- ✅ Message item (model name, time) appears immediately  
- ❌ Actual message content is delayed by several seconds


https://github.com/user-attachments/assets/dd8f2810-f766-4af5-a8bb-94fd6c0409a1



## Root Cause: Zod Union Validation Order

ORPC validates every yielded event against `WorkspaceChatMessageSchema`. The schema was defined as:

```typescript
export const WorkspaceChatMessageSchema = z.union([
  MuxMessageSchema,                    // ← Tried FIRST for every event
  z.discriminatedUnion("type", [...]), // ← Streaming events live here
  ...
]);
```

**The problem:** `z.union()` tries each schema in order until one passes.

For every `stream-delta` event (20+ per second during streaming):
1. `MuxMessageSchema` is tried first → **fails** (wrong shape: has `id`/`role`/`parts`, stream-delta has `type`/`messageId`/`delta`)
2. Then `discriminatedUnion` is checked → finds matching `type: "stream-delta"` → passes

This failed validation attempt on `MuxMessageSchema` runs for **every single streaming event**. With rapid deltas, the overhead accumulates and causes visible delay.

### Why Token Count Updated But Content Didn't

Both depend on the same event flow, but token counts are accumulated totals that remain stable once computed. Message content requires constructing new `DisplayedMessage` objects with accumulated text. The validation overhead delayed the entire pipeline, but cumulative metrics (tokens) appeared more responsive than the content itself.

## Solution

Reorder the union to put `discriminatedUnion` first:

```typescript
export const WorkspaceChatMessageSchema = z.union([
  z.discriminatedUnion("type", [...]),  // Most streaming events match here instantly (O(1) lookup)
  WorkspaceInitEventSchema,
  MuxMessageSchema,                      // Full messages only on stream-end/history replay
]);
```

Since streaming events have a `type` field, `discriminatedUnion` provides O(1) lookup - no failed validation attempts.

Also consolidated the two separate `discriminatedUnion` calls into one for cleaner code.

## Changes

- `src/common/orpc/schemas/stream.ts`: Reordered union members, merged discriminated unions, added explanatory comment

---

_Generated with `mux`_