### PR TITLE
🤖 fix: don't persist compaction model as workspace AI settings

### DIFF
--- a/tests/ipc/workspaceAISettings.test.ts
+++ b/tests/ipc/workspaceAISettings.test.ts
@@ -48,4 +48,56 @@ describe("workspace.updateAISettings", () => {
       await cleanupTempGitRepo(tempGitRepo);
     }
   }, 60000);
+
+  test("compaction requests do not override workspace aiSettings", async () => {
+    const env: TestEnvironment = await createTestEnvironment();
+    const tempGitRepo = await createTempGitRepo();
+
+    try {
+      const branchName = generateBranchName("ai-settings-compact");
+      const createResult = await createWorkspace(env, tempGitRepo, branchName);
+      if (!createResult.success) {
+        throw new Error(`Workspace creation failed: ${createResult.error}`);
+      }
+
+      const workspaceId = createResult.metadata.id;
+      expect(workspaceId).toBeTruthy();
+
+      const client = resolveOrpcClient(env);
+
+      // Set initial workspace AI settings
+      const updateResult = await client.workspace.updateAISettings({
+        workspaceId: workspaceId!,
+        aiSettings: { model: "anthropic:claude-sonnet-4-20250514", thinkingLevel: "medium" },
+      });
+      expect(updateResult.success).toBe(true);
+
+      // Send a compaction request with a different model
+      // The muxMetadata type: "compaction-request" should prevent AI settings from being persisted
+      await client.workspace.sendMessage({
+        workspaceId: workspaceId!,
+        message: "Summarize the conversation",
+        options: {
+          model: "openai:gpt-4.1-mini", // Different model for compaction
+          thinkingLevel: "off",
+          mode: "compact",
+          muxMetadata: {
+            type: "compaction-request",
+            rawCommand: "/compact",
+            parsed: {},
+          },
+        },
+      });
+
+      // Verify the original workspace AI settings were NOT overwritten
+      const info = await client.workspace.getInfo({ workspaceId: workspaceId! });
+      expect(info?.aiSettings).toEqual({
+        model: "anthropic:claude-sonnet-4-20250514",
+        thinkingLevel: "medium",
+      });
+    } finally {
+      await cleanupTestEnvironment(env);
+      await cleanupTempGitRepo(tempGitRepo);
+    }
+  }, 60000);
 });


### PR DESCRIPTION
## Problem

When compaction is triggered with a specific model (e.g., `/compact -m openai:gpt-4.1-mini`), the backend was incorrectly persisting that model to the workspace's AI settings, overwriting the user's preferred model.

After compaction completed, the workspace would be set to use the compaction model instead of the model the user had selected.

## Root Cause

Regression introduced in 1ae03776 (#1203) which added a "safety net" to persist AI settings from `sendMessage`/`resumeStream` for cross-device consistency. This safety net didn't account for compaction requests which intentionally use a different (often cheaper/faster) model.

cc @tomaskoubek (regressor)

## Fix

Skip persisting AI settings when:
- `sendMessage` is called with `muxMetadata.type === "compaction-request"`
- `resumeStream` is called with `options.mode === "compact"`

## Testing

- Added IPC test verifying compaction requests don't override workspace AI settings
- Existing `updateAISettings` test still passes

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
