### PR TITLE
🤖 fix: prevent devcontainer config loading flash

### DIFF
--- a/src/browser/components/ChatInput/CreationControls.tsx
+++ b/src/browser/components/ChatInput/CreationControls.tsx
@@ -558,7 +558,10 @@ export function CreationControls(props: CreationControlsProps) {
           <div className="border-border-medium flex w-fit flex-col gap-1.5 rounded-md border p-2">
             <div className="flex flex-col gap-1">
               <label className="text-muted-foreground text-xs">Config</label>
-              {devcontainerSelection.uiMode === "dropdown" ? (
+              {devcontainerSelection.uiMode === "loading" ? (
+                // Skeleton placeholder while loading - matches dropdown dimensions
+                <div className="bg-bg-dark/50 h-6 w-[280px] animate-pulse rounded-md" />
+              ) : devcontainerSelection.uiMode === "dropdown" ? (
                 <RadixSelect
                   value={devcontainerSelection.configPath}
                   onValueChange={(value) =>

--- a/src/browser/utils/devcontainerSelection.test.ts
+++ b/src/browser/utils/devcontainerSelection.test.ts
@@ -32,27 +32,28 @@ describe("resolveDevcontainerSelection", () => {
   describe("loading state", () => {
     const loadingState: RuntimeAvailabilityState = { status: "loading" };
 
-    it("returns input mode with no implicit default (P2 fix)", () => {
+    it("returns loading mode with skeleton placeholder (avoids flash)", () => {
       const result = resolveDevcontainerSelection({
         selectedRuntime: { mode: "devcontainer", configPath: "" },
         availabilityState: loadingState,
       });
 
-      expect(result.uiMode).toBe("input");
+      expect(result.uiMode).toBe("loading");
       expect(result.configPath).toBe("");
       expect(result.isCreatable).toBe(false);
-      expect(result.helperText).toBe("Loading configs…");
+      expect(result.helperText).toBeNull();
     });
 
-    it("is creatable when user provides explicit path", () => {
+    it("blocks creation during loading even with explicit path", () => {
       const result = resolveDevcontainerSelection({
         selectedRuntime: { mode: "devcontainer", configPath: ".devcontainer.json" },
         availabilityState: loadingState,
       });
 
-      expect(result.uiMode).toBe("input");
+      expect(result.uiMode).toBe("loading");
       expect(result.configPath).toBe(".devcontainer.json");
-      expect(result.isCreatable).toBe(true);
+      // Block creation until configs loaded to avoid invalid selections
+      expect(result.isCreatable).toBe(false);
     });
   });
 

--- a/src/browser/utils/devcontainerSelection.ts
+++ b/src/browser/utils/devcontainerSelection.ts
@@ -14,7 +14,7 @@ import type { RuntimeAvailabilityState } from "@/browser/components/ChatInput/us
 export const DEFAULT_DEVCONTAINER_CONFIG_PATH = ".devcontainer/devcontainer.json";
 
 /** UI mode for devcontainer config controls */
-export type DevcontainerUiMode = "hidden" | "dropdown" | "input";
+export type DevcontainerUiMode = "hidden" | "loading" | "dropdown" | "input";
 
 /** Result of devcontainer selection resolution */
 export interface DevcontainerSelection {
@@ -63,14 +63,14 @@ export function resolveDevcontainerSelection(
 
   const selectedPath = selectedRuntime.configPath.trim();
 
-  // Loading state - show input, no implicit default (P2 fix)
+  // Loading state - show skeleton placeholder to avoid flash when switching to dropdown
   if (availabilityState.status === "loading") {
     return {
       configPath: selectedPath,
       configs: [],
-      uiMode: "input",
-      helperText: "Loading configs…",
-      isCreatable: selectedPath.length > 0,
+      uiMode: "loading",
+      helperText: null,
+      isCreatable: false, // Block creation until configs loaded
     };
   }
 


### PR DESCRIPTION
## Summary

Prevents layout flash when devcontainer configs are loading by replacing the input + "Loading configs…" text with a skeleton placeholder.

## Background

When creating a workspace with devcontainer runtime selected, the config controls section would flash:
1. First showing an input field with "Loading configs…" helper text
2. Then switching to a dropdown after configs loaded

This caused a visual layout shift as the control type changed.

## Implementation

- Added `loading` uiMode to `DevcontainerUiMode` type
- During loading, now shows a skeleton placeholder that matches the dropdown dimensions (`h-6 w-[280px]`)
- Removed "Loading configs…" helper text (no text during loading)
- Block workspace creation during loading to ensure valid config selection

## Risks

Low risk - only affects the visual display during the brief loading phase. Creation is blocked until configs load, ensuring users can't submit with potentially invalid selections.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$9.16`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=9.16 -->
