### PR TITLE
🤖 ci: remove size limits from auto-cleanup prompt

### DIFF
--- a/.github/prompts/auto-cleanup.md
+++ b/.github/prompts/auto-cleanup.md
@@ -30,7 +30,6 @@ Constraints:
 - Prefer local refactors; avoid sweeping renames across many files.
 - No dependency bumps.
 - Avoid CI/workflow changes.
-- Keep it small: **≤3 files changed** and **≤100 LOC touched**.
 
 Examples of good changes:
 


### PR DESCRIPTION
Drop the "≤3 files / ≤100 LOC" constraint from the auto-cleanup agent prompt. The behavior-preserving requirement is the actual safety boundary; size limits just prevent valuable cleanups.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-5` • Thinking: `high` • Cost: `$N/A`_

<!-- mux-attribution: model=anthropic:claude-opus-4-5 thinking=high costs=N/A -->
