### PR TITLE
🤖 fix: remove default MUX_DEBUG_LLM_REQUEST=1 from dev/start targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,15 +142,13 @@ dev: node_modules/.installed build-main ## Start development server (Vite + node
 	# On Windows, use npm run because bunx doesn't correctly pass arguments to concurrently
 	# https://github.com/oven-sh/bun/issues/18275
 	@NODE_OPTIONS="--max-old-space-size=4096" \
-		MUX_DEBUG_LLM_REQUEST=$(or $(MUX_DEBUG_LLM_REQUEST),1) \
 		npm x concurrently -k --raw \
 		"bun x nodemon --watch src --watch tsconfig.main.json --watch tsconfig.json --ext ts,tsx,json --ignore dist --ignore node_modules --exec node scripts/build-main-watch.js" \
 		'npx esbuild src/cli/api.ts $(ESBUILD_CLI_FLAGS) --watch' \
 		"vite"
 else
 dev: node_modules/.installed build-main build-preload ## Start development server (Vite + tsgo watcher for 10x faster type checking)
-	@MUX_DEBUG_LLM_REQUEST=$(or $(MUX_DEBUG_LLM_REQUEST),1) \
-		bun x concurrently -k \
+	@bun x concurrently -k \
 		"bun x concurrently \"$(TSGO) -w -p tsconfig.main.json\" \"bun x tsc-alias -w -p tsconfig.main.json\"" \
 		'bun x esbuild src/cli/api.ts $(ESBUILD_CLI_FLAGS) --watch' \
 		"vite"
@@ -186,9 +184,7 @@ endif
 
 
 start: node_modules/.installed build-main build-preload build-static ## Build and start Electron app
-	@NODE_ENV=development \
-		MUX_DEBUG_LLM_REQUEST=$(or $(MUX_DEBUG_LLM_REQUEST),1) \
-		bunx electron --remote-debugging-port=9222 .
+	@NODE_ENV=development bunx electron --remote-debugging-port=9222 .
 
 ## Build targets (can run in parallel)
 build: node_modules/.installed src/version.ts build-renderer build-main build-preload build-icons build-static ## Build all targets


### PR DESCRIPTION
Removes the default `MUX_DEBUG_LLM_REQUEST=1` from `make dev` and `make start` targets.

This was added in #1698 but causes verbose log spam on every LLM request during normal development.

Developers can still opt-in when needed:
```bash
make start MUX_DEBUG_LLM_REQUEST=1
```

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.31`_
