### PR TITLE
🤖 fix: preserve parent agent mode in synthetic auto-resume messages

### DIFF
--- a/src/common/orpc/schemas/stream.ts
+++ b/src/common/orpc/schemas/stream.ts
@@ -138,6 +138,7 @@ export const StreamEndEventSchema = z.object({
   metadata: z
     .object({
       model: z.string(),
+      agentId: AgentIdSchema.optional().catch(undefined),
       thinkingLevel: ThinkingLevelSchema.optional(),
       routedThroughGateway: z.boolean().optional(),
       // Total usage across all steps (for cost calculation)

--- a/src/node/services/streamSimulation.ts
+++ b/src/node/services/streamSimulation.ts
@@ -161,6 +161,7 @@ export async function simulateToolPolicyNoop(
     messageId: ctx.assistantMessageId,
     metadata: {
       model: ctx.canonicalModelString,
+      agentId: ctx.effectiveAgentId,
       thinkingLevel: ctx.effectiveThinkingLevel,
       routedThroughGateway: ctx.routedThroughGateway,
       systemMessageTokens: ctx.systemMessageTokens,


### PR DESCRIPTION
## Summary

When a parent workspace spawns sub-agent tasks, it gets auto-resumed via synthetic messages once the child finishes or the parent's stream ends with pending tasks. These auto-resume messages always hardcoded `agentId` to `WORKSPACE_DEFAULTS.agentId` (`"exec"`), regardless of the parent's actual agent mode — causing an unexpected mode switch (e.g., plan → exec) from the user's perspective.

Most of the diff is tests.

## Background

Two code paths send synthetic auto-resume messages to parent workspaces:

1. **`handleStreamEnd`** — when the parent's stream ends and it still has pending child tasks
2. **`deliverReportToParent`** — when all child tasks complete and the parent isn't streaming

Both paths were doing `entry.workspace.agentId ?? WORKSPACE_DEFAULTS.agentId`, which always resolved to `"exec"`.

## Implementation

Introduces `resolveParentAutoResumeOptions()` with a 3-tier fallback chain:

1. **Stream-end event metadata** — `agentId` is now included in `StreamEndEventSchema` and emitted by `streamManager.ts` and `streamSimulation.ts`
2. **Last assistant message in history** — scans the last 20 messages for the most recent assistant message with an `agentId` in its metadata (restart-safe)
3. **Default** — falls back to `WORKSPACE_DEFAULTS.agentId` (`"exec"`)

Both parent auto-resume paths now use this method. A `ParentAutoResumeHint` interface tightens the typing of the hint parameter.

## Validation

- 4 new tests covering all tiers: event metadata → history fallback → default `"exec"` fallback, plus the task-completion path
- All 40 `taskService` tests pass
- Typecheck clean

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `high` • Cost: `$1.08`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=high costs=1.08 -->
