### PR TITLE
🤖 fix: add cursor-pointer to 1M context toggle button

### DIFF
--- a/src/browser/components/Toggle1MContext.tsx
+++ b/src/browser/components/Toggle1MContext.tsx
@@ -28,7 +28,7 @@ export const Toggle1MContext: React.FC<Toggle1MContextProps> = (props) => {
       type="button"
       onClick={() => toggle1MContext(props.model)}
       className={cn(
-        "flex items-center gap-1.5 text-[11px] transition-colors",
+        "flex cursor-pointer items-center gap-1.5 text-[11px] transition-colors",
         enabled ? "text-accent" : "text-muted hover:text-foreground"
       )}
       aria-label={enabled ? `Disable ${label}` : `Enable ${label}`}


### PR DESCRIPTION
## Summary

Adds `cursor-pointer` to the `Toggle1MContext` button so it visually behaves like a clickable element on hover.

## Background

The 1M context toggle in the context usage UI (`ContextUsageIndicatorButton` and `ContextUsageBar`) renders as a `<button>` but didn't change the cursor on hover, making it feel unresponsive.

## Implementation

Single-class addition (`cursor-pointer`) to the button's Tailwind classes in `Toggle1MContext.tsx`.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$N/A`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=N/A -->
