### PR TITLE
🤖 feat: add gpt-5.3-codex as known model for OpenAI OAuth

### DIFF
--- a/docs/config/models.mdx
+++ b/docs/config/models.mdx
@@ -19,6 +19,7 @@ Mux ships with curated models kept up to date with the frontier. Use any custom 
 | GPT-5.2                | openai:gpt-5.2                | `gpt`                                    |         |
 | GPT-5.2 Pro            | openai:gpt-5.2-pro            | `gpt-pro`                                |         |
 | GPT-5.2 Codex          | openai:gpt-5.2-codex          | `codex`                                  |         |
+| GPT-5.3 Codex          | openai:gpt-5.3-codex          | `codex-5.3`                              |         |
 | GPT-5.1 Codex          | openai:gpt-5.1-codex          | `codex-5.1`                              |         |
 | GPT-5.1 Codex Mini     | openai:gpt-5.1-codex-mini     | `codex-mini`                             |         |
 | GPT-5.1 Codex Max      | openai:gpt-5.1-codex-max      | `codex-max`                              |         |

--- a/src/common/constants/knownModels.ts
+++ b/src/common/constants/knownModels.ts
@@ -65,6 +65,13 @@ const MODEL_DEFINITIONS = {
     warm: true,
     tokenizerOverride: "openai/gpt-5",
   },
+  GPT_53_CODEX: {
+    provider: "openai",
+    providerModelId: "gpt-5.3-codex",
+    aliases: ["codex-5.3"],
+    warm: true,
+    tokenizerOverride: "openai/gpt-5",
+  },
   GPT_CODEX: {
     provider: "openai",
     providerModelId: "gpt-5.1-codex",

--- a/src/common/utils/thinking/policy.ts
+++ b/src/common/utils/thinking/policy.ts
@@ -26,6 +26,7 @@ export type ThinkingPolicy = readonly ThinkingLevel[];
  * Rules:
  * - openai:gpt-5.1-codex-max → ["off", "low", "medium", "high", "xhigh"] (5 levels including xhigh)
  * - openai:gpt-5.2-codex → ["off", "low", "medium", "high", "xhigh"] (5 levels including xhigh)
+ * - openai:gpt-5.3-codex → ["off", "low", "medium", "high", "xhigh"] (5 levels including xhigh)
  * - openai:gpt-5.2 → ["off", "low", "medium", "high", "xhigh"] (5 levels including xhigh)
  * - openai:gpt-5.2-pro → ["medium", "high", "xhigh"] (3 levels)
  * - openai:gpt-5-pro → ["high"] (only supported level, legacy)
@@ -57,8 +58,8 @@ export function getThinkingPolicyForModel(modelString: string): ThinkingPolicy {
     return ["off", "low", "medium", "high", "xhigh"];
   }
 
-  // GPT-5.2-Codex supports 5 reasoning levels including xhigh (Extra High)
-  if (/^gpt-5\.2-codex(?!-[a-z])/.test(withoutProviderNamespace)) {
+  // GPT-5.2-Codex and GPT-5.3-Codex support 5 reasoning levels including xhigh (Extra High)
+  if (/^gpt-5\.[23]-codex(?!-[a-z])/.test(withoutProviderNamespace)) {
     return ["off", "low", "medium", "high", "xhigh"];
   }
 

--- a/src/common/utils/tokens/models-extra.ts
+++ b/src/common/utils/tokens/models-extra.ts
@@ -94,6 +94,21 @@ export const modelsExtra: Record<string, ModelData> = {
     supports_response_schema: true,
   },
 
+  // GPT-5.3-Codex - same pricing as gpt-5.2-codex
+  "gpt-5.3-codex": {
+    max_input_tokens: 272000,
+    max_output_tokens: 128000,
+    input_cost_per_token: 0.00000175, // $1.75 per million input tokens
+    output_cost_per_token: 0.000014, // $14 per million output tokens
+    cache_read_input_token_cost: 0.000000175, // $0.175 per million cached input tokens
+    litellm_provider: "openai",
+    mode: "responses",
+    supports_function_calling: true,
+    supports_vision: true,
+    supports_reasoning: true,
+    supports_response_schema: true,
+  },
+
   // GPT-5.2 Pro - Released December 11, 2025
   // $21/M input, $168/M output
   // Supports medium, high, xhigh reasoning levels


### PR DESCRIPTION
## Summary

Adds `gpt-5.3-codex` as a known model so it automatically appears in the model picker when a user logs in with OpenAI OAuth.

## Background

`gpt-5.3-codex` was already listed in `CODEX_OAUTH_ALLOWED_MODELS` and `CODEX_OAUTH_REQUIRED_MODELS` but was missing from `KNOWN_MODELS`, pricing data, and thinking policy — so it wouldn't show up in the model selector.

## Implementation

- Added `GPT_53_CODEX` entry to `KNOWN_MODELS` in `knownModels.ts` with alias `codex-5.3`
- Added pricing data in `models-extra.ts` (same as gpt-5.2-codex)
- Extended thinking policy regex to cover `gpt-5.[23]-codex` (supports off/low/medium/high/xhigh)
- Regenerated `docs/config/models.mdx` via `make fmt`

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `off` • Cost: `$N/A`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=off costs=N/A -->
