### PR TITLE
🤖 fix: wire up OPEN_IN_EDITOR keybind handler

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "mux",

--- a/src/browser/components/AIView.tsx
+++ b/src/browser/components/AIView.tsx
@@ -34,6 +34,7 @@ import { ProviderOptionsProvider } from "@/browser/contexts/ProviderOptionsConte
 import { formatKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
 import { useAutoScroll } from "@/browser/hooks/useAutoScroll";
 import { useOpenTerminal } from "@/browser/hooks/useOpenTerminal";
+import { useOpenInEditor } from "@/browser/hooks/useOpenInEditor";
 import { readPersistedState, usePersistedState } from "@/browser/hooks/usePersistedState";
 import { useThinking } from "@/browser/contexts/ThinkingContext";
 import {
@@ -371,6 +372,11 @@ const AIViewInner: React.FC<AIViewProps> = ({
     openTerminal(workspaceId, runtimeConfig);
   }, [workspaceId, openTerminal, runtimeConfig]);
 
+  const openInEditor = useOpenInEditor();
+  const handleOpenInEditor = useCallback(() => {
+    void openInEditor(workspaceId, namedWorkspacePath, runtimeConfig);
+  }, [workspaceId, namedWorkspacePath, openInEditor, runtimeConfig]);
+
   // Auto-scroll when messages or todos update (during streaming)
   useEffect(() => {
     if (workspaceState && autoScroll) {
@@ -414,6 +420,7 @@ const AIViewInner: React.FC<AIViewProps> = ({
     chatInputAPI,
     jumpToBottom,
     handleOpenTerminal,
+    handleOpenInEditor,
     aggregator,
     setEditingMessage,
     vimEnabled,

--- a/src/browser/hooks/useAIViewKeybinds.ts
+++ b/src/browser/hooks/useAIViewKeybinds.ts
@@ -22,6 +22,7 @@ interface UseAIViewKeybindsParams {
   chatInputAPI: React.RefObject<ChatInputAPI | null>;
   jumpToBottom: () => void;
   handleOpenTerminal: () => void;
+  handleOpenInEditor: () => void;
   aggregator: StreamingMessageAggregator | undefined; // For compaction detection
   setEditingMessage: (editing: { id: string; content: string } | undefined) => void;
   vimEnabled: boolean; // For vim-aware interrupt keybind
@@ -34,6 +35,7 @@ interface UseAIViewKeybindsParams {
  * - Ctrl+Shift+T: Toggle thinking level
  * - Ctrl+G: Jump to bottom
  * - Ctrl+T: Open terminal
+ * - Ctrl+Shift+E: Open in editor
  * - Ctrl+C (during compaction in vim mode): Cancel compaction, restore command
  *
  * Note: In vim mode, Ctrl+C always interrupts streams. Use vim yank (y) commands for copying.
@@ -49,6 +51,7 @@ export function useAIViewKeybinds({
   chatInputAPI,
   jumpToBottom,
   handleOpenTerminal,
+  handleOpenInEditor,
   aggregator,
   setEditingMessage,
   vimEnabled,
@@ -144,6 +147,9 @@ export function useAIViewKeybinds({
       } else if (matchesKeybind(e, KEYBINDS.OPEN_TERMINAL)) {
         e.preventDefault();
         handleOpenTerminal();
+      } else if (matchesKeybind(e, KEYBINDS.OPEN_IN_EDITOR)) {
+        e.preventDefault();
+        handleOpenInEditor();
       }
     };
 
@@ -152,6 +158,7 @@ export function useAIViewKeybinds({
   }, [
     jumpToBottom,
     handleOpenTerminal,
+    handleOpenInEditor,
     workspaceId,
     canInterrupt,
     showRetryBarrier,


### PR DESCRIPTION
The `Ctrl+Shift+E` (`Cmd+Shift+E` on Mac) shortcut was defined in `KEYBINDS` and shown in the tooltip, but no keyboard listener was ever registered.

Adds the handler to `useAIViewKeybinds` alongside `OPEN_TERMINAL`.

_Generated with `mux`_