### PR TITLE
🤖 feat: raise max parallel agent tasks cap to 256

### DIFF
--- a/src/common/types/tasks.ts
+++ b/src/common/types/tasks.ts
@@ -20,7 +20,7 @@ export interface TaskSettings {
 }
 
 export const TASK_SETTINGS_LIMITS = {
-  maxParallelAgentTasks: { min: 1, max: 10, default: 3 },
+  maxParallelAgentTasks: { min: 1, max: 256, default: 3 },
   maxTaskNestingDepth: { min: 1, max: 5, default: 3 },
 } as const;
 


### PR DESCRIPTION
## Summary

Raise the hard cap for **Max Parallel Agent Tasks** from **10 → 256** so server-mode deployments can run substantially more agent tasks concurrently.

## Background

The previous cap of 10 prevented higher-throughput setups from configuring parallelism to match available CPU/memory and provider limits.

## Implementation

- Updated `TASK_SETTINGS_LIMITS.maxParallelAgentTasks.max` to `256` in `src/common/types/tasks.ts`.
- This automatically updates both the Settings UI range and backend clamping/validation.

## Validation

- `make static-check`

## Risks

- Setting this too high can increase CPU/memory pressure and make port collisions more likely (since mux doesn't isolate service ports across workspaces). The value remains user-configurable and still clamped to a finite maximum.

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: $0.93_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=0.93 -->
