### PR TITLE
🤖 fix: hide gateway icon when gateway is disabled

### DIFF
--- a/src/browser/components/ModelSelector.tsx
+++ b/src/browser/components/ModelSelector.tsx
@@ -266,8 +266,8 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
       const innerProvider =
         provider === "mux-gateway" && modelName.includes("/") ? modelName.split("/")[0] : provider;
 
-      // Show gateway icon if configured and provider supports it
-      const showGatewayIcon = gateway.isConfigured && isProviderSupported(value);
+      // Show gateway icon if gateway is active (configured AND enabled) and provider supports it
+      const showGatewayIcon = gateway.isActive && isProviderSupported(value);
 
       return (
         <div ref={containerRef} className="relative flex items-center gap-1">

--- a/src/browser/hooks/useGatewayModels.test.ts
+++ b/src/browser/hooks/useGatewayModels.test.ts
@@ -25,6 +25,20 @@ void mock.module("@/browser/hooks/useProvidersConfig", () => ({
   useProvidersConfig: useProvidersConfigMock,
 }));
 
+// Mock useAPI - the hook uses api.config.updateMuxGatewayPrefs for persistence
+// but has a defensive guard so it's safe to pass null/undefined.
+void mock.module("@/browser/contexts/API", () => ({
+  useAPI: () => ({
+    api: {
+      config: {
+        updateMuxGatewayPrefs: () => Promise.resolve({ success: true }),
+      },
+    },
+    status: "connected" as const,
+    error: null,
+  }),
+}));
+
 describe("useGateway", () => {
   beforeEach(() => {
     globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;


### PR DESCRIPTION
## Summary

The gateway icon in ChatInput was showing even when gateway was disabled at the provider level. This fix changes the visibility check from `isConfigured` to `isActive` (which is `isConfigured && isEnabled`), so the icon properly hides when the user toggles gateway off.

## Changes

- `ModelSelector.tsx`: Changed `gateway.isConfigured` to `gateway.isActive` for icon visibility
- `useGatewayModels.test.ts`: Added `useAPI` mock (required for existing tests to run without APIProvider context)

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$8.00`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=8.00 -->