### PR TITLE
🤖 fix: enable message queueing during stream-starting phase

### DIFF
--- a/src/browser/components/ChatInput/types.ts
+++ b/src/browser/components/ChatInput/types.ts
@@ -24,6 +24,7 @@ export interface ChatInputWorkspaceVariant {
   onProviderConfig?: (provider: string, keyPath: string[], value: string) => Promise<void>;
   onModelChange?: (model: string) => void;
   isCompacting?: boolean;
+  isStreamStarting?: boolean;
   editingMessage?: { id: string; content: string; imageParts?: ImagePart[] };
   onCancelEdit?: () => void;
   onEditLastUserMessage?: () => void;

--- a/src/browser/components/ChatPane.tsx
+++ b/src/browser/components/ChatPane.tsx
@@ -151,7 +151,7 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
   useEffect(() => {
     workspaceStateRef.current = workspaceState;
   }, [workspaceState]);
-  const { messages, canInterrupt, isCompacting, loading } = workspaceState;
+  const { messages, canInterrupt, isCompacting, isStreamStarting, loading } = workspaceState;
 
   // Apply message transformations:
   // 1. Merge consecutive identical stream errors
@@ -691,6 +691,7 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
         workspaceId={workspaceId}
         projectName={projectName}
         workspaceName={workspaceName}
+        isStreamStarting={isStreamStarting}
         runtimeConfig={runtimeConfig}
         isQueuedAgentTask={isQueuedAgentTask}
         isCompacting={isCompacting}
@@ -720,6 +721,7 @@ interface ChatInputPaneProps {
   runtimeConfig?: RuntimeConfig;
   isQueuedAgentTask: boolean;
   isCompacting: boolean;
+  isStreamStarting: boolean;
   canInterrupt: boolean;
   autoCompactionResult: ReturnType<typeof checkAutoCompaction>;
   shouldShowCompactionWarning: boolean;
@@ -770,6 +772,7 @@ const ChatInputPane: React.FC<ChatInputPaneProps> = (props) => {
             ? "Queued — waiting for an available parallel task slot. This will start automatically."
             : undefined
         }
+        isStreamStarting={props.isStreamStarting}
         isCompacting={props.isCompacting}
         editingMessage={props.editingMessage}
         onCancelEdit={props.onCancelEdit}

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -51,6 +51,7 @@ export interface WorkspaceState {
   queuedMessage: QueuedMessage | null;
   canInterrupt: boolean;
   isCompacting: boolean;
+  isStreamStarting: boolean;
   awaitingUserQuestion: boolean;
   loading: boolean;
   muxMessages: MuxMessage[];
@@ -895,6 +896,9 @@ export class WorkspaceStore {
       const activeStreams = aggregator.getActiveStreams();
       const messages = aggregator.getAllMessages();
       const metadata = this.workspaceMetadata.get(workspaceId);
+      const pendingStreamStartTime = aggregator.getPendingStreamStartTime();
+      const canInterrupt = activeStreams.length > 0;
+      const isStreamStarting = pendingStreamStartTime !== null && !canInterrupt;
 
       // Live streaming stats
       const activeStreamMessageId = aggregator.getActiveStreamMessageId();
@@ -909,8 +913,9 @@ export class WorkspaceStore {
         name: metadata?.name ?? workspaceId, // Fall back to ID if metadata missing
         messages: aggregator.getDisplayedMessages(),
         queuedMessage: transient.queuedMessage,
-        canInterrupt: activeStreams.length > 0,
+        canInterrupt,
         isCompacting: aggregator.isCompacting(),
+        isStreamStarting,
         awaitingUserQuestion: aggregator.hasAwaitingUserQuestion(),
         loading: !hasMessages && !transient.caughtUp,
         muxMessages: messages,
@@ -919,7 +924,7 @@ export class WorkspaceStore {
         todos: aggregator.getCurrentTodos(),
         lastAbortReason: aggregator.getLastAbortReason(),
         agentStatus: aggregator.getAgentStatus(),
-        pendingStreamStartTime: aggregator.getPendingStreamStartTime(),
+        pendingStreamStartTime,
         pendingCompactionModel: aggregator.getPendingCompactionModel(),
         runtimeStatus: aggregator.getRuntimeStatus(),
         streamingTokenCount,

--- a/src/browser/utils/chatCommands.test.ts
+++ b/src/browser/utils/chatCommands.test.ts
@@ -521,7 +521,7 @@ describe("handlePlanShowCommand", () => {
         agentId: "exec",
       },
       setImageAttachments: mock(() => undefined),
-      setIsSending: mock(() => undefined),
+      setSendingState: mock(() => undefined),
     };
   };
 
@@ -590,7 +590,7 @@ describe("handlePlanOpenCommand", () => {
         agentId: "exec",
       },
       setImageAttachments: mock(() => undefined),
-      setIsSending: mock(() => undefined),
+      setSendingState: mock(() => undefined),
     };
   };
 
@@ -647,7 +647,7 @@ describe("handleCompactCommand", () => {
     const setInput = mock(() => undefined);
     const setToast = mock(() => undefined);
     const setImageAttachments = mock(() => undefined);
-    const setIsSending = mock(() => undefined);
+    const setSendingState = mock(() => undefined);
 
     // Track the options passed to sendMessage
     const sendMessageMock = mock(() => Promise.resolve(sendMessageResult));
@@ -657,7 +657,7 @@ describe("handleCompactCommand", () => {
       setInput,
       setToast,
       setImageAttachments,
-      setIsSending,
+      setSendingState,
       reviews: options?.reviews,
       api: {
         workspace: {

--- a/src/browser/utils/chatCommands.ts
+++ b/src/browser/utils/chatCommands.ts
@@ -151,7 +151,7 @@ export async function processSlashCommand(
   const {
     api: client,
     setInput,
-    setIsSending,
+    setSendingState,
     setToast,
     variant,
     setVimEnabled,
@@ -162,7 +162,7 @@ export async function processSlashCommand(
   // 1. Global Commands
   if (parsed.type === "providers-set") {
     if (context.onProviderConfig) {
-      setIsSending(true);
+      setSendingState(true);
       setInput(""); // Clear input immediately
 
       try {
@@ -188,7 +188,7 @@ export async function processSlashCommand(
         // The caller (ChatInput) pattern is: if (!result.clearInput) setInput(original).
         // So we should return clearInput: false on error.
       } finally {
-        setIsSending(false);
+        setSendingState(false);
       }
       return { clearInput: true, toastShown: true };
     }
@@ -391,12 +391,12 @@ async function handleForkCommand(
     workspaceId,
     sendMessageOptions,
     setInput,
-    setIsSending,
+    setSendingState,
     setToast,
   } = context;
 
   setInput(""); // Clear input immediately
-  setIsSending(true);
+  setSendingState(true);
 
   try {
     // Note: workspaceId is required for fork, but SlashCommandContext allows undefined workspaceId.
@@ -442,7 +442,7 @@ async function handleForkCommand(
     });
     return { clearInput: false, toastShown: true };
   } finally {
-    setIsSending(false);
+    setSendingState(false);
   }
 }
 
@@ -761,7 +761,8 @@ export interface CommandHandlerContext {
   editMessageId?: string;
   setInput: (value: string) => void;
   setImageAttachments: (images: ImageAttachment[]) => void;
-  setIsSending: (value: boolean) => void;
+  /** Increment/decrement the sending counter. Pass true to increment, false to decrement. */
+  setSendingState: (increment: boolean) => void;
   setToast: (toast: Toast) => void;
   onCancelEdit?: () => void;
 }
@@ -785,7 +786,7 @@ export async function handleNewCommand(
     workspaceId,
     sendMessageOptions,
     setInput,
-    setIsSending,
+    setSendingState,
     setToast,
   } = context;
 
@@ -818,7 +819,7 @@ export async function handleNewCommand(
   }
 
   setInput("");
-  setIsSending(true);
+  setSendingState(true);
 
   try {
     // Get workspace info to extract projectPath
@@ -867,7 +868,7 @@ export async function handleNewCommand(
     });
     return { clearInput: false, toastShown: true };
   } finally {
-    setIsSending(false);
+    setSendingState(false);
   }
 }
 
@@ -885,7 +886,7 @@ export async function handleCompactCommand(
     editMessageId,
     setInput,
     setImageAttachments,
-    setIsSending,
+    setSendingState,
     setToast,
     onCancelEdit,
   } = context;
@@ -898,7 +899,7 @@ export async function handleCompactCommand(
 
   setInput("");
   setImageAttachments([]);
-  setIsSending(true);
+  setSendingState(true);
 
   try {
     const result = await executeCompaction({
@@ -952,7 +953,7 @@ export async function handleCompactCommand(
     });
     return { clearInput: false, toastShown: true };
   } finally {
-    setIsSending(false);
+    setSendingState(false);
   }
 }
 

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -800,6 +800,7 @@ export class StreamingMessageAggregator {
    * Note: This returns the *override* model from the /compact command. If the user didn't
    * specify a model, compaction uses the workspace default model and we intentionally return null.
    */
+
   getPendingCompactionModel(): string | null {
     if (this.pendingStreamStartTime === null) return null;
     return this.pendingCompactionRequest?.model ?? null;

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -1761,7 +1761,11 @@ export class WorkspaceService extends EventEmitter {
       // Persist last-used model + thinking level for cross-device consistency.
       await this.maybePersistAISettingsFromOptions(workspaceId, resolvedOptions, "send");
 
-      if (this.aiService.isStreaming(workspaceId) && !resolvedOptions?.editMessageId) {
+      const shouldQueue =
+        !resolvedOptions?.editMessageId &&
+        (this.aiService.isStreaming(workspaceId) || session.isStreamStarting());
+
+      if (shouldQueue) {
         const pendingAskUserQuestion = askUserQuestionManager.getLatestPending(workspaceId);
         if (pendingAskUserQuestion) {
           try {

--- a/tests/ipc/queuedMessages.starting.test.ts
+++ b/tests/ipc/queuedMessages.starting.test.ts
@@ -1,0 +1,177 @@
+import { createTestEnvironment, cleanupTestEnvironment, type TestEnvironment } from "./setup";
+import {
+  createTempGitRepo,
+  cleanupTempGitRepo,
+  createWorkspace,
+  generateBranchName,
+  sendMessageWithModel,
+  waitFor,
+  HAIKU_MODEL,
+  createStreamCollector,
+} from "./helpers";
+import { isMuxMessage } from "@/common/orpc/types";
+import { buildMockStreamStartGateMessage } from "@/node/services/mock/mockAiRouter";
+
+describe("Queued messages during stream start", () => {
+  let env: TestEnvironment | null = null;
+  let repoPath: string | null = null;
+
+  beforeEach(async () => {
+    env = await createTestEnvironment();
+    env.services.aiService.enableMockMode();
+
+    repoPath = await createTempGitRepo();
+  });
+
+  afterEach(async () => {
+    if (repoPath) {
+      await cleanupTempGitRepo(repoPath);
+      repoPath = null;
+    }
+    if (env) {
+      await cleanupTestEnvironment(env);
+      env = null;
+    }
+  });
+
+  test("queues follow-up message sent before stream-start and auto-sends after first stream", async () => {
+    if (!env || !repoPath) {
+      throw new Error("Test environment not initialized");
+    }
+
+    const branchName = generateBranchName("test-starting-queue");
+    const result = await createWorkspace(env, repoPath, branchName);
+    if (!result.success) {
+      throw new Error(`Failed to create workspace: ${result.error}`);
+    }
+
+    const workspaceId = result.metadata.id;
+    const collector = createStreamCollector(env.orpc, workspaceId);
+    collector.start();
+
+    try {
+      await collector.waitForSubscription(5000);
+
+      const gatedMessage = buildMockStreamStartGateMessage("First message");
+      const aiService = env.services.aiService;
+      const session = env.services.workspaceService.getOrCreateSession(workspaceId);
+      const firstSendPromise = sendMessageWithModel(env, workspaceId, gatedMessage, HAIKU_MODEL);
+      let firstSendResolved = false;
+      void firstSendPromise.then(() => {
+        firstSendResolved = true;
+      });
+
+      const sawFirstUserMessage = await waitFor(() => {
+        return collector
+          .getEvents()
+          .some(
+            (event) =>
+              isMuxMessage(event) &&
+              event.role === "user" &&
+              event.parts.some((part) => "text" in part && part.text === gatedMessage)
+          );
+      }, 5000);
+      if (!sawFirstUserMessage) {
+        throw new Error("First user message was not emitted before mock stream start gate");
+      }
+
+      const sawStartingWindow = await waitFor(() => {
+        return session.isStreamStarting() && !aiService.isStreaming(workspaceId);
+      }, 5000);
+      if (!sawStartingWindow) {
+        throw new Error("Stream never entered starting window before follow-up could queue");
+      }
+
+      const sawStreamStartEarly = collector
+        .getEvents()
+        .some((event) => "type" in event && event.type === "stream-start");
+      if (firstSendResolved) {
+        throw new Error("First send resolved before follow-up could queue");
+      }
+
+      if (sawStreamStartEarly) {
+        throw new Error("Stream started before follow-up was queued; mock gate released early");
+      }
+
+      const secondSendResult = await sendMessageWithModel(
+        env,
+        workspaceId,
+        "Second message",
+        HAIKU_MODEL
+      );
+
+      aiService.releaseMockStreamStartGate(workspaceId);
+      expect(secondSendResult.success).toBe(true);
+
+      await collector.waitForEvent("stream-start", 15000);
+      await collector.waitForEvent("stream-end", 15000);
+
+      const sawSecondStreamStart = await waitFor(() => {
+        const streamStarts = collector
+          .getEvents()
+          .filter((event) => "type" in event && event.type === "stream-start");
+        return streamStarts.length >= 2;
+      }, 15000);
+      if (!sawSecondStreamStart) {
+        throw new Error("Second stream never started after queued message release");
+      }
+
+      const promptResult = aiService.debugGetLastMockPrompt(workspaceId);
+      if (!promptResult.success || !promptResult.data) {
+        throw new Error("Mock prompt snapshot missing after queued stream start");
+      }
+      const promptUserMessages = promptResult.data
+        .filter((message) => message.role === "user")
+        .map((message) =>
+          message.parts
+            .filter((part) => "text" in part)
+            .map((part) => part.text)
+            .join("")
+        );
+      expect(promptUserMessages).toEqual(expect.arrayContaining([gatedMessage, "Second message"]));
+
+      const sawSecondStreamEnd = await waitFor(() => {
+        const streamEnds = collector
+          .getEvents()
+          .filter((event) => "type" in event && event.type === "stream-end");
+        return streamEnds.length >= 2;
+      }, 15000);
+      const timestampedEvents = collector.getTimestampedEvents();
+      const streamStarts = timestampedEvents.filter(
+        (entry) => "type" in entry.event && entry.event.type === "stream-start"
+      );
+      const streamEnds = timestampedEvents.filter(
+        (entry) => "type" in entry.event && entry.event.type === "stream-end"
+      );
+      if (streamStarts.length >= 2 && streamEnds.length >= 1) {
+        const secondStartTime = streamStarts[1].arrivedAt;
+        const firstEndTime = streamEnds[0].arrivedAt;
+        if (secondStartTime < firstEndTime) {
+          throw new Error("Second stream started before the first stream ended");
+        }
+      }
+
+      if (!sawSecondStreamEnd) {
+        throw new Error("Second stream never finished after queued message release");
+      }
+
+      const userMessages = collector
+        .getEvents()
+        .filter(isMuxMessage)
+        .filter((event) => event.role === "user")
+        .map((event) =>
+          event.parts
+            .filter((part) => "text" in part)
+            .map((part) => part.text)
+            .join("")
+        );
+      expect(userMessages).toEqual(expect.arrayContaining([gatedMessage, "Second message"]));
+
+      const firstSendResult = await firstSendPromise;
+      expect(firstSendResult.success).toBe(true);
+    } finally {
+      collector.stop();
+      await env.orpc.workspace.remove({ workspaceId });
+    }
+  }, 35000);
+});


### PR DESCRIPTION
## Summary

Fixes a UX bug where the chat input was disabled during the "stream starting" phase (the window between when a user sends a message and when the AI stream actually starts). This prevented users from queueing follow-up messages before streaming begins. The fix generalizes the existing "compaction-starting" concept to all streams.

## Background

When a user sends a message, there's a brief window (typically <1s but sometimes longer) where:
1. The message is sent to the backend
2. The AI provider is contacted
3. The stream hasn't started yet

During this window, the frontend was disabling the input, and the backend wasn't queuing messages. This was confusing because users couldn't add follow-up thoughts before the AI started responding.

## Implementation

**Frontend changes:**
- `WorkspaceStore`: Added `isStreamStarting` state derived from `pendingStreamStartTime !== null && !canInterrupt`
- `ChatInput`: Uses `isStreamStarting` prop to keep input enabled during the starting phase (only blocks when actually streaming)
- Generalized "compaction-starting" concept to all streams

**Backend changes:**
- `AgentSession`: Renamed `compactionStarting` to `streamStarting`, applies to all `sendMessage()` and `resumeStream()` calls
- `WorkspaceService`: Queue condition now checks `session.isStreamStarting()` in addition to `aiService.isStreaming()`

**Test infrastructure:**
- Added mock stream-start gate mechanism (`[mock:wait-start]` marker) for deterministic testing
- Added prompt snapshot API (`debugGetLastMockPrompt`) to verify both messages reach the model
- Test uses explicit synchronization instead of sleeps

## Validation

- Added `tests/ipc/queuedMessages.starting.test.ts` that proves:
  1. User sends message with gate marker
  2. System enters starting state (not yet streaming)
  3. User sends follow-up message
  4. Gate is released, stream starts
  5. Both messages appear in the prompt sent to the model
  6. Both user messages appear in the collected events

## Risks

Low risk - the change makes the system more permissive (allows queueing where it previously didn't) rather than adding new restrictions. The backend queue logic is additive and uses the same code path as the existing streaming queue.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$25.80`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=25.80 -->
