### PR TITLE
🤖 fix: keep manifest/icon URLs absolute for Coder hosted app

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,9 @@
     />
     <meta name="description" content="Parallel agentic development with Electron + React" />
     <meta name="theme-color" content="#1e1e1e" />
-    <link rel="manifest" href="/manifest.json" />
-    <link rel="icon" href="/favicon.ico" />
-    <link rel="apple-touch-icon" href="/icon.png" />
+    <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" vite-ignore />
+    <link rel="icon" href="/favicon.ico" vite-ignore />
+    <link rel="apple-touch-icon" href="/icon.png" vite-ignore />
     <title>mux - coder multiplexer</title>
     <style>
       body {


### PR DESCRIPTION
When mux is hosted as a Coder Application and loaded from `/workspace/<id>`, the browser can end up requesting the web manifest at `/workspace/manifest.json` (Vite `base: "./"` HTML rewriting + deep route).

Manifest fetches are credential-less by default, which triggers Coder's `applications/auth-redirect` and a CORS failure.

Fix:
- Keep manifest href root-absolute in built HTML (`vite-ignore`)
- Ensure cookies are sent for the manifest request (`crossorigin="use-credentials"`)
- Harden favicon + apple-touch-icon similarly (`vite-ignore`)

Test:
- `make build-renderer` (verified `dist/index.html` uses `/manifest.json`)
- `make static-check`

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh`_
