### PR TITLE
🤖 fix: disable text highlighting on mobile touch devices

### DIFF
--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -1067,6 +1067,18 @@ body,
 
   body {
     font-size: 15px;
+    /* User request: prevent accidental text highlighting while tapping/scrolling on touch devices. */
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  /* Keep selection/caret behavior in editable controls on touch devices. */
+  input,
+  textarea,
+  [contenteditable="true"],
+  [contenteditable="plaintext-only"] {
+    -webkit-user-select: text;
+    user-select: text;
   }
 
   button,


### PR DESCRIPTION
## Summary
Disable accidental text highlighting for coarse-pointer mobile layouts while preserving selection behavior in editable controls.

## Background
On touch devices, taps and scroll gestures can unintentionally highlight page text, which makes interaction feel janky. The requested behavior is to disable highlighting on mobile touch devices.

## Implementation
- Updated `src/browser/styles/globals.css` within the existing `@media (max-width: 768px) and (pointer: coarse)` block.
- Set `-webkit-user-select: none` and `user-select: none` on `body`.
- Re-enabled selection/caret behavior for editable elements:
  - `input`
  - `textarea`
  - `[contenteditable="true"]`
  - `[contenteditable="plaintext-only"]`

## Validation
- `make static-check`

## Risks
Low risk, scoped to mobile touch devices only. Non-editable text is no longer selectable on those devices by design.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.00 -->
