### PR TITLE
🤖 fix: make code_execution runtime-first for one-off scripts

### DIFF
--- a/src/node/services/tools/code_execution.ts
+++ b/src/node/services/tools/code_execution.ts
@@ -104,8 +104,9 @@ ${muxTypes}
     ): Promise<PTCExecutionResult> => {
       const execStartTime = Date.now();
 
-      // Static analysis before execution - catch syntax errors, forbidden patterns, and type errors
-      const analysis = await analyzeCode(code, muxTypes);
+      // Static analysis before execution - catch syntax errors and sandbox-forbidden patterns.
+      // TypeScript typing issues are intentionally non-blocking for one-off runtime scripts.
+      const analysis = await analyzeCode(code);
       if (!analysis.valid) {
         const errorMessages = analysis.errors.map((e) => {
           const location =


### PR DESCRIPTION
## Summary
Make `code_execution` runtime-first for one-off scripts by removing TypeScript type validation from the pre-execution hard gate. Static analysis still blocks on syntax and sandbox-safety violations, while type-only issues now fail (or succeed) at runtime through normal tool/function execution paths.

## Background
Initial observation from usage:
- A script that did `const x = mux.file_read(...); return x.content;` failed pre-execution with TypeScript union errors, including:
  - `Property 'content' does not exist on type 'FileReadResult'`
- The same logic then passed when rewritten with repetitive ternaries like `x.success ? x.content : x.error`.

This made one-off scripts brittle and wasteful: the model had to spend extra tokens rewriting boilerplate and often required an additional tool call round-trip just to satisfy static typing.

## Implementation
- `src/node/services/tools/code_execution.ts`
  - Changed preflight call from `analyzeCode(code, muxTypes)` to `analyzeCode(code)`.
  - Kept hard blocking for:
    - syntax errors
    - forbidden constructs (`require`, `import()`)
    - unavailable globals (`process`, `window`, etc.)
  - Updated inline comments to document that TypeScript typing issues are intentionally non-blocking for one-off runtime scripts.

- `src/node/services/tools/code_execution.test.ts`
  - Updated expectations that previously asserted `Code analysis failed` for type-only issues.
  - Added runtime-oriented assertions for:
    - invalid tool args
    - missing/non-existent tool calls
    - schema validation errors surfacing from runtime/tool validation paths.

## Performance impact
This should improve performance in two ways:
1. **Less retry churn / fewer round trips**
   - Scripts no longer fail early on type-only diagnostics, so the model is less likely to emit a second corrective `code_execution` call.
2. **Lower preflight overhead per call**
   - We skip TypeScript type-checking in the gating phase and only run syntax/sandbox safety checks before execution.

Net effect: faster successful completion for one-off scripts and fewer wasted tokens on type-narrowing boilerplate rewrites.

## Validation
- `make static-check`
- `bun test src/node/services/tools/code_execution.test.ts`
- `bun test src/node/services/tools/code_execution.integration.test.ts`
- `bun test src/node/services/ptc/quickjsRuntime.test.ts`
- `make typecheck`
- `make fmt-check`

## Risks
- **Behavioral change:** some scripts that previously failed preflight on type-only issues now execute and may fail at runtime instead.
- **Mitigation:** syntax/sandbox safety gates remain intact, and runtime tool/schema validation errors are still surfaced clearly.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.00 -->
