### PR TITLE
🤖 tests: remove tautological alias-mapping and constant-mirroring tests

### DIFF
--- a/src/common/utils/ai/models.test.ts
+++ b/src/common/utils/ai/models.test.ts
@@ -4,7 +4,6 @@ import {
   getModelName,
   supports1MContext,
   isValidModelFormat,
-  resolveModelAlias,
 } from "./models";
 
 describe("normalizeGatewayModel", () => {
@@ -103,26 +102,5 @@ describe("isValidModelFormat", () => {
 
     // Empty string
     expect(isValidModelFormat("")).toBe(false);
-  });
-});
-
-describe("resolveModelAlias", () => {
-  it("resolves known aliases to full model strings", () => {
-    expect(resolveModelAlias("haiku")).toBe("anthropic:claude-haiku-4-5");
-    expect(resolveModelAlias("sonnet")).toBe("anthropic:claude-sonnet-4-6");
-    expect(resolveModelAlias("opus")).toBe("anthropic:claude-opus-4-6");
-    expect(resolveModelAlias("grok")).toBe("xai:grok-4-1-fast");
-    expect(resolveModelAlias("codex")).toBe("openai:gpt-5.2-codex");
-    expect(resolveModelAlias("gemini")).toBe("google:gemini-3.1-pro-preview");
-    expect(resolveModelAlias("codex-mini")).toBe("openai:gpt-5.1-codex-mini");
-    expect(resolveModelAlias("spark")).toBe("openai:gpt-5.3-codex-spark");
-    expect(resolveModelAlias("gemini-pro")).toBe("google:gemini-3.1-pro-preview");
-    expect(resolveModelAlias("gemini-flash")).toBe("google:gemini-3-flash-preview");
-  });
-
-  it("returns non-alias strings unchanged", () => {
-    expect(resolveModelAlias("anthropic:custom-model")).toBe("anthropic:custom-model");
-    expect(resolveModelAlias("openai:gpt-5.2")).toBe("openai:gpt-5.2");
-    expect(resolveModelAlias("unknown")).toBe("unknown");
   });
 });

--- a/src/common/utils/tokens/modelStats.test.ts
+++ b/src/common/utils/tokens/modelStats.test.ts
@@ -21,24 +21,16 @@ describe("getModelStats", () => {
     test("should find models in models-extra.ts", () => {
       const stats = getModelStats("openai:gpt-5.2-pro");
       expect(stats).not.toBeNull();
-      expect(stats?.max_input_tokens).toBe(272000);
-      expect(stats?.input_cost_per_token).toBe(0.000021);
-    });
-
-    test("should include spark model config from models-extra.ts", () => {
-      const stats = getModelStats("openai:gpt-5.3-codex-spark");
-      expect(stats).not.toBeNull();
-      expect(stats?.max_input_tokens).toBe(128000);
-      expect(stats?.max_output_tokens).toBe(128000);
-      expect(stats?.input_cost_per_token).toBe(0.00000175);
-      expect(stats?.output_cost_per_token).toBe(0.000014);
+      expect(stats?.max_input_tokens).toBeGreaterThan(0);
+      expect(stats?.input_cost_per_token).toBeGreaterThan(0);
     });
 
     test("models-extra.ts should override models.json", () => {
-      // gpt-5.2-codex exists in both files - models-extra.ts has correct 272k, models.json has incorrect 400k
+      // gpt-5.2-codex exists in both files - models-extra.ts has correct 272k, models.json has incorrect 400k.
+      // The exact value matters here: it proves the override mechanism works.
       const stats = getModelStats("openai:gpt-5.2-codex");
       expect(stats).not.toBeNull();
-      expect(stats?.max_input_tokens).toBe(272000); // models-extra.ts override
+      expect(stats?.max_input_tokens).toBe(272000);
     });
   });
 
@@ -46,15 +38,13 @@ describe("getModelStats", () => {
     test("should find ollama gpt-oss:20b with cloud suffix", () => {
       const stats = getModelStats("ollama:gpt-oss:20b");
       expect(stats).not.toBeNull();
-      expect(stats?.max_input_tokens).toBe(131072);
-      expect(stats?.input_cost_per_token).toBe(0); // Local models are free
-      expect(stats?.output_cost_per_token).toBe(0);
+      expect(stats?.max_input_tokens).toBeGreaterThan(0);
     });
 
     test("should find ollama gpt-oss:120b with cloud suffix", () => {
       const stats = getModelStats("ollama:gpt-oss:120b");
       expect(stats).not.toBeNull();
-      expect(stats?.max_input_tokens).toBe(131072);
+      expect(stats?.max_input_tokens).toBeGreaterThan(0);
     });
 
     test("should find ollama deepseek-v3.1:671b with cloud suffix", () => {
@@ -97,13 +87,13 @@ describe("getModelStats", () => {
     test("should prefer github copilot provider-specific limits", () => {
       const stats = getModelStats("github-copilot:gpt-4-o-preview");
       expect(stats).not.toBeNull();
-      expect(stats?.max_input_tokens).toBe(64000);
+      expect(stats?.max_input_tokens).toBeGreaterThan(0);
     });
 
     test("should default missing copilot costs to zero", () => {
       const stats = getModelStats("github-copilot:gpt-4.1");
       expect(stats).not.toBeNull();
-      expect(stats?.max_input_tokens).toBe(128000);
+      expect(stats?.max_input_tokens).toBeGreaterThan(0);
       expect(stats?.input_cost_per_token).toBe(0);
       expect(stats?.output_cost_per_token).toBe(0);
     });
@@ -136,8 +126,8 @@ describe("getModelStats", () => {
     test("should handle mux-gateway:anthropic/model format", () => {
       const stats = getModelStats("mux-gateway:anthropic/claude-sonnet-4-5");
       expect(stats).not.toBeNull();
-      expect(stats?.input_cost_per_token).toBe(0.000003);
-      expect(stats?.output_cost_per_token).toBe(0.000015);
+      expect(stats?.input_cost_per_token).toBeGreaterThan(0);
+      expect(stats?.output_cost_per_token).toBeGreaterThan(0);
     });
 
     test("should handle mux-gateway:openai/model format", () => {
@@ -188,23 +178,23 @@ describe("getModelStats", () => {
       const stats = getModelStats(KNOWN_MODELS.SONNET.id);
 
       expect(stats).not.toBeNull();
-      expect(stats?.input_cost_per_token).toBe(0.000003);
-      expect(stats?.output_cost_per_token).toBe(0.000015);
-      expect(stats?.max_input_tokens).toBe(200000);
+      expect(stats?.input_cost_per_token).toBeGreaterThan(0);
+      expect(stats?.output_cost_per_token).toBeGreaterThan(0);
+      expect(stats?.max_input_tokens).toBeGreaterThan(0);
     });
 
     it("should handle model without provider prefix", () => {
       const stats = getModelStats("claude-sonnet-4-5");
 
       expect(stats).not.toBeNull();
-      expect(stats?.input_cost_per_token).toBe(0.000003);
+      expect(stats?.input_cost_per_token).toBeGreaterThan(0);
     });
 
     it("should return cache pricing when available", () => {
       const stats = getModelStats(KNOWN_MODELS.SONNET.id);
 
-      expect(stats?.cache_creation_input_token_cost).toBe(0.00000375);
-      expect(stats?.cache_read_input_token_cost).toBe(3e-7);
+      expect(stats?.cache_creation_input_token_cost).toBeDefined();
+      expect(stats?.cache_read_input_token_cost).toBeDefined();
     });
 
     it("should return null for unknown models", () => {


### PR DESCRIPTION
## Summary

Remove tautological tests that merely re-assert hardcoded values already defined in production constant tables (`MODEL_ABBREVIATIONS`, `models-extra.ts`, `models.json`), providing zero bug-detection value.

## Background

PR #2552 added several tests for the new `gpt-5.3-codex-spark` model that followed the existing pattern of copying exact constant values into test assertions. This pattern is tautological — if someone changes a model's pricing in `models-extra.ts`, these tests break not because of a bug, but because the hardcoded test values no longer match the updated constants. An audit of the full test suite identified two files with this anti-pattern.

## Implementation

**`models.test.ts`** — Removed the entire `resolveModelAlias` describe block (both "resolves known aliases" and "returns non-alias strings unchanged" tests). The function under test is a 3-line `Object.hasOwn` + property access into `MODEL_ABBREVIATIONS` — no logic to exercise.

**`modelStats.test.ts`** — Two changes:
- Removed "should include spark model config from models-extra.ts" entirely (100% tautological — 4 hardcoded `.toBe()` assertions copied verbatim from `models-extra.ts`)
- Replaced hardcoded constant values in 8 other tests with structural assertions (`toBeGreaterThan(0)`, `toBeDefined()`) that still verify the lookup logic found results without mirroring exact data values

Tests that exercise actual logic (regex routing in thinking policy, merge strategies in model capabilities, string parsing in model display, cross-source integration guards in knownModels) were audited and kept.

## Validation

- 43 tests pass across both files (0 failures)
- `make typecheck` clean
- `make lint` clean

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$2.42`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=2.42 -->
