### PR TITLE
🤖 fix: add EPIPE to retryable sync errors

### DIFF
--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -510,7 +510,8 @@ export class SSHRuntime extends RemoteRuntime {
               errorMsg.includes("pack-objects died") ||
               errorMsg.includes("Connection reset") ||
               errorMsg.includes("Connection closed") ||
-              errorMsg.includes("Broken pipe");
+              errorMsg.includes("Broken pipe") ||
+              errorMsg.includes("EPIPE");
 
             if (!isRetryable || attempt === maxSyncAttempts) {
               initLogger.logStderr(`Failed to sync project: ${errorMsg}`);


### PR DESCRIPTION
## Summary

Adds `EPIPE` to the list of retryable error patterns when syncing project files to a remote Coder workspace, preventing transient network failures from permanently bricking workspace creation.

## Background

When the SSH connection drops mid-transfer during git bundle sync, the error can manifest as:

```
fatal: sha1 file '<stdout>' write error: Connection reset by peer
Failed to sync project: write EPIPE
```

The existing retry logic (3 attempts, linear backoff) handles similar errors like "Connection reset", "Connection closed", and "Broken pipe", but was missing `EPIPE` (the Unix broken pipe signal that occurs when writing to a pipe whose read end has closed).

## Implementation

Single-line addition to the `isRetryable` check in `SSHRuntime.ts`.

## Validation

- Verified the error pattern matches the user-reported failure message
- Confirmed existing retry infrastructure handles the retry cleanly (cleanup + backoff)

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.82`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=0.82 -->
