### PR TITLE
🤖 fix: avoid false liveness reconnects during active stream traffic

### DIFF
--- a/src/browser/contexts/API.test.tsx
+++ b/src/browser/contexts/API.test.tsx
@@ -51,6 +51,10 @@ class MockWebSocket {
   }
 }
 
+function createOrpcPongResponseFrame(id: number): string {
+  return JSON.stringify({ i: id, p: { b: "pong" } });
+}
+
 const originalFetch = globalThis.fetch;
 let fetchImpl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> = () =>
   Promise.resolve({
@@ -489,6 +493,68 @@ describe("API reconnection", () => {
     { timeout: 15000 }
   );
   test(
+    "counts stream traffic while liveness probes are in flight",
+    async () => {
+      let pingCallCount = 0;
+      let isAuthCheck = true;
+
+      pingImpl = () => {
+        pingCallCount++;
+
+        if (isAuthCheck) {
+          isAuthCheck = false;
+          return Promise.resolve("pong");
+        }
+
+        // Keep liveness probes pending long enough to overlap with the next interval.
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve("pong");
+          }, 9000);
+        });
+      };
+
+      render(
+        <APIProvider createWebSocket={createMockWebSocket}>
+          <APIStateObserver onState={() => undefined} />
+        </APIProvider>
+      );
+
+      const ws1 = MockWebSocket.lastInstance();
+      expect(ws1).toBeDefined();
+
+      await act(async () => {
+        ws1!.simulateOpen();
+        await new Promise((r) => setTimeout(r, 10));
+      });
+
+      await waitFor(
+        () => {
+          expect(pingCallCount).toBeGreaterThanOrEqual(2);
+        },
+        { timeout: 7000 }
+      );
+
+      const pingCallsWhenProbeStarted = pingCallCount;
+
+      const messageInterval = setInterval(() => {
+        ws1!.simulateMessage({ type: "stream-delta" });
+      }, 250);
+
+      try {
+        await new Promise((r) => setTimeout(r, 6000));
+      } finally {
+        clearInterval(messageInterval);
+      }
+
+      // Stream traffic during an in-flight probe should keep the connection healthy and
+      // suppress additional liveness probes for the next interval.
+      expect(pingCallCount).toBe(pingCallsWhenProbeStarted);
+    },
+    { timeout: 20000 }
+  );
+
+  test(
     "does not treat delayed liveness ping replies as stream traffic",
     async () => {
       const states: string[] = [];
@@ -502,7 +568,7 @@ describe("API reconnection", () => {
         // The delayed reply is emitted as a WS message to mimic network delivery.
         return new Promise((resolve) => {
           setTimeout(() => {
-            activeSocket?.simulateMessage({ type: "delayed-liveness-reply" });
+            activeSocket?.simulateMessage(createOrpcPongResponseFrame(pingCallCount));
             resolve("pong");
           }, 3500);
         });

--- a/src/browser/contexts/API.tsx
+++ b/src/browser/contexts/API.tsx
@@ -84,6 +84,56 @@ function closeWebSocketSafely(ws: WebSocket) {
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function tryParseJSONFramePayload(data: unknown): Record<string, unknown> | null {
+  if (typeof data !== "string" && !(data instanceof ArrayBuffer) && !ArrayBuffer.isView(data)) {
+    return null;
+  }
+
+  const rawPayload =
+    typeof data === "string"
+      ? data
+      : new TextDecoder().decode(
+          data instanceof ArrayBuffer
+            ? new Uint8Array(data)
+            : new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+        );
+
+  try {
+    const parsed: unknown = JSON.parse(rawPayload);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function isLikelyOrpcPongResponseFrame(data: unknown): boolean {
+  const payload = tryParseJSONFramePayload(data);
+  if (!payload) {
+    return false;
+  }
+
+  // Defensive guard: ORPC frames should always carry a numeric request id.
+  if (typeof payload.i !== "number") {
+    return false;
+  }
+
+  // Event iterator and abort frames are never ping responses.
+  if (payload.t === 3 || payload.t === 4) {
+    return false;
+  }
+
+  if (!isRecord(payload.p)) {
+    return false;
+  }
+
+  // ORPC encodes normal response bodies at payload.p.b.
+  return payload.p.b === "pong";
+}
+
 function createElectronClient(): { client: APIClient; cleanup: () => void } {
   const { port1: clientPort, port2: serverPort } = new MessageChannel();
   window.postMessage("start-orpc-client", "*", [serverPort]);
@@ -209,7 +259,7 @@ export const APIProvider = (props: APIProviderProps) => {
 
       setState({ status: "connecting" });
       const { client, cleanup, ws } = createBrowserClient(token, wsFactory);
-      ws.addEventListener("message", () => {
+      ws.addEventListener("message", (event) => {
         // User rationale: during large catch-up streams, ORPC ping responses can be delayed
         // behind data frames. Treat inbound non-probe traffic as proof of liveness to avoid
         // unnecessary reconnect loops for healthy-but-busy connections.
@@ -217,9 +267,14 @@ export const APIProvider = (props: APIProviderProps) => {
           return;
         }
 
-        // Exclude delayed responses for in-flight liveness probes so probe replies
-        // do not mask repeated timeout failures.
-        if (livenessPingsInFlightCountRef.current > 0) {
+        // Keep counting stream frames while liveness probes are in flight; otherwise a slow
+        // probe could incorrectly hide active traffic and trigger false reconnects.
+        //
+        // Only ignore frames that look like ORPC "pong" responses from those probes.
+        const isLikelyProbeReply =
+          livenessPingsInFlightCountRef.current > 0 && isLikelyOrpcPongResponseFrame(event.data);
+
+        if (isLikelyProbeReply) {
           return;
         }
 


### PR DESCRIPTION
## Summary
This change makes browser-mode API liveness checks resilient during high-volume stream catch-up by treating recent inbound WebSocket traffic as proof that the connection is healthy. When data frames are actively arriving, the client now skips the extra ORPC liveness ping for that interval instead of risking unnecessary reconnect escalation.

## Background
In server mode, ORPC liveness pings share the same WebSocket as stream traffic. During backlog replay/catch-up, ping responses can be delayed behind data frames and trigger false "degraded/reconnect" transitions even though the connection is still healthy and delivering messages.

## Implementation
- Added `lastInboundBrowserFrameAtRef` in `APIProvider` to track latest inbound WS message timestamp.
- Added a browser WebSocket `message` listener (connection-id guarded) to update that timestamp.
- Updated liveness loop to:
  - short-circuit as healthy when inbound traffic is recent (`<= LIVENESS_TIMEOUT_MS`), and
  - only send `client.general.ping("liveness")` when traffic has been idle.
- Refactored shared healthy-state reset logic into `markConnectionHealthy()`.
- Added test coverage:
  - `treats active inbound traffic as healthy and skips liveness pings`
  - verifies pings are suppressed while inbound frames are flowing and resume once traffic stops.

## Validation
- `bun test src/browser/contexts/API.test.tsx` ✅
- `make typecheck` ✅
- `make static-check` ⚠️ blocked in local environment at `flake-hash-check` due nix build failures outside this change:
  - electron header download TLS certificate chain failure (`unable to get local issuer certificate`)
  - icon generation path failure in nix sandbox (`build/icon.iconset/...: No such file or directory`)

## Risks
- Low risk: change is scoped to browser WebSocket liveness behavior only.
- Behavior change is intentional: active inbound traffic now counts as liveness to prevent false reconnect loops under heavy stream load.

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$1.50`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=1.50 -->
