### PR TITLE
🤖 fix: prevent layout shift when ChatInput placeholder disappears

### DIFF
--- a/src/browser/hooks/useAutoResizeTextarea.ts
+++ b/src/browser/hooks/useAutoResizeTextarea.ts
@@ -13,13 +13,9 @@ export function useAutoResizeTextarea(
     const el = ref.current;
     if (!el) return;
 
-    // For empty/whitespace content, let CSS min-height handle sizing
-    if (!value.trim()) {
-      el.style.height = "";
-      return;
-    }
-
-    // For non-empty content, measure and set height
+    // Always measure to avoid layout shift when placeholder disappears.
+    // Placeholder text doesn't contribute to scrollHeight, so we need
+    // consistent measurement whether content is empty or not.
     el.style.height = "auto";
     const max = window.innerHeight * (maxHeightVh / 100);
     el.style.height = Math.min(el.scrollHeight, max) + "px";


### PR DESCRIPTION
Remove special-case handling for empty content in `useAutoResizeTextarea`.
The hook now consistently measures `scrollHeight` regardless of content,
preventing layout shift when users start typing and the placeholder
disappears.

**Root cause:** Empty textareas cleared `style.height` to rely on CSS `min-height`, but switching to `scrollHeight` measurement when content appeared caused a visible jump since placeholder text doesn't contribute to `scrollHeight`.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
