### PR TITLE
🤖 fix: harden updater check UX and persist update channel

### DIFF
--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -75,6 +75,37 @@ describe("Config", () => {
     });
   });
 
+  describe("update channel preference", () => {
+    it("defaults to stable when no channel is configured", () => {
+      expect(config.getUpdateChannel()).toBe("stable");
+    });
+
+    it("persists nightly channel selection", async () => {
+      await config.setUpdateChannel("nightly");
+
+      const restartedConfig = new Config(tempDir);
+      expect(restartedConfig.getUpdateChannel()).toBe("nightly");
+
+      const raw = JSON.parse(fs.readFileSync(path.join(tempDir, "config.json"), "utf-8")) as {
+        updateChannel?: unknown;
+      };
+      expect(raw.updateChannel).toBe("nightly");
+    });
+
+    it("persists explicit stable channel selection", async () => {
+      await config.setUpdateChannel("nightly");
+      await config.setUpdateChannel("stable");
+
+      const restartedConfig = new Config(tempDir);
+      expect(restartedConfig.getUpdateChannel()).toBe("stable");
+
+      const raw = JSON.parse(fs.readFileSync(path.join(tempDir, "config.json"), "utf-8")) as {
+        updateChannel?: unknown;
+      };
+      expect(raw.updateChannel).toBe("stable");
+    });
+  });
+
   describe("server GitHub owner auth setting", () => {
     it("persists serverAuthGithubOwner", async () => {
       await config.editConfig((cfg) => {

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -444,9 +444,9 @@ export class Config {
         data.terminalDefaultShell = terminalDefaultShell;
       }
 
-      // Stable is default: only persist non-default channel values.
-      if (config.updateChannel === "nightly") {
-        data.updateChannel = "nightly";
+      const updateChannel = parseUpdateChannel(config.updateChannel);
+      if (updateChannel) {
+        data.updateChannel = updateChannel;
       }
 
       await writeFileAtomic(this.configFile, JSON.stringify(data, null, 2), "utf-8");
@@ -472,11 +472,7 @@ export class Config {
 
   async setUpdateChannel(channel: UpdateChannel): Promise<void> {
     await this.editConfig((config) => {
-      if (channel === "stable") {
-        delete config.updateChannel;
-      } else {
-        config.updateChannel = channel;
-      }
+      config.updateChannel = channel;
       return config;
     });
   }

--- a/src/node/services/updateService.test.ts
+++ b/src/node/services/updateService.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, mock } from "bun:test";
+import type { Config } from "@/node/config";
+import type { UpdateChannel } from "@/common/types/project";
+import { UpdateService } from "./updateService";
+
+function createMockConfig(initialChannel: UpdateChannel) {
+  const state: { channel: UpdateChannel } = { channel: initialChannel };
+  const getUpdateChannel = mock(() => state.channel);
+  const setUpdateChannel = mock((channel: UpdateChannel) => {
+    state.channel = channel;
+    return Promise.resolve();
+  });
+
+  return {
+    config: {
+      getUpdateChannel,
+      setUpdateChannel,
+    } as unknown as Config,
+    getUpdateChannel,
+    setUpdateChannel,
+  };
+}
+
+describe("UpdateService channel persistence", () => {
+  it("reads persisted channel from config during startup", () => {
+    const { config, getUpdateChannel } = createMockConfig("nightly");
+
+    const service = new UpdateService(config);
+
+    expect(getUpdateChannel).toHaveBeenCalledTimes(1);
+    expect(service.getChannel()).toBe("nightly");
+    expect(getUpdateChannel).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists channel changes via config service", async () => {
+    const { config, setUpdateChannel } = createMockConfig("stable");
+
+    const service = new UpdateService(config);
+
+    await service.setChannel("nightly");
+    expect(setUpdateChannel).toHaveBeenCalledWith("nightly");
+    expect(service.getChannel()).toBe("nightly");
+
+    await service.setChannel("stable");
+    expect(setUpdateChannel).toHaveBeenLastCalledWith("stable");
+    expect(service.getChannel()).toBe("stable");
+  });
+});


### PR DESCRIPTION
## Summary
Improve desktop updater resilience and UX by sanitizing update-check errors, translating missing `latest-*.yml` publish-window failures into a friendly retry message, and persisting the stable/nightly update channel selection so it survives restarts.

## Background
During nightly publish windows, `electron-updater` can receive a 404 for `latest-*.yml` before artifacts are fully available. That error previously surfaced a low-level stack + header blob in the About dialog. Also, update channel selection needed to be explicitly persisted so user intent is retained across sessions.

## Implementation
- Added update-check error shaping in `UpdaterService`:
  - Detect missing `latest-*.yml` + 404 signatures and show a user-friendly message.
  - Sanitize other check errors to first-line, length-limited text to avoid dumping stack traces into UI.
  - Applied message shaping across updater check failure paths (`error` event, rejected check promise, sync catch).
- Persisted update channel preference explicitly in config:
  - `Config.saveConfig()` now writes valid `updateChannel` values (`stable` and `nightly`).
  - `Config.setUpdateChannel()` stores the selected channel directly.
- Kept runtime update-service channel state aligned with persisted config:
  - `UpdateService` reads channel once at startup and uses it for updater initialization.
  - `UpdateService.getChannel()` returns cached channel in non-desktop/no-impl mode.
  - `UpdateService.setChannel()` updates cached state after successful persistence.
- Added regression tests:
  - Friendly messaging for missing nightly metadata errors.
  - Config-level channel persistence (including explicit stable).
  - UpdateService startup/read + write-on-change channel behavior.

## Validation
- `make static-check`
- `bun test src/desktop/updater.test.ts`
- `bun test src/node/config.test.ts src/node/services/updateService.test.ts`
- `bun x eslint src/desktop/updater.ts src/desktop/updater.test.ts src/node/config.ts src/node/config.test.ts src/node/services/updateService.ts src/node/services/updateService.test.ts`

## Risks
- Low-to-moderate risk in updater error classification: logic intentionally narrows the friendly-message mapping to 404 + `latest-*.yml` signatures and preserves non-check-phase behavior.
- Config persistence now records explicit `stable`; this is intentional for preserving user choice and remains backward-compatible with default-to-stable reads.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.01`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.01 -->
