### PR TITLE
🤖 feat: add --budget flag to mux run for cost limits

### DIFF
--- a/docs/guides/github-actions.mdx
+++ b/docs/guides/github-actions.mdx
@@ -26,10 +26,11 @@ Here's a minimal example that runs mux in a GitHub Action:
 
 ### Key Options for CI
 
-| Option    | Purpose                                    |
-| --------- | ------------------------------------------ |
-| `--quiet` | Only output final result (cleaner logs)    |
-| `--json`  | Machine-readable NDJSON output for parsing |
+| Option           | Purpose                                        |
+| ---------------- | ---------------------------------------------- |
+| `--quiet`        | Only output final result (cleaner logs)        |
+| `--json`         | Machine-readable NDJSON output for parsing     |
+| `--budget <usd>` | Limit spending per run (e.g., `--budget 1.00`) |
 
 ## Example: Auto-Label Issues and PRs
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -62,6 +62,7 @@ mux run --json "List all TypeScript files" | jq '.type'
 | `--mode <mode>`        |       | Agent mode: `plan` or `exec`                                    | `exec`            |
 | `--thinking <level>`   | `-t`  | Thinking level: `off`, `low`, `medium`, `high`                  | `medium`          |
 | `--timeout <duration>` |       | Timeout (e.g., `5m`, `300s`, `300000`)                          | No timeout        |
+| `--budget <usd>`       | `-b`  | Stop when session cost exceeds budget (USD)                     | No limit          |
 | `--experiment <id>`    | `-e`  | Enable experiment (repeatable)                                  | None              |
 | `--json`               |       | Output NDJSON for programmatic use                              | Off               |
 | `--quiet`              | `-q`  | Only output final result                                        | Off               |
@@ -93,6 +94,9 @@ mux run -r "ssh dev@staging.example.com" -d /app "Update dependencies"
 
 # Scripted usage with timeout
 mux run --json --timeout 5m "Generate API documentation" > output.jsonl
+
+# Limit spending to $2.00
+mux run --budget 2.00 "Refactor the authentication module"
 ```
 
 ## `mux server`


### PR DESCRIPTION
Add real-time cost tracking with `--budget <usd>` flag that stops the session when cumulative costs exceed the specified threshold.

## Implementation

- Reuses existing cost utilities (`createDisplayUsage`, `getTotalCost`) from frontend
- Handles `usage-delta` events to track cumulative session cost  
- Gracefully aborts stream when budget exceeded
- Rejects with error if model has unknown pricing (can't enforce budget)

## Exit codes

| Code | Meaning |
|------|---------|
| 0 | Success |
| 1 | Error (including unknown model pricing) |
| 2 | Budget exceeded (distinct for scripting) |

## Usage

```bash
mux run --budget 1.50 "Quick code review"
mux run -b 0.25 "List files"
```

## NDJSON output (--json)

```json
{"type":"budget-exceeded","spent":1.23,"budget":1.00}
{"type":"budget-error","error":"Cannot enforce budget: unknown pricing for model \"x\"","model":"x"}
```

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$4.21`_
