### PR TITLE
🤖 fix: prevent auto-labeler from creating new labels

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -32,9 +32,10 @@ jobs:
           [ -z "$ANTHROPIC_API_KEY" ] && echo "Skipping (no API key)" && exit 0
 
           bunx mux@next run --budget 0.50 "
-            Label this GitHub $TYPE. Steps:
+            Label this GitHub $TYPE using ONLY existing labels. Steps:
             1. gh label list --json name,description
             2. gh $TYPE view $NUMBER
             3. gh $TYPE edit $NUMBER --add-label <labels>
-            Pick 1-3 fitting labels. If none fit, skip step 3.
+            Pick 1-3 labels from the list in step 1. Do NOT create new labels.
+            If no existing labels fit well, skip step 3.
           "

--- a/docs/guides/github-actions.mdx
+++ b/docs/guides/github-actions.mdx
@@ -73,11 +73,12 @@ jobs:
           [ -z "$ANTHROPIC_API_KEY" ] && echo "Skipping (no API key)" && exit 0
 
           bunx mux@next run --budget 0.50 "
-            Label this GitHub $TYPE. Steps:
+            Label this GitHub $TYPE using ONLY existing labels. Steps:
             1. gh label list --json name,description
             2. gh $TYPE view $NUMBER
             3. gh $TYPE edit $NUMBER --add-label <labels>
-            Pick 1-3 fitting labels. If none fit, skip step 3.
+            Pick 1-3 labels from the list in step 1. Do NOT create new labels.
+            If no existing labels fit well, skip step 3.
           "
 ```
 


### PR DESCRIPTION
The auto-labeler prompt was not explicit enough about only using existing labels. This change makes the constraint clear:

- "using ONLY existing labels"
- "Pick 1-3 labels from the list in step 1"
- "Do NOT create new labels"

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$3.75`_