### PR TITLE
🤖 fix: prevent infinite agent loop from [CONTINUE] sentinel

### DIFF
--- a/src/browser/utils/messages/modelMessageTransform.test.ts
+++ b/src/browser/utils/messages/modelMessageTransform.test.ts
@@ -945,47 +945,6 @@ describe("modelMessageTransform", () => {
   });
 });
 
-describe("transformModelMessages noPrefill", () => {
-  it("appends [CONTINUE] sentinel when last message is assistant and noPrefill is true", () => {
-    const messages: ModelMessage[] = [
-      { role: "user", content: [{ type: "text", text: "Hello" }] },
-      { role: "assistant", content: [{ type: "text", text: "Hi there" }] },
-    ];
-
-    const result = transformModelMessages(messages, "anthropic", { noPrefill: true });
-
-    const last = result[result.length - 1];
-    expect(last.role).toBe("user");
-    expect((last as { content: Array<{ type: string; text: string }> }).content).toEqual([
-      { type: "text", text: "[CONTINUE]" },
-    ]);
-  });
-
-  it("does not append sentinel when last message is user", () => {
-    const messages: ModelMessage[] = [
-      { role: "user", content: [{ type: "text", text: "Hello" }] },
-      { role: "assistant", content: [{ type: "text", text: "Hi" }] },
-      { role: "user", content: [{ type: "text", text: "Thanks" }] },
-    ];
-
-    const result = transformModelMessages(messages, "anthropic", { noPrefill: true });
-
-    expect(result[result.length - 1].role).toBe("user");
-    expect(result.length).toBe(3);
-  });
-
-  it("does not append sentinel when noPrefill is false", () => {
-    const messages: ModelMessage[] = [
-      { role: "user", content: [{ type: "text", text: "Hello" }] },
-      { role: "assistant", content: [{ type: "text", text: "Hi there" }] },
-    ];
-
-    const result = transformModelMessages(messages, "anthropic", { noPrefill: false });
-
-    expect(result[result.length - 1].role).toBe("assistant");
-  });
-});
-
 describe("stripOrphanedToolCalls", () => {
   it("drops tool calls without results and orphaned tool results", () => {
     const messages: ModelMessage[] = [

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -409,7 +409,6 @@ export class AIService extends EventEmitter {
         effectiveModelString,
         canonicalModelString,
         canonicalProviderName,
-        canonicalModelId,
         routedThroughGateway,
       } = modelResult.data;
 
@@ -603,7 +602,6 @@ export class AIService extends EventEmitter {
         providerForMessages: canonicalProviderName,
         effectiveThinkingLevel,
         modelString,
-        canonicalModelId,
         workspaceId,
       });
 

--- a/src/node/services/coreServices.ts
+++ b/src/node/services/coreServices.ts
@@ -113,6 +113,7 @@ export function createCoreServices(opts: CoreServicesOptions): CoreServices {
     initStateManager
   );
   aiService.setTaskService(taskService);
+  workspaceService.setTaskService(taskService);
 
   return {
     historyService,

--- a/src/node/services/messagePipeline.ts
+++ b/src/node/services/messagePipeline.ts
@@ -58,8 +58,6 @@ export interface PrepareMessagesOptions {
   effectiveThinkingLevel: ThinkingLevel;
   /** Full model string (used for cache control). */
   modelString: string;
-  /** Canonical model ID (used for noPrefill detection). */
-  canonicalModelId?: string;
   /** Workspace ID (used only for debug logging). */
   workspaceId: string;
 }
@@ -100,7 +98,6 @@ export async function prepareMessagesForProvider(
     providerForMessages,
     effectiveThinkingLevel,
     modelString,
-    canonicalModelId,
     workspaceId,
   } = opts;
 
@@ -181,9 +178,6 @@ export async function prepareMessagesForProvider(
   const transformedMessages = transformModelMessages(modelMessages, providerForMessages, {
     anthropicThinkingEnabled:
       providerForMessages === "anthropic" && effectiveThinkingLevel !== "off",
-    // Opus 4.6 doesn't support assistant message prefill (returns 400 error).
-    // Append a [CONTINUE] user sentinel if conversation ends with assistant.
-    noPrefill: canonicalModelId?.includes("opus-4-6") ?? false,
   });
 
   // Apply cache control for Anthropic models AFTER transformation

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -784,12 +784,12 @@ describe("TaskService", () => {
     const { aiService } = createAIServiceMocks(config, {
       isStreaming: mock((workspaceId: string) => workspaceId === reportedTaskId),
     });
-    const { workspaceService, resumeStream } = createWorkspaceServiceMocks();
+    const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
     const { taskService } = createTaskServiceHarness(config, { aiService, workspaceService });
 
     await taskService.initialize();
 
-    expect(resumeStream).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
 
     const cfg = config.loadConfigOrDefault();
     const queued = Array.from(cfg.projects.values())
@@ -1164,7 +1164,7 @@ describe("TaskService", () => {
     });
 
     const { aiService } = createAIServiceMocks(config);
-    const { workspaceService, resumeStream } = createWorkspaceServiceMocks();
+    const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
     const { taskService } = createTaskServiceHarness(config, { aiService, workspaceService });
 
     const internal = taskService as unknown as {
@@ -1179,25 +1179,17 @@ describe("TaskService", () => {
       parts: [],
     });
 
-    expect(resumeStream).toHaveBeenCalledTimes(1);
-    expect(resumeStream).toHaveBeenCalledWith(
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
       rootWorkspaceId,
+      expect.stringContaining(childTaskId),
       expect.objectContaining({
         model: "openai:gpt-5.2",
         thinkingLevel: "medium",
-      })
+      }),
+      // Auto-resume skips counter reset
+      expect.objectContaining({ skipAutoResumeReset: true })
     );
-
-    const resumeCalls = (resumeStream as unknown as { mock: { calls: unknown[][] } }).mock.calls;
-    const options = resumeCalls[0]?.[1];
-    if (!options || typeof options !== "object") {
-      throw new Error("Expected resumeStream to be called with an options object");
-    }
-
-    const additionalSystemInstructions = (options as { additionalSystemInstructions?: unknown })
-      .additionalSystemInstructions;
-    expect(typeof additionalSystemInstructions).toBe("string");
-    expect(additionalSystemInstructions).toContain(childTaskId);
   });
 
   test("terminateDescendantAgentTask stops stream, removes workspace, and rejects waiters", async () => {
@@ -1339,13 +1331,14 @@ describe("TaskService", () => {
     });
 
     const { aiService } = createAIServiceMocks(config);
-    const { workspaceService, resumeStream } = createWorkspaceServiceMocks();
+    const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
     const { taskService } = createTaskServiceHarness(config, { aiService, workspaceService });
 
     await taskService.initialize();
 
-    expect(resumeStream).toHaveBeenCalledWith(
+    expect(sendMessage).toHaveBeenCalledWith(
       childId,
+      expect.stringContaining("awaiting its final agent_report"),
       expect.objectContaining({
         toolPolicy: [{ regex_match: "^agent_report$", action: "require" }],
       })
@@ -1832,7 +1825,7 @@ describe("TaskService", () => {
     });
 
     const { aiService, stopStream } = createAIServiceMocks(config);
-    const { workspaceService, resumeStream, remove, emit } = createWorkspaceServiceMocks();
+    const { workspaceService, sendMessage, remove, emit } = createWorkspaceServiceMocks();
     const { historyService, partialService, taskService } = createTaskServiceHarness(config, {
       aiService,
       workspaceService,
@@ -1997,7 +1990,12 @@ describe("TaskService", () => {
     );
 
     expect(remove).toHaveBeenCalled();
-    expect(resumeStream).toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(
+      parentId,
+      expect.stringContaining("sub-agent task(s) have completed"),
+      expect.any(Object),
+      expect.objectContaining({ skipAutoResumeReset: true })
+    );
     expect(emit).toHaveBeenCalled();
   });
 
@@ -2389,7 +2387,11 @@ describe("TaskService", () => {
     });
 
     const { aiService } = createAIServiceMocks(config);
-    const { workspaceService, resumeStream, remove } = createWorkspaceServiceMocks();
+    const {
+      workspaceService,
+      sendMessage: sendMessageMock,
+      remove,
+    } = createWorkspaceServiceMocks();
     const { historyService, partialService, taskService } = createTaskServiceHarness(config, {
       aiService,
       workspaceService,
@@ -2492,7 +2494,12 @@ describe("TaskService", () => {
     }
 
     expect(remove).toHaveBeenCalled();
-    expect(resumeStream).toHaveBeenCalled();
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      parentId,
+      expect.stringContaining("sub-agent task(s) have completed"),
+      expect.any(Object),
+      expect.objectContaining({ skipAutoResumeReset: true })
+    );
   });
 
   test("uses agent_report from stream-end parts instead of fallback", async () => {
@@ -2526,7 +2533,7 @@ describe("TaskService", () => {
     });
 
     const { aiService } = createAIServiceMocks(config);
-    const { workspaceService, sendMessage, resumeStream, remove } = createWorkspaceServiceMocks();
+    const { workspaceService, sendMessage, remove } = createWorkspaceServiceMocks();
     const { partialService, taskService } = createTaskServiceHarness(config, {
       aiService,
       workspaceService,
@@ -2576,7 +2583,13 @@ describe("TaskService", () => {
       ],
     });
 
-    expect(sendMessage).not.toHaveBeenCalled();
+    // No "agent_report reminder" sendMessage should fire (the report was in stream-end parts).
+    // The only sendMessage call should be the parent auto-resume after the child reports.
+    const sendCalls = (sendMessage as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    for (const call of sendCalls) {
+      const msg = call[1] as string;
+      expect(msg).not.toContain("agent_report");
+    }
 
     const updatedParentPartial = await partialService.readPartial(parentId);
     expect(updatedParentPartial).not.toBeNull();
@@ -2609,7 +2622,10 @@ describe("TaskService", () => {
     expect(ws?.taskStatus).toBe("reported");
 
     expect(remove).toHaveBeenCalled();
-    expect(resumeStream).toHaveBeenCalled();
+    // sendMessage is called once for the "ended without agent_report" reminder
+    // and NOT for resumeStream (since "second attempt" was already simulated).
+    // The parent auto-resume sendMessage also fires since no active descendants remain.
+    expect(sendMessage).toHaveBeenCalled();
   });
 
   test("missing agent_report triggers one reminder, then posts fallback output and cleans up", async () => {
@@ -2643,8 +2659,7 @@ describe("TaskService", () => {
     });
 
     const { aiService } = createAIServiceMocks(config);
-    const { workspaceService, sendMessage, resumeStream, remove, emit } =
-      createWorkspaceServiceMocks();
+    const { workspaceService, sendMessage, remove, emit } = createWorkspaceServiceMocks();
     const { historyService, partialService, taskService } = createTaskServiceHarness(config, {
       aiService,
       workspaceService,
@@ -2746,7 +2761,13 @@ describe("TaskService", () => {
     expect(ws?.taskStatus).toBe("reported");
 
     expect(remove).toHaveBeenCalled();
-    expect(resumeStream).toHaveBeenCalled();
+    // Parent auto-resume now uses sendMessage instead of resumeStream
+    expect(sendMessage).toHaveBeenCalledWith(
+      parentId,
+      expect.stringContaining("sub-agent task(s) have completed"),
+      expect.any(Object),
+      expect.objectContaining({ skipAutoResumeReset: true })
+    );
   });
 
   test("falls back to default trunk when parent branch does not exist locally", async () => {
@@ -2819,4 +2840,205 @@ describe("TaskService", () => {
     expect(childEntry).toBeTruthy();
     expect(childEntry?.runtimeConfig?.type).toBe("worktree");
   }, 20_000);
+
+  describe("parent auto-resume flood protection", () => {
+    async function setupParentWithActiveChild(rootDirPath: string) {
+      const config = await createTestConfig(rootDirPath);
+      const projectPath = path.join(rootDirPath, "repo");
+      await fsPromises.mkdir(projectPath, { recursive: true });
+
+      const rootWorkspaceId = "root-resume-111";
+      const childTaskId = "child-resume-222";
+
+      await config.saveConfig({
+        projects: new Map([
+          [
+            projectPath,
+            {
+              workspaces: [
+                {
+                  path: path.join(projectPath, "root"),
+                  id: rootWorkspaceId,
+                  name: "root",
+                  aiSettings: { model: "openai:gpt-5.2", thinkingLevel: "medium" as const },
+                },
+                {
+                  path: path.join(projectPath, "child-task"),
+                  id: childTaskId,
+                  name: "child-task",
+                  parentWorkspaceId: rootWorkspaceId,
+                  agentType: "explore",
+                  taskStatus: "running" as const,
+                  taskModelString: "openai:gpt-5.2",
+                },
+              ],
+            },
+          ],
+        ]),
+        taskSettings: { maxParallelAgentTasks: 3, maxTaskNestingDepth: 3 },
+      });
+
+      const { aiService } = createAIServiceMocks(config);
+      const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
+      const { taskService } = createTaskServiceHarness(config, {
+        aiService,
+        workspaceService,
+      });
+
+      const internal = taskService as unknown as {
+        handleStreamEnd: (event: StreamEndEvent) => Promise<void>;
+      };
+
+      const makeStreamEndEvent = (): StreamEndEvent => ({
+        type: "stream-end",
+        workspaceId: rootWorkspaceId,
+        messageId: `assistant-${Date.now()}`,
+        metadata: { model: "openai:gpt-5.2" },
+        parts: [],
+      });
+
+      return {
+        config,
+        taskService,
+        internal,
+        sendMessage,
+        rootWorkspaceId,
+        childTaskId,
+        projectPath,
+        makeStreamEndEvent,
+      };
+    }
+
+    test("stops auto-resuming after MAX_CONSECUTIVE_PARENT_AUTO_RESUMES (3)", async () => {
+      const { internal, sendMessage, makeStreamEndEvent } =
+        await setupParentWithActiveChild(rootDir);
+
+      // First 3 calls should trigger sendMessage (limit is 3)
+      for (let i = 0; i < 3; i++) {
+        await internal.handleStreamEnd(makeStreamEndEvent());
+      }
+      expect(sendMessage).toHaveBeenCalledTimes(3);
+
+      // 4th call should NOT trigger sendMessage (limit exceeded)
+      await internal.handleStreamEnd(makeStreamEndEvent());
+      expect(sendMessage).toHaveBeenCalledTimes(3); // still 3
+    });
+
+    test("resetAutoResumeCount allows more resumes after limit", async () => {
+      const { internal, sendMessage, taskService, rootWorkspaceId, makeStreamEndEvent } =
+        await setupParentWithActiveChild(rootDir);
+
+      // Exhaust the auto-resume limit
+      for (let i = 0; i < 3; i++) {
+        await internal.handleStreamEnd(makeStreamEndEvent());
+      }
+      expect(sendMessage).toHaveBeenCalledTimes(3);
+
+      // Blocked (limit reached)
+      await internal.handleStreamEnd(makeStreamEndEvent());
+      expect(sendMessage).toHaveBeenCalledTimes(3);
+
+      // User sends a message → resets the counter
+      taskService.resetAutoResumeCount(rootWorkspaceId);
+
+      // Now auto-resume should work again
+      await internal.handleStreamEnd(makeStreamEndEvent());
+      expect(sendMessage).toHaveBeenCalledTimes(4);
+    });
+
+    test("counter is per-workspace (different workspaces are independent)", async () => {
+      const config = await createTestConfig(rootDir);
+      const projectPath = path.join(rootDir, "repo");
+      await fsPromises.mkdir(projectPath, { recursive: true });
+
+      const rootA = "root-A";
+      const rootB = "root-B";
+      const childA = "child-A";
+      const childB = "child-B";
+
+      await config.saveConfig({
+        projects: new Map([
+          [
+            projectPath,
+            {
+              workspaces: [
+                {
+                  path: path.join(projectPath, "root-a"),
+                  id: rootA,
+                  name: "root-a",
+                  aiSettings: { model: "openai:gpt-5.2", thinkingLevel: "medium" as const },
+                },
+                {
+                  path: path.join(projectPath, "child-a"),
+                  id: childA,
+                  name: "child-a",
+                  parentWorkspaceId: rootA,
+                  taskStatus: "running" as const,
+                  taskModelString: "openai:gpt-5.2",
+                },
+                {
+                  path: path.join(projectPath, "root-b"),
+                  id: rootB,
+                  name: "root-b",
+                  aiSettings: { model: "openai:gpt-5.2", thinkingLevel: "medium" as const },
+                },
+                {
+                  path: path.join(projectPath, "child-b"),
+                  id: childB,
+                  name: "child-b",
+                  parentWorkspaceId: rootB,
+                  taskStatus: "running" as const,
+                  taskModelString: "openai:gpt-5.2",
+                },
+              ],
+            },
+          ],
+        ]),
+        taskSettings: { maxParallelAgentTasks: 5, maxTaskNestingDepth: 3 },
+      });
+
+      const { aiService } = createAIServiceMocks(config);
+      const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
+      const { taskService } = createTaskServiceHarness(config, {
+        aiService,
+        workspaceService,
+      });
+
+      const internal = taskService as unknown as {
+        handleStreamEnd: (event: StreamEndEvent) => Promise<void>;
+      };
+
+      // Exhaust limit on workspace A
+      for (let i = 0; i < 3; i++) {
+        await internal.handleStreamEnd({
+          type: "stream-end",
+          workspaceId: rootA,
+          messageId: `a-${i}`,
+          metadata: { model: "openai:gpt-5.2" },
+          parts: [],
+        });
+      }
+      expect(sendMessage).toHaveBeenCalledTimes(3);
+
+      // Workspace A is now blocked
+      await internal.handleStreamEnd({
+        type: "stream-end",
+        workspaceId: rootA,
+        messageId: "a-blocked",
+        metadata: { model: "openai:gpt-5.2" },
+        parts: [],
+      });
+      expect(sendMessage).toHaveBeenCalledTimes(3); // still 3
+
+      // Workspace B should still work (independent counter)
+      await internal.handleStreamEnd({
+        type: "stream-end",
+        workspaceId: rootB,
+        messageId: "b-0",
+        metadata: { model: "openai:gpt-5.2" },
+        parts: [],
+      });
+      expect(sendMessage).toHaveBeenCalledTimes(4); // B worked
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the infinite agent loop where the agent acknowledges "stop" but a `[CONTINUE]` sentinel is automatically injected, causing the agent to keep working indefinitely.

## Background

The `noPrefill` `[CONTINUE]` sentinel was a band-aid over a structural issue: `resumeStream()` starts a stream without adding a user message, leaving the conversation ending with an assistant message. Opus 4.6 rejects trailing assistant messages with a 400 error, so `noPrefill` was added to inject a synthetic `[CONTINUE]` user message at transform time. But the model interprets `[CONTINUE]` as "the user wants me to keep working," creating infinite loops.

Three `taskService` callers used `resumeStream()` without adding a user message:
- Startup recovery for `awaiting_report` tasks
- Parent auto-resume when it has active descendants
- Parent auto-resume after child reports

## Implementation

1. **Convert broken `resumeStream` callers to `sendMessage`** — all 3 callers have explicit instructions for the agent, so a user message is the correct semantic. Each passes `skipAutoResumeReset: true` to preserve flood protection.

2. **Structural guard in `streamWithHistory()`** — after reading history, if the last message is a non-partial assistant, persist a `[CONTINUE]` sentinel before streaming. Defense-in-depth for any future caller that starts a stream with a trailing assistant. Logs a warning when triggered.

3. **Remove `noPrefill` mechanism** — the structural guard + `addInterruptedSentinel` make it redundant. Removed from `modelMessageTransform.ts`, `messagePipeline.ts`, and `aiService.ts`.

4. **Preserve flood protection** — `sendMessage` normally calls `resetAutoResumeCount`. Auto-resume callers pass `{ skipAutoResumeReset: true }` via the internal parameter to avoid defeating the consecutive limit.

## Validation

- All 33 taskService tests pass (updated to assert `sendMessage` instead of `resumeStream`)
- All 59 modelMessageTransform tests pass (noPrefill tests removed)
- `make static-check` passes (typecheck, lint, fmt)

## Risks

- **Low**: Parent workspaces now receive explicit user messages during auto-resume instead of system-instruction-only streams. The messages contain the same directive text, just delivered as user messages. This is actually better because the model gets a proper conversational turn.
- **Low**: The `streamWithHistory` guard is defense-in-depth only — all callers now properly use `sendMessage`, so the guard should never fire in normal operation.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$28.14`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=28.14 -->
