### PR TITLE
🤖 fix: prevent user message code blocks from overflowing

### DIFF
--- a/src/browser/components/Messages/MessageWindow.tsx
+++ b/src/browser/components/Messages/MessageWindow.tsx
@@ -72,7 +72,7 @@ export const MessageWindow: React.FC<MessageWindowProps> = ({
     <div
       className={cn(
         "mt-4 mb-1 flex flex-col relative isolate",
-        variant === "user" && "ml-auto w-fit",
+        variant === "user" && "ml-auto w-fit max-w-full",
         variant === "assistant" && "w-full text-foreground",
         isLastPartOfMessage && "mb-4"
       )}
@@ -81,7 +81,7 @@ export const MessageWindow: React.FC<MessageWindowProps> = ({
       <div
         className={cn(
           variant === "user" &&
-            "bg-[var(--color-user-surface)] border border-[var(--color-user-border)] rounded-lg px-3 py-2 overflow-hidden shadow-sm",
+            "bg-[var(--color-user-surface)] border border-[var(--color-user-border)] rounded-lg px-3 py-2 overflow-x-auto shadow-sm",
           variant === "assistant" && "px-1 py-1"
         )}
       >

--- a/src/browser/components/Messages/UserMessageContent.tsx
+++ b/src/browser/components/Messages/UserMessageContent.tsx
@@ -15,7 +15,6 @@ interface UserMessageContentProps {
 const markdownStyles: Record<UserMessageContentProps["variant"], React.CSSProperties> = {
   sent: {
     color: "var(--color-user-text)",
-    whiteSpace: "pre-wrap",
     overflowWrap: "break-word",
     wordBreak: "break-word",
   },
@@ -24,7 +23,6 @@ const markdownStyles: Record<UserMessageContentProps["variant"], React.CSSProper
     fontFamily: "var(--font-monospace)",
     fontSize: "12px",
     lineHeight: "16px",
-    whiteSpace: "pre-wrap",
     overflowWrap: "break-word",
     wordBreak: "break-word",
     opacity: 0.9,

--- a/src/browser/stories/App.markdown.stories.tsx
+++ b/src/browser/stories/App.markdown.stories.tsx
@@ -350,6 +350,55 @@ const reallyLongVariableName = someFunction(argumentOne, argumentTwo, argumentTh
 
 This is a very long paragraph without any breaks that should demonstrate text wrapping behavior in the chat message container. The text should wrap at the container boundary and not cause horizontal overflow that creates a scrollbar on the entire chat area. If you see a horizontal scrollbar, the CSS is broken.`;
 
+const USER_CODE_BLOCKS = `Here's the error:
+
+\`\`\`
+npm install
+\`\`\`
+
+And the full output:
+
+\`\`\`
+Expected ahead ≥ 2, got: {"ahead":1,"behind":0,"dirty":true,"outgoingAdditions":2,"outgoingDeletions":0,"incomingAdditions":0,"incomingDeletions":0}
+\`\`\`
+
+Short JS:
+
+\`\`\`js
+const x = 42;
+\`\`\`
+
+Long JS:
+
+\`\`\`js
+const reallyLongVariableName = someFunction(argumentOne, argumentTwo, argumentThree, argumentFour, argumentFive, argumentSix);
+\`\`\`
+
+Any ideas?`;
+
+/** User message with code blocks - tests scrolling for long lines */
+export const UserMessageCodeBlock: AppStory = {
+  render: () => (
+    <AppWithMocks
+      setup={() =>
+        setupSimpleChatStory({
+          workspaceId: "ws-user-code",
+          messages: [
+            createUserMessage("msg-1", USER_CODE_BLOCKS, {
+              historySequence: 1,
+              timestamp: STABLE_TIMESTAMP - 10000,
+            }),
+            createAssistantMessage("msg-2", "I can help with that error.", {
+              historySequence: 2,
+              timestamp: STABLE_TIMESTAMP,
+            }),
+          ],
+        })
+      }
+    />
+  ),
+};
+
 /** Long lines in code blocks and lists - regression test for horizontal overflow */
 export const LongLinesOverflow: AppStory = {
   render: () => (


### PR DESCRIPTION
## Summary

Unlanguaged code blocks in user messages were horizontally overflowing instead of scrolling. This regression was introduced in PR #1757 when user messages started rendering via `MarkdownRenderer`.

## Changes

- Add `max-w-full` to user message container to constrain width within parent
- Change `overflow-hidden` → `overflow-x-auto` to allow code blocks to scroll horizontally
- Remove `whiteSpace: pre-wrap` inline style that was interfering with CSS defaults
- Add regression test case in `App.markdown.stories.tsx`

## Testing

- `make static-check` ✅
- View **App/Markdown/LongLinesOverflow** story - user message code block now scrolls

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$2.78`_