### PR TITLE
🤖 bench: add task timestamps to BigQuery uploads

### DIFF
--- a/scripts/upload-harbor-results.py
+++ b/scripts/upload-harbor-results.py
@@ -118,6 +118,11 @@ def extract_task_timestamps(trial_result: dict) -> tuple[str | None, str | None]
     if not started or not finished:
         return None, None
 
+    # Normalize RFC3339 'Z' suffix to '+00:00' for fromisoformat compatibility
+    # (Python < 3.11 rejects trailing 'Z', common in JS/Harbor output)
+    started = started.replace("Z", "+00:00") if isinstance(started, str) else started
+    finished = finished.replace("Z", "+00:00") if isinstance(finished, str) else finished
+
     # Validate timestamps parse correctly before sending to BQ
     try:
         datetime.fromisoformat(started)

--- a/scripts/upload-tbench-results.py
+++ b/scripts/upload-tbench-results.py
@@ -130,6 +130,11 @@ def extract_task_timestamps(trial_result: dict) -> tuple[str | None, str | None]
     if not started or not finished:
         return None, None
 
+    # Normalize RFC3339 'Z' suffix to '+00:00' for fromisoformat compatibility
+    # (Python < 3.11 rejects trailing 'Z', common in JS/Harbor output)
+    started = started.replace("Z", "+00:00") if isinstance(started, str) else started
+    finished = finished.replace("Z", "+00:00") if isinstance(finished, str) else finished
+
     # Validate timestamps parse correctly before sending to BQ
     try:
         datetime.fromisoformat(started)


### PR DESCRIPTION
## Summary

Extract per-task agent execution timestamps from Harbor's trial `result.json` and upload them to BigQuery. Duration can be computed at query time rather than storing a precomputed value.

## Background

The tbench pipeline tracks pass/fail, token counts, and cost per task — but no timing data reaches BigQuery. The SKILL.md references duration stats (mean ~6min, p95 ~15min) from a one-off manual analysis, but these are never recorded systematically. This blocks trend analysis of task durations across models, commits, and experiments.

Harbor's trial runner already records timing automatically via `TrialResult.agent_execution.started_at/finished_at` — the data was just never extracted by the upload scripts.

## Implementation

**New columns:** `task_started_at` and `task_completed_at` (ISO 8601 TIMESTAMP)

- Added `extract_task_timestamps()` to both `scripts/upload-tbench-results.py` and `scripts/upload-harbor-results.py`
  - Prefers `agent_execution` timing (excludes env setup + verification)
  - Falls back to top-level trial `started_at`/`finished_at`
  - Validates timestamps parse correctly before including them
- Added `_filter_rows_for_table_schema()` to `upload-tbench-results.py` (mirroring what `upload-harbor-results.py` already has) — this drops unknown keys so the scripts can deploy safely before BQ columns are added

**Example BQ query for durations:**
```sql
SELECT
  task_id,
  model_name,
  TIMESTAMP_DIFF(task_completed_at, task_started_at, SECOND) AS duration_secs
FROM `mux-benchmarks.benchmarks.tbench_results`
WHERE dataset = 'terminal-bench@2.0'
```

## Deploy

After merging, add the BQ columns:
```sql
ALTER TABLE `mux-benchmarks.benchmarks.tbench_results`
ADD COLUMN task_started_at TIMESTAMP;

ALTER TABLE `mux-benchmarks.benchmarks.tbench_results`
ADD COLUMN task_completed_at TIMESTAMP;

ALTER TABLE `mux-benchmarks.benchmarks.harbor_results`
ADD COLUMN task_started_at TIMESTAMP;

ALTER TABLE `mux-benchmarks.benchmarks.harbor_results`
ADD COLUMN task_completed_at TIMESTAMP;
```

The `_filter_rows_for_table_schema` guard means the script deploys safely even before the columns exist — new fields are silently dropped until the schema is updated.

## Risks

Low — both upload scripts already defensively filter rows against the BQ table schema (harbor had this, tbench gets it in this PR). New fields are nullable and ignored until the BQ columns are created.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$5.58`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=5.58 -->
