### PR TITLE
🤖 fix: persist status URL across sessions via localStorage

### DIFF
--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -685,8 +685,8 @@ export class WorkspaceStore {
     createdAt: string
   ): StreamingMessageAggregator {
     if (!this.aggregators.has(workspaceId)) {
-      // Create new aggregator with required createdAt
-      this.aggregators.set(workspaceId, new StreamingMessageAggregator(createdAt));
+      // Create new aggregator with required createdAt and workspaceId for localStorage persistence
+      this.aggregators.set(workspaceId, new StreamingMessageAggregator(createdAt, workspaceId));
       this.workspaceCreatedAt.set(workspaceId, createdAt);
     }
 

--- a/src/browser/utils/messages/StreamingMessageAggregator.status.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.status.test.ts
@@ -759,4 +759,73 @@ describe("StreamingMessageAggregator - Agent Status", () => {
     expect(finalStatus?.message).toBe("Tests passed");
     expect(finalStatus?.url).toBe(testUrl); // URL from previous stream persists!
   });
+
+  it("should persist URL across multiple assistant messages when loading from history", () => {
+    // Regression test: URL should persist even when only the most recent assistant message
+    // has a status_set without a URL - the URL from an earlier message should be used
+    const aggregator = new StreamingMessageAggregator("2024-01-01T00:00:00.000Z");
+    const testUrl = "https://github.com/owner/repo/pull/123";
+
+    // Historical messages: first assistant sets URL, second assistant updates status without URL
+    const historicalMessages = [
+      {
+        id: "user1",
+        role: "user" as const,
+        parts: [{ type: "text" as const, text: "Make a PR" }],
+        metadata: { timestamp: 1000, historySequence: 1 },
+      },
+      {
+        id: "assistant1",
+        role: "assistant" as const,
+        parts: [
+          {
+            type: "dynamic-tool" as const,
+            toolName: "status_set",
+            toolCallId: "tool1",
+            state: "output-available" as const,
+            input: { emoji: "🔗", message: "PR submitted", url: testUrl },
+            output: { success: true, emoji: "🔗", message: "PR submitted", url: testUrl },
+            timestamp: 1001,
+            tokens: 10,
+          },
+        ],
+        metadata: { timestamp: 1001, historySequence: 2 },
+      },
+      {
+        id: "user2",
+        role: "user" as const,
+        parts: [{ type: "text" as const, text: "Continue" }],
+        metadata: { timestamp: 2000, historySequence: 3 },
+      },
+      {
+        id: "assistant2",
+        role: "assistant" as const,
+        parts: [
+          {
+            type: "dynamic-tool" as const,
+            toolName: "status_set",
+            toolCallId: "tool2",
+            state: "output-available" as const,
+            input: { emoji: "✅", message: "Tests passed" },
+            output: { success: true, emoji: "✅", message: "Tests passed" }, // No URL!
+            timestamp: 2001,
+            tokens: 10,
+          },
+        ],
+        metadata: { timestamp: 2001, historySequence: 4 },
+      },
+    ];
+
+    aggregator.loadHistoricalMessages(historicalMessages);
+
+    const status = aggregator.getAgentStatus();
+    expect(status?.emoji).toBe("✅");
+    expect(status?.message).toBe("Tests passed");
+    // URL from the first assistant message should persist!
+    expect(status?.url).toBe(testUrl);
+  });
+
+  // Note: URL persistence through compaction is handled via localStorage,
+  // which is tested in integration tests. The aggregator saves lastStatusUrl
+  // to localStorage when it changes, and loads it on construction.
 });


### PR DESCRIPTION
Status URLs now persist through page reloads and compactions via localStorage.

## Changes
- `StreamingMessageAggregator` takes optional `workspaceId` in constructor
- Saves `lastStatusUrl` to localStorage keyed by workspace when set
- Loads on construction so URL survives history rewrites

Regression introduced in cc64299d.

_Generated with `mux`_