### PR TITLE
🤖 fix: classify Anthropic 'Input is too long' as context_exceeded

### DIFF
--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -2354,7 +2354,8 @@ export class StreamManager extends EventEmitter {
       }
 
       // Check for Anthropic context exceeded errors
-      if (error.message.includes("prompt is too long:")) {
+      const msgLower = error.message.toLowerCase();
+      if (msgLower.includes("prompt is too long") || msgLower.includes("input is too long")) {
         return "context_exceeded";
       }
 


### PR DESCRIPTION
## Summary

Anthropic's "Input is too long for requested model" error was misclassified as `api` instead of `context_exceeded`, preventing users from seeing the compaction suggestion UI.

Closes https://github.com/coder/mux/issues/1702

## Background

In `categorizeError`, the `APICallError` block only checked for `"prompt is too long:"` — the older Anthropic error format. The newer `"Input is too long for requested model"` variant fell through to `return "api"` and never reached the generic `"too long"` string match lower in the function (which only applies to plain `Error` instances, not `APICallError`).

## Implementation

Added a second case-insensitive check for `"input is too long"` alongside the existing `"prompt is too long"` pattern inside the `APICallError.isInstance()` block.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh -->
