### PR TITLE
🤖 feat: add universal skills load path

### DIFF
--- a/docs/agents/agent-skills.mdx
+++ b/docs/agents/agent-skills.mdx
@@ -28,13 +28,15 @@ npx skills add https://github.com/anthropics/skills --skill frontend-design
 
 ## Where skills live
 
-Mux discovers skills from three roots:
+Mux discovers skills from four roots:
 
 - **Workspace-local**: `.mux/skills/<skill-name>/SKILL.md` (in the workspace working directory)
-- **Global**: `~/.mux/skills/<skill-name>/SKILL.md`
+- **Global (Mux-specific)**: `~/.mux/skills/<skill-name>/SKILL.md`
+- **Universal (cross-tool)**: `~/.agents/skills/<skill-name>/SKILL.md`
 - **Built-in**: shipped with Mux
 
-If a skill exists in multiple locations, the precedence order is: **workspace-local > global > built-in**.
+If a skill exists in multiple locations, the precedence order is:
+**workspace-local > global (`~/.mux/skills`) > universal (`~/.agents/skills`) > built-in**.
 
 <Info>
   Mux reads skills using the active workspace runtime. For SSH workspaces, skills are read from the

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -697,7 +697,7 @@ export const TOOL_DEFINITIONS = {
   agent_skill_read: {
     description:
       "Load an Agent Skill's SKILL.md (YAML frontmatter + markdown body) by name. " +
-      "Skills are discovered from <projectRoot>/.mux/skills/<name>/SKILL.md and ~/.mux/skills/<name>/SKILL.md.",
+      "Skills are discovered from <projectRoot>/.mux/skills/<name>/SKILL.md, ~/.mux/skills/<name>/SKILL.md, and ~/.agents/skills/<name>/SKILL.md.",
     schema: z
       .object({
         name: SkillNameSchema.describe("Skill name (directory name under the skills root)"),


### PR DESCRIPTION
## Summary
Add support for a universal skills directory at `~/.agents/skills` so Mux can discover and load shared skills beyond `~/.mux/skills`.

## Background
Users may already keep cross-tool skills under `~/.agents/skills`. Mux previously only scanned project-local `.mux/skills` and `~/.mux/skills`, so those shared skills were not visible unless manually mirrored.

## Implementation
- Extended `AgentSkillsRoots` with optional `universalRoot` and set default to `~/.agents/skills`.
- Updated skill discovery/read paths to scan global roots in deterministic order:
  - project `.mux/skills`
  - `~/.mux/skills`
  - `~/.agents/skills`
  - built-ins fallback
- Added a focused unit test covering precedence and universal-only lookup.
- Updated tool description and docs to reflect the new root and precedence.

## Validation
- `bun test src/node/services/agentSkills/agentSkillsService.test.ts`
- `make typecheck`
- `make static-check`

## Risks
Low. Changes are scoped to skill root enumeration/lookup and preserve existing precedence by keeping `~/.mux/skills` ahead of `~/.agents/skills`.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.00 -->
