### PR TITLE
🤖 fix: resolve race conditions in stream error handling and test flakiness

### DIFF
--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1270,7 +1270,7 @@ export class AIService extends EventEmitter {
   debugTriggerStreamError(
     workspaceId: string,
     errorMessage = "Test-triggered stream error"
-  ): boolean {
+  ): Promise<boolean> {
     return this.streamManager.debugTriggerStreamError(workspaceId, errorMessage);
   }
 

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -108,7 +108,7 @@ export class WorkspaceService extends EventEmitter {
    * This is used by integration tests to simulate network errors mid-stream.
    * @returns true if an active stream was found and error was triggered
    */
-  debugTriggerStreamError(workspaceId: string, errorMessage?: string): boolean {
+  debugTriggerStreamError(workspaceId: string, errorMessage?: string): Promise<boolean> {
     return this.aiService.debugTriggerStreamError(workspaceId, errorMessage);
   }
 


### PR DESCRIPTION
## Summary
- Make `debugTriggerStreamError` async and await `processingPromise` to ensure error handling completes before returning (eliminates duplicate error-handling logic)
- Wait for in-flight partial writes before writing error state to prevent inconsistent `partial.json`
- Pass `toolPolicy` on resume to match original message (tools disabled → text output)
- Add delay after resume to let history update complete before reading

_Generated with `mux`_