### PR TITLE
🤖 fix: preserve thinking preference on model clamp

### DIFF
--- a/src/browser/components/ThinkingSlider.tsx
+++ b/src/browser/components/ThinkingSlider.tsx
@@ -122,6 +122,15 @@ export const ThinkingSliderComponent: React.FC<ThinkingControlProps> = ({ modelS
 
   const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const index = parseInt(e.target.value, 10);
+
+    // Guard against programmatic value updates (e.g., when a model change clamps
+    // the effective thinking level). In those cases the slider's controlled value
+    // already matches the event value, and we should not overwrite the user's
+    // preferred level.
+    if (index === sliderValue) {
+      return;
+    }
+
     const newLevel = allowed[index];
     if (newLevel) {
       handleThinkingLevelChange(newLevel);


### PR DESCRIPTION
Summary
- Prevent the thinking slider from persisting a policy-clamped level when the model changes.

Background
- The thinking persistence flake occurs when a model switch clamps xhigh → high and the range input fires an onChange during render, overwriting the stored preference. Switching back then reads "high" instead of the prior xhigh.

Implementation
- Ignore slider change events that match the already-rendered slider value so programmatic updates don’t overwrite user preferences.

Validation
- make static-check

Risks
- Low: the guard only skips redundant updates when the slider value already matches the UI, leaving intentional user changes untouched.

---

_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `xhigh` • Cost: `$2.22`_

<!-- mux-attribution: model=openai:gpt-5.2-codex thinking=xhigh costs=2.22 -->
