### PR TITLE
🤖 fix: update lastReadTimestamp when user sends message to prevent false unread indicator

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -37,6 +37,7 @@ import {
   VIM_ENABLED_KEY,
   getProjectScopeId,
   getPendingScopeId,
+  getWorkspaceLastReadKey,
 } from "@/common/constants/storage";
 import {
   handleNewCommand,
@@ -2047,6 +2048,12 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
             runtimeType,
             sendMessageOptions.thinkingLevel ?? "off"
           );
+
+          // Mark workspace as read after sending a message.
+          // This prevents the unread indicator from showing when the user
+          // just interacted with the workspace (their own message bumps recencyTimestamp,
+          // but since they initiated it, they've "read" the workspace).
+          updatePersistedState(getWorkspaceLastReadKey(props.workspaceId), Date.now());
 
           // Mark attached reviews as completed (checked)
           if (sentReviewIds.length > 0) {

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -1946,6 +1946,12 @@ export const workspaceStore = {
    */
   simulateFileModifyingToolEnd: (workspaceId: string) =>
     getStoreInstance().simulateFileModifyingToolEnd(workspaceId),
+  /**
+   * Get sidebar-specific state for a workspace.
+   * Useful in tests for checking recencyTimestamp without hooks.
+   */
+  getWorkspaceSidebarState: (workspaceId: string) =>
+    getStoreInstance().getWorkspaceSidebarState(workspaceId),
 };
 
 /**

--- a/tests/ui/unreadIndicator.integration.test.ts
+++ b/tests/ui/unreadIndicator.integration.test.ts
@@ -1,0 +1,282 @@
+/**
+ * UI integration tests for the unread indicator.
+ *
+ * The unread indicator shows when a workspace has activity the user hasn't seen.
+ * Key components:
+ * - recencyTimestamp: derived from the most recent user message or compacted message
+ * - lastReadTimestamp: persisted in localStorage, updated when workspace is selected
+ * - isUnread: recencyTimestamp > lastReadTimestamp
+ *
+ * Bug under test: The unread indicator may incorrectly show as "unread" after a stream
+ * completes, even when the user is actively viewing the workspace.
+ */
+
+import { waitFor } from "@testing-library/react";
+
+import { preloadTestModules } from "../ipc/setup";
+import { createAppHarness, type AppHarness } from "./harness";
+import { readPersistedState, updatePersistedState } from "@/browser/hooks/usePersistedState";
+import { getWorkspaceLastReadKey } from "@/common/constants/storage";
+import { workspaceStore } from "@/browser/stores/WorkspaceStore";
+
+/**
+ * Get the unread state for a workspace from the WorkspaceStore.
+ */
+function getWorkspaceUnreadState(workspaceId: string): {
+  recencyTimestamp: number | null;
+  isUnread: (lastReadTimestamp: number) => boolean;
+} {
+  const state = workspaceStore.getWorkspaceSidebarState(workspaceId);
+  return {
+    recencyTimestamp: state.recencyTimestamp,
+    isUnread: (lastReadTimestamp: number) =>
+      state.recencyTimestamp !== null && state.recencyTimestamp > lastReadTimestamp,
+  };
+}
+
+/**
+ * Get the lastReadTimestamp from persisted state.
+ */
+function getLastReadTimestamp(workspaceId: string): number {
+  return readPersistedState<number>(getWorkspaceLastReadKey(workspaceId), 0);
+}
+
+/**
+ * Find the workspace element in the sidebar and check if it shows the unread indicator.
+ */
+function getWorkspaceUnreadIndicator(
+  container: HTMLElement,
+  workspaceId: string
+): { element: HTMLElement; hasUnreadBar: boolean } | null {
+  const workspaceEl = container.querySelector(
+    `[data-workspace-id="${workspaceId}"]`
+  ) as HTMLElement | null;
+
+  if (!workspaceEl) return null;
+
+  // The unread bar is a span with the unread styling
+  const unreadBar = workspaceEl.querySelector(
+    'span[class*="bg-muted-foreground"]'
+  ) as HTMLElement | null;
+
+  return {
+    element: workspaceEl,
+    hasUnreadBar: unreadBar !== null && unreadBar.getAttribute("aria-hidden") !== "true",
+  };
+}
+
+describe("Unread indicator (mock AI router)", () => {
+  beforeAll(async () => {
+    await preloadTestModules();
+  });
+
+  describe("basic unread tracking", () => {
+    let app: AppHarness;
+
+    beforeEach(async () => {
+      app = await createAppHarness({ branchPrefix: "unread" });
+    });
+
+    afterEach(async () => {
+      await app.dispose();
+    });
+
+    test("workspace is not unread when first opened", async () => {
+      // When a workspace is first selected, it should not show as unread
+      const lastRead = getLastReadTimestamp(app.workspaceId);
+      const { recencyTimestamp, isUnread } = getWorkspaceUnreadState(app.workspaceId);
+
+      // A fresh workspace may have recencyTimestamp from createdAt
+      // but lastReadTimestamp should be set when we selected it
+      expect(lastRead).toBeGreaterThan(0);
+      expect(isUnread(lastRead)).toBe(false);
+    });
+
+    test("recencyTimestamp updates when user sends a message", async () => {
+      const beforeSend = getWorkspaceUnreadState(app.workspaceId);
+      const beforeRecency = beforeSend.recencyTimestamp;
+
+      await app.chat.send("Hello, this is a test message");
+      await app.chat.expectTranscriptContains("Mock response: Hello, this is a test message");
+
+      const afterSend = getWorkspaceUnreadState(app.workspaceId);
+
+      // Recency should have updated to reflect the user message timestamp
+      expect(afterSend.recencyTimestamp).not.toBeNull();
+      if (beforeRecency !== null) {
+        expect(afterSend.recencyTimestamp).toBeGreaterThanOrEqual(beforeRecency);
+      }
+    });
+
+    test("assistant message alone does NOT update recencyTimestamp", async () => {
+      // This test validates that recency is computed from user messages,
+      // not from assistant responses.
+
+      await app.chat.send("First message");
+      await app.chat.expectTranscriptContains("Mock response: First message");
+
+      const afterFirstMessage = getWorkspaceUnreadState(app.workspaceId);
+      const recencyAfterFirst = afterFirstMessage.recencyTimestamp;
+
+      // Wait a bit to ensure any timing differences would be detectable
+      await new Promise((r) => setTimeout(r, 50));
+
+      // The recency should not have changed from just the assistant response
+      // (recency is set by the user message, not the assistant response)
+      const currentState = getWorkspaceUnreadState(app.workspaceId);
+      expect(currentState.recencyTimestamp).toBe(recencyAfterFirst);
+    });
+  });
+
+  describe("unread indicator during streaming", () => {
+    let app: AppHarness;
+
+    beforeEach(async () => {
+      app = await createAppHarness({ branchPrefix: "unread-stream" });
+    });
+
+    afterEach(async () => {
+      await app.dispose();
+    });
+
+    test("workspace should NOT show unread after stream completes while viewing it", async () => {
+      // This is the bug scenario:
+      // 1. User is viewing workspace A
+      // 2. User sends message
+      // 3. Stream starts and completes
+      // 4. Workspace should NOT show as unread (user is actively viewing it)
+
+      await app.chat.send("Test message for unread bug");
+      await app.chat.expectTranscriptContains("Mock response: Test message for unread bug");
+
+      // After stream completes, check unread state
+      const lastReadAfter = getLastReadTimestamp(app.workspaceId);
+      const { recencyTimestamp, isUnread } = getWorkspaceUnreadState(app.workspaceId);
+
+      // The workspace should NOT be unread while we're viewing it.
+      // The fix (in ChatInput) updates lastReadTimestamp when user sends a message,
+      // ensuring that user-initiated activity doesn't trigger the unread indicator.
+      expect(isUnread(lastReadAfter)).toBe(false);
+
+      // lastReadTimestamp should be >= recencyTimestamp after the fix
+      if (recencyTimestamp !== null) {
+        expect(lastReadAfter).toBeGreaterThanOrEqual(recencyTimestamp);
+      }
+    });
+
+    test("workspace should show unread when activity happens in non-selected workspace", async () => {
+      // Simulate activity in a workspace the user is NOT viewing
+      // by temporarily switching away
+
+      // First, send a message while viewing
+      await app.chat.send("Initial message");
+      await app.chat.expectTranscriptContains("Mock response: Initial message");
+
+      // Record timestamps
+      const recencyAfterFirstMsg = getWorkspaceUnreadState(app.workspaceId).recencyTimestamp;
+
+      // Simulate "looking away" by setting lastReadTimestamp to the past
+      const pastTime = (recencyAfterFirstMsg ?? Date.now()) - 10000;
+      updatePersistedState(getWorkspaceLastReadKey(app.workspaceId), pastTime);
+
+      // Now simulate another message arriving (as if from background)
+      await app.chat.send("Second message while away");
+      await app.chat.expectTranscriptContains("Mock response: Second message while away");
+
+      // The workspace should now show as unread
+      const { isUnread, recencyTimestamp } = getWorkspaceUnreadState(app.workspaceId);
+      expect(recencyTimestamp).not.toBeNull();
+      expect(isUnread(pastTime)).toBe(true);
+    });
+  });
+
+  describe("unread bar visibility", () => {
+    let app: AppHarness;
+
+    beforeEach(async () => {
+      app = await createAppHarness({ branchPrefix: "unread-bar" });
+    });
+
+    afterEach(async () => {
+      await app.dispose();
+    });
+
+    test("unread bar is hidden when workspace is selected", async () => {
+      // Even if isUnread is true, the unread bar should be hidden when selected
+
+      // Force unread state by backdating lastReadTimestamp
+      await app.chat.send("Test message");
+      await app.chat.expectTranscriptContains("Mock response: Test message");
+
+      const recency = getWorkspaceUnreadState(app.workspaceId).recencyTimestamp;
+      const pastTime = (recency ?? Date.now()) - 5000;
+      updatePersistedState(getWorkspaceLastReadKey(app.workspaceId), pastTime);
+
+      // Wait for state to propagate
+      await waitFor(() => {
+        const { isUnread } = getWorkspaceUnreadState(app.workspaceId);
+        expect(isUnread(pastTime)).toBe(true);
+      });
+
+      // But the unread bar should still be hidden because the workspace is selected
+      const indicator = getWorkspaceUnreadIndicator(app.view.container, app.workspaceId);
+      expect(indicator).not.toBeNull();
+      // showUnreadBar has condition: !(isSelected && !isDisabled)
+      // Since workspace is selected, unread bar should not show
+      expect(indicator?.hasUnreadBar).toBe(false);
+    });
+  });
+
+  describe("recency computation correctness", () => {
+    let app: AppHarness;
+
+    beforeEach(async () => {
+      app = await createAppHarness({ branchPrefix: "recency" });
+    });
+
+    afterEach(async () => {
+      await app.dispose();
+    });
+
+    test("recencyTimestamp is based on user message, not assistant message", async () => {
+      // Send a user message and note the recency
+      const beforeSend = Date.now();
+      await app.chat.send("User message for recency test");
+
+      // Wait for stream to complete
+      await app.chat.expectTranscriptContains("Mock response: User message for recency test");
+      const afterComplete = Date.now();
+
+      const { recencyTimestamp } = getWorkspaceUnreadState(app.workspaceId);
+
+      // The recency should be from the user message time, not the assistant completion time
+      // It should be between when we sent and shortly after (user message timestamp)
+      expect(recencyTimestamp).not.toBeNull();
+      // Allow some tolerance for timing
+      expect(recencyTimestamp!).toBeGreaterThanOrEqual(beforeSend - 100);
+      // Recency should NOT be updated to the stream completion time
+      // (this would be a bug - assistant messages shouldn't affect recency)
+      // A rough heuristic: if it's way past when we sent, something is wrong
+      expect(recencyTimestamp!).toBeLessThan(afterComplete + 1000);
+    });
+
+    test("multiple user messages update recencyTimestamp to the latest", async () => {
+      await app.chat.send("First message");
+      await app.chat.expectTranscriptContains("Mock response: First message");
+
+      const recency1 = getWorkspaceUnreadState(app.workspaceId).recencyTimestamp;
+
+      // Small delay to ensure different timestamps
+      await new Promise((r) => setTimeout(r, 50));
+
+      await app.chat.send("Second message");
+      await app.chat.expectTranscriptContains("Mock response: Second message");
+
+      const recency2 = getWorkspaceUnreadState(app.workspaceId).recencyTimestamp;
+
+      expect(recency2).not.toBeNull();
+      expect(recency1).not.toBeNull();
+      expect(recency2!).toBeGreaterThan(recency1!);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a bug where the unread indicator would incorrectly show as "unread" after a user sent a message in the currently viewed workspace.

## Background

The unread indicator uses two timestamps:
- `lastReadTimestamp`: when the user last "read" the workspace (updated on selection)
- `recencyTimestamp`: derived from the most recent user message timestamp

When a user sends a message while viewing a workspace:
1. `lastReadTimestamp` was only updated when the workspace was **selected**
2. The user message gets a new timestamp, updating `recencyTimestamp`
3. Since `recencyTimestamp > lastReadTimestamp`, the workspace incorrectly appeared "unread" even though the user just interacted with it

## Implementation

**`src/browser/components/ChatInput/index.tsx`**: Update `lastReadTimestamp` immediately after a message is successfully sent. This ensures user-initiated activity doesn't trigger the unread indicator.

**`src/browser/stores/WorkspaceStore.ts`**: Added `getWorkspaceSidebarState` to the exported `workspaceStore` object to enable tests to access sidebar state without hooks.

**`tests/ui/unreadIndicator.integration.test.ts`**: Comprehensive test suite (8 tests) covering:
- Workspace not unread when first opened
- recencyTimestamp updates on user message
- Assistant messages don't affect recencyTimestamp
- **Workspace NOT unread after stream completes while viewing it** (the bug scenario)
- Workspace shows unread for activity in non-selected workspace
- Unread bar hidden when workspace selected
- recencyTimestamp based on user message, not assistant
- Multiple user messages update recencyTimestamp correctly

## Risks

Low risk. The fix adds a single `updatePersistedState` call in the success path of message sending. The behavior change is correct: when a user sends a message, they've clearly "seen" the workspace.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$4.91`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=4.91 -->
