### PR TITLE
🤖 perf: skip redundant bun cache restore when node_modules exists

### DIFF
--- a/.github/actions/setup-mux/action.yml
+++ b/.github/actions/setup-mux/action.yml
@@ -22,8 +22,20 @@ runs:
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-bun-${{ steps.bun-version.outputs.version }}-node-modules-
 
+    - name: Check if node_modules exists
+      id: check-node-modules
+      shell: bash
+      run: |
+        if [ -d "node_modules" ] && [ -d "node_modules/.bin" ]; then
+          echo "exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+        fi
+
+    # Only restore bun install cache when node_modules is completely missing.
+    # This avoids 88+ seconds of tar/zstd decompression on Windows for partial cache hits.
     - name: Cache bun install cache
-      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      if: steps.check-node-modules.outputs.exists != 'true'
       id: cache-bun-install
       uses: actions/cache@v4
       with:
@@ -33,6 +45,6 @@ runs:
           ${{ runner.os }}-bun-cache-
 
     - name: Install dependencies
-      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      if: steps.check-node-modules.outputs.exists != 'true'
       shell: bash
       run: bun install --frozen-lockfile


### PR DESCRIPTION
## Problem

Windows builds were taking ~8 minutes, with setup-mux taking ~2.5 minutes.

### Root Cause

The `cache-hit` output from `actions/cache` is `false` for partial restore-key matches. This caused:

1. node_modules cache restored via restore-key → `cache-hit='false'`
2. Bun install cache also restored (275MB) → 88s decompression on Windows tar/zstd
3. `bun install` runs but is a no-op (node_modules exists)
4. Post-job: both caches re-saved with new keys (~77s combined)

### Timeline breakdown (from [this run](https://github.com/coder/mux/actions/runs/20063325241/job/57545464568)):

| Step | Duration |
|------|----------|
| Restore node_modules | 30s |
| **Restore bun cache** | **88s** ← wasted |
| bun install | 0.5s |
| choco install make | 12s |
| bun run build | 53s |
| make dist-win | 163s |
| **Post: save caches** | **77s** ← partially wasted |

## Solution

Check if `node_modules/.bin` actually exists after cache restore, instead of relying on `cache-hit` output. This is more reliable for determining if we need to install dependencies.

## Expected improvement

~88-165 seconds saved on Windows builds when lockfile hash changes (partial cache hit scenario).

_Generated with `mux`_