### PR TITLE
🤖 perf: event-driven git status updates instead of polling

### DIFF
--- a/src/browser/components/RightSidebar/CodeReview/ReviewPanel.tsx
+++ b/src/browser/components/RightSidebar/CodeReview/ReviewPanel.tsx
@@ -45,6 +45,7 @@ import { applyFrontendFilters } from "@/browser/utils/review/filterHunks";
 import { cn } from "@/common/lib/utils";
 import { useAPI, type APIClient } from "@/browser/contexts/API";
 import { workspaceStore } from "@/browser/stores/WorkspaceStore";
+import { invalidateGitStatus } from "@/browser/stores/GitStatusStore";
 
 /** Stats reported to parent for tab display */
 interface ReviewPanelStats {
@@ -242,6 +243,7 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
     diffBase: filters.diffBase,
     onRefresh: () => setRefreshTrigger((prev) => prev + 1),
     scrollContainerRef,
+    onGitStatusRefresh: () => invalidateGitStatus(workspaceId),
   });
 
   const handleRefresh = () => {

--- a/src/browser/stores/GitStatusStore.ts
+++ b/src/browser/stores/GitStatusStore.ts
@@ -10,25 +10,26 @@ import {
 import { useSyncExternalStore } from "react";
 import { MapStore } from "./MapStore";
 import { isSSHRuntime } from "@/common/types/runtime";
+import { RefreshController } from "@/browser/utils/RefreshController";
 
 /**
  * External store for git status of all workspaces.
  *
  * Architecture:
  * - Lives outside React lifecycle (stable references)
- * - Polls git status every 3 seconds
+ * - Event-driven updates (no polling):
+ *   - Initial subscription triggers immediate fetch
+ *   - File-modifying tools trigger debounced refresh (3s)
+ *   - Window focus triggers refresh for visible workspaces
+ *   - Explicit invalidation (branch switch, etc.)
  * - Manages git fetch with exponential backoff
  * - Notifies subscribers when status changes
  * - Components only re-render when their specific workspace status changes
  *
- * Migration from GitStatusContext:
- * - Eliminates provider re-renders every 3 seconds
- * - useSyncExternalStore enables selective re-renders
- * - Store manages polling logic internally (no useEffect cleanup in components)
+ * Uses RefreshController for debouncing, focus handling, and in-flight guards.
  */
 
 // Configuration
-const GIT_STATUS_INTERVAL_MS = 3000; // 3 seconds - interactive updates
 const MAX_CONCURRENT_GIT_OPS = 5;
 
 // Fetch configuration - aggressive intervals for fresh data
@@ -45,16 +46,28 @@ export class GitStatusStore {
   private statuses = new MapStore<string, GitStatus | null>();
   private fetchCache = new Map<string, FetchState>();
   private client: RouterClient<AppRouter> | null = null;
-  private pollInterval: NodeJS.Timeout | null = null;
   private immediateUpdateQueued = false;
   private workspaceMetadata = new Map<string, FrontendWorkspaceMetadata>();
   private isActive = true;
 
+  // File modification subscription
+  private fileModifyUnsubscribe: (() => void) | null = null;
+
+  // RefreshController handles debouncing, focus/visibility, and in-flight guards
+  private readonly refreshController: RefreshController;
+
   setClient(client: RouterClient<AppRouter>) {
     this.client = client;
   }
+
   constructor() {
-    // Store is ready for workspace sync
+    // Create refresh controller with proactive focus refresh (catches external git changes)
+    this.refreshController = new RefreshController({
+      onRefresh: () => this.updateGitStatus(),
+      debounceMs: 3000, // Same as TOOL_REFRESH_DEBOUNCE_MS in ReviewPanel
+      refreshOnFocus: true, // Proactively refresh on focus to catch external changes
+      focusDebounceMs: 500, // Prevent spam from rapid alt-tabbing
+    });
   }
 
   /**
@@ -70,16 +83,14 @@ export class GitStatusStore {
   subscribeKey = (workspaceId: string, listener: () => void) => {
     const unsubscribe = this.statuses.subscribeKey(workspaceId, listener);
 
-    // If a component subscribes after we started polling (common on initial load),
-    // kick an immediate update so the UI doesn't wait for the next interval tick.
-    //
-    // We schedule the update as a microtask to avoid doing work in the subscribe
-    // call itself, and to preserve the batching/concurrency limits of updateGitStatus().
+    // If a component subscribes after initial load, kick an immediate update
+    // so the UI doesn't wait. Uses microtask to batch multiple subscriptions.
+    // Routes through RefreshController to respect in-flight guards.
     if (!this.immediateUpdateQueued && this.isActive && this.client) {
       this.immediateUpdateQueued = true;
       queueMicrotask(() => {
         this.immediateUpdateQueued = false;
-        void this.updateGitStatus();
+        this.refreshController.requestImmediate();
       });
     }
 
@@ -114,8 +125,8 @@ export class GitStatusStore {
     this.statusCache.set(workspaceId, null);
     // Bump version to notify subscribers of the null state
     this.statuses.bump(workspaceId);
-    // Trigger immediate update to fetch fresh status
-    void this.updateGitStatus();
+    // Trigger immediate refresh (routes through RefreshController for in-flight guard)
+    this.refreshController.requestImmediate();
   }
 
   private statusCache = new Map<string, GitStatus | null>();
@@ -146,38 +157,11 @@ export class GitStatusStore {
       }
     }
 
-    // Start polling only once (not on every sync)
-    if (!this.pollInterval) {
-      this.startPolling();
-    }
-  }
+    // Bind focus/visibility listeners once (catches external git changes)
+    this.refreshController.bindListeners();
 
-  /**
-   * Start polling git status.
-   */
-  private startPolling(): void {
-    // Clear existing interval
-    if (this.pollInterval) {
-      clearInterval(this.pollInterval);
-    }
-
-    // Run immediately
-    void this.updateGitStatus();
-
-    // Poll at configured interval
-    this.pollInterval = setInterval(() => {
-      void this.updateGitStatus();
-    }, GIT_STATUS_INTERVAL_MS);
-  }
-
-  /**
-   * Stop polling git status.
-   */
-  private stopPolling(): void {
-    if (this.pollInterval) {
-      clearInterval(this.pollInterval);
-      this.pollInterval = null;
-    }
+    // Initial fetch for all workspaces (routes through RefreshController)
+    this.refreshController.requestImmediate();
   }
 
   /**
@@ -480,9 +464,35 @@ export class GitStatusStore {
    */
   dispose(): void {
     this.isActive = false;
-    this.stopPolling();
     this.statuses.clear();
     this.fetchCache.clear();
+    this.fileModifyUnsubscribe?.();
+    this.fileModifyUnsubscribe = null;
+    this.refreshController.dispose();
+  }
+
+  /**
+   * Subscribe to file-modifying tool completions from WorkspaceStore.
+   * Triggers debounced git status refresh when files change.
+   * Idempotent: only subscribes once, subsequent calls are no-ops.
+   */
+  subscribeToFileModifications(
+    subscribeAny: (listener: (workspaceId: string) => void) => () => void
+  ): void {
+    // Only subscribe once - subsequent calls are no-ops
+    if (this.fileModifyUnsubscribe) {
+      return;
+    }
+
+    this.fileModifyUnsubscribe = subscribeAny((workspaceId) => {
+      // Only schedule if workspace has subscribers (same optimization as before)
+      if (!this.statuses.hasKeySubscribers(workspaceId)) {
+        return;
+      }
+
+      // RefreshController handles debouncing, focus gating, and in-flight guards
+      this.refreshController.schedule();
+    });
   }
 }
 

--- a/src/browser/utils/RefreshController.test.ts
+++ b/src/browser/utils/RefreshController.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from "@jest/globals";
+import { RefreshController } from "./RefreshController";
+
+describe("RefreshController", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("debounces multiple schedule() calls", () => {
+    const onRefresh = jest.fn<() => void>();
+    const controller = new RefreshController({ onRefresh, debounceMs: 100 });
+
+    controller.schedule();
+    controller.schedule();
+    controller.schedule();
+
+    expect(onRefresh).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(100);
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+
+    controller.dispose();
+  });
+
+  it("requestImmediate() bypasses debounce", () => {
+    const onRefresh = jest.fn<() => void>();
+    const controller = new RefreshController({ onRefresh, debounceMs: 100 });
+
+    controller.schedule();
+    expect(onRefresh).not.toHaveBeenCalled();
+
+    controller.requestImmediate();
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+
+    // Original debounce timer should be cleared
+    jest.advanceTimersByTime(100);
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+
+    controller.dispose();
+  });
+
+  it("guards against concurrent sync refreshes (in-flight queuing)", () => {
+    // Track if refresh is currently in-flight
+    let inFlight = false;
+    const onRefresh = jest.fn(() => {
+      // Simulate sync operation that takes time
+      expect(inFlight).toBe(false); // Should never be called while already in-flight
+      inFlight = true;
+      // Immediately complete (sync)
+      inFlight = false;
+    });
+
+    const controller = new RefreshController({ onRefresh, debounceMs: 100 });
+
+    // Multiple immediate requests should only call once (queued ones execute after)
+    controller.requestImmediate();
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+
+    controller.dispose();
+  });
+
+  it("isRefreshing reflects in-flight state", () => {
+    let resolveRefresh: () => void;
+    const refreshPromise = new Promise<void>((resolve) => {
+      resolveRefresh = resolve;
+    });
+
+    const onRefresh = jest.fn(() => refreshPromise);
+    const controller = new RefreshController({ onRefresh, debounceMs: 100 });
+
+    expect(controller.isRefreshing).toBe(false);
+
+    controller.requestImmediate();
+    expect(controller.isRefreshing).toBe(true);
+
+    // Complete the promise
+    resolveRefresh!();
+
+    controller.dispose();
+  });
+
+  it("dispose() cleans up debounce timer", () => {
+    const onRefresh = jest.fn<() => void>();
+    const controller = new RefreshController({ onRefresh, debounceMs: 100 });
+
+    controller.schedule();
+    controller.dispose();
+
+    jest.advanceTimersByTime(100);
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it("does not refresh after dispose", () => {
+    const onRefresh = jest.fn<() => void>();
+    const controller = new RefreshController({ onRefresh, debounceMs: 100 });
+
+    controller.dispose();
+    controller.schedule();
+    controller.requestImmediate();
+
+    jest.advanceTimersByTime(100);
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/src/browser/utils/RefreshController.ts
+++ b/src/browser/utils/RefreshController.ts
@@ -1,0 +1,213 @@
+/**
+ * Generic refresh controller with debouncing, focus/visibility handling, and in-flight guards.
+ *
+ * Handles common patterns for event-driven refresh:
+ * - Debounces rapid trigger events (trailing edge)
+ * - Pauses refresh while document is hidden, flushes when visible
+ * - Optionally triggers proactive refresh on focus (for catching external changes)
+ * - Guards against concurrent refresh operations
+ * - Debounces rapid focus/blur cycles
+ *
+ * Used by GitStatusStore and useReviewRefreshController.
+ */
+
+export interface RefreshControllerOptions {
+  /** Called to execute the actual refresh. Can be async. */
+  onRefresh: () => Promise<void> | void;
+
+  /** Debounce delay for triggered refreshes (ms). Default: 3000 */
+  debounceMs?: number;
+
+  /**
+   * Whether to proactively refresh on focus, not just flush pending.
+   * Enable for stores that need to catch external changes (e.g., git status).
+   * Default: false (only flush pending refreshes)
+   */
+  refreshOnFocus?: boolean;
+
+  /** Minimum interval between focus-triggered refreshes (ms). Default: 500 */
+  focusDebounceMs?: number;
+}
+
+export class RefreshController {
+  private readonly onRefresh: () => Promise<void> | void;
+  private readonly debounceMs: number;
+  private readonly refreshOnFocus: boolean;
+  private readonly focusDebounceMs: number;
+
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private inFlight = false;
+  private pendingBecauseHidden = false;
+  private pendingBecauseInFlight = false;
+  private lastFocusRefreshMs = 0;
+  private disposed = false;
+
+  // Track if listeners are bound (for cleanup)
+  private listenersBound = false;
+  private boundHandleVisibility: (() => void) | null = null;
+  private boundHandleFocus: (() => void) | null = null;
+
+  constructor(options: RefreshControllerOptions) {
+    this.onRefresh = options.onRefresh;
+    this.debounceMs = options.debounceMs ?? 3000;
+    this.refreshOnFocus = options.refreshOnFocus ?? false;
+    this.focusDebounceMs = options.focusDebounceMs ?? 500;
+  }
+
+  /**
+   * Schedule a debounced refresh. Multiple calls within debounceMs coalesce.
+   */
+  schedule(): void {
+    if (this.disposed) return;
+
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      this.tryRefresh();
+    }, this.debounceMs);
+  }
+
+  /**
+   * Request immediate refresh, bypassing debounce but respecting in-flight guard.
+   */
+  requestImmediate(): void {
+    if (this.disposed) return;
+
+    // Clear any pending debounce
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+
+    this.tryRefresh();
+  }
+
+  /**
+   * Attempt refresh, respecting pause conditions.
+   */
+  private tryRefresh(): void {
+    if (this.disposed) return;
+
+    // Hidden → queue for visibility
+    if (typeof document !== "undefined" && document.hidden) {
+      this.pendingBecauseHidden = true;
+      return;
+    }
+
+    // In-flight → queue for completion
+    if (this.inFlight) {
+      this.pendingBecauseInFlight = true;
+      return;
+    }
+
+    this.executeRefresh();
+  }
+
+  /**
+   * Execute the refresh, tracking in-flight state.
+   */
+  private executeRefresh(): void {
+    if (this.disposed) return;
+
+    this.inFlight = true;
+
+    const maybePromise = this.onRefresh();
+
+    const onComplete = () => {
+      this.inFlight = false;
+
+      // Process any queued refresh
+      if (this.pendingBecauseInFlight) {
+        this.pendingBecauseInFlight = false;
+        // Defer to avoid recursive stack
+        setTimeout(() => this.tryRefresh(), 0);
+      }
+    };
+
+    if (maybePromise instanceof Promise) {
+      void maybePromise.finally(onComplete);
+    } else {
+      onComplete();
+    }
+  }
+
+  /**
+   * Handle focus/visibility return. Call from visibility/focus listeners.
+   */
+  private handleReturn(): void {
+    if (this.disposed) return;
+    if (typeof document !== "undefined" && document.hidden) return;
+
+    // Flush pending hidden refresh
+    if (this.pendingBecauseHidden) {
+      this.pendingBecauseHidden = false;
+      this.tryRefresh();
+      return; // Don't double-refresh with proactive
+    }
+
+    // Proactive refresh on focus (with debounce)
+    if (this.refreshOnFocus) {
+      const now = Date.now();
+      if (now - this.lastFocusRefreshMs >= this.focusDebounceMs) {
+        this.lastFocusRefreshMs = now;
+        this.tryRefresh();
+      }
+    }
+  }
+
+  /**
+   * Bind focus/visibility listeners. Call once after construction.
+   * Safe to call in non-browser environments (no-op).
+   */
+  bindListeners(): void {
+    if (this.listenersBound) return;
+    if (typeof document === "undefined" || typeof window === "undefined") return;
+
+    this.listenersBound = true;
+
+    this.boundHandleVisibility = () => {
+      if (document.visibilityState === "visible") {
+        this.handleReturn();
+      }
+    };
+
+    this.boundHandleFocus = () => {
+      this.handleReturn();
+    };
+
+    document.addEventListener("visibilitychange", this.boundHandleVisibility);
+    window.addEventListener("focus", this.boundHandleFocus);
+  }
+
+  /**
+   * Whether a refresh is currently in-flight.
+   */
+  get isRefreshing(): boolean {
+    return this.inFlight;
+  }
+
+  /**
+   * Clean up timers and listeners.
+   */
+  dispose(): void {
+    this.disposed = true;
+
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+
+    if (this.listenersBound) {
+      if (this.boundHandleVisibility) {
+        document.removeEventListener("visibilitychange", this.boundHandleVisibility);
+      }
+      if (this.boundHandleFocus) {
+        window.removeEventListener("focus", this.boundHandleFocus);
+      }
+      this.listenersBound = false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Replaces 3-second interval polling for git status (dirty/ahead-behind/additions-deletions) with event-driven updates.

## Trigger strategy

Git status now refreshes when:
- **File-modifying tool completions** (bash, file_edit_*) — 3s trailing-edge debounce, same as ReviewPanel
- **Window focus / visibility change** — catches external git operations (user ran git commands outside mux)
- **Initial UI subscription** — immediate fetch when workspace indicator first renders
- **Explicit invalidation** — branch switches and other actions that already call `invalidateWorkspace()`

## Implementation

- **GitStatusStore**: Removed interval polling; added focus/visibility listeners; wires into WorkspaceStore's file-modification events via `subscribeToFileModifications()`
- **WorkspaceStore**: Consolidated `subscribeFileModifyingTool` API — single method with optional workspace filter instead of two separate methods
- **AppLoader**: Wires the subscription at init time
- **Preserved optimization**: Only fetches status for workspaces with active UI subscribers (`hasKeySubscribers`)

## Validation

- `make typecheck` ✓
- `bun test src/browser/stores/` ✓ (60 tests)
- `make static-check` ✓

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
