### PR TITLE
🤖 fix: Enter accepts selected tab completion instead of sending

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -2255,9 +2255,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     const hasAtMentionSuggestionMenu = showAtMentionSuggestions && atMentionSuggestions.length > 0;
 
     // Don't handle keys if suggestions are visible.
-    //
-    // NOTE: For slash command suggestions, Enter should still submit the command.
-    // For file (@mention) suggestions, Enter accepts the selection.
+    // Enter/Tab/arrows/Escape are handled by CommandSuggestions for both slash and @mention menus.
     if (
       (hasCommandSuggestionMenu && COMMAND_SUGGESTION_KEYS.includes(e.key)) ||
       (hasAtMentionSuggestionMenu && FILE_SUGGESTION_KEYS.includes(e.key))

--- a/src/browser/components/CommandSuggestions.test.tsx
+++ b/src/browser/components/CommandSuggestions.test.tsx
@@ -107,4 +107,110 @@ describe("CommandSuggestions", () => {
 
     expect(getByText("b").closest('[role="option"]')?.getAttribute("aria-selected")).toBe("true");
   });
+
+  it("accepts the selected suggestion on Enter (slash commands)", () => {
+    const suggestions = [makeSuggestion("a"), makeSuggestion("b"), makeSuggestion("c")];
+    let selected: SlashSuggestion | null = null;
+
+    const { getByText } = render(
+      <CommandSuggestions
+        suggestions={suggestions}
+        onSelectSuggestion={(s) => {
+          selected = s;
+        }}
+        onDismiss={() => undefined}
+        isVisible
+        isFileSuggestion={false}
+      />
+    );
+
+    // Navigate to 'b'
+    fireEvent.keyDown(document, { key: "ArrowDown" });
+    expect(getByText("b").closest('[role="option"]')?.getAttribute("aria-selected")).toBe("true");
+
+    // Press Enter to accept
+    fireEvent.keyDown(document, { key: "Enter" });
+
+    expect(selected).not.toBeNull();
+    expect(selected!.id).toBe("b");
+  });
+
+  it("accepts the selected suggestion on Tab", () => {
+    const suggestions = [makeSuggestion("a"), makeSuggestion("b"), makeSuggestion("c")];
+    let selected: SlashSuggestion | null = null;
+
+    const { getByText } = render(
+      <CommandSuggestions
+        suggestions={suggestions}
+        onSelectSuggestion={(s) => {
+          selected = s;
+        }}
+        onDismiss={() => undefined}
+        isVisible
+      />
+    );
+
+    // Navigate to 'c'
+    fireEvent.keyDown(document, { key: "ArrowDown" });
+    fireEvent.keyDown(document, { key: "ArrowDown" });
+    expect(getByText("c").closest('[role="option"]')?.getAttribute("aria-selected")).toBe("true");
+
+    // Press Tab to accept
+    fireEvent.keyDown(document, { key: "Tab" });
+
+    expect(selected).not.toBeNull();
+    expect(selected!.id).toBe("c");
+  });
+
+  it("does not accept on Shift+Enter (allows newline)", () => {
+    const suggestions = [makeSuggestion("a"), makeSuggestion("b")];
+    let selected: SlashSuggestion | null = null;
+
+    render(
+      <CommandSuggestions
+        suggestions={suggestions}
+        onSelectSuggestion={(s) => {
+          selected = s;
+        }}
+        onDismiss={() => undefined}
+        isVisible
+      />
+    );
+
+    // Press Shift+Enter (should not select)
+    fireEvent.keyDown(document, { key: "Enter", shiftKey: true });
+
+    expect(selected).toBeNull();
+  });
+
+  it("dismisses on Escape and stops propagation", () => {
+    const suggestions = [makeSuggestion("a"), makeSuggestion("b")];
+    let dismissed = false;
+    let propagated = false;
+
+    // Add a window listener to detect if event propagates
+    const windowListener = () => {
+      propagated = true;
+    };
+    window.addEventListener("keydown", windowListener);
+
+    render(
+      <CommandSuggestions
+        suggestions={suggestions}
+        onSelectSuggestion={() => undefined}
+        onDismiss={() => {
+          dismissed = true;
+        }}
+        isVisible
+      />
+    );
+
+    // Press Escape
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(dismissed).toBe(true);
+    expect(propagated).toBe(false);
+
+    window.removeEventListener("keydown", windowListener);
+  });
 });

--- a/src/browser/components/CommandSuggestions.tsx
+++ b/src/browser/components/CommandSuggestions.tsx
@@ -5,10 +5,8 @@ import type { SlashSuggestion } from "@/browser/utils/slashCommands/types";
 import { FileIcon } from "@/browser/components/FileIcon";
 
 // Keys for navigating slash command suggestions.
-//
-// IMPORTANT: Do NOT treat Enter as a suggestion key here. Enter should submit the slash command
-// ("send message"). Autocomplete selection should be via Tab.
-export const COMMAND_SUGGESTION_KEYS = ["Tab", "ArrowUp", "ArrowDown", "Escape"];
+// Enter or Tab accepts the highlighted suggestion; Shift+Enter inserts a newline.
+export const COMMAND_SUGGESTION_KEYS = ["Tab", "Enter", "ArrowUp", "ArrowDown", "Escape"];
 
 // Keys for navigating file path (@mention) suggestions.
 //
@@ -197,8 +195,6 @@ export const CommandSuggestions: React.FC<CommandSuggestionsProps> = ({
           }
           break;
         case "Enter":
-          // For slash commands, Enter should submit the command (send message), not autocomplete.
-          if (!isFileSuggestion) break;
           if (!e.shiftKey && suggestions.length > 0) {
             e.preventDefault();
             onSelectSuggestion(suggestions[selectedIndex]);
@@ -206,6 +202,7 @@ export const CommandSuggestions: React.FC<CommandSuggestionsProps> = ({
           break;
         case "Escape":
           e.preventDefault();
+          e.stopPropagation();
           onDismiss();
           break;
       }

--- a/tests/e2e/utils/ui.ts
+++ b/tests/e2e/utils/ui.ts
@@ -183,6 +183,11 @@ export function createWorkspaceUI(page: Page, context: DemoProjectConfig): Works
       });
       await expect(input).toBeVisible();
       await input.fill(message);
+      // Slash commands open a suggestion menu; dismiss it before sending so Enter
+      // doesn't accept a completion instead of submitting the message.
+      if (message.startsWith("/")) {
+        await page.keyboard.press("Escape");
+      }
       await page.keyboard.press("Enter");
     },
 
@@ -233,8 +238,10 @@ export function createWorkspaceUI(page: Page, context: DemoProjectConfig): Works
         timeout: 30_000,
       });
 
-      // Send the command
+      // Send the command. Dismiss suggestion menu first so Enter sends instead of
+      // accepting a completion.
       await input.fill(command);
+      await page.keyboard.press("Escape");
       await page.keyboard.press("Enter");
 
       // Wait for the toast we started watching for


### PR DESCRIPTION
## Summary

When browsing slash command completions (the dropdown triggered by typing `/`), pressing **Enter** now inserts the highlighted suggestion instead of immediately sending the message. Additionally, pressing **Escape** to dismiss the suggestion list no longer interrupts an active stream.

## Background

Previously, the slash command suggestion menu explicitly excluded Enter from its handled keys, causing Enter to fall through to the "send message" handler. This was inconsistent with:
1. The UI footer text which says "Enter or Tab to complete"
2. The `@file` mention suggestions which already accept on Enter

Similarly, Escape only called `preventDefault()` without stopping propagation, so the global stream interrupt handler would still fire when dismissing suggestions.

## Implementation

- Added `"Enter"` to `COMMAND_SUGGESTION_KEYS` so ChatInput stands down when the slash menu is open
- Removed the `if (!isFileSuggestion) break;` guard in the Enter handler so it applies to all suggestion menus
- Added `e.stopPropagation()` to the Escape handler to prevent the stream interrupt from firing
- Updated comments to reflect the new behavior

## Validation

- Added 4 unit tests:
  - "accepts the selected suggestion on Enter (slash commands)"
  - "accepts the selected suggestion on Tab"
  - "does not accept on Shift+Enter (allows newline)"
  - "dismisses on Escape and stops propagation"
- All 6 CommandSuggestions tests pass
- `make typecheck` passes

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$4.35`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=4.35 -->
