### PR TITLE
🤖 fix: prevent horizontal scrollbar in costs sidebar

### DIFF
--- a/src/browser/components/RightSidebar/ContextUsageBar.tsx
+++ b/src/browser/components/RightSidebar/ContextUsageBar.tsx
@@ -40,7 +40,7 @@ const ContextUsageBarComponent: React.FC<ContextUsageBarProps> = ({
         </span>
       </div>
 
-      <div className="relative w-full py-2">
+      <div className="relative w-full overflow-hidden py-2">
         <TokenMeter segments={data.segments} orientation="horizontal" />
         {autoCompaction && data.maxTokens && <HorizontalThresholdSlider config={autoCompaction} />}
       </div>


### PR DESCRIPTION
The costs sidebar had a spurious horizontal scrollbar appearing when the auto-compaction threshold slider was at 70% or higher.

## Root Cause

The threshold slider's drag handle is 32px wide, positioned at `calc(threshold% - 16px)`. At high threshold values, the right edge extends beyond the container. The parent div lacked `overflow-hidden`, so it caused horizontal overflow.

## Fix

Add `overflow-hidden` to the container div that holds the TokenMeter and HorizontalThresholdSlider.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
