### PR TITLE
🤖 fix: flaky git status ahead count test

### DIFF
--- a/src/browser/stores/GitStatusStore.ts
+++ b/src/browser/stores/GitStatusStore.ts
@@ -153,6 +153,14 @@ export class GitStatusStore {
   }
 
   /**
+   * Check if any git status fetch is currently in-flight.
+   * Use this to ensure no background fetch can race with operations that change git state.
+   */
+  isAnyRefreshInFlight(): boolean {
+    return this.refreshController.isRefreshing;
+  }
+
+  /**
    * Subscribe to refreshing state changes for a specific workspace.
    */
   subscribeRefreshingKey = (workspaceId: string, listener: () => void) => {


### PR DESCRIPTION
## Summary

Fix race condition in `git status reflects ahead count` test where background git status fetches could complete mid-commit, causing the test to see `ahead:1` instead of `ahead:2`.

## Root Cause

The test waited for `isWorkspaceRefreshing()` to be false, but that flag only tracked refreshes triggered by `invalidateWorkspace()`. The **initial subscription fetch** (triggered via `requestImmediate()`) didn't set that flag, so the test would proceed while a fetch was still in-flight.

## Changes

- **`src/browser/stores/GitStatusStore.ts`**: Add `isAnyRefreshInFlight()` to expose whether any fetch is currently in progress (wraps `RefreshController.isRefreshing`)
- **`tests/ui/helpers.ts`**: Add `waitForIdleGitStatus()` helper that waits for both idle state AND status predicate
- **`tests/ui/gitStatus.integration.test.ts`**: Use idle-wait before making commits, use `invalidateGitStatus()` for reliable refresh

## Validation

- 20+ consecutive test passes (was flaking ~1 in 10)
- Faster execution: ~350ms (was ~1000ms with previous delay-based attempt)
- All 4 tests in the file pass
- `make static-check` passes

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$10.86`_