### PR TITLE
🤖 fix: roll up sub-agent usage into parent on delete

### DIFF
--- a/src/common/orpc/schemas/stream.ts
+++ b/src/common/orpc/schemas/stream.ts
@@ -221,6 +221,17 @@ export const ErrorEventSchema = z.object({
   errorType: StreamErrorTypeSchema.optional(),
 });
 
+/**
+ * Emitted when a child workspace is deleted and its accumulated session usage has been
+ * rolled up into the parent workspace.
+ */
+export const SessionUsageDeltaEventSchema = z.object({
+  type: z.literal("session-usage-delta"),
+  workspaceId: z.string().meta({ description: "Parent workspace ID" }),
+  sourceWorkspaceId: z.string().meta({ description: "Deleted child workspace ID" }),
+  byModelDelta: z.record(z.string(), ChatUsageDisplaySchema),
+  timestamp: z.number(),
+});
 export const UsageDeltaEventSchema = z.object({
   type: z.literal("usage-delta"),
   workspaceId: z.string(),
@@ -320,6 +331,7 @@ export const WorkspaceChatMessageSchema = z.discriminatedUnion("type", [
   ErrorEventSchema,
   // Usage and queue events
   UsageDeltaEventSchema,
+  SessionUsageDeltaEventSchema,
   QueuedMessageChangedEventSchema,
   RestoreToInputEventSchema,
   // Idle compaction notification

--- a/src/node/services/serviceContainer.ts
+++ b/src/node/services/serviceContainer.ts
@@ -107,7 +107,8 @@ export class ServiceContainer {
       this.aiService,
       this.initStateManager,
       this.extensionMetadata,
-      this.backgroundProcessManager
+      this.backgroundProcessManager,
+      this.sessionUsageService
     );
     this.workspaceService.setMCPServerManager(this.mcpServerManager);
     this.taskService = new TaskService(


### PR DESCRIPTION
Sub-agent/task workspaces currently store session usage in their own `~/.mux/sessions/<id>/session-usage.json`. When a task workspace is deleted, that directory is removed, so the cost is lost.

This PR preserves sub-agent cost by rolling the child workspace's accumulated `byModel` usage into the parent workspace **during workspace deletion**, and emits a lightweight chat event so the parent Costs UI updates immediately.

### Implementation notes
- `SessionUsageService.rollUpUsageIntoParent()` merges `byModel` usage and uses an on-disk idempotency ledger (`rolledUpFrom`) to prevent double-counting.
- `WorkspaceService.remove()` performs the roll-up before deleting the child session dir, then (best-effort) emits a `session-usage-delta` event to the parent session.
- Renderer `WorkspaceStore` handles `session-usage-delta` by merging it into in-memory `sessionUsage` and bumping usage recomputation.

### Validation
- `make static-check`
- `bun test src/node/services/sessionUsageService.test.ts`

---

<details>
<summary>📋 Implementation Plan</summary>

# Aggregate sub-agent cost into parent workspace (task creator)

## Goal
Prevent **sub-agent/task cost data** from disappearing when the sub-agent workspace is deleted.

User preference (per clarification):
- **Display:** merge into the parent workspace’s *Session total*
- **Timing:** roll-up **on sub-agent workspace deletion** (covers auto-cleanup + termination)
- **UX:** parent Costs UI should **update immediately** in the same app session

## Current behavior (what we found)
- Usage/cost is persisted **per-workspace** in `~/.mux/sessions/<workspaceId>/session-usage.json` via `SessionUsageService`.
  - Written on every `stream-end` in `src/node/services/streamManager.ts` → `sessionUsageService.recordUsage()`.
  - File is deleted when the workspace is removed: `WorkspaceService.remove()` does `rm -rf ~/.mux/sessions/<workspaceId>`.
- Agent tasks are normal workspaces with `parentWorkspaceId` stored in config (`WorkspaceConfigEntry.parentWorkspaceId`).
- Auto-cleanup of reported tasks calls `WorkspaceService.remove(id, true)` (`TaskService.cleanupReportedLeafTask`).

**Result:** if a task workspace incurred e.g. `$1`, then gets deleted, its `session-usage.json` is deleted too, and the cost becomes unrecoverable.

## Recommended approach (roll-up on deletion + live UI delta)
Implement a **roll-up step inside workspace deletion**:
1) Before deleting the sub-agent session dir, read the child’s `session-usage.json` (rebuild from `chat.jsonl` if missing/corrupt).
2) Merge `child.byModel` into the parent’s `session-usage.json` **without** changing parent `lastRequest`.
3) Emit a lightweight onChat event to the parent workspace so the renderer can update its in-memory totals immediately.

### Why this approach
- Covers all deletion paths that currently lose cost:
  - auto-cleanup of reported tasks
  - manual delete
  - task termination (`terminateDescendantAgentTask`)
- Does **not** touch the hot streaming path.
- Naturally supports nested tasks: leaf rolls into parent; if parent later deleted, it rolls further upward.

### Net LoC estimate (product code)
~180–260 LoC
- Backend roll-up + idempotency: ~80–120
- New onChat event schema/type + emit: ~40–70
- Renderer store handler: ~40–70

## Implementation plan

### 1) Backend: add a “roll-up” API to `SessionUsageService`
File: `src/node/services/sessionUsageService.ts`
- Extend `SessionUsageFile` to include an **optional idempotency ledger**:
  - `rolledUpFrom?: Record<string, true>` (keyed by child workspaceId)
- Add a method like:
  - `rollUpUsageIntoParent(parentWorkspaceId, childWorkspaceId, childUsageByModel)`
  - Behavior:
    - assert non-empty IDs
    - lock `parentWorkspaceId`
    - read parent file
    - if `rolledUpFrom[childWorkspaceId]` already set → **no-op** (prevents double-count on concurrent remove calls)
    - for each model in `childUsageByModel`: `sumUsageHistory([existing, delta])`
    - write file back (do **not** set `lastRequest`)

Notes:
- Keep `version: 1` and treat `rolledUpFrom` as forward-compatible optional data.
- Use `config.findWorkspace(parentWorkspaceId)` guard to avoid creating new session dirs for already-deleted parents.

### 2) Backend: perform roll-up inside `WorkspaceService.remove()`
File: `src/node/services/workspaceService.ts`
- After runtime deletion succeeds (or `force=true` fallback), but **before** deleting the session dir:
  - Determine `parentWorkspaceId` from `metadata.parentWorkspaceId`.
  - Read child usage via `SessionUsageService.getSessionUsage(childWorkspaceId)`.
  - If present, call `rollUpUsageIntoParent(parentWorkspaceId, childWorkspaceId, child.byModel)`.
  - Best-effort logging on failures; never block deletion on roll-up errors.

Important ordering constraint:
- Do **not** roll up if `runtime.deleteWorkspace()` fails and `force=false` (because the workspace wasn’t actually removed).

### 3) Backend→Frontend: emit a new onChat event to update UI immediately
Files:
- `src/common/orpc/schemas/stream.ts`
- `src/common/orpc/types.ts`

Add a new `WorkspaceChatMessage` variant, e.g.:
- `type: "session-usage-delta"`
- payload:
  - `workspaceId` (the parent)
  - `sourceWorkspaceId` (the deleted child)
  - `byModelDelta: Record<string, ChatUsageDisplay>`
  - `timestamp`

Emit it from `WorkspaceService.remove()` **after** successfully persisting the roll-up into the parent.

### 4) Renderer: apply `session-usage-delta` to in-memory totals
File: `src/browser/stores/WorkspaceStore.ts`
- Add a handler in `bufferedEventHandlers` for `"session-usage-delta"`:
  - Read `current = this.sessionUsage.get(workspaceId) ?? { byModel: {}, version: 1 }`
  - For each model in delta: merge via `sumUsageHistory`
  - **Do not** touch `current.lastRequest`
  - `this.sessionUsage.set(workspaceId, current)`
  - `this.usageStore.bump(workspaceId)`

This makes Costs UI update immediately for the parent workspace even if no stream is active.

### 5) Tests
- Unit tests (`bun test`) for the new roll-up behavior in `src/node/services/sessionUsageService.test.ts`:
  - Rolls up child byModel into parent
  - Does not modify parent `lastRequest`
  - Idempotent when called twice for same `(parent, child)`
- (Optional) higher-level test: simulate `WorkspaceService.remove()` calling roll-up and emitting delta (only add if straightforward).

## Edge cases / defensive checks
- **Concurrent remove:** handled by `rolledUpFrom` ledger under a parent file lock.
- **Missing/corrupt child usage file:** `getSessionUsage(child)` already rebuilds from history; if that also fails/empty, skip roll-up.
- **Missing parent (already deleted):** skip roll-up to avoid orphan session dirs.
- **Cycle safety:** `cleanupReportedLeafTask` already guards cycles; roll-up code should still avoid parent==child.

<details>
<summary>Alternatives considered</summary>

### A) Bubble usage on every `stream-end`
- Pros: parent totals update in near-real-time.
- Cons: touches hot path; must avoid clobbering parent `lastRequest`; still needs UI signaling.

### B) Roll-up only at `agent_report`
- Pros: simple.
- Cons: misses terminated tasks and any other deletion path.

### C) Persist a project-level ledger
- Pros: survives parent session corruption/rebuild.
- Cons: bigger product decision + new file format/UI surface.

</details>

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.2` • Thinking: `xhigh`_
