### PR TITLE
🤖 feat: add gpt-5.3-codex to Codex OAuth model sets

### DIFF
--- a/src/common/constants/codexOAuth.ts
+++ b/src/common/constants/codexOAuth.ts
@@ -107,6 +107,7 @@ export const CODEX_OAUTH_ALLOWED_MODELS = new Set<string>([
   "gpt-5.1-codex-mini",
   "gpt-5.2",
   "gpt-5.2-codex",
+  "gpt-5.3-codex",
   "gpt-5.1-codex",
 ]);
 
@@ -117,6 +118,7 @@ export const CODEX_OAUTH_REQUIRED_MODELS = new Set<string>([
   "gpt-5.1-codex-max",
   "gpt-5.1-codex-mini",
   "gpt-5.2-codex",
+  "gpt-5.3-codex",
   "gpt-5.1-codex",
 ]);
 


### PR DESCRIPTION
## Summary

Adds `gpt-5.3-codex` to the Codex OAuth authentication model sets so it can be routed through the ChatGPT subscription OAuth flow.

## Background

The new `gpt-5.3-codex` model uses the same Codex OAuth authentication path as other codex models (`gpt-5.2-codex`, `gpt-5.1-codex`, etc.). It needs to be registered in both model sets to work correctly.

## Implementation

Added `gpt-5.3-codex` to both sets in `src/common/constants/codexOAuth.ts`:

- **`CODEX_OAUTH_ALLOWED_MODELS`** — models that *may* be routed through Codex OAuth
- **`CODEX_OAUTH_REQUIRED_MODELS`** — models that *require* Codex OAuth (cannot fall back to OpenAI API keys)

The existing helper functions (`isCodexOauthAllowedModelId`, `isCodexOauthRequiredModelId`) automatically recognize the new model with or without the `openai:` prefix.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `high` • Cost: `$0.39`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=high costs=0.39 -->
