### PR TITLE
🤖 fix: prevent unhandled rejection from void exitCode.finally()

### DIFF
--- a/src/node/runtime/LocalBaseRuntime.ts
+++ b/src/node/runtime/LocalBaseRuntime.ts
@@ -181,7 +181,7 @@ export abstract class LocalBaseRuntime implements Runtime {
       }, options.timeout * 1000);
 
       // Clear timeout if process exits naturally
-      void exitCode.finally(() => clearTimeout(timeoutHandle));
+      void exitCode.catch(() => undefined).finally(() => clearTimeout(timeoutHandle));
     }
 
     return { stdout, stderr, stdin, exitCode, duration };

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -271,7 +271,7 @@ export class SSHRuntime implements Runtime {
       }, options.timeout * 1000);
 
       // Clear timeout if process exits naturally
-      void exitCode.finally(() => clearTimeout(timeoutHandle));
+      void exitCode.catch(() => undefined).finally(() => clearTimeout(timeoutHandle));
     }
 
     return { stdout, stderr, stdin, exitCode, duration };

--- a/src/node/services/tools/bash.ts
+++ b/src/node/services/tools/bash.ts
@@ -610,6 +610,9 @@ ${scriptWithEnv}`;
       // Also race with the background promise to detect early return request
       const foregroundCompletion = Promise.all([execStream.exitCode, consumeStdout, consumeStderr]);
 
+      // Attach a no-op rejection handler to prevent Node's unhandled rejection warning.
+      void foregroundCompletion.catch(() => undefined);
+
       let exitCode: number;
       try {
         const result = await Promise.race([

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2320,15 +2320,8 @@ export class WorkspaceService extends EventEmitter {
 
       return Ok(result);
     } catch (error) {
-      // Race with workspace removal: cwd was deleted after the guard check but before/during spawn.
-      // Return the same error as the guard so callers handle it uniformly.
-      // RuntimeError stores cause as a property, and spawn ENOENT has code on the cause.
-      const cause =
-        error instanceof Error && "cause" in error ? (error as { cause?: Error }).cause : undefined;
-      const isEnoent = cause instanceof Error && "code" in cause && cause.code === "ENOENT";
-      if (isEnoent && this.removingWorkspaces.has(workspaceId)) {
-        return Err(`Workspace ${workspaceId} is being removed`);
-      }
+      // bashTool.execute returns error results instead of throwing, so this only catches
+      // failures from setup code (getWorkspaceMetadata, findWorkspace, createRuntime, etc.)
       const message = error instanceof Error ? error.message : String(error);
       return Err(`Failed to execute bash command: ${message}`);
     }


### PR DESCRIPTION
## Problem

The test `sections.integration.test.ts` was flaky with `spawn bash ENOENT` errors. When a workspace is removed while GitStatusStore has an in-flight bash call, the spawn fails and `exitCode` rejects.

The root cause was `void exitCode.finally(() => clearTimeout(...))` in `LocalBaseRuntime.ts`:

```javascript
void exitCode.finally(() => clearTimeout(timeoutHandle));
```

This is a footgun because `.finally()` returns a **new promise** that rejects if the original rejects. The `void` discards that promise with no handler attached, so Node fires `unhandledRejection`.

## Fix

Use `.catch(() => undefined).finally(cleanup)` instead. The `.catch()` swallows the rejection, so `.finally()` sees a resolved promise and its returned promise won't reject.

## Changes

| File | Change |
|------|--------|
| `LocalBaseRuntime.ts` | `exitCode.catch(() => undefined).finally(...)` - **the actual fix** |
| `SSHRuntime.ts` | Same pattern (consistency) |
| `bash.ts` | Added `void foregroundCompletion.catch()` for defense-in-depth |
| `workspaceService.ts` | Removed dead ENOENT-handling code (bash.ts returns error results, doesn't throw) |

## Verification

Tested by modifying the test to remove the workspace before `cleanupView()` (forcing the race):
- No fixes: **FAIL**
- bash.ts fix only: **FAIL**
- LocalBaseRuntime fix only: **PASS**

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
