### PR TITLE
🤖 fix: add ellipsis truncation to long project names

### DIFF
--- a/src/browser/components/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar.tsx
@@ -521,7 +521,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                                     const abbrevPath = PlatformPaths.abbreviate(projectPath);
                                     const { basename } = PlatformPaths.splitAbbreviated(abbrevPath);
                                     return (
-                                      <span className="text-foreground font-medium">
+                                      <span className="text-foreground truncate font-medium">
                                         {basename}
                                       </span>
                                     );


### PR DESCRIPTION
_Generated with `mux`_

Long project names in the sidebar were being cut off abruptly. Added `truncate` class to the project name span so they show ellipsis like workspace names do.