### PR TITLE
🤖 fix: correct react-effects skill name to match directory

### DIFF
--- a/.mux/skills/react-effects/SKILL.md
+++ b/.mux/skills/react-effects/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: React Effects
+name: react-effects
 description: Guidelines for when to use (and avoid) useEffect in React components
 ---
 


### PR DESCRIPTION
The agentskills.io spec requires frontmatter `name` to exactly match the parent directory name.

`"React Effects" !== "react-effects"` caused skill discovery to silently skip this skill, making `agent_skill_read` fail with "Agent skill not found".

## Why the `name` field exists

The [agentskills.io specification](https://agentskills.io/specification) explicitly requires:

> **`name` field** ... Must match the parent directory name

This redundancy is intentional in the spec for:
1. **Portability** - if you zip/share a skill, the name is self-contained in the file
2. **Validation** - explicit declaration catches accidental renames

## Debugging notes

The validation failure was hard to find because errors are silently swallowed in `agentSkillsService.ts`:

```ts
try {
  return await readAgentSkillFromDir(runtime, skillDir, name, candidate.scope);
} catch {
  continue;  // Silent failure
}
```

Built-in skills (like `mux-docs`) worked fine, masking the issue for project skills.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$2.61`_
