### PR TITLE
🤖 feat: include workspaceId in message_sent telemetry payload

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -1018,6 +1018,7 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
         } else {
           // Track telemetry for successful message send
           telemetry.messageSent(
+            props.workspaceId,
             sendMessageOptions.model,
             mode,
             actualMessageText.length,

--- a/src/browser/hooks/useTelemetry.ts
+++ b/src/browser/hooks/useTelemetry.ts
@@ -29,7 +29,7 @@ import type {
  *
  * telemetry.workspaceSwitched(fromId, toId);
  * telemetry.workspaceCreated(workspaceId, runtimeType);
- * telemetry.messageSent(model, mode, messageLength, runtimeType, thinkingLevel);
+ * telemetry.messageSent(workspaceId, model, mode, messageLength, runtimeType, thinkingLevel);
  * telemetry.streamCompleted(model, wasInterrupted, durationSecs, outputTokens);
  * telemetry.providerConfigured(provider, keyType);
  * telemetry.commandUsed(commandType);
@@ -48,13 +48,14 @@ export function useTelemetry() {
 
   const messageSent = useCallback(
     (
+      workspaceId: string,
       model: string,
       mode: string,
       messageLength: number,
       runtimeType: TelemetryRuntimeType,
       thinkingLevel: TelemetryThinkingLevel
     ) => {
-      trackMessageSent(model, mode, messageLength, runtimeType, thinkingLevel);
+      trackMessageSent(workspaceId, model, mode, messageLength, runtimeType, thinkingLevel);
     },
     []
   );

--- a/src/common/orpc/schemas/telemetry.ts
+++ b/src/common/orpc/schemas/telemetry.ts
@@ -61,6 +61,7 @@ const WorkspaceSwitchedPropertiesSchema = z.object({
 });
 
 const MessageSentPropertiesSchema = z.object({
+  workspaceId: z.string(),
   model: z.string(),
   mode: z.string(),
   message_length_b2: z.number(),

--- a/src/common/telemetry/payload.ts
+++ b/src/common/telemetry/payload.ts
@@ -92,6 +92,8 @@ export type TelemetryThinkingLevel = "off" | "low" | "medium" | "high";
  * Chat/AI interaction events
  */
 export interface MessageSentPayload {
+  /** Workspace ID (randomly generated, safe to send) */
+  workspaceId: string;
   /** Full model identifier (e.g., 'anthropic/claude-3-5-sonnet-20241022') */
   model: string;
   /** UI mode (e.g., 'plan', 'exec', 'edit') */

--- a/src/common/telemetry/tracking.ts
+++ b/src/common/telemetry/tracking.ts
@@ -65,6 +65,7 @@ export function trackWorkspaceSwitched(fromWorkspaceId: string, toWorkspaceId: s
  * @param messageLength - Raw character count (will be rounded to base-2)
  */
 export function trackMessageSent(
+  workspaceId: string,
   model: string,
   mode: string,
   messageLength: number,
@@ -74,6 +75,7 @@ export function trackMessageSent(
   trackEvent({
     event: "message_sent",
     properties: {
+      workspaceId,
       model,
       mode,
       message_length_b2: roundToBase2(messageLength),


### PR DESCRIPTION
_Generated with `mux`_

Adds the workspace ID (already random/anonymous) to the `message_sent` telemetry event for per-workspace analytics.

The workspace ID is randomly generated (e.g., UUID format) and contains no user information, so it's safe to include per the existing privacy guidelines in `payload.ts`.