### PR TITLE
🤖 feat: improve MCP servers (global config, status, startup)

### DIFF
--- a/docs/agents/system-prompt.mdx
+++ b/docs/agents/system-prompt.mdx
@@ -140,11 +140,11 @@ function buildMCPContext(mcpServers: MCPServerMap): string {
 
   return `
 <mcp>
-MCP (Model Context Protocol) servers provide additional tools. Configured in user's local project's .mux/mcp.jsonc:
+MCP (Model Context Protocol) servers provide additional tools. Configured in ~/.mux/mcp.jsonc (global) and/or your project's .mux/mcp.jsonc (project):
 
 ${serverList}
 
-Use /mcp add|edit|remove or Settings → Projects to manage servers.
+Use Settings → Projects to manage servers (global or project), or /mcp add|edit|remove for project config.
 </mcp>
 `;
 }

--- a/docs/config/mcp-servers.mdx
+++ b/docs/config/mcp-servers.mdx
@@ -3,32 +3,67 @@ title: MCP Servers
 description: Extend agent capabilities with Model Context Protocol servers
 ---
 
-MCP (Model Context Protocol) servers provide additional tools to agents. Configure them per-project in `.mux/mcp.jsonc`.
+MCP (Model Context Protocol) servers provide additional tools to agents.
+
+Mux supports two configuration scopes:
+
+- **Global** (`~/.mux/mcp.jsonc`) — shared across all projects on this machine
+- **Project** (`<project>/.mux/mcp.jsonc`) — applies to all workspaces created from that project
+
+If the same server name exists in both files, the **project** definition wins.
 
 ## Configuration
 
-You can either configure the servers in the UI (`Ctrl+,`):
+You can configure servers in the UI (`Ctrl+,`) under **Settings → Projects**:
 
 ![MCP Servers UI](../img/mcp-servers-1.webp)
 
-Or directly in the `.mux/mcp.jsonc` file in your project root:
+Or directly in JSONC (same schema for both global and project files):
 
 ```jsonc
 {
   "servers": {
-    // Knowledge graph for persistent memory
+    // Simple form (stdio)
     "memory": "npx -y @modelcontextprotocol/server-memory",
-    // Browser automation and screenshots
-    "chrome": "npx -y chrome-devtools-mcp@latest --headless",
+
+    // Full form (stdio)
+    "chrome": {
+      "transport": "stdio",
+      "command": "npx -y chrome-devtools-mcp@latest --headless",
+      "disabled": false,
+    },
+
+    // Remote server (http/sse/auto)
+    "my-remote": {
+      "transport": "auto",
+      "url": "http://127.0.0.1:8080/mcp",
+      "headers": {
+        // Header values can come from project secrets
+        "Authorization": { "secret": "MY_TOKEN" },
+      },
+    },
   },
 }
 ```
 
-Each entry maps a server name to its shell command. The command must start a process that speaks MCP over stdio (NDJSON format).
+### Notes
+
+- `transport` can be `stdio`, `http`, `sse`, or `auto` (auto will try HTTP and fall back to SSE when needed).
+- `headers` secret references are resolved from **project secrets** (Settings → Projects → Secrets), even for globally-configured servers.
+- `toolAllowlist` (optional) restricts which tools from a server are exposed.
+
+## Workspace runtime status & restarts
+
+Open **Workspace MCP Configuration** from the workspace header to:
+
+- see per-server runtime status (running / failed / not started)
+- restart a specific server when it's misbehaving
+
+Note: restarts are disabled while a stream is active.
 
 ## Slash Commands
 
-Manage MCP servers directly from chat:
+Manage **project** MCP servers directly from chat (these commands modify `<project>/.mux/mcp.jsonc`):
 
 | Command                      | Description                         |
 | ---------------------------- | ----------------------------------- |
@@ -47,14 +82,14 @@ Examples:
 
 ## Scope
 
-MCP servers have two scopes:
-
-- **Configuration** is per-project — The `.mux/mcp.jsonc` file lives in your project root and applies to all workspaces created from that project
-- **Runtime instances** are per-workspace — Each workspace runs its own server processes, so state in one workspace doesn't affect another
+- **Global configuration** — `~/.mux/mcp.jsonc`
+- **Project configuration** — `<project>/.mux/mcp.jsonc`
+- **Per-workspace overrides** — `.mux/mcp.local.jsonc`
+- **Runtime instances** — Each workspace runs its own server processes, so state in one workspace doesn't affect another
 
 ## Per-workspace overrides
 
-mux supports per-workspace MCP overrides (enable/disable servers and restrict tool allowlists) without modifying the project-level `.mux/mcp.jsonc`.
+mux supports per-workspace MCP overrides (enable/disable servers and restrict tool allowlists) without modifying config files.
 
 These overrides are stored in a workspace-local file: `.mux/mcp.local.jsonc`.
 
@@ -62,7 +97,7 @@ These overrides are stored in a workspace-local file: `.mux/mcp.local.jsonc`.
 - When Mux writes this file, it also adds it to the workspace's local git excludes (`.git/info/exclude`) so it doesn't get accidentally committed
 - Older mux versions stored these overrides in `~/.mux/config.json`; mux will migrate them into `.mux/mcp.local.jsonc` on first use
 
-This means you configure servers once per project, but each workspace (branch) gets isolated server instances with independent state.
+This means you configure servers once globally / per-project, but each workspace (branch) gets isolated server instances with independent state.
 
 ## Behavior
 
@@ -79,6 +114,8 @@ Browse available servers at [mcp.so](https://mcp.so/) or the [MCP servers reposi
 
 If a server fails to start:
 
-1. **Test the command manually** — Run the command in your terminal to verify it works
-2. **Check dependencies** — Ensure required packages are installed (`npx -y` downloads on first run)
-3. **Use the Test button** — Settings → Projects shows connection errors inline
+1. **Check the warning message in chat** — mux will report MCP server startup failures during message send
+2. **Use the Test button** — Settings → Projects shows connection errors inline
+3. **Restart the server** — Open Workspace MCP Configuration and click Restart
+4. **Test the command manually** — Run the command in your terminal to verify it works
+5. **Check dependencies** — Ensure required packages are installed (`npx -y` downloads on first run)

--- a/src/browser/components/Settings/sections/ProjectSettingsSection.tsx
+++ b/src/browser/components/Settings/sections/ProjectSettingsSection.tsx
@@ -3,6 +3,7 @@ import { usePolicy } from "@/browser/contexts/PolicyContext";
 import { useAPI } from "@/browser/contexts/API";
 import { useSettings } from "@/browser/contexts/SettingsContext";
 import { useProjectContext } from "@/browser/contexts/ProjectContext";
+import assert from "@/common/utils/assert";
 import {
   Trash2,
   Play,
@@ -10,7 +11,6 @@ import {
   CheckCircle,
   XCircle,
   Plus,
-  Server,
   Pencil,
   Check,
   X,
@@ -29,7 +29,13 @@ import { createEditKeyHandler } from "@/browser/utils/ui/keybinds";
 import { Switch } from "@/browser/components/ui/switch";
 import { cn } from "@/common/lib/utils";
 import { formatRelativeTime } from "@/browser/utils/ui/dateTime";
-import type { CachedMCPTestResult, MCPServerInfo, MCPServerTransport } from "@/common/types/mcp";
+import type {
+  CachedMCPTestResult,
+  MCPConfigDiagnostics,
+  MCPHeaderValue,
+  MCPServerInfo,
+  MCPServerTransport,
+} from "@/common/types/mcp";
 import { useMCPTestCache } from "@/browser/hooks/useMCPTestCache";
 import { MCPHeadersEditor } from "@/browser/components/MCPHeadersEditor";
 import {
@@ -39,15 +45,44 @@ import {
 } from "@/browser/utils/mcpHeaders";
 import { ToolSelector } from "@/browser/components/ToolSelector";
 
+const MCP_SERVER_SECTION_ID_PREFIX = "mcp-server-settings";
+
+type McpAllowUserDefined =
+  | {
+      stdio: boolean;
+      remote: boolean;
+    }
+  | undefined;
+
+function formatDiagnosticsSummary(diag: MCPConfigDiagnostics): {
+  parseSummary: string | null;
+  validationSummary: string | null;
+} {
+  const parseSummary =
+    diag.parseErrors.length === 0
+      ? null
+      : diag.parseErrors.length === 1
+        ? `1 parse error in ${diag.filePath}`
+        : `${diag.parseErrors.length} parse errors in ${diag.filePath}`;
+
+  const validationSummary =
+    diag.validationErrors.length === 0
+      ? null
+      : diag.validationErrors.length === 1
+        ? "1 validation error"
+        : `${diag.validationErrors.length} validation errors`;
+
+  return { parseSummary, validationSummary };
+}
+
 /** Component for managing tool allowlist for a single MCP server */
 const ToolAllowlistSection: React.FC<{
   serverName: string;
   availableTools: string[];
   currentAllowlist?: string[];
   testedAt: number;
-  projectPath: string;
-}> = ({ serverName, availableTools, currentAllowlist, testedAt, projectPath }) => {
-  const { api } = useAPI();
+  onSaveAllowlist: (toolAllowlist: string[]) => Promise<{ success: boolean; error?: string }>;
+}> = ({ serverName: _serverName, availableTools, currentAllowlist, testedAt, onSaveAllowlist }) => {
   const [expanded, setExpanded] = useState(false);
   const [saving, setSaving] = useState(false);
   // Always use an array internally - undefined from props means all tools allowed
@@ -65,8 +100,6 @@ const ToolAllowlistSection: React.FC<{
 
   const handleToggleTool = useCallback(
     async (toolName: string, allowed: boolean) => {
-      if (!api) return;
-
       const newAllowlist = allowed
         ? [...localAllowlist, toolName]
         : localAllowlist.filter((t) => t !== toolName);
@@ -76,11 +109,7 @@ const ToolAllowlistSection: React.FC<{
       setSaving(true);
 
       try {
-        const result = await api.projects.mcp.setToolAllowlist({
-          projectPath,
-          name: serverName,
-          toolAllowlist: newAllowlist,
-        });
+        const result = await onSaveAllowlist(newAllowlist);
         if (!result.success) {
           setLocalAllowlist(currentAllowlist ?? [...availableTools]);
           console.error("Failed to update tool allowlist:", result.error);
@@ -92,22 +121,18 @@ const ToolAllowlistSection: React.FC<{
         setSaving(false);
       }
     },
-    [api, projectPath, serverName, localAllowlist, currentAllowlist, availableTools]
+    [onSaveAllowlist, localAllowlist, currentAllowlist, availableTools]
   );
 
   const handleAllowAll = useCallback(async () => {
-    if (!api || allAllowed) return;
+    if (allAllowed) return;
 
     const newAllowlist = [...availableTools];
     setLocalAllowlist(newAllowlist);
     setSaving(true);
 
     try {
-      const result = await api.projects.mcp.setToolAllowlist({
-        projectPath,
-        name: serverName,
-        toolAllowlist: newAllowlist,
-      });
+      const result = await onSaveAllowlist(newAllowlist);
       if (!result.success) {
         setLocalAllowlist(currentAllowlist ?? [...availableTools]);
         console.error("Failed to clear tool allowlist:", result.error);
@@ -118,20 +143,16 @@ const ToolAllowlistSection: React.FC<{
     } finally {
       setSaving(false);
     }
-  }, [api, projectPath, serverName, allAllowed, currentAllowlist, availableTools]);
+  }, [onSaveAllowlist, allAllowed, currentAllowlist, availableTools]);
 
   const handleSelectNone = useCallback(async () => {
-    if (!api || allDisabled) return;
+    if (allDisabled) return;
 
     setLocalAllowlist([]);
     setSaving(true);
 
     try {
-      const result = await api.projects.mcp.setToolAllowlist({
-        projectPath,
-        name: serverName,
-        toolAllowlist: [],
-      });
+      const result = await onSaveAllowlist([]);
       if (!result.success) {
         setLocalAllowlist(currentAllowlist ?? [...availableTools]);
         console.error("Failed to set empty tool allowlist:", result.error);
@@ -142,7 +163,7 @@ const ToolAllowlistSection: React.FC<{
     } finally {
       setSaving(false);
     }
-  }, [api, projectPath, serverName, allDisabled, currentAllowlist, availableTools]);
+  }, [onSaveAllowlist, allDisabled, currentAllowlist, availableTools]);
 
   return (
     <div>
@@ -174,32 +195,84 @@ const ToolAllowlistSection: React.FC<{
   );
 };
 
-export const ProjectSettingsSection: React.FC = () => {
-  const { api } = useAPI();
-  const policyState = usePolicy();
-  const mcpAllowUserDefined =
-    policyState.status.state === "enforced" ? policyState.policy?.mcp.allowUserDefined : undefined;
-  const mcpDisabledByPolicy = Boolean(
-    mcpAllowUserDefined?.stdio === false && mcpAllowUserDefined.remote === false
+interface McpServersEditorProps {
+  title: string;
+  description?: React.ReactNode;
+
+  disabledByPolicy: boolean;
+  mcpAllowUserDefined: McpAllowUserDefined;
+
+  projectSecretKeys: string[];
+
+  testCachePrefix?: string;
+
+  testCache: Record<string, CachedMCPTestResult>;
+  cacheTestResult: (name: string, result: CachedMCPTestResult["result"]) => void;
+  clearTestResult: (name: string) => void;
+
+  loadDiagnostics?: () => Promise<MCPConfigDiagnostics>;
+
+  loadServers: () => Promise<Record<string, MCPServerInfo>>;
+
+  addOrUpdateServer: (input: {
+    name: string;
+    transport: MCPServerTransport;
+    value: string;
+    headers?: Record<string, MCPHeaderValue>;
+  }) => Promise<{ success: boolean; error?: string }>;
+
+  removeServer: (name: string) => Promise<{ success: boolean; error?: string }>;
+
+  setEnabled: (name: string, enabled: boolean) => Promise<{ success: boolean; error?: string }>;
+
+  testServerByName: (name: string) => Promise<CachedMCPTestResult["result"]>;
+
+  testServerAdhoc: (input: {
+    transport: MCPServerTransport;
+    value: string;
+    headers?: Record<string, MCPHeaderValue>;
+  }) => Promise<CachedMCPTestResult["result"]>;
+
+  setToolAllowlist: (
+    name: string,
+    toolAllowlist: string[]
+  ) => Promise<{ success: boolean; error?: string }>;
+}
+
+const McpServersEditor: React.FC<McpServersEditorProps> = (props) => {
+  const {
+    title,
+    description,
+    disabledByPolicy,
+    mcpAllowUserDefined,
+    projectSecretKeys,
+    testCachePrefix,
+    testCache,
+    cacheTestResult,
+    clearTestResult,
+    loadDiagnostics,
+    loadServers,
+    addOrUpdateServer,
+    removeServer,
+    setEnabled,
+    testServerByName,
+    testServerAdhoc,
+    setToolAllowlist,
+  } = props;
+
+  const cacheKey = useCallback(
+    (serverName: string) => (testCachePrefix ? `${testCachePrefix}:${serverName}` : serverName),
+    [testCachePrefix]
   );
-  const { projectsTargetProjectPath, clearProjectsTargetProjectPath } = useSettings();
-  const { projects, getSecrets } = useProjectContext();
-  const projectList = Array.from(projects.keys());
 
   // Core state
-  const [selectedProject, setSelectedProject] = useState<string>("");
   const [servers, setServers] = useState<Record<string, MCPServerInfo>>({});
+  const [diagnostics, setDiagnostics] = useState<MCPConfigDiagnostics | null>(null);
   const [loading, setLoading] = useState(false);
 
-  const [projectSecretKeys, setProjectSecretKeys] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
 
   // Test state with caching
-  const {
-    cache: testCache,
-    setResult: cacheTestResult,
-    clearResult: clearTestResult,
-  } = useMCPTestCache(selectedProject);
   const [testingServer, setTestingServer] = useState<string | null>(null);
 
   interface EditableServer {
@@ -215,16 +288,17 @@ export const ProjectSettingsSection: React.FC = () => {
 
   // Ensure the "Add server" transport select always points to a policy-allowed value.
   useEffect(() => {
-    if (!mcpAllowUserDefined) {
+    const allowUserDefined = mcpAllowUserDefined;
+    if (!allowUserDefined) {
       return;
     }
 
     const isAllowed = (transport: MCPServerTransport): boolean => {
       if (transport === "stdio") {
-        return mcpAllowUserDefined.stdio;
+        return allowUserDefined.stdio;
       }
 
-      return mcpAllowUserDefined.remote;
+      return allowUserDefined.remote;
     };
 
     setNewServer((prev) => {
@@ -232,9 +306,9 @@ export const ProjectSettingsSection: React.FC = () => {
         return prev;
       }
 
-      const fallback: MCPServerTransport | null = mcpAllowUserDefined.stdio
+      const fallback: MCPServerTransport | null = allowUserDefined.stdio
         ? "stdio"
-        : mcpAllowUserDefined.remote
+        : allowUserDefined.remote
           ? "http"
           : null;
 
@@ -245,6 +319,7 @@ export const ProjectSettingsSection: React.FC = () => {
       return { ...prev, transport: fallback, value: "", headersRows: [] };
     });
   }, [mcpAllowUserDefined]);
+
   const [newServer, setNewServer] = useState<EditableServer>({
     name: "",
     transport: "stdio",
@@ -259,65 +334,27 @@ export const ProjectSettingsSection: React.FC = () => {
   const [editing, setEditing] = useState<EditableServer | null>(null);
   const [savingEdit, setSavingEdit] = useState(false);
 
-  // Set default project when projects load (or when deep-linking into a specific project)
-  useEffect(() => {
-    if (projectList.length === 0) return;
-
-    if (projectsTargetProjectPath) {
-      const target = projectsTargetProjectPath;
-      clearProjectsTargetProjectPath();
-
-      if (projectList.includes(target)) {
-        setSelectedProject(target);
-      } else if (!selectedProject || !projectList.includes(selectedProject)) {
-        setSelectedProject(projectList[0]);
-      }
-
-      return;
-    }
-
-    if (!selectedProject || !projectList.includes(selectedProject)) {
-      setSelectedProject(projectList[0]);
-    }
-  }, [projectList, selectedProject, projectsTargetProjectPath, clearProjectsTargetProjectPath]);
-
   const refresh = useCallback(async () => {
-    if (!api || !selectedProject) return;
     setLoading(true);
+
     try {
-      const mcpResult = await api.projects.mcp.list({ projectPath: selectedProject });
+      const [mcpResult, diag] = await Promise.all([
+        loadServers(),
+        loadDiagnostics ? loadDiagnostics() : Promise.resolve(null),
+      ]);
+
       setServers(mcpResult ?? {});
+      setDiagnostics(diag);
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load project settings");
+      setServers({});
+      setDiagnostics(null);
+      setError(err instanceof Error ? err.message : "Failed to load MCP servers");
     } finally {
       setLoading(false);
     }
-  }, [api, selectedProject]);
+  }, [loadServers, loadDiagnostics]);
 
-  useEffect(() => {
-    if (!selectedProject) {
-      setProjectSecretKeys([]);
-      return;
-    }
-
-    let cancelled = false;
-    (async () => {
-      try {
-        const secrets = await getSecrets(selectedProject);
-        if (cancelled) return;
-        setProjectSecretKeys(secrets.map((s) => s.key));
-      } catch (err) {
-        if (cancelled) return;
-        console.error("Failed to load project secrets:", err);
-        setProjectSecretKeys([]);
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [getSecrets, selectedProject]);
   useEffect(() => {
     void refresh();
   }, [refresh]);
@@ -329,14 +366,13 @@ export const ProjectSettingsSection: React.FC = () => {
 
   const handleRemove = useCallback(
     async (name: string) => {
-      if (!api || !selectedProject) return;
       setLoading(true);
       try {
-        const result = await api.projects.mcp.remove({ projectPath: selectedProject, name });
+        const result = await removeServer(name);
         if (!result.success) {
           setError(result.error ?? "Failed to remove MCP server");
         } else {
-          clearTestResult(name);
+          clearTestResult(cacheKey(name));
           await refresh();
         }
       } catch (err) {
@@ -345,23 +381,19 @@ export const ProjectSettingsSection: React.FC = () => {
         setLoading(false);
       }
     },
-    [api, selectedProject, refresh, clearTestResult]
+    [removeServer, clearTestResult, cacheKey, refresh]
   );
 
   const handleToggleEnabled = useCallback(
     async (name: string, enabled: boolean) => {
-      if (!api || !selectedProject) return;
       // Optimistic update
       setServers((prev) => ({
         ...prev,
         [name]: { ...prev[name], disabled: !enabled },
       }));
+
       try {
-        const result = await api.projects.mcp.setEnabled({
-          projectPath: selectedProject,
-          name,
-          enabled,
-        });
+        const result = await setEnabled(name, enabled);
         if (!result.success) {
           // Revert on error
           setServers((prev) => ({
@@ -379,18 +411,17 @@ export const ProjectSettingsSection: React.FC = () => {
         setError(err instanceof Error ? err.message : "Failed to update server");
       }
     },
-    [api, selectedProject]
+    [setEnabled]
   );
 
   const handleTest = useCallback(
     async (name: string) => {
-      if (!api || !selectedProject) return;
       setTestingServer(name);
       try {
-        const result = await api.projects.mcp.test({ projectPath: selectedProject, name });
-        cacheTestResult(name, result);
+        const result = await testServerByName(name);
+        cacheTestResult(cacheKey(name), result);
       } catch (err) {
-        cacheTestResult(name, {
+        cacheTestResult(cacheKey(name), {
           success: false,
           error: err instanceof Error ? err.message : "Test failed",
         });
@@ -398,14 +429,14 @@ export const ProjectSettingsSection: React.FC = () => {
         setTestingServer(null);
       }
     },
-    [api, selectedProject, cacheTestResult]
+    [testServerByName, cacheTestResult, cacheKey]
   );
 
-  const serverDisplayValue = (entry: MCPServerInfo): string =>
-    entry.transport === "stdio" ? entry.command : entry.url;
-
   const handleTestNewServer = useCallback(async () => {
-    if (!api || !selectedProject || !newServer.value.trim()) return;
+    if (!newServer.value.trim()) {
+      return;
+    }
+
     setTestingNew(true);
     setNewTestResult(null);
 
@@ -421,15 +452,10 @@ export const ProjectSettingsSection: React.FC = () => {
         throw new Error(validation.errors[0]);
       }
 
-      const result = await api.projects.mcp.test({
-        projectPath: selectedProject,
-        ...(newServer.transport === "stdio"
-          ? { command: newServer.value.trim() }
-          : {
-              transport: newServer.transport,
-              url: newServer.value.trim(),
-              headers,
-            }),
+      const result = await testServerAdhoc({
+        transport: newServer.transport,
+        value: newServer.value.trim(),
+        headers,
       });
 
       setNewTestResult({ result, testedAt: Date.now() });
@@ -441,17 +467,13 @@ export const ProjectSettingsSection: React.FC = () => {
     } finally {
       setTestingNew(false);
     }
-  }, [
-    api,
-    selectedProject,
-    newServer.transport,
-    newServer.value,
-    newServer.headersRows,
-    projectSecretKeys,
-  ]);
+  }, [newServer, projectSecretKeys, testServerAdhoc]);
 
   const handleAddServer = useCallback(async () => {
-    if (!api || !selectedProject || !newServer.name.trim() || !newServer.value.trim()) return;
+    if (!newServer.name.trim() || !newServer.value.trim()) {
+      return;
+    }
+
     setAddingServer(true);
     setError(null);
 
@@ -467,16 +489,11 @@ export const ProjectSettingsSection: React.FC = () => {
         throw new Error(validation.errors[0]);
       }
 
-      const result = await api.projects.mcp.add({
-        projectPath: selectedProject,
+      const result = await addOrUpdateServer({
         name: newServer.name.trim(),
-        ...(newServer.transport === "stdio"
-          ? { transport: "stdio", command: newServer.value.trim() }
-          : {
-              transport: newServer.transport,
-              url: newServer.value.trim(),
-              headers,
-            }),
+        transport: newServer.transport,
+        value: newServer.value.trim(),
+        headers,
       });
 
       if (!result.success) {
@@ -484,8 +501,9 @@ export const ProjectSettingsSection: React.FC = () => {
       } else {
         // Cache the test result if we have one
         if (newTestResult?.result.success) {
-          cacheTestResult(newServer.name.trim(), newTestResult.result);
+          cacheTestResult(cacheKey(newServer.name.trim()), newTestResult.result);
         }
+
         setNewServer({ name: "", transport: "stdio", value: "", headersRows: [] });
         setNewTestResult(null);
         await refresh();
@@ -495,7 +513,15 @@ export const ProjectSettingsSection: React.FC = () => {
     } finally {
       setAddingServer(false);
     }
-  }, [api, selectedProject, newServer, newTestResult, refresh, cacheTestResult, projectSecretKeys]);
+  }, [
+    newServer,
+    newTestResult,
+    projectSecretKeys,
+    addOrUpdateServer,
+    cacheTestResult,
+    cacheKey,
+    refresh,
+  ]);
 
   const handleStartEdit = useCallback((name: string, entry: MCPServerInfo) => {
     setEditing({
@@ -511,7 +537,10 @@ export const ProjectSettingsSection: React.FC = () => {
   }, []);
 
   const handleSaveEdit = useCallback(async () => {
-    if (!api || !selectedProject || !editing?.value.trim()) return;
+    if (!editing?.value.trim()) {
+      return;
+    }
+
     setSavingEdit(true);
     setError(null);
 
@@ -527,23 +556,18 @@ export const ProjectSettingsSection: React.FC = () => {
         throw new Error(validation.errors[0]);
       }
 
-      const result = await api.projects.mcp.add({
-        projectPath: selectedProject,
+      const result = await addOrUpdateServer({
         name: editing.name,
-        ...(editing.transport === "stdio"
-          ? { transport: "stdio", command: editing.value.trim() }
-          : {
-              transport: editing.transport,
-              url: editing.value.trim(),
-              headers,
-            }),
+        transport: editing.transport,
+        value: editing.value.trim(),
+        headers,
       });
 
       if (!result.success) {
         setError(result.error ?? "Failed to update MCP server");
       } else {
         // Clear cached test result since config changed
-        clearTestResult(editing.name);
+        clearTestResult(cacheKey(editing.name));
         setEditing(null);
         await refresh();
       }
@@ -552,20 +576,10 @@ export const ProjectSettingsSection: React.FC = () => {
     } finally {
       setSavingEdit(false);
     }
-  }, [api, selectedProject, editing, refresh, clearTestResult, projectSecretKeys]);
+  }, [editing, projectSecretKeys, addOrUpdateServer, clearTestResult, cacheKey, refresh]);
 
-  if (projectList.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center py-12 text-center">
-        <Server className="text-muted mb-3 h-10 w-10" />
-        <p className="text-muted text-sm">
-          No projects configured. Add a project first to manage settings.
-        </p>
-      </div>
-    );
-  }
-
-  const projectName = (path: string) => path.split(/[\\/]/).pop() ?? path;
+  const serverDisplayValue = (entry: MCPServerInfo): string =>
+    entry.transport === "stdio" ? entry.command : entry.url;
 
   const newHeadersValidation =
     newServer.transport === "stdio"
@@ -590,377 +604,725 @@ export const ProjectSettingsSection: React.FC = () => {
         }).validation
       : { errors: [], warnings: [] };
 
+  const idPrefix = `${MCP_SERVER_SECTION_ID_PREFIX}-${title.replace(/\s+/g, "-").toLowerCase()}`;
+  // Avoid invalid IDs when title has weird characters.
+  assert(idPrefix.length > 0, "idPrefix must be non-empty");
+
+  const hasDiagnostics = Boolean(
+    diagnostics && (diagnostics.parseErrors.length > 0 || diagnostics.validationErrors.length > 0)
+  );
+
   return (
-    <div className="space-y-6">
-      {/* Intro + Project selector */}
-      <div>
-        <p className="text-muted mb-4 text-xs">
-          Configure project-specific settings. Settings are stored in{" "}
-          <code className="text-accent">.mux/</code> within your project.
-        </p>
-        <div className="flex items-center justify-between">
-          <div>
-            <div className="text-foreground text-sm">Project</div>
-            <div className="text-muted text-xs">Select a project to configure</div>
-          </div>
-          <Select value={selectedProject} onValueChange={setSelectedProject}>
-            <SelectTrigger className="border-border-medium bg-background-secondary hover:bg-hover h-9 w-auto min-w-[160px] cursor-pointer rounded-md border px-3 text-sm transition-colors">
-              <SelectValue placeholder="Select project" />
-            </SelectTrigger>
-            <SelectContent>
-              {projectList.map((path) => (
-                <SelectItem key={path} value={path}>
-                  {projectName(path)}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+    <div>
+      <div className="mb-3">
+        <h3 className="text-foreground mb-1 text-sm font-medium">{title}</h3>
+        {description}
       </div>
 
-      {/* MCP Servers */}
-      <div>
-        <h3 className="text-foreground mb-4 text-sm font-medium">MCP Servers</h3>
+      {disabledByPolicy ? (
+        <p className="text-muted py-2 text-sm">MCP servers are disabled by policy.</p>
+      ) : (
+        <>
+          {hasDiagnostics && diagnostics && (
+            <div
+              className={cn(
+                "border-border-medium mb-3 rounded-md border px-3 py-2 text-xs",
+                diagnostics.parseErrors.length > 0
+                  ? "bg-destructive/10 text-destructive"
+                  : "bg-yellow-500/10 text-yellow-500"
+              )}
+            >
+              {(() => {
+                const summary = formatDiagnosticsSummary(diagnostics);
 
-        {mcpDisabledByPolicy ? (
-          <p className="text-muted py-2 text-sm">MCP servers are disabled by policy.</p>
-        ) : (
-          <>
-            {error && (
-              <div className="bg-destructive/10 text-destructive mb-3 flex items-center gap-2 rounded-md px-3 py-2 text-sm">
-                <XCircle className="h-4 w-4 shrink-0" />
-                {error}
+                return (
+                  <>
+                    {summary.parseSummary && (
+                      <div className="font-medium">{summary.parseSummary}</div>
+                    )}
+                    {summary.validationSummary && (
+                      <div className="font-medium">{summary.validationSummary}</div>
+                    )}
+
+                    <div className="mt-1 font-mono break-all opacity-80">
+                      {diagnostics.filePath}
+                    </div>
+
+                    {diagnostics.parseErrors.slice(0, 3).map((e, idx) => (
+                      <div key={`${idx}-${e.offset}`} className="mt-1 opacity-90">
+                        {e.message} (offset {e.offset})
+                      </div>
+                    ))}
+
+                    {diagnostics.validationErrors.slice(0, 3).map((e, idx) => (
+                      <div key={`${idx}-${e.serverName ?? "unknown"}`} className="mt-1 opacity-90">
+                        {e.serverName ? `${e.serverName}: ` : ""}
+                        {e.message}
+                      </div>
+                    ))}
+
+                    {(diagnostics.parseErrors.length > 3 ||
+                      diagnostics.validationErrors.length > 3) && (
+                      <div className="mt-1 opacity-80">…</div>
+                    )}
+                  </>
+                );
+              })()}
+            </div>
+          )}
+
+          {error && (
+            <div className="bg-destructive/10 text-destructive mb-3 flex items-center gap-2 rounded-md px-3 py-2 text-sm">
+              <XCircle className="h-4 w-4 shrink-0" />
+              {error}
+            </div>
+          )}
+
+          {/* Server list */}
+          <div className="space-y-2">
+            {loading ? (
+              <div className="text-muted flex items-center gap-2 py-4 text-sm">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Loading servers…
               </div>
-            )}
-
-            {/* Server list */}
-            <div className="space-y-2">
-              {loading ? (
-                <div className="text-muted flex items-center gap-2 py-4 text-sm">
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  Loading servers…
-                </div>
-              ) : Object.keys(servers).length === 0 ? (
-                <p className="text-muted py-2 text-sm">No MCP servers configured yet.</p>
-              ) : (
-                Object.entries(servers).map(([name, entry]) => {
-                  const isTesting = testingServer === name;
-                  const cached = testCache[name];
-                  const isEditing = editing?.name === name;
-                  const isEnabled = !entry.disabled;
-                  return (
-                    <div
-                      key={name}
-                      className="border-border-medium bg-background-secondary overflow-hidden rounded-md border"
-                    >
-                      <div className="flex items-start gap-3 px-3 py-2.5">
-                        <Switch
-                          checked={isEnabled}
-                          onCheckedChange={(checked) => void handleToggleEnabled(name, checked)}
-                          title={isEnabled ? "Disable server" : "Enable server"}
-                          className="mt-0.5 shrink-0"
-                        />
-                        <div className={cn("min-w-0 flex-1", !isEnabled && "opacity-50")}>
-                          <div className="flex items-center gap-2">
-                            <span className="text-foreground text-sm font-medium">{name}</span>
-                            {cached?.result.success && !isEditing && isEnabled && (
-                              <span
-                                className="rounded bg-green-500/10 px-1.5 py-0.5 text-xs text-green-500"
-                                title={`Tested ${formatRelativeTime(cached.testedAt)}`}
-                              >
-                                {cached.result.tools.length} tools
-                              </span>
-                            )}
-                            {!isEnabled && <span className="text-muted text-xs">disabled</span>}
-                          </div>
-                          {isEditing ? (
-                            <div className="mt-2 space-y-2">
-                              <p className="text-muted text-xs">transport: {editing.transport}</p>
-                              <input
-                                type="text"
-                                value={editing.value}
-                                onChange={(e) => setEditing({ ...editing, value: e.target.value })}
-                                className="bg-modal-bg border-border-medium focus:border-accent w-full rounded border px-2 py-1.5 font-mono text-xs focus:outline-none"
-                                autoFocus
-                                spellCheck={false}
-                                onKeyDown={createEditKeyHandler({
-                                  onSave: () => void handleSaveEdit(),
-                                  onCancel: handleCancelEdit,
-                                })}
-                              />
-                              {editing.transport !== "stdio" && (
-                                <div>
-                                  <div className="text-muted mb-1 text-[11px]">
-                                    HTTP headers (optional)
-                                  </div>
-                                  <MCPHeadersEditor
-                                    rows={editing.headersRows}
-                                    onChange={(rows) =>
-                                      setEditing({
-                                        ...editing,
-                                        headersRows: rows,
-                                      })
-                                    }
-                                    secretKeys={projectSecretKeys}
-                                    disabled={savingEdit}
-                                  />
-                                </div>
-                              )}
-                            </div>
-                          ) : (
-                            <p className="text-muted mt-0.5 font-mono text-xs break-all">
-                              {serverDisplayValue(entry)}
-                            </p>
+            ) : Object.keys(servers).length === 0 ? (
+              <p className="text-muted py-2 text-sm">No MCP servers configured yet.</p>
+            ) : (
+              Object.entries(servers).map(([name, entry]) => {
+                const isTesting = testingServer === name;
+                const cached = testCache[cacheKey(name)];
+                const isEditing = editing?.name === name;
+                const isEnabled = !entry.disabled;
+                return (
+                  <div
+                    key={name}
+                    className="border-border-medium bg-background-secondary overflow-hidden rounded-md border"
+                  >
+                    <div className="flex items-start gap-3 px-3 py-2.5">
+                      <Switch
+                        checked={isEnabled}
+                        onCheckedChange={(checked) => void handleToggleEnabled(name, checked)}
+                        title={isEnabled ? "Disable server" : "Enable server"}
+                        className="mt-0.5 shrink-0"
+                      />
+                      <div className={cn("min-w-0 flex-1", !isEnabled && "opacity-50")}>
+                        <div className="flex items-center gap-2">
+                          <span className="text-foreground text-sm font-medium">{name}</span>
+                          {cached?.result.success && !isEditing && isEnabled && (
+                            <span
+                              className="rounded bg-green-500/10 px-1.5 py-0.5 text-xs text-green-500"
+                              title={`Tested ${formatRelativeTime(cached.testedAt)}`}
+                            >
+                              {cached.result.tools.length} tools
+                            </span>
                           )}
+                          {!isEnabled && <span className="text-muted text-xs">disabled</span>}
                         </div>
-                        <div className="flex shrink-0 items-center gap-0.5">
-                          {isEditing ? (
-                            <>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                onClick={() => void handleSaveEdit()}
-                                disabled={
-                                  savingEdit ||
-                                  !editing.value.trim() ||
-                                  editHeadersValidation.errors.length > 0
-                                }
-                                className="h-7 w-7 text-green-500 hover:text-green-400"
-                                title="Save (Enter)"
-                              >
-                                {savingEdit ? (
-                                  <Loader2 className="h-4 w-4 animate-spin" />
-                                ) : (
-                                  <Check className="h-4 w-4" />
-                                )}
-                              </Button>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                onClick={handleCancelEdit}
-                                disabled={savingEdit}
-                                className="text-muted hover:text-foreground h-7 w-7"
-                                title="Cancel (Esc)"
-                              >
-                                <X className="h-4 w-4" />
-                              </Button>
-                            </>
-                          ) : (
-                            <>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                onClick={() => void handleTest(name)}
-                                disabled={isTesting}
-                                className="text-muted hover:text-accent h-7 w-7"
-                                title="Test connection"
-                              >
-                                {isTesting ? (
-                                  <Loader2 className="h-4 w-4 animate-spin" />
-                                ) : (
-                                  <Play className="h-4 w-4" />
-                                )}
-                              </Button>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                onClick={() => handleStartEdit(name, entry)}
-                                className="text-muted hover:text-accent h-7 w-7"
-                                title="Edit server"
-                              >
-                                <Pencil className="h-4 w-4" />
-                              </Button>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                onClick={() => void handleRemove(name)}
-                                disabled={loading}
-                                className="text-muted hover:text-error h-7 w-7"
-                                title="Remove server"
-                              >
-                                <Trash2 className="h-4 w-4" />
-                              </Button>
-                            </>
-                          )}
+                        {isEditing ? (
+                          <div className="mt-2 space-y-2">
+                            <p className="text-muted text-xs">transport: {editing.transport}</p>
+                            <input
+                              type="text"
+                              value={editing.value}
+                              onChange={(e) =>
+                                setEditing({
+                                  ...editing,
+                                  value: e.target.value,
+                                })
+                              }
+                              className="bg-modal-bg border-border-medium focus:border-accent w-full rounded border px-2 py-1.5 font-mono text-xs focus:outline-none"
+                              autoFocus
+                              spellCheck={false}
+                              onKeyDown={createEditKeyHandler({
+                                onSave: () => void handleSaveEdit(),
+                                onCancel: handleCancelEdit,
+                              })}
+                            />
+                            {editing.transport !== "stdio" && (
+                              <div>
+                                <div className="text-muted mb-1 text-[11px]">
+                                  HTTP headers (optional)
+                                </div>
+                                <MCPHeadersEditor
+                                  rows={editing.headersRows}
+                                  onChange={(rows) =>
+                                    setEditing({
+                                      ...editing,
+                                      headersRows: rows,
+                                    })
+                                  }
+                                  secretKeys={projectSecretKeys}
+                                  disabled={savingEdit}
+                                />
+                              </div>
+                            )}
+                          </div>
+                        ) : (
+                          <p className="text-muted mt-0.5 font-mono text-xs break-all">
+                            {serverDisplayValue(entry)}
+                          </p>
+                        )}
+                      </div>
+                      <div className="flex shrink-0 items-center gap-0.5">
+                        {isEditing ? (
+                          <>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => void handleSaveEdit()}
+                              disabled={
+                                savingEdit ||
+                                !editing.value.trim() ||
+                                editHeadersValidation.errors.length > 0
+                              }
+                              className="h-7 w-7 text-green-500 hover:text-green-400"
+                              title="Save (Enter)"
+                            >
+                              {savingEdit ? (
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                              ) : (
+                                <Check className="h-4 w-4" />
+                              )}
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={handleCancelEdit}
+                              disabled={savingEdit}
+                              className="text-muted hover:text-foreground h-7 w-7"
+                              title="Cancel (Esc)"
+                            >
+                              <X className="h-4 w-4" />
+                            </Button>
+                          </>
+                        ) : (
+                          <>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => void handleTest(name)}
+                              disabled={isTesting}
+                              className="text-muted hover:text-accent h-7 w-7"
+                              title="Test connection"
+                            >
+                              {isTesting ? (
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                              ) : (
+                                <Play className="h-4 w-4" />
+                              )}
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => handleStartEdit(name, entry)}
+                              className="text-muted hover:text-accent h-7 w-7"
+                              title="Edit server"
+                            >
+                              <Pencil className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => void handleRemove(name)}
+                              disabled={loading}
+                              className="text-muted hover:text-error h-7 w-7"
+                              title="Remove server"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                    {cached && !cached.result.success && !isEditing && (
+                      <div className="border-border-medium text-destructive border-t px-3 py-2 text-xs">
+                        <div className="flex items-start gap-1.5">
+                          <XCircle className="mt-0.5 h-3 w-3 shrink-0" />
+                          <span>{cached.result.error}</span>
                         </div>
                       </div>
-                      {cached && !cached.result.success && !isEditing && (
-                        <div className="border-border-medium text-destructive border-t px-3 py-2 text-xs">
-                          <div className="flex items-start gap-1.5">
-                            <XCircle className="mt-0.5 h-3 w-3 shrink-0" />
-                            <span>{cached.result.error}</span>
-                          </div>
-                        </div>
-                      )}
-                      {cached?.result.success && cached.result.tools.length > 0 && !isEditing && (
-                        <div className="border-border-medium border-t px-3 py-2">
-                          <ToolAllowlistSection
-                            serverName={name}
-                            availableTools={cached.result.tools}
-                            currentAllowlist={entry.toolAllowlist}
-                            testedAt={cached.testedAt}
-                            projectPath={selectedProject}
-                          />
-                        </div>
-                      )}
-                    </div>
-                  );
-                })
-              )}
-            </div>
+                    )}
+                    {cached?.result.success && cached.result.tools.length > 0 && !isEditing && (
+                      <div className="border-border-medium border-t px-3 py-2">
+                        <ToolAllowlistSection
+                          serverName={name}
+                          availableTools={cached.result.tools}
+                          currentAllowlist={entry.toolAllowlist}
+                          testedAt={cached.testedAt}
+                          onSaveAllowlist={(toolAllowlist) => setToolAllowlist(name, toolAllowlist)}
+                        />
+                      </div>
+                    )}
+                  </div>
+                );
+              })
+            )}
+          </div>
 
-            {/* Add server form */}
-            <details className="group mt-3">
-              <summary className="text-accent hover:text-accent/80 flex cursor-pointer list-none items-center gap-1 text-sm font-medium">
-                <ChevronRight className="h-4 w-4 transition-transform group-open:rotate-90" />
-                Add server
-              </summary>
-              <div className="border-border-medium bg-background-secondary mt-2 space-y-3 rounded-md border p-3">
-                <div>
-                  <label htmlFor="server-name" className="text-muted mb-1 block text-xs">
-                    Name
-                  </label>
-                  <input
-                    id="server-name"
-                    type="text"
-                    placeholder="e.g., memory"
-                    value={newServer.name}
-                    onChange={(e) => setNewServer((prev) => ({ ...prev, name: e.target.value }))}
-                    className="bg-modal-bg border-border-medium focus:border-accent w-full rounded border px-2 py-1.5 text-sm focus:outline-none"
-                  />
-                </div>
+          {/* Add server form */}
+          <details className="group mt-3">
+            <summary className="text-accent hover:text-accent/80 flex cursor-pointer list-none items-center gap-1 text-sm font-medium">
+              <ChevronRight className="h-4 w-4 transition-transform group-open:rotate-90" />
+              Add server
+            </summary>
+            <div className="border-border-medium bg-background-secondary mt-2 space-y-3 rounded-md border p-3">
+              <div>
+                <label
+                  htmlFor={`${idPrefix}-server-name`}
+                  className="text-muted mb-1 block text-xs"
+                >
+                  Name
+                </label>
+                <input
+                  id={`${idPrefix}-server-name`}
+                  type="text"
+                  placeholder="e.g., memory"
+                  value={newServer.name}
+                  onChange={(e) => setNewServer((prev) => ({ ...prev, name: e.target.value }))}
+                  className="bg-modal-bg border-border-medium focus:border-accent w-full rounded border px-2 py-1.5 text-sm focus:outline-none"
+                />
+              </div>
 
+              <div>
+                <label className="text-muted mb-1 block text-xs">Transport</label>
+                <Select
+                  value={newServer.transport}
+                  onValueChange={(value) =>
+                    setNewServer((prev) => ({
+                      ...prev,
+                      transport: value as MCPServerTransport,
+                      value: "",
+                      headersRows: [],
+                    }))
+                  }
+                >
+                  <SelectTrigger className="border-border-medium bg-modal-bg h-8 w-full text-sm">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {mcpAllowUserDefined?.stdio !== false && (
+                      <SelectItem value="stdio">Stdio</SelectItem>
+                    )}
+                    {mcpAllowUserDefined?.remote !== false && (
+                      <>
+                        <SelectItem value="http">HTTP (Streamable)</SelectItem>
+                        <SelectItem value="sse">SSE (Legacy)</SelectItem>
+                        <SelectItem value="auto">Auto (HTTP → SSE)</SelectItem>
+                      </>
+                    )}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div>
+                <label
+                  htmlFor={`${idPrefix}-server-value`}
+                  className="text-muted mb-1 block text-xs"
+                >
+                  {newServer.transport === "stdio" ? "Command" : "URL"}
+                </label>
+                <input
+                  id={`${idPrefix}-server-value`}
+                  type="text"
+                  placeholder={
+                    newServer.transport === "stdio"
+                      ? "e.g., npx -y @modelcontextprotocol/server-memory"
+                      : "e.g., http://localhost:3333/mcp"
+                  }
+                  value={newServer.value}
+                  onChange={(e) => setNewServer((prev) => ({ ...prev, value: e.target.value }))}
+                  spellCheck={false}
+                  className="bg-modal-bg border-border-medium focus:border-accent w-full rounded border px-2 py-1.5 font-mono text-sm focus:outline-none"
+                />
+              </div>
+
+              {newServer.transport !== "stdio" && (
                 <div>
-                  <label className="text-muted mb-1 block text-xs">Transport</label>
-                  <Select
-                    value={newServer.transport}
-                    onValueChange={(value) =>
+                  <label className="text-muted mb-1 block text-xs">HTTP headers (optional)</label>
+                  <MCPHeadersEditor
+                    rows={newServer.headersRows}
+                    onChange={(rows) =>
                       setNewServer((prev) => ({
                         ...prev,
-                        transport: value as MCPServerTransport,
-                        value: "",
-                        headersRows: [],
+                        headersRows: rows,
                       }))
                     }
-                  >
-                    <SelectTrigger className="border-border-medium bg-modal-bg h-8 w-full text-sm">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {mcpAllowUserDefined?.stdio !== false && (
-                        <SelectItem value="stdio">Stdio</SelectItem>
-                      )}
-                      {mcpAllowUserDefined?.remote !== false && (
-                        <>
-                          <SelectItem value="http">HTTP (Streamable)</SelectItem>
-                          <SelectItem value="sse">SSE (Legacy)</SelectItem>
-                          <SelectItem value="auto">Auto (HTTP → SSE)</SelectItem>
-                        </>
-                      )}
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                <div>
-                  <label htmlFor="server-value" className="text-muted mb-1 block text-xs">
-                    {newServer.transport === "stdio" ? "Command" : "URL"}
-                  </label>
-                  <input
-                    id="server-value"
-                    type="text"
-                    placeholder={
-                      newServer.transport === "stdio"
-                        ? "e.g., npx -y @modelcontextprotocol/server-memory"
-                        : "e.g., http://localhost:3333/mcp"
-                    }
-                    value={newServer.value}
-                    onChange={(e) => setNewServer((prev) => ({ ...prev, value: e.target.value }))}
-                    spellCheck={false}
-                    className="bg-modal-bg border-border-medium focus:border-accent w-full rounded border px-2 py-1.5 font-mono text-sm focus:outline-none"
+                    secretKeys={projectSecretKeys}
+                    disabled={addingServer || testingNew}
                   />
                 </div>
+              )}
 
-                {newServer.transport !== "stdio" && (
-                  <div>
-                    <label className="text-muted mb-1 block text-xs">HTTP headers (optional)</label>
-                    <MCPHeadersEditor
-                      rows={newServer.headersRows}
-                      onChange={(rows) =>
-                        setNewServer((prev) => ({
-                          ...prev,
-                          headersRows: rows,
-                        }))
-                      }
-                      secretKeys={projectSecretKeys}
-                      disabled={addingServer || testingNew}
-                    />
-                  </div>
-                )}
-
-                {/* Test result */}
-                {newTestResult && (
-                  <div
-                    className={cn(
-                      "flex items-start gap-2 rounded-md px-3 py-2 text-sm",
-                      newTestResult.result.success
-                        ? "bg-green-500/10 text-green-500"
-                        : "bg-destructive/10 text-destructive"
-                    )}
-                  >
-                    {newTestResult.result.success ? (
-                      <>
-                        <CheckCircle className="mt-0.5 h-4 w-4 shrink-0" />
-                        <div>
-                          <span className="font-medium">
-                            Connected — {newTestResult.result.tools.length} tools
-                          </span>
-                          {newTestResult.result.tools.length > 0 && (
-                            <p className="mt-0.5 text-xs opacity-80">
-                              {newTestResult.result.tools.join(", ")}
-                            </p>
-                          )}
-                        </div>
-                      </>
-                    ) : (
-                      <>
-                        <XCircle className="mt-0.5 h-4 w-4 shrink-0" />
-                        <span>{newTestResult.result.error}</span>
-                      </>
-                    )}
-                  </div>
-                )}
-
-                <div className="flex gap-2 pt-1">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => void handleTestNewServer()}
-                    disabled={!canTest || testingNew}
-                  >
-                    {testingNew ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    ) : (
-                      <Play className="h-3.5 w-3.5" />
-                    )}
-                    {testingNew ? "Testing…" : "Test"}
-                  </Button>
-                  <Button
-                    size="sm"
-                    onClick={() => void handleAddServer()}
-                    disabled={!canAdd || addingServer}
-                  >
-                    {addingServer ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    ) : (
-                      <Plus className="h-3.5 w-3.5" />
-                    )}
-                    {addingServer ? "Adding…" : "Add"}
-                  </Button>
+              {/* Test result */}
+              {newTestResult && (
+                <div
+                  className={cn(
+                    "flex items-start gap-2 rounded-md px-3 py-2 text-sm",
+                    newTestResult.result.success
+                      ? "bg-green-500/10 text-green-500"
+                      : "bg-destructive/10 text-destructive"
+                  )}
+                >
+                  {newTestResult.result.success ? (
+                    <>
+                      <CheckCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                      <div>
+                        <span className="font-medium">
+                          Connected — {newTestResult.result.tools.length} tools
+                        </span>
+                        {newTestResult.result.tools.length > 0 && (
+                          <p className="mt-0.5 text-xs opacity-80">
+                            {newTestResult.result.tools.join(", ")}
+                          </p>
+                        )}
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <XCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                      <span>{newTestResult.result.error}</span>
+                    </>
+                  )}
                 </div>
+              )}
+
+              <div className="flex gap-2 pt-1">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void handleTestNewServer()}
+                  disabled={!canTest || testingNew}
+                >
+                  {testingNew ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Play className="h-3.5 w-3.5" />
+                  )}
+                  {testingNew ? "Testing…" : "Test"}
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={() => void handleAddServer()}
+                  disabled={!canAdd || addingServer}
+                >
+                  {addingServer ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Plus className="h-3.5 w-3.5" />
+                  )}
+                  {addingServer ? "Adding…" : "Add"}
+                </Button>
               </div>
-            </details>
-          </>
+            </div>
+          </details>
+        </>
+      )}
+    </div>
+  );
+};
+
+export const ProjectSettingsSection: React.FC = () => {
+  const { api } = useAPI();
+  const policyState = usePolicy();
+
+  const mcpAllowUserDefined: McpAllowUserDefined =
+    policyState.status.state === "enforced" ? policyState.policy?.mcp.allowUserDefined : undefined;
+
+  const mcpDisabledByPolicy = Boolean(
+    mcpAllowUserDefined?.stdio === false && mcpAllowUserDefined.remote === false
+  );
+
+  const { projectsTargetProjectPath, clearProjectsTargetProjectPath } = useSettings();
+  const { projects, getSecrets } = useProjectContext();
+
+  const projectList = Array.from(projects.keys());
+
+  const [selectedProject, setSelectedProject] = useState<string>("");
+  const [projectSecretKeys, setProjectSecretKeys] = useState<string[]>([]);
+
+  const {
+    cache: testCache,
+    setResult: cacheTestResult,
+    clearResult: clearTestResult,
+  } = useMCPTestCache(selectedProject);
+
+  // Default project selection (or deep-link into a target project from elsewhere)
+  useEffect(() => {
+    if (projectList.length === 0) {
+      setSelectedProject("");
+      return;
+    }
+
+    if (projectsTargetProjectPath) {
+      const target = projectsTargetProjectPath;
+      clearProjectsTargetProjectPath();
+
+      if (projectList.includes(target)) {
+        setSelectedProject(target);
+        return;
+      }
+    }
+
+    if (!selectedProject || !projectList.includes(selectedProject)) {
+      setSelectedProject(projectList[0]);
+    }
+  }, [projectList, selectedProject, projectsTargetProjectPath, clearProjectsTargetProjectPath]);
+
+  // Fetch secret keys for header validation in the MCP UI.
+  useEffect(() => {
+    if (!selectedProject) {
+      setProjectSecretKeys([]);
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const secrets = await getSecrets(selectedProject);
+        if (cancelled) return;
+        setProjectSecretKeys(secrets.map((s) => s.key));
+      } catch (err) {
+        if (cancelled) return;
+        console.error("Failed to load project secrets:", err);
+        setProjectSecretKeys([]);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [getSecrets, selectedProject]);
+
+  const projectName = (path: string) => path.split(/[\\/]/).pop() ?? path;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <p className="text-muted mb-4 text-xs">
+          Configure MCP servers globally (stored in{" "}
+          <code className="text-accent">~/.mux/mcp.jsonc</code>) and per-project (stored in{" "}
+          <code className="text-accent">.mux/mcp.jsonc</code>). Project servers override global
+          servers on name collisions.
+        </p>
+
+        {projectList.length === 0 ? (
+          <div className="text-muted text-xs">
+            No projects configured yet. Global MCP servers can still be configured below.
+          </div>
+        ) : (
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="text-foreground text-sm">Project</div>
+              <div className="text-muted text-xs">Select a project to configure</div>
+            </div>
+            <Select value={selectedProject} onValueChange={setSelectedProject}>
+              <SelectTrigger className="border-border-medium bg-background-secondary hover:bg-hover h-9 w-auto min-w-[160px] cursor-pointer rounded-md border px-3 text-sm transition-colors">
+                <SelectValue placeholder="Select project" />
+              </SelectTrigger>
+              <SelectContent>
+                {projectList.map((path) => (
+                  <SelectItem key={path} value={path}>
+                    {projectName(path)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
         )}
+      </div>
+
+      <McpServersEditor
+        title="Global MCP Servers"
+        description={
+          <p className="text-muted text-xs">
+            Applies to all projects. To test a server (and to validate secret header references),
+            pick a project above.
+          </p>
+        }
+        disabledByPolicy={mcpDisabledByPolicy}
+        mcpAllowUserDefined={mcpAllowUserDefined}
+        projectSecretKeys={projectSecretKeys}
+        testCachePrefix="global"
+        testCache={testCache}
+        cacheTestResult={cacheTestResult}
+        clearTestResult={clearTestResult}
+        loadDiagnostics={() =>
+          api
+            ? api.global.mcp.getDiagnostics()
+            : Promise.resolve({
+                filePath: "",
+                parseErrors: [],
+                validationErrors: [],
+              })
+        }
+        loadServers={() => (api ? api.global.mcp.list() : Promise.resolve({}))}
+        addOrUpdateServer={({ name, transport, value, headers }) => {
+          if (!api) {
+            return Promise.resolve({ success: false, error: "API unavailable" });
+          }
+
+          return api.global.mcp.add({
+            name,
+            ...(transport === "stdio"
+              ? { transport: "stdio", command: value }
+              : { transport, url: value, headers }),
+          });
+        }}
+        removeServer={(name) => {
+          if (!api) {
+            return Promise.resolve({ success: false, error: "API unavailable" });
+          }
+          return api.global.mcp.remove({ name });
+        }}
+        setEnabled={(name, enabled) => {
+          if (!api) {
+            return Promise.resolve({ success: false, error: "API unavailable" });
+          }
+          return api.global.mcp.setEnabled({ name, enabled });
+        }}
+        testServerByName={(name) => {
+          if (!api) {
+            return Promise.resolve({ success: false, error: "API unavailable" });
+          }
+          if (!selectedProject) {
+            return Promise.resolve({
+              success: false,
+              error: "Select a project first (needed to resolve secret headers)",
+            });
+          }
+          return api.global.mcp.test({ projectPath: selectedProject, name });
+        }}
+        testServerAdhoc={({ transport, value, headers }) => {
+          if (!api) {
+            return Promise.resolve({ success: false, error: "API unavailable" });
+          }
+          if (!selectedProject) {
+            return Promise.resolve({
+              success: false,
+              error: "Select a project first (needed to resolve secret headers)",
+            });
+          }
+
+          return api.global.mcp.test({
+            projectPath: selectedProject,
+            ...(transport === "stdio" ? { command: value } : { transport, url: value, headers }),
+          });
+        }}
+        setToolAllowlist={(name, toolAllowlist) => {
+          if (!api) {
+            return Promise.resolve({ success: false, error: "API unavailable" });
+          }
+          return api.global.mcp.setToolAllowlist({ name, toolAllowlist });
+        }}
+      />
+
+      <div className="border-border-medium border-t pt-6">
+        <McpServersEditor
+          title="Project MCP Servers"
+          description={
+            <p className="text-muted text-xs">
+              Stored in <code className="text-accent">.mux/mcp.jsonc</code> in your project.
+            </p>
+          }
+          disabledByPolicy={mcpDisabledByPolicy}
+          mcpAllowUserDefined={mcpAllowUserDefined}
+          projectSecretKeys={projectSecretKeys}
+          testCache={testCache}
+          cacheTestResult={cacheTestResult}
+          clearTestResult={clearTestResult}
+          loadDiagnostics={() => {
+            if (!api) {
+              return Promise.resolve({ filePath: "", parseErrors: [], validationErrors: [] });
+            }
+            if (!selectedProject) {
+              return Promise.resolve({ filePath: "", parseErrors: [], validationErrors: [] });
+            }
+
+            return api.projects.mcp.getDiagnostics({ projectPath: selectedProject });
+          }}
+          loadServers={() => {
+            if (!api) {
+              return Promise.resolve({});
+            }
+            if (!selectedProject) {
+              return Promise.resolve({});
+            }
+            return api.projects.mcp.list({ projectPath: selectedProject });
+          }}
+          addOrUpdateServer={({ name, transport, value, headers }) => {
+            if (!api) {
+              return Promise.resolve({ success: false, error: "API unavailable" });
+            }
+            if (!selectedProject) {
+              return Promise.resolve({ success: false, error: "Select a project first" });
+            }
+
+            return api.projects.mcp.add({
+              projectPath: selectedProject,
+              name,
+              ...(transport === "stdio"
+                ? { transport: "stdio", command: value }
+                : { transport, url: value, headers }),
+            });
+          }}
+          removeServer={(name) => {
+            if (!api) {
+              return Promise.resolve({ success: false, error: "API unavailable" });
+            }
+            if (!selectedProject) {
+              return Promise.resolve({ success: false, error: "Select a project first" });
+            }
+
+            return api.projects.mcp.remove({ projectPath: selectedProject, name });
+          }}
+          setEnabled={(name, enabled) => {
+            if (!api) {
+              return Promise.resolve({ success: false, error: "API unavailable" });
+            }
+            if (!selectedProject) {
+              return Promise.resolve({ success: false, error: "Select a project first" });
+            }
+
+            return api.projects.mcp.setEnabled({ projectPath: selectedProject, name, enabled });
+          }}
+          testServerByName={(name) => {
+            if (!api) {
+              return Promise.resolve({ success: false, error: "API unavailable" });
+            }
+            if (!selectedProject) {
+              return Promise.resolve({ success: false, error: "Select a project first" });
+            }
+
+            return api.projects.mcp.test({ projectPath: selectedProject, name });
+          }}
+          testServerAdhoc={({ transport, value, headers }) => {
+            if (!api) {
+              return Promise.resolve({ success: false, error: "API unavailable" });
+            }
+            if (!selectedProject) {
+              return Promise.resolve({ success: false, error: "Select a project first" });
+            }
+
+            return api.projects.mcp.test({
+              projectPath: selectedProject,
+              ...(transport === "stdio" ? { command: value } : { transport, url: value, headers }),
+            });
+          }}
+          setToolAllowlist={(name, toolAllowlist) => {
+            if (!api) {
+              return Promise.resolve({ success: false, error: "API unavailable" });
+            }
+            if (!selectedProject) {
+              return Promise.resolve({ success: false, error: "Select a project first" });
+            }
+
+            return api.projects.mcp.setToolAllowlist({
+              projectPath: selectedProject,
+              name,
+              toolAllowlist,
+            });
+          }}
+        />
       </div>
     </div>
   );

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -448,7 +448,7 @@ async function main(): Promise<number> {
   }
 
   // Initialize MCP support
-  const mcpConfigService = new MCPConfigService();
+  const mcpConfigService = new MCPConfigService(config);
   const inlineServers: Record<string, string> = {};
   for (const entry of opts.mcp) {
     inlineServers[entry.name] = entry.command;

--- a/src/common/orpc/schemas.ts
+++ b/src/common/orpc/schemas.ts
@@ -172,6 +172,7 @@ export {
   debug,
   features,
   general,
+  global,
   menu,
   agentSkills,
   agents,

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -33,12 +33,19 @@ import {
 } from "./agentDefinition";
 import {
   MCPAddParamsSchema,
+  MCPConfigDiagnosticsSchema,
+  MCPGlobalAddParamsSchema,
+  MCPGlobalRemoveParamsSchema,
+  MCPGlobalSetEnabledParamsSchema,
+  MCPGlobalSetToolAllowlistParamsSchema,
   MCPRemoveParamsSchema,
   MCPServerMapSchema,
   MCPSetEnabledParamsSchema,
   MCPSetToolAllowlistParamsSchema,
   MCPTestParamsSchema,
   MCPTestResultSchema,
+  MCPWorkspaceMcpRestartParamsSchema,
+  MCPWorkspaceMcpStatusSchema,
   WorkspaceMCPOverridesSchema,
 } from "./mcp";
 import { PolicyGetResponseSchema } from "./policy";
@@ -261,6 +268,10 @@ export const projects = {
       input: z.object({ projectPath: z.string() }),
       output: MCPServerMapSchema,
     },
+    getDiagnostics: {
+      input: z.object({ projectPath: z.string() }),
+      output: MCPConfigDiagnosticsSchema,
+    },
     add: {
       input: MCPAddParamsSchema,
       output: ResultSchema(z.void(), z.string()),
@@ -390,6 +401,40 @@ const DebugLlmRequestSnapshotSchema = z
       .optional(),
   })
   .strict();
+
+// Global (user-level) config
+export const global = {
+  mcp: {
+    list: {
+      input: z.void(),
+      output: MCPServerMapSchema,
+    },
+    getDiagnostics: {
+      input: z.void(),
+      output: MCPConfigDiagnosticsSchema,
+    },
+    add: {
+      input: MCPGlobalAddParamsSchema,
+      output: ResultSchema(z.void(), z.string()),
+    },
+    remove: {
+      input: MCPGlobalRemoveParamsSchema,
+      output: ResultSchema(z.void(), z.string()),
+    },
+    test: {
+      input: MCPTestParamsSchema,
+      output: MCPTestResultSchema,
+    },
+    setEnabled: {
+      input: MCPGlobalSetEnabledParamsSchema,
+      output: ResultSchema(z.void(), z.string()),
+    },
+    setToolAllowlist: {
+      input: MCPGlobalSetToolAllowlistParamsSchema,
+      output: ResultSchema(z.void(), z.string()),
+    },
+  },
+};
 
 export const workspace = {
   list: {
@@ -737,6 +782,14 @@ export const workspace = {
         workspaceId: z.string(),
         overrides: WorkspaceMCPOverridesSchema,
       }),
+      output: ResultSchema(z.void(), z.string()),
+    },
+    status: {
+      input: z.object({ workspaceId: z.string() }),
+      output: MCPWorkspaceMcpStatusSchema,
+    },
+    restart: {
+      input: MCPWorkspaceMcpRestartParamsSchema,
       output: ResultSchema(z.void(), z.string()),
     },
   },

--- a/src/common/types/mcp.ts
+++ b/src/common/types/mcp.ts
@@ -81,3 +81,44 @@ export interface WorkspaceMCPOverrides {
    */
   toolAllowlist?: Record<string, string[]>;
 }
+
+// ---------------------------------------------------------------------------
+// Global MCP config + runtime status (issue #2060)
+// ---------------------------------------------------------------------------
+
+export type MCPServerOrigin = "global" | "project" | "inline";
+
+export interface MCPServerWithOrigin {
+  info: MCPServerInfo;
+  origin: MCPServerOrigin;
+}
+
+export interface MCPConfigParseError {
+  message: string;
+  offset: number;
+  length: number;
+}
+
+export interface MCPConfigValidationError {
+  message: string;
+  serverName?: string;
+}
+
+export interface MCPConfigDiagnostics {
+  filePath: string;
+  parseErrors: MCPConfigParseError[];
+  validationErrors: MCPConfigValidationError[];
+}
+
+export type MCPServerRuntimeState = "not_started" | "starting" | "running" | "failed" | "stopped";
+
+export interface MCPServerRuntimeStatus {
+  state: MCPServerRuntimeState;
+  toolCount?: number;
+  resolvedTransport?: "stdio" | "http" | "sse";
+  autoFallbackUsed?: boolean;
+  lastStartedAt?: number;
+  lastStoppedAt?: number;
+  lastError?: string;
+  lastErrorAt?: number;
+}

--- a/src/node/services/mcpConfigService.test.ts
+++ b/src/node/services/mcpConfigService.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import * as fs from "fs/promises";
 import * as path from "path";
 import * as os from "os";
+import { Config } from "@/node/config";
 import { MCPConfigService } from "./mcpConfigService";
 import { MCPServerManager } from "./mcpServerManager";
 import type { WorkspaceMCPOverrides } from "@/common/types/mcp";
@@ -13,7 +14,7 @@ describe("MCP server disable filtering", () => {
 
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-test-"));
-    configService = new MCPConfigService();
+    configService = new MCPConfigService(new Config(tempDir));
     serverManager = new MCPServerManager(configService);
   });
 
@@ -58,7 +59,7 @@ describe("Workspace MCP overrides filtering", () => {
 
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-test-"));
-    configService = new MCPConfigService();
+    configService = new MCPConfigService(new Config(tempDir));
     serverManager = new MCPServerManager(configService);
 
     // Set up multiple servers for testing

--- a/src/node/services/mcpConfigService.ts
+++ b/src/node/services/mcpConfigService.ts
@@ -4,17 +4,33 @@ import * as jsonc from "jsonc-parser";
 import writeFileAtomic from "write-file-atomic";
 import type {
   MCPConfig,
+  MCPConfigDiagnostics,
   MCPHeaderValue,
   MCPServerInfo,
   MCPServerTransport,
 } from "@/common/types/mcp";
+import type { Config } from "@/node/config";
 import { log } from "@/node/services/log";
 import { Ok, Err } from "@/common/types/result";
 import type { Result } from "@/common/types/result";
 
 export class MCPConfigService {
-  private getConfigPath(projectPath: string): string {
+  constructor(private readonly config: Config) {}
+
+  // Avoid spamming logs when a config file is permanently malformed.
+  private readonly loggedParseErrors = new Set<string>();
+
+  private getProjectConfigPath(projectPath: string): string {
     return path.join(projectPath, ".mux", "mcp.jsonc");
+  }
+
+  private getGlobalConfigPath(): string {
+    return path.join(this.config.rootDir, "mcp.jsonc");
+  }
+
+  // Backwards-compatible alias: existing call sites treat this as the project config file.
+  private getConfigPath(projectPath: string): string {
+    return this.getProjectConfigPath(projectPath);
   }
 
   private async pathExists(targetPath: string): Promise<boolean> {
@@ -31,6 +47,23 @@ export class MCPConfigService {
     if (!(await this.pathExists(muxDir))) {
       await fs.promises.mkdir(muxDir, { recursive: true });
     }
+  }
+
+  private logParseErrorsOnce(filePath: string, errors: jsonc.ParseError[]): void {
+    if (errors.length === 0) {
+      return;
+    }
+
+    if (this.loggedParseErrors.has(filePath)) {
+      return;
+    }
+
+    this.loggedParseErrors.add(filePath);
+
+    log.warn("[MCP] Failed to parse MCP config (JSONC parse errors)", {
+      filePath,
+      errorCount: errors.length,
+    });
   }
 
   /**
@@ -90,8 +123,9 @@ export class MCPConfigService {
       }
     }
 
-    // If it has a url, prefer HTTP-based transports (default to auto).
-    if (url) {
+    // If it has a url field, prefer HTTP-based transports (default to auto).
+    // Note: treat empty-string url as "configured but invalid" so diagnostics can surface it.
+    if (url !== undefined) {
       const httpTransport = transport && transport !== "stdio" ? transport : "auto";
       return {
         transport: httpTransport,
@@ -111,6 +145,26 @@ export class MCPConfigService {
     };
   }
 
+  private validateServers(
+    servers: Record<string, MCPServerInfo>
+  ): MCPConfigDiagnostics["validationErrors"] {
+    const validationErrors: MCPConfigDiagnostics["validationErrors"] = [];
+
+    for (const [serverName, info] of Object.entries(servers)) {
+      if (info.transport === "stdio") {
+        if (!info.command.trim()) {
+          validationErrors.push({ message: "missing command", serverName });
+        }
+        continue;
+      }
+
+      if (!info.url.trim()) {
+        validationErrors.push({ message: "missing url", serverName });
+      }
+    }
+
+    return validationErrors;
+  }
   async getConfig(projectPath: string): Promise<MCPConfig> {
     const filePath = this.getConfigPath(projectPath);
     try {
@@ -119,7 +173,14 @@ export class MCPConfigService {
         return { servers: {} };
       }
       const raw = await fs.promises.readFile(filePath, "utf-8");
-      const parsed = jsonc.parse(raw) as { servers?: Record<string, unknown> } | undefined;
+      const errors: jsonc.ParseError[] = [];
+      const parsed = jsonc.parse(raw, errors) as { servers?: Record<string, unknown> } | undefined;
+
+      if (errors.length > 0) {
+        this.logParseErrorsOnce(filePath, errors);
+        return { servers: {} };
+      }
+
       if (!parsed || typeof parsed !== "object" || !parsed.servers) {
         return { servers: {} };
       }
@@ -181,6 +242,146 @@ export class MCPConfigService {
     await writeFileAtomic(filePath, JSON.stringify({ servers: output }, null, 2), "utf-8");
   }
 
+  private async getGlobalConfig(): Promise<MCPConfig> {
+    const filePath = this.getGlobalConfigPath();
+
+    try {
+      const exists = await this.pathExists(filePath);
+      if (!exists) {
+        return { servers: {} };
+      }
+
+      const raw = await fs.promises.readFile(filePath, "utf-8");
+      const errors: jsonc.ParseError[] = [];
+      const parsed = jsonc.parse(raw, errors) as { servers?: Record<string, unknown> } | undefined;
+
+      if (errors.length > 0) {
+        this.logParseErrorsOnce(filePath, errors);
+        return { servers: {} };
+      }
+
+      if (!parsed || typeof parsed !== "object" || !parsed.servers) {
+        return { servers: {} };
+      }
+
+      // Normalize all entries on read.
+      const servers: Record<string, MCPServerInfo> = {};
+      for (const [name, entry] of Object.entries(parsed.servers)) {
+        servers[name] = this.normalizeEntry(entry);
+      }
+
+      return { servers };
+    } catch (error) {
+      log.error("[MCP] Failed to read global MCP config", { filePath, error });
+      return { servers: {} };
+    }
+  }
+
+  private async saveGlobalConfig(config: MCPConfig): Promise<void> {
+    // Global MCP config lives in ~/.mux (Config.rootDir); ensure it exists for new installs/tests.
+    await fs.promises.mkdir(this.config.rootDir, { recursive: true });
+
+    const filePath = this.getGlobalConfigPath();
+
+    // Write minimal format:
+    // - string for stdio servers without extra settings
+    // - object when:
+    //   - disabled/toolAllowlist set, or
+    //   - non-stdio transport, or
+    //   - headers present
+    //
+    // toolAllowlist: undefined = all tools (omit), [] = no tools, [...] = those tools
+    const output: Record<string, unknown> = {};
+
+    for (const [name, entry] of Object.entries(config.servers)) {
+      const hasSettings = entry.disabled || entry.toolAllowlist !== undefined;
+
+      if (entry.transport === "stdio") {
+        if (!hasSettings) {
+          output[name] = entry.command;
+          continue;
+        }
+
+        const obj: Record<string, unknown> = {
+          command: entry.command,
+        };
+        if (entry.disabled) obj.disabled = true;
+        if (entry.toolAllowlist !== undefined) obj.toolAllowlist = entry.toolAllowlist;
+        output[name] = obj;
+        continue;
+      }
+
+      const obj: Record<string, unknown> = {
+        transport: entry.transport,
+        url: entry.url,
+      };
+      if (entry.headers) obj.headers = entry.headers;
+      if (entry.disabled) obj.disabled = true;
+      if (entry.toolAllowlist !== undefined) obj.toolAllowlist = entry.toolAllowlist;
+
+      output[name] = obj;
+    }
+
+    await writeFileAtomic(filePath, JSON.stringify({ servers: output }, null, 2), "utf-8");
+  }
+
+  private async getConfigDiagnostics(filePath: string): Promise<MCPConfigDiagnostics> {
+    try {
+      const exists = await this.pathExists(filePath);
+      if (!exists) {
+        return { filePath, parseErrors: [], validationErrors: [] };
+      }
+
+      const raw = await fs.promises.readFile(filePath, "utf-8");
+      const errors: jsonc.ParseError[] = [];
+      const parsed = jsonc.parse(raw, errors) as { servers?: Record<string, unknown> } | undefined;
+
+      const parseErrors: MCPConfigDiagnostics["parseErrors"] = errors.map((error) => ({
+        message: jsonc.printParseErrorCode(error.error),
+        offset: error.offset,
+        length: error.length,
+      }));
+
+      if (errors.length > 0) {
+        return { filePath, parseErrors, validationErrors: [] };
+      }
+
+      if (!parsed || typeof parsed !== "object" || !parsed.servers) {
+        return { filePath, parseErrors: [], validationErrors: [] };
+      }
+
+      const servers: Record<string, MCPServerInfo> = {};
+      for (const [name, entry] of Object.entries(parsed.servers)) {
+        servers[name] = this.normalizeEntry(entry);
+      }
+
+      return {
+        filePath,
+        parseErrors: [],
+        validationErrors: this.validateServers(servers),
+      };
+    } catch (error) {
+      return {
+        filePath,
+        parseErrors: [
+          {
+            message: error instanceof Error ? error.message : String(error),
+            offset: 0,
+            length: 0,
+          },
+        ],
+        validationErrors: [],
+      };
+    }
+  }
+
+  async getProjectConfigDiagnostics(projectPath: string): Promise<MCPConfigDiagnostics> {
+    return this.getConfigDiagnostics(this.getProjectConfigPath(projectPath));
+  }
+
+  async getGlobalConfigDiagnostics(): Promise<MCPConfigDiagnostics> {
+    return this.getConfigDiagnostics(this.getGlobalConfigPath());
+  }
   /** List all servers with normalized config */
   async listServers(projectPath: string): Promise<Record<string, MCPServerInfo>> {
     const cfg = await this.getConfig(projectPath);
@@ -301,6 +502,130 @@ export class MCPConfigService {
       return Ok(undefined);
     } catch (error) {
       log.error("Failed to update MCP server tool allowlist", { projectPath, name, error });
+      return Err(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Global MCP servers (~/.mux/mcp.jsonc)
+  // ---------------------------------------------------------------------------
+
+  async listGlobalServers(): Promise<Record<string, MCPServerInfo>> {
+    const cfg = await this.getGlobalConfig();
+    return cfg.servers;
+  }
+
+  async addGlobalServer(
+    name: string,
+    input: {
+      transport?: MCPServerTransport;
+      command?: string;
+      url?: string;
+      headers?: Record<string, MCPHeaderValue>;
+    }
+  ): Promise<Result<void>> {
+    if (!name.trim()) {
+      return Err("Server name is required");
+    }
+
+    const transport: MCPServerTransport = input.transport ?? "stdio";
+
+    if (transport === "stdio") {
+      if (!input.command?.trim()) {
+        return Err("Command is required");
+      }
+    } else {
+      if (!input.url?.trim()) {
+        return Err("URL is required");
+      }
+    }
+
+    const cfg = await this.getGlobalConfig();
+    const existing = cfg.servers[name];
+
+    const base = {
+      disabled: existing?.disabled ?? false,
+      toolAllowlist: existing?.toolAllowlist,
+    };
+
+    const next: MCPServerInfo =
+      transport === "stdio"
+        ? {
+            transport: "stdio",
+            command: input.command!,
+            ...base,
+          }
+        : {
+            transport,
+            url: input.url!,
+            headers: input.headers,
+            ...base,
+          };
+
+    cfg.servers[name] = next;
+
+    try {
+      await this.saveGlobalConfig(cfg);
+      return Ok(undefined);
+    } catch (error) {
+      log.error("[MCP] Failed to save global MCP server", { name, error });
+      return Err(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  async setGlobalServerEnabled(name: string, enabled: boolean): Promise<Result<void>> {
+    const cfg = await this.getGlobalConfig();
+    const entry = cfg.servers[name];
+    if (!entry) {
+      return Err(`Server ${name} not found`);
+    }
+
+    cfg.servers[name] = { ...entry, disabled: !enabled };
+
+    try {
+      await this.saveGlobalConfig(cfg);
+      return Ok(undefined);
+    } catch (error) {
+      log.error("[MCP] Failed to update global MCP server enabled state", { name, error });
+      return Err(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  async removeGlobalServer(name: string): Promise<Result<void>> {
+    const cfg = await this.getGlobalConfig();
+    if (!cfg.servers[name]) {
+      return Err(`Server ${name} not found`);
+    }
+
+    delete cfg.servers[name];
+
+    try {
+      await this.saveGlobalConfig(cfg);
+      return Ok(undefined);
+    } catch (error) {
+      log.error("[MCP] Failed to remove global MCP server", { name, error });
+      return Err(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  async setGlobalToolAllowlist(name: string, toolAllowlist: string[]): Promise<Result<void>> {
+    const cfg = await this.getGlobalConfig();
+    const entry = cfg.servers[name];
+    if (!entry) {
+      return Err(`Server ${name} not found`);
+    }
+
+    // [] = no tools allowed, [...tools] = those tools allowed
+    cfg.servers[name] = {
+      ...entry,
+      toolAllowlist,
+    };
+
+    try {
+      await this.saveGlobalConfig(cfg);
+      return Ok(undefined);
+    } catch (error) {
+      log.error("[MCP] Failed to update global MCP server tool allowlist", { name, error });
       return Err(error instanceof Error ? error.message : String(error));
     }
   }

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -8,11 +8,14 @@ import type { Tool } from "ai";
 interface MCPServerManagerTestAccess {
   workspaceServers: Map<string, unknown>;
   cleanupIdleServers: () => void;
-  startServers: (...args: unknown[]) => Promise<Map<string, unknown>>;
+  startServers: (
+    ...args: unknown[]
+  ) => Promise<{ instances: Map<string, unknown>; errors: Record<string, string> }>;
 }
 
 describe("MCPServerManager", () => {
   let configService: {
+    listGlobalServers: ReturnType<typeof mock>;
     listServers: ReturnType<typeof mock>;
   };
 
@@ -21,6 +24,7 @@ describe("MCPServerManager", () => {
 
   beforeEach(() => {
     configService = {
+      listGlobalServers: mock(() => Promise.resolve({})),
       listServers: mock(() => Promise.resolve({})),
     };
 
@@ -131,8 +135,8 @@ describe("MCPServerManager", () => {
     } as unknown as Tool;
 
     const startServersMock = mock(() =>
-      Promise.resolve(
-        new Map([
+      Promise.resolve({
+        instances: new Map([
           [
             "server",
             {
@@ -144,8 +148,9 @@ describe("MCPServerManager", () => {
               close,
             },
           ],
-        ])
-      )
+        ]),
+        errors: {},
+      })
     );
 
     access.startServers = startServersMock;
@@ -207,8 +212,8 @@ describe("MCPServerManager", () => {
     let startCount = 0;
     const startServersMock = mock(() => {
       startCount += 1;
-      return Promise.resolve(
-        new Map([
+      return Promise.resolve({
+        instances: new Map([
           [
             "server",
             {
@@ -220,8 +225,9 @@ describe("MCPServerManager", () => {
               close: startCount === 1 ? close1 : close2,
             },
           ],
-        ])
-      );
+        ]),
+        errors: {},
+      });
     });
 
     access.startServers = startServersMock;
@@ -278,8 +284,8 @@ describe("MCPServerManager", () => {
       startCount += 1;
 
       if (startCount === 1) {
-        return Promise.resolve(
-          new Map([
+        return Promise.resolve({
+          instances: new Map([
             [
               "serverA",
               {
@@ -302,12 +308,13 @@ describe("MCPServerManager", () => {
                 close: closeB1,
               },
             ],
-          ])
-        );
+          ]),
+          errors: {},
+        });
       }
 
-      return Promise.resolve(
-        new Map([
+      return Promise.resolve({
+        instances: new Map([
           [
             "serverA",
             {
@@ -319,8 +326,9 @@ describe("MCPServerManager", () => {
               close: closeA2,
             },
           ],
-        ])
-      );
+        ]),
+        errors: {},
+      });
     });
 
     access.startServers = startServersMock;
@@ -373,8 +381,8 @@ describe("MCPServerManager", () => {
     const dummyToolB = { execute: mock(() => Promise.resolve({ ok: true })) } as unknown as Tool;
 
     const startServersMock = mock(() =>
-      Promise.resolve(
-        new Map([
+      Promise.resolve({
+        instances: new Map([
           [
             "serverA",
             {
@@ -397,8 +405,9 @@ describe("MCPServerManager", () => {
               close: mock(() => Promise.resolve(undefined)),
             },
           ],
-        ])
-      )
+        ]),
+        errors: {},
+      })
     );
 
     access.startServers = startServersMock;

--- a/src/node/services/serviceContainer.ts
+++ b/src/node/services/serviceContainer.ts
@@ -120,7 +120,7 @@ export class ServiceContainer {
     this.projectService = new ProjectService(config);
     this.initStateManager = new InitStateManager(config);
     this.workspaceMcpOverridesService = new WorkspaceMcpOverridesService(config);
-    this.mcpConfigService = new MCPConfigService();
+    this.mcpConfigService = new MCPConfigService(config);
     this.extensionMetadata = new ExtensionMetadataService(
       path.join(config.rootDir, "extensionMetadata.json")
     );

--- a/src/node/services/systemMessage.ts
+++ b/src/node/services/systemMessage.ts
@@ -162,11 +162,11 @@ function buildMCPContext(mcpServers: MCPServerMap): string {
 
   return `
 <mcp>
-MCP (Model Context Protocol) servers provide additional tools. Configured in user's local project's .mux/mcp.jsonc:
+MCP (Model Context Protocol) servers provide additional tools. Configured in ~/.mux/mcp.jsonc (global) and/or your project's .mux/mcp.jsonc (project):
 
 ${serverList}
 
-Use /mcp add|edit|remove or Settings → Projects to manage servers.
+Use Settings → Projects to manage servers (global or project), or /mcp add|edit|remove for project config.
 </mcp>
 `;
 }


### PR DESCRIPTION
## Summary

Implements MCP improvements from issue #2060:

- Adds a global/shared MCP config file (`~/.mux/mcp.jsonc`) and merges global + project servers.
- Makes MCP server startup resilient (parallel startup + per-server timeouts) so one hung server can’t block a send.
- Exposes per-server runtime status + restart controls in the Workspace MCP modal.
- Emits a non-spam chat warning when MCP tools are unavailable due to startup failures.

## Background

Issue: #2060

## Implementation

- **Config scopes**
  - Global config: `~/.mux/mcp.jsonc`
  - Project config: `<project>/.mux/mcp.jsonc`
  - Precedence: global < project < inline
- **Startup reliability**
  - Adds timeouts around spawn/connect/list-tools and starts servers in parallel.
- **Workspace UX**
  - Workspace MCP modal now shows merged servers, origin (global/project), runtime status, and restart buttons.
  - Restart is disabled while a stream is active or when there are unsaved overrides.
- **Chat warnings**
  - Injects a synthetic assistant warning message on send when MCP servers fail, with dedupe/cooldown.

## Validation

- `make static-check`

## Risks

- Servers that take >10s to spawn/connect/list tools will be treated as failed and retried later; this is intentional to avoid hangs.

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$5.22`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=5.22 -->
