### PR TITLE
🤖 fix: use subtle grey tone for Cache Create token color

### DIFF
--- a/src/browser/stories/App.rightsidebar.stories.tsx
+++ b/src/browser/stories/App.rightsidebar.stories.tsx
@@ -103,7 +103,7 @@ export const CostsTab: AppStory = {
 
 /**
  * Costs tab showing cache create vs cache read differentiation.
- * Cache create (orange) is typically more expensive than cache read (grey).
+ * Cache create is more expensive than cache read; both render in grey tones.
  * This story uses realistic Anthropic-style usage where most input is cached.
  */
 export const CostsTabWithCacheCreate: AppStory = {

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -131,7 +131,7 @@
     --color-token-input: hsl(120 40% 35%);
     --color-token-output: hsl(207 100% 40%);
     --color-token-cached: hsl(0 0% 50%);
-    --color-token-cache-create: hsl(30 90% 50%);
+    --color-token-cache-create: hsl(140 20% 55%);
 
     /* Plan surfaces */
     --surface-plan-gradient: linear-gradient(
@@ -384,7 +384,7 @@
   --color-token-input: hsl(125 45% 36%);
   --color-token-output: hsl(207 90% 40%);
   --color-token-cached: hsl(210 16% 50%);
-  --color-token-cache-create: hsl(30 85% 45%);
+  --color-token-cache-create: hsl(140 18% 52%);
 
   --surface-plan-gradient: linear-gradient(
     135deg,
@@ -624,7 +624,7 @@
   --color-token-input: #859900;
   --color-token-output: #268bd2;
   --color-token-cached: #839496;
-  --color-token-cache-create: #cb4b16;
+  --color-token-cache-create: #6b9b7a;
 
   --surface-plan-gradient: linear-gradient(135deg, color-mix(in srgb, var(--color-plan-mode), transparent 94%) 0%, color-mix(in srgb, var(--color-plan-mode), transparent 97%) 100%);
   --surface-plan-border: color-mix(in srgb, var(--color-plan-mode), transparent 78%);
@@ -839,7 +839,7 @@
   --color-token-input: #859900;
   --color-token-output: #268bd2;
   --color-token-cached: #586e75;
-  --color-token-cache-create: #cb4b16;
+  --color-token-cache-create: #5a8a6a;
 
   --surface-plan-gradient: linear-gradient(135deg, color-mix(in srgb, var(--color-plan-mode), transparent 92%) 0%, color-mix(in srgb, var(--color-plan-mode), transparent 95%) 100%);
   --surface-plan-border: color-mix(in srgb, var(--color-plan-mode), transparent 70%);


### PR DESCRIPTION
Change Cache Create token color from orange to a muted greyish-green for a more cohesive, less distracting token meter display.

| Theme | Before | After |
|-------|--------|-------|
| Default | `hsl(30 90% 50%)` (orange) | `hsl(140 20% 55%)` (muted green) |
| Nord | `hsl(30 85% 45%)` (orange) | `hsl(140 18% 52%)` (muted green) |
| Solarized Light | `#cb4b16` (orange) | `#6b9b7a` (sage green) |
| Solarized Dark | `#cb4b16` (orange) | `#5a8a6a` (darker sage) |

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_