### PR TITLE
🤖 refactor: clarify mux help chat workspace

### DIFF
--- a/src/browser/components/ArchivedWorkspaces.tsx
+++ b/src/browser/components/ArchivedWorkspaces.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MUX_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
+
 import { cn } from "@/common/lib/utils";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import { useWorkspaceContext } from "@/browser/contexts/WorkspaceContext";
@@ -684,14 +684,12 @@ export const ArchivedWorkspaces: React.FC<ArchivedWorkspacesProps> = ({
                             className="h-4 w-4 rounded border-gray-600 bg-transparent"
                             aria-label={`Select ${displayTitle}`}
                           />
-                          {workspace.id !== MUX_CHAT_WORKSPACE_ID && (
-                            <RuntimeBadge
-                              runtimeConfig={workspace.runtimeConfig}
-                              isWorking={false}
-                              workspacePath={workspace.namedWorkspacePath}
-                              workspaceName={workspaceNameForTooltip}
-                            />
-                          )}
+                          <RuntimeBadge
+                            runtimeConfig={workspace.runtimeConfig}
+                            isWorking={false}
+                            workspacePath={workspace.namedWorkspacePath}
+                            workspaceName={workspaceNameForTooltip}
+                          />
                           <div className="min-w-0 flex-1">
                             <div className="text-foreground truncate text-sm font-medium">
                               {displayTitle}

--- a/src/browser/components/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar.tsx
@@ -40,7 +40,7 @@ import { WorkspaceStatusIndicator } from "./WorkspaceStatusIndicator";
 import { RenameProvider } from "@/browser/contexts/WorkspaceRenameContext";
 import { useProjectContext } from "@/browser/contexts/ProjectContext";
 import { ChevronRight, CircleHelp, KeyRound } from "lucide-react";
-import { MUX_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
+import { MUX_HELP_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
 import { useWorkspaceContext } from "@/browser/contexts/WorkspaceContext";
 import { usePopoverError } from "@/browser/hooks/usePopoverError";
 import { PopoverError } from "./PopoverError";
@@ -67,7 +67,7 @@ const MuxChatHelpButton: React.FC<{
   onClick: () => void;
   isSelected: boolean;
 }> = ({ onClick, isSelected }) => {
-  const { isUnread: hasUnread } = useWorkspaceUnread(MUX_CHAT_WORKSPACE_ID);
+  const { isUnread: hasUnread } = useWorkspaceUnread(MUX_HELP_CHAT_WORKSPACE_ID);
   const isUnread = hasUnread && !isSelected;
 
   return (
@@ -307,7 +307,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
   );
 
   const handleOpenMuxChat = useCallback(() => {
-    const meta = workspaceMetadata.get(MUX_CHAT_WORKSPACE_ID);
+    const meta = workspaceMetadata.get(MUX_HELP_CHAT_WORKSPACE_ID);
 
     handleSelectWorkspace(
       meta
@@ -319,7 +319,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
           }
         : {
             // Fallback: navigate by ID; metadata will fill in once refreshed.
-            workspaceId: MUX_CHAT_WORKSPACE_ID,
+            workspaceId: MUX_HELP_CHAT_WORKSPACE_ID,
             projectPath: "",
             projectName: "Mux",
             namedWorkspacePath: "",
@@ -515,7 +515,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
 
   // Hide the built-in Chat with Mux system project from the normal projects list.
   // We still render the mux-chat workspace as a dedicated pinned row above projects.
-  const muxChatMetadata = workspaceMetadata.get(MUX_CHAT_WORKSPACE_ID);
+  const muxChatMetadata = workspaceMetadata.get(MUX_HELP_CHAT_WORKSPACE_ID);
   const muxChatProjectPath = muxChatMetadata?.projectPath ?? null;
   const visibleProjectPaths = React.useMemo(
     () =>
@@ -539,7 +539,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
       // Create new workspace for the project of the selected workspace
       if (matchesKeybind(e, KEYBINDS.NEW_WORKSPACE) && selectedWorkspace) {
         e.preventDefault();
-        if (selectedWorkspace.workspaceId === MUX_CHAT_WORKSPACE_ID) {
+        if (selectedWorkspace.workspaceId === MUX_HELP_CHAT_WORKSPACE_ID) {
           return;
         }
         handleAddWorkspace(selectedWorkspace.projectPath);
@@ -583,9 +583,9 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                     <>
                       <MuxChatHelpButton
                         onClick={handleOpenMuxChat}
-                        isSelected={selectedWorkspace?.workspaceId === MUX_CHAT_WORKSPACE_ID}
+                        isSelected={selectedWorkspace?.workspaceId === MUX_HELP_CHAT_WORKSPACE_ID}
                       />
-                      <WorkspaceStatusIndicator workspaceId={MUX_CHAT_WORKSPACE_ID} />
+                      <WorkspaceStatusIndicator workspaceId={MUX_HELP_CHAT_WORKSPACE_ID} />
                     </>
                   )}
                 </div>

--- a/src/browser/components/WorkspaceDragLayer.tsx
+++ b/src/browser/components/WorkspaceDragLayer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MUX_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
+
 import { useDragLayer } from "react-dnd";
 import { WORKSPACE_DRAG_TYPE, type WorkspaceDragItem } from "./WorkspaceSectionDropZone";
 import { RuntimeBadge } from "./RuntimeBadge";
@@ -50,9 +50,7 @@ export const WorkspaceDragLayer: React.FC = () => {
             "bg-sidebar border-border border shadow-lg"
           )}
         >
-          {workspaceItem.workspaceId !== MUX_CHAT_WORKSPACE_ID && (
-            <RuntimeBadge runtimeConfig={workspaceItem.runtimeConfig} isWorking={false} />
-          )}
+          <RuntimeBadge runtimeConfig={workspaceItem.runtimeConfig} isWorking={false} />
           <span className="text-foreground truncate text-sm">{displayTitle}</span>
         </div>
       </div>

--- a/src/browser/components/WorkspaceHeader.tsx
+++ b/src/browser/components/WorkspaceHeader.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import { Bell, BellOff, Menu, Pencil, Server } from "lucide-react";
 import { CUSTOM_EVENTS } from "@/common/constants/events";
 import { cn } from "@/common/lib/utils";
-import { MUX_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
+
 import {
   RIGHT_SIDEBAR_COLLAPSED_KEY,
   getNotifyOnResponseKey,
@@ -63,7 +63,6 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
   const { api } = useAPI();
   const openTerminalPopout = useOpenTerminal();
   const openInEditor = useOpenInEditor();
-  const isMuxChat = workspaceId === MUX_CHAT_WORKSPACE_ID;
   const gitStatus = useGitStatus(workspaceId);
   const { canInterrupt, isStarting, awaitingUserQuestion, loadedSkills } =
     useWorkspaceSidebarState(workspaceId);
@@ -212,28 +211,24 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
             <Menu className="h-3.5 w-3.5" />
           </Button>
         )}
-        {!isMuxChat && (
-          <RuntimeBadge
-            runtimeConfig={runtimeConfig}
-            isWorking={isWorking}
-            workspacePath={namedWorkspacePath}
-            workspaceName={workspaceName}
-            tooltipSide="bottom"
-          />
-        )}
+        <RuntimeBadge
+          runtimeConfig={runtimeConfig}
+          isWorking={isWorking}
+          workspacePath={namedWorkspacePath}
+          workspaceName={workspaceName}
+          tooltipSide="bottom"
+        />
         <span className="min-w-0 truncate font-mono text-xs">{projectName}</span>
-        {!isMuxChat && (
-          <div className="flex items-center gap-1">
-            <BranchSelector workspaceId={workspaceId} workspaceName={workspaceName} />
-            <GitStatusIndicator
-              gitStatus={gitStatus}
-              workspaceId={workspaceId}
-              projectPath={projectPath}
-              tooltipPosition="bottom"
-              isWorking={isWorking}
-            />
-          </div>
-        )}
+        <div className="flex items-center gap-1">
+          <BranchSelector workspaceId={workspaceId} workspaceName={workspaceName} />
+          <GitStatusIndicator
+            gitStatus={gitStatus}
+            workspaceId={workspaceId}
+            projectPath={projectPath}
+            tooltipPosition="bottom"
+            isWorking={isWorking}
+          />
+        </div>
       </div>
       <div className={cn("flex items-center gap-2", isDesktop && "titlebar-no-drag")}>
         <WorkspaceLinks workspaceId={workspaceId} />

--- a/src/browser/components/WorkspaceListItem.tsx
+++ b/src/browser/components/WorkspaceListItem.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/common/lib/utils";
 import { useGitStatus } from "@/browser/stores/GitStatusStore";
 import { useWorkspaceUnread } from "@/browser/hooks/useWorkspaceUnread";
 import { useWorkspaceSidebarState } from "@/browser/stores/WorkspaceStore";
-import { MUX_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
+import { MUX_HELP_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import React, { useState, useEffect } from "react";
 import { useDrag } from "react-dnd";
@@ -52,7 +52,7 @@ const WorkspaceListItemInner: React.FC<WorkspaceListItemProps> = ({
 }) => {
   // Destructure metadata for convenience
   const { id: workspaceId, namedWorkspacePath, status } = metadata;
-  const isMuxChat = workspaceId === MUX_CHAT_WORKSPACE_ID;
+  const isMuxHelpChat = workspaceId === MUX_HELP_CHAT_WORKSPACE_ID;
   const isCreating = status === "creating";
   const isDisabled = isCreating || isArchiving;
 
@@ -219,7 +219,7 @@ const WorkspaceListItemInner: React.FC<WorkspaceListItemProps> = ({
           unreadBar
         )}
         {/* Archive button - vertically centered against entire item */}
-        {!isMuxChat && !isCreating && !isEditing && (
+        {!isMuxHelpChat && !isCreating && !isEditing && (
           <div className="relative inline-flex h-4 w-4 shrink-0 items-center self-center">
             <Tooltip>
               <TooltipTrigger asChild>
@@ -243,21 +243,16 @@ const WorkspaceListItemInner: React.FC<WorkspaceListItemProps> = ({
         )}
         <div className="flex min-w-0 flex-1 flex-col gap-1">
           <div className="grid min-w-0 grid-cols-[auto_1fr_auto] items-center gap-1.5">
-            {!isMuxChat && (
-              <RuntimeBadge
-                runtimeConfig={metadata.runtimeConfig}
-                isWorking={isWorking}
-                tooltipSide="bottom"
-                workspaceName={metadata.name}
-                workspacePath={namedWorkspacePath}
-              />
-            )}
+            <RuntimeBadge
+              runtimeConfig={metadata.runtimeConfig}
+              isWorking={isWorking}
+              tooltipSide="bottom"
+              workspaceName={metadata.name}
+              workspacePath={namedWorkspacePath}
+            />
             {isEditing ? (
               <input
-                className={cn(
-                  "bg-input-bg text-input-text border-input-border font-inherit focus:border-input-border-focus min-w-0 flex-1 rounded-sm border px-1 text-left text-[13px] outline-none",
-                  isMuxChat ? "col-span-3" : "col-span-2"
-                )}
+                className="bg-input-bg text-input-text border-input-border font-inherit focus:border-input-border-focus col-span-2 min-w-0 flex-1 rounded-sm border px-1 text-left text-[13px] outline-none"
                 value={editingTitle}
                 onChange={(e) => setEditingTitle(e.target.value)}
                 onKeyDown={handleEditKeyDown}

--- a/src/browser/contexts/RouterContext.tsx
+++ b/src/browser/contexts/RouterContext.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import { MemoryRouter, useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { readPersistedState } from "@/browser/hooks/usePersistedState";
-import { MUX_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
+import { MUX_HELP_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
 import { SELECTED_WORKSPACE_KEY } from "@/common/constants/storage";
 import { getProjectRouteId } from "@/common/utils/projectRouteId";
 import type { WorkspaceSelection } from "@/browser/components/ProjectSidebar";
@@ -59,7 +59,7 @@ function getInitialRoute(): string {
   if (savedWorkspace?.workspaceId) {
     return `/workspace/${encodeURIComponent(savedWorkspace.workspaceId)}`;
   }
-  return `/workspace/${encodeURIComponent(MUX_CHAT_WORKSPACE_ID)}`;
+  return `/workspace/${encodeURIComponent(MUX_HELP_CHAT_WORKSPACE_ID)}`;
 }
 
 /** Sync router state to browser URL (dev server only, not Electron/Storybook). */

--- a/src/browser/contexts/WorkspaceContext.tsx
+++ b/src/browser/contexts/WorkspaceContext.tsx
@@ -13,7 +13,7 @@ import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import type { ThinkingLevel } from "@/common/types/thinking";
 import type { WorkspaceSelection } from "@/browser/components/ProjectSidebar";
 import type { RuntimeConfig } from "@/common/types/runtime";
-import { MUX_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
+import { MUX_HELP_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
 import {
   deleteWorkspaceStorage,
   getAgentIdKey,
@@ -754,8 +754,8 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
 
   const beginWorkspaceCreation = useCallback(
     (projectPath: string, sectionId?: string) => {
-      if (workspaceMetadata.get(MUX_CHAT_WORKSPACE_ID)?.projectPath === projectPath) {
-        navigateToWorkspace(MUX_CHAT_WORKSPACE_ID);
+      if (workspaceMetadata.get(MUX_HELP_CHAT_WORKSPACE_ID)?.projectPath === projectPath) {
+        navigateToWorkspace(MUX_HELP_CHAT_WORKSPACE_ID);
         return;
       }
 

--- a/src/browser/stories/mocks/orpc.ts
+++ b/src/browser/stories/mocks/orpc.ts
@@ -25,10 +25,10 @@ import type { DebugLlmRequestSnapshot } from "@/common/types/debugLlmRequest";
 import type { Secret } from "@/common/types/secrets";
 import type { ChatStats } from "@/common/types/chatStats";
 import {
-  MUX_CHAT_AGENT_ID,
-  MUX_CHAT_WORKSPACE_ID,
-  MUX_CHAT_WORKSPACE_NAME,
-  MUX_CHAT_WORKSPACE_TITLE,
+  MUX_HELP_CHAT_AGENT_ID,
+  MUX_HELP_CHAT_WORKSPACE_ID,
+  MUX_HELP_CHAT_WORKSPACE_NAME,
+  MUX_HELP_CHAT_WORKSPACE_TITLE,
 } from "@/common/constants/muxChat";
 import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
 import {
@@ -271,17 +271,17 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
   // App now boots into the built-in mux-chat workspace by default.
   // Ensure Storybook mocks always include it so stories don't render "Workspace not found".
   const muxChatWorkspace: FrontendWorkspaceMetadata = {
-    id: MUX_CHAT_WORKSPACE_ID,
-    name: MUX_CHAT_WORKSPACE_NAME,
-    title: MUX_CHAT_WORKSPACE_TITLE,
+    id: MUX_HELP_CHAT_WORKSPACE_ID,
+    name: MUX_HELP_CHAT_WORKSPACE_NAME,
+    title: MUX_HELP_CHAT_WORKSPACE_TITLE,
     projectName: "Mux",
     projectPath: "/Users/dev/.mux/system/chat-with-mux",
     namedWorkspacePath: "/Users/dev/.mux/system/chat-with-mux",
     runtimeConfig: { type: "local" },
-    agentId: MUX_CHAT_AGENT_ID,
+    agentId: MUX_HELP_CHAT_AGENT_ID,
   };
 
-  const workspaces = inputWorkspaces.some((w) => w.id === MUX_CHAT_WORKSPACE_ID)
+  const workspaces = inputWorkspaces.some((w) => w.id === MUX_HELP_CHAT_WORKSPACE_ID)
     ? inputWorkspaces
     : [muxChatWorkspace, ...inputWorkspaces];
 

--- a/src/common/constants/muxChat.ts
+++ b/src/common/constants/muxChat.ts
@@ -1,4 +1,4 @@
-export const MUX_CHAT_WORKSPACE_ID = "mux-chat" as const;
-export const MUX_CHAT_WORKSPACE_NAME = "chat-with-mux" as const;
-export const MUX_CHAT_WORKSPACE_TITLE = "Chat with Mux" as const;
-export const MUX_CHAT_AGENT_ID = "mux" as const;
+export const MUX_HELP_CHAT_WORKSPACE_ID = "mux-chat" as const;
+export const MUX_HELP_CHAT_WORKSPACE_NAME = "chat-with-mux" as const;
+export const MUX_HELP_CHAT_WORKSPACE_TITLE = "Chat with Mux" as const;
+export const MUX_HELP_CHAT_AGENT_ID = "mux" as const;

--- a/src/common/utils/tools/tools.ts
+++ b/src/common/utils/tools/tools.ts
@@ -1,5 +1,5 @@
 import { type Tool } from "ai";
-import { MUX_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
+import { MUX_HELP_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
 import assert from "@/common/utils/assert";
 import { createFileReadTool } from "@/node/services/tools/file_read";
 import { createBashTool } from "@/node/services/tools/bash";
@@ -377,7 +377,7 @@ export async function getToolsForModel(
   const allowlistedToolNames = new Set(
     getAvailableTools(modelString, {
       enableAgentReport: config.enableAgentReport,
-      enableMuxGlobalAgentsTools: workspaceId === MUX_CHAT_WORKSPACE_ID,
+      enableMuxGlobalAgentsTools: workspaceId === MUX_HELP_CHAT_WORKSPACE_ID,
     })
   );
   for (const toolName of Object.keys(mcpTools ?? {})) {

--- a/src/node/constants/muxChat.ts
+++ b/src/node/constants/muxChat.ts
@@ -6,7 +6,7 @@ import * as path from "path";
  * Note: This must be computed from the active mux home dir (Config.rootDir) so
  * tests and dev installs (MUX_ROOT) behave consistently.
  */
-export function getMuxChatProjectPath(muxHome: string): string {
+export function getMuxHelpChatProjectPath(muxHome: string): string {
   // Use a pretty basename for UI display (project name = basename of projectPath).
   return path.join(muxHome, "system", "Mux");
 }

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -47,7 +47,7 @@ import type { SendMessageError } from "@/common/types/errors";
 import { getToolsForModel } from "@/common/utils/tools/tools";
 import { createRuntime } from "@/node/runtime/runtimeFactory";
 import { getMuxEnv, getRuntimeType } from "@/node/runtime/initHook";
-import { MUX_CHAT_AGENT_ID, MUX_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
+import { MUX_HELP_CHAT_AGENT_ID, MUX_HELP_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
 import { secretsToRecord } from "@/common/types/secrets";
 import type { MuxProviderOptions } from "@/common/types/providerOptions";
 import type { BackgroundProcessManager } from "@/node/services/backgroundProcessManager";
@@ -1320,8 +1320,8 @@ export class AIService extends EventEmitter {
       // - Child workspaces (tasks) use their persisted agentId/agentType.
       // - Main workspaces use the requested agentId (frontend), falling back to exec.
       const requestedAgentIdRaw =
-        workspaceId === MUX_CHAT_WORKSPACE_ID
-          ? MUX_CHAT_AGENT_ID
+        workspaceId === MUX_HELP_CHAT_WORKSPACE_ID
+          ? MUX_HELP_CHAT_AGENT_ID
           : ((metadata.parentWorkspaceId ? (metadata.agentId ?? metadata.agentType) : undefined) ??
             (typeof agentId === "string" ? agentId : undefined) ??
             "exec");
@@ -1381,7 +1381,7 @@ export class AIService extends EventEmitter {
       // The Chat with Mux system workspace must remain sandboxed regardless of caller-supplied
       // toolPolicy (defense-in-depth).
       const systemWorkspaceToolPolicy: ToolPolicy | undefined =
-        workspaceId === MUX_CHAT_WORKSPACE_ID
+        workspaceId === MUX_HELP_CHAT_WORKSPACE_ID
           ? [
               { regex_match: ".*", action: "disable" },
 
@@ -1441,7 +1441,7 @@ export class AIService extends EventEmitter {
       // Fetch MCP server config for system prompt (before building message)
       // Pass overrides to filter out disabled servers
       const mcpServers =
-        this.mcpServerManager && workspaceId !== MUX_CHAT_WORKSPACE_ID
+        this.mcpServerManager && workspaceId !== MUX_HELP_CHAT_WORKSPACE_ID
           ? await this.mcpServerManager.listServers(metadata.projectPath, mcpOverrides)
           : undefined;
 
@@ -1673,7 +1673,7 @@ export class AIService extends EventEmitter {
 
       // Load project secrets (system workspace never gets secrets injected)
       const projectSecrets =
-        workspaceId === MUX_CHAT_WORKSPACE_ID
+        workspaceId === MUX_HELP_CHAT_WORKSPACE_ID
           ? []
           : this.config.getProjectSecrets(metadata.projectPath);
 
@@ -1684,7 +1684,7 @@ export class AIService extends EventEmitter {
       let mcpStats: MCPWorkspaceStats | undefined;
       let mcpSetupDurationMs = 0;
 
-      if (this.mcpServerManager && workspaceId !== MUX_CHAT_WORKSPACE_ID) {
+      if (this.mcpServerManager && workspaceId !== MUX_HELP_CHAT_WORKSPACE_ID) {
         const start = Date.now();
         try {
           const result = await this.mcpServerManager.getToolsForWorkspace({

--- a/src/node/services/serviceContainer.ts
+++ b/src/node/services/serviceContainer.ts
@@ -2,12 +2,12 @@ import * as os from "os";
 import * as path from "path";
 import * as fsPromises from "fs/promises";
 import {
-  MUX_CHAT_AGENT_ID,
-  MUX_CHAT_WORKSPACE_ID,
-  MUX_CHAT_WORKSPACE_NAME,
-  MUX_CHAT_WORKSPACE_TITLE,
+  MUX_HELP_CHAT_AGENT_ID,
+  MUX_HELP_CHAT_WORKSPACE_ID,
+  MUX_HELP_CHAT_WORKSPACE_NAME,
+  MUX_HELP_CHAT_WORKSPACE_TITLE,
 } from "@/common/constants/muxChat";
-import { getMuxChatProjectPath } from "@/node/constants/muxChat";
+import { getMuxHelpChatProjectPath } from "@/node/constants/muxChat";
 import { createMuxMessage } from "@/common/types/message";
 import { log } from "@/node/services/log";
 import type { Config } from "@/node/config";
@@ -55,8 +55,8 @@ import { getSigningService, type SigningService } from "@/node/services/signingS
 import { coderService, type CoderService } from "@/node/services/coderService";
 import { setGlobalCoderService } from "@/node/runtime/runtimeFactory";
 
-const MUX_CHAT_WELCOME_MESSAGE_ID = "mux-chat-welcome";
-const MUX_CHAT_WELCOME_MESSAGE = `Hi, I'm Mux.
+const MUX_HELP_CHAT_WELCOME_MESSAGE_ID = "mux-chat-welcome";
+const MUX_HELP_CHAT_WELCOME_MESSAGE = `Hi, I'm Mux.
 
 This is your built-in **Chat with Mux** workspace — a safe place to ask questions about Mux itself.
 
@@ -258,7 +258,7 @@ export class ServiceContainer {
   }
 
   private async ensureMuxChatWorkspace(): Promise<void> {
-    const projectPath = getMuxChatProjectPath(this.config.rootDir);
+    const projectPath = getMuxHelpChatProjectPath(this.config.rootDir);
 
     // Ensure the directory exists (LocalRuntime uses project dir directly).
     await fsPromises.mkdir(projectPath, { recursive: true });
@@ -270,14 +270,14 @@ export class ServiceContainer {
         config.projects.set(projectPath, projectConfig);
       }
 
-      const existing = projectConfig.workspaces.find((w) => w.id === MUX_CHAT_WORKSPACE_ID);
+      const existing = projectConfig.workspaces.find((w) => w.id === MUX_HELP_CHAT_WORKSPACE_ID);
       if (!existing) {
         projectConfig.workspaces.push({
           path: projectPath,
-          id: MUX_CHAT_WORKSPACE_ID,
-          name: MUX_CHAT_WORKSPACE_NAME,
-          title: MUX_CHAT_WORKSPACE_TITLE,
-          agentId: MUX_CHAT_AGENT_ID,
+          id: MUX_HELP_CHAT_WORKSPACE_ID,
+          name: MUX_HELP_CHAT_WORKSPACE_NAME,
+          title: MUX_HELP_CHAT_WORKSPACE_TITLE,
+          agentId: MUX_HELP_CHAT_AGENT_ID,
           createdAt: new Date().toISOString(),
           runtimeConfig: { type: "local" },
         });
@@ -286,9 +286,9 @@ export class ServiceContainer {
 
       // Self-heal: enforce invariants for the system workspace.
       existing.path = projectPath;
-      existing.name = MUX_CHAT_WORKSPACE_NAME;
-      existing.title = MUX_CHAT_WORKSPACE_TITLE;
-      existing.agentId = MUX_CHAT_AGENT_ID;
+      existing.name = MUX_HELP_CHAT_WORKSPACE_NAME;
+      existing.title = MUX_HELP_CHAT_WORKSPACE_TITLE;
+      existing.agentId = MUX_HELP_CHAT_AGENT_ID;
       existing.createdAt ??= new Date().toISOString();
       existing.runtimeConfig = { type: "local" };
       existing.archivedAt = undefined;
@@ -300,7 +300,7 @@ export class ServiceContainer {
   }
 
   private async ensureMuxChatWelcomeMessage(): Promise<void> {
-    const historyResult = await this.historyService.getHistory(MUX_CHAT_WORKSPACE_ID);
+    const historyResult = await this.historyService.getHistory(MUX_HELP_CHAT_WORKSPACE_ID);
     if (!historyResult.success) {
       log.warn("[ServiceContainer] Failed to read mux-chat history for welcome message", {
         error: historyResult.error,
@@ -313,14 +313,17 @@ export class ServiceContainer {
     }
 
     const message = createMuxMessage(
-      MUX_CHAT_WELCOME_MESSAGE_ID,
+      MUX_HELP_CHAT_WELCOME_MESSAGE_ID,
       "assistant",
-      MUX_CHAT_WELCOME_MESSAGE,
+      MUX_HELP_CHAT_WELCOME_MESSAGE,
       // Note: This message should be visible in the UI, so it must NOT be marked synthetic.
       { timestamp: Date.now() }
     );
 
-    const appendResult = await this.historyService.appendToHistory(MUX_CHAT_WORKSPACE_ID, message);
+    const appendResult = await this.historyService.appendToHistory(
+      MUX_HELP_CHAT_WORKSPACE_ID,
+      message
+    );
     if (!appendResult.success) {
       log.warn("[ServiceContainer] Failed to seed mux-chat welcome message", {
         error: appendResult.error,

--- a/src/node/services/systemMessage.ts
+++ b/src/node/services/systemMessage.ts
@@ -12,7 +12,7 @@ import {
   stripScopedInstructionSections,
 } from "@/node/utils/main/markdown";
 import type { Runtime } from "@/node/runtime/Runtime";
-import { MUX_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
+import { MUX_HELP_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
 import { getMuxHome } from "@/common/constants/paths";
 import { discoverAgentSkills } from "@/node/services/agentSkills/agentSkillsService";
 import { log } from "@/node/services/log";
@@ -296,7 +296,7 @@ export async function readToolInstructions(
 
   return extractToolInstructions(globalInstructions, contextInstructions, modelString, {
     enableAgentReport: Boolean(metadata.parentWorkspaceId),
-    enableMuxGlobalAgentsTools: metadata.id === MUX_CHAT_WORKSPACE_ID,
+    enableMuxGlobalAgentsTools: metadata.id === MUX_HELP_CHAT_WORKSPACE_ID,
     agentInstructions,
   });
 }

--- a/src/node/services/tools/agent_skill_read.test.ts
+++ b/src/node/services/tools/agent_skill_read.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect } from "bun:test";
 import type { ToolCallOptions } from "ai";
 
 import { AgentSkillReadToolResultSchema } from "@/common/utils/tools/toolDefinitions";
-import { MUX_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
+import { MUX_HELP_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
 import { createAgentSkillReadTool } from "./agent_skill_read";
 import { createTestToolConfig, TestTempDir } from "./testHelpers";
 
@@ -27,7 +27,9 @@ async function writeProjectSkill(workspacePath: string, name: string): Promise<v
 describe("agent_skill_read (Chat with Mux sandbox)", () => {
   it("allows reading built-in skills", async () => {
     using tempDir = new TestTempDir("test-agent-skill-read-mux-chat");
-    const baseConfig = createTestToolConfig(tempDir.path, { workspaceId: MUX_CHAT_WORKSPACE_ID });
+    const baseConfig = createTestToolConfig(tempDir.path, {
+      workspaceId: MUX_HELP_CHAT_WORKSPACE_ID,
+    });
 
     const tool = createAgentSkillReadTool(baseConfig);
 
@@ -53,7 +55,9 @@ describe("agent_skill_read (Chat with Mux sandbox)", () => {
     using tempDir = new TestTempDir("test-agent-skill-read-mux-chat-reject");
     await writeProjectSkill(tempDir.path, "foo");
 
-    const baseConfig = createTestToolConfig(tempDir.path, { workspaceId: MUX_CHAT_WORKSPACE_ID });
+    const baseConfig = createTestToolConfig(tempDir.path, {
+      workspaceId: MUX_HELP_CHAT_WORKSPACE_ID,
+    });
     const tool = createAgentSkillReadTool(baseConfig);
 
     const raw: unknown = await Promise.resolve(tool.execute!({ name: "foo" }, mockToolCallOptions));

--- a/src/node/services/tools/agent_skill_read.ts
+++ b/src/node/services/tools/agent_skill_read.ts
@@ -1,4 +1,4 @@
-import { MUX_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
+import { MUX_HELP_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
 import { getBuiltInSkillByName } from "@/node/services/agentSkills/builtInSkillDefinitions";
 
 import { tool } from "ai";
@@ -43,7 +43,7 @@ export const createAgentSkillReadTool: ToolFactory = (config: ToolConfiguration)
         // Chat with Mux intentionally has no generic filesystem access. Restrict skill reads to
         // built-in skills (bundled in the app) so users can access help like `mux-docs` without
         // granting access to project/global skills on disk.
-        if (config.workspaceId === MUX_CHAT_WORKSPACE_ID) {
+        if (config.workspaceId === MUX_HELP_CHAT_WORKSPACE_ID) {
           const builtIn = getBuiltInSkillByName(parsedName.data);
           if (!builtIn) {
             return {

--- a/src/node/services/tools/agent_skill_read_file.test.ts
+++ b/src/node/services/tools/agent_skill_read_file.test.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import { describe, it, expect } from "bun:test";
 import type { ToolCallOptions } from "ai";
 
-import { MUX_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
+import { MUX_HELP_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
 import { AgentSkillReadFileToolResultSchema } from "@/common/utils/tools/toolDefinitions";
 import { createAgentSkillReadFileTool } from "./agent_skill_read_file";
 import { createTestToolConfig, TestTempDir } from "./testHelpers";
@@ -27,7 +27,9 @@ async function writeProjectSkill(workspacePath: string, name: string): Promise<v
 describe("agent_skill_read_file (Chat with Mux sandbox)", () => {
   it("allows reading built-in skill files", async () => {
     using tempDir = new TestTempDir("test-agent-skill-read-file-mux-chat");
-    const baseConfig = createTestToolConfig(tempDir.path, { workspaceId: MUX_CHAT_WORKSPACE_ID });
+    const baseConfig = createTestToolConfig(tempDir.path, {
+      workspaceId: MUX_HELP_CHAT_WORKSPACE_ID,
+    });
 
     const tool = createAgentSkillReadFileTool(baseConfig);
 
@@ -55,7 +57,9 @@ describe("agent_skill_read_file (Chat with Mux sandbox)", () => {
     using tempDir = new TestTempDir("test-agent-skill-read-file-mux-chat-reject");
     await writeProjectSkill(tempDir.path, "foo");
 
-    const baseConfig = createTestToolConfig(tempDir.path, { workspaceId: MUX_CHAT_WORKSPACE_ID });
+    const baseConfig = createTestToolConfig(tempDir.path, {
+      workspaceId: MUX_HELP_CHAT_WORKSPACE_ID,
+    });
     const tool = createAgentSkillReadFileTool(baseConfig);
 
     const raw: unknown = await Promise.resolve(

--- a/src/node/services/tools/agent_skill_read_file.ts
+++ b/src/node/services/tools/agent_skill_read_file.ts
@@ -1,4 +1,4 @@
-import { MUX_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
+import { MUX_HELP_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
 import { getBuiltInSkillByName } from "@/node/services/agentSkills/builtInSkillDefinitions";
 
 import { tool } from "ai";
@@ -132,7 +132,7 @@ export const createAgentSkillReadFileTool: ToolFactory = (config: ToolConfigurat
         // Chat with Mux intentionally has no generic filesystem access. Restrict skill file reads
         // to built-in skills (bundled in the app) so users can access help like `mux-docs` without
         // granting access to project/global skills on disk.
-        if (config.workspaceId === MUX_CHAT_WORKSPACE_ID) {
+        if (config.workspaceId === MUX_HELP_CHAT_WORKSPACE_ID) {
           const builtInSkill = getBuiltInSkillByName(parsedName.data);
           if (!builtInSkill) {
             return {

--- a/src/node/services/tools/mux_global_agents.test.ts
+++ b/src/node/services/tools/mux_global_agents.test.ts
@@ -4,9 +4,9 @@ import * as path from "path";
 import type { ToolCallOptions } from "ai";
 
 import {
-  MUX_CHAT_WORKSPACE_ID,
-  MUX_CHAT_WORKSPACE_NAME,
-  MUX_CHAT_WORKSPACE_TITLE,
+  MUX_HELP_CHAT_WORKSPACE_ID,
+  MUX_HELP_CHAT_WORKSPACE_NAME,
+  MUX_HELP_CHAT_WORKSPACE_TITLE,
 } from "@/common/constants/muxChat";
 import { FILE_EDIT_DIFF_OMITTED_MESSAGE } from "@/common/types/tools";
 
@@ -23,11 +23,11 @@ describe("mux_global_agents_* tools", () => {
   it("reads ~/.mux/AGENTS.md (returns empty string if missing)", async () => {
     using muxHome = new TestTempDir("mux-global-agents");
 
-    const workspaceSessionDir = path.join(muxHome.path, "sessions", MUX_CHAT_WORKSPACE_ID);
+    const workspaceSessionDir = path.join(muxHome.path, "sessions", MUX_HELP_CHAT_WORKSPACE_ID);
     await fs.mkdir(workspaceSessionDir, { recursive: true });
 
     const config = createTestToolConfig(muxHome.path, {
-      workspaceId: MUX_CHAT_WORKSPACE_ID,
+      workspaceId: MUX_HELP_CHAT_WORKSPACE_ID,
       sessionsDir: workspaceSessionDir,
     });
 
@@ -47,7 +47,7 @@ describe("mux_global_agents_* tools", () => {
     const agentsPath = path.join(muxHome.path, "AGENTS.md");
     await fs.writeFile(
       agentsPath,
-      `# ${MUX_CHAT_WORKSPACE_TITLE}\n${MUX_CHAT_WORKSPACE_NAME}\n`,
+      `# ${MUX_HELP_CHAT_WORKSPACE_TITLE}\n${MUX_HELP_CHAT_WORKSPACE_NAME}\n`,
       "utf-8"
     );
 
@@ -57,19 +57,19 @@ describe("mux_global_agents_* tools", () => {
     };
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.content).toContain(MUX_CHAT_WORKSPACE_TITLE);
-      expect(result.content).toContain(MUX_CHAT_WORKSPACE_NAME);
+      expect(result.content).toContain(MUX_HELP_CHAT_WORKSPACE_TITLE);
+      expect(result.content).toContain(MUX_HELP_CHAT_WORKSPACE_NAME);
     }
   });
 
   it("refuses to write without explicit confirmation", async () => {
     using muxHome = new TestTempDir("mux-global-agents");
 
-    const workspaceSessionDir = path.join(muxHome.path, "sessions", MUX_CHAT_WORKSPACE_ID);
+    const workspaceSessionDir = path.join(muxHome.path, "sessions", MUX_HELP_CHAT_WORKSPACE_ID);
     await fs.mkdir(workspaceSessionDir, { recursive: true });
 
     const config = createTestToolConfig(muxHome.path, {
-      workspaceId: MUX_CHAT_WORKSPACE_ID,
+      workspaceId: MUX_HELP_CHAT_WORKSPACE_ID,
       sessionsDir: workspaceSessionDir,
     });
 
@@ -100,11 +100,11 @@ describe("mux_global_agents_* tools", () => {
   it("writes ~/.mux/AGENTS.md and returns a diff", async () => {
     using muxHome = new TestTempDir("mux-global-agents");
 
-    const workspaceSessionDir = path.join(muxHome.path, "sessions", MUX_CHAT_WORKSPACE_ID);
+    const workspaceSessionDir = path.join(muxHome.path, "sessions", MUX_HELP_CHAT_WORKSPACE_ID);
     await fs.mkdir(workspaceSessionDir, { recursive: true });
 
     const config = createTestToolConfig(muxHome.path, {
-      workspaceId: MUX_CHAT_WORKSPACE_ID,
+      workspaceId: MUX_HELP_CHAT_WORKSPACE_ID,
       sessionsDir: workspaceSessionDir,
     });
 
@@ -131,11 +131,11 @@ describe("mux_global_agents_* tools", () => {
   it("rejects symlink targets", async () => {
     using muxHome = new TestTempDir("mux-global-agents");
 
-    const workspaceSessionDir = path.join(muxHome.path, "sessions", MUX_CHAT_WORKSPACE_ID);
+    const workspaceSessionDir = path.join(muxHome.path, "sessions", MUX_HELP_CHAT_WORKSPACE_ID);
     await fs.mkdir(workspaceSessionDir, { recursive: true });
 
     const config = createTestToolConfig(muxHome.path, {
-      workspaceId: MUX_CHAT_WORKSPACE_ID,
+      workspaceId: MUX_HELP_CHAT_WORKSPACE_ID,
       sessionsDir: workspaceSessionDir,
     });
 

--- a/src/node/services/tools/mux_global_agents_read.ts
+++ b/src/node/services/tools/mux_global_agents_read.ts
@@ -4,7 +4,7 @@ import { tool } from "ai";
 
 import type { ToolConfiguration, ToolFactory } from "@/common/utils/tools/tools";
 import { TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
-import { MUX_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
+import { MUX_HELP_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
 
 function getMuxHomeFromWorkspaceSessionDir(config: ToolConfiguration): string {
   if (!config.workspaceSessionDir) {
@@ -39,7 +39,7 @@ export const createMuxGlobalAgentsReadTool: ToolFactory = (config: ToolConfigura
       { abortSignal: _abortSignal }
     ): Promise<MuxGlobalAgentsReadToolOutput> => {
       try {
-        if (config.workspaceId !== MUX_CHAT_WORKSPACE_ID) {
+        if (config.workspaceId !== MUX_HELP_CHAT_WORKSPACE_ID) {
           return {
             success: false,
             error: "mux_global_agents_read is only available in the Chat with Mux system workspace",

--- a/src/node/services/tools/mux_global_agents_write.ts
+++ b/src/node/services/tools/mux_global_agents_write.ts
@@ -4,7 +4,7 @@ import { tool } from "ai";
 
 import type { ToolConfiguration, ToolFactory } from "@/common/utils/tools/tools";
 import { TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
-import { MUX_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
+import { MUX_HELP_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
 import { FILE_EDIT_DIFF_OMITTED_MESSAGE } from "@/common/types/tools";
 import { generateDiff } from "./fileCommon";
 
@@ -51,7 +51,7 @@ export const createMuxGlobalAgentsWriteTool: ToolFactory = (config: ToolConfigur
       { abortSignal: _abortSignal }
     ): Promise<MuxGlobalAgentsWriteToolOutput> => {
       try {
-        if (config.workspaceId !== MUX_CHAT_WORKSPACE_ID) {
+        if (config.workspaceId !== MUX_HELP_CHAT_WORKSPACE_ID) {
           return {
             success: false,
             error:

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2,8 +2,8 @@ import { EventEmitter } from "events";
 import * as path from "path";
 import * as fsPromises from "fs/promises";
 import assert from "@/common/utils/assert";
-import { MUX_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
-import { getMuxChatProjectPath } from "@/node/constants/muxChat";
+import { MUX_HELP_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
+import { getMuxHelpChatProjectPath } from "@/node/constants/muxChat";
 import type { Config } from "@/node/config";
 import type { Result } from "@/common/types/result";
 import { Ok, Err } from "@/common/types/result";
@@ -620,7 +620,7 @@ export class WorkspaceService extends EventEmitter {
     sectionId?: string
   ): Promise<Result<{ metadata: FrontendWorkspaceMetadata }>> {
     // Chat with Mux is a built-in system workspace; it cannot host additional workspaces.
-    if (projectPath === getMuxChatProjectPath(this.config.rootDir)) {
+    if (projectPath === getMuxHelpChatProjectPath(this.config.rootDir)) {
       return Err("Cannot create workspaces in the Chat with Mux system project");
     }
 
@@ -812,7 +812,7 @@ export class WorkspaceService extends EventEmitter {
   }
 
   async remove(workspaceId: string, force = false): Promise<Result<void>> {
-    if (workspaceId === MUX_CHAT_WORKSPACE_ID) {
+    if (workspaceId === MUX_HELP_CHAT_WORKSPACE_ID) {
       return Err("Cannot remove the Chat with Mux system workspace");
     }
 
@@ -1236,7 +1236,7 @@ export class WorkspaceService extends EventEmitter {
    * but can be viewed on the project page. Safe and reversible.
    */
   async archive(workspaceId: string): Promise<Result<void>> {
-    if (workspaceId === MUX_CHAT_WORKSPACE_ID) {
+    if (workspaceId === MUX_HELP_CHAT_WORKSPACE_ID) {
       return Err("Cannot archive the Chat with Mux system workspace");
     }
 
@@ -1296,7 +1296,7 @@ export class WorkspaceService extends EventEmitter {
    * Unarchive a workspace. Restores it to the main sidebar view.
    */
   async unarchive(workspaceId: string): Promise<Result<void>> {
-    if (workspaceId === MUX_CHAT_WORKSPACE_ID) {
+    if (workspaceId === MUX_HELP_CHAT_WORKSPACE_ID) {
       return Err("Cannot unarchive the Chat with Mux system workspace");
     }
 
@@ -1543,7 +1543,7 @@ export class WorkspaceService extends EventEmitter {
     newName: string
   ): Promise<Result<{ metadata: FrontendWorkspaceMetadata; projectPath: string }>> {
     try {
-      if (sourceWorkspaceId === MUX_CHAT_WORKSPACE_ID) {
+      if (sourceWorkspaceId === MUX_HELP_CHAT_WORKSPACE_ID) {
         return Err("Cannot fork the Chat with Mux system workspace");
       }
 

--- a/tests/ui/muxChatWorkspace.integration.test.ts
+++ b/tests/ui/muxChatWorkspace.integration.test.ts
@@ -13,8 +13,8 @@ import { createTestEnvironment, cleanupTestEnvironment, preloadTestModules } fro
 import { cleanupTempGitRepo, createTempGitRepo, generateBranchName } from "../ipc/helpers";
 
 import { detectDefaultTrunkBranch } from "@/node/git";
-import { getMuxChatProjectPath } from "@/node/constants/muxChat";
-import { MUX_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
+import { getMuxHelpChatProjectPath } from "@/node/constants/muxChat";
+import { MUX_HELP_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
 
 import { installDom } from "./dom";
 import { renderApp } from "./renderReviewPanel";
@@ -47,7 +47,7 @@ describe("Chat with Mux system workspace (UI)", () => {
       await view.waitForReady();
       await waitForWorkspaceChatToRender(view.container);
 
-      expect(window.location.pathname).toBe(`/workspace/${MUX_CHAT_WORKSPACE_ID}`);
+      expect(window.location.pathname).toBe(`/workspace/${MUX_HELP_CHAT_WORKSPACE_ID}`);
       expect(view.queryByText("Welcome to Mux")).toBeNull();
 
       // On first boot, the mux-chat workspace should seed a synthetic welcome message.
@@ -109,7 +109,7 @@ describe("Chat with Mux system workspace (UI)", () => {
 
       await waitFor(
         () => {
-          expect(window.location.pathname).toBe(`/workspace/${MUX_CHAT_WORKSPACE_ID}`);
+          expect(window.location.pathname).toBe(`/workspace/${MUX_HELP_CHAT_WORKSPACE_ID}`);
         },
         { timeout: 10_000 }
       );
@@ -144,7 +144,7 @@ describe("Chat with Mux system workspace (UI)", () => {
       await waitForWorkspaceChatToRender(view.container);
 
       // The system project itself should be hidden from the sidebar projects list.
-      const systemProjectPath = getMuxChatProjectPath(env.config.rootDir);
+      const systemProjectPath = getMuxHelpChatProjectPath(env.config.rootDir);
       await waitFor(
         () => {
           expect(
@@ -158,7 +158,7 @@ describe("Chat with Mux system workspace (UI)", () => {
       // it's accessed via the Mux logo / help icon in the header. Verify no workspace
       // row exists for it (which means no Archive button by design).
       expect(
-        view.container.querySelector(`[data-workspace-id="${MUX_CHAT_WORKSPACE_ID}"]`)
+        view.container.querySelector(`[data-workspace-id="${MUX_HELP_CHAT_WORKSPACE_ID}"]`)
       ).toBeNull();
 
       // Ctrl+N should not redirect to /project when mux-chat is selected.
@@ -167,7 +167,7 @@ describe("Chat with Mux system workspace (UI)", () => {
       });
 
       await new Promise((r) => setTimeout(r, 200));
-      expect(window.location.pathname).toBe(`/workspace/${MUX_CHAT_WORKSPACE_ID}`);
+      expect(window.location.pathname).toBe(`/workspace/${MUX_HELP_CHAT_WORKSPACE_ID}`);
     } finally {
       await cleanupView(view, cleanupDom);
       await cleanupTestEnvironment(env);


### PR DESCRIPTION
Summary
- rename the built-in Chat with Mux identifiers to MUX_HELP_CHAT_* for clarity
- stop hiding runtime/branch/git UI badges in the help chat workspace

Background
- `isMuxChat` reads like “any mux chat” instead of the built-in help chat; the help chat already has a real projectPath under ~/.mux/system/Mux, so special casing in the UI is unnecessary

Implementation
- rename constants + helper to MUX_HELP_CHAT_* / getMuxHelpChatProjectPath
- update call sites across frontend, backend, tests, and story mocks
- remove runtime/branch/git badge guards while keeping archive guards for the system workspace

Validation
- make static-check

Risks
- Low: changes are naming/conditional cleanup; help chat is local/non-git so branch+git indicators remain empty but still render safely

---

_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `xhigh` • Cost: `$2.42`_

<!-- mux-attribution: model=openai:gpt-5.2-codex thinking=xhigh costs=2.42 -->
