### PR TITLE
🤖 fix: cycle models through all visible models

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -278,7 +278,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const focusBorderColor = currentAgent?.uiColor ?? "var(--color-border-light)";
   const {
     models,
-    customModels,
     hiddenModels,
     hideModel,
     unhideModel,
@@ -438,12 +437,8 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     ]
   );
 
-  // Model cycling candidates. Prefer the user's custom model list (as configured in Settings).
-  // If no custom models are configured, fall back to the full suggested list.
-  const cycleModels = useMemo(
-    () => (customModels.length > 0 ? customModels : models),
-    [customModels, models]
-  );
+  // Model cycling candidates: all visible models (custom + built-in, minus hidden).
+  const cycleModels = models;
 
   const cycleToNextModel = useCallback(() => {
     if (cycleModels.length < 2) {

--- a/src/browser/utils/ui/keybinds.test.ts
+++ b/src/browser/utils/ui/keybinds.test.ts
@@ -1,20 +1,53 @@
 import { describe, it, expect } from "bun:test";
 import { matchesKeybind, type Keybind } from "./keybinds";
 
-describe("matchesKeybind", () => {
-  // Helper to create a minimal keyboard event
-  function createEvent(overrides: Partial<KeyboardEvent> = {}): KeyboardEvent {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    return {
-      key: "a",
-      ctrlKey: false,
-      shiftKey: false,
-      altKey: false,
-      metaKey: false,
-      ...overrides,
-    } as KeyboardEvent;
-  }
+// Helper to create a minimal keyboard event
+function createEvent(overrides: Partial<KeyboardEvent> = {}): KeyboardEvent {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  return {
+    key: "a",
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    ...overrides,
+  } as KeyboardEvent;
+}
 
+describe("CYCLE_MODEL keybind (Ctrl+/)", () => {
+  it("matches Ctrl+/ on Linux/Windows", () => {
+    // Mock non-Mac platform
+    globalThis.window = { api: { platform: "linux" } } as unknown as Window & typeof globalThis;
+    const event = createEvent({ key: "/", ctrlKey: true });
+    expect(matchesKeybind(event, { key: "/", ctrl: true })).toBe(true);
+  });
+
+  it("matches Cmd+/ on macOS", () => {
+    // Mock Mac platform
+    globalThis.window = { api: { platform: "darwin" } } as unknown as Window & typeof globalThis;
+    const event = createEvent({ key: "/", metaKey: true });
+    expect(matchesKeybind(event, { key: "/", ctrl: true })).toBe(true);
+  });
+
+  it("matches Ctrl+/ on macOS (either behavior)", () => {
+    // Mock Mac platform
+    globalThis.window = { api: { platform: "darwin" } } as unknown as Window & typeof globalThis;
+    const event = createEvent({ key: "/", ctrlKey: true });
+    expect(matchesKeybind(event, { key: "/", ctrl: true })).toBe(true);
+  });
+
+  it("does not match just /", () => {
+    const event = createEvent({ key: "/" });
+    expect(matchesKeybind(event, { key: "/", ctrl: true })).toBe(false);
+  });
+
+  it("does not match Ctrl+? (shifted /)", () => {
+    const event = createEvent({ key: "?", ctrlKey: true, shiftKey: true });
+    expect(matchesKeybind(event, { key: "/", ctrl: true })).toBe(false);
+  });
+});
+
+describe("matchesKeybind", () => {
   it("should return false when event.key is undefined", () => {
     // This can happen with dead keys, modifier-only events, etc.
     const event = createEvent({ key: undefined as unknown as string });


### PR DESCRIPTION
## Summary

Fixes Ctrl+/ model cycling when custom models are configured.

## Problem

Previously, the model cycling logic would prefer custom models if any were configured:
```typescript
const cycleModels = customModels.length > 0 ? customModels : models;
```

This caused a bug where having exactly 1 custom model would break cycling entirely, since the `cycleModels` list had only 1 item, failing the `length < 2` guard.

## Solution

Simplify the logic: always cycle through all visible models (custom + built-in, minus hidden). This matches user expectations since the model selector shows all visible models.

```typescript
const cycleModels = models;
```

## Testing

- Added test coverage for the `CYCLE_MODEL` keybind matching
- Manual testing with 1, 2, and 3+ visible models

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$5.11`_