### PR TITLE
🤖 fix: align right sidebar collapse button with content

### DIFF
--- a/src/browser/components/RightSidebar.tsx
+++ b/src/browser/components/RightSidebar.tsx
@@ -1255,15 +1255,21 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
 
             <div className="flex min-h-0 min-w-0 flex-1 flex-col">
               {renderLayoutNode(layout.root)}
+              <SidebarCollapseButton
+                collapsed={collapsed}
+                onToggle={() => setCollapsed(!collapsed)}
+                side="right"
+              />
             </div>
           </div>
         )}
-
-        <SidebarCollapseButton
-          collapsed={collapsed}
-          onToggle={() => setCollapsed(!collapsed)}
-          side="right"
-        />
+        {collapsed && (
+          <SidebarCollapseButton
+            collapsed={collapsed}
+            onToggle={() => setCollapsed(!collapsed)}
+            side="right"
+          />
+        )}
       </SidebarContainer>
 
       {/* Drag overlay - shows tab being dragged at cursor position */}


### PR DESCRIPTION
## Summary

Fix the right sidebar collapse button overflowing into the chat view by moving it inside the content column when expanded.

## Background

The collapse button (`»`) was rendered as a direct child of the sidebar container, spanning its full width. However, the sidebar content is inset by a 2px resize handle on the left edge. This caused the button to extend 2px further left than the content above it, creating visual misalignment.

## Implementation

Move the collapse button inside the content flex column when expanded, so it inherits the same horizontal bounds. When collapsed, the button continues to render directly in the container (no resize handle present in that state).

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$1.02`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=1.02 -->
