### PR TITLE
🤖 fix: show forked workspace in sidebar immediately

### DIFF
--- a/tests/ui/workspaceFork.integration.test.ts
+++ b/tests/ui/workspaceFork.integration.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Integration tests for workspace forking UX.
+ *
+ * Regression test: after running `/fork <name>` from a workspace, the newly-created
+ * workspace should appear in the sidebar immediately (i.e. without being hidden
+ * under an "older" age tier).
+ */
+
+import "./dom";
+import { waitFor } from "@testing-library/react";
+
+import { shouldRunIntegrationTests } from "../testUtils";
+import { preloadTestModules } from "../ipc/setup";
+import { generateBranchName } from "../ipc/helpers";
+
+import { createAppHarness } from "./harness";
+
+const describeIntegration = shouldRunIntegrationTests() ? describe : describe.skip;
+
+describeIntegration("Workspace Fork (UI)", () => {
+  beforeAll(async () => {
+    await preloadTestModules();
+  });
+
+  test("/fork adds the new workspace to the sidebar immediately", async () => {
+    const app = await createAppHarness({ branchPrefix: "ui-fork" });
+
+    let forkedWorkspaceId: string | null = null;
+
+    try {
+      // Ensure the source workspace has a non-zero recency so that age-tier bucketing
+      // is active (otherwise "always show one workspace" can mask regressions).
+      await app.chat.send("Hello from source workspace");
+      await app.chat.expectTranscriptContains("Mock response: Hello from source workspace");
+
+      const forkBranch = generateBranchName("ui-fork-child");
+      await app.chat.send(`/fork ${forkBranch}`);
+
+      // Wait for navigation to the forked workspace.
+      await waitFor(
+        () => {
+          const path = window.location.pathname;
+          if (!path.startsWith("/workspace/")) {
+            throw new Error(`Unexpected path after fork: ${path}`);
+          }
+
+          const currentId = decodeURIComponent(path.slice("/workspace/".length));
+          if (currentId === app.workspaceId) {
+            throw new Error("Still on source workspace after fork");
+          }
+
+          forkedWorkspaceId = currentId;
+        },
+        { timeout: 10_000 }
+      );
+
+      if (!forkedWorkspaceId) {
+        throw new Error("Missing forked workspace ID after navigation");
+      }
+
+      // KEY ASSERTION: the new workspace should appear in the sidebar without requiring
+      // expanding an "Older than X days" tier.
+      await waitFor(
+        () => {
+          const el = app.view.container.querySelector(
+            `[data-workspace-id=\"${forkedWorkspaceId}\"]`
+          ) as HTMLElement | null;
+          if (!el) {
+            throw new Error("Forked workspace not found in sidebar");
+          }
+        },
+        { timeout: 1_000 }
+      );
+    } finally {
+      if (forkedWorkspaceId) {
+        await app.env.orpc.workspace
+          .remove({ workspaceId: forkedWorkspaceId, options: { force: true } })
+          .catch(() => {});
+      }
+
+      await app.dispose();
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
Summary
- Fixes a `/fork` UX regression where the newly-created workspace could fail to show up in the left sidebar immediately.
- Adds a UI integration test covering `/fork` sidebar visibility.

Background
- The fork switch is driven by a custom browser event. Previously, if the event fired before `ProjectContext` finished loading, the handler would early-return and skip updating sidebar state.

Implementation
- App fork-switch handler no longer early-returns when the project isn't present yet.
- If the project is missing, we trigger `refreshProjects()` best-effort.

Validation
- `TEST_INTEGRATION=1 bun x jest tests/ui/workspaceFork.integration.test.ts --runTestsByPath --testTimeout=60000 --silent`
- `make static-check`

Risks
- Low: change is scoped to the fork-switch event path and uses best-effort refresh.

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `high` • Cost: `$39.08`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=high costs=39.08 -->
