### PR TITLE
🤖 feat: add response notification controls

### DIFF
--- a/docs/config/notifications.mdx
+++ b/docs/config/notifications.mdx
@@ -5,9 +5,13 @@ description: Configure how agents notify you about important events
 
 ## Overview
 
-Mux agents can send system notifications to alert you about important events. Notifications appear as native OS notifications (macOS Notification Center, Windows Toast, Linux notification daemon) and work even when Mux is in the background.
+Mux can send system notifications to alert you about important events. Notifications appear as native OS notifications (macOS Notification Center, Windows Toast, Linux notification daemon) and work even when Mux is in the background. Clicking a notification takes you directly to the workspace that sent it.
 
-The `notify` tool gives agents the ability to send these notifications. Clicking a notification takes you directly to the workspace that sent it. You control when and how agents use this tool through your prompts or scoped instructions.
+There are two ways to receive notifications:
+
+1. **Automatic notifications** — Toggle the bell icon in the workspace header to get notified when the agent completes a response. Use <kbd>Ctrl+Shift+N</kbd> (<kbd>⌘+Shift+N</kbd> on macOS) to toggle quickly.
+
+2. **Agent-triggered notifications** — The `notify` tool lets agents send notifications for specific events. You control when agents use this through prompts or scoped instructions.
 
 ## Quick examples
 

--- a/src/browser/components/ChatInput/useCreationWorkspace.ts
+++ b/src/browser/components/ChatInput/useCreationWorkspace.ts
@@ -16,6 +16,8 @@ import {
   getInputKey,
   getInputImagesKey,
   getModelKey,
+  getNotifyOnResponseAutoEnableKey,
+  getNotifyOnResponseKey,
   getThinkingLevelKey,
   getWorkspaceAISettingsByModeKey,
   getPendingScopeId,
@@ -83,6 +85,15 @@ function syncCreationPreferences(projectPath: string, workspaceId: string): void
       },
       {}
     );
+  }
+
+  // Auto-enable notifications if the project-level preference is set
+  const autoEnableNotifications = readPersistedState<boolean>(
+    getNotifyOnResponseAutoEnableKey(projectPath),
+    false
+  );
+  if (autoEnableNotifications) {
+    updatePersistedState(getNotifyOnResponseKey(workspaceId), true);
   }
 }
 

--- a/src/browser/components/Settings/sections/KeybindsSection.tsx
+++ b/src/browser/components/Settings/sections/KeybindsSection.tsx
@@ -49,6 +49,7 @@ const KEYBIND_LABELS: Record<keyof typeof KEYBINDS, string> = {
   TOGGLE_VOICE_INPUT: "Toggle voice input",
   NAVIGATE_BACK: "Navigate back",
   NAVIGATE_FORWARD: "Navigate forward",
+  TOGGLE_NOTIFICATIONS: "Toggle notifications",
 };
 
 /** Groups for organizing keybinds in the UI */
@@ -63,6 +64,7 @@ const KEYBIND_GROUPS: Array<{ label: string; keys: Array<keyof typeof KEYBINDS> 
       "TOGGLE_SIDEBAR",
       "CYCLE_MODEL",
       "TOGGLE_THINKING",
+      "TOGGLE_NOTIFICATIONS",
     ],
   },
   {

--- a/src/browser/utils/ui/keybinds.ts
+++ b/src/browser/utils/ui/keybinds.ts
@@ -339,6 +339,11 @@ export const KEYBINDS = {
   // macOS: Cmd+], Win/Linux: Ctrl+]
   // Standard browser/editor forward navigation
   NAVIGATE_FORWARD: { key: "]", ctrl: true },
+
+  /** Toggle notifications on response for current workspace */
+  // macOS: Cmd+Shift+N, Win/Linux: Ctrl+Shift+N
+  // "N" for Notifications
+  TOGGLE_NOTIFICATIONS: { key: "N", ctrl: true, shift: true },
 } as const;
 
 /**

--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -368,6 +368,25 @@ export function getFileTreeExpandStateKey(workspaceId: string): string {
  * Stores the most recent successful status_set payload (emoji, message, url)
  * Format: "statusState:{workspaceId}"
  */
+
+/**
+ * Get the localStorage key for "notify on response" toggle per workspace.
+ * When true, a browser notification is shown when assistant responses complete.
+ * Format: "notifyOnResponse:{workspaceId}"
+ */
+export function getNotifyOnResponseKey(workspaceId: string): string {
+  return `notifyOnResponse:${workspaceId}`;
+}
+
+/**
+ * Get the localStorage key for "auto-enable notifications" toggle per project.
+ * When true, new workspaces in this project automatically have notifications enabled.
+ * Format: "notifyOnResponseAutoEnable:{projectPath}"
+ */
+export function getNotifyOnResponseAutoEnableKey(projectPath: string): string {
+  return `notifyOnResponseAutoEnable:${projectPath}`;
+}
+
 export function getStatusStateKey(workspaceId: string): string {
   return `statusState:${workspaceId}`;
 }


### PR DESCRIPTION
## Summary
- add a workspace notification bell with an interactive popover and keybind toggle
- support project-level auto-enable for new workspaces
- trigger browser notifications on response completion when enabled

## Implementation
- add workspace + project localStorage keys for notification preferences
- wire response-complete callbacks into the aggregator/store and App handler
- add popover UI with per-workspace toggle, auto-enable setting, and keybind hints
- auto-enable notifications during workspace creation when the project setting is on

## Validation
- make static-check

## Risks
- Low: gated behind user toggles and browser notification permissions

---

_Generated with `mux` • Model: `mux-gateway:openai/gpt-5.2-codex` • Thinking: `xhigh` • Cost: `$3.50`_

<!-- mux-attribution: model=mux-gateway:openai/gpt-5.2-codex thinking=xhigh costs=3.50 -->
