### PR TITLE
🤖 fix: pad right sidebar tab strip

### DIFF
--- a/src/browser/components/RightSidebar/RightSidebarTabStrip.tsx
+++ b/src/browser/components/RightSidebar/RightSidebarTabStrip.tsx
@@ -144,8 +144,8 @@ export const RightSidebarTabStrip: React.FC<RightSidebarTabStripProps> = ({
     <div
       ref={setNodeRef}
       className={cn(
-        "border-border-light flex min-w-0 items-center border-b px-2 transition-colors",
-        isDesktop ? DESKTOP_TITLEBAR_MIN_HEIGHT_CLASS : "py-1.5",
+        "border-border-light flex min-w-0 items-center border-b px-2 py-1.5 transition-colors",
+        isDesktop && DESKTOP_TITLEBAR_MIN_HEIGHT_CLASS,
         showDropHighlight && "bg-accent/30",
         isDraggingFromHere && "bg-accent/10",
         // In desktop mode, make header draggable for window movement


### PR DESCRIPTION
## Summary
- keep RightSidebar tab strip padding even when tabs wrap in desktop mode

## Testing
- make static-check

---
_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `xhigh` • Cost: `$0.32`_
