### PR TITLE
🤖 feat: render user messages as markdown

### DIFF
--- a/src/browser/components/Messages/UserMessageContent.tsx
+++ b/src/browser/components/Messages/UserMessageContent.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { ReviewNoteDataForDisplay } from "@/common/types/message";
 import type { ImagePart } from "@/common/orpc/schemas";
 import { ReviewBlockFromData } from "../shared/ReviewBlock";
+import { MarkdownRenderer } from "./MarkdownRenderer";
 
 interface UserMessageContentProps {
   content: string;
@@ -11,10 +12,24 @@ interface UserMessageContentProps {
   variant: "sent" | "queued";
 }
 
-const textStyles = {
-  sent: "font-primary m-0 leading-6 break-words whitespace-pre-wrap text-[var(--color-user-text)]",
-  queued: "text-subtle m-0 font-mono text-xs leading-4 break-words whitespace-pre-wrap opacity-90",
-} as const;
+const markdownStyles: Record<UserMessageContentProps["variant"], React.CSSProperties> = {
+  sent: {
+    color: "var(--color-user-text)",
+    whiteSpace: "pre-wrap",
+    overflowWrap: "break-word",
+    wordBreak: "break-word",
+  },
+  queued: {
+    color: "var(--color-subtle)",
+    fontFamily: "var(--font-monospace)",
+    fontSize: "12px",
+    lineHeight: "16px",
+    whiteSpace: "pre-wrap",
+    overflowWrap: "break-word",
+    wordBreak: "break-word",
+    opacity: 0.9,
+  },
+};
 
 const imageContainerStyles = {
   sent: "mt-3 flex flex-wrap gap-3",
@@ -50,10 +65,12 @@ export const UserMessageContent: React.FC<UserMessageContentProps> = ({
           {reviews.map((review, idx) => (
             <ReviewBlockFromData key={idx} data={review} />
           ))}
-          {textContent && <pre className={textStyles[variant]}>{textContent}</pre>}
+          {textContent && (
+            <MarkdownRenderer content={textContent} style={markdownStyles[variant]} />
+          )}
         </div>
       ) : (
-        content && <pre className={textStyles[variant]}>{content}</pre>
+        content && <MarkdownRenderer content={content} style={markdownStyles[variant]} />
       )}
       {imageParts && imageParts.length > 0 && (
         <div className={imageContainerStyles[variant]}>


### PR DESCRIPTION
## Summary
- render user messages via the shared MarkdownRenderer
- preserve sent/queued styling by applying inline style overrides

## Testing
- make static-check

## Why
- let user-authored markdown render consistently with assistant/tool markdown

---
_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `xhigh` • Cost: `$0.75`_
