### PR TITLE
🤖 feat: visualize awaited tasks in task_await

### DIFF
--- a/tests/ui/taskAwaitVisualization.integration.test.ts
+++ b/tests/ui/taskAwaitVisualization.integration.test.ts
@@ -1,0 +1,127 @@
+/**
+ * UI integration test for task_await execution visualization.
+ *
+ * When a task_await tool call is in-progress (state: input-available), we should render
+ * the awaited task IDs (best-effort) instead of only a generic "Waiting..." message.
+ */
+
+import "./dom";
+
+import { waitFor } from "@testing-library/react";
+
+import { createTestEnvironment, cleanupTestEnvironment, preloadTestModules } from "../ipc/setup";
+import { cleanupTempGitRepo, createTempGitRepo, generateBranchName } from "../ipc/helpers";
+import { detectDefaultTrunkBranch } from "@/node/git";
+import { HistoryService } from "@/node/services/historyService";
+import { createMuxMessage } from "@/common/types/message";
+
+import { installDom } from "./dom";
+import { renderApp } from "./renderReviewPanel";
+import { cleanupView, setupWorkspaceView } from "./helpers";
+
+async function waitForWorkspaceChatToRender(container: HTMLElement): Promise<void> {
+  await waitFor(
+    () => {
+      const messageWindow = container.querySelector('[data-testid="message-window"]');
+      if (!messageWindow) {
+        throw new Error("Workspace chat view not rendered yet");
+      }
+    },
+    { timeout: 30_000 }
+  );
+}
+
+async function seedHistory(historyService: HistoryService, workspaceId: string): Promise<void> {
+  const awaitedTaskIds = ["task-a", "task-b"];
+
+  const userMessage = createMuxMessage("user-1", "user", "Wait for tasks");
+
+  const taskAwaitToolMessage = createMuxMessage(
+    "assistant-task-await",
+    "assistant",
+    "",
+    undefined,
+    [
+      {
+        type: "dynamic-tool" as const,
+        toolCallId: "tool-task-await-1",
+        toolName: "task_await" as const,
+        state: "input-available" as const,
+        input: {
+          task_ids: awaitedTaskIds,
+          timeout_secs: 30,
+        },
+      },
+    ]
+  );
+
+  for (const msg of [userMessage, taskAwaitToolMessage]) {
+    const result = await historyService.appendToHistory(workspaceId, msg);
+    if (!result.success) {
+      throw new Error(`Failed to append history: ${result.error}`);
+    }
+  }
+}
+
+describe("task_await executing visualization", () => {
+  beforeAll(async () => {
+    await preloadTestModules();
+  });
+
+  test("renders awaited task IDs while executing", async () => {
+    const env = await createTestEnvironment();
+    const repoPath = await createTempGitRepo();
+    const cleanupDom = installDom();
+    let view: ReturnType<typeof renderApp> | undefined;
+    let workspaceId: string | undefined;
+
+    try {
+      const trunkBranch = await detectDefaultTrunkBranch(repoPath);
+      const branchName = generateBranchName("ui-task-await-visualization");
+
+      const createResult = await env.orpc.workspace.create({
+        projectPath: repoPath,
+        branchName,
+        trunkBranch,
+      });
+
+      if (!createResult.success) {
+        throw new Error(`Failed to create workspace: ${createResult.error}`);
+      }
+
+      workspaceId = createResult.metadata.id;
+
+      const historyService = new HistoryService(env.config);
+      await seedHistory(historyService, workspaceId);
+
+      view = renderApp({ apiClient: env.orpc, metadata: createResult.metadata });
+      await setupWorkspaceView(view, createResult.metadata, workspaceId);
+      await waitForWorkspaceChatToRender(view.container);
+
+      const toolName = view.getByText("task_await");
+      toolName.click();
+
+      await waitFor(() => {
+        expect(view?.queryAllByText("task-a")).toHaveLength(1);
+        expect(view?.queryAllByText("task-b")).toHaveLength(1);
+      });
+    } finally {
+      if (view) {
+        await cleanupView(view, cleanupDom);
+      } else {
+        cleanupDom();
+      }
+
+      if (workspaceId) {
+        try {
+          await env.orpc.workspace.remove({ workspaceId, options: { force: true } });
+        } catch {
+          // Best effort cleanup.
+        }
+      }
+
+      await cleanupTestEnvironment(env);
+      await cleanupTempGitRepo(repoPath);
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
Summary
- Improve `task_await` tool cards by listing the awaited task IDs while the tool call is still executing, using best-effort metadata (workspace tasks + background bash).

Implementation
- Added a reusable `TaskRow` renderer and reused it for `task_list`.
- Enhanced `task_await` executing state to render per-task rows (agent tasks via workspace metadata; bash tasks via background process store).
- Added a UI integration test covering the executing visualization.

Validation
- `make static-check`

---

<details>
<summary>📋 Implementation Plan</summary>

# Visualize awaited tasks in `task_await` tool cards

## Context / Why
Today, an in-progress `task_await` tool card only shows a count (e.g. “Waiting for: 1 task(s)”) plus a generic “Waiting for tasks to complete…”. This makes it hard to understand *which* tasks are being awaited (and which one is stuck), especially when multiple background tasks exist.

Goal: while `task_await` is **executing** and has no results yet, render a compact task list (similar to `task_list`) showing the awaited task IDs and best-effort metadata (status/title/agent type/depth when available).

## Evidence
- `src/browser/components/tools/TaskToolCall.tsx`
  - `TaskAwaitToolCall` currently renders only count + timeout and then “Waiting for tasks to complete…” when `status === "executing"` and `result?.results` is empty.
  - `TaskListToolCall` already has a good task-row visualization via `TaskListItem`.
- Task schemas
  - `task_await` args include optional `task_ids` and `timeout_secs` (`src/common/utils/tools/toolDefinitions.ts`).
  - `task_list` output tasks include `taskId`, `status`, `agentType`, `title`, and `depth`.
- Frontend live metadata sources
  - Workspace task metadata (queued/running/awaiting_report/reported) is available via `useOptionalWorkspaceContext().workspaceMetadata` (`src/browser/contexts/WorkspaceContext.tsx`, schema in `src/common/orpc/schemas/workspace.ts`).
  - Background bash processes are available via `useBackgroundProcesses(workspaceId)` (`src/browser/stores/BackgroundBashStore.ts`).
  - The current chat/workspace id is available via `useOptionalMessageListContext()` (`src/browser/components/Messages/MessageListContext.tsx`).

## Plan (recommended) — live preview list for executing `task_await`
**Net LoC estimate (product code only):** ~80–140

### 1) Add a “task row” renderer we can reuse
**File:** `src/browser/components/tools/TaskToolCall.tsx`

- Extract the existing `TaskListItem` markup into a small reusable component (keeps the `task_list` and `task_await` visuals consistent):

```tsx
type TaskRowProps = {
  taskId: string;
  status: string;
  agentType?: string;
  title?: string;
  depth?: number;
};

const TaskRow: React.FC<TaskRowProps> = (props) => (
  <div className="bg-code-bg flex flex-wrap items-center gap-2 rounded-sm p-2">
    <TaskId id={props.taskId} />
    <TaskStatusBadge status={props.status} />
    {props.agentType && <AgentTypeBadge type={props.agentType} />}
    {props.title && (
      <span className="text-foreground max-w-[200px] truncate text-[11px]">{props.title}</span>
    )}
    {typeof props.depth === "number" && props.depth > 0 && (
      <span className="text-muted text-[10px]">depth: {props.depth}</span>
    )}
  </div>
);
```

- Re-implement `TaskListItem` as a thin wrapper around `TaskRow`.

### 2) Build best-effort awaited-task summaries (IDs → metadata)
**File:** `src/browser/components/tools/TaskToolCall.tsx`

In/near `TaskAwaitToolCall`, compute a list of `TaskRowProps` when:
- `status === "executing"`
- `results.length === 0`
- there are awaited tasks (explicit `args.task_ids`, or derived list if we can)

Data sources (in order):
1. **Workspace tasks**: `useOptionalWorkspaceContext()?.workspaceMetadata.get(taskId)`
   - `status`: `metadata.taskStatus ?? "waiting"`
   - `title`: `metadata.title`
   - `agentType`: `metadata.agentType`
   - `depth`: compute by walking `parentWorkspaceId` pointers until reaching the current chat workspace.
2. **Bash tasks** (task IDs that start with `bash:`):
   - Use `useOptionalMessageListContext()` to get the current `workspaceId`.
   - Use `useBackgroundProcesses(workspaceId)` and match the process id (suffix after `bash:`).
   - Map process status → task badge status:
     - `running` → `running`
     - `exited` → `reported`
     - `killed` → `terminated`
     - `failed` → `error`
   - `title`: `proc.displayName ?? proc.id`
   - `depth`: `1` (direct child of the current workspace)
3. Fallback if nothing is known: show `status: "waiting"` and no title/agentType/depth.

Defensive details for depth:
- Guard against missing metadata and cycles.
- Cap traversal (e.g., max 50 hops) to avoid pathological loops.

```ts
function computeDepthFromRoot(
  rootWorkspaceId: string,
  leafTaskId: string,
  workspaceMetadata: Map<string, FrontendWorkspaceMetadata>
): number | undefined {
  const visited = new Set<string>();
  let depth = 0;
  let cur = leafTaskId;

  while (depth < 50) {
    if (visited.has(cur)) return undefined;
    visited.add(cur);

    const meta = workspaceMetadata.get(cur);
    const parent = meta?.parentWorkspaceId;
    if (!parent) return undefined;

    depth += 1;
    if (parent === rootWorkspaceId) return depth;

    cur = parent;
  }

  return undefined;
}
```

### 3) Render the awaited task list during execution
**File:** `src/browser/components/tools/TaskToolCall.tsx`

Replace the current executing-empty state:

```tsx
} : status === "executing" ? (
  <div className="text-muted text-[11px] italic">
    Waiting for tasks to complete
    <LoadingDots />
  </div>
)
```

with something like:

```tsx
) : status === "executing" ? (
  awaitedRows.length > 0 ? (
    <div className="space-y-2">
      {awaitedRows.map((row) => (
        <TaskRow key={row.taskId} {...row} />
      ))}
      <div className="text-muted mt-1 text-[11px] italic">
        Waiting for tasks to complete
        <LoadingDots />
      </div>
    </div>
  ) : (
    <div className="text-muted text-[11px] italic">
      Waiting for tasks to complete
      <LoadingDots />
    </div>
  )
)
```

Notes:
- Keep the existing “Config info” line (timeout/filter). The new list replaces the *count-only* experience with an explicit per-task visualization.
- Use only existing `TaskStatusBadge` colors; if we introduce the string status `waiting`, it will fall back to the muted default (or add an explicit `case "waiting"` → muted style).

### 4) UI test coverage
**Add file:** `tests/ui/taskAwaitVisualization.integration.test.ts`

Test intent: an executing `task_await` card should show each awaited task ID as an item (not just a count).

Approach:
- Create a workspace (same harness as `tests/ui/taskReportRelocation.integration.test.ts`).
- Seed history with a `task_await` tool part in **`state: "input-available"`** (no output) and `input.task_ids = ["task-a", "task-b"]`.
- Render, expand the `task_await` card, assert both IDs are present.

This keeps the test fast (no real tasks) and validates the UI upgrade.

<details>
<summary>Optional follow-up (not required for initial change)</summary>

- When `args.task_ids` is omitted (meaning “await all active descendant tasks”), derive the awaited list from `workspaceMetadata` (active descendant child workspaces) and display them too.
- Enrich rows further by also showing metadata for non-completed `task_await` results (e.g., when `timeout_secs: 0` returns active statuses) by looking up titles from workspace metadata.

</details>

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$2.17`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=2.17 -->
