### PR TITLE
🤖 fix: add explicit char limit to workspace name prompt

### DIFF
--- a/src/node/services/workspaceTitleGenerator.ts
+++ b/src/node/services/workspaceTitleGenerator.ts
@@ -15,7 +15,7 @@ const workspaceIdentitySchema = z.object({
     .min(2)
     .max(20)
     .describe(
-      "Codebase area (1-2 words): lowercase, hyphens only, e.g. 'sidebar', 'auth', 'config'"
+      "Codebase area (1-2 words, max 15 chars): lowercase, hyphens only, e.g. 'sidebar', 'auth', 'config'"
     ),
   title: z
     .string()
@@ -96,7 +96,7 @@ export async function generateWorkspaceIdentity(
 "${message}"
 
 Requirements:
-- name: The area of the codebase being worked on (1-2 words, git-safe: lowercase, hyphens only). Random bytes will be appended for uniqueness, so focus on the area not the specific task. Examples: "sidebar", "auth", "config", "api"
+- name: The area of the codebase being worked on (1-2 words, max 15 chars, git-safe: lowercase, hyphens only). Random bytes will be appended for uniqueness, so focus on the area not the specific task. Examples: "sidebar", "auth", "config", "api"
 - title: A 2-5 word description in verb-noun format. Examples: "Fix plan mode", "Add user authentication", "Refactor sidebar layout"`,
       });
 


### PR DESCRIPTION
## Summary

Adds explicit character limit guidance to workspace name generation prompts to prevent AI models from generating names that exceed the 20-character schema limit.

## Background

AI models (especially Haiku) don't always respect JSON schema numeric constraints—they need explicit guidance in the prompt text. The schema already had `.max(20)` but the AI wasn't seeing this constraint, resulting in names like `"workspace-integration"` (21 chars) that fail validation:

```
AI_NoObjectGeneratedError: No object generated: response did not match schema.
...
"code": "too_big",
"maximum": 20,
"message": "Too big: expected string to have <=20 characters"
```

## Implementation

Added "max 15 chars" to both:
1. The schema `.describe()` text
2. The prompt requirements text

The 15-char target leaves room for the `-xxxx` suffix that gets appended, while the 20-char schema constraint remains as a safety net.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.45`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=0.45 -->
