### PR TITLE
🤖 fix: recover workspace identity from conversational model responses

### DIFF
--- a/src/node/services/workspaceTitleGenerator.test.ts
+++ b/src/node/services/workspaceTitleGenerator.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { extractIdentityFromText } from "./workspaceTitleGenerator";
+
+describe("extractIdentityFromText", () => {
+  test("extracts from markdown bold + backtick format", () => {
+    const text = [
+      'Based on the development task "testing", here are my recommendations:',
+      "",
+      "**name:** `testing`",
+      "- Concise, git-safe (lowercase), and clearly identifies the codebase area",
+      "",
+      "**title:** `Improve test coverage`",
+      "- Follows the verb-noun format and describes the testing work generically",
+    ].join("\n");
+
+    const result = extractIdentityFromText(text);
+    expect(result).toEqual({ name: "testing", title: "Improve test coverage" });
+  });
+
+  test("extracts from embedded JSON object", () => {
+    const text =
+      'Here is the result: {"name": "sidebar", "title": "Fix sidebar layout"} as requested.';
+    const result = extractIdentityFromText(text);
+    expect(result).toEqual({ name: "sidebar", title: "Fix sidebar layout" });
+  });
+
+  test("extracts from JSON with reverse field order", () => {
+    const text = '{"title": "Add user auth", "name": "auth"}';
+    const result = extractIdentityFromText(text);
+    expect(result).toEqual({ name: "auth", title: "Add user auth" });
+  });
+
+  test("extracts from quoted values in prose", () => {
+    const text = 'The name: "config" and title: "Refactor config loading"';
+    const result = extractIdentityFromText(text);
+    expect(result).toEqual({ name: "config", title: "Refactor config loading" });
+  });
+
+  test("sanitizes name to be git-safe", () => {
+    const text = ["**name:** `My Feature`", "**title:** `Add cool feature`"].join("\n");
+    const result = extractIdentityFromText(text);
+    expect(result).toEqual({ name: "my-feature", title: "Add cool feature" });
+  });
+
+  test("returns null for empty text", () => {
+    expect(extractIdentityFromText("")).toBeNull();
+  });
+
+  test("returns null when only name is present", () => {
+    const text = "**name:** `testing`\nSome other content without title";
+    expect(extractIdentityFromText(text)).toBeNull();
+  });
+
+  test("returns null when only title is present", () => {
+    const text = "**title:** `Fix bugs`\nSome other content without name";
+    expect(extractIdentityFromText(text)).toBeNull();
+  });
+
+  test("returns null when name is too short after sanitization", () => {
+    const text = "**name:** `-`\n**title:** `Fix something here`";
+    expect(extractIdentityFromText(text)).toBeNull();
+  });
+
+  test("returns null when title is too short", () => {
+    const text = "**name:** `auth`\n**title:** `Fix`";
+    expect(extractIdentityFromText(text)).toBeNull();
+  });
+
+  test("returns null for completely unrelated text", () => {
+    const text = "I'm sorry, I cannot help with that request. Please try again.";
+    expect(extractIdentityFromText(text)).toBeNull();
+  });
+
+  test("handles the exact failing response from the bug report", () => {
+    // This is the exact text content from the claude-haiku response that triggered the bug.
+    // In the raw API response JSON, newlines are escaped as \n — once parsed they become
+    // real newline characters in the string that NoObjectGeneratedError.text carries.
+    const text = [
+      'Based on the development task "testing", here are my recommendations:',
+      "",
+      "**name:** `testing`",
+      "- Concise, git-safe (lowercase), and clearly identifies the codebase area",
+      "",
+      "**title:** `Improve test coverage`",
+      "- Follows the verb-noun format and describes the testing work generically",
+      "",
+      "These are suitable for a testing-focused development task.",
+    ].join("\n");
+
+    const result = extractIdentityFromText(text);
+    expect(result).toEqual({ name: "testing", title: "Improve test coverage" });
+  });
+});

--- a/src/node/services/workspaceTitleGenerator.ts
+++ b/src/node/services/workspaceTitleGenerator.ts
@@ -1,4 +1,4 @@
-import { streamText, Output } from "ai";
+import { NoObjectGeneratedError, streamText, Output } from "ai";
 import { z } from "zod";
 import type { AIService } from "./aiService";
 import { log } from "./log";
@@ -104,6 +104,8 @@ Requirements:
       });
 
       // Awaiting .output triggers full stream consumption and JSON parsing.
+      // If the model returned conversational text instead of JSON, this throws
+      // NoObjectGeneratedError — caught below with a text fallback parser.
       const output = await stream.output;
 
       const suffix = generateNameSuffix();
@@ -116,6 +118,27 @@ Requirements:
         modelUsed: modelString,
       });
     } catch (error) {
+      // Some models ignore the structured output instruction and return
+      // conversational text (e.g. "**name:** `testing`\n**title:** `Improve test coverage`").
+      // NoObjectGeneratedError carries the raw .text — try to extract name/title
+      // from it before giving up on this candidate.
+      if (NoObjectGeneratedError.isInstance(error) && error.text) {
+        const textFallback = extractIdentityFromText(error.text);
+        if (textFallback) {
+          log.info(
+            `Name generation: structured output failed for ${modelString}, recovered from text fallback`
+          );
+          const suffix = generateNameSuffix();
+          const sanitizedName = sanitizeBranchName(textFallback.name, 20);
+          const nameWithSuffix = `${sanitizedName}-${suffix}`;
+          return Ok({
+            name: nameWithSuffix,
+            title: textFallback.title,
+            modelUsed: modelString,
+          });
+        }
+      }
+
       // API error (invalid key, quota, network, etc.) - try next candidate
       lastApiError = error instanceof Error ? error.message : String(error);
       log.warn(`Name generation failed with ${modelString}, trying next candidate`, {
@@ -130,6 +153,60 @@ Requirements:
     ? `Name generation failed: ${lastApiError}`
     : "Name generation failed - no working model found";
   return Err({ type: "unknown", raw: errorMessage });
+}
+
+/**
+ * Fallback: extract name/title from conversational model text when structured
+ * JSON output parsing fails. Handles common patterns like:
+ *   **name:** `testing`          or  "name": "testing"
+ *   **title:** `Improve tests`   or  "title": "Improve tests"
+ *
+ * Returns null if either field cannot be reliably extracted.
+ */
+export function extractIdentityFromText(text: string): { name: string; title: string } | null {
+  // Try JSON extraction first (model may have embedded JSON in prose)
+  const jsonMatch = /\{[^}]*"name"\s*:\s*"([^"]+)"[^}]*"title"\s*:\s*"([^"]+)"[^}]*\}/.exec(text);
+  if (jsonMatch) {
+    return validateExtracted(jsonMatch[1], jsonMatch[2]);
+  }
+  // Also try reverse field order in JSON
+  const jsonMatchReverse = /\{[^}]*"title"\s*:\s*"([^"]+)"[^}]*"name"\s*:\s*"([^"]+)"[^}]*\}/.exec(
+    text
+  );
+  if (jsonMatchReverse) {
+    return validateExtracted(jsonMatchReverse[2], jsonMatchReverse[1]);
+  }
+
+  // Try markdown/prose patterns: **name:** `value` or name: "value"
+  // In bold markdown the colon sits inside the stars: **name:**
+  const nameMatch =
+    /\*?\*?name:\*?\*?\s*`([^`]+)`/i.exec(text) ?? /\bname:\s*"([^"]+)"/i.exec(text);
+  const titleMatch =
+    /\*?\*?title:\*?\*?\s*`([^`]+)`/i.exec(text) ?? /\btitle:\s*"([^"]+)"/i.exec(text);
+
+  if (nameMatch && titleMatch) {
+    return validateExtracted(nameMatch[1], titleMatch[1]);
+  }
+
+  return null;
+}
+
+/** Validate extracted values against the same constraints as the schema. */
+function validateExtracted(
+  rawName: string,
+  rawTitle: string
+): { name: string; title: string } | null {
+  const name = rawName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-+/g, "-");
+  const title = rawTitle.trim();
+
+  if (name.length < 2 || name.length > 20) return null;
+  if (title.length < 5 || title.length > 60) return null;
+
+  return { name, title };
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a text-based fallback parser to workspace title generation so it succeeds even when models ignore the `Output.object` structured output instruction and return conversational prose instead of JSON.

## Background

Some models (observed with `claude-haiku-4-5-20251001`) respond to the workspace identity generation prompt with conversational markdown like:

```
**name:** `testing`
**title:** `Improve test coverage`
```

instead of the expected JSON object. The AI SDK's `Output.object` parser throws `NoObjectGeneratedError` (with the raw text in `.text`), and the catch block previously only logged the error and moved to the next candidate — wasting valid data.

## Implementation

- In the catch block of `generateWorkspaceIdentity`, detect `NoObjectGeneratedError` and extract `name`/`title` from its `.text` property using `extractIdentityFromText()`
- The new `extractIdentityFromText()` function tries multiple extraction strategies in order:
  1. Embedded JSON objects (both field orders)
  2. Markdown bold + backtick patterns (`**name:** \`value\``)
  3. Quoted prose patterns (`name: "value"`)
- Extracted values are validated against the same constraints as the Zod schema (length, git-safe characters)
- Added 12 unit tests covering all extraction patterns, edge cases, and the exact failing response from the bug report

## Validation

- 12/12 unit tests pass
- `make typecheck` passes
- `make static-check` passes (lint, format, docs links, shellcheck)

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `high` • Cost: `$0.00`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=high costs=0.00 -->
