### PR TITLE
🤖 fix: deterministic project sidebar sort order

### DIFF
--- a/src/common/utils/projectOrdering.test.ts
+++ b/src/common/utils/projectOrdering.test.ts
@@ -69,11 +69,25 @@ describe("projectOrdering", () => {
       expect(result).toEqual(["/a", "/b"]);
     });
 
-    it("prepends new projects to the front", () => {
+    it("prepends new projects to the front in lexical order", () => {
       const projects = createProjects(["/a", "/b", "/c", "/d"]);
       const order = ["/b", "/a"];
       const result = normalizeOrder(order, projects);
+      // /c and /d are missing from order, prepended in lexical order
       expect(result).toEqual(["/c", "/d", "/b", "/a"]);
+    });
+
+    it("sorts missing projects lexically for deterministic order", () => {
+      // Even if Map iteration order is non-lexical, missing projects should be sorted
+      const projects = new Map<string, ProjectConfig>([
+        ["/z-project", { workspaces: [] }],
+        ["/a-project", { workspaces: [] }],
+        ["/m-project", { workspaces: [] }],
+      ]);
+      const order: string[] = []; // empty order, all projects are "missing"
+      const result = normalizeOrder(order, projects);
+      // Should be lexically sorted regardless of Map insertion order
+      expect(result).toEqual(["/a-project", "/m-project", "/z-project"]);
     });
 
     it("preserves order of existing projects", () => {

--- a/src/common/utils/projectOrdering.ts
+++ b/src/common/utils/projectOrdering.ts
@@ -68,7 +68,10 @@ export function reorderProjects(
 export function normalizeOrder(order: string[], projects: Map<string, ProjectConfig>): string[] {
   const present = new Set(projects.keys());
   const filtered = order.filter((p) => present.has(p));
-  const missing = Array.from(projects.keys()).filter((p) => !filtered.includes(p));
+  // Sort missing projects lexically for deterministic order (avoids flaky UI in Storybook)
+  const missing = Array.from(projects.keys())
+    .filter((p) => !filtered.includes(p))
+    .sort((a, b) => a.localeCompare(b));
   return [...missing, ...filtered];
 }
 


### PR DESCRIPTION
Sort missing projects lexically in `normalizeOrder()` to ensure deterministic order when projects aren't in the persisted `projectOrder` (e.g., in Storybook where localStorage may be empty).

**Root cause:** When projects were missing from the persisted `projectOrder`, `normalizeOrder` would prepend them using `Array.from(projects.keys())` which depends on Map iteration order. This order is determined by insertion order into the Map, which could vary based on how `groupWorkspacesByProject` built it.

**Fix:** Sort the missing projects lexically before prepending to ensure deterministic order.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_