### PR TITLE
🤖 fix: always pass --org to Coder CLI and handle non-JSON preset output

### DIFF
--- a/src/browser/components/ChatInput/CoderControls.tsx
+++ b/src/browser/components/ChatInput/CoderControls.tsx
@@ -179,11 +179,10 @@ export function CoderWorkspaceForm(props: CoderWorkspaceFormProps) {
     } else {
       // Switch to new workspace mode (workspaceName omitted; backend derives from branch)
       const firstTemplate = templates[0];
-      const firstIsDuplicate = firstTemplate && hasTemplateDuplicateName(firstTemplate, templates);
       onCoderConfigChange({
         existingWorkspace: false,
         template: firstTemplate?.name,
-        templateOrg: firstIsDuplicate ? firstTemplate?.organizationName : undefined,
+        templateOrg: firstTemplate?.organizationName,
       });
     }
   };
@@ -194,7 +193,13 @@ export function CoderWorkspaceForm(props: CoderWorkspaceFormProps) {
     // Value is "org/name" when duplicates exist, otherwise just "name"
     const [orgOrName, maybeName] = value.split("/");
     const templateName = maybeName ?? orgOrName;
-    const templateOrg = maybeName ? orgOrName : undefined;
+
+    // Always resolve the org from the templates list so --org is passed to CLI
+    // even when the user belongs to multiple orgs but template names don't collide
+    const matchedTemplate = templates.find(
+      (t) => t.name === templateName && (maybeName ? t.organizationName === orgOrName : true)
+    );
+    const templateOrg = maybeName ? orgOrName : matchedTemplate?.organizationName;
 
     onCoderConfigChange({
       ...coderConfig,

--- a/src/browser/hooks/useCoderWorkspace.test.ts
+++ b/src/browser/hooks/useCoderWorkspace.test.ts
@@ -19,7 +19,7 @@ describe("buildAutoSelectedTemplateConfig", () => {
       preset: "my-preset",
       existingWorkspace: false,
       template: "template-a",
-      templateOrg: undefined,
+      templateOrg: "default-org",
     });
   });
 

--- a/src/browser/hooks/useCoderWorkspace.ts
+++ b/src/browser/hooks/useCoderWorkspace.ts
@@ -27,14 +27,11 @@ export function buildAutoSelectedTemplateConfig(
     return null;
   }
   const firstTemplate = templates[0];
-  const firstIsDuplicate = templates.some(
-    (t) => t.name === firstTemplate.name && t.organizationName !== firstTemplate.organizationName
-  );
   return {
     ...(currentConfig ?? {}),
     existingWorkspace: false,
     template: firstTemplate.name,
-    templateOrg: firstIsDuplicate ? firstTemplate.organizationName : undefined,
+    templateOrg: firstTemplate.organizationName,
   };
 }
 
@@ -366,17 +363,10 @@ export function useCoderWorkspace({
       if (newEnabled) {
         // Initialize config for new workspace mode (workspaceName omitted; backend derives)
         const firstTemplate = templates[0];
-        const firstIsDuplicate = firstTemplate
-          ? templates.some(
-              (t) =>
-                t.name === firstTemplate.name &&
-                t.organizationName !== firstTemplate.organizationName
-            )
-          : false;
         onCoderConfigChange({
           existingWorkspace: false,
           template: firstTemplate?.name,
-          templateOrg: firstIsDuplicate ? firstTemplate?.organizationName : undefined,
+          templateOrg: firstTemplate?.organizationName,
         });
       } else {
         onCoderConfigChange(null);

--- a/src/node/services/coderService.test.ts
+++ b/src/node/services/coderService.test.ts
@@ -473,6 +473,14 @@ describe("CoderService", () => {
       expect(presets).toEqual({ ok: true, presets: [] });
     });
 
+    it("returns empty array when CLI prints info message instead of JSON", async () => {
+      mockExecOk('No presets found for template "my-template" and template-version "v1".\n');
+
+      const presets = await service.listPresets("my-template");
+
+      expect(presets).toEqual({ ok: true, presets: [] });
+    });
+
     it("returns error result on error", async () => {
       mockExecError(new Error("template not found"));
 

--- a/src/node/services/coderService.ts
+++ b/src/node/services/coderService.ts
@@ -655,7 +655,8 @@ export class CoderService {
       );
       const { stdout } = await proc.result;
 
-      if (!stdout.trim()) {
+      // Same non-JSON guard as listPresets (CLI prints info message for no presets)
+      if (!stdout.trim() || !stdout.trimStart().startsWith("[")) {
         return new Set();
       }
 
@@ -878,8 +879,10 @@ export class CoderService {
       );
       const { stdout } = await proc.result;
 
-      // Handle empty output (no presets)
-      if (!stdout.trim()) {
+      // Handle empty output or non-JSON info messages (no presets).
+      // CLI prints "No presets found for template ..." to stdout even with --output=json
+      // because the Go handler returns early before the formatter runs.
+      if (!stdout.trim() || !stdout.trimStart().startsWith("[")) {
         return { ok: true, presets: [] };
       }
 


### PR DESCRIPTION
## Summary

Fixes two bugs in Coder preset loading that cause "Error loading presets" in the UI.

## Background

**Bug 1 — Missing `--org`:** When a user belongs to multiple Coder organizations, the CLI requires `--org` on commands like `coder templates presets list` and `coder create`. Mux only set `templateOrg` (which becomes `--org`) when template names collided across orgs, but the CLI needs it whenever the user is in multiple orgs regardless of name uniqueness.

**Bug 2 — Non-JSON "No presets" output:** When a template has no presets, the CLI writes `No presets found for template "..." and template-version "...".` to stdout with exit code 0, even with `--output=json`. The Go handler returns early before the JSON formatter runs. Our code only guarded against empty stdout, so `JSON.parse()` threw on this human-readable message.

## Implementation

**Fix 1:** Always populate `templateOrg` from the template's `organizationName` (already available from `listTemplates`). Changed 4 sites in `useCoderWorkspace.ts` and `CoderControls.tsx` that previously gated on duplicate-name detection. Removed the now-dead `firstIsDuplicate` variables.

**Fix 2:** In both `listPresets` and `getPresetParamNames`, replaced the `!stdout.trim()` guard with `!stdout.trim() || !stdout.trimStart().startsWith("[")` — if stdout isn't a JSON array, treat it as no presets.

## Validation

- Verified with `coder templates presets list <template> --org coder --output=json` that `--org` resolves the multi-org error
- Verified `coder templates presets list product-ops-takehome --org coder --output=json` prints human-readable message (not JSON) for templates with no presets
- Audited all CLI calls: only `coder create` and `coder templates presets list` accept `--org`, both already pass it when `org` is defined
- All 66 coderService tests pass (including new test for non-JSON output)
- All 5 useCoderWorkspace tests pass
- Typecheck clean, static-check clean

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$N/A`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh -->
