### PR TITLE
🤖 fix: hide status text on narrow viewport containers

### DIFF
--- a/src/browser/components/tools/shared/ToolPrimitives.tsx
+++ b/src/browser/components/tools/shared/ToolPrimitives.tsx
@@ -86,7 +86,7 @@ export const StatusIndicator: React.FC<StatusIndicatorProps> = ({
   <span
     className={cn(
       "text-[10px] ml-auto opacity-80 whitespace-nowrap shrink-0",
-      "[&_.status-text]:inline [@container(max-width:500px)]:&:has(.status-text):after:content-['']  [@container(max-width:500px)]:&_.status-text]:hidden",
+      "[&_.status-text]:inline [@container(max-width:350px)]:[&_.status-text]:hidden",
       getStatusColor(status),
       className
     )}


### PR DESCRIPTION
When tool container width is ≤350px, hide the status text ('executing', 'completed', etc.) and show only the icon/indicator. This prevents overflow when viewport is constrained.

**Changes:**
- Fix malformed Tailwind container query syntax
- Use proper `[@container]` with `[&_.status-text]` selector

**Result:**
- "... executing" → "..." (animated ellipsis only)
- "✓ completed" → "✓"
- "✗ failed" → "✗"
- etc.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
