### PR TITLE
🤖 fix: suppress tutorial tooltips during splash screens

### DIFF
--- a/src/browser/components/splashScreens/SplashScreenProvider.tsx
+++ b/src/browser/components/splashScreens/SplashScreenProvider.tsx
@@ -1,6 +1,19 @@
-import React, { useState, useCallback, useEffect, type ReactNode } from "react";
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  type ReactNode,
+} from "react";
 import { SPLASH_REGISTRY, DISABLE_SPLASH_SCREENS, type SplashConfig } from "./index";
 import { useAPI } from "@/browser/contexts/API";
+
+const SplashScreenActiveContext = createContext(false);
+
+export function useIsSplashScreenActive(): boolean {
+  return useContext(SplashScreenActiveContext);
+}
 
 export function SplashScreenProvider({ children }: { children: ReactNode }) {
   const { api } = useAPI();
@@ -55,15 +68,12 @@ export function SplashScreenProvider({ children }: { children: ReactNode }) {
     setQueue((q) => q.slice(1));
   }, [currentSplash, api]);
 
-  // Don't render splash until we've loaded the viewed state
-  if (!loaded) {
-    return <>{children}</>;
-  }
+  const isSplashScreenActive = loaded && currentSplash !== null;
 
   return (
-    <>
+    <SplashScreenActiveContext.Provider value={isSplashScreenActive}>
       {children}
-      {currentSplash && <currentSplash.component onDismiss={() => void dismiss()} />}
-    </>
+      {loaded && currentSplash && <currentSplash.component onDismiss={() => void dismiss()} />}
+    </SplashScreenActiveContext.Provider>
   );
 }

--- a/src/browser/contexts/TutorialContext.tsx
+++ b/src/browser/contexts/TutorialContext.tsx
@@ -6,6 +6,7 @@ import {
   type TutorialState,
   type TutorialSequence,
 } from "@/common/constants/storage";
+import { useIsSplashScreenActive } from "@/browser/components/splashScreens/SplashScreenProvider";
 import { readPersistedState, updatePersistedState } from "@/browser/hooks/usePersistedState";
 
 // Tutorial step definitions for each sequence
@@ -73,6 +74,7 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
   const [tutorialState, setTutorialState] = useState<TutorialState>(() =>
     readPersistedState(TUTORIAL_STATE_KEY, DEFAULT_TUTORIAL_STATE)
   );
+  const isSplashScreenActive = useIsSplashScreenActive();
   const [activeSequence, setActiveSequence] = useState<TutorialSequence | null>(null);
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
 
@@ -158,7 +160,7 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
   return (
     <TutorialContext.Provider value={contextValue}>
       {children}
-      {currentStep && activeSteps && (
+      {!isSplashScreenActive && currentStep && activeSteps && (
         <TutorialTooltip
           step={currentStep}
           currentStep={currentStepIndex + 1}


### PR DESCRIPTION
When a splash screen (e.g. onboarding wizard) is active, tutorial tooltips can render above it due to their high z-index.

This change exposes a lightweight `useIsSplashScreenActive()` context from `SplashScreenProvider` and gates `TutorialProvider`'s tooltip rendering while a splash is open.

Validation:
- `make static-check`

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$N/A`_
