### PR TITLE
🤖 fix: align section picker dropdown to trigger pill

### DIFF
--- a/src/browser/components/ChatInput/CreationControls.tsx
+++ b/src/browser/components/ChatInput/CreationControls.tsx
@@ -278,7 +278,7 @@ function SectionSelectItem(props: { section: SectionConfig }) {
   return (
     <SelectPrimitive.Item
       value={props.section.id}
-      className="hover:bg-hover focus:bg-hover flex cursor-default select-none items-center gap-2.5 rounded-sm px-3 py-1.5 text-sm font-medium outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+      className="hover:bg-hover focus:bg-hover flex cursor-default items-center gap-2.5 rounded-sm px-3 py-1.5 text-sm font-medium outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
     >
       <span className="size-2.5 shrink-0 rounded-full" style={{ backgroundColor: color }} />
       <SelectPrimitive.ItemText>{props.section.name}</SelectPrimitive.ItemText>
@@ -301,54 +301,48 @@ function SectionPicker(props: SectionPickerProps) {
 
   return (
     <div
-      className="inline-flex w-fit items-center gap-2.5 rounded-md border px-3 py-1.5 transition-colors"
-      style={{
-        borderColor: selectedSection ? sectionColor : "var(--color-border-medium)",
-        borderLeftWidth: selectedSection ? "3px" : "1px",
-        backgroundColor: selectedSection ? `${sectionColor}08` : "transparent",
-      }}
+      className="relative inline-flex items-center"
       data-testid="section-selector"
       data-selected-section={normalizedSelectedSectionId ?? ""}
     >
-      {/* Color indicator dot */}
-      <div
-        className="size-2.5 shrink-0 rounded-full transition-colors"
-        style={{
-          backgroundColor: selectedSection ? sectionColor : "var(--color-muted)",
-          opacity: selectedSection ? 1 : 0.4,
-        }}
-      />
-      <label className="text-muted-foreground shrink-0 text-xs">Section</label>
       <RadixSelect
         value={normalizedSelectedSectionId ?? ""}
         onValueChange={(value) => onSectionChange(value.trim() ? value : null)}
         disabled={disabled}
       >
+        {/* Trigger IS the full pill so Radix aligns the dropdown to it. */}
         <SelectTrigger
           className={cn(
-            "h-auto border-0 bg-transparent px-0 py-0 text-sm font-medium shadow-none focus:ring-0",
+            "inline-flex h-auto w-auto items-center gap-2.5 rounded-md border bg-transparent py-1.5 pl-3 text-sm font-medium shadow-none transition-colors focus:ring-0",
+            normalizedSelectedSectionId ? "pr-8" : "pr-3",
             selectedSection ? "text-foreground" : "text-muted"
           )}
+          style={{
+            borderColor: selectedSection ? sectionColor : "var(--color-border-medium)",
+            borderLeftWidth: selectedSection ? "3px" : "1px",
+            backgroundColor: selectedSection ? `${sectionColor}08` : "transparent",
+          }}
         >
+          {/* Color indicator dot */}
+          <div
+            className="size-2.5 shrink-0 rounded-full transition-colors"
+            style={{
+              backgroundColor: selectedSection ? sectionColor : "var(--color-muted)",
+              opacity: selectedSection ? 1 : 0.4,
+            }}
+          />
+          <span className="text-muted-foreground shrink-0 text-xs">Section</span>
           <SelectValue placeholder="Select..." />
         </SelectTrigger>
-        <SelectContent
-          className="border-border-medium bg-separator"
-          style={
-            selectedSection
-              ? {
-                  borderColor: sectionColor,
-                  borderLeftWidth: "3px",
-                  backgroundColor: `${sectionColor}08`,
-                }
-              : undefined
-          }
-        >
+        <SelectContent className="border-border-medium">
           {sections.map((section) => (
             <SectionSelectItem key={section.id} section={section} />
           ))}
         </SelectContent>
       </RadixSelect>
+      {/* Clear button is a sibling (not nested in the trigger) to avoid
+          nesting interactive elements. Absolutely positioned over the
+          right padding reserved by the trigger's pr-8. */}
       {normalizedSelectedSectionId && (
         <Tooltip>
           <TooltipTrigger asChild>
@@ -362,7 +356,7 @@ function SectionPicker(props: SectionPickerProps) {
                 onSectionChange(null);
               }}
               className={cn(
-                "text-muted hover:text-error -mr-1 inline-flex size-5 items-center justify-center rounded-sm transition-colors",
+                "text-muted hover:text-error absolute right-1.5 top-1/2 -translate-y-1/2 inline-flex size-5 items-center justify-center rounded-sm transition-colors",
                 "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent",
                 "disabled:pointer-events-none disabled:opacity-50"
               )}


### PR DESCRIPTION
## Summary

Fixes the Section picker dropdown on the new workspace screen so the open menu aligns with and visually matches the trigger pill control.

## Background

The Section selector renders a styled "pill" (colored dot + "Section" label + value + border accent), but the Radix `SelectTrigger` only wrapped the inner text value. This caused the dropdown to be misaligned and narrower than the pill, with mismatched surface/border styling.

## Implementation

**Trigger restructure** — moved the dot, "Section" label, and pill styling (border color, accent tint) inside the `SelectTrigger` so Radix positions and sizes the dropdown relative to the entire visible control.

**Clear button** — repositioned as an absolute-positioned sibling outside the trigger (avoids nesting interactive `<button>` inside `<button>`). The trigger reserves right padding (`pr-8`) when a section is selected.

**Custom `SectionSelectItem`** — replaces the shared `SelectItem` with a local component that renders a colored dot per section (matching the trigger) instead of the default checkmark layout. Uses `text-sm font-medium` to match trigger typography.

**Dropdown styling** — `SelectContent` uses `border-border-medium` to match the pill's border token.

All changes are scoped to `SectionPicker` in `CreationControls.tsx` — no shared UI components modified.

## Validation

- `make typecheck` passes
- Preserved `data-testid="section-selector"`, `data-selected-section`, and `aria-label="Clear section selection"` for test compatibility
- Manual verification via dev-server-sandbox

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$5.40`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=5.40 -->
