### PR TITLE
🤖 fix: make edit title tooltip disappear instantly on hover leave

### DIFF
--- a/src/browser/components/WorkspaceListItem.tsx
+++ b/src/browser/components/WorkspaceListItem.tsx
@@ -190,7 +190,7 @@ const WorkspaceListItemInner: React.FC<WorkspaceListItemProps> = ({
                 data-workspace-id={workspaceId}
               />
             ) : (
-              <Tooltip>
+              <Tooltip disableHoverableContent>
                 <TooltipTrigger asChild>
                   <span
                     className={cn(


### PR DESCRIPTION
The "Double-click to edit title" tooltip on workspace items now closes immediately when the cursor leaves the trigger element, instead of staying open when hovering over the tooltip content.

**Change:** Added `disableHoverableContent` prop to the specific Tooltip component wrapping the workspace title.

---
_Generated with `mux` • Model: `mux-gateway:anthropic/claude-opus-4-5` • Thinking: `high`_
