### PR TITLE
🤖 fix: shorten Terminal Font helper text

### DIFF
--- a/src/browser/components/Settings/sections/GeneralSection.tsx
+++ b/src/browser/components/Settings/sections/GeneralSection.tsx
@@ -222,12 +222,6 @@ export function GeneralSection() {
                 <div className="text-warning text-xs">{terminalFontWarning}</div>
               ) : null}
               <div className="text-muted text-xs">Set this to a monospace font you like.</div>
-              {isBrowserMode ? (
-                <div className="text-muted text-xs">
-                  Browser mode uses fonts installed on the client device (plus the bundled symbols
-                  fallback). Fonts installed on the mux server are not used.
-                </div>
-              ) : null}
               <div className="text-muted text-xs">
                 Preview:{" "}
                 <span className="text-foreground" style={{ fontFamily: terminalFontPreviewFamily }}>


### PR DESCRIPTION
Summary
- Shortened the Terminal Font helper copy to start at “Set this…” and removed the browser mode-only note (keeps it under two lines).

Validation
- make static-check

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: $0.10_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=0.10 -->
