### PR TITLE
feat: unify Electron and CLI with shared oRPC API server

### DIFF
--- a/src/cli/api.ts
+++ b/src/cli/api.ts
@@ -3,19 +3,63 @@
  *
  * This module is loaded lazily to avoid pulling in ESM-only dependencies
  * (trpc-cli) when running other commands like the desktop app.
+ *
+ * Server discovery priority:
+ * 1. MUX_SERVER_URL env var (explicit override)
+ * 2. Lockfile at ~/.mux/server.lock (running Electron or mux server)
+ * 3. Fallback to http://localhost:3000
  */
 
 import { createCli } from "trpc-cli";
 import { router } from "@/node/orpc/router";
 import { proxifyOrpc } from "./proxifyOrpc";
+import { ServerLockfile } from "@/node/services/serverLockfile";
+import { getMuxHome } from "@/common/constants/paths";
 import type { Command } from "commander";
 
-const baseUrl = process.env.MUX_SERVER_URL ?? "http://localhost:3000";
-const authToken = process.env.MUX_SERVER_AUTH_TOKEN;
+interface ServerDiscovery {
+  baseUrl: string;
+  authToken: string | undefined;
+}
 
-const proxiedRouter = proxifyOrpc(router(), { baseUrl, authToken });
-const cli = createCli({ router: proxiedRouter }).buildProgram() as Command;
+async function discoverServer(): Promise<ServerDiscovery> {
+  // Priority 1: Explicit env vars override everything
+  if (process.env.MUX_SERVER_URL) {
+    return {
+      baseUrl: process.env.MUX_SERVER_URL,
+      authToken: process.env.MUX_SERVER_AUTH_TOKEN,
+    };
+  }
 
-cli.name("mux api");
-cli.description("Interact with the mux API via a running server");
-cli.parse();
+  // Priority 2: Try lockfile discovery (running Electron or mux server)
+  try {
+    const lockfile = new ServerLockfile(getMuxHome());
+    const data = await lockfile.read();
+    if (data) {
+      return {
+        baseUrl: data.baseUrl,
+        authToken: data.token,
+      };
+    }
+  } catch {
+    // Ignore lockfile errors
+  }
+
+  // Priority 3: Default fallback (standalone server on default port)
+  return {
+    baseUrl: "http://localhost:3000",
+    authToken: process.env.MUX_SERVER_AUTH_TOKEN,
+  };
+}
+
+// Run async discovery then start CLI
+(async () => {
+  const { baseUrl, authToken } = await discoverServer();
+
+  const proxiedRouter = proxifyOrpc(router(), { baseUrl, authToken });
+  const cli = createCli({ router: proxiedRouter }).buildProgram() as Command;
+
+  cli.name("mux api");
+  cli.description("Interact with the mux API via a running server");
+  cli.parse();
+})();

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -1,0 +1,262 @@
+/**
+ * E2E tests for the CLI layer (mux api commands).
+ *
+ * These tests verify that:
+ * 1. CLI commands work correctly via HTTP to a real server
+ * 2. Input schema transformations (proxifyOrpc) are correct
+ * 3. Authentication flows work as expected
+ *
+ * Uses bun:test and the same server setup pattern as server.test.ts.
+ * Tests the full flow: CLI args → trpc-cli → proxifyOrpc → HTTP → oRPC server
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import * as os from "os";
+import * as path from "path";
+import * as fs from "fs/promises";
+import type { BrowserWindow, WebContents } from "electron";
+
+import { createCli, FailedToExitError } from "trpc-cli";
+import { router } from "@/node/orpc/router";
+import { proxifyOrpc } from "./proxifyOrpc";
+import type { ORPCContext } from "@/node/orpc/context";
+import { Config } from "@/node/config";
+import { ServiceContainer } from "@/node/services/serviceContainer";
+import { createOrpcServer, type OrpcServer } from "@/node/orpc/server";
+
+// --- Test Server Factory ---
+
+interface TestServerHandle {
+  server: OrpcServer;
+  tempDir: string;
+  close: () => Promise<void>;
+}
+
+/**
+ * Create a test server using the actual createOrpcServer function.
+ * Sets up services and config in a temp directory.
+ */
+async function createTestServer(authToken?: string): Promise<TestServerHandle> {
+  // Create temp dir for config
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-cli-test-"));
+  const config = new Config(tempDir);
+
+  // Mock BrowserWindow
+  const mockWindow: BrowserWindow = {
+    isDestroyed: () => false,
+    setTitle: () => undefined,
+    webContents: {
+      send: () => undefined,
+      openDevTools: () => undefined,
+    } as unknown as WebContents,
+  } as unknown as BrowserWindow;
+
+  // Initialize services
+  const services = new ServiceContainer(config);
+  await services.initialize();
+  services.windowService.setMainWindow(mockWindow);
+
+  // Build context
+  const context: ORPCContext = {
+    projectService: services.projectService,
+    workspaceService: services.workspaceService,
+    providerService: services.providerService,
+    terminalService: services.terminalService,
+    windowService: services.windowService,
+    updateService: services.updateService,
+    tokenizerService: services.tokenizerService,
+    serverService: services.serverService,
+    menuEventService: services.menuEventService,
+    voiceService: services.voiceService,
+  };
+
+  // Use the actual createOrpcServer function
+  const server = await createOrpcServer({
+    context,
+    authToken,
+    // port 0 = random available port
+    onOrpcError: () => undefined, // Silence errors in tests
+  });
+
+  return {
+    server,
+    tempDir,
+    close: async () => {
+      await server.close();
+      // Cleanup temp directory
+      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
+    },
+  };
+}
+
+// --- CLI Runner Factory ---
+
+/**
+ * Create a CLI runner that executes commands against a running server.
+ * Uses trpc-cli's programmatic API to avoid subprocess overhead.
+ */
+function createCliRunner(baseUrl: string, authToken?: string) {
+  const proxiedRouter = proxifyOrpc(router(), { baseUrl, authToken });
+  const cli = createCli({ router: proxiedRouter });
+
+  return async (args: string[]): Promise<unknown> => {
+    return cli
+      .run({
+        argv: args,
+        process: { exit: () => void 0 as never },
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        logger: { info: () => {}, error: () => {} },
+      })
+      .catch((err) => {
+        // Extract the result or re-throw the actual error
+        while (err instanceof FailedToExitError) {
+          if (err.exitCode === 0) {
+            return err.cause; // This is the return value of the procedure
+          }
+          err = err.cause; // Use the underlying error
+        }
+        throw err;
+      });
+  };
+}
+
+// --- Tests ---
+
+describe("CLI via HTTP", () => {
+  let serverHandle: TestServerHandle;
+  let runCli: (args: string[]) => Promise<unknown>;
+
+  beforeAll(async () => {
+    serverHandle = await createTestServer();
+    runCli = createCliRunner(serverHandle.server.baseUrl);
+  });
+
+  afterAll(async () => {
+    await serverHandle.close();
+  });
+
+  describe("void input schemas (regression for proxifyOrpc fix)", () => {
+    // These tests verify the fix in proxifyOrpc.ts that transforms {} to undefined
+    // for z.void() inputs. Without the fix, these would fail with BAD_REQUEST.
+
+    test("workspace list works with void input", async () => {
+      const result = await runCli(["workspace", "list"]);
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    test("providers list works with void input", async () => {
+      const result = (await runCli(["providers", "list"])) as string[];
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toContain("anthropic");
+    });
+
+    test("projects list works with void input", async () => {
+      const result = await runCli(["projects", "list"]);
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    test("providers get-config works with void input", async () => {
+      const result = await runCli(["providers", "get-config"]);
+      expect(typeof result).toBe("object");
+      expect(result).not.toBeNull();
+    });
+
+    test("workspace activity list works with void input", async () => {
+      const result = await runCli(["workspace", "activity", "list"]);
+      expect(typeof result).toBe("object");
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe("string input schemas", () => {
+    test("general ping with string argument", async () => {
+      const result = await runCli(["general", "ping", "hello"]);
+      expect(result).toBe("Pong: hello");
+    });
+
+    test("general ping with empty string", async () => {
+      const result = await runCli(["general", "ping", ""]);
+      expect(result).toBe("Pong: ");
+    });
+
+    test("general ping with special characters", async () => {
+      const result = await runCli(["general", "ping", "hello world!"]);
+      expect(result).toBe("Pong: hello world!");
+    });
+  });
+
+  describe("object input schemas", () => {
+    test("workspace get-info with workspace-id option", async () => {
+      const result = await runCli(["workspace", "get-info", "--workspace-id", "nonexistent"]);
+      expect(result).toBeNull(); // Non-existent workspace returns null
+    });
+
+    test("general tick with object options", async () => {
+      const result = await runCli(["general", "tick", "--count", "2", "--interval-ms", "10"]);
+      // tick returns an async generator, so result should be the generator
+      expect(result).toBeDefined();
+    });
+  });
+});
+
+describe("CLI Authentication", () => {
+  test("valid auth token allows requests", async () => {
+    const authToken = "test-secret-token";
+    const serverHandle = await createTestServer(authToken);
+    const runCli = createCliRunner(serverHandle.server.baseUrl, authToken);
+
+    try {
+      const result = await runCli(["workspace", "list"]);
+      expect(Array.isArray(result)).toBe(true);
+    } finally {
+      await serverHandle.close();
+    }
+  });
+
+  test("invalid auth token rejects requests", async () => {
+    const authToken = "correct-token";
+    const serverHandle = await createTestServer(authToken);
+    const runCli = createCliRunner(serverHandle.server.baseUrl, "wrong-token");
+
+    try {
+      let threw = false;
+      try {
+        await runCli(["workspace", "list"]);
+      } catch {
+        threw = true;
+      }
+      expect(threw).toBe(true);
+    } finally {
+      await serverHandle.close();
+    }
+  });
+
+  test("missing auth token when required rejects requests", async () => {
+    const authToken = "required-token";
+    const serverHandle = await createTestServer(authToken);
+    const runCli = createCliRunner(serverHandle.server.baseUrl); // No token
+
+    try {
+      let threw = false;
+      try {
+        await runCli(["workspace", "list"]);
+      } catch {
+        threw = true;
+      }
+      expect(threw).toBe(true);
+    } finally {
+      await serverHandle.close();
+    }
+  });
+
+  test("no auth token required when server has none", async () => {
+    const serverHandle = await createTestServer(); // No auth token on server
+    const runCli = createCliRunner(serverHandle.server.baseUrl); // No token
+
+    try {
+      const result = await runCli(["workspace", "list"]);
+      expect(Array.isArray(result)).toBe(true);
+    } finally {
+      await serverHandle.close();
+    }
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -40,8 +40,9 @@ if (subcommand === "run") {
   require("./server");
 } else if (subcommand === "api") {
   process.argv.splice(2, 1);
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  require("./api");
+  // Dynamic import required: trpc-cli is ESM-only and can't be require()'d
+  // eslint-disable-next-line no-restricted-syntax
+  void import("./api");
 } else if (
   subcommand === "desktop" ||
   (isElectron && (subcommand === undefined || isElectronLaunchArg))

--- a/src/cli/server.test.ts
+++ b/src/cli/server.test.ts
@@ -24,7 +24,7 @@ import type { ORPCContext } from "@/node/orpc/context";
 import { Config } from "@/node/config";
 import { ServiceContainer } from "@/node/services/serviceContainer";
 import type { RouterClient } from "@orpc/server";
-import { createOrpcServer, type OrpcServer } from "./orpcServer";
+import { createOrpcServer, type OrpcServer } from "@/node/orpc/server";
 
 // --- Test Server Factory ---
 

--- a/src/node/services/serverLockfile.test.ts
+++ b/src/node/services/serverLockfile.test.ts
@@ -1,0 +1,164 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as os from "os";
+import { ServerLockfile } from "./serverLockfile";
+
+describe("ServerLockfile", () => {
+  let tempDir: string;
+  let lockfile: ServerLockfile;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-lock-test-"));
+    lockfile = new ServerLockfile(tempDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("acquire creates lockfile with correct data", async () => {
+    await lockfile.acquire("http://localhost:12345", "test-token");
+
+    const data = await lockfile.read();
+    expect(data).not.toBeNull();
+    expect(data!.baseUrl).toBe("http://localhost:12345");
+    expect(data!.token).toBe("test-token");
+    expect(data!.pid).toBe(process.pid);
+    expect(data!.startedAt).toBeDefined();
+  });
+
+  test("read returns null for non-existent lockfile", async () => {
+    const data = await lockfile.read();
+    expect(data).toBeNull();
+  });
+
+  test("read returns null for stale lockfile (dead PID)", async () => {
+    const lockPath = lockfile.getLockPath();
+
+    // Write lockfile with fake dead PID
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({
+        pid: 999999999, // Very unlikely to be a real PID
+        baseUrl: "http://localhost:12345",
+        token: "test-token",
+        startedAt: new Date().toISOString(),
+      })
+    );
+
+    const data = await lockfile.read();
+    expect(data).toBeNull();
+
+    // Stale lockfile should be cleaned up
+    let exists = true;
+    try {
+      await fs.access(lockPath);
+    } catch {
+      exists = false;
+    }
+    expect(exists).toBe(false);
+  });
+
+  test("read returns data for lockfile with current PID", async () => {
+    await lockfile.acquire("http://127.0.0.1:54321", "valid-token");
+
+    const data = await lockfile.read();
+    expect(data).not.toBeNull();
+    expect(data!.baseUrl).toBe("http://127.0.0.1:54321");
+    expect(data!.token).toBe("valid-token");
+  });
+
+  test("release removes lockfile", async () => {
+    await lockfile.acquire("http://localhost:12345", "test-token");
+    const lockPath = lockfile.getLockPath();
+
+    let exists = true;
+    try {
+      await fs.access(lockPath);
+    } catch {
+      exists = false;
+    }
+    expect(exists).toBe(true);
+
+    await lockfile.release();
+
+    try {
+      await fs.access(lockPath);
+      exists = true;
+    } catch {
+      exists = false;
+    }
+    expect(exists).toBe(false);
+  });
+
+  test("release is idempotent (no error if file doesn't exist)", async () => {
+    // Should not throw
+    await lockfile.release();
+    await lockfile.release();
+  });
+
+  test("lockfile has restrictive permissions on unix", async () => {
+    // Skip on Windows where file permissions work differently
+    if (process.platform === "win32") {
+      return;
+    }
+
+    await lockfile.acquire("http://localhost:12345", "test-token");
+    const lockPath = lockfile.getLockPath();
+    const stats = await fs.stat(lockPath);
+
+    // 0o600 = owner read/write only
+    expect(stats.mode & 0o777).toBe(0o600);
+  });
+
+  test("acquire overwrites existing lockfile", async () => {
+    await lockfile.acquire("http://localhost:11111", "first-token");
+    await lockfile.acquire("https://my.machine.local/mux", "second-token");
+
+    const data = await lockfile.read();
+    expect(data).not.toBeNull();
+    expect(data!.baseUrl).toBe("https://my.machine.local/mux");
+    expect(data!.token).toBe("second-token");
+  });
+
+  test("read handles corrupted lockfile gracefully", async () => {
+    const lockPath = lockfile.getLockPath();
+    await fs.writeFile(lockPath, "not valid json");
+
+    const data = await lockfile.read();
+    expect(data).toBeNull();
+  });
+
+  test("acquire creates parent directory if it doesn't exist", async () => {
+    const nestedDir = path.join(tempDir, "nested", "dir");
+    const nestedLockfile = new ServerLockfile(nestedDir);
+
+    await nestedLockfile.acquire("http://localhost:12345", "test-token");
+
+    const data = await nestedLockfile.read();
+    expect(data).not.toBeNull();
+    expect(data!.baseUrl).toBe("http://localhost:12345");
+  });
+
+  test("getLockPath returns correct path", () => {
+    const expectedPath = path.join(tempDir, "server.lock");
+    expect(lockfile.getLockPath()).toBe(expectedPath);
+  });
+
+  test("supports HTTPS URLs", async () => {
+    await lockfile.acquire("https://secure.example.com:8443/api", "secure-token");
+
+    const data = await lockfile.read();
+    expect(data).not.toBeNull();
+    expect(data!.baseUrl).toBe("https://secure.example.com:8443/api");
+  });
+
+  test("supports URLs with path prefixes", async () => {
+    await lockfile.acquire("https://my.machine.local/mux/", "path-token");
+
+    const data = await lockfile.read();
+    expect(data).not.toBeNull();
+    expect(data!.baseUrl).toBe("https://my.machine.local/mux/");
+  });
+});

--- a/src/node/services/serverLockfile.ts
+++ b/src/node/services/serverLockfile.ts
@@ -1,0 +1,109 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+import { z } from "zod";
+
+export const ServerLockDataSchema = z.object({
+  pid: z.number(),
+  /** Base URL for HTTP API (e.g., "http://localhost:3000" or "https://my.box.com/mux") */
+  baseUrl: z.url(),
+  token: z.string(),
+  startedAt: z.string(),
+});
+
+export type ServerLockData = z.infer<typeof ServerLockDataSchema>;
+
+/**
+ * Manages the server lockfile at ~/.mux/server.lock
+ *
+ * The lockfile enables CLI tools to discover a running mux server
+ * (either Electron app or standalone mux server) and connect to it.
+ */
+export class ServerLockfile {
+  private readonly lockPath: string;
+
+  constructor(muxHome: string) {
+    this.lockPath = path.join(muxHome, "server.lock");
+  }
+
+  /**
+   * Acquire the lockfile with the given baseUrl and token.
+   * Writes atomically with 0600 permissions (owner read/write only).
+   */
+  async acquire(baseUrl: string, token: string): Promise<void> {
+    const data: ServerLockData = {
+      pid: process.pid,
+      baseUrl,
+      token,
+      startedAt: new Date().toISOString(),
+    };
+
+    // Ensure directory exists
+    const dir = path.dirname(this.lockPath);
+    try {
+      await fs.access(dir);
+    } catch {
+      await fs.mkdir(dir, { recursive: true });
+    }
+
+    // Write atomically by writing to temp file then renaming
+    const tempPath = `${this.lockPath}.${process.pid}.tmp`;
+    await fs.writeFile(tempPath, JSON.stringify(data, null, 2), {
+      mode: 0o600, // Owner read/write only
+    });
+    await fs.rename(tempPath, this.lockPath);
+  }
+
+  /**
+   * Read the lockfile and validate it.
+   * Returns null if the lockfile doesn't exist or is stale (dead PID).
+   */
+  async read(): Promise<ServerLockData | null> {
+    try {
+      await fs.access(this.lockPath);
+      const content = await fs.readFile(this.lockPath, "utf-8");
+      const data = ServerLockDataSchema.parse(JSON.parse(content));
+
+      // Validate PID is still alive
+      if (!this.isProcessAlive(data.pid)) {
+        // Clean up stale lockfile
+        await this.release();
+        return null;
+      }
+
+      return data;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Release the lockfile by deleting it.
+   */
+  async release(): Promise<void> {
+    try {
+      await fs.unlink(this.lockPath);
+    } catch {
+      // Ignore cleanup errors (file may not exist)
+    }
+  }
+
+  /**
+   * Check if a process with the given PID is still running.
+   * Uses signal 0 which tests existence without actually sending a signal.
+   */
+  private isProcessAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Get the path to the lockfile (for testing/debugging).
+   */
+  getLockPath(): string {
+    return this.lockPath;
+  }
+}

--- a/src/node/services/serverService.test.ts
+++ b/src/node/services/serverService.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as os from "os";
+import * as net from "net";
 import { ServerService } from "./serverService";
+import type { ORPCContext } from "@/node/orpc/context";
+import { ServerLockDataSchema } from "./serverLockfile";
 
 describe("ServerService", () => {
   test("initializes with null path", async () => {
@@ -27,5 +33,149 @@ describe("ServerService", () => {
     expect(await service.getLaunchProject()).toBe("/test/path");
     service.setLaunchProject(null);
     expect(await service.getLaunchProject()).toBeNull();
+  });
+});
+
+describe("ServerService.startServer", () => {
+  let tempDir: string;
+
+  // Minimal context stub - server creation only needs the shape, not real services
+  const stubContext: Partial<ORPCContext> = {};
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-server-test-"));
+  });
+
+  afterEach(async () => {
+    // Restore permissions before cleanup
+    try {
+      await fs.chmod(tempDir, 0o755);
+    } catch {
+      // ignore
+    }
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  /** Check if a port is in use by attempting to connect to it */
+  async function isPortListening(port: number): Promise<boolean> {
+    return new Promise((resolve) => {
+      const socket = new net.Socket();
+      socket.setTimeout(100);
+      socket.on("connect", () => {
+        socket.destroy();
+        resolve(true);
+      });
+      socket.on("timeout", () => {
+        socket.destroy();
+        resolve(false);
+      });
+      socket.on("error", () => {
+        resolve(false);
+      });
+      socket.connect(port, "127.0.0.1");
+    });
+  }
+
+  test("cleans up server when lockfile acquisition fails", async () => {
+    // Skip on Windows where chmod doesn't work the same way
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const service = new ServerService();
+
+    // Make muxHome read-only so lockfile.acquire() will fail
+    await fs.chmod(tempDir, 0o444);
+
+    let thrownError: Error | null = null;
+
+    try {
+      // Start server - this should fail when trying to write lockfile
+      await service.startServer({
+        muxHome: tempDir,
+        context: stubContext as ORPCContext,
+        authToken: "test-token",
+        port: 0, // random port
+      });
+    } catch (err) {
+      thrownError = err as Error;
+    }
+
+    // Verify that an error was thrown
+    expect(thrownError).not.toBeNull();
+    expect(thrownError!.message).toMatch(/EACCES|permission denied/i);
+
+    // Verify the server is NOT left running
+    expect(service.isServerRunning()).toBe(false);
+    expect(service.getServerInfo()).toBeNull();
+  });
+
+  test("does not delete another process's lockfile when start fails", async () => {
+    const service = new ServerService();
+
+    // Create a lockfile simulating another running server (use our own PID so it appears "alive")
+    const lockPath = path.join(tempDir, "server.lock");
+    const existingLockData = {
+      pid: process.pid,
+      baseUrl: "http://127.0.0.1:9999",
+      token: "other-server-token",
+      startedAt: new Date().toISOString(),
+    };
+    await fs.writeFile(lockPath, JSON.stringify(existingLockData, null, 2));
+
+    // Try to start - should fail due to existing server
+    let thrownError: Error | null = null;
+    try {
+      await service.startServer({
+        muxHome: tempDir,
+        context: stubContext as ORPCContext,
+        authToken: "test-token",
+        port: 0,
+      });
+    } catch (err) {
+      thrownError = err as Error;
+    }
+
+    expect(thrownError).not.toBeNull();
+    expect(thrownError!.message).toMatch(/already running/i);
+
+    // Critical: call stopServer (simulating cleanup in finally block)
+    await service.stopServer();
+
+    // Verify the OTHER process's lockfile was NOT deleted
+    const lockContent = await fs.readFile(lockPath, "utf-8");
+    const lockData = ServerLockDataSchema.parse(JSON.parse(lockContent));
+    expect(lockData.baseUrl).toBe("http://127.0.0.1:9999");
+    expect(lockData.token).toBe("other-server-token");
+  });
+
+  test("successful start creates lockfile and server", async () => {
+    const service = new ServerService();
+
+    const info = await service.startServer({
+      muxHome: tempDir,
+      context: stubContext as ORPCContext,
+      authToken: "test-token",
+      port: 0,
+    });
+
+    try {
+      expect(info.baseUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+      expect(info.token).toBe("test-token");
+      expect(service.isServerRunning()).toBe(true);
+
+      // Verify lockfile was created
+      const lockPath = path.join(tempDir, "server.lock");
+      const lockContent = await fs.readFile(lockPath, "utf-8");
+      const lockData = ServerLockDataSchema.parse(JSON.parse(lockContent));
+      expect(lockData.baseUrl).toBe(info.baseUrl);
+      expect(lockData.token).toBe("test-token");
+
+      // Verify server is actually listening
+      const port = parseInt(info.baseUrl.split(":")[2], 10);
+      expect(await isPortListening(port)).toBe(true);
+    } finally {
+      await service.stopServer();
+    }
   });
 });

--- a/src/node/services/serverService.ts
+++ b/src/node/services/serverService.ts
@@ -1,5 +1,33 @@
+import { createOrpcServer, type OrpcServer, type OrpcServerOptions } from "@/node/orpc/server";
+import { ServerLockfile } from "./serverLockfile";
+import type { ORPCContext } from "@/node/orpc/context";
+import type { AppRouter } from "@/node/orpc/router";
+
+export interface ServerInfo {
+  baseUrl: string;
+  token: string;
+}
+
+export interface StartServerOptions {
+  /** Path to mux home directory (for lockfile) */
+  muxHome: string;
+  /** oRPC context with services */
+  context: ORPCContext;
+  /** Auth token for the server */
+  authToken: string;
+  /** Port to bind to (0 = random) */
+  port?: number;
+  /** Optional pre-created router (if not provided, creates router(authToken)) */
+  router?: AppRouter;
+  /** Whether to serve static files */
+  serveStatic?: boolean;
+}
+
 export class ServerService {
   private launchProjectPath: string | null = null;
+  private server: OrpcServer | null = null;
+  private lockfile: ServerLockfile | null = null;
+  private serverInfo: ServerInfo | null = null;
 
   /**
    * Set the launch project path
@@ -13,5 +41,88 @@ export class ServerService {
    */
   getLaunchProject(): Promise<string | null> {
     return Promise.resolve(this.launchProjectPath);
+  }
+
+  /**
+   * Start the HTTP/WS API server.
+   *
+   * @throws Error if a server is already running (check lockfile first)
+   */
+  async startServer(options: StartServerOptions): Promise<ServerInfo> {
+    if (this.server) {
+      throw new Error("Server already running in this process");
+    }
+
+    // Create lockfile instance for checking - don't store yet
+    const lockfile = new ServerLockfile(options.muxHome);
+
+    // Check for existing server (another process)
+    const existing = await lockfile.read();
+    if (existing) {
+      throw new Error(
+        `Another mux server is already running at ${existing.baseUrl} (PID: ${existing.pid})`
+      );
+    }
+
+    // Create the server (Electron always binds to 127.0.0.1)
+    const serverOptions: OrpcServerOptions = {
+      host: "127.0.0.1",
+      port: options.port ?? 0,
+      context: options.context,
+      authToken: options.authToken,
+      router: options.router,
+      serveStatic: options.serveStatic ?? false,
+    };
+
+    const server = await createOrpcServer(serverOptions);
+
+    // Acquire the lockfile - clean up server if this fails
+    try {
+      await lockfile.acquire(server.baseUrl, options.authToken);
+    } catch (err) {
+      await server.close();
+      throw err;
+    }
+
+    // Only store references after successful acquisition - ensures stopServer
+    // won't delete another process's lockfile if we failed before acquiring
+    this.lockfile = lockfile;
+    this.server = server;
+    this.serverInfo = {
+      baseUrl: this.server.baseUrl,
+      token: options.authToken,
+    };
+
+    return this.serverInfo;
+  }
+
+  /**
+   * Stop the HTTP/WS API server and release the lockfile.
+   */
+  async stopServer(): Promise<void> {
+    if (this.lockfile) {
+      await this.lockfile.release();
+      this.lockfile = null;
+    }
+    if (this.server) {
+      await this.server.close();
+      this.server = null;
+    }
+    this.serverInfo = null;
+  }
+
+  /**
+   * Get information about the running server.
+   * Returns null if no server is running in this process.
+   */
+  getServerInfo(): ServerInfo | null {
+    return this.serverInfo;
+  }
+
+  /**
+   * Check if a server is running in this process.
+   */
+  isServerRunning(): boolean {
+    return this.server !== null;
   }
 }


### PR DESCRIPTION
## Summary

- Electron now runs an HTTP/WS API server on `127.0.0.1` alongside the existing MessagePort transport
- Both transports share the same oRPC router instance with auth middleware
- CLI tools can discover and connect to the running Electron app via lockfile at `~/.mux/server.lock`

## Changes

- Add `ServerLockfile` service for server discovery and conflict detection
- Extend `ServerService` with `startServer`/`stopServer` lifecycle methods
- Move `orpcServer.ts` to `src/node/orpc/server.ts` (shared module)
- Electron generates auth token, injects synthetic header for MessagePort
- CLI server checks lockfile to prevent conflicts
- CLI api auto-discovers running server via lockfile

## Environment Variables

| Variable | Purpose |
|----------|---------|
| `MUX_SERVER_AUTH_TOKEN` | Override auth token |
| `MUX_SERVER_PORT` | Fixed port (default: random) |
| `MUX_NO_API_SERVER=1` | Disable API server in Electron |

## Test plan

- [x] `make typecheck` passes
- [x] `make lint` passes
- [x] ServerLockfile tests pass (11 tests)
- [x] oRPC server tests pass (13 tests)

---
_Generated with mux_