### PR TITLE
🤖 fix: advance onboarding after project add

### DIFF
--- a/src/browser/components/splashScreens/OnboardingWizardSplash.tsx
+++ b/src/browser/components/splashScreens/OnboardingWizardSplash.tsx
@@ -20,7 +20,6 @@ import {
 } from "@/browser/components/icons/RuntimeIcons";
 import { ProjectCreateForm } from "@/browser/components/ProjectCreateModal";
 import { useProjectContext } from "@/browser/contexts/ProjectContext";
-import { useWorkspaceContext } from "@/browser/contexts/WorkspaceContext";
 import { Button } from "@/browser/components/ui/button";
 import { useSettings } from "@/browser/contexts/SettingsContext";
 import { getStoredAuthToken } from "@/browser/components/AuthTokenModal";
@@ -183,7 +182,6 @@ export function OnboardingWizardSplash(props: { onDismiss: () => void }) {
   const { open: openSettings } = useSettings();
   const { config: providersConfig, loading: providersLoading } = useProvidersConfig();
   const { addProject, projects } = useProjectContext();
-  const { beginWorkspaceCreation } = useWorkspaceContext();
 
   const [direction, setDirection] = useState<Direction>("forward");
 
@@ -649,6 +647,8 @@ export function OnboardingWizardSplash(props: { onDismiss: () => void }) {
       ),
     });
 
+    const projectStepIndex = nextSteps.length;
+
     nextSteps.push({
       key: "projects",
       title: "Add your first project",
@@ -676,7 +676,8 @@ export function OnboardingWizardSplash(props: { onDismiss: () => void }) {
               onSuccess={(normalizedPath, projectConfig) => {
                 addProject(normalizedPath, projectConfig);
                 updatePersistedState(getAgentsInitNudgeKey(normalizedPath), true);
-                beginWorkspaceCreation(normalizedPath);
+                setDirection("forward");
+                setStepIndex(projectStepIndex + 1);
               }}
             />
           </div>
@@ -815,7 +816,6 @@ export function OnboardingWizardSplash(props: { onDismiss: () => void }) {
   }, [
     addProject,
     agentPickerShortcut,
-    beginWorkspaceCreation,
     cancelMuxGatewayLogin,
     commandPaletteShortcut,
     configuredProviders.length,


### PR DESCRIPTION
## Summary
- keep the onboarding wizard on the project step instead of navigating into workspace creation
- advance to the next wizard step after a successful project add

## Testing
- `make static-check`

---
_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `xhigh` • Cost: `$0.71`_
