### PR TITLE
🤖 feat: enable Mux Gateway by default after login

### DIFF
--- a/src/browser/components/Settings/sections/ProvidersSection.tsx
+++ b/src/browser/components/Settings/sections/ProvidersSection.tsx
@@ -284,6 +284,10 @@ export function ProvidersSection() {
               // Ignore errors fetching config; fall back to the current snapshot.
             }
 
+            if (attempt !== muxGatewayLoginAttemptRef.current) {
+              return;
+            }
+
             setGatewayModels(getEligibleGatewayModels(latestConfig));
             muxGatewayApplyDefaultModelsOnSuccessRef.current = false;
           }

--- a/src/browser/components/splashScreens/LoginWithMuxGateway.tsx
+++ b/src/browser/components/splashScreens/LoginWithMuxGateway.tsx
@@ -125,6 +125,10 @@ export function LoginWithMuxGatewaySplash(props: { onDismiss: () => void }) {
               // Ignore errors fetching config; fall back to the current snapshot.
             }
 
+            if (attempt !== loginAttemptRef.current) {
+              return;
+            }
+
             updatePersistedState(
               GATEWAY_MODELS_KEY,
               getSuggestedModels(latestConfig).filter(isProviderSupported)


### PR DESCRIPTION
This updates the Mux Gateway OAuth login flows (splash screen + Settings → Providers) to automatically enable Mux Gateway routing for all eligible models after a successful first-time login.

- Only applies when the user wasn't already logged in (avoids clobbering per-model choices on re-login).
- Uses the existing “Default” behavior (sets `gateway-models` to all supported models).

## Validation
- `make static-check`

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh`_
