### PR TITLE
🤖 fix: stats tool timing uses wall time

### DIFF
--- a/src/common/orpc/schemas/workspaceStats.ts
+++ b/src/common/orpc/schemas/workspaceStats.ts
@@ -95,7 +95,7 @@ export const WorkspaceStatsSnapshotSchema = z.object({
 });
 
 export const SessionTimingFileSchema = z.object({
-  version: z.literal(1),
+  version: z.literal(2),
   lastRequest: CompletedStreamStatsSchema.optional(),
   session: SessionTimingStatsSchema,
 });


### PR DESCRIPTION
Fixes Stats tab timing where tool execution could exceed total wait time.

Root cause: tool execution time was summed per tool call, double-counting overlapping/parallel tool runs.

Changes:
- Compute tool execution as *wall time* (union of in-flight tool intervals) in `SessionTimingService`.
- Bump `session-timing.json` schema version to avoid mixing old inflated totals with new semantics.
- Add unit test covering overlapping tool calls.

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix Stats tab tool execution time overcounting

## What’s happening (root cause)
The Stats tab uses backend timing stats from `SessionTimingService` (`WorkspaceStatsSnapshot`). In `src/node/services/sessionTimingService.ts`, tool execution is computed as the **sum of each tool call duration**:

- `handleToolCallEnd`: `completedToolExecutionMs += (end - start)` per tool call.
- `getActiveStreamStats` / `handleStreamEnd`: adds `now - toolStart` (or `endTimestamp - toolStart`) for each pending tool.

That definition **double-counts overlapping tool calls** (parallel tool calling / nested tool calls), so `toolExecutionMs` can exceed `totalDurationMs`. The validator flags this (`tool_gt_total`, `percent_out_of_range`), but:

- completed invalid timings are still persisted and accumulated into `session.totalToolExecutionMs` via `applyCompletedStreamToFile`.
- the UI’s Session view doesn’t surface “invalid timing” warnings, so users just see huge tool totals and >100% bars.

**Primary hotspots**
- Backend: `src/node/services/sessionTimingService.ts`
  - `handleToolCallEnd` (adds each tool duration)
  - `getActiveStreamStats` (sums pending tools)
  - `handleStreamEnd` (sums pending tools)
  - `applyCompletedStreamToFile` (accumulates invalid stats into session totals)
- UI display: `src/browser/components/RightSidebar/StatsTab.tsx` (percentages are simple `toolExecutionMs / totalDuration` with no clamping)

<details>
<summary>Why the numbers can exceed 100% (example)</summary>

If a model starts 8 tools in parallel and they each run for 10s, the current metric reports ~80s “tool execution” even though the user only waited ~10s for tools.

</details>

---

## Recommended approach (A): Track *tool wall time* (union of overlaps)
**Goal:** Make `toolExecutionMs` represent *wall-clock time where ≥1 tool was in-flight*, which is the number users expect when comparing against overall request duration.

### A1) Update `SessionTimingService` tool timing algorithm (net ~+35 LoC)
Replace the “sum of per-tool durations” accumulator with a “wall time” accumulator:

- Add fields to `ActiveStreamState`:
  - `toolWallMs: number` (accumulated)
  - `toolWallStartMs: number | null` (start of current ≥1-tool segment)
  - keep `pendingToolStarts: Map<string, number>` for idempotency/defensive cleanup
- On `tool-call-start`:
  - if this is the **first active tool** (`pendingToolStarts.size === 0`), set `toolWallStartMs = timestamp`
  - add toolCallId to `pendingToolStarts`
- On `tool-call-end`:
  - remove toolCallId from `pendingToolStarts` (ignore unknown ids)
  - if this ended the **last active tool** (`pendingToolStarts.size === 0`), add `timestamp - toolWallStartMs` to `toolWallMs` and clear `toolWallStartMs`
- For active stats (`getActiveStreamStats`):
  - `toolExecutionMs = toolWallMs + (toolWallStartMs ? now - toolWallStartMs : 0)`
- For completed stats (`handleStreamEnd`):
  - close any open segment at `endTimestamp` (same idea as active)

Defensive programming notes:
- Clamp segment additions with `Math.max(0, end - start)` (timestamps can be out-of-order).
- If `pendingToolStarts.size > 0` but `toolWallStartMs === null` (should be impossible), recover by setting `toolWallStartMs = min(pendingToolStarts.values())` and mark timing invalid.

### A2) Don’t carry corrupted historical totals forward (schema/version bump) (net ~+10 LoC)
Because `session-timing.json` stores only aggregates, we can’t repair old sessions after changing semantics. Prevent “mixed semantics” totals by bumping the on-disk version:

- Update `SessionTimingFileSchema` / `createEmptyTimingFile` to `version: 2`.
- Update `readTimingFile()` to treat version mismatch as “reset” without logging as “corrupted”.

### A3) Tests + validation (no product LoC)
- Update/add unit tests in `src/node/services/sessionTimingService.test.ts`:
  - new case: 2 overlapping tools where sum > duration; assert `toolExecutionMs` equals union and `invalid === false`.
  - ensure `toolExecutionMs <= totalDurationMs` invariant in normal cases.
- Manual check:
  - Run a session with `multi_tool_use.parallel` tool bursts and confirm Session tool % stays ≤100% and roughly matches human-perceived waits.

---

## Optional UI hardening (B): Clamp percentages + show session-level warning
If we want the UI to be resilient even if timing is invalid (clock skew, missing events):

- Clamp `toolPercentage/modelPercentage/ttftPercentage` to `[0, 100]` for bar widths.
- Consider adding `invalidCount` to session stats (schema change) so the Session view can show “X requests had invalid timing; totals may be off”.

**Net product LoC:** ~+15–40 depending on whether we add new schema fields.

---

## Alternatives considered
### C) Minimal patch: cap toolExecution to totalDuration when persisting (net ~+10 LoC)
Pros: very small.
Cons: still misattributes time; hides overlap rather than measuring it.

### D) Record both metrics: tool wall time + sum-of-tools (net ~+100–150 LoC)
Pros: preserves a “total tool compute time” metric for power users.
Cons: larger schema/UI/telemetry surface; migration work.

---

## Acceptance criteria
- For any completed request: `0 <= toolExecutionMs <= totalDurationMs` under normal event ordering.
- Stats tab Session view never shows tool execution > total duration after the version bump.
- Overlapping tool calls no longer inflate tool time.

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: $1.42_
