### PR TITLE
🤖 fix: LoadingDots layout shift during animation

### DIFF
--- a/src/browser/components/tools/shared/ToolPrimitives.tsx
+++ b/src/browser/components/tools/shared/ToolPrimitives.tsx
@@ -139,7 +139,7 @@ export const LoadingDots: React.FC<React.HTMLAttributes<HTMLSpanElement>> = ({
 }) => (
   <span
     className={cn(
-      "after:content-[''] after:animate-[ellipsis_1.2s_steps(4,end)_infinite]",
+      "after:inline-block after:w-[3ch] after:text-left after:content-[''] after:animate-[ellipsis_1.2s_steps(4,end)_infinite]",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary

Fixes layout shift in the `LoadingDots` component as the content animates from `.` → `..` → `...`.

## Fix

Add fixed width (`3ch`) and `text-left` alignment so the element doesn't change size during animation.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_