### PR TITLE
🤖 fix: correct context usage double-counting after AI SDK v6 upgrade

### DIFF
--- a/src/common/utils/tokens/displayUsage.test.ts
+++ b/src/common/utils/tokens/displayUsage.test.ts
@@ -3,70 +3,107 @@ import { createDisplayUsage } from "./displayUsage";
 import type { LanguageModelV2Usage } from "@ai-sdk/provider";
 
 describe("createDisplayUsage", () => {
-  describe("Provider-specific cached token handling", () => {
-    // OpenAI reports inputTokens INCLUSIVE of cachedInputTokens
-    // We must subtract cached from input to avoid double-counting
-    const openAIUsage: LanguageModelV2Usage = {
-      inputTokens: 108200, // Includes 71600 cached
-      outputTokens: 227,
-      totalTokens: 108427,
-      cachedInputTokens: 71600,
-    };
+  describe("AI SDK v6: unified cached token subtraction", () => {
+    // AI SDK v6 changed semantics: ALL providers now report inputTokens INCLUSIVE
+    // of cached tokens. We always subtract cachedInputTokens + cacheCreateTokens
+    // to get the true non-cached input.
 
-    test("subtracts cached tokens for direct OpenAI model", () => {
+    test("subtracts cached tokens for OpenAI model", () => {
+      const openAIUsage: LanguageModelV2Usage = {
+        inputTokens: 108200, // Includes 71600 cached
+        outputTokens: 227,
+        totalTokens: 108427,
+        cachedInputTokens: 71600,
+      };
+
       const result = createDisplayUsage(openAIUsage, "openai:gpt-5.2");
 
       expect(result).toBeDefined();
       expect(result!.cached.tokens).toBe(71600);
-      // Input should be raw minus cached: 108200 - 71600 = 36600
+      // Input = raw minus cached: 108200 - 71600 = 36600
       expect(result!.input.tokens).toBe(36600);
     });
 
     test("subtracts cached tokens for gateway OpenAI model", () => {
-      // Gateway format: mux-gateway:openai/model-name
+      const openAIUsage: LanguageModelV2Usage = {
+        inputTokens: 108200,
+        outputTokens: 227,
+        totalTokens: 108427,
+        cachedInputTokens: 71600,
+      };
+
       const result = createDisplayUsage(openAIUsage, "mux-gateway:openai/gpt-5.2");
 
       expect(result).toBeDefined();
       expect(result!.cached.tokens).toBe(71600);
-      // Should also subtract: 108200 - 71600 = 36600
+      // Input = raw minus cached: 108200 - 71600 = 36600
       expect(result!.input.tokens).toBe(36600);
     });
 
-    test("does NOT subtract cached tokens for Anthropic model", () => {
-      // Anthropic reports inputTokens EXCLUDING cachedInputTokens
+    test("subtracts cached tokens for Anthropic model (v6 semantics)", () => {
+      // In v6, Anthropic now reports inputTokens INCLUSIVE of cached tokens
+      // (matching OpenAI/Google behavior). inputTokens = input + cache_read + cache_write.
       const anthropicUsage: LanguageModelV2Usage = {
-        inputTokens: 36600, // Already excludes cached
+        inputTokens: 108200, // 36600 non-cached + 71600 cache_read
         outputTokens: 227,
         totalTokens: 108427,
         cachedInputTokens: 71600,
       };
 
-      const result = createDisplayUsage(anthropicUsage, "anthropic:claude-sonnet-4-5");
+      const result = createDisplayUsage(anthropicUsage, "anthropic:claude-opus-4-6");
 
       expect(result).toBeDefined();
       expect(result!.cached.tokens).toBe(71600);
-      // Input stays as-is for Anthropic
+      // Input = raw minus cached: 108200 - 71600 = 36600 (non-cached only)
       expect(result!.input.tokens).toBe(36600);
     });
 
-    test("does NOT subtract cached tokens for gateway Anthropic model", () => {
+    test("subtracts cached tokens for gateway Anthropic model", () => {
       const anthropicUsage: LanguageModelV2Usage = {
-        inputTokens: 36600,
+        inputTokens: 108200,
         outputTokens: 227,
         totalTokens: 108427,
         cachedInputTokens: 71600,
       };
 
-      const result = createDisplayUsage(anthropicUsage, "mux-gateway:anthropic/claude-sonnet-4-5");
+      const result = createDisplayUsage(anthropicUsage, "mux-gateway:anthropic/claude-opus-4-6");
 
       expect(result).toBeDefined();
       expect(result!.cached.tokens).toBe(71600);
-      // Input stays as-is for gateway Anthropic
+      // Input = raw minus cached: 108200 - 71600 = 36600
       expect(result!.input.tokens).toBe(36600);
     });
 
-    test("subtracts cached tokens for direct Google model", () => {
-      // Google also reports inputTokens INCLUSIVE of cachedInputTokens
+    test("subtracts both cached and cache-create for Anthropic with cache creation", () => {
+      // Anthropic with both cache_read and cache_creation tokens
+      // inputTokens = 500 non-cached + 100000 cache_read + 5000 cache_write = 105500
+      const usage: LanguageModelV2Usage = {
+        inputTokens: 105500,
+        outputTokens: 1000,
+        totalTokens: 106500,
+        cachedInputTokens: 100000,
+      };
+
+      const result = createDisplayUsage(usage, "anthropic:claude-opus-4-6", {
+        anthropic: { cacheCreationInputTokens: 5000 },
+      });
+
+      expect(result).toBeDefined();
+      expect(result!.input.tokens).toBe(500); // 105500 - 100000 - 5000
+      expect(result!.cached.tokens).toBe(100000);
+      expect(result!.cacheCreate.tokens).toBe(5000);
+      expect(result!.output.tokens).toBe(1000);
+
+      // Total should match actual context (no double counting)
+      const total =
+        result!.input.tokens +
+        result!.cached.tokens +
+        result!.cacheCreate.tokens +
+        result!.output.tokens;
+      expect(total).toBe(106500);
+    });
+
+    test("subtracts cached tokens for Google model", () => {
       const googleUsage: LanguageModelV2Usage = {
         inputTokens: 74300, // Includes 42600 cached
         outputTokens: 1600,
@@ -78,7 +115,7 @@ describe("createDisplayUsage", () => {
 
       expect(result).toBeDefined();
       expect(result!.cached.tokens).toBe(42600);
-      // Input should be raw minus cached: 74300 - 42600 = 31700
+      // Input = raw minus cached: 74300 - 42600 = 31700
       expect(result!.input.tokens).toBe(31700);
     });
 
@@ -94,8 +131,29 @@ describe("createDisplayUsage", () => {
 
       expect(result).toBeDefined();
       expect(result!.cached.tokens).toBe(42600);
-      // Should also subtract: 74300 - 42600 = 31700
+      // Input = raw minus cached: 74300 - 42600 = 31700
       expect(result!.input.tokens).toBe(31700);
+    });
+  });
+
+  describe("backward compatibility with pre-v6 data", () => {
+    test("clamps to 0 when pre-v6 Anthropic data has inputTokens excluding cache", () => {
+      // Pre-v6 historical data: inputTokens excluded cache, so subtracting
+      // would go negative. Math.max(0, ...) ensures no negative values.
+      const oldFormatUsage: LanguageModelV2Usage = {
+        inputTokens: 500, // Pre-v6: non-cached only
+        outputTokens: 227,
+        totalTokens: 72327,
+        cachedInputTokens: 71600,
+      };
+
+      const result = createDisplayUsage(oldFormatUsage, "anthropic:claude-sonnet-4-5");
+
+      expect(result).toBeDefined();
+      // Input clamps to 0 (500 - 71600 would be negative)
+      expect(result!.input.tokens).toBe(0);
+      expect(result!.cached.tokens).toBe(71600);
+      // Total is approximately correct (off by 500 non-cached, acceptable for old data)
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes incorrect context utilization display after the AI SDK v5→v6 upgrade. The v6 SDK changed how Anthropic reports `inputTokens` — it now **includes** cached tokens (matching OpenAI/Google behavior), but our display code still assumed the old Anthropic semantics where `inputTokens` excluded cache tokens.

## Background

The AI SDK v6 migration (commits `6b9dce97`, `b21c6952`, `6ca28e7d`) bumped `@ai-sdk/anthropic` from v2 to v3. In v3, the Anthropic provider changed its usage conversion:

- **v2 (old):** `inputTokens` = `input_tokens` (non-cached only, Anthropic API field)
- **v3 (new):** `inputTokens` = `input_tokens + cache_read_input_tokens + cache_creation_input_tokens` (total)

Our `createDisplayUsage()` had provider-specific branching:
- OpenAI/Google: subtract `cachedInputTokens` from `inputTokens` (since they included cache)
- Anthropic: use `inputTokens` as-is (since it excluded cache)

After v6, the Anthropic path double-counted cache tokens in the context meter — both in the "input" segment (which now included cache tokens) and again in the dedicated "cached"/"cacheCreate" segments. This caused the context bar to show ~2x the actual usage for cached Anthropic conversations.

## Implementation

- **Unified subtraction:** Always subtract both `cachedInputTokens` and `cacheCreateTokens` from `rawInputTokens` regardless of provider. This works because all providers now report inclusive totals in v6.
- **Backward compat:** `Math.max(0, ...)` guards against pre-v6 historical data in `chat.jsonl` where Anthropic's `inputTokens` already excluded cache (subtraction would go negative). The small non-cached input portion is lost for old data but totals remain approximately correct.
- **Removed dead code:** Provider detection (`isOpenAI`, `isGoogle`, `normalizeGatewayModel`) is no longer needed in `displayUsage.ts`.
- **Updated tests:** Rewrote `displayUsage.test.ts` to use v6 data shapes, added cache-creation subtraction test, and backward compat test.

## Validation

Verified with manual data simulation:
- V6 Anthropic (cache_read=100k, input=500): total = 101,500 ✓ (was 201,500)
- V6 Anthropic with cache_create: total = 106,500 ✓ (was 212,000)
- V6 OpenAI (unchanged): total = 108,427 ✓

## Risks

**Low.** The change simplifies the code path (removes provider branching, one formula for all). Historical pre-v6 data for Anthropic may show 0 in the "input" segment but total context is approximately correct. No other providers are affected since their semantics were already "inputTokens inclusive of cache".

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `high` • Cost: `$N/A`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=high costs=N/A -->
