### PR TITLE
🤖 fix: make hidden-message indicators follow omission seams

### DIFF
--- a/src/browser/components/Messages/UserMessage.tsx
+++ b/src/browser/components/Messages/UserMessage.tsx
@@ -141,40 +141,9 @@ export const UserMessage: React.FC<UserMessageProps> = ({
     </span>
   ) : null;
   const syntheticClassName = cn(className, isSynthetic && "opacity-70");
-  const truncationReminder = message.hiddenCountBeforeUser != null && (
-    <div
-      data-testid="hidden-gap-reminder"
-      className="text-muted my-2 flex items-center gap-2 text-xs"
-    >
-      <div className="border-border flex-1 border-b border-dashed" />
-      <span>
-        {message.hiddenCountBeforeUser} message{message.hiddenCountBeforeUser !== 1 ? "s" : ""}{" "}
-        hidden
-      </span>
-      <div className="border-border flex-1 border-b border-dashed" />
-    </div>
-  );
 
   if (isLocalCommandOutput) {
     return (
-      <>
-        {truncationReminder}
-        <MessageWindow
-          label={label}
-          message={message}
-          buttons={buttons}
-          className={syntheticClassName}
-          variant="user"
-        >
-          <TerminalOutput output={extractedOutput} isError={false} />
-        </MessageWindow>
-      </>
-    );
-  }
-
-  return (
-    <>
-      {truncationReminder}
       <MessageWindow
         label={label}
         message={message}
@@ -182,15 +151,27 @@ export const UserMessage: React.FC<UserMessageProps> = ({
         className={syntheticClassName}
         variant="user"
       >
-        <UserMessageContent
-          content={content}
-          commandPrefix={message.commandPrefix}
-          agentSkillSnapshot={message.agentSkill?.snapshot}
-          reviews={message.reviews}
-          fileParts={message.fileParts}
-          variant="sent"
-        />
+        <TerminalOutput output={extractedOutput} isError={false} />
       </MessageWindow>
-    </>
+    );
+  }
+
+  return (
+    <MessageWindow
+      label={label}
+      message={message}
+      buttons={buttons}
+      className={syntheticClassName}
+      variant="user"
+    >
+      <UserMessageContent
+        content={content}
+        commandPrefix={message.commandPrefix}
+        agentSkillSnapshot={message.agentSkill?.snapshot}
+        reviews={message.reviews}
+        fileParts={message.fileParts}
+        variant="sent"
+      />
+    </MessageWindow>
   );
 };

--- a/src/browser/utils/messages/messageUtils.test.ts
+++ b/src/browser/utils/messages/messageUtils.test.ts
@@ -91,6 +91,20 @@ describe("shouldBypassDeferredMessages", () => {
     expect(shouldBypassDeferredMessages([completedBash], [])).toBe(true);
   });
 
+  it("returns true when snapshots have same length but different row identity/order", () => {
+    const userRow: DisplayedMessage = {
+      type: "user",
+      id: "u-1",
+      historyId: "h-user",
+      content: "hello",
+      historySequence: 0,
+    };
+
+    expect(shouldBypassDeferredMessages([completedBash, userRow], [userRow, completedBash])).toBe(
+      true
+    );
+  });
+
   it("returns false when both snapshots are settled and in sync", () => {
     expect(shouldBypassDeferredMessages([completedBash], [completedBash])).toBe(false);
   });

--- a/src/browser/utils/messages/transcriptTruncationPlan.test.ts
+++ b/src/browser/utils/messages/transcriptTruncationPlan.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+import type { DisplayedMessage } from "@/common/types/message";
+import {
+  buildTranscriptTruncationPlan,
+  MAX_HISTORY_HIDDEN_SEGMENTS,
+} from "./transcriptTruncationPlan";
+
+const ALWAYS_KEEP_MESSAGE_TYPES = new Set<DisplayedMessage["type"]>([
+  "user",
+  "stream-error",
+  "compaction-boundary",
+  "plan-display",
+  "workspace-init",
+]);
+
+function user(id: string, sequence: number): DisplayedMessage {
+  return {
+    type: "user",
+    id,
+    historyId: `history-${id}`,
+    content: id,
+    historySequence: sequence,
+  };
+}
+
+function assistant(id: string, sequence: number): DisplayedMessage {
+  return {
+    type: "assistant",
+    id,
+    historyId: `history-${id}`,
+    content: id,
+    historySequence: sequence,
+    isStreaming: false,
+    isPartial: false,
+    isCompacted: false,
+    isIdleCompacted: false,
+  };
+}
+
+function tool(id: string, sequence: number): DisplayedMessage {
+  return {
+    type: "tool",
+    id,
+    historyId: `history-${id}`,
+    toolCallId: `call-${id}`,
+    toolName: "bash",
+    args: { script: "echo hi", timeout_secs: 1, display_name: "test" },
+    status: "completed",
+    isPartial: false,
+    historySequence: sequence,
+  };
+}
+
+function reasoning(id: string, sequence: number): DisplayedMessage {
+  return {
+    type: "reasoning",
+    id,
+    historyId: `history-${id}`,
+    content: id,
+    historySequence: sequence,
+    isStreaming: false,
+    isPartial: false,
+  };
+}
+
+function compactionBoundary(
+  id: string,
+  sequence: number,
+  position: "start" | "end" = "start"
+): DisplayedMessage {
+  return {
+    type: "compaction-boundary",
+    id,
+    historySequence: sequence,
+    position,
+  };
+}
+
+describe("buildTranscriptTruncationPlan", () => {
+  test("places an omission marker directly before a kept non-user seam", () => {
+    const displayedMessages: DisplayedMessage[] = [
+      user("u0", 0),
+      assistant("a0", 1),
+      user("u1", 2),
+      assistant("a1", 3),
+      compactionBoundary("boundary-1", 4, "start"),
+      user("u2", 5),
+      assistant("a2", 6),
+      user("u3", 7),
+      assistant("a3", 8),
+      user("u4", 9),
+    ];
+
+    const plan = buildTranscriptTruncationPlan({
+      displayedMessages,
+      maxDisplayedMessages: 4,
+      alwaysKeepMessageTypes: ALWAYS_KEEP_MESSAGE_TYPES,
+    });
+
+    const markerIndices = plan.rows
+      .map((message, index) => (message.type === "history-hidden" ? index : -1))
+      .filter((index) => index !== -1);
+
+    expect(markerIndices).toHaveLength(2);
+    const secondMarkerIndex = markerIndices[1];
+    expect(plan.rows[secondMarkerIndex + 1]?.type).toBe("compaction-boundary");
+  });
+
+  test("keeps a trailing omission marker at the old/recent seam when no later user exists", () => {
+    const displayedMessages: DisplayedMessage[] = [
+      user("u0", 0),
+      assistant("a0", 1),
+      user("u1", 2),
+      assistant("a1", 3),
+      assistant("a2", 4),
+      tool("tool-1", 5),
+      reasoning("reasoning-1", 6),
+      assistant("a3", 7),
+    ];
+
+    const plan = buildTranscriptTruncationPlan({
+      displayedMessages,
+      maxDisplayedMessages: 4,
+      alwaysKeepMessageTypes: ALWAYS_KEEP_MESSAGE_TYPES,
+    });
+
+    const markerIndices = plan.rows
+      .map((message, index) => (message.type === "history-hidden" ? index : -1))
+      .filter((index) => index !== -1);
+
+    expect(markerIndices).toHaveLength(2);
+    const trailingMarkerIndex = markerIndices[1];
+    expect(plan.rows[trailingMarkerIndex + 1]?.id).toBe("a2");
+  });
+
+  test("caps omission markers by merging older runs", () => {
+    const displayedMessages: DisplayedMessage[] = [];
+    for (let i = 0; i < 20; i++) {
+      displayedMessages.push(user(`u${i}`, i * 2));
+      displayedMessages.push(assistant(`a${i}`, i * 2 + 1));
+    }
+
+    const plan = buildTranscriptTruncationPlan({
+      displayedMessages,
+      maxDisplayedMessages: 4,
+      alwaysKeepMessageTypes: ALWAYS_KEEP_MESSAGE_TYPES,
+      maxHiddenSegments: 3,
+    });
+
+    expect(MAX_HISTORY_HIDDEN_SEGMENTS).toBeGreaterThan(3);
+    expect(plan.segments).toHaveLength(3);
+    expect(plan.hiddenCount).toBe(18);
+    expect(plan.segments.map((segment) => segment.hiddenCount)).toEqual([16, 1, 1]);
+
+    const markerRows = plan.rows.filter(
+      (message): message is Extract<DisplayedMessage, { type: "history-hidden" }> => {
+        return message.type === "history-hidden";
+      }
+    );
+    expect(markerRows).toHaveLength(3);
+    expect(markerRows.map((row) => row.hiddenCount)).toEqual([16, 1, 1]);
+  });
+});

--- a/src/browser/utils/messages/transcriptTruncationPlan.ts
+++ b/src/browser/utils/messages/transcriptTruncationPlan.ts
@@ -1,0 +1,219 @@
+import type { DisplayedMessage } from "@/common/types/message";
+
+/**
+ * Upper bound for distinct hidden-gap rows.
+ *
+ * In transcripts with many tiny omission runs (e.g. alternating user/assistant history),
+ * rendering one marker per run can recreate large DOM row counts. We keep locality for
+ * recent runs while merging older runs into a single earlier marker when this cap is exceeded.
+ */
+export const MAX_HISTORY_HIDDEN_SEGMENTS = 8;
+
+interface OmittedMessageCounts {
+  tool: number;
+  reasoning: number;
+}
+
+export interface OmissionSegment {
+  insertAtKeptIndex: number;
+  hiddenCount: number;
+  omittedMessageCounts: OmittedMessageCounts;
+}
+
+export interface TranscriptTruncationPlan {
+  rows: DisplayedMessage[];
+  hiddenCount: number;
+  segments: OmissionSegment[];
+}
+
+export interface BuildTranscriptTruncationPlanArgs {
+  displayedMessages: DisplayedMessage[];
+  maxDisplayedMessages: number;
+  alwaysKeepMessageTypes: Set<DisplayedMessage["type"]>;
+  maxHiddenSegments?: number;
+}
+
+interface CollectedOmissions {
+  keptOldMessages: DisplayedMessage[];
+  segments: OmissionSegment[];
+  hiddenCount: number;
+}
+
+interface OmissionRunState {
+  insertAtKeptIndex: number;
+  hiddenCount: number;
+  omittedMessageCounts: OmittedMessageCounts;
+}
+
+function collectOmissions(
+  oldMessages: DisplayedMessage[],
+  alwaysKeepMessageTypes: Set<DisplayedMessage["type"]>
+): CollectedOmissions {
+  const keptOldMessages: DisplayedMessage[] = [];
+  const segments: OmissionSegment[] = [];
+  let hiddenCount = 0;
+  let activeRun: OmissionRunState | null = null;
+
+  for (const message of oldMessages) {
+    if (alwaysKeepMessageTypes.has(message.type)) {
+      if (activeRun !== null) {
+        segments.push(activeRun);
+        activeRun = null;
+      }
+      keptOldMessages.push(message);
+      continue;
+    }
+
+    activeRun ??= {
+      insertAtKeptIndex: keptOldMessages.length,
+      hiddenCount: 0,
+      omittedMessageCounts: { tool: 0, reasoning: 0 },
+    };
+
+    activeRun.hiddenCount += 1;
+    hiddenCount += 1;
+
+    if (message.type === "tool") {
+      activeRun.omittedMessageCounts.tool += 1;
+    } else if (message.type === "reasoning") {
+      activeRun.omittedMessageCounts.reasoning += 1;
+    }
+  }
+
+  if (activeRun !== null) {
+    segments.push(activeRun);
+  }
+
+  return { keptOldMessages, segments, hiddenCount };
+}
+
+function mergeOmissionSegments(segments: OmissionSegment[]): OmissionSegment {
+  const first = segments[0];
+  let hiddenCount = 0;
+  let toolCount = 0;
+  let reasoningCount = 0;
+
+  for (const segment of segments) {
+    hiddenCount += segment.hiddenCount;
+    toolCount += segment.omittedMessageCounts.tool;
+    reasoningCount += segment.omittedMessageCounts.reasoning;
+  }
+
+  return {
+    insertAtKeptIndex: first?.insertAtKeptIndex ?? 0,
+    hiddenCount,
+    omittedMessageCounts: {
+      tool: toolCount,
+      reasoning: reasoningCount,
+    },
+  };
+}
+
+function capOmissionSegments(
+  segments: OmissionSegment[],
+  maxHiddenSegments: number
+): OmissionSegment[] {
+  const normalizedMax = Number.isFinite(maxHiddenSegments)
+    ? Math.max(1, Math.trunc(maxHiddenSegments))
+    : 1;
+  if (segments.length <= normalizedMax) {
+    return segments;
+  }
+
+  const mergedPrefixCount = segments.length - normalizedMax + 1;
+  const mergedPrefix = mergeOmissionSegments(segments.slice(0, mergedPrefixCount));
+  return [mergedPrefix, ...segments.slice(mergedPrefixCount)];
+}
+
+function renderKeptRowsWithMarkers(
+  keptOldMessages: DisplayedMessage[],
+  segments: OmissionSegment[]
+): DisplayedMessage[] {
+  if (segments.length === 0) {
+    return [...keptOldMessages];
+  }
+
+  const rows: DisplayedMessage[] = [];
+  let segmentIndex = 0;
+
+  for (let keptIndex = 0; keptIndex <= keptOldMessages.length; keptIndex++) {
+    while (
+      segmentIndex < segments.length &&
+      segments[segmentIndex]?.insertAtKeptIndex === keptIndex
+    ) {
+      const segment = segments[segmentIndex];
+      const omittedMessageCounts =
+        segment.omittedMessageCounts.tool > 0 || segment.omittedMessageCounts.reasoning > 0
+          ? segment.omittedMessageCounts
+          : undefined;
+
+      rows.push({
+        type: "history-hidden",
+        id: `history-hidden-${segmentIndex + 1}`,
+        hiddenCount: segment.hiddenCount,
+        historySequence: -1,
+        omittedMessageCounts,
+      });
+
+      segmentIndex += 1;
+    }
+
+    if (keptIndex < keptOldMessages.length) {
+      rows.push(keptOldMessages[keptIndex]);
+    }
+  }
+
+  return rows;
+}
+
+/**
+ * Build displayed transcript rows for truncated history.
+ *
+ * Strategy:
+ * - Keep recent rows intact (last N rows)
+ * - In older rows, preserve only always-keep message types
+ * - Replace each omitted run with an explicit history-hidden marker row
+ * - Cap marker count to avoid re-creating huge DOM row counts for tiny alternating runs
+ */
+export function buildTranscriptTruncationPlan(
+  args: BuildTranscriptTruncationPlanArgs
+): TranscriptTruncationPlan {
+  if (
+    args.maxDisplayedMessages <= 0 ||
+    args.displayedMessages.length <= args.maxDisplayedMessages
+  ) {
+    return {
+      rows: args.displayedMessages,
+      hiddenCount: 0,
+      segments: [],
+    };
+  }
+
+  const recentMessages = args.displayedMessages.slice(-args.maxDisplayedMessages);
+  const oldMessages = args.displayedMessages.slice(0, -args.maxDisplayedMessages);
+
+  const omissionCollection = collectOmissions(oldMessages, args.alwaysKeepMessageTypes);
+  if (omissionCollection.hiddenCount === 0) {
+    return {
+      rows: [...omissionCollection.keptOldMessages, ...recentMessages],
+      hiddenCount: 0,
+      segments: [],
+    };
+  }
+
+  const cappedSegments = capOmissionSegments(
+    omissionCollection.segments,
+    args.maxHiddenSegments ?? MAX_HISTORY_HIDDEN_SEGMENTS
+  );
+
+  const rows = [
+    ...renderKeptRowsWithMarkers(omissionCollection.keptOldMessages, cappedSegments),
+    ...recentMessages,
+  ];
+
+  return {
+    rows,
+    hiddenCount: omissionCollection.hiddenCount,
+    segments: cappedSegments,
+  };
+}

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -489,8 +489,6 @@ export type DisplayedMessage =
        */
       commandPrefix?: string;
       fileParts?: FilePart[]; // Optional attachments
-      /** Number of messages omitted by truncation immediately before this user message. */
-      hiddenCountBeforeUser?: number;
       historySequence: number; // Global ordering across all messages
       isSynthetic?: boolean;
       timestamp?: number;


### PR DESCRIPTION
## Summary
Refactors transcript truncation omission handling into an explicit planner that emits `history-hidden` marker rows at omission seams, removes inline user-gap reminder rendering, and hardens deferred snapshot bypass logic so stale deferred ordering cannot temporarily misplace omission indicators.

## Background
The previous omission path mixed a single global marker with per-user hidden-gap reminders, which encoded placement policy in implicit loop state (`insertionIndex`, `pendingOmittedCount`, `consumedFirstOmittedRun`). That made omission placement harder to reason about and produced edge cases where indicators felt disconnected from omitted runs.

## Implementation
- Added `buildTranscriptTruncationPlan` in `src/browser/utils/messages/transcriptTruncationPlan.ts`:
  - collects omission runs in old history,
  - emits explicit `history-hidden` rows per run at seam positions,
  - caps marker row count (`MAX_HISTORY_HIDDEN_SEGMENTS`) by merging older runs to protect DOM size.
- Switched `StreamingMessageAggregator` truncation path to call the planner.
- Removed `hiddenCountBeforeUser` from `DisplayedMessage` user type and removed inline reminder UI in `UserMessage`.
- Updated deferred bypass logic (`shouldBypassDeferredMessages`) to bypass when snapshots are same length but diverge in row identity/order.
- Added/updated tests:
  - new planner unit tests (`transcriptTruncationPlan.test.ts`),
  - updated aggregator truncation expectations for multi-segment markers,
  - updated deferred-bypass tests,
  - updated UI truncation test expectations to aggregate across marker rows.

## Validation
- `make static-check`
- `bun test src/browser/utils/messages/transcriptTruncationPlan.test.ts src/browser/utils/messages/StreamingMessageAggregator.test.ts src/browser/utils/messages/messageUtils.test.ts`
- Attempted `bun test ./tests/ui/chat/truncation.test.ts -t "shows a generic hidden indicator and preserves assistant meta rows"` (environmental failure in this workspace: `Cannot find module '@/version'` from telemetry service import path)

## Risks
- Behavior change: omission UI now surfaces explicit seam markers (capped) instead of per-user reminder text.
- Risk is primarily in transcript rendering expectations and any downstream assumptions about marker cardinality.
- Mitigated with planner-focused and aggregator/UI expectation updates.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.00 -->
