### PR TITLE
🤖 fix: chat messages overflow horizontally

### DIFF
--- a/src/browser/components/AIView.tsx
+++ b/src/browser/components/AIView.tsx
@@ -607,7 +607,7 @@ const AIViewInner: React.FC<AIViewProps> = ({
             tabIndex={0}
             data-testid="message-window"
             data-loaded={!loading}
-            className="h-full overflow-y-auto p-[15px] leading-[1.5] break-words whitespace-pre-wrap"
+            className="h-full overflow-x-hidden overflow-y-auto p-[15px] leading-[1.5] break-words whitespace-pre-wrap"
           >
             <div
               ref={innerRef}

--- a/src/browser/components/Messages/MessageWindow.tsx
+++ b/src/browser/components/Messages/MessageWindow.tsx
@@ -69,9 +69,9 @@ export const MessageWindow: React.FC<MessageWindowProps> = ({
   return (
     <div
       className={cn(
-        "mt-4 mb-1 flex w-full flex-col relative isolate w-fit",
-        variant === "user" && "ml-auto",
-        variant === "assistant" && "text-foreground",
+        "mt-4 mb-1 flex flex-col relative isolate",
+        variant === "user" && "ml-auto w-fit",
+        variant === "assistant" && "w-full text-foreground",
         isLastPartOfMessage && "mb-4"
       )}
       data-message-block

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -1458,6 +1458,8 @@ code {
   border-radius: 4px;
   overflow-x: auto;
   margin: 1em 0;
+  width: fit-content;
+  max-width: 100%;
 }
 
 .markdown-content pre code {
@@ -1500,7 +1502,8 @@ code {
 
 .markdown-content table {
   border-collapse: collapse;
-  width: 100%;
+  width: fit-content;
+  max-width: 100%;
   margin: 1em 0;
 }
 
@@ -1613,6 +1616,9 @@ span.search-highlight {
 .code-block-wrapper {
   position: relative;
   margin: 0.75em 0;
+  width: fit-content;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 /* Code block with line numbers - each line is a grid row */
@@ -1621,7 +1627,7 @@ span.search-highlight {
   grid-template-columns: auto 1fr;
   background: var(--color-code-bg);
   border-radius: 4px;
-  padding: 6px 0;
+  padding: 6px 40px 6px 0; /* Right padding for copy button */
   font-family: var(--font-monospace);
   font-size: 12px;
   line-height: 1.6;


### PR DESCRIPTION
Fix for horizontal overflow in chat messages. Code blocks and long lines were causing a horizontal scrollbar on the entire chat area.

## Root cause

`MessageWindow.tsx` had conflicting Tailwind classes:
```tsx
"mt-4 mb-1 flex w-full flex-col relative isolate w-fit"
```

The `w-fit` allowed message containers to grow beyond parent bounds based on content width.

## Fix

- Apply `w-fit` only to user messages (needed for right-alignment with `ml-auto`)
- Apply `w-full` only to assistant messages (constrains to parent width)
- Add `overflow-x-hidden` to the scroll container as defensive measure
- Add `width: fit-content; max-width: 100%` to code blocks, tables, and pre elements so they shrink to content but can't overflow

## Testing

Added a storybook story (`LongLinesOverflow`) with long code lines, URLs, and inline code that asserts no horizontal overflow on the message container.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
