### PR TITLE
🤖 fix: make collapsed sidebar toggles full-height

### DIFF
--- a/src/browser/components/ui/SidebarCollapseButton.tsx
+++ b/src/browser/components/ui/SidebarCollapseButton.tsx
@@ -32,7 +32,11 @@ export const SidebarCollapseButton: React.FC<SidebarCollapseButtonProps> = ({
         <button
           onClick={onToggle}
           aria-label={label}
-          className="text-muted border-dark hover:bg-hover hover:text-foreground mt-auto flex h-6 w-full cursor-pointer items-center justify-center border-t border-none bg-transparent p-0 text-xs transition-all duration-200"
+          className={
+            collapsed
+              ? "text-muted hover:bg-hover hover:text-foreground flex w-full flex-1 cursor-pointer items-center justify-center bg-transparent p-0 text-xs transition-all duration-200"
+              : "text-muted border-dark hover:bg-hover hover:text-foreground mt-auto flex h-6 w-full cursor-pointer items-center justify-center border-t border-none bg-transparent p-0 text-xs transition-all duration-200"
+          }
         >
           {chevron}
         </button>


### PR DESCRIPTION
When the sidebar is collapsed, the collapse/expand control now:
- Fills the full sidebar height (entire strip is clickable)
- Centers the chevron vertically

This applies to both the left Projects sidebar and the right sidebar via the shared `SidebarCollapseButton`.

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$1.48`_
