### PR TITLE
🤖 fix: remove watch depth limit breaking HMR for nested files

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -103,9 +103,6 @@ export default defineConfig(({ mode }) => ({
       // If using polling, set a reasonable interval (in milliseconds)
       interval: 1000,
       
-      // Limit the depth of directory traversal
-      depth: 3,
-      
       // Additional options for Windows specifically
       ...(process.platform === 'win32' && {
         // Increase the binary interval for better Windows performance


### PR DESCRIPTION
The `depth: 3` setting added in #540 for Windows compatibility prevents Vite from detecting changes in directories deeper than 3 levels. Source files go up to 6 levels deep (e.g., `src/browser/components/Settings/sections/`).

This broke HMR for most component files during `make dev`.

The other Windows-specific settings (polling, awaitWriteFinish) remain in place - only the depth restriction is removed.

cc @ibetitsmike

_Generated with `mux`_