### PR TITLE
🤖 docs: require reading pull-requests skill before creating PRs

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -9,7 +9,7 @@ description: Agent instructions for AI assistants working on the Mux codebase
 
 - `mux`: Electron + React desktop app for parallel agent workflows; UX must be fast, responsive, predictable.
 - Minor breaking changes are expected, but critical flows must allow upgrade↔downgrade without friction; skip migrations when breakage is tightly scoped.
-- For PRs, commits, and public issues, consult the `pull-requests` skill for attribution footer requirements and workflow conventions.
+- **Before creating or updating any PR, commit, or public issue**, you **MUST** read the `pull-requests` skill (`agent_skill_read`) for attribution footer requirements and workflow conventions. Do not skip this step.
 
 ## External Submissions
 


### PR DESCRIPTION
## Summary

Strengthens the AGENTS.md guidance to explicitly require agents to read the `pull-requests` skill before creating or updating any PR, commit, or public issue.

## Background

An agent committed, pushed, and opened a PR without reading the `pull-requests` skill first, missing required attribution footers and workflow conventions. The previous wording ("consult the `pull-requests` skill") was too weak—agents treated it as optional advice rather than a mandatory step.

## Implementation

Changed the instruction from passive "consult" to explicit "**MUST** read" with the tool name (`agent_skill_read`) and a "Do not skip this step" suffix.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$0.30`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=0.30 -->
