### PR TITLE
🤖 fix: eliminate chat textarea race condition on initial render

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -641,8 +641,10 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
       if (ok) {
         setInput("");
         setImageAttachments([]);
+        // Height is managed by VimTextArea's useLayoutEffect - clear inline style
+        // to let CSS min-height take over
         if (inputRef.current) {
-          inputRef.current.style.height = "36px";
+          inputRef.current.style.height = "";
         }
       }
       setIsSending(false);
@@ -661,7 +663,7 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
         if (parsed.type === "clear") {
           setInput("");
           if (inputRef.current) {
-            inputRef.current.style.height = "36px";
+            inputRef.current.style.height = "";
           }
           await props.onTruncateHistory(1.0);
           setToast({
@@ -676,7 +678,7 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
         if (parsed.type === "truncate") {
           setInput("");
           if (inputRef.current) {
-            inputRef.current.style.height = "36px";
+            inputRef.current.style.height = "";
           }
           await props.onTruncateHistory(parsed.percentage);
           setToast({
@@ -994,9 +996,9 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
         // These will be restored if the send operation fails
         setInput("");
         setImageAttachments([]);
-        // Reset textarea height
+        // Clear inline height style - VimTextArea's useLayoutEffect will handle sizing
         if (inputRef.current) {
-          inputRef.current.style.height = "36px";
+          inputRef.current.style.height = "";
         }
 
         const result = await api.workspace.sendMessage({


### PR DESCRIPTION
The chat input textarea could appear too large on initial app launch, then collapse to correct size when text was entered.

**Root cause:** The previous fix used `useLayoutEffect` but still relied on measuring `scrollHeight` after setting `height: auto`. For an empty textarea, this measurement could return incorrect values before the flex container layout had settled.

**Fix:** Skip `scrollHeight` measurement entirely when the textarea is empty or whitespace-only. Instead, clear the inline height style and let the CSS `min-h-8` (32px) handle sizing. This is deterministic and avoids the race condition.

Also unified height management: ChatInput no longer hardcodes `36px` when clearing input - it clears the inline style to let VimTextArea's CSS take over, ensuring consistent behavior.

---
_Generated with `mux`_