### PR TITLE
🤖 fix: make file edit tools CRLF/LF agnostic

### DIFF
--- a/src/node/services/tools/eol.ts
+++ b/src/node/services/tools/eol.ts
@@ -1,0 +1,24 @@
+export type FileEol = "\n" | "\r\n";
+
+/**
+ * Normalize all newline styles to LF.
+ *
+ * This is intentionally conservative and scoped to file-edit tools where we want
+ * to be resilient to Windows CRLF vs. model-generated LF mismatches.
+ */
+export function normalizeNewlinesToLF(text: string): string {
+  return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+/**
+ * Detect a file's newline style.
+ *
+ * We prefer CRLF if we see any CRLF sequences.
+ */
+export function detectFileEol(originalContent: string): FileEol {
+  return originalContent.includes("\r\n") ? "\r\n" : "\n";
+}
+
+export function convertNewlines(text: string, eol: FileEol): string {
+  return normalizeNewlinesToLF(text).replace(/\n/g, eol);
+}

--- a/src/node/services/tools/file_edit_replace.test.ts
+++ b/src/node/services/tools/file_edit_replace.test.ts
@@ -80,6 +80,73 @@ describe("file_edit_replace_string tool", () => {
 
     expect(await readFile(testFilePath)).toBe("Hello universe\nThis is a test\nGoodbye world");
   });
+
+  it("matches LF args against a CRLF file and preserves CRLF", async () => {
+    await setupFile(testFilePath, "Hello world\r\nThis is a test\r\nGoodbye world\r\n");
+    const tool = createFileEditReplaceStringTool({
+      ...getTestDeps(),
+      cwd: testDir,
+      runtime: createRuntime({ type: "local", srcBaseDir: "/tmp" }),
+      runtimeTempDir: "/tmp",
+    });
+
+    const payload: FileEditReplaceStringToolArgs = {
+      file_path: "test.txt",
+      old_string: "Hello world\nThis is a test\n",
+      new_string: "Hello universe\nThis is a CRLF test\n",
+    };
+
+    const result = await executeStringReplace(tool, payload);
+
+    expect(result.success).toBe(true);
+    expect(await readFile(testFilePath)).toBe(
+      "Hello universe\r\nThis is a CRLF test\r\nGoodbye world\r\n"
+    );
+  });
+
+  it("does not modify the file when old_string is missing", async () => {
+    const original = "Hello world\n";
+    await setupFile(testFilePath, original);
+    const tool = createFileEditReplaceStringTool({
+      ...getTestDeps(),
+      cwd: testDir,
+      runtime: createRuntime({ type: "local", srcBaseDir: "/tmp" }),
+      runtimeTempDir: "/tmp",
+    });
+
+    const payload: FileEditReplaceStringToolArgs = {
+      file_path: "test.txt",
+      old_string: "Goodbye world\n",
+      new_string: "replaced\n",
+    };
+
+    const result = await executeStringReplace(tool, payload);
+
+    expect(result.success).toBe(false);
+    expect(await readFile(testFilePath)).toBe(original);
+  });
+
+  it("does not modify the file when old_string is ambiguous", async () => {
+    const original = "repeat\nrepeat\n";
+    await setupFile(testFilePath, original);
+    const tool = createFileEditReplaceStringTool({
+      ...getTestDeps(),
+      cwd: testDir,
+      runtime: createRuntime({ type: "local", srcBaseDir: "/tmp" }),
+      runtimeTempDir: "/tmp",
+    });
+
+    const payload: FileEditReplaceStringToolArgs = {
+      file_path: "test.txt",
+      old_string: "repeat",
+      new_string: "REPLACED",
+    };
+
+    const result = await executeStringReplace(tool, payload);
+
+    expect(result.success).toBe(false);
+    expect(await readFile(testFilePath)).toBe(original);
+  });
 });
 
 describe("file_edit_replace_lines tool", () => {
@@ -120,5 +187,27 @@ describe("file_edit_replace_lines tool", () => {
     }
 
     expect(await readFile(testFilePath)).toBe("line1\nLINE2\nLINE3\nline4");
+  });
+
+  it("preserves CRLF when replacing lines in a CRLF file", async () => {
+    await setupFile(testFilePath, "line1\r\nline2\r\nline3\r\nline4");
+    const tool = createFileEditReplaceLinesTool({
+      ...getTestDeps(),
+      cwd: testDir,
+      runtime: createRuntime({ type: "local", srcBaseDir: "/tmp" }),
+      runtimeTempDir: "/tmp",
+    });
+
+    const payload: FileEditReplaceLinesToolArgs = {
+      file_path: "test.txt",
+      start_line: 2,
+      end_line: 3,
+      new_lines: ["LINE2", "LINE3"],
+    };
+
+    const result = await executeLinesReplace(tool, payload);
+
+    expect(result.success).toBe(true);
+    expect(await readFile(testFilePath)).toBe("line1\r\nLINE2\r\nLINE3\r\nline4");
   });
 });


### PR DESCRIPTION
Fixes coder/mux#894.

## What changed
- Detect the target file’s EOL (CRLF vs LF) and coerce `old_string` / `before` / `after` / replacement text to that EOL when needed.
- Preserve CRLF when doing line-range replacements.
- Add CRLF-focused regression tests for replace + insert.

## Testing
- `bun test src/node/services/tools/file_edit_replace.test.ts src/node/services/tools/file_edit_insert.test.ts`
- `make static-check`

---
_Generated with `mux` • Model: openai:gpt-5.2 • Thinking: xhigh • Cost: $2.32_
