### PR TITLE
🤖 fix: use streamText for workspace title generation to fix Codex OAuth

### DIFF
--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1063,6 +1063,7 @@ export class AIService extends EventEmitter {
                     "temperature",
                     "top_p",
                     "include",
+                    "text", // structured output via Output.object → text.format
                   ]);
 
                   for (const key of Object.keys(json)) {


### PR DESCRIPTION
## Summary

Fixes workspace name generation failing with "Bad Request" (400) when using Codex OAuth models (`gpt-5.1-codex-mini`, `gpt-5.3-codex`).

## Background

The Codex OAuth endpoint (`chatgpt.com/backend-api/codex/responses`) requires `stream: true` in the request body and rejects non-streaming requests with HTTP 400. The workspace title generator was using `generateText` from the AI SDK, which sends non-streaming requests (no `stream` field in the body). All other Codex interactions use `streamText` which sets `stream: true` automatically, so they work fine.

## Implementation

Two changes:

1. **Switch `generateText` → `streamText`** in `workspaceTitleGenerator.ts` — `streamText` sets `stream: true` in the request body, making it compatible with the Codex endpoint. The `Output.object` structured output is still supported; we await `stream.output` which triggers full stream consumption and JSON parsing.

2. **Add `text` to `CODEX_ALLOWED_PARAMS`** in `aiService.ts` — When using `Output.object`, the AI SDK sends `text: { format: { type: "json_schema", ... } }` for structured output. This parameter was being stripped by the Codex allowlist, preventing the model from knowing it should return JSON in a specific schema.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `high` • Cost: `$N/A`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=high costs=N/A -->
