### PR TITLE
🤖 fix: show XHIGH instead of MAX for thinking

### DIFF
--- a/src/browser/components/ThinkingSlider.tsx
+++ b/src/browser/components/ThinkingSlider.tsx
@@ -84,7 +84,7 @@ export const ThinkingSliderComponent: React.FC<ThinkingControlProps> = ({ modelS
         <TooltipTrigger asChild>
           <div className="flex items-center">
             <span
-              className="w-[4ch] text-center text-[11px] select-none"
+              className="w-[5ch] text-center text-[11px] select-none"
               style={getTextStyle(value)}
               aria-label={`Thinking level fixed to ${fixedLevel}`}
             >
@@ -124,7 +124,7 @@ export const ThinkingSliderComponent: React.FC<ThinkingControlProps> = ({ modelS
               setThinkingLevel(allowed[nextIndex]);
             }}
             data-thinking-label
-            className="hover:bg-hover w-[4ch] min-w-[4ch] shrink-0 rounded-sm bg-transparent p-0 text-center text-[11px] transition-all duration-200 select-none"
+            className="hover:bg-hover w-[5ch] min-w-[5ch] shrink-0 rounded-sm bg-transparent p-0 text-center text-[11px] transition-all duration-200 select-none"
             style={textStyle}
             aria-live="polite"
             aria-label={`Thinking level: ${effectiveThinkingLevel}. Click to cycle.`}

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -77,7 +77,7 @@ import { execSync } from "child_process";
 import { getParseOptions } from "./argv";
 import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 
-// Display labels for CLI help (OFF, LOW, MED, HIGH, MAX)
+// Display labels for CLI help (OFF, LOW, MED, HIGH, XHIGH)
 const THINKING_LABELS_LIST = Object.values(THINKING_DISPLAY_LABELS).join(", ");
 
 type CLIMode = "plan" | "exec";
@@ -117,7 +117,7 @@ function parseThinkingLevel(value: string | undefined): ThinkingLevel | undefine
     return level;
   }
   throw new Error(
-    `Invalid thinking level "${value}". Expected: ${THINKING_LABELS_LIST} (or legacy: medium, xhigh)`
+    `Invalid thinking level "${value}". Expected: ${THINKING_LABELS_LIST} (or legacy: medium, max)`
   );
 }
 

--- a/src/common/types/thinking.ts
+++ b/src/common/types/thinking.ts
@@ -17,12 +17,12 @@ export const THINKING_DISPLAY_LABELS: Record<ThinkingLevel, string> = {
   low: "LOW",
   medium: "MED",
   high: "HIGH",
-  xhigh: "MAX",
+  xhigh: "XHIGH",
 };
 
 /**
  * Reverse mapping from display labels to internal values
- * Supports both display labels (OFF, LOW, MED, HIGH, MAX) and legacy values
+ * Supports both display labels (OFF, LOW, MED, HIGH, XHIGH) and legacy values (medium, max)
  */
 const DISPLAY_LABEL_TO_LEVEL: Record<string, ThinkingLevel> = {
   // Display labels (case-insensitive matching handled in parseThinkingDisplayLabel)
@@ -30,10 +30,10 @@ const DISPLAY_LABEL_TO_LEVEL: Record<string, ThinkingLevel> = {
   low: "low",
   med: "medium",
   high: "high",
-  max: "xhigh",
+  xhigh: "xhigh",
   // Legacy values for backward compatibility
   medium: "medium",
-  xhigh: "xhigh",
+  max: "xhigh",
 };
 
 /**

--- a/tests/e2e/utils/ui.ts
+++ b/tests/e2e/utils/ui.ts
@@ -175,7 +175,7 @@ export function createWorkspaceUI(page: Page, context: DemoProjectConfig): Works
 
     /**
      * Set the thinking level using paddle controls.
-     * Values map to: 0=OFF, 1=LOW, 2=MED, 3=HIGH, 4=MAX
+     * Values map to: 0=OFF, 1=LOW, 2=MED, 3=HIGH, 4=XHIGH
      */
     async setThinkingLevel(targetLevel: number): Promise<void> {
       if (!Number.isInteger(targetLevel)) {
@@ -185,7 +185,7 @@ export function createWorkspaceUI(page: Page, context: DemoProjectConfig): Works
         throw new Error(`Thinking level ${targetLevel} is outside expected range 0-4`);
       }
 
-      const levelLabels = ["OFF", "LOW", "MED", "HIGH", "MAX"];
+      const levelLabels = ["OFF", "LOW", "MED", "HIGH", "XHIGH"];
       const targetLabel = levelLabels[targetLevel];
 
       const label = thinkingLevelLabel(page);
@@ -198,7 +198,10 @@ export function createWorkspaceUI(page: Page, context: DemoProjectConfig): Works
       // Get current level by reading the label text
       const getCurrentLevel = async (): Promise<number> => {
         const text = await label.textContent();
-        const labelIndex = levelLabels.findIndex((l) => text?.includes(l));
+        const normalized = text?.trim().toUpperCase() ?? "";
+
+        // Note: XHIGH contains HIGH as a substring, so we must avoid includes()-based matching here.
+        const labelIndex = levelLabels.findIndex((l) => normalized === l);
         return labelIndex === -1 ? 0 : labelIndex;
       };
 

--- a/tests/ui/thinkingPersistence.integration.test.ts
+++ b/tests/ui/thinkingPersistence.integration.test.ts
@@ -95,10 +95,10 @@ async function selectModel(
   );
 }
 
-async function setThinkingToMax(container: HTMLElement): Promise<void> {
-  // Wait for the thinking slider to render and for it to show MAX.
+async function setThinkingToXHigh(container: HTMLElement): Promise<void> {
+  // Wait for the thinking slider to render and for it to show XHIGH.
   // We click the right paddle (second button) repeatedly to increase levels.
-  // For CODEX model the levels are: OFF → LOW → MED → HIGH → MAX
+  // For CODEX model the levels are: OFF → LOW → MED → HIGH → XHIGH
   await waitFor(
     async () => {
       const group = container.querySelector('[data-component="ThinkingSliderGroup"]');
@@ -110,7 +110,7 @@ async function setThinkingToMax(container: HTMLElement): Promise<void> {
         .querySelector("[data-thinking-label]")
         ?.textContent?.trim()
         ?.toUpperCase();
-      if (label === "MAX") {
+      if (label === "XHIGH") {
         return; // Done!
       }
 
@@ -143,19 +143,19 @@ async function expectThinkingLabel(container: HTMLElement, expected: string): Pr
 }
 
 describeIntegration("Thinking level persistence", () => {
-  test("keeps MAX preference when switching away and back", async () => {
+  test("keeps XHIGH preference when switching away and back", async () => {
     const harness = await createAppHarness({ branchPrefix: "thinking" });
 
     try {
       await selectModel(harness.view.container, harness.workspaceId, CODEX_MODEL);
-      await setThinkingToMax(harness.view.container);
-      await expectThinkingLabel(harness.view.container, "MAX");
+      await setThinkingToXHigh(harness.view.container);
+      await expectThinkingLabel(harness.view.container, "XHIGH");
 
       await selectModel(harness.view.container, harness.workspaceId, OPUS_MODEL);
       await expectThinkingLabel(harness.view.container, "HIGH");
 
       await selectModel(harness.view.container, harness.workspaceId, CODEX_MODEL);
-      await expectThinkingLabel(harness.view.container, "MAX");
+      await expectThinkingLabel(harness.view.container, "XHIGH");
     } finally {
       await harness.dispose();
     }


### PR DESCRIPTION
## Summary
- Restore the thinking level display label for `xhigh` from **MAX** back to **XHIGH**.
- Widen the thinking label slot so `XHIGH` fits cleanly in the header controls.

## Background
Mux uses `xhigh` as the internal thinking level (and OpenAI `reasoningEffort` value). Displaying it as **MAX** obscures the underlying setting and can be confusing when users expect to see the literal level name.

The **MAX** label was introduced in commit `2a5f444db6f97a7f27ab3cc21d3ba28367cb76f0` (ammar-agent) as part of UI tightening work.

## Implementation
- Update `THINKING_DISPLAY_LABELS` so `xhigh` renders as `XHIGH`.
- Keep `max` as a legacy/CLI alias when parsing user input.
- Adjust `ThinkingSlider` layout from `4ch` → `5ch` to prevent truncation.
- Update UI/E2E tests to expect `XHIGH` (and avoid substring matching pitfalls since `XHIGH` contains `HIGH`).

## Validation
- `make static-check -j1`
- `make test`
- `TEST_INTEGRATION=1 bun x jest tests/ui/thinkingPersistence.integration.test.ts`

## Risks
Low: label-only UI change plus a small layout width tweak in the thinking control.

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$1.46`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=1.46 -->
