### PR TITLE
🤖 fix: disable AI SDK warning logging

### DIFF
--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -42,6 +42,9 @@ import type { SessionUsageService } from "./sessionUsageService";
 import { createDisplayUsage } from "@/common/utils/tokens/displayUsage";
 import { normalizeGatewayModel } from "@/common/utils/ai/models";
 
+// Disable AI SDK warning logging (e.g., "setting `toolChoice` to `none` is not supported")
+globalThis.AI_SDK_LOG_WARNINGS = false;
+
 // Type definitions for stream parts with extended properties
 interface ReasoningDeltaPart {
   type: "reasoning-delta";


### PR DESCRIPTION
Disables AI SDK warning logging by setting `globalThis.AI_SDK_LOG_WARNINGS = false`.

This suppresses noisy warnings like "setting `toolChoice` to `none` is not supported".

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_