### PR TITLE
🤖 fix: use regional locale for build date display

### DIFF
--- a/src/browser/components/TitleBar.tsx
+++ b/src/browser/components/TitleBar.tsx
@@ -34,12 +34,13 @@ function hasBuildInfo(value: unknown): value is VersionMetadata {
   return typeof candidate.buildTime === "string";
 }
 
-function formatUSDate(isoDate: string): string {
+function formatLocalDate(isoDate: string): string {
   const date = new Date(isoDate);
-  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-  const day = String(date.getUTCDate()).padStart(2, "0");
-  const year = date.getUTCFullYear();
-  return `${month}/${day}/${year}`;
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
 }
 
 function formatExtendedTimestamp(isoDate: string): string {
@@ -61,7 +62,7 @@ function parseBuildInfo(version: unknown) {
     const gitDescribe = typeof git_describe === "string" ? git_describe : undefined;
 
     return {
-      buildDate: formatUSDate(buildTime),
+      buildDate: formatLocalDate(buildTime),
       extendedTimestamp: formatExtendedTimestamp(buildTime),
       gitDescribe,
     };


### PR DESCRIPTION
Replace hardcoded US date format (MM/DD/YYYY) with `toLocaleDateString()` to respect the user's regional settings.

## Changes
- Renamed `formatUSDate` → `formatLocalDate`
- Uses `toLocaleDateString(undefined, {...})` with `undefined` locale to automatically use the user's system locale
- Maintains the same date components (year, month, day) but adapts ordering and separators to regional conventions

**Examples:**
- US: 12/05/2025
- UK/EU: 05/12/2025
- Germany: 05.12.2025
- Japan: 2025/12/05

_Generated with `mux`_