### PR TITLE
🤖 feat: add 'gemini' as primary alias for gemini-3-pro

### DIFF
--- a/docs/config/models.mdx
+++ b/docs/config/models.mdx
@@ -22,7 +22,7 @@ Mux ships with curated models kept up to date with the frontier. Use any custom 
 | GPT-5.1 Codex          | openai:gpt-5.1-codex          | `codex-5.1`                              |         |
 | GPT-5.1 Codex Mini     | openai:gpt-5.1-codex-mini     | `codex-mini`                             |         |
 | GPT-5.1 Codex Max      | openai:gpt-5.1-codex-max      | `codex-max`                              |         |
-| Gemini 3 Pro Preview   | google:gemini-3-pro-preview   | `gemini-3`, `gemini-3-pro`               |         |
+| Gemini 3 Pro Preview   | google:gemini-3-pro-preview   | `gemini`, `gemini-3`, `gemini-3-pro`     |         |
 | Gemini 3 Flash Preview | google:gemini-3-flash-preview | `gemini-3-flash`                         |         |
 | Grok 4 1 Fast          | xai:grok-4-1-fast             | `grok`, `grok-4`, `grok-4.1`, `grok-4-1` |         |
 | Grok Code Fast 1       | xai:grok-code-fast-1          | `grok-code`                              |         |

--- a/src/common/constants/knownModels.ts
+++ b/src/common/constants/knownModels.ts
@@ -87,7 +87,7 @@ const MODEL_DEFINITIONS = {
   GEMINI_3_PRO: {
     provider: "google",
     providerModelId: "gemini-3-pro-preview",
-    aliases: ["gemini-3", "gemini-3-pro"],
+    aliases: ["gemini", "gemini-3", "gemini-3-pro"],
     tokenizerOverride: "google/gemini-2.5-pro",
   },
   GEMINI_3_FLASH: {


### PR DESCRIPTION
## Summary

Add `gemini` as the primary alias for `GEMINI_3_PRO`, following the pattern of other models (`grok`, `opus`, `sonnet`, etc.).

## Implementation

Updated `src/common/constants/knownModels.ts` to add `"gemini"` as the first alias:
- **Before:** `["gemini-3", "gemini-3-pro"]`
- **After:** `["gemini", "gemini-3", "gemini-3-pro"]`

Old aliases are preserved for backwards compatibility.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.23`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=0.23 -->
