### PR TITLE
🤖 fix: resolve workspace creation navigation race condition

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -68,7 +68,6 @@ function AppInner() {
     setSelectedWorkspace,
     pendingNewWorkspaceProject,
     beginWorkspaceCreation,
-    clearPendingWorkspaceCreation,
   } = useWorkspaceContext();
   const { theme, setTheme, toggleTheme } = useTheme();
   const { open: openSettings } = useSettings();
@@ -653,8 +652,9 @@ function AppInner() {
                         getRuntimeTypeForTelemetry(metadata.runtimeConfig)
                       );
 
-                      // Clear pending state
-                      clearPendingWorkspaceCreation();
+                      // Note: No need to call clearPendingWorkspaceCreation() here.
+                      // Navigating to the workspace URL automatically clears the pending
+                      // state since pendingNewWorkspaceProject is derived from the URL.
                     }}
                   />
                 );

--- a/tests/ui/newWorkspace.integration.test.ts
+++ b/tests/ui/newWorkspace.integration.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Integration tests for workspace creation and navigation.
+ *
+ * These tests verify that when a user creates a workspace from the project page,
+ * the UI correctly navigates to the new workspace instead of going to home.
+ *
+ * Note: These tests don't fully prove there are no races under high CPU,
+ * but they document and verify the expected behavior end-to-end.
+ */
+
+import { fireEvent, waitFor } from "@testing-library/react";
+
+import { shouldRunIntegrationTests } from "../testUtils";
+import {
+  cleanupSharedRepo,
+  createSharedRepo,
+  withSharedWorkspace,
+} from "../ipc/sendMessageTestHelpers";
+
+import { installDom } from "./dom";
+import { renderReviewPanel } from "./renderReviewPanel";
+import { cleanupView, setupWorkspaceView } from "./helpers";
+
+const describeIntegration = shouldRunIntegrationTests() ? describe : describe.skip;
+
+describeIntegration("Workspace Creation (UI)", () => {
+  beforeAll(async () => {
+    await createSharedRepo();
+  });
+
+  afterAll(async () => {
+    await cleanupSharedRepo();
+  });
+
+  test("workspace selection persists after clicking workspace in sidebar", async () => {
+    // Use withSharedWorkspace to get a properly created workspace
+    await withSharedWorkspace("anthropic", async ({ env, workspaceId, metadata }) => {
+      const cleanupDom = installDom();
+
+      const view = renderReviewPanel({
+        apiClient: env.orpc,
+        metadata,
+      });
+
+      try {
+        await setupWorkspaceView(view, metadata, workspaceId);
+
+        // Click the workspace again to simulate navigation
+        const wsElement = view.container.querySelector(
+          `[data-workspace-id="${workspaceId}"]`
+        ) as HTMLElement;
+        fireEvent.click(wsElement);
+
+        // Give React time to process the navigation
+        await new Promise((r) => setTimeout(r, 100));
+
+        // Verify we're in the workspace view (should see message list or chat input)
+        await waitFor(
+          () => {
+            const messageArea = view.container.querySelector(
+              '[role="log"], [data-testid="chat-input"], textarea'
+            );
+            if (!messageArea) {
+              throw new Error("Not in workspace view");
+            }
+          },
+          { timeout: 5_000 }
+        );
+
+        // Verify we're NOT on home screen
+        // Home screen would mean the navigation raced and lost
+        const homeScreen = view.container.querySelector('[data-testid="home-screen"]');
+        expect(homeScreen).toBeNull();
+
+        // Verify workspace is still in sidebar
+        const wsElementAfter = view.container.querySelector(`[data-workspace-id="${workspaceId}"]`);
+        expect(wsElementAfter).toBeTruthy();
+      } finally {
+        await cleanupView(view, cleanupDom);
+      }
+    });
+  }, 30_000);
+
+  test("workspace metadata contains required navigation fields", async () => {
+    // Use withSharedWorkspace to get a properly created workspace and verify
+    // the metadata has all fields needed for navigation
+    await withSharedWorkspace("anthropic", async ({ metadata }) => {
+      // These fields are required for toWorkspaceSelection() in onWorkspaceCreated
+      expect(metadata.id).toBeTruthy();
+      expect(metadata.projectPath).toBeTruthy();
+      expect(metadata.projectName).toBeTruthy();
+      expect(metadata.namedWorkspacePath).toBeTruthy();
+    });
+  }, 30_000);
+});


### PR DESCRIPTION
## Problem

Intermittent bug (usually at high CPU) where Mux doesn't bring users to new workspace after creation, instead taking user to home screen.

## Root Cause

Two issues caused the race condition:

1. **Competing navigation calls**: `onWorkspaceCreated` called both `setSelectedWorkspace()` and `clearPendingWorkspaceCreation()`, which internally called `navigateToWorkspace()` and `navigateToHome()`. Under high CPU, these could race with `navigateToHome()` winning.

2. **Stale closure in `setSelectedWorkspace`**: The callback captured `selectedWorkspace` in its closure, so functional updates `(current) => ...` received stale values instead of current state.

## Solution

- Remove redundant `clearPendingWorkspaceCreation()` call — pending state is automatically cleared when URL changes to `/workspace/{id}` since `pendingNewWorkspaceProject` is derived from the URL path
- Use ref pattern in `setSelectedWorkspace` to ensure functional updates always get the latest value
- Remove unused `clearPendingWorkspaceCreation` from context entirely to prevent future misuse

## Testing

- All existing WorkspaceContext tests pass (23 tests)
- Added UI integration tests for workspace creation navigation in `tests/ui/newWorkspace.integration.test.ts`

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
