### PR TITLE
🤖 fix: accept command alias for bash tool

### DIFF
--- a/src/common/utils/tools/toolDefinitions.test.ts
+++ b/src/common/utils/tools/toolDefinitions.test.ts
@@ -15,6 +15,46 @@ describe("TOOL_DEFINITIONS", () => {
     }
   });
 
+  it("accepts bash tool calls using command (alias for script)", () => {
+    const parsed = TOOL_DEFINITIONS.bash.schema.safeParse({
+      command: "ls",
+      timeout_secs: 60,
+      run_in_background: false,
+      display_name: "Test",
+    });
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.script).toBe("ls");
+      expect("command" in parsed.data).toBe(false);
+    }
+  });
+
+  it("prefers script when both script and command are provided", () => {
+    const parsed = TOOL_DEFINITIONS.bash.schema.safeParse({
+      script: "echo hi",
+      command: "ls",
+      timeout_secs: 60,
+      run_in_background: false,
+      display_name: "Test",
+    });
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.script).toBe("echo hi");
+    }
+  });
+
+  it("rejects bash tool calls missing both script and command", () => {
+    const parsed = TOOL_DEFINITIONS.bash.schema.safeParse({
+      timeout_secs: 60,
+      run_in_background: false,
+      display_name: "Test",
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
   it("asks for clarification via ask_user_question (instead of emitting open questions)", () => {
     expect(TOOL_DEFINITIONS.ask_user_question.description).toContain(
       "MUST be used when you need user clarification"


### PR DESCRIPTION
Summary
- Accepts legacy `command` as an alias for `script` in the `bash` tool args schema.
- Prevents schema validation failures that caused bash tool calls to fail execution or render as `GenericToolCall`.

Background
Some models occasionally emit `{ "command": "..." }` for the bash tool. Mux expects `{ "script": "..." }`, so those tool calls failed validation.

Implementation
- Added a `z.preprocess` shim on `TOOL_DEFINITIONS.bash.schema` to normalize `command → script`.
- Dropped the legacy `command` field during normalization to keep args canonical.
- Added unit tests covering alias acceptance, precedence, and missing-field rejection.

Validation
- `make static-check`

Risks
Low. This only broadens accepted input for the `bash` tool schema; existing `{ script: ... }` calls are unchanged.

---

<details>
<summary>📋 Implementation Plan</summary>

# Accept `command` alias for `bash` tool args (Zod-only)

## Context / Why
Some LLMs occasionally emit `{"command": "…"}` when calling the `bash` tool, but Mux currently expects `{"script": "…"}`. Today that tool call fails schema validation, which means:
- The tool won’t execute.
- The UI may fall back to `GenericToolCall` rendering.
- Tool-call repair may kick in unnecessarily.

Goal: make Mux tolerant to `command` as a legacy/alias field while keeping `script` as the canonical field everywhere.

## Evidence
- `src/common/utils/tools/toolDefinitions.ts` defines `TOOL_DEFINITIONS.bash.schema` and already uses aliasing patterns elsewhere (e.g. `task` supports deprecated `subagent_type`).
- `src/node/services/tools/bash.ts` consumes validated args as `{ script, timeout_secs, run_in_background, display_name }`.
- `src/node/services/streamManager.ts` persists/emits `part.input` from the AI SDK’s parsed tool call.
- AI SDK parses + validates tool call JSON via the tool’s `inputSchema` and uses the **validated value** as `part.input` (see `node_modules/ai/dist/index.js` `parseToolCall/doParseToolCall`). This means normalizing in Zod should propagate to stored history + UI.

## Recommended approach (A): Zod `preprocess` remap (minimal)
**Net new product LoC:** ~10–20

### Key idea
Keep the canonical schema shape the same (`script` required) but wrap it in a Zod `preprocess` that:
- If `script` is missing and `command` is a string, copies `command → script`.
- Otherwise, leaves input unchanged.

Because the inner schema is still `{ script: string; … }`, all downstream code can remain unchanged.

### Implementation steps
1. **Add a normalization wrapper** in `src/common/utils/tools/toolDefinitions.ts` around `TOOL_DEFINITIONS.bash.schema`:
   - Use `z.preprocess((value) => { … }, z.object({ script: …, timeout_secs: …, run_in_background: …, display_name: … }))`.
   - Defensive checks:
     - Only treat `value` as a plain object when `typeof value === "object" && value !== null`.
     - Only remap when `typeof obj.command === "string"` and `typeof obj.script !== "string"`.
   - Add an inline comment documenting this as a compatibility alias for model/tool-call variance.

2. **No changes expected** in:
   - `src/node/services/tools/bash.ts` (still destructures `script`).
   - UI components (tool-call args stored/emitted should now contain `script`).
   - Shared types (`BashToolArgs` can remain `script: string`).

3. **Add unit coverage** in `src/common/utils/tools/toolDefinitions.test.ts`:
   - `TOOL_DEFINITIONS.bash.schema.safeParse({ command: "ls", timeout_secs: 60, run_in_background: false, display_name: "Test" })` should succeed.
   - Assert `parsed.data.script === "ls"`.
   - Optional: a precedence test where both are supplied (`script` wins).

4. **Sanity-check tool-call rendering** (manual / smoke): run an AI session or a small harness that injects a tool call with `{command: …}` and confirm it executes and renders as BashToolCall.

### Notes / gotchas
- This is “pure Zod” for the runtime boundary, but it does introduce a ZodEffects wrapper. If anything relies on introspecting the schema as a plain `z.object`, update those call sites to treat it as generic `z.ZodType` (most already do).

## Alternative approach (B): Explicit union + downstream handling
**Net new product LoC:** ~40–80

Define `bash` args as a union of:
- `{ script: string, … }`
- `{ command: string, … }`

Then update backend/UI/types to resolve `script` vs `command` everywhere (including rendering). This is more invasive and spreads alias handling across the codebase.

## Optional follow-up (separate PR): fix tool-schema JSON generation used for token counting
**Net new product LoC:** ~10–30

`getToolSchemas()` currently uses `zod-to-json-schema`, which appears to produce empty schemas under Zod v4. Consider switching token-counting schema generation to `@ai-sdk/provider-utils` (`asSchema(zod).jsonSchema`) so token estimates better match what the model actually receives.

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: $3.20_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=3.20 -->
