### PR TITLE
🤖 feat: add API key links to provider settings

### DIFF
--- a/src/browser/components/Settings/sections/ProvidersSection.tsx
+++ b/src/browser/components/Settings/sections/ProvidersSection.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from "react";
-import { ChevronDown, ChevronRight, Check, X, Eye, EyeOff } from "lucide-react";
+import { ChevronDown, ChevronRight, Check, X, Eye, EyeOff, ExternalLink } from "lucide-react";
+
 import { createEditKeyHandler } from "@/browser/utils/ui/keybinds";
 import { SUPPORTED_PROVIDERS } from "@/common/constants/providers";
 import type { ProviderName } from "@/common/constants/providers";
@@ -83,6 +84,20 @@ function getProviderFields(provider: ProviderName): FieldConfig[] {
     },
   ];
 }
+
+/**
+ * URLs to create/manage API keys for each provider.
+ */
+const PROVIDER_KEY_URLS: Partial<Record<ProviderName, string>> = {
+  anthropic: "https://console.anthropic.com/settings/keys",
+  openai: "https://platform.openai.com/api-keys",
+  google: "https://aistudio.google.com/app/apikey",
+  xai: "https://console.x.ai/team/default/api-keys",
+  deepseek: "https://platform.deepseek.com/api_keys",
+  openrouter: "https://openrouter.ai/settings/keys",
+  // bedrock: AWS credential chain, no simple key URL
+  // ollama: local service, no key needed
+};
 
 export function ProvidersSection() {
   const { api } = useAPI();
@@ -260,6 +275,19 @@ export function ProvidersSection() {
             {/* Provider settings */}
             {isExpanded && (
               <div className="border-border-medium space-y-3 border-t px-4 py-3">
+                {/* Quick link to get API key */}
+                {PROVIDER_KEY_URLS[provider] && (
+                  <a
+                    href={PROVIDER_KEY_URLS[provider]}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-muted hover:text-accent inline-flex items-center gap-1 text-xs transition-colors"
+                  >
+                    Get API Key
+                    <ExternalLink className="h-2.5 w-2.5" />
+                  </a>
+                )}
+
                 {fields.map((fieldConfig) => {
                   const isEditing =
                     editingField?.provider === provider && editingField?.field === fieldConfig.key;

--- a/src/browser/stories/App.settings.stories.tsx
+++ b/src/browser/stories/App.settings.stories.tsx
@@ -180,6 +180,37 @@ export const ProvidersConfigured: AppStory = {
   },
 };
 
+/** Providers section - expanded to show quick links (docs + get API key) */
+export const ProvidersExpanded: AppStory = {
+  render: () => (
+    <AppWithMocks
+      setup={() =>
+        setupSettingsStory({
+          providersConfig: {
+            anthropic: { apiKeySet: true, baseUrl: "" },
+            openai: { apiKeySet: false, baseUrl: "" },
+            xai: { apiKeySet: false, baseUrl: "" },
+          },
+        })
+      }
+    />
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    await openSettingsToSection(canvasElement, "providers");
+
+    const body = within(canvasElement.ownerDocument.body);
+    const dialog = await body.findByRole("dialog");
+    const dialogCanvas = within(dialog);
+
+    // Click on a provider to expand it and reveal the API key link
+    const openaiButton = await dialogCanvas.findByRole("button", { name: /openai/i });
+    await userEvent.click(openaiButton);
+
+    // Verify "Get API Key" link is visible
+    await dialogCanvas.findByRole("link", { name: /get api key/i });
+  },
+};
+
 /** Models section - no custom models */
 export const ModelsEmpty: AppStory = {
   render: () => (


### PR DESCRIPTION
Add "Get API Key" link in the expanded provider section that opens the provider's API key management page.

Links appear when a provider is expanded, keeping the collapsed view clean. Styled consistently with surrounding UI.

### Key URLs provided for:
- Anthropic: console.anthropic.com/settings/keys
- OpenAI: platform.openai.com/api-keys
- Google: aistudio.google.com/app/apikey
- xAI: console.x.ai/team/default/api-keys
- DeepSeek: platform.deepseek.com/api_keys
- OpenRouter: openrouter.ai/settings/keys

Bedrock and Ollama don't show the link (AWS credential chain / local service).

Added `ProvidersExpanded` story to capture the expanded state with visible link.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
