### PR TITLE
🤖 fix: make fork failure fatal for Coder workspaces

### DIFF
--- a/src/node/runtime/CoderSSHRuntime.ts
+++ b/src/node/runtime/CoderSSHRuntime.ts
@@ -578,7 +578,8 @@ export class CoderSSHRuntime extends SSHRuntime {
    */
   override async forkWorkspace(params: WorkspaceForkParams): Promise<WorkspaceForkResult> {
     const result = await super.forkWorkspace(params);
-    if (!result.success) return result;
+    // Coder tasks must share the parent's VM - don't fall back to creating a new one
+    if (!result.success) return { ...result, failureIsFatal: true };
 
     // Both workspaces now share the Coder workspace - mark as existing so
     // deleting either mux workspace won't destroy the underlying Coder workspace

--- a/src/node/runtime/Runtime.ts
+++ b/src/node/runtime/Runtime.ts
@@ -258,6 +258,11 @@ export interface WorkspaceForkResult {
   forkedRuntimeConfig?: RuntimeConfig;
   /** Updated runtime config for source workspace (e.g., mark as shared) */
   sourceRuntimeConfig?: RuntimeConfig;
+  /**
+   * When true and success=false, don't fall back to createWorkspace.
+   * Use when the runtime provisions shared infrastructure that subagents must share.
+   */
+  failureIsFatal?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

When a Coder subagent's fork fails, prevent the fallback to `createWorkspace` which would incorrectly try to provision a new Coder VM.

## Background

A user encountered `error: a workspace already exists named "mux-workspace-draft-esph"` when creating a Coder subagent. This was caused by a cascading failure:

1. EPIPE during parent init → git bundle/clone to remote fails
2. Parent partially created → Coder VM exists, but no git repo on remote
3. User spawns subagent → `forkWorkspace` tries to clone from parent's empty directory
4. Fork fails → fallback uses parent's config with `existingWorkspace: false`
5. `coder create` with parent's workspace name → **already exists!**

The core issue: subagents should **never** create a new Coder workspace—they must share the parent's VM.

## Implementation

Added `failureIsFatal?: boolean` to `WorkspaceForkResult`. When a runtime returns this flag on fork failure, TaskService fails immediately instead of falling back to `createWorkspace`.

CoderSSHRuntime now sets `failureIsFatal: true` when fork fails, enforcing the invariant that Coder subagents share the parent's VM.

This approach:
- Keeps the decision per-fork (data) rather than per-runtime-class (flag)
- Preserves fallback behavior for other runtimes (worktree, plain SSH)
- Is easy to extend if other runtimes need similar behavior

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$8.29`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=8.29 -->
