### PR TITLE
🤖 refactor: rename file_edit_insert before/after to insert_after/insert_before

### DIFF
--- a/src/common/types/tools.ts
+++ b/src/common/types/tools.ts
@@ -112,10 +112,10 @@ export interface FileEditErrorResult extends ToolOutputUiOnlyFields {
 export interface FileEditInsertToolArgs {
   file_path: string;
   content: string;
-  /** Optional substring that must appear immediately before the insertion point */
-  before?: string;
-  /** Optional substring that must appear immediately after the insertion point */
-  after?: string;
+  /** Anchor text to insert before. Content will be placed immediately before this substring. */
+  insert_before?: string;
+  /** Anchor text to insert after. Content will be placed immediately after this substring. */
+  insert_after?: string;
 }
 
 // FileEditInsertToolResult derived from Zod schema (single source of truth)

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -614,7 +614,7 @@ export const TOOL_DEFINITIONS = {
   file_edit_insert: {
     description:
       "Insert content into a file using substring guards. " +
-      "Provide exactly one of before or after to anchor the operation when editing an existing file. " +
+      "Provide exactly one of insert_before or insert_after to anchor the operation when editing an existing file. " +
       "When the file does not exist, it is created automatically without guards. " +
       "Optional before/after substrings must uniquely match surrounding content. " +
       "Avoid short guards like `}` or `}\\n` that match multiple locations — " +
@@ -623,20 +623,24 @@ export const TOOL_DEFINITIONS = {
       .object({
         file_path: FILE_EDIT_FILE_PATH,
         content: z.string().describe("The content to insert"),
-        before: z
+        insert_before: z
           .string()
           .min(1)
           .optional()
-          .describe("Optional substring that must appear immediately before the insertion point"),
-        after: z
+          .describe(
+            "Anchor text to insert before. Content will be placed immediately before this substring."
+          ),
+        insert_after: z
           .string()
           .min(1)
           .optional()
-          .describe("Optional substring that must appear immediately after the insertion point"),
+          .describe(
+            "Anchor text to insert after. Content will be placed immediately after this substring."
+          ),
       })
-      .refine((data) => !(data.before !== undefined && data.after !== undefined), {
-        message: "Provide only one of before or after (not both).",
-        path: ["before"],
+      .refine((data) => !(data.insert_before !== undefined && data.insert_after !== undefined), {
+        message: "Provide only one of insert_before or insert_after (not both).",
+        path: ["insert_before"],
       }),
   },
   ask_user_question: {

--- a/src/node/services/tools/file_edit_insert.test.ts
+++ b/src/node/services/tools/file_edit_insert.test.ts
@@ -36,12 +36,12 @@ describe("file_edit_insert tool", () => {
     await fs.rm(testDir, { recursive: true, force: true });
   });
 
-  it("inserts content using before guard", async () => {
+  it("inserts content using insert_after guard", async () => {
     const tool = createTestTool(testDir);
     const args: FileEditInsertToolArgs = {
       file_path: path.relative(testDir, testFilePath),
       content: "Line 2\n",
-      before: "Line 1\n",
+      insert_after: "Line 1\n",
     };
 
     const result = (await tool.execute!(args, mockToolCallOptions)) as FileEditInsertToolResult;
@@ -51,14 +51,14 @@ describe("file_edit_insert tool", () => {
     expect(updated).toBe("Line 1\nLine 2\nLine 3");
   });
 
-  it("inserts content using before guard when file uses CRLF", async () => {
+  it("inserts content using insert_after guard when file uses CRLF", async () => {
     await fs.writeFile(testFilePath, "Line 1\r\nLine 3\r\n");
 
     const tool = createTestTool(testDir);
     const args: FileEditInsertToolArgs = {
       file_path: path.relative(testDir, testFilePath),
       content: "Line 2\n",
-      before: "Line 1\n",
+      insert_after: "Line 1\n",
     };
 
     const result = (await tool.execute!(args, mockToolCallOptions)) as FileEditInsertToolResult;
@@ -68,12 +68,12 @@ describe("file_edit_insert tool", () => {
     expect(updated).toBe("Line 1\r\nLine 2\r\nLine 3\r\n");
   });
 
-  it("inserts content using after guard", async () => {
+  it("inserts content using insert_before guard", async () => {
     const tool = createTestTool(testDir);
     const args: FileEditInsertToolArgs = {
       file_path: path.relative(testDir, testFilePath),
       content: "Header\n",
-      after: "Line 1",
+      insert_before: "Line 1",
     };
 
     const result = (await tool.execute!(args, mockToolCallOptions)) as FileEditInsertToolResult;
@@ -87,7 +87,7 @@ describe("file_edit_insert tool", () => {
     const args: FileEditInsertToolArgs = {
       file_path: path.relative(testDir, testFilePath),
       content: "middle\n",
-      before: "repeat\n",
+      insert_after: "repeat\n",
     };
 
     const result = (await tool.execute!(args, mockToolCallOptions)) as FileEditInsertToolResult;
@@ -104,7 +104,7 @@ describe("file_edit_insert tool", () => {
     const args: FileEditInsertToolArgs = {
       file_path: path.relative(testDir, testFilePath),
       content: "Line 2\n",
-      before: "does not exist\n",
+      insert_after: "does not exist\n",
     };
 
     const result = (await tool.execute!(args, mockToolCallOptions)) as FileEditInsertToolResult;
@@ -113,19 +113,19 @@ describe("file_edit_insert tool", () => {
     expect(await fs.readFile(testFilePath, "utf-8")).toBe(original);
   });
 
-  it("fails when both before and after are provided", async () => {
+  it("fails when both insert_before and insert_after are provided", async () => {
     const tool = createTestTool(testDir);
     const args: FileEditInsertToolArgs = {
       file_path: path.relative(testDir, testFilePath),
       content: "oops",
-      before: "Line 1",
-      after: "Line 3",
+      insert_after: "Line 1",
+      insert_before: "Line 3",
     };
 
     const result = (await tool.execute!(args, mockToolCallOptions)) as FileEditInsertToolResult;
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error).toContain("only one of before or after");
+      expect(result.error).toContain("only one of insert_before or insert_after");
     }
   });
 
@@ -152,7 +152,7 @@ describe("file_edit_insert tool", () => {
     const result = (await tool.execute!(args, mockToolCallOptions)) as FileEditInsertToolResult;
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error).toContain("Provide either a before or after guard");
+      expect(result.error).toContain("Provide either insert_before or insert_after guard");
     }
   });
 });
@@ -239,7 +239,7 @@ describe("file_edit_insert plan mode enforcement", () => {
     const args: FileEditInsertToolArgs = {
       file_path: testFilePath,
       content: "// header\n",
-      after: "const x = 1;",
+      insert_before: "const x = 1;",
     };
 
     const result = (await tool.execute!(args, mockToolCallOptions)) as FileEditInsertToolResult;


### PR DESCRIPTION
## Summary

Renames the confusing `before`/`after` parameters in `file_edit_insert` to semantically clear `insert_after`/`insert_before`.

## Background

Agents frequently misunderstand the `before`/`after` parameter semantics:
- `before: "X"` meant X appears **before** the insertion point → content inserted **after** X
- `after: "Y"` meant Y appears **after** the insertion point → content inserted **before** Y

This was counterintuitive. The DOM API's `insertAdjacentHTML` uses clearer naming (`beforebegin`/`afterend`) that describes where the **new content goes**, not where the anchor is.

## Implementation

| Old | New | Meaning |
|-----|-----|---------|
| `before` | `insert_after` | "Insert my content after this anchor text" |
| `after` | `insert_before` | "Insert my content before this anchor text" |

**New descriptions:**
- `insert_before`: "Anchor text to insert before. Content will be placed immediately before this substring."
- `insert_after`: "Anchor text to insert after. Content will be placed immediately after this substring."

**Files changed:**
- `src/common/types/tools.ts` - Updated `FileEditInsertToolArgs` interface
- `src/common/utils/tools/toolDefinitions.ts` - Updated schema and descriptions
- `src/node/services/tools/file_edit_insert.ts` - Updated implementation
- `src/node/services/tools/file_edit_insert.test.ts` - Updated all test cases

## Risks

Low risk - this is a breaking change to the tool interface, but:
1. The IPC boundary docs say "It is safe to assume frontend/backend are always in sync. Freely make breaking changes."
2. All tests pass and behavior is unchanged, only names are clearer

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$2.69`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=2.69 -->
