### PR TITLE
🤖 fix: add sidebar toggle to new workspace creation screen

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -51,6 +51,7 @@ import { TutorialProvider } from "./contexts/TutorialContext";
 import { TooltipProvider } from "./components/ui/tooltip";
 import { ExperimentsProvider } from "./contexts/ExperimentsContext";
 import { getWorkspaceSidebarKey } from "./utils/workspace";
+import { CreationHeader } from "./components/CreationHeader";
 
 const THINKING_LEVELS: ThinkingLevel[] = ["off", "low", "medium", "high"];
 
@@ -627,70 +628,83 @@ function AppInner() {
                 const projectName =
                   projectPath.split("/").pop() ?? projectPath.split("\\").pop() ?? "Project";
                 return (
-                  <ModeProvider projectPath={projectPath}>
-                    <ProviderOptionsProvider>
-                      <ThinkingProvider projectPath={projectPath}>
-                        <ChatInput
-                          variant="creation"
-                          projectPath={projectPath}
-                          projectName={projectName}
-                          onProviderConfig={handleProviderConfig}
-                          onReady={handleCreationChatReady}
-                          onWorkspaceCreated={(metadata) => {
-                            // IMPORTANT: Add workspace to store FIRST (synchronous) to ensure
-                            // the store knows about it before React processes the state updates.
-                            // This prevents race conditions where the UI tries to access the
-                            // workspace before the store has created its aggregator.
-                            workspaceStore.addWorkspace(metadata);
+                  <>
+                    <CreationHeader
+                      projectName={projectName}
+                      onToggleSidebar={handleToggleSidebar}
+                      sidebarCollapsed={sidebarCollapsed}
+                    />
+                    <ModeProvider projectPath={projectPath}>
+                      <ProviderOptionsProvider>
+                        <ThinkingProvider projectPath={projectPath}>
+                          <ChatInput
+                            variant="creation"
+                            projectPath={projectPath}
+                            projectName={projectName}
+                            onProviderConfig={handleProviderConfig}
+                            onReady={handleCreationChatReady}
+                            onWorkspaceCreated={(metadata) => {
+                              // IMPORTANT: Add workspace to store FIRST (synchronous) to ensure
+                              // the store knows about it before React processes the state updates.
+                              // This prevents race conditions where the UI tries to access the
+                              // workspace before the store has created its aggregator.
+                              workspaceStore.addWorkspace(metadata);
 
-                            // Add to workspace metadata map (triggers React state update)
-                            setWorkspaceMetadata((prev) =>
-                              new Map(prev).set(metadata.id, metadata)
-                            );
+                              // Add to workspace metadata map (triggers React state update)
+                              setWorkspaceMetadata((prev) =>
+                                new Map(prev).set(metadata.id, metadata)
+                              );
 
-                            // Only switch to new workspace if user hasn't selected another one
-                            // during the creation process (selectedWorkspace was null when creation started)
-                            setSelectedWorkspace((current) => {
-                              if (current !== null) {
-                                // User has already selected another workspace - don't override
-                                return current;
-                              }
-                              return {
-                                workspaceId: metadata.id,
-                                projectPath: metadata.projectPath,
-                                projectName: metadata.projectName,
-                                namedWorkspacePath: metadata.namedWorkspacePath,
-                              };
-                            });
+                              // Only switch to new workspace if user hasn't selected another one
+                              // during the creation process (selectedWorkspace was null when creation started)
+                              setSelectedWorkspace((current) => {
+                                if (current !== null) {
+                                  // User has already selected another workspace - don't override
+                                  return current;
+                                }
+                                return {
+                                  workspaceId: metadata.id,
+                                  projectPath: metadata.projectPath,
+                                  projectName: metadata.projectName,
+                                  namedWorkspacePath: metadata.namedWorkspacePath,
+                                };
+                              });
 
-                            // Track telemetry
-                            telemetry.workspaceCreated(
-                              metadata.id,
-                              getRuntimeTypeForTelemetry(metadata.runtimeConfig)
-                            );
+                              // Track telemetry
+                              telemetry.workspaceCreated(
+                                metadata.id,
+                                getRuntimeTypeForTelemetry(metadata.runtimeConfig)
+                              );
 
-                            // Clear pending state
-                            clearPendingWorkspaceCreation();
-                          }}
-                        />
-                      </ThinkingProvider>
-                    </ProviderOptionsProvider>
-                  </ModeProvider>
+                              // Clear pending state
+                              clearPendingWorkspaceCreation();
+                            }}
+                          />
+                        </ThinkingProvider>
+                      </ProviderOptionsProvider>
+                    </ModeProvider>
+                  </>
                 );
               })()
             ) : (
-              <div
-                className="[&_p]:text-muted [&_h2]:text-foreground mx-auto w-full max-w-3xl text-center [&_h2]:mb-4 [&_h2]:font-bold [&_h2]:tracking-tight [&_p]:leading-[1.6]"
-                style={{
-                  padding: "clamp(40px, 10vh, 100px) 20px",
-                  fontSize: "clamp(14px, 2vw, 16px)",
-                }}
-              >
-                <h2 style={{ fontSize: "clamp(24px, 5vw, 36px)", letterSpacing: "-1px" }}>
-                  Welcome to Mux
-                </h2>
-                <p>Select a workspace from the sidebar or add a new one to get started.</p>
-              </div>
+              <>
+                <CreationHeader
+                  onToggleSidebar={handleToggleSidebar}
+                  sidebarCollapsed={sidebarCollapsed}
+                />
+                <div
+                  className="[&_p]:text-muted [&_h2]:text-foreground mx-auto w-full max-w-3xl text-center [&_h2]:mb-4 [&_h2]:font-bold [&_h2]:tracking-tight [&_p]:leading-[1.6]"
+                  style={{
+                    padding: "clamp(40px, 10vh, 100px) 20px",
+                    fontSize: "clamp(14px, 2vw, 16px)",
+                  }}
+                >
+                  <h2 style={{ fontSize: "clamp(24px, 5vw, 36px)", letterSpacing: "-1px" }}>
+                    Welcome to Mux
+                  </h2>
+                  <p>Select a workspace from the sidebar or add a new one to get started.</p>
+                </div>
+              </>
             )}
           </div>
         </div>

--- a/src/browser/components/CreationHeader.tsx
+++ b/src/browser/components/CreationHeader.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { PanelLeft } from "lucide-react";
+import { Tooltip, TooltipTrigger, TooltipContent } from "./ui/tooltip";
+import { formatKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
+import { Button } from "@/browser/components/ui/button";
+
+interface CreationHeaderProps {
+  projectName?: string;
+  onToggleSidebar: () => void;
+  sidebarCollapsed: boolean;
+}
+
+/**
+ * Minimal header for the workspace creation screen and welcome screen.
+ * Shows a sidebar toggle button that's especially important on mobile
+ * where the hamburger menu might not be visible (non-touch devices at narrow widths).
+ */
+export const CreationHeader: React.FC<CreationHeaderProps> = ({
+  projectName,
+  onToggleSidebar,
+  sidebarCollapsed,
+}) => {
+  return (
+    <div
+      data-testid="creation-header"
+      className="bg-sidebar border-border-light flex h-8 items-center justify-between border-b px-[15px] [@media(max-width:768px)]:h-auto [@media(max-width:768px)]:py-2 [@media(max-width:768px)]:pl-[60px]"
+    >
+      <div className="text-foreground flex min-w-0 items-center gap-2.5 overflow-hidden font-semibold">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onToggleSidebar}
+              className="text-muted hover:text-foreground h-6 w-6 shrink-0"
+              aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+            >
+              <PanelLeft className="h-4 w-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" align="start">
+            {sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"} (
+            {formatKeybind(KEYBINDS.TOGGLE_SIDEBAR)})
+          </TooltipContent>
+        </Tooltip>
+        {projectName && <span className="min-w-0 truncate font-mono text-xs">{projectName}</span>}
+        {!projectName && <span className="text-muted text-xs">New workspace</span>}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
Added a CreationHeader component that displays on both the workspace creation screen and welcome screen, providing a visible sidebar toggle button.

This addresses the issue where the sidebar wasn't easily toggleable on these screens, especially:

- On desktop with collapsed sidebar (previously only a thin strip with a small « button at the bottom)
- On non-touch devices at narrow widths (hamburger menu only shows for touch devices via `pointer: coarse` media query)

The header matches the WorkspaceHeader styling and shows the project name when on the creation screen.

_Generated with `mux`_