### PR TITLE
🤖 fix: initialize git repos in e2e fixtures

### DIFF
--- a/tests/e2e/utils/demoProject.ts
+++ b/tests/e2e/utils/demoProject.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import { spawnSync } from "child_process";
 import { Config } from "../../../src/node/config";
 
 export interface DemoProjectConfig {
@@ -48,6 +49,16 @@ export function prepareDemoProject(
   fs.mkdirSync(projectPath, { recursive: true });
   fs.mkdirSync(workspacePath, { recursive: true });
   fs.mkdirSync(sessionsDir, { recursive: true });
+
+  // Initialize git repos with an initial commit so git commands work properly.
+  // Empty repos cause errors like "fatal: ref HEAD is not a symbolic ref" when
+  // detecting the default branch.
+  for (const repoPath of [projectPath, workspacePath]) {
+    spawnSync("git", ["init", "-q"], { cwd: repoPath });
+    spawnSync("git", ["config", "user.email", "test@example.com"], { cwd: repoPath });
+    spawnSync("git", ["config", "user.name", "Test"], { cwd: repoPath });
+    spawnSync("git", ["commit", "--allow-empty", "-q", "-m", "init"], { cwd: repoPath });
+  }
 
   // E2E tests use legacy workspace ID format to test backward compatibility.
   // Production code now uses generateStableId() for new workspaces.


### PR DESCRIPTION
The e2e test fixtures created directories but didn't run `git init`, causing `listBranches()` to fail with 'Not a git repository' errors.

These errors were logged but didn't fail tests since the tests don't rely on branch-loading functionality - they were just noise in the CI output.

**Fix:** run `git init -q` for both projectPath and workspacePath so the fixtures behave like real projects.

_Generated with `mux`_