### PR TITLE
🤖 fix: skip stream interrupt keybind when terminal is focused

### DIFF
--- a/src/browser/components/TerminalView.tsx
+++ b/src/browser/components/TerminalView.tsx
@@ -2,6 +2,7 @@ import { useRef, useEffect, useState, useCallback } from "react";
 import { init, Terminal, FitAddon } from "ghostty-web";
 import { useAPI } from "@/browser/contexts/API";
 import { useTerminalRouter } from "@/browser/terminal/TerminalRouterContext";
+import { TERMINAL_CONTAINER_ATTR } from "@/browser/utils/ui/keybinds";
 
 interface TerminalViewProps {
   workspaceId: string;
@@ -511,6 +512,7 @@ export function TerminalView({
       <div
         ref={containerRef}
         className="terminal-container"
+        {...{ [TERMINAL_CONTAINER_ATTR]: true }}
         style={{
           flex: 1,
           minHeight: 0,

--- a/src/browser/hooks/useAIViewKeybinds.ts
+++ b/src/browser/hooks/useAIViewKeybinds.ts
@@ -1,6 +1,11 @@
 import { useEffect } from "react";
 import type { ChatInputAPI } from "@/browser/components/ChatInput";
-import { matchesKeybind, KEYBINDS, isEditableElement } from "@/browser/utils/ui/keybinds";
+import {
+  matchesKeybind,
+  KEYBINDS,
+  isEditableElement,
+  isTerminalFocused,
+} from "@/browser/utils/ui/keybinds";
 import type { StreamingMessageAggregator } from "@/browser/utils/messages/StreamingMessageAggregator";
 import { isCompactingStream, cancelCompaction } from "@/browser/utils/compaction/handler";
 import { useAPI } from "@/browser/contexts/API";
@@ -53,8 +58,8 @@ export function useAIViewKeybinds({
         : KEYBINDS.INTERRUPT_STREAM_NORMAL;
 
       // Interrupt stream: Ctrl+C in vim mode, Esc in normal mode
-      // Only intercept if actively compacting (otherwise allow browser default for copy in vim mode)
-      if (matchesKeybind(e, interruptKeybind)) {
+      // Skip if terminal is focused - let terminal handle Ctrl+C (sends SIGINT to process)
+      if (matchesKeybind(e, interruptKeybind) && !isTerminalFocused(e.target)) {
         // ask_user_question is a special waiting state: don't interrupt it with Esc/Ctrl+C.
         // Users can still respond via the questions UI, or type in chat to cancel.
         if (aggregator?.hasAwaitingUserQuestion()) {

--- a/src/browser/utils/ui/keybinds.ts
+++ b/src/browser/utils/ui/keybinds.ts
@@ -139,6 +139,29 @@ export function isEditableElement(target: EventTarget | null): boolean {
 }
 
 /**
+ * Data attribute used to identify terminal containers.
+ * Used by isTerminalFocused() to detect when keyboard events should be
+ * routed to the terminal instead of handled globally.
+ */
+export const TERMINAL_CONTAINER_ATTR = "data-terminal-container";
+
+/**
+ * Check if the event target is inside a terminal container.
+ * Used to let terminal components handle their own keyboard shortcuts
+ * (like Ctrl+C for SIGINT) instead of intercepting them globally.
+ */
+export function isTerminalFocused(target: EventTarget | null): boolean {
+  if (!target) {
+    return false;
+  }
+  // Check if HTMLElement exists (not available in non-DOM test environments)
+  if (typeof HTMLElement === "undefined" || !(target instanceof HTMLElement)) {
+    return false;
+  }
+  return target.closest(`[${TERMINAL_CONTAINER_ATTR}]`) !== null;
+}
+
+/**
  * Format a keybind for display to users.
  * Returns Mac-style symbols on macOS, or Windows-style text elsewhere.
  */


### PR DESCRIPTION
## Problem

Ctrl+C was interrupting the AI stream even when focus was in the terminal. This happened because `useAIViewKeybinds` uses capture phase (`{ capture: true }`) to intercept keyboard events before they bubble through the DOM. The result was that **both** actions fired:

1. Stream interruption (capture phase handler)
2. SIGINT to terminal process (terminal's bubble phase handler)

## Solution

Add `isTerminalFocused()` utility that checks if the event target is inside a `.terminal-container` element. The interrupt keybind handler now skips when terminal is focused, letting only the terminal handle Ctrl+C for SIGINT.

## Changes

- `src/browser/utils/ui/keybinds.ts`: Add `isTerminalFocused()` utility function
- `src/browser/hooks/useAIViewKeybinds.ts`: Check terminal focus before handling interrupt keybind

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$2.31`_
