### PR TITLE
feat: unadvertised skills via `advertise: false`

### DIFF
--- a/.mux/skills/deep-review/SKILL.md
+++ b/.mux/skills/deep-review/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: deep-review
+description: Sub-agent powered code reviews spanning correctness, tests, consistency, and fit
+advertise: false
+---
+
+# Deep Review Mode
+
+Provide an **excellent code review** by defaulting to **parallelism**.
+
+You should use sub-agents to review the change from multiple angles (correctness, tests, consistency, UX, performance, safety). Each sub-agent should have a focused mandate and return actionable findings with file paths.
+
+## Step 0: Establish the review surface
+
+Before reviewing, gather context:
+
+- Identify the change scope: `git diff --name-only` (or the file list the user provides).
+- Skim the diff for intent and risk: `git diff`.
+- Note which layers are touched:
+  - UI (React/components/styles)
+  - Main process / backend services
+  - IPC boundary / shared types
+  - Tooling/scripts
+  - Docs
+  - Tests
+
+If the change is large, split review by module and prioritize **high-risk** paths.
+
+## Spawn the right sub-agents (change-type aware)
+
+Spawn **2–5** sub-agents depending on scope. Tailor them to the change.
+
+### Suggested sub-agent set
+
+- **Correctness & edge cases** (always)
+  - Goal: find logic bugs, missing error handling, race conditions, broken invariants.
+- **Tests & verification** (always)
+  - Goal: evaluate test coverage, propose missing tests, suggest commands to validate.
+- **Consistency & architecture** (usually)
+  - Goal: ensure changes match existing patterns, abstractions, and boundaries.
+- **UX & accessibility** (when UI changed)
+  - Goal: keyboard flows, a11y, visual consistency, empty/loading/error states.
+- **Performance & reliability** (when hot paths / streaming / IO changed)
+  - Goal: latency, unnecessary work, blocking calls, memory growth, resilience.
+- **Docs & developer experience** (when docs/scripts/public API changed)
+  - Goal: clarity, correctness, navigation updates, link integrity.
+
+## Synthesize into a single excellent review
+
+When sub-agent results arrive, produce a consolidated review with:
+
+1. **Summary** (what changed + overall risk)
+2. **Issues** 
+3. **Questions** (unknown intent; ask for clarification)
+4. **Suggested validation plan** (commands + manual checks)
+
+Issues should have a severity in form of:
+
+| Severity | Description | Example |
+|----------|-------------|
+| P0 | Change must not be merged until resolved | Change would permanently break core workflows if merged. |
+| P1 | Change should not be merged| New code will not work as expected due to severe bugs|
+| P2 | Consideration required before merging | The change creates inconsistency / fragility |
+| P3 | Minor issue | The change introduces a minor issue that may be addressed later |
+| P4 | Long-term issue | The change raises concerns about long-term maintainability or may break under rare conditions |
+
+### Review rubric
+
+Use this rubric to avoid blind spots:
+
+- **Correctness**: invariants, edge cases, error handling, races
+- **Fitness**: does it meet the user goal, and does it match product constraints?
+- **Tests**: coverage of new logic, regression tests, deterministic behavior
+- **Consistency**: patterns, naming, types, boundaries, IPC typing
+- **Maintainability**: complexity, duplication, readability
+- **Performance**: hot paths, streaming, excessive re-renders/IO
+- **Safety**: secrets, path traversal, injection risks, filesystem safety
+- **DX**: logs, error messages, debuggability
+
+## Anti-patterns
+
+- **Single-threaded review** of a large change (spawn sub-agents).
+- **Vague feedback** (“looks good”) without actionable items and file paths.
+- **Non-verifiable suggestions** (always include a validation plan).
+- **Scope creep** disguised as review (focus on minimal changes unless risk demands more).

--- a/docs/agents/agent-skills.mdx
+++ b/docs/agents/agent-skills.mdx
@@ -12,7 +12,19 @@ Mux follows the Agent Skills specification and exposes skills to models in two s
 1. **Index in the system prompt**: Mux lists available skills (name + description).
 2. **Tool-based loading**: the agent calls tools to load a full skill when needed.
 
-This keeps the system prompt small while still making skills discoverable.
+Skills help you practice progressive disclosure, where the LLM sees only the necessary context to complete
+the task at hand.
+
+The easiest way to invoke a skill in Mux is to use the `/<skill-name>` slash command. For example:
+`/mux-docs suggest tool hooks for this project`.
+
+You can find a list of community-maintained, curated skills at [skills.sh](https://skills.sh/).
+
+You can easily add those skills to your Mux instance with:
+
+```bash
+npx skills add https://github.com/anthropics/skills --skill frontend-design
+```
 
 ## Where skills live
 
@@ -58,54 +70,116 @@ Optional fields:
 - `license`
 - `compatibility`
 - `metadata` (string key/value map)
+- `advertise` (boolean) — set to `false` to omit a skill from the system prompt index (see [Unadvertised skills](#unadvertised-skills) below)
 
 Mux ignores unknown frontmatter keys (for example `allowed-tools`).
 
-Example:
+## Unadvertised skills
+
+By default, Mux _advertises_ skills by listing them in the system prompt’s `<agent-skills>` index.
+
+Set `advertise: false` in the frontmatter to exclude a skill from that index. Unadvertised skills:
+
+- **Are not listed** in the system prompt (reducing token overhead)
+- **Can still be invoked** via `/{skill-name}` slash command or `agent_skill_read({ name: "skill-name" })`
+- **Still appear** in Mux’s UI lists (for example `/` slash suggestions)
+- **Are useful for**: skills meant only for sub-agents, advanced users, or internal orchestration
+
+### Example: `deep-review` skill
+
+The Mux repository includes an unadvertised `deep-review` skill that encourages aggressive use of sub-agents to produce excellent code reviews (correctness, tests, consistency, UX, performance). Invoke it with `/deep-review` when you want a thorough, parallelized review. This skill is defined in `.mux/skills/deep-review/SKILL.md`.
+
+{/* BEGIN DEEP_REVIEW_SKILL */}
 
 ```md
 ---
-name: my-skill
-description: Build and validate a release branch.
-license: MIT
-metadata:
-  owner: platform
+name: deep-review
+description: Sub-agent powered code reviews spanning correctness, tests, consistency, and fit
+advertise: false
 ---
 
-# My Skill
+# Deep Review Mode
 
-1. Do the thing...
+Provide an **excellent code review** by defaulting to **parallelism**.
+
+You should use sub-agents to review the change from multiple angles (correctness, tests, consistency, UX, performance, safety). Each sub-agent should have a focused mandate and return actionable findings with file paths.
+
+## Step 0: Establish the review surface
+
+Before reviewing, gather context:
+
+- Identify the change scope: `git diff --name-only` (or the file list the user provides).
+- Skim the diff for intent and risk: `git diff`.
+- Note which layers are touched:
+  - UI (React/components/styles)
+  - Main process / backend services
+  - IPC boundary / shared types
+  - Tooling/scripts
+  - Docs
+  - Tests
+
+If the change is large, split review by module and prioritize **high-risk** paths.
+
+## Spawn the right sub-agents (change-type aware)
+
+Spawn **2–5** sub-agents depending on scope. Tailor them to the change.
+
+### Suggested sub-agent set
+
+- **Correctness & edge cases** (always)
+  - Goal: find logic bugs, missing error handling, race conditions, broken invariants.
+- **Tests & verification** (always)
+  - Goal: evaluate test coverage, propose missing tests, suggest commands to validate.
+- **Consistency & architecture** (usually)
+  - Goal: ensure changes match existing patterns, abstractions, and boundaries.
+- **UX & accessibility** (when UI changed)
+  - Goal: keyboard flows, a11y, visual consistency, empty/loading/error states.
+- **Performance & reliability** (when hot paths / streaming / IO changed)
+  - Goal: latency, unnecessary work, blocking calls, memory growth, resilience.
+- **Docs & developer experience** (when docs/scripts/public API changed)
+  - Goal: clarity, correctness, navigation updates, link integrity.
+
+## Synthesize into a single excellent review
+
+When sub-agent results arrive, produce a consolidated review with:
+
+1. **Summary** (what changed + overall risk)
+2. **Issues**
+3. **Questions** (unknown intent; ask for clarification)
+4. **Suggested validation plan** (commands + manual checks)
+
+Issues should have a severity in form of:
+
+| Severity | Description                              | Example                                                                                       |
+| -------- | ---------------------------------------- | --------------------------------------------------------------------------------------------- |
+| P0       | Change must not be merged until resolved | Change would permanently break core workflows if merged.                                      |
+| P1       | Change should not be merged              | New code will not work as expected due to severe bugs                                         |
+| P2       | Consideration required before merging    | The change creates inconsistency / fragility                                                  |
+| P3       | Minor issue                              | The change introduces a minor issue that may be addressed later                               |
+| P4       | Long-term issue                          | The change raises concerns about long-term maintainability or may break under rare conditions |
+
+### Review rubric
+
+Use this rubric to avoid blind spots:
+
+- **Correctness**: invariants, edge cases, error handling, races
+- **Fitness**: does it meet the user goal, and does it match product constraints?
+- **Tests**: coverage of new logic, regression tests, deterministic behavior
+- **Consistency**: patterns, naming, types, boundaries, IPC typing
+- **Maintainability**: complexity, duplication, readability
+- **Performance**: hot paths, streaming, excessive re-renders/IO
+- **Safety**: secrets, path traversal, injection risks, filesystem safety
+- **DX**: logs, error messages, debuggability
+
+## Anti-patterns
+
+- **Single-threaded review** of a large change (spawn sub-agents).
+- **Vague feedback** (“looks good”) without actionable items and file paths.
+- **Non-verifiable suggestions** (always include a validation plan).
+- **Scope creep** disguised as review (focus on minimal changes unless risk demands more).
 ```
 
-## Using skills in Mux
-
-Mux injects an `<agent-skills>` block into the system prompt listing the available skills.
-
-You can apply a skill in two ways:
-
-- **Explicit (slash command)**: type `/{skill-name}` (optionally followed by a message: `/{skill-name} ...`) in the chat input. Mux will send your message normally (or a small default message if you omit one), and persist a synthetic snapshot of the skill body in history immediately before that message.
-  - Example: `/init` runs the built-in `init` skill to bootstrap `AGENTS.md`. You can override it with `~/.mux/skills/init/SKILL.md` (or `.mux/skills/init/SKILL.md` for a single project).
-  - Type `/` to see skills in the suggestions list.
-- **Agent-initiated (tool call)**: the agent can load skills on-demand.
-
-To load a skill, the agent calls:
-
-```ts
-agent_skill_read({ name: "my-skill" });
-```
-
-If your skill references additional files (cheatsheets, templates, etc.), the agent can read them with:
-
-```ts
-agent_skill_read_file({ name: "my-skill", filePath: "references/template.md" });
-```
-
-`agent_skill_read_file` supports `offset` / `limit` (like `file_read`) and rejects absolute paths and `..` traversal.
-
-<Info>
-  `agent_skill_read_file` uses the same output limits as `file_read` (roughly 16KB per call,
-  numbered lines). Files are limited to 1MB. Read large files in chunks with `offset`/`limit`.
-</Info>
+{/* END DEEP_REVIEW_SKILL */}
 
 ## Current limitations
 
@@ -126,3 +200,7 @@ agent_skill_read_file({ name: "my-skill", filePath: "references/template.md" });
 - [Integrate skills into your agent](https://agentskills.io/integrate-skills) (tool-based vs filesystem-based)
 - [Example skills (GitHub)](https://github.com/anthropics/skills)
 - [skills-ref validation library (GitHub)](https://github.com/agentskills/agentskills/tree/main/skills-ref)
+
+```
+
+```

--- a/scripts/gen_docs.ts
+++ b/scripts/gen_docs.ts
@@ -16,16 +16,10 @@ import * as path from "path";
 import * as yaml from "yaml";
 import * as prettier from "prettier";
 import { KNOWN_MODELS, DEFAULT_MODEL } from "../src/common/constants/knownModels";
-import {
-  buildCompactionPrompt,
-  DEFAULT_COMPACTION_WORD_TARGET,
-} from "../src/common/constants/ui";
+import { buildCompactionPrompt, DEFAULT_COMPACTION_WORD_TARGET } from "../src/common/constants/ui";
 import { formatModelDisplayName } from "../src/common/utils/ai/modelDisplay";
 import { AgentDefinitionFrontmatterSchema } from "../src/common/orpc/schemas/agentDefinition";
-import {
-  PROVIDER_ENV_VARS,
-  AZURE_OPENAI_ENV_VARS,
-} from "../src/node/utils/providerRequirements";
+import { PROVIDER_ENV_VARS, AZURE_OPENAI_ENV_VARS } from "../src/node/utils/providerRequirements";
 
 const MODE = process.argv[2] === "check" ? "check" : "write";
 const DOCS_DIR = path.join(import.meta.dir, "..", "docs");
@@ -308,7 +302,6 @@ function generateCompactionUserPromptBlock(): string {
   return "```text\n" + prompt.trim() + "\n```";
 }
 
-
 async function syncCompactionCustomizationDocs(): Promise<boolean> {
   // These markers live in the same file, so they must be updated sequentially.
   const systemPromptResult = await syncCompactAgentSystemPrompt();
@@ -323,7 +316,6 @@ async function syncCompactionUserPrompt(): Promise<boolean> {
     generateBlock: generateCompactionUserPromptBlock,
   });
 }
-
 
 // ---------------------------------------------------------------------------
 // User notify tool docs sync
@@ -415,26 +407,32 @@ function generateProviderEnvVarsBlock(): string {
 
     if (vars.baseUrl?.length) {
       lines.push(
-        `| ${displayName.padEnd(12)} | \`${vars.baseUrl[0]}\``.padEnd(42) + " | Custom API endpoint |"
+        `| ${displayName.padEnd(12)} | \`${vars.baseUrl[0]}\``.padEnd(42) +
+          " | Custom API endpoint |"
       );
     }
     if (vars.organization?.length) {
       lines.push(
-        `| ${displayName.padEnd(12)} | \`${vars.organization[0]}\``.padEnd(42) + " | Organization ID     |"
+        `| ${displayName.padEnd(12)} | \`${vars.organization[0]}\``.padEnd(42) +
+          " | Organization ID     |"
       );
     }
   }
 
   // Azure OpenAI (special case)
-  lines.push(`| Azure OpenAI | \`${AZURE_OPENAI_ENV_VARS.apiKey}\``.padEnd(42) + " | API key             |");
+  lines.push(
+    `| Azure OpenAI | \`${AZURE_OPENAI_ENV_VARS.apiKey}\``.padEnd(42) + " | API key             |"
+  );
   lines.push(
     `| Azure OpenAI | \`${AZURE_OPENAI_ENV_VARS.endpoint}\``.padEnd(42) + " | Endpoint URL        |"
   );
   lines.push(
-    `| Azure OpenAI | \`${AZURE_OPENAI_ENV_VARS.deployment}\``.padEnd(42) + " | Deployment name     |"
+    `| Azure OpenAI | \`${AZURE_OPENAI_ENV_VARS.deployment}\``.padEnd(42) +
+      " | Deployment name     |"
   );
   lines.push(
-    `| Azure OpenAI | \`${AZURE_OPENAI_ENV_VARS.apiVersion}\``.padEnd(42) + " | API version         |"
+    `| Azure OpenAI | \`${AZURE_OPENAI_ENV_VARS.apiVersion}\``.padEnd(42) +
+      " | API version         |"
   );
 
   lines.push("");
@@ -459,13 +457,7 @@ async function syncProviderEnvVars(): Promise<boolean> {
 // ---------------------------------------------------------------------------
 
 function generateAutoLabelWorkflowBlock(): string {
-  const workflowPath = path.join(
-    import.meta.dir,
-    "..",
-    ".github",
-    "workflows",
-    "auto-label.yml"
-  );
+  const workflowPath = path.join(import.meta.dir, "..", ".github", "workflows", "auto-label.yml");
   const content = fs.readFileSync(workflowPath, "utf-8");
   return "```yaml\n" + content.trim() + "\n```";
 }
@@ -476,6 +468,26 @@ async function syncAutoLabelWorkflow(): Promise<boolean> {
     sourceLabel: ".github/workflows/auto-label.yml",
     markerName: "AUTO_LABEL_WORKFLOW",
     generateBlock: generateAutoLabelWorkflowBlock,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Deep review skill sync
+// ---------------------------------------------------------------------------
+
+function generateDeepReviewSkillBlock(): string {
+  const skillPath = path.join(import.meta.dir, "..", ".mux", "skills", "deep-review", "SKILL.md");
+  const content = fs.readFileSync(skillPath, "utf-8");
+  // Use 5 backticks to wrap the skill content since it may contain nested code blocks with 3 backticks.
+  return "`````md\n" + content.trim() + "\n`````";
+}
+
+async function syncDeepReviewSkill(): Promise<boolean> {
+  return syncDoc({
+    docsFile: "agents/agent-skills.mdx",
+    sourceLabel: ".mux/skills/deep-review/SKILL.md",
+    markerName: "DEEP_REVIEW_SKILL",
+    generateBlock: generateDeepReviewSkillBlock,
   });
 }
 
@@ -492,6 +504,7 @@ async function main(): Promise<void> {
     syncNotifyDocs(),
     syncProviderEnvVars(),
     syncAutoLabelWorkflow(),
+    syncDeepReviewSkill(),
   ]);
 
   if (results.some((r) => !r)) {

--- a/src/browser/components/SkillIndicator.tsx
+++ b/src/browser/components/SkillIndicator.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Check } from "lucide-react";
+import { Check, EyeOff } from "lucide-react";
 import { cn } from "@/common/lib/utils";
 import { SkillIcon } from "@/browser/components/icons/SkillIcon";
 import { HoverClickPopover } from "@/browser/components/ui/hover-click-popover";
@@ -49,6 +49,7 @@ const SkillsPopoverContent: React.FC<SkillsPopoverContentProps> = (props) => {
             </div>
             {skills.map((skill) => {
               const isLoaded = loadedSkillNames.has(skill.name);
+              const isUnadvertised = skill.advertise === false;
               return (
                 <div key={skill.name} className="flex items-start gap-2">
                   <div className="bg-muted-foreground/30 mt-1.5 h-1 w-1 shrink-0 rounded-full" />
@@ -60,6 +61,12 @@ const SkillsPopoverContent: React.FC<SkillsPopoverContentProps> = (props) => {
                       )}
                     >
                       {skill.name}
+                      {isUnadvertised && (
+                        <EyeOff
+                          className="text-muted-foreground ml-1 inline h-3 w-3"
+                          aria-label="Not advertised in system prompt"
+                        />
+                      )}
                       {isLoaded && <Check className="text-success ml-1 inline h-3 w-3" />}
                     </span>
                     <span className="text-muted-foreground text-[11px] leading-snug">

--- a/src/common/orpc/schemas/agentSkill.ts
+++ b/src/common/orpc/schemas/agentSkill.ts
@@ -21,12 +21,18 @@ export const AgentSkillFrontmatterSchema = z.object({
   license: z.string().optional(),
   compatibility: z.string().min(1).max(500).optional(),
   metadata: z.record(z.string(), z.string()).optional(),
+
+  // When false, skill is NOT listed in the tool description's skill index.
+  // Unadvertised skills can still be invoked via /skill-name or agent_skill_read({ name: "skill-name" }).
+  // Use for internal orchestration skills, sub-agent-only skills, or power-user workflows.
+  advertise: z.boolean().optional(),
 });
 
 export const AgentSkillDescriptorSchema = z.object({
   name: SkillNameSchema,
   description: z.string().min(1).max(1024),
   scope: AgentSkillScopeSchema,
+  advertise: z.boolean().optional(),
 });
 
 export const AgentSkillPackageSchema = z

--- a/src/node/services/agentSkills/agentSkillsService.test.ts
+++ b/src/node/services/agentSkills/agentSkillsService.test.ts
@@ -38,6 +38,7 @@ describe("agentSkillsService", () => {
     const skills = await discoverAgentSkills(runtime, project.path, { roots });
 
     // Should include project/global skills plus built-in skills
+    // Note: deep-review skill is a project skill in the Mux repo, not a built-in
     expect(skills.map((s) => s.name)).toEqual(["bar", "foo", "init", "mux-docs"]);
 
     const foo = skills.find((s) => s.name === "foo");

--- a/src/node/services/agentSkills/agentSkillsService.ts
+++ b/src/node/services/agentSkills/agentSkillsService.ts
@@ -128,6 +128,7 @@ async function readSkillDescriptorFromDir(
       name: parsed.frontmatter.name,
       description: parsed.frontmatter.description,
       scope,
+      advertise: parsed.frontmatter.advertise,
     };
 
     const validated = AgentSkillDescriptorSchema.safeParse(descriptor);

--- a/src/node/services/agentSkills/builtInSkillDefinitions.ts
+++ b/src/node/services/agentSkills/builtInSkillDefinitions.ts
@@ -57,6 +57,7 @@ export function getBuiltInSkillDescriptors(): AgentSkillDescriptor[] {
     name: pkg.frontmatter.name,
     description: pkg.frontmatter.description,
     scope: pkg.scope,
+    advertise: pkg.frontmatter.advertise,
   }));
 }
 

--- a/src/node/services/agentSkills/parseSkillMarkdown.test.ts
+++ b/src/node/services/agentSkills/parseSkillMarkdown.test.ts
@@ -47,6 +47,27 @@ Body
     expect(result.frontmatter.description).toBe("Hello");
   });
 
+  test("parses advertise field in frontmatter", () => {
+    const content = `---
+name: internal-skill
+description: An internal skill not shown in the index
+advertise: false
+---
+Body
+`;
+
+    const directoryName = SkillNameSchema.parse("internal-skill");
+
+    const result = parseSkillMarkdown({
+      content,
+      byteSize: Buffer.byteLength(content, "utf-8"),
+      directoryName,
+    });
+
+    expect(result.frontmatter.name).toBe("internal-skill");
+    expect(result.frontmatter.advertise).toBe(false);
+  });
+
   test("throws on missing frontmatter", () => {
     const content = "# No frontmatter\n";
     expect(() =>

--- a/src/node/services/tools/agent_skill_read.ts
+++ b/src/node/services/tools/agent_skill_read.ts
@@ -20,7 +20,9 @@ function formatError(error: unknown): string {
  */
 function buildSkillReadDescription(config: ToolConfiguration): string {
   const baseDescription = TOOL_DEFINITIONS.agent_skill_read.description;
-  const skills = config.availableSkills ?? [];
+  // Filter out unadvertised skills from the tool description.
+  // Unadvertised skills can still be invoked via /skill-name or agent_skill_read.
+  const skills = (config.availableSkills ?? []).filter((s) => s.advertise !== false);
 
   if (skills.length === 0) {
     return baseDescription;


### PR DESCRIPTION
## Summary

Add support for **unadvertised skills** via `advertise: false` in skill frontmatter.

Unadvertised skills:
- Are **not listed** in the tool description's skill index (reducing token overhead)
- **Can still be invoked** via `/{skill-name}` slash command or `agent_skill_read({ name: "skill-name" })`
- **Still appear** in Mux's UI lists (e.g., `/` slash suggestions)
- Are useful for: internal orchestration skills, sub-agent-only skills, or power-user workflows

## Changes

### Schema & filtering
- Add `advertise: z.boolean().optional()` to `AgentSkillFrontmatterSchema` and `AgentSkillDescriptorSchema`
- Filter skills with `advertise: false` from the tool description in `agent_skill_read.ts`

### UI
- Add EyeOff icon indicator in `SkillIndicator` for unadvertised skills
- Add full-app story (`SkillIndicator_UnadvertisedSkills`) in `App.agentSkills.stories.tsx`

### Example skill
- Add **`deep-review`** as a project skill (`.mux/skills/deep-review/SKILL.md`)
- A sub-agent-powered code review workflow spanning correctness, tests, consistency, UX, and performance
- Invoke with `/deep-review` for thorough, parallelized reviews

### Documentation
- Document the `advertise` field in `docs/agents/agent-skills.mdx`
- Add docs generator support for `deep-review` skill content sync

## Test plan

- `make static-check` passes
- Skill tests pass (`bun test --grep skill`)
- Manual: `/deep-review` slash command loads the skill and provides review guidance
- Story: `SkillIndicator_UnadvertisedSkills` shows EyeOff icons for unadvertised skills
