### PR TITLE
🤖 fix: use Windows-style path placeholder on Windows

### DIFF
--- a/src/browser/components/ProjectCreateModal.tsx
+++ b/src/browser/components/ProjectCreateModal.tsx
@@ -53,7 +53,9 @@ export const ProjectCreateForm = React.forwardRef<ProjectCreateFormHandle, Proje
       autoFocus = false,
       onIsCreatingChange,
       submitLabel = "Add Project",
-      placeholder = "/home/user/projects/my-project",
+      placeholder = window.api?.platform === "win32"
+        ? "C:\\Users\\user\\projects\\my-project"
+        : "/home/user/projects/my-project",
       hideFooter = false,
     },
     ref


### PR DESCRIPTION
## Summary

The project create modal placeholder showed `/home/user/projects/my-project` on all platforms, which looks out of place on Windows. Now shows `C:\Users\user\projects\my-project` when running on Windows.

## Implementation

Uses `window.api?.platform` (exposed from preload) to detect Windows and show the appropriate path style.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$1.35`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=1.35 -->
