### PR TITLE
🤖 fix: apply gateway transformation to compaction model

### DIFF
--- a/src/browser/utils/messages/compactionOptions.ts
+++ b/src/browser/utils/messages/compactionOptions.ts
@@ -7,6 +7,7 @@
 
 import type { SendMessageOptions } from "@/common/orpc/types";
 import type { CompactionRequestData } from "@/common/types/message";
+import { toGatewayModel } from "@/browser/hooks/useGatewayModels";
 
 /**
  * Apply compaction-specific option overrides to base options.
@@ -24,7 +25,8 @@ export function applyCompactionOverrides(
   compactData: CompactionRequestData
 ): SendMessageOptions {
   // Use custom model if specified, otherwise use workspace default
-  const compactionModel = compactData.model ?? baseOptions.model;
+  // Apply gateway transformation - compactData.model is raw, baseOptions.model is already transformed
+  const compactionModel = compactData.model ? toGatewayModel(compactData.model) : baseOptions.model;
 
   return {
     ...baseOptions,


### PR DESCRIPTION
Compaction model preference was bypassing mux-gateway even when the user had gateway enabled for that model. The raw model ID from `resolveCompactionModel()` was used directly without applying `toGatewayModel()` transformation.

Now `applyCompactionOverrides()` applies the gateway transformation when a compaction-specific model is used, ensuring consistent routing behavior with normal message flow.

_Generated with `mux`_