### PR TITLE
🤖 fix: always disable OpenAI truncation

### DIFF
--- a/src/browser/components/ModelSettings.tsx
+++ b/src/browser/components/ModelSettings.tsx
@@ -8,7 +8,7 @@ interface ModelSettingsProps {
 }
 
 export const ModelSettings: React.FC<ModelSettingsProps> = (props) => {
-  const { options, setAnthropicOptions, setOpenAIOptions } = useProviderOptions();
+  const { options, setAnthropicOptions } = useProviderOptions();
 
   const renderOption = (
     id: string,
@@ -47,19 +47,6 @@ export const ModelSettings: React.FC<ModelSettingsProps> = (props) => {
       (checked) => setAnthropicOptions({ ...options.anthropic, use1MContext: checked }),
       "Enable 1M token context window (beta feature for Claude Sonnet 4/4.5)"
     );
-  }
-
-  const provider = props.model.split(":")[0];
-  if (provider === "openai") {
-    if (import.meta.env.DEV) {
-      return renderOption(
-        "openai-trunc",
-        "No Trunc",
-        options.openai?.disableAutoTruncation ?? false,
-        (checked) => setOpenAIOptions({ ...options.openai, disableAutoTruncation: checked }),
-        "Disable Auto-Truncation (Only visible in Dev mode)"
-      );
-    }
   }
 
   return null;

--- a/src/browser/contexts/ProviderOptionsContext.tsx
+++ b/src/browser/contexts/ProviderOptionsContext.tsx
@@ -1,23 +1,14 @@
-import React, { createContext, useContext, useLayoutEffect } from "react";
-import {
-  readPersistedState,
-  updatePersistedState,
-  usePersistedState,
-} from "@/browser/hooks/usePersistedState";
+import React, { createContext, useContext } from "react";
+import { usePersistedState } from "@/browser/hooks/usePersistedState";
 import type { MuxProviderOptions } from "@/common/types/providerOptions";
 
 interface ProviderOptionsContextType {
   options: MuxProviderOptions;
   setAnthropicOptions: (options: MuxProviderOptions["anthropic"]) => void;
-  setOpenAIOptions: (options: MuxProviderOptions["openai"]) => void;
   setGoogleOptions: (options: MuxProviderOptions["google"]) => void;
 }
 
 const ProviderOptionsContext = createContext<ProviderOptionsContextType | undefined>(undefined);
-
-const OPENAI_OPTIONS_KEY = "provider_options_openai";
-// One-time migration key: force disableAutoTruncation to true for existing users
-const OPENAI_TRUNCATION_MIGRATION_KEY = "provider_options_openai_truncation_migrated";
 
 export function ProviderOptionsProvider({ children }: { children: React.ReactNode }) {
   const [anthropicOptions, setAnthropicOptions] = usePersistedState<
@@ -25,21 +16,6 @@ export function ProviderOptionsProvider({ children }: { children: React.ReactNod
   >("provider_options_anthropic", {
     use1MContext: false,
   });
-
-  const [openaiOptions, setOpenAIOptions] = usePersistedState<MuxProviderOptions["openai"]>(
-    OPENAI_OPTIONS_KEY,
-    { disableAutoTruncation: true }
-  );
-
-  // One-time migration: force disableAutoTruncation to true for existing users
-  useLayoutEffect(() => {
-    const alreadyMigrated = readPersistedState<boolean>(OPENAI_TRUNCATION_MIGRATION_KEY, false);
-    if (alreadyMigrated) {
-      return;
-    }
-    updatePersistedState(OPENAI_OPTIONS_KEY, { disableAutoTruncation: true });
-    updatePersistedState(OPENAI_TRUNCATION_MIGRATION_KEY, true);
-  }, []);
 
   const [googleOptions, setGoogleOptions] = usePersistedState<MuxProviderOptions["google"]>(
     "provider_options_google",
@@ -49,11 +25,9 @@ export function ProviderOptionsProvider({ children }: { children: React.ReactNod
   const value = {
     options: {
       anthropic: anthropicOptions,
-      openai: openaiOptions,
       google: googleOptions,
     },
     setAnthropicOptions,
-    setOpenAIOptions,
     setGoogleOptions,
   };
 

--- a/src/browser/hooks/useProviderOptions.ts
+++ b/src/browser/hooks/useProviderOptions.ts
@@ -5,7 +5,6 @@ export function useProviderOptions() {
   return {
     options: context.options,
     setAnthropicOptions: context.setAnthropicOptions,
-    setOpenAIOptions: context.setOpenAIOptions,
     setGoogleOptions: context.setGoogleOptions,
   };
 }

--- a/src/browser/utils/messages/sendOptions.ts
+++ b/src/browser/utils/messages/sendOptions.ts
@@ -25,14 +25,10 @@ function getProviderOptions(): MuxProviderOptions {
     "provider_options_anthropic",
     { use1MContext: false }
   );
-  const openai = readPersistedState<MuxProviderOptions["openai"]>("provider_options_openai", {
-    disableAutoTruncation: true,
-  });
   const google = readPersistedState<MuxProviderOptions["google"]>("provider_options_google", {});
 
   return {
     anthropic,
-    openai,
     google,
   };
 }

--- a/src/common/orpc/schemas/providerOptions.ts
+++ b/src/common/orpc/schemas/providerOptions.ts
@@ -14,10 +14,6 @@ export const MuxProviderOptionsSchema = z.object({
         description:
           "OpenAI service tier: priority (low-latency), flex (50% cheaper, higher latency), auto/default (standard)",
       }),
-      disableAutoTruncation: z
-        .boolean()
-        .optional()
-        .meta({ description: "Disable automatic context truncation (useful for testing)" }),
       forceContextLimitError: z.boolean().optional().meta({
         description: "Force context limit error (used in integration tests to simulate overflow)",
       }),

--- a/src/common/utils/ai/providerOptions.test.ts
+++ b/src/common/utils/ai/providerOptions.test.ts
@@ -122,7 +122,7 @@ describe("buildProviderOptions - Anthropic", () => {
   });
 });
 
-describe("buildProviderOptions - OpenAI promptCacheKey", () => {
+describe("buildProviderOptions - OpenAI", () => {
   // Helper to extract OpenAI options from the result
   const getOpenAIOptions = (
     result: ReturnType<typeof buildProviderOptions>
@@ -147,6 +147,7 @@ describe("buildProviderOptions - OpenAI promptCacheKey", () => {
 
       expect(openai).toBeDefined();
       expect(openai!.promptCacheKey).toBe("mux-v1-abc123");
+      expect(openai!.truncation).toBe("disabled");
     });
 
     test("should derive promptCacheKey for gateway OpenAI model", () => {
@@ -162,6 +163,7 @@ describe("buildProviderOptions - OpenAI promptCacheKey", () => {
 
       expect(openai).toBeDefined();
       expect(openai!.promptCacheKey).toBe("mux-v1-workspace-xyz");
+      expect(openai!.truncation).toBe("disabled");
     });
   });
 });

--- a/src/common/utils/ai/providerOptions.ts
+++ b/src/common/utils/ai/providerOptions.ts
@@ -208,9 +208,6 @@ export function buildProviderOptions(
       }
     }
 
-    // Check if auto-truncation should be disabled (for testing context limit errors)
-    const disableAutoTruncation = muxProviderOptions?.openai?.disableAutoTruncation ?? false;
-
     // Prompt cache key: derive from workspaceId
     // This helps OpenAI route requests to cached prefixes for improved hit rates
     // workspaceId is always passed from AIService.streamMessage for real requests
@@ -220,7 +217,6 @@ export function buildProviderOptions(
       reasoningEffort,
       thinkingLevel: effectiveThinking,
       previousResponseId,
-      disableAutoTruncation,
       promptCacheKey,
     });
 
@@ -230,8 +226,8 @@ export function buildProviderOptions(
       openai: {
         parallelToolCalls: true, // Always enable concurrent tool execution
         serviceTier,
-        // Automatically truncate conversation to fit context window, unless disabled for testing
-        truncation: disableAutoTruncation ? "disabled" : "auto",
+        // Never allow server-side truncation (mux handles context via compaction)
+        truncation: "disabled",
         // Stable prompt cache key to improve OpenAI cache hit rates
         // See: https://sdk.vercel.ai/providers/ai-sdk-providers/openai#responses-models
         ...(promptCacheKey && { promptCacheKey }),


### PR DESCRIPTION
Ensure OpenAI Responses API calls never truncate conversation server-side by forcing `truncation: "disabled"` and removing the dev-only "No Trunc" toggle.

- Removed `disableAutoTruncation` from provider options schema and storage.
- Hardcode OpenAI `truncation: "disabled"` in both the AI SDK providerOptions builder and the OpenAI fetch wrapper.
- Updated tests to use `forceContextLimitError` for deterministic context overflow coverage.

---

<details>
<summary>📋 Implementation Plan</summary>

# Remove OpenAI “No Trunc” toggle; always disable server-side truncation

## Goal
- **Always** send OpenAI Responses API requests with **`truncation: "disabled"`** so the server never truncates conversation history.
- Remove the **user/dev-configurable** “No Trunc” (`disableAutoTruncation`) option since it’s redundant.

## Recommended approach (net product LoC: ~-50)

### 1) Delete the toggle + its persisted state
**UI**
- `src/browser/components/ModelSettings.tsx`
  - Remove the OpenAI-only, DEV-only checkbox (`"No Trunc"`).
  - After this, `ModelSettings` becomes Anthropic-only (1M toggle) and returns `null` otherwise.

**Persisted state / context**
- `src/browser/contexts/ProviderOptionsContext.tsx`
  - Remove:
    - `OPENAI_OPTIONS_KEY` / `OPENAI_TRUNCATION_MIGRATION_KEY`
    - The OpenAI `usePersistedState(...)` entry
    - The one-time migration `useLayoutEffect` that forces `disableAutoTruncation: true`
    - `setOpenAIOptions` from the context type + value
- `src/browser/hooks/useProviderOptions.ts`
  - Remove `setOpenAIOptions` from the returned object.

**Non-React send path**
- `src/browser/utils/messages/sendOptions.ts`
  - Stop reading `provider_options_openai` from localStorage.
  - Remove `openai` from the returned `MuxProviderOptions` object (leave `anthropic`, `google`).

> Back-compat: leaving the old localStorage keys in place is fine; after this change they’re simply ignored.

### 2) Remove the option from the shared schema/types
- `src/common/orpc/schemas/providerOptions.ts`
  - Remove `openai.disableAutoTruncation` from `MuxProviderOptionsSchema`.
  - This automatically removes it from the inferred `MuxProviderOptions` TS type.

### 3) Enforce truncation disabled in all OpenAI requests
**ProviderOptions mapping (AI SDK)**
- `src/common/utils/ai/providerOptions.ts`
  - In the OpenAI branch:
    - Delete the `disableAutoTruncation` read/logging.
    - Hardcode:
      - `truncation: "disabled"`
    - Keep `serviceTier`, `parallelToolCalls`, `promptCacheKey`, `reasoningEffort`, and `previousResponseId` behavior unchanged.

**Fetch-level safety net (guarantee “never auto”)**
- `src/node/services/aiService.ts`
  - Update the OpenAI fetch wrapper currently named `fetchWithOpenAITruncation`:
    - Remove any references to `muxProviderOptions.openai.disableAutoTruncation`.
    - For `POST` requests to `/v1/responses` with a JSON string body:
      - Parse JSON, set **`json.truncation = "disabled"`** (override regardless of existing value), stringify, and forward.
    - Update the comment to reflect the new invariant (this is now a correctness guarantee, not a temporary override).

<details>
<summary>Why enforce at both layers?</summary>

- `buildProviderOptions()` is the “intended” path, but the fetch wrapper guarantees the invariant even if:
  - a future SDK change stops forwarding provider options
  - another callsite hits `/v1/responses` without going through our provider-options builder

Since the requirement is “never truncates server-side”, the fetch wrapper is the safest backstop.
</details>

### 4) Tests + validation
**Unit tests**
- `src/common/utils/ai/providerOptions.test.ts`
  - Add a focused test asserting OpenAI provider options always include `truncation: "disabled"` for:
    - `openai:gpt-5.2` (direct)
    - `mux-gateway:openai/gpt-5.2` (gateway-normalized)

**Integration tests**
- `tests/ipc/sendMessage.heavy.test.ts`
  - Remove or rewrite the `"respects disableAutoTruncation flag"` test (feature no longer exists).
  - If you still want coverage for “context too long” handling, prefer a deterministic test using `providerOptions.openai.forceContextLimitError` (already supported in `AIService.streamMessage`).

**Commands**
- `make fmt-check`
- `make lint`
- `make typecheck`
- `bun test src/common/utils/ai/providerOptions.test.ts`
- (optional) `TEST_INTEGRATION=1 bun x jest tests/ipc/sendMessage.heavy.test.ts -t "context"`

---

## Alternatives considered
<details>
<summary>Keep the option but hide it</summary>

- Would reduce code churn, but keeps dead configuration and test-only paths alive.
- Also risks someone re-enabling truncation accidentally later.

Given the stated invariant (“always disable”), removal is cleaner and safer.
</details>

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.2` • Thinking: `xhigh`_
