### PR TITLE
🤖 fix: add monospace font to code execution show code view

### DIFF
--- a/src/browser/components/tools/shared/HighlightedCode.tsx
+++ b/src/browser/components/tools/shared/HighlightedCode.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { highlightCode } from "@/browser/utils/highlighting/highlightWorkerClient";
 import { extractShikiLines } from "@/browser/utils/highlighting/shiki-shared";
 import { useTheme } from "@/browser/contexts/ThemeContext";
+import { cn } from "@/common/lib/utils";
 
 interface HighlightedCodeProps {
   code: string;
@@ -72,15 +73,17 @@ export const HighlightedCode: React.FC<HighlightedCodeProps> = ({
     );
   }
 
+  const baseClasses = cn("font-mono text-[11px] leading-relaxed", className);
+
   if (highlightedLines) {
     return (
       <div
-        className={className}
+        className={baseClasses}
         dangerouslySetInnerHTML={{ __html: highlightedLines.join("\n") }}
       />
     );
   }
-  return <div className={className}>{code}</div>;
+  return <div className={baseClasses}>{code}</div>;
 };
 
 interface JsonHighlightProps {


### PR DESCRIPTION
## Summary

The `HighlightedCode` component was missing `font-mono` styling when rendering without line numbers, causing the code execution "Show Code" view to display in the default font instead of monospace.

## Changes

- Added `font-mono text-[11px] leading-relaxed` classes to the non-line-number rendering paths in `HighlightedCode.tsx`
- Added `ShowCodeView` story with a play function that clicks the "Show Code" button to capture this behavior

## Testing

The new story clicks the "Show Code" button and verifies the `.font-mono` class is present on the code display.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_