### PR TITLE
🤖 bench: fix token tracking for Terminal-Bench runs

### DIFF
--- a/benchmarks/terminal_bench/mux-run.sh
+++ b/benchmarks/terminal_bench/mux-run.sh
@@ -98,8 +98,8 @@ fi
 
 # Extract usage and cost from the JSONL output.
 # Prefer the run-complete event (emitted at end of --json run) which has aggregated
-# totals. Fall back to summing usage-delta events when run-complete is missing
-# (e.g. process killed by timeout, stdout not flushed before exit).
+# totals. Fall back to summing usage-delta + session-usage-delta events when
+# run-complete is missing (e.g. process killed by timeout, stdout not flushed).
 python3 -c '
 import json, sys
 result = {"input": 0, "output": 0, "cost_usd": None}
@@ -107,6 +107,11 @@ result = {"input": 0, "output": 0, "cost_usd": None}
 # Each usage-delta contains cumulative totals for its message, so we keep the
 # latest per message and sum across messages at the end.
 cumulative_by_msg = {}
+# Track sub-agent usage from session-usage-delta events. These carry per-model
+# byModelDelta dicts with {input: {tokens, cost_usd}, output: {tokens, cost_usd}, ...}.
+# Each event is an incremental delta, so we sum them all.
+subagent_input = 0
+subagent_output = 0
 for line in open(sys.argv[1]):
     try:
         obj = json.loads(line)
@@ -121,13 +126,22 @@ for line in open(sys.argv[1]):
         payload = obj.get("payload") or obj
         if payload.get("type") == "usage-delta":
             msg_id = payload.get("messageId", "")
-            usage = payload.get("usage") or payload.get("cumulativeUsage") or {}
+            # Prefer cumulativeUsage (running total across all steps in a message)
+            # over usage (per-step delta). Keeping the latest cumulative per message
+            # gives the correct total when summed across messages.
+            usage = payload.get("cumulativeUsage") or payload.get("usage") or {}
             cumulative_by_msg[msg_id] = usage
+        elif payload.get("type") == "session-usage-delta":
+            for model_usage in (payload.get("byModelDelta") or {}).values():
+                subagent_input += (model_usage.get("input") or {}).get("tokens", 0)
+                subagent_output += (model_usage.get("output") or {}).get("tokens", 0)
     except Exception:
         pass
-# No run-complete found — aggregate the last usage-delta per message
+# No run-complete found — aggregate the last usage-delta per message + sub-agent totals
 for usage in cumulative_by_msg.values():
     result["input"] += (usage.get("inputTokens", 0) or 0)
     result["output"] += (usage.get("outputTokens", 0) or 0)
+result["input"] += subagent_input
+result["output"] += subagent_output
 print(json.dumps(result))
 ' "${MUX_OUTPUT_FILE}" > "${MUX_TOKEN_FILE}" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Fixes token usage tracking for Terminal-Bench benchmark runs. In the Opus 4.6 run (21764435584), **69/89 tasks reported 0 tokens** despite completing successfully. After this fix, **77/89 tasks** correctly report non-zero token usage.

## Background

The `mux run --json` CLI emits a `run-complete` event at the end with aggregated usage/cost data. The benchmark harness (`mux-run.sh`) extracts tokens from this event for BigQuery reporting. However, two issues caused most tasks to miss it:

1. **Stdout flush race**: `process.exit()` terminates immediately, dropping buffered stdout writes. The `run-complete` line — the very last output — was frequently lost when piped through `tee`.
2. **No fallback**: When `run-complete` was missing (timeout kills, flush failures), the extraction script yielded `{"input": 0, "output": 0}` with no fallback.

## Implementation

### 1. Flush stdout before exit (`src/cli/run.ts`)
Check `process.stdout.writableNeedDrain` before calling `process.exit()`. If the write buffer hasn't drained, wait for the `drain` event first. This ensures the `run-complete` JSON line survives through pipes.

### 2. Usage-delta fallback (`benchmarks/terminal_bench/mux-run.sh`)
When `run-complete` is absent, aggregate `usage-delta` events as a fallback. Each `usage-delta` carries cumulative per-message totals, so we keep the latest per `messageId` and sum across messages. This correctly captures tokens even for tasks killed by timeout.

## Validation

Tested the new extraction logic against all 89 tasks from run 21764435584:
- **Before**: 20/89 tasks had non-zero tokens
- **After**: 77/89 tasks have non-zero tokens
- Remaining 12: 11 AgentTimeoutError (no stdout captured) + 1 DaytonaError

Example outputs:
- `chess-best-move` (no run-complete): `{"input": 30323, "output": 386}` ✅ (was 0/0)
- `bn-fit-modify` (has run-complete): `{"input": 12, "output": 6638, "cost_usd": 0.29}` ✅ (unchanged)
- `protein-assembly` (sub-agents): `{"input": 100771, "output": 773}` ✅ (was 0/0)

## Opus 4.6 Run Analysis (21764435584)

For reference, here are the full results from the benchmark run that exposed this issue:

| Metric | Value |
|--------|-------|
| **Mean Score** | 0.573 (57.3%) |
| **Passed** | 51/89 |
| **Failed (score 0)** | 37/89 |
| **AgentTimeoutError** | 11 |
| **DaytonaError** | 1 |
| **AgentSetupTimeoutError** | 0 ✅ |
| **Sub-agent usage** | 9/89 tasks (10%) |

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `max` • Cost: `$74.41`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=max costs=74.41 -->
