### PR TITLE
🤖 feat: add workspace universal skills path and concurrent loading

### DIFF
--- a/docs/agents/agent-skills.mdx
+++ b/docs/agents/agent-skills.mdx
@@ -28,15 +28,16 @@ npx skills add https://github.com/anthropics/skills --skill frontend-design
 
 ## Where skills live
 
-Mux discovers skills from four roots:
+Mux discovers skills from five roots:
 
 - **Workspace-local**: `.mux/skills/<skill-name>/SKILL.md` (in the workspace working directory)
 - **Global (Mux-specific)**: `~/.mux/skills/<skill-name>/SKILL.md`
+- **Workspace universal**: `.agent/skills/<skill-name>/SKILL.md` (in the workspace working directory)
 - **Universal (cross-tool)**: `~/.agents/skills/<skill-name>/SKILL.md`
 - **Built-in**: shipped with Mux
 
 If a skill exists in multiple locations, the precedence order is:
-**workspace-local > global (`~/.mux/skills`) > universal (`~/.agents/skills`) > built-in**.
+**workspace-local > global (`~/.mux/skills`) > workspace universal (`.agent/skills`) > universal (`~/.agents/skills`) > built-in**.
 
 <Info>
   Mux reads skills using the active workspace runtime. For SSH workspaces, skills are read from the

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -697,7 +697,7 @@ export const TOOL_DEFINITIONS = {
   agent_skill_read: {
     description:
       "Load an Agent Skill's SKILL.md (YAML frontmatter + markdown body) by name. " +
-      "Skills are discovered from <projectRoot>/.mux/skills/<name>/SKILL.md, ~/.mux/skills/<name>/SKILL.md, and ~/.agents/skills/<name>/SKILL.md.",
+      "Skills are discovered from <projectRoot>/.mux/skills/<name>/SKILL.md, <projectRoot>/.agent/skills/<name>/SKILL.md, ~/.mux/skills/<name>/SKILL.md, and ~/.agents/skills/<name>/SKILL.md.",
     schema: z
       .object({
         name: SkillNameSchema.describe("Skill name (directory name under the skills root)"),

--- a/src/node/services/tools/agent_skill_read.ts
+++ b/src/node/services/tools/agent_skill_read.ts
@@ -46,7 +46,7 @@ function buildSkillReadDescription(config: ToolConfiguration): string {
 
 /**
  * Agent Skill read tool factory.
- * Reads and validates a skill's SKILL.md from project-local or global skills roots.
+ * Reads and validates a skill's SKILL.md from project-local, global, or universal skills roots.
  */
 export const createAgentSkillReadTool: ToolFactory = (config: ToolConfiguration) => {
   return tool({


### PR DESCRIPTION
## Summary
Follow-up to #2419: add workspace universal skill loading from `.agent/skills` and parallelize skill root/descriptor loading to reduce latency (especially for remote runtimes).

## Background
The initial universal-path support added `~/.agents/skills`, but users also keep universal skills in workspace-level `.agent/skills`. Also, skill discovery/read paths were still mostly serialized, which can amplify SSH latency.

## Implementation
- Added workspace universal default root:
  - `<projectRoot>/.agent/skills`
- Kept universal roots under global precedence semantics:
  - project `.mux/skills`
  - `~/.mux/skills`
  - `<projectRoot>/.agent/skills`
  - `~/.agents/skills`
  - built-ins fallback
- Refactored discovery internals to:
  - resolve/list all roots concurrently
  - group candidates by skill name
  - resolve descriptor candidates concurrently across skills (with ordered fallback per skill name)
- Refactored `readAgentSkill` to probe candidate roots concurrently while preserving precedence in selection.
- Added tests covering:
  - default roots include workspace/home universal paths
  - workspace/home universal discovery semantics
  - fallback when higher-precedence skill is invalid
- Updated docs/tool descriptions to include `.agent/skills`.

## Validation
- `bun test src/node/services/agentSkills/agentSkillsService.test.ts`
- `make typecheck`
- `make static-check`

## Risks
Low-to-moderate. This is a behavior-preserving refactor with more concurrency and one additional root, but it touches core discovery/read flow. Tests were expanded for precedence and fallback behavior.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.00 -->
