### PR TITLE
perf: increase renderer heap limit to 8GB

### DIFF
--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -31,6 +31,13 @@ import {
   dialog,
   screen,
 } from "electron";
+
+// Increase renderer V8 heap limit from default ~4GB to 8GB.
+// At ~3.9GB usage, the default limit causes frequent Mark-Compact GC cycles
+// with low mutator utilization (~39%), degrading UI responsiveness.
+// Must be called before app.whenReady().
+app.commandLine.appendSwitch("js-flags", "--max-old-space-size=8192");
+
 import * as fs from "fs";
 import * as path from "path";
 import type { Config } from "@/node/config";


### PR DESCRIPTION
The renderer was running at ~3.9GB against V8's default ~4GB limit, causing:
- Frequent Mark-Compact (stop-the-world) GC cycles
- Failed scavenges forcing expensive full-heap collections  
- Only ~39% mutator utilization (61% GC overhead)

Increasing to 8GB gives V8 headroom to run fewer, more efficient collections.

---
*Generated with [mux](https://github.com/coder/mux) by @anthropics/claude-sonnet-4*