### PR TITLE
🤖 fix: make chat compaction controls open in a dialog

### DIFF
--- a/src/browser/components/Settings/sections/ModelRow.tsx
+++ b/src/browser/components/Settings/sections/ModelRow.tsx
@@ -3,7 +3,6 @@ import { createEditKeyHandler } from "@/browser/utils/ui/keybinds";
 import { GatewayToggleButton } from "@/browser/components/GatewayToggleButton";
 import { cn } from "@/common/lib/utils";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/browser/components/ui/tooltip";
-import { HoverClickPopover } from "@/browser/components/ui/hover-click-popover";
 import { ProviderWithIcon } from "@/browser/components/ProviderIcon";
 import { Button } from "@/browser/components/ui/button";
 import { getModelStats, type ModelStats } from "@/common/utils/tokens/modelStats";
@@ -332,26 +331,21 @@ export function ModelRow(props: ModelRowProps) {
       {/* Actions */}
       <td className="w-28 py-1.5 pr-2 md:w-32 md:pr-3">
         <div className="flex items-center justify-end gap-0.5">
-          {/*
-            Keep model context-window/pricing details in a dialog-style popover so
-            users can intentionally open and inspect it without hover timing.
-          */}
-          <HoverClickPopover
-            content={
+          {/* Info tooltip */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className="text-muted hover:text-foreground p-0.5 transition-colors"
+                aria-label="Model details"
+              >
+                <Info className="h-3.5 w-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top" align="end" className="p-3">
               <ModelTooltipContent fullId={props.fullId} aliases={props.aliases} stats={stats} />
-            }
-            side="top"
-            align="end"
-            contentClassName="bg-modal-bg border-separator-light w-auto min-w-0 max-w-xs rounded px-[10px] py-[6px] text-[11px] font-normal shadow-[0_2px_8px_rgba(0,0,0,0.4)]"
-          >
-            <button
-              type="button"
-              className="text-muted hover:text-foreground p-0.5 transition-colors"
-              aria-label="Model details"
-            >
-              <Info className="h-3.5 w-3.5" />
-            </button>
-          </HoverClickPopover>
+            </TooltipContent>
+          </Tooltip>
           {/* Visibility toggle button */}
           {props.onToggleVisibility && (
             <button


### PR DESCRIPTION
## Summary
Convert the chat context-usage compaction control to open a dialog instead of the hover/click tooltip-style popover, so auto-compaction and idle-compaction settings remain stable while editing.

## Background
The compaction settings trigger in chat was implemented with a hover/click popover pattern. That made this control feel tooltip-like and transient while adjusting settings. This change switches it to a dialog interaction as requested.

## Implementation
- Updated `src/browser/components/ContextUsageIndicatorButton.tsx`:
  - Replaced `HoverClickPopover` with `Dialog` + `DialogTrigger` + `DialogContent`.
  - Added a dialog header/title (`Compaction settings`) for clear modal semantics.
  - Removed popover-specific portal-dismiss workarounds that are no longer needed.
  - Kept existing compaction controls and behavior (threshold slider, idle compaction toggle/input, 1M toggle) unchanged inside the new dialog.
- Reverted the accidental `ModelRow` tooltip change so the PR only contains the intended chat compaction interaction change.

## Validation
- `make static-check`

## Risks
Low risk, scoped to the chat context-usage indicator interaction pattern.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.00 -->
