### PR TITLE
🤖 feat: convert debug LLM request button to /debug-llm-request command

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -50,7 +50,7 @@ import {
   type CommandHandlerContext,
 } from "@/browser/utils/chatCommands";
 import { shouldTriggerAutoCompaction } from "@/browser/utils/compaction/shouldTriggerAutoCompaction";
-import { CUSTOM_EVENTS } from "@/common/constants/events";
+import { CUSTOM_EVENTS, createCustomEvent } from "@/common/constants/events";
 import { findAtMentionAtCursor } from "@/common/utils/atMentions";
 import {
   getSlashCommandSuggestions,
@@ -1425,6 +1425,12 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         if (parsed.type === "mcp-open") {
           setInput("");
           open("projects");
+          return;
+        }
+
+        if (parsed.type === "debug-llm-request") {
+          setInput("");
+          window.dispatchEvent(createCustomEvent(CUSTOM_EVENTS.OPEN_DEBUG_LLM_REQUEST));
           return;
         }
 

--- a/src/browser/components/WorkspaceHeader.tsx
+++ b/src/browser/components/WorkspaceHeader.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { Code2Icon, Pencil, Server } from "lucide-react";
+import { Pencil, Server } from "lucide-react";
+import { CUSTOM_EVENTS } from "@/common/constants/events";
 import { cn } from "@/common/lib/utils";
 import { RIGHT_SIDEBAR_COLLAPSED_KEY } from "@/common/constants/storage";
 import { GitStatusIndicator } from "./GitStatusIndicator";
@@ -91,6 +92,13 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
     return () => clearTimeout(timer);
   }, [startTutorial, isSequenceCompleted]);
 
+  // Listen for /debug-llm-request command to open modal
+  useEffect(() => {
+    const handler = () => setDebugLlmRequestOpen(true);
+    window.addEventListener(CUSTOM_EVENTS.OPEN_DEBUG_LLM_REQUEST, handler);
+    return () => window.removeEventListener(CUSTOM_EVENTS.OPEN_DEBUG_LLM_REQUEST, handler);
+  }, []);
+
   // On Windows/Linux, the native window controls overlay the top-right of the app.
   // When the right sidebar is collapsed (20px), this header stretches underneath
   // those controls and the MCP/editor/terminal buttons become unclickable.
@@ -136,24 +144,6 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
         </div>
       </div>
       <div className={cn("flex items-center gap-2", isDesktop && "titlebar-no-drag")}>
-        {window.api?.debugLlmRequest === true && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => setDebugLlmRequestOpen(true)}
-                className="text-muted hover:text-foreground h-6 w-6 shrink-0"
-                data-testid="workspace-llm-request-button"
-              >
-                <Code2Icon className="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" align="center">
-              Debug: last LLM request
-            </TooltipContent>
-          </Tooltip>
-        )}
         <WorkspaceLinks workspaceId={workspaceId} />
         {editorError && <span className="text-danger-soft text-xs">{editorError}</span>}
         <Tooltip>

--- a/src/browser/utils/slashCommands/registry.ts
+++ b/src/browser/utils/slashCommands/registry.ts
@@ -665,6 +665,13 @@ const idleCommandDefinition: SlashCommandDefinition = {
   },
 };
 
+const debugLlmRequestCommandDefinition: SlashCommandDefinition = {
+  key: "debug-llm-request",
+  description: "Show the last LLM request sent (debug)",
+  appendSpace: false,
+  handler: (): ParsedCommand => ({ type: "debug-llm-request" }),
+};
+
 const mcpCommandDefinition: SlashCommandDefinition = {
   key: "mcp",
   description: "Manage MCP servers for this project",
@@ -709,6 +716,7 @@ export const SLASH_COMMAND_DEFINITIONS: readonly SlashCommandDefinition[] = [
   mcpCommandDefinition,
   idleCommandDefinition,
   initCommandDefinition,
+  debugLlmRequestCommandDefinition,
 ];
 
 export const SLASH_COMMAND_DEFINITION_MAP = new Map(

--- a/src/browser/utils/slashCommands/types.ts
+++ b/src/browser/utils/slashCommands/types.ts
@@ -35,6 +35,7 @@ export type ParsedCommand =
   | { type: "mcp-open" }
   | { type: "plan-show" }
   | { type: "plan-open" }
+  | { type: "debug-llm-request" }
   | { type: "init" }
   | { type: "unknown-command"; command: string; subcommand?: string }
   | { type: "idle-compaction"; hours: number | null }

--- a/src/common/constants/events.ts
+++ b/src/common/constants/events.ts
@@ -74,6 +74,12 @@ export const CUSTOM_EVENTS = {
    * No detail
    */
   TOGGLE_VOICE_INPUT: "mux:toggleVoiceInput",
+
+  /**
+   * Event to open the debug LLM request modal
+   * No detail
+   */
+  OPEN_DEBUG_LLM_REQUEST: "mux:openDebugLlmRequest",
 } as const;
 
 /**
@@ -115,6 +121,7 @@ export interface CustomEventPayloads {
     runtime?: string;
   };
   [CUSTOM_EVENTS.TOGGLE_VOICE_INPUT]: never; // No payload
+  [CUSTOM_EVENTS.OPEN_DEBUG_LLM_REQUEST]: never; // No payload
 }
 
 /**


### PR DESCRIPTION
Convert the Debug LLM Request button in WorkspaceHeader to a slash command to preserve header real-estate.

## Changes

- Remove Debug button from WorkspaceHeader
- Add `/debug-llm-request` slash command to open the debug modal
- Add `OPEN_DEBUG_LLM_REQUEST` custom event for cross-component communication
- Modal functionality unchanged, just triggered via command instead of button

## Usage

Type `/debug-llm-request` in the chat input and press Enter to open the debug modal.

cc @ThomasK33 - this changes the feature you introduced in #1698 by moving access from a header button to a slash command, freeing up header real-estate while preserving the functionality.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$1.44`_
