### PR TITLE
🤖 fix: increase storybook helper timeout for CI cold start

### DIFF
--- a/src/browser/stories/storyPlayHelpers.ts
+++ b/src/browser/stories/storyPlayHelpers.ts
@@ -7,6 +7,8 @@ import { waitFor } from "@storybook/test";
  * to let any pending coalesced scroll from useAutoScroll complete.
  */
 export async function waitForChatMessagesLoaded(canvasElement: HTMLElement): Promise<void> {
+  // Use 15s timeout to handle CI cold-start scenarios where large dependencies
+  // (Shiki, Mermaid) are still being loaded/initialized
   await waitFor(
     () => {
       const messageWindow = canvasElement.querySelector('[data-testid="message-window"]');
@@ -14,7 +16,7 @@ export async function waitForChatMessagesLoaded(canvasElement: HTMLElement): Pro
         throw new Error("Messages not loaded yet");
       }
     },
-    { timeout: 5000 }
+    { timeout: 15000 }
   );
 
   // One RAF to let any pending coalesced scroll complete


### PR DESCRIPTION
## Summary

Fixes intermittent flakes in Storybook tests (including TaskWorkflow) during CI cold-start scenarios.

## Problem

The `waitForChatMessagesLoaded` helper in `storyPlayHelpers.ts` used a 5 second timeout. In CI, the first test(s) can take longer to load due to large dependencies (Shiki, Mermaid) being initialized. This caused failures with the error:

```
Message: Messages not loaded yet
```

Example failure in [CI run 20416096418](https://github.com/coder/mux/actions/runs/20416096418) for TaskWorkflow story.

## Fix

Bumped timeout from 5s to 15s, matching the fix in `App.markdown.stories.tsx` (fcecf8067) for the same cold-start issue.

## Testing

- `make typecheck` passes
- Ran storybook tests 5 times locally, all passed

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_