### PR TITLE
🤖 fix: improve mobile layout with fixed header and hidden right sidebar

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -702,7 +702,7 @@ function AppInner() {
   return (
     <>
       <div
-        className="bg-bg-dark mobile-layout flex h-screen overflow-hidden"
+        className="bg-bg-dark mobile-layout flex h-full overflow-hidden pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)]"
         onMouseUp={handleMouseNavigation}
       >
         <LeftSidebar

--- a/src/browser/components/ChatInput/CreationCenterContent.tsx
+++ b/src/browser/components/ChatInput/CreationCenterContent.tsx
@@ -20,7 +20,7 @@ export function CreationCenterContent(props: CreationCenterContentProps) {
   }
 
   return (
-    <div className="bg-bg-dark/80 absolute inset-0 z-10 flex items-center justify-center backdrop-blur-sm">
+    <div className="bg-bg-dark/80 fixed inset-0 z-10 flex items-center justify-center backdrop-blur-sm">
       <div className="max-w-xl px-8 text-center">
         <div className="bg-accent mb-4 inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-current border-r-transparent"></div>
         <h2 className="text-foreground mb-2 text-lg font-medium">Creating workspace</h2>

--- a/src/browser/components/ChatPane.tsx
+++ b/src/browser/components/ChatPane.tsx
@@ -537,7 +537,8 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
         onOpenTerminal={onOpenTerminal}
       />
 
-      <div className="relative flex-1 overflow-hidden">
+      {/* Spacer for fixed mobile header - mobile-header-spacer adds padding-top on touch devices */}
+      <div className="mobile-header-spacer relative flex-1 overflow-hidden">
         <div
           ref={contentRef}
           onWheel={markUserInteraction}

--- a/src/browser/components/RightSidebar.tsx
+++ b/src/browser/components/RightSidebar.tsx
@@ -131,11 +131,10 @@ const SidebarContainer: React.FC<SidebarContainerProps> = ({
     <div
       className={cn(
         "bg-sidebar border-l border-border-light flex flex-col overflow-hidden flex-shrink-0",
+        // Hide on mobile touch devices - too narrow for useful interaction
+        "mobile-hide-right-sidebar",
         !isResizing && "transition-[width] duration-200",
         collapsed && "sticky right-0 z-10 shadow-[-2px_0_4px_rgba(0,0,0,0.2)]",
-        // Mobile: Show vertical meter when collapsed (20px), full width when expanded
-        "max-md:border-l-0 max-md:border-t max-md:border-border-light",
-        !collapsed && "max-md:w-full max-md:relative max-md:max-h-[50vh]",
         // In desktop mode, hide the left border when collapsed to avoid
         // visual separation in the titlebar area (overlay buttons zone)
         isDesktop && collapsed && "border-l-0"

--- a/src/browser/components/WorkspaceHeader.tsx
+++ b/src/browser/components/WorkspaceHeader.tsx
@@ -66,10 +66,12 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
   });
 
   const handleOpenTerminal = useCallback(() => {
-    if (onOpenTerminal) {
+    // On mobile touch devices, always use popout since the right sidebar is hidden
+    const isMobileTouch = window.matchMedia("(max-width: 768px) and (pointer: coarse)").matches;
+    if (onOpenTerminal && !isMobileTouch) {
       onOpenTerminal();
     } else {
-      // Fallback to popout if no integrated terminal callback provided
+      // Fallback to popout if no integrated terminal callback provided or on mobile
       void openTerminalPopout(workspaceId, runtimeConfig);
     }
   }, [workspaceId, openTerminalPopout, runtimeConfig, onOpenTerminal]);
@@ -113,10 +115,12 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
       style={headerRightPadding > 0 ? { paddingRight: headerRightPadding } : undefined}
       data-testid="workspace-header"
       className={cn(
-        "bg-sidebar border-border-light flex items-center justify-between border-b px-[15px] [@media(max-width:768px)]:h-auto [@media(max-width:768px)]:flex-wrap [@media(max-width:768px)]:gap-2 [@media(max-width:768px)]:py-2",
+        "bg-sidebar border-border-light flex items-center justify-between border-b px-2",
         isDesktop ? DESKTOP_TITLEBAR_HEIGHT_CLASS : "h-8",
         // In desktop mode, make header draggable for window movement
-        isDesktop && "titlebar-drag"
+        isDesktop && "titlebar-drag",
+        // Keep header visible when iOS keyboard opens and causes scroll
+        "mobile-sticky-header"
       )}
     >
       <div

--- a/src/browser/components/WorkspaceShell.tsx
+++ b/src/browser/components/WorkspaceShell.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useRef } from "react";
 import { cn } from "@/common/lib/utils";
 import { RIGHT_SIDEBAR_WIDTH_KEY } from "@/common/constants/storage";
 import { useResizableSidebar } from "@/browser/hooks/useResizableSidebar";
+import { useOpenTerminal } from "@/browser/hooks/useOpenTerminal";
 import { RightSidebar } from "./RightSidebar";
 import { PopoverError } from "./PopoverError";
 import type { RuntimeConfig } from "@/common/types/runtime";
@@ -56,9 +57,19 @@ export const WorkspaceShell: React.FC<WorkspaceShellProps> = (props) => {
 
   const { width: sidebarWidth, isResizing, startResize } = sidebar;
   const addTerminalRef = useRef<((options?: TerminalSessionCreateOptions) => void) | null>(null);
-  const handleOpenTerminal = useCallback((options?: TerminalSessionCreateOptions) => {
-    addTerminalRef.current?.(options);
-  }, []);
+  const openTerminalPopout = useOpenTerminal();
+  const handleOpenTerminal = useCallback(
+    (options?: TerminalSessionCreateOptions) => {
+      // On mobile touch devices, always use popout since the right sidebar is hidden
+      const isMobileTouch = window.matchMedia("(max-width: 768px) and (pointer: coarse)").matches;
+      if (isMobileTouch) {
+        void openTerminalPopout(props.workspaceId, props.runtimeConfig, options);
+      } else {
+        addTerminalRef.current?.(options);
+      }
+    },
+    [openTerminalPopout, props.workspaceId, props.runtimeConfig]
+  );
 
   const reviews = useReviews(props.workspaceId);
   const { addReview } = reviews;

--- a/src/browser/hooks/useOpenTerminal.ts
+++ b/src/browser/hooks/useOpenTerminal.ts
@@ -2,7 +2,11 @@ import { useCallback } from "react";
 import { useAPI } from "@/browser/contexts/API";
 import type { RuntimeConfig } from "@/common/types/runtime";
 import { isSSHRuntime } from "@/common/types/runtime";
-import { createTerminalSession, openTerminalPopout } from "@/browser/utils/terminal";
+import {
+  createTerminalSession,
+  openTerminalPopout,
+  type TerminalSessionCreateOptions,
+} from "@/browser/utils/terminal";
 
 /**
  * Hook to open a terminal window for a workspace.
@@ -20,7 +24,11 @@ export function useOpenTerminal() {
   const { api } = useAPI();
 
   return useCallback(
-    async (workspaceId: string, runtimeConfig?: RuntimeConfig) => {
+    async (
+      workspaceId: string,
+      runtimeConfig?: RuntimeConfig,
+      options?: TerminalSessionCreateOptions
+    ) => {
       if (!api) return;
 
       // Check if running in browser mode
@@ -33,7 +41,7 @@ export function useOpenTerminal() {
       // because the PTY service handles the SSH connection to the remote host
       if (isBrowser || isSSH) {
         // Create terminal session first - window needs sessionId to connect
-        const session = await createTerminalSession(api, workspaceId);
+        const session = await createTerminalSession(api, workspaceId, options);
         openTerminalPopout(api, workspaceId, session.sessionId);
       } else {
         // In Electron (desktop) mode with local workspace, open the native system terminal

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -1073,6 +1073,33 @@ body,
   .mobile-main-content {
     width: 100% !important;
   }
+
+  /* Keep workspace header visible when keyboard opens - fixed positioning
+     because iOS Safari scrolls the visual viewport, not a scroll container.
+     Left/right safe-area insets ensure header content avoids notch in landscape.
+     min-height 44px for touch targets, but allow growth for wrapped controls. */
+  .mobile-sticky-header {
+    position: fixed !important;
+    top: env(safe-area-inset-top, 0px) !important;
+    left: env(safe-area-inset-left, 0px) !important;
+    right: env(safe-area-inset-right, 0px) !important;
+    z-index: 50 !important;
+    min-height: 44px !important;
+    height: auto !important;
+    flex-wrap: wrap !important;
+  }
+
+  /* Add padding to content below fixed header so it's not hidden underneath.
+     Use generous padding (88px = 2x touch targets) to accommodate header wrapping.
+     A true dynamic solution would require JS to measure header height. */
+  .mobile-header-spacer {
+    padding-top: 88px !important;
+  }
+
+  /* Hide right sidebar on mobile - too narrow for useful interaction */
+  .mobile-hide-right-sidebar {
+    display: none !important;
+  }
 }
 
 /* Tailwind utility extensions for dark theme surfaces */
@@ -1094,24 +1121,24 @@ html,
 body,
 #root,
 #storybook-root {
-  /* Use dvh (dynamic viewport height) on supported browsers - this accounts for
-     mobile browser chrome and keyboard accessory bars */
-  min-height: 100dvh;
-  /* Fallback for older browsers */
+  /* Fallback for older browsers that don't support dvh */
   min-height: 100vh;
+  height: 100vh;
 }
 
-/* Handle safe areas for notched devices and keyboard accessory bars */
-@supports (padding: env(safe-area-inset-top)) {
-  /* Apply padding to account for iOS safe areas (notch at top, home indicator at bottom) */
+/* Use dvh (dynamic viewport height) on supported browsers - this accounts for
+   mobile browser chrome and keyboard accessory bars. Using @supports ensures
+   dvh takes precedence over the vh fallback above. */
+@supports (height: 100dvh) {
   #root,
   #storybook-root {
-    padding-top: env(safe-area-inset-top, 0);
-    padding-bottom: env(safe-area-inset-bottom, 0);
-    padding-left: env(safe-area-inset-left, 0);
-    padding-right: env(safe-area-inset-right, 0);
+    min-height: 100dvh;
+    height: 100dvh;
   }
 }
+
+/* Safe areas for notched devices handled via Tailwind arbitrary values:
+   pt-[env(safe-area-inset-top)] and pb-[env(safe-area-inset-bottom)] */
 
 /* For PWA mode, ensure the viewport meta tag handles the keyboard properly
    Note: This is a CSS-only solution; the actual fix requires the viewport


### PR DESCRIPTION
## Summary

Improves mobile UX for iOS/touch devices by fixing header visibility issues and simplifying the layout.

## Changes

1. **Fixed workspace header on mobile** - The header is now `position: fixed` on touch devices so it stays visible when the iOS keyboard opens (which scrolls the viewport). Positioned below the iPhone notch using `env(safe-area-inset-top)` with left/right safe-area insets for landscape support.

2. **Hidden right sidebar on mobile** - The right sidebar (MCP servers, editor, terminal) is hidden on mobile touch devices since it's too narrow to be useful at small widths. Terminal actions now route to popout windows.

3. **Fixed blur overlay positioning** - Changed the "Creating workspace" blur overlay from `absolute` to `fixed` positioning so it covers the full viewport including notch areas.

4. **Safe-area padding on all sides** - Added all four safe-area insets to the main container for proper handling on notched devices in all orientations.

5. **dvh/vh fallback fix** - Used `@supports` to properly cascade dvh over vh fallback in root height CSS.

6. **44px touch targets** - Header height accommodates 44px touch targets with flex-wrap support for narrow screens.

7. **Terminal popout on mobile** - Extended `useOpenTerminal` to forward terminal options (like `initialCommand`) when routing to popout on mobile.

## Testing

Tested on iOS Simulator (iPhone 16e) via Safari:
- Header stays visible when tapping the message input and keyboard opens
- Header positioned correctly below the notch
- Right sidebar hidden on narrow screens
- Blur overlay covers full screen during workspace creation
- Terminal buttons open popout windows on mobile

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$13.63`_
