### PR TITLE
🤖 fix: align GH server auth login flow with provider copy/open pattern

### DIFF
--- a/src/browser/components/AuthTokenModal.tsx
+++ b/src/browser/components/AuthTokenModal.tsx
@@ -313,7 +313,17 @@ export function AuthTokenModal(props: AuthTokenModalProps) {
                         return;
                       }
 
-                      void navigator.clipboard.writeText(githubUserCode);
+                      const clipboard = navigator.clipboard;
+                      if (clipboard?.writeText) {
+                        try {
+                          void clipboard.writeText(githubUserCode).catch(() => {
+                            // Ignore clipboard write failures so login can continue.
+                          });
+                        } catch {
+                          // Ignore clipboard access failures so login can continue.
+                        }
+                      }
+
                       window.open(githubVerificationUri, "_blank", "noopener");
                     }}
                     className="h-8 px-3 text-xs"


### PR DESCRIPTION
## Summary
This updates the server-auth GitHub device flow in `AuthTokenModal` to match the provider auth pattern used elsewhere: users now copy the code and open GitHub in one explicit action instead of being redirected immediately.

## Background
The previous modal flow auto-opened the verification URL as soon as the device flow started, which often sent users to GitHub before they had copied the code. That added context switching and unnecessary friction during login.

## Implementation
- Removed auto-opening of the GitHub verification URL when the flow enters `waiting`.
- Replaced the ghost `Copy` action with a single `Copy & Open GitHub` button that:
  - copies the device code to clipboard, and
  - opens the verification page in a new tab.
- Added inline waiting feedback with a spinner (`Loader2`) and "Waiting for authorization...".
- Removed now-unused copied-state/timer logic and related cleanup.

## Validation
- `make static-check`

## Risks
Low risk and scoped to the GitHub device login UI in the auth token modal. Main behavioral change is intentional user-controlled browser open timing.

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix GH Login Flow to Match Provider Auth Pattern

## Context / Why

The GitHub device-flow login in `AuthTokenModal` (server auth) auto-opens the browser
**before** the user has a chance to copy the device code. The user lands on GitHub's
verification page empty-handed and must alt-tab back to the app to copy the code.

The provider auth flows (Codex OAuth, Copilot OAuth in `ProvidersSection`) use a better
pattern: show the code first with a **"Copy & Open"** button that copies to clipboard
*and* opens the browser in one click. This plan aligns the GH server-auth flow with that
established pattern.

## Evidence

| File | Role |
|---|---|
| `src/browser/components/AuthTokenModal.tsx` (lines 163–263, 302–363) | Current GH device flow UI — auto-opens browser on L198, separate ghost "Copy" button |
| `src/browser/components/Settings/sections/ProvidersSection.tsx` (L1304–1331, L1575–1601) | Target pattern — "Copy & Open" button, spinner, no auto-open |

### Current GH flow (AuthTokenModal)
1. Click "Login with GitHub"
2. Backend returns `userCode` + `verificationUri`
3. **Browser auto-opens** `verificationUri` immediately (L198)
4. UI shows code with a small ghost "Copy" button
5. Fallback link: "If the browser didn't open…"
6. **No spinner** while waiting

### Target pattern (ProvidersSection — Copilot/Codex)
1. Click "Connect"
2. Backend returns `userCode` + `verificationUri`
3. UI shows code with a **"Copy & Open GitHub"** button
4. Button click → copies code to clipboard **and** opens browser
5. Shows **spinner** with "Waiting for authorization…"

## Implementation

**Single file: `src/browser/components/AuthTokenModal.tsx`** · ~+10 / −15 net ≈ −5 LoC

### 1. Remove auto-open of browser (L198)

Delete:
```tsx
window.open(verificationUri, "_blank", "noopener");
```

The browser should only open when the user clicks "Copy & Open GitHub".

### 2. Replace ghost "Copy" button with "Copy & Open GitHub" button

Replace the current device-code block (L325–357) with the provider-consistent pattern:

```tsx
{githubLoginStatus === "waiting" && githubUserCode ? (
  <div className="bg-background-tertiary space-y-2 rounded-md p-3">
    <p className="text-muted text-xs">
      Enter this code on GitHub:
    </p>
    <div className="flex items-center gap-2">
      <code className="text-foreground text-lg font-bold tracking-widest">
        {githubUserCode}
      </code>
      <Button
        size="sm"
        aria-label="Copy and open GitHub verification page"
        onClick={() => {
          void navigator.clipboard.writeText(githubUserCode);
          if (githubVerificationUri) {
            window.open(githubVerificationUri, "_blank", "noopener");
          }
        }}
        className="h-8 px-3 text-xs"
        disabled={!githubVerificationUri}
      >
        Copy & Open GitHub
      </Button>
    </div>
    <p className="text-muted inline-flex items-center gap-2 text-xs">
      <Loader2 aria-hidden className="h-3.5 w-3.5 animate-spin" />
      Waiting for authorization...
    </p>
  </div>
) : null}
```

Key changes vs current code:
- **Code color**: `text-accent` → `text-foreground` (matches provider pattern)
- **Button**: ghost "Copy" → regular `sm` "Copy & Open GitHub" that copies **and** opens
- **Spinner**: add `<Loader2>` + "Waiting for authorization…" (currently missing)
- **Remove**: "If the browser didn't open" fallback link (no longer needed; user controls the open)

### 3. Remove `copyGithubUserCode` callback and related state

The dedicated `copyGithubUserCode` callback (L248–263), `githubCodeCopied` state (L77),
and `copiedTimeoutRef` (L80) become dead code since the new button inlines the copy+open
logic. Remove them.

### 4. Add `Loader2` import

Add `Loader2` to the existing import from `lucide-react` (or add a new import if none exists).

```tsx
import { Loader2 } from "lucide-react";
```

## Validation

- `make typecheck` — no type errors from removed state / changed JSX
- `make lint` — no unused variables from removed `githubCodeCopied` / `copiedTimeoutRef` / `copyGithubUserCode`
- Manual: open AuthTokenModal, verify code is shown with "Copy & Open GitHub" button, browser only opens on click

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.88`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.88 -->
