### PR TITLE
🤖 fix: tighten user list spacing

### DIFF
--- a/src/browser/components/Messages/UserMessageContent.tsx
+++ b/src/browser/components/Messages/UserMessageContent.tsx
@@ -34,6 +34,8 @@ const imageContainerStyles = {
   queued: "mt-2 flex flex-wrap gap-2",
 } as const;
 
+const markdownClassName = "user-message-markdown";
+
 const imageStyles = {
   sent: "max-h-[300px] max-w-72 rounded-xl border border-[var(--color-attachment-border)] object-cover",
   queued: "border-border-light max-h-[300px] max-w-80 rounded border",
@@ -64,11 +66,21 @@ export const UserMessageContent: React.FC<UserMessageContentProps> = ({
             <ReviewBlockFromData key={idx} data={review} />
           ))}
           {textContent && (
-            <MarkdownRenderer content={textContent} style={markdownStyles[variant]} />
+            <MarkdownRenderer
+              content={textContent}
+              className={markdownClassName}
+              style={markdownStyles[variant]}
+            />
           )}
         </div>
       ) : (
-        content && <MarkdownRenderer content={content} style={markdownStyles[variant]} />
+        content && (
+          <MarkdownRenderer
+            content={content}
+            className={markdownClassName}
+            style={markdownStyles[variant]}
+          />
+        )
       )}
       {imageParts && imageParts.length > 0 && (
         <div className={imageContainerStyles[variant]}>

--- a/src/browser/stories/App.markdown.stories.tsx
+++ b/src/browser/stories/App.markdown.stories.tsx
@@ -350,6 +350,10 @@ const reallyLongVariableName = someFunction(argumentOne, argumentTwo, argumentTh
 
 This is a very long paragraph without any breaks that should demonstrate text wrapping behavior in the chat message container. The text should wrap at the container boundary and not cause horizontal overflow that creates a scrollbar on the entire chat area. If you see a horizontal scrollbar, the CSS is broken.`;
 
+const USER_LIST_CONTENT = `1. something
+2. something
+3. something`;
+
 const USER_CODE_BLOCKS = `Here's the error:
 
 \`\`\`
@@ -375,6 +379,50 @@ const reallyLongVariableName = someFunction(argumentOne, argumentTwo, argumentTh
 \`\`\`
 
 Any ideas?`;
+
+/** User message list spacing - regression test for extra list padding */
+export const UserMessageListSpacing: AppStory = {
+  render: () => (
+    <AppWithMocks
+      setup={() =>
+        setupSimpleChatStory({
+          workspaceId: "ws-user-list",
+          messages: [
+            createUserMessage("msg-1", USER_LIST_CONTENT, {
+              historySequence: 1,
+              timestamp: STABLE_TIMESTAMP - 10000,
+            }),
+            createAssistantMessage("msg-2", "Noted.", {
+              historySequence: 2,
+              timestamp: STABLE_TIMESTAMP,
+            }),
+          ],
+        })
+      }
+    />
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    await waitForChatMessagesLoaded(canvasElement);
+
+    const orderedList = await waitFor(
+      () => {
+        const list = canvasElement.querySelector(".user-message-markdown ol");
+        if (!list) throw new Error("User list not found");
+        return list as HTMLOListElement;
+      },
+      { timeout: 5000 }
+    );
+
+    const listStyle = window.getComputedStyle(orderedList);
+    await expect(listStyle.marginTop).toBe("0px");
+    await expect(listStyle.marginBottom).toBe("0px");
+
+    const firstItem = orderedList.querySelector("li");
+    if (!firstItem) throw new Error("List item not found");
+    const itemStyle = window.getComputedStyle(firstItem);
+    await expect(itemStyle.paddingBottom).toBe("0px");
+  },
+};
 
 /** User message with code blocks - tests scrolling for long lines */
 export const UserMessageCodeBlock: AppStory = {

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -1430,6 +1430,15 @@ code {
   list-style-type: decimal;
 }
 
+
+.markdown-content.user-message-markdown ul,
+.markdown-content.user-message-markdown ol {
+  margin: 0;
+}
+
+.markdown-content.user-message-markdown li {
+  padding-bottom: 0;
+}
 .markdown-content li {
   margin: 0;
   padding: 0 0 4px 0;


### PR DESCRIPTION
## Summary
- tag user message markdown containers for list-specific spacing overrides
- remove extra list margins/padding in user messages
- add a storybook regression for user list spacing

## Why
- User message ordered lists were inheriting markdown list padding, adding extra vertical space compared to plain lines.

## Testing
- make typecheck
- make static-check

---

_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `xhigh` • Cost: `$0.36`_
