### PR TITLE
🤖 fix: support Docker images with non-root default users

### DIFF
--- a/src/node/runtime/DockerRuntime.ts
+++ b/src/node/runtime/DockerRuntime.ts
@@ -975,9 +975,9 @@ export class DockerRuntime extends RemoteRuntime {
       const destGid = gidResult.stdout.trim() || "0";
       const destHome = homeResult.stdout.trim() || "/root";
 
-      // Create /var/mux/plans (git clone will create /src)
+      // Create /src and /var/mux/plans as root, then chown to container user
       const mkdirResult = await runDockerCommand(
-        `docker exec --user root ${destContainerName} sh -c 'mkdir -p /var/mux/plans && chown ${destUid}:${destGid} /var/mux /var/mux/plans'`,
+        `docker exec --user root ${destContainerName} sh -c 'mkdir -p ${CONTAINER_SRC_DIR} /var/mux/plans && chown ${destUid}:${destGid} ${CONTAINER_SRC_DIR} /var/mux /var/mux/plans'`,
         10000
       );
       if (mkdirResult.exitCode !== 0) {


### PR DESCRIPTION
## Problem

Docker images like `codercom/enterprise-base` and `codercom/example-base` run as a non-root user by default (e.g., `coder` with uid 1000). Previously, DockerRuntime failed with "Permission denied" errors:

**During workspace creation:**
```
Preparing workspace directory...
Failed to create workspace directory: mkdir: cannot create directory '/src': Permission denied
mkdir: cannot create directory '/var/mux': Permission denied
```

**During streaming (after workspace created):**
```
Error: Failed to stream message: Failed to create temp directory /root/.mux-tmp/...: exit code 1
```

## Root Cause

1. `mkdir /src` and `mkdir /var/mux/plans` ran as the container's default user, which doesn't have permission to create top-level directories
2. `~` was hardcoded to resolve to `/root`, but non-root users can't write there

## Solution

- Detect container's default user (uid/gid/home) after container creation via `id -u`, `id -g`, `echo $HOME`
- Create workspace directories using `docker exec --user root`, then `chown` to the container user
- Resolve `~` paths using the detected home directory instead of hardcoded `/root`

## Images That Now Work

| Image | Default User | Previously | Now |
|-------|-------------|------------|-----|
| `codercom/enterprise-base` | `coder` (1000) | ❌ Permission denied | ✅ Works |
| `codercom/example-base` | `coder` (1000) | ❌ Permission denied | ✅ Works |
| `node:20`, `ubuntu`, etc. | `root` (0) | ✅ Works | ✅ Works (unchanged) |

## Why This Is Safe (No Migration Required)

- **Workspace config entries unchanged** - same structure, same container name derivation
- **Existing containers not modified** - we don't retroactively `chown` or restructure existing containers
- **Root-based images behave identically** - uid=0 detected, home=/root, same as before
- **User detection runs lazily** - `ensureReady()` detects user info when container starts, so existing workspaces automatically get correct `~` resolution on next use

## Testing

Tested with `codercom/example-base:latest`:
- ✅ Workspace creation succeeds
- ✅ Streaming works (temp dirs created in `/home/coder/.mux-tmp/...`)
- ✅ VS Code Dev Containers can attach and edit `/src`

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$3.77`_
