### PR TITLE
🤖 fix: focus review panel on Cmd/Ctrl+2

### DIFF
--- a/src/browser/components/RightSidebar.tsx
+++ b/src/browser/components/RightSidebar.tsx
@@ -756,6 +756,10 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
             if (sessionId) {
               setAutoFocusTerminalSession(sessionId);
             }
+          } else if (target?.tab === "review") {
+            // Review panel keyboard navigation (j/k) is gated on focus. If the user explicitly
+            // opened the tab via shortcut, focus the panel so it works immediately.
+            _setFocusTrigger((prev) => prev + 1);
           }
 
           setLayout((prev) => selectTabByIndex(prev, i));
@@ -767,7 +771,7 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [initialActiveTab, setAutoFocusTerminalSession, setCollapsed, setLayout]);
+  }, [initialActiveTab, setAutoFocusTerminalSession, setCollapsed, setLayout, _setFocusTrigger]);
 
   const usage = useWorkspaceUsage(workspaceId);
 

--- a/tests/ui/reviewFocus.integration.test.ts
+++ b/tests/ui/reviewFocus.integration.test.ts
@@ -1,0 +1,75 @@
+import { fireEvent, waitFor } from "@testing-library/react";
+
+import { shouldRunIntegrationTests } from "../testUtils";
+import {
+  cleanupSharedRepo,
+  createSharedRepo,
+  withSharedWorkspace,
+} from "../ipc/sendMessageTestHelpers";
+
+import { installDom } from "./dom";
+import { renderReviewPanel } from "./renderReviewPanel";
+import { cleanupView, setupWorkspaceView } from "./helpers";
+
+const describeIntegration = shouldRunIntegrationTests() ? describe : describe.skip;
+
+describeIntegration("ReviewPanel focus (UI + ORPC)", () => {
+  beforeAll(async () => {
+    await createSharedRepo();
+  });
+
+  afterAll(async () => {
+    await cleanupSharedRepo();
+  });
+
+  test("Cmd/Ctrl+2 focuses the review panel so j/k navigation works without clicking", async () => {
+    await withSharedWorkspace("anthropic", async ({ env, workspaceId, metadata }) => {
+      const cleanupDom = installDom();
+
+      const view = renderReviewPanel({
+        apiClient: env.orpc,
+        metadata,
+      });
+
+      try {
+        await setupWorkspaceView(view, metadata, workspaceId);
+
+        // Ensure focus starts outside the review panel.
+        await view.selectTab("costs");
+        const costsTab = view.container.querySelector(
+          '[role="tab"][aria-controls*="costs"]'
+        ) as HTMLElement | null;
+        expect(costsTab).not.toBeNull();
+        costsTab?.focus();
+
+        // Trigger the tab shortcut for the 2nd right-sidebar tab (default: Review).
+        // Use ctrlKey so this works regardless of OS detection (matchesKeybind treats
+        // Ctrl/Cmd as equivalent on macOS).
+        fireEvent.keyDown(window, { key: "2", ctrlKey: true });
+
+        await waitFor(
+          () => {
+            const reviewPanel = view.container.querySelector(
+              '[data-testid="review-panel"]'
+            ) as HTMLElement | null;
+            if (!reviewPanel) {
+              throw new Error("Review panel not mounted");
+            }
+
+            const active = document.activeElement;
+            if (!(active instanceof HTMLElement)) {
+              throw new Error("No active element");
+            }
+
+            if (!reviewPanel.contains(active)) {
+              throw new Error("Review panel not focused");
+            }
+          },
+          { timeout: 10_000 }
+        );
+      } finally {
+        await cleanupView(view, cleanupDom);
+      }
+    });
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary
- When switching to the **Review** right-sidebar tab via the tab-position shortcut (**Cmd/Ctrl+2**), automatically focus the review panel so `j`/`k` navigation works immediately.

## Background
The ReviewPanel’s keyboard navigation is gated on the panel having focus. Previously, opening the tab via Cmd/Ctrl+2 left focus elsewhere (e.g. chat input / tab button), forcing an extra click.

## Implementation
- In the right-sidebar tab-position keydown handler, detect when the target tab is `review` and bump the existing `focusTrigger` state.
- `ReviewPanel` already listens to `focusTrigger` and calls `focus()` on its root container.

## Validation
- `make typecheck`
- `make static-check`
- Added an integration test covering the focus behavior (runs under `TEST_INTEGRATION=1`).

---

<details>
<summary>📋 Implementation Plan</summary>

# Focus Review panel on Cmd+2 (tab shortcut)

## Context / Why
- `Cmd+2` (macOS) / `Ctrl+2` (other OSes) switches the Right Sidebar to “tab 2” (default layout: **Review**).
- In `ReviewPanel`, `j`/`k` navigation is only enabled when the panel has focus.
- Today, switching to Review via the shortcut leaves focus elsewhere (e.g. chat input or the tab button), so users must click inside the panel before `j`/`k` works.

Goal: when the user uses the **tab-position shortcut** to open/switch to the Review panel, programmatically focus the Review panel container so keyboard navigation works immediately.

## Evidence
- `src/browser/components/RightSidebar.tsx`
  - Registers a `window` `keydown` listener for `KEYBINDS.SIDEBAR_TAB_1..9` (Cmd/Ctrl+1-9) and calls `setLayout(selectTabByIndex(...))` + `setCollapsed(false)`.
  - Has special-case auto-focus for **terminal** tabs but not for **review**.
  - Defines `focusTrigger` state intended to “Trigger for focusing Review panel” but never increments it.
- `src/browser/components/RightSidebar/CodeReview/ReviewPanel.tsx`
  - Root panel is focusable (`tabIndex={0}`) and toggles `isPanelFocused` via `onFocus`/`onBlur`.
  - The `j`/`k` (and related) keyboard handler is only installed while `isPanelFocused` is true.
  - Already supports programmatic focus via `useEffect(() => panelRef.current?.focus(), [focusTrigger])`.
- `src/browser/utils/ui/keybinds.ts`
  - `matchesKeybind` treats `ctrl: true` keybinds as **Ctrl or Cmd on macOS** (so `Cmd+2` is handled by the same code path).

## Plan

### Approach A (recommended): Trigger existing `focusTrigger` when switching to Review via Cmd/Ctrl+<n>
**Net LoC (product code): ~+6**

1. **Wire focus into the tab-position shortcut handler**
   - In `RightSidebar.tsx`’s `handleKeyDown` loop for `SIDEBAR_TAB_1..9`, after computing `target`:
     - If `target?.tab === "review"`, increment the component state `focusTrigger` (e.g. `_setFocusTrigger((n) => n + 1)`).
   - Keep existing terminal auto-focus behavior intact.
   - Add the setter to the effect dependency list.

2. **(Optional hardening) Schedule focus on the next frame**
   - If focusing proves flaky while expanding the sidebar from collapsed state, wrap the `panelRef.current?.focus()` inside `ReviewPanel`’s `focusTrigger` effect in a `requestAnimationFrame`.
   - Keep this null-safe; no throws on missing refs.

3. **Regression test (UI integration)**
   - Add a focused test under `tests/ui/` that:
     - Renders the full app (`renderApp`/`renderReviewPanel`) with a workspace selected.
     - Dispatches the shortcut (`fireEvent.keyDown(window, { key: "2", ctrlKey: true })`).
     - Asserts that the review panel container (`[data-testid="review-panel"]`) becomes focused (e.g. `document.activeElement === reviewPanel` or `reviewPanel.contains(document.activeElement)`).
   - This directly proves the “no click required” behavior.

4. **Manual QA checklist**
   - From chat input, press **Cmd+2** → Review becomes visible and immediately accepts `j`/`k`.
   - With the right sidebar collapsed, press **Cmd+2** → sidebar expands and focus lands in Review.
   - Ensure **Cmd/Ctrl+<n>** still works for other tabs; terminal tabs still focus the terminal.

<details>
<summary>Notes / edge cases</summary>

- **Split layouts:** the sidebar supports multiple tabsets. If multiple tabsets can mount a `ReviewPanel` simultaneously (e.g., both tabsets have activeTab=review), a single global `focusTrigger` could cause multiple panels to call `focus()`.
  - If this shows up in practice, scope the focus trigger to the *target tabset* (e.g., store `{ tabsetId, token }` and only pass the token to that tabset’s `ReviewPanel`).

</details>

### Approach B (optional): Also focus Review when selected via mouse click
**Net LoC (product code): ~+18**

- Add a `onRequestReviewFocus()` callback from `RightSidebarComponent` down into `RightSidebarTabsetNode`.
- In `RightSidebarTabsetNode`’s `selectTab(tab)` handler, call `onRequestReviewFocus()` when `tab === "review"`.
- Pros: consistent focus behavior for both keyboard and click.
- Cons: slightly more prop plumbing; confirm it doesn’t steal focus during non-user-driven layout changes.

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$1.38`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=1.38 -->
