### PR TITLE
🤖 fix: add git fetch before sync check in wait_pr_checks.sh

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -22,12 +22,7 @@ description: Agent instructions for AI assistants working on the mux codebase
 ## PR + Release Workflow
 
 - Reuse existing PRs; never close or recreate without instruction. Force-push updates.
-- After every push run:
-
-```bash
-gh pr view <number> --json mergeable,mergeStateStatus | jq '.'
-./scripts/wait_pr_checks.sh <pr_number>
-```
+- After every push run `./scripts/wait_pr_checks.sh <pr_number>` to ensure CI passes.
 
 - When posting multi-line comments with `gh` (e.g., `@codex review`), **do not** rely on `\n` escapes inside quoted `--body` strings (they will be sent as literal text). Prefer `--body-file -` with a heredoc to preserve real newlines:
 

--- a/scripts/wait_pr_checks.sh
+++ b/scripts/wait_pr_checks.sh
@@ -42,6 +42,9 @@ if [[ -z "$REMOTE_BRANCH" ]]; then
   fi
 fi
 
+# Fetch latest remote state before comparing
+git fetch origin "$CURRENT_BRANCH" --quiet 2>/dev/null || true
+
 # Check if local and remote are in sync
 LOCAL_HASH=$(git rev-parse HEAD)
 REMOTE_HASH=$(git rev-parse "$REMOTE_BRANCH")


### PR DESCRIPTION
## Summary

The `wait_pr_checks.sh` script was comparing local HEAD against stale tracking refs, causing false "not in sync" errors when called immediately after a push.

## Changes

- Add `git fetch origin $CURRENT_BRANCH --quiet` before comparing local/remote hashes
- Simplify AGENTS.md post-push instruction (redundant `gh pr view` removed since script handles sync validation)

## Root Cause

The script did `git rev-parse "$REMOTE_BRANCH"` without fetching first, comparing against the local copy of the remote ref which could be stale after a push.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.20`_
<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=0.20 -->