### PR TITLE
🤖 fix: persist todo list across compactions

### DIFF
--- a/src/browser/utils/messages/attachmentRenderer.test.ts
+++ b/src/browser/utils/messages/attachmentRenderer.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "@jest/globals";
+import { renderAttachmentToContent } from "./attachmentRenderer";
+import type { TodoListAttachment } from "@/common/types/attachment";
+
+describe("attachmentRenderer", () => {
+  it("renders todo list inline and mentions todo_read", () => {
+    const attachment: TodoListAttachment = {
+      type: "todo_list",
+      todos: [
+        { content: "Completed task", status: "completed" },
+        { content: "In progress task", status: "in_progress" },
+        { content: "Pending task", status: "pending" },
+      ],
+    };
+
+    const content = renderAttachmentToContent(attachment);
+
+    expect(content).toContain("todo_read");
+    expect(content).toContain("[x]");
+    expect(content).toContain("[>]");
+    expect(content).toContain("[ ]");
+    expect(content).toContain("Completed task");
+    expect(content).toContain("In progress task");
+    expect(content).toContain("Pending task");
+
+    // Should not leak file paths (inline only).
+    expect(content).not.toContain("todos.json");
+    expect(content).not.toContain("~/.mux");
+  });
+});

--- a/src/browser/utils/messages/attachmentRenderer.ts
+++ b/src/browser/utils/messages/attachmentRenderer.ts
@@ -1,6 +1,7 @@
 import type {
   PostCompactionAttachment,
   PlanFileReferenceAttachment,
+  TodoListAttachment,
   EditedFilesReferenceAttachment,
 } from "@/common/types/attachment";
 
@@ -14,6 +15,21 @@ Plan contents:
 ${attachment.planContent}
 
 If this plan is relevant to the current work and not already complete, continue working on it.`;
+}
+
+/**
+ * Render a todo list attachment to a content string.
+ */
+function renderTodoListAttachment(attachment: TodoListAttachment): string {
+  const items = attachment.todos
+    .map((todo) => {
+      const statusMarker =
+        todo.status === "completed" ? "[x]" : todo.status === "in_progress" ? "[>]" : "[ ]";
+      return `- ${statusMarker} ${todo.content}`;
+    })
+    .join("\n");
+
+  return `TODO list (persisted; \`todo_read\` will return this):\n${items || "- (empty)"}`;
 }
 
 /**
@@ -42,6 +58,8 @@ export function renderAttachmentToContent(attachment: PostCompactionAttachment):
   switch (attachment.type) {
     case "plan_file_reference":
       return renderPlanFileReference(attachment);
+    case "todo_list":
+      return renderTodoListAttachment(attachment);
     case "edited_files_reference":
       return renderEditedFilesReference(attachment);
   }

--- a/src/common/types/attachment.ts
+++ b/src/common/types/attachment.ts
@@ -15,17 +15,29 @@ export interface EditedFileReference {
   truncated: boolean;
 }
 
+export interface TodoListAttachment {
+  type: "todo_list";
+  todos: Array<{
+    content: string;
+    status: "pending" | "in_progress" | "completed";
+  }>;
+}
+
 export interface EditedFilesReferenceAttachment {
   type: "edited_files_reference";
   files: EditedFileReference[];
 }
 
-export type PostCompactionAttachment = PlanFileReferenceAttachment | EditedFilesReferenceAttachment;
+export type PostCompactionAttachment =
+  | PlanFileReferenceAttachment
+  | TodoListAttachment
+  | EditedFilesReferenceAttachment;
 
 /**
  * Exclusion state for post-compaction context items.
  * Items are identified by:
  * - "plan" for the plan file
+ * - "todo" for the todo list
  * - "file:<path>" for tracked files (path is the full file path)
  */
 export interface PostCompactionExclusions {

--- a/src/common/utils/tools/tools.ts
+++ b/src/common/utils/tools/tools.ts
@@ -59,6 +59,8 @@ export interface ToolConfiguration {
    * Used for streaming bash stdout/stderr to the UI without sending it to the model.
    */
   emitChatEvent?: (event: WorkspaceChatMessage) => void;
+  /** Workspace session directory (e.g. ~/.mux/sessions/<workspaceId>) for persistent tool state */
+  workspaceSessionDir?: string;
   /** Workspace ID for tracking background processes and plan storage */
   workspaceId?: string;
   /** Callback to record file state for external edit detection (plan files) */

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1356,6 +1356,7 @@ export class AIService extends EventEmitter {
             }
             this.emit(event.type, event as never);
           },
+          workspaceSessionDir: this.config.getSessionDir(workspaceId),
           planFilePath,
           workspaceId,
           // Only child workspaces (tasks) can report to a parent.

--- a/src/node/services/tools/testHelpers.ts
+++ b/src/node/services/tools/testHelpers.ts
@@ -56,6 +56,7 @@ export function createTestToolConfig(
 ): ToolConfiguration {
   return {
     cwd: tempDir,
+    workspaceSessionDir: options?.sessionsDir ?? tempDir,
     runtime: new LocalRuntime(tempDir),
     runtimeTempDir: tempDir,
     niceness: options?.niceness,


### PR DESCRIPTION
Persist TODO tool state under the workspace session directory so it survives stream cleanup and chat history compactions. Also inject the persisted TODO list as an inline post-compaction context attachment (mentions `todo_read`), ordered after the plan attachment and before edited-file diffs.

- Store TODOs in `~/.mux*/sessions/<workspaceId>/todos.json` (atomic writes + workspace locks)
- Add `todo_list` post-compaction attachment + renderer
- Update todo tool tests and add a renderer unit test

---

<details>
<summary>📋 Implementation Plan</summary>

# Persist TODOs across compactions + inject into post-compaction context

## Goal

When a workspace’s chat history is compacted, **the TODO list should not be lost**. After compaction:

- `todo_read` should return the same TODO list that existed before compaction.
- The next model request should receive a **post-compaction context attachment** containing the TODO list (similar to plan/file-diff attachments).
- The attachment should **inline the TODO list text** (no file path), and explicitly note that `todo_read` will return this list.

## Recommended approach (net ~180–260 LoC product code)

### 1) Make TODO storage workspace-scoped (not stream-scoped)

**Problem today**
- `src/node/services/tools/todo.ts` stores todos in `<runtimeTempDir>/todos.json`.
- `runtimeTempDir` is per-stream and is deleted on stream end, so TODOs disappear after compaction/turn completion.

**Change**
- Persist todos to the workspace session directory:
  - `~/.mux*/sessions/<workspaceId>/todos.json` (i.e. `config.getSessionDir(workspaceId)/todos.json`).
- Keep the on-disk JSON format the same as today (array of `{content,status}`) to minimize churn.

**Plumbing**
- Extend `ToolConfiguration` with a workspace session dir so tools don’t need to guess the mux root:
  - File: `src/common/utils/tools/tools.ts`
  - Add optional field: `workspaceSessionDir?: string`.
- Populate it where tools are created:
  - File: `src/node/services/aiService.ts`
  - Pass: `workspaceSessionDir: this.config.getSessionDir(workspaceId)`.
- Update test helpers:
  - File: `src/node/services/tools/testHelpers.ts`
  - Set `workspaceSessionDir` to an isolated temp path.

**Tool implementation update**
- File: `src/node/services/tools/todo.ts`
  - Replace `getTodoFilePath(tempDir)` with `getTodoFilePath(workspaceSessionDir)`.
  - Require `config.workspaceId` and `config.workspaceSessionDir` (defensive `assert(...)` + clear error if missing).
  - Use local fs + atomic writes + workspace locks (mirror `SessionFileManager`/`SessionUsageService` pattern):
    - lock key: `workspaceId`
    - file path: `path.join(workspaceSessionDir, "todos.json")`
    - read: return `[]` on ENOENT/parse failure
    - write: validate ordering + `MAX_TODOS`, then `mkdir -p` session dir + `write-file-atomic`

> This ensures TODOs survive: compaction history replacement, stream temp dir cleanup, reload, and new turns.

### 2) Attach TODO list into the post-compaction context message

**Add a new attachment type**
- File: `src/common/types/attachment.ts`
  - Add:
    - `TodoListAttachment { type: "todo_list"; todos: Array<{content,status}> }`
  - Extend `PostCompactionAttachment` union.

**Render as inline text (no path)**
- File: `src/browser/utils/messages/attachmentRenderer.ts`
  - Add `renderTodoListAttachment()` with output like:

  ```
  TODO list (persisted; `todo_read` will return this):
  - [x] …
  - [>] …
  - [ ] …
  ```

  Mapping:
  - `completed` → `[x]`
  - `in_progress` → `[>]`
  - `pending` → `[ ]`

**Generate + include the attachment**
- File: `src/node/services/agentSession.ts`
  - After computing `excludedItems` and generating the existing attachments (plan + edited files), load todos from `config.getSessionDir(workspaceId)/todos.json`.
  - If non-empty, append/insert a `todo_list` attachment.
  - Prefer ordering: plan → todo_list → edited_files.

**(Optional, small) Exclusions parity**
- File: `src/common/types/attachment.ts`
  - Update `PostCompactionExclusions` comment to include a new item id: `"todo"`.
- File: `src/node/services/agentSession.ts`
  - Skip TODO attachment when `excludedItems.has("todo")`.

### 3) Tests + validation (net ~80–140 LoC tests)

- Update existing TODO storage tests to match new persistence location:
  - File: `src/node/services/tools/todo.test.ts`
  - Set `workspaceSessionDir` to a temp dir.
  - Assert that writing todos then reading them still works even if you “rotate” `runtimeTempDir` (simulating a new stream).
- Add a small unit test for the new attachment renderer:
  - New file (or colocate): `src/browser/utils/messages/attachmentRenderer.test.ts`
  - Assert:
    - output contains the task texts + status markers
    - output mentions `todo_read`
    - output does **not** contain any file path

## Alternatives considered

<details>
<summary>Store TODOs remotely under <code>~/.mux</code> via Runtime IO</summary>

Pros:
- Matches how plan files are accessed (runtime + tilde paths).

Cons:
- TODOs are UI/workspace state (like chat history/session usage), so local session storage is a better fit.
- Testability is worse if paths rely on real <code>os.homedir()</code> expansion.
</details>

## Rollout notes

- The context injection portion should stay behind the existing `postCompactionContext` experiment gate (same as plan/diffs).
- Persistence (`todo_read`/`todo_write`) should work regardless of the experiment flag.

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.2` • Thinking: `xhigh`_
