### PR TITLE
🤖 fix: preserve skill invocation context in user messages

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -129,6 +129,14 @@ type CreationRuntimeValidationError =
   | { mode: "ssh"; kind: "missingCoderTemplate" }
   | { mode: "ssh"; kind: "missingCoderPreset" };
 
+/**
+ * Format user message text for skill invocation.
+ * Makes it explicit to the model that a skill was invoked.
+ */
+function formatSkillInvocationText(skillName: string, userMessage: string): string {
+  return userMessage ? `Using skill ${skillName}: ${userMessage}` : `Use skill ${skillName}`;
+}
+
 function validateCreationRuntime(
   runtime: ParsedRuntime,
   coderPresetCount: number
@@ -1434,7 +1442,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
             }
 
             if (skill) {
-              const userText = afterPrefix.trimStart() || `Run the "${skill.name}" skill.`;
+              const userText = formatSkillInvocationText(skill.name, afterPrefix.trimStart());
 
               if (!api) {
                 pushToast({ type: "error", message: "Not connected to server" });
@@ -1527,7 +1535,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           }
 
           if (skill) {
-            const userText = afterPrefix.trimStart() || `Run the "${skill.name}" skill.`;
+            const userText = formatSkillInvocationText(skill.name, afterPrefix.trimStart());
 
             skillInvocation = { descriptor: skill, userText };
             parsed = null;

--- a/src/node/services/messageQueue.test.ts
+++ b/src/node/services/messageQueue.test.ts
@@ -234,7 +234,7 @@ describe("MessageQueue", () => {
         muxMetadata: metadata,
       };
 
-      expect(() => queue.add('Run the "init" skill.', options)).toThrow(
+      expect(() => queue.add("Using skill init", options)).toThrow(
         /Cannot queue agent skill invocation/
       );
     });
@@ -247,7 +247,7 @@ describe("MessageQueue", () => {
         scope: "built-in",
       };
 
-      queue.add('Run the "init" skill.', {
+      queue.add("Use skill init", {
         model: "claude-3-5-sonnet-20241022",
         muxMetadata: metadata,
       });


### PR DESCRIPTION
## Summary

When invoking a skill via slash command (e.g., `/pull-requests submit`), the command prefix was being stripped, leaving just the user text. This made it unclear to the model that the message was a skill invocation.

## Background

The model receives skill content as a synthetic user message with `<agent-skill>` wrapper, but the actual user message only contained the text after the slash command. For `/pull-requests submit`, the model would see just `submit` without context about why the skill content appeared.

## Implementation

Added `formatSkillInvocationText` helper that formats the user message as:
- `Using skill pull-requests: submit` (with user text)
- `Using skill pull-requests` (without user text)

This is token-efficient (no XML tags) and explicit to models.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$6.00`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=6.00 -->
