### PR TITLE
🤖 feat: add AI app attribution headers

### DIFF
--- a/src/constants/appAttribution.ts
+++ b/src/constants/appAttribution.ts
@@ -1,0 +1,7 @@
+// App attribution values for AI provider requests.
+//
+// These are used by OpenRouter (and other compatible platforms) to attribute
+// requests to mux (e.g., for leaderboards).
+
+export const MUX_APP_ATTRIBUTION_TITLE = "mux";
+export const MUX_APP_ATTRIBUTION_URL = "https://mux.coder.com";


### PR DESCRIPTION
Adds default app attribution headers (`HTTP-Referer`, `X-Title`) to all AI SDK provider requests, enabling OpenRouter (and compatible gateways) to attribute mux usage.

- Implemented `buildAppAttributionHeaders` (case-insensitive merge, never overwrites user-provided values)
- Applied during model creation so all `streamText()` calls inherit it
- Added unit tests

---

<details>
<summary>📋 Implementation Plan</summary>

# 🤖 Plan: Add app attribution headers to AI SDK streaming (OpenRouter leaderboard)

## Goal
Ensure mux’s `streamText()` calls include **app attribution** so OpenRouter (and any other compatible gateway) can attribute traffic to mux (e.g., for leaderboards).

For OpenRouter specifically, this means sending these request headers:
- `HTTP-Referer`: a stable URL for the app (recommended by OpenRouter)
- `X-Title`: a human-readable app name

## Recommended approach (A): Inject attribution headers for **all providers** in `AIService.createModel()` (default-on)
**Net new product LoC:** ~30–55

### Why this approach
- Covers **every** provider (OpenRouter + others) without needing to touch `streamText()` call sites.
- Future-proof: any future non-streaming usage will automatically carry the same attribution.
- Allows user overrides via `providers.jsonc` `headers` (we never overwrite existing `HTTP-Referer` / `X-Title`, case-insensitive).

### Implementation steps
1. **Add centralized constants** for mux attribution values
   - Add `src/constants/appAttribution.ts` exporting:
     - `MUX_APP_ATTRIBUTION_TITLE` = `"mux"`
     - `MUX_APP_ATTRIBUTION_URL` = `"https://mux.coder.com"`

2. **Add a small, tested header-merge helper** (defensive + case-insensitive)
   - In `src/node/services/aiService.ts`, export:
     - `buildAppAttributionHeaders(existing?: Record<string, string>): Record<string, string>`
   - Behavior:
     - Preserve all unrelated headers.
     - Add missing headers using canonical casing (`HTTP-Referer`, `X-Title`).
     - Never overwrite existing values (match keys case-insensitively).

3. **Wire into model creation once**
   - In `AIService.createModel()` (after baseUrl → baseURL normalization), apply:
     - `providerConfig.headers = buildAppAttributionHeaders(providerConfig.headers)`
   - This automatically affects OpenRouter and every other provider branch because they all pass `headers` through to the provider factory.

4. **Unit tests**
   - Extend `src/node/services/aiService.test.ts` with `describe("buildAppAttributionHeaders", ...)`.
   - Test cases:
     - adds both headers when no headers exist
     - adds only the missing header when one is present
     - does not overwrite existing values (including different casing like `http-referer`, `X-TITLE`)
     - preserves unrelated headers

### Validation
- `make typecheck`
- `bun test src/node/services/aiService.test.ts`
- Manual: run a request through any provider (especially OpenRouter) and confirm the headers appear upstream.

## Rollout / compatibility notes
- This should be a non-breaking behavioral addition.
- We must ensure we **never** overwrite user-provided `HTTP-Referer` / `X-Title` (case-insensitive check).

</details>

---
_Generated with `mux` • Model: "unknown" • Thinking: "unknown"_
