### PR TITLE
🤖 fix: Send button follows agent uiColor

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -2495,11 +2495,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                       onClick={() => void handleSend()}
                       disabled={!canSend}
                       aria-label="Send message"
+                      style={{ backgroundColor: focusBorderColor }}
                       className={cn(
-                        "inline-flex items-center gap-1 rounded-sm border border-border-light px-1.5 py-0.5 text-[11px] font-medium text-white transition-colors duration-200 disabled:opacity-50",
-                        mode === "plan"
-                          ? "bg-plan-mode hover:bg-plan-mode-hover disabled:hover:bg-plan-mode"
-                          : "bg-exec-mode hover:bg-exec-mode-hover disabled:hover:bg-exec-mode"
+                        "border-border-light inline-flex items-center gap-1 rounded-sm border px-1.5 py-0.5 text-[11px] font-medium transition-colors duration-200 hover:brightness-110 disabled:opacity-50 disabled:hover:brightness-100",
+                        currentAgent?.uiColor ? "text-white" : "text-text"
                       )}
                     >
                       <SendHorizontal className="h-3.5 w-3.5" strokeWidth={2.5} />

--- a/src/browser/stories/mocks/orpc.ts
+++ b/src/browser/stories/mocks/orpc.ts
@@ -277,6 +277,7 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
         uiSelectable: true,
         subagentRunnable: false,
         base: "plan",
+        uiColor: "var(--color-plan-mode)",
       },
       {
         id: "exec",
@@ -285,6 +286,7 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
         description: "Implement changes in the repository",
         uiSelectable: true,
         subagentRunnable: true,
+        uiColor: "var(--color-exec-mode)",
       },
       {
         id: "compact",


### PR DESCRIPTION
## Summary

The Send Message button now uses `focusBorderColor` (derived from `currentAgent.uiColor`) instead of hard-coded mode-based classes, ensuring the button color matches the selected agent.

## Background

The Send button was using mode-based Tailwind classes (`bg-plan-mode`/`bg-exec-mode`) which only covered the two built-in modes. Custom agents with their own `uiColor` were ignored, causing a mismatch between the agent picker pill and the send button.

## Implementation

- Replace class-based background colors with inline `style={{ backgroundColor: focusBorderColor }}`
- Use `hover:brightness-110` for hover effect (works with any color value)
- Falls back to `var(--color-border-light)` until agents load (consistent with textarea border)

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$1.83`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=1.83 -->
