### PR TITLE
🤖 fix: eliminate terminal resize race condition

### DIFF
--- a/src/browser/terminal/TerminalSessionRouter.ts
+++ b/src/browser/terminal/TerminalSessionRouter.ts
@@ -149,9 +149,12 @@ export class TerminalSessionRouter {
 
   /**
    * Resize a terminal session.
+   *
+   * Returns a promise that resolves when the backend handler has completed.
+   * (This is used by TerminalView to keep frontend and PTY dimensions in sync.)
    */
-  resize(sessionId: string, cols: number, rows: number): void {
-    void this.api.terminal.resize({ sessionId, cols, rows });
+  resize(sessionId: string, cols: number, rows: number): Promise<void> {
+    return this.api.terminal.resize({ sessionId, cols, rows });
   }
 
   /**


### PR DESCRIPTION
The previous approach resized the frontend terminal immediately but debounced the PTY resize by 300ms. During that window, shell output formatted for the old dimensions would display incorrectly in the already-resized frontend terminal, causing text clobbering.

**Symptoms:** Output from commands like `git status --stat` would have columns bleeding into each other - e.g., diff stats appearing mid-line, "modified" becoming "commodified" as text from different areas overlapped.

**Root cause:** Frontend `fitAddon.fit()` ran immediately on resize, but `router.resize()` was debounced by 300ms. During that 300ms window, the shell formatted output for the old PTY dimensions while the frontend displayed it at the new dimensions.

**Fix:** Use `requestAnimationFrame` to batch resize events, then resize both frontend and PTY in the same tick. This eliminates the window where sizes can diverge.

- Simpler code (no setTimeout, no pendingResize state)
- Natural batching via RAF (coalesces rapid resize events)
- No race between frontend and PTY dimensions

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: $3.75_