### PR TITLE
🤖 fix: unify loading workspaces loader

### DIFF
--- a/mobile/src/screens/ProjectsScreen.tsx
+++ b/mobile/src/screens/ProjectsScreen.tsx
@@ -476,7 +476,7 @@ export function ProjectsScreen(): JSX.Element {
             <View style={{ paddingVertical: spacing.xxl, alignItems: "center" }}>
               <ActivityIndicator size="large" color={theme.colors.accent} />
               <ThemedText variant="caption" style={{ marginTop: spacing.sm }}>
-                Loading workspaces…
+                Loading workspaces...
               </ThemedText>
             </View>
           ) : hasError ? (

--- a/src/browser/components/LoadingScreen.test.tsx
+++ b/src/browser/components/LoadingScreen.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { GlobalWindow } from "happy-dom";
+import { cleanup, render } from "@testing-library/react";
+
+import { LoadingScreen } from "./LoadingScreen";
+
+describe("LoadingScreen", () => {
+  beforeEach(() => {
+    globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
+    globalThis.document = globalThis.window.document;
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.window = undefined as unknown as Window & typeof globalThis;
+    globalThis.document = undefined as unknown as Document;
+  });
+
+  test("renders the boot loader markup", () => {
+    const { container, getByRole, getByText } = render(<LoadingScreen />);
+
+    expect(getByRole("status")).toBeTruthy();
+    expect(getByText("Loading workspaces...")).toBeTruthy();
+    expect(container.querySelector(".boot-loader__spinner")).toBeTruthy();
+  });
+});

--- a/src/browser/components/LoadingScreen.tsx
+++ b/src/browser/components/LoadingScreen.tsx
@@ -1,9 +1,11 @@
 export function LoadingScreen() {
+  // Keep the markup/classes in sync with index.html's boot loader so the inline styles
+  // apply immediately and we avoid a flash of unstyled / missing spinner before Tailwind/globals.css loads.
   return (
-    <div className="bg-bg-dark flex h-full w-full items-center justify-center">
-      <div className="flex flex-col items-center gap-4">
-        <div className="border-border-light h-12 w-12 animate-spin rounded-full border-4 border-t-transparent" />
-        <p className="text-text-secondary text-sm">Loading workspaces...</p>
+    <div className="boot-loader" role="status" aria-live="polite" aria-busy="true">
+      <div className="boot-loader__inner">
+        <div className="boot-loader__spinner" aria-hidden="true" />
+        <p className="boot-loader__text">Loading workspaces...</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Unifies the cold-start **“Loading workspaces...”** UI by having the React `LoadingScreen` render the same `boot-loader` markup/classes as the pre-JS placeholder in `index.html`. This prevents a flash where the spinner/text render unstyled (or the spinner appears missing) before Tailwind/`globals.css` has loaded.

## Implementation
- Updated `src/browser/components/LoadingScreen.tsx` to reuse the `boot-loader*` DOM + classnames.
- Normalized the mobile string to `Loading workspaces...` for consistency.
- Added `src/browser/components/LoadingScreen.test.tsx` to lock the markup (role=status + spinner element).

## Validation
- `make static-check`
- `bun test src/browser/components/LoadingScreen.test.tsx`

## Risks
Low. Markup-only change for the initial loader, using existing inline boot CSS; includes a regression test.

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$1.29`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=1.29 -->
