### PR TITLE
🤖 fix: prevent Escape from interrupting stream when closing dialogs

### DIFF
--- a/src/browser/components/tools/shared/ToolResultImages.tsx
+++ b/src/browser/components/tools/shared/ToolResultImages.tsx
@@ -118,12 +118,6 @@ export const ToolResultImages: React.FC<ToolResultImagesProps> = ({ result }) =>
       {/* Lightbox modal for full-size image viewing */}
       <Dialog open={selectedImage !== null} onOpenChange={() => setSelectedImage(null)}>
         <DialogContent
-          onKeyDown={(e) => {
-            // Prevent Escape from propagating to global handlers (stream interrupt)
-            if (e.key === "Escape") {
-              e.stopPropagation();
-            }
-          }}
           maxWidth="90vw"
           maxHeight="90vh"
           className="flex items-center justify-center bg-black/90 p-2"

--- a/src/browser/components/ui/dialog.tsx
+++ b/src/browser/components/ui/dialog.tsx
@@ -44,30 +44,50 @@ const DialogContent = React.forwardRef<
     /** Maximum height of the dialog */
     maxHeight?: string;
   }
->(({ className, children, showCloseButton = true, maxWidth, maxHeight, style, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        "bg-dark border-border fixed top-[50%] left-[50%] z-[1500] grid w-[90%] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
-        !maxWidth && "max-w-lg",
-        maxHeight && "overflow-y-auto",
-        className
-      )}
-      style={{ ...(maxWidth && { maxWidth }), ...(maxHeight && { maxHeight }), ...style }}
-      {...props}
-    >
-      {children}
-      {showCloseButton && (
-        <DialogPrimitive.Close className="text-muted hover:text-foreground absolute top-4 right-4 rounded-sm transition-colors focus:outline-none disabled:pointer-events-none">
-          <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
-      )}
-    </DialogPrimitive.Content>
-  </DialogPortal>
-));
+>(
+  (
+    {
+      className,
+      children,
+      showCloseButton = true,
+      maxWidth,
+      maxHeight,
+      style,
+      onEscapeKeyDown,
+      ...props
+    },
+    ref
+  ) => (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        onEscapeKeyDown={(e) => {
+          // Prevent Escape from propagating to global handlers (e.g., stream interrupt).
+          // Radix uses capture phase for Escape, so we must use onEscapeKeyDown (not onKeyDown).
+          e.stopPropagation();
+          onEscapeKeyDown?.(e);
+        }}
+        className={cn(
+          "bg-dark border-border fixed top-[50%] left-[50%] z-[1500] grid w-[90%] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
+          !maxWidth && "max-w-lg",
+          maxHeight && "overflow-y-auto",
+          className
+        )}
+        style={{ ...(maxWidth && { maxWidth }), ...(maxHeight && { maxHeight }), ...style }}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close className="text-muted hover:text-foreground absolute top-4 right-4 rounded-sm transition-colors focus:outline-none disabled:pointer-events-none">
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+);
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (


### PR DESCRIPTION
Move Escape key `stopPropagation` into `DialogContent` component so all dialogs automatically prevent bubbling to global handlers (like stream interrupt). This removes the need for each dialog to implement this pattern individually.

**Changes:**
- `dialog.tsx`: Add `onKeyDown` handler that stops Escape propagation, while still calling any consumer-provided `onKeyDown`
- `ToolResultImages.tsx`: Remove redundant handler now that it's centralized

**Testing:**
1. Open Settings modal while a stream is active
2. Press Escape to close Settings
3. Stream should continue (no longer interrupted)

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
