### PR TITLE
🤖 ci: use gpt-5.2-codex for nightly bench

### DIFF
--- a/.github/workflows/nightly-terminal-bench.yml
+++ b/.github/workflows/nightly-terminal-bench.yml
@@ -47,7 +47,7 @@ jobs:
           INPUT_MODELS: ${{ inputs.models }}
         run: |
           if [ "$INPUT_MODELS" = "all" ] || [ -z "$INPUT_MODELS" ]; then
-            echo 'models=["anthropic/claude-opus-4-5","openai/gpt-5.2"]' >> "$GITHUB_OUTPUT"
+            echo 'models=["anthropic/claude-opus-4-5","openai/gpt-5.2-codex"]' >> "$GITHUB_OUTPUT"
           else
             # Convert comma-separated to JSON array
             models_json=$(echo "$INPUT_MODELS" | jq -R -s -c 'split(",") | map(gsub("^\\s+|\\s+$"; ""))')


### PR DESCRIPTION
Use gpt-5.2-codex instead of naked gpt-5.2 for the nightly terminal-bench workflow.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.10`_
