### PR TITLE
🤖 docs: add Coder runtime documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -63,6 +63,7 @@
                   "runtime/local",
                   "runtime/worktree",
                   "runtime/ssh",
+                  "runtime/coder",
                   "runtime/docker"
                 ]
               },

--- a/docs/runtime/coder.mdx
+++ b/docs/runtime/coder.mdx
@@ -1,0 +1,36 @@
+---
+title: Coder Runtime
+description: Run agents on Coder workspaces
+---
+
+Mux can use [Coder Workspaces](https://coder.com/docs) as SSH hosts. When enabled, Mux talks to the Coder CLI on your local machine to list templates/presets/workspaces and connects over SSH. Connecting to an existing Coder workspace lets multiple Mux workspaces share the same Coder host, which avoids per-workspace provisioning overhead.
+
+## Requirements
+
+- Coder CLI **v2.25.0+** installed on the machine running Mux and logged in to your deployment
+- Access to a Coder template (for new workspaces) or an existing workspace
+- A workspace image with git and your toolchain
+
+## Create a new Coder workspace
+
+1. Choose **SSH** as the runtime and enable **Use Coder Workspace**.
+2. Select **New**.
+3. Pick a template and (if available) a preset.
+4. Mux creates a Coder workspace named `mux-<workspace-name>` (derived from your Mux workspace name), waits for startup scripts, then connects over SSH.
+
+If multiple organizations have templates with the same name, Mux shows the organization name so you can pick the right one.
+
+## Use an existing Coder workspace
+
+1. Choose **Existing**.
+2. Select a workspace from the list (status is shown).
+3. Mux will start the workspace if it is stopped, then connect to `<workspace-name>.coder`.
+
+## SSH setup
+
+Mux runs `coder config-ssh --yes` before connecting, which creates SSH aliases like `<workspace-name>.coder` in `~/.ssh/config`.
+
+## Notes
+
+- If the **Use Coder Workspace** checkbox is missing, verify that the Coder CLI is found on the PATH.
+- Each Mux workspace still lives in its own directory on the remote machine, even when sharing a single Coder workspace.

--- a/docs/runtime/ssh.mdx
+++ b/docs/runtime/ssh.mdx
@@ -79,9 +79,4 @@ Host my-server
 
 ## Coder Workspaces
 
-If you're using [Coder Workspaces](https://coder.com/docs), you can use an existing workspace as a Mux agent host:
-
-1. Run `coder config-ssh`
-2. Use `coder.<workspace-name>` as your SSH host when creating a new Mux workspace
-
-This multiplexes many Mux workspaces onto a single Coder workspace, which avoids per-workspace provisioning overhead.
+If you use [Coder](https://coder.com), see the [Coder runtime](/runtime/coder) page.

--- a/src/node/builtinSkills/mux-docs.md
+++ b/src/node/builtinSkills/mux-docs.md
@@ -68,6 +68,7 @@ Use this index to find a page's:
       - Local Runtime (`/runtime/local`) → `references/docs/runtime/local.mdx` — Run agents directly in your project directory
       - Worktree Runtime (`/runtime/worktree`) → `references/docs/runtime/worktree.mdx` — Isolated git worktree environments for parallel agent work
       - SSH Runtime (`/runtime/ssh`) → `references/docs/runtime/ssh.mdx` — Run agents on remote hosts over SSH for security and performance
+      - Coder Runtime (`/runtime/coder`) → `references/docs/runtime/coder.mdx` — Run agents on Coder workspaces
       - Docker Runtime (`/runtime/docker`) → `references/docs/runtime/docker.mdx` — Run agents in isolated Docker containers
     - **Hooks**
       - Init Hooks (`/hooks/init`) → `references/docs/hooks/init.mdx` — Run setup commands automatically when creating new workspaces


### PR DESCRIPTION
Adds a dedicated documentation page for the Coder runtime integration.

- New `docs/runtime/coder.mdx` page covering requirements, SSH setup, creating new workspaces, and using existing workspaces
- Updates SSH runtime page to link to the new Coder page
- Adds Coder to the navigation in `docs.json`

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.62`_