### PR TITLE
🤖 fix: preserve context usage across workspace replay

### DIFF
--- a/src/common/orpc/schemas/stream.ts
+++ b/src/common/orpc/schemas/stream.ts
@@ -400,6 +400,10 @@ export const UsageDeltaEventSchema = z.object({
   type: z.literal("usage-delta"),
   workspaceId: z.string(),
   messageId: z.string(),
+  replay: z
+    .boolean()
+    .optional()
+    .meta({ description: "True when this event is emitted during stream replay" }),
 
   // Step-level: this step only (for context window display)
   usage: LanguageModelV2UsageSchema,


### PR DESCRIPTION
## Summary
- Emit `usage-delta` during stream replay so reconnecting clients immediately receive context and cumulative usage state.
- Preserve last-known workspace usage across full replay resets to prevent context/cost bars from flashing empty while transcript state is rebuilding.
- Add regression tests for replayed usage emission and usage visibility during replay reset windows.

## Background
Switching back to a workspace during an active/reconnecting stream could clear context usage indicators until a later live `finish-step` emitted a new `usage-delta`. This made context pressure and costs disappear transiently, even though tracked usage state was already available.

## Implementation
- `StreamManager.replayStream` now emits a replay-marked `usage-delta` from tracked `lastStepUsage` + `cumulativeUsage` once part replay is complete.
- `UsageDeltaEventSchema` now supports optional `replay` to align with other replay-capable stream events.
- `WorkspaceStore` now captures a pre-replay usage snapshot before clearing aggregators and serves that snapshot as a temporary fallback when replay has no messages loaded yet.
- On authoritative `caught-up`, `WorkspaceStore` clears the temporary snapshot and bumps usage immediately.
- Cleanup paths remove any stale pre-replay snapshot data when workspaces are deleted.

## Validation
- `make static-check`
- `bun test src/node/services/streamManager.test.ts`
- `bun test src/browser/stores/WorkspaceStore.test.ts`

## Risks
Low-to-moderate. The change touches replay/state-reset plumbing, but behavior is tightly covered by targeted tests and full static checks.

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix: Context Usage Bars Disappear on Workspace Switch

## Context / Why

When a user switches from one workspace to another, the context usage bar (shown in the Costs tab and below the chat input) disappears and only reappears after the next `usage-delta` event (i.e., the next AI step finishes). This is a poor UX—the user loses visibility into how full the context window is and what the session has cost so far.

**Root causes (two gaps):**

1. **Backend replay gap:** `StreamManager.replayStream` replays text/reasoning/tool parts but **skips `usage-delta`** events. The accumulated `cumulativeUsage` and `lastStepUsage` exist on `WorkspaceStreamInfo` but are never sent to a reconnecting subscriber.

2. **Frontend reset gap:** `resetChatStateForReplay` clears the aggregator (wiping all messages and their embedded `contextUsage`), then bumps the usage store, causing the UI to render empty. After replay completes, the usage store bump is deferred to `requestIdleCallback`, creating a visible flash where the transcript is back but the bars are still empty.

## Evidence

| File | Lines | Role |
|------|-------|------|
| `src/node/services/streamManager.ts` | L329-335 | `cumulativeUsage`, `lastStepUsage` exist on `WorkspaceStreamInfo` |
| `src/node/services/streamManager.ts` | L756-804 | `emitPartAsEvent` only handles `text`, `reasoning`, `dynamic-tool` |
| `src/node/services/streamManager.ts` | L2993-3067 | `replayStream` iterates parts, never emits `usage-delta` |
| `src/node/services/streamManager.ts` | L1872-1906 | Live `finish-step` path builds and emits `usage-delta` |
| `src/browser/stores/WorkspaceStore.ts` | L2530-2557 | `resetChatStateForReplay` clears aggregator + bumps `states` |
| `src/browser/stores/WorkspaceStore.ts` | L1922-2023 | `getWorkspaceUsage` relies entirely on aggregator (no fallback) |
| `src/browser/stores/WorkspaceStore.ts` | L1293-1308 | `scheduleCaughtUpUsageBump` defers to `requestIdleCallback` |

## Implementation Plan

### Part 1: Backend — Emit accumulated usage during replay (~15 LoC)

**File:** `src/node/services/streamManager.ts` — `replayStream` method (after L3065)

After replaying all parts, if `streamInfo` has accumulated usage (`lastStepUsage` exists), emit a synthetic `usage-delta` event so the reconnecting frontend receives the current state:

```typescript
// In replayStream(), after the for-loop over filteredReplayParts (after line 3066):

// Replay accumulated usage so reconnecting subscribers see context window + cost state.
// Live streaming emits usage-delta on each finish-step; replay must send the current
// accumulated snapshot so the frontend doesn't start from zero.
if (streamInfo.lastStepUsage) {
  const usageEvent: UsageDeltaEvent = {
    type: "usage-delta",
    workspaceId: workspaceId as string,
    messageId: streamInfo.messageId,
    // Last step's usage = current context window snapshot
    usage: streamInfo.lastStepUsage,
    providerMetadata: streamInfo.lastStepProviderMetadata,
    // Cumulative = total cost so far in this stream
    cumulativeUsage: streamInfo.cumulativeUsage,
    cumulativeProviderMetadata: streamInfo.cumulativeProviderMetadata,
    replay: true,
  };
  this.emit("usage-delta", usageEvent);
}
```

**Check:** The `UsageDeltaEvent` type/schema may need a `replay?: boolean` field. Verify whether the schema (`UsageDeltaEventSchema` in `src/common/orpc/schemas/stream.ts`) already has it, and if not, add it (matching the existing `replay` field pattern on `stream-delta`, `reasoning-delta`, etc.). The frontend aggregator should accept it without changes since it just processes the usage data regardless.

### Part 2: Frontend — Preserve last-known usage across replay reset (~15 LoC)

**File:** `src/browser/stores/WorkspaceStore.ts` — `resetChatStateForReplay`

Before clearing the aggregator, snapshot the current `lastContextUsage` and `liveUsage` from the usage store so we can serve it as a fallback during the replay window:

```typescript
// In resetChatStateForReplay, before aggregator.clear():

// Preserve last-known usage so the UI doesn't flash empty during replay.
// getWorkspaceUsage() will fall back to this until the replayed data catches up.
const currentUsage = this.usageStore.peek(workspaceId);
if (currentUsage && currentUsage.totalTokens > 0) {
  this.preReplayUsageSnapshot.set(workspaceId, currentUsage);
}
```

Add the map field:
```typescript
// New field on WorkspaceStore (near other Maps):
private preReplayUsageSnapshot = new Map<string, WorkspaceUsageState>();
```

**File:** `src/browser/stores/WorkspaceStore.ts` — `getWorkspaceUsage`

When the aggregator is empty (just cleared for replay), fall back to the snapshot:

```typescript
// In getWorkspaceUsage, after the aggregator check:
const aggregator = this.aggregators.get(workspaceId);
if (!aggregator) {
  return { totalTokens: 0 };
}

// During replay, the aggregator is empty. Fall back to pre-replay snapshot
// so the usage bars don't flash to zero.
const messages = aggregator.getAllMessages();
if (messages.length === 0) {
  const snapshot = this.preReplayUsageSnapshot.get(workspaceId);
  if (snapshot) {
    return snapshot;
  }
}
// ... rest of existing logic
```

**Cleanup:** Clear the snapshot once replay catches up (in the `caught-up` handler or `scheduleCaughtUpUsageBump`):

```typescript
// In the caught-up event handler, after marking caughtUp = true:
this.preReplayUsageSnapshot.delete(workspaceId);
```

<details>
<summary>Why not use workspaceActivity as the fallback?</summary>

The `workspaceActivity` snapshot (`WorkspaceActivitySnapshot`) does **not** currently carry `lastContextUsage` data. Adding it would require:
- Extending the schema in `src/common/orpc/schemas/workspace.ts`
- Updating `ExtensionMetadataService` to persist it
- Updating `WorkspaceService` to emit it

This is a larger change and introduces a new persistence path. The simpler approach—caching the previous value in a local Map during the replay window—achieves the same UX with no backend schema changes.
</details>

### Part 3: Remove idle deferral for post-replay usage bump (~5 LoC)

**File:** `src/browser/stores/WorkspaceStore.ts` — Where `scheduleCaughtUpUsageBump` is called

After the replay catches up, the usage store bump is deferred to `requestIdleCallback`, creating a visible gap where the transcript reappears but the bars remain stale. Change the caught-up path to bump usage synchronously (or with a microtask) instead of waiting for idle:

```typescript
// Replace scheduleCaughtUpUsageBump(workspaceId) in the caught-up handler with:
this.preReplayUsageSnapshot.delete(workspaceId);
this.usageStore.bump(workspaceId);
```

<details>
<summary>Why is this safe?</summary>

The idle deferral was added to avoid a second full ChatPane render pass blocking first transcript paint. But since we now serve the pre-replay snapshot during the window, the "caught-up" bump is a delta update (old snapshot → fresh data) rather than a zero → data flash. The render cost is modest, and the alternative (visible bar disappearance) is worse UX.

If profiling shows this is costly, the deferral can be restored with a very short timeout (e.g., `setTimeout(fn, 0)`) instead of `requestIdleCallback`.
</details>

## Estimated LoC

| Part | Product code | Test code |
|------|-------------|-----------|
| Part 1: Backend replay emit | ~15 | ~20 |
| Part 2: Frontend snapshot fallback | ~15 | ~15 |
| Part 3: Remove idle deferral | ~5 (net negative) | 0 |
| **Total** | **~35** | **~35** |

## Validation

1. `make typecheck` — ensures new fields/types are consistent
2. `make test` — existing usage/streaming tests pass
3. Targeted test: verify `replayStream` emits `usage-delta` when `lastStepUsage` exists
4. Manual: switch between two workspaces (one actively streaming) and verify bars persist

</details>

---
_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `1223617{MUX_COSTS_USD}`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=3.09 -->
