### PR TITLE
🤖 fix: disable default browser focus outline

### DIFF
--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -1,4 +1,12 @@
 @import "tailwindcss";
+
+/* Disable the default browser focus outline (the blue ring).
+   Components can still use intentional focus styles like border-color changes. */
+*:focus,
+*:focus-visible {
+  outline: none;
+}
+
 @source "../node_modules/streamdown/dist/index.js";
 
 /* Geist Font Declarations */


### PR DESCRIPTION
Remove the default blue focus outline that browsers apply. Components can still define intentional focus styles (like border color changes) - this only removes the browser's default outline.

Fixes flaky Storybook snapshots where focus state was inconsistent.

_Generated with `mux`_