### PR TITLE
🤖 fix: sanitize PDF filenames for Anthropic API validation

### DIFF
--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -30,6 +30,7 @@ import type { NestedToolCall } from "@/common/orpc/schemas/message";
 import {
   coerceStreamErrorTypeForMessage,
   createErrorEvent,
+  stripNoisyErrorPrefix,
   type StreamErrorPayload,
 } from "@/node/services/utils/sendMessageError";
 import type { PartialService } from "./partialService";
@@ -1723,7 +1724,10 @@ export class StreamManager extends EventEmitter {
     error: unknown
   ): StreamErrorPayload & { errorType: StreamErrorType } {
     // Extract error message (errors thrown from 'error' parts already have the correct message)
-    let errorMessage: string = error instanceof Error ? error.message : String(error);
+    // Apply prefix stripping to remove noisy "undefined: " prefixes from provider errors
+    let errorMessage: string = stripNoisyErrorPrefix(
+      error instanceof Error ? error.message : String(error)
+    );
     let actualError: unknown = error;
 
     // For categorization, use the cause if available (preserves the original error structure)

--- a/src/node/services/utils/sendMessageError.test.ts
+++ b/src/node/services/utils/sendMessageError.test.ts
@@ -130,4 +130,34 @@ describe("createUnknownSendMessageError", () => {
     expect(() => createUnknownSendMessageError("")).toThrow();
     expect(() => createUnknownSendMessageError("   ")).toThrow();
   });
+
+  test("strips 'undefined: ' prefix from error messages", () => {
+    const result = createUnknownSendMessageError(
+      "undefined: The document file name can only contain alphanumeric characters"
+    );
+
+    expect(result.type).toBe("unknown");
+    if (result.type === "unknown") {
+      expect(result.raw).toBe("The document file name can only contain alphanumeric characters");
+      expect(result.raw).not.toContain("undefined:");
+    }
+  });
+
+  test("preserves messages without 'undefined: ' prefix", () => {
+    const result = createUnknownSendMessageError("Normal error message");
+
+    expect(result.type).toBe("unknown");
+    if (result.type === "unknown") {
+      expect(result.raw).toBe("Normal error message");
+    }
+  });
+
+  test("only strips prefix when at the start of message", () => {
+    const result = createUnknownSendMessageError("Error code undefined: something happened");
+
+    expect(result.type).toBe("unknown");
+    if (result.type === "unknown") {
+      expect(result.raw).toBe("Error code undefined: something happened");
+    }
+  });
 });

--- a/src/node/utils/messages/sanitizeAnthropicDocumentFilename.test.ts
+++ b/src/node/utils/messages/sanitizeAnthropicDocumentFilename.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "bun:test";
+import {
+  sanitizeAnthropicDocumentFilename,
+  sanitizeAnthropicPdfFilenames,
+} from "./sanitizeAnthropicDocumentFilename";
+import type { MuxMessage } from "@/common/types/message";
+
+describe("sanitizeAnthropicDocumentFilename", () => {
+  it("replaces periods with spaces", () => {
+    expect(sanitizeAnthropicDocumentFilename("file.pdf")).toBe("file pdf");
+    expect(sanitizeAnthropicDocumentFilename("report.v2.pdf")).toBe("report v2 pdf");
+  });
+
+  it("preserves allowed characters", () => {
+    expect(sanitizeAnthropicDocumentFilename("my-file")).toBe("my-file");
+    expect(sanitizeAnthropicDocumentFilename("file (1)")).toBe("file (1)");
+    expect(sanitizeAnthropicDocumentFilename("file [draft]")).toBe("file [draft]");
+    expect(sanitizeAnthropicDocumentFilename("Document 2024")).toBe("Document 2024");
+  });
+
+  it("replaces underscores with spaces", () => {
+    expect(sanitizeAnthropicDocumentFilename("my_file_name")).toBe("my file name");
+  });
+
+  it("collapses consecutive whitespace", () => {
+    expect(sanitizeAnthropicDocumentFilename("file...name")).toBe("file name");
+    expect(sanitizeAnthropicDocumentFilename("a  b  c")).toBe("a b c");
+    expect(sanitizeAnthropicDocumentFilename("file___name")).toBe("file name");
+  });
+
+  it("trims leading and trailing whitespace", () => {
+    expect(sanitizeAnthropicDocumentFilename(".file.")).toBe("file");
+    expect(sanitizeAnthropicDocumentFilename("  spaced  ")).toBe("spaced");
+  });
+
+  it("returns fallback for undefined input", () => {
+    expect(sanitizeAnthropicDocumentFilename(undefined)).toBe("Document");
+    expect(sanitizeAnthropicDocumentFilename(undefined, "PDF")).toBe("PDF");
+  });
+
+  it("returns fallback for empty result after sanitization", () => {
+    expect(sanitizeAnthropicDocumentFilename("...")).toBe("Document");
+    expect(sanitizeAnthropicDocumentFilename("___", "Attachment")).toBe("Attachment");
+  });
+
+  it("handles realistic filenames from the reported issue", () => {
+    // Original filename that triggered the error
+    expect(sanitizeAnthropicDocumentFilename("D19910350Lj.pdf")).toBe("D19910350Lj pdf");
+  });
+});
+
+describe("sanitizeAnthropicPdfFilenames", () => {
+  const createUserMessageWithPdf = (filename: string): MuxMessage => ({
+    id: "msg-1",
+    role: "user",
+    parts: [
+      { type: "text", text: "Check this document" },
+      {
+        type: "file",
+        url: "data:application/pdf;base64,JVBERi0...",
+        mediaType: "application/pdf",
+        filename,
+      },
+    ],
+  });
+
+  it("sanitizes PDF filenames in user messages", () => {
+    const messages: MuxMessage[] = [createUserMessageWithPdf("report.pdf")];
+
+    const result = sanitizeAnthropicPdfFilenames(messages);
+
+    expect(result[0].parts[1]).toEqual({
+      type: "file",
+      url: "data:application/pdf;base64,JVBERi0...",
+      mediaType: "application/pdf",
+      filename: "report pdf",
+    });
+  });
+
+  it("does not mutate original messages", () => {
+    const messages: MuxMessage[] = [createUserMessageWithPdf("original.pdf")];
+    const originalFilename = (messages[0].parts[1] as { filename: string }).filename;
+
+    sanitizeAnthropicPdfFilenames(messages);
+
+    expect((messages[0].parts[1] as { filename: string }).filename).toBe(originalFilename);
+  });
+
+  it("passes through assistant messages unchanged", () => {
+    const assistantMessage: MuxMessage = {
+      id: "msg-2",
+      role: "assistant",
+      parts: [{ type: "text", text: "Response" }],
+    };
+
+    const result = sanitizeAnthropicPdfFilenames([assistantMessage]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(assistantMessage); // Same reference
+  });
+
+  it("does not sanitize non-PDF files", () => {
+    const imageMessage: MuxMessage = {
+      id: "msg-3",
+      role: "user",
+      parts: [
+        {
+          type: "file",
+          url: "data:image/png;base64,...",
+          mediaType: "image/png",
+          filename: "screenshot.png",
+        },
+      ],
+    };
+
+    const result = sanitizeAnthropicPdfFilenames([imageMessage]);
+
+    expect(result[0]).toBe(imageMessage); // Same reference - no change
+  });
+
+  it("handles case-insensitive media type matching", () => {
+    const messages: MuxMessage[] = [
+      {
+        id: "msg-4",
+        role: "user",
+        parts: [
+          {
+            type: "file",
+            url: "data:application/pdf;base64,...",
+            mediaType: "APPLICATION/PDF", // uppercase
+            filename: "test.pdf",
+          },
+        ],
+      },
+    ];
+
+    const result = sanitizeAnthropicPdfFilenames(messages);
+
+    expect((result[0].parts[0] as { filename: string }).filename).toBe("test pdf");
+  });
+
+  it("returns original array if no changes needed", () => {
+    const messages: MuxMessage[] = [
+      {
+        id: "msg-5",
+        role: "user",
+        parts: [{ type: "text", text: "No attachments here" }],
+      },
+    ];
+
+    const result = sanitizeAnthropicPdfFilenames(messages);
+
+    expect(result).toBe(messages); // Same array reference
+  });
+});

--- a/src/node/utils/messages/sanitizeAnthropicDocumentFilename.ts
+++ b/src/node/utils/messages/sanitizeAnthropicDocumentFilename.ts
@@ -1,0 +1,94 @@
+import type { MuxMessage } from "@/common/types/message";
+
+const PDF_MEDIA_TYPE = "application/pdf";
+
+/**
+ * Sanitize a document filename to comply with Anthropic's validation rules.
+ *
+ * Anthropic enforces strict character set validation on document block metadata:
+ * - Allowed: alphanumeric, whitespace, hyphen (-), parentheses, square brackets
+ * - Disallowed: periods (.), underscores (_), slashes, etc.
+ * - No consecutive whitespace allowed
+ *
+ * @param filename - Original filename (e.g., "D19910350Lj.pdf")
+ * @param fallback - Fallback if result would be empty (default: "Document")
+ * @returns Sanitized filename (e.g., "D19910350Lj [pdf]")
+ */
+export function sanitizeAnthropicDocumentFilename(
+  filename: string | undefined,
+  fallback = "Document"
+): string {
+  if (!filename) {
+    return fallback;
+  }
+
+  // Replace disallowed characters with space
+  // Allowed: alphanumeric, whitespace, hyphen, parentheses (), square brackets []
+  const sanitized = filename.replace(/[^a-zA-Z0-9\s\-()[\]]/g, " ");
+
+  // Collapse consecutive whitespace to single space and trim
+  const collapsed = sanitized.replace(/\s+/g, " ").trim();
+
+  // Return fallback if empty after sanitization
+  return collapsed || fallback;
+}
+
+/**
+ * Sanitize PDF document filenames in user messages for Anthropic API requests.
+ *
+ * This is a request-only transformation - the original filenames are preserved in
+ * persisted history and the UI. Only the outgoing API request gets sanitized names.
+ *
+ * Why: Anthropic validates document "file name/title" with a strict character set that
+ * rejects common filename characters like periods (.). This causes uploads to fail with:
+ * "The document file name can only contain alphanumeric characters, whitespace characters,
+ * hyphens, parentheses, and square brackets."
+ *
+ * @param messages - MuxMessage array to process
+ * @returns New array with sanitized PDF filenames (does not mutate input)
+ */
+export function sanitizeAnthropicPdfFilenames(messages: MuxMessage[]): MuxMessage[] {
+  let didChange = false;
+
+  const result = messages.map((msg) => {
+    if (msg.role !== "user") {
+      return msg;
+    }
+
+    // Check if any part needs sanitization
+    const hasPdfWithFilename = msg.parts.some(
+      (part) =>
+        part.type === "file" &&
+        part.mediaType.toLowerCase() === PDF_MEDIA_TYPE &&
+        part.filename !== undefined
+    );
+
+    if (!hasPdfWithFilename) {
+      return msg;
+    }
+
+    didChange = true;
+
+    const newParts = msg.parts.map((part) => {
+      if (
+        part.type === "file" &&
+        part.mediaType.toLowerCase() === PDF_MEDIA_TYPE &&
+        part.filename !== undefined
+      ) {
+        return {
+          ...part,
+          filename: sanitizeAnthropicDocumentFilename(part.filename),
+        };
+      }
+      return part;
+    });
+
+    return {
+      ...msg,
+      parts: newParts,
+    };
+  });
+
+  // Return original array if nothing changed (optimization)
+  return didChange ? result : messages;
+}


### PR DESCRIPTION
## Summary

Sanitize PDF document filenames before sending them to the Anthropic API to prevent validation errors when uploading files with common naming patterns (e.g., `D19910350Lj.pdf`).

## Background

Anthropic enforces strict character set validation on document block metadata, rejecting filenames containing periods, underscores, and other common characters. Users encounter the error:

> `undefined: The document file name can only contain alphanumeric characters, whitespace characters, hyphens, parentheses, and square brackets.`

This is a "self-healing" fix that transparently sanitizes filenames at request time while preserving the original filename in the UI and chat history.

## Implementation

1. **New sanitizer utility** (`src/node/utils/messages/sanitizeAnthropicDocumentFilename.ts`)
   - `sanitizeAnthropicDocumentFilename()` - transforms filenames by replacing disallowed chars with spaces, collapsing consecutive whitespace, and providing a fallback
   - `sanitizeAnthropicPdfFilenames()` - applies sanitization to PDF file parts in user messages

2. **Integration in aiService.ts**
   - Added sanitization step in request pipeline, only for Anthropic provider
   - Placed after SVG inlining, before tool media extraction
   - Does not mutate persisted history or UI display

3. **Error message cleanup**
   - Strip `undefined:` prefix from provider errors in `createUnknownSendMessageError()`

Example transformation:
- Input: `D19910350Lj.pdf` → API receives: `D19910350Lj pdf`
- User sees: `D19910350Lj.pdf` (unchanged)

## Validation

- Added 29 unit tests covering sanitization logic and message processing
- All 2924 tests pass
- Static check passes

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$8.99`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=8.99 -->
