### PR TITLE
🤖 fix: shorten Bedrock display name and fix overflow

### DIFF
--- a/src/browser/components/Settings/sections/ModelRow.tsx
+++ b/src/browser/components/Settings/sections/ModelRow.tsx
@@ -38,7 +38,7 @@ export function ModelRow(props: ModelRowProps) {
         <ProviderWithIcon
           provider={props.provider}
           displayName
-          className="text-muted w-16 shrink-0 text-xs md:w-20"
+          className="text-muted w-16 shrink-0 overflow-hidden text-xs md:w-20"
         />
         {props.isEditing ? (
           <div className="flex min-w-0 flex-1 items-center gap-1">

--- a/src/common/constants/providers.ts
+++ b/src/common/constants/providers.ts
@@ -69,7 +69,7 @@ export const PROVIDER_DEFINITIONS = {
     requiresApiKey: true,
   },
   bedrock: {
-    displayName: "Amazon Bedrock",
+    displayName: "Bedrock",
     import: () => import("@ai-sdk/amazon-bedrock"),
     factoryName: "createAmazonBedrock",
     requiresApiKey: false, // Uses AWS credential chain


### PR DESCRIPTION
_Generated with `mux`_

- Change display name from "Amazon Bedrock" to "Bedrock" (AWS icon already present)
- Add `overflow-hidden` to provider column in ModelRow to prevent long names from bleeding into model name area