### PR TITLE
🤖 fix: show full Codex comments and harden tool_post hook

### DIFF
--- a/.mux/tool_post
+++ b/.mux/tool_post
@@ -2,7 +2,8 @@
 # .mux/tool_post - Format TypeScript and Markdown files after edits
 
 if [[ "$MUX_TOOL" == file_edit_* ]]; then
-  file=$(echo "$MUX_TOOL_INPUT" | jq -r '.file_path')
+  file=$(echo "$MUX_TOOL_INPUT" | jq -r '.file_path' 2>/dev/null) || exit 0
+  [[ -z "$file" || "$file" == "null" ]] && exit 0
 
   case "$file" in
     *.ts|*.tsx)

--- a/scripts/check_codex_comments.sh
+++ b/scripts/check_codex_comments.sh
@@ -95,20 +95,11 @@ if [ $TOTAL_UNRESOLVED -gt 0 ]; then
   echo "Codex comments:"
 
   if [ "$REGULAR_COUNT" -gt 0 ]; then
-    echo "$REGULAR_COMMENTS" | jq -r '.[] | "  - [\(.created_at)] \(.body[0:100] | gsub("\\n"; " "))..."'
+    echo "$REGULAR_COMMENTS" | jq -r '.[] | "  - [\(.createdAt)]\n\(.body)\n"'
   fi
 
   if [ "$UNRESOLVED_COUNT" -gt 0 ]; then
-    THREAD_SUMMARY=$(echo "$UNRESOLVED_THREADS" | jq '[.[] | {
-      createdAt: .comments.nodes[0].createdAt,
-      thread: .id,
-      comment: .comments.nodes[0].id,
-      path: (.comments.nodes[0].path // "comment"),
-      line: (.comments.nodes[0].line // ""),
-      snippet: (.comments.nodes[0].body[0:100] | gsub("\n"; " "))
-    }]')
-
-    echo "$THREAD_SUMMARY" | jq -r '.[] | "  - [\(.createdAt)] thread=\(.thread) comment=\(.comment) \(.path):\(.line) - \(.snippet)..."'
+    echo "$UNRESOLVED_THREADS" | jq -r '.[] | "  - [\(.comments.nodes[0].createdAt)] thread=\(.id) \(.comments.nodes[0].path // "comment"):\(.comments.nodes[0].line // "")\n\(.comments.nodes[0].body)\n"'
     echo ""
     echo "Resolve review threads with: ./scripts/resolve_pr_comment.sh <thread_id>"
   fi


### PR DESCRIPTION
## Summary

Fixes `check_codex_comments.sh` to display full comment bodies instead of truncating to 100 characters, and hardens the `.mux/tool_post` hook to gracefully handle jq parse errors.

## Changes

### `scripts/check_codex_comments.sh`
- Removed 100-character truncation (`body[0:100]`) for both regular comments and review threads
- Full comment bodies are now displayed with preserved newlines
- Simplified the jq expressions by removing intermediate JSON transformation

### `.mux/tool_post`
- Added `2>/dev/null` to suppress jq parse errors when tool input contains special characters
- Added early exit if file path extraction fails or returns null
- Prevents spurious error messages when editing non-TS/MD files (like shell scripts)

## Validation

Tested jq expressions with mock data to confirm full comments display correctly with preserved formatting.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.51`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=0.51 -->
