### PR TITLE
🤖 ci: inherit secrets for nightly terminal-bench

### DIFF
--- a/.github/workflows/nightly-terminal-bench.yml
+++ b/.github/workflows/nightly-terminal-bench.yml
@@ -29,10 +29,7 @@ jobs:
       concurrency: "1"
       task_names: "chess-best-move"
       experiments: ${{ inputs.experiments }}
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+    secrets: inherit
 
   determine-models:
     name: Determine models to test
@@ -71,7 +68,4 @@ jobs:
       concurrency: "48"
       env: "daytona"
       experiments: ${{ inputs.experiments }}
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- pass secrets through the nightly terminal-bench reusable workflow via `secrets: inherit`
- ensure the BigQuery upload step can read `GCP_SA_KEY` without extra wiring

## Why
- reusable workflows do not inherit secrets by default, so the nightly run was skipping BQ uploads

## Testing
- make typecheck

---
_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `xhigh` • Cost: `$0.61`_
