### PR TITLE
🤖 fix: prevent thinking block collapse on page load

### DIFF
--- a/src/browser/components/Messages/ReasoningMessage.tsx
+++ b/src/browser/components/Messages/ReasoningMessage.tsx
@@ -14,7 +14,7 @@ interface ReasoningMessageProps {
 const REASONING_FONT_CLASSES = "font-primary text-[12px] leading-[18px]";
 
 export const ReasoningMessage: React.FC<ReasoningMessageProps> = ({ message, className }) => {
-  const [isExpanded, setIsExpanded] = useState(true);
+  const [isExpanded, setIsExpanded] = useState(message.isStreaming);
   // Track the height when expanded to reserve space during collapse transitions
   const [expandedHeight, setExpandedHeight] = useState<number | null>(null);
   const contentRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
When navigating to a chat with existing thinking blocks, they would collapse immediately after the page loaded, causing a jarring layout shift.

**Root cause:** The `ReasoningMessage` component initialized `isExpanded` to `true`, then a `useEffect` collapsed it when `isStreaming` was false. For historical messages (already `isStreaming: false`), this effect fired on mount—expanding then immediately collapsing.

**Fix:** Initialize `isExpanded` to `message.isStreaming`. Historical messages start collapsed; actively streaming messages start expanded and collapse when streaming ends.

---
_Generated with `mux`_