### PR TITLE
🤖 fix: use stopWhen to cleanly stop stream when message is queued

### DIFF
--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -703,7 +703,8 @@ export class AgentSession {
       changedFileAttachments.length > 0 ? changedFileAttachments : undefined,
       postCompactionAttachments,
       options?.experiments,
-      options?.disableWorkspaceAgents
+      options?.disableWorkspaceAgents,
+      () => !this.messageQueue.isEmpty()
     );
   }
 
@@ -746,9 +747,6 @@ export class AgentSession {
       ) {
         this.onPostCompactionStateChange?.();
       }
-
-      // Tool call completed: auto-send queued messages
-      this.sendQueuedMessages();
     });
     forward("reasoning-delta", (payload) => this.emitChatEvent(payload));
     forward("reasoning-end", (payload) => this.emitChatEvent(payload));

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1022,7 +1022,8 @@ export class AIService extends EventEmitter {
     changedFileAttachments?: EditedFileAttachment[],
     postCompactionAttachments?: PostCompactionAttachment[] | null,
     experiments?: { programmaticToolCalling?: boolean; programmaticToolCallingExclusive?: boolean },
-    disableWorkspaceAgents?: boolean
+    disableWorkspaceAgents?: boolean,
+    hasQueuedMessage?: () => boolean
   ): Promise<Result<void, SendMessageError>> {
     try {
       if (this.mockModeEnabled && this.mockAiStreamPlayer) {
@@ -1792,7 +1793,8 @@ export class AIService extends EventEmitter {
         providerOptions,
         maxOutputTokens,
         effectiveToolPolicy,
-        streamToken // Pass the pre-generated stream token
+        streamToken, // Pass the pre-generated stream token
+        hasQueuedMessage
       );
 
       if (!streamResult.success) {


### PR DESCRIPTION
## Problem

When a user queues a message while the agent is streaming, the existing `tool-call-end` handler immediately called `sendQueuedMessages()`, which cleared the queue and tried to start a new stream. But the old stream was still running—`stopWhen` hadn't been checked yet—creating a race condition.

## Solution

Use AI SDK's `stopWhen` callback to check for queued messages at step boundaries:

1. Thread a `hasQueuedMessage` callback from AgentSession through AIService to StreamManager
2. Add the callback to `stopWhen: [stepCountIs(100000), () => hasQueuedMessage?.() ?? false]`
3. Remove `sendQueuedMessages()` from `tool-call-end`—only `stream-end` dispatches now

## Why this is better

**Before:** `tool-call-end` → clear queue → `stopWhen` checks empty queue → stream continues → `ensureStreamSafety` eventually kills it

**After:** `tool-call-end` → `stopWhen` checks non-empty queue → stream stops gracefully → `stream-end` → dispatch queued message

The stream stops cleanly at the step boundary using AI SDK's built-in mechanism, with a single dispatch point in `stream-end`.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
