### PR TITLE
🤖 fix: adjust solarized themes for sidebar icons and accent colors

### DIFF
--- a/src/browser/components/RuntimeBadge.tsx
+++ b/src/browser/components/RuntimeBadge.tsx
@@ -21,12 +21,12 @@ const RUNTIME_STYLES = {
   ssh: {
     idle: "bg-transparent text-muted border-[var(--color-runtime-ssh)]/50",
     working:
-      "bg-[var(--color-runtime-ssh)]/20 text-[var(--color-runtime-ssh)] border-[var(--color-runtime-ssh)]/60 animate-pulse",
+      "bg-[var(--color-runtime-ssh)]/20 text-[var(--color-runtime-ssh-text)] border-[var(--color-runtime-ssh)]/60 animate-pulse",
   },
   worktree: {
     idle: "bg-transparent text-muted border-[var(--color-runtime-worktree)]/50",
     working:
-      "bg-[var(--color-runtime-worktree)]/20 text-[var(--color-runtime-worktree)] border-[var(--color-runtime-worktree)]/60 animate-pulse",
+      "bg-[var(--color-runtime-worktree)]/20 text-[var(--color-runtime-worktree-text)] border-[var(--color-runtime-worktree)]/60 animate-pulse",
   },
   local: {
     idle: "bg-transparent text-muted border-[var(--color-runtime-local)]/50",

--- a/src/browser/components/RuntimeIconSelector.tsx
+++ b/src/browser/components/RuntimeIconSelector.tsx
@@ -22,12 +22,12 @@ const RUNTIME_STYLES = {
   ssh: {
     idle: "bg-transparent text-muted border-[var(--color-runtime-ssh)]/30 hover:border-[var(--color-runtime-ssh)]/50",
     active:
-      "bg-[var(--color-runtime-ssh)]/20 text-[var(--color-runtime-ssh)] border-[var(--color-runtime-ssh)]/60",
+      "bg-[var(--color-runtime-ssh)]/20 text-[var(--color-runtime-ssh-text)] border-[var(--color-runtime-ssh)]/60",
   },
   worktree: {
     idle: "bg-transparent text-muted border-[var(--color-runtime-worktree)]/30 hover:border-[var(--color-runtime-worktree)]/50",
     active:
-      "bg-[var(--color-runtime-worktree)]/20 text-[var(--color-runtime-worktree)] border-[var(--color-runtime-worktree)]/60",
+      "bg-[var(--color-runtime-worktree)]/20 text-[var(--color-runtime-worktree-text)] border-[var(--color-runtime-worktree)]/60",
   },
   local: {
     idle: "bg-transparent text-muted border-[var(--color-runtime-local)]/30 hover:border-[var(--color-runtime-local)]/50",

--- a/src/browser/components/ThinkingSlider.tsx
+++ b/src/browser/components/ThinkingSlider.tsx
@@ -30,7 +30,7 @@ const GLOW_INTENSITIES: Record<number, { track: string; thumb: string }> = {
 const getTextStyle = (n: number): React.CSSProperties => {
   if (n === 0) {
     return {
-      color: "var(--color-muted)",
+      color: "var(--color-text-secondary)",
       fontWeight: 400,
       textShadow: "none",
       fontSize: "10px",
@@ -52,7 +52,7 @@ const getTextStyle = (n: number): React.CSSProperties => {
 const getSliderStyles = (value: number, isHover = false) => {
   const effectiveValue = isHover ? Math.min(value + 1, 3) : value;
   // Use CSS variable for thumb color when active
-  const thumbBg = value === 0 ? "var(--color-muted)" : "var(--color-thinking-mode)";
+  const thumbBg = value === 0 ? "var(--color-text-secondary)" : "var(--color-thinking-mode)";
 
   return {
     trackShadow: GLOW_INTENSITIES[effectiveValue].track,

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -64,7 +64,9 @@
 
     /* Runtime icon colors (matches Tailwind blue-500/purple-500) */
     --color-runtime-ssh: #3b82f6;
+    --color-runtime-ssh-text: #60a5fa; /* blue-400 */
     --color-runtime-worktree: #a855f7;
+    --color-runtime-worktree-text: #c084fc; /* purple-400 */
     --color-runtime-local: hsl(0 0% 60%); /* matches --color-muted-foreground */
 
     /* Background & Layout */
@@ -307,7 +309,9 @@
 
   /* Runtime icon colors (matches Tailwind blue-500/purple-500) */
   --color-runtime-ssh: #3b82f6;
+  --color-runtime-ssh-text: #60a5fa;
   --color-runtime-worktree: #a855f7;
+  --color-runtime-worktree-text: #c084fc;
   --color-runtime-local: hsl(210 14% 48%); /* matches --color-muted-foreground */
 
   --color-background: hsl(210 33% 98%);
@@ -535,7 +539,9 @@
 
   /* Runtime icon colors - using solarized palette */
   --color-runtime-ssh: #268bd2; /* blue */
+  --color-runtime-ssh-text: #268bd2;
   --color-runtime-worktree: #6c71c4; /* violet */
+  --color-runtime-worktree-text: #6c71c4;
   --color-runtime-local: #839496; /* base0 */
 
   /* Background & Layout - Solarized base colors */
@@ -746,7 +752,9 @@
 
   /* Runtime icon colors - using solarized palette */
   --color-runtime-ssh: #268bd2; /* blue */
+  --color-runtime-ssh-text: #268bd2;
   --color-runtime-worktree: #6c71c4; /* violet */
+  --color-runtime-worktree-text: #6c71c4;
   --color-runtime-local: #839496; /* base0 */
 
   /* Background & Layout - Solarized dark base colors


### PR DESCRIPTION
## Summary

Adjusts the solarized themes to properly use the solarized color palette for:
- Runtime icons (local/worktree/SSH)
- Thinking slider and label
- Visual separation between sidebar, workspace, and input areas

## Changes

### Theme colors
- Add `--color-runtime-*` CSS variables using solarized palette:
  - SSH: blue (`#268bd2`)
  - Worktree: violet (`#6c71c4`)
  - Local: base0 (`#839496`)
- Update thinking colors to use solarized violet (`#6c71c4`)
- Create visual separation in solarized-dark: workspace slightly darker than sidebar

### Component updates
- Refactor `RuntimeBadge` and `RuntimeIconSelector` to use CSS variables instead of hardcoded Tailwind colors
- Update `ThinkingSlider` to use `--color-thinking-mode` CSS variable for label and glow effects

_Generated with `mux`_