### PR TITLE
🤖 fix: add src/version.ts dependency to storybook target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -403,7 +403,7 @@ check-docs-links: ## Check documentation for broken links
 	@cd docs && npx mintlify broken-links
 
 ## Storybook
-storybook: node_modules/.installed ## Start Storybook development server
+storybook: node_modules/.installed src/version.ts ## Start Storybook development server
 	$(check_node_version)
 	@bun x storybook dev -p 6006 $(STORYBOOK_OPEN_FLAG)
 


### PR DESCRIPTION
The `storybook` target runs Vite which imports `@/version`, but wasn't generating `src/version.ts` first. This caused "Failed to resolve import" errors when running `make storybook` in a fresh worktree.

`storybook-build` already had this dependency; `storybook` was missing it.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
