### PR TITLE
🤖 fix: filter SSH multiplexing stderr noise from command output

### DIFF
--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -667,7 +667,8 @@ export class SSHRuntime implements Runtime {
 
     // Suppress SSH warnings (e.g., ControlMaster messages) that would pollute command output
     // These go to stderr and get merged with stdout in bash tool results
-    args.push("-o", "LogLevel=ERROR");
+    // Use FATAL (not ERROR) because mux_client_request_session messages are at ERROR level
+    args.push("-o", "LogLevel=FATAL");
 
     // Add ControlMaster options for connection multiplexing
     // This ensures all SSH operations reuse the master connection


### PR DESCRIPTION
The previous fix (#981) used `LogLevel=ERROR`, but `mux_client_request_session` messages are at ERROR level in OpenSSH. 

Using `LogLevel=FATAL` suppresses these while still showing fatal connection failures.

## One-line fix
```diff
- args.push("-o", "LogLevel=ERROR");
+ args.push("-o", "LogLevel=FATAL");
```

_Generated with `mux`_