### PR TITLE
🤖 feat: preserve failure status when redacting tool outputs in shared transcripts

### DIFF
--- a/src/browser/components/tools/shared/NestedToolsContainer.tsx
+++ b/src/browser/components/tools/shared/NestedToolsContainer.tsx
@@ -22,7 +22,12 @@ export const NestedToolsContainer: React.FC<NestedToolsContainerProps> = ({
   return (
     <div className="-mx-3 space-y-3">
       {calls.map((call) => {
-        const status = getNestedToolStatus(call.state, call.output, parentInterrupted ?? false);
+        const status = getNestedToolStatus(
+          call.state,
+          call.output,
+          parentInterrupted ?? false,
+          call.failed
+        );
         return (
           <NestedToolRenderer
             key={call.toolCallId}

--- a/src/browser/components/tools/shared/codeExecutionTypes.ts
+++ b/src/browser/components/tools/shared/codeExecutionTypes.ts
@@ -38,5 +38,6 @@ export interface NestedToolCall {
   input: unknown;
   output?: unknown;
   state: "input-available" | "output-available" | "output-redacted";
+  failed?: boolean;
   timestamp?: number;
 }

--- a/src/browser/components/tools/shared/toolUtils.tsx
+++ b/src/browser/components/tools/shared/toolUtils.tsx
@@ -133,11 +133,12 @@ export function isFailedToolOutput(output: unknown): boolean {
 export function getNestedToolStatus(
   state: "input-available" | "output-available" | "output-redacted",
   output: unknown,
-  parentInterrupted: boolean
+  parentInterrupted: boolean,
+  failed?: boolean
 ): ToolStatus {
   if (state === "output-available") {
     return isFailedToolOutput(output) ? "failed" : "completed";
   }
-  if (state === "output-redacted") return "redacted";
+  if (state === "output-redacted") return failed ? "failed" : "redacted";
   return parentInterrupted ? "interrupted" : "executing";
 }

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -2087,7 +2087,7 @@ export class StreamingMessageAggregator {
             // Check if result indicates failure (for tools that return { success: boolean })
             status = hasFailureResult(part.output) ? "failed" : "completed";
           } else if (part.state === "output-redacted") {
-            status = "redacted";
+            status = part.failed ? "failed" : "redacted";
           } else if (part.state === "input-available") {
             // Most unfinished tool calls in partial messages represent an interruption.
             // ask_user_question is different: it's intentionally waiting on user input,

--- a/src/common/orpc/schemas/message.ts
+++ b/src/common/orpc/schemas/message.ts
@@ -46,6 +46,7 @@ export const NestedToolCallSchema = z.object({
   input: z.unknown(),
   output: z.unknown().optional(),
   state: z.enum(["input-available", "output-available", "output-redacted"]),
+  failed: z.boolean().optional(),
   timestamp: z.number().optional(),
 });
 
@@ -64,6 +65,7 @@ export const DynamicToolPartAvailableSchema = MuxToolPartBase.extend({
 });
 export const DynamicToolPartRedactedSchema = MuxToolPartBase.extend({
   state: z.literal("output-redacted"),
+  failed: z.boolean().optional(),
   nestedCalls: z.array(NestedToolCallSchema).optional(),
 });
 

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -539,6 +539,7 @@ export type DisplayedMessage =
         input: unknown;
         output?: unknown;
         state: "input-available" | "output-available" | "output-redacted";
+        failed?: boolean;
         timestamp?: number;
       }>;
     }


### PR DESCRIPTION
## Summary

When tool outputs are stripped for sharing (`output-redacted`), failure information was lost — every redacted tool showed the same muted "redacted" status. This adds an optional `failed` boolean to the redacted schema so failed tools still render as failed (red X) even when their output content is redacted.

## Background

Follow-up to the `output-redacted` feature (PR #2202). `stripToolPartOutput` drops the entire `output` object (which contains `{ success: false }` or `{ error: "..." }`), and sets `state: "output-redacted"`. Downstream, the aggregator mapped that to a single `"redacted"` display status — no way to distinguish failed-then-redacted from succeeded-then-redacted.

## Implementation

Adds an optional `failed?: boolean` field to the redacted state, populated at strip time by inspecting the output before dropping it:

| File | Change |
|------|--------|
| `src/common/orpc/schemas/message.ts` | `failed: z.boolean().optional()` on `NestedToolCallSchema` + `DynamicToolPartRedactedSchema` |
| `src/common/utils/messages/transcriptShare.ts` | `isFailedOutput()` helper; wired into `stripNestedToolCallOutput` and `stripToolPartOutput` |
| `src/browser/utils/messages/StreamingMessageAggregator.ts` | `"output-redacted"` branch checks `part.failed` → picks `"failed"` vs `"redacted"` |
| `src/browser/components/tools/shared/toolUtils.tsx` | `getNestedToolStatus` accepts optional `failed` param |
| `src/browser/components/tools/shared/NestedToolsContainer.tsx` | Passes `call.failed` through |
| `src/browser/components/tools/shared/codeExecutionTypes.ts` | `failed?: boolean` on `NestedToolCall` interface |
| `src/common/types/message.ts` | `failed?: boolean` on inline nested call type |
| `src/common/utils/messages/transcriptShare.test.ts` | 4 new test cases for failed/success × tool/nested-call |

No rendering changes needed — `GenericToolCall`, `BashToolCall`, `ToolPrimitives`, and `getStatusDisplay` already handle the `"failed"` status with the correct red X icon.

## Risks

Low. The `failed` field is optional, so existing persisted data without it parses fine (defaults to `undefined` → treated as not-failed). No migration needed.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `high` • Cost: `$2.93`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=high costs=2.93 -->