### PR TITLE
🤖 fix: add consistent padding to bash tool waiting state

### DIFF
--- a/src/browser/components/tools/BashToolCall.tsx
+++ b/src/browser/components/tools/BashToolCall.tsx
@@ -136,7 +136,7 @@ export const BashToolCall: React.FC<BashToolCallProps> = ({
 
           {status === "executing" && !result && (
             <DetailSection>
-              <DetailContent>
+              <DetailContent className="px-2 py-1.5">
                 Waiting for result
                 <LoadingDots />
               </DetailContent>


### PR DESCRIPTION
Fixes padding inconsistency in the bash tool's "Waiting for result" section when expanded during execution.

## Changes
- Add `px-2 py-1.5` padding to the `DetailContent` in the waiting state to match Script/Output sections
- Add `WithBashToolWaiting` story to demonstrate the executing state with proper padding

_Generated with `mux`_