### PR TITLE
🤖 ci: delete nightly releases via GitHub API

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -88,8 +88,10 @@ jobs:
 
             echo "Release $RELEASE_TAG is incomplete (missing: ${MISSING_ASSETS[*]})"
             echo "Deleting $RELEASE_TAG so this run can rebuild desktop artifacts"
-            # Use checkout-free deletion so release cleanup never depends on local git state.
-            gh release delete "$RELEASE_TAG" --yes
+            # Use API-only deletion so release cleanup never depends on local git state.
+            if release_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/$RELEASE_TAG" --jq '.id' 2>/dev/null); then
+              gh api --silent -X DELETE "repos/${GITHUB_REPOSITORY}/releases/$release_id"
+            fi
             gh api --silent -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/$RELEASE_TAG" || true
           fi
 
@@ -141,8 +143,9 @@ jobs:
               continue
             fi
             echo "Deleting old nightly release $tag"
-            # Keep this cleanup job checkout-free: `--cleanup-tag` shells out to git
-            # and fails on runners without a local repository clone.
-            gh release delete "$tag" --yes
+            # Keep this cleanup job checkout-free: use API-only deletion (no local git).
+            if release_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/$tag" --jq '.id' 2>/dev/null); then
+              gh api --silent -X DELETE "repos/${GITHUB_REPOSITORY}/releases/$release_id"
+            fi
             gh api --silent -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/$tag" || true
           done


### PR DESCRIPTION
## Summary
Make nightly release cleanup fully API-driven so it works without a local git checkout.

## Background
Nightly cleanup failed again on **February 20, 2026** in run `22223890423`, job `64287749147`, with:
`failed to run git: fatal: not a git repository (or any of the parent directories): .git`.

The previous fix removed `--cleanup-tag`, but `gh release delete` itself still tries to infer repo context via git when run in checkout-free jobs.

## Implementation
- Replaced `gh release delete ...` with API-only release deletion in both nightly cleanup paths:
  - `compute-version` incomplete-release rebuild path
  - `cleanup-old-nightlies` deletion loop
- New flow:
  - Resolve release ID with `gh api repos/${GITHUB_REPOSITORY}/releases/tags/<tag> --jq '.id'`
  - Delete release via `gh api -X DELETE repos/${GITHUB_REPOSITORY}/releases/<id>`
  - Delete tag ref via `gh api -X DELETE repos/${GITHUB_REPOSITORY}/git/refs/tags/<tag> || true`
- Added comments clarifying why this path is API-only and checkout-free.

## Validation
- `make static-check`

## Risks
Low. Behavior remains equivalent (delete old nightly releases/tags) while removing implicit local-git coupling.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.00 -->
