### PR TITLE
🤖 fix: workspace sidebar updates immediately on creation

### DIFF
--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -402,6 +402,12 @@ export class WorkspaceStore {
   subscribe = this.states.subscribeAny;
 
   /**
+   * Subscribe to derived state changes (recency, etc.).
+   * Use for hooks that depend on derived.bump() rather than states.bump().
+   */
+  subscribeDerived = this.derived.subscribeAny;
+
+  /**
    * Subscribe to changes for a specific workspace.
    * Only notified when this workspace's state changes.
    */
@@ -1087,11 +1093,12 @@ export function useWorkspaceStoreRaw(): WorkspaceStore {
 
 /**
  * Hook to get workspace recency timestamps.
+ * Subscribes to derived state since recency is updated via derived.bump("recency").
  */
 export function useWorkspaceRecency(): Record<string, number> {
   const store = getStoreInstance();
 
-  return useSyncExternalStore(store.subscribe, () => store.getWorkspaceRecency());
+  return useSyncExternalStore(store.subscribeDerived, () => store.getWorkspaceRecency());
 }
 
 /**


### PR DESCRIPTION
The `useWorkspaceRecency` hook was subscribed to `states.subscribeAny`, but workspace recency is bumped via `derived.bump("recency")`. This caused a delay between workspace creation and the sidebar reflecting the new workspace.

## Root Cause

When a workspace is created:
1. `addWorkspace` is called, which calls `this.derived.bump("recency")` (line 731)
2. `useWorkspaceRecency` was subscribed to `store.subscribe` which delegates to `states.subscribeAny`
3. Since recency is bumped on `derived`, not `states`, React wasn't notified of the change
4. The sidebar would only update when some other action triggered a `states` bump

## Fix

1. Added `subscribeDerived` method to `WorkspaceStore` that exposes `derived.subscribeAny`
2. Updated `useWorkspaceRecency` to use `subscribeDerived` instead of `subscribe`

Now when `derived.bump("recency")` is called, the subscription fires immediately and React re-renders the sidebar with the new workspace.

_Generated with `mux`_