### PR TITLE
🤖 fix: resolve model aliases in CLI run command

### DIFF
--- a/src/browser/utils/slashCommands/registry.ts
+++ b/src/browser/utils/slashCommands/registry.ts
@@ -10,6 +10,7 @@ import type {
 } from "./types";
 import minimist from "minimist";
 import { MODEL_ABBREVIATIONS } from "@/common/constants/knownModels";
+import { resolveModelAlias } from "@/common/utils/ai/models";
 
 /**
  * Parse multiline command input into first-line tokens and remaining message
@@ -274,9 +275,7 @@ const compactCommandDefinition: SlashCommandDefinition = {
     // Handle -m (model) flag: resolve abbreviation if present, otherwise use as-is
     let model: string | undefined;
     if (parsed.m !== undefined && typeof parsed.m === "string" && parsed.m.trim().length > 0) {
-      const modelInput = parsed.m.trim();
-      // Check if it's an abbreviation
-      model = MODEL_ABBREVIATIONS[modelInput] ?? modelInput;
+      model = resolveModelAlias(parsed.m.trim());
     }
 
     // Reject extra positional arguments UNLESS they're from multiline content
@@ -395,18 +394,10 @@ const modelCommandDefinition: SlashCommandDefinition = {
     if (cleanRemainingTokens.length === 1) {
       const token = cleanRemainingTokens[0];
 
-      // Check if it's an abbreviation
-      if (MODEL_ABBREVIATIONS[token]) {
-        return {
-          type: "model-set",
-          modelString: MODEL_ABBREVIATIONS[token],
-        };
-      }
-
-      // Otherwise treat as full model string (e.g., "anthropic:opus" or "anthropic:claude-opus-4-1")
+      // Resolve abbreviation if present, otherwise use as full model string
       return {
         type: "model-set",
-        modelString: token,
+        modelString: resolveModelAlias(token),
       };
     }
 

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -45,7 +45,7 @@ import {
   formatGenericToolEnd,
   isMultilineResultTool,
 } from "./toolFormatters";
-import { defaultModel } from "@/common/utils/ai/models";
+import { defaultModel, resolveModelAlias } from "@/common/utils/ai/models";
 import { buildProvidersFromEnv, hasAnyConfiguredProvider } from "@/node/utils/providerRequirements";
 
 import type { ThinkingLevel } from "@/common/types/thinking";
@@ -347,7 +347,7 @@ async function main(): Promise<void> {
   const projectDir = path.resolve(opts.dir);
   await ensureDirectory(projectDir);
 
-  const model: string = opts.model;
+  const model: string = resolveModelAlias(opts.model);
   const runtimeConfig = parseRuntimeConfig(opts.runtime, config.srcDir);
   const thinkingLevel = parseThinkingLevel(opts.thinking);
   const initialMode = parseMode(opts.mode);

--- a/src/common/utils/ai/models.test.ts
+++ b/src/common/utils/ai/models.test.ts
@@ -4,6 +4,7 @@ import {
   getModelName,
   supports1MContext,
   isValidModelFormat,
+  resolveModelAlias,
 } from "./models";
 
 describe("normalizeGatewayModel", () => {
@@ -91,5 +92,21 @@ describe("isValidModelFormat", () => {
 
     // Empty string
     expect(isValidModelFormat("")).toBe(false);
+  });
+});
+
+describe("resolveModelAlias", () => {
+  it("resolves known aliases to full model strings", () => {
+    expect(resolveModelAlias("haiku")).toBe("anthropic:claude-haiku-4-5");
+    expect(resolveModelAlias("sonnet")).toBe("anthropic:claude-sonnet-4-5");
+    expect(resolveModelAlias("opus")).toBe("anthropic:claude-opus-4-5");
+    expect(resolveModelAlias("grok")).toBe("xai:grok-4-1-fast");
+    expect(resolveModelAlias("codex")).toBe("openai:gpt-5.1-codex");
+  });
+
+  it("returns non-alias strings unchanged", () => {
+    expect(resolveModelAlias("anthropic:custom-model")).toBe("anthropic:custom-model");
+    expect(resolveModelAlias("openai:gpt-5.2")).toBe("openai:gpt-5.2");
+    expect(resolveModelAlias("unknown")).toBe("unknown");
   });
 });

--- a/src/common/utils/ai/models.ts
+++ b/src/common/utils/ai/models.ts
@@ -2,9 +2,18 @@
  * Model configuration and constants
  */
 
-import { DEFAULT_MODEL } from "@/common/constants/knownModels";
+import { DEFAULT_MODEL, MODEL_ABBREVIATIONS } from "@/common/constants/knownModels";
 
 export const defaultModel = DEFAULT_MODEL;
+
+/**
+ * Resolve model alias to full model string.
+ * If the input is an alias (e.g., "haiku", "sonnet"), returns the full model string.
+ * Otherwise returns the input unchanged.
+ */
+export function resolveModelAlias(modelInput: string): string {
+  return MODEL_ABBREVIATIONS[modelInput] ?? modelInput;
+}
 
 /**
  * Validate model string format (must be "provider:model-id").


### PR DESCRIPTION
Add `resolveModelAlias()` utility to convert short aliases (haiku, sonnet, opus, grok, etc.) to full model strings (anthropic:claude-haiku-4-5, etc.).

**Changes:**
- CLI run command now correctly handles aliases like `mux run -m haiku`
- Frontend slash commands now use the shared `resolveModelAlias` function
- Added tests for the new utility

**Before:**
```
$ mux run -m haiku say hello
Error: Failed to send message: {"type":"invalid_model_string","message":"Invalid model string format: \haiku\"}
```

**After:**
```
$ mux run -m haiku say hello
# Works correctly, resolves to anthropic:claude-haiku-4-5
```

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$1.12`_