### PR TITLE
🤖 fix: align git status tooltip near indicator in workspace header

### DIFF
--- a/src/browser/components/GitStatusIndicatorView.tsx
+++ b/src/browser/components/GitStatusIndicatorView.tsx
@@ -342,7 +342,7 @@ export const GitStatusIndicatorView: React.FC<GitStatusIndicatorViewProps> = ({
       </HoverCardTrigger>
       <HoverCardContent
         side={tooltipPosition === "right" ? "right" : "bottom"}
-        align="center"
+        align={tooltipPosition === "right" ? "center" : "start"}
         sideOffset={8}
         collisionPadding={8}
         className="bg-modal-bg text-foreground border-separator-light z-[10000] max-h-[400px] w-auto max-w-96 min-w-0 overflow-auto px-3 py-2 font-mono text-[11px] whitespace-pre shadow-[0_4px_12px_rgba(0,0,0,0.5)]"

--- a/src/browser/stories/App.titlebar.stories.tsx
+++ b/src/browser/stories/App.titlebar.stories.tsx
@@ -1,0 +1,109 @@
+/**
+ * Workspace titlebar / header stories
+ */
+
+import { appMeta, AppWithMocks, type AppStory } from "./meta.js";
+import {
+  NOW,
+  createWorkspace,
+  groupWorkspacesByProject,
+  type GitStatusFixture,
+} from "./mockFactory";
+import { createGitStatusExecutor, expandProjects, selectWorkspace } from "./storyHelpers";
+import { GIT_STATUS_INDICATOR_MODE_KEY } from "@/common/constants/storage";
+import { within, userEvent, waitFor } from "@storybook/test";
+
+import { createMockORPCClient } from "../../../.storybook/mocks/orpc";
+
+export default {
+  ...appMeta,
+  title: "App/Titlebar",
+};
+
+/**
+ * Git status tooltip in workspace header - verifies alignment is near the indicator.
+ * The header uses tooltipPosition="bottom" which requires align="start" to stay anchored.
+ */
+export const GitStatusTooltip: AppStory = {
+  render: () => (
+    <AppWithMocks
+      setup={() => {
+        window.localStorage.setItem(GIT_STATUS_INDICATOR_MODE_KEY, JSON.stringify("line-delta"));
+
+        const workspaces = [
+          createWorkspace({
+            id: "ws-active",
+            name: "feature/tooltip-test",
+            projectName: "my-app",
+            createdAt: new Date(NOW - 3600000).toISOString(),
+          }),
+        ];
+
+        const gitStatus = new Map<string, GitStatusFixture>([
+          [
+            "ws-active",
+            {
+              ahead: 3,
+              behind: 2,
+              dirty: 5,
+              outgoingAdditions: 150,
+              outgoingDeletions: 30,
+              headCommit: "WIP: Testing tooltip alignment",
+            },
+          ],
+        ]);
+
+        // Select workspace so header is visible
+        selectWorkspace(workspaces[0]);
+        expandProjects(["/home/user/projects/my-app"]);
+
+        return createMockORPCClient({
+          projects: groupWorkspacesByProject(workspaces),
+          workspaces,
+          executeBash: createGitStatusExecutor(gitStatus),
+        });
+      }}
+    />
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+
+    // Wait for the workspace header to render with git status
+    await waitFor(
+      () => {
+        canvas.getByTestId("workspace-header");
+      },
+      { timeout: 5000 }
+    );
+
+    // Wait for git status to appear in the header specifically
+    const header = canvas.getByTestId("workspace-header");
+    await waitFor(
+      () => {
+        within(header).getByText("+150");
+      },
+      { timeout: 5000 }
+    );
+
+    // Hover over the git status indicator in the header (not the sidebar)
+    const plusIndicator = within(header).getByText("+150");
+    await userEvent.hover(plusIndicator);
+
+    // Wait for tooltip to appear with correct alignment (portaled with data-state="open")
+    // The key fix: data-align="start" anchors tooltip near the indicator (not "center")
+    await waitFor(
+      () => {
+        const tooltip = document.body.querySelector<HTMLElement>(
+          '.bg-modal-bg[data-state="open"][data-align="start"]'
+        );
+        if (!tooltip) throw new Error("git status tooltip not visible with align=start");
+        // Verify tooltip has expected structure
+        within(tooltip).getByText("Divergence:");
+      },
+      { timeout: 5000 }
+    );
+
+    // Double-RAF to ensure layout is stable after async rendering
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+  },
+};


### PR DESCRIPTION
## Problem

The git status tooltip in the workspace header was not positioned near the status indicator. The sidebar version worked correctly.

## Solution

The `HoverCardContent` was using `align="center"` for both tooltip positions. When the tooltip appears at the bottom (workspace header), centering caused it to float away from the indicator.

Changed alignment to be position-dependent:
- `tooltipPosition="right"` (sidebar) → `align="center"` - centers vertically, natural for list items
- `tooltipPosition="bottom"` (header) → `align="start"` - anchors to left edge of trigger

## Testing

Added `GitStatusHeaderTooltip` story that:
- Selects a workspace so header is visible
- Sets up git status with line deltas and dirty state
- Hovers over the indicator and waits for tooltip
- Captures the hovered state for visual regression testing

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
