### PR TITLE
🤖 fix: add filter_exclude guidance to bash_output description

### DIFF
--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -244,7 +244,8 @@ export const TOOL_DEFINITIONS = {
       "Returns stdout and stderr output along with process status. " +
       "Supports optional regex filtering to show only lines matching a pattern. " +
       "WARNING: When using filter, non-matching lines are permanently discarded. " +
-      "Use timeout to wait for output instead of polling repeatedly.",
+      "Use timeout to wait for output instead of polling repeatedly. " +
+      "If you've called this 3+ times on the same process, use filter_exclude with a longer timeout instead.",
     schema: z.object({
       process_id: z.string().describe("The ID of the background process to retrieve output from"),
       filter: z


### PR DESCRIPTION
Agents were repeatedly calling bash_output in tight loops instead of using filter_exclude with longer timeouts. Added a concrete trigger ('3+ times') to help agents recognize polling spam and switch to the better pattern.

_Generated with `mux`_