### PR TITLE
🤖 fix: recover from lost OpenAI previousResponseId

### DIFF
--- a/tests/ipc/openaiPreviousResponseIdRecovery.test.ts
+++ b/tests/ipc/openaiPreviousResponseIdRecovery.test.ts
@@ -2,7 +2,7 @@
  * OpenAI previousResponseId recovery integration test.
  *
  * This simulates a corrupted previousResponseId and verifies the runtime
- * records it as lost so subsequent requests recover successfully.
+ * retries the request without it so the first request succeeds.
  */
 
 import { randomBytes } from "crypto";
@@ -36,7 +36,7 @@ describeIntegration("OpenAI previousResponseId recovery", () => {
   configureTestRetries(3);
 
   test.concurrent(
-    "filters invalid previousResponseId after OpenAI rejects it",
+    "recovers from invalid previousResponseId on the first request",
     async () => {
       const { env, workspaceId, cleanup } = await setupWorkspace("openai");
 
@@ -64,26 +64,10 @@ describeIntegration("OpenAI previousResponseId recovery", () => {
         });
         expect(replaceResult.success).toBe(true);
 
-        const errorCollector = createStreamCollector(env.orpc, workspaceId);
-        errorCollector.start();
+        const streamCollector = createStreamCollector(env.orpc, workspaceId);
+        streamCollector.start();
 
-        const errorResult = await sendMessageWithModel(env, workspaceId, "Say OK.", OPENAI_MODEL, {
-          thinkingLevel: "medium",
-          toolPolicy: DISABLE_TOOLS,
-        });
-        expect(errorResult.success).toBe(true);
-
-        const errorEvent = await errorCollector.waitForEvent("stream-error", 60000);
-        expect(errorEvent).toBeDefined();
-        if (errorEvent?.type === "stream-error") {
-          expect(errorEvent.error).toContain(invalidResponseId);
-        }
-        errorCollector.stop();
-
-        const recoveryCollector = createStreamCollector(env.orpc, workspaceId);
-        recoveryCollector.start();
-
-        const recoveryResult = await sendMessageWithModel(
+        const result = await sendMessageWithModel(
           env,
           workspaceId,
           "Respond with DONE.",
@@ -93,17 +77,17 @@ describeIntegration("OpenAI previousResponseId recovery", () => {
             toolPolicy: DISABLE_TOOLS,
           }
         );
-        expect(recoveryResult.success).toBe(true);
+        expect(result.success).toBe(true);
 
-        const recoveryEnd = await recoveryCollector.waitForEvent("stream-end", 60000);
-        expect(recoveryEnd).toBeDefined();
+        const streamEnd = await streamCollector.waitForEvent("stream-end", 60000);
+        expect(streamEnd).toBeDefined();
 
-        const recoveryErrors = recoveryCollector
+        const streamErrors = streamCollector
           .getEvents()
           .filter((event) => "type" in event && event.type === "stream-error");
-        expect(recoveryErrors.length).toBe(0);
+        expect(streamErrors.length).toBe(0);
 
-        recoveryCollector.stop();
+        streamCollector.stop();
       } finally {
         await cleanup();
       }


### PR DESCRIPTION
## Summary
- capture OpenAI error codes/status from Error.cause when tracking lost previousResponseIds
- add an IPC integration test that corrupts the previousResponseId and verifies recovery on the next request

## Testing
- make static-check
- TEST_INTEGRATION=1 bun x jest tests/ipc/openaiPreviousResponseIdRecovery.test.ts

---
_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `xhigh` • Cost: `$7.36`_
