### PR TITLE
🤖 fix: retry sonnet 4.5 compaction with 1m context

### DIFF
--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -46,7 +46,7 @@ import type { TodoItem } from "@/common/types/tools";
 import type { PostCompactionAttachment, PostCompactionExclusions } from "@/common/types/attachment";
 import { TURNS_BETWEEN_ATTACHMENTS } from "@/common/constants/attachments";
 import { extractEditedFileDiffs } from "@/common/utils/messages/extractEditedFiles";
-import { getModelName, getModelProvider, isValidModelFormat } from "@/common/utils/ai/models";
+import { normalizeGatewayModel, isValidModelFormat } from "@/common/utils/ai/models";
 import { readAgentSkill } from "@/node/services/agentSkills/agentSkillsService";
 import { materializeFileAtMentions } from "@/node/services/fileAtMentions";
 
@@ -870,10 +870,9 @@ export class AgentSession {
   }
 
   private isSonnet45Model(modelString: string): boolean {
-    return (
-      getModelProvider(modelString) === "anthropic" &&
-      getModelName(modelString).toLowerCase().startsWith("claude-sonnet-4-5")
-    );
+    const normalized = normalizeGatewayModel(modelString);
+    const [provider, modelName] = normalized.split(":", 2);
+    return provider === "anthropic" && modelName?.toLowerCase().startsWith("claude-sonnet-4-5");
   }
 
   private withAnthropic1MContext(
@@ -904,10 +903,9 @@ export class AgentSession {
   }
 
   private isGptClassModel(modelString: string): boolean {
-    return (
-      getModelProvider(modelString) === "openai" &&
-      getModelName(modelString).toLowerCase().startsWith("gpt-")
-    );
+    const normalized = normalizeGatewayModel(modelString);
+    const [provider, modelName] = normalized.split(":", 2);
+    return provider === "openai" && modelName?.toLowerCase().startsWith("gpt-");
   }
 
   private async maybeRetryCompactionOnContextExceeded(data: {


### PR DESCRIPTION
## Summary
- reuse the compaction retry flow to enable Anthropic 1M context for Sonnet 4.5 after a context_exceeded failure
- preserve the user's existing 1M context setting so the first compaction attempt honors it
- normalize mux-gateway model strings when detecting gpt-* and sonnet-4-5 retries

## Why
- Sonnet 4.5 can exceed the default context window during large compactions; retrying with 1M context keeps compaction resilient without changing the user's initial preference
- gateway models must be detected correctly so retries trigger consistently

## Testing
- make static-check

---
_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `xhigh` • Cost: `$2.77`_
