### PR TITLE
🤖 feat: add navigation between user messages in chat

### DIFF
--- a/src/browser/components/Messages/MessageRenderer.tsx
+++ b/src/browser/components/Messages/MessageRenderer.tsx
@@ -3,7 +3,7 @@ import type { FilePart } from "@/common/orpc/types";
 import type { DisplayedMessage } from "@/common/types/message";
 import type { BashOutputGroupInfo } from "@/browser/utils/messages/messageUtils";
 import type { ReviewNoteData } from "@/common/types/review";
-import { UserMessage } from "./UserMessage";
+import { UserMessage, type UserMessageNavigation } from "./UserMessage";
 import { AssistantMessage } from "./AssistantMessage";
 import { ToolMessage } from "./ToolMessage";
 import { ReasoningMessage } from "./ReasoningMessage";
@@ -26,6 +26,8 @@ interface MessageRendererProps {
   isLatestProposePlan?: boolean;
   /** Optional bash_output grouping info (computed at render-time) */
   bashOutputGroup?: BashOutputGroupInfo;
+  /** Navigation info for user messages (backward/forward between user messages) */
+  userMessageNavigation?: UserMessageNavigation;
 }
 
 // Memoized to prevent unnecessary re-renders when parent (AIView) updates
@@ -39,6 +41,7 @@ export const MessageRenderer = React.memo<MessageRendererProps>(
     onReviewNote,
     isLatestProposePlan,
     bashOutputGroup,
+    userMessageNavigation,
   }) => {
     // Route based on message type
     switch (message.type) {
@@ -49,6 +52,7 @@ export const MessageRenderer = React.memo<MessageRendererProps>(
             className={className}
             onEdit={onEditUserMessage}
             isCompacting={isCompacting}
+            navigation={userMessageNavigation}
           />
         );
       case "assistant":


### PR DESCRIPTION
## Summary

Adds backward/forward navigation controls to user messages in the chat UI, allowing users to quickly jump between their own messages in a conversation.

## Background

When reviewing long conversations, users need to navigate between their own messages to retrace their questions or commands. This change adds chevron navigation buttons (◀ ▶) to the user message action row.

## Implementation

- **UserMessage.tsx**: Added `UserMessageNavigation` interface and navigation buttons to the action row. Buttons render when there are 2+ user messages; disabled state (reduced opacity) when at first/last message to prevent layout shift.
- **MessageRenderer.tsx**: Passes navigation prop through to UserMessage.
- **ChatPane.tsx**: Computes a navigation map (`userMessageNavMap`) from deferred messages, builds prev/next links for each user message. Adds `handleNavigateToMessage` callback that scrolls to target using `scrollIntoView({ behavior: "smooth", block: "center" })`.

Key design decisions:
- Navigation appears only when there are 2+ user messages (single-message chats unchanged)
- Both buttons always render to preserve layout consistency; disabled buttons use `opacity-30`
- Scrolls to center the target message in the viewport

## Risks

Low risk—additive UI change. Navigation is isolated to user messages and uses existing `data-message-id` attributes for scroll targeting.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$2.67`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=2.67 -->
