### PR TITLE
(Re-)fix: shiki-shared import path

### DIFF
--- a/scripts/mdbook-shiki.ts
+++ b/scripts/mdbook-shiki.ts
@@ -6,7 +6,7 @@
  */
 
 import { createHighlighter } from "shiki";
-import { SHIKI_THEME, mapToShikiLang, extractShikiLines } from "../src/utils/highlighting/shiki-shared";
+import { SHIKI_DARK_THEME, mapToShikiLang, extractShikiLines } from "../src/browser/utils/highlighting/shiki-shared";
 import { renderToStaticMarkup } from "react-dom/server";
 import { CodeBlockSSR } from "../src/browser/components/Messages/CodeBlockSSR";
 


### PR DESCRIPTION
That got reverted in another revert (a2a417ed).