### PR TITLE
🤖 fix: close terminal tabs on exit

### DIFF
--- a/src/browser/components/RightSidebar/TerminalTab.tsx
+++ b/src/browser/components/RightSidebar/TerminalTab.tsx
@@ -14,6 +14,8 @@ interface TerminalTabProps {
   autoFocus?: boolean;
   /** Called when autoFocus has been consumed (to clear the parent state) */
   onAutoFocusConsumed?: () => void;
+  /** Called when the terminal session exits. */
+  onExit?: () => void;
 }
 
 /**
@@ -45,6 +47,7 @@ export const TerminalTab: React.FC<TerminalTabProps> = (props) => {
       onTitleChange={props.onTitleChange}
       onAutoFocusConsumed={props.onAutoFocusConsumed}
       autoFocus={props.autoFocus ?? false}
+      onExit={props.onExit}
     />
   );
 };

--- a/src/browser/terminal-window.tsx
+++ b/src/browser/terminal-window.tsx
@@ -8,9 +8,26 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { TerminalView } from "@/browser/components/TerminalView";
-import { APIProvider } from "@/browser/contexts/API";
+import { APIProvider, useAPI } from "@/browser/contexts/API";
 import { TerminalRouterProvider } from "@/browser/terminal/TerminalRouterContext";
 import "./styles/globals.css";
+
+function TerminalWindowContent(props: { workspaceId: string; sessionId: string }) {
+  const { api } = useAPI();
+
+  return (
+    <TerminalView
+      workspaceId={props.workspaceId}
+      sessionId={props.sessionId}
+      visible={true}
+      onExit={() => {
+        api?.terminal.closeWindow({ workspaceId: props.workspaceId }).catch((err) => {
+          console.warn("[TerminalWindow] Failed to close terminal window:", err);
+        });
+      }}
+    />
+  );
+}
 
 // Get workspace ID from query parameter
 const params = new URLSearchParams(window.location.search);
@@ -32,7 +49,7 @@ if (!workspaceId || !sessionId) {
   ReactDOM.createRoot(document.getElementById("root")!).render(
     <APIProvider>
       <TerminalRouterProvider>
-        <TerminalView workspaceId={workspaceId} sessionId={sessionId} visible={true} />
+        <TerminalWindowContent workspaceId={workspaceId} sessionId={sessionId} />
       </TerminalRouterProvider>
     </APIProvider>
   );


### PR DESCRIPTION
Summary
- Close terminal tabs when their session exits via per-tab exit listeners in TerminalView.
- Remove global exit listener bookkeeping in RightSidebar while keeping shared cleanup logic.
- Continue closing pop-out terminal windows on session exit.

Background
- Exit events were previously handled by a RightSidebar-level listener map. This refactor keeps exit handling local to each TerminalView so hidden tabs still close while reducing global state.

Implementation
- Thread an onExit callback from RightSidebar -> TerminalTab -> TerminalView.
- Add a dedicated onExit stream effect in TerminalView (independent of visibility) and reuse the same exit handling logic for router subscriptions.
- Keep removeTerminalTab as the centralized cleanup path and use it for exit-driven closure.

Validation
- make static-check

Risks
- Low: changes are confined to terminal tab lifecycle handling and reuse the existing layout cleanup path.

---

_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `xhigh` • Cost: `$6.93`_

<!-- mux-attribution: model=openai:gpt-5.2-codex thinking=xhigh costs=6.93 -->
