### PR TITLE
🤖 fix: reduce Storybook flake in Markdown code blocks

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -22,7 +22,9 @@ const config: StorybookConfig = {
       // Prevent Vite from discovering new deps mid-test and forcing a full reload (test-storybook
       // interprets reloads as navigations and flakes). Keep this list minimal.
       optimizeDeps: {
-        include: ["@radix-ui/react-checkbox"],
+        // Storybook test runs can flake if Vite decides to prebundle newly-discovered deps mid-run,
+        // because the preview reload is interpreted as a navigation.
+        include: ["@radix-ui/react-checkbox", "shiki"],
       },
     });
   },

--- a/src/browser/stories/App.markdown.stories.tsx
+++ b/src/browser/stories/App.markdown.stories.tsx
@@ -252,14 +252,21 @@ export const CodeBlocks: AppStory = {
         if (candidates.length < 3) {
           throw new Error(`Expected 3 code-block-wrappers, found ${candidates.length}`);
         }
-        // Each must have highlighted spans (Shiki wraps tokens in spans)
+        // Each wrapper must have switched from plain <code> rendering to Shiki HTML.
+        // Don't rely on nested <span> tokens because plaintext highlighting may not emit them.
         for (const wrapper of candidates) {
-          if (!wrapper.querySelector(".code-line span")) {
-            throw new Error("Not all code blocks highlighted yet");
+          const lines = Array.from(wrapper.querySelectorAll(".code-line"));
+          if (lines.length === 0) {
+            throw new Error("Code lines not rendered yet");
+          }
+          for (const line of lines) {
+            if (line.querySelector("code")) {
+              throw new Error("Not all code blocks highlighted yet");
+            }
           }
         }
       },
-      { timeout: 5000 }
+      { timeout: 15000 }
     );
 
     // Highlighting changes code block height, triggering ResizeObserver → coalesced RAF scroll.


### PR DESCRIPTION
## Summary

Fixes intermittent flakes in the **App → Markdown → CodeBlocks** Storybook interaction test.

## Changes

1. **More reliable "highlighting finished" detection** — The play function was waiting for `.code-line span`, but Shiki's plaintext highlighting can produce lines without nested spans, making that selector unreliable. Changed to verify each `.code-block-wrapper` has switched off the plain fallback path by asserting no `.code-line` still contains a `<code>` child. Also bumped timeout from 5s → 15s to cover cold-start Shiki worker initialization.

2. **Prevent Vite mid-run dependency re-optimization** — Added `shiki` to `.storybook/main.ts` `optimizeDeps.include` so Vite doesn't discover/prebundle it during test runs (which triggers preview reloads that `test-storybook` treats as flaky failures).

## Testing

- Ran `make static-check` locally (all green)
- Ran the specific story test multiple times: `node_modules/.bin/test-storybook --no-cache --maxWorkers 1 -- --testPathPatterns App\.markdown\.stories`

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
