### PR TITLE
🤖 fix: clarify subagent committed-only visibility

### DIFF
--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -741,6 +741,8 @@ export const TOOL_DEFINITIONS = {
   task: {
     description:
       "Spawn a sub-agent task (child workspace). " +
+      "\n\nIMPORTANT: Subagents only see committed state. Uncommitted changes are not available. " +
+      "Commit any changes you want the sub-agent to consider before spawning a task. " +
       "\n\nProvide agentId (preferred) or subagent_type, prompt, title, run_in_background. " +
       "\n\nWhen delegating, include a compact task brief (Task / Background / Scope / Starting points / Acceptance / Deliverables / Constraints). " +
       "Avoid telling the sub-agent to read your plan file; child workspaces do not automatically have access to it. " +


### PR DESCRIPTION
## Summary

Clarifies the `task` tool description so it’s explicit that subagents only see **committed** repo state (uncommitted changes aren’t available).

## Background

Users can run `/deep-review` (or spawn subagents directly) while their workspace is dirty; subagents are created from committed state, so they often see an empty diff and can’t review the intended changes.

## Implementation

- Added an **IMPORTANT** note to the `task` tool description advising users to commit any changes they want a subagent to consider.

## Validation

- `make static-check`

## Risks

Low (documentation-only change).

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$7.03`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=7.03 -->
