### PR TITLE
🤖 feat: add SSH config hosts dropdown

### DIFF
--- a/.storybook/mocks/orpc.ts
+++ b/.storybook/mocks/orpc.ts
@@ -413,5 +413,11 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
         await new Promise(() => {});
       },
     },
+    ssh: {
+      getConfigHosts: async () => ["dev-server", "prod-server", "staging"],
+    },
+    voice: {
+      transcribe: async () => ({ success: false, error: "Not implemented in mock" }),
+    },
   } as unknown as APIClient;
 }

--- a/src/browser/components/ChatInput/CreationControls.tsx
+++ b/src/browser/components/ChatInput/CreationControls.tsx
@@ -7,6 +7,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "../ui/tooltip";
 import { SSHIcon, WorktreeIcon, LocalIcon } from "../icons/RuntimeIcons";
 import { DocsLink } from "../DocsLink";
 import type { WorkspaceNameState } from "@/browser/hooks/useWorkspaceName";
+import { SSHHostInput } from "./SSHHostInput";
 
 interface CreationControlsProps {
   branches: string[];
@@ -296,13 +297,10 @@ export function CreationControls(props: CreationControlsProps) {
           {props.runtimeMode === RUNTIME_MODE.SSH && (
             <div className="flex items-center gap-2">
               <label className="text-muted-foreground text-xs">host</label>
-              <input
-                type="text"
+              <SSHHostInput
                 value={props.sshHost}
-                onChange={(e) => props.onSshHostChange(e.target.value)}
-                placeholder="user@host"
+                onChange={props.onSshHostChange}
                 disabled={props.disabled}
-                className="bg-bg-dark text-foreground border-border-medium focus:border-accent h-7 w-36 rounded-md border px-2 text-sm focus:outline-none disabled:opacity-50"
               />
             </div>
           )}

--- a/src/browser/components/ChatInput/SSHHostInput.tsx
+++ b/src/browser/components/ChatInput/SSHHostInput.tsx
@@ -1,0 +1,153 @@
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import { useAPI } from "@/browser/contexts/API";
+
+interface SSHHostInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  disabled: boolean;
+}
+
+/**
+ * SSH host input with dropdown of hosts from SSH config.
+ * Shows dropdown above the input when focused and there are matching hosts.
+ */
+export function SSHHostInput(props: SSHHostInputProps) {
+  const { api } = useAPI();
+  const [hosts, setHosts] = useState<string[]>([]);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<Array<HTMLDivElement | null>>([]);
+
+  // Fetch SSH config hosts on mount
+  useEffect(() => {
+    if (!api) return;
+    api.ssh
+      .getConfigHosts()
+      .then(setHosts)
+      .catch(() => setHosts([]));
+  }, [api]);
+
+  // Filter hosts based on current input
+  const filteredHosts = hosts.filter((host) =>
+    host.toLowerCase().includes(props.value.toLowerCase())
+  );
+
+  // Handle clicking outside to close dropdown
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setShowDropdown(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const { onChange } = props;
+  const selectHost = useCallback(
+    (host: string) => {
+      onChange(host);
+      setShowDropdown(false);
+      setHighlightedIndex(-1);
+      inputRef.current?.focus();
+    },
+    [onChange]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!showDropdown || filteredHosts.length === 0) {
+        return;
+      }
+
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setHighlightedIndex((prev) => (prev < filteredHosts.length - 1 ? prev + 1 : 0));
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : filteredHosts.length - 1));
+          break;
+        case "Enter":
+          if (highlightedIndex >= 0) {
+            e.preventDefault();
+            selectHost(filteredHosts[highlightedIndex]);
+          }
+          break;
+        case "Escape":
+          e.preventDefault();
+          setShowDropdown(false);
+          setHighlightedIndex(-1);
+          break;
+      }
+    },
+    [showDropdown, filteredHosts, highlightedIndex, selectHost]
+  );
+
+  const handleFocus = () => {
+    if (filteredHosts.length > 0) {
+      setShowDropdown(true);
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    props.onChange(e.target.value);
+    // Show dropdown when typing if there are matches
+    if (hosts.length > 0) {
+      setShowDropdown(true);
+    }
+    setHighlightedIndex(-1);
+  };
+
+  // Scroll highlighted item into view
+  useEffect(() => {
+    if (highlightedIndex >= 0 && itemRefs.current[highlightedIndex]) {
+      itemRefs.current[highlightedIndex]?.scrollIntoView({
+        block: "nearest",
+        behavior: "smooth",
+      });
+    }
+  }, [highlightedIndex]);
+
+  // Show dropdown when there are filtered hosts
+  const shouldShowDropdown = showDropdown && filteredHosts.length > 0 && !props.disabled;
+
+  return (
+    <div ref={containerRef} className="relative">
+      <input
+        ref={inputRef}
+        type="text"
+        value={props.value}
+        onChange={handleChange}
+        onFocus={handleFocus}
+        onKeyDown={handleKeyDown}
+        placeholder="user@host"
+        disabled={props.disabled}
+        className="bg-separator text-foreground border-border-medium focus:border-accent w-32 rounded border px-1 py-0.5 text-xs focus:outline-none disabled:opacity-50"
+        autoComplete="off"
+      />
+      {shouldShowDropdown && (
+        <div className="bg-separator border-border-light absolute bottom-full left-0 z-[1000] mb-1 max-h-[150px] min-w-32 overflow-y-auto rounded border shadow-[0_4px_12px_rgba(0,0,0,0.3)]">
+          {filteredHosts.map((host, index) => (
+            <div
+              key={host}
+              ref={(el) => (itemRefs.current[index] = el)}
+              onClick={() => selectHost(host)}
+              onMouseEnter={() => setHighlightedIndex(index)}
+              className={`cursor-pointer px-2 py-1 text-xs ${
+                index === highlightedIndex
+                  ? "bg-accent text-white"
+                  : "text-foreground hover:bg-border-medium"
+              }`}
+            >
+              {host}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -79,6 +79,7 @@ async function createTestServer(authToken?: string): Promise<TestServerHandle> {
     voiceService: services.voiceService,
     telemetryService: services.telemetryService,
     sessionUsageService: services.sessionUsageService,
+    sshService: services.sshService,
   };
 
   // Use the actual createOrpcServer function

--- a/src/cli/server.test.ts
+++ b/src/cli/server.test.ts
@@ -82,6 +82,7 @@ async function createTestServer(): Promise<TestServerHandle> {
     voiceService: services.voiceService,
     telemetryService: services.telemetryService,
     sessionUsageService: services.sessionUsageService,
+    sshService: services.sshService,
   };
 
   // Use the actual createOrpcServer function

--- a/src/cli/server.ts
+++ b/src/cli/server.ts
@@ -98,6 +98,7 @@ const mockWindow: BrowserWindow = {
     telemetryService: serviceContainer.telemetryService,
     experimentsService: serviceContainer.experimentsService,
     sessionUsageService: serviceContainer.sessionUsageService,
+    sshService: serviceContainer.sshService,
   };
 
   const server = await createOrpcServer({

--- a/src/common/orpc/schemas.ts
+++ b/src/common/orpc/schemas.ts
@@ -136,6 +136,7 @@ export {
   ProvidersConfigMapSchema,
   server,
   splashScreens,
+  ssh,
   tasks,
   experiments,
   ExperimentValueSchema,

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -798,6 +798,18 @@ export const voice = {
   },
 };
 
+// SSH utilities
+export const ssh = {
+  /**
+   * Get list of hosts from user's SSH config file (~/.ssh/config).
+   * Returns hosts sorted alphabetically, excluding wildcards and negation patterns.
+   */
+  getConfigHosts: {
+    input: z.void(),
+    output: z.array(z.string()),
+  },
+};
+
 // Debug endpoints (test-only, not for production use)
 export const debug = {
   /**

--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -347,6 +347,7 @@ async function loadServices(): Promise<void> {
     telemetryService: services.telemetryService,
     experimentsService: services.experimentsService,
     sessionUsageService: services.sessionUsageService,
+    sshService: services.sshService,
   };
 
   electronIpcMain.on("start-orpc-server", (event) => {

--- a/src/node/orpc/context.ts
+++ b/src/node/orpc/context.ts
@@ -21,6 +21,7 @@ import type { FeatureFlagService } from "@/node/services/featureFlagService";
 import type { SessionTimingService } from "@/node/services/sessionTimingService";
 import type { SessionUsageService } from "@/node/services/sessionUsageService";
 import type { TaskService } from "@/node/services/taskService";
+import type { SSHService } from "@/node/services/sshService";
 
 export interface ORPCContext {
   config: Config;
@@ -45,5 +46,6 @@ export interface ORPCContext {
   telemetryService: TelemetryService;
   experimentsService: ExperimentsService;
   sessionUsageService: SessionUsageService;
+  sshService: SSHService;
   headers?: IncomingHttpHeaders;
 }

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -1490,6 +1490,14 @@ export const router = (authToken?: string) => {
           await context.experimentsService.refreshAll();
         }),
     },
+    ssh: {
+      getConfigHosts: t
+        .input(schemas.ssh.getConfigHosts.input)
+        .output(schemas.ssh.getConfigHosts.output)
+        .handler(async ({ context }) => {
+          return context.sshService.getConfigHosts();
+        }),
+    },
     debug: {
       triggerStreamError: t
         .input(schemas.debug.triggerStreamError.input)

--- a/src/node/services/serviceContainer.ts
+++ b/src/node/services/serviceContainer.ts
@@ -40,6 +40,7 @@ import { MCPServerManager } from "@/node/services/mcpServerManager";
 import { SessionUsageService } from "@/node/services/sessionUsageService";
 import { IdleCompactionService } from "@/node/services/idleCompactionService";
 import { TaskService } from "@/node/services/taskService";
+import { SSHService } from "@/node/services/sshService";
 
 /**
  * ServiceContainer - Central dependency container for all backend services.
@@ -72,6 +73,7 @@ export class ServiceContainer {
   public readonly sessionTimingService: SessionTimingService;
   public readonly experimentsService: ExperimentsService;
   public readonly sessionUsageService: SessionUsageService;
+  public readonly sshService: SSHService;
   private readonly initStateManager: InitStateManager;
   private readonly extensionMetadata: ExtensionMetadataService;
   private readonly ptyService: PTYService;
@@ -181,6 +183,7 @@ export class ServiceContainer {
       this.sessionTimingService.handleStreamAbort(data)
     );
     this.workspaceService.setExperimentsService(this.experimentsService);
+    this.sshService = new SSHService();
   }
 
   async initialize(): Promise<void> {

--- a/src/node/services/sshService.ts
+++ b/src/node/services/sshService.ts
@@ -1,0 +1,39 @@
+import * as fsPromises from "fs/promises";
+import * as path from "path";
+
+/**
+ * SSH utilities service.
+ */
+export class SSHService {
+  /**
+   * Parse SSH config file and extract host definitions.
+   * Returns list of configured hosts sorted alphabetically.
+   */
+  async getConfigHosts(): Promise<string[]> {
+    const sshConfigPath = path.join(process.env.HOME ?? "", ".ssh", "config");
+    try {
+      const content = await fsPromises.readFile(sshConfigPath, "utf-8");
+      const hosts = new Set<string>();
+
+      // Parse Host directives - each can have multiple patterns separated by whitespace
+      // Skip wildcards (*) and negation patterns (!)
+      for (const line of content.split("\n")) {
+        const trimmed = line.trim();
+        if (trimmed.toLowerCase().startsWith("host ")) {
+          const patterns = trimmed.slice(5).trim().split(/\s+/);
+          for (const pattern of patterns) {
+            // Skip wildcards and negation patterns
+            if (!pattern.includes("*") && !pattern.includes("?") && !pattern.startsWith("!")) {
+              hosts.add(pattern);
+            }
+          }
+        }
+      }
+
+      return Array.from(hosts).sort((a, b) => a.localeCompare(b));
+    } catch {
+      // File doesn't exist or can't be read - return empty list
+      return [];
+    }
+  }
+}

--- a/tests/ipc/setup.ts
+++ b/tests/ipc/setup.ts
@@ -91,6 +91,7 @@ export async function createTestEnvironment(): Promise<TestEnvironment> {
     experimentsService: services.experimentsService,
     telemetryService: services.telemetryService,
     sessionUsageService: services.sessionUsageService,
+    sshService: services.sshService,
   };
   const orpc = createOrpcTestClient(orpcContext);
 


### PR DESCRIPTION
When selecting SSH runtime, the host input now shows a dropdown with hosts from the user's `~/.ssh/config` file.

## Features

- Parses Host directives from SSH config (skipping wildcards and negation patterns)
- Shows dropdown above the input when focused
- Supports keyboard navigation (arrow keys, Enter, Escape)
- Filters hosts as user types
- Works in both browser and desktop modes

## Implementation

- Added `SSH_CONFIG_HOSTS` IPC channel and handler that parses `~/.ssh/config`
- Created `SSHHostInput` component with autocomplete dropdown
- Updated `CreationControls` to use the new component

_Generated with `mux`_