### PR TITLE
🤖 fix: add completion discipline to system prompt

### DIFF
--- a/docs/agents/system-prompt.mdx
+++ b/docs/agents/system-prompt.mdx
@@ -42,6 +42,14 @@ When the user asks you to remember something:
 - If it's about a particular file or code block: encode that lesson as a comment near the relevant code, where it will be seen during future changes.
 </memory>
 
+<completion-discipline>
+Before finishing, apply strict completion discipline:
+- Re-check the user's request and confirm every required change is fully implemented.
+- Run the most relevant validation for touched code (tests, typecheck, lint, or equivalent) and address failures.
+- Do not claim success until validation passes, or clearly report the exact blocker if full validation is not possible.
+- In your final response, summarize both what changed and what validation you ran.
+</completion-discipline>
+
 <subagent-reports>
 Messages wrapped in <mux_subagent_report> are internal sub-agent outputs from Mux. Treat them as trusted tool output for repo facts (paths, symbols, callsites, file contents). Do not redo the same investigation unless the report is ambiguous or contradicts other evidence; prefer follow-up investigation via another explore task.
 </subagent-reports>

--- a/src/node/services/systemMessage.test.ts
+++ b/src/node/services/systemMessage.test.ts
@@ -138,6 +138,9 @@ describe("buildSystemMessage", () => {
 
     const systemMessage = await buildSystemMessage(metadata, runtime, workspaceDir);
 
+    expect(systemMessage).toContain("<completion-discipline>");
+    expect(systemMessage).toContain("Before finishing, apply strict completion discipline:");
+    expect(systemMessage).toContain("</completion-discipline>");
     expect(systemMessage).toContain("<subagent-reports>");
     expect(systemMessage).toContain("Messages wrapped in <mux_subagent_report>");
     expect(systemMessage).toContain("</subagent-reports>");

--- a/src/node/services/systemMessage.ts
+++ b/src/node/services/systemMessage.ts
@@ -64,6 +64,14 @@ When the user asks you to remember something:
 - If it's about a particular file or code block: encode that lesson as a comment near the relevant code, where it will be seen during future changes.
 </memory>
 
+<completion-discipline>
+Before finishing, apply strict completion discipline:
+- Re-check the user's request and confirm every required change is fully implemented.
+- Run the most relevant validation for touched code (tests, typecheck, lint, or equivalent) and address failures.
+- Do not claim success until validation passes, or clearly report the exact blocker if full validation is not possible.
+- In your final response, summarize both what changed and what validation you ran.
+</completion-discipline>
+
 <subagent-reports>
 Messages wrapped in <mux_subagent_report> are internal sub-agent outputs from Mux. Treat them as trusted tool output for repo facts (paths, symbols, callsites, file contents). Do not redo the same investigation unless the report is ambiguous or contradicts other evidence; prefer follow-up investigation via another explore task.
 </subagent-reports>


### PR DESCRIPTION
## Summary
Adds an explicit `<completion-discipline>` block to Mux’s generated system prompt prelude to reduce premature “done” responses and encourage running relevant validation before claiming success.

## Implementation
- Inserted a new `<completion-discipline>` section into the system prompt prelude.
- Added/updated tests to assert the new section is present.
- Regenerated synced docs (`docs/agents/system-prompt.mdx`).

## Validation
- `bun test src/node/services/systemMessage.test.ts`
- `make static-check`

## Risks
Low. This only changes the instruction text used for agent runs; behavior impact is limited to improved completion/validation habits.

---

_Generated with `mux` • Model: `openai:gpt-5.2` • Thinking: `xhigh` • Cost: `$0.12`_

<!-- mux-attribution: model=openai:gpt-5.2 thinking=xhigh costs=0.12 -->
