### PR TITLE
🤖 fix: improve workspace rename UI interactions

### DIFF
--- a/src/browser/components/WorkspaceListItem.tsx
+++ b/src/browser/components/WorkspaceListItem.tsx
@@ -91,7 +91,9 @@ const WorkspaceListItemInner: React.FC<WorkspaceListItemProps> = ({
       e.preventDefault();
       void handleConfirmRename();
     } else if (e.key === "Escape") {
+      // Stop propagation to prevent global Escape handler from interrupting stream
       e.preventDefault();
+      e.stopPropagation();
       handleCancelRename();
     }
   };
@@ -188,7 +190,7 @@ const WorkspaceListItemInner: React.FC<WorkspaceListItemProps> = ({
             )}
 
             <div className="flex items-center gap-1">
-              {!isCreating && (
+              {!isCreating && !isEditing && (
                 <>
                   <GitStatusIndicator
                     gitStatus={gitStatus}


### PR DESCRIPTION
Hides the X button during workspace rename to avoid confusion with delete.

Previously the X button would still show "Remove workspace" tooltip during rename mode, leading to accidental workspace deletion when users intended to cancel rename.

**Fix:** Hide the X button entirely while the rename input is active. Users can press Escape to cancel rename instead (the natural behavior).

Also prevents Escape key from propagating to global stream interrupt handler.

_Generated with `mux`_