### PR TITLE
🤖 feat: show 'Compaction complete' in response notifications

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -679,11 +679,13 @@ function AppInner() {
     // Callback for "notify on response" feature - fires when any assistant response completes.
     // Only notify when isFinal=true (assistant done with all work, no more active streams).
     // finalText is extracted by the aggregator (text after tool calls).
+    // isCompaction is true when this was a compaction stream (for special notification text).
     const handleResponseComplete = (
       workspaceId: string,
       _messageId: string,
       isFinal: boolean,
-      finalText: string
+      finalText: string,
+      isCompaction: boolean
     ) => {
       // Only notify on final message (when assistant is done with all work)
       if (!isFinal) return;
@@ -700,11 +702,14 @@ function AppInner() {
       const metadata = workspaceMetadataRef.current.get(workspaceId);
       const title = metadata?.title ?? metadata?.name ?? "Response complete";
 
-      const body = finalText
-        ? finalText.length > 200
-          ? `${finalText.slice(0, 197)}…`
-          : finalText
-        : "Response complete";
+      // For compaction completions, use a specific message instead of the summary text
+      const body = isCompaction
+        ? "Compaction complete"
+        : finalText
+          ? finalText.length > 200
+            ? `${finalText.slice(0, 197)}…`
+            : finalText
+          : "Response complete";
 
       // Send browser notification
       if ("Notification" in window) {

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -342,8 +342,15 @@ export class WorkspaceStore {
   // Global callback when a response completes (for "notify on response" feature)
   // isFinal is true when no more active streams remain (assistant done with all work)
   // finalText is the text content after any tool calls (for notification body)
+  // isCompaction is true when this was a compaction stream (for special notification text)
   private responseCompleteCallback:
-    | ((workspaceId: string, messageId: string, isFinal: boolean, finalText: string) => void)
+    | ((
+        workspaceId: string,
+        messageId: string,
+        isFinal: boolean,
+        finalText: string,
+        isCompaction: boolean
+      ) => void)
     | null = null;
 
   // Tracks when a file-modifying tool (file_edit_*, bash) last completed per workspace.
@@ -643,9 +650,16 @@ export class WorkspaceStore {
    * Set the callback for when a response completes (used for "notify on response" feature).
    * isFinal is true when no more active streams remain (assistant done with all work).
    * finalText is the text content after any tool calls (for notification body).
+   * isCompaction is true when this was a compaction stream (for special notification text).
    */
   setOnResponseComplete(
-    callback: (workspaceId: string, messageId: string, isFinal: boolean, finalText: string) => void
+    callback: (
+      workspaceId: string,
+      messageId: string,
+      isFinal: boolean,
+      finalText: string,
+      isCompaction: boolean
+    ) => void
   ): void {
     this.responseCompleteCallback = callback;
     // Update existing aggregators with the callback


### PR DESCRIPTION
## Summary

When the 'notify on response' feature triggers for a post-compaction message, show "Compaction complete" as the notification body instead of the compaction summary text.

## Background

The compaction summary text can be long and technical, making it unsuitable for notification body content. Users just need to know compaction finished, not see the full summary.

## Implementation

- Added `isCompaction` parameter to the `onResponseComplete` callback signature in `StreamingMessageAggregator`
- Captured `wasCompacting` from the stream context before cleanup (since cleanup removes the stream)
- Updated `WorkspaceStore` callback type to include the new parameter
- Added logic in `App.tsx` to show "Compaction complete" when `isCompaction` is true

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$1.08`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=1.08 -->