### PR TITLE
🤖 fix: enable PDF input for Opus 4.6

### DIFF
--- a/src/common/utils/ai/modelCapabilities.test.ts
+++ b/src/common/utils/ai/modelCapabilities.test.ts
@@ -17,6 +17,12 @@ describe("getModelCapabilities", () => {
     expect(caps?.supportsPdfInput).toBe(true);
   });
 
+  it("keeps explicit PDF support for Opus 4.6 from models-extra", () => {
+    const caps = getModelCapabilities("anthropic:claude-opus-4-6");
+    expect(caps).not.toBeNull();
+    expect(caps?.supportsPdfInput).toBe(true);
+  });
+
   it("returns capabilities for models present only in models-extra", () => {
     // This model is defined in models-extra.ts but not (yet) in upstream models.json.
     const caps = getModelCapabilities("openrouter:z-ai/glm-4.6");

--- a/src/common/utils/tokens/models-extra.ts
+++ b/src/common/utils/tokens/models-extra.ts
@@ -15,6 +15,8 @@ interface ModelData {
   mode?: string;
   supports_function_calling?: boolean;
   supports_vision?: boolean;
+  supports_pdf_input?: boolean;
+  max_pdf_size_mb?: number;
   supports_reasoning?: boolean;
   supports_response_schema?: boolean;
   knowledge_cutoff?: string;
@@ -37,6 +39,8 @@ export const modelsExtra: Record<string, ModelData> = {
     mode: "chat",
     supports_function_calling: true,
     supports_vision: true,
+    // User-reported issue: Opus 4.6 should accept PDF attachments like other Claude 4.x models.
+    supports_pdf_input: true,
     supports_reasoning: true,
     supports_response_schema: true,
   },


### PR DESCRIPTION
## Summary
Mark `claude-opus-4-6` as PDF-capable in `models-extra` so PDF attachments are accepted for Opus 4.6.

## Background
Opus 4.6 should support PDF input, but our capability metadata only marked vision support. The frontend/backend preflight checks rely on `supportsPdfInput`, so Opus 4.6 PDF attachments were incorrectly rejected.

## Implementation
- Extended `ModelData` in `models-extra.ts` to include PDF capability fields used by capability extraction.
- Added `supports_pdf_input: true` for `claude-opus-4-6`.
- Added a regression test in `modelCapabilities.test.ts` asserting `anthropic:claude-opus-4-6` reports `supportsPdfInput: true`.

## Validation
- `bun test src/common/utils/ai/modelCapabilities.test.ts`
- `make static-check`

## Risks
Low. This only updates model metadata and a focused regression test. The change enables an existing code path (PDF handling) for Opus 4.6 rather than introducing a new one.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$n/a`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=n/a -->
