### PR TITLE
🤖 fix: use JSON mode for workspace title generation

### DIFF
--- a/src/node/services/workspaceTitleGenerator.ts
+++ b/src/node/services/workspaceTitleGenerator.ts
@@ -34,6 +34,7 @@ export async function generateWorkspaceName(
     const result = await generateObject({
       model: modelResult.data,
       schema: workspaceNameSchema,
+      mode: "json",
       prompt: `Generate a git-safe branch/workspace name for this development task:\n\n"${message}"\n\nRequirements:\n- Git-safe identifier (e.g., "automatic-title-generation")\n- Lowercase, hyphens only, no spaces\n- Concise (2-5 words) and descriptive of the task`,
     });
 


### PR DESCRIPTION
_Generated with `mux`_

Use `mode: "json"` for workspace title generation instead of the default tool mode, avoiding `tool_choice: any` in the API request.