### PR TITLE
🤖 fix: use correct AI SDK type "provider" for provider-native tools

### DIFF
--- a/src/common/utils/ai/cacheStrategy.test.ts
+++ b/src/common/utils/ai/cacheStrategy.test.ts
@@ -261,11 +261,12 @@ describe("cacheStrategy", () => {
     });
 
     it("should handle provider-defined tools without recreating them", () => {
-      // Provider-defined tools (like Anthropic's webSearch) have type: "provider-defined"
-      // and cannot be recreated with createTool() - they have special internal properties
+      // AI SDK uses type: "provider" for provider-native tools (e.g., Anthropic's webSearch_20250305).
+      // These cannot be recreated with createTool() - they have special internal properties
+      // like id, args, supportsDeferredResults that must be preserved.
       const providerDefinedTool = {
-        type: "provider-defined" as const,
-        id: "web_search",
+        type: "provider" as const,
+        id: "anthropic.web_search_20250305",
         name: "web_search_20250305",
         args: { maxUses: 1000 },
         // Note: no description or execute - these are handled internally by the SDK
@@ -297,7 +298,7 @@ describe("cacheStrategy", () => {
         type: string;
         providerOptions: unknown;
       };
-      expect(cachedWebSearch.type).toBe("provider-defined");
+      expect(cachedWebSearch.type).toBe("provider");
       expect(cachedWebSearch.providerOptions).toEqual({
         anthropic: { cacheControl: { type: "ephemeral" } },
       });

--- a/src/common/utils/ai/cacheStrategy.ts
+++ b/src/common/utils/ai/cacheStrategy.ts
@@ -156,7 +156,10 @@ export function applyCacheControlToTools<T extends Record<string, Tool>>(
       // with createTool() - they have special properties. Instead, spread providerOptions
       // directly onto the tool object. While this doesn't work for regular tools (SDK
       // requires providerOptions at creation time), provider-defined tools handle it.
-      const isProviderDefinedTool = (existingTool as { type?: string }).type === "provider-defined";
+      // AI SDK uses type: "provider" for provider-native tools (e.g., Anthropic's webSearch_20250305).
+      // If this check fails, the tool is reconstructed via createTool() which strips the provider
+      // identity — causing the API to treat it as a regular client-side tool with no server execution.
+      const isProviderDefinedTool = existingTool.type === "provider";
 
       if (isProviderDefinedTool) {
         // Provider-defined tools: add providerOptions directly (SDK handles it differently)

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -757,6 +757,7 @@ export class StreamManager extends EventEmitter {
     streamInfo: WorkspaceStreamInfo
   ): Promise<void> {
     if (!streamInfo.softInterrupt.pending) return;
+
     try {
       streamInfo.state = StreamState.STOPPING;
 


### PR DESCRIPTION
## Summary

Fix provider-native tools (`web_search`, `web_fetch`) silently aborting streams with zero errors or logs.

## Background

When using Anthropic's provider-native `web_search` tool, streams would abort silently — no errors logged, no `stream-error` event, just "Cleaned up temp dir" from the finally block. All tool calls remained in `state: "input-available"` with zero results. This was 100% reproducible.

## Root Cause

`applyCacheControlToTools` in `cacheStrategy.ts` checked for `type === "provider-defined"`, but the AI SDK uses `type === "provider"` for provider-native tools. This check always failed, causing the function to reconstruct the tool via `createTool()`, which stripped the provider identity (`type`, `id`, `args`, `supportsDeferredResults`).

The effect chain:
1. `applyCacheControlToTools` misidentifies `web_search` as a regular tool
2. Reconstructs it via `createTool()`, losing `type: "provider"` and `id: "anthropic.web_search_20250305"`
3. AI SDK serializes it as `{"type":"function", "name":"web_search", "input_schema":{...}}`
4. Anthropic API treats it as a client-side tool → returns `tool_use` blocks (`toolu_` prefix) instead of `server_tool_use` blocks (`srvtoolu_` prefix)
5. No `execute` function exists for provider-native tools → step ends immediately with `finishReason=tool-calls`
6. Stream finishes "successfully" with orphaned tool calls and zero results

## Implementation

One-line fix: `"provider-defined"` → `"provider"` in `cacheStrategy.ts:159`, plus test correction.

## Validation

- Confirmed fix works in Electron with `MUX_DEBUG=1`: tool call IDs now show `srvtoolu_` prefix, `tool-result` events arrive after search execution, and text response streams normally
- `bun test src/common/utils/ai/cacheStrategy.test.ts` — 17/17 pass
- Verified via standalone Bun script that the SDK works correctly outside Electron (isolating the issue to the cache control code path)
- Verified via curl that the Anthropic API returns results correctly with both thinking and non-thinking modes

## Risks

Low. The change only affects how `applyCacheControlToTools` handles provider-native tools — the fix makes it correctly preserve their identity via object spread instead of reconstructing them. All other tools (regular function tools) are unaffected since they take the `else` branch which remains unchanged.

---

<details>
<summary>📋 Implementation Plan</summary>

# Diagnose & Fix: `web_search`/`web_fetch` Silent Stream Abort

## Context & Goal

When an agent uses the provider-native `web_search` tool (Anthropic's `webSearch_20250305`), the
stream aborts silently — no errors logged, no `stream-error` event, just "Cleaned up temp dir" from
the `finally` block. All tool calls remain in `state: "input-available"` (no results ever arrive).
This is 100% reproducible (5/5 streams failed identically in the debug session).

**Goal:** Determine the exact root cause via targeted instrumentation, then fix it.

## What We've Eliminated

| Hypothesis | Status | Evidence |
|---|---|---|
| Anthropic API doesn't return results | ❌ Eliminated | curl test with thinking confirmed inline results |
| HTTP/fetch timeout | ❌ Eliminated | `bodyTimeout: 0, headersTimeout: 0` in `aiService.ts:140-143`; no `timeout` param to `streamText` |
| AI SDK default timeout | ❌ Eliminated | `getTotalTimeoutMs(undefined) → void 0`; no `AbortSignal.timeout()` created |
| Zod schema rejects `citations_delta` | ❌ Eliminated | `@ai-sdk/anthropic@3.0.37` fully handles `citations_delta` |
| Deferred results multi-step confusion | ❌ Eliminated | curl+thinking shows results arrive in same response |
| System1 wrapper interference | ❌ Eliminated | System1 only wraps `bash`/`bash_output`/`task_await` |

## Remaining Candidate Root Causes

### 🥇 External abort signal fires during search execution pause
Something triggers `abortController.abort()` while the SSE connection is idle waiting for
Anthropic to execute searches. Candidates: `ensureStreamSafety` (new stream replacing old),
soft interrupt, lifecycle event, or frontend disconnect.

### 🥈 Electron/Chromium networking stack drops idle SSE connections
Even though undici's `bodyTimeout` is 0, Electron's process-level networking may enforce its
own idle connection limits. The ~5-15s search execution pause on Anthropic's side could exceed
an internal threshold.

### 🥉 `prepareStep` callback throws during multi-step transition
The `extractToolMediaAsUserMessagesFromModelMessages` callback may not handle `server_tool_use`
content blocks, causing a silent step failure that ends the stream.

## Implementation Plan

### Phase 1: Instrumentation (pinpoint the cause) — ~+60 LoC

#### 1a. Log ALL `fullStream` events and stream exit state

**File:** `src/node/services/streamManager.ts` — `processStreamWithCleanup` method

At the top of the `for await` loop (after line 1311):
```typescript
for await (const part of streamInfo.streamResult.fullStream) {
  // === NEW: Log every stream event for debugging ===
  if (log.isDebugEnabled()) {
    const extra = 'toolCallId' in (part as any) ? ` toolCallId=${(part as any).toolCallId}` : '';
    log.debug(`[StreamManager] fullStream event: type=${(part as any).type}${extra}`);
  }
  // ... existing abort check at line 1314
```

After the `for await` loop exits (after line 1628, before `flushPartialWrite`):
```typescript
// === NEW: Detect orphaned tool calls ===
const orphanedTools = [...toolCalls.entries()].filter(([id]) => {
  const part = streamInfo.parts.find(
    (p) => p.type === 'dynamic-tool' && p.toolCall?.toolCallId === id
  );
  return part?.state === 'input-available';
});
if (orphanedTools.length > 0) {
  log.warn(
    `[StreamManager] ORPHANED tool calls (no results received):`,
    orphanedTools.map(([id, tc]) => `${tc.toolName}(${id})`).join(', ')
  );
}
log.warn(
  `[StreamManager] fullStream exhausted.`,
  `aborted=${streamInfo.abortController.signal.aborted}`,
  `reason=${String(streamInfo.abortController.signal.reason ?? 'none')}`,
  `parts=${streamInfo.parts.length}`,
  `toolCalls=${toolCalls.size}`
);
```

#### 1b. Log abort source with stack traces

**File:** `src/node/services/streamManager.ts` — `cancelStreamSafely` (~line 717) and `checkSoftCancelStream` (~line 755)

Add at the top of each:
```typescript
log.warn(`[StreamManager] ${methodName} called for ${workspaceId}`, new Error('abort stack').stack);
```

#### 1c. Log `finish-step` reason

In the `finish-step` handler (around line 1582), add after the existing usage tracking:
```typescript
log.debug(
  `[StreamManager] finish-step: finishReason=${(part as any).finishReason ?? 'unknown'}`,
  `usage=${JSON.stringify(finishStepPart.usage)}`
);
```

#### 1d. Fix dead-code `default` handler

The `emitToolCallDeltaIfPresent` (line 464) checks for `"tool-call-delta"` which doesn't exist
in AI SDK v6 (replaced by `tool-input-start/delta/end`). Replace the `default` case (line 1375):

```typescript
default: {
  // Log unhandled event types (AI SDK v6 has 23 types, we handle 13)
  // Known unhandled: source, tool-input-start/delta/end, reasoning-start,
  //                  file, tool-output-denied, tool-approval-request, abort, raw
  const eventType = (part as any).type;
  if (eventType !== 'raw' && eventType !== 'start') {
    log.debug(`[StreamManager] unhandled stream event: type=${eventType}`);
  }
  break;
}
```

### Phase 2: Standalone Reproduction Script — ~+30 LoC

Create `scripts/debug-web-search-stream.ts` to test the stream **outside Electron** using the
same AI SDK + Anthropic SDK versions. This isolates whether the issue is Electron-specific.

```typescript
import { streamText } from 'ai';
import { createAnthropic } from '@ai-sdk/anthropic';

const anthropic = createAnthropic({});
const result = streamText({
  model: anthropic('claude-opus-4-6'),
  thinking: { type: 'enabled', budgetTokens: 10000 },
  tools: {
    web_search: anthropic.tools.webSearch_20250305({ maxUses: 3 }),
  },
  messages: [{ role: 'user', content: 'What is the context window of Claude Opus 4?' }],
  maxSteps: 5,
});

for await (const part of result.fullStream) {
  const ts = new Date().toISOString();
  const extra = 'toolCallId' in part ? ` id=${part.toolCallId}` : '';
  console.log(`[${ts}] ${part.type}${extra}`);
}
console.log('✅ Stream finished successfully');
```

Run with: `ANTHROPIC_API_KEY=... bun run scripts/debug-web-search-stream.ts`

**Outcome interpretation:**
- ✅ Works in Bun → issue is Electron-specific (Phase 3 needed)
- ❌ Fails in Bun → issue is SDK-level (file SDK bug report)

### Phase 3: Electron-specific investigation (if Phase 2 succeeds)

If the standalone script works fine:

1. **Test with mitmproxy** to capture the raw HTTP traffic from the Electron app:
   ```bash
   mitmproxy --listen-port 8888 --mode regular
   # In another terminal:
   HTTPS_PROXY=http://localhost:8888 NODE_TLS_REJECT_UNAUTHORIZED=0 MUX_DEBUG=1 make start
   ```
   Look for: premature connection close during the search execution pause.

2. **Check Electron `net` module interference** — search for any Electron-level network
   interceptors, session handlers, or certificate policies that might affect long-lived SSE
   connections. Check `src/main.ts` and `src/preload.ts`.

3. **Test if `EnvHttpProxyAgent` (undici) is actually used** — Electron might bypass undici
   entirely and use Chromium's networking stack for `fetch()`. Add logging to confirm which
   fetch implementation runs:
   ```typescript
   // In defaultFetchWithUnlimitedTimeout (aiService.ts:159):
   log.debug('[FETCH] Using undici dispatcher, url=', String(input).slice(0, 80));
   ```

### Phase 4: Observability Improvements (independent of root cause) — ~+20 LoC

These should ship regardless since they address real gaps:

1. **Orphaned tool call detection** (from 1a above) — permanent `log.warn`
2. **`finishReason` logging** in `finish-step` handler (from 1c)
3. **Replace dead-code `default`** handler with meaningful logging (from 1d)

## Estimated Impact

- **Phase 1:** ~+60 LoC (instrumentation — some may be removed after diagnosis)
- **Phase 2:** ~+30 LoC (new script file)
- **Phase 3:** 0 LoC (manual investigation only)
- **Phase 4:** ~+20 LoC (permanent observability improvements)
- **Total net product code:** ~+20 LoC permanent (Phase 4), rest is diagnostic

## Execution Order

1. Phase 1 + Phase 4 in one commit (instrument + improve observability)
2. Phase 2 (standalone reproduction script)
3. Test: run `make start` with `MUX_DEBUG=1`, trigger web_search, read new logs
4. Test: run standalone script outside Electron
5. Based on results → Phase 3 if needed, or file SDK bug

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `anthropic:claude-opus-4-6` • Thinking: `max`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=max -->
