### PR TITLE
🤖 fix: use clean URLs in docs links

### DIFF
--- a/docs/agentic-git-identity.md
+++ b/docs/agentic-git-identity.md
@@ -44,7 +44,7 @@ Classic tokens are easier to configure than fine-grained tokens for repository a
 
 ## Step 3: Configure Git Identity
 
-Add the Git identity environment variables as [Project Secrets](./project-secrets.md) in mux:
+Add the Git identity environment variables as [Project Secrets](/project-secrets) in mux:
 
 1. Open mux and find your project in the sidebar
 2. Click the 🔑 key icon to open the secrets modal

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,10 +18,10 @@ mux helps you work with multiple coding assistants more effectively via:
 
 ## Quick Links
 
-- [Install](./install.md) - Download and installation instructions
-- [Why Parallelize?](./why-parallelize.md) - Why parallelize?
-- [Keyboard Shortcuts](./keybinds.md) - Complete keyboard reference
-- [AGENTS](./AGENTS.md) - Developer guide for AI assistants
+- [Install](/install) - Download and installation instructions
+- [Why Parallelize?](/why-parallelize) - Why parallelize?
+- [Keyboard Shortcuts](/keybinds) - Complete keyboard reference
+- [AGENTS](/AGENTS) - Developer guide for AI assistants
 
 ## License
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -5,7 +5,7 @@ description: Configure AI providers including Anthropic, OpenAI, Google, xAI, an
 
 See also:
 
-- [System Prompt](./system-prompt.md)
+- [System Prompt](/system-prompt)
 
 mux supports multiple AI providers through its flexible provider architecture.
 

--- a/docs/mux-codes.md
+++ b/docs/mux-codes.md
@@ -10,7 +10,7 @@ A code looks like `ABC-123`.
 Redemption is straightforward:
 
 1. Go to [gateway.mux.coder.com](https://gateway.mux.coder.com) and follow instructions to enable the code.
-1. Open Mux (see [install](./install.md) for instructions)
+1. Open Mux (see [install](/install) for instructions)
 1. Click the Settings icon in the top left corner (Cmd+, on macOS)
 1. Under Providers, enter the code under Mux Gateway:
    ![Mux Gateway Code](./img/mux-gateway-code.webp)

--- a/docs/project-secrets.md
+++ b/docs/project-secrets.md
@@ -54,4 +54,4 @@ The agent doesn't need to explicitly reference secrets - they're available as re
 
 ## Related
 
-- [Agentic Git Identity](./agentic-git-identity.md) - Configure Git credentials for AI commits using Project Secrets
+- [Agentic Git Identity](/agentic-git-identity) - Configure Git credentials for AI commits using Project Secrets

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -5,11 +5,11 @@ description: Configure where and how mux executes agent workspaces
 
 Runtimes determine where and how mux executes agent workspaces.
 
-| Runtime                               | Isolation                                  | Best For                                 |
-| ------------------------------------- | ------------------------------------------ | ---------------------------------------- |
-| **[Local](./runtime/local.md)**       | All workspaces share the project directory | Quick edits to your working copy         |
-| **[Worktree](./runtime/worktree.md)** | Each workspace gets its own directory      | Running multiple agents in parallel      |
-| **[SSH](./runtime/ssh.md)**           | Remote execution over SSH                  | Security, performance, heavy parallelism |
+| Runtime                           | Isolation                                  | Best For                                 |
+| --------------------------------- | ------------------------------------------ | ---------------------------------------- |
+| **[Local](/runtime/local)**       | All workspaces share the project directory | Quick edits to your working copy         |
+| **[Worktree](/runtime/worktree)** | Each workspace gets its own directory      | Running multiple agents in parallel      |
+| **[SSH](/runtime/ssh)**           | Remote execution over SSH                  | Security, performance, heavy parallelism |
 
 ## Choosing a Runtime
 
@@ -17,7 +17,7 @@ When creating a workspace, select the runtime from the dropdown in the workspace
 
 ## Init Hooks
 
-[Init hooks](./init-hooks.md) can detect the runtime type via the `MUX_RUNTIME` environment variable:
+[Init hooks](/init-hooks) can detect the runtime type via the `MUX_RUNTIME` environment variable:
 
 - `local` — Local runtime
 - `worktree` — Worktree runtime

--- a/docs/runtime/ssh.md
+++ b/docs/runtime/ssh.md
@@ -6,12 +6,12 @@ description: Run agents on remote hosts over SSH for security and performance
 mux supports using remote hosts over SSH for workspaces. When configured, all tool operations will
 execute over SSH and the agent is securely isolated from your local machine.
 
-Our security architecture considers the remote machine potentially hostile. No keys or credentials are implicitly transferred there—just the git archive and [Project Secrets](../project-secrets.md).
+Our security architecture considers the remote machine potentially hostile. No keys or credentials are implicitly transferred there—just the git archive and [Project Secrets](/project-secrets).
 
 We highly recommend using SSH workspaces for an optimal experience:
 
 - **Security**: Prompt injection risk is contained to the credentials / files on the remote machine.
-  - SSH remotes pair nicely with [agentic git identities](../agentic-git-identity.md)
+  - SSH remotes pair nicely with [agentic git identities](/agentic-git-identity)
 - **Performance**: Run many, many agents in parallel while maintaining good battery life and UI performance
 
 ![ssh workspaces](../img/new-workspace-ssh.webp)

--- a/docs/vscode-extension.md
+++ b/docs/vscode-extension.md
@@ -87,6 +87,6 @@ repository.
 
 ## Related
 
-- [Workspaces Overview](./workspaces.md)
-- [SSH Runtime](./runtime/ssh.md)
+- [Workspaces Overview](/workspaces)
+- [SSH Runtime](/runtime/ssh)
 - [VS Code Remote-SSH Documentation](https://code.visualstudio.com/docs/remote/ssh)

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -7,13 +7,13 @@ Workspaces in mux provide isolated development environments for parallel agent w
 
 ## Runtimes
 
-mux supports three [runtime types](./runtime.md):
+mux supports three [runtime types](/runtime):
 
-- **[Local](./runtime/local.md)**: Run directly in your project directory. No isolation—best for quick edits to your working copy.
+- **[Local](/runtime/local)**: Run directly in your project directory. No isolation—best for quick edits to your working copy.
 
-- **[Worktree](./runtime/worktree.md)**: Isolated directories using [git worktrees](https://git-scm.com/docs/git-worktree). Worktrees share `.git` with your main repository while maintaining independent working changes.
+- **[Worktree](/runtime/worktree)**: Isolated directories using [git worktrees](https://git-scm.com/docs/git-worktree). Worktrees share `.git` with your main repository while maintaining independent working changes.
 
-- **[SSH](./runtime/ssh.md)**: Remote execution over SSH. Ideal for heavy workloads, security isolation, or leveraging remote infrastructure.
+- **[SSH](/runtime/ssh)**: Remote execution over SSH. Ideal for heavy workloads, security isolation, or leveraging remote infrastructure.
 
 ## Choosing a Runtime
 
@@ -35,7 +35,7 @@ The runtime is selected when you create a workspace:
 Here are a few practical approaches to reviewing changes from workspaces, depending on how much you want your agent to interact with `git`:
 
 - **Agent codes, commits, and pushes**: Ask agent to submit a PR and review changes in your git Web UI (GitHub, GitLab, etc.)
-  - Also see: [Agentic Git Identity](./agentic-git-identity.md)
+  - Also see: [Agentic Git Identity](/agentic-git-identity)
   - This is the preferred approach for `mux` development but requires additional care with repository security.
 - **Agent codes and commits**: Review changes from the main repository via `git diff <workspace-branch>`, push changes when deemed acceptable.
 - **Agent codes**: Enter worktree (click Terminal icon in workspace top bar), run `git add -p` and progressively accept changes into a commit.


### PR DESCRIPTION
Replace `.md` file links with clean URLs for Mintlify compatibility.

For example: `[install](./install.md)` → `[install](/install)`

**Files updated:** 9 docs files with internal links

_Generated with mux_