### PR TITLE
🤖 refactor: simplify model selector UI

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -144,7 +144,7 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const modelSelectorRef = useRef<ModelSelectorRef>(null);
   const [mode, setMode] = useMode();
-  const { recentModels, addModel, evictModel, defaultModel, setDefaultModel } = useModelLRU();
+  const { recentModels, addModel, defaultModel, setDefaultModel } = useModelLRU();
   const commandListId = useId();
   const telemetry = useTelemetry();
   const [vimEnabled, setVimEnabled] = usePersistedState<boolean>(VIM_ENABLED_KEY, false, {
@@ -904,7 +904,6 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
                   value={preferredModel}
                   onChange={setPreferredModel}
                   recentModels={recentModels}
-                  onRemoveModel={evictModel}
                   onComplete={() => inputRef.current?.focus()}
                   defaultModel={defaultModel}
                   onSetDefaultModel={setDefaultModel}

--- a/src/browser/components/ModelSelector.stories.tsx
+++ b/src/browser/components/ModelSelector.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { ModelSelector } from "./ModelSelector";
 import { action } from "storybook/actions";
+import { SettingsProvider } from "@/browser/contexts/SettingsContext";
 
 const meta = {
   title: "Components/ModelSelector",
@@ -9,6 +10,13 @@ const meta = {
     layout: "padded",
   },
   tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <SettingsProvider>
+        <Story />
+      </SettingsProvider>
+    ),
+  ],
   argTypes: {
     value: {
       control: { type: "text" },
@@ -17,10 +25,6 @@ const meta = {
     onChange: {
       control: false,
       description: "Callback when model changes",
-    },
-    onRemoveModel: {
-      control: false,
-      description: "Callback when a model is removed",
     },
     recentModels: {
       control: { type: "object" },
@@ -40,7 +44,6 @@ export const Default: Story = {
   args: {
     value: "anthropic:claude-sonnet-4-5",
     onChange: action("onChange"),
-    onRemoveModel: action("onRemoveModel"),
     recentModels: ["anthropic:claude-sonnet-4-5", "anthropic:claude-opus-4-1", "openai:gpt-5-pro"],
     onComplete: action("onComplete"),
   },
@@ -50,7 +53,6 @@ export const LongModelName: Story = {
   args: {
     value: "anthropic:claude-opus-4-20250514-preview-experimental",
     onChange: action("onChange"),
-    onRemoveModel: action("onRemoveModel"),
     recentModels: [
       "anthropic:claude-opus-4-20250514-preview-experimental",
       "anthropic:claude-sonnet-4-20250514-preview-experimental",
@@ -64,7 +66,6 @@ export const WithManyModels: Story = {
   args: {
     value: "anthropic:claude-sonnet-4-5",
     onChange: action("onChange"),
-    onRemoveModel: action("onRemoveModel"),
     recentModels: [
       "anthropic:claude-sonnet-4-5",
       "anthropic:claude-opus-4-1",
@@ -82,7 +83,6 @@ export const WithDefaultModel: Story = {
   args: {
     value: "anthropic:claude-sonnet-4-5",
     onChange: action("onChange"),
-    onRemoveModel: action("onRemoveModel"),
     recentModels: ["anthropic:claude-sonnet-4-5", "anthropic:claude-opus-4-1", "openai:gpt-5-pro"],
     onComplete: action("onComplete"),
     defaultModel: "anthropic:claude-opus-4-1",


### PR DESCRIPTION
- Remove add/remove model capabilities from dropdown (use Settings instead)
- Keep favorites (star) functionality
- Add gear icon to open Settings → Models tab
- Only allow selecting from existing models
- `/model` command validates provider and auto-adds new models via settings API
- Show "No matching models" in dropdown when filter has no results

_Generated with `mux`_