### PR TITLE
🤖 ci: skip Windows build on PR, keep in merge queue

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -285,7 +285,8 @@ jobs:
   build-windows:
     name: Build / Windows
     needs: [changes]
-    if: ${{ needs.changes.outputs.src == 'true' || needs.changes.outputs.config == 'true' }}
+    # Windows builds are slow - only run in merge queue, not on every PR push
+    if: ${{ github.event_name == 'merge_group' && (needs.changes.outputs.src == 'true' || needs.changes.outputs.config == 'true') }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Windows builds are slow (~3-4 min). This skips them on regular PR pushes but keeps them running in the merge queue to catch platform-specific issues before merging to main.

**Change:** Modified `build-windows` job condition to only run on `merge_group` events (same pattern as `smoke-docker`).

_Generated with `mux`_