### PR TITLE
🤖 fix: emit stream-abort when interrupting before stream-start

### DIFF
--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -806,6 +806,29 @@ describe("StreamManager - ask_user_question Partial Persistence", () => {
   });
 });
 
+describe("StreamManager - stopStream", () => {
+  test("emits stream-abort when stopping non-existent stream", async () => {
+    const mockHistoryService = createMockHistoryService();
+    const mockPartialService = createMockPartialService();
+    const streamManager = new StreamManager(mockHistoryService, mockPartialService);
+
+    // Track emitted events
+    const abortEvents: Array<{ workspaceId: string; messageId: string }> = [];
+    streamManager.on("stream-abort", (data: { workspaceId: string; messageId: string }) => {
+      abortEvents.push(data);
+    });
+
+    // Stop a stream that doesn't exist (simulates interrupt before stream-start)
+    const result = await streamManager.stopStream("test-workspace");
+
+    expect(result.success).toBe(true);
+    expect(abortEvents).toHaveLength(1);
+    expect(abortEvents[0].workspaceId).toBe("test-workspace");
+    // messageId is empty for synthetic abort (no actual stream existed)
+    expect(abortEvents[0].messageId).toBe("");
+  });
+});
+
 // Note: Comprehensive Anthropic cache control tests are in cacheStrategy.test.ts
 // Those unit tests cover all cache control functionality without requiring
 // complex setup. StreamManager integrates those functions directly.

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -1929,7 +1929,17 @@ export class StreamManager extends EventEmitter {
     try {
       const streamInfo = this.workspaceStreams.get(typedWorkspaceId);
       if (!streamInfo) {
-        return Ok(undefined); // No active stream
+        // Emit abort event so frontend clears pending stream state.
+        // This handles the case where user interrupts before stream-start arrives.
+        // Use empty messageId - frontend handles gracefully (just clears pendingStreamStartTime).
+        this.emit("stream-abort", {
+          type: "stream-abort",
+          workspaceId,
+          messageId: "",
+          metadata: {},
+          abandonPartial: options?.abandonPartial ?? false,
+        });
+        return Ok(undefined);
       }
 
       const soft = options?.soft ?? false;


### PR DESCRIPTION
## Problem

When user interrupts during the 'starting' phase (before `stream-start` arrives):
1. Frontend sets `pendingStreamStartTime` when user sends message
2. User hits Ctrl+C → `interruptStream` called on backend
3. Backend has no active stream yet → returns success without emitting `stream-abort`
4. Frontend `pendingStreamStartTime` is never cleared
5. UI shows 'starting...' indefinitely (or triggers retry logic after grace period)

## Solution

Emit `stream-abort` with an empty messageId when no stream exists. The frontend already handles this gracefully - it clears `pendingStreamStartTime` unconditionally on `stream-abort`, then looks up the messageId (finding nothing, which is fine).

## Testing

Added unit test verifying `stream-abort` is emitted when stopping a non-existent stream.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$4.20`_