### PR TITLE
🤖 bench: ensure python3 is available in sandbox

### DIFF
--- a/benchmarks/terminal_bench/mux_setup.sh.j2
+++ b/benchmarks/terminal_bench/mux_setup.sh.j2
@@ -25,6 +25,7 @@ ensure_tool() {
 ensure_tool curl
 ensure_tool git
 ensure_tool unzip
+ensure_tool python3
 export BUN_INSTALL="${BUN_INSTALL:-/root/.bun}"
 export PATH="${BUN_INSTALL}/bin:${PATH}"
 


### PR DESCRIPTION
## Summary

Add `python3` to the list of tools installed during Terminal-Bench agent setup, so the agent has access to Python for binary data analysis tasks.

## Background

In the `password-recovery` benchmark run (`jobs/2026-02-07__22-23-08/`), the agent attempted `python` and `python3` early in execution — both returned `command not found` (exitCode=127). It fell back to writing complex Perl one-liners for binary data analysis (RAID stripe reconstruction, zip carving, hex parsing), which were slow to write, error-prone (one had a syntax error), and consumed valuable tool-call budget. The agent timed out after 52 turns without writing an answer file.

## Implementation

One-line addition to `benchmarks/terminal_bench/mux_setup.sh.j2`: `ensure_tool python3` alongside existing `curl`, `git`, `unzip`.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$2.60`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=2.60 -->
