### PR TITLE
🤖 fix: harden backend reconnect subscriptions

### DIFF
--- a/src/browser/components/AppLoader.tsx
+++ b/src/browser/components/AppLoader.tsx
@@ -80,12 +80,11 @@ function AppLoaderInner() {
 
   // Sync stores when metadata finishes loading
   useEffect(() => {
-    if (api) {
-      workspaceStoreInstance.setClient(api);
-      gitStatusStore.setClient(api);
-      backgroundBashStore.setClient(api);
-      getPRStatusStoreInstance().setClient(api);
-    }
+    // Keep store clients in sync even during backend restarts (api can be null while reconnecting).
+    workspaceStoreInstance.setClient(api ?? null);
+    gitStatusStore.setClient(api ?? null);
+    backgroundBashStore.setClient(api ?? null);
+    getPRStatusStoreInstance().setClient(api ?? null);
 
     if (!workspaceContext.loading) {
       workspaceStoreInstance.syncWorkspaces(workspaceContext.workspaceMetadata);

--- a/src/browser/contexts/WorkspaceContext.tsx
+++ b/src/browser/contexts/WorkspaceContext.tsx
@@ -44,6 +44,7 @@ import { normalizeAgentAiDefaults } from "@/common/types/agentAiDefaults";
 import { isWorkspaceArchived } from "@/common/utils/archive";
 import { getProjectRouteId } from "@/common/utils/projectRouteId";
 import { shouldApplyWorkspaceAiSettingsFromBackend } from "@/browser/utils/workspaceAiSettingsSync";
+import { isAbortError } from "@/browser/utils/isAbortError";
 import { useRouter } from "@/browser/contexts/RouterContext";
 
 /**
@@ -815,7 +816,7 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
           }
         }
       } catch (err) {
-        if (!signal.aborted) {
+        if (!signal.aborted && !isAbortError(err)) {
           console.error("Failed to subscribe to metadata:", err);
         }
       }

--- a/src/browser/stores/GitStatusStore.ts
+++ b/src/browser/stores/GitStatusStore.ts
@@ -60,8 +60,16 @@ export class GitStatusStore {
   // Per-workspace refreshing state for UI shimmer effects
   private refreshingWorkspaces = new MapStore<string, boolean>();
 
-  setClient(client: RouterClient<AppRouter>) {
+  setClient(client: RouterClient<AppRouter> | null): void {
     this.client = client;
+
+    if (!client) {
+      return;
+    }
+
+    if (this.workspaceMetadata.size > 0) {
+      this.refreshController.requestImmediate();
+    }
   }
 
   constructor() {

--- a/src/browser/stores/PRStatusStore.ts
+++ b/src/browser/stores/PRStatusStore.ts
@@ -140,8 +140,12 @@ export class PRStatusStore {
     });
   }
 
-  setClient(client: RouterClient<AppRouter>): void {
+  setClient(client: RouterClient<AppRouter> | null): void {
     this.client = client;
+
+    if (!client) {
+      return;
+    }
 
     // If hooks subscribed before the client was ready, ensure we refresh once it is.
     if (this.workspaceSubscriptionCounts.size > 0) {

--- a/src/browser/utils/isAbortError.ts
+++ b/src/browser/utils/isAbortError.ts
@@ -1,0 +1,8 @@
+export function isAbortError(error: unknown): boolean {
+  if (error instanceof Error) {
+    return error.name === "AbortError";
+  }
+
+  const name = (error as { name?: unknown } | null)?.name;
+  return typeof name === "string" && name === "AbortError";
+}


### PR DESCRIPTION
Summary
- Harden store/client resubscription paths so background bash and chat state recover cleanly after reconnects.

Background
- Backend restarts during dev-server workflows can leave stale subscriptions or require a refresh to recover; this follow-up hardens the remaining edge cases.

Implementation
- Clear stats subscriptions on any client swap, and make onChat waits abortable on client changes.
- Add bounded retry/backoff for background bash subscriptions and clear retry state on stop/client loss.
- Deduplicate AbortError detection into a shared utility.

Validation
- `make static-check`

Risks
- Low. Changes touch subscription retry paths; regressions would surface as missed resubscriptions or extra retry attempts.

---

_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `xhigh` • Cost: `$9.74`_

<!-- mux-attribution: model=openai:gpt-5.2-codex thinking=xhigh costs=9.74 -->
