### PR TITLE
🤖 fix: change default mux.md share expiration to Never

### DIFF
--- a/src/browser/components/ShareMessagePopover.tsx
+++ b/src/browser/components/ShareMessagePopover.tsx
@@ -329,7 +329,7 @@ export const ShareMessagePopover: React.FC<ShareMessagePopoverProps> = ({
 
   // Get preferred expiration from localStorage
   const getPreferredExpiration = (): ExpirationValue => {
-    return readPersistedState<ExpirationValue>(SHARE_EXPIRATION_KEY, "7d");
+    return readPersistedState<ExpirationValue>(SHARE_EXPIRATION_KEY, "never");
   };
 
   // Save preferred expiration to localStorage


### PR DESCRIPTION
Change the default share expiration for mux.md from 7 days to Never.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
