### PR TITLE
🤖 fix: update InitMessage to match app aesthetic

### DIFF
--- a/src/browser/components/Messages/InitMessage.tsx
+++ b/src/browser/components/Messages/InitMessage.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { cn } from "@/common/lib/utils";
 import type { DisplayedMessage } from "@/common/types/message";
+import { Loader2, Wrench, CheckCircle2, AlertCircle } from "lucide-react";
+import { Shimmer } from "../ai-elements/shimmer";
 
 interface InitMessageProps {
   message: Extract<DisplayedMessage, { type: "workspace-init" }>;
@@ -9,33 +11,53 @@ interface InitMessageProps {
 
 export const InitMessage = React.memo<InitMessageProps>(({ message, className }) => {
   const isError = message.status === "error";
+  const isRunning = message.status === "running";
+  const isSuccess = message.status === "success";
 
   return (
     <div
       className={cn(
-        "flex flex-col gap-1.5 border-b p-3 font-mono text-xs text-text-lighter",
-        isError ? "bg-init-error-bg border-init-error-border" : "bg-init-bg border-init-border",
+        "my-2 rounded border px-3 py-2",
+        isError ? "border-init-error-border bg-init-error-bg" : "border-init-border bg-init-bg",
         className
       )}
     >
-      <div className="text-bright flex items-center gap-2">
-        <span>🔧</span>
-        <div>
-          {message.status === "running" ? (
-            <span>Running init hook...</span>
-          ) : message.status === "success" ? (
-            <span>✅ Init hook completed successfully</span>
-          ) : (
-            <span>
-              Init hook exited with code {message.exitCode}. Workspace is ready, but some setup
-              failed.
-            </span>
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            "flex-shrink-0",
+            isError ? "text-error" : isSuccess ? "text-success" : "text-accent"
           )}
-          <div className="text-muted mt-0.5 font-mono text-[11px]">{message.hookPath}</div>
-        </div>
+        >
+          {isRunning ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : isSuccess ? (
+            <CheckCircle2 className="size-3.5" />
+          ) : isError ? (
+            <AlertCircle className="size-3.5" />
+          ) : (
+            <Wrench className="size-3.5" />
+          )}
+        </span>
+        <span className="font-primary text-foreground text-[12px]">
+          {isRunning ? (
+            <Shimmer colorClass="var(--color-accent)">Running init hook...</Shimmer>
+          ) : isSuccess ? (
+            "Init hook completed"
+          ) : (
+            <span className="text-error">Init hook failed (exit code {message.exitCode})</span>
+          )}
+        </span>
       </div>
+      <div className="text-muted mt-1 truncate font-mono text-[11px]">{message.hookPath}</div>
       {message.lines.length > 0 && (
-        <pre className="m-0 max-h-[120px] overflow-auto rounded border border-white/[0.08] bg-black/15 px-2 py-1.5 whitespace-pre-wrap">
+        <pre
+          className={cn(
+            "m-0 mt-2.5 max-h-[120px] overflow-auto rounded-sm",
+            "bg-black/30 px-2 py-1.5 font-mono text-[11px] leading-relaxed whitespace-pre-wrap",
+            isError ? "text-danger-soft" : "text-light"
+          )}
+        >
           {message.lines.join("\n")}
         </pre>
       )}

--- a/src/browser/stories/App.chat.stories.tsx
+++ b/src/browser/stories/App.chat.stories.tsx
@@ -15,6 +15,8 @@ import {
   createGenericTool,
   createPendingTool,
 } from "./mockFactory";
+
+import type { WorkspaceChatMessage } from "@/common/orpc/types";
 import { updatePersistedState } from "@/browser/hooks/usePersistedState";
 import { getModelKey } from "@/common/constants/storage";
 import { setupSimpleChatStory, setupStreamingChatStory, setWorkspaceInput } from "./storyHelpers";
@@ -960,6 +962,130 @@ export const DiffPaddingAlignment: AppStory = {
           "The bottom red padding strip should align exactly with the gutter/content boundary. " +
           "Before the fix, the padding strip used ch units without font-monospace, " +
           "causing misalignment that scaled with line number width.",
+      },
+    },
+  },
+};
+
+/**
+ * Story showing the InitMessage component in success state.
+ * Tests the workspace init hook display with completed status.
+ */
+export const InitHookSuccess: AppStory = {
+  render: () => (
+    <AppWithMocks
+      setup={() =>
+        setupSimpleChatStory({
+          workspaceId: "ws-init-success",
+          messages: [
+            createUserMessage("msg-1", "Start working on the project", {
+              historySequence: 1,
+              timestamp: STABLE_TIMESTAMP - 100000,
+            }),
+          ],
+          onChat: (_wsId, emit) => {
+            // Emit init events to show completed init hook
+            setTimeout(() => {
+              emit({
+                type: "init-start",
+                hookPath: "/home/user/projects/my-app/.mux/init.sh",
+                timestamp: STABLE_TIMESTAMP - 110000,
+              } as WorkspaceChatMessage);
+              emit({
+                type: "init-output",
+                line: "Installing dependencies...",
+                timestamp: STABLE_TIMESTAMP - 109000,
+              } as WorkspaceChatMessage);
+              emit({
+                type: "init-output",
+                line: "Setting up environment variables...",
+                timestamp: STABLE_TIMESTAMP - 108000,
+              } as WorkspaceChatMessage);
+              emit({
+                type: "init-output",
+                line: "Starting development server...",
+                timestamp: STABLE_TIMESTAMP - 107000,
+              } as WorkspaceChatMessage);
+              emit({
+                type: "init-end",
+                exitCode: 0,
+                timestamp: STABLE_TIMESTAMP - 106000,
+              } as WorkspaceChatMessage);
+            }, 100);
+          },
+        })
+      }
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Shows the InitMessage component after a successful init hook execution. " +
+          "The message displays with a green checkmark, hook path, and output lines.",
+      },
+    },
+  },
+};
+
+/**
+ * Story showing the InitMessage component in error state.
+ * Tests the workspace init hook display with failed status.
+ */
+export const InitHookError: AppStory = {
+  render: () => (
+    <AppWithMocks
+      setup={() =>
+        setupSimpleChatStory({
+          workspaceId: "ws-init-error",
+          messages: [
+            createUserMessage("msg-1", "Start working on the project", {
+              historySequence: 1,
+              timestamp: STABLE_TIMESTAMP - 100000,
+            }),
+          ],
+          onChat: (_wsId, emit) => {
+            // Emit init events to show failed init hook
+            setTimeout(() => {
+              emit({
+                type: "init-start",
+                hookPath: "/home/user/projects/my-app/.mux/init.sh",
+                timestamp: STABLE_TIMESTAMP - 110000,
+              } as WorkspaceChatMessage);
+              emit({
+                type: "init-output",
+                line: "Installing dependencies...",
+                timestamp: STABLE_TIMESTAMP - 109000,
+              } as WorkspaceChatMessage);
+              emit({
+                type: "init-output",
+                line: "ERROR: Failed to install package 'missing-dep'",
+                timestamp: STABLE_TIMESTAMP - 108000,
+                isError: true,
+              } as WorkspaceChatMessage);
+              emit({
+                type: "init-output",
+                line: "ERROR: npm ERR! code E404",
+                timestamp: STABLE_TIMESTAMP - 107500,
+                isError: true,
+              } as WorkspaceChatMessage);
+              emit({
+                type: "init-end",
+                exitCode: 1,
+                timestamp: STABLE_TIMESTAMP - 107000,
+              } as WorkspaceChatMessage);
+            }, 100);
+          },
+        })
+      }
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Shows the InitMessage component after a failed init hook execution. " +
+          "The message displays with a red alert icon, error styling, and error output.",
       },
     },
   },


### PR DESCRIPTION
## Summary

Update the InitMessage component to match the visual patterns used throughout the rest of the app.

## Changes

| Aspect | Before | After |
|--------|--------|-------|
| **Border** | `border-b` (bottom only) | `rounded border` (all sides, rounded corners) |
| **Icons** | Emoji (🔧, ✅) | Lucide icons with semantic colors |
| **Running state** | Plain text | Shimmer animation |
| **Typography** | `font-mono` everywhere | `font-primary` for text, `font-mono` for paths |
| **Color coding** | Minimal | `text-accent` / `text-success` / `text-error` |

Follows patterns from `ReasoningMessage`, `StreamErrorMessage`, `TerminalOutput`, and `StreamingBarrier`.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_