### PR TITLE
🤖 docs: add Discord badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Build](https://github.com/coder/mux/actions/workflows/build.yml/badge.svg?event=merge_group)](https://github.com/coder/mux/actions/workflows/build.yml?query=event:merge_group)
 [![Download](https://img.shields.io/badge/Download-Releases-purple)](https://github.com/coder/mux/releases)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL%203.0-blue.svg)](LICENSE)
+[![Discord](https://img.shields.io/discord/1446553342699507907?logo=discord&label=Discord)](https://discord.gg/thkEdtwm8c)
 
 </div>
 


### PR DESCRIPTION
Adds a shields.io Discord badge linking to the mux Discord server.

_Generated with `mux`_