### PR TITLE
🤖 ci: run nightly benchmarks twice daily (peak + trough model load)

### DIFF
--- a/.github/workflows/nightly-terminal-bench.yml
+++ b/.github/workflows/nightly-terminal-bench.yml
@@ -2,8 +2,11 @@ name: Nightly Terminal-Bench
 
 on:
   schedule:
-    # Run full benchmark suite every night at midnight UTC
-    - cron: "0 0 * * *"
+    # Run twice daily, 12 h apart, at times representing peak and trough model load.
+    # 10:00 UTC (2 AM PT) – lowest US model usage (overnight)
+    # 22:00 UTC (2 PM PT) – highest US model usage (mid-afternoon business hours)
+    - cron: "0 10 * * *"
+    - cron: "0 22 * * *"
   workflow_dispatch:
     inputs:
       models:


### PR DESCRIPTION
## Summary

Run the nightly Terminal-Bench benchmark suite twice per day instead of once, at times chosen to maximize the difference in model API load between runs.

## Background

Running benchmarks at a single time of day means results only capture model performance under one load regime. By running at both peak and trough times, we can observe whether provider load affects benchmark scores.

## Implementation

Changed the cron schedule from a single daily run at midnight UTC to two runs 12 hours apart:

- **10:00 UTC (2 AM PT)** — trough: US overnight, minimal model API traffic
- **22:00 UTC (2 PM PT)** — peak: mid-afternoon US business hours, highest model API traffic

## Risks

Low. Doubles Daytona usage and API spend for nightly runs. No logic changes.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `high` • Cost: `$7.01`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=high costs=7.01 -->
