### PR TITLE
🤖 fix: block user-facing fork for SSH/Docker workspaces

### DIFF
--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -1366,6 +1366,16 @@ export class WorkspaceService extends EventEmitter {
         type: "local",
         srcBaseDir: this.config.srcDir,
       };
+
+      // Block fork for remote runtimes - creates broken workspaces
+      // Sub-agent task spawning uses a different code path (TaskService.create)
+      if (isSSHRuntime(sourceRuntimeConfig)) {
+        return Err("Forking SSH workspaces is not supported. Create a new workspace instead.");
+      }
+      if (isDockerRuntime(sourceRuntimeConfig)) {
+        return Err("Forking Docker workspaces is not supported. Create a new workspace instead.");
+      }
+
       const runtime = createRuntime(sourceRuntimeConfig, {
         projectPath: foundProjectPath,
         workspaceName: sourceMetadata.name,


### PR DESCRIPTION
## What
Blocks the user-facing `/fork` command for SSH and Docker workspaces.

## Why
Regression from #1446 which implemented `SSHRuntime.forkWorkspace()` to support sub-agent task spawning. That change unintentionally enabled the user-facing `/fork` command for SSH workspaces, creating broken workspaces that show incorrectly in the UI.

## Changes
- Add check in `WorkspaceService.fork()` to return error for SSH/Docker runtimes
- Sub-agent task spawning continues to work via `TaskService.create()` which uses a different code path

## Regression PR
#1446

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.97`_