### PR TITLE
🤖 feat: include hook_path in tool hook responses

### DIFF
--- a/src/common/types/tools.ts
+++ b/src/common/types/tools.ts
@@ -361,6 +361,8 @@ export interface WithHookOutput {
   hook_output?: string;
   /** Total hook execution time (pre + post) in milliseconds */
   hook_duration_ms?: number;
+  /** Path to the hook file that produced this output (helps the model investigate/modify) */
+  hook_path?: string;
 }
 
 /**

--- a/src/node/services/tools/withHooks.test.ts
+++ b/src/node/services/tools/withHooks.test.ts
@@ -137,7 +137,7 @@ exit 1
     expect(result.hook_output).toContain("Lint failed: syntax error");
   });
 
-  test("appends hook_output when hook succeeds with output", async () => {
+  test("appends hook_output and hook_path when hook succeeds with output", async () => {
     const hookDir = path.join(tempDir, ".mux");
     const hookPath = path.join(hookDir, "tool_hook");
     await fs.mkdir(hookDir, { recursive: true });
@@ -164,9 +164,11 @@ exit 0
     const result = (await wrappedTool.execute!({ input: "test" }, {} as never)) as {
       output: string;
       hook_output?: string;
+      hook_path?: string;
     };
     expect(result.output).toBe("edit complete");
     expect(result.hook_output).toContain("Formatted: test.ts");
+    expect(result.hook_path).toBe(hookPath);
   });
 
   test("passes env to hook", async () => {


### PR DESCRIPTION
## Summary

When tool hooks run and produce output, the response now includes the path to the hook file that generated the output. This helps models investigate or modify the hook behavior when they receive hook feedback.

## Background

Tool hooks can produce output that gets included in the tool result (e.g., formatter messages, lint errors). Previously, the model only saw the output text without knowing which file produced it. Including the hook path enables the model to:
- Read the hook file to understand its behavior
- Suggest modifications to the hook if needed
- Better understand the project's hook configuration

## Implementation

- Added `hook_path?: string` field to `WithHookOutput` interface in `src/common/types/tools.ts`
- Updated `appendHookOutput` function to accept and propagate hook paths through all result types
- Updated all three call sites in `withHooks.ts` to pass the relevant hook path

### Example output

```json
{
  "success": true,
  "output": "...",
  "hook_output": "Formatted: test.ts",
  "hook_duration_ms": 42,
  "hook_path": "/path/to/project/.mux/tool_hook"
}
```

## Validation

- Extended existing test to verify `hook_path` is correctly included in results
- All tests pass, static-check passes

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.91`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=0.91 -->
