### PR TITLE
🤖 ci: add code-to-docs link validation to static-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,7 @@ build/icon.png: docs/img/logo.webp scripts/generate-icons.ts
 	@bun scripts/generate-icons.ts png
 
 ## Quality checks (can run in parallel)
-static-check: lint typecheck fmt-check check-eager-imports check-bench-agent check-docs-links ## Run all static checks
+static-check: lint typecheck fmt-check check-eager-imports check-bench-agent check-docs-links check-code-docs-links ## Run all static checks
 
 check-bench-agent: ## Verify terminal-bench agent configuration and imports
 	@./scripts/check-bench-agent.sh
@@ -400,6 +400,9 @@ docs-server: node_modules/.installed ## Serve documentation locally (Mintlify de
 check-docs-links: ## Check documentation for broken links
 	@echo "🔗 Checking documentation links..."
 	@cd docs && npx mintlify broken-links
+
+check-code-docs-links: ## Validate code references to docs paths
+	@./scripts/check-code-docs-links.sh
 
 ## Storybook
 storybook: node_modules/.installed src/version.ts ## Start Storybook development server

--- a/scripts/check-code-docs-links.sh
+++ b/scripts/check-code-docs-links.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Validates that code references to docs (URLs and DocsLink paths) resolve to existing doc files.
+set -euo pipefail
+
+DOCS_BASE="https://mux.coder.com"
+DOCS_DIR="docs"
+EXIT_CODE=0
+
+check_path() {
+  local path="$1"
+  local source="$2"
+
+  # Strip anchor
+  path="${path%%#*}"
+  # Strip trailing slash
+  path="${path%/}"
+  # Empty path = index
+  [[ -z "$path" ]] && path="index"
+  # Strip leading slash
+  path="${path#/}"
+
+  # Check existence
+  if [[ -f "$DOCS_DIR/${path}.mdx" ]] || [[ -f "$DOCS_DIR/${path}/index.mdx" ]]; then
+    return 0
+  fi
+
+  echo "❌ Broken doc link: /${path}"
+  echo "   Source: $source"
+  EXIT_CODE=1
+}
+
+echo "🔗 Checking code-to-docs links..."
+
+# Extract from README.md
+while IFS= read -r url; do
+  path="${url#$DOCS_BASE}"
+  check_path "$path" "README.md"
+done < <(grep -oP "https://mux\.coder\.com[^\s\)\"']*" README.md 2>/dev/null || true)
+
+# Extract from source files (URLs) - skip gateway URLs
+while IFS=: read -r file line url; do
+  [[ "$url" == *"gateway."* ]] && continue
+  path="${url#$DOCS_BASE}"
+  check_path "$path" "$file:$line"
+done < <(grep -rn --include="*.ts" --include="*.tsx" -oP "https://mux\.coder\.com[^\s\)\"']*" src/ 2>/dev/null || true)
+
+# Extract DocsLink paths
+while IFS= read -r match; do
+  file="${match%%:*}"
+  rest="${match#*:}"
+  line="${rest%%:*}"
+  path=$(echo "$match" | grep -oP 'path="[^"]*"' | sed 's/path="//;s/"$//')
+  check_path "$path" "$file:$line (DocsLink)"
+done < <(grep -rn --include="*.tsx" 'DocsLink' src/ | grep 'path="' || true)
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+  echo "✅ All code-to-docs links valid"
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary

Adds `scripts/check-code-docs-links.sh` which validates that code references to docs actually resolve, making docs rearchitecture safe.

### What's checked

| Source | Pattern | Example |
|--------|---------|---------|
| README.md | `https://mux.coder.com/*` | `[docs](https://mux.coder.com/runtime)` |
| Source URLs | `https://mux.coder.com/*` | `window.open("https://mux.coder.com/keybinds")` |
| DocsLink component | `path="/..."` | `<DocsLink path="/models">` |

### Validation

Each extracted path is checked against:
- `docs/{path}.mdx`
- `docs/{path}/index.mdx` (for nested routes)

Gateway URLs (`gateway.mux.coder.com`) are skipped.

### Integration

New `check-code-docs-links` target added to `static-check` dependencies.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
