### PR TITLE
🤖 fix: remove mock.module causing test pollution across files

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "mux",

--- a/src/common/utils/ai/providerOptions.test.ts
+++ b/src/common/utils/ai/providerOptions.test.ts
@@ -4,7 +4,6 @@
 
 import { describe, test, expect, mock } from "bun:test";
 import { buildProviderOptions } from "./providerOptions";
-import type { ThinkingLevel } from "@/common/types/thinking";
 
 // Mock the log module to avoid console noise
 void mock.module("@/node/services/log", () => ({
@@ -14,11 +13,6 @@ void mock.module("@/node/services/log", () => ({
     warn: (): void => undefined,
     error: (): void => undefined,
   },
-}));
-
-// Mock enforceThinkingPolicy to pass through
-void mock.module("@/browser/utils/thinking/policy", () => ({
-  enforceThinkingPolicy: (_model: string, level: ThinkingLevel) => level,
 }));
 
 describe("buildProviderOptions - Anthropic", () => {


### PR DESCRIPTION
## Problem

The `enforceThinkingPolicy` tests in `policy.test.ts` fail intermittently depending on test execution order. When `providerOptions.test.ts` runs before `policy.test.ts`, the policy tests fail because they receive a mocked pass-through function instead of the real implementation.

**Root cause:** `providerOptions.test.ts` uses `mock.module("@/browser/utils/thinking/policy", ...)` at module load time, which globally replaces the real module. Bun's `mock.module` does not isolate between test files—this is a [known limitation](https://github.com/oven-sh/bun/issues/12823).

**Why it's flaky:** Bun randomizes test file order. Different seeds produce different orderings:
- `--seed=2`: policy tests pass (providerOptions runs after policy)
- `--seed=1`, `--seed=42`, default: policy tests fail (providerOptions runs before policy)

## Solution

Remove the `mock.module` for `enforceThinkingPolicy` from `providerOptions.test.ts`.

## Why this fix is safe

The mock was added to test `buildProviderOptions` output formatting in isolation—passing arbitrary thinking levels without policy clamping. However, examining the tests:

- They use thinking levels (`"medium"`, `"high"`, `"low"`, `"off"`) that are valid for the models being tested
- `enforceThinkingPolicy` returns these levels unchanged for these model/level combinations
- The tests still pass without the mock because the real policy allows these levels

The mock was defensive but unnecessary. Removing it:
1. Fixes the flaky test
2. Follows the codebase's preference for avoiding mocks (per AGENTS.md)
3. Makes tests more honest—they now test real behavior

## Verification

```
# Before fix (default seed): 5 failures
bun test src

# After fix: 0 failures across all seeds
bun test src                    # 1571 pass, 0 fail
bun test --seed=1 src           # passes
bun test --seed=42 src          # passes
```

_Generated with `mux`_