### PR TITLE
🤖 fix: add padding to bash tool SCRIPT section

### DIFF
--- a/src/browser/components/tools/BashToolCall.tsx
+++ b/src/browser/components/tools/BashToolCall.tsx
@@ -104,7 +104,7 @@ export const BashToolCall: React.FC<BashToolCallProps> = ({
         <ToolDetails>
           <DetailSection>
             <DetailLabel>Script</DetailLabel>
-            <DetailContent>{args.script}</DetailContent>
+            <DetailContent className="px-2 py-1.5">{args.script}</DetailContent>
           </DetailSection>
 
           {result && (

--- a/src/browser/stories/mockFactory.ts
+++ b/src/browser/stories/mockFactory.ts
@@ -255,6 +255,24 @@ export function createFileEditTool(toolCallId: string, filePath: string, diff: s
   };
 }
 
+export function createBashTool(
+  toolCallId: string,
+  script: string,
+  output: string,
+  exitCode = 0,
+  timeoutSecs = 3,
+  durationMs = 50
+): MuxPart {
+  return {
+    type: "dynamic-tool",
+    toolCallId,
+    toolName: "bash",
+    state: "output-available",
+    input: { script, run_in_background: false, timeout_secs: timeoutSecs },
+    output: { success: exitCode === 0, output, exitCode, wall_duration_ms: durationMs },
+  };
+}
+
 export function createTerminalTool(
   toolCallId: string,
   command: string,


### PR DESCRIPTION
Added `px-2 py-1.5` padding to the `DetailContent` component which renders the Script section in the expanded bash tool view. This matches the padding used by the Output section and `OutputPaths` component.

Also added:
- `createBashTool` mockFactory helper
- `WithBashTool` story that auto-expands a bash tool to visually validate the fix

_Generated with `mux`_