### PR TITLE
🤖 fix: preserve OpenAI reasoning providerMetadata for Responses API

### DIFF
--- a/src/common/orpc/schemas/message.ts
+++ b/src/common/orpc/schemas/message.ts
@@ -16,6 +16,7 @@ export const MuxReasoningPartSchema = z.object({
   type: z.literal("reasoning"),
   text: z.string(),
   timestamp: z.number().optional(),
+  providerMetadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 // Base schema for tool parts - shared fields

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -145,6 +145,9 @@ export interface MuxReasoningPart {
   type: "reasoning";
   text: string;
   timestamp?: number;
+  // Provider-specific metadata (e.g., OpenAI itemId for Responses API)
+  // Required to reconstruct reasoning parts when sending back to the provider
+  providerMetadata?: Record<string, unknown>;
 }
 
 // File/Image part type for multimodal messages (matches AI SDK FileUIPart)


### PR DESCRIPTION
## Problem

When using OpenAI reasoning models (o1, o3-mini, etc.), mux was showing warnings:

```
AI SDK Warning: Non-OpenAI reasoning parts are not supported. Skipping reasoning part: {"type":"reasoning","text":"..."}
```

This occurred because:
1. OpenAI's Responses API returns reasoning parts with `providerMetadata.openai.itemId` which is required when sending reasoning parts back in subsequent requests. mux wasn't capturing this metadata.
2. When conversation history contained reasoning from non-OpenAI models (e.g., Claude extended thinking), those parts would cause warnings when sent to OpenAI since they don't have the required `itemId`.

## Solution

### Capture providerMetadata from OpenAI reasoning streams
- Add `providerMetadata` field to `MuxReasoningPart` type
- Update `streamManager.ts` to capture `providerMetadata` from reasoning-delta events
- Use SDK's `delta` field (not `text`) for reasoning content

### Filter non-OpenAI reasoning before sending to OpenAI
- Add `filterNonOpenAIReasoningParts()` function that strips reasoning parts without `providerOptions.openai.itemId`
- Apply filter BEFORE coalescing to prevent mixing non-OpenAI reasoning with valid OpenAI reasoning

The AI SDK's `convertToModelMessages()` maps `providerMetadata` → `providerOptions`, so storing it on reasoning parts ensures proper round-tripping.

## Testing

- All unit tests pass (1851 tests)
- Static checks pass
- Added 3 new tests for non-OpenAI reasoning filtering
- Updated existing tests to include required `providerOptions.openai.itemId`

---
_Generated with `mux` • Model: `claude-sonnet-4-20250514` • Thinking: `low`_