### PR TITLE
🤖 fix: sticky project header in sidebar

### DIFF
--- a/src/browser/components/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar.tsx
@@ -104,8 +104,9 @@ const MuxChatHelpButton: React.FC<{
   );
 };
 
+// Keep the project header visible while scrolling through long workspace lists.
 const PROJECT_ITEM_BASE_CLASS =
-  "py-2 pl-2 pr-3 flex items-center border-l-transparent bg-sidebar transition-colors duration-150";
+  "sticky top-0 z-10 py-2 pl-2 pr-3 flex items-center border-l-transparent bg-sidebar transition-colors duration-150";
 
 function getProjectItemClassName(opts: {
   isDragging: boolean;


### PR DESCRIPTION
Summary
- Make each project header in the left sidebar sticky so the active project name stays visible while scrolling long workspace lists.

Implementation
- Apply `position: sticky` (`sticky top-0 z-10`) to the project header row.

Validation
- `make static-check`

Risks
- Low: CSS-only change scoped to project header rendering.

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$unknown`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=unknown -->
