### PR TITLE
🤖 refactor: move Plan actions to bottom with icon buttons

### DIFF
--- a/src/browser/components/Messages/MessageWindow.tsx
+++ b/src/browser/components/Messages/MessageWindow.tsx
@@ -142,7 +142,7 @@ interface IconActionButtonProps {
   button: ButtonConfig;
 }
 
-const IconActionButton: React.FC<IconActionButtonProps> = ({ button }) => {
+export const IconActionButton: React.FC<IconActionButtonProps> = ({ button }) => {
   const content = (
     <Button
       onClick={button.onClick}

--- a/src/browser/stories/App.chat.stories.tsx
+++ b/src/browser/stories/App.chat.stories.tsx
@@ -14,6 +14,7 @@ import {
   createStatusTool,
   createGenericTool,
   createPendingTool,
+  createProposePlanTool,
 } from "./mockFactory";
 
 import type { WorkspaceChatMessage } from "@/common/orpc/types";
@@ -1191,6 +1192,81 @@ export const InitHookError: AppStory = {
         story:
           "Shows the InitMessage component after a failed init hook execution. " +
           "The message displays with a red alert icon, error styling, and error output.",
+      },
+    },
+  },
+};
+
+/**
+ * Story showing a propose_plan tool call with Plan UI.
+ * Tests the plan card rendering with icon action buttons at the bottom.
+ */
+export const ProposePlan: AppStory = {
+  render: () => (
+    <AppWithMocks
+      setup={() =>
+        setupSimpleChatStory({
+          workspaceId: "ws-plan",
+          messages: [
+            createUserMessage("msg-1", "Help me refactor the authentication module", {
+              historySequence: 1,
+              timestamp: STABLE_TIMESTAMP - 300000,
+            }),
+            createAssistantMessage(
+              "msg-2",
+              "I'll create a plan for refactoring the authentication module.",
+              {
+                historySequence: 2,
+                timestamp: STABLE_TIMESTAMP - 290000,
+                toolCalls: [
+                  createProposePlanTool(
+                    "call-plan-1",
+                    `# Authentication Module Refactor
+
+## Overview
+
+Refactor the authentication system to improve security and maintainability.
+
+## Tasks
+
+1. **Extract JWT utilities** - Move token generation and validation to dedicated module
+2. **Add refresh token support** - Implement secure refresh token rotation
+3. **Improve password hashing** - Upgrade to Argon2id with proper salt rounds
+4. **Add rate limiting** - Implement per-IP and per-user rate limits
+5. **Session management** - Add Redis-backed session store
+
+## Implementation Order
+
+\`\`\`mermaid
+graph TD
+    A[Extract JWT utils] --> B[Add refresh tokens]
+    B --> C[Improve hashing]
+    C --> D[Add rate limiting]
+    D --> E[Session management]
+\`\`\`
+
+## Success Criteria
+
+- All existing tests pass
+- New tests for refresh token flow
+- Security audit passes
+- Performance benchmarks maintained`
+                  ),
+                ],
+              }
+            ),
+          ],
+        })
+      }
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Shows the ProposePlanToolCall component with a completed plan. " +
+          "The plan card displays with the title in the header and icon action buttons " +
+          "(Copy, Start Here, Show Text) at the bottom, matching the AssistantMessage aesthetic.",
       },
     },
   },

--- a/src/browser/stories/mockFactory.ts
+++ b/src/browser/stories/mockFactory.ts
@@ -358,6 +358,31 @@ export function createGenericTool(
   };
 }
 
+/** Create a propose_plan tool call with markdown plan content */
+export function createProposePlanTool(
+  toolCallId: string,
+  planContent: string,
+  planPath = ".mux/plan.md"
+): MuxPart {
+  // Extract title from first heading
+  const titleMatch = /^#\s+(.+)$/m.exec(planContent);
+  const title = titleMatch ? titleMatch[1] : "Plan";
+
+  return {
+    type: "dynamic-tool",
+    toolCallId,
+    toolName: "propose_plan",
+    state: "output-available",
+    input: { title, plan: planContent },
+    output: {
+      success: true,
+      planPath,
+      planContent, // Include for story rendering
+      message: `Plan saved to ${planPath}`,
+    },
+  };
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // CODE EXECUTION (PTC) TOOL FACTORIES
 // ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Move Plan tool call actions from the header to the bottom row, matching the AssistantMessage aesthetic.

## Changes

- Export `IconActionButton` from `MessageWindow` for reuse
- Replace text buttons with icon buttons (Clipboard, Pencil, ListStart, FileText, X)
- Clean up header to show only title and emoji
- Maintain button order: Copy → Start Here → Show Text → Edit
- Use ref for Edit button to position error popovers correctly

## Before/After

**Before:** Text buttons in the header row
**After:** Icon buttons in a bottom actions row (consistent with assistant messages)

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
