### PR TITLE
🤖 fix: keep slash command visible in suggestions

### DIFF
--- a/src/browser/components/CommandSuggestions.tsx
+++ b/src/browser/components/CommandSuggestions.tsx
@@ -280,11 +280,19 @@ export const CommandSuggestions: React.FC<CommandSuggestionsProps> = ({
           {isFileSuggestion && (
             <FileIcon filePath={suggestion.display} className="shrink-0 text-sm" />
           )}
-          <div className="font-monospace text-foreground min-w-0 flex-1 truncate text-xs">
+          <div
+            className={cn(
+              "font-monospace text-foreground text-xs",
+              isFileSuggestion ? "min-w-0 flex-1 truncate" : "shrink-0 whitespace-nowrap"
+            )}
+          >
             <HighlightedText text={suggestion.display} query={highlightQuery} />
           </div>
           <div
-            className="text-secondary max-w-[70%] min-w-0 truncate text-[11px]"
+            className={cn(
+              "text-secondary min-w-0 truncate text-[11px]",
+              isFileSuggestion ? "max-w-[70%]" : "flex-1 text-right"
+            )}
             title={suggestion.description}
           >
             {suggestion.description}


### PR DESCRIPTION
## What

Slash command suggestions now always show the full command (e.g. `/fork`), and only truncate the description with an ellipsis when it overflows.

## Why

Long descriptions were causing the command column to shrink and render as `/f…`, making it harder to scan commands.

## How

- For slash command suggestions:
  - Command uses `whitespace-nowrap` + `shrink-0`
  - Description takes the remaining width and truncates with `truncate`
- File path suggestions keep the existing layout.

## Testing

- `make static-check`
- `bun test src/browser/components/CommandSuggestions.test.tsx`

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$1.60`_
