### PR TITLE
🤖 fix: preserve newlines in user message markdown

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -77,6 +77,7 @@
         "react-router-dom": "^7.11.0",
         "rehype-harden": "^1.1.5",
         "rehype-sanitize": "^6.0.0",
+        "remark-breaks": "^4.0.0",
         "shescape": "^2.1.6",
         "source-map-support": "^0.5.21",
         "ssh-config": "^5.0.4",
@@ -2814,6 +2815,8 @@
 
     "mdast-util-mdxjs-esm": ["mdast-util-mdxjs-esm@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg=="],
 
+    "mdast-util-newline-to-break": ["mdast-util-newline-to-break@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-find-and-replace": "^3.0.0" } }, "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog=="],
+
     "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
 
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
@@ -3263,6 +3266,8 @@
     "rehype-sanitize": ["rehype-sanitize@6.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-sanitize": "^5.0.0" } }, "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg=="],
 
     "release-zalgo": ["release-zalgo@1.0.0", "", { "dependencies": { "es6-error": "^4.0.1" } }, "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA=="],
+
+    "remark-breaks": ["remark-breaks@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-newline-to-break": "^2.0.0", "unified": "^11.0.0" } }, "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ=="],
 
     "remark-cjk-friendly": ["remark-cjk-friendly@1.2.3", "", { "dependencies": { "micromark-extension-cjk-friendly": "1.2.3" }, "peerDependencies": { "@types/mdast": "^4.0.0", "unified": "^11.0.0" }, "optionalPeers": ["@types/mdast"] }, "sha512-UvAgxwlNk+l9Oqgl/9MWK2eWRS7zgBW/nXX9AthV7nd/3lNejF138E7Xbmk9Zs4WjTJGs721r7fAEc7tNFoH7g=="],
 

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "react-router-dom": "^7.11.0",
     "rehype-harden": "^1.1.5",
     "rehype-sanitize": "^6.0.0",
+    "remark-breaks": "^4.0.0",
     "shescape": "^2.1.6",
     "source-map-support": "^0.5.21",
     "ssh-config": "^5.0.4",

--- a/src/browser/components/Messages/MarkdownRenderer.tsx
+++ b/src/browser/components/Messages/MarkdownRenderer.tsx
@@ -6,16 +6,24 @@ interface MarkdownRendererProps {
   content: string;
   className?: string;
   style?: React.CSSProperties;
+  /**
+   * Preserve single newlines as line breaks (like GitHub-flavored markdown).
+   * When true, single newlines in text become <br> elements instead of being
+   * collapsed to spaces. Useful for user-authored content where newlines
+   * are intentional. Default: false.
+   */
+  preserveLineBreaks?: boolean;
 }
 
 export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   content,
   className,
   style,
+  preserveLineBreaks,
 }) => {
   return (
     <div className={cn("markdown-content", className)} style={style}>
-      <MarkdownCore content={content} />
+      <MarkdownCore content={content} preserveLineBreaks={preserveLineBreaks} />
     </div>
   );
 };

--- a/src/browser/components/Messages/UserMessageContent.tsx
+++ b/src/browser/components/Messages/UserMessageContent.tsx
@@ -121,6 +121,7 @@ export const UserMessageContent: React.FC<UserMessageContentProps> = (props) => 
           content={textContent}
           className={markdownClassName}
           style={markdownStyles[props.variant]}
+          preserveLineBreaks
         />
       );
     }
@@ -141,6 +142,7 @@ export const UserMessageContent: React.FC<UserMessageContentProps> = (props) => 
             content={remainingContent.trim()}
             className={markdownClassName}
             style={markdownStyles[props.variant]}
+            preserveLineBreaks
           />
         )}
       </div>


### PR DESCRIPTION
## Summary

User messages now preserve intentional line breaks. Previously, `hello\nworld` was rendered as `hello world`; now it renders with the newline preserved.

## Background

Standard markdown collapses single newlines to spaces. This is fine for assistant-generated content but not for user-authored messages where newlines are intentional.

## Implementation

- Added `remark-breaks` dependency - converts single newlines to `<br>` elements (GitHub-style markdown)
- Added `preserveLineBreaks` prop to `MarkdownCore` and `MarkdownRenderer` (default: `false`)
- Enabled `preserveLineBreaks` in `UserMessageContent` for both rendering paths

This keeps assistant message behavior unchanged while giving user messages the expected newline handling.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$1.11`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=1.11 -->
