### PR TITLE
🤖 fix: preserve thinking level on model switch

### DIFF
--- a/src/browser/components/ThinkingSlider.tsx
+++ b/src/browser/components/ThinkingSlider.tsx
@@ -151,7 +151,12 @@ export const ThinkingSliderComponent: React.FC<ThinkingControlProps> = ({ modelS
     <Tooltip>
       <TooltipTrigger asChild>
         <div className="flex items-center gap-2">
+          {/*
+            Remount on model changes so range clamping doesn't emit an onChange
+            that overwrites the user's preferred thinking level.
+          */}
           <input
+            key={modelString}
             type="range"
             min="0"
             max={maxSteps}


### PR DESCRIPTION
## Summary
- remount the thinking slider input when the model changes to avoid clamped range changes persisting a downgraded thinking level

## Background
Switching from an xhigh-capable model to a high-only model can clamp the range input value and trigger an onChange, overwriting the stored thinking preference. Returning to the original model then loses the xhigh setting.

## Implementation
- key the range input on the model string so model changes remount the slider instead of mutating max/value in place

## Validation
- bun test ./tests/ui/thinkingPersistence.integration.test.ts (skipped by runner)
- make static-check

## Risks
Low. Change is scoped to remounting the slider input on model changes; if any regression occurs it would be limited to the thinking level UI refresh.

---

_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `xhigh` • Cost: `$3.60`_

<!-- mux-attribution: model=openai:gpt-5.2-codex thinking=xhigh costs=3.60 -->
