### PR TITLE
🤖 fix: use hourglass icon for waiting status

### DIFF
--- a/src/browser/components/icons/EmojiIcon.tsx
+++ b/src/browser/components/icons/EmojiIcon.tsx
@@ -45,6 +45,7 @@ const EMOJI_TO_ICON: Record<string, LucideIcon> = {
   "❌": X,
   "🚀": Rocket,
   "⏳": Hourglass,
+  "⌛": Hourglass,
   "🔗": Link,
   "🔄": RefreshCw,
   "🧪": Beaker,
@@ -78,8 +79,7 @@ const EMOJI_TO_ICON: Record<string, LucideIcon> = {
 };
 
 const SPINNING_EMOJI = new Set([
-  // In tool output and agent status, these represent "working"/"refreshing".
-  "⏳",
+  // In tool output and agent status, these represent "refreshing".
   "🔄",
 ]);
 

--- a/src/browser/components/tools/StatusSetToolCall.tsx
+++ b/src/browser/components/tools/StatusSetToolCall.tsx
@@ -25,11 +25,7 @@ export const StatusSetToolCall: React.FC<StatusSetToolCallProps> = ({
   return (
     <ToolContainer expanded={false}>
       <ToolHeader>
-        <ToolIcon
-          toolName="status_set"
-          emoji={args.emoji}
-          emojiSpin={status === "pending" || status === "executing"}
-        />
+        <ToolIcon toolName="status_set" emoji={args.emoji} />
         <span className="text-muted-foreground italic">{args.message}</span>
         {errorMessage && <span className="text-error-foreground">({errorMessage})</span>}
         <StatusIndicator status={status}>{statusDisplay}</StatusIndicator>

--- a/src/browser/components/tools/shared/ToolPrimitives.tsx
+++ b/src/browser/components/tools/shared/ToolPrimitives.tsx
@@ -191,7 +191,7 @@ interface ToolIconProps {
   /**
    * Optional control for whether the emoji icon should spin.
    *
-   * This is useful when the emoji represents "working" (⏳/🔄), but the tool call itself
+   * This is useful when the emoji maps to a spinner (e.g. 🔄), but the tool call itself
    * is already completed.
    */
   emojiSpin?: boolean;


### PR DESCRIPTION
This swaps the sidebar/tool status emoji rendering for “waiting” from a spinning loader to a static hourglass.

- Map ⏳/⌛ to `Hourglass` in `EmojiIcon` and remove ⏳ from the default spinning emoji set
- Simplify `status_set` tool call rendering (no per-status spinning override)
- Update `ToolIcon` prop docs to reflect spinner-only cases (e.g. 🔄)

Validation:
- `make static-check`

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$4.59`_
