### PR TITLE
🤖 fix: guide agent to evaluate plan relevance before incremental edits

### DIFF
--- a/src/common/utils/ui/modeUtils.ts
+++ b/src/common/utils/ui/modeUtils.ts
@@ -7,7 +7,7 @@ import type { ToolPolicy } from "@/common/utils/tools/toolPolicy";
  */
 export function getPlanModeInstruction(planFilePath: string, planExists: boolean): string {
   const fileStatus = planExists
-    ? `A plan file already exists at ${planFilePath}. You can read it and make incremental edits using the file_edit_* tools.`
+    ? `A plan file already exists at ${planFilePath}. First, read it to determine if it's relevant to the current request. If the current request is unrelated to the existing plan, delete the file and start fresh. If relevant, make incremental edits using the file_edit_* tools.`
     : `No plan file exists yet. You should create your plan at ${planFilePath} using the file_edit_* tools.`;
 
   return `You are in Plan Mode. ${fileStatus}


### PR DESCRIPTION
## Problem

When a user requests a new plan for something entirely different from the previous task, the agent keeps referring to and building upon the old plan. This happens because:

1. The plan file persists across different requests (stored at `~/.mux/plans/{workspaceId}.md`)
2. When `planExists` is true, the instruction said: "You can read it and make incremental edits"
3. This biased the agent toward incremental edits rather than recognizing when a fresh start is needed

## Solution

Updated `getPlanModeInstruction` to give the agent clear guidance about evaluating whether the existing plan is relevant:

1. **Read first** - Agent must read the plan before deciding
2. **Evaluate relevance** - Explicitly check if it relates to current request
3. **Delete if unrelated** - Clear guidance to remove stale plans
4. **Keep incremental edits** - Still available when plan IS relevant

_Generated with `mux`_