### PR TITLE
🤖 fix: remove settings tutorial tooltip

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -9,7 +9,6 @@ import {
 } from "../src/common/constants/storage";
 import { NOW } from "../src/browser/stories/mockFactory";
 
-
 const STORYBOOK_FONTS_READY_TIMEOUT_MS = 2500;
 
 let fontsReadyPromise: Promise<void> | null = null;
@@ -46,7 +45,7 @@ function disableTutorials() {
   if (typeof localStorage !== "undefined") {
     const disabledState: TutorialState = {
       disabled: true,
-      completed: { settings: true, creation: true, workspace: true },
+      completed: { creation: true, workspace: true },
     };
     localStorage.setItem(TUTORIAL_STATE_KEY, JSON.stringify(disabledState));
   }

--- a/src/browser/components/SettingsButton.tsx
+++ b/src/browser/components/SettingsButton.tsx
@@ -13,7 +13,6 @@ export function SettingsButton() {
       className="border-border-light text-muted-foreground hover:border-border-medium/80 hover:bg-toggle-bg/70 h-5 w-5 border"
       aria-label="Open settings"
       data-testid="settings-button"
-      data-tutorial="settings-button"
     >
       <Settings className="h-3.5 w-3.5" aria-hidden />
     </Button>

--- a/src/browser/components/TitleBar.tsx
+++ b/src/browser/components/TitleBar.tsx
@@ -6,7 +6,6 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "./ui/tooltip";
 import type { UpdateStatus } from "@/common/orpc/types";
 import { Download, Loader2, RefreshCw } from "lucide-react";
 
-import { useTutorial } from "@/browser/contexts/TutorialContext";
 import { useAPI } from "@/browser/contexts/API";
 import {
   isDesktopMode,
@@ -68,17 +67,6 @@ export function TitleBar() {
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>({ type: "idle" });
   const [isCheckingOnHover, setIsCheckingOnHover] = useState(false);
   const lastHoverCheckTime = useRef<number>(0);
-
-  const { startSequence } = useTutorial();
-
-  // Start settings tutorial on first launch
-  useEffect(() => {
-    // Small delay to ensure UI is rendered before showing tutorial
-    const timer = setTimeout(() => {
-      startSequence("settings");
-    }, 500);
-    return () => clearTimeout(timer);
-  }, [startSequence]);
 
   useEffect(() => {
     // Skip update checks in browser mode - app updates only apply to Electron

--- a/src/browser/components/WorkspaceHeader.tsx
+++ b/src/browser/components/WorkspaceHeader.tsx
@@ -49,7 +49,7 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
   const openInEditor = useOpenInEditor();
   const gitStatus = useGitStatus(workspaceId);
   const { canInterrupt } = useWorkspaceSidebarState(workspaceId);
-  const { startSequence: startTutorial, isSequenceCompleted } = useTutorial();
+  const { startSequence: startTutorial } = useTutorial();
   const [editorError, setEditorError] = useState<string | null>(null);
   const [debugLlmRequestOpen, setDebugLlmRequestOpen] = useState(false);
   const [mcpModalOpen, setMcpModalOpen] = useState(false);
@@ -78,19 +78,14 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
     }
   }, [workspaceId, namedWorkspacePath, openInEditor, runtimeConfig]);
 
-  // Start workspace tutorial on first entry (only if settings tutorial is done)
+  // Start workspace tutorial on first entry
   useEffect(() => {
-    // Don't show workspace tutorial until settings tutorial is completed
-    // This prevents both tutorials from competing on first launch
-    if (!isSequenceCompleted("settings")) {
-      return;
-    }
     // Small delay to ensure UI is rendered
     const timer = setTimeout(() => {
       startTutorial("workspace");
     }, 300);
     return () => clearTimeout(timer);
-  }, [startTutorial, isSequenceCompleted]);
+  }, [startTutorial]);
 
   // Listen for /debug-llm-request command to open modal
   useEffect(() => {

--- a/src/browser/contexts/TutorialContext.tsx
+++ b/src/browser/contexts/TutorialContext.tsx
@@ -10,14 +10,6 @@ import { readPersistedState, updatePersistedState } from "@/browser/hooks/usePer
 
 // Tutorial step definitions for each sequence
 const TUTORIAL_SEQUENCES: Record<TutorialSequence, TutorialStep[]> = {
-  settings: [
-    {
-      target: "settings-button",
-      title: "Settings",
-      content: "Configure providers, models and other settings here.",
-      position: "bottom",
-    },
-  ],
   creation: [
     {
       target: "model-selector",

--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -264,11 +264,11 @@ export const DEFAULT_EDITOR_CONFIG: EditorConfig = {
 
 /**
  * Tutorial state storage key (global)
- * Stores: { disabled: boolean, completed: { settings?: true, creation?: true, workspace?: true } }
+ * Stores: { disabled: boolean, completed: { creation?: true, workspace?: true } }
  */
 export const TUTORIAL_STATE_KEY = "tutorialState";
 
-export type TutorialSequence = "settings" | "creation" | "workspace";
+export type TutorialSequence = "creation" | "workspace";
 
 export interface TutorialState {
   disabled: boolean;


### PR DESCRIPTION
Removes the auto-started settings tutorial tooltip (and its tutorial sequence) so the Settings button no longer triggers an onboarding overlay.

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$0.80`_
