### PR TITLE
🤖 fix: reset retry backoff after stop then retry

### DIFF
--- a/src/browser/components/Messages/ChatBarrier/RetryBarrier.tsx
+++ b/src/browser/components/Messages/ChatBarrier/RetryBarrier.tsx
@@ -99,11 +99,15 @@ export const RetryBarrier: React.FC<RetryBarrierProps> = (props) => {
   // Emits event to useResumeManager instead of calling resumeStream directly
   // This keeps all retry logic centralized in one place
   const handleManualRetry = () => {
+    const resetBackoff = !autoRetry;
     enableAutoRetryPreference(props.workspaceId); // Re-enable auto-retry for next failure
 
-    // Create manual retry state: immediate retry BUT preserves attempt counter
-    // This prevents infinite retry loops without backoff if the retry fails
-    updatePersistedState(getRetryStateKey(props.workspaceId), createManualRetryState(attempt));
+    // User rationale: after explicitly stopping auto-retry, hitting Retry should
+    // start a fresh backoff window instead of inheriting a long prior delay.
+    updatePersistedState(
+      getRetryStateKey(props.workspaceId),
+      createManualRetryState(attempt, { resetBackoff })
+    );
 
     // Emit event to useResumeManager - it will handle the actual resume
     // Pass isManual flag to bypass eligibility checks (user explicitly wants to retry)

--- a/src/browser/utils/messages/retryState.ts
+++ b/src/browser/utils/messages/retryState.ts
@@ -36,16 +36,22 @@ export function createFreshRetryState(): RetryState {
 /**
  * Create retry state for manual retry (user-initiated)
  *
- * Makes the retry immediately eligible BUT preserves the attempt counter
- * to maintain backoff progression if the retry fails.
+ * Makes the retry immediately eligible while allowing callers to choose whether
+ * the attempt counter should be preserved or reset.
  *
- * This prevents infinite retry loops without backoff.
+ * Preserving the attempt keeps exponential backoff progression if the retry
+ * fails again. Resetting the attempt is useful when the user explicitly stopped
+ * auto-retry and wants a fresh retry cycle.
  *
- * @param currentAttempt - Current attempt count to preserve backoff progression
+ * @param currentAttempt - Current attempt count
+ * @param options.resetBackoff - When true, reset attempt to 0 for a fresh cycle
  */
-export function createManualRetryState(currentAttempt: number): RetryState {
+export function createManualRetryState(
+  currentAttempt: number,
+  options?: { resetBackoff?: boolean }
+): RetryState {
   return {
-    attempt: currentAttempt,
+    attempt: options?.resetBackoff ? 0 : currentAttempt,
     retryStartTime: Date.now() - INITIAL_DELAY, // Make immediately eligible
     lastError: undefined, // Clear error (user is manually retrying)
   };


### PR DESCRIPTION
## Summary
Reset retry backoff after an explicit Stop → Retry flow so users get a fresh retry cycle instead of inheriting a long prior delay.

## Background
Retry state previously preserved the attempt counter for all manual retries. That is desirable for normal manual retries during an active auto-retry cycle, but it made Stop → Retry feel sluggish because the next failure resumed from an already-large backoff window.

## Implementation
- Extended `createManualRetryState` with an optional `resetBackoff` flag.
- Updated `RetryBarrier` manual retry handling to set `resetBackoff` when auto-retry is currently disabled (the user explicitly pressed Stop).
- Kept existing manual retry behavior unchanged when auto-retry is still enabled (attempt counter preserved).
- Added unit tests covering both preserved-attempt and reset-attempt paths.

## Validation
- `bun test src/browser/utils/messages/retryState.test.ts`
- `make static-check`

## Risks
Low risk and scoped to retry state transitions. The change is gated to manual retries after explicit Stop and preserves prior behavior for normal manual retries.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.00 -->
