### PR TITLE
🤖 fix: reorder settings to place Models after Providers

### DIFF
--- a/src/browser/components/Settings/SettingsModal.tsx
+++ b/src/browser/components/Settings/SettingsModal.tsx
@@ -51,6 +51,12 @@ const BASE_SECTIONS: SettingsSection[] = [
     component: ProvidersSection,
   },
   {
+    id: "models",
+    label: "Models",
+    icon: <Cpu className="h-4 w-4" />,
+    component: ModelsSection,
+  },
+  {
     id: "mcp",
     label: "MCP",
     icon: <Server className="h-4 w-4" />,
@@ -61,12 +67,6 @@ const BASE_SECTIONS: SettingsSection[] = [
     label: "Secrets",
     icon: <Lock className="h-4 w-4" />,
     component: SecretsSection,
-  },
-  {
-    id: "models",
-    label: "Models",
-    icon: <Cpu className="h-4 w-4" />,
-    component: ModelsSection,
   },
   {
     id: "layouts",


### PR DESCRIPTION
## Summary

Moves the **Models** section to appear directly after **Providers** in the settings sidebar, grouping related configuration together.

## Background

Models and Providers are closely related — providers supply the API keys that models use. Having them adjacent makes the settings flow more intuitive.

**Before:** General → Agents → Providers → MCP → Secrets → Models → …
**After:** General → Agents → Providers → Models → MCP → Secrets → …

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$0.08`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=0.08 -->
