### PR TITLE
🤖 fix: dedicate F2 to workspace title editing

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -95,7 +95,7 @@ HistoryService is pure local disk I/O with a single dependency (`getSessionDir`)
 
 ## Command Palette & UI Access
 
-- Open palette with `Cmd+Shift+P` (mac) / `Ctrl+Shift+P` (win/linux) / `F2`; quick toggle via `Cmd+P` / `Ctrl+P`.
+- Open palette with `Cmd+Shift+P` (mac) / `Ctrl+Shift+P` (win/linux); quick toggle via `Cmd+P` / `Ctrl+P`.
 - Palette covers workspace mgmt, navigation, chat utils, mode/model switches, slash commands (`/` for suggestions, `>` for actions).
 
 ## Styling

--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -17,7 +17,7 @@ import {
   readPersistedState,
 } from "./hooks/usePersistedState";
 import { useResizableSidebar } from "./hooks/useResizableSidebar";
-import { matchesKeybind, KEYBINDS, isEditableElement } from "./utils/ui/keybinds";
+import { matchesKeybind, KEYBINDS } from "./utils/ui/keybinds";
 import { handleLayoutSlotHotkeys } from "./utils/ui/layoutSlotHotkeys";
 import { buildSortedWorkspacesByProject } from "./utils/ui/workspaceFiltering";
 import { getVisibleWorkspaceIds } from "./utils/ui/workspaceDomNav";
@@ -674,30 +674,12 @@ function AppInner() {
       } else if (matchesKeybind(e, KEYBINDS.PREV_WORKSPACE)) {
         e.preventDefault();
         handleNavigateWorkspace("prev");
-      } else if (
-        matchesKeybind(e, KEYBINDS.OPEN_COMMAND_PALETTE_ALT) &&
-        !sidebarCollapsed &&
-        selectedWorkspace &&
-        selectedWorkspace.workspaceId !== MUX_HELP_CHAT_WORKSPACE_ID &&
-        !isEditableElement(e.target)
-      ) {
-        // F2 edits the selected workspace title in the expanded sidebar; skip
-        // command palette handling so both shortcuts don't fire.
-        return;
-      } else if (
-        matchesKeybind(e, KEYBINDS.OPEN_COMMAND_PALETTE) ||
-        matchesKeybind(e, KEYBINDS.OPEN_COMMAND_PALETTE_ALT)
-      ) {
+      } else if (matchesKeybind(e, KEYBINDS.OPEN_COMMAND_PALETTE)) {
         e.preventDefault();
         if (isCommandPaletteOpen) {
           closeCommandPalette();
         } else {
-          // Alternate palette shortcut opens in command mode (with ">") while the
-          // primary Ctrl/Cmd+Shift+P shortcut opens default workspace-switch mode.
-          const initialQuery = matchesKeybind(e, KEYBINDS.OPEN_COMMAND_PALETTE_ALT)
-            ? ">"
-            : undefined;
-          openCommandPalette(initialQuery);
+          openCommandPalette();
         }
       } else if (matchesKeybind(e, KEYBINDS.OPEN_MUX_CHAT)) {
         e.preventDefault();
@@ -723,12 +705,9 @@ function AppInner() {
     handleNavigateWorkspace,
     handleOpenMuxChat,
     setSidebarCollapsed,
-    sidebarCollapsed,
     isCommandPaletteOpen,
     closeCommandPalette,
     openCommandPalette,
-    creationProjectPath,
-    selectedWorkspace,
     openSettings,
     navigate,
   ]);

--- a/src/browser/components/Settings/sections/KeybindsSection.tsx
+++ b/src/browser/components/Settings/sections/KeybindsSection.tsx
@@ -30,7 +30,6 @@ const KEYBIND_LABELS: Record<keyof typeof KEYBINDS, string> = {
   SHARE_TRANSCRIPT: "Share transcript",
   CONFIGURE_MCP: "Configure MCP servers",
   OPEN_COMMAND_PALETTE: "Command palette",
-  OPEN_COMMAND_PALETTE_ALT: "Command palette (alternate)",
   OPEN_MUX_CHAT: "Open Chat with Mux",
   TOGGLE_THINKING: "Toggle thinking",
   FOCUS_CHAT: "Focus chat input",
@@ -148,9 +147,7 @@ const KEYBIND_GROUPS: Array<{ label: string; keys: Array<keyof typeof KEYBINDS> 
 // Some actions have multiple equivalent shortcuts; render alternates on the same row.
 const KEYBIND_DISPLAY_ALTERNATES: Partial<
   Record<keyof typeof KEYBINDS, Array<keyof typeof KEYBINDS>>
-> = {
-  OPEN_COMMAND_PALETTE: ["OPEN_COMMAND_PALETTE_ALT"],
-};
+> = {};
 
 export function KeybindsSection() {
   return (

--- a/src/browser/components/splashScreens/OnboardingWizardSplash.tsx
+++ b/src/browser/components/splashScreens/OnboardingWizardSplash.tsx
@@ -481,7 +481,6 @@ export function OnboardingWizardSplash(props: { onDismiss: () => void }) {
   }, [configuredProviders.length, hasConfiguredProvidersAtStart, providersLoading]);
 
   const commandPaletteShortcut = formatKeybind(KEYBINDS.OPEN_COMMAND_PALETTE);
-  const commandPaletteShortcutAlt = formatKeybind(KEYBINDS.OPEN_COMMAND_PALETTE_ALT);
   const agentPickerShortcut = formatKeybind(KEYBINDS.TOGGLE_AGENT);
   const cycleAgentShortcut = formatKeybind(KEYBINDS.CYCLE_AGENT);
 
@@ -871,8 +870,6 @@ export function OnboardingWizardSplash(props: { onDismiss: () => void }) {
           <div className="mt-3 flex flex-wrap items-center gap-2">
             <span className="text-muted text-sm">Open command palette</span>
             <kbd className={KBD_CLASSNAME}>{commandPaletteShortcut}</kbd>
-            <span className="text-muted text-sm">or</span>
-            <kbd className={KBD_CLASSNAME}>{commandPaletteShortcutAlt}</kbd>
           </div>
 
           <div className="mt-3">
@@ -893,7 +890,6 @@ export function OnboardingWizardSplash(props: { onDismiss: () => void }) {
     agentPickerShortcut,
     cancelMuxGatewayLogin,
     commandPaletteShortcut,
-    commandPaletteShortcutAlt,
     configuredProviders.length,
     configuredProvidersSummary,
     cycleAgentShortcut,

--- a/src/browser/utils/ui/keybinds.test.ts
+++ b/src/browser/utils/ui/keybinds.test.ts
@@ -165,10 +165,10 @@ describe("matchesKeybind", () => {
     expect(matchesKeybind(event, keybind)).toBe(true);
   });
 
-  it("should match F2 for OPEN_COMMAND_PALETTE_ALT", () => {
-    const event = createEvent({ key: "F2" });
+  it("should match Ctrl/Cmd+Shift+P for OPEN_COMMAND_PALETTE", () => {
+    const event = createEvent({ key: "P", ctrlKey: true, shiftKey: true });
 
-    expect(matchesKeybind(event, KEYBINDS.OPEN_COMMAND_PALETTE_ALT)).toBe(true);
+    expect(matchesKeybind(event, KEYBINDS.OPEN_COMMAND_PALETTE)).toBe(true);
   });
 
   it("should match complex multi-modifier combination", () => {

--- a/src/browser/utils/ui/keybinds.ts
+++ b/src/browser/utils/ui/keybinds.ts
@@ -322,10 +322,6 @@ export const KEYBINDS = {
   // macOS: Cmd+Shift+P, Win/Linux: Ctrl+Shift+P
   OPEN_COMMAND_PALETTE: { key: "P", ctrl: true, shift: true },
 
-  /** Open Command Palette (alternate) */
-  // Browser-safe fallback for Ctrl+Shift+P, which can be intercepted by Firefox.
-  OPEN_COMMAND_PALETTE_ALT: { key: "F2" },
-
   /** Open Chat with Mux */
   // User requested F1 for quick access to the built-in help chat.
   OPEN_MUX_CHAT: { key: "F1" },


### PR DESCRIPTION
## Summary
Removes the `F2` command-palette alternate shortcut so `F2` is consistently reserved for workspace title editing/generation in the sidebar.

## Background
`F2` was bound to both workspace-title editing and command-palette open behavior. This created an input race where rename was less reliable.

## Implementation
- Removed `OPEN_COMMAND_PALETTE_ALT` (`F2`) from `KEYBINDS`.
- Simplified `App.tsx` keydown handling to only use `OPEN_COMMAND_PALETTE` (`Cmd/Ctrl+Shift+P`) for palette open/toggle.
- Removed stale UI references to the alternate palette shortcut in:
  - Settings keybind list
  - Onboarding command palette guidance
- Updated keybind test coverage to assert the primary palette shortcut path.
- Updated `docs/AGENTS.md` command palette shortcut description to match runtime behavior.

## Validation
- `make static-check`
- `bun test src/browser/utils/ui/keybinds.test.ts`

## Risks
Low. This change removes one shortcut and related display text; primary command palette shortcut remains unchanged.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.00 -->
