### PR TITLE
🤖 fix: preserve Host header in Vite /orpc proxy to fix dev-server 403s

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -164,7 +164,9 @@ export default defineConfig(({ mode }) => {
       proxy: {
         "/orpc": {
           target: backendProxyTarget,
-          changeOrigin: true,
+          // Preserve the original Host so backend origin validation compares against
+          // the public dev-server origin (localhost:5173) instead of 127.0.0.1:3000.
+          changeOrigin: false,
           ws: true,
         },
         "/api": {


### PR DESCRIPTION
## Summary

Fix dev-server 403s on `/orpc/ws` that caused "Loading workspaces..." to hang forever in the browser.

## Background

When running `make dev-server` and opening `localhost:5173`, the Vite proxy forwarded `/orpc/ws` requests to the backend at `127.0.0.1:3000` with `changeOrigin: true`. This rewrote the `Host` header to `127.0.0.1:3000` while the browser's `Origin` header remained `http://localhost:5173`. The backend's origin validation middleware compared these two, found a mismatch, and returned 403 Forbidden — preventing the WebSocket connection from ever establishing.

Without a working WebSocket, `api.workspace.list()` never completed, so `WorkspaceContext.loading` stayed `true` and the UI was stuck on "Loading workspaces..." indefinitely.

## Implementation

One-line change: set `changeOrigin: false` on the `/orpc` Vite proxy entry, matching what `/auth` already does. This preserves the original `Host` header so it matches the browser's `Origin`, and the backend's origin validation passes correctly.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$4.17`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=4.17 -->
