### PR TITLE
🤖 fix: prevent stats page from immediately navigating away

### DIFF
--- a/src/browser/contexts/WorkspaceContext.tsx
+++ b/src/browser/contexts/WorkspaceContext.tsx
@@ -562,6 +562,7 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
     currentProjectId,
     currentProjectPathFromState,
     currentSettingsSection,
+    isAnalyticsOpen,
     pendingSectionId,
     pendingDraftId,
   } = useRouter();
@@ -575,10 +576,13 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
     // workspace context (e.g., navigating to Home).
     if (currentWorkspaceId) {
       workspaceStore.setActiveWorkspaceId(currentWorkspaceId);
-    } else if (!currentSettingsSection) {
+    } else if (!currentSettingsSection && !isAnalyticsOpen) {
+      // Only null out the active workspace when truly leaving a workspace
+      // context (e.g., navigating to Home). Settings and analytics pages
+      // should preserve the subscription so chat messages aren't cleared.
       workspaceStore.setActiveWorkspaceId(null);
     }
-  }, [workspaceStore, currentWorkspaceId, currentSettingsSection]);
+  }, [workspaceStore, currentWorkspaceId, currentSettingsSection, isAnalyticsOpen]);
   const [workspaceMetadata, setWorkspaceMetadataState] = useState<
     Map<string, FrontendWorkspaceMetadata>
   >(new Map());
@@ -982,11 +986,12 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
     // Skip if we already have a selected workspace (from localStorage or URL hash)
     if (selectedWorkspace) return;
 
-    // Skip if user is on the settings page — navigating to /settings/:section
-    // clears the workspace from the URL, making selectedWorkspace null. Without
-    // this guard the effect would auto-select a workspace and navigate away from
-    // settings immediately.
+    // Skip if user is on the settings or analytics page — navigating to
+    // /settings/:section or /analytics clears the workspace from the URL,
+    // making selectedWorkspace null. Without this guard the effect would
+    // auto-select a workspace and navigate away immediately.
     if (currentSettingsSection) return;
+    if (isAnalyticsOpen) return;
 
     // Skip if user is in the middle of creating a workspace
     if (pendingNewWorkspaceProject) return;
@@ -1032,6 +1037,7 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
     loading,
     selectedWorkspace,
     currentSettingsSection,
+    isAnalyticsOpen,
     pendingNewWorkspaceProject,
     workspaceMetadata,
     setSelectedWorkspace,


### PR DESCRIPTION
## Summary

Fix the stats/analytics page immediately flashing back to the previous workspace when opened.

## Background

When clicking the stats button (top-right), the app would briefly show the analytics page then snap back to the previous workspace. This happened because two effects in `WorkspaceContext` lacked guards for the analytics route — they treated the analytics page as "no workspace selected" and auto-navigated away.

## Implementation

Added `isAnalyticsOpen` guards to two effects in `src/browser/contexts/WorkspaceContext.tsx`, mirroring the existing `currentSettingsSection` pattern:

1. **`useLayoutEffect` (workspace subscription cleanup)** — Previously cleared the active workspace ID when navigating to `/analytics` since both `currentWorkspaceId` and `currentSettingsSection` were null. Now also checks `isAnalyticsOpen` to preserve the workspace subscription.

2. **`useEffect` (launch project check)** — Previously saw `selectedWorkspace` as null on `/analytics`, called `getLaunchProject()`, found a workspace, and auto-navigated away. Now returns early when `isAnalyticsOpen` is true.

`isAnalyticsOpen` was already exported by `RouterContext` — it just wasn't consumed in `WorkspaceContext`.

## Risks

Low — the change is narrowly scoped to two guard conditions and directly mirrors the existing settings-page pattern. No new state or side effects introduced.

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$6.75`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=6.75 -->
