### PR TITLE
🤖 feat: wire up MUX_COSTS_USD env var for bash commands

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -13,11 +13,11 @@ description: Agent instructions for AI assistants working on the mux codebase
 
   ```md
   ---
-  _Generated with `mux` • Model: `<modelString>` • Thinking: `<thinkingLevel>`_
-  <!-- mux-attribution: model=<modelString> thinking=<thinkingLevel> -->
+  _Generated with `mux` • Model: `<modelString>` • Thinking: `<thinkingLevel>` • Cost: `$<costs>`_
+  <!-- mux-attribution: model=<modelString> thinking=<thinkingLevel> costs=<costs> -->
   ```
 
-  Always check `$MUX_MODEL_STRING` and `$MUX_THINKING_LEVEL` via bash before creating PRs—include them in the footer if set.
+  Always check `$MUX_MODEL_STRING`, `$MUX_THINKING_LEVEL`, and `$MUX_COSTS_USD` via bash before creating or updating PRs—include them in the footer if set.
 
 ## PR + Release Workflow
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -69,7 +69,8 @@
                 "group": "Hooks",
                 "pages": [
                   "hooks/init",
-                  "hooks/tools"
+                  "hooks/tools",
+                  "hooks/environment-variables"
                 ]
               }
             ]

--- a/docs/hooks/environment-variables.mdx
+++ b/docs/hooks/environment-variables.mdx
@@ -1,0 +1,46 @@
+---
+title: Environment Variables
+description: Environment variables available in agent bash commands and hooks
+---
+
+The following environment variables are available in all agent bash tool executions, including [init hooks](/hooks/init).
+
+## Available Variables
+
+| Variable             | Description                                                                                                                   |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `MUX_PROJECT_PATH`   | Absolute path to the project root on the **local machine**. Always refers to your local project path, even on SSH workspaces. |
+| `MUX_RUNTIME`        | Runtime type: `"local"`, `"worktree"`, `"ssh"`, or `"docker"`                                                                 |
+| `MUX_WORKSPACE_NAME` | Name of the workspace (typically the branch name)                                                                             |
+| `MUX_MODEL_STRING`   | Model identifier (e.g., `"anthropic:claude-sonnet-4-20250514"`)                                                               |
+| `MUX_THINKING_LEVEL` | Reasoning level: `"off"`, `"low"`, `"medium"`, or `"high"`                                                                    |
+| `MUX_COSTS_USD`      | Cumulative session costs in USD, formatted to 2 decimal places (e.g., `"1.23"`)                                               |
+
+## Usage Example
+
+```bash
+#!/usr/bin/env bash
+
+echo "Project: $MUX_PROJECT_PATH"
+echo "Runtime: $MUX_RUNTIME"
+echo "Workspace: $MUX_WORKSPACE_NAME"
+echo "Model: $MUX_MODEL_STRING"
+echo "Thinking: $MUX_THINKING_LEVEL"
+echo "Costs: \$${MUX_COSTS_USD:-0.00}"
+
+# Runtime-specific behavior
+if [ "$MUX_RUNTIME" = "ssh" ]; then
+  echo "Running on SSH remote"
+elif [ "$MUX_RUNTIME" = "docker" ]; then
+  echo "Running in Docker container"
+else
+  echo "Running locally"
+fi
+```
+
+## Use Cases
+
+- **PR footers**: Include model and cost information in automated PR descriptions
+- **Conditional logic**: Adapt scripts based on runtime environment
+- **Logging**: Track which model and settings were used for a task
+- **Cost monitoring**: Check cumulative costs before expensive operations

--- a/docs/hooks/init.mdx
+++ b/docs/hooks/init.mdx
@@ -32,14 +32,7 @@ The init script runs in the workspace directory with the workspace's environment
 
 ## Environment Variables
 
-Init hooks receive the following environment variables (also available in all agent bash tool executions):
-
-- `MUX_PROJECT_PATH` - Absolute path to the project root on the **local machine**
-  - Always refers to your local project path, even on SSH workspaces
-  - Useful for logging, debugging, or runtime-specific logic
-- `MUX_RUNTIME` - Runtime type: `"local"`, `"worktree"`, or `"ssh"`
-  - Use this to detect whether the hook is running locally or remotely
-- `MUX_WORKSPACE_NAME` - Name of the workspace (typically the branch name)
+Init hooks receive [environment variables](/hooks/environment-variables) including `MUX_PROJECT_PATH`, `MUX_RUNTIME`, `MUX_WORKSPACE_NAME`, and more.
 
 **Note for SSH workspaces:** Since the project is synced to the remote machine, files exist in both locations. The init hook runs in the workspace directory (`$PWD`), so use relative paths to reference project files:
 

--- a/src/node/builtinSkills/mux-docs.md
+++ b/src/node/builtinSkills/mux-docs.md
@@ -71,6 +71,7 @@ Use this index to find a page's:
     - **Hooks**
       - Init Hooks (`/hooks/init`) → `references/docs/hooks/init.mdx` — Run setup commands automatically when creating new workspaces
       - Tool Hooks (`/hooks/tools`) → `references/docs/hooks/tools.mdx` — Block dangerous commands, lint after edits, and set up your environment
+      - Environment Variables (`/hooks/environment-variables`) → `references/docs/hooks/environment-variables.mdx` — Environment variables available in agent bash commands and hooks
   - **Agents**
     - Agents (`/agents`) → `references/docs/agents/index.mdx` — Define custom agents (modes + subagents) with Markdown files
     - Instruction Files (`/agents/instruction-files`) → `references/docs/agents/instruction-files.mdx` — Configure agent behavior with AGENTS.md files

--- a/src/node/runtime/initHook.test.ts
+++ b/src/node/runtime/initHook.test.ts
@@ -120,6 +120,7 @@ describe("getMuxEnv", () => {
     expect(env.MUX_WORKSPACE_NAME).toBe("feature-branch");
     expect(env.MUX_MODEL_STRING).toBeUndefined();
     expect(env.MUX_THINKING_LEVEL).toBeUndefined();
+    expect(env.MUX_COSTS_USD).toBeUndefined();
   });
 
   it("should include model + thinking env vars when provided", () => {
@@ -140,5 +141,31 @@ describe("getMuxEnv", () => {
 
     expect(env.MUX_MODEL_STRING).toBe("anthropic:claude-3-5-sonnet");
     expect(env.MUX_THINKING_LEVEL).toBe("off");
+  });
+
+  it("should include MUX_COSTS_USD when costsUsd is provided", () => {
+    const env = getMuxEnv("/path/to/project", "worktree", "feature-branch", {
+      modelString: "anthropic:claude-opus-4-5",
+      thinkingLevel: "high",
+      costsUsd: 1.2345,
+    });
+
+    expect(env.MUX_COSTS_USD).toBe("1.23");
+  });
+
+  it("should include MUX_COSTS_USD=0.00 when costsUsd is 0", () => {
+    const env = getMuxEnv("/path/to/project", "worktree", "main", {
+      costsUsd: 0,
+    });
+
+    expect(env.MUX_COSTS_USD).toBe("0.00");
+  });
+
+  it("should not include MUX_COSTS_USD when costsUsd is undefined", () => {
+    const env = getMuxEnv("/path/to/project", "worktree", "main", {
+      modelString: "openai:gpt-4",
+    });
+
+    expect(env.MUX_COSTS_USD).toBeUndefined();
   });
 });

--- a/src/node/runtime/initHook.ts
+++ b/src/node/runtime/initHook.ts
@@ -48,6 +48,8 @@ export function getMuxEnv(
   options?: {
     modelString?: string;
     thinkingLevel?: ThinkingLevel;
+    /** Cumulative session costs in USD (if available) */
+    costsUsd?: number;
   }
 ): Record<string, string> {
   if (!projectPath) {
@@ -69,6 +71,10 @@ export function getMuxEnv(
 
   if (options?.thinkingLevel !== undefined) {
     env.MUX_THINKING_LEVEL = options.thinkingLevel;
+  }
+
+  if (options?.costsUsd !== undefined) {
+    env.MUX_COSTS_USD = options.costsUsd.toFixed(2);
   }
 
   return env;


### PR DESCRIPTION
Wire up `MUX_COSTS_USD` environment variable so agents can include session costs in PR footers.

## Changes

- **`src/node/runtime/initHook.ts`**: Add `costsUsd` option to `getMuxEnv()`, exports `MUX_COSTS_USD` formatted to 2 decimal places
- **`src/node/services/aiService.ts`**: Store `sessionUsageService` as class property, compute cumulative costs before creating tools, pass to `getMuxEnv()`
- **`AGENTS.md`**: Update PR footer template to include costs, instruct agents to check `$MUX_COSTS_USD`
- **Tests**: Added 3 test cases for `MUX_COSTS_USD` formatting and edge cases

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$N/A`_
