### PR TITLE
🤖 feat: show partial costs with unknown model indicator

### DIFF
--- a/src/browser/components/RightSidebar/CostsTab.tsx
+++ b/src/browser/components/RightSidebar/CostsTab.tsx
@@ -10,6 +10,7 @@ import { TOKEN_COMPONENT_COLORS } from "@/common/utils/tokens/tokenMeterUtils";
 import { ConsumerBreakdown } from "./ConsumerBreakdown";
 import { HorizontalThresholdSlider } from "./ThresholdSlider";
 import { useAutoCompactionSettings } from "@/browser/hooks/useAutoCompactionSettings";
+import { Tooltip, TooltipTrigger, TooltipContent } from "../ui/tooltip";
 
 // Format token display - show k for thousands with 1 decimal
 const formatTokens = (tokens: number) =>
@@ -394,8 +395,19 @@ const CostsTabComponent: React.FC<CostsTabProps> = ({ workspaceId }) => {
                             onChange={setViewMode}
                           />
                         </div>
-                        <span className="text-muted text-xs">
+                        <span className="text-muted flex items-center gap-1 text-xs">
                           {formatCostWithDollar(totalCost)}
+                          {displayUsage?.hasUnknownCosts && (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span className="text-warning cursor-help">?</span>
+                              </TooltipTrigger>
+                              <TooltipContent side="bottom" className="max-w-[200px]">
+                                Cost may be incomplete — some models in this session have unknown
+                                pricing
+                              </TooltipContent>
+                            </Tooltip>
+                          )}
                         </span>
                       </div>
                       <div className="relative w-full">

--- a/src/common/utils/tokens/usageAggregator.ts
+++ b/src/common/utils/tokens/usageAggregator.ts
@@ -29,6 +29,9 @@ export interface ChatUsageDisplay {
 
   // Optional model field for display purposes (context window calculation, etc.)
   model?: string;
+
+  // True if any model in the sum had unknown pricing (costs are partial/incomplete)
+  hasUnknownCosts?: boolean;
 }
 
 /**
@@ -68,13 +71,9 @@ export function sumUsageHistory(usageHistory: ChatUsageDisplay[]): ChatUsageDisp
     }
   }
 
-  // If any costs were undefined, set all to undefined
+  // Flag if any costs were undefined (partial/incomplete total)
   if (hasUndefinedCosts) {
-    sum.input.cost_usd = undefined;
-    sum.cached.cost_usd = undefined;
-    sum.cacheCreate.cost_usd = undefined;
-    sum.output.cost_usd = undefined;
-    sum.reasoning.cost_usd = undefined;
+    sum.hasUnknownCosts = true;
   }
 
   return sum;


### PR DESCRIPTION
When a conversation includes models with unknown pricing, show the partial cost (from known models) with a **?** indicator and tooltip explaining the cost may be incomplete.

## Before
If any model had unknown pricing → all costs became `undefined` → UI showed "??"

## After
Known costs are summed → UI shows `$X.XX ?` with tooltip: "Cost may be incomplete—some models in this session have unknown pricing"

## Changes
- Added `hasUnknownCosts` flag to `ChatUsageDisplay` interface
- Modified `sumUsageHistory` to keep partial costs instead of wiping to undefined
- Added tooltip indicator in CostsTab when flag is set
- Added tests for multi-model cost calculation

_Generated with `mux`_