### PR TITLE
🤖 feat: show loading spinner in agent picker while agents load

### DIFF
--- a/src/browser/components/AgentModePicker.tsx
+++ b/src/browser/components/AgentModePicker.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ChevronDown, FolderX, RefreshCw } from "lucide-react";
+import { ChevronDown, FolderX, Loader2, RefreshCw } from "lucide-react";
 
 import { useAgent } from "@/browser/contexts/AgentContext";
 import { CUSTOM_EVENTS } from "@/common/constants/events";
@@ -176,6 +176,7 @@ export const AgentModePicker: React.FC<AgentModePickerProps> = (props) => {
     agentId,
     setAgentId,
     agents,
+    loaded,
     refresh,
     refreshing,
     disableWorkspaceAgents,
@@ -537,7 +538,16 @@ export const AgentModePicker: React.FC<AgentModePickerProps> = (props) => {
 
           <div className="max-h-[220px] overflow-y-auto">
             {filteredOptions.length === 0 ? (
-              <div className="text-muted-light px-2.5 py-2 text-[11px]">No matching agents</div>
+              <div className="text-muted-light px-2.5 py-2 text-[11px]">
+                {!loaded ? (
+                  <span className="flex items-center gap-1.5">
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                    Loading agents…
+                  </span>
+                ) : (
+                  "No matching agents"
+                )}
+              </div>
             ) : (
               filteredOptions.map((opt, index) => {
                 const isHighlighted = index === highlightedIndex;


### PR DESCRIPTION
## Summary

Show a loading spinner in the agent picker dropdown while agent definitions are being fetched, instead of the misleading "No matching agents" message.

<img width="304" height="111" alt="image" src="https://github.com/user-attachments/assets/b9767dc1-812e-4d3c-b92d-e2ad018f5fd0" />


## Background

When the SSH control master dies and reconnects, `agents.list` takes a moment (the backend calls `waitForInit`). During this window the picker dropdown shows "No matching agents" because `agents` is `[]` and `loaded` is still `false` — giving the false impression that no agents exist.

## Implementation

`AgentContext` already tracks a `loaded` boolean, but `AgentModePicker` never consumed it. This PR destructures `loaded` from `useAgent()` and branches the empty-state UI:

- **`!loaded`** → inline `Loader2` spinner + "Loading agents…"
- **`loaded` but empty** → existing "No matching agents" (e.g. user is filtering with no results)

Single file change, +12 −2.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$1.47`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=1.47 -->
