### PR TITLE
🤖 fix: inject <base href="/"> for mux server deep-link refresh

### DIFF
--- a/src/node/orpc/server.test.ts
+++ b/src/node/orpc/server.test.ts
@@ -24,7 +24,8 @@ describe("createOrpcServer", () => {
     const stubContext: Partial<ORPCContext> = {};
 
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-static-"));
-    const indexHtml = "<!doctype html><title>mux</title><div>ok</div>";
+    const indexHtml =
+      "<!doctype html><html><head><title>mux</title></head><body><div>ok</div></body></html>";
 
     let server: Awaited<ReturnType<typeof createOrpcServer>> | null = null;
 
@@ -42,7 +43,9 @@ describe("createOrpcServer", () => {
 
       const uiRes = await fetch(`${server.baseUrl}/some/spa/route`);
       expect(uiRes.status).toBe(200);
-      expect(await uiRes.text()).toContain("mux");
+      const uiText = await uiRes.text();
+      expect(uiText).toContain("mux");
+      expect(uiText).toContain('<base href="/"');
 
       const apiRes = await fetch(`${server.baseUrl}/api/not-a-real-route`);
       expect(apiRes.status).toBe(404);


### PR DESCRIPTION
When `mux server` is used as a web app, the Vite build uses a relative base (`./`).
On hard-refresh of deep links like `/workspace/<id>`, browsers can resolve asset URLs relative to `/workspace/`, producing requests like `/workspace/manifest.json`.

This change makes the server serve a transformed `index.html` for the SPA fallback with an injected `<base href="/" />`, so relative asset URLs resolve from the origin root regardless of the current route.

Tests:
- `bun test src/node/orpc/server.test.ts`

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh`_
