### PR TITLE
🤖 feat: show provider configuration UI on Project page

### DIFF
--- a/src/browser/components/ConfigureProvidersPrompt.tsx
+++ b/src/browser/components/ConfigureProvidersPrompt.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { Settings, Zap } from "lucide-react";
+import { useSettings } from "@/browser/contexts/SettingsContext";
+import { Button } from "./ui/button";
+
+/**
+ * Large prompt displayed when no providers are configured.
+ * Directs users to configure API providers before they can start using the app.
+ */
+export function ConfigureProvidersPrompt() {
+  const settings = useSettings();
+
+  const handleOpenProviders = () => {
+    settings.open("providers");
+  };
+
+  return (
+    <div
+      className="border-border bg-card/50 flex flex-col items-center justify-center gap-4 rounded-lg border p-8 text-center"
+      data-testid="configure-providers-prompt"
+    >
+      <div className="bg-primary/10 flex h-12 w-12 items-center justify-center rounded-full">
+        <Zap className="text-primary h-6 w-6" />
+      </div>
+      <div className="space-y-2">
+        <h2 className="text-foreground text-lg font-semibold">Configure an LLM Provider</h2>
+        <p className="text-muted-foreground max-w-sm text-sm">
+          To start a workspace, you&apos;ll need to configure at least one LLM provider with API
+          credentials.
+        </p>
+      </div>
+      <Button onClick={handleOpenProviders} className="gap-2">
+        <Settings className="h-4 w-4" />
+        Open Provider Settings
+      </Button>
+    </div>
+  );
+}

--- a/src/browser/components/ConfiguredProvidersBar.tsx
+++ b/src/browser/components/ConfiguredProvidersBar.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { Check, Settings } from "lucide-react";
+import type { ProvidersConfigMap } from "@/common/orpc/types";
+import { SUPPORTED_PROVIDERS, PROVIDER_DISPLAY_NAMES } from "@/common/constants/providers";
+import { hasProviderIcon, ProviderIcon } from "./ProviderIcon";
+import { useSettings } from "@/browser/contexts/SettingsContext";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
+
+interface ConfiguredProvidersBarProps {
+  providersConfig: ProvidersConfigMap;
+}
+
+/**
+ * Compact horizontal bar showing configured provider icons with a link to add more.
+ * Displayed above ChatInput on the Project page.
+ */
+export function ConfiguredProvidersBar(props: ConfiguredProvidersBarProps) {
+  const settings = useSettings();
+  const configuredProviders = SUPPORTED_PROVIDERS.filter(
+    (p) => props.providersConfig[p]?.isConfigured
+  );
+
+  const handleOpenProviders = () => {
+    settings.open("providers");
+  };
+
+  const tooltipText = configuredProviders.map((p) => PROVIDER_DISPLAY_NAMES[p]).join(", ");
+
+  return (
+    <div className="text-muted-foreground flex items-center justify-center gap-2 py-1.5 text-sm">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="border-border/50 hover:border-border inline-flex items-center gap-1.5 rounded border px-2 py-1 text-sm transition-colors">
+            <Check className="text-success h-3.5 w-3.5" />
+            <span className="flex items-center gap-1">
+              {configuredProviders.map((provider) =>
+                hasProviderIcon(provider) ? (
+                  <ProviderIcon key={provider} provider={provider} />
+                ) : (
+                  <span key={provider} className="text-muted-foreground text-xs font-medium">
+                    {PROVIDER_DISPLAY_NAMES[provider]}
+                  </span>
+                )
+              )}
+            </span>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top">{tooltipText}</TooltipContent>
+      </Tooltip>
+      <button
+        type="button"
+        onClick={handleOpenProviders}
+        className="text-muted-foreground/70 hover:text-foreground inline-flex items-center gap-1 text-xs transition-colors"
+      >
+        <Settings className="h-3 w-3" />
+        <span>Providers</span>
+      </button>
+    </div>
+  );
+}

--- a/src/browser/components/ProjectPage.autofocus.test.tsx
+++ b/src/browser/components/ProjectPage.autofocus.test.tsx
@@ -16,6 +16,20 @@ void mock.module("@/browser/contexts/API", () => ({
   }),
 }));
 
+// Mock useProvidersConfig to return a configured provider so ChatInput renders
+void mock.module("@/browser/hooks/useProvidersConfig", () => ({
+  useProvidersConfig: () => ({
+    config: { anthropic: { apiKeySet: true, isConfigured: true } },
+    loading: false,
+    error: null,
+  }),
+}));
+
+// Mock ConfiguredProvidersBar to avoid tooltip/context dependencies
+void mock.module("./ConfiguredProvidersBar", () => ({
+  ConfiguredProvidersBar: () => <div data-testid="ConfiguredProvidersBarMock" />,
+}));
+
 // Mock ChatInput to simulate the old (buggy) behavior where onReady can fire again
 // on unrelated re-renders (e.g. workspace list updates).
 void mock.module("./ChatInput/index", () => ({

--- a/src/browser/components/ProviderIcon.tsx
+++ b/src/browser/components/ProviderIcon.tsx
@@ -27,6 +27,13 @@ const PROVIDER_ICONS: Partial<Record<ProviderName, React.FC>> = {
   "mux-gateway": GatewayIcon,
 };
 
+/**
+ * Check if a provider has an icon available.
+ */
+export function hasProviderIcon(provider: string): boolean {
+  return provider in PROVIDER_ICONS;
+}
+
 export interface ProviderIconProps {
   provider: string;
   className?: string;

--- a/src/browser/components/Settings/sections/ProvidersSection.tsx
+++ b/src/browser/components/Settings/sections/ProvidersSection.tsx
@@ -171,23 +171,9 @@ export function ProvidersSection() {
     [api, updateOptimistically]
   );
 
+  /** Check if provider is configured (uses backend-computed isConfigured) */
   const isConfigured = (provider: string): boolean => {
-    const providerConfig = config?.[provider];
-    if (!providerConfig) return false;
-
-    // For Bedrock, check if any AWS credential field is set
-    if (provider === "bedrock" && providerConfig.aws) {
-      const { aws } = providerConfig;
-      return !!(aws.region ?? aws.bearerTokenSet ?? aws.accessKeyIdSet ?? aws.secretAccessKeySet);
-    }
-
-    // For Mux Gateway, check couponCodeSet
-    if (provider === "mux-gateway") {
-      return providerConfig.couponCodeSet ?? false;
-    }
-
-    // For other providers, check apiKeySet
-    return providerConfig.apiKeySet ?? false;
+    return config?.[provider]?.isConfigured ?? false;
   };
 
   const getFieldValue = (provider: string, field: string): string | undefined => {

--- a/src/browser/hooks/useModelsFromSettings.test.ts
+++ b/src/browser/hooks/useModelsFromSettings.test.ts
@@ -20,9 +20,14 @@ describe("getSuggestedModels", () => {
     }
 
     const config: ProvidersConfigMap = {
-      openai: { apiKeySet: true, models: ["my-team-model"] },
-      [builtInProvider]: { apiKeySet: true, models: [builtInModelId] },
-      "mux-gateway": { apiKeySet: true, couponCodeSet: true, models: ["ignored"] },
+      openai: { apiKeySet: true, isConfigured: true, models: ["my-team-model"] },
+      [builtInProvider]: { apiKeySet: true, isConfigured: true, models: [builtInModelId] },
+      "mux-gateway": {
+        apiKeySet: true,
+        isConfigured: true,
+        couponCodeSet: true,
+        models: ["ignored"],
+      },
     };
 
     const suggested = getSuggestedModels(config);

--- a/src/browser/stories/App.chat.stories.tsx
+++ b/src/browser/stories/App.chat.stories.tsx
@@ -237,7 +237,7 @@ export const VoiceInputNoApiKey: AppStory = {
           messages: [],
           // No OpenAI key configured - voice button should be disabled with tooltip
           providersConfig: {
-            anthropic: { apiKeySet: true },
+            anthropic: { apiKeySet: true, isConfigured: true },
             // openai deliberately missing
           },
         })
@@ -727,7 +727,7 @@ export const ModelSelectorPrettyWithGateway: AppStory = {
           workspaceId,
           messages: [],
           providersConfig: {
-            "mux-gateway": { apiKeySet: false, couponCodeSet: true },
+            "mux-gateway": { apiKeySet: false, couponCodeSet: true, isConfigured: true },
           },
         });
       }}

--- a/src/browser/stories/App.errors.stories.tsx
+++ b/src/browser/stories/App.errors.stories.tsx
@@ -119,8 +119,8 @@ export const ContextExceededSuggestion: AppStory = {
         return setupCustomChatStory({
           workspaceId,
           providersConfig: {
-            openai: { apiKeySet: true },
-            xai: { apiKeySet: true },
+            openai: { apiKeySet: true, isConfigured: true },
+            xai: { apiKeySet: true, isConfigured: true },
           },
           chatHandler: (callback: (event: WorkspaceChatMessage) => void) => {
             setTimeout(() => {

--- a/src/browser/stories/App.settings.stories.tsx
+++ b/src/browser/stories/App.settings.stories.tsx
@@ -35,7 +35,10 @@ export default {
 
 /** Setup basic workspace for settings stories */
 function setupSettingsStory(options: {
-  providersConfig?: Record<string, { apiKeySet: boolean; baseUrl?: string; models?: string[] }>;
+  providersConfig?: Record<
+    string,
+    { apiKeySet: boolean; isConfigured: boolean; baseUrl?: string; models?: string[] }
+  >;
   providersList?: string[];
   agentAiDefaults?: AgentAiDefaults;
   taskSettings?: Partial<TaskSettings>;
@@ -167,9 +170,13 @@ export const ProvidersConfigured: AppStory = {
       setup={() =>
         setupSettingsStory({
           providersConfig: {
-            anthropic: { apiKeySet: true, baseUrl: "" },
-            openai: { apiKeySet: true, baseUrl: "https://custom.openai.com/v1" },
-            xai: { apiKeySet: false, baseUrl: "" },
+            anthropic: { apiKeySet: true, isConfigured: true, baseUrl: "" },
+            openai: {
+              apiKeySet: true,
+              isConfigured: true,
+              baseUrl: "https://custom.openai.com/v1",
+            },
+            xai: { apiKeySet: false, isConfigured: false, baseUrl: "" },
           },
         })
       }
@@ -187,9 +194,9 @@ export const ProvidersExpanded: AppStory = {
       setup={() =>
         setupSettingsStory({
           providersConfig: {
-            anthropic: { apiKeySet: true, baseUrl: "" },
-            openai: { apiKeySet: false, baseUrl: "" },
-            xai: { apiKeySet: false, baseUrl: "" },
+            anthropic: { apiKeySet: true, isConfigured: true, baseUrl: "" },
+            openai: { apiKeySet: false, isConfigured: false, baseUrl: "" },
+            xai: { apiKeySet: false, isConfigured: false, baseUrl: "" },
           },
         })
       }
@@ -218,8 +225,8 @@ export const ModelsEmpty: AppStory = {
       setup={() =>
         setupSettingsStory({
           providersConfig: {
-            anthropic: { apiKeySet: true, baseUrl: "", models: [] },
-            openai: { apiKeySet: true, baseUrl: "", models: [] },
+            anthropic: { apiKeySet: true, isConfigured: true, baseUrl: "", models: [] },
+            openai: { apiKeySet: true, isConfigured: true, baseUrl: "", models: [] },
           },
         })
       }
@@ -239,16 +246,19 @@ export const ModelsConfigured: AppStory = {
           providersConfig: {
             anthropic: {
               apiKeySet: true,
+              isConfigured: true,
               baseUrl: "",
               models: ["claude-sonnet-4-20250514", "claude-opus-4-20250514"],
             },
             openai: {
               apiKeySet: true,
+              isConfigured: true,
               baseUrl: "",
               models: ["gpt-4o", "gpt-4o-mini", "o1-preview"],
             },
             xai: {
               apiKeySet: false,
+              isConfigured: false,
               baseUrl: "",
               models: ["grok-beta"],
             },

--- a/src/browser/stories/App.welcome.stories.tsx
+++ b/src/browser/stories/App.welcome.stories.tsx
@@ -354,3 +354,101 @@ export const ProjectPageWithArchivedWorkspaces: AppStory = {
     />
   ),
 };
+
+/**
+ * No providers configured - shows the configure providers prompt.
+ * This is displayed instead of ChatInput when the user hasn't set up any API keys.
+ */
+export const NoProvidersConfigured: AppStory = {
+  render: () => (
+    <AppWithMocks
+      setup={() => {
+        expandProjects(["/Users/dev/my-project"]);
+        return createMockORPCClient({
+          projects: new Map([projectWithNoWorkspaces("/Users/dev/my-project")]),
+          workspaces: [],
+          // Empty providers config - no API keys set
+          providersConfig: {},
+        });
+      }}
+    />
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const storyRoot = document.getElementById("storybook-root") ?? canvasElement;
+    const canvas = within(storyRoot);
+
+    // Wait for the configure prompt to appear
+    await canvas.findByTestId("configure-providers-prompt", {}, { timeout: 10000 });
+  },
+};
+
+/**
+ * Single provider configured - shows the provider bar with one icon and ChatInput.
+ */
+export const SingleProviderConfigured: AppStory = {
+  render: () => (
+    <AppWithMocks
+      setup={() => {
+        expandProjects(["/Users/dev/my-project"]);
+        return createMockORPCClient({
+          projects: new Map([projectWithNoWorkspaces("/Users/dev/my-project")]),
+          workspaces: [],
+          providersConfig: {
+            anthropic: { apiKeySet: true, isConfigured: true },
+          },
+        });
+      }}
+    />
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const storyRoot = document.getElementById("storybook-root") ?? canvasElement;
+    const canvas = within(storyRoot);
+
+    // Wait for the provider bar to appear (it contains "Providers" settings link)
+    await waitFor(
+      () => {
+        if (!canvas.queryByText("Providers")) {
+          throw new Error("Provider bar not visible");
+        }
+      },
+      { timeout: 10000 }
+    );
+  },
+};
+
+/**
+ * Multiple providers configured - shows the provider bar with multiple icons.
+ */
+export const MultipleProvidersConfigured: AppStory = {
+  render: () => (
+    <AppWithMocks
+      setup={() => {
+        expandProjects(["/Users/dev/my-project"]);
+        return createMockORPCClient({
+          projects: new Map([projectWithNoWorkspaces("/Users/dev/my-project")]),
+          workspaces: [],
+          providersConfig: {
+            anthropic: { apiKeySet: true, isConfigured: true },
+            openai: { apiKeySet: true, isConfigured: true },
+            google: { apiKeySet: true, isConfigured: true },
+            xai: { apiKeySet: true, isConfigured: true },
+          },
+        });
+      }}
+    />
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const storyRoot = document.getElementById("storybook-root") ?? canvasElement;
+    const canvas = within(storyRoot);
+
+    // Wait for the provider bar to appear
+    await waitFor(
+      () => {
+        if (!canvas.queryByText("Providers")) {
+          throw new Error("Provider bar not visible");
+        }
+      },
+      { timeout: 10000 }
+    );
+  },
+};

--- a/src/browser/stories/mocks/orpc.ts
+++ b/src/browser/stories/mocks/orpc.ts
@@ -186,7 +186,7 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
     workspaces = [],
     onChat,
     executeBash,
-    providersConfig = {},
+    providersConfig = { anthropic: { apiKeySet: true, isConfigured: true } },
     providersList = [],
     onProjectRemove,
     backgroundProcesses = new Map<string, MockBackgroundProcess[]>(),

--- a/src/common/orpc/schemas/api.test.ts
+++ b/src/common/orpc/schemas/api.test.ts
@@ -35,6 +35,7 @@ describe("ProviderConfigInfoSchema conformance", () => {
   it("preserves all ProviderConfigInfo fields (base case)", () => {
     const full: ProviderConfigInfo = {
       apiKeySet: true,
+      isConfigured: true,
       baseUrl: "https://api.example.com",
       models: ["model-a", "model-b"],
     };
@@ -48,6 +49,7 @@ describe("ProviderConfigInfoSchema conformance", () => {
   it("preserves all ProviderConfigInfo fields (with AWS/Bedrock)", () => {
     const full: ProviderConfigInfo = {
       apiKeySet: false,
+      isConfigured: false,
       baseUrl: undefined,
       models: [],
       aws: {
@@ -68,6 +70,7 @@ describe("ProviderConfigInfoSchema conformance", () => {
   it("preserves all ProviderConfigInfo fields (with couponCodeSet)", () => {
     const full: ProviderConfigInfo = {
       apiKeySet: true,
+      isConfigured: true,
       couponCodeSet: true,
     };
 
@@ -81,6 +84,7 @@ describe("ProviderConfigInfoSchema conformance", () => {
     // This is the most comprehensive test - includes ALL possible fields
     const full: ProviderConfigInfo = {
       apiKeySet: true,
+      isConfigured: true,
       baseUrl: "https://custom.endpoint.com",
       models: ["claude-3-opus", "claude-3-sonnet"],
       serviceTier: "flex",
@@ -111,14 +115,17 @@ describe("ProviderConfigInfoSchema conformance", () => {
     const full: ProvidersConfigMap = {
       anthropic: {
         apiKeySet: true,
+        isConfigured: true,
         models: ["claude-3-opus"],
       },
       openai: {
         apiKeySet: true,
+        isConfigured: true,
         serviceTier: "auto",
       },
       bedrock: {
         apiKeySet: false,
+        isConfigured: false,
         aws: {
           region: "us-west-2",
           bearerTokenSet: false,
@@ -128,6 +135,7 @@ describe("ProviderConfigInfoSchema conformance", () => {
       },
       "mux-gateway": {
         apiKeySet: false,
+        isConfigured: false,
         couponCodeSet: true,
         models: ["anthropic/claude-sonnet-4-5"],
       },

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -97,6 +97,8 @@ export const AWSCredentialStatusSchema = z.object({
 
 export const ProviderConfigInfoSchema = z.object({
   apiKeySet: z.boolean(),
+  /** Whether this provider is configured and ready to use */
+  isConfigured: z.boolean(),
   baseUrl: z.string().optional(),
   models: z.array(z.string()).optional(),
   /** OpenAI-specific fields */

--- a/src/node/services/providerService.ts
+++ b/src/node/services/providerService.ts
@@ -8,6 +8,7 @@ import type {
   ProvidersConfigMap,
 } from "@/common/orpc/types";
 import { log } from "@/node/services/log";
+import { checkProviderConfigured } from "@/node/utils/providerRequirements";
 
 // Re-export types for backward compatibility
 export type { AWSCredentialStatus, ProviderConfigInfo, ProvidersConfigMap };
@@ -64,6 +65,7 @@ export class ProviderService {
 
       const providerInfo: ProviderConfigInfo = {
         apiKeySet: !!config.apiKey,
+        isConfigured: false, // computed below
         baseUrl: config.baseUrl,
         models: config.models,
       };
@@ -95,6 +97,9 @@ export class ProviderService {
         const muxConfig = config as { couponCode?: string; voucher?: string };
         providerInfo.couponCodeSet = !!(muxConfig.couponCode ?? muxConfig.voucher);
       }
+
+      // Compute isConfigured using shared utility (checks config + env vars)
+      providerInfo.isConfigured = checkProviderConfigured(provider, config).isConfigured;
 
       result[provider] = providerInfo;
     }

--- a/src/node/utils/providerRequirements.ts
+++ b/src/node/utils/providerRequirements.ts
@@ -1,0 +1,111 @@
+/**
+ * Provider credential resolution - single source of truth for provider authentication.
+ *
+ * Used by:
+ * - providerService.ts: UI status (isConfigured flag for frontend)
+ * - aiService.ts: runtime credential resolution before making API calls
+ */
+
+import { PROVIDER_DEFINITIONS, type ProviderName } from "@/common/constants/providers";
+
+/** Raw provider config shape (subset of providers.jsonc entry) */
+export interface ProviderConfigRaw {
+  apiKey?: string;
+  baseUrl?: string;
+  baseURL?: string; // Anthropic uses baseURL
+  models?: string[];
+  region?: string;
+  bearerToken?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  couponCode?: string;
+  voucher?: string; // legacy mux-gateway field
+}
+
+/** Result of resolving provider credentials */
+export interface ResolvedCredentials {
+  isConfigured: boolean;
+  /** What's missing, if not configured (for error messages) */
+  missingRequirement?: "api_key" | "region" | "coupon_code";
+
+  // Resolved credential values - aiService uses these directly
+  apiKey?: string; // anthropic, openai, etc.
+  region?: string; // bedrock
+  couponCode?: string; // mux-gateway
+  baseUrl?: string; // anthropic (from env)
+}
+
+/** Legacy alias for backward compatibility */
+export type ProviderConfigCheck = Pick<ResolvedCredentials, "isConfigured" | "missingRequirement">;
+
+/**
+ * Resolve provider credentials from config and environment.
+ * Returns both configuration status AND resolved credential values.
+ *
+ * @param provider - Provider name
+ * @param config - Raw config from providers.jsonc (or empty object)
+ * @param env - Environment variables (defaults to process.env)
+ */
+export function resolveProviderCredentials(
+  provider: ProviderName,
+  config: ProviderConfigRaw,
+  env: Record<string, string | undefined> = process.env
+): ResolvedCredentials {
+  // Bedrock: region required (credentials via AWS SDK chain)
+  if (provider === "bedrock") {
+    // Check config first, then env vars - empty strings treated as unset
+    const configRegion = typeof config.region === "string" && config.region ? config.region : null;
+    const region = configRegion ?? env.AWS_REGION ?? env.AWS_DEFAULT_REGION;
+    return region
+      ? { isConfigured: true, region }
+      : { isConfigured: false, missingRequirement: "region" };
+  }
+
+  // Mux Gateway: coupon code required (no env var support)
+  if (provider === "mux-gateway") {
+    const couponCode = config.couponCode ?? config.voucher;
+    return couponCode
+      ? { isConfigured: true, couponCode }
+      : { isConfigured: false, missingRequirement: "coupon_code" };
+  }
+
+  // Keyless providers (e.g., ollama): require explicit opt-in via baseUrl or models
+  // We can't detect if Ollama is running without a network probe, so require config
+  const def = PROVIDER_DEFINITIONS[provider];
+  if (!def.requiresApiKey) {
+    const hasExplicitConfig = Boolean(config.baseUrl ?? (config.models?.length ?? 0) > 0);
+    return { isConfigured: hasExplicitConfig };
+  }
+
+  // Anthropic: special handling for multiple env vars + base URL from env
+  if (provider === "anthropic") {
+    // Check config first, then env vars - empty strings treated as unset
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- empty string should be treated as unset
+    const configKey = config.apiKey || null;
+    const apiKey = configKey ?? env.ANTHROPIC_API_KEY ?? env.ANTHROPIC_AUTH_TOKEN;
+    const baseUrl = config.baseURL ?? config.baseUrl ?? env.ANTHROPIC_BASE_URL;
+    return apiKey
+      ? { isConfigured: true, apiKey, baseUrl }
+      : { isConfigured: false, missingRequirement: "api_key" };
+  }
+
+  // Standard API key providers: config only (no env fallback in aiService)
+  if (config.apiKey) {
+    return { isConfigured: true, apiKey: config.apiKey };
+  }
+
+  return { isConfigured: false, missingRequirement: "api_key" };
+}
+
+/**
+ * Check if a provider is configured (has necessary credentials).
+ * Convenience wrapper around resolveProviderCredentials for UI status checks.
+ */
+export function checkProviderConfigured(
+  provider: ProviderName,
+  config: ProviderConfigRaw,
+  env: Record<string, string | undefined> = process.env
+): ProviderConfigCheck {
+  const { isConfigured, missingRequirement } = resolveProviderCredentials(provider, config, env);
+  return { isConfigured, missingRequirement };
+}

--- a/tests/ipc/setup.ts
+++ b/tests/ipc/setup.ts
@@ -57,6 +57,17 @@ export async function createTestEnvironment(): Promise<TestEnvironment> {
   // Create config with temporary directory
   const config = new Config(tempDir);
 
+  // Some UI tests render ProjectPage, which now hard-blocks workspace creation when no providers
+  // are configured. For non-integration tests, seed a dummy provider so the UI can render.
+  //
+  // For integration tests (TEST_INTEGRATION=1), do NOT write dummy keys here (they would override
+  // real env-backed credentials used by tests like name generation).
+  if (!shouldRunIntegrationTests()) {
+    config.saveProvidersConfig({
+      anthropic: { apiKey: "test-key-for-ui-tests" },
+    });
+  }
+
   // Create mock BrowserWindow
   const mockWindow = createMockBrowserWindow();
 


### PR DESCRIPTION
## Summary

On the Project screen, this PR adds conditional UI based on provider configuration state:

### When no providers are configured
Shows a prominent `ConfigureProvidersPrompt` component that:
- Displays a clear message explaining that providers need to be configured
- Has a button that deep-links directly to Settings → Providers

### When providers are configured  
Shows `ConfiguredProvidersBar` above ChatInput:
- Compact horizontal carousel of configured provider icons (no names, minimal vertical space)
- Tooltips on hover show provider display names
- Persistent "Configure providers" link to add more

### Screenshots

The storybook stories demonstrate both states:
- `NoProvidersConfigured` - Shows the configure prompt
- `SingleProviderConfigured` - Shows bar with one icon
- `MultipleProvidersConfigured` - Shows bar with multiple icons

### Implementation Details

- `ConfigureProvidersPrompt`: Large CTA shown when no providers configured
- `ConfiguredProvidersBar`: Compact icon carousel with settings link
- `ProjectPage`: Uses `useProvidersConfig()` hook to conditionally render

Provider detection logic considers:
- `apiKeySet` for most providers
- `couponCodeSet` for mux-gateway
- AWS credentials for bedrock (bearerToken OR accessKeyId + secretAccessKey)

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
