### PR TITLE
🤖 fix: agent inheritance circular dependency with same-name overrides

### DIFF
--- a/docs/agents.mdx
+++ b/docs/agents.mdx
@@ -128,6 +128,23 @@ ui:
 
 This completely removes the agent from discovery. To override (replace) a built-in instead, omit `disabled` and provide your own configuration.
 
+## Extending Built-in Agents
+
+You can extend a built-in agent by creating a file with the **same name** and using `base` to inherit from it:
+
+```md
+---
+name: Exec
+base: exec
+---
+
+Additional project-specific instructions that append to built-in exec.
+```
+
+This works because when resolving `base: exec`, mux skips the current scope (project) and looks for `exec` in lower-priority scopes (global, then built-in). Your project-local `exec.md` extends the built-in exec, not itself.
+
+**Common pattern:** Add repo-specific guidance (CI commands, test patterns) without duplicating the built-in instructions.
+
 ## Tool Policy Semantics
 
 Tools are controlled via an explicit **whitelist**. The `tools` array lists patterns (exact names or regex) that the agent can use. If `tools` is omitted or empty, no tools are available.

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1159,7 +1159,9 @@ export class AIService extends EventEmitter {
         workspaceId,
       });
 
-      const agentIsPlanLike = isPlanLike(effectiveAgentId, agentsForInheritance);
+      const agentIsPlanLike = isPlanLike(effectiveAgentId, agentsForInheritance, {
+        isPreResolvedChain: true,
+      });
       const effectiveMode: AgentMode = agentIsPlanLike ? "plan" : "exec";
 
       const cfg = this.config.loadConfigOrDefault();
@@ -1174,7 +1176,6 @@ export class AIService extends EventEmitter {
       // Agent policy establishes baseline (deny-all + enable whitelist + runtime restrictions).
       // Caller policy then narrows further if needed.
       const agentToolPolicy = resolveToolPolicyForAgent({
-        agentId: effectiveAgentId,
         agents: agentsForInheritance,
         isSubagent: isSubagentWorkspace,
         disableTaskToolsForDepth: shouldDisableTaskToolsForDepth,


### PR DESCRIPTION
## Problem

After the agent definitions merge (#1389), Mux broke when project-local agents
tried to extend built-in agents of the same name. For example:

```md
# .mux/agents/exec.md
---
name: Exec
base: exec  # Tries to extend built-in exec
---
Project-specific additions.
```

This caused either:
- An infinite loop (readAgentDefinition kept finding the same project file)
- False cycle detection (since both project/exec and built-in/exec have ID "exec")

## Solution

1. **Add `skipScopesAbove` option to `readAgentDefinition`**: When resolving a base
   agent with the same ID as the current agent, skip the current scope and look
   at lower-priority scopes (global, then built-in).

2. **Track visited packages by `(id:scope)` tuple**: This allows the same agent ID
   to appear at multiple scopes in the inheritance chain without triggering false
   cycle detection. A real cycle would still be detected (same id AND same scope).

3. **Update both resolution paths**:
   - `resolveAgentBody()` for system prompt inheritance
   - `resolveAgentInheritanceChain()` for tool policy inheritance

## Testing

- Added test: "same-name override: project agent with base: self extends built-in/global, not itself"
- Added test: "readAgentDefinition with skipScopesAbove skips higher-priority scopes"
- All existing agent tests pass

## Documentation

Added new section "Extending Built-in Agents" in docs/agents.mdx explaining the pattern.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
