### PR TITLE
🤖 feat: monospace font in chat input for vim mode

### DIFF
--- a/src/browser/components/VimTextArea.tsx
+++ b/src/browser/components/VimTextArea.tsx
@@ -250,7 +250,8 @@ export const VimTextArea = React.forwardRef<HTMLTextAreaElement, VimTextAreaProp
               ...(trailingAction ? { scrollbarGutter: "stable both-edges" } : {}),
             }}
             className={cn(
-              "w-full border text-light py-1.5 px-2 rounded font-sans text-[13px] resize-none min-h-8 max-h-[50vh] overflow-y-auto",
+              "w-full border text-light py-1.5 px-2 rounded text-[13px] resize-none min-h-8 max-h-[50vh] overflow-y-auto",
+              vimEnabled ? "font-monospace" : "font-sans",
               "placeholder:text-placeholder",
               "focus:outline-none",
               trailingAction && "pr-10",


### PR DESCRIPTION
Uses monospace font for the chat input textarea when vim mode is enabled, providing better visual indication that vim keybindings are active.

The font switches conditionally based on the `vimEnabled` state - it applies in both insert and normal vim modes when vim is toggled on.

_Generated with `mux`_