### PR TITLE
🤖 fix: guard activate handler against services race condition

### DIFF
--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -607,7 +607,8 @@ if (gotTheLock) {
 
   app.on("activate", () => {
     // Skip splash on reactivation - services already loaded, window creation is fast
-    if (app.isReady() && mainWindow === null) {
+    // Guard: services must be loaded (prevents race if activate fires during startup)
+    if (app.isReady() && mainWindow === null && services) {
       createWindow();
     }
   });


### PR DESCRIPTION
On macOS, clicking the dock icon during startup (while splash is visible and services are loading) fires the activate event. The handler was calling `createWindow()` without checking if services were initialized, causing an assertion failure:

```
AssertionError: Services must be loaded before creating window
at createWindow (src/desktop/main.ts:409:9)
at App.<anonymous> (src/desktop/main.ts:611:7)
```

**Fix:** Added `services` check to the activate handler condition. If services aren't ready, the handler does nothing and normal startup flow creates the window.

---
_Generated with `mux`_