### PR TITLE
🤖 fix: rename post-compaction context section to Artifacts

### DIFF
--- a/src/browser/components/RightSidebar/PostCompactionSection.tsx
+++ b/src/browser/components/RightSidebar/PostCompactionSection.tsx
@@ -93,8 +93,8 @@ export const PostCompactionSection: React.FC<PostCompactionSectionProps> = (prop
               </span>
             </TooltipTrigger>
             <TooltipContent side="top" showArrow={false}>
-              This section is still the post-compaction context. After compaction, its contents are
-              appended.
+              After compaction, included artifacts in this list (plan + selected file diffs) are
+              attached to your next message so the agent keeps important earlier context.
             </TooltipContent>
           </Tooltip>
         </div>


### PR DESCRIPTION
## Summary
Renames the right sidebar post-compaction header from **Post-Compaction Context** to **Artifacts** and adds an info tooltip that clarifies the section still represents post-compaction context appended after compaction.

## Background
The previous title was long and less scannable in the sidebar. This change keeps the label concise while preserving behavioral clarity with inline explanatory tooltip copy.

## Implementation
- Updated `PostCompactionSection` header label text to `Artifacts`.
- Added the `Info` icon next to the title.
- Added a tooltip on hover with explanatory copy about post-compaction behavior.

## Validation
- `make static-check`
- `make test`

## Risks
Low. This is a focused UI text/icon update in a single component with no backend or state-model changes.

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Rename “Post-Compaction Context” → “Artifacts” + info tooltip

## Context / Why
The right sidebar currently shows a collapsible section titled **“Post-Compaction Context”**. We want to:

1. Rename the visible section title to **“Artifacts”**.
2. Add an **information (i) icon** next to the title.
3. On hover, show a tooltip clarifying that this section *still represents the post-compaction context* and that its contents will be *appended after compaction*.

This keeps the UI label short (“Artifacts”) while preserving clarity about the underlying behavior.

## Evidence (what I verified)
- `src/browser/components/RightSidebar/PostCompactionSection.tsx`
  - Header label is rendered inside the section toggle button:
    ```tsx
    <span className="text-muted text-xs font-medium">Post-Compaction Context</span>
    ```
- `src/browser/components/ui/tooltip.tsx`
  - Tooltip primitives are available (`Tooltip`, `TooltipTrigger`, `TooltipContent`).
- Repo-wide search shows the only literal occurrence of **“Post-Compaction Context”** is in `PostCompactionSection.tsx`.

## Implementation details (recommended approach)
### 1) Update the header label
**File:** `src/browser/components/RightSidebar/PostCompactionSection.tsx`
- Change the header text from `Post-Compaction Context` → `Artifacts`.

### 2) Add an Info icon + tooltip next to the title
**File:** `src/browser/components/RightSidebar/PostCompactionSection.tsx`

- Extend the `lucide-react` import to include `Info`.
- Replace the single `<span>` title with a small flex row containing:
  - The new label (`Artifacts`)
  - A tooltip-triggering info icon

**Important constraint:** the title currently lives inside a `<button>` (the collapse toggle). Nesting another `<button>` inside it would be invalid HTML, so the tooltip trigger should be a non-button element (e.g. a `<span>`) to avoid nested interactive controls.

Proposed shape:

```tsx
import { ChevronRight, FileText, ExternalLink, Check, Eye, EyeOff, Info } from "lucide-react";
// Tooltip imports already exist in this file

...

<button
  onClick={() => setCollapsed((prev) => !prev)}
  className="flex w-full items-center justify-between text-left"
  type="button"
>
  <div className="flex items-center gap-1.5">
    <span className="text-muted text-xs font-medium">Artifacts</span>

    <Tooltip>
      <TooltipTrigger asChild>
        <span className="text-muted hover:text-foreground inline-flex items-center">
          <Info className="h-3 w-3" />
        </span>
      </TooltipTrigger>
      <TooltipContent side="top" showArrow={false}>
        This section is still the post-compaction context. After compaction, its contents are appended.
      </TooltipContent>
    </Tooltip>
  </div>

  <ChevronRight
    className={`text-muted h-3.5 w-3.5 transition-transform duration-200 ${collapsed ? "" : "rotate-90"}`}
  />
</button>
```

Tooltip copy can be tweaked, but should include both points explicitly:
- “still the post-compaction context”
- “contents will be appended after compaction”

<details>
<summary>Alternative (more keyboard-accessible) approach</summary>

If we want the info icon to be focusable (not just hoverable), we can refactor the header so the collapse trigger is *not* a `<button>` wrapping the icon. For example, use a non-button container for the row and put separate `<button>` elements for:
- the collapse toggle, and
- the info icon trigger.

This is a slightly larger refactor (extra markup + potential key handling) but enables keyboard focus/tooltip on the icon.

</details>

## Validation
- Run formatting/lint/typecheck:
  - `make fmt-check` (or `make fmt`)
  - `make lint`
  - `make typecheck`
- Run tests (at least UI/unit): `make test`
- If any UI tests/snapshots reference the old header label, update them to expect “Artifacts” (none found by literal-string search).

## Net LoC estimate (product code)
- **~+10 / -1 (≈ +9 net)** in `PostCompactionSection.tsx` (import + header markup + tooltip text).

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.40`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.40 -->
