### PR TITLE
🤖 refactor: rename coupon code to voucher for mux-gateway

### DIFF
--- a/src/browser/components/Settings/sections/ProvidersSection.tsx
+++ b/src/browser/components/Settings/sections/ProvidersSection.tsx
@@ -45,11 +45,9 @@ function getProviderFields(provider: ProviderName): FieldConfig[] {
     ];
   }
 
-  // Mux Gateway only needs couponCode
+  // Mux Gateway only needs voucher
   if (provider === "mux-gateway") {
-    return [
-      { key: "couponCode", label: "Coupon Code", placeholder: "Enter coupon code", type: "secret" },
-    ];
+    return [{ key: "voucher", label: "Voucher", placeholder: "Enter voucher", type: "secret" }];
   }
 
   // Default for most providers
@@ -152,9 +150,9 @@ export function ProvidersSection() {
       );
     }
 
-    // For Mux Gateway, check couponCodeSet
+    // For Mux Gateway, check voucherSet
     if (provider === "mux-gateway") {
-      return providerConfig.couponCodeSet ?? false;
+      return providerConfig.voucherSet ?? false;
     }
 
     // For other providers, check apiKeySet
@@ -172,8 +170,8 @@ export function ProvidersSection() {
     if (fieldConfig.type === "secret") {
       // For apiKey, we have apiKeySet from the sanitized config
       if (field === "apiKey") return config[provider]?.apiKeySet ?? false;
-      // For couponCode (mux-gateway), check couponCodeSet
-      if (field === "couponCode") return config[provider]?.couponCodeSet ?? false;
+      // For voucher (mux-gateway), check voucherSet
+      if (field === "voucher") return config[provider]?.voucherSet ?? false;
       // For other secrets, check if the field exists in the raw config
       // Since we don't expose secret values, we assume they're not set if undefined
       const providerConfig = config[provider] as Record<string, unknown> | undefined;

--- a/src/browser/components/Settings/types.ts
+++ b/src/browser/components/Settings/types.ts
@@ -17,7 +17,7 @@ export interface ProviderConfigDisplay {
   accessKeyIdSet?: boolean;
   secretAccessKeySet?: boolean;
   // Mux Gateway-specific fields
-  couponCodeSet?: boolean;
+  voucherSet?: boolean;
   // Allow additional fields for extensibility
   [key: string]: unknown;
 }

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -724,9 +724,9 @@ export class AIService extends EventEmitter {
 
       // Handle Mux Gateway provider
       if (providerName === "mux-gateway") {
-        // Mux Gateway uses couponCode as the API key
-        const couponCode = providerConfig.couponCode;
-        if (typeof couponCode !== "string" || !couponCode) {
+        // Mux Gateway uses voucher as the API key (fallback to legacy couponCode)
+        const voucher = providerConfig.voucher ?? providerConfig.couponCode;
+        if (typeof voucher !== "string" || !voucher) {
           return Err({
             type: "api_key_not_found",
             provider: providerName,
@@ -746,7 +746,7 @@ export class AIService extends EventEmitter {
         const gatewayBaseURL =
           providerConfig.baseURL ?? "https://gateway.mux.coder.com/api/v1/ai-gateway/v1/ai";
         const gateway = createGateway({
-          apiKey: couponCode,
+          apiKey: voucher,
           baseURL: gatewayBaseURL,
           fetch: fetchWithCacheControl,
         });

--- a/src/node/services/ipcMain.ts
+++ b/src/node/services/ipcMain.ts
@@ -1536,13 +1536,13 @@ export class IpcMain {
           // Load current providers config or create empty
           const providersConfig = this.config.loadProvidersConfig() ?? {};
 
-          // Track if this is first time setting couponCode for mux-gateway
-          const isFirstMuxGatewayCoupon =
+          // Track if this is first time setting voucher for mux-gateway
+          const isFirstMuxGatewayVoucher =
             provider === "mux-gateway" &&
             keyPath.length === 1 &&
-            keyPath[0] === "couponCode" &&
+            keyPath[0] === "voucher" &&
             value !== "" &&
-            !providersConfig[provider]?.couponCode;
+            !providersConfig[provider]?.voucher;
 
           // Ensure provider exists
           if (!providersConfig[provider]) {
@@ -1570,7 +1570,7 @@ export class IpcMain {
           }
 
           // Add default models when setting up mux-gateway for the first time
-          if (isFirstMuxGatewayCoupon) {
+          if (isFirstMuxGatewayVoucher) {
             const providerConfig = providersConfig[provider] as Record<string, unknown>;
             if (!providerConfig.models || (providerConfig.models as string[]).length === 0) {
               providerConfig.models = [
@@ -1652,9 +1652,9 @@ export class IpcMain {
             providerData.secretAccessKeySet = !!providerConfig.secretAccessKey;
           }
 
-          // Mux Gateway-specific fields
+          // Mux Gateway-specific fields (fallback to legacy couponCode)
           if (provider === "mux-gateway") {
-            providerData.couponCodeSet = !!providerConfig.couponCode;
+            providerData.voucherSet = !!(providerConfig.voucher ?? providerConfig.couponCode);
           }
 
           sanitized[provider] = providerData;


### PR DESCRIPTION
Renames all 'coupon code' references to 'voucher' for mux-gateway provider.

_Generated with `mux`_