### PR TITLE
🤖 fix: preserve strict origin checks behind proxies

### DIFF
--- a/src/node/orpc/server.test.ts
+++ b/src/node/orpc/server.test.ts
@@ -550,6 +550,30 @@ describe("createOrpcServer", () => {
     }
   });
 
+  test("rejects downgraded HTTP origins when X-Forwarded-Proto includes multiple hops", async () => {
+    const stubContext: Partial<ORPCContext> = {};
+
+    let server: Awaited<ReturnType<typeof createOrpcServer>> | null = null;
+    try {
+      server = await createOrpcServer({
+        host: "127.0.0.1",
+        port: 0,
+        context: stubContext as ORPCContext,
+      });
+
+      const response = await fetch(`${server.baseUrl}/health`, {
+        headers: {
+          Origin: server.baseUrl,
+          "X-Forwarded-Proto": "https,http",
+        },
+      });
+
+      expect(response.status).toBe(403);
+    } finally {
+      await server?.close();
+    }
+  });
+
   test("allows HTTP requests without Origin headers", async () => {
     const stubContext: Partial<ORPCContext> = {};
 
@@ -666,6 +690,33 @@ describe("createOrpcServer", () => {
         headers: {
           origin: server.baseUrl,
           "x-forwarded-proto": "https",
+        },
+      });
+
+      await waitForWebSocketRejection(ws);
+    } finally {
+      ws?.terminate();
+      await server?.close();
+    }
+  });
+
+  test("rejects downgraded WebSocket origins when X-Forwarded-Proto includes multiple hops", async () => {
+    const stubContext: Partial<ORPCContext> = {};
+
+    let server: Awaited<ReturnType<typeof createOrpcServer>> | null = null;
+    let ws: WebSocket | null = null;
+
+    try {
+      server = await createOrpcServer({
+        host: "127.0.0.1",
+        port: 0,
+        context: stubContext as ORPCContext,
+      });
+
+      ws = new WebSocket(server.wsUrl, {
+        headers: {
+          origin: server.baseUrl,
+          "x-forwarded-proto": "https,http",
         },
       });
 

--- a/src/node/orpc/server.ts
+++ b/src/node/orpc/server.ts
@@ -138,30 +138,6 @@ function getFirstHeaderValue(req: OriginValidationRequest, headerName: string): 
   return firstValue?.length ? firstValue : null;
 }
 
-function getHeaderValues(req: OriginValidationRequest, headerName: string): string[] {
-  const rawValue = req.headers[headerName.toLowerCase()];
-  const values = Array.isArray(rawValue) ? rawValue : [rawValue];
-
-  const parsed: string[] = [];
-
-  for (const value of values) {
-    if (typeof value !== "string") {
-      continue;
-    }
-
-    for (const part of value.split(",")) {
-      const trimmed = part.trim();
-      if (trimmed.length === 0 || parsed.includes(trimmed)) {
-        continue;
-      }
-
-      parsed.push(trimmed);
-    }
-  }
-
-  return parsed;
-}
-
 function normalizeProtocol(rawProtocol: string): "http" | "https" | null {
   const normalized = rawProtocol.trim().toLowerCase().replace(/:$/, "");
   if (normalized === "http" || normalized === "https") {
@@ -199,20 +175,20 @@ function inferProtocol(req: OriginValidationRequest): "http" | "https" {
 
 function getExpectedOrigins(req: OriginValidationRequest): string[] {
   const hosts = [
-    ...getHeaderValues(req, "x-forwarded-host"),
-    ...getHeaderValues(req, "host"),
-  ].filter((value, index, values) => values.indexOf(value) === index);
+    getFirstHeaderValue(req, "x-forwarded-host"),
+    getFirstHeaderValue(req, "host"),
+  ].filter(
+    (value, index, values): value is string => value !== null && values.indexOf(value) === index
+  );
 
   if (hosts.length === 0) {
     return [];
   }
 
-  const protocols = getHeaderValues(req, "x-forwarded-proto")
-    .map((value) => normalizeProtocol(value))
-    .filter((value): value is "http" | "https" => value !== null);
-  if (protocols.length === 0) {
-    protocols.push(inferProtocol(req));
-  }
+  // Trust only the first X-Forwarded-Proto hop. Falling back to inferred protocol is
+  // only safe when the header is absent or invalid.
+  const forwardedProtocol = normalizeProtocol(getFirstHeaderValue(req, "x-forwarded-proto") ?? "");
+  const protocols = forwardedProtocol === null ? [inferProtocol(req)] : [forwardedProtocol];
 
   const expectedOrigins: string[] = [];
   for (const protocol of protocols) {


### PR DESCRIPTION
## Summary
Fix false CORS/WS origin rejections when `mux server` runs behind reverse proxies (including Coder app proxy and subpath routing) that forward internal host headers, while preserving strict scheme/origin security boundaries.

## Background
Some proxied deployments sent `Origin` with the public app host while `X-Forwarded-Host` was internal/proxy-local. Our origin check trusted a single expected origin, so static assets and websocket upgrades were rejected with `403` even for legitimate same-origin browser requests. This also showed up in subpath app URLs.

This change keeps the security posture from https://github.com/coder/security/issues/120 by continuing to block cross-origin requests and explicitly rejecting protocol-downgrade origins when `X-Forwarded-Proto` is provided.

## Implementation
- Replaced single `getExpectedOrigin()` lookup with `getExpectedOrigins()` that combines:
  - `X-Forwarded-Host` (first hop) and `Host`
  - `X-Forwarded-Proto` first hop only
  - inferred socket/request protocol only when forwarded proto is absent/invalid
- Updated `isOriginAllowed()` to check the normalized request origin against expected origin candidates (preserving loopback-equivalence behavior).
- Applied the same expected-origin candidate logic to:
  - HTTP/CORS middleware
  - WebSocket upgrade origin validation
- Improved warning logs to emit `expectedOrigins` for easier proxy debugging.
- Added regression coverage for:
  - same-origin HTTP and WS requests when `X-Forwarded-Host` is mismatched
  - rejecting downgraded HTTP and WS origins when `X-Forwarded-Proto` pins `https`
  - rejecting downgraded HTTP and WS origins when `X-Forwarded-Proto` contains multi-hop values (for example `https,http`)

## Validation
- `make static-check`
- `make build-main`
- `bun test src/node/orpc/server.test.ts`
- `make typecheck`
- `bun x eslint src/node/orpc/server.ts src/node/orpc/server.test.ts`
- `env TEST_INTEGRATION=1 bun x jest tests/ipc/runtime/originFetch.test.ts --runInBand` (twice)

## Risks
Low-to-moderate. This expands acceptable origin matching from one derived origin to a constrained set built from request host/proxy headers. It still requires exact origin match (or existing loopback alias equivalence), and restricts scheme matching to one trusted forwarded-proto hop.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.01`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.01 -->
