### PR TITLE
🤖 fix: accept longer ask_user_question headers

### DIFF
--- a/src/common/utils/tools/toolDefinitions.test.ts
+++ b/src/common/utils/tools/toolDefinitions.test.ts
@@ -24,6 +24,33 @@ describe("TOOL_DEFINITIONS", () => {
     );
   });
 
+  it("accepts ask_user_question headers longer than 12 characters", () => {
+    const parsed = TOOL_DEFINITIONS.ask_user_question.schema.safeParse({
+      questions: [
+        {
+          question: "How should docs be formatted?",
+          header: "Documentation",
+          options: [
+            { label: "Inline", description: "Explain in code comments" },
+            { label: "Sections", description: "Separate markdown sections" },
+          ],
+          multiSelect: false,
+        },
+        {
+          question: "Should we show error handling?",
+          header: "Error Handling",
+          options: [
+            { label: "Minimal", description: "Let errors bubble" },
+            { label: "Basic", description: "Catch common errors" },
+          ],
+          multiSelect: false,
+        },
+      ],
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
   it("rejects task(kind=bash) tool calls (bash is a separate tool)", () => {
     const parsed = TOOL_DEFINITIONS.task.schema.safeParse({
       // Legacy shape; should not validate against the current task schema.

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -32,7 +32,7 @@ export const AskUserQuestionOptionSchema = z
 export const AskUserQuestionQuestionSchema = z
   .object({
     question: z.string().min(1),
-    header: z.string().min(1).max(12),
+    header: z.string().min(1).max(32).describe("Short label shown in the UI (keep it concise)"),
     options: z.array(AskUserQuestionOptionSchema).min(2).max(4),
     multiSelect: z.boolean(),
   })


### PR DESCRIPTION
Fixes #1421.

The `ask_user_question` tool schema previously limited `questions[].header` to 12 characters, which caused first-attempt tool calls to fail when models generated reasonable labels like "Documentation" or "Error Handling".

This relaxes the limit to 32 characters and adds a regression test.

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh`_
