### PR TITLE
🤖 ci: skip duplicate macOS/Windows builds on merge-queue push

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -365,7 +365,7 @@ jobs:
   build-macos:
     name: Build / macOS
     needs: [changes]
-    if: ${{ needs.changes.outputs.src == 'true' || needs.changes.outputs.config == 'true' }}
+    if: ${{ (needs.changes.outputs.src == 'true' || needs.changes.outputs.config == 'true') && (github.event_name != 'push' || github.actor != 'github-merge-queue[bot]') }}
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-macos-15' || 'macos-latest' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -399,8 +399,8 @@ jobs:
   build-windows:
     name: Build / Windows
     needs: [changes]
-    # Windows builds are slow - only run in merge queue and main pushes, not on every PR push
-    if: ${{ (github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && (needs.changes.outputs.src == 'true' || needs.changes.outputs.config == 'true') }}
+    # Windows builds are slow - only run in merge queue and main pushes (excluding merge-queue-bot to avoid duplicate runs)
+    if: ${{ (github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.actor != 'github-merge-queue[bot]')) && (needs.changes.outputs.src == 'true' || needs.changes.outputs.config == 'true') }}
     runs-on: windows-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Eliminates duplicate macOS and Windows builds when PRs merge via the merge queue.

## Problem

When using GitHub's merge queue, both builds were running **twice**:
1. `merge_group` event — validates the PR before merge ✓
2. `push` event — runs again after merge-queue-bot pushes to main ✗

## Scenarios After Fix

| Event | Actor | macOS | Windows |
|-------|-------|-------|---------|
| `pull_request` | human | ✅ runs | ❌ skipped |
| `merge_group` | bot | ✅ runs | ✅ runs |
| `push` to main | merge-queue-bot | ❌ **skipped** | ❌ **skipped** |
| `push` to main | human (bypass) | ✅ runs (signed) | ✅ runs (signed) |
| `workflow_dispatch` | human | ✅ runs | ❌ skipped |

**Code signing preserved:** Direct pushes to main (admin bypasses, hotfixes) still trigger signed builds since the actor is human, not the merge-queue-bot.

## Impact

~10 min CI savings per merged PR (4 min macOS + 6 min Windows).

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.61`_

