### PR TITLE
🤖 fix: disable PostHog telemetry in dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,13 +131,13 @@ dev: node_modules/.installed build-main ## Start development server (Vite + node
 	@echo "Starting dev mode (3 watchers: nodemon for main process, esbuild for api, vite for renderer)..."
 	# On Windows, use npm run because bunx doesn't correctly pass arguments to concurrently
 	# https://github.com/oven-sh/bun/issues/18275
-	@NODE_OPTIONS="--max-old-space-size=4096" npm x concurrently -k --raw \
+	@MUX_DISABLE_TELEMETRY=$(or $(MUX_DISABLE_TELEMETRY),1) NODE_OPTIONS="--max-old-space-size=4096" npm x concurrently -k --raw \
 		"bun x nodemon --watch src --watch tsconfig.main.json --watch tsconfig.json --ext ts,tsx,json --ignore dist --ignore node_modules --exec node scripts/build-main-watch.js" \
 		"npx esbuild src/cli/api.ts --bundle --format=esm --platform=node --target=node20 --outfile=dist/cli/api.mjs --external:zod --external:commander --external:@trpc/server --watch" \
 		"vite"
 else
 dev: node_modules/.installed build-main build-preload ## Start development server (Vite + tsgo watcher for 10x faster type checking)
-	@bun x concurrently -k \
+	@MUX_DISABLE_TELEMETRY=$(or $(MUX_DISABLE_TELEMETRY),1) bun x concurrently -k \
 		"bun x concurrently \"$(TSGO) -w -p tsconfig.main.json\" \"bun x tsc-alias -w -p tsconfig.main.json\"" \
 		"bun x esbuild src/cli/api.ts --bundle --format=esm --platform=node --target=node20 --outfile=dist/cli/api.mjs --external:zod --external:commander --external:@trpc/server --watch" \
 		"vite"
@@ -151,7 +151,7 @@ dev-server: node_modules/.installed build-main ## Start server mode with hot rel
 	@echo ""
 	@echo "For remote access: make dev-server VITE_HOST=0.0.0.0 BACKEND_HOST=0.0.0.0"
 	@# On Windows, use npm run because bunx doesn't correctly pass arguments
-	@npmx concurrently -k \
+	@MUX_DISABLE_TELEMETRY=$(or $(MUX_DISABLE_TELEMETRY),1) npmx concurrently -k \
 		"npmx nodemon --watch src --watch tsconfig.main.json --watch tsconfig.json --ext ts,tsx,json --ignore dist --ignore node_modules --exec node scripts/build-main-watch.js" \
 		"npx esbuild src/cli/api.ts --bundle --format=esm --platform=node --target=node20 --outfile=dist/cli/api.mjs --external:zod --external:commander --external:@trpc/server --watch" \
 		"npmx nodemon --watch dist/cli/index.js --watch dist/cli/server.js --delay 500ms --exec \"node dist/cli/index.js server --host $(or $(BACKEND_HOST),localhost) --port $(or $(BACKEND_PORT),3000)\"" \
@@ -163,7 +163,7 @@ dev-server: node_modules/.installed build-main ## Start server mode with hot rel
 	@echo "  Frontend (with HMR):     http://$(or $(VITE_HOST),localhost):$(or $(VITE_PORT),5173)"
 	@echo ""
 	@echo "For remote access: make dev-server VITE_HOST=0.0.0.0 BACKEND_HOST=0.0.0.0"
-	@bun x concurrently -k \
+	@MUX_DISABLE_TELEMETRY=$(or $(MUX_DISABLE_TELEMETRY),1) bun x concurrently -k \
 		"bun x concurrently \"$(TSGO) -w -p tsconfig.main.json\" \"bun x tsc-alias -w -p tsconfig.main.json\"" \
 		"bun x esbuild src/cli/api.ts --bundle --format=esm --platform=node --target=node20 --outfile=dist/cli/api.mjs --external:zod --external:commander --external:@trpc/server --watch" \
 		"bun x nodemon --watch dist/cli/index.js --watch dist/cli/server.js --delay 500ms --exec 'NODE_ENV=development node dist/cli/index.js server --host $(or $(BACKEND_HOST),localhost) --port $(or $(BACKEND_PORT),3000)'" \
@@ -173,7 +173,7 @@ endif
 
 
 start: node_modules/.installed build-main build-preload build-static ## Build and start Electron app
-	@NODE_ENV=development bunx electron --remote-debugging-port=9222 .
+	@NODE_ENV=development MUX_DISABLE_TELEMETRY=$(or $(MUX_DISABLE_TELEMETRY),1) bunx electron --remote-debugging-port=9222 .
 
 ## Build targets (can run in parallel)
 build: node_modules/.installed src/version.ts build-renderer build-main build-preload build-icons build-static ## Build all targets

--- a/src/common/types/global.d.ts
+++ b/src/common/types/global.d.ts
@@ -15,6 +15,8 @@ declare global {
       chrome?: string;
       electron?: string;
     };
+    // Allow maintainers to opt into telemetry while running the dev server.
+    enableTelemetryInDev?: boolean;
     // E2E test mode flag - used to adjust UI behavior (e.g., longer toast durations)
     isE2E?: boolean;
     // Optional ORPC-backed API surfaces populated in tests/storybook mocks

--- a/src/desktop/preload.ts
+++ b/src/desktop/preload.ts
@@ -32,4 +32,5 @@ contextBridge.exposeInMainWorld("api", {
     electron: process.versions.electron,
   },
   isE2E: process.env.MUX_E2E === "1",
+  enableTelemetryInDev: process.env.MUX_ENABLE_TELEMETRY_IN_DEV === "1",
 });

--- a/src/node/services/telemetryService.test.ts
+++ b/src/node/services/telemetryService.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+
+import { shouldEnableTelemetry, type TelemetryEnablementContext } from "./telemetryService";
+
+function createContext(overrides: Partial<TelemetryEnablementContext>): TelemetryEnablementContext {
+  return {
+    env: overrides.env ?? {},
+    isElectron: overrides.isElectron ?? false,
+    isPackaged: overrides.isPackaged ?? null,
+  };
+}
+
+describe("TelemetryService enablement", () => {
+  test("disables telemetry when explicitly disabled", () => {
+    const enabled = shouldEnableTelemetry(
+      createContext({
+        env: { MUX_DISABLE_TELEMETRY: "1" },
+        isElectron: true,
+        isPackaged: true,
+      })
+    );
+
+    expect(enabled).toBe(false);
+  });
+
+  test("disables telemetry in E2E runs", () => {
+    const enabled = shouldEnableTelemetry(
+      createContext({
+        env: { MUX_E2E: "1" },
+        isElectron: true,
+        isPackaged: true,
+      })
+    );
+
+    expect(enabled).toBe(false);
+  });
+
+  test("disables telemetry in test environments", () => {
+    const enabled = shouldEnableTelemetry(
+      createContext({
+        env: { NODE_ENV: "test" },
+        isElectron: true,
+        isPackaged: true,
+      })
+    );
+
+    expect(enabled).toBe(false);
+  });
+
+  test("disables telemetry in CI environments", () => {
+    const enabled = shouldEnableTelemetry(
+      createContext({
+        env: { CI: "true" },
+        isElectron: true,
+        isPackaged: true,
+      })
+    );
+
+    expect(enabled).toBe(false);
+  });
+
+  test("disables telemetry in unpackaged Electron by default", () => {
+    const enabled = shouldEnableTelemetry(
+      createContext({
+        env: {},
+        isElectron: true,
+        isPackaged: false,
+      })
+    );
+
+    expect(enabled).toBe(false);
+  });
+
+  test("enables telemetry in packaged Electron by default", () => {
+    const enabled = shouldEnableTelemetry(
+      createContext({
+        env: {},
+        isElectron: true,
+        isPackaged: true,
+      })
+    );
+
+    expect(enabled).toBe(true);
+  });
+
+  test("disables telemetry in NODE_ENV=development by default", () => {
+    const enabled = shouldEnableTelemetry(
+      createContext({
+        env: { NODE_ENV: "development" },
+        isElectron: false,
+      })
+    );
+
+    expect(enabled).toBe(false);
+  });
+
+  test("allows opting into telemetry in dev", () => {
+    const enabled = shouldEnableTelemetry(
+      createContext({
+        env: {
+          NODE_ENV: "development",
+          MUX_ENABLE_TELEMETRY_IN_DEV: "1",
+        },
+        isElectron: false,
+      })
+    );
+
+    expect(enabled).toBe(true);
+  });
+
+  test("allows opting into telemetry in unpackaged Electron", () => {
+    const enabled = shouldEnableTelemetry(
+      createContext({
+        env: { MUX_ENABLE_TELEMETRY_IN_DEV: "1" },
+        isElectron: true,
+        isPackaged: false,
+      })
+    );
+
+    expect(enabled).toBe(true);
+  });
+
+  test("dev opt-in does not bypass test env disable", () => {
+    const enabled = shouldEnableTelemetry(
+      createContext({
+        env: {
+          NODE_ENV: "test",
+          MUX_ENABLE_TELEMETRY_IN_DEV: "1",
+        },
+        isElectron: false,
+      })
+    );
+
+    expect(enabled).toBe(false);
+  });
+});


### PR DESCRIPTION
Ensures PostHog telemetry is never sent from local development runs by default.

- Backend: disable telemetry for unpackaged Electron, NODE_ENV=development, and MUX_E2E=1 (opt-in via MUX_ENABLE_TELEMETRY_IN_DEV=1).
- Frontend: skip forwarding events when running under the Vite dev server unless opted in (Electron preload exposes enableTelemetryInDev).
- Dev Make targets default MUX_DISABLE_TELEMETRY=1 (overrideable via make/env).

Validation:
- make static-check
- bun test src/node/services/telemetryService.test.ts

---

<details>
<summary>📋 Implementation Plan</summary>

# Ensure PostHog telemetry is **never** sent in development

## Goal
Make it *provably impossible* for local development runs to submit any events (including `error_occurred`) to PostHog, while keeping telemetry enabled for real packaged releases.

## Current behavior (what I verified)
- Backend telemetry is implemented in `src/node/services/telemetryService.ts` using `posthog-node` and a hard-coded project key/host.
- Telemetry is only disabled for:
  - `MUX_DISABLE_TELEMETRY=1`
  - test/CI envs (`NODE_ENV=test`, Jest/Vitest vars, `TEST_INTEGRATION=1`, or common CI env vars)
- `make start` runs Electron with `NODE_ENV=development`, and the renderer unconditionally calls `trackAppStarted()` at boot (`src/browser/main.tsx`).
- **There is currently no dev-mode guard** (`NODE_ENV=development` or `app.isPackaged===false`) in either the frontend telemetry client or the backend telemetry service.

=> As-is, running mux locally in dev mode can send telemetry to the production PostHog project unless each dev explicitly sets `MUX_DISABLE_TELEMETRY=1`.

---

## Recommended approach (A): Disable telemetry by default in dev, allow explicit opt-in
**Net LoC estimate (prod code only): ~35–60 LoC**

### 1) Backend: treat Electron dev (and explicit dev env) as “telemetry disabled”
Make `TelemetryService.initialize()` a no-op unless we are in a *production-like* runtime.

Implementation sketch:
- Extend `isTelemetryDisabled()` in `src/node/services/telemetryService.ts` with:
  - `process.env.NODE_ENV === "development"`
  - **Electron dev detection**:
    - If `process.versions.electron` exists, dynamically resolve `app.isPackaged` (only in Electron runtime).
    - If `app.isPackaged === false`, disable telemetry.
- Add an escape hatch for local testing:
  - `MUX_ENABLE_TELEMETRY_IN_DEV=1` (or similar) overrides the dev-disable behavior.

Notes:
- Avoid importing `electron` at module top-level to keep server-mode (`mux server`) safe; only load Electron APIs when `process.versions.electron` is present.

### 2) Frontend: short-circuit in Vite dev builds (belt-and-suspenders)
In `src/common/telemetry/client.ts`:
- Early return when `import.meta.env.DEV` is true.
- Keep the same `MUX_ENABLE_TELEMETRY_IN_DEV=1` override (if we add it) so we can test locally when needed.

Rationale: backend gating is sufficient for “no data leaves the machine”, but frontend gating also prevents noisy ORPC calls and makes intent obvious.

### 3) Dev tooling: default `MUX_DISABLE_TELEMETRY=1` in `make dev`, `make start`, `make dev-server`
Even with code-level guards, set the env var in the dev targets so:
- developers get an immediate, explicit guarantee
- the behavior is consistent across desktop + server mode

---

## Tests / validation
- Add a small unit test for the enable/disable decision logic (recommended to extract a pure helper like `shouldEnableTelemetry({...})`).
  - Matrix:
    - Electron + `isPackaged=false` => disabled
    - Electron + `isPackaged=true` => enabled
    - `NODE_ENV=development` => disabled
    - override env (`MUX_ENABLE_TELEMETRY_IN_DEV=1`) => enabled (even in dev)
    - existing test/CI envs remain disabled
- Manual sanity check:
  - Run `make start` and confirm logs show telemetry disabled and no `telemetry_id` file is created in mux home.

---

## Alternative (B): Makefile-only kill switch
**Net LoC estimate (prod code only): ~0 LoC (Makefile only)**

Just set `MUX_DISABLE_TELEMETRY=1` in dev targets.

Downside: not “absolute” because it’s easy to bypass (run Electron/CLI directly), and it doesn’t document the intended policy in code.

---

## Rollout / compatibility notes
- This change should not affect packaged builds; telemetry remains on there.
- If we add `MUX_ENABLE_TELEMETRY_IN_DEV=1`, we preserve the ability to test PostHog integration intentionally.

</details>

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh`_
