### PR TITLE
🤖 fix: remove chat focus hint

### DIFF
--- a/src/browser/components/VimTextArea.tsx
+++ b/src/browser/components/VimTextArea.tsx
@@ -1,9 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useAutoResizeTextarea } from "@/browser/hooks/useAutoResizeTextarea";
-import { isVscodeWebview } from "@/browser/utils/env";
 import * as vim from "@/browser/utils/vim";
 import { Tooltip, TooltipTrigger, TooltipContent, HelpIndicator } from "./ui/tooltip";
-import { formatKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
 import { stopKeyboardPropagation } from "@/browser/utils/events";
 import { cn } from "@/common/lib/utils";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
@@ -74,7 +72,6 @@ export const VimTextArea = React.forwardRef<HTMLTextAreaElement, VimTextAreaProp
       }
     }, [vimEnabled]);
 
-    const [isFocused, setIsFocused] = useState(false);
     const [desiredColumn, setDesiredColumn] = useState<number | null>(null);
     const [pendingOp, setPendingOp] = useState<null | {
       op: "d" | "y" | "c";
@@ -180,7 +177,6 @@ export const VimTextArea = React.forwardRef<HTMLTextAreaElement, VimTextAreaProp
     // Build mode indicator content
     const showVimMode = vimEnabled && vimMode === "normal";
     const pendingCommand = showVimMode ? vim.formatPendingCommand(pendingOp) : "";
-    const showFocusHint = !isFocused && !isVscodeWebview();
 
     return (
       <div style={{ width: "100%" }} data-component="VimTextAreaContainer">
@@ -221,11 +217,6 @@ export const VimTextArea = React.forwardRef<HTMLTextAreaElement, VimTextAreaProp
               </>
             )}
           </div>
-          {showFocusHint && (
-            <div className="ml-auto flex items-center gap-1 font-mono">
-              <span>{formatKeybind(KEYBINDS.FOCUS_CHAT)} to focus</span>
-            </div>
-          )}
         </div>
         <div style={{ position: "relative" }} data-component="VimTextAreaWrapper">
           <textarea
@@ -233,8 +224,6 @@ export const VimTextArea = React.forwardRef<HTMLTextAreaElement, VimTextAreaProp
             value={value}
             onChange={(e) => onChange(e.target.value)}
             onKeyDown={handleKeyDownInternal}
-            onFocus={() => setIsFocused(true)}
-            onBlur={() => setIsFocused(false)}
             spellCheck={false}
             autoCorrect="off"
             autoCapitalize="none"


### PR DESCRIPTION
## Summary
Removes the “Ctrl+I to focus” hint above the chat textarea (the focus keybind itself is unchanged).

## Implementation
- Removed the focus-hint render path from `VimTextArea`.
- Dropped the focus-tracking state/handlers that existed only to support the hint.

## Validation
- `make static-check`

---

<details>
<summary>📋 Implementation Plan</summary>

# Remove “Ctrl+I to focus” hint from chat input

## Context / Why
The chat input area currently shows a small right-aligned hint **“Ctrl+I to focus”** (generated from the `FOCUS_CHAT` keybind) when the textarea is not focused. The request is to remove that UI hint while keeping the rest of the chat input behavior intact.

## Evidence
- `src/browser/components/VimTextArea.tsx` renders the hint when blurred:
  - `const showFocusHint = !isFocused && !isVscodeWebview();`
  - JSX: `<span>{formatKeybind(KEYBINDS.FOCUS_CHAT)} to focus</span>`
  - `isFocused` is tracked via textarea `onFocus`/`onBlur` handlers.
- `src/browser/utils/ui/keybinds.ts` defines `KEYBINDS.FOCUS_CHAT: { key: "I", ctrl: true }`.
- `src/browser/hooks/useAIViewKeybinds.ts` binds `KEYBINDS.FOCUS_CHAT` globally to `chatInputAPI.current?.focus()`.

## Implementation details
### Approach A (recommended): Remove only the hint (keep keybind)
**Net LoC (product code): ~-10 to -20**

1. **Remove hint rendering + related focus-tracking state**
   - File: `src/browser/components/VimTextArea.tsx`
   - Edits:
     - Delete `isFocused` state and `setIsFocused` usage:
       - `const [isFocused, setIsFocused] = useState(false);`
       - textarea props: `onFocus={() => setIsFocused(true)}` / `onBlur={() => setIsFocused(false)}`
     - Delete the `showFocusHint` constant.
     - Delete the JSX block that renders the hint:

       ```tsx
       {showFocusHint && (
         <div className="ml-auto flex items-center gap-1 font-mono">
           <span>{formatKeybind(KEYBINDS.FOCUS_CHAT)} to focus</span>
         </div>
       )}
       ```

     - Clean up now-unused imports:
       - `isVscodeWebview` (only used by `showFocusHint`)
       - `formatKeybind, KEYBINDS` (only used by the hint)

   Notes:
   - This keeps the existing status-bar layout/height stable (avoids layout shift when vim mode toggles).
   - Removing the internal `onFocus`/`onBlur` handlers also avoids any accidental override/ordering issues with `...rest` textarea props.

2. **Leave the keybind behavior unchanged**
   - No changes needed in:
     - `src/browser/utils/ui/keybinds.ts` (`KEYBINDS.FOCUS_CHAT`)
     - `src/browser/hooks/useAIViewKeybinds.ts` (still focuses chat on Ctrl+I / ⌘I)

<details>
<summary>Alternative (not requested): disable the keybind entirely</summary>
If the intent is to remove both the hint and the shortcut itself, also remove/disable the `KEYBINDS.FOCUS_CHAT` handling in `useAIViewKeybinds.ts` and consider updating any docs that mention it.
</details>

## Validation
- Run: `make lint` + `make typecheck` (or the repo’s equivalent CI targets).
- Manual:
  1. Open a workspace → AI view.
  2. Confirm the “Ctrl+I to focus” label no longer appears above the chat textarea.
  3. Confirm **Ctrl+I** (Win/Linux) / **⌘I** (macOS) still focuses the chat input.
  4. If vim mode is enabled, confirm the “normal” indicator still appears in normal mode.

</details>

---

_Generated with `mux` • Model: openai:gpt-5.2 • Thinking: xhigh • Cost: `$0.57`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=0.57 -->
