### PR TITLE
🤖 docs: capitalize Mux product name in prose

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,6 +1,6 @@
 ---
 title: AGENTS.md
-description: Agent instructions for AI assistants working on the mux codebase
+description: Agent instructions for AI assistants working on the Mux codebase
 ---
 
 **Prime directive:** keep edits minimal and token-efficient—say only what conveys actionable signal.
@@ -74,7 +74,7 @@ EOF
 ## Refactoring & Runtime Etiquette
 
 - Use `git mv` to retain history when moving files.
-- Never kill the running mux process; rely on `make typecheck` + targeted `bun test path/to/file.test.ts` for validation (run `make test` only when necessary; it can be slow).
+- Never kill the running Mux process; rely on `make typecheck` + targeted `bun test path/to/file.test.ts` for validation (run `make test` only when necessary; it can be slow).
 
 ## Self-Healing & Crash Resilience
 

--- a/docs/config/agentic-git-identity.mdx
+++ b/docs/config/agentic-git-identity.mdx
@@ -3,7 +3,7 @@ title: Agentic Git Identity
 description: Configure a separate Git identity for AI-generated commits
 ---
 
-Configure mux to use a separate Git identity for AI-generated commits, making it easy to distinguish between human and AI contributions. Reasons to use a separate identity include:
+Configure Mux to use a separate Git identity for AI-generated commits, making it easy to distinguish between human and AI contributions. Reasons to use a separate identity include:
 
 - Clear attribution
 - Preventing (accidental) destructive actions
@@ -38,7 +38,7 @@ Classic tokens are easier to configure than fine-grained tokens for repository a
 2. Go to [Settings → Developer settings → Personal access tokens → Tokens (classic)](https://github.com/settings/tokens)
 3. Click "Generate new token (classic)"
 4. Configure the token:
-   - **Note**: "mux agent token" (or similar)
+   - **Note**: "Mux agent token" (or similar)
    - **Expiration**: Choose based on your security preferences
    - **Scopes**: Select `repo` (Full control of private repositories)
 5. Click "Generate token"
@@ -46,9 +46,9 @@ Classic tokens are easier to configure than fine-grained tokens for repository a
 
 ## Step 3: Configure Git Identity
 
-Add the Git identity environment variables as [Project Secrets](/config/project-secrets) in mux:
+Add the Git identity environment variables as [Project Secrets](/config/project-secrets) in Mux:
 
-1. Open mux and find your project in the sidebar
+1. Open Mux and find your project in the sidebar
 2. Click the 🔑 key icon to open the secrets modal
 3. Add the following four secrets:
    - `GIT_AUTHOR_NAME` = `Your Name (Agent)`
@@ -60,7 +60,7 @@ Add the Git identity environment variables as [Project Secrets](/config/project-
 These environment variables will be automatically injected when the agent runs Git commands in that project.
 
 <Info>
-  If you need the agent identity outside of mux, you can alternatively set these as global
+  If you need the agent identity outside of Mux, you can alternatively set these as global
   environment variables in your shell configuration (`~/.zshrc`, `~/.bashrc`, etc.)
 </Info>
 
@@ -121,7 +121,7 @@ For guaranteed attribution, you can use Git's built-in hooks instead:
 
 ### Using a Git Hook
 
-Create a `prepare-commit-msg` hook that adds co-author attribution only when running inside mux:
+Create a `prepare-commit-msg` hook that adds co-author attribution only when running inside Mux:
 
 ```bash
 #!/bin/bash
@@ -130,7 +130,7 @@ Create a `prepare-commit-msg` hook that adds co-author attribution only when run
 COMMIT_MSG_FILE=$1
 COMMIT_SOURCE=$2
 
-# Only add co-author when running in mux
+# Only add co-author when running in Mux
 if [ -z "$MUX_RUNTIME" ]; then
   exit 0
 fi
@@ -155,7 +155,7 @@ chmod +x .git/hooks/prepare-commit-msg
 
 <Info>
   This approach uses your normal Git identity for commits, but adds a trailer indicating AI
-  involvement. The hook only activates inside mux workspaces (detected via `MUX_RUNTIME`).
+  involvement. The hook only activates inside Mux workspaces (detected via `MUX_RUNTIME`).
 </Info>
 
 ### Comparison

--- a/docs/config/project-secrets.mdx
+++ b/docs/config/project-secrets.mdx
@@ -3,7 +3,7 @@ title: Project Secrets
 description: Manage environment variables and API keys for your projects
 ---
 
-Securely manage environment variables for your projects in mux. Project secrets are automatically injected when the agent executes bash commands, making it easy to provide API keys, tokens, and other sensitive configuration.
+Securely manage environment variables for your projects in Mux. Project secrets are automatically injected when the agent executes bash commands, making it easy to provide API keys, tokens, and other sensitive configuration.
 
 ![Project Secrets Modal](../img/project-secrets.webp)
 

--- a/docs/config/vim-mode.mdx
+++ b/docs/config/vim-mode.mdx
@@ -1,9 +1,9 @@
 ---
 title: Vim Mode
-description: Vim-style editing in the mux chat input
+description: Vim-style editing in the Mux chat input
 ---
 
-mux includes a built-in Vim mode for the chat input, providing familiar Vim-style editing for power users.
+Mux includes a built-in Vim mode for the chat input, providing familiar Vim-style editing for power users.
 
 ## Enabling Vim Mode
 

--- a/docs/getting-started/why-parallelize.mdx
+++ b/docs/getting-started/why-parallelize.mdx
@@ -8,6 +8,6 @@ A few reasons parallel workspaces matter:
 - **Keep context aligned**: Create dedicated workspaces for threads like `code-review`, `refactor`, and `new-feature`.
 - **Run long jobs in the background**: Kick off a slow, high-accuracy model for a deep investigation or refactor.
   - Streams resume after restarts or intermittent connection issues.
-  - mux shows an indicator when the model finishes.
+  - Mux shows an indicator when the model finishes.
 - **A/B implementations**: Try multiple approaches to the same problem and keep the best one.
 - **Tangent management**: Fork or create a new workspace for side quests so the main thread stays focused.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,15 +1,15 @@
 ---
 title: Introduction
-description: mux - Coding Agent Multiplexer for AI-assisted development
+description: Mux - Coding Agent Multiplexer for AI-assisted development
 ---
 
-![mux product screenshot](/img/product-hero.webp)
+![Mux product screenshot](/img/product-hero.webp)
 
-**mux** (Coding Agent Multiplexer) is a cross-platform desktop application for AI-assisted development with isolated workspace management.
+**Mux** (Coding Agent Multiplexer) is a cross-platform desktop application for AI-assisted development with isolated workspace management.
 
-## What is mux?
+## What is Mux?
 
-mux helps you work with multiple coding assistants more effectively via:
+Mux helps you work with multiple coding agents more effectively via:
 
 - Isolated workspaces with central view on git status updates
 - Multi-model (`sonnet-4-*`, `grok-*`, `gpt-5-*`, `opus-4-*`) support
@@ -25,6 +25,6 @@ mux helps you work with multiple coding assistants more effectively via:
 
 ## License
 
-mux is licensed under the [GNU Affero General Public License v3.0 (AGPL-3.0)](https://github.com/coder/mux/blob/main/LICENSE).
+Mux is licensed under the [GNU Affero General Public License v3.0 (AGPL-3.0)](https://github.com/coder/mux/blob/main/LICENSE).
 
 Copyright (C) 2025 Coder Technologies, Inc.

--- a/docs/integrations/vscode-extension.mdx
+++ b/docs/integrations/vscode-extension.mdx
@@ -1,9 +1,9 @@
 ---
 title: VS Code Extension
-description: Pair mux workspaces with VS Code and Cursor editors
+description: Pair Mux workspaces with VS Code and Cursor editors
 ---
 
-The mux VS Code extension allows you to easily pair with mux during development. Our extension works with VS Code and Cursor.
+The Mux VS Code extension allows you to easily pair with Mux during development. Our extension works with VS Code and Cursor.
 
 It's especially useful for completing the "last mile" of a task or establishing the initial architecture.
 
@@ -11,7 +11,7 @@ It's especially useful for completing the "last mile" of a task or establishing 
 
 The extension has a small initial surface area: a command to open a workspace and a Secondary Sidebar Chat view (Preview).
 
-![mux VS Code extension screenshot](../img/vscode-ext.webp)
+![Mux VS Code extension screenshot](../img/vscode-ext.webp)
 
 1. Press `Cmd+Shift+P` (or `Ctrl+Shift+P` on Windows/Linux)
 2. Type "mux: Open Workspace"
@@ -31,12 +31,12 @@ The extension works with both local and SSH workspaces.
 You can find it in the **Secondary Sidebar** under the `mux` container: **Chat (Preview)**.
 
 1. Open **Chat (Preview)**
-2. Select a mux workspace from the picker
+2. Select a Mux workspace from the picker
 3. Chat normally; use the pencil icon to open the workspace in a new window
 
-To send messages, mux must be connected in server/API mode.
+To send messages, Mux must be connected in server/API mode.
 
-If you hit issues, please report them on the [mux GitHub issues page](https://github.com/coder/mux/issues).
+If you hit issues, please report them on the [Mux GitHub issues page](https://github.com/coder/mux/issues).
 
 ## Installation
 

--- a/docs/reference/benchmarking.mdx
+++ b/docs/reference/benchmarking.mdx
@@ -1,15 +1,15 @@
 ---
 title: Terminal Benchmarking
-description: Run Terminal-Bench benchmarks with the mux adapter
+description: Run Terminal-Bench benchmarks with the Mux adapter
 ---
 
-mux ships with a headless adapter for [Terminal-Bench](https://www.tbench.ai/). The adapter runs the Electron backend without opening a window and exercises it through the same IPC paths we use in integration tests. This page documents how to launch benchmarks from the repository tree.
+Mux ships with a headless adapter for [Terminal-Bench](https://www.tbench.ai/). The adapter runs the Electron backend without opening a window and exercises it through the same IPC paths we use in integration tests. This page documents how to launch benchmarks from the repository tree.
 
 ## Prerequisites
 
 - Docker must be installed and running. Terminal-Bench executes each task inside a dedicated Docker container.
 - `uv` is available in the nix `devShell` (provided via `flake.nix`), or install it manually from [docs.astral.sh/uv](https://docs.astral.sh/uv/).
-- Standard provider API keys (e.g. `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) should be exported so mux can stream responses.
+- Standard provider API keys (e.g. `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) should be exported so Mux can stream responses.
 
 Optional environment overrides:
 
@@ -17,14 +17,14 @@ Optional environment overrides:
 | --------------------- | --------------------------------------------------------- | -------------------------------------- |
 | `MUX_AGENT_REPO_ROOT` | Path copied into each task container                      | repo root inferred from the agent file |
 | `MUX_TRUNK`           | Branch checked out when preparing the project             | `main`                                 |
-| `MUX_WORKSPACE_ID`    | Workspace identifier used inside mux                      | `mux-bench`                            |
+| `MUX_WORKSPACE_ID`    | Workspace identifier used inside Mux                      | `mux-bench`                            |
 | `MUX_MODEL`           | Preferred model (supports `provider/model` syntax)        | `anthropic/claude-sonnet-4-5`          |
 | `MUX_THINKING_LEVEL`  | Optional reasoning level (`off`, `low`, `medium`, `high`) | `high`                                 |
 | `MUX_MODE`            | Starting mode (`plan` or `exec`)                          | `exec`                                 |
 | `MUX_RUNTIME`         | Runtime type (`local`, `worktree`, or `ssh <host>`)       | `worktree`                             |
 | `MUX_TIMEOUT_MS`      | Optional stream timeout in milliseconds                   | no timeout                             |
-| `MUX_CONFIG_ROOT`     | Location for mux session data inside the container        | `/root/.mux`                           |
-| `MUX_APP_ROOT`        | Path where the mux sources are staged                     | `/opt/mux-app`                         |
+| `MUX_CONFIG_ROOT`     | Location for Mux session data inside the container        | `/root/.mux`                           |
+| `MUX_APP_ROOT`        | Path where the Mux sources are staged                     | `/opt/mux-app`                         |
 | `MUX_PROJECT_PATH`    | Explicit project directory inside the task container      | auto-detected from common paths        |
 
 ## Running Terminal-Bench
@@ -40,7 +40,7 @@ uvx terminal-bench run \
   --n-tasks 1
 ```
 
-This downloads the Terminal-Bench runner, copies the mux sources into the container, and validates the adapter against the first task only. Use this before attempting a full sweep.
+This downloads the Terminal-Bench runner, copies the Mux sources into the container, and validates the adapter against the first task only. Use this before attempting a full sweep.
 
 ### Full dataset
 
@@ -67,11 +67,11 @@ Use `TB_CONCURRENCY=<n>` to control `--n-concurrent` (number of concurrently run
 
 The adapter lives in `benchmarks/terminal_bench/mux_agent.py`. For each task it:
 
-1. Copies the mux repository (package manifests + `src/`) into `/tmp/mux-app` inside the container.
+1. Copies the Mux repository (package manifests + `src/`) into `/tmp/mux-app` inside the container.
 2. Ensures Bun exists, then runs `bun install --frozen-lockfile`.
 3. Launches `mux run` (`src/cli/run.ts`) to prepare workspace metadata and stream the instruction, storing state under `MUX_CONFIG_ROOT` (default `/root/.mux`).
 
-`MUX_MODEL` accepts either the mux colon form (`anthropic:claude-sonnet-4-5`) or the Terminal-Bench slash form (`anthropic/claude-sonnet-4-5`); the adapter normalises whichever you provide.
+`MUX_MODEL` accepts either the Mux colon form (`anthropic:claude-sonnet-4-5`) or the Terminal-Bench slash form (`anthropic/claude-sonnet-4-5`); the adapter normalises whichever you provide.
 
 ## Troubleshooting
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -1,7 +1,7 @@
 ---
 title: CLI
 sidebarTitle: CLI
-description: Run one-off agent tasks from the command line with mux run
+description: Run one-off agent tasks from the command line with `mux run`
 ---
 
 <Note>
@@ -10,7 +10,7 @@ description: Run one-off agent tasks from the command line with mux run
   Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) or similar TUIs.
 </Note>
 
-mux provides a CLI for running one-off agent tasks without the desktop app. Unlike the interactive desktop experience, `mux run` executes a single request to completion and exits.
+Mux provides a CLI for running one-off agent tasks without the desktop app. Unlike the interactive desktop experience, `mux run` executes a single request to completion and exits.
 
 <Card title="GitHub Actions Guide" icon="github" href="/guides/github-actions">
   Learn how to use `mux run` in CI/CD pipelines

--- a/docs/reference/storybook.mdx
+++ b/docs/reference/storybook.mdx
@@ -1,9 +1,9 @@
 ---
 title: Storybook
-description: Develop and test mux UI states in isolation
+description: Develop and test Mux UI states in isolation
 ---
 
-Storybook renders mux's **renderer UI** without running the full Electron app.
+Storybook renders Mux's **renderer UI** without running the full Electron app.
 
 ## Starting Storybook
 
@@ -29,7 +29,7 @@ The output will be in `storybook-static/`.
 
 ## Writing Stories (full app only)
 
-mux intentionally uses **full-app** stories (no isolated component stories).
+Mux intentionally uses **full-app** stories (no isolated component stories).
 
 Stories live in `src/browser/stories/` and must be named `App.*.stories.tsx`.
 

--- a/docs/reference/telemetry.mdx
+++ b/docs/reference/telemetry.mdx
@@ -1,18 +1,18 @@
 ---
 title: Telemetry
-description: What mux collects, what it doesn’t, and how to disable it
+description: What Mux collects, what it doesn’t, and how to disable it
 ---
 
-mux collects anonymous usage telemetry to help improve the product.
+Mux collects anonymous usage telemetry to help improve the product.
 
 ## Privacy policy
 
-- **No personal information**: mux does not collect usernames, project names, file paths, or code content.
+- **No personal information**: Mux does not collect usernames, project names, file paths, or code content.
 - **Random IDs only**: Only randomly generated workspace IDs are sent.
 - **No hashing**: Hashing is vulnerable to rainbow table attacks.
 - **Transparent payload**: See exactly what is sent in [`src/common/telemetry/payload.ts`](https://github.com/coder/mux/blob/main/src/common/telemetry/payload.ts).
 
-## What mux tracks
+## What Mux tracks
 
 All telemetry events include basic system information:
 
@@ -28,7 +28,7 @@ All telemetry events include basic system information:
 - **Message sending**: When messages are sent (model, mode, message length rounded to base-2)
 - **Errors**: Error types and context (no sensitive data)
 
-### What mux does _not_ track
+### What Mux does _not_ track
 
 - Your messages or code
 - Project names or file paths
@@ -48,7 +48,7 @@ This disables telemetry collection at the backend level.
 
 <Note>
   Disabling telemetry also hides the **Share** button on assistant messages. Link sharing uses
-  [mux.md](https://mux.md), a separate mux service, and is gated on telemetry enablement to respect
+  [mux.md](https://mux.md), a separate Mux service, and is gated on telemetry enablement to respect
   your privacy preferences.
 </Note>
 

--- a/docs/runtime/docker.mdx
+++ b/docs/runtime/docker.mdx
@@ -13,7 +13,7 @@ Docker runtime runs each workspace in a separate Docker container, providing ful
 
 ## How it works
 
-1. When you create a Docker workspace, mux starts a container from your chosen image
+1. When you create a Docker workspace, Mux starts a container from your chosen image
 2. Your project code is synced to `/src` inside the container via git bundle
 3. Commands run inside the container with `docker exec`
 4. Deleting the workspace removes the container
@@ -32,4 +32,4 @@ Check "Share credentials" when creating a Docker workspace to enable git authent
 
 - **SSH agent forwarding** — Your SSH keys work inside the container without copying private keys
 - **Git config** — Host `~/.gitconfig` is copied into the container so git has your identity and settings
-- **GitHub CLI** — If `GH_TOKEN` is set in [project secrets](/config/project-secrets), mux runs `gh auth setup-git` to configure HTTPS authentication (requires `gh` CLI in the container image)
+- **GitHub CLI** — If `GH_TOKEN` is set in [project secrets](/config/project-secrets), Mux runs `gh auth setup-git` to configure HTTPS authentication (requires `gh` CLI in the container image)

--- a/docs/runtime/index.mdx
+++ b/docs/runtime/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Runtimes
-description: Configure where and how mux executes agent workspaces
+description: Configure where and how Mux executes agent workspaces
 ---
 
-Runtimes determine where and how mux executes agent workspaces.
+Runtimes determine where and how Mux executes agent workspaces.
 
 | Runtime                           | Isolation                                  | Best For                                  |
 | --------------------------------- | ------------------------------------------ | ----------------------------------------- |

--- a/docs/runtime/local.mdx
+++ b/docs/runtime/local.mdx
@@ -15,7 +15,7 @@ Local runtime runs the agent directly in your project directory—the same direc
 
 <Warning>
   **No isolation**: Multiple local workspaces for the same project see and modify the same files.
-  Running them simultaneously can cause conflicts. mux shows a warning when another local workspace
+  Running them simultaneously can cause conflicts. Mux shows a warning when another local workspace
   is actively streaming.
 </Warning>
 

--- a/docs/runtime/ssh.mdx
+++ b/docs/runtime/ssh.mdx
@@ -3,11 +3,11 @@ title: SSH Runtime
 description: Run agents on remote hosts over SSH for security and performance
 ---
 
-mux can run workspaces on a remote host over SSH. When configured, tool operations (file reads/edits, `bash`, etc.) execute on the remote machine.
+Mux can run workspaces on a remote host over SSH. When configured, tool operations (file reads/edits, `bash`, etc.) execute on the remote machine.
 
 ## Threat model
 
-mux treats the remote host as potentially hostile. By default it does **not** forward your local keys or credentials.
+Mux treats the remote host as potentially hostile. By default it does **not** forward your local keys or credentials.
 
 The only data synced to the remote machine is:
 
@@ -30,7 +30,7 @@ The host field accepts anything you can pass to `ssh <host>`:
 - a username and hostname (for example `user@my-server.com`)
 - an alias from your `~/.ssh/config` (for example `my-server`)
 
-mux delegates SSH configuration to your system `ssh` command, so advanced settings live in `~/.ssh/config`.
+Mux delegates SSH configuration to your system `ssh` command, so advanced settings live in `~/.ssh/config`.
 
 Example entry:
 
@@ -43,7 +43,7 @@ Host ovh-1
 ## Authentication
 
 <Info>
-  mux delegates to `ssh`. This is an abbreviated reference of common ways `ssh` authenticates.
+  Mux delegates to `ssh`. This is an abbreviated reference of common ways `ssh` authenticates.
 </Info>
 
 ### Local default keys
@@ -79,9 +79,9 @@ Host my-server
 
 ## Coder Workspaces
 
-If you're using [Coder Workspaces](https://coder.com/docs), you can use an existing workspace as a mux agent host:
+If you're using [Coder Workspaces](https://coder.com/docs), you can use an existing workspace as a Mux agent host:
 
 1. Run `coder config-ssh`
-2. Use `coder.<workspace-name>` as your SSH host when creating a new mux workspace
+2. Use `coder.<workspace-name>` as your SSH host when creating a new Mux workspace
 
-This multiplexes many mux workspaces onto a single Coder workspace, which avoids per-workspace provisioning overhead.
+This multiplexes many Mux workspaces onto a single Coder workspace, which avoids per-workspace provisioning overhead.

--- a/docs/workspaces/compaction/automatic.mdx
+++ b/docs/workspaces/compaction/automatic.mdx
@@ -1,19 +1,19 @@
 ---
 title: Automatic Compaction
-description: Let mux automatically compact your conversations based on usage or idle time
+description: Let Mux automatically compact your conversations based on usage or idle time
 ---
 
-mux can run `/compact` for you to keep context size manageable. There are two types of automatic compaction:
+Mux can run `/compact` for you to keep context size manageable. There are two types of automatic compaction:
 
 - **Usage-based**: Compacts when your conversation reaches a configurable percentage of the model's context window
 - **Idle-based**: Optionally compacts inactive workspaces after a period of time
 
 ## Usage-based auto-compaction
 
-When enabled, mux monitors your context usage and:
+When enabled, Mux monitors your context usage and:
 
 1. Shows a subtle warning as you approach the threshold (e.g., "Auto-Compact in 12% usage")
-2. When you send your next message **at or above the threshold**, mux runs compaction first, then automatically sends your message as a follow-up
+2. When you send your next message **at or above the threshold**, Mux runs compaction first, then automatically sends your message as a follow-up
 
 ### Configure the threshold
 
@@ -23,11 +23,11 @@ When enabled, mux monitors your context usage and:
 - Default is **70%**
 - Set it to **100%** to disable usage-based auto-compaction
 
-mux caps the enabled threshold at **90%** to leave a safety buffer before hard context limits.
+Mux caps the enabled threshold at **90%** to leave a safety buffer before hard context limits.
 
 ### Force-compaction during streaming
 
-If a single response pushes context usage above your threshold while streaming, mux may interrupt and compact automatically once you exceed the threshold by an additional buffer (currently **+5%**). After compaction, mux resumes the conversation automatically.
+If a single response pushes context usage above your threshold while streaming, Mux may interrupt and compact automatically once you exceed the threshold by an additional buffer (currently **+5%**). After compaction, Mux resumes the conversation automatically.
 
 This safety mechanism prevents hitting hard context limits mid-stream.
 
@@ -37,7 +37,7 @@ This safety mechanism prevents hitting hard context limits mid-stream.
 
 Idle-based auto-compaction is **off by default**.
 
-When enabled for a project, mux periodically checks for workspaces that:
+When enabled for a project, Mux periodically checks for workspaces that:
 
 - Have been inactive for the configured number of hours
 - Are not currently streaming
@@ -78,12 +78,12 @@ Disable idle compaction for this project.
 ### Notes
 
 - The setting is **per project** (applies to all workspaces in the project)
-- mux checks roughly **once per hour**, so compaction may not trigger immediately when the timer expires
+- Mux checks roughly **once per hour**, so compaction may not trigger immediately when the timer expires
 
 ---
 
 ## General notes
 
 - Auto-compaction uses API tokens (same cost model as `/compact`)
-- Auto-compaction requires known model context limits; if mux can't determine a model's context window, usage-based auto-compaction won't run
+- Auto-compaction requires known model context limits; if Mux can't determine a model's context window, usage-based auto-compaction won't run
 - Both types of auto-compaction use the same summarization logic as manual `/compact`

--- a/docs/workspaces/compaction/customization.mdx
+++ b/docs/workspaces/compaction/customization.mdx
@@ -3,7 +3,7 @@ title: Customization
 description: Customize the compaction system prompt
 ---
 
-You can customize how mux summarizes conversations during compaction by overriding the `compact` agent.
+You can customize how Mux summarizes conversations during compaction by overriding the `compact` agent.
 
 ## Override the `compact` agent
 
@@ -83,4 +83,4 @@ Write in a factual, dense style. Every sentence should convey essential context.
 
 - Custom `compact` agents apply to both manual `/compact` and auto-compaction.
 - Tools are always disabled during compaction.
-- `-t` sets `maxOutputTokens`; mux converts this into an approximate word target for the instruction message.
+- `-t` sets `maxOutputTokens`; Mux converts this into an approximate word target for the instruction message.

--- a/docs/workspaces/compaction/index.mdx
+++ b/docs/workspaces/compaction/index.mdx
@@ -24,4 +24,4 @@ As conversations grow, they consume more of the model's context window. Compacti
 ## Next steps
 
 - [Manual Compaction](/workspaces/compaction/manual) — Commands for manually managing context
-- [Automatic Compaction](/workspaces/compaction/automatic) — Let mux compact for you based on usage or idle time
+- [Automatic Compaction](/workspaces/compaction/automatic) — Let Mux compact for you based on usage or idle time

--- a/docs/workspaces/sharing.mdx
+++ b/docs/workspaces/sharing.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Sharing
 description: Share encrypted messages with cryptographic signatures via mux.md
 ---
 
-mux lets you share assistant messages via [mux.md](https://mux.md), an end-to-end encrypted paste service. Shared messages can also be cryptographically signed to prove authorship.
+Mux lets you share assistant messages via [mux.md](https://mux.md), an end-to-end encrypted paste service. Shared messages can also be cryptographically signed to prove authorship.
 
 ![Sharing](../img/message-sharing.webp)
 
@@ -12,7 +12,7 @@ mux lets you share assistant messages via [mux.md](https://mux.md), an end-to-en
 
 1. **End-to-end encryption**: Content is encrypted in your browser using AES-256-GCM before upload. The encryption key stays in the URL fragment and is never sent to the server.
 
-2. **Optional signing**: When a signing key is available, mux signs the content with your private key. Recipients can verify the signature on mux.md.
+2. **Optional signing**: When a signing key is available, Mux signs the content with your private key. Recipients can verify the signature on mux.md.
 
 3. **Expiration**: Shares can expire after 1 hour, 24 hours, 7 days, 30 days, or never. You can change expiration after sharing.
 
@@ -22,9 +22,9 @@ Signing proves that you authored a shared message. When enabled, mux.md displays
 
 ### Signing key discovery
 
-mux looks for a signing key in these locations (first match wins):
+Mux looks for a signing key in these locations (first match wins):
 
-1. `~/.mux/message_signing_key` — mux-specific key (can be a symlink)
+1. `~/.mux/message_signing_key` — Mux-specific key (can be a symlink)
 2. `~/.ssh/id_ed25519` — standard SSH Ed25519 key
 3. `~/.ssh/id_ecdsa` — standard SSH ECDSA key
 
@@ -46,7 +46,7 @@ Encrypted keys (passphrase-protected) are skipped automatically.
 
 ### GitHub identity detection
 
-To display your GitHub username on signed shares, mux detects your identity via the GitHub CLI:
+To display your GitHub username on signed shares, Mux detects your identity via the GitHub CLI:
 
 ```bash
 gh auth status
@@ -65,17 +65,17 @@ Click the pen icon (✏️) in the share popover to toggle signing on or off. Th
 
 When signing is disabled (or no key is found), shares are still encrypted—they just won’t include a signature.
 
-## Using shared content in mux
+## Using shared content in Mux
 
-mux can read mux.md URLs using the `web_fetch` tool. When you paste a mux.md link into chat, mux decrypts the content client-side and makes it available to the assistant.
+Mux can read mux.md URLs using the `web_fetch` tool. When you paste a mux.md link into chat, Mux decrypts the content client-side and makes it available to the assistant.
 
 This enables several workflows:
 
-- **Cross-session sharing**: Move context or instructions between workspaces in the same mux client
-- **Team collaboration**: Send encrypted snippets to teammates who can paste them into their own mux sessions
+- **Cross-session sharing**: Move context or instructions between workspaces in the same Mux client
+- **Team collaboration**: Send encrypted snippets to teammates who can paste them into their own Mux sessions
 - **Preserving context**: Save important outputs and retrieve them later in new conversations
 
-Paste any `https://mux.md/<id>#<key>` URL into your message, and mux will fetch and decrypt the content.
+Paste any `https://mux.md/<id>#<key>` URL into your message, and Mux will fetch and decrypt the content.
 
 <Tip>
   The encryption key (after `#`) never leaves your client. Only the encrypted blob travels over the
@@ -94,4 +94,4 @@ ssh-keygen -t ed25519 -f ~/.mux/message_signing_key -N ""
 ssh-keygen -t ecdsa -b 256 -f ~/.mux/message_signing_key -N ""
 ```
 
-The `-N ""` flag creates a key without a passphrase (required for mux to use it automatically).
+The `-N ""` flag creates a key without a passphrase (required for Mux to use it automatically).

--- a/src/node/builtinSkills/mux-docs.md
+++ b/src/node/builtinSkills/mux-docs.md
@@ -46,14 +46,14 @@ Use this index to find a page's:
 <!-- BEGIN DOCS_TREE -->
 - **Documentation**
   - **Getting Started**
-    - Introduction (`/`) → `references/docs/index.mdx` — mux - Coding Agent Multiplexer for AI-assisted development
+    - Introduction (`/`) → `references/docs/index.mdx` — Mux - Coding Agent Multiplexer for AI-assisted development
     - Install (`/install`) → `references/docs/install.mdx` — Download and install mux for macOS, Linux, and Windows
     - **Models**
       - Models (`/config/models`) → `references/docs/config/models.mdx` — Select and configure AI models in mux
       - Providers (`/config/providers`) → `references/docs/config/providers.mdx` — Configure API keys and settings for AI providers
     - Why Parallelize? (`/getting-started/why-parallelize`) → `references/docs/getting-started/why-parallelize.mdx` — Use cases for running multiple AI agents in parallel
     - Mux Codes (`/getting-started/mux-codes`) → `references/docs/getting-started/mux-codes.mdx` — Redeem free LLM token credits for evaluating Mux
-    - CLI (`/reference/cli`) → `references/docs/reference/cli.mdx` — Run one-off agent tasks from the command line with mux run
+    - CLI (`/reference/cli`) → `references/docs/reference/cli.mdx` — Run one-off agent tasks from the command line with `mux run`
   - **Workspaces**
     - Workspaces (`/workspaces`) → `references/docs/workspaces/index.mdx` — Isolated development environments for parallel agent work
     - Forking Workspaces (`/workspaces/fork`) → `references/docs/workspaces/fork.mdx` — Clone workspaces with conversation history to explore alternatives
@@ -61,10 +61,10 @@ Use this index to find a page's:
     - **Compaction**
       - Compaction (`/workspaces/compaction`) → `references/docs/workspaces/compaction/index.mdx` — Managing conversation context size with compaction
       - Manual Compaction (`/workspaces/compaction/manual`) → `references/docs/workspaces/compaction/manual.mdx` — Commands for manually managing conversation context
-      - Automatic Compaction (`/workspaces/compaction/automatic`) → `references/docs/workspaces/compaction/automatic.mdx` — Let mux automatically compact your conversations based on usage or idle time
+      - Automatic Compaction (`/workspaces/compaction/automatic`) → `references/docs/workspaces/compaction/automatic.mdx` — Let Mux automatically compact your conversations based on usage or idle time
       - Customization (`/workspaces/compaction/customization`) → `references/docs/workspaces/compaction/customization.mdx` — Customize the compaction system prompt
     - **Runtimes**
-      - Runtimes (`/runtime`) → `references/docs/runtime/index.mdx` — Configure where and how mux executes agent workspaces
+      - Runtimes (`/runtime`) → `references/docs/runtime/index.mdx` — Configure where and how Mux executes agent workspaces
       - Local Runtime (`/runtime/local`) → `references/docs/runtime/local.mdx` — Run agents directly in your project directory
       - Worktree Runtime (`/runtime/worktree`) → `references/docs/runtime/worktree.mdx` — Isolated git worktree environments for parallel agent work
       - SSH Runtime (`/runtime/ssh`) → `references/docs/runtime/ssh.mdx` — Run agents on remote hosts over SSH for security and performance
@@ -86,18 +86,18 @@ Use this index to find a page's:
     - Agentic Git Identity (`/config/agentic-git-identity`) → `references/docs/config/agentic-git-identity.mdx` — Configure a separate Git identity for AI-generated commits
     - Keyboard Shortcuts (`/config/keybinds`) → `references/docs/config/keybinds.mdx` — Complete keyboard shortcut reference for mux
     - Notifications (`/config/notifications`) → `references/docs/config/notifications.mdx` — Configure how agents notify you about important events
-    - Vim Mode (`/config/vim-mode`) → `references/docs/config/vim-mode.mdx` — Vim-style editing in the mux chat input
+    - Vim Mode (`/config/vim-mode`) → `references/docs/config/vim-mode.mdx` — Vim-style editing in the Mux chat input
   - **Guides**
     - GitHub Actions (`/guides/github-actions`) → `references/docs/guides/github-actions.mdx` — Automate your workflows with mux run in GitHub Actions
     - Agentic Git Identity (`/config/agentic-git-identity`) → `references/docs/config/agentic-git-identity.mdx` — Configure a separate Git identity for AI-generated commits
     - Prompting Tips (`/agents/prompting-tips`) → `references/docs/agents/prompting-tips.mdx` — Tips and tricks for getting the most out of your AI agents
   - **Integrations**
-    - VS Code Extension (`/integrations/vscode-extension`) → `references/docs/integrations/vscode-extension.mdx` — Pair mux workspaces with VS Code and Cursor editors
+    - VS Code Extension (`/integrations/vscode-extension`) → `references/docs/integrations/vscode-extension.mdx` — Pair Mux workspaces with VS Code and Cursor editors
   - **Reference**
-    - Telemetry (`/reference/telemetry`) → `references/docs/reference/telemetry.mdx` — What mux collects, what it doesn’t, and how to disable it
-    - Storybook (`/reference/storybook`) → `references/docs/reference/storybook.mdx` — Develop and test mux UI states in isolation
-    - Terminal Benchmarking (`/reference/benchmarking`) → `references/docs/reference/benchmarking.mdx` — Run Terminal-Bench benchmarks with the mux adapter
-    - AGENTS.md (`/AGENTS`) → `references/docs/AGENTS.md` — Agent instructions for AI assistants working on the mux codebase
+    - Telemetry (`/reference/telemetry`) → `references/docs/reference/telemetry.mdx` — What Mux collects, what it doesn’t, and how to disable it
+    - Storybook (`/reference/storybook`) → `references/docs/reference/storybook.mdx` — Develop and test Mux UI states in isolation
+    - Terminal Benchmarking (`/reference/benchmarking`) → `references/docs/reference/benchmarking.mdx` — Run Terminal-Bench benchmarks with the Mux adapter
+    - AGENTS.md (`/AGENTS`) → `references/docs/AGENTS.md` — Agent instructions for AI assistants working on the Mux codebase
 <!-- END DOCS_TREE -->
 
 1. Read the docs navigation (source of truth for which pages exist):


### PR DESCRIPTION
Standardizes references to "Mux" (uppercase) as the product name in documentation.

## Changes

19 files updated with consistent capitalization:
- `docs/index.mdx` - Main intro page
- `docs/AGENTS.md` - Agent instructions  
- `docs/reference/*.mdx` - CLI, storybook, benchmarking, telemetry
- `docs/workspaces/*.mdx` - Sharing, compaction docs
- `docs/runtime/*.mdx` - Local, SSH, Docker, worktree runtimes
- `docs/config/*.mdx` - Git identity, secrets, vim mode, etc.
- `docs/integrations/vscode-extension.mdx`
- `docs/getting-started/why-parallelize.mdx`

## Preserved lowercase "mux" in:
- CLI commands: `mux run`, `npx mux`, `mux server`
- File paths: `~/.mux/`, `.mux/agents/`
- URLs: `mux.md`, `github.com/coder/mux`
- Environment variables: `MUX_RUNTIME`, `MUX_CONFIG_ROOT`
- Code blocks and inline code

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$6.34`_
