### PR TITLE
🤖 fix: improve workspace deletion UX with spinner and idempotency

### DIFF
--- a/src/browser/components/ArchivedWorkspaces.tsx
+++ b/src/browser/components/ArchivedWorkspaces.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/common/lib/utils";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import { useWorkspaceContext } from "@/browser/contexts/WorkspaceContext";
 import { useAPI } from "@/browser/contexts/API";
-import { Trash2, Search } from "lucide-react";
+import { Trash2, Search, Loader2 } from "lucide-react";
 import { ArchiveIcon, ArchiveRestoreIcon } from "./icons/ArchiveIcon";
 import { Tooltip, TooltipTrigger, TooltipContent } from "./ui/tooltip";
 import { RuntimeBadge } from "./RuntimeBadge";
@@ -616,7 +616,7 @@ export const ArchivedWorkspaces: React.FC<ArchivedWorkspacesProps> = ({
                   </div>
                   {/* Workspaces in this period */}
                   {periodWorkspaces.map((workspace) => {
-                    const isProcessing = processingIds.has(workspace.id);
+                    const isProcessing = processingIds.has(workspace.id) || workspace.isRemoving;
                     const isSelected = selectedIds.has(workspace.id);
                     const branchForTooltip =
                       workspace.title && workspace.title !== workspace.name
@@ -690,7 +690,11 @@ export const ArchivedWorkspaces: React.FC<ArchivedWorkspacesProps> = ({
                                 className="text-muted rounded p-1.5 transition-colors hover:bg-white/10 hover:text-red-400 disabled:opacity-50"
                                 aria-label={`Delete workspace ${displayTitle}`}
                               >
-                                <Trash2 className="h-4 w-4" />
+                                {isProcessing ? (
+                                  <Loader2 className="h-4 w-4 animate-spin" />
+                                ) : (
+                                  <Trash2 className="h-4 w-4" />
+                                )}
                               </button>
                             </TooltipTrigger>
                             <TooltipContent>Delete permanently (local branch too)</TooltipContent>

--- a/src/common/orpc/schemas/workspace.ts
+++ b/src/common/orpc/schemas/workspace.ts
@@ -92,6 +92,9 @@ export const FrontendWorkspaceMetadataSchema = WorkspaceMetadataSchema.extend({
     description:
       "If set, this workspace has an incompatible runtime configuration (e.g., from a newer version of mux). The workspace should be displayed but interactions should show this error message.",
   }),
+  isRemoving: z.boolean().optional().meta({
+    description: "True if this workspace is currently being deleted (deletion in progress).",
+  }),
 });
 
 export const WorkspaceActivitySnapshotSchema = z.object({


### PR DESCRIPTION
## Summary

Improves workspace deletion UX in the archived workspaces list:

1. **Spinner feedback**: Replace trash icon with spinning loader while deletion is in progress
2. **Persist state across navigation**: Expose `isRemoving` via the workspace list API so the spinner shows even after navigating away and back
3. **Idempotent deletion**: Backend returns success (not error) if deletion is already in progress, preventing race conditions from double-clicks or concurrent tabs

## Motivation

This PR is necessary for the Coder workspace integration, where workspace deletion can take 30+ seconds to several minutes due to remote API calls and cleanup operations. Without this change, users would see a briefly disabled button with no visual feedback, potentially leading to confusion or repeated delete attempts.

## Changes

| File | Change |
|------|--------|
| `src/node/services/workspaceService.ts` | Add `isRemoving()` method, return `Ok` when already deleting, enrich `list()` with `isRemoving` |
| `src/common/orpc/schemas/workspace.ts` | Add optional `isRemoving` field to `FrontendWorkspaceMetadataSchema` |
| `src/browser/components/ArchivedWorkspaces.tsx` | Show `Loader2` spinner when deleting, combine local + API state for `isProcessing` |

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$6.28`_
