### PR TITLE
🤖 fix: prevent Escape from interrupting stream during voice recording

### DIFF
--- a/src/browser/hooks/useVoiceInput.ts
+++ b/src/browser/hooks/useVoiceInput.ts
@@ -335,6 +335,7 @@ export function useVoiceInput(options: UseVoiceInputOptions): UseVoiceInputResul
         stop({ send: true });
       } else if (e.key === "Escape") {
         e.preventDefault();
+        e.stopPropagation(); // Prevent global stream interrupt handler
         cancel();
       } else if (matchesKeybind(e, KEYBINDS.TOGGLE_VOICE_INPUT)) {
         e.preventDefault();


### PR DESCRIPTION
When recording voice input while streaming, pressing Escape to cancel recording would also interrupt the active chat stream. This is the same issue fixed in PR #954 (workspace renaming) and PR #1010 (message editing).

Added `stopPropagation()` to the Escape handler in `useVoiceInput.ts` to prevent the event from reaching the global stream interrupt handler in `useAIViewKeybinds`.

I explored ways to unify this pattern (centralized Escape registry, checking `defaultPrevented`, single global handler with state checks) but none were better than the simple `stopPropagation()` approach—each adds coupling or complexity without meaningful benefit. The DOM's event propagation model is designed for exactly this case.

Closes #1170

---
_Generated with `mux`_