### PR TITLE
🤖 feat: abbreviate display of Codex model names

### DIFF
--- a/docs/config/models.mdx
+++ b/docs/config/models.mdx
@@ -18,11 +18,11 @@ Mux ships with curated models kept up to date with the frontier. Use any custom 
 | Haiku 4.5              | anthropic:claude-haiku-4-5    | `haiku`                                  |         |
 | GPT-5.2                | openai:gpt-5.2                | `gpt`                                    |         |
 | GPT-5.2 Pro            | openai:gpt-5.2-pro            | `gpt-pro`                                |         |
-| GPT-5.2 Codex          | openai:gpt-5.2-codex          | `codex`                                  |         |
-| GPT-5.3 Codex          | openai:gpt-5.3-codex          | `codex-5.3`                              |         |
-| GPT-5.3 Codex Spark    | openai:gpt-5.3-codex-spark    | `spark`                                  |         |
-| GPT-5.1 Codex Mini     | openai:gpt-5.1-codex-mini     | `codex-mini`                             |         |
-| GPT-5.1 Codex Max      | openai:gpt-5.1-codex-max      | `codex-max`                              |         |
+| Codex 5.2              | openai:gpt-5.2-codex          | `codex`                                  |         |
+| Codex 5.3              | openai:gpt-5.3-codex          | `codex-5.3`                              |         |
+| Spark 5.3              | openai:gpt-5.3-codex-spark    | `spark`                                  |         |
+| Codex Mini 5.1         | openai:gpt-5.1-codex-mini     | `codex-mini`                             |         |
+| Codex Max 5.1          | openai:gpt-5.1-codex-max      | `codex-max`                              |         |
 | Gemini 3.1 Pro Preview | google:gemini-3.1-pro-preview | `gemini`, `gemini-pro`                   |         |
 | Gemini 3 Flash Preview | google:gemini-3-flash-preview | `gemini-flash`                           |         |
 | Grok 4 1 Fast          | xai:grok-4-1-fast             | `grok`, `grok-4`, `grok-4.1`, `grok-4-1` |         |

--- a/src/common/utils/ai/modelDisplay.test.ts
+++ b/src/common/utils/ai/modelDisplay.test.ts
@@ -19,6 +19,27 @@ describe("formatModelDisplayName", () => {
       expect(formatModelDisplayName("gpt-4o")).toBe("GPT-4o");
       expect(formatModelDisplayName("gpt-4o-mini")).toBe("GPT-4o Mini");
     });
+
+    test("formats Codex models with Codex branding", () => {
+      expect(formatModelDisplayName("gpt-5.3-codex")).toBe("Codex 5.3");
+      expect(formatModelDisplayName("gpt-5.2-codex")).toBe("Codex 5.2");
+      expect(formatModelDisplayName("gpt-5.1-codex-mini")).toBe("Codex Mini 5.1");
+      expect(formatModelDisplayName("gpt-5.1-codex-max")).toBe("Codex Max 5.1");
+    });
+
+    test("ignores date suffixes on Codex models", () => {
+      expect(formatModelDisplayName("gpt-5.1-codex-max-2025-12-01")).toBe("Codex Max 5.1");
+      expect(formatModelDisplayName("gpt-5.3-codex-2025-06-15")).toBe("Codex 5.3");
+    });
+
+    test("preserves unknown Codex qualifiers", () => {
+      expect(formatModelDisplayName("gpt-5.3-codex-preview")).toBe("Codex Preview 5.3");
+      expect(formatModelDisplayName("gpt-5.3-codex-preview-2")).toBe("Codex Preview 2 5.3");
+    });
+
+    test("formats Codex Spark models with Spark branding", () => {
+      expect(formatModelDisplayName("gpt-5.3-codex-spark")).toBe("Spark 5.3");
+    });
   });
 
   describe("Gemini models", () => {

--- a/src/common/utils/ai/modelDisplay.ts
+++ b/src/common/utils/ai/modelDisplay.ts
@@ -8,6 +8,8 @@
  * Examples:
  * - "claude-sonnet-4-5" -> "Sonnet 4.5"
  * - "claude-opus-4-1" -> "Opus 4.1"
+ * - "gpt-5.3-codex" -> "Codex 5.3"
+ * - "gpt-5.3-codex-spark" -> "Spark 5.3"
  * - "gpt-5-pro" -> "GPT-5 Pro"
  * - "gpt-4o" -> "GPT-4o"
  * - "gemini-2-0-flash-exp" -> "Gemini 2.0 Flash Exp"
@@ -64,13 +66,33 @@ export function formatModelDisplayName(modelName: string): string {
 
   // GPT models
   if (lower.startsWith("gpt-")) {
-    // "gpt-5-pro" -> "GPT-5 Pro"
-    // "gpt-4o" -> "GPT-4o"
-    // "gpt-4o-mini" -> "GPT-4o Mini"
     const parts = lower.split("-");
 
     if (parts.length >= 2) {
-      // Keep "gpt" and first part together (gpt-5, gpt-4o)
+      // Codex Spark models: "gpt-5.3-codex-spark" -> "Spark 5.3"
+      if (parts.includes("codex") && parts.includes("spark")) {
+        const version = parts[1]; // e.g., "5.3"
+        return `Spark ${version}`;
+      }
+
+      // Codex models: "gpt-5.3-codex" -> "Codex 5.3", "gpt-5.1-codex-mini" -> "Codex Mini 5.1"
+      // Keep all suffixes as qualifiers but strip trailing date stamps (YYYYMMDD or
+      // YYYY-MM-DD split across segments). A trailing date is detected as a 4-digit
+      // year followed by any remaining segments, e.g. "-2025-12-01" or "-20251201".
+      const codexIdx = parts.indexOf("codex");
+      if (codexIdx >= 2) {
+        const version = parts[1]; // e.g., "5.3"
+        const afterCodex = parts.slice(codexIdx + 1);
+        // Find where a trailing date stamp begins (4-digit year segment like "2025")
+        const dateStart = afterCodex.findIndex((p) => /^\d{4,}$/.test(p));
+        const qualifierParts = dateStart >= 0 ? afterCodex.slice(0, dateStart) : afterCodex;
+        const qualifiers = qualifierParts.map(capitalize).join(" ");
+        return qualifiers ? `Codex ${qualifiers} ${version}` : `Codex ${version}`;
+      }
+
+      // "gpt-5-pro" -> "GPT-5 Pro"
+      // "gpt-4o" -> "GPT-4o"
+      // "gpt-4o-mini" -> "GPT-4o Mini"
       const base = `GPT-${parts[1]}`;
 
       // Capitalize remaining parts


### PR DESCRIPTION
## Summary

Update model display names so Codex and Spark models show product branding instead of the generic "GPT-{version}" prefix.

## Background

The `formatModelDisplayName` function generically formats all `gpt-*` models as "GPT-{version} {Suffix}". This resulted in codex models displaying as "GPT-5.3 Codex" and spark models as "GPT-5.3 Codex Spark" rather than the cleaner product branding.

## Implementation

Added special cases in the GPT branch of `formatModelDisplayName`:

1. **Spark models** — detected first (both `codex` and `spark` in the ID), formatted as `Spark {version}`
2. **Codex models** — detected next, formatted as `Codex {version}` with known qualifiers (mini, max, pro) placed between the brand and version; date suffixes are ignored to avoid mangled display

| Model ID | Before | After |
|---|---|---|
| `gpt-5.3-codex` | GPT-5.3 Codex | **Codex 5.3** |
| `gpt-5.2-codex` | GPT-5.2 Codex | **Codex 5.2** |
| `gpt-5.1-codex-mini` | GPT-5.1 Codex Mini | **Codex Mini 5.1** |
| `gpt-5.1-codex-max` | GPT-5.1 Codex Max | **Codex Max 5.1** |
| `gpt-5.3-codex-spark` | GPT-5.3 Codex Spark | **Spark 5.3** |

Affects all consumers of `formatModelDisplayName` — model selector, message model display, compaction suggestions, and slash command descriptions.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$0.62`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=0.62 -->
