### PR TITLE
🤖 fix: include TTFT in stats timing percentages

### DIFF
--- a/src/browser/utils/timingPercentages.test.ts
+++ b/src/browser/utils/timingPercentages.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+import { computeTimingPercentages } from "./timingPercentages";
+
+describe("computeTimingPercentages", () => {
+  test("rounds and distributes so components sum to 100% when breakdown covers total", () => {
+    const result = computeTimingPercentages({
+      totalDurationMs: 151_300,
+      ttftMs: 4_300,
+      modelMs: 56_000,
+      toolsMs: 91_000,
+    });
+
+    expect(result).toEqual({ ttft: 3, model: 37, tools: 60 });
+    expect(result.ttft + result.model + result.tools).toBe(100);
+  });
+
+  test("handles equal thirds (stable tie-breaking)", () => {
+    const result = computeTimingPercentages({
+      totalDurationMs: 3,
+      ttftMs: 1,
+      modelMs: 1,
+      toolsMs: 1,
+    });
+
+    expect(result).toEqual({ ttft: 34, model: 33, tools: 33 });
+    expect(result.ttft + result.model + result.tools).toBe(100);
+  });
+
+  test("returns all zeros when totalDurationMs is 0", () => {
+    expect(
+      computeTimingPercentages({
+        totalDurationMs: 0,
+        ttftMs: 10,
+        modelMs: 10,
+        toolsMs: 10,
+      })
+    ).toEqual({ ttft: 0, model: 0, tools: 0 });
+  });
+
+  test("keeps totals aligned with the covered share when the breakdown is incomplete", () => {
+    const result = computeTimingPercentages({
+      totalDurationMs: 100,
+      ttftMs: 10,
+      modelMs: 10,
+      toolsMs: 10,
+    });
+
+    expect(result).toEqual({ ttft: 10, model: 10, tools: 10 });
+    expect(result.ttft + result.model + result.tools).toBe(30);
+  });
+
+  test("clamps negative and non-finite inputs", () => {
+    const result = computeTimingPercentages({
+      totalDurationMs: Number.POSITIVE_INFINITY,
+      ttftMs: -10,
+      modelMs: Number.NaN,
+      toolsMs: 10,
+    });
+
+    expect(result).toEqual({ ttft: 0, model: 0, tools: 0 });
+  });
+});

--- a/src/browser/utils/timingPercentages.ts
+++ b/src/browser/utils/timingPercentages.ts
@@ -1,0 +1,108 @@
+export interface TimingPercentages {
+  ttft: number;
+  model: number;
+  tools: number;
+}
+
+function sanitizeMs(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, value);
+}
+
+/**
+ * Compute integer percentages for a TTFT/model/tools timing breakdown.
+ *
+ * - Uses `totalDurationMs` as the denominator (so missing/invalid timing data can still
+ *   surface as a bar that doesn't fill to 100%).
+ * - Distributes rounding so the displayed integers sum to the rounded total.
+ */
+export function computeTimingPercentages(params: {
+  totalDurationMs: number;
+  ttftMs: number;
+  modelMs: number;
+  toolsMs: number;
+}): TimingPercentages {
+  const totalDurationMs = sanitizeMs(params.totalDurationMs);
+  const ttftMs = sanitizeMs(params.ttftMs);
+  const modelMs = sanitizeMs(params.modelMs);
+  const toolsMs = sanitizeMs(params.toolsMs);
+
+  if (totalDurationMs <= 0) {
+    return { ttft: 0, model: 0, tools: 0 };
+  }
+
+  const items = [
+    { key: "ttft", raw: (ttftMs / totalDurationMs) * 100 },
+    { key: "model", raw: (modelMs / totalDurationMs) * 100 },
+    { key: "tools", raw: (toolsMs / totalDurationMs) * 100 },
+  ] as const;
+
+  const rawSum = items.reduce((acc, item) => acc + item.raw, 0);
+  const targetTotal = Math.max(0, Math.min(100, Math.round(rawSum)));
+
+  const computed = items.map((item, index) => {
+    const floored = Math.floor(item.raw);
+    return {
+      key: item.key,
+      index,
+      remainder: item.raw - floored,
+      value: floored,
+    };
+  });
+
+  const remaining = targetTotal - computed.reduce((acc, item) => acc + item.value, 0);
+
+  if (remaining > 0) {
+    // Add percentage points to items with the largest remainders.
+    const byRemainder = [...computed].sort((a, b) => {
+      if (b.remainder !== a.remainder) return b.remainder - a.remainder;
+      return a.index - b.index;
+    });
+
+    for (let i = 0; i < remaining; i++) {
+      byRemainder[i % byRemainder.length].value += 1;
+    }
+  } else if (remaining < 0) {
+    // Remove percentage points from items with the smallest remainders.
+    const toRemove = -remaining;
+    const byRemainder = [...computed].sort((a, b) => {
+      if (a.remainder !== b.remainder) return a.remainder - b.remainder;
+      return a.index - b.index;
+    });
+
+    let left = toRemove;
+    for (const item of byRemainder) {
+      if (left <= 0) break;
+      if (item.value <= 0) continue;
+      item.value -= 1;
+      left -= 1;
+    }
+
+    // Extremely defensive: if timing data is severely invalid, clamp by removing any
+    // remaining difference from the largest bucket.
+    if (left > 0) {
+      const largest = byRemainder[byRemainder.length - 1];
+      if (largest) {
+        largest.value = Math.max(0, largest.value - left);
+      }
+    }
+  }
+
+  const result: TimingPercentages = { ttft: 0, model: 0, tools: 0 };
+  for (const item of computed) {
+    const clamped = Math.max(0, Math.min(100, item.value));
+    if (item.key === "ttft") result.ttft = clamped;
+    else if (item.key === "model") result.model = clamped;
+    else result.tools = clamped;
+  }
+
+  // Final defensive clamp: ensure we hit the target total, even if earlier logic was
+  // perturbed by bad inputs (NaN/Inf/etc.).
+  const sum = result.ttft + result.model + result.tools;
+  if (sum !== targetTotal) {
+    const delta = targetTotal - sum;
+    result.tools = Math.max(0, Math.min(100, result.tools + delta));
+  }
+
+  return result;
+}


### PR DESCRIPTION
Summary:
- Fix Stats tab Timing breakdown so TTFT shows a percentage and the displayed percentages align with the 3-segment bar.

Implementation:
- Added a small helper to compute integer TTFT/model/tool percentages with largest-remainder rounding.
- Switched StatsTab to use the helper for both the bar widths and the table percent labels.

Validation:
- make typecheck
- make static-check
- bun test src/browser/utils/timingPercentages.test.ts

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix Stats tab timing percentages

## Context / Why
The Stats tab’s **Timing** breakdown shows a progress bar with 3 segments:
- **Time to First Token (TTFT)**
- **Model Time** (streaming time)
- **Tool Execution**

But the table only renders percentages for **Model Time** and **Tool Execution**, so the visible percentages often sum to **< 100%** (the missing share is TTFT).

Goal: make the UI’s timing breakdown internally consistent and intuitive (percentages should add up the same way the bar visually does).

## Evidence
- `src/browser/components/RightSidebar/StatsTab.tsx`
  - Computes `toolPercentage`, `modelPercentage`, **and `ttftPercentage`** based on `totalDuration`.
  - Renders the TTFT segment in the progress bar, but the TTFT row in the table does **not** include `percentage`, while Model/Tool rows do.
  - Result: displayed `%` values omit TTFT.

---

## Recommended approach (A): Show TTFT percentage (and optionally guarantee sum=100)
**Net LoC (product code): ~15–35**

### 1) Display TTFT percentage in the components table
- In `StatsTab.tsx`, add `percentage: ttftPercentage` to the TTFT component entry in the `components` array.
- Keep the existing session label **“Avg. Time to First Token”** (duration stays average), but the percentage will reflect TTFT’s share of total time (consistent with the bar, which uses total TTFT time).

### 2) (Optional but recommended) Normalize displayed percentages so they always sum to 100
Even after showing TTFT, integer rounding can yield totals like 99%/101%.
- Add a small helper (ideally a pure function in a small module) that:
  - Takes durations `{ ttftMsForBar, modelDisplayMs, toolExecutionMs }` and `totalDuration`
  - Computes **integer** percentages using a “largest remainder” style allocation so the integers sum to **exactly 100**
  - Uses those integers for both:
    - Progress bar segment widths
    - Table percent labels

### 3) Add unit tests for the percentage helper
- Add a focused unit test suite for the helper to lock in invariants:
  - Percentages are integers in `[0, 100]`
  - They sum to `100` when `totalDuration > 0` and durations represent the full breakdown
  - Representative cases (from screenshots):
    - `ttft=4.3s, model=56s, tool=91s` → `3% / 37% / 60%`
    - Equal thirds should still sum to 100 (e.g., `1/1/1` should become `34/33/33` or similar deterministic split)

### 4) Manual QA
- Verify both **Session** and **Last Request** views:
  - TTFT row now shows a `%`
  - Percentages shown in the table align with the bar segments
  - Values are sensible for:
    - tool-heavy requests
    - model-only requests (no tools)
    - very short requests (rounding edge cases)

<details>
<summary>Notes / edge cases</summary>

- **Active streams waiting for first token**: while `ttftMs` is still `null`, the UI currently treats TTFT as 0 for the bar. If we later want the bar to show “waiting time so far”, we can treat `elapsedMs` as provisional TTFT when `ttftMs === null`.
- **Session view nuance**: the TTFT duration shown is an average, while the bar’s TTFT segment is based on total TTFT time across the session. Adding a percent keeps the bar+table consistent, but it’s worth validating that the combined “avg duration + % share” is not confusing.

</details>

---

## Alternative approach (B): Normalize Model/Tool to sum to 100 (exclude TTFT)
**Net LoC (product code): ~10–20**

- Keep TTFT without a percent.
- Recompute Model and Tool percentages using `(totalDuration - ttftMsForBar)` as the denominator so they sum to 100.

Downside: the percentages would no longer match the progress bar (which includes TTFT as a segment), and it hides TTFT’s share rather than making it explicit.

</details>

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$1.21`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=1.21 -->
