### PR TITLE
🤖 fix: refresh PR status after cache hydration

### DIFF
--- a/src/browser/stores/PRStatusStore.ts
+++ b/src/browser/stores/PRStatusStore.ts
@@ -344,7 +344,9 @@ export class PRStatusStore {
 
   private shouldFetchWorkspace(entry: WorkspacePRCacheEntry | undefined, now: number): boolean {
     if (!entry) return true;
-    if (entry.loading) return false;
+    // Allow refresh if entry was hydrated from localStorage (fetchedAt === 0)
+    // but is marked loading - this means we have stale cached data and need fresh data.
+    if (entry.loading && entry.fetchedAt !== 0) return false;
 
     if (entry.error) {
       return now - entry.fetchedAt > ERROR_RETRY_DELAY_MS;


### PR DESCRIPTION
## Summary
- allow PR status refresh when cached entries were hydrated from localStorage
- prevent cached loading states from sticking indefinitely

## Background
Persisted PR status entries are rehydrated with `loading: true` and `fetchedAt: 0` to show cached state quickly. The refresh gate treated any `loading` entry as in-flight, so it never re-fetched and left the badge pulsing red forever.

## Implementation
- treat `loading` entries with `fetchedAt === 0` as safe to refresh while still blocking truly in-flight requests

## Validation
- make static-check

## Risks
- Low: only changes the refresh gate for cached entries; could add an extra fetch on startup but avoids stale UI.

---

_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `xhigh` • Cost: `$1.33`_

<!-- mux-attribution: model=openai:gpt-5.2-codex thinking=xhigh costs=1.33 -->
