### PR TITLE
🤖 fix: improve file_edit_insert guard guidance

### DIFF
--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -540,7 +540,9 @@ export const TOOL_DEFINITIONS = {
       "Insert content into a file using substring guards. " +
       "Provide exactly one of before or after to anchor the operation when editing an existing file. " +
       "When the file does not exist, it is created automatically without guards. " +
-      `Optional before/after substrings must uniquely match surrounding content. ${TOOL_EDIT_WARNING}`,
+      "Optional before/after substrings must uniquely match surrounding content. " +
+      "Avoid short guards like `}` or `}\\n` that match multiple locations — " +
+      `use longer patterns like full function signatures or unique comments. ${TOOL_EDIT_WARNING}`,
     schema: z
       .object({
         file_path: FILE_EDIT_FILE_PATH,

--- a/src/node/services/tools/file_edit_insert.ts
+++ b/src/node/services/tools/file_edit_insert.ts
@@ -183,7 +183,7 @@ function findUniqueSubstringIndex(
   const secondIndex = haystack.indexOf(needle, firstIndex + needle.length);
   if (secondIndex !== -1) {
     return guardFailure(
-      `Guard mismatch: ${label} substring matched multiple times. Provide a more specific string.`
+      `Guard mismatch: ${label} substring matched multiple times. Include more surrounding context (e.g., full signature, adjacent lines) to make it unique.`
     );
   }
 


### PR DESCRIPTION
Improve tool description and error message to help models avoid common guard failures (short patterns like `}` matching multiple locations).

**Changes:**
- Add guidance in description: avoid short guards, use full signatures or unique comments
- Improve error message: suggest including more surrounding context (e.g., full signature, adjacent lines)

**Before:** Error said "Provide a more specific string" with no actionable guidance.
**After:** Error suggests "Include more surrounding context (e.g., full signature, adjacent lines) to make it unique."

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.24`_