### PR TITLE
🤖 fix: ellipsize titlebar version text in sidebar header

### DIFF
--- a/src/browser/components/TitleBar.tsx
+++ b/src/browser/components/TitleBar.tsx
@@ -254,7 +254,7 @@ export function TitleBar() {
     >
       <div
         className={cn(
-          "mr-4 flex min-w-0",
+          "mr-4 flex min-w-0 flex-1",
           leftInset > 0 ? "flex-col" : "items-center gap-2",
           isDesktop && "titlebar-no-drag"
         )}
@@ -263,7 +263,9 @@ export function TitleBar() {
           <TooltipTrigger asChild>
             <div
               className={cn(
-                "flex items-center gap-1.5",
+                // Keep the version row shrinkable so long git-describe values ellipsize
+                // instead of overlapping the gateway/settings controls.
+                "flex min-w-0 max-w-full items-center gap-1.5",
                 isUpdateActionable ? "cursor-pointer hover:opacity-70" : "cursor-default"
               )}
               onClick={handleUpdateClick}
@@ -271,7 +273,7 @@ export function TitleBar() {
             >
               <div
                 className={cn(
-                  "min-w-0 cursor-text truncate font-normal tracking-wider select-text",
+                  "min-w-0 flex-1 cursor-text truncate font-normal tracking-wider select-text",
                   leftInset > 0 ? "text-[10px]" : "text-xs"
                 )}
               >
@@ -289,7 +291,7 @@ export function TitleBar() {
           </TooltipContent>
         </Tooltip>
       </div>
-      <div className={cn("flex items-center gap-1.5", isDesktop && "titlebar-no-drag")}>
+      <div className={cn("flex shrink-0 items-center gap-1.5", isDesktop && "titlebar-no-drag")}>
         {gateway.isActive && (
           <Tooltip>
             <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary
Constrain the top-left version text in the sidebar title bar so long `git describe` strings truncate with an ellipsis instead of running into the Mux Gateway / Settings controls.

## Background
When version identifiers are long, the title-bar text could consume too much horizontal space and visually collide with the action icons on the right. The header should preserve those controls and ellipsize the version label first.

## Implementation
- Made the left title-bar section grow/shrink with `flex-1 min-w-0`.
- Made the version row itself shrinkable (`min-w-0 max-w-full`) and the version text `flex-1 truncate`.
- Marked the right icon cluster as `shrink-0` so gateway/settings controls keep their size.
- Added an inline comment explaining the rationale for the shrink/ellipsis behavior.

## Validation
- `make static-check` (passes)

## Risks
Low risk. Change is limited to title-bar layout classes in `TitleBar.tsx`; no behavior changes outside visual overflow handling.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$n/a`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=n/a -->
