### PR TITLE
🤖 fix: bind zoom-in to Ctrl/Cmd+=

### DIFF
--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -299,7 +299,8 @@ function createMenu() {
         { role: "toggleDevTools" },
         { type: "separator" },
         { role: "resetZoom" },
-        { role: "zoomIn" },
+        // Bind zoom-in to Ctrl/Cmd+= so the standard shortcut works without requiring Shift.
+        { role: "zoomIn", accelerator: "CommandOrControl+=" },
         { role: "zoomOut" },
         { type: "separator" },
         {


### PR DESCRIPTION
## Summary
Bind the Electron `zoomIn` menu role to `CommandOrControl+=` so the standard zoom-in shortcut works in the desktop app.

Closes https://github.com/coder/mux/issues/1654

## Background
In the app, zoom out (`Ctrl+-`) and reset (`Ctrl+0`) worked, but zoom in did not when pressing `Ctrl` + `=`. Electron's default `zoomIn` role accelerator resolves to a `Plus` binding that commonly requires `Shift`, which made the expected shortcut unreliable.

## Implementation
- Updated `src/desktop/main.ts` in the View menu setup.
- Kept the built-in `zoomIn` role behavior.
- Overrode only the accelerator to `CommandOrControl+=`.

## Validation
- `make static-check`

## Risks
Low risk. The change is scoped to a single menu accelerator override and does not alter zoom behavior implementation, zoom-out, or zoom-reset bindings.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.75`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.75 -->
