### PR TITLE
🤖 fix: prevent terminal flashing during agent streaming

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -90,6 +90,7 @@ description: Agent instructions for AI assistants working on the Mux codebase
 ## Component State & Storage
 
 - Prefer **self-contained components** over utility functions + hook proliferation. A component that takes `workspaceId` and computes everything internally is better than one that requires 10 props drilled from parent hooks.
+- **Colocate subscriptions with consumers** — Don't pass frequently-updating values (streaming stats, live costs, timers) as props through intermediate components. Instead, have the leaf component that displays the value subscribe directly. This prevents re-renders from cascading through expensive sibling subtrees (e.g., terminal). See `CostsTabLabel`/`StatsTabLabel` for examples.
 - Parent components own localStorage interactions; children announce intent only.
 - **Never call `localStorage` directly** — always use `usePersistedState`/`readPersistedState`/`updatePersistedState` helpers. This includes inside `useCallback`, event handlers, and non-React functions. The helpers handle JSON parsing, error recovery, and cross-component sync.
 - When a component needs to read persisted state it doesn't own (to avoid layout flash), use `readPersistedState` in `useState` initializer: `useState(() => readPersistedState(key, default))`.


### PR DESCRIPTION
## Summary

Fixes terminal flashing/re-rendering while agent is working by colocating stats subscriptions with the tab label components that actually consume them.

Closes https://github.com/coder/mux/issues/2121

## Background

`sessionDuration` and `sessionCost` were being computed in `RightSidebar` and passed as props through `RightSidebarTabsetNode` → `TerminalTab` → `TerminalView`. Since these values update frequently during agent streaming, the entire subtree would re-render, causing visible flashing in the terminal (especially noticeable in Safari).

## Implementation

- `CostsTabLabel` and `StatsTabLabel` now subscribe to their own data via `useWorkspaceUsage()` and `useWorkspaceStatsSnapshot()` respectively
- Removed `sessionCost` and `sessionDuration` props from `RightSidebarTabsetNodeProps`
- Added guidance to AGENTS.md to prevent this pattern from recurring

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$6.21`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=6.21 -->
