### PR TITLE
🤖 fix: restore slash commands in workspace creation mode

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -411,10 +411,10 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
 
   // Watch input for slash commands
   useEffect(() => {
-    const suggestions = getSlashCommandSuggestions(input, { providerNames });
+    const suggestions = getSlashCommandSuggestions(input, { providerNames, variant });
     setCommandSuggestions(suggestions);
     setShowCommandSuggestions(suggestions.length > 0);
-  }, [input, providerNames]);
+  }, [input, providerNames, variant]);
 
   // Load provider names for suggestions
   useEffect(() => {
@@ -1335,18 +1335,16 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
         data-component="ChatInputSection"
       >
         <div className="mx-auto w-full max-w-4xl">
-          {/* Creation toast */}
-          {variant === "creation" && (
-            <ChatInputToast
-              toast={creationState.toast}
-              onDismiss={() => creationState.setToast(null)}
-            />
-          )}
-
-          {/* Workspace toast */}
-          {variant === "workspace" && (
-            <ChatInputToast toast={toast} onDismiss={handleToastDismiss} />
-          )}
+          {/* Toast - show shared toast (slash commands) or variant-specific toast */}
+          <ChatInputToast
+            toast={toast ?? (variant === "creation" ? creationState.toast : null)}
+            onDismiss={() => {
+              handleToastDismiss();
+              if (variant === "creation") {
+                creationState.setToast(null);
+              }
+            }}
+          />
 
           {/* Attached reviews preview - show styled blocks with remove/edit buttons */}
           {/* Hide during send to avoid duplicate display with the sent message */}
@@ -1369,17 +1367,17 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
             </div>
           )}
 
-          {/* Command suggestions - workspace only */}
-          {variant === "workspace" && (
-            <CommandSuggestions
-              suggestions={commandSuggestions}
-              onSelectSuggestion={handleCommandSelect}
-              onDismiss={() => setShowCommandSuggestions(false)}
-              isVisible={showCommandSuggestions}
-              ariaLabel="Slash command suggestions"
-              listId={commandListId}
-            />
-          )}
+          {/* Command suggestions - available in both variants */}
+          {/* In creation mode, use portal (anchorRef) to escape overflow:hidden containers */}
+          <CommandSuggestions
+            suggestions={commandSuggestions}
+            onSelectSuggestion={handleCommandSelect}
+            onDismiss={() => setShowCommandSuggestions(false)}
+            isVisible={showCommandSuggestions}
+            ariaLabel="Slash command suggestions"
+            listId={commandListId}
+            anchorRef={variant === "creation" ? inputRef : undefined}
+          />
 
           <div className="relative flex items-end" data-component="ChatInputControls">
             {/* Recording/transcribing overlay - replaces textarea when active */}

--- a/src/browser/utils/chatCommands.ts
+++ b/src/browser/utils/chatCommands.ts
@@ -18,6 +18,7 @@ import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import type { RuntimeConfig } from "@/common/types/runtime";
 import { RUNTIME_MODE, SSH_RUNTIME_PREFIX } from "@/common/types/runtime";
 import { CUSTOM_EVENTS, createCustomEvent } from "@/common/constants/events";
+import { WORKSPACE_ONLY_COMMANDS } from "@/constants/slashCommands";
 import type { Toast } from "@/browser/components/ChatInputToast";
 import type { ParsedCommand } from "@/browser/utils/slashCommands/types";
 import { applyCompactionOverrides } from "@/browser/utils/messages/compactionOptions";
@@ -237,8 +238,7 @@ export async function processSlashCommand(
   }
 
   // 2. Workspace Commands
-  const workspaceCommands = ["clear", "truncate", "compact", "fork", "new"];
-  const isWorkspaceCommand = workspaceCommands.includes(parsed.type);
+  const isWorkspaceCommand = WORKSPACE_ONLY_COMMANDS.has(parsed.type);
 
   if (isWorkspaceCommand) {
     if (variant !== "workspace") {

--- a/src/browser/utils/slashCommands/types.ts
+++ b/src/browser/utils/slashCommands/types.ts
@@ -74,6 +74,8 @@ export interface SlashSuggestion {
 
 export interface SlashSuggestionContext {
   providerNames?: string[];
+  /** Variant determines which commands are available */
+  variant?: "workspace" | "creation";
 }
 
 export interface SuggestionDefinition {

--- a/src/constants/slashCommands.ts
+++ b/src/constants/slashCommands.ts
@@ -1,0 +1,15 @@
+/**
+ * Slash command constants shared between suggestion filtering and command execution.
+ */
+
+/**
+ * Commands that only work in workspace context (not during creation).
+ * These commands require an existing workspace with conversation history.
+ */
+export const WORKSPACE_ONLY_COMMANDS: ReadonlySet<string> = new Set([
+  "clear",
+  "truncate",
+  "compact",
+  "fork",
+  "new",
+]);


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/coder/mux/pull/784 where slash commands were accidentally removed from creation mode during the ORPC migration.

Supporting global commands like `/providers` in creation mode was originally introduced in https://github.com/coder/mux/pull/704. This PR restores that functionality with an improvement: workspace-only commands (`clear`, `truncate`, `compact`, `fork`, `new`) are now filtered from suggestions in creation mode rather than just showing an error toast when executed.

## Changes

- Restore `CommandSuggestions` in creation mode with portal rendering (to escape `overflow:hidden` containers)
- Filter workspace-only commands from suggestions based on variant
- Unify toast handling to show slash command feedback in both modes
- Extract `WORKSPACE_ONLY_COMMANDS` to shared constant to avoid duplication between suggestion filtering and command execution

_Generated with `mux`_