### PR TITLE
🤖 fix: validate mode at stats schema boundaries

### DIFF
--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -124,7 +124,7 @@ export interface MuxMetadata {
   // Readers should use helper: isCompacted = compacted !== undefined && compacted !== false
   compacted?: "user" | "idle" | boolean;
   toolPolicy?: ToolPolicy; // Tool policy active when this message was sent (user messages only)
-  mode?: string; // The mode (plan/exec/etc) active when this message was sent (assistant messages only)
+  mode?: string; // The mode active when this message was sent (assistant messages only) - plan/exec today, custom modes in future
   cmuxMetadata?: MuxFrontendMetadata; // Frontend-defined metadata, backend treats as black-box
   muxMetadata?: MuxFrontendMetadata; // Frontend-defined metadata, backend treats as black-box
 }

--- a/src/node/services/sessionTimingService.ts
+++ b/src/node/services/sessionTimingService.ts
@@ -482,11 +482,15 @@ export class SessionTimingService {
 
     const model = normalizeGatewayModel(data.model);
 
+    // Validate mode: stats schema only accepts "plan" | "exec" for now.
+    // Custom modes will need schema updates when supported.
+    const mode = data.mode === "plan" || data.mode === "exec" ? data.mode : undefined;
+
     const state: ActiveStreamState = {
       workspaceId: data.workspaceId,
       messageId: data.messageId,
       model,
-      mode: data.mode,
+      mode,
       startTimeMs: data.startTime,
       firstTokenTimeMs: null,
       completedToolExecutionMs: 0,

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -865,7 +865,9 @@ export class StreamManager extends EventEmitter {
       streamInfo.state = StreamState.STREAMING;
 
       // Emit stream start event (include mode from initialMetadata if available)
-      const streamStartMode = streamInfo.initialMetadata?.mode as "plan" | "exec" | undefined;
+      // Validate mode - stats schema only accepts "plan" | "exec" for now
+      const rawMode = streamInfo.initialMetadata?.mode;
+      const streamStartMode = rawMode === "plan" || rawMode === "exec" ? rawMode : undefined;
       this.emit("stream-start", {
         type: "stream-start",
         workspaceId: workspaceId as string,
@@ -1776,7 +1778,10 @@ export class StreamManager extends EventEmitter {
     await this.tokenTracker.setModel(streamInfo.model);
 
     // Emit stream-start event (include mode from initialMetadata if available)
-    const replayMode = streamInfo.initialMetadata?.mode as "plan" | "exec" | undefined;
+    // Validate mode - stats schema only accepts "plan" | "exec" for now
+    const rawReplayMode = streamInfo.initialMetadata?.mode;
+    const replayMode =
+      rawReplayMode === "plan" || rawReplayMode === "exec" ? rawReplayMode : undefined;
     this.emit("stream-start", {
       type: "stream-start",
       workspaceId,


### PR DESCRIPTION
MuxMetadata.mode is typed as `string` (for future custom modes), but the stats Zod schemas only accept `"plan" | "exec" | undefined`. The code was casting mode without validation, which TypeScript allowed but Zod rejected at runtime.

This caused ZodError spam on every stream delta event, since each delta triggers `getSnapshot()` which parses the schema.

**Fix:** Validate mode before storing/emitting - treat unknown modes as undefined for stats purposes.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_