### PR TITLE
🤖 refactor: unify WorkspaceListItem for draft and regular workspaces

### DIFF
--- a/src/browser/stories/storyHelpers.ts
+++ b/src/browser/stories/storyHelpers.ts
@@ -23,6 +23,9 @@ import {
   getReviewsKey,
   getHunkFirstSeenKey,
   REVIEW_SORT_ORDER_KEY,
+  WORKSPACE_DRAFTS_BY_PROJECT_KEY,
+  getDraftScopeId,
+  getWorkspaceNameStateKey,
 } from "@/common/constants/storage";
 import type { ReviewSortOrder } from "@/common/types/review";
 import type { HunkFirstSeenState } from "@/browser/hooks/useHunkFirstSeen";
@@ -108,6 +111,60 @@ export function setReviewSortOrder(order: ReviewSortOrder): void {
 }
 
 /** Create a sample review for stories */
+// ═══════════════════════════════════════════════════════════════════════════════
+// WORKSPACE DRAFTS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export interface WorkspaceDraftFixture {
+  draftId: string;
+  /** Optional: section ID the draft belongs to */
+  sectionId?: string | null;
+  /** Optional: draft prompt text */
+  prompt?: string;
+  /** Optional: workspace name (either manual or generated) */
+  workspaceName?: string;
+  /** Optional: timestamp for sorting */
+  createdAt?: number;
+}
+
+/**
+ * Set workspace drafts for a project in localStorage.
+ * This seeds the sidebar with UI-only draft placeholders.
+ */
+export function setWorkspaceDrafts(projectPath: string, drafts: WorkspaceDraftFixture[]): void {
+  // Set the drafts index
+  const draftsByProject = JSON.parse(
+    localStorage.getItem(WORKSPACE_DRAFTS_BY_PROJECT_KEY) ?? "{}"
+  ) as Record<string, Array<{ draftId: string; sectionId?: string | null; createdAt?: number }>>;
+
+  draftsByProject[projectPath] = drafts.map((d) => ({
+    draftId: d.draftId,
+    sectionId: d.sectionId,
+    createdAt: d.createdAt ?? Date.now(),
+  }));
+
+  localStorage.setItem(WORKSPACE_DRAFTS_BY_PROJECT_KEY, JSON.stringify(draftsByProject));
+
+  // Set individual draft data (prompt and name)
+  for (const draft of drafts) {
+    const scopeId = getDraftScopeId(projectPath, draft.draftId);
+
+    // Set prompt if provided
+    if (draft.prompt !== undefined) {
+      localStorage.setItem(getInputKey(scopeId), JSON.stringify(draft.prompt));
+    }
+
+    // Set workspace name state if provided
+    if (draft.workspaceName !== undefined) {
+      const nameState = {
+        autoGenerate: false,
+        manualName: draft.workspaceName,
+      };
+      localStorage.setItem(getWorkspaceNameStateKey(scopeId), JSON.stringify(nameState));
+    }
+  }
+}
+
 export function createReview(
   id: string,
   filePath: string,


### PR DESCRIPTION
## Summary

Unifies the `WorkspaceListItem` component to handle both regular workspaces and draft workspaces (UI-only placeholders), fixing visual inconsistencies and adding Storybook coverage to prevent future regressions.

## Background

The recent restyle of `WorkspaceListItem` didn't capture the Draft workspace feature that was added separately. The `DraftWorkspaceListItem` in `ProjectSidebar` had different styling:
- Used `border-l-[3px]` instead of absolute-positioned bar
- Had `text-[14px]` instead of `text-[13px]`
- Different button alignment and structure

This inconsistency meant drafts visually didn't match regular workspaces, and there was no Storybook coverage to catch such regressions.

## Implementation

1. **Unified `WorkspaceListItem` component** with `variant: "draft"` support:
   - Extracted shared utilities: `LIST_ITEM_BASE_CLASSES`, `getItemPaddingLeft()`, `SelectionBar`, `ActionButtonWrapper`
   - Both variants share the same visual foundation via these shared components

2. **Aesthetic differentiation for drafts**:
   - Italic text for draft titles
   - Dashed selection bar (repeating gradient) when selected, vs solid blue for regular workspaces

3. **Refactored `ProjectSidebar`**:
   - Removed inline `DraftWorkspaceListItem` 
   - Added `DraftWorkspaceListItemWrapper` that fetches draft data and delegates to unified component

4. **Added Storybook coverage**:
   - `WorkspaceDrafts` story: Various draft states (named, unnamed, with/without prompt)
   - `WorkspaceDraftSelected` story: Shows dashed selection indicator
   - `setWorkspaceDrafts()` helper for seeding draft data in stories

## Validation

- All static checks pass (`make static-check`)
- TypeScript compiles cleanly
- Related tests pass

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$3.87`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=3.87 -->
