### PR TITLE
🤖 tests: clear workspace drafts in storybook preview

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -10,6 +10,7 @@ import {
   type TutorialState,
 } from "../src/common/constants/storage";
 import { NOW } from "../src/browser/stories/mockFactory";
+import { updatePersistedState } from "../src/browser/hooks/usePersistedState";
 
 const STORYBOOK_FONTS_READY_TIMEOUT_MS = 2500;
 
@@ -70,10 +71,9 @@ function collapseProjects() {
 
 // Clear workspace drafts to ensure deterministic snapshots.
 // Drafts persist in localStorage and can leak between stories causing flaky diffs.
+// Uses updatePersistedState to notify subscribers (WorkspaceContext uses listener: true).
 function clearWorkspaceDrafts() {
-  if (typeof localStorage !== "undefined") {
-    localStorage.setItem(WORKSPACE_DRAFTS_BY_PROJECT_KEY, JSON.stringify({}));
-  }
+  updatePersistedState(WORKSPACE_DRAFTS_BY_PROJECT_KEY, {});
 }
 
 const preview: Preview = {


### PR DESCRIPTION
## Summary

Fixes Storybook flakiness where some stories show a random number of draft workspaces leaking from other stories.

## Background

The recent addition of draft workspaces (#1918) stores draft state in localStorage under the `workspaceDraftsByProject` key. This persisted state was leaking between Storybook stories, causing non-deterministic snapshots.

## Implementation

Added `clearWorkspaceDrafts()` to the Storybook preview decorator, following the existing pattern used for other localStorage keys (`TUTORIAL_STATE_KEY`, `RIGHT_SIDEBAR_COLLAPSED_KEY`, `EXPANDED_PROJECTS_KEY`) that are reset before each story renders.

Uses `updatePersistedState` (rather than direct `localStorage.setItem`) to properly notify subscribers, since `WorkspaceContext` uses `listener: true` for this key.

## Validation

- `make typecheck` passes

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.69`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=0.69 -->
