### PR TITLE
🤖 fix: use destroy() for splash screen to avoid WebContents race

### DIFF
--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -286,8 +286,11 @@ async function showSplashScreen() {
 function closeSplashScreen() {
   if (splashWindow) {
     console.log(`[${timestamp()}] Closing splash screen...`);
-    splashWindow.close();
+    const win = splashWindow;
     splashWindow = null;
+    if (!win.isDestroyed()) {
+      win.destroy(); // Immediate destruction - avoids race with internal renderer scripts
+    }
   }
 }
 

--- a/src/node/services/tools/notify.ts
+++ b/src/node/services/tools/notify.ts
@@ -76,7 +76,7 @@ async function sendElectronNotification(
     notification.on("click", () => {
       const windows = BrowserWindow.getAllWindows();
       const mainWindow = windows[0];
-      if (mainWindow) {
+      if (mainWindow && !mainWindow.isDestroyed()) {
         // Restore if minimized, then focus
         if (mainWindow.isMinimized()) {
           mainWindow.restore();


### PR DESCRIPTION
When the splash screen closes via `close()`, Electron's internal sandboxed renderer scripts may still be executing. These scripts try to access `webContents` properties after destruction, causing:

```
Error invoking remote method 'BROWSER_GET_LAST_WEB_PREFERENCES': WebContents does not exist
Electron sandboxed_renderer.bundle.js script failed to run
TypeError: object null is not iterable
```

**Fix:** Use `destroy()` instead of `close()` for immediate window destruction without waiting for internal scripts. This is appropriate since the splash has no state to preserve.

Also adds `isDestroyed()` guard in `notify.ts` for notification click handlers.

---
_Generated with `mux` • Model: `mux-gateway:anthropic/claude-opus-4-5` • Thinking: `high` • Cost: `$2.42`_
<!-- mux-attribution: model=mux-gateway:anthropic/claude-opus-4-5 thinking=high costs=2.42 -->
