### PR TITLE
🤖 docs: clarify skill discovery uses workspace, not project path

### DIFF
--- a/docs/agents/agent-skills.mdx
+++ b/docs/agents/agent-skills.mdx
@@ -5,7 +5,7 @@ description: Share reusable workflows and references with skills
 
 ## Overview
 
-Agent Skills are reusable, file-based “playbooks” that you can share across projects or keep project-local.
+Agent Skills are reusable, file-based “playbooks” that you can share across projects or keep workspace-local.
 
 Mux follows the Agent Skills specification and exposes skills to models in two steps:
 
@@ -18,11 +18,11 @@ This keeps the system prompt small while still making skills discoverable.
 
 Mux discovers skills from three roots:
 
-- **Project-local**: `<projectRoot>/.mux/skills/<skill-name>/SKILL.md`
+- **Workspace-local**: `.mux/skills/<skill-name>/SKILL.md` (in the workspace working directory)
 - **Global**: `~/.mux/skills/<skill-name>/SKILL.md`
 - **Built-in**: shipped with Mux
 
-If a skill exists in multiple locations, the precedence order is: **project-local > global > built-in**.
+If a skill exists in multiple locations, the precedence order is: **workspace-local > global > built-in**.
 
 <Info>
   Mux reads skills using the active workspace runtime. For SSH workspaces, skills are read from the


### PR DESCRIPTION
## Summary

Skills are read from the **workspace working directory** (worktree, SSH clone, Docker container, etc.), not the original project path. The previous terminology "project-local" was misleading since skills use the Runtime abstraction and respect the active workspace.

## Changes

- Change "Project-local" → "Workspace-local"
- Update path from `<projectRoot>/.mux/skills/` → `.mux/skills/` (relative to workspace)
- Add clarification that this is the workspace working directory

## Why

The implementation reads skills via `runtime.normalizePath(".mux/skills", workspacePath)`, where `workspacePath` is the workspace directory—not `projectPath`. This enables live editing of skills in worktrees/SSH clones, but the docs implied they came from the original project.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$2.98`_