### PR TITLE
🤖 tests: clear workspace drafts in storybook preview

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -6,6 +6,7 @@ import {
   TUTORIAL_STATE_KEY,
   RIGHT_SIDEBAR_COLLAPSED_KEY,
   EXPANDED_PROJECTS_KEY,
+  WORKSPACE_DRAFTS_BY_PROJECT_KEY,
   type TutorialState,
 } from "../src/common/constants/storage";
 import { NOW } from "../src/browser/stories/mockFactory";
@@ -67,6 +68,14 @@ function collapseProjects() {
   }
 }
 
+// Clear workspace drafts to ensure deterministic snapshots.
+// Drafts persist in localStorage and can leak between stories causing flaky diffs.
+function clearWorkspaceDrafts() {
+  if (typeof localStorage !== "undefined") {
+    localStorage.setItem(WORKSPACE_DRAFTS_BY_PROJECT_KEY, JSON.stringify({}));
+  }
+}
+
 const preview: Preview = {
   globalTypes: {
     theme: {
@@ -119,6 +128,9 @@ const preview: Preview = {
       // Collapse projects by default so one story doesn't leak expanded state into the next.
       // Stories that want expanded projects should call expandProjects() in setup.
       collapseProjects();
+
+      // Clear workspace drafts so they don't leak between stories.
+      clearWorkspaceDrafts();
 
       return (
         <ThemeProvider forcedTheme={mode}>


### PR DESCRIPTION
## Summary

Fixes Storybook flakiness where some stories show a random number of draft workspaces leaking from other stories.

## Background

The recent addition of draft workspaces (#1918) stores draft state in localStorage under the `workspaceDraftsByProject` key. This persisted state was leaking between Storybook stories, causing non-deterministic snapshots.

## Implementation

Added `clearWorkspaceDrafts()` to the Storybook preview decorator, following the existing pattern used for other localStorage keys (`TUTORIAL_STATE_KEY`, `RIGHT_SIDEBAR_COLLAPSED_KEY`, `EXPANDED_PROJECTS_KEY`) that are reset before each story renders.

## Validation

- `make typecheck` passes
- `make fmt-check` passes
- `bun run storybook:build` succeeds

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.69`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=0.69 -->
