### PR TITLE
🤖 tests: deflake Chat > Streaming story

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "mux",

--- a/src/browser/stories/mockFactory.ts
+++ b/src/browser/stories/mockFactory.ts
@@ -694,19 +694,10 @@ export function createStreamingChatHandler(opts: {
       }
     }, 50);
 
-    // Keep streaming state alive
-    const intervalId = setInterval(() => {
-      callback({
-        type: "stream-delta",
-        workspaceId: "mock",
-        messageId: opts.streamingMessageId,
-        delta: ".",
-        tokens: 0,
-        timestamp: NOW,
-      });
-    }, 2000);
-
-    return () => clearInterval(intervalId);
+    // Keep the streaming state active, but avoid emitting periodic visible deltas.
+    // Those deltas can make visual snapshots flaky (different text length per run).
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    return () => {};
   };
 }
 


### PR DESCRIPTION
The `App/Chat` → `Streaming` story used a periodic `stream-delta` of "." to keep the stream “alive”.

That makes snapshots flaky because the rendered assistant text can differ depending on how long the story has been mounted when the snapshot is taken.

This change removes the periodic visible deltas while still leaving the story in an active streaming state.

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh`_
