### PR TITLE
🤖 fix: document server access auth and GitHub owner login

### DIFF
--- a/docs/config/server-access.mdx
+++ b/docs/config/server-access.mdx
@@ -1,0 +1,83 @@
+---
+title: Server Access
+description: Configure authentication and session controls for mux server/browser mode
+---
+
+`mux server` can be accessed from browsers, mobile devices, and other machines on your network. This page covers how access control works, including the GitHub owner login allowlist.
+
+## Authentication modes
+
+By default, server access is protected by a bearer token.
+
+Token resolution order:
+
+1. `--no-auth` (disables auth entirely)
+2. `--auth-token <token>`
+3. `MUX_SERVER_AUTH_TOKEN`
+4. Auto-generated token at startup
+
+<Warning>
+  `--no-auth` makes the server open to anyone who can reach it. Use only on trusted/private
+  networks.
+</Warning>
+
+## Configure GitHub owner login
+
+Mux can optionally allow GitHub Device Flow login for exactly one GitHub account.
+
+Set the allowed account with either:
+
+- Environment variable: `MUX_SERVER_AUTH_GITHUB_OWNER`
+- Config file key: `serverAuthGithubOwner` in `~/.mux/config.json`
+
+There is currently no UI control for this setting; configure it via env/config.
+
+Example:
+
+```json
+{
+  "serverAuthGithubOwner": "octocat"
+}
+```
+
+If both are set, `MUX_SERVER_AUTH_GITHUB_OWNER` takes precedence.
+
+When enabled, the auth modal shows **Login with GitHub**. Mux verifies the GitHub `login` value against the configured owner (case-insensitive). Non-matching users are rejected.
+
+<Note>
+  This allowlist currently supports a single GitHub username. It does not support multiple users or
+  GitHub organization membership rules.
+</Note>
+
+## Server Access settings page
+
+Open **Settings → Server Access** to manage browser sessions.
+
+You can:
+
+- Refresh active sessions
+- Revoke a specific session
+- Log out the current session
+- Revoke all other sessions
+
+This page manages cookie-backed browser sessions. Token-based access remains valid until you rotate/change the server token.
+
+## Network exposure and bind settings
+
+To expose Mux beyond localhost and configure bind host/port in the UI:
+
+1. Open **Settings → Experiments**
+2. Enable **Expose API server on LAN/VPN**
+3. Configure bind host, port, and **Serve mux web UI**
+4. Click **Apply**
+
+Equivalent CLI options:
+
+- `--host <host>`
+- `--port <port>`
+- `--ssh-host <host>`
+- `--add-project <path>`
+
+## Related
+
+- [CLI reference](/reference/cli)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -98,6 +98,7 @@
               "config/agentic-git-identity",
               "config/keybinds",
               "config/notifications",
+              "config/server-access",
               "config/vim-mode"
             ]
           },
@@ -158,6 +159,7 @@
     { "source": "/agentic-git-identity", "destination": "/config/agentic-git-identity" },
     { "source": "/keybinds", "destination": "/config/keybinds" },
     { "source": "/notifications", "destination": "/config/notifications" },
+    { "source": "/server-access", "destination": "/config/server-access" },
     { "source": "/cli", "destination": "/reference/cli" },
     { "source": "/guides/cli", "destination": "/reference/cli" },
     { "source": "/context-management", "destination": "/workspaces/compaction" },

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -100,18 +100,30 @@ mux run --budget 2.00 "Refactor the authentication module"
 
 ## `mux server`
 
-Start the HTTP/WebSocket server for remote access (e.g., from mobile devices):
+Start the HTTP/WebSocket server for remote access (for example, from a phone or another machine):
 
 ```bash
-mux server --port 3000 --host 0.0.0.0
+mux server --host 0.0.0.0 --port 3000
 ```
 
 Options:
 
-- `--host <host>` - Host to bind to (default: `localhost`)
+- `--host <host>` - Host/interface to bind to (default: `localhost`)
 - `--port <port>` - Port to bind to (default: `3000`)
-- `--auth-token <token>` - Optional bearer token for authentication
+- `--auth-token <token>` - Bearer token for HTTP/WS auth
+- `--no-auth` - Disable authentication entirely
+- `--print-auth-token` - Always print the auth token on startup
+- `--ssh-host <host>` - SSH hostname/alias used for editor deep links in browser mode
 - `--add-project <path>` - Add and open project at the specified path
+
+Auth token precedence:
+
+1. `--no-auth`
+2. `--auth-token`
+3. `MUX_SERVER_AUTH_TOKEN`
+4. Auto-generated token
+
+GitHub owner login for browser sessions is configured separately via `MUX_SERVER_AUTH_GITHUB_OWNER` or `serverAuthGithubOwner` in `~/.mux/config.json`. See [Server Access](/config/server-access).
 
 ## `mux desktop`
 

--- a/src/node/builtinSkills/mux-docs.md
+++ b/src/node/builtinSkills/mux-docs.md
@@ -89,6 +89,7 @@ Use this index to find a page's:
     - Agentic Git Identity (`/config/agentic-git-identity`) → `references/docs/config/agentic-git-identity.mdx` — Configure a separate Git identity for AI-generated commits
     - Keyboard Shortcuts (`/config/keybinds`) → `references/docs/config/keybinds.mdx` — Complete keyboard shortcut reference for Mux
     - Notifications (`/config/notifications`) → `references/docs/config/notifications.mdx` — Configure how agents notify you about important events
+    - Server Access (`/config/server-access`) → `references/docs/config/server-access.mdx` — Configure authentication and session controls for mux server/browser mode
     - Vim Mode (`/config/vim-mode`) → `references/docs/config/vim-mode.mdx` — Vim-style editing in the Mux chat input
   - **Guides**
     - GitHub Actions (`/guides/github-actions`) → `references/docs/guides/github-actions.mdx` — Automate your workflows with mux run in GitHub Actions


### PR DESCRIPTION
## Summary

Add dedicated documentation for mux server access controls, including GitHub owner allowlist login configuration, and wire it into docs navigation.

## Background

The `serverAuthGithubOwner` / `MUX_SERVER_AUTH_GITHUB_OWNER` feature existed in code but was not documented for users. The CLI docs also omitted several `mux server` auth and server-access flags.

## Implementation

- Added a new page: `docs/config/server-access.mdx`
  - Token auth modes and precedence
  - GitHub owner login configuration (`MUX_SERVER_AUTH_GITHUB_OWNER` / `serverAuthGithubOwner`)
  - Current limitation (single username; no org/multi-user rules)
  - Session management in **Settings → Server Access**
  - Network/bind settings in **Settings → Experiments**
- Updated `docs/docs.json`
  - Added `config/server-access` to Configuration navigation
  - Added `/server-access` redirect
- Updated `docs/reference/cli.mdx`
  - Expanded `mux server` options (`--no-auth`, `--print-auth-token`, `--ssh-host`)
  - Added auth token precedence and link to the new Server Access page
- Regenerated `src/node/builtinSkills/mux-docs.md` via docs sync tooling

## Validation

- `make fmt`
- `make fmt-check`
- `make check-docs-links`
- `make check-code-docs-links`
- `make static-check`

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.74`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.74 -->
