### PR TITLE
🤖 feat: move Mux logo from TitleBar to Projects header

### DIFF
--- a/src/browser/components/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar.tsx
@@ -1,6 +1,9 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { cn } from "@/common/lib/utils";
 import { isDesktopMode } from "@/browser/hooks/useDesktopTitlebar";
+import MuxLogoDark from "@/browser/assets/logos/mux-logo-dark.svg?react";
+import MuxLogoLight from "@/browser/assets/logos/mux-logo-light.svg?react";
+import { useTheme } from "@/browser/contexts/ThemeContext";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
 import { EXPANDED_PROJECTS_KEY } from "@/common/constants/storage";
@@ -240,6 +243,10 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
     reorderSections,
     assignWorkspaceToSection,
   } = useProjectContext();
+
+  // Theme for logo variant
+  const { theme } = useTheme();
+  const MuxLogo = theme === "dark" || theme === "solarized-dark" ? MuxLogoDark : MuxLogoLight;
 
   // Mobile breakpoint for auto-closing sidebar
   const MOBILE_BREAKPOINT = 768;
@@ -483,8 +490,8 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
         >
           {!collapsed && (
             <>
-              <div className="border-dark flex items-center justify-between border-b p-4">
-                <h2 className="text-foreground m-0 text-lg font-medium">Projects</h2>
+              <div className="border-dark flex items-center justify-between border-b py-3 pr-3 pl-4">
+                <MuxLogo className="h-5 w-[44px]" aria-label="Projects" />
                 <button
                   onClick={onAddProject}
                   aria-label="Add project"

--- a/src/browser/components/RightSidebar/RightSidebarTabStrip.tsx
+++ b/src/browser/components/RightSidebar/RightSidebarTabStrip.tsx
@@ -6,7 +6,11 @@ import { CSS } from "@dnd-kit/utilities";
 import { useDroppable, useDndContext } from "@dnd-kit/core";
 import { Plus } from "lucide-react";
 import type { TabType } from "@/browser/types/rightSidebar";
-import { isDesktopMode, getTitlebarRightInset } from "@/browser/hooks/useDesktopTitlebar";
+import {
+  isDesktopMode,
+  getTitlebarRightInset,
+  DESKTOP_TITLEBAR_MIN_HEIGHT_CLASS,
+} from "@/browser/hooks/useDesktopTitlebar";
 
 // Re-export for consumers that import from this file
 export { getTabName } from "./tabs";
@@ -141,7 +145,7 @@ export const RightSidebarTabStrip: React.FC<RightSidebarTabStripProps> = ({
       ref={setNodeRef}
       className={cn(
         "border-border-light flex min-w-0 items-center border-b px-2 transition-colors",
-        isDesktop ? "min-h-10" : "py-1.5",
+        isDesktop ? DESKTOP_TITLEBAR_MIN_HEIGHT_CLASS : "py-1.5",
         showDropHighlight && "bg-accent/30",
         isDraggingFromHere && "bg-accent/10",
         // In desktop mode, make header draggable for window movement

--- a/src/browser/components/WorkspaceHeader.tsx
+++ b/src/browser/components/WorkspaceHeader.tsx
@@ -16,7 +16,11 @@ import { useTutorial } from "@/browser/contexts/TutorialContext";
 import { useOpenTerminal } from "@/browser/hooks/useOpenTerminal";
 import { useOpenInEditor } from "@/browser/hooks/useOpenInEditor";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
-import { getTitlebarRightInset, isDesktopMode } from "@/browser/hooks/useDesktopTitlebar";
+import {
+  getTitlebarRightInset,
+  isDesktopMode,
+  DESKTOP_TITLEBAR_HEIGHT_CLASS,
+} from "@/browser/hooks/useDesktopTitlebar";
 import { WorkspaceLinks } from "./WorkspaceLinks";
 
 interface WorkspaceHeaderProps {
@@ -99,7 +103,7 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
       data-testid="workspace-header"
       className={cn(
         "bg-sidebar border-border-light flex items-center justify-between border-b px-[15px] [@media(max-width:768px)]:h-auto [@media(max-width:768px)]:flex-wrap [@media(max-width:768px)]:gap-2 [@media(max-width:768px)]:py-2 [@media(max-width:768px)]:pl-[60px]",
-        isDesktop ? "h-10" : "h-8",
+        isDesktop ? DESKTOP_TITLEBAR_HEIGHT_CLASS : "h-8",
         // In desktop mode, make header draggable for window movement
         isDesktop && "titlebar-drag"
       )}

--- a/src/browser/hooks/useDesktopTitlebar.ts
+++ b/src/browser/hooks/useDesktopTitlebar.ts
@@ -51,6 +51,13 @@ export const MAC_TRAFFIC_LIGHTS_INSET = 80;
 export const WIN_LINUX_OVERLAY_INSET = 138;
 
 /**
+ * Tailwind height classes for the desktop titlebar.
+ * Use these in components that need to align with the titlebar height.
+ */
+export const DESKTOP_TITLEBAR_HEIGHT_CLASS = "h-9"; // 36px
+export const DESKTOP_TITLEBAR_MIN_HEIGHT_CLASS = "min-h-9"; // 36px
+
+/**
  * Returns the left inset needed for macOS traffic lights.
  * Returns 0 if not in desktop mode or not on macOS.
  */


### PR DESCRIPTION
Move the Mux logo from the TitleBar to replace the "Projects" text header in the sidebar, and reduce the desktop titlebar height.

## Changes
- Replace `<h2>Projects</h2>` with theme-aware `<MuxLogo>` in ProjectSidebar
- Align logo with project chevrons (`pl-4`) and increase size (`h-5`)
- Remove the Mux logo + shimmer animation from TitleBar
- Keep the update indicator (spinner/badge) and version/build metadata tooltip
- Reduce desktop titlebar height from 40px to 36px (`h-9`)
- Add `DESKTOP_TITLEBAR_HEIGHT_CLASS` / `DESKTOP_TITLEBAR_MIN_HEIGHT_CLASS` constants to DRY up the height

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$2.04`_
