### PR TITLE
🤖 fix: allow HTTP connections on iOS dev builds

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,8 @@
 # Mintlify docs that use JSX comments which prettier mangles
 docs/system-prompt.md
+
+# Expo prebuild outputs (generated + gitignored)
+mobile/.expo/
+mobile/ios/
+mobile/android/
+mobile/expo-env.d.ts

--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -1,0 +1,58 @@
+// Dynamic Expo config.
+//
+// We intentionally keep iOS App Transport Security (ATS) strict for preview/production
+// builds, but allow plain HTTP in *dev* builds so the app can talk to a local mux
+// server (e.g. http://<lan-ip>:3000) without having to run TLS locally.
+//
+// EAS sets EAS_BUILD_PROFILE to the profile name (development|preview|production).
+
+const appJson = require("./app.json");
+
+/**
+ * @param {unknown} value
+ * @returns {asserts value is { expo: import("@expo/config-types").ExpoConfig }}
+ */
+function assertAppJson(value) {
+  if (!value || typeof value !== "object") {
+    throw new Error("Expected app.json to be an object");
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  if (!("expo" in value)) {
+    throw new Error("Expected app.json to have an `expo` key");
+  }
+}
+
+/**
+ * @param {import("@expo/config-types").ExpoConfig} expoConfig
+ */
+function withDevAtsException(expoConfig) {
+  const ios = expoConfig.ios ?? {};
+  const infoPlist = ios.infoPlist ?? {};
+  const ats = infoPlist.NSAppTransportSecurity ?? {};
+
+  return {
+    ...expoConfig,
+    ios: {
+      ...ios,
+      infoPlist: {
+        ...infoPlist,
+        NSAppTransportSecurity: {
+          ...ats,
+          NSAllowsArbitraryLoads: true,
+        },
+      },
+    },
+  };
+}
+
+module.exports = () => {
+  assertAppJson(appJson);
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  const expoConfig = appJson.expo;
+
+  const buildProfile = process.env.EAS_BUILD_PROFILE;
+  const allowInsecureHttp = !buildProfile || buildProfile === "development";
+
+  return allowInsecureHttp ? withDevAtsException(expoConfig) : expoConfig;
+};


### PR DESCRIPTION
This scopes the iOS App Transport Security (ATS) exception to **dev builds** so the mobile app can talk to a local mux server over plain HTTP (e.g. `http://<lan-ip>:3000`) without needing local TLS.

- Adds `mobile/app.config.js` to inject `NSAppTransportSecurity.NSAllowsArbitraryLoads = true` when:
  - `EAS_BUILD_PROFILE` is unset (local `expo run:ios`), or
  - `EAS_BUILD_PROFILE=development`.
- Keeps preview/production builds on the default ATS behavior.
- Updates `.prettierignore` to exclude Expo prebuild outputs (`mobile/ios`, `mobile/android`, etc.) so `make static-check` doesn’t fail after generating native projects.

Validation:
- `make static-check`

---

<details>
<summary>📋 Implementation Plan</summary>

# Build + deploy the iOS app locally (Xcode / physical iPhone)

## What this repo is
- The React Native app lives in `mobile/` and is **Expo SDK 54** (React Native **0.81.5**).
- There is **no committed `ios/` directory**; Expo generates it (git-ignored) via `expo prebuild` / `expo run:ios`.

---

## Recommended workflow (dev build on a physical device)

### 0) Prereqs (one-time)
- macOS + **Xcode 16+** (required by `mobile/README.md`).
- Node.js **20.19.4+**.
- **bun**.
- An iPhone connected via USB (or paired for wireless debugging) with **Developer Mode enabled**.
- An Apple ID added in Xcode (Xcode → Settings → Accounts) for code signing.

> If you are **not** on the Apple Developer Team that owns `com.coder.mux-mobile`, you’ll need to change the bundle ID (next step) or Xcode signing will fail.

### 1) (If needed) Set a bundle identifier you can sign
Edit `mobile/app.json`:
- `expo.ios.bundleIdentifier` (currently `com.coder.mux-mobile`)

Then regenerate native code after changing it:
```bash
cd mobile
bun install
bunx expo prebuild --clean
```

### 2) Install JS deps
```bash
cd mobile
bun install
```

### 3) Generate the native iOS project (if not already generated)
```bash
cd mobile
bunx expo prebuild --clean
```

### 4) Open the generated Xcode workspace
```bash
cd mobile
open ios/*.xcworkspace
```

### 5) Build + install onto your iPhone from Xcode
In Xcode:
1. Select your **physical iPhone** as the run destination.
2. Set **Signing & Capabilities** → Team to your Apple ID/team.
3. Press **Run** (▶) to build and install.

---

## Command-only alternative (no manual Xcode clicking)
Expo can generate + build + install onto a connected iPhone for you:
```bash
cd mobile
bun install
bunx expo run:ios --device
```

If you prefer the repo script:
```bash
cd mobile
bun run ios -- --device
```

---

## Useful follow-ups (app actually working on device)
- If the app needs to talk to a server, don’t use `localhost` in `mobile/app.json` → `expo.extra.mux.baseUrl`; use a LAN/Tailscale IP that your iPhone can reach (per `mobile/README.md`).

---

## Troubleshooting: “App Transport Security policy requires the use of a secure connection”
This iOS error means the app is trying to `fetch()` from a plain-HTTP URL (e.g., `http://<your-ip>:3000`), and iOS blocks it by default.

### Option A (preferred): use HTTPS for the backend
- Run your mux server behind HTTPS (any local TLS proxy is fine) and set `mobile/app.json` → `expo.extra.mux.baseUrl` to an `https://…` URL.
- **LoC impact:** 0 (no app code changes required).

### Option B (dev-only): allow HTTP via ATS exception in the Expo iOS config
1) Edit `mobile/app.json` and add an `infoPlist` override under `expo.ios`:

```json
{
  "expo": {
    "ios": {
      "bundleIdentifier": "com.coder.mux-mobile",
      "infoPlist": {
        "NSAppTransportSecurity": {
          "NSAllowsArbitraryLoads": true
        }
      }
    }
  }
}
```

2) Regenerate the native project and rebuild:
```bash
cd mobile
bunx expo prebuild --clean
bunx expo run:ios --device
```

- **LoC impact:** ~8–12 lines (in `mobile/app.json`).
- Don’t ship this to the App Store; it’s intended for local/dev only.

### Option C (quick local hack): toggle ATS in Xcode
- Open the generated iOS project in Xcode and set Info.plist:
  - `App Transport Security Settings` → `Allow Arbitrary Loads` = YES
- Rebuild.

> This will be overwritten the next time you run `expo prebuild --clean`, so Option B is the “sticky” way.

---

## LoC impact
- **0 LoC** for build/deploy steps.
- **~8–12 LoC** only if you add the ATS exception to `mobile/app.json`.

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.2` • Thinking: `xhigh`_

