### PR TITLE
🤖 fix: keep Orchestrator visible in Settings agent defaults

### DIFF
--- a/src/browser/components/Settings/sections/TasksSection.tsx
+++ b/src/browser/components/Settings/sections/TasksSection.tsx
@@ -590,10 +590,13 @@ export function TasksSection() {
   const listedAgents = agents.length > 0 ? agents : FALLBACK_AGENTS;
   const enabledAgentIdSet = new Set(enabledAgentIds);
 
+  const showInSettingsUiAgents = (agent: AgentDefinitionDescriptor) =>
+    agent.uiSelectable || agent.id === "orchestrator";
+
   const uiAgents = useMemo(
     () =>
       [...listedAgents]
-        .filter((agent) => agent.uiSelectable)
+        .filter((agent) => showInSettingsUiAgents(agent))
         .sort((a, b) => a.name.localeCompare(b.name)),
     [listedAgents]
   );
@@ -603,7 +606,7 @@ export function TasksSection() {
       [...listedAgents]
         // Keep the sections mutually exclusive: UI agents belong under "UI agents" even if they
         // can also run as sub-agents.
-        .filter((agent) => agent.subagentRunnable && !agent.uiSelectable)
+        .filter((agent) => agent.subagentRunnable && !showInSettingsUiAgents(agent))
         .sort((a, b) => a.name.localeCompare(b.name)),
     [listedAgents]
   );
@@ -611,7 +614,7 @@ export function TasksSection() {
   const internalAgents = useMemo(
     () =>
       [...listedAgents]
-        .filter((agent) => !agent.uiSelectable && !agent.subagentRunnable)
+        .filter((agent) => !agent.subagentRunnable && !showInSettingsUiAgents(agent))
         .sort((a, b) => a.name.localeCompare(b.name)),
     [listedAgents]
   );
@@ -714,6 +717,11 @@ export function TasksSection() {
 
             {agent.description ? (
               <div className="text-muted mt-1 text-xs">{agent.description}</div>
+            ) : null}
+            {agent.id === "orchestrator" && !agent.uiSelectable ? (
+              <div className="text-muted mt-1 text-xs italic">
+                Agent is available when workspace contains a plan created in Plan mode.
+              </div>
             ) : null}
           </div>
 


### PR DESCRIPTION
## Summary
Make Orchestrator always visible in **Settings → Agent Defaults → UI agents**, even when the current workspace has no accepted plan.

## Background
Orchestrator currently requires a workspace plan (`ui.requires: [plan]`), so `uiSelectable` becomes false when no plan file exists. That behavior is correct for the chat agent picker, but it also hid Orchestrator from Settings, making its defaults harder to discover and configure.

## Implementation
- Updated `src/browser/components/Settings/sections/TasksSection.tsx` to use a shared predicate for Settings section partitioning:
  - Treat `orchestrator` as part of Settings “UI agents” regardless of `uiSelectable`.
  - Keep section membership mutually exclusive for UI agents / sub-agents / internal.
- Added a contextual note on the Orchestrator row when it is not currently selectable:
  - `Agent is available when workspace contains a plan created in Plan mode.`
- Left runtime selectability untouched (no changes to backend plan gating or agent picker filtering).

## Validation
- `make static-check`

## Risks
Low risk and UI-scoped:
- Change is limited to Settings categorization/rendering in `TasksSection.tsx`.
- Agent picker behavior remains unchanged because it still filters by `uiSelectable`.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$2.29`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=2.29 -->
