### PR TITLE
🤖 fix: acquire SSH connection before bundle transfer

### DIFF
--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -625,6 +625,12 @@ export class SSHRuntime implements Runtime {
 
       // Step 2: Create bundle locally and pipe to remote file via SSH
       initLogger.logStep(`Creating git bundle...`);
+
+      // Ensure SSH connection is established before starting the bundle transfer
+      // Without this, the SSH command in the pipe may fail to connect, causing
+      // the git bundle process to receive SIGPIPE and report "pack-objects died"
+      await sshConnectionPool.acquireConnection(this.config);
+
       await new Promise<void>((resolve, reject) => {
         // Check if aborted before spawning
         if (abortSignal?.aborted) {


### PR DESCRIPTION
The `syncProjectToRemote` function was running the git bundle transfer via SSH without first ensuring the SSH connection was established through the connection pool.

When the SSH part of the pipeline fails (connection refused, auth timeout, etc.), it closes the pipe and git's `pack-objects` process receives SIGPIPE, resulting in the cryptic error:
```
error: pack-objects died
Failed to sync project: Failed to create bundle: error: pack-objects died
```

## Fix

Call `acquireConnection()` before spawning the bundle transfer pipeline. This ensures:
- The SSH ControlMaster connection is established with proper backoff/retry
- Early failure with clear errors instead of pipe errors
- Consistent connection handling with other SSH operations

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_