### PR TITLE
🤖 feat: middle-click to close closeable sidebar tabs

### DIFF
--- a/src/browser/components/RightSidebar.tsx
+++ b/src/browser/components/RightSidebar.tsx
@@ -343,6 +343,12 @@ const RightSidebarTabsetNode: React.FC<RightSidebarTabsetNodeProps> = (props) =>
         label,
         tooltip,
         tab,
+        // Terminal and file tabs are closeable
+        onClose: isTerminal
+          ? () => props.onCloseTerminal(tab)
+          : isFileTab(tab)
+            ? () => props.onCloseFile(tab)
+            : undefined,
       },
     ];
   });

--- a/src/browser/components/RightSidebar/RightSidebarTabStrip.tsx
+++ b/src/browser/components/RightSidebar/RightSidebarTabStrip.tsx
@@ -29,6 +29,8 @@ export interface RightSidebarTabStripItem {
   disabled?: boolean;
   /** The tab type (used for drag identification) */
   tab: TabType;
+  /** Optional callback to close this tab (for closeable tabs like terminals) */
+  onClose?: () => void;
 }
 
 interface RightSidebarTabStripProps {
@@ -85,6 +87,13 @@ const SortableTab: React.FC<{
               isDragging && "cursor-grabbing opacity-50"
             )}
             onClick={item.onSelect}
+            onAuxClick={(e) => {
+              // Middle-click (button 1) closes closeable tabs
+              if (e.button === 1 && item.onClose) {
+                e.preventDefault();
+                item.onClose();
+              }
+            }}
             id={item.id}
             role="tab"
             type="button"


### PR DESCRIPTION
Add middle-click (auxclick button 1) support for closing terminal and file viewer tabs in the right sidebar panes view, matching common IDE/browser tab behavior.

**Changes:**
- Added `onClose` callback to `RightSidebarTabStripItem` interface
- Added `onAuxClick` handler to tab buttons that triggers close on middle-click
- Wired up close handlers for both terminal and file viewer tabs

---
_Generated with `mux` • Model: `mux-gateway:anthropic/claude-opus-4-5` • Thinking: `high` • Cost: `$1.04`_
