### PR TITLE
🤖 fix: avoid WSL launcher focus loop on Windows

### DIFF
--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -390,13 +390,16 @@ async function loadServices(): Promise<void> {
     if (process.platform !== "win32") return false;
 
     const normalize = (p: string) => p.replace(/\//g, "\\").toLowerCase();
-    const isWslLauncher = (p: string) =>
-      p === "wsl" ||
-      p === "wsl.exe" ||
-      p === "bash" ||
-      p === "bash.exe" ||
-      p.endsWith("\\windows\\system32\\bash.exe") ||
-      p.endsWith("\\windows\\system32\\wsl.exe");
+    const isWslLauncher = (p: string) => {
+      const base = path.win32.basename(p);
+      return (
+        p === "wsl" ||
+        base === "wsl.exe" ||
+        p === "bash" ||
+        p === "bash.exe" ||
+        p.endsWith("\\windows\\system32\\bash.exe")
+      );
+    };
 
     const envShell = process.env.SHELL?.trim();
     if (envShell && isWslLauncher(normalize(envShell))) {
@@ -410,6 +413,7 @@ async function loadServices(): Promise<void> {
       const result = execSync("where bash", {
         encoding: "utf8",
         stdio: ["pipe", "pipe", "ignore"],
+        windowsHide: true,
       });
       const firstPath = result
         .split(/\r?\n/)

--- a/src/node/utils/main/bashPath.test.ts
+++ b/src/node/utils/main/bashPath.test.ts
@@ -1,4 +1,4 @@
-import { getBashPathForPlatform } from "./bashPath";
+import { getBashPath, getBashPathForPlatform, resetBashPathCache } from "./bashPath";
 
 describe("getBashPathForPlatform (Windows)", () => {
   it("skips WSL launcher when it is first in PATH", () => {
@@ -58,5 +58,47 @@ describe("getBashPathForPlatform (Windows)", () => {
         existsSyncFn,
       })
     ).toThrow(/WSL is not supported/);
+  });
+});
+
+describe("getBashPath (Windows)", () => {
+  beforeEach(() => {
+    resetBashPathCache();
+  });
+
+  it("caches failures to avoid repeated `where` probes", () => {
+    let execCalls = 0;
+    const execSyncFn = () => {
+      execCalls++;
+      throw new Error("not in PATH");
+    };
+
+    const existsSyncFn = () => false;
+    const nowFn = () => 0;
+
+    expect(() =>
+      getBashPath({
+        platform: "win32",
+        env: {},
+        execSyncFn,
+        existsSyncFn,
+        nowFn,
+      })
+    ).toThrow(/Git Bash not found/);
+
+    const callsAfterFirst = execCalls;
+    expect(callsAfterFirst).toBeGreaterThan(0);
+
+    expect(() =>
+      getBashPath({
+        platform: "win32",
+        env: {},
+        execSyncFn,
+        existsSyncFn,
+        nowFn,
+      })
+    ).toThrow(/Git Bash not found/);
+
+    expect(execCalls).toBe(callsAfterFirst);
   });
 });

--- a/src/node/utils/main/resolveLocalPtyShell.test.ts
+++ b/src/node/utils/main/resolveLocalPtyShell.test.ts
@@ -57,6 +57,20 @@ describe("resolveLocalPtyShell", () => {
     });
   });
 
+  it("on Windows, ignores WSL wsl.exe in SHELL and prefers Git Bash", () => {
+    const result = resolveLocalPtyShell({
+      platform: "win32",
+      env: { SHELL: "C:\\Program Files\\WSL\\wsl.exe" },
+      isCommandAvailable: () => false,
+      getBashPath: () => "C:\\Program Files\\Git\\bin\\bash.exe",
+    });
+
+    expect(result).toEqual({
+      command: "C:\\Program Files\\Git\\bin\\bash.exe",
+      args: ["--login", "-i"],
+    });
+  });
+
   it("on Windows, falls back to pwsh when Git Bash is unavailable", () => {
     const result = resolveLocalPtyShell({
       platform: "win32",

--- a/src/node/utils/main/resolveLocalPtyShell.ts
+++ b/src/node/utils/main/resolveLocalPtyShell.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "child_process";
+import path from "path";
 
 import { getBashPath } from "@/node/utils/main/bashPath";
 
@@ -37,13 +38,13 @@ function looksLikeWslShell(envShell: string): boolean {
   }
 
   const normalized = envShell.replace(/\//g, "\\").toLowerCase();
+  const base = path.win32.basename(normalized);
   return (
     normalized === "wsl" ||
-    normalized === "wsl.exe" ||
+    base === "wsl.exe" ||
     normalized === "bash" ||
     normalized === "bash.exe" ||
-    normalized.endsWith("\\windows\\system32\\bash.exe") ||
-    normalized.endsWith("\\windows\\system32\\wsl.exe")
+    normalized.endsWith("\\windows\\system32\\bash.exe")
   );
 }
 


### PR DESCRIPTION
Fixes #1697.

## What changed
- Treat any `wsl.exe` path (e.g. `C:\\Program Files\\WSL\\wsl.exe`) as a WSL launcher in Windows shell detection.
- Add `windowsHide: true` to `where git` / `where bash` probes to prevent console flash/focus steal.
- Add short negative-caching for Git Bash resolution failures to avoid tight retry loops when the toolchain is missing.

## Why
Mux doesn’t support WSL on Windows, but certain configurations can cause us to repeatedly invoke a WSL launcher (or repeatedly probe for Git Bash) which steals focus and triggers a focus-refresh feedback loop.

## Testing
- `bun test src/node/utils/main/bashPath.test.ts src/node/utils/main/resolveLocalPtyShell.test.ts`
- `make static-check`

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$5.88`_
