### PR TITLE
🤖 fix: init hook output colors in light mode

### DIFF
--- a/src/browser/components/Messages/InitMessage.tsx
+++ b/src/browser/components/Messages/InitMessage.tsx
@@ -77,8 +77,8 @@ export const InitMessage = React.memo<InitMessageProps>(({ message, className })
           ref={preRef}
           className={cn(
             "m-0 mt-2.5 max-h-[120px] overflow-auto rounded-sm",
-            "bg-black/30 px-2 py-1.5 font-mono text-[11px] leading-relaxed whitespace-pre-wrap",
-            isError ? "text-danger-soft" : "text-light"
+            "bg-init-output-bg px-2 py-1.5 font-mono text-[11px] leading-relaxed whitespace-pre-wrap",
+            isError ? "text-init-output-error-text" : "text-init-output-text"
           )}
         >
           {message.truncatedLines && (
@@ -88,7 +88,7 @@ export const InitMessage = React.memo<InitMessageProps>(({ message, className })
             </span>
           )}
           {message.lines.map((line, idx) => (
-            <span key={idx} className={line.isError ? "text-danger-soft" : undefined}>
+            <span key={idx} className={line.isError ? "text-init-output-error-text" : undefined}>
               {line.line}
               {idx < message.lines.length - 1 ? "\n" : ""}
             </span>

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -271,6 +271,9 @@
     --color-init-border: hsl(210 27% 25%); /* #2f3f52 */
     --color-init-error-bg: hsl(0 33% 17%); /* #3a1e1e */
     --color-init-error-border: hsl(0 28% 30%); /* #653737 */
+    --color-init-output-bg: hsl(210 20% 12%); /* dark output bg */
+    --color-init-output-text: hsl(0 0% 73%); /* light text */
+    --color-init-output-error-text: hsl(6 93% 71%); /* error text */
 
     /* Toast and notification backgrounds */
     --color-toast-success-bg: hsl(207 100% 37% / 0.13); /* #0e639c with 20% opacity */
@@ -530,6 +533,15 @@
   --color-review-warning-light: hsl(38 100% 88%);
 
   --color-error-bg-dark: hsl(0 65% 86%);
+
+  /* Init message surfaces */
+  --color-init-bg: hsl(210 36% 94%);
+  --color-init-border: hsl(210 28% 82%);
+  --color-init-error-bg: hsl(0 56% 94%);
+  --color-init-error-border: hsl(0 48% 78%);
+  --color-init-output-bg: hsl(210 30% 90%);
+  --color-init-output-text: hsl(210 18% 28%);
+  --color-init-output-error-text: hsl(0 65% 42%);
 
   --radius: 0.5rem;
 }


### PR DESCRIPTION
Fixes init hook output rendering in light theme by:
- Adding light-theme overrides for init surfaces.
- Using init output theme tokens for the log <pre> instead of hardcoded dark colors.

Validation:
- `make static-check`

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `high` • Cost: `$0.82`_
