### PR TITLE
🤖 fix: prevent Tooltip controlled/uncontrolled switch in DiffIndicator

### DIFF
--- a/src/browser/components/shared/DiffRenderer.tsx
+++ b/src/browser/components/shared/DiffRenderer.tsx
@@ -901,7 +901,7 @@ export const SelectableDiffRenderer = React.memo<SelectableDiffRendererProps>(
                     }}
                     reviewButton={
                       onReviewNote && (
-                        <Tooltip {...(selection || isDragging ? { open: false } : {})}>
+                        <Tooltip open={selection || isDragging ? false : undefined}>
                           <TooltipTrigger asChild>
                             <button
                               className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-sm text-[var(--color-review-accent)]/60 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 hover:text-[var(--color-review-accent)] active:scale-90"


### PR DESCRIPTION
The Tooltip in DiffIndicator was conditionally spreading `{ open: false }` when dragging/selecting and `{}` otherwise, causing React to warn about switching between controlled and uncontrolled modes.

Fix by always passing the `open` prop with `undefined` for default behavior.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_