### PR TITLE
🤖 feat: persist provider selection when adding custom models

### DIFF
--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -37,6 +37,12 @@ export const GLOBAL_SCOPE_ID = "__global__";
 export const UI_THEME_KEY = "uiTheme";
 
 /**
+ * Get the localStorage key for the last selected provider when adding custom models (global)
+ * Format: "lastCustomModelProvider"
+ */
+export const LAST_CUSTOM_MODEL_PROVIDER_KEY = "lastCustomModelProvider";
+
+/**
  * Get the localStorage key for the currently selected workspace (global)
  * Format: "selectedWorkspace"
  */


### PR DESCRIPTION
The provider dropdown in the custom models form now remembers your last selection via localStorage, making it faster to add multiple models for the same provider.

## Changes

- Added `LAST_CUSTOM_MODEL_PROVIDER_KEY` storage constant
- Replaced inline `NewModelForm` state with `usePersistedState` for provider and regular `useState` for model ID
- Provider selection persists across sessions; model ID clears after each add

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.61`_