### PR TITLE
🤖 fix: align review read-more context base

### DIFF
--- a/src/browser/components/RightSidebar/CodeReview/useReadMore.ts
+++ b/src/browser/components/RightSidebar/CodeReview/useReadMore.ts
@@ -72,7 +72,7 @@ export function useReadMore(options: UseReadMoreOptions): UseReadMoreResult {
   const [atBOF, setAtBOF] = useState(() => hunk.oldStart <= 1);
   const [atEOF, setAtEOF] = useState(false);
 
-  // Git ref to read from
+  // Git ref expression to read from (merge-base for branch diffs)
   const gitRef = useMemo(
     () => getOldFileRef(diffBase, includeUncommitted),
     [diffBase, includeUncommitted]

--- a/src/browser/utils/review/readFileLines.ts
+++ b/src/browser/utils/review/readFileLines.ts
@@ -45,11 +45,13 @@ export async function readFileLines(
 
 /**
  * Determine which git ref to use for reading file context.
+ *
+ * Note: branch diffs use merge-base under the hood, so return a shell expression
+ * that resolves to the merge-base commit when needed.
  */
-export function getOldFileRef(diffBase: string, includeUncommitted: boolean): string {
+export function getOldFileRef(diffBase: string, _includeUncommitted: boolean): string {
   if (diffBase === "--staged" || diffBase === "HEAD") return "HEAD";
-  if (includeUncommitted) return diffBase;
-  return diffBase;
+  return `$(git merge-base ${diffBase} HEAD 2>/dev/null || echo ${diffBase})`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- resolve read-more context against the merge-base commit used by branch diffs
- keep expanded context line numbers aligned with the hunk to avoid duplicated lines after collapse breaks

## Testing
- make typecheck
- make static-check

---

_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `xhigh` • Cost: `$1.81`_
