### PR TITLE
🤖 fix: show full sidebar chat title tooltip

### DIFF
--- a/src/browser/components/WorkspaceListItem.tsx
+++ b/src/browser/components/WorkspaceListItem.tsx
@@ -215,6 +215,7 @@ const WorkspaceListItemInner: React.FC<WorkspaceListItemProps> = ({
             <RuntimeBadge
               runtimeConfig={metadata.runtimeConfig}
               isWorking={isWorking}
+              tooltipSide="bottom"
               workspaceName={metadata.name}
               workspacePath={namedWorkspacePath}
             />
@@ -243,7 +244,6 @@ const WorkspaceListItemInner: React.FC<WorkspaceListItemProps> = ({
                       e.stopPropagation();
                       startEditing();
                     }}
-                    title={isDisabled ? undefined : "Double-click to edit title"}
                   >
                     {isWorking || isCreating ? (
                       <Shimmer className="w-full truncate" colorClass="var(--color-foreground)">
@@ -254,7 +254,14 @@ const WorkspaceListItemInner: React.FC<WorkspaceListItemProps> = ({
                     )}
                   </span>
                 </TooltipTrigger>
-                <TooltipContent align="start">Double-click to edit title</TooltipContent>
+                <TooltipContent align="start" className="max-w-[420px]">
+                  <div className="flex flex-col gap-1">
+                    <div className="text-foreground font-medium break-words whitespace-normal">
+                      {displayTitle}
+                    </div>
+                    {!isDisabled && <div className="text-muted">Double-click to edit title</div>}
+                  </div>
+                </TooltipContent>
               </Tooltip>
             )}
 


### PR DESCRIPTION
## Summary
- Sidebar chat titles now show the **full title** on hover (even when truncated).
- Fixes the “double tooltip” behavior by removing the native `title=` tooltip and reducing tooltip overlap from the runtime badge.

## Implementation
- `WorkspaceListItem`: replace the title tooltip content with the full `displayTitle` + (when enabled) the edit hint.
- Remove the native HTML `title="Double-click to edit title"` attribute.
- Render the `RuntimeBadge` tooltip on the bottom in the sidebar to avoid accidental overlap.

## Validation
- `make static-check`

## Risks
- Low. Scoped to sidebar tooltip rendering for workspace rows.

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$3.43`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=3.43 -->
