### PR TITLE
🤖 fix: use lucide icons for update indicator

### DIFF
--- a/src/browser/components/TitleBar.tsx
+++ b/src/browser/components/TitleBar.tsx
@@ -4,6 +4,7 @@ import { VERSION } from "@/version";
 import { SettingsButton } from "./SettingsButton";
 import { Tooltip, TooltipTrigger, TooltipContent } from "./ui/tooltip";
 import type { UpdateStatus } from "@/common/orpc/types";
+import { Download, Loader2, RefreshCw } from "lucide-react";
 
 import { useTutorial } from "@/browser/contexts/TutorialContext";
 import { useAPI } from "@/browser/contexts/API";
@@ -247,13 +248,15 @@ export function TitleBar() {
                 onClick={handleUpdateClick}
                 onMouseEnter={handleIndicatorHover}
               >
-                <span className="text-sm">
-                  {indicatorStatus === "disabled"
-                    ? "⊘"
-                    : indicatorStatus === "downloading"
-                      ? "⟳"
-                      : "↓"}
-                </span>
+                {indicatorStatus === "disabled" ? (
+                  <span className="text-sm">⊘</span>
+                ) : indicatorStatus === "downloading" ? (
+                  <Loader2 className="size-3.5 animate-spin" />
+                ) : indicatorStatus === "downloaded" ? (
+                  <RefreshCw className="size-3.5" />
+                ) : (
+                  <Download className="size-3.5" />
+                )}
               </div>
             </TooltipTrigger>
             <TooltipContent align="start" className="pointer-events-auto">


### PR DESCRIPTION
Fixes swapped icons in the TitleBar update indicator:

- **downloading**: `Loader2` with spin animation (was showing refresh glyph `⟳`)
- **downloaded/ready**: `RefreshCw` (was showing download arrow `↓`)
- **available**: `Download` icon (unchanged semantics, just lucide now)

### Testing

```bash
make dev                        # Terminal 1
DEBUG_UPDATER=9.9.9 make start  # Terminal 2
```

1. Wait ~0.5s → **available** (green Download icon)
2. Click indicator → **downloading** (blue spinning Loader2)
3. Wait ~2s → **downloaded/ready** (orange RefreshCw icon)

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
