### PR TITLE
🤖 fix: restore titlebar drag region between version text and settings buttons

### DIFF
--- a/src/browser/components/TitleBar.tsx
+++ b/src/browser/components/TitleBar.tsx
@@ -253,6 +253,8 @@ export function TitleBar() {
       style={leftInset > 0 ? { paddingLeft: leftInset } : undefined}
     >
       <div
+        // Desktop titlebar: this wrapper is `flex-1` (for version ellipsis) so it fills the gap.
+        // Keep it draggable; apply `titlebar-no-drag` only to the interactive controls inside.
         className={cn(
           "mr-4 flex min-w-0 flex-1",
           leftInset > 0 ? "flex-col" : "items-center gap-2"


### PR DESCRIPTION
## Summary

Restores the draggable gap between the version number and the gateway/settings buttons in the left sidebar titlebar header.

## Background

Commit cfc2bbdd7 ("fix: ellipsize titlebar version text in sidebar header #2255") added `flex-1` to the left wrapper div so long `git describe` strings would ellipsize. However, that div also carried `titlebar-no-drag`, so the expanded area absorbed all the space between the version text and the right-side buttons — making it non-draggable.

## Implementation

Move `titlebar-no-drag` from the left `flex-1` wrapper div down to its interactive child (the version text + update badge click target). The wrapper now inherits `titlebar-drag` from the outer container, so the empty gap is draggable again. The ellipsis behavior is preserved since `flex-1` + `min-w-0` + `truncate` remain on the wrapper/child chain.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$1.05`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=1.05 -->
