### PR TITLE
🤖 fix: make file filter indicator more prominent in Code Review

### DIFF
--- a/src/browser/components/RightSidebar/CodeReview/FileTree.tsx
+++ b/src/browser/components/RightSidebar/CodeReview/FileTree.tsx
@@ -254,16 +254,21 @@ export const FileTree: React.FC<FileTreeExternalProps> = ({
     { listener: true }
   );
 
+  // Extract display name for filter indicator
+  const filterDisplayName = selectedPath ? (selectedPath.split("/").pop() ?? selectedPath) : null;
+
   return (
     <>
       <div className="border-border-light text-muted font-primary flex items-center gap-2 border-b px-2 py-1 text-[11px]">
         <span>Files</span>
         {selectedPath && (
           <button
-            className="text-dim font-primary hover:text-muted ml-auto cursor-pointer border-none bg-transparent p-0 text-[10px] transition-colors duration-150"
+            className="bg-code-keyword-overlay text-foreground hover:bg-code-keyword-overlay/80 ml-auto flex cursor-pointer items-center gap-1 rounded px-1.5 py-0.5 text-[10px] transition-colors"
             onClick={() => onSelectFile(null)}
+            title={`Filtering: ${selectedPath}\nClick to clear`}
           >
-            ✕
+            <span className="max-w-[120px] truncate">{filterDisplayName}</span>
+            <span className="text-muted">✕</span>
           </button>
         )}
       </div>


### PR DESCRIPTION
## Problem

The file filter in the Code Review tab was not obvious when active - only a small "✕" button appeared in the FileTree header, making it easy to miss and hard to clear.

## Solution

**Improved file filter indicator:**
- Replace minimal "✕" button with a pill-style button showing the filtered filename
- Use `bg-code-keyword-overlay` background for visual distinction (matches selected items)
- Truncate long filenames (max 120px) with full path in tooltip
- Tooltip shows full path and "Click to clear" instruction

**Added Storybook coverage:**
- New `ReviewTabWithFileFilter` story demonstrates the active filter state
- Play function verifies the filter indicator is visible

### Before vs After

**Before:** Only a subtle "✕" appeared:
```
Files                    ✕
```

**After:** Prominent button with filename:
```
Files            [Button.tsx ✕]
```

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
