### PR TITLE
🤖 fix: show old/new line numbers in diffs

### DIFF
--- a/src/browser/components/ReviewsBanner.tsx
+++ b/src/browser/components/ReviewsBanner.tsx
@@ -137,17 +137,20 @@ const ReviewItem: React.FC<ReviewItemProps> = ({
     [handleSaveEdit, handleCancelEdit]
   );
 
-  // Format code for diff display - add diff markers if not present
+  // Prefer selectedDiff (raw diff) when available so reviewers see syntax highlighting consistently.
   const diffContent = useMemo(() => {
+    if (review.data.selectedDiff) {
+      return review.data.selectedDiff;
+    }
+
+    // Legacy: selectedCode may be plain code or diff-ish text.
     const lines = review.data.selectedCode.split("\n");
-    // Check if lines already have diff markers
     const hasDiffMarkers = lines.some((l) => /^[+-\s]/.test(l));
     if (hasDiffMarkers) {
       return review.data.selectedCode;
     }
-    // Add context markers
     return lines.map((l) => ` ${l}`).join("\n");
-  }, [review.data.selectedCode]);
+  }, [review.data.selectedCode, review.data.selectedDiff]);
 
   const age = formatRelativeTime(review.createdAt);
 
@@ -245,7 +248,13 @@ const ReviewItem: React.FC<ReviewItemProps> = ({
         <div className="border-border-light border-t">
           {/* Code diff */}
           <div className="max-h-32 overflow-auto text-[11px]">
-            <DiffRenderer content={diffContent} showLineNumbers={false} fontSize="11px" />
+            <DiffRenderer
+              content={diffContent}
+              showLineNumbers={Boolean(review.data.selectedDiff)}
+              oldStart={review.data.oldStart ?? 1}
+              newStart={review.data.newStart ?? 1}
+              fontSize="11px"
+            />
           </div>
 
           {/* Comment section */}

--- a/src/browser/utils/highlighting/diffChunking.test.ts
+++ b/src/browser/utils/highlighting/diffChunking.test.ts
@@ -8,7 +8,8 @@ describe("groupDiffLines", () => {
     expect(chunks).toHaveLength(1);
     expect(chunks[0].type).toBe("add");
     expect(chunks[0].lines).toEqual(["line1", "line2", "line3"]);
-    expect(chunks[0].lineNumbers).toEqual([1, 2, 3]);
+    expect(chunks[0].oldLineNumbers).toEqual([null, null, null]);
+    expect(chunks[0].newLineNumbers).toEqual([1, 2, 3]);
   });
 
   it("should group consecutive removes into a chunk", () => {
@@ -18,7 +19,8 @@ describe("groupDiffLines", () => {
     expect(chunks).toHaveLength(1);
     expect(chunks[0].type).toBe("remove");
     expect(chunks[0].lines).toEqual(["line1", "line2"]);
-    expect(chunks[0].lineNumbers).toEqual([10, 11]);
+    expect(chunks[0].oldLineNumbers).toEqual([10, 11]);
+    expect(chunks[0].newLineNumbers).toEqual([null, null]);
   });
 
   it("should split chunks on type change", () => {
@@ -40,9 +42,11 @@ describe("groupDiffLines", () => {
 
     expect(chunks).toHaveLength(2);
     expect(chunks[0].type).toBe("add");
-    expect(chunks[0].lineNumbers).toEqual([1]); // First chunk starts at newStart=1
+    expect(chunks[0].oldLineNumbers).toEqual([null]);
+    expect(chunks[0].newLineNumbers).toEqual([1]); // First chunk starts at newStart=1
     expect(chunks[1].type).toBe("add");
-    expect(chunks[1].lineNumbers).toEqual([20]); // Second chunk resets to header's +20
+    expect(chunks[1].oldLineNumbers).toEqual([null]);
+    expect(chunks[1].newLineNumbers).toEqual([20]); // Second chunk resets to header's +20
   });
 
   it("should track line numbers correctly for mixed diff", () => {
@@ -52,16 +56,20 @@ describe("groupDiffLines", () => {
     expect(chunks).toHaveLength(4);
 
     // Context line increments both old and new
-    expect(chunks[0].lineNumbers).toEqual([5]);
+    expect(chunks[0].oldLineNumbers).toEqual([5]);
+    expect(chunks[0].newLineNumbers).toEqual([10]);
 
     // Add line increments only new
-    expect(chunks[1].lineNumbers).toEqual([11]);
+    expect(chunks[1].oldLineNumbers).toEqual([null]);
+    expect(chunks[1].newLineNumbers).toEqual([11]);
 
     // Context after add
-    expect(chunks[2].lineNumbers).toEqual([6]);
+    expect(chunks[2].oldLineNumbers).toEqual([6]);
+    expect(chunks[2].newLineNumbers).toEqual([12]);
 
     // Remove after context increments only old
-    expect(chunks[3].lineNumbers).toEqual([7]);
+    expect(chunks[3].oldLineNumbers).toEqual([7]);
+    expect(chunks[3].newLineNumbers).toEqual([null]);
   });
 
   it("should handle empty input", () => {

--- a/src/browser/utils/highlighting/diffChunking.ts
+++ b/src/browser/utils/highlighting/diffChunking.ts
@@ -4,7 +4,8 @@ export interface DiffChunk {
   type: Exclude<DiffLineType, "header">; // 'add' | 'remove' | 'context'
   lines: string[]; // Line content (without +/- prefix)
   startIndex: number; // Original line index in diff
-  lineNumbers: number[]; // Line numbers for display
+  oldLineNumbers: Array<number | null>;
+  newLineNumbers: Array<number | null>;
 }
 
 /**
@@ -40,21 +41,23 @@ export function groupDiffLines(lines: string[], oldStart: number, newStart: numb
       continue;
     }
 
-    // Determine line type and number
+    // Determine line type and line numbers.
     let type: Exclude<DiffLineType, "header">;
-    let lineNum: number;
+    let oldLineNumber: number | null;
+    let newLineNumber: number | null;
 
     if (firstChar === "+") {
       type = "add";
-      lineNum = newLineNum++;
+      oldLineNumber = null;
+      newLineNumber = newLineNum++;
     } else if (firstChar === "-") {
       type = "remove";
-      lineNum = oldLineNum++;
+      oldLineNumber = oldLineNum++;
+      newLineNumber = null;
     } else {
       type = "context";
-      lineNum = oldLineNum;
-      oldLineNum++;
-      newLineNum++;
+      oldLineNumber = oldLineNum++;
+      newLineNumber = newLineNum++;
     }
 
     // Start new chunk if type changed or no current chunk
@@ -69,13 +72,15 @@ export function groupDiffLines(lines: string[], oldStart: number, newStart: numb
         type,
         lines: [],
         startIndex: i,
-        lineNumbers: [],
+        oldLineNumbers: [],
+        newLineNumbers: [],
       };
     }
 
     // Add line to current chunk (without +/- prefix)
     currentChunk.lines.push(line.slice(1));
-    currentChunk.lineNumbers.push(lineNum);
+    currentChunk.oldLineNumbers.push(oldLineNumber);
+    currentChunk.newLineNumbers.push(newLineNumber);
   }
 
   // Flush final chunk

--- a/src/browser/utils/highlighting/highlightDiffChunk.test.ts
+++ b/src/browser/utils/highlighting/highlightDiffChunk.test.ts
@@ -12,7 +12,8 @@ describe("highlightDiffChunk", () => {
     type: "add",
     lines: ["const x = 1;", "const y = 2;"],
     startIndex: 0,
-    lineNumbers: [1, 2],
+    oldLineNumbers: [null, null],
+    newLineNumbers: [1, 2],
   };
 
   describe("plain text files", () => {
@@ -23,7 +24,8 @@ describe("highlightDiffChunk", () => {
       expect(result.usedFallback).toBe(false);
       expect(result.lines).toHaveLength(2);
       expect(result.lines[0].html).toBe("const x = 1;");
-      expect(result.lines[0].lineNumber).toBe(1);
+      expect(result.lines[0].oldLineNumber).toBeNull();
+      expect(result.lines[0].newLineNumber).toBe(1);
     });
 
     it("should escape HTML in plain text fallback", async () => {
@@ -31,7 +33,8 @@ describe("highlightDiffChunk", () => {
         type: "add",
         lines: ['<script>alert("xss")</script>'],
         startIndex: 0,
-        lineNumbers: [1],
+        oldLineNumbers: [null],
+        newLineNumbers: [1],
       };
 
       const result = await highlightDiffChunk(htmlChunk, "text");
@@ -42,9 +45,11 @@ describe("highlightDiffChunk", () => {
     it("should preserve line numbers and original indices for text files", async () => {
       const result = await highlightDiffChunk(mockChunk, "text");
 
-      expect(result.lines[0].lineNumber).toBe(1);
+      expect(result.lines[0].oldLineNumber).toBeNull();
+      expect(result.lines[0].newLineNumber).toBe(1);
       expect(result.lines[0].originalIndex).toBe(0);
-      expect(result.lines[1].lineNumber).toBe(2);
+      expect(result.lines[1].oldLineNumber).toBeNull();
+      expect(result.lines[1].newLineNumber).toBe(2);
       expect(result.lines[1].originalIndex).toBe(1);
     });
 
@@ -53,13 +58,15 @@ describe("highlightDiffChunk", () => {
         type: "context",
         lines: [""],
         startIndex: 0,
-        lineNumbers: [1],
+        oldLineNumbers: [1],
+        newLineNumbers: [1],
       };
 
       const result = await highlightDiffChunk(emptyChunk, "text");
 
       expect(result.lines).toHaveLength(1);
-      expect(result.lines[0].lineNumber).toBe(1);
+      expect(result.lines[0].oldLineNumber).toBe(1);
+      expect(result.lines[0].newLineNumber).toBe(1);
     });
 
     it("should handle multiple line types", async () => {
@@ -67,7 +74,8 @@ describe("highlightDiffChunk", () => {
         type: "remove",
         lines: ["old code"],
         startIndex: 5,
-        lineNumbers: [10],
+        oldLineNumbers: [10],
+        newLineNumbers: [null],
       };
 
       const result = await highlightDiffChunk(removeChunk, "text");
@@ -81,7 +89,8 @@ describe("highlightDiffChunk", () => {
         type: "add",
         lines: ["    const x = 1;", "        const y = 2;", "  const z = 3;"],
         startIndex: 0,
-        lineNumbers: [1, 2, 3],
+        oldLineNumbers: [null, null, null],
+        newLineNumbers: [1, 2, 3],
       };
 
       const result = await highlightDiffChunk(indentedChunk, "text");
@@ -98,7 +107,8 @@ describe("highlightDiffChunk", () => {
         type: "add",
         lines: ["const x  =  1;", "if (x    &&    y)"],
         startIndex: 0,
-        lineNumbers: [1, 2],
+        oldLineNumbers: [null, null],
+        newLineNumbers: [1, 2],
       };
 
       const result = await highlightDiffChunk(spacedChunk, "text");
@@ -120,7 +130,8 @@ describe("highlightDiffChunk", () => {
         type: "add",
         lines: ["    const x = 1;", "        const y = 2;", "  const z = 3;"],
         startIndex: 0,
-        lineNumbers: [1, 2, 3],
+        oldLineNumbers: [null, null, null],
+        newLineNumbers: [1, 2, 3],
       };
 
       const result = await highlightDiffChunk(chunk, "typescript");
@@ -144,7 +155,8 @@ describe("highlightDiffChunk", () => {
         type: "add",
         lines: ["const x = 1;", "const y = 2;"],
         startIndex: 0,
-        lineNumbers: [1, 2],
+        oldLineNumbers: [null, null],
+        newLineNumbers: [1, 2],
       };
 
       const result = await highlightDiffChunk(chunk, "typescript");
@@ -164,7 +176,8 @@ describe("highlightDiffChunk", () => {
         type: "add",
         lines: ['const str = "unclosed'],
         startIndex: 0,
-        lineNumbers: [1],
+        oldLineNumbers: [null],
+        newLineNumbers: [1],
       };
 
       const result = await highlightDiffChunk(chunk, "typescript");
@@ -180,7 +193,8 @@ describe("highlightDiffChunk", () => {
         type: "context",
         lines: ["", "const y = 2;", ""],
         startIndex: 0,
-        lineNumbers: [1, 2, 3],
+        oldLineNumbers: [1, 2, 3],
+        newLineNumbers: [1, 2, 3],
       };
 
       const result = await highlightDiffChunk(chunk, "typescript");
@@ -199,7 +213,8 @@ describe("highlightDiffChunk", () => {
         type: "add",
         lines: ["if (x && y) { return true; }"],
         startIndex: 0,
-        lineNumbers: [1],
+        oldLineNumbers: [null],
+        newLineNumbers: [1],
       };
 
       const result = await highlightDiffChunk(chunk, "typescript");
@@ -215,7 +230,8 @@ describe("highlightDiffChunk", () => {
         type: "add",
         lines: ["const obj = { nested: { value: 1 } };"],
         startIndex: 0,
-        lineNumbers: [1],
+        oldLineNumbers: [null],
+        newLineNumbers: [1],
       };
 
       const result = await highlightDiffChunk(chunk, "typescript");
@@ -234,14 +250,18 @@ describe("highlightDiffChunk", () => {
         type: "remove",
         lines: ["const a = 1;", "const b = 2;", "const c = 3;"],
         startIndex: 10,
-        lineNumbers: [15, 16, 17],
+        oldLineNumbers: [15, 16, 17],
+        newLineNumbers: [null, null, null],
       };
 
       const result = await highlightDiffChunk(chunk, "typescript");
 
-      expect(result.lines[0].lineNumber).toBe(15);
-      expect(result.lines[1].lineNumber).toBe(16);
-      expect(result.lines[2].lineNumber).toBe(17);
+      expect(result.lines[0].oldLineNumber).toBe(15);
+      expect(result.lines[1].oldLineNumber).toBe(16);
+      expect(result.lines[2].oldLineNumber).toBe(17);
+      expect(result.lines[0].newLineNumber).toBeNull();
+      expect(result.lines[1].newLineNumber).toBeNull();
+      expect(result.lines[2].newLineNumber).toBeNull();
       expect(result.lines[0].originalIndex).toBe(10);
       expect(result.lines[1].originalIndex).toBe(11);
       expect(result.lines[2].originalIndex).toBe(12);
@@ -252,7 +272,8 @@ describe("highlightDiffChunk", () => {
         type: "add",
         lines: ["function test() {", "  return 42;", "}"],
         startIndex: 0,
-        lineNumbers: [1, 2, 3],
+        oldLineNumbers: [null, null, null],
+        newLineNumbers: [1, 2, 3],
       };
 
       const result = await highlightDiffChunk(chunk, "typescript");
@@ -273,7 +294,8 @@ describe("highlightDiffChunk", () => {
           type: "add",
           lines: ["def hello():", '    print("world")'],
           startIndex: 0,
-          lineNumbers: [1, 2],
+          oldLineNumbers: [null, null],
+          newLineNumbers: [1, 2],
         };
 
         // Python might not be loaded yet
@@ -290,7 +312,8 @@ describe("highlightDiffChunk", () => {
           type: "add",
           lines: ["some code in unknown language"],
           startIndex: 0,
-          lineNumbers: [1],
+          oldLineNumbers: [null],
+          newLineNumbers: [1],
         };
 
         const result = await highlightDiffChunk(chunk, "totally-fake-language");
@@ -306,14 +329,16 @@ describe("highlightDiffChunk", () => {
           type: "add",
           lines: ["const x = 1;"],
           startIndex: 0,
-          lineNumbers: [1],
+          oldLineNumbers: [null],
+          newLineNumbers: [1],
         };
 
         const chunk2: DiffChunk = {
           type: "add",
           lines: ["const y = 2;"],
           startIndex: 0,
-          lineNumbers: [1],
+          oldLineNumbers: [null],
+          newLineNumbers: [1],
         };
 
         // Highlight both concurrently - should handle race safely

--- a/src/browser/utils/highlighting/highlightDiffChunk.ts
+++ b/src/browser/utils/highlighting/highlightDiffChunk.ts
@@ -22,7 +22,8 @@ const MAX_DIFF_SIZE_BYTES = 32768; // 32kb
 
 export interface HighlightedLine {
   html: string; // HTML content (already escaped and tokenized)
-  lineNumber: number;
+  oldLineNumber: number | null;
+  newLineNumber: number | null;
   originalIndex: number; // Index in original diff
 }
 
@@ -54,7 +55,8 @@ export async function highlightDiffChunk(
       type: chunk.type,
       lines: chunk.lines.map((line, i) => ({
         html: escapeHtml(line),
-        lineNumber: chunk.lineNumbers[i],
+        oldLineNumber: chunk.oldLineNumbers[i],
+        newLineNumber: chunk.newLineNumbers[i],
         originalIndex: chunk.startIndex + i,
       })),
       usedFallback: false,
@@ -98,7 +100,8 @@ export async function highlightDiffChunk(
       type: chunk.type,
       lines: lines.map((html, i) => ({
         html,
-        lineNumber: chunk.lineNumbers[i],
+        oldLineNumber: chunk.oldLineNumbers[i],
+        newLineNumber: chunk.newLineNumbers[i],
         originalIndex: chunk.startIndex + i,
       })),
       usedFallback: false,
@@ -117,7 +120,8 @@ function createFallbackChunk(chunk: DiffChunk): HighlightedChunk {
     type: chunk.type,
     lines: chunk.lines.map((line, i) => ({
       html: escapeHtml(line),
-      lineNumber: chunk.lineNumbers[i],
+      oldLineNumber: chunk.oldLineNumbers[i],
+      newLineNumber: chunk.newLineNumbers[i],
       originalIndex: chunk.startIndex + i,
     })),
     usedFallback: true,

--- a/src/common/types/review.ts
+++ b/src/common/types/review.ts
@@ -112,8 +112,24 @@ export interface ReviewNoteData {
   filePath: string;
   /** Line range (e.g., "42" or "42-45") */
   lineRange: string;
-  /** Selected code lines with line numbers and +/-/space indicators */
+
+  /**
+   * Human-readable selected code included in the message payload.
+   * Historically this included embedded line numbers; keep for backwards compatibility.
+   */
   selectedCode: string;
+
+  /**
+   * Raw diff snippet for UI rendering (lines start with + / - / space).
+   * When present, the UI should prefer this for consistent syntax highlighting.
+   */
+  selectedDiff?: string;
+
+  /** Starting old line number for rendering selectedDiff (if present). */
+  oldStart?: number;
+  /** Starting new line number for rendering selectedDiff (if present). */
+  newStart?: number;
+
   /** User's review comment */
   userNote: string;
 }


### PR DESCRIPTION
Aligns diff viewer with GitHub's visual/interaction model:

- **Dual line-number columns** (old/new) to clarify pre- vs post-change lines
- **Review note formatting** includes both ranges (e.g. `-12-14 +15-17`)
- **Restored +/− indicators** with hover-to-replace review button (MessageSquare)
- **Deduplicated rendering** via shared `DiffLineGutter` and `DiffIndicator` components
- **Polished review input** styled to sit within the diff seamlessly, background matches surrounding line type (add/remove/context)

_Generated with `mux`_