### PR TITLE
🤖 ci: add gpt-5.2 + gemini-3 to nightly terminal-bench

### DIFF
--- a/.github/workflows/nightly-terminal-bench.yml
+++ b/.github/workflows/nightly-terminal-bench.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       models:
-        description: 'Models to test (comma-separated, or "all" for both)'
+        description: 'Models to test (comma-separated, or "all" for opus + gpt-5.2-codex + gpt-5.2 + google/gemini-3-pro-preview)'
         required: false
         default: "all"
         type: string
@@ -44,7 +44,7 @@ jobs:
           INPUT_MODELS: ${{ inputs.models }}
         run: |
           if [ "$INPUT_MODELS" = "all" ] || [ -z "$INPUT_MODELS" ]; then
-            echo 'models=["anthropic/claude-opus-4-5","openai/gpt-5.2-codex"]' >> "$GITHUB_OUTPUT"
+            echo 'models=["anthropic/claude-opus-4-5","openai/gpt-5.2-codex","openai/gpt-5.2","google/gemini-3-pro-preview"]' >> "$GITHUB_OUTPUT"
           else
             # Convert comma-separated to JSON array
             models_json=$(echo "$INPUT_MODELS" | jq -R -s -c 'split(",") | map(gsub("^\\s+|\\s+$"; ""))')

--- a/.github/workflows/terminal-bench.yml
+++ b/.github/workflows/terminal-bench.yml
@@ -53,6 +53,8 @@ on:
         required: true
       OPENAI_API_KEY:
         required: true
+      GOOGLE_API_KEY:
+        required: false
       DAYTONA_API_KEY:
         required: false
       GCP_SA_KEY:
@@ -149,6 +151,7 @@ jobs:
           MUX_EXPERIMENTS: ${{ inputs.experiments }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
 
       - name: Print results summary


### PR DESCRIPTION
## Summary

Extend the nightly Terminal-Bench run matrix to include **OpenAI GPT-5.2 (base)** and **Google Gemini 3 Pro (preview)** in addition to the existing Opus + GPT-5.2-Codex runs.

## Implementation
- Nightly workflow default `all` models now includes:
  - `anthropic/claude-opus-4-5`
  - `openai/gpt-5.2-codex`
  - `openai/gpt-5.2`
  - `google/gemini-3-pro-preview`
- Reusable `terminal-bench.yml` workflow now accepts and exports `GOOGLE_API_KEY` (no `GOOGLE_GENERATIVE_AI_API_KEY`).

## Validation
- `make static-check`

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Add GPT-5.2 as a Terminal-Bench nightly target

## Context / Why
We currently run Terminal-Bench (terminal-bench@2.0 via Harbor) in CI and on a nightly schedule. Nightly runs are currently hard-coded to run two “primary” model targets:
- `anthropic/claude-opus-4-5` (aka Opus 4.5)
- `openai/gpt-5.2-codex`

Goal: add **a third nightly target** for **`openai/gpt-5.2` (GPT-5.2 “base”)**, in addition to the existing two, so we get comparable nightly TB2.0 results for GPT-5.2 vs GPT-5.2-Codex vs Opus.

## Evidence (what we verified)
- Local/CI entrypoint is `make benchmark-terminal`, which runs `uvx harbor run ...` and accepts `TB_MODEL`, `TB_DATASET`, `TB_CONCURRENCY`, etc. (`Makefile`, target `benchmark-terminal`).
- CI workflow wrapper is reusable workflow `.github/workflows/terminal-bench.yml`, which calls `make benchmark-terminal` and wires inputs → env vars (`TB_MODEL`, `TB_ARGS`, `TB_ENV`, etc.).
- Nightly schedule is `.github/workflows/nightly-terminal-bench.yml`:
  - does a smoke test first
  - then computes a `models` matrix; default `all` currently expands to `anthropic/claude-opus-4-5` + `openai/gpt-5.2-codex` (line ~47)
  - sets thinking level to `xhigh` for any model string containing `gpt-5` (so GPT-5.2 will automatically match).
- Harbor results are written under `jobs/<timestamp>/...` (e.g., `jobs/<ts>/result.json`, `jobs/<ts>/trials/...`). The CI workflow captures `benchmark.log` and uploads `jobs/` as a GitHub Actions artifact; results may also be uploaded to BigQuery via `scripts/upload-tbench-results.py`.
- Model identifiers already exist in app model registry (`src/common/constants/knownModels.ts` includes `gpt-5.2` and `gpt-5.2-codex`).

## Recommended approach (minimal): extend the nightly models matrix
**Net LoC estimate (product code only):** ~0–2 lines (single-line YAML edit + input description tweak).

1. **Update `.github/workflows/nightly-terminal-bench.yml` default “all” list**
   - In `determine-models` step, extend the JSON array written to `$GITHUB_OUTPUT` to include `"openai/gpt-5.2"`.
   - Keep ordering intentional (e.g., Opus → GPT-5.2-Codex → GPT-5.2), since models run sequentially (`max-parallel: 1`).

2. **Fix the workflow_dispatch input description**
   - Update the `models` input description (“all for both”) so it reflects the new default set (now 3 models).

3. **Sanity-check there are no other hard-coded nightly model lists**
   - Quick repo search for `openai/gpt-5.2-codex` / `claude-opus-4-5` to confirm only the nightly workflow needs updating.

4. **Validation (post-change)**
   - Run a smoke TB job for the new model (single task) to ensure credentials + model name normalization works:
     - CI: trigger `.github/workflows/terminal-bench.yml` with `model_name=openai/gpt-5.2`, `task_names=chess-best-move`, `concurrency=1`.
     - Local (optional): `TB_MODEL=openai/gpt-5.2 TB_TASK_NAMES="chess-best-move" TB_CONCURRENCY=1 make benchmark-terminal`.

<details>
<summary>Notes / risks</summary>

- **Runtime + cost increase:** nightly will run 3 full suites instead of 2. Because the workflow intentionally runs models sequentially (`max-parallel: 1`), total wall time will increase roughly proportionally.
- **Thinking level:** nightly uses `contains(matrix.model, 'gpt-5') && 'xhigh' || 'high'`; GPT-5.2 will inherit `xhigh` automatically.
- No app code change should be required: the workflow passes `openai/gpt-5.2` through to Harbor + the mux bench agent, and the agent already normalizes `provider/model` → `provider:model`.

</details>

</details>

---
_Generated with `mux` • Model: openai:gpt-5.2 • Thinking: xhigh • Cost: $1.73_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=1.73 -->
