### PR TITLE
🤖 ci: add step names to macOS artifact uploads

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -393,13 +393,15 @@ jobs:
           AC_APIKEY_ID: ${{ secrets.AC_APIKEY_ID }}
           AC_APIKEY_ISSUER_ID: ${{ secrets.AC_APIKEY_ISSUER_ID }}
       - run: make dist-mac
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - name: Upload x64 artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: build-macos-x64
           path: release/*-x64.dmg
           retention-days: 30
           if-no-files-found: error
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - name: Upload arm64 artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: build-macos-arm64
           path: release/*-arm64.dmg


### PR DESCRIPTION
## Summary

Add step names to the two macOS artifact upload steps in `pr.yml` so they display distinctly in the GitHub Actions UI.

## Background

Both `upload-artifact` steps in the `build-macos` job were showing as generic "actions/upload-artifact" in the UI, making it unclear which architecture was being uploaded.

## Implementation

Added `name:` fields to each upload step:
- "Upload x64 artifact"
- "Upload arm64 artifact"

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.44`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=0.44 -->
