### PR TITLE
🤖 feat: sidebar terminal activity indicator with OSC prompt detection

### DIFF
--- a/src/browser/components/WorkspaceListItem.tsx
+++ b/src/browser/components/WorkspaceListItem.tsx
@@ -20,6 +20,7 @@ import { Trash2, Ellipsis, Loader2, Sparkles } from "lucide-react";
 import { WorkspaceStatusIndicator } from "./WorkspaceStatusIndicator";
 import { Shimmer } from "./ai-elements/shimmer";
 import { ArchiveIcon } from "./icons/ArchiveIcon";
+import { WorkspaceTerminalIcon } from "./icons/WorkspaceTerminalIcon";
 import { WORKSPACE_DRAG_TYPE, type WorkspaceDragItem } from "./WorkspaceSectionDropZone";
 import { useLinkSharingEnabled } from "@/browser/contexts/TelemetryEnabledContext";
 import { formatKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
@@ -371,7 +372,7 @@ function RegularWorkspaceListItemInner(props: WorkspaceListItemProps) {
     }
   };
 
-  const { canInterrupt, awaitingUserQuestion, isStarting, agentStatus } =
+  const { canInterrupt, awaitingUserQuestion, isStarting, agentStatus, terminalActiveCount } =
     useWorkspaceSidebarState(workspaceId);
 
   const fallbackModel = useWorkspaceFallbackModel(workspaceId);
@@ -657,6 +658,20 @@ function RegularWorkspaceListItemInner(props: WorkspaceListItemProps) {
 
             {!isInitializing && !isEditing && (
               <div className="flex items-center gap-1">
+                {terminalActiveCount > 0 && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="text-muted flex items-center gap-0.5">
+                        <WorkspaceTerminalIcon className="h-3 w-3" />
+                        <span className="text-[11px]">{terminalActiveCount}</span>
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent side="right">
+                      {terminalActiveCount} terminal{terminalActiveCount !== 1 ? "s" : ""} running
+                      commands
+                    </TooltipContent>
+                  </Tooltip>
+                )}
                 <GitStatusIndicator
                   gitStatus={gitStatus}
                   workspaceId={workspaceId}

--- a/src/browser/components/WorkspaceMenuBar.tsx
+++ b/src/browser/components/WorkspaceMenuBar.tsx
@@ -41,6 +41,7 @@ import { ShareTranscriptDialog } from "./ShareTranscriptDialog";
 import { ConfirmationModal } from "./ConfirmationModal";
 import { PopoverError } from "./PopoverError";
 import { WorkspaceActionsMenuContent } from "./WorkspaceActionsMenuContent";
+import { WorkspaceTerminalIcon } from "./icons/WorkspaceTerminalIcon";
 
 import { SkillIndicator } from "./SkillIndicator";
 import { useAPI } from "@/browser/contexts/API";
@@ -484,9 +485,7 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
               className="text-muted hover:text-foreground ml-1 h-6 w-6 shrink-0 [&_svg]:h-4 [&_svg]:w-4"
               data-tutorial="terminal-button"
             >
-              <svg viewBox="0 0 16 16" fill="currentColor">
-                <path d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0114.25 15H1.75A1.75 1.75 0 010 13.25V2.75zm1.75-.25a.25.25 0 00-.25.25v10.5c0 .138.112.25.25.25h12.5a.25.25 0 00.25-.25V2.75a.25.25 0 00-.25-.25H1.75zM7.25 8a.75.75 0 01-.22.53l-2.25 2.25a.75.75 0 01-1.06-1.06L5.44 8 3.72 6.28a.75.75 0 111.06-1.06l2.25 2.25c.141.14.22.331.22.53zm1.5 1.5a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3z" />
-              </svg>
+              <WorkspaceTerminalIcon />
             </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom" align="center">

--- a/src/browser/components/icons/WorkspaceTerminalIcon.tsx
+++ b/src/browser/components/icons/WorkspaceTerminalIcon.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+export const WorkspaceTerminalIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg {...props} viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+    <path d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0114.25 15H1.75A1.75 1.75 0 010 13.25V2.75zm1.75-.25a.25.25 0 00-.25.25v10.5c0 .138.112.25.25.25h12.5a.25.25 0 00.25-.25V2.75a.25.25 0 00-.25-.25H1.75zM7.25 8a.75.75 0 01-.22.53l-2.25 2.25a.75.75 0 01-1.06-1.06L5.44 8 3.72 6.28a.75.75 0 111.06-1.06l2.25 2.25c.141.14.22.331.22.53zm1.5 1.5a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3z" />
+  </svg>
+);

--- a/src/browser/stories/mocks/orpc.ts
+++ b/src/browser/stories/mocks/orpc.ts
@@ -1424,6 +1424,18 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
       },
     },
     terminal: {
+      activity: {
+        subscribe: async function* (_input?: void, opts?: { signal?: AbortSignal }) {
+          yield { type: "snapshot" as const, workspaces: {} };
+          await new Promise<void>((resolve) => {
+            if (opts?.signal?.aborted) {
+              resolve();
+              return;
+            }
+            opts?.signal?.addEventListener("abort", () => resolve(), { once: true });
+          });
+        },
+      },
       listSessions: (input: { workspaceId: string }) =>
         Promise.resolve(terminalSessionIdsByWorkspace.get(input.workspaceId) ?? []),
       create: (input: {

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -1437,6 +1437,38 @@ export const terminal = {
     output: z.void(),
   },
   /**
+   * Subscribe to terminal activity changes across all workspaces.
+   * First event is a snapshot of all workspace aggregates.
+   * Subsequent events are per-workspace updates.
+   */
+  activity: {
+    subscribe: {
+      input: z.void(),
+      output: eventIterator(
+        z.discriminatedUnion("type", [
+          z.object({
+            type: z.literal("snapshot"),
+            workspaces: z.record(
+              z.string(),
+              z.object({
+                activeCount: z.number(),
+                totalSessions: z.number(),
+              })
+            ),
+          }),
+          z.object({
+            type: z.literal("update"),
+            workspaceId: z.string(),
+            activity: z.object({
+              activeCount: z.number(),
+              totalSessions: z.number(),
+            }),
+          }),
+        ])
+      ),
+    },
+  },
+  /**
    * List active terminal sessions for a workspace.
    * Used by frontend to discover existing sessions to reattach to after reload.
    */

--- a/src/constants/terminalActivity.ts
+++ b/src/constants/terminalActivity.ts
@@ -1,0 +1,6 @@
+/**
+ * When a session has not observed any OSC title/prompt signals,
+ * the newline-running heuristic auto-resets to idle after this duration.
+ * Prevents permanent false-running state in non-OSC shells.
+ */
+export const NO_OSC_IDLE_FALLBACK_MS = 10_000;

--- a/src/node/services/terminalService.test.ts
+++ b/src/node/services/terminalService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock, beforeEach, afterEach, spyOn, type Mock } from "bun:test";
+import { describe, it, expect, mock, beforeEach, afterEach, spyOn, vi, type Mock } from "bun:test";
 import { TerminalService } from "./terminalService";
 import type { PTYService } from "./ptyService";
 import type { Config } from "@/node/config";
@@ -59,14 +59,13 @@ const sendInputMock = mock(() => {
 const closeSessionMock = mock(() => {
   /* no-op */
 });
-const getWorkspaceSessionIdsMock = mock(() => [] as string[]);
+const getWorkspaceSessionIdsMock = mock(() => []);
 const closeWorkspaceSessionsMock = mock(() => {
   /* no-op */
 });
 const closeAllSessionsMock = mock(() => {
   /* no-op */
 });
-const getSessionsMock = mock(() => new Map());
 
 const mockPTYService = {
   createSession: createSessionMock,
@@ -76,7 +75,6 @@ const mockPTYService = {
   getWorkspaceSessionIds: getWorkspaceSessionIdsMock,
   closeWorkspaceSessions: closeWorkspaceSessionsMock,
   closeAllSessions: closeAllSessionsMock,
-  getSessions: getSessionsMock,
 } as unknown as PTYService;
 
 const openTerminalWindowMock = mock(() => Promise.resolve());
@@ -93,9 +91,17 @@ describe("TerminalService", () => {
   let service: TerminalService;
 
   beforeEach(() => {
+    // Some tests temporarily replace createSession to capture callbacks.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockPTYService.createSession as any) = createSessionMock;
+
     service = new TerminalService(mockConfig, mockPTYService);
     service.setTerminalWindowManager(mockWindowManager);
     createSessionMock.mockClear();
+    closeSessionMock.mockClear();
+    getWorkspaceSessionIdsMock.mockClear();
+    closeWorkspaceSessionsMock.mockClear();
+    closeAllSessionsMock.mockClear();
     getEffectiveSecretsMock.mockClear();
     resizeMock.mockClear();
     sendInputMock.mockClear();
@@ -103,7 +109,6 @@ describe("TerminalService", () => {
     getWorkspaceSessionIdsMock.mockClear();
     closeWorkspaceSessionsMock.mockClear();
     closeAllSessionsMock.mockClear();
-    getSessionsMock.mockClear();
     openTerminalWindowMock.mockClear();
   });
 
@@ -200,35 +205,31 @@ describe("TerminalService", () => {
     expect(sendInputMock).toHaveBeenCalledWith("session-1", "ls\n");
   });
 
-  it("should close workspace sessions by fan-out through close", () => {
-    getWorkspaceSessionIdsMock.mockReturnValue(["session-1", "session-2"]);
-    const closeSpy = spyOn(service, "close");
+  it("should close workspace sessions via terminateTrackedSessions", async () => {
+    // Create real sessions so sessionActivity is populated
+    await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });
+    closeSessionMock.mockClear();
 
     service.closeWorkspaceSessions("ws-1");
 
-    expect(getWorkspaceSessionIdsMock).toHaveBeenCalledWith("ws-1");
-    expect(closeSpy).toHaveBeenCalledTimes(2);
-    expect(closeSpy).toHaveBeenNthCalledWith(1, "session-1");
-    expect(closeSpy).toHaveBeenNthCalledWith(2, "session-2");
+    expect(closeSessionMock).toHaveBeenCalled();
+    // PTY bulk close should NOT be used — we route through per-session termination
     expect(closeWorkspaceSessionsMock).not.toHaveBeenCalled();
+    // Activity should be fully cleaned up
+    expect(service.getWorkspaceActivity("ws-1")).toEqual({ activeCount: 0, totalSessions: 0 });
   });
 
-  it("should close all sessions by fan-out through close", () => {
-    getSessionsMock.mockReturnValue(
-      new Map<string, unknown>([
-        ["session-1", { workspaceId: "ws-1" }],
-        ["session-2", { workspaceId: "ws-2" }],
-      ])
-    );
-    const closeSpy = spyOn(service, "close");
+  it("should close all sessions via terminateTrackedSessions", async () => {
+    // Create a real session so sessionActivity is populated
+    await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });
+    closeSessionMock.mockClear();
 
     service.closeAllSessions();
 
-    expect(getSessionsMock).toHaveBeenCalled();
-    expect(closeSpy).toHaveBeenCalledTimes(2);
-    expect(closeSpy).toHaveBeenNthCalledWith(1, "session-1");
-    expect(closeSpy).toHaveBeenNthCalledWith(2, "session-2");
+    expect(closeSessionMock).toHaveBeenCalled();
+    // PTY bulk close should NOT be used
     expect(closeAllSessionsMock).not.toHaveBeenCalled();
+    expect(service.getWorkspaceActivity("ws-1")).toEqual({ activeCount: 0, totalSessions: 0 });
   });
 
   it("should open terminal window via manager", async () => {
@@ -280,6 +281,406 @@ describe("TerminalService", () => {
     // Let's just restore it to createSessionMock.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (mockPTYService.createSession as any) = createSessionMock;
+  });
+  describe("terminal activity tracking", () => {
+    let capturedOnData: ((data: string) => void) | undefined;
+    let capturedOnExit: ((code: number) => void) | undefined;
+    const onDataBySession = new Map<string, (data: string) => void>();
+    let sessionCounter = 0;
+
+    beforeEach(() => {
+      capturedOnData = undefined;
+      capturedOnExit = undefined;
+      onDataBySession.clear();
+      sessionCounter = 0;
+
+      // Override createSession to capture onData/onExit callbacks.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockPTYService.createSession as any) = mock(
+        (
+          params: TerminalCreateParams,
+          _runtime: unknown,
+          _path: string,
+          onData: (d: string) => void,
+          onExit: (code: number) => void
+        ) => {
+          sessionCounter += 1;
+          const sessionId = `session-${params.workspaceId}-${sessionCounter}`;
+          capturedOnData = onData;
+          capturedOnExit = onExit;
+          onDataBySession.set(sessionId, onData);
+
+          return Promise.resolve({
+            sessionId,
+            workspaceId: params.workspaceId,
+            cols: params.cols,
+            rows: params.rows,
+          });
+        }
+      );
+    });
+
+    async function sendTitle(
+      onData: ((data: string) => void) | undefined,
+      title: string
+    ): Promise<void> {
+      if (!onData) {
+        throw new Error("Expected createSession to capture onData callback");
+      }
+
+      onData(`\x1b]0;${title}\x07`);
+      // xterm/headless processes writes asynchronously.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    async function sendPromptMarker(
+      onData: ((data: string) => void) | undefined,
+      marker: string
+    ): Promise<void> {
+      if (!onData) {
+        throw new Error("Expected createSession to capture onData callback");
+      }
+
+      onData(`\x1b]133;${marker}\x07`);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    it("classifies idle titles as not running", async () => {
+      await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });
+
+      const initial = service.getWorkspaceActivity("ws-1");
+      expect(initial.totalSessions).toBe(1);
+      expect(initial.activeCount).toBe(0);
+
+      await sendTitle(capturedOnData, "bash");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(0);
+
+      await sendTitle(capturedOnData, "zsh");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(0);
+
+      await sendTitle(capturedOnData, "/home/user/project");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(0);
+
+      await sendTitle(capturedOnData, "~/project");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(0);
+
+      await sendTitle(capturedOnData, "user@host:/path");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(0);
+    });
+
+    it("classifies command titles as running", async () => {
+      await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });
+
+      const initial = service.getWorkspaceActivity("ws-1");
+      expect(initial.totalSessions).toBe(1);
+      expect(initial.activeCount).toBe(0);
+
+      await sendTitle(capturedOnData, "vim main.ts");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(1);
+
+      await sendTitle(capturedOnData, "npm run build");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(1);
+
+      await sendTitle(capturedOnData, "htop");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(1);
+    });
+
+    it("sendInput with newline marks session as running", async () => {
+      const session = await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(0);
+
+      service.sendInput(session.sessionId, "make build\r");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(1);
+
+      await sendTitle(capturedOnData, "~/project");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(0);
+    });
+
+    it("sendInput without newline does not mark running", async () => {
+      const session = await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });
+      service.sendInput(session.sessionId, "a");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(0);
+
+      service.sendInput(session.sessionId, "bc");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(0);
+    });
+
+    it("OSC 133 prompt-start (A) marks session as idle", async () => {
+      const session = await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });
+
+      // Simulate: user runs command
+      service.sendInput(session.sessionId, "sleep infinity\r");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(1);
+
+      // Fish sends OSC 133;D (command done) then 133;A (prompt start)
+      await sendPromptMarker(capturedOnData, "D;130");
+      // D should be ignored — still running
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(1);
+
+      await sendPromptMarker(capturedOnData, "A;special_key=1");
+      // A flips to idle
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(0);
+    });
+
+    it("OSC 133 command-start (C) marks session as running", async () => {
+      await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(0);
+
+      await sendPromptMarker(capturedOnData, "C");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(1);
+
+      // Prompt returns
+      await sendPromptMarker(capturedOnData, "A");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(0);
+    });
+
+    it("transitions between running and idle", async () => {
+      await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(0);
+
+      await sendTitle(capturedOnData, "make build");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(1);
+
+      await sendTitle(capturedOnData, "bash");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(0);
+    });
+
+    it("emits activity change events with dedup", async () => {
+      const changes: string[] = [];
+      const unsubscribe = service.onActivityChange((workspaceId) => changes.push(workspaceId));
+
+      await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });
+      expect(changes).toEqual(["ws-1"]);
+
+      const countAfterCreate = changes.length;
+      await sendTitle(capturedOnData, "make test");
+      expect(changes.length).toBe(countAfterCreate + 1);
+
+      const countAfterFirstCommand = changes.length;
+      await sendTitle(capturedOnData, "npm test");
+      expect(changes.length).toBe(countAfterFirstCommand);
+
+      await sendTitle(capturedOnData, "bash");
+      expect(changes.length).toBe(countAfterFirstCommand + 1);
+
+      const countAfterIdle = changes.length;
+      await sendTitle(capturedOnData, "zsh");
+      expect(changes.length).toBe(countAfterIdle);
+
+      unsubscribe();
+    });
+
+    it("cleans up activity on session exit", async () => {
+      await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });
+
+      await sendTitle(capturedOnData, "make build");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(1);
+      expect(service.getWorkspaceActivity("ws-1").totalSessions).toBe(1);
+
+      if (!capturedOnExit) {
+        throw new Error("Expected createSession to capture onExit callback");
+      }
+
+      capturedOnExit(0);
+      expect(service.getWorkspaceActivity("ws-1").totalSessions).toBe(0);
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(0);
+    });
+
+    it("returns aggregate across workspace sessions via getAllWorkspaceActivity", async () => {
+      const firstSession = await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });
+      const secondSession = await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });
+
+      const firstOnData = onDataBySession.get(firstSession.sessionId);
+      const secondOnData = onDataBySession.get(secondSession.sessionId);
+
+      await sendTitle(firstOnData, "vim");
+      const activity = service.getWorkspaceActivity("ws-1");
+      expect(activity.totalSessions).toBe(2);
+      expect(activity.activeCount).toBe(1);
+
+      await sendTitle(secondOnData, "npm test");
+      const activity2 = service.getWorkspaceActivity("ws-1");
+      expect(activity2.activeCount).toBe(2);
+
+      const all = service.getAllWorkspaceActivity();
+      expect(all["ws-1"]).toEqual({ activeCount: 2, totalSessions: 2 });
+    });
+
+    it("clears activity on bulk workspace close without exit callback", async () => {
+      const session = await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });
+      service.sendInput(session.sessionId, "make build\n");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(1);
+      expect(service.getWorkspaceActivity("ws-1").totalSessions).toBe(1);
+
+      service.closeWorkspaceSessions("ws-1");
+      expect(service.getWorkspaceActivity("ws-1")).toEqual({ activeCount: 0, totalSessions: 0 });
+    });
+
+    it("clears all activity on global close without exit callbacks", async () => {
+      const configRef = mockConfig as unknown as {
+        getAllWorkspaceMetadata: typeof mockConfig.getAllWorkspaceMetadata;
+      };
+      const originalGetAllWorkspaceMetadata = configRef.getAllWorkspaceMetadata;
+      configRef.getAllWorkspaceMetadata = mock(() =>
+        Promise.resolve([
+          {
+            id: "ws-1",
+            projectPath: "/tmp/project",
+            name: "main",
+            runtimeConfig: { type: "local", srcBaseDir: "/tmp" },
+          },
+          {
+            id: "ws-2",
+            projectPath: "/tmp/project2",
+            name: "dev",
+            runtimeConfig: { type: "local", srcBaseDir: "/tmp" },
+          },
+        ])
+      ) as unknown as typeof configRef.getAllWorkspaceMetadata;
+
+      try {
+        const s1 = await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });
+        const s2 = await service.create({ workspaceId: "ws-2", cols: 80, rows: 24 });
+        service.sendInput(s1.sessionId, "cmd1\n");
+        service.sendInput(s2.sessionId, "cmd2\n");
+
+        expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(1);
+        expect(service.getWorkspaceActivity("ws-2").activeCount).toBe(1);
+
+        service.closeAllSessions();
+        expect(service.getWorkspaceActivity("ws-1")).toEqual({ activeCount: 0, totalSessions: 0 });
+        expect(service.getWorkspaceActivity("ws-2")).toEqual({ activeCount: 0, totalSessions: 0 });
+        expect(Object.keys(service.getAllWorkspaceActivity())).toHaveLength(0);
+      } finally {
+        configRef.getAllWorkspaceMetadata = originalGetAllWorkspaceMetadata;
+      }
+    });
+  });
+
+  describe("no-OSC idle fallback", () => {
+    let capturedOnData: ((data: string) => void) | undefined;
+    let sessionCounter = 0;
+    let originalSetTimeout: typeof globalThis.setTimeout;
+    let originalClearTimeout: typeof globalThis.clearTimeout;
+    type TimerHandle = ReturnType<typeof setTimeout> | number;
+    const fallbackTimerHandles: TimerHandle[] = [];
+    const fallbackCallbacks = new Map<TimerHandle, () => void>();
+
+    function fireFallbackTimer(handle: TimerHandle): void {
+      const callback = fallbackCallbacks.get(handle);
+      if (!callback) {
+        throw new Error("Expected fallback timer callback to be captured");
+      }
+
+      originalClearTimeout(handle);
+      fallbackCallbacks.delete(handle);
+      callback();
+    }
+
+    beforeEach(() => {
+      capturedOnData = undefined;
+      sessionCounter = 0;
+      fallbackTimerHandles.length = 0;
+      fallbackCallbacks.clear();
+      originalSetTimeout = globalThis.setTimeout;
+      originalClearTimeout = globalThis.clearTimeout;
+
+      vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+        handler: TimerHandler,
+        timeout?: number,
+        ...args: unknown[]
+      ) => {
+        const handle = originalSetTimeout(handler, timeout, ...args);
+
+        if (timeout === 10_000 && typeof handler === "function") {
+          fallbackTimerHandles.push(handle);
+          fallbackCallbacks.set(handle, handler as () => void);
+        }
+
+        return handle;
+      }) as typeof globalThis.setTimeout);
+
+      vi.spyOn(globalThis, "clearTimeout").mockImplementation(((handle: TimerHandle) => {
+        fallbackCallbacks.delete(handle);
+        return originalClearTimeout(handle);
+      }) as typeof globalThis.clearTimeout);
+
+      // Override createSession to capture onData callback.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockPTYService.createSession as any) = mock(
+        (
+          params: TerminalCreateParams,
+          _runtime: unknown,
+          _path: string,
+          onData: (d: string) => void,
+          _onExit: (code: number) => void
+        ) => {
+          sessionCounter += 1;
+          const sessionId = `session-${params.workspaceId}-${sessionCounter}`;
+          capturedOnData = onData;
+
+          return Promise.resolve({
+            sessionId,
+            workspaceId: params.workspaceId,
+            cols: params.cols,
+            rows: params.rows,
+          });
+        }
+      );
+    });
+
+    afterEach(() => {
+      for (const handle of fallbackTimerHandles) {
+        originalClearTimeout(handle);
+      }
+      vi.restoreAllMocks();
+    });
+
+    it("resets to idle after fallback timeout when no OSC observed", async () => {
+      const session = await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });
+      service.sendInput(session.sessionId, "make build\r");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(1);
+      expect(fallbackTimerHandles).toHaveLength(1);
+
+      fireFallbackTimer(fallbackTimerHandles[0]);
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(0);
+    });
+
+    it("does not use fallback once OSC activity is observed", async () => {
+      const session = await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });
+
+      if (!capturedOnData) {
+        throw new Error("Expected createSession to capture onData callback");
+      }
+
+      capturedOnData(`\x1b]0;bash\x07`);
+      await new Promise((resolve) => originalSetTimeout(resolve, 10));
+
+      service.sendInput(session.sessionId, "make build\r");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(1);
+      expect(fallbackTimerHandles).toHaveLength(0);
+    });
+
+    it("refreshes fallback timer on repeated newlines", async () => {
+      const session = await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });
+      service.sendInput(session.sessionId, "cmd1\r");
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(1);
+      expect(fallbackTimerHandles).toHaveLength(1);
+
+      const firstHandle = fallbackTimerHandles[0];
+      service.sendInput(session.sessionId, "cmd2\r");
+      expect(fallbackTimerHandles).toHaveLength(2);
+
+      const secondHandle = fallbackTimerHandles[1];
+      const clearTimeoutCalls = (globalThis.clearTimeout as Mock<typeof globalThis.clearTimeout>)
+        .mock.calls;
+      const clearedFirstHandle = clearTimeoutCalls.some(([handle]) => handle === firstHandle);
+      expect(clearedFirstHandle).toBe(true);
+
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(1);
+      fireFallbackTimer(secondHandle);
+      expect(service.getWorkspaceActivity("ws-1").activeCount).toBe(0);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Show a terminal activity indicator in the workspace sidebar — a terminal icon + count badge appears when integrated terminal sessions are actively running commands.

## Background

When multiple workspaces have integrated terminals open, there's no visual signal about which workspaces have active commands running. Users must switch to each workspace to check terminal state. This feature surfaces terminal activity directly in the sidebar for at-a-glance awareness.

## Implementation

**Activity detection** uses three complementary signals:
- **Input-driven:** `sendInput()` with `\r`/`\n` marks session as running
- **OSC 0/2 title heuristics:** idle-pattern titles (CWD paths, shell names, `user@host:` prompts) reset to idle — covers bash/zsh
- **OSC 133 semantic prompt markers:** `A` → idle, `C` → running — covers fish

**Session lifecycle** is designed around a single termination primitive (`terminateTrackedSessions`) that all close paths route through (single close, workspace close, global shutdown), guaranteeing cleanup even when PTY exit callbacks don't fire synchronously.

**Non-OSC resilience:** shells that don't emit OSC sequences get an automatic idle fallback timer (10s) to prevent permanent false-running state. Once a session observes any OSC activity, it's promoted to OSC-driven mode and the fallback is cancelled.

**Data flow:** `TerminalService` → ORPC streaming subscription → `WorkspaceStore.WorkspaceSidebarState` → `WorkspaceListItem` renders badge when `terminalActiveCount > 0`.

Uses `headless.parser.registerOscHandler()` instead of `onTitleChange` because xterm v6's internal event forwarding doesn't fire in this app despite the parser correctly processing OSC sequences.

### Key design decisions

- Sessions start as `isRunning: false` because shells emit a CWD title almost immediately on startup, making an optimistic `true` default flash and disappear.
- Terminal activity is composed into existing `WorkspaceSidebarState` (not a separate store) for cohesive sidebar rendering.
- Shared `WorkspaceTerminalIcon` component extracted from `WorkspaceMenuBar` for reuse in sidebar badge.

## Validation

- 30 tests pass in `terminalService.test.ts` covering: idle/command title classification, sendInput newline → running, OSC 133 prompt markers, activity change dedup, session exit cleanup, bulk workspace/global close cleanup, aggregate computation, and no-OSC idle fallback (timer refresh + OSC-driven immunity)
- `WorkspaceStore.test.ts` terminal activity tests pass (snapshot propagation + zero defaults)
- `make static-check` passes (typecheck, lint, fmt, broken-links)

## Risks

- **OSC title heuristic false negatives:** commands whose titles match idle patterns (e.g., a program named `bash`) will appear idle. Low severity — the input-driven signal covers the initial running transition.
- **Non-OSC fallback window:** 10s is a heuristic; very long commands in non-OSC shells will flash running→idle→running if the user sends another newline. Acceptable tradeoff vs permanent stuck state.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$40.68`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=40.68 -->
