### PR TITLE
🤖 fix: move Skill badge count to bottom-right in workspace header

### DIFF
--- a/src/browser/components/SkillIndicator.tsx
+++ b/src/browser/components/SkillIndicator.tsx
@@ -61,7 +61,7 @@ export const SkillIndicator: React.FC<SkillIndicatorProps> = (props) => {
           <SkillIcon className="h-4 w-4" />
           <span
             className={cn(
-              "absolute -right-1 -top-1 flex h-3.5 min-w-3.5 items-center justify-center",
+              "absolute -bottom-1 -right-1 flex h-3.5 min-w-3.5 items-center justify-center",
               "rounded-full border border-border bg-sidebar px-0.5 text-[9px] font-medium",
               loadedCount > 0 ? "text-foreground" : "text-muted"
             )}


### PR DESCRIPTION
## Summary

Moves the skill count badge in the workspace header from top-right to bottom-right positioning.

## Implementation

Changed the badge positioning class from `-top-1` to `-bottom-1` in `SkillIndicator.tsx`.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.12`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=0.12 -->
