### PR TITLE
🤖 refactor: remove model visibility toggle from ChatInput ModelSelector

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -354,15 +354,8 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
   // Use current agent's uiColor, or neutral border until agents load
   const focusBorderColor = currentAgent?.uiColor ?? "var(--color-border-light)";
-  const {
-    models,
-    hiddenModels,
-    hideModel,
-    unhideModel,
-    ensureModelInSettings,
-    defaultModel,
-    setDefaultModel,
-  } = useModelsFromSettings();
+  const { models, hiddenModels, ensureModelInSettings, defaultModel, setDefaultModel } =
+    useModelsFromSettings();
 
   const [agentAiDefaults] = usePersistedState<AgentAiDefaults>(
     AGENT_AI_DEFAULTS_KEY,
@@ -2217,9 +2210,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                     onComplete={() => inputRef.current?.focus()}
                     defaultModel={defaultModel}
                     onSetDefaultModel={setDefaultModel}
-                    onHideModel={hideModel}
                     hiddenModels={hiddenModels}
-                    onUnhideModel={unhideModel}
                     onOpenSettings={() => open("models")}
                   />
                   <div className="hidden [@media(hover:hover)_and_(pointer:fine)]:block">


### PR DESCRIPTION
## Summary

Remove the ability to toggle model visibility from the ChatInput's ModelSelector dropdown. Model visibility can now only be managed in Settings > Models.

## Background

Having model visibility toggles in multiple places (both the ChatInput dropdown and Settings) creates a confusing UX. Consolidating this to a single location (Settings) makes it clearer where users should go to manage which models appear in their selector.

## Implementation

- Removed `onHideModel` and `onUnhideModel` props from the `<ModelSelector>` in ChatInput
- Kept `hiddenModels` prop so hidden models still appear faded in the dropdown (visual feedback)
- Cleaned up unused `hideModel` and `unhideModel` from the `useModelsFromSettings()` destructuring

The ModelSelector component already checks `{(onHideModel ?? onUnhideModel) ? ...}` before rendering the eye icon toggle, so simply not passing these props removes the toggle UI.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.65`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=0.65 -->
