### PR TITLE
🤖 fix: sort completed reviews recent-first

### DIFF
--- a/src/browser/components/ReviewsBanner.tsx
+++ b/src/browser/components/ReviewsBanner.tsx
@@ -335,7 +335,10 @@ const ReviewsBannerInner: React.FC<ReviewsBannerInnerProps> = ({ workspaceId }) 
   // "attached" reviews are shown in ChatInput, so we only show "pending" and "checked" here
   const { pendingList, completedList } = useMemo(() => {
     const pending = reviewsHook.reviews.filter((r) => r.status === "pending");
-    const completed = reviewsHook.reviews.filter((r) => r.status === "checked");
+    // Sort completed reviews recent-first (by when they were checked, falling back to creation time)
+    const completed = reviewsHook.reviews
+      .filter((r) => r.status === "checked")
+      .sort((a, b) => (b.statusChangedAt ?? b.createdAt) - (a.statusChangedAt ?? a.createdAt));
     return { pendingList: pending, completedList: completed };
   }, [reviewsHook.reviews]);
 


### PR DESCRIPTION
Sort completed reviews by most recent first instead of oldest first.

Uses `statusChangedAt` (when the review was marked as checked/completed), falling back to `createdAt` for reviews without that timestamp.

More intuitive for users since:
- Most recently completed reviews appear at the top
- Users typically want to see their latest completed work first
- Older completed reviews are still accessible below

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_