### PR TITLE
🤖 fix: show "starting..." before stream-start in sidebar

### DIFF
--- a/src/browser/components/WorkspaceStatusIndicator.tsx
+++ b/src/browser/components/WorkspaceStatusIndicator.tsx
@@ -53,12 +53,18 @@ export const WorkspaceStatusIndicator = memo<{
     );
   }
 
-  const isWorking = (canInterrupt || isStarting || isCreating) && !awaitingUserQuestion;
-  if (!isWorking) {
+  const phase: "starting" | "streaming" | null = canInterrupt
+    ? "streaming"
+    : isStarting || isCreating
+      ? "starting"
+      : null;
+
+  if (!phase) {
     return null;
   }
 
   const modelToShow = canInterrupt ? (currentModel ?? fallbackModel) : fallbackModel;
+  const suffix = phase === "starting" ? "- starting..." : "- streaming...";
 
   return (
     <div className="text-muted flex min-w-0 items-center gap-1.5 text-xs">
@@ -67,10 +73,12 @@ export const WorkspaceStatusIndicator = memo<{
           <span className="min-w-0 truncate">
             <ModelDisplay modelString={modelToShow} showTooltip={false} />
           </span>
-          <span className="shrink-0 opacity-70">- streaming...</span>
+          <span className="shrink-0 opacity-70">{suffix}</span>
         </>
       ) : (
-        <span className="min-w-0 truncate">Assistant - streaming...</span>
+        <span className="min-w-0 truncate">
+          {phase === "starting" ? "Assistant - starting..." : "Assistant - streaming..."}
+        </span>
       )}
     </div>
   );

--- a/tests/ui/workspaceIntermediateStatus.integration.test.ts
+++ b/tests/ui/workspaceIntermediateStatus.integration.test.ts
@@ -1,8 +1,8 @@
 /**
  * UI integration test for the “working but no status_set yet” intermediate status.
  *
- * Expectation: While a stream is starting/streaming and no status_set tool has been received,
- * the workspace sidebar row should show provider icon + model name + streaming label.
+ * Expectation: While a stream is starting and no status_set tool has been received,
+ * the workspace sidebar row should show provider icon + model name + starting label.
  */
 
 import "./dom";
@@ -27,7 +27,7 @@ describe("Workspace intermediate status (mock AI router)", () => {
     await preloadTestModules();
   });
 
-  test("shows model + streaming while stream is starting and before status_set", async () => {
+  test("shows model + starting while stream is starting and before status_set", async () => {
     const app = await createAppHarness({ branchPrefix: "status-intermediate" });
 
     const collector = createStreamCollector(app.env.orpc, app.workspaceId);
@@ -60,7 +60,7 @@ describe("Workspace intermediate status (mock AI router)", () => {
           }
 
           const text = wsEl.textContent ?? "";
-          expect(text.toLowerCase()).toContain("streaming");
+          expect(text.toLowerCase()).toContain("starting");
         },
         { timeout: 10_000 }
       );


### PR DESCRIPTION
## Summary
Sidebar workspace rows no longer claim "streaming..." while the app is still waiting for `stream-start` (e.g. blocked in an init hook). During that window we show "starting..." instead.

## Background
The chat barrier correctly differentiates "starting" vs "streaming", but the sidebar status row always rendered "streaming..." for both phases. This was misleading when no stream had actually begun.

## Implementation
- Updated `WorkspaceStatusIndicator` to compute a phase:
  - `starting` when `isStarting || isCreating` (and not interruptible yet)
  - `streaming` only once `canInterrupt` is true
- Updated the UI integration test to assert "starting" during the gated pre-`stream-start` window.

## Validation
- `make static-check`

## Risks
Low. Copy-only change to sidebar status text plus a test update.

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix misleading “streaming…” status during init hook / pre-stream start

## Context / Why
When a workspace is blocked in the init hook (or otherwise waiting for `stream-start`), the chat barrier correctly shows **“starting…”**, but the sidebar workspace row shows **“<model> - streaming…”**. That implies tokens are streaming even though no stream has started, which is confusing.

**Goal:** Make sidebar status accurately reflect the actual phase:
- **starting**: message sent / waiting for `stream-start` (includes “init hook running” window)
- **streaming**: active stream exists (`canInterrupt` / activeStreams > 0)

**Non-goals:** change backend init-hook behavior or redesign all “tool running” UX (can be a follow-up).

## Evidence (current behavior in code)
- `src/browser/components/WorkspaceStatusIndicator.tsx`
  - Computes `isWorking = (canInterrupt || isStarting || isCreating)`.
  - When “working”, always renders the suffix `- streaming...` (even when `isStarting` is true).
- `src/browser/components/Messages/ChatBarrier/StreamingBarrier.tsx`
  - Computes `isStarting = pendingStreamStartTime !== null && !canInterrupt`.
  - Shows `${modelName} starting...` for the starting phase.
- `src/browser/utils/messages/StreamingMessageAggregator.ts`
  - Tracks init hook events (`init-start/init-output/init-end`). While init is running there are **no active streams**, so `canInterrupt` remains false.
- `tests/ui/workspaceIntermediateStatus.integration.test.ts`
  - Currently asserts the sidebar contains “streaming” **while `WorkspaceSidebarState.isStarting === true` and before `stream-start` arrives**.

## Recommended approach (A): Distinguish “starting” vs “streaming” in the sidebar
**Net LoC (product code only): ~10–20**

### 1) Update the sidebar indicator label
**File:** `src/browser/components/WorkspaceStatusIndicator.tsx`

**Change:** render `- starting...` when the workspace is “working” due to `isStarting` (or `isCreating`), and reserve `- streaming...` for `canInterrupt`.

Implementation shape:
```tsx
const phase: "starting" | "streaming" | null =
  canInterrupt ? "streaming" : (isStarting || isCreating) ? "starting" : null;

if (!phase) return null;

const modelToShow = canInterrupt ? (currentModel ?? fallbackModel) : fallbackModel;
const suffix = phase === "starting" ? "- starting..." : "- streaming...";

return (
  <div className="text-muted flex min-w-0 items-center gap-1.5 text-xs">
    {modelToShow ? (
      <>
        <span className="min-w-0 truncate">
          <ModelDisplay modelString={modelToShow} showTooltip={false} />
        </span>
        <span className="shrink-0 opacity-70">{suffix}</span>
      </>
    ) : (
      <span className="min-w-0 truncate">{phase === "starting" ? "Assistant - starting..." : "Assistant - streaming..."}</span>
    )}
  </div>
);
```

Notes:
- Preserve existing precedence:
  - `awaitingUserQuestion` block stays first.
  - `agentStatus` stays second.
- Treat `isCreating` as “starting” (it’s also “not streaming yet”).

### 2) Update the UI integration test
**File:** `tests/ui/workspaceIntermediateStatus.integration.test.ts`

Update the test to match the new semantics:
- Rename/comment to “starting”.
- Replace:
  - `expect(text.toLowerCase()).toContain("streaming")`
  - with `expect(text.toLowerCase()).toContain("starting")`

Keep the assertion that `stream-start` has not fired yet (still validates the “starting window”).

### 3) Validation
Run (in Exec mode):
- `make fmt`
- `make test` (or at least the single test file above)
- `make static-check`

## Optional follow-up (B): Show “Running init hook…” instead of generic “starting”
**Net LoC (product code only): ~60–120**

<details>
<summary>Details</summary>

If you want the sidebar (and possibly the barrier) to explicitly say **“Running init hook…”** while the hook runs:

- Expose a lightweight `isInitRunning()` (or `getInitStatus()`) on `StreamingMessageAggregator`.
- Plumb that boolean into `WorkspaceState` / `WorkspaceSidebarState` via `WorkspaceStore`.
- Give it precedence over `isStarting` when choosing the label.

A similar pattern could later surface the currently executing tool name (bash/file_read/etc.) to avoid “streaming…” during long tool phases.

</details>

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: $2.26_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=2.26 -->
