### PR TITLE
🤖 fix: ignore stale origin/HEAD in git status scripts

### DIFF
--- a/src/browser/components/hooks/useGitBranchDetails.ts
+++ b/src/browser/components/hooks/useGitBranchDetails.ts
@@ -184,10 +184,12 @@ export function useGitBranchDetails(
 # Get current branch
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")
 
-# Get primary branch (main or master)
-PRIMARY_BRANCH=$(git branch -r 2>/dev/null | grep -E 'origin/(main|master)$' | head -1 | sed 's@^.*origin/@@' || echo "main")
-
-if [ -z "$PRIMARY_BRANCH" ]; then
+# Get primary branch (main or master) - check refs directly for reliability
+if git rev-parse --verify "refs/remotes/origin/main" >/dev/null 2>&1; then
+  PRIMARY_BRANCH="main"
+elif git rev-parse --verify "refs/remotes/origin/master" >/dev/null 2>&1; then
+  PRIMARY_BRANCH="master"
+else
   PRIMARY_BRANCH="main"
 fi
 

--- a/src/browser/stories/App.sidebar.stories.tsx
+++ b/src/browser/stories/App.sidebar.stories.tsx
@@ -113,7 +113,7 @@ function createGitStatusExecutor(gitStatus?: Map<string, GitStatusFixture>) {
     }
 
     // GitStatusStore consolidated status script
-    if (script.includes("PRIMARY_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD")) {
+    if (script.includes("---PRIMARY---") && script.includes("---SHOW_BRANCH---")) {
       const output = createGitStatusOutput(status);
       return Promise.resolve({ success: true as const, output, exitCode: 0, wall_duration_ms: 50 });
     }

--- a/src/common/utils/git/parseGitStatus.test.ts
+++ b/src/common/utils/git/parseGitStatus.test.ts
@@ -1,4 +1,4 @@
-import { parseGitRevList } from "./parseGitStatus";
+import { parseGitRevList, parseGitShowBranchForStatus } from "./parseGitStatus";
 
 // Base result shape with zero line deltas (parseGitRevList doesn't compute these)
 const base = {
@@ -37,5 +37,58 @@ describe("parseGitRevList", () => {
     expect(parseGitRevList("   ")).toBe(null);
     expect(parseGitRevList("\n")).toBe(null);
     expect(parseGitRevList("\t")).toBe(null);
+  });
+});
+
+function makeBehindCommitLines(count: number): string {
+  return Array.from({ length: count }, (_, i) => ` + [${i + 1}] behind commit ${i + 1}`).join("\n");
+}
+
+describe("parseGitShowBranchForStatus", () => {
+  test("parses 2-branch output correctly", () => {
+    const output = `! [HEAD] feat: add feature
+ ! [origin/main] fix: bug fix
+--
++  [cf9cbfb7] feat: add feature
+++ [306f4968] fix: bug fix`;
+
+    const result = parseGitShowBranchForStatus(output);
+    expect(result).not.toBeNull();
+    expect(result!.ahead).toBe(1);
+    expect(result!.behind).toBe(0);
+  });
+
+  test("parses 2-branch output with behind commits", () => {
+    const output = `! [HEAD] feat: add feature
+ ! [origin/main] latest on main
+--
++  [cf9cbfb7] feat: add feature
+${makeBehindCommitLines(9)}
+++ [base] common ancestor`;
+
+    const result = parseGitShowBranchForStatus(output);
+    expect(result).not.toBeNull();
+    expect(result!.ahead).toBe(1);
+    expect(result!.behind).toBe(9);
+  });
+
+  test("handles 3-branch output (misuse case)", () => {
+    // This tests what happens if 3-branch output is accidentally fed to the parser.
+    // The parser uses columns 0 and 1, ignoring column 2.
+    const output = `! [HEAD] feat: add feature
+ ! [origin/main] fix: bug fix
+  ! [origin/feature] feat: add feature
+---
++ + [cf9cbfb7] feat: add feature
+ ++ [306f4968] fix: bug fix`;
+
+    // With 3 columns: "+ +" means col0='+', col1=' ', col2='+'
+    // Parser sees col0='+', col1=' ' -> ahead
+    // With 3 columns: " ++" means col0=' ', col1='+', col2='+'
+    // Parser sees col0=' ', col1='+' -> behind
+    const result = parseGitShowBranchForStatus(output);
+    expect(result).not.toBeNull();
+    expect(result!.ahead).toBe(1); // "+ +" has col0='+', col1=' '
+    expect(result!.behind).toBe(1); // " ++" has col0=' ', col1='+'
   });
 });


### PR DESCRIPTION
## Context

#1414 (merged) unified the review-base selector with the git status indicator so the diff view and divergence numbers use the same base.

However, mux workspaces can be created from git bundles, and those clones can inherit a stale `refs/remotes/origin/HEAD` (e.g. pointing at a feature branch). If we use `origin/HEAD` as the base (explicitly or implicitly), ahead/behind can be computed against the wrong remote ref.

## What this PR changes (follow-up)

- **`generateGitStatusScript()`**
  - Treats `origin/HEAD` as **auto-detect** even if configured as the base ref
  - Uses configured `origin/<branch>` when present (with main↔master fallback if the ref doesn't exist locally)
  - When auto-detecting, ignores suspicious `origin/HEAD` values and prefers `origin/main` or `origin/master`
- **`GIT_FETCH_SCRIPT`**
  - Derives the remote default branch + SHA via `git ls-remote --symref origin HEAD` (instead of local `origin/HEAD`)
- **Storybook mock**
  - Detects the consolidated git status script via output markers (less brittle)
- **Tests**
  - Adds unit coverage for `parseGitShowBranchForStatus`

## Regression risk

- Auto-detection uses more heuristics; repos without `origin/main` or `origin/master` may fall back differently than before.
- `GIT_FETCH_SCRIPT` now depends on `git ls-remote --symref origin HEAD`; if the remote is unreachable/slow, fetch will be skipped and statuses may remain stale until a later refresh/manual fetch.
- If a user intentionally configured `origin/HEAD` as a base ref, it will now be treated as auto-detect (by design) to avoid stale/incorrect divergence.

## Testing

- `make static-check`

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh`_
