### PR TITLE
🤖 fix: place Anthropic cache marker on last message

### DIFF
--- a/src/common/utils/ai/cacheStrategy.ts
+++ b/src/common/utils/ai/cacheStrategy.ts
@@ -66,10 +66,10 @@ function addCacheControlToLastContentPart(msg: ModelMessage): ModelMessage {
 
 /**
  * Apply cache control to messages for Anthropic models.
- * Caches all messages except the last user message for optimal cache hits.
+ * Adds a cache marker to the last message so the entire conversation is cached.
  *
  * NOTE: The SDK requires providerOptions on content parts, not on the message.
- * We add cache_control to the last content part of the second-to-last message.
+ * We add cache_control to the last content part of the last message.
  */
 export function applyCacheControl(messages: ModelMessage[], modelString: string): ModelMessage[] {
   // Only apply cache control for Anthropic models
@@ -77,14 +77,13 @@ export function applyCacheControl(messages: ModelMessage[], modelString: string)
     return messages;
   }
 
-  // Need at least 2 messages to add a cache breakpoint
-  if (messages.length < 2) {
+  // Need at least 1 message to add a cache breakpoint
+  if (messages.length < 1) {
     return messages;
   }
 
-  // Add cache breakpoint at the second-to-last message
-  // This caches everything up to (but not including) the current user message
-  const cacheIndex = messages.length - 2;
+  // Add cache breakpoint at the last message
+  const cacheIndex = messages.length - 1;
 
   return messages.map((msg, index) => {
     if (index === cacheIndex) {

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -102,7 +102,7 @@ if (typeof globalFetchWithExtras.certificate === "function") {
  *
  * Injects cache_control on:
  * 1. Last tool (caches all tool definitions)
- * 2. Second-to-last message's last content part (caches conversation history)
+ * 2. Last message's last content part (caches entire conversation)
  */
 function wrapFetchWithAnthropicCacheControl(baseFetch: typeof fetch): typeof fetch {
   const cachingFetch = async (
@@ -123,11 +123,11 @@ function wrapFetchWithAnthropicCacheControl(baseFetch: typeof fetch): typeof fet
         lastTool.cache_control ??= { type: "ephemeral" };
       }
 
-      // Inject cache_control on second-to-last message's last content part
-      // This caches conversation history up to (but not including) the current user message
-      if (Array.isArray(json.messages) && json.messages.length >= 2) {
-        const secondToLastMsg = json.messages[json.messages.length - 2] as Record<string, unknown>;
-        const content = secondToLastMsg.content;
+      // Inject cache_control on last message's last content part
+      // This caches the entire conversation
+      if (Array.isArray(json.messages) && json.messages.length >= 1) {
+        const lastMsg = json.messages[json.messages.length - 1] as Record<string, unknown>;
+        const content = lastMsg.content;
 
         if (Array.isArray(content) && content.length > 0) {
           // Array content: add cache_control to last part


### PR DESCRIPTION
Previously, the Anthropic cache marker was placed on the second-to-last message. This change moves it to the last message so the entire conversation is cached.

_Generated with `mux`_