### PR TITLE
🤖 fix: add plan file path hint to file_read errors in plan mode

### DIFF
--- a/src/node/services/tools/file_read.ts
+++ b/src/node/services/tools/file_read.ts
@@ -43,9 +43,14 @@ export const createFileReadTool: ToolFactory = (config: ToolConfiguration) => {
         if (!(await isPlanFilePath(filePath, config))) {
           const pathValidation = validatePathInCwd(filePath, config.cwd, config.runtime);
           if (pathValidation) {
+            // In plan mode, hint about the plan file path to help model recover
+            const hint =
+              config.mode === "plan" && config.planFilePath
+                ? ` In plan mode, use the plan file path exactly as provided: ${config.planFilePath}`
+                : "";
             return {
               success: false,
-              error: pathValidation.error,
+              error: pathValidation.error + hint,
             };
           }
         }


### PR DESCRIPTION
## Summary

When a model in plan mode tries to read/write a file outside the workspace directory using an expanded path (e.g., `/Users/ammar/.mux/plans/gbot/main.md` instead of `~/.mux/plans/gbot/main.md`), the error now includes a helpful hint with the exact plan file path to use.

## Problem

Models would sometimes expand `~` to the full home directory path when accessing the plan file, causing path validation to fail because:
1. The `isPlanFilePath` check compares resolved paths
2. In development mode, `~/.mux` expands to `~/.mux-dev` via `getMuxHome()`
3. But the model's manual expansion stays as `~/.mux`

## Solution

Instead of complex path normalization heuristics, we add a clear hint to the error message:

> `In plan mode, use the plan file path exactly as provided: ~/.mux/plans/project/workspace.md`

This allows the model to self-correct on the next attempt by using the verbatim path from the system prompt.

## Test Plan

- Added unit test verifying the hint appears in plan mode errors
- `make static-check` passes

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `medium` • Cost: `$3.54`_
