### PR TITLE
🤖 fix: block oversized SVG attachments

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -1249,7 +1249,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         })
         .catch((error) => {
           console.error("Failed to process pasted image:", error);
-          pushToast({ type: "error", message: "Failed to process image" });
+          pushToast({
+            type: "error",
+            message: error instanceof Error ? error.message : "Failed to process image",
+          });
         });
     },
     [editingMessage, pushToast, setImageAttachments]
@@ -1334,7 +1337,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         })
         .catch((error) => {
           console.error("Failed to process dropped image:", error);
-          pushToast({ type: "error", message: "Failed to process image" });
+          pushToast({
+            type: "error",
+            message: error instanceof Error ? error.message : "Failed to process image",
+          });
         });
     },
     [editingMessage, pushToast, setImageAttachments]

--- a/src/browser/utils/imageHandling.test.ts
+++ b/src/browser/utils/imageHandling.test.ts
@@ -1,3 +1,4 @@
+import { MAX_SVG_TEXT_CHARS } from "@/common/constants/imageAttachments";
 import { describe, expect, test } from "@jest/globals";
 import {
   generateImageId,
@@ -53,6 +54,12 @@ describe("imageHandling", () => {
       });
     });
 
+    test("rejects SVGs larger than MAX_SVG_TEXT_CHARS", async () => {
+      const svg = `<svg>${"a".repeat(MAX_SVG_TEXT_CHARS + 1)}</svg>`;
+      const file = new File([svg], "test.svg", { type: "image/svg+xml" });
+
+      await expect(fileToImageAttachment(file)).rejects.toThrow("SVG attachments must be");
+    });
     test("handles JPEG images", async () => {
       const blob = new Blob(["fake jpeg data"], { type: "image/jpeg" });
       const file = new File([blob], "test.jpg", { type: "image/jpeg" });

--- a/src/common/constants/imageAttachments.ts
+++ b/src/common/constants/imageAttachments.ts
@@ -1,0 +1,5 @@
+export const SVG_MEDIA_TYPE = "image/svg+xml";
+
+// Large SVGs can cause provider request failures when we inline SVG as text.
+// Keep this conservative so users get fast feedback at attach-time.
+export const MAX_SVG_TEXT_CHARS = 50_000;


### PR DESCRIPTION
Summary
- Prevent attaching SVG image files with >50,000 characters (these can error during send).
- Add a request-time guardrail so oversized/invalid SVGs in history are omitted (instead of throwing).

Implementation
- Added a shared `MAX_SVG_TEXT_CHARS` constant.
- `fileToImageAttachment()` now checks SVG text length and fails fast with a user-facing error.
- `inlineSvgAsTextForProvider()` now enforces the same char limit and replaces failures with a small placeholder text part.

Validation
- `make static-check`
- `bun x jest src/browser/utils/imageHandling.test.ts src/node/utils/messages/inlineSvgAsTextForProvider.test.ts`

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$1.22`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=1.22 -->
