### PR TITLE
🤖 fix: teach Ask mode to trust Explore reports

### DIFF
--- a/.mux/agents/ask.md
+++ b/.mux/agents/ask.md
@@ -18,10 +18,12 @@ You are **Ask**.
 Your job is to answer the user's question by delegating research to sub-agents (typically **Explore**), then synthesizing a concise, actionable response.
 
 ## When to delegate
+
 - Delegate when the question requires repository exploration, multiple viewpoints, or verification.
 - If the answer is obvious and does not require looking anything up, answer directly.
 
 ## Delegation workflow
+
 1. Break the question into **1–3** focused research threads.
 2. Spawn Explore sub-agents in parallel using the `task` tool:
    - `agentId: "explore"` (or `subagent_type: "explore"`)
@@ -31,7 +33,9 @@ Your job is to answer the user's question by delegating research to sub-agents (
 4. Synthesize:
    - Provide the final answer first.
    - Then include supporting details (paths, commands, edge cases).
+   - Trust Explore sub-agent reports as authoritative for repo facts (paths/symbols/callsites). Do not redo the same investigation yourself; only re-check if the report is ambiguous or contradicts other evidence.
 
 ## Safety rules
+
 - Do **not** modify repository files.
 - Prefer `agentId: "explore"`. Only use `"exec"` if the user explicitly asks to implement changes.

--- a/src/node/services/agentDefinitions/agentDefinitionsService.test.ts
+++ b/src/node/services/agentDefinitions/agentDefinitionsService.test.ts
@@ -130,6 +130,14 @@ Replaced body.
     expect(replacerBody).not.toContain("Base instructions");
   });
 
+  test("Ask agent instructs to trust Explore sub-agent reports", async () => {
+    const askAgentPath = path.join(process.cwd(), ".mux", "agents", "ask.md");
+    const content = await fs.readFile(askAgentPath, "utf-8");
+
+    expect(content).toContain("Trust Explore sub-agent reports as authoritative for repo facts");
+    expect(content).toContain("ambiguous or contradicts other evidence");
+  });
+
   test("same-name override: project agent with base: self extends built-in/global, not itself", async () => {
     using project = new DisposableTempDir("agent-same-name");
     using global = new DisposableTempDir("agent-same-name-global");


### PR DESCRIPTION
## Summary

Teach Ask mode to trust Explore sub-agent reports for repo facts (paths/symbols/callsites), avoiding redundant investigation work.

## Implementation

- Added Plan-mode-style trust guidance to `.mux/agents/ask.md`.
- Added a regression test to ensure the guidance doesn't regress.

## Validation

- `bun test src/node/services/agentDefinitions/agentDefinitionsService.test.ts`
- `make static-check`

## Risks

Low — prompt-only change + unit test.

---

<details>
<summary>📋 Implementation Plan</summary>

# Add “trust sub-agent reports” guidance to Ask mode

## Context / Why
Ask mode delegates investigation to Explore sub-agents, but (unlike Plan mode) it doesn’t explicitly tell the assistant it can *trust* those reports for repo facts. This can lead to redundant re-checking (extra `grep`/`file_read`/etc.) and wasted tokens. The goal is to add the same “trust the Explore report unless ambiguous/contradictory” guidance that Plan mode already has.

## Evidence (what we verified)
- Plan mode already includes the trust guidance in `src/common/utils/ui/modeUtils.ts` (`getPlanModeInstruction(...)`).
- Ask mode instructions live in `.mux/agents/ask.md` (delegation workflow section), and Ask mode uses Explore sub-agents.
- `.mux/agents/*.md` are loaded via `src/node/services/agentDefinitions/agentDefinitionsService.ts` → parsed by `parseAgentDefinitionMarkdown.ts` → resolved via `resolveAgentBody(...)` → injected into the final system prompt by `src/node/services/aiService.ts` / `buildSystemMessage(...)`.
- There are tests for agent parsing/resolution, but none currently assert on the *content* of `.mux/agents/ask.md`.

## Recommended approach (minimal + consistent)
**Net LoC (product code): +3–6** (Ask agent markdown only)

1. **Update Ask mode prompt text**
   - Edit `.mux/agents/ask.md` under `## Delegation workflow` (right after the “Synthesize” bullets).
   - Add an instruction mirroring Plan mode’s wording:
     - “Trust Explore sub-agent reports as authoritative for repo facts (paths/symbols/callsites). Do not redo the same investigation yourself; only re-check if a report is ambiguous or contradicts other evidence.”
   - Keep it scoped to *repo facts / tool outputs* (not security guarantees).

2. **Add a small regression test (recommended)**
   - Add/extend a unit test (likely in `src/node/services/agentDefinitions/agentDefinitionsService.test.ts`) that reads/parses `.mux/agents/ask.md` and asserts it contains the new trust instruction (match on a couple of key phrases/keywords rather than exact prose).
   - This prevents accidental removal/regression while staying resilient to minor rewording.

3. **Run validation**
   - Run targeted unit tests for agent definitions + system message building (at minimum the agentDefinitions tests; optionally systemMessage tests).

## Alternative (more systemic, higher effort)
**Net LoC (product code): +10–25**

Add a shared “trust sub-agent reports” snippet as a reusable constant in code and inject it automatically whenever the active agent/mode uses Explore sub-agents.

<details>
<summary>Tradeoffs</summary>

- Pros: guarantees consistent wording across modes; avoids forgetting to update one prompt.
- Cons: more plumbing; harder to keep the instruction scoped (risk of affecting Exec/other modes); less transparent than a direct edit to `ask.md`.

</details>

## Acceptance criteria
- Ask mode prompt contains explicit guidance to trust Explore sub-agent reports for repo facts and not re-investigate unless ambiguous/contradictory.
- No behavior regressions in agent definition parsing/resolution.
- Tests pass.

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: $1.15_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=1.15 -->
