### PR TITLE
🤖 perf: skip Electron caches for Windows test jobs

### DIFF
--- a/.github/actions/setup-mux/action.yml
+++ b/.github/actions/setup-mux/action.yml
@@ -1,5 +1,10 @@
 name: "Setup Mux"
 description: "Setup Bun and install dependencies with caching"
+inputs:
+  skip-build-caches:
+    description: "Skip Electron and electron-builder caches (for test-only jobs)"
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -56,8 +61,10 @@ runs:
         bun install --frozen-lockfile
 
     # Cache Electron binaries and electron-builder resources (NSIS, etc.)
-    # These are downloaded during electron-builder and can be 200MB+ total
+    # These are downloaded during electron-builder and can be 200MB+ total.
+    # Skip for test-only jobs to save ~30s on Windows (260MB + 11MB cache restore).
     - name: Cache Electron
+      if: ${{ inputs.skip-build-caches != 'true' }}
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
@@ -69,6 +76,7 @@ runs:
           ${{ runner.os }}-${{ runner.arch }}-electron-
 
     - name: Cache electron-builder
+      if: ${{ inputs.skip-build-caches != 'true' }}
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -254,6 +254,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-mux
+        with:
+          skip-build-caches: true
       - name: Generate version.ts
         shell: bash
         run: ./scripts/generate-version.sh


### PR DESCRIPTION
## Summary

Adds a `skip-build-caches` input to the `setup-mux` action to skip Electron and electron-builder cache restore/save operations for test-only jobs.

## Problem

The `Test / Windows` job was restoring ~270MB of unnecessary caches:
- Electron binaries (260MB) — only needed for building/running the app
- electron-builder (11MB) — only needed for packaging installers

These caches take ~30s to restore on Windows due to slow tar/zstd decompression, even though the job only runs unit tests and integration smoke tests that don't use Electron.

## Solution

- Add `skip-build-caches` input to `setup-mux` (default: `false`)
- Wrap Electron/electron-builder cache steps with conditional
- Use `skip-build-caches: true` in `test-windows` job

## Impact

**Expected savings on Windows:** ~30s (cache restore + post-run save)

The tests don't reference Electron — verified with `grep -l "electron"` across all test files run by this job.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$1.92`_
