### PR TITLE
🤖 fix: show title instead of name for draft workspaces in sidebar

### DIFF
--- a/src/browser/components/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar.tsx
@@ -13,6 +13,7 @@ import {
   getInputKey,
   getWorkspaceNameStateKey,
 } from "@/common/constants/storage";
+import { getDisplayTitleFromPersistedState } from "@/browser/hooks/useWorkspaceName";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend, getEmptyImage } from "react-dnd-html5-backend";
 import { useDrag, useDrop, useDragLayer } from "react-dnd";
@@ -208,32 +209,13 @@ function DraftWorkspaceListItemWrapper(props: DraftWorkspaceListItemWrapperProps
     listener: true,
   });
 
-  const workspaceName = (() => {
-    if (!workspaceNameState || typeof workspaceNameState !== "object") {
-      return "";
-    }
-
-    const record = workspaceNameState as Record<string, unknown>;
-    const autoGenerate = record.autoGenerate !== false;
-
-    if (autoGenerate) {
-      const generatedIdentity = record.generatedIdentity;
-      if (!generatedIdentity || typeof generatedIdentity !== "object") {
-        return "";
-      }
-
-      const generatedRecord = generatedIdentity as Record<string, unknown>;
-      return typeof generatedRecord.name === "string" ? generatedRecord.name : "";
-    }
-
-    return typeof record.manualName === "string" ? record.manualName : "";
-  })();
+  const workspaceTitle = getDisplayTitleFromPersistedState(workspaceNameState);
 
   // Collapse whitespace so multi-line prompts show up nicely as a single-line preview.
   const promptPreview =
     typeof draftPrompt === "string" ? draftPrompt.trim().replace(/\s+/g, " ") : "";
 
-  const titleText = workspaceName.trim().length > 0 ? workspaceName.trim() : "Draft";
+  const titleText = workspaceTitle.trim().length > 0 ? workspaceTitle.trim() : "Draft";
 
   return (
     <WorkspaceListItem


### PR DESCRIPTION
## Summary

Draft workspaces in the sidebar now show the human-readable title (e.g., "Fix plan mode over SSH") instead of the git-safe branch name (e.g., "plan-a1b2"), matching the display behavior of real workspaces.

## Background

When workspace name generation runs, it produces both:
- `name`: git-safe branch name (e.g., `"plan-a1b2"`)
- `title`: human-readable title (e.g., `"Fix plan mode over SSH"`)

Real workspaces already display `metadata.title ?? metadata.name` (preferring title), but draft workspaces were only reading and displaying the `name` field.

## Implementation

- Added `getDisplayTitleFromPersistedState()` helper in `useWorkspaceName.ts` that extracts the display title from persisted workspace name state
- Updated `DraftWorkspaceListItem` in `ProjectSidebar.tsx` to use this shared helper instead of duplicating the extraction logic
- The helper prefers `title` over `name` for auto-generated identities, matching real workspace display behavior

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.83`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=0.83 -->
