### PR TITLE
🤖 feat: add cost tracking to tbench results

### DIFF
--- a/.mux/skills/tbench/SKILL.md
+++ b/.mux/skills/tbench/SKILL.md
@@ -9,6 +9,8 @@ This directory contains the mux agent adapter for [Terminal-Bench 2.0](https://t
 
 ## Quick Start
 
+When user asks to run a tbench, generally assume they mean in CI via workflow_dispatch.
+
 ```bash
 # Run full benchmark suite
 make benchmark-terminal

--- a/benchmarks/terminal_bench/mux_agent.py
+++ b/benchmarks/terminal_bench/mux_agent.py
@@ -273,12 +273,15 @@ class MuxAgent(BaseInstalledAgent):
         self.populate_context_post_run(context)
 
     def populate_context_post_run(self, context: AgentContext) -> None:
-        """Extract token usage from the token file written by mux-run.sh."""
+        """Extract token usage and cost from the token file written by mux-run.sh."""
         token_file = self.logs_dir / "mux-tokens.json"
         if token_file.exists():
             try:
                 data = json.loads(token_file.read_text())
                 context.n_input_tokens = data.get("input", 0)
                 context.n_output_tokens = data.get("output", 0)
+                # cost_usd is computed by mux CLI from model pricing
+                if data.get("cost_usd") is not None:
+                    context.cost_usd = data["cost_usd"]
             except Exception:
-                pass  # Token extraction is best-effort
+                pass  # Token/cost extraction is best-effort

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -973,10 +973,29 @@ async function main(): Promise<number> {
       }
     }
 
+    // Compute final usage/cost summary
+    const totalUsage = sumUsageHistory(usageHistory);
+    const totalCost = getTotalCost(totalUsage);
+
+    // Emit run-complete event in JSON mode with usage and cost
+    if (emitJson) {
+      emitJsonLine({
+        type: "run-complete",
+        usage: totalUsage
+          ? {
+              inputTokens: totalUsage.input.tokens,
+              outputTokens: totalUsage.output.tokens,
+              cachedTokens: totalUsage.cached.tokens,
+              cacheCreateTokens: totalUsage.cacheCreate.tokens,
+              reasoningTokens: totalUsage.reasoning.tokens,
+            }
+          : null,
+        cost_usd: totalCost ?? null,
+      });
+    }
+
     // Print cost summary at end of run (unless --hide-costs or --json)
     if (!hideCosts && !emitJson) {
-      const totalUsage = sumUsageHistory(usageHistory);
-      const totalCost = getTotalCost(totalUsage);
       // Skip if no cost data or if model pricing is unknown (would show misleading $0.00)
       if (totalCost !== undefined && !totalUsage?.hasUnknownCosts) {
         const costLine = `Cost: ${formatCostWithDollar(totalCost)}`;


### PR DESCRIPTION
## Summary

Add cost tracking to Terminal-Bench results by leveraging the mux CLI's existing cost computation, ensuring costs stay in sync with the pricing used for budget enforcement.

## Background

Previously, tbench results only tracked token counts. To understand benchmark economics (cost per task, cost vs pass rate, etc.), we need actual USD costs. Rather than duplicating model pricing in the upload script, this change extracts costs computed by the mux CLI itself.

## Implementation

1. **CLI run-complete event** (`src/cli/run.ts`): Added a new `run-complete` JSON event emitted at end of `--json` runs containing:
   - Token usage breakdown (input, output, cached, cacheCreate, reasoning)
   - `cost_usd` computed from the CLI's pricing data

2. **mux-run.sh**: Updated to extract `cost_usd` from the `run-complete` event instead of computing it from stream-end tokens

3. **mux_agent.py**: Pass `cost_usd` to Harbor's `AgentContext`

4. **upload-tbench-results.py**: Read `cost_usd` from agent result instead of computing from static pricing table

5. **BigQuery schema**: Added `cost_usd FLOAT64` column to `tbench_results` table

## Validation

- `make static-check` passes
- Python syntax check passes
- Verified xhigh run is still in progress (21466031280)

---

_Generated with `mux` • Model: `anthropic:claude-sonnet-4-5` • Thinking: `high`_

<!-- mux-attribution: model=anthropic:claude-sonnet-4-5 thinking=high -->
