### PR TITLE
🤖 fix: allow @file mentions inside slash commands

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -1064,17 +1064,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       return;
     }
 
-    // Prefer slash command suggestions when the input is a command.
-    if (input.trimStart().startsWith("/")) {
-      // Invalidate any in-flight completion request.
-      atMentionRequestIdRef.current++;
-      lastAtMentionScopeIdRef.current = null;
-      lastAtMentionQueryRef.current = null;
-      setAtMentionSuggestions([]);
-      setShowAtMentionSuggestions(false);
-      return;
-    }
-
     const cursor = inputRef.current?.selectionStart ?? input.length;
     const match = findAtMentionAtCursor(input, cursor);
 
@@ -2392,10 +2381,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                   aria-label={editingMessage ? "Edit your last message" : "Message Claude"}
                   aria-autocomplete="list"
                   aria-controls={
-                    showCommandSuggestions && commandSuggestions.length > 0
-                      ? commandListId
-                      : showAtMentionSuggestions && atMentionSuggestions.length > 0
-                        ? atMentionListId
+                    showAtMentionSuggestions && atMentionSuggestions.length > 0
+                      ? atMentionListId
+                      : showCommandSuggestions && commandSuggestions.length > 0
+                        ? commandListId
                         : undefined
                   }
                   aria-expanded={

--- a/tests/ui/chat/fileMentionsWithSlashCommands.test.ts
+++ b/tests/ui/chat/fileMentionsWithSlashCommands.test.ts
@@ -1,0 +1,39 @@
+import "../dom";
+import { waitFor } from "@testing-library/react";
+
+import { preloadTestModules } from "../../ipc/setup";
+import { createAppHarness } from "../harness";
+
+describe("File mentions with slash commands", () => {
+  beforeAll(async () => {
+    await preloadTestModules();
+  });
+
+  test("/sonnet @ shows file path suggestions", async () => {
+    const app = await createAppHarness({ branchPrefix: "file-mention-slash" });
+
+    try {
+      await app.chat.typeWithoutSending("/sonnet @");
+
+      await waitFor(
+        () => {
+          const listbox = app.view.container.querySelector(
+            '[role="listbox"][aria-label="File path suggestions"]'
+          );
+
+          if (!listbox) {
+            throw new Error("File path suggestion listbox not found");
+          }
+
+          const options = listbox.querySelectorAll('[role="option"]');
+          if (options.length === 0) {
+            throw new Error("No file suggestions shown");
+          }
+        },
+        { timeout: 10_000 }
+      );
+    } finally {
+      await app.dispose();
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

Allow `@file` mentions to work alongside `/` slash commands in the chat input. Previously, typing `/sonnet @` would suppress all file path suggestions — now they appear as expected.

Fixes #2414.

## Background

The chat input had a mutual exclusion rule: if the draft starts with `/`, the `@file` autocomplete system was completely disabled (early return in the `useEffect` that watches for `@` mentions). This prevented users from referencing files in one-shot model commands (`/sonnet @src/foo.ts please review`) or multiline command bodies (`/compact\n@src/bar.ts`).

The `findAtMentionAtCursor()` function already correctly gates file suggestions to when the cursor is inside an `@…` token, so the blanket `/` suppression was unnecessary.

## Implementation

- **Removed the early-return block** in the "Watch input/cursor for @file mentions" effect that suppressed suggestions whenever `input.trimStart().startsWith("/")`. The existing `findAtMentionAtCursor()` check is the correct guard.
- **Fixed `aria-controls` order** on `VimTextArea` to match the existing `suppressKeys` precedence (file suggestions first, then slash command suggestions). This is a small a11y consistency fix.

## Validation

- New UI test: `tests/ui/chat/fileMentionsWithSlashCommands.test.ts` — types `/sonnet @` and asserts the file path suggestion listbox appears with at least one option.
- Existing `modelOneshot` tests still pass (5/5).
- `make static-check` passes.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$0.49`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=0.49 -->
