### PR TITLE
🤖 fix: resolve CSS variables for voice waveform canvas rendering

### DIFF
--- a/src/browser/components/ChatInput/RecordingOverlay.tsx
+++ b/src/browser/components/ChatInput/RecordingOverlay.tsx
@@ -18,6 +18,22 @@ const NUM_SAMPLES = WINDOW_DURATION_MS / SAMPLE_INTERVAL_MS;
 // waking JavaScript at 120Hz+ on high refresh rate displays
 const RENDER_INTERVAL_MS = 1000 / 60;
 
+/**
+ * Resolve CSS variable to its computed value.
+ * Canvas 2D API doesn't understand CSS custom properties, so we need to resolve them.
+ */
+function resolveCssColor(color: string): string {
+  if (!color.startsWith("var(")) return color;
+
+  // Extract variable name from var(--name) or var(--name, fallback)
+  const match = /^var\(([^,)]+)/.exec(color);
+  if (!match) return color;
+
+  const varName = match[1].trim();
+  const computed = getComputedStyle(document.documentElement).getPropertyValue(varName).trim();
+  return computed || color;
+}
+
 interface RecordingOverlayProps {
   state: VoiceInputState;
   /** CSS color value for agent (e.g., "var(--color-exec-mode)") */
@@ -208,7 +224,7 @@ const SlidingWaveform: React.FC<SlidingWaveformProps> = (props) => {
       const gap = barWidth * 0.4;
       const centerY = canvas.height / 2;
 
-      ctx.fillStyle = props.color;
+      ctx.fillStyle = resolveCssColor(props.color);
 
       for (let i = 0; i < numBars; i++) {
         const scaledAmplitude = Math.min(1, samples[i] * 3); // Boost for visibility


### PR DESCRIPTION
## Problem

Voice input waveform bars were rendering **black** instead of the agent theme color.

## Root Cause

Canvas 2D API doesn't understand CSS custom properties. When agent colors are defined as CSS variables like `var(--color-exec-mode)`, setting `ctx.fillStyle = 'var(--color-exec-mode)'` doesn't work—the browser can't resolve the variable in canvas context, resulting in black bars.

## Solution

Added `resolveCssColor()` helper in `RecordingOverlay.tsx` that:
- Returns non-var colors unchanged (e.g., `#ff0000`, `hsl(...)`)
- Extracts variable name from `var(--name)` or `var(--name, fallback)`
- Resolves via `getComputedStyle(document.documentElement).getPropertyValue(varName)`

## Note

Storybook coverage for the voice recording overlay was attempted but caused widespread test failures (pointer-events issues in unrelated stories). The fix itself is straightforward and minimal—just CSS variable resolution for canvas context.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$10.56`_