### PR TITLE
🤖 fix: enable discriminated union narrowing in code_execution sandbox

### DIFF
--- a/src/node/services/ptc/typeValidator.test.ts
+++ b/src/node/services/ptc/typeValidator.test.ts
@@ -302,6 +302,37 @@ mux.file_read({ path: "wrong" });`,
     expect(result.valid).toBe(true);
   });
 
+  test("allows discriminated union narrowing with negation (!result.success)", () => {
+    // This is the idiomatic pattern for handling Result types
+    const result = validateTypes(
+      `
+      const result = mux.file_read({ filePath: "test.txt" });
+      if (!result.success) {
+        console.log(result.error);  // Should be allowed after narrowing
+        return { error: result.error };
+      }
+      return { content: result.content };
+    `,
+      muxTypes
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  test("allows discriminated union narrowing with === false", () => {
+    const result = validateTypes(
+      `
+      const result = mux.file_read({ filePath: "test.txt" });
+      if (result.success === false) {
+        console.log(result.error);
+        return null;
+      }
+      return result.content;
+    `,
+      muxTypes
+    );
+    expect(result.valid).toBe(true);
+  });
+
   test("catches syntax error gracefully", () => {
     const result = validateTypes(
       `

--- a/src/node/services/ptc/typeValidator.ts
+++ b/src/node/services/ptc/typeValidator.ts
@@ -117,6 +117,7 @@ ${muxTypes}
   const compilerOptions: ts.CompilerOptions = {
     noEmit: true,
     strict: false, // Don't require explicit types on everything
+    strictNullChecks: true, // Enable discriminated union narrowing (e.g., `if (!result.success) { result.error }`)
     noImplicitAny: false, // Allow any types
     skipLibCheck: true,
     target: ts.ScriptTarget.ES2020,


### PR DESCRIPTION
Enable `strictNullChecks: true` in the TypeScript compiler options for the code_execution sandbox type validator. This allows idiomatic error handling patterns that Claude Opus 4.5 commonly generates:

```javascript
const result = mux.file_read({ filePath: 'config.json' });
if (!result.success) {
  console.warn(result.error);  // ✅ Now works!
  return { error: result.error };
}
```

Previously, `!result.success` didn't narrow the type, so accessing `.error` after the check would fail type validation with:

```
Property 'error' does not exist on type 'FileReadResult'.
  Property 'error' does not exist on type '{ success: true; ... }'.
```

Agents had to use the less idiomatic `result.success === false` pattern instead.

## Root Cause

TypeScript's control-flow narrowing for boolean-like discriminants (`!result.success`) requires `strictNullChecks` to be enabled. Without it, the type checker doesn't properly narrow discriminated unions after negation checks.

## Fix

Enable `strictNullChecks: true` while keeping `strict: false` and `noImplicitAny: false` to maintain lenient typing for agent code. This gives us the narrowing behavior without requiring explicit type annotations everywhere.

## Testing

- All 132 PTC tests pass
- Added 2 new tests for discriminated union narrowing with both `!result.success` and `=== false` patterns

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$2.59`_
