### PR TITLE
🤖 fix: preserve image attachments on message edit

### DIFF
--- a/src/browser/components/AIView.tsx
+++ b/src/browser/components/AIView.tsx
@@ -52,6 +52,7 @@ import {
 } from "@/browser/stores/WorkspaceStore";
 import { WorkspaceHeader } from "./WorkspaceHeader";
 
+import type { ImagePart } from "@/common/orpc/types";
 import type { DisplayedMessage } from "@/common/types/message";
 import type { RuntimeConfig } from "@/common/types/runtime";
 import { getRuntimeTypeForTelemetry } from "@/common/telemetry";
@@ -169,9 +170,9 @@ const AIViewInner: React.FC<AIViewProps> = ({
     pendingModel
   );
 
-  const [editingMessage, setEditingMessage] = useState<{ id: string; content: string } | undefined>(
-    undefined
-  );
+  const [editingMessage, setEditingMessage] = useState<
+    { id: string; content: string; imageParts?: ImagePart[] } | undefined
+  >(undefined);
 
   // Track which bash_output groups are expanded (keyed by first message ID)
   const [expandedBashGroups, setExpandedBashGroups] = useState<Set<string>>(new Set());
@@ -299,9 +300,12 @@ const AIViewInner: React.FC<AIViewProps> = ({
   const { thinkingLevel: currentWorkspaceThinking, setThinkingLevel } = useThinking();
 
   // Handlers for editing messages
-  const handleEditUserMessage = useCallback((messageId: string, content: string) => {
-    setEditingMessage({ id: messageId, content });
-  }, []);
+  const handleEditUserMessage = useCallback(
+    (messageId: string, content: string, imageParts?: ImagePart[]) => {
+      setEditingMessage({ id: messageId, content, imageParts });
+    },
+    []
+  );
 
   const handleEditQueuedMessage = useCallback(async () => {
     const queuedMessage = workspaceState?.queuedMessage;
@@ -357,6 +361,7 @@ const AIViewInner: React.FC<AIViewProps> = ({
     setEditingMessage({
       id: lastUserMessage.historyId,
       content: getEditableUserMessageText(lastUserMessage),
+      imageParts: lastUserMessage.imageParts,
     });
     setAutoScroll(false); // Show jump-to-bottom indicator
 

--- a/src/browser/components/ChatInput/types.ts
+++ b/src/browser/components/ChatInput/types.ts
@@ -23,7 +23,7 @@ export interface ChatInputWorkspaceVariant {
   onProviderConfig?: (provider: string, keyPath: string[], value: string) => Promise<void>;
   onModelChange?: (model: string) => void;
   isCompacting?: boolean;
-  editingMessage?: { id: string; content: string };
+  editingMessage?: { id: string; content: string; imageParts?: ImagePart[] };
   onCancelEdit?: () => void;
   onEditLastUserMessage?: () => void;
   canInterrupt?: boolean;

--- a/src/browser/components/ImageAttachments.tsx
+++ b/src/browser/components/ImageAttachments.tsx
@@ -8,11 +8,14 @@ export interface ImageAttachment {
 
 interface ImageAttachmentsProps {
   images: ImageAttachment[];
-  onRemove: (id: string) => void;
+  /** If omitted, attachments are displayed read-only (no remove button). */
+  onRemove?: (id: string) => void;
 }
 
 export const ImageAttachments: React.FC<ImageAttachmentsProps> = ({ images, onRemove }) => {
   if (images.length === 0) return null;
+
+  const handleRemove = onRemove;
 
   return (
     <div className="flex flex-wrap gap-2 py-2">
@@ -26,14 +29,16 @@ export const ImageAttachments: React.FC<ImageAttachmentsProps> = ({ images, onRe
             alt="Attached image"
             className="pointer-events-none col-start-1 row-start-1 h-full w-full object-cover"
           />
-          <button
-            onClick={() => onRemove(image.id)}
-            title="Remove image"
-            className="col-start-1 row-start-1 m-0.5 flex h-5 w-5 cursor-pointer items-center justify-center self-start justify-self-end rounded-full border-0 bg-black/70 p-0 text-sm leading-none text-white hover:bg-black/90"
-            aria-label="Remove image"
-          >
-            ×
-          </button>
+          {handleRemove && (
+            <button
+              onClick={() => handleRemove(image.id)}
+              title="Remove image"
+              className="col-start-1 row-start-1 m-0.5 flex h-5 w-5 cursor-pointer items-center justify-center self-start justify-self-end rounded-full border-0 bg-black/70 p-0 text-sm leading-none text-white hover:bg-black/90"
+              aria-label="Remove image"
+            >
+              ×
+            </button>
+          )}
         </div>
       ))}
     </div>

--- a/src/browser/components/Messages/MessageRenderer.tsx
+++ b/src/browser/components/Messages/MessageRenderer.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import type { ImagePart } from "@/common/orpc/types";
 import type { DisplayedMessage } from "@/common/types/message";
 import type { BashOutputGroupInfo } from "@/browser/utils/messages/messageUtils";
 import type { ReviewNoteData } from "@/common/types/review";
@@ -15,7 +16,7 @@ import { removeEphemeralMessage } from "@/browser/stores/WorkspaceStore";
 interface MessageRendererProps {
   message: DisplayedMessage;
   className?: string;
-  onEditUserMessage?: (messageId: string, content: string) => void;
+  onEditUserMessage?: (messageId: string, content: string, imageParts?: ImagePart[]) => void;
   onEditQueuedMessage?: () => void;
   workspaceId?: string;
   isCompacting?: boolean;

--- a/src/browser/components/Messages/UserMessage.tsx
+++ b/src/browser/components/Messages/UserMessage.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import type { ImagePart } from "@/common/orpc/types";
 import type { DisplayedMessage } from "@/common/types/message";
 import type { ButtonConfig } from "./MessageWindow";
 import { MessageWindow } from "./MessageWindow";
@@ -15,7 +16,7 @@ import { Clipboard, ClipboardCheck, Pencil } from "lucide-react";
 interface UserMessageProps {
   message: DisplayedMessage & { type: "user" };
   className?: string;
-  onEdit?: (messageId: string, content: string) => void;
+  onEdit?: (messageId: string, content: string, imageParts?: ImagePart[]) => void;
   isCompacting?: boolean;
   clipboardWriteText?: (data: string) => Promise<void>;
 }
@@ -50,7 +51,7 @@ export const UserMessage: React.FC<UserMessageProps> = ({
   const handleEdit = () => {
     if (onEdit && !isLocalCommandOutput) {
       const editText = getEditableUserMessageText(message);
-      onEdit(message.historyId, editText);
+      onEdit(message.historyId, editText, message.imageParts);
     }
   };
 

--- a/src/node/services/agentSession.editMessageId.test.ts
+++ b/src/node/services/agentSession.editMessageId.test.ts
@@ -6,6 +6,7 @@ import type { PartialService } from "@/node/services/partialService";
 import type { InitStateManager } from "@/node/services/initStateManager";
 import type { BackgroundProcessManager } from "@/node/services/backgroundProcessManager";
 import type { Config } from "@/node/config";
+import { createMuxMessage } from "@/common/types/message";
 import type { MuxMessage } from "@/common/types/message";
 import type { SendMessageError } from "@/common/types/errors";
 import type { Result } from "@/common/types/result";
@@ -88,5 +89,99 @@ describe("AgentSession.sendMessage (editMessageId)", () => {
     expect(truncateAfterMessage.mock.calls).toHaveLength(1);
     expect(appendToHistory.mock.calls).toHaveLength(1);
     expect(streamMessage.mock.calls).toHaveLength(1);
+  });
+
+  it("preserves image parts when editing and imageParts are omitted", async () => {
+    const workspaceId = "ws-test";
+
+    const config = {
+      srcDir: "/tmp",
+      getSessionDir: (_workspaceId: string) => "/tmp",
+    } as unknown as Config;
+
+    const originalMessageId = "user-message-with-image";
+    const originalImageUrl = "data:image/png;base64,AAAA";
+
+    const messages: MuxMessage[] = [
+      createMuxMessage(originalMessageId, "user", "original", { historySequence: 0 }, [
+        { type: "file" as const, mediaType: "image/png", url: originalImageUrl },
+      ]),
+    ];
+    let nextSeq = 1;
+
+    const truncateAfterMessage = mock((_workspaceId: string, _messageId: string) => {
+      void _messageId;
+      return Promise.resolve(Ok(undefined));
+    });
+
+    const appendToHistory = mock((_workspaceId: string, message: MuxMessage) => {
+      message.metadata = { ...(message.metadata ?? {}), historySequence: nextSeq++ };
+      messages.push(message);
+      return Promise.resolve(Ok(undefined));
+    });
+
+    const getHistory = mock((_workspaceId: string): Promise<Result<MuxMessage[], string>> => {
+      return Promise.resolve(Ok([...messages]));
+    });
+
+    const historyService = {
+      truncateAfterMessage,
+      appendToHistory,
+      getHistory,
+    } as unknown as HistoryService;
+
+    const partialService = {
+      commitToHistory: mock((_workspaceId: string) => Promise.resolve(Ok(undefined))),
+    } as unknown as PartialService;
+
+    const aiEmitter = new EventEmitter();
+    const streamMessage = mock((_messages: MuxMessage[]) => {
+      return Promise.resolve(Ok(undefined));
+    });
+    const aiService = Object.assign(aiEmitter, {
+      isStreaming: mock((_workspaceId: string) => false),
+      stopStream: mock((_workspaceId: string) => Promise.resolve(Ok(undefined))),
+      streamMessage: streamMessage as unknown as (
+        ...args: Parameters<AIService["streamMessage"]>
+      ) => Promise<Result<void, SendMessageError>>,
+    }) as unknown as AIService;
+
+    const initStateManager = new EventEmitter() as unknown as InitStateManager;
+
+    const backgroundProcessManager = {
+      cleanup: mock((_workspaceId: string) => Promise.resolve()),
+      setMessageQueued: mock((_workspaceId: string, _queued: boolean) => {
+        void _queued;
+      }),
+    } as unknown as BackgroundProcessManager;
+
+    const session = new AgentSession({
+      workspaceId,
+      config,
+      historyService,
+      partialService,
+      aiService,
+      initStateManager,
+      backgroundProcessManager,
+    });
+
+    const result = await session.sendMessage("edited", {
+      model: "anthropic:claude-3-5-sonnet-latest",
+      editMessageId: originalMessageId,
+    });
+
+    expect(result.success).toBe(true);
+    expect(getHistory.mock.calls.length).toBeGreaterThan(0);
+    expect(truncateAfterMessage.mock.calls).toHaveLength(1);
+    expect(appendToHistory.mock.calls).toHaveLength(1);
+
+    const appendedMessage = appendToHistory.mock.calls[0][1];
+    const appendedFileParts = appendedMessage.parts.filter(
+      (part) => part.type === "file"
+    ) as Array<{ type: "file"; url: string; mediaType: string }>;
+
+    expect(appendedFileParts).toHaveLength(1);
+    expect(appendedFileParts[0].url).toBe(originalImageUrl);
+    expect(appendedFileParts[0].mediaType).toBe("image/png");
   });
 });


### PR DESCRIPTION
Fixes a regression where editing a user message would drop its image attachments.

- Thread `imageParts` through the edit pipeline (message -> AIView -> ChatInput) so entering edit mode restores images instead of clearing them.
- Lock attachments during edit (read-only): hide remove controls and ignore paste/drop image additions.
- Add a backend guard: if an edit request omits `imageParts`, reuse the original message’s file parts from history.

Validation:
- `make static-check`
- `bun test src/node/services/agentSession.editMessageId.test.ts`

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix: Editing a message drops image attachments

## Problem
When the user edits a message that contains image attachments (either a queued message or an already-sent/history message), the images disappear and the edited message is re-sent without them.

## Root cause (confirmed in code)
1. **Frontend edit-mode state drops images**
   - `AIView` stores `editingMessage` as `{ id, content }` (no `imageParts`).
   - `UserMessage` calls `onEdit(messageId, content)` (no `imageParts`).
   - `ChatInput` explicitly clears images when `editingMessage` becomes active:
     - `src/browser/components/ChatInput/index.tsx`: `setDraft({ text: editingMessage.content, images: [] })`.

2. **Backend “edit” is destructive (truncate + append)**
   - `AgentSession.sendMessage` with `editMessageId` calls `HistoryService.truncateAfterMessage(...)`, which **removes the original message and all following messages**.
   - The backend then appends a *new* user message using only the fields provided in `sendMessage.options` (`message` text + optional `imageParts`).
   - If the frontend sends `imageParts: undefined` (or an empty list), the original attachments are unrecoverable.

> Note: queued-message editing (restore-to-input) already restores images correctly via `ChatInputAPI.restoreImages(...)`; the regression is primarily the historical message edit pipeline.

---

## Recommended approach (full fix) — preserve + lock attachments
**Net new product LoC (est.):** ~90–140

### 1) Carry imageParts through the “edit message” pipeline (renderer → AIView → ChatInput)
- Update callback + state shapes to include `imageParts?: ImagePart[]`:
  - `src/browser/components/Messages/UserMessage.tsx`
  - `src/browser/components/Messages/MessageRenderer.tsx`
  - `src/browser/components/AIView.tsx`
  - `src/browser/components/ChatInput/types.ts`

**Implementation details**
- Change `onEdit` signature to `(messageId: string, content: string, imageParts?: ImagePart[]) => void`.
- When clicking Edit on a user message, pass `message.imageParts`.
- When using “edit last user message” (ArrowUp), include `lastUserMessage.imageParts` in `setEditingMessage(...)`.

### 2) Initialize ChatInput’s draft with the original images in edit mode
- In `src/browser/components/ChatInput/index.tsx` edit-mode `useEffect`, replace `images: []` with images derived from `editingMessage.imageParts`.
- Prefer a small pure helper (easy to unit test) such as:
  - `imagePartsToAttachments(imageParts: ImagePart[], idPrefix: string): ImageAttachment[]`

### 3) Enforce “text-only edits” in the UI (attachments visible but read-only)
To match the requirement “I can only change the message’s text”:
- Update `src/browser/components/ImageAttachments.tsx` so the remove control is optional:
  - e.g. `onRemove?: (id: string) => void` or `readOnly?: boolean`.
  - When editing, render images but hide/disable the remove button.
- In `ChatInput`, when `editingMessage` is set:
  - Disable adding images via paste / drag-drop (early-return from `handlePaste` / `handleDrop`; optionally show a toast like “Images can’t be changed while editing”).

### 4) Defense-in-depth: preserve original image parts server-side during edit
Even with the UI fix, we should prevent older clients / future regressions from dropping attachments.

- In `src/node/services/agentSession.ts`:
  1. If `options.editMessageId` is set, load the existing message from `historyService.getHistory(...)` **before truncating**.
  2. Extract its existing image/file parts.
  3. When constructing the new edited user message:
     - If `options.imageParts` is missing/empty, **reuse the original image parts**.
     - (Optional, stricter) If `options.imageParts` differs from original, ignore them or return an error, enforcing “text-only” at the API boundary.

---

## Tests
### Backend (fast unit test)
- Extend `src/node/services/agentSession.editMessageId.test.ts`:
  - Seed history with a user message that contains a `file` part.
  - Call `sendMessage("edited text", { editMessageId: <id>, model: ..., imageParts: undefined })`.
  - Assert the appended message still contains the image part.

### Frontend (focused unit tests)
Pick one (keep it minimal):
- Unit test for `imagePartsToAttachments(...)` helper (pure).
- Or a small `@testing-library/react` test for `ChatInput` edit-mode initialization (ensure attachments render in edit mode).

---

## Manual QA checklist
1. Send a user message with 1–2 images.
2. Click **Edit** on that message.
   - Images should still be shown in ChatInput.
   - Remove button should be hidden/disabled (text-only).
   - Pasting/dropping images should not change attachments.
3. Send the edit.
   - History should still show the images on the edited message.
4. Repeat while a stream is active (queued message) and ensure queued edit still restores images.

---

<details>
<summary>Alternative: Frontend-only fix (no backend guard)</summary>

**Net new product LoC (est.):** ~40–70

- Do steps (1) and (2) only.
- Pros: minimal change.
- Cons: older clients / future regressions can still drop images because backend edit is delete+append.

</details>

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.2` • Thinking: `xhigh`_
