### PR TITLE
🤖 perf: reduce sidebar re-renders on workspace create/archive

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "./contexts/RouterContext";
 import { useNavigate } from "react-router-dom";
 import "./styles/globals.css";
 import { useWorkspaceContext, toWorkspaceSelection } from "./contexts/WorkspaceContext";
+import { MUX_HELP_CHAT_WORKSPACE_ID } from "@/common/constants/muxChat";
 import { useProjectContext } from "./contexts/ProjectContext";
 import type { WorkspaceSelection } from "./components/ProjectSidebar";
 import { LeftSidebar } from "./components/LeftSidebar";
@@ -287,6 +288,9 @@ function AppInner() {
       }),
     [projects, workspaceMetadata, workspaceRecency]
   );
+
+  // Pre-compute for the sidebar so it doesn't need WorkspaceMetadataContext
+  const muxChatProjectPath = workspaceMetadata.get(MUX_HELP_CHAT_WORKSPACE_ID)?.projectPath ?? null;
 
   const handleNavigateWorkspace = useCallback(
     (direction: "next" | "prev") => {
@@ -884,6 +888,7 @@ function AppInner() {
           onStartResize={leftSidebar.startResize}
           sortedWorkspacesByProject={sortedWorkspacesByProject}
           workspaceRecency={workspaceRecency}
+          muxChatProjectPath={muxChatProjectPath}
         />
         <div className="mobile-main-content flex min-w-0 flex-1 flex-col overflow-hidden">
           <WindowsToolchainBanner />

--- a/src/browser/components/LeftSidebar.tsx
+++ b/src/browser/components/LeftSidebar.tsx
@@ -13,6 +13,7 @@ interface LeftSidebarProps {
   onStartResize?: (e: React.MouseEvent) => void;
   sortedWorkspacesByProject: Map<string, FrontendWorkspaceMetadata[]>;
   workspaceRecency: Record<string, number>;
+  muxChatProjectPath: string | null;
 }
 
 export function LeftSidebar(props: LeftSidebarProps) {

--- a/src/browser/components/WorkspaceListItem.tsx
+++ b/src/browser/components/WorkspaceListItem.tsx
@@ -585,7 +585,11 @@ function RegularWorkspaceListItemInner(props: WorkspaceListItemProps) {
                   <span className="min-w-0 truncate">Archiving...</span>
                 </div>
               ) : (
-                <WorkspaceStatusIndicator workspaceId={workspaceId} fallbackModel={fallbackModel} />
+                <WorkspaceStatusIndicator
+                  workspaceId={workspaceId}
+                  fallbackModel={fallbackModel}
+                  isCreating={isCreating}
+                />
               )}
             </div>
           )}

--- a/src/browser/components/WorkspaceStatusIndicator.tsx
+++ b/src/browser/components/WorkspaceStatusIndicator.tsx
@@ -1,7 +1,6 @@
 import { useWorkspaceSidebarState } from "@/browser/stores/WorkspaceStore";
 import { ModelDisplay } from "@/browser/components/Messages/ModelDisplay";
 import { EmojiIcon } from "@/browser/components/icons/EmojiIcon";
-import { useWorkspaceContext } from "@/browser/contexts/WorkspaceContext";
 import { CircleHelp, ExternalLinkIcon } from "lucide-react";
 import { memo } from "react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "./ui/tooltip";
@@ -10,13 +9,12 @@ import { Button } from "./ui/button";
 export const WorkspaceStatusIndicator = memo<{
   workspaceId: string;
   fallbackModel: string;
-}>(({ workspaceId, fallbackModel }) => {
+  /** When true the workspace is still being provisioned (show "starting…"). Passed as
+   *  a prop so this component doesn't need to subscribe to the full WorkspaceContext. */
+  isCreating?: boolean;
+}>(({ workspaceId, fallbackModel, isCreating }) => {
   const { canInterrupt, isStarting, awaitingUserQuestion, currentModel, agentStatus } =
     useWorkspaceSidebarState(workspaceId);
-  const { workspaceMetadata } = useWorkspaceContext();
-
-  const metadata = workspaceMetadata.get(workspaceId);
-  const isCreating = metadata?.status === "creating";
 
   // Show prompt when ask_user_question is pending - make it prominent
   if (awaitingUserQuestion) {

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -1723,6 +1723,15 @@ export class WorkspaceStore {
   /**
    * Add a workspace and subscribe to its IPC events.
    */
+
+  /**
+   * Imperative metadata lookup — no React subscription. Safe to call from
+   * event handlers / callbacks without causing re-renders.
+   */
+  getWorkspaceMetadata(workspaceId: string): FrontendWorkspaceMetadata | undefined {
+    return this.workspaceMetadata.get(workspaceId);
+  }
+
   addWorkspace(metadata: FrontendWorkspaceMetadata): void {
     const workspaceId = metadata.id;
 


### PR DESCRIPTION
## Summary

Eliminates unnecessary sidebar re-render cascades triggered by workspace create/archive operations by splitting `WorkspaceContext` into separate metadata and actions contexts, and removing context subscriptions from leaf components that don't need them.

## Background

Every workspace operation (create, archive, rename) mutates the `workspaceMetadata` Map, which was bundled into a single `WorkspaceContext`. Since React Context doesn't support selectors, **every** consumer re-rendered on any metadata change — including the entire `ProjectSidebarInner` tree (every expanded project, every workspace row, every section header) and every mounted `WorkspaceStatusIndicator` instance.

The re-render cascade looked like:

```
workspaceMetadata Map changes
  → WorkspaceContext useMemo dependency fires
    → ALL useWorkspaceContext() consumers re-render (bypasses React.memo)
      → ProjectSidebarInner re-renders entire sidebar tree
      → Every mounted WorkspaceStatusIndicator re-renders
```

## Implementation

### 1. Remove `useWorkspaceContext()` from `WorkspaceStatusIndicator`
The parent `RegularWorkspaceListItemInner` already computes `isCreating` from `metadata.status`. Pass it as a prop instead of subscribing to the full context — eliminates N redundant context re-renders (one per visible workspace).

### 2. Split `WorkspaceContext` into metadata + actions contexts
- **`WorkspaceMetadataContext`** — holds `{ workspaceMetadata, loading }` (changes on every workspace op)
- **`WorkspaceActionsContext`** — holds everything else: selection, drafts, stable callbacks (changes only on selection/draft ops)
- Backward-compatible `useWorkspaceContext()` merges both; new `useWorkspaceActions()` and `useWorkspaceMetadata()` hooks allow targeted subscriptions

### 3. Decouple `ProjectSidebarInner` from metadata context
- Switch from `useWorkspaceContext()` to `useWorkspaceActions()` — no metadata subscription
- Add `WorkspaceStore.getWorkspaceMetadata(id)` for imperative reads in click handlers (no subscription)
- Pass `muxChatProjectPath` as a prop from `App.tsx` instead of reading from context

### 4. Fix `new Set()` instability
Replace `new Set(expandedProjectsArray)` with `Array.includes()` — the React Compiler cannot stabilize `Set` allocations (per AGENTS.md). For typical sidebar sizes (< 20 projects) the performance is equivalent.

### After the fix

```
workspaceMetadata Map changes
  → WorkspaceMetadataContext changes
    → App.tsx re-renders → useStableReference catches unchanged sort → no sidebar re-render
  → WorkspaceActionsContext is STABLE
    → ProjectSidebarInner does NOT re-render ✅
    → WorkspaceStatusIndicator does NOT re-render ✅
```

## Risks

- **Low:** `useWorkspaceContext()` remains backward-compatible (merges both contexts), so existing consumers outside the sidebar are unaffected.
- **Low:** `WorkspaceStore.getWorkspaceMetadata()` reads from the store's internal metadata Map which is already kept in sync via `addWorkspace()`/`syncWorkspaces()`.
- **Low:** `muxChatProjectPath` is now a prop from `App.tsx` — derived from the same metadata Map that `App.tsx` already subscribes to.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `high` • Cost: `$117.32`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=high costs=117.32 -->
