### PR TITLE
🤖 fix: align hook output caret with tool carets

### DIFF
--- a/src/browser/components/tools/shared/HookOutputDisplay.tsx
+++ b/src/browser/components/tools/shared/HookOutputDisplay.tsx
@@ -53,7 +53,7 @@ export const HookOutputDisplay: React.FC<HookOutputDisplayProps> = ({
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <div className={cn("mt-1.5", className)}>
+    <div className={cn("mt-1.5 px-3", className)}>
       <button
         type="button"
         onClick={() => setExpanded(!expanded)}


### PR DESCRIPTION
HookOutputDisplay is rendered outside ToolContainer, so it was missing the `px-3` horizontal padding that tools have. Added matching padding to align the ChevronRight with the tool ExpandIcon.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.51`_