### PR TITLE
🤖 feat: show auto-compaction indicator in context bar tooltip

### DIFF
--- a/src/browser/components/ContextUsageIndicatorButton.tsx
+++ b/src/browser/components/ContextUsageIndicatorButton.tsx
@@ -45,7 +45,7 @@ export const ContextUsageIndicatorButton: React.FC<ContextUsageIndicatorButtonPr
           </PopoverTrigger>
         </TooltipTrigger>
         <TooltipContent side="bottom" align="end" className="w-80">
-          <ContextUsageBar data={data} />
+          <ContextUsageBar data={data} autoCompactionThreshold={autoCompaction?.threshold} />
         </TooltipContent>
       </Tooltip>
 

--- a/src/browser/components/RightSidebar/ContextUsageBar.tsx
+++ b/src/browser/components/RightSidebar/ContextUsageBar.tsx
@@ -1,12 +1,18 @@
 import React from "react";
 import { TokenMeter } from "./TokenMeter";
-import { HorizontalThresholdSlider, type AutoCompactionConfig } from "./ThresholdSlider";
+import {
+  HorizontalThresholdSlider,
+  HorizontalThresholdIndicator,
+  type AutoCompactionConfig,
+} from "./ThresholdSlider";
 import { formatTokens, type TokenMeterData } from "@/common/utils/tokens/tokenMeterUtils";
 
 interface ContextUsageBarProps {
   data: TokenMeterData;
   /** Auto-compaction settings for threshold slider */
   autoCompaction?: AutoCompactionConfig;
+  /** Show text-only indicator for auto-compaction threshold (for tooltips) */
+  autoCompactionThreshold?: number;
   showTitle?: boolean;
   testId?: string;
 }
@@ -14,6 +20,7 @@ interface ContextUsageBarProps {
 const ContextUsageBarComponent: React.FC<ContextUsageBarProps> = ({
   data,
   autoCompaction,
+  autoCompactionThreshold,
   showTitle = true,
   testId,
 }) => {
@@ -24,6 +31,10 @@ const ContextUsageBarComponent: React.FC<ContextUsageBarProps> = ({
   const percentageDisplay = data.maxTokens ? ` (${data.totalPercentage.toFixed(1)}%)` : "";
 
   const showWarning = !data.maxTokens;
+
+  // Show read-only indicator when threshold provided but no interactive config
+  const showReadOnlyIndicator =
+    autoCompactionThreshold !== undefined && !autoCompaction && data.maxTokens;
 
   return (
     <div data-testid={testId} className="relative flex flex-col gap-1">
@@ -43,6 +54,9 @@ const ContextUsageBarComponent: React.FC<ContextUsageBarProps> = ({
       <div className="relative w-full py-2">
         <TokenMeter segments={data.segments} orientation="horizontal" />
         {autoCompaction && data.maxTokens && <HorizontalThresholdSlider config={autoCompaction} />}
+        {showReadOnlyIndicator && (
+          <HorizontalThresholdIndicator threshold={autoCompactionThreshold} />
+        )}
       </div>
 
       {showWarning && (

--- a/src/browser/components/RightSidebar/ThresholdSlider.tsx
+++ b/src/browser/components/RightSidebar/ThresholdSlider.tsx
@@ -279,3 +279,56 @@ export const HorizontalThresholdSlider: React.FC<{ config: AutoCompactionConfig 
 export const VerticalThresholdSlider: React.FC<{ config: AutoCompactionConfig }> = ({ config }) => (
   <ThresholdSlider config={config} orientation="vertical" />
 );
+
+// ----- Read-only indicator (for tooltips) -----
+
+interface ThresholdIndicatorProps {
+  /** Threshold percentage (0-100). 100 means disabled. */
+  threshold: number;
+}
+
+/**
+ * A read-only visual indicator showing the auto-compaction threshold position.
+ * Shows the same notch markers as the interactive slider, but without drag functionality.
+ * Designed for use in tooltips where interaction isn't possible.
+ */
+export const HorizontalThresholdIndicator: React.FC<ThresholdIndicatorProps> = ({ threshold }) => {
+  const isEnabled = threshold < DISABLE_THRESHOLD;
+  const color = isEnabled ? "var(--color-plan-mode)" : "var(--color-muted)";
+
+  // Container covers the full bar area
+  const containerStyle: React.CSSProperties = {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    zIndex: 50,
+    pointerEvents: "none",
+  };
+
+  // Indicator positioning
+  const indicatorStyle: React.CSSProperties = {
+    position: "absolute",
+    pointerEvents: "none",
+    display: "flex",
+    alignItems: "center",
+    left: `${threshold}%`,
+    top: "50%",
+    transform: "translate(-50%, -50%)",
+    flexDirection: "column",
+  };
+
+  // Line between triangles
+  const lineStyle: React.CSSProperties = { width: 1, height: 6, background: color };
+
+  return (
+    <div style={containerStyle}>
+      <div style={indicatorStyle}>
+        <Triangle direction="down" color={color} />
+        <div style={lineStyle} />
+        <Triangle direction="up" color={color} />
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
Add a threshold indicator to the context usage tooltip. When hovering over the context bar, users now see the current auto-compaction setting.

The popover (click) continues to show the interactive slider for adjusting the threshold.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_