### PR TITLE
🤖 perf: speed up tool_post tailwind class ordering (13x faster)

### DIFF
--- a/.mux/eslint-tailwind-only.mjs
+++ b/.mux/eslint-tailwind-only.mjs
@@ -1,0 +1,26 @@
+import tailwindcss from "eslint-plugin-tailwindcss";
+import tseslint from "typescript-eslint";
+
+export default [
+  {
+    files: ["**/*.{ts,tsx}"],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    plugins: { tailwindcss },
+    settings: {
+      tailwindcss: {
+        // Don't try to load Tailwind config (v4 doesn't export resolveConfig)
+        config: false,
+        cssFiles: ["**/*.css", "!**/node_modules", "!**/.*", "!**/dist", "!**/build"],
+        callees: [],
+      },
+    },
+    rules: {
+      "tailwindcss/classnames-order": "warn",
+    },
+  },
+];

--- a/.mux/tool_post
+++ b/.mux/tool_post
@@ -9,8 +9,8 @@ if [[ "$MUX_TOOL" == file_edit_* ]]; then
       before=$(cat "$file" 2>/dev/null) || exit 0
       # 1. Format with prettier
       bun run prettier --write --log-level silent "$file" 2>/dev/null || true
-      # 2. Fix tailwind class ordering (eslint wins over prettier for class order)
-      bun run eslint --fix --quiet "$file" 2>/dev/null || true
+      # 2. Fix tailwind class ordering (minimal config for speed)
+      bun run eslint --fix --quiet --no-config-lookup --no-inline-config --config .mux/eslint-tailwind-only.mjs "$file" 2>/dev/null || true
       # Only output if file changed
       if [[ "$(cat "$file")" != "$before" ]]; then
         echo "Formatted: $file"


### PR DESCRIPTION
## Summary

Speed up the `.mux/tool_post` tailwind class ordering fix from ~7s to ~0.5s per file (13x faster).

## Background

The `tool_post` hook runs on every TS/TSX file edit to auto-format and fix tailwind class ordering. It was running the full project eslint config (typescript-eslint, react, react-hooks, custom rules, etc.) when only the `tailwindcss/classnames-order` rule was needed.

## Implementation

- Create a minimal eslint config (`.mux/eslint-tailwind-only.mjs`) with only the tailwind plugin and classnames-order rule
- Use `--no-config-lookup` flag to prevent eslint from loading the project's full config
- Update `tool_post` to use the new minimal config

## Validation

Benchmarked both approaches on `src/browser/App.tsx`:
- **Old (full config):** ~6.8s
- **New (minimal config):** ~0.5s

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.36`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=0.36 -->
