### PR TITLE
🤖 feat: remember right sidebar width per tab (Costs vs Review)

### DIFF
--- a/src/browser/stories/App.rightsidebar.stories.tsx
+++ b/src/browser/stories/App.rightsidebar.stories.tsx
@@ -8,7 +8,11 @@ import { appMeta, AppWithMocks, type AppStory } from "./meta.js";
 import { setupSimpleChatStory } from "./storyHelpers";
 import { createUserMessage, createAssistantMessage } from "./mockFactory";
 import { within, userEvent, waitFor } from "@storybook/test";
-import { RIGHT_SIDEBAR_TAB_KEY } from "@/common/constants/storage";
+import {
+  RIGHT_SIDEBAR_TAB_KEY,
+  RIGHT_SIDEBAR_COSTS_WIDTH_KEY,
+  RIGHT_SIDEBAR_REVIEW_WIDTH_KEY,
+} from "@/common/constants/storage";
 import type { ComponentType } from "react";
 import type { MockSessionUsage } from "../../../.storybook/mocks/orpc";
 
@@ -65,6 +69,9 @@ export const CostsTab: AppStory = {
     <AppWithMocks
       setup={() => {
         localStorage.setItem(RIGHT_SIDEBAR_TAB_KEY, JSON.stringify("costs"));
+        // Set per-tab widths: costs at 350px, review at 700px
+        localStorage.setItem(RIGHT_SIDEBAR_COSTS_WIDTH_KEY, "350");
+        localStorage.setItem(RIGHT_SIDEBAR_REVIEW_WIDTH_KEY, "700");
 
         return setupSimpleChatStory({
           workspaceId: "ws-costs",
@@ -96,12 +103,16 @@ export const CostsTab: AppStory = {
 
 /**
  * Review tab selected - click switches from Costs to Review tab
+ * Verifies per-tab width persistence: starts at Costs width (350px), switches to Review width (700px)
  */
 export const ReviewTab: AppStory = {
   render: () => (
     <AppWithMocks
       setup={() => {
         localStorage.setItem(RIGHT_SIDEBAR_TAB_KEY, JSON.stringify("costs"));
+        // Set distinct widths per tab to verify switching behavior
+        localStorage.setItem(RIGHT_SIDEBAR_COSTS_WIDTH_KEY, "350");
+        localStorage.setItem(RIGHT_SIDEBAR_REVIEW_WIDTH_KEY, "700");
 
         return setupSimpleChatStory({
           workspaceId: "ws-review",

--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -240,6 +240,19 @@ export const RIGHT_SIDEBAR_TAB_KEY = "right-sidebar-tab";
 export const RIGHT_SIDEBAR_COLLAPSED_KEY = "right-sidebar:collapsed";
 
 /**
+ * Right sidebar width for Costs tab (global)
+ * Format: "right-sidebar:width:costs"
+ */
+export const RIGHT_SIDEBAR_COSTS_WIDTH_KEY = "right-sidebar:width:costs";
+
+/**
+ * Right sidebar width for Review tab (global)
+ * Reuses legacy key to preserve existing user preferences
+ * Format: "review-sidebar-width"
+ */
+export const RIGHT_SIDEBAR_REVIEW_WIDTH_KEY = "review-sidebar-width";
+
+/**
  * Get the localStorage key for unified Review search state per workspace
  * Stores: { input: string, useRegex: boolean, matchCase: boolean }
  * Format: "reviewSearchState:{workspaceId}"


### PR DESCRIPTION
## Summary

- **Costs tab**: default 300px, remembers last resized width
- **Review tab**: default 600px, remembers last resized width  
- Switching tabs immediately swaps to that tab's saved width with smooth 200ms transition
- Review tab reuses legacy `review-sidebar-width` key for backwards compatibility

## Changes

- Added `RIGHT_SIDEBAR_COSTS_WIDTH_KEY` and `RIGHT_SIDEBAR_REVIEW_WIDTH_KEY` storage constants
- `AIView` now tracks selected tab and uses separate `useResizableSidebar` hooks per tab
- Transition animation enabled when not actively resizing

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_