### PR TITLE
🤖 fix: prevent model selection reset in creation mode

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -253,12 +253,21 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
         }
   );
 
-  // When entering creation mode (or when the default model changes), reset the
-  // project-scoped model to the explicit default so manual picks don't bleed
-  // into subsequent creation flows.
+  // When entering creation mode, initialize the project-scoped model to the
+  // default so previous manual picks don't bleed into new creation flows.
+  // Only runs once per creation session (not when defaultModel changes, which
+  // would clobber the user's intentional model selection).
+  const creationModelInitialized = useRef<string | null>(null);
   useEffect(() => {
     if (variant === "creation" && defaultModel) {
-      updatePersistedState(storageKeys.modelKey, defaultModel);
+      // Only initialize once per project scope
+      if (creationModelInitialized.current !== storageKeys.modelKey) {
+        creationModelInitialized.current = storageKeys.modelKey;
+        updatePersistedState(storageKeys.modelKey, defaultModel);
+      }
+    } else if (variant !== "creation") {
+      // Reset when leaving creation mode so re-entering triggers initialization
+      creationModelInitialized.current = null;
     }
   }, [variant, defaultModel, storageKeys.modelKey]);
 

--- a/src/browser/components/ChatInput/useCreationWorkspace.ts
+++ b/src/browser/components/ChatInput/useCreationWorkspace.ts
@@ -6,7 +6,7 @@ import type { ThinkingLevel } from "@/common/types/thinking";
 import { parseRuntimeString } from "@/browser/utils/chatCommands";
 import { useDraftWorkspaceSettings } from "@/browser/hooks/useDraftWorkspaceSettings";
 import { readPersistedState, updatePersistedState } from "@/browser/hooks/usePersistedState";
-import { useSendMessageOptions } from "@/browser/hooks/useSendMessageOptions";
+import { getSendOptionsFromStorage } from "@/browser/utils/messages/sendOptions";
 import {
   getInputKey,
   getModelKey,
@@ -95,8 +95,8 @@ export function useCreationWorkspace({
     getRuntimeString,
   } = useDraftWorkspaceSettings(projectPath, branches, recommendedTrunk);
 
-  // Get send options from shared hook (uses project-scoped storage key)
-  const sendMessageOptions = useSendMessageOptions(getProjectScopeId(projectPath));
+  // Project scope ID for reading send options at send time
+  const projectScopeId = getProjectScopeId(projectPath);
 
   // Load branches on mount
   useEffect(() => {
@@ -130,6 +130,11 @@ export function useCreationWorkspace({
         const runtimeConfig: RuntimeConfig | undefined = runtimeString
           ? parseRuntimeString(runtimeString, "")
           : undefined;
+
+        // Read send options fresh from localStorage at send time to avoid
+        // race conditions with React state updates (requestAnimationFrame batching
+        // in usePersistedState can delay state updates after model selection)
+        const sendMessageOptions = getSendOptionsFromStorage(projectScopeId);
 
         // Send message with runtime config and creation-specific params
         const result = await api.workspace.sendMessage({
@@ -188,9 +193,9 @@ export function useCreationWorkspace({
       api,
       isSending,
       projectPath,
+      projectScopeId,
       onWorkspaceCreated,
       getRuntimeString,
-      sendMessageOptions,
       settings.trunkBranch,
     ]
   );

--- a/src/browser/utils/messages/sendOptions.ts
+++ b/src/browser/utils/messages/sendOptions.ts
@@ -60,6 +60,7 @@ export function getSendOptionsFromStorage(workspaceId: string): SendMessageOptio
 
   return {
     model,
+    mode: mode === "exec" || mode === "plan" ? mode : "exec", // Only pass exec/plan to backend
     thinkingLevel: effectiveThinkingLevel,
     toolPolicy: modeToToolPolicy(mode),
     additionalSystemInstructions,


### PR DESCRIPTION
There were two issues causing the wrong model to be used when creating workspaces:

1. **Stale React state**: The `handleSend` callback in `useCreationWorkspace` captured `sendMessageOptions` from `useSendMessageOptions`, but that hook's state updates were delayed by `requestAnimationFrame` batching in `usePersistedState`. If the user selected a model and clicked send before the next animation frame, the old model value would be used.

2. **Effect overwriting selection**: The useEffect that initialized the model to the default when entering creation mode could re-run and overwrite the user's selection if `defaultModel` changed for any reason.

**Fixes:**
- Read send options fresh from localStorage at send time using `getSendOptionsFromStorage` instead of relying on potentially-stale React state
- Track initialization state with a ref so the model is only set once per entry into creation mode, not on every `defaultModel` change

Also added `mode` field to `getSendOptionsFromStorage` return value for parity with `useSendMessageOptions`.

_Generated with `mux`_