### PR TITLE
🤖 ci: generate npm shrinkwrap for published package

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -254,6 +254,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/setup-mux
+      - run: ./scripts/generate-npm-shrinkwrap.sh
       - run: make build
       - run: npm pack
       - env:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Generate version file
         run: ./scripts/generate-version.sh
 
+      - name: Generate npm shrinkwrap
+        run: ./scripts/generate-npm-shrinkwrap.sh
+
       - name: Build application
         run: make build
 

--- a/package.json
+++ b/package.json
@@ -237,6 +237,7 @@
     "dist/**/*.png",
     "dist/assets/**/*",
     "scripts/postinstall.sh",
+    "npm-shrinkwrap.json",
     "README.md",
     "LICENSE"
   ],

--- a/scripts/generate-npm-shrinkwrap.sh
+++ b/scripts/generate-npm-shrinkwrap.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Generate npm-shrinkwrap.json for the root mux package.
+# We rely on npm's resolver and only include production dependencies.
+
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+cd "$ROOT_DIR"
+
+echo "Generating npm-shrinkwrap.json (production dependencies only)..."
+
+rm -f package-lock.json npm-shrinkwrap.json
+
+npm install --package-lock-only --omit=dev --ignore-scripts --no-audit --no-fund --legacy-peer-deps
+
+if [[ ! -f package-lock.json ]]; then
+  echo "package-lock.json was not generated." >&2
+  exit 1
+fi
+
+cp package-lock.json npm-shrinkwrap.json
+rm -f package-lock.json
+
+if [[ ! -f npm-shrinkwrap.json ]]; then
+  echo "npm-shrinkwrap.json was not generated." >&2
+  exit 1
+fi
+
+echo "Generated npm-shrinkwrap.json"


### PR DESCRIPTION
## Summary
- add a script to generate npm-shrinkwrap.json for prod dependencies
- run shrinkwrap generation before packing in publish/PR smoke workflows
- include npm-shrinkwrap.json in the npm package files list

## Testing
- make typecheck
- make static-check

---
_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `xhigh` • Cost: `$0.37`_
