### PR TITLE
🤖 fix: include Ask in fallback agent list

### DIFF
--- a/src/browser/components/Settings/sections/TasksSection.tsx
+++ b/src/browser/components/Settings/sections/TasksSection.tsx
@@ -54,6 +54,16 @@ const FALLBACK_AGENTS: AgentDefinitionDescriptor[] = [
     subagentRunnable: true,
   },
   {
+    // Keep Ask visible when workspace agent discovery is unavailable.
+    id: "ask",
+    scope: "built-in",
+    name: "Ask",
+    description: "Delegate questions to Explore sub-agents and synthesize an answer.",
+    uiSelectable: true,
+    subagentRunnable: false,
+    base: "exec",
+  },
+  {
     id: "compact",
     scope: "built-in",
     name: "Compact",


### PR DESCRIPTION
## Summary
Add the Ask built-in agent to the settings fallback agent list so it remains visible in Agent Defaults when workspace agent discovery is unavailable.

## Background
`TasksSection` renders `FALLBACK_AGENTS` whenever no workspace is selected or the agents list fails to load. That fallback list omitted Ask, which made the UI look like Ask had been removed.

## Implementation
- Added an `ask` entry to `FALLBACK_AGENTS` in `src/browser/components/Settings/sections/TasksSection.tsx`
- Matched Ask metadata to the built-in definition (`uiSelectable: true`, `subagentRunnable: false`, `base: "exec"`)
- Added a short inline comment clarifying why Ask is included in fallback.

## Validation
- `make typecheck`
- `make static-check`

## Risks
Low risk. Change is a static fallback list update used only when agent discovery is unavailable. It does not alter runtime agent discovery or execution behavior.

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.83`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.83 -->
