### PR TITLE
🤖 fix: disable UI-only tools in mux run CLI mode

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -601,7 +601,16 @@ async function main(): Promise<number> {
     providerOptions: {
       openai: { serviceTier: opts.serviceTier },
     },
-    // toolPolicy is computed by backend from agent definitions (resolveToolPolicyForAgent)
+    // Disable UI-only tools that have no effect in CLI mode:
+    // - status_set: backend no-op, status indicator only visible in desktop UI
+    // - todo_write/todo_read: TODO list only visible in desktop UI
+    // - notify: sends OS notifications via Electron, silently swallowed in CLI
+    toolPolicy: [
+      { regex_match: "status_set", action: "disable" as const },
+      { regex_match: "todo_write", action: "disable" as const },
+      { regex_match: "todo_read", action: "disable" as const },
+      { regex_match: "notify", action: "disable" as const },
+    ],
     // Plan agent instructions are handled by the backend (has access to plan file path)
   });
 


### PR DESCRIPTION
## Summary

Disables four UI-only tools in `mux run` that waste tool calls because they have no visible effect in CLI mode.

## Background

When running `mux run`, the agent has access to all the same tools as in the desktop app. Several of these tools only affect the desktop UI and are either backend no-ops or silently swallowed in CLI:

| Tool | Why it's useless in CLI |
|------|------------------------|
| `status_set` | Backend no-op — sets a persistent status indicator only visible in the desktop UI |
| `todo_write` | Writes a TODO list that's only displayed in the desktop UI sidebar |
| `todo_read` | Reads that same invisible TODO list |
| `notify` | Sends OS notifications via Electron; silently swallowed when Electron isn't running |

Each call wastes a tool round-trip and tokens on schema/description.

## Implementation

Added a `toolPolicy` to `buildSendOptions` in `src/cli/run.ts` that disables these four tools. The caller-supplied `toolPolicy` is merged *after* the agent-defined policy (last-match-wins), so these disables take precedence regardless of the agent definition's allowlist.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `high` • Cost: `$0`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=high costs=0 -->
