### PR TITLE
🤖 feat: include model + thinking in bash tool env

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -9,7 +9,15 @@ description: Agent instructions for AI assistants working on the mux codebase
 
 - `mux`: Electron + React desktop app for parallel agent workflows; UX must be fast, responsive, predictable.
 - Minor breaking changes are expected, but critical flows must allow upgrade↔downgrade without friction; skip migrations when breakage is tightly scoped.
-- Public work (issues/PRs/commits) must use 🤖 in the title and include "_Generated with `mux`_" in the body when applicable.
+- Public work (issues/PRs/commits) must use 🤖 in the title and include this footer in the body:
+
+  ```md
+  ---
+  _Generated with `mux` • Model: `<modelString>` • Thinking: `<thinkingLevel>`_
+  <!-- mux-attribution: model=<modelString> thinking=<thinkingLevel> -->
+  ```
+
+  Prefer sourcing values from `$MUX_MODEL_STRING` and `$MUX_THINKING_LEVEL` (bash tool env).
 
 ## PR + Release Workflow
 

--- a/src/node/runtime/initHook.ts
+++ b/src/node/runtime/initHook.ts
@@ -3,6 +3,7 @@ import * as fsPromises from "fs/promises";
 import * as path from "path";
 import type { InitLogger } from "./Runtime";
 import type { RuntimeConfig } from "@/common/types/runtime";
+import type { ThinkingLevel } from "@/common/types/thinking";
 import { isWorktreeRuntime, isSSHRuntime } from "@/common/types/runtime";
 
 /**
@@ -38,13 +39,34 @@ export function getInitHookPath(projectPath: string): string {
 export function getMuxEnv(
   projectPath: string,
   runtime: "local" | "worktree" | "ssh",
-  workspaceName: string
+  workspaceName: string,
+  options?: {
+    modelString?: string;
+    thinkingLevel?: ThinkingLevel;
+  }
 ): Record<string, string> {
-  return {
+  if (!projectPath) {
+    throw new Error("getMuxEnv: projectPath is required");
+  }
+  if (!workspaceName) {
+    throw new Error("getMuxEnv: workspaceName is required");
+  }
+
+  const env: Record<string, string> = {
     MUX_PROJECT_PATH: projectPath,
     MUX_RUNTIME: runtime,
     MUX_WORKSPACE_NAME: workspaceName,
   };
+
+  if (options?.modelString) {
+    env.MUX_MODEL_STRING = options.modelString;
+  }
+
+  if (options?.thinkingLevel !== undefined) {
+    env.MUX_THINKING_LEVEL = options.thinkingLevel;
+  }
+
+  return env;
 }
 
 /**

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1150,7 +1150,11 @@ export class AIService extends EventEmitter {
           muxEnv: getMuxEnv(
             metadata.projectPath,
             getRuntimeType(metadata.runtimeConfig),
-            metadata.name
+            metadata.name,
+            {
+              modelString,
+              thinkingLevel: thinkingLevel ?? "off",
+            }
           ),
           runtimeTempDir,
           backgroundProcessManager: this.backgroundProcessManager,


### PR DESCRIPTION
Expose model + thinking level for PR attribution via bash env vars.

- `getMuxEnv(...)` now supports optional `{ modelString, thinkingLevel }`
- `AIService` threads the current model + effective thinking level into tool env as:
  - `MUX_MODEL_STRING`
  - `MUX_THINKING_LEVEL`
- `docs/AGENTS.md` updated to require the new attribution footer format.

Validation:
- `bun test src/node/runtime/initHook.test.ts`
- `make static-check`

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Extend GitHub PR attribution with model + thinking level

## Problem
Today, PR bodies often end with a simple attribution footer like:

- `_Generated with \`mux\`_`

You want that attribution to also include:

1. The **model** used to generate the changes.
2. The **thinking level** used.

## Goals
- Provide a **standard, copy/pasteable attribution footer format** that includes model + thinking level.
- Make the **exact model + thinking level available to the agent at runtime** so the footer can be accurate (no guessing).
- Keep changes minimal; avoid introducing a full GitHub integration feature unless required.

## Non-goals (for this iteration)
- Automatically creating PRs from inside mux via a dedicated “Create PR” tool/UI.
- Retroactively editing existing PRs server-side via GitHub Actions.

## Recommended output format
Make the footer a single line (easy to scan) plus optional machine-readable comment (easy to parse later):

```md
---
_Generated with `mux` • Model: `<modelString>` • Thinking: `<thinkingLevel>`_
<!-- mux-attribution: model=<modelString> thinking=<thinkingLevel> -->
```

Notes:
- Use the **full mux `modelString`** (e.g. `openai:gpt-5.2-pro`) to avoid ambiguity.
- `thinkingLevel` should be mux’s unified values: `off|low|medium|high|xhigh`.
- No PR URL/number is included in the PR body attribution (it’s already on the PR).

## Approach options

### Approach A (recommended): Expose model/thinking context + update instructions (low risk)
**Net LoC estimate (product code only): ~40–90 LoC**

Implement:
- Surface `modelString` + `thinkingLevel` in the **bash tool environment** as `MUX_MODEL_STRING` and `MUX_THINKING_LEVEL` so `gh pr ...` workflows can reference them.
- Update repo `AGENTS.md` guidance to require the richer attribution footer.
- **Do not** inject `thinkingLevel` into the system prompt (to avoid prompt-cache misses when switching e.g. `high` → `medium`).

Why this is enough:
- mux doesn’t currently own PR creation; agents typically run `gh` via the bash tool.
- Env vars are available exactly where PR bodies are usually authored (shell workflows) without changing the LLM prompt/caching behavior.

### Approach B: Add a helper CLI/script for “create PR with mux attribution”
**Net LoC estimate (product code only): ~0 LoC** (mostly script/docs), or **~200–400 LoC** if built into mux CLI/tools.

Implement a script (e.g. `scripts/gh_pr_create_with_mux_attribution.ts`) that:
1. Creates the PR via `gh pr create ...`.
2. Ensures the PR body includes the attribution footer using `$MUX_MODEL_STRING` / `$MUX_THINKING_LEVEL`.

This makes “add the correct footer” a single command, but is more opinionated and adds surface area.

## Detailed implementation plan (Approach A)

### 1) Preserve prompt caching behavior
- **Do not** add per-request dynamic metadata (especially `thinkingLevel`) into the system prompt.
  - Prompt caching (e.g. Anthropic prompt caching) keys off the input; changing the system prompt when switching `high` → `medium` would reduce cache hits.
- Therefore, this change intentionally avoids modifying `buildSystemMessage(...)`.

### 2) Add env vars for bash-based PR flows
- Extend `getMuxEnv(...)` to optionally accept `{ modelString, thinkingLevel }`.
- Populate:
  - `MUX_MODEL_STRING=<modelString>`
  - `MUX_THINKING_LEVEL=<thinkingLevel||off>`

Files:
- `src/node/runtime/initHook.ts` (extend `getMuxEnv` signature + implementation)
- `src/node/services/aiService.ts` (pass model/thinking into `getMuxEnv` for tool calls)

Notes:
- Keep existing callers intact by making the new argument optional.
- It’s OK that init hooks (which aren’t tied to a model invocation) won’t always set these vars.

### 3) Update AGENTS.md guidance to require the richer footer
- Replace the existing instruction about `_Generated with \`mux\`_` with the new required template.
- Add a short note:
  - model/thinking values should be sourced from `$MUX_MODEL_STRING` and `$MUX_THINKING_LEVEL` in bash (preferred; doesn’t affect prompt caching).

Files:
- `AGENTS.md`
- `docs/AGENTS.md` (keep in sync if both are published)

### 4) Tests
Add/update unit tests so this doesn’t regress:
- Add/extend a `getMuxEnv` unit test (either new or in an existing runtime test file)
  - `getMuxEnv` includes the new env vars when options are provided.
  - Existing env vars remain unchanged.

## Validation steps (manual)
- In a bash tool call (or any `gh` workflow), run:
  - `echo "$MUX_MODEL_STRING"`
  - `echo "$MUX_THINKING_LEVEL"`
- Create/update a PR body footer and confirm it renders as expected.
- Switch thinking level (e.g. `high` → `medium`) and confirm prompt caching behavior is unchanged (since the system prompt isn’t modified by this feature).

## Decisions (confirmed)
- Footer includes **only** model + thinking level (no PR URL/number).
- Footer label uses `Thinking:` (aligns with mux naming) and records the mux `thinkingLevel` value (`off|low|medium|high|xhigh`).
- Include the hidden HTML comment for machine parsing.
- Use the **current** modelString/thinkingLevel at PR creation/update time (no aggregation across sessions).

</details>

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `high`_
<!-- mux-attribution: model=openai:gpt-5.2 thinking=high -->
