### PR TITLE
🤖 fix: improve PTC type validator for ES2023 and empty object patterns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,10 +225,10 @@ build-static: ## Copy static assets to dist
 	@mkdir -p dist
 	@cp static/splash.html dist/splash.html
 	@cp -r public/* dist/
-	# Copy TypeScript lib files for PTC runtime type validation (es5 through es2020).
-	# electron-builder ignores .d.ts files by default and this cannot be overridden:
-	# https://github.com/electron-userland/electron-builder/issues/5064
-	# Workaround: rename to .d.ts.txt extension to bypass the filter.
+	@# Copy TypeScript lib files for PTC runtime type validation (es5 through es2023).
+	@# electron-builder ignores .d.ts files by default and this cannot be overridden:
+	@# https://github.com/electron-userland/electron-builder/issues/5064
+	@# Workaround: rename to .d.ts.txt extension to bypass the filter.
 	@mkdir -p dist/typescript-lib
 	@for f in node_modules/typescript/lib/lib.es5.d.ts \
 	          node_modules/typescript/lib/lib.es2015*.d.ts \
@@ -236,7 +236,10 @@ build-static: ## Copy static assets to dist
 	          node_modules/typescript/lib/lib.es2017*.d.ts \
 	          node_modules/typescript/lib/lib.es2018*.d.ts \
 	          node_modules/typescript/lib/lib.es2019*.d.ts \
-	          node_modules/typescript/lib/lib.es2020*.d.ts; do \
+	          node_modules/typescript/lib/lib.es2020*.d.ts \
+	          node_modules/typescript/lib/lib.es2021*.d.ts \
+	          node_modules/typescript/lib/lib.es2022*.d.ts \
+	          node_modules/typescript/lib/lib.es2023*.d.ts; do \
 		cp "$$f" "dist/typescript-lib/$$(basename $$f).txt"; \
 	done
 

--- a/src/node/services/tools/code_execution.ts
+++ b/src/node/services/tools/code_execution.ts
@@ -62,9 +62,7 @@ export async function createCodeExecutionTool(
   const muxTypes = await getCachedMuxTypes(bridgeableTools);
 
   return tool({
-    description: `Execute JavaScript code in a sandboxed environment with access to Mux tools.
-
-Important: Batch multiple tool calls in one invocation to minimize round trips.
+    description: `Execute sandboxed JavaScript to batch tools and transform outputs.
 
 **Available tools (TypeScript definitions):**
 \`\`\`typescript


### PR DESCRIPTION
## Summary

Fixes two issues in the programmatic tool calling (PTC) type validator:

### 1. Empty Object Pattern (TS2339 filter)

Claude frequently uses this pattern to collate parallel tool calls:
```javascript
const results = {};
results.file1 = mux.file_read({ filePath: "a.txt" });
results.file2 = mux.file_read({ filePath: "b.txt" });
```

This was causing false TS2339 errors. Added a filter that allows properties on empty object literals (`on type '{}'`) while still catching:
- `mux.*` typos (critical)
- Property typos on typed objects
- Missing/wrong arguments

### 2. ES2021+ Features (lib resolution fix)

Root cause: custom compiler host was overriding lib file resolution in both development and production, breaking TypeScript's internal `/// <reference lib="..." />` directive resolution.

Fix: Only override lib loading in production (where files are renamed to `.d.ts.txt`). In development, let TypeScript use its default resolution.

## Changes

- **typeValidator.ts**: Added TS2339 filter, upgraded lib to ES2023, production-only lib override
- **Makefile**: Bundle ES2021, ES2022, ES2023 lib files
- **typeValidator.test.ts**: 3 new tests for the fixes

## Testing

```bash
bun test src/node/services/ptc/typeValidator.test.ts
```

All 16 tests pass, covering:
- Core type checking (existing behavior)
- Empty object pattern (new)
- ES2021+ features: `replaceAll`, `at`, `Object.hasOwn` (new)
- Mux tool typos still caught (regression test)

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
