### PR TITLE
🤖 fix: mock Date.now() in Storybook for deterministic snapshots

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,6 +3,11 @@ import type { Preview } from "@storybook/react-vite";
 import { ThemeProvider, type ThemeMode } from "../src/browser/contexts/ThemeContext";
 import "../src/browser/styles/globals.css";
 import { TUTORIAL_STATE_KEY, type TutorialState } from "../src/common/constants/storage";
+import { NOW } from "../src/browser/stories/mockFactory";
+
+// Mock Date.now() globally for deterministic snapshots
+// Components using Date.now() for elapsed time calculations need stable reference
+Date.now = () => NOW;
 
 // Disable tutorials by default in Storybook to prevent them from interfering with stories
 // Individual stories can override this by setting localStorage before rendering


### PR DESCRIPTION
## Problem

The `WithBashToolWaiting` story was flaky because the elapsed time display changed every run.

The `BashToolCall` component calculates elapsed time using `Date.now()` for the current time, but stories use a fixed timestamp (`NOW = 1700000000000`, Nov 2023) for message timestamps. This meant the elapsed time showed something like `33000000s` (the difference between real `Date.now()` and the fixed timestamp), which changed every second.

## Solution

Mock `Date.now()` globally in Storybook preview to return the same stable `NOW` timestamp used by all test fixtures. Now the elapsed time calculation is deterministic.

_Generated with `mux`_