### PR TITLE
🤖 fix: allow layout slot hotkeys while typing

### DIFF
--- a/src/browser/utils/ui/layoutSlotHotkeys.test.ts
+++ b/src/browser/utils/ui/layoutSlotHotkeys.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { GlobalWindow } from "happy-dom";
+
+import { handleLayoutSlotHotkeys } from "./layoutSlotHotkeys";
+import type { LayoutPresetsConfig, LayoutPreset } from "@/common/types/uiLayouts";
+
+function createEvent(overrides: Partial<KeyboardEvent> = {}): KeyboardEvent {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  return {
+    key: "1",
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    preventDefault: () => undefined,
+    ...overrides,
+  } as KeyboardEvent;
+}
+
+function createPreset(): LayoutPreset {
+  return {
+    id: "preset-1",
+    name: "Slot 1",
+    leftSidebarCollapsed: false,
+    rightSidebar: {
+      collapsed: false,
+      width: { mode: "px", value: 400 },
+      layout: {
+        version: 1,
+        nextId: 1,
+        focusedTabsetId: "tabset-1",
+        root: {
+          type: "tabset",
+          id: "tabset-1",
+          tabs: ["costs"],
+          activeTab: "costs",
+        },
+      },
+    },
+  };
+}
+
+function createLayoutPresetsWithSlot1(): LayoutPresetsConfig {
+  return {
+    version: 2,
+    slots: [{ slot: 1, preset: createPreset() }],
+  };
+}
+
+describe("handleLayoutSlotHotkeys", () => {
+  beforeEach(() => {
+    const happyWindow = new GlobalWindow();
+    globalThis.window = happyWindow as unknown as Window & typeof globalThis;
+    globalThis.document = happyWindow.document as unknown as Document;
+    (globalThis as unknown as { HTMLElement: unknown }).HTMLElement = happyWindow.HTMLElement;
+  });
+
+  afterEach(() => {
+    globalThis.window = undefined as unknown as Window & typeof globalThis;
+    globalThis.document = undefined as unknown as Document;
+    (globalThis as unknown as { HTMLElement?: unknown }).HTMLElement = undefined;
+  });
+
+  test("handles slot hotkey even when focus is in a textarea", () => {
+    const applySlotToWorkspace = mock((_workspaceId: string, _slot: number) => Promise.resolve());
+    const preventDefault = mock(() => undefined);
+
+    const textarea = document.createElement("textarea");
+
+    const handled = handleLayoutSlotHotkeys(
+      createEvent({ key: "1", ctrlKey: true, altKey: true, target: textarea, preventDefault }),
+      {
+        isCommandPaletteOpen: false,
+        isSettingsOpen: false,
+        selectedWorkspaceId: "ws",
+        layoutPresets: createLayoutPresetsWithSlot1(),
+        applySlotToWorkspace,
+      }
+    );
+
+    expect(handled).toBe(true);
+    expect(preventDefault.mock.calls.length).toBe(1);
+    expect(applySlotToWorkspace.mock.calls).toEqual([["ws", 1]]);
+  });
+
+  test("does not handle slot hotkey when a terminal is focused", () => {
+    const applySlotToWorkspace = mock((_workspaceId: string, _slot: number) => Promise.resolve());
+
+    const terminalContainer = document.createElement("div");
+    terminalContainer.setAttribute("data-terminal-container", "true");
+
+    const textarea = document.createElement("textarea");
+    terminalContainer.appendChild(textarea);
+
+    const handled = handleLayoutSlotHotkeys(
+      createEvent({ key: "1", ctrlKey: true, altKey: true, target: textarea }),
+      {
+        isCommandPaletteOpen: false,
+        isSettingsOpen: false,
+        selectedWorkspaceId: "ws",
+        layoutPresets: createLayoutPresetsWithSlot1(),
+        applySlotToWorkspace,
+      }
+    );
+
+    expect(handled).toBe(false);
+    expect(applySlotToWorkspace.mock.calls.length).toBe(0);
+  });
+
+  test("does not handle slot hotkey when AltGr is active", () => {
+    const applySlotToWorkspace = mock((_workspaceId: string, _slot: number) => Promise.resolve());
+
+    const textarea = document.createElement("textarea");
+
+    const handled = handleLayoutSlotHotkeys(
+      createEvent({
+        key: "1",
+        ctrlKey: true,
+        altKey: true,
+        target: textarea,
+        getModifierState: (key: string) => key === "AltGraph",
+      }),
+      {
+        isCommandPaletteOpen: false,
+        isSettingsOpen: false,
+        selectedWorkspaceId: "ws",
+        layoutPresets: createLayoutPresetsWithSlot1(),
+        applySlotToWorkspace,
+      }
+    );
+
+    expect(handled).toBe(false);
+    expect(applySlotToWorkspace.mock.calls.length).toBe(0);
+  });
+});

--- a/src/browser/utils/ui/layoutSlotHotkeys.ts
+++ b/src/browser/utils/ui/layoutSlotHotkeys.ts
@@ -1,0 +1,72 @@
+import type { LayoutPresetsConfig, LayoutSlotNumber } from "@/common/types/uiLayouts";
+import { getEffectiveSlotKeybind, getPresetForSlot } from "@/browser/utils/uiLayouts";
+import { matchesKeybind, isTerminalFocused } from "@/browser/utils/ui/keybinds";
+
+export function handleLayoutSlotHotkeys(
+  e: KeyboardEvent,
+  params: {
+    isCommandPaletteOpen: boolean;
+    isSettingsOpen: boolean;
+    selectedWorkspaceId: string | null;
+    layoutPresets: LayoutPresetsConfig;
+    applySlotToWorkspace: (workspaceId: string, slot: LayoutSlotNumber) => Promise<void>;
+  }
+): boolean {
+  if (params.isCommandPaletteOpen || params.isSettingsOpen) {
+    return false;
+  }
+
+  const workspaceId = params.selectedWorkspaceId;
+  if (!workspaceId) {
+    return false;
+  }
+
+  // Slot hotkeys are global, but we avoid stealing keyboard shortcuts from terminals.
+  if (isTerminalFocused(e.target)) {
+    return false;
+  }
+
+  // AltGr is commonly implemented as Ctrl+Alt; avoid treating it as our shortcut.
+  if (typeof e.getModifierState === "function" && e.getModifierState("AltGraph")) {
+    return false;
+  }
+
+  for (const slot of [1, 2, 3, 4, 5, 6, 7, 8, 9] as const) {
+    const preset = getPresetForSlot(params.layoutPresets, slot);
+    if (!preset) {
+      continue;
+    }
+
+    const keybind = getEffectiveSlotKeybind(params.layoutPresets, slot);
+    if (!keybind || !matchesKeybind(e, keybind)) {
+      continue;
+    }
+
+    e.preventDefault();
+    void params.applySlotToWorkspace(workspaceId, slot).catch(() => {
+      // Best-effort only.
+    });
+    return true;
+  }
+
+  // Custom overrides for additional slots (10+).
+  for (const slotConfig of params.layoutPresets.slots) {
+    if (slotConfig.slot <= 9) {
+      continue;
+    }
+    if (!slotConfig.preset || !slotConfig.keybindOverride) {
+      continue;
+    }
+    if (!matchesKeybind(e, slotConfig.keybindOverride)) {
+      continue;
+    }
+
+    e.preventDefault();
+    void params.applySlotToWorkspace(workspaceId, slotConfig.slot).catch(() => {
+      // Best-effort only.
+    });
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
Summary
- Fixes layout slot hotkeys (Ctrl/Cmd+Alt+1..9 by default) so they work even when a text input/textarea is focused.
- Keeps protections for terminal focus and AltGr (AltGraph) keyboards.

Implementation
- Centralized slot hotkey handling into `handleLayoutSlotHotkeys`.
- Removed the `isEditableElement(...)` early-return that prevented slot hotkeys while typing.

Validation
- `bun test src/browser/utils/ui/layoutSlotHotkeys.test.ts`
- `make static-check`

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix: Layout slot hotkeys should work while a text input is focused

## Context / Why
Users expect the **layout slot hotkeys** (apply saved UI layout presets) to be global. Today they stop working when focus is inside a text field (e.g., the chat prompt textarea), which makes quick layout switching frustrating during normal use.

Goal: make **layout slot hotkeys** work even when an `<input>` / `<textarea>` is focused, while preserving safety for:
- Command Palette / Settings (don’t trigger behind modal UIs)
- Terminal focus (don’t steal key chords intended for xterm/shell)
- AltGr keyboards (don’t misinterpret `Ctrl+Alt` used for typing)

## Evidence (why this happens)
- `src/browser/App.tsx` registers a **capture-phase** `window` `keydown` listener for layout slots.
  - It returns early when `isEditableElement(e.target)` is true:
    - `// Don't let global slot hotkeys fire while the user is typing.`
    - `if (isEditableElement(e.target) || isTerminalFocused(e.target)) return;`
  - Therefore, when the chat input textarea is focused, **slot hotkeys never reach the matching logic**.
- `src/browser/utils/ui/keybinds.ts`:
  - `isEditableElement()` returns true for `input`, `textarea`, and `contentEditable="true"`.
  - `isTerminalFocused()` detects `[data-terminal-container]` ancestors.
- `src/browser/utils/uiLayouts.ts`:
  - Default slot keybinds for slots 1–9 are `{ ctrl: true, alt: true, key: "1".."9" }` (macOS treats `ctrl` as Ctrl/Cmd by default via `matchesKeybind`).

---

## Approach A (recommended): Allow layout slot hotkeys even while typing
**Net new LoC (product code): ~5–20**

### Plan
1. **Change the guard order/logic in `src/browser/App.tsx`** (inside the “Layout slot hotkeys” `handleKeyDownCapture`).
   - Keep existing early returns:
     - command palette / settings open
     - no `selectedWorkspace`
   - Keep (or move earlier) the existing **AltGraph/AltGr** protection:
     - `if (e.getModifierState?.("AltGraph")) return;`
   - Update the “typing” guard so that **editable elements no longer block layout slot hotkeys**.
     - Minimal/safe version:
       - Remove `isEditableElement(e.target)` from the early return
       - Keep `isTerminalFocused(e.target)` in the early return
   - Update the comment to reflect the new intent (e.g., “slot hotkeys are global; only blocked for terminal + AltGr + modal UIs”).

2. **Regression tests**
   - Add a focused test that proves: when a textarea is focused, pressing the slot hotkey still applies the slot.
   - Suggested options (choose the least invasive that the repo’s existing harness supports):
     - **UI test (preferred for behavior):** in `tests/ui`, render the full app, focus the chat textarea, send `Cmd/Ctrl+Alt+1`, and assert a visible layout change from a known preset.
     - **Unit test (fallback):** extract a tiny helper from the App.tsx handler (e.g., `findMatchingLayoutSlot(e, layoutPresets)`) and verify it matches regardless of `e.target` being an input, while still ignoring AltGraph.

3. **Validation**
   - Run `make typecheck`.
   - Run the new/updated targeted test(s).

<details>
<summary>Why this approach is safe</summary>

- Slot hotkeys are chorded (`Ctrl/Cmd+Alt+<digit>`) and already `preventDefault()` when matched.
- The code already includes an AltGr guard (`AltGraph`) explicitly to avoid `Ctrl+Alt` typing collisions on many keyboard layouts.
- Keeping `isTerminalFocused()` preserves terminal-first behavior.
</details>

---

## Approach B (optional): Make it configurable in Settings
**Net new LoC (product code): ~60–140**

### Plan
- Add a boolean setting (persisted) like **“Enable layout slot hotkeys while typing”**.
- Default it to **enabled** (to satisfy the reported issue) or keep current default (if you want conservative behavior) and document the trade-off.
- Gate the editable-element early return behind this flag.
- Add a small Settings UI control + tooltip.

---

## Recommendation
Implement **Approach A** first (simple and matches user expectations). Only add Approach B if you expect meaningful disagreement about whether slot hotkeys should be allowed while typing.


</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$0.54`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=0.54 -->
