### PR TITLE
🤖 fix: clarify MUX_PROJECT_PATH refers to local machine in remote runtimes

### DIFF
--- a/docs/agents/system-prompt.mdx
+++ b/docs/agents/system-prompt.mdx
@@ -96,6 +96,15 @@ function buildEnvironmentContext(workspacePath: string, runtimeType: RuntimeMode
       assertNever(runtimeType, `Unknown runtime type: ${String(runtimeType)}`);
   }
 
+  // Remote runtimes: clarify that MUX_PROJECT_PATH is the user's local path
+  const isRemote = runtimeType === RUNTIME_MODE.SSH || runtimeType === RUNTIME_MODE.DOCKER;
+  if (isRemote) {
+    lines = [
+      ...lines,
+      "- $MUX_PROJECT_PATH refers to the user's local machine, not this environment",
+    ];
+  }
+
   return `
 <environment>
 ${description}

--- a/src/node/services/systemMessage.ts
+++ b/src/node/services/systemMessage.ts
@@ -119,6 +119,15 @@ function buildEnvironmentContext(workspacePath: string, runtimeType: RuntimeMode
       assertNever(runtimeType, `Unknown runtime type: ${String(runtimeType)}`);
   }
 
+  // Remote runtimes: clarify that MUX_PROJECT_PATH is the user's local path
+  const isRemote = runtimeType === RUNTIME_MODE.SSH || runtimeType === RUNTIME_MODE.DOCKER;
+  if (isRemote) {
+    lines = [
+      ...lines,
+      "- $MUX_PROJECT_PATH refers to the user's local machine, not this environment",
+    ];
+  }
+
   return `
 <environment>
 ${description}


### PR DESCRIPTION
SSH and Docker workspaces run in isolated environments but `MUX_PROJECT_PATH` contains the user's local project path. Without this clarification, agents would sometimes cd to parent directories trying to reconcile the conflicting paths they saw in the environment vs the system prompt.

Adds a line to the environment context for remote runtimes:
```
- $MUX_PROJECT_PATH refers to the user's local machine, not this environment
```

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$3.94`_