### PR TITLE
🤖 fix: bash tool elapsed time always shows seconds

### DIFF
--- a/src/browser/components/tools/BashToolCall.tsx
+++ b/src/browser/components/tools/BashToolCall.tsx
@@ -83,7 +83,7 @@ export const BashToolCall: React.FC<BashToolCallProps> = ({
             >
               timeout: {args.timeout_secs ?? BASH_DEFAULT_TIMEOUT_SECS}s
               {result && ` • took ${formatDuration(result.wall_duration_ms)}`}
-              {!result && isPending && elapsedTime > 0 && ` • ${formatDuration(elapsedTime)}`}
+              {!result && isPending && elapsedTime > 0 && ` • ${Math.round(elapsedTime / 1000)}s`}
             </span>
             {result && (
               <span


### PR DESCRIPTION
The shared `formatDuration` function introduced in e9542000 can display minutes/hours for long-running processes, but the elapsed time counter shown next to the timeout should always use seconds for consistency.

The timeout is always in seconds (e.g., `timeout: 3s`), so the live elapsed counter should match (e.g., `3s`, not `3m` after 180 seconds).

The completed "took" result still uses `formatDuration` since human-readable durations make sense for finished tasks.

cc @ethanndickson

_Generated with `mux`_