### PR TITLE
🤖 fix: allow Codex OAuth for gpt-5.3-codex-spark

### DIFF
--- a/src/common/constants/codexOAuth.ts
+++ b/src/common/constants/codexOAuth.ts
@@ -94,6 +94,7 @@ export const CODEX_OAUTH_ALLOWED_MODELS = new Set<string>([
   "gpt-5.2",
   "gpt-5.2-codex",
   "gpt-5.3-codex",
+  "gpt-5.3-codex-spark",
   "gpt-5.1-codex",
 ]);
 


### PR DESCRIPTION
Summary
Added `gpt-5.3-codex-spark` to the Codex OAuth allowlist so this model can route through the ChatGPT Codex OAuth path when OAuth credentials are available.

Background
A new model ID was needed to behave like other OAuth-eligible Codex variants. The allowlist check is an exact `Set.has()` match in shared constants, so the model must be explicitly listed.

Implementation
- Updated `src/common/constants/codexOAuth.ts`:
  - Added `"gpt-5.3-codex-spark"` to `CODEX_OAUTH_ALLOWED_MODELS`
- No behavior changes outside existing allowlist gating logic.

Validation
- `bun test src/browser/hooks/useModelsFromSettings.test.ts src/node/services/providerModelFactory.test.ts`
- `make static-check`

Risks
Low risk. This is a one-line additive allowlist change in shared constants. Existing required-model behavior remains unchanged.

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh`_

---
_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.55`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.55 -->
