### PR TITLE
🤖 feat: materialize @file mentions for prompt cache stability

### DIFF
--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -219,6 +219,12 @@ export interface MuxMetadata {
   mode?: AgentMode; // The mode active when this message was sent (assistant messages only)
   cmuxMetadata?: MuxFrontendMetadata; // Frontend-defined metadata, backend treats as black-box
   muxMetadata?: MuxFrontendMetadata; // Frontend-defined metadata, backend treats as black-box
+  /**
+   * @file mention snapshot token(s) this message provides content for.
+   * When present, injectFileAtMentions() skips re-reading these tokens,
+   * preserving prompt cache stability across turns.
+   */
+  fileAtMentionSnapshot?: string[];
 }
 
 // Extended tool part type that supports interrupted tool calls (input-available state)


### PR DESCRIPTION
## Summary

Materializes `@file` mentions into persisted snapshot messages to improve prompt cache stability.

### Problem

`@file` mentions were being re-read on every send via `injectFileAtMentions()`. If a file changed between turns, it would modify earlier parts of the prompt prefix, reducing prompt-cache hit rates for Anthropic and OpenAI.

### Solution

1. **Expand on send, persist to history**: When a user message contains `@file` mentions, read the files once and persist the `<mux-file>` blocks as a synthetic message with `fileAtMentionSnapshot` metadata
2. **Skip re-reading materialized tokens**: `injectFileAtMentions()` now pre-populates `seenTokens` from any messages that have `fileAtMentionSnapshot` metadata
3. **Surface changes via diffs**: Call `recordFileState()` during materialization so subsequent file edits appear as `<system-file-update>` diffs instead of silently changing cached content

### Changes

- Added `fileAtMentionSnapshot?: string[]` to `MuxMetadata` interface
- Added `materializeFileAtMentions()` function to read files and produce stable blocks
- Updated `injectFileAtMentions()` to skip tokens with persisted snapshots
- Added `materializeFileAtMentionsSnapshot()` method to `AgentSession`
- Integrated into `sendMessage()` flow

### Testing

- Added tests for `injectFileAtMentions` skipping materialized tokens
- Added tests for `materializeFileAtMentions` (basic files, line ranges, empty, errors)
- All existing tests pass
- `make static-check` passes

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
