### PR TITLE
🤖 fix: compaction UI shows 'streaming' instead of 'compacting'

### DIFF
--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -954,8 +954,12 @@ export class StreamingMessageAggregator {
     // - pending /compact metadata captured from the triggering user message, or
     // - last user message metadata (reconnect scenario).
     const isCompacting = (() => {
-      if (data.mode !== undefined) {
-        return data.mode === "compact";
+      // If the backend explicitly labels the stream as compact, that's authoritative.
+      // Note: Today the backend may send mode="exec" even for compaction streams
+      // (AIService derives mode from the agent/toolchain), so a non-compact mode is
+      // not sufficient to conclude "not compacting".
+      if (data.mode === "compact") {
+        return true;
       }
 
       if (this.pendingCompactionRequest !== null) {


### PR DESCRIPTION
## Problem

Compaction streams displayed "streaming" status in the barrier instead of "compacting", and lacked the blue shimmer highlight on the assistant message.

## Root Cause

Regression from PR #1564 ("show compaction model during starting phase", commit `1b937cc8`, Jan 10, 2026).

That PR changed compaction detection in `handleStreamStart` to treat any defined `stream-start.mode` as authoritative:

```typescript
// Before fix (broken):
if (data.mode !== undefined) {
  return data.mode === "compact";  // When mode="exec", returns false immediately
}
// pendingCompactionRequest fallback NEVER reached when mode is present
```

The problem: The backend sends `mode="exec"` for compaction streams because `AIService` derives mode from the resolved agent/toolchain (not from the original request's `mode: "compact"`). So when compaction streams arrived with `mode: "exec"`, the check returned `false` immediately and skipped all fallback detection.

## Fix

Only treat `mode === "compact"` as an authoritative **positive** signal. When mode is `"exec"` or `"plan"`, fall through to existing fallbacks:

```typescript
// After fix:
if (data.mode === "compact") {
  return true;
}
// When mode="exec", we now fall through to:
if (this.pendingCompactionRequest !== null) {
  return true;  // This IS reached now
}
// ... history scan fallback
```

## Regression Tests Added

- Reconnect scenario: last user message is `compaction-request`, `stream-start.mode === "exec"` → `isCompacting()` must be `true`
- Live flow: `handleMessage()` with `compaction-request`, then `stream-start.mode === "exec"` → `isCompacting()` must be `true`  
- Explicit: `stream-start.mode === "compact"` → `isCompacting()` must be `true`

## Validation

- `bun test src/browser/utils/messages/StreamingMessageAggregator.test.ts` ✅
- `make static-check` ✅

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$8.42`_
