### PR TITLE
🤖 feat: display costs for archived workspaces

### DIFF
--- a/.storybook/mocks/orpc.ts
+++ b/.storybook/mocks/orpc.ts
@@ -362,6 +362,13 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
         },
       },
       getSessionUsage: async (input: { workspaceId: string }) => sessionUsage.get(input.workspaceId),
+      getSessionUsageBatch: async (input: { workspaceIds: string[] }) => {
+        const result: Record<string, MockSessionUsage | undefined> = {};
+        for (const id of input.workspaceIds) {
+          result[id] = sessionUsage.get(id);
+        }
+        return result;
+      },
       mcp: {
         get: async (input: { workspaceId: string }) => mcpOverrides.get(input.workspaceId) ?? {},
         set: async () => ({ success: true, data: undefined }),

--- a/src/browser/components/RightSidebar/CostsTab.tsx
+++ b/src/browser/components/RightSidebar/CostsTab.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import { useWorkspaceUsage, useWorkspaceConsumers } from "@/browser/stores/WorkspaceStore";
 import { getModelStats } from "@/common/utils/tokens/modelStats";
-import { sumUsageHistory, type ChatUsageDisplay } from "@/common/utils/tokens/usageAggregator";
+import {
+  sumUsageHistory,
+  formatCostWithDollar,
+  type ChatUsageDisplay,
+} from "@/common/utils/tokens/usageAggregator";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
 import { ToggleGroup, type ToggleOption } from "../ToggleGroup";
 import { useProviderOptions } from "@/browser/hooks/useProviderOptions";
@@ -19,22 +23,6 @@ import { PostCompactionSection } from "./PostCompactionSection";
 import { usePostCompactionState } from "@/browser/hooks/usePostCompactionState";
 import { useExperimentValue } from "@/browser/contexts/ExperimentsContext";
 import { EXPERIMENT_IDS } from "@/common/constants/experiments";
-
-// Format cost display - show "??" if undefined, "<$0.01" for very small values, otherwise fixed precision
-const formatCost = (cost: number | undefined): string => {
-  if (cost === undefined) return "??";
-  if (cost === 0) return "0.00";
-  if (cost >= 0.01) return cost.toFixed(2);
-  // For values < 0.01, show as "<$0.01" (without $ prefix when used)
-  return "<0.01";
-};
-
-// Format cost with dollar sign
-const formatCostWithDollar = (cost: number | undefined): string => {
-  if (cost === undefined) return "??";
-  if (cost > 0 && cost < 0.01) return "~$0.00";
-  return `$${formatCost(cost)}`;
-};
 
 /**
  * Calculate cost with elevated pricing for 1M context (200k-1M tokens)

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -472,6 +472,11 @@ export const workspace = {
     input: z.object({ workspaceId: z.string() }),
     output: SessionUsageFileSchema.optional(),
   },
+  /** Batch fetch session usage for multiple workspaces (for archived workspaces cost display) */
+  getSessionUsageBatch: {
+    input: z.object({ workspaceIds: z.array(z.string()) }),
+    output: z.record(z.string(), SessionUsageFileSchema.optional()),
+  },
   /** Per-workspace MCP configuration (overrides project-level mcp.jsonc) */
   mcp: {
     get: {

--- a/src/common/utils/tokens/usageAggregator.ts
+++ b/src/common/utils/tokens/usageAggregator.ts
@@ -78,3 +78,33 @@ export function sumUsageHistory(usageHistory: ChatUsageDisplay[]): ChatUsageDisp
 
   return sum;
 }
+
+/**
+ * Calculate total cost from a ChatUsageDisplay object.
+ * Returns undefined if no cost data is available.
+ */
+export function getTotalCost(usage: ChatUsageDisplay | undefined): number | undefined {
+  if (!usage) return undefined;
+  const components = ["input", "cached", "cacheCreate", "output", "reasoning"] as const;
+  let total = 0;
+  let hasAnyCost = false;
+  for (const key of components) {
+    const cost = usage[key].cost_usd;
+    if (cost !== undefined) {
+      total += cost;
+      hasAnyCost = true;
+    }
+  }
+  return hasAnyCost ? total : undefined;
+}
+
+/**
+ * Format cost for display with dollar sign.
+ * Returns "~$0.00" for very small values, "$X.XX" otherwise.
+ */
+export function formatCostWithDollar(cost: number | undefined): string {
+  if (cost === undefined) return "";
+  if (cost === 0) return "$0.00";
+  if (cost < 0.01) return "~$0.00";
+  return `$${cost.toFixed(2)}`;
+}

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -1052,6 +1052,12 @@ export const router = (authToken?: string) => {
         .handler(async ({ context, input }) => {
           return context.sessionUsageService.getSessionUsage(input.workspaceId);
         }),
+      getSessionUsageBatch: t
+        .input(schemas.workspace.getSessionUsageBatch.input)
+        .output(schemas.workspace.getSessionUsageBatch.output)
+        .handler(async ({ context, input }) => {
+          return context.sessionUsageService.getSessionUsageBatch(input.workspaceIds);
+        }),
       stats: {
         subscribe: t
           .input(schemas.workspace.stats.subscribe.input)


### PR DESCRIPTION
## Summary

This PR adds cost display for archived workspaces to help users track spending across their archived work.

### Features

- **Per-workspace cost display**: Each archived workspace row shows its total cost
- **Per-period rollup costs**: Each time bucket header (Today, Yesterday, This Week, etc.) shows the sum of costs for workspaces in that period  
- **Total cost**: The main header shows total cost across all archived workspaces

### UI Layout

Costs are displayed without increasing screen real-estate:
- **Header**: `Archived Workspaces (34) $52.18`
- **Period header**: `Today  $12.45` (right-aligned)
- **Workspace row**: Cost displayed before action buttons

### Implementation

- Added `getSessionUsageBatch` API to fetch session usage for multiple workspaces in one call (avoids N+1 queries)
- Batch API skips message rebuild for speed (archived workspaces should already have session-usage.json)
- Graceful degradation: costs only appear when data is available

### Storybook

Updated `ProjectPageWithArchivedWorkspaces` story with mock cost data demonstrating varied costs across time buckets.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_