### PR TITLE
🤖 fix: hide devcontainer button during loading to prevent flash

### DIFF
--- a/src/browser/components/ChatInput/CreationControls.tsx
+++ b/src/browser/components/ChatInput/CreationControls.tsx
@@ -164,10 +164,13 @@ function RuntimeButtonGroup(props: RuntimeButtonGroupProps) {
   const state = props.runtimeAvailabilityState;
   const availabilityMap = state?.status === "loaded" ? state.data : null;
 
-  // Hide devcontainer only when confirmed missing (not during loading - would cause layout flash)
+  // Hide devcontainer while loading OR when confirmed missing.
+  // Only show when availability is loaded and devcontainer is available.
+  // This prevents layout flash for projects without devcontainer.json (the common case).
   const hideDevcontainer =
-    availabilityMap?.devcontainer?.available === false &&
-    availabilityMap.devcontainer.reason === "No devcontainer.json found";
+    state?.status === "loading" ||
+    (availabilityMap?.devcontainer?.available === false &&
+      availabilityMap.devcontainer.reason === "No devcontainer.json found");
 
   const runtimeOptions = hideDevcontainer
     ? RUNTIME_OPTIONS.filter((option) => option.value !== RUNTIME_MODE.DEVCONTAINER)


### PR DESCRIPTION
## Summary

Fixes the devcontainer runtime button briefly appearing then disappearing when opening workspace creation for projects without devcontainer.json.

## Background

The button was visible for ~500ms during loading, then would hide once availability confirmed no devcontainer.json exists. The existing comment even noted this concern but the logic was inverted—it showed during loading instead of hiding.

## Implementation

Changed `hideDevcontainer` logic in `RuntimeButtonGroup` to also hide during `loading` state. The button now only appears when:
- Availability is loaded AND devcontainer is available, OR
- Availability check failed (fallback—let user try, validation happens at creation time)

## Risks

Low—only affects visual display during the brief loading phase. Projects with devcontainer.json still see the button once loading completes.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$1.25`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=1.25 -->
