### PR TITLE
🤖 tests: fix git config lock contention in concurrent tests

### DIFF
--- a/tests/ipc/sendMessageTestHelpers.ts
+++ b/tests/ipc/sendMessageTestHelpers.ts
@@ -17,7 +17,6 @@ import {
   cleanupTempGitRepo,
   generateBranchName,
   createStreamCollector,
-  addFakeOrigin,
   INIT_HOOK_WAIT_MS,
 } from "./helpers";
 import { detectDefaultTrunkBranch } from "../../src/node/git";
@@ -31,14 +30,11 @@ let sharedRepoPath: string | null = null;
 /**
  * Create shared test environment and git repo.
  * Call in beforeAll() to share resources across tests.
- * Adds a fake origin remote for GitStatusStore tests.
  */
 export async function createSharedRepo(): Promise<void> {
   await preloadTestModules();
   sharedEnv = await createTestEnvironment();
   sharedRepoPath = await createTempGitRepo();
-  // Add fake origin for GitStatusStore to detect ahead/behind status
-  await addFakeOrigin(sharedRepoPath);
 }
 
 /**

--- a/tests/ui/gitStatus.integration.test.ts
+++ b/tests/ui/gitStatus.integration.test.ts
@@ -4,8 +4,10 @@ import { shouldRunIntegrationTests } from "../testUtils";
 import {
   cleanupSharedRepo,
   createSharedRepo,
+  getSharedRepoPath,
   withSharedWorkspace,
 } from "../ipc/sendMessageTestHelpers";
+import { addFakeOrigin } from "../ipc/helpers";
 
 import { installDom } from "./dom";
 import { renderReviewPanel } from "./renderReviewPanel";
@@ -32,6 +34,8 @@ function simulateWindowFocus(): void {
 describeIntegration("GitStatus (UI + ORPC)", () => {
   beforeAll(async () => {
     await createSharedRepo();
+    // Add fake origin for ahead/behind status tests
+    await addFakeOrigin(getSharedRepoPath());
   });
 
   afterAll(async () => {


### PR DESCRIPTION
## Problem

Integration tests (`sendMessage.*.test.ts`) frequently fail on first attempt but pass on retry, causing test runs to take 8 minutes instead of 2 minutes.

The failures show:
```
error: could not lock config file .git/config: File exists
error: unable to write upstream branch configuration
```

## Root Cause

PR #1322 (Dec 26) added `addFakeOrigin()` to `createSharedRepo()` for GitStatusPolling tests. This added an origin remote to the shared test repo.

When concurrent tests (`test.concurrent()`) run `git worktree add -b`, git tries to set up upstream tracking, which writes to `.git/config`. Multiple concurrent writes cause lock contention.

**Before PR #1322:** No origin → no tracking attempted → no lock
**After PR #1322:** Fake origin → tracking attempted → lock contention

## Fix

Remove `addFakeOrigin()` from `createSharedRepo()`. Only `gitStatus.integration.test.ts` needs it for ahead/behind status tests, so it now calls `addFakeOrigin()` in its own `beforeAll()`.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
