### PR TITLE
🤖 feat: change '+' button to '+ New Project' in sidebar header

### DIFF
--- a/src/browser/components/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar.tsx
@@ -495,9 +495,10 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                 <button
                   onClick={onAddProject}
                   aria-label="Add project"
-                  className="text-secondary hover:bg-hover hover:border-border-light flex h-6 w-6 cursor-pointer items-center justify-center rounded border border-transparent bg-transparent text-lg leading-none transition-all duration-200"
+                  className="text-secondary hover:bg-hover hover:border-border-light flex h-6 cursor-pointer items-center gap-1 rounded border border-transparent bg-transparent px-1.5 text-xs transition-all duration-200"
                 >
-                  +
+                  <span className="text-base leading-none">+</span>
+                  <span>New Project</span>
                 </button>
               </div>
               <div className="flex-1 overflow-y-auto">


### PR DESCRIPTION
Follow-up to #1662 (logo move) - now that "Projects" text is gone, the "+" button needs clearer labeling.

## Changes
- Change the `+` button next to the Mux logo to show `+ New Project`
- Update styling for the wider button (flex, gap, px padding)

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$2.04`_
