### PR TITLE
🤖 fix: softer question indicator color + Enter key to advance

### DIFF
--- a/src/browser/components/WorkspaceStatusIndicator.tsx
+++ b/src/browser/components/WorkspaceStatusIndicator.tsx
@@ -10,7 +10,7 @@ export const WorkspaceStatusIndicator = memo<{ workspaceId: string }>(({ workspa
   // Show prompt when ask_user_question is pending - make it prominent
   if (awaitingUserQuestion) {
     return (
-      <div className="flex min-w-0 items-center gap-1.5 rounded bg-yellow-500/20 px-1.5 py-0.5 text-xs text-yellow-400">
+      <div className="bg-plan-mode-alpha text-plan-mode-light flex min-w-0 items-center gap-1.5 rounded px-1.5 py-0.5 text-xs">
         <span className="-mt-0.5 shrink-0 text-[10px]">❓</span>
         <span className="min-w-0 truncate font-medium">Mux has a few questions</span>
       </div>

--- a/src/browser/components/tools/AskUserQuestionToolCall.tsx
+++ b/src/browser/components/tools/AskUserQuestionToolCall.tsx
@@ -504,6 +504,12 @@ export function AskUserQuestionToolCall(props: {
                               },
                             }));
                           }}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter" && currentDraft.otherText.trim().length > 0) {
+                              e.preventDefault();
+                              setActiveIndex(activeIndex + 1);
+                            }
+                          }}
                         />
                       )}
                     </div>


### PR DESCRIPTION
Fix two issues with the `ask_user_question` tool UI:

1. **Softer indicator color** - The "Mux has a few questions" status indicator was using a bright yellow that was harsh on the eyes. Changed to plan-mode blue which is softer and semantically indicates "awaiting user input".

2. **Enter key advances** - When selecting "Other" and typing a free-text answer, pressing Enter now advances to the next question (when text is non-empty).

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Fix ask_user_question UI Issues

## Summary

Fix two issues:
1. Replace eye-burning bright yellow "Mux has a few questions" indicator with a softer color
2. Add Enter key handling to advance from "Other" text input

**Estimated net LoC:** +8

---

## Issue 1: Overly Bright Yellow Status Indicator

**Problem:** The "Mux has a few questions" indicator in `WorkspaceStatusIndicator.tsx` uses hardcoded `bg-yellow-500/20 text-yellow-400` which is too bright/harsh.

**Solution:** Use the app's plan-mode blue (`bg-plan-mode-alpha text-plan-mode-light`) for consistency with "waiting for input" semantics.

---

## Issue 2: Enter Key Doesn't Advance from Other Input

**Problem:** When the user selects "Other" and types a free-text answer, pressing Enter does nothing.

**Solution:** Add `onKeyDown` handler to the Input that advances to the next question when Enter is pressed and text is non-empty.

</details>

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
