### PR TITLE
🤖 fix: restore mobile compaction slider drag and disable Enter-to-send

### DIFF
--- a/src/browser/components/ChatInput/index.tsx
+++ b/src/browser/components/ChatInput/index.tsx
@@ -2150,6 +2150,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
     // Handle send message (Shift+Enter for newline is default behavior)
     if (matchesKeybind(e, KEYBINDS.SEND_MESSAGE)) {
+      // Mobile keyboards should keep Enter for newlines; sending remains button-driven.
+      if (isMobileTouch) {
+        return;
+      }
       e.preventDefault();
       void handleSend();
     }


### PR DESCRIPTION
## Summary
Fixes two mobile chat input UX issues: the auto-compaction threshold slider is now draggable on touch devices, and pressing Enter on mobile no longer sends a message.

## Background
On coarse-pointer/mobile devices, the compaction threshold handle relied on mouse events, which made the control effectively unusable. Also, Enter-to-send on mobile conflicted with expected keyboard behavior where Enter should insert a newline.

## Implementation
- Switched `ThresholdSlider` from mouse-only handlers to pointer events (`onPointerDown` + `pointermove/pointerup/pointercancel`) so dragging works for touch and mouse.
- Tracked `pointerId` during drag to avoid cross-pointer interference.
- Added `touchAction: "none"` on the drag handle to prevent scroll gestures from stealing drag interactions.
- Updated chat input key handling to ignore `SEND_MESSAGE` keybind when `isMobileTouch` is true, preserving Enter for newline insertion on mobile.

## Validation
- `make static-check`

## Risks
Low risk. Changes are scoped to the compaction threshold slider interaction path and chat input Enter key handling on mobile touch devices.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.00 -->
