### PR TITLE
🤖 fix: redact base64 blobs for local token counting

### DIFF
--- a/src/common/utils/tokens/safeStringifyForCounting.test.ts
+++ b/src/common/utils/tokens/safeStringifyForCounting.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+
+import { safeStringifyForCounting } from "./safeStringifyForCounting";
+
+describe("safeStringifyForCounting", () => {
+  test("redacts AI SDK media blocks (base64)", () => {
+    const input = {
+      type: "media",
+      data: "A".repeat(100_000),
+      mediaType: "image/png",
+    };
+
+    const serialized = safeStringifyForCounting(input);
+
+    expect(serialized).toContain("[omitted base64 len=100000]");
+    expect(serialized).not.toContain("A".repeat(1024));
+  });
+
+  test("redacts base64 data URLs", () => {
+    const dataUrl = `data:image/png;base64,${"A".repeat(1000)}`;
+
+    const serialized = safeStringifyForCounting({ url: dataUrl });
+
+    expect(serialized).toContain("data:image/png;base64,[omitted len=1000]");
+    expect(serialized).not.toContain("A".repeat(256));
+  });
+
+  test("does not throw on circular structures", () => {
+    const obj: Record<string, unknown> = { a: 1 };
+    obj.self = obj;
+
+    const serialized = safeStringifyForCounting(obj);
+
+    expect(serialized).toContain("[circular]");
+  });
+});

--- a/src/common/utils/tokens/safeStringifyForCounting.ts
+++ b/src/common/utils/tokens/safeStringifyForCounting.ts
@@ -1,0 +1,72 @@
+/**
+ * Safe JSON.stringify variant for *local* token counting.
+ *
+ * This is used for UI stats/weighting (Tokenizer tab, truncation heuristics),
+ * not for provider payloads.
+ *
+ * The goal is to keep the serialized output stable-ish while redacting heavy
+ * blobs (notably base64-encoded screenshots).
+ */
+
+const DATA_URL_BASE64_MARKER = ";base64,";
+
+function redactDataUrl(value: string): string | null {
+  if (!value.startsWith("data:")) {
+    return null;
+  }
+
+  const markerIndex = value.indexOf(DATA_URL_BASE64_MARKER);
+  if (markerIndex === -1) {
+    return null;
+  }
+
+  const mime = value.slice("data:".length, markerIndex) || "<unknown>";
+  const base64Len = value.length - (markerIndex + DATA_URL_BASE64_MARKER.length);
+
+  return `data:${mime}${DATA_URL_BASE64_MARKER}[omitted len=${base64Len}]`;
+}
+
+function isAiSdkMediaBlock(
+  value: unknown
+): value is { type: "media"; data: string; mediaType: string } {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    record.type === "media" &&
+    typeof record.data === "string" &&
+    typeof record.mediaType === "string"
+  );
+}
+
+export function safeStringifyForCounting(data: unknown): string {
+  try {
+    const seen = new WeakSet<object>();
+
+    return JSON.stringify(data, (_key, value: unknown) => {
+      if (typeof value === "string") {
+        return redactDataUrl(value) ?? value;
+      }
+
+      if (isAiSdkMediaBlock(value)) {
+        return {
+          ...value,
+          data: `[omitted base64 len=${value.data.length}]`,
+        };
+      }
+
+      if (value !== null && typeof value === "object") {
+        if (seen.has(value)) {
+          return "[circular]";
+        }
+        seen.add(value);
+      }
+
+      return value;
+    });
+  } catch {
+    return "[unserializable]";
+  }
+}

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -9,6 +9,7 @@ import { workspaceFileLocks } from "@/node/utils/concurrency/workspaceFileLocks"
 import { log } from "./log";
 import { getTokenizerForModel } from "@/node/utils/main/tokenizer";
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
+import { safeStringifyForCounting } from "@/common/utils/tokens/safeStringifyForCounting";
 import { normalizeLegacyMuxMetadata } from "@/node/utils/messages/legacy";
 
 /**
@@ -400,7 +401,7 @@ export class HistoryService {
         // We stringify the entire message for simplicity - only relative weights matter
         const messageTokens: Array<{ message: MuxMessage; tokens: number }> = await Promise.all(
           messages.map(async (msg) => {
-            const tokens = await tokenizer.countTokens(JSON.stringify(msg));
+            const tokens = await tokenizer.countTokens(safeStringifyForCounting(msg));
             return { message: msg, tokens };
           })
         );

--- a/src/node/utils/main/tokenizer.ts
+++ b/src/node/utils/main/tokenizer.ts
@@ -8,6 +8,7 @@ import { run } from "./workerPool";
 import { TOKENIZER_MODEL_OVERRIDES, DEFAULT_WARM_MODELS } from "@/common/constants/knownModels";
 import { normalizeGatewayModel } from "@/common/utils/ai/models";
 import { log } from "@/node/services/log";
+import { safeStringifyForCounting } from "@/common/utils/tokens/safeStringifyForCounting";
 
 /**
  * Public tokenizer interface exposed to callers.
@@ -218,7 +219,7 @@ export function countTokensBatch(modelString: string, texts: string[]): Promise<
 }
 
 export function countTokensForData(data: unknown, tokenizer: Tokenizer): Promise<number> {
-  const serialized = JSON.stringify(data);
+  const serialized = safeStringifyForCounting(data);
   return tokenizer.countTokens(serialized);
 }
 


### PR DESCRIPTION
Fixes local token-estimation skew where tool outputs (e.g. MCP screenshot results) are counted via `JSON.stringify(...)`, making base64 blobs look like hundreds of thousands of tokens.

- Add `safeStringifyForCounting()` to redact AI SDK `{ type: "media" }` parts and base64 data URLs before counting.
- Use it in `countTokensForData()` (Tokenizer tab / consumer breakdown) and `HistoryService.truncateHistory()` weighting.
- Add unit tests to prevent regressions.

Validation:
- `make static-check`

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$0.52`_
