### PR TITLE
🤖 fix: trust Explore reports in Plan Mode prompt

### DIFF
--- a/src/common/utils/ui/modeUtils.test.ts
+++ b/src/common/utils/ui/modeUtils.test.ts
@@ -31,6 +31,7 @@ describe("getPlanModeInstruction", () => {
   it("includes sub-agent delegation guidance", () => {
     const instruction = getPlanModeInstruction("/tmp/plan.md", false);
 
+    expect(instruction).toContain("Trust Explore sub-agent reports as authoritative");
     expect(instruction).toContain('MUST ONLY spawn `agentId: "explore"` tasks');
     expect(instruction).toContain("Do NOT call `propose_plan` until");
   });

--- a/src/common/utils/ui/modeUtils.ts
+++ b/src/common/utils/ui/modeUtils.ts
@@ -32,6 +32,7 @@ If you need investigation (codebase exploration, tracing callsites, locating pat
 - Use \`agentId: "explore"\` for read-only repo/code exploration and optional web lookups when relevant.
 - In each task prompt, specify explicit deliverables (what questions to answer, what files/symbols to locate, and the exact output format you want back).
 - Prefer running multiple Explore tasks in parallel with \`run_in_background: true\`, then use \`task_await\` (optionally with \`task_ids\`) until all spawned tasks are \`completed\`.
+- Trust Explore sub-agent reports as authoritative for repo facts (paths/symbols/callsites). Do not redo the same investigation yourself; only re-check if the report is ambiguous or contradicts other evidence.
 - While Explore tasks run, do NOT perform broad repo exploration yourself. Wait for the reports, then synthesize the plan in this session.
 - Do NOT call \`propose_plan\` until you have awaited and incorporated sub-agent reports.
 


### PR DESCRIPTION
## Summary
Add explicit Plan Mode guidance to trust Explore sub-agent reports, so the main agent doesn't re-run the same repo investigation work.

## Background
Plan Mode already encourages delegating investigation to Explore sub-agents, but without an explicit “trust the report” rule the parent agent can still waste time/tokens re-checking the same file facts.

## Implementation
- Added a Plan Mode instruction bullet: trust Explore sub-agent reports for repo facts and only re-check when ambiguous/contradictory.
- Added a unit test assertion to prevent regressions in the instruction text.

## Validation
- `make static-check`

## Risks
Low. This is prompt text + test only. The new guidance still allows spot-checking when reports are unclear or conflict with other evidence.

---

<details>
<summary>📋 Implementation Plan</summary>

# Update Plan Mode prompt to trust sub-agent reports

## Context / Why
Plan Mode currently instructs the agent to delegate investigation to Explore sub-agents, but it *does not explicitly say* that the parent agent may rely on those sub-agent reports without re-doing the same verification itself. Adding this guidance reduces duplicated repo exploration and makes Plan Mode faster/less token-wasteful.

## Evidence
- `src/common/utils/ui/modeUtils.ts` → `getPlanModeInstruction()` is the canonical runtime Plan Mode instruction injector; its “delegate to Explore sub-agents” section currently has no trust guidance.
- `src/node/builtinAgents/plan.md` contains the base Plan agent text (including “Investigation step (required)”) but also does not mention trusting sub-agent findings.
- `src/common/utils/ui/modeUtils.test.ts` asserts key Plan Mode instruction fragments; it should be extended to cover the new trust guidance.

## Recommended approach (minimal + canonical)
**Edit `getPlanModeInstruction()` to explicitly trust Explore reports and avoid redundant verification.** *(net +3 LoC product code)*

1. **Switch to Exec mode** (Plan Mode can only edit the plan file).
2. **Update Plan Mode instruction text** in `src/common/utils/ui/modeUtils.ts`:
   - In the sub-agent delegation bullet list (around the existing “In each task prompt, specify explicit deliverables…” line), insert a new bullet such as:
     - “Trust Explore sub-agent reports as authoritative for repo facts (paths/symbols/callsites). Do not redo the same investigation yourself; only re-check if the report is ambiguous or contradicts other evidence.”
   - Keep the tone consistent with surrounding rules; avoid unconditional language that conflicts with other correctness directives.
3. **Update unit tests** in `src/common/utils/ui/modeUtils.test.ts`:
   - Extend the “includes sub-agent delegation guidance” test to assert the new trust wording is present.
4. **(Optional) Align base Plan agent copy** in `src/node/builtinAgents/plan.md`:
   - Consider a small tweak to the “Investigation step (required)” paragraph to clarify that investigation can be delegated and sub-agent reports count as evidence. *(net +1–2 LoC product code)*
5. **Validate**:
   - Run `make test` (alias for `make test-unit`) to ensure prompt string + tests are consistent.
   - Sanity-check in the UI that Plan Mode additional instructions now include the new bullet.

<details>
<summary>Notes / pitfalls</summary>

- `getPlanModeInstruction()` is a template literal containing escaped backticks; ensure any added inline code formatting uses `\`` where needed.
- Keep wording precise: we want to stop *duplicative* verification (re-opening the same files just to confirm), not discourage targeted spot-checks when something is unclear.

</details>

</details>

---
_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: $0.81_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=0.81 -->
