### PR TITLE
🤖 perf: skip code signing in merge queue to enable parallel builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,30 +18,8 @@ jobs:
 
       - uses: ./.github/actions/setup-mux
 
-      # Skip signing setup for PRs - electron-builder skips signing anyway,
-      # but setting CSC_LINK forces our Makefile to build sequentially.
-      # Without CSC_LINK, x64 and arm64 build in parallel (~90s savings).
-      - name: Setup code signing
-        if: github.event_name != 'pull_request'
-        run: ./scripts/setup-macos-signing.sh
-        env:
-          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
-          AC_APIKEY_P8_BASE64: ${{ secrets.AC_APIKEY_P8_BASE64 }}
-          AC_APIKEY_ID: ${{ secrets.AC_APIKEY_ID }}
-          AC_APIKEY_ISSUER_ID: ${{ secrets.AC_APIKEY_ISSUER_ID }}
-
-      - name: Verify signing setup
-        if: github.event_name != 'pull_request'
-        run: |
-          if [ -n "${CSC_LINK:-}" ]; then
-            echo "✅ Code signing enabled"
-            security list-keychains -d user
-            security find-identity -v -p codesigning
-          else
-            echo "⚠️ Code signing NOT enabled"
-          fi
-
+      # No code signing - releases use release.yml (triggered by tag publish).
+      # Without CSC_LINK, x64 and arm64 builds run in parallel (~12 min faster).
       - name: Package for macOS
         run: make dist-mac
 


### PR DESCRIPTION
The macOS build workflow was taking 24+ minutes because code signing was enabled for `merge_group` events. This forced sequential x64+arm64 builds to avoid keychain race conditions.

Since merge queue builds don't need signed artifacts (only releases do), we can safely skip signing and let both architectures build in parallel. This should cut the macOS build time roughly in half (~12 min).

**Before:** [24m40s for macOS build](https://github.com/coder/mux/actions/runs/19892016638/job/57012954221)

**After:** Expected ~12 min (parallel x64+arm64 builds)

---
_Generated with `mux`_