### PR TITLE
🤖 fix: lazy-load ssh2 to prevent NAPI crash in Bun

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -421,12 +421,13 @@ export default defineConfig([
     },
   },
   {
-    // Allow dynamic imports for lazy-loading AI SDK packages (startup optimization)
+    // Allow dynamic imports for lazy-loading (startup optimization / platform compat)
     files: [
       "src/services/aiService.ts",
       "src/utils/tools/tools.ts",
       "src/utils/ai/providerFactory.ts",
       "src/utils/main/tokenizer.ts",
+      "src/node/runtime/SSH2ConnectionPool.ts",
     ],
     rules: {
       "no-restricted-syntax": "off",


### PR DESCRIPTION
## Summary

The `ssh2` native module (`sshcrypto.node`) is eagerly loaded at startup through the import chain `runtimeFactory → transports/index → SSH2Transport → SSH2ConnectionPool → ssh2`. This crashes Bun with a `uv_version_string` NAPI panic since Bun doesn't support that libuv function.

## Implementation

- Change `import { Client } from "ssh2"` to `import type { Client }` in `SSH2ConnectionPool.ts` (type-only, erased at runtime)
- Lazy-load `ssh2` via `await import("ssh2")` inside `connectWithKey()` — the only place `Client` is constructed
- Add `SSH2ConnectionPool.ts` to the eslint dynamic-import allowlist

SSH2 is now only loaded when an SSH2 connection is actually attempted.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$33.02`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=33.02 -->
