### PR TITLE
🤖 fix: spawn local PTY terminals on Windows

### DIFF
--- a/src/node/utils/main/resolveLocalPtyShell.test.ts
+++ b/src/node/utils/main/resolveLocalPtyShell.test.ts
@@ -1,0 +1,80 @@
+import { resolveLocalPtyShell } from "./resolveLocalPtyShell";
+
+describe("resolveLocalPtyShell", () => {
+  it("uses SHELL when it is set and non-empty", () => {
+    const result = resolveLocalPtyShell({
+      platform: "linux",
+      env: { SHELL: "  /usr/bin/fish  " },
+      isCommandAvailable: () => {
+        throw new Error("isCommandAvailable should not be called");
+      },
+      getBashPath: () => {
+        throw new Error("getBashPath should not be called");
+      },
+    });
+
+    expect(result).toEqual({ command: "/usr/bin/fish", args: [] });
+  });
+
+  it("on Windows, treats empty SHELL as unset and prefers Git Bash", () => {
+    const result = resolveLocalPtyShell({
+      platform: "win32",
+      env: { SHELL: "" },
+      isCommandAvailable: () => false,
+      getBashPath: () => "C:\\Program Files\\Git\\bin\\bash.exe",
+    });
+
+    expect(result).toEqual({
+      command: "C:\\Program Files\\Git\\bin\\bash.exe",
+      args: ["--login", "-i"],
+    });
+  });
+
+  it("on Windows, falls back to pwsh when Git Bash is unavailable", () => {
+    const result = resolveLocalPtyShell({
+      platform: "win32",
+      env: { SHELL: "" },
+      isCommandAvailable: (command) => command === "pwsh",
+      getBashPath: () => {
+        throw new Error("Git Bash not installed");
+      },
+    });
+
+    expect(result).toEqual({ command: "pwsh", args: [] });
+  });
+
+  it("on Windows, falls back to COMSPEC/cmd.exe when no other shells are available", () => {
+    const result = resolveLocalPtyShell({
+      platform: "win32",
+      env: { SHELL: "   ", COMSPEC: "C:\\Windows\\System32\\cmd.exe" },
+      isCommandAvailable: () => false,
+      getBashPath: () => {
+        throw new Error("Git Bash not installed");
+      },
+    });
+
+    expect(result).toEqual({ command: "C:\\Windows\\System32\\cmd.exe", args: [] });
+  });
+
+  it("on Linux, falls back to /bin/bash when SHELL is unset", () => {
+    const result = resolveLocalPtyShell({
+      platform: "linux",
+      env: {},
+      isCommandAvailable: () => false,
+      getBashPath: () => "bash",
+    });
+
+    expect(result).toEqual({ command: "/bin/bash", args: [] });
+  });
+
+  it("on macOS, falls back to /bin/zsh when SHELL is unset", () => {
+    const result = resolveLocalPtyShell({
+      platform: "darwin",
+      env: {},
+      isCommandAvailable: () => false,
+      getBashPath: () => "bash",
+    });
+
+    expect(result).toEqual({ command: "/bin/zsh", args: [] });
+  });
+});

--- a/src/node/utils/main/resolveLocalPtyShell.ts
+++ b/src/node/utils/main/resolveLocalPtyShell.ts
@@ -1,0 +1,81 @@
+import { spawnSync } from "child_process";
+
+import { getBashPath } from "@/node/utils/main/bashPath";
+
+export interface ResolvedPtyShell {
+  command: string;
+  args: string[];
+}
+
+export interface ResolveLocalPtyShellParams {
+  platform: NodeJS.Platform;
+  env: NodeJS.ProcessEnv;
+  isCommandAvailable: (command: string) => boolean;
+  getBashPath: () => string;
+}
+
+function defaultIsCommandAvailable(platform: NodeJS.Platform): (command: string) => boolean {
+  return (command: string) => {
+    if (!command) return false;
+
+    try {
+      const result = spawnSync(platform === "win32" ? "where" : "which", [command], {
+        stdio: "ignore",
+      });
+      return result.status === 0;
+    } catch {
+      return false;
+    }
+  };
+}
+
+/**
+ * Resolve the best shell to use for a *local* PTY session.
+ *
+ * We keep this as a small, mostly-pure helper so it can be unit-tested without
+ * mutating `process.platform` / `process.env`.
+ */
+export function resolveLocalPtyShell(
+  params: Partial<ResolveLocalPtyShellParams> = {}
+): ResolvedPtyShell {
+  const platform = params.platform ?? process.platform;
+  const env = params.env ?? process.env;
+  const isCommandAvailable = params.isCommandAvailable ?? defaultIsCommandAvailable(platform);
+  const getBashPathFn = params.getBashPath ?? getBashPath;
+
+  // `process.env.SHELL` can be present-but-empty (""), especially in packaged apps.
+  // Treat empty/whitespace as "unset".
+  const envShell = env.SHELL?.trim();
+  if (envShell) {
+    return { command: envShell, args: [] };
+  }
+
+  if (platform === "win32") {
+    // Prefer Git Bash when available (works well with repo tooling).
+    try {
+      const bashPath = getBashPathFn().trim();
+      if (bashPath) {
+        return { command: bashPath, args: ["--login", "-i"] };
+      }
+    } catch {
+      // Git Bash not available; fall back to PowerShell / cmd.
+    }
+
+    if (isCommandAvailable("pwsh")) {
+      return { command: "pwsh", args: [] };
+    }
+
+    if (isCommandAvailable("powershell")) {
+      return { command: "powershell", args: [] };
+    }
+
+    const comspec = env.COMSPEC?.trim();
+    return { command: comspec && comspec.length > 0 ? comspec : "cmd.exe", args: [] };
+  }
+
+  if (platform === "darwin") {
+    return { command: "/bin/zsh", args: [] };
+  }
+
+  return { command: "/bin/bash", args: [] };
+}


### PR DESCRIPTION
This fixes embedded terminal creation on Windows failing with:

- `Failed to spawn Local terminal: File not found:`

Root cause was `PTYService` using `process.env.SHELL ?? "/bin/bash"` for *local* PTY sessions. On Windows this can be unset, invalid, or even present-but-empty (`SHELL=""`), which results in node-pty attempting to spawn an empty executable.

### What changed
- Added `resolveLocalPtyShell()` to pick a sane default shell per platform.
  - Windows: prefer Git Bash (if available), else `pwsh` → `powershell` → `COMSPEC`/`cmd.exe`
  - Non-Windows: prefer non-empty `SHELL`, else `/bin/zsh` (macOS) or `/bin/bash`
- `PTYService` local sessions now use the resolver and include args (e.g. `--login -i` for Git Bash).
- Improved PTY spawn failures to include the attempted command/args/cwd/platform (and preserve the original error as `cause`).

### Validation
- `bun test src/node/utils/main/resolveLocalPtyShell.test.ts`
- `make static-check`

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$2.00`_
