### PR TITLE
🤖 fix: prevent race condition when reloading with stale workspace

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -121,14 +121,6 @@ function AppInner() {
     prevWorkspaceRef.current = selectedWorkspace;
   }, [selectedWorkspace, telemetry]);
 
-  // Validate selectedWorkspace when metadata changes
-  // Clear selection if workspace was deleted
-  useEffect(() => {
-    if (selectedWorkspace && !workspaceMetadata.has(selectedWorkspace.workspaceId)) {
-      setSelectedWorkspace(null);
-    }
-  }, [selectedWorkspace, workspaceMetadata, setSelectedWorkspace]);
-
   // Track last-read timestamps for unread indicators
   const { lastReadTimestamps, onToggleUnread } = useUnreadTracking(selectedWorkspace);
 


### PR DESCRIPTION
## Problem

On page reload in Electron, the app fails to restore the previously selected workspace and instead shows the home page with this error:

```
Workspace 6164ccb357 no longer exists, clearing selection
```

## Root Cause

Two race conditions were causing this:

### 1. API connection timing
`WorkspaceContext`'s `loadWorkspaceMetadata()` returned early when `api` was null (during initial 'connecting' state), but `setLoading(false)` was still called. This caused `App` to render with empty metadata while `selectedWorkspace` was restored from localStorage, triggering the validation effect to clear the selection.

### 2. Missing metadata guard
Even after fixing the API timing, if `selectedWorkspace` from localStorage referred to a deleted workspace, the `AIView` would try to render before the validation effect could clear the stale selection.

## Solution

1. **Wait for API**: `loadWorkspaceMetadata` now returns a boolean indicating success. The effect only calls `setLoading(false)` after actual load. When `api` becomes available, the effect re-runs.

2. **Guard AIView render**: If `selectedWorkspace` exists but `currentMetadata` is undefined, return `null` instead of rendering `AIView`. The validation effect will clear the stale selection on the next tick.

3. **Remove redundant effect**: Removed the simple validation effect (lines 126-130) since the comprehensive one (lines 165-189) handles all cases including missing fields update.

---

_Generated with `mux`_