### PR TITLE
🤖 feat: add clear option for API keys in settings

### DIFF
--- a/src/browser/components/Settings/sections/ProvidersSection.tsx
+++ b/src/browser/components/Settings/sections/ProvidersSection.tsx
@@ -269,7 +269,9 @@ export function ProvidersSection() {
                               : (fieldValue ?? "Default")}
                           </span>
                           <div className="flex gap-2">
-                            {fieldConfig.type === "text" && fieldValue && (
+                            {(fieldConfig.type === "text"
+                              ? !!fieldValue
+                              : fieldConfig.type === "secret" && fieldIsSet) && (
                               <button
                                 type="button"
                                 onClick={() => void handleClearField(provider, fieldConfig.key)}


### PR DESCRIPTION
Adds a "Clear" button for secret fields (API keys, tokens, etc.) in the Providers settings section. Previously this button only appeared for text fields.

_Generated with `mux`_