### PR TITLE
🤖 ci: add Windows build to PR/merge queue and code signing to releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,42 @@ jobs:
           retention-days: 30
           if-no-files-found: error
 
+  build-windows:
+    name: Build Windows
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for git describe to find tags
+
+      - uses: ./.github/actions/setup-mux
+
+      - name: Install GNU Make (for build)
+        run: choco install -y make
+
+      - name: Verify tools
+        shell: bash
+        run: |
+          make --version
+          bun --version
+          magick --version | head -1
+
+      - name: Build application
+        run: bun run build
+
+      # No code signing - releases use release.yml (triggered by tag publish).
+      - name: Package for Windows
+        run: make dist-win
+
+      - name: Upload Windows exe
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-exe
+          path: release/*.exe
+          retention-days: 30
+          if-no-files-found: error
+
   build-vscode-extension:
     name: Build VS Code Extension
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-16' || 'ubuntu-latest' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,6 +168,22 @@ jobs:
       - name: Build application
         run: bun run build
 
+      - name: Setup code signing
+        shell: bash
+        run: |
+          if [ -n "$WINDOWS_CERTIFICATE" ]; then
+            echo "Setting up Windows code signing certificate..."
+            echo "$WINDOWS_CERTIFICATE" | base64 -d > /tmp/certificate.pfx
+            echo "CSC_LINK=/tmp/certificate.pfx" >> "$GITHUB_ENV"
+            echo "CSC_KEY_PASSWORD=$WINDOWS_CERTIFICATE_PWD" >> "$GITHUB_ENV"
+            echo "✅ Windows code signing configured"
+          else
+            echo "⚠️ No Windows code signing certificate provided - building unsigned"
+          fi
+        env:
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PWD: ${{ secrets.WINDOWS_CERTIFICATE_PWD }}
+
       - name: Package and publish for Windows (.exe)
         run: bun x electron-builder --win --publish always
         env:


### PR DESCRIPTION
- Add Windows build job to build.yml (runs on PRs and merge queue)
- Add Windows code signing setup to release.yml (mirrors Mac signing pattern)  
- Uses WINDOWS_CERTIFICATE and WINDOWS_CERTIFICATE_PWD secrets

_Generated with `mux`_