### PR TITLE
🤖 fix: prevent double compaction when /compact is already queued

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "mux",

--- a/src/browser/components/AIView.tsx
+++ b/src/browser/components/AIView.tsx
@@ -781,6 +781,7 @@ const AIViewInner: React.FC<AIViewProps> = ({
           canInterrupt={canInterrupt}
           onReady={handleChatInputReady}
           autoCompactionCheck={autoCompactionResult}
+          hasQueuedCompaction={workspaceState.queuedMessage?.hasCompactionRequest}
           attachedReviews={reviews.attachedReviews}
           onDetachReview={reviews.detachReview}
           onDetachAllReviews={reviews.detachAllAttached}

--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -163,6 +163,8 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const editingMessage = variant === "workspace" ? props.editingMessage : undefined;
   const isCompacting = variant === "workspace" ? (props.isCompacting ?? false) : false;
   const canInterrupt = variant === "workspace" ? (props.canInterrupt ?? false) : false;
+  const hasQueuedCompaction =
+    variant === "workspace" ? (props.hasQueuedCompaction ?? false) : false;
   // runtimeType for telemetry - defaults to "worktree" if not provided
   const runtimeType = variant === "workspace" ? (props.runtimeType ?? "worktree") : "worktree";
 
@@ -1455,7 +1457,12 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       // Result is computed in parent (AIView) and passed down to avoid duplicate calculation
       if (
         variant === "workspace" &&
-        shouldTriggerAutoCompaction(props.autoCompactionCheck, isCompacting, !!editingMessage)
+        shouldTriggerAutoCompaction(
+          props.autoCompactionCheck,
+          isCompacting,
+          !!editingMessage,
+          hasQueuedCompaction
+        )
       ) {
         // Prepare image parts for the continue message
         const imageParts = imageAttachments.map((img) => ({

--- a/src/browser/components/ChatInput/types.ts
+++ b/src/browser/components/ChatInput/types.ts
@@ -32,6 +32,8 @@ export interface ChatInputWorkspaceVariant {
   disabledReason?: string;
   onReady?: (api: ChatInputAPI) => void;
   autoCompactionCheck?: AutoCompactionCheckResult; // Computed in parent (AIView) to avoid duplicate calculation
+  /** True if there's already a compaction request queued (prevents double-compaction) */
+  hasQueuedCompaction?: boolean;
   /** Reviews currently attached to chat (from useReviews hook) */
   attachedReviews?: Review[];
   /** Detach a review from chat input (sets status to pending) */

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -515,6 +515,7 @@ export class WorkspaceStore {
             content: data.displayText,
             imageParts: data.imageParts,
             reviews: data.reviews,
+            hasCompactionRequest: data.hasCompactionRequest,
           }
         : null;
 

--- a/src/browser/utils/compaction/shouldTriggerAutoCompaction.test.ts
+++ b/src/browser/utils/compaction/shouldTriggerAutoCompaction.test.ts
@@ -56,4 +56,28 @@ describe("shouldTriggerAutoCompaction", () => {
     };
     expect(shouldTriggerAutoCompaction(check, false, false)).toBe(true);
   });
+
+  test("returns false when compaction is already queued", () => {
+    const check: AutoCompactionCheckResult = {
+      usagePercentage: 85,
+      thresholdPercentage: 60,
+      shouldShowWarning: true,
+      shouldForceCompact: false,
+    };
+    // Even when threshold is exceeded, don't trigger if compaction is already queued
+    expect(shouldTriggerAutoCompaction(check, false, false, true)).toBe(false);
+  });
+
+  test("returns true when no compaction is queued", () => {
+    const check: AutoCompactionCheckResult = {
+      usagePercentage: 85,
+      thresholdPercentage: 60,
+      shouldShowWarning: true,
+      shouldForceCompact: false,
+    };
+    // Should trigger when hasQueuedCompaction is false
+    expect(shouldTriggerAutoCompaction(check, false, false, false)).toBe(true);
+    // Should also trigger when hasQueuedCompaction is undefined (backwards compat)
+    expect(shouldTriggerAutoCompaction(check, false, false, undefined)).toBe(true);
+  });
 });

--- a/src/browser/utils/compaction/shouldTriggerAutoCompaction.ts
+++ b/src/browser/utils/compaction/shouldTriggerAutoCompaction.ts
@@ -7,11 +7,14 @@ import type { AutoCompactionCheckResult } from "./autoCompactionCheck";
 export function shouldTriggerAutoCompaction(
   autoCompactionCheck: AutoCompactionCheckResult | undefined,
   isCompacting: boolean,
-  isEditing: boolean
+  isEditing: boolean,
+  hasQueuedCompaction?: boolean
 ): boolean {
   if (!autoCompactionCheck) return false;
   if (isCompacting) return false;
   if (isEditing) return false;
+  // Don't trigger auto-compaction if there's already a /compact queued
+  if (hasQueuedCompaction) return false;
 
   return autoCompactionCheck.usagePercentage >= autoCompactionCheck.thresholdPercentage;
 }

--- a/src/common/orpc/schemas/stream.ts
+++ b/src/common/orpc/schemas/stream.ts
@@ -301,6 +301,8 @@ export const QueuedMessageChangedEventSchema = z.object({
   displayText: z.string(),
   imageParts: z.array(ImagePartSchema).optional(),
   reviews: z.array(ReviewNoteDataSchema).optional(),
+  /** True when the queued message is a compaction request (/compact) */
+  hasCompactionRequest: z.boolean().optional(),
 });
 
 export const RestoreToInputEventSchema = z.object({

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -301,6 +301,8 @@ export interface QueuedMessage {
   imageParts?: ImagePart[];
   /** Structured review data for rich UI display (from muxMetadata) */
   reviews?: ReviewNoteDataForDisplay[];
+  /** True when the queued message is a compaction request (/compact) */
+  hasCompactionRequest?: boolean;
 }
 
 // Helper to create a simple text message

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -872,6 +872,7 @@ export class AgentSession {
       displayText: this.messageQueue.getDisplayText(),
       imageParts: this.messageQueue.getImageParts(),
       reviews: this.messageQueue.getReviews(),
+      hasCompactionRequest: this.messageQueue.hasCompactionRequest(),
     });
   }
 


### PR DESCRIPTION
## Problem

When a `/compact` command was queued while an agent was running, sending reviews with an empty message would trigger another auto-compaction instead of sending the reviews normally.

## Root Cause

`shouldTriggerAutoCompaction()` checked `isCompacting`, which only detects **active** compaction streams - not **queued** compaction requests waiting to execute.

## Solution

Add `hasCompactionRequest` flag that propagates from the backend `MessageQueue` to the frontend:

1. Backend emits `hasCompactionRequest` in `queued-message-changed` event
2. Frontend passes this to `shouldTriggerAutoCompaction()`
3. Function returns `false` when a compaction is already queued

## Testing

- Added unit tests for the new parameter in `shouldTriggerAutoCompaction.test.ts`
- All existing tests pass
- `make static-check` passes

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
