### PR TITLE
🤖 fix: resolve model/thinking before propose_plan action sends

### DIFF
--- a/src/browser/components/WorkspaceModeAISync.tsx
+++ b/src/browser/components/WorkspaceModeAISync.tsx
@@ -13,12 +13,12 @@ import {
 } from "@/common/constants/storage";
 import { getDefaultModel } from "@/browser/hooks/useModelsFromSettings";
 import { setWorkspaceModelWithOrigin } from "@/browser/utils/modelChange";
-import { coerceThinkingLevel, type ThinkingLevel } from "@/common/types/thinking";
+import {
+  resolveWorkspaceAiSettingsForAgent,
+  type WorkspaceAISettingsCache,
+} from "@/browser/utils/workspaceModeAi";
+import type { ThinkingLevel } from "@/common/types/thinking";
 import type { AgentAiDefaults } from "@/common/types/agentAiDefaults";
-
-type WorkspaceAISettingsCache = Partial<
-  Record<string, { model: string; thinkingLevel: ThinkingLevel }>
->;
 
 export function WorkspaceModeAISync(props: { workspaceId: string }): null {
   const workspaceId = props.workspaceId;
@@ -60,60 +60,18 @@ export function WorkspaceModeAISync(props: { workspaceId: string }): null {
     prevAgentIdRef.current = normalizedAgentId;
     prevWorkspaceIdRef.current = workspaceId;
 
-    const activeDescriptor = agents.find((entry) => entry.id === normalizedAgentId);
-    const fallbackAgentId =
-      activeDescriptor?.base ?? (normalizedAgentId === "plan" ? "plan" : "exec");
-    const fallbackIds =
-      fallbackAgentId && fallbackAgentId !== normalizedAgentId
-        ? [normalizedAgentId, fallbackAgentId]
-        : [normalizedAgentId];
-
-    const hasWorkspaceOverrideForAgent = workspaceByAgent[normalizedAgentId] !== undefined;
-
-    const configuredDefaults = agentAiDefaults[normalizedAgentId];
-    const inheritedConfiguredDefaults =
-      hasWorkspaceOverrideForAgent || configuredDefaults !== undefined
-        ? undefined
-        : fallbackIds
-            .slice(1)
-            .map((id) => agentAiDefaults[id])
-            .find((entry) => entry !== undefined);
-    const descriptorDefaults = fallbackIds
-      .map((id) => agents.find((entry) => entry.id === id)?.aiDefaults)
-      .find((entry) => entry !== undefined);
-
-    const configuredModelDefault =
-      configuredDefaults?.modelString ?? inheritedConfiguredDefaults?.modelString;
-    const configuredThinkingDefault =
-      configuredDefaults?.thinkingLevel ?? inheritedConfiguredDefaults?.thinkingLevel;
-    const descriptorModelDefault = descriptorDefaults?.model;
-    const descriptorThinkingDefault = descriptorDefaults?.thinkingLevel;
-
     const existingModel = readPersistedState<string>(modelKey, fallbackModel);
-    // Precedence: explicit Settings override -> workspace by-agent value -> descriptor default
-    // -> current workspace value. "Inherit" removes the explicit override, so it falls through.
-    // For derived agents, inherited (base) Settings defaults are only considered when this agent
-    // has neither a workspace override nor its own Settings entry, matching task creation precedence.
-    const candidateModel =
-      configuredModelDefault ??
-      fallbackIds.map((id) => workspaceByAgent[id]?.model).find((entry) => entry !== undefined) ??
-      descriptorModelDefault ??
-      existingModel;
-    const resolvedModel =
-      typeof candidateModel === "string" && candidateModel.trim().length > 0
-        ? candidateModel
-        : fallbackModel;
-
     const existingThinking = readPersistedState<ThinkingLevel>(thinkingKey, "off");
-    const candidateThinking =
-      configuredThinkingDefault ??
-      fallbackIds
-        .map((id) => workspaceByAgent[id]?.thinkingLevel)
-        .find((entry) => entry !== undefined) ??
-      descriptorThinkingDefault ??
-      existingThinking ??
-      "off";
-    const resolvedThinking = coerceThinkingLevel(candidateThinking) ?? "off";
+
+    const { resolvedModel, resolvedThinking } = resolveWorkspaceAiSettingsForAgent({
+      agentId: normalizedAgentId,
+      agents,
+      agentAiDefaults,
+      workspaceByAgent,
+      fallbackModel,
+      existingModel,
+      existingThinking,
+    });
 
     if (existingModel !== resolvedModel) {
       setWorkspaceModelWithOrigin(

--- a/src/browser/utils/workspaceModeAi.ts
+++ b/src/browser/utils/workspaceModeAi.ts
@@ -1,0 +1,84 @@
+import type { AgentDefinitionDescriptor } from "@/common/types/agentDefinition";
+import type { AgentAiDefaults } from "@/common/types/agentAiDefaults";
+import { coerceThinkingLevel, type ThinkingLevel } from "@/common/types/thinking";
+
+export type WorkspaceAISettingsCache = Partial<
+  Record<string, { model: string; thinkingLevel: ThinkingLevel }>
+>;
+
+function normalizeAgentId(agentId: string): string {
+  return typeof agentId === "string" && agentId.trim().length > 0
+    ? agentId.trim().toLowerCase()
+    : "exec";
+}
+
+// Keep agent -> model/thinking precedence in one place so mode switches that send immediately
+// (like propose_plan Implement / Start Orchestrator) resolve the same settings as sync effects.
+export function resolveWorkspaceAiSettingsForAgent(args: {
+  agentId: string;
+  agents: AgentDefinitionDescriptor[];
+  agentAiDefaults: AgentAiDefaults;
+  workspaceByAgent: WorkspaceAISettingsCache;
+  fallbackModel: string;
+  existingModel: string;
+  existingThinking: ThinkingLevel;
+}): { resolvedModel: string; resolvedThinking: ThinkingLevel } {
+  const normalizedAgentId = normalizeAgentId(args.agentId);
+
+  const activeDescriptor = args.agents.find((entry) => entry.id === normalizedAgentId);
+  const fallbackAgentId =
+    activeDescriptor?.base ?? (normalizedAgentId === "plan" ? "plan" : "exec");
+  const fallbackIds =
+    fallbackAgentId && fallbackAgentId !== normalizedAgentId
+      ? [normalizedAgentId, fallbackAgentId]
+      : [normalizedAgentId];
+
+  const hasWorkspaceOverrideForAgent = args.workspaceByAgent[normalizedAgentId] !== undefined;
+
+  const configuredDefaults = args.agentAiDefaults[normalizedAgentId];
+  const inheritedConfiguredDefaults =
+    hasWorkspaceOverrideForAgent || configuredDefaults !== undefined
+      ? undefined
+      : fallbackIds
+          .slice(1)
+          .map((id) => args.agentAiDefaults[id])
+          .find((entry) => entry !== undefined);
+  const descriptorDefaults = fallbackIds
+    .map((id) => args.agents.find((entry) => entry.id === id)?.aiDefaults)
+    .find((entry) => entry !== undefined);
+
+  const configuredModelDefault =
+    configuredDefaults?.modelString ?? inheritedConfiguredDefaults?.modelString;
+  const configuredThinkingDefault =
+    configuredDefaults?.thinkingLevel ?? inheritedConfiguredDefaults?.thinkingLevel;
+  const descriptorModelDefault = descriptorDefaults?.model;
+  const descriptorThinkingDefault = descriptorDefaults?.thinkingLevel;
+
+  // Precedence: explicit Settings override -> workspace by-agent value -> descriptor default
+  // -> current workspace value. "Inherit" removes the explicit override, so it falls through.
+  // For derived agents, inherited (base) Settings defaults are only considered when this agent
+  // has neither a workspace override nor its own Settings entry, matching task creation precedence.
+  const candidateModel =
+    configuredModelDefault ??
+    fallbackIds
+      .map((id) => args.workspaceByAgent[id]?.model)
+      .find((entry) => entry !== undefined) ??
+    descriptorModelDefault ??
+    args.existingModel;
+  const resolvedModel =
+    typeof candidateModel === "string" && candidateModel.trim().length > 0
+      ? candidateModel
+      : args.fallbackModel;
+
+  const candidateThinking =
+    configuredThinkingDefault ??
+    fallbackIds
+      .map((id) => args.workspaceByAgent[id]?.thinkingLevel)
+      .find((entry) => entry !== undefined) ??
+    descriptorThinkingDefault ??
+    args.existingThinking ??
+    "off";
+  const resolvedThinking = coerceThinkingLevel(candidateThinking) ?? "off";
+
+  return { resolvedModel, resolvedThinking };
+}


### PR DESCRIPTION
## Summary
Fixes a mode-switch race in `propose_plan` primary actions so the first follow-up request after clicking **Implement** or **Start Orchestrator** uses the target agent's resolved model/thinking settings.

## Background
`ProposePlanToolCall` switched `agentId` and then immediately sent a follow-up message using options read from storage. Because `WorkspaceModeAISync` updates model/thinking asynchronously in an effect, the send could still use stale planning-mode model/thinking values. This also risked persisting stale values for the new agent on the backend.

## Implementation
- extracted shared agent AI settings resolution into `src/browser/utils/workspaceModeAi.ts`
- refactored `WorkspaceModeAISync` to use the shared resolver
- updated `ProposePlanToolCall` handlers to:
  - resolve target-agent model/thinking synchronously
  - persist `agentId`, model, and thinking before sending
  - explicitly override `agentId`, `model`, and `thinkingLevel` in `sendMessage` options
- expanded `ProposePlanToolCall` tests with an `AgentProvider` harness and assertions that Implement/Start Orchestrator sends use target-agent model/thinking values

## Validation
- `bun test src/browser/components/tools/ProposePlanToolCall.test.tsx src/browser/components/WorkspaceModeAISync.test.tsx`
- `make typecheck`
- `make static-check`

## Risks
Low-to-moderate. This change centralizes and reuses existing precedence logic; the main risk is behavior drift in model/thinking precedence. Regression tests were added around the exact Implement/Start Orchestrator paths that previously raced.

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix model selection when switching modes via Propose Plan actions

## Context / Why
Clicking **Implement** or **Start Orchestrator** on a `propose_plan` message switches the workspace agent correctly, but the *follow-up request* is sent using the **previous (planning) model/thinking settings**. This is because the UI updates `agentId` immediately, but the model/thinking sync happens later in a `useEffect`, and the backend trusts the model passed from the frontend.

Impact:
- The first “Implement the plan” / “Start orchestrating…” request uses the wrong model.
- The backend persists the stale model as the last-used model for the new agent (can “poison” per-agent workspace defaults).

## Evidence
- `src/browser/components/tools/ProposePlanToolCall.tsx`
  - `handleImplement()` updates `agentId` then immediately calls `getSendOptionsFromStorage(workspaceId)` and sends the message.
  - `handleStartOrchestrator()` does the same and only overrides `agentId`, not `model`.
- `src/browser/utils/messages/sendOptions.ts`
  - `getSendOptionsFromStorage()` reads `model` from `localStorage` key `model:${workspaceId}` and thinking from `thinkingLevel:${workspaceId}`.
- `src/browser/components/WorkspaceModeAISync.tsx`
  - Updates `model:${workspaceId}` and `thinkingLevel:${workspaceId}` *in a `useEffect`* after `agentId` changes → too late for the immediate send.
- Backend confirmation:
  - `src/node/services/workspaceService.ts` / `src/node/services/agentSession.ts` / `src/node/services/aiService.ts` use `options.model` from the IPC request; they do **not** override it based on `agentId`.

## Implementation details (recommended)
**Approach A (recommended): compute + apply the target agent’s model/thinking synchronously in the Propose Plan button handlers, using the same precedence rules as `WorkspaceModeAISync`.**

Net new product LoC estimate: **~80–140 LoC** (utility extraction + small handler changes).

### 1) Extract a shared resolver for “agentId → model/thinking”
Create a small pure helper that implements the precedence logic currently embedded in `WorkspaceModeAISync`:

- **New file** (suggested): `src/browser/utils/workspaceModeAi.ts`
- **Export**:
  - `type WorkspaceAISettingsCache = Partial<Record<string, { model: string; thinkingLevel: ThinkingLevel }>>`
  - `resolveWorkspaceAiSettingsForAgent({...}): { resolvedModel: string; resolvedThinking: ThinkingLevel }`

Shape (keep identical behavior to `WorkspaceModeAISync`):

```ts
// src/browser/utils/workspaceModeAi.ts
export function resolveWorkspaceAiSettingsForAgent(args: {
  agentId: string;
  agents: AgentDefinitionDescriptor[]; // may be []
  agentAiDefaults: AgentAiDefaults;
  workspaceByAgent: WorkspaceAISettingsCache;
  fallbackModel: string;
  existingModel: string;
  existingThinking: ThinkingLevel;
}): { resolvedModel: string; resolvedThinking: ThinkingLevel } {
  // (Move the candidateModel/candidateThinking logic out of WorkspaceModeAISync)
}
```

Then refactor `WorkspaceModeAISync.tsx` to call this helper (no behavior change; should keep all current tests passing).

### 2) Fix ProposePlanToolCall handlers to send with resolved model/thinking
Update `src/browser/components/tools/ProposePlanToolCall.tsx`:

- In both `handleImplement` and `handleStartOrchestrator`:
  1. Determine `targetAgentId` (`exec` or `orchestrator`).
  2. Read the inputs needed for resolution:
     - `agentAiDefaults` from `AGENT_AI_DEFAULTS_KEY`
     - `workspaceByAgent` from `getWorkspaceAISettingsByAgentKey(workspaceId)`
     - `existingModel` / `existingThinking` from `getModelKey(workspaceId)` / `getThinkingLevelKey(workspaceId)`
     - `fallbackModel` from `getDefaultModel()`
     - `agents` list from `useAgent()` (if available); otherwise pass `[]` as a safe fallback.
  3. Compute `{ resolvedModel, resolvedThinking }` via the shared helper.
  4. Persist the new mode + settings *before* sending (for UI consistency):
     - `updatePersistedState(getAgentIdKey(workspaceId), targetAgentId)`
     - if model changed: `setWorkspaceModelWithOrigin(workspaceId, resolvedModel, "agent")`
     - if thinking changed: `updatePersistedState(getThinkingLevelKey(workspaceId), resolvedThinking)`
  5. Send the message with explicit overrides to avoid any storage timing issues:
     - `options: { ...getSendOptionsFromStorage(workspaceId), agentId: targetAgentId, model: resolvedModel, thinkingLevel: resolvedThinking }`

Key snippet (conceptual):

```ts
const targetAgentId = "exec";
updatePersistedState(getAgentIdKey(workspaceId), targetAgentId);

const { resolvedModel, resolvedThinking } = resolveWorkspaceAiSettingsForAgent(...);

setWorkspaceModelWithOrigin(workspaceId, resolvedModel, "agent");
updatePersistedState(getThinkingLevelKey(workspaceId), resolvedThinking);

const baseOptions = getSendOptionsFromStorage(workspaceId);
await api.workspace.sendMessage({
  workspaceId,
  message: "Implement the plan",
  options: {
    ...baseOptions,
    agentId: targetAgentId,
    model: resolvedModel,
    thinkingLevel: resolvedThinking,
  },
});
```

Notes:
- Overriding `model`/`thinkingLevel` in the actual `sendMessage` call is important so correctness does not depend on `localStorage` writes being observable immediately (and keeps tests robust when `updatePersistedState` is mocked).
- This also prevents backend “poisoning” because the backend will persist the *correct* model/thinking for the new agent.

### 3) Add regression tests
Update `src/browser/components/tools/ProposePlanToolCall.test.tsx`:

- Extend existing tests:
  - `"switches to exec and sends a message when clicking Implement"`
  - `"switches to orchestrator and sends a message when clicking Start Orchestrator"`
- Seed the workspace’s current model/thinking to represent “plan settings” (e.g., `model:${workspaceId} = planModel`).
- Seed `AGENT_AI_DEFAULTS_KEY` (or `workspaceAISettingsByAgent`) so `exec` has a different model/thinking.
- Assert that `sendMessageCalls[0].options.model` (and `thinkingLevel`) match the resolved **target agent** values, not the previous plan values.

If the implementation uses `useAgent()` inside `ProposePlanToolCall`, wrap the render in an `AgentProvider` test harness (similar to `WorkspaceModeAISync.test.tsx`) so the hook has a provider.

### 4) Validation
Run targeted checks:
- `make test` (at least UI/unit tests; ensure the updated ProposePlanToolCall tests pass)
- `make typecheck`

## Alternatives considered
<details>
<summary>Approach B: backend resolves model from agentId (not recommended for this fix)</summary>

- Change backend `WorkspaceService.sendMessage` to ignore/override `options.model` based on agent defaults.
- Pros: defensive; prevents any frontend race from ever sending stale model.
- Cons: larger behavioral change, requires defining authoritative backend precedence rules, and may conflict with user-selected per-workspace model overrides.

Net new product LoC estimate: ~150–300 LoC.
</details>

<details>
<summary>Approach C: eliminate the general agent-switch race globally</summary>

The same underlying race can still occur if a user manually switches agent and immediately hits Enter before `WorkspaceModeAISync` runs.

A broader follow-up would be to compute the resolved model/thinking *at send time* (or synchronously during `setAgentId`) instead of relying on a `useEffect` to update `model:${workspaceId}`.

This is out of scope for the minimal ProposePlan fix but may be worth doing if users hit the issue outside `propose_plan`.
</details>

</details>

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh`_

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$2.15`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=2.15 -->
