### PR TITLE
🤖 fix: clarify code_execution tool description to prevent await usage

### DIFF
--- a/src/node/services/tools/code_execution.ts
+++ b/src/node/services/tools/code_execution.ts
@@ -72,7 +72,7 @@ ${muxTypes}
 \`\`\`
 
 **Usage notes:**
-- \`mux.*\` functions return results directly (no \`await\` needed)
+- \`mux.*\` functions are synchronous—do not use \`await\`
 - Use \`return\` to provide a final result to the model
 - Use \`console.log/warn/error\` for debugging - output is captured
 - Results are JSON-serialized; non-serializable values return \`{ error: "..." }\`
@@ -85,7 +85,7 @@ ${muxTypes}
         .string()
         .min(1)
         .describe(
-          "JavaScript code to execute. All mux.* functions are async. Use 'return' for final result."
+          "JavaScript code to execute. mux.* calls are synchronous—do not use await. Use 'return' for final result."
         ),
       timeout_secs: z
         .number()


### PR DESCRIPTION
## Summary

Fix contradictory guidance in the `code_execution` tool description that was causing models to incorrectly use `await` with `mux.*` calls.

## Background

Models frequently write `await mux.*()` in code_execution scripts, which fails static analysis with an error like "await is not supported". Investigation revealed the tool description contained contradictory guidance:

- **Usage notes** said: "`mux.*` functions return results directly (no `await` needed)"
- **Field description** said: "All mux.* functions are async"

The word "async" strongly implies await should be used. Models were reasonably interpreting "async" as requiring await, then hitting the static analysis error.

In reality, `mux.*` functions in the QuickJS sandbox are **synchronous**—they block until the operation completes and return the value directly (not a Promise). The sandbox handles async internally but exposes a sync interface to the script.

### Note on field descriptions

The `.describe()` on zod schema fields **does** get converted to JSON schema and sent to the model. Verified by testing `z.toJSONSchema()` - the field description appears in the schema's `properties.<field>.description`. So both the main tool description and the field description are visible to the model, and both needed to be fixed.

## Implementation

Updated both descriptions to be explicit and consistent:

- Usage notes: `mux.*` functions are synchronous—do not use `await`
- Field description: "mux.* calls are synchronous—do not use await"

## Validation

- All 24 existing code_execution tests pass
- The static analysis error for `await mux.*` still triggers (tested manually)

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.56`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=0.56 -->
