### PR TITLE
🤖 fix: capture response in last LLM request modal

### DIFF
--- a/src/browser/components/DebugLlmRequestModal.tsx
+++ b/src/browser/components/DebugLlmRequestModal.tsx
@@ -8,7 +8,7 @@ import { useCopyToClipboard } from "@/browser/hooks/useCopyToClipboard";
 import { copyToClipboard } from "@/browser/utils/clipboard";
 
 const JsonOutput: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <div className="bg-code-bg text-text mt-3 max-h-[40vh] w-full max-w-full min-w-0 overflow-auto rounded-sm">
+  <div className="bg-code-bg text-text mt-3 w-full max-w-full min-w-0 overflow-x-auto rounded-sm">
     <pre className="min-w-max p-3 font-mono text-xs leading-relaxed whitespace-pre">{children}</pre>
   </div>
 );
@@ -176,7 +176,7 @@ export const DebugLlmRequestModal: React.FC<DebugLlmRequestModalProps> = ({
                   <summary className="text-foreground cursor-pointer text-sm font-medium">
                     System message
                   </summary>
-                  <pre className="bg-code-bg text-text mt-3 max-h-[40vh] overflow-auto rounded-sm p-3 font-mono text-xs leading-relaxed whitespace-pre-wrap">
+                  <pre className="bg-code-bg text-text mt-3 rounded-sm p-3 font-mono text-xs leading-relaxed whitespace-pre-wrap">
                     {snapshot.systemMessage}
                   </pre>
                 </details>
@@ -186,6 +186,19 @@ export const DebugLlmRequestModal: React.FC<DebugLlmRequestModalProps> = ({
                     Messages
                   </summary>
                   <JsonOutput>{JSON.stringify(snapshot.messages, null, 2)}</JsonOutput>
+                </details>
+
+                <details className="border-border-light bg-modal-bg min-w-0 rounded-md border p-3">
+                  <summary className="text-foreground cursor-pointer text-sm font-medium">
+                    Response
+                  </summary>
+                  {snapshot.response ? (
+                    <JsonOutput>{JSON.stringify(snapshot.response, null, 2)}</JsonOutput>
+                  ) : (
+                    <div className="text-muted mt-3 text-xs">
+                      No response captured yet (wait for the stream to finish).
+                    </div>
+                  )}
                 </details>
 
                 <details className="border-border-light bg-modal-bg min-w-0 rounded-md border p-3">

--- a/src/browser/stories/App.errors.stories.tsx
+++ b/src/browser/stories/App.errors.stories.tsx
@@ -108,6 +108,7 @@ const LARGE_DIFF = [
 const createDebugLlmRequestSnapshot = (workspaceId: string): DebugLlmRequestSnapshot => ({
   capturedAt: STABLE_TIMESTAMP - 45000,
   workspaceId,
+  messageId: "assistant-debug-1",
   model: "anthropic:claude-3-5-sonnet-20241022",
   providerName: "anthropic",
   thinkingLevel: "medium",
@@ -131,6 +132,35 @@ const createDebugLlmRequestSnapshot = (workspaceId: string): DebugLlmRequestSnap
       content: "Summarized 3 tasks, trimmed history, and queued a retry.",
     },
   ],
+  response: {
+    capturedAt: STABLE_TIMESTAMP - 44000,
+    metadata: {
+      model: "anthropic:claude-3-5-sonnet-20241022",
+      usage: {
+        inputTokens: 123,
+        outputTokens: 456,
+        totalTokens: 579,
+      },
+      duration: 1234,
+      systemMessageTokens: 42,
+    },
+    parts: [
+      {
+        type: "text",
+        text: "Here’s a concise summary and the next steps to resume safely.",
+        timestamp: STABLE_TIMESTAMP - 44000,
+      },
+      {
+        type: "dynamic-tool",
+        toolCallId: "tool-1",
+        toolName: "write_summary",
+        state: "output-available",
+        input: { tasks: 3 },
+        output: { ok: true },
+        timestamp: STABLE_TIMESTAMP - 43950,
+      },
+    ],
+  },
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -8,7 +8,13 @@ import { ProjectConfigSchema, SectionConfigSchema } from "./project";
 import { ResultSchema } from "./result";
 import { RuntimeConfigSchema, RuntimeAvailabilitySchema } from "./runtime";
 import { SecretSchema } from "./secrets";
-import { SendMessageOptionsSchema, UpdateStatusSchema, WorkspaceChatMessageSchema } from "./stream";
+import {
+  CompletedMessagePartSchema,
+  SendMessageOptionsSchema,
+  StreamEndEventSchema,
+  UpdateStatusSchema,
+  WorkspaceChatMessageSchema,
+} from "./stream";
 import { LayoutPresetsConfigSchema } from "./uiLayouts";
 import {
   TerminalCreateParamsSchema,
@@ -333,6 +339,7 @@ const DebugLlmRequestSnapshotSchema = z
   .object({
     capturedAt: z.number(),
     workspaceId: z.string(),
+    messageId: z.string().optional(),
     model: z.string(),
     providerName: z.string(),
     thinkingLevel: z.string(),
@@ -341,6 +348,14 @@ const DebugLlmRequestSnapshotSchema = z
     maxOutputTokens: z.number().optional(),
     systemMessage: z.string(),
     messages: z.array(z.unknown()),
+    response: z
+      .object({
+        capturedAt: z.number(),
+        metadata: StreamEndEventSchema.shape.metadata,
+        parts: z.array(CompletedMessagePartSchema),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 

--- a/src/common/types/debugLlmRequest.test.ts
+++ b/src/common/types/debugLlmRequest.test.ts
@@ -7,6 +7,7 @@ describe("DebugLlmRequestSnapshot", () => {
     const snapshot: DebugLlmRequestSnapshot = {
       capturedAt: Date.now(),
       workspaceId: "workspace-1",
+      messageId: "assistant-1",
       model: "anthropic:claude-3-5-sonnet",
       providerName: "anthropic",
       thinkingLevel: "off",
@@ -18,6 +19,18 @@ describe("DebugLlmRequestSnapshot", () => {
         { role: "user", content: "hello" },
         { role: "assistant", content: [{ type: "text", text: "hi" }] },
       ],
+      response: {
+        capturedAt: Date.now(),
+        metadata: {
+          model: "anthropic:claude-3-5-sonnet",
+          usage: {
+            inputTokens: 1,
+            outputTokens: 2,
+            totalTokens: 3,
+          },
+        },
+        parts: [{ type: "text", text: "done" }],
+      },
     };
 
     expect(() => JSON.stringify(snapshot)).not.toThrow();

--- a/src/common/types/debugLlmRequest.ts
+++ b/src/common/types/debugLlmRequest.ts
@@ -1,3 +1,5 @@
+import type { CompletedMessagePart, StreamEndEvent } from "./stream";
+
 /**
  * Captured snapshot of the exact LLM request payload for debugging.
  *
@@ -8,6 +10,13 @@
 export interface DebugLlmRequestSnapshot {
   capturedAt: number;
   workspaceId: string;
+
+  /**
+   * Message ID used for the assistant placeholder / stream.
+   *
+   * Used to associate the request snapshot with the eventual stream-end response.
+   */
+  messageId?: string;
 
   model: string;
   providerName: string;
@@ -20,4 +29,11 @@ export interface DebugLlmRequestSnapshot {
   systemMessage: string;
   /** Final ModelMessage[] after transforms, stored as unknown for IPC safety */
   messages: unknown[];
+
+  /** Provider-agnostic response capture from stream-end (parts + metadata). */
+  response?: {
+    capturedAt: number;
+    metadata: StreamEndEvent["metadata"];
+    parts: CompletedMessagePart[];
+  };
 }


### PR DESCRIPTION
## Summary
Adds response capture to the **Last LLM request** debug modal by persisting the stream-end metadata + parts alongside the request snapshot.

## Background
Previously the modal only showed the outbound request and used per-section scrollbars, which made long payloads hard to inspect.

## Implementation
- Extend `DebugLlmRequestSnapshot` (and ORPC schema) to optionally include `messageId` + `response`.
- Capture response data on `stream-end` in `AIService` (best-effort; never breaks streaming).
- Update the modal to scroll as a whole and add a **Response** section.
- Update the Storybook fixture.

## Validation
- `make static-check`

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Improve “Last LLM request” debug modal (scroll + capture response)

## Context / Why
The **Last LLM request** debug modal (`DebugLlmRequestModal`) currently captures and displays the exact **request payload** sent to the provider for a workspace. Two UX/debug gaps:

1. When multiple `<details>` sections are expanded, the modal becomes awkward to navigate because **each section has its own vertical scrollbar** (`max-h-[40vh] overflow-auto`), making it hard to scroll the overall modal.
2. The snapshot only includes the **request**, not the **response** returned by the provider/AI SDK (“inference API”), which makes debugging provider behavior and tool/usage output harder.

Goal: make the modal comfortably scroll as a whole, and extend the snapshot so the modal can show the final provider response (stream-end parts + metadata).

## Evidence (current code)
- UI modal: `src/browser/components/DebugLlmRequestModal.tsx`
  - Uses native `<details>/<summary>` sections.
  - `JsonOutput` and the system message `<pre>` are capped with `max-h-[40vh] overflow-auto`.
  - `DialogContent maxHeight="85vh"` relies on `DialogContent` auto-adding `overflow-y-auto`.
- Dialog behavior: `src/browser/components/ui/dialog.tsx`
  - `DialogContent` applies `overflow-y-auto` when `maxHeight` is provided.
- Backend snapshot capture: `src/node/services/aiService.ts`
  - Captures `DebugLlmRequestSnapshot` before delegating to `StreamManager.startStream` and stores it in-memory (`lastLlmRequestByWorkspace`).
  - `AIService.setupStreamEventForwarding()` forwards `stream-end` events from `StreamManager`.
- Stream-end response data exists: `src/common/orpc/schemas/stream.ts`
  - `StreamEndEventSchema` includes `parts: CompletedMessagePart[]` and `metadata` (usage/providerMetadata/etc).
- API contract is strict: `src/common/orpc/schemas/api.ts`
  - `DebugLlmRequestSnapshotSchema` is `.strict()`; adding fields requires updating this schema.

## Recommended approach (net ~90–140 LoC)
### 1) Extend the debug snapshot to include response data
**Files:**
- `src/common/types/debugLlmRequest.ts`
- `src/common/orpc/schemas/api.ts`

Changes:
- Add a stable identifier to match request↔response:
  - `messageId?: string` (the `assistantMessageId` used for the stream).
- Add an optional response payload:
  - `response?: { capturedAt: number; metadata: StreamEndEvent["metadata"]; parts: CompletedMessagePart[] }`
  - Keep the response structured-clone safe (only plain JSON-ish data).
- Update the Zod `DebugLlmRequestSnapshotSchema` in `schemas/api.ts` accordingly.
  - Import `CompletedMessagePartSchema` (and optionally reuse the metadata shape from `StreamEndEventSchema`) from `./stream`.

Defensive notes:
- Keep all new fields optional so story fixtures and any older callers don’t break.
- Prefer storing the *already-serialized* `CompletedMessagePart[]` (what we write to history) rather than trying to capture raw HTTP payloads.

### 2) Capture the response on `stream-end`
**File:** `src/node/services/aiService.ts`

Changes:
- In `setupStreamEventForwarding()`, expand the `stream-end` listener to:
  1. Continue forwarding the event (`this.emit("stream-end", data)`), and
  2. Attempt to attach `{capturedAt, metadata, parts}` onto the latest snapshot for that workspace.

Matching logic:
- If a snapshot exists for `workspaceId` and either:
  - `snapshot.messageId === data.messageId`, **or**
  - `snapshot.messageId` is missing (legacy/fixture),
  then attach the response.

Cloning / safety:
- Use `structuredClone` (fallback to `JSON.parse(JSON.stringify(...))`) when storing the response to avoid accidental retention of non-cloneable objects.
- Wrap in `try/catch` and log a warning (debug feature must never break streaming).

### 3) Make the modal scroll naturally when multiple sections are expanded
**File:** `src/browser/components/DebugLlmRequestModal.tsx`

Changes:
- Shift vertical scrolling responsibility to the modal (already capped at `85vh`) by removing per-section vertical scroll caps:
  - Update `JsonOutput`:
    - Remove `max-h-[40vh] overflow-auto`.
    - Replace with `overflow-x-auto` (keep horizontal scrolling for long JSON lines).
  - Update the System message `<pre>`:
    - Remove `max-h-[40vh] overflow-auto`.
- (Optional, only if needed after manual check) If the header controls feel like they should stay visible, follow the existing “scrollable modal body” layout pattern:
  - Make `DialogContent` a `flex flex-col overflow-hidden` container and put the main content in a `flex-1 overflow-y-auto` wrapper.

### 4) Display the captured response in the modal
**File:** `src/browser/components/DebugLlmRequestModal.tsx`

Changes:
- Add a new `<details>` section, e.g. **Response**.
  - If `snapshot.response` is present, render it via `JsonOutput`.
  - Otherwise show a small hint like: “No response captured yet (wait for the stream to finish).”
- The existing **Copy JSON** / **Download** actions will automatically include the response because they stringify the full snapshot.

### 5) Update Storybook fixture to cover the new UI (optional but recommended)
**File:** `src/browser/stories/App.errors.stories.tsx`

Changes:
- Extend `createDebugLlmRequestSnapshot()` to include a representative `response` object (and `messageId` if you decide to display it).
- (Optional) In the story’s `play`, expand multiple `<details>` sections so Chromatic visually verifies scroll behavior.

## Alternatives considered
<details>
<summary>Capture raw provider HTTP response (not recommended) (net ~250–500 LoC)</summary>

You *can* wrap the provider `fetch` (in `AIService.createModel` / provider fetch wrappers) to capture raw request/response headers and bodies.

Downsides:
- Streaming responses are hard to capture without buffering (which defeats streaming and risks high memory usage).
- Providers differ significantly in wire formats; you’d likely need per-provider adapters.

Unless we explicitly need the raw HTTP payload, the stream-end parts + metadata is a better, provider-agnostic “inference response”.
</details>

## Validation checklist
- Manual:
  - Send a message in a workspace.
  - Open **Last LLM request** modal.
  - Expand **System message**, **Messages**, **Response**, and confirm the modal scrolls cleanly as a whole.
  - Confirm **Response** appears after the stream finishes (and **Copy JSON** includes it).
- Automated:
  - `make typecheck`
  - `make lint` and `make fmt-check`
  - (If we add/update stories) run Storybook/Chromatic as usual.

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `55901{MUX_COSTS_USD}`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=2.25 -->
