### PR TITLE
🤖 fix: prevent init state persist race condition

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -114,6 +114,7 @@ Avoid mock-heavy tests that verify implementation details rather than behavior. 
 - Use `using` declarations (or equivalent disposables) for processes, file handles, etc., to ensure cleanup even on errors.
 - Centralize magic constants under `src/constants/`; share them instead of duplicating values across layers.
 - Never repeat constant values (like keybinds) in comments—they become stale when the constant changes.
+- **Avoid `void asyncFn()`** - fire-and-forget async calls hide race conditions. When state is observable by other code (in-memory cache, event emitters), ensure visibility order matches invariants. If memory and disk must stay in sync, persist before updating memory so observers see consistent state.
 
 ## Component State & Storage
 


### PR DESCRIPTION
Fixed flaky test `should persist init state to disk for replay across page reloads`.

## Root Cause

Race condition in `InitStateManager.endInit()`:
1. In-memory state was updated (`exitCode`) synchronously
2. Then `persist()` was awaited to write to disk
3. But `logComplete()` called `endInit()` with `void` (fire-and-forget)

If replay happened while `persist()` was still running, it would see `exitCode !== null` but the file wouldn't exist yet.

## Fix

Persist state BEFORE updating in-memory `exitCode`, ensuring the invariant: **if `init-end` is visible (live or replay), the file MUST exist**.

## Validation

- Test passes consistently (5 consecutive runs)
- All init tests pass
- Full static-check passes

_Generated with `mux`_