### PR TITLE
🤖 feat: allow unlimited bash_output timeout with queued message interruption

### DIFF
--- a/src/browser/components/tools/shared/ToolPrimitives.tsx
+++ b/src/browser/components/tools/shared/ToolPrimitives.tsx
@@ -215,10 +215,10 @@ export const ExitCodeBadge: React.FC<ExitCodeBadgeProps> = ({ exitCode, classNam
 );
 
 /**
- * Badge for displaying process status (exited, killed, failed)
+ * Badge for displaying process status (exited, killed, failed, interrupted)
  */
 interface ProcessStatusBadgeProps {
-  status: "exited" | "killed" | "failed";
+  status: "exited" | "killed" | "failed" | "interrupted";
   exitCode?: number;
   className?: string;
 }
@@ -233,7 +233,9 @@ export const ProcessStatusBadge: React.FC<ProcessStatusBadgeProps> = ({
       "inline-block shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium whitespace-nowrap",
       status === "exited" && exitCode === 0
         ? "bg-success text-on-success"
-        : "bg-danger text-on-danger",
+        : status === "interrupted"
+          ? "bg-warning text-on-warning"
+          : "bg-danger text-on-danger",
       className
     )}
   >

--- a/src/common/types/tools.ts
+++ b/src/common/types/tools.ts
@@ -235,7 +235,7 @@ export interface BashOutputToolArgs {
 export type BashOutputToolResult =
   | {
       success: true;
-      status: "running" | "exited" | "killed" | "failed";
+      status: "running" | "exited" | "killed" | "failed" | "interrupted";
       output: string;
       exitCode?: number;
       note?: string; // Agent-only message (not displayed in UI)

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -257,12 +257,11 @@ export const TOOL_DEFINITIONS = {
       timeout_secs: z
         .number()
         .min(0)
-        .max(15)
         .describe(
-          "Seconds to wait for new output (0-15). " +
+          "Seconds to wait for new output. " +
             "If no output is immediately available and process is still running, " +
             "blocks up to this duration. Returns early when output arrives or process exits. " +
-            "Use this instead of polling in a loop."
+            "Only use long timeouts (>15s) when no other useful work can be done in parallel."
         ),
     }),
   },

--- a/src/node/services/tools/bash_output.ts
+++ b/src/node/services/tools/bash_output.ts
@@ -11,7 +11,10 @@ export const createBashOutputTool: ToolFactory = (config: ToolConfiguration) => 
   return tool({
     description: TOOL_DEFINITIONS.bash_output.description,
     inputSchema: TOOL_DEFINITIONS.bash_output.schema,
-    execute: async ({ process_id, filter, timeout_secs }): Promise<BashOutputToolResult> => {
+    execute: async (
+      { process_id, filter, timeout_secs },
+      { abortSignal }
+    ): Promise<BashOutputToolResult> => {
       if (!config.backgroundProcessManager) {
         return {
           success: false,
@@ -36,7 +39,14 @@ export const createBashOutputTool: ToolFactory = (config: ToolConfiguration) => 
       }
 
       // Get incremental output with blocking wait
-      return await config.backgroundProcessManager.getOutput(process_id, filter, timeout_secs);
+      // Pass workspaceId so getOutput can check for queued messages
+      return await config.backgroundProcessManager.getOutput(
+        process_id,
+        filter,
+        timeout_secs,
+        abortSignal,
+        config.workspaceId
+      );
     },
   });
 };


### PR DESCRIPTION
## Summary

Allow `bash_output` to wait for any amount of time (removing the previous 15-second limit), while ensuring the chat stays responsive by detecting when users queue new messages.

## Changes

### 1. Remove timeout limit
- Removed `.max(15)` constraint from the schema
- Updated description to guide agents: "Only use long timeouts (>15s) when no other useful work can be done in parallel"

### 2. Add abort signal support
- `getOutput()` accepts optional `abortSignal` parameter
- Returns `status: "interrupted"` when stream is cancelled

### 3. Add queued message detection
- Added `setMessageQueued()` / `hasQueuedMessage()` to `BackgroundProcessManager`
- `queueMessage()` sets the flag; `sendQueuedMessages()` / `clearQueue()` clears it
- `getOutput()` checks for queued messages in polling loop and returns early

### Flow when user sends message during `bash_output` wait:
1. `queueMessage()` → `setMessageQueued(workspaceId, true)`
2. `bash_output`'s `getOutput()` polling loop detects `hasQueuedMessage() = true`
3. Returns `{ status: "interrupted", output: "(waiting interrupted)" }`
4. `tool-call-end` fires → `sendQueuedMessages()` processes queued message

### 4. UI update
- `ProcessStatusBadge` now supports "interrupted" status with warning color

## Testing
- Added test for abort signal interruption
- Added test for queued message interruption
- All 14 `bash_output` tests pass

---
_Generated with `mux`_