### PR TITLE
🤖 fix: pass muxEnv to background bash

### DIFF
--- a/src/node/services/tools/bash.ts
+++ b/src/node/services/tools/bash.ts
@@ -257,7 +257,8 @@ export const createBashTool: ToolFactory = (config: ToolConfiguration) => {
           script,
           {
             cwd: config.cwd,
-            env: config.secrets,
+            // Match foreground bash behavior: muxEnv is present and secrets override it.
+            env: { ...(config.muxEnv ?? {}), ...(config.secrets ?? {}) },
             niceness: config.niceness,
             displayName: display_name,
             isForeground: false, // Explicit background


### PR DESCRIPTION
Fixes missing `MUX_MODEL_STRING` / `MUX_THINKING_LEVEL` in explicitly-backgrounded bash tool calls (`run_in_background: true`) by passing `muxEnv` through to `BackgroundProcessManager.spawn()` (secrets still override).

Adds a regression test that starts a background bash process and asserts it can read both env vars.

---

<details>
<summary>📋 Implementation Plan</summary>

# 🤖 fix: ensure MUX model + thinking env are set for GPT‑5.2 (esp. background bash)

## What’s broken
When running commands via the **bash tool** in *background mode* (`run_in_background: true`), the environment inside the spawned process does **not** include:

- `MUX_MODEL_STRING`
- `MUX_THINKING_LEVEL`

This shows up most often when using `openai:gpt-5.2` because that model tends to trigger longer-running tool usage (builds/tests/dev servers) where backgrounding is common.

## Root cause (code-level)
We *do* compute the MUX env (including model + thinking) correctly:

- `src/node/runtime/initHook.ts:getMuxEnv()` supports `{ modelString, thinkingLevel }` and will set:
  - `env.MUX_MODEL_STRING = options.modelString`
  - `env.MUX_THINKING_LEVEL = options.thinkingLevel`

We *do* pass it for AI tool calls:

- `src/node/services/aiService.ts` builds tool config with:
  - `muxEnv: getMuxEnv(..., { modelString, thinkingLevel: thinkingLevel ?? "off" })`

But the **bash tool’s explicit background path drops `muxEnv`**:

- `src/node/services/tools/bash.ts` (inside `createBashTool`, `if (run_in_background) { ... }`)
  - currently calls `backgroundProcessManager.spawn(..., { env: config.secrets, ... })`
  - **does not include `config.muxEnv`**, so `MUX_*` variables (including model/thinking) never reach the background process.

Foreground execution *does* include it (`env: { ...config.muxEnv, ...config.secrets }`), which is why this can look “model-specific” depending on tool usage patterns.

## Proposed fixes
### Approach A (recommended): Fix background bash env injection (small + correct)
**Net LoC (product code): ~10–20**

1. Update `src/node/services/tools/bash.ts` background path to pass merged env:
   - `env: { ...(config.muxEnv ?? {}), ...(config.secrets ?? {}) }`
   - preserve current precedence: **secrets override muxEnv**.
2. Add/extend unit tests in `src/node/services/tools/bash.test.ts`:
   - new test under `describe("bash tool - background execution")` asserting:
     - set `config.muxEnv = { MUX_MODEL_STRING: "openai:gpt-5.2", MUX_THINKING_LEVEL: "medium" }`
     - run background script: `echo "MODEL:$MUX_MODEL_STRING THINKING:$MUX_THINKING_LEVEL"`
     - read output via `BackgroundProcessManager.getOutput(processId, ..., timeout=2)`
     - assert output contains both values.
3. (Optional) Add a second test that proves `config.secrets` overrides `config.muxEnv` for the same key, matching existing foreground behavior.

Why this is enough:
- It directly addresses the only place where we *intentionally* bypass `runtime.exec(... env: ...)` and manually spawn a background process.

### Approach B (stretch): Also thread model/thinking into ORPC `workspace.executeBash`
**Net LoC (product code): ~80–150**

If the bug report is actually about **UI-driven** bash (ORPC) rather than AI tool calls, we currently don’t provide *any* `muxEnv` there.

Implementation idea:
1. Extend `src/common/orpc/schemas/api.ts` `workspace.executeBash.input` to accept optional:
   - `modelString?: string`
   - `thinkingLevel?: ThinkingLevel`
2. Update `src/node/services/workspaceService.ts:executeBash()` to pass:
   - `muxEnv: getMuxEnv(metadata.projectPath, getRuntimeType(metadata.runtimeConfig), metadata.name, { modelString, thinkingLevel })`
3. Update all call sites in the browser that use `api.workspace.executeBash(...)` to pass the current model/thinking if readily available.

I’m **not** recommending this by default because it’s broader surface area and not necessary to fix the bash tool behavior for agents.

## Validation plan
- Run unit tests that cover the bug:
  - `bun test src/node/services/tools/bash.test.ts -t "background"`
- Then run repo checks:
  - `make typecheck`
  - `make test`

## Acceptance criteria
- In a background bash tool call, `echo $MUX_MODEL_STRING` and `echo $MUX_THINKING_LEVEL` return non-empty values matching the active workspace session configuration (e.g., `openai:gpt-5.2`, `medium`).
- Existing foreground bash behavior remains unchanged.

## Notes / risks
- Low risk: change is localized to the background spawn path.
- Background processes already support env injection via `buildWrapperScript` (`export KEY='value'`), so this is just fixing the missing inputs.

</details>

---
_Generated with `mux` • Model: `unknown` • Thinking: `unknown`_
