### PR TITLE
🤖 fix: remove escape-to-cancel on new workspace page

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -648,14 +648,6 @@ function AppInner() {
                             // Clear pending state
                             clearPendingWorkspaceCreation();
                           }}
-                          onCancel={
-                            pendingNewWorkspaceProject
-                              ? () => {
-                                  // User cancelled workspace creation - clear pending state
-                                  clearPendingWorkspaceCreation();
-                                }
-                              : undefined
-                          }
                         />
                       </ThinkingProvider>
                     </ProviderOptionsProvider>

--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -1065,13 +1065,6 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    // Handle cancel for creation variant
-    if (variant === "creation" && matchesKeybind(e, KEYBINDS.CANCEL) && props.onCancel) {
-      e.preventDefault();
-      props.onCancel();
-      return;
-    }
-
     // Handle voice input toggle (Ctrl+D / Cmd+D)
     if (matchesKeybind(e, KEYBINDS.TOGGLE_VOICE_INPUT) && voiceInput.shouldShowUI) {
       e.preventDefault();

--- a/src/browser/components/ChatInput/types.ts
+++ b/src/browser/components/ChatInput/types.ts
@@ -39,7 +39,6 @@ export interface ChatInputCreationVariant {
   onWorkspaceCreated: (metadata: FrontendWorkspaceMetadata) => void;
   onProviderConfig?: (provider: string, keyPath: string[], value: string) => Promise<void>;
   onModelChange?: (model: string) => void;
-  onCancel?: () => void;
   disabled?: boolean;
   onReady?: (api: ChatInputAPI) => void;
 }


### PR DESCRIPTION
The new workspace / new chat screen is not a modal - it's the default view when no workspace is selected. Having Escape dismiss it was confusing, especially when using vim mode where Escape is needed for mode transitions.

## Changes
- Removed `onCancel` prop from `ChatInputCreationVariant`
- Removed Escape key handler for creation variant cancel
- Removed `onCancel` prop passed from App.tsx

_Generated with `mux`_