### PR TITLE
🤖 refactor: move 'Load all' to new line and always underline

### DIFF
--- a/src/browser/components/Messages/HistoryHiddenMessage.tsx
+++ b/src/browser/components/Messages/HistoryHiddenMessage.tsx
@@ -61,19 +61,16 @@ export const HistoryHiddenMessage: React.FC<HistoryHiddenMessageProps> = ({
       <span className="text-muted">
         Omitted {message.hiddenCount} message{message.hiddenCount !== 1 ? "s" : ""} for performance
         {omittedSuffix}
-        {workspaceId && (
-          <>
-            {" "}
-            <button
-              type="button"
-              className="text-link hover:text-link-hover cursor-pointer border-none bg-transparent p-0 font-medium hover:underline"
-              onClick={() => showAllMessages(workspaceId)}
-            >
-              Load all
-            </button>
-          </>
-        )}
       </span>
+      {workspaceId && (
+        <button
+          type="button"
+          className="text-link hover:text-link-hover cursor-pointer border-none bg-transparent p-0 font-medium underline"
+          onClick={() => showAllMessages(workspaceId)}
+        >
+          Load all
+        </button>
+      )}
       <svg
         aria-hidden="true"
         className="text-border shrink-0"


### PR DESCRIPTION
## Summary

Moves the 'Load all' button in the history hidden message component to a new line below the omitted message count text, and ensures it is always underlined to appear as a hyperlink.

## Changes

- Extracted 'Load all' button from inline text to a sibling element
- Added persistent underline styling ( class) instead of only on hover
- Button now appears below the 'Omitted X messages...' text due to flex wrapping

---

_Generated with `mux` • Model: `openrouter:moonshotai/kimi-k2.5` • Thinking: `high` • Cost: `$0.02`_

<!-- mux-attribution: model=openrouter:moonshotai/kimi-k2.5 thinking=high costs=0.02 -->