### PR TITLE
chore: remove opus-4.5 alias from known models

### DIFF
--- a/docs/config/models.mdx
+++ b/docs/config/models.mdx
@@ -14,7 +14,6 @@ Mux ships with curated models kept up to date with the frontier. Use any custom 
 | Model                  | ID                            | Aliases                                  | Default |
 | ---------------------- | ----------------------------- | ---------------------------------------- | ------- |
 | Opus 4.6               | anthropic:claude-opus-4-6     | `opus`                                   | ✓       |
-| Opus 4.5               | anthropic:claude-opus-4-5     | `opus-4.5`                               |         |
 | Sonnet 4.5             | anthropic:claude-sonnet-4-5   | `sonnet`                                 |         |
 | Haiku 4.5              | anthropic:claude-haiku-4-5    | `haiku`                                  |         |
 | GPT-5.2                | openai:gpt-5.2                | `gpt`                                    |         |

--- a/src/browser/utils/slashCommands/suggestions.test.ts
+++ b/src/browser/utils/slashCommands/suggestions.test.ts
@@ -89,11 +89,10 @@ describe("getSlashCommandSuggestions", () => {
 
   it("filters model suggestions by partial input", () => {
     const suggestions = getSlashCommandSuggestions("/model op");
-    // Both "opus" (opus-4-6) and "opus-4.5" match the "op" prefix
-    expect(suggestions).toHaveLength(2);
+    // Only "opus" (opus-4-6) matches the "op" prefix
+    expect(suggestions).toHaveLength(1);
     const displays = suggestions.map((s) => s.display);
     expect(displays).toContain("opus");
-    expect(displays).toContain("opus-4.5");
   });
 
   it("suggests model aliases as one-shot commands", () => {

--- a/src/common/constants/knownModels.ts
+++ b/src/common/constants/knownModels.ts
@@ -33,12 +33,6 @@ const MODEL_DEFINITIONS = {
     aliases: ["opus"],
     warm: true,
   },
-  OPUS_45: {
-    provider: "anthropic",
-    providerModelId: "claude-opus-4-5",
-    aliases: ["opus-4.5"],
-    warm: false,
-  },
   SONNET: {
     provider: "anthropic",
     providerModelId: "claude-sonnet-4-5",


### PR DESCRIPTION
## Remove `opus-4.5` alias from known models

The `opus-4.5` shorthand alias is no longer needed — Opus 4.6 is the current model and owns the `opus` alias. Removing the `OPUS_45` known-model entry declutters the model picker and slash-command suggestions.

### Changes

- **`src/common/constants/knownModels.ts`** — Removed `OPUS_45` entry (6 lines). This automatically drops it from `KNOWN_MODELS`, `MODEL_ABBREVIATIONS`, `KNOWN_MODEL_OPTIONS`, and the model picker.
- **`src/browser/utils/slashCommands/suggestions.test.ts`** — Updated the `"op"` prefix test to expect 1 result (`opus`) instead of 2.
- **`docs/config/models.mdx`** — Regenerated via `make fmt` to stay in sync.

All behavioral logic (effort parameter, thinking budgets, provider options, `isOpus45` branch) remains unchanged. Users can still reference `anthropic:claude-opus-4-5` directly.

---

<details>
<summary>📋 Implementation Plan</summary>

# Remove Opus 4.5 Alias

## Context / Why

The `opus-4.5` shorthand alias is no longer needed — Opus 4.6 is the current model and owns the `opus` alias. Removing the `OPUS_45` known-model entry declutters the model picker and slash-command suggestions. All behavioral logic (effort parameter, thinking budgets, provider options) stays intact since users can still use `anthropic:claude-opus-4-5` directly.

## Scope

Remove **only the `OPUS_45` known-model entry** (and its `opus-4.5` alias). Everything else — effort handling in `providerOptions.ts`, thinking types, cost metadata, and the `isOpus45` branch — remains unchanged.

## Implementation (~−10 LoC)

### 1. Remove `OPUS_45` entry from `knownModels.ts`

Delete lines 36–41:

```ts
  OPUS_45: {
    provider: "anthropic",
    providerModelId: "claude-opus-4-5",
    aliases: ["opus-4.5"],
    warm: false,
  },
```

This automatically removes it from `KNOWN_MODELS`, `MODEL_ABBREVIATIONS`, `KNOWN_MODEL_OPTIONS`, and the model picker. No other file imports `OPUS_45` by key.

### 2. Update test: slash-command suggestions

`src/browser/utils/slashCommands/suggestions.test.ts:90-97` — the `"op"` prefix test currently expects 2 results (`opus` and `opus-4.5`). Update to expect only 1 result (`opus`).

### 3. Verify

Run `grep -r "opus-4\.5\|OPUS_45" src/` to confirm no stale references to the alias or key remain. (References to `opus-4-5` in provider logic, thinking types, and cost metadata are expected and should stay.)

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh`_
