### PR TITLE
🤖 feat: view output for background bash tasks

### DIFF
--- a/src/browser/components/BackgroundBashOutputDialog.tsx
+++ b/src/browser/components/BackgroundBashOutputDialog.tsx
@@ -1,0 +1,154 @@
+import React, { useEffect, useState } from "react";
+import { CopyButton } from "./ui/CopyButton";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./ui/dialog";
+import { DetailContent } from "./tools/shared/ToolPrimitives";
+import { useAPI } from "@/browser/contexts/API";
+import {
+  appendLiveBashOutputChunk,
+  type LiveBashOutputInternal,
+} from "@/browser/utils/messages/liveBashOutputBuffer";
+import { BASH_TRUNCATE_MAX_TOTAL_BYTES } from "@/common/constants/toolLimits";
+
+const BACKGROUND_BASH_INITIAL_TAIL_BYTES = 64_000;
+const BACKGROUND_BASH_POLL_INTERVAL_MS = 500;
+
+interface BackgroundBashOutputDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  workspaceId: string;
+  processId: string;
+  displayName?: string;
+}
+
+export const BackgroundBashOutputDialog: React.FC<BackgroundBashOutputDialogProps> = (props) => (
+  <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+    <DialogContent className="max-h-[80vh] max-w-4xl overflow-hidden">
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2">
+          <span className="font-mono text-sm">{props.displayName ?? props.processId}</span>
+          {props.displayName && (
+            <code className="rounded bg-[var(--color-bg-tertiary)] px-1.5 py-0.5 font-mono text-[10px]">
+              {props.processId}
+            </code>
+          )}
+        </DialogTitle>
+      </DialogHeader>
+
+      <BackgroundBashOutputViewer workspaceId={props.workspaceId} processId={props.processId} />
+    </DialogContent>
+  </Dialog>
+);
+
+const BackgroundBashOutputViewer: React.FC<{ workspaceId: string; processId: string }> = (
+  props
+) => {
+  const { api } = useAPI();
+
+  const [output, setOutput] = useState<LiveBashOutputInternal | undefined>(undefined);
+  const [status, setStatus] = useState<"running" | "exited" | "killed" | "failed">("running");
+  const [truncatedStart, setTruncatedStart] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    setOutput(undefined);
+    setStatus("running");
+    setTruncatedStart(false);
+    setError(null);
+    setIsLoading(true);
+
+    if (!api) {
+      setIsLoading(false);
+      setError("API unavailable");
+      return;
+    }
+
+    let cancelled = false;
+
+    const run = async () => {
+      let offset: number | undefined = undefined;
+
+      while (!cancelled) {
+        const result = await api.workspace.backgroundBashes.getOutput(
+          offset === undefined
+            ? {
+                workspaceId: props.workspaceId,
+                processId: props.processId,
+                tailBytes: BACKGROUND_BASH_INITIAL_TAIL_BYTES,
+              }
+            : {
+                workspaceId: props.workspaceId,
+                processId: props.processId,
+                fromOffset: offset,
+              }
+        );
+
+        if (cancelled) return;
+
+        setIsLoading(false);
+
+        if (!result.success) {
+          setError(result.error);
+          return;
+        }
+
+        setStatus(result.data.status);
+        if (result.data.truncatedStart) {
+          setTruncatedStart(true);
+        }
+
+        offset = result.data.nextOffset;
+
+        if (result.data.output.length > 0) {
+          setOutput((prev) =>
+            appendLiveBashOutputChunk(
+              prev,
+              { text: result.data.output, isError: false },
+              BASH_TRUNCATE_MAX_TOTAL_BYTES
+            )
+          );
+        }
+
+        if (result.data.status !== "running") {
+          return;
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, BACKGROUND_BASH_POLL_INTERVAL_MS));
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [api, props.processId, props.workspaceId]);
+
+  const text = output?.combined ?? "";
+  const isTruncatedToMaxBytes = output?.truncated ?? false;
+
+  return (
+    <div className="flex min-h-0 flex-col gap-2 overflow-hidden">
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-muted font-mono text-[11px]">status: {status}</div>
+        <CopyButton text={text} className="h-6" />
+      </div>
+
+      {truncatedStart && (
+        <div className="text-muted text-[10px] italic">
+          Showing last {Math.round(BACKGROUND_BASH_INITIAL_TAIL_BYTES / 1000)}KB
+        </div>
+      )}
+
+      {isTruncatedToMaxBytes && (
+        <div className="text-muted text-[10px] italic">Output truncated (showing last ~1MB)</div>
+      )}
+
+      {error && <div className="text-error text-[11px]">{error}</div>}
+
+      <DetailContent className="max-h-[60vh] min-h-[200px] px-2 py-1.5">
+        {isLoading ? "Loading…" : text.length > 0 ? text : error ? "" : "No output yet"}
+      </DetailContent>
+    </div>
+  );
+};

--- a/src/browser/components/BackgroundProcessesBanner.tsx
+++ b/src/browser/components/BackgroundProcessesBanner.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useCallback, useEffect } from "react";
-import { Terminal, X, ChevronDown, ChevronRight, Loader2 } from "lucide-react";
+import { Terminal, X, ChevronDown, ChevronRight, Loader2, FileText } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "./ui/tooltip";
 import { cn } from "@/common/lib/utils";
+import { BackgroundBashOutputDialog } from "./BackgroundBashOutputDialog";
 import { formatDuration } from "./tools/shared/toolUtils";
 import {
   useBackgroundBashTerminatingIds,
@@ -30,6 +31,7 @@ interface BackgroundProcessesBannerProps {
  * Displays "N running bashes" which expands on click to show details.
  */
 export const BackgroundProcessesBanner: React.FC<BackgroundProcessesBannerProps> = (props) => {
+  const [viewingProcessId, setViewingProcessId] = useState<string | null>(null);
   const [isExpanded, setIsExpanded] = useState(false);
   const [, setTick] = useState(0);
   const processes = useBackgroundProcesses(props.workspaceId);
@@ -38,6 +40,7 @@ export const BackgroundProcessesBanner: React.FC<BackgroundProcessesBannerProps>
 
   // Filter to only running processes
   const runningProcesses = processes.filter((p) => p.status === "running");
+  const viewingProcess = processes.find((p) => p.id === viewingProcessId) ?? null;
   const count = runningProcesses.length;
 
   // Update duration display every second when expanded
@@ -46,6 +49,11 @@ export const BackgroundProcessesBanner: React.FC<BackgroundProcessesBannerProps>
     const interval = setInterval(() => setTick((t) => t + 1), 1000);
     return () => clearInterval(interval);
   }, [isExpanded, count]);
+
+  const handleViewOutput = useCallback((processId: string, event: React.MouseEvent) => {
+    event.stopPropagation();
+    setViewingProcessId(processId);
+  }, []);
 
   const handleTerminate = useCallback(
     (processId: string, event: React.MouseEvent) => {
@@ -59,84 +67,121 @@ export const BackgroundProcessesBanner: React.FC<BackgroundProcessesBannerProps>
     setIsExpanded((prev) => !prev);
   }, []);
 
-  // Don't render if no running processes
-  if (count === 0) {
+  // Don't render if no running processes and no dialog open.
+  if (count === 0 && !viewingProcessId) {
     return null;
   }
 
   return (
-    <div className="border-border bg-dark border-t px-[15px]">
-      {/* Collapsed banner - thin stripe, content aligned with chat */}
-      <button
-        type="button"
-        onClick={handleToggle}
-        className="group mx-auto flex w-full max-w-4xl items-center gap-2 px-2 py-1 text-xs transition-colors"
-      >
-        <Terminal className="text-muted group-hover:text-secondary size-3.5 transition-colors" />
-        <span className="text-muted group-hover:text-secondary transition-colors">
-          <span className="font-medium">{count}</span>
-          {" background bash"}
-          {count !== 1 && "es"}
-        </span>
-        <div className="ml-auto">
-          {isExpanded ? (
-            <ChevronDown className="text-muted group-hover:text-secondary size-3.5 transition-colors" />
-          ) : (
-            <ChevronRight className="text-muted group-hover:text-secondary size-3.5 transition-colors" />
+    <>
+      {count > 0 && (
+        <div className="border-border bg-dark border-t px-[15px]">
+          {/* Collapsed banner - thin stripe, content aligned with chat */}
+          <button
+            type="button"
+            onClick={handleToggle}
+            className="group mx-auto flex w-full max-w-4xl items-center gap-2 px-2 py-1 text-xs transition-colors"
+          >
+            <Terminal className="text-muted group-hover:text-secondary size-3.5 transition-colors" />
+            <span className="text-muted group-hover:text-secondary transition-colors">
+              <span className="font-medium">{count}</span>
+              {" background bash"}
+              {count !== 1 && "es"}
+            </span>
+            <div className="ml-auto">
+              {isExpanded ? (
+                <ChevronDown className="text-muted group-hover:text-secondary size-3.5 transition-colors" />
+              ) : (
+                <ChevronRight className="text-muted group-hover:text-secondary size-3.5 transition-colors" />
+              )}
+            </div>
+          </button>
+
+          {/* Expanded view - content aligned with chat */}
+          {isExpanded && (
+            <div className="border-border mx-auto max-h-48 max-w-4xl space-y-1.5 overflow-y-auto border-t py-2">
+              {runningProcesses.map((proc) => {
+                const isTerminating = terminatingIds.has(proc.id);
+                return (
+                  <div
+                    key={proc.id}
+                    className={cn(
+                      "hover:bg-hover flex items-center justify-between gap-3 rounded px-2 py-1.5",
+                      "transition-colors",
+                      isTerminating && "pointer-events-none opacity-50"
+                    )}
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div
+                        className="text-foreground truncate font-mono text-xs"
+                        title={proc.script}
+                      >
+                        {proc.displayName ?? truncateScript(proc.script)}
+                      </div>
+                      <div className="text-muted font-mono text-[10px]">pid {proc.pid}</div>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-2">
+                      <span className="text-muted text-[10px]">
+                        {formatDuration(Date.now() - proc.startTime)}
+                      </span>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            disabled={isTerminating}
+                            onClick={(e) => handleViewOutput(proc.id, e)}
+                            className={cn(
+                              "text-muted hover:text-secondary rounded p-1 transition-colors",
+                              isTerminating && "cursor-not-allowed"
+                            )}
+                          >
+                            <FileText size={14} />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent>View output</TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            disabled={isTerminating}
+                            onClick={(e) => handleTerminate(proc.id, e)}
+                            className={cn(
+                              "text-muted hover:text-error rounded p-1 transition-colors",
+                              isTerminating && "cursor-not-allowed"
+                            )}
+                          >
+                            {isTerminating ? (
+                              <Loader2 size={14} className="animate-spin" />
+                            ) : (
+                              <X size={14} />
+                            )}
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent>Terminate process</TooltipContent>
+                      </Tooltip>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
           )}
         </div>
-      </button>
-
-      {/* Expanded view - content aligned with chat */}
-      {isExpanded && (
-        <div className="border-border mx-auto max-h-48 max-w-4xl space-y-1.5 overflow-y-auto border-t py-2">
-          {runningProcesses.map((proc) => {
-            const isTerminating = terminatingIds.has(proc.id);
-            return (
-              <div
-                key={proc.id}
-                className={cn(
-                  "hover:bg-hover flex items-center justify-between gap-3 rounded px-2 py-1.5",
-                  "transition-colors",
-                  isTerminating && "pointer-events-none opacity-50"
-                )}
-              >
-                <div className="min-w-0 flex-1">
-                  <div className="text-foreground truncate font-mono text-xs" title={proc.script}>
-                    {proc.displayName ?? truncateScript(proc.script)}
-                  </div>
-                  <div className="text-muted font-mono text-[10px]">pid {proc.pid}</div>
-                </div>
-                <div className="flex shrink-0 items-center gap-2">
-                  <span className="text-muted text-[10px]">
-                    {formatDuration(Date.now() - proc.startTime)}
-                  </span>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        disabled={isTerminating}
-                        onClick={(e) => handleTerminate(proc.id, e)}
-                        className={cn(
-                          "text-muted hover:text-error rounded p-1 transition-colors",
-                          isTerminating && "cursor-not-allowed"
-                        )}
-                      >
-                        {isTerminating ? (
-                          <Loader2 size={14} className="animate-spin" />
-                        ) : (
-                          <X size={14} />
-                        )}
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent>Terminate process</TooltipContent>
-                  </Tooltip>
-                </div>
-              </div>
-            );
-          })}
-        </div>
       )}
-    </div>
+
+      {viewingProcessId && (
+        <BackgroundBashOutputDialog
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) {
+              setViewingProcessId(null);
+            }
+          }}
+          workspaceId={props.workspaceId}
+          processId={viewingProcessId}
+          displayName={viewingProcess?.displayName}
+        />
+      )}
+    </>
   );
 };

--- a/src/browser/stories/mocks/orpc.ts
+++ b/src/browser/stories/mocks/orpc.ts
@@ -643,6 +643,11 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
           await new Promise<void>(() => undefined);
         },
         terminate: () => Promise.resolve({ success: true, data: undefined }),
+        getOutput: () =>
+          Promise.resolve({
+            success: true,
+            data: { status: "running" as const, output: "", nextOffset: 0, truncatedStart: false },
+          }),
         sendToBackground: () => Promise.resolve({ success: true, data: undefined }),
       },
       stats: {

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -589,6 +589,26 @@ export const workspace = {
       input: z.object({ workspaceId: z.string(), toolCallId: z.string() }),
       output: ResultSchema(z.void(), z.string()),
     },
+    /**
+     * Peek output for a background bash process without consuming the bash_output cursor.
+     */
+    getOutput: {
+      input: z.object({
+        workspaceId: z.string(),
+        processId: z.string(),
+        fromOffset: z.number().int().nonnegative().optional(),
+        tailBytes: z.number().int().positive().max(1_000_000).optional(),
+      }),
+      output: ResultSchema(
+        z.object({
+          status: z.enum(["running", "exited", "killed", "failed"]),
+          output: z.string(),
+          nextOffset: z.number().int().nonnegative(),
+          truncatedStart: z.boolean(),
+        }),
+        z.string()
+      ),
+    },
   },
   /**
    * Get post-compaction context state for a workspace.

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -1524,6 +1524,20 @@ export const router = (authToken?: string) => {
             }
             return { success: true, data: undefined };
           }),
+        getOutput: t
+          .input(schemas.workspace.backgroundBashes.getOutput.input)
+          .output(schemas.workspace.backgroundBashes.getOutput.output)
+          .handler(async ({ context, input }) => {
+            const result = await context.workspaceService.getBackgroundProcessOutput(
+              input.workspaceId,
+              input.processId,
+              { fromOffset: input.fromOffset, tailBytes: input.tailBytes }
+            );
+            if (!result.success) {
+              return { success: false, error: result.error };
+            }
+            return { success: true, data: result.data };
+          }),
       },
       getPostCompactionState: t
         .input(schemas.workspace.getPostCompactionState.input)

--- a/src/node/runtime/Runtime.ts
+++ b/src/node/runtime/Runtime.ts
@@ -103,6 +103,12 @@ export interface BackgroundHandle {
   writeMeta(metaJson: string): Promise<void>;
 
   /**
+   * Get the current size of output.log in bytes.
+   * Used to tail output without reading the entire file.
+   */
+  getOutputFileSize(): Promise<number>;
+
+  /**
    * Read output from output.log at the given byte offset.
    * Returns the content read and the new offset (for incremental reads).
    * Works on both local and SSH runtimes by using runtime.exec() internally.


### PR DESCRIPTION
## Summary
- Adds a **View output** action for running background bash processes (from both the Background Processes banner and backgrounded bash tool calls).
- Opens a small log viewer that **polls incrementally** and keeps output bounded (reuses the existing ~1MB truncation behavior).

## Implementation notes
- New ORPC endpoint `workspace.backgroundBashes.getOutput` lets the UI **peek** background `output.log` without consuming the agent cursor (`bash_output` / `task_await`).
- Backend supports an initial **tail** read (default ~64KB) and subsequent reads by byte offset.

## Testing
- `make static-check`

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Show buffered output for backgrounded bash tasks

## Goal
When a `bash` tool call is running **in the background** (`run_in_background: true` or foreground→background), let the user inspect the **accumulated stdout/stderr so far** in the UI (similar to the foreground `BashToolCall` output view).

UX target:
- From the **BackgroundProcessesBanner** row and from the **BashToolCall** card, the user can **click** a background process to open a small log viewer (popover or modal).
- While open, the log viewer can **incrementally update** (poll) until the process exits.
- Output display is **bounded** (e.g. keep last ~1MB like `liveBashOutputBuffer`).

Non-goals (initial cut):
- Persistence across app restart.
- Separate stdout vs stderr streams (background output is already merged into `output.log`).

---

## Implementation (chosen): On-demand popover log viewer + new ORPC endpoint (net +250–450 LoC)

### Backend: expose “peek” output without consuming the tool cursor
**Why:** `BackgroundProcessManager.getOutput()` mutates `proc.outputBytesRead` (used by `bash_output` / `task_await`). The UI must not advance that cursor or the agent will miss output.

Implement a separate read path that:
- reads `output.log` at a caller-provided byte offset
- returns `{ chunk, nextOffset, status }`
- does **not** mutate `proc.outputBytesRead` or `proc.incompleteLineBuffer`

Concrete steps:
1. **ORPC schema**
   - Add `workspace.backgroundBashes.getOutput`:
     - input: `{ workspaceId, processId, fromOffset?: number, tailBytes?: number }`
       - if `fromOffset` is omitted, treat as “initial open” and return a tail chunk (default `tailBytes = 64_000`).
     - output: `{ success, data?: { status, output, nextOffset, truncatedStart }, error? }`
       - `truncatedStart: boolean` indicates we started from a non-zero offset.

2. **router + workspaceService**
   - Add router handler for `backgroundBashes.getOutput`.
   - Add `WorkspaceService.getBackgroundProcessOutput(...)` that:
     - verifies process exists and belongs to `workspaceId` (same pattern as `terminateBackgroundProcess`).
     - delegates to the manager.

3. **backgroundProcessManager**
   - Add `readOutput(processId, { fromOffset?: number; tailBytes?: number })`.
   - Implementation notes:
     - use `getProcess(processId)` to refresh status/exitCode.
     - if `fromOffset` is provided: `proc.handle.readOutput(fromOffset)`.
     - else: compute a start offset for “tail” and read from there.
     - **Important:** do not touch `proc.outputBytesRead`.

4. **BackgroundHandle support for tail**
   `BackgroundHandle.readOutput(offset)` reads “offset → EOF”; for initial open we want “EOF - N → EOF”.

   Preferred implementation:
   - Extend `BackgroundHandle` with `getOutputFileSize(): Promise<number>`.
   - Implement cross-platform size lookup in handles:
     - try `stat -c%s`, fallback to `stat -f%z`, fallback to `wc -c`.
   - In manager: `startOffset = Math.max(0, size - tailBytes)`.

5. Defensive guardrails
   - Assert non-negative offsets.
   - Clamp `tailBytes` to a sane max (e.g. 1MB).
   - If the log file doesn’t exist yet: return empty output.

### Renderer: reusable BackgroundBashOutputViewer (popover or modal)
1. Add a component that:
   - takes `{ workspaceId, processId, displayName? }`
   - calls `api.workspace.backgroundBashes.getOutput()`
   - maintains local state:
     - `offset` cursor (starts `undefined` to trigger the initial tail fetch)
     - `buffer` (append chunks; keep last ~1MB)
     - `truncatedStart` + `bufferTruncated`
     - `status` (`running|exited|killed|failed`)

2. Polling (only while viewer is open)
   - While open and running, poll ~every 500ms:
     - `getOutput({ fromOffset: offset })`
     - append + update offset
   - Stop polling when closed or when status != running.

3. UI integration
   - **BackgroundProcessesBanner** (`src/browser/components/BackgroundProcessesBanner.tsx`)
     - Add a “View output” icon button per row (next to terminate).
     - Clicking opens a `Popover` (or `Dialog`) that renders the viewer.
   - **BashToolCall** (`src/browser/components/tools/BashToolCall.tsx`)
     - When `"backgroundProcessId" in result`, add an inline “View output” action.

4. Display details
   - Render output using the same monospace primitives as tool calls (`DetailContent` / `OutputSection`).
   - Show small notes when:
     - `truncatedStart` (e.g., “Showing last 64KB”).
     - buffer truncates (“Showing last ~1MB”).
   - Optional: “Copy output” button.

### Validation
- Unit test pure logic:
  - tail start offset calculation + buffer truncation.
- Optional lightweight integration test if it’s easy to hook up:
  - spawn a background bash that prints lines with delays and verify the ORPC call returns incremental output.



</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: openai:gpt-5.2 • Thinking: xhigh • Cost: $9.12_
