### PR TITLE
🤖 fix: preserve Coder template/preset persistence on reload

### DIFF
--- a/src/browser/hooks/useCoderWorkspace.test.ts
+++ b/src/browser/hooks/useCoderWorkspace.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { buildAutoSelectedTemplateConfig } from "./useCoderWorkspace";
+import type { CoderTemplate } from "@/common/orpc/schemas/coder";
+
+const makeTemplate = (name: string, org = "default-org"): CoderTemplate => ({
+  name,
+  displayName: name,
+  organizationName: org,
+});
+
+describe("buildAutoSelectedTemplateConfig", () => {
+  test("preserves preset when auto-selecting first template", () => {
+    const currentConfig = { preset: "my-preset" };
+    const templates = [makeTemplate("template-a")];
+
+    const result = buildAutoSelectedTemplateConfig(currentConfig, templates);
+
+    expect(result).toEqual({
+      preset: "my-preset",
+      existingWorkspace: false,
+      template: "template-a",
+      templateOrg: undefined,
+    });
+  });
+
+  test("sets templateOrg when first template name is duplicated across orgs", () => {
+    const templates = [makeTemplate("shared-name", "org-1"), makeTemplate("shared-name", "org-2")];
+
+    const result = buildAutoSelectedTemplateConfig(null, templates);
+
+    expect(result).toEqual({
+      existingWorkspace: false,
+      template: "shared-name",
+      templateOrg: "org-1",
+    });
+  });
+
+  test("returns null when template is already selected", () => {
+    const currentConfig = { template: "existing-template" };
+    const templates = [makeTemplate("template-a")];
+
+    expect(buildAutoSelectedTemplateConfig(currentConfig, templates)).toBeNull();
+  });
+
+  test("returns null when existingWorkspace is true", () => {
+    const currentConfig = { existingWorkspace: true };
+    const templates = [makeTemplate("template-a")];
+
+    expect(buildAutoSelectedTemplateConfig(currentConfig, templates)).toBeNull();
+  });
+
+  test("returns null when templates array is empty", () => {
+    expect(buildAutoSelectedTemplateConfig(null, [])).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

Persisted template/preset values were being overwritten when returning to the Coder workspace creation flow. Two bugs:

1. **Ref sync timing**: `coderConfigRef` was updated via `useEffect`, but the template fetch callback could complete before the effect ran, reading stale `null` values and triggering auto-select unnecessarily.

2. **Auto-select dropped preset**: When auto-selecting the first template, the new config object didn't preserve existing fields like `preset`, causing the preset auto-select to also fire.

## Fix

- Sync refs during render (not in useEffect) so async callbacks always see current values
- Spread `currentConfig` when auto-selecting to preserve existing fields

## Testing

- Extracted `buildAutoSelectedTemplateConfig()` helper with 5 unit tests
- Manual testing: select non-default template/preset → navigate away → return → selection preserved ✅

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$4.13`_
