### PR TITLE
🤖 fix: infer tool failure from error field

### DIFF
--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -54,12 +54,16 @@ function hasSuccessResult(result: unknown): boolean {
 }
 
 /**
- * Check if a tool result indicates failure (for tools that return { success: boolean })
+ * Check if a tool result indicates failure.
+ * Handles both explicit failure ({ success: false }) and implicit failure ({ error: "..." })
  */
 function hasFailureResult(result: unknown): boolean {
-  return (
-    typeof result === "object" && result !== null && "success" in result && result.success === false
-  );
+  if (typeof result !== "object" || result === null) return false;
+  // Explicit failure
+  if ("success" in result && result.success === false) return true;
+  // Implicit failure - error field present
+  if ("error" in result && result.error) return true;
+  return false;
 }
 
 export class StreamingMessageAggregator {

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -938,6 +938,7 @@ export class StreamManager extends EventEmitter {
 
             // Format error output
             const errorOutput = {
+              success: false,
               error:
                 typeof toolErrorPart.error === "string"
                   ? toolErrorPart.error


### PR DESCRIPTION
## Problem

When in Plan Mode, file edit tools (`file_edit_*`) are disabled via tool policy. However, the model doesn't know about this policy and may still attempt to call these tools*.

When this happens:

1. The AI SDK emits a `tool-error` event with the error message
2. The error output was `{ error: "Model tried to call unavailable tool..." }`
3. The frontend's `hasFailureResult()` only checked for `success === false`
4. Since there was no `success` field, the tool call showed **"completed"** status instead of **"failed"**

This made it appear the edit succeeded when it actually failed, and the error wasn't visible in the dropdown.

## Solution

Update `hasFailureResult()` to infer failure from the presence of an `error` field, not just explicit `success: false`:

```typescript
function hasFailureResult(result: unknown): boolean {
  if (typeof result !== "object" || result === null) return false;
  // Explicit failure
  if ("success" in result && result.success === false) return true;
  // Implicit failure - error field present
  if ("error" in result && result.error) return true;
  return false;
}
```

This is more defensive and handles any tool error that includes an `error` field, regardless of whether `success` is explicitly set.

*This only appears to happen when the context includes usage of those tools. I assume this isn't an easily solvable problem as an agent author, the model sees the tool is disabled, but it also sees it being used dozens of times in the context. How does it know it's really disabled?

---

_Generated with `mux`_