### PR TITLE
🤖 fix: emit change event when background process exit is detected

### DIFF
--- a/src/node/services/backgroundProcessManager.ts
+++ b/src/node/services/backgroundProcessManager.ts
@@ -419,6 +419,7 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
             `BackgroundProcessManager: Failed to update meta.json: ${getErrorMessage(err)}`
           );
         });
+        this.emitChange(proc.workspaceId);
       }
     }
 
@@ -584,6 +585,7 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
             `BackgroundProcessManager: Failed to update meta.json: ${getErrorMessage(err)}`
           );
         });
+        this.emitChange(proc.workspaceId);
       }
     }
   }


### PR DESCRIPTION
## Problem

The background bash banner was not updating when processes exited naturally. It would appear when a process started and disappear if you clicked terminate, but stayed visible when a process completed on its own.

## Root Cause

When `list()` or `getProcess()` polled the exit code and discovered a process had exited, the status was updated internally but `emitChange()` was never called to notify the subscription in `router.ts`.

## Fix

Add `emitChange(proc.workspaceId)` in both `refreshRunningStatuses()` and `getProcess()` when a process is discovered to have exited.

_Generated with `mux`_