### PR TITLE
🤖 refactor: remove Agent/Mode scoped instructions

### DIFF
--- a/docs/agents/instruction-files.mdx
+++ b/docs/agents/instruction-files.mdx
@@ -25,12 +25,22 @@ If a base file is found, mux also appends `AGENTS.local.md` from the same direct
 
 ## Scoped instructions
 
-mux supports **scoped instructions** that activate only in specific contexts. You define them using special headings in your instruction files:
+mux supports **scoped instructions** that activate only in specific contexts. You define them using special headings:
 
-- `Agent: <agentId>` — Active only for a specific agent definition (e.g., plan, exec, explore).
-- `Mode: <mode>` — Active only in specific interaction modes (e.g., plan, exec).
 - `Model: <regex>` — Active only for specific models (e.g., GPT-4, Claude).
 - `Tool: <tool_name>` — Appended to the description of specific tools.
+
+These scoped headings work identically in both:
+
+1. **AGENTS.md files** (global `~/.mux/AGENTS.md` or workspace `<workspace>/AGENTS.md`)
+2. **Custom agent definitions** (the Markdown body of `.mux/agents/<name>.md` files)
+
+When searching for a matching section, mux checks sources in this order: agent definition → workspace AGENTS.md → global AGENTS.md. The first match wins.
+
+<Note>
+  Agent-specific and mode-specific scoped instructions (`Agent:` and `Mode:`) have been removed. Use
+  [custom agent definitions](/agents) instead to customize behavior per agent.
+</Note>
 
 ### General Rules
 
@@ -38,62 +48,6 @@ mux supports **scoped instructions** that activate only in specific contexts. Yo
 - **First Match Wins**: Only the _first_ matching section found is used. Overriding global defaults is as simple as defining the same section in your workspace.
 - **Isolation**: These sections are **stripped** from the general `<custom-instructions>` block. Their content is injected only where it belongs (e.g., into a specific tool's description or a special XML tag).
 - **Boundaries**: A section's content includes everything until the next heading of the same or higher level.
-
----
-
-### Mode Prompts
-
-Use mode-specific sections to optimize context and customize behavior for specific workflow stages. The active mode's content is injected via a `<mode>` tag.
-
-**Syntax**: `Mode: <mode>` (case-insensitive)
-
-**Example**:
-
-```markdown
-# General Instructions
-
-- Be concise
-
-## Mode: Plan
-
-When planning:
-
-- Focus on goals and trade-offs
-- Propose alternatives with pros/cons
-
-## Mode: Compact
-
-- Preserve key decisions
-- Be extremely concise
-```
-
-**Available modes**:
-
-- **exec** (default) — Normal operations.
-- **plan** — Active in Plan Mode.
-- **compact** — Used during `/compact` to guide history summarization.
-
-### Agent Prompts
-
-Use agent-specific sections to customize behavior for a single agent definition. The selected agent’s content is injected via an `<agent-...>` tag.
-
-**Syntax**: `Agent: <agentId>` (case-insensitive)
-
-**Example**:
-
-```markdown
-## Agent: review
-
-When reviewing:
-
-- Prefer short, high-signal comments
-- Call out risky changes and missing tests
-```
-
-Notes:
-
-- `agentId` comes from the agent definition filename (e.g., `.mux/agents/review.md` → `review`).
-- `Mode:` prompts still apply based on the selected agent’s base policy. Use `Mode:` for shared behavior across multiple agents; use `Agent:` for per-agent behavior.
 
 ---
 
@@ -153,6 +107,6 @@ Customize how the AI uses specific tools by appending instructions to their desc
   AGENTS.local.md    # Personal tweaks (gitignored)
 
 my-project/
-  AGENTS.md          # Project instructions (may include "Mode: Plan", etc.)
+  AGENTS.md          # Project instructions
   AGENTS.local.md    # Personal tweaks (gitignored)
 ```

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1396,14 +1396,10 @@ export class AIService extends EventEmitter {
         metadata,
         runtime,
         workspacePath,
-        effectiveMode,
         effectiveAdditionalInstructions,
         modelString,
         mcpServers,
-        {
-          agentId: effectiveAgentId,
-          agentSystemPrompt,
-        }
+        { agentSystemPrompt }
       );
 
       // Count system message tokens for cost tracking
@@ -1443,12 +1439,13 @@ export class AIService extends EventEmitter {
 
       const runtimeTempDir = await this.streamManager.createTempDirForStream(streamToken, runtime);
 
-      // Extract tool-specific instructions from AGENTS.md files
+      // Extract tool-specific instructions from AGENTS.md files and agent definition
       const toolInstructions = await readToolInstructions(
         metadata,
         runtime,
         workspacePath,
-        modelString
+        modelString,
+        agentSystemPrompt
       );
 
       // Get model-specific tools with workspace path (correct for local or remote)

--- a/src/node/services/systemMessage.ts
+++ b/src/node/services/systemMessage.ts
@@ -5,8 +5,6 @@ import {
   readInstructionSetFromRuntime,
 } from "@/node/utils/main/instructionFiles";
 import {
-  extractAgentSection,
-  extractModeSection,
   extractModelSection,
   extractToolSection,
   stripScopedInstructionSections,
@@ -180,30 +178,50 @@ function getSystemDirectory(): string {
 }
 
 /**
+ * Search instruction sources in priority order: agent → context → global.
+ * Returns the first non-null result from the extractor function.
+ */
+function searchInstructionSources<T>(
+  sources: { agent?: string | null; context?: string | null; global?: string | null },
+  extractor: (source: string) => T | null
+): T | null {
+  // Priority: agent definition → workspace/project AGENTS.md → global AGENTS.md
+  for (const src of [sources.agent, sources.context, sources.global]) {
+    if (src) {
+      const result = extractor(src);
+      if (result !== null) return result;
+    }
+  }
+  return null;
+}
+
+/**
  * Extract tool-specific instructions from instruction sources.
- * Searches context (workspace/project) first, then falls back to global instructions.
+ * Searches agent instructions first, then context (workspace/project), then global.
  *
  * @param globalInstructions Global instructions from ~/.mux/AGENTS.md
  * @param contextInstructions Context instructions from workspace/project AGENTS.md
  * @param modelString Active model identifier to determine available tools
+ * @param options.enableAgentReport Whether to include agent_report in available tools
+ * @param options.agentInstructions Optional agent definition body (searched first)
  * @returns Map of tool names to their additional instructions
  */
 export function extractToolInstructions(
   globalInstructions: string | null,
   contextInstructions: string | null,
   modelString: string,
-  options?: { enableAgentReport?: boolean }
+  options?: { enableAgentReport?: boolean; agentInstructions?: string }
 ): Record<string, string> {
   const availableTools = getAvailableTools(modelString, undefined, options);
   const toolInstructions: Record<string, string> = {};
+  const sources = {
+    agent: options?.agentInstructions,
+    context: contextInstructions,
+    global: globalInstructions,
+  };
 
   for (const toolName of availableTools) {
-    // Try context instructions first, then global
-    const content =
-      (contextInstructions && extractToolSection(contextInstructions, toolName)) ??
-      (globalInstructions && extractToolSection(globalInstructions, toolName)) ??
-      null;
-
+    const content = searchInstructionSources(sources, (src) => extractToolSection(src, toolName));
     if (content) {
       toolInstructions[toolName] = content;
     }
@@ -220,13 +238,15 @@ export function extractToolInstructions(
  * @param runtime - Runtime for reading workspace files (supports SSH)
  * @param workspacePath - Workspace directory path
  * @param modelString - Active model identifier to determine available tools
+ * @param agentInstructions - Optional agent definition body (searched first for tool sections)
  * @returns Map of tool names to their additional instructions
  */
 export async function readToolInstructions(
   metadata: WorkspaceMetadata,
   runtime: Runtime,
   workspacePath: string,
-  modelString: string
+  modelString: string,
+  agentInstructions?: string
 ): Promise<Record<string, string>> {
   const [globalInstructions, contextInstructions] = await readInstructionSources(
     metadata,
@@ -236,6 +256,7 @@ export async function readToolInstructions(
 
   return extractToolInstructions(globalInstructions, contextInstructions, modelString, {
     enableAgentReport: Boolean(metadata.parentWorkspaceId),
+    agentInstructions,
   });
 }
 
@@ -267,7 +288,7 @@ async function readInstructionSources(
  * Instruction layers:
  * 1. Global: ~/.mux/AGENTS.md (always included)
  * 2. Context: workspace/AGENTS.md OR project/AGENTS.md (workspace takes precedence)
- * 3. Mode: Extracts "Mode: <mode>" section from context then global (if mode provided)
+ * 3. Model: Extracts "Model: <regex>" section from context then global (if modelString provided)
  *
  * File search order: AGENTS.md → AGENT.md → CLAUDE.md
  * Local variants: AGENTS.local.md appended if found (for .gitignored personal preferences)
@@ -275,7 +296,6 @@ async function readInstructionSources(
  * @param metadata - Workspace metadata (contains projectPath)
  * @param runtime - Runtime for reading workspace files (supports SSH)
  * @param workspacePath - Workspace directory path
- * @param mode - Optional mode name (e.g., "plan", "exec")
  * @param additionalSystemInstructions - Optional instructions appended last
  * @param modelString - Active model identifier used for Model-specific sections
  * @param mcpServers - Optional MCP server configuration (name -> command)
@@ -285,12 +305,10 @@ export async function buildSystemMessage(
   metadata: WorkspaceMetadata,
   runtime: Runtime,
   workspacePath: string,
-  mode?: string,
   additionalSystemInstructions?: string,
   modelString?: string,
   mcpServers?: MCPServerMap,
   options?: {
-    agentId?: string;
     agentSystemPrompt?: string;
   }
 ): Promise<string> {
@@ -312,11 +330,6 @@ export async function buildSystemMessage(
   // Add agent skills context (if any)
   systemMessage += await buildAgentSkillsContext(runtime, workspacePath);
 
-  const agentPrompt = options?.agentSystemPrompt?.trim();
-  if (agentPrompt) {
-    systemMessage += `\n<agent-instructions>\n${agentPrompt}\n</agent-instructions>`;
-  }
-
   // Read instruction sets
   const [globalInstructions, contextInstructions] = await readInstructionSources(
     metadata,
@@ -324,12 +337,20 @@ export async function buildSystemMessage(
     workspacePath
   );
 
+  const agentPrompt = options?.agentSystemPrompt?.trim() ?? null;
+
   // Combine: global + context (workspace takes precedence over project) after stripping scoped sections
+  // Also strip scoped sections from agent prompt for consistency
   const sanitizeScopedInstructions = (input?: string | null): string | undefined => {
     if (!input) return undefined;
     const stripped = stripScopedInstructionSections(input);
     return stripped.trim().length > 0 ? stripped : undefined;
   };
+
+  const sanitizedAgentPrompt = sanitizeScopedInstructions(agentPrompt);
+  if (sanitizedAgentPrompt) {
+    systemMessage += `\n<agent-instructions>\n${sanitizedAgentPrompt}\n</agent-instructions>`;
+  }
 
   const customInstructionSources = [
     sanitizeScopedInstructions(globalInstructions),
@@ -337,48 +358,16 @@ export async function buildSystemMessage(
   ].filter((value): value is string => Boolean(value));
   const customInstructions = customInstructionSources.join("\n\n");
 
-  // Extract agent-specific section (context first, then global fallback)
-  const agentId = options?.agentId;
-  let agentContent: string | null = null;
-  if (agentId) {
-    agentContent =
-      (contextInstructions && extractAgentSection(contextInstructions, agentId)) ??
-      (globalInstructions && extractAgentSection(globalInstructions, agentId)) ??
-      null;
-  }
-
-  // Extract mode-specific section (context first, then global fallback)
-  let modeContent: string | null = null;
-  if (mode) {
-    modeContent =
-      (contextInstructions && extractModeSection(contextInstructions, mode)) ??
-      (globalInstructions && extractModeSection(globalInstructions, mode)) ??
-      null;
-  }
-
-  // Extract model-specific section based on active model identifier (context first)
-  let modelContent: string | null = null;
-  if (modelString) {
-    modelContent =
-      (contextInstructions && extractModelSection(contextInstructions, modelString)) ??
-      (globalInstructions && extractModelSection(globalInstructions, modelString)) ??
-      null;
-  }
+  // Extract model-specific section based on active model identifier
+  const modelContent = modelString
+    ? searchInstructionSources(
+        { agent: agentPrompt, context: contextInstructions, global: globalInstructions },
+        (src) => extractModelSection(src, modelString)
+      )
+    : null;
 
   if (customInstructions) {
     systemMessage += `\n<custom-instructions>\n${customInstructions}\n</custom-instructions>`;
-  }
-
-  const modeSection = buildTaggedSection(modeContent, mode, "mode");
-  if (agentId) {
-    const agentSection = buildTaggedSection(agentContent, `agent-${agentId}`, "agent");
-    if (agentSection) {
-      systemMessage += agentSection;
-    }
-  }
-
-  if (modeSection) {
-    systemMessage += modeSection;
   }
 
   if (modelContent && modelString) {

--- a/src/node/utils/main/markdown.test.ts
+++ b/src/node/utils/main/markdown.test.ts
@@ -1,264 +1,4 @@
-import { extractModeSection, extractToolSection, stripScopedInstructionSections } from "./markdown";
-
-describe("extractModeSection", () => {
-  describe("basic extraction", () => {
-    it("should extract content under Mode: plan heading", () => {
-      const markdown = `
-# General Instructions
-Some general content
-
-# Mode: Plan
-Planning specific content
-More planning stuff
-
-# Other Section
-Other content
-`.trim();
-
-      const result = extractModeSection(markdown, "plan");
-      expect(result).toBe("Planning specific content\nMore planning stuff");
-    });
-
-    it("should return null when mode section doesn't exist", () => {
-      const markdown = `
-# General Instructions
-Some content
-
-# Other Section
-Other content
-`.trim();
-
-      const result = extractModeSection(markdown, "plan");
-      expect(result).toBeNull();
-    });
-
-    it("should return null for empty markdown", () => {
-      expect(extractModeSection("", "plan")).toBeNull();
-    });
-
-    it("should return null for empty mode", () => {
-      expect(extractModeSection("# Mode: plan\nContent", "")).toBeNull();
-    });
-  });
-
-  describe("case insensitivity", () => {
-    it("should match case-insensitive heading", () => {
-      const markdown = "# MODE: PLAN\nContent here";
-      const result = extractModeSection(markdown, "plan");
-      expect(result).toBe("Content here");
-    });
-
-    it("should match mixed case heading", () => {
-      const markdown = "# MoDe: PlAn\nContent here";
-      const result = extractModeSection(markdown, "plan");
-      expect(result).toBe("Content here");
-    });
-
-    it("should match with case-insensitive mode parameter", () => {
-      const markdown = "# Mode: plan\nContent here";
-      const result = extractModeSection(markdown, "PLAN");
-      expect(result).toBe("Content here");
-    });
-  });
-
-  describe("heading levels", () => {
-    it("should work with h1 heading", () => {
-      const markdown = "# Mode: Plan\nContent";
-      expect(extractModeSection(markdown, "plan")).toBe("Content");
-    });
-
-    it("should work with h2 heading", () => {
-      const markdown = "## Mode: Plan\nContent";
-      expect(extractModeSection(markdown, "plan")).toBe("Content");
-    });
-
-    it("should work with h3 heading", () => {
-      const markdown = "### Mode: Plan\nContent";
-      expect(extractModeSection(markdown, "plan")).toBe("Content");
-    });
-
-    it("should work with h6 heading", () => {
-      const markdown = "###### Mode: Plan\nContent";
-      expect(extractModeSection(markdown, "plan")).toBe("Content");
-    });
-  });
-
-  describe("section boundaries", () => {
-    it("should stop at next same-level heading", () => {
-      const markdown = `
-# Mode: Plan
-Planning content
-
-# Next Section
-Other content
-`.trim();
-
-      const result = extractModeSection(markdown, "plan");
-      expect(result).toBe("Planning content");
-    });
-
-    it("should stop at next higher-level heading", () => {
-      const markdown = `
-## Mode: Plan
-Planning content
-
-# Next Section
-Other content
-`.trim();
-
-      const result = extractModeSection(markdown, "plan");
-      expect(result).toBe("Planning content");
-    });
-
-    it("should include lower-level headings in section", () => {
-      const markdown = `
-# Mode: Plan
-Planning content
-
-## Subsection
-More details
-
-### Deep subsection
-Even more
-
-# Next Section
-Other content
-`.trim();
-
-      const result = extractModeSection(markdown, "plan");
-      expect(result).toContain("Planning content");
-      expect(result).toContain("## Subsection");
-      expect(result).toContain("More details");
-      expect(result).toContain("### Deep subsection");
-      expect(result).toContain("Even more");
-      expect(result).not.toContain("# Next Section");
-    });
-
-    it("should extract until end of file if no boundary heading", () => {
-      const markdown = `
-# Mode: Plan
-Planning content
-
-## Subsection
-More content
-
-Final paragraph
-`.trim();
-
-      const result = extractModeSection(markdown, "plan");
-      expect(result).toContain("Planning content");
-      expect(result).toContain("## Subsection");
-      expect(result).toContain("More content");
-      expect(result).toContain("Final paragraph");
-    });
-  });
-
-  describe("first match wins", () => {
-    it("should return only first matching section", () => {
-      const markdown = `
-# Mode: Plan
-First plan section
-
-# Other Section
-Other content
-
-# Mode: Plan
-Second plan section (should be ignored)
-`.trim();
-
-      const result = extractModeSection(markdown, "plan");
-      expect(result).toBe("First plan section");
-      expect(result).not.toContain("Second plan section");
-    });
-  });
-
-  describe("different modes", () => {
-    it("should extract exec mode section", () => {
-      const markdown = `
-# Mode: Plan
-Plan content
-
-# Mode: Exec
-Exec content
-
-# Mode: Review
-Review content
-`.trim();
-
-      const result = extractModeSection(markdown, "exec");
-      expect(result).toBe("Exec content");
-    });
-
-    it("should handle custom mode names", () => {
-      const markdown = "# Mode: Custom-Mode-Name\nCustom content";
-      const result = extractModeSection(markdown, "custom-mode-name");
-      expect(result).toBe("Custom content");
-    });
-  });
-
-  describe("edge cases", () => {
-    it("should trim whitespace from extracted content", () => {
-      const markdown = `
-# Mode: Plan
-
-
-Planning content with blank lines
-
-
-# Next Section
-`.trim();
-
-      const result = extractModeSection(markdown, "plan");
-      expect(result).toBe("Planning content with blank lines");
-    });
-
-    it("should return null for section with only whitespace", () => {
-      const markdown = `
-# Mode: Plan
-
-
-# Next Section
-`.trim();
-
-      const result = extractModeSection(markdown, "plan");
-      expect(result).toBeNull();
-    });
-
-    it("should handle sections with code blocks", () => {
-      const markdown = `
-# Mode: Plan
-Use this pattern:
-
-\`\`\`typescript
-const x = 1;
-\`\`\`
-
-# Next
-`.trim();
-
-      const result = extractModeSection(markdown, "plan");
-      expect(result).toContain("Use this pattern:");
-      expect(result).toContain("```typescript");
-      expect(result).toContain("const x = 1;");
-    });
-
-    it("should handle sections with lists", () => {
-      const markdown = `
-# Mode: Plan
-- Item 1
-- Item 2
-  - Nested item
-
-# Next
-`.trim();
-
-      const result = extractModeSection(markdown, "plan");
-      expect(result).toContain("- Item 1");
-      expect(result).toContain("- Item 2");
-      expect(result).toContain("- Nested item");
-    });
-  });
-});
+import { extractToolSection, stripScopedInstructionSections } from "./markdown";
 
 describe("extractToolSection", () => {
   describe("basic extraction", () => {
@@ -371,24 +111,6 @@ Second bash section (should be ignored)
 });
 
 describe("stripScopedInstructionSections", () => {
-  it("should strip Mode sections", () => {
-    const markdown = `
-# General
-General content
-
-# Mode: plan
-Plan content
-
-# More General
-More general content
-`.trim();
-
-    const result = stripScopedInstructionSections(markdown);
-    expect(result).toContain("General content");
-    expect(result).toContain("More general content");
-    expect(result).not.toContain("Plan content");
-  });
-
   it("should strip Model sections", () => {
     const markdown = `
 # General
@@ -425,13 +147,10 @@ More general content
     expect(result).not.toContain("Tool-specific content");
   });
 
-  it("should strip all scoped sections together", () => {
+  it("should strip Model and Tool sections together", () => {
     const markdown = `
 # General
 General content
-
-# Mode: plan
-Plan content
 
 # Model: gpt-4
 Model content
@@ -446,16 +165,34 @@ More general content
     const result = stripScopedInstructionSections(markdown);
     expect(result).toContain("General content");
     expect(result).toContain("More general content");
-    expect(result).not.toContain("Plan content");
     expect(result).not.toContain("Model content");
     expect(result).not.toContain("Tool content");
   });
 
+  it("should NOT strip Agent or Mode sections (no longer scoped)", () => {
+    const markdown = `
+# General
+General content
+
+# Agent: foo
+Agent content
+
+# Mode: plan
+Mode content
+
+# More General
+More general content
+`.trim();
+
+    const result = stripScopedInstructionSections(markdown);
+    expect(result).toContain("General content");
+    expect(result).toContain("More general content");
+    expect(result).toContain("Agent content");
+    expect(result).toContain("Mode content");
+  });
+
   it("should return empty string for markdown with only scoped sections", () => {
     const markdown = `
-# Mode: plan
-Plan content
-
 # Model: gpt-4
 Model content
 

--- a/src/node/utils/main/markdown.ts
+++ b/src/node/utils/main/markdown.ts
@@ -77,32 +77,6 @@ function removeSectionsByHeading(markdown: string, headingMatcher: HeadingMatche
 }
 
 /**
- * Extract the content under a heading titled "Mode: <mode>" (case-insensitive).
- */
-
-/**
- * Extract the content under a heading titled "Agent: <agentId>" (case-insensitive).
- */
-export function extractAgentSection(markdown: string, agentId: string): string | null {
-  if (!markdown || !agentId) return null;
-
-  const expectedHeading = `agent: ${agentId}`.toLowerCase();
-  return extractSectionByHeading(
-    markdown,
-    (headingText) => headingText.toLowerCase() === expectedHeading
-  );
-}
-export function extractModeSection(markdown: string, mode: string): string | null {
-  if (!markdown || !mode) return null;
-
-  const expectedHeading = `mode: ${mode}`.toLowerCase();
-  return extractSectionByHeading(
-    markdown,
-    (headingText) => headingText.toLowerCase() === expectedHeading
-  );
-}
-
-/**
  * Extract the first section whose heading matches "Model: <regex>" and whose regex matches
  * the provided model identifier. Matching is case-insensitive by default unless the regex
  * heading explicitly specifies flags via /pattern/flags syntax.
@@ -161,11 +135,6 @@ export function stripScopedInstructionSections(markdown: string): string {
 
   return removeSectionsByHeading(markdown, (headingText) => {
     const normalized = headingText.trim().toLowerCase();
-    return (
-      normalized.startsWith("agent:") ||
-      normalized.startsWith("mode:") ||
-      normalized.startsWith("model:") ||
-      normalized.startsWith("tool:")
-    );
+    return normalized.startsWith("model:") || normalized.startsWith("tool:");
   });
 }


### PR DESCRIPTION
## Summary

Removes `Agent:` and `Mode:` scoped instruction headings from AGENTS.md files. These features are redundant now that custom agent definitions provide a better mechanism for agent-specific behavior.

## Changes

- **Remove `Agent:` and `Mode:` scoped instructions** (breaking change)
  - `extractAgentSection()` and `extractModeSection()` removed from markdown.ts
  - `stripScopedInstructionSections()` now only strips `Model:` and `Tool:` headings
  - `buildSystemMessage()` signature simplified: `mode` parameter removed, `agentId` option removed
  - Documentation updated to point users to custom agent definitions

- **Remaining scoped instructions (`Model:` and `Tool:`) now work identically in AGENTS.md files AND custom agent definitions**
  - Agent definition body is processed for `Model:` and `Tool:` sections
  - Priority order: agent definition → workspace AGENTS.md → global AGENTS.md (first match wins)
  - Scoped sections are stripped from `<agent-instructions>` just like they are from `<custom-instructions>`
  - Documentation clarified to explain this parity

## Breaking Changes

- `Agent:` and `Mode:` headings in AGENTS.md files will no longer be extracted and injected as scoped sections
- These headings will now remain in `<custom-instructions>` if present (treated as regular markdown)
- Users relying on `Agent:` or `Mode:` scoped instructions should migrate to custom agent definitions

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_

