### PR TITLE
🤖 fix: remove duplicate caught-up event in onChat subscription

### DIFF
--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -370,15 +370,10 @@ export const router = (authToken?: string) => {
             push(message);
           });
 
-          // 2. Replay history
+          // 2. Replay history (sends caught-up at the end)
           await session.replayHistory(({ message }) => {
             push(message);
           });
-
-          // 3. Signal that subscription is established and history replay is complete
-          // This allows clients to know when they can safely send messages without
-          // missing events due to async generator setup timing
-          push({ type: "caught-up" });
 
           try {
             yield* iterate();


### PR DESCRIPTION
## Summary

The `onChat` handler was pushing a `caught-up` event after `replayHistory`, but `replayHistory` already sends `caught-up` at the end of `emitHistoricalEvents`. This resulted in two `caught-up` events being sent to the client.

## Changes

- Removed the duplicate `push({ type: "caught-up" })` from the router since `session.replayHistory()` already sends it

## Testing

- Existing integration tests pass (`resumeStream.test.ts`)
- `WorkspaceStore.test.ts` passes
- Typecheck passes

---
_Generated with `mux`_