### PR TITLE
fix: use cygpath on Windows for temp dir path conversion

### DIFF
--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -271,7 +271,10 @@ export class StreamManager extends EventEmitter {
   public async createTempDirForStream(streamToken: StreamToken, runtime: Runtime): Promise<string> {
     // Create directory and get absolute path (works for both local and remote)
     // Use 'cd' + 'pwd' to resolve ~ to absolute path
-    const command = `mkdir -p ~/.mux-tmp/${streamToken} && cd ~/.mux-tmp/${streamToken} && pwd`;
+    // On Windows, use cygpath to convert Git Bash path to native Windows path
+    const isWindows = process.platform === "win32";
+    const pwdCmd = isWindows ? 'cygpath -w "$(pwd)"' : "pwd";
+    const command = `mkdir -p ~/.mux-tmp/${streamToken} && cd ~/.mux-tmp/${streamToken} && ${pwdCmd}`;
     const result = await execBuffered(runtime, command, {
       cwd: "/",
       timeout: 10,


### PR DESCRIPTION
## Problem

On Windows, `createTempDirForStream` runs a shell command via Git Bash that returns a Unix-style path like `/c/Users/ethan/.mux-tmp/854e934d`.

During cleanup, Node's `fs.access()` and `spawn()` APIs misinterpret this path as `C:\c\Users\...` instead of `C:\Users\...`, causing cleanup to fail:

```
Failed to cleanup temp dir /c/Users/ethan/.mux-tmp/854e934d: RuntimeError: Working directory does not exist
  path: 'C:\c\Users\ethan\.mux-tmp'
```

## Fix

Use `cygpath -w` on Windows to convert the `pwd` output to native Windows path format (`C:\Users\ethan\.mux-tmp\abc123`), which Node APIs handle correctly.