### PR TITLE
🤖 fix: close and clear workspace terminals on archive

### DIFF
--- a/src/node/services/terminalService.ts
+++ b/src/node/services/terminalService.ts
@@ -672,7 +672,9 @@ export class TerminalService {
    * Called when a workspace is removed to prevent resource leaks.
    */
   closeWorkspaceSessions(workspaceId: string): void {
-    this.ptyService.closeWorkspaceSessions(workspaceId);
+    const sessionIds = this.getWorkspaceSessionIds(workspaceId);
+    // Route bulk-close through TerminalService.close() so cleanup() runs for backend state.
+    sessionIds.forEach((sessionId) => this.close(sessionId));
   }
 
   /**
@@ -680,7 +682,9 @@ export class TerminalService {
    * Called during server shutdown to prevent orphan PTY processes.
    */
   closeAllSessions(): void {
-    this.ptyService.closeAllSessions();
+    const sessionIds = Array.from(this.ptyService.getSessions().keys());
+    // Route bulk-close through TerminalService.close() so cleanup() runs for backend state.
+    sessionIds.forEach((sessionId) => this.close(sessionId));
   }
 
   private cleanup(sessionId: string) {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2463,6 +2463,9 @@ export class WorkspaceService extends EventEmitter {
         }
       }
 
+      // Archiving hides workspace UI; do not leave terminal PTYs running headless.
+      this.terminalService?.closeWorkspaceSessions(workspaceId);
+
       await this.config.editConfig((config) => {
         const projectConfig = config.projects.get(projectPath);
         if (projectConfig) {


### PR DESCRIPTION
## Summary

Archiving a workspace now properly kills all terminal PTY processes and clears persisted terminal UI state, preventing headless terminal processes from lingering after archive.

## Background

When a workspace was archived, the backend marked it as archived and the frontend hid it from the UI, but terminal PTY processes were left running headlessly. This wasted system resources and could cause confusion if the workspace was later unarchived with stale terminal state.

## Implementation

**1. TerminalService bulk-close cleanup parity** (`terminalService.ts`)  
`closeWorkspaceSessions()` and `closeAllSessions()` now fan out through `close()` per-session, ensuring PTY kill + `cleanup()` (headless terminal disposal, emitters, serialize addons) — matching the UI delete-button path.

**2. Archive terminal cleanup** (`workspaceService.ts`)  
`archive()` calls `closeWorkspaceSessions(workspaceId)` after stream interruption and before persisting `archivedAt`.

**3. Frontend persisted terminal tab clearing** (`WorkspaceContext.tsx`)  
On successful archive, strips terminal tabs from persisted sidebar layout and clears terminal titles. Layout read is guarded with `isRightSidebarLayoutState()` so invalid persisted JSON never causes a false archive failure.

## Validation

- 2 new TerminalService tests verify fan-out close semantics
- 2 new WorkspaceService tests verify archive terminal cleanup (success + hook-failure cases)
- 2 new WorkspaceContext tests verify schema-safe layout cleanup (invalid layout shape, valid layout with terminal tabs)
- `make static-check` passes

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$12.12`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=12.12 -->
