### PR TITLE
🤖 ci: run tests/ui on browser OR backend changes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -133,12 +133,11 @@ jobs:
           if [[ "$BACKEND" == "true" ]]; then
             echo "Backend changes detected - running all integration tests"
             TEST_INTEGRATION=1 bun x jest --coverage --maxWorkers=100% --silent tests/
-            exit 0
+          else
+            # Browser-only changes: run tests/ui
+            echo "Browser changes detected - running tests/ui"
+            TEST_INTEGRATION=1 bun x jest --coverage --maxWorkers=100% --silent tests/ui/
           fi
-          
-          # Browser-only changes: run tests/ui
-          echo "Browser changes detected - running tests/ui"
-          TEST_INTEGRATION=1 bun x jest --coverage --maxWorkers=100% --silent tests/ui/
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Add `browser` filter to change detection and update `test-integration` job to run `tests/ui` when there are browser OR backend changes.

## Changes

- **New `browser` filter**: Triggers on `src/browser/**` and `tests/ui/**` changes
- **Updated test-integration logic**:
  - Backend changes → run all `tests/` (includes `tests/ui`)
  - Browser-only changes → run `tests/ui/` only
  - Neither → skip integration tests

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
