### PR TITLE
🤖 fix: enable resize handle on Costs tab

### DIFF
--- a/src/browser/components/RightSidebar.tsx
+++ b/src/browser/components/RightSidebar.tsx
@@ -249,8 +249,8 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
     >
       {/* Full view when not collapsed */}
       <div className={cn("flex-row h-full", !showCollapsed ? "flex" : "hidden")}>
-        {/* Resize handle (left edge) when Review tab is active */}
-        {selectedTab === "review" && onStartResize && (
+        {/* Resize handle (left edge) */}
+        {onStartResize && (
           <div
             className={cn(
               "w-0.5 flex-shrink-0 z-10 transition-[background] duration-150 cursor-col-resize",


### PR DESCRIPTION
The sidebar width is now shared between Costs and Review tabs (from #1172), but the resize handle was still only visible on Review. Show the handle on both tabs so users can resize regardless of which tab is active.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_