### PR TITLE
🤖 feat: block mux-gateway from /providers slash command

### DIFF
--- a/src/browser/utils/slashCommands/parser.test.ts
+++ b/src/browser/utils/slashCommands/parser.test.ts
@@ -63,6 +63,15 @@ describe("commandParser", () => {
       );
     });
 
+    it("rejects mux-gateway provider for /providers set", () => {
+      expectParse("/providers set mux-gateway couponCode abc123", {
+        type: "command-invalid-args",
+        command: "providers set",
+        input: "mux-gateway",
+        usage: "/providers set <provider> <key> <value>",
+      });
+    });
+
     it("should handle quoted arguments", () => {
       expectProvidersSet(
         '/providers set anthropic apiKey "my key with spaces"',


### PR DESCRIPTION
Remove the ability to configure mux-gateway through slash commands.

## Changes

- Added a blocklist that prevents `/providers set mux-gateway ...` from being executed
- Removed mux-gateway from the provider suggestions in `/providers set`
- Removed mux-gateway key hints (couponCode) from the slash command registry
- Added a test to verify mux-gateway is rejected

Mux Gateway settings should be configured in the Settings UI, not via slash commands.

---
*Generated with [Mux](https://mux.coder.com)*