### PR TITLE
feat: add --clean-providers/--clean-projects flags to sandbox scripts

### DIFF
--- a/.mux/skills/dev-desktop-sandbox/SKILL.md
+++ b/.mux/skills/dev-desktop-sandbox/SKILL.md
@@ -18,7 +18,7 @@ make dev-desktop-sandbox
 ## What it does
 
 - Creates a fresh temporary `MUX_ROOT` directory
-- Copies these files into the sandbox if present:
+- Copies these files into the sandbox if present (unless disabled by flags):
   - `providers.jsonc` (provider config)
   - `config.json` (project list)
 - Picks free ports:
@@ -38,6 +38,15 @@ make dev-desktop-sandbox
 ## Options
 
 ```bash
+# Start with a clean instance (do not copy providers or projects)
+make dev-desktop-sandbox DEV_DESKTOP_SANDBOX_ARGS="--clean-providers --clean-projects"
+
+# Skip copying providers.jsonc
+make dev-desktop-sandbox DEV_DESKTOP_SANDBOX_ARGS="--clean-providers"
+
+# Clear projects from config.json (preserves other config)
+make dev-desktop-sandbox DEV_DESKTOP_SANDBOX_ARGS="--clean-projects"
+
 # Use a specific root to seed from (defaults to $MUX_ROOT then ~/.mux-dev then ~/.mux)
 SEED_MUX_ROOT=~/.mux-dev make dev-desktop-sandbox
 

--- a/.mux/skills/dev-server-sandbox/SKILL.md
+++ b/.mux/skills/dev-server-sandbox/SKILL.md
@@ -22,7 +22,7 @@ make dev-server-sandbox
 ## What it does
 
 - Creates a fresh temporary `MUX_ROOT` directory
-- Copies these files into the sandbox if present:
+- Copies these files into the sandbox if present (unless disabled by flags):
   - `providers.jsonc` (provider config)
   - `config.json` (project list)
 - Picks free ports (`BACKEND_PORT`, `VITE_PORT`)
@@ -32,6 +32,15 @@ make dev-server-sandbox
 ## Options
 
 ```bash
+# Start with a clean instance (do not copy providers or projects)
+make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-providers --clean-projects"
+
+# Skip copying providers.jsonc
+make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-providers"
+
+# Clear projects from config.json (preserves other config)
+make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-projects"
+
 # Use a specific root to seed from (defaults to ~/.mux-dev then ~/.mux)
 SEED_MUX_ROOT=~/.mux-dev make dev-server-sandbox
 

--- a/Makefile
+++ b/Makefile
@@ -185,9 +185,9 @@ endif
 
 
 dev-desktop-sandbox: ## Start an isolated Electron dev instance (fresh MUX_ROOT + free ports)
-	@bun scripts/dev-desktop-sandbox.ts
+	@bun scripts/dev-desktop-sandbox.ts $(DEV_DESKTOP_SANDBOX_ARGS)
 dev-server-sandbox: ## Start an isolated dev-server instance (fresh MUX_ROOT + free ports)
-	@bun scripts/dev-server-sandbox.ts
+	@bun scripts/dev-server-sandbox.ts $(DEV_SERVER_SANDBOX_ARGS)
 
 start: node_modules/.installed build-main build-preload build-static ## Build and start Electron app
 	@NODE_ENV=development bunx electron --remote-debugging-port=9222 .

--- a/scripts/dev-desktop-sandbox.ts
+++ b/scripts/dev-desktop-sandbox.ts
@@ -16,6 +16,11 @@
  * Usage:
  *   make dev-desktop-sandbox
  *
+ * Optional CLI flags:
+ *   - --clean-providers
+ *   - --clean-projects
+ *   - --help
+ *
  * Optional env vars:
  *   - SEED_MUX_ROOT=/path/to/mux/home   # where to copy providers.jsonc/config.json from
  *   - KEEP_SANDBOX=1                   # don't delete temp MUX_ROOT on exit
@@ -33,12 +38,48 @@ import * as path from "path";
 
 import {
   chooseSeedMuxRoot,
+  copyConfigClearingProjectsIfExists,
   copyFileIfExists,
   forwardSignalsToChildProcesses,
   getFreePort,
   parseOptionalPort,
   waitForHttpReady,
 } from "./sandboxUtils";
+
+type SandboxCliFlags = {
+  cleanProviders: boolean;
+  cleanProjects: boolean;
+  help: boolean;
+};
+
+function parseSandboxCliFlags(argv: string[]): SandboxCliFlags {
+  const args = new Set(argv);
+  const knownArgs = new Set(["--clean-providers", "--clean-projects", "--help"]);
+
+  for (const arg of args) {
+    if (!knownArgs.has(arg)) {
+      throw new Error(`Unknown arg: ${arg}`);
+    }
+  }
+
+  return {
+    cleanProviders: args.has("--clean-providers"),
+    cleanProjects: args.has("--clean-projects"),
+    help: args.has("--help"),
+  };
+}
+
+function printHelp(): void {
+  console.log(`Usage:
+  make dev-desktop-sandbox
+
+Optional CLI flags:
+  --clean-providers   Do not copy providers.jsonc into the sandbox
+  --clean-projects    Do not import projects from config.json (projects will be empty)
+
+Note: to pass flags via make, use:
+  make dev-desktop-sandbox DEV_DESKTOP_SANDBOX_ARGS="--clean-providers --clean-projects"`);
+}
 
 function parseElectronDebugPort(
   raw: string | undefined
@@ -97,12 +138,22 @@ async function waitForChildExit(child: ReturnType<typeof spawn>, name: string): 
 }
 
 async function main(): Promise<number> {
+  const cliFlags = parseSandboxCliFlags(process.argv.slice(2));
+  if (cliFlags.help) {
+    printHelp();
+    return 0;
+  }
+
+  const cleanProviders = cliFlags.cleanProviders;
+  const cleanProjects = cliFlags.cleanProjects;
+
   const keepSandbox = process.env.KEEP_SANDBOX === "1";
   const makeCmd = process.env.MAKE ?? "make";
 
   // Do any validation that might throw *before* creating the temp root so we
   // don't leave behind stale `mux-desktop-*` directories for simple mistakes.
-  const seedMuxRoot = chooseSeedMuxRoot();
+  const shouldSeed = !(cleanProviders && cleanProjects);
+  const seedMuxRoot = shouldSeed ? chooseSeedMuxRoot() : null;
 
   const vitePortOverride = parseOptionalPort(process.env.VITE_PORT);
   const debugPortConfig = parseElectronDebugPort(process.env.ELECTRON_DEBUG_PORT);
@@ -135,14 +186,20 @@ async function main(): Promise<number> {
   let electronProc: ReturnType<typeof spawn> | null = null;
 
   try {
-    const seedProvidersPath = seedMuxRoot ? path.join(seedMuxRoot, "providers.jsonc") : null;
+    const seedProvidersPath =
+      seedMuxRoot && !cleanProviders ? path.join(seedMuxRoot, "providers.jsonc") : null;
     const seedConfigPath = seedMuxRoot ? path.join(seedMuxRoot, "config.json") : null;
 
+    const sandboxProvidersPath = path.join(muxRoot, "providers.jsonc");
+    const sandboxConfigPath = path.join(muxRoot, "config.json");
+
     const copiedProviders = seedProvidersPath
-      ? copyFileIfExists(seedProvidersPath, path.join(muxRoot, "providers.jsonc"), { mode: 0o600 })
+      ? copyFileIfExists(seedProvidersPath, sandboxProvidersPath, { mode: 0o600 })
       : false;
     const copiedConfig = seedConfigPath
-      ? copyFileIfExists(seedConfigPath, path.join(muxRoot, "config.json"))
+      ? cleanProjects
+        ? copyConfigClearingProjectsIfExists(seedConfigPath, sandboxConfigPath)
+        : copyFileIfExists(seedConfigPath, sandboxConfigPath)
       : false;
 
     console.log("\nStarting mux desktop sandbox...");
@@ -153,6 +210,10 @@ async function main(): Promise<number> {
       console.log(`  Copied providers: ${copiedProviders ? "yes" : "no"}`);
     } else {
       console.log("  Seeded from:     (none)");
+    }
+    if (cleanProviders || cleanProjects) {
+      console.log(`  Clean providers: ${cleanProviders ? "yes" : "no"}`);
+      console.log(`  Clean projects:  ${cleanProjects ? "yes" : "no"}`);
     }
     console.log(`  Vite:            http://127.0.0.1:${vitePort}`);
     if (electronDebugPort !== null) {

--- a/scripts/sandboxUtils.ts
+++ b/scripts/sandboxUtils.ts
@@ -58,6 +58,37 @@ export function chooseSeedMuxRoot(): string | null {
   return null;
 }
 
+export function copyConfigClearingProjectsIfExists(sourcePath: string, destPath: string): boolean {
+  if (!fileExists(sourcePath)) return false;
+
+  function sanitizeConfig(value: unknown): Record<string, unknown> {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      return { projects: [] };
+    }
+
+    return { ...(value as Record<string, unknown>), projects: [] };
+  }
+
+  let parsed: unknown;
+  try {
+    const raw = fs.readFileSync(sourcePath, "utf-8");
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    console.warn(`Failed to read/parse config.json at ${sourcePath}:`, err);
+    parsed = null;
+  }
+
+  const sanitized = sanitizeConfig(parsed);
+
+  try {
+    fs.writeFileSync(destPath, JSON.stringify(sanitized, null, 2));
+    return true;
+  } catch (err) {
+    console.warn(`Failed to write config.json at ${destPath}:`, err);
+    return false;
+  }
+}
+
 export function copyFileIfExists(
   sourcePath: string,
   destPath: string,


### PR DESCRIPTION
Adds optional CLI flags to `dev-server-sandbox` and `dev-desktop-sandbox` scripts:

- `--clean-providers`: Skip copying `providers.jsonc` into the sandbox
- `--clean-projects`: Copy `config.json` but clear the projects list (preserves other settings)

**Usage via make:**
```bash
make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-providers --clean-projects"
make dev-desktop-sandbox DEV_DESKTOP_SANDBOX_ARGS="--clean-projects"
```

This makes it easy to start a truly fresh sandbox without inheriting credentials or project state from the host mux installation.

---
*Generated with [mux](https://mux.coder.com)*