### PR TITLE
🤖 chore: update homepage from cmux.io to mux.coder.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,21 @@ Here are some specific use cases we enable:
 
 ## Features
 
-- **Isolated workspaces** with central view on git divergence ([docs](https://cmux.io/runtime.html))
-  - **[Local](https://cmux.io/runtime/local.html)**: run directly in your project directory
-  - **[Worktree](https://cmux.io/runtime/worktree.html)**: git worktrees on your local machine
-  - **[SSH](https://cmux.io/runtime/ssh.html)**: remote execution on a server over SSH
+- **Isolated workspaces** with central view on git divergence ([docs](https://mux.coder.com/runtime.html))
+  - **[Local](https://mux.coder.com/runtime/local.html)**: run directly in your project directory
+  - **[Worktree](https://mux.coder.com/runtime/worktree.html)**: git worktrees on your local machine
+  - **[SSH](https://mux.coder.com/runtime/ssh.html)**: remote execution on a server over SSH
 - **Multi-model** (`sonnet-4-*`, `grok-*`, `gpt-5-*`, `opus-4-*`)
-  - Ollama supported for local LLMs ([docs](https://cmux.io/models.html#ollama-local))
-  - OpenRouter supported for long-tail of LLMs ([docs](https://cmux.io/models.html#openrouter-cloud))
-- **VS Code Extension**: Jump into mux workspaces directly from VS Code ([docs](https://cmux.io/vscode-extension.html))
+  - Ollama supported for local LLMs ([docs](https://mux.coder.com/models.html#ollama-local))
+  - OpenRouter supported for long-tail of LLMs ([docs](https://mux.coder.com/models.html#openrouter-cloud))
+- **VS Code Extension**: Jump into mux workspaces directly from VS Code ([docs](https://mux.coder.com/vscode-extension.html))
 - Supporting UI and keybinds for efficiently managing a suite of agents
 - Rich markdown outputs (mermaid diagrams, LaTeX, etc.)
 
 mux has a custom agent loop but much of the core UX is inspired by Claude Code. You'll find familiar features like Plan/Exec mode, vim inputs, `/compact` and new ones
-like [opportunistic compaction](https://cmux.io/context-management.html) and [mode prompts](https://cmux.io/instruction-files.html#mode-prompts).
+like [opportunistic compaction](https://mux.coder.com/context-management.html) and [mode prompts](https://mux.coder.com/instruction-files.html#mode-prompts).
 
-**[Read the full documentation →](https://cmux.io)**
+**[Read the full documentation →](https://mux.coder.com)**
 
 ## Install
 
@@ -58,7 +58,7 @@ like [opportunistic compaction](https://cmux.io/context-management.html) and [mo
 Download pre-built binaries from [the releases page](https://github.com/coder/mux/releases) for
 macOS and Linux.
 
-[More on installation →](https://cmux.io/install.html)
+[More on installation →](https://mux.coder.com/install.html)
 
 ## Screenshots
 
@@ -99,7 +99,7 @@ macOS and Linux.
 
 ## More reading
 
-See [the documentation](https://cmux.io) for more details.
+See [the documentation](https://mux.coder.com) for more details.
 
 ## Development
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-cmux.io
+mux.coder.com

--- a/src/browser/utils/commands/sources.ts
+++ b/src/browser/utils/commands/sources.ts
@@ -487,7 +487,7 @@ export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandActi
       section: section.help,
       run: () => {
         try {
-          window.open("https://cmux.io/keybinds.html", "_blank");
+          window.open("https://mux.coder.com/keybinds.html", "_blank");
         } catch {
           /* ignore */
         }

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,6 +1,6 @@
 # mux VS Code Extension
 
-Open [mux](https://cmux.io) workspaces from VS Code or Cursor.
+Open [mux](https://mux.coder.com) workspaces from VS Code or Cursor.
 
 ## Installation
 


### PR DESCRIPTION
_Generated with `mux`_

Updates all homepage URL references from `cmux.io` to `mux.coder.com`.

**DNS verified:**
```
$ dig mux.coder.com CNAME +short
coder.github.io.
```

**Files changed:**
- `docs/CNAME` - GitHub Pages custom domain
- `README.md` - documentation links
- `src/browser/utils/commands/sources.ts` - keybinds help link
- `vscode/README.md` - extension description