### PR TITLE
🤖 feat: add /compact guidance to compaction settings modal

### DIFF
--- a/src/browser/components/ContextUsageIndicatorButton.tsx
+++ b/src/browser/components/ContextUsageIndicatorButton.tsx
@@ -276,7 +276,7 @@ export const ContextUsageIndicatorButton: React.FC<ContextUsageIndicatorButtonPr
           <div>
             • <span className="font-mono">-t max output tokens</span>
           </div>
-          <div>• add a followup message on the next line</div>
+          <div>• Add a followup message on the next line</div>
         </div>
         <AutoCompactSettings
           data={data}


### PR DESCRIPTION
## Summary

Adds discoverability copy for manual compaction to the **Compaction settings** modal (context usage dialog), so users can find `/compact` without cluttering the inline auto-compact warning.

## Background

Users currently have no obvious way to discover manual compaction. We first tried placing this hint in the inline auto-compact indicator, but product direction is to keep that indicator minimal and surface command guidance in the modal only.

Closes #566

## Implementation

- Added a muted help line inside `AutoCompactSettings` in `src/browser/components/ContextUsageIndicatorButton.tsx`:
  - `Run /compact to compact manually · -m model · -t max output tokens · add a followup message on the next line`
- Kept command tokens (`/compact`, `-m model`, `-t max output tokens`) in monospace styling for scanability.
- Left inline `CompactionWarning` focused on threshold status only.

## Validation

- `make typecheck`
- `make static-check`

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$1.71`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=1.71 -->
