### PR TITLE
🤖 fix: use static mode for completed markdown to prevent render delay

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "mux",

--- a/src/browser/components/Messages/MarkdownCore.tsx
+++ b/src/browser/components/Messages/MarkdownCore.tsx
@@ -62,6 +62,9 @@ export const MarkdownCore = React.memo<MarkdownCoreProps>(
           remarkPlugins={REMARK_PLUGINS}
           rehypePlugins={REHYPE_PLUGINS}
           parseIncompleteMarkdown={parseIncompleteMarkdown}
+          // Use "static" mode for completed content to bypass useTransition() deferral.
+          // After ORPC migration, async event boundaries let React deprioritize transitions indefinitely.
+          mode={parseIncompleteMarkdown ? "streaming" : "static"}
           className="space-y-2" // Reduce from default space-y-4 (16px) to space-y-2 (8px)
           controls={{ table: false, code: true, mermaid: true }} // Disable table copy/download, keep code/mermaid controls
         >


### PR DESCRIPTION
## Summary

Fixes plan body taking 10+ seconds to render after the ORPC migration.

## Root Cause

After ORPC, IPC events go through async iterators with microtask boundaries, giving React more opportunities to deprioritize Streamdown's `useTransition()` indefinitely.

## Fix

Set `mode="static"` for completed content (`parseIncompleteMarkdown=false`) to bypass `useTransition()` and render immediately. This aligns with Streamdown's intended API:
- `mode="streaming"` - for incremental content, uses `useTransition()`
- `mode="static"` - for complete content, renders immediately

Even if this doesn't fully resolve the delay, the change is correct regardless - we were incorrectly using streaming mode for all content, including completed messages.

---
_Generated with `mux`_