### PR TITLE
🤖 fix: prevent retry UI during workspace initialization

### DIFF
--- a/src/browser/utils/messages/retryEligibility.ts
+++ b/src/browser/utils/messages/retryEligibility.ts
@@ -88,14 +88,19 @@ export function hasInterruptedStream(
     if (elapsed < PENDING_STREAM_START_GRACE_PERIOD_MS) return false;
   }
 
-  // Don't show retry barrier if workspace init is still running
-  // The backend is intentionally waiting for init to complete before starting the stream
+  const lastMessage = messages[messages.length - 1];
+
+  // Don't show retry barrier if workspace init is still running AND no stream error yet.
+  // The backend is intentionally waiting for init to complete before starting the stream.
+  // But if a stream error has already occurred (e.g., init timeout), still show the barrier.
   const initMessage = messages.find((m) => m.type === "workspace-init");
-  if (initMessage?.type === "workspace-init" && initMessage.status === "running") {
+  if (
+    initMessage?.type === "workspace-init" &&
+    initMessage.status === "running" &&
+    lastMessage.type !== "stream-error"
+  ) {
     return false;
   }
-
-  const lastMessage = messages[messages.length - 1];
 
   // ask_user_question is a special case: an unfinished tool call represents an
   // intentional "waiting for user input" state, not a stream interruption.

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1106,6 +1106,16 @@ export class AIService extends EventEmitter {
         return Err({ type: "unknown", raw: "Aborted during initialization wait" });
       }
 
+      // Verify runtime is reachable (container exists and can be started).
+      // If the container was deleted mid-session, this surfaces a clear error.
+      const readyResult = await runtime.ensureReady();
+      if (!readyResult.ready) {
+        return Err({
+          type: "unknown",
+          raw: readyResult.error ?? "Container unavailable. It may have been deleted.",
+        });
+      }
+
       // Resolve the active agent definition.
       //
       // Precedence:


### PR DESCRIPTION
## Summary

Two fixes for Docker runtime error handling during message streaming:

### Commit 1: Move waitForInit earlier to prevent retry UI during init

Moves `waitForInit()` earlier in `streamMessage()` so that initialization completes before we attempt to stream. This prevents the retry barrier from flickering during workspace initialization - the "starting..." indicator stays until init completes.

### Commit 2: Check container exists before streaming

Adds `ensureReady()` check after `waitForInit()` to detect when a container has been deleted mid-session. Previously this showed a confusing error:

> Failed to stream message: Failed to create temp directory ~/.mux-tmp/...: exit code 1

Now it surfaces the actual docker error (e.g., "Error response from daemon: No such container: ...").

## Future Work

Container creation UX needs revision to surface errors better when the image is invalid or container creation fails. The likely approach is to not create the workspace until the container exists, but that requires streaming the init logs elsewhere (currently they're shown in the workspace chat).

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
