### PR TITLE
🤖 fix: preserve review state when renaming workspaces

### DIFF
--- a/src/browser/hooks/useReviewState.ts
+++ b/src/browser/hooks/useReviewState.ts
@@ -6,18 +6,12 @@
 import { useCallback, useMemo, useEffect, useState } from "react";
 import { usePersistedState } from "./usePersistedState";
 import type { ReviewState, HunkReadState } from "@/common/types/review";
+import { getReviewStateKey } from "@/common/constants/storage";
 
 /**
  * Maximum number of read states to keep per workspace (LRU eviction)
  */
 const MAX_READ_STATES = 1024;
-
-/**
- * Get the localStorage key for review state
- */
-function getReviewStateKey(workspaceId: string): string {
-  return `review-state:${workspaceId}`;
-}
 
 /**
  * Evict oldest read states if count exceeds max

--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -195,6 +195,15 @@ export const DEFAULT_TUTORIAL_STATE: TutorialState = {
 };
 
 /**
+ * Get the localStorage key for review (hunk read) state per workspace
+ * Stores which hunks have been marked as read during code review
+ * Format: "review-state:{workspaceId}"
+ */
+export function getReviewStateKey(workspaceId: string): string {
+  return `review-state:${workspaceId}`;
+}
+
+/**
  * Get the localStorage key for hunk expand/collapse state in Review tab
  * Stores user's manual expand/collapse preferences per hunk
  * Format: "reviewExpandState:{workspaceId}"
@@ -278,6 +287,7 @@ const PERSISTENT_WORKSPACE_KEY_FUNCTIONS: Array<(workspaceId: string) => string>
   getThinkingLevelKey,
   getAutoRetryKey,
   getRetryStateKey,
+  getReviewStateKey,
   getReviewExpandStateKey,
   getFileTreeExpandStateKey,
   getReviewSearchStateKey,


### PR DESCRIPTION
The `getReviewStateKey` function was defined locally in `useReviewState.ts` but not included in `PERSISTENT_WORKSPACE_KEY_FUNCTIONS`, so review state (which hunks were marked as read) was not migrated during workspace rename.

**Fix:** Moved `getReviewStateKey` to `storage.ts` and added it to the migration list.

_Generated with `mux`_