### PR TITLE
🤖 fix: open SSH files in editor deep links

### DIFF
--- a/src/browser/utils/openInEditor.ts
+++ b/src/browser/utils/openInEditor.ts
@@ -124,13 +124,13 @@ export async function openInEditor(args: {
     }
     // else: localhost access to local workspace → no SSH needed
 
-    // SSH deep links can open files directly (VS Code/Cursor/Zed).
-    const targetPath = args.targetPath;
-
+    // VS Code/Cursor SSH deep links treat the path as a folder unless a line/column is present.
     const deepLink = getEditorDeepLink({
       editor: editorConfig.editor as DeepLinkEditor,
-      path: targetPath,
+      path: args.targetPath,
       sshHost,
+      line: args.isFile && sshHost ? 1 : undefined,
+      column: args.isFile && sshHost ? 1 : undefined,
     });
 
     if (!deepLink) {


### PR DESCRIPTION
Fixes the "Edit" action for files inside SSH workspaces.

### What changed
- For SSH deep links, VS Code/Cursor treat the path as a folder unless line/column info is present.
- When opening a *file* over SSH, we now append `:1:1` so the editor opens the file directly.
- Docker behavior is unchanged (still opens the parent dir).

### Validation
- `bun test src/browser/utils/openInEditor.test.ts`
- `make static-check`

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `high` • Cost: `$4.69`_
