### PR TITLE
🤖 fix: code block overflow in plans

### DIFF
--- a/src/browser/stories/App.chat.stories.tsx
+++ b/src/browser/stories/App.chat.stories.tsx
@@ -1389,6 +1389,61 @@ graph TD
   },
 };
 
+/**
+ * Story showing a propose_plan with a code block containing long horizontal content.
+ * Tests that code blocks wrap correctly instead of overflowing the container.
+ */
+export const ProposePlanWithLongCodeBlock: AppStory = {
+  render: () => (
+    <AppWithMocks
+      setup={() =>
+        setupSimpleChatStory({
+          workspaceId: "ws-plan-overflow",
+          messages: [
+            createUserMessage("msg-1", "The CI is failing with this error, can you help?", {
+              historySequence: 1,
+              timestamp: STABLE_TIMESTAMP,
+            }),
+            createAssistantMessage("msg-2", "I see the issue. Here's my plan to fix it:", {
+              historySequence: 2,
+              timestamp: STABLE_TIMESTAMP,
+              toolCalls: [
+                createProposePlanTool(
+                  "call-plan-1",
+                  `# Fix CI Pipeline Failure
+
+## Problem
+
+The deployment step is failing due to a configuration mismatch:
+
+\`\`\`json
+{"error":"ConfigurationError","message":"Environment variable AWS_REGION is required but not set","stack":"at validateConfig (deploy.js:42)","context":{"requiredVars":["AWS_REGION","AWS_ACCESS_KEY_ID","AWS_SECRET_ACCESS_KEY"],"missingVars":["AWS_REGION"]}}
+\`\`\`
+
+## Solution
+
+1. Add the missing \`AWS_REGION\` environment variable to the CI configuration
+2. Update the deployment script to provide better error messages
+3. Add a pre-flight check to catch missing variables earlier`
+                ),
+              ],
+            }),
+          ],
+        })
+      }
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Tests that code blocks within plans wrap correctly instead of overflowing. " +
+          "The long JSON error line should wrap within the plan card.",
+      },
+    },
+  },
+};
+
 // Message content used in SigningBadgePassphraseWarning story
 const SIGNING_WARNING_MESSAGE_CONTENT = "Hello! How can I help you today?";
 

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -1602,7 +1602,7 @@ span.search-highlight {
 /* Code block with line numbers - each line is a grid row */
 .code-block-container {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto minmax(0, 1fr);
   background: var(--color-code-bg);
   border-radius: 4px;
   padding: 6px 40px 6px 0; /* Right padding for copy button */


### PR DESCRIPTION
## Summary

Code blocks with syntax highlighting in plan tool calls were overflowing horizontally instead of wrapping like they do in user/assistant messages.

## Root Cause

CSS Grid's `1fr` is shorthand for `minmax(auto, 1fr)`, which means the column won't shrink below its content width (min-content). User messages worked because they pass inline styles (`word-break`, `overflow-wrap`) that reduce min-content width.

Plans don't apply those styles, so the grid's min-content width stays large and `auto 1fr` refuses to shrink — forcing overflow.

## Fix

Change `.code-block-container` grid from:
```css
grid-template-columns: auto 1fr;
```
to:
```css
grid-template-columns: auto minmax(0, 1fr);
```

This explicitly allows the column to shrink below content size, enabling `white-space: pre-wrap` to work correctly regardless of inherited styles.

## Testing

- Added a story (`ProposePlanWithLongCodeBlock`) showing a plan with a long JSON code block
- Verified wrapping now works like user messages

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$4.25`_
