### PR TITLE
🤖 fix: replace gateway default toggle with enable-all button

### DIFF
--- a/src/browser/components/Settings/sections/ProvidersSection.tsx
+++ b/src/browser/components/Settings/sections/ProvidersSection.tsx
@@ -868,15 +868,37 @@ export function ProvidersSection() {
                           Turn on Mux Gateway for every eligible model.
                         </span>
                       </div>
-                      <Button
-                        size="sm"
-                        variant="secondary"
-                        onClick={enableGatewayForAllModels}
-                        disabled={!canEnableGatewayForAllModels}
-                        aria-label="Enable Mux Gateway for all models"
-                      >
-                        Enable all
-                      </Button>
+                      {canEnableGatewayForAllModels ? (
+                        <Button
+                          size="sm"
+                          variant="secondary"
+                          onClick={enableGatewayForAllModels}
+                          aria-label="Enable Mux Gateway for all models"
+                        >
+                          Enable all
+                        </Button>
+                      ) : (
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="inline-flex">
+                                <Button
+                                  size="sm"
+                                  variant="secondary"
+                                  onClick={enableGatewayForAllModels}
+                                  disabled
+                                  aria-label="Enable Mux Gateway for all models"
+                                >
+                                  Enable all
+                                </Button>
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              All eligible models are already enabled.
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      )}
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
Summary
- replace the Mux Gateway Default toggle with an Enable all button that is disabled when no change would occur
- keep gateway model persistence logic consistent while applying to all eligible models

Background
- the Default toggle was effectively a no-op when all eligible models were already enabled; a button better communicates the one-way action

Implementation
- compute whether enabling all models would change the current selection
- replace the toggle UI with a disabled/enabled button that applies the eligible model set

Validation
- make typecheck
- make static-check

Risks
- Low: settings UI-only change scoped to gateway preferences

---

_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `high` • Cost: `$6.50`_

<!-- mux-attribution: model=openai:gpt-5.2-codex thinking=high costs=6.50 -->
