### PR TITLE
🤖 fix: preserve workspace section on /fork

### DIFF
--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -807,8 +807,23 @@ export class Config {
         path: workspacePath,
         id: metadata.id,
         name: metadata.name,
+        title: metadata.title,
         createdAt: metadata.createdAt,
+        aiSettingsByAgent: metadata.aiSettingsByAgent,
         runtimeConfig: metadata.runtimeConfig,
+        aiSettings: metadata.aiSettings,
+        parentWorkspaceId: metadata.parentWorkspaceId,
+        agentType: metadata.agentType,
+        agentId: metadata.agentId,
+        taskStatus: metadata.taskStatus,
+        reportedAt: metadata.reportedAt,
+        taskModelString: metadata.taskModelString,
+        taskThinkingLevel: metadata.taskThinkingLevel,
+        taskPrompt: metadata.taskPrompt,
+        taskTrunkBranch: metadata.taskTrunkBranch,
+        archivedAt: metadata.archivedAt,
+        unarchivedAt: metadata.unarchivedAt,
+        sectionId: metadata.sectionId,
       };
 
       if (existingIndex >= 0) {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -1719,6 +1719,8 @@ export class WorkspaceService extends EventEmitter {
         createdAt: new Date().toISOString(),
         runtimeConfig: forkedRuntimeConfig,
         namedWorkspacePath,
+        // Preserve workspace organization when forking via /fork.
+        sectionId: sourceMetadata.sectionId,
       };
 
       await this.config.addWorkspace(foundProjectPath, metadata);


### PR DESCRIPTION
Summary
- Preserve workspace `sectionId` when forking a workspace via `/fork`, so the forked workspace stays in the same sidebar section.

Background
- Previously, `/fork` created a new workspace but dropped the source workspace's `sectionId`, causing the forked workspace to appear unsectioned.

Implementation
- Propagate `sectionId` from the source workspace metadata to the forked workspace metadata.
- Ensure `Config.addWorkspace()` persists `sectionId` (and other optional metadata fields) into `config.json` instead of dropping them.
- Add a `tests/ui` integration test that runs `/fork` and asserts the forked workspace remains in the same section.

Validation
- `TEST_INTEGRATION=1 bun x jest tests/ui/sections.integration.test.ts -t "/fork preserves section assignment"`
- `make static-check`

Risks
- Low. This touches fork metadata persistence and the config writer path used by a few code paths (`addWorkspace`).

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$1.68`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=1.68 -->
