### PR TITLE
🤖 fix: change AgentsInitBanner CTA button from 'Initialize' to 'Run /init'

### DIFF
--- a/src/browser/components/AgentsInitBanner.tsx
+++ b/src/browser/components/AgentsInitBanner.tsx
@@ -35,7 +35,7 @@ export function AgentsInitBanner(props: AgentsInitBannerProps) {
           className="bg-accent hover:bg-accent/80 text-accent-foreground inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors"
           data-testid="agents-init-run"
         >
-          Initialize
+          Run /init
         </button>
         <button
           type="button"


### PR DESCRIPTION
## Summary

Changes the AgentsInitBanner CTA button text from "Initialize" to "Run /init".

## Background

The previous "Initialize" text was misleading when an `AGENTS.md` already exists—the description says "Add or improve", implying the action works in both cases.

"Run /init" is accurate regardless of whether the file is being created or improved, and it teaches users the slash command so they can run it themselves later.

---

_Generated with [mux](https://github.com/coder/mux) · `anthropic:claude-opus-4-5`_
