### PR TITLE
🤖 fix: mark SSH connections healthy after successful operations

### DIFF
--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -228,8 +228,11 @@ export class SSHRuntime implements Runtime {
 
         // SSH exit code 255 indicates connection failure - report to pool for backoff
         // This prevents thundering herd when a previously healthy host goes down
+        // Any other exit code means the connection worked (command may have failed)
         if (exitCode === 255) {
           sshConnectionPool.reportFailure(this.config, "SSH connection failed (exit code 255)");
+        } else {
+          sshConnectionPool.markHealthy(this.config);
         }
 
         resolve(exitCode);
@@ -473,6 +476,8 @@ export class SSHRuntime implements Runtime {
           return;
         }
 
+        // Connection worked - mark healthy to clear any backoff state
+        sshConnectionPool.markHealthy(this.config);
         const output = stdout.trim();
         resolve(output);
       });


### PR DESCRIPTION
_Generated with `mux`_

## Problem

SSH connections entered backoff on failures but never recovered on success, causing frequent errors like:
```
SSH connection to ovh-1 is in backoff for 3s. Last error: SSH connection failed (exit code 255)
```

## Fix

Call `markHealthy()` after successful SSH operations (any exit code ≠ 255). This creates symmetric health tracking so transient failures recover automatically once the connection is working again.

## Changes

- Added `markHealthy()` call in `exec()` when SSH exits with code ≠ 255
- Added `markHealthy()` call in `execSSHCommand()` on success