### PR TITLE
🤖 fix: eliminate jank when switching sidebar tabs

### DIFF
--- a/src/browser/components/AIView.tsx
+++ b/src/browser/components/AIView.tsx
@@ -105,10 +105,11 @@ const AIViewInner: React.FC<AIViewProps> = ({
   const { workspaceMetadata } = useWorkspaceContext();
   const chatAreaRef = useRef<HTMLDivElement>(null);
 
-  // Track which right sidebar tab is selected (listener: true to sync with RightSidebar changes)
-  const [selectedRightTab] = usePersistedState<TabType>(RIGHT_SIDEBAR_TAB_KEY, "costs", {
-    listener: true,
-  });
+  // AIView owns tab state to ensure tab + width update atomically (prevents jank during tab switch)
+  const [selectedRightTab, setSelectedRightTab] = usePersistedState<TabType>(
+    RIGHT_SIDEBAR_TAB_KEY,
+    "costs"
+  );
 
   // Resizable RightSidebar width - separate hooks per tab for independent persistence
   const costsSidebar = useResizableSidebar({
@@ -794,6 +795,8 @@ const AIViewInner: React.FC<AIViewProps> = ({
         key={workspaceId}
         workspaceId={workspaceId}
         workspacePath={namedWorkspacePath}
+        selectedTab={selectedRightTab}
+        onTabChange={setSelectedRightTab}
         width={sidebarWidth}
         onStartResize={startResize}
         isResizing={isResizing}

--- a/src/browser/components/RightSidebar/CodeReview/ReviewPanel.tsx
+++ b/src/browser/components/RightSidebar/CodeReview/ReviewPanel.tsx
@@ -48,6 +48,7 @@ import { applyFrontendFilters } from "@/browser/utils/review/filterHunks";
 import { findNextHunkId, findNextHunkIdAfterFileRemoval } from "@/browser/utils/review/navigation";
 import { cn } from "@/common/lib/utils";
 import { useAPI, type APIClient } from "@/browser/contexts/API";
+import { Loader2 } from "lucide-react";
 import { workspaceStore } from "@/browser/stores/WorkspaceStore";
 import { invalidateGitStatus } from "@/browser/stores/GitStatusStore";
 
@@ -1028,8 +1029,8 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
           {diffState.message}
         </div>
       ) : diffState.status === "loading" ? (
-        <div className="text-muted flex h-full items-center justify-center text-sm">
-          Loading diff...
+        <div className="flex h-full items-center justify-center">
+          <Loader2 className="text-muted h-6 w-6 animate-spin" />
         </div>
       ) : (
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">


### PR DESCRIPTION
## Problem
When switching between Review and Costs tabs in the right sidebar, the sidebar would visually jump—appearing to briefly collapse before expanding to the correct width.

## Root Cause
Race condition between two components sharing state:
- `RightSidebar` owned `selectedTab` state via `usePersistedState`
- `AIView` listened to that state with `{ listener: true }` and derived `sidebarWidth`

When clicking a tab, RightSidebar rendered immediately with the new tab but stale width props from AIView (which had not re-rendered yet), causing a visual jump during the intermediate state.

## Solution
1. **Lift tab state to AIView** - Now owns both `selectedTab` and width, passing them together to RightSidebar. This eliminates the render race where tab and width could be out of sync.

2. **Keep sidebar DOM mounted when collapsed** - Changed from `return null` to rendering with `width: 0px` and `isCollapsed` prop. This preserves the CSS transition target so width changes animate smoothly.

3. **Return actual stored width from hook** - `useResizableSidebar` now returns `undefined` when no custom width exists (allowing auto-wide mode for Review) and returns the stored custom width regardless of `enabled` state (keeping width stable during tab switches).

## Testing
- Rapidly switch between Review and Costs tabs
- Verify smooth 200ms transition without visual jump
- Confirm tab selection persists across page reload
- Confirm custom widths (after drag-resize) persist per-tab

---
_Generated with `mux` • Model: `mux-gateway:anthropic/claude-opus-4-5` • Thinking: `high`_