### PR TITLE
🤖 fix: use undated model IDs for mux-gateway defaults

### DIFF
--- a/src/node/services/ipcMain.ts
+++ b/src/node/services/ipcMain.ts
@@ -1572,8 +1572,8 @@ export class IpcMain {
             const providerConfig = providersConfig[provider] as Record<string, unknown>;
             if (!providerConfig.models || (providerConfig.models as string[]).length === 0) {
               providerConfig.models = [
-                "anthropic/claude-sonnet-4-5-20250514",
-                "anthropic/claude-opus-4-5-20250514",
+                "anthropic/claude-sonnet-4-5",
+                "anthropic/claude-opus-4-5",
                 "openai/gpt-5.1",
                 "openai/gpt-5.1-codex",
               ];


### PR DESCRIPTION
Vercel AI gateway under mux-gateway doesn't support dated model identifiers like `claude-sonnet-4-5-20250514`. Use `claude-sonnet-4-5` and `claude-opus-4-5` instead for the default models added on first coupon entry.

_Generated with `mux`_