### PR TITLE
🤖 fix: resolve console errors for ORPC iterator and HelpIndicator ref

### DIFF
--- a/src/browser/components/ui/tooltip.tsx
+++ b/src/browser/components/ui/tooltip.tsx
@@ -46,15 +46,17 @@ const TooltipContent = React.forwardRef<
 ));
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 
-const HelpIndicator: React.FC<{ className?: string; children?: React.ReactNode }> = ({
-  className,
-  children,
-}) => (
+const HelpIndicator = React.forwardRef<
+  HTMLSpanElement,
+  { className?: string; children?: React.ReactNode }
+>(({ className, children }, ref) => (
   <span
+    ref={ref}
     className={cn("text-muted flex cursor-help items-center text-[10px] leading-none", className)}
   >
     {children}
   </span>
-);
+));
+HelpIndicator.displayName = "HelpIndicator";
 
 export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider, TooltipArrow, HelpIndicator };


### PR DESCRIPTION
## Summary

Fixes two console errors that appear during normal operation:

### 1. React ref warning for HelpIndicator
```
Warning: Function components cannot be given refs. Attempts to access this ref will fail.
Check the render method of `Primitive.button.SlotClone`.
```

**Cause:** `HelpIndicator` was a plain function component used inside `TooltipTrigger` with `asChild`, which needs to forward refs.

**Fix:** Converted to `React.forwardRef`.

### 2. ORPC Event Iterator Validation Failed
```
[WorkspaceStore] Error in onChat subscription for xxx: ORPCError: Event iterator validation failed
Caused by: ErrorEvent: An error event was received
```

**Cause:** When the underlying transport (WebSocket/MessagePort) has an error during workspace removal, ORPC throws `EVENT_ITERATOR_VALIDATION_FAILED` because the transport's `ErrorEvent` can't be validated against the chat message schema.

**Fix:** Suppress this specific error only when the workspace has been removed (race condition between server error and client cleanup). If the workspace still exists and we get this error, it's logged as before since that would indicate a real problem.

---
_Generated with `mux`_