### PR TITLE
🤖 fix: extend workspace effects into starting

### DIFF
--- a/src/browser/components/WorkspaceHeader.tsx
+++ b/src/browser/components/WorkspaceHeader.tsx
@@ -53,7 +53,8 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
   const openTerminalPopout = useOpenTerminal();
   const openInEditor = useOpenInEditor();
   const gitStatus = useGitStatus(workspaceId);
-  const { canInterrupt } = useWorkspaceSidebarState(workspaceId);
+  const { canInterrupt, isStarting, awaitingUserQuestion } = useWorkspaceSidebarState(workspaceId);
+  const isWorking = (canInterrupt || isStarting) && !awaitingUserQuestion;
   const { startSequence: startTutorial } = useTutorial();
   const [editorError, setEditorError] = useState<string | null>(null);
   const [debugLlmRequestOpen, setDebugLlmRequestOpen] = useState(false);
@@ -138,7 +139,7 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
         )}
         <RuntimeBadge
           runtimeConfig={runtimeConfig}
-          isWorking={canInterrupt}
+          isWorking={isWorking}
           workspacePath={namedWorkspacePath}
           workspaceName={workspaceName}
           tooltipSide="bottom"
@@ -151,7 +152,7 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
             workspaceId={workspaceId}
             projectPath={projectPath}
             tooltipPosition="bottom"
-            isWorking={canInterrupt}
+            isWorking={isWorking}
           />
         </div>
       </div>

--- a/src/browser/components/WorkspaceListItem.tsx
+++ b/src/browser/components/WorkspaceListItem.tsx
@@ -109,8 +109,8 @@ const WorkspaceListItemInner: React.FC<WorkspaceListItemProps> = ({
     }
   };
 
-  const { canInterrupt, awaitingUserQuestion } = useWorkspaceSidebarState(workspaceId);
-  const isWorking = canInterrupt && !awaitingUserQuestion;
+  const { canInterrupt, awaitingUserQuestion, isStarting } = useWorkspaceSidebarState(workspaceId);
+  const isWorking = (canInterrupt || isStarting) && !awaitingUserQuestion;
   const safeDepth = typeof depth === "number" && Number.isFinite(depth) ? Math.max(0, depth) : 0;
   const paddingLeft = 9 + Math.min(32, safeDepth) * 12;
 

--- a/src/browser/components/WorkspaceStatusDot.tsx
+++ b/src/browser/components/WorkspaceStatusDot.tsx
@@ -11,10 +11,16 @@ export const WorkspaceStatusDot = memo<{
   size?: number;
 }>(
   ({ workspaceId, lastReadTimestamp, onClick, size = 8 }) => {
-    const { canInterrupt, awaitingUserQuestion, currentModel, agentStatus, recencyTimestamp } =
-      useWorkspaceSidebarState(workspaceId);
+    const {
+      canInterrupt,
+      isStarting,
+      awaitingUserQuestion,
+      currentModel,
+      agentStatus,
+      recencyTimestamp,
+    } = useWorkspaceSidebarState(workspaceId);
 
-    const streaming = canInterrupt && !awaitingUserQuestion;
+    const isWorking = (canInterrupt || isStarting) && !awaitingUserQuestion;
 
     // Compute unread status if lastReadTimestamp provided (sidebar only)
     const unread = useMemo(() => {
@@ -26,18 +32,18 @@ export const WorkspaceStatusDot = memo<{
     const title = useMemo(
       () =>
         getStatusTooltip({
-          isStreaming: streaming,
+          isStreaming: isWorking,
           isAwaitingInput: awaitingUserQuestion,
           streamingModel: currentModel,
           agentStatus,
           isUnread: unread,
           recencyTimestamp,
         }),
-      [streaming, awaitingUserQuestion, currentModel, agentStatus, unread, recencyTimestamp]
+      [isWorking, awaitingUserQuestion, currentModel, agentStatus, unread, recencyTimestamp]
     );
 
-    const bgColor = canInterrupt ? "bg-blue-400" : unread ? "bg-gray-300" : "bg-muted-dark";
-    const cursor = onClick && !streaming ? "cursor-pointer" : "cursor-default";
+    const bgColor = isWorking ? "bg-blue-400" : unread ? "bg-gray-300" : "bg-muted-dark";
+    const cursor = onClick && !isWorking ? "cursor-pointer" : "cursor-default";
 
     return (
       <Tooltip>
@@ -48,8 +54,8 @@ export const WorkspaceStatusDot = memo<{
               "rounded-full shrink-0 transition-colors duration-200",
               bgColor,
               cursor,
-              onClick && !streaming && "hover:opacity-70",
-              streaming && "animate-pulse"
+              onClick && !isWorking && "hover:opacity-70",
+              isWorking && "animate-pulse"
             )}
             onClick={(e) => {
               e.stopPropagation();

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -153,6 +153,7 @@ export interface SessionTimingStats {
  */
 export interface WorkspaceSidebarState {
   canInterrupt: boolean;
+  isStarting: boolean;
   awaitingUserQuestion: boolean;
   currentModel: string | null;
   recencyTimestamp: number | null;
@@ -901,6 +902,7 @@ export class WorkspaceStore {
    */
   getWorkspaceSidebarState(workspaceId: string): WorkspaceSidebarState {
     const fullState = this.getWorkspaceState(workspaceId);
+    const isStarting = fullState.pendingStreamStartTime !== null && !fullState.canInterrupt;
 
     const cached = this.sidebarStateCache.get(workspaceId);
     if (cached && this.sidebarStateSourceState.get(workspaceId) === fullState) {
@@ -913,6 +915,7 @@ export class WorkspaceStore {
     // use useWorkspaceStatsSnapshot() which has its own subscription.
     if (
       cached?.canInterrupt === fullState.canInterrupt &&
+      cached.isStarting === isStarting &&
       cached.awaitingUserQuestion === fullState.awaitingUserQuestion &&
       cached.currentModel === fullState.currentModel &&
       cached.recencyTimestamp === fullState.recencyTimestamp &&
@@ -927,6 +930,7 @@ export class WorkspaceStore {
     // Create and cache new state
     const newState: WorkspaceSidebarState = {
       canInterrupt: fullState.canInterrupt,
+      isStarting,
       awaitingUserQuestion: fullState.awaitingUserQuestion,
       currentModel: fullState.currentModel,
       recencyTimestamp: fullState.recencyTimestamp,


### PR DESCRIPTION
Summary
- Treat workspace "starting" as a working state so streaming visual effects (shimmer/pulse) stay active before stream-start.

Background
- The sidebar effects only followed active streams, leaving a gap during the pre-stream starting phase.

Implementation
- Added an isStarting flag to sidebar state derived from pendingStreamStartTime.
- Reused the working predicate in workspace header, list item shimmer, and status dot pulse/color.

Validation
- make static-check

Risks
- Low: UI-only state derivation; no backend behavior changes.

---

_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `xhigh` • Cost: `$1.66`_

<!-- mux-attribution: model=openai:gpt-5.2-codex thinking=xhigh costs=1.66 -->
