### PR TITLE
🤖 fix: prevent ChatInput control overlap on narrow screens

### DIFF
--- a/src/browser/components/AgentModePicker.tsx
+++ b/src/browser/components/AgentModePicker.tsx
@@ -453,7 +453,10 @@ export const AgentModePicker: React.FC<AgentModePickerProps> = (props) => {
         </TooltipContent>
       </Tooltip>
 
-      <AgentHelpTooltip />
+      {/* Tooltip is hover-only; hide it on touch + narrow layouts to avoid overlap. */}
+      <div className="hidden [@container(min-width:420px)]:[@media(hover:hover)_and_(pointer:fine)]:block">
+        <AgentHelpTooltip />
+      </div>
 
       {isPickerOpen && (
         <div className="bg-separator border-border-light absolute right-0 bottom-full z-[1020] mb-1 max-w-[420px] min-w-72 overflow-hidden rounded border shadow-[0_4px_12px_rgba(0,0,0,0.3)]">

--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -2424,7 +2424,11 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                   </div>
                 </div>
 
-                <div className="flex shrink-0 items-center" data-component="ThinkingSliderGroup">
+                {/* On narrow layouts, hide the thinking paddles to prevent control overlap. */}
+                <div
+                  className="flex shrink-0 items-center [@container(max-width:420px)]:[&_[data-thinking-paddle]]:hidden"
+                  data-component="ThinkingSliderGroup"
+                >
                   <ThinkingSliderComponent modelString={baseModel} />
                 </div>
 


### PR DESCRIPTION
## Summary
Prevent the ChatInput mode row from overlapping/clipping at ~390px width by compacting a couple of controls.

## Background
On narrow/mobile-sized layouts (e.g. 390×844), the thinking control could get clipped, and the agent `?` help tooltip is hover-only (non-functional on touch) while consuming horizontal space.

## Implementation
- Hide the thinking paddles on narrow containers (label remains clickable to cycle levels).
- Hide the hover-only agent help `?` on touch + narrow containers to free space.

## Validation
- `make static-check`

## Risks
Low: changes are gated behind container/media queries; wider/hover-capable layouts are unchanged.

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$2.23`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=2.23 -->
