### PR TITLE
🤖 tests: wait for scroll stabilization in task tool stories

### DIFF
--- a/src/browser/stories/App.task.stories.tsx
+++ b/src/browser/stories/App.task.stories.tsx
@@ -5,6 +5,7 @@
 
 import { appMeta, AppWithMocks, type AppStory } from "./meta.js";
 import { setupSimpleChatStory } from "./storyHelpers";
+import { waitForScrollStabilization } from "./storyPlayHelpers";
 import {
   createUserMessage,
   createAssistantMessage,
@@ -116,6 +117,9 @@ Key patterns:
       }
     />
   ),
+  play: async ({ canvasElement }) => {
+    await waitForScrollStabilization(canvasElement);
+  },
 };
 
 /**
@@ -165,6 +169,9 @@ Found **47 test files** across the project:
       }
     />
   ),
+  play: async ({ canvasElement }) => {
+    await waitForScrollStabilization(canvasElement);
+  },
 };
 
 /**
@@ -239,4 +246,7 @@ export const TaskErrorStates: AppStory = {
       }
     />
   ),
+  play: async ({ canvasElement }) => {
+    await waitForScrollStabilization(canvasElement);
+  },
 };

--- a/src/browser/stories/storyPlayHelpers.ts
+++ b/src/browser/stories/storyPlayHelpers.ts
@@ -38,3 +38,17 @@ export async function waitForChatInputAutofocusDone(canvasElement: HTMLElement):
 export function blurActiveElement(): void {
   (document.activeElement as HTMLElement | null)?.blur?.();
 }
+
+/**
+ * Wait for chat messages to load and async rendering (markdown, etc.) to settle.
+ *
+ * Use this for stories with MarkdownRenderer content that changes element heights
+ * after rendering, triggering ResizeObserver scroll. Waits for messages to load
+ * plus double-RAF for coalesced scroll to fire and layout to settle.
+ */
+export async function waitForScrollStabilization(canvasElement: HTMLElement): Promise<void> {
+  await waitForChatMessagesLoaded(canvasElement);
+
+  // Wait 2 RAFs: one for coalesced scroll to fire, one for layout to settle
+  await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+}


### PR DESCRIPTION
Task tool stories (TaskWorkflow, TaskWithReport, TaskErrorStates) were
flaky because MarkdownRenderer in task reports changes element heights
after rendering, triggering ResizeObserver → coalesced RAF scroll.
Chromatic could capture snapshots before scroll completed.

Add play functions that wait for chat messages to load, then double-RAF
to let ResizeObserver scroll fire and layout settle, matching the
pattern from CodeBlocks story fix.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_