### PR TITLE
🤖 perf: remove redundant metadata fetches after workspace updates

### DIFF
--- a/src/browser/contexts/WorkspaceContext.tsx
+++ b/src/browser/contexts/WorkspaceContext.tsx
@@ -590,8 +590,9 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
           // Backend has already updated the config - reload projects to get updated state
           await refreshProjects();
 
-          // Reload workspace metadata
-          await loadWorkspaceMetadata();
+          // Workspace metadata subscription handles the removal automatically.
+          // No need to refetch all metadata - this avoids expensive post-compaction
+          // state checks for all workspaces.
 
           // If the removed workspace was selected (URL was on this workspace),
           // navigate to its project page instead of going home
@@ -610,14 +611,7 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
         return { success: false, error: errorMessage };
       }
     },
-    [
-      currentWorkspaceId,
-      loadWorkspaceMetadata,
-      navigateToProject,
-      refreshProjects,
-      selectedWorkspace,
-      api,
-    ]
+    [currentWorkspaceId, navigateToProject, refreshProjects, selectedWorkspace, api]
   );
 
   /**
@@ -638,8 +632,9 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
       try {
         const result = await api.workspace.updateTitle({ workspaceId, title: newTitle });
         if (result.success) {
-          // Reload workspace metadata to get the updated title
-          await loadWorkspaceMetadata();
+          // Workspace metadata subscription handles the title update automatically.
+          // No need to refetch all metadata - this avoids expensive post-compaction
+          // state checks for all workspaces (which can be slow for SSH workspaces).
           return { success: true };
         } else {
           console.error("Failed to update workspace title:", result.error);
@@ -651,7 +646,7 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
         return { success: false, error: errorMessage };
       }
     },
-    [loadWorkspaceMetadata, api]
+    [api]
   );
 
   const archiveWorkspace = useCallback(
@@ -682,8 +677,7 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
       try {
         const result = await api.workspace.unarchive({ workspaceId });
         if (result.success) {
-          // Reload workspace metadata to get the updated state
-          await loadWorkspaceMetadata();
+          // Workspace metadata subscription handles the state update automatically.
           return { success: true };
         } else {
           console.error("Failed to unarchive workspace:", result.error);
@@ -695,7 +689,7 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
         return { success: false, error: errorMessage };
       }
     },
-    [loadWorkspaceMetadata, api]
+    [api]
   );
 
   const refreshWorkspaceMetadata = useCallback(async () => {


### PR DESCRIPTION
## Summary

The frontend was calling `loadWorkspaceMetadata()` after title/archive/remove operations even though the backend already emits updated metadata through the subscription. This caused a full `workspace.list()` call which:

1. Fetches metadata for ALL workspaces
2. When post-compaction experiment is enabled, runs `getPostCompactionState()` for each workspace  
3. For SSH workspaces, this involves `runtime.stat()` calls over the network

For SSH workspaces with multiple open projects, this could add **several seconds of latency** to simple title updates.

## Fix

Trust the metadata subscription (like `archiveWorkspace` already does) instead of re-fetching everything. The subscription handler already correctly updates the `workspaceMetadata` map when metadata events arrive.

## Changes

- `renameWorkspace`: Remove `loadWorkspaceMetadata()` call
- `removeWorkspace`: Remove `loadWorkspaceMetadata()` call  
- `unarchiveWorkspace`: Remove `loadWorkspaceMetadata()` call

## Regression Risk: Low

This change aligns these operations with the existing `archiveWorkspace` pattern, which already trusts the subscription and has the comment: *"Workspace list + navigation are driven by the workspace metadata subscription."*

**Why this is safe:**
1. **Backend guarantees emit**: After each operation, the backend explicitly calls `session.emitMetadata()` or `this.emit("metadata", ...)` with the updated metadata
2. **Subscription is reliable**: The `onMetadata` async iterator is an established pattern used throughout the app
3. **Battle-tested pattern**: `archiveWorkspace` has been using this exact approach without issues
4. **Graceful degradation**: Even if a subscription event were missed (unlikely), the next app refresh or workspace switch would restore correct state

**What could go wrong:**
- If subscription delivery fails silently, the UI might show stale data until next refresh
- This is theoretical - the subscription uses oRPC streaming which surfaces errors

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$1.26`_