### PR TITLE
🤖 fix: normalize MCP tool names for provider validation

### DIFF
--- a/src/common/utils/tools/mcpToolName.test.ts
+++ b/src/common/utils/tools/mcpToolName.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+
+import { uniqueSuffix } from "@/common/utils/hasher";
+
+import { buildMcpToolName, normalizeMcpToolNamePart } from "./mcpToolName";
+
+describe("mcpToolName", () => {
+  describe("normalizeMcpToolNamePart", () => {
+    test("lowercases and replaces spaces with underscores", () => {
+      expect(normalizeMcpToolNamePart("Chrome DevTools")).toBe("chrome_devtools");
+    });
+
+    test("treats non-alphanumeric characters as separators", () => {
+      expect(normalizeMcpToolNamePart("chrome-devtools/mcp")).toBe("chrome_devtools_mcp");
+    });
+
+    test("falls back to 'unknown' when nothing is left after sanitization", () => {
+      expect(normalizeMcpToolNamePart("!!!")).toBe("unknown");
+    });
+  });
+
+  describe("buildMcpToolName", () => {
+    test("builds a stable base name for provider-safe MCP tools", () => {
+      const usedNames = new Set<string>();
+      const result = buildMcpToolName({
+        serverName: "Chrome DevTools",
+        toolName: "click",
+        usedNames,
+      });
+
+      expect(result).toEqual({
+        toolName: "chrome_devtools_click",
+        baseName: "chrome_devtools_click",
+        wasSuffixed: false,
+      });
+    });
+
+    test("adds a stable suffix on collision", () => {
+      const usedNames = new Set<string>();
+
+      const first = buildMcpToolName({ serverName: "foo bar", toolName: "baz", usedNames });
+      expect(first).toBeDefined();
+      expect(first!.toolName).toBe("foo_bar_baz");
+      expect(first!.wasSuffixed).toBe(false);
+
+      const second = buildMcpToolName({ serverName: "foo_bar", toolName: "baz", usedNames });
+      expect(second).toBeDefined();
+      expect(second!.baseName).toBe("foo_bar_baz");
+      expect(second!.wasSuffixed).toBe(true);
+
+      const expectedSuffix = uniqueSuffix(["foo_bar", "baz"]);
+      expect(second!.toolName).toBe(`foo_bar_baz_${expectedSuffix}`);
+    });
+
+    test("enforces the 64 character limit via truncation + suffix", () => {
+      const usedNames = new Set<string>();
+
+      const serverName = "a".repeat(60);
+      const toolName = "b".repeat(10);
+
+      const result = buildMcpToolName({ serverName, toolName, usedNames });
+      expect(result).toBeDefined();
+      expect(result!.wasSuffixed).toBe(true);
+      expect(result!.toolName.length).toBe(64);
+
+      const expectedSuffix = uniqueSuffix([serverName, toolName]);
+      expect(result!.toolName.endsWith(`_${expectedSuffix}`)).toBe(true);
+      expect(result!.toolName).toMatch(/^[a-z0-9_]+$/);
+    });
+  });
+});

--- a/src/common/utils/tools/mcpToolName.ts
+++ b/src/common/utils/tools/mcpToolName.ts
@@ -1,0 +1,112 @@
+import { uniqueSuffix } from "@/common/utils/hasher";
+
+const DEFAULT_MCP_TOOL_NAME_PART = "unknown";
+
+// Be conservative: some providers have strict tool-name validation and limits.
+export const MAX_MCP_TOOL_NAME_CHARS = 64;
+
+const MCP_TOOL_NAME_PATTERN = /^[a-z0-9_]+$/;
+
+/**
+ * Normalize a single component used to build an MCP tool name.
+ *
+ * Note: This is NOT user-facing. It's purely to ensure provider-safe tool keys.
+ */
+export function normalizeMcpToolNamePart(input: string): string {
+  const normalized = input
+    .normalize("NFKD")
+    .toLowerCase()
+    // Replace whitespace and any non-[a-z0-9_] characters with underscores.
+    // (Treat '-' as '_' too for maximum provider compatibility.)
+    .replace(/[^a-z0-9_]+/g, "_")
+    // Collapse consecutive underscores.
+    .replace(/_+/g, "_")
+    // Trim leading/trailing underscores.
+    .replace(/^_+|_+$/g, "");
+
+  return normalized.length > 0 ? normalized : DEFAULT_MCP_TOOL_NAME_PART;
+}
+
+export interface BuildMcpToolNameOptions {
+  serverName: string;
+  toolName: string;
+  usedNames: Set<string>;
+}
+
+export interface BuildMcpToolNameResult {
+  toolName: string;
+  /**
+   * The normalized tool name without any collision/truncation suffix.
+   * Useful for debugging/logging.
+   */
+  baseName: string;
+  /** True when we added a hash suffix due to collision or length constraints. */
+  wasSuffixed: boolean;
+}
+
+function buildMcpToolNameWithSuffix(baseName: string, suffix: string): string {
+  // Ensure we always fit the suffix + separator.
+  const trimmedSuffix = suffix.slice(0, 8);
+  const suffixWithSeparator = `_${trimmedSuffix}`;
+
+  const maxBaseLength = MAX_MCP_TOOL_NAME_CHARS - suffixWithSeparator.length;
+  if (maxBaseLength <= 0) {
+    return `tool${suffixWithSeparator}`.slice(0, MAX_MCP_TOOL_NAME_CHARS);
+  }
+
+  const trimmedBase = baseName.slice(0, maxBaseLength).replace(/_+$/g, "") || "tool";
+  return `${trimmedBase}${suffixWithSeparator}`;
+}
+
+/**
+ * Build a provider-safe, collision-resistant MCP tool name.
+ *
+ * The tool name is derived from `${serverName}_${toolName}`, but normalized to:
+ * - lowercase
+ * - underscore-delimited
+ * - <= 64 characters
+ * - [a-z0-9_]+ only
+ *
+ * If the normalized name collides with an existing tool name (or exceeds 64 chars),
+ * a stable hash suffix is appended.
+ */
+export function buildMcpToolName(options: BuildMcpToolNameOptions): BuildMcpToolNameResult | null {
+  const serverPart = normalizeMcpToolNamePart(options.serverName);
+  const toolPart = normalizeMcpToolNamePart(options.toolName);
+  const baseName = `${serverPart}_${toolPart}`;
+
+  if (!MCP_TOOL_NAME_PATTERN.test(baseName)) {
+    return null;
+  }
+
+  let finalName = baseName;
+  let wasSuffixed = false;
+
+  if (finalName.length > MAX_MCP_TOOL_NAME_CHARS || options.usedNames.has(finalName)) {
+    wasSuffixed = true;
+
+    // Use a stable suffix derived from the *original* server/tool names so that renaming
+    // only happens when necessary (collisions/length), and remains deterministic.
+    const suffix = uniqueSuffix([options.serverName, options.toolName]);
+    finalName = buildMcpToolNameWithSuffix(baseName, suffix);
+
+    // Extremely defensive: in the astronomically unlikely case of a hash collision,
+    // attempt a second derivation before giving up.
+    if (options.usedNames.has(finalName)) {
+      const suffix2 = uniqueSuffix([options.serverName, options.toolName, "2"]);
+      finalName = buildMcpToolNameWithSuffix(baseName, suffix2);
+
+      if (options.usedNames.has(finalName)) {
+        return null;
+      }
+    }
+  }
+
+  if (!MCP_TOOL_NAME_PATTERN.test(finalName) || finalName.length > MAX_MCP_TOOL_NAME_CHARS) {
+    return null;
+  }
+
+  options.usedNames.add(finalName);
+
+  return { toolName: finalName, baseName, wasSuffixed };
+}

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -422,7 +422,8 @@ describe("MCPServerManager", () => {
       },
     });
 
-    expect(Object.keys(toolsResult.tools)).toContain("serverA_tool");
-    expect(Object.keys(toolsResult.tools)).not.toContain("serverB_tool");
+    // Tool names are normalized to provider-safe keys (lowercase + underscore-delimited).
+    expect(Object.keys(toolsResult.tools)).toContain("servera_tool");
+    expect(Object.keys(toolsResult.tools)).not.toContain("serverb_tool");
   });
 });

--- a/tests/ipc/mcpConfig.test.ts
+++ b/tests/ipc/mcpConfig.test.ts
@@ -329,7 +329,7 @@ describeIntegration("MCP server integration with model", () => {
         console.log("[MCP Test] Adding MCP server...");
         const addResult = await client.projects.mcp.add({
           projectPath: tempGitRepo,
-          name: "memory",
+          name: "memory server",
           command: "npx -y @modelcontextprotocol/server-memory",
         });
         expect(addResult.success).toBe(true);
@@ -374,8 +374,10 @@ describeIntegration("MCP server integration with model", () => {
         // Should have at least one tool call
         expect(toolCallStarts.length).toBeGreaterThan(0);
 
-        // Should have called the MCP memory tool (namespaced as memory_create_entities)
-        const mcpToolCall = toolCallStarts.find((e) => e.toolName === "memory_create_entities");
+        // Should have called the MCP memory tool (namespaced as memory_server_create_entities)
+        const mcpToolCall = toolCallStarts.find(
+          (e) => e.toolName === "memory_server_create_entities"
+        );
         expect(mcpToolCall).toBeDefined();
 
         // Verify response mentions the entity was created


### PR DESCRIPTION
## Summary
Normalize namespaced MCP tool keys so they always satisfy provider tool-name validation (regex + 64-char cap), even when the MCP server name contains spaces or other non-identifier characters.

## Background
Mux currently namespaces MCP tools as `${serverName}_${toolName}`. When a user configures an MCP server name with spaces (e.g. `Chrome DevTools`), the resulting tool key contains spaces and some providers reject the request before any tool can run.

## Implementation
- Added `buildMcpToolName()` helper to:
  - normalize server/tool name parts (lowercase + underscore-delimited)
  - enforce `^[a-z0-9_]+$` and a 64-character limit
  - append a deterministic hash suffix when truncation/collision is required
- Updated `MCPServerManager.collectTools()` to use the normalized tool names (with stable sorting for deterministic collision handling).
- Added unit tests for the normalizer/key builder and updated MCP integration coverage with a server name containing spaces.

## Validation
- `make static-check`

## Risks
- MCP tool keys may change for servers whose names previously contained characters like spaces or `-`. This could require updating any user-configured tool policies that match on the old names.

---

<details>
<summary>📋 Implementation Plan</summary>

# MCP tool name normalization (spaces in server name break provider validation)

## Context / Why
Mux namespaces MCP tools as `${serverName}_${toolName}` to avoid collisions. If the user names an MCP server with spaces (e.g. `"Chrome DevTools"`), the resulting tool keys contain spaces (e.g. `"Chrome DevTools_click"`). Several providers/SDKs validate tool names against a strict identifier regex (e.g. `[a-zA-Z0-9_-]+`, often with a 64-char limit), so the stream fails before any tool can run.

**Goal:** Make MCP tool *keys* provider-safe (spaces → `_`, lowercase, etc.) in a way that:
- fixes existing configs immediately (no migration required),
- stays deterministic across runs,
- avoids collisions,
- does not break server overrides/tool allowlists that are keyed by the original server name.

## Evidence (repo pointers)
- `src/node/services/mcpServerManager.ts::collectTools()` currently builds namespaced tool keys as:
  - `const namespacedName = `${instance.name}_${toolName}`;` (line ~828)
- MCP server names come from user input and are persisted as keys in `.mux/mcp.jsonc` without pattern validation:
  - UI trims only: `ProjectSettingsSection.tsx::handleAddServer()`
  - Backend check is only `if (!name.trim())`: `src/node/services/mcpConfigService.ts::addServer()`
  - ORPC schema: `src/common/orpc/schemas/mcp.ts::MCPAddParamsSchema` uses `name: z.string()` (no regex)
- Workspace overrides and tool allowlists are keyed by **server name** and raw MCP tool names (not namespaced):
  - `src/common/orpc/schemas/mcp.ts::WorkspaceMCPOverridesSchema` (comment + schema)
- Mux does not validate tool keys before handing them to the AI SDK; provider/SDK validation surfaces the regex error:
  - `src/common/utils/tools/tools.ts::getToolsForModel()` merges `mcpTools` directly into the tool map.

## Recommended approach: normalize MCP *namespaced tool keys* at aggregation time (≈ +80 LoC product)

### 1) Introduce a small, reusable normalizer
Add a helper (proposal: `src/common/utils/tools/normalizeToolName.ts` or `src/common/utils/identifiers.ts`) to normalize a single identifier “part”:
- lowercase
- replace whitespace and any non-`[a-z0-9_]` character with `_`
  - (treat `-` as `_` too for maximum provider compatibility)
- collapse consecutive underscores
- trim leading/trailing underscores
- return a fallback (`"unknown"`) if the result is empty

### 2) Build deterministic, provider-safe MCP tool keys
Add a helper (can live alongside the normalizer) that produces the final tool key:
- Inputs: `serverName: string`, `mcpToolName: string`
- Base: `${norm(serverName)}_${norm(mcpToolName)}`
- Enforce constraints:
  - must match `^[a-z0-9_]+$`
  - must be **≤ 64 chars** (use the most restrictive common limit)
- Collision handling (deterministic):
  - keep a `Set` of emitted tool keys during aggregation
  - if the base key collides (or needs truncation), append a short stable suffix derived from the original full name (e.g. DJB2 hash hex of `${serverName}_${mcpToolName}`):
    - `chrome_devtools_click_ab12cd`
  - ensure the suffix logic itself respects the 64-char limit by truncating the base before adding `_suffix`

**Defensive behavior:** If (unexpectedly) a valid key cannot be produced, log an error and *skip that tool* rather than crashing or bricking the entire stream.

### 3) Apply normalization in `MCPServerManager.collectTools()`
Change:
- `aggregated[`${instance.name}_${toolName}`] = tool;`

To:
- `const toolKey = buildMcpToolKey({ serverName: instance.name, toolName });`
- `if (toolKey) aggregated[toolKey] = tool;`

This fixes the bug without touching persisted server names (so `.mux/mcp.jsonc` and workspace overrides remain valid).

### 4) Logging + model context (optional)
- If normalization changes the key (or collision suffix is applied), add `log.debug`/`log.warn` with `{ serverName, toolName, originalKey, toolKey }`.
- Optionally enrich MCP tool descriptions so the model still sees the “pretty” names even though the key is sanitized.

### 5) Tests
- Unit tests for the normalizer + key builder:
  - spaces → `_`, uppercase → lowercase, invalid chars
  - collision disambiguation
  - 64-char enforcement
- Integration test (or extend existing `tests/ipc/mcpConfig.test.ts`):
  - add a server named `"Chrome DevTools"`
  - ensure the emitted `tool-call-start.toolName` matches the sanitized form (e.g. `chrome_devtools_create_entities`)

## Alternatives (with tradeoffs)

<details>
<summary>A) Normalize/validate server name at save-time (≈ +40 LoC product, but breaking-ish)</summary>

- Update `MCPAddParamsSchema` to restrict/normalize `name`, and update `MCPConfigService.addServer()` to persist the normalized name.
- Downside: the server name is the **config key** and is referenced by workspace overrides (`disabledServers`, `enabledServers`, `toolAllowlist`). Renaming it requires migration and/or best-effort remapping.
</details>

<details>
<summary>B) Introduce stable server IDs (≈ +250–400 LoC product, most robust long-term)</summary>

- Persist servers as objects `{ id, displayName, ... }` and use `id` for tool namespacing.
- Pros: tool keys stable across display-name edits; avoids collisions.
- Cons: requires config format migration + UI changes + override mapping.
</details>

<details>
<summary>C) Fail fast with a clearer error message only (≈ +30–60 LoC product)</summary>

- Validate tool keys before calling the provider and show an actionable message.
- Improves UX but does not fix the underlying ergonomics; still requires the user to rename the server.
</details>

## Rollout / acceptance criteria
- A server named with spaces (e.g. `Chrome DevTools`) no longer causes provider tool-name validation errors.
- Generated MCP tool keys are deterministic and satisfy the strictest provider regex/length constraints.
- Existing `.mux/mcp.jsonc` and `.mux/mcp.local.jsonc` continue to work unchanged.


</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: $1.51_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=1.51 -->
