### PR TITLE
🤖 ci: don't cancel main builds on new pushes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,8 +14,10 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # For PRs: group by PR number so pushes to same PR cancel previous runs
+  # For main: use unique SHA so builds never cancel each other (we want all artifacts)
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Permissions for GCP workload identity authentication (Windows code signing on main)
 permissions:


### PR DESCRIPTION
Quick follow-up to #1469.

Use unique SHA for main push concurrency groups so builds never cancel each other. We want every main push to produce artifacts.

PRs still cancel previous runs on the same PR number.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_