### PR TITLE
🤖 feat: add first-class link support with PR status badges

### DIFF
--- a/src/browser/components/AppLoader.tsx
+++ b/src/browser/components/AppLoader.tsx
@@ -4,6 +4,7 @@ import { AuthTokenModal } from "./AuthTokenModal";
 import { LoadingScreen } from "./LoadingScreen";
 import { useWorkspaceStoreRaw, workspaceStore } from "../stores/WorkspaceStore";
 import { useGitStatusStoreRaw } from "../stores/GitStatusStore";
+import { getPRStatusStoreInstance } from "../stores/PRStatusStore";
 import { ProjectProvider, useProjectContext } from "../contexts/ProjectContext";
 import { APIProvider, useAPI, type APIClient } from "@/browser/contexts/API";
 import { WorkspaceProvider, useWorkspaceContext } from "../contexts/WorkspaceContext";
@@ -64,6 +65,7 @@ function AppLoaderInner() {
     if (api) {
       workspaceStoreInstance.setClient(api);
       gitStatusStore.setClient(api);
+      getPRStatusStoreInstance().setClient(api);
     }
 
     if (!workspaceContext.loading) {

--- a/src/browser/components/LinksDropdown.tsx
+++ b/src/browser/components/LinksDropdown.tsx
@@ -1,0 +1,123 @@
+/**
+ * Dropdown component for displaying detected links from chat.
+ */
+
+import { useState } from "react";
+import { Link, ExternalLink, ChevronDown, Copy, Check } from "lucide-react";
+import type { GenericLink } from "@/common/types/links";
+import { useCopyToClipboard } from "@/browser/hooks/useCopyToClipboard";
+import { formatRelativeTime } from "@/browser/utils/ui/dateTime";
+import { Tooltip, TooltipTrigger, TooltipContent } from "./ui/tooltip";
+import { Button } from "./ui/button";
+import { Popover, PopoverTrigger, PopoverContent } from "./ui/popover";
+
+interface LinksDropdownProps {
+  /** Generic (non-PR) links */
+  links: GenericLink[];
+}
+
+/**
+ * Truncate URL for display
+ */
+function truncateUrl(url: string, maxLength = 60): string {
+  // Remove protocol
+  const withoutProtocol = url.replace(/^https?:\/\//, "");
+
+  if (withoutProtocol.length <= maxLength) {
+    return withoutProtocol;
+  }
+
+  return withoutProtocol.slice(0, maxLength - 3) + "...";
+}
+
+/**
+ * Single link row with copy functionality
+ */
+function LinkRow({ link, onNavigate }: { link: GenericLink; onNavigate: () => void }) {
+  const { copied, copyToClipboard } = useCopyToClipboard();
+
+  const handleCopy = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    void copyToClipboard(link.url);
+  };
+
+  const tooltipContent = (
+    <div className="flex flex-col gap-1">
+      <div className="break-all">{link.url}</div>
+      <div className="text-muted-foreground text-xs">
+        Seen {link.occurrenceCount} time{link.occurrenceCount !== 1 ? "s" : ""} · Last seen{" "}
+        {formatRelativeTime(link.detectedAt)}
+      </div>
+    </div>
+  );
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className="hover:bg-accent group flex items-center gap-2 rounded px-2 py-1.5">
+          <a
+            href={link.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex min-w-0 flex-1 items-center gap-2"
+            onClick={onNavigate}
+          >
+            <ExternalLink className="h-3 w-3 shrink-0 opacity-50" />
+            <span className="min-w-0 truncate text-xs">{link.title ?? truncateUrl(link.url)}</span>
+          </a>
+          <button
+            onClick={handleCopy}
+            className="text-muted hover:text-foreground shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
+            title="Copy link"
+          >
+            {copied ? <Check className="text-success h-3 w-3" /> : <Copy className="h-3 w-3" />}
+          </button>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent side="left" className="max-w-md">
+        {tooltipContent}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function LinksDropdown({ links }: LinksDropdownProps) {
+  const [open, setOpen] = useState(false);
+
+  if (links.length === 0) {
+    return null;
+  }
+
+  // Sort links: most recently seen first
+  const sortedLinks = [...links].sort((a, b) => b.detectedAt - a.detectedAt);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-muted hover:text-foreground h-6 gap-1 px-2"
+            >
+              <Link className="h-3 w-3" />
+              <span className="text-xs">{links.length}</span>
+              <ChevronDown className="h-3 w-3" />
+            </Button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Links found in chat</TooltipContent>
+      </Tooltip>
+
+      <PopoverContent align="end" className="w-96 p-1">
+        <div className="flex max-h-80 flex-col gap-0.5 overflow-y-auto">
+          {sortedLinks.map((link) => (
+            <LinkRow key={link.url} link={link} onNavigate={() => setOpen(false)} />
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/browser/components/PRLinkBadge.tsx
+++ b/src/browser/components/PRLinkBadge.tsx
@@ -1,0 +1,177 @@
+/**
+ * PR link badge component for displaying GitHub PR status in header.
+ */
+
+import {
+  ExternalLink,
+  GitPullRequest,
+  Loader2,
+  Check,
+  X,
+  AlertCircle,
+  CircleDot,
+} from "lucide-react";
+import type { GitHubPRLinkWithStatus } from "@/common/types/links";
+import { Tooltip, TooltipTrigger, TooltipContent } from "./ui/tooltip";
+import { Button } from "./ui/button";
+import { cn } from "@/common/lib/utils";
+
+interface PRLinkBadgeProps {
+  prLink: GitHubPRLinkWithStatus;
+  onRefresh?: () => void;
+}
+
+/**
+ * Get status color class based on PR merge state
+ */
+function getStatusColorClass(prLink: GitHubPRLinkWithStatus): string {
+  if (prLink.loading) return "text-muted";
+  if (prLink.error) return "text-danger-soft";
+  if (!prLink.status) return "text-muted";
+
+  const { state, mergeable, mergeStateStatus, isDraft, hasFailedChecks, hasPendingChecks } =
+    prLink.status;
+
+  if (state === "MERGED") return "text-purple-500";
+  if (state === "CLOSED") return "text-danger-soft";
+  if (isDraft || mergeStateStatus === "DRAFT") return "text-muted";
+
+  if (mergeable === "CONFLICTING" || mergeStateStatus === "DIRTY") return "text-danger-soft";
+
+  if (mergeStateStatus === "CLEAN") return "text-success";
+  if (mergeStateStatus === "BEHIND") return "text-warning";
+
+  // Prefer check rollup when available; fall back to mergeStateStatus.
+  if (hasFailedChecks || mergeStateStatus === "UNSTABLE") return "text-danger-soft";
+  if (hasPendingChecks) return "text-warning";
+
+  if (mergeStateStatus === "BLOCKED" || mergeStateStatus === "HAS_HOOKS") {
+    return "text-warning";
+  }
+
+  return "text-muted";
+}
+
+/**
+ * Get status icon based on PR state
+ */
+function StatusIcon({ prLink }: { prLink: GitHubPRLinkWithStatus }) {
+  if (prLink.loading) {
+    return <Loader2 className="h-3 w-3 animate-spin" />;
+  }
+  if (prLink.error) {
+    return <AlertCircle className="h-3 w-3" />;
+  }
+  if (!prLink.status) {
+    return <GitPullRequest className="h-3 w-3" />;
+  }
+
+  const { state, mergeable, mergeStateStatus, isDraft, hasFailedChecks, hasPendingChecks } =
+    prLink.status;
+
+  if (state === "MERGED") {
+    return <Check className="h-3 w-3" />;
+  }
+  if (state === "CLOSED") {
+    return <X className="h-3 w-3" />;
+  }
+
+  if (isDraft || mergeStateStatus === "DRAFT") {
+    return <GitPullRequest className="h-3 w-3" />;
+  }
+
+  if (mergeable === "CONFLICTING" || mergeStateStatus === "DIRTY") {
+    return <X className="h-3 w-3" />;
+  }
+
+  if (mergeStateStatus === "CLEAN") {
+    return <Check className="h-3 w-3" />;
+  }
+
+  // Prefer check rollup when available; fall back to mergeStateStatus.
+  if (hasFailedChecks || mergeStateStatus === "UNSTABLE") {
+    return <X className="h-3 w-3" />;
+  }
+  if (hasPendingChecks || mergeStateStatus === "BLOCKED") {
+    return <CircleDot className="h-3 w-3" />;
+  }
+
+  return <GitPullRequest className="h-3 w-3" />;
+}
+
+/**
+ * Format PR tooltip content
+ */
+function getTooltipContent(prLink: GitHubPRLinkWithStatus): string {
+  if (prLink.loading) return "Loading PR status...";
+  if (prLink.error) return `Error: ${prLink.error}`;
+  if (!prLink.status) return `PR #${prLink.number}`;
+
+  const {
+    title,
+    state,
+    mergeable,
+    mergeStateStatus,
+    isDraft,
+    hasFailedChecks,
+    hasPendingChecks,
+    headRefName,
+    baseRefName,
+  } = prLink.status;
+
+  const lines = [title || `PR #${prLink.number}`];
+
+  if (isDraft) {
+    lines.push("Draft PR");
+  } else if (state === "MERGED") {
+    lines.push("Merged");
+  } else if (state === "CLOSED") {
+    lines.push("Closed");
+  } else {
+    if (mergeable === "CONFLICTING" || mergeStateStatus === "DIRTY") {
+      lines.push("Has merge conflicts");
+    } else if (mergeStateStatus === "BEHIND") {
+      lines.push("Behind base branch");
+    } else if (mergeStateStatus === "CLEAN") {
+      lines.push("Ready to merge");
+    } else if (hasFailedChecks || mergeStateStatus === "UNSTABLE") {
+      lines.push("Checks failing");
+    } else if (hasPendingChecks) {
+      lines.push("Checks pending");
+    } else if (mergeStateStatus === "BLOCKED" || mergeStateStatus === "HAS_HOOKS") {
+      lines.push("Merge blocked");
+    } else {
+      lines.push("Open");
+    }
+  }
+
+  lines.push(`${headRefName} → ${baseRefName}`);
+
+  return lines.join("\n");
+}
+
+export function PRLinkBadge({ prLink }: PRLinkBadgeProps) {
+  const colorClass = getStatusColorClass(prLink);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className={cn("h-6 gap-1 px-2 text-xs font-medium", colorClass)}
+          asChild
+        >
+          <a href={prLink.url} target="_blank" rel="noopener noreferrer">
+            <StatusIcon prLink={prLink} />
+            <span>#{prLink.number}</span>
+            <ExternalLink className="h-3 w-3 opacity-50" />
+          </a>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent align="center" className="whitespace-pre-line">
+        {getTooltipContent(prLink)}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/browser/components/WorkspaceHeader.tsx
+++ b/src/browser/components/WorkspaceHeader.tsx
@@ -15,6 +15,7 @@ import { useTutorial } from "@/browser/contexts/TutorialContext";
 import { useOpenTerminal } from "@/browser/hooks/useOpenTerminal";
 import { useOpenInEditor } from "@/browser/hooks/useOpenInEditor";
 import { isDesktopMode } from "@/browser/hooks/useDesktopTitlebar";
+import { WorkspaceLinks } from "./WorkspaceLinks";
 
 interface WorkspaceHeaderProps {
   workspaceId: string;
@@ -112,8 +113,9 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
           />
         </div>
       </div>
-      <div className={cn("flex items-center", isDesktop && "titlebar-no-drag")}>
-        {editorError && <span className="text-danger-soft mr-2 text-xs">{editorError}</span>}
+      <div className={cn("flex items-center gap-2", isDesktop && "titlebar-no-drag")}>
+        <WorkspaceLinks workspaceId={workspaceId} />
+        {editorError && <span className="text-danger-soft text-xs">{editorError}</span>}
         <Tooltip>
           <TooltipTrigger asChild>
             <Button

--- a/src/browser/components/WorkspaceLinks.tsx
+++ b/src/browser/components/WorkspaceLinks.tsx
@@ -1,0 +1,42 @@
+/**
+ * Component to display detected links in the workspace header.
+ * Shows:
+ * - PR badge: from branch-based detection (via `gh pr view`)
+ * - Links dropdown: from chat-extracted links
+ */
+
+import { useWorkspaceLinks } from "@/browser/stores/WorkspaceStore";
+import { useWorkspacePR } from "@/browser/stores/PRStatusStore";
+import type { GenericLink } from "@/common/types/links";
+import { PRLinkBadge } from "./PRLinkBadge";
+import { LinksDropdown } from "./LinksDropdown";
+
+interface WorkspaceLinksProps {
+  workspaceId: string;
+}
+
+export function WorkspaceLinks({ workspaceId }: WorkspaceLinksProps) {
+  // Get links extracted from chat (for dropdown)
+  const { detectedLinks } = useWorkspaceLinks(workspaceId);
+
+  // Get PR for this workspace's branch (not from chat)
+  const workspacePR = useWorkspacePR(workspaceId);
+
+  // Filter out generic links (non-PR) for dropdown
+  const genericLinks = detectedLinks.filter((link): link is GenericLink => link.type === "generic");
+
+  // Don't render anything if no PR and no links
+  if (!workspacePR && genericLinks.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      {/* Show the workspace's PR badge (from branch detection) */}
+      {workspacePR && <PRLinkBadge prLink={workspacePR} />}
+
+      {/* Generic links dropdown (from chat) */}
+      {genericLinks.length > 0 && <LinksDropdown links={genericLinks} />}
+    </div>
+  );
+}

--- a/src/browser/stores/PRStatusStore.ts
+++ b/src/browser/stores/PRStatusStore.ts
@@ -1,0 +1,413 @@
+/**
+ * Store for managing GitHub PR status information.
+ *
+ * Architecture:
+ * - Lives outside React lifecycle (stable references)
+ * - Detects workspace PR from current branch via `gh pr view`
+ * - Caches status with TTL
+ * - Refreshes on focus (like GitStatusStore)
+ * - Notifies subscribers when status changes
+ *
+ * PR detection:
+ * - Branch-based: Runs `gh pr view` without URL to detect PR for current branch
+ */
+
+import type { RouterClient } from "@orpc/server";
+import type { AppRouter } from "@/node/orpc/router";
+import type { GitHubPRLink, GitHubPRStatus, GitHubPRLinkWithStatus } from "@/common/types/links";
+/**
+ * Parse a GitHub PR URL to extract owner, repo, and number.
+ * Returns null if the URL is not a valid GitHub PR URL.
+ */
+function parseGitHubPRUrl(url: string): { owner: string; repo: string; number: number } | null {
+  const match = /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/.exec(url);
+  if (!match) return null;
+  return { owner: match[1], repo: match[2], number: parseInt(match[3], 10) };
+}
+import { MapStore } from "./MapStore";
+import { RefreshController } from "@/browser/utils/RefreshController";
+import { useSyncExternalStore } from "react";
+
+// Cache TTL: PR status is refreshed at most every 5 seconds
+const STATUS_CACHE_TTL_MS = 5 * 1000;
+
+// How long to wait before retrying after an error
+const ERROR_RETRY_DELAY_MS = 5 * 1000;
+
+function summarizeStatusCheckRollup(raw: unknown): {
+  hasPendingChecks: boolean;
+  hasFailedChecks: boolean;
+} {
+  if (!Array.isArray(raw)) {
+    return { hasPendingChecks: false, hasFailedChecks: false };
+  }
+
+  let hasPendingChecks = false;
+  let hasFailedChecks = false;
+
+  for (const item of raw) {
+    if (typeof item !== "object" || item === null) {
+      continue;
+    }
+
+    const record = item as Record<string, unknown>;
+    const status = record.status;
+    const conclusion = record.conclusion;
+
+    // Many check APIs represent "pending" as a non-COMPLETED status and/or a null conclusion.
+    if (typeof status === "string" && status !== "COMPLETED") {
+      hasPendingChecks = true;
+    }
+
+    if (conclusion == null) {
+      hasPendingChecks = true;
+      continue;
+    }
+
+    if (typeof conclusion === "string") {
+      // GitHub-style conclusions (StatusState is different from CheckConclusionState, but this is close enough)
+      const normalized = conclusion.toUpperCase();
+      if (
+        normalized === "FAILURE" ||
+        normalized === "CANCELLED" ||
+        normalized === "TIMED_OUT" ||
+        normalized === "ACTION_REQUIRED" ||
+        normalized === "STARTUP_FAILURE"
+      ) {
+        hasFailedChecks = true;
+      }
+    }
+  }
+
+  return { hasPendingChecks, hasFailedChecks };
+}
+
+/**
+ * Workspace PR detection result (from branch, not chat).
+ */
+interface WorkspacePRCacheEntry {
+  /** The detected PR link (null if no PR for this branch) */
+  prLink: GitHubPRLink | null;
+  /** PR status if available */
+  status?: GitHubPRStatus;
+  error?: string;
+  fetchedAt: number;
+  loading: boolean;
+}
+
+/**
+ * Store for GitHub PR status. Fetches status via gh CLI and caches results.
+ */
+export class PRStatusStore {
+  private client: RouterClient<AppRouter> | null = null;
+  private readonly refreshController: RefreshController;
+  private isActive = true;
+
+  // Workspace-based PR detection (keyed by workspaceId)
+  private workspacePRSubscriptions = new MapStore<string, WorkspacePRCacheEntry>();
+  private workspacePRCache = new Map<string, WorkspacePRCacheEntry>();
+
+  // Track active subscriptions per workspace so we only refresh workspaces that are actually visible.
+  private workspaceSubscriptionCounts = new Map<string, number>();
+
+  // Like GitStatusStore: batch immediate refreshes triggered by subscriptions.
+  private immediateUpdateQueued = false;
+
+  constructor() {
+    this.refreshController = new RefreshController({
+      onRefresh: () => this.refreshAll(),
+      debounceMs: 5000,
+      refreshOnFocus: true,
+      focusDebounceMs: 1000,
+    });
+  }
+
+  setClient(client: RouterClient<AppRouter>): void {
+    this.client = client;
+
+    // If hooks subscribed before the client was ready, ensure we refresh once it is.
+    if (this.workspaceSubscriptionCounts.size > 0) {
+      this.refreshController.requestImmediate();
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Workspace-based PR detection (primary mode)
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Subscribe to workspace PR changes (branch-based detection).
+   *
+   * Like GitStatusStore: subscriptions drive refresh. Components should not need to
+   * manually "monitor" workspaces.
+   */
+  subscribeWorkspace = (workspaceId: string, listener: () => void) => {
+    const unsubscribe = this.workspacePRSubscriptions.subscribeKey(workspaceId, listener);
+
+    // Track active subscriptions so focus refresh only runs for visible workspaces.
+    const current = this.workspaceSubscriptionCounts.get(workspaceId) ?? 0;
+    this.workspaceSubscriptionCounts.set(workspaceId, current + 1);
+
+    // Bind focus/visibility listeners once we have any subscribers.
+    this.refreshController.bindListeners();
+
+    // Kick an immediate refresh so the UI doesn't wait for the next focus event.
+    // Use a microtask to batch multiple subscribe calls in the same render.
+    if (!this.immediateUpdateQueued && this.isActive && this.client) {
+      this.immediateUpdateQueued = true;
+      queueMicrotask(() => {
+        this.immediateUpdateQueued = false;
+        this.refreshController.requestImmediate();
+      });
+    }
+
+    return () => {
+      unsubscribe();
+      const next = (this.workspaceSubscriptionCounts.get(workspaceId) ?? 1) - 1;
+      if (next <= 0) {
+        this.workspaceSubscriptionCounts.delete(workspaceId);
+      } else {
+        this.workspaceSubscriptionCounts.set(workspaceId, next);
+      }
+    };
+  };
+
+  /**
+   * Get workspace PR detection result.
+   */
+  getWorkspacePR(workspaceId: string): WorkspacePRCacheEntry | undefined {
+    return this.workspacePRCache.get(workspaceId);
+  }
+
+  /**
+   * Detect PR for workspace's current branch via `gh pr view`.
+   */
+  private async detectWorkspacePR(workspaceId: string): Promise<void> {
+    if (!this.client || !this.isActive) return;
+
+    // Mark as loading
+    const existing = this.workspacePRCache.get(workspaceId);
+    this.workspacePRCache.set(workspaceId, {
+      prLink: existing?.prLink ?? null,
+      status: existing?.status,
+      loading: true,
+      fetchedAt: Date.now(),
+    });
+    this.workspacePRSubscriptions.bump(workspaceId);
+
+    try {
+      // Run gh pr view without URL - detects PR for current branch
+      const result = await this.client.workspace.executeBash({
+        workspaceId,
+        script: `gh pr view --json number,url,state,mergeable,mergeStateStatus,title,isDraft,headRefName,baseRefName,statusCheckRollup 2>/dev/null || echo '{"no_pr":true}'`,
+        options: { timeout_secs: 15 },
+      });
+
+      if (!this.isActive) return;
+
+      if (!result.success || !result.data.success) {
+        this.workspacePRCache.set(workspaceId, {
+          prLink: null,
+          error: "Failed to run gh CLI",
+          loading: false,
+          fetchedAt: Date.now(),
+        });
+        this.workspacePRSubscriptions.bump(workspaceId);
+        return;
+      }
+
+      const output = result.data.output;
+      if (output) {
+        const parsed = JSON.parse(output) as Record<string, unknown>;
+
+        if ("no_pr" in parsed) {
+          // No PR for this branch
+          this.workspacePRCache.set(workspaceId, {
+            prLink: null,
+            loading: false,
+            fetchedAt: Date.now(),
+          });
+        } else {
+          // Parse PR link from URL
+          const prUrl = parsed.url as string;
+          const prLinkBase = parseGitHubPRUrl(prUrl);
+
+          if (!prLinkBase) {
+            this.workspacePRCache.set(workspaceId, {
+              prLink: null,
+              error: "Invalid PR URL from gh CLI",
+              loading: false,
+              fetchedAt: Date.now(),
+            });
+          } else {
+            const { hasPendingChecks, hasFailedChecks } = summarizeStatusCheckRollup(
+              parsed.statusCheckRollup
+            );
+
+            const status: GitHubPRStatus = {
+              state: (parsed.state as GitHubPRStatus["state"]) ?? "OPEN",
+              mergeable: (parsed.mergeable as GitHubPRStatus["mergeable"]) ?? "UNKNOWN",
+              mergeStateStatus:
+                (parsed.mergeStateStatus as GitHubPRStatus["mergeStateStatus"]) ?? "UNKNOWN",
+              title: (parsed.title as string) ?? "",
+              isDraft: (parsed.isDraft as boolean) ?? false,
+              headRefName: (parsed.headRefName as string) ?? "",
+              baseRefName: (parsed.baseRefName as string) ?? "",
+              hasPendingChecks,
+              hasFailedChecks,
+              fetchedAt: Date.now(),
+            };
+
+            const prLink: GitHubPRLink = {
+              type: "github-pr",
+              url: prUrl,
+              ...prLinkBase,
+              detectedAt: Date.now(),
+              occurrenceCount: 1,
+            };
+
+            this.workspacePRCache.set(workspaceId, {
+              prLink,
+              status,
+              loading: false,
+              fetchedAt: Date.now(),
+            });
+          }
+        }
+      } else {
+        this.workspacePRCache.set(workspaceId, {
+          prLink: null,
+          error: "Empty response from gh CLI",
+          loading: false,
+          fetchedAt: Date.now(),
+        });
+      }
+
+      this.workspacePRSubscriptions.bump(workspaceId);
+    } catch (err) {
+      if (!this.isActive) return;
+
+      this.workspacePRCache.set(workspaceId, {
+        prLink: null,
+        error: err instanceof Error ? err.message : "Unknown error",
+        loading: false,
+        fetchedAt: Date.now(),
+      });
+      this.workspacePRSubscriptions.bump(workspaceId);
+    }
+  }
+
+  private shouldFetchWorkspace(entry: WorkspacePRCacheEntry | undefined, now: number): boolean {
+    if (!entry) return true;
+    if (entry.loading) return false;
+
+    if (entry.error) {
+      return now - entry.fetchedAt > ERROR_RETRY_DELAY_MS;
+    }
+
+    return now - entry.fetchedAt > STATUS_CACHE_TTL_MS;
+  }
+
+  /**
+   * Refresh PR status for all subscribed workspaces.
+   * Called via RefreshController (focus + debounced refresh).
+   */
+  private async refreshAll(): Promise<void> {
+    if (!this.client || !this.isActive) return;
+
+    const workspaceIds = Array.from(this.workspaceSubscriptionCounts.keys());
+    if (workspaceIds.length === 0) {
+      return;
+    }
+
+    const now = Date.now();
+    const refreshes: Array<Promise<void>> = [];
+
+    for (const workspaceId of workspaceIds) {
+      const cached = this.workspacePRCache.get(workspaceId);
+      if (this.shouldFetchWorkspace(cached, now)) {
+        refreshes.push(this.detectWorkspacePR(workspaceId));
+      }
+    }
+
+    await Promise.all(refreshes);
+  }
+
+  /**
+   * Dispose the store.
+   */
+  dispose(): void {
+    this.isActive = false;
+    this.refreshController.dispose();
+  }
+}
+
+// Singleton instance
+let storeInstance: PRStatusStore | null = null;
+
+export function getPRStatusStoreInstance(): PRStatusStore {
+  storeInstance ??= new PRStatusStore();
+  return storeInstance;
+}
+
+export function setPRStatusStoreInstance(store: PRStatusStore): void {
+  storeInstance = store;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// React hooks
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Cache for useWorkspacePR hook to return stable references
+const workspacePRHookCache = new Map<string, GitHubPRLinkWithStatus | null>();
+
+/**
+ * Hook to get PR for a workspace (branch-based detection).
+ * Returns the detected PR with status, or null if no PR for this branch.
+ */
+export function useWorkspacePR(workspaceId: string): GitHubPRLinkWithStatus | null {
+  const store = getPRStatusStoreInstance();
+
+  return useSyncExternalStore(
+    (listener) => store.subscribeWorkspace(workspaceId, listener),
+    () => {
+      const cached = store.getWorkspacePR(workspaceId);
+      const existing = workspacePRHookCache.get(workspaceId);
+
+      // No data yet
+      if (!cached) {
+        if (existing === null) return existing;
+        workspacePRHookCache.set(workspaceId, null);
+        return null;
+      }
+
+      // No PR for this branch
+      if (!cached.prLink) {
+        if (existing === null) return existing;
+        workspacePRHookCache.set(workspaceId, null);
+        return null;
+      }
+
+      // Return same reference if nothing meaningful changed
+      if (
+        existing &&
+        existing.url === cached.prLink.url &&
+        existing.status === cached.status &&
+        existing.loading === cached.loading &&
+        existing.error === cached.error
+      ) {
+        return existing;
+      }
+
+      // Build new object and cache it
+      const newResult: GitHubPRLinkWithStatus = {
+        ...cached.prLink,
+        status: cached.status,
+        loading: cached.loading,
+        error: cached.error,
+      };
+      workspacePRHookCache.set(workspaceId, newResult);
+      return newResult;
+    }
+  );
+}

--- a/src/browser/stories/App.links.stories.tsx
+++ b/src/browser/stories/App.links.stories.tsx
@@ -1,0 +1,409 @@
+/**
+ * PR link badge and links dropdown stories
+ *
+ * Shows various PR status states in the workspace header.
+ */
+
+import { appMeta, AppWithMocks, type AppStory } from "./meta.js";
+import {
+  NOW,
+  STABLE_TIMESTAMP,
+  createWorkspace,
+  createUserMessage,
+  createAssistantMessage,
+  createStaticChatHandler,
+  groupWorkspacesByProject,
+} from "./mockFactory";
+import { createOnChatAdapter, selectWorkspace as selectWorkspaceHelper } from "./storyHelpers";
+import { createMockORPCClient } from "@/browser/stories/mocks/orpc";
+
+export default {
+  ...appMeta,
+  title: "App/Links",
+};
+
+/**
+ * PR status fixture for mocking gh pr view output
+ */
+interface PRStatusFixture {
+  number: number;
+  url: string;
+  state: "OPEN" | "CLOSED" | "MERGED";
+  mergeable: "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
+  mergeStateStatus:
+    | "CLEAN"
+    | "BLOCKED"
+    | "BEHIND"
+    | "DIRTY"
+    | "UNSTABLE"
+    | "HAS_HOOKS"
+    | "DRAFT"
+    | "UNKNOWN";
+  title: string;
+  isDraft: boolean;
+  headRefName: string;
+  baseRefName: string;
+  statusCheckRollup?: Array<{ status?: string; conclusion?: string | null }>;
+}
+
+/**
+ * Creates an executeBash function that returns PR status for gh pr view commands.
+ */
+function createPRStatusExecutor(prStatuses: Map<string, PRStatusFixture | "no_pr" | "error">) {
+  return (workspaceId: string, script: string) => {
+    // Handle gh pr view commands
+    if (script.includes("gh pr view")) {
+      const status = prStatuses.get(workspaceId);
+
+      if (!status || status === "error") {
+        return Promise.resolve({
+          success: true as const,
+          output: '{"no_pr":true}',
+          exitCode: 0,
+          wall_duration_ms: 50,
+        });
+      }
+
+      if (status === "no_pr") {
+        return Promise.resolve({
+          success: true as const,
+          output: '{"no_pr":true}',
+          exitCode: 0,
+          wall_duration_ms: 50,
+        });
+      }
+
+      return Promise.resolve({
+        success: true as const,
+        output: JSON.stringify(status),
+        exitCode: 0,
+        wall_duration_ms: 50,
+      });
+    }
+
+    // Default: return empty success
+    return Promise.resolve({
+      success: true as const,
+      output: "",
+      exitCode: 0,
+      wall_duration_ms: 50,
+    });
+  };
+}
+
+/**
+ * Shows all PR status badge variants:
+ * - Ready to merge (green checkmark)
+ * - Checks pending (yellow)
+ * - Checks failing (red)
+ * - Behind base branch (yellow)
+ * - Draft PR (muted)
+ * - Merged (purple)
+ * - Closed (red)
+ * - No PR for branch
+ */
+export const PRStatusBadges: AppStory = {
+  render: () => (
+    <AppWithMocks
+      setup={() => {
+        const workspaces = [
+          // Ready to merge
+          createWorkspace({
+            id: "ws-ready",
+            name: "feature/ready-to-merge",
+            projectName: "my-app",
+            createdAt: new Date(NOW - 3600000).toISOString(),
+          }),
+          // Checks pending
+          createWorkspace({
+            id: "ws-blocked",
+            name: "feature/checks-pending",
+            projectName: "my-app",
+            createdAt: new Date(NOW - 7200000).toISOString(),
+          }),
+          // Checks failing
+          createWorkspace({
+            id: "ws-failed-checks",
+            name: "feature/checks-failing",
+            projectName: "my-app",
+            createdAt: new Date(NOW - 9000000).toISOString(),
+          }),
+          // Behind base branch
+          createWorkspace({
+            id: "ws-behind",
+            name: "feature/needs-rebase",
+            projectName: "my-app",
+            createdAt: new Date(NOW - 10800000).toISOString(),
+          }),
+          // Has conflicts
+          createWorkspace({
+            id: "ws-conflicts",
+            name: "feature/has-conflicts",
+            projectName: "my-app",
+            createdAt: new Date(NOW - 14400000).toISOString(),
+          }),
+          // Draft PR
+          createWorkspace({
+            id: "ws-draft",
+            name: "feature/work-in-progress",
+            projectName: "my-app",
+            createdAt: new Date(NOW - 18000000).toISOString(),
+          }),
+          // Merged
+          createWorkspace({
+            id: "ws-merged",
+            name: "feature/already-merged",
+            projectName: "my-app",
+            createdAt: new Date(NOW - 21600000).toISOString(),
+          }),
+          // Closed
+          createWorkspace({
+            id: "ws-closed",
+            name: "feature/abandoned",
+            projectName: "my-app",
+            createdAt: new Date(NOW - 25200000).toISOString(),
+          }),
+          // No PR
+          createWorkspace({
+            id: "ws-no-pr",
+            name: "main",
+            projectName: "my-app",
+            createdAt: new Date(NOW - 28800000).toISOString(),
+          }),
+        ];
+
+        const prStatuses = new Map<string, PRStatusFixture | "no_pr">([
+          [
+            "ws-ready",
+            {
+              number: 1623,
+              url: "https://github.com/coder/mux/pull/1623",
+              state: "OPEN",
+              mergeable: "MERGEABLE",
+              mergeStateStatus: "CLEAN",
+              title: "feat: add first-class link support",
+              isDraft: false,
+              headRefName: "feature/ready-to-merge",
+              baseRefName: "main",
+            },
+          ],
+          [
+            "ws-blocked",
+            {
+              number: 1624,
+              url: "https://github.com/coder/mux/pull/1624",
+              state: "OPEN",
+              mergeable: "MERGEABLE",
+              mergeStateStatus: "BLOCKED",
+              title: "fix: resolve flaky test",
+              isDraft: false,
+              headRefName: "feature/checks-pending",
+              baseRefName: "main",
+              statusCheckRollup: [{ status: "IN_PROGRESS", conclusion: null }],
+            },
+          ],
+          [
+            "ws-failed-checks",
+            {
+              number: 1628,
+              url: "https://github.com/coder/mux/pull/1628",
+              state: "OPEN",
+              mergeable: "MERGEABLE",
+              mergeStateStatus: "BLOCKED",
+              title: "fix: failing checks",
+              isDraft: false,
+              headRefName: "feature/checks-failing",
+              baseRefName: "main",
+              statusCheckRollup: [{ status: "COMPLETED", conclusion: "FAILURE" }],
+            },
+          ],
+          [
+            "ws-behind",
+            {
+              number: 1625,
+              url: "https://github.com/coder/mux/pull/1625",
+              state: "OPEN",
+              mergeable: "MERGEABLE",
+              mergeStateStatus: "BEHIND",
+              title: "docs: update README",
+              isDraft: false,
+              headRefName: "feature/needs-rebase",
+              baseRefName: "main",
+            },
+          ],
+          [
+            "ws-conflicts",
+            {
+              number: 1626,
+              url: "https://github.com/coder/mux/pull/1626",
+              state: "OPEN",
+              mergeable: "CONFLICTING",
+              mergeStateStatus: "DIRTY",
+              title: "refactor: rename utils",
+              isDraft: false,
+              headRefName: "feature/has-conflicts",
+              baseRefName: "main",
+            },
+          ],
+          [
+            "ws-draft",
+            {
+              number: 1627,
+              url: "https://github.com/coder/mux/pull/1627",
+              state: "OPEN",
+              mergeable: "UNKNOWN",
+              mergeStateStatus: "UNKNOWN",
+              title: "WIP: experimental feature",
+              isDraft: true,
+              headRefName: "feature/work-in-progress",
+              baseRefName: "main",
+            },
+          ],
+          [
+            "ws-merged",
+            {
+              number: 1620,
+              url: "https://github.com/coder/mux/pull/1620",
+              state: "MERGED",
+              mergeable: "UNKNOWN",
+              mergeStateStatus: "UNKNOWN",
+              title: "feat: previous feature",
+              isDraft: false,
+              headRefName: "feature/already-merged",
+              baseRefName: "main",
+            },
+          ],
+          [
+            "ws-closed",
+            {
+              number: 1618,
+              url: "https://github.com/coder/mux/pull/1618",
+              state: "CLOSED",
+              mergeable: "UNKNOWN",
+              mergeStateStatus: "UNKNOWN",
+              title: "feat: abandoned approach",
+              isDraft: false,
+              headRefName: "feature/abandoned",
+              baseRefName: "main",
+            },
+          ],
+          ["ws-no-pr", "no_pr"],
+        ]);
+
+        // Simple chat handler - just show messages
+        const chatHandlers = new Map<string, ReturnType<typeof createStaticChatHandler>>();
+        for (const ws of workspaces) {
+          chatHandlers.set(
+            ws.id,
+            createStaticChatHandler([
+              createUserMessage("msg-1", "Show PR status", {
+                historySequence: 1,
+                timestamp: STABLE_TIMESTAMP - 60000,
+              }),
+              createAssistantMessage("msg-2", "Here's the PR status for this workspace.", {
+                historySequence: 2,
+                timestamp: STABLE_TIMESTAMP,
+              }),
+            ])
+          );
+        }
+
+        // Select the first workspace
+        selectWorkspaceHelper(workspaces[0]);
+
+        return createMockORPCClient({
+          projects: groupWorkspacesByProject(workspaces),
+          workspaces,
+          onChat: createOnChatAdapter(chatHandlers),
+          executeBash: createPRStatusExecutor(prStatuses),
+        });
+      }}
+    />
+  ),
+};
+
+/**
+ * Shows links dropdown with various URLs extracted from chat.
+ */
+export const LinksDropdown: AppStory = {
+  render: () => (
+    <AppWithMocks
+      setup={() => {
+        const workspaces = [
+          createWorkspace({
+            id: "ws-with-links",
+            name: "feature/links",
+            projectName: "my-app",
+            createdAt: new Date(NOW - 3600000).toISOString(),
+          }),
+        ];
+
+        const prStatuses = new Map<string, PRStatusFixture>([
+          [
+            "ws-with-links",
+            {
+              number: 1623,
+              url: "https://github.com/coder/mux/pull/1623",
+              state: "OPEN",
+              mergeable: "MERGEABLE",
+              mergeStateStatus: "CLEAN",
+              title: "feat: add link support",
+              isDraft: false,
+              headRefName: "feature/links",
+              baseRefName: "main",
+            },
+          ],
+        ]);
+
+        // Chat with various links
+        const chatHandlers = new Map<string, ReturnType<typeof createStaticChatHandler>>();
+        chatHandlers.set(
+          "ws-with-links",
+          createStaticChatHandler([
+            createUserMessage("msg-1", "Add link support", {
+              historySequence: 1,
+              timestamp: STABLE_TIMESTAMP - 120000,
+            }),
+            createAssistantMessage(
+              "msg-2",
+              `I'll help you add link support. Here are some relevant resources:
+
+- Documentation: https://docs.example.com/links
+- API Reference: https://api.example.com/v1/docs
+- Related issue: https://github.com/coder/mux/issues/1500
+
+Let me check the implementation at https://github.com/coder/mux/blob/main/src/links.ts`,
+              {
+                historySequence: 2,
+                timestamp: STABLE_TIMESTAMP - 60000,
+              }
+            ),
+            createUserMessage("msg-3", "Also check the tests", {
+              historySequence: 3,
+              timestamp: STABLE_TIMESTAMP - 30000,
+            }),
+            createAssistantMessage(
+              "msg-4",
+              `Found the tests at https://github.com/coder/mux/blob/main/src/links.test.ts
+
+Also see the CI workflow: https://github.com/coder/mux/actions/runs/12345`,
+              {
+                historySequence: 4,
+                timestamp: STABLE_TIMESTAMP,
+              }
+            ),
+          ])
+        );
+
+        selectWorkspaceHelper(workspaces[0]);
+
+        return createMockORPCClient({
+          projects: groupWorkspacesByProject(workspaces),
+          workspaces,
+          onChat: createOnChatAdapter(chatHandlers),
+          executeBash: createPRStatusExecutor(prStatuses),
+        });
+      }}
+    />
+  ),
+};

--- a/src/browser/utils/messages/StreamingMessageAggregator.links.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.links.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { StreamingMessageAggregator } from "./StreamingMessageAggregator";
+import type {
+  StreamStartEvent,
+  StreamDeltaEvent,
+  StreamEndEvent,
+  ToolCallStartEvent,
+  ToolCallEndEvent,
+} from "@/common/types/stream";
+
+// Test without workspace ID to avoid localStorage dependency
+const TEST_CREATED_AT = "2024-01-01T00:00:00.000Z";
+const TEST_WORKSPACE_ID = "test-workspace";
+
+// Helper to create stream-start event
+function makeStreamStart(messageId: string, historySequence = 1): StreamStartEvent {
+  return {
+    type: "stream-start",
+    workspaceId: TEST_WORKSPACE_ID,
+    messageId,
+    model: "test-model",
+    historySequence,
+    startTime: Date.now(),
+  };
+}
+
+// Helper to create stream-delta event
+function makeStreamDelta(messageId: string, delta: string, tokens = 10): StreamDeltaEvent {
+  return {
+    type: "stream-delta",
+    workspaceId: TEST_WORKSPACE_ID,
+    messageId,
+    delta,
+    tokens,
+    timestamp: Date.now(),
+  };
+}
+
+// Helper to create stream-end event
+function makeStreamEnd(messageId: string): StreamEndEvent {
+  return {
+    type: "stream-end",
+    workspaceId: TEST_WORKSPACE_ID,
+    messageId,
+    metadata: { model: "test-model" },
+    parts: [],
+  };
+}
+
+// Helper to create tool-call-start event
+function makeToolCallStart(messageId: string, toolCallId: string): ToolCallStartEvent {
+  return {
+    type: "tool-call-start",
+    workspaceId: TEST_WORKSPACE_ID,
+    messageId,
+    toolCallId,
+    toolName: "bash",
+    args: {},
+    tokens: 0,
+    timestamp: Date.now(),
+  };
+}
+
+// Helper to create tool-call-end event
+function makeToolCallEnd(messageId: string, toolCallId: string, result: unknown): ToolCallEndEvent {
+  return {
+    type: "tool-call-end",
+    workspaceId: TEST_WORKSPACE_ID,
+    messageId,
+    toolCallId,
+    toolName: "bash",
+    result,
+    timestamp: Date.now(),
+  };
+}
+
+describe("StreamingMessageAggregator link detection", () => {
+  let aggregator: StreamingMessageAggregator;
+
+  beforeEach(() => {
+    // Create aggregator without workspace ID to avoid localStorage
+    aggregator = new StreamingMessageAggregator(TEST_CREATED_AT);
+  });
+
+  describe("getDetectedLinks", () => {
+    it("returns empty array initially", () => {
+      expect(aggregator.getDetectedLinks()).toEqual([]);
+    });
+  });
+
+  describe("link extraction from complete parts", () => {
+    it("extracts links after stream-end", () => {
+      aggregator.handleStreamStart(makeStreamStart("msg1"));
+      aggregator.handleStreamDelta(
+        makeStreamDelta(
+          "msg1",
+          "I've opened a PR at https://github.com/owner/repo/pull/123 for review"
+        )
+      );
+
+      // Links not extracted yet during streaming (URL could be split across deltas)
+      expect(aggregator.getDetectedLinks()).toHaveLength(0);
+
+      // Links extracted on stream-end when text part is complete
+      aggregator.handleStreamEnd(makeStreamEnd("msg1"));
+
+      const links = aggregator.getDetectedLinks();
+      expect(links).toHaveLength(1);
+      // All chat links are now generic (PR badge uses branch-based detection)
+      expect(links[0]).toMatchObject({
+        type: "generic",
+        url: "https://github.com/owner/repo/pull/123",
+      });
+      // Should have metadata
+      expect(links[0]?.detectedAt).toBeGreaterThan(0);
+      expect(links[0]?.occurrenceCount).toBe(1);
+    });
+
+    it("extracts links from tool outputs during streaming", () => {
+      aggregator.handleStreamStart(makeStreamStart("msg1"));
+      aggregator.handleStreamDelta(makeStreamDelta("msg1", "Running checks..."));
+
+      aggregator.handleToolCallStart(makeToolCallStart("msg1", "tool1"));
+      aggregator.handleToolCallEnd(makeToolCallEnd("msg1", "tool1", "See https://example.com"));
+
+      // Tool outputs are stable and should surface links immediately.
+      const links = aggregator.getDetectedLinks();
+      expect(links).toHaveLength(1);
+      expect(links[0]).toMatchObject({ type: "generic", url: "https://example.com" });
+    });
+
+    it("does not extract assistant text links until stream-end", () => {
+      aggregator.handleStreamStart(makeStreamStart("msg1"));
+      aggregator.handleStreamDelta(makeStreamDelta("msg1", "See https://example.com/docs"));
+
+      aggregator.handleToolCallStart(makeToolCallStart("msg1", "tool1"));
+      aggregator.handleToolCallEnd(makeToolCallEnd("msg1", "tool1", "no links"));
+
+      // Still streaming - assistant text is considered unstable for link extraction.
+      expect(aggregator.getDetectedLinks()).toHaveLength(0);
+
+      aggregator.handleStreamEnd(makeStreamEnd("msg1"));
+      expect(aggregator.getDetectedLinks().map((l) => l.url)).toContain("https://example.com/docs");
+    });
+
+    it("extracts generic links from assistant text", () => {
+      aggregator.handleStreamStart(makeStreamStart("msg1"));
+      aggregator.handleStreamDelta(
+        makeStreamDelta("msg1", "Check out https://example.com/docs for more info")
+      );
+      aggregator.handleStreamEnd(makeStreamEnd("msg1"));
+
+      const links = aggregator.getDetectedLinks();
+      expect(links).toHaveLength(1);
+      expect(links[0]).toMatchObject({
+        type: "generic",
+        url: "https://example.com/docs",
+      });
+      expect(links[0].detectedAt).toBeGreaterThan(0);
+      expect(links[0].occurrenceCount).toBe(1);
+    });
+
+    it("deduplicates links in final message", () => {
+      aggregator.handleStreamStart(makeStreamStart("msg1"));
+      // Same link mentioned twice across deltas (will be merged into one text part)
+      aggregator.handleStreamDelta(makeStreamDelta("msg1", "See https://example.com", 5));
+      aggregator.handleStreamDelta(
+        makeStreamDelta("msg1", " and also https://example.com again", 5)
+      );
+      aggregator.handleStreamEnd(makeStreamEnd("msg1"));
+
+      const links = aggregator.getDetectedLinks();
+      expect(links).toHaveLength(1);
+    });
+
+    it("extracts multiple distinct links", () => {
+      aggregator.handleStreamStart(makeStreamStart("msg1"));
+      aggregator.handleStreamDelta(
+        makeStreamDelta("msg1", "https://example.com https://github.com/o/r/pull/1")
+      );
+      aggregator.handleStreamEnd(makeStreamEnd("msg1"));
+
+      const links = aggregator.getDetectedLinks();
+      expect(links).toHaveLength(2);
+      expect(links[0].url).toBe("https://example.com");
+      expect(links[1].url).toBe("https://github.com/o/r/pull/1");
+    });
+
+    it("extracts URLs split across deltas after compaction at stream-end", () => {
+      aggregator.handleStreamStart(makeStreamStart("msg1"));
+      // URL split across deltas - each partial won't match URL regex
+      aggregator.handleStreamDelta(makeStreamDelta("msg1", "Check https://githu", 3));
+      aggregator.handleStreamDelta(makeStreamDelta("msg1", "b.com/owner/repo/pu", 3));
+      aggregator.handleStreamDelta(makeStreamDelta("msg1", "ll/123 please", 3));
+
+      // Links not extracted yet (partials don't match)
+      expect(aggregator.getDetectedLinks()).toHaveLength(0);
+
+      // Stream-end triggers compaction which merges text, then rescans
+      aggregator.handleStreamEnd(makeStreamEnd("msg1"));
+
+      // Link should be detected from compacted text
+      const links = aggregator.getDetectedLinks();
+      expect(links).toHaveLength(1);
+      expect(links[0].url).toBe("https://github.com/owner/repo/pull/123");
+    });
+
+    it("extracts URLs split across deltas before tool call after stream-end", () => {
+      aggregator.handleStreamStart(makeStreamStart("msg1"));
+      // URL split across deltas before tool call
+      aggregator.handleStreamDelta(makeStreamDelta("msg1", "See https://github", 3));
+      aggregator.handleStreamDelta(makeStreamDelta("msg1", ".com/o/r/pull/99 ", 3));
+
+      // Tool call starts - assistant text is still streaming (links extracted on stream-end)
+      aggregator.handleToolCallStart(makeToolCallStart("msg1", "tool1"));
+
+      // Stream-end should still catch it after compaction
+      aggregator.handleStreamEnd(makeStreamEnd("msg1"));
+
+      // Link should be detected after stream-end compaction
+      const links = aggregator.getDetectedLinks();
+      expect(links).toHaveLength(1);
+      expect(links[0].url).toBe("https://github.com/o/r/pull/99");
+    });
+
+    it("extracts multiple links in order", () => {
+      aggregator.handleStreamStart(makeStreamStart("msg1"));
+      aggregator.handleStreamDelta(makeStreamDelta("msg1", "First: https://github.com/o/r/pull/1"));
+      aggregator.handleStreamDelta(
+        makeStreamDelta("msg1", " Second: https://github.com/o/r/pull/2")
+      );
+      aggregator.handleStreamEnd(makeStreamEnd("msg1"));
+
+      // Both links should be detected in order
+      const links = aggregator.getDetectedLinks();
+      expect(links).toHaveLength(2);
+      expect(links.map((l) => l.url)).toEqual([
+        "https://github.com/o/r/pull/1",
+        "https://github.com/o/r/pull/2",
+      ]);
+    });
+  });
+
+  describe("clear()", () => {
+    it("clears links along with messages", () => {
+      aggregator.handleStreamStart(makeStreamStart("msg1"));
+      aggregator.handleStreamDelta(makeStreamDelta("msg1", "https://example.com"));
+      aggregator.handleStreamEnd(makeStreamEnd("msg1"));
+
+      aggregator.clear();
+
+      expect(aggregator.getDetectedLinks()).toEqual([]);
+    });
+  });
+});

--- a/src/common/types/links.test.ts
+++ b/src/common/types/links.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "bun:test";
+import { extractUrls, categorizeUrl, deduplicateLinks, type DetectedLink } from "./links";
+
+describe("extractUrls", () => {
+  it("extracts URLs from plain text", () => {
+    const text = "Check out https://example.com and https://github.com/repo";
+    expect(extractUrls(text)).toEqual(["https://example.com", "https://github.com/repo"]);
+  });
+
+  it("handles markdown links", () => {
+    const text = "See [the PR](https://github.com/owner/repo/pull/123) for details";
+    expect(extractUrls(text)).toEqual(["https://github.com/owner/repo/pull/123"]);
+  });
+
+  it("strips trailing punctuation", () => {
+    const text = "Visit https://example.com. Or https://other.com!";
+    expect(extractUrls(text)).toEqual(["https://example.com", "https://other.com"]);
+  });
+
+  it("handles URLs in code blocks", () => {
+    const text = "```\nhttps://example.com/api\n```";
+    expect(extractUrls(text)).toEqual(["https://example.com/api"]);
+  });
+
+  it("returns empty array for text without URLs", () => {
+    expect(extractUrls("No links here")).toEqual([]);
+  });
+
+  it("handles complex URLs with paths and query strings", () => {
+    const text = "API: https://api.example.com/v1/users?page=1&limit=10";
+    expect(extractUrls(text)).toEqual(["https://api.example.com/v1/users?page=1&limit=10"]);
+  });
+
+  it("handles terminal output with tabs and column separators", () => {
+    // This is typical gh CLI output format
+    const text =
+      "Build / Linux\tpending\t0\thttps://github.com/owner/repo/actions/runs/123/job/456\t\nBuild / macOS\tpass\t8s\thttps://github.com/owner/repo/actions/runs/123/job/789\t";
+    expect(extractUrls(text)).toEqual([
+      "https://github.com/owner/repo/actions/runs/123/job/456",
+      "https://github.com/owner/repo/actions/runs/123/job/789",
+    ]);
+  });
+
+  it("handles URLs with backslash escapes from terminal", () => {
+    const text = "See https://github.com/owner/repo\\nMore text";
+    expect(extractUrls(text)).toEqual(["https://github.com/owner/repo"]);
+  });
+
+  it("handles URLs ending with literal backslash-t", () => {
+    // This pattern appears in gh pr checks output
+    const text = "Mintlify Deployment\\tskipping\\t0\\thttps://mintlify.com\\t";
+    expect(extractUrls(text)).toEqual(["https://mintlify.com"]);
+  });
+
+  it("handles mixed tab formats", () => {
+    // Mix of actual tabs and literal \t sequences
+    const text = "Check\thttps://example.com\\t\\nNext";
+    expect(extractUrls(text)).toEqual(["https://example.com"]);
+  });
+});
+
+describe("categorizeUrl", () => {
+  it("creates generic links with metadata", () => {
+    const result = categorizeUrl("https://example.com/page");
+    expect(result.type).toBe("generic");
+    expect(result.url).toBe("https://example.com/page");
+    // Should have metadata initialized
+    expect(result.detectedAt).toBeGreaterThan(0);
+    expect(result.occurrenceCount).toBe(1);
+  });
+
+  it("accepts custom timestamp", () => {
+    const timestamp = 1234567890;
+    const result = categorizeUrl("https://example.com", timestamp);
+    expect(result.detectedAt).toBe(timestamp);
+  });
+});
+
+describe("deduplicateLinks", () => {
+  const now = Date.now();
+
+  it("removes duplicate links by URL", () => {
+    const links: DetectedLink[] = [
+      { type: "generic", url: "https://a.com", detectedAt: now, occurrenceCount: 1 },
+      { type: "generic", url: "https://b.com", detectedAt: now, occurrenceCount: 1 },
+      { type: "generic", url: "https://a.com", detectedAt: now, occurrenceCount: 1 },
+    ];
+    const result = deduplicateLinks(links);
+    expect(result).toHaveLength(2);
+    expect(result[0].url).toBe("https://a.com");
+    expect(result[1].url).toBe("https://b.com");
+  });
+
+  it("keeps first occurrence of duplicate", () => {
+    const links: DetectedLink[] = [
+      {
+        type: "generic",
+        url: "https://a.com",
+        title: "First",
+        detectedAt: now,
+        occurrenceCount: 1,
+      },
+      {
+        type: "generic",
+        url: "https://a.com",
+        title: "Second",
+        detectedAt: now,
+        occurrenceCount: 1,
+      },
+    ];
+    const result = deduplicateLinks(links);
+    expect(result).toHaveLength(1);
+    expect((result[0] as { title?: string }).title).toBe("First");
+  });
+});

--- a/src/common/types/links.ts
+++ b/src/common/types/links.ts
@@ -1,0 +1,158 @@
+/**
+ * Types for detected links in chat messages.
+ * Links are extracted incrementally during message streaming.
+ */
+
+/**
+ * Base link metadata common to all link types.
+ */
+export interface BaseLinkMetadata {
+  /** Timestamp when the link was last detected (used for sorting + "last seen" UI) */
+  detectedAt: number;
+  /** Number of times this link appeared in messages */
+  occurrenceCount: number;
+}
+
+/**
+ * A GitHub PR link with parsed metadata.
+ */
+export interface GitHubPRLink extends BaseLinkMetadata {
+  type: "github-pr";
+  url: string;
+  owner: string;
+  repo: string;
+  number: number;
+}
+
+/**
+ * A generic link (non-PR).
+ */
+export interface GenericLink extends BaseLinkMetadata {
+  type: "generic";
+  url: string;
+  /** Optional display text extracted from markdown [text](url) */
+  title?: string;
+}
+
+/**
+ * Union of all detected link types.
+ */
+export type DetectedLink = GitHubPRLink | GenericLink;
+
+/**
+ * PR status information fetched from GitHub via gh CLI.
+ */
+export interface GitHubPRStatus {
+  /** PR state: OPEN, CLOSED, MERGED */
+  state: "OPEN" | "CLOSED" | "MERGED";
+  /** Whether the PR is mergeable */
+  mergeable: "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
+  /** Merge state status (GitHub merge box state). */
+  mergeStateStatus:
+    | "CLEAN"
+    | "BLOCKED"
+    | "BEHIND"
+    | "DIRTY"
+    | "UNSTABLE"
+    | "HAS_HOOKS"
+    | "DRAFT"
+    | "UNKNOWN";
+  /** PR title */
+  title: string;
+  /** Whether the PR is a draft */
+  isDraft: boolean;
+  /** Head branch name */
+  headRefName: string;
+  /** Base branch name */
+  baseRefName: string;
+
+  /**
+   * Whether any checks are still pending/running.
+   * Optional: not all gh versions/API payloads include check rollup data.
+   */
+  hasPendingChecks?: boolean;
+
+  /**
+   * Whether any checks have failed.
+   * Optional: not all gh versions/API payloads include check rollup data.
+   */
+  hasFailedChecks?: boolean;
+
+  /** Last fetched timestamp */
+  fetchedAt: number;
+}
+
+/**
+ * Extended PR link with status information.
+ */
+export interface GitHubPRLinkWithStatus extends GitHubPRLink {
+  status?: GitHubPRStatus;
+  /** Whether status is currently being fetched */
+  loading?: boolean;
+  /** Error message if status fetch failed */
+  error?: string;
+}
+
+/**
+ * Extract all URLs from a text string.
+ * Uses a simple regex that matches http/https URLs.
+ * Handles markdown artifacts, terminal output, and trailing punctuation.
+ */
+export function extractUrls(text: string): string[] {
+  // Match URLs starting with http:// or https://
+  // Stop at: whitespace, quotes, brackets, backticks, backslashes, or end of string
+  const urlRegex = /https?:\/\/[^\s<>"')\]`\\]+/g;
+  const matches = text.match(urlRegex) ?? [];
+
+  // Clean up trailing artifacts that are likely not part of the URL
+  return matches
+    .map((url) =>
+      url
+        // Remove trailing escape sequences (\t, \n, \r) - literal backslash+char
+        .replace(/\\[tnr]+$/, "")
+        // Remove trailing punctuation
+        .replace(/[.,;:!?)]+$/, "")
+        // Remove trailing markdown code fence markers
+        .replace(/`+$/, "")
+    )
+    .filter((url) => {
+      // Filter out malformed URLs that are too short or don't have a domain
+      try {
+        const parsed = new URL(url);
+        return parsed.hostname.includes(".");
+      } catch {
+        return false;
+      }
+    });
+}
+
+/**
+ * Create a generic link from a URL.
+ * Initializes metadata (detectedAt, occurrenceCount) for the new link.
+ *
+ * Note: PR links are detected via branch-based detection (gh pr view),
+ * not from chat URL extraction. All chat links are treated as generic.
+ *
+ * @param url The URL
+ * @param timestamp The timestamp when this link was detected (defaults to now)
+ */
+export function categorizeUrl(url: string, timestamp: number = Date.now()): GenericLink {
+  return {
+    type: "generic",
+    url,
+    detectedAt: timestamp,
+    occurrenceCount: 1,
+  };
+}
+
+/**
+ * Deduplicate links by URL, keeping the first occurrence.
+ */
+export function deduplicateLinks<T extends { url: string }>(links: T[]): T[] {
+  const seen = new Set<string>();
+  return links.filter((link) => {
+    if (seen.has(link.url)) return false;
+    seen.add(link.url);
+    return true;
+  });
+}


### PR DESCRIPTION
## Summary

Add link detection and display to the workspace header, with special handling for GitHub PR links.

## Features

- **Branch-based PR detection**: Automatically detects PR for current branch via `gh pr view` (no URL argument)
- **Link extraction**: Scans assistant text and tool output for URLs (shown in dropdown)
- **PR badge display**: Shows workspace's PR as a clickable badge in the workspace header
- **PR status enrichment**: Fetches PR state (open/merged/closed), mergeability, and draft status
- **Generic links dropdown**: Non-PR URLs displayed in a scrollable dropdown with copy functionality

## Architecture

### Two separate concerns
1. **PR detection** (badge): Branch-based via `gh pr view` - robust, doesn't depend on chat content
2. **Link extraction** (dropdown): Scans chat for URLs - shows relevant links mentioned in conversation

### PR detection flow
```
WorkspaceLinks mounts
  → monitorWorkspace(workspaceId)
  → gh pr view --json ...  (no URL = current branch)
  → PRStatusStore caches result
  → useWorkspacePR(workspaceId) returns PR with status
```

### Link extraction robustness
- Only scans **complete** text parts (triggered on `tool-call-start` or `stream-end`)
- Rescans after compaction to catch URLs split across deltas
- Tracks occurrence count and last-seen timestamp

### Design decisions
- Links derived from message history on load, **not persisted to localStorage**
- PR badge comes from branch detection, **not** from chat-extracted PR links
- Dropdown sorted by occurrence count (most seen first), then recency

## UX Features
- Copy button on each link in dropdown
- Hover tooltip shows full URL + "Seen N times · Last seen X ago"
- Scrollable dropdown (max 10 visible, all accessible via scroll)
- PR badge shows status icons (draft, checks, mergeability)

---
_Generated with `mux` • Model: `${MUX_MODEL_STRING:-unknown}` • Thinking: `${MUX_THINKING_LEVEL:-unknown}` • Cost: `$${MUX_COSTS_USD:-unknown}`_
