### PR TITLE
🤖 fix: align favorite star icon with edit/delete buttons in model settings

### DIFF
--- a/src/browser/components/Tooltip.tsx
+++ b/src/browser/components/Tooltip.tsx
@@ -46,7 +46,7 @@ export const TooltipWrapper: React.FC<TooltipWrapperProps> = ({ inline = false, 
     <TooltipContext.Provider value={{ isHovered, setIsHovered, triggerRef }}>
       <span
         ref={triggerRef}
-        className={cn("relative", inline ? "inline-block" : "block")}
+        className={cn("relative", inline ? "inline-flex items-center" : "block")}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
       >


### PR DESCRIPTION
_Generated with `mux`_

Changed `TooltipWrapper` inline mode from `inline-block` to `inline-flex items-center` to properly center-align wrapped buttons within flex containers.

This fixes the misaligned favorite star icon in the Models settings tab - now aligns with the edit and delete buttons on both custom and built-in model rows.