### PR TITLE
🤖 fix: prevent duplicate stream on SSH workspace first message

### DIFF
--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -834,7 +834,9 @@ export class AgentSession {
     const { model } = options;
     assert(typeof model === "string" && model.trim().length > 0, "resumeStream requires a model");
 
-    if (this.aiService.isStreaming(this.workspaceId)) {
+    // Guard against auto-retry starting a second stream while the initial send is
+    // still waiting for init hooks to complete.
+    if (this.streamStarting || this.aiService.isStreaming(this.workspaceId)) {
       return Ok(undefined);
     }
 


### PR DESCRIPTION
## Summary

Fixes a race condition where SSH workspaces produce duplicate responses on the first message. The auto-retry system (`useResumeManager`) was starting a second stream while the initial `sendMessage()` was still waiting for init hooks to complete.

## Background

On SSH workspaces with slow init (e.g., Coder or remote hosts), the timeline was:
1. `sendMessage()` sets `streamStarting = true`, then awaits `waitForInit()`
2. Init takes seconds; frontend polling sees last message is `type: "user"` (no assistant response yet)
3. Init completes → auto-retry eligibility check passes
4. `resumeStream()` only checked `isStreaming()` which was `false` (StreamManager not started yet)
5. **Two concurrent streams** run: original `sendMessage` + spurious `resumeStream`

## Implementation

Add `streamStarting` to the guard in `resumeStream()`:

```typescript
if (this.streamStarting || this.aiService.isStreaming(this.workspaceId)) {
  return Ok(undefined);
}
```

This prevents auto-retry from starting a second stream while the initial send is waiting on init hooks.

## Risks

**Low.** This is a minimal, surgical fix that adds a single guard check. The `streamStarting` flag already exists and is correctly managed by `sendMessage()`/`resumeStream()` in their try/finally blocks. The only change is consulting it earlier in `resumeStream()`.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$12.75`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=12.75 -->
