### PR TITLE
🤖 fix: use caret-current for light theme compatibility

### DIFF
--- a/src/browser/components/VimTextArea.tsx
+++ b/src/browser/components/VimTextArea.tsx
@@ -274,7 +274,7 @@ export const VimTextArea = React.forwardRef<HTMLTextAreaElement, VimTextAreaProp
               !isEditing && (mode === "plan" ? "focus:border-plan-mode" : "focus:border-exec-mode"),
               vimMode === "normal"
                 ? "caret-transparent selection:bg-white/50"
-                : "caret-white selection:bg-selection"
+                : "caret-current selection:bg-selection"
             )}
           />
           {trailingAction && (


### PR DESCRIPTION
Changes `caret-white` to `caret-current` in VimTextArea, so the caret inherits the text color and remains visible in light theme.

_Generated with `mux`_