### PR TITLE
🤖 fix: gateway status dot always green when disabled

### DIFF
--- a/src/browser/components/Settings/sections/ProvidersSection.tsx
+++ b/src/browser/components/Settings/sections/ProvidersSection.tsx
@@ -1084,7 +1084,9 @@ export function ProvidersSection() {
 
       {visibleProviders.map((provider) => {
         const isExpanded = expandedProvider === provider;
-        const enabled = isEnabled(provider);
+        // mux-gateway stores its enabled state separately (gateway-enabled localStorage key),
+        // not in the standard provider config, so use the gateway hook's state directly.
+        const enabled = provider === "mux-gateway" ? gateway.isEnabled : isEnabled(provider);
         const configured = isConfigured(provider);
         const fields = getProviderFields(provider);
         const statusDotColor = !enabled


### PR DESCRIPTION
## Summary

The Mux Gateway status dot in the provider sidebar always shows green (configured) even when the gateway is disabled, because the dot color logic reads from the standard provider config path (`config?.["mux-gateway"]?.isEnabled`) which is always `undefined` for gateway — falling back to `true`.

## Background

Mux Gateway stores its enabled state separately from other providers, using a dedicated `gateway-enabled` localStorage key managed by the `useGateway()` hook. The generic `isEnabled(provider)` helper doesn't know about this, so it always reports gateway as enabled.

Other parts of the UI (title bar, the toggle inside the expanded gateway section) correctly use `gateway.isEnabled` / `gateway.isActive` from the hook.

## Implementation

One-line fix: when computing `enabled` for the provider list, special-case `mux-gateway` to read from `gateway.isEnabled` (already in scope) instead of the generic `isEnabled()` helper.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$0.62`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=0.62 -->
