### PR TITLE
🤖 fix: LoadingDots animation broken since Tailwind migration

### DIFF
--- a/src/browser/components/tools/shared/ToolPrimitives.tsx
+++ b/src/browser/components/tools/shared/ToolPrimitives.tsx
@@ -139,8 +139,7 @@ export const LoadingDots: React.FC<React.HTMLAttributes<HTMLSpanElement>> = ({
 }) => (
   <span
     className={cn(
-      "after:content-['...'] after:animate-[dots_1.5s_infinite]",
-      "[&]:after:[@keyframes_dots]{0%,20%{content:'.'};40%{content:'..'};60%,100%{content:'...'}}",
+      "after:content-[''] after:animate-[ellipsis_1.2s_steps(4,end)_infinite]",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary

The `LoadingDots` component broke during the Tailwind migration in #379. The original styled-components version had a working `@keyframes dots` animation, but the Tailwind conversion attempted to define keyframes inline via arbitrary syntax (`[&]:after:[@keyframes_dots]...`) which doesn't work.

## Fix

Use the existing `@keyframes ellipsis` animation that's already defined in `globals.css`.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_