### PR TITLE
🤖 fix: track System 1 agent token usage in workspace costs

### DIFF
--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -912,6 +912,7 @@ export class AIService extends EventEmitter {
                 this.providerModelFactory.resolveGatewayModelString(ms, dm, eg),
               createModel: (ms, o) => this.createModel(ms, o),
               emitBashOutput: (ev) => this.emit("bash-output", ev),
+              sessionUsageService: this.sessionUsageService,
             })
           : tools;
 


### PR DESCRIPTION
## Summary

System 1 (the internal agent that filters large bash outputs) makes LLM calls via `generateText` but discards the usage stats, making its token consumption invisible in the Costs tab. This PR wires up usage tracking so System 1 costs are recorded and displayed alongside all other workspace costs.

## Background

When a bash tool produces large output, System 1 runs a background LLM call to identify the important parts (errors, stack traces, etc.) and filters out the rest. These calls consume tokens but the usage was silently discarded — users were unknowingly underreporting their actual spend.

## Implementation

**`src/node/services/system1/system1AgentRunner.ts`**
- Import `LanguageModelV2Usage` from `@ai-sdk/provider`
- Widen `GenerateTextLike` return type to include optional `usage`
- Add `usage?: LanguageModelV2Usage` to the function's return type
- Return `usage: response.usage` from successful calls

**`src/node/services/aiService.ts`**
- Import `createDisplayUsage` from `@/common/utils/tokens/displayUsage`
- After a successful System 1 call, convert raw usage via `createDisplayUsage()` and record it with `void this.sessionUsageService.recordUsage()` (fire-and-forget, matching the existing StreamManager pattern)

System 1 costs are attributed to whatever model it uses (e.g., `openai:gpt-4o-mini`), so they naturally merge into the same model bucket in the Costs tab — no new UI category needed.

## Risks

Low. The change is additive: it surfaces usage that was previously discarded. The fire-and-forget `void` pattern matches existing cost recording in StreamManager. Failed/timed-out System 1 calls return `undefined`, so no spurious usage is recorded.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `high` • Cost: `$10.96`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=high costs=10.96 -->