### PR TITLE
🤖 feat: add OpenAPI spec and Scalar API docs endpoints

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "@mozilla/readability": "^0.6.0",
         "@openrouter/ai-sdk-provider": "^1.2.5",
         "@orpc/client": "^1.11.3",
+        "@orpc/openapi": "^1.12.2",
         "@orpc/server": "^1.11.3",
         "@orpc/zod": "^1.11.3",
         "@radix-ui/react-checkbox": "^1.3.3",

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,8 +18,8 @@ module.exports = {
   transform: {
     "^.+\\.(ts|tsx|js|mjs)$": ["babel-jest"],
   },
-  // Transform ESM modules (like shiki, @orpc) to CommonJS for Jest
-  transformIgnorePatterns: ["node_modules/(?!(@orpc|shiki)/)"],
+  // Transform ESM modules to CommonJS for Jest
+  transformIgnorePatterns: ["node_modules/(?!(@orpc|shiki|json-schema-typed|rou3)/)"],
   // Run tests in parallel (use 50% of available cores, or 4 minimum)
   maxWorkers: "50%",
   // Force exit after tests complete to avoid hanging on lingering handles

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@mozilla/readability": "^0.6.0",
     "@openrouter/ai-sdk-provider": "^1.2.5",
     "@orpc/client": "^1.11.3",
+    "@orpc/openapi": "^1.12.2",
     "@orpc/server": "^1.11.3",
     "@orpc/zod": "^1.11.3",
     "@radix-ui/react-checkbox": "^1.3.3",


### PR DESCRIPTION
## Summary
- Add `/api/spec.json` endpoint serving OpenAPI 3.x spec generated from oRPC router
- Add `/api/docs` endpoint with Scalar API reference UI
- Add OpenAPI REST handler for Scalar/OpenAPI clients
- Return `specUrl` and `docsUrl` from server start

_Generated with `mux`_