### PR TITLE
🤖 fix: improve file explorer git status contrast in light themes

### DIFF
--- a/src/browser/components/RightSidebar/ExplorerTab.tsx
+++ b/src/browser/components/RightSidebar/ExplorerTab.tsx
@@ -358,19 +358,25 @@ export const ExplorerTab: React.FC<ExplorerTabProps> = (props) => {
     const isModified = state.gitStatus.modified.has(node.path);
     const isUntracked = state.gitStatus.untracked.has(node.path);
 
-    // Determine text color based on git status (modified takes precedence over untracked)
-    const textColor = isModified
-      ? "var(--color-git-modified)"
+    const statusTextClass = isModified
+      ? "text-[var(--color-git-modified)]"
       : isUntracked
-        ? "var(--color-git-untracked)"
+        ? "text-[var(--color-git-untracked)]"
         : undefined;
+
+    // Git status colors can lose contrast against focus/hover row backgrounds in light themes
+    // (notably Flexoki light). Override to the normal foreground color when highlighted so
+    // the selected row stays readable.
+    const statusTextHighlightOverrideClass = statusTextClass
+      ? "group-hover:text-foreground group-focus:text-foreground"
+      : undefined;
 
     return (
       <div key={key}>
         <button
           type="button"
           className={cn(
-            "flex w-full cursor-pointer items-center gap-1 px-2 py-0.5 text-left text-sm hover:bg-accent/50",
+            "group flex w-full cursor-pointer items-center gap-1 px-2 py-0.5 text-left text-sm hover:bg-accent/50",
             "focus:bg-accent/50 focus:outline-none",
             isIgnored && "opacity-50"
           )}
@@ -404,7 +410,7 @@ export const ExplorerTab: React.FC<ExplorerTabProps> = (props) => {
               <FileIcon fileName={node.name} style={{ fontSize: 18 }} className="h-4 w-4" />
             </>
           )}
-          <span className="truncate" style={textColor ? { color: textColor } : undefined}>
+          <span className={cn("truncate", statusTextClass, statusTextHighlightOverrideClass)}>
             {node.name}
           </span>
         </button>

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -390,6 +390,9 @@
 
   /* File explorer */
   --color-folder-icon: #c9a227; /* darker gold for light theme */
+  /* Darken git status colors so they remain readable on light backgrounds */
+  --color-git-modified: color-mix(in srgb, var(--color-git-dirty), black 40%);
+  --color-git-untracked: color-mix(in srgb, var(--color-success), black 30%);
 
   --color-background: hsl(210 33% 98%);
   --color-background-secondary: hsl(210 36% 95%);
@@ -626,6 +629,9 @@
 
   /* File explorer */
   --color-folder-icon: #ad8301; /* Flexoki yellow-600 */
+  /* Darken git status colors so they remain readable on light backgrounds */
+  --color-git-modified: color-mix(in srgb, var(--color-warning), black 25%);
+  --color-git-untracked: color-mix(in srgb, var(--color-success), black 10%);
 
   /* Runtime badges (ensure readable on light background) */
   --color-runtime-ssh-text: color-mix(in srgb, var(--color-runtime-ssh), black 20%);


### PR DESCRIPTION
Summary
- Improves contrast for git status colors in the file explorer (notably Flexoki light), where untracked/modified file names were hard to read on light backgrounds.

Background
- `--color-git-untracked` / `--color-git-modified` were tuned for dark mode and weren’t overridden in light themes, so Flexoki light inherited very low-contrast greens/yellows.

Implementation
- Added light-theme overrides for `--color-git-untracked` and `--color-git-modified` in `globals.css`.
- Updated `ExplorerTab` to use Tailwind classes for git status text colors and fall back to normal foreground color when the row is hover/focus highlighted (keeps selected rows readable).

Validation
- `make static-check`

Risks
- Low. Scoped to file explorer row text coloring and theme variables.

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$unknown`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=unknown -->
