### PR TITLE
🤖 fix: contain diff horizontal overflow within component

### DIFF
--- a/src/browser/components/shared/DiffRenderer.tsx
+++ b/src/browser/components/shared/DiffRenderer.tsx
@@ -297,14 +297,14 @@ export const DiffContainer: React.FC<
   return (
     <div
       className={cn(
-        "relative m-0 rounded-sm border border-border-light bg-code-bg [&_*]:text-[inherit]",
+        "relative m-0 overflow-x-auto rounded-sm border border-border-light bg-code-bg [&_*]:text-[inherit]",
         className
       )}
     >
       <div
         ref={contentRef}
         className={cn(
-          "font-monospace grid overflow-x-auto",
+          "font-monospace grid",
           clampContent ? "overflow-y-hidden" : "overflow-y-visible",
           showOverflowControls && "pb-6"
         )}

--- a/src/browser/stories/App.chat.stories.tsx
+++ b/src/browser/stories/App.chat.stories.tsx
@@ -1014,6 +1014,65 @@ export const DiffPaddingAlignment: AppStory = {
 };
 
 /**
+ * Story to verify diff horizontal scrolling with long lines.
+ * When code lines exceed container width, the diff should scroll horizontally
+ * rather than overflow outside its container. The background colors for
+ * additions/deletions should span the full scrollable width.
+ */
+export const DiffHorizontalScroll: AppStory = {
+  render: () => (
+    <AppWithMocks
+      setup={() =>
+        setupSimpleChatStory({
+          workspaceId: "ws-diff-scroll",
+          messages: [
+            createUserMessage("msg-1", "Show me a diff with very long lines", {
+              historySequence: 1,
+              timestamp: STABLE_TIMESTAMP - 100000,
+            }),
+            createAssistantMessage(
+              "msg-2",
+              "Here's a diff with lines that require horizontal scrolling:",
+              {
+                historySequence: 2,
+                timestamp: STABLE_TIMESTAMP - 90000,
+                toolCalls: [
+                  createFileEditTool(
+                    "call-1",
+                    "src/config/longLines.ts",
+                    [
+                      "--- src/config/longLines.ts",
+                      "+++ src/config/longLines.ts",
+                      "@@ -1,4 +1,4 @@",
+                      " // Short context line",
+                      "-export const VERY_LONG_CONFIG_OPTION_NAME_THAT_EXCEEDS_NORMAL_WIDTH = { description: 'This is an extremely long configuration value that should definitely cause horizontal scrolling in the diff viewer component', defaultValue: false };",
+                      "+export const VERY_LONG_CONFIG_OPTION_NAME_THAT_EXCEEDS_NORMAL_WIDTH = { description: 'This is an extremely long configuration value that should definitely cause horizontal scrolling in the diff viewer component', defaultValue: true, enabled: true };",
+                      " // Another short line",
+                      " export const SHORT = 1;",
+                    ].join("\n")
+                  ),
+                ],
+              }
+            ),
+          ],
+        })
+      }
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Verifies diff container scrolls horizontally for long lines. " +
+          "The diff should NOT overflow outside its container. " +
+          "Background colors (red for deletions, green for additions) should " +
+          "extend to the full scrollable width when scrolling right.",
+      },
+    },
+  },
+};
+
+/**
  * Story showing the InitMessage component in success state.
  * Tests the workspace init hook display with completed status.
  */


### PR DESCRIPTION
## Problem

After the previous fix (#1344) that ensured backgrounds span the full scrollable width, diffs in chat were overflowing outside their container and overlaying other content instead of scrolling.

## Solution

Moved `overflow-x: auto` from the inner grid to the outer container. This ensures the entire diff component scrolls horizontally rather than the content overflowing outside.

## Regression Prevention

Added a new storybook story `DiffHorizontalScroll` that shows a diff with very long lines. This story can be used to verify:
- The diff scrolls horizontally (doesn't overflow container)
- Background colors span the full scrollable width when scrolling right

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_