### PR TITLE
🤖 fix: forwardRef GatewayIcon for Radix Tooltip

### DIFF
--- a/src/browser/components/icons/GatewayIcon.tsx
+++ b/src/browser/components/icons/GatewayIcon.tsx
@@ -10,26 +10,31 @@ interface GatewayIconProps extends React.SVGProps<SVGSVGElement> {
  * Gateway icon - represents routing through Mux Gateway.
  * Circle with M logo. Active state adds outer ring.
  */
-export function GatewayIcon(props: GatewayIconProps) {
-  const { active, ...svgProps } = props;
+export const GatewayIcon = React.forwardRef<SVGSVGElement, GatewayIconProps>(
+  function GatewayIcon(props, ref) {
+    const { active, ...svgProps } = props;
 
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      {...svgProps}
-    >
-      {/* Outer glow ring when active */}
-      {active && <circle cx="12" cy="12" r="11" strokeWidth="1" opacity="0.5" />}
-      {/* Main circle */}
-      <circle cx="12" cy="12" r="8" />
-      {/* M letter */}
-      <path d="M8 16V8l4 5 4-5v8" />
-    </svg>
-  );
-}
+    return (
+      <svg
+        ref={ref}
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        {...svgProps}
+      >
+        {/* Outer glow ring when active */}
+        {active && <circle cx="12" cy="12" r="11" strokeWidth="1" opacity="0.5" />}
+        {/* Main circle */}
+        <circle cx="12" cy="12" r="8" />
+        {/* M letter */}
+        <path d="M8 16V8l4 5 4-5v8" />
+      </svg>
+    );
+  }
+);
+
+GatewayIcon.displayName = "GatewayIcon";


### PR DESCRIPTION
Fixes the React warning (`Function components cannot be given refs`) when `GatewayIcon` is used as a Radix `TooltipTrigger` child (`asChild`).

- Convert `GatewayIcon` to `React.forwardRef` and forward the ref to the underlying `<svg>`.

Validation:
- `make static-check`

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$n/a`_
