### PR TITLE
🤖 feat: add agent cycling keybind and improve agent picker keybinds

### DIFF
--- a/src/browser/components/AgentModePicker.tsx
+++ b/src/browser/components/AgentModePicker.tsx
@@ -154,6 +154,8 @@ const AgentHelpTooltip: React.FC = () => (
       <br />
       Open picker: {formatKeybind(KEYBINDS.TOGGLE_MODE)}
       <br />
+      Cycle agents: {formatKeybind(KEYBINDS.CYCLE_AGENT)}
+      <br />
       Quick select: {formatNumberedKeybind(0).replace("1", "1-9")} (when open)
       <br />
       <br />

--- a/src/browser/components/AgentSelector.tsx
+++ b/src/browser/components/AgentSelector.tsx
@@ -30,7 +30,9 @@ const AgentHelpTooltip: React.FC = () => (
       Selects an agent definition (system prompt + tool policy).
       <br />
       <br />
-      Cycle agents with: {formatKeybind(KEYBINDS.TOGGLE_MODE)}
+      Open picker: {formatKeybind(KEYBINDS.TOGGLE_MODE)}
+      <br />
+      Cycle agents: {formatKeybind(KEYBINDS.CYCLE_AGENT)}
     </TooltipContent>
   </Tooltip>
 );

--- a/src/browser/components/Settings/sections/KeybindsSection.tsx
+++ b/src/browser/components/Settings/sections/KeybindsSection.tsx
@@ -5,7 +5,8 @@ import { KEYBINDS, formatKeybind } from "@/browser/utils/ui/keybinds";
  * Derived from the comments in keybinds.ts.
  */
 const KEYBIND_LABELS: Record<keyof typeof KEYBINDS, string> = {
-  TOGGLE_MODE: "Cycle agent (Exec/Plan/Other)",
+  TOGGLE_MODE: "Open agent picker",
+  CYCLE_AGENT: "Cycle agent",
   SEND_MESSAGE: "Send message",
   NEW_LINE: "Insert newline",
   CANCEL: "Cancel / Close modal",
@@ -46,6 +47,7 @@ const KEYBIND_GROUPS: Array<{ label: string; keys: Array<keyof typeof KEYBINDS> 
     label: "General",
     keys: [
       "TOGGLE_MODE",
+      "CYCLE_AGENT",
       "OPEN_COMMAND_PALETTE",
       "OPEN_SETTINGS",
       "TOGGLE_SIDEBAR",

--- a/src/browser/components/tools/ProposePlanToolCall.tsx
+++ b/src/browser/components/tools/ProposePlanToolCall.tsx
@@ -364,9 +364,9 @@ export const ProposePlanToolCall: React.FC<ProposePlanToolCallProps> = (props) =
       {/* Completion guidance: only for completed tool calls without errors, not ephemeral previews */}
       {!isEphemeralPreview && status === "completed" && !errorMessage && (
         <div className="plan-divider text-muted mt-3 border-t pt-3 text-[11px] leading-normal italic">
-          Respond with revisions or switch to the Exec agent (cycle with
-          <span className="font-primary not-italic">{formatKeybind(KEYBINDS.TOGGLE_MODE)}</span>)
-          and ask to implement.
+          Respond with revisions or switch to the Exec agent (
+          <span className="font-primary not-italic">{formatKeybind(KEYBINDS.CYCLE_AGENT)}</span> to
+          cycle) and ask to implement.
         </div>
       )}
     </div>

--- a/src/browser/utils/commands/sources.ts
+++ b/src/browser/utils/commands/sources.ts
@@ -451,11 +451,20 @@ export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandActi
     const list: CommandAction[] = [
       {
         id: CommandIds.modeToggle(),
-        title: "Cycle Agent (Exec/Plan/Other)",
+        title: "Open Agent Picker",
         section: section.mode,
         shortcutHint: formatKeybind(KEYBINDS.TOGGLE_MODE),
         run: () => {
-          const ev = new KeyboardEvent("keydown", { key: "M", ctrlKey: true, shiftKey: true });
+          window.dispatchEvent(createCustomEvent(CUSTOM_EVENTS.OPEN_AGENT_PICKER));
+        },
+      },
+      {
+        id: "cycle-agent",
+        title: "Cycle Agent",
+        section: section.mode,
+        shortcutHint: formatKeybind(KEYBINDS.CYCLE_AGENT),
+        run: () => {
+          const ev = new KeyboardEvent("keydown", { key: ".", ctrlKey: true });
           window.dispatchEvent(ev);
         },
       },

--- a/src/browser/utils/ui/keybinds.ts
+++ b/src/browser/utils/ui/keybinds.ts
@@ -190,8 +190,11 @@ export function formatKeybind(keybind: Keybind): string {
  * We also like vim keybinds.
  */
 export const KEYBINDS = {
-  /** Cycle between Exec / Plan / Other agents */
-  TOGGLE_MODE: { key: "M", ctrl: true, shift: true },
+  /** Open agent picker (focuses search) */
+  TOGGLE_MODE: { key: "A", ctrl: true, shift: true },
+
+  /** Cycle to next agent without opening picker */
+  CYCLE_AGENT: { key: ".", ctrl: true },
 
   /** Send message / Submit form */
   SEND_MESSAGE: { key: "Enter" },


### PR DESCRIPTION
## Summary

Adds a new keybind for cycling agents and improves the agent picker keybinds to be more idiomatic.

### New keybinds

| Action | Keybind |
|--------|---------|
| Open agent picker | `Ctrl+Shift+A` / `⌘⇧A` |
| Cycle agent | `Ctrl+.` / `⌘.` |

This mirrors the model keybind pattern (`Ctrl+/` cycles models).

### Changes

- Add `CYCLE_AGENT` keybind (`Ctrl+.` / `⌘.`) to cycle through agents without opening picker
- Change `TOGGLE_MODE` from `Ctrl+Shift+M` to `Ctrl+Shift+A` (A for Agent)
- Implement `cycleToNextAgent` in ModeContext that cycles through UI-selectable agents
- Update command palette with separate "Open Agent Picker" and "Cycle Agent" commands
- Update tooltips in AgentModePicker and AgentSelector to show both keybinds
- Update KeybindsSection to include new keybind

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
