### PR TITLE
🤖 fix: use atomic writes for experiments cache

### DIFF
--- a/src/node/services/experimentsService.ts
+++ b/src/node/services/experimentsService.ts
@@ -4,7 +4,9 @@ import { getMuxHome } from "@/common/constants/paths";
 import type { ExperimentValue } from "@/common/orpc/types";
 import { log } from "@/node/services/log";
 import type { TelemetryService } from "@/node/services/telemetryService";
+
 import * as fs from "fs/promises";
+import writeFileAtomic from "write-file-atomic";
 import * as path from "path";
 
 export type { ExperimentValue };
@@ -298,7 +300,7 @@ export class ExperimentsService {
       };
 
       await fs.mkdir(this.muxHome, { recursive: true });
-      await fs.writeFile(this.cacheFilePath, JSON.stringify(payload, null, 2), "utf-8");
+      await writeFileAtomic(this.cacheFilePath, JSON.stringify(payload, null, 2), "utf-8");
     } catch {
       // Ignore cache persistence failures
     }


### PR DESCRIPTION
The test `refreshExperiment updates cache and writes it to disk` was flaky because `fs.writeFile` is not atomic — it truncates the file before writing, creating a race window where readers can see an empty or partial file.

Switch to `write-file-atomic` which writes to a temp file then renames, making the operation atomic.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_