### PR TITLE
🤖 feat: disable auto truncation by default for OpenAI models

### DIFF
--- a/src/browser/utils/messages/sendOptions.ts
+++ b/src/browser/utils/messages/sendOptions.ts
@@ -26,7 +26,7 @@ function getProviderOptions(): MuxProviderOptions {
     { use1MContext: false }
   );
   const openai = readPersistedState<MuxProviderOptions["openai"]>("provider_options_openai", {
-    disableAutoTruncation: false,
+    disableAutoTruncation: true,
   });
   const google = readPersistedState<MuxProviderOptions["google"]>("provider_options_google", {});
 

--- a/tests/ipc/sendMessage.heavy.test.ts
+++ b/tests/ipc/sendMessage.heavy.test.ts
@@ -41,13 +41,21 @@ describeIntegration("sendMessage heavy/load tests", () => {
         await withSharedWorkspace(provider, async ({ env, workspaceId, collector }) => {
           // Build up large conversation history to exceed context limit
           // This approach is model-agnostic - it keeps sending until we've built up enough history
+          // Use auto-truncation enabled (disableAutoTruncation: false) so history builds up successfully
           const largeMessage = "x".repeat(50_000);
           for (let i = 0; i < 10; i++) {
             await sendMessageWithModel(
               env,
               workspaceId,
               `Message ${i}: ${largeMessage}`,
-              modelString(provider, model)
+              modelString(provider, model),
+              {
+                providerOptions: {
+                  openai: {
+                    disableAutoTruncation: false,
+                  },
+                },
+              }
             );
             await collector.waitForEvent("stream-end", 30000);
             collector.clear();
@@ -93,8 +101,14 @@ describeIntegration("sendMessage heavy/load tests", () => {
             env,
             workspaceId,
             "This should succeed with auto-truncation",
-            modelString(provider, model)
-            // disableAutoTruncation defaults to false (auto-truncation enabled)
+            modelString(provider, model),
+            {
+              providerOptions: {
+                openai: {
+                  disableAutoTruncation: false,
+                },
+              },
+            }
           );
 
           expect(successResult.success).toBe(true);


### PR DESCRIPTION
Change the default value of `disableAutoTruncation` from `false` to `true`, so the dev-only "No Trunc" checkbox is checked by default.

---
_Generated with `mux` • Model: `mux-gateway:anthropic/claude-opus-4-5` • Thinking: `high`_