### PR TITLE
🤖 feat: show tool hook output in chat UI

### DIFF
--- a/src/browser/components/Messages/ToolMessage.tsx
+++ b/src/browser/components/Messages/ToolMessage.tsx
@@ -3,6 +3,7 @@ import type { DisplayedMessage } from "@/common/types/message";
 import type { ReviewNoteData } from "@/common/types/review";
 import type { BashOutputGroupInfo } from "@/browser/utils/messages/messageUtils";
 import { getToolComponent } from "../tools/shared/getToolComponent";
+import { HookOutputDisplay, extractHookOutput } from "../tools/shared/HookOutputDisplay";
 
 interface ToolMessageProps {
   message: DisplayedMessage & { type: "tool" };
@@ -42,6 +43,9 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
       ? bashOutputGroup.position
       : undefined;
 
+  // Extract hook output if present (only shown when hook produced output)
+  const hookOutput = extractHookOutput(result);
+
   return (
     <div className={className}>
       <ToolComponent
@@ -68,6 +72,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
         // CodeExecution-specific
         nestedCalls={message.nestedCalls}
       />
+      {hookOutput && <HookOutputDisplay output={hookOutput} />}
     </div>
   );
 };

--- a/src/browser/components/tools/shared/HookOutputDisplay.test.ts
+++ b/src/browser/components/tools/shared/HookOutputDisplay.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect } from "bun:test";
+import { extractHookOutput } from "./HookOutputDisplay";
+
+describe("extractHookOutput", () => {
+  test("returns null for null input", () => {
+    expect(extractHookOutput(null)).toBeNull();
+  });
+
+  test("returns null for undefined input", () => {
+    expect(extractHookOutput(undefined)).toBeNull();
+  });
+
+  test("returns null for non-object input", () => {
+    expect(extractHookOutput("string")).toBeNull();
+    expect(extractHookOutput(42)).toBeNull();
+    expect(extractHookOutput(true)).toBeNull();
+  });
+
+  test("returns null when hook_output is missing", () => {
+    expect(extractHookOutput({ success: true })).toBeNull();
+    expect(extractHookOutput({ output: "some output" })).toBeNull();
+  });
+
+  test("returns null when hook_output is empty string", () => {
+    expect(extractHookOutput({ hook_output: "" })).toBeNull();
+  });
+
+  test("returns null when hook_output is not a string", () => {
+    expect(extractHookOutput({ hook_output: 123 })).toBeNull();
+    expect(extractHookOutput({ hook_output: null })).toBeNull();
+    expect(extractHookOutput({ hook_output: { nested: true } })).toBeNull();
+  });
+
+  test("extracts hook_output when present and non-empty", () => {
+    expect(extractHookOutput({ hook_output: "lint errors found" })).toBe("lint errors found");
+    expect(extractHookOutput({ success: true, hook_output: "formatter ran" })).toBe(
+      "formatter ran"
+    );
+  });
+
+  test("extracts hook_output with multiline content", () => {
+    const multiline = "Line 1\nLine 2\nLine 3";
+    expect(extractHookOutput({ hook_output: multiline })).toBe(multiline);
+  });
+});

--- a/src/browser/components/tools/shared/HookOutputDisplay.tsx
+++ b/src/browser/components/tools/shared/HookOutputDisplay.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from "react";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/common/lib/utils";
+import type { WithHookOutput } from "@/common/types/tools";
+
+interface HookOutputDisplayProps {
+  output: string;
+  className?: string;
+}
+
+/**
+ * Type guard to check if an object has hook_output.
+ */
+function hasHookOutput(result: unknown): result is WithHookOutput & { hook_output: string } {
+  return (
+    typeof result === "object" &&
+    result !== null &&
+    "hook_output" in result &&
+    typeof (result as WithHookOutput).hook_output === "string"
+  );
+}
+
+/**
+ * Extract hook_output from a tool result object.
+ * Returns null if no hook output or if the result is not an object with hook_output.
+ */
+export function extractHookOutput(result: unknown): string | null {
+  if (!hasHookOutput(result)) return null;
+  return result.hook_output.length > 0 ? result.hook_output : null;
+}
+
+/**
+ * Subtle, expandable display for tool hook output.
+ * Only shown when a hook produced output (non-empty).
+ */
+export const HookOutputDisplay: React.FC<HookOutputDisplayProps> = ({ output, className }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className={cn("mt-1.5", className)}>
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className={cn(
+          "flex items-center gap-1 text-[10px] text-muted-foreground/70 hover:text-muted-foreground",
+          "transition-colors cursor-pointer select-none"
+        )}
+      >
+        <ChevronRight
+          size={12}
+          className={cn("transition-transform duration-150", expanded && "rotate-90")}
+        />
+        <span className="font-medium">hook output</span>
+      </button>
+      {expanded && (
+        <pre
+          className={cn(
+            "mt-1 ml-3 px-2 py-1.5 rounded text-[10px] leading-relaxed",
+            "bg-muted/30 text-muted-foreground",
+            "whitespace-pre-wrap break-words max-h-[150px] overflow-y-auto",
+            "border-l-2 border-muted-foreground/20"
+          )}
+        >
+          {output}
+        </pre>
+      )}
+    </div>
+  );
+};

--- a/src/browser/stories/App.chat.stories.tsx
+++ b/src/browser/stories/App.chat.stories.tsx
@@ -16,6 +16,8 @@ import {
   createPendingTool,
   createProposePlanTool,
   createWebSearchTool,
+  createBashTool,
+  withHookOutput,
 } from "./mockFactory";
 
 import type { WorkspaceChatMessage } from "@/common/orpc/types";
@@ -1428,6 +1430,144 @@ export const SigningBadgePassphraseWarning: AppStory = {
       description: {
         story:
           "Shows the signing badge in warning state (yellow) when a signing key exists but is passphrase-protected.",
+      },
+    },
+  },
+};
+
+/** Tool hooks output - shows subtle expandable hook output on tool results */
+export const ToolHooksOutput: AppStory = {
+  render: () => (
+    <AppWithMocks
+      setup={() =>
+        setupSimpleChatStory({
+          workspaceId: "ws-tool-hooks",
+          messages: [
+            createUserMessage("msg-1", "Can you fix the lint errors in app.ts?", {
+              historySequence: 1,
+              timestamp: STABLE_TIMESTAMP - 100000,
+            }),
+            createAssistantMessage("msg-2", "I'll fix the lint errors.", {
+              historySequence: 2,
+              timestamp: STABLE_TIMESTAMP - 90000,
+              toolCalls: [
+                // File edit with lint hook output (formatter ran)
+                withHookOutput(
+                  createFileEditTool(
+                    "call-1",
+                    "src/app.ts",
+                    [
+                      "--- src/app.ts",
+                      "+++ src/app.ts",
+                      "@@ -1,3 +1,3 @@",
+                      "-const x=1",
+                      "+const x = 1;",
+                      " ",
+                      " export default x;",
+                    ].join("\n")
+                  ),
+                  "prettier: reformatted src/app.ts\neslint: auto-fixed 2 issues"
+                ),
+                // Bash with failing hook (lint check failed)
+                withHookOutput(
+                  createBashTool(
+                    "call-2",
+                    "npm run build",
+                    "Build complete.",
+                    0,
+                    30,
+                    1500,
+                    "Build"
+                  ),
+                  "post-build hook: running type check...\n✗ Found 1 type error:\n  src/utils.ts:42 - Type 'string' is not assignable to type 'number'"
+                ),
+              ],
+            }),
+            createAssistantMessage("msg-3", "Let me also read the config file.", {
+              historySequence: 3,
+              timestamp: STABLE_TIMESTAMP - 80000,
+              toolCalls: [
+                // File read with no hook output (normal - hook did nothing)
+                createFileReadTool(
+                  "call-3",
+                  "tsconfig.json",
+                  '{\n  "compilerOptions": {\n    "strict": true\n  }\n}'
+                ),
+              ],
+            }),
+          ],
+        })
+      }
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Shows tool hook output as a subtle expandable section below tool results. " +
+          "Hook output only appears when a hook produced output (non-empty). " +
+          "The first two tools have hook output, the third does not.",
+      },
+    },
+  },
+};
+
+/** Tool hooks output expanded - shows hook output in expanded state */
+export const ToolHooksOutputExpanded: AppStory = {
+  render: () => (
+    <AppWithMocks
+      setup={() =>
+        setupSimpleChatStory({
+          workspaceId: "ws-tool-hooks-expanded",
+          messages: [
+            createUserMessage("msg-1", "Run the formatter", {
+              historySequence: 1,
+              timestamp: STABLE_TIMESTAMP - 100000,
+            }),
+            createAssistantMessage("msg-2", "Running the formatter.", {
+              historySequence: 2,
+              timestamp: STABLE_TIMESTAMP - 90000,
+              toolCalls: [
+                withHookOutput(
+                  createBashTool(
+                    "call-1",
+                    "npx prettier --write .",
+                    "Formatted 15 files.",
+                    0,
+                    10,
+                    800,
+                    "Prettier"
+                  ),
+                  "post-hook: git status check\nM  src/app.ts\nM  src/utils.ts\nM  src/config.ts\n\n3 files modified by formatter"
+                ),
+              ],
+            }),
+          ],
+        })
+      }
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Wait for the tool to render
+    await canvas.findByText("npx prettier --write .", {}, { timeout: 5000 });
+
+    // Wait for rendering to complete
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+
+    // Find and click the hook output button to expand it
+    const hookButton = await canvas.findByText("hook output", {}, { timeout: 3000 });
+    await userEvent.click(hookButton);
+
+    // Wait for the expanded content to be visible
+    await canvas.findByText(/post-hook: git status check/, {}, { timeout: 3000 });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Shows the hook output display in its expanded state, revealing the full hook output.",
       },
     },
   },

--- a/src/browser/stories/mockFactory.ts
+++ b/src/browser/stories/mockFactory.ts
@@ -409,6 +409,27 @@ export function createProposePlanTool(
   };
 }
 
+/**
+ * Add hook_output to a tool part's output.
+ * Use this to simulate a tool hook that ran and produced output.
+ * Only works on tool parts with state="output-available".
+ */
+export function withHookOutput(toolPart: MuxPart, hookOutput: string): MuxPart {
+  if (toolPart.type !== "dynamic-tool" || toolPart.state !== "output-available") {
+    return toolPart;
+  }
+  const existingOutput = toolPart.output;
+  return {
+    ...toolPart,
+    output: {
+      ...(typeof existingOutput === "object" && existingOutput !== null
+        ? existingOutput
+        : { result: existingOutput }),
+      hook_output: hookOutput,
+    },
+  };
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // CODE EXECUTION (PTC) TOOL FACTORIES
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/common/types/tools.ts
+++ b/src/common/types/tools.ts
@@ -325,3 +325,21 @@ export type NotifyToolResult =
       success: false;
       error: string;
     };
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Hook Output Types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Tool results may include hook_output when a tool hook (pre/post) produced output.
+ * This is added by withHooks.ts in the backend.
+ */
+export interface WithHookOutput {
+  hook_output?: string;
+}
+
+/**
+ * Type utility to add hook_output to any tool result type.
+ * Use this when you need to represent a result that may have hook output attached.
+ */
+export type MayHaveHookOutput<T> = T & WithHookOutput;


### PR DESCRIPTION
Add subtle expandable indicator for tool hook output in chat history. Only shown when a hook produced non-empty output (i.e., it won't appear if the hook exited normally without doing anything).

## Changes

- **`HookOutputDisplay.tsx`** - New component with chevron toggle, starts collapsed
- **`extractHookOutput`** - Utility to safely extract `hook_output` from tool results
- **`ToolMessage.tsx`** - Integration to show hook output after any tool
- **Storybook** - Two stories: collapsed state and expanded state (via play function)
- **Tests** - Unit tests for extraction logic edge cases

## Visual

Collapsed: `▶ hook output` in muted 10px text below the tool
Expanded: Pre block with left border accent, max 150px height with scroll

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$2.86`_
