### PR TITLE
🤖 fix: skip splash screen on macOS dock reactivation

### DIFF
--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -557,27 +557,9 @@ if (gotTheLock) {
   });
 
   app.on("activate", () => {
-    // Only create window if app is ready and no window exists
-    // This prevents "Cannot create BrowserWindow before app is ready" error
+    // Skip splash on reactivation - services already loaded, window creation is fast
     if (app.isReady() && mainWindow === null) {
-      void (async () => {
-        try {
-          await showSplashScreen();
-          await loadServices();
-          createWindow();
-        } catch (error) {
-          console.error(`[${timestamp()}] Failed to recreate window:`, error);
-          closeSplashScreen();
-
-          const errorMessage =
-            error instanceof Error ? `${error.message}\n\n${error.stack ?? ""}` : String(error);
-
-          dialog.showErrorBox(
-            "Window Creation Failed",
-            `Failed to recreate the application window:\n\n${errorMessage}`
-          );
-        }
-      })();
+      createWindow();
     }
   });
 }


### PR DESCRIPTION
## Problem

`ERR_FAILED (-2)` loading `splash.html` from ASAR intermittently on macOS dock reactivation because:
- macOS App Nap throttles idle apps
- File descriptors to ASAR archive may be reclaimed after inactivity
- The `activate` event fires before I/O is fully responsive

## Solution

Skip the splash screen on reactivation. Services are already loaded from initial launch, so window creation is fast (~100ms). The splash exists to cover heavy initialization—unnecessary on reactivation.

**-20 LoC, +2 LoC** (net: -18)

## Alternatives Considered

| Option | Tradeoff |
|--------|----------|
| Retry with backoff | Adds complexity, user still sees delay on failure |
| Disable App Nap | System-wide side effects, not recommended |
| Inline splash HTML as data URL | Avoids file I/O but complicates build |

_Generated with `mux`_