### PR TITLE
🤖 fix: npx mux run broken + add CLI docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -32,6 +32,7 @@
             "pages": [
               "index",
               "install",
+              "reference/cli",
               {
                 "group": "Models",
                 "pages": ["config/models", "config/providers"]

--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -72,3 +72,23 @@ The app is code-signed and notarized by Apple, so it will open without security 
 2. Run: `xattr -cr /Applications/Mux.app`
 3. Run: `codesign --force --deep --sign - /Applications/Mux.app`
 4. Now you can open the app normally
+
+## CLI via npm
+
+The mux CLI can also be run directly via `npx` without installing the desktop app:
+
+```bash
+# Run agent tasks
+npx mux run "Fix the failing tests"
+
+# Start the server for remote/mobile access
+npx mux server --port 3000
+```
+
+Or install globally:
+
+```bash
+npm install -g mux
+```
+
+This is ideal for CI/CD pipelines and scripted automation. See the [CLI documentation](/reference/cli) for all available commands and options.

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -5,13 +5,28 @@ description: Run one-off agent tasks from the command line with mux run
 
 mux provides a CLI for running one-off agent tasks without the desktop app. Unlike the interactive desktop experience, `mux run` executes a single request to completion and exits.
 
+## Installation
+
+The CLI is available via npm and can be run directly with `npx`:
+
+```bash
+# Run without installing
+npx mux run "Fix the failing tests"
+
+# Or install globally
+npm install -g mux
+mux run "Fix the failing tests"
+```
+
+Using `npx mux` is especially convenient for CI/CD pipelines where you don't want to manage a global installation.
+
 ## `mux run`
 
 Execute a one-off agent task:
 
 ```bash
 # Basic usage - run in current directory
-mux run "Fix the failing tests"
+npx mux run "Fix the failing tests"
 
 # Specify a directory
 mux run --dir /path/to/project "Add authentication"
@@ -69,6 +84,31 @@ mux run -r "ssh dev@staging.example.com" -d /app "Update dependencies"
 # Scripted usage with timeout
 mux run --json --timeout 5m "Generate API documentation" > output.jsonl
 ```
+
+### CI/CD Automation
+
+`npx mux run` works well in CI pipelines. Here's a GitHub Actions example:
+
+```yaml
+- name: Fix lint errors with mux
+  env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  run: npx mux run --timeout 5m "Fix the ESLint errors in this PR"
+
+- name: Generate changelog
+  env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  run: |
+    npx mux run --json --quiet "Generate a changelog entry for this PR" \
+      > changelog.json
+```
+
+Key considerations for CI:
+
+- **Always set `--timeout`** to prevent runaway jobs
+- **Use `--json`** for machine-readable output you can parse downstream
+- **Use `--quiet`** when you only need the final result
+- **Provide API keys** via environment variables (e.g., `ANTHROPIC_API_KEY`)
 
 ## `mux server`
 

--- a/src/node/builtinSkills/mux-docs.md
+++ b/src/node/builtinSkills/mux-docs.md
@@ -48,6 +48,7 @@ Use this index to find a page's:
   - **Getting Started**
     - Introduction (`/`) → `references/docs/index.mdx` — mux - Coding Agent Multiplexer for AI-assisted development
     - Install (`/install`) → `references/docs/install.mdx` — Download and install mux for macOS, Linux, and Windows
+    - Command Line Interface (`/reference/cli`) → `references/docs/reference/cli.mdx` — Run one-off agent tasks from the command line with mux run
     - **Models**
       - Models (`/config/models`) → `references/docs/config/models.mdx` — Select and configure AI models in mux
       - Providers (`/config/providers`) → `references/docs/config/providers.mdx` — Configure API keys and settings for AI providers

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -14,6 +14,7 @@
   "include": [
     "src/version.ts",
     "src/cli/index.ts",
+    "src/cli/run.ts",
     "src/cli/server.ts",
     "src/desktop/**/*",
     "src/node/**/*",


### PR DESCRIPTION
## Summary

`npx mux@latest run` was broken - the `run.js` file was missing from the npm package because `src/cli/run.ts` wasn't included in `tsconfig.main.json`.

## Changes

**Bug fix:**
- Added `src/cli/run.ts` to `tsconfig.main.json` include array

**Documentation:**
- Added `reference/cli` to Getting Started navigation
- Added Installation section with `npx mux` examples to CLI docs
- Added CI/CD automation section with GitHub Actions example
- Added CLI via npm section to install page (at bottom, includes `mux server`)

**CI protection:**
- Extended `check-bench-agent.sh` to verify npm package CLI completeness
- Checks that `index.js`, `run.js`, `server.js`, `argv.js` exist in `dist/cli/`
- Runs `node dist/cli/index.js run --help` to catch MODULE_NOT_FOUND errors
- Provides clear fix guidance pointing to `tsconfig.main.json`

This runs as part of `make static-check` on every PR - no new CI jobs.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
