### PR TITLE
🤖 fix: make StreamError storybook story deterministic

### DIFF
--- a/src/browser/stories/App.errors.stories.tsx
+++ b/src/browser/stories/App.errors.stories.tsx
@@ -14,6 +14,7 @@ import {
   createFileEditTool,
   createStaticChatHandler,
 } from "./mockFactory";
+import { getAutoRetryKey } from "@/common/constants/storage";
 import { selectWorkspace, setupSimpleChatStory, setupCustomChatStory } from "./storyHelpers";
 import { createMockORPCClient } from "../../../.storybook/mocks/orpc";
 
@@ -99,9 +100,13 @@ const LARGE_DIFF = [
 export const StreamError: AppStory = {
   render: () => (
     <AppWithMocks
-      setup={() =>
-        setupCustomChatStory({
-          workspaceId: "ws-error",
+      setup={() => {
+        const workspaceId = "ws-error";
+        // Disable auto-retry to show deterministic "Retry" button instead of countdown timer
+        localStorage.setItem(getAutoRetryKey(workspaceId), JSON.stringify(false));
+
+        return setupCustomChatStory({
+          workspaceId,
           chatHandler: (callback: (event: WorkspaceChatMessage) => void) => {
             setTimeout(() => {
               callback(
@@ -123,8 +128,8 @@ export const StreamError: AppStory = {
             // eslint-disable-next-line @typescript-eslint/no-empty-function
             return () => {};
           },
-        })
-      }
+        });
+      }}
     />
   ),
 };


### PR DESCRIPTION
Disable auto-retry in the StreamError story to show the deterministic 'Retry' button instead of a live countdown timer. The countdown was flaky in visual tests because it used `Date.now()` to calculate remaining time.

_Generated with `mux`_