### PR TITLE
🤖 fix: show task_await titles when missing

### DIFF
--- a/tests/ui/taskReportRelocation.integration.test.ts
+++ b/tests/ui/taskReportRelocation.integration.test.ts
@@ -75,7 +75,6 @@ async function seedHistory(historyService: HistoryService, workspaceId: string):
             {
               status: "completed" as const,
               taskId,
-              title: "Background analysis",
               reportMarkdown: "Hello from **report**\n\n- item 1\n- item 2",
             },
           ],
@@ -168,6 +167,7 @@ describe("Task report relocation UI", () => {
       });
 
       expect(awaitMessageBlock?.textContent).toContain("completed");
+      expect(awaitMessageBlock?.textContent).toContain("Background analysis");
       expect(awaitMessageBlock?.textContent).not.toContain("Hello from report");
       expect(awaitMessageBlock?.textContent).not.toContain("item 1");
       expect(awaitMessageBlock?.textContent).not.toContain("item 2");


### PR DESCRIPTION
Summary
- Fix `task_await` result rows so they always show a meaningful title by falling back to the original `task` spawn title (and then workspace metadata) when the completed result omits `title`.

Background
- `task_await` completed results may legitimately omit `title` (e.g. older `agent_report` payloads). The UI currently hides the title element entirely, leaving blank-looking rows.

Implementation
- Extend render-time task linking to capture spawn titles from `task` tool calls.
- Use a fallback chain for `task_await` row titles: `result.title` → spawn title → workspace title/name.
- Update UI integration coverage for the missing-title case.

Validation
- `make static-check`
- `TEST_INTEGRATION=1 bun x jest tests/ui/taskReportRelocation.integration.test.ts`

Risks
- Low. UI-only change with best-effort fallbacks; no schema or backend behavior changes.

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix: `task_await` rows can show blank titles

## Context / Why
In the `task_await` tool card, each result row shows:

- task id
- status
- *(optional)* title

Today, the title for **completed** `task_await` results is sourced from `result.title`, which is optional. If a sub-agent finishes with an `agent_report` that omits `title`, the backend returns `title: undefined`, and the UI’s conditional render hides the label entirely—leaving an awkward blank row (like in your screenshot).

**Goal:** Always render a reasonable name for each awaited task by using a fallback chain:

1. `task_await` completed result title (`result.title`) when present
2. spawn title from the original `task` tool call (`args.title`) when available
3. workspace metadata title/name (best-effort) when available

Non-goals:
- Changing the tool schema to require `title`
- Forcing models/subagents to always set `agent_report.title`

## Evidence (repo)
- UI renders task titles conditionally:
  - `src/browser/components/tools/TaskToolCall.tsx`
    - `TaskRow`: `{props.title && <span ...>{props.title}</span>}`
    - `TaskAwaitResult`: `const title = isCompleted ? result.title : undefined;` then `{title && ...}`
- Tool result schema makes title optional:
  - `src/common/utils/tools/toolDefinitions.ts` → `TaskAwaitToolCompletedResultSchema` has `title: z.string().optional()`
- Backend passes through the agent report’s optional title:
  - `src/node/services/tools/task_await.ts` → `title: report.title`
- Render-time message utility already scans history for task spawn cards:
  - `src/browser/utils/messages/taskReportLinking.ts` (`computeTaskReportLinking`)
- There’s an existing UI integration test that seeds both a `task` spawn card and a `task_await` completion:
  - `tests/ui/taskReportRelocation.integration.test.ts`

---

## Recommended approach (UI-only fallback)
This keeps the fix local to the renderer and makes it testable without requiring a backend migration.

### 1) Extend `TaskReportLinking` to capture spawn titles
**File:** `src/browser/utils/messages/taskReportLinking.ts`

Add a new map to the return object:
- `spawnTitleByTaskId: Map<string, string>`

Populate it during the existing first pass over `task` tool calls (we already extract `taskId` from `msg.result`; also extract `title` from `msg.args`).

Suggested shape (illustrative):

```ts
export interface TaskReportLinking {
  reportByTaskId: Map<string, LinkedTaskReport>;
  suppressReportInAwaitTaskIds: Set<string>;
  spawnTitleByTaskId: Map<string, string>;
}

export function computeTaskReportLinking(messages: DisplayedMessage[]): TaskReportLinking {
  const spawnTitleByTaskId = new Map<string, string>();
  const taskToolCallTaskIds = new Set<string>();

  for (const msg of messages) {
    if (msg.type !== "tool" || msg.toolName !== "task") continue;

    const taskId = getTaskIdFromToolResult(msg.result);
    if (!taskId) continue;

    taskToolCallTaskIds.add(taskId);

    const rawTitle = (msg.args as { title?: unknown }).title;
    const title = typeof rawTitle === "string" ? rawTitle.trim() : "";
    if (title.length > 0) {
      spawnTitleByTaskId.set(taskId, title);
    }
  }

  // ... existing second pass for reportByTaskId

  return { reportByTaskId, suppressReportInAwaitTaskIds, spawnTitleByTaskId };
}
```

Notes:
- Keep the parsing defensive (history can contain older/invalid shapes).
- If multiple `task` tool calls somehow reuse a taskId, “last wins” is fine (same behavior as `reportByTaskId`).

### 2) Use fallbacks when rendering `task_await` rows
**File:** `src/browser/components/tools/TaskToolCall.tsx`

Update `TaskAwaitToolCall` → results mapping to compute a fallback title per row and pass it down.

**Fallback order:**
1. `result.title` (trimmed, non-empty)
2. `taskReportLinking?.spawnTitleByTaskId.get(taskId)`
3. `workspaceContext?.workspaceMetadata.get(taskId)` → `metadata.title ?? metadata.name`

Suggested change sketch:

```tsx
// In TaskAwaitToolCall
const workspaceMetadata = workspaceContext?.workspaceMetadata;

function getWorkspaceTitle(taskId: string): string | undefined {
  const metadata = workspaceMetadata?.get(taskId);
  const t = metadata?.title?.trim();
  if (t) return t;
  const n = metadata?.name?.trim();
  return n && n.length > 0 ? n : undefined;
}

...
{results.map((r, idx) => {
  const taskId = typeof r.taskId === "string" ? r.taskId : null;
  const spawnTitle = taskId ? taskReportLinking?.spawnTitleByTaskId.get(taskId) : undefined;
  const fallbackTitle = (spawnTitle?.trim().length ? spawnTitle : undefined) ??
    (taskId ? getWorkspaceTitle(taskId) : undefined);

  return (
    <TaskAwaitResult
      key={r.taskId ?? idx}
      result={r}
      fallbackTitle={fallbackTitle}
      suppressReport={...}
    />
  );
})}
```

Then update `TaskAwaitResult` to prefer `result.title` but fall back when it’s missing:

```tsx
const reportTitle =
  result.status === "completed" && typeof result.title === "string" && result.title.trim().length > 0
    ? result.title
    : undefined;

const title = reportTitle ?? props.fallbackTitle;
```

This also fixes a similar UX issue for non-completed results (e.g., `running`) returned from `task_await` due to timeout: they currently *never* display a title because the schema doesn’t include `title` on those variants.

### 3) Add/adjust UI coverage
**File:** `tests/ui/taskReportRelocation.integration.test.ts`

This test already seeds:
- a `task` tool call with `input.title: "Background analysis"`
- a `task_await` tool call with a completed result

Update the seeded `task_await` output to omit `title` and assert the UI still displays the spawn title:

- In `seedHistory(...)`, change:
  - remove `title: "Background analysis"` from the `task_await` completed result
- After expanding the `task_await` message, add:
  - `expect(awaitMessageBlock?.textContent).toContain("Background analysis")`

This validates the regression you hit without needing a real backend-created task workspace.

---

## Validation
Run locally:
- `make fmt`
- `make typecheck`
- `TEST_INTEGRATION=1 bun x jest tests/ui/taskReportRelocation.integration.test.ts`
- (optional) `make test-integration` (runs all unit + integration tests)

---

## LoC estimate (product code)
- **Recommended (UI-only fallback):** ~30–55 net LoC
  - `taskReportLinking.ts` (new map + extraction)
  - `TaskToolCall.tsx` (fallback plumb + title selection)

<details>
<summary>Alternative: backend always provide a title (not recommended for first pass)</summary>

A more “source-of-truth” fix would be to ensure the backend always returns a non-empty title for agent tasks in `task_await` by falling back to the task’s spawn title stored in workspace/task metadata.

Pros:
- Works even if the UI doesn’t have any history context.

Cons:
- Requires finding/adding an API to read a task’s persisted spawn title at await time (or persisting a fallback at `agent_report` finalization).
- Slightly higher risk, and harder to cover with existing UI tests.

If we need this later, a good place to implement is where reports/artifacts are persisted for restart-safety (see `TaskService.finalizeAgentTaskReport(...)` in `src/node/services/taskService.ts`).

</details>

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$2.02`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=2.02 -->
