### PR TITLE
🤖 fix: re-evaluate task queue when maxParallelAgentTasks changes

### DIFF
--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -401,6 +401,9 @@ export const router = (authToken?: string) => {
 
             return result;
           });
+
+          // Re-evaluate task queue in case more slots opened up
+          await context.taskService.maybeStartQueuedTasks();
         }),
     },
     agents: {

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -1243,7 +1243,7 @@ export class TaskService {
     return depth;
   }
 
-  private async maybeStartQueuedTasks(): Promise<void> {
+  async maybeStartQueuedTasks(): Promise<void> {
     await using _lock = await this.mutex.acquire();
 
     const configAtStart = this.config.loadConfigOrDefault();


### PR DESCRIPTION
## Problem

When a user has queued agent tasks and increases `maxParallelAgentTasks` in Settings → Tasks, the queued tasks don't immediately start. They only start on the next "natural trigger" (task completion, termination, etc.).

**Root cause:** The `saveConfig` handler in the oRPC router persists the config to disk, but doesn't notify `TaskService` to re-evaluate the queue.

## Solution

Call `taskService.maybeStartQueuedTasks()` after saving config. This method is:
- Already designed to be called opportunistically (safe to call even if nothing changed)
- Uses a mutex internally for concurrency safety
- Reads fresh config on each invocation

The fix is minimal: make `maybeStartQueuedTasks()` public and call it after config save.

## Testing

1. Start multiple tasks that exceed current `maxParallelAgentTasks` (some will queue)
2. Increase `maxParallelAgentTasks` in Settings → Tasks  
3. Queued tasks should immediately start (within ~400ms debounce from UI)

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
