### PR TITLE
🤖 refactor: thinking level synonyms + provider-specific display

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -1340,7 +1340,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         low: "Low — adds light reasoning",
         medium: "Medium — balanced reasoning",
         high: "High — maximum reasoning depth",
-        xhigh: "Max — highest reasoning depth",
+        xhigh: "Max — deepest possible reasoning",
         max: "Max — deepest possible reasoning",
       };
 

--- a/src/browser/components/ThinkingSlider.tsx
+++ b/src/browser/components/ThinkingSlider.tsx
@@ -12,9 +12,10 @@ import { enforceThinkingPolicy, getThinkingPolicyForModel } from "@/common/utils
 import { cn } from "@/common/lib/utils";
 
 // Uses CSS variable --color-thinking-mode for theme compatibility
-const BASE_THINKING_LEVELS: ThinkingLevel[] = THINKING_LEVELS.filter((level) => level !== "xhigh");
+// All levels are shown; policy determines which are available per model
+const BASE_THINKING_LEVELS: ThinkingLevel[] = [...THINKING_LEVELS];
 
-// Text styling based on level (n: 0-4, mapping off/low/medium/high/max)
+// Text styling based on level (n: 0-5, mapping off/low/medium/high/xhigh/max)
 // Uses CSS variables for theme compatibility
 const getTextStyle = (n: number): React.CSSProperties => {
   if (n === 0) {

--- a/src/browser/contexts/ThinkingContext.tsx
+++ b/src/browser/contexts/ThinkingContext.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import React, { createContext, useContext, useEffect, useMemo, useCallback } from "react";
-import type { ThinkingLevel } from "@/common/types/thinking";
+import { THINKING_LEVEL_OFF, type ThinkingLevel } from "@/common/types/thinking";
 import {
   readPersistedState,
   updatePersistedState,
@@ -56,7 +56,7 @@ export const ThinkingProvider: React.FC<ThinkingProviderProps> = (props) => {
   // Workspace-scoped thinking. (No longer per-model.)
   const [thinkingLevel, setThinkingLevelInternal] = usePersistedState<ThinkingLevel>(
     thinkingKey,
-    "off",
+    THINKING_LEVEL_OFF,
     { listener: true }
   );
 

--- a/src/browser/utils/commands/sources.ts
+++ b/src/browser/utils/commands/sources.ts
@@ -696,7 +696,7 @@ export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandActi
         low: "Low — add a bit of reasoning",
         medium: "Medium — balanced reasoning",
         high: "High — maximum reasoning depth",
-        xhigh: "Max — highest reasoning depth",
+        xhigh: "Max — deepest possible reasoning",
         max: "Max — deepest possible reasoning",
       };
       const currentLevel = p.getThinkingLevel(workspaceId);

--- a/src/cli/debug/replay-history.ts
+++ b/src/cli/debug/replay-history.ts
@@ -16,6 +16,8 @@ import * as path from "path";
 import { parseArgs } from "util";
 import { defaultConfig } from "@/node/config";
 import type { MuxMessage } from "@/common/types/message";
+import type { ThinkingLevel } from "@/common/types/thinking";
+import { enforceThinkingPolicy } from "@/common/utils/thinking/policy";
 import { createMuxMessage } from "@/common/types/message";
 import { InitStateManager } from "@/node/services/initStateManager";
 import { AIService } from "@/node/services/aiService";
@@ -136,7 +138,10 @@ async function main() {
   );
 
   const modelString = values.model ?? "openai:gpt-5-codex";
-  const thinkingLevel = (values.thinking ?? "high") as "low" | "medium" | "high";
+  const thinkingLevel = enforceThinkingPolicy(
+    modelString,
+    (values.thinking ?? "high") as ThinkingLevel
+  );
 
   try {
     // Stream the message - pass all messages including the new one

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -78,7 +78,7 @@ import { execSync } from "child_process";
 import { getParseOptions } from "./argv";
 import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 
-// Display labels for CLI help (OFF, LOW, MED, HIGH, XHIGH)
+// Display labels for CLI help (OFF, LOW, MED, HIGH, MAX)
 const THINKING_LABELS_LIST = Object.values(THINKING_DISPLAY_LABELS).join(", ");
 
 type CLIMode = "plan" | "exec";

--- a/src/common/types/thinking.test.ts
+++ b/src/common/types/thinking.test.ts
@@ -1,22 +1,24 @@
 import { describe, expect, test } from "bun:test";
-import { getThinkingDisplayLabel } from "./thinking";
+import { coerceThinkingLevel, getThinkingDisplayLabel } from "./thinking";
 
 describe("getThinkingDisplayLabel", () => {
-  test("returns MAX for xhigh on Opus 4.6", () => {
+  test("returns MAX for xhigh/max on Anthropic models", () => {
     expect(getThinkingDisplayLabel("xhigh", "anthropic:claude-opus-4-6")).toBe("MAX");
-  });
-
-  test("returns MAX for xhigh on Opus 4.6 behind mux-gateway", () => {
+    expect(getThinkingDisplayLabel("max", "anthropic:claude-opus-4-6")).toBe("MAX");
     expect(getThinkingDisplayLabel("xhigh", "mux-gateway:anthropic/claude-opus-4-6")).toBe("MAX");
+    expect(getThinkingDisplayLabel("xhigh", "anthropic:claude-opus-4-5")).toBe("MAX");
   });
 
-  test("returns XHIGH for xhigh on non-Opus 4.6 models", () => {
+  test("returns XHIGH for xhigh/max on OpenAI models", () => {
     expect(getThinkingDisplayLabel("xhigh", "openai:gpt-5.2")).toBe("XHIGH");
-    expect(getThinkingDisplayLabel("xhigh", "anthropic:claude-opus-4-5")).toBe("XHIGH");
+    expect(getThinkingDisplayLabel("max", "openai:gpt-5.2")).toBe("XHIGH");
+    expect(getThinkingDisplayLabel("xhigh", "mux-gateway:openai/gpt-5.2")).toBe("XHIGH");
+    expect(getThinkingDisplayLabel("max", "mux-gateway:openai/gpt-5.2")).toBe("XHIGH");
   });
 
-  test("returns XHIGH for xhigh when no model specified", () => {
-    expect(getThinkingDisplayLabel("xhigh")).toBe("XHIGH");
+  test("returns MAX for xhigh/max when no model specified (default)", () => {
+    expect(getThinkingDisplayLabel("xhigh")).toBe("MAX");
+    expect(getThinkingDisplayLabel("max")).toBe("MAX");
   });
 
   test("returns standard labels for non-xhigh levels regardless of model", () => {
@@ -24,5 +26,26 @@ describe("getThinkingDisplayLabel", () => {
     expect(getThinkingDisplayLabel("low", "anthropic:claude-opus-4-6")).toBe("LOW");
     expect(getThinkingDisplayLabel("medium", "anthropic:claude-opus-4-6")).toBe("MED");
     expect(getThinkingDisplayLabel("high", "anthropic:claude-opus-4-6")).toBe("HIGH");
+  });
+});
+
+describe("coerceThinkingLevel", () => {
+  test("normalizes shorthand aliases", () => {
+    expect(coerceThinkingLevel("med")).toBe("medium");
+  });
+
+  test("passes through all canonical levels including max", () => {
+    expect(coerceThinkingLevel("off")).toBe("off");
+    expect(coerceThinkingLevel("low")).toBe("low");
+    expect(coerceThinkingLevel("medium")).toBe("medium");
+    expect(coerceThinkingLevel("high")).toBe("high");
+    expect(coerceThinkingLevel("xhigh")).toBe("xhigh");
+    expect(coerceThinkingLevel("max")).toBe("max");
+  });
+
+  test("returns undefined for invalid values", () => {
+    expect(coerceThinkingLevel("invalid")).toBeUndefined();
+    expect(coerceThinkingLevel(42)).toBeUndefined();
+    expect(coerceThinkingLevel(null)).toBeUndefined();
   });
 });

--- a/src/common/types/thinking.ts
+++ b/src/common/types/thinking.ts
@@ -10,44 +10,45 @@ export type ThinkingLevel = (typeof THINKING_LEVELS)[number];
 
 /**
  * User-facing display labels for thinking levels.
- * Used in CLI help text and contexts without model info.
- * For UI with model context, prefer getThinkingDisplayLabel() which shows
- * "MAX" instead of "XHIGH" for models that use the max effort level.
+ * Used in CLI help text and UI display.
  */
 export const THINKING_DISPLAY_LABELS: Record<ThinkingLevel, string> = {
   off: "OFF",
   low: "LOW",
   medium: "MED",
   high: "HIGH",
-  xhigh: "XHIGH",
+  xhigh: "MAX",
   max: "MAX",
 };
 
 /**
- * Model-aware display label for thinking levels.
- * Opus 4.6 maps xhigh to "max" effort, so show "MAX" instead of "XHIGH".
- * Falls back to the static THINKING_DISPLAY_LABELS for all other cases.
+ * Display label for thinking levels, with provider-aware xhigh labeling.
+ * OpenAI models show "XHIGH" (their API term); Anthropic/default show "MAX".
+ * Medium always displays as "MED".
  */
 export function getThinkingDisplayLabel(level: ThinkingLevel, modelString?: string): string {
-  if (level === "xhigh" && modelString?.toLowerCase().includes("opus-4-6")) {
-    return "MAX";
+  // xhigh and max are synonyms; show provider-aligned label
+  if ((level === "xhigh" || level === "max") && modelString) {
+    const normalized = modelString.trim().toLowerCase();
+    // OpenAI models: "openai:gpt-5.2" or "mux-gateway:openai/gpt-5.2"
+    if (normalized.startsWith("openai:")) return "XHIGH";
+    const withoutPrefix = normalized.replace(/^[a-z0-9_-]+:\s*/, "");
+    if (withoutPrefix.startsWith("openai/")) return "XHIGH";
   }
   return THINKING_DISPLAY_LABELS[level];
 }
 
 /**
- * Reverse mapping from display labels to internal values
- * Supports both display labels (OFF, LOW, MED, HIGH, XHIGH) and legacy values (medium, max)
+ * Reverse mapping from display labels/aliases to internal ThinkingLevel values.
+ * Accepts both canonical names and shorthand aliases (e.g., "med" → "medium").
  */
 const DISPLAY_LABEL_TO_LEVEL: Record<string, ThinkingLevel> = {
-  // Display labels (case-insensitive matching handled in parseThinkingDisplayLabel)
   off: "off",
   low: "low",
   med: "medium",
   high: "high",
-  xhigh: "xhigh",
   max: "max",
-  // Legacy values for backward compatibility
+  xhigh: "xhigh",
   medium: "medium",
 };
 
@@ -70,7 +71,18 @@ export function isThinkingLevel(value: unknown): value is ThinkingLevel {
   return typeof value === "string" && THINKING_LEVELS.includes(value as ThinkingLevel);
 }
 
+/**
+ * Synonym aliases for CLI/UI input: "med" → "medium".
+ * "xhigh" and "max" are both first-class ThinkingLevel values (not synonyms).
+ */
+export const THINKING_LEVEL_SYNONYMS: Readonly<Record<string, ThinkingLevel>> = {
+  med: "medium",
+};
+
 export function coerceThinkingLevel(value: unknown): ThinkingLevel | undefined {
+  if (typeof value !== "string") return undefined;
+  const synonym = THINKING_LEVEL_SYNONYMS[value];
+  if (synonym) return synonym;
   return isThinkingLevel(value) ? value : undefined;
 }
 
@@ -91,8 +103,8 @@ export const ANTHROPIC_THINKING_BUDGETS: Record<ThinkingLevel, number> = {
   low: 4000,
   medium: 10000,
   high: 20000,
-  xhigh: 20000, // Same as high - Anthropic doesn't support xhigh
-  max: 20000, // Same as high - budget ceiling; effort: "max" controls depth
+  xhigh: 20000, // Same as high - budget ceiling; effort: "max" controls depth
+  max: 20000,
 };
 
 /**
@@ -104,34 +116,28 @@ export type AnthropicEffortLevel = "low" | "medium" | "high" | "max";
  * Anthropic effort parameter mapping (Opus 4.5+)
  *
  * The effort parameter controls how much computational work the model applies.
- * Available on Opus 4.5 and Opus 4.6.
- *
- * - Opus 4.5 supports: low, medium, high
- * - Opus 4.6 supports: low, medium, high, max
- *
- * This base mapping uses "high" as the ceiling for xhigh. The providerOptions
- * builder upgrades to "max" specifically for Opus 4.6.
+ * - Opus 4.5 supports: low, medium, high (policy clamps xhigh → high)
+ * - Opus 4.6 supports: low, medium, high, max (xhigh maps to "max" effort)
  */
-export const ANTHROPIC_EFFORT: Record<ThinkingLevel, AnthropicEffortLevel> = {
+const ANTHROPIC_EFFORT: Record<ThinkingLevel, AnthropicEffortLevel> = {
   off: "low",
   low: "low",
   medium: "medium",
   high: "high",
-  xhigh: "high", // Opus 4.6 overrides this to "max" in providerOptions.ts
-  max: "max", // Claude Opus 4.6 only; policy.ts gates access per model
-};
-
-/**
- * Anthropic effort mapping specifically for Opus 4.6+ that supports "max" effort
- */
-export const ANTHROPIC_EFFORT_MAX: Record<ThinkingLevel, AnthropicEffortLevel> = {
-  off: "low",
-  low: "low",
-  medium: "medium",
-  high: "high",
-  xhigh: "max",
+  xhigh: "max", // Opus 4.6; policy clamps Opus 4.5 to "high" so xhigh never reaches 4.5
   max: "max",
 };
+
+export function getAnthropicEffort(level: ThinkingLevel): AnthropicEffortLevel {
+  return ANTHROPIC_EFFORT[level];
+}
+
+/**
+ * Default thinking level when no value is set (UI initial state, backend fallback).
+ * Semantically different from DEFAULT_THINKING_LEVEL which is the level used
+ * when a user opts *into* thinking (e.g., CLI `--thinking` with no explicit level).
+ */
+export const THINKING_LEVEL_OFF: ThinkingLevel = "off";
 
 /**
  * Default thinking level to use when toggling thinking on
@@ -150,8 +156,8 @@ export const OPENAI_REASONING_EFFORT: Record<ThinkingLevel, string | undefined> 
   low: "low",
   medium: "medium",
   high: "high",
-  xhigh: "xhigh", // Extra High - supported by models that expose xhigh (e.g., gpt-5.1-codex-max, gpt-5.2)
-  max: "xhigh", // Map to OpenAI's highest reasoning effort
+  xhigh: "xhigh", // Maps 1:1 to OpenAI's reasoning effort value
+  max: "xhigh",
 };
 
 /**
@@ -170,7 +176,7 @@ export const GEMINI_THINKING_BUDGETS: Record<ThinkingLevel, number> = {
   medium: 8192,
   high: 16384, // Conservative max (some models go to 32k)
   xhigh: 16384, // Same as high - Gemini doesn't support xhigh
-  max: 16384, // Same as high - Gemini doesn't support max
+  max: 16384,
 } as const;
 export const OPENROUTER_REASONING_EFFORT: Record<
   ThinkingLevel,
@@ -181,5 +187,5 @@ export const OPENROUTER_REASONING_EFFORT: Record<
   medium: "medium",
   high: "high",
   xhigh: "high", // Fallback to high - OpenRouter doesn't support xhigh
-  max: "high", // Fallback to high - OpenRouter doesn't support max
+  max: "high",
 };

--- a/src/common/utils/ai/providerOptions.test.ts
+++ b/src/common/utils/ai/providerOptions.test.ts
@@ -76,8 +76,8 @@ describe("buildProviderOptions - Anthropic", () => {
       expect(anthropic.effort).toBe("medium");
     });
 
-    test("should map max to max effort for Opus 4.6", () => {
-      const result = buildProviderOptions("anthropic:claude-opus-4-6", "max");
+    test("should map xhigh to max effort for Opus 4.6", () => {
+      const result = buildProviderOptions("anthropic:claude-opus-4-6", "xhigh");
       const anthropic = (result as Record<string, unknown>).anthropic as Record<string, unknown>;
 
       expect(anthropic.thinking).toEqual({ type: "adaptive" });

--- a/src/common/utils/thinking/policy.test.ts
+++ b/src/common/utils/thinking/policy.test.ts
@@ -169,20 +169,20 @@ describe("getThinkingPolicyForModel", () => {
     ]);
   });
 
-  test("returns 5 levels including max for Opus 4.6", () => {
+  test("returns 5 levels including xhigh for Opus 4.6", () => {
     expect(getThinkingPolicyForModel("anthropic:claude-opus-4-6")).toEqual([
       "off",
       "low",
       "medium",
       "high",
-      "max",
+      "xhigh",
     ]);
     expect(getThinkingPolicyForModel("anthropic:claude-opus-4-6-20260201")).toEqual([
       "off",
       "low",
       "medium",
       "high",
-      "max",
+      "xhigh",
     ]);
     // Behind gateway
     expect(getThinkingPolicyForModel("mux-gateway:anthropic/claude-opus-4-6")).toEqual([
@@ -190,7 +190,7 @@ describe("getThinkingPolicyForModel", () => {
       "low",
       "medium",
       "high",
-      "max",
+      "xhigh",
     ]);
   });
 
@@ -293,47 +293,27 @@ describe("enforceThinkingPolicy", () => {
     });
   });
 
-  describe("Opus 4.6 (5 levels including max)", () => {
-    test("allows all 5 levels including max", () => {
+  describe("Opus 4.6 (5 levels including xhigh)", () => {
+    test("allows all 5 levels including xhigh", () => {
       expect(enforceThinkingPolicy("anthropic:claude-opus-4-6", "off")).toBe("off");
       expect(enforceThinkingPolicy("anthropic:claude-opus-4-6", "low")).toBe("low");
       expect(enforceThinkingPolicy("anthropic:claude-opus-4-6", "medium")).toBe("medium");
       expect(enforceThinkingPolicy("anthropic:claude-opus-4-6", "high")).toBe("high");
-      expect(enforceThinkingPolicy("anthropic:claude-opus-4-6", "max")).toBe("max");
+      expect(enforceThinkingPolicy("anthropic:claude-opus-4-6", "xhigh")).toBe("xhigh");
     });
   });
 
-  describe("xhigh fallback for non-codex-max models", () => {
+  describe("xhigh fallback for models without xhigh support", () => {
     test("clamps to highest allowed when xhigh requested on standard model", () => {
-      // Standard models don't support xhigh, so clamp to the highest allowed level.
       expect(enforceThinkingPolicy("anthropic:claude-opus-4-5", "xhigh")).toBe("high");
     });
 
     test("falls back to high when xhigh requested on gpt-5-pro", () => {
-      // gpt-5-pro only supports high, so xhigh falls back to high
       expect(enforceThinkingPolicy("openai:gpt-5-pro", "xhigh")).toBe("high");
     });
-  });
 
-  describe("max level enforcement", () => {
-    test("preserves max for Opus 4.6", () => {
-      expect(enforceThinkingPolicy("anthropic:claude-opus-4-6", "max")).toBe("max");
-    });
-
-    test("preserves max for gateway Opus 4.6", () => {
-      expect(enforceThinkingPolicy("mux-gateway:anthropic/claude-opus-4-6", "max")).toBe("max");
-    });
-
-    test("clamps max to high for Opus 4.5 (does not support max)", () => {
-      expect(enforceThinkingPolicy("anthropic:claude-opus-4-5", "max")).toBe("high");
-    });
-
-    test("clamps max to xhigh for OpenAI models with xhigh support", () => {
-      expect(enforceThinkingPolicy("openai:gpt-5.2", "max")).toBe("xhigh");
-    });
-
-    test("clamps max to high for standard Anthropic models", () => {
-      expect(enforceThinkingPolicy("anthropic:claude-sonnet-4-5", "max")).toBe("high");
+    test("clamps xhigh to high for standard Anthropic models", () => {
+      expect(enforceThinkingPolicy("anthropic:claude-sonnet-4-5", "xhigh")).toBe("high");
     });
   });
 });

--- a/src/common/utils/thinking/policy.ts
+++ b/src/common/utils/thinking/policy.ts
@@ -44,9 +44,9 @@ export function getThinkingPolicyForModel(modelString: string): ThinkingPolicy {
   //   mux-gateway:openai/gpt-5.2-pro -> openai/gpt-5.2-pro -> gpt-5.2-pro
   const withoutProviderNamespace = withoutPrefix.replace(/^[a-z0-9_-]+\//, "");
 
-  // Claude Opus 4.6 supports 5 levels including max (mapped to "max" effort)
+  // Claude Opus 4.6 supports 5 levels including xhigh (mapped to "max" effort)
   if (withoutProviderNamespace.includes("opus-4-6")) {
-    return ["off", "low", "medium", "high", "max"];
+    return ["off", "low", "medium", "high", "xhigh"];
   }
 
   // GPT-5.1-Codex-Max supports 5 reasoning levels including xhigh (Extra High)
@@ -87,7 +87,7 @@ export function getThinkingPolicyForModel(modelString: string): ThinkingPolicy {
     return ["low", "high"];
   }
 
-  // Default policy: standard 4 levels (off/low/medium/high). Models with xhigh/max must opt in above.
+  // Default policy: standard 4 levels (off/low/medium/high). Models with xhigh must opt in above.
   return ["off", "low", "medium", "high"];
 }
 

--- a/src/constants/workspaceDefaults.ts
+++ b/src/constants/workspaceDefaults.ts
@@ -32,7 +32,7 @@ Object.freeze(STORAGE_KEYS);
  * Do not modify these values at runtime - they serve as the single source of truth.
  */
 
-import type { ThinkingLevel } from "@/common/types/thinking";
+import { THINKING_LEVEL_OFF } from "@/common/types/thinking";
 import { DEFAULT_MODEL } from "@/common/constants/knownModels";
 
 /**
@@ -44,7 +44,7 @@ export const WORKSPACE_DEFAULTS = {
   agentId: "exec" as const,
 
   /** Default thinking/reasoning level for new workspaces */
-  thinkingLevel: "off" as ThinkingLevel,
+  thinkingLevel: THINKING_LEVEL_OFF,
 
   /**
    * Default AI model for new workspaces.

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -94,7 +94,7 @@ import type { TaskService } from "@/node/services/taskService";
 import { buildProviderOptions } from "@/common/utils/ai/providerOptions";
 import { enforceThinkingPolicy } from "@/common/utils/thinking/policy";
 import { resolveProviderCredentials } from "@/node/utils/providerRequirements";
-import type { ThinkingLevel } from "@/common/types/thinking";
+import { THINKING_LEVEL_OFF, type ThinkingLevel } from "@/common/types/thinking";
 import { DEFAULT_TASK_SETTINGS, SYSTEM1_BASH_OUTPUT_COMPACTION_LIMITS } from "@/common/types/tasks";
 import type {
   StreamAbortEvent,
@@ -1647,7 +1647,7 @@ export class AIService extends EventEmitter {
 
       // Mode (plan|exec|compact) is derived from the selected agent definition.
       const effectiveMuxProviderOptions: MuxProviderOptions = muxProviderOptions ?? {};
-      const effectiveThinkingLevel: ThinkingLevel = thinkingLevel ?? "off";
+      const effectiveThinkingLevel: ThinkingLevel = thinkingLevel ?? THINKING_LEVEL_OFF;
 
       // For xAI models, swap between reasoning and non-reasoning variants based on thinking level
       // Similar to how OpenAI handles reasoning vs non-reasoning models


### PR DESCRIPTION
## Summary

Cleans up thinking level handling: makes `xhigh` and `max` both first-class `ThinkingLevel` values with identical semantics, adds provider-aware display labels in the ThinkingSlider, and simplifies Anthropic effort mapping.

## Background

After Opus 4.6 support landed (#2182), the codebase had `"max"` newly introduced alongside the established `"xhigh"` — both meaning the same thing across all providers. Meanwhile, `getAnthropicEffort` carried separate base/max effort tables and a `supportsMax` parameter, and `buildProviderOptions` had a redundant `enforceThinkingPolicy` call (callers already clamp).

Goals:
- Accept both `xhigh` and `max` everywhere (CLI, UI, persisted data, schemas) so nothing breaks on upgrade/downgrade
- Show provider-aligned labels: **XHIGH** for OpenAI models, **MAX** for Anthropic/default
- Simplify internal plumbing that was duplicated or over-engineered

## Implementation

### Thinking level representation
- **6 canonical values:** `["off", "low", "medium", "high", "xhigh", "max"]` — both `xhigh` and `max` are first-class, mapping to identical provider values in all 5 mapping tables
- **`THINKING_LEVEL_SYNONYMS`** — `{ med: "medium" }` for CLI/UI shorthand input
- All zod schemas (8 files) updated to accept `"max"` alongside `"xhigh"`
- `TelemetryThinkingLevel` updated to include `"max"`

### Provider-aware display
- **`getThinkingDisplayLabel(level, modelString)`** — now uses `modelString` (previously declared but unused) to detect OpenAI models and return `"XHIGH"`; Anthropic and unspecified models get `"MAX"`
- ThinkingSlider already passes `modelString` in all 3 callsites — picks up the new behavior automatically

### Simplifications (retained from earlier cleanup)
- **`getAnthropicEffort(level)`** — collapsed `ANTHROPIC_EFFORT` + `ANTHROPIC_EFFORT_MAX` into a single `Record<ThinkingLevel, AnthropicEffortLevel>`, removed `supportsMax` parameter. Policy already clamps Opus 4.5 to `"high"`, so `xhigh`/`max` never reaches it
- **Removed double `enforceThinkingPolicy`** from `buildProviderOptions` — all production callers (agentSession, taskService, system-1 stream) pre-clamp; added enforcement to `replay-history.ts` (debug CLI) as belt-and-suspenders
- **Removed redundant Gemini inline remapping** — policy enforcement handles Flash/Pro clamping upstream
- **`THINKING_LEVEL_OFF` constant** centralized for `"off"` defaults

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `high` • Cost: `$219.83`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=high costs=219.83 -->
