### PR TITLE
🤖 feat: stabilize agent ordering in selector dropdown

### DIFF
--- a/src/browser/components/AgentModePicker.tsx
+++ b/src/browser/components/AgentModePicker.tsx
@@ -18,6 +18,7 @@ import {
   KEYBINDS,
   matchNumberedKeybind,
 } from "@/browser/utils/ui/keybinds";
+import { sortAgentsStable } from "@/browser/utils/agents";
 
 interface AgentModePickerProps {
   className?: string;
@@ -166,19 +167,7 @@ const AgentHelpTooltip: React.FC = () => (
 );
 
 function resolveAgentOptions(agents: AgentDefinitionDescriptor[]): AgentOption[] {
-  return agents
-    .filter((entry) => entry.uiSelectable)
-    .map((entry) => ({
-      id: entry.id,
-      name: entry.name,
-      uiColor: entry.uiColor,
-      description: entry.description,
-      scope: entry.scope,
-      base: entry.base,
-      tools: entry.tools,
-      aiDefaults: entry.aiDefaults,
-      subagentRunnable: entry.subagentRunnable,
-    }));
+  return sortAgentsStable(agents.filter((entry) => entry.uiSelectable));
 }
 
 export const AgentModePicker: React.FC<AgentModePickerProps> = (props) => {

--- a/src/browser/components/AgentSelector.tsx
+++ b/src/browser/components/AgentSelector.tsx
@@ -15,6 +15,7 @@ import {
   SelectValue,
 } from "@/browser/components/ui/select";
 import { formatKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
+import { sortAgentsStable } from "@/browser/utils/agents";
 import { cn } from "@/common/lib/utils";
 
 interface AgentSelectorProps {
@@ -44,7 +45,7 @@ export const AgentSelector: React.FC<AgentSelectorProps> = (props) => {
 
   const options =
     selectable.length > 0
-      ? selectable
+      ? sortAgentsStable(selectable)
       : [
           { id: "exec", name: "Exec" },
           { id: "plan", name: "Plan" },

--- a/src/browser/contexts/ModeContext.tsx
+++ b/src/browser/contexts/ModeContext.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/common/constants/storage";
 import type { AgentDefinitionDescriptor } from "@/common/types/agentDefinition";
 import type { UIMode } from "@/common/types/mode";
+import { sortAgentsStable } from "@/browser/utils/agents";
 
 type ModeContextType = [UIMode, (mode: UIMode) => void];
 
@@ -188,8 +189,11 @@ export const ModeProvider: React.FC<ModeProviderProps> = (props) => {
     [setAgentId]
   );
 
-  // Get UI-selectable agents for cycling
-  const selectableAgents = useMemo(() => agents.filter((a) => a.uiSelectable), [agents]);
+  // Get UI-selectable agents in stable order for cycling
+  const selectableAgents = useMemo(
+    () => sortAgentsStable(agents.filter((a) => a.uiSelectable)),
+    [agents]
+  );
 
   // Cycle to next agent
   const cycleToNextAgent = useCallback(() => {

--- a/src/browser/utils/agents.test.ts
+++ b/src/browser/utils/agents.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { sortAgentsStable } from "./agents";
+
+describe("sortAgentsStable", () => {
+  test("sorts built-in agents in stable order", () => {
+    const agents = [
+      { id: "plan", name: "Plan" },
+      { id: "exec", name: "Exec" },
+    ];
+
+    const sorted = sortAgentsStable(agents);
+    expect(sorted.map((a) => a.id)).toEqual(["exec", "plan"]);
+  });
+
+  test("places custom agents after built-ins, sorted alphabetically", () => {
+    const agents = [
+      { id: "zebra", name: "Zebra Agent" },
+      { id: "plan", name: "Plan" },
+      { id: "alpha", name: "Alpha Agent" },
+      { id: "exec", name: "Exec" },
+    ];
+
+    const sorted = sortAgentsStable(agents);
+    expect(sorted.map((a) => a.id)).toEqual(["exec", "plan", "alpha", "zebra"]);
+  });
+
+  test("handles only custom agents", () => {
+    const agents = [
+      { id: "beta", name: "Beta" },
+      { id: "alpha", name: "Alpha" },
+    ];
+
+    const sorted = sortAgentsStable(agents);
+    expect(sorted.map((a) => a.id)).toEqual(["alpha", "beta"]);
+  });
+
+  test("does not mutate the original array", () => {
+    const agents = [
+      { id: "plan", name: "Plan" },
+      { id: "exec", name: "Exec" },
+    ];
+    const original = [...agents];
+
+    sortAgentsStable(agents);
+    expect(agents).toEqual(original);
+  });
+});

--- a/src/browser/utils/agents.ts
+++ b/src/browser/utils/agents.ts
@@ -1,0 +1,25 @@
+import type { AgentDefinitionDescriptor } from "@/common/types/agentDefinition";
+
+// Built-in agents in stable order (determines Ctrl+1, Ctrl+2, etc.)
+// Only includes agents that are uiSelectable by default.
+const BUILTIN_AGENT_ORDER: readonly string[] = ["exec", "plan"];
+
+/**
+ * Sort agents with stable ordering: built-ins first (exec, plan),
+ * then custom agents alphabetically by name.
+ */
+export function sortAgentsStable<T extends Pick<AgentDefinitionDescriptor, "id" | "name">>(
+  agents: T[]
+): T[] {
+  return [...agents].sort((a, b) => {
+    const aIndex = BUILTIN_AGENT_ORDER.indexOf(a.id);
+    const bIndex = BUILTIN_AGENT_ORDER.indexOf(b.id);
+    const aIsBuiltin = aIndex !== -1;
+    const bIsBuiltin = bIndex !== -1;
+
+    if (aIsBuiltin && bIsBuiltin) return aIndex - bIndex;
+    if (aIsBuiltin) return -1;
+    if (bIsBuiltin) return 1;
+    return a.name.localeCompare(b.name);
+  });
+}


### PR DESCRIPTION
## Summary

Stabilizes the position of agents in the dropdown so keyboard shortcuts are predictable:

- **Exec** is always position 1 (Ctrl+1)
- **Plan** is always position 2 (Ctrl+2)
- Custom agents appear after built-ins, sorted alphabetically by name

### Changes

- Added `sortAgentsStable()` utility in `src/browser/utils/agents.ts`
- Applied stable ordering to:
  - `AgentModePicker` dropdown
  - `AgentSelector` dropdown
  - Agent cycling (Tab shortcut)

### Testing

- Added unit tests for the sorting utility
- Verified existing tests pass

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_