### PR TITLE
🤖 fix: model selector icon alignment when visibility toggle absent

### DIFF
--- a/src/browser/components/ModelSelector.tsx
+++ b/src/browser/components/ModelSelector.tsx
@@ -389,8 +389,15 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
                   )}
                   onClick={() => handleSelectModel(model)}
                 >
-                  {/* Grid: model name | gateway | visibility | default */}
-                  <div className="grid w-full min-w-0 grid-cols-[1fr_20px_30px_30px] items-center gap-1">
+                  {/* Grid: model name | gateway | [visibility] | default - visibility column only when callbacks present */}
+                  <div
+                    className={cn(
+                      "grid w-full min-w-0 items-center gap-1",
+                      (onHideModel ?? onUnhideModel)
+                        ? "grid-cols-[1fr_20px_30px_30px]"
+                        : "grid-cols-[1fr_20px_30px]"
+                    )}
+                  >
                     <span className="min-w-0 truncate">{model}</span>
                     {/* Gateway toggle */}
                     {gateway.canToggleModel(model) ? (
@@ -405,7 +412,7 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
                       <span /> // Empty cell for alignment
                     )}
                     {/* Visibility toggle - Eye with line-through when hidden */}
-                    {(onHideModel ?? onUnhideModel) ? (
+                    {(onHideModel ?? onUnhideModel) && (
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <button
@@ -449,8 +456,6 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
                             : "Hide model from selector"}
                         </TooltipContent>
                       </Tooltip>
-                    ) : (
-                      <span /> // Empty cell for alignment
                     )}
                     {/* Default star */}
                     {onSetDefaultModel ? (


### PR DESCRIPTION
## Summary

Fix visual regression where gateway and default star icons in the ModelSelector dropdown had a gap between them after removing the visibility toggle.

## Background

PR #2042 removed the visibility toggle from the ChatInput's ModelSelector to consolidate that UX in Settings. However, the grid layout still reserved 30px for the visibility column, creating an unwanted gap between the gateway toggle and default star icons.

## Implementation

- Made the grid columns dynamic based on whether visibility callbacks are provided:
  - With visibility: `grid-cols-[1fr_20px_30px_30px]` (4 columns)
  - Without visibility: `grid-cols-[1fr_20px_30px]` (3 columns)
- Changed visibility rendering from ternary (`? ... : <span />`) to conditional (`&& ...`) since no placeholder is needed
- Added `ModelSelectorDropdownOpen` story to capture the dropdown visual state for regression testing

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$1.26`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=1.26 -->
