### PR TITLE
🤖 feat: Models page table layout with context window and rich tooltips

### DIFF
--- a/src/browser/components/Settings/sections/ModelRow.tsx
+++ b/src/browser/components/Settings/sections/ModelRow.tsx
@@ -6,6 +6,103 @@ import { cn } from "@/common/lib/utils";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/browser/components/ui/tooltip";
 import { ProviderWithIcon } from "@/browser/components/ProviderIcon";
 import { Button } from "@/browser/components/ui/button";
+import { getModelStats, type ModelStats } from "@/common/utils/tokens/modelStats";
+
+/** Format tokens as human-readable string (e.g. 200000 -> "200k") */
+function formatTokenCount(tokens: number): string {
+  if (tokens >= 1_000_000) {
+    const m = tokens / 1_000_000;
+    return m % 1 === 0 ? `${m}M` : `${m.toFixed(1)}M`;
+  }
+  if (tokens >= 1_000) {
+    const k = tokens / 1_000;
+    return k % 1 === 0 ? `${k}k` : `${k.toFixed(1)}k`;
+  }
+  return tokens.toString();
+}
+
+/** Format cost per million tokens (e.g. 0.000001 -> "$1.00") */
+function formatCostPerMillion(costPerToken: number): string {
+  const perMillion = costPerToken * 1_000_000;
+  if (perMillion < 0.01) return "~$0.00";
+  return `$${perMillion.toFixed(2)}`;
+}
+
+function ModelTooltipContent(props: {
+  fullId: string;
+  aliases?: string[];
+  stats: ModelStats | null;
+}) {
+  return (
+    <div className="max-w-xs space-y-2 text-xs">
+      <div className="text-foreground font-mono">{props.fullId}</div>
+
+      {props.aliases && props.aliases.length > 0 && (
+        <div className="text-muted">
+          <span className="text-muted-light">Aliases: </span>
+          {props.aliases.join(", ")}
+        </div>
+      )}
+
+      {props.stats && (
+        <>
+          <div className="border-separator-light border-t pt-2">
+            <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+              <div className="text-muted-light">Context Window</div>
+              <div className="text-foreground">
+                {formatTokenCount(props.stats.max_input_tokens)}
+              </div>
+
+              {props.stats.max_output_tokens && (
+                <>
+                  <div className="text-muted-light">Max Output</div>
+                  <div className="text-foreground">
+                    {formatTokenCount(props.stats.max_output_tokens)}
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+
+          <div className="border-separator-light border-t pt-2">
+            <div className="text-muted-light mb-1">Pricing (per 1M tokens)</div>
+            <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+              <div className="text-muted-light">Input</div>
+              <div className="text-foreground">
+                {formatCostPerMillion(props.stats.input_cost_per_token)}
+              </div>
+
+              <div className="text-muted-light">Output</div>
+              <div className="text-foreground">
+                {formatCostPerMillion(props.stats.output_cost_per_token)}
+              </div>
+
+              {props.stats.cache_read_input_token_cost !== undefined && (
+                <>
+                  <div className="text-muted-light">Cache Read</div>
+                  <div className="text-foreground">
+                    {formatCostPerMillion(props.stats.cache_read_input_token_cost)}
+                  </div>
+                </>
+              )}
+
+              {props.stats.cache_creation_input_token_cost !== undefined && (
+                <>
+                  <div className="text-muted-light">Cache Write</div>
+                  <div className="text-foreground">
+                    {formatCostPerMillion(props.stats.cache_creation_input_token_cost)}
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+
+      {!props.stats && <div className="text-muted-light italic">No pricing data available</div>}
+    </div>
+  );
+}
 
 export interface ModelRowProps {
   provider: string;
@@ -36,16 +133,19 @@ export interface ModelRowProps {
 }
 
 export function ModelRow(props: ModelRowProps) {
-  return (
-    <div className="border-border-medium bg-background-secondary flex items-center justify-between gap-2 rounded-md border px-2 py-1.5 md:px-3">
-      <div className="flex min-w-0 flex-1 items-center gap-1.5 md:gap-2">
-        <ProviderWithIcon
-          provider={props.provider}
-          displayName
-          className="text-muted w-16 shrink-0 overflow-hidden text-xs md:w-20"
-        />
-        {props.isEditing ? (
-          <div className="flex min-w-0 flex-1 items-center gap-1">
+  const stats = getModelStats(props.fullId);
+
+  // Editing mode - render as a full-width row
+  if (props.isEditing) {
+    return (
+      <tr className="border-border-medium border-b">
+        <td colSpan={4} className="px-2 py-1.5 md:px-3">
+          <div className="flex items-center gap-2">
+            <ProviderWithIcon
+              provider={props.provider}
+              displayName
+              className="text-muted w-16 shrink-0 overflow-hidden text-xs md:w-20"
+            />
             <input
               type="text"
               value={props.editValue ?? props.modelId}
@@ -57,29 +157,6 @@ export function ModelRow(props: ModelRowProps) {
               className="bg-modal-bg border-border-medium focus:border-accent min-w-0 flex-1 rounded border px-2 py-0.5 font-mono text-xs focus:outline-none"
               autoFocus
             />
-            {props.editError && <div className="text-error text-xs">{props.editError}</div>}
-          </div>
-        ) : (
-          <div className="flex min-w-0 flex-1 items-center gap-2">
-            <span className="text-foreground min-w-0 truncate font-mono text-xs">
-              {props.modelId}
-            </span>
-            {props.aliases && props.aliases.length > 0 && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span className="text-muted-light shrink-0 text-xs">
-                    ({props.aliases.join(", ")})
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent align="center">Use with /m {props.aliases[0]}</TooltipContent>
-              </Tooltip>
-            )}
-          </div>
-        )}
-      </div>
-      <div className="ml-2 flex shrink-0 items-center gap-0.5">
-        {props.isEditing ? (
-          <>
             <Button
               variant="ghost"
               size="icon"
@@ -100,122 +177,155 @@ export function ModelRow(props: ModelRowProps) {
             >
               <X className="h-3.5 w-3.5" />
             </Button>
-          </>
-        ) : (
-          <>
-            {/* Visibility toggle button */}
-            {props.onToggleVisibility && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={props.onToggleVisibility}
-                    className={cn(
-                      "relative p-0.5 transition-colors",
-                      props.isHiddenFromSelector
-                        ? "text-muted-light"
-                        : "text-muted hover:text-foreground"
-                    )}
-                    aria-label={
-                      props.isHiddenFromSelector
-                        ? "Show in model selector"
-                        : "Hide from model selector"
-                    }
-                  >
-                    <Eye
-                      className={cn(
-                        "h-3.5 w-3.5",
-                        props.isHiddenFromSelector ? "opacity-30" : "opacity-70"
-                      )}
-                    />
-                    {props.isHiddenFromSelector && (
-                      <span className="bg-muted-light absolute inset-0 m-auto h-px w-4 rotate-45" />
-                    )}
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent align="center">
-                  {props.isHiddenFromSelector
-                    ? "Hidden from selector (click to show)"
-                    : "Hide from model selector"}
-                </TooltipContent>
-              </Tooltip>
-            )}
-            {/* Gateway toggle button */}
-            {props.onToggleGateway && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={props.onToggleGateway}
-                    className={cn(
-                      "p-0.5 transition-colors",
-                      props.isGatewayEnabled ? "text-accent" : "text-muted hover:text-accent"
-                    )}
-                    aria-label={
-                      props.isGatewayEnabled ? "Disable Mux Gateway" : "Enable Mux Gateway"
-                    }
-                  >
-                    <GatewayIcon className="h-3.5 w-3.5" active={props.isGatewayEnabled} />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent align="center">
-                  {props.isGatewayEnabled ? "Using Mux Gateway" : "Use Mux Gateway"}
-                </TooltipContent>
-              </Tooltip>
-            )}
-            {/* Favorite/default button */}
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => {
-                    if (!props.isDefault) props.onSetDefault();
+          </div>
+          {props.editError && <div className="text-error mt-1 text-xs">{props.editError}</div>}
+        </td>
+      </tr>
+    );
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <tr
+          className={cn(
+            "border-border-medium hover:bg-background-secondary/50 group border-b transition-colors",
+            props.isHiddenFromSelector && "opacity-50"
+          )}
+        >
+          {/* Provider */}
+          <td className="w-20 py-1.5 pr-2 pl-2 md:w-24 md:pl-3">
+            <ProviderWithIcon
+              provider={props.provider}
+              displayName
+              className="text-muted overflow-hidden text-xs"
+            />
+          </td>
+
+          {/* Model ID + Aliases */}
+          <td className="min-w-0 py-1.5 pr-2">
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="text-foreground min-w-0 truncate font-mono text-xs">
+                {props.modelId}
+              </span>
+              {props.aliases && props.aliases.length > 0 && (
+                <span className="text-muted-light shrink-0 text-xs">({props.aliases[0]})</span>
+              )}
+            </div>
+          </td>
+
+          {/* Context Window */}
+          <td className="w-16 py-1.5 pr-2 text-right md:w-20">
+            <span className="text-muted text-xs">
+              {stats ? formatTokenCount(stats.max_input_tokens) : "—"}
+            </span>
+          </td>
+
+          {/* Actions */}
+          <td className="w-28 py-1.5 pr-2 md:w-32 md:pr-3">
+            <div className="flex items-center justify-end gap-0.5">
+              {/* Visibility toggle button */}
+              {props.onToggleVisibility && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    props.onToggleVisibility?.();
                   }}
                   className={cn(
-                    "h-6 w-6",
-                    props.isDefault
-                      ? "cursor-default text-yellow-400 hover:text-yellow-400"
-                      : "text-muted hover:text-yellow-400"
+                    "relative p-0.5 transition-colors",
+                    props.isHiddenFromSelector
+                      ? "text-muted-light"
+                      : "text-muted hover:text-foreground"
                   )}
-                  disabled={props.isDefault}
-                  aria-label={props.isDefault ? "Current default model" : "Set as default model"}
+                  aria-label={
+                    props.isHiddenFromSelector
+                      ? "Show in model selector"
+                      : "Hide from model selector"
+                  }
                 >
-                  <Star className={cn("h-3.5 w-3.5", props.isDefault && "fill-current")} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent align="center">
-                {props.isDefault ? "Default model" : "Set as default"}
-              </TooltipContent>
-            </Tooltip>
-            {/* Edit/delete buttons only for custom models */}
-            {props.isCustom && (
-              <>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={props.onStartEdit}
-                  disabled={Boolean(props.saving) || Boolean(props.hasActiveEdit)}
-                  className="text-muted hover:text-foreground h-6 w-6"
-                  title="Edit model"
+                  <Eye
+                    className={cn(
+                      "h-3.5 w-3.5",
+                      props.isHiddenFromSelector ? "opacity-30" : "opacity-70"
+                    )}
+                  />
+                  {props.isHiddenFromSelector && (
+                    <span className="bg-muted-light absolute inset-0 m-auto h-px w-4 rotate-45" />
+                  )}
+                </button>
+              )}
+              {/* Gateway toggle button */}
+              {props.onToggleGateway && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    props.onToggleGateway?.();
+                  }}
+                  className={cn(
+                    "p-0.5 transition-colors",
+                    props.isGatewayEnabled ? "text-accent" : "text-muted hover:text-accent"
+                  )}
+                  aria-label={props.isGatewayEnabled ? "Disable Mux Gateway" : "Enable Mux Gateway"}
                 >
-                  <Pencil className="h-3.5 w-3.5" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={props.onRemove}
-                  disabled={Boolean(props.saving) || Boolean(props.hasActiveEdit)}
-                  className="text-muted hover:text-error h-6 w-6"
-                  title="Remove model"
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                </Button>
-              </>
-            )}
-          </>
-        )}
-      </div>
-    </div>
+                  <GatewayIcon className="h-3.5 w-3.5" active={props.isGatewayEnabled} />
+                </button>
+              )}
+              {/* Favorite/default button */}
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (!props.isDefault) props.onSetDefault();
+                }}
+                className={cn(
+                  "p-0.5 transition-colors",
+                  props.isDefault
+                    ? "cursor-default text-yellow-400"
+                    : "text-muted hover:text-yellow-400"
+                )}
+                disabled={props.isDefault}
+                aria-label={props.isDefault ? "Current default model" : "Set as default model"}
+              >
+                <Star className={cn("h-3.5 w-3.5", props.isDefault && "fill-current")} />
+              </button>
+              {/* Edit/delete buttons only for custom models */}
+              {props.isCustom && (
+                <>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      props.onStartEdit?.();
+                    }}
+                    disabled={Boolean(props.saving) || Boolean(props.hasActiveEdit)}
+                    className="text-muted hover:text-foreground p-0.5 transition-colors"
+                    aria-label="Edit model"
+                  >
+                    <Pencil className="h-3.5 w-3.5" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      props.onRemove?.();
+                    }}
+                    disabled={Boolean(props.saving) || Boolean(props.hasActiveEdit)}
+                    className="text-muted hover:text-error p-0.5 transition-colors"
+                    aria-label="Remove model"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                </>
+              )}
+            </div>
+          </td>
+        </tr>
+      </TooltipTrigger>
+      <TooltipContent side="top" align="start" className="p-3">
+        <ModelTooltipContent fullId={props.fullId} aliases={props.aliases} stats={stats} />
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/src/browser/components/Settings/sections/ModelsSection.tsx
+++ b/src/browser/components/Settings/sections/ModelsSection.tsx
@@ -21,6 +21,23 @@ import { Button } from "@/browser/components/ui/button";
 // Providers to exclude from the custom models UI (handled specially or internal)
 const HIDDEN_PROVIDERS = new Set(["mux-gateway"]);
 
+// Shared header cell styles
+const headerCellBase = "py-1.5 pr-2 text-xs font-medium text-muted";
+
+// Table header component to avoid duplication
+function ModelsTableHeader() {
+  return (
+    <thead>
+      <tr className="border-border-medium bg-background-secondary/50 border-b">
+        <th className={`${headerCellBase} pl-2 text-left md:pl-3`}>Provider</th>
+        <th className={`${headerCellBase} text-left`}>Model</th>
+        <th className={`${headerCellBase} w-16 text-right md:w-20`}>Context</th>
+        <th className={`${headerCellBase} w-28 text-right md:w-32 md:pr-3`}>Actions</th>
+      </tr>
+    </thead>
+  );
+}
+
 interface EditingState {
   provider: string;
   originalModelId: string;
@@ -178,7 +195,7 @@ export function ModelsSection() {
       </p>
 
       {/* Custom Models - shown first */}
-      <div className="space-y-1.5">
+      <div className="space-y-3">
         <div className="text-muted text-xs font-medium tracking-wide uppercase">Custom Models</div>
 
         {/* Add new model form */}
@@ -220,78 +237,95 @@ export function ModelsSection() {
           {error && !editing && <div className="text-error mt-1.5 text-xs">{error}</div>}
         </div>
 
-        {/* List custom models */}
-        {customModels.map((model) => {
-          const isModelEditing =
-            editing?.provider === model.provider && editing?.originalModelId === model.modelId;
-          return (
-            <ModelRow
-              key={model.fullId}
-              provider={model.provider}
-              modelId={model.modelId}
-              fullId={model.fullId}
-              isCustom={true}
-              isDefault={defaultModel === model.fullId}
-              isEditing={isModelEditing}
-              editValue={isModelEditing ? editing.newModelId : undefined}
-              editError={isModelEditing ? error : undefined}
-              saving={false}
-              hasActiveEdit={editing !== null}
-              isGatewayEnabled={gateway.modelUsesGateway(model.fullId)}
-              onSetDefault={() => setDefaultModel(model.fullId)}
-              onStartEdit={() => handleStartEdit(model.provider, model.modelId)}
-              onSaveEdit={handleSaveEdit}
-              onCancelEdit={handleCancelEdit}
-              onEditChange={(value) =>
-                setEditing((prev) => (prev ? { ...prev, newModelId: value } : null))
-              }
-              onRemove={() => handleRemoveModel(model.provider, model.modelId)}
-              isHiddenFromSelector={hiddenModels.includes(model.fullId)}
-              onToggleVisibility={() =>
-                hiddenModels.includes(model.fullId)
-                  ? unhideModel(model.fullId)
-                  : hideModel(model.fullId)
-              }
-              onToggleGateway={
-                gateway.canToggleModel(model.fullId)
-                  ? () => gateway.toggleModelGateway(model.fullId)
-                  : undefined
-              }
-            />
-          );
-        })}
+        {/* Table of custom models */}
+        {customModels.length > 0 && (
+          <div className="border-border-medium overflow-hidden rounded-md border">
+            <table className="w-full">
+              <ModelsTableHeader />
+              <tbody>
+                {customModels.map((model) => {
+                  const isModelEditing =
+                    editing?.provider === model.provider &&
+                    editing?.originalModelId === model.modelId;
+                  return (
+                    <ModelRow
+                      key={model.fullId}
+                      provider={model.provider}
+                      modelId={model.modelId}
+                      fullId={model.fullId}
+                      isCustom={true}
+                      isDefault={defaultModel === model.fullId}
+                      isEditing={isModelEditing}
+                      editValue={isModelEditing ? editing.newModelId : undefined}
+                      editError={isModelEditing ? error : undefined}
+                      saving={false}
+                      hasActiveEdit={editing !== null}
+                      isGatewayEnabled={gateway.modelUsesGateway(model.fullId)}
+                      onSetDefault={() => setDefaultModel(model.fullId)}
+                      onStartEdit={() => handleStartEdit(model.provider, model.modelId)}
+                      onSaveEdit={handleSaveEdit}
+                      onCancelEdit={handleCancelEdit}
+                      onEditChange={(value) =>
+                        setEditing((prev) => (prev ? { ...prev, newModelId: value } : null))
+                      }
+                      onRemove={() => handleRemoveModel(model.provider, model.modelId)}
+                      isHiddenFromSelector={hiddenModels.includes(model.fullId)}
+                      onToggleVisibility={() =>
+                        hiddenModels.includes(model.fullId)
+                          ? unhideModel(model.fullId)
+                          : hideModel(model.fullId)
+                      }
+                      onToggleGateway={
+                        gateway.canToggleModel(model.fullId)
+                          ? () => gateway.toggleModelGateway(model.fullId)
+                          : undefined
+                      }
+                    />
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
 
       {/* Built-in Models */}
-      <div className="space-y-1.5">
+      <div className="space-y-3">
         <div className="text-muted text-xs font-medium tracking-wide uppercase">
           Built-in Models
         </div>
-        {builtInModels.map((model) => (
-          <ModelRow
-            key={model.fullId}
-            provider={model.provider}
-            modelId={model.modelId}
-            fullId={model.fullId}
-            aliases={model.aliases}
-            isCustom={false}
-            isDefault={defaultModel === model.fullId}
-            isEditing={false}
-            isGatewayEnabled={gateway.modelUsesGateway(model.fullId)}
-            onSetDefault={() => setDefaultModel(model.fullId)}
-            isHiddenFromSelector={hiddenModels.includes(model.fullId)}
-            onToggleVisibility={() =>
-              hiddenModels.includes(model.fullId)
-                ? unhideModel(model.fullId)
-                : hideModel(model.fullId)
-            }
-            onToggleGateway={
-              gateway.canToggleModel(model.fullId)
-                ? () => gateway.toggleModelGateway(model.fullId)
-                : undefined
-            }
-          />
-        ))}
+        <div className="border-border-medium overflow-hidden rounded-md border">
+          <table className="w-full">
+            <ModelsTableHeader />
+            <tbody>
+              {builtInModels.map((model) => (
+                <ModelRow
+                  key={model.fullId}
+                  provider={model.provider}
+                  modelId={model.modelId}
+                  fullId={model.fullId}
+                  aliases={model.aliases}
+                  isCustom={false}
+                  isDefault={defaultModel === model.fullId}
+                  isEditing={false}
+                  isGatewayEnabled={gateway.modelUsesGateway(model.fullId)}
+                  onSetDefault={() => setDefaultModel(model.fullId)}
+                  isHiddenFromSelector={hiddenModels.includes(model.fullId)}
+                  onToggleVisibility={() =>
+                    hiddenModels.includes(model.fullId)
+                      ? unhideModel(model.fullId)
+                      : hideModel(model.fullId)
+                  }
+                  onToggleGateway={
+                    gateway.canToggleModel(model.fullId)
+                      ? () => gateway.toggleModelGateway(model.fullId)
+                      : undefined
+                  }
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Convert the Models settings page from a list layout to a proper table layout with:

- **Context column** - Shows model context window size (e.g., 200k, 272k)
- **Rich tooltip on hover** - Full model details including:
  - Full model ID and aliases
  - Context window and max output tokens  
  - Pricing breakdown (input, output, cache read/write costs per 1M tokens)

## Changes

- `ModelRow.tsx`: Now renders as table row (`<tr>`) with Provider, Model, Context, and Actions columns. Added `ModelTooltipContent` component for rich hover tooltips using data from `models.json`.
- `ModelsSection.tsx`: Changed from list to table layout. Extracted `ModelsTableHeader` component for reuse.

## Screenshots

The tooltip shows detailed model information when hovering over any row.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$4.64`_