### PR TITLE
🤖 fix: resolve opt-in global secret references for project envs

### DIFF
--- a/src/browser/components/Settings/sections/SecretsSection.tsx
+++ b/src/browser/components/Settings/sections/SecretsSection.tsx
@@ -350,6 +350,12 @@ export const SecretsSection: React.FC = () => {
           <p className="text-muted mt-1 text-xs">
             Scope: <span className="text-foreground">{scopeLabel}</span>
           </p>
+          <p className="text-muted mt-1 text-xs">
+            Global secrets are shared storage only; they are not injected by default.
+          </p>
+          <p className="text-muted mt-1 text-xs">
+            Project secrets control injection. Use Type: Global to reference a global value.
+          </p>
         </div>
 
         <ToggleGroup


### PR DESCRIPTION
## Summary
Change project effective-secret resolution to be opt-in for global values, so only project-defined keys are injected while still allowing global references to resolve.

## Background
Project secrets can reference global secrets via `{ secret: "KEY" }`, but previous merge-by-key behavior could produce a self-reference cycle for same-key aliases and could unintentionally inject all globals.

## Implementation
- Updated `Config.getEffectiveSecrets()` to return project-scoped injection keys only.
- Resolved project `{ secret: "KEY" }` values against global secret literals before downstream `secretsToRecord()` calls.
- Added/updated unit tests for non-inheritance, alias resolution, and same-key alias resolution.
- Clarified settings UI copy: global secrets are shared storage; project secrets control injection.

## Validation
- `make static-check`
- `bun test src/node/config.test.ts`
- `make typecheck`
- `make fmt-check`

## Risks
Low. Scope is limited to secret resolution semantics and settings copy. Main behavior shift is intentional: globals are no longer implicitly injected.

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix global secret references in integrated terminal + tools (opt-in)

## Context / Why
Today, project-scoped secrets can be set to **Type: Global** in the UI, which stores them as a reference value:

```ts
{ key: "OPENAI_API_KEY", value: { secret: "OPENAI_API_KEY" } }
```

However, the backend currently computes project secrets via `Config.getEffectiveSecrets()`, which **merges global + project secrets by key**. When a project secret references a global secret **with the same key**, the merge overwrites the global literal value with the project’s `{secret: ...}` reference, creating a **self-referential cycle**. `secretsToRecord()` defensively drops cycles, so the environment variable is omitted—exactly what you’re seeing in the integrated terminal.

Separately (and per your expectation), **global secrets should not be blindly inherited by all projects**. They should be a shared value store that projects opt into by referencing them.

## Evidence (repo)
- Project secret “Global” references are stored as `{ value: { secret: string } }` and the dropdown is populated from global keys:
  - `src/browser/components/Settings/sections/SecretsSection.tsx` (`updateSecretValueKind`, `isReference`, `globalSecretKeys`)
- Current effective-secret computation merges global + project by key:
  - `src/node/config.ts` → `getEffectiveSecrets()`
- Alias/cycle resolution drops self-references:
  - `src/common/types/secrets.ts` → `secretsToRecord()`
- Integrated terminal injects secrets via `secretsToRecord(config.getEffectiveSecrets(projectPath))`:
  - `src/node/services/terminalService.ts` → `create()`

## Implementation plan (recommended)

### Approach A (recommended): Make global secrets opt-in; resolve project references against global values
**Net LoC (product code only): ~+25 / -10**

1. **Change `Config.getEffectiveSecrets(projectPath)` semantics** to return *only the project’s injected keys*, with any global references inlined to literal strings.

   - Compute a resolved lookup table for globals:
     - `const globalRecord = secretsToRecord(this.getGlobalSecrets())`
   - Load raw project secrets:
     - `const projectSecrets = this.getProjectSecrets(projectPath)`
   - For each project secret:
     - If `value` is `{ secret: target }` **and** `globalRecord` contains `target`, replace the project secret’s value with the resolved global string.
     - Otherwise, leave the value unchanged (so intra-project aliases—if any—still resolve via the existing `secretsToRecord()` callsites).
   - **Do not** include global secrets as standalone env vars unless the project explicitly defines a key for them.

   Intended shape:

   ```ts
   // src/node/config.ts
   import { secretsToRecord } from "@/common/types/secrets";

   function isSecretReferenceValue(value: unknown): value is { secret: string } {
     return (
       typeof value === "object" &&
       value !== null &&
       "secret" in value &&
       typeof (value as { secret?: unknown }).secret === "string"
     );
   }

   getEffectiveSecrets(projectPath: string): Secret[] {
     const globalRecord = secretsToRecord(this.getGlobalSecrets());
     const projectSecrets = this.getProjectSecrets(projectPath);

     return projectSecrets.map((secret) => {
       if (!secret || typeof secret.key !== "string") {
         return secret;
       }

       if (!isSecretReferenceValue(secret.value)) {
         return secret;
       }

       const target = secret.value.secret.trim();
       if (!target) {
         return secret;
       }

       // IMPORTANT: allow empty-string secrets; check `!== undefined`, not truthiness.
       const resolved = globalRecord[target];
       if (resolved !== undefined) {
         return { ...secret, value: resolved };
       }

       return secret;
     });
   }
   ```

   This fixes the self-cycle (`OPENAI_API_KEY` → global `OPENAI_API_KEY`) and enforces opt-in injection.

2. **Update unit tests** to match the desired behavior:
   - `src/node/config.test.ts`
     - Replace the test asserting “merges global + project secrets” with:
       - **does not inherit globals by default**
     - Update the “resolves project secret aliases to global secrets” test to assert:
       - referencing a global secret injects only the project key
       - same-key reference (`OPENAI_API_KEY` → `OPENAI_API_KEY`) resolves correctly

   Suggested new assertions:

   ```ts
   await config.updateGlobalSecrets([{ key: "GLOBAL_TOKEN", value: "abc" }]);
   await config.updateProjectSecrets(projectPath, [{ key: "TOKEN", value: { secret: "GLOBAL_TOKEN" } }]);

   expect(secretsToRecord(config.getEffectiveSecrets(projectPath))).toEqual({ TOKEN: "abc" });

   await config.updateGlobalSecrets([{ key: "OPENAI_API_KEY", value: "abc" }]);
   await config.updateProjectSecrets(projectPath, [
     { key: "OPENAI_API_KEY", value: { secret: "OPENAI_API_KEY" } },
   ]);

   expect(secretsToRecord(config.getEffectiveSecrets(projectPath))).toEqual({ OPENAI_API_KEY: "abc" });
   ```

3. **Clarify UI copy** in `SecretsSection.tsx` to reduce future confusion:
   - Explicitly state that **global secrets are not injected** into a project/workspace unless the project defines a secret that references them (Type: Global).
   - Add a short line distinguishing **Global = storage** vs **Project = injection**.


## Validation
- Run unit tests: `make test` (at minimum ensure `src/node/config.test.ts` passes).
- Smoke test in the app:
  1. Set global `OPENAI_API_KEY`.
  2. In a project, add `OPENAI_API_KEY` with **Type: Global** and select `OPENAI_API_KEY`.
  3. Open a *new* integrated terminal and confirm `echo $OPENAI_API_KEY` is non-empty.

<details>
<summary>Notes / gotchas</summary>

- Long-lived integrated terminals won’t pick up secret changes until you restart the terminal session (environment variables are set at process spawn time).
- Remote runtimes (ssh/docker/devcontainer) intentionally skip terminal env injection today; this plan doesn’t change that behavior.

</details>

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$1.56`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=1.56 -->
