### PR TITLE
🤖 ci: optimize Windows builds with caching and MSYS2

### DIFF
--- a/.github/actions/setup-mux/action.yml
+++ b/.github/actions/setup-mux/action.yml
@@ -48,3 +48,27 @@ runs:
       if: steps.check-node-modules.outputs.exists != 'true'
       shell: bash
       run: bun install --frozen-lockfile
+
+    # Cache Electron binaries and electron-builder resources (NSIS, etc.)
+    # These are downloaded during electron-builder and can be 200MB+ total
+    - name: Cache Electron
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/electron
+          ~/Library/Caches/electron
+          ~/AppData/Local/electron/Cache
+        key: ${{ runner.os }}-${{ runner.arch }}-electron-${{ hashFiles('**/bun.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-electron-
+
+    - name: Cache electron-builder
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/electron-builder
+          ~/Library/Caches/electron-builder
+          ~/AppData/Local/electron-builder/Cache
+        key: ${{ runner.os }}-${{ runner.arch }}-electron-builder-${{ hashFiles('**/bun.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-electron-builder-

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -292,8 +292,13 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-mux
-      - name: Install GNU Make
-        run: choco install -y make
+      - name: Add MSYS2 make to PATH
+        shell: pwsh
+        run: |
+          # MSYS2 is pre-installed on Windows runners, just needs to be in PATH
+          # Install make via pacman (faster than choco)
+          C:\msys64\usr\bin\pacman.exe -S --noconfirm make
+          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Verify tools
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,12 +152,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || github.ref }}
-          fetch-depth: 0 # Required for git describe to find tags
+          fetch-depth: 0
 
       - uses: ./.github/actions/setup-mux
 
-      - name: Install GNU Make (for build)
-        run: choco install -y make
+      - name: Add MSYS2 make to PATH
+        shell: pwsh
+        run: |
+          # MSYS2 is pre-installed on Windows runners, just needs to be in PATH
+          # Install make via pacman (faster than choco)
+          C:\msys64\usr\bin\pacman.exe -S --noconfirm make
+          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Verify tools
         shell: bash


### PR DESCRIPTION
_Generated with `mux`_

Optimizations:
- Cache Electron binaries and electron-builder resources
- Replace `choco install make` with MSYS2 pacman (pre-installed)

**Benchmarks (warm cache):**
| Runner | Total | dist-win |
|--------|-------|----------|
| windows-latest | 5m58s | 166s |
| depot-windows-2022-16 | 7m23s | 85s |
| depot-windows-2022-32 | 7m31s | 82s |

Depot runners have 2x faster electron-builder but ~130s setup overhead negates the gains. Keeping `windows-latest`.