### PR TITLE
🤖 test: wait for init in GIT_TERMINAL_PROMPT test to prevent Windows flakiness

### DIFF
--- a/tests/ipc/executeBash.test.ts
+++ b/tests/ipc/executeBash.test.ts
@@ -1,6 +1,11 @@
 import { shouldRunIntegrationTests, createTestEnvironment, cleanupTestEnvironment } from "./setup";
-import { createTempGitRepo, cleanupTempGitRepo, createWorkspace } from "./helpers";
-import { resolveOrpcClient } from "./helpers";
+import {
+  createTempGitRepo,
+  cleanupTempGitRepo,
+  createWorkspace,
+  waitForInitComplete,
+  resolveOrpcClient,
+} from "./helpers";
 import type { WorkspaceMetadata } from "../../src/common/types/workspace";
 
 type WorkspaceCreationResult = Awaited<ReturnType<typeof createWorkspace>>;
@@ -273,6 +278,9 @@ describeIntegration("executeBash", () => {
         const createResult = await createWorkspace(env, tempGitRepo, "test-git-env");
         const workspaceId = expectWorkspaceCreationSuccess(createResult).id;
         const client = resolveOrpcClient(env);
+
+        // Wait for init to complete (prevents Windows filesystem timing issues)
+        await waitForInitComplete(env, workspaceId);
 
         // Verify GIT_TERMINAL_PROMPT is set to 0
         const gitEnvResult = await client.workspace.executeBash({


### PR DESCRIPTION
## Summary

Fix flaky Windows CI test `should set GIT_TERMINAL_PROMPT=0 to prevent credential prompts`.

## Problem

The test was failing intermittently on Windows CI (newly added in #1779) with:
```
expect(gitEnvResult.success).toBe(true);
Expected: true
Received: false
```

The oRPC call itself was failing before bash even ran.

## Root Cause

The test called `executeBash` immediately after `createWorkspace` without waiting for init completion. On Windows, filesystem timing issues (NTFS metadata delays, concurrent test contention) can cause the workspace metadata lookup to fail.

## Solution

Added `waitForInitComplete(env, workspaceId)` after workspace creation to ensure the workspace is fully ready before running bash commands. This follows the pattern used in other robust tests like `initWorkspace.test.ts`.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$4.50`_