### PR TITLE
🤖 fix: deterministic project ordering when no custom order set

### DIFF
--- a/src/common/utils/projectOrdering.test.ts
+++ b/src/common/utils/projectOrdering.test.ts
@@ -17,10 +17,10 @@ describe("projectOrdering", () => {
   };
 
   describe("sortProjectsByOrder", () => {
-    it("returns natural order when order array is empty", () => {
+    it("returns lexical order when order array is empty", () => {
       const projects = createProjects(["/a", "/c", "/b"]);
       const result = sortProjectsByOrder(projects, []);
-      expect(result.map(([p]) => p)).toEqual(["/a", "/c", "/b"]);
+      expect(result.map(([p]) => p)).toEqual(["/a", "/b", "/c"]);
     });
 
     it("sorts projects according to order array", () => {

--- a/src/common/utils/projectOrdering.ts
+++ b/src/common/utils/projectOrdering.ts
@@ -15,7 +15,10 @@ export function sortProjectsByOrder(
 ): Array<[string, ProjectConfig]> {
   const entries = Array.from(projects.entries());
 
-  if (order.length === 0) return entries; // Natural order
+  if (order.length === 0) {
+    // Sort lexically for stable, deterministic order
+    return entries.sort(([a], [b]) => a.localeCompare(b));
+  }
 
   const pos = new Map(order.map((p, i) => [p, i]));
 


### PR DESCRIPTION
## Problem

The Comprehensive demo story had flaky snapshots because projects in the sidebar did not render in a consistent order when `projectOrder` was empty (initial state in Storybook).

**Root cause:** `sortProjectsByOrder()` returned projects in Map insertion order when `order` was empty. Map insertion order depends on how data is constructed, making it non-deterministic across test runs.

## Solution

When no custom order is set, sort projects lexically instead of using insertion order. This guarantees a stable, deterministic render order.

## Impact

- **Storybook:** Projects render in consistent alphabetical order when no custom ordering is saved
- **Production:** New users see projects sorted alphabetically until they drag-reorder
- **Existing users:** No change—their saved `projectOrder` is non-empty, so existing sort logic applies

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_