### PR TITLE
fix: disable SSH ControlMaster for git bundle transfers

### DIFF
--- a/src/node/runtime/RemoteRuntime.ts
+++ b/src/node/runtime/RemoteRuntime.ts
@@ -267,7 +267,7 @@ export abstract class RemoteRuntime implements Runtime {
       write: async (chunk) => {
         const nodeStdin = childProcess.stdin;
         if (!nodeStdin || nodeStdin.destroyed) {
-          return;
+          throw new Error("Remote stdin closed unexpectedly");
         }
 
         await new Promise<void>((resolve, reject) => {

--- a/src/node/runtime/Runtime.ts
+++ b/src/node/runtime/Runtime.ts
@@ -67,6 +67,12 @@ export interface ExecOptions {
   abortSignal?: AbortSignal;
   /** Force PTY allocation (SSH only - adds -t flag) */
   forcePTY?: boolean;
+  /**
+   * Disable SSH ControlMaster multiplexing for this command.
+   * Required for large binary stdin pipes through ProxyCommand-based connections
+   * (e.g., Coder SSH proxy) where multiplexing corrupts/truncates data.
+   */
+  noControlMaster?: boolean;
 }
 
 /**

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -263,6 +263,7 @@ export class SSHRuntime extends RemoteRuntime {
       forcePTY: options.forcePTY,
       timeout: options.timeout,
       abortSignal: options.abortSignal,
+      noControlMaster: options.noControlMaster,
     });
   }
 
@@ -615,9 +616,12 @@ export class SSHRuntime extends RemoteRuntime {
     });
 
     const remoteAbortController = createAbortController(300_000, abortSignal);
+    // Disable SSH ControlMaster for the bundle pipe. Multiplexed channels through
+    // ProxyCommand-based connections (Coder SSH proxy) corrupt large binary transfers.
     const remoteStream = await this.exec(`cat > ${this.quoteForRemote(remoteBundlePath)}`, {
       cwd: "~",
       abortSignal: remoteAbortController.signal,
+      noControlMaster: true,
     });
 
     try {

--- a/src/node/runtime/transports/OpenSSHTransport.ts
+++ b/src/node/runtime/transports/OpenSSHTransport.ts
@@ -56,7 +56,10 @@ export class OpenSSHTransport implements SSHTransport {
     });
 
     // Note: use -tt (not -t) so PTY allocation works even when stdin is a pipe.
-    const sshArgs: string[] = [options.forcePTY ? "-tt" : "-T", ...this.buildSSHArgs()];
+    const sshArgs: string[] = [
+      options.forcePTY ? "-tt" : "-T",
+      ...this.buildSSHArgs({ noControlMaster: options.noControlMaster }),
+    ];
 
     const connectTimeout =
       options.timeout !== undefined ? Math.min(Math.ceil(options.timeout), 15) : 15;
@@ -101,7 +104,7 @@ export class OpenSSHTransport implements SSHTransport {
     });
   }
 
-  private buildSSHArgs(): string[] {
+  private buildSSHArgs(options?: { noControlMaster?: boolean }): string[] {
     const args: string[] = [];
 
     if (this.config.port) {
@@ -115,9 +118,18 @@ export class OpenSSHTransport implements SSHTransport {
     }
 
     args.push("-o", "LogLevel=FATAL");
-    args.push("-o", "ControlMaster=auto");
-    args.push("-o", `ControlPath=${this.controlPath}`);
-    args.push("-o", "ControlPersist=60");
+
+    // SSH ControlMaster multiplexing corrupts large binary stdin pipes through
+    // ProxyCommand-based connections (e.g., Coder's `coder ssh --stdio` proxy).
+    // Disable multiplexing when the caller needs a dedicated connection for bulk data transfer.
+    // Explicitly set ControlMaster=no to override any user/system SSH config that enables it.
+    if (options?.noControlMaster) {
+      args.push("-o", "ControlMaster=no");
+    } else {
+      args.push("-o", "ControlMaster=auto");
+      args.push("-o", `ControlPath=${this.controlPath}`);
+      args.push("-o", "ControlPersist=60");
+    }
 
     return args;
   }

--- a/src/node/runtime/transports/SSHTransport.ts
+++ b/src/node/runtime/transports/SSHTransport.ts
@@ -15,6 +15,8 @@ export interface SpawnOptions {
   forcePTY?: boolean;
   timeout?: number;
   abortSignal?: AbortSignal;
+  /** Skip ControlMaster multiplexing for this connection. */
+  noControlMaster?: boolean;
 }
 
 export interface PtySessionParams {


### PR DESCRIPTION
## Summary

- Add `noControlMaster` option to `ExecOptions`/`SpawnOptions` that explicitly sets `-o ControlMaster=no` to force-disable SSH multiplexing per-command, overriding any user/system SSH config
- Apply it to the bundle transfer `cat >` pipe in `transferBundleToRemote`
- Fix silent data loss in `RemoteRuntime`'s `WritableStream` write handler (throw instead of silently returning when stdin is destroyed)

## Context

When creating a mux workspace in an existing Coder workspace backed by a large repo (~646 MB bundle), the git bundle transfer was silently truncated to ~815 KB. This left a corrupted bundle on the remote that could never be cloned, causing `ensureReady()` to report "Workspace setup incomplete: repository not found."

**Root cause:** OpenSSH `ControlMaster=auto` multiplexing corrupts large binary stdin pipes routed through Coder's SSH ProxyCommand (`coder ssh --stdio`). The multiplexed channel dies after ~815 KB.

Confirmed by reproducing the exact failure in isolation:

| Test | ControlMaster | Bytes transferred | Result |
|------|--------------|-------------------|--------|
| With ControlMaster | `auto` + `ControlPersist=60` | 815,458 | FAIL - stdin destroyed |
| Without ControlMaster | none | 645,720,725 | Success |

The secondary fix (throwing on destroyed stdin writes) ensures that if a similar transport failure happens in the future, the error propagates immediately rather than silently dropping data and reporting an empty error message ("Failed to upload bundle:").

## Test plan

- [x] `make typecheck` passes
- [x] `make test` passes (all 184 runtime tests pass; 17 pre-existing failures in unrelated tests)
- [ ] Manual: create a mux workspace targeting an existing Coder workspace with a large repo and confirm bundle transfers successfully

---

> Generated with [Claude Code](https://claude.com/claude-code) and [Conductor](https://conductor.build)