### PR TITLE
🤖 fix: clarify workspace path in environment context

### DIFF
--- a/docs/agents/system-prompt.mdx
+++ b/docs/agents/system-prompt.mdx
@@ -55,6 +55,7 @@ function buildEnvironmentContext(workspacePath: string, runtimeType: RuntimeMode
     "- This IS a git repository - run git commands directly (no cd needed)",
     "- Tools run here automatically",
     "- You are meant to do your work isolated from the user and other agents",
+    "- Parent directories may contain other workspaces - do not confuse them with this project",
   ];
 
   let description: string;

--- a/src/node/services/systemMessage.ts
+++ b/src/node/services/systemMessage.ts
@@ -78,6 +78,7 @@ function buildEnvironmentContext(workspacePath: string, runtimeType: RuntimeMode
     "- This IS a git repository - run git commands directly (no cd needed)",
     "- Tools run here automatically",
     "- You are meant to do your work isolated from the user and other agents",
+    "- Parent directories may contain other workspaces - do not confuse them with this project",
   ];
 
   let description: string;


### PR DESCRIPTION
## Problem

SSH runtime agents would sometimes start exploration from the wrong directory. For example, with workspace path `/root/mux/mux/ssh-runtime-xyz`, agents might run:

```bash
find /root/mux -type f -name "*.ts" | head -50
```

...searching from `/root/mux` instead of the actual workspace.

## Root Cause

The nested path pattern (`/root/mux/mux/...`) was confusing models into thinking `/root/mux` was "the repo" since it's a shorter/simpler-looking parent path.

## Fix

Add explicit guidance in the environment context that parent directories contain other workspaces, not this project's source code.

The new line in the system prompt:
```
- Parent directories may contain other workspaces - do not confuse them with this project
```

This framing allows legitimate system exploration while discouraging the common mistake.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$1.37`_