### PR TITLE
🤖 fix: prevent workspace create selection race

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useCallback, useRef } from "react";
 import "./styles/globals.css";
-import { useWorkspaceContext } from "./contexts/WorkspaceContext";
+import { useWorkspaceContext, toWorkspaceSelection } from "./contexts/WorkspaceContext";
 import { useProjectContext } from "./contexts/ProjectContext";
 import type { WorkspaceSelection } from "./components/ProjectSidebar";
 import { LeftSidebar } from "./components/LeftSidebar";
@@ -114,7 +114,6 @@ function AppInner() {
   const startWorkspaceCreation = useStartWorkspaceCreation({
     projects,
     beginWorkspaceCreation,
-    setSelectedWorkspace,
   });
 
   useEffect(() => {
@@ -203,12 +202,7 @@ function AppInner() {
       } else if (!selectedWorkspace.namedWorkspacePath && metadata.namedWorkspacePath) {
         // Old localStorage entry missing namedWorkspacePath - update it once
         console.log(`Updating workspace ${selectedWorkspace.workspaceId} with missing fields`);
-        setSelectedWorkspace({
-          workspaceId: metadata.id,
-          projectPath: metadata.projectPath,
-          projectName: metadata.projectName,
-          namedWorkspacePath: metadata.namedWorkspacePath,
-        });
+        setSelectedWorkspace(toWorkspaceSelection(metadata));
       }
     }
   }, [selectedWorkspace, workspaceMetadata, setSelectedWorkspace]);
@@ -274,12 +268,7 @@ function AppInner() {
       const targetMetadata = sortedWorkspaces[targetIndex];
       if (!targetMetadata) return;
 
-      setSelectedWorkspace({
-        projectPath: selectedWorkspace.projectPath,
-        projectName: selectedWorkspace.projectName,
-        namedWorkspacePath: targetMetadata.namedWorkspacePath,
-        workspaceId: targetMetadata.id,
-      });
+      setSelectedWorkspace(toWorkspaceSelection(targetMetadata));
     },
     [selectedWorkspace, sortedWorkspacesByProject, setSelectedWorkspace]
   );
@@ -587,12 +576,7 @@ function AppInner() {
       });
 
       // Switch to the new workspace
-      setSelectedWorkspace({
-        workspaceId: workspaceInfo.id,
-        projectPath: workspaceInfo.projectPath,
-        projectName: workspaceInfo.projectName,
-        namedWorkspacePath: workspaceInfo.namedWorkspacePath,
-      });
+      setSelectedWorkspace(toWorkspaceSelection(workspaceInfo));
     };
 
     window.addEventListener(CUSTOM_EVENTS.WORKSPACE_FORK_SWITCH, handleForkSwitch as EventListener);
@@ -706,12 +690,7 @@ function AppInner() {
                                 // User has already selected another workspace - don't override
                                 return current;
                               }
-                              return {
-                                workspaceId: metadata.id,
-                                projectPath: metadata.projectPath,
-                                projectName: metadata.projectName,
-                                namedWorkspacePath: metadata.namedWorkspacePath,
-                              };
+                              return toWorkspaceSelection(metadata);
                             });
 
                             // Track telemetry

--- a/src/browser/hooks/useStartWorkspaceCreation.ts
+++ b/src/browser/hooks/useStartWorkspaceCreation.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect } from "react";
 import type { ProjectConfig } from "@/node/config";
-import type { WorkspaceSelection } from "@/browser/components/ProjectSidebar";
 import { CUSTOM_EVENTS, type CustomEventPayloads } from "@/common/constants/events";
 import { updatePersistedState } from "@/browser/hooks/usePersistedState";
 import {
@@ -53,7 +52,6 @@ export function persistWorkspaceCreationPrefill(
 interface UseStartWorkspaceCreationOptions {
   projects: Map<string, ProjectConfig>;
   beginWorkspaceCreation: (projectPath: string) => void;
-  setSelectedWorkspace: (selection: WorkspaceSelection | null) => void;
 }
 
 function resolveProjectPath(
@@ -70,7 +68,6 @@ function resolveProjectPath(
 export function useStartWorkspaceCreation({
   projects,
   beginWorkspaceCreation,
-  setSelectedWorkspace,
 }: UseStartWorkspaceCreationOptions) {
   const startWorkspaceCreation = useCallback(
     (projectPath: string, detail?: StartWorkspaceCreationDetail) => {
@@ -83,9 +80,8 @@ export function useStartWorkspaceCreation({
 
       persistWorkspaceCreationPrefill(resolvedProjectPath, detail);
       beginWorkspaceCreation(resolvedProjectPath);
-      setSelectedWorkspace(null);
     },
-    [projects, beginWorkspaceCreation, setSelectedWorkspace]
+    [projects, beginWorkspaceCreation]
   );
 
   useEffect(() => {


### PR DESCRIPTION
Fixes a race where the server-mode launch-project auto-selection could win over an in-progress workspace creation, leaving the UI in the wrong workspace state.

Changes:
- Cancel in-flight launch-project selection when creation starts
- Centralize WorkspaceSelection construction via toWorkspaceSelection()
- Remove redundant selection reset in useStartWorkspaceCreation
- Add regression test for launch-project vs pending creation

Test:
- make static-check

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh`_
