### PR TITLE
🤖 fix: require explicit open for device OAuth verification

### DIFF
--- a/src/browser/components/Settings/sections/ProvidersSection.tsx
+++ b/src/browser/components/Settings/sections/ProvidersSection.tsx
@@ -6,6 +6,7 @@ import {
   Eye,
   EyeOff,
   ExternalLink,
+  Loader2,
   ShieldCheck,
   X,
 } from "lucide-react";
@@ -245,17 +246,7 @@ export function ProvidersSection() {
   const [codexOauthDeviceFlow, setCodexOauthDeviceFlow] = useState<CodexOauthDeviceFlow | null>(
     null
   );
-
-  const [codexOauthCodeCopied, setCodexOauthCodeCopied] = useState(false);
-  const codexOauthCopiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (codexOauthCopiedTimeoutRef.current !== null) {
-        clearTimeout(codexOauthCopiedTimeoutRef.current);
-      }
-    };
-  }, []);
+  const [codexOauthAuthorizeUrl, setCodexOauthAuthorizeUrl] = useState<string | null>(null);
 
   const codexOauthIsConnected = config?.openai?.codexOauthSet === true;
   const openaiApiKeySet = config?.openai?.apiKeySet === true;
@@ -286,6 +277,7 @@ export function ProvidersSection() {
     setCodexOauthError(null);
     setCodexOauthDesktopFlowId(null);
     setCodexOauthDeviceFlow(null);
+    setCodexOauthAuthorizeUrl(null);
 
     try {
       setCodexOauthStatus("starting");
@@ -314,7 +306,7 @@ export function ProvidersSection() {
         setCodexOauthStatus("waiting");
 
         // Keep device-code login manual per user request: we only open the
-        // verification page from the explicit "Copy & open" action.
+        // verification page from the explicit "Copy & Open" action.
         const waitResult = await api.codexOauth.waitForDeviceFlow({
           flowId: startResult.data.flowId,
         });
@@ -331,6 +323,7 @@ export function ProvidersSection() {
 
         setCodexOauthStatus("idle");
         setCodexOauthDeviceFlow(null);
+        setCodexOauthAuthorizeUrl(null);
         await refresh();
         return;
       }
@@ -352,10 +345,8 @@ export function ProvidersSection() {
 
       const { flowId, authorizeUrl } = startResult.data;
       setCodexOauthDesktopFlowId(flowId);
+      setCodexOauthAuthorizeUrl(authorizeUrl);
       setCodexOauthStatus("waiting");
-
-      // Desktop main process intercepts external window.open() calls and routes them via shell.openExternal.
-      window.open(authorizeUrl, "_blank", "noopener");
 
       const waitResult = await api.codexOauth.waitForDesktopFlow({ flowId });
 
@@ -402,6 +393,7 @@ export function ProvidersSection() {
     setCodexOauthError(null);
     setCodexOauthDesktopFlowId(null);
     setCodexOauthDeviceFlow(null);
+    setCodexOauthAuthorizeUrl(null);
 
     try {
       setCodexOauthStatus("starting");
@@ -443,6 +435,7 @@ export function ProvidersSection() {
 
       setCodexOauthStatus("idle");
       setCodexOauthDeviceFlow(null);
+      setCodexOauthAuthorizeUrl(null);
       await refresh();
     } catch (err) {
       if (attempt !== codexOauthAttemptRef.current) {
@@ -474,6 +467,7 @@ export function ProvidersSection() {
     setCodexOauthError(null);
     setCodexOauthDesktopFlowId(null);
     setCodexOauthDeviceFlow(null);
+    setCodexOauthAuthorizeUrl(null);
 
     try {
       setCodexOauthStatus("starting");
@@ -517,6 +511,7 @@ export function ProvidersSection() {
 
     setCodexOauthDesktopFlowId(null);
     setCodexOauthDeviceFlow(null);
+    setCodexOauthAuthorizeUrl(null);
     setCodexOauthStatus("idle");
     setCodexOauthError(null);
   };
@@ -528,6 +523,8 @@ export function ProvidersSection() {
   const [muxGatewayDesktopFlowId, setMuxGatewayDesktopFlowId] = useState<string | null>(null);
   const [muxGatewayServerState, setMuxGatewayServerState] = useState<string | null>(null);
 
+  const [muxGatewayAuthorizeUrl, setMuxGatewayAuthorizeUrl] = useState<string | null>(null);
+
   const cancelMuxGatewayLogin = () => {
     muxGatewayApplyDefaultModelsOnSuccessRef.current = false;
     muxGatewayLoginAttemptRef.current++;
@@ -538,6 +535,7 @@ export function ProvidersSection() {
 
     setMuxGatewayDesktopFlowId(null);
     setMuxGatewayServerState(null);
+    setMuxGatewayAuthorizeUrl(null);
     setMuxGatewayLoginStatus("idle");
     setMuxGatewayLoginError(null);
   };
@@ -574,6 +572,7 @@ export function ProvidersSection() {
       setMuxGatewayLoginError(null);
       setMuxGatewayDesktopFlowId(null);
       setMuxGatewayServerState(null);
+      setMuxGatewayAuthorizeUrl(null);
 
       if (isDesktop) {
         if (!api) {
@@ -600,10 +599,8 @@ export function ProvidersSection() {
 
         const { flowId, authorizeUrl } = startResult.data;
         setMuxGatewayDesktopFlowId(flowId);
+        setMuxGatewayAuthorizeUrl(authorizeUrl);
         setMuxGatewayLoginStatus("waiting");
-
-        // Desktop main process intercepts external window.open() calls and routes them via shell.openExternal.
-        window.open(authorizeUrl, "_blank", "noopener");
 
         if (attempt !== muxGatewayLoginAttemptRef.current) {
           return;
@@ -637,63 +634,54 @@ export function ProvidersSection() {
           return;
         }
 
+        setMuxGatewayAuthorizeUrl(null);
         setMuxGatewayLoginStatus("error");
         setMuxGatewayLoginError(waitResult.error);
         return;
       }
 
       // Browser/server mode: use unauthenticated bootstrap route.
-      // Open popup synchronously to preserve user gesture context (avoids popup blockers).
-      const popup = window.open("about:blank", "_blank");
-      if (!popup) {
-        throw new Error("Popup blocked - please allow popups and try again.");
-      }
-
       setMuxGatewayLoginStatus("starting");
 
       const startUrl = new URL(`${backendBaseUrl}/auth/mux-gateway/start`);
       const authToken = getServerAuthToken();
 
-      let json: { authorizeUrl?: unknown; state?: unknown; error?: unknown };
-      try {
-        const res = await fetch(startUrl, {
-          headers: authToken ? { Authorization: `Bearer ${authToken}` } : undefined,
-        });
+      const res = await fetch(startUrl, {
+        headers: authToken ? { Authorization: `Bearer ${authToken}` } : undefined,
+      });
 
-        const contentType = res.headers.get("content-type") ?? "";
-        if (!contentType.includes("application/json")) {
-          const body = await res.text();
-          const prefix = body.trim().slice(0, 80);
-          throw new Error(
-            `Unexpected response from ${startUrl.toString()} (expected JSON, got ${
-              contentType || "unknown"
-            }): ${prefix}`
-          );
-        }
+      const contentType = res.headers.get("content-type") ?? "";
+      if (!contentType.includes("application/json")) {
+        const body = await res.text();
+        const prefix = body.trim().slice(0, 80);
+        throw new Error(
+          `Unexpected response from ${startUrl.toString()} (expected JSON, got ${
+            contentType || "unknown"
+          }): ${prefix}`
+        );
+      }
 
-        json = (await res.json()) as typeof json;
+      const json = (await res.json()) as {
+        authorizeUrl?: unknown;
+        state?: unknown;
+        error?: unknown;
+      };
 
-        if (!res.ok) {
-          const message = typeof json.error === "string" ? json.error : `HTTP ${res.status}`;
-          throw new Error(message);
-        }
-      } catch (err) {
-        popup.close();
-        throw err;
+      if (!res.ok) {
+        const message = typeof json.error === "string" ? json.error : `HTTP ${res.status}`;
+        throw new Error(message);
       }
 
       if (attempt !== muxGatewayLoginAttemptRef.current) {
-        popup.close();
         return;
       }
 
       if (typeof json.authorizeUrl !== "string" || typeof json.state !== "string") {
-        popup.close();
         throw new Error(`Invalid response from ${startUrl.pathname}`);
       }
 
       setMuxGatewayServerState(json.state);
-      popup.location.href = json.authorizeUrl;
+      setMuxGatewayAuthorizeUrl(json.authorizeUrl);
       setMuxGatewayLoginStatus("waiting");
     } catch (err) {
       if (attempt !== muxGatewayLoginAttemptRef.current) {
@@ -701,6 +689,7 @@ export function ProvidersSection() {
       }
 
       const message = err instanceof Error ? err.message : String(err);
+      setMuxGatewayAuthorizeUrl(null);
       setMuxGatewayLoginStatus("error");
       setMuxGatewayLoginError(message);
     }
@@ -741,12 +730,14 @@ export function ProvidersSection() {
           }
         }
 
+        setMuxGatewayAuthorizeUrl(null);
         setMuxGatewayLoginStatus("success");
         void refreshMuxGatewayAccountStatus();
         return;
       }
 
       const msg = typeof data.error === "string" ? data.error : "Login failed";
+      setMuxGatewayAuthorizeUrl(null);
       setMuxGatewayLoginStatus("error");
       setMuxGatewayLoginError(msg);
     };
@@ -785,18 +776,8 @@ export function ProvidersSection() {
   const [copilotFlowId, setCopilotFlowId] = useState<string | null>(null);
   const [copilotUserCode, setCopilotUserCode] = useState<string | null>(null);
   const [copilotVerificationUri, setCopilotVerificationUri] = useState<string | null>(null);
-  const [copilotCodeCopied, setCopilotCodeCopied] = useState(false);
   const copilotLoginAttemptRef = useRef(0);
   const copilotFlowIdRef = useRef<string | null>(null);
-  const copilotCopiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (copilotCopiedTimeoutRef.current !== null) {
-        clearTimeout(copilotCopiedTimeoutRef.current);
-      }
-    };
-  }, []);
 
   const copilotApiKeySet = config?.["github-copilot"]?.apiKeySet ?? false;
   const copilotLoginInProgress =
@@ -884,7 +865,7 @@ export function ProvidersSection() {
       setCopilotLoginStatus("waiting");
 
       // Keep device-code login manual per user request: we only open the
-      // verification page from the explicit "Copy & open" action.
+      // verification page from the explicit "Copy & Open" action.
 
       // Wait for flow to complete (polling happens on backend)
       const waitResult = await api.copilotOauth.waitForDeviceFlow({ flowId });
@@ -1192,7 +1173,7 @@ export function ProvidersSection() {
                     </div>
 
                     <div className="space-y-2">
-                      <div className="flex items-center gap-2">
+                      <div className="flex flex-wrap items-center gap-2">
                         <Button
                           size="sm"
                           onClick={() => {
@@ -1202,6 +1183,20 @@ export function ProvidersSection() {
                         >
                           {muxGatewayLoginButtonLabel}
                         </Button>
+
+                        {muxGatewayLoginStatus === "waiting" && muxGatewayAuthorizeUrl && (
+                          <Button
+                            size="sm"
+                            aria-label="Copy and open Mux Gateway authorization page"
+                            onClick={() => {
+                              void navigator.clipboard.writeText(muxGatewayAuthorizeUrl);
+                              window.open(muxGatewayAuthorizeUrl, "_blank", "noopener");
+                            }}
+                            className="h-8 px-3 text-xs"
+                          >
+                            Copy & Open Mux Gateway
+                          </Button>
+                        )}
 
                         {muxGatewayLoginInProgress && (
                           <Button variant="secondary" size="sm" onClick={cancelMuxGatewayLogin}>
@@ -1217,8 +1212,9 @@ export function ProvidersSection() {
                       </div>
 
                       {muxGatewayLoginStatus === "waiting" && (
-                        <p className="text-muted text-xs">
-                          Finish the login flow in your browser, then return here.
+                        <p className="text-muted inline-flex items-center gap-2 text-xs">
+                          <Loader2 aria-hidden className="h-3.5 w-3.5 animate-spin" />
+                          Waiting for authorization...
                         </p>
                       )}
 
@@ -1318,47 +1314,28 @@ export function ProvidersSection() {
                         <div className="bg-background-tertiary space-y-2 rounded-md p-3">
                           <p className="text-muted text-xs">Enter this code on GitHub:</p>
                           <div className="flex items-center gap-2">
-                            <code className="text-accent text-lg font-bold tracking-widest">
+                            <code className="text-foreground text-lg font-bold tracking-widest">
                               {copilotUserCode}
                             </code>
                             <Button
-                              variant="ghost"
                               size="sm"
-                              aria-label="Copy verification code and open verification page"
+                              aria-label="Copy and open GitHub verification page"
                               onClick={() => {
                                 void navigator.clipboard.writeText(copilotUserCode);
-                                setCopilotCodeCopied(true);
-                                if (copilotCopiedTimeoutRef.current !== null) {
-                                  clearTimeout(copilotCopiedTimeoutRef.current);
-                                }
-                                copilotCopiedTimeoutRef.current = setTimeout(
-                                  () => setCopilotCodeCopied(false),
-                                  2000
-                                );
-
                                 if (copilotVerificationUri) {
                                   window.open(copilotVerificationUri, "_blank", "noopener");
                                 }
                               }}
-                              className="text-muted hover:text-foreground h-auto px-1 py-0 text-xs"
+                              className="h-8 px-3 text-xs"
+                              disabled={!copilotVerificationUri}
                             >
-                              {copilotCodeCopied ? "Copied!" : "Copy & open"}
+                              Copy & Open GitHub
                             </Button>
                           </div>
-                          {copilotVerificationUri && (
-                            <p className="text-muted text-xs">
-                              Continue in your browser:{" "}
-                              <a
-                                href={copilotVerificationUri}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-accent hover:text-accent-light underline"
-                              >
-                                open the verification page
-                              </a>
-                              .
-                            </p>
-                          )}
+                          <p className="text-muted inline-flex items-center gap-2 text-xs">
+                            <Loader2 aria-hidden className="h-3.5 w-3.5 animate-spin" />
+                            Waiting for authorization...
+                          </p>
                         </div>
                       )}
 
@@ -1511,6 +1488,22 @@ export function ProvidersSection() {
                         Connect (Device)
                       </Button>
 
+                      {codexOauthStatus === "waiting" &&
+                        !codexOauthDeviceFlow &&
+                        codexOauthAuthorizeUrl && (
+                          <Button
+                            size="sm"
+                            aria-label="Copy and open OpenAI authorization page"
+                            onClick={() => {
+                              void navigator.clipboard.writeText(codexOauthAuthorizeUrl);
+                              window.open(codexOauthAuthorizeUrl, "_blank", "noopener");
+                            }}
+                            className="h-8 px-3 text-xs"
+                          >
+                            Copy & Open OpenAI
+                          </Button>
+                        )}
+
                       {codexOauthLoginInProgress && (
                         <Button variant="secondary" size="sm" onClick={cancelCodexOauth}>
                           Cancel
@@ -1537,48 +1530,32 @@ export function ProvidersSection() {
                           Enter this code on the OpenAI verification page:
                         </p>
                         <div className="flex items-center gap-2">
-                          <code className="text-accent text-lg font-bold tracking-widest">
+                          <code className="text-foreground text-lg font-bold tracking-widest">
                             {codexOauthDeviceFlow.userCode}
                           </code>
                           <Button
-                            variant="ghost"
                             size="sm"
-                            aria-label="Copy verification code and open verification page"
+                            aria-label="Copy and open OpenAI verification page"
                             onClick={() => {
                               void navigator.clipboard.writeText(codexOauthDeviceFlow.userCode);
-                              setCodexOauthCodeCopied(true);
-                              if (codexOauthCopiedTimeoutRef.current !== null) {
-                                clearTimeout(codexOauthCopiedTimeoutRef.current);
-                              }
-                              codexOauthCopiedTimeoutRef.current = setTimeout(
-                                () => setCodexOauthCodeCopied(false),
-                                2000
-                              );
                               window.open(codexOauthDeviceFlow.verifyUrl, "_blank", "noopener");
                             }}
-                            className="text-muted hover:text-foreground h-auto px-1 py-0 text-xs"
+                            className="h-8 px-3 text-xs"
                           >
-                            {codexOauthCodeCopied ? "Copied!" : "Copy & open"}
+                            Copy & Open OpenAI
                           </Button>
                         </div>
-                        <p className="text-muted text-xs">
-                          Continue in your browser:{" "}
-                          <a
-                            href={codexOauthDeviceFlow.verifyUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-accent hover:text-accent-light underline"
-                          >
-                            open the verification page
-                          </a>
-                          .
+                        <p className="text-muted inline-flex items-center gap-2 text-xs">
+                          <Loader2 aria-hidden className="h-3.5 w-3.5 animate-spin" />
+                          Waiting for authorization...
                         </p>
                       </div>
                     )}
 
                     {codexOauthStatus === "waiting" && !codexOauthDeviceFlow && (
-                      <p className="text-muted text-xs">
-                        Finish the login flow in your browser, then return here.
+                      <p className="text-muted inline-flex items-center gap-2 text-xs">
+                        <Loader2 aria-hidden className="h-3.5 w-3.5 animate-spin" />
+                        Waiting for authorization...
                       </p>
                     )}
 


### PR DESCRIPTION
## Summary
This refines OAuth UX in Providers so opening auth pages is always explicit and the device-code UI is clearer. All three provider paths now use explicit **Copy & Open {Provider}** actions (GitHub, OpenAI, Mux Gateway), with visible waiting indicators.

## Background
The previous flow could auto-open OAuth pages and used subtle inline copy controls. The requested behavior was:
- no automatic OAuth page opening
- stronger, button-like copy/open actions
- provider-specific button text
- no extra link below the code block
- spinner while waiting for authorization

## Implementation
- Removed automatic OAuth page opening in Providers for:
  - OpenAI desktop/browser-connect path
  - GitHub Copilot device-code flow
  - Mux Gateway desktop and server flow starts
- Added explicit primary actions:
  - `Copy & Open GitHub`
  - `Copy & Open OpenAI`
  - `Copy & Open Mux Gateway`
- Updated device-code cards:
  - code text now uses neutral foreground color
  - removed the lower "open the verification page" link section
  - added inline spinner + `Waiting for authorization...`
- Added waiting-state spinner for Mux Gateway auth status and explicit Copy & Open action while waiting.

## Validation
- `make static-check`

## Risks
Low risk and scoped to OAuth UI behavior in `ProvidersSection`. Backend OAuth services and token handling are unchanged.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.00 -->
