### PR TITLE
🤖 fix: restore hidden tray window when relaunching on Windows

### DIFF
--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -175,6 +175,8 @@ let mainWindowFinishedLoading = false;
 function focusMainWindow() {
   if (!mainWindow) return;
   if (mainWindow.isMinimized()) mainWindow.restore();
+  // Closing Mux on Windows hides to tray; show it again when a second-instance launch occurs.
+  mainWindow.show();
   mainWindow.focus();
 }
 


### PR DESCRIPTION
## Summary
Fixes a Windows tray edge case where relaunching Mux from the Start Menu after closing-to-tray did not bring the window back.

## Background
On Windows, closing the window hides Mux to the tray (`mainWindow.hide()`). Launching Mux again triggers Electron's `second-instance` path, which previously only attempted `restore()` (for minimized windows) and `focus()`. Hidden windows are neither minimized nor visible, so the app stayed hidden.

Closes #2288.

## Implementation
- Updated `focusMainWindow()` in `src/desktop/main.ts` to call `mainWindow.show()` before `mainWindow.focus()`.
- Added an inline comment explaining that this specifically handles close-to-tray behavior on Windows during second-instance launches.

## Validation
- `make typecheck`
- `make lint`
- `make static-check`

## Risks
Low risk. The change only touches the window focus helper and aligns it with the existing `openMuxFromTray()` behavior, which already calls `show()`.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.35`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.35 -->
