### PR TITLE
🤖 fix: correct web_fetch timeout unit (20000s → 20s)

### DIFF
--- a/src/node/services/tools/web_fetch.ts
+++ b/src/node/services/tools/web_fetch.ts
@@ -112,7 +112,7 @@ export const createWebFetchTool: ToolFactory = (config: ToolConfiguration) => {
         const result = await execBuffered(config.runtime, curlCommand, {
           cwd: config.cwd,
           abortSignal,
-          timeout: (WEB_FETCH_TIMEOUT_SECS + 5) * 1000, // Slightly longer than curl's timeout
+          timeout: WEB_FETCH_TIMEOUT_SECS + 5, // Slightly longer than curl's timeout (seconds)
         });
 
         if (result.exitCode !== 0) {


### PR DESCRIPTION
## Summary

Fixes the `web_fetch` tool hanging indefinitely on network issues (#966).

## Root Cause

The `Runtime.exec` timeout option expects **seconds**, but `web_fetch.ts` was multiplying by 1000 (treating it as milliseconds):

```typescript
// BUG: This resulted in 20,000 seconds (~5.5 hours) instead of 20 seconds
timeout: (WEB_FETCH_TIMEOUT_SECS + 5) * 1000
```

## Fix

Remove the `* 1000` multiplication:

```typescript
timeout: WEB_FETCH_TIMEOUT_SECS + 5  // 20 seconds
```

## Testing

- Typecheck passes
- Lint passes

Fixes #966

---
_Generated with `mux`_