### PR TITLE
🤖 fix: /compact now backgrounds running bash processes

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -1408,10 +1408,13 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           const result = await handleCompactCommand(parsed, context);
           if (!result.clearInput) {
             setInput(messageText); // Restore input on error
-          } else if (reviewsData && reviewsData.length > 0) {
-            // Mark attached reviews as checked on success
-            const sentReviewIds = attachedReviews.map((r) => r.id);
-            props.onCheckReviews?.(sentReviewIds);
+          } else {
+            if (reviewsData && reviewsData.length > 0) {
+              // Mark attached reviews as checked on success
+              const sentReviewIds = attachedReviews.map((r) => r.id);
+              props.onCheckReviews?.(sentReviewIds);
+            }
+            props.onMessageSent?.();
           }
           return;
         }


### PR DESCRIPTION
When a regular message is sent, `ChatInput` calls `onMessageSent` which triggers `handleMessageSentBackground()` to send any foreground bash processes to background. The `/compact` command handler was returning early without calling `onMessageSent`, so foreground bashes weren't being backgrounded.

## Changes
- Added `onMessageSent` call on successful `/compact` command
- Added integration test to verify and prevent regression

## Testing
- All 4 compaction UI tests pass
- `make static-check` passes

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
