### PR TITLE
🤖 fix: auto-expand new projects in sidebar

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -41,6 +41,7 @@ import {
   getThinkingLevelByModelKey,
   getThinkingLevelKey,
   getWorkspaceAISettingsByAgentKey,
+  EXPANDED_PROJECTS_KEY,
 } from "@/common/constants/storage";
 import { migrateGatewayModel } from "@/browser/hooks/useGatewayModels";
 import { getDefaultModel } from "@/browser/hooks/useModelsFromSettings";
@@ -926,6 +927,12 @@ function AppInner() {
           onSuccess={(normalizedPath, projectConfig) => {
             addProject(normalizedPath, projectConfig);
             updatePersistedState(getAgentsInitNudgeKey(normalizedPath), true);
+            // Auto-expand new project in sidebar
+            updatePersistedState<string[]>(
+              EXPANDED_PROJECTS_KEY,
+              (prev) => [...(Array.isArray(prev) ? prev : []), normalizedPath],
+              []
+            );
             beginWorkspaceCreation(normalizedPath);
           }}
         />


### PR DESCRIPTION
## Summary

When adding a new project, it's now automatically expanded in the sidebar so the user can immediately see it's ready for a new workspace.

## Background

Closes #1971

Users expected to see their new project expanded in the sidebar after creation, but it remained collapsed. This was confusing because the workspace creation flow navigates to the project page, yet the sidebar didn't visually reflect the active project.

## Implementation

Added a call to `updatePersistedState` in the `ProjectCreateModal.onSuccess` callback that adds the new project path to the `expandedProjects` localStorage array. The sidebar's `usePersistedState` hook automatically syncs and re-renders with the project expanded.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$2.30`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=2.30 -->
