### PR TITLE
🤖 fix: blur after click in storybook play functions for deterministic snapshots

### DIFF
--- a/src/browser/stories/App.chat.stories.tsx
+++ b/src/browser/stories/App.chat.stories.tsx
@@ -249,6 +249,8 @@ npm test 2>&1 | head -20`,
       const toolHeader = canvas.getByText(/set -e/);
       await userEvent.click(toolHeader);
     });
+    // Remove unintended focus state for deterministic visual snapshot
+    (document.activeElement as HTMLElement)?.blur();
   },
 };
 
@@ -297,6 +299,8 @@ export const WithBashToolWaiting: AppStory = {
       const toolHeader = canvas.getByText(/npm test/);
       await userEvent.click(toolHeader);
     });
+    // Remove unintended focus state for deterministic visual snapshot
+    (document.activeElement as HTMLElement)?.blur();
   },
 };
 
@@ -444,6 +448,8 @@ export const GenericTool: AppStory = {
       const toolHeader = canvas.getByText("fetch_data");
       await userEvent.click(toolHeader);
     });
+    // Remove unintended focus state for deterministic visual snapshot
+    (document.activeElement as HTMLElement)?.blur();
   },
 };
 


### PR DESCRIPTION
## Summary

Fixes flaky Chromatic snapshots where the AIView container sometimes shows a focus outline and sometimes doesn't.

## Problem

The AIView container has `tabIndex={0}` for keyboard scrolling accessibility. When storybook play functions use `userEvent.click()` to expand tool calls, the click can non-deterministically trigger `focus-visible` on the container, causing intermittent focus outlines in visual snapshots.

## Solution

Add `blur()` after clicks in affected play functions to ensure the visual snapshot captures the intended state (expanded tool) without unrelated focus styling.

This preserves the accessibility feature (focus outline) in production while making the stories test what they're meant to test.

_Generated with `mux`_