### PR TITLE
🤖 fix: reread plan after compaction

### DIFF
--- a/src/common/utils/ui/modeUtils.test.ts
+++ b/src/common/utils/ui/modeUtils.test.ts
@@ -1,4 +1,4 @@
-import { getPlanModeInstruction } from "./modeUtils";
+import { getPlanFileHint, getPlanModeInstruction } from "./modeUtils";
 
 describe("getPlanModeInstruction", () => {
   it("provides plan file path context", () => {
@@ -33,5 +33,21 @@ describe("getPlanModeInstruction", () => {
 
     expect(instruction).toContain('MUST ONLY spawn `agentId: "explore"` tasks');
     expect(instruction).toContain("Do NOT call `propose_plan` until");
+  });
+});
+
+describe("getPlanFileHint", () => {
+  it("returns null when the plan file does not exist", () => {
+    expect(getPlanFileHint("/tmp/plan.md", false)).toBeNull();
+  });
+
+  it("includes post-compaction guidance and an ignore escape hatch", () => {
+    const hint = getPlanFileHint("/tmp/plan.md", true);
+
+    if (!hint) throw new Error("expected non-null hint");
+
+    expect(hint).toContain("A plan file exists at: /tmp/plan.md");
+    expect(hint).toContain("compaction/context reset");
+    expect(hint).toContain("If it is unrelated to the current request, ignore it.");
   });
 });

--- a/src/common/utils/ui/modeUtils.ts
+++ b/src/common/utils/ui/modeUtils.ts
@@ -11,7 +11,7 @@ export function getPlanModeInstruction(planFilePath: string, planExists: boolean
     ? "You must use the plan file path exactly as shown (including the leading `~/`); do not expand `~` or use alternate paths that resolve to the same file."
     : "You must use the plan file path exactly as shown; do not rewrite it or use alternate paths that resolve to the same file.";
   const fileStatus = planExists
-    ? `A plan file already exists at ${planFilePath}. First, read it to determine if it's relevant to the current request. If the current request is unrelated to the existing plan, delete the file and start fresh. If relevant, make incremental edits using the file_edit_* tools.`
+    ? `A plan file already exists at ${planFilePath}. First, read it to determine if it's relevant to the current request. After any compaction/context reset (when earlier messages are replaced by a summary), re-read the plan before continuing. If the current request is unrelated to the existing plan, delete the file and start fresh. If relevant, make incremental edits using the file_edit_* tools.`
     : `No plan file exists yet. You should create your plan at ${planFilePath} using the file_edit_* tools.`;
 
   return `Plan file path: ${planFilePath} (MUST use this exact path string for tool calls; do NOT rewrite it into another form, even if it resolves to the same file)
@@ -59,5 +59,5 @@ If the user suggests that you should make edits to other files, ask them to swit
 export function getPlanFileHint(planFilePath: string, planExists: boolean): string | null {
   if (!planExists) return null;
 
-  return `A plan file exists at: ${planFilePath}. If a previously developed plan is relevant to the current work, read it and follow it. Otherwise, ignore it.`;
+  return `A plan file exists at: ${planFilePath}. If you are continuing previous work—especially after any compaction/context reset (when earlier messages are replaced by a summary)—you MUST read it before proceeding and use it as the source of truth for what remains. If it is unrelated to the current request, ignore it.`;
 }


### PR DESCRIPTION
Strengthen the system prompt plan-file hint so agents explicitly re-read the plan after compaction/context resets (and treat it as the source of truth), reducing drift after history is replaced by a summary.

This also mirrors the guidance in Plan Mode instructions and adds unit coverage for the non-Plan hint generation.

---

<details>
<summary>📋 Implementation Plan</summary>

# Reword plan-file system prompt hint (post-compaction continuity)

## Goal
Make the system prompt’s plan-file hint explicitly instruct agents to **re-read the plan after compaction/context loss** so they reliably resume remaining work instead of guessing.

## Recommended approach (update both non-Plan + Plan Mode)

### 1) Strengthen the non-Plan hint (`getPlanFileHint`)
Edit `src/common/utils/ui/modeUtils.ts` → `getPlanFileHint(planFilePath, planExists)` to replace the current sentence with something that:
- says this file is the **source of truth** when resuming work
- explicitly calls out **compaction/context reset** as the key time to re-read
- keeps the “ignore if unrelated” escape hatch

**Proposed wording (drop-in replacement):**

```ts
return `A plan file exists at: ${planFilePath}. If you are continuing previous work—especially after any compaction/context reset (when earlier messages are replaced by a summary)—you MUST read it before proceeding and use it as the source of truth for what remains. If it is unrelated to the current request, ignore it.`;
```

### 2) Mirror the intent in Plan Mode (`getPlanModeInstruction`)
Edit the Plan Mode instructions in the same file (`getPlanModeInstruction(...)`) to add a short, parallel sentence (so Plan Mode and non-Plan don’t diverge):
- “After compaction/context reset, re-read the plan before continuing.”

Keep this minimal to avoid bloating the system prompt.

## Validation
1. **Unit test**: add/update tests for `modeUtils` (e.g. `src/common/utils/ui/modeUtils.test.ts`) asserting:
   - the hint includes “compaction/context reset” (or equivalent)
   - the hint still includes “If it is unrelated … ignore it.”
2. Run:
   - `make typecheck`
   - `bun test <the new/updated test file>`
   - `make static-check`

## Alternatives

### A) Minimal scope (only non-Plan hint)
Only change `getPlanFileHint` and leave Plan Mode text as-is.

- **Pros:** smallest change / lowest token impact.
- **Cons:** slightly inconsistent guidance across modes.

## Net LoC estimate (product code only)
- **Alternative A:** ~+1 LoC (single string change).
- **Recommended approach:** ~+3 LoC (adjust both `getPlanFileHint` + Plan Mode instruction).

<details>
<summary>Notes / rationale</summary>

- Compaction in Mux replaces prior history with a summary message; the plan file is the most reliable structured “state” artifact that survives across that reset.
- The parenthetical (“when earlier messages are replaced by a summary”) makes the instruction actionable even if the model doesn’t know the term “compaction”.

</details>

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: $1.73_
