### PR TITLE
🤖 fix: prevent stale redirect after workspace deletion

### DIFF
--- a/src/browser/contexts/WorkspaceContext.tsx
+++ b/src/browser/contexts/WorkspaceContext.tsx
@@ -353,9 +353,10 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
           await loadWorkspaceMetadata();
 
           // Clear selected workspace if it was removed
-          if (selectedWorkspace?.workspaceId === workspaceId) {
-            setSelectedWorkspace(null);
-          }
+          // Use functional update to check *current* selection, not stale closure value
+          setSelectedWorkspace((current) =>
+            current?.workspaceId === workspaceId ? null : current
+          );
           return { success: true };
         } else {
           console.error("Failed to remove workspace:", result.error);
@@ -367,7 +368,7 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
         return { success: false, error: errorMessage };
       }
     },
-    [loadWorkspaceMetadata, refreshProjects, selectedWorkspace, setSelectedWorkspace, api]
+    [loadWorkspaceMetadata, refreshProjects, setSelectedWorkspace, api]
   );
 
   const renameWorkspace = useCallback(


### PR DESCRIPTION
When deleting a workspace, the redirect logic was using a stale closure value of `selectedWorkspace`. If the user navigated to another workspace while the delete was in progress, they'd still get redirected to the project page because the callback captured the old selection.

**Fix:** Use functional update form of `setSelectedWorkspace` to check the *current* selection at the time the delete completes, not the value captured when the callback was created.

_Generated with `mux`_