### PR TITLE
🤖 fix: restore SSH label in new workspace page

### DIFF
--- a/src/browser/components/ChatInput/CreationControls.tsx
+++ b/src/browser/components/ChatInput/CreationControls.tsx
@@ -71,7 +71,7 @@ const RUNTIME_OPTIONS: Array<{
   },
   {
     value: RUNTIME_MODE.SSH,
-    label: "Remote",
+    label: "SSH",
     description: "Clone on SSH host",
     docsPath: "/runtime/ssh",
     Icon: SSHIcon,


### PR DESCRIPTION
## Summary

Restores the "SSH" label in the new workspace runtime selector, which was inadvertently changed to "Remote" in 59be949a (#1094).

The rest of the UI consistently uses "SSH" for this runtime type (e.g., RuntimeIconSelector, RuntimeBadge).

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
