### PR TITLE
🤖 refactor: compact ReviewPanel hunk header and controls

### DIFF
--- a/src/browser/components/RightSidebar/CodeReview/BaseSelectorPopover.tsx
+++ b/src/browser/components/RightSidebar/CodeReview/BaseSelectorPopover.tsx
@@ -1,0 +1,130 @@
+/**
+ * BaseSelectorPopover - Dropdown for selecting diff base (similar to BranchSelector)
+ */
+
+import React, { useState, useRef, useEffect } from "react";
+import { Check } from "lucide-react";
+import { cn } from "@/common/lib/utils";
+import { Popover, PopoverContent, PopoverTrigger } from "@/browser/components/ui/popover";
+
+const BASE_SUGGESTIONS = [
+  "HEAD",
+  "--staged",
+  "main",
+  "origin/main",
+  "HEAD~1",
+  "HEAD~2",
+  "develop",
+  "origin/develop",
+] as const;
+
+interface BaseSelectorPopoverProps {
+  value: string;
+  onChange: (value: string) => void;
+  className?: string;
+}
+
+export function BaseSelectorPopover({ value, onChange, className }: BaseSelectorPopoverProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [inputValue, setInputValue] = useState(value);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Sync input with external value changes
+  useEffect(() => {
+    setInputValue(value);
+  }, [value]);
+
+  // Focus input when popover opens
+  useEffect(() => {
+    if (isOpen) {
+      // Small delay to let popover render
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }, [isOpen]);
+
+  const handleSelect = (selected: string) => {
+    onChange(selected);
+    setInputValue(selected);
+    setIsOpen(false);
+  };
+
+  const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      const trimmed = inputValue.trim();
+      if (trimmed) {
+        onChange(trimmed);
+        setIsOpen(false);
+      }
+    } else if (e.key === "Escape") {
+      setInputValue(value);
+      setIsOpen(false);
+    }
+  };
+
+  const handleInputBlur = () => {
+    const trimmed = inputValue.trim();
+    if (trimmed && trimmed !== value) {
+      onChange(trimmed);
+    } else {
+      setInputValue(value);
+    }
+  };
+
+  // Filter suggestions based on input
+  const searchLower = inputValue.toLowerCase();
+  const filteredSuggestions = BASE_SUGGESTIONS.filter((s) => s.toLowerCase().includes(searchLower));
+
+  return (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <button
+          className={cn(
+            "text-muted-light hover:bg-hover hover:text-foreground flex items-center gap-1 rounded-sm px-1 py-0.5 font-mono text-[11px] transition-colors",
+            className
+          )}
+        >
+          <span className="truncate">{value}</span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-[160px] p-0">
+        {/* Search/edit input */}
+        <div className="border-border border-b px-2 py-1.5">
+          <input
+            ref={inputRef}
+            type="text"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleInputKeyDown}
+            onBlur={handleInputBlur}
+            placeholder="Enter base..."
+            className="text-foreground placeholder:text-muted w-full bg-transparent font-mono text-[11px] outline-none"
+          />
+        </div>
+
+        <div className="max-h-[200px] overflow-y-auto p-1">
+          {filteredSuggestions.length === 0 ? (
+            <div className="text-muted py-2 text-center text-[10px]">
+              Press Enter to use &ldquo;{inputValue}&rdquo;
+            </div>
+          ) : (
+            filteredSuggestions.map((suggestion) => (
+              <button
+                key={suggestion}
+                onClick={() => handleSelect(suggestion)}
+                className="hover:bg-hover flex w-full items-center gap-1.5 rounded-sm px-2 py-1 font-mono text-[11px]"
+              >
+                <Check
+                  className={cn(
+                    "h-3 w-3 shrink-0",
+                    suggestion === value ? "opacity-100" : "opacity-0"
+                  )}
+                />
+                <span className="truncate">{suggestion}</span>
+              </button>
+            ))
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/browser/components/RightSidebar/CodeReview/FileTree.tsx
+++ b/src/browser/components/RightSidebar/CodeReview/FileTree.tsx
@@ -131,16 +131,16 @@ const TreeNodeContent: React.FC<{
     <>
       <div
         className={cn(
-          "py-1 px-2 cursor-pointer select-none flex items-center gap-2 rounded my-0.5",
+          "cursor-pointer select-none flex items-center gap-1.5 rounded py-0.5 px-1.5",
           isSelected ? "bg-code-keyword-overlay" : "bg-transparent hover:bg-white/5"
         )}
-        style={{ paddingLeft: `${depth * 16 + 8}px` }}
+        style={{ paddingLeft: `${depth * 12 + 4}px` }}
         onClick={handleClick}
       >
         {node.isDirectory ? (
           <>
             <span
-              className="inline-flex h-4 w-4 shrink-0 items-center justify-center transition-transform duration-200"
+              className="text-muted inline-flex h-3 w-3 shrink-0 items-center justify-center text-[8px] transition-transform duration-200"
               style={{ transform: isOpen ? "rotate(90deg)" : "rotate(0deg)" }}
               data-toggle
               onClick={handleToggleClick}
@@ -256,18 +256,18 @@ export const FileTree: React.FC<FileTreeExternalProps> = ({
 
   return (
     <>
-      <div className="border-border-light text-foreground font-primary flex items-center gap-2 border-b px-3 py-2 text-xs font-medium">
-        <span>Files Changed</span>
+      <div className="border-border-light text-muted font-primary flex items-center gap-2 border-b px-2 py-1 text-[11px]">
+        <span>Files</span>
         {selectedPath && (
           <button
-            className="text-muted font-primary hover:text-foreground ml-auto cursor-pointer rounded-[3px] border-none bg-transparent px-2 py-0.5 text-[11px] transition-all duration-200 hover:bg-white/5"
+            className="text-dim font-primary hover:text-muted ml-auto cursor-pointer border-none bg-transparent p-0 text-[10px] transition-colors duration-150"
             onClick={() => onSelectFile(null)}
           >
-            Clear filter
+            ✕
           </button>
         )}
       </div>
-      <div className="font-monospace min-h-0 flex-1 overflow-y-auto p-3 text-xs">
+      <div className="font-monospace min-h-0 flex-1 overflow-y-auto px-1 py-1 text-[11px]">
         {isLoading && !root ? (
           <div className="text-muted py-5 text-center">Loading file tree...</div>
         ) : root ? (

--- a/src/browser/components/RightSidebar/CodeReview/HunkViewer.tsx
+++ b/src/browser/components/RightSidebar/CodeReview/HunkViewer.tsx
@@ -196,36 +196,39 @@ export const HunkViewer = React.memo<HunkViewerProps>(
         tabIndex={0}
         data-hunk-id={hunkId}
       >
-        <div className="bg-separator border-border-light font-monospace flex items-center justify-between gap-2 border-b px-3 py-2 text-xs">
-          {isRead && (
+        <div className="border-border-light font-monospace flex items-center gap-1.5 border-b px-2 py-1 text-[11px]">
+          {onToggleRead && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <span
-                  className="text-read mr-1 inline-flex items-center text-sm"
-                  aria-label="Marked as read"
+                <button
+                  className={cn(
+                    "text-muted hover:text-read flex cursor-pointer items-center bg-transparent border-none p-0 text-[11px] transition-colors duration-150",
+                    isRead && "text-read"
+                  )}
+                  data-hunk-id={hunkId}
+                  onClick={handleToggleRead}
+                  aria-label={`Mark as read (${formatKeybind(KEYBINDS.TOGGLE_HUNK_READ)})`}
                 >
-                  ✓
-                </span>
+                  {isRead ? "✓" : "○"}
+                </button>
               </TooltipTrigger>
-              <TooltipContent align="center" side="top">
-                Marked as read
+              <TooltipContent align="start" side="top">
+                Mark as read ({formatKeybind(KEYBINDS.TOGGLE_HUNK_READ)}) · Mark file (
+                {formatKeybind(KEYBINDS.MARK_FILE_READ)})
               </TooltipContent>
             </Tooltip>
           )}
           <div
-            className="text-foreground min-w-0 truncate font-medium"
+            className="text-foreground min-w-0 truncate"
             dangerouslySetInnerHTML={{ __html: highlightedFilePath }}
           />
-          <div className="flex shrink-0 items-center gap-2 text-[11px] whitespace-nowrap">
+          <div className="text-muted ml-auto flex shrink-0 items-center gap-1.5 whitespace-nowrap">
             {!isPureRename && (
-              <span className="flex gap-2 text-[11px]">
+              <>
                 {additions > 0 && <span className="text-success-light">+{additions}</span>}
-                {deletions > 0 && <span className="text-warning-light">-{deletions}</span>}
-              </span>
+                {deletions > 0 && <span className="text-warning-light">−{deletions}</span>}
+              </>
             )}
-            <span className="text-muted">
-              ({lineCount} {lineCount === 1 ? "line" : "lines"})
-            </span>
             <Tooltip>
               <TooltipTrigger asChild>
                 <span className="text-dim cursor-default">{formatRelativeTime(firstSeenAt)}</span>
@@ -234,24 +237,6 @@ export const HunkViewer = React.memo<HunkViewerProps>(
                 First seen: {new Date(firstSeenAt).toLocaleString()}
               </TooltipContent>
             </Tooltip>
-            {onToggleRead && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    className="border-border-light text-muted hover:border-read hover:text-read flex cursor-pointer items-center gap-1 rounded-[3px] border bg-transparent px-1.5 py-0.5 text-[11px] transition-all duration-200 hover:bg-white/5 active:scale-95"
-                    data-hunk-id={hunkId}
-                    onClick={handleToggleRead}
-                    aria-label={`Mark as read (${formatKeybind(KEYBINDS.TOGGLE_HUNK_READ)})`}
-                  >
-                    {isRead ? "○" : "◉"}
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent align="end" side="top">
-                  Mark as read ({formatKeybind(KEYBINDS.TOGGLE_HUNK_READ)}) · Mark file (
-                  {formatKeybind(KEYBINDS.MARK_FILE_READ)})
-                </TooltipContent>
-              </Tooltip>
-            )}
           </div>
         </div>
 

--- a/src/browser/components/RightSidebar/CodeReview/ReviewPanel.tsx
+++ b/src/browser/components/RightSidebar/CodeReview/ReviewPanel.tsx
@@ -1008,61 +1008,53 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
           )}
 
           {/* Search bar - always visible at top, not sticky */}
-          <div className="border-border-light bg-separator border-b px-3 py-2">
-            <div className="border-border-light bg-dark hover:border-border-gray focus-within:border-accent focus-within:hover:border-accent flex items-stretch overflow-hidden rounded border transition-[border-color] duration-150">
-              <input
-                ref={searchInputRef}
-                type="text"
-                placeholder={`Search in files and hunks... (${formatKeybind(KEYBINDS.FOCUS_REVIEW_SEARCH)})`}
-                value={searchState.input}
-                onChange={(e) => setSearchState({ ...searchState, input: e.target.value })}
-                className="text-foreground placeholder:text-dim focus:bg-separator flex h-full flex-1 items-center border-none bg-transparent px-2.5 py-1.5 font-sans text-xs leading-[1.4] outline-none"
-              />
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    className={cn(
-                      "py-1.5 px-2.5 border-none border-l border-light text-[11px] font-monospace font-semibold leading-[1.4] cursor-pointer outline-none transition-all duration-150 whitespace-nowrap flex items-center h-full",
-                      searchState.useRegex
-                        ? "bg-review-bg-blue text-accent-light shadow-[inset_0_0_0_1px_rgba(77,184,255,0.4)] hover:bg-review-bg-info hover:text-accent-light"
-                        : "bg-transparent text-subtle hover:bg-separator hover:text-foreground",
-                      "active:translate-y-px"
-                    )}
-                    onClick={() =>
-                      setSearchState({ ...searchState, useRegex: !searchState.useRegex })
-                    }
-                  >
-                    .*
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  {searchState.useRegex ? "Using regex search" : "Using substring search"}
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    className={cn(
-                      "py-1.5 px-2.5 border-none border-l border-light text-[11px] font-monospace font-semibold leading-[1.4] cursor-pointer outline-none transition-all duration-150 whitespace-nowrap flex items-center h-full",
-                      searchState.matchCase
-                        ? "bg-review-bg-blue text-accent-light shadow-[inset_0_0_0_1px_rgba(77,184,255,0.4)] hover:bg-review-bg-info hover:text-accent-light"
-                        : "bg-transparent text-subtle hover:bg-separator hover:text-foreground",
-                      "active:translate-y-px"
-                    )}
-                    onClick={() =>
-                      setSearchState({ ...searchState, matchCase: !searchState.matchCase })
-                    }
-                  >
-                    Aa
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  {searchState.matchCase
-                    ? "Match case (case-sensitive)"
-                    : "Ignore case (case-insensitive)"}
-                </TooltipContent>
-              </Tooltip>
-            </div>
+          <div className="border-border-light flex items-center gap-1.5 border-b px-2 py-1">
+            <input
+              ref={searchInputRef}
+              type="text"
+              placeholder={`Search... (${formatKeybind(KEYBINDS.FOCUS_REVIEW_SEARCH)})`}
+              value={searchState.input}
+              onChange={(e) => setSearchState({ ...searchState, input: e.target.value })}
+              className="bg-dark text-foreground border-border-medium placeholder:text-dim hover:border-accent focus:border-accent min-w-0 flex-1 rounded border px-1.5 py-0.5 font-mono text-[11px] transition-[border-color] duration-150 focus:outline-none"
+            />
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  className={cn(
+                    "font-monospace cursor-pointer border-none bg-transparent p-0 text-[11px] font-semibold transition-colors duration-150",
+                    searchState.useRegex ? "text-accent-light" : "text-muted hover:text-foreground"
+                  )}
+                  onClick={() =>
+                    setSearchState({ ...searchState, useRegex: !searchState.useRegex })
+                  }
+                >
+                  .*
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {searchState.useRegex ? "Using regex search" : "Using substring search"}
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  className={cn(
+                    "font-monospace cursor-pointer border-none bg-transparent p-0 text-[11px] font-semibold transition-colors duration-150",
+                    searchState.matchCase ? "text-accent-light" : "text-muted hover:text-foreground"
+                  )}
+                  onClick={() =>
+                    setSearchState({ ...searchState, matchCase: !searchState.matchCase })
+                  }
+                >
+                  Aa
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {searchState.matchCase
+                  ? "Match case (case-sensitive)"
+                  : "Ignore case (case-insensitive)"}
+              </TooltipContent>
+            </Tooltip>
           </div>
 
           {/* Single scrollable area containing both file tree and hunks */}

--- a/src/browser/components/RightSidebar/CodeReview/UntrackedStatus.tsx
+++ b/src/browser/components/RightSidebar/CodeReview/UntrackedStatus.tsx
@@ -160,14 +160,14 @@ export const UntrackedStatus: React.FC<UntrackedStatusProps> = ({
     <div ref={containerRef} className="inline-block">
       <div
         className={cn(
-          "py-1 px-2.5 rounded font-medium text-[11px] whitespace-nowrap transition-all duration-200",
+          "py-0.5 px-1.5 rounded text-[11px] whitespace-nowrap transition-colors duration-150",
           hasUntracked
-            ? "bg-review-bg-warning border border-review-warning text-info-yellow cursor-pointer hover:bg-review-warning-light hover:border-review-warning-medium"
-            : "bg-transparent border border-transparent text-muted cursor-default"
+            ? "text-info-yellow cursor-pointer hover:text-[hsl(38,100%,65%)]"
+            : "text-dim cursor-default"
         )}
         onClick={() => hasUntracked && setShowTooltip(!showTooltip)}
       >
-        {isLoading ? "..." : `${count} Untracked`}
+        {isLoading ? "…" : hasUntracked ? `+${count}` : ""}
       </div>
 
       {showTooltip &&

--- a/src/browser/components/shared/DiffRenderer.tsx
+++ b/src/browser/components/shared/DiffRenderer.tsx
@@ -281,13 +281,15 @@ export const DiffContainer: React.FC<
   const isOverflowing = useOverflowDetection(contentRef, { enabled: clampContent });
   const showOverflowControls = clampContent && isOverflowing;
 
-  // Calculate gutter width to match DiffLineGutter layout:
-  // px-1 (4px) + oldWidthCh + gap-0.5 (2px) + ml-3 (12px) + newWidthCh + px-1 (4px)
-  // When line numbers hidden, gutter is just px-1 (8px total)
+  // Calculate gutter width to match DiffLineGutter + DiffIndicator layout:
+  // DiffLineGutter: px-1 (8px) + oldWidthCh + gap-0.5 (2px) + ml-3 (12px) + newWidthCh
+  // DiffIndicator: w-4 (16px)
+  // Total: 8px + oldWidthCh + 14px + newWidthCh + 16px = 38px + oldWidthCh + newWidthCh
+  // When line numbers hidden: px-1 (8px) + w-4 (16px) = 24px
   const gutterWidth =
     showLineNumbers && lineNumberWidths
-      ? `calc(8px + ${lineNumberWidths.oldWidthCh}ch + 14px + ${lineNumberWidths.newWidthCh}ch)`
-      : "8px";
+      ? `calc(38px + ${lineNumberWidths.oldWidthCh}ch + ${lineNumberWidths.newWidthCh}ch)`
+      : "24px";
 
   // Padding strip mirrors gutter/content background split of diff lines
   // Must use font-monospace so ch units match DiffLineGutter's character widths


### PR DESCRIPTION
Cleans up the aesthetic of the ReviewPanel with a preference for compact design.

## Changes

### HunkViewer (hunk header)
- Reduced padding: `px-3 py-2` → `px-2 py-1`
- Removed background (`bg-separator border-b`)
- Moved read toggle to left side for better scan pattern
- Simplified toggle button: border-less `○`/`✓` that changes color when read
- Removed line count display (kept additions/deletions and relative time)
- Used proper minus sign `−` instead of `-` for deletions

### ReviewControls
- Reduced padding: `px-3 py-2 gap-3` → `px-2 py-1 gap-2`
- Removed background (`bg-separator`)
- Grouped Base input with label and set-default button
- Smaller input width: `w-36` → `w-24`
- Set Default → `★` star icon with hover tooltip
- Smaller checkboxes: `h-3 w-3`
- Muted checkbox labels that brighten on hover
- Shortened label: "Show read" → "Read"
- Sort dropdown standalone (removed "Sort:" label)
- Compact stats: `{read} read / {total} total` → `{read}/{total}`
- Right-aligned stats + untracked indicator

### UntrackedStatus
- Minimal text-only styling (removed background/border)
- Compact format: `N Untracked` → `+N` (only shows when >0)
- Smaller padding

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
