### PR TITLE
🤖 fix: ignore codex boilerplate in wait_pr_codex

### DIFF
--- a/scripts/wait_pr_codex.sh
+++ b/scripts/wait_pr_codex.sh
@@ -180,7 +180,8 @@ while true; do
     exit 1
   fi
 
-  REQUEST_AT=$(echo "$RESULT" | jq -r '[.data.repository.pullRequest.comments.nodes[] | select(.body | contains("@codex review"))] | sort_by(.createdAt) | last | .createdAt // empty')
+  # Ignore Codex's own comments since they mention "@codex review" in boilerplate.
+  REQUEST_AT=$(echo "$RESULT" | jq -r --arg bot "$BOT_LOGIN_GRAPHQL" '[.data.repository.pullRequest.comments.nodes[] | select(.author.login != $bot and (.body | contains("@codex review")))] | sort_by(.createdAt) | last | .createdAt // empty')
 
   if [[ -z "$REQUEST_AT" ]]; then
     echo "❌ No '@codex review' comment found on PR #$PR_NUMBER." >&2


### PR DESCRIPTION
Summary:
- Ignore Codex bot comments when locating the latest @codex review request so approval comments don’t reset the wait loop.

Background:
- Codex approval comments include boilerplate mentioning "@codex review", which caused the script to treat approvals as new requests and wait forever.

Implementation:
- Filter the request search to comments not authored by the Codex bot and document the rationale inline.

Validation:
- make static-check

Risks:
- Low; only affects request timestamp detection in the wait script.

---

_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `xhigh` • Cost: `$0.91`_

<!-- mux-attribution: model=openai:gpt-5.2-codex thinking=xhigh costs=0.91 -->
