### PR TITLE
🤖 fix: correct GPT-5.2 context window to 272k tokens

### DIFF
--- a/src/common/utils/tokens/modelStats.test.ts
+++ b/src/common/utils/tokens/modelStats.test.ts
@@ -23,6 +23,13 @@ describe("getModelStats", () => {
       expect(stats?.max_input_tokens).toBe(400000);
       expect(stats?.input_cost_per_token).toBe(0.000015);
     });
+
+    test("models-extra.ts should override models.json", () => {
+      // gpt-5.2 exists in both files - models-extra.ts has correct 272k, models.json has incorrect 400k
+      const stats = getModelStats("openai:gpt-5.2");
+      expect(stats).not.toBeNull();
+      expect(stats?.max_input_tokens).toBe(272000); // models-extra.ts override
+    });
   });
 
   describe("ollama model lookups with cloud suffix", () => {

--- a/src/common/utils/tokens/modelStats.ts
+++ b/src/common/utils/tokens/modelStats.ts
@@ -96,17 +96,17 @@ export function getModelStats(modelString: string): ModelStats | null {
   const normalized = normalizeGatewayModel(modelString);
   const lookupKeys = generateLookupKeys(normalized);
 
-  // Try each lookup pattern in main models.json
+  // Check models-extra.ts first (overrides for models with incorrect upstream data)
   for (const key of lookupKeys) {
-    const data = (modelsData as Record<string, RawModelData>)[key];
+    const data = (modelsExtra as Record<string, RawModelData>)[key];
     if (data && isValidModelData(data)) {
       return extractModelStats(data);
     }
   }
 
-  // Fall back to models-extra.ts
+  // Fall back to main models.json
   for (const key of lookupKeys) {
-    const data = (modelsExtra as Record<string, RawModelData>)[key];
+    const data = (modelsData as Record<string, RawModelData>)[key];
     if (data && isValidModelData(data)) {
       return extractModelStats(data);
     }

--- a/src/common/utils/tokens/models-extra.ts
+++ b/src/common/utils/tokens/models-extra.ts
@@ -45,7 +45,7 @@ export const modelsExtra: Record<string, ModelData> = {
   // Cached input: $0.175/M
   // Supports off, low, medium, high, xhigh reasoning levels
   "gpt-5.2": {
-    max_input_tokens: 400000,
+    max_input_tokens: 272000,
     max_output_tokens: 128000,
     input_cost_per_token: 0.00000175, // $1.75 per million input tokens
     output_cost_per_token: 0.000014, // $14 per million output tokens
@@ -64,7 +64,7 @@ export const modelsExtra: Record<string, ModelData> = {
   // $21/M input, $168/M output
   // Supports medium, high, xhigh reasoning levels
   "gpt-5.2-pro": {
-    max_input_tokens: 400000,
+    max_input_tokens: 272000,
     max_output_tokens: 128000,
     input_cost_per_token: 0.000021, // $21 per million input tokens
     output_cost_per_token: 0.000168, // $168 per million output tokens


### PR DESCRIPTION
GPT-5.2 and GPT-5.2 Pro have a 272k token context window, not 400k. This matches the documented limits for the GPT-5.x model family.

---
_Generated with `mux` • Model: `mux-gateway:anthropic/claude-opus-4-5` • Thinking: `high`_