### PR TITLE
🤖 fix: VS Code extension uses oRPC server when available

### DIFF
--- a/vscode/src/muxConfig.ts
+++ b/vscode/src/muxConfig.ts
@@ -1,63 +1,96 @@
-import * as path from "path";
-import * as os from "os";
+import type {
+  FrontendWorkspaceMetadata,
+  WorkspaceActivitySnapshot,
+} from "mux/common/types/workspace";
 import { Config } from "mux/node/config";
-import type { WorkspaceMetadata } from "mux/common/types/workspace";
-import { type ExtensionMetadata, readExtensionMetadata } from "mux/node/utils/extensionMetadata";
-import { getProjectName } from "mux/node/utils/runtime/helpers";
-import { createRuntime } from "mux/node/runtime/runtimeFactory";
+import { readExtensionMetadata } from "mux/node/utils/extensionMetadata";
+import {
+  createOrpcHttpClient,
+  discoverMuxServer,
+  type DiscoveredMuxServer,
+} from "./orpcClient";
 
 /**
- * Workspace with extension metadata for display in VS Code extension.
- * Combines workspace metadata from main app with extension-specific data.
+ * Workspace with activity metadata for display in VS Code extension.
  */
-export interface WorkspaceWithContext extends WorkspaceMetadata {
-  projectPath: string;
-  extensionMetadata?: ExtensionMetadata;
+export interface WorkspaceWithContext extends FrontendWorkspaceMetadata {
+  extensionMetadata?: WorkspaceActivitySnapshot;
 }
 
-/**
- * Get all workspaces from mux config, enriched with extension metadata.
- * Uses main app's Config class to read workspace metadata, then enriches
- * with extension-specific data (recency, streaming status).
- */
-export async function getAllWorkspaces(): Promise<WorkspaceWithContext[]> {
+export class MuxServerConnectionError extends Error {
+  readonly baseUrl: string;
+  readonly innerError: unknown;
+
+  constructor(baseUrl: string, innerError: unknown) {
+    super(`Failed to connect to mux server at ${baseUrl}`);
+    this.baseUrl = baseUrl;
+    this.innerError = innerError;
+  }
+}
+
+export interface GetAllWorkspacesOptions {
+  /** Skip server discovery and read from local mux files directly. */
+  forceFiles?: boolean;
+}
+
+export async function getAllWorkspaces(
+  options: GetAllWorkspacesOptions = {}
+): Promise<WorkspaceWithContext[]> {
+  if (!options.forceFiles) {
+    const server = await discoverMuxServer();
+    if (server) {
+      try {
+        return await getAllWorkspacesViaOrpc(server);
+      } catch (error) {
+        throw new MuxServerConnectionError(server.baseUrl, error);
+      }
+    }
+  }
+
+  return getAllWorkspacesViaFiles();
+}
+
+async function getAllWorkspacesViaOrpc(
+  server: DiscoveredMuxServer
+): Promise<WorkspaceWithContext[]> {
+  const api = createOrpcHttpClient(server);
+
+  const [workspaces, activityByWorkspaceId] = await Promise.all([
+    api.workspace.list(),
+    api.workspace.activity.list(),
+  ]);
+
+  const enriched: WorkspaceWithContext[] = workspaces.map((ws) => ({
+    ...ws,
+    extensionMetadata: activityByWorkspaceId[ws.id],
+  }));
+
+  sortByRecency(enriched);
+  return enriched;
+}
+
+async function getAllWorkspacesViaFiles(): Promise<WorkspaceWithContext[]> {
   const config = new Config();
   const workspaces = await config.getAllWorkspaceMetadata();
   const extensionMeta = readExtensionMetadata();
 
-  console.log(`[mux] Read ${extensionMeta.size} entries from extension metadata`);
+  const enriched: WorkspaceWithContext[] = workspaces.map((ws) => ({
+    ...ws,
+    extensionMetadata: extensionMeta.get(ws.id),
+  }));
 
-  // Enrich with extension metadata
-  const enriched: WorkspaceWithContext[] = workspaces.map((ws) => {
-    const meta = extensionMeta.get(ws.id);
-    if (meta) {
-      console.log(`[mux]   ${ws.id}: recency=${meta.recency}, streaming=${meta.streaming}`);
-    }
-    return {
-      ...ws,
-      extensionMetadata: meta,
-    };
-  });
+  sortByRecency(enriched);
+  return enriched;
+}
 
-  // Sort by recency (extension metadata > createdAt > name)
+function sortByRecency(workspaces: WorkspaceWithContext[]): void {
   const recencyOf = (w: WorkspaceWithContext): number =>
     w.extensionMetadata?.recency ?? (w.createdAt ? Date.parse(w.createdAt) : 0);
 
-  enriched.sort((a, b) => {
+  workspaces.sort((a, b) => {
     const aRecency = recencyOf(a);
     const bRecency = recencyOf(b);
     if (aRecency !== bRecency) return bRecency - aRecency;
     return a.name.localeCompare(b.name);
   });
-
-  return enriched;
-}
-
-/**
- * Get the workspace path for local or SSH workspaces
- * Uses Runtime to compute path using main app's logic
- */
-export function getWorkspacePath(workspace: WorkspaceWithContext): string {
-  const runtime = createRuntime(workspace.runtimeConfig, { projectPath: workspace.projectPath });
-  return runtime.getWorkspacePath(workspace.projectPath, workspace.name);
 }

--- a/vscode/src/orpcClient.ts
+++ b/vscode/src/orpcClient.ts
@@ -1,0 +1,51 @@
+import { RPCLink as HTTPRPCLink } from "@orpc/client/fetch";
+import type { RouterClient } from "@orpc/server";
+import { getMuxHome } from "mux/common/constants/paths";
+import { createClient } from "mux/common/orpc/client";
+import type { AppRouter } from "mux/node/orpc/router";
+import { ServerLockfile } from "mux/node/services/serverLockfile";
+
+export interface DiscoveredMuxServer {
+  baseUrl: string;
+  authToken?: string;
+}
+
+export type OrpcApiClient = RouterClient<AppRouter>;
+
+function normalizeBaseUrl(baseUrl: string): string {
+  // Avoid double slashes when constructing `${baseUrl}/orpc`.
+  return baseUrl.replace(/\/+$/, "");
+}
+
+export async function discoverMuxServer(): Promise<DiscoveredMuxServer | null> {
+  // Priority 1: Explicit env vars override everything
+  if (process.env.MUX_SERVER_URL) {
+    const authToken = process.env.MUX_SERVER_AUTH_TOKEN?.trim();
+    return {
+      baseUrl: normalizeBaseUrl(process.env.MUX_SERVER_URL),
+      authToken: authToken ? authToken : undefined,
+    };
+  }
+
+  // Priority 2: Try lockfile discovery (running Electron or mux server)
+  const lockfile = new ServerLockfile(getMuxHome());
+  const data = await lockfile.read();
+  if (!data) {
+    return null;
+  }
+
+  const authToken = data.token.trim();
+  return {
+    baseUrl: normalizeBaseUrl(data.baseUrl),
+    authToken: authToken ? authToken : undefined,
+  };
+}
+
+export function createOrpcHttpClient(server: DiscoveredMuxServer): OrpcApiClient {
+  const link = new HTTPRPCLink({
+    url: `${server.baseUrl}/orpc`,
+    headers: server.authToken ? { Authorization: `Bearer ${server.authToken}` } : undefined,
+  });
+
+  return createClient(link);
+}

--- a/vscode/src/workspaceOpener.ts
+++ b/vscode/src/workspaceOpener.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { WorkspaceWithContext, getWorkspacePath } from "./muxConfig";
+import { WorkspaceWithContext } from "./muxConfig";
 
 /**
  * Check if a Remote-SSH extension is installed
@@ -18,7 +18,7 @@ function isRemoteSshInstalled(): boolean {
 export async function openWorkspace(workspace: WorkspaceWithContext) {
   // Handle local runtimes: "local", "worktree", or legacy "local" with srcBaseDir
   if (workspace.runtimeConfig.type === "local" || workspace.runtimeConfig.type === "worktree") {
-    const workspacePath = getWorkspacePath(workspace);
+    const workspacePath = workspace.namedWorkspacePath;
     const uri = vscode.Uri.file(workspacePath);
 
     await vscode.commands.executeCommand("vscode.openFolder", uri, {
@@ -53,7 +53,7 @@ export async function openWorkspace(workspace: WorkspaceWithContext) {
   }
 
   const host = workspace.runtimeConfig.host;
-  const remotePath = getWorkspacePath(workspace);
+  const remotePath = workspace.namedWorkspacePath;
 
   // Format: vscode-remote://ssh-remote+<host><absolute-path>
   // Both ms-vscode-remote.remote-ssh and anysphere.remote-ssh use the same URI scheme


### PR DESCRIPTION
### What
- VS Code extension now discovers a running mux server via `MUX_SERVER_URL` or `~/.mux/server.lock` and uses HTTP oRPC for workspace listing/activity.
- Falls back to the existing file-based metadata when no server is detected.
- If a server is detected but unreachable, prompts the user to retry or explicitly opt into using local files (to avoid silently racing the server).
- Uses backend-computed `namedWorkspacePath` for opening workspaces (local/worktree + SSH).

### Validation
- `make static-check`
- `cd vscode && bun run compile`

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh`_
