### PR TITLE
🤖 feat: add System 1 experiment + model preference

### DIFF
--- a/src/browser/components/Settings/sections/ModelsSection.tsx
+++ b/src/browser/components/Settings/sections/ModelsSection.tsx
@@ -1,12 +1,15 @@
 import React, { useState, useCallback, useRef, useEffect } from "react";
 import { Plus, Loader2, Check, ChevronDown } from "lucide-react";
 import { SUPPORTED_PROVIDERS, PROVIDER_DISPLAY_NAMES } from "@/common/constants/providers";
+import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
 import {
   LAST_CUSTOM_MODEL_PROVIDER_KEY,
   PREFERRED_COMPACTION_MODEL_KEY,
+  PREFERRED_SYSTEM_1_MODEL_KEY,
 } from "@/common/constants/storage";
 import { useModelsFromSettings, getSuggestedModels } from "@/browser/hooks/useModelsFromSettings";
+import { useExperimentValue } from "@/browser/hooks/useExperiments";
 import { useGateway } from "@/browser/hooks/useGatewayModels";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
 import { ModelRow } from "./ModelRow";
@@ -239,6 +242,15 @@ export function ModelsSection() {
     { listener: true }
   );
 
+  const system1Enabled = useExperimentValue(EXPERIMENT_IDS.SYSTEM_1);
+
+  // System 1 model preference (experiment-gated)
+  const [system1Model, setSystem1Model] = usePersistedState<string>(
+    PREFERRED_SYSTEM_1_MODEL_KEY,
+    "",
+    { listener: true }
+  );
+
   // All models (including hidden) for the settings dropdowns
   const allModels = getSuggestedModels(config);
 
@@ -411,6 +423,22 @@ export function ModelsSection() {
               />
             </div>
           </div>
+          {system1Enabled && (
+            <div className="flex items-center gap-4 px-2 py-2 md:px-3">
+              <div className="w-28 shrink-0 md:w-32">
+                <div className="text-muted text-xs">System 1</div>
+                <div className="text-muted-light text-[10px]">Context optimization</div>
+              </div>
+              <div className="min-w-0 flex-1">
+                <SearchableModelSelect
+                  value={system1Model}
+                  onChange={setSystem1Model}
+                  models={allModels}
+                  emptyOption={{ value: "", label: "Use workspace model" }}
+                />
+              </div>
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/common/constants/experiments.ts
+++ b/src/common/constants/experiments.ts
@@ -10,6 +10,7 @@ export const EXPERIMENT_IDS = {
   PROGRAMMATIC_TOOL_CALLING: "programmatic-tool-calling",
   PROGRAMMATIC_TOOL_CALLING_EXCLUSIVE: "programmatic-tool-calling-exclusive",
   CONFIGURABLE_BIND_URL: "configurable-bind-url",
+  SYSTEM_1: "system-1",
 } as const;
 
 export type ExperimentId = (typeof EXPERIMENT_IDS)[keyof typeof EXPERIMENT_IDS];
@@ -66,6 +67,14 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     name: "Expose API server on LAN/VPN",
     description:
       "Allow mux to listen on a non-localhost address so other devices on your LAN/VPN can connect. Anyone on your network with the auth token can access your mux API. HTTP only; use only on trusted networks (Tailscale recommended).",
+    enabledByDefault: false,
+    userOverridable: true,
+    showInSettings: true,
+  },
+  [EXPERIMENT_IDS.SYSTEM_1]: {
+    id: EXPERIMENT_IDS.SYSTEM_1,
+    name: "System 1",
+    description: "Context optimization helpers inspired by Thinking, Fast and Slow (Kahneman)",
     enabledByDefault: false,
     userOverridable: true,
     showInSettings: true,

--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -207,6 +207,12 @@ export function getLastRuntimeConfigKey(projectPath: string): string {
 export const PREFERRED_COMPACTION_MODEL_KEY = "preferredCompactionModel";
 
 /**
+ * Get the localStorage key for the preferred System 1 model (global)
+ * Format: "preferredSystem1Model"
+ */
+export const PREFERRED_SYSTEM_1_MODEL_KEY = "preferredSystem1Model";
+
+/**
  * Get the localStorage key for cached mode AI defaults (global).
  * Format: "modeAiDefaults"
  */


### PR DESCRIPTION
Adds a new user-overridable **System 1** experiment and a corresponding model preference.

When enabled, **Settings → Models** shows a **System 1** selector (stored in localStorage) so future context-optimization features can pick a dedicated model, or fall back to the workspace model.

Validation:
- `make static-check`

---

<details>
<summary>📋 Implementation Plan</summary>

# Add "System 1" experiment + model preference

## Recommended approach: localStorage model preference + UI gating _(net +35 LoC)_

### 1) Add the experiment flag (shown in **Settings → Experiments**)
- Update `src/common/constants/experiments.ts`:
  - Add `SYSTEM_1: "system-1"` to `EXPERIMENT_IDS`.
  - Add an entry in `EXPERIMENTS`:
    - `name`: `System 1`
    - `description`: short blurb like “Context optimization helpers inspired by *Thinking, Fast and Slow* (Kahneman).”
    - `enabledByDefault: false`
    - `userOverridable: true` (required to show in Settings)
    - `showInSettings: true`

### 2) Add a persisted config key for the System 1 model
- Update `src/common/constants/storage.ts`:
  - Add `export const PREFERRED_SYSTEM_1_MODEL_KEY = "preferredSystem1Model";`
  - Keep it near `PREFERRED_COMPACTION_MODEL_KEY` since it’s another global model preference.

### 3) Add the "System 1" row to **Settings → Models** (only when enabled)
- Update `src/browser/components/Settings/sections/ModelsSection.tsx`:
  - Import:
    - `EXPERIMENT_IDS` from `@/common/constants/experiments`
    - `useExperimentValue` from `@/browser/hooks/useExperiments`
    - `PREFERRED_SYSTEM_1_MODEL_KEY` from `@/common/constants/storage`
  - Add state:
    - `const system1Enabled = useExperimentValue(EXPERIMENT_IDS.SYSTEM_1);`
    - `const [system1Model, setSystem1Model] = usePersistedState<string>(PREFERRED_SYSTEM_1_MODEL_KEY, "", { listener: true });`
  - Render (immediately **below** the compaction model row):
    - `{system1Enabled && (
        <div className="flex items-center ...">...
          <div className="text-muted text-xs">System 1</div>
          <div className="text-muted-light text-[10px]">Context optimization</div>
          <SearchableModelSelect
            value={system1Model}
            onChange={setSystem1Model}
            models={allModels}
            emptyOption={{ value: "", label: "Use workspace model" }}
          />
        </div>
      )}`

### 4) Validation (manual)
- Enable **System 1** in **Settings → Experiments**.
- Open **Settings → Models** and confirm the new **System 1** selector appears under **Compaction Model**.
- Pick a model; confirm it persists after reload.
- Disable the experiment; confirm the row hides but the stored preference remains (for future feature work).

<details>
<summary>Alternative: persist System 1 model in ~/.mux/config.json (not recommended right now)</summary>

This would require adding a new field to the main config schema + IPC plumbing to read/write it from the Settings UI. It’s more complex and higher risk for a setting that is not consumed yet.

- Expected net new product code: **+100–150 LoC** (schema/type updates + backend config save + renderer API + UI).

</details>

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: $1.85_
