### PR TITLE
🤖 fix: reduce tool icon size

### DIFF
--- a/src/browser/components/tools/shared/ToolPrimitives.tsx
+++ b/src/browser/components/tools/shared/ToolPrimitives.tsx
@@ -204,7 +204,7 @@ export const ToolIcon: React.FC<ToolIconProps> = ({ toolName, emoji, className }
       <TooltipTrigger asChild>
         <span
           className={cn(
-            "inline-flex shrink-0 items-center justify-center text-secondary [&_svg]:size-3.5",
+            "inline-flex shrink-0 items-center justify-center text-secondary [&_svg]:size-3",
             className
           )}
         >


### PR DESCRIPTION
## Summary
- shrink tool header icon size to better match text scale

## Testing
- `make static-check`

---

_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `xhigh` • Cost: `$0.14`_
