### PR TITLE
🤖 test: add ssh2 runtime tests and avoid backoff on channel errors

### DIFF
--- a/src/node/runtime/transports/SSH2Transport.ts
+++ b/src/node/runtime/transports/SSH2Transport.ts
@@ -189,10 +189,6 @@ export class SSH2Transport implements SSHTransport {
         }
       });
 
-      channel.on("error", (err: Error) => {
-        ssh2ConnectionPool.reportFailure(this.config, getErrorMessage(err));
-      });
-
       const process = new SSH2ChildProcess(channel) as unknown as ChildProcess;
       return { process };
     } catch (error) {

--- a/tests/runtime/ssh2-runtime.test.ts
+++ b/tests/runtime/ssh2-runtime.test.ts
@@ -1,0 +1,121 @@
+/**
+ * SSH2 Transport Integration Tests
+ *
+ * Focused tests for the SSH2 transport (ssh2 npm library) against a real
+ * Docker SSH server. These tests are isolated from the main runtime suite
+ * to keep SSH2-specific coverage small and easy to diagnose.
+ *
+ * Tests use the same Docker fixture as runtime.test.ts but explicitly use
+ * `createSSHTransport(config, true)` to exercise the SSH2 code path.
+ */
+
+import {
+  isDockerAvailable,
+  startSSHServer,
+  stopSSHServer,
+  type SSHServerConfig,
+} from "./test-fixtures/ssh-fixture";
+import { TestWorkspace } from "./test-fixtures/test-helpers";
+import { SSHRuntime } from "@/node/runtime/SSHRuntime";
+import { createSSHTransport } from "@/node/runtime/transports";
+import { execBuffered, readFileString, writeFileString } from "@/node/utils/runtime/helpers";
+
+function shouldRunIntegrationTests(): boolean {
+  return process.env.TEST_INTEGRATION === "1" || process.env.TEST_INTEGRATION === "true";
+}
+
+const describeIntegration = shouldRunIntegrationTests() ? describe : describe.skip;
+
+let sshConfig: SSHServerConfig | undefined;
+
+/**
+ * Create an SSHRuntime using the SSH2 transport (not OpenSSH)
+ */
+function createSSH2Runtime(config: SSHServerConfig): SSHRuntime {
+  const sshRuntimeConfig = {
+    host: "testuser@localhost",
+    srcBaseDir: config.workdir,
+    identityFile: config.privateKeyPath,
+    port: config.port,
+  };
+  // useSSH2 = true to exercise the ssh2 library transport
+  return new SSHRuntime(sshRuntimeConfig, createSSHTransport(sshRuntimeConfig, true));
+}
+
+describeIntegration("SSH2 Transport integration tests", () => {
+  beforeAll(async () => {
+    if (!(await isDockerAvailable())) {
+      throw new Error(
+        "Docker is required for SSH2 integration tests. Please install Docker or skip tests by unsetting TEST_INTEGRATION."
+      );
+    }
+
+    console.log("Starting SSH server container for SSH2 tests...");
+    sshConfig = await startSSHServer();
+    console.log(`SSH server ready on port ${sshConfig.port}`);
+  }, 120000);
+
+  afterAll(async () => {
+    if (sshConfig) {
+      console.log("Stopping SSH server container...");
+      await stopSSHServer(sshConfig);
+    }
+  }, 30000);
+
+  describe("exec() - Command execution via SSH2", () => {
+    test("returns correct exit code for failed commands", async () => {
+      const runtime = createSSH2Runtime(sshConfig!);
+      await using workspace = await TestWorkspace.create(runtime, "ssh");
+
+      const result = await execBuffered(runtime, "exit 42", {
+        cwd: workspace.path,
+        timeout: 30,
+      });
+
+      expect(result.exitCode).toBe(42);
+    });
+
+    test("captures stderr separately", async () => {
+      const runtime = createSSH2Runtime(sshConfig!);
+      await using workspace = await TestWorkspace.create(runtime, "ssh");
+
+      const result = await execBuffered(runtime, 'echo "out" && echo "err" >&2', {
+        cwd: workspace.path,
+        timeout: 30,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe("out");
+      expect(result.stderr.trim()).toBe("err");
+    });
+  });
+
+  describe("File operations via SSH2", () => {
+    test("writes and reads file roundtrip", async () => {
+      const runtime = createSSH2Runtime(sshConfig!);
+      await using workspace = await TestWorkspace.create(runtime, "ssh");
+
+      const testContent = "Hello from SSH2 transport test!\nLine 2\n";
+      const filePath = `${workspace.path}/test-file.txt`;
+
+      await writeFileString(runtime, filePath, testContent);
+      const readContent = await readFileString(runtime, filePath);
+
+      expect(readContent).toBe(testContent);
+    });
+
+    test("handles binary-like content", async () => {
+      const runtime = createSSH2Runtime(sshConfig!);
+      await using workspace = await TestWorkspace.create(runtime, "ssh");
+
+      // Content with special characters that might trip up text handling
+      const testContent = "Line with special chars: \t\r\nUnicode: 日本語 émojis: 🚀\n";
+      const filePath = `${workspace.path}/special-chars.txt`;
+
+      await writeFileString(runtime, filePath, testContent);
+      const readContent = await readFileString(runtime, filePath);
+
+      expect(readContent).toBe(testContent);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds dedicated SSH2 transport integration tests and fixes a bug where channel-level errors incorrectly triggered connection backoff.

## Changes

### 1. SSH2 Integration Tests (`tests/runtime/ssh2-runtime.test.ts`)

Small, focused test suite for the SSH2 transport (ssh2 npm library) against a real Docker SSH server:

- **Exit code handling** - verifies non-zero exit codes propagate correctly
- **Stderr separation** - ensures stdout/stderr streams are captured separately  
- **File roundtrip** - write and read file content
- **Special characters** - Unicode, emoji, tabs, etc.

Tests are isolated from the main runtime suite to keep SSH2-specific coverage small and easy to diagnose. Uses the existing Docker SSH fixture.

### 2. SSH2Transport Bug Fix

**Removed the channel-level error handler that called `ssh2ConnectionPool.reportFailure()`:**

```diff
-      channel.on("error", (err: Error) => {
-        ssh2ConnectionPool.reportFailure(this.config, getErrorMessage(err));
-      });
```

**Why this was a bug:**

Channel errors are often command-level issues (abort, cleanup, EOF, process termination) that have nothing to do with connection health. Reporting these as failures poisoned the shared connection pool, triggering exponential backoff even when the SSH connection was perfectly healthy.

Connection-level failures are already reported in the appropriate places:
- `SSH2ConnectionPool.connect()` reports failures when connection acquisition fails
- The `try/catch` in `spawnRemoteProcess` reports failures when `exec()` setup fails

This matches OpenSSH transport behavior where only actual connection failures trigger backoff, not individual command errors.

---

_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `high`_
