### PR TITLE
🤖 feat: signing badge warning state for passphrase-protected keys

### DIFF
--- a/src/browser/stories/App.chat.stories.tsx
+++ b/src/browser/stories/App.chat.stories.tsx
@@ -22,6 +22,7 @@ import { updatePersistedState } from "@/browser/hooks/usePersistedState";
 import { getModelKey } from "@/common/constants/storage";
 import { setupSimpleChatStory, setupStreamingChatStory, setWorkspaceInput } from "./storyHelpers";
 import { within, userEvent, waitFor } from "@storybook/test";
+import { warmHashCache, setShareData } from "@/browser/utils/sharedUrlCache";
 
 export default {
   ...appMeta,
@@ -1330,6 +1331,97 @@ graph TD
           "Shows the ProposePlanToolCall component with a completed plan. " +
           "The plan card displays with the title in the header and icon action buttons " +
           "(Copy, Start Here, Show Text) at the bottom, matching the AssistantMessage aesthetic.",
+      },
+    },
+  },
+};
+
+// Message content used in SigningBadgePassphraseWarning story
+const SIGNING_WARNING_MESSAGE_CONTENT = "Hello! How can I help you today?";
+
+/**
+ * Story showing the signing badge in warning state when key requires passphrase.
+ * The signing badge displays yellow when a compatible key exists but is passphrase-protected.
+ */
+export const SigningBadgePassphraseWarning: AppStory = {
+  // Use loaders to pre-warm hash cache before component mounts (fixes race condition)
+  loaders: [
+    async () => {
+      // Warm the hash cache to ensure consistent hashing
+      await warmHashCache(SIGNING_WARNING_MESSAGE_CONTENT);
+      // Now set share data with the warmed hash
+      setShareData(SIGNING_WARNING_MESSAGE_CONTENT, {
+        url: "https://mux.md/story-test#fake-key",
+        id: "story-share-id",
+        mutateKey: "story-mutate-key",
+        expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000, // 7 days
+        signed: false,
+      });
+      return {};
+    },
+  ],
+  render: () => (
+    <AppWithMocks
+      setup={() =>
+        setupSimpleChatStory({
+          workspaceId: "ws-signing-warning",
+          messages: [
+            createUserMessage("msg-1", "Hello", {
+              historySequence: 1,
+              timestamp: STABLE_TIMESTAMP - 300000,
+            }),
+            createAssistantMessage("msg-2", SIGNING_WARNING_MESSAGE_CONTENT, {
+              historySequence: 2,
+              timestamp: STABLE_TIMESTAMP - 290000,
+            }),
+          ],
+          signingCapabilities: {
+            publicKey: null,
+            githubUser: null,
+            error: {
+              message:
+                "Signing key requires a passphrase. Create an unencrypted key at ~/.mux/message_signing_key or use ssh-add.",
+              hasEncryptedKey: true,
+            },
+          },
+        })
+      }
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const storyRoot = document.getElementById("storybook-root") ?? canvasElement;
+    const canvas = within(storyRoot);
+
+    // Wait for the assistant message to appear
+    await canvas.findByText(SIGNING_WARNING_MESSAGE_CONTENT, {}, { timeout: 5000 });
+
+    // Wait for React to finish any pending updates after rendering
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+
+    // Find and click the Share button (should show "Already shared" due to loader)
+    const shareButton = await canvas.findByLabelText("Already shared", {}, { timeout: 3000 });
+
+    // Wait a bit for button to be fully interactive
+    await new Promise((r) => setTimeout(r, 100));
+    await userEvent.click(shareButton);
+
+    // Wait for the popover to open (renders in a portal, so search document)
+    await waitFor(
+      () => {
+        const popover = document.querySelector('[role="dialog"]');
+        if (!popover) throw new Error("Share popover not found");
+      },
+      { timeout: 5000 }
+    );
+
+    // Allow the signing badge to render with its warning state
+    await new Promise((r) => setTimeout(r, 200));
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Shows the signing badge in warning state (yellow) when a signing key exists but is passphrase-protected.",
       },
     },
   },

--- a/src/browser/stories/mocks/orpc.ts
+++ b/src/browser/stories/mocks/orpc.ts
@@ -132,6 +132,12 @@ export interface MockORPCClientOptions {
   }) => Promise<{ success: true } | { success: false; error: string }>;
   /** Idle compaction hours per project (null = disabled) */
   idleCompactionHours?: Map<string, number | null>;
+  /** Override signing capabilities response */
+  signingCapabilities?: {
+    publicKey: string | null;
+    githubUser: string | null;
+    error: { message: string; hasEncryptedKey: boolean } | null;
+  };
 }
 
 interface MockBackgroundProcess {
@@ -198,6 +204,7 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
     agentDefinitions: initialAgentDefinitions,
     listBranches: customListBranches,
     gitInit: customGitInit,
+    signingCapabilities: customSigningCapabilities,
   } = options;
 
   // Feature flags
@@ -317,12 +324,13 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
     },
     signing: {
       capabilities: () =>
-        Promise.resolve({
-          publicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMockKey",
-          githubUser: "mockuser",
-          email: "mockuser@example.com",
-          error: null,
-        }),
+        Promise.resolve(
+          customSigningCapabilities ?? {
+            publicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMockKey",
+            githubUser: "mockuser",
+            error: null,
+          }
+        ),
       sign: () =>
         Promise.resolve({
           signature: "mockSignature==",

--- a/src/browser/stories/storyHelpers.ts
+++ b/src/browser/stories/storyHelpers.ts
@@ -252,6 +252,12 @@ export interface SimpleChatSetupOptions {
   onChat?: (workspaceId: string, emit: (msg: WorkspaceChatMessage) => void) => void;
   /** Idle compaction hours for context meter (null = disabled) */
   idleCompactionHours?: number | null;
+  /** Override signing capabilities (for testing warning states) */
+  signingCapabilities?: {
+    publicKey: string | null;
+    githubUser: string | null;
+    error: { message: string; hasEncryptedKey: boolean } | null;
+  };
 }
 
 /**
@@ -320,6 +326,7 @@ export function setupSimpleChatStory(opts: SimpleChatSetupOptions): APIClient {
     statsTabVariant: opts.statsTabEnabled ? "stats" : "control",
     sessionUsage: sessionUsageMap,
     idleCompactionHours,
+    signingCapabilities: opts.signingCapabilities,
   });
 }
 

--- a/src/browser/utils/sharedUrlCache.ts
+++ b/src/browser/utils/sharedUrlCache.ts
@@ -83,6 +83,18 @@ function entryKey(hash: string): string {
 }
 
 /**
+ * Pre-warm the hash cache for content.
+ * Ensures consistent hashing between setShareData and getShareData calls
+ * by waiting for the async SHA-256 computation to complete.
+ */
+export async function warmHashCache(content: string): Promise<void> {
+  // Trigger the fallback hash (which kicks off async SHA-256)
+  hashContent(content);
+  // Wait for async hash to complete and populate cache
+  await hashContentAsync(content);
+}
+
+/**
  * Get the cached share data for content, if it exists and hasn't expired.
  */
 export function getShareData(content: string): ShareData | undefined {

--- a/src/common/orpc/schemas/signing.ts
+++ b/src/common/orpc/schemas/signing.ts
@@ -11,13 +11,20 @@ import { z } from "zod";
 
 export const signingCapabilitiesInput = z.object({});
 
+export const signingErrorOutput = z.object({
+  /** Error message */
+  message: z.string(),
+  /** True if a compatible key was found but requires a passphrase */
+  hasEncryptedKey: z.boolean(),
+});
+
 export const signingCapabilitiesOutput = z.object({
   /** Public key in OpenSSH format (ssh-ed25519 AAAA...), null if no Ed25519 key found */
   publicKey: z.string().nullable(),
   /** Detected GitHub username, if any */
   githubUser: z.string().nullable(),
-  /** Error message if key loading or identity detection failed */
-  error: z.string().nullable(),
+  /** Error info if key loading or identity detection failed */
+  error: signingErrorOutput.nullable(),
 });
 
 export type SigningCapabilities = z.infer<typeof signingCapabilitiesOutput>;


### PR DESCRIPTION
## Summary

When a signing key exists but requires a passphrase, the signing badge now displays in a warning state (yellow) instead of the normal muted state. The tooltip explains the issue and provides remediation steps.

## Changes

- **SigningService**: Track `hasEncryptedKey` state when parsing fails due to encryption/passphrase, return structured error with this flag
- **Schema**: Nest `hasEncryptedKey` under `error` object as a sub-field
- **SigningBadge UI**: Add yellow warning color and specific message for encrypted key scenario
- **Tests**: Add test cases for encrypted key detection and fallback
- **Storybook**: Add `SigningBadgePassphraseWarning` story to capture the UI

## Behavior

| State | Icon Color | Tooltip Message |
|-------|-----------|-----------------|
| Signed/enabled with key | Blue | "✓ Signed" or "Signing enabled" |
| Encrypted key found (no usable key) | Yellow | "⚠ Key requires passphrase" + instructions |
| No key found | Muted/gray | "Signing disabled" |

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
