### PR TITLE
🤖 fix: prevent useTheme crash during AppLoader loading

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -22,7 +22,7 @@ import { useStableReference, compareMaps } from "./hooks/useStableReference";
 import { CommandRegistryProvider, useCommandRegistry } from "./contexts/CommandRegistryContext";
 import { useOpenTerminal } from "./hooks/useOpenTerminal";
 import type { CommandAction } from "./contexts/CommandRegistryContext";
-import { ThemeProvider, useTheme, type ThemeMode } from "./contexts/ThemeContext";
+import { useTheme, type ThemeMode } from "./contexts/ThemeContext";
 import { CommandPalette } from "./components/CommandPalette";
 import { buildCoreSources, type BuildSourcesParams } from "./utils/commands/sources";
 
@@ -770,23 +770,21 @@ function AppInner() {
 
 function App() {
   return (
-    <ThemeProvider>
-      <ExperimentsProvider>
-        <FeatureFlagsProvider>
-          <TooltipProvider delayDuration={200}>
-            <SettingsProvider>
-              <SplashScreenProvider>
-                <TutorialProvider>
-                  <CommandRegistryProvider>
-                    <AppInner />
-                  </CommandRegistryProvider>
-                </TutorialProvider>
-              </SplashScreenProvider>
-            </SettingsProvider>
-          </TooltipProvider>
-        </FeatureFlagsProvider>
-      </ExperimentsProvider>
-    </ThemeProvider>
+    <ExperimentsProvider>
+      <FeatureFlagsProvider>
+        <TooltipProvider delayDuration={200}>
+          <SettingsProvider>
+            <SplashScreenProvider>
+              <TutorialProvider>
+                <CommandRegistryProvider>
+                  <AppInner />
+                </CommandRegistryProvider>
+              </TutorialProvider>
+            </SplashScreenProvider>
+          </SettingsProvider>
+        </TooltipProvider>
+      </FeatureFlagsProvider>
+    </ExperimentsProvider>
   );
 }
 

--- a/src/browser/components/AppLoader.tsx
+++ b/src/browser/components/AppLoader.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import App from "../App";
 import { AuthTokenModal } from "./AuthTokenModal";
+import { ThemeProvider } from "../contexts/ThemeContext";
 import { LoadingScreen } from "./LoadingScreen";
 import { useWorkspaceStoreRaw, workspaceStore } from "../stores/WorkspaceStore";
 import { useGitStatusStoreRaw } from "../stores/GitStatusStore";
@@ -31,15 +32,17 @@ interface AppLoaderProps {
  */
 export function AppLoader(props: AppLoaderProps) {
   return (
-    <APIProvider client={props.client}>
-      <RouterProvider>
-        <ProjectProvider>
-          <WorkspaceProvider>
-            <AppLoaderInner />
-          </WorkspaceProvider>
-        </ProjectProvider>
-      </RouterProvider>
-    </APIProvider>
+    <ThemeProvider>
+      <APIProvider client={props.client}>
+        <RouterProvider>
+          <ProjectProvider>
+            <WorkspaceProvider>
+              <AppLoaderInner />
+            </WorkspaceProvider>
+          </ProjectProvider>
+        </RouterProvider>
+      </APIProvider>
+    </ThemeProvider>
   );
 }
 


### PR DESCRIPTION
Fixes a renderer crash when `useTheme()` is called before `App` mounts its providers (e.g. from `LoadingScreen`).

- Move `ThemeProvider` from `App.tsx` up into `AppLoader` so loading/auth screens are always covered.
- Add a regression test that mocks `LoadingScreen` to call `useTheme()`.
- Add a small `location` shim in bun test preload to keep the unit suite order-independent when some Happy DOM tests attach `window`.

Validation:
- `make static-check`

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh`_
