### PR TITLE
🤖 fix: show user messages immediately without deferral

### DIFF
--- a/src/browser/components/AIView.tsx
+++ b/src/browser/components/AIView.tsx
@@ -169,7 +169,15 @@ const AIViewInner: React.FC<AIViewProps> = ({
   // during rapid updates (streaming), keeping the UI responsive.
   // Must be defined before any early returns to satisfy React Hooks rules.
   const mergedMessages = useMemo(() => mergeConsecutiveStreamErrors(messages), [messages]);
-  const deferredMessages = useDeferredValue(mergedMessages);
+  const deferredMergedMessages = useDeferredValue(mergedMessages);
+
+  // CRITICAL: When message count changes (new message sent/received), show immediately.
+  // Only defer content changes within existing messages (streaming deltas).
+  // This ensures user messages appear instantly while keeping streaming performant.
+  const deferredMessages =
+    mergedMessages.length !== deferredMergedMessages.length
+      ? mergedMessages
+      : deferredMergedMessages;
 
   // Get active stream message ID for token counting
   const activeStreamMessageId = aggregator?.getActiveStreamMessageId();


### PR DESCRIPTION
## Summary

Fixes a UX issue where there was an occasional delay between sending a message and it appearing in the chat window. During this delay, the input was cleared but the user message wasn't visible anywhere.

### Root Cause

`useDeferredValue` (added in #1004 to improve streaming performance) was deferring **all** message list updates, including new user messages. This is correct for streaming deltas (where rapid updates benefit from deferral) but wrong for user-initiated messages (where immediate feedback is expected).

### Fix

Compare the message counts between the current and deferred values:
- **Count differs** (new message added) → Show immediately
- **Count same** (content changes in existing messages) → Defer for performance

This preserves the streaming optimization while ensuring user messages appear instantly.

### Testing

- `make static-check` ✅
- `make test` on WorkspaceStore ✅

_Generated with `mux`_