### PR TITLE
🤖 fix: prevent agent settings model dropdown layout shift

### DIFF
--- a/src/browser/components/Settings/sections/TasksSection.tsx
+++ b/src/browser/components/Settings/sections/TasksSection.tsx
@@ -721,6 +721,7 @@ export function TasksSection() {
                 models={models}
                 hiddenModels={hiddenModels}
                 variant="box"
+                dropdownMode="fixed"
                 className="bg-modal-bg"
               />
               {modelValue !== INHERIT ? (
@@ -788,6 +789,7 @@ export function TasksSection() {
                 models={models}
                 hiddenModels={hiddenModels}
                 variant="box"
+                dropdownMode="fixed"
                 className="bg-modal-bg"
               />
               {modelValue !== INHERIT ? (


### PR DESCRIPTION
## Summary
Fix the Agents settings model dropdown so it opens as a stable overlay without layout shift, jitter, or wheel-scroll chaining into the settings pane.

## Background
This bug had three related symptoms in Settings → Agents:
- opening the model menu could shift layout,
- positioning could drift/jitter inside the dialog,
- scrolling inside the dropdown could move the underlying settings window.

The root cause was overlay rendering/positioning inside transformed dialog context plus uncontained wheel behavior.

## Implementation
- Kept `ModelSelector` default behavior unchanged for existing callers (`dropdownMode="inline"`).
- In `dropdownMode="fixed"`:
  - Render dropdown through a React portal (`document.body`) so it positions against the viewport instead of a transformed dialog ancestor.
  - Anchor dropdown under the trigger using measured `getBoundingClientRect()` coordinates.
  - Reposition on resize/scroll with `requestAnimationFrame` scheduling and skip list-internal scroll events to avoid jitter.
  - Preserve outside-click behavior by treating both the trigger container and portaled dropdown as inside click targets.
  - Added wheel containment so dropdown interactions do not scroll the underlying settings container:
    - non-scrollable dropdown regions (header/footer) stop wheel propagation/default,
    - the list prevents scroll chaining at top/bottom edges,
    - list uses `overscrollBehavior: contain`.
- Agents settings (`TasksSection`) continues using `dropdownMode="fixed"` for both known and unknown agent model selectors.

## Validation
- `make typecheck`
- `bun x eslint src/browser/components/ModelSelector.tsx src/browser/components/Settings/sections/TasksSection.tsx`
- `make static-check`

## Risks
Low. Behavior changes are scoped to `ModelSelector` fixed mode; inline mode behavior remains unchanged for existing callsites.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.00 -->
