### PR TITLE
🤖 fix: add Zed Remote SSH deep links

### DIFF
--- a/src/browser/utils/editorDeepLinks.test.ts
+++ b/src/browser/utils/editorDeepLinks.test.ts
@@ -66,13 +66,22 @@ describe("getEditorDeepLink", () => {
       expect(url).toBe("cursor://vscode-remote/ssh-remote+devbox/home/user/project/file.ts");
     });
 
-    test("returns null for zed with SSH host (unsupported)", () => {
+    test("generates zed://ssh URL for SSH host", () => {
       const url = getEditorDeepLink({
         editor: "zed",
         path: "/home/user/project/file.ts",
         sshHost: "devbox",
       });
-      expect(url).toBeNull();
+      expect(url).toBe("zed://ssh/devbox/home/user/project/file.ts");
+    });
+
+    test("includes port in zed://ssh URL when provided in sshHost", () => {
+      const url = getEditorDeepLink({
+        editor: "zed",
+        path: "/home/user/project/file.ts",
+        sshHost: "devbox:2222",
+      });
+      expect(url).toBe("zed://ssh/devbox:2222/home/user/project/file.ts");
     });
 
     test("encodes SSH host with special characters", () => {

--- a/src/browser/utils/editorDeepLinks.ts
+++ b/src/browser/utils/editorDeepLinks.ts
@@ -19,21 +19,28 @@ export interface DeepLinkOptions {
 /**
  * Generate an editor deep link URL.
  *
- * @returns Deep link URL, or null if the editor doesn't support the requested config
- *          (e.g., Zed doesn't support SSH remote)
+ * @returns Deep link URL, or null if the editor doesn't support the requested config.
  */
 export function getEditorDeepLink(options: DeepLinkOptions): string | null {
   const { editor, path, sshHost, line, column } = options;
 
-  // Zed doesn't support Remote-SSH
-  if (sshHost && editor === "zed") {
-    return null;
-  }
-
   const scheme = editor; // vscode, cursor, zed all use their name as scheme
 
   if (sshHost) {
-    // Remote-SSH format: vscode://vscode-remote/ssh-remote+host/path
+    // Zed remote-SSH deep links use a different format than VS Code/Cursor.
+    // https://zed.dev/docs/remote-development
+    if (editor === "zed") {
+      let url = `${scheme}://ssh/${sshHost}${path}`;
+      if (line != null) {
+        url += `:${line}`;
+        if (column != null) {
+          url += `:${column}`;
+        }
+      }
+      return url;
+    }
+
+    // VS Code/Cursor Remote-SSH format: vscode://vscode-remote/ssh-remote+host/path
     let url = `${scheme}://vscode-remote/ssh-remote+${encodeURIComponent(sshHost)}${path}`;
     if (line != null) {
       url += `:${line}`;

--- a/src/browser/utils/openInEditor.ts
+++ b/src/browser/utils/openInEditor.ts
@@ -41,15 +41,12 @@ export async function openInEditor(args: {
     return { success: false, error: "Please configure a custom editor command in Settings" };
   }
 
-  // For SSH workspaces, validate the editor supports Remote-SSH (only VS Code/Cursor)
+  // For SSH workspaces, validate the editor supports SSH connections
   if (isSSH) {
-    if (editorConfig.editor === "zed") {
-      return { success: false, error: "Zed does not support Remote-SSH for SSH workspaces" };
-    }
     if (editorConfig.editor === "custom") {
       return {
         success: false,
-        error: "Custom editors do not support Remote-SSH for SSH workspaces",
+        error: "Custom editors do not support SSH connections for SSH workspaces",
       };
     }
   }
@@ -101,7 +98,7 @@ export async function openInEditor(args: {
     if (editorConfig.editor === "custom") {
       return {
         success: false,
-        error: "Custom editors are not supported in browser mode. Use VS Code or Cursor.",
+        error: "Custom editors are not supported in browser mode. Use VS Code, Cursor, or Zed.",
       };
     }
 
@@ -110,6 +107,9 @@ export async function openInEditor(args: {
     if (isSSH && args.runtimeConfig?.type === "ssh") {
       // SSH workspace: use the configured SSH host
       sshHost = args.runtimeConfig.host;
+      if (editorConfig.editor === "zed" && args.runtimeConfig.port != null) {
+        sshHost = sshHost + ":" + args.runtimeConfig.port;
+      }
     } else if (!isLocalhost(window.location.hostname)) {
       // Remote server + local workspace: need SSH to reach server's files
       const serverSshHost = await args.api?.server.getSshHost();

--- a/src/browser/utils/openInEditorDeepLinkFallback.test.ts
+++ b/src/browser/utils/openInEditorDeepLinkFallback.test.ts
@@ -44,7 +44,7 @@ describe("getEditorDeepLinkFallbackUrl", () => {
     expect(url).toBe("cursor://vscode-remote/ssh-remote+devbox/home/user/project/file.ts");
   });
 
-  test("returns null for zed + SSH runtime (unsupported)", () => {
+  test("returns zed://ssh URL for SSH runtime", () => {
     const runtimeConfig: RuntimeConfig = {
       type: "ssh",
       host: "devbox",
@@ -58,7 +58,25 @@ describe("getEditorDeepLinkFallbackUrl", () => {
       error: "Editor command not found: zed",
     });
 
-    expect(url).toBeNull();
+    expect(url).toBe("zed://ssh/devbox/home/user/project/file.ts");
+  });
+
+  test("includes port in zed://ssh URL for SSH runtime when provided", () => {
+    const runtimeConfig: RuntimeConfig = {
+      type: "ssh",
+      host: "devbox",
+      port: 2222,
+      srcBaseDir: "~/mux",
+    };
+
+    const url = getEditorDeepLinkFallbackUrl({
+      editor: "zed",
+      targetPath: "/home/user/project/file.ts",
+      runtimeConfig,
+      error: "Editor command not found: zed",
+    });
+
+    expect(url).toBe("zed://ssh/devbox:2222/home/user/project/file.ts");
   });
 
   test("returns null when error is not command-not-found", () => {

--- a/src/browser/utils/openInEditorDeepLinkFallback.ts
+++ b/src/browser/utils/openInEditorDeepLinkFallback.ts
@@ -29,7 +29,13 @@ export function getEditorDeepLinkFallbackUrl(args: {
 
   if (!deepLinkEditor) return null;
 
-  const sshHost = isSSHRuntime(args.runtimeConfig) ? args.runtimeConfig.host : undefined;
+  let sshHost: string | undefined;
+  if (isSSHRuntime(args.runtimeConfig)) {
+    sshHost = args.runtimeConfig.host;
+    if (deepLinkEditor === "zed" && args.runtimeConfig.port != null) {
+      sshHost = sshHost + ":" + args.runtimeConfig.port;
+    }
+  }
 
   return getEditorDeepLink({
     editor: deepLinkEditor,


### PR DESCRIPTION
## What changed
- Enable Zed for SSH workspaces in browser mode by generating `zed://ssh/<host[:port]>/<path>` deep links.
- Ensure Zed deep-link fallback includes `host:port` for non-22 SSH ports.
- In Electron mode, open SSH targets in Zed via `zed 'ssh://<host[:port]><path>'`.

## Testing
- `bun test src/browser/utils/editorDeepLinks.test.ts src/browser/utils/openInEditorDeepLinkFallback.test.ts`
- `make static-check`

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$3.56`_
