### PR TITLE
🤖 feat: auto-resize textarea for plan mode question answering

### DIFF
--- a/src/browser/components/VimTextArea.tsx
+++ b/src/browser/components/VimTextArea.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { useAutoResizeTextarea } from "@/browser/hooks/useAutoResizeTextarea";
 import type { UIMode } from "@/common/types/mode";
 import * as vim from "@/browser/utils/vim";
 import { Tooltip, TooltipTrigger, TooltipContent, HelpIndicator } from "./ui/tooltip";
@@ -80,28 +81,7 @@ export const VimTextArea = React.forwardRef<HTMLTextAreaElement, VimTextAreaProp
     }>(null);
     const yankBufferRef = useRef<string>("");
 
-    // Auto-resize when value changes
-    // Uses useLayoutEffect to measure and set height synchronously before paint.
-    // Key insight: when value is empty or whitespace-only, skip measurement entirely
-    // and use the CSS min-height. This avoids race conditions where scrollHeight
-    // returns incorrect values before flexbox layout settles.
-    useLayoutEffect(() => {
-      const el = textareaRef.current;
-      if (!el) return;
-
-      // For empty/whitespace content, let CSS min-height handle sizing.
-      // This is deterministic and avoids measuring scrollHeight when the
-      // flex container may not have settled.
-      if (!value.trim()) {
-        el.style.height = "";
-        return;
-      }
-
-      // For non-empty content, measure and set height
-      el.style.height = "auto";
-      const max = window.innerHeight * 0.5; // 50vh
-      el.style.height = Math.min(el.scrollHeight, max) + "px";
-    }, [value]);
+    useAutoResizeTextarea(textareaRef, value, 50);
 
     const suppressSet = useMemo(() => new Set(suppressKeys ?? []), [suppressKeys]);
 

--- a/src/browser/hooks/useAutoResizeTextarea.ts
+++ b/src/browser/hooks/useAutoResizeTextarea.ts
@@ -1,0 +1,27 @@
+import { useLayoutEffect, type RefObject } from "react";
+
+/**
+ * Auto-resize a textarea to fit its content.
+ * Uses useLayoutEffect to measure and set height synchronously before paint.
+ */
+export function useAutoResizeTextarea(
+  ref: RefObject<HTMLTextAreaElement | null>,
+  value: string,
+  maxHeightVh = 30
+): void {
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    // For empty/whitespace content, let CSS min-height handle sizing
+    if (!value.trim()) {
+      el.style.height = "";
+      return;
+    }
+
+    // For non-empty content, measure and set height
+    el.style.height = "auto";
+    const max = window.innerHeight * (maxHeightVh / 100);
+    el.style.height = Math.min(el.scrollHeight, max) + "px";
+  }, [ref, value, maxHeightVh]);
+}

--- a/src/browser/stories/App.chat.stories.tsx
+++ b/src/browser/stories/App.chat.stories.tsx
@@ -432,6 +432,52 @@ export const AskUserQuestionCompleted: AppStory = {
   ),
 };
 
+/**
+ * Test "Other" option with auto-resizing textarea.
+ * Shows the textarea expanded with multi-line content to demonstrate auto-resize.
+ */
+export const AskUserQuestionOther: AppStory = {
+  render: () => (
+    <AppWithMocks
+      setup={() =>
+        setupSimpleChatStory({
+          messages: [
+            createUserMessage("msg-1", "How should I set this up?", {
+              historySequence: 1,
+              timestamp: STABLE_TIMESTAMP - 3000,
+            }),
+            createAssistantMessage("msg-2", "Let me ask a few questions.", {
+              historySequence: 2,
+              timestamp: STABLE_TIMESTAMP - 2000,
+              toolCalls: [
+                createPendingTool("call-ask-1", "ask_user_question", {
+                  questions: [
+                    {
+                      question: "Describe your use case in detail",
+                      header: "Use Case",
+                      options: [
+                        { label: "Web app", description: "A web application" },
+                        { label: "CLI tool", description: "A command-line tool" },
+                      ],
+                      multiSelect: false,
+                    },
+                  ],
+                  // Pre-fill with "Other" selected to show the textarea
+                  answers: {
+                    "Describe your use case in detail":
+                      "I'm building a complex application.\nIt needs web, CLI, and API support.\nThe architecture should be modular.",
+                  },
+                }),
+              ],
+            }),
+          ],
+          gitStatus: { dirty: 0 },
+        })
+      }
+    />
+  ),
+};
+
 /** Generic tool call with JSON-highlighted arguments and results */
 export const GenericTool: AppStory = {
   render: () => (


### PR DESCRIPTION
Replace single-line input with auto-resizing textarea for the "Other" option in plan mode question answering (`ask_user_question` tool).

## Changes

- **New hook `useAutoResizeTextarea`** - Extracted from VimTextArea for reuse. Automatically resizes textarea to fit content up to a configurable max height.

- **AskUserQuestionToolCall** - Uses the new hook for the "Other" text input:
  - Text wraps naturally instead of scrolling horizontally
  - Grows vertically as you type (up to 30vh)
  - Shift+Enter for newlines, Enter to submit

- **VimTextArea** - Refactored to use the shared hook (no behavior change)

- **Story** - Added `AskUserQuestionOther` for manual testing

## Testing

Run Storybook and navigate to **App / Chat / Ask User Question Other** to see the auto-resize behavior.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
