### PR TITLE
🤖 docs: require checking env vars for PR attribution

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -17,7 +17,7 @@ description: Agent instructions for AI assistants working on the mux codebase
   <!-- mux-attribution: model=<modelString> thinking=<thinkingLevel> -->
   ```
 
-  Prefer sourcing values from `$MUX_MODEL_STRING` and `$MUX_THINKING_LEVEL` (bash tool env).
+  Always check `$MUX_MODEL_STRING` and `$MUX_THINKING_LEVEL` via bash before creating PRs—include them in the footer if set.
 
 ## PR + Release Workflow
 


### PR DESCRIPTION
## Problem

AGENTS.md used soft language ("Prefer sourcing values from...") for the `$MUX_MODEL_STRING` and `$MUX_THINKING_LEVEL` env vars, which agents ignored—they guessed values instead of checking.

## Solution

Changed to explicit requirement: "Always check ... via bash before creating PRs—include them in the footer if set."

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high -->