### PR TITLE
🤖 fix: buffer terminal output until client subscribes

### DIFF
--- a/src/browser/api.ts
+++ b/src/browser/api.ts
@@ -343,7 +343,11 @@ const webApi: IPCApi = {
     onOutput: (sessionId: string, callback: (data: string) => void) => {
       // Subscribe to terminal output events via WebSocket
       const channel = `terminal:output:${sessionId}`;
-      return wsManager.on(channel, callback as (data: unknown) => void);
+      const unsubscribe = wsManager.on(channel, callback as (data: unknown) => void);
+      // Tell server we're ready to receive output - this flushes any buffered output
+      // that arrived before we registered our handler (fixes first prompt issue)
+      void invokeIPC(IPC_CHANNELS.TERMINAL_SUBSCRIBE, sessionId);
+      return unsubscribe;
     },
     onExit: (sessionId: string, callback: (exitCode: number) => void) => {
       // Subscribe to terminal exit events via WebSocket

--- a/src/common/constants/ipc-constants.ts
+++ b/src/common/constants/ipc-constants.ts
@@ -44,6 +44,7 @@ export const IPC_CHANNELS = {
   TERMINAL_CLOSE: "terminal:close",
   TERMINAL_RESIZE: "terminal:resize",
   TERMINAL_INPUT: "terminal:input",
+  TERMINAL_SUBSCRIBE: "terminal:subscribe",
   TERMINAL_WINDOW_OPEN: "terminal:window:open",
   TERMINAL_WINDOW_CLOSE: "terminal:window:close",
 

--- a/src/desktop/preload.ts
+++ b/src/desktop/preload.ts
@@ -193,6 +193,8 @@ const api: IPCApi = {
       const channel = `terminal:output:${sessionId}`;
       const handler = (_event: unknown, data: string) => callback(data);
       ipcRenderer.on(channel, handler);
+      // Tell server we're ready to receive output - flushes any buffered output
+      void ipcRenderer.invoke(IPC_CHANNELS.TERMINAL_SUBSCRIBE, sessionId);
       return () => ipcRenderer.removeListener(channel, handler);
     },
     onExit: (sessionId: string, callback: (exitCode: number) => void) => {

--- a/src/node/services/ipcMain.ts
+++ b/src/node/services/ipcMain.ts
@@ -1905,6 +1905,18 @@ export class IpcMain {
       }
     });
 
+    // Subscribe to terminal output (flushes buffered output)
+    // In browser mode, output is buffered until the client subscribes to avoid
+    // losing initial output (like the shell prompt) during the HTTP round-trip.
+    ipcMain.handle(IPC_CHANNELS.TERMINAL_SUBSCRIBE, (_event, sessionId: string) => {
+      try {
+        this.ptyService.subscribeOutput(sessionId);
+      } catch (err) {
+        log.error("Error subscribing to terminal:", err);
+        throw err;
+      }
+    });
+
     ipcMain.handle(IPC_CHANNELS.TERMINAL_WINDOW_OPEN, async (_event, workspaceId: string) => {
       console.log(`[BACKEND] TERMINAL_WINDOW_OPEN handler called with: ${workspaceId}`);
       try {


### PR DESCRIPTION
In server mode, there was a race condition where the shell prompt would be lost because the PTY started emitting output before the HTTP response (with session ID) returned and before the client registered its WebSocket handler.

**The fix adds output buffering on the server side:**
- PTY output is buffered in the session until client subscribes
- New `TERMINAL_SUBSCRIBE` IPC channel to signal readiness
- Client calls subscribe after registering its output handler
- Server flushes buffered output when subscribe is called

This ensures the initial shell prompt is always delivered to the terminal.

_Generated with `mux`_