### PR TITLE
🤖 ci: install chat-components deps for publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -181,9 +181,14 @@ jobs:
 
           echo "Updated package.json to version ${NPM_VERSION}"
 
+      - name: Install chat-components deps
+        working-directory: packages/chat-components
+        run: bun install
+
       - name: Build chat-components package
         working-directory: packages/chat-components
         run: bun run build
+
 
       - name: Check if chat-components version exists
         id: chat-components-check-exists


### PR DESCRIPTION
## Summary
- install `packages/chat-components` dependencies in publish workflow before building

## Testing
- make static-check

---
_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `high` • Cost: `$10.81`_
