### PR TITLE
🤖 fix: exclude release/ from shellcheck glob in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ lint-zizmor: ## Run zizmor security analysis on GitHub Actions workflows
 	@./scripts/zizmor.sh --min-confidence high .
 
 # Shell files to lint (excludes node_modules, build artifacts, .git)
-SHELL_SRC_FILES := $(shell find . -not \( -path '*/.git/*' -o -path './node_modules/*' -o -path './build/*' -o -path './dist/*' -o -path './benchmarks/terminal_bench/.leaderboard_cache/*' \) -type f -name '*.sh' 2>/dev/null)
+SHELL_SRC_FILES := $(shell find . -not \( -path '*/.git/*' -o -path './node_modules/*' -o -path './build/*' -o -path './dist/*' -o -path './release/*' -o -path './benchmarks/terminal_bench/.leaderboard_cache/*' \) -type f -name '*.sh' 2>/dev/null)
 
 lint-shellcheck: ## Run shellcheck on shell scripts
 	shellcheck --external-sources $(SHELL_SRC_FILES)


### PR DESCRIPTION
## Summary

Exclude `release/` from the shellcheck `find` glob in the Makefile so vendored third-party scripts (e.g., `node-pty/deps/winpty/misc/color-test.sh` inside the Electron build output) aren't linted.

## Background

After building, `release/linux-unpacked/` contains unpacked Electron app artifacts including vendored shell scripts from `node-pty`. The `SHELL_SRC_FILES` find command wasn't excluding `release/`, causing `make lint-shellcheck` to fail on code we don't own.

## Implementation

Added `-o -path './release/*'` to the exclusion list in the `SHELL_SRC_FILES` find command, matching how `node_modules/`, `build/`, and `dist/` are already excluded.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `medium` • Cost: `$0.79`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=medium costs=0.79 -->
