### PR TITLE
🤖 fix: add NON_INTERACTIVE_ENV_VARS to SSHRuntime.exec()

### DIFF
--- a/tests/runtime/runtime.test.ts
+++ b/tests/runtime/runtime.test.ts
@@ -113,6 +113,21 @@ describeIntegration("Runtime integration tests", () => {
           expect(result.stdout.trim()).toBe("test-value");
         });
 
+        test.concurrent("sets NON_INTERACTIVE_ENV_VARS to prevent prompts", async () => {
+          const runtime = createRuntime();
+          await using workspace = await TestWorkspace.create(runtime, type);
+
+          // Verify GIT_TERMINAL_PROMPT is set to 0 (prevents credential prompts)
+          const result = await execBuffered(
+            runtime,
+            'echo "GIT_TERMINAL_PROMPT=$GIT_TERMINAL_PROMPT GIT_EDITOR=$GIT_EDITOR"',
+            { cwd: workspace.path, timeout: 30 }
+          );
+
+          expect(result.stdout).toContain("GIT_TERMINAL_PROMPT=0");
+          expect(result.stdout).toContain("GIT_EDITOR=true");
+        });
+
         test.concurrent("handles empty output", async () => {
           const runtime = createRuntime();
           await using workspace = await TestWorkspace.create(runtime, type);


### PR DESCRIPTION
_Generated with `mux`_

Prevents git operations from blocking on editor/credential prompts when running in SSH workspaces, matching LocalRuntime behavior.

## Changes
- Import and apply `NON_INTERACTIVE_ENV_VARS` in `SSHRuntime.exec()`
- Add test verifying env vars are set for both runtime types

## Before
`SSHRuntime.exec()` only exported `options.env`, so SSH workspaces could hang when git tried to open an editor or prompt for credentials.

## After
Both `LocalRuntime` and `SSHRuntime` now apply `NON_INTERACTIVE_ENV_VARS` (`GIT_EDITOR`, `GIT_TERMINAL_PROMPT`, etc.) to prevent blocking prompts.