### PR TITLE
🤖 feat(vscode): allow extension to be installed remotely

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,11 +2,12 @@
   "name": "mux",
   "displayName": "mux",
   "description": "Open mux workspaces directly from VS Code",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "coder",
   "icon": "icon.png",
   "extensionKind": [
-    "ui"
+    "ui",
+    "workspace"
   ],
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
Add `workspace` to `extensionKind` so the extension can be installed on remote machines (SSH, WSL, containers).

Bump version to 0.1.1.

_Generated with `mux`_