### PR TITLE
🤖 fix: restore streaming barrier token count display

### DIFF
--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -53,6 +53,9 @@ export interface WorkspaceState {
   todos: TodoItem[];
   agentStatus: { emoji: string; message: string; url?: string } | undefined;
   pendingStreamStartTime: number | null;
+  // Live streaming stats (updated on each stream-delta)
+  streamingTokenCount: number | undefined;
+  streamingTPS: number | undefined;
 }
 
 /**
@@ -821,6 +824,15 @@ export class WorkspaceStore {
       const messages = aggregator.getAllMessages();
       const metadata = this.workspaceMetadata.get(workspaceId);
 
+      // Live streaming stats
+      const activeStreamMessageId = aggregator.getActiveStreamMessageId();
+      const streamingTokenCount = activeStreamMessageId
+        ? aggregator.getStreamingTokenCount(activeStreamMessageId)
+        : undefined;
+      const streamingTPS = activeStreamMessageId
+        ? aggregator.getStreamingTPS(activeStreamMessageId)
+        : undefined;
+
       return {
         name: metadata?.name ?? workspaceId, // Fall back to ID if metadata missing
         messages: aggregator.getDisplayedMessages(),
@@ -835,6 +847,8 @@ export class WorkspaceStore {
         todos: aggregator.getCurrentTodos(),
         agentStatus: aggregator.getAgentStatus(),
         pendingStreamStartTime: aggregator.getPendingStreamStartTime(),
+        streamingTokenCount,
+        streamingTPS,
       };
     });
   }


### PR DESCRIPTION
## Problem

PR #1280 made StreamingBarrier self-contained but broke token count display. The barrier always showed "0 tokens" unless the statsTab experiment was enabled.

## Root Cause

`useWorkspaceAggregator` returns the aggregator reference without subscribing to updates. The aggregator is mutated in place during streaming, but React doesn't know to re-render.

Previously, AIView computed token counts and re-rendered frequently due to many state dependencies. The self-contained barrier lacked those dependencies.

## Solution

Add a 100ms polling interval during active streaming/compacting phases to force re-renders and pick up updated token counts from the aggregator.

## Also

- Rename `statsEnabled` → `statsTabEnabled` for clarity (matches experiment name)
- Move hooks before early return to satisfy React rules-of-hooks

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `medium`_