### PR TITLE
🤖 ci: restore development builds on main with code signing

### DIFF
--- a/.github/actions/setup-windows-signing/action.yml
+++ b/.github/actions/setup-windows-signing/action.yml
@@ -1,0 +1,58 @@
+name: "Setup Windows Code Signing"
+description: "Configure EV code signing for Windows builds using GCP KMS"
+
+inputs:
+  ev_signing_cert:
+    description: "EV signing certificate (PEM format)"
+    required: false
+  gcp_workload_id_provider:
+    description: "GCP Workload Identity Provider"
+    required: false
+  gcp_service_account:
+    description: "GCP Service Account"
+    required: false
+
+outputs:
+  gcloud_access_token:
+    description: "GCP access token for signing"
+    value: ${{ steps.gcloud_auth.outputs.access_token }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Java
+      uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
+      with:
+        distribution: "zulu"
+        java-version: "11.0"
+
+    - name: Authenticate to Google Cloud
+      id: gcloud_auth
+      if: inputs.gcp_workload_id_provider != ''
+      uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
+      with:
+        workload_identity_provider: ${{ inputs.gcp_workload_id_provider }}
+        service_account: ${{ inputs.gcp_service_account }}
+        token_format: "access_token"
+
+    - name: Setup code signing
+      shell: pwsh
+      run: |
+        if (-not $env:EV_SIGNING_CERT) {
+          Write-Host "⚠️ No Windows code signing certificate provided - building unsigned"
+          exit 0
+        }
+
+        # Save EV certificate to temp file
+        $certPath = Join-Path $env:TEMP "ev_cert.pem"
+        Set-Content -Path $certPath -Value $env:EV_SIGNING_CERT
+        Add-Content -Path $env:GITHUB_ENV -Value "EV_CERTIFICATE_PATH=$certPath"
+
+        # Download jsign
+        $jsignPath = Join-Path $env:TEMP "jsign-6.0.jar"
+        Invoke-WebRequest -Uri "https://github.com/ebourg/jsign/releases/download/6.0/jsign-6.0.jar" -OutFile $jsignPath
+        Add-Content -Path $env:GITHUB_ENV -Value "JSIGN_PATH=$jsignPath"
+
+        Write-Host "✅ Windows EV code signing configured"
+      env:
+        EV_SIGNING_CERT: ${{ inputs.ev_signing_cert }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,8 @@
 name: PR
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: ["**"]
   merge_group:
@@ -14,6 +16,11 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
+# Permissions for GCP workload identity authentication (Windows code signing on main)
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   # Detect what files changed to determine which jobs/tests to run
@@ -241,7 +248,8 @@ jobs:
 
   smoke-docker:
     name: Smoke / Docker
-    if: github.event_name == 'merge_group'
+    # Only run on merge queue and main pushes (not every PR)
+    if: github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-16' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
@@ -299,6 +307,15 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-mux
+      - name: Setup code signing
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: ./scripts/setup-macos-signing.sh
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          AC_APIKEY_P8_BASE64: ${{ secrets.AC_APIKEY_P8_BASE64 }}
+          AC_APIKEY_ID: ${{ secrets.AC_APIKEY_ID }}
+          AC_APIKEY_ISSUER_ID: ${{ secrets.AC_APIKEY_ISSUER_ID }}
       - run: make dist-mac
       - uses: actions/upload-artifact@v4
         with:
@@ -316,8 +333,8 @@ jobs:
   build-windows:
     name: Build / Windows
     needs: [changes]
-    # Windows builds are slow - only run in merge queue, not on every PR push
-    if: ${{ github.event_name == 'merge_group' && (needs.changes.outputs.src == 'true' || needs.changes.outputs.config == 'true') }}
+    # Windows builds are slow - only run in merge queue and main pushes, not on every PR push
+    if: ${{ (github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && (needs.changes.outputs.src == 'true' || needs.changes.outputs.config == 'true') }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -338,7 +355,22 @@ jobs:
           bun --version
           magick --version | head -1
       - run: bun run build
-      - run: make dist-win
+      - name: Setup code signing
+        id: signing
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: ./.github/actions/setup-windows-signing
+        with:
+          ev_signing_cert: ${{ secrets.EV_SIGNING_CERT }}
+          gcp_workload_id_provider: ${{ vars.GCP_WORKLOAD_ID_PROVIDER }}
+          gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+      - name: Package for Windows
+        run: make dist-win
+        env:
+          # EV signing environment variables (used by custom sign script if configured)
+          EV_KEYSTORE: ${{ vars.EV_KEYSTORE }}
+          EV_KEY: ${{ vars.EV_KEY }}
+          EV_TSA_URL: ${{ vars.EV_TSA_URL }}
+          GCLOUD_ACCESS_TOKEN: ${{ steps.signing.outputs.gcloud_access_token }}
       - uses: actions/upload-artifact@v4
         with:
           name: build-windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,43 +174,13 @@ jobs:
       - name: Build application
         run: bun run build
 
-      # Setup Java for jsign (EV code signing with GCP KMS)
-      - name: Setup Java
-        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
-        with:
-          distribution: "zulu"
-          java-version: "11.0"
-
-      - name: Authenticate to Google Cloud
-        id: gcloud_auth
-        if: ${{ vars.GCP_WORKLOAD_ID_PROVIDER != '' }}
-        uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
-        with:
-          workload_identity_provider: ${{ vars.GCP_WORKLOAD_ID_PROVIDER }}
-          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
-          token_format: "access_token"
-
       - name: Setup code signing
-        shell: pwsh
-        run: |
-          if (-not $env:EV_SIGNING_CERT) {
-            Write-Host "⚠️ No Windows code signing certificate provided - building unsigned"
-            exit 0
-          }
-
-          # Save EV certificate to temp file
-          $certPath = Join-Path $env:TEMP "ev_cert.pem"
-          Set-Content -Path $certPath -Value $env:EV_SIGNING_CERT
-          Add-Content -Path $env:GITHUB_ENV -Value "EV_CERTIFICATE_PATH=$certPath"
-
-          # Download jsign
-          $jsignPath = Join-Path $env:TEMP "jsign-6.0.jar"
-          Invoke-WebRequest -Uri "https://github.com/ebourg/jsign/releases/download/6.0/jsign-6.0.jar" -OutFile $jsignPath
-          Add-Content -Path $env:GITHUB_ENV -Value "JSIGN_PATH=$jsignPath"
-
-          Write-Host "✅ Windows EV code signing configured"
-        env:
-          EV_SIGNING_CERT: ${{ secrets.EV_SIGNING_CERT }}
+        id: signing
+        uses: ./.github/actions/setup-windows-signing
+        with:
+          ev_signing_cert: ${{ secrets.EV_SIGNING_CERT }}
+          gcp_workload_id_provider: ${{ vars.GCP_WORKLOAD_ID_PROVIDER }}
+          gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
       - name: Package and publish for Windows (.exe)
         run: bun x electron-builder --win --publish always
@@ -220,7 +190,7 @@ jobs:
           EV_KEYSTORE: ${{ vars.EV_KEYSTORE }}
           EV_KEY: ${{ vars.EV_KEY }}
           EV_TSA_URL: ${{ vars.EV_TSA_URL }}
-          GCLOUD_ACCESS_TOKEN: ${{ steps.gcloud_auth.outputs.access_token }}
+          GCLOUD_ACCESS_TOKEN: ${{ steps.signing.outputs.gcloud_access_token }}
 
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v4

--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -15,21 +15,17 @@ Download pre-built binaries from [the releases page](https://github.com/coder/mu
 
 ### Development Builds
 
-Download pre-built binaries of `main` from [GitHub Actions](https://github.com/coder/mux/actions/workflows/build.yml):
+Download pre-built binaries of `main` from [GitHub Actions](https://github.com/coder/mux/actions/workflows/pr.yml?query=event:push+branch:main):
 
 - **macOS**: Signed and notarized DMG
-  - `macos-dmg-x64` (Intel Macs)
-  - `macos-dmg-arm64` (Apple Silicon)
-- **Linux**: AppImage (portable, works on most distros)
-
-<Info>
-  Windows builds are only available from [releases](https://github.com/coder/mux/releases), not from
-  development builds.
-</Info>
+  - `build-macos-x64` (Intel Macs)
+  - `build-macos-arm64` (Apple Silicon)
+- **Linux**: `build-linux` AppImage (portable, works on most distros)
+- **Windows**: `build-windows` installer exe
 
 To download:
 
-1. Go to the [Build workflow](https://github.com/coder/mux/actions/workflows/build.yml?query=event:merge_group)
+1. Go to the [PR workflow (main branch)](https://github.com/coder/mux/actions/workflows/pr.yml?query=event:push+branch:main)
 2. Click on the latest successful run
 3. Scroll down to "Artifacts" section
 4. Download the appropriate artifact for your platform


### PR DESCRIPTION
## Summary

Restores automatic development builds on `main` branch that stopped running around Dec 7 when the standalone `build.yml` was merged into `pr.yml` but the push trigger wasn't preserved.

## Changes

- Add `push: branches: [main]` trigger to PR workflow
- Enable macOS code signing for main pushes (via `setup-macos-signing.sh`)
- Enable Windows EV code signing for main pushes (via new composite action)
- Extract Windows signing logic into `.github/actions/setup-windows-signing` (DRY with release.yml)
- Update `smoke-docker` and `build-windows` conditions to include main pushes
- Update docs with correct workflow URL and artifact names

## Artifacts

Development builds now produce:
- `build-macos-x64` / `build-macos-arm64` (signed & notarized)
- `build-linux` (AppImage)
- `build-windows` (signed exe)

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_