### PR TITLE
🤖 fix: show tier-specific count when age section is expanded

### DIFF
--- a/src/browser/components/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar.tsx
@@ -627,7 +627,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                               // Empty tiers are skipped automatically
                               const renderTier = (tierIndex: number): React.ReactNode => {
                                 const bucket = buckets[tierIndex];
-                                // Sum remaining workspaces from this tier onward
+                                // Sum remaining workspaces from this tier onward (for collapsed state)
                                 const remainingCount = buckets
                                   .slice(tierIndex)
                                   .reduce((sum, b) => sum + b.length, 0);
@@ -638,6 +638,8 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                                 const isExpanded = expandedOldWorkspaces[key] ?? false;
                                 const thresholdDays = AGE_THRESHOLDS_DAYS[tierIndex];
                                 const thresholdLabel = formatDaysThreshold(thresholdDays);
+                                // When expanded, show only this tier's count; when collapsed, show cumulative
+                                const displayCount = isExpanded ? bucket.length : remainingCount;
 
                                 return (
                                   <>
@@ -654,7 +656,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                                       <div className="flex items-center gap-1.5">
                                         <span>Older than {thresholdLabel}</span>
                                         <span className="text-dim font-normal">
-                                          ({remainingCount})
+                                          ({displayCount})
                                         </span>
                                       </div>
                                       <span


### PR DESCRIPTION
When an 'Older than X days' section is expanded, the count now shows only workspaces in that specific tier rather than the cumulative count of all nested tiers.

**Before (confusing):**
```
▶ Older than 1 day (5)    ← 5 total hidden, good

▼ Older than 1 day (5)    ← still says 5, but only 2 visible here
    workspace-a
    workspace-b
  ▶ Older than 7 days (3) ← the other 3 are hidden here
```

**After (clear):**
```
▶ Older than 1 day (5)    ← 5 total hidden, good (unchanged)

▼ Older than 1 day (2)    ← now matches the 2 visible items
    workspace-a
    workspace-b
  ▶ Older than 7 days (3)
```

_Generated with `mux`_