### PR TITLE
🤖 fix: prevent stream replay from corrupting timing stats

### DIFF
--- a/src/common/orpc/schemas/stream.ts
+++ b/src/common/orpc/schemas/stream.ts
@@ -52,6 +52,10 @@ export const StreamStartEventSchema = z.object({
   type: z.literal("stream-start"),
   workspaceId: z.string(),
   messageId: z.string(),
+  replay: z
+    .boolean()
+    .optional()
+    .meta({ description: "True when this event is emitted during stream replay" }),
   model: z.string(),
   historySequence: z.number().meta({
     description: "Backend assigns global message ordering",
@@ -68,6 +72,10 @@ export const StreamDeltaEventSchema = z.object({
   type: z.literal("stream-delta"),
   workspaceId: z.string(),
   messageId: z.string(),
+  replay: z
+    .boolean()
+    .optional()
+    .meta({ description: "True when this event is emitted during stream replay" }),
   delta: z.string(),
   tokens: z.number().meta({
     description: "Token count for this delta",
@@ -169,6 +177,10 @@ export const ToolCallStartEventSchema = z.object({
   type: z.literal("tool-call-start"),
   workspaceId: z.string(),
   messageId: z.string(),
+  replay: z
+    .boolean()
+    .optional()
+    .meta({ description: "True when this event is emitted during stream replay" }),
   toolCallId: z.string(),
   toolName: z.string(),
   args: z.unknown(),
@@ -181,6 +193,10 @@ export const ToolCallDeltaEventSchema = z.object({
   type: z.literal("tool-call-delta"),
   workspaceId: z.string(),
   messageId: z.string(),
+  replay: z
+    .boolean()
+    .optional()
+    .meta({ description: "True when this event is emitted during stream replay" }),
   toolCallId: z.string(),
   toolName: z.string(),
   delta: z.unknown(),
@@ -210,6 +226,10 @@ export const ToolCallEndEventSchema = z.object({
   type: z.literal("tool-call-end"),
   workspaceId: z.string(),
   messageId: z.string(),
+  replay: z
+    .boolean()
+    .optional()
+    .meta({ description: "True when this event is emitted during stream replay" }),
   toolCallId: z.string(),
   toolName: z.string(),
   result: z.unknown(),
@@ -221,6 +241,10 @@ export const ReasoningDeltaEventSchema = z.object({
   type: z.literal("reasoning-delta"),
   workspaceId: z.string(),
   messageId: z.string(),
+  replay: z
+    .boolean()
+    .optional()
+    .meta({ description: "True when this event is emitted during stream replay" }),
   delta: z.string(),
   tokens: z.number().meta({ description: "Token count for this delta" }),
   timestamp: z.number().meta({ description: "When delta was received (Date.now())" }),
@@ -234,6 +258,10 @@ export const ReasoningEndEventSchema = z.object({
   type: z.literal("reasoning-end"),
   workspaceId: z.string(),
   messageId: z.string(),
+  replay: z
+    .boolean()
+    .optional()
+    .meta({ description: "True when this event is emitted during stream replay" }),
 });
 
 export const ErrorEventSchema = z.object({

--- a/src/node/services/sessionTimingService.ts
+++ b/src/node/services/sessionTimingService.ts
@@ -601,6 +601,7 @@ export class SessionTimingService {
   // --- Stream event handlers (wired from AIService) ---
 
   handleStreamStart(data: StreamStartEvent): void {
+    if (data.replay === true) return;
     if (!this.isEnabled()) return;
 
     assert(typeof data.workspaceId === "string" && data.workspaceId.length > 0);
@@ -633,6 +634,7 @@ export class SessionTimingService {
   }
 
   handleStreamDelta(data: StreamDeltaEvent): void {
+    if (data.replay === true) return;
     const state = this.activeStreams.get(data.workspaceId);
     if (!state) return;
 
@@ -650,6 +652,7 @@ export class SessionTimingService {
   }
 
   handleReasoningDelta(data: ReasoningDeltaEvent): void {
+    if (data.replay === true) return;
     const state = this.activeStreams.get(data.workspaceId);
     if (!state) return;
 
@@ -671,6 +674,7 @@ export class SessionTimingService {
   }
 
   handleToolCallStart(data: ToolCallStartEvent): void {
+    if (data.replay === true) return;
     const state = this.activeStreams.get(data.workspaceId);
     if (!state) return;
 
@@ -707,6 +711,7 @@ export class SessionTimingService {
   }
 
   handleToolCallDelta(data: ToolCallDeltaEvent): void {
+    if (data.replay === true) return;
     const state = this.activeStreams.get(data.workspaceId);
     if (!state) return;
 
@@ -721,6 +726,7 @@ export class SessionTimingService {
   }
 
   handleToolCallEnd(data: ToolCallEndEvent): void {
+    if (data.replay === true) return;
     const state = this.activeStreams.get(data.workspaceId);
     if (!state) return;
 

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -838,10 +838,16 @@ describe("StreamManager - replayStream", () => {
     // Suppress error events from bubbling up as uncaught exceptions during tests
     streamManager.on("error", () => undefined);
 
+    let sawStreamStart = false;
+    streamManager.on("stream-start", (event: { replay?: boolean | undefined }) => {
+      sawStreamStart = true;
+      expect(event.replay).toBe(true);
+    });
     const workspaceId = "ws-replay-snapshot";
 
     const deltas: string[] = [];
-    streamManager.on("stream-delta", (event: { delta: string }) => {
+    streamManager.on("stream-delta", (event: { delta: string; replay?: boolean | undefined }) => {
+      expect(event.replay).toBe(true);
       deltas.push(event.delta);
     });
 
@@ -890,6 +896,7 @@ describe("StreamManager - replayStream", () => {
     };
 
     await streamManager.replayStream(workspaceId);
+    expect(sawStreamStart).toBe(true);
 
     // If replayStream iterates the live array, it would also emit "b".
     expect(deltas).toEqual(["a"]);


### PR DESCRIPTION
## Summary
Fix Stats tab timing corruption caused by stream replay events being counted as live timing data (leading to Tool Execution > Total and invalid percent anomalies).

## Background
On reconnect, `StreamManager.replayStream()` re-emits historical tool/stream events through the same emitter that `SessionTimingService` listens to. Those replayed events could inflate tool wall-time (especially because replayed tool-end timestamps can be "now"), which then poisons `lastRequest` and session aggregates.

## Implementation
- Add `replay?: boolean` to stream/tool/reasoning event schemas.
- Mark replayed events with `replay: true` during `replayStream()`.
- Ignore replayed events in `SessionTimingService` so only true live events affect timing stats.
- Add unit tests to ensure replay flags are set and replay doesn’t mutate timing files.

## Validation
- `make static-check`

## Risks
Low. This only affects how timing stats are derived from events; it does not change message content or tool execution behavior. Replay-tagging is optional/backward compatible.

---

<details>
<summary>📋 Implementation Plan</summary>

# Stats tab: Tool Execution time > Total (workspace `system-1-dwqk`)

## Context / Why
The Stats tab’s timing breakdown is showing **Tool Execution** that exceeds the **Total** duration, and the UI flags `Invalid timing data: tool_gt_total, percent_out_of_range`.

Goal: trace the code path that produces `toolExecutionMs` / `totalDurationMs`, form a concrete hypothesis for why tool time can become larger than total, and propose a focused fix plan.

## Evidence (what I traced)
- **Frontend validation surfacing**
  - `src/browser/components/RightSidebar/StatsTab.tsx`
    - Displays `Invalid timing data: {anomalies}` when `lastData.invalid` is true.
    - Uses `snapshot.active ?? snapshot.lastRequest` for “Last Request” and sums `session.* + active.*` for “Session”.

- **Backend invariants and anomaly detection**
  - `src/node/services/sessionTimingService.ts`
    - `validateTiming()` pushes:
      - `tool_gt_total` when `toolExecutionMs > totalDurationMs`.
      - `percent_out_of_range` when derived % is outside `[0, 100]`.
    - `computeCompletedStreamStats()` can produce `toolExecutionMs` from tool-wall segments (union logic) and `totalDurationMs` from stream metadata duration.
    - `applyCompletedStreamToFile()` rolls `completed.toolExecutionMs` into `session.totalToolExecutionMs` with **no sanitization**, so a single bad request can poison session totals.

- **Replay path that re-emits stream + tool events**
  - `src/node/services/agentSession.ts`
    - On subscribe/reconnect, if a stream is active (`aiService.getStreamInfo()`), it calls `aiService.replayStream()`.
  - `src/node/services/streamManager.ts`
    - `replayStream()` emits `stream-start`, then iterates `streamInfo.parts` and calls `emitPartAsEvent()`.
    - `emitPartAsEvent()` special-cases tool parts:
      - Emits `tool-call-start` using `part.timestamp ?? Date.now()`.
      - If the tool part is already `output-available`, it emits `tool-call-end` with **`timestamp: Date.now()`** (i.e., replay-time, not tool completion-time).
  - `src/node/services/serviceContainer.ts`
    - Wires `aiService.on("stream-*"|"tool-call-*")` directly into `SessionTimingService.*`.
    - Therefore **replay events are currently treated as real events** by the timing service.

## Hypothesis (most likely root cause)
**Timing stats are being corrupted by stream replay on reconnect.**

During reconnect, `StreamManager.replayStream()` re-emits historical tool events over the same `AIService` emitter that `SessionTimingService` listens to.

Two compounding effects can inflate tool time well beyond total:
1. **Replayed `tool-call-end` uses `Date.now()`** (replay-time), making each replayed tool appear to run until “now”.
2. **Replay emits tool-start and tool-end back-to-back per tool part**, so `SessionTimingService` sees tools as *sequential* (no overlap), even if they actually overlapped. With many tool calls, this turns the intended “union of tool wall time” into something closer to a sum, easily exceeding `totalDurationMs`.

This matches the UI symptom: `toolExecutionMs` becomes huge and triggers `tool_gt_total` + `percent_out_of_range`, and the bad values are then rolled into session totals.

## Plan (recommended)
### Approach A (recommended): Mark replayed events and ignore them in `SessionTimingService`
**Net LoC (product code): ~120–180**

1. **Add an explicit `replay?: boolean` field to stream/tool event schemas**
   - Update Zod schemas in `src/common/orpc/schemas/stream.ts` for:
     - `StreamStartEventSchema`, `StreamDeltaEventSchema`
     - `ToolCallStartEventSchema`, `ToolCallDeltaEventSchema`, `ToolCallEndEventSchema`
     - `ReasoningDeltaEventSchema`, `ReasoningEndEventSchema`
     - (Optional) any other events emitted during replay.
   - Keep it optional and default false to remain backward compatible.

2. **Emit `replay: true` for replayed events only**
   - In `src/node/services/streamManager.ts` (`replayStream()` / helpers), set `replay: true` on:
     - the replayed `stream-start`
     - every replayed part event (stream-delta, reasoning-delta, tool-call-start/end, etc.)

3. **Make timing stats immune to replay**
   - In `src/node/services/sessionTimingService.ts`, early-return in each handler when `data.replay === true`.
   - This prevents:
     - resetting active timing state on replayed `stream-start`
     - re-counting tokens/tool time from replayed deltas/tool events

4. **Add regression tests**
   - `src/node/services/sessionTimingService.test.ts`
     - New test: feed a normal stream sequence, then feed the same sequence again with `replay: true`; assert snapshot + persisted `session-timing.json` do not change.
   - `src/node/services/streamManager.test.ts`
     - Extend existing replay tests to assert replayed events include `replay: true`.

5. **(Optional defensive hardening)**
   - In `applyCompletedStreamToFile()` (or just before calling it), clamp obviously-invalid values so one bad request can’t poison session totals:
     - `safeToolMs = Math.min(completed.toolExecutionMs, completed.totalDurationMs)`
     - `safeStreamingMs = Math.min(completed.streamingMs, completed.totalDurationMs)`
   - Keep the `invalid/anomalies` on `lastRequest` so the UI still surfaces corruption, while session aggregates remain usable.

### Approach B (alternative): Stop using emitter-based replay for active streams; send a snapshot message instead
**Net LoC (product code): ~80–140**

- In `AgentSession.emitHistoricalEvents()`, when `streamInfo` exists, **avoid `aiService.replayStream()`**.
- Instead, send a single “partial message snapshot” to the subscriber (using `partial` from disk but overwrite `parts` with `streamInfo.parts`), then rely on live events for future updates.
- Pros: avoids *all* backend side effects of replay.
- Cons: riskier — must verify the renderer correctly treats this as an in-progress streaming message and doesn’t regress TPS/token UI.

## Suggested first repro to validate hypothesis
1. Start a long-running agent response that triggers multiple tool calls (especially `multi_tool_use.parallel`).
2. While it’s streaming, force a reconnect path (e.g., renderer reload / workspace re-open / second subscriber).
3. Observe whether tool time spikes and `tool_gt_total` appears soon after reconnect.

If reproduced, Approach A should eliminate the spike without changing UX.

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$4.72`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=4.72 -->
