### PR TITLE
🤖 fix: use global timeout for mux agent in Terminal-Bench

### DIFF
--- a/benchmarks/terminal_bench/mux_agent.py
+++ b/benchmarks/terminal_bench/mux_agent.py
@@ -221,11 +221,11 @@ class MuxAgent(AbstractInstalledAgent):
     def _run_agent_commands(self, instruction: str) -> list[TerminalCommand]:
         escaped = shlex.quote(instruction)
         command = f"bash /installed-agent/{self._RUNNER_NAME} {escaped}"
-        # Don't set max_timeout_sec - terminal-bench enforces global timeout
         return [
             TerminalCommand(
                 command=command,
                 min_timeout_sec=0.0,
+                max_timeout_sec=float("inf"),  # Let global timeout handle this
                 block=True,
                 append_enter=True,
             )


### PR DESCRIPTION
## Problem

Nightly Terminal-Bench runs show tasks "timing out after 1800.0s" when they've only been running for ~3-4 minutes:

```
04:26:22 Starting harness run
04:30:09 Agent timed out after 1800.0s for task build-linux-kernel-qemu.
04:30:34 Agent timed out after 1800.0s for task play-zork.
```

This results in **47 out of 80 tasks timing out** and an accuracy of only ~41% when many of those tasks would have succeeded given more time.

## Root Cause

Terminal-Bench has **two independent timeout mechanisms**:

| Timeout | Default | Purpose |
|---------|---------|---------|
| Per-command (`TerminalCommand.max_timeout_sec`) | **180s** | Individual shell commands |
| Global agent (`--global-agent-timeout-sec`) | 1800s | Overall task limit |

The mux agent wraps the entire agent session in a single blocking command (`bash mux-run.sh`), but **did not set `max_timeout_sec`**, causing it to inherit the 180s default.

When `send_keys` times out after 180s, it raises `TimeoutError`. In Python 3.11+, this is the same as `asyncio.TimeoutError`, so Terminal-Bench catches it and logs "Agent timed out after 1800.0s" (the *configured* global timeout, not the *actual* 180s that fired).

## Why 180s Per-Command Timeout Is Wrong for Agent Wrappers

The 180s default is designed for **interactive shell commands** where the agent makes many small calls:

```
agent: run `make build`     → waits up to 180s → prompt returns
agent: run `./test.sh`      → waits up to 180s → prompt returns  
agent: run `cat output.log` → waits up to 180s → prompt returns
```

But mux (like Claude Code and Codex) wraps the **entire agent session** in a single command:

```
harness: run `bash mux-run.sh "build a linux kernel"`
         ↳ mux agent works for 15 minutes internally
         ↳ shell prompt returns when agent finishes
```

With a 180s per-command timeout, the agent gets killed after 3 minutes even if it's productively working on a 15-minute task.

## Why Global Timeout Is Correct

The global timeout (`--global-agent-timeout-sec 1800`) wraps the entire `perform_task()` call with `asyncio.wait_for()`. This is the right place to enforce time limits because:

1. **It measures actual agent runtime** - starts when the agent begins working, not during setup
2. **It's configurable per-run** - we set it to 1800s via `TB_TIMEOUT` in the Makefile
3. **It catches stuck agents** - if the agent loops forever, it gets killed at 30 min
4. **It doesn't kill productive work** - tasks that need 10-20 minutes can complete

## The Fix

Set `max_timeout_sec=float("inf")` to disable the per-command timeout, matching the pattern used by all official Terminal-Bench agents:

```python
# claude_code_agent.py
TerminalCommand(
    command=f"claude --verbose ...",
    max_timeout_sec=float("inf"),  # ← Standard pattern
    block=True,
)

# codex_agent.py
TerminalCommand(
    command="codex exec ...",
    max_timeout_sec=float("inf"),  # ← Standard pattern
    block=True,
)
```

## Expected Impact

Tasks that need 3-30 minutes to complete (kernel builds, model training, complex debugging) will now have time to finish instead of being killed at 3 minutes. Accuracy should improve significantly.

## Verification

The math confirms this was the bug:
- 80 tasks, 47 "timed out after 1800s"
- Total run time: **69 minutes**
- If 47 tasks actually waited 1800s each: `47 × 30min / 4 concurrency = 352 minutes minimum`
- Actual timing matches `47 × 3min / 4 = ~35 minutes` → tasks were dying at **180s**, not 1800s

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$8.49`_
