### PR TITLE
🤖 fix: simplify Editor settings UI

### DIFF
--- a/src/browser/components/Settings/sections/GeneralSection.tsx
+++ b/src/browser/components/Settings/sections/GeneralSection.tsx
@@ -8,8 +8,6 @@ import {
   SelectValue,
 } from "@/browser/components/ui/select";
 import { Input } from "@/browser/components/ui/input";
-import { Checkbox } from "@/browser/components/ui/checkbox";
-import { Tooltip, TooltipTrigger, TooltipContent } from "@/browser/components/ui/tooltip";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
 import {
   EDITOR_CONFIG_KEY,
@@ -40,13 +38,6 @@ export function GeneralSection() {
     setEditorConfig((prev) => ({ ...prev, customCommand }));
   };
 
-  const handleRemoteExtensionChange = (useRemoteExtension: boolean) => {
-    setEditorConfig((prev) => ({ ...prev, useRemoteExtension }));
-  };
-
-  // Remote-SSH is only supported for VS Code and Cursor
-  const supportsRemote = editorConfig.editor === "vscode" || editorConfig.editor === "cursor";
-
   return (
     <div className="space-y-6">
       <div>
@@ -71,67 +62,41 @@ export function GeneralSection() {
         </div>
       </div>
 
-      <div>
-        <h3 className="text-foreground mb-4 text-sm font-medium">Editor</h3>
-        <div className="space-y-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <div className="text-foreground text-sm">Default Editor</div>
-              <div className="text-muted text-xs">Editor to open workspaces in</div>
-            </div>
-            <Select value={editorConfig.editor} onValueChange={handleEditorChange}>
-              <SelectTrigger className="border-border-medium bg-background-secondary hover:bg-hover h-9 w-auto cursor-pointer rounded-md border px-3 text-sm transition-colors">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {EDITOR_OPTIONS.map((option) => (
-                  <SelectItem key={option.value} value={option.value}>
-                    {option.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          {editorConfig.editor === "custom" && (
-            <div className="flex items-center justify-between">
-              <div>
-                <div className="text-foreground text-sm">Custom Command</div>
-                <div className="text-muted text-xs">Command to run (path will be appended)</div>
-              </div>
-              <Input
-                value={editorConfig.customCommand ?? ""}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  handleCustomCommandChange(e.target.value)
-                }
-                placeholder="e.g., nvim"
-                className="border-border-medium bg-background-secondary h-9 w-40"
-              />
-            </div>
-          )}
-
-          {supportsRemote && (
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <div className="text-foreground text-sm">Use Remote-SSH for SSH workspaces</div>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="text-muted cursor-help text-xs">(?)</span>
-                  </TooltipTrigger>
-                  <TooltipContent side="top" className="max-w-xs">
-                    When enabled, opens SSH workspaces directly in the editor using the Remote-SSH
-                    extension. Requires the Remote-SSH extension to be installed.
-                  </TooltipContent>
-                </Tooltip>
-              </div>
-              <Checkbox
-                checked={editorConfig.useRemoteExtension}
-                onCheckedChange={handleRemoteExtensionChange}
-              />
-            </div>
-          )}
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-foreground text-sm">Editor</div>
+          <div className="text-muted text-xs">Editor to open workspaces in</div>
         </div>
+        <Select value={editorConfig.editor} onValueChange={handleEditorChange}>
+          <SelectTrigger className="border-border-medium bg-background-secondary hover:bg-hover h-9 w-auto cursor-pointer rounded-md border px-3 text-sm transition-colors">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {EDITOR_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
+
+      {editorConfig.editor === "custom" && (
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="text-foreground text-sm">Custom Command</div>
+            <div className="text-muted text-xs">Command to run (path will be appended)</div>
+          </div>
+          <Input
+            value={editorConfig.customCommand ?? ""}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              handleCustomCommandChange(e.target.value)
+            }
+            placeholder="e.g., nvim"
+            className="border-border-medium bg-background-secondary h-9 w-40"
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/browser/hooks/useOpenInEditor.ts
+++ b/src/browser/hooks/useOpenInEditor.ts
@@ -44,8 +44,8 @@ export function useOpenInEditor() {
         return { success: false, error: "Please configure a custom editor command in Settings" };
       }
 
-      // For SSH workspaces, validate the editor supports remote
-      if (isSSH && editorConfig.useRemoteExtension) {
+      // For SSH workspaces, validate the editor supports Remote-SSH
+      if (isSSH) {
         if (editorConfig.editor === "zed") {
           return { success: false, error: "Zed does not support Remote-SSH for SSH workspaces" };
         }
@@ -55,14 +55,6 @@ export function useOpenInEditor() {
             error: "Custom editors do not support Remote-SSH for SSH workspaces",
           };
         }
-      }
-
-      // For SSH workspaces without remote extension, we can't open
-      if (isSSH && !editorConfig.useRemoteExtension) {
-        return {
-          success: false,
-          error: "Enable 'Use Remote-SSH' in Settings to open SSH workspaces in editor",
-        };
       }
 
       // Call the backend API

--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -168,12 +168,10 @@ export type EditorType = "vscode" | "cursor" | "zed" | "custom";
 export interface EditorConfig {
   editor: EditorType;
   customCommand?: string; // Only when editor='custom'
-  useRemoteExtension: boolean; // For SSH workspaces, use Remote-SSH
 }
 
 export const DEFAULT_EDITOR_CONFIG: EditorConfig = {
   editor: "vscode",
-  useRemoteExtension: true,
 };
 
 /**

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -416,7 +416,6 @@ const EditorTypeSchema = z.enum(["vscode", "cursor", "zed", "custom"]);
 const EditorConfigSchema = z.object({
   editor: EditorTypeSchema,
   customCommand: z.string().optional(),
-  useRemoteExtension: z.boolean(),
 });
 
 // General
@@ -491,7 +490,7 @@ export const general = {
   },
   /**
    * Open the workspace in the user's configured editor.
-   * For SSH workspaces with useRemoteExtension enabled, uses Remote-SSH extension.
+   * For SSH workspaces, uses Remote-SSH extension (VS Code/Cursor only).
    */
   openWorkspaceInEditor: {
     input: z.object({

--- a/src/node/services/editorService.ts
+++ b/src/node/services/editorService.ts
@@ -6,7 +6,6 @@ import { log } from "@/node/services/log";
 export interface EditorConfig {
   editor: string;
   customCommand?: string;
-  useRemoteExtension: boolean;
 }
 
 /**
@@ -29,7 +28,7 @@ export class EditorService {
 
   /**
    * Open the workspace in the user's configured code editor.
-   * For SSH workspaces with Remote-SSH extension enabled, opens directly in the editor.
+   * For SSH workspaces, opens via Remote-SSH extension (VS Code/Cursor only).
    */
   async openWorkspaceInEditor(
     workspaceId: string,
@@ -63,15 +62,7 @@ export class EditorService {
       }
 
       if (isSSH) {
-        // SSH workspace handling
-        if (!editorConfig.useRemoteExtension) {
-          return {
-            success: false,
-            error: "Cannot open SSH workspace without Remote-SSH extension enabled",
-          };
-        }
-
-        // Only VS Code and Cursor support Remote-SSH
+        // SSH workspace handling - only VS Code and Cursor support Remote-SSH
         if (editorConfig.editor !== "vscode" && editorConfig.editor !== "cursor") {
           return {
             success: false,


### PR DESCRIPTION
Simplifies the Editor settings in the General section:

- Removed redundant 'Editor' section header - now just a single 'Editor' row
- Removed 'Use Remote-SSH' checkbox - SSH workspaces always use Remote-SSH when the editor supports it (VS Code/Cursor)
- Removed `useRemoteExtension` from `EditorConfig` type and storage

For SSH workspaces, there's no other sensible path than Remote-SSH, so the checkbox was unnecessary. When users click 'Open in Editor' on an SSH workspace with VS Code/Cursor, it just works. If the Remote-SSH extension isn't installed, the editor itself prompts to install it.

---
_Generated with `mux`_