### PR TITLE
🤖 fix: align secondary text in RightSidebar tab titles

### DIFF
--- a/src/browser/components/RightSidebar.tsx
+++ b/src/browser/components/RightSidebar.tsx
@@ -271,7 +271,7 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
               <TooltipTrigger asChild>
                 <button
                   className={cn(
-                    "rounded-md px-3 py-1 text-xs font-medium transition-all duration-150 flex items-center gap-1.5",
+                    "rounded-md px-3 py-1 text-xs font-medium transition-all duration-150 flex items-baseline gap-1.5",
                     selectedTab === "costs"
                       ? "bg-hover text-foreground"
                       : "bg-transparent text-muted hover:bg-hover/50 hover:text-foreground"
@@ -299,7 +299,7 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
               <TooltipTrigger asChild>
                 <button
                   className={cn(
-                    "rounded-md px-3 py-1 text-xs font-medium transition-all duration-150 flex items-center gap-1.5",
+                    "rounded-md px-3 py-1 text-xs font-medium transition-all duration-150 flex items-baseline gap-1.5",
                     selectedTab === "review"
                       ? "bg-hover text-foreground"
                       : "bg-transparent text-muted hover:bg-hover/50 hover:text-foreground"


### PR DESCRIPTION
Change tab button flex alignment from `items-center` to `items-baseline` so that secondary text (cost like `$0.56` and review count like `2/5`) aligns horizontally with the tab name despite different font sizes (`text-xs` vs `text-[10px]`).

_Generated with `mux`_