### PR TITLE
🤖 fix: allow dynamic-bag reads on const {} in PTC validator

### DIFF
--- a/src/node/services/ptc/typeValidator.test.ts
+++ b/src/node/services/ptc/typeValidator.test.ts
@@ -316,6 +316,31 @@ mux.file_read({ path: "wrong" });`,
     expect(result.valid).toBe(true);
   });
 
+  test("catches bag reads in bracket-write RHS before assignment applies", () => {
+    const result = validateTypes(
+      `
+      const r = {};
+      r["a"] = r.typo;
+    `,
+      muxTypes
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.message.includes("typo"))).toBe(true);
+  });
+
+  test("catches bag reads in bracket-write index expression before assignment applies", () => {
+    const result = validateTypes(
+      `
+      const r = {};
+      r[r.typo] = 1;
+    `,
+      muxTypes
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.message.includes("typo"))).toBe(true);
+  });
   test("does not suppress bag reads in nested function due to outer writes", () => {
     const result = validateTypes(
       `

--- a/src/node/services/ptc/typeValidator.ts
+++ b/src/node/services/ptc/typeValidator.ts
@@ -318,7 +318,12 @@ function findDynamicEmptyObjectBagFirstWritePosByContainer(
         const receiverSymbol = checker.getSymbolAtLocation(receiverIdent);
         if (receiverSymbol && emptyLiteralSymbols.has(receiverSymbol)) {
           const writeContainer = getEnclosingFunctionLikeContainer(node, sourceFile);
-          maybeRecordWrite(receiverSymbol, writeContainer, node.getStart(sourceFile));
+
+          // Record the "write" position *after* the assignment has evaluated. JS evaluates the
+          // element-access base + index + RHS before applying the assignment, so using the node's
+          // start would incorrectly treat reads inside the assignment expression as "after" the
+          // write (e.g. `r["a"] = r.typo`).
+          maybeRecordWrite(receiverSymbol, writeContainer, node.right.getEnd());
         }
       }
     }


### PR DESCRIPTION
## Summary

Fixes the PTC type validator to suppress TS2339 on `{}` only for true "dynamic bag" flows (empty object literal + bracket writes), instead of suppressing all TS2339 on `{}` which hid real safety checks.

## Background

The PTC type validator runs TypeScript diagnostics on agent code before execution. When agents build objects dynamically:

```js
const results = {};
for (const f of files) { results[f.label] = mux.file_read(...); }
return results.workspaceconnections.success;
//     ^ TS2339: Property 'workspaceconnections' does not exist on type '{}'
```

Bracket writes (`results[key] = val`) don't trigger TS2339 (because `noImplicitAny: false`), but subsequent dot-notation reads do. The first commit broadly suppressed ALL TS2339 on `{}`, but this also hid real errors:

- **Union types** like `{} | ToolResult` where `{}` is only one branch
- **Accidental shadowing** like `const mux = {}; mux.file_read(...)` — a real runtime error
- **Compound assignments** like `obj.count += 1` on unknown properties

## Implementation

Replaced the broad `isEmptyObjectPropertyError` with two targeted filters:

**1. `isEmptyObjectWriteError`** (restored from before) — suppresses dot-notation WRITES to `{}` like `results.foo = val`. Uses AST to verify the property access is on the left side of `=`.

**2. `isDynamicBagReadError`** (new) — suppresses dot-notation READS only when ALL of:
- The variable was declared as `const x = {}` (empty literal)
- The variable has element-access writes somewhere (`x[key] = val`)
- The variable is NOT `mux` (preserves shadowing detection)
- The access is a pure read (NOT compound assignments like `+=`, NOT `++`/`--`)

Supporting functions:
- **`findDynamicEmptyObjectBagVars`** — single AST walk to identify variables that are both empty-literal-initialized and have bracket writes
- **`findPropertyAccessContext`** — shared helper to walk from a token to its enclosing `PropertyAccessExpression` + receiver

## Validation

- 60/60 typeValidator tests pass
- 34/34 staticAnalysis tests pass
- `make typecheck` clean

### New regression tests

| Test | Ensures |
|---|---|
| `allows reads from {} after bracket writes` | Original bug fix — bracket-write + dot-read pattern works |
| `allows multiple dot reads from {} bag after bracket writes` | Chained access with ternary on bag vars works |
| `still catches mux shadowing with {}` | `const mux = {}; mux.file_read(...)` still errors |
| `catches reads on {} without bracket writes (not a dynamic bag)` | Plain `{}` without bracket writes still catches typos |
| `catches compound assignment on {} bag (+=)` | `results.count += 1` still errors even on bag vars |

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh -->
