### PR TITLE
🤖 refactor: move Chat with Mux into header indicator

### DIFF
--- a/src/browser/components/WorkspaceListItem.tsx
+++ b/src/browser/components/WorkspaceListItem.tsx
@@ -2,8 +2,7 @@ import { useRename } from "@/browser/contexts/WorkspaceRenameContext";
 import { stopKeyboardPropagation } from "@/browser/utils/events";
 import { cn } from "@/common/lib/utils";
 import { useGitStatus } from "@/browser/stores/GitStatusStore";
-import { usePersistedState } from "@/browser/hooks/usePersistedState";
-import { getWorkspaceLastReadKey } from "@/common/constants/storage";
+import { useWorkspaceUnread } from "@/browser/hooks/useWorkspaceUnread";
 import { useWorkspaceSidebarState } from "@/browser/stores/WorkspaceStore";
 import { MUX_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
@@ -57,9 +56,7 @@ const WorkspaceListItemInner: React.FC<WorkspaceListItemProps> = ({
   const isCreating = status === "creating";
   const isDisabled = isCreating || isArchiving;
 
-  const [lastReadTimestamp] = usePersistedState<number>(getWorkspaceLastReadKey(workspaceId), 0, {
-    listener: true,
-  });
+  const { isUnread } = useWorkspaceUnread(workspaceId);
   const gitStatus = useGitStatus(workspaceId);
 
   // Get title edit context (renamed from rename context since we now edit titles, not names)
@@ -112,10 +109,8 @@ const WorkspaceListItemInner: React.FC<WorkspaceListItemProps> = ({
     }
   };
 
-  const { canInterrupt, awaitingUserQuestion, isStarting, recencyTimestamp } =
-    useWorkspaceSidebarState(workspaceId);
+  const { canInterrupt, awaitingUserQuestion, isStarting } = useWorkspaceSidebarState(workspaceId);
 
-  const isUnread = recencyTimestamp !== null && recencyTimestamp > lastReadTimestamp;
   const showUnreadBar = !isCreating && !isEditing && isUnread && !(isSelected && !isDisabled);
   const barColorClass =
     isSelected && !isDisabled

--- a/src/browser/hooks/useWorkspaceUnread.ts
+++ b/src/browser/hooks/useWorkspaceUnread.ts
@@ -1,0 +1,21 @@
+import { usePersistedState } from "@/browser/hooks/usePersistedState";
+import { useWorkspaceSidebarState } from "@/browser/stores/WorkspaceStore";
+import { getWorkspaceLastReadKey } from "@/common/constants/storage";
+
+/**
+ * Hook to determine if a workspace has unread messages.
+ * Returns { isUnread, lastReadTimestamp, recencyTimestamp } for flexibility.
+ */
+export function useWorkspaceUnread(workspaceId: string): {
+  isUnread: boolean;
+  lastReadTimestamp: number;
+  recencyTimestamp: number | null;
+} {
+  const [lastReadTimestamp] = usePersistedState<number>(getWorkspaceLastReadKey(workspaceId), 0, {
+    listener: true,
+  });
+  const { recencyTimestamp } = useWorkspaceSidebarState(workspaceId);
+  const isUnread = recencyTimestamp !== null && recencyTimestamp > lastReadTimestamp;
+
+  return { isUnread, lastReadTimestamp, recencyTimestamp };
+}

--- a/tests/ui/muxChatWorkspace.integration.test.ts
+++ b/tests/ui/muxChatWorkspace.integration.test.ts
@@ -154,18 +154,12 @@ describe("Chat with Mux system workspace (UI)", () => {
         { timeout: 10_000 }
       );
 
-      const muxChatRow = await waitFor(
-        () => {
-          const el = view.container.querySelector(
-            `[data-workspace-id="${MUX_CHAT_WORKSPACE_ID}"]`
-          ) as HTMLElement | null;
-          if (!el) throw new Error("mux-chat workspace not found in sidebar");
-          return el;
-        },
-        { timeout: 10_000 }
-      );
-
-      expect(muxChatRow.querySelector('button[aria-label^="Archive workspace"]')).toBeNull();
+      // Chat with Mux is no longer rendered as a WorkspaceListItem in the sidebar;
+      // it's accessed via the Mux logo / help icon in the header. Verify no workspace
+      // row exists for it (which means no Archive button by design).
+      expect(
+        view.container.querySelector(`[data-workspace-id="${MUX_CHAT_WORKSPACE_ID}"]`)
+      ).toBeNull();
 
       // Ctrl+N should not redirect to /project when mux-chat is selected.
       await act(async () => {


### PR DESCRIPTION
## Summary

Move the Chat with Mux workspace status indicator from being a separate `WorkspaceListItem` in the sidebar's scrollable area to a compact helper indicator displayed directly to the right of the Mux logo in the header.

## Implementation

- Added `WorkspaceStatusIndicator` import to `ProjectSidebar.tsx`
- Wrapped the Mux logo button and new status indicator in a flex container
- Removed the separate `WorkspaceListItem` rendering for `muxChatMetadata`
- Added `shrink-0` to the logo button and "New Project" button to prevent shrinking
- Added `min-w-0` to the container to allow the status indicator to truncate properly

The status indicator will display:
- Agent status emoji + message when the Chat with Mux workspace is active
- "Mux has a few questions" prompt when there's a pending `ask_user_question`
- Nothing when there's no active status

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.62`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=0.62 -->