### PR TITLE
🤖 fix: tolerate VerifierTimeoutError in Terminal-Bench workflow

### DIFF
--- a/.github/workflows/terminal-bench.yml
+++ b/.github/workflows/terminal-bench.yml
@@ -171,12 +171,13 @@ jobs:
             exit 1
           fi
           # Count timeout errors separately from other errors
-          TIMEOUT_ERRORS=$(find jobs -name 'exception.txt' -exec grep -l "AgentTimeoutError" {} \; 2>/dev/null | wc -l | tr -d ' ')
+          # Both AgentTimeoutError and VerifierTimeoutError are expected for hard tasks
+          TIMEOUT_ERRORS=$(find jobs -name 'exception.txt' -exec grep -lE "(AgentTimeoutError|VerifierTimeoutError)" {} \; 2>/dev/null | wc -l | tr -d ' ')
           OTHER_ERRORS=$((N_ERRORS - TIMEOUT_ERRORS))
           if [ "$OTHER_ERRORS" -gt 0 ]; then
             echo "❌ $OTHER_ERRORS task(s) had non-timeout errors - agent setup or execution failed"
             echo "--- Exception details (excluding timeouts) ---"
-            find jobs -name 'exception.txt' -exec sh -c 'grep -L "AgentTimeoutError" "$1" 2>/dev/null && echo "=== $1 ===" && cat "$1"' _ {} \; 2>/dev/null || true
+            find jobs -name 'exception.txt' -exec sh -c 'grep -qE "(AgentTimeoutError|VerifierTimeoutError)" "$1" || { echo "=== $1 ===" && cat "$1"; }' _ {} \; 2>/dev/null || true
             exit 1
           fi
           if [ "$TIMEOUT_ERRORS" -gt 0 ]; then


### PR DESCRIPTION
## Problem

The [nightly Opus run (21014410751)](https://github.com/coder/mux/actions/runs/21014410751) failed with:

- 89 trials, 11 errors
- 10 `AgentTimeoutError` (tolerated correctly)
- 1 `VerifierTimeoutError` (not tolerated, caused failure)

The `VerifierTimeoutError` occurred on `feal-differential-cryptanalysis` - the verifier (test harness) timed out after 1800s. This is similar to an agent timeout - the task is genuinely hard.

## Fix

Update the workflow to treat both `AgentTimeoutError` and `VerifierTimeoutError` as expected timeout errors that don't fail the build.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$32.00`_
