### PR TITLE
🤖 ci: forward Google keys + add Gemini Flash to nightly tbench

### DIFF
--- a/.github/workflows/nightly-terminal-bench.yml
+++ b/.github/workflows/nightly-terminal-bench.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       models:
-        description: 'Models to test (comma-separated, or "all" for opus + gpt-5.2-codex + gpt-5.2 + google/gemini-3-pro-preview)'
+        description: 'Models to test (comma-separated, or "all" for opus + gpt-5.2-codex + gpt-5.2 + google/gemini-3-pro-preview + google/gemini-3-flash-preview)'
         required: false
         default: "all"
         type: string
@@ -44,7 +44,7 @@ jobs:
           INPUT_MODELS: ${{ inputs.models }}
         run: |
           if [ "$INPUT_MODELS" = "all" ] || [ -z "$INPUT_MODELS" ]; then
-            echo 'models=["anthropic/claude-opus-4-5","openai/gpt-5.2-codex","openai/gpt-5.2","google/gemini-3-pro-preview"]' >> "$GITHUB_OUTPUT"
+            echo 'models=["anthropic/claude-opus-4-5","openai/gpt-5.2-codex","openai/gpt-5.2","google/gemini-3-pro-preview","google/gemini-3-flash-preview"]' >> "$GITHUB_OUTPUT"
           else
             # Convert comma-separated to JSON array
             models_json=$(echo "$INPUT_MODELS" | jq -R -s -c 'split(",") | map(gsub("^\\s+|\\s+$"; ""))')

--- a/.github/workflows/terminal-bench.yml
+++ b/.github/workflows/terminal-bench.yml
@@ -152,6 +152,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
 
       - name: Print results summary


### PR DESCRIPTION
## Summary

- Forward Google provider credentials into the Terminal-Bench Harbor sandbox and fail fast when missing for `google:*` models.
- Add `google/gemini-3-flash-preview` to the nightly Terminal-Bench default model list to help triage `gemini-3-pro-preview` failures.
- Export `GOOGLE_GENERATIVE_AI_API_KEY` in CI for consistency with Mux’s preferred env var name.

## Background

Nightly Terminal-Bench runs currently include `google/gemini-3-pro-preview`, but recent runs have effectively been failing (reported ~0% pass). This PR fixes a likely cause (Google API keys not being forwarded into the sandbox) and adds Flash as a comparison point.

## Implementation

- `benchmarks/terminal_bench/mux_agent.py`: forward `GOOGLE_GENERATIVE_AI_API_KEY` / `GOOGLE_API_KEY` (and `GOOGLE_BASE_URL`) into the container env; raise a clear error if a Google model is selected without credentials.
- `.github/workflows/nightly-terminal-bench.yml`: include `google/gemini-3-flash-preview` in the default model matrix.
- `.github/workflows/terminal-bench.yml`: export `GOOGLE_GENERATIVE_AI_API_KEY` alongside `GOOGLE_API_KEY`.

## Validation

- `make static-check`

---

<details>
<summary>📋 Implementation Plan</summary>

# Add Gemini 3 Flash to nightly Terminal-Bench (and fix Google key forwarding)

## Context / Why
Nightly Terminal-Bench runs currently include `google/gemini-3-pro-preview`, but it appears to be effectively unusable (reported ~0% pass rate). Adding `google/gemini-3-flash-preview` to the nightly model list will help distinguish:
- **setup/integration issue** (both Pro and Flash fail similarly), vs
- **model-specific issue** (Pro fails but Flash works).

During investigation, we found a likely **setup bug**: the Terminal-Bench mux agent adapter does **not** forward Google API key env vars into the task environment, so Gemini requests can fail with `api_key_not_found` even when CI provides `GOOGLE_API_KEY`.

## Evidence (repo)
- `.github/workflows/nightly-terminal-bench.yml`
  - Default `models=[..., "google/gemini-3-pro-preview"]` when `inputs.models == all` (line ~47).
- `.github/workflows/terminal-bench.yml`
  - Passes `GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}` into the benchmark job env (line ~154).
- `benchmarks/terminal_bench/mux_agent.py`
  - `_PROVIDER_ENV_KEYS` omits `GOOGLE_API_KEY` / `GOOGLE_GENERATIVE_AI_API_KEY` / `GOOGLE_BASE_URL` (lines ~37–48), so those variables are never copied into the container env.
- `src/common/constants/knownModels.ts`
  - Both Gemini 3 models already exist:
    - `google:gemini-3-pro-preview`
    - `google:gemini-3-flash-preview`
- `src/node/utils/providerRequirements.ts`
  - Google provider credentials are sourced from `GOOGLE_GENERATIVE_AI_API_KEY` or `GOOGLE_API_KEY`.

<details>
<summary>Root-cause hypothesis (why Gemini is 0% today)</summary>

`terminal-bench.yml` exports `GOOGLE_API_KEY` on the GitHub runner, but Harbor runs the agent inside a container/sandbox. The mux Terminal-Bench adapter (`mux_agent.py`) constructs an explicit env dict from a small allowlist (`_PROVIDER_ENV_KEYS` + `_CONFIG_ENV_KEYS`). Since Google env vars aren’t on that allowlist, they never reach the sandbox, and Mux can’t authenticate to the Google provider.

</details>

---

## Recommended approach (fix setup + add flash) — net **~+10 LoC** (product code)

### 1) Forward Google credentials into Terminal-Bench task environments
**Edit:** `benchmarks/terminal_bench/mux_agent.py`
- Add the following to `_PROVIDER_ENV_KEYS`:
  - `GOOGLE_GENERATIVE_AI_API_KEY`
  - `GOOGLE_API_KEY`
  - `GOOGLE_BASE_URL` (optional but low-risk)

**Optional defensive check (nice-to-have):**
- If `MUX_MODEL` starts with `google:` and neither `GOOGLE_GENERATIVE_AI_API_KEY` nor `GOOGLE_API_KEY` is set, raise a clear error early (so failures are unmistakably “missing creds”, not “0% pass”).

### 2) Add Gemini 3 Flash to the nightly model matrix
**Edit:** `.github/workflows/nightly-terminal-bench.yml`
- In the `determine-models` job default list (the `"all"` case), append:
  - `google/gemini-3-flash-preview`
- Update the `workflow_dispatch.inputs.models.description` string to mention the new default list.

### 3) (Optional) Export both Google env var spellings in CI
**Edit:** `.github/workflows/terminal-bench.yml`
- Keep existing `GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}`.
- Also set:
  - `GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}`

This makes CI consistent with Mux’s preferred env var name while remaining backward-compatible.

### 4) Validation / success criteria
- **Fast CI proof:** workflow-dispatch `Nightly Terminal-Bench` with
  - `models=google/gemini-3-pro-preview,google/gemini-3-flash-preview`
  - Verify logs no longer show credential errors (e.g., `api_key_not_found` for provider `google`).
- **Behavioral proof:** At least one of the Gemini models achieves a non-zero pass rate (or, at minimum, runs trials without auth/setup errors).
- **Decision point:**
  - If Flash works and Pro doesn’t → investigate Pro-specific issues (model support, thinking-level compatibility, API quirks).
  - If both still fail → investigate Google provider integration / API responses using the per-task logs.

---

## Alternative (YAML-only: add flash) — net **~+2 LoC** (product code)
Only update `.github/workflows/nightly-terminal-bench.yml` to include `google/gemini-3-flash-preview`.

**Expectation:** If the root cause is missing Google credential forwarding, Flash will likely also end up ~0% pass, so this doesn’t strongly differentiate “setup vs Pro”.

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: openai:gpt-5.2 • Thinking: xhigh_
