### PR TITLE
🤖 fix(stories): update Welcome stories for mux-chat boot behavior

### DIFF
--- a/src/browser/stories/App.welcome.stories.tsx
+++ b/src/browser/stories/App.welcome.stories.tsx
@@ -52,8 +52,8 @@ export default {
   title: "App/Welcome",
 };
 
-/** Welcome screen shown when no projects exist */
-export const WelcomeScreen: AppStory = {
+/** Chat with Mux - the default boot state (no user projects) */
+export const ChatWithMux: AppStory = {
   render: () => (
     <AppWithMocks
       setup={() =>
@@ -84,6 +84,10 @@ export const CreateWorkspace: AppStory = {
       }}
     />
   ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const storyRoot = document.getElementById("storybook-root") ?? canvasElement;
+    await openFirstProjectCreationView(storyRoot);
+  },
 };
 
 /** Creation view with multiple projects - shows sidebar with projects */


### PR DESCRIPTION
## Summary

Updates Welcome stories in Storybook to properly reflect the new mux-chat boot behavior.

## Background

The app now boots into the built-in `mux-chat` workspace by default. Several stories were showing "Chat With Mux" selected when they should either:
1. Embrace it as the new welcome screen (for the empty state)
2. Navigate away to show a different view (for project creation)

## Implementation

- **Renamed `WelcomeScreen` → `ChatWithMux`**: The old name was misleading since mux-chat IS the new welcome experience when no projects exist. The story now accurately describes what it shows.

- **Added play function to `CreateWorkspace`**: Uses the existing `openFirstProjectCreationView()` helper to navigate from mux-chat to the project creation view, so the story actually shows the intended UI.

- **TitleBar:MacOSDesktop**: Unchanged - the story's purpose is demonstrating title bar layout on macOS desktop, not workspace selection.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$1.45`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=1.45 -->
