### PR TITLE
🤖 fix: retry previousResponseId during tool steps

### DIFF
--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -774,6 +774,29 @@ describe("StreamManager - previousResponseId recovery", () => {
     expect(result).toEqual(cumulativeUsage);
   });
 
+  test("resolveTotalUsageForStreamEnd treats non-zero fields as valid usage", () => {
+    const mockHistoryService = createMockHistoryService();
+    const mockPartialService = createMockPartialService();
+    const streamManager = new StreamManager(mockHistoryService, mockPartialService);
+
+    const resolveMethod = Reflect.get(streamManager, "resolveTotalUsageForStreamEnd") as (
+      streamInfo: unknown,
+      totalUsage: unknown
+    ) => unknown;
+    expect(typeof resolveMethod).toBe("function");
+
+    const cumulativeUsage = { inputTokens: 4, outputTokens: 1, totalTokens: 0 };
+    const totalUsage = { inputTokens: 1, outputTokens: 2, totalTokens: 3 };
+
+    const result = resolveMethod.call(
+      streamManager,
+      { didRetryPreviousResponseIdAtStep: true, cumulativeUsage },
+      totalUsage
+    );
+
+    expect(result).toEqual(cumulativeUsage);
+  });
+
   test("resolveTotalUsageForStreamEnd keeps stream total without step retry", () => {
     const mockHistoryService = createMockHistoryService();
     const mockPartialService = createMockPartialService();


### PR DESCRIPTION
Summary
- retry previousResponseId failures at step boundaries without dropping prior tool parts
- track last step messages for safe mid-stream retries and preserve usage state
- surface a clearer error message and add unit coverage for step-boundary retry

Background
Gateway sometimes returns "previous response not found" after a tool step begins, which previously surfaced as an abrupt stream error because retries only fired before any parts were emitted.

Implementation
- track step boundaries + latest step messages to allow a safe retry when no output was emitted for the current step
- preserve existing parts/usage on retry and rehydrate the step prompt without previousResponseId
- update stream error messaging for previousResponseId failures
- add a unit test covering step-boundary retries

Validation
- bun test src/node/services/streamManager.test.ts
- make static-check

Risks
Low. Retry is gated to step boundaries where no output has been emitted for the current step to avoid duplicate tool calls or text.

---

_Generated with `mux` • Model: `mux-gateway:openai/gpt-5.2-codex` • Thinking: `xhigh` • Cost: `$5.13`_

<!-- mux-attribution: model=mux-gateway:openai/gpt-5.2-codex thinking=xhigh costs=5.13 -->
