### PR TITLE
🤖 fix: lazy-load ssh-agent import + bun lockfile-free CI check

### DIFF
--- a/scripts/check-bench-agent.sh
+++ b/scripts/check-bench-agent.sh
@@ -83,13 +83,45 @@ if [[ ${#MISSING_FILES[@]} -gt 0 ]]; then
   exit 1
 fi
 
-# Verify the built CLI can actually run (catches missing dependencies/imports)
-if ! output=$(node "$REPO_ROOT/dist/cli/index.js" run --help 2>&1); then
-  if echo "$output" | grep -qE "Cannot find module|MODULE_NOT_FOUND"; then
-    echo "❌ Error: Built CLI has missing module dependencies:"
-    echo "$output"
-    exit 1
-  fi
+# Verify that CLI subcommands boot WITHOUT a lockfile using bun's resolver.
+# npm and bun resolve pre-release caret ranges differently — bun includes the
+# stable release (e.g. ^0.1.0-main.28 → 0.1.0) while npm does not. Since users
+# run `bun x mux@latest`, we must test with bun to catch resolution mismatches.
+echo ""
+echo "Checking CLI subcommand imports (bun, lockfile-free)..."
+
+CHECK_DIR=$(mktemp -d)
+trap 'rm -rf "$CHECK_DIR"' EXIT
+
+# Copy built dist and package.json — but NO lockfile, shrinkwrap, or node_modules.
+cp -r "$REPO_ROOT/dist" "$CHECK_DIR/dist"
+cp "$REPO_ROOT/package.json" "$CHECK_DIR/package.json"
+
+# Strip devDependencies so bun only resolves production deps (matching published package).
+node -e "
+  const pkg = JSON.parse(require('fs').readFileSync('$CHECK_DIR/package.json', 'utf8'));
+  delete pkg.devDependencies;
+  require('fs').writeFileSync('$CHECK_DIR/package.json', JSON.stringify(pkg, null, 2) + '\n');
+"
+
+if ! install_output=$(cd "$CHECK_DIR" && bun install --ignore-scripts 2>&1); then
+  echo "❌ Error: bun install (lockfile-free) failed:"
+  echo "$install_output"
+  exit 1
 fi
 
-echo "✅ npm package CLI is complete (all required files present)"
+CLI_SUBCMDS=(run server)
+for subcmd in "${CLI_SUBCMDS[@]}"; do
+  if ! output=$(node "$CHECK_DIR/dist/cli/index.js" "$subcmd" --help 2>&1); then
+    if echo "$output" | grep -qE "Cannot find module|MODULE_NOT_FOUND|not defined by \"exports\""; then
+      echo "❌ Error: 'mux $subcmd --help' failed (bun lockfile-free resolution):"
+      echo "$output"
+      echo ""
+      echo "A dependency likely resolved to a version missing a required export."
+      echo "Pin the dep to an exact version or lazy-load the import."
+      exit 1
+    fi
+  fi
+done
+
+echo "✅ npm package CLI is complete (all subcommands boot under bun lockfile-free resolution)"


### PR DESCRIPTION
## Summary

Lazy-load the `@coder/mux-md-client/ssh-agent` subpath import so the server can start even when bun resolves the dependency to a version missing the export. Add a bun lockfile-free `--help` check to `make static-check` that exercises both `run` and `server` import chains to catch this and any future dependency resolution issue.

## Background

`signingService.ts` had a **top-level** `import ... from "@coder/mux-md-client/ssh-agent"` which executes eagerly via the import chain `server.ts → serviceContainer.ts → signingService.ts`. When `bun x mux@latest` resolved the dependency to `@coder/mux-md-client@0.1.0` (stable, missing the `./ssh-agent` export), the process crashed before serving any requests. `mux run` was unaffected because its import chain doesn't touch `signingService`.

The prior fix (PR #2237) pinned the dep version, but only shipped in `@next` — `mux@latest` (`0.16.0`) still has the old range. CI never caught it because **npm and bun resolve pre-release caret ranges differently**:

| Range | npm resolves to | bun resolves to |
|---|---|---|
| `^0.1.0-main.28` | `0.1.0-main.29` ✅ | `0.1.0` ❌ |

All previous CI checks used npm, which masked the bug.

## Implementation

**`src/node/services/signingService.ts`**: Replace the top-level import with a dynamic `import()` at the single callsite inside `signMessage()`. This function is `async` and only invoked when a user actively signs via ssh-agent, so the lazy load has zero UX impact. Node caches modules after first load.

**`scripts/check-bench-agent.sh`**: Replace the old `node dist/cli/index.js run --help` check (which ran against lockfile-resolved `node_modules`) with a lockfile-free check that:
1. Copies `dist/` and `package.json` to a temp dir (no lockfile or `node_modules`)
2. Strips `devDependencies` and runs `bun install --ignore-scripts`
3. Exercises `mux run --help` AND `mux server --help` against the freshly-resolved deps

This catches any dependency resolution failure in either import chain, using the same resolver that `bun x` users hit.

## Validation

- `make static-check` passes
- All 14 signing service tests pass including ssh-agent tests
- **Regression test**: reverted lazy import + caret range → check correctly fails:
  ```
  ❌ Error: 'mux server --help' failed (bun lockfile-free resolution):
  Error: Package subpath './ssh-agent' is not defined by "exports"
  ```

---

_Generated with `mux` · Model: `anthropic:claude-opus-4-6` · Thinking: `xhigh` · Cost: `$N/A`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=N/A -->
