### PR TITLE
🤖 feat: add ability to disable MCP servers

### DIFF
--- a/.github/actions/setup-mux/action.yml
+++ b/.github/actions/setup-mux/action.yml
@@ -44,8 +44,10 @@ runs:
         restore-keys: |
           ${{ runner.os }}-bun-cache-
 
+    # Always run install if we didn't get an exact cache hit.
+    # This handles restore-key matches which may have stale/incomplete node_modules.
     - name: Install dependencies
-      if: steps.check-node-modules.outputs.exists != 'true'
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
       shell: bash
       run: bun install --frozen-lockfile
 

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.8",
@@ -897,6 +898,8 @@
     "@radix-ui/react-separator": ["@radix-ui/react-separator@1.1.8", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g=="],
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
+
+    "@radix-ui/react-switch": ["@radix-ui/react-switch@1.2.6", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ=="],
 
     "@radix-ui/react-tabs": ["@radix-ui/react-tabs@1.1.13", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A=="],
 
@@ -3784,6 +3787,8 @@
 
     "@radix-ui/react-select/@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
 
+    "@radix-ui/react-switch/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
     "@radix-ui/react-tabs/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
     "@radix-ui/react-toggle/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
@@ -4243,6 +4248,8 @@
     "@radix-ui/react-roving-focus/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-scroll-area/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-switch/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-tabs/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@coder/mux-mobile",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/src/browser/components/ui/switch.tsx
+++ b/src/browser/components/ui/switch.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import * as SwitchPrimitives from "@radix-ui/react-switch";
+
+import { cn } from "@/common/lib/utils";
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-accent data-[state=unchecked]:bg-zinc-600",
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export { Switch };

--- a/src/common/orpc/schemas.ts
+++ b/src/common/orpc/schemas.ts
@@ -40,9 +40,10 @@ export { MuxProviderOptionsSchema } from "./schemas/providerOptions";
 
 // MCP schemas
 export {
-  MCPServerMapSchema,
   MCPAddParamsSchema,
   MCPRemoveParamsSchema,
+  MCPServerMapSchema,
+  MCPSetEnabledParamsSchema,
   MCPTestParamsSchema,
   MCPTestResultSchema,
 } from "./schemas/mcp";

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -19,6 +19,7 @@ import {
   MCPAddParamsSchema,
   MCPRemoveParamsSchema,
   MCPServerMapSchema,
+  MCPSetEnabledParamsSchema,
   MCPTestParamsSchema,
   MCPTestResultSchema,
 } from "./mcp";
@@ -152,6 +153,10 @@ export const projects = {
     test: {
       input: MCPTestParamsSchema,
       output: MCPTestResultSchema,
+    },
+    setEnabled: {
+      input: MCPSetEnabledParamsSchema,
+      output: ResultSchema(z.void(), z.string()),
     },
   },
   secrets: {

--- a/src/common/orpc/schemas/mcp.ts
+++ b/src/common/orpc/schemas/mcp.ts
@@ -1,7 +1,5 @@
 import { z } from "zod";
 
-export const MCPServerMapSchema = z.record(z.string(), z.string());
-
 export const MCPAddParamsSchema = z.object({
   projectPath: z.string(),
   name: z.string(),
@@ -12,6 +10,17 @@ export const MCPRemoveParamsSchema = z.object({
   projectPath: z.string(),
   name: z.string(),
 });
+
+export const MCPSetEnabledParamsSchema = z.object({
+  projectPath: z.string(),
+  name: z.string(),
+  enabled: z.boolean(),
+});
+
+export const MCPServerMapSchema = z.record(
+  z.string(),
+  z.object({ command: z.string(), disabled: z.boolean() })
+);
 
 /**
  * Unified test params - provide either name (to test configured server) or command (to test arbitrary command).

--- a/src/common/types/mcp.ts
+++ b/src/common/types/mcp.ts
@@ -1,7 +1,14 @@
-export interface MCPConfig {
-  servers: Record<string, string>;
+/** Normalized server info (always has disabled field) */
+export interface MCPServerInfo {
+  command: string;
+  disabled: boolean;
 }
 
+export interface MCPConfig {
+  servers: Record<string, MCPServerInfo>;
+}
+
+/** Internal map of server name → command string (used after filtering disabled) */
 export type MCPServerMap = Record<string, string>;
 
 /** Result of testing an MCP server connection */

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -235,6 +235,12 @@ export const router = (authToken?: string) => {
           .handler(({ context, input }) =>
             context.mcpServerManager.test(input.projectPath, input.name, input.command)
           ),
+        setEnabled: t
+          .input(schemas.projects.mcp.setEnabled.input)
+          .output(schemas.projects.mcp.setEnabled.output)
+          .handler(({ context, input }) =>
+            context.mcpConfigService.setServerEnabled(input.projectPath, input.name, input.enabled)
+          ),
       },
     },
     nameGeneration: {

--- a/src/node/services/mcpConfigService.test.ts
+++ b/src/node/services/mcpConfigService.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as os from "os";
+import { MCPConfigService } from "./mcpConfigService";
+import { MCPServerManager } from "./mcpServerManager";
+
+describe("MCP server disable filtering", () => {
+  let tempDir: string;
+  let configService: MCPConfigService;
+  let serverManager: MCPServerManager;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-test-"));
+    configService = new MCPConfigService();
+    serverManager = new MCPServerManager(configService);
+  });
+
+  afterEach(async () => {
+    serverManager.dispose();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("disabled servers are filtered from manager.listServers", async () => {
+    // Add two servers
+    await configService.addServer(tempDir, "enabled-server", "cmd1");
+    await configService.addServer(tempDir, "disabled-server", "cmd2");
+
+    // Disable one
+    await configService.setServerEnabled(tempDir, "disabled-server", false);
+
+    // Config service returns both (with disabled flag)
+    const allServers = await configService.listServers(tempDir);
+    expect(allServers).toEqual({
+      "enabled-server": { command: "cmd1", disabled: false },
+      "disabled-server": { command: "cmd2", disabled: true },
+    });
+
+    // Server manager filters to enabled only
+    const enabledServers = await serverManager.listServers(tempDir);
+    expect(enabledServers).toEqual({ "enabled-server": "cmd1" });
+  });
+});

--- a/vscode/bun.lock
+++ b/vscode/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "mux",


### PR DESCRIPTION
Adds a toggle to disable MCP servers without removing them from config. Disabled servers retain their configuration but don't inject tools into conversations.

**Why:** Tool definitions consume context tokens. When you don't need a server's tools for a particular task, disabling it avoids unnecessarily blowing up the context. This mirrors similar functionality in Claude Code.

**Changes:**
- Switch toggle in project settings (left side of each server row)
- Config format: string when enabled, `{ command, disabled: true }` when disabled
- Backwards compatible with existing configs
- Optimistic UI updates

**CI fix:** Also fixes a caching bug in `setup-mux` action where restore-key matches (partial cache hits) would skip `bun install`, causing builds to fail when new dependencies were added. Now runs install on any non-exact cache hit while preserving the Windows optimization that skips bun cache decompression when `node_modules` already exists.

---
_Generated with `mux`_