### PR TITLE
🤖 fix: use file mtime for accurate background process exit time

### DIFF
--- a/src/node/runtime/Runtime.ts
+++ b/src/node/runtime/Runtime.ts
@@ -79,11 +79,12 @@ export interface BackgroundHandle {
   readonly outputDir: string;
 
   /**
-   * Get the exit code if the process has exited.
+   * Get the exit code and exit time if the process has exited.
    * Returns null if still running.
    * Async because SSH needs to read remote exit_code file.
+   * exitTime is epoch ms - from file mtime for nohup processes, Date.now() for migrated.
    */
-  getExitCode(): Promise<number | null>;
+  getExitCode(): Promise<{ code: number; exitTime: number } | null>;
 
   /**
    * Terminate the process (SIGTERM → wait → SIGKILL).

--- a/src/node/services/backgroundProcessManager.ts
+++ b/src/node/services/backgroundProcessManager.ts
@@ -387,12 +387,12 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
 
     // Refresh status if still running (exit code null = still running)
     if (proc.status === "running") {
-      const exitCode = await proc.handle.getExitCode();
-      if (exitCode !== null) {
+      const result = await proc.handle.getExitCode();
+      if (result !== null) {
         log.debug(`Background process ${proc.id} has exited`);
         proc.status = "exited";
-        proc.exitCode = exitCode;
-        proc.exitTime = Date.now();
+        proc.exitCode = result.code;
+        proc.exitTime = result.exitTime;
         await this.updateMetaFile(proc).catch((err: unknown) => {
           log.debug(
             `BackgroundProcessManager: Failed to update meta.json: ${getErrorMessage(err)}`
@@ -537,12 +537,12 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
     );
 
     for (const proc of runningProcesses) {
-      const exitCode = await proc.handle.getExitCode();
-      if (exitCode !== null) {
+      const result = await proc.handle.getExitCode();
+      if (result !== null) {
         log.debug(`Background process ${proc.id} has exited`);
         proc.status = "exited";
-        proc.exitCode = exitCode;
-        proc.exitTime = Date.now();
+        proc.exitCode = result.code;
+        proc.exitTime = result.exitTime;
         await this.updateMetaFile(proc).catch((err: unknown) => {
           log.debug(
             `BackgroundProcessManager: Failed to update meta.json: ${getErrorMessage(err)}`
@@ -577,8 +577,9 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
 
       // Update process status and exit code
       proc.status = "killed";
-      proc.exitCode = (await proc.handle.getExitCode()) ?? undefined;
-      proc.exitTime ??= Date.now();
+      const result = await proc.handle.getExitCode();
+      proc.exitCode = result?.code;
+      proc.exitTime = result?.exitTime ?? Date.now();
 
       // Update meta.json
       await this.updateMetaFile(proc).catch((err: unknown) => {


### PR DESCRIPTION
## Summary

Background processes started with `run_in_background: true` use nohup and file-based exit code detection. Previously, `exitTime` was set to `Date.now()` when we **detected** the exit (by reading the exit_code file), not when the process actually exited.

This caused incorrect `uptime_ms` values - a 3-second process could show 12+ seconds if we didn't check until later.

## Fix

Read the exit_code file's mtime (set by bash trap on process exit) and use that as the true exit time.

## Changes

- `BackgroundHandle.getExitCode()` now returns `{ code, exitTime } | null`
- `RuntimeBackgroundHandle` uses `date -r FILE +%s` (cross-platform) to get mtime
- `MigratedBackgroundHandle` captures `Date.now()` on exitCode promise resolve
- All callers updated to use `result.exitTime`

## Cross-platform

`date -r FILE` works on:
- Linux (GNU date)
- macOS (BSD date)
- Git Bash (MSYS2/GNU coreutils)
- WSL

## Testing

- `make typecheck` ✅
- Existing tests pass ✅

_Generated with `mux`_