### PR TITLE
🤖 fix: auto-update and verify Nix flake offline cache hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ build/icon.png: docs/img/logo-white.svg scripts/generate-icons.ts
 	@bun scripts/generate-icons.ts png
 
 ## Quality checks (can run in parallel)
-static-check: lint typecheck fmt-check check-eager-imports check-bench-agent check-docs-links check-code-docs-links lint-shellcheck ## Run all static checks (lint + typecheck + fmt-check)
+static-check: lint typecheck fmt-check check-eager-imports check-bench-agent check-docs-links check-code-docs-links lint-shellcheck flake-hash-check ## Run all static checks (lint + typecheck + fmt-check)
 
 check-bench-agent: node_modules/.installed src/version.ts $(BUILTIN_SKILLS_GENERATED) ## Verify terminal-bench agent configuration and imports
 	@./scripts/check-bench-agent.sh

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,8 @@
             '';
 
             outputHashMode = "recursive";
-            outputHash = "sha256-DRMDENMs0/18qjwrQKfWdtBAy2H+JlrKim9kNzpNW44=";
+            # Marker used by scripts/update_flake_hash.sh to update this hash in place.
+            outputHash = "sha256-NLycgRQNkS3a9jz6qFsdeOHEUDu373hQ6ntOLtOVK0M="; # mux-offline-cache-hash
           };
 
           configurePhase = ''

--- a/fmt.mk
+++ b/fmt.mk
@@ -3,7 +3,7 @@
 # This file contains all code formatting logic.
 # Included by the main Makefile.
 
-.PHONY: fmt fmt-check fmt-prettier fmt-prettier-check fmt-shell fmt-shell-check fmt-nix fmt-nix-check fmt-python fmt-python-check fmt-sync-docs fmt-sync-docs-check
+.PHONY: fmt fmt-check fmt-prettier fmt-prettier-check fmt-shell fmt-shell-check fmt-nix fmt-nix-check fmt-python fmt-python-check fmt-sync-docs fmt-sync-docs-check update-flake-hash flake-hash-check
 
 # Centralized patterns - single source of truth
 PRETTIER_PATTERNS := 'src/**/*.{ts,tsx,json}' 'mobile/**/*.{ts,tsx,json}' 'tests/**/*.ts' 'docs/**/*.mdx' 'package.json' 'tsconfig*.json' 'README.md'
@@ -91,6 +91,24 @@ else
 		diff -u flake.nix "$$tmp_dir/flake.nix" || true; \
 		exit 1; \
 	fi
+endif
+
+update-flake-hash: ## Update flake.nix offlineCache outputHash from nix build output
+ifeq ($(NIX),)
+	@echo "Nix not found; skipping flake hash update"
+else ifeq ($(wildcard flake.nix),)
+	@echo "flake.nix not found; skipping flake hash update"
+else
+	@./scripts/update_flake_hash.sh
+endif
+
+flake-hash-check: ## Verify flake.nix offlineCache outputHash is current
+ifeq ($(NIX),)
+	@echo "Nix not found; skipping flake hash check"
+else ifeq ($(wildcard flake.nix),)
+	@echo "flake.nix not found; skipping flake hash check"
+else
+	@./scripts/update_flake_hash.sh --check
 endif
 
 fmt-sync-docs:

--- a/scripts/update_flake_hash.sh
+++ b/scripts/update_flake_hash.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+
+# Updates the flake offline cache outputHash marker in flake.nix using the
+# replacement hash reported by `nix build .#mux`. In `--check` mode, it writes
+# the expected result to a temp file, shows a diff, and exits non-zero on drift.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MODE="update"
+
+if [ "${1:-}" = "--check" ]; then
+  MODE="check"
+elif [ "${1:-}" != "" ]; then
+  echo "Usage: $0 [--check]"
+  exit 1
+fi
+
+cd "$PROJECT_ROOT"
+
+if ! command -v nix &>/dev/null; then
+  echo "Error: nix command not found."
+  exit 1
+fi
+
+flake_path="$PROJECT_ROOT/flake.nix"
+if [ ! -f "$flake_path" ]; then
+  echo "Error: flake.nix not found at $flake_path."
+  exit 1
+fi
+
+# Some environments (including CI/sandboxes) have a read-only ~/.cache.
+# Point Nix cache writes to a writable location so hash refresh still works.
+tmp_root="${TMPDIR:-/tmp}/mux-nix-cache"
+mkdir -p "$tmp_root"
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$tmp_root}"
+
+hash_marker="mux-offline-cache-hash"
+
+current_hash="$(sed -nE "s/^[[:space:]]*outputHash = \"(sha256-[^\"]+)\";[[:space:]]*# ${hash_marker}$/\\1/p" "$flake_path" | head -n1)"
+if [ -z "$current_hash" ]; then
+  echo "Error: could not find outputHash line tagged with # ${hash_marker} in flake.nix."
+  exit 1
+fi
+
+echo "Checking flake output hash..."
+set +e
+build_output="$(nix build .#mux --no-link 2>&1)"
+build_status=$?
+set -e
+
+if [ "$build_status" -ne 0 ] && printf '%s\n' "$build_output" | grep -Fq "fetcher-cache-v4.sqlite"; then
+  retry_root="$(mktemp -d "${TMPDIR:-/tmp}/mux-nix-home.XXXXXX")"
+  mkdir -p "$retry_root/.cache"
+
+  set +e
+  build_output="$(
+    HOME="$retry_root" \
+      XDG_CACHE_HOME="$retry_root/.cache" \
+      NIX_CONFIG="use-xdg-base-directories = true" \
+      nix build .#mux --no-link 2>&1
+  )"
+  build_status=$?
+  set -e
+
+  rm -rf "$retry_root"
+fi
+
+if [ "$build_status" -eq 0 ]; then
+  echo "outputHash is already up to date: $current_hash"
+  exit 0
+fi
+
+# Nix reports the correct fixed-output hash as "got: sha256-...".
+new_hash="$(printf '%s\n' "$build_output" | sed -nE 's/.*got:[[:space:]]*(sha256-[A-Za-z0-9+/=]+).*/\1/p' | tail -n1)"
+if [ -z "$new_hash" ]; then
+  echo "Error: build failed but no replacement hash was found."
+  printf '%s\n' "$build_output"
+  exit "$build_status"
+fi
+
+if [ "$new_hash" = "$current_hash" ]; then
+  echo "Build failed, but reported hash matches current hash: $current_hash"
+  printf '%s\n' "$build_output"
+  exit "$build_status"
+fi
+
+replace_hash() {
+  local input_file="$1"
+  local output_file="$2"
+  awk -v new_hash="$new_hash" -v hash_marker="$hash_marker" '
+  BEGIN {
+    updated = 0
+  }
+  {
+    if (!updated && $0 ~ ("^[[:space:]]*outputHash[[:space:]]*=[[:space:]]*\"sha256-[^\"]+\";[[:space:]]*# " hash_marker "$")) {
+      sub(/"sha256-[^"]+"/, "\"" new_hash "\"")
+      updated = 1
+    }
+    print
+  }
+  END {
+    if (!updated) {
+      exit 1
+    }
+  }
+' "$input_file" >"$output_file"
+}
+
+if [ "$MODE" = "check" ]; then
+  tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/check-flake-hash.XXXXXX")"
+  trap 'rm -rf "$tmp_dir"' EXIT
+  cp "$flake_path" "$tmp_dir/flake.nix"
+  replace_hash "$tmp_dir/flake.nix" "$tmp_dir/flake.nix.updated"
+
+  if ! cmp -s "$flake_path" "$tmp_dir/flake.nix.updated"; then
+    echo "flake.nix offline cache hash is out of date. Run 'make update-flake-hash' to fix."
+    diff -u "$flake_path" "$tmp_dir/flake.nix.updated" || true
+    exit 1
+  fi
+  exit 0
+fi
+
+tmp_file="$(mktemp "${TMPDIR:-/tmp}/flake.nix.XXXXXX")"
+trap 'rm -f "$tmp_file"' EXIT
+replace_hash "$flake_path" "$tmp_file"
+mv "$tmp_file" "$flake_path"
+trap - EXIT
+
+echo "Updated outputHash:"
+echo "  old: $current_hash"
+echo "  new: $new_hash"
+echo "Run: nix build .#mux --no-link"


### PR DESCRIPTION
## Summary

Automate flake.nix offline cache hash maintenance with a single script that can both update the hash and check for drift in static checks.

## Background

The fixed-output hash for the offline dependency cache is easy to miss after lockfile or toolchain changes, which causes Nix build failures and inconsistent local/remote evaluation.

## Implementation

- Add scripts/update_flake_hash.sh with two modes:
  - default: run nix build .#mux --no-link, parse the replacement got hash, and update the tagged hash line in flake.nix.
  - --check: write the expected output to a temp file, print diff -u, and exit non-zero if the hash is stale.
- Tag the target hash line in flake.nix with # mux-offline-cache-hash so updates are unambiguous.
- Add update-flake-hash and flake-hash-check targets in fmt.mk with the same skip behavior as fmt-nix/fmt-nix-check (skip when Nix or flake.nix is unavailable).
- Include flake-hash-check in make static-check.

## Validation

- bash -n scripts/update_flake_hash.sh
- make help confirms update-flake-hash and flake-hash-check targets
- Full Nix execution depends on environment Nix daemon access