### PR TITLE
🤖 fix: eliminate project page flash after workspace creation splash screen

### DIFF
--- a/src/browser/contexts/RouterContext.tsx
+++ b/src/browser/contexts/RouterContext.tsx
@@ -185,9 +185,14 @@ function RouterContextInner(props: { children: ReactNode }) {
   return <RouterContext.Provider value={value}>{props.children}</RouterContext.Provider>;
 }
 
+// Disable startTransition wrapping for navigation state updates so they
+// batch with other normal-priority React state updates in the same tick.
+// Without this, React processes navigation at transition (lower) priority,
+// causing a flash of stale UI between normal-priority updates (e.g.
+// setIsSending(false)) and the deferred route change.
 export function RouterProvider(props: { children: ReactNode }) {
   return (
-    <MemoryRouter initialEntries={[getInitialRoute()]}>
+    <MemoryRouter initialEntries={[getInitialRoute()]} unstable_useTransitions={false}>
       <RouterContextInner>{props.children}</RouterContextInner>
     </MemoryRouter>
   );

--- a/tests/ui/sections.integration.test.ts
+++ b/tests/ui/sections.integration.test.ts
@@ -422,18 +422,10 @@ describeIntegration("Workspace Sections", () => {
 
         await user.click(sendButton);
 
-        // Ensure the slash command succeeded.
-        await waitFor(
-          () => {
-            expect(view.container.textContent ?? "").toContain(
-              `Forked to workspace "${forkedName}"`
-            );
-          },
-          { timeout: 30_000 }
-        );
-
-        // Find the forked workspace in the sidebar by its name/title.
-        // Avoid polling the backend (workspace.list) in a UI integration test.
+        // Wait for the forked workspace to appear in the sidebar.
+        // The fork may navigate to the new workspace immediately (navigation
+        // is synchronous / normal priority), so we verify success through the
+        // sidebar rather than checking for a transient chat message.
         await waitFor(
           () => {
             const workspaceRow = findWorkspaceRowByTitle(view.container, forkedName);


### PR DESCRIPTION
## Summary

Eliminates a brief flash of the project page that appears between the workspace creation splash screen and the workspace page.

## Background

After the workspace creation splash screen animation, users would briefly see the project page before being navigated to the newly created workspace. This was a visual glitch caused by a React state update priority split.

## Implementation

React Router v7's `MemoryRouter` wraps all navigation state updates in `React.startTransition()` by default, making them lower priority than normal React state updates. During workspace creation, this created a two-render gap:

1. **Render 1 (normal priority):** `setIsSending(false)` and `setWorkspaceMetadata()` are processed — the splash overlay is removed but the URL still points to `/project`, so the project page briefly renders.
2. **Render 2 (transition priority):** `navigate(/workspace/<id>)` is processed — the URL updates and the workspace page renders.

The fix passes `unstable_useTransitions={false}` to `MemoryRouter`, making navigation updates normal priority so they batch with other state updates in a single render. The app uses `MemoryRouter` without loaders or actions and gains no benefit from transition-wrapped navigation.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$N/A`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=N/A -->
