### PR TITLE
🤖 fix: filter telemetry DAUs from CI/automation environments

### DIFF
--- a/src/common/telemetry/client.ts
+++ b/src/common/telemetry/client.ts
@@ -12,15 +12,35 @@
 import type { TelemetryEventPayload } from "./payload";
 
 /**
- * Check if we're running in a test environment
+ * Check if running in a CI/automation environment.
+ * Covers major CI providers. This is a subset of what the backend checks
+ * since the browser process has limited env var access.
+ */
+function isCIEnvironment(): boolean {
+  if (typeof process === "undefined") {
+    return false;
+  }
+  return (
+    process.env.CI === "true" ||
+    process.env.CI === "1" ||
+    process.env.GITHUB_ACTIONS === "true" ||
+    process.env.GITLAB_CI === "true" ||
+    process.env.JENKINS_URL !== undefined ||
+    process.env.CIRCLECI === "true"
+  );
+}
+
+/**
+ * Check if we're running in a test or CI environment
  */
 function isTestEnvironment(): boolean {
   return (
-    typeof process !== "undefined" &&
-    (process.env.NODE_ENV === "test" ||
-      process.env.JEST_WORKER_ID !== undefined ||
-      process.env.VITEST !== undefined ||
-      process.env.TEST_INTEGRATION === "1")
+    (typeof process !== "undefined" &&
+      (process.env.NODE_ENV === "test" ||
+        process.env.JEST_WORKER_ID !== undefined ||
+        process.env.VITEST !== undefined ||
+        process.env.TEST_INTEGRATION === "1")) ||
+    isCIEnvironment()
   );
 }
 

--- a/src/node/services/telemetryService.ts
+++ b/src/node/services/telemetryService.ts
@@ -25,7 +25,47 @@ const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
 const TELEMETRY_ID_FILE = "telemetry_id";
 
 /**
- * Check if telemetry is disabled via environment variable
+ * Check if running in a CI/automation environment.
+ * Covers major CI providers: GitHub Actions, GitLab CI, Jenkins, CircleCI,
+ * Travis, Azure Pipelines, Bitbucket, TeamCity, Buildkite, etc.
+ */
+function isCIEnvironment(): boolean {
+  return (
+    // Generic CI indicator (set by most CI systems)
+    process.env.CI === "true" ||
+    process.env.CI === "1" ||
+    // GitHub Actions
+    process.env.GITHUB_ACTIONS === "true" ||
+    // GitLab CI
+    process.env.GITLAB_CI === "true" ||
+    // Jenkins
+    process.env.JENKINS_URL !== undefined ||
+    // CircleCI
+    process.env.CIRCLECI === "true" ||
+    // Travis CI
+    process.env.TRAVIS === "true" ||
+    // Azure Pipelines
+    process.env.TF_BUILD === "True" ||
+    // Bitbucket Pipelines
+    process.env.BITBUCKET_BUILD_NUMBER !== undefined ||
+    // TeamCity
+    process.env.TEAMCITY_VERSION !== undefined ||
+    // Buildkite
+    process.env.BUILDKITE === "true" ||
+    // AWS CodeBuild
+    process.env.CODEBUILD_BUILD_ID !== undefined ||
+    // Drone CI
+    process.env.DRONE === "true" ||
+    // AppVeyor
+    process.env.APPVEYOR === "True" ||
+    // Vercel / Netlify (build environments)
+    process.env.VERCEL === "1" ||
+    process.env.NETLIFY === "true"
+  );
+}
+
+/**
+ * Check if telemetry is disabled via environment variable or automation context
  */
 function isTelemetryDisabled(): boolean {
   return (
@@ -33,7 +73,8 @@ function isTelemetryDisabled(): boolean {
     process.env.NODE_ENV === "test" ||
     process.env.JEST_WORKER_ID !== undefined ||
     process.env.VITEST !== undefined ||
-    process.env.TEST_INTEGRATION === "1"
+    process.env.TEST_INTEGRATION === "1" ||
+    isCIEnvironment()
   );
 }
 


### PR DESCRIPTION
Added comprehensive CI environment detection to prevent automated sources (CI pipelines, testing) from being counted as DAUs.

## CI Providers Filtered

- GitHub Actions, GitLab CI, Jenkins, CircleCI, Travis CI
- Azure Pipelines, Bitbucket Pipelines, TeamCity, Buildkite
- AWS CodeBuild, Drone CI, AppVeyor, Vercel, Netlify

Both backend (`telemetryService.ts`) and frontend (`client.ts`) now check for CI environments before sending telemetry events.

_Generated with `mux`_