### PR TITLE
🤖 fix: show removeProject errors in UI instead of only console

### DIFF
--- a/.storybook/mocks/orpc.ts
+++ b/.storybook/mocks/orpc.ts
@@ -25,6 +25,8 @@ export interface MockORPCClientOptions {
   providersConfig?: Record<string, { apiKeySet: boolean; baseUrl?: string; models?: string[] }>;
   /** List of available provider names */
   providersList?: string[];
+  /** Mock for projects.remove - return error string to simulate failure */
+  onProjectRemove?: (projectPath: string) => { success: true } | { success: false; error: string };
 }
 
 /**
@@ -52,6 +54,7 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
     executeBash,
     providersConfig = {},
     providersList = [],
+    onProjectRemove,
   } = options;
 
   const workspaceMap = new Map(workspaces.map((w) => [w.id, w]));
@@ -99,7 +102,12 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
         branches: ["main", "develop", "feature/new-feature"],
         recommendedTrunk: "main",
       }),
-      remove: async () => ({ success: true, data: undefined }),
+      remove: async (input: { projectPath: string }) => {
+        if (onProjectRemove) {
+          return onProjectRemove(input.projectPath);
+        }
+        return { success: true, data: undefined };
+      },
       secrets: {
         get: async () => [],
         update: async () => ({ success: true, data: undefined }),

--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -183,11 +183,11 @@ function AppInner() {
   const openWorkspaceInTerminal = useOpenTerminal();
 
   const handleRemoveProject = useCallback(
-    async (path: string) => {
+    async (path: string): Promise<{ success: boolean; error?: string }> => {
       if (selectedWorkspace?.projectPath === path) {
         setSelectedWorkspace(null);
       }
-      await removeProject(path);
+      return removeProject(path);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [selectedWorkspace, setSelectedWorkspace]

--- a/src/browser/components/PopoverError.tsx
+++ b/src/browser/components/PopoverError.tsx
@@ -1,0 +1,44 @@
+import { createPortal } from "react-dom";
+import type { PopoverErrorState } from "@/browser/hooks/usePopoverError";
+
+interface PopoverErrorProps {
+  error: PopoverErrorState | null;
+  prefix: string;
+  onDismiss?: () => void;
+}
+
+/**
+ * Floating error popover that displays near the trigger element.
+ * Styled to match the app's toast error design.
+ */
+export function PopoverError(props: PopoverErrorProps) {
+  if (!props.error) return null;
+
+  return createPortal(
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="bg-dark border-toast-error-border text-toast-error-text pointer-events-auto fixed z-[10000] flex max-w-80 animate-[toastSlideIn_0.2s_ease-out] items-start gap-2 rounded border px-3 py-2 text-xs shadow-[0_4px_12px_rgba(0,0,0,0.3)]"
+      style={{
+        top: `${props.error.position.top}px`,
+        left: `${props.error.position.left}px`,
+      }}
+    >
+      <span className="text-sm leading-none">⚠</span>
+      <div className="flex-1 leading-[1.4] break-words whitespace-pre-wrap">
+        <span className="font-medium">{props.prefix}</span>
+        <p className="text-light mt-1">{props.error.error}</p>
+      </div>
+      {props.onDismiss && (
+        <button
+          onClick={props.onDismiss}
+          aria-label="Dismiss"
+          className="flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center border-0 bg-transparent p-0 text-base leading-none text-inherit opacity-60 transition-opacity hover:opacity-100"
+        >
+          ×
+        </button>
+      )}
+    </div>,
+    document.body
+  );
+}

--- a/src/browser/hooks/usePopoverError.ts
+++ b/src/browser/hooks/usePopoverError.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface PopoverErrorState {
+  id: string;
+  error: string;
+  position: { top: number; left: number };
+}
+
+export interface UsePopoverErrorResult {
+  error: PopoverErrorState | null;
+  showError: (id: string, error: string, anchor?: { top: number; left: number }) => void;
+  clearError: () => void;
+}
+
+/**
+ * Hook for managing popover error state with auto-dismiss and click-outside behavior.
+ * @param autoDismissMs - Time in ms before auto-dismissing (default: 5000)
+ */
+export function usePopoverError(autoDismissMs = 5000): UsePopoverErrorResult {
+  const [error, setError] = useState<PopoverErrorState | null>(null);
+  const timeoutRef = useRef<number | null>(null);
+
+  const clearError = useCallback(() => {
+    setError(null);
+    if (timeoutRef.current) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const showError = useCallback(
+    (id: string, errorMsg: string, anchor?: { top: number; left: number }) => {
+      if (timeoutRef.current) {
+        window.clearTimeout(timeoutRef.current);
+      }
+
+      const position = anchor ?? {
+        top: window.scrollY + 32,
+        left: Math.max(window.innerWidth - 420, 16),
+      };
+
+      setError({ id, error: errorMsg, position });
+
+      timeoutRef.current = window.setTimeout(() => {
+        setError(null);
+        timeoutRef.current = null;
+      }, autoDismissMs);
+    },
+    [autoDismissMs]
+  );
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  // Click-outside to dismiss
+  useEffect(() => {
+    if (!error) return;
+
+    const handleClickOutside = () => clearError();
+
+    // Delay to avoid immediate dismissal from the triggering click
+    const timeoutId = window.setTimeout(() => {
+      document.addEventListener("click", handleClickOutside, { once: true });
+    }, 0);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+      document.removeEventListener("click", handleClickOutside);
+    };
+  }, [error, clearError]);
+
+  return { error, showError, clearError };
+}


### PR DESCRIPTION
When removing a project fails (e.g., when it has active workspaces), the error was only logged to the console and not shown in the UI. 

## Changes
- Changed `removeProject` to return `{ success, error }` result instead of `void`
- Added `projectRemoveError` state and `showProjectRemoveError` helper in `ProjectSidebar`
- Display error popup near the remove button when project removal fails
- Matches the existing pattern used for workspace removal errors

The error message now appears as a floating popup near the remove button, auto-dismissing after 5 seconds (same behavior as workspace removal errors).

_Generated with `mux`_