### PR TITLE
🤖 fix: prevent splash screen from closing on backdrop click

### DIFF
--- a/src/browser/components/splashScreens/SplashScreen.tsx
+++ b/src/browser/components/splashScreens/SplashScreen.tsx
@@ -38,7 +38,7 @@ export function SplashScreen(props: SplashScreenProps) {
 
   return (
     <Dialog open onOpenChange={(open) => !open && props.onDismiss()}>
-      <DialogContent maxWidth="500px">
+      <DialogContent maxWidth="500px" onInteractOutside={(e) => e.preventDefault()}>
         <DialogHeader>
           <DialogTitle>{props.title}</DialogTitle>
         </DialogHeader>


### PR DESCRIPTION
Splash screens now only close via explicit button actions (primary action or dismiss button), not by clicking outside. This prevents conflicts where clicking on an overlapping tutorial tooltip would inadvertently dismiss the splash screen.

---
_Generated with `mux` • Model: `mux-gateway:anthropic/claude-opus-4-5` • Thinking: `high` • Cost: `$0.38`_