### PR TITLE
🤖 feat: make gateway icon clickable to toggle off

### DIFF
--- a/src/browser/components/ModelSelector.tsx
+++ b/src/browser/components/ModelSelector.tsx
@@ -259,12 +259,17 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
           {gatewayActive && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <GatewayIcon
-                  className="text-accent h-3 w-3 shrink-0"
-                  active
-                  role="img"
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    gateway.toggleModelGateway(value);
+                  }}
+                  className="cursor-pointer transition-opacity hover:opacity-70"
                   aria-label="Using Mux Gateway"
-                />
+                >
+                  <GatewayIcon className="text-accent h-3 w-3 shrink-0" active />
+                </button>
               </TooltipTrigger>
               <TooltipContent align="center">Using Mux Gateway</TooltipContent>
             </Tooltip>


### PR DESCRIPTION
## Summary

Makes the Mux Gateway icon in the model selector clickable. Clicking it toggles gateway off for that model, causing the icon to disappear (since the icon only shows when gateway is active for the current model).

## Implementation

- Wrapped the `GatewayIcon` in a button element
- Added `onClick` handler that calls `gateway.toggleModelGateway(value)`
- Added `cursor-pointer` for proper hover affordance
- Used `e.stopPropagation()` to prevent triggering the model selector dropdown

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.98`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=0.98 -->