### PR TITLE
🤖 fix: show error popover when section delete fails

### DIFF
--- a/src/browser/components/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar.tsx
@@ -293,6 +293,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
   const [archivingWorkspaceIds, setArchivingWorkspaceIds] = useState<Set<string>>(new Set());
   const workspaceArchiveError = usePopoverError();
   const projectRemoveError = usePopoverError();
+  const sectionRemoveError = usePopoverError();
   const [secretsModalState, setSecretsModalState] = useState<{
     isOpen: boolean;
     projectPath: string;
@@ -367,6 +368,23 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
     },
     [onArchiveWorkspace, workspaceArchiveError]
   );
+
+  const handleRemoveSection = async (
+    projectPath: string,
+    sectionId: string,
+    buttonElement: HTMLElement
+  ) => {
+    const result = await removeSection(projectPath, sectionId);
+    if (!result.success) {
+      const error = result.error ?? "Failed to remove section";
+      const rect = buttonElement.getBoundingClientRect();
+      const anchor = {
+        top: rect.top + window.scrollY,
+        left: rect.right + 10,
+      };
+      sectionRemoveError.showError(sectionId, error, anchor);
+    }
+  };
 
   const handleOpenSecrets = async (projectPath: string) => {
     const secrets = await onGetSecrets(projectPath);
@@ -818,8 +836,12 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                                         onChangeColor={(color) => {
                                           void updateSection(projectPath, section.id, { color });
                                         }}
-                                        onDelete={() => {
-                                          void removeSection(projectPath, section.id);
+                                        onDelete={(e) => {
+                                          void handleRemoveSection(
+                                            projectPath,
+                                            section.id,
+                                            e.currentTarget
+                                          );
                                         }}
                                       />
                                       {isSectionExpanded && (
@@ -920,6 +942,11 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
             error={projectRemoveError.error}
             prefix="Failed to remove project"
             onDismiss={projectRemoveError.clearError}
+          />
+          <PopoverError
+            error={sectionRemoveError.error}
+            prefix="Failed to remove section"
+            onDismiss={sectionRemoveError.clearError}
           />
         </div>
       </DndProvider>

--- a/src/browser/components/SectionHeader.tsx
+++ b/src/browser/components/SectionHeader.tsx
@@ -14,7 +14,7 @@ interface SectionHeaderProps {
   onAddWorkspace: () => void;
   onRename: (name: string) => void;
   onChangeColor: (color: string) => void;
-  onDelete: () => void;
+  onDelete: (event: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 export const SectionHeader: React.FC<SectionHeaderProps> = ({
@@ -206,7 +206,7 @@ export const SectionHeader: React.FC<SectionHeaderProps> = ({
         <Tooltip>
           <TooltipTrigger asChild>
             <button
-              onClick={onDelete}
+              onClick={(e) => onDelete(e)}
               className="text-muted hover:text-danger-light hover:bg-danger-light/10 flex h-5 w-5 cursor-pointer items-center justify-center rounded border-none bg-transparent p-0 transition-colors"
               aria-label="Delete section"
             >


### PR DESCRIPTION
When a user tries to delete a section that has active (non-archived) workspaces, the backend correctly rejects the operation but the UI silently discarded the error. Now displays an error popover near the delete button with a message explaining why the operation failed.

## Changes

- Changed `SectionHeader` `onDelete` to pass the mouse event for positioning the error popover
- Added `sectionRemoveError` using `usePopoverError` in `ProjectSidebar`
- Added `handleRemoveSection` that awaits the result and shows error on failure
- Added `PopoverError` component for section removal errors
- Added UI test to verify error popover appears with correct message

## Testing

Added integration test in `tests/ui/sections.integration.test.ts`:
- Creates a section with an active workspace
- Clicks the delete button
- Verifies error popover appears with "active workspace" in the message

All 8 section tests pass.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$2.08`_
