### PR TITLE
🤖 feat: sort review hunks by 'Last edit at' timestamp

### DIFF
--- a/src/browser/components/RightSidebar/CodeReview/HunkViewer.tsx
+++ b/src/browser/components/RightSidebar/CodeReview/HunkViewer.tsx
@@ -13,6 +13,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "../../ui/tooltip";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
 import { getReviewExpandStateKey } from "@/common/constants/storage";
 import { KEYBINDS, formatKeybind } from "@/browser/utils/ui/keybinds";
+import { formatRelativeTime } from "@/browser/utils/ui/dateTime";
 import { cn } from "@/common/lib/utils";
 
 interface HunkViewerProps {
@@ -21,6 +22,8 @@ interface HunkViewerProps {
   workspaceId: string;
   isSelected?: boolean;
   isRead?: boolean;
+  /** Timestamp when this hunk content was first seen (for "Last edit at" display) */
+  firstSeenAt: number;
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
   onToggleRead?: (e: React.MouseEvent<HTMLElement>) => void;
   onRegisterToggleExpand?: (hunkId: string, toggleFn: () => void) => void;
@@ -35,6 +38,7 @@ export const HunkViewer = React.memo<HunkViewerProps>(
     workspaceId,
     isSelected,
     isRead = false,
+    firstSeenAt,
     onClick,
     onToggleRead,
     onRegisterToggleExpand,
@@ -222,6 +226,14 @@ export const HunkViewer = React.memo<HunkViewerProps>(
             <span className="text-muted">
               ({lineCount} {lineCount === 1 ? "line" : "lines"})
             </span>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="text-dim cursor-default">{formatRelativeTime(firstSeenAt)}</span>
+              </TooltipTrigger>
+              <TooltipContent align="center" side="top">
+                First seen: {new Date(firstSeenAt).toLocaleString()}
+              </TooltipContent>
+            </Tooltip>
             {onToggleRead && (
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/src/browser/components/RightSidebar/CodeReview/ReviewControls.tsx
+++ b/src/browser/components/RightSidebar/CodeReview/ReviewControls.tsx
@@ -4,9 +4,14 @@
 
 import React, { useState } from "react";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
-import type { ReviewFilters, ReviewStats } from "@/common/types/review";
+import type { ReviewFilters, ReviewStats, ReviewSortOrder } from "@/common/types/review";
 import { RefreshButton } from "./RefreshButton";
 import { UntrackedStatus } from "./UntrackedStatus";
+
+const SORT_OPTIONS: Array<{ value: ReviewSortOrder; label: string }> = [
+  { value: "file-order", label: "File order" },
+  { value: "last-edit", label: "Last edit" },
+];
 
 interface ReviewControlsProps {
   filters: ReviewFilters;
@@ -74,6 +79,10 @@ export const ReviewControls: React.FC<ReviewControlsProps> = ({
     onFiltersChange({ ...filters, showReadHunks: e.target.checked });
   };
 
+  const handleSortChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    onFiltersChange({ ...filters, sortOrder: e.target.value as ReviewSortOrder });
+  };
+
   const handleSetDefault = () => {
     setDefaultBase(filters.diffBase);
   };
@@ -127,6 +136,22 @@ export const ReviewControls: React.FC<ReviewControlsProps> = ({
       <label className="text-foreground flex cursor-pointer items-center gap-1.5 text-[11px] whitespace-nowrap hover:text-[var(--color-hover-foreground)] [&_input[type='checkbox']]:cursor-pointer">
         <input type="checkbox" checked={filters.showReadHunks} onChange={handleShowReadToggle} />
         Show read
+      </label>
+
+      <label className="text-foreground flex cursor-pointer items-center gap-1.5 text-[11px] whitespace-nowrap">
+        <span className="text-muted font-medium">Sort:</span>
+        <select
+          aria-label="Sort hunks by"
+          value={filters.sortOrder}
+          onChange={handleSortChange}
+          className="bg-dark text-foreground border-border-medium hover:border-accent focus:border-accent cursor-pointer rounded border px-1.5 py-0.5 text-[11px] transition-[border-color] duration-200 focus:outline-none"
+        >
+          {SORT_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
       </label>
 
       <UntrackedStatus

--- a/src/browser/hooks/useHunkFirstSeen.ts
+++ b/src/browser/hooks/useHunkFirstSeen.ts
@@ -1,0 +1,125 @@
+/**
+ * Hook for tracking when hunk content addresses were first seen.
+ * Used to sort hunks by "last edit at" (LIFO) in the Review panel.
+ *
+ * The hunk ID is already a content-based hash, so we use it as the content address.
+ * We track the first time we see each hunk ID, which represents when the edit
+ * that created this hunk content was first observed.
+ */
+
+import { useCallback, useRef } from "react";
+import { usePersistedState } from "./usePersistedState";
+import { getHunkFirstSeenKey } from "@/common/constants/storage";
+
+/**
+ * Maximum number of first-seen records to keep per workspace (LRU eviction)
+ */
+const MAX_FIRST_SEEN_RECORDS = 2048;
+
+/**
+ * First-seen timestamps keyed by hunk ID (content address)
+ */
+export interface HunkFirstSeenState {
+  /** Hunk ID -> timestamp when first seen */
+  firstSeen: Record<string, number>;
+}
+
+/**
+ * Evict oldest entries if count exceeds max.
+ * Keeps the newest maxCount entries by timestamp.
+ */
+function evictOldestEntries(
+  firstSeen: Record<string, number>,
+  maxCount: number
+): Record<string, number> {
+  const entries = Object.entries(firstSeen);
+  if (entries.length <= maxCount) return firstSeen;
+
+  // Sort by timestamp descending (newest first)
+  entries.sort((a, b) => b[1] - a[1]);
+
+  // Keep only the newest maxCount
+  return Object.fromEntries(entries.slice(0, maxCount));
+}
+
+export interface UseHunkFirstSeenReturn {
+  /** Get the first-seen timestamp for a hunk ID, or undefined if never seen */
+  getFirstSeen: (hunkId: string) => number | undefined;
+
+  /** Record first-seen timestamps for new hunk IDs (ignores already-seen IDs) */
+  recordFirstSeen: (hunkIds: string[]) => void;
+
+  /** Get all first-seen records (for sorting) */
+  firstSeenMap: Record<string, number>;
+}
+
+/**
+ * Hook for tracking when hunks were first seen in a workspace.
+ * Automatically records first-seen timestamps and provides lookup.
+ */
+export function useHunkFirstSeen(workspaceId: string): UseHunkFirstSeenReturn {
+  const [state, setState] = usePersistedState<HunkFirstSeenState>(
+    getHunkFirstSeenKey(workspaceId),
+    { firstSeen: {} }
+  );
+
+  // Track pending updates to batch them
+  const pendingUpdatesRef = useRef<Set<string>>(new Set());
+  const updateScheduledRef = useRef(false);
+
+  const getFirstSeen = useCallback(
+    (hunkId: string): number | undefined => {
+      return state.firstSeen[hunkId];
+    },
+    [state.firstSeen]
+  );
+
+  const recordFirstSeen = useCallback(
+    (hunkIds: string[]) => {
+      // Add new IDs to pending set
+      for (const id of hunkIds) {
+        if (!(id in state.firstSeen)) {
+          pendingUpdatesRef.current.add(id);
+        }
+      }
+
+      // If we have pending updates and haven't scheduled yet, schedule a batch update
+      if (pendingUpdatesRef.current.size > 0 && !updateScheduledRef.current) {
+        updateScheduledRef.current = true;
+
+        // Use microtask to batch multiple recordFirstSeen calls in same render
+        queueMicrotask(() => {
+          updateScheduledRef.current = false;
+          const pending = pendingUpdatesRef.current;
+          if (pending.size === 0) return;
+
+          pendingUpdatesRef.current = new Set();
+          const timestamp = Date.now();
+
+          setState((prev) => {
+            // Double-check which IDs are actually new (state may have changed)
+            const newIds = Array.from(pending).filter((id) => !(id in prev.firstSeen));
+            if (newIds.length === 0) return prev;
+
+            const newFirstSeen = { ...prev.firstSeen };
+            for (const id of newIds) {
+              newFirstSeen[id] = timestamp;
+            }
+
+            // Apply LRU eviction if needed
+            const evicted = evictOldestEntries(newFirstSeen, MAX_FIRST_SEEN_RECORDS);
+
+            return { firstSeen: evicted };
+          });
+        });
+      }
+    },
+    [state.firstSeen, setState]
+  );
+
+  return {
+    getFirstSeen,
+    recordFirstSeen,
+    firstSeenMap: state.firstSeen,
+  };
+}

--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -223,6 +223,21 @@ export function getReviewStateKey(workspaceId: string): string {
 }
 
 /**
+ * Get the localStorage key for hunk first-seen timestamps per workspace
+ * Tracks when each hunk content address was first observed (for LIFO sorting)
+ * Format: "hunkFirstSeen:{workspaceId}"
+ */
+export function getHunkFirstSeenKey(workspaceId: string): string {
+  return `hunkFirstSeen:${workspaceId}`;
+}
+
+/**
+ * Get the localStorage key for review sort order preference (global)
+ * Format: "review-sort-order"
+ */
+export const REVIEW_SORT_ORDER_KEY = "review-sort-order";
+
+/**
  * Get the localStorage key for hunk expand/collapse state in Review tab
  * Stores user's manual expand/collapse preferences per hunk
  * Format: "reviewExpandState:{workspaceId}"
@@ -330,6 +345,7 @@ const PERSISTENT_WORKSPACE_KEY_FUNCTIONS: Array<(workspaceId: string) => string>
   getAutoRetryKey,
   getRetryStateKey,
   getReviewStateKey,
+  getHunkFirstSeenKey,
   getReviewExpandStateKey,
   getFileTreeExpandStateKey,
   getReviewSearchStateKey,

--- a/src/common/types/review.ts
+++ b/src/common/types/review.ts
@@ -69,6 +69,11 @@ export interface ReviewState {
 }
 
 /**
+ * Sort order options for review panel hunks
+ */
+export type ReviewSortOrder = "file-order" | "last-edit";
+
+/**
  * Filter options for review panel
  */
 export interface ReviewFilters {
@@ -80,6 +85,8 @@ export interface ReviewFilters {
   diffBase: string;
   /** Whether to include uncommitted changes (staged + unstaged) in the diff */
   includeUncommitted: boolean;
+  /** Sort order for hunks */
+  sortOrder: ReviewSortOrder;
 }
 
 /**


### PR DESCRIPTION
## Summary

Add LIFO sorting option for hunks in the Review panel based on when each hunk's content was first observed. This makes the review panel reflect the order of edit events in the chat, showing the most recently edited hunks first.

## Changes

- **New hook**: `useHunkFirstSeen` - Tracks first-seen timestamps per hunk ID (content address) with LRU eviction
- **ReviewControls**: Added sort dropdown with options "File order" (default) and "Last edit"
- **HunkViewer**: Displays relative timestamps in hunk headers (e.g., "5 minutes ago") with tooltip showing full timestamp
- **ReviewPanel**: Integrates sorting logic and first-seen tracking
- **Storybook**: Added stories for both sort modes (`ReviewTabSortByLastEdit`, `ReviewTabSortByFileOrder`)

## How it works

1. The hunk ID already serves as a content address (hash of path + line range + content)
2. When hunks are loaded, we record the first time we see each ID
3. Sorting by "Last edit" orders hunks by first-seen timestamp (newest first = LIFO)
4. Sort preference persists globally via localStorage
5. New hunks without first-seen data default to `Date.now()` for backwards compatibility

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
