### PR TITLE
🤖 fix: show disabled voice button with HTTPS tooltip on insecure contexts

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -1066,6 +1066,7 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
                     state={voiceInput.state}
                     isApiKeySet={voiceInput.isApiKeySet}
                     shouldShowUI={voiceInput.shouldShowUI}
+                    requiresSecureContext={voiceInput.requiresSecureContext}
                     onToggle={voiceInput.toggle}
                     disabled={disabled || isSending}
                   />


### PR DESCRIPTION
_Generated with mux_

When accessing mux over HTTP (non-localhost), `navigator.mediaDevices` is undefined due to browser security restrictions. Previously this caused a crash or hidden button.

Now shows a disabled mic button with tooltip: "Voice input requires a secure connection. Use HTTPS or access via localhost."

Changes:
- Add `requiresSecureContext` flag to `useVoiceInput` hook
- Show disabled button with educational tooltip instead of hiding/crashing
- Prioritize HTTPS message over API key message (check HTTPS first)