### PR TITLE
🤖 fix: add static-check tools to nix devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -147,22 +147,40 @@
         };
 
         devShells.default = pkgs.mkShell {
-          buildInputs = with pkgs; [
-            bun
-            git
-            bash
-            nixfmt-rfc-style
+          buildInputs =
+            with pkgs;
+            [
+              bun
 
-            # Documentation
-            mdbook
-            mdbook-mermaid
-            mdbook-linkcheck
-            mdbook-pagetoc
+              # Node + build tooling
+              nodejs
+              gnumake
 
-            # Terminal bench
-            uv
-            asciinema
-          ];
+              # Common CLIs
+              git
+              bash
+
+              # Nix tooling
+              nixfmt-rfc-style
+
+              # Repo linting (make static-check)
+              go
+              shellcheck
+              shfmt
+              gh
+              jq
+
+              # Documentation
+              mdbook
+              mdbook-mermaid
+              mdbook-linkcheck
+              mdbook-pagetoc
+
+              # Terminal bench
+              uv
+              asciinema
+            ]
+            ++ lib.optionals stdenv.isLinux [ docker ];
         };
       }
     );


### PR DESCRIPTION
PR #1595 added `actionlint`/`zizmor`/ShellCheck to `make static-check`, but the Nix devShell in `flake.nix` didn’t include the corresponding CLIs. This makes `nix develop` users fail local `make static-check`.

Changes:
- Add `go`, `shellcheck`, `shfmt`, `gh`, `jq`, `nodejs`, `gnumake` to `devShells.default`.
- Add `docker` to the devShell on Linux only (zizmor runs via a Docker image; macOS should use Docker Desktop).

Validation:
- `make -j static-check`
- `nix flake show path:. --no-write-lock-file` (via `nixos/nix` docker image)

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$2.20`_
