### PR TITLE
🤖 perf: speed up CI with approx tokenizer and parallel static-check

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -77,7 +77,7 @@ jobs:
             experimental-features = nix-command flakes
       - run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
-      - run: make -j3 static-check
+      - run: make -j static-check
 
   test-unit:
     name: Test / Unit
@@ -86,8 +86,6 @@ jobs:
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-16' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup-mux
       - run: make build-main
       - run: bun test --coverage --coverage-reporter=lcov ${{ github.event.inputs.test_filter || 'src' }}
@@ -106,8 +104,6 @@ jobs:
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-16' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup-mux
       - run: make build-main
       - name: Run integration tests
@@ -146,8 +142,6 @@ jobs:
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-16' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup-mux
       - uses: ./.github/actions/setup-playwright
       - run: make storybook-build
@@ -171,8 +165,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup-mux
       - name: Install xvfb
         if: matrix.os == 'linux'

--- a/src/cli/run.test.ts
+++ b/src/cli/run.test.ts
@@ -102,8 +102,8 @@ describe("mux CLI", () => {
     test("--version shows version info", async () => {
       const result = await runCli(["--version"]);
       expect(result.exitCode).toBe(0);
-      // Version format: vX.Y.Z-N-gHASH (HASH)
-      expect(result.stdout).toMatch(/v\d+\.\d+\.\d+/);
+      // Version format: vX.Y.Z-N-gHASH (HASH) or just HASH (HASH) in shallow clones
+      expect(result.stdout).toMatch(/v\d+\.\d+\.\d+|^[0-9a-f]{7,}/);
     });
 
     test("unknown command shows error", async () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -7,6 +7,12 @@ import assert from "assert";
 import "disposablestack/auto";
 
 assert.equal(typeof Symbol.dispose, "symbol");
+// Use fast approximate token counting in Jest to avoid 10s WASM cold starts
+// Individual tests can override with MUX_FORCE_REAL_TOKENIZER=1
+if (process.env.MUX_FORCE_REAL_TOKENIZER !== "1") {
+  process.env.MUX_APPROX_TOKENIZER ??= "1";
+}
+
 assert.equal(typeof Symbol.asyncDispose, "symbol");
 
 // Polyfill File for undici in jest environment


### PR DESCRIPTION
Speeds up CI by:

1. **Approximate tokenizer for tests** - Defaults Jest to `length/4` token counting instead of loading the 10s WASM tokenizer
2. **Parallel static-check** - Removes `-j3` limit, allowing all 6 subtasks to run in parallel
3. **Shallow checkout for tests** - Test jobs don't need full git history

## Changes

### Tokenizer (`src/node/utils/main/tokenizer.ts`)
- Add `shouldUseApproxTokenizer()` that checks `MUX_APPROX_TOKENIZER=1`
- Short-circuit all tokenizer functions when in approx mode
- Override with `MUX_FORCE_REAL_TOKENIZER=1` for tests needing real tokenization

### Test setup (`tests/setup.ts`)
- Default `MUX_APPROX_TOKENIZER=1` in Jest

### CI (`.github/workflows/pr.yml`)
- `make -j static-check` (was `-j3`)
- Remove `fetch-depth: 0` from test-unit, test-integration, test-storybook, test-e2e

### Test fix (`src/cli/run.test.ts`)
- Update version test to accept both `vX.Y.Z` and hash-only formats (shallow clones don't have tags)

_Generated with `mux`_