### PR TITLE
🤖 ci: clarify wait_pr_checks as a last-step helper

### DIFF
--- a/.mux/skills/pull-requests/SKILL.md
+++ b/.mux/skills/pull-requests/SKILL.md
@@ -31,10 +31,10 @@ Always check `$MUX_MODEL_STRING`, `$MUX_THINKING_LEVEL`, and `$MUX_COSTS_USD` vi
 
 ## CI & Validation
 
-- After pushing, you may use `./scripts/wait_pr_checks.sh <pr_number>` to wait for CI to pass.
-- Use `wait_pr_checks` only when there's no more useful work to do.
-- Waiting for PR checks can take 10+ minutes, so prefer local validation (e.g., run a subset of integration tests) to catch issues early.
-- If asked to fix an issue in CI, first replicate it locally, get it to pass locally, then use `wait_pr_checks` to wait for CI to pass.
+- Use `wait_pr_checks` only as a **last-step** helper when there's no more useful local work left.
+- Prefer local validation first (e.g., `make static-check` or a targeted test subset) because CI waiting can take 10+ minutes.
+- After local validation is done and no useful work remains, run `./scripts/wait_pr_checks.sh <pr_number>`.
+- If asked to fix an issue in CI, first replicate it locally, get it to pass locally, then use `wait_pr_checks`.
 
 ## Status Decoding
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -49,6 +49,8 @@ description: Agent instructions for AI assistants working on the Mux codebase
 - **Codex reviews:** if a PR has Codex review comments, address + resolve them, then re-request review by commenting `@codex review` on the PR. Repeat until `./scripts/check_codex_comments.sh <pr_number>` reports none.
 - Full `static-check` includes docs link checking via `mintlify broken-links`.
 
+- `./scripts/wait_pr_checks.sh` is a tail-end CI polling helper. Use it only after local validation and after you've exhausted useful local work.
+
 ## Testing: HistoryService
 
 HistoryService is pure local disk I/O with a single dependency (`getSessionDir`). **Always use a real instance** via `createTestHistoryService()` (`src/node/services/testHistoryService.ts`) rather than mocking.


### PR DESCRIPTION
## Summary
Clarifies PR workflow guidance so `wait_pr_checks` is treated as a tail-end CI polling helper, not a default first step after push.

## Background
Some model runs were jumping to CI waiting too early instead of finishing useful local validation/work first. We wanted to tighten prompt guidance without adding script-level enforcement.

## Implementation
- Reworded `.mux/skills/pull-requests/SKILL.md` CI guidance to explicitly frame `wait_pr_checks` as a last-step helper.
- Added matching reminder text in `docs/AGENTS.md` under tooling/commands so this expectation is visible in baseline agent instructions.

## Validation
- `make static-check`

## Risks
Low risk: documentation/instruction-only changes (no runtime behavior changes).

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.01`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.01 -->
