### PR TITLE
🤖 fix: keep /init skill hover preview opaque

### DIFF
--- a/src/browser/components/Messages/UserMessageContent.tsx
+++ b/src/browser/components/Messages/UserMessageContent.tsx
@@ -4,7 +4,7 @@ import type { ReviewNoteDataForDisplay } from "@/common/types/message";
 import type { FilePart } from "@/common/orpc/schemas";
 import { cn } from "@/common/lib/utils";
 import { ReviewBlockFromData } from "../shared/ReviewBlock";
-import { HoverCard, HoverCardContent, HoverCardTrigger } from "../ui/hover-card";
+import { HoverCard, HoverCardContent, HoverCardPortal, HoverCardTrigger } from "../ui/hover-card";
 import { isDesktopMode } from "@/browser/hooks/useDesktopTitlebar";
 import { MarkdownRenderer } from "./MarkdownRenderer";
 
@@ -176,13 +176,16 @@ export const UserMessageContent: React.FC<UserMessageContentProps> = (props) => 
         <HoverCardTrigger asChild>
           <CommandPrefixBadge prefix={shouldHighlightPrefix} className="cursor-help" />
         </HoverCardTrigger>
-        <HoverCardContent
-          align="start"
-          side="top"
-          className="border-border-medium max-h-[360px] w-[520px] max-w-[80vw] overflow-auto border-2 p-3"
-        >
-          <MarkdownRenderer content={snapshotMarkdown} preserveLineBreaks />
-        </HoverCardContent>
+        {/* Keep skill preview above chat chrome and fully opaque while hovering. */}
+        <HoverCardPortal>
+          <HoverCardContent
+            align="start"
+            side="top"
+            className="border-border-medium bg-modal-bg z-[1600] max-h-[360px] w-[520px] max-w-[80vw] overflow-auto border-2 p-3"
+          >
+            <MarkdownRenderer content={snapshotMarkdown} preserveLineBreaks />
+          </HoverCardContent>
+        </HoverCardPortal>
       </HoverCard>
     ) : (
       <CommandPrefixBadge prefix={shouldHighlightPrefix} />

--- a/src/browser/components/ui/hover-card.tsx
+++ b/src/browser/components/ui/hover-card.tsx
@@ -7,6 +7,8 @@ const HoverCard = HoverCardPrimitive.Root;
 
 const HoverCardTrigger = HoverCardPrimitive.Trigger;
 
+const HoverCardPortal = HoverCardPrimitive.Portal;
+
 const HoverCardContent = React.forwardRef<
   React.ElementRef<typeof HoverCardPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
@@ -28,4 +30,4 @@ const HoverCardContent = React.forwardRef<
 ));
 HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
 
-export { HoverCard, HoverCardTrigger, HoverCardContent };
+export { HoverCard, HoverCardTrigger, HoverCardPortal, HoverCardContent };


### PR DESCRIPTION
Summary
This fixes the `/init` skill command-prefix hover preview in chat so the rich snapshot card renders as an opaque floating surface above message chrome instead of blending with underlying content.

Background
The hover preview content was rendered inline without a portal at this callsite, which made it vulnerable to local stacking contexts in the chat message tree. Even with `bg-modal-bg`, the surface could appear visually transparent/bleeding due to layering.

Implementation
- Exported `HoverCardPortal` from the shared hover-card wrapper (`src/browser/components/ui/hover-card.tsx`).
- Updated the `/init` snapshot preview in `UserMessageContent` to render `HoverCardContent` through `HoverCardPortal`.
- Added callsite-level classes `bg-modal-bg` and `z-[1600]` plus an inline rationale comment to keep this floating preview opaque and above chat chrome.

Validation
- `make typecheck`
- `make lint`
- `make static-check`

Risks
Low risk and tightly scoped to one hover-card callsite plus a non-breaking primitive export. Existing hover-card consumers are unchanged unless they opt into the new portal export.

---

<details>
<summary>📋 Implementation Plan</summary>

## Context / Why
The `/init` skill preview hover tooltip (the rich card with YAML frontmatter + markdown body) is rendering with an effectively transparent background in chat, making underlying content bleed through and harming readability. We need a focused UI fix that keeps the card opaque and layered above surrounding message content without destabilizing other tooltip/popover surfaces.

## Evidence
- `src/browser/components/Messages/UserMessageContent.tsx` (lines 174–186): the rich `/init` preview is rendered via `HoverCard` + `HoverCardContent` around `CommandPrefixBadge`.
- `src/browser/components/Messages/UserMessageContent.tsx` (lines 49–67): snapshot markdown is intentionally rich (YAML fenced block + body), matching the screenshot.
- `src/browser/components/ui/hover-card.tsx`: shared hover card content class includes `bg-modal-bg`, but content is **not** wrapped in a Radix portal and defaults to low stacking (`z-50`).
- `src/browser/components/ui/popover.tsx`: popovers already use `PopoverPrimitive.Portal` and much higher stacking (`z-[1600]`), which is the stable pattern for floating surfaces in this codebase.
- `src/browser/styles/globals.css`: `--color-modal-bg` is opaque in all shipped themes; transparency is therefore likely from rendering context/layering, not token value.

## Implementation details
### Approach A (recommended) — Scope the fix to the `/init` preview hover card (**net +10 to +16 LoC**)
1. **Expose the portal primitive from the hover-card wrapper**
   - **File:** `src/browser/components/ui/hover-card.tsx`
   - **Symbols:** `HoverCardPortal` export
   - Add a typed alias to `HoverCardPrimitive.Portal` and export it with existing hover-card primitives.

   ```tsx
   const HoverCardPortal = HoverCardPrimitive.Portal;
   ...
   export { HoverCard, HoverCardTrigger, HoverCardPortal, HoverCardContent };
   ```

2. **Render the skill snapshot hover content through a portal + explicit high stacking**
   - **File:** `src/browser/components/Messages/UserMessageContent.tsx`
   - **Symbols:** `UserMessageContent` rich-prefix hover block
   - Update imports to include `HoverCardPortal`.
   - Wrap the existing `HoverCardContent` for `snapshotMarkdown` in `<HoverCardPortal>`.
   - Add explicit `z-[1600]` and `bg-modal-bg` on this callsite so the card stays above message chrome and remains opaque even if base wrapper classes evolve.
   - Add a short “why” comment: this preview is a floating surface and must escape local stacking/opacity contexts.

   ```tsx
   <HoverCard openDelay={150}>
     <HoverCardTrigger asChild>
       <CommandPrefixBadge prefix={shouldHighlightPrefix} className="cursor-help" />
     </HoverCardTrigger>

     {/* Keep skill snapshot preview fully opaque + above message layers. */}
     <HoverCardPortal>
       <HoverCardContent
         align="start"
         side="top"
         className="z-[1600] border-border-medium bg-modal-bg max-h-[360px] w-[520px] max-w-[80vw] overflow-auto border-2 p-3"
       >
         <MarkdownRenderer content={snapshotMarkdown} preserveLineBreaks />
       </HoverCardContent>
     </HoverCardPortal>
   </HoverCard>
   ```

3. **Sanity-check adjacent hover-card callsites for regressions**
   - **Files:**
     - `src/browser/components/WorkspaceListItem.tsx`
     - `src/browser/components/GitStatusIndicatorView.tsx`
   - No code changes planned unless behavior regression appears.

<details>
<summary>Fallback if transparency persists after Approach A</summary>

### Approach B — Promote portal behavior in shared hover-card wrapper (**net +6 to +12 LoC**)
- Move `HoverCardPrimitive.Content` inside `HoverCardPrimitive.Portal` directly in `src/browser/components/ui/hover-card.tsx` (shared default), and bump wrapper default from `z-50` to `z-[1600]` to align with popover layering.
- This is broader blast radius (all hover cards), so only apply if scoped callsite fix does not resolve the issue.

</details>

## Validation plan
1. `make typecheck`
2. `make lint` (or targeted lint if repo convention allows)
3. Manual UI verification in app (`make dev`):
   - Hover `/init` command prefix badge in a user message and confirm preview background is fully opaque.
   - Confirm preview is layered above surrounding chat content and status overlays.
   - Smoke-check existing hover cards (workspace title hover + git status hover) still open/close correctly.

</details>

---
_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$3.25`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=3.25 -->
