### PR TITLE
🤖 perf: reduce ChatInput rerenders during streaming

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -116,7 +116,7 @@ import type { ImagePart } from "@/common/orpc/types";
 
 export type { ChatInputProps, ChatInputAPI };
 
-export const ChatInput: React.FC<ChatInputProps> = (props) => {
+const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const { api } = useAPI();
   const { variant } = props;
 
@@ -1631,6 +1631,9 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
     </Wrapper>
   );
 };
+
+export const ChatInput = React.memo(ChatInputInner);
+ChatInput.displayName = "ChatInput";
 
 const TokenCountDisplay: React.FC<{ reader: TokenCountReader }> = ({ reader }) => {
   const tokens = reader();


### PR DESCRIPTION
_Generated with `mux`_

## What
Reduce `ChatInput` re-renders during streaming by:
- adding an explicit `React.memo` boundary for `ChatInput`
- stabilizing `AIView → ChatInput` props (memoized auto-compaction result, stable review callbacks)
- removing handler churn tied to streaming updates by reading latest workspace state via a ref

## How to verify
- Start a long streaming response and profile renders: `ChatInput` should no longer commit on each delta.