### PR TITLE
🤖 fix: prevent layout flash in New Workspace page

### DIFF
--- a/src/browser/hooks/useDraftWorkspaceSettings.ts
+++ b/src/browser/hooks/useDraftWorkspaceSettings.ts
@@ -300,10 +300,11 @@ export function useDraftWorkspaceSettings(
 
   // When the user switches into SSH/Docker/Devcontainer mode, seed the field with the remembered config.
   // This avoids clearing the last values when the UI switches modes with an empty field.
+  // Skip on initial mount (prevMode === null) since useState initializer handles that case.
   const prevSelectedRuntimeModeRef = useRef<RuntimeMode | null>(null);
   useEffect(() => {
     const prevMode = prevSelectedRuntimeModeRef.current;
-    if (prevMode !== selectedRuntime.mode) {
+    if (prevMode !== null && prevMode !== selectedRuntime.mode) {
       if (selectedRuntime.mode === RUNTIME_MODE.SSH) {
         const needsHostRestore = !selectedRuntime.host.trim() && lastSshHost.trim();
         const needsCoderRestore =

--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -94,6 +94,24 @@ export function getMCPTestResultsKey(projectPath: string): string {
 }
 
 /**
+ * Get the localStorage key for cached archived workspaces per project
+ * Format: "archivedWorkspaces:{projectPath}"
+ * Stores: Array of workspace metadata objects (optimistic cache)
+ */
+export function getArchivedWorkspacesKey(projectPath: string): string {
+  return `archivedWorkspaces:${projectPath}`;
+}
+
+/**
+ * Get the localStorage key for cached MCP servers per project
+ * Format: "mcpServers:{projectPath}"
+ * Stores: Record<serverName, MCPServerInfo> (optimistic cache)
+ */
+export function getMCPServersKey(projectPath: string): string {
+  return `mcpServers:${projectPath}`;
+}
+
+/**
  * Get the localStorage key for thinking level preference per scope (workspace/project).
  * Format: "thinkingLevel:{scopeId}"
  */


### PR DESCRIPTION
## Summary

Fixes multiple layout flash issues in the New Workspace page where UI elements would pop in after the initial render.

## Issues Fixed

1. **Branch selector flash**: The branch selector was hidden initially (`branches = []`) and appeared after the async `listBranches` API completed

2. **Initial mount effect**: A `useEffect` in `useDraftWorkspaceSettings` was firing on initial mount because `prevMode = null !== selectedRuntime.mode`, causing unnecessary state updates

3. **Provider bar flash**: The ConfiguredProvidersBar appeared suddenly after providers config loaded

4. **SSH host flash with Coder**: When Coder was being checked and user had saved Coder config, the SSH host field would briefly appear then disappear once Coder enabled

5. **Archived workspaces flash**: The archived workspaces section would pop in stark after async load

## Implementation

1. **`useDraftWorkspaceSettings.ts`**: Added `prevMode !== null` check to skip the "restore remembered config" effect on initial mount

2. **`CreationControls.tsx`**: 
   - Added loading placeholder skeleton for branch selector
   - Hide SSH host field when Coder is checking but has saved config (will enable after check)

3. **`ProjectPage.tsx`**: 
   - Added loading skeleton for providers bar while loading
   - Added localStorage cache for archived workspaces with optimistic rendering

4. **`storage.ts`**: Added `getArchivedWorkspacesKey()` for the archived workspaces cache

---

_🤖 Generated with [mux](https://github.com/coder/mux)_

<!-- mux-attribution: model=anthropic:claude-sonnet-4-20250514 -->