### PR TITLE
🤖 fix: self-heal stale chat subscriptions after sleep/wake

### DIFF
--- a/src/browser/components/AIView.tsx
+++ b/src/browser/components/AIView.tsx
@@ -75,6 +75,7 @@ import { ReviewsBanner } from "./ReviewsBanner";
 import type { ReviewNoteData } from "@/common/types/review";
 import { PopoverError } from "./PopoverError";
 import { ConnectionStatusIndicator } from "./ConnectionStatusIndicator";
+import { SubscriptionStatusIndicator } from "./SubscriptionStatusIndicator";
 import { useWorkspaceContext } from "@/browser/contexts/WorkspaceContext";
 
 interface AIViewProps {
@@ -754,6 +755,7 @@ const AIViewInner: React.FC<AIViewProps> = ({
         />
         <ReviewsBanner workspaceId={workspaceId} />
         <ConnectionStatusIndicator />
+        <SubscriptionStatusIndicator workspaceId={workspaceId} />
         {isQueuedAgentTask && (
           <div className="border-border-medium bg-background-secondary text-muted mb-2 rounded-md border px-3 py-2 text-xs">
             This agent task is queued and will start automatically when a parallel slot is

--- a/src/browser/components/AppLoader.tsx
+++ b/src/browser/components/AppLoader.tsx
@@ -60,7 +60,7 @@ function AppLoaderInner() {
   // Sync stores when metadata finishes loading
   useEffect(() => {
     if (api) {
-      workspaceStoreInstance.setClient(api);
+      workspaceStoreInstance.setClient(api, apiState.connectionEpoch);
       gitStatusStore.setClient(api);
     }
 
@@ -83,6 +83,7 @@ function AppLoaderInner() {
     workspaceStoreInstance,
     gitStatusStore,
     api,
+    apiState.connectionEpoch,
   ]);
 
   // If we're in browser mode and auth is required, show the token prompt before any data loads.

--- a/src/browser/components/SubscriptionStatusIndicator.tsx
+++ b/src/browser/components/SubscriptionStatusIndicator.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { useWorkspaceState } from "@/browser/stores/WorkspaceStore";
+
+interface SubscriptionStatusIndicatorProps {
+  workspaceId: string;
+}
+
+/**
+ * Displays workspace chat subscription status when reconnecting.
+ * Shows a subtle banner when the subscription watchdog detects a stall
+ * and is restarting the subscription.
+ */
+export const SubscriptionStatusIndicator: React.FC<SubscriptionStatusIndicatorProps> = (props) => {
+  const state = useWorkspaceState(props.workspaceId);
+
+  if (state.subscriptionStatus !== "reconnecting") {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center justify-center gap-2 py-1 text-xs text-yellow-600">
+      <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-yellow-500" />
+      <span>Reconnecting chat stream…</span>
+    </div>
+  );
+};

--- a/src/browser/contexts/WorkspaceContext.test.tsx
+++ b/src/browser/contexts/WorkspaceContext.test.tsx
@@ -785,7 +785,7 @@ async function setup() {
   );
 
   // Inject client immediately to handle race conditions where effects run before store update
-  getWorkspaceStoreRaw().setClient(currentClientMock as APIClient);
+  getWorkspaceStoreRaw().setClient(currentClientMock as APIClient, 1);
 
   await waitFor(() => expect(contextRef.current).toBeTruthy());
   return () => contextRef.current!;

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -67,7 +67,7 @@ describe("WorkspaceStore", () => {
     mockOnModelUsed = mock(() => undefined);
     store = new WorkspaceStore(mockOnModelUsed);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-    store.setClient(mockClient as any);
+    store.setClient(mockClient as any, 1);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Problem

In mux **server mode** (browser UI), after idle time or sleep/wake, the chat UI can stop reflecting live stream state:
- You can hit Send and the input clears
- The message (and subsequent assistant stream) does **not** appear in the transcript
- No "connection lost / reconnecting / degraded" banner shows
- A full page refresh reloads history and reveals the conversation did happen

## Root Cause

The transcript is **not** updated optimistically on send; it updates only via the streaming subscription `workspace.onChat`. Any failure where the async iterator **stalls without ending/throwing** produces exactly this UX: the RPC send succeeds, but the UI never receives the `type:"message"` / stream events that drive the transcript.

## Solution

### 1. connectionEpoch tracking
`APIProvider` increments a `connectionEpoch` on each new connection. `WorkspaceStore` restarts all subscriptions when the epoch changes, preventing stale iterators from the old connection.

### 2. Subscription watchdog
Monitors all chat subscriptions and auto-restarts them if:
- No `caught-up` received within 15s (buffering stall)
- Active stream has no events for 30s (stream stall)

### 3. UI feedback
New `SubscriptionStatusIndicator` shows "Reconnecting chat stream…" when a subscription is being restarted, so users know recovery is in progress.

### 4. Diagnostics
Added logging for WS close events (code/reason) and ping failures to help debug future connection issues.

## Testing

- `make static-check` passes
- Manual testing: after sleep/wake, subscriptions should auto-recover without refresh

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
