### PR TITLE
🤖 fix: reduce ChatInput min-height for workspace variant

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -2402,7 +2402,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                     (showCommandSuggestions && commandSuggestions.length > 0) ||
                     (showAtMentionSuggestions && atMentionSuggestions.length > 0)
                   }
-                  className="min-h-28"
+                  className={variant === "creation" ? "min-h-28" : "min-h-16"}
                 />
                 {/* Keep cycle shortcuts visible in both creation + workspace without bloating the footer or crowding it. */}
                 {input.trim() === "" && !editingMessage && (


### PR DESCRIPTION
## Summary

Restore a compact default height for the workspace ChatInput. The creation variant keeps its taller minimum for shortcut badge overlays.

## Background

Commit a1c1b15 (`feat: surface creation shortcut badges`) applied a blanket `min-h-28` (112px) to both creation and workspace variants. Previously the workspace variant had no override and fell through to `min-h-8` (32px). The 3.5× jump made the workspace input feel unnecessarily bloated when idle.

## Implementation

Restore per-variant sizing on the `<VimTextArea>` className:
- **Creation:** `min-h-28` (unchanged) — needs room for inline shortcut badge overlay
- **Workspace:** `min-h-16` (64px) — fits two visual lines (content + keybind hints) and auto-grows via `useAutoResizeTextarea`

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$1.09`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=1.09 -->
