### PR TITLE
🤖 fix: derive TelemetryRuntimeType from RuntimeModeSchema

### DIFF
--- a/src/common/orpc/schemas/telemetry.ts
+++ b/src/common/orpc/schemas/telemetry.ts
@@ -7,6 +7,7 @@
 
 import { z } from "zod";
 import { AgentModeSchema } from "../../types/mode";
+import { RuntimeModeSchema } from "./runtime";
 
 // Error context enum (matches payload.ts)
 const ErrorContextSchema = z.enum([
@@ -20,8 +21,8 @@ const ErrorContextSchema = z.enum([
   "git-operation",
 ]);
 
-// Runtime type enum (matches payload.ts TelemetryRuntimeType)
-const TelemetryRuntimeTypeSchema = z.enum(["local", "worktree", "ssh"]);
+// Runtime type - derived from RuntimeModeSchema to stay in sync
+const TelemetryRuntimeTypeSchema = RuntimeModeSchema;
 
 // Frontend platform info (matches payload.ts FrontendPlatformInfo)
 const FrontendPlatformInfoSchema = z.object({

--- a/src/common/telemetry/payload.ts
+++ b/src/common/telemetry/payload.ts
@@ -21,6 +21,7 @@
  */
 
 import type { AgentMode } from "@/common/types/mode";
+import type { RuntimeMode } from "@/common/types/runtime";
 
 /**
  * Base properties included with all telemetry events
@@ -50,10 +51,10 @@ export interface AppStartedPayload {
 }
 
 /**
- * Runtime type for telemetry - normalized from RuntimeConfig
- * Values: 'local' (project-dir), 'worktree' (git worktree isolation), 'ssh' (remote execution)
+ * Runtime type for telemetry - derived from RuntimeMode to stay in sync.
+ * Values: 'local' (project-dir), 'worktree' (git worktree isolation), 'ssh' (remote), 'docker' (container)
  */
-export type TelemetryRuntimeType = "local" | "worktree" | "ssh";
+export type TelemetryRuntimeType = RuntimeMode;
 
 /**
  * Frontend platform info - browser/client environment

--- a/src/common/telemetry/utils.ts
+++ b/src/common/telemetry/utils.ts
@@ -48,22 +48,18 @@ export function getRuntimeTypeForTelemetry(
     return "worktree";
   }
 
-  if (runtimeConfig.type === "ssh") {
-    return "ssh";
+  switch (runtimeConfig.type) {
+    case "ssh":
+      return "ssh";
+    case "docker":
+      return "docker";
+    case "worktree":
+      return "worktree";
+    case "local":
+      // Check if it has srcBaseDir (legacy worktree)
+      if ("srcBaseDir" in runtimeConfig && runtimeConfig.srcBaseDir) {
+        return "worktree"; // Legacy worktree config
+      }
+      return "local"; // True project-dir local
   }
-
-  if (runtimeConfig.type === "worktree") {
-    return "worktree";
-  }
-
-  // "local" type - check if it has srcBaseDir (legacy worktree)
-  if (runtimeConfig.type === "local") {
-    if ("srcBaseDir" in runtimeConfig && runtimeConfig.srcBaseDir) {
-      return "worktree"; // Legacy worktree config
-    }
-    return "local"; // True project-dir local
-  }
-
-  // Fallback
-  return "worktree";
 }


### PR DESCRIPTION
## Problem

`TelemetryRuntimeType` was a hardcoded union (`"local" | "worktree" | "ssh"`) that got out of sync when Docker runtime was added.

## Solution

Derive telemetry types from the source of truth (`RuntimeModeSchema`):

- **payload.ts**: `TelemetryRuntimeType = RuntimeMode` (type alias)
- **telemetry.ts**: `TelemetryRuntimeTypeSchema = RuntimeModeSchema` (zod schema)
- **utils.ts**: Exhaustive `switch` in `getRuntimeTypeForTelemetry()`

The exhaustive switch ensures compile errors if new runtime types are added without updating telemetry handling.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.98`_