### PR TITLE
🤖 bench: keep background processes alive for extrenal verifiers

### DIFF
--- a/benchmarks/terminal_bench/mux-run.sh
+++ b/benchmarks/terminal_bench/mux-run.sh
@@ -69,6 +69,7 @@ cmd=(bun src/cli/run.ts
   --model "${MUX_MODEL}"
   --mode "${MUX_MODE}"
   --thinking "${MUX_THINKING_LEVEL}"
+  --keep-background-processes
   --json)
 
 if [[ -n "${MUX_RUNTIME}" ]]; then


### PR DESCRIPTION
## Summary

Adds a `--keep-background-processes` CLI flag to `mux run` that prevents background processes from being terminated when the CLI session exits. This fixes Terminal-Bench service-task failures where verifiers attempt to connect to servers that were already killed.

## Background

Terminal-Bench service tasks (e.g. `pypi-server`, `hf-model-inference`) start a long-lived server in the background during the agent session. After `mux run` completes, Harbor's separate verifier process checks that server is still running. Today, `mux run` unconditionally terminates all background processes on exit via:

1. `AgentSession.dispose()` → `backgroundProcessManager.cleanup(workspaceId)`
2. `run.ts` finally block → `backgroundProcessManager.terminateAll()`

This means verifiers always find a dead service. The compaction path also kills background processes mid-session, which would break long-running bench trials.

## Implementation

**`src/cli/run.ts`:**
- New `--keep-background-processes` CLI flag (also respects `MUX_KEEP_BACKGROUND_PROCESSES=1` env var)
- Gates `backgroundProcessManager.terminateAll()` in the `finally` block behind the flag
- Passes the flag through to `AgentSession`

**`src/node/services/agentSession.ts`:**
- New `keepBackgroundProcesses` option (default `false`) on `AgentSessionOptions`
- Gates `backgroundProcessManager.cleanup()` in both `dispose()` and the compaction path

**`benchmarks/terminal_bench/mux-run.sh`:**
- Passes `--keep-background-processes` in the benchmark CLI invocation

Default behavior for desktop app and non-bench CLI usage is **unchanged** — cleanup still runs unless the flag is explicitly set.

## Risks

Low. The flag is opt-in and only affects bench/CI. Desktop app paths don't pass it. The only risk is processes leaking in bench sandboxes, but those are ephemeral containers that get destroyed after each trial.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$4.10`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=4.10 -->
