### PR TITLE
🤖 fix: include missing built-in agents in fallback settings

### DIFF
--- a/src/browser/components/Settings/sections/TasksSection.tsx
+++ b/src/browser/components/Settings/sections/TasksSection.tsx
@@ -80,6 +80,33 @@ const FALLBACK_AGENTS: AgentDefinitionDescriptor[] = [
     subagentRunnable: true,
     base: "exec",
   },
+  {
+    id: "mux",
+    scope: "built-in",
+    name: "Mux",
+    description: "Configure mux global behavior (system workspace)",
+    uiSelectable: false,
+    subagentRunnable: false,
+  },
+  {
+    // Keep every built-in agent ID in the fallback list so user overrides don't
+    // get mislabeled as "Unknown agents" when workspace discovery is unavailable.
+    id: "orchestrator",
+    scope: "built-in",
+    name: "Orchestrator",
+    description: "Coordinate sub-agent implementation and apply patches",
+    uiSelectable: true,
+    subagentRunnable: false,
+    base: "exec",
+  },
+  {
+    id: "system1_bash",
+    scope: "built-in",
+    name: "System1 Bash",
+    description: "Fast bash-output filtering (internal)",
+    uiSelectable: false,
+    subagentRunnable: false,
+  },
 ];
 
 function getAgentDefinitionPath(agent: AgentDefinitionDescriptor): string | null {


### PR DESCRIPTION
## Summary
Add the missing built-in agents to `FALLBACK_AGENTS` in Settings so local `agentAiDefaults` overrides for built-ins are not shown under "Unknown agents" when workspace agent discovery is unavailable.

## Background
`Unknown agents` is computed from `agentAiDefaults` minus the currently listed agents. During fallback mode, `listedAgents` comes from `FALLBACK_AGENTS`. Since `mux`, `orchestrator`, and `system1_bash` were omitted from that list, configured overrides for those built-ins were misclassified as unknown.

## Implementation
- Updated `src/browser/components/Settings/sections/TasksSection.tsx`
  - Added fallback descriptors for:
    - `mux`
    - `orchestrator`
    - `system1_bash`
- Added an inline comment documenting why fallback must include all built-in IDs.

## Validation
- `make static-check`

## Risks
Low. This is a fallback-only list update used when discovery is unavailable; it aligns fallback behavior with existing built-in agent definitions and only affects Settings classification/rendering.

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.93`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.93 -->
