### PR TITLE
🤖 perf: cap shimmer animation at 30fps + fix layout shift

### DIFF
--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -1683,7 +1683,8 @@ pre code {
   background-clip: text;
   -webkit-background-clip: text;
   color: transparent;
-  animation: shimmer-text-sweep var(--shimmer-duration, 1.4s) linear infinite;
+  /* Cap at ~30fps (42 steps over 1.4s) to reduce repaints on high-refresh displays */
+  animation: shimmer-text-sweep var(--shimmer-duration, 1.4s) steps(42, end) infinite;
   /* Decoration inheritance must be explicit for background-clip: text */
   text-decoration: inherit;
   box-decoration-break: clone;


### PR DESCRIPTION
## Summary
Caps the shimmer animation at 30fps to reduce repaints on high-refresh displays.

### Changes
- Uses `steps(42, end)` timing function to limit animation to ~30fps
- On 240hz monitors, this reduces repaints by 8x (240 → 30)
- Still smooth enough for a loading indicator

### Why?
`background-position` isn't compositor-only, so each frame triggers a main thread repaint. On high-refresh displays this was causing noticeable frame drops during streaming.

---
_Generated with `mux`_