### PR TITLE
🤖 fix: clean up GitHub Actions guide wording

### DIFF
--- a/docs/guides/github-actions.mdx
+++ b/docs/guides/github-actions.mdx
@@ -19,10 +19,10 @@ Here's a minimal example that runs mux in a GitHub Action:
   env:
     ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  run: bunx mux run "Review this PR for critical issues. Use set_exit_code to exit 1 if issues are found."
+  run: bunx mux run "Review this PR for critical issues. If any are found, exit with 1 to block merge."
 ```
 
-The `set_exit_code` tool (CLI-only) lets agents set the process exit code to signal failure.
+`mux run` supports agent-controlled exit codes, so the workflow step can fail when issues are found.
 
 ### Key Options for CI
 
@@ -33,7 +33,7 @@ The `set_exit_code` tool (CLI-only) lets agents set the process exit code to sig
 
 ## Example: Auto-Label Issues and PRs
 
-This workflow automatically labels new issues and pull requests by having mux analyze the content and select appropriate labels from your repository's label set.
+This is the exact workflow used live in the Mux repo (see [`.github/workflows/auto-label.yml`](https://github.com/coder/mux/blob/main/.github/workflows/auto-label.yml)). It automatically labels new issues and pull requests by having mux analyze the content and select appropriate labels from your repository's label set.
 
 {/* BEGIN AUTO_LABEL_WORKFLOW */}
 


### PR DESCRIPTION
- Update the basic `mux run` example to say "Exit with 1" (no internal tool name).
- Add a note that the auto-label workflow is used live in the Mux repo and link to the workflow file.

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$28.03`_
