### PR TITLE
🤖 fix: show provider icons in model dropdown selectors

### DIFF
--- a/src/browser/components/Settings/sections/ModelsSection.tsx
+++ b/src/browser/components/Settings/sections/ModelsSection.tsx
@@ -21,7 +21,8 @@ import {
 } from "@/browser/components/ui/select";
 import { Popover, PopoverContent, PopoverTrigger } from "@/browser/components/ui/popover";
 import { Button } from "@/browser/components/ui/button";
-import { getModelName } from "@/common/utils/ai/models";
+import { getModelName, getModelProvider } from "@/common/utils/ai/models";
+import { ProviderIcon } from "@/browser/components/ProviderIcon";
 import { cn } from "@/common/lib/utils";
 
 /** Searchable model dropdown with keyboard navigation */
@@ -42,6 +43,7 @@ function SearchableModelSelect(props: {
     props.emptyOption && !props.value
       ? props.emptyOption.label
       : (getModelName(props.value) ?? props.placeholder ?? "Select model");
+  const selectedProvider = props.value ? getModelProvider(props.value) : "";
 
   // Filter models based on search
   const searchLower = search.toLowerCase();
@@ -52,7 +54,7 @@ function SearchableModelSelect(props: {
   );
 
   // Build list of all selectable items (empty option + filtered models)
-  const items: Array<{ value: string; label: string; isMuted?: boolean }> = [];
+  const items: Array<{ value: string; label: string; provider?: string; isMuted?: boolean }> = [];
   if (props.emptyOption) {
     items.push({
       value: props.emptyOption.value,
@@ -61,7 +63,11 @@ function SearchableModelSelect(props: {
     });
   }
   for (const model of filteredModels) {
-    items.push({ value: model, label: getModelName(model) ?? model });
+    items.push({
+      value: model,
+      label: getModelName(model) ?? model,
+      provider: getModelProvider(model),
+    });
   }
 
   // Reset highlight when search changes or popover opens
@@ -120,7 +126,15 @@ function SearchableModelSelect(props: {
     <Popover open={isOpen} onOpenChange={setIsOpen} modal>
       <PopoverTrigger asChild>
         <button className="bg-background-secondary border-border-medium focus:border-accent flex h-8 w-full items-center justify-between rounded border px-2 text-xs">
-          <span className={cn("truncate", !props.value && props.emptyOption && "text-muted")}>
+          <span
+            className={cn(
+              "flex items-center gap-1.5 truncate",
+              !props.value && props.emptyOption && "text-muted"
+            )}
+          >
+            {selectedProvider && (
+              <ProviderIcon provider={selectedProvider} className="text-muted shrink-0" />
+            )}
             {displayValue}
           </span>
           <ChevronDown className="text-muted h-3 w-3 shrink-0" />
@@ -164,6 +178,9 @@ function SearchableModelSelect(props: {
                       : "opacity-0"
                   )}
                 />
+                {item.provider && (
+                  <ProviderIcon provider={item.provider} className="text-muted shrink-0" />
+                )}
                 <span className={cn("truncate", item.isMuted && "text-muted")}>{item.label}</span>
               </button>
             ))

--- a/src/common/utils/ai/models.ts
+++ b/src/common/utils/ai/models.ts
@@ -59,6 +59,20 @@ export function getModelName(modelString: string): string {
 }
 
 /**
+ * Extract the provider from a model string (e.g., "anthropic:claude-sonnet-4-5" -> "anthropic")
+ * @param modelString - Full model string in format "provider:model-name"
+ * @returns The provider part (before the colon), or empty string if no colon is found
+ */
+export function getModelProvider(modelString: string): string {
+  const normalized = normalizeGatewayModel(modelString);
+  const colonIndex = normalized.indexOf(":");
+  if (colonIndex === -1) {
+    return "";
+  }
+  return normalized.substring(0, colonIndex);
+}
+
+/**
  * Check if a model supports the 1M context window.
  * The 1M context window is only available for Claude Sonnet 4 and Sonnet 4.5.
  * @param modelString - Full model string in format "provider:model-name"


### PR DESCRIPTION
Add provider indication to the SearchableModelSelect component used in the Models settings page. This helps distinguish between the same model available from different providers (e.g., `anthropic:claude-sonnet-4-5` vs `openrouter:claude-sonnet-4-5`).

## Changes

- Add `getModelProvider()` utility to extract provider from model string
- Show provider icon in dropdown trigger button next to selected model
- Show provider icon in dropdown list items

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.88`_