### PR TITLE
🤖 fix: scroll to bottom on workspace switch using ResizeObserver

### DIFF
--- a/src/browser/components/AIView.tsx
+++ b/src/browser/components/AIView.tsx
@@ -209,6 +209,7 @@ const AIViewInner: React.FC<AIViewProps> = ({
   // Use auto-scroll hook for scroll management
   const {
     contentRef,
+    innerRef,
     autoScroll,
     setAutoScroll,
     performAutoScroll,
@@ -500,7 +501,10 @@ const AIViewInner: React.FC<AIViewProps> = ({
             data-testid="message-window"
             className="h-full overflow-y-auto p-[15px] leading-[1.5] break-words whitespace-pre-wrap"
           >
-            <div className={cn("max-w-4xl mx-auto", mergedMessages.length === 0 && "h-full")}>
+            <div
+              ref={innerRef}
+              className={cn("max-w-4xl mx-auto", mergedMessages.length === 0 && "h-full")}
+            >
               {mergedMessages.length === 0 ? (
                 <div className="text-placeholder flex h-full flex-1 flex-col items-center justify-center text-center [&_h3]:m-0 [&_h3]:mb-2.5 [&_h3]:text-base [&_h3]:font-medium [&_p]:m-0 [&_p]:text-[13px]">
                   <h3>No Messages Yet</h3>


### PR DESCRIPTION
Fixes workspace switch not scrolling to bottom reliably.

## Problem
Clicking a workspace didn't always scroll to the bottom because async content (Shiki highlighting, Mermaid diagrams, images) rendered after the double `requestAnimationFrame` scroll completed.

## Solution
Replace double RAF with a `ResizeObserver` on the inner message container. When the container grows during the auto-scroll window, we re-scroll to bottom. The observer is managed via a callback ref that properly cleans up on unmount/re-attach.

_Generated with `mux`_