### PR TITLE
🤖 fix: rename agent shortcut hint text

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -2432,7 +2432,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                     </span>
                     <span>
                       <span className="font-mono">{formatKeybind(KEYBINDS.CYCLE_AGENT)}</span>
-                      <span> - change agent mode</span>
+                      <span> - change agent</span>
                     </span>
                   </div>
                 )}


### PR DESCRIPTION
Summary
Renames the empty-chat shortcut hint text from "change agent mode" to "change agent" in the chat input footer.

Background
The requested UI wording should avoid the extra "mode" term and match the action more directly.

Implementation
Updated the label for the KEYBINDS.CYCLE_AGENT hint in src/browser/components/ChatInput/index.tsx.

Validation
- make static-check

Risks
Low risk. This is a one-line, user-visible text change in a shortcut hint.

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.00 -->
