### PR TITLE
🤖 refactor: extract GatewayToggleButton for consistent hover states

### DIFF
--- a/src/browser/components/GatewayToggleButton.tsx
+++ b/src/browser/components/GatewayToggleButton.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { cn } from "@/common/lib/utils";
+import { GatewayIcon } from "./icons/GatewayIcon";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
+
+interface GatewayToggleButtonProps {
+  /** Whether gateway is currently enabled for this model */
+  active: boolean;
+  /** Called when user clicks to toggle */
+  onToggle: () => void;
+  /** Visual variant */
+  variant?: "bordered" | "plain";
+  /** Icon size */
+  size?: "sm" | "md";
+  /** Whether to show tooltip */
+  showTooltip?: boolean;
+  className?: string;
+}
+
+/**
+ * Toggle button for enabling/disabling Mux Gateway on a model.
+ * Provides consistent hover states across usages:
+ * - Active: accent color, dims on hover
+ * - Inactive: muted color, brightens on hover (but not to accent)
+ */
+export function GatewayToggleButton(props: GatewayToggleButtonProps) {
+  const { active, onToggle, variant = "plain", size = "md", showTooltip = false } = props;
+
+  const sizeClasses = {
+    sm: { container: "h-5 w-5", icon: "h-3 w-3" },
+    md: { container: "", icon: "h-3.5 w-3.5" },
+  }[size];
+
+  const button = (
+    <button
+      type="button"
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        onToggle();
+      }}
+      className={cn(
+        "transition-colors duration-150",
+        variant === "bordered" &&
+          cn(
+            "flex items-center justify-center rounded-sm border",
+            sizeClasses.container,
+            active
+              ? "border-accent/40 text-accent hover:opacity-70"
+              : "border-border-light/40 text-muted-light hover:border-muted/60 hover:text-muted"
+          ),
+        variant === "plain" &&
+          cn("p-0.5", active ? "text-accent hover:opacity-70" : "text-muted hover:text-foreground"),
+        props.className
+      )}
+      aria-label={active ? "Disable Mux Gateway" : "Enable Mux Gateway"}
+    >
+      <GatewayIcon className={sizeClasses.icon} active={active} />
+    </button>
+  );
+
+  if (!showTooltip) {
+    return button;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent align="center">
+        {active ? "Using Mux Gateway" : "Use Mux Gateway"}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/browser/components/ModelSelector.tsx
+++ b/src/browser/components/ModelSelector.tsx
@@ -8,6 +8,7 @@ import React, {
 } from "react";
 import { cn } from "@/common/lib/utils";
 import { Eye, Settings, ShieldCheck, Star, ChevronDown } from "lucide-react";
+import { GatewayToggleButton } from "./GatewayToggleButton";
 import { GatewayIcon } from "./icons/GatewayIcon";
 import { ProviderIcon } from "./ProviderIcon";
 import { Tooltip, TooltipTrigger, TooltipContent } from "./ui/tooltip";
@@ -393,40 +394,13 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
                     <span className="min-w-0 truncate">{model}</span>
                     {/* Gateway toggle */}
                     {gateway.canToggleModel(model) ? (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <button
-                            type="button"
-                            onMouseDown={(e) => e.preventDefault()}
-                            onClick={(e) => {
-                              e.preventDefault();
-                              e.stopPropagation();
-                              gateway.toggleModelGateway(model);
-                            }}
-                            className={cn(
-                              "flex h-5 w-5 items-center justify-center rounded-sm border transition-colors duration-150",
-                              gateway.modelUsesGateway(model)
-                                ? "text-accent border-accent/40"
-                                : "text-muted-light border-border-light/40 hover:border-foreground/60 hover:text-foreground"
-                            )}
-                            aria-label={
-                              gateway.modelUsesGateway(model)
-                                ? "Disable Mux Gateway"
-                                : "Enable Mux Gateway"
-                            }
-                          >
-                            <GatewayIcon
-                              className="h-3 w-3"
-                              active={gateway.modelUsesGateway(model)}
-                            />
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent align="center">
-                          {gateway.modelUsesGateway(model)
-                            ? "Using Mux Gateway"
-                            : "Use Mux Gateway"}
-                        </TooltipContent>
-                      </Tooltip>
+                      <GatewayToggleButton
+                        active={gateway.modelUsesGateway(model)}
+                        onToggle={() => gateway.toggleModelGateway(model)}
+                        variant="bordered"
+                        size="sm"
+                        showTooltip
+                      />
                     ) : (
                       <span /> // Empty cell for alignment
                     )}

--- a/src/browser/components/Settings/sections/ModelRow.tsx
+++ b/src/browser/components/Settings/sections/ModelRow.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Check, Eye, Info, Pencil, Star, Trash2, X } from "lucide-react";
 import { createEditKeyHandler } from "@/browser/utils/ui/keybinds";
-import { GatewayIcon } from "@/browser/components/icons/GatewayIcon";
+import { GatewayToggleButton } from "@/browser/components/GatewayToggleButton";
 import { cn } from "@/common/lib/utils";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/browser/components/ui/tooltip";
 import { ProviderWithIcon } from "@/browser/components/ProviderIcon";
@@ -266,20 +266,10 @@ export function ModelRow(props: ModelRowProps) {
           )}
           {/* Gateway toggle button */}
           {props.onToggleGateway && (
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                props.onToggleGateway?.();
-              }}
-              className={cn(
-                "p-0.5 transition-colors",
-                props.isGatewayEnabled ? "text-accent" : "text-muted hover:text-accent"
-              )}
-              aria-label={props.isGatewayEnabled ? "Disable Mux Gateway" : "Enable Mux Gateway"}
-            >
-              <GatewayIcon className="h-3.5 w-3.5" active={props.isGatewayEnabled} />
-            </button>
+            <GatewayToggleButton
+              active={props.isGatewayEnabled ?? false}
+              onToggle={() => props.onToggleGateway?.()}
+            />
           )}
           {/* Favorite/default button */}
           <button


### PR DESCRIPTION
## Summary

Extract a shared `GatewayToggleButton` component to fix confusing hover states where the inactive hover looked identical to the enabled state.

## Background

The gateway icon's hover state was the same as its enabled state, making it difficult to tell whether the icon was already active or just being hovered. This was confusing when enabling/disabling gateway routing.

## Implementation

Created `GatewayToggleButton` component with:
- **Props:** `active`, `onToggle`, `variant` (bordered/plain), `size` (sm/md), `showTooltip`
- **Consistent hover behavior:**
  - Active state: accent color, dims on hover (`hover:opacity-70`)
  - Inactive state: muted color, brightens slightly but NOT to accent color

Updated consumers:
- `ModelSelector.tsx` - dropdown uses `variant="bordered" size="sm" showTooltip`
- `ModelRow.tsx` - settings row uses defaults (`variant="plain" size="md"`)

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$1.21`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=1.21 -->
