### PR TITLE
🤖 fix: resolve bash tool story flakiness

### DIFF
--- a/src/browser/components/AIView.tsx
+++ b/src/browser/components/AIView.tsx
@@ -562,6 +562,7 @@ const AIViewInner: React.FC<AIViewProps> = ({
             aria-label="Conversation transcript"
             tabIndex={0}
             data-testid="message-window"
+            data-loaded={!loading}
             className="h-full overflow-y-auto p-[15px] leading-[1.5] break-words whitespace-pre-wrap"
           >
             <div


### PR DESCRIPTION
The `expandAllBashTools` helper had a race condition where it would find and click expand icons before all messages had finished rendering.

**Root cause:** `createStaticChatHandler` sends messages async (50ms delay), and `waitFor` succeeded as soon as *any* expand icons appeared, missing tools that rendered in later React commits.

**Fix:**
- Add `data-loaded` attribute to message-window in AIView.tsx that reflects the actual loading state (true when caught-up received)
- Update `expandAllBashTools` to wait for `data-loaded="true"` before finding expand icons

This is non-racy because `data-loaded` only becomes true after `caught-up` is processed, and all messages are sent before `caught-up`.

_Generated with `mux`_