### PR TITLE
🤖 fix: queue attached reviews when sending /compact command

### DIFF
--- a/src/browser/components/AIView.tsx
+++ b/src/browser/components/AIView.tsx
@@ -64,7 +64,7 @@ import { ConcurrentLocalWarning } from "./ConcurrentLocalWarning";
 import { BackgroundProcessesBanner } from "./BackgroundProcessesBanner";
 import { useBackgroundBashHandlers } from "@/browser/hooks/useBackgroundBashHandlers";
 import { checkAutoCompaction } from "@/browser/utils/compaction/autoCompactionCheck";
-import { executeCompaction } from "@/browser/utils/chatCommands";
+import { executeCompaction, buildContinueMessage } from "@/browser/utils/chatCommands";
 import { useProviderOptions } from "@/browser/hooks/useProviderOptions";
 import { useAutoCompactionSettings } from "../hooks/useAutoCompactionSettings";
 import { useSendMessageOptions } from "@/browser/hooks/useSendMessageOptions";
@@ -226,7 +226,11 @@ const AIViewInner: React.FC<AIViewProps> = ({
       api,
       workspaceId,
       sendMessageOptions: pendingSendOptions,
-      continueMessage: { text: "Continue" },
+      continueMessage: buildContinueMessage({
+        text: "Continue",
+        model: pendingSendOptions.model,
+        mode: pendingSendOptions.mode === "plan" ? "plan" : "exec",
+      }),
     });
   }, [api, workspaceId, pendingSendOptions]);
 

--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -48,6 +48,7 @@ import {
   forkWorkspace,
   prepareCompactionMessage,
   executeCompaction,
+  buildContinueMessage,
   type CommandHandlerContext,
 } from "@/browser/utils/chatCommands";
 import { shouldTriggerAutoCompaction } from "@/browser/utils/compaction/shouldTriggerAutoCompaction";
@@ -1479,8 +1480,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           mediaType: img.mediaType,
         }));
 
-        // Prepare reviews data for the continue message (orthogonal to compaction)
-        // Review.data is already ReviewNoteData shape
+        // Prepare reviews data for the continue message
         const reviewsData =
           attachedReviews.length > 0 ? attachedReviews.map((r) => r.data) : undefined;
 
@@ -1496,12 +1496,13 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           const result = await executeCompaction({
             api,
             workspaceId: props.workspaceId,
-            continueMessage: {
+            continueMessage: buildContinueMessage({
               text: messageText,
               imageParts,
-              model: sendMessageOptions.model,
               reviews: reviewsData,
-            },
+              model: sendMessageOptions.model,
+              mode: sendMessageOptions.mode === "plan" ? "plan" : "exec",
+            }),
             sendMessageOptions,
           });
 


### PR DESCRIPTION
## Problem

When sending `/compact` with reviews attached, the reviews were not being included in the `continueMessage` that gets queued for after compaction completes.

## Solution

- Add `reviews` field to `CommandHandlerContext` interface
- Update `handleCompactCommand` to pass reviews to `executeCompaction`
- Update ChatInput to extract reviews and pass them to the context
- Mark reviews as checked after successful `/compact` with reviews

## Testing (TDD)

Added tests for:
- `prepareCompactionMessage` with reviews (verified existing functionality works)
- `handleCompactCommand` with reviews (tests drove the fix)

All tests pass, `make static-check` passes.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
