### PR TITLE
🤖 fix: show disabled checkbox with tooltip for outdated Coder CLI

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -611,9 +611,11 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           selectedSectionId,
           onSectionChange: setSelectedSectionId,
           runtimeFieldError,
-          // Pass coderProps when CLI is available, Coder is enabled, or still checking (so "Checking…" UI renders)
+          // Pass coderProps when CLI is available/outdated, Coder is enabled, or still checking (so "Checking…" UI renders)
           coderProps:
-            coderState.coderInfo?.available || coderState.enabled || coderState.coderInfo === null
+            coderState.coderInfo === null ||
+            coderState.enabled ||
+            coderState.coderInfo?.state !== "unavailable"
               ? {
                   enabled: coderState.enabled,
                   onEnabledChange: coderState.setEnabled,

--- a/src/browser/stories/mocks/orpc.ts
+++ b/src/browser/stories/mocks/orpc.ts
@@ -227,7 +227,7 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
     gitInit: customGitInit,
     runtimeAvailability: customRuntimeAvailability,
     signingCapabilities: customSigningCapabilities,
-    coderInfo = { available: false },
+    coderInfo = { state: "unavailable" as const, reason: "missing" as const },
     coderTemplates = [],
     coderPresets = new Map<string, CoderPreset[]>(),
     coderWorkspaces = [],

--- a/src/common/orpc/schemas/coder.ts
+++ b/src/common/orpc/schemas/coder.ts
@@ -23,11 +23,20 @@ export const CoderWorkspaceConfigSchema = z.object({
 
 export type CoderWorkspaceConfig = z.infer<typeof CoderWorkspaceConfigSchema>;
 
-// Coder CLI availability info
-export const CoderInfoSchema = z.object({
-  available: z.boolean(),
-  version: z.string().optional(),
-});
+// Coder CLI unavailable reason - "missing" or error with message
+export const CoderUnavailableReasonSchema = z.union([
+  z.literal("missing"),
+  z.object({ kind: z.literal("error"), message: z.string() }),
+]);
+
+export type CoderUnavailableReason = z.infer<typeof CoderUnavailableReasonSchema>;
+
+// Coder CLI availability info - discriminated union by state
+export const CoderInfoSchema = z.discriminatedUnion("state", [
+  z.object({ state: z.literal("available"), version: z.string() }),
+  z.object({ state: z.literal("outdated"), version: z.string(), minVersion: z.string() }),
+  z.object({ state: z.literal("unavailable"), reason: CoderUnavailableReasonSchema }),
+]);
 
 export type CoderInfo = z.infer<typeof CoderInfoSchema>;
 


### PR DESCRIPTION
When Coder CLI is installed but below minimum version (2.25.0):
- Show disabled checkbox with tooltip explaining version mismatch
- Clear any existing Coder config when CLI becomes unavailable/outdated

**Schema changes:**
- Add `CoderUnavailableReasonSchema`: `"missing" | { kind: "error", message }`
- `CoderInfoSchema` unavailable state now requires `reason` field

**Backend changes:**
- `classifyCoderError()` distinguishes ENOENT/command-not-found → `reason: "missing"` from other errors → `reason: { kind: "error", message }` (sanitized, single-line, 200 char cap)
- Version missing from CLI output returns error reason

**Frontend changes:**
- `useCoderWorkspace` derives `enabled = coderConfig != null && coderInfo?.state === "available"`
- Clears config in fetch handler when CLI unavailable (no useEffect anti-pattern)
- `CoderControls`: outdated shows disabled checkbox with tooltip, unavailable hides checkbox entirely

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high`_
