### PR TITLE
🤖 fix: block tilde paths from escaping workspace restrictions

### DIFF
--- a/src/node/services/tools/fileCommon.test.ts
+++ b/src/node/services/tools/fileCommon.test.ts
@@ -147,6 +147,25 @@ describe("fileCommon", () => {
       const result = validatePathInCwd("../outside.ts", cwdWithSlash, runtime);
       expect(result).not.toBeNull();
     });
+
+    it("should reject tilde paths outside cwd", () => {
+      // Tilde paths expand to home directory, which is outside /workspace/project
+      const result = validatePathInCwd("~/other-project/file.ts", cwd, runtime);
+      expect(result).not.toBeNull();
+      expect(result?.error).toContain("restricted to the workspace directory");
+    });
+
+    it("should reject tilde paths to sensitive files", () => {
+      const result = validatePathInCwd("~/.ssh/id_rsa", cwd, runtime);
+      expect(result).not.toBeNull();
+      expect(result?.error).toContain("restricted to the workspace directory");
+    });
+
+    it("should reject bare tilde path", () => {
+      const result = validatePathInCwd("~", cwd, runtime);
+      expect(result).not.toBeNull();
+      expect(result?.error).toContain("restricted to the workspace directory");
+    });
   });
 
   describe("validateNoRedundantPrefix", () => {

--- a/src/node/services/tools/fileCommon.ts
+++ b/src/node/services/tools/fileCommon.ts
@@ -3,6 +3,7 @@ import assert from "@/common/utils/assert";
 import { createPatch } from "diff";
 import type { FileStat, Runtime } from "@/node/runtime/Runtime";
 import { SSHRuntime } from "@/node/runtime/SSHRuntime";
+import { expandTilde } from "@/node/runtime/tildeExpansion";
 import type { ToolConfiguration } from "@/common/utils/tools/tools";
 
 /**
@@ -216,13 +217,19 @@ export function validatePathInCwd(
     assert(path.isAbsolute(dir), `extraAllowedDir must be an absolute path: '${dir}'`);
   }
 
-  const filePathIsAbsolute = path.isAbsolute(filePath);
+  // Expand tildes FIRST so we validate the actual destination path.
+  // Without this, ~/outside/file.ts would be treated as a relative path
+  // (path.isAbsolute('~/...') returns false) and incorrectly pass validation.
+  const expandedPath = expandTilde(filePath);
+  const filePathIsAbsolute = path.isAbsolute(expandedPath);
 
   // Only allow extraAllowedDirs when the caller provides an absolute path.
   // This prevents relative-path escapes (e.g., ../...) from bypassing cwd restrictions.
 
   // Resolve the path (handles relative paths and normalizes)
-  const resolvedPath = filePathIsAbsolute ? path.resolve(filePath) : path.resolve(cwd, filePath);
+  const resolvedPath = filePathIsAbsolute
+    ? path.resolve(expandedPath)
+    : path.resolve(cwd, expandedPath);
 
   const allowedRoots = [cwd, ...(filePathIsAbsolute ? trimmedExtraAllowedDirs : [])].map((dir) =>
     path.resolve(dir)


### PR DESCRIPTION
## Summary

Fixes a security bug where tilde-prefixed paths (e.g., `~/cmux/file.ts`) could bypass workspace directory restrictions, allowing agents to read/write files anywhere on the filesystem.

## Background

`validatePathInCwd()` checked paths before tilde expansion. Since Node's `path.isAbsolute('~/...')` returns `false`, tilde paths were treated as relative and incorrectly passed validation. The actual file operation then expanded the tilde, accessing files outside the workspace.

Example attack: A workspace at `~/.mux/src/coder/worktree-xyz` could read `~/cmux/src/secret.ts` by using the tilde path, which would:
1. Pass validation (resolved as `~/.mux/src/coder/worktree-xyz/~/cmux/src/secret.ts` - garbage but under cwd)
2. Actually read `/Users/ethan/cmux/src/secret.ts` after tilde expansion

## Implementation

Expand tildes in `validatePathInCwd()` **before** path resolution so validation sees the actual destination path.

## Risks

Low - this is a strictly tighter security check. The only potential breakage would be if any legitimate use case relied on tilde paths to access files outside the workspace, which would be a bug anyway.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$1.48`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=1.48 -->
