### PR TITLE
🤖 feat: persist per-workspace model + thinking

### DIFF
--- a/src/browser/components/ChatInput/useCreationWorkspace.test.tsx
+++ b/src/browser/components/ChatInput/useCreationWorkspace.test.tsx
@@ -7,6 +7,7 @@ import {
   getModeKey,
   getPendingScopeId,
   getProjectScopeId,
+  getThinkingLevelKey,
 } from "@/common/constants/storage";
 import type { SendMessageError as _SendMessageError } from "@/common/types/errors";
 import type { WorkspaceChatMessage } from "@/common/orpc/types";
@@ -83,11 +84,18 @@ type ListBranchesArgs = Parameters<APIClient["projects"]["listBranches"]>[0];
 type WorkspaceSendMessageArgs = Parameters<APIClient["workspace"]["sendMessage"]>[0];
 type WorkspaceSendMessageResult = Awaited<ReturnType<APIClient["workspace"]["sendMessage"]>>;
 type WorkspaceCreateArgs = Parameters<APIClient["workspace"]["create"]>[0];
+type WorkspaceUpdateAISettingsArgs = Parameters<APIClient["workspace"]["updateAISettings"]>[0];
+type WorkspaceUpdateAISettingsResult = Awaited<
+  ReturnType<APIClient["workspace"]["updateAISettings"]>
+>;
 type WorkspaceCreateResult = Awaited<ReturnType<APIClient["workspace"]["create"]>>;
 type NameGenerationArgs = Parameters<APIClient["nameGeneration"]["generate"]>[0];
 type NameGenerationResult = Awaited<ReturnType<APIClient["nameGeneration"]["generate"]>>;
 type MockOrpcProjectsClient = Pick<APIClient["projects"], "listBranches">;
-type MockOrpcWorkspaceClient = Pick<APIClient["workspace"], "sendMessage" | "create">;
+type MockOrpcWorkspaceClient = Pick<
+  APIClient["workspace"],
+  "sendMessage" | "create" | "updateAISettings"
+>;
 type MockOrpcNameGenerationClient = Pick<APIClient["nameGeneration"], "generate">;
 type WindowWithApi = Window & typeof globalThis;
 type WindowApi = WindowWithApi["api"];
@@ -114,6 +122,9 @@ interface SetupWindowOptions {
   sendMessage?: ReturnType<
     typeof mock<(args: WorkspaceSendMessageArgs) => Promise<WorkspaceSendMessageResult>>
   >;
+  updateAISettings?: ReturnType<
+    typeof mock<(args: WorkspaceUpdateAISettingsArgs) => Promise<WorkspaceUpdateAISettingsResult>>
+  >;
   create?: ReturnType<typeof mock<(args: WorkspaceCreateArgs) => Promise<WorkspaceCreateResult>>>;
   nameGeneration?: ReturnType<
     typeof mock<(args: NameGenerationArgs) => Promise<NameGenerationResult>>
@@ -124,6 +135,7 @@ const setupWindow = ({
   listBranches,
   sendMessage,
   create,
+  updateAISettings,
   nameGeneration,
 }: SetupWindowOptions = {}) => {
   const listBranchesMock =
@@ -157,6 +169,15 @@ const setupWindow = ({
       } as WorkspaceCreateResult);
     });
 
+  const updateAISettingsMock =
+    updateAISettings ??
+    mock<(args: WorkspaceUpdateAISettingsArgs) => Promise<WorkspaceUpdateAISettingsResult>>(() => {
+      return Promise.resolve({
+        success: true,
+        data: undefined,
+      } as WorkspaceUpdateAISettingsResult);
+    });
+
   const nameGenerationMock =
     nameGeneration ??
     mock<(args: NameGenerationArgs) => Promise<NameGenerationResult>>(() => {
@@ -176,6 +197,7 @@ const setupWindow = ({
     workspace: {
       sendMessage: (input: WorkspaceSendMessageArgs) => sendMessageMock(input),
       create: (input: WorkspaceCreateArgs) => createMock(input),
+      updateAISettings: (input: WorkspaceUpdateAISettingsArgs) => updateAISettingsMock(input),
     },
     nameGeneration: {
       generate: (input: NameGenerationArgs) => nameGenerationMock(input),
@@ -213,6 +235,7 @@ const setupWindow = ({
     workspace: {
       list: rejectNotImplemented("workspace.list"),
       create: (args: WorkspaceCreateArgs) => createMock(args),
+      updateAISettings: (args: WorkspaceUpdateAISettingsArgs) => updateAISettingsMock(args),
       remove: rejectNotImplemented("workspace.remove"),
       rename: rejectNotImplemented("workspace.rename"),
       fork: rejectNotImplemented("workspace.fork"),
@@ -278,7 +301,11 @@ const setupWindow = ({
 
   return {
     projectsApi: { listBranches: listBranchesMock },
-    workspaceApi: { sendMessage: sendMessageMock, create: createMock },
+    workspaceApi: {
+      sendMessage: sendMessageMock,
+      create: createMock,
+      updateAISettings: updateAISettingsMock,
+    },
     nameGenerationApi: { generate: nameGenerationMock },
   };
 };
@@ -466,7 +493,7 @@ describe("useCreationWorkspace", () => {
     const pendingInputKey = getInputKey(pendingScopeId);
     const pendingImagesKey = getInputImagesKey(pendingScopeId);
     expect(updatePersistedStateCalls).toContainEqual([modeKey, "plan"]);
-    // Note: thinking level is no longer synced per-workspace, it's stored per-model globally
+    // Thinking is workspace-scoped, but this test doesn't set a project-scoped thinking preference.
     expect(updatePersistedStateCalls).toContainEqual([pendingInputKey, ""]);
     expect(updatePersistedStateCalls).toContainEqual([pendingImagesKey, undefined]);
   });
@@ -510,7 +537,10 @@ describe("useCreationWorkspace", () => {
     expect(onWorkspaceCreated.mock.calls.length).toBe(0);
     await waitFor(() => expect(getHook().toast?.message).toBe("backend exploded"));
     await waitFor(() => expect(getHook().isSending).toBe(false));
-    expect(updatePersistedStateCalls).toEqual([]);
+
+    // Side effect: send-options reader may migrate thinking level into the project scope.
+    const thinkingKey = getThinkingLevelKey(getProjectScopeId(TEST_PROJECT_PATH));
+    expect(updatePersistedStateCalls).toEqual([[thinkingKey, "off"]]);
   });
 });
 

--- a/src/browser/components/ThinkingSlider.tsx
+++ b/src/browser/components/ThinkingSlider.tsx
@@ -199,7 +199,7 @@ export const ThinkingSliderComponent: React.FC<ThinkingControlProps> = ({ modelS
         </div>
       </TooltipTrigger>
       <TooltipContent align="center">
-        Thinking: {formatKeybind(KEYBINDS.TOGGLE_THINKING)} to cycle. Saved per model.
+        Thinking: {formatKeybind(KEYBINDS.TOGGLE_THINKING)} to cycle. Saved per workspace.
       </TooltipContent>
     </Tooltip>
   );

--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -58,8 +58,18 @@ export function getMCPTestResultsKey(projectPath: string): string {
 }
 
 /**
- * Get the localStorage key for thinking level preference per model (global)
+ * Get the localStorage key for thinking level preference per scope (workspace/project).
+ * Format: "thinkingLevel:{scopeId}"
+ */
+export function getThinkingLevelKey(scopeId: string): string {
+  return `thinkingLevel:${scopeId}`;
+}
+
+/**
+ * LEGACY: Get the localStorage key for thinking level preference per model (global).
  * Format: "thinkingLevel:model:{modelName}"
+ *
+ * Kept for one-time migration to per-workspace thinking.
  */
 export function getThinkingLevelByModelKey(modelName: string): string {
   return `thinkingLevel:model:${modelName}`;
@@ -306,6 +316,7 @@ const PERSISTENT_WORKSPACE_KEY_FUNCTIONS: Array<(workspaceId: string) => string>
   getInputKey,
   getInputImagesKey,
   getModeKey,
+  getThinkingLevelKey,
   getAutoRetryKey,
   getRetryStateKey,
   getReviewStateKey,
@@ -315,7 +326,7 @@ const PERSISTENT_WORKSPACE_KEY_FUNCTIONS: Array<(workspaceId: string) => string>
   getReviewsKey,
   getAutoCompactionEnabledKey,
   getStatusStateKey,
-  // Note: thinking level and auto-compaction threshold are per-model, not per-workspace
+  // Note: auto-compaction threshold is per-model, not per-workspace
 ];
 
 /**

--- a/src/common/orpc/schemas.ts
+++ b/src/common/orpc/schemas.ts
@@ -11,6 +11,7 @@ export { RuntimeConfigSchema, RuntimeModeSchema } from "./schemas/runtime";
 export { ProjectConfigSchema, WorkspaceConfigSchema } from "./schemas/project";
 
 // Workspace schemas
+export { WorkspaceAISettingsSchema } from "./schemas/workspaceAiSettings";
 export {
   FrontendWorkspaceMetadataSchema,
   GitStatusSchema,

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -15,6 +15,7 @@ import {
 } from "./terminal";
 import { BashToolResultSchema, FileTreeNodeSchema } from "./tools";
 import { FrontendWorkspaceMetadataSchema, WorkspaceActivitySnapshotSchema } from "./workspace";
+import { WorkspaceAISettingsSchema } from "./workspaceAiSettings";
 import {
   MCPAddParamsSchema,
   MCPRemoveParamsSchema,
@@ -249,6 +250,13 @@ export const workspace = {
   },
   updateTitle: {
     input: z.object({ workspaceId: z.string(), title: z.string() }),
+    output: ResultSchema(z.void(), z.string()),
+  },
+  updateAISettings: {
+    input: z.object({
+      workspaceId: z.string(),
+      aiSettings: WorkspaceAISettingsSchema,
+    }),
     output: ResultSchema(z.void(), z.string()),
   },
   fork: {

--- a/src/common/orpc/schemas/project.ts
+++ b/src/common/orpc/schemas/project.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { RuntimeConfigSchema } from "./runtime";
 import { WorkspaceMCPOverridesSchema } from "./mcp";
+import { WorkspaceAISettingsSchema } from "./workspaceAiSettings";
 
 export const WorkspaceConfigSchema = z.object({
   path: z.string().meta({
@@ -22,6 +23,9 @@ export const WorkspaceConfigSchema = z.object({
     .meta({ description: "ISO 8601 creation timestamp - optional for legacy" }),
   runtimeConfig: RuntimeConfigSchema.optional().meta({
     description: "Runtime configuration (local vs SSH) - optional, defaults to local",
+  }),
+  aiSettings: WorkspaceAISettingsSchema.optional().meta({
+    description: "Workspace-scoped AI settings (model + thinking level)",
   }),
   mcp: WorkspaceMCPOverridesSchema.optional().meta({
     description: "Per-workspace MCP overrides (disabled servers, tool allowlists)",

--- a/src/common/orpc/schemas/workspace.ts
+++ b/src/common/orpc/schemas/workspace.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { RuntimeConfigSchema } from "./runtime";
+import { WorkspaceAISettingsSchema } from "./workspaceAiSettings";
 
 export const WorkspaceMetadataSchema = z.object({
   id: z.string().meta({
@@ -25,6 +26,9 @@ export const WorkspaceMetadataSchema = z.object({
   }),
   runtimeConfig: RuntimeConfigSchema.meta({
     description: "Runtime configuration for this workspace (always set, defaults to local on load)",
+  }),
+  aiSettings: WorkspaceAISettingsSchema.optional().meta({
+    description: "Workspace-scoped AI settings (model + thinking level) persisted in config",
   }),
   status: z.enum(["creating"]).optional().meta({
     description:

--- a/src/common/orpc/schemas/workspaceAiSettings.ts
+++ b/src/common/orpc/schemas/workspaceAiSettings.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+/**
+ * Workspace-scoped AI settings that should persist across devices.
+ *
+ * Notes:
+ * - `model` must be canonical "provider:model" (NOT mux-gateway:provider/model).
+ * - `thinkingLevel` is workspace-scoped (saved per workspace, not per-model).
+ */
+export const WorkspaceAISettingsSchema = z.object({
+  model: z.string().meta({ description: 'Canonical model id in the form "provider:model"' }),
+  thinkingLevel: z.enum(["off", "low", "medium", "high", "xhigh"]).meta({
+    description: "Thinking/reasoning effort level",
+  }),
+});

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -301,6 +301,7 @@ export class Config {
               createdAt: workspace.createdAt ?? new Date().toISOString(),
               // GUARANTEE: All workspaces must have runtimeConfig (apply default if missing)
               runtimeConfig: workspace.runtimeConfig ?? DEFAULT_RUNTIME_CONFIG,
+              aiSettings: workspace.aiSettings,
             };
 
             // Migrate missing createdAt to config for next load
@@ -340,6 +341,9 @@ export class Config {
             // GUARANTEE: All workspaces must have runtimeConfig
             metadata.runtimeConfig ??= DEFAULT_RUNTIME_CONFIG;
 
+            // Preserve any config-only fields that may not exist in legacy metadata.json
+            metadata.aiSettings ??= workspace.aiSettings;
+
             // Migrate to config for next load
             workspace.id = metadata.id;
             workspace.name = metadata.name;
@@ -363,6 +367,7 @@ export class Config {
               createdAt: new Date().toISOString(),
               // GUARANTEE: All workspaces must have runtimeConfig
               runtimeConfig: DEFAULT_RUNTIME_CONFIG,
+              aiSettings: workspace.aiSettings,
             };
 
             // Save to config for next load
@@ -387,6 +392,7 @@ export class Config {
             createdAt: new Date().toISOString(),
             // GUARANTEE: All workspaces must have runtimeConfig (even in error cases)
             runtimeConfig: DEFAULT_RUNTIME_CONFIG,
+            aiSettings: workspace.aiSettings,
           };
           workspaceMetadata.push(this.addPathsToMetadata(metadata, workspace.path, projectPath));
         }

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -365,6 +365,12 @@ export const router = (authToken?: string) => {
         .handler(async ({ context, input }) => {
           return context.workspaceService.updateTitle(input.workspaceId, input.title);
         }),
+      updateAISettings: t
+        .input(schemas.workspace.updateAISettings.input)
+        .output(schemas.workspace.updateAISettings.output)
+        .handler(async ({ context, input }) => {
+          return context.workspaceService.updateAISettings(input.workspaceId, input.aiSettings);
+        }),
       fork: t
         .input(schemas.workspace.fork.input)
         .output(schemas.workspace.fork.output)

--- a/tests/ipc/workspaceAISettings.test.ts
+++ b/tests/ipc/workspaceAISettings.test.ts
@@ -1,0 +1,51 @@
+/**
+ * IPC tests for workspace-scoped AI settings persistence.
+ *
+ * Verifies that model + thinking level can be persisted per workspace and
+ * are returned via metadata APIs (list/getInfo).
+ */
+
+import { createTestEnvironment, cleanupTestEnvironment } from "./setup";
+import type { TestEnvironment } from "./setup";
+import {
+  createTempGitRepo,
+  cleanupTempGitRepo,
+  generateBranchName,
+  createWorkspace,
+} from "./helpers";
+import { resolveOrpcClient } from "./helpers";
+
+describe("workspace.updateAISettings", () => {
+  test("persists aiSettings and returns them via workspace.getInfo and workspace.list", async () => {
+    const env: TestEnvironment = await createTestEnvironment();
+    const tempGitRepo = await createTempGitRepo();
+
+    try {
+      const branchName = generateBranchName("ai-settings");
+      const createResult = await createWorkspace(env, tempGitRepo, branchName);
+      if (!createResult.success) {
+        throw new Error(`Workspace creation failed: ${createResult.error}`);
+      }
+
+      const workspaceId = createResult.metadata.id;
+      expect(workspaceId).toBeTruthy();
+
+      const client = resolveOrpcClient(env);
+      const updateResult = await client.workspace.updateAISettings({
+        workspaceId: workspaceId!,
+        aiSettings: { model: "openai:gpt-5.2", thinkingLevel: "xhigh" },
+      });
+      expect(updateResult.success).toBe(true);
+
+      const info = await client.workspace.getInfo({ workspaceId: workspaceId! });
+      expect(info?.aiSettings).toEqual({ model: "openai:gpt-5.2", thinkingLevel: "xhigh" });
+
+      const list = await client.workspace.list({ includePostCompaction: false });
+      const fromList = list.find((m) => m.id === workspaceId);
+      expect(fromList?.aiSettings).toEqual({ model: "openai:gpt-5.2", thinkingLevel: "xhigh" });
+    } finally {
+      await cleanupTestEnvironment(env);
+      await cleanupTempGitRepo(tempGitRepo);
+    }
+  }, 60000);
+});


### PR DESCRIPTION
Persist per-workspace model and thinking/reasoning level on the backend so that opening the same workspace from another browser/device restores the same AI configuration.

### Changes

- **New shared schema** `WorkspaceAISettings` (`model`, `thinkingLevel`) added to workspace config and metadata schemas.
- **New ORPC endpoint** `workspace.updateAISettings` to explicitly persist settings changes.
- **Backend safety net**: `sendMessage` and `resumeStream` also persist "last used" settings for older/CLI clients.
- **Frontend thinking is now workspace-scoped** (`thinkingLevel:{workspaceId}`) with migration from legacy per-model keys.
- **LocalStorage seeding from backend metadata** ensures cross-device convergence.
- **UI changes back-persist** model and thinking to backend immediately.
- **Creation flow** copies project-scoped preferences and best-effort persists to backend.

### Testing

- Updated `ThinkingContext.test.tsx` for workspace-scoped thinking + migration.
- Added `WorkspaceContext.test.tsx` test for backend metadata seeding localStorage.
- Added IPC test `tests/ipc/workspaceAISettings.test.ts` verifying persistence + list/getInfo.

---

<details>
<summary>📋 Implementation Plan</summary>

# Persist per-workspace model + reasoning (thinking) on the backend

## Goal
Make **model selection** and **thinking/reasoning level**:
- **Workspace-scoped** (not per-model, not global)
- **Persisted server-side** so opening the same workspace from another browser/device restores the same configuration

Non-goals (for this change): persisting provider options (e.g. truncation), global default model, or draft input.

---

## Recommended approach (net +250–400 LoC product)
### 1) Define a single workspace AI settings shape (shared types)
**Why:** avoid ad-hoc keys and keep the IPC/API boundary strongly typed.

- Add a reusable schema/type (common):
  - `WorkspaceAISettings`:
    - `model: string` (canonical `provider:model`, *not* `mux-gateway:provider/model`)
    - `thinkingLevel: ThinkingLevel` (`off|low|medium|high|xhigh`)

- Extend persisted config shape:
  - `WorkspaceConfigSchema` (in `src/common/orpc/schemas/project.ts`): add optional `aiSettings?: WorkspaceAISettings`

- Extend workspace metadata returned to clients:
  - `WorkspaceMetadataSchema` (in `src/common/orpc/schemas/workspace.ts`): add optional `aiSettings?: WorkspaceAISettings`
  - (Frontend schema automatically inherits via `FrontendWorkspaceMetadataSchema.extend(...)`)

### 2) Backend: persist + serve workspace AI settings
**Persistence location:** `~/.mux/config.json` under each workspace entry (alongside `runtimeConfig`, `mcp`, etc.)

#### 2.1 Add an API to update settings explicitly
- Add a new ORPC endpoint:
  - `workspace.updateAISettings` (name bikesheddable)
  - Input: `{ workspaceId: string, aiSettings: WorkspaceAISettings }`
  - Output: `Result<void, string>`

- Node implementation (`WorkspaceService`):
  - Validate workspace exists via `config.findWorkspace(workspaceId)`.
  - `config.editConfig(...)` to locate the workspace entry and set `workspaceEntry.aiSettings = normalizedSettings`.
  - **Normalize defensively**:
    - `model = normalizeGatewayModel(model)` (from `src/common/utils/ai/models.ts`)
    - `thinkingLevel = enforceThinkingPolicy(model, thinkingLevel)` (single source of truth)
  - After save, re-fetch via `config.getAllWorkspaceMetadata()` and emit `onMetadata` update *only if the value changed* (avoid spam).

#### 2.2 Also persist “last used” settings on message send (safety net)
Even if a client forgets to call `updateAISettings` (CLI/extension/old client), the backend should learn the last used values.

- In `WorkspaceService.sendMessage(...)` and `resumeStream(...)`:
  - Extract `options.model` + `options.thinkingLevel` and write to `workspaceEntry.aiSettings` (same normalization as above).
  - Only write when different.

> This makes “chatted with it earlier” reliably populate the backend state.

### 3) Frontend: treat backend as source of truth, but keep localStorage as a fast cache
#### 3.1 Change thinking persistence to be **workspace-scoped**
- Add a new storage helper:
  - `getThinkingLevelKey(scopeId: string): string` → `thinkingLevel:${scopeId}`
  - Update `PERSISTENT_WORKSPACE_KEY_FUNCTIONS` to include it (so fork copies it, delete removes it).

- Update `ThinkingProvider` to use **scope-based keying**:
  - Scope priority similar to `ModeProvider`:
    - workspace: `thinkingLevel:{workspaceId}`
    - creation: `thinkingLevel:__project__/{projectPath}`
  - Remove the current “key depends on selected model” behavior.

- Update non-React send option reader:
  - `getSendOptionsFromStorage(...)` should read thinking via `getThinkingLevelKey(scopeId)`.

- Update UI copy:
  - Thinking slider tooltip text from “Saved per model” → “Saved per workspace”.

#### 3.2 Seed localStorage from backend workspace metadata
**Where:** `WorkspaceContext.loadWorkspaceMetadata()` + the `workspace.onMetadata` subscription handler.

- When metadata arrives for a workspace:
  - If `metadata.aiSettings?.model` exists → write it to `localStorage` key `model:{workspaceId}`.
  - If `metadata.aiSettings?.thinkingLevel` exists → write it to `thinkingLevel:{workspaceId}`.
  - Only write when the value differs (avoid unnecessary re-renders from `updatePersistedState`).

This ensures:
- new device with empty localStorage adopts backend settings
- existing device with stale localStorage is corrected to backend

#### 3.3 Persist changes back to the backend when the user changes the UI
- Model changes:
  - In `ChatInput`’s `setPreferredModel(...)` (workspace variant only):
    - Update localStorage as today
    - Call `api.workspace.updateAISettings({ workspaceId, aiSettings: { model, thinkingLevel: currentThinking } })`

- Thinking changes:
  - Wrap `setThinkingLevel` in `ThinkingProvider` (workspace variant only):
    - Update localStorage
    - Call `api.workspace.updateAISettings(...)` with `{ model: currentModel, thinkingLevel: newLevel }`

Notes:
- Use `enforceThinkingPolicy` client-side too (keep UI/BE consistent) but backend remains final authority.
- If `api` is unavailable, keep localStorage update (offline-friendly) and rely on sendMessage persistence later.

#### 3.4 Creation flow
- Keep project-scoped model + thinking in localStorage while creating.
- When a workspace is created:
  - Continue copying project-scoped values into the new workspace-scoped keys (update `syncCreationPreferences` to include thinking).
  - Optionally call `workspace.updateAISettings(...)` right after creation (best effort) so the workspace is immediately portable even before the first message sends.

### 4) Migration + compatibility
- **Config.json:** new `aiSettings` fields are optional → old configs load fine; old mux versions should ignore unknown fields.
- **localStorage:** migrate legacy per-model thinking into the new per-workspace key:
  - On workspace open, if `thinkingLevel:{workspaceId}` is missing:
    - read `model:{workspaceId}` (or default)
    - read old `thinkingLevel:model:{model}`
    - set `thinkingLevel:{workspaceId}` to that value

Put this migration in a single place (e.g., the same “seed from metadata” helper) so it runs once.

---

## Validation / tests
- Update unit tests that assert per-model thinking:
  - `src/browser/contexts/ThinkingContext.test.tsx` should instead verify thinking is stable across model changes (except clamping).
- Add a backend test that `workspace.updateAISettings`:
  - persists into config
  - is returned by `workspace.list/getInfo`
- Add a lightweight frontend test that WorkspaceContext seeding writes the expected localStorage keys when metadata contains `aiSettings`.

---

<details>
<summary>Alternatives considered</summary>

### A) Persist only on sendMessage (no new endpoint) (net +120–200 LoC)
- Backend writes `aiSettings` from `sendMessage/resumeStream` options.
- Frontend only seeds localStorage from metadata when local keys are missing.

Pros: less surface area.
Cons: doesn’t sync if user changes model/thinking but hasn’t sent yet; stale localStorage on an existing device may never converge.

### B) Remove localStorage for model/thinking entirely (net +500–900 LoC)
- Replace `usePersistedState(getModelKey(...))` usage with a workspace settings store sourced from backend.

Pros: true single source of truth.
Cons: much bigger refactor; riskier.

</details>

</details>

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `high`_
