### PR TITLE
🤖 feat: add Settings to macOS menu bar

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -479,6 +479,14 @@ function AppInner() {
     openSettings,
   ]);
 
+  // Subscribe to menu bar "Open Settings" (macOS Cmd+, from app menu)
+  useEffect(() => {
+    const unsubscribe = window.api.menu?.onOpenSettings(() => {
+      openSettings();
+    });
+    return () => unsubscribe?.();
+  }, [openSettings]);
+
   // Handle workspace fork switch event
   useEffect(() => {
     const handleForkSwitch = (e: Event) => {

--- a/src/common/constants/ipc-constants.ts
+++ b/src/common/constants/ipc-constants.ts
@@ -50,6 +50,9 @@ export const IPC_CHANNELS = {
   // Window channels
   WINDOW_SET_TITLE: "window:setTitle",
 
+  // Menu channels (main -> renderer)
+  MENU_OPEN_SETTINGS: "menu:openSettings",
+
   // Debug channels (for testing only)
   DEBUG_TRIGGER_STREAM_ERROR: "debug:triggerStreamError",
 

--- a/src/common/types/ipc.ts
+++ b/src/common/types/ipc.ts
@@ -377,6 +377,9 @@ export interface IPCApi {
     install(): void;
     onStatus(callback: (status: UpdateStatus) => void): () => void;
   };
+  menu?: {
+    onOpenSettings(callback: () => void): () => void;
+  };
   server?: {
     getLaunchProject(): Promise<string | null>;
   };

--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -187,6 +187,16 @@ function createMenu() {
       submenu: [
         { role: "about" },
         { type: "separator" },
+        {
+          label: "Settings...",
+          accelerator: "Cmd+,",
+          click: () => {
+            if (mainWindow) {
+              mainWindow.webContents.send(IPC_CHANNELS.MENU_OPEN_SETTINGS);
+            }
+          },
+        },
+        { type: "separator" },
         { role: "services", submenu: [] },
         { type: "separator" },
         { role: "hide" },

--- a/src/desktop/preload.ts
+++ b/src/desktop/preload.ts
@@ -210,6 +210,13 @@ const api: IPCApi = {
     closeWindow: (workspaceId: string) =>
       ipcRenderer.invoke(IPC_CHANNELS.TERMINAL_WINDOW_CLOSE, workspaceId),
   },
+  menu: {
+    onOpenSettings: (callback: () => void) => {
+      const handler = () => callback();
+      ipcRenderer.on(IPC_CHANNELS.MENU_OPEN_SETTINGS, handler);
+      return () => ipcRenderer.removeListener(IPC_CHANNELS.MENU_OPEN_SETTINGS, handler);
+    },
+  },
 };
 
 // Expose the API along with platform/versions


### PR DESCRIPTION
Adds a Settings menu item to the macOS application menu (`Cmd+,`) for easier access to the settings modal.

Closes #810

_Generated with `mux`_