### PR TITLE
🤖 fix: skip name generation when manual workspace name is provided

### DIFF
--- a/src/browser/components/ChatInput/useCreationWorkspace.ts
+++ b/src/browser/components/ChatInput/useCreationWorkspace.ts
@@ -352,7 +352,14 @@ export function useCreationWorkspace({
 
       setIsSending(true);
       setToast(null);
-      setCreatingWithIdentity(null);
+      // If user provided a manual name, show it immediately in the overlay
+      // instead of "Generating name…". Auto-generated names still show the
+      // loading text until generation resolves.
+      setCreatingWithIdentity(
+        !workspaceNameState.autoGenerate && workspaceNameState.name.trim()
+          ? { name: workspaceNameState.name.trim(), title: workspaceNameState.name.trim() }
+          : null
+      );
 
       try {
         // Wait for identity generation to complete (blocks if still in progress)
@@ -569,6 +576,8 @@ export function useCreationWorkspace({
       settings.thinkingLevel,
       settings.trunkBranch,
       waitForGeneration,
+      workspaceNameState.autoGenerate,
+      workspaceNameState.name,
       sectionId,
       draftId,
       promoteWorkspaceDraft,

--- a/src/browser/hooks/useWorkspaceName.ts
+++ b/src/browser/hooks/useWorkspaceName.ts
@@ -374,13 +374,9 @@ export function useWorkspaceName(options: UseWorkspaceNameOptions): UseWorkspace
         setError("Please enter a workspace name");
         return null;
       }
-      // Generate identity for the message to get the title, then override name with manual
-      const identity = await generateIdentity(message);
-      if (identity) {
-        // Use manual name with AI-generated title
-        return { name: manualName.trim(), title: identity.title };
-      }
-      // Fallback: if generation fails, use manual name as title too
+      // Manual name provided — skip LLM call entirely.
+      // The manual name doubles as the display title; users who type a custom
+      // name expect to see exactly that in the sidebar.
       return { name: manualName.trim(), title: manualName.trim() };
     }
 


### PR DESCRIPTION
## Summary

Eliminates the 1–3 second "Generating name…" spinner when creating a workspace with a manually-entered name. The overlay now instantly shows the user's chosen name, and `waitForGeneration()` returns synchronously instead of making an unnecessary LLM call.

## Background

When a user manually types a workspace name (disabling auto-generation) and hits Send, the creation overlay still showed "Generating name…" while an LLM call ran in the background — just to generate a *title*. This was confusing (the user already chose their name) and delayed showing the chat window by 1–3 seconds.

## Implementation

**`src/browser/hooks/useWorkspaceName.ts`** — `waitForGeneration()` manual-mode branch:
- Removed the `await generateIdentity(message)` LLM call. Now returns `{ name: manualName, title: manualName }` synchronously. The manual name is used as the display title — users who type a custom name expect to see exactly that in the sidebar.

**`src/browser/components/ChatInput/useCreationWorkspace.ts`** — `handleSend()`:
- Instead of always setting `creatingWithIdentity` to `null` (showing "Generating name…"), checks if the user has a manual name and sets it immediately — the overlay shows the workspace name from frame one.

Auto-generate mode is completely unchanged.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$5.30`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=5.30 -->
