### PR TITLE
🤖 fix: use platform-aware keybind in review comment hints

### DIFF
--- a/src/browser/components/ReviewsBanner.tsx
+++ b/src/browser/components/ReviewsBanner.tsx
@@ -29,7 +29,7 @@ import type { Review } from "@/common/types/review";
 import { useReviews } from "@/browser/hooks/useReviews";
 import { formatRelativeTime } from "@/browser/utils/ui/dateTime";
 import { DiffRenderer } from "./shared/DiffRenderer";
-import { matchesKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
+import { matchesKeybind, formatKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // ERROR BOUNDARY
@@ -262,7 +262,9 @@ const ReviewItem: React.FC<ReviewItemProps> = ({
                   placeholder="Your comment..."
                 />
                 <div className="flex items-center justify-end gap-1">
-                  <span className="text-muted mr-2 text-[10px]">⌘Enter to save, Esc to cancel</span>
+                  <span className="text-muted mr-2 text-[10px]">
+                    {formatKeybind(KEYBINDS.SAVE_EDIT)} to save, Esc to cancel
+                  </span>
                   <Button
                     variant="ghost"
                     size="sm"

--- a/src/browser/components/shared/ReviewBlock.tsx
+++ b/src/browser/components/shared/ReviewBlock.tsx
@@ -10,7 +10,7 @@ import React, { useState, useCallback, useRef, useMemo } from "react";
 import { MessageSquare, X, Pencil, Check } from "lucide-react";
 import { DiffRenderer } from "./DiffRenderer";
 import { Button } from "../ui/button";
-import { matchesKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
+import { matchesKeybind, formatKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
 import type { ReviewNoteDataForDisplay } from "@/common/types/message";
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -130,7 +130,9 @@ const ReviewBlockCore: React.FC<ReviewBlockCoreProps> = ({
                 placeholder="Your comment..."
               />
               <div className="flex items-center justify-end gap-1">
-                <span className="text-muted mr-1 text-[10px]">⌘Enter save, Esc cancel</span>
+                <span className="text-muted mr-1 text-[10px]">
+                  {formatKeybind(KEYBINDS.SAVE_EDIT)} save, Esc cancel
+                </span>
                 <Button
                   variant="ghost"
                   size="sm"


### PR DESCRIPTION
_Generated with `mux`_

The review comment editor showed "⌘Enter save, Esc cancel" regardless of platform. Now uses `formatKeybind(KEYBINDS.SAVE_EDIT)` to show:
- **Linux/Windows**: Ctrl+Enter
- **macOS**: ⌘·Enter