### PR TITLE
🤖 fix: bundle TypeScript libs for PTC type validation in production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,20 @@ build-static: ## Copy static assets to dist
 	@mkdir -p dist
 	@cp static/splash.html dist/splash.html
 	@cp -r public/* dist/
+	# Copy TypeScript lib files for PTC runtime type validation (es5 through es2020).
+	# electron-builder ignores .d.ts files by default and this cannot be overridden:
+	# https://github.com/electron-userland/electron-builder/issues/5064
+	# Workaround: rename to .d.ts.txt extension to bypass the filter.
+	@mkdir -p dist/typescript-lib
+	@for f in node_modules/typescript/lib/lib.es5.d.ts \
+	          node_modules/typescript/lib/lib.es2015*.d.ts \
+	          node_modules/typescript/lib/lib.es2016*.d.ts \
+	          node_modules/typescript/lib/lib.es2017*.d.ts \
+	          node_modules/typescript/lib/lib.es2018*.d.ts \
+	          node_modules/typescript/lib/lib.es2019*.d.ts \
+	          node_modules/typescript/lib/lib.es2020*.d.ts; do \
+		cp "$$f" "dist/typescript-lib/$$(basename $$f).txt"; \
+	done
 
 # Always regenerate version file (marked as .PHONY above)
 version: ## Generate version file

--- a/src/browser/components/tools/CodeExecutionToolCall.tsx
+++ b/src/browser/components/tools/CodeExecutionToolCall.tsx
@@ -16,9 +16,6 @@ interface CodeExecutionToolCallProps {
   nestedCalls?: NestedToolCall[];
 }
 
-// Threshold for auto-collapsing long results (characters)
-const LONG_RESULT_THRESHOLD = 200;
-
 export const CodeExecutionToolCall: React.FC<CodeExecutionToolCallProps> = ({
   args,
   result,
@@ -36,9 +33,7 @@ export const CodeExecutionToolCall: React.FC<CodeExecutionToolCallProps> = ({
       : JSON.stringify(result.result, null, 2);
   }, [result]);
 
-  // Auto-expand result if it's short
-  const isLongResult = formattedResult ? formattedResult.length > LONG_RESULT_THRESHOLD : false;
-  const [resultExpanded, setResultExpanded] = useState(!isLongResult);
+  const [resultExpanded, setResultExpanded] = useState(false);
 
   // Use streaming nested calls if available, otherwise fall back to result
   const toolCalls = nestedCalls ?? [];
@@ -47,7 +42,7 @@ export const CodeExecutionToolCall: React.FC<CodeExecutionToolCallProps> = ({
   const isComplete = status === "completed" || status === "failed";
 
   return (
-    <fieldset className="border-foreground/20 flex flex-col gap-3 rounded-lg border border-dashed px-3 pt-2 pb-3">
+    <fieldset className="border-foreground/20 mt-3 flex flex-col gap-3 rounded-lg border border-dashed px-3 pt-2 pb-3">
       {/* Legend title with status - sits on the border */}
       <legend className="flex items-center gap-2 px-2">
         <span className="text-foreground text-sm font-medium">Code Execution</span>

--- a/src/node/services/ptc/typeGenerator.ts
+++ b/src/node/services/ptc/typeGenerator.ts
@@ -188,10 +188,7 @@ async function getResultTypeString(toolName: string): Promise<string | null> {
  * @returns `.d.ts` content as a string
  */
 export async function generateMuxTypes(tools: Record<string, Tool>): Promise<string> {
-  const lines: string[] = [
-    "declare namespace mux {",
-    "  // NOTE: Promise.all() executes sequentially in this sandbox (not parallel)",
-  ];
+  const lines: string[] = ["declare namespace mux {"];
   let mcpToolsPresent = false;
 
   // Sort tool names for deterministic output

--- a/src/node/services/tools/code_execution.ts
+++ b/src/node/services/tools/code_execution.ts
@@ -64,6 +64,8 @@ export async function createCodeExecutionTool(
   return tool({
     description: `Execute JavaScript code in a sandboxed environment with access to Mux tools.
 
+Important: Batch multiple tool calls in one invocation to minimize round trips.
+
 **Available tools (TypeScript definitions):**
 \`\`\`typescript
 ${muxTypes}
@@ -75,7 +77,6 @@ ${muxTypes}
 - Use \`console.log/warn/error\` for debugging - output is captured
 - Results are JSON-serialized; non-serializable values return \`{ error: "..." }\`
 - On failure, partial results (completed tool calls) are returned for debugging
-- \`Promise.all()\` executes tools sequentially (sandbox limitation), not in parallel
 
 **Security:** The sandbox has no access to \`require\`, \`import\`, \`process\`, \`fetch\`, or filesystem outside of \`mux.*\` tools.`,
 


### PR DESCRIPTION
## Summary

Fixes PTC (Programmatic Tool Calling) failing in production builds due to missing TypeScript lib files.

## Problems Fixed

1. **nanoid not found** - `nanoid` was only a transitive dev dependency (via postcss). Replaced with `crypto.randomBytes`.

2. **TypeScript lib files missing** - The type validator uses TypeScript's compiler API which needs `lib.es2020.d.ts` and dependencies. electron-builder has a hardcoded filter that excludes all `.d.ts` files from the asar ([electron-builder#5064](https://github.com/electron-userland/electron-builder/issues/5064)).

## Solution

- Copy only needed lib files (es5 through es2020, 48 files) to `dist/typescript-lib/` during build
- Rename to `.d.ts.txt` to bypass electron-builder's filter
- Custom compiler host in `typeValidator.ts` maps TypeScript's requests back to the renamed files

## Other Changes

- Collapse code_execution Result boxes by default (was always expanded due to useState bug)
- Add margin between consecutive code execution blocks
- Update tool description to emphasize batching calls

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
