### PR TITLE
🤖 feat: add connection status indicator for mux server

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -48,6 +48,7 @@ import { SettingsProvider, useSettings } from "./contexts/SettingsContext";
 import { SettingsModal } from "./components/Settings/SettingsModal";
 import { SplashScreenProvider } from "./components/splashScreens/SplashScreenProvider";
 import { TutorialProvider } from "./contexts/TutorialContext";
+import { ConnectionStatusIndicator } from "./components/ConnectionStatusIndicator";
 import { TooltipProvider } from "./components/ui/tooltip";
 import { ExperimentsProvider } from "./contexts/ExperimentsContext";
 import { getWorkspaceSidebarKey } from "./utils/workspace";
@@ -630,6 +631,7 @@ function AppInner() {
                   <ModeProvider projectPath={projectPath}>
                     <ProviderOptionsProvider>
                       <ThinkingProvider projectPath={projectPath}>
+                        <ConnectionStatusIndicator />
                         <ChatInput
                           variant="creation"
                           projectPath={projectPath}

--- a/src/browser/components/AIView.tsx
+++ b/src/browser/components/AIView.tsx
@@ -70,6 +70,7 @@ import { useReviews } from "@/browser/hooks/useReviews";
 import { ReviewsBanner } from "./ReviewsBanner";
 import type { ReviewNoteData } from "@/common/types/review";
 import { PopoverError } from "./PopoverError";
+import { ConnectionStatusIndicator } from "./ConnectionStatusIndicator";
 
 interface AIViewProps {
   workspaceId: string;
@@ -756,6 +757,7 @@ const AIViewInner: React.FC<AIViewProps> = ({
           onTerminate={handleTerminateBackgroundBash}
         />
         <ReviewsBanner workspaceId={workspaceId} />
+        <ConnectionStatusIndicator />
         <ChatInput
           variant="workspace"
           workspaceId={workspaceId}

--- a/src/browser/components/ConnectionStatusIndicator.tsx
+++ b/src/browser/components/ConnectionStatusIndicator.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { useAPI } from "@/browser/contexts/API";
+
+/**
+ * Displays connection status to the user when not fully connected.
+ * - degraded: pings failing but WebSocket open (yellow warning)
+ * - reconnecting: WebSocket closed, attempting reconnect (yellow warning with attempt count)
+ * - error: failed to reconnect (red error with retry button)
+ *
+ * Does not render when connected or connecting (initial load).
+ */
+export const ConnectionStatusIndicator: React.FC = () => {
+  const apiState = useAPI();
+
+  // Don't show anything when connected or during initial connection
+  if (apiState.status === "connected" || apiState.status === "connecting") {
+    return null;
+  }
+
+  // Auth required is handled by a separate modal flow
+  if (apiState.status === "auth_required") {
+    return null;
+  }
+
+  if (apiState.status === "degraded") {
+    return (
+      <div className="flex items-center justify-center gap-2 py-1 text-xs text-yellow-600">
+        <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-yellow-500" />
+        <span>Connection unstable — messages may be delayed</span>
+      </div>
+    );
+  }
+
+  if (apiState.status === "reconnecting") {
+    return (
+      <div className="flex items-center justify-center gap-2 py-1 text-xs text-yellow-600">
+        <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-yellow-500" />
+        <span>
+          Reconnecting to server
+          {apiState.attempt > 1 && ` (attempt ${apiState.attempt})`}…
+        </span>
+      </div>
+    );
+  }
+
+  if (apiState.status === "error") {
+    return (
+      <div className="flex items-center justify-center gap-2 py-1 text-xs text-red-500">
+        <span className="inline-block h-2 w-2 rounded-full bg-red-500" />
+        <span>Connection lost</span>
+        <button type="button" onClick={apiState.retry} className="underline hover:no-underline">
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return null;
+};


### PR DESCRIPTION
## Summary

When using mux in server mode (browser), messages typed in the chat sometimes don't appear or are silently lost. This PR adds a client-side liveness check and UI indicator to surface connection issues to the user.

## Changes

### API Context Enhancement
- Added periodic ping-based liveness check (every 5s with 3s timeout)
- Introduced new `degraded` connection status for when pings fail but WebSocket is still open
- After 2 consecutive ping failures, status transitions from `connected` → `degraded`
- Successful ping restores `degraded` → `connected`

### New ConnectionStatusIndicator Component
- Shows nothing when connected or during initial connection
- Yellow pulsing indicator + "Connection unstable — messages may be delayed" for degraded state
- Yellow indicator + "Reconnecting to server (attempt N)..." for reconnecting state  
- Red indicator + "Connection lost" with Retry button for error state

### Integration
- Added to AIView (workspace variant) above ChatInput
- Added to App.tsx (creation variant) for consistency

## Testing
- Existing API tests pass
- Typecheck, lint, and static-check all pass
- The liveness check only runs for browser WebSocket connections (not Electron or test clients)

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_