### PR TITLE
🤖 fix: clear base selector search on open to show all suggestions

### DIFF
--- a/src/browser/components/RightSidebar/CodeReview/BaseSelectorPopover.tsx
+++ b/src/browser/components/RightSidebar/CodeReview/BaseSelectorPopover.tsx
@@ -45,10 +45,10 @@ export function BaseSelectorPopover({
     setInputValue(value);
   }, [value]);
 
-  // Focus input when popover opens
+  // Clear search and focus input when popover opens
   useEffect(() => {
     if (isOpen) {
-      // Small delay to let popover render
+      setInputValue(""); // Clear to show all suggestions
       setTimeout(() => inputRef.current?.focus(), 0);
     }
   }, [isOpen]);


### PR DESCRIPTION
When opening the base selector in the review UI, the dropdown list was pre-filtered based on the current value (e.g., "origin/main"), preventing users from seeing all suggestions.

Now the search input clears when opening, showing all options immediately. The current value is still indicated with a checkmark.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.93`_
