### PR TITLE
🤖 fix: wire Codex OAuth for mux run and benchmark adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,4 +130,6 @@ mobile/.expo/
 .mux/mcp.jsonc
 # Terminal-Bench leaderboard cache
 benchmarks/terminal_bench/.leaderboard_cache/
+# Terminal-Bench job output
+jobs/
 

--- a/docs/reference/benchmarking.mdx
+++ b/docs/reference/benchmarking.mdx
@@ -13,19 +13,20 @@ Mux ships with a headless adapter for [Terminal-Bench](https://www.tbench.ai/). 
 
 Optional environment overrides:
 
-| Variable              | Purpose                                              | Default                                |
-| --------------------- | ---------------------------------------------------- | -------------------------------------- |
-| `MUX_AGENT_REPO_ROOT` | Path copied into each task container                 | repo root inferred from the agent file |
-| `MUX_TRUNK`           | Branch checked out when preparing the project        | `main`                                 |
-| `MUX_WORKSPACE_ID`    | Workspace identifier used inside Mux                 | `mux-bench`                            |
-| `MUX_MODEL`           | Preferred model (supports `provider/model` syntax)   | `anthropic/claude-sonnet-4-5`          |
-| `MUX_THINKING_LEVEL`  | Reasoning level (`OFF`, `LOW`, `MED`, `HIGH`, `MAX`) | `HIGH`                                 |
-| `MUX_MODE`            | Starting mode (`plan` or `exec`)                     | `exec`                                 |
-| `MUX_RUNTIME`         | Runtime type (`local`, `worktree`, or `ssh <host>`)  | `worktree`                             |
-| `MUX_TIMEOUT_MS`      | Optional stream timeout in milliseconds              | no timeout                             |
-| `MUX_CONFIG_ROOT`     | Location for Mux session data inside the container   | `/root/.mux`                           |
-| `MUX_APP_ROOT`        | Path where the Mux sources are staged                | `/opt/mux-app`                         |
-| `MUX_PROJECT_PATH`    | Explicit project directory inside the task container | auto-detected from common paths        |
+| Variable              | Purpose                                                 | Default                                |
+| --------------------- | ------------------------------------------------------- | -------------------------------------- |
+| `MUX_AGENT_REPO_ROOT` | Path copied into each task container                    | repo root inferred from the agent file |
+| `MUX_TRUNK`           | Branch checked out when preparing the project           | `main`                                 |
+| `MUX_WORKSPACE_ID`    | Workspace identifier used inside Mux                    | `mux-bench`                            |
+| `MUX_MODEL`           | Preferred model (supports `provider/model` syntax)      | `anthropic/claude-sonnet-4-5`          |
+| `MUX_THINKING_LEVEL`  | Reasoning level (`OFF`, `LOW`, `MED`, `HIGH`, `MAX`)    | `HIGH`                                 |
+| `MUX_MODE`            | Starting mode (`plan` or `exec`)                        | `exec`                                 |
+| `MUX_RUNTIME`         | Runtime type (`local`, `worktree`, or `ssh <host>`)     | `worktree`                             |
+| `MUX_TIMEOUT_MS`      | Optional stream timeout in milliseconds                 | no timeout                             |
+| `MUX_PROVIDERS_FILE`  | Host path to `providers.jsonc` copied into each sandbox | unset (use env vars only)              |
+| `MUX_CONFIG_ROOT`     | Location for Mux session data inside the container      | `/root/.mux`                           |
+| `MUX_APP_ROOT`        | Path where the Mux sources are staged                   | `/opt/mux-app`                         |
+| `MUX_PROJECT_PATH`    | Explicit project directory inside the task container    | auto-detected from common paths        |
 
 ## Running Terminal-Bench
 

--- a/src/node/utils/providerRequirements.test.ts
+++ b/src/node/utils/providerRequirements.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+
+import type { ProvidersConfig } from "@/node/config";
+import { hasAnyConfiguredProvider } from "./providerRequirements";
+
+describe("hasAnyConfiguredProvider", () => {
+  it("returns false for null or empty config", () => {
+    expect(hasAnyConfiguredProvider(null)).toBe(false);
+    expect(hasAnyConfiguredProvider({})).toBe(false);
+  });
+
+  it("returns true when a provider has an API key", () => {
+    const providers: ProvidersConfig = {
+      anthropic: { apiKey: "sk-ant-test" },
+    };
+
+    expect(hasAnyConfiguredProvider(providers)).toBe(true);
+  });
+
+  it("returns true for OpenAI Codex OAuth-only configuration", () => {
+    const providers: ProvidersConfig = {
+      openai: {
+        codexOauth: {
+          type: "oauth",
+          access: "test-access-token",
+          refresh: "test-refresh-token",
+          expires: Date.now() + 60_000,
+          accountId: "acct_123",
+        },
+      },
+    };
+
+    expect(hasAnyConfiguredProvider(providers)).toBe(true);
+  });
+
+  it("returns true for keyless providers with explicit config", () => {
+    const providers: ProvidersConfig = {
+      ollama: {
+        baseUrl: "http://localhost:11434/api",
+      },
+    };
+
+    expect(hasAnyConfiguredProvider(providers)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Wire Codex OAuth support into `mux run` (CLI) and the Terminal-Bench adapter so benchmark runs can use OAuth-only credentials from `providers.jsonc` instead of requiring API key environment variables.

## Background

Running `make benchmark-terminal TB_MODEL=openai/gpt-5.3-codex` with OAuth-only `providers.jsonc` fails in two ways:
1. The CLI aborts with "No provider credentials found" because `hasAnyConfiguredProvider` only checks for `apiKey` strings, missing OAuth credentials.
2. Even if that passes, the runtime throws "Codex OAuth service not initialized" because `mux run` uses `createCoreServices` which doesn't wire `CodexOauthService`.

Additionally, the Terminal-Bench Docker sandbox has no mechanism to receive the host's `providers.jsonc`, so OAuth tokens are absent in the container.

## Implementation

**`src/cli/run.ts`** — Instantiate `CodexOauthService` and wire it to `aiService` via `setCodexOauthService()`, matching the desktop app's `ServiceContainer` wiring. Dispose on cleanup.

**`src/node/utils/providerRequirements.ts`** — Refactor `hasAnyConfiguredProvider` to:
- Recognize OpenAI Codex OAuth (`codexOauth` field parsed via `parseCodexOauthAuth`)
- Use `checkProviderConfigured` for known providers (handles keyless providers like Ollama)
- Fall back to `apiKey` check for unknown providers

**`benchmarks/terminal_bench/mux_agent.py`** — Add `MUX_PROVIDERS_FILE` env var support. When set, `_stage_providers_config()` uploads the host file into the sandbox at `$MUX_CONFIG_ROOT/providers.jsonc` during setup.

**`.gitignore`** — Ignore Terminal-Bench `jobs/` output directory.

## Validation

- New unit tests in `providerRequirements.test.ts` cover null/empty, API key, OAuth-only, and keyless provider configs (4 tests, all passing)
- Existing `codexOauthAuth.test.ts` and `codexOauthService.test.ts` suites pass (44 tests total across 3 files)
- `make static-check` passes (lint, typecheck, format, docs link check)

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$1.80`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=1.80 -->
