### PR TITLE
🤖 feat: add horizontal wheel scroll to pane tabs

### DIFF
--- a/src/browser/components/RightSidebar/RightSidebarTabStrip.tsx
+++ b/src/browser/components/RightSidebar/RightSidebarTabStrip.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useRef } from "react";
 import { cn } from "@/common/lib/utils";
+import { useHorizontalWheelScroll } from "@/browser/hooks/useHorizontalWheelScroll";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
@@ -127,6 +128,10 @@ export const RightSidebarTabStrip: React.FC<RightSidebarTabStripProps> = ({
   const isDesktop = isDesktopMode();
   const rightInset = getTitlebarRightInset();
 
+  // Enable horizontal scrolling via mouse wheel
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  useHorizontalWheelScroll(scrollContainerRef);
+
   return (
     <div
       ref={setNodeRef}
@@ -143,6 +148,7 @@ export const RightSidebarTabStrip: React.FC<RightSidebarTabStripProps> = ({
       aria-label={ariaLabel}
     >
       <div
+        ref={scrollContainerRef}
         className={cn(
           "flex min-w-0 flex-1 items-center gap-1 overflow-x-auto",
           // In desktop mode, the tab strip sits in the titlebar drag region.

--- a/src/browser/hooks/useHorizontalWheelScroll.ts
+++ b/src/browser/hooks/useHorizontalWheelScroll.ts
@@ -1,0 +1,26 @@
+import { useEffect, type RefObject } from "react";
+
+/**
+ * Converts vertical wheel scroll to horizontal scroll on an overflow-x container.
+ * Useful for tab strips and other horizontal scrollable areas.
+ */
+export function useHorizontalWheelScroll(ref: RefObject<HTMLElement | null>): void {
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const handleWheel = (e: WheelEvent) => {
+      // Only intercept if there's horizontal overflow
+      if (el.scrollWidth <= el.clientWidth) return;
+
+      // Convert vertical scroll to horizontal
+      if (e.deltaY !== 0) {
+        e.preventDefault();
+        el.scrollLeft += e.deltaY;
+      }
+    };
+
+    el.addEventListener("wheel", handleWheel, { passive: false });
+    return () => el.removeEventListener("wheel", handleWheel);
+  }, [ref]);
+}


### PR DESCRIPTION
Scrolling with mouse wheel over pane tabs now scrolls horizontally when tabs overflow. Previously required manually grabbing the scrollbar.

## Changes
- Add `useHorizontalWheelScroll` hook (reusable for other horizontal scroll areas)
- Integrate into `RightSidebarTabStrip`

---
_Generated with `mux` • Model: `mux-gateway:anthropic/claude-opus-4-5` • Thinking: `high` • Cost: `$0.34`_
