### PR TITLE
🤖 fix: show red border on empty Docker image/SSH host fields

### DIFF
--- a/src/browser/components/ChatInput/CreationControls.tsx
+++ b/src/browser/components/ChatInput/CreationControls.tsx
@@ -36,6 +36,8 @@ interface CreationControlsProps {
   selectedSectionId?: string | null;
   /** Callback when section selection changes */
   onSectionChange?: (sectionId: string | null) => void;
+  /** Which runtime field (if any) is in error state for visual feedback */
+  runtimeFieldError?: "docker" | "ssh" | null;
 }
 
 /** Runtime type button group with icons and colors */
@@ -424,7 +426,10 @@ export function CreationControls(props: CreationControlsProps) {
                 onChange={(e) => onSelectedRuntimeChange({ mode: "ssh", host: e.target.value })}
                 placeholder="user@host"
                 disabled={props.disabled}
-                className="bg-bg-dark text-foreground border-border-medium focus:border-accent h-7 w-36 rounded-md border px-2 text-sm focus:outline-none disabled:opacity-50"
+                className={cn(
+                  "bg-bg-dark text-foreground border-border-medium focus:border-accent h-7 w-36 rounded-md border px-2 text-sm focus:outline-none disabled:opacity-50",
+                  props.runtimeFieldError === "ssh" && "border-red-500"
+                )}
               />
             </div>
           )}
@@ -449,7 +454,10 @@ export function CreationControls(props: CreationControlsProps) {
                 }
                 placeholder="node:20"
                 disabled={props.disabled}
-                className="bg-bg-dark text-foreground border-border-medium focus:border-accent h-7 w-36 rounded-md border px-2 text-sm focus:outline-none disabled:opacity-50"
+                className={cn(
+                  "bg-bg-dark text-foreground border-border-medium focus:border-accent h-7 w-36 rounded-md border px-2 text-sm focus:outline-none disabled:opacity-50",
+                  props.runtimeFieldError === "docker" && "border-red-500"
+                )}
               />
             </div>
           )}

--- a/src/browser/components/ChatInput/useCreationWorkspace.ts
+++ b/src/browser/components/ChatInput/useCreationWorkspace.ts
@@ -214,6 +214,9 @@ export function useCreationWorkspace({
     async (messageText: string, imageParts?: ImagePart[]): Promise<boolean> => {
       if (!messageText.trim() || isSending || !api) return false;
 
+      // Build runtime config early (used later for workspace creation)
+      const runtimeConfig: RuntimeConfig | undefined = buildRuntimeConfig(settings.selectedRuntime);
+
       setIsSending(true);
       setToast(null);
       setCreatingWithIdentity(null);
@@ -229,33 +232,6 @@ export function useCreationWorkspace({
 
         // Set the confirmed identity for splash UI display
         setCreatingWithIdentity(identity);
-
-        // Build runtime config from selected runtime (preserves all fields like shareCredentials)
-        const runtimeConfig: RuntimeConfig | undefined = buildRuntimeConfig(
-          settings.selectedRuntime
-        );
-
-        // Validate Docker image is not empty
-        if (runtimeConfig?.type === "docker" && !runtimeConfig.image?.trim()) {
-          setToast({
-            id: Date.now().toString(),
-            type: "error",
-            message: "Docker image is required",
-          });
-          setIsSending(false);
-          return false;
-        }
-
-        // Validate SSH host is not empty
-        if (runtimeConfig?.type === "ssh" && !runtimeConfig.host?.trim()) {
-          setToast({
-            id: Date.now().toString(),
-            type: "error",
-            message: "SSH host is required",
-          });
-          setIsSending(false);
-          return false;
-        }
 
         // Read send options fresh from localStorage at send time to avoid
         // race conditions with React state updates (requestAnimationFrame batching

--- a/src/common/types/runtime.ts
+++ b/src/common/types/runtime.ts
@@ -139,13 +139,13 @@ export function buildRuntimeConfig(parsed: ParsedRuntime): RuntimeConfig | undef
     case RUNTIME_MODE.SSH:
       return {
         type: RUNTIME_MODE.SSH,
-        host: parsed.host,
+        host: parsed.host.trim(),
         srcBaseDir: "~/mux", // Default remote base directory (tilde resolved by backend)
       };
     case RUNTIME_MODE.DOCKER:
       return {
         type: RUNTIME_MODE.DOCKER,
-        image: parsed.image,
+        image: parsed.image.trim(),
         shareCredentials: parsed.shareCredentials,
       };
     case RUNTIME_MODE.LOCAL:


### PR DESCRIPTION
## Summary

Instead of disabling the send button when Docker image or SSH host fields are empty in the creation flow, keep the button enabled and show a red border on the offending field when the user attempts to send.

## Changes

- Add `runtimeFieldError` state to track which field needs error highlight
- Pass error state to `CreationControls` for red border styling (`border-red-500`)
- Clear error automatically when user fills in the field or switches runtime mode
- Remove validation toasts for these specific errors (red border is the feedback)
- Trim image/host values in `buildRuntimeConfig` to handle whitespace

## Behavior

| Scenario | Old | New |
|----------|-----|-----|
| Docker image empty | Send button disabled | Button enabled; clicking shows red border |
| SSH host empty | Spinner, then toast | Red border immediately (no spinner) |
| User fills in field | N/A | Red border clears |
| User switches runtime | N/A | Red border clears |

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
