### PR TITLE
🤖 fix: remove blue focus border from ReviewPanel

### DIFF
--- a/src/browser/components/RightSidebar/CodeReview/ReviewPanel.tsx
+++ b/src/browser/components/RightSidebar/CodeReview/ReviewPanel.tsx
@@ -955,7 +955,7 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
       tabIndex={0}
       onFocus={() => setIsPanelFocused(true)}
       onBlur={() => setIsPanelFocused(false)}
-      className="bg-dark [container-type:inline-size] flex h-full min-h-0 flex-col outline-none [container-name:review-panel] focus-within:shadow-[inset_0_0_0_1px_rgba(0,122,204,0.2)]"
+      className="bg-dark [container-type:inline-size] flex h-full min-h-0 flex-col outline-none [container-name:review-panel]"
     >
       {/* Always show controls so user can change diff base */}
       <ReviewControls


### PR DESCRIPTION
## Summary

Removes the `focus-within:shadow-[inset_0_0_0_1px_rgba(0,122,204,0.2)]` styling from the ReviewPanel container that caused a blue border to appear around the entire panel (including above the review controls) when entering a new review.

## Before/After

- **Before**: When focusing the review note textarea, a blue inset border appeared around the entire panel
- **After**: No visual focus indicator on the panel container (the panel already tracks focus state via `isPanelFocused` for functional purposes like keyboard navigation gating)

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_