### PR TITLE
🤖 ci: run actionlint/zizmor only when .github/** changes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -108,8 +108,18 @@ jobs:
           curl --retry 5 --retry-all-errors --retry-delay 2 -LsSf https://astral.sh/uv/install.sh | sh
       - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - run: make -j static-check
+
+  lint-actions:
+    name: Lint Actions
+    needs: [changes]
+    if: ${{ (needs.changes.outputs.config == 'true') && (github.event_name != 'push' || github.actor != 'github-merge-queue[bot]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - run: make lint-actions
         env:
-          # Used by zizmor to lint third-party GitHub actions
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test-unit:
@@ -487,6 +497,7 @@ jobs:
     needs:
       - changes
       - static-check
+      - lint-actions
       - test-unit
       - test-integration
       - test-storybook

--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ build/icon.png: docs/img/logo.webp scripts/generate-icons.ts
 	@bun scripts/generate-icons.ts png
 
 ## Quality checks (can run in parallel)
-static-check: lint typecheck fmt-check check-eager-imports check-bench-agent check-docs-links check-code-docs-links lint-actions lint-shellcheck ## Run all static checks
+static-check: lint typecheck fmt-check check-eager-imports check-bench-agent check-docs-links check-code-docs-links lint-shellcheck ## Run all static checks
 
 check-bench-agent: ## Verify terminal-bench agent configuration and imports
 	@./scripts/check-bench-agent.sh


### PR DESCRIPTION
## Summary

Move actionlint and zizmor linting out of `static-check` and into a dedicated CI job that only runs when config files change (includes `.github/**`).

## Background

Running actionlint and zizmor on every PR adds unnecessary CI time when workflow files haven't changed.

## Implementation

- Removed `lint-actions` dependency from `static-check` in Makefile
- Added new `lint-actions` CI job with path filtering (uses existing `config` filter which includes `.github/**`)
- Added `lint-actions` to `required` job dependencies

The `make lint-actions` target remains available for local use.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$1.33`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=1.33 -->
