### PR TITLE
Command palette: fzf-like fuzzy term search

### DIFF
--- a/src/browser/utils/fuzzySearch.test.ts
+++ b/src/browser/utils/fuzzySearch.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import {
+  fuzzySubsequenceMatch,
+  matchesAllTerms,
+  normalizeFuzzyText,
+  splitQueryIntoTerms,
+} from "./fuzzySearch";
+
+describe("fuzzySearch", () => {
+  test("normalizeFuzzyText lowercases and replaces common separators", () => {
+    expect(normalizeFuzzyText("Ask: check plan→orchestrator")).toBe("ask check plan orchestrator");
+  });
+
+  test("splitQueryIntoTerms splits on spaces and common punctuation", () => {
+    expect(splitQueryIntoTerms("ask check")).toEqual(["ask", "check"]);
+    expect(splitQueryIntoTerms("ask:check")).toEqual(["ask", "check"]);
+    expect(splitQueryIntoTerms("ask/check")).toEqual(["ask", "check"]);
+    expect(splitQueryIntoTerms("ask→check")).toEqual(["ask", "check"]);
+  });
+
+  test("fuzzySubsequenceMatch matches in-order characters with gaps", () => {
+    expect(fuzzySubsequenceMatch("Workspace Switch", "ws")).toBe(true);
+    expect(fuzzySubsequenceMatch("Workspace Switch", "sw")).toBe(true);
+    expect(fuzzySubsequenceMatch("Workspace Switch", "zz")).toBe(false);
+  });
+
+  test("matchesAllTerms ANDs terms and tolerates formatting punctuation", () => {
+    const text = "Ask: check plan→orchestrator switch behavior";
+
+    // Regression: `ask check` should match `Ask: check …`
+    expect(matchesAllTerms(text, "ask check")).toBe(true);
+
+    // Terms can appear in any order.
+    expect(matchesAllTerms(text, "orchestrator ask")).toBe(true);
+
+    // Query punctuation is treated as a separator.
+    expect(matchesAllTerms(text, "ask:check")).toBe(true);
+    expect(matchesAllTerms(text, "ask/check")).toBe(true);
+    expect(matchesAllTerms(text, "ask→check")).toBe(true);
+
+    expect(matchesAllTerms(text, "ask missing")).toBe(false);
+  });
+});

--- a/src/browser/utils/fuzzySearch.ts
+++ b/src/browser/utils/fuzzySearch.ts
@@ -1,0 +1,71 @@
+import assert from "@/common/utils/assert";
+
+/**
+ * Small fuzzy-matching helpers for the command palette (and similar UIs).
+ *
+ * We want something closer to an fzf experience:
+ * - Space-separated terms are ANDed.
+ * - Common formatting punctuation (e.g. `Ask: check …`) doesn't block matches.
+ * - Each term is matched as a fuzzy subsequence (in-order characters; gaps allowed).
+ *
+ * NOTE: This intentionally does *not* score/rank matches; it's used as a boolean filter.
+ */
+
+const NORMALIZE_SEPARATORS_RE = /[:•·→/\\\-_]+/g;
+
+export function normalizeFuzzyText(text: string): string {
+  assert(typeof text === "string", "normalizeFuzzyText: text must be a string");
+
+  return text.toLowerCase().replace(NORMALIZE_SEPARATORS_RE, " ").replace(/\s+/g, " ").trim();
+}
+
+export function splitQueryIntoTerms(query: string): string[] {
+  assert(typeof query === "string", "splitQueryIntoTerms: query must be a string");
+
+  const normalized = normalizeFuzzyText(query);
+  if (!normalized) return [];
+
+  return normalized.split(" ").filter((t) => t.length > 0);
+}
+
+function fuzzySubsequenceMatchNormalized(haystack: string, needle: string): boolean {
+  // By convention, an empty needle matches everything.
+  if (!needle) return true;
+  if (!haystack) return false;
+
+  let needleIdx = 0;
+  for (const ch of haystack) {
+    if (ch === needle[needleIdx]) {
+      needleIdx++;
+      if (needleIdx >= needle.length) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+export function fuzzySubsequenceMatch(haystack: string, needle: string): boolean {
+  assert(typeof haystack === "string", "fuzzySubsequenceMatch: haystack must be a string");
+  assert(typeof needle === "string", "fuzzySubsequenceMatch: needle must be a string");
+
+  return fuzzySubsequenceMatchNormalized(normalizeFuzzyText(haystack), normalizeFuzzyText(needle));
+}
+
+export function matchesAllTerms(haystack: string, query: string): boolean {
+  assert(typeof haystack === "string", "matchesAllTerms: haystack must be a string");
+  assert(typeof query === "string", "matchesAllTerms: query must be a string");
+
+  const terms = splitQueryIntoTerms(query);
+  if (terms.length === 0) return true;
+
+  const normalizedHaystack = normalizeFuzzyText(haystack);
+  for (const term of terms) {
+    if (!fuzzySubsequenceMatchNormalized(normalizedHaystack, term)) {
+      return false;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
Command palette search now behaves more like a fuzzy finder:

- Treats space-separated terms as ANDed matches (fzf “extended search” style).
- Normalizes common formatting punctuation so `ask check` matches titles like `Ask: check …`.
- Always includes command subtitles in keywords so secondary info (e.g. workspace “streaming”) is searchable.

Tests:
- Added unit coverage for the fuzzy matcher and the `ask check` regression.

---

<details>
<summary>📋 Implementation Plan</summary>

# Command palette: fzf-like fuzzy search plan

## Context / Why
- Today the command palette search is **literal substring** matching.
- This breaks “fzf muscle memory” cases like typing `ask check` and expecting it to match a workspace title like `Ask: check …` (because the title contains `:` between `ask` and `check`).
- Goal: make search behave more like a **true fuzzy finder**:
  - space-separated terms are **AND**’d (fzf “extended search” style)
  - punctuation/formatting characters don’t block matches
  - (optionally) character-level fuzzy matching enables abbreviations (e.g. `ws sw` → “Workspace Switch”)
  - keep existing palette modes (`>…` for commands, `/…` for slash commands) and prompt flows

## Evidence (what we observed in code)
- `src/browser/components/CommandPalette.tsx`
  - `Command` uses a custom `filter` that does `searchableText.includes(search)` and returns `1|0`.
  - `Command.Item` passes `value={item.title}` so the searchable text includes workspace titles like `Ask: …`.
  - `>` mode is implemented by stripping the leading `>` inside the filter (but still uses `includes`).
- `src/browser/utils/commandPaletteFiltering.ts`
  - Default mode shows only workspace switch commands (`ws:switch:*`), `>` shows everything except workspace switching, `/` is handled separately.
- `src/browser/utils/commands/sources.ts`
  - Workspace switch entries use `meta.title ?? meta.name` for `title`; `meta.title` commonly contains prompt-like formatting (e.g. `Ask: …`).

---

## Recommended approach (incremental, minimal UX risk)
### A) Tokenized fuzzy match (fzf-style “extended search”), keep current ordering
**Net LoC estimate (product code only): ~+70–120**

**Key idea:** keep the existing “recent-first then alphabetical” ordering by continuing to return `1|0` from the cmdk filter, but make the **match decision** fuzzy and token-aware.

#### Implementation steps
1. **Add a small reusable matcher utility** (new file, e.g. `src/browser/utils/fuzzySearch.ts`).
   - `splitQueryIntoTerms(query: string): string[]`
     - `trim()`
     - split on whitespace
     - drop empty terms
   - `normalizeFuzzyText(text: string): string` (optional but recommended)
     - lowercase
     - collapse repeated whitespace
     - replace common “formatting punctuation” with spaces (at least `:`, `•`, and unicode arrows like `→`)
     - *Keep this conservative to avoid surprising matches; we can extend over time.*
   - `fuzzySubsequenceMatch(haystack: string, needle: string): boolean`
     - true if all characters in `needle` appear in-order within `haystack` (case-insensitive)
   - `matchesAllTerms(haystack: string, query: string): boolean`
     - `terms.every(term => fuzzySubsequenceMatch(normalize(haystack), normalize(term)))`
2. **Update the cmdk filter in `CommandPalette.tsx`** to use the helper.
   - Keep building `searchableText` from `value + keywords`.
   - Strip `>` prefix for command mode as today.
   - If the (stripped) query is empty → return `1`.
   - Else → `return matchesAllTerms(searchableText, actualSearch) ? 1 : 0`.
   - Keep the return values as `1|0` to preserve the current stable ordering (recency + alpha) and grouping.
3. **Make subtitle consistently searchable** (small UX win).
   - Today: subtitle is only used as keywords *when explicit keywords are missing*.
   - Proposed: always include `subtitle` in `keywords` (append + de-dupe) so fuzzy search works uniformly across items.

#### Tests (to prevent regressions)
- Unit test the helper (fast, deterministic).
  - `"ask check"` matches `"Ask: check plan→orchestrator switch behavior"`.
  - multiple terms out of order: `"orchestrator ask"` matches the same title.
  - punctuation tolerance: `"ask:check"`, `"ask/check"`, `"ask→check"` all match.
- Add a small regression test that exercises the `CommandPalette` filter behavior for:
  - default mode
  - `>` mode
  - prompt `select` mode (options search)

#### Why this is the recommended first step
- Fixes the reported issue immediately.
- Delivers “fzf-like” matching without reworking cmdk list behavior.
- Preserves intentional UX: recent items stay at the top.

---

## Optional follow-ups (bigger UX wins)
### B) True fzf-style ranking + match highlighting
**Net LoC estimate (product code only): ~+180–320**

- Compute per-item match score (sum of token scores; boosts for word boundaries / contiguous runs).
- Sort within each group by score, with recency as a secondary boost.
- Render title/subtitle with highlighted matched characters.

<details>
<summary>Notes / tradeoffs</summary>

- cmdk’s built-in fuzzy scoring exists, but today we override it. If we start returning non-constant scores, cmdk may reorder results and fight with the current “recent-first” ordering.
- For predictable UX, consider doing *all* filtering + sorting in our own code (and set `shouldFilter={false}`), leaving cmdk only for keyboard navigation + selection.
- Highlighting requires a matcher that can return match indices, not just boolean.

</details>

### C) Ultra-minimal fix (if we want the smallest diff)
**Net LoC estimate (product code only): ~+15–30**

- Split the query on whitespace and require each token to be `includes()` within the searchable text.
- This fixes `ask check` vs `Ask: check …` but does **not** provide true fuzzy abbreviation matching.

---

## Acceptance criteria
- Typing `ask check` returns the workspace whose title is `Ask: check …`.
- Search remains case-insensitive and resilient to punctuation/formatting characters (`:`, `•`, `→`, `/`, etc.).
- Existing palette modes remain intact:
  - default: workspaces
  - `>`: commands
  - `/`: slash commands
- Prompt `select` fields get the same improved fuzzy matching as the main palette.

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.2` • Thinking: `xhigh`_
