### PR TITLE
🤖 fix: require PR metadata to describe full diff

### DIFF
--- a/.mux/skills/pull-requests/SKILL.md
+++ b/.mux/skills/pull-requests/SKILL.md
@@ -27,6 +27,7 @@ Always check `$MUX_MODEL_STRING`, `$MUX_THINKING_LEVEL`, and `$MUX_COSTS_USD` vi
 - Reuse existing PRs; never close or recreate without instruction.
 - Force-push minor PR updates; otherwise add a new commit to preserve the change timeline.
 - If a PR is already open for your change, keep it up to date with the latest commits; don't leave it stale.
+- When updating a PR, ensure the title and body describe the **entire** diff against the base branch—not just the most recent commit or push.
 - Never enable auto-merge or merge into `main` yourself. The user must explicitly merge PRs.
 
 ## CI & Validation


### PR DESCRIPTION
## Summary
Tightens the `pull-requests` skill guidance so PR titles and bodies must describe the entire diff against the base branch, not just the latest commit/push.

## Background
Our agent has been overfitting PR metadata to only the most recent change set. Since PR metadata should represent what will actually be squash-merged, this needed to be explicit in the skill guidance.

## Implementation
- Added a lifecycle-rule bullet in `.mux/skills/pull-requests/SKILL.md` requiring title/body coverage of the full PR diff.
- Kept the new sentence concise to avoid duplicating rationale already documented elsewhere in the same file.

## Validation
- `make static-check`

## Risks
Low. Documentation-only change to agent guidance.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.25`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.25 -->
