### PR TITLE
🤖 fix: avoid duplicate sub-agent tasks on timeout

### DIFF
--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -173,6 +173,10 @@ export const TaskToolQueuedResultSchema = z
   .object({
     status: z.enum(["queued", "running"]),
     taskId: z.string(),
+    note: z
+      .string()
+      .min(1)
+      .describe("Additional guidance for the caller (e.g., use task_await to monitor progress)."),
   })
   .strict();
 
@@ -741,7 +745,8 @@ export const TOOL_DEFINITIONS = {
       "\n\nWhen delegating, include a compact task brief (Task / Background / Scope / Starting points / Acceptance / Deliverables / Constraints). " +
       "Avoid telling the sub-agent to read your plan file; child workspaces do not automatically have access to it. " +
       "\n\nIf run_in_background is false, waits for the sub-agent to finish and returns a completed reportMarkdown. " +
-      "If run_in_background is true, returns a queued/running taskId; use task_await to wait for completion, task_list to rediscover active tasks, and task_terminate to stop it. " +
+      "If the foreground wait times out, returns a queued/running taskId with a note (the task continues running); use task_await to monitor progress. " +
+      "If run_in_background is true, returns a queued/running taskId with a note; use task_await to wait for completion, task_list to rediscover active tasks, and task_terminate to stop it. " +
       "Use the bash tool to run shell commands.",
     schema: TaskToolArgsSchema,
   },


### PR DESCRIPTION
## Summary
When the `task` tool is called with `run_in_background: false`, a long-running sub-agent could previously time out the foreground wait and surface a tool error even though the child task kept running. Models often respond by retrying the `task` call, accidentally spawning duplicate sub-agent workspaces.

This change treats that foreground timeout as a **soft timeout**: return the existing `taskId` with a `queued`/`running` status and a note instructing the caller to use `task_await`.

## Implementation
- `task` tool now catches the specific `Timed out waiting for agent_report` error and returns `{ status, taskId, note }` instead of throwing.
- Queued/running `task` results now require `note` in the schema, so models consistently see follow-up guidance.
- Added/updated unit tests (including a regression test for the timeout path).

## Validation
- `make static-check`

## Risks
Low. Behavior changes only for the specific `Timed out waiting for agent_report` error; other errors still surface.

---

<details>
<summary>📋 Implementation Plan</summary>

# Prevent duplicate sub-agent tasks when `task` foreground wait times out

## Context / Why
When a parent agent calls the `task` tool with `run_in_background: false`, Mux currently waits (up to a fixed timeout) for the child workspace to call `agent_report`. If that wait times out, the tool call fails with `Timed out waiting for agent_report` **even though the child task is still running**.

Many models react to this tool failure by retrying the same `task` call (often with `run_in_background: true`), which creates a **second identical child task** and effectively abandons the original child workspace.

**Goal:** If the foreground wait hits its timeout, treat it as a *soft timeout*: return success with the existing `taskId` and an in-progress status so the parent can `task_await` the original task instead of spawning a duplicate.

## Evidence (what we verified)
- `TaskService.waitForAgentReport()` has a hardcoded default 10-minute timeout and rejects with `new Error("Timed out waiting for agent_report")` without terminating the child. (`src/node/services/taskService.ts`, `waitForAgentReport`, ~L1002–1156)
- `task` tool (`run_in_background: false`) directly awaits `waitForAgentReport()` and does not catch timeouts, so the tool call fails. (`src/node/services/tools/task.ts`, ~L105)
- `task_await` already treats `/timed out/i` as non-fatal and returns the current task status instead of erroring. (`src/node/services/tools/task_await.ts`, ~L187–226)
- UI “backgrounded” is already supported for successful tool calls that return `status: queued|running`. (`src/browser/components/tools/TaskToolCall.tsx`, `effectiveStatus` logic)

## Recommended approach: Soft-timeout → return in-progress result (no duplicate)
**Net LoC (product code only): ~35–60**

### 1) Make `task` tool resilient to report-wait timeout
**File:** `src/node/services/tools/task.ts` (`createTaskTool`)

Wrap the foreground `waitForAgentReport()` in a `try/catch`.

- If the error is the agent_report wait timeout, return a *successful* `TaskToolResult` with the existing `taskId` and an in-progress status.
- The parent model can then call `task_await` (or `task_list`) rather than spawning another `task`.

Suggested shape:

```ts
// src/node/services/tools/task.ts

const taskId = created.data.taskId;

if (run_in_background) {
  return parseToolResult(
    TaskToolResultSchema,
    {
      status: created.data.status,
      taskId,
      note: "Task started in background. Use task_await to monitor progress.",
    },
    "task"
  );
}

try {
  const report = await taskService.waitForAgentReport(taskId, {
    abortSignal,
    requestingWorkspaceId: workspaceId,
  });

  return parseToolResult(TaskToolResultSchema, {
    status: "completed" as const,
    taskId,
    reportMarkdown: report.reportMarkdown,
    title: report.title,
    agentId: requestedAgentId,
    agentType: requestedAgentId,
  }, "task");
} catch (err) {
  if (abortSignal?.aborted) throw new Error("Interrupted");

  const message = err instanceof Error ? err.message : String(err);

  // Soft timeout: child task is still running; don’t force the model to retry/spawn duplicates.
  if (message === "Timed out waiting for agent_report") {
    // Best-effort: reflect current status, but keep within TaskToolResultSchema.
    const status = taskService.getAgentTaskStatus(taskId);
    const normalized = status === "queued" ? "queued" : "running";

    return parseToolResult(TaskToolResultSchema, {
      status: normalized,
      taskId,
      note:
        "Task exceeded foreground wait limit and continues running in background. Use task_await to monitor progress.",
    }, "task");
  }

  throw err;
}
```

**Acceptance criteria:**
- When the 10-minute `waitForAgentReport()` limit is hit, the parent receives `{ status: "running"|"queued", taskId, note }` (success), not a tool error.
- The original child workspace continues running; the parent can call `task_await` using the returned `taskId`.
- The model no longer “troubleshoots” by spawning a second identical `task` (because it no longer sees a tool failure).

### 2) Add a required `note` field to queued/running `task` results
This is a small schema expansion that improves model behavior by explicitly instructing what to do next.

**Files:**
- `src/common/utils/tools/toolDefinitions.ts`
  - Update `TaskToolQueuedResultSchema` to require `note: string` (non-empty) for `queued|running`.
  - Update `TOOL_DEFINITIONS.task.description` to mention:
    - queued/running results include a `note` that tells the model to use `task_await`.
    - Even with `run_in_background: false`, the tool may return `queued/running` (with a `taskId`) if waiting for `agent_report` times out.
- `src/node/services/tools/task.ts`
  - Populate `note` in both the `run_in_background: true` path and the soft-timeout path (schema requires it).

### 3) Tests
**File:** `src/node/services/tools/task.test.ts`
Update existing `run_in_background: true` test to expect `note`, and add a regression test covering the timeout path:
- Mock `taskService.create()` → `Ok({ taskId: "child-task", status: "running" })`
- Mock `taskService.waitForAgentReport()` → `Promise.reject(new Error("Timed out waiting for agent_report"))`
- Mock `taskService.getAgentTaskStatus()` → `"running"` (or `"queued"`)
- Assert the tool returns `{ status: "running", taskId: "child-task", note: expect.any(String) }` (and that `note` tells the model to use `task_await`)

## Alternative/extra guardrail (optional): task de-duplication via idempotency
**Net LoC (product code only): ~120–220**

If we want defense-in-depth (in case other errors cause model retries), add a de-duplication mechanism so the same parent can’t accidentally spawn identical concurrent tasks.

<details>
<summary>Design sketch</summary>

- Add optional `idempotency_key` to the `task` tool args schema.
  - The caller (mux runtime) can set this automatically using `toolCallId`, so the model doesn’t need to.
- Persist the idempotency key on the child task’s config entry (or in a per-parent map).
- On `taskService.create()` (or inside `task` tool before calling `create()`):
  - If there is an *active* descendant task with the same `idempotency_key` (and same parentWorkspaceId), return its `taskId` instead of creating a new workspace.

Pros: prevents duplicates even when the model retries for reasons other than the report wait timeout.
Cons: more invasive (needs persistence + compatibility + careful scoping to avoid reusing tasks intentionally).

</details>

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: $

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=6.33 -->
