### PR TITLE
🤖 fix: normalize mux gateway usage from v2 flat to v3 nested format

### DIFF
--- a/src/node/services/providerModelFactory.ts
+++ b/src/node/services/providerModelFactory.ts
@@ -24,6 +24,10 @@ import type { CodexOauthService } from "@/node/services/codexOauthService";
 import { normalizeGatewayModel, supports1MContext } from "@/common/utils/ai/models";
 import { MUX_APP_ATTRIBUTION_TITLE, MUX_APP_ATTRIBUTION_URL } from "@/constants/appAttribution";
 import { resolveProviderCredentials } from "@/node/utils/providerRequirements";
+import {
+  normalizeGatewayStreamUsage,
+  normalizeGatewayGenerateResult,
+} from "@/node/utils/gatewayStreamNormalization";
 import { EnvHttpProxyAgent, type Dispatcher } from "undici";
 
 // ---------------------------------------------------------------------------
@@ -1014,7 +1018,35 @@ export class ProviderModelFactory {
           baseURL: gatewayBaseURL,
           fetch: fetchWithAutoLogout,
         });
-        return Ok(gateway(modelId));
+        const model = gateway(modelId);
+
+        // Normalize usage format from the gateway server.
+        // The gateway SDK declares specificationVersion "v3", so the AI SDK core
+        // expects nested v3 usage: { inputTokens: { total, ... }, outputTokens: { total, ... } }.
+        // However the gateway server may return flat v2-style usage
+        // (e.g. { inputTokens: 123, outputTokens: 456 }), causing
+        // asLanguageModelUsage to produce undefined → 0 for all token counts.
+        // These wrappers detect flat usage and convert to v3 nested format.
+        const originalDoStream = model.doStream.bind(model);
+        model.doStream = async (options) => {
+          const result = await originalDoStream(options);
+          return {
+            ...result,
+            // Type assertion safe: the transform only modifies the shape of usage/finishReason
+            // fields within existing chunks, it doesn't change the stream part types.
+            stream: result.stream.pipeThrough(
+              normalizeGatewayStreamUsage()
+            ) as typeof result.stream,
+          };
+        };
+
+        const originalDoGenerate = model.doGenerate.bind(model);
+        model.doGenerate = async (options) => {
+          const result = await originalDoGenerate(options);
+          return normalizeGatewayGenerateResult(result);
+        };
+
+        return Ok(model);
       }
 
       // GitHub Copilot — OpenAI-compatible with custom auth headers

--- a/src/node/utils/gatewayStreamNormalization.test.ts
+++ b/src/node/utils/gatewayStreamNormalization.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from "bun:test";
+import {
+  isV3Usage,
+  flatUsageToV3,
+  normalizeFinishReason,
+  normalizeGatewayGenerateResult,
+  normalizeGatewayStreamUsage,
+  type V3Usage,
+} from "./gatewayStreamNormalization";
+
+describe("isV3Usage", () => {
+  it("returns true for v3 nested usage", () => {
+    expect(
+      isV3Usage({
+        inputTokens: { total: 100 },
+        outputTokens: { total: 50 },
+      })
+    ).toBe(true);
+  });
+
+  it("returns false for flat v2 usage", () => {
+    expect(isV3Usage({ inputTokens: 100, outputTokens: 50 })).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isV3Usage(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isV3Usage(undefined)).toBe(false);
+  });
+
+  it("returns false for non-object", () => {
+    expect(isV3Usage("string")).toBe(false);
+    expect(isV3Usage(42)).toBe(false);
+  });
+});
+
+describe("flatUsageToV3", () => {
+  it("converts basic flat usage to v3 nested format", () => {
+    const result = flatUsageToV3({
+      inputTokens: 1000,
+      outputTokens: 500,
+    });
+
+    expect(result.inputTokens.total).toBe(1000);
+    expect(result.outputTokens.total).toBe(500);
+    expect(result.raw).toEqual({ inputTokens: 1000, outputTokens: 500 });
+  });
+
+  it("handles cached input tokens", () => {
+    const result = flatUsageToV3({
+      inputTokens: 1000,
+      outputTokens: 500,
+      cachedInputTokens: 300,
+    });
+
+    expect(result.inputTokens.total).toBe(1000);
+    expect(result.inputTokens.cacheRead).toBe(300);
+    expect(result.inputTokens.noCache).toBe(700); // 1000 - 300
+  });
+
+  it("handles reasoning tokens", () => {
+    const result = flatUsageToV3({
+      inputTokens: 1000,
+      outputTokens: 500,
+      reasoningTokens: 200,
+    });
+
+    expect(result.outputTokens.total).toBe(500);
+    expect(result.outputTokens.reasoning).toBe(200);
+    expect(result.outputTokens.text).toBe(300); // 500 - 200
+  });
+
+  it("handles all token types together", () => {
+    const result = flatUsageToV3({
+      inputTokens: 2000,
+      outputTokens: 800,
+      cachedInputTokens: 500,
+      reasoningTokens: 100,
+    });
+
+    expect(result.inputTokens.total).toBe(2000);
+    expect(result.inputTokens.noCache).toBe(1500);
+    expect(result.inputTokens.cacheRead).toBe(500);
+    expect(result.outputTokens.total).toBe(800);
+    expect(result.outputTokens.text).toBe(700);
+    expect(result.outputTokens.reasoning).toBe(100);
+  });
+
+  it("handles missing fields gracefully", () => {
+    const result = flatUsageToV3({});
+
+    expect(result.inputTokens.total).toBeUndefined();
+    expect(result.inputTokens.noCache).toBeUndefined();
+    expect(result.outputTokens.total).toBeUndefined();
+    expect(result.outputTokens.text).toBeUndefined();
+  });
+
+  it("preserves raw original usage", () => {
+    const original = { inputTokens: 42, outputTokens: 17, totalTokens: 59 };
+    const result = flatUsageToV3(original);
+    expect(result.raw).toEqual(original);
+  });
+});
+
+describe("normalizeFinishReason", () => {
+  it("returns undefined for null/undefined", () => {
+    expect(normalizeFinishReason(null)).toBeUndefined();
+    expect(normalizeFinishReason(undefined)).toBeUndefined();
+  });
+
+  it("passes through v3 format unchanged", () => {
+    const v3 = { unified: "stop", raw: "stop" };
+    expect(normalizeFinishReason(v3)).toBe(v3);
+  });
+
+  it("converts plain string to v3 format", () => {
+    expect(normalizeFinishReason("stop")).toEqual({ unified: "stop", raw: "stop" });
+    expect(normalizeFinishReason("length")).toEqual({ unified: "length", raw: "length" });
+    expect(normalizeFinishReason("tool-calls")).toEqual({
+      unified: "tool-calls",
+      raw: "tool-calls",
+    });
+  });
+
+  it('converts "unknown" to "other"', () => {
+    expect(normalizeFinishReason("unknown")).toEqual({ unified: "other", raw: "unknown" });
+  });
+
+  it("handles non-string non-object as 'other'", () => {
+    expect(normalizeFinishReason(42)).toEqual({ unified: "other", raw: "other" });
+  });
+});
+
+describe("normalizeGatewayGenerateResult", () => {
+  it("converts flat usage in generate result", () => {
+    const result = normalizeGatewayGenerateResult({
+      content: [{ type: "text", text: "hello" }],
+      usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+      finishReason: "stop",
+    });
+
+    // Usage should be v3 nested
+    const usage = result.usage as V3Usage;
+    expect(usage.inputTokens.total).toBe(100);
+    expect(usage.outputTokens.total).toBe(50);
+
+    // finishReason should be v3 object (cast because generic return type
+    // preserves the input shape, but the value is actually transformed)
+    expect(result.finishReason as unknown).toEqual({ unified: "stop", raw: "stop" });
+  });
+
+  it("preserves already-v3 usage", () => {
+    const v3Usage: V3Usage = {
+      inputTokens: { total: 100, noCache: 80, cacheRead: 20, cacheWrite: undefined },
+      outputTokens: { total: 50, text: 40, reasoning: 10 },
+    };
+    const result = normalizeGatewayGenerateResult({
+      usage: v3Usage,
+      finishReason: { unified: "stop", raw: "stop" },
+    });
+
+    // Should not be modified
+    expect(result.usage).toBe(v3Usage);
+  });
+
+  it("preserves other result fields", () => {
+    const result = normalizeGatewayGenerateResult({
+      content: [{ type: "text", text: "hello" }],
+      usage: { inputTokens: 10, outputTokens: 5 },
+      providerMetadata: { openai: { foo: "bar" } },
+    });
+
+    expect(result.content).toEqual([{ type: "text", text: "hello" }]);
+    expect(result.providerMetadata).toEqual({ openai: { foo: "bar" } });
+  });
+});
+
+describe("normalizeGatewayStreamUsage", () => {
+  async function collectStream(chunks: unknown[]): Promise<unknown[]> {
+    const stream = new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(chunk);
+        }
+        controller.close();
+      },
+    });
+
+    const result: unknown[] = [];
+    const transformed: ReadableStream<unknown> = stream.pipeThrough(normalizeGatewayStreamUsage());
+    const reader = transformed.getReader();
+    for (;;) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      result.push(chunk.value);
+    }
+    return result;
+  }
+
+  it("passes non-finish events through unchanged", async () => {
+    const chunks = [
+      { type: "text-delta", text: "hello" },
+      { type: "reasoning-delta", text: "thinking" },
+      { type: "tool-input-start", toolName: "bash" },
+    ];
+
+    const result = await collectStream(chunks);
+    expect(result).toEqual(chunks);
+  });
+
+  it("converts flat usage in finish events to v3 format", async () => {
+    const chunks = [
+      { type: "text-delta", text: "hello" },
+      {
+        type: "finish",
+        finishReason: "stop",
+        usage: { inputTokens: 1000, outputTokens: 500, totalTokens: 1500 },
+      },
+    ];
+
+    const result = await collectStream(chunks);
+
+    // First chunk unchanged
+    expect(result[0]).toEqual({ type: "text-delta", text: "hello" });
+
+    // Finish chunk should have v3 usage
+    const finish = result[1] as Record<string, unknown>;
+    expect(finish.type).toBe("finish");
+
+    const usage = finish.usage as V3Usage;
+    expect(usage.inputTokens.total).toBe(1000);
+    expect(usage.outputTokens.total).toBe(500);
+
+    // finishReason should be v3 object
+    expect(finish.finishReason).toEqual({ unified: "stop", raw: "stop" });
+  });
+
+  it("preserves already-v3 finish events", async () => {
+    const v3Finish = {
+      type: "finish",
+      finishReason: { unified: "stop", raw: "stop" },
+      usage: {
+        inputTokens: { total: 100, noCache: 80, cacheRead: 20, cacheWrite: undefined },
+        outputTokens: { total: 50, text: 40, reasoning: 10 },
+      },
+    };
+
+    const result = await collectStream([v3Finish]);
+    const finish = result[0] as Record<string, unknown>;
+    // Usage should be the same v3 object (not re-wrapped)
+    expect(finish.usage).toBe(v3Finish.usage);
+  });
+
+  it("handles null/undefined values gracefully", async () => {
+    const result = await collectStream([null, undefined, "string", 42]);
+    // Non-objects pass through
+    expect(result).toEqual([null, undefined, "string", 42]);
+  });
+
+  it("handles finish events with no usage", async () => {
+    const chunks = [{ type: "finish", finishReason: "stop" }];
+    const result = await collectStream(chunks);
+    const finish = result[0] as Record<string, unknown>;
+    expect(finish.type).toBe("finish");
+    // No usage field, just finishReason normalized
+    expect(finish.finishReason).toEqual({ unified: "stop", raw: "stop" });
+  });
+
+  it("handles finish with cached and reasoning tokens", async () => {
+    const chunks = [
+      {
+        type: "finish",
+        finishReason: "stop",
+        usage: {
+          inputTokens: 2000,
+          outputTokens: 800,
+          cachedInputTokens: 500,
+          reasoningTokens: 200,
+          totalTokens: 2800,
+        },
+      },
+    ];
+
+    const result = await collectStream(chunks);
+    const finish = result[0] as Record<string, unknown>;
+    const usage = finish.usage as V3Usage;
+
+    expect(usage.inputTokens.total).toBe(2000);
+    expect(usage.inputTokens.cacheRead).toBe(500);
+    expect(usage.inputTokens.noCache).toBe(1500);
+    expect(usage.outputTokens.total).toBe(800);
+    expect(usage.outputTokens.reasoning).toBe(200);
+    expect(usage.outputTokens.text).toBe(600);
+  });
+});

--- a/src/node/utils/gatewayStreamNormalization.ts
+++ b/src/node/utils/gatewayStreamNormalization.ts
@@ -1,0 +1,137 @@
+/**
+ * Gateway stream normalization utilities.
+ *
+ * The @ai-sdk/gateway SDK declares specificationVersion "v3", so the AI SDK
+ * core expects v3-format stream events. But the mux gateway server may send
+ * "finish" events with flat v2-style usage or plain string finishReason.
+ * These utilities detect and convert to v3 format so the AI SDK can extract
+ * usage (inputTokens, outputTokens, etc.) correctly.
+ *
+ * Without this normalization, asLanguageModelUsage() does usage.inputTokens.total
+ * which yields undefined when inputTokens is a number (flat v2 format), causing
+ * the Cost panel to show 0 tokens.
+ */
+
+/**
+ * V3 specification protocol usage format (nested).
+ * The AI SDK core's asLanguageModelUsage() expects this shape.
+ */
+export interface V3Usage {
+  inputTokens: { total?: number; noCache?: number; cacheRead?: number; cacheWrite?: number };
+  outputTokens: { total?: number; text?: number; reasoning?: number };
+  raw?: unknown;
+}
+
+/**
+ * Check whether a usage value is already in v3 nested format.
+ * V3 usage has inputTokens as an object with a `total` field;
+ * v2/flat usage has inputTokens as a number.
+ */
+export function isV3Usage(usage: unknown): usage is V3Usage {
+  if (typeof usage !== "object" || usage == null) return false;
+  const u = usage as Record<string, unknown>;
+  return typeof u.inputTokens === "object" && u.inputTokens != null;
+}
+
+/**
+ * Convert flat (v2-style) usage to v3 nested format.
+ */
+export function flatUsageToV3(usage: Record<string, unknown>): V3Usage {
+  const inputTokens = typeof usage.inputTokens === "number" ? usage.inputTokens : undefined;
+  const outputTokens = typeof usage.outputTokens === "number" ? usage.outputTokens : undefined;
+  const cachedInputTokens =
+    typeof usage.cachedInputTokens === "number" ? usage.cachedInputTokens : undefined;
+  const reasoningTokens =
+    typeof usage.reasoningTokens === "number" ? usage.reasoningTokens : undefined;
+
+  return {
+    inputTokens: {
+      total: inputTokens,
+      noCache:
+        inputTokens != null && cachedInputTokens != null
+          ? inputTokens - cachedInputTokens
+          : undefined,
+      cacheRead: cachedInputTokens,
+      cacheWrite: undefined,
+    },
+    outputTokens: {
+      total: outputTokens,
+      text:
+        outputTokens != null && reasoningTokens != null
+          ? outputTokens - reasoningTokens
+          : undefined,
+      reasoning: reasoningTokens,
+    },
+    raw: usage,
+  };
+}
+
+/**
+ * Normalize a finish-reason value to v3 format { unified, raw }.
+ * The gateway server may send a plain string instead of the nested object.
+ */
+export function normalizeFinishReason(fr: unknown): { unified: string; raw: unknown } | undefined {
+  if (fr == null) return undefined;
+  if (typeof fr === "object" && "unified" in (fr as Record<string, unknown>)) {
+    return fr as { unified: string; raw: unknown };
+  }
+  // Plain string → convert to v3 object
+  const str = typeof fr === "string" ? fr : "other";
+  return { unified: str === "unknown" ? "other" : str, raw: str };
+}
+
+/**
+ * Normalize a doGenerate result from the gateway.
+ * Converts flat usage and plain-string finishReason to v3 nested format.
+ */
+export function normalizeGatewayGenerateResult<T extends Record<string, unknown>>(result: T): T {
+  const normalized: Record<string, unknown> = { ...result };
+
+  if (result.usage != null && !isV3Usage(result.usage)) {
+    normalized.usage = flatUsageToV3(result.usage as Record<string, unknown>);
+  }
+
+  if (result.finishReason != null) {
+    const fr = normalizeFinishReason(result.finishReason);
+    if (fr) normalized.finishReason = fr;
+  }
+
+  return normalized as T;
+}
+
+/**
+ * TransformStream that normalizes gateway SSE stream events.
+ *
+ * Only transforms "finish" events; all other chunks pass through unchanged.
+ */
+export function normalizeGatewayStreamUsage(): TransformStream {
+  return new TransformStream({
+    transform(chunk: unknown, controller: TransformStreamDefaultController) {
+      if (typeof chunk !== "object" || chunk == null) {
+        controller.enqueue(chunk);
+        return;
+      }
+
+      const c = chunk as Record<string, unknown>;
+      if (c.type !== "finish") {
+        controller.enqueue(chunk);
+        return;
+      }
+
+      // Normalize usage: convert flat → v3 nested if needed
+      let usage = c.usage;
+      if (usage != null && !isV3Usage(usage)) {
+        usage = flatUsageToV3(usage as Record<string, unknown>);
+      }
+
+      // Normalize finishReason: convert string → { unified, raw } if needed
+      const finishReason = normalizeFinishReason(c.finishReason);
+
+      controller.enqueue({
+        ...c,
+        ...(usage != null && { usage }),
+        ...(finishReason != null && { finishReason }),
+      });
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Fixes the mux gateway chat showing 0 input/output tokens and $0.00 cost for all models (including GPT 5.2). The consumer breakdown (User, System, Assistant, Reasoning) was correct because it uses local tokenization, but the API-reported usage was lost.

## Background

The `@ai-sdk/gateway` SDK declares `specificationVersion: "v3"`, so the AI SDK core expects stream events with **nested** v3 usage format:
```json
{ "inputTokens": { "total": 1000, "cacheRead": 200 }, "outputTokens": { "total": 500, "reasoning": 100 } }
```

However, the mux gateway server returns usage in the **flat** v2-style format:
```json
{ "inputTokens": 1000, "outputTokens": 500, "cachedInputTokens": 200, "reasoningTokens": 100 }
```

When the AI SDK's `asLanguageModelUsage()` processes this, it does `usage.inputTokens.total` which evaluates to `(1000).total → undefined`. All token counts become `undefined`, which `addUsage()` treats as 0.

## Implementation

- **New utility file** `src/node/utils/gatewayStreamNormalization.ts`:
  - `isV3Usage()` — detects whether usage is already in v3 nested format
  - `flatUsageToV3()` — converts flat v2 usage to v3 nested format
  - `normalizeFinishReason()` — converts plain string finish reasons to v3 `{ unified, raw }` format
  - `normalizeGatewayStreamUsage()` — TransformStream that normalizes `finish` events in the SSE stream
  - `normalizeGatewayGenerateResult()` — normalizes doGenerate results

- **Wrapped gateway model** in `providerModelFactory.ts`:
  - `doStream` is wrapped to pipe through `normalizeGatewayStreamUsage()`
  - `doGenerate` is wrapped to pass through `normalizeGatewayGenerateResult()`
  - Both are no-ops when usage is already in v3 format (forward-compatible)

## Validation

- 25 unit tests covering all normalization functions:
  - Flat → nested conversion with all token types (input, output, cached, reasoning)
  - Passthrough of already-v3 formatted data
  - Stream transform with mixed event types
  - Edge cases (null, undefined, empty, non-object values)
- All static checks pass (`make static-check`)

## Risks

**Low risk.** The normalization is a no-op when usage is already in v3 format, so if/when the gateway server updates to send v3 format natively, this code gracefully becomes a passthrough. The transform only touches `finish` events in the stream — all other events pass through unchanged.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$N/A`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=N/A -->
