### PR TITLE
🤖 fix: SSH2 exit code race condition causing flaky tests

### DIFF
--- a/src/node/runtime/transports/SSH2Transport.ts
+++ b/src/node/runtime/transports/SSH2Transport.ts
@@ -45,8 +45,12 @@ class SSH2ChildProcess extends EventEmitter {
       this.signalCode = typeof signal === "string" ? signal : null;
     });
 
-    channel.on("close", () => {
-      this.emit("close", this.exitCode ?? 0, this.signalCode);
+    channel.on("close", (code?: number | null, signal?: string | null) => {
+      // Prefer code from close event args (ssh2 passes exit args to close),
+      // fall back to stored exitCode from exit event handler
+      const finalCode = typeof code === "number" ? code : this.exitCode;
+      const finalSignal = typeof signal === "string" ? signal : this.signalCode;
+      this.emit("close", finalCode ?? 0, finalSignal);
     });
 
     channel.on("error", (err: Error) => {


### PR DESCRIPTION
## Summary

Fixes flaky test `returns correct exit code for failed commands` in `tests/runtime/ssh2-runtime.test.ts`.

## Root Cause

The SSH2 channel's `close` event receives the same exit code/signal arguments as the `exit` event (per ssh2 docs). The previous code ignored these arguments and relied on instance state (`this.exitCode`) set by the `exit` handler, which caused a race condition when `close` fired before `exit` was processed—resulting in exit code `0` instead of the actual value.

## Fix

Use the `close` event's arguments directly, falling back to stored state only when not provided:

```typescript
channel.on("close", (code?: number | null, signal?: string | null) => {
  const finalCode = typeof code === "number" ? code : this.exitCode;
  const finalSignal = typeof signal === "string" ? signal : this.signalCode;
  this.emit("close", finalCode ?? 0, finalSignal);
});
```

This handles all cases:
- **Exit fired before close:** `close` receives the code as argument → use it directly
- **Exit didn't fire (optional per SSH2 spec):** `close` won't have code → fall back to stored state
- **Race condition:** `close` event's argument is authoritative, no dependency on instance state timing

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$1.27`_
