### PR TITLE
🤖 fix: center sidebar hamburger alignment

### DIFF
--- a/src/browser/components/WorkspaceListItem.tsx
+++ b/src/browser/components/WorkspaceListItem.tsx
@@ -139,12 +139,8 @@ function SelectionBar(props: { isSelected: boolean; showUnread?: boolean; isDraf
 /** Action button wrapper (archive/delete) with consistent sizing and alignment */
 function ActionButtonWrapper(props: { hasSubtitle: boolean; children: React.ReactNode }) {
   return (
-    <div
-      className={cn(
-        "relative inline-flex h-4 w-4 shrink-0 items-center",
-        props.hasSubtitle ? "self-center" : "self-start mt-0.5"
-      )}
-    >
+    <div className={cn("relative inline-flex h-4 w-4 shrink-0 items-center self-center")}>
+      {/* Keep the hamburger vertically centered even for single-row items. */}
       {props.children}
     </div>
   );


### PR DESCRIPTION
Summary
- center the workspace row hamburger/action button vertically even when there is only one row
- keep the alignment rationale inline to preserve the intended layout behavior

Background
- the new left-sidebar hamburger sat too high on single-row workspace items

Implementation
- remove the conditional top margin and always self-center the action button wrapper

Validation
- make static-check

Risks
- low; change is limited to sidebar row layout alignment

---

_Generated with `mux` • Model: `openai:gpt-5.2-codex` • Thinking: `xhigh` • Cost: `$0.13`_

<!-- mux-attribution: model=openai:gpt-5.2-codex thinking=xhigh costs=0.13 -->
