### PR TITLE
🤖 feat: add OpenAI promptCacheKey for improved caching

### DIFF
--- a/src/common/utils/ai/providerOptions.test.ts
+++ b/src/common/utils/ai/providerOptions.test.ts
@@ -2,6 +2,7 @@
  * Tests for provider options builder
  */
 
+import type { OpenAIResponsesProviderOptions } from "@ai-sdk/openai";
 import { describe, test, expect, mock } from "bun:test";
 import { buildProviderOptions } from "./providerOptions";
 
@@ -117,6 +118,50 @@ describe("buildProviderOptions - Anthropic", () => {
           sendReasoning: true,
         },
       });
+    });
+  });
+});
+
+describe("buildProviderOptions - OpenAI promptCacheKey", () => {
+  // Helper to extract OpenAI options from the result
+  const getOpenAIOptions = (
+    result: ReturnType<typeof buildProviderOptions>
+  ): OpenAIResponsesProviderOptions | undefined => {
+    if ("openai" in result) {
+      return result.openai;
+    }
+    return undefined;
+  };
+
+  describe("promptCacheKey derivation", () => {
+    test("should derive promptCacheKey from workspaceId when provided", () => {
+      const result = buildProviderOptions(
+        "openai:gpt-5.2",
+        "off",
+        undefined,
+        undefined,
+        undefined,
+        "abc123"
+      );
+      const openai = getOpenAIOptions(result);
+
+      expect(openai).toBeDefined();
+      expect(openai!.promptCacheKey).toBe("mux-v1-abc123");
+    });
+
+    test("should derive promptCacheKey for gateway OpenAI model", () => {
+      const result = buildProviderOptions(
+        "mux-gateway:openai/gpt-5.2",
+        "off",
+        undefined,
+        undefined,
+        undefined,
+        "workspace-xyz"
+      );
+      const openai = getOpenAIOptions(result);
+
+      expect(openai).toBeDefined();
+      expect(openai!.promptCacheKey).toBe("mux-v1-workspace-xyz");
     });
   });
 });

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1365,12 +1365,14 @@ export class AIService extends EventEmitter {
       // Build provider options based on thinking level and message history
       // Pass filtered messages so OpenAI can extract previousResponseId for persistence
       // Also pass callback to filter out lost responseIds (OpenAI invalidated them)
+      // Pass workspaceId to derive stable promptCacheKey for OpenAI caching
       const providerOptions = buildProviderOptions(
         modelString,
         thinkingLevel ?? "off",
         filteredMessages,
         (id) => this.streamManager.isResponseIdLost(id),
-        effectiveMuxProviderOptions
+        effectiveMuxProviderOptions,
+        workspaceId
       );
 
       // Debug dump: Log the complete LLM request when MUX_DEBUG_LLM_REQUEST is set


### PR DESCRIPTION
Wire AI SDK's `providerOptions.openai.promptCacheKey` to improve OpenAI prompt cache hit rates.

## Changes

- Derive cache key as `mux-v1-{workspaceId}` for OpenAI requests
- Pass workspaceId from `AIService.streamMessage` to `buildProviderOptions`
- Only set promptCacheKey when workspaceId is available (always true in real requests)

This enables OpenAI to route requests to cached prefixes within a workspace, improving cache hit rates for repeated calls.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_