### PR TITLE
🤖 refactor: unify OAuth callback pages with shared styled template

### DIFF
--- a/src/node/services/mcpOauthService.ts
+++ b/src/node/services/mcpOauthService.ts
@@ -9,6 +9,7 @@ import type { MCPConfigService } from "@/node/services/mcpConfigService";
 import type { WindowService } from "@/node/services/windowService";
 import type { TelemetryService } from "@/node/services/telemetryService";
 import { log } from "@/node/services/log";
+import { escapeHtml, renderOAuthCallbackPage } from "@/node/services/oauthCallbackPage";
 import type { Result } from "@/common/types/result";
 import { Err, Ok } from "@/common/types/result";
 import { roundToBase2 } from "@/common/telemetry/utils";
@@ -1142,19 +1143,14 @@ export class McpOauthService {
       input.res.statusCode = 400;
     }
 
-    input.res.end(`<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="color-scheme" content="dark light" />
-    <title>${title}</title>
-  </head>
-  <body>
-    <h1>${title}</h1>
-    <p>${description}</p>
-  </body>
-</html>`);
+    input.res.end(
+      renderOAuthCallbackPage({
+        title,
+        description,
+        success: result.success,
+        mode: { type: "desktop" },
+      })
+    );
 
     await this.finishDesktopFlow(input.flowId, result);
   }
@@ -1480,13 +1476,4 @@ export class McpOauthService {
       mode: 0o600,
     });
   }
-}
-
-function escapeHtml(input: string): string {
-  return input
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
 }

--- a/src/node/services/oauthCallbackPage.ts
+++ b/src/node/services/oauthCallbackPage.ts
@@ -1,0 +1,155 @@
+/**
+ * Shared HTML rendering for all OAuth callback pages (desktop and web mode).
+ *
+ * All callback pages use the same branded layout (external site.css from
+ * gateway.mux.coder.com) so users see a consistent "mux" experience
+ * regardless of which OAuth provider they authenticated with.
+ */
+
+// -- Escape helpers ----------------------------------------------------------
+
+/** Escape HTML special characters to prevent XSS in interpolated strings. */
+export function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+/**
+ * JSON-serialize a value and escape `</script>` sequences so the output
+ * is safe to embed inside an HTML `<script>` block.
+ */
+export function escapeJsonForHtmlScript(value: unknown): string {
+  // Prevent `</script>` injection when embedding untrusted strings in an inline <script>.
+  return JSON.stringify(value).replaceAll("<", "\\u003c");
+}
+
+// -- Page rendering ----------------------------------------------------------
+
+type CallbackMode =
+  /** Desktop: auto-close the tab on success. */
+  | { type: "desktop" }
+  /** Web: postMessage to opener + "Return to Mux" button. */
+  | { type: "web"; payloadJson: string; returnUrl: string };
+
+export interface CallbackPageOptions {
+  title: string;
+  /** Pre-escaped HTML description (caller is responsible for escaping). */
+  description: string;
+  success: boolean;
+  mode: CallbackMode;
+}
+
+/** Generate a fully-styled callback result page. */
+export function renderOAuthCallbackPage(opts: CallbackPageOptions): string {
+  const { title, description, success, mode } = opts;
+
+  const hintHtml = success
+    ? mode.type === "web"
+      ? '<p class="muted">This tab should close automatically.</p>'
+      : '<p class="muted">Mux should now be in the foreground. You can close this tab.</p>'
+    : '<p class="muted">You can close this tab.</p>';
+
+  const returnBtnHtml =
+    mode.type === "web"
+      ? `<p><a class="btn primary" href="${mode.returnUrl}">Return to Mux</a></p>`
+      : "";
+
+  const scriptBody =
+    mode.type === "web" ? buildWebScript(mode.payloadJson) : buildDesktopScript(success);
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="dark light" />
+    <meta name="theme-color" content="#0e0e0e" />
+    <title>${title}</title>
+    <link rel="stylesheet" href="https://gateway.mux.coder.com/static/css/site.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="site-header">
+        <div class="container">
+          <div class="header-title">mux</div>
+        </div>
+      </header>
+
+      <main class="site-main">
+        <div class="container">
+          <div class="content-surface">
+            <h1>${title}</h1>
+            <p>${description}</p>
+            ${hintHtml}
+            ${returnBtnHtml}
+          </div>
+        </div>
+      </main>
+    </div>
+
+    <script>
+      (() => {
+${scriptBody}
+      })();
+    </script>
+  </body>
+</html>`;
+}
+
+function buildDesktopScript(success: boolean): string {
+  return `        const ok = ${success ? "true" : "false"};
+        if (!ok) return;
+        try { window.close(); } catch {}
+        setTimeout(() => { try { window.close(); } catch {} }, 50);`;
+}
+
+function buildWebScript(payloadJson: string): string {
+  return `        const payload = ${payloadJson};
+        const ok = payload.ok === true;
+
+        try {
+          if (window.opener && typeof window.opener.postMessage === "function") {
+            window.opener.postMessage(payload, "*");
+          }
+        } catch {
+          // Ignore postMessage failures.
+        }
+
+        if (!ok) {
+          return;
+        }
+
+        try {
+          if (window.opener && typeof window.opener.focus === "function") {
+            window.opener.focus();
+          }
+        } catch {
+          // Ignore focus failures.
+        }
+
+        try {
+          window.close();
+        } catch {
+          // Ignore close failures.
+        }
+
+        setTimeout(() => {
+          try {
+            window.close();
+          } catch {
+            // Ignore close failures.
+          }
+        }, 50);
+
+        setTimeout(() => {
+          try {
+            window.location.replace("/");
+          } catch {
+            // Ignore navigation failures.
+          }
+        }, 150);`;
+}


### PR DESCRIPTION
## Summary

All OAuth callback pages now share the same branded Mux Gateway look — previously only the gateway page was styled while others were bare or minimally styled.

## Background

The codebase had 3 tiers of callback page styling:
1. **Rich** (Mux Gateway desktop + ORPC Gateway + ORPC MCP) — external `site.css`, branded header, `.content-surface` layout
2. **Medium** (Governor desktop + ORPC Governor) — inline CSS with `system-ui` font, centered but no branding
3. **Bare** (Codex/OpenAI + MCP desktop) — completely unstyled, browser defaults only

Additionally, `escapeHtml()` was duplicated 5 times and `escapeJsonForHtmlScript()` was duplicated twice across these files.

## Implementation

- New `src/node/services/oauthCallbackPage.ts` with:
  - `renderOAuthCallbackPage()` — generates the full styled HTML for both desktop (auto-close) and web (postMessage + "Return to Mux" button) callback modes
  - `escapeHtml()` and `escapeJsonForHtmlScript()` — consolidated from 7 duplicate definitions
- Updated all 5 consumer files to use the shared helper:
  - `codexOauthService.ts` (bare → rich)
  - `mcpOauthService.ts` (bare → rich)
  - `muxGovernorOauthService.ts` (medium → rich)
  - `muxGatewayOauthService.ts` (already rich, now uses shared module)
  - `orpc/server.ts` (3 callback routes consolidated)

Net -191 lines changed.

## Validation

- TypeScript compiles cleanly (only pre-existing `node-pty` errors remain)
- All related tests pass (`codexOauthService.test.ts`, `mcpOauthService.test.ts`, `server.test.ts`)
- Format check passes

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `high` • Cost: `$n/a`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=high costs=n/a -->
