### PR TITLE
🤖 fix: preserve plan file after propose_plan Start Here

### DIFF
--- a/src/browser/components/tools/ProposePlanToolCall.test.tsx
+++ b/src/browser/components/tools/ProposePlanToolCall.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { GlobalWindow } from "happy-dom";
+import { cleanup, render } from "@testing-library/react";
+
+import { TooltipProvider } from "../ui/tooltip";
+
+import { ProposePlanToolCall } from "./ProposePlanToolCall";
+
+let startHereCalls: Array<{
+  workspaceId: string | undefined;
+  content: string;
+  isCompacted: boolean;
+  options: { deletePlanFile?: boolean } | undefined;
+}> = [];
+
+const useStartHereMock = mock(
+  (
+    workspaceId: string | undefined,
+    content: string,
+    isCompacted: boolean,
+    options?: { deletePlanFile?: boolean }
+  ) => {
+    startHereCalls.push({ workspaceId, content, isCompacted, options });
+    return {
+      openModal: () => undefined,
+      isStartingHere: false,
+      buttonLabel: "Start Here",
+      buttonEmoji: "",
+      disabled: false,
+      modal: null,
+    };
+  }
+);
+
+void mock.module("@/browser/hooks/useStartHere", () => ({
+  useStartHere: useStartHereMock,
+}));
+
+void mock.module("@/browser/contexts/API", () => ({
+  useAPI: () => ({ api: null, status: "connected" as const, error: null }),
+}));
+
+void mock.module("@/browser/hooks/useOpenInEditor", () => ({
+  useOpenInEditor: () => () => Promise.resolve({ success: true } as const),
+}));
+
+void mock.module("@/browser/contexts/WorkspaceContext", () => ({
+  useWorkspaceContext: () => ({
+    workspaceMetadata: new Map<string, { runtimeConfig?: unknown }>(),
+  }),
+}));
+
+describe("ProposePlanToolCall Start Here", () => {
+  beforeEach(() => {
+    startHereCalls = [];
+    globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
+    globalThis.document = globalThis.window.document;
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.window = undefined as unknown as Window & typeof globalThis;
+    globalThis.document = undefined as unknown as Document;
+  });
+
+  test("keeps plan file on disk and includes plan path note in Start Here content", () => {
+    const planPath = "~/.mux/plans/demo/ws-123.md";
+
+    render(
+      <TooltipProvider>
+        <ProposePlanToolCall
+          args={{}}
+          result={{
+            success: true,
+            planPath,
+            // Old-format chat history may include planContent; this is the easiest path to
+            // ensure the rendered Start Here message includes the full plan + the path note.
+            planContent: "# My Plan\n\nDo the thing.",
+          }}
+          workspaceId="ws-123"
+          isLatest={false}
+        />
+      </TooltipProvider>
+    );
+
+    expect(startHereCalls.length).toBe(1);
+    expect(startHereCalls[0]?.options).toBeUndefined();
+    expect(startHereCalls[0]?.isCompacted).toBe(false);
+
+    // The Start Here message should explicitly tell the user the plan file remains on disk.
+    expect(startHereCalls[0]?.content).toContain("*Plan file preserved at:*");
+    expect(startHereCalls[0]?.content).toContain(planPath);
+  });
+});

--- a/src/browser/components/tools/ProposePlanToolCall.tsx
+++ b/src/browser/components/tools/ProposePlanToolCall.tsx
@@ -223,8 +223,11 @@ export const ProposePlanToolCall: React.FC<ProposePlanToolCallProps> = (props) =
     planTitle = "Plan";
   }
 
-  // Format: Title as H1 + plan content for "Start Here" functionality
-  const startHereContent = `# ${planTitle}\n\n${planContent}`;
+  // Format: Title as H1 + plan content for "Start Here" functionality.
+  // Note: we intentionally preserve the plan file on disk when starting here so it can be
+  // referenced later (e.g., via post-compaction attachments).
+  const planPathNote = planPath ? `\n\n---\n\n*Plan file preserved at:* \`${planPath}\`` : "";
+  const startHereContent = `# ${planTitle}\n\n${planContent}${planPathNote}`;
   const {
     openModal,
     buttonLabel,
@@ -233,8 +236,7 @@ export const ProposePlanToolCall: React.FC<ProposePlanToolCallProps> = (props) =
   } = useStartHere(
     workspaceId,
     startHereContent,
-    false, // Plans are never already compacted
-    { deletePlanFile: true }
+    false // Plans are never already compacted
   );
 
   // Copy to clipboard with feedback

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -1921,7 +1921,8 @@ export class WorkspaceService extends EventEmitter {
       }
 
       // Optional cleanup: delete plan file when caller explicitly requests it.
-      // Used by propose_plan "Start Here" to prevent stale plans from lingering on disk.
+      // Note: the propose_plan UI keeps the plan file on disk; this flag is reserved for
+      // explicit reset flows and backwards compatibility.
       if (options?.deletePlanFile === true) {
         const metadata = await this.getInfo(workspaceId);
         if (metadata) {


### PR DESCRIPTION
Fixes a case where clicking **Start Here** on a proposed plan deletes the plan
markdown file, preventing post-compaction `plan_file_reference` attachments.

- Stop requesting `deletePlanFile` when starting from a proposed plan
- Include the plan path in the Start Here message (when known)
- Add a unit test covering the Start Here hook inputs

Validation: `make static-check`.

---

<details>
<summary>📋 Implementation Plan</summary>

# Preserve plan file across compactions (post-compaction attachments)

## What’s happening (root cause)

Compaction itself **does not delete the plan file**.

- **Compaction path**: `CompactionHandler.performCompaction()` clears only `chat.jsonl` via `HistoryService.clearHistory()` and then appends a summary message. It never calls the workspace-level history helpers that clean up plan files.
  - `src/node/services/compactionHandler.ts` → `historyService.clearHistory()`
  - `src/node/services/historyService.ts` → `truncateHistory(..., 1.0)` (deletes `chat.jsonl` only)

The plan markdown file is deleted by *other* “reset-like” flows:

1) **“Start Here” on a proposed plan** (most likely):
   - UI: `ProposePlanToolCall.tsx` calls `useStartHere(..., { deletePlanFile: true })`.
   - ORPC: `api.workspace.replaceChatHistory({ deletePlanFile: true })`.
   - Backend: `WorkspaceService.replaceHistory(..., { deletePlanFile: true })` → `deletePlanFilesForWorkspace()`.

2) **Full history clear**: `WorkspaceService.truncateHistory(workspaceId, 1.0)` also deletes the plan file.

Because the proposed-plan “Start Here” flow deletes the plan file, later compactions can’t generate the `plan_file_reference` post-compaction attachment (AttachmentService reads the plan file from disk).

## Repro (current behavior)

1. Enter Plan Mode and write a plan (plan file exists under `~/.mux/plans/<project>/<workspace>.md`).
2. Call `propose_plan`.
3. Click **Start Here** in the plan tool UI.
4. Observe the plan file is removed from `~/.mux/plans/...`.
5. Later, when compaction happens, `AttachmentService.generatePlanFileReference()` returns `null` (file missing), so the post-compaction attachment does not include the plan.

## Fix options

### Option A (recommended): Don’t delete the plan file on propose_plan “Start Here”
**Net LoC (product code): ~+0 to +10**

1. **Frontend:** keep the plan file on disk when the user clicks **Start Here**:
   - `src/browser/components/tools/ProposePlanToolCall.tsx`
   - Change `useStartHere(..., { deletePlanFile: true })` → omit the option (or pass `{ deletePlanFile: false }`).
2. **Frontend UX (recommended):** add a small note into the Start Here content that the plan is still stored at the plan file path.
   - Keep it short and conditional on `planPath` being known (so it doesn’t break legacy/edge cases).
   - Example copy: `*Plan file preserved at: <path>*`.
3. **Backend comment cleanup:** update/remove the comment in `WorkspaceService.replaceHistory()` that claims propose_plan Start Here deletes the plan file.
4. (Optional) Keep the backend `deletePlanFile` plumbing intact (it may still be useful for a future explicit “delete plan file” action).

Why this works: post-compaction attachments read the plan file from disk (`AttachmentService.generatePlanFileReference`), and the attachment system is explicitly “mode-agnostic” (valuable in exec mode too).

### Option B: Keep deleting the plan file, but persist a “plan snapshot” for compaction
**Net LoC (product code): ~+120–200**

Store an immutable snapshot at Start Here time (e.g., `~/.mux/sessions/<ws>/plan-snapshot.md`), and have `AttachmentService` fall back to this snapshot when the plan file is missing.

This keeps the “no lingering plan files” behavior but still preserves plan context for post-compaction attachments.

<details>
<summary>Details (Option B)</summary>

- On Start Here (propose plan), write snapshot before deleting plan file.
- Update `AttachmentService.generatePlanFileReference()` to:
  1) read `getPlanFilePath()`
  2) read legacy path
  3) read snapshot path
- Decide cleanup rules (delete snapshot on full clear, workspace delete, etc.).

</details>

### Option C (defensive hardening): If plan file is missing, don’t filter plan diffs out
**Net LoC (product code): ~+10–25**

In `AttachmentService.generatePostCompactionAttachments()`, only filter out plan paths from `edited_files_reference` **if** a `plan_file_reference` attachment was successfully created.

This doesn’t fix the Start Here case (history was replaced, so there are no plan diffs to extract), but it prevents *other* “plan file missing” scenarios from silently dropping plan context.

## Tests / validation

1. Manual:
   - Run through the repro steps and confirm the plan file still exists after Start Here.
   - Confirm the Start Here message includes the “plan file preserved at …” note (with the correct path).
   - Trigger compaction and verify a `plan_file_reference` post-compaction attachment is injected.

2. Automated (pick one):
   - Browser unit test: mount `ProposePlanToolCall` and assert `replaceChatHistory` is called with `deletePlanFile: undefined/false`, and that the `summaryMessage` content includes the plan path note.
   - Node unit test: verify `WorkspaceService.replaceHistory(..., { deletePlanFile: true })` deletes plan file, and `deletePlanFile: false` does not (guard against regressions).

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: openai:gpt-5.2 • Thinking: xhigh_
