### PR TITLE
🤖 fix: prevent settings page from immediately redirecting back to workspace

### DIFF
--- a/src/browser/contexts/WorkspaceContext.tsx
+++ b/src/browser/contexts/WorkspaceContext.tsx
@@ -525,6 +525,7 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
     currentWorkspaceId,
     currentProjectId,
     currentProjectPathFromState,
+    currentSettingsSection,
     pendingSectionId,
     pendingDraftId,
   } = useRouter();
@@ -933,6 +934,12 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
     // Skip if we already have a selected workspace (from localStorage or URL hash)
     if (selectedWorkspace) return;
 
+    // Skip if user is on the settings page — navigating to /settings/:section
+    // clears the workspace from the URL, making selectedWorkspace null. Without
+    // this guard the effect would auto-select a workspace and navigate away from
+    // settings immediately.
+    if (currentSettingsSection) return;
+
     // Skip if user is in the middle of creating a workspace
     if (pendingNewWorkspaceProject) return;
 
@@ -976,6 +983,7 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
     api,
     loading,
     selectedWorkspace,
+    currentSettingsSection,
     pendingNewWorkspaceProject,
     workspaceMetadata,
     setSelectedWorkspace,


### PR DESCRIPTION
## Summary

Fix a bug where clicking the settings button briefly shows the settings page, then immediately redirects back to the workspace view.

## Background

When the settings page was refactored from a modal dialog to a full-page route (`/settings/:section`), a conflict was introduced with the workspace auto-selection logic. The auto-selection effect in `WorkspaceContext` is designed to recover from a "no workspace selected" state (e.g., on app launch via `mux .`), but it doesn't know about the settings route.

The sequence:
1. User clicks Settings → URL changes to `/settings/general`
2. `currentWorkspaceId` (derived from `/workspace/:id` pattern) becomes `null`
3. `selectedWorkspace` (derived from `currentWorkspaceId`) becomes `null`
4. The launch-project `useEffect` sees no workspace selected, finds one via `getLaunchProject()`, and calls `setSelectedWorkspace(...)`
5. `setSelectedWorkspace` calls `navigateToWorkspace(id)`, overwriting the `/settings` URL → user is kicked back to the workspace

## Implementation

Add a `currentSettingsSection` guard to the auto-selection `useEffect` in `WorkspaceContext.tsx`. When the user is on a settings route, the effect bails out early instead of trying to "recover" a workspace selection.

The change is 3 lines of logic + comments in a single file:
1. Destructure `currentSettingsSection` from the existing `useRouter()` call
2. Add `if (currentSettingsSection) return;` guard in the effect
3. Add `currentSettingsSection` to the effect's dependency array

## Risks

Low. The guard only suppresses auto-selection while on settings routes. When the user navigates back from settings, `RouterContext` restores the previous workspace URL via `lastNonSettingsLocationRef`, so the workspace selection is restored through the normal URL-driven path.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$1.15`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=1.15 -->
