### PR TITLE
🤖 fix: validate persisted trunk branch against available branches

### DIFF
--- a/src/browser/hooks/useDraftWorkspaceSettings.ts
+++ b/src/browser/hooks/useDraftWorkspaceSettings.ts
@@ -299,7 +299,7 @@ export function useDraftWorkspaceSettings(
 
   // Initialize trunk branch from backend recommendation or first branch
   useEffect(() => {
-    if (!trunkBranch && branches.length > 0) {
+    if (branches.length > 0 && (!trunkBranch || !branches.includes(trunkBranch))) {
       const defaultBranch = recommendedTrunk ?? branches[0];
       setTrunkBranch(defaultBranch);
     }


### PR DESCRIPTION
## Summary

Reset stale trunk branch selections during workspace creation so we never attempt to create a workspace from a branch that doesn’t exist in the current project.

## Background

The trunk branch used for workspace creation is persisted in localStorage. If that value becomes stale (for example, the project’s branches change, the project path is reused, or some other flow writes an unexpected value), the branch selector renders empty because the selected value isn’t in the options list — but the stale value still gets sent to `workspace.create()`. That produces errors like `fatal: invalid reference: <branch>` even though the UI shows no selection.

This fix doesn’t depend on how the stale value got into storage; it simply prevents invalid persisted values from being used.

## Implementation

Validate the persisted trunk branch against the current branch list and reset to the recommended/default branch when it isn’t present:

```tsx
if (branches.length > 0 && (!trunkBranch || !branches.includes(trunkBranch))) {
  const defaultBranch = recommendedTrunk ?? branches[0];
  setTrunkBranch(defaultBranch);
}
```

## Validation

- `make static-check`

## Risks

Low. The change only normalizes the trunk branch when it’s missing or invalid; valid persisted selections are preserved.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$5.56`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=5.56 -->
