### PR TITLE
🤖 feat(cli): remove --timeout, add --hide-costs and cost summary

### DIFF
--- a/src/cli/run.test.ts
+++ b/src/cli/run.test.ts
@@ -123,7 +123,7 @@ describe("mux CLI", () => {
       expect(result.stdout).toContain("--runtime");
       expect(result.stdout).toContain("--mode");
       expect(result.stdout).toContain("--thinking");
-      expect(result.stdout).toContain("--timeout");
+      expect(result.stdout).toContain("--hide-costs");
       expect(result.stdout).toContain("--json");
       expect(result.stdout).toContain("--quiet");
     });
@@ -150,12 +150,6 @@ describe("mux CLI", () => {
       const result = await runRunDirect(["--mode", "chaos", "test message"]);
       expect(result.exitCode).toBe(1);
       expect(result.output).toContain("Invalid mode");
-    });
-
-    test("invalid timeout shows error", async () => {
-      const result = await runRunDirect(["--timeout", "abc", "test message"]);
-      expect(result.exitCode).toBe(1);
-      expect(result.output).toContain("Invalid timeout");
     });
 
     test("nonexistent directory shows error", async () => {


### PR DESCRIPTION
## Summary

- **Remove `--timeout` flag** from `mux run` - duplicates Unix primitives like `timeout(1)` (e.g., `timeout 5m mux run "..."`)
- **Add `--hide-costs` flag** to suppress cost summary
- **Print total cost at end of run** (unless `--hide-costs` or `--json` mode)

Example output:
```
... agent output ...

Cost: $0.42
```

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$1.80`_
