### PR TITLE
🤖 refactor: make mux run fully ephemeral

### DIFF
--- a/src/cli/run.test.ts
+++ b/src/cli/run.test.ts
@@ -126,8 +126,6 @@ describe("mux CLI", () => {
       expect(result.stdout).toContain("--timeout");
       expect(result.stdout).toContain("--json");
       expect(result.stdout).toContain("--quiet");
-      expect(result.stdout).toContain("--workspace-id");
-      expect(result.stdout).toContain("--config-root");
     });
 
     test("shows default model as opus", async () => {


### PR DESCRIPTION
## Summary

`mux run` now runs completely ephemeral - it doesn't write any persistent state to `~/.mux/` and is fully decoupled from the Mux UI.

## Changes

- **Use temp dir for session data**: All session data (history, partials, metadata) now goes to a `DisposableTempDir` that is automatically cleaned up on exit
- **Still load providers/secrets from real config**: Reads `~/.mux/providers.jsonc` and `~/.mux/secrets.json` to authenticate and provide project secrets to tools/MCP servers
- **Remove continuation options**: Removed `--workspace`, `--workspace-id`, and `--config-root` CLI options since they're no longer relevant
- **Display thinking blocks in purple**: Reasoning/thinking blocks are now streamed to stderr with purple coloring (TTY-aware using chalk)
- **Concatenate message args**: `mux run fix the tests` now works the same as `mux run "fix the tests"`
- **Simplified flow**: Removed the `continueWorkspace` code path entirely

## Why

`mux run` is meant for one-off CLI agent sessions. It shouldn't pollute the Mux UI with workspaces that don't belong there.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_