### PR TITLE
🤖 fix: allow loading hidden chat history

### DIFF
--- a/src/browser/components/Messages/HistoryHiddenMessage.tsx
+++ b/src/browser/components/Messages/HistoryHiddenMessage.tsx
@@ -1,14 +1,17 @@
 import React from "react";
 import { cn } from "@/common/lib/utils";
 import type { DisplayedMessage } from "@/common/types/message";
+import { showAllMessages } from "@/browser/stores/WorkspaceStore";
 
 interface HistoryHiddenMessageProps {
   message: DisplayedMessage & { type: "history-hidden" };
+  workspaceId?: string;
   className?: string;
 }
 
 export const HistoryHiddenMessage: React.FC<HistoryHiddenMessageProps> = ({
   message,
+  workspaceId,
   className,
 }) => {
   return (
@@ -21,6 +24,18 @@ export const HistoryHiddenMessage: React.FC<HistoryHiddenMessageProps> = ({
     >
       {message.hiddenCount} older message{message.hiddenCount !== 1 ? "s" : ""} hidden for
       performance
+      {workspaceId && (
+        <>
+          {" "}
+          <button
+            type="button"
+            className="text-link hover:text-link-hover cursor-pointer border-none bg-transparent p-0 hover:underline"
+            onClick={() => showAllMessages(workspaceId)}
+          >
+            Load all
+          </button>
+        </>
+      )}
     </div>
   );
 };

--- a/src/browser/components/Messages/MessageRenderer.tsx
+++ b/src/browser/components/Messages/MessageRenderer.tsx
@@ -76,7 +76,9 @@ export const MessageRenderer = React.memo<MessageRendererProps>(
       case "stream-error":
         return <StreamErrorMessage message={message} className={className} />;
       case "history-hidden":
-        return <HistoryHiddenMessage message={message} className={className} />;
+        return (
+          <HistoryHiddenMessage message={message} className={className} workspaceId={workspaceId} />
+        );
       case "workspace-init":
         return <InitMessage message={message} className={className} />;
       case "plan-display":

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -1617,9 +1617,7 @@ export class WorkspaceStore {
   ): StreamingMessageAggregator {
     if (!this.aggregators.has(workspaceId)) {
       // Create new aggregator with required createdAt and workspaceId for localStorage persistence
-      const aggregator = new StreamingMessageAggregator(createdAt, workspaceId, unarchivedAt, {
-        debugShowAllMessages: window.api?.debugShowAllMessages === true,
-      });
+      const aggregator = new StreamingMessageAggregator(createdAt, workspaceId, unarchivedAt);
       // Wire up navigation callback for notification clicks
       if (this.navigateToWorkspaceCallback) {
         aggregator.onNavigateToWorkspace = this.navigateToWorkspaceCallback;
@@ -1953,6 +1951,24 @@ export function useWorkspaceAggregator(
 ): StreamingMessageAggregator | undefined {
   const store = useWorkspaceStoreRaw();
   return store.getAggregator(workspaceId);
+}
+
+/**
+ * Disable the displayed message cap for a workspace and trigger a re-render.
+ * Used by HistoryHiddenMessage “Load all”.
+ */
+export function showAllMessages(workspaceId: string): void {
+  assert(
+    typeof workspaceId === "string" && workspaceId.length > 0,
+    "showAllMessages requires workspaceId"
+  );
+
+  const store = getStoreInstance();
+  const aggregator = store.getAggregator(workspaceId);
+  if (aggregator) {
+    aggregator.setShowAllMessages(true);
+    store.bumpState(workspaceId);
+  }
 }
 
 /**

--- a/src/common/types/global.d.ts
+++ b/src/common/types/global.d.ts
@@ -16,7 +16,6 @@ declare global {
       electron?: string;
     };
     // Debug flags (dev-only, passed through preload)
-    debugShowAllMessages?: boolean;
     debugLlmRequest?: boolean;
     // Allow maintainers to opt into telemetry while running the dev server.
     enableTelemetryInDev?: boolean;

--- a/src/desktop/preload.ts
+++ b/src/desktop/preload.ts
@@ -35,8 +35,6 @@ contextBridge.exposeInMainWorld("api", {
   enableTelemetryInDev: process.env.MUX_ENABLE_TELEMETRY_IN_DEV === "1",
   // Note: When debugging LLM requests, we also want to see synthetic/request-only
   // messages in the chat history so the UI matches what was sent to the provider.
-  debugShowAllMessages:
-    process.env.MUX_DEBUG_SHOW_ALL_MESSAGES === "1" || process.env.MUX_DEBUG_LLM_REQUEST === "1",
   debugLlmRequest: process.env.MUX_DEBUG_LLM_REQUEST === "1",
   // NOTE: This is intentionally async so the preload script does not rely on Node builtins
   // like `child_process` (which can break in hardened/sandboxed environments).


### PR DESCRIPTION
## Summary

Add a **Load all** control to the “older messages hidden for performance” banner so users can reveal the full chat history for a workspace.

## Implementation

- Add a per-workspace `showAllMessages` toggle in `StreamingMessageAggregator` to bypass `MAX_DISPLAYED_MESSAGES`.
- Expose `showAllMessages(workspaceId)` in `WorkspaceStore` and re-render on click.
- Wire `workspaceId` into `HistoryHiddenMessage` and render a `Load all` button.

## Validation

- `bun test src/browser/utils/messages/StreamingMessageAggregator.test.ts`
- `make typecheck`
- `make static-check`

---

<details>
<summary>📋 Implementation Plan</summary>

# Add “Load all” control for hidden chat history

## Context / Why
Mux currently caps the number of chat messages rendered in the DOM for performance. When a workspace has more than 128 displayed messages, the UI shows a banner like:

> `86 older messages hidden for performance`

…but there’s no way for a user to expand the view, making older messages effectively inaccessible.

Goal: add a **“Load all”** link/button on that banner that expands the chat to render **all** messages for that workspace.

## Evidence
- `src/browser/utils/messages/StreamingMessageAggregator.ts`
  - `const MAX_DISPLAYED_MESSAGES = 128;` (line ~54)
  - `getDisplayedMessages()` slices to the last 128 and prepends a synthetic `DisplayedMessage` of type `"history-hidden"` when over the limit (lines ~2028–2046).
- `src/browser/components/Messages/HistoryHiddenMessage.tsx`
  - Renders the banner text: `{hiddenCount} older messages hidden for performance`.
- `src/browser/components/Messages/MessageRenderer.tsx`
  - Switch case routes `"history-hidden"` → `<HistoryHiddenMessage … />`.
  - Already receives `workspaceId` prop (optional) from `ChatPane`.
- `src/browser/stores/WorkspaceStore.ts`
  - `getWorkspaceState()` uses `aggregator.getDisplayedMessages()` for `workspaceState.messages`.
  - Aggregators already hold the full history in memory; the clamp is render-only.
- Tests already cover the cap behavior (currently via `debugShowAllMessages`; will be updated to `showAllMessages`):
  - `src/browser/utils/messages/StreamingMessageAggregator.test.ts` has `"should disable displayed message cap when enabled"`.

## Recommended approach (minimal change): user-triggered “show all messages” toggle (per workspace, in-memory)
**Net LoC (product code): ~40–60**

### 1) Use a single `showAllMessages` flag (remove `debugShowAllMessages`)
Files:
- `src/browser/utils/messages/StreamingMessageAggregator.ts`
- (plumbing) `src/desktop/preload.ts`, `src/common/types/global.d.ts`, `src/browser/stores/WorkspaceStore.ts`

- Replace the current `debugShowAllMessages` field/option with **one** mutable `showAllMessages` flag that controls the DOM cap.
  - `private showAllMessages: boolean;`
  - `setShowAllMessages(value: boolean): void`
- Keep synthetic/request-only messages **debug-only** (don’t expose them via the user-facing “Load all” action).
  - Gate synthetic rendering on an existing debug signal (e.g. `window.api?.debugLlmRequest === true`) rather than `showAllMessages`.
- Update `getDisplayedMessages()`:
  - Synthetic filter uses the debug-only flag.
  - Cap uses `showAllMessages`:
    - `if (!this.showAllMessages && displayedMessages.length > MAX_DISPLAYED_MESSAGES) { … }`
- In `setShowAllMessages`, defensively:
  - `assert(typeof value === "boolean")`
  - No-op if unchanged.
  - Invalidate display caches so React gets a new snapshot (clear `cache.displayedMessages` + `cache.latestStreamingBashToolCallId`, or call `invalidateCache()`).

### 2) Expose a tiny WorkspaceStore action to flip the flag and bump state
File: `src/browser/stores/WorkspaceStore.ts`

- Add a small exported helper similar to `addEphemeralMessage/removeEphemeralMessage`, e.g.:
  - `export function showAllMessages(workspaceId: string): void`
- Implementation:
  - `const store = getStoreInstance()`
  - `const aggregator = store.getAggregator(workspaceId)`
  - If present: `aggregator.setShowAllMessages(true)` then `store.bumpState(workspaceId)`
  - Be defensive: assert `workspaceId` is non-empty; treat missing aggregator as a no-op (don’t throw from a button click).

### 3) Add the “Load all” UI control on the banner
Files:
- `src/browser/components/Messages/HistoryHiddenMessage.tsx`
- `src/browser/components/Messages/MessageRenderer.tsx`

Changes:
- Extend `HistoryHiddenMessageProps` with `workspaceId?: string`.
- Render a button/link after the existing text:
  - Label must be exactly: `Load all`
  - Use a `<button type="button">` for accessibility.
  - Styling: reuse existing link styles (e.g. `text-link hover:text-link-hover`).
- Wire it:
  - `MessageRenderer` passes `workspaceId` through when `message.type === "history-hidden"`.
  - `HistoryHiddenMessage` calls `showAllMessages(workspaceId)` on click (guard if undefined).

### 4) Update/add tests
File: `src/browser/utils/messages/StreamingMessageAggregator.test.ts`

Add a focused unit test proving the new behavior:
- Given 200 user messages, default aggregator returns 129 displayed (including `history-hidden`).
- After calling `aggregator.setShowAllMessages(true)`, `getDisplayedMessages()` returns 200 and includes **no** `history-hidden` message.
- (Optional) Ensure synthetic message visibility is unchanged (still hidden unless debug LLM request mode is enabled).

### 5) (Optional) Storybook follow-up
File: `src/browser/stories/App.errors.stories.tsx`

- The existing `HiddenHistory` story will automatically show the new control.
- If desired, add a `play` step that clicks `Load all` to verify it doesn’t throw (even if the story’s mocked data can’t actually “reveal” older messages).

## Alternatives considered
<details>
<summary>Alternative: true pagination / virtualization (better long-term perf, more work)</summary>

- Implement “Load 128 more” (or virtualization) instead of “Load all”.
- Pros: avoids rendering thousands of Markdown messages.
- Cons: significantly more UI + scroll-position management.
- Net LoC (product code): ~200–500+ depending on virtualization approach.

</details>

## Acceptance criteria
- When the banner `“N older messages hidden for performance”` is present, it includes a clickable **`Load all`** control.
- Clicking **Load all** removes the cap for that workspace and reveals the previously hidden messages.
- No backend/IPC changes required.
- Unit tests updated and passing.

</details>

---

_Generated with `mux` • Model: openai:gpt-5.2 • Thinking: xhigh • Cost: $3.96_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=3.96 -->
