### PR TITLE
🤖 feat: show one-shot command prefix on user messages

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -1976,11 +1976,28 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         muxMetadata = reviewMetadata;
 
         const effectiveModel = modelOverride ?? compactionOptions.model ?? sendMessageOptions.model;
+        // For one-shot overrides, store the original input as rawCommand so the
+        // command prefix (e.g., "/opus+high") stays visible in the user message.
+        const oneshotCommandPrefix = modelOneShot
+          ? messageText
+              .trim()
+              .slice(0, messageText.trim().length - modelOneShot.message.length)
+              .trimEnd()
+          : undefined;
         muxMetadata = muxMetadata
-          ? { ...muxMetadata, requestedModel: effectiveModel }
+          ? {
+              ...muxMetadata,
+              requestedModel: effectiveModel,
+              ...(oneshotCommandPrefix
+                ? { rawCommand: messageText.trim(), commandPrefix: oneshotCommandPrefix }
+                : {}),
+            }
           : {
               type: "normal",
               requestedModel: effectiveModel,
+              ...(oneshotCommandPrefix
+                ? { rawCommand: messageText.trim(), commandPrefix: oneshotCommandPrefix }
+                : {}),
             };
 
         // Capture review IDs before clearing (for marking as checked on success)

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -313,6 +313,8 @@ export type MuxFrontendMetadata = MuxFrontendMetadataBase &
       }
     | {
         type: "normal"; // Regular messages
+        /** Original user input for one-shot overrides (e.g., "/opus+high do something") — used as display content so the command prefix remains visible. */
+        rawCommand?: string;
       }
   );
 


### PR DESCRIPTION
## Summary

Show one-shot slash commands (e.g., `/opus+high`) as a highlighted prefix in user message bubbles, reusing the existing `commandPrefix` infrastructure that already works for `/compact` and skill invocations.

## Implementation

- **`MuxFrontendMetadata`**: Added optional `rawCommand` to the `normal` variant.
- **`ChatInput`**: Set `rawCommand` + `commandPrefix` on `muxMetadata` for `model-oneshot` sends.

No changes to the aggregator or rendering — they already handle `rawCommand`/`commandPrefix` generically.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$14.51`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=14.51 -->
