### PR TITLE
🤖 feat: add experiment support to terminal bench workflow

### DIFF
--- a/.github/workflows/nightly-terminal-bench.yml
+++ b/.github/workflows/nightly-terminal-bench.yml
@@ -11,6 +11,10 @@ on:
         required: false
         default: "all"
         type: string
+      experiments:
+        description: "Experiments to enable (comma-separated)"
+        required: false
+        type: string
 
 jobs:
   determine-models:
@@ -45,6 +49,7 @@ jobs:
       dataset: "terminal-bench-core==0.1.1"
       concurrency: "4"
       livestream: false
+      experiments: ${{ inputs.experiments }}
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/terminal-bench.yml
+++ b/.github/workflows/terminal-bench.yml
@@ -34,6 +34,10 @@ on:
         description: "Additional arguments to pass to terminal-bench"
         required: false
         type: string
+      experiments:
+        description: "Experiments to enable (comma-separated)"
+        required: false
+        type: string
     secrets:
       ANTHROPIC_API_KEY:
         required: true
@@ -72,6 +76,10 @@ on:
         description: "Additional arguments to pass to terminal-bench"
         required: false
         type: string
+      experiments:
+        description: "Experiments to enable (comma-separated)"
+        required: false
+        type: string
 
 jobs:
   benchmark:
@@ -108,7 +116,10 @@ jobs:
           TB_CONCURRENCY: ${{ inputs.concurrency }}
           TB_LIVESTREAM: ${{ inputs.livestream && '1' || '' }}
           TB_SAMPLE_SIZE: ${{ inputs.sample_size }}
-          TB_ARGS: ${{ inputs.model_name && format('--agent-kwarg model_name={0} --agent-kwarg thinking_level={1} {2}', inputs.model_name, inputs.thinking_level, inputs.extra_args) || inputs.extra_args }}
+          TB_ARGS: >-
+            ${{ inputs.model_name && format('--agent-kwarg model_name={0} --agent-kwarg thinking_level={1}', inputs.model_name, inputs.thinking_level) || '' }}
+            ${{ inputs.extra_args || '' }}
+          MUX_EXPERIMENTS: ${{ inputs.experiments }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 

--- a/benchmarks/terminal_bench/README.md
+++ b/benchmarks/terminal_bench/README.md
@@ -62,11 +62,16 @@ The mux agent supports the following kwargs (passed via `--agent-kwarg`):
 - `model_name`: Model to use (e.g., `anthropic:claude-sonnet-4-5`, `openai:gpt-5-codex`)
 - `thinking_level`: Thinking level (`off`, `low`, `medium`, `high`)
 - `mode`: Agent mode (`plan`, `exec`)
+- `experiments`: Experiments to enable, comma-separated (e.g., `programmatic-tool-calling`)
 
 **Example:**
 
 ```bash
+# Run with specific model and thinking level
 make benchmark-terminal TB_ARGS="--agent-kwarg model_name=openai:gpt-5-codex --agent-kwarg thinking_level=high"
+
+# Run with multiple experiments
+make benchmark-terminal TB_ARGS="--agent-kwarg experiments=programmatic-tool-calling-exclusive,post-compaction-context"
 ```
 
 ## Results

--- a/benchmarks/terminal_bench/mux-run.sh
+++ b/benchmarks/terminal_bench/mux-run.sh
@@ -30,6 +30,7 @@ MUX_WORKSPACE_ID="${MUX_WORKSPACE_ID:-mux-bench}"
 MUX_THINKING_LEVEL="${MUX_THINKING_LEVEL:-high}"
 MUX_MODE="${MUX_MODE:-exec}"
 MUX_RUNTIME="${MUX_RUNTIME:-}"
+MUX_EXPERIMENTS="${MUX_EXPERIMENTS:-}"
 
 resolve_project_path() {
   if [[ -n "${MUX_PROJECT_PATH}" ]]; then
@@ -93,6 +94,19 @@ fi
 
 if [[ -n "${MUX_RUNTIME}" ]]; then
   cmd+=(--runtime "${MUX_RUNTIME}")
+fi
+
+# Add experiment flags (comma-separated → repeated --experiment flags)
+if [[ -n "${MUX_EXPERIMENTS}" ]]; then
+  IFS=',' read -r -a experiments <<<"${MUX_EXPERIMENTS}"
+  for exp in "${experiments[@]}"; do
+    # Trim whitespace
+    exp="${exp#"${exp%%[![:space:]]*}"}"
+    exp="${exp%"${exp##*[![:space:]]}"}"
+    if [[ -n "${exp}" ]]; then
+      cmd+=(--experiment "${exp}")
+    fi
+  done
 fi
 
 # Terminal-bench enforces timeouts via --global-agent-timeout-sec

--- a/benchmarks/terminal_bench/mux_agent.py
+++ b/benchmarks/terminal_bench/mux_agent.py
@@ -63,6 +63,7 @@ class MuxAgent(AbstractInstalledAgent):
         "MUX_WORKSPACE_ID",
         "MUX_MODE",
         "MUX_RUNTIME",
+        "MUX_EXPERIMENTS",
     )
 
     def __init__(
@@ -70,6 +71,7 @@ class MuxAgent(AbstractInstalledAgent):
         model_name: str = "anthropic:claude-sonnet-4-5",
         mode: str | None = None,
         thinking_level: str | None = None,
+        experiments: str | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -93,6 +95,7 @@ class MuxAgent(AbstractInstalledAgent):
         self._mode = mode.lower() if mode else None
         self._thinking_level = thinking_level.lower() if thinking_level else None
         self._model_name = (model_name or "").strip()
+        self._experiments = (experiments or "").strip() if experiments else None
 
     @staticmethod
     def name() -> str:
@@ -156,6 +159,10 @@ class MuxAgent(AbstractInstalledAgent):
         if project_path := env.get("MUX_PROJECT_PATH"):
             if not project_path.strip():
                 raise ValueError("MUX_PROJECT_PATH must be non-empty when provided")
+
+        # Set experiments from kwarg (takes precedence over env var)
+        if self._experiments:
+            env["MUX_EXPERIMENTS"] = self._experiments
 
         return env
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -51,6 +51,7 @@ mux run --json "List all TypeScript files" | jq '.type'
 | `--mode <mode>`        |       | Agent mode: `plan` or `exec`                                    | `exec`            |
 | `--thinking <level>`   | `-t`  | Thinking level: `off`, `low`, `medium`, `high`                  | `medium`          |
 | `--timeout <duration>` |       | Timeout (e.g., `5m`, `300s`, `300000`)                          | No timeout        |
+| `--experiment <id>`    | `-e`  | Enable experiment (repeatable)                                  | None              |
 | `--json`               |       | Output NDJSON for programmatic use                              | Off               |
 | `--quiet`              | `-q`  | Only output final result                                        | Off               |
 | `--workspace-id <id>`  |       | Explicit workspace ID                                           | Auto-generated    |


### PR DESCRIPTION
Add `--experiment` CLI flag and workflow inputs to enable experiments (e.g., `programmatic-tool-calling-exclusive`) during terminal bench runs.

## Data Flow

```
Workflow input (comma-separated)
    ↓
--agent-kwarg experiments=X
    ↓
MuxAgent(experiments=X)
    ↓
MUX_EXPERIMENTS env var
    ↓
mux-run.sh → --experiment flags
    ↓
run.ts → SendMessageOptions.experiments
    ↓
AIService enables experiment
```

## Usage

### Via GitHub Actions
Trigger nightly-terminal-bench with:
- `experiments: programmatic-tool-calling-exclusive`
- `experiments: programmatic-tool-calling-exclusive,post-compaction-context`

### Via CLI
```bash
bun src/cli/run.ts -e programmatic-tool-calling-exclusive "your prompt"
bun src/cli/run.ts --experiment programmatic-tool-calling-exclusive --experiment post-compaction-context "your prompt"
```

### Via make
```bash
make benchmark-terminal TB_ARGS="--agent-kwarg experiments=programmatic-tool-calling-exclusive"
```

## Changes
- `src/cli/run.ts`: Add `--experiment` flag with validation against `EXPERIMENT_IDS`
- `benchmarks/terminal_bench/mux-run.sh`: Parse `MUX_EXPERIMENTS` env var
- `benchmarks/terminal_bench/mux_agent.py`: Accept `experiments` kwarg
- `.github/workflows/terminal-bench.yml`: Add `experiments` input
- `.github/workflows/nightly-terminal-bench.yml`: Pass through experiments
- `docs/reference/cli.mdx`: Document `--experiment` flag
- `benchmarks/terminal_bench/README.md`: Document `experiments` kwarg

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$12.40`_
