### PR TITLE
🤖 fix: prevent Windows bash windows from stealing focus

### DIFF
--- a/src/node/runtime/LocalBaseRuntime.ts
+++ b/src/node/runtime/LocalBaseRuntime.ts
@@ -91,6 +91,8 @@ export abstract class LocalBaseRuntime implements Runtime {
       // NOTE: detached:true does NOT cause bash to wait for background jobs when using 'exit' event
       // instead of 'close' event. The 'exit' event fires when bash exits, ignoring background children.
       detached: true,
+      // Prevent console window from appearing on Windows (WSL bash spawns steal focus otherwise)
+      windowsHide: true,
     });
 
     // Wrap in DisposableProcess for automatic cleanup
@@ -373,6 +375,8 @@ export abstract class LocalBaseRuntime implements Runtime {
           ...process.env,
           ...getInitHookEnv(projectPath, runtimeType),
         },
+        // Prevent console window from appearing on Windows
+        windowsHide: true,
       });
 
       proc.stdout.on("data", (data: Buffer) => {

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -185,6 +185,8 @@ export class SSHRuntime implements Runtime {
     // Spawn ssh command
     const sshProcess = spawn("ssh", sshArgs, {
       stdio: ["pipe", "pipe", "pipe"],
+      // Prevent console window from appearing on Windows
+      windowsHide: true,
     });
 
     // Wrap in DisposableProcess for automatic cleanup
@@ -408,7 +410,10 @@ export class SSHRuntime implements Runtime {
     sshArgs.push(this.config.host, command);
 
     return new Promise((resolve, reject) => {
-      const proc = spawn("ssh", sshArgs);
+      const proc = spawn("ssh", sshArgs, {
+        // Prevent console window from appearing on Windows
+        windowsHide: true,
+      });
       let stdout = "";
       let stderr = "";
       let timedOut = false;
@@ -591,7 +596,10 @@ export class SSHRuntime implements Runtime {
 
         log.debug(`Creating bundle: ${command}`);
         const bashPath = getBashPath();
-        const proc = spawn(bashPath, ["-c", command]);
+        const proc = spawn(bashPath, ["-c", command], {
+          // Prevent console window from appearing on Windows
+          windowsHide: true,
+        });
 
         const cleanup = streamProcessToLogger(proc, initLogger, {
           logStdout: false,

--- a/src/node/services/bashExecutionService.ts
+++ b/src/node/services/bashExecutionService.ts
@@ -138,6 +138,8 @@ export class BashExecutionService {
       // When bash spawns background processes, detached:true allows killing
       // the entire group via process.kill(-pid)
       detached: config.detached ?? true,
+      // Prevent console window from appearing on Windows (WSL bash spawns steal focus otherwise)
+      windowsHide: true,
     });
 
     log.debug(`BashExecutionService: Spawned process with PID ${child.pid ?? "unknown"}`);


### PR DESCRIPTION
On Windows, when spawning bash processes (via Git Bash or WSL), the
default behavior creates visible console windows that steal focus.

Add `windowsHide: true` to all `spawn()` calls that run background bash
or ssh processes. This prevents the console windows from appearing.

The terminal service spawn calls intentionally remain visible since
they're meant to open user-facing terminal windows.

**Fixed locations:**
- `LocalBaseRuntime.ts`: exec() and runInitHook()
- `bashExecutionService.ts`: executeStreaming()
- `SSHRuntime.ts`: exec(), execSSHCommand(), and bundle creation

_Generated with `mux`_