### PR TITLE
🤖 fix: sort draft workspaces by newest first

### DIFF
--- a/src/browser/components/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar.tsx
@@ -887,7 +887,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                               const depthByWorkspaceId = computeWorkspaceDepthMap(allWorkspaces);
                               const sortedDrafts = draftsForProject
                                 .slice()
-                                .sort((a, b) => a.createdAt - b.createdAt);
+                                .sort((a, b) => b.createdAt - a.createdAt);
                               const draftNumberById = new Map(
                                 sortedDrafts.map(
                                   (draft, index) => [draft.draftId, index + 1] as const


### PR DESCRIPTION
## Summary

Fixes a bug where newly created draft workspaces appeared at the bottom of the workspace list instead of the top.

## Background

Draft workspaces were sorted by `a.createdAt - b.createdAt` (ascending/oldest-first order), causing new drafts to appear at the bottom. This was inconsistent with how regular workspaces are sorted (most recent first via `workspaceRecency`).

## Implementation

Changed the sort comparator in `ProjectSidebar.tsx` from `a.createdAt - b.createdAt` to `b.createdAt - a.createdAt` so newer drafts appear at the top.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.64`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=0.64 -->
