### PR TITLE
🤖 ci: keep nightly cleanup checkout-free

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -88,7 +88,9 @@ jobs:
 
             echo "Release $RELEASE_TAG is incomplete (missing: ${MISSING_ASSETS[*]})"
             echo "Deleting $RELEASE_TAG so this run can rebuild desktop artifacts"
-            gh release delete "$RELEASE_TAG" --yes --cleanup-tag
+            # Use checkout-free deletion so release cleanup never depends on local git state.
+            gh release delete "$RELEASE_TAG" --yes
+            gh api --silent -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/$RELEASE_TAG" || true
           fi
 
           gh release create "$RELEASE_TAG" --prerelease --target "$BUILD_SHA" --title "$RELEASE_TAG" --notes "Automated nightly build from main ($(date -u +%Y-%m-%d))"
@@ -139,5 +141,8 @@ jobs:
               continue
             fi
             echo "Deleting old nightly release $tag"
-            gh release delete "$tag" --yes --cleanup-tag
+            # Keep this cleanup job checkout-free: `--cleanup-tag` shells out to git
+            # and fails on runners without a local repository clone.
+            gh release delete "$tag" --yes
+            gh api --silent -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/$tag" || true
           done


### PR DESCRIPTION
## Summary
Fix nightly release cleanup so it no longer depends on a local git checkout.

## Background
The nightly cleanup workflow failed on **February 19, 2026** in job `64119285477` with:
`fatal: not a git repository (or any of the parent directories): .git`.

That failure happened because `gh release delete --cleanup-tag` shells out to local git in a job that intentionally does not run `actions/checkout`.

## Implementation
- Updated `.github/workflows/nightly.yml` to remove `--cleanup-tag` in both nightly release deletion paths:
  - incomplete-release rebuild path in `compute-version`
  - `cleanup-old-nightlies` deletion loop
- Added explicit GitHub API tag deletion in both places:
  - `gh api --silent -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/<tag>" || true`
- Added comments explaining why cleanup is checkout-free.

## Validation
- `make static-check`

## Risks
Low risk. Behavior is equivalent for normal cases, and missing tag refs are tolerated with `|| true` to avoid false-failures.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.00 -->
