### PR TITLE
🤖 fix: cache plan content in localStorage to prevent layout flash

### DIFF
--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -340,10 +340,20 @@ const PERSISTENT_WORKSPACE_KEY_FUNCTIONS: Array<(workspaceId: string) => string>
 ];
 
 /**
+ * Get the localStorage key for cached plan content for a workspace
+ * Stores: { content: string; path: string } - used for optimistic rendering
+ * Format: "planContent:{workspaceId}"
+ */
+export function getPlanContentKey(workspaceId: string): string {
+  return `planContent:${workspaceId}`;
+}
+
+/**
  * Additional ephemeral keys to delete on workspace removal (not copied on fork)
  */
 const EPHEMERAL_WORKSPACE_KEY_FUNCTIONS: Array<(workspaceId: string) => string> = [
   getCancelledCompactionKey,
+  getPlanContentKey, // Cache only, no need to preserve on fork
 ];
 
 /**


### PR DESCRIPTION
When loading a workspace with an existing plan, the ProposePlanToolCall component previously showed placeholder text while fetching fresh content from disk, causing a jarring layout flash when the full content arrived.

Now plan content is cached in localStorage and rendered optimistically on load. The cache is updated whenever fresh content is fetched, so users always see current content without the flash.

## Changes
- Add `getPlanContentKey()` to storage.ts for plan content cache
- Initialize ProposePlanToolCall with cached content from localStorage  
- Update cache on successful fetch

## How it works
1. **First load** of a workspace with a plan: shows placeholder briefly, then caches content
2. **Subsequent loads**: renders cached content instantly (no flash), fetches fresh content in background, updates cache
3. **External edits**: detected on window focus, cache updated with new content

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_