### PR TITLE
🤖 feat: add polling detection to bash_output tool

### DIFF
--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -244,8 +244,7 @@ export const TOOL_DEFINITIONS = {
       "Returns stdout and stderr output along with process status. " +
       "Supports optional regex filtering to show only lines matching a pattern. " +
       "WARNING: When using filter, non-matching lines are permanently discarded. " +
-      "Use timeout to wait for output instead of polling repeatedly. " +
-      "If you've called this 3+ times on the same process, use filter_exclude with a longer timeout instead.",
+      "Use timeout to wait for output instead of polling repeatedly.",
     schema: z.object({
       process_id: z.string().describe("The ID of the background process to retrieve output from"),
       filter: z


### PR DESCRIPTION
When agents call `bash_output` 3+ times on a running process without using `filter_exclude`, return a note instructing them to use `filter_exclude` with a longer timeout instead of polling repeatedly.

## Changes

- Track `getOutputCallCount` per background process
- Return a `note` field with guidance when polling detected (3+ calls, no filter_exclude, process still running)
- Simplified tool description (runtime now handles the guidance dynamically)

## Example note returned

```
STOP POLLING. You've called bash_output 3+ times on this process. This wastes tokens and clutters the conversation. Instead, make ONE call with: filter='⏳|progress|waiting|\.\.\.', filter_exclude=true, timeout_secs=120. This blocks until meaningful output arrives.
```

## Tests

Added 3 tests covering:
1. Note appears after 3+ calls without filter_exclude on running process
2. Note does NOT appear when filter_exclude is used  
3. Note does NOT appear when process has exited

_Generated with `mux`_