### PR TITLE
🤖 fix: avoid PTC false positives for require/import in strings

### DIFF
--- a/src/node/services/ptc/staticAnalysis.test.ts
+++ b/src/node/services/ptc/staticAnalysis.test.ts
@@ -299,15 +299,16 @@ const z = 3;`);
       expect(result.valid).toBe(true);
     });
 
-    test("require in string literal - still false positive for patterns", async () => {
+    test("require in string literal does NOT error (AST-based detection)", async () => {
       const result = await analyzeCode(`
         const msg = "Use require() to import modules";
         console.log(msg);
       `);
-      // Known limitation: pattern-based detection for require() can't distinguish strings
-      // This is acceptable since agents rarely put "require()" in string literals
-      expect(result.valid).toBe(false); // False positive for pattern detection
-      expect(result.errors.some((e) => e.message.includes("require()"))).toBe(true);
+
+      // We intentionally avoid pattern/substring scanning for require()/import() because those
+      // keywords can appear in user strings.
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
     });
 
     test("process in string literal does NOT error (AST-based detection)", async () => {


### PR DESCRIPTION
## Summary
Stop Programmatic Tool Calling (PTC) static analysis from rejecting substrings like `require(` / `import(` when they appear inside **string literals**.

## Background
PTC previously used regex substring scanning for forbidden constructs. That produced false positives for perfectly valid code such as logging/help text containing "require()".

## Implementation
- Removed regex-based forbidden-pattern scanning for `require(` / `import(`.
- Added AST-based detection that flags only **real** call expressions (`require()` and dynamic `import()`).
- Updated/added tests to ensure:
  - real `require()` calls are still rejected
  - keywords inside strings are allowed

## Validation
- `bun test src/node/services/ptc/*.test.ts`

## Risks
Low. This narrows detection from substring matches to AST call expressions, reducing false positives while preserving the same security posture (real `require()` / `import()` still fail early with friendly errors).

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `medium` • Cost: `$2.13`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=medium costs=2.13 -->
