### PR TITLE
🤖 fix: interrupt stream when workspace is deleted

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@coder/cmux",

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -92,6 +92,10 @@ export class AgentSession {
       return;
     }
     this.disposed = true;
+
+    // Stop any active stream (fire and forget - disposal shouldn't block)
+    void this.aiService.stopStream(this.workspaceId, /* abandonPartial */ true);
+
     for (const { event, handler } of this.aiListeners) {
       this.aiService.off(event, handler as never);
     }


### PR DESCRIPTION
When a workspace is deleted while an agent is streaming, the stream wasn't being interrupted and would continue running in the background.

## Fix

Stop any active stream in `AgentSession.dispose()` before cleaning up listeners. This ensures streams are always stopped when the session is disposed, regardless of the disposal trigger.

Uses fire-and-forget semantics since disposal shouldn't block, and abandons the partial since the workspace is being deleted anyway.

---
_Generated with `mux`_