### PR TITLE
🤖 tests: fix flaky ECDSA key length and background bash tests

### DIFF
--- a/src/node/services/signingService.test.ts
+++ b/src/node/services/signingService.test.ts
@@ -73,9 +73,10 @@ describe("SigningService", () => {
       expect(creds.privateKeyBase64).toBeDefined();
       expect(creds.privateKeyBase64.length).toBeGreaterThan(0);
       expect(creds.publicKey).toStartWith("ecdsa-sha2-nistp256 ");
-      // ECDSA P-256 private scalar is 32 bytes
+      // ECDSA P-256 private scalar is up to 32 bytes (may be 31 if leading byte is zero)
       const keyBytes = Buffer.from(creds.privateKeyBase64, "base64");
-      expect(keyBytes.length).toBe(32);
+      expect(keyBytes.length).toBeGreaterThanOrEqual(31);
+      expect(keyBytes.length).toBeLessThanOrEqual(32);
     });
   });
 


### PR DESCRIPTION
Two flaky test fixes:

1. **ECDSA key length**: P-256 private key scalars can be 31 or 32 bytes depending on whether the leading byte is zero. The test incorrectly expected exactly 32 bytes.

2. **Background bash task_list**: Remove flaky task_list assertions from LLM-based tests. The task_list functionality is already tested deterministically in `backgroundBashDirect.test.ts`. LLM-based tests have inherent timing flakiness that makes them unreliable for this verification.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
