### PR TITLE
🤖 fix: support Electron flags (--no-sandbox) in packaged AppImage

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,6 +23,7 @@
 import { Command } from "commander";
 import { VERSION } from "../version";
 import {
+  CLI_GLOBAL_FLAGS,
   detectCliEnvironment,
   getParseOptions,
   getSubcommand,
@@ -79,10 +80,22 @@ if (subcommand === "run") {
   const gitCommit =
     typeof versionRecord.git_commit === "string" ? versionRecord.git_commit : "unknown";
 
+  // Global flags are defined in CLI_GLOBAL_FLAGS (argv.ts) for routing logic.
+  // Commander auto-adds --help/-h. We define --version/-v below.
   program
     .name("mux")
     .description("Mux - AI agent orchestration")
     .version(`${gitDescribe} (${gitCommit})`, "-v, --version");
+
+  // Sanity check: ensure version flags match CLI_GLOBAL_FLAGS
+  if (process.env.NODE_ENV !== "production") {
+    const versionFlags = ["-v", "--version"];
+    for (const flag of versionFlags) {
+      if (!CLI_GLOBAL_FLAGS.includes(flag as (typeof CLI_GLOBAL_FLAGS)[number])) {
+        console.warn(`Warning: version flag "${flag}" not in CLI_GLOBAL_FLAGS`);
+      }
+    }
+  }
 
   // Register subcommand stubs for help display (actual implementations are above)
   // `run` is only available via bun/node CLI, not bundled in Electron


### PR DESCRIPTION
## Summary

Fix `./mux.AppImage --no-sandbox` and other Electron flags not working - they were incorrectly falling through to CLI help instead of launching the desktop app.

## Problem

After the previous CLI argv fix (#1161), Electron flags like `--no-sandbox` in packaged AppImage were treated as unknown CLI arguments:

```
./mux.AppImage --no-sandbox  # showed CLI help instead of launching desktop
```

## Root Cause

`isElectronLaunchArg()` immediately returned `false` for all packaged Electron flags, not distinguishing between:
- **CLI flags** (`--help`, `--version`) → should show CLI help
- **Electron flags** (`--no-sandbox`, `--disable-gpu`) → should launch desktop

## Solution

- Add `CLI_GLOBAL_FLAGS` constant listing flags that should show CLI help
- Update `isElectronLaunchArg()` to return `true` for non-CLI flags in packaged mode
- Add runtime sanity check (dev mode only) to warn if flags get out of sync
- Add tests for the new behavior

## Manual Test Results

| Command | Result |
|---------|--------|
| `./mux.AppImage --no-sandbox` | ✅ Launches desktop |
| `./mux.AppImage --disable-gpu` | ✅ Launches desktop |
| `./mux.AppImage --help` | ✅ Shows CLI help |
| `./mux.AppImage --version` | ✅ Shows version |
| `./mux.AppImage server --help` | ✅ Shows server options |
| `bunx electron . --no-sandbox` | ✅ Launches desktop (dev mode) |

---
_Generated with `mux` • Model: `anthropic:claude-sonnet-4-20250514` • Thinking: `low`_