### PR TITLE
🤖 fix: prevent Escape in image preview from canceling stream

### DIFF
--- a/src/browser/components/tools/shared/ToolResultImages.tsx
+++ b/src/browser/components/tools/shared/ToolResultImages.tsx
@@ -118,6 +118,12 @@ export const ToolResultImages: React.FC<ToolResultImagesProps> = ({ result }) =>
       {/* Lightbox modal for full-size image viewing */}
       <Dialog open={selectedImage !== null} onOpenChange={() => setSelectedImage(null)}>
         <DialogContent
+          onKeyDown={(e) => {
+            // Prevent Escape from propagating to global handlers (stream interrupt)
+            if (e.key === "Escape") {
+              e.stopPropagation();
+            }
+          }}
           maxWidth="90vw"
           maxHeight="90vh"
           className="flex items-center justify-center bg-black/90 p-2"


### PR DESCRIPTION
When viewing an image preview (lightbox), pressing Escape should only close the preview dialog, not also interrupt the active AI stream.

Added `stopPropagation()` on the Escape keydown event in the DialogContent to prevent it from bubbling to the global stream interrupt handler.

---
_Generated with `mux` • Model: `mux-gateway:anthropic/claude-opus-4-5` • Thinking: `high`_