### PR TITLE
🤖 fix: add Ctrl+I focus keybind to new chat page

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -446,6 +446,12 @@ function AppInner() {
       } else if (matchesKeybind(e, KEYBINDS.OPEN_SETTINGS)) {
         e.preventDefault();
         openSettings();
+      } else if (matchesKeybind(e, KEYBINDS.FOCUS_CHAT)) {
+        // Focus creation chat when on new chat page (no workspace selected)
+        if (creationProjectPath && creationChatInputRef.current) {
+          e.preventDefault();
+          creationChatInputRef.current.focus();
+        }
       }
     };
 
@@ -457,6 +463,7 @@ function AppInner() {
     isCommandPaletteOpen,
     closeCommandPalette,
     openCommandPalette,
+    creationProjectPath,
     openSettings,
   ]);
 


### PR DESCRIPTION
The new chat page (workspace creation flow) displays "⌘I to focus" but the keybind wasn't actually registered there.

**Problem:** The `FOCUS_CHAT` keybind handler was only in `useAIViewKeybinds` (used by `AIView.tsx` for existing workspaces), but not in `App.tsx` where the creation variant of ChatInput is rendered.

**Fix:** Added the `FOCUS_CHAT` keybind to App.tsx's global keydown handler, which focuses the creation chat input when on the new chat page.

_Generated with `mux`_