### PR TITLE
🤖 feat: defer auto-refresh while composing review note

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -115,6 +115,13 @@ Avoid mock-heavy tests that verify implementation details rather than behavior. 
 - Skip tautological tests (simple mappings, identical copies of implementation); focus on invariants and boundary failures.
 - Keep utils pure or parameterize external effects for easier testing.
 
+### UI Tests (`tests/ui`)
+
+- Tests in `tests/ui` must render the **full app** via `AppLoader` and drive interactions from the **user's perspective** (clicking, typing, navigating).
+- Use `renderReviewPanel()` helper or similar patterns that render `<AppLoader client={apiClient} />`.
+- Never test isolated components or utility functions here—those belong as unit tests beside implementation (`*.test.ts`).
+- These tests require `TEST_INTEGRATION=1` and real API keys; use `shouldRunIntegrationTests()` guard.
+
 ### Integration Testing
 
 - Use `bun x jest` (optionally `TEST_INTEGRATION=1`). Examples:

--- a/src/browser/components/RightSidebar/CodeReview/HunkViewer.tsx
+++ b/src/browser/components/RightSidebar/CodeReview/HunkViewer.tsx
@@ -29,6 +29,8 @@ interface HunkViewerProps {
   onRegisterToggleExpand?: (hunkId: string, toggleFn: () => void) => void;
   onReviewNote?: (data: ReviewNoteData) => void;
   searchConfig?: SearchHighlightConfig;
+  /** Callback when review note composition state changes */
+  onComposingChange?: (isComposing: boolean) => void;
 }
 
 export const HunkViewer = React.memo<HunkViewerProps>(
@@ -44,6 +46,7 @@ export const HunkViewer = React.memo<HunkViewerProps>(
     onRegisterToggleExpand,
     onReviewNote,
     searchConfig,
+    onComposingChange,
   }) => {
     // Ref for the hunk container to track visibility
     const hunkRef = React.useRef<HTMLDivElement>(null);
@@ -263,6 +266,7 @@ export const HunkViewer = React.memo<HunkViewerProps>(
             }}
             searchConfig={searchConfig}
             enableHighlighting={isVisible}
+            onComposingChange={onComposingChange}
           />
         ) : (
           <div

--- a/src/browser/components/RightSidebar/CodeReview/ReviewControls.tsx
+++ b/src/browser/components/RightSidebar/CodeReview/ReviewControls.tsx
@@ -21,6 +21,8 @@ interface ReviewControlsProps {
   onFiltersChange: (filters: ReviewFilters) => void;
   onRefresh?: () => void;
   isLoading?: boolean;
+  /** Whether refresh is blocked (e.g., user composing review note) */
+  isRefreshBlocked?: boolean;
   workspaceId: string;
   workspacePath: string;
   refreshTrigger?: number;
@@ -34,6 +36,7 @@ export const ReviewControls: React.FC<ReviewControlsProps> = ({
   onFiltersChange,
   onRefresh,
   isLoading = false,
+  isRefreshBlocked = false,
   workspaceId,
   workspacePath,
   refreshTrigger,
@@ -71,6 +74,7 @@ export const ReviewControls: React.FC<ReviewControlsProps> = ({
         <RefreshButton
           onClick={onRefresh}
           isLoading={isLoading}
+          disabled={isRefreshBlocked}
           lastRefreshInfo={lastRefreshInfo}
         />
       )}


### PR DESCRIPTION
When a user is selecting code or composing a review note in the diff, auto-refresh is now deferred until they complete or cancel the note. This prevents in-flight review comments from being lost when files change.

## Implementation

- Add `onComposingChange` callback to `DiffRenderer` and `HunkViewer`
- Track composing state per hunk in `ReviewPanel` via `composingHunksRef`
- Extend `RefreshController` `isPaused` check to include composing state
- Call `notifyUnpaused()` when composition ends to flush any pending refresh
- Manual refresh (button click or Ctrl+R) still bypasses pause

## Tests

- Add unit tests for pause/unpause behavior in `reviewNoteDeferRefresh.test.ts`

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
