### PR TITLE
🤖 fix: support AWS profile selection for Bedrock

### DIFF
--- a/src/browser/components/Settings/sections/ProvidersSection.tsx
+++ b/src/browser/components/Settings/sections/ProvidersSection.tsx
@@ -81,6 +81,13 @@ function getProviderFields(provider: ProviderName): FieldConfig[] {
     return [
       { key: "region", label: "Region", placeholder: "us-east-1", type: "text" },
       {
+        key: "profile",
+        label: "AWS Profile",
+        placeholder: "my-sso-profile",
+        type: "text",
+        optional: true,
+      },
+      {
         key: "bearerToken",
         label: "Bearer Token",
         placeholder: "AWS_BEARER_TOKEN_BEDROCK",
@@ -586,9 +593,9 @@ export function ProvidersSection() {
     const providerConfig = config?.[provider];
     if (!providerConfig) return undefined;
 
-    // For bedrock, check aws nested object for region
-    if (provider === "bedrock" && field === "region") {
-      return providerConfig.aws?.region;
+    // For bedrock, check aws nested object for region/profile
+    if (provider === "bedrock" && (field === "region" || field === "profile")) {
+      return field === "region" ? providerConfig.aws?.region : providerConfig.aws?.profile;
     }
 
     // For standard fields like baseUrl

--- a/src/common/orpc/schemas/api.test.ts
+++ b/src/common/orpc/schemas/api.test.ts
@@ -20,6 +20,7 @@ describe("ProviderConfigInfoSchema conformance", () => {
   it("preserves all AWSCredentialStatus fields", () => {
     const full: AWSCredentialStatus = {
       region: "us-east-1",
+      profile: "my-sso-profile",
       bearerTokenSet: true,
       accessKeyIdSet: true,
       secretAccessKeySet: false,
@@ -54,6 +55,7 @@ describe("ProviderConfigInfoSchema conformance", () => {
       models: [],
       aws: {
         region: "eu-west-1",
+        profile: "my-sso-profile",
         bearerTokenSet: false,
         accessKeyIdSet: true,
         secretAccessKeySet: true,
@@ -90,6 +92,7 @@ describe("ProviderConfigInfoSchema conformance", () => {
       serviceTier: "flex",
       aws: {
         region: "ap-northeast-1",
+        profile: "my-sso-profile",
         bearerTokenSet: true,
         accessKeyIdSet: true,
         secretAccessKeySet: true,
@@ -128,6 +131,7 @@ describe("ProviderConfigInfoSchema conformance", () => {
         isConfigured: false,
         aws: {
           region: "us-west-2",
+          profile: "my-sso-profile",
           bearerTokenSet: false,
           accessKeyIdSet: true,
           secretAccessKeySet: true,

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -103,6 +103,8 @@ export const tokenizer = {
 // Providers
 export const AWSCredentialStatusSchema = z.object({
   region: z.string().optional(),
+  /** Optional AWS shared config profile name (equivalent to AWS_PROFILE). */
+  profile: z.string().optional(),
   bearerTokenSet: z.boolean(),
   accessKeyIdSet: z.boolean(),
   secretAccessKeySet: z.boolean(),

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1060,6 +1060,13 @@ export class AIService extends EventEmitter {
         }
         const { region } = creds;
 
+        // Optional AWS shared config profile name (equivalent to AWS_PROFILE).
+        // Useful for SSO profiles when Mux isn't launched with AWS_PROFILE set.
+        const profile =
+          typeof providerConfig.profile === "string" && providerConfig.profile.trim()
+            ? providerConfig.profile.trim()
+            : undefined;
+
         const baseFetch = getProviderFetch(providerConfig);
         const { createAmazonBedrock } = await PROVIDER_REGISTRY.bedrock();
 
@@ -1110,7 +1117,7 @@ export class AIService extends EventEmitter {
         // - And more...
         const provider = createAmazonBedrock({
           region,
-          credentialProvider: fromNodeProviderChain(),
+          credentialProvider: fromNodeProviderChain(profile ? { profile } : {}),
           fetch: baseFetch,
         });
         return Ok(provider(modelId));

--- a/src/node/services/providerService.ts
+++ b/src/node/services/providerService.ts
@@ -69,6 +69,8 @@ export class ProviderService {
         models?: string[];
         serviceTier?: unknown;
         region?: string;
+        /** Optional AWS shared config profile name (equivalent to AWS_PROFILE). */
+        profile?: string;
         bearerToken?: string;
         accessKeyId?: string;
         secretAccessKey?: string;
@@ -111,6 +113,7 @@ export class ProviderService {
       if (provider === "bedrock") {
         providerInfo.aws = {
           region: config.region,
+          profile: config.profile,
           bearerTokenSet: !!config.bearerToken,
           accessKeyIdSet: !!config.accessKeyId,
           secretAccessKeySet: !!config.secretAccessKey,


### PR DESCRIPTION
Summary
- Adds an optional Bedrock provider setting `profile` (AWS shared config profile name) so users can select an AWS SSO profile without needing to launch Mux with `AWS_PROFILE`.

Background
- Bedrock SigV4 auth relies on the AWS credential provider chain. When Mux is launched from a GUI, it often doesn’t inherit `AWS_PROFILE`, so SSO credentials in a non-default profile aren’t found.

Implementation
- Settings UI: adds an "AWS Profile" field under Bedrock provider settings.
- Backend: plumbs the configured profile through provider config info and uses it when constructing the AWS credential chain (`fromNodeProviderChain({ profile })`).

Validation
- `make static-check`

Risks
- Low: the new field is optional; existing Bedrock setups (bearer token / static keys / default profile) behave the same.

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$0.51`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=0.51 -->
