### PR TITLE
🤖 fix: show sidebar toggle button on workspace creation screen

### DIFF
--- a/src/browser/components/LeftSidebar.tsx
+++ b/src/browser/components/LeftSidebar.tsx
@@ -18,14 +18,16 @@ export function LeftSidebar(props: LeftSidebarProps) {
 
   return (
     <>
-      {/* Hamburger menu button - only visible on mobile */}
+      {/* Hamburger menu button - visible when sidebar is collapsed
+          On mobile: positioned at top-left (sidebar slides off-screen)
+          On desktop: positioned after the collapsed sidebar strip */}
       {collapsed && (
         <button
           onClick={onToggleCollapsed}
           title="Open sidebar"
           aria-label="Open sidebar menu"
           className={cn(
-            "hidden mobile-menu-btn fixed top-3 left-3 z-30",
+            "sidebar-toggle-btn fixed top-3 z-30 flex",
             "w-10 h-10 bg-sidebar border border-border-light rounded-md cursor-pointer",
             "items-center justify-center text-foreground text-xl transition-all duration-200",
             "shadow-[0_2px_4px_rgba(0,0,0,0.3)]",

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -1003,8 +1003,19 @@ body,
   overflow: hidden;
 }
 
+/* Sidebar toggle button positioning
+   On desktop: positioned after the collapsed sidebar strip (w-8 = 32px)
+   On mobile: positioned at top-left (sidebar slides off-screen) */
+.sidebar-toggle-btn {
+  left: calc(2rem + 12px); /* 32px sidebar + 12px gap */
+}
+
 /* Mobile improvements - only apply to touch devices */
 @media (max-width: 768px) and (pointer: coarse) {
+  /* On mobile, sidebar slides off-screen, so position toggle at top-left */
+  .sidebar-toggle-btn {
+    left: 12px;
+  }
   html {
     -webkit-text-size-adjust: 100%;
     touch-action: manipulation;


### PR DESCRIPTION
## Summary

When the sidebar is collapsed on the workspace creation screen, users had no obvious way to expand it (only keyboard shortcut Ctrl+P worked).

## Changes

- Added a hamburger toggle button that is always visible when the sidebar is collapsed
- On desktop: positioned next to the collapsed sidebar strip (44px from left)
- On mobile: positioned at top-left corner (12px from left)

## Testing

- Typecheck passes
- Static check passes

_Generated with `mux`_