### PR TITLE
🤖 fix: prevent bash output layout flash on streaming→static transition

### DIFF
--- a/src/browser/components/ChatPane.tsx
+++ b/src/browser/components/ChatPane.tsx
@@ -22,6 +22,7 @@ import {
   shouldShowInterruptedBarrier,
   mergeConsecutiveStreamErrors,
   computeBashOutputGroupInfo,
+  shouldBypassDeferredMessages,
 } from "@/browser/utils/messages/messageUtils";
 import { computeTaskReportLinking } from "@/browser/utils/messages/taskReportLinking";
 import { BashOutputCollapsedIndicator } from "./tools/BashOutputCollapsedIndicator";
@@ -188,12 +189,11 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
   // useDeferredValue can defer indefinitely if React keeps getting new work (rapid deltas).
   // During active streaming (reasoning, text), we MUST show immediate updates or the UI
   // appears frozen while only the token counter updates (reads aggregator directly).
-  // Only use deferred messages when the stream is idle and no content is changing.
-  const hasActiveStream = transformedMessages.some((m) => "isStreaming" in m && m.isStreaming);
-  const deferredMessages =
-    hasActiveStream || transformedMessages.length !== deferredTransformedMessages.length
-      ? transformedMessages
-      : deferredTransformedMessages;
+  const shouldBypassDeferral = shouldBypassDeferredMessages(
+    transformedMessages,
+    deferredTransformedMessages
+  );
+  const deferredMessages = shouldBypassDeferral ? transformedMessages : deferredTransformedMessages;
 
   const latestMessageId = getLastNonDecorativeMessage(deferredMessages)?.id ?? null;
   const messageListContextValue = useMemo(


### PR DESCRIPTION
## Summary

Fix a layout flash in the chat streaming UI when bash tool output switches from live streaming to static completed output.

## Background

When a bash tool call finishes, the `WorkspaceStore` clears the live output buffer immediately on `tool-call-end`. However, `ChatPane` uses `useDeferredValue` to batch-render the message list, and the deferral bypass only checked for assistant text/reasoning streaming (`isStreaming`). Tool messages with `status: "executing"` were not considered "active," so React could render a stale deferred snapshot where the tool was still marked executing but its live output buffer was already cleared — producing a visible flash of "No output yet" before the final static output appeared.

## Why existing mitigations didn't fix this

Two prior efforts in `BashToolCall` specifically targeted layout flash but addressed different layers of the problem:

1. **Unified output DOM tree** (`BashToolCall.tsx:343-345`). The output section uses a single `<DetailContent>` element that conditionally renders either live or completed output via a ternary, rather than mounting/unmounting separate elements. This prevents React from destroying and recreating the DOM node on transition, preserving scroll position. However, it can't help when **props themselves are stale** — if the component receives `status: "executing"` with an empty live buffer (because the store already cleared it), the ternary picks the live-output branch and renders "No output yet" regardless of DOM stability.

2. **Delayed auto-expand timer** (`BashToolCall.tsx:152-165`). A 300ms `setTimeout` delays auto-expansion of the output section so fast-completing commands skip the expand entirely, avoiding a flash of briefly-visible-then-collapsed output. This helps when the flash comes from expand/collapse toggling, but does nothing for the content flash inside an already-expanded output section where the stale deferred props cause the wrong branch of the output ternary to render.

Both mitigations operate inside `BashToolCall` and assume their props reflect current state. The actual bug is one layer up: `ChatPane` was feeding stale deferred props to `BashToolCall` during the executing→completed transition because `useDeferredValue` wasn't bypassed for executing tool calls.

## Implementation

Extracted `shouldBypassDeferredMessages()` into `messageUtils.ts` so the logic is testable outside of React. The function now checks **both** the immediate and deferred message snapshots for active rows (assistant `isStreaming` or tool `status === "executing"`), plus the existing length-mismatch guard. This ensures we never show a stale deferred snapshot that diverges from current store state during streaming→completed transitions.

## Risks

Low — the change is additive to the existing bypass condition. The only behavioral difference is that deferral is also skipped while any tool is executing, which is the correct semantic (tool output is actively changing via the live output store). Worst case, slightly more immediate renders during tool execution, which was already the behavior during assistant text streaming.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=0.00 -->
