### PR TITLE
🤖 fix: align integrated terminal env with bash tool context

### DIFF
--- a/src/node/services/ptyService.ts
+++ b/src/node/services/ptyService.ts
@@ -39,6 +39,10 @@ interface SessionData {
   onExit: (exitCode: number) => void;
 }
 
+interface CreateSessionOptions {
+  env?: NodeJS.ProcessEnv;
+}
+
 /**
  * Create a data handler that buffers incomplete escape sequences
  */
@@ -86,7 +90,8 @@ export class PTYService {
     workspacePath: string,
     onData: (data: string) => void,
     onExit: (exitCode: number) => void,
-    runtimeConfig?: RuntimeConfig
+    runtimeConfig?: RuntimeConfig,
+    options?: CreateSessionOptions
   ): Promise<TerminalSession> {
     // Include a random suffix to avoid collisions when creating multiple sessions quickly.
     // Collisions can cause two PTYs to appear "merged" under one sessionId.
@@ -154,6 +159,7 @@ export class PTYService {
         cols: params.cols,
         rows: params.rows,
         preferElectronBuild: true,
+        env: options?.env,
         logLocalEnv: true,
       });
     } else if (runtime instanceof DockerRuntime) {


### PR DESCRIPTION
## Summary

This change aligns integrated **local/worktree** terminal sessions with the bash tool environment by injecting stable `MUX_*` context plus effective project secrets.

## Background

Before this change, the bash tool received `MUX_*` and secret env vars while integrated PTY terminals inherited only `process.env`. That mismatch caused interactive terminal behavior to diverge from tool executions.

## Implementation

- In `TerminalService.create()`:
  - Compute stable terminal context with `getMuxEnv(...)` + `getRuntimeType(...)`.
  - Inject only stable `MUX_*` keys (no dynamic cost/model fields).
  - Inject effective project secrets for local/worktree terminals via `secretsToRecord(...)`.
  - Skip secrets for `MUX_HELP_CHAT_WORKSPACE_ID` as defense-in-depth.
  - Pass the computed env to PTY creation.
- In `PTYService.createSession()`:
  - Added optional `options.env` parameter.
  - Forward `options.env` to local `spawnPtyProcess(...)`.
- In `terminalService.test.ts`:
  - Updated mocks/signatures for new createSession args.
  - Added assertions that `create()` propagates `MUX_PROJECT_PATH`, `MUX_RUNTIME`, `MUX_WORKSPACE_NAME`, and secrets.

## Validation

- `make static-check`
- `bun test src/node/services/terminalService.test.ts`
- `make typecheck`
- `bun run eslint src/node/services/terminalService.ts src/node/services/ptyService.ts src/node/services/terminalService.test.ts`

## Risks

- Local/worktree terminals now inherit configured secrets (intended for parity), so subprocesses launched from those terminals also inherit them.
- Remote/docker/devcontainer integrated terminal env parity is intentionally not changed in this PR.

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Align integrated terminal env with bash tool (MUX\_\* + secrets)

## Context / Why

Mux currently injects `MUX_*` environment variables and configured secrets into **tool executions** (e.g. the `bash` tool), but **not** into the **integrated terminal** (PTY sessions). This makes interactive debugging and running scripts in the terminal meaningfully different from what agents/tools experience.

Goals:

- Reduce “bash tool vs terminal” surprises by making the integrated terminal include the same **stable** `MUX_*` context.
- Also inject configured secrets into **local/worktree** integrated terminals (always on), so interactive commands behave like the `bash` tool.

Non-goals:

- Do **not** apply `NON_INTERACTIVE_ENV_VARS` (e.g. `GIT_TERMINAL_PROMPT=0`) to interactive terminals.
- Do **not** attempt to keep dynamic vars like `MUX_COSTS_USD` “live” inside long-running terminal sessions.

## Evidence (current behavior)

- Tool env injection is centralized in `getMuxEnv()`:
  - `src/node/runtime/initHook.ts:getMuxEnv()` sets `MUX_PROJECT_PATH`, `MUX_RUNTIME`, `MUX_WORKSPACE_NAME` (+ optional dynamic vars).
- The `bash` tool explicitly merges `muxEnv` + `secrets`:
  - `src/node/services/tools/bash.ts` passes `env: { ...config.muxEnv, ...config.secrets, ...NON_INTERACTIVE_ENV_VARS }` into `runtime.exec()`.
- Integrated terminal PTYs inherit from `process.env` only:
  - `src/node/runtime/ptySpawn.ts:spawnPtyProcess()` builds `mergedEnv = { ...process.env, ...request.env }`, but `request.env` is never provided by terminal creation today.
  - `src/node/services/ptyService.ts` calls `spawnPtyProcess({ ... })` without `env` for Local/Docker/Devcontainer.
- Terminal creation has all the metadata needed to compute stable `MUX_*` + secrets:
  - `src/node/services/terminalService.ts:create()` loads workspace metadata (projectPath, name, runtimeConfig) before calling `ptyService.createSession()`.

## Recommended approach

### Approach A (recommended): Inject stable `MUX_*` vars into integrated terminals (safe default)

Inject only the stable context vars into terminals:

- `MUX_PROJECT_PATH`
- `MUX_RUNTIME`
- `MUX_WORKSPACE_NAME`

Do **not** inject dynamic tool-only vars (`MUX_MODEL_STRING`, `MUX_THINKING_LEVEL`, `MUX_COSTS_USD`) since they will go stale.

**Net LoC (product code): ~40–80**

### Approach B: Inject secrets into local/worktree integrated terminals (always on)

- Merge `secretsToRecord(config.getEffectiveSecrets(projectPath))` into the env for **local/worktree** terminal PTYs only.
- Do not inject secrets into Docker/Devcontainer/SSH terminals (they require command-line / transport env injection and have higher exposure risk).

**Net LoC (product code): ~80–140**

<details>
<summary>Alternative (defer): full parity across SSH/Docker/Devcontainer terminals</summary>

Full parity is possible but has security and ergonomics pitfalls:

- OpenSSH PTY sessions build a remote command string (`ssh host "cd ... && exec $SHELL -i"`). Injecting secrets there would embed them in a local command line (visible via `ps`, logs, etc.).
- `docker exec -e KEY=VALUE ...` also exposes secrets via args.
- SSH2 transport _may_ support `env` on `client.shell()` (needs verification), but would still send secrets over the SSH channel.

Recommendation: only propagate **stable `MUX_*`** to remote terminals (if desired), and keep secrets injection **local-only** unless we add a safer mechanism.

**Net LoC (product code): ~300–600**

</details>

## Implementation details (ordered)

### 1) Build a terminal env map in `TerminalService.create()`

**File:** `src/node/services/terminalService.ts`

- Import helpers:
  - `getMuxEnv`, `getRuntimeType` from `@/node/runtime/initHook`
  - `secretsToRecord` from `@/common/types/secrets`
  - (optional safety) `MUX_HELP_CHAT_WORKSPACE_ID` from `@/common/constants/muxChat`

- Compute env once, before calling `ptyService.createSession()`:

```ts
const muxEnv = getMuxEnv(
  workspaceMetadata.projectPath,
  getRuntimeType(workspaceMetadata.runtimeConfig),
  workspaceMetadata.name,
);

const secrets = secretsToRecord(
  this.config.getEffectiveSecrets(workspaceMetadata.projectPath),
);

const terminalEnv: NodeJS.ProcessEnv = { ...muxEnv, ...secrets };
```

- Pass `terminalEnv` down into `PTYService.createSession()` (see next step).

Notes:

- Keep this env computation backend-side (don’t extend `TerminalCreateParamsSchema`) so secrets never cross the IPC boundary.
- Hard-disable secrets for the help/system workspace ID (defense-in-depth, consistent with AI tool policy).
- Apply the resulting env only to local/worktree PTYs (don’t thread secrets into Docker/Devcontainer/SSH spawn paths).

### 2) Thread env through `PTYService.createSession()` to local terminal spawns

**File:** `src/node/services/ptyService.ts`

- Extend the signature with an optional env payload:
  - e.g. add final param `options?: { env?: NodeJS.ProcessEnv }`
- In the `runtime instanceof LocalBaseRuntime` branch, pass `options?.env` to `spawnPtyProcess({ env: ... })`.

Shape:

```ts
ptyProcess = spawnPtyProcess({
  runtimeLabel,
  command: shell.command,
  args: shell.args,
  cwd: workspacePath,
  cols: params.cols,
  rows: params.rows,
  preferElectronBuild: true,
  env: options?.env,
  logLocalEnv: true,
});
```

Guardrails:

- Do **not** add `NON_INTERACTIVE_ENV_VARS` here.
- Ensure we never override `TERM` (ptySpawn already forces `xterm-256color`).

### 3) Tests

**File:** `src/node/services/terminalService.test.ts`

- Update the `createSessionMock` signature to accept the new param.
- Add an assertion that `TerminalService.create()` calls `ptyService.createSession()` with an env containing:
  - `MUX_PROJECT_PATH=/tmp/project`
  - `MUX_RUNTIME=worktree|local` (based on `getRuntimeType` behavior)
  - `MUX_WORKSPACE_NAME=main`
- Add an assertion that secrets from `getEffectiveSecrets()` are included in the env passed to `ptyService.createSession()` (for local/worktree terminals).

(Optionally) add a focused unit test that verifies `PTYService` passes `env` through to `spawnPtyProcess` for local runtimes.

### 4) UX / docs (minimal)

- Add a short inline comment in `TerminalService` explaining why we inject only stable `MUX_*` and why secrets are limited to local/worktree terminals.
- Add a warning comment near the secrets injection: any process started from this terminal inherits the secrets.

</details>

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$1.04`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=1.04 -->
