### PR TITLE
🤖 fix: respect Cmd shortcuts on macOS in browser

### DIFF
--- a/src/browser/utils/ui/keybinds.test.ts
+++ b/src/browser/utils/ui/keybinds.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { matchesKeybind, KEYBINDS } from "./keybinds";
+import { isMac, matchesKeybind, KEYBINDS } from "./keybinds";
 import type { Keybind } from "@/common/types/keybind";
 
 // Helper to create a minimal keyboard event
@@ -14,6 +14,29 @@ function createEvent(overrides: Partial<KeyboardEvent> = {}): KeyboardEvent {
     ...overrides,
   } as KeyboardEvent;
 }
+
+describe("isMac", () => {
+  it("falls back to navigator.platform when Electron API is missing", () => {
+    const originalWindow = globalThis.window;
+    const originalNavigator = globalThis.navigator;
+
+    // Simulate browser mode on macOS (no Electron preload API)
+    globalThis.window = {} as unknown as Window & typeof globalThis;
+    globalThis.navigator = {
+      platform: "MacIntel",
+      userAgent: "Mozilla/5.0",
+    } as unknown as Navigator;
+
+    expect(isMac()).toBe(true);
+
+    // Ctrl-style keybinds should match Cmd (Meta) on macOS
+    const event = createEvent({ key: "P", metaKey: true, shiftKey: true });
+    expect(matchesKeybind(event, KEYBINDS.OPEN_COMMAND_PALETTE)).toBe(true);
+
+    globalThis.window = originalWindow;
+    globalThis.navigator = originalNavigator;
+  });
+});
 
 describe("CYCLE_MODEL keybind (Ctrl+/)", () => {
   it("matches Ctrl+/ on Linux/Windows", () => {

--- a/src/browser/utils/ui/keybinds.ts
+++ b/src/browser/utils/ui/keybinds.ts
@@ -18,11 +18,28 @@ export type { Keybind };
 export function isMac(): boolean {
   try {
     if (typeof window === "undefined") return false;
+
+    // Prefer Electron's preload API when available.
     interface MinimalAPI {
-      platform: string;
+      platform?: string;
     }
     const api = (window as unknown as { api?: MinimalAPI }).api;
-    return api?.platform === "darwin";
+    if (api?.platform != null) {
+      return api.platform === "darwin";
+    }
+
+    // Browser mode fallback: detect platform via Navigator.
+    if (typeof navigator === "undefined") return false;
+    interface MinimalNavigator {
+      platform?: string;
+      userAgent?: string;
+      userAgentData?: {
+        platform?: string;
+      };
+    }
+    const nav = navigator as unknown as MinimalNavigator;
+    const platform = nav.userAgentData?.platform ?? nav.platform ?? nav.userAgent ?? "";
+    return /mac|iphone|ipad|ipod/i.test(platform);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
When running Mux in a regular browser (no Electron preload), keyboard shortcuts were always treated as Windows/Linux (`Ctrl`) even on macOS.

This updates keybind platform detection so browser sessions on macOS use **Cmd (Meta)** shortcuts and render `⌘` hints.

## Background
`src/browser/utils/ui/keybinds.ts` relied on `window.api.platform` (Electron preload). In a normal browser, `window.api` is undefined, so we always fell back to non-mac behavior.

## Implementation
- Updated `isMac()` to prefer `window.api.platform` when available, otherwise fall back to browser detection via `navigator.userAgentData?.platform ?? navigator.platform ?? navigator.userAgent`.
- Added a unit test covering the browser fallback path (`navigator.platform = "MacIntel"`, no `window.api`).

## Validation
- `make static-check`

## Risks
Low: change is localized to macOS detection and is only exercised when the Electron preload API is absent.

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$0.69`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=0.69 -->
