### PR TITLE
🤖 feat: persist project page URL for refresh restoration

### DIFF
--- a/src/browser/contexts/RouterContext.tsx
+++ b/src/browser/contexts/RouterContext.tsx
@@ -22,11 +22,24 @@ export function useRouter(): RouterContext {
   return ctx;
 }
 
-/** Get initial route from localStorage (restores last workspace). */
+/** Get initial route from browser URL or localStorage. */
 function getInitialRoute(): string {
-  const saved = readPersistedState<WorkspaceSelection | null>(SELECTED_WORKSPACE_KEY, null);
-  if (saved?.workspaceId) {
-    return `/workspace/${encodeURIComponent(saved.workspaceId)}`;
+  // In browser mode, read route directly from URL (enables refresh restoration)
+  if (window.location.protocol !== "file:" && !window.location.pathname.endsWith("iframe.html")) {
+    const url = window.location.pathname + window.location.search;
+    // Only use URL if it's a valid route (starts with /, not just "/" or empty)
+    if (url.startsWith("/") && url !== "/") {
+      return url;
+    }
+  }
+
+  // In Electron (file://), fallback to localStorage for workspace restoration
+  const savedWorkspace = readPersistedState<WorkspaceSelection | null>(
+    SELECTED_WORKSPACE_KEY,
+    null
+  );
+  if (savedWorkspace?.workspaceId) {
+    return `/workspace/${encodeURIComponent(savedWorkspace.workspaceId)}`;
   }
   return "/";
 }


### PR DESCRIPTION
In browser mode, read the initial route directly from the browser URL instead of relying solely on localStorage. This enables refresh restoration for all routes (workspaces, project pages) without duplicating URL state.

## Changes

- **Browser mode**: Read from `window.location` on init to restore any route on refresh
- **Electron mode**: Fallback to localStorage for workspace restoration (file:// URLs don't persist routes)
- Skip in Storybook (iframe.html detection)

## How it works

The app uses `MemoryRouter` with one-way sync (router → browser URL via `useUrlSync`). This change adds the reverse: reading FROM the browser URL when initializing the router in browser mode.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_