### PR TITLE
🤖 fix: MCP button opens project settings with project pre-selected

### DIFF
--- a/src/browser/components/Settings/sections/ProjectSettingsSection.tsx
+++ b/src/browser/components/Settings/sections/ProjectSettingsSection.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { useAPI } from "@/browser/contexts/API";
 import { useProjectContext } from "@/browser/contexts/ProjectContext";
+import { useSettings } from "@/browser/contexts/SettingsContext";
 import {
   Trash2,
   Play,
@@ -174,10 +175,11 @@ const ToolAllowlistSection: React.FC<{
 export const ProjectSettingsSection: React.FC = () => {
   const { api } = useAPI();
   const { projects } = useProjectContext();
+  const { initialProjectPath } = useSettings();
   const projectList = Array.from(projects.keys());
 
   // Core state
-  const [selectedProject, setSelectedProject] = useState<string>("");
+  const [selectedProject, setSelectedProject] = useState<string>(initialProjectPath ?? "");
   const [servers, setServers] = useState<Record<string, MCPServerInfo>>({});
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -225,12 +227,14 @@ export const ProjectSettingsSection: React.FC = () => {
     setIdleHoursInput(idleHours?.toString() ?? "24");
   }, [idleHours]);
 
-  // Set default project when projects load
+  // Set project when initialProjectPath changes or default to first project
   useEffect(() => {
-    if (projectList.length > 0 && !selectedProject) {
+    if (initialProjectPath && projectList.includes(initialProjectPath)) {
+      setSelectedProject(initialProjectPath);
+    } else if (projectList.length > 0 && !selectedProject) {
       setSelectedProject(projectList[0]);
     }
-  }, [projectList, selectedProject]);
+  }, [projectList, selectedProject, initialProjectPath]);
 
   const refresh = useCallback(async () => {
     if (!api || !selectedProject) return;

--- a/src/browser/components/WorkspaceHeader.tsx
+++ b/src/browser/components/WorkspaceHeader.tsx
@@ -3,7 +3,7 @@ import { Pencil, Server } from "lucide-react";
 import { GitStatusIndicator } from "./GitStatusIndicator";
 import { RuntimeBadge } from "./RuntimeBadge";
 import { BranchSelector } from "./BranchSelector";
-import { WorkspaceMCPModal } from "./WorkspaceMCPModal";
+
 import { Tooltip, TooltipTrigger, TooltipContent } from "./ui/tooltip";
 import { formatKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
 import { useGitStatus } from "@/browser/stores/GitStatusStore";
@@ -13,6 +13,7 @@ import type { RuntimeConfig } from "@/common/types/runtime";
 import { useTutorial } from "@/browser/contexts/TutorialContext";
 import { useOpenTerminal } from "@/browser/hooks/useOpenTerminal";
 import { useOpenInEditor } from "@/browser/hooks/useOpenInEditor";
+import { useSettings } from "@/browser/contexts/SettingsContext";
 
 interface WorkspaceHeaderProps {
   workspaceId: string;
@@ -36,8 +37,8 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
   const gitStatus = useGitStatus(workspaceId);
   const { canInterrupt } = useWorkspaceSidebarState(workspaceId);
   const { startSequence: startTutorial, isSequenceCompleted } = useTutorial();
+  const { open: openSettings } = useSettings();
   const [editorError, setEditorError] = useState<string | null>(null);
-  const [mcpModalOpen, setMcpModalOpen] = useState(false);
 
   const handleOpenTerminal = useCallback(() => {
     openTerminal(workspaceId, runtimeConfig);
@@ -96,7 +97,7 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
             <Button
               variant="ghost"
               size="icon"
-              onClick={() => setMcpModalOpen(true)}
+              onClick={() => openSettings("projects", projectPath)}
               className="text-muted hover:text-foreground h-6 w-6 shrink-0"
               data-testid="workspace-mcp-button"
             >
@@ -104,7 +105,7 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
             </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom" align="center">
-            Configure MCP servers for this workspace
+            Configure MCP servers for this project
           </TooltipContent>
         </Tooltip>
         <Tooltip>
@@ -141,12 +142,6 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
           </TooltipContent>
         </Tooltip>
       </div>
-      <WorkspaceMCPModal
-        workspaceId={workspaceId}
-        projectPath={projectPath}
-        open={mcpModalOpen}
-        onOpenChange={setMcpModalOpen}
-      />
     </div>
   );
 };

--- a/src/browser/contexts/SettingsContext.tsx
+++ b/src/browser/contexts/SettingsContext.tsx
@@ -10,7 +10,9 @@ import React, {
 interface SettingsContextValue {
   isOpen: boolean;
   activeSection: string;
-  open: (section?: string) => void;
+  /** Pre-selected project path when opening the projects section */
+  initialProjectPath: string | null;
+  open: (section?: string, projectPath?: string) => void;
   close: () => void;
   setActiveSection: (section: string) => void;
 }
@@ -28,9 +30,11 @@ const DEFAULT_SECTION = "general";
 export function SettingsProvider(props: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(false);
   const [activeSection, setActiveSection] = useState(DEFAULT_SECTION);
+  const [initialProjectPath, setInitialProjectPath] = useState<string | null>(null);
 
-  const open = useCallback((section?: string) => {
+  const open = useCallback((section?: string, projectPath?: string) => {
     if (section) setActiveSection(section);
+    setInitialProjectPath(projectPath ?? null);
     setIsOpen(true);
   }, []);
 
@@ -42,11 +46,12 @@ export function SettingsProvider(props: { children: ReactNode }) {
     () => ({
       isOpen,
       activeSection,
+      initialProjectPath,
       open,
       close,
       setActiveSection,
     }),
-    [isOpen, activeSection, open, close]
+    [isOpen, activeSection, initialProjectPath, open, close]
   );
 
   return <SettingsContext.Provider value={value}>{props.children}</SettingsContext.Provider>;


### PR DESCRIPTION
The MCP server button in the workspace header now navigates directly to the project settings with the current project pre-selected, rather than opening a separate workspace MCP modal.

## Changes

- Extended `SettingsContext` to accept optional `projectPath` when opening
- `ProjectSettingsSection` now respects `initialProjectPath` from context  
- Removed `WorkspaceMCPModal` from `WorkspaceHeader` (component still exists for potential future use)
- Updated stories to test new navigation flow

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `medium`_