### PR TITLE
🤖 fix: prevent useReviews re-renders from cascading

### DIFF
--- a/src/browser/components/AIView.tsx
+++ b/src/browser/components/AIView.tsx
@@ -235,12 +235,14 @@ const AIViewInner: React.FC<AIViewProps> = ({
   }, []);
 
   // Handler for review notes from Code Review tab - adds review (starts attached)
+  // Depend only on addReview (not whole reviews object) to keep callback stable
+  const { addReview } = reviews;
   const handleReviewNote = useCallback(
     (data: ReviewNoteData) => {
-      reviews.addReview(data);
+      addReview(data);
       // New reviews start with status "attached" so they appear in chat input immediately
     },
-    [reviews]
+    [addReview]
   );
 
   // Handler for manual compaction from CompactionWarning click

--- a/src/browser/hooks/useReviews.ts
+++ b/src/browser/hooks/useReviews.ts
@@ -266,21 +266,40 @@ export function useReviews(workspaceId: string): UseReviewsReturn {
     [state.reviews]
   );
 
-  return {
-    reviews,
-    pendingCount,
-    attachedCount,
-    checkedCount,
-    attachedReviews,
-    addReview,
-    attachReview,
-    detachReview,
-    checkReview,
-    uncheckReview,
-    removeReview,
-    updateReviewNote,
-    clearChecked,
-    clearAll,
-    getReview,
-  };
+  return useMemo(
+    () => ({
+      reviews,
+      pendingCount,
+      attachedCount,
+      checkedCount,
+      attachedReviews,
+      addReview,
+      attachReview,
+      detachReview,
+      checkReview,
+      uncheckReview,
+      removeReview,
+      updateReviewNote,
+      clearChecked,
+      clearAll,
+      getReview,
+    }),
+    [
+      reviews,
+      pendingCount,
+      attachedCount,
+      checkedCount,
+      attachedReviews,
+      addReview,
+      attachReview,
+      detachReview,
+      checkReview,
+      uncheckReview,
+      removeReview,
+      updateReviewNote,
+      clearChecked,
+      clearAll,
+      getReview,
+    ]
+  );
 }


### PR DESCRIPTION
Fixes re-render issues caused by unstable callback references:

- Memoize `useReviews` return object to prevent creating new object on every render
- Destructure `addReview` in AIView and depend only on it (not whole `reviews` object) so `handleReviewNote` callback stays stable

Without this fix, every render creates a new `reviews` object → `handleReviewNote` callback recreated → all components receiving it re-render.

_Generated with mux_