### PR TITLE
🤖 fix: preserve reviews in continueMessage for resume and edit paths

### DIFF
--- a/src/browser/hooks/useResumeManager.ts
+++ b/src/browser/hooks/useResumeManager.ts
@@ -9,6 +9,7 @@ import {
   isNonRetryableSendError,
 } from "@/browser/utils/messages/retryEligibility";
 import { applyCompactionOverrides } from "@/browser/utils/messages/compactionOptions";
+import { rebuildContinueMessage } from "@/common/types/message";
 import type { SendMessageError } from "@/common/types/errors";
 import {
   createFailedRetryState,
@@ -173,15 +174,15 @@ export function useResumeManager() {
         if (lastUserMsg?.compactionRequest) {
           // Apply compaction overrides using shared function (same as ChatInput)
           // This ensures custom model/tokens are preserved across resume
+          // Use rebuildContinueMessage to properly reconstruct from persisted data
+          // with defaults for any fields missing from older code versions
           options = applyCompactionOverrides(options, {
             model: lastUserMsg.compactionRequest.parsed.model,
             maxOutputTokens: lastUserMsg.compactionRequest.parsed.maxOutputTokens,
-            continueMessage: {
-              text: lastUserMsg.compactionRequest.parsed.continueMessage?.text ?? "",
-              imageParts: lastUserMsg.compactionRequest.parsed.continueMessage?.imageParts,
-              model: lastUserMsg.compactionRequest.parsed.continueMessage?.model ?? options.model,
-              mode: lastUserMsg.compactionRequest.parsed.continueMessage?.mode ?? "exec",
-            },
+            continueMessage: rebuildContinueMessage(
+              lastUserMsg.compactionRequest.parsed.continueMessage,
+              { model: options.model, mode: "exec" }
+            ),
           });
         }
       }

--- a/src/browser/utils/chatCommands.ts
+++ b/src/browser/utils/chatCommands.ts
@@ -9,10 +9,11 @@
 import type { RouterClient } from "@orpc/server";
 import type { AppRouter } from "@/node/orpc/router";
 import type { SendMessageOptions, ImagePart } from "@/common/orpc/types";
-import type {
-  MuxFrontendMetadata,
-  CompactionRequestData,
-  ContinueMessage,
+import {
+  type MuxFrontendMetadata,
+  type CompactionRequestData,
+  type ContinueMessage,
+  buildContinueMessage,
 } from "@/common/types/message";
 import type { ReviewNoteData } from "@/common/types/review";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
@@ -597,33 +598,8 @@ export function formatNewCommand(
 // Compaction
 // ============================================================================
 
-/**
- * Build a ContinueMessage from raw inputs.
- * Centralizes the has-content check and field construction to avoid duplication
- * across executeCompaction() call sites.
- *
- * @returns ContinueMessage if there's content to continue with, undefined otherwise
- */
-export function buildContinueMessage(opts: {
-  text?: string;
-  imageParts?: ImagePart[];
-  reviews?: ReviewNoteData[];
-  model: string;
-  mode: "exec" | "plan";
-}): ContinueMessage | undefined {
-  const hasText = opts.text && opts.text.length > 0;
-  const hasImages = opts.imageParts && opts.imageParts.length > 0;
-  const hasReviews = opts.reviews && opts.reviews.length > 0;
-  if (!hasText && !hasImages && !hasReviews) return undefined;
-
-  return {
-    text: opts.text ?? "",
-    imageParts: opts.imageParts,
-    reviews: opts.reviews,
-    model: opts.model,
-    mode: opts.mode,
-  };
-}
+// Re-export buildContinueMessage from common/types for backward compatibility
+export { buildContinueMessage } from "@/common/types/message";
 
 export interface CompactionOptions {
   api?: RouterClient<AppRouter>;

--- a/src/common/types/message.test.ts
+++ b/src/common/types/message.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import { buildContinueMessage, rebuildContinueMessage } from "./message";
+import type { ReviewNoteData } from "./review";
+
+// Helper to create valid ReviewNoteData for tests
+const makeReview = (filePath: string): ReviewNoteData => ({
+  filePath,
+  lineRange: "1-10",
+  selectedCode: "const x = 1;",
+  userNote: "fix this",
+});
+
+describe("buildContinueMessage", () => {
+  test("returns undefined when no content provided", () => {
+    const result = buildContinueMessage({
+      model: "test-model",
+      mode: "exec",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  test("returns undefined when text is empty string", () => {
+    const result = buildContinueMessage({
+      text: "",
+      model: "test-model",
+      mode: "exec",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  test("returns message when text is provided", () => {
+    const result = buildContinueMessage({
+      text: "hello",
+      model: "test-model",
+      mode: "exec",
+    });
+    // Check individual fields instead of toEqual (branded type can't be matched with plain object)
+    expect(result?.text).toBe("hello");
+    expect(result?.model).toBe("test-model");
+    expect(result?.mode).toBe("exec");
+    expect(result?.imageParts).toBeUndefined();
+    expect(result?.reviews).toBeUndefined();
+  });
+
+  test("returns message when only images provided", () => {
+    const result = buildContinueMessage({
+      imageParts: [{ url: "data:image/png;base64,abc", mediaType: "image/png" }],
+      model: "test-model",
+      mode: "plan",
+    });
+    expect(result?.imageParts?.length).toBe(1);
+    expect(result?.text).toBe("");
+    expect(result?.mode).toBe("plan");
+  });
+
+  test("returns message when only reviews provided", () => {
+    const result = buildContinueMessage({
+      reviews: [makeReview("a.ts")],
+      model: "test-model",
+      mode: "exec",
+    });
+    expect(result?.reviews?.length).toBe(1);
+    expect(result?.text).toBe("");
+  });
+});
+
+describe("rebuildContinueMessage", () => {
+  test("returns undefined when persisted is undefined", () => {
+    const result = rebuildContinueMessage(undefined, { model: "default", mode: "exec" });
+    expect(result).toBeUndefined();
+  });
+
+  test("returns undefined when persisted has no content", () => {
+    const result = rebuildContinueMessage({}, { model: "default", mode: "exec" });
+    expect(result).toBeUndefined();
+  });
+
+  test("uses persisted values when available", () => {
+    const result = rebuildContinueMessage(
+      { text: "continue", model: "persisted-model", mode: "plan" },
+      { model: "default", mode: "exec" }
+    );
+    expect(result?.text).toBe("continue");
+    expect(result?.model).toBe("persisted-model");
+    expect(result?.mode).toBe("plan");
+  });
+
+  test("uses defaults when persisted values missing", () => {
+    const result = rebuildContinueMessage(
+      { text: "continue" },
+      { model: "default-model", mode: "plan" }
+    );
+    expect(result?.text).toBe("continue");
+    expect(result?.model).toBe("default-model");
+    expect(result?.mode).toBe("plan");
+  });
+
+  test("preserves reviews from persisted data", () => {
+    const review = makeReview("a.ts");
+    const result = rebuildContinueMessage(
+      { text: "review this", reviews: [review] },
+      { model: "m", mode: "exec" }
+    );
+    expect(result?.reviews?.length).toBe(1);
+    expect(result?.reviews?.[0].filePath).toBe("a.ts");
+  });
+
+  test("preserves imageParts from persisted data", () => {
+    const result = rebuildContinueMessage(
+      {
+        text: "with image",
+        imageParts: [{ url: "data:image/png;base64,xyz", mediaType: "image/png" }],
+      },
+      { model: "m", mode: "exec" }
+    );
+    expect(result?.imageParts?.length).toBe(1);
+  });
+});


### PR DESCRIPTION
Two bugs were dropping reviews from compaction `continueMessage`:

## Bug 1: useResumeManager drops reviews on compaction resume

When resuming a failed compaction stream, the code manually reconstructed `continueMessage` but omitted the `reviews` field. This meant if a compaction with attached reviews failed and needed retry, the reviews would be lost.

**Fix:** Use new `rebuildContinueMessage()` factory that properly reconstructs from persisted data.

## Bug 2: ChatInput edit-mode loses attachments

When editing an existing `/compact` command, the regeneration path only passed text to `continueMessage`, losing any images/reviews attached during the edit.

**Fix:** Use `buildContinueMessage()` with current attachments (images, reviews) so they're properly queued after compaction completes.

## Refactor: Branded ContinueMessage type

To prevent this class of bugs in the future, `ContinueMessage` is now a **branded type** that can only be created via factory functions:
- `buildContinueMessage()` - for new messages with content validation
- `rebuildContinueMessage()` - for reconstructing from persisted/storage data

TypeScript will now reject any code that tries to construct `{ text: '...' }` directly where `ContinueMessage` is expected - the compiler enforces that all construction goes through the factories.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
