### PR TITLE
🤖 revert: undo Settings Orchestrator default visibility (#2494)

### DIFF
--- a/src/browser/components/Settings/sections/TasksSection.tsx
+++ b/src/browser/components/Settings/sections/TasksSection.tsx
@@ -590,13 +590,10 @@ export function TasksSection() {
   const listedAgents = agents.length > 0 ? agents : FALLBACK_AGENTS;
   const enabledAgentIdSet = new Set(enabledAgentIds);
 
-  const showInSettingsUiAgents = (agent: AgentDefinitionDescriptor) =>
-    agent.uiSelectable || agent.id === "orchestrator";
-
   const uiAgents = useMemo(
     () =>
       [...listedAgents]
-        .filter((agent) => showInSettingsUiAgents(agent))
+        .filter((agent) => agent.uiSelectable)
         .sort((a, b) => a.name.localeCompare(b.name)),
     [listedAgents]
   );
@@ -606,7 +603,7 @@ export function TasksSection() {
       [...listedAgents]
         // Keep the sections mutually exclusive: UI agents belong under "UI agents" even if they
         // can also run as sub-agents.
-        .filter((agent) => agent.subagentRunnable && !showInSettingsUiAgents(agent))
+        .filter((agent) => agent.subagentRunnable && !agent.uiSelectable)
         .sort((a, b) => a.name.localeCompare(b.name)),
     [listedAgents]
   );
@@ -614,7 +611,7 @@ export function TasksSection() {
   const internalAgents = useMemo(
     () =>
       [...listedAgents]
-        .filter((agent) => !agent.subagentRunnable && !showInSettingsUiAgents(agent))
+        .filter((agent) => !agent.uiSelectable && !agent.subagentRunnable)
         .sort((a, b) => a.name.localeCompare(b.name)),
     [listedAgents]
   );
@@ -717,11 +714,6 @@ export function TasksSection() {
 
             {agent.description ? (
               <div className="text-muted mt-1 text-xs">{agent.description}</div>
-            ) : null}
-            {agent.id === "orchestrator" && !agent.uiSelectable ? (
-              <div className="text-muted mt-1 text-xs italic">
-                Agent is available when workspace contains a plan created in Plan mode.
-              </div>
             ) : null}
           </div>
 


### PR DESCRIPTION
## Summary
Revert the behavioral/UI tweak from [#2494](https://github.com/coder/mux/pull/2494) so **Settings → Agent defaults** goes back to only listing agents that are currently `uiSelectable`.

## Background
PR #2494 intentionally kept Orchestrator visible in Settings even when a workspace had no accepted plan. This change reverts that update per request.

## Implementation
- Reverted `src/browser/components/Settings/sections/TasksSection.tsx` to the pre-#2494 section-filtering logic.
- Removed the Settings-only special-case that always surfaced `orchestrator` in “UI agents”.

## Validation
- `make static-check`

## Risks
Low and scoped to Settings agent categorization. This restores the prior behavior from before #2494.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$unknown`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=unknown -->
