### PR TITLE
🤖 fix: strip trailing slashes from project paths

### DIFF
--- a/src/node/utils/pathUtils.test.ts
+++ b/src/node/utils/pathUtils.test.ts
@@ -129,5 +129,23 @@ describe("pathUtils", () => {
       expect(result.valid).toBe(true);
       expect(result.expandedPath).toBe(tempDir);
     });
+
+    it("should strip trailing slashes from path", async () => {
+      // Create .git directory for validation
+      // eslint-disable-next-line local/no-sync-fs-methods -- Test setup only
+      fs.mkdirSync(path.join(tempDir, ".git"));
+
+      // Test with single trailing slash
+      const resultSingle = await validateProjectPath(`${tempDir}/`);
+      expect(resultSingle.valid).toBe(true);
+      expect(resultSingle.expandedPath).toBe(tempDir);
+      expect(resultSingle.expandedPath).not.toMatch(/[/\\]$/);
+
+      // Test with multiple trailing slashes
+      const resultMultiple = await validateProjectPath(`${tempDir}//`);
+      expect(resultMultiple.valid).toBe(true);
+      expect(resultMultiple.expandedPath).toBe(tempDir);
+      expect(resultMultiple.expandedPath).not.toMatch(/[/\\]$/);
+    });
   });
 });

--- a/src/node/utils/pathUtils.ts
+++ b/src/node/utils/pathUtils.ts
@@ -27,6 +27,21 @@ export function expandTilde(inputPath: string): string {
 }
 
 /**
+ * Strip trailing slashes from a path.
+ * path.normalize() preserves a single trailing slash which breaks basename extraction.
+ *
+ * @param inputPath - Path that may have trailing slashes
+ * @returns Path without trailing slashes
+ *
+ * @example
+ * stripTrailingSlashes("/home/user/project/") // => "/home/user/project"
+ * stripTrailingSlashes("/home/user/project//") // => "/home/user/project"
+ */
+export function stripTrailingSlashes(inputPath: string): string {
+  return inputPath.replace(/[/\\]+$/, "");
+}
+
+/**
  * Validate that a project path exists, is a directory, and is a git repository
  * Automatically expands tilde and normalizes the path
  *
@@ -47,8 +62,8 @@ export async function validateProjectPath(inputPath: string): Promise<PathValida
   // Expand tilde if present
   const expandedPath = expandTilde(inputPath);
 
-  // Normalize to resolve any .. or . in the path
-  const normalizedPath = path.normalize(expandedPath);
+  // Normalize to resolve any .. or . in the path, then strip trailing slashes
+  const normalizedPath = stripTrailingSlashes(path.normalize(expandedPath));
 
   // Check if path exists
   try {

--- a/tests/e2e/scenarios/projectPath.spec.ts
+++ b/tests/e2e/scenarios/projectPath.spec.ts
@@ -1,0 +1,83 @@
+import { electronTest as test, electronExpect as expect } from "../electronTest";
+import fs from "fs";
+import path from "path";
+import { spawnSync } from "child_process";
+
+test.skip(
+  ({ browserName }) => browserName !== "chromium",
+  "Electron scenario runs on chromium only"
+);
+
+test.describe("Project Path Handling", () => {
+  test("project with trailing slash displays correctly", async ({ workspace, page }) => {
+    const { configRoot } = workspace;
+    const srcDir = path.join(configRoot, "src");
+    const sessionsDir = path.join(configRoot, "sessions");
+
+    // Create a project path WITH trailing slash to simulate the bug
+    const projectPathWithSlash = path.join(configRoot, "fixtures", "trailing-slash-project") + "/";
+    const projectName = "trailing-slash-project"; // Expected extracted name
+    const workspaceBranch = "test-branch";
+    const workspacePath = path.join(srcDir, projectName, workspaceBranch);
+
+    // Create directories
+    fs.mkdirSync(path.dirname(projectPathWithSlash), { recursive: true });
+    fs.mkdirSync(projectPathWithSlash, { recursive: true });
+    fs.mkdirSync(workspacePath, { recursive: true });
+    fs.mkdirSync(sessionsDir, { recursive: true });
+
+    // Initialize git repos
+    for (const repoPath of [projectPathWithSlash, workspacePath]) {
+      spawnSync("git", ["init", "-q"], { cwd: repoPath });
+      spawnSync("git", ["config", "user.email", "test@example.com"], { cwd: repoPath });
+      spawnSync("git", ["config", "user.name", "Test"], { cwd: repoPath });
+      spawnSync("git", ["commit", "--allow-empty", "-q", "-m", "init"], { cwd: repoPath });
+    }
+
+    // Write config with trailing slash in project path - this tests the migration
+    const configPayload = {
+      projects: [[projectPathWithSlash, { workspaces: [{ path: workspacePath }] }]],
+    };
+    fs.writeFileSync(path.join(configRoot, "config.json"), JSON.stringify(configPayload, null, 2));
+
+    // Create workspace session with metadata
+    const workspaceId = `${projectName}-${workspaceBranch}`;
+    const workspaceSessionDir = path.join(sessionsDir, workspaceId);
+    fs.mkdirSync(workspaceSessionDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(workspaceSessionDir, "metadata.json"),
+      JSON.stringify({
+        id: workspaceId,
+        name: workspaceBranch,
+        projectName,
+        projectPath: projectPathWithSlash,
+      })
+    );
+    fs.writeFileSync(path.join(workspaceSessionDir, "chat.jsonl"), "");
+
+    // Reload the page to pick up the new config
+    await page.reload();
+    await page.waitForLoadState("domcontentloaded");
+
+    // Find the project in the sidebar - it should show the project name, not empty
+    const navigation = page.getByRole("navigation", { name: "Projects" });
+    await expect(navigation).toBeVisible();
+
+    // The project name should be visible (extracted correctly despite trailing slash)
+    // If the bug was present, we'd see an empty project name or just "/"
+    await expect(navigation.getByText(projectName)).toBeVisible();
+
+    // Verify the workspace is also visible under the project
+    const projectItem = navigation.locator('[role="button"][aria-controls]').first();
+    await expect(projectItem).toBeVisible();
+
+    // Expand to see workspace
+    const expandButton = projectItem.getByRole("button", { name: /expand project/i });
+    if (await expandButton.isVisible()) {
+      await expandButton.click();
+    }
+
+    // Workspace branch should be visible
+    await expect(navigation.getByText(workspaceBranch)).toBeVisible();
+  });
+});


### PR DESCRIPTION
Fixes #1063

Project paths with trailing slashes (e.g. `/home/user/project/`) caused mangled workspace names because `basename('/path/')` returns an empty string.

The fix strips trailing slashes in `validateProjectPath()`, which is the central validation point for all project paths.

---

_Generated with `mux`_