### PR TITLE
🤖 feat: add F4 alternate command palette shortcut

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -96,7 +96,7 @@ HistoryService is pure local disk I/O with a single dependency (`getSessionDir`)
 
 ## Command Palette & UI Access
 
-- Open palette with `Cmd+Shift+P` (mac) / `Ctrl+Shift+P` (win/linux); quick toggle via `Cmd+P` / `Ctrl+P`.
+- Open palette with `Cmd+Shift+P` (mac) / `Ctrl+Shift+P` (win/linux) / `F4`; quick toggle via `Cmd+P` / `Ctrl+P`.
 - Palette covers workspace mgmt, navigation, chat utils, mode/model switches, slash commands (`/` for suggestions, `>` for actions).
 
 ## Styling

--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -678,12 +678,20 @@ function AppInner() {
       } else if (matchesKeybind(e, KEYBINDS.PREV_WORKSPACE)) {
         e.preventDefault();
         handleNavigateWorkspace("prev");
-      } else if (matchesKeybind(e, KEYBINDS.OPEN_COMMAND_PALETTE)) {
+      } else if (
+        matchesKeybind(e, KEYBINDS.OPEN_COMMAND_PALETTE) ||
+        matchesKeybind(e, KEYBINDS.OPEN_COMMAND_PALETTE_ACTIONS)
+      ) {
         e.preventDefault();
         if (isCommandPaletteOpen) {
           closeCommandPalette();
         } else {
-          openCommandPalette();
+          // Alternate palette shortcut opens in command mode (with ">") while the
+          // primary Ctrl/Cmd+Shift+P shortcut opens default workspace-switch mode.
+          const initialQuery = matchesKeybind(e, KEYBINDS.OPEN_COMMAND_PALETTE_ACTIONS)
+            ? ">"
+            : undefined;
+          openCommandPalette(initialQuery);
         }
       } else if (matchesKeybind(e, KEYBINDS.OPEN_MUX_CHAT)) {
         e.preventDefault();

--- a/src/browser/components/Settings/sections/KeybindsSection.tsx
+++ b/src/browser/components/Settings/sections/KeybindsSection.tsx
@@ -30,6 +30,7 @@ const KEYBIND_LABELS: Record<keyof typeof KEYBINDS, string> = {
   SHARE_TRANSCRIPT: "Share transcript",
   CONFIGURE_MCP: "Configure MCP servers",
   OPEN_COMMAND_PALETTE: "Command palette",
+  OPEN_COMMAND_PALETTE_ACTIONS: "Command palette (alternate)",
   OPEN_MUX_CHAT: "Open Chat with Mux",
   TOGGLE_THINKING: "Toggle thinking",
   FOCUS_CHAT: "Focus chat input",
@@ -150,7 +151,9 @@ const KEYBIND_GROUPS: Array<{ label: string; keys: Array<keyof typeof KEYBINDS> 
 // Some actions have multiple equivalent shortcuts; render alternates on the same row.
 const KEYBIND_DISPLAY_ALTERNATES: Partial<
   Record<keyof typeof KEYBINDS, Array<keyof typeof KEYBINDS>>
-> = {};
+> = {
+  OPEN_COMMAND_PALETTE: ["OPEN_COMMAND_PALETTE_ACTIONS"],
+};
 
 export function KeybindsSection() {
   return (

--- a/src/browser/components/splashScreens/OnboardingWizardSplash.tsx
+++ b/src/browser/components/splashScreens/OnboardingWizardSplash.tsx
@@ -482,6 +482,7 @@ export function OnboardingWizardSplash(props: { onDismiss: () => void }) {
   }, [configuredProviders.length, hasConfiguredProvidersAtStart, providersLoading]);
 
   const commandPaletteShortcut = formatKeybind(KEYBINDS.OPEN_COMMAND_PALETTE);
+  const commandPaletteActionsShortcut = formatKeybind(KEYBINDS.OPEN_COMMAND_PALETTE_ACTIONS);
   const agentPickerShortcut = formatKeybind(KEYBINDS.TOGGLE_AGENT);
   const cycleAgentShortcut = formatKeybind(KEYBINDS.CYCLE_AGENT);
 
@@ -878,8 +879,9 @@ export function OnboardingWizardSplash(props: { onDismiss: () => void }) {
           </div>
 
           <p className="mt-3">
-            Tip: type <code className="text-accent">&gt;</code> for commands and{" "}
-            <code className="text-accent">/</code> for slash commands.
+            Tip: type <code className="text-accent">&gt;</code> for commands, press{" "}
+            <kbd className={KBD_CLASSNAME}>{commandPaletteActionsShortcut}</kbd> to open command
+            mode directly, and use <code className="text-accent">/</code> for slash commands.
           </p>
         </>
       ),
@@ -890,6 +892,7 @@ export function OnboardingWizardSplash(props: { onDismiss: () => void }) {
     addProject,
     agentPickerShortcut,
     cancelMuxGatewayLogin,
+    commandPaletteActionsShortcut,
     commandPaletteShortcut,
     configuredProviders.length,
     configuredProvidersSummary,

--- a/src/browser/utils/ui/keybinds.test.ts
+++ b/src/browser/utils/ui/keybinds.test.ts
@@ -171,6 +171,12 @@ describe("matchesKeybind", () => {
     expect(matchesKeybind(event, KEYBINDS.OPEN_COMMAND_PALETTE)).toBe(true);
   });
 
+  it("should match F4 for OPEN_COMMAND_PALETTE_ACTIONS", () => {
+    const event = createEvent({ key: "F4" });
+
+    expect(matchesKeybind(event, KEYBINDS.OPEN_COMMAND_PALETTE_ACTIONS)).toBe(true);
+  });
+
   it("should match complex multi-modifier combination", () => {
     const event = createEvent({ key: "P", ctrlKey: true, shiftKey: true });
     const keybind: Keybind = { key: "P", ctrl: true, shift: true };

--- a/src/browser/utils/ui/keybinds.ts
+++ b/src/browser/utils/ui/keybinds.ts
@@ -335,6 +335,10 @@ export const KEYBINDS = {
   // macOS: Cmd+Shift+P, Win/Linux: Ctrl+Shift+P
   OPEN_COMMAND_PALETTE: { key: "P", ctrl: true, shift: true },
 
+  /** Open Command Palette directly in command mode (prefills ">") */
+  // F4 avoids browser-level collisions with Ctrl/Cmd+Shift+P in Firefox.
+  OPEN_COMMAND_PALETTE_ACTIONS: { key: "F4" },
+
   /** Open Chat with Mux */
   // User requested F1 for quick access to the built-in help chat.
   OPEN_MUX_CHAT: { key: "F1" },


### PR DESCRIPTION
## Summary
Adds a browser-safe alternate command-palette shortcut (`F4`) that opens directly in command mode with `>` prefilled, while preserving `Cmd/Ctrl+Shift+P` for default workspace-switch mode.

## Background
`Ctrl/Cmd+Shift+P` can be intercepted in browser contexts (especially Firefox), which makes the palette harder to reach. Earlier alternate-shortcut work was removed due conflicts with other function keys, but the `initialQuery` plumbing remained in place.

## Implementation
- Added `KEYBINDS.OPEN_COMMAND_PALETTE_ACTIONS` bound to `F4`.
- Updated `App.tsx` shortcut handling to use a single combined branch for both palette keybinds:
  - primary shortcut opens default mode
  - alternate shortcut opens with `openCommandPalette(">")`
- Updated Settings keybind rendering to show alternate shortcut on the same row via `KEYBIND_DISPLAY_ALTERNATES`.
- Updated onboarding command-palette tip to mention direct command-mode open.
- Updated docs command-palette shortcut line to include `F4`.
- Added unit test coverage for `OPEN_COMMAND_PALETTE_ACTIONS` key matching.

## Validation
- `bun test src/browser/utils/ui/keybinds.test.ts`
- `make typecheck`
- `make lint`
- `make static-check`

## Risks
Low risk. The change is scoped to keybinding registration/display and command-palette open wiring. Primary shortcut behavior remains unchanged.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$2.63`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=2.63 -->
