### PR TITLE
🤖 feat: add Keybinds section to Settings

### DIFF
--- a/src/browser/components/Settings/SettingsModal.tsx
+++ b/src/browser/components/Settings/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Settings, Key, Cpu, X, Briefcase, FlaskConical, Bot } from "lucide-react";
+import { Settings, Key, Cpu, X, Briefcase, FlaskConical, Bot, Keyboard } from "lucide-react";
 import { useSettings } from "@/browser/contexts/SettingsContext";
 import { Dialog, DialogContent, DialogTitle, VisuallyHidden } from "@/browser/components/ui/dialog";
 import { GeneralSection } from "./sections/GeneralSection";
@@ -9,6 +9,7 @@ import { ModelsSection } from "./sections/ModelsSection";
 import { Button } from "@/browser/components/ui/button";
 import { ProjectSettingsSection } from "./sections/ProjectSettingsSection";
 import { ExperimentsSection } from "./sections/ExperimentsSection";
+import { KeybindsSection } from "./sections/KeybindsSection";
 import type { SettingsSection } from "./types";
 
 const SECTIONS: SettingsSection[] = [
@@ -47,6 +48,12 @@ const SECTIONS: SettingsSection[] = [
     label: "Experiments",
     icon: <FlaskConical className="h-4 w-4" />,
     component: ExperimentsSection,
+  },
+  {
+    id: "keybinds",
+    label: "Keybinds",
+    icon: <Keyboard className="h-4 w-4" />,
+    component: KeybindsSection,
   },
 ];
 

--- a/src/browser/components/Settings/sections/KeybindsSection.tsx
+++ b/src/browser/components/Settings/sections/KeybindsSection.tsx
@@ -1,0 +1,123 @@
+import { KEYBINDS, formatKeybind } from "@/browser/utils/ui/keybinds";
+
+/**
+ * Human-readable labels for keybind IDs.
+ * Derived from the comments in keybinds.ts.
+ */
+const KEYBIND_LABELS: Record<keyof typeof KEYBINDS, string> = {
+  TOGGLE_MODE: "Toggle Plan/Exec mode",
+  SEND_MESSAGE: "Send message",
+  NEW_LINE: "Insert newline",
+  CANCEL: "Cancel / Close modal",
+  CANCEL_EDIT: "Cancel editing message",
+  SAVE_EDIT: "Save edit",
+  INTERRUPT_STREAM_VIM: "Interrupt stream (Vim mode)",
+  INTERRUPT_STREAM_NORMAL: "Interrupt stream",
+  FOCUS_INPUT_I: "Focus input (i)",
+  FOCUS_INPUT_A: "Focus input (a)",
+  NEW_WORKSPACE: "New workspace",
+  JUMP_TO_BOTTOM: "Jump to bottom",
+  NEXT_WORKSPACE: "Next workspace",
+  PREV_WORKSPACE: "Previous workspace",
+  TOGGLE_SIDEBAR: "Toggle sidebar",
+  CYCLE_MODEL: "Cycle model",
+  OPEN_TERMINAL: "Open in terminal",
+  OPEN_IN_EDITOR: "Open in editor",
+  OPEN_COMMAND_PALETTE: "Command palette",
+  TOGGLE_THINKING: "Toggle thinking",
+  FOCUS_CHAT: "Focus chat input",
+  COSTS_TAB: "Costs tab",
+  REVIEW_TAB: "Review tab",
+  STATS_TAB: "Stats tab",
+  REFRESH_REVIEW: "Refresh diff",
+  FOCUS_REVIEW_SEARCH: "Search in review",
+  TOGGLE_HUNK_READ: "Toggle hunk read",
+  MARK_HUNK_READ: "Mark hunk read",
+  MARK_HUNK_UNREAD: "Mark hunk unread",
+  MARK_FILE_READ: "Mark file read",
+  TOGGLE_HUNK_COLLAPSE: "Toggle hunk collapse",
+  OPEN_SETTINGS: "Open settings",
+  TOGGLE_VOICE_INPUT: "Toggle voice input",
+};
+
+/** Groups for organizing keybinds in the UI */
+const KEYBIND_GROUPS: Array<{ label: string; keys: Array<keyof typeof KEYBINDS> }> = [
+  {
+    label: "General",
+    keys: [
+      "TOGGLE_MODE",
+      "OPEN_COMMAND_PALETTE",
+      "OPEN_SETTINGS",
+      "TOGGLE_SIDEBAR",
+      "CYCLE_MODEL",
+      "TOGGLE_THINKING",
+    ],
+  },
+  {
+    label: "Chat",
+    keys: [
+      "SEND_MESSAGE",
+      "NEW_LINE",
+      "FOCUS_CHAT",
+      "FOCUS_INPUT_I",
+      "FOCUS_INPUT_A",
+      "CANCEL",
+      "INTERRUPT_STREAM_NORMAL",
+      "INTERRUPT_STREAM_VIM",
+      "TOGGLE_VOICE_INPUT",
+    ],
+  },
+  {
+    label: "Editing",
+    keys: ["SAVE_EDIT", "CANCEL_EDIT"],
+  },
+  {
+    label: "Navigation",
+    keys: ["NEW_WORKSPACE", "NEXT_WORKSPACE", "PREV_WORKSPACE", "JUMP_TO_BOTTOM"],
+  },
+  {
+    label: "Tabs",
+    keys: ["COSTS_TAB", "REVIEW_TAB", "STATS_TAB"],
+  },
+  {
+    label: "Code Review",
+    keys: [
+      "REFRESH_REVIEW",
+      "FOCUS_REVIEW_SEARCH",
+      "TOGGLE_HUNK_READ",
+      "MARK_HUNK_READ",
+      "MARK_HUNK_UNREAD",
+      "MARK_FILE_READ",
+      "TOGGLE_HUNK_COLLAPSE",
+    ],
+  },
+  {
+    label: "External",
+    keys: ["OPEN_TERMINAL", "OPEN_IN_EDITOR"],
+  },
+];
+
+export function KeybindsSection() {
+  return (
+    <div className="space-y-6">
+      {KEYBIND_GROUPS.map((group) => (
+        <div key={group.label}>
+          <h3 className="text-foreground mb-3 text-sm font-medium">{group.label}</h3>
+          <div className="space-y-1">
+            {group.keys.map((key) => (
+              <div
+                key={key}
+                className="flex items-center justify-between rounded px-2 py-1.5 text-sm"
+              >
+                <span className="text-muted">{KEYBIND_LABELS[key]}</span>
+                <kbd className="bg-background-secondary text-foreground border-border-medium rounded border px-2 py-0.5 font-mono text-xs">
+                  {formatKeybind(KEYBINDS[key])}
+                </kbd>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/browser/stories/App.settings.stories.tsx
+++ b/src/browser/stories/App.settings.stories.tsx
@@ -262,4 +262,12 @@ export const ExperimentsToggleOff: AppStory = {
   },
 };
 
+/** Keybinds section - shows keyboard shortcuts reference */
+export const Keybinds: AppStory = {
+  render: () => <AppWithMocks setup={() => setupSettingsStory({})} />,
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    await openSettingsToSection(canvasElement, "keybinds");
+  },
+};
+
 // NOTE: Projects section stories live in App.projectSettings.stories.tsx


### PR DESCRIPTION
Adds an automatically generated keybinds reference to the Settings modal.

## Changes

- **New `KeybindsSection` component** that displays all keybinds from the centralized `KEYBINDS` registry
- Groups keybinds by category (General, Chat, Editing, Navigation, Tabs, Code Review, External)
- Uses `formatKeybind()` for OS-appropriate display (⌘ symbols on Mac, Ctrl+ on Windows/Linux)
- **New Storybook story** for the Keybinds settings page

## How it works

The keybinds reference is generated from the source of truth (`KEYBINDS` in `keybinds.ts`). When keybinds are added/modified, only the `KEYBIND_LABELS` map needs updating for human-readable labels.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
