### PR TITLE
🤖 feat: show boot loader on cold start

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,11 +18,87 @@
         padding: 0;
         overflow: hidden;
         background: var(--color-background, #1e1e1e);
+        color: var(--color-foreground, #d4d4d4);
+        font-family: var(
+          --font-primary,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Geist",
+          system-ui,
+          "Segoe UI",
+          "Roboto",
+          "Helvetica Neue",
+          Arial,
+          sans-serif,
+          "Apple Color Emoji",
+          "Segoe UI Emoji",
+          "Segoe UI Symbol"
+        );
+        font-size: 14px;
       }
+
+      :root[data-theme="light"] body {
+        background: #f5f6f8;
+      }
+
       #root {
         height: 100vh; /* fallback for older browsers */
         height: 100dvh;
         overflow: hidden;
+      }
+
+      /* Pre-JS placeholder to avoid a blank screen on cold start. */
+      .boot-loader {
+        height: 100vh; /* fallback for older browsers */
+        height: 100dvh;
+        width: 100vw;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .boot-loader__inner {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 16px;
+      }
+
+      .boot-loader__spinner {
+        height: 48px;
+        width: 48px;
+        box-sizing: border-box;
+        border-radius: 9999px;
+        border: 4px solid var(--color-border-light, #262626);
+        border-top-color: transparent;
+        animation: boot-loader-spin 1s linear infinite;
+      }
+
+      :root[data-theme="light"] .boot-loader__spinner {
+        border-color: var(--color-border-light, #d0d7de);
+        border-top-color: transparent;
+      }
+
+      .boot-loader__text {
+        margin: 0;
+        font-size: 14px;
+        color: var(--color-text-secondary, #6b6b6b);
+      }
+
+      :root[data-theme="light"] .boot-loader__text {
+        color: var(--color-text-secondary, #607081);
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .boot-loader__spinner {
+          animation: none;
+        }
+      }
+
+      @keyframes boot-loader-spin {
+        to {
+          transform: rotate(360deg);
+        }
       }
     </style>
     <script>
@@ -53,7 +129,14 @@
     </script>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <div class="boot-loader" role="status" aria-live="polite" aria-busy="true">
+        <div class="boot-loader__inner">
+          <div class="boot-loader__spinner" aria-hidden="true"></div>
+          <p class="boot-loader__text">Loading workspaces...</p>
+        </div>
+      </div>
+    </div>
     <script type="module" src="/src/browser/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
Adds a minimal pre-JS "boot loader" (spinner + text) inside `#root` so the mux server UI isn't blank while the JS bundle downloads/executes.

- Includes light-theme fallbacks before bundled CSS loads.
- Respects `prefers-reduced-motion`.

Validation:
- `make static-check`

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `.21`_