### PR TITLE
🤖 refactor: add react-effects skill and fix KebabMenu useEffect

### DIFF
--- a/.mux/skills/react-effects/SKILL.md
+++ b/.mux/skills/react-effects/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: React Effects
+description: Guidelines for when to use (and avoid) useEffect in React components
+---
+
+# React Effects Guidelines
+
+**Primary reference:** https://react.dev/learn/you-might-not-need-an-effect
+
+## Quick Decision Tree
+
+Before adding `useEffect`, ask:
+
+1. **Can I calculate this during render?** → Derive it, don't store + sync
+2. **Is this resetting state when a prop changes?** → Use `key` prop instead
+3. **Is this triggered by a user event?** → Put it in the event handler
+4. **Am I syncing with an external system?** → Effect is appropriate
+
+## Legitimate Effect Uses
+
+- DOM manipulation (focus, scroll, measure)
+- External widget lifecycle (terminal, charts, non-React libraries)
+- Browser API subscriptions (ResizeObserver, IntersectionObserver)
+- Data fetching on mount/prop change
+- Global event listeners
+
+## Common Anti-Patterns
+
+```tsx
+// ❌ Derived state stored separately
+const [fullName, setFullName] = useState('');
+useEffect(() => setFullName(first + ' ' + last), [first, last]);
+
+// ✅ Calculate during render
+const fullName = first + ' ' + last;
+```
+
+```tsx
+// ❌ Event logic in effect
+useEffect(() => { if (isOpen) doSomething(); }, [isOpen]);
+
+// ✅ In the handler
+const handleOpen = () => { setIsOpen(true); doSomething(); };
+```
+
+```tsx
+// ❌ Reset state on prop change
+useEffect(() => { setComment(''); }, [userId]);
+
+// ✅ Use key to reset
+<Profile userId={userId} key={userId} />
+```
+
+## External Store Subscriptions
+
+For subscribing to external data stores (not DOM APIs), prefer `useSyncExternalStore`:
+
+```tsx
+// ❌ Manual subscription in effect
+const [isOnline, setIsOnline] = useState(true);
+useEffect(() => {
+  const update = () => setIsOnline(navigator.onLine);
+  window.addEventListener('online', update);
+  window.addEventListener('offline', update);
+  return () => { /* cleanup */ };
+}, []);
+
+// ✅ Built-in hook for external stores
+const isOnline = useSyncExternalStore(
+  subscribe,
+  () => navigator.onLine,  // client
+  () => true               // server
+);
+```
+
+## Data Fetching Cleanup
+
+Always handle race conditions with an `ignore` flag:
+
+```tsx
+useEffect(() => {
+  let ignore = false;
+  fetchData(query).then(result => {
+    if (!ignore) setData(result);
+  });
+  return () => { ignore = true; };
+}, [query]);
+```
+
+## App Initialization
+
+For once-per-app-load logic (not once-per-mount), use a module-level guard:
+
+```tsx
+let didInit = false;
+
+function App() {
+  useEffect(() => {
+    if (!didInit) {
+      didInit = true;
+      loadDataFromLocalStorage();
+      checkAuthToken();
+    }
+  }, []);
+}
+```
+
+Or run during module initialization (before render):
+
+```tsx
+if (typeof window !== 'undefined') {
+  checkAuthToken();
+  loadDataFromLocalStorage();
+}
+```

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -67,6 +67,7 @@ EOF
 - Core UX: projects sidebar (left panel), workspace management (local git worktrees or SSH clones), config stored in `~/.mux/config.json`.
 - Fetch bulk data in one IPC call—no O(n) frontend→backend loops.
 - **React Compiler enabled** — auto-memoization handles components/hooks; do not add manual `React.memo()`, `useMemo`, or `useCallback` for memoization purposes. Focus instead on fixing unstable object references that the compiler cannot optimize (e.g., `new Set()` in state setters, inline object literals as props).
+- **useEffect** — Before adding effects, consult the `react-effects` skill. Most effects for derived state, prop resets, or event-triggered logic are anti-patterns.
 
 ## Tooling & Commands
 

--- a/src/browser/components/KebabMenu.tsx
+++ b/src/browser/components/KebabMenu.tsx
@@ -32,16 +32,17 @@ export const KebabMenu: React.FC<KebabMenuProps> = ({ items, className }) => {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
-  // Calculate dropdown position when menu opens
-  useEffect(() => {
-    if (isOpen && buttonRef.current) {
+  const handleToggle = () => {
+    if (!isOpen && buttonRef.current) {
+      // Calculate position when opening (not via effect)
       const rect = buttonRef.current.getBoundingClientRect();
       setDropdownPosition({
         top: rect.bottom + 4, // 4px gap below button
         left: rect.right - 160, // Align right edge (160px = min-width)
       });
     }
-  }, [isOpen]);
+    setIsOpen(!isOpen);
+  };
 
   // Close menu when clicking outside
   useEffect(() => {
@@ -76,7 +77,7 @@ export const KebabMenu: React.FC<KebabMenuProps> = ({ items, className }) => {
           <TooltipTrigger asChild>
             <button
               ref={buttonRef}
-              onClick={() => setIsOpen(!isOpen)}
+              onClick={handleToggle}
               className={cn(
                 "border border-white/20 text-foreground text-[10px] py-0.5 px-2 rounded-[3px] cursor-pointer transition-all duration-200 font-primary flex items-center justify-center whitespace-nowrap",
                 isOpen ? "bg-white/10" : "bg-none",


### PR DESCRIPTION
## Summary

Adds a project skill for React effects guidelines and fixes one trivial useEffect anti-pattern.

## Changes

1. **New skill: `.mux/skills/react-effects/SKILL.md`**
   - Decision tree for when to use/avoid useEffect
   - Common anti-patterns with examples
   - Links to React's "You Might Not Need an Effect" as primary reference
   - Covers: derived state, key resets, event handlers, useSyncExternalStore, data fetching cleanup, app initialization

2. **AGENTS.md update**
   - References the skill: "Before adding effects, consult the `react-effects` skill"

3. **KebabMenu.tsx fix**
   - Moved dropdown position calculation from useEffect to click handler
   - Eliminates unnecessary render cycle (click → state → render → effect → state → re-render)
   - Now: click → calculate position → state → render

## Testing

- `make typecheck` passes
- Manual: open any kebab menu (⋮) in the app, verify it appears in correct position

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$10.05`_
