### PR TITLE
🤖 fix: prevent escape from interrupting stream during message editing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "mux",

--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -1231,6 +1231,7 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
     if (matchesKeybind(e, KEYBINDS.CANCEL_EDIT)) {
       if (variant === "workspace" && editingMessage && props.onCancelEdit && !vimEnabled) {
         e.preventDefault();
+        e.stopPropagation(); // Prevent global handler from interrupting stream
         setDraft(preEditDraftRef.current);
         props.onCancelEdit();
         const isFocused = document.activeElement === inputRef.current;

--- a/src/browser/components/VimTextArea.tsx
+++ b/src/browser/components/VimTextArea.tsx
@@ -166,6 +166,7 @@ export const VimTextArea = React.forwardRef<HTMLTextAreaElement, VimTextAreaProp
         return;
       }
       if (result.action === "escapeInNormalMode") {
+        e.stopPropagation(); // Prevent global handler from interrupting stream
         onEscapeInNormalMode?.();
         return;
       }


### PR DESCRIPTION
When editing a message while streaming, pressing Escape to cancel editing would also interrupt the active stream. This is the same issue fixed in PR #954 for workspace renaming.

Added `stopPropagation()` in both code paths:
- Non-vim mode: ChatInput's CANCEL_EDIT handler
- Vim mode: VimTextArea's escapeInNormalMode handler

This prevents the Escape keydown event from reaching the global stream interrupt handler in `useAIViewKeybinds`.

_Generated with `mux`_