### PR TITLE
🤖 fix: eliminate streaming barrier flash with optimistic states

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -136,6 +136,7 @@ Avoid mock-heavy tests that verify implementation details rather than behavior. 
 
 ## Component State & Storage
 
+- Prefer **self-contained components** over utility functions + hook proliferation. A component that takes `workspaceId` and computes everything internally is better than one that requires 10 props drilled from parent hooks.
 - Parent components own localStorage interactions; children announce intent only.
 - **Never call `localStorage` directly** — always use `usePersistedState`/`readPersistedState`/`updatePersistedState` helpers. This includes inside `useCallback`, event handlers, and non-React functions. The helpers handle JSON parsing, error recovery, and cross-component sync.
 - When a component needs to read persisted state it doesn't own (to avoid layout flash), use `readPersistedState` in `useState` initializer: `useState(() => readPersistedState(key, default))`.

--- a/src/browser/components/Messages/ChatBarrier/StreamingBarrier.tsx
+++ b/src/browser/components/Messages/ChatBarrier/StreamingBarrier.tsx
@@ -1,21 +1,118 @@
 import React from "react";
 import { BaseBarrier } from "./BaseBarrier";
+import { getModelName } from "@/common/utils/ai/models";
+import { formatKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
+import { VIM_ENABLED_KEY, getModelKey } from "@/common/constants/storage";
+import { readPersistedState } from "@/browser/hooks/usePersistedState";
+import {
+  useWorkspaceState,
+  useWorkspaceAggregator,
+  useWorkspaceStatsSnapshot,
+} from "@/browser/stores/WorkspaceStore";
+import { useFeatureFlags } from "@/browser/contexts/FeatureFlagsContext";
+import { getDefaultModel } from "@/browser/hooks/useModelsFromSettings";
+
+type StreamingPhase =
+  | "starting" // Message sent, waiting for stream-start
+  | "interrupting" // User triggered interrupt, waiting for stream-abort
+  | "streaming" // Normal streaming
+  | "compacting" // Compaction in progress
+  | "awaiting-input"; // ask_user_question waiting for response
 
 interface StreamingBarrierProps {
+  workspaceId: string;
   className?: string;
-  statusText: string; // e.g., "claude-sonnet-4-5 streaming..."
-  cancelText: string; // e.g., "hit Esc to cancel"
-  tokenCount?: number;
-  tps?: number;
 }
 
-export const StreamingBarrier: React.FC<StreamingBarrierProps> = ({
-  className,
-  statusText,
-  cancelText,
-  tokenCount,
-  tps,
-}) => {
+/**
+ * Self-contained streaming status barrier.
+ * Computes all state internally from workspaceId - no props drilling needed.
+ * Returns null when there's nothing to show.
+ */
+export const StreamingBarrier: React.FC<StreamingBarrierProps> = ({ workspaceId, className }) => {
+  const workspaceState = useWorkspaceState(workspaceId);
+  const aggregator = useWorkspaceAggregator(workspaceId);
+  const statsSnapshot = useWorkspaceStatsSnapshot(workspaceId);
+  const { statsTabState } = useFeatureFlags();
+  const statsEnabled = Boolean(statsTabState?.enabled);
+
+  const { canInterrupt, isCompacting, awaitingUserQuestion, currentModel, pendingStreamStartTime } =
+    workspaceState;
+
+  // Determine if we're in "starting" phase (message sent, waiting for stream-start)
+  const isStarting = pendingStreamStartTime !== null && !canInterrupt;
+
+  // Compute streaming phase
+  const phase: StreamingPhase | null = (() => {
+    if (isStarting) return "starting";
+    if (!canInterrupt) return null;
+    if (aggregator?.hasInterruptingStream()) return "interrupting";
+    if (awaitingUserQuestion) return "awaiting-input";
+    if (isCompacting) return "compacting";
+    return "streaming";
+  })();
+
+  // Nothing to show
+  if (!phase) return null;
+
+  // Model to display: for "starting" read from localStorage (cheap), otherwise use currentModel
+  const model =
+    phase === "starting"
+      ? (readPersistedState<string | null>(getModelKey(workspaceId), null) ?? getDefaultModel())
+      : currentModel;
+  const modelName = model ? getModelName(model) : null;
+
+  // Vim mode affects cancel keybind hint (read once per render, no subscription needed)
+  const vimEnabled = readPersistedState(VIM_ENABLED_KEY, false);
+
+  // Compute status text based on phase
+  const statusText = (() => {
+    switch (phase) {
+      case "starting":
+        return modelName ? `${modelName} starting...` : "starting...";
+      case "interrupting":
+        return "interrupting...";
+      case "awaiting-input":
+        return "Awaiting your input...";
+      case "compacting":
+        return modelName ? `${modelName} compacting...` : "compacting...";
+      case "streaming":
+        return modelName ? `${modelName} streaming...` : "streaming...";
+    }
+  })();
+
+  // Compute cancel hint based on phase
+  const cancelText = (() => {
+    switch (phase) {
+      case "starting":
+      case "interrupting":
+        return "";
+      case "awaiting-input":
+        return "type a message to respond";
+      case "compacting":
+      case "streaming":
+        return `hit ${formatKeybind(vimEnabled ? KEYBINDS.INTERRUPT_STREAM_VIM : KEYBINDS.INTERRUPT_STREAM_NORMAL)} to cancel`;
+    }
+  })();
+
+  // Only show token count during active streaming/compacting
+  const showTokenCount = phase === "streaming" || phase === "compacting";
+
+  // Get token stats from aggregator or stats snapshot
+  const activeStreamMessageId = aggregator?.getActiveStreamMessageId();
+  const tokenCount =
+    showTokenCount && activeStreamMessageId
+      ? statsEnabled && statsSnapshot?.active?.messageId === activeStreamMessageId
+        ? statsSnapshot.active.liveTokenCount
+        : aggregator?.getStreamingTokenCount(activeStreamMessageId)
+      : undefined;
+  const tps =
+    showTokenCount && activeStreamMessageId
+      ? statsEnabled && statsSnapshot?.active?.messageId === activeStreamMessageId
+        ? statsSnapshot.active.liveTPS
+        : aggregator?.getStreamingTPS(activeStreamMessageId)
+      : undefined;
+
   return (
     <div className={`flex items-center justify-between gap-4 ${className ?? ""}`}>
       <div className="flex flex-1 items-center gap-2">

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -989,6 +989,19 @@ export class WorkspaceStore {
     return this.aggregators.get(workspaceId);
   }
 
+  /**
+   * Mark the current active stream as "interrupting" (transient state).
+   * Call this before invoking interruptStream so the UI shows "interrupting..."
+   * immediately, avoiding a visual flash when the backend confirmation arrives.
+   */
+  setInterrupting(workspaceId: string): void {
+    const aggregator = this.aggregators.get(workspaceId);
+    if (aggregator) {
+      aggregator.setInterrupting();
+      this.states.bump(workspaceId);
+    }
+  }
+
   getWorkspaceStatsSnapshot(workspaceId: string): WorkspaceStatsSnapshot | null {
     return this.statsStore.get(workspaceId, () => {
       return this.workspaceStats.get(workspaceId) ?? null;


### PR DESCRIPTION
## Problem

When interrupting a chat with a queued message, there's a visual flash because the "interrupted" barrier appears after the backend confirms the abort - but the user's new message has already appeared in the chat.

Similarly, at the start of a stream, there's a layout flash when the streaming barrier appears after the first stream-start event arrives.

## Solution

Add optimistic UI states for the streaming barrier:

- **`starting...`** - shown immediately when message is sent, before `stream-start` arrives
- **`interrupting...`** - shown immediately when user triggers interrupt, before `stream-abort` arrives

This eliminates layout shifts at both the start and end of streams.

## Changes

- `StreamingMessageAggregator`: track `interruptingMessageId` transient state with `setInterrupting()`, `hasInterruptingStream()` methods
- `WorkspaceStore`: expose `setInterrupting(workspaceId)` method
- `AIView`: 
  - Show StreamingBarrier when `canInterrupt || isStarting`
  - Status text: `starting...` → `streaming...` → `interrupting...` → InterruptedBarrier
  - Hide cancel hint and token counts during starting/interrupting states

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_