### PR TITLE
🤖 fix: inline SVG attachments as text

### DIFF
--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1298,9 +1298,9 @@ export class AIService extends EventEmitter {
       const sanitizedMessages = sanitizeToolInputs(redactedForProvider);
       log.debug_obj(`${workspaceId}/2b_sanitized_messages.json`, sanitizedMessages);
 
-      // Inline SVG user attachments as text for providers that don't accept image/svg+xml.
+      // Inline SVG user attachments as text (providers generally don't accept image/svg+xml as an image input).
       // This is request-only (does not mutate persisted history).
-      const messagesWithInlinedSvg = inlineSvgAsTextForProvider(sanitizedMessages, providerName);
+      const messagesWithInlinedSvg = inlineSvgAsTextForProvider(sanitizedMessages);
 
       // Convert MuxMessage to ModelMessage format using Vercel AI SDK utility
       // Type assertion needed because MuxMessage has custom tool parts for interrupted tools

--- a/src/node/utils/messages/inlineSvgAsTextForProvider.test.ts
+++ b/src/node/utils/messages/inlineSvgAsTextForProvider.test.ts
@@ -19,7 +19,7 @@ describe("inlineSvgAsTextForProvider", () => {
       },
     ];
 
-    const result = inlineSvgAsTextForProvider(messages, "openai");
+    const result = inlineSvgAsTextForProvider(messages);
 
     expect(result[0].parts.some((p) => p.type === "file")).toBe(false);
 
@@ -45,7 +45,7 @@ describe("inlineSvgAsTextForProvider", () => {
       },
     ];
 
-    const result = inlineSvgAsTextForProvider(messages, "openai");
+    const result = inlineSvgAsTextForProvider(messages);
 
     const inlined = result[0].parts.filter((p) => p.type === "text")[1];
     expect(inlined.text).toContain(svg);
@@ -67,7 +67,7 @@ describe("inlineSvgAsTextForProvider", () => {
       },
     ];
 
-    expect(() => inlineSvgAsTextForProvider(messages, "openai", { maxSvgTextBytes: 10 })).toThrow(
+    expect(() => inlineSvgAsTextForProvider(messages, { maxSvgTextBytes: 10 })).toThrow(
       "too large"
     );
   });
@@ -82,7 +82,7 @@ describe("inlineSvgAsTextForProvider", () => {
       },
     ];
 
-    const result = inlineSvgAsTextForProvider(messages, "openai");
+    const result = inlineSvgAsTextForProvider(messages);
     expect(result).toBe(messages);
   });
 });


### PR DESCRIPTION
### What
When a user attaches an `image/svg+xml` file, we now inline the SVG XML as a text part in the provider request instead of sending it as an image.

This avoids provider-side image validation errors (most vision endpoints only accept raster formats).

### Notes
- Request-only/self-healing: does **not** mutate persisted history/UI.
- Scope: **user** `file` parts only (tool-result SVGs remain blocked).
- Includes a max decoded-size guard (default: 200 KiB) to avoid dumping huge SVGs into prompts.

### Validation
- `bun test src/node/utils/messages/inlineSvgAsTextForProvider.test.ts`
- `make static-check`

---
_Generated with `mux` • Model: openai:gpt-5.2 • Thinking: xhigh_
