### PR TITLE
🤖 fix: add Shift+M file-read hint in immersive review footer

### DIFF
--- a/src/browser/components/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/components/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -1663,6 +1663,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
             <KeycapGroup keys={["↑", "↓"]} label="line" />
             <KeycapGroup keys={["Shift", "↑↓"]} label="select" />
             <KeycapGroup keys={["m"]} label="read" />
+            <KeycapGroup keys={["⇧M"]} label="file read" />
             <KeycapGroup keys={["⇧C"]} label="comment" />
             <KeycapGroup keys={["⇧L", "⇧D"]} label="like / dislike" />
             <KeycapGroup keys={["Enter"]} label="submit" />


### PR DESCRIPTION
## Summary
Keep existing Code Review shortcuts from `main` unchanged and improve discoverability by showing the file-level mark-as-read shortcut in immersive mode.

## Background
- `main` already supports file-level mark-as-read via `Shift+M`.
- Rebinding shortcuts was no longer desired.
- The remaining gap was discoverability in the immersive review footer.

## Implementation
- Rebased branch onto `main` and dropped shortcut remap changes.
- Added a footer hint in `ImmersiveReviewView` for file-level read:
  - `⇧M` → `file read`
- Left keybind behavior untouched (`r` hunk read, `Shift+M` file read, `Cmd/Ctrl+R` refresh).

## Validation
- `make typecheck`
- `make static-check`

## Risks
Low risk. This is a UI hint-only change with no shortcut behavior or handler logic modifications.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.96`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.96 -->
