### PR TITLE
🤖 fix: preserve usage data when stream is interrupted

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@coder/cmux",

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -144,6 +144,8 @@ export class WorkspaceStore {
       // Don't reset retry state here - stream might still fail after starting
       // Retry state will be reset on stream-end (successful completion)
       this.states.bump(workspaceId);
+      // Bump usage store so liveUsage is recomputed with new activeStreamId
+      this.usageStore.bump(workspaceId);
     },
     "stream-delta": (workspaceId, aggregator, data) => {
       aggregator.handleStreamDelta(data as never);

--- a/src/common/types/stream.ts
+++ b/src/common/types/stream.ts
@@ -59,7 +59,14 @@ export interface StreamAbortEvent {
   messageId: string;
   // Metadata may contain usage if abort occurred after stream completed processing
   metadata?: {
+    // Total usage across all steps (for cost calculation)
     usage?: LanguageModelV2Usage;
+    // Last step's usage (for context window display - inputTokens = current context size)
+    contextUsage?: LanguageModelV2Usage;
+    // Provider metadata for cost calculation (cache tokens, etc.)
+    providerMetadata?: Record<string, unknown>;
+    // Last step's provider metadata (for context window cache display)
+    contextProviderMetadata?: Record<string, unknown>;
     duration?: number;
   };
   abandonPartial?: boolean;


### PR DESCRIPTION
## Problem

When a stream is interrupted (e.g., by a queued message, user cancellation, or starting a new message), the usage data (breakdown by type and context window) resets to 0.

### Root Causes

**1. AI SDK's `totalUsage` returns zeros on abort**

In `cancelStreamSafely()`, we called `getStreamMetadata()` which awaits the AI SDK's `totalUsage` promise. When a stream is aborted mid-execution, this promise resolves with **zeros** (not `undefined`), so our fallback logic (`totalUsage ?? cumulativeUsage`) never triggered.

**2. `usageStore` cache not invalidated on `stream-start`**

The `MapStore` caches computed usage state. When a new stream starts after an abort:
- `stream-abort` bumps `usageStore` ✓
- `stream-start` only bumped `states`, NOT `usageStore` ✗
- The stale cached value showed `liveUsage` as undefined

## Solution

1. **Use tracked `cumulativeUsage` directly** instead of AI SDK's unreliable `totalUsage` on abort. This is updated on each `finish-step` event (before tool execution), so it has accurate data even when interrupted mid-tool-call.

2. **Bump `usageStore` on `stream-start`** to invalidate the cache when a new stream begins.

### Trade-off

Usage from the **interrupted step** is abandoned. The AI SDK's `finish-step` event fires *before* tool execution begins, so if we abort during tool execution, that step's usage was already recorded. However, if we abort during the model's response generation (before `finish-step`), that partial step's usage is lost. This is acceptable since:
- We can't get reliable data from the SDK for interrupted steps
- Cumulative usage from all *completed* steps is preserved
- The alternative (zeros everywhere) is worse

---
_Generated with `mux`_