### PR TITLE
🤖 fix: stabilize compaction doc anchor slugs

### DIFF
--- a/docs/workspaces/compaction/index.mdx
+++ b/docs/workspaces/compaction/index.mdx
@@ -7,13 +7,13 @@ As conversations grow, they consume more of the model's context window. Compacti
 
 ## Approaches
 
-| Approach                                                                  | Speed            | Context Preservation | Cost            | Reversible |
-| ------------------------------------------------------------------------- | ---------------- | -------------------- | --------------- | ---------- |
-| [Start Here](/workspaces/compaction/manual#start-here)                    | Instant          | Intelligent          | Free            | Yes        |
-| [`/compact`](/workspaces/compaction/manual#compact---ai-summarization)    | Slower (uses AI) | Intelligent          | Uses API tokens | No         |
-| [`/clear`](/workspaces/compaction/manual#clear---clear-all-history)       | Instant          | None                 | Free            | No         |
-| [`/truncate`](/workspaces/compaction/manual#truncate---simple-truncation) | Instant          | Temporal             | Free            | No         |
-| [Auto-Compaction](/workspaces/compaction/automatic)                       | Automatic        | Intelligent          | Uses API tokens | No         |
+| Approach                                                                | Speed            | Context Preservation | Cost            | Reversible |
+| ----------------------------------------------------------------------- | ---------------- | -------------------- | --------------- | ---------- |
+| [Start Here](/workspaces/compaction/manual#start-here)                  | Instant          | Intelligent          | Free            | Yes        |
+| [`/compact`](/workspaces/compaction/manual#compact-ai-summarization)    | Slower (uses AI) | Intelligent          | Uses API tokens | No         |
+| [`/clear`](/workspaces/compaction/manual#clear-all-history)             | Instant          | None                 | Free            | No         |
+| [`/truncate`](/workspaces/compaction/manual#truncate-simple-truncation) | Instant          | Temporal             | Free            | No         |
+| [Auto-Compaction](/workspaces/compaction/automatic)                     | Automatic        | Intelligent          | Uses API tokens | No         |
 
 ## When to compact
 

--- a/docs/workspaces/compaction/manual.mdx
+++ b/docs/workspaces/compaction/manual.mdx
@@ -18,7 +18,7 @@ This is a form of "opportunistic compaction" — the content is already well-str
 
 ---
 
-## `/compact` — AI Summarization
+## Compact (AI Summarization)
 
 Compress conversation history using AI summarization. Replaces the conversation with a compact summary that preserves context.
 
@@ -94,7 +94,7 @@ Combine custom model, token limit, and auto-continue message.
 
 ---
 
-## `/clear` — Clear All History
+## Clear All History
 
 Remove all messages from conversation history.
 
@@ -112,7 +112,7 @@ Remove all messages from conversation history.
 
 ---
 
-## `/truncate` — Simple Truncation
+## Truncate (Simple Truncation)
 
 Remove a percentage of messages from conversation history (from the oldest first).
 


### PR DESCRIPTION
## Summary

Fixes the Static Checks CI failure (`check-docs-links`) that is currently breaking all PRs.

## Background

The compaction doc headings used backtick-wrapped `/commands` and em-dashes (`—`), e.g. ``## `/compact` — AI Summarization``. These produce different anchor slugs across mintlify versions — the CI version generates slugs incompatible with the `#compact---ai-summarization` anchors in `index.mdx`, causing 3 broken-link errors.

## Implementation

- Simplified headings to plain text (e.g. `## Compact (AI Summarization)`) which produce stable, predictable slugs
- Updated the corresponding anchor links in `index.mdx`

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$6.14`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=6.14 -->
