### PR TITLE
🤖 fix: preserve sidebar alignment during workspace archive/remove

### DIFF
--- a/src/browser/components/WorkspaceListItem.tsx
+++ b/src/browser/components/WorkspaceListItem.tsx
@@ -643,9 +643,11 @@ function RegularWorkspaceListItemInner(props: WorkspaceListItemProps) {
               </TooltipContent>
             </Tooltip>
           </ActionButtonWrapper>
+        ) : isDisabled ? (
+          // Invisible spacer preserves title alignment during archive/remove transitions
+          <div className="h-4 w-4 shrink-0" />
         ) : (
-          !isEditing &&
-          !isDisabled && (
+          !isEditing && (
             <ActionButtonWrapper hasSubtitle={hasStatusText}>
               {/* Keep the overflow menu in the left action slot to avoid duplicate affordances. */}
               <Popover


### PR DESCRIPTION
## Summary

Archiving (or removing) a workspace caused its title to shift ~24px to the left in the sidebar because the `ActionButtonWrapper` was conditionally hidden.

## Background

The sidebar row layout is `[SelectionBar] [ActionButtonWrapper 16px] [gap-2] [Title]`. When `isDisabled` (set during archive/remove), the `!isDisabled` guard on line 648 prevented the `ActionButtonWrapper` from rendering, removing the 16px spacer + 8px flex gap.

## Implementation

- Add a `<div className="h-4 w-4 shrink-0" />` spacer when `isDisabled` to preserve horizontal alignment
- Add `ArchivingWorkspaceAlignment` Storybook story that triggers the archiving transient state via a never-resolving mock, capturing the regression visually

## Validation

- Typecheck passes
- Story exercises the exact flow: hover → overflow menu → "Archive chat" → verifies "Archiving..." text appears with title aligned

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$2.36`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=2.36 -->
