### PR TITLE
🤖 bench: add gpt-5.3-codex to leaderboard MODEL_METADATA

### DIFF
--- a/benchmarks/terminal_bench/prepare_leaderboard_submission.py
+++ b/benchmarks/terminal_bench/prepare_leaderboard_submission.py
@@ -112,6 +112,13 @@ MODEL_METADATA = {
         "model_org_display_name": "OpenAI",
         "folder_name": "GPT-5-Codex",
     },
+    "openai/gpt-5.3-codex": {
+        "model_name": "gpt-5.3-codex",
+        "model_provider": "openai",
+        "model_display_name": "GPT-5.3 Codex",
+        "model_org_display_name": "OpenAI",
+        "folder_name": "GPT-5.3-Codex",
+    },
 }
 
 


### PR DESCRIPTION
## Summary

Add `openai/gpt-5.3-codex` to the `MODEL_METADATA` dictionary in `prepare_leaderboard_submission.py` so the script can handle runs using this model without falling back to generic defaults.

## Background

A Terminal-Bench run with `openai/gpt-5.3-codex` was completed (65.2%, 58/89 tasks passed). The prepare script needs this model entry to generate the correct folder name (`Mux__GPT-5.3-Codex`) and metadata.yaml for leaderboard submission.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$1.69`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=1.69 -->
