### PR TITLE
🤖 fix: add macOS fullscreen keyboard shortcut (Ctrl+Cmd+F)

### DIFF
--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -172,7 +172,10 @@ function createMenu() {
         { role: "zoomIn" },
         { role: "zoomOut" },
         { type: "separator" },
-        { role: "togglefullscreen" },
+        {
+          role: "togglefullscreen",
+          accelerator: process.platform === "darwin" ? "Ctrl+Command+F" : "F11",
+        },
       ],
     },
     {


### PR DESCRIPTION
The `togglefullscreen` menu role doesn't automatically bind the standard macOS keyboard shortcut. This adds explicit accelerators:

- **macOS**: `Ctrl+Command+F` (standard macOS fullscreen shortcut)
- **Windows/Linux**: `F11` (standard fullscreen shortcut)

This enables Rectangle and similar window managers to trigger fullscreen via the standard shortcut.

_Generated with `mux`_