### PR TITLE
🤖 feat: add mouse back/forward button navigation

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -1,5 +1,6 @@
 import { Menu } from "lucide-react";
 import { useEffect, useCallback, useRef } from "react";
+import { useNavigate } from "react-router-dom";
 import "./styles/globals.css";
 import { useWorkspaceContext, toWorkspaceSelection } from "./contexts/WorkspaceContext";
 import { useProjectContext } from "./contexts/ProjectContext";
@@ -116,6 +117,9 @@ function AppInner() {
   const creationProjectPath = !selectedWorkspace
     ? (pendingNewWorkspaceProject ?? defaultProjectPath)
     : null;
+
+  // History navigation (back/forward)
+  const navigate = useNavigate();
 
   const startWorkspaceCreation = useStartWorkspaceCreation({
     projects,
@@ -537,6 +541,12 @@ function AppInner() {
       } else if (matchesKeybind(e, KEYBINDS.OPEN_SETTINGS)) {
         e.preventDefault();
         openSettings();
+      } else if (matchesKeybind(e, KEYBINDS.NAVIGATE_BACK)) {
+        e.preventDefault();
+        void navigate(-1);
+      } else if (matchesKeybind(e, KEYBINDS.NAVIGATE_FORWARD)) {
+        e.preventDefault();
+        void navigate(1);
       }
     };
 
@@ -550,7 +560,21 @@ function AppInner() {
     openCommandPalette,
     creationProjectPath,
     openSettings,
+    navigate,
   ]);
+  // Mouse back/forward buttons (buttons 3 and 4)
+  const handleMouseNavigation = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.button === 3) {
+        e.preventDefault();
+        void navigate(-1);
+      } else if (e.button === 4) {
+        e.preventDefault();
+        void navigate(1);
+      }
+    },
+    [navigate]
+  );
 
   // Layout slot hotkeys (Ctrl/Cmd+Alt+1..9 by default)
   useEffect(() => {
@@ -727,7 +751,10 @@ function AppInner() {
 
   return (
     <>
-      <div className="bg-bg-dark mobile-layout flex h-screen overflow-hidden">
+      <div
+        className="bg-bg-dark mobile-layout flex h-screen overflow-hidden"
+        onMouseUp={handleMouseNavigation}
+      >
         <LeftSidebar
           lastReadTimestamps={lastReadTimestamps}
           onToggleUnread={onToggleUnread}

--- a/src/browser/components/Settings/sections/KeybindsSection.tsx
+++ b/src/browser/components/Settings/sections/KeybindsSection.tsx
@@ -46,6 +46,8 @@ const KEYBIND_LABELS: Record<keyof typeof KEYBINDS, string> = {
   TOGGLE_HUNK_COLLAPSE: "Toggle hunk collapse",
   OPEN_SETTINGS: "Open settings",
   TOGGLE_VOICE_INPUT: "Toggle voice input",
+  NAVIGATE_BACK: "Navigate back",
+  NAVIGATE_FORWARD: "Navigate forward",
 };
 
 /** Groups for organizing keybinds in the UI */
@@ -82,7 +84,14 @@ const KEYBIND_GROUPS: Array<{ label: string; keys: Array<keyof typeof KEYBINDS> 
   },
   {
     label: "Navigation",
-    keys: ["NEW_WORKSPACE", "NEXT_WORKSPACE", "PREV_WORKSPACE", "JUMP_TO_BOTTOM"],
+    keys: [
+      "NEW_WORKSPACE",
+      "NEXT_WORKSPACE",
+      "PREV_WORKSPACE",
+      "NAVIGATE_BACK",
+      "NAVIGATE_FORWARD",
+      "JUMP_TO_BOTTOM",
+    ],
   },
   {
     label: "Sidebar Tabs",

--- a/src/browser/contexts/RouterContext.tsx
+++ b/src/browser/contexts/RouterContext.tsx
@@ -123,8 +123,10 @@ function RouterContextInner(props: { children: ReactNode }) {
   }, [location.pathname, location.search]);
   const pendingSectionId = location.pathname === "/project" ? searchParams.get("section") : null;
 
+  // Navigation functions use push (not replace) to build history for back/forward navigation.
+  // See App.tsx handleMouseNavigation and KEYBINDS.NAVIGATE_BACK/FORWARD.
   const navigateToWorkspace = useCallback((id: string) => {
-    void navigateRef.current(`/workspace/${encodeURIComponent(id)}`, { replace: true });
+    void navigateRef.current(`/workspace/${encodeURIComponent(id)}`);
   }, []);
 
   const navigateToProject = useCallback((path: string, sectionId?: string) => {
@@ -132,11 +134,11 @@ function RouterContextInner(props: { children: ReactNode }) {
     const url = sectionId
       ? `/project?project=${encodeURIComponent(projectId)}&section=${encodeURIComponent(sectionId)}`
       : `/project?project=${encodeURIComponent(projectId)}`;
-    void navigateRef.current(url, { replace: true, state: { projectPath: path } });
+    void navigateRef.current(url, { state: { projectPath: path } });
   }, []);
 
   const navigateToHome = useCallback(() => {
-    void navigateRef.current("/", { replace: true });
+    void navigateRef.current("/");
   }, []);
 
   const value = useMemo<RouterContext>(

--- a/src/browser/utils/ui/keybinds.ts
+++ b/src/browser/utils/ui/keybinds.ts
@@ -323,6 +323,16 @@ export const KEYBINDS = {
   // macOS: Cmd+D, Win/Linux: Ctrl+D
   // "D" for Dictate - intuitive and available
   TOGGLE_VOICE_INPUT: { key: "d", ctrl: true },
+
+  /** Navigate back in history */
+  // macOS: Cmd+[, Win/Linux: Ctrl+[
+  // Standard browser/editor back navigation
+  NAVIGATE_BACK: { key: "[", ctrl: true },
+
+  /** Navigate forward in history */
+  // macOS: Cmd+], Win/Linux: Ctrl+]
+  // Standard browser/editor forward navigation
+  NAVIGATE_FORWARD: { key: "]", ctrl: true },
 } as const;
 
 /**


### PR DESCRIPTION
Add history-based navigation between workspaces using mouse side buttons and keyboard shortcuts.

## What

- **Mouse**: Back/forward side buttons
- **Keyboard**: `Cmd+[` / `Cmd+]` (Mac) or `Ctrl+[` / `Ctrl+]` (Win/Linux)

## How

- Changed `replace: true` → push (default) in router navigation so history accumulates
- Added `NAVIGATE_BACK` / `NAVIGATE_FORWARD` keybinds
- Added `onMouseUp` handler on root div for mouse button navigation
- Added new shortcuts to Settings > Keybinds > Navigation section

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$3.64`_
