### PR TITLE
🤖 fix: split timing stats by agentId

### DIFF
--- a/src/browser/components/RightSidebar/StatsTab.label.test.ts
+++ b/src/browser/components/RightSidebar/StatsTab.label.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+
+import { formatModelBreakdownLabel } from "./StatsTab";
+
+describe("formatModelBreakdownLabel", () => {
+  test("prefers agentId over mode", () => {
+    expect(
+      formatModelBreakdownLabel({ model: "openai:gpt-4o", mode: "exec", agentId: "explore" })
+    ).toBe("openai:gpt-4o (explore)");
+  });
+
+  test("falls back to mode when agentId is missing", () => {
+    expect(formatModelBreakdownLabel({ model: "openai:gpt-4o", mode: "plan" })).toBe(
+      "openai:gpt-4o (plan)"
+    );
+  });
+
+  test("shows model only when no split label is available", () => {
+    expect(formatModelBreakdownLabel({ model: "openai:gpt-4o" })).toBe("openai:gpt-4o");
+  });
+});

--- a/src/common/orpc/schemas/workspaceStats.ts
+++ b/src/common/orpc/schemas/workspaceStats.ts
@@ -1,8 +1,12 @@
 import { z } from "zod";
 import { AgentModeSchema } from "../../types/mode";
+import { AgentIdSchema } from "./agentDefinition";
 
 // Mode is an enum, but we defensively drop unknown values when replaying old history.
 const ModeSchema = AgentModeSchema.optional().catch(undefined);
+// Agent IDs should already be safe (they come from filenames), but defensively drop unknown values
+// when replaying old history.
+const AgentIdStatsSchema = AgentIdSchema.optional().catch(undefined);
 
 export const TimingAnomalySchema = z.enum([
   "negative_duration",
@@ -16,6 +20,7 @@ export const ActiveStreamStatsSchema = z.object({
   messageId: z.string(),
   model: z.string(),
   mode: ModeSchema,
+  agentId: AgentIdStatsSchema,
 
   elapsedMs: z.number(),
   ttftMs: z.number().nullable(),
@@ -39,6 +44,7 @@ export const CompletedStreamStatsSchema = z.object({
   messageId: z.string(),
   model: z.string(),
   mode: ModeSchema,
+  agentId: AgentIdStatsSchema,
 
   totalDurationMs: z.number(),
   ttftMs: z.number().nullable(),
@@ -56,6 +62,7 @@ export const CompletedStreamStatsSchema = z.object({
 export const ModelTimingStatsSchema = z.object({
   model: z.string(),
   mode: ModeSchema,
+  agentId: AgentIdStatsSchema,
 
   totalDurationMs: z.number(),
   totalToolExecutionMs: z.number(),
@@ -81,7 +88,11 @@ export const SessionTimingStatsSchema = z.object({
   totalOutputTokens: z.number(),
   totalReasoningTokens: z.number(),
 
-  /** Per-model breakdown (key is stable identifier like normalizeGatewayModel(model) or model:mode). */
+  /**
+   * Per-model breakdown.
+   *
+   * Key is a stable identifier like normalizeGatewayModel(model) or model:agentId (fallback: model:mode).
+   */
   byModel: z.record(z.string(), ModelTimingStatsSchema),
 });
 


### PR DESCRIPTION
Summary
- Fix Stats → Timing → Session → “By model” split view to distinguish explore sub-agents from exec/plan by using `agentId` (so explore traffic doesn’t show up as `(exec)`).

Background
- Timing stats previously persisted only `mode` (plan/exec) and dropped `agentId`, so explore sub-agent streams were indistinguishable and displayed as exec.

Implementation
- Persist `agentId` in timing stats (active, completed, and per-model rollups).
- Prefer `model:agentId` (fallback `model:mode`) as the per-model breakdown key.
- Update Stats UI to label entries using `agentId ?? mode` and rename the toggle to “Split by agent”.

Validation
- `make static-check`
- `make test`

Risks
- Low: `agentId` is additive/optional and existing `session-timing.json` files still parse.
- Session per-model keys will differ going forward (`model:agentId`), but we retain fallback behavior for legacy entries.

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix stats tab mislabeling: explore sub-agents shown as exec

## Context / Why
In the Stats tab (Timing → Session → “By model” with “Split by mode” enabled), requests made by **explore** sub-agents (e.g. using `anthropic:claude-haiku-4-5`) are displayed as **`(exec)`**, even when the user only runs that model via explore tasks.

Goal: ensure stats correctly distinguish **explore** (and other sub-agent IDs) from exec/plan so the “By model” breakdown matches how requests were actually produced.

## Evidence (repo + UI)
- User report + screenshot: `anthropic:claude-haiku-4-5` shows `(exec)` in Stats → Session.
- UI label logic only understands `plan` vs `exec`:
  - `src/browser/components/RightSidebar/StatsTab.tsx` renders `(${entry.mode})` only for `plan|exec`.
- Stream pipeline carries **both** `mode` and `agentId`:
  - `StreamStartEvent` includes `mode?: AgentMode` and `agentId?: string`.
- Timing stats persistence/aggregation keeps `mode` but drops full agent identity:
  - `src/node/services/sessionTimingService.ts` validates `mode` to `plan|exec` and persists that, but does **not** persist `agentId`.
- Mode is derived from “plan-like toolchain” and defaults to exec; explore agents therefore end up with `mode="exec"` even though `agentId="explore"`:
  - `src/node/services/aiService.ts` computes `effectiveMode` as `plan|exec|compact`.

(These paths/symbols were traced via explore sub-agent investigation.)

---

## Recommended approach (A): Track `agentId` in timing stats and split by agent
**Net LoC estimate (product code): ~60–120 LoC**

### Design
- Keep the existing **base mode** field for backwards compatibility (`plan|exec|compact`).
- Add **`agentId?: string`** to timing stats and use it as the *primary* dimension for the “split” view.
  - This makes explore/trace/custom agents first-class without exploding the `AgentMode` union.

### Implementation steps
1. **Schema: persist agentId**
   - Update `src/common/orpc/schemas/workspaceStats.ts` to include `agentId?: AgentIdSchema` on:
     - `ActiveStreamStats`
     - `CompletedStreamStats`
     - `ModelTimingStats`
   - Keep fields optional so existing `session-timing.json` continues to parse without migrations.

2. **Backend: capture agentId from stream-start and carry through to completed stats**
   - In `src/node/services/sessionTimingService.ts`:
     - Store `agentId` on the in-memory “active stream” record created in `handleStreamStart()`.
     - When a stream completes, copy `agentId` into the `CompletedStreamStats` entry.

3. **Backend: change the by-model grouping key to prefer agentId**
   - Update the “key” function (today effectively `model + mode`) to:
     - Use `${model}:${agentId}` when `agentId` is present.
     - Else fall back to `${model}:${mode}` (legacy).
   - Ensure rollups from sub-agent workspaces preserve the new field (should be automatic once persisted).

4. **UI: display agentId in the “split” view**
   - In `src/browser/components/RightSidebar/StatsTab.tsx`:
     - When rendering the per-model entry label, prefer `entry.agentId ?? entry.mode`.
       - Expected: `anthropic:claude-haiku-4-5 (explore)`.
     - Consider renaming the checkbox label from **“Split by mode”** → **“Split by agent”** (or similar) since it’s no longer strictly plan/exec.
     - Keep the “unsplit” behavior the same: consolidate by model regardless of agent.

5. **Defensive checks / self-healing**
   - Guard against malformed/unknown `agentId` strings when reading stats (schema should already constrain via `AgentIdSchema`; still handle `undefined`).
   - Don’t crash if older stats files contain unexpected keys; treat unknown as “no split label”.

6. **Validation**
   - Manual repro:
     1) Start a normal chat (exec or plan).
     2) Spawn an explore sub-agent that uses haiku.
     3) Open Stats → Timing → Session → enable split.
     4) Confirm haiku shows `(explore)` and main model shows `(plan)` or `(exec)`.
   - Run: `make test` + `make typecheck` (and any focused tests for timing/stats if they exist).

### Why this fixes the screenshot
Even if explore tasks are “exec-like” in base mode, the true identity is `agentId="explore"`. Persisting and displaying `agentId` makes the stats breakdown reflect what the user actually ran.

---

## Alternative approach (B): Add `explore` as a first-class `AgentMode`
**Net LoC estimate (product code): ~90–180 LoC**

### Sketch
- Extend `AgentMode` / `ModeSchema` to include `"explore"`.
- Change `aiService.ts` to set `mode="explore"` when `agentId === "explore"`.
- Update `sessionTimingService.ts` validation (currently only `plan|exec`) to accept explore.
- Update `StatsTab.tsx` label mapping to handle explore.

<details>
<summary>Trade-offs</summary>

- Conflates “base mode” (plan vs exec) with “agent identity” (explore/trace/custom).
- Requires updating unions/schemas and possibly migrations for persisted stats.
- Less future-proof for arbitrary custom agents.

</details>

---

## Proposed order of work
1. Implement Approach A end-to-end (schema + backend + UI).
2. Manually confirm it fixes the observed mislabeling.
3. Only consider Approach B if product explicitly wants explore to be treated as a true third mode everywhere.

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: $3.36_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=3.36 -->
