### PR TITLE
🤖 fix: honor target agent settings in switch_agent follow-ups

### DIFF
--- a/src/node/services/agentSession.switchAgent.test.ts
+++ b/src/node/services/agentSession.switchAgent.test.ts
@@ -228,7 +228,14 @@ describe("AgentSession switch_agent target validation", () => {
     const { historyService, cleanup } = await createTestHistoryService();
     historyCleanup = cleanup;
 
-    const session = createSession(historyService, projectDir.path, projectDir.path);
+    const session = createSession(historyService, projectDir.path, projectDir.path, {
+      aiSettingsByAgent: {
+        exec: {
+          model: "anthropic:claude-sonnet-4-5",
+          thinkingLevel: "high",
+        },
+      },
+    });
 
     try {
       const internals = session as unknown as SessionInternals;
@@ -240,7 +247,7 @@ describe("AgentSession switch_agent target validation", () => {
           agentId: "hidden-agent",
           followUp: "Should not send",
         },
-        { model: "openai:gpt-4o-mini", agentId: "exec" },
+        { model: "openai:gpt-4o-mini", agentId: "exec", thinkingLevel: "low" },
         "openai:gpt-4o"
       );
 
@@ -252,6 +259,8 @@ describe("AgentSession switch_agent target validation", () => {
       const [messageArg, optionsArg] = firstCall as unknown as [string, SendMessageOptions];
       expect(messageArg).toContain('target "hidden-agent" is unavailable');
       expect(optionsArg.agentId).toBe("exec");
+      expect(optionsArg.model).toBe("openai:gpt-4o-mini");
+      expect(optionsArg.thinkingLevel).toBe("low");
     } finally {
       session.dispose();
     }

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -4233,8 +4233,12 @@ export class AgentSession {
     // agent's persisted model/thinking settings. If no per-agent override
     // exists, inherit from the outgoing stream options.
     const metadataResult = await this.aiService.getWorkspaceMetadata(this.workspaceId);
+    // If we had to reroute to a safe fallback target (hidden/disabled/missing
+    // requested target), keep recovery in the current stream settings instead of
+    // applying persisted per-agent overrides for the fallback agent.
+    const usedFallbackTarget = targetAgentId !== switchResult.agentId;
     const targetAgentSettings =
-      metadataResult.success === true
+      metadataResult.success === true && !usedFallbackTarget
         ? metadataResult.data.aiSettingsByAgent?.[targetAgentId]
         : undefined;
     const workspaceAiSettings =


### PR DESCRIPTION
## Summary
Fix `switch_agent` synthetic follow-up dispatch to use the target agent's configured AI settings when present, instead of always inheriting the outgoing stream model.

## Background
When Auto switched to another agent (for example, Exec -> Plan), the synthetic follow-up could keep using Auto/Exec's model even when the target agent had a workspace-configured override in `aiSettingsByAgent`. This made handoffs ignore user-configured per-agent defaults.

## Implementation
- Updated `dispatchAgentSwitch` in `AgentSession` to resolve target settings from workspace metadata and prefer:
  1. `aiSettingsByAgent[targetAgentId]`
  2. workspace-level `aiSettings`
  3. outgoing stream options / fallback model (inherit behavior)
- Applied the same precedence for `thinkingLevel`.
- Added explicit rationale comments in code so future changes preserve handoff semantics.
- Extended switch-agent tests to cover:
  - inherit path when no target override exists
  - target override path when `aiSettingsByAgent` is set

## Validation
- `make static-check`
- `bun test src/node/services/agentSession.switchAgent.test.ts`
- `make typecheck`

## Risks
Low risk and scoped to switch-agent synthetic follow-up option construction. Existing fallback behavior remains covered by tests.

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix: `switch_agent` should use target agent's configured model, not inherit

## Context / Why

When the Auto agent calls `switch_agent` to hand off to Exec, the new stream inherits the model from Auto's stream. The user expects the target agent to use its own configured model from `aiSettingsByAgent` (persisted in `~/.mux/config.json` per workspace). The model should only be inherited when the target agent has no explicit setting (i.e., "inherit" = absence of entry).

## Evidence

- **`dispatchAgentSwitch`** (`src/node/services/agentSession.ts:4168–4265`) resolves `effectiveModel` exclusively from the outgoing stream's `currentOptions.model` / `fallbackModel` — never consults `aiSettingsByAgent`.
- **`aiSettingsByAgent`** is already persisted in backend `WorkspaceMetadata` (`src/common/orpc/schemas/workspaceAiSettings.ts`) with `{ model, thinkingLevel }` per agent ID.
- **`AgentSession` already reads it** in other paths: startup retry (line ~903), compaction (line ~4408). Access is via `this.aiService.getWorkspaceMetadata(this.workspaceId)`.
- **Existing tests** in `src/node/services/agentSession.switchAgent.test.ts` mock `getWorkspaceMetadata` without `aiSettingsByAgent`, so they currently test the inherit path.
- **"Inherit" semantics**: absence of an entry in `aiSettingsByAgent` for the target agent = inherit. No schema change needed — this matches how the frontend handles it (deleting the entry when "Inherit" is selected in Settings).

## Implementation

### 1. `src/node/services/agentSession.ts` — `dispatchAgentSwitch` (~8 LoC)

After resolving `targetAgentId` and before building `followUpOptions`, read workspace metadata and prefer the target agent's configured model/thinkingLevel:

```typescript
// After line ~4231 (after followUpText resolution, before effectiveModel)

// Prefer the target agent's persisted model/thinkingLevel over inheriting
// from the outgoing stream. Absence of an entry = "inherit" (current behavior).
const metadata = await this.aiService.getWorkspaceMetadata(this.workspaceId);
const targetAgentSettings =
  metadata?.success === true
    ? (metadata.data.aiSettingsByAgent?.[targetAgentId] ??
       metadata.data.aiSettings)
    : undefined;

const normalizedOptionModel = currentOptions?.model?.trim();
const effectiveModel =
  targetAgentSettings?.model?.trim() ||      // 1. target agent's configured model
  normalizedOptionModel ||                    // 2. inherit from outgoing stream
  fallbackModel.trim();                       // 3. stream metadata fallback

// Same for thinkingLevel — prefer target agent's setting
const effectiveThinkingLevel =
  targetAgentSettings?.thinkingLevel ??       // 1. target agent's configured level
  currentOptions?.thinkingLevel;              // 2. inherit from outgoing stream
```

Then update `followUpOptions` to use `effectiveThinkingLevel` unconditionally instead of only spreading from `currentOptions`:

```typescript
const followUpOptions: SendMessageOptions = {
  model: effectiveModel,
  agentId: targetAgentId,
  ...(effectiveThinkingLevel != null && { thinkingLevel: effectiveThinkingLevel }),
  // ... rest unchanged
};
```

### 2. `src/node/services/agentSession.switchAgent.test.ts` — new test (~30 LoC)

Add a test where `getWorkspaceMetadata` returns `aiSettingsByAgent` with an entry for the target agent, and verify the target's configured model is used instead of the outgoing stream's model:

```typescript
test("uses target agent's configured model from aiSettingsByAgent", async () => {
  // Setup with aiSettingsByAgent: { plan: { model: "anthropic:claude-...", thinkingLevel: "high" } }
  // Call dispatchAgentSwitch targeting "plan" with currentOptions.model = "openai:gpt-4o-mini"
  // Assert: optionsArg.model === "anthropic:claude-..."
  // Assert: optionsArg.thinkingLevel === "high"
});
```

Also add a test confirming inheritance when no entry exists (the existing test implicitly covers this, but make it explicit):

```typescript
test("inherits model from outgoing stream when target has no aiSettingsByAgent entry", async () => {
  // Same as existing "dispatches synthetic follow-up" test but make the assertion intent explicit
});
```

### 3. Update `SessionInternals` type in test file (if `dispatchAgentSwitch` signature is unchanged — it is, since we read metadata internally)

No signature change needed — `dispatchAgentSwitch` already has access to `this.aiService` and the metadata lookup is internal.

## Estimated LoC

- **Product code**: ~+10 net (metadata lookup + model/thinkingLevel resolution)
- **Test code**: ~+40 net (2 new test cases)

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$3.06`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=3.06 -->
