### PR TITLE
🤖 fix: add unmount guard to useCreationWorkspace branch loading

### DIFF
--- a/src/browser/components/ChatInput/useCreationWorkspace.ts
+++ b/src/browser/components/ChatInput/useCreationWorkspace.ts
@@ -136,19 +136,26 @@ export function useCreationWorkspace({
     if (!projectPath.length || !api) {
       return;
     }
+    let mounted = true;
     setBranchesLoaded(false);
     const loadBranches = async () => {
       try {
         const result = await api.projects.listBranches({ projectPath });
+        if (!mounted) return;
         setBranches(result.branches);
         setRecommendedTrunk(result.recommendedTrunk);
       } catch (err) {
         console.error("Failed to load branches:", err);
       } finally {
-        setBranchesLoaded(true);
+        if (mounted) {
+          setBranchesLoaded(true);
+        }
       }
     };
     void loadBranches();
+    return () => {
+      mounted = false;
+    };
   }, [projectPath, api]);
 
   const handleSend = useCallback(


### PR DESCRIPTION
Fixes flaky test `workspaceLifecycle.integration.test.ts` that was failing with:

```
TypeError: Cannot read properties of undefined (reading 'event')
    at setBranchesLoaded (src/browser/components/ChatInput/useCreationWorkspace.ts:148:9)
```

**Root cause:** The `useEffect` that loads branches was calling `setBranchesLoaded(true)` after the async `listBranches` API call completed. If the component unmounted during that API call (e.g., during test cleanup), React's internal event scheduling was already torn down.

**Fix:** Add a `mounted` flag with cleanup function. The async callback now checks `if (!mounted)` before any state updates, preventing updates after unmount.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
