### PR TITLE
🤖 fix: collapse right sidebar by default in Storybook

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,7 +2,11 @@ import React from "react";
 import type { Preview } from "@storybook/react-vite";
 import { ThemeProvider, type ThemeMode } from "../src/browser/contexts/ThemeContext";
 import "../src/browser/styles/globals.css";
-import { TUTORIAL_STATE_KEY, type TutorialState } from "../src/common/constants/storage";
+import {
+  TUTORIAL_STATE_KEY,
+  RIGHT_SIDEBAR_COLLAPSED_KEY,
+  type TutorialState,
+} from "../src/common/constants/storage";
 import { NOW } from "../src/browser/stories/mockFactory";
 
 // Mock Date.now() globally for deterministic snapshots
@@ -18,6 +22,14 @@ function disableTutorials() {
       completed: { settings: true, creation: true, workspace: true },
     };
     localStorage.setItem(TUTORIAL_STATE_KEY, JSON.stringify(disabledState));
+  }
+}
+
+// Collapse right sidebar by default to ensure deterministic snapshots
+// Stories that need expanded sidebar call expandRightSidebar() in their setup
+function collapseRightSidebar() {
+  if (typeof localStorage !== "undefined") {
+    localStorage.setItem(RIGHT_SIDEBAR_COLLAPSED_KEY, JSON.stringify(true));
   }
 }
 
@@ -55,6 +67,10 @@ const preview: Preview = {
       if (!context.parameters?.tutorialEnabled) {
         disableTutorials();
       }
+
+      // Collapse right sidebar by default for deterministic snapshots
+      // Stories can expand via expandRightSidebar() in setup after this runs
+      collapseRightSidebar();
 
       return (
         <ThemeProvider forcedTheme={mode}>


### PR DESCRIPTION
## Problem

Right sidebar expansion state was non-deterministic across Storybook stories because:
- Storybook/Chromatic preserves `localStorage` across story runs in the same session
- `App.rightsidebar.stories.tsx` calls `expandRightSidebar()` to show the sidebar
- Other stories that don't explicitly set sidebar state would inherit whatever state was left behind

## Solution

Add `collapseRightSidebar()` to the global decorator in `.storybook/preview.tsx`. This ensures every story starts with a collapsed right sidebar, and stories that need it expanded call `expandRightSidebar()` in their setup after the decorator runs.

Follows the same pattern already used for disabling tutorials globally.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
