### PR TITLE
🤖 fix: dispatch providers-config-changed on coupon save

### DIFF
--- a/src/browser/components/Settings/sections/ProvidersSection.tsx
+++ b/src/browser/components/Settings/sections/ProvidersSection.tsx
@@ -116,6 +116,9 @@ export function ProvidersSection() {
       setConfig(cfg);
       setEditingField(null);
       setEditValue("");
+
+      // Notify other components about the change
+      window.dispatchEvent(new Event("providers-config-changed"));
     } finally {
       setSaving(false);
     }
@@ -127,6 +130,9 @@ export function ProvidersSection() {
       await window.api.providers.setProviderConfig(provider, [field], "");
       const cfg = await window.api.providers.getConfig();
       setConfig(cfg);
+
+      // Notify other components about the change
+      window.dispatchEvent(new Event("providers-config-changed"));
     } finally {
       setSaving(false);
     }


### PR DESCRIPTION
ProvidersSection was not notifying useModelLRU when provider configs (like mux-gateway coupon) were saved. This caused mux-gateway models to only appear after navigating away and back to ChatInput.

Now dispatches `providers-config-changed` after saves, matching ModelsSection.

_Generated with `mux`_