### PR TITLE
🤖 feat: use workspace name for plan file storage

### DIFF
--- a/src/common/utils/planStorage.test.ts
+++ b/src/common/utils/planStorage.test.ts
@@ -2,25 +2,22 @@ import { getPlanFilePath, getLegacyPlanFilePath } from "./planStorage";
 
 describe("planStorage", () => {
   describe("getPlanFilePath", () => {
-    it("should return path with project name, hash, and workspace name", () => {
-      const result = getPlanFilePath("fix-plan-mode", "mux", "/home/user/mux");
-      // Hash of "/home/user/mux" is deterministic
-      expect(result).toMatch(/^~\/\.mux\/plans\/mux-[a-f0-9]{6}\/fix-plan-mode\.md$/);
-    });
-
-    it("should produce different paths for different project paths with same basename", () => {
-      const result1 = getPlanFilePath("main", "mux", "/home/user/work/mux");
-      const result2 = getPlanFilePath("main", "mux", "/tmp/mux");
-      expect(result1).not.toBe(result2);
-      // Both should follow the pattern
-      expect(result1).toMatch(/^~\/\.mux\/plans\/mux-[a-f0-9]{6}\/main\.md$/);
-      expect(result2).toMatch(/^~\/\.mux\/plans\/mux-[a-f0-9]{6}\/main\.md$/);
+    it("should return path with project name and workspace name", () => {
+      const result = getPlanFilePath("fix-plan-a1b2", "mux");
+      expect(result).toBe("~/.mux/plans/mux/fix-plan-a1b2.md");
     });
 
     it("should produce same path for same inputs", () => {
-      const result1 = getPlanFilePath("fix-bug", "myproject", "/path/to/myproject");
-      const result2 = getPlanFilePath("fix-bug", "myproject", "/path/to/myproject");
+      const result1 = getPlanFilePath("fix-bug-x1y2", "myproject");
+      const result2 = getPlanFilePath("fix-bug-x1y2", "myproject");
       expect(result1).toBe(result2);
+    });
+
+    it("should organize plans by project folder", () => {
+      const result1 = getPlanFilePath("sidebar-a1b2", "mux");
+      const result2 = getPlanFilePath("auth-c3d4", "other-project");
+      expect(result1).toBe("~/.mux/plans/mux/sidebar-a1b2.md");
+      expect(result2).toBe("~/.mux/plans/other-project/auth-c3d4.md");
     });
   });
 

--- a/src/common/utils/planStorage.ts
+++ b/src/common/utils/planStorage.ts
@@ -1,37 +1,19 @@
 /**
- * Create a short hash from a string (for project path disambiguation).
- * Uses a simple djb2-like hash algorithm suitable for browser and Node.js.
- */
-function shortHash(str: string): string {
-  let hash = 5381;
-  for (let i = 0; i < str.length; i++) {
-    hash = (hash * 33) ^ str.charCodeAt(i);
-  }
-  // Convert to unsigned 32-bit and take first 6 hex characters
-  return (hash >>> 0).toString(16).padStart(8, "0").slice(0, 6);
-}
-
-/**
  * Get the plan file path for a workspace.
  * Returns a path with ~ prefix that works with both local and SSH runtimes.
  * The runtime will expand ~ to the appropriate home directory.
  *
- * Plan files are stored at: ~/.mux/plans/{projectName}-{pathHash}/{workspaceName}.md
+ * Plan files are stored at: ~/.mux/plans/{projectName}/{workspaceName}.md
  *
- * The pathHash is derived from the full project path to avoid collisions between
- * projects with the same basename (e.g., ~/work/mux vs ~/tmp/mux).
+ * Workspace names include a random suffix (e.g., "sidebar-a1b2") making them
+ * globally unique with high probability. The project folder is for organization
+ * and discoverability, not uniqueness.
  *
- * @param workspaceName - Human-readable workspace name (e.g., "fix-plan-mode")
+ * @param workspaceName - Human-readable workspace name with suffix (e.g., "fix-plan-a1b2")
  * @param projectName - Project name extracted from project path (e.g., "mux")
- * @param projectPath - Full project path for disambiguation (e.g., "/home/user/mux")
  */
-export function getPlanFilePath(
-  workspaceName: string,
-  projectName: string,
-  projectPath: string
-): string {
-  const hash = shortHash(projectPath);
-  return `~/.mux/plans/${projectName}-${hash}/${workspaceName}.md`;
+export function getPlanFilePath(workspaceName: string, projectName: string): string {
+  return `~/.mux/plans/${projectName}/${workspaceName}.md`;
 }
 
 /**

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -54,10 +54,10 @@ import type {
 import { applyToolPolicy, type ToolPolicy } from "@/common/utils/tools/toolPolicy";
 import { MockScenarioPlayer } from "./mock/mockScenarioPlayer";
 import { EnvHttpProxyAgent, type Dispatcher } from "undici";
-import { getPlanFilePath, getLegacyPlanFilePath } from "@/common/utils/planStorage";
+import { getPlanFilePath } from "@/common/utils/planStorage";
 import { getPlanModeInstruction } from "@/common/utils/ui/modeUtils";
 import type { UIMode } from "@/common/types/mode";
-import { readFileString, writeFileString, execBuffered } from "@/node/utils/runtime/helpers";
+import { readPlanFile } from "@/node/utils/runtime/helpers";
 
 // Export a standalone version of getToolsForModel for use in backend
 
@@ -992,37 +992,18 @@ export class AIService extends EventEmitter {
       // Construct plan mode instruction if in plan mode
       // This is done backend-side because we have access to the plan file path
       let effectiveAdditionalInstructions = additionalSystemInstructions;
-      const planFilePath = getPlanFilePath(
+      const planFilePath = getPlanFilePath(metadata.name, metadata.projectName);
+
+      // Read plan file (handles legacy migration transparently)
+      const planResult = await readPlanFile(
+        runtime,
         metadata.name,
         metadata.projectName,
-        metadata.projectPath
+        workspaceId
       );
-      const legacyPlanPath = getLegacyPlanFilePath(workspaceId);
+
       if (mode === "plan") {
-        // Check if plan file exists using runtime (supports both local and SSH)
-        // Try new path first, then legacy path
-        let planExists = false;
-        try {
-          await runtime.stat(planFilePath);
-          planExists = true;
-        } catch {
-          // Try legacy path
-          try {
-            await runtime.stat(legacyPlanPath);
-            planExists = true;
-            // Migrate legacy plan to new location
-            try {
-              const content = await readFileString(runtime, legacyPlanPath);
-              await writeFileString(runtime, planFilePath, content);
-              await execBuffered(runtime, `rm -f "${legacyPlanPath}"`, { cwd: "/tmp", timeout: 5 });
-            } catch {
-              // Migration failed, but plan exists at legacy path
-            }
-          } catch {
-            // File doesn't exist at either location
-          }
-        }
-        const planModeInstruction = getPlanModeInstruction(planFilePath, planExists);
+        const planModeInstruction = getPlanModeInstruction(planFilePath, planResult.exists);
         effectiveAdditionalInstructions = additionalSystemInstructions
           ? `${planModeInstruction}\n\n${additionalSystemInstructions}`
           : planModeInstruction;
@@ -1035,34 +1016,8 @@ export class AIService extends EventEmitter {
         const lastAssistantMessage = [...filteredMessages]
           .reverse()
           .find((m) => m.role === "assistant");
-        if (lastAssistantMessage?.metadata?.mode === "plan") {
-          // Try new path first, then legacy path (reuse paths computed above)
-          try {
-            const content = await readFileString(runtime, planFilePath);
-            if (content.trim()) {
-              planContentForTransition = content;
-            }
-          } catch {
-            // Try legacy path
-            try {
-              const content = await readFileString(runtime, legacyPlanPath);
-              if (content.trim()) {
-                planContentForTransition = content;
-                // Migrate legacy plan to new location
-                try {
-                  await writeFileString(runtime, planFilePath, content);
-                  await execBuffered(runtime, `rm -f "${legacyPlanPath}"`, {
-                    cwd: "/tmp",
-                    timeout: 5,
-                  });
-                } catch {
-                  // Migration failed, but we have the content
-                }
-              }
-            } catch {
-              // No plan file exists, proceed without plan content
-            }
-          }
+        if (lastAssistantMessage?.metadata?.mode === "plan" && planResult.content.trim()) {
+          planContentForTransition = planResult.content;
         }
       }
 

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -39,8 +39,8 @@ import { DisposableTempDir } from "@/node/services/tempDir";
 import { createBashTool } from "@/node/services/tools/bash";
 import type { BashToolResult } from "@/common/types/tools";
 import { secretsToRecord } from "@/common/types/secrets";
-import { getPlanFilePath } from "@/common/utils/planStorage";
-import { readFileString, writeFileString, execBuffered } from "@/node/utils/runtime/helpers";
+
+import { movePlanFile } from "@/node/utils/runtime/helpers";
 
 /** Maximum number of retry attempts when workspace name collides */
 const MAX_WORKSPACE_NAME_COLLISION_RETRIES = 3;
@@ -562,25 +562,7 @@ export class WorkspaceService extends EventEmitter {
       });
 
       // Rename plan file if it exists (uses workspace name, not ID)
-      const oldPlanPath = getPlanFilePath(
-        oldName,
-        oldMetadata.projectName,
-        oldMetadata.projectPath
-      );
-      const newPlanPath = getPlanFilePath(
-        newName,
-        oldMetadata.projectName,
-        oldMetadata.projectPath
-      );
-      try {
-        await runtime.stat(oldPlanPath);
-        // Plan file exists, move it to the new location
-        const content = await readFileString(runtime, oldPlanPath);
-        await writeFileString(runtime, newPlanPath, content);
-        await execBuffered(runtime, `rm -f "${oldPlanPath}"`, { cwd: "/tmp", timeout: 5 });
-      } catch {
-        // No plan file to rename, that's fine
-      }
+      await movePlanFile(runtime, oldName, newName, oldMetadata.projectName);
 
       const allMetadataUpdated = await this.config.getAllWorkspaceMetadata();
       const updatedMetadata = allMetadataUpdated.find((m) => m.id === workspaceId);

--- a/tests/ipc/fileChangeNotification.test.ts
+++ b/tests/ipc/fileChangeNotification.test.ts
@@ -96,12 +96,11 @@ describeIntegration("File Change Notification Integration", () => {
     const workspaceId = createResult.metadata.id;
     const workspaceName = createResult.metadata.name;
     const projectName = createResult.metadata.projectName;
-    const projectPath = createResult.metadata.projectPath;
 
     try {
       // 2. Get the AgentSession and plan file path
       const session = env.services.workspaceService.getOrCreateSession(workspaceId);
-      const planPath = getPlanFilePath(workspaceName, projectName, projectPath);
+      const planPath = getPlanFilePath(workspaceName, projectName);
 
       // 3. Create the plan directory and file
       const planDir = join(planPath, "..");
@@ -211,12 +210,11 @@ describeIntegration("File Change Notification Integration", () => {
     const workspaceId = createResult.metadata.id;
     const workspaceName = createResult.metadata.name;
     const projectName = createResult.metadata.projectName;
-    const projectPath = createResult.metadata.projectPath;
 
     try {
       // 2. Get the AgentSession and plan file path
       const session = env.services.workspaceService.getOrCreateSession(workspaceId);
-      const planPath = getPlanFilePath(workspaceName, projectName, projectPath);
+      const planPath = getPlanFilePath(workspaceName, projectName);
 
       // 3. Create the plan directory and file
       const planDir = join(planPath, "..");

--- a/tests/ipc/planCommands.test.ts
+++ b/tests/ipc/planCommands.test.ts
@@ -81,11 +81,10 @@ describeIntegration("Plan Commands Integration", () => {
       const workspaceId = createResult.metadata.id;
       const workspaceName = createResult.metadata.name;
       const projectName = createResult.metadata.projectName;
-      const projectPath = createResult.metadata.projectPath;
 
       try {
         // Create a plan file
-        const planPath = getPlanFilePath(workspaceName, projectName, projectPath);
+        const planPath = getPlanFilePath(workspaceName, projectName);
         const expandedPlanPath = expandTilde(planPath);
         const planDir = path.dirname(expandedPlanPath);
         await fs.mkdir(planDir, { recursive: true });
@@ -121,11 +120,10 @@ describeIntegration("Plan Commands Integration", () => {
       const workspaceId = createResult.metadata.id;
       const workspaceName = createResult.metadata.name;
       const projectName = createResult.metadata.projectName;
-      const projectPath = createResult.metadata.projectPath;
 
       try {
         // Create an empty plan file
-        const planPath = getPlanFilePath(workspaceName, projectName, projectPath);
+        const planPath = getPlanFilePath(workspaceName, projectName);
         const expandedPlanPath = expandTilde(planPath);
         const planDir = path.dirname(expandedPlanPath);
         await fs.mkdir(planDir, { recursive: true });
@@ -161,11 +159,10 @@ describeIntegration("Plan Commands Integration", () => {
       const workspaceId = createResult.metadata.id;
       const workspaceName = createResult.metadata.name;
       const projectName = createResult.metadata.projectName;
-      const projectPath = createResult.metadata.projectPath;
 
       try {
         // Create a plan file
-        const planPath = getPlanFilePath(workspaceName, projectName, projectPath);
+        const planPath = getPlanFilePath(workspaceName, projectName);
         const planDir = path.dirname(planPath);
         await fs.mkdir(planDir, { recursive: true });
         await fs.writeFile(planPath, "# Test Plan");


### PR DESCRIPTION
Store plan files at `~/.mux/plans/{projectName}/{workspaceName}.md` instead of `~/.mux/plans/{workspaceId}.md` for better discoverability.

## Changes
- `getPlanFilePath` now takes `(workspaceName, projectName)`
- Added `getLegacyPlanFilePath` for migration support
- Migrate legacy plans to new location on read
- Handle plan file rename when workspace is renamed

## New Format
- Makes plans discoverable: `ls ~/.mux/plans/mux/` shows all mux workspace plans
- Provides global uniqueness via `projectName + workspaceName`
- Supports future workspace rename by moving files within project folder

## Legacy Support
- On read, checks new path first, falls back to legacy
- When legacy found, migrates to new location and deletes old file

_Generated with `mux`_