### PR TITLE
🤖 fix: wait for initial git status fetch in flaky test

### DIFF
--- a/tests/ui/gitStatus.integration.test.ts
+++ b/tests/ui/gitStatus.integration.test.ts
@@ -139,6 +139,11 @@ describeIntegration("GitStatus (UI + ORPC)", () => {
       try {
         await setupWorkspaceView(view, metadata, workspaceId);
 
+        // Wait for any initial git status fetch to complete before making commits.
+        // The RefreshController has debounce/min-interval guards that can delay
+        // subsequent refreshes if we start too quickly.
+        await waitForGitStatusElement(view.container, workspaceId, 10_000);
+
         // Make 2 commits to get ahead of remote
         for (let i = 0; i < 2; i++) {
           const bashRes = await env.orpc.workspace.executeBash({


### PR DESCRIPTION
## Summary

Fix flaky test `git status reflects ahead count` in `tests/ui/gitStatus.integration.test.ts`.

## Root Cause

Race condition between initial git status fetch and test commits:

1. `setupWorkspaceView` triggered an initial git status fetch via `RefreshController.requestImmediate()`
2. Test immediately made commits without waiting for initial fetch to complete
3. When `simulateWindowFocus()` fired, focus-triggered refresh was queued with 3s debounce if initial fetch was still in-flight
4. Test sometimes caught intermediate state (`ahead: 1, dirty: true`) instead of final state (`ahead: 2`)

## Fix

Wait for the initial git status element to appear before making commits. This ensures the `RefreshController`'s in-flight guards don't block the focus-triggered refresh.

## Testing

Ran the test multiple times locally - all passes:
```
Run 1: (pass) git status reflects ahead count [699.00ms]
Run 2: (pass) git status reflects ahead count [698.00ms]
Run 3: (pass) git status reflects ahead count [685.00ms]
```

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$2.35`_