### PR TITLE
🤖 fix: redirect to new chat after adding project

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -680,7 +680,10 @@ function AppInner() {
         <ProjectCreateModal
           isOpen={isProjectCreateModalOpen}
           onClose={closeProjectCreateModal}
-          onSuccess={addProject}
+          onSuccess={(normalizedPath, projectConfig) => {
+            addProject(normalizedPath, projectConfig);
+            beginWorkspaceCreation(normalizedPath);
+          }}
         />
         <SettingsModal />
       </div>


### PR DESCRIPTION
_Generated with `mux`_

After adding a new project via the create modal, the user is now automatically redirected to a new chat for that project by calling `beginWorkspaceCreation(normalizedPath)` alongside `addProject`.