### PR TITLE
🤖 feat: backend mux.md signing via ssh-agent

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "@ai-sdk/openai": "^2.0.76",
         "@ai-sdk/xai": "^2.0.39",
         "@aws-sdk/credential-providers": "^3.940.0",
-        "@coder/mux-md-client": "^0.1.0-main.14",
+        "@coder/mux-md-client": "^0.1.0-main.21",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -537,7 +537,7 @@
 
     "@chevrotain/utils": ["@chevrotain/utils@11.0.3", "", {}, "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="],
 
-    "@coder/mux-md-client": ["@coder/mux-md-client@0.1.0-main.14", "", { "dependencies": { "@noble/curves": "^2.0.1", "@noble/ed25519": "^3.0.0", "@noble/hashes": "^2.0.1" } }, "sha512-f7ePWaitBh/QzlzGZVH9QRy5JNNVnZEyHb+efapqIRan4gS3aLS622frasPV/w8JGGft/zgBHGfaJFlXreIesw=="],
+    "@coder/mux-md-client": ["@coder/mux-md-client@0.1.0-main.21", "", { "dependencies": { "@noble/curves": "^2.0.1", "@noble/ed25519": "^3.0.0", "@noble/hashes": "^2.0.1" } }, "sha512-Lf1KYNeRVg4Apjf9gtuJ7IQHEl6oi0YM5BN47RdSC/mhPrC+Uf3dWS6obFceoJV2R4kriFzqoar/fHdsf6XFCg=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 

--- a/docs/workspaces/sharing.mdx
+++ b/docs/workspaces/sharing.mdx
@@ -28,6 +28,9 @@ Mux looks for a signing key in these locations (first match wins):
 2. `~/.ssh/id_ed25519` — standard SSH Ed25519 key
 3. `~/.ssh/id_ecdsa` — standard SSH ECDSA key
 
+Mux can also sign using keys loaded in your SSH agent when `SSH_AUTH_SOCK` is set (for example,
+1Password's SSH agent). Agent-backed keys are preferred over the default `~/.ssh/id_*` files.
+
 <Tip>
   To reuse an existing key without copying it:
 
@@ -42,7 +45,7 @@ ln -s ~/.ssh/id_ed25519 ~/.mux/message_signing_key
 - **Ed25519** (recommended) — fast, secure, 32-byte keys
 - **ECDSA** — P-256, P-384, and P-521 curves supported
 
-Encrypted keys (passphrase-protected) are skipped automatically.
+Encrypted key files (passphrase-protected) are skipped automatically unless the key is available via ssh-agent.
 
 ### GitHub identity detection
 
@@ -61,7 +64,7 @@ If you're logged in with `gh auth login`, your GitHub username appears on mux.md
 
 ### Enabling/disabling signing
 
-Click the pen icon (✏️) in the share popover to toggle signing on or off. This setting persists across sessions.
+Click the pen icon in the share popover to toggle signing on or off. This setting persists across sessions.
 
 When signing is disabled (or no key is found), shares are still encrypted—they just won’t include a signature.
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@ai-sdk/openai": "^2.0.76",
     "@ai-sdk/xai": "^2.0.39",
     "@aws-sdk/credential-providers": "^3.940.0",
-    "@coder/mux-md-client": "^0.1.0-main.14",
+    "@coder/mux-md-client": "^0.1.0-main.21",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/src/common/lib/muxMd.ts
+++ b/src/common/lib/muxMd.ts
@@ -13,11 +13,12 @@ import {
   parseUrl,
   type FileInfo,
   type SignOptions,
+  type SignatureEnvelope,
   type UploadResult,
 } from "@coder/mux-md-client";
 
 // Re-export types from package
-export type { FileInfo, SignOptions, UploadResult };
+export type { FileInfo, SignOptions, SignatureEnvelope, UploadResult };
 
 export const MUX_MD_BASE_URL = "https://mux.md";
 export const MUX_MD_HOST = "mux.md";
@@ -46,6 +47,11 @@ export function parseMuxMdUrl(url: string): { id: string; key: string } | null {
 export interface UploadOptions {
   /** Expiration time (ISO date string or Date object) */
   expiresAt?: string | Date;
+  /**
+   * Precomputed signature envelope to embed in the encrypted payload.
+   * Takes precedence over `sign`.
+   */
+  signature?: SignatureEnvelope;
   /** Sign options for native signing via mux-md-client */
   sign?: SignOptions;
 }
@@ -63,6 +69,7 @@ export async function uploadToMuxMd(
   return upload(new TextEncoder().encode(content), fileInfo, {
     baseUrl: MUX_MD_BASE_URL,
     expiresAt: options.expiresAt,
+    signature: options.signature,
     sign: options.sign,
   });
 }

--- a/src/common/orpc/schemas.ts
+++ b/src/common/orpc/schemas.ts
@@ -182,7 +182,7 @@ export {
   TelemetryEventSchema,
   signing,
   type SigningCapabilities,
-  type SignCredentials,
+  type SignatureEnvelope,
   terminal,
   tokenizer,
   update,

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -62,7 +62,7 @@ export const experiments = {
 export { telemetry, TelemetryEventSchema } from "./telemetry";
 
 // Re-export signing schemas
-export { signing, type SigningCapabilities, type SignCredentials } from "./signing";
+export { signing, type SigningCapabilities, type SignatureEnvelope } from "./signing";
 
 // --- API Router Schemas ---
 

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -2013,11 +2013,11 @@ export const router = (authToken?: string) => {
         .handler(async ({ context }) => {
           return context.signingService.getCapabilities();
         }),
-      getSignCredentials: t
-        .input(schemas.signing.getSignCredentials.input)
-        .output(schemas.signing.getSignCredentials.output)
-        .handler(async ({ context }) => {
-          return context.signingService.getSignCredentials();
+      signMessage: t
+        .input(schemas.signing.signMessage.input)
+        .output(schemas.signing.signMessage.output)
+        .handler(({ context, input }) => {
+          return context.signingService.signMessage(input.content);
         }),
       clearIdentityCache: t
         .input(schemas.signing.clearIdentityCache.input)


### PR DESCRIPTION
## Summary
Move mux.md share signing fully into the Node backend and add SSH-agent support (including 1Password’s agent) so shares can be “Verified” without exposing private key bytes to the renderer.

## Background
The previous flow sent raw private key material to the renderer (base64) so the browser could sign. That prevented signing with agent-only keys and is a larger key-handling surface than needed.

## Implementation
- Replace `getSignCredentials` (private key IPC) with a new `signMessage` ORPC endpoint that returns a mux.md `SignatureEnvelope`.
- Backend (`SigningService`) now:
  - prefers an explicit unencrypted disk key at `~/.mux/message_signing_key`
  - otherwise uses `SSH_AUTH_SOCK` (ssh-agent) when available (supports `ssh-ed25519` + ECDSA nistp256/384/521)
  - otherwise falls back to default disk keys (`~/.ssh/id_ed25519`, `~/.ssh/id_ecdsa`)
  - skips encrypted key files unless the key is available via ssh-agent
  - supports agent selection overrides via `MUX_SIGNING_PUBLIC_KEY` / `MUX_SIGNING_KEY_FINGERPRINT`
- Frontend no longer decodes / handles private keys; it requests a signature envelope and passes it through to mux-md-client upload.
- Update docs + UI copy to mention SSH agent / 1Password.

## Validation
- `make static-check`
- Updated `SigningService` tests to cover disk-key signing and ssh-agent signing (via temporary `ssh-agent` + `ssh-add`).

## Risks
- Low: on any signing failure we degrade to “upload unsigned” so sharing still works.

---

<details>
<summary>📋 Implementation Plan</summary>

# Backend signing for mux.md shares (ssh-agent + disk keys / 1Password)

## Context / Why
Mux can share plans/messages to **mux.md** with an optional signature so the share shows as “Verified” on mux.md. Today, Mux’s signing flow requires **raw private key bytes loaded from an unencrypted key file on disk**, which prevents using SSH keys that live only in an SSH agent (e.g. **1Password’s SSH agent**) and also blocks passphrase-protected keys unless you create an unencrypted copy.

Goal: **move all signing to the Node backend** and support signing via `ssh-agent` (`SSH_AUTH_SOCK`) so keys managed by 1Password can sign shares and show as verified on mux.md, without needing a private key file on disk *and without shipping private key bytes to the renderer*.

## Success criteria
- Renderer never receives private key bytes (remove `privateKeyBase64` IPC path).
- Signing works when the key lives only in an SSH agent (`SSH_AUTH_SOCK`), including 1Password’s SSH agent.
- Passphrase-protected key files remain skipped **unless** the key is available via ssh-agent.
- Any signing failure degrades to “upload unsigned” (sharing must still succeed).

## Evidence (what exists today)
- Signing credentials are loaded from disk via `sshpk` and returned to the renderer as base64 bytes:
  - `src/node/services/signingService.ts` (`getDefaultKeyPaths()`, `getCapabilities()`, `getSignCredentials()`) loads from `~/.mux/message_signing_key`, `~/.ssh/id_ed25519`, `~/.ssh/id_ecdsa` and skips encrypted keys.
- The renderer performs signing during upload by passing `SignOptions.privateKey` into `@coder/mux-md-client`:
  - `src/browser/components/ShareMessagePopover.tsx` calls `api.signing.getSignCredentials()` and then `uploadToMuxMd(..., { sign })`.
- Current wrapper + RPC usage:
  - `src/common/lib/muxMd.ts` `uploadToMuxMd()` currently exposes `{ expiresAt, sign }` and forwards only `sign` into `@coder/mux-md-client.upload()` (no `signature` pass-through yet).
  - `src/common/orpc/schemas/signing.ts` currently exposes `capabilities`, `getSignCredentials`, `clearIdentityCache`; `src/node/orpc/router.ts` wires these to `SigningService`.
  - `src/browser/components/ShareMessagePopover.tsx` calls `api.signing.getSignCredentials()` in **two** places (initial share + toggle signing) and base64-decodes `privateKeyBase64` in the renderer.
- `@coder/mux-md-client` has been updated in `node_modules/` (now `0.1.0-main.21`) to support **external signing**:
  - `UploadOptions.signature?: SignatureEnvelope` (precomputed envelope; takes precedence over `sign`)
  - `SignOptions` union includes `{ signer: (data: Uint8Array) => Promise<SignatureEnvelope> }` for agent-backed keys
  - Node-only `@coder/mux-md-client/ssh-agent` export provides `createSshAgentSigner()` / `createSshAgentSignatureEnvelope()`
  - `createSignatureEnvelope()` is now exported for disk-key signing
  - Evidence: `node_modules/@coder/mux-md-client/dist/index.d.ts`, `node_modules/@coder/mux-md-client/dist/ssh-agent.d.ts`
- Repo already depends on `ssh2` (`^1.17.0`) which includes an ssh-agent client suitable for 1Password’s agent.

## Recommended approach
### Approach A (recommended): backend-only signing (disk key or ssh-agent) via mux-md-client external signing
**Net new product LoC estimate:** ~240–330

Key idea: keep encryption/upload in the renderer, but have the **Node backend produce a mux.md `SignatureEnvelope`** using the updated mux-md-client APIs:
- On-disk keys: `createSignatureEnvelope()` (exported from `@coder/mux-md-client`)
- SSH agent keys (1Password): `createSshAgentSignatureEnvelope()` (exported from `@coder/mux-md-client/ssh-agent`)

Flow:
1) Renderer sends `content` to the backend and receives a mux.md-compatible `SignatureEnvelope`.
2) Renderer calls `uploadToMuxMd(content, fileInfo, { expiresAt, signature })` and mux-md-client embeds the signature into the encrypted payload.

## Implementation plan

### 1) Thread `SignatureEnvelope` through muxMd wrapper + add ORPC signing endpoint
- Update `src/common/lib/muxMd.ts`:
  - Extend wrapper `UploadOptions` with `signature?: SignatureEnvelope` and pass it through to `@coder/mux-md-client.upload()`.
  - Re-export `SignatureEnvelope` type from `@coder/mux-md-client` for use in ORPC schemas.
  - Keep existing `sign?: SignOptions` in the wrapper API for compatibility, but stop using it from the share UI.
- Update ORPC (`src/common/orpc/schemas/signing.ts` + `src/node/orpc/router.ts`):
  - Keep `capabilities` + `clearIdentityCache` endpoints (same semantics).
  - Add `signMessage` input: `{ content: string }`.
  - Output: `SignatureEnvelope` (`{ sig: string; publicKey: string; githubUser?: string }`).
  - Remove `getSignCredentials` entirely (and all `privateKeyBase64` transport).

### 2) Implement backend signing in `SigningService` (disk + ssh-agent)
Extend `src/node/services/signingService.ts` (or split to `sshAgentSigning.ts` but keep public API in `SigningService`) to return a mux.md `SignatureEnvelope` **without exposing private key bytes**:

**2.1 Detect agent + choose a key**
- Keep existing disk key search order (`getDefaultKeyPaths()` today):
  1) `~/.mux/message_signing_key` (explicit override)
  2) `~/.ssh/id_ed25519`
  3) `~/.ssh/id_ecdsa`
- If `process.env.SSH_AUTH_SOCK` is set, query the agent:
  - Use `ssh2.Agent` + `getIdentities()`.
  - For each identity, derive a usable selection record:
    - Build OpenSSH public key string: `${algo} ${base64(keyBlob)}` where `algo` is parsed from the key blob (first SSH “string”).
    - Validate/normalize by calling `parsePublicKey(publicKey)` from `@coder/mux-md-client`.
    - Compute fingerprint via `computeFingerprint(parsed.keyBytes)` (yields `SHA256:...`).
  - Filter to supported key types (`ssh-ed25519`, `ecdsa-sha2-nistp256|384|521`).
- Selection rules (safe default):
  1) If the explicit disk key loads successfully, use it (preserves existing override).
  2) Else if agent has a supported key, prefer Ed25519 then ECDSA.
  3) Else fall back to disk defaults.
- Add an env override (maps directly to mux-md-client’s ssh-agent helper options):
  - `MUX_SIGNING_PUBLIC_KEY` (full OpenSSH pubkey string)
  - `MUX_SIGNING_KEY_FINGERPRINT` (`SHA256:...`)

**2.2 Create SignatureEnvelopes using mux-md-client helpers**
- Implement `signMessage(content: string): Promise<SignatureEnvelope>` (or an internal helper that signs UTF-8 bytes) that:
  - Encodes `content` as UTF-8 bytes (`new TextEncoder().encode(content)`).
  - Disk key path:
    - load key from disk as today (via `sshpk`) to get `privateKeyBytes` + `publicKeyOpenSSH`
    - call `createSignatureEnvelope(bytes, privateKeyBytes, publicKeyOpenSSH, { githubUser })` from `@coder/mux-md-client`
  - SSH agent path (1Password):
    - call `createSshAgentSignatureEnvelope(bytes, { sshAuthSock, publicKey, fingerprint, githubUser })` from `@coder/mux-md-client/ssh-agent`
  - Return the resulting `SignatureEnvelope` directly (it is already mux.md-compatible).

**2.3 Capabilities updates**
Update `getCapabilities()` to report a usable `publicKey` when:
- an unencrypted on-disk key exists (current behavior), **or**
- an ssh-agent identity is available (new behavior).

Also update error messaging:
- If only encrypted key files are found and agent has **no** usable keys: keep `hasEncryptedKey: true` and keep the existing “passphrase required” guidance.
- If a usable agent key exists: set `error: null` (no warning), regardless of encrypted disk keys.
- If an env override is set but no matching agent identity is found: return a clear error (and `publicKey: null`) so the UI explains what to fix.

**2.4 Defensive programming / self-healing**
- Add assertions with explicit errors for:
  - missing/invalid `SSH_AUTH_SOCK`
  - unsupported agent key types
  - malformed signature blobs
  - unexpected signature lengths per curve
- Ensure failures *never* brick sharing: all errors should degrade to “upload unsigned”.

### 3) Renderer: request a `SignatureEnvelope` and pass it to mux-md-client
Update `src/browser/components/ShareMessagePopover.tsx`:

- In `handleShare()` (and the “toggle signing regenerate” path):
  1) If signing is enabled and a key is available, call `api.signing.signMessage({ content })` to get a `SignatureEnvelope`.
  2) Call `uploadToMuxMd(content, fileInfo, { expiresAt, signature })`.
  3) If signing is disabled or signing fails, call `uploadToMuxMd(content, fileInfo, { expiresAt })` (unsigned).
- Update cached `ShareData.signed` to reflect `Boolean(signature)`.
- Remove `getSignCredentials()` usage and any `privateKeyBase64` decoding in the renderer.

This preserves the “encrypted in your browser” property while keeping private key material out of the renderer.

### 4) Tests
- Update `src/node/services/signingService.test.ts` to cover:
  - on-disk key signing via `signMessage` (Ed25519 + ECDSA)
  - ssh-agent signing via a temporary `ssh-agent` + `ssh-add` (covers 1Password-style agent semantics)
  - verification using `@coder/mux-md-client`’s `parsePublicKey()` + `verifySignature()` against the produced `sig` bytes
  - regression: encrypted key file present + agent key available => capabilities show a key and signing works

### 5) Docs + UX copy
- Update `docs/workspaces/sharing.mdx`:
  - Add ssh-agent as a supported key source (mention 1Password explicitly).
  - Update “Encrypted keys are skipped” to: “Encrypted key files are skipped **unless the key is available via ssh-agent**.”
- Update in-app tooltip copy in `ShareMessagePopover.tsx`:
  - Replace “Create an unencrypted key … or use ssh-add” with clearer guidance:
    - “Use an unencrypted key file **or** ensure your SSH agent (e.g. 1Password) is running and `SSH_AUTH_SOCK` is set.”



</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.2` • Thinking: `high` • Cost: `$14.53`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=high costs=14.53 -->
