### PR TITLE
🤖 fix: merge model capability overrides and clarify PDF suggestions

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -1907,10 +1907,12 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       if (pdfAttachments.length > 0) {
         const caps = getModelCapabilities(baseModel);
         if (caps && !caps.supportsPdfInput) {
-          const pdfCapableExamples = Object.values(KNOWN_MODELS)
+          const pdfCapableKnownModels = Object.values(KNOWN_MODELS)
             .map((m) => m.id)
-            .filter((model) => getModelCapabilities(model)?.supportsPdfInput)
-            .slice(0, 3);
+            .filter((model) => getModelCapabilities(model)?.supportsPdfInput);
+          const pdfCapableExamples = pdfCapableKnownModels.slice(0, 3);
+          const examplesSuffix =
+            pdfCapableKnownModels.length > pdfCapableExamples.length ? ", and others." : ".";
 
           pushToast({
             type: "error",
@@ -1918,7 +1920,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
             message:
               `Model ${baseModel} does not support PDF input.` +
               (pdfCapableExamples.length > 0
-                ? ` Try: ${pdfCapableExamples.join(", ")}.`
+                ? ` Try e.g.: ${pdfCapableExamples.join(", ")}${examplesSuffix}`
                 : " Choose a model with PDF support."),
           });
           setSendingCount((c) => c - 1);

--- a/src/browser/components/ChatInput/useCreationWorkspace.ts
+++ b/src/browser/components/ChatInput/useCreationWorkspace.ts
@@ -326,10 +326,12 @@ export function useCreationWorkspace({
         if (pdfFileParts.length > 0) {
           const caps = getModelCapabilities(baseModel);
           if (caps && !caps.supportsPdfInput) {
-            const pdfCapableExamples = Object.values(KNOWN_MODELS)
+            const pdfCapableKnownModels = Object.values(KNOWN_MODELS)
               .map((m) => m.id)
-              .filter((model) => getModelCapabilities(model)?.supportsPdfInput)
-              .slice(0, 3);
+              .filter((model) => getModelCapabilities(model)?.supportsPdfInput);
+            const pdfCapableExamples = pdfCapableKnownModels.slice(0, 3);
+            const examplesSuffix =
+              pdfCapableKnownModels.length > pdfCapableExamples.length ? ", and others." : ".";
 
             setToast({
               id: Date.now().toString(),
@@ -338,7 +340,7 @@ export function useCreationWorkspace({
               message:
                 `Model ${baseModel} does not support PDF input.` +
                 (pdfCapableExamples.length > 0
-                  ? ` Try: ${pdfCapableExamples.join(", ")}.`
+                  ? ` Try e.g.: ${pdfCapableExamples.join(", ")}${examplesSuffix}`
                   : " Choose a model with PDF support."),
             });
             setIsSending(false);

--- a/src/common/utils/ai/modelCapabilities.test.ts
+++ b/src/common/utils/ai/modelCapabilities.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { getModelCapabilities, getSupportedInputMediaTypes } from "./modelCapabilities";
 
 describe("getModelCapabilities", () => {
@@ -7,6 +7,20 @@ describe("getModelCapabilities", () => {
     expect(caps).not.toBeNull();
     expect(caps?.supportsPdfInput).toBe(true);
     expect(caps?.supportsVision).toBe(true);
+  });
+
+  it("merges models.json + modelsExtra so overrides don't wipe capabilities", () => {
+    // claude-opus-4-5 exists in both sources; modelsExtra intentionally overrides
+    // pricing/token limits, but it should not wipe upstream capability flags.
+    const caps = getModelCapabilities("anthropic:claude-opus-4-5");
+    expect(caps).not.toBeNull();
+    expect(caps?.supportsPdfInput).toBe(true);
+  });
+
+  it("returns capabilities for models present only in models-extra", () => {
+    // This model is defined in models-extra.ts but not (yet) in upstream models.json.
+    const caps = getModelCapabilities("openrouter:z-ai/glm-4.6");
+    expect(caps).not.toBeNull();
   });
 
   it("returns maxPdfSizeMb when present in model metadata", () => {


### PR DESCRIPTION
## Summary
Fixes PDF capability detection by merging upstream LiteLLM model metadata with local overrides, and clarifies that the UI’s “Try:” list is only examples.

## Background
- Many models in `models.json` declare `supports_pdf_input: true`, but some models were still treated as non-PDF-capable because `models-extra.ts` entries were overriding (and effectively wiping) upstream capability flags.
- The UI also intentionally shows only a small example list of PDF-capable models.

## Implementation
- **Capability merge (Option 1B):** `getModelCapabilities()` now merges `{...models.json, ...modelsExtra}` (extras win) so overrides don’t drop unrelated capability flags like `supports_pdf_input` / `max_pdf_size_mb`.
- **UX clarity (Option 3):** PDF preflight toasts now say **“Try e.g.: …”** and append **“, and others.”** when there are more PDF-capable known models than we display.
- Added unit coverage for the merged-capability behavior.

## Validation
- `bun test src/common/utils/ai/modelCapabilities.test.ts`
- `make static-check`

## Risks
Low. This only affects capability inference for models present in both metadata sources; extras continue to override pricing/token limits, but no longer inadvertently remove upstream capabilities.

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$4.24`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=4.24 -->
