### PR TITLE
🤖 fix: persist localStorage writes synchronously to prevent data loss

### DIFF
--- a/src/browser/hooks/usePersistedState.ts
+++ b/src/browser/hooks/usePersistedState.ts
@@ -146,27 +146,27 @@ export function usePersistedState<T>(
       setState((prevState) => {
         const newValue = value instanceof Function ? value(prevState) : value;
 
-        // Batch localStorage writes in microtask to avoid blocking UI
-        queueMicrotask(() => {
-          if (typeof window !== "undefined" && window.localStorage) {
-            try {
-              if (newValue === undefined || newValue === null) {
-                window.localStorage.removeItem(key);
-              } else {
-                window.localStorage.setItem(key, JSON.stringify(newValue));
-              }
-
-              // Dispatch custom event for same-tab synchronization
-              // Include origin marker to prevent echo
-              const customEvent = new CustomEvent(getStorageChangeEvent(key), {
-                detail: { key, newValue, origin: componentIdRef.current },
-              });
-              window.dispatchEvent(customEvent);
-            } catch (error) {
-              console.warn(`Error writing to localStorage key "${key}":`, error);
+        // Write to localStorage synchronously to ensure data persists
+        // even if app closes immediately after (e.g., Electron quit, crash).
+        // This fixes race condition where queueMicrotask deferred writes could be lost.
+        if (typeof window !== "undefined" && window.localStorage) {
+          try {
+            if (newValue === undefined || newValue === null) {
+              window.localStorage.removeItem(key);
+            } else {
+              window.localStorage.setItem(key, JSON.stringify(newValue));
             }
+
+            // Dispatch custom event for same-tab synchronization
+            // Include origin marker to prevent echo
+            const customEvent = new CustomEvent(getStorageChangeEvent(key), {
+              detail: { key, newValue, origin: componentIdRef.current },
+            });
+            window.dispatchEvent(customEvent);
+          } catch (error) {
+            console.warn(`Error writing to localStorage key "${key}":`, error);
           }
-        });
+        }
 
         return newValue;
       });


### PR DESCRIPTION
## Problem

Reviews attached to chat were lost on Electron restart because localStorage writes were deferred via `queueMicrotask`. If the app closed before the microtask ran (e.g., force quit, crash, or immediate close), the data was never persisted.

## Root Cause

`usePersistedState` hook was using `queueMicrotask` to batch localStorage writes for "performance optimization" (added in #330). However, this introduced a race condition:

1. User creates a review → React state updates immediately
2. Microtask queued to write to localStorage
3. User closes app (or it crashes) → Microtask never runs
4. On restart → localStorage has stale/missing data

## Solution

Remove `queueMicrotask` and write to localStorage synchronously. This ensures data persists immediately after state change, at the cost of a small blocking operation (~1-2ms for typical JSON.stringify + setItem).

The synchronous write is acceptable because:
- localStorage writes are fast (~1-2ms for typical data)
- Data integrity is more important than micro-optimization
- The deferred write was a premature optimization that caused real bugs

## Testing

- [x] `make typecheck` passes
- [x] `make lint` passes
- [x] `make static-check` passes
- [x] Existing tests pass

_Generated with `mux`_