### PR TITLE
🤖 fix: prevent compaction summary loss from race condition

### DIFF
--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -110,6 +110,7 @@ export class AgentSession {
     this.compactionHandler = new CompactionHandler({
       workspaceId: this.workspaceId,
       historyService: this.historyService,
+      partialService: this.partialService,
       emitter: this.emitter,
     });
 


### PR DESCRIPTION
## Problem

When compaction completes, there's a race condition that can cause the compaction summary to be lost from context:

1. StreamManager emits `stream-end` then continues to `deletePartial`/`updateHistory`
2. CompactionHandler runs (async), clears history, appends summary
3. `sendQueuedMessages` triggers `commitToHistory`
4. `commitToHistory` finds stale `partial.json` (not yet deleted by StreamManager)
5. The stale partial has the OLD historySequence from pre-compaction
6. `commitToHistory` appends this stale message to history, corrupting context

## Solution

CompactionHandler now deletes `partial.json` BEFORE clearing history. This ensures any concurrent `commitToHistory` calls find no partial and become no-ops.

## Changes

- `src/node/services/compactionHandler.ts` - Delete partial before compaction
- `src/node/services/agentSession.ts` - Pass partialService to CompactionHandler
- `src/node/services/compactionHandler.test.ts` - Test for the fix

_Generated with `mux`_