### PR TITLE
🤖 ci: move workflow permissions to job-level for least-privilege

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,10 +19,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# Permissions for GCP workload identity authentication (Windows code signing on main)
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   # Detect what files changed to determine which jobs/tests to run
@@ -367,6 +365,9 @@ jobs:
     # Windows builds are slow - only run in merge queue and main pushes, not on every PR push
     if: ${{ (github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && (needs.changes.outputs.src == 'true' || needs.changes.outputs.config == 'true') }}
     runs-on: windows-latest
+    permissions:
+      contents: read
+      id-token: write # GCP workload identity for Windows code signing
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,6 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: write # Required for electron-builder to upload release assets
-  id-token: write # Required for GCP workload identity authentication (Windows code signing)
-
 env:
   RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name || github.ref_name }}
 
@@ -47,6 +43,8 @@ jobs:
     name: Build and Release macOS
     needs: preflight
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-macos-15' || 'macos-latest' }}
+    permissions:
+      contents: write # Upload release assets
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -78,6 +76,8 @@ jobs:
     name: Build and Release Linux
     needs: preflight
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-16' || 'ubuntu-latest' }}
+    permissions:
+      contents: write # Upload release assets
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -100,6 +100,8 @@ jobs:
     name: Build and Release VS Code Extension
     needs: preflight
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-16' || 'ubuntu-latest' }}
+    permissions:
+      contents: write # Upload .vsix to release
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -153,6 +155,9 @@ jobs:
     name: Build and Release Windows
     needs: preflight
     runs-on: windows-latest
+    permissions:
+      contents: write # Upload release assets
+      id-token: write # GCP workload identity for code signing
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,14 +1,4 @@
 # zizmor configuration
 # https://docs.zizmor.sh/configuration/
 
-rules:
-  # TODO: Move these workflow-level permissions to job-level for least-privilege.
-  # These permissions are documented in the workflow files with specific reasons.
-  # Moving to job-level requires restructuring since multiple jobs need them.
-  excessive-permissions:
-    ignore:
-      # TODO: Move id-token:write to only the jobs that need GCP workload identity
-      - pr.yml:25
-      # TODO: Move contents:write and id-token:write to only the release job
-      - release.yml:14
-      - release.yml:15
+rules: {}


### PR DESCRIPTION
Move workflow-level permissions to job-level for least-privilege, addressing the `excessive-permissions` zizmor findings.

## Changes

**pr.yml:**
- Remove `id-token: write` from workflow-level
- Add job-level permissions to `build-windows` (the only job needing GCP workload identity for code signing)

**release.yml:**
- Remove workflow-level `contents: write` and `id-token: write`
- Add `contents: write` to build jobs that upload release assets
- Add `id-token: write` only to `build-windows` for GCP auth

**zizmor.yml:**
- Remove `excessive-permissions` ignore rules (no longer needed)

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
