### PR TITLE
🤖 tests: remove tautological tests that mirror static content

### DIFF
--- a/src/common/utils/ui/modeUtils.test.ts
+++ b/src/common/utils/ui/modeUtils.test.ts
@@ -16,25 +16,6 @@ describe("getPlanModeInstruction", () => {
     expect(instruction).toContain("A plan file already exists");
     expect(instruction).toContain("read it to determine if it's relevant");
   });
-
-  it("includes instructions to use ask_user_question (and avoid post-propose_plan clutter)", () => {
-    const instruction = getPlanModeInstruction("/tmp/plan.md", false);
-
-    expect(instruction).toContain("MUST use the ask_user_question tool");
-    expect(instruction).toContain('Do not include an "Open Questions" section');
-
-    // UI already renders the plan + plan file location, so the agent should not repeat them in chat.
-    expect(instruction).toContain("do not repeat/paste the plan contents");
-    expect(instruction).toContain('do not say "the plan is ready at <path>"');
-  });
-
-  it("includes sub-agent delegation guidance", () => {
-    const instruction = getPlanModeInstruction("/tmp/plan.md", false);
-
-    expect(instruction).toContain("Trust Explore sub-agent reports as authoritative");
-    expect(instruction).toContain('MUST ONLY spawn `agentId: "explore"` tasks');
-    expect(instruction).toContain("Do NOT call `propose_plan` until");
-  });
 });
 
 describe("getPlanFileHint", () => {

--- a/src/node/services/agentDefinitions/agentDefinitionsService.test.ts
+++ b/src/node/services/agentDefinitions/agentDefinitionsService.test.ts
@@ -6,7 +6,6 @@ import { describe, expect, test } from "bun:test";
 import { AgentIdSchema } from "@/common/orpc/schemas";
 import { LocalRuntime } from "@/node/runtime/LocalRuntime";
 import { DisposableTempDir } from "@/node/services/tempDir";
-import { getBuiltInAgentDefinitions } from "./builtInAgentDefinitions";
 import {
   discoverAgentDefinitions,
   readAgentDefinition,
@@ -130,15 +129,6 @@ Replaced body.
     const replacerBody = await resolveAgentBody(runtime, tempDir.path, "replacer", { roots });
     expect(replacerBody).toBe("Replaced body.\n");
     expect(replacerBody).not.toContain("Base instructions");
-  });
-
-  test("Ask agent instructs to trust Explore sub-agent reports", () => {
-    const ask = getBuiltInAgentDefinitions().find((a) => a.id === "ask");
-    expect(ask).toBeDefined();
-    expect(ask!.frontmatter.ui?.color).toBe("var(--color-ask-mode)");
-
-    expect(ask!.body).toContain("Trust Explore sub-agent reports as authoritative for repo facts");
-    expect(ask!.body).toContain("ambiguous or contradicts other evidence");
   });
 
   test("same-name override: project agent with base: self extends built-in/global, not itself", async () => {

--- a/src/node/services/systemMessage.test.ts
+++ b/src/node/services/systemMessage.test.ts
@@ -127,25 +127,6 @@ describe("buildSystemMessage", () => {
     mockHomedir?.mockRestore();
   });
 
-  test("includes mux_subagent_report guidance in the system prompt", async () => {
-    const metadata: WorkspaceMetadata = {
-      id: "test-workspace",
-      name: "test-workspace",
-      projectName: "test-project",
-      projectPath: projectDir,
-      runtimeConfig: DEFAULT_RUNTIME_CONFIG,
-    };
-
-    const systemMessage = await buildSystemMessage(metadata, runtime, workspaceDir);
-
-    expect(systemMessage).toContain("<completion-discipline>");
-    expect(systemMessage).toContain("Before finishing, apply strict completion discipline:");
-    expect(systemMessage).toContain("</completion-discipline>");
-    expect(systemMessage).toContain("<subagent-reports>");
-    expect(systemMessage).toContain("Messages wrapped in <mux_subagent_report>");
-    expect(systemMessage).toContain("</subagent-reports>");
-  });
-
   test("includes general instructions in custom-instructions", async () => {
     await fs.writeFile(
       path.join(projectDir, "AGENTS.md"),


### PR DESCRIPTION
## Summary

Removes 4 tautological tests across 3 files that only asserted hardcoded strings appear in output where those strings are static constants — providing zero behavioral coverage and adding maintenance burden (any prompt wording change requires updating tests that test nothing).

## Background

PR #2273 highlighted the pattern: when the system prompt `PRELUDE` gains a new section, tests get added that assert the exact static text appears in the output of `buildSystemMessage()`. Since `PRELUDE` is unconditionally included via `PRELUDE.trim()`, these tests are tautological — they verify a template literal contains its own content.

A broader scan found the same anti-pattern in two other test files.

## Implementation

**Removed tests (4 tests, 15 tautological assertions):**

| File | Test | Assertions | Mirrors |
|------|------|-----------|---------|
| `systemMessage.test.ts` | "includes mux_subagent_report guidance in the system prompt" | 6 | `PRELUDE` constant (`<completion-discipline>`, `<subagent-reports>`) |
| `modeUtils.test.ts` | "includes instructions to use ask_user_question..." | 4 | Static return text of `getPlanModeInstruction()` |
| `modeUtils.test.ts` | "includes sub-agent delegation guidance" | 3 | Static return text of `getPlanModeInstruction()` |
| `agentDefinitionsService.test.ts` | "Ask agent instructs to trust Explore sub-agent reports" | 2 | Static content from `ask.md` built-in agent |

**Kept tests** — all remaining tests in these files exercise real conditional logic: file reading, model-section regex matching, precedence/fallback behavior, instruction scoping, `planExists` branching, etc.

## Risks

Low. Only removes tests that provided no behavioral signal. All remaining tests pass.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=0.00 -->
