### PR TITLE
🤖 fix: use Radix tooltip for compaction slider in sidebar

### DIFF
--- a/src/browser/components/RightSidebar/ThresholdSlider.tsx
+++ b/src/browser/components/RightSidebar/ThresholdSlider.tsx
@@ -1,20 +1,15 @@
-import React, { useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import React, { useRef } from "react";
 import {
   AUTO_COMPACTION_THRESHOLD_MIN,
   AUTO_COMPACTION_THRESHOLD_MAX,
 } from "@/common/constants/ui";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/browser/components/ui/tooltip";
 
 // ----- Types -----
 
 export interface AutoCompactionConfig {
   threshold: number;
   setThreshold: (threshold: number) => void;
-}
-
-interface ThresholdSliderProps {
-  config: AutoCompactionConfig;
-  orientation: "horizontal" | "vertical";
 }
 
 // ----- Constants -----
@@ -27,35 +22,21 @@ const TRIANGLE_SIZE = 4;
 
 // ----- Subcomponents -----
 
-/** CSS triangle pointing in specified direction */
-const Triangle: React.FC<{ direction: "up" | "down" | "left" | "right"; color: string }> = ({
-  direction,
-  color,
-}) => {
-  const styles: React.CSSProperties = { width: 0, height: 0 };
-
-  if (direction === "up" || direction === "down") {
-    styles.borderLeft = `${TRIANGLE_SIZE}px solid transparent`;
-    styles.borderRight = `${TRIANGLE_SIZE}px solid transparent`;
-    if (direction === "down") {
-      styles.borderTop = `${TRIANGLE_SIZE}px solid ${color}`;
-    } else {
-      styles.borderBottom = `${TRIANGLE_SIZE}px solid ${color}`;
-    }
-  } else {
-    styles.borderTop = `${TRIANGLE_SIZE}px solid transparent`;
-    styles.borderBottom = `${TRIANGLE_SIZE}px solid transparent`;
-    if (direction === "right") {
-      styles.borderLeft = `${TRIANGLE_SIZE}px solid ${color}`;
-    } else {
-      styles.borderRight = `${TRIANGLE_SIZE}px solid ${color}`;
-    }
-  }
-
+/** CSS triangle pointing up or down */
+const Triangle: React.FC<{ direction: "up" | "down"; color: string }> = ({ direction, color }) => {
+  const styles: React.CSSProperties = {
+    width: 0,
+    height: 0,
+    borderLeft: `${TRIANGLE_SIZE}px solid transparent`,
+    borderRight: `${TRIANGLE_SIZE}px solid transparent`,
+    ...(direction === "down"
+      ? { borderTop: `${TRIANGLE_SIZE}px solid ${color}` }
+      : { borderBottom: `${TRIANGLE_SIZE}px solid ${color}` }),
+  };
   return <div style={styles} />;
 };
 
-// ----- Shared utilities -----
+// ----- Utilities -----
 
 /** Clamp and snap percentage to valid threshold values */
 const snapPercent = (raw: number): number => {
@@ -69,64 +50,19 @@ const applyThreshold = (pct: number, setThreshold: (v: number) => void): void =>
 };
 
 /** Get tooltip text based on threshold */
-const getTooltipText = (threshold: number, orientation: "horizontal" | "vertical"): string => {
+const getTooltipText = (threshold: number): string => {
   const isEnabled = threshold < DISABLE_THRESHOLD;
-  const direction = orientation === "horizontal" ? "left" : "up";
   return isEnabled
     ? `Auto-compact at ${threshold}% · Drag to adjust (per-model)`
-    : `Auto-compact disabled · Drag ${direction} to enable (per-model)`;
+    : `Auto-compact disabled · Drag left to enable (per-model)`;
 };
 
-// ----- Portal Tooltip (vertical only) -----
-
-interface VerticalSliderTooltipProps {
-  text: string;
-  anchorRect: DOMRect;
-  threshold: number;
-}
+// ----- Main component -----
 
 /**
- * Portal-based tooltip for vertical slider only.
- * Renders to document.body to escape the narrow container's clipping.
- * Horizontal slider uses native `title` attribute instead (simpler, no clipping issues).
- */
-const VerticalSliderTooltip: React.FC<VerticalSliderTooltipProps> = ({
-  text,
-  anchorRect,
-  threshold,
-}) => {
-  // Position to the left of the bar, aligned with threshold position
-  const indicatorY = anchorRect.top + (anchorRect.height * threshold) / 100;
-
-  const style: React.CSSProperties = {
-    position: "fixed",
-    zIndex: 9999,
-    background: "var(--color-modal-bg)",
-    color: "var(--color-bright)",
-    padding: "6px 10px",
-    borderRadius: 4,
-    fontSize: 12,
-    whiteSpace: "nowrap",
-    pointerEvents: "none",
-    boxShadow: "0 2px 8px rgba(0,0,0,0.3)",
-    right: window.innerWidth - anchorRect.left + 8,
-    top: indicatorY,
-    transform: "translateY(-50%)",
-  };
-
-  return createPortal(<div style={style}>{text}</div>, document.body);
-};
-
-// ----- Main component: ThresholdSlider -----
-
-/**
- * A draggable threshold indicator for progress bars (horizontal or vertical).
- *
- * - Horizontal: Renders as a vertical line with up/down triangle handles.
- *   Drag left/right to adjust threshold. Drag to 100% (right) to disable.
- *
- * - Vertical: Renders as a horizontal line with left/right triangle handles.
- *   Drag up/down to adjust threshold. Drag to 100% (bottom) to disable.
+ * A draggable threshold indicator for horizontal progress bars.
+ * Renders as a vertical line with up/down triangle handles.
+ * Drag left/right to adjust threshold. Drag to 100% (right) to disable.
  *
  * USAGE: Place as a sibling AFTER the progress bar, both inside a relative container.
  *
@@ -137,10 +73,8 @@ const VerticalSliderTooltip: React.FC<VerticalSliderTooltipProps> = ({
  * how Tailwind's JIT compiler or class application interacts with dynamically
  * rendered components in this context. Inline styles work reliably.
  */
-export const ThresholdSlider: React.FC<ThresholdSliderProps> = ({ config, orientation }) => {
+export const ThresholdSlider: React.FC<{ config: AutoCompactionConfig }> = ({ config }) => {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [isHovered, setIsHovered] = useState(false);
-  const isHorizontal = orientation === "horizontal";
 
   const handleMouseDown = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -148,20 +82,14 @@ export const ThresholdSlider: React.FC<ThresholdSliderProps> = ({ config, orient
     const rect = containerRef.current?.getBoundingClientRect();
     if (!rect) return;
 
-    const calcPercent = (clientX: number, clientY: number) => {
-      if (isHorizontal) {
-        return snapPercent(((clientX - rect.left) / rect.width) * 100);
-      } else {
-        // Vertical: top = low %, bottom = high %
-        return snapPercent(((clientY - rect.top) / rect.height) * 100);
-      }
-    };
+    const calcPercent = (clientX: number) =>
+      snapPercent(((clientX - rect.left) / rect.width) * 100);
 
     const apply = (pct: number) => applyThreshold(pct, config.setThreshold);
 
-    apply(calcPercent(e.clientX, e.clientY));
+    apply(calcPercent(e.clientX));
 
-    const onMove = (ev: MouseEvent) => apply(calcPercent(ev.clientX, ev.clientY));
+    const onMove = (ev: MouseEvent) => apply(calcPercent(ev.clientX));
     const onUp = () => {
       document.removeEventListener("mousemove", onMove);
       document.removeEventListener("mouseup", onUp);
@@ -172,7 +100,7 @@ export const ThresholdSlider: React.FC<ThresholdSliderProps> = ({ config, orient
 
   const isEnabled = config.threshold < DISABLE_THRESHOLD;
   const color = isEnabled ? "var(--color-plan-mode)" : "var(--color-muted)";
-  const tooltipText = getTooltipText(config.threshold, orientation);
+  const tooltipText = getTooltipText(config.threshold);
 
   // Container styles - covers the full bar area for drag handling
   // Uses pointer-events: none by default, only the indicator handle has pointer-events: auto
@@ -184,98 +112,53 @@ export const ThresholdSlider: React.FC<ThresholdSliderProps> = ({ config, orient
     left: 0,
     right: 0,
     zIndex: 50,
-    pointerEvents: "none", // Let events pass through to tooltip beneath
+    pointerEvents: "none",
   };
 
   // Drag handle around the indicator - this captures mouse events
   const DRAG_ZONE_SIZE = 16; // pixels on each side of the indicator
   const handleStyle: React.CSSProperties = {
     position: "absolute",
-    cursor: isHorizontal ? "ew-resize" : "ns-resize",
-    pointerEvents: "auto", // Only this element captures events
-    ...(isHorizontal
-      ? {
-          left: `calc(${config.threshold}% - ${DRAG_ZONE_SIZE}px)`,
-          width: DRAG_ZONE_SIZE * 2,
-          top: 0,
-          bottom: 0,
-        }
-      : {
-          top: `calc(${config.threshold}% - ${DRAG_ZONE_SIZE}px)`,
-          height: DRAG_ZONE_SIZE * 2,
-          left: 0,
-          right: 0,
-        }),
+    cursor: "ew-resize",
+    pointerEvents: "auto",
+    left: `calc(${config.threshold}% - ${DRAG_ZONE_SIZE}px)`,
+    width: DRAG_ZONE_SIZE * 2,
+    top: 0,
+    bottom: 0,
   };
 
-  // Indicator positioning - use transform for centering on both axes
+  // Indicator positioning
   const indicatorStyle: React.CSSProperties = {
     position: "absolute",
     pointerEvents: "none",
     display: "flex",
     alignItems: "center",
-    ...(isHorizontal
-      ? {
-          left: `${config.threshold}%`,
-          top: "50%",
-          transform: "translate(-50%, -50%)",
-          flexDirection: "column",
-        }
-      : {
-          top: `${config.threshold}%`,
-          left: "50%",
-          transform: "translate(-50%, -50%)",
-          flexDirection: "row",
-        }),
+    flexDirection: "column",
+    left: `${config.threshold}%`,
+    top: "50%",
+    transform: "translate(-50%, -50%)",
   };
-
-  // Line between triangles
-  const lineStyle: React.CSSProperties = isHorizontal
-    ? { width: 1, height: 6, background: color }
-    : { width: 6, height: 1, background: color };
-
-  // Get container rect for tooltip positioning (vertical only)
-  const containerRect = containerRef.current?.getBoundingClientRect();
 
   return (
     <div ref={containerRef} style={containerStyle}>
-      {/* Drag handle - captures mouse events in a small zone around the indicator */}
-      <div
-        style={handleStyle}
-        onMouseDown={handleMouseDown}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-        // Horizontal uses native title (simpler, no clipping issues with wide tooltips)
-        title={isHorizontal ? tooltipText : undefined}
-      />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div style={handleStyle} onMouseDown={handleMouseDown} />
+        </TooltipTrigger>
+        <TooltipContent side="top" showArrow={false}>
+          {tooltipText}
+        </TooltipContent>
+      </Tooltip>
 
       {/* Visual indicator - pointer events disabled */}
       <div style={indicatorStyle}>
-        <Triangle direction={isHorizontal ? "down" : "right"} color={color} />
-        <div style={lineStyle} />
-        <Triangle direction={isHorizontal ? "up" : "left"} color={color} />
+        <Triangle direction="down" color={color} />
+        <div style={{ width: 1, height: 6, background: color }} />
+        <Triangle direction="up" color={color} />
       </div>
-
-      {/* Portal tooltip for vertical only - escapes narrow container clipping */}
-      {!isHorizontal && isHovered && containerRect && (
-        <VerticalSliderTooltip
-          text={tooltipText}
-          anchorRect={containerRect}
-          threshold={config.threshold}
-        />
-      )}
     </div>
   );
 };
 
-// ----- Convenience exports -----
-
 /** Horizontal threshold slider (alias for backwards compatibility) */
-export const HorizontalThresholdSlider: React.FC<{ config: AutoCompactionConfig }> = ({
-  config,
-}) => <ThresholdSlider config={config} orientation="horizontal" />;
-
-/** Vertical threshold slider */
-export const VerticalThresholdSlider: React.FC<{ config: AutoCompactionConfig }> = ({ config }) => (
-  <ThresholdSlider config={config} orientation="vertical" />
-);
+export const HorizontalThresholdSlider = ThresholdSlider;


### PR DESCRIPTION
## Summary

Replace the native `title` attribute with a Radix Tooltip for the auto-compaction threshold slider in the right sidebar. This makes the tooltip appear instantly with styled UI instead of the slow (~700ms delay) native browser tooltip.

## Background

The compaction slider in the right sidebar showed a slow, ugly native browser tooltip, while the same slider in the context bar popup showed a nice styled Radix tooltip instantly. Both used the same `HorizontalThresholdSlider` component—the difference was that the native `title` attribute has a built-in delay.

## Implementation

- Replace native `title` with `<Tooltip>`/`<TooltipTrigger>`/`<TooltipContent>` from Radix
- Remove dead code for unused vertical slider orientation (~130 lines):
  - `VerticalThresholdSlider` export (never imported anywhere)
  - `VerticalSliderTooltip` portal component
  - `orientation` prop and all conditionals
  - `createPortal` import
  - Triangle left/right direction support
- Keep `HorizontalThresholdSlider` as an alias for backwards compatibility

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$2.06`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=2.06 -->
