### PR TITLE
🤖 fix: avoid agent loading flash in agent defaults

### DIFF
--- a/src/browser/components/Settings/sections/TasksSection.tsx
+++ b/src/browser/components/Settings/sections/TasksSection.tsx
@@ -406,7 +406,10 @@ export function TasksSection() {
                 return;
               }
 
-              setAgentsLoaded(false);
+              // Refresh in the background so enablement inheritance stays accurate after saving
+              // defaults, but keep the existing list rendered to avoid a "Loading agents…" flash
+              // while the user tweaks values.
+              setAgentsLoadFailed(false);
               void Promise.all([
                 api.agents.list({ projectPath, workspaceId }),
                 api.agents.list({ projectPath, workspaceId, includeDisabled: true }),


### PR DESCRIPTION
## Summary
- Prevent Settings → Agent Defaults from flashing **“Loading agents…”** on every change.

## Background
Saving agent defaults triggers a refresh of agent definitions/enabled state. We were setting `agentsLoaded` to `false` before that refresh, which briefly rendered the loading label even though we already had a list on-screen.

## Implementation
- Keep the existing agent list rendered while the post-save refresh runs in the background.
- Clear any prior `agentsLoadFailed` error when starting the refresh.

## Validation
- `make static-check`

## Risks
Low (UI-only). Refresh behavior is unchanged; we just avoid toggling the “loading” UI state during background updates.

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$unknown`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=unknown -->
