### PR TITLE
🤖 fix: add gpt-5.3-codex-spark model override

### DIFF
--- a/src/common/utils/ai/modelCapabilities.test.ts
+++ b/src/common/utils/ai/modelCapabilities.test.ts
@@ -23,6 +23,12 @@ describe("getModelCapabilities", () => {
     expect(caps).not.toBeNull();
   });
 
+  it("keeps GPT-5.3-Codex-Spark as text-only via models-extra override", () => {
+    const caps = getModelCapabilities("openai:gpt-5.3-codex-spark");
+    expect(caps).not.toBeNull();
+    expect(caps?.supportsVision).toBe(false);
+  });
+
   it("returns maxPdfSizeMb when present in model metadata", () => {
     const caps = getModelCapabilities("google:gemini-1.5-flash");
     expect(caps).not.toBeNull();

--- a/src/common/utils/tokens/modelStats.test.ts
+++ b/src/common/utils/tokens/modelStats.test.ts
@@ -24,6 +24,13 @@ describe("getModelStats", () => {
       expect(stats?.input_cost_per_token).toBe(0.000021);
     });
 
+    test("should find GPT-5.3-Codex-Spark in models-extra.ts", () => {
+      const stats = getModelStats("openai:gpt-5.3-codex-spark");
+      expect(stats).not.toBeNull();
+      expect(stats?.max_input_tokens).toBe(128000);
+      expect(stats?.max_output_tokens).toBe(128000);
+    });
+
     test("models-extra.ts should override models.json", () => {
       // gpt-5.2-codex exists in both files - models-extra.ts has correct 272k, models.json has incorrect 400k
       const stats = getModelStats("openai:gpt-5.2-codex");

--- a/src/common/utils/tokens/models-extra.ts
+++ b/src/common/utils/tokens/models-extra.ts
@@ -109,6 +109,23 @@ export const modelsExtra: Record<string, ModelData> = {
     supports_response_schema: true,
   },
 
+  // GPT-5.3-Codex-Spark - Released February 13, 2026
+  // OpenAI says this is a text-only Codex variant with a 128k context window.
+  // API pricing is not published yet, so we temporarily mirror GPT-5.3-Codex pricing.
+  "gpt-5.3-codex-spark": {
+    max_input_tokens: 128000,
+    max_output_tokens: 128000,
+    input_cost_per_token: 0.00000175, // $1.75 per million input tokens (temporary)
+    output_cost_per_token: 0.000014, // $14 per million output tokens (temporary)
+    cache_read_input_token_cost: 0.000000175, // $0.175 per million cached input tokens (temporary)
+    litellm_provider: "openai",
+    mode: "responses",
+    supports_function_calling: true,
+    supports_vision: false,
+    supports_reasoning: true,
+    supports_response_schema: true,
+  },
+
   // GPT-5.2 Pro - Released December 11, 2025
   // $21/M input, $168/M output
   // Supports medium, high, xhigh reasoning levels


### PR DESCRIPTION
## Summary
Add a local `models-extra.ts` override for OpenAI's newly announced `gpt-5.3-codex-spark` model so pricing/token accounting and capability checks work before upstream `models.json` catches up.

## Background
The model appeared after our current upstream model snapshot, and user workflows rely on local override data for cost/context UI and routing metadata.

## Implementation
- Added `gpt-5.3-codex-spark` to `src/common/utils/tokens/models-extra.ts`.
- Set context/output to 128k and marked the model as text-only (`supports_vision: false`) based on launch details.
- Added focused tests in:
  - `src/common/utils/tokens/modelStats.test.ts`
  - `src/common/utils/ai/modelCapabilities.test.ts`

## Validation
- `make static-check`
- `bun test src/common/utils/tokens/modelStats.test.ts src/common/utils/ai/modelCapabilities.test.ts`

## Risks
Low. Change is additive and isolated to model metadata lookup paths.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.00 -->
