### PR TITLE
🤖 fix: improve ORPC error logs

### DIFF
--- a/src/common/orpc/schemas/uiLayouts.ts
+++ b/src/common/orpc/schemas/uiLayouts.ts
@@ -5,8 +5,11 @@ import type {
 import { z } from "zod";
 
 export const KeybindSchema = z
+  // Keep in sync with the Keybind type (including allowShift). Strict schemas will
+  // otherwise reject normalized config objects that include optional fields.
   .object({
     key: z.string().min(1),
+    allowShift: z.boolean().optional(),
     ctrl: z.boolean().optional(),
     shift: z.boolean().optional(),
     alt: z.boolean().optional(),

--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -18,6 +18,7 @@ import { randomBytes } from "crypto";
 import { RPCHandler } from "@orpc/server/message-port";
 import { onError } from "@orpc/server";
 import { router } from "@/node/orpc/router";
+import { formatOrpcError } from "@/node/orpc/formatOrpcError";
 import { ServerLockfile } from "@/node/services/serverLockfile";
 import "disposablestack/auto";
 
@@ -343,8 +344,9 @@ async function loadServices(): Promise<void> {
 
   const orpcHandler = new RPCHandler(orpcRouter, {
     interceptors: [
-      onError((error) => {
-        console.error("ORPC Error:", error);
+      onError((error, options) => {
+        const formatted = formatOrpcError(error, options);
+        console.error(formatted.message);
       }),
     ],
   });

--- a/src/node/orpc/formatOrpcError.test.ts
+++ b/src/node/orpc/formatOrpcError.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { ORPCError, ValidationError } from "@orpc/server";
+import { formatOrpcError } from "./formatOrpcError";
+
+describe("formatOrpcError", () => {
+  test("formats output validation errors with request context + issues", () => {
+    const cause = new ValidationError({
+      message: "Validation failed",
+      issues: [
+        {
+          message: "Invalid type",
+          path: ["slots", 0, "preset"],
+        },
+      ],
+      data: { version: 2, slots: [] },
+    });
+
+    const error = new ORPCError("INTERNAL_SERVER_ERROR", {
+      message: "Output validation failed",
+      cause,
+    });
+
+    const formatted = formatOrpcError(error, {
+      prefix: "/orpc",
+      request: {
+        method: "GET",
+        url: new URL("http://localhost/orpc/uiLayouts/getAll"),
+        headers: { authorization: "Bearer secret" },
+      },
+    });
+
+    expect(formatted.message).toContain("GET /orpc/uiLayouts/getAll");
+    expect(formatted.message).toContain("INTERNAL_SERVER_ERROR");
+    expect(formatted.message).toContain("Output validation failed");
+    expect(formatted.message).toContain("slots[0].preset");
+
+    // The whole point of this formatter is to avoid useless `[Object]` / `[Array]` output.
+    expect(formatted.message).not.toContain("[Object]");
+    expect(formatted.message).not.toContain("[Array]");
+
+    const request = formatted.debugDump.request as Record<string, unknown>;
+    const headers = request.headers as Record<string, unknown>;
+    expect(headers.authorization).toBe("<redacted>");
+  });
+
+  test("does not throw for non-error values", () => {
+    const formatted = formatOrpcError({ hello: "world" });
+    expect(formatted.message).toContain("ORPC");
+    expect(formatted.message).toContain("hello");
+  });
+});

--- a/src/node/orpc/formatOrpcError.ts
+++ b/src/node/orpc/formatOrpcError.ts
@@ -1,0 +1,395 @@
+import { ORPCError, ValidationError } from "@orpc/server";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import { inspect } from "node:util";
+
+export interface FormattedOrpcError {
+  /**
+   * Human-readable error message suitable for console output.
+   *
+   * Keep this as a string so we don't lose nested details to Node's `[Object]` / `[Array]` printing.
+   */
+  message: string;
+  /**
+   * JSON-serializable debug payload for log.debug_obj().
+   *
+   * This is intentionally best-effort and must never throw.
+   */
+  debugDump: Record<string, unknown>;
+}
+
+interface RequestContext {
+  method?: string;
+  /** Full URL string (if available). */
+  url?: string;
+  /** URL pathname + search (if available). */
+  path?: string;
+  prefix?: string;
+  headers?: Record<string, unknown>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isUnknownArray(value: unknown): value is readonly unknown[] {
+  return Array.isArray(value);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const proto = Object.getPrototypeOf(value) as object | null;
+  return proto === Object.prototype || proto === null;
+}
+
+function redactHeaders(headers: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(headers)) {
+    return undefined;
+  }
+
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(headers)) {
+    const lower = key.toLowerCase();
+    if (lower === "authorization" || lower === "cookie" || lower === "set-cookie") {
+      result[key] = "<redacted>";
+      continue;
+    }
+
+    result[key] = value;
+  }
+
+  return result;
+}
+
+function extractRequestContext(interceptorOptions: unknown): RequestContext {
+  if (!isRecord(interceptorOptions)) {
+    return {};
+  }
+
+  const prefix =
+    typeof interceptorOptions.prefix === "string" ? interceptorOptions.prefix : undefined;
+  const request = isRecord(interceptorOptions.request) ? interceptorOptions.request : undefined;
+
+  const method = request && typeof request.method === "string" ? request.method : undefined;
+
+  const urlRaw = request ? request.url : undefined;
+  const url =
+    urlRaw instanceof URL ? urlRaw.toString() : typeof urlRaw === "string" ? urlRaw : undefined;
+
+  const path = urlRaw instanceof URL ? `${urlRaw.pathname}${urlRaw.search}` : undefined;
+
+  const headers = request ? redactHeaders(request.headers) : undefined;
+
+  return {
+    method,
+    url,
+    path,
+    prefix,
+    headers,
+  };
+}
+
+interface JsonSafeOptions {
+  depth: number;
+  seen: WeakSet<object>;
+}
+
+function toJsonSafe(value: unknown, options: JsonSafeOptions): unknown {
+  if (value === undefined) {
+    return null;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+
+  if (typeof value === "function") {
+    return `[Function${value.name ? ` ${value.name}` : ""}]`;
+  }
+
+  if (typeof value === "symbol") {
+    return value.toString();
+  }
+
+  if (value instanceof URL) {
+    return value.toString();
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+      cause:
+        options.depth > 0
+          ? toJsonSafe(value.cause, { ...options, depth: options.depth - 1 })
+          : undefined,
+    };
+  }
+
+  if (Array.isArray(value)) {
+    if (options.depth <= 0) {
+      return `Array(${value.length})`;
+    }
+
+    return value
+      .slice(0, 100)
+      .map((entry) => toJsonSafe(entry, { ...options, depth: options.depth - 1 }));
+  }
+
+  if (isPlainObject(value)) {
+    if (options.seen.has(value)) {
+      return "[Circular]";
+    }
+
+    if (options.depth <= 0) {
+      return `Object(${Object.keys(value).length})`;
+    }
+
+    options.seen.add(value);
+
+    const out: Record<string, unknown> = {};
+    const entries = Object.entries(value);
+
+    for (const [key, entry] of entries.slice(0, 200)) {
+      out[key] = toJsonSafe(entry, { ...options, depth: options.depth - 1 });
+    }
+
+    if (entries.length > 200) {
+      out.__truncated__ = `+${entries.length - 200} keys`;
+    }
+
+    return out;
+  }
+
+  return value;
+}
+
+function summarizeForLogs(value: unknown, depth = 1): string {
+  if (value === undefined) {
+    return "undefined";
+  }
+
+  if (value === null) {
+    return "null";
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.length > 300 ? `${value.slice(0, 300)}…` : value;
+    return JSON.stringify(trimmed);
+  }
+
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+
+  if (value instanceof URL) {
+    return value.toString();
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (Array.isArray(value)) {
+    return `Array(${value.length})`;
+  }
+
+  if (isPlainObject(value)) {
+    const keys = Object.keys(value);
+
+    if (depth <= 0) {
+      return `Object(${keys.length})`;
+    }
+
+    const preview = keys.slice(0, 10).map((key) => {
+      const entry = value[key];
+      return `${key}: ${summarizeForLogs(entry, depth - 1)}`;
+    });
+
+    const suffix = keys.length > 10 ? ", …" : "";
+    return `{ ${preview.join(", ")}${suffix} }`;
+  }
+
+  // Fallback for non-plain objects.
+  return inspect(value, { depth: 3, maxArrayLength: 50, breakLength: 120 });
+}
+
+function isIssue(value: unknown): value is StandardSchemaV1.Issue {
+  return isRecord(value) && typeof value.message === "string";
+}
+
+function formatIssuePath(path: StandardSchemaV1.Issue["path"]): string {
+  if (!path || path.length === 0) {
+    return "<root>";
+  }
+
+  const parts: string[] = [];
+
+  for (const segment of path) {
+    const key =
+      typeof segment === "object" && segment !== null && "key" in segment
+        ? (segment as { key: PropertyKey }).key
+        : segment;
+
+    if (typeof key === "number") {
+      parts.push(`[${key}]`);
+      continue;
+    }
+
+    if (typeof key === "string") {
+      const isIdentifier = /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key);
+      if (parts.length === 0) {
+        parts.push(isIdentifier ? key : `[${JSON.stringify(key)}]`);
+      } else {
+        parts.push(isIdentifier ? `.${key}` : `[${JSON.stringify(key)}]`);
+      }
+      continue;
+    }
+
+    const rendered = typeof key === "symbol" ? key.toString() : String(key);
+    parts.push(parts.length === 0 ? `[${rendered}]` : `[${rendered}]`);
+  }
+
+  return parts.join("");
+}
+
+function getValidationErrorInfo(
+  cause: unknown
+): { message?: string; issues: readonly StandardSchemaV1.Issue[]; data: unknown } | null {
+  if (cause instanceof ValidationError) {
+    return {
+      message: cause.message,
+      issues: cause.issues,
+      data: cause.data,
+    };
+  }
+
+  if (!isRecord(cause) || !isUnknownArray(cause.issues)) {
+    return null;
+  }
+
+  const issues = cause.issues.filter(isIssue);
+
+  return {
+    message: typeof cause.message === "string" ? cause.message : undefined,
+    issues,
+    data: "data" in cause ? cause.data : undefined,
+  };
+}
+
+function formatUnknown(value: unknown): string {
+  if (value instanceof Error) {
+    return value.stack ?? `${value.name}: ${value.message}`;
+  }
+
+  return inspect(value, { depth: 5, maxArrayLength: 50, breakLength: 120 });
+}
+
+export function formatOrpcError(error: unknown, interceptorOptions?: unknown): FormattedOrpcError {
+  try {
+    const requestContext = extractRequestContext(interceptorOptions);
+    const where =
+      requestContext.method && requestContext.path
+        ? `${requestContext.method} ${requestContext.path}`
+        : (requestContext.path ?? requestContext.url);
+
+    const whereSuffix = where ? ` ${where}` : "";
+
+    const debugDump: Record<string, unknown> = {
+      request: requestContext,
+    };
+
+    if (error instanceof ORPCError) {
+      const code = typeof error.code === "string" ? error.code : String(error.code);
+      const status = typeof error.status === "number" ? error.status : undefined;
+
+      debugDump.error = {
+        type: "ORPCError",
+        code,
+        status,
+        message: error.message,
+        data: toJsonSafe(error.data, { depth: 6, seen: new WeakSet() }),
+        stack: error.stack,
+      };
+
+      const validation = getValidationErrorInfo(error.cause);
+      if (validation) {
+        debugDump.cause = {
+          type: "ValidationError",
+          message: validation.message,
+          issues: toJsonSafe(validation.issues, { depth: 6, seen: new WeakSet() }),
+          data: toJsonSafe(validation.data, { depth: 6, seen: new WeakSet() }),
+        };
+
+        const lines: string[] = [];
+        lines.push(
+          `ORPC${whereSuffix}: ${code} ${error.message}${
+            status !== undefined ? ` (status ${status})` : ""
+          }`
+        );
+
+        if (validation.issues.length > 0) {
+          const maxIssues = 5;
+          lines.push(`Validation issues (${validation.issues.length}):`);
+
+          for (const issue of validation.issues.slice(0, maxIssues)) {
+            const path = formatIssuePath(issue.path);
+            lines.push(`  - ${path}: ${issue.message}`);
+          }
+
+          if (validation.issues.length > maxIssues) {
+            lines.push(`  (+${validation.issues.length - maxIssues} more)`);
+          }
+        }
+
+        lines.push(`Data: ${summarizeForLogs(validation.data, 1)}`);
+
+        return {
+          message: lines.join("\n"),
+          debugDump,
+        };
+      }
+
+      // Non-validation ORPC error.
+      debugDump.cause = toJsonSafe(error.cause, { depth: 6, seen: new WeakSet() });
+
+      return {
+        message: `ORPC${whereSuffix}: ${code} ${error.message}${
+          status !== undefined ? ` (status ${status})` : ""
+        }`,
+        debugDump,
+      };
+    }
+
+    // Unknown error shape.
+    debugDump.error = toJsonSafe(error, { depth: 6, seen: new WeakSet() });
+
+    return {
+      message: `ORPC${whereSuffix}: ${formatUnknown(error)}`,
+      debugDump,
+    };
+  } catch (formatError) {
+    // Best-effort: formatting should never crash the server.
+    const fallback = `ORPC: Failed to format error: ${formatUnknown(formatError)}\nOriginal error: ${formatUnknown(error)}`;
+
+    return {
+      message: fallback,
+      debugDump: {
+        formatError: toJsonSafe(formatError, { depth: 4, seen: new WeakSet() }),
+        originalError: toJsonSafe(error, { depth: 4, seen: new WeakSet() }),
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Summary
Improve oRPC error logging so “Output validation failed” (and similar) errors are readable and actionable instead of collapsing into `[Object]` / `[Array]`.

## Background
Mux currently logs raw oRPC error objects in both the node HTTP server and the desktop MessagePort handler, which makes validation errors difficult to diagnose.

## Implementation
- Added a defensive `formatOrpcError()` helper that:
  - extracts request context (method + path)
  - expands `ValidationError` issues into readable `path: message` lines
  - redacts sensitive headers
  - produces a JSON-safe debug dump payload
- Updated the node oRPC server default `onOrpcError` handler to log the formatted message and dump structured details to `~/.mux/debug_obj/orpc/*.json` in debug mode.
- Updated the desktop MessagePort oRPC handler to log the same formatted message.
- Fixed `uiLayouts` schema drift by allowing the optional `allowShift` field in `KeybindSchema` (strict schemas were rejecting normalized config objects).

## Validation
- `make static-check`
- `make test-unit`

## Risks
Low. Changes are isolated to logging/formatting paths and a backwards-compatible schema tweak.

---

<details>
<summary>📋 Implementation Plan</summary>

# Improve ORPC output-validation error logs

## Context / Why
Running `make start` currently emits repeated oRPC errors like **“Output validation failed”** where the nested details collapse into `[Object]` / `[Array]`, making it hard to see **what field failed** and **which ORPC call produced it**.

Goal: make ORPC errors actionable in terminal logs by:
- showing **where** (route/procedure) the error happened
- showing **what** failed (validation issues paths/messages + small payload summary)
- optionally dumping full details to `~/.mux/debug_obj/` in debug mode

## Evidence (what we verified)
- `src/node/orpc/server.ts` default handler logs raw objects: `log.error("ORPC Error:", error);` (line ~143).
- `src/desktop/main.ts` message-port handler logs raw objects: `console.error("ORPC Error:", error);` (lines ~346–348).
- `onError()` from `@orpc/shared` calls the callback as `callback(error, options, ...rest)` so we can log request context. (`node_modules/@orpc/shared/dist/index.mjs`).
- Output validation failures are thrown as `ORPCError("INTERNAL_SERVER_ERROR", { message: "Output validation failed", cause: new ValidationError({ issues, data: output }) })`. (`node_modules/@orpc/server/dist/shared/server.Ds4HPpvH.mjs`).
- `ValidationError` exposes `issues: StandardSchemaV1.Issue[]` + `data`. (`node_modules/@orpc/contract/dist/shared/contract.TuRtB1Ca.d.ts`).
- Likely concrete offender from the sample payload `{ version: 2, slots: [...] }`: `uiLayouts.getAll` returns persisted config without normalization, while the output schema is strict (`LayoutPresetsConfigSchema`). (`src/node/orpc/router.ts`, `src/common/orpc/schemas/uiLayouts.ts`).

---

## Recommended approach (A): add a real ORPC error formatter + include request route
**Net new product LoC:** ~80–130

### 1) Add a small formatter helper (new file)
Create a tiny, dependency-light helper (e.g. `src/node/orpc/formatOrpcError.ts` or `src/common/utils/formatOrpcError.ts`) that:
- Accepts `error: unknown` and optional `{ method, url, prefix }` extracted from the interceptor `options`.
- Never throws (wrap in `try/catch`, fallback to `String(error)`).
- Produces a readable, mostly single-line summary, plus a multiline “details” block when useful.

**Formatting rules:**
- If `error` is `ORPCError`:
  - include `code`, `status` (if present), `message`
  - if `error.cause` looks like a `ValidationError` (has `issues`), format issues like:
    - `path.to.field: message` (limit first 3–5, show `(+N more)`)
  - include a small `cause.data` summary (top-level keys + array lengths), not full dump.
- For everything else:
  - include `error.message` and `error.stack` if available.
- Use `node:util` `inspect()` as the final fallback with explicit options (e.g. `depth: 5`, `maxArrayLength: 50`) to avoid `[Object]` / `[Array]`.

### 2) Use the formatter in the server ORPC handler
Update `src/node/orpc/server.ts`:
- Change `onOrpcError` default to `(error, options) => { ... }`.
- Log *where* from `options.request.method` + `options.request.url` (or at least pathname).
- Log formatted summary instead of raw `error`.
- Keep the existing UNAUTHORIZED suppression.

**Debug mode:**
- When `log.isDebugMode()` is true, `log.debug_obj()` a JSON object containing:
  - request method/url (and maybe headers with `authorization` redacted)
  - `error.code/status/message/stack`
  - `cause.issues` and `cause.data`

### 3) Use the formatter in the desktop MessagePort ORPC handler
Update `src/desktop/main.ts`:
- Change the message-port interceptor to `(error, options) => { ... }`.
- Print the same formatted summary (via `console.error`) and include `options.request.url` if present.

### 4) Tests (unit-level)
Add a small test suite for the formatter:
- “Validation error prints issues paths/messages (no `[Object]`)”.
- “Non-object / weird errors don’t crash formatter”.
- If feasible, construct a real `ValidationError` + `ORPCError` instance; otherwise mock the minimal shape (`{ code, message, cause: { issues, data } }`).

---

## Optional follow-up (B): stop the spam by self-healing `uiLayouts.getAll`
**Net new product LoC:** ~20–80

Update `src/node/orpc/router.ts` `uiLayouts.getAll` to return a sanitized shape that always satisfies the output schema:
- `return normalizeLayoutPresetsConfig(config.layoutPresets ?? DEFAULT_LAYOUT_PRESETS_CONFIG);`

<details>
<summary>Tradeoffs / why this might still be needed even after better logs</summary>

Even with better logs, this particular error can spam continuously during startup if a persisted config contains extra/malformed keys. Self-healing avoids repeated INTERNAL_SERVER_ERRORs and aligns with mux’s “don’t brick on malformed persisted state” doctrine.

Note: current normalization does not deeply strip unknown keys inside nested layout nodes; if that’s the real cause, either:
- enhance normalization to rebuild layout nodes strictly, OR
- consider changing the zod schemas for these persisted-config shapes from `.strict()` to `.strip()` so unknown keys are dropped instead of erroring.
</details>

---

## Optional follow-up (C): rate-limit duplicate ORPC error logs
**Net new product LoC:** ~20–40

If the same formatted `(route + code + first issue)` repeats rapidly, suppress duplicates for a short window (e.g. 5–10s) with a tiny in-memory LRU.

---

## Validation / Done-ness checklist
- `make start` logs show ORPC errors with:
  - request method + URL/path
  - expanded validation issues (no `[Object]` / `[Array]`)
  - clear “output vs input validation” distinction
- With `MUX_DEBUG=1`, a debug dump is written under `~/.mux/debug_obj/` for deep inspection.

</details>

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: "openai:gpt-5.2" • Thinking: "xhigh" • Cost: $4.09_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=4.09 -->
