### PR TITLE
🤖 fix: replace streaming escape hint with stop control

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -2218,6 +2218,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     }
   };
 
+  const interruptKeybind = vimEnabled
+    ? KEYBINDS.INTERRUPT_STREAM_VIM
+    : KEYBINDS.INTERRUPT_STREAM_NORMAL;
+
   // Build placeholder text based on current state
   const placeholder = (() => {
     // Creation view keeps the onboarding prompt; workspace stays concise for the inline hints.
@@ -2239,9 +2243,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       }
     }
     if (isCompacting) {
-      const interruptKeybind = vimEnabled
-        ? KEYBINDS.INTERRUPT_STREAM_VIM
-        : KEYBINDS.INTERRUPT_STREAM_NORMAL;
       return `Compacting... (${formatKeybind(interruptKeybind)} cancel | ${formatKeybind(KEYBINDS.SEND_MESSAGE)} to queue)`;
     }
 

--- a/src/browser/components/ChatPane.tsx
+++ b/src/browser/components/ChatPane.tsx
@@ -747,6 +747,7 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
                 <PinnedTodoList workspaceId={workspaceId} />
                 <StreamingBarrier
                   workspaceId={workspaceId}
+                  vimEnabled={vimEnabled}
                   onCancelCompaction={handleCancelCompactionFromBarrier}
                 />
                 {shouldShowQueuedAgentTaskPrompt && (

--- a/src/browser/components/Messages/ChatBarrier/StreamingBarrierView.test.tsx
+++ b/src/browser/components/Messages/ChatBarrier/StreamingBarrierView.test.tsx
@@ -16,9 +16,30 @@ describe("StreamingBarrierView", () => {
     globalThis.document = undefined as unknown as Document;
   });
 
-  test("renders cancel hint as a button when onCancel is provided", () => {
+  test("renders stop button when onCancel is provided", () => {
     const onCancel = mock(() => undefined);
 
+    const view = render(
+      <StreamingBarrierView
+        statusText="streaming..."
+        cancelText="hit Esc to cancel"
+        cancelShortcutText="Esc"
+        onCancel={onCancel}
+      />
+    );
+
+    const stopButton = view.getByRole("button", { name: "Stop streaming" });
+    expect(stopButton.textContent).toContain("Stop");
+    expect(stopButton.textContent).toContain("Esc");
+    expect(stopButton.getAttribute("title")).toBe("Esc");
+
+    fireEvent.click(stopButton);
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not render shortcut badge when cancelShortcutText is omitted", () => {
+    const onCancel = mock(() => undefined);
     const view = render(
       <StreamingBarrierView
         statusText="streaming..."
@@ -27,9 +48,9 @@ describe("StreamingBarrierView", () => {
       />
     );
 
-    fireEvent.click(view.getByRole("button", { name: "Interrupt streaming" }));
-
-    expect(onCancel).toHaveBeenCalledTimes(1);
+    const stopButton = view.getByRole("button", { name: "Stop streaming" });
+    expect(stopButton.textContent).toContain("Stop");
+    expect(stopButton.textContent).not.toContain("Esc");
   });
 
   test("renders cancel hint as plain text when onCancel is omitted", () => {
@@ -38,6 +59,6 @@ describe("StreamingBarrierView", () => {
     );
 
     expect(view.getByText("hit Esc to cancel")).toBeTruthy();
-    expect(view.queryByRole("button", { name: "Interrupt streaming" })).toBeNull();
+    expect(view.queryByRole("button", { name: "Stop streaming" })).toBeNull();
   });
 });

--- a/src/browser/components/Messages/ChatBarrier/StreamingBarrierView.tsx
+++ b/src/browser/components/Messages/ChatBarrier/StreamingBarrierView.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { CircleStopIcon } from "lucide-react";
 
 import { BaseBarrier } from "./BaseBarrier";
 
@@ -9,6 +10,8 @@ export interface StreamingBarrierViewProps {
   cancelText: string;
   /** Optional click handler that turns cancelText into a tappable control. */
   onCancel?: () => void;
+  /** Optional keyboard hint shown inline on larger screens (e.g., "Esc"). */
+  cancelShortcutText?: string;
   className?: string;
   /** Optional hint element shown after status (e.g., settings link) */
   hintElement?: React.ReactNode;
@@ -35,18 +38,27 @@ export const StreamingBarrierView: React.FC<StreamingBarrierViewProps> = (props)
           </span>
         )}
       </div>
-      <div className="text-muted ml-auto text-[11px] whitespace-nowrap">
+      <div className="ml-auto">
         {props.onCancel && props.cancelText.length > 0 ? (
           <button
             type="button"
             onClick={props.onCancel}
-            className="hover:text-foreground cursor-pointer underline decoration-dotted underline-offset-2"
-            aria-label="Interrupt streaming"
+            title={props.cancelShortcutText}
+            className="text-muted hover:text-foreground inline-flex h-6 cursor-pointer items-center rounded-sm px-1.5 py-0.5 text-[11px] leading-none font-medium transition-colors duration-200"
+            aria-label="Stop streaming"
           >
-            {props.cancelText}
+            <CircleStopIcon className="h-3.5 w-3.5 shrink-0" strokeWidth={2.2} />
+            <span className="ml-1 leading-none">Stop</span>
+            {props.cancelShortcutText && (
+              <span className="border-border-medium text-muted ml-2 hidden items-center rounded border px-1 py-[1px] text-[10px] leading-none sm:inline-flex">
+                {props.cancelShortcutText}
+              </span>
+            )}
           </button>
         ) : (
-          <span className="select-none">{props.cancelText}</span>
+          <span className="text-muted text-[11px] whitespace-nowrap select-none">
+            {props.cancelText}
+          </span>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
Replace the streaming barrier's old interrupt hint text with a dedicated inline Stop control, while keeping keyboard interruption discoverable and accurate.

## Background
The previous text hint (`hit Escape to cancel`) was less obvious than a direct control and could become inaccurate in vim mode. The desired UX is a clear Stop affordance with shortcut context, including responsive behavior on smaller screens.

## Implementation
- Replaced the right-side streaming hint with a clickable `Stop` control in `StreamingBarrierView`:
  - circular stop icon + `Stop` label
  - inline shortcut badge on larger screens (`sm+`)
  - mobile/small screens keep icon + Stop without badge
  - restored native tooltip (`title`) to show the same shortcut value
- Updated `StreamingBarrier` to:
  - support stop action during `starting`, `streaming`, and `compacting`
  - preserve existing compaction cancel semantics
  - normalize `Escape` to `Esc` for display
  - receive `vimEnabled` from `ChatPane` so the shortcut reflects current mode immediately (e.g. vim interrupt shortcut)
- Kept interruption behavior unchanged for awaiting-user-input states (non-interruptible from this control).
- Updated and expanded tests for:
  - stop button rendering
  - inline shortcut badge behavior
  - tooltip shortcut value
  - vim-mode shortcut display
  - interruption behavior across streaming phases

## Validation
- `make static-check`
- `bun test src/browser/components/Messages/ChatBarrier/StreamingBarrierView.test.tsx src/browser/components/Messages/ChatBarrier/StreamingBarrier.test.tsx`

## Risks
Low-to-moderate UI behavior risk around barrier interactions; covered by focused tests on rendering and click behavior across streaming phases.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.02`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.02 -->
