### PR TITLE
🤖 perf: renderer hot paths + build optimizations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,11 +91,9 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy bundled server and frontend assets
-# Vite outputs JS/CSS/HTML directly to dist/ (assetsDir: ".")
+# Vite outputs to dist/renderer/ (assetsDir: ".")
 COPY --from=builder /app/dist/server-bundle.js ./dist/
-COPY --from=builder /app/dist/*.html ./dist/
-COPY --from=builder /app/dist/*.js ./dist/
-COPY --from=builder /app/dist/*.css ./dist/
+COPY --from=builder /app/dist/renderer ./dist/renderer
 COPY --from=builder /app/dist/static ./dist/static
 
 # Copy only native modules needed at runtime (node-pty for terminal support)

--- a/package.json
+++ b/package.json
@@ -240,7 +240,6 @@
     ],
     "asarUnpack": [
       "dist/**/*.wasm",
-      "dist/**/*.map",
       "**/node_modules/node-pty/build/**/*"
     ],
     "mac": {

--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -513,8 +513,8 @@ function createWindow() {
       });
     }
   } else {
-    // Production mode: load built files
-    const htmlPath = path.join(__dirname, "../index.html");
+    // Production mode: load built files from dist/renderer/
+    const htmlPath = path.join(__dirname, "../renderer/index.html");
     console.log(`[${timestamp()}] [window] Loading from file: ${htmlPath}`);
     void mainWindow.loadFile(htmlPath);
   }

--- a/src/desktop/terminalWindowManager.ts
+++ b/src/desktop/terminalWindowManager.ts
@@ -82,8 +82,8 @@ export class TerminalWindowManager {
       );
       terminalWindow.webContents.openDevTools();
     } else {
-      // Production mode (or E2E dist mode) - load from built files
-      await terminalWindow.loadFile(path.join(__dirname, "../terminal.html"), {
+      // Production mode (or E2E dist mode) - load from built files in dist/renderer/
+      await terminalWindow.loadFile(path.join(__dirname, "../renderer/terminal.html"), {
         query: { workspaceId },
       });
     }

--- a/src/node/orpc/server.ts
+++ b/src/node/orpc/server.ts
@@ -97,8 +97,8 @@ export async function createOrpcServer({
   authToken,
   context,
   serveStatic = false,
-  // From dist/node/orpc/, go up 2 levels to reach dist/ where index.html lives
-  staticDir = path.join(__dirname, "../.."),
+  // From dist/node/orpc/, go up 2 levels to reach dist/renderer/ where index.html lives
+  staticDir = path.join(__dirname, "../../renderer"),
   onOrpcError = (error) => {
     // Auth failures are expected in browser mode while the user enters the token.
     // Avoid spamming error logs with stack traces on every unauthenticated request.

--- a/src/node/services/serverService.ts
+++ b/src/node/services/serverService.ts
@@ -214,7 +214,8 @@ export class ServerService {
 
     this.apiAuthToken = options.authToken;
 
-    const staticDir = path.join(__dirname, "../..");
+    // Renderer output is in dist/renderer/ (2 levels up from dist/node/services/, then into renderer/)
+    const staticDir = path.join(__dirname, "../../renderer");
     let serveStatic = options.serveStatic ?? false;
     if (serveStatic) {
       const indexPath = path.join(staticDir, "index.html");

--- a/tests/e2e/electronTest.ts
+++ b/tests/e2e/electronTest.ts
@@ -26,7 +26,7 @@ const BASE_DEV_SERVER_PORT = Number(process.env.MUX_E2E_DEVSERVER_PORT_BASE ?? "
 const shouldLoadDist = process.env.MUX_E2E_LOAD_DIST === "1";
 
 const REQUIRED_DIST_FILES = [
-  path.join(appRoot, "dist", "index.html"),
+  path.join(appRoot, "dist", "renderer", "index.html"),
   path.join(appRoot, "dist", "cli", "index.js"),
   path.join(appRoot, "dist", "desktop", "main.js"),
   path.join(appRoot, "dist", "preload.js"),


### PR DESCRIPTION
## Summary

Implements performance optimizations from the Electron guide-based analysis. Focus areas:

### Build/Packaging (C1-C3)
- **Sourcemap gating**: Production builds no longer include renderer sourcemaps (opt-in via `MUX_RENDERER_SOURCEMAPS=1`)
- **Clean dist structure**: Renderer output isolated to `dist/renderer/` with `emptyOutDir: true` to prevent stale asset accumulation
- **Chunk splitting**: Mermaid (~2.3MB) and ghostty-web (~634KB) split into on-demand chunks loaded only when needed

### Renderer Hot Paths (B1-B2, B5)
- **O(n) bash grouping**: Precompute bash output group boundaries once per message list instead of O(n²) per-render computation
- **Lazy Mermaid**: Defer rendering until visible via IntersectionObserver + cache rendered SVGs
- **Dynamic imports**: Mermaid and ghostty-web loaded on-demand to reduce initial bundle parse/execute time
- **Adaptive polling**: `useResumeManager` now uses 1s interval when workspaces need attention, 5s when idle

## Testing

- `make typecheck` ✓
- Existing unit tests pass (messageUtils, Mermaid)
- Build produces correct structure with chunked deps

## Not Included (future follow-ups)
- B3: Review panel virtualization (needs `@tanstack/react-virtual` + more complex changes)
- B4: Persisted-state fan-out optimization (would require lifting state to parent)

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
