### PR TITLE
🤖 perf: reorder file_edit_insert params — guards before content

### DIFF
--- a/src/common/types/tools.ts
+++ b/src/common/types/tools.ts
@@ -112,11 +112,11 @@ export interface FileEditErrorResult extends ToolOutputUiOnlyFields {
 
 export interface FileEditInsertToolArgs {
   file_path: string;
-  content: string;
   /** Anchor text to insert before. Content will be placed immediately before this substring. */
   insert_before?: string;
   /** Anchor text to insert after. Content will be placed immediately after this substring. */
   insert_after?: string;
+  content: string;
 }
 
 // FileEditInsertToolResult derived from Zod schema (single source of truth)

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -713,7 +713,6 @@ export const TOOL_DEFINITIONS = {
     schema: z
       .object({
         file_path: FILE_EDIT_FILE_PATH,
-        content: z.string().describe("The content to insert"),
         insert_before: z
           .string()
           .min(1)
@@ -728,6 +727,7 @@ export const TOOL_DEFINITIONS = {
           .describe(
             "Anchor text to insert after. Content will be placed immediately after this substring."
           ),
+        content: z.string().describe("The content to insert"),
       })
       .refine((data) => !(data.insert_before !== undefined && data.insert_after !== undefined), {
         message: "Provide only one of insert_before or insert_after (not both).",


### PR DESCRIPTION
## Summary

Reorder `file_edit_insert` tool parameters so anchor guards (`insert_before`/`insert_after`) appear before `content` in the schema. This aligns with how all other edit tools are structured and should reduce malformed edits from LLMs.

## Background

LLMs produce better tool calls when anchor/matching parameters appear before content — the model "decides where" before "deciding what." Every other edit tool already follows this pattern:

| Tool | Parameter order |
|------|----------------|
| `file_edit_replace_string` | `file_path` → `old_string` → `new_string` → `replace_count` |
| `file_edit_replace_lines` | `file_path` → `start_line` → `end_line` → `new_lines` → `expected_lines` |
| **`file_edit_insert` (before)** | `file_path` → **`content`** → `insert_before` → `insert_after` |
| **`file_edit_insert` (after)** | `file_path` → `insert_before` → `insert_after` → **`content`** |

Property order in `z.object()` is preserved through the Zod → JSON Schema → provider API pipeline (confirmed via `zod3ToJsonSchema` `for…in` iteration), so this reorder directly affects what models see.

## Implementation

Two-file change, net zero LoC:
- **`src/common/utils/tools/toolDefinitions.ts`** — moved `insert_before`/`insert_after` before `content` in the Zod schema
- **`src/common/types/tools.ts`** — reordered `FileEditInsertToolArgs` interface to match

No changes needed to:
- Implementation (`file_edit_insert.ts`) — destructures by name
- Tests — all reference params by name
- PTC type generator — reads from Zod schema dynamically

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$48.85`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=48.85 -->
