### PR TITLE
🤖 fix: remove maxLength limit on switch_agent followUp parameter

### DIFF
--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -535,7 +535,7 @@ export const SwitchAgentToolArgsSchema = z
   .object({
     agentId: AgentIdSchema,
     reason: z.string().max(512).nullish(),
-    followUp: z.string().max(2000).nullish(),
+    followUp: z.string().nullish(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

Remove the 2000-character `maxLength` constraint on the `followUp` parameter of the `switch_agent` tool, allowing agents to pass longer context when switching.

## Background

The `switch_agent` tool's `followUp` parameter was capped at 2000 characters via `z.string().max(2000)`. This limit was unnecessarily restrictive — when an agent switches to another agent, the follow-up context often needs to carry substantial detail (task briefs, implementation plans, multi-step instructions) that easily exceeds 2k characters.

## Implementation

One-line change in `src/common/utils/tools/toolDefinitions.ts`:

```diff
-    followUp: z.string().max(2000).nullish(),
+    followUp: z.string().nullish(),
```

The `reason` field retains its 512-char limit since it serves a different purpose (short rationale for the switch).

## Validation

- Typecheck, lint, and format checks all pass locally.
- Existing `switch_agent.test.ts` tests pass (2/2).

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$0.37`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=0.37 -->
