### PR TITLE
🤖 fix: debounce mermaid diagram rendering during streaming

### DIFF
--- a/src/browser/components/Messages/Mermaid.tsx
+++ b/src/browser/components/Messages/Mermaid.tsx
@@ -168,11 +168,8 @@ export const Mermaid: React.FC<{ chart: string }> = ({ chart }) => {
       } catch (err) {
         if (cancelled) return;
 
-        // Clean up any DOM elements mermaid might have created with our ID
-        const errorElement = document.getElementById(id);
-        if (errorElement) {
-          errorElement.remove();
-        }
+        // Don't remove elements by ID - with stable IDs, we'd remove the last valid render
+        // Mermaid error artifacts are cleaned up by subsequent successful renders
 
         setError(err instanceof Error ? err.message : "Failed to render diagram");
         // Don't clear SVG - keep showing last valid render during errors


### PR DESCRIPTION
Fixes flickering when mermaid diagrams are streamed by an agent.

## Problem

When streaming a mermaid diagram, every token triggered a new `mermaid.render()` call with a fresh random ID, causing:
- Constant re-rendering and layout recalculation
- Visual flickering between valid renders and error states
- Layout shifts as ELK recalculated from scratch each time

## Solution

- **350ms debounce** on chart content changes
- **Stable ID via `useId()`** preserves ELK layout between renders
- **Keep last valid SVG** during transient parse errors instead of showing placeholder
- **Cancelled flag** prevents stale async updates

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
