### PR TITLE
🤖 refactor: redesign Project Settings page

### DIFF
--- a/src/browser/stories/App.projectSettings.stories.tsx
+++ b/src/browser/stories/App.projectSettings.stories.tsx
@@ -1,10 +1,10 @@
 /**
- * MCP (Model Context Protocol) configuration stories
+ * Project Settings stories
  *
- * Shows different states and interactions for MCP server configuration:
- * - Project-level settings (enable/disable servers, tool allowlists)
- * - Workspace-level overrides (enable disabled servers, disable enabled servers)
- * - Tool selection with All/None bulk actions
+ * Shows different states and interactions for project-level configuration:
+ * - MCP servers (enable/disable, tool allowlists)
+ * - Idle compaction settings
+ * - Workspace-level MCP overrides
  *
  * Uses play functions to navigate to settings and interact with the UI.
  */
@@ -19,7 +19,7 @@ import { getMCPTestResultsKey } from "@/common/constants/storage";
 
 export default {
   ...appMeta,
-  title: "App/MCP",
+  title: "App/Project Settings",
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/browser/stories/App.settings.stories.tsx
+++ b/src/browser/stories/App.settings.stories.tsx
@@ -5,6 +5,9 @@
  * - General (theme toggle)
  * - Providers (API key configuration)
  * - Models (custom model management)
+ * - Experiments
+ *
+ * NOTE: Projects/MCP stories live in App.mcp.stories.tsx
  *
  * Uses play functions to open the settings modal and navigate to sections.
  */
@@ -200,3 +203,5 @@ export const ExperimentsToggleOff: AppStory = {
     // Default state is OFF - no clicks needed
   },
 };
+
+// NOTE: Projects section stories live in App.projectSettings.stories.tsx


### PR DESCRIPTION
## Summary

Redesigns the Project Settings section to match the visual patterns used in GeneralSection and ProvidersSection.

## Changes

### Layout & Structure
- Row-based layout with labels/descriptions on left, controls on right
- Clear section headers with consistent typography
- Intro paragraph explaining where settings are stored

### Idle Compaction
- Replaced checkbox with Switch component (consistent with other toggles)
- Clean two-row layout for enable toggle and hours threshold

### MCP Servers
- Cleaner card design using `bg-background-secondary`
- Error states and tool allowlist in bordered subsections
- Tighter action button grouping

### Add Server Form
- Converted to collapsible `<details>` element (reduces visual noise when not adding)
- Accent-colored summary with chevron animation
- Smaller, consistently styled form inputs

### Styling Consistency
- `text-muted` for descriptions, `text-foreground` for labels
- `bg-modal-bg` and `focus:border-accent` for inputs
- Removed heavy borders and backgrounds

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_