### PR TITLE
🤖 ci: add Windows build to PR/merge queue and EV code signing to releases

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -282,6 +282,33 @@ jobs:
           retention-days: 30
           if-no-files-found: error
 
+  build-windows:
+    name: Build / Windows
+    needs: [changes]
+    if: ${{ needs.changes.outputs.src == 'true' || needs.changes.outputs.config == 'true' }}
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-mux
+      - name: Install GNU Make
+        run: choco install -y make
+      - name: Verify tools
+        shell: bash
+        run: |
+          make --version
+          bun --version
+          magick --version | head -1
+      - run: bun run build
+      - run: make dist-win
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-windows
+          path: release/*.exe
+          retention-days: 30
+          if-no-files-found: error
+
   build-vscode:
     name: Build / VS Code
     needs: [changes]
@@ -327,6 +354,7 @@ jobs:
       - smoke-docker
       - build-linux
       - build-macos
+      - build-windows
       - build-vscode
       - codex-comments
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write # Required for electron-builder to upload release assets
+  id-token: write # Required for GCP workload identity authentication (Windows code signing)
 
 env:
   RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name || github.ref_name }}
@@ -168,10 +169,53 @@ jobs:
       - name: Build application
         run: bun run build
 
+      # Setup Java for jsign (EV code signing with GCP KMS)
+      - name: Setup Java
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
+        with:
+          distribution: "zulu"
+          java-version: "11.0"
+
+      - name: Authenticate to Google Cloud
+        id: gcloud_auth
+        if: ${{ vars.GCP_WORKLOAD_ID_PROVIDER != '' }}
+        uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_ID_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          token_format: "access_token"
+
+      - name: Setup code signing
+        shell: pwsh
+        run: |
+          if (-not $env:EV_SIGNING_CERT) {
+            Write-Host "⚠️ No Windows code signing certificate provided - building unsigned"
+            exit 0
+          }
+
+          # Save EV certificate to temp file
+          $certPath = Join-Path $env:TEMP "ev_cert.pem"
+          Set-Content -Path $certPath -Value $env:EV_SIGNING_CERT
+          Add-Content -Path $env:GITHUB_ENV -Value "EV_CERTIFICATE_PATH=$certPath"
+
+          # Download jsign
+          $jsignPath = Join-Path $env:TEMP "jsign-6.0.jar"
+          Invoke-WebRequest -Uri "https://github.com/ebourg/jsign/releases/download/6.0/jsign-6.0.jar" -OutFile $jsignPath
+          Add-Content -Path $env:GITHUB_ENV -Value "JSIGN_PATH=$jsignPath"
+
+          Write-Host "✅ Windows EV code signing configured"
+        env:
+          EV_SIGNING_CERT: ${{ secrets.EV_SIGNING_CERT }}
+
       - name: Package and publish for Windows (.exe)
         run: bun x electron-builder --win --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # EV signing environment variables (used by custom sign script if configured)
+          EV_KEYSTORE: ${{ vars.EV_KEYSTORE }}
+          EV_KEY: ${{ vars.EV_KEY }}
+          EV_TSA_URL: ${{ vars.EV_TSA_URL }}
+          GCLOUD_ACCESS_TOKEN: ${{ steps.gcloud_auth.outputs.access_token }}
 
   notify-discord:
     name: Notify Discord

--- a/package.json
+++ b/package.json
@@ -257,7 +257,11 @@
     "win": {
       "target": "nsis",
       "icon": "build/icon.png",
-      "artifactName": "${productName}-${version}-${arch}.${ext}"
+      "artifactName": "${productName}-${version}-${arch}.${ext}",
+      "sign": "scripts/sign-windows.js",
+      "signingHashAlgorithms": [
+        "sha256"
+      ]
     },
     "npmRebuild": false,
     "buildDependenciesFromSource": false

--- a/scripts/sign-windows.js
+++ b/scripts/sign-windows.js
@@ -1,0 +1,78 @@
+/**
+ * Windows EV code signing script for electron-builder
+ * Uses jsign with GCP Cloud KMS for EV certificate signing
+ *
+ * Required environment variables:
+ *   JSIGN_PATH          - Path to jsign JAR file
+ *   EV_KEYSTORE         - GCP Cloud KMS keystore URL
+ *   EV_KEY              - Key alias in the keystore
+ *   EV_CERTIFICATE_PATH - Path to the EV certificate PEM file
+ *   EV_TSA_URL          - Timestamp server URL
+ *   GCLOUD_ACCESS_TOKEN - GCP access token for authentication
+ */
+
+const { execSync } = require("child_process");
+const path = require("path");
+
+/**
+ * @param {import("electron-builder").CustomWindowsSignTaskConfiguration} configuration
+ * @returns {Promise<void>}
+ */
+exports.default = async function sign(configuration) {
+  const filePath = configuration.path;
+
+  // Check if signing is configured
+  if (!process.env.JSIGN_PATH || !process.env.EV_KEYSTORE) {
+    console.log(
+      `⚠️ Windows code signing not configured - skipping signing for ${filePath}`
+    );
+    return;
+  }
+
+  // Validate required environment variables
+  const requiredVars = [
+    "JSIGN_PATH",
+    "EV_KEYSTORE",
+    "EV_KEY",
+    "EV_CERTIFICATE_PATH",
+    "EV_TSA_URL",
+    "GCLOUD_ACCESS_TOKEN",
+  ];
+
+  for (const varName of requiredVars) {
+    if (!process.env[varName]) {
+      throw new Error(`Missing required environment variable: ${varName}`);
+    }
+  }
+
+  console.log(`Signing ${filePath} with EV certificate...`);
+
+  const jsignArgs = [
+    "-jar",
+    process.env.JSIGN_PATH,
+    "--storetype",
+    "GOOGLECLOUD",
+    "--storepass",
+    process.env.GCLOUD_ACCESS_TOKEN,
+    "--keystore",
+    process.env.EV_KEYSTORE,
+    "--alias",
+    process.env.EV_KEY,
+    "--certfile",
+    process.env.EV_CERTIFICATE_PATH,
+    "--tsmode",
+    "RFC3161",
+    "--tsaurl",
+    process.env.EV_TSA_URL,
+    filePath,
+  ];
+
+  try {
+    execSync(`java ${jsignArgs.map((a) => `"${a}"`).join(" ")}`, {
+      stdio: "inherit",
+    });
+    console.log(`✅ Successfully signed ${filePath}`);
+  } catch (error) {
+    throw new Error(`Failed to sign ${filePath}: ${error.message}`);
+  }
+};


### PR DESCRIPTION
Adds Windows EV code signing using jsign + GCP Cloud KMS (same approach as coder/coder).

## Changes
- Custom signing script at `scripts/sign-windows.js` for electron-builder
- Release workflow authenticates to GCP and runs jsign for EV signing
- Gracefully skips signing if secrets not configured

## Required repo configuration (already done)
- Variables: `EV_KEYSTORE`, `EV_KEY`, `EV_TSA_URL`, `GCP_WORKLOAD_ID_PROVIDER`, `GCP_SERVICE_ACCOUNT`
- Secrets: `EV_SIGNING_CERT`

_Generated with `mux`_