### PR TITLE
🤖 fix: use neutral border color until agents load

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -307,11 +307,11 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const { agentId, agents } = useAgent();
 
   // Get the active agent's uiColor for focus border styling.
-  // Falls back to exec-mode styling if the agent hasn't loaded yet.
+  // Backend resolves uiColor from inheritance chain; we just use it directly.
   const focusBorderColor = useMemo(() => {
     const normalizedId = typeof agentId === "string" ? agentId.trim().toLowerCase() : "";
-    const descriptor = agents.find((entry) => entry.id === normalizedId);
-    return descriptor?.uiColor ?? "var(--color-exec-mode)";
+    const descriptor = agents.find((a) => a.id === normalizedId);
+    return descriptor?.uiColor ?? "var(--color-border-light)";
   }, [agentId, agents]);
   const {
     models,


### PR DESCRIPTION
When workspace loads, the agents list is fetched async and starts empty. This caused `isPlanLike()` to return `false`, showing the exec purple border even when Plan mode was selected.

Instead of guessing which color to show, use a neutral grey (`--color-border-light`) on the ChatInput focus border until agents are loaded, then show the correct plan/exec color.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_