### PR TITLE
🤖 feat: add mux-docs built-in skill with auto-generated docs index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,9 @@ test_hot_reload.sh
 
 # mdBook auto-generated assets
 docs/theme/pagetoc.css
+
+# Build-time generated files
+*.generated.ts
 docs/theme/pagetoc.js
 mobile/.expo/
 .mux/mcp.jsonc

--- a/fmt.mk
+++ b/fmt.mk
@@ -95,6 +95,8 @@ endif
 
 fmt-sync-docs:
 	@bun scripts/gen_docs.ts
+	@bun scripts/gen_builtin_skills.ts --sync-mux-docs-skill
 
 fmt-sync-docs-check:
 	@bun scripts/gen_docs.ts check
+	@bun scripts/gen_builtin_skills.ts check --sync-mux-docs-skill

--- a/scripts/check-code-docs-links.sh
+++ b/scripts/check-code-docs-links.sh
@@ -37,9 +37,10 @@ while IFS= read -r url; do
   check_path "$path" "README.md"
 done < <(grep -oP "https://mux\.coder\.com[^\s\)\"']*" README.md 2>/dev/null || true)
 
-# Extract from source files (URLs) - skip gateway URLs
+# Extract from source files (URLs) - skip gateway URLs and generated files
 while IFS=: read -r file line url; do
   [[ "$url" == *"gateway."* ]] && continue
+  [[ "$file" == *.generated.ts ]] && continue
   path="${url#$DOCS_BASE}"
   check_path "$path" "$file:$line"
 done < <(grep -rn --include="*.ts" --include="*.tsx" -oP "https://mux\.coder\.com[^\s\)\"']*" src/ 2>/dev/null || true)

--- a/scripts/gen_builtin_skills.ts
+++ b/scripts/gen_builtin_skills.ts
@@ -1,0 +1,373 @@
+#!/usr/bin/env bun
+/**
+ * Generate built-in agent skills content.
+ *
+ * Usage:
+ *   bun scripts/gen_builtin_skills.ts         # write mode
+ *   bun scripts/gen_builtin_skills.ts check   # check mode
+ *
+ * This script writes:
+ *   - src/node/services/agentSkills/builtInSkillContent.generated.ts
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as prettier from "prettier";
+import * as yaml from "yaml";
+
+const ARGS = new Set(process.argv.slice(2));
+const MODE = ARGS.has("check") ? "check" : "write";
+const SYNC_MUX_DOCS_SKILL = ARGS.has("--sync-mux-docs-skill");
+
+const PROJECT_ROOT = path.join(import.meta.dir, "..");
+const BUILTIN_SKILLS_DIR = path.join(PROJECT_ROOT, "src", "node", "builtinSkills");
+const DOCS_DIR = path.join(PROJECT_ROOT, "docs");
+const OUTPUT_PATH = path.join(
+  PROJECT_ROOT,
+  "src",
+  "node",
+  "services",
+  "agentSkills",
+  "builtInSkillContent.generated.ts"
+);
+
+function normalizeNewlines(input: string): string {
+  return input.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function readFileLines(filePath: string): string[] {
+  return normalizeNewlines(fs.readFileSync(filePath, "utf-8")).split("\n");
+}
+
+
+function oneLine(input: string): string {
+  return input.replace(/\s+/g, " ").trim();
+}
+
+function injectBetweenHtmlCommentMarkers(content: string, markerName: string, block: string): string {
+  const beginMarker = `<!-- BEGIN ${markerName} -->`;
+  const endMarker = `<!-- END ${markerName} -->`;
+
+  const beginIdx = content.indexOf(beginMarker);
+  const endIdx = content.indexOf(endMarker);
+
+  if (beginIdx === -1 || endIdx === -1 || endIdx < beginIdx) {
+    throw new Error(`Missing markers for ${markerName}`);
+  }
+
+  const before = content.slice(0, beginIdx + beginMarker.length);
+  const after = content.slice(endIdx);
+
+  const trimmedBlock = block.trimEnd();
+  return `${before}\n${trimmedBlock}\n${after}`;
+}
+
+function parseYamlFrontmatter(content: string): Record<string, unknown> | null {
+  const normalized = normalizeNewlines(content);
+  if (!normalized.startsWith("---\n")) return null;
+
+  const lines = normalized.split("\n");
+  const endIndex = lines.findIndex((line, idx) => idx > 0 && line.trim() === "---");
+  if (endIndex === -1) return null;
+
+  const yamlText = lines.slice(1, endIndex).join("\n");
+  const parsed = yaml.parse(yamlText);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  return parsed as Record<string, unknown>;
+}
+
+function extractDocMeta(content: string): { title?: string; description?: string } {
+  const fm = parseYamlFrontmatter(content);
+  if (!fm) return {};
+
+  const title = typeof fm.title === "string" ? oneLine(fm.title) : undefined;
+  const description = typeof fm.description === "string" ? oneLine(fm.description) : undefined;
+  return { title, description };
+}
+
+function routeForDocsPage(page: string): string {
+  return page === "index" ? "/" : `/${page}`;
+}
+function posixPath(input: string): string {
+  return input.split(path.sep).join(path.posix.sep);
+}
+
+function extractDocsPagesFromNav(node: unknown, out: string[], seen: Set<string>): void {
+  if (typeof node === "string") {
+    if (!seen.has(node)) {
+      seen.add(node);
+      out.push(node);
+    }
+    return;
+  }
+
+  if (!node || typeof node !== "object") return;
+
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      extractDocsPagesFromNav(item, out, seen);
+    }
+    return;
+  }
+
+  const anyNode = node as Record<string, unknown>;
+  if (Array.isArray(anyNode.groups)) {
+    extractDocsPagesFromNav(anyNode.groups, out, seen);
+  }
+  if (Array.isArray(anyNode.pages)) {
+    extractDocsPagesFromNav(anyNode.pages, out, seen);
+  }
+}
+
+
+interface DocsPageInfo {
+  page: string;
+  route: string;
+  referencePath: string;
+  title: string;
+  description?: string;
+}
+
+function renderDocsTreeNode(
+  node: unknown,
+  indent: number,
+  lines: string[],
+  pageInfoByPage: Map<string, DocsPageInfo>
+): void {
+  const prefix = "  ".repeat(indent);
+
+  if (typeof node === "string") {
+    const info = pageInfoByPage.get(node);
+    if (!info) {
+      throw new Error(`Missing docs page info for '${node}'`);
+    }
+
+    const suffix = info.description ? ` — ${info.description}` : "";
+    lines.push(
+      `${prefix}- ${info.title} (\`${info.route}\`) → \`${info.referencePath}\`${suffix}`
+    );
+    return;
+  }
+
+  if (!node || typeof node !== "object") return;
+
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      renderDocsTreeNode(item, indent, lines, pageInfoByPage);
+    }
+    return;
+  }
+
+  const anyNode = node as Record<string, unknown>;
+
+  if (typeof anyNode.tab === "string" && Array.isArray(anyNode.groups)) {
+    lines.push(`${prefix}- **${anyNode.tab}**`);
+    renderDocsTreeNode(anyNode.groups, indent + 1, lines, pageInfoByPage);
+    return;
+  }
+
+  if (typeof anyNode.group === "string" && Array.isArray(anyNode.pages)) {
+    lines.push(`${prefix}- **${anyNode.group}**`);
+    renderDocsTreeNode(anyNode.pages, indent + 1, lines, pageInfoByPage);
+    return;
+  }
+
+  // Fallback: recurse into known containers.
+  if (Array.isArray(anyNode.groups)) {
+    renderDocsTreeNode(anyNode.groups, indent, lines, pageInfoByPage);
+  }
+  if (Array.isArray(anyNode.pages)) {
+    renderDocsTreeNode(anyNode.pages, indent, lines, pageInfoByPage);
+  }
+}
+
+function renderDocsTree(docsJson: unknown, pageInfoByPage: Map<string, DocsPageInfo>): string {
+  const tabs = (docsJson as any)?.navigation?.tabs;
+  if (!Array.isArray(tabs)) {
+    throw new Error("docs/docs.json: expected navigation.tabs array");
+  }
+
+  const lines: string[] = [];
+  for (const tab of tabs) {
+    renderDocsTreeNode(tab, 0, lines, pageInfoByPage);
+  }
+
+  return lines.join("\n");
+}
+function extractDocsPages(docsJson: unknown): string[] {
+  const tabs = (docsJson as any)?.navigation?.tabs;
+  if (!Array.isArray(tabs)) {
+    throw new Error("docs/docs.json: expected navigation.tabs array");
+  }
+
+  const pages: string[] = [];
+  const seen = new Set<string>();
+  for (const tab of tabs) {
+    extractDocsPagesFromNav((tab as any)?.groups, pages, seen);
+  }
+  return pages;
+}
+
+function resolveDocsPageFilePath(page: string): string {
+  const candidates = [
+    path.join(DOCS_DIR, `${page}.mdx`),
+    path.join(DOCS_DIR, `${page}.md`),
+    path.join(DOCS_DIR, page, "index.mdx"),
+    path.join(DOCS_DIR, page, "index.md"),
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+
+  throw new Error(`docs/docs.json references '${page}' but no file found under docs/`);
+}
+
+
+interface GenerateResult {
+  output: string;
+  muxDocsSkillWasUpdated: boolean;
+  muxDocsSkillOutOfSync: boolean;
+}
+function renderJoinedLines(lines: string[], indent: string): string {
+  const innerIndent = indent + "  ";
+  const rendered = lines.map((line) => `${innerIndent}${JSON.stringify(line)},`).join("\n");
+  return `[\n${rendered}\n${indent}].join(\"\\n\")`;
+}
+
+function generate(): GenerateResult {
+  const skills = fs
+    .readdirSync(BUILTIN_SKILLS_DIR)
+    .filter((entry) => entry.endsWith(".md"))
+    .sort((a, b) => a.localeCompare(b));
+
+  const fileMaps: Record<string, Record<string, string[]>> = {};
+
+  let muxDocsSkillWasUpdated = false;
+  let muxDocsSkillOutOfSync = false;
+
+  for (const filename of skills) {
+    const skillName = filename.slice(0, -3);
+    const skillPath = path.join(BUILTIN_SKILLS_DIR, filename);
+
+    const skillContent = normalizeNewlines(fs.readFileSync(skillPath, "utf-8"));
+
+    const files: Record<string, string[]> = {
+      "SKILL.md": skillContent.split("\n"),
+    };
+
+    // mux-docs: embed docs site content as progressive-disclosure reference files.
+    if (skillName === "mux-docs") {
+      const docsConfigPath = path.join(DOCS_DIR, "docs.json");
+      const docsConfigRaw = fs.readFileSync(docsConfigPath, "utf-8");
+      files["references/docs/docs.json"] = readFileLines(docsConfigPath);
+
+      const docsConfig = JSON.parse(docsConfigRaw);
+      const pages = extractDocsPages(docsConfig);
+
+      const pageInfoByPage = new Map<string, DocsPageInfo>();
+
+      for (const page of pages) {
+        const resolvedPath = resolveDocsPageFilePath(page);
+        const rel = posixPath(path.relative(DOCS_DIR, resolvedPath));
+        const key = `references/docs/${rel}`;
+
+        const docLines = readFileLines(resolvedPath);
+        files[key] = docLines;
+
+        const meta = extractDocMeta(docLines.join("\n"));
+        pageInfoByPage.set(page, {
+          page,
+          route: routeForDocsPage(page),
+          referencePath: key,
+          title: meta.title ?? page,
+          description: meta.description,
+        });
+      }
+
+      const docsTree = renderDocsTree(docsConfig, pageInfoByPage);
+      const updatedSkillContent = injectBetweenHtmlCommentMarkers(skillContent, "DOCS_TREE", docsTree);
+      files["SKILL.md"] = updatedSkillContent.split("\n");
+
+      if (SYNC_MUX_DOCS_SKILL && updatedSkillContent !== skillContent) {
+        if (MODE === "check") {
+          muxDocsSkillOutOfSync = true;
+        } else {
+          fs.writeFileSync(skillPath, updatedSkillContent, "utf-8");
+          muxDocsSkillWasUpdated = true;
+        }
+      }
+    }
+
+    fileMaps[skillName] = files;
+  }
+
+  let output = "";
+  output += "// AUTO-GENERATED - DO NOT EDIT\n";
+  output += "// Run: bun scripts/gen_builtin_skills.ts\n";
+  output += "// Source: src/node/builtinSkills/*.md and docs/\n\n";
+  output += "export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {\n";
+
+  const sortedSkillNames = Object.keys(fileMaps).sort((a, b) => a.localeCompare(b));
+  for (const skillName of sortedSkillNames) {
+    output += `  ${JSON.stringify(skillName)}: {\n`;
+    const files = fileMaps[skillName] ?? {};
+    for (const filePath of Object.keys(files).sort((a, b) => a.localeCompare(b))) {
+      output += `    ${JSON.stringify(filePath)}: ${renderJoinedLines(files[filePath]!, "    ")},\n`;
+    }
+    output += "  },\n";
+  }
+
+  output += "};\n";
+
+  return { output, muxDocsSkillWasUpdated, muxDocsSkillOutOfSync };
+}
+
+async function main(): Promise<void> {
+  const { output: raw, muxDocsSkillWasUpdated, muxDocsSkillOutOfSync } = generate();
+
+  const prettierConfig = await prettier.resolveConfig(OUTPUT_PATH);
+  const formatted = await prettier.format(raw, {
+    ...prettierConfig,
+    filepath: OUTPUT_PATH,
+  });
+
+  const current = fs.existsSync(OUTPUT_PATH) ? fs.readFileSync(OUTPUT_PATH, "utf-8") : null;
+  const outputOutOfSync = current !== formatted;
+
+  const muxDocsSkillPath = path.join(BUILTIN_SKILLS_DIR, "mux-docs.md");
+
+  if (MODE === "check") {
+    if (!outputOutOfSync && !muxDocsSkillOutOfSync) {
+      console.log(`✓ ${path.relative(PROJECT_ROOT, OUTPUT_PATH)} is up-to-date`);
+      return;
+    }
+
+    if (muxDocsSkillOutOfSync) {
+      console.error(`✗ ${path.relative(PROJECT_ROOT, muxDocsSkillPath)} is out of sync`);
+    }
+
+    if (outputOutOfSync) {
+      console.error(`✗ ${path.relative(PROJECT_ROOT, OUTPUT_PATH)} is out of sync`);
+    }
+
+    console.error("  Run 'make fmt' to regenerate.");
+    process.exit(1);
+  }
+
+  if (outputOutOfSync) {
+    fs.writeFileSync(OUTPUT_PATH, formatted, "utf-8");
+    console.log(`✓ Updated ${path.relative(PROJECT_ROOT, OUTPUT_PATH)}`);
+  } else {
+    console.log(`✓ ${path.relative(PROJECT_ROOT, OUTPUT_PATH)} is up-to-date`);
+  }
+
+  if (muxDocsSkillWasUpdated) {
+    console.log(`✓ Updated ${path.relative(PROJECT_ROOT, muxDocsSkillPath)}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/generate-builtin-skills.sh
+++ b/scripts/generate-builtin-skills.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Generate src/node/services/agentSkills/builtInSkillContent.generated.ts
+
+set -euo pipefail
+
+bun scripts/gen_builtin_skills.ts
+
+echo "Generated src/node/services/agentSkills/builtInSkillContent.generated.ts"

--- a/src/common/orpc/schemas/agentSkill.ts
+++ b/src/common/orpc/schemas/agentSkill.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const AgentSkillScopeSchema = z.enum(["project", "global"]);
+export const AgentSkillScopeSchema = z.enum(["project", "global", "built-in"]);
 
 /**
  * Skill name per agentskills.io

--- a/src/node/builtinSkills/mux-docs.md
+++ b/src/node/builtinSkills/mux-docs.md
@@ -1,0 +1,123 @@
+---
+name: mux-docs
+description: Index + offline snapshot of mux documentation (progressive disclosure).
+---
+
+# mux docs
+
+This built-in skill helps the agent answer questions about **mux** (Coding Agent Multiplexer) without dumping the entire docs into context.
+
+## How to use
+
+### Prefer: read the bundled docs snapshot (recommended)
+
+This skill bundles an **offline snapshot of the mux docs** under `references/docs/`.
+
+Why prefer the bundled snapshot?
+
+1. The docs tree below is guaranteed to match what’s embedded.
+2. It’s more likely to match *your installed mux version* (the live site may be ahead).
+
+To read a specific page:
+
+```ts
+agent_skill_read_file({
+  name: "mux-docs",
+  filePath: "references/docs/config/models.mdx",
+});
+```
+
+### Fallback: fetch the live docs (for newer features)
+
+If the bundled docs don’t mention something (or you suspect the docs site has newer info), use `web_fetch`:
+
+```ts
+web_fetch({ url: "https://mux.coder.com/config/models" });
+web_fetch({ url: "https://mux.coder.com/agents" });
+```
+
+#### Docs tree (auto-generated)
+
+Use this index to find a page's:
+
+- **Docs route** (for `web_fetch`)
+- **Embedded file path** (for `agent_skill_read_file`)
+
+<!-- BEGIN DOCS_TREE -->
+- **Documentation**
+  - **Getting Started**
+    - Introduction (`/`) → `references/docs/index.mdx` — mux - Coding Agent Multiplexer for AI-assisted development
+    - Install (`/install`) → `references/docs/install.mdx` — Download and install mux for macOS, Linux, and Windows
+    - Why Parallelize? (`/getting-started/why-parallelize`) → `references/docs/getting-started/why-parallelize.mdx` — Use cases for running multiple AI agents in parallel
+    - Mux Codes (`/getting-started/mux-codes`) → `references/docs/getting-started/mux-codes.mdx` — Redeem free LLM token credits for evaluating Mux
+  - **Workspaces**
+    - Workspaces (`/workspaces`) → `references/docs/workspaces/index.mdx` — Isolated development environments for parallel agent work
+    - Forking Workspaces (`/workspaces/fork`) → `references/docs/workspaces/fork.mdx` — Clone workspaces with conversation history to explore alternatives
+    - **Runtimes**
+      - Runtimes (`/runtime`) → `references/docs/runtime/index.mdx` — Configure where and how mux executes agent workspaces
+      - Local Runtime (`/runtime/local`) → `references/docs/runtime/local.mdx` — Run agents directly in your project directory
+      - Worktree Runtime (`/runtime/worktree`) → `references/docs/runtime/worktree.mdx` — Isolated git worktree environments for parallel agent work
+      - SSH Runtime (`/runtime/ssh`) → `references/docs/runtime/ssh.mdx` — Run agents on remote hosts over SSH for security and performance
+    - **Hooks**
+      - Init Hooks (`/hooks/init`) → `references/docs/hooks/init.mdx` — Run setup commands automatically when creating new workspaces
+      - Tool Hooks (`/hooks/tools`) → `references/docs/hooks/tools.mdx` — Block dangerous commands, lint after edits, and set up your environment
+  - **Agents**
+    - Agents (`/agents`) → `references/docs/agents/index.mdx` — Define custom agents (modes + subagents) with Markdown files
+    - Instruction Files (`/agents/instruction-files`) → `references/docs/agents/instruction-files.mdx` — Configure agent behavior with AGENTS.md files
+    - Agent Skills (`/agents/agent-skills`) → `references/docs/agents/agent-skills.mdx` — Share reusable workflows and references with skills
+    - Plan Mode (`/agents/plan-mode`) → `references/docs/agents/plan-mode.mdx` — Review and collaborate on plans before execution
+    - System Prompt (`/agents/system-prompt`) → `references/docs/agents/system-prompt.mdx` — How mux constructs the system prompt for AI models
+  - **Configuration**
+    - Models (`/config/models`) → `references/docs/config/models.mdx` — Configure AI providers including Anthropic, OpenAI, Google, xAI, DeepSeek, and more
+    - MCP Servers (`/config/mcp-servers`) → `references/docs/config/mcp-servers.mdx` — Extend agent capabilities with Model Context Protocol servers
+    - Project Secrets (`/config/project-secrets`) → `references/docs/config/project-secrets.mdx` — Manage environment variables and API keys for your projects
+    - Agentic Git Identity (`/config/agentic-git-identity`) → `references/docs/config/agentic-git-identity.mdx` — Configure a separate Git identity for AI-generated commits
+    - Keyboard Shortcuts (`/config/keybinds`) → `references/docs/config/keybinds.mdx` — Complete keyboard shortcut reference for mux
+    - Notifications (`/config/notifications`) → `references/docs/config/notifications.mdx` — Configure how agents notify you about important events
+  - **Guides**
+    - Command Line Interface (`/guides/cli`) → `references/docs/guides/cli.mdx` — Run one-off agent tasks from the command line with mux run
+    - Context Management (`/guides/context-management`) → `references/docs/guides/context-management.mdx` — Commands for managing conversation history and token usage
+    - Message Sharing (`/guides/sharing`) → `references/docs/guides/sharing.mdx` — Share encrypted messages with cryptographic signatures via mux.md
+    - Prompting Tips (`/guides/prompting-tips`) → `references/docs/guides/prompting-tips.mdx` — Tips and tricks for getting the most out of your AI agents
+    - Vim Mode (`/guides/vim-mode`) → `references/docs/guides/vim-mode.mdx` — Vim-style editing in the mux chat input
+  - **Integrations**
+    - VS Code Extension (`/integrations/vscode-extension`) → `references/docs/integrations/vscode-extension.mdx` — Pair mux workspaces with VS Code and Cursor editors
+  - **Reference**
+    - Telemetry (`/reference/telemetry`) → `references/docs/reference/telemetry.mdx` — What mux collects, what it doesn’t, and how to disable it
+    - Storybook (`/reference/storybook`) → `references/docs/reference/storybook.mdx` — Develop and test mux UI states in isolation
+    - Terminal Benchmarking (`/reference/benchmarking`) → `references/docs/reference/benchmarking.mdx` — Run Terminal-Bench benchmarks with the mux adapter
+    - AGENTS.md (`/AGENTS`) → `references/docs/AGENTS.md` — Agent instructions for AI assistants working on the mux codebase
+<!-- END DOCS_TREE -->
+
+1. Read the docs navigation (source of truth for which pages exist):
+
+```ts
+agent_skill_read_file({ name: "mux-docs", filePath: "references/docs/docs.json" });
+```
+
+2. Read a specific page by path (mirrors `docs/` in the mux repo):
+
+- `/agents` → `references/docs/agents/index.mdx`
+- `/config/models` → `references/docs/config/models.mdx`
+- `/runtime` → `references/docs/runtime/index.mdx`
+
+```ts
+agent_skill_read_file({
+  name: "mux-docs",
+  filePath: "references/docs/config/models.mdx",
+});
+```
+
+Notes:
+
+- Many pages are `.mdx`; some are `.../index.mdx`.
+- Images are not embedded; you may see `/img/...` references.
+
+## When to use
+
+Use this skill when the user asks how mux works (workspaces, runtimes, agents, models, hooks, keybinds, etc.).
+
+## Links
+
+- **GitHub**: https://github.com/coder/mux
+- **Documentation**: https://mux.coder.com

--- a/src/node/services/agentSkills/builtInSkillDefinitions.ts
+++ b/src/node/services/agentSkills/builtInSkillDefinitions.ts
@@ -1,0 +1,126 @@
+import * as path from "node:path";
+
+import type { AgentSkillDescriptor, AgentSkillPackage, SkillName } from "@/common/types/agentSkill";
+import { parseSkillMarkdown } from "./parseSkillMarkdown";
+import { BUILTIN_SKILL_FILES } from "./builtInSkillContent.generated";
+
+/**
+ * Built-in skill definitions.
+ *
+ * Source of truth is:
+ * - src/node/builtinSkills/*.md (SKILL.md content)
+ * - docs/ (embedded for mux-docs)
+ *
+ * Content is generated into builtInSkillContent.generated.ts via scripts/gen_builtin_skills.ts.
+ */
+
+interface BuiltInSource {
+  name: SkillName;
+  files: Record<string, string>;
+}
+
+const BUILT_IN_SOURCES: BuiltInSource[] = Object.entries(BUILTIN_SKILL_FILES).map(
+  ([name, files]) => ({ name, files })
+);
+
+let cachedPackages: AgentSkillPackage[] | null = null;
+
+function parseBuiltIns(): AgentSkillPackage[] {
+  return BUILT_IN_SOURCES.map(({ name, files }) => {
+    const content = files["SKILL.md"];
+    if (content === undefined) {
+      throw new Error(`Built-in skill '${name}' is missing SKILL.md`);
+    }
+
+    const parsed = parseSkillMarkdown({
+      content,
+      byteSize: Buffer.byteLength(content, "utf8"),
+      directoryName: name,
+    });
+
+    return {
+      scope: "built-in" as const,
+      directoryName: name,
+      frontmatter: parsed.frontmatter,
+      body: parsed.body.trim(),
+    };
+  });
+}
+
+export function getBuiltInSkillDefinitions(): AgentSkillPackage[] {
+  cachedPackages ??= parseBuiltIns();
+  return cachedPackages;
+}
+
+export function getBuiltInSkillDescriptors(): AgentSkillDescriptor[] {
+  return getBuiltInSkillDefinitions().map((pkg) => ({
+    name: pkg.frontmatter.name,
+    description: pkg.frontmatter.description,
+    scope: pkg.scope,
+  }));
+}
+
+export function getBuiltInSkillByName(name: SkillName): AgentSkillPackage | undefined {
+  return getBuiltInSkillDefinitions().find((pkg) => pkg.frontmatter.name === name);
+}
+
+function isAbsolutePathAny(filePath: string): boolean {
+  if (filePath.startsWith("/") || filePath.startsWith("\\")) return true;
+
+  // Windows drive letter paths (e.g., C:\foo or C:/foo)
+  if (/^[A-Za-z]:/.test(filePath)) {
+    const sep = filePath[2];
+    return sep === "\\" || sep === "/";
+  }
+
+  return false;
+}
+
+function normalizeBuiltInSkillFilePath(filePath: string): string {
+  if (!filePath) {
+    throw new Error("filePath is required");
+  }
+
+  // Disallow absolute paths and home-relative paths.
+  if (isAbsolutePathAny(filePath) || filePath.startsWith("~")) {
+    throw new Error(`Invalid filePath (must be relative to the skill directory): ${filePath}`);
+  }
+
+  // Always normalize with posix separators (built-in skill file paths are stored posix-style).
+  const normalized = path.posix.normalize(filePath.replaceAll("\\", "/"));
+  const stripped = normalized.startsWith("./") ? normalized.slice(2) : normalized;
+
+  if (stripped === "" || stripped === "." || stripped.endsWith("/")) {
+    throw new Error(`Invalid filePath (expected a file, got directory): ${filePath}`);
+  }
+
+  if (stripped === ".." || stripped.startsWith("../")) {
+    throw new Error(`Invalid filePath (path traversal): ${filePath}`);
+  }
+
+  return stripped;
+}
+
+export function readBuiltInSkillFile(
+  name: SkillName,
+  filePath: string
+): { resolvedPath: string; content: string } {
+  const resolvedPath = normalizeBuiltInSkillFilePath(filePath);
+
+  const skillFiles = BUILTIN_SKILL_FILES[name];
+  if (!skillFiles) {
+    throw new Error(`Built-in skill not found: ${name}`);
+  }
+
+  const content = skillFiles[resolvedPath];
+  if (content === undefined) {
+    throw new Error(`Built-in skill file not found: ${name}/${resolvedPath}`);
+  }
+
+  return { resolvedPath, content };
+}
+
+/** Exposed for testing - clears cached parsed packages */
+export function clearBuiltInSkillCache(): void {
+  cachedPackages = null;
+}

--- a/src/node/services/tools/agent_skill_read_file.ts
+++ b/src/node/services/tools/agent_skill_read_file.ts
@@ -8,10 +8,86 @@ import {
   readAgentSkill,
   resolveAgentSkillFilePath,
 } from "@/node/services/agentSkills/agentSkillsService";
-import { validateFileSize } from "@/node/services/tools/fileCommon";
+import { MAX_FILE_SIZE, validateFileSize } from "@/node/services/tools/fileCommon";
+import { readBuiltInSkillFile } from "@/node/services/agentSkills/builtInSkillDefinitions";
 import { RuntimeError } from "@/node/runtime/Runtime";
 import { readFileString } from "@/node/utils/runtime/helpers";
 
+function readContentWithFileReadLimits(input: {
+  fullContent: string;
+  fileSize: number;
+  modifiedTime: string;
+  offset?: number;
+  limit?: number;
+}): AgentSkillReadFileToolResult {
+  if (input.fileSize > MAX_FILE_SIZE) {
+    const sizeMB = (input.fileSize / (1024 * 1024)).toFixed(2);
+    const maxMB = (MAX_FILE_SIZE / (1024 * 1024)).toFixed(2);
+    return {
+      success: false,
+      error: `File is too large (${sizeMB}MB). Maximum supported size is ${maxMB}MB.`,
+    };
+  }
+
+  const lines = input.fullContent === "" ? [] : input.fullContent.split("\n");
+
+  if (input.offset !== undefined && input.offset > lines.length) {
+    return {
+      success: false,
+      error: `Offset ${input.offset} is beyond file length`,
+    };
+  }
+
+  const startLineNumber = input.offset ?? 1;
+  const startIdx = startLineNumber - 1;
+  const endIdx = input.limit !== undefined ? startIdx + input.limit : lines.length;
+
+  const numberedLines: string[] = [];
+  let totalBytesAccumulated = 0;
+  const MAX_LINE_BYTES = 1024;
+  const MAX_LINES = 1000;
+  const MAX_TOTAL_BYTES = 16 * 1024; // 16KB
+
+  for (let i = startIdx; i < Math.min(endIdx, lines.length); i++) {
+    const line = lines[i];
+    const lineNumber = i + 1;
+
+    let processedLine = line;
+    const lineBytes = Buffer.byteLength(line, "utf-8");
+    if (lineBytes > MAX_LINE_BYTES) {
+      processedLine = Buffer.from(line, "utf-8").subarray(0, MAX_LINE_BYTES).toString("utf-8");
+      processedLine += "... [truncated]";
+    }
+
+    const numberedLine = `${lineNumber}\t${processedLine}`;
+    const numberedLineBytes = Buffer.byteLength(numberedLine, "utf-8");
+
+    if (totalBytesAccumulated + numberedLineBytes > MAX_TOTAL_BYTES) {
+      return {
+        success: false,
+        error: `Output would exceed ${MAX_TOTAL_BYTES} bytes. Please read less at a time using offset and limit parameters.`,
+      };
+    }
+
+    numberedLines.push(numberedLine);
+    totalBytesAccumulated += numberedLineBytes + 1;
+
+    if (numberedLines.length > MAX_LINES) {
+      return {
+        success: false,
+        error: `Output would exceed ${MAX_LINES} lines. Please read less at a time using offset and limit parameters.`,
+      };
+    }
+  }
+
+  return {
+    success: true,
+    file_size: input.fileSize,
+    modifiedTime: input.modifiedTime,
+    lines_read: numberedLines.length,
+    content: numberedLines.join("\n"),
+  };
+}
 function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -44,11 +120,6 @@ export const createAgentSkillReadFileTool: ToolFactory = (config: ToolConfigurat
 
       try {
         const resolvedSkill = await readAgentSkill(config.runtime, workspacePath, parsedName.data);
-        const targetPath = resolveAgentSkillFilePath(
-          config.runtime,
-          resolvedSkill.skillDir,
-          filePath
-        );
 
         if (offset !== undefined && offset < 1) {
           return {
@@ -56,6 +127,24 @@ export const createAgentSkillReadFileTool: ToolFactory = (config: ToolConfigurat
             error: `Offset must be positive (got ${offset})`,
           };
         }
+
+        // Built-in skills are embedded in the app bundle (no filesystem access).
+        if (resolvedSkill.package.scope === "built-in") {
+          const builtIn = readBuiltInSkillFile(parsedName.data, filePath);
+          return readContentWithFileReadLimits({
+            fullContent: builtIn.content,
+            fileSize: Buffer.byteLength(builtIn.content, "utf-8"),
+            modifiedTime: new Date(0).toISOString(),
+            offset,
+            limit,
+          });
+        }
+
+        const targetPath = resolveAgentSkillFilePath(
+          config.runtime,
+          resolvedSkill.skillDir,
+          filePath
+        );
 
         let stat;
         try {
@@ -98,66 +187,13 @@ export const createAgentSkillReadFileTool: ToolFactory = (config: ToolConfigurat
           throw err;
         }
 
-        const lines = fullContent === "" ? [] : fullContent.split("\n");
-
-        if (offset !== undefined && offset > lines.length) {
-          return {
-            success: false,
-            error: `Offset ${offset} is beyond file length`,
-          };
-        }
-
-        const startLineNumber = offset ?? 1;
-        const startIdx = startLineNumber - 1;
-        const endIdx = limit !== undefined ? startIdx + limit : lines.length;
-
-        const numberedLines: string[] = [];
-        let totalBytesAccumulated = 0;
-        const MAX_LINE_BYTES = 1024;
-        const MAX_LINES = 1000;
-        const MAX_TOTAL_BYTES = 16 * 1024; // 16KB
-
-        for (let i = startIdx; i < Math.min(endIdx, lines.length); i++) {
-          const line = lines[i];
-          const lineNumber = i + 1;
-
-          let processedLine = line;
-          const lineBytes = Buffer.byteLength(line, "utf-8");
-          if (lineBytes > MAX_LINE_BYTES) {
-            processedLine = Buffer.from(line, "utf-8")
-              .subarray(0, MAX_LINE_BYTES)
-              .toString("utf-8");
-            processedLine += "... [truncated]";
-          }
-
-          const numberedLine = `${lineNumber}\t${processedLine}`;
-          const numberedLineBytes = Buffer.byteLength(numberedLine, "utf-8");
-
-          if (totalBytesAccumulated + numberedLineBytes > MAX_TOTAL_BYTES) {
-            return {
-              success: false,
-              error: `Output would exceed ${MAX_TOTAL_BYTES} bytes. Please read less at a time using offset and limit parameters.`,
-            };
-          }
-
-          numberedLines.push(numberedLine);
-          totalBytesAccumulated += numberedLineBytes + 1;
-
-          if (numberedLines.length > MAX_LINES) {
-            return {
-              success: false,
-              error: `Output would exceed ${MAX_LINES} lines. Please read less at a time using offset and limit parameters.`,
-            };
-          }
-        }
-
-        return {
-          success: true,
-          file_size: stat.size,
+        return readContentWithFileReadLimits({
+          fullContent,
+          fileSize: stat.size,
           modifiedTime: stat.modifiedTime.toISOString(),
-          lines_read: numberedLines.length,
-          content: numberedLines.join("\n"),
-        };
+          offset,
+          limit,
+        });
       } catch (error) {
         return {
           success: false,


### PR DESCRIPTION
## Summary

Implements a built-in skill that provides comprehensive Mux documentation to agents without manual installation. Agents can use `agent_skill_read("mux-docs")` to get an indexed tree of all docs, then selectively load specific pages via `agent_skill_read_file`.

## Key Changes

### Infrastructure
- **Schema:** Extended `AgentSkillScope` to include `"built-in"` scope
- **Registry:** Added `builtInSkillDefinitions.ts` to manage built-in skill metadata and virtual file retrieval
- **Discovery:** Updated `agentSkillsService.ts` to discover/read built-in skills (lower precedence than project/global)
- **Tool:** Updated `agent_skill_read_file` to serve virtual files from embedded content

### Content Generation
- **Generator:** Created `gen_builtin_skills.ts` that:
  - Parses `docs/docs.json` navigation structure
  - Scans all `.mdx` files and extracts frontmatter titles
  - Generates a docs tree index injected into `mux-docs.md`
  - Produces `builtInSkillContent.generated.ts` with all content embedded
- **Build Integration:** Hooked into `make fmt` and build targets

### Progressive Disclosure Pattern
1. Agent reads `mux-docs/SKILL.md` → gets instructions + docs tree index
2. Agent uses `agent_skill_read_file` to load specific pages on-demand
3. Docs match installed Mux version (no stale web content)

## Testing
- Unit tests added for built-in skill loading and precedence
- `make static-check` passes

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
