### PR TITLE
🤖 ci: avoid terminal-bench artifact name collisions

### DIFF
--- a/.github/workflows/terminal-bench.yml
+++ b/.github/workflows/terminal-bench.yml
@@ -226,14 +226,25 @@ jobs:
         id: artifact-name
         env:
           MODEL_NAME: ${{ inputs.model_name }}
+          DATASET: ${{ inputs.dataset }}
+          TASK_NAMES: ${{ inputs.task_names }}
           RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
-          if [ -n "$MODEL_NAME" ]; then
-            # Replace colons and slashes with hyphens for filesystem compatibility
-            ARTIFACT_NAME="terminal-bench-results-$(echo "$MODEL_NAME-$RUN_ID" | tr ':/' '--')"
+          # actions/upload-artifact@v4 requires artifact names to be unique per workflow run.
+          # Nightly workflows can run multiple jobs with the same model (e.g. Harbor smoke tests),
+          # so include dataset + task selection in the artifact name.
+          sanitize() { printf "%s" "$1" | tr ' :/@' '-' | tr -cd 'A-Za-z0-9._-'; }
+
+          SAFE_MODEL=$(sanitize "${MODEL_NAME:-no-model}")
+          SAFE_DATASET=$(sanitize "${DATASET:-unknown-dataset}")
+          if [ -n "${TASK_NAMES:-}" ]; then
+            SAFE_TASKS=$(sanitize "$TASK_NAMES")
           else
-            ARTIFACT_NAME="terminal-bench-results-$RUN_ID"
+            SAFE_TASKS="all-tasks"
           fi
+
+          ARTIFACT_NAME="terminal-bench-results-${SAFE_MODEL}-${SAFE_DATASET}-${SAFE_TASKS}-${RUN_ID}-a${RUN_ATTEMPT}"
           echo "name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
           echo "Artifact name: $ARTIFACT_NAME"
 


### PR DESCRIPTION
## Summary

Fixes Nightly Terminal-Bench failures where multiple Harbor smoke-test jobs attempt to upload the same artifact name (actions/upload-artifact@v4 409 Conflict).

## Background

The reusable workflow computed artifact names from only `model_name` + `github.run_id`, but `run_id` is shared across all jobs in a run and several smoke tests reuse the same model.

## Implementation

- Include `dataset`, `task_names` (or `all-tasks`), and `github.run_attempt` in the artifact name so uploads are unique per job invocation.
- Sanitize components so the final name is safe for GitHub artifact naming.

## Validation

- `make static-check`

## Risks

Low. This only changes artifact naming in GitHub Actions.

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix nightly Terminal-Bench + Harbor smoke-test failures (artifact name collisions)

## Context / Why
The scheduled **Nightly Terminal-Bench** workflow is running the main Terminal-Bench model matrix successfully, but the **Harbor SWE-style smoke-test jobs** fail at the final `actions/upload-artifact@v4` step with a **409 Conflict** (“artifact … already exists”). That turns the whole workflow run red even though the benchmark itself succeeded.

Root cause: the reusable workflow `.github/workflows/terminal-bench.yml` names artifacts using only **model_name + github.run_id**. `github.run_id` is shared across all jobs in a run, and multiple smoke tests use the same `model_name` (`anthropic/claude-sonnet-4-5`), so they try to upload the *same* artifact name.

Goal: make artifact uploads **always unique per job invocation** so Harbor smoke tests (and any future duplicate-model jobs) don’t collide and fail.

## Evidence (what I checked)
- GitHub Actions run **21499295779** (Nightly Terminal-Bench) on `main` created **2026-01-30 00:05:50Z** (event: `schedule`) shows multiple Harbor smoke-test job failures.
  - `gh run view 21499295779 --json …` reports `conclusion=failure`.
  - Job list shows the main benchmark jobs succeeded, but three Harbor smoke tests failed.
  - Failure log lines show `actions/upload-artifact@v4` returning **409 Conflict** (“artifact with this name already exists on the workflow run”).
- Workflow implementation:
  - `.github/workflows/terminal-bench.yml` computes artifact name only from **model_name + github.run_id**:
    - `ARTIFACT_NAME="terminal-bench-results-$(echo "$MODEL_NAME-$RUN_ID" | tr ':/' '--')"`
  - `.github/workflows/nightly-terminal-bench.yml` runs multiple smoke-test jobs with the *same* `model_name: anthropic/claude-sonnet-4-5` in the same workflow run (same `github.run_id`), so they compute the same artifact name.

<details>
<summary>Notes on the YAML syntax error screenshot</summary>

Your screenshot showing `Invalid workflow file … nightly-terminal-bench.yml#L38` matches an earlier commit on PR branch `nightly-harbor-swe-bq` where the job name contained an unquoted `": "` sequence:

```yaml
name: Smoke test (swebench-verified: django__django-10097)
```

That was invalid YAML and was later fixed on `main` by quoting the string. The *current* nightly failures on `main` (2026-01-30) are caused by the artifact-name collision described above.
</details>

## Proposed fix (recommended)
### Make artifact names unique across datasets/tasks and run attempts
Update `.github/workflows/terminal-bench.yml` **Set artifact name** step to incorporate:
- `inputs.dataset` (differentiates Terminal-Bench vs Harbor datasets)
- `inputs.task_names` (differentiates smoke-test single-task runs vs “all tasks”)
- `github.run_attempt` (avoids collisions when re-running a workflow run)

**Key constraint:** don’t add a new `workflow_dispatch` input (GitHub caps `workflow_dispatch.inputs` at 10). Use existing inputs instead.

#### Concrete edit (shape)
In `.github/workflows/terminal-bench.yml`, replace the current artifact-name computation with something like:

```diff
       - name: Set artifact name
         if: always()
         id: artifact-name
         env:
           MODEL_NAME: ${{ inputs.model_name }}
+          DATASET: ${{ inputs.dataset }}
+          TASK_NAMES: ${{ inputs.task_names }}
           RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
-          if [ -n "$MODEL_NAME" ]; then
-            # Replace colons and slashes with hyphens for filesystem compatibility
-            ARTIFACT_NAME="terminal-bench-results-$(echo "$MODEL_NAME-$RUN_ID" | tr ':/' '--')"
-          else
-            ARTIFACT_NAME="terminal-bench-results-$RUN_ID"
-          fi
+          # actions/upload-artifact@v4 requires artifact names to be unique per workflow run.
+          # Nightly workflows can run multiple jobs with the same model (e.g. Harbor smoke tests),
+          # so include dataset + task selection in the artifact name.
+          sanitize() { echo "$1" | tr ' :/@\n\t' '-' | tr -cd 'A-Za-z0-9._-'; }
+
+          SAFE_MODEL=$(sanitize "${MODEL_NAME:-no-model}")
+          SAFE_DATASET=$(sanitize "${DATASET:-unknown-dataset}")
+          SAFE_TASKS=$(sanitize "${TASK_NAMES:-all-tasks}")
+
+          ARTIFACT_NAME="terminal-bench-results-${SAFE_MODEL}-${SAFE_DATASET}-${SAFE_TASKS}-${RUN_ID}-a${RUN_ATTEMPT}"
           echo "name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
           echo "Artifact name: $ARTIFACT_NAME"
```

This keeps the uniqueness within a run:
- Harbor smoke tests each have distinct `dataset` (and distinct `task_names`).
- Terminal-Bench matrix jobs each have distinct `model_name`.
- Re-runs won’t collide because of `run_attempt`.

**Net LoC (product code only): 0** (workflow-only change)

## Validation plan
1. Trigger a manual run of **Nightly Terminal-Bench** (or re-run the failed scheduled run) after landing the change.
2. Confirm **all jobs** succeed, especially:
   - `Smoke test (chess-best-move)`
   - `Smoke test (swebench-verified …)`
   - `Smoke test (swe-gen-js …)`
   - `Smoke test (aider-polyglot …)`
3. Confirm artifacts exist for each job, and their names are distinct.
4. (Optional) Ensure BigQuery upload steps still run as before (they occur before artifact upload).

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$2.25`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=2.25 -->
