### PR TITLE
🤖 fix: use --frozen-lockfile in .mux/init to prevent bun.lock diffs

### DIFF
--- a/.mux/init
+++ b/.mux/init
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 echo "Installing dependencies with bun..."
-bun install
+# Keep tool bootstrap read-only for lockfiles so opening a workspace never dirties bun.lock.
+bun install --frozen-lockfile
 echo "Dependencies installed successfully!"
 


### PR DESCRIPTION
## Summary

The `.mux/init` script ran bare `bun install`, which could resolve updated packages and modify `bun.lock`. This caused every new workspace to start with a dirty working tree.

## Implementation

Changed `bun install` → `bun install --frozen-lockfile` so the init hook installs exactly what the lockfile specifies without writing back to it.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=0.00 -->
