### PR TITLE
🤖 chore: source shared ~/.mux/.envrc from direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -7,3 +7,10 @@ fi
 nix_direnv_manual_reload
 
 use flake .
+
+# Optional: shared per-user env vars for all mux worktrees
+MUX_SHARED_ENVRC="$HOME/.mux/.envrc"
+if [[ -f "$MUX_SHARED_ENVRC" ]]; then
+  # source_env() also calls watch_file(), so edits trigger direnv reloads.
+  source_env "$MUX_SHARED_ENVRC"
+fi


### PR DESCRIPTION
This adds an optional `source_env` include to the repo `.envrc` so you can keep shared environment variables in `~/.mux/.envrc` and have them apply across all mux worktrees.

- Only loads if the file exists.
- Uses `source_env`, which also `watch_file`s the shared file so changes trigger `direnv reload` automatically.

Validation:
- `make static-check`

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: shared env vars via ~/.mux/.envrc

**Targets**
- Repo root: `.envrc` (direnv + nix-direnv)
- Shared user file: `~/.mux/.envrc` (not committed; holds env exports)

**Net LoC (repo):** ~+3–6

---

## 1) Update repo <code>.envrc</code> to optionally source <code>~/.mux/.envrc</code>
1. Keep the existing nix-direnv bootstrap intact.
2. After `use flake .`, add:

```bash
# Optional: shared per-user env vars for all mux worktrees
MUX_SHARED_ENVRC="$HOME/.mux/.envrc"
if [[ -f "$MUX_SHARED_ENVRC" ]]; then
  # source_env() also calls watch_file(), so edits trigger direnv reloads.
  source_env "$MUX_SHARED_ENVRC"
fi
```

This stays **direnv-scoped**: vars only apply while you’re inside an allowed worktree.

---

## 2) Put env vars into <code>~/.mux/.envrc</code>
Add plain bash exports, e.g.:

```bash
export OPENAI_API_KEY="..."
export ANTHROPIC_API_KEY="..."
```

---

## 3) Validation
- In the repo: `direnv reload`
- Confirm vars are set: `echo "$OPENAI_API_KEY"` (or `env | grep OPENAI_API_KEY`) 

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: $1.50_
