### PR TITLE
🤖 fix: show max label for Opus reasoning in Settings

### DIFF
--- a/src/browser/components/Settings/sections/System1Section.tsx
+++ b/src/browser/components/Settings/sections/System1Section.tsx
@@ -27,7 +27,11 @@ import {
   type TaskSettings,
 } from "@/common/types/tasks";
 import { enforceThinkingPolicy, getThinkingPolicyForModel } from "@/common/utils/thinking/policy";
-import { THINKING_LEVELS, coerceThinkingLevel } from "@/common/types/thinking";
+import {
+  THINKING_LEVELS,
+  coerceThinkingLevel,
+  getThinkingOptionLabel,
+} from "@/common/types/thinking";
 
 import { SearchableModelSelect } from "../components/SearchableModelSelect";
 
@@ -345,7 +349,7 @@ export function System1Section() {
                 <SelectContent>
                   {allowedThinkingLevels.map((level) => (
                     <SelectItem key={level} value={level}>
-                      {level}
+                      {getThinkingOptionLabel(level, effectiveSystem1ModelStringForThinking)}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/src/browser/components/Settings/sections/TasksSection.tsx
+++ b/src/browser/components/Settings/sections/TasksSection.tsx
@@ -30,7 +30,7 @@ import {
   normalizeTaskSettings,
   type TaskSettings,
 } from "@/common/types/tasks";
-import type { ThinkingLevel } from "@/common/types/thinking";
+import { getThinkingOptionLabel, type ThinkingLevel } from "@/common/types/thinking";
 import { enforceThinkingPolicy, getThinkingPolicyForModel } from "@/common/utils/thinking/policy";
 
 const INHERIT = "__inherit__";
@@ -750,7 +750,7 @@ export function TasksSection() {
                 <SelectItem value={INHERIT}>Inherit</SelectItem>
                 {allowedThinkingLevels.map((level) => (
                   <SelectItem key={level} value={level}>
-                    {level}
+                    {getThinkingOptionLabel(level, effectiveModel)}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -817,7 +817,7 @@ export function TasksSection() {
                 <SelectItem value={INHERIT}>Inherit</SelectItem>
                 {allowedThinkingLevels.map((level) => (
                   <SelectItem key={level} value={level}>
-                    {level}
+                    {getThinkingOptionLabel(level, effectiveModel)}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/src/common/types/thinking.test.ts
+++ b/src/common/types/thinking.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, test } from "bun:test";
 import {
   coerceThinkingLevel,
   getThinkingDisplayLabel,
-  parseThinkingInput,
+  getThinkingOptionLabel,
   MAX_THINKING_INDEX,
+  parseThinkingInput,
 } from "./thinking";
 
 describe("getThinkingDisplayLabel", () => {
@@ -31,6 +32,21 @@ describe("getThinkingDisplayLabel", () => {
     expect(getThinkingDisplayLabel("low", "anthropic:claude-opus-4-6")).toBe("LOW");
     expect(getThinkingDisplayLabel("medium", "anthropic:claude-opus-4-6")).toBe("MED");
     expect(getThinkingDisplayLabel("high", "anthropic:claude-opus-4-6")).toBe("HIGH");
+  });
+});
+
+describe("getThinkingOptionLabel", () => {
+  test("renders max for xhigh on Anthropic models", () => {
+    expect(getThinkingOptionLabel("xhigh", "anthropic:claude-opus-4-6")).toBe("max");
+  });
+
+  test("renders xhigh for xhigh/max on OpenAI models", () => {
+    expect(getThinkingOptionLabel("xhigh", "openai:gpt-5.2")).toBe("xhigh");
+    expect(getThinkingOptionLabel("max", "openai:gpt-5.2")).toBe("xhigh");
+  });
+
+  test("preserves non-xhigh labels", () => {
+    expect(getThinkingOptionLabel("medium", "anthropic:claude-opus-4-6")).toBe("medium");
   });
 });
 

--- a/src/common/types/thinking.ts
+++ b/src/common/types/thinking.ts
@@ -39,6 +39,20 @@ export function getThinkingDisplayLabel(level: ThinkingLevel, modelString?: stri
 }
 
 /**
+ * UI option label for thinking levels.
+ *
+ * Settings dropdowns use lowercase labels for most levels, but xhigh/max should
+ * remain provider-aware to match the model's terminology.
+ */
+export function getThinkingOptionLabel(level: ThinkingLevel, modelString?: string): string {
+  if (level !== "xhigh" && level !== "max") {
+    return level;
+  }
+
+  return getThinkingDisplayLabel(level, modelString) === "XHIGH" ? "xhigh" : "max";
+}
+
+/**
  * Reverse mapping from display labels/aliases to internal ThinkingLevel values.
  * Accepts both canonical names and shorthand aliases (e.g., "med" → "medium").
  */


### PR DESCRIPTION
Summary
This PR makes Settings reasoning dropdown labels provider-aware for xhigh/max so Opus 4.6 displays `max` instead of the raw internal `xhigh` value.

Background
We store `xhigh` internally for policy consistency, but Anthropic Opus 4.6 should present that level to users as `max`. Settings was previously rendering raw level values, which exposed provider-internal terminology and made the UI inconsistent.

Implementation
- Added `getThinkingOptionLabel(level, modelString?)` in `src/common/types/thinking.ts`.
- Updated Settings reasoning dropdown labels to use the helper in:
  - `TasksSection` (agent defaults + unknown agent defaults)
  - `System1Section`
- Added tests in `src/common/types/thinking.test.ts` validating provider-aware option labels.

Validation
- `bun test src/common/types/thinking.test.ts`
- `make static-check`

Risks
Low risk. The change only affects displayed label text in Settings dropdown options; stored values and policy enforcement remain unchanged.

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Show `max` for Opus 4.6 reasoning in Settings

## Context / Why
The Settings UI currently renders reasoning option labels directly from raw policy values (`off`, `low`, `medium`, `high`, `xhigh`). For Anthropic Opus 4.6 this is misleading, because internally we store `xhigh` but present it to users as **max**. The screenshot shows this mismatch in the Task agent defaults UI (`xhigh` selected for Opus 4.6).

User impact: people configuring agents in Settings see provider-internal terminology instead of the product label they expect, which makes reasoning choices look inconsistent across the app.

## Evidence
- `src/browser/components/Settings/sections/TasksSection.tsx` renders reasoning options with `{level}` in both agent cards and unknown-agent cards, so Opus 4.6 shows `xhigh` literally.
- `src/browser/components/Settings/sections/System1Section.tsx` uses the same raw `{level}` rendering for System 1 reasoning.
- `src/common/types/thinking.ts` already has provider-aware label logic (`getThinkingDisplayLabel`), proving we already distinguish OpenAI `XHIGH` vs Anthropic `MAX`.
- `src/common/types/thinking.test.ts` already validates provider-aware display behavior for `xhigh/max`.

These files are sufficient to plan the fix because they cover: (1) where labels are rendered in Settings, and (2) existing canonical label semantics.

## Recommended approach (net LoC estimate: **+20 to +30 product LoC**)

1. **Add a UI-facing option-label helper in `src/common/types/thinking.ts`** that preserves existing lowercase option style for normal levels but remaps `xhigh/max` provider-aware:
   - OpenAI model strings => `xhigh`
   - Anthropic/default => `max`
   - Keep storage values unchanged (`xhigh` stays the value for Opus 4.6 policy)

   ```ts
   export function getThinkingOptionLabel(level: ThinkingLevel, modelString?: string): string {
     if (level !== "xhigh" && level !== "max") {
       return level;
     }

     const display = getThinkingDisplayLabel(level, modelString);
     return display === "XHIGH" ? "xhigh" : "max";
   }
   ```

2. **Update Settings dropdown renderers to use the helper for label text only** (not values):
   - `src/browser/components/Settings/sections/TasksSection.tsx`
     - `renderAgentDefaults`
     - `renderUnknownAgentDefaults`
   - `src/browser/components/Settings/sections/System1Section.tsx`

   ```tsx
   {allowedThinkingLevels.map((level) => (
     <SelectItem key={level} value={level}>
       {getThinkingOptionLabel(level, effectiveModel)}
     </SelectItem>
   ))}
   ```

   For `System1Section`, pass `effectiveSystem1ModelStringForThinking` as the model context.

3. **Add focused regression tests in `src/common/types/thinking.test.ts`** for the new helper:
   - `xhigh` + Opus 4.6 => `max`
   - `xhigh` + OpenAI model => `xhigh`
   - non-`xhigh` levels remain unchanged (`medium` => `medium`)

4. **Verification**
   - Run: `bun test src/common/types/thinking.test.ts`
   - Manually verify in Settings:
     - Agent defaults (Tasks section), Opus 4.6 model shows `max` in Reasoning dropdown/selected value.
     - OpenAI reasoning-capable model still shows `xhigh`.
     - System 1 reasoning dropdown follows the same behavior.

<details>
<summary>Why this approach</summary>

- It keeps persisted/config values and provider option mapping untouched (low risk).
- It aligns all Settings reasoning selectors with existing provider-aware label semantics already defined in `thinking.ts`.
- It avoids a brittle one-off special case in a single component and prevents the same mismatch in System1 settings.

</details>

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: $0.00_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.00 -->
