### PR TITLE
🤖 feat: manage Coder SSH config and migrate suffix to mux--coder

### DIFF
--- a/docs/runtime/coder.mdx
+++ b/docs/runtime/coder.mdx
@@ -24,11 +24,11 @@ If multiple organizations have templates with the same name, Mux shows the organ
 
 1. Choose **Existing**.
 2. Select a workspace from the list (status is shown).
-3. Mux will start the workspace if it is stopped, then connect to `<workspace-name>.coder`.
+3. Mux will start the workspace if it is stopped, then connect to `<workspace-name>.mux--coder`.
 
 ## SSH setup
 
-Mux runs `coder config-ssh --yes` before connecting, which creates SSH aliases like `<workspace-name>.coder` in `~/.ssh/config`.
+Mux writes and maintains a mux-owned SSH config block before connecting, creating aliases like `<workspace-name>.mux--coder` in `~/.ssh/config`.
 
 ## Notes
 

--- a/src/browser/utils/policyUi.test.ts
+++ b/src/browser/utils/policyUi.test.ts
@@ -59,7 +59,7 @@ describe("policyUi", () => {
     const sshHost: ParsedRuntime = { mode: RUNTIME_MODE.SSH, host: "user@host" };
     const sshCoder: ParsedRuntime = {
       mode: RUNTIME_MODE.SSH,
-      host: "workspace.coder",
+      host: "workspace.mux--coder",
       coder: { existingWorkspace: true, workspaceName: "workspace" },
     };
 

--- a/src/constants/coder.ts
+++ b/src/constants/coder.ts
@@ -1,0 +1,23 @@
+// Canonical Coder-related constants shared across mux.
+// The ".mux--coder" suffix ensures mux's SSH config block never
+// collides with user-managed or Coder CLI-managed SSH entries.
+
+export const MUX_CODER_HOST_SUFFIX = "mux--coder";
+
+/** Build the SSH hostname for a Coder workspace (e.g. `my-ws.mux--coder`). */
+export function toMuxCoderHost(workspaceName: string): string {
+  return `${workspaceName}.${MUX_CODER_HOST_SUFFIX}`;
+}
+
+/**
+ * Resolve the canonical SSH host for a Coder workspace.
+ * If workspaceName is provided, returns `<name>.mux--coder`;
+ * otherwise falls back to the raw host (non-Coder SSH or already-normalized).
+ */
+export function resolveCoderSSHHost(host: string, workspaceName?: string): string {
+  const name = workspaceName?.trim();
+  return name ? toMuxCoderHost(name) : host;
+}
+
+export const MUX_CODER_SSH_BLOCK_START = "# --- START MUX CODER SSH ---";
+export const MUX_CODER_SSH_BLOCK_END = "# --- END MUX CODER SSH ---";

--- a/src/node/runtime/muxSshConfigWriter.test.ts
+++ b/src/node/runtime/muxSshConfigWriter.test.ts
@@ -1,0 +1,461 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import * as crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  MUX_CODER_HOST_SUFFIX,
+  MUX_CODER_SSH_BLOCK_END,
+  MUX_CODER_SSH_BLOCK_START,
+} from "@/constants/coder";
+import { ensureMuxCoderSSHConfigFile } from "./muxSshConfigWriter";
+
+function renderExpectedMuxBlock(coderBinaryPath: string): string {
+  const quotedPath = `"${coderBinaryPath.replaceAll('"', String.raw`\"`)}"`;
+
+  return [
+    MUX_CODER_SSH_BLOCK_START,
+    `Host *.${MUX_CODER_HOST_SUFFIX}`,
+    "  ConnectTimeout 0",
+    "  LogLevel ERROR",
+    "  StrictHostKeyChecking no",
+    "  UserKnownHostsFile /dev/null",
+    `  ProxyCommand ${quotedPath} "ssh" "--stdio" "--hostname-suffix" "${MUX_CODER_HOST_SUFFIX}" "%h"`,
+    MUX_CODER_SSH_BLOCK_END,
+  ].join("\n");
+}
+
+describe("ensureMuxCoderSSHConfigFile", () => {
+  const coderBinaryPath = "/usr/local/bin/coder";
+  let tempDirs: string[] = [];
+
+  async function makeSSHConfigPath(): Promise<string> {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-ssh-writer-"));
+    tempDirs.push(tempDir);
+    return path.join(tempDir, ".ssh", "config");
+  }
+
+  async function writeSSHConfig(sshConfigPath: string, content: string): Promise<void> {
+    await fs.mkdir(path.dirname(sshConfigPath), { recursive: true, mode: 0o700 });
+    await fs.writeFile(sshConfigPath, content, "utf8");
+  }
+
+  async function readSSHConfig(sshConfigPath: string): Promise<string> {
+    return fs.readFile(sshConfigPath, "utf8");
+  }
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((tempDir) => fs.rm(tempDir, { recursive: true, force: true })));
+    tempDirs = [];
+  });
+
+  it("creates block from an empty config", async () => {
+    const sshConfigPath = await makeSSHConfigPath();
+
+    await ensureMuxCoderSSHConfigFile({ coderBinaryPath, sshConfigPath });
+
+    const content = await readSSHConfig(sshConfigPath);
+    expect(content).toBe(`${renderExpectedMuxBlock(coderBinaryPath)}\n`);
+  });
+
+  it("preserves existing config file mode", async () => {
+    const sshConfigPath = await makeSSHConfigPath();
+    await writeSSHConfig(sshConfigPath, "Host github.com\n");
+    await fs.chmod(sshConfigPath, 0o644);
+
+    await ensureMuxCoderSSHConfigFile({ coderBinaryPath, sshConfigPath });
+
+    const mode = await fs.stat(sshConfigPath).then((stats) => stats.mode & 0o777);
+    expect(mode).toBe(0o644);
+  });
+
+  it("defaults to 0o600 for a newly created config file", async () => {
+    const sshConfigPath = await makeSSHConfigPath();
+
+    await ensureMuxCoderSSHConfigFile({ coderBinaryPath, sshConfigPath });
+
+    const mode = await fs.stat(sshConfigPath).then((stats) => stats.mode & 0o777);
+    expect(mode).toBe(0o600);
+  });
+
+  it("preserves symlinked SSH config paths by writing through to the symlink target", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-ssh-writer-link-"));
+    tempDirs.push(tempDir);
+
+    const sshDir = path.join(tempDir, ".ssh");
+    const sshConfigPath = path.join(sshDir, "config");
+    const dotfilesDir = path.join(tempDir, "dotfiles");
+    const targetConfigPath = path.join(dotfilesDir, "ssh_config");
+
+    await fs.mkdir(sshDir, { recursive: true, mode: 0o700 });
+    await fs.mkdir(dotfilesDir, { recursive: true, mode: 0o700 });
+    await fs.writeFile(targetConfigPath, "Host github.com\n", "utf8");
+    await fs.symlink(path.relative(sshDir, targetConfigPath), sshConfigPath);
+
+    await ensureMuxCoderSSHConfigFile({ coderBinaryPath, sshConfigPath });
+
+    const linkStats = await fs.lstat(sshConfigPath);
+    expect(linkStats.isSymbolicLink()).toBe(true);
+
+    const targetContent = await readSSHConfig(targetConfigPath);
+    expect(targetContent).toContain("Host *.mux--coder");
+    expect(targetContent).toContain('--hostname-suffix" "mux--coder" "%h"');
+
+    const linkedContent = await readSSHConfig(sshConfigPath);
+    expect(linkedContent).toBe(targetContent);
+  });
+
+  it("preserves dangling symlink by writing to the intended target path", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-ssh-test-"));
+    tempDirs.push(tempDir);
+
+    const targetPath = path.join(tempDir, "dotfiles", "ssh_config");
+    const symlinkPath = path.join(tempDir, "config");
+
+    // Create directory for the target but NOT the target file itself (dangling symlink).
+    await fs.mkdir(path.join(tempDir, "dotfiles"), { recursive: true });
+    await fs.symlink(targetPath, symlinkPath);
+
+    await ensureMuxCoderSSHConfigFile({ coderBinaryPath, sshConfigPath: symlinkPath });
+
+    // Symlink must still exist and point to the target.
+    const stat = await fs.lstat(symlinkPath);
+    expect(stat.isSymbolicLink()).toBe(true);
+    const linkTarget = await fs.readlink(symlinkPath);
+    expect(linkTarget).toBe(targetPath);
+
+    // Content was written to the target file (which now exists).
+    const content = await fs.readFile(targetPath, "utf8");
+    expect(content).toContain(MUX_CODER_SSH_BLOCK_START);
+
+    // Reading through the symlink yields the same content.
+    const throughLink = await fs.readFile(symlinkPath, "utf8");
+    expect(throughLink).toBe(content);
+  });
+
+  it("preserves dangling multi-hop symlink chain", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-ssh-test-"));
+    tempDirs.push(tempDir);
+
+    const targetPath = path.join(tempDir, "dotfiles", "ssh_config");
+    const linkA = path.join(tempDir, "linkA");
+    const configLink = path.join(tempDir, "config");
+
+    // Create directory but NOT the target file (dangling).
+    await fs.mkdir(path.join(tempDir, "dotfiles"), { recursive: true });
+    await fs.symlink(targetPath, linkA);
+    await fs.symlink(linkA, configLink);
+
+    await ensureMuxCoderSSHConfigFile({ coderBinaryPath, sshConfigPath: configLink });
+
+    // Both symlinks must survive.
+    expect((await fs.lstat(configLink)).isSymbolicLink()).toBe(true);
+    expect((await fs.lstat(linkA)).isSymbolicLink()).toBe(true);
+
+    // Target was created with mux block.
+    const content = await fs.readFile(targetPath, "utf8");
+    expect(content).toContain(MUX_CODER_SSH_BLOCK_START);
+  });
+
+  it("preserves multi-hop symlink chain by writing to final target", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-ssh-test-"));
+    tempDirs.push(tempDir);
+
+    const realFile = path.join(tempDir, "real_ssh_config");
+    const linkA = path.join(tempDir, "linkA");
+    const configLink = path.join(tempDir, "config");
+
+    await fs.writeFile(realFile, "", { mode: 0o644 });
+    await fs.symlink(realFile, linkA);
+    await fs.symlink(linkA, configLink);
+
+    await ensureMuxCoderSSHConfigFile({ coderBinaryPath, sshConfigPath: configLink });
+
+    // Both symlinks must remain intact.
+    const configStat = await fs.lstat(configLink);
+    expect(configStat.isSymbolicLink()).toBe(true);
+    const linkAStat = await fs.lstat(linkA);
+    expect(linkAStat.isSymbolicLink()).toBe(true);
+
+    // Content was written to the final real file.
+    const content = await fs.readFile(realFile, "utf8");
+    expect(content).toContain(MUX_CODER_SSH_BLOCK_START);
+
+    // Reading through the chain yields the same content.
+    const throughChain = await fs.readFile(configLink, "utf8");
+    expect(throughChain).toBe(content);
+  });
+
+  it("appends block to existing non-mux config while preserving existing bytes", async () => {
+    const sshConfigPath = await makeSSHConfigPath();
+    const existingContent = ["Host github.com", "  User git", ""].join("\n");
+    await writeSSHConfig(sshConfigPath, existingContent);
+
+    await ensureMuxCoderSSHConfigFile({ coderBinaryPath, sshConfigPath });
+
+    const content = await readSSHConfig(sshConfigPath);
+    expect(content.slice(0, existingContent.length)).toBe(existingContent);
+    expect(content).toBe(`${existingContent}${renderExpectedMuxBlock(coderBinaryPath)}\n`);
+  });
+
+  it("uses mux--coder suffix without mutating existing *.coder host globs", async () => {
+    const sshConfigPath = await makeSSHConfigPath();
+    const existingContent = [
+      "Host *.coder",
+      "  User legacy-user",
+      "  ProxyCommand /usr/local/bin/coder-legacy --stdio %h",
+      "",
+    ].join("\n");
+    await writeSSHConfig(sshConfigPath, existingContent);
+
+    await ensureMuxCoderSSHConfigFile({ coderBinaryPath, sshConfigPath });
+
+    const content = await readSSHConfig(sshConfigPath);
+    expect(content.slice(0, existingContent.length)).toBe(existingContent);
+    expect(content).toContain("Host *.mux--coder");
+    expect(content).toContain('--hostname-suffix" "mux--coder" "%h"');
+  });
+
+  it("replaces an existing mux block and preserves surrounding content", async () => {
+    const sshConfigPath = await makeSSHConfigPath();
+    const originalBinaryPath = "/opt/coder-old";
+    const existingContent = [
+      "Host github.com",
+      "  User git",
+      renderExpectedMuxBlock(originalBinaryPath),
+      "Host internal",
+      "  User dev",
+      "",
+    ].join("\n");
+
+    await writeSSHConfig(sshConfigPath, existingContent);
+
+    await ensureMuxCoderSSHConfigFile({ coderBinaryPath, sshConfigPath });
+
+    const content = await readSSHConfig(sshConfigPath);
+    const expected = [
+      "Host github.com",
+      "  User git",
+      renderExpectedMuxBlock(coderBinaryPath),
+      "Host internal",
+      "  User dev",
+      "",
+    ].join("\n");
+
+    expect(content).toBe(expected);
+  });
+
+  it("replaces mux block when it is at the very start of the file", async () => {
+    const sshConfigPath = await makeSSHConfigPath();
+    const originalBinaryPath = "/opt/coder-old";
+    const userContent = ["Host github.com", "  User git", ""].join("\n");
+    const existingContent = `${renderExpectedMuxBlock(originalBinaryPath)}\n${userContent}`;
+    await writeSSHConfig(sshConfigPath, existingContent);
+
+    await ensureMuxCoderSSHConfigFile({ coderBinaryPath, sshConfigPath });
+
+    const content = await readSSHConfig(sshConfigPath);
+    expect(content).toBe(`${renderExpectedMuxBlock(coderBinaryPath)}\n${userContent}`);
+  });
+
+  it("replaces mux block when it is at the very end with no trailing newline", async () => {
+    const sshConfigPath = await makeSSHConfigPath();
+    const originalBinaryPath = "/opt/coder-old";
+    const userContent = ["Host github.com", "  User git"].join("\n");
+    const existingContent = `${userContent}\n${renderExpectedMuxBlock(originalBinaryPath)}`;
+    await writeSSHConfig(sshConfigPath, existingContent);
+
+    await ensureMuxCoderSSHConfigFile({ coderBinaryPath, sshConfigPath });
+
+    const content = await readSSHConfig(sshConfigPath);
+    expect(content).toBe(`${userContent}\n${renderExpectedMuxBlock(coderBinaryPath)}`);
+  });
+
+  it("is idempotent when called repeatedly with the same binary path", async () => {
+    const sshConfigPath = await makeSSHConfigPath();
+
+    await ensureMuxCoderSSHConfigFile({ coderBinaryPath, sshConfigPath });
+    const firstWrite = await readSSHConfig(sshConfigPath);
+
+    await ensureMuxCoderSSHConfigFile({ coderBinaryPath, sshConfigPath });
+    const secondWrite = await readSSHConfig(sshConfigPath);
+
+    expect(secondWrite).toBe(firstWrite);
+  });
+
+  it("updates ProxyCommand when binary path changes", async () => {
+    const sshConfigPath = await makeSSHConfigPath();
+
+    await ensureMuxCoderSSHConfigFile({ coderBinaryPath, sshConfigPath });
+    await ensureMuxCoderSSHConfigFile({
+      coderBinaryPath: "/Applications/Coder.app/Contents/MacOS/coder",
+      sshConfigPath,
+    });
+
+    const content = await readSSHConfig(sshConfigPath);
+    expect(content).toContain(
+      'ProxyCommand "/Applications/Coder.app/Contents/MacOS/coder" "ssh" "--stdio" "--hostname-suffix" "mux--coder" "%h"'
+    );
+    expect(content).not.toContain(
+      'ProxyCommand "/usr/local/bin/coder" "ssh" "--stdio" "--hostname-suffix" "mux--coder" "%h"'
+    );
+  });
+
+  it("supports binary paths with spaces", async () => {
+    const sshConfigPath = await makeSSHConfigPath();
+    const spacedPath = "/usr/local/my dir/coder";
+
+    await ensureMuxCoderSSHConfigFile({ coderBinaryPath: spacedPath, sshConfigPath });
+
+    const content = await readSSHConfig(sshConfigPath);
+    expect(content).toContain('ProxyCommand "/usr/local/my dir/coder"');
+  });
+
+  it("escapes embedded double quotes in binary path", async () => {
+    const sshConfigPath = await makeSSHConfigPath();
+    const quotedPath = '/path/to/"coder"';
+
+    await ensureMuxCoderSSHConfigFile({ coderBinaryPath: quotedPath, sshConfigPath });
+
+    const content = await readSSHConfig(sshConfigPath);
+    expect(content).toContain('ProxyCommand "/path/to/\\"coder\\""');
+  });
+
+  it("quotes paths containing shell metacharacters", async () => {
+    const sshConfigPath = await makeSSHConfigPath();
+    const trickyPath = "/usr/$HOME/`whoami`/$(id)/coder";
+
+    await ensureMuxCoderSSHConfigFile({ coderBinaryPath: trickyPath, sshConfigPath });
+
+    const content = await readSSHConfig(sshConfigPath);
+    // Double-quoting preserves the literal path in the SSH config file.
+    // On POSIX, $ and backticks may expand at exec time — this is an accepted
+    // tradeoff shared by coder/coder and coder/vscode-coder. Realistic binary
+    // paths from PATH resolution never contain these characters.
+    expect(content).toContain('ProxyCommand "/usr/$HOME/`whoami`/$(id)/coder"');
+  });
+
+  it("escapes embedded single quotes in binary path", async () => {
+    const sshConfigPath = await makeSSHConfigPath();
+    const pathWithQuote = "/usr/local/it's/coder";
+
+    await ensureMuxCoderSSHConfigFile({ coderBinaryPath: pathWithQuote, sshConfigPath });
+
+    const content = await readSSHConfig(sshConfigPath);
+    expect(content).toContain('ProxyCommand "/usr/local/it\'s/coder"');
+  });
+
+  it("preserves backslashes in Windows-style paths", async () => {
+    const sshConfigPath = await makeSSHConfigPath();
+    const windowsPath = "C:\\Program Files\\Coder\\bin\\coder.exe";
+
+    await ensureMuxCoderSSHConfigFile({ coderBinaryPath: windowsPath, sshConfigPath });
+
+    const content = await readSSHConfig(sshConfigPath);
+    expect(content).toContain('ProxyCommand "C:\\Program Files\\Coder\\bin\\coder.exe"');
+  });
+
+  it("rejects binary paths containing newlines", async () => {
+    const sshConfigPath = await makeSSHConfigPath();
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- Bun's expect().rejects.toThrow() is thenable at runtime
+    await expect(
+      ensureMuxCoderSSHConfigFile({ coderBinaryPath: "/path\n/coder", sshConfigPath })
+    ).rejects.toThrow(/newline/i);
+  });
+
+  it("adds a separating newline before appending when existing content has no trailing newline", async () => {
+    const sshConfigPath = await makeSSHConfigPath();
+    const existingContent = ["Host github.com", "  User git"].join("\n");
+    await writeSSHConfig(sshConfigPath, existingContent);
+
+    await ensureMuxCoderSSHConfigFile({ coderBinaryPath, sshConfigPath });
+
+    const content = await readSSHConfig(sshConfigPath);
+    expect(content).toBe(`${existingContent}\n${renderExpectedMuxBlock(coderBinaryPath)}\n`);
+  });
+
+  it("throws on duplicate markers", async () => {
+    const sshConfigPath = await makeSSHConfigPath();
+    const corruptedConfig = [
+      MUX_CODER_SSH_BLOCK_START,
+      MUX_CODER_SSH_BLOCK_START,
+      "Host *.mux--coder",
+      MUX_CODER_SSH_BLOCK_END,
+      "",
+    ].join("\n");
+
+    await writeSSHConfig(sshConfigPath, corruptedConfig);
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- Bun's expect().rejects.toThrow() is thenable at runtime
+    await expect(ensureMuxCoderSSHConfigFile({ coderBinaryPath, sshConfigPath })).rejects.toThrow(
+      /duplicate/i
+    );
+  });
+
+  it("throws on duplicate END markers", async () => {
+    const sshConfigPath = await makeSSHConfigPath();
+    const corruptedConfig = [
+      MUX_CODER_SSH_BLOCK_START,
+      "Host *.mux--coder",
+      MUX_CODER_SSH_BLOCK_END,
+      MUX_CODER_SSH_BLOCK_END,
+      "",
+    ].join("\n");
+
+    await writeSSHConfig(sshConfigPath, corruptedConfig);
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- Bun's expect().rejects.toThrow() is thenable at runtime
+    await expect(ensureMuxCoderSSHConfigFile({ coderBinaryPath, sshConfigPath })).rejects.toThrow(
+      /duplicate/i
+    );
+  });
+
+  it.each([
+    {
+      caseName: "only START marker is present",
+      config: [MUX_CODER_SSH_BLOCK_START, "Host *.mux--coder", ""].join("\n"),
+    },
+    {
+      caseName: "only END marker is present",
+      config: ["Host *.mux--coder", MUX_CODER_SSH_BLOCK_END, ""].join("\n"),
+    },
+  ])("throws on mismatched markers when $caseName", async ({ config }) => {
+    const sshConfigPath = await makeSSHConfigPath();
+    await writeSSHConfig(sshConfigPath, config);
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- Bun's expect().rejects.toThrow() is thenable at runtime
+    await expect(ensureMuxCoderSSHConfigFile({ coderBinaryPath, sshConfigPath })).rejects.toThrow(
+      /mismatched/i
+    );
+  });
+
+  it("uses collision-proof temp paths when concurrent calls share a timestamp", async () => {
+    const sshConfigPath = await makeSSHConfigPath();
+
+    const nowSpy = spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    const uuidSpy = spyOn(crypto, "randomUUID")
+      .mockReturnValueOnce("aaaa-1111" as ReturnType<typeof crypto.randomUUID>)
+      .mockReturnValueOnce("bbbb-2222" as ReturnType<typeof crypto.randomUUID>);
+    const writeFileSpy = spyOn(fs, "writeFile");
+
+    try {
+      await Promise.all([
+        ensureMuxCoderSSHConfigFile({ coderBinaryPath, sshConfigPath }),
+        ensureMuxCoderSSHConfigFile({ coderBinaryPath, sshConfigPath }),
+      ]);
+
+      const tempPaths = writeFileSpy.mock.calls
+        .map(([filePath]) => filePath as string)
+        .filter((p) => p.includes(".mux-tmp."));
+
+      // Both calls must have used distinct temp paths despite identical PID + timestamp.
+      expect(tempPaths.length).toBeGreaterThanOrEqual(2);
+      expect(new Set(tempPaths).size).toBe(tempPaths.length);
+    } finally {
+      nowSpy.mockRestore();
+      uuidSpy.mockRestore();
+      writeFileSpy.mockRestore();
+    }
+  });
+});

--- a/src/node/runtime/muxSshConfigWriter.ts
+++ b/src/node/runtime/muxSshConfigWriter.ts
@@ -1,0 +1,254 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  MUX_CODER_HOST_SUFFIX,
+  MUX_CODER_SSH_BLOCK_END,
+  MUX_CODER_SSH_BLOCK_START,
+} from "@/constants/coder";
+
+interface EnsureMuxCoderSSHConfigFileOptions {
+  coderBinaryPath: string;
+  sshConfigPath?: string;
+}
+
+/**
+ * Quote a string for safe embedding in an SSH ProxyCommand directive.
+ * Uses double-quoting so the value works in both POSIX shells (/bin/sh -c)
+ * and Windows cmd.exe (/d /s /c). Single quotes are not recognized by cmd.exe.
+ *
+ * Matches the strategy from coder/vscode-coder's escapeCommandArg.
+ * Rejects paths containing newlines (would corrupt SSH config file format).
+ */
+function escapeCommandArg(arg: string): string {
+  if (arg.includes("\n") || arg.includes("\r")) {
+    throw new Error("Invalid coder binary path: newline characters are not allowed.");
+  }
+
+  // Escape embedded double quotes; wrap in double quotes.
+  // Backslashes preserved as-is (important for Windows paths like C:\Program Files\...).
+  const escaped = arg.replaceAll('"', String.raw`\"`);
+  return `"${escaped}"`;
+}
+
+function renderProxyCommand(coderBinaryPath: string): string {
+  const argv = [
+    coderBinaryPath,
+    "ssh",
+    "--stdio",
+    "--hostname-suffix",
+    MUX_CODER_HOST_SUFFIX,
+    "%h",
+  ];
+
+  return `ProxyCommand ${argv.map(escapeCommandArg).join(" ")}`;
+}
+
+function renderMuxBlock(coderBinaryPath: string): string {
+  return [
+    MUX_CODER_SSH_BLOCK_START,
+    `Host *.${MUX_CODER_HOST_SUFFIX}`,
+    "  ConnectTimeout 0",
+    "  LogLevel ERROR",
+    "  StrictHostKeyChecking no",
+    "  UserKnownHostsFile /dev/null",
+    `  ${renderProxyCommand(coderBinaryPath)}`,
+    MUX_CODER_SSH_BLOCK_END,
+  ].join("\n");
+}
+
+function countOccurrences(content: string, marker: string): number {
+  if (marker.length === 0) {
+    return 0;
+  }
+
+  return content.split(marker).length - 1;
+}
+
+function replaceMuxBlock(existingContent: string, nextMuxBlock: string): string {
+  const startMarkerIndex = existingContent.indexOf(MUX_CODER_SSH_BLOCK_START);
+  const endMarkerIndex = existingContent.indexOf(MUX_CODER_SSH_BLOCK_END, startMarkerIndex);
+
+  if (startMarkerIndex === -1 || endMarkerIndex === -1 || endMarkerIndex < startMarkerIndex) {
+    throw new Error("Corrupted SSH config: invalid Mux Coder SSH marker order.");
+  }
+
+  const lineStartIndex = existingContent.lastIndexOf("\n", startMarkerIndex);
+  const replaceStart = lineStartIndex === -1 ? 0 : lineStartIndex + 1;
+
+  const lineEndIndex = existingContent.indexOf("\n", endMarkerIndex);
+  const replaceEnd = lineEndIndex === -1 ? existingContent.length : lineEndIndex + 1;
+
+  const beforeBlock = existingContent.slice(0, replaceStart);
+  const afterBlock = existingContent.slice(replaceEnd);
+
+  if (afterBlock.length === 0) {
+    const blockHadTrailingNewline = lineEndIndex !== -1;
+    const suffix = blockHadTrailingNewline ? "\n" : "";
+    return `${beforeBlock}${nextMuxBlock}${suffix}`;
+  }
+
+  return `${beforeBlock}${nextMuxBlock}\n${afterBlock}`;
+}
+
+function appendMuxBlock(existingContent: string, nextMuxBlock: string): string {
+  if (existingContent.length === 0) {
+    return `${nextMuxBlock}\n`;
+  }
+
+  if (existingContent.endsWith("\n")) {
+    return `${existingContent}${nextMuxBlock}\n`;
+  }
+
+  return `${existingContent}\n${nextMuxBlock}\n`;
+}
+
+/**
+ * Manually follow a symlink chain to find the intended final target,
+ * even when the final target file doesn't exist yet (dangling).
+ * Throws on symlink loops (visited set check).
+ */
+async function followSymlinkChain(symlinkPath: string): Promise<string> {
+  const maxHops = 40; // SYMLOOP_MAX on most systems
+  let current = symlinkPath;
+  const visited = new Set<string>();
+
+  for (let i = 0; i < maxHops; i++) {
+    const target = await fs.readlink(current);
+    const resolved = path.resolve(path.dirname(current), target);
+
+    if (visited.has(resolved)) {
+      const err = new Error(`Symlink loop detected: ${resolved}`) as NodeJS.ErrnoException;
+      err.code = "ELOOP";
+      throw err;
+    }
+    visited.add(resolved);
+
+    try {
+      const stats = await fs.lstat(resolved);
+      if (!stats.isSymbolicLink()) {
+        return resolved;
+      }
+      current = resolved;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
+        return resolved;
+      }
+      throw error;
+    }
+  }
+
+  const err = new Error(`Too many levels of symbolic links: ${current}`) as NodeJS.ErrnoException;
+  err.code = "ELOOP";
+  throw err;
+}
+
+async function resolveSSHConfigWritePath(sshConfigPath: string): Promise<string> {
+  try {
+    const stats = await fs.lstat(sshConfigPath);
+    if (!stats.isSymbolicLink()) {
+      return sshConfigPath;
+    }
+
+    try {
+      // Fast path: realpath follows full chain when target exists.
+      return await fs.realpath(sshConfigPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
+        // Dangling symlink: target doesn't exist yet.
+        // Manually follow the chain to find the intended write target.
+        return await followSymlinkChain(sshConfigPath);
+      }
+      throw error;
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
+      // Path itself doesn't exist (not even as a symlink).
+      return sshConfigPath;
+    }
+
+    throw error;
+  }
+}
+
+async function loadSSHConfigContent(
+  sshConfigPath: string
+): Promise<{ content: string; mode: number }> {
+  try {
+    const [stats, content] = await Promise.all([
+      fs.stat(sshConfigPath),
+      fs.readFile(sshConfigPath, "utf8"),
+    ]);
+
+    return {
+      content,
+      mode: stats.mode & 0o777,
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
+      return {
+        content: "",
+        mode: 0o600,
+      };
+    }
+
+    throw error;
+  }
+}
+
+/** Collision-proof temp path: UUID nonce ensures uniqueness even when concurrent calls share a PID + timestamp. */
+function makeAtomicTempPath(sshConfigPath: string): string {
+  return `${sshConfigPath}.mux-tmp.${process.pid}.${Date.now()}.${crypto.randomUUID()}`;
+}
+
+async function writeConfigAtomically(
+  sshConfigPath: string,
+  content: string,
+  mode: number
+): Promise<void> {
+  const tempPath = makeAtomicTempPath(sshConfigPath);
+
+  try {
+    await fs.writeFile(tempPath, content, { encoding: "utf8", mode });
+    await fs.chmod(tempPath, mode);
+    await fs.rename(tempPath, sshConfigPath);
+  } catch (error) {
+    await fs.rm(tempPath, { force: true });
+    throw error;
+  }
+}
+
+export async function ensureMuxCoderSSHConfigFile(
+  opts: EnsureMuxCoderSSHConfigFileOptions
+): Promise<void> {
+  const configuredSSHConfigPath = opts.sshConfigPath ?? path.join(os.homedir(), ".ssh", "config");
+  // Preserve users' symlinked ~/.ssh/config setups by writing to the symlink target,
+  // rather than replacing the symlink path itself.
+  const sshConfigPath = await resolveSSHConfigWritePath(configuredSSHConfigPath);
+  const sshConfigDir = path.dirname(sshConfigPath);
+
+  await fs.mkdir(sshConfigDir, { recursive: true, mode: 0o700 });
+
+  const { content: existingContent, mode: existingMode } =
+    await loadSSHConfigContent(sshConfigPath);
+
+  const startMarkerCount = countOccurrences(existingContent, MUX_CODER_SSH_BLOCK_START);
+  const endMarkerCount = countOccurrences(existingContent, MUX_CODER_SSH_BLOCK_END);
+
+  if (startMarkerCount > 1 || endMarkerCount > 1) {
+    throw new Error("Corrupted SSH config: duplicate Mux Coder SSH markers detected.");
+  }
+
+  if (startMarkerCount !== endMarkerCount) {
+    throw new Error("Corrupted SSH config: mismatched Mux Coder SSH markers detected.");
+  }
+
+  const nextMuxBlock = renderMuxBlock(opts.coderBinaryPath);
+  const nextContent =
+    startMarkerCount === 1
+      ? replaceMuxBlock(existingContent, nextMuxBlock)
+      : appendMuxBlock(existingContent, nextMuxBlock);
+
+  await writeConfigAtomically(sshConfigPath, nextContent, existingMode);
+}

--- a/src/node/runtime/runtimeFactory.ts
+++ b/src/node/runtime/runtimeFactory.ts
@@ -16,6 +16,7 @@ import type { CoderService } from "@/node/services/coderService";
 import { Config } from "@/node/config";
 import { checkDevcontainerCliVersion } from "./devcontainerCli";
 import { buildDevcontainerConfigInfo, scanDevcontainerConfigs } from "./devcontainerConfigs";
+import { resolveCoderSSHHost } from "@/constants/coder";
 import { getErrorMessage } from "@/common/utils/errors";
 
 // Re-export for backward compatibility with existing imports
@@ -159,8 +160,11 @@ export function createRuntime(config: RuntimeConfig, options?: CreateRuntimeOpti
       });
 
     case "ssh": {
+      // Normalize Coder host before transport creation so both transport
+      // and runtime use the canonical *.mux--coder hostname from the start.
+      const sshHost = resolveCoderSSHHost(config.host, config.coder?.workspaceName);
       const sshConfig = {
-        host: config.host,
+        host: sshHost,
         srcBaseDir: config.srcBaseDir,
         bgOutputDir: config.bgOutputDir,
         identityFile: config.identityFile,

--- a/src/node/runtime/sshConfigParser.test.ts
+++ b/src/node/runtime/sshConfigParser.test.ts
@@ -14,21 +14,21 @@ describe("resolveSSHConfig", () => {
       await fs.mkdir(path.join(tempDir, ".ssh"), { recursive: true });
 
       const config = [
-        "Host *.coder",
+        "Host *.mux--coder",
         "  User coder-user",
         "  UserKnownHostsFile /dev/null",
         "",
-        'Match host *.coder !exec "exit 1"',
+        'Match host *.mux--coder !exec "exit 1"',
         "  ProxyCommand /usr/local/bin/coder --stdio %h",
         "",
       ].join("\n");
 
       await fs.writeFile(path.join(tempDir, ".ssh", "config"), config, "utf8");
 
-      const resolved = await resolveSSHConfig("pog2.coder");
+      const resolved = await resolveSSHConfig("pog2.mux--coder");
 
       expect(resolved.user).toBe("coder-user");
-      expect(resolved.hostName).toBe("pog2.coder");
+      expect(resolved.hostName).toBe("pog2.mux--coder");
       expect(resolved.proxyCommand).toBe("/usr/local/bin/coder --stdio %h");
     } finally {
       if (previousUserProfile === undefined) {

--- a/src/node/services/serviceContainer.ts
+++ b/src/node/services/serviceContainer.ts
@@ -304,10 +304,10 @@ export class ServiceContainer {
     // Start idle compaction checker
     this.idleCompactionService.start();
 
-    // Refresh Coder SSH config in background (handles binary path changes on restart)
+    // Refresh mux-owned Coder SSH config in background (handles binary path changes on restart)
     // Skip getCoderInfo() to avoid caching "unavailable" if coder isn't installed yet
-    void this.coderService.ensureSSHConfig().catch(() => {
-      // Ignore errors - coder may not be installed
+    void this.coderService.ensureMuxCoderSSHConfig().catch((error: unknown) => {
+      log.warn("Background mux SSH config setup failed", { error });
     });
 
     // Ensure the built-in Chat with Mux system workspace exists.

--- a/src/node/utils/paths.test.ts
+++ b/src/node/utils/paths.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { PlatformPaths } from "./paths.main";
-import { toPosixPath } from "./paths";
+import { toPosixPath, toWindowsPath } from "./paths";
 import * as os from "os";
 import * as path from "path";
 
@@ -234,5 +234,27 @@ describe("toPosixPath", () => {
       // This prevents crashes if Git Bash is misconfigured
       expect(true).toBe(true); // Cannot easily test without mocking execSync
     });
+  });
+});
+
+describe("toWindowsPath", () => {
+  test("converts MSYS drive-letter path to Windows format", () => {
+    expect(toWindowsPath("/c/Users/me/coder.exe")).toBe("C:\\Users\\me\\coder.exe");
+  });
+
+  test("uppercases the drive letter", () => {
+    expect(toWindowsPath("/d/Program Files/Coder/coder.exe")).toBe(
+      "D:\\Program Files\\Coder\\coder.exe"
+    );
+  });
+
+  test("returns non-MSYS paths unchanged", () => {
+    expect(toWindowsPath("/usr/local/bin/coder")).toBe("/usr/local/bin/coder");
+    expect(toWindowsPath("C:\\Users\\me\\coder.exe")).toBe("C:\\Users\\me\\coder.exe");
+    expect(toWindowsPath("coder")).toBe("coder");
+  });
+
+  test("handles root of drive", () => {
+    expect(toWindowsPath("/c/coder.exe")).toBe("C:\\coder.exe");
   });
 });

--- a/src/node/utils/paths.ts
+++ b/src/node/utils/paths.ts
@@ -18,3 +18,20 @@ export function toPosixPath(windowsPath: string): string {
     return windowsPath;
   }
 }
+
+/**
+ * Convert an MSYS/Cygwin-style path to a native Windows path.
+ * Recognizes the `/x/...` convention (single drive letter after leading slash).
+ * Non-MSYS paths (already native, or relative) are returned unchanged.
+ *
+ * Use this when a command resolved in Git Bash needs to be written into
+ * a context that runs under cmd.exe (e.g., SSH ProxyCommand).
+ */
+export function toWindowsPath(msysPath: string): string {
+  // Match MSYS drive-letter convention: /c/Users/... → C:\Users\...
+  const match = /^\/([a-zA-Z])\/(.*)$/.exec(msysPath);
+  if (!match) return msysPath;
+  const drive = match[1].toUpperCase();
+  const rest = match[2].replaceAll("/", "\\");
+  return `${drive}:\\${rest}`;
+}

--- a/tests/runtime/runtime.test.ts
+++ b/tests/runtime/runtime.test.ts
@@ -2278,7 +2278,7 @@ describeIntegration("Runtime integration tests", () => {
             createWorkspaceCalled = true;
             yield "should not happen";
           },
-          ensureSSHConfig: async () => {
+          ensureMuxCoderSSHConfig: async () => {
             // This SHOULD be called - it's safe and idempotent
           },
           getWorkspaceStatus: () =>


### PR DESCRIPTION
## Summary

Implements a mux-managed SSH config writer for Coder workspaces and migrates the SSH hostname suffix from `.mux.coder` → `.mux--coder` to fix a glob collision where user `Host *.coder` entries match mux's dotted hosts.

## Background

Coder workspaces need a `Host *.mux--coder` SSH config block with a `ProxyCommand` that routes connections through `coder ssh`. Previously mux used a dotted suffix (`.mux.coder`) that collided with user-managed `Host *.coder` SSH entries. The new double-dash suffix (`mux--coder`) is hostname-safe and avoids glob collisions by construction.

## Implementation

### SSH Config Writer (`muxSshConfigWriter.ts`, ~240 LoC)
- Atomic writes via temp + rename to prevent partial config corruption
- Full symlink chain resolution (`fs.realpath()` for live targets, `followSymlinkChain()` for dangling symlinks with loop detection)
- Collision-proof temp paths via `crypto.randomUUID()` nonce
- Cross-platform double-quote escaping for `ProxyCommand` argv (works in both `/bin/sh -c` and Windows `cmd.exe /d /s /c`; matches `coder/vscode-coder`'s `escapeCommandArg` strategy)
- Mode-preserving writes; creates `~/.ssh/config` with `0o600` if missing

### Host Normalization
- Shared `resolveCoderSSHHost()` helper in `src/constants/coder.ts` normalizes host from `workspaceName` when present
- **Factory-level normalization**: `runtimeFactory.ts` normalizes host *before* creating `SSHTransport`, ensuring transport and runtime use the same canonical `*.mux--coder` hostname
- `CoderSSHRuntime` constructor reuses the same helper (no drift between factory and constructor paths)

### Windows Path Normalization
- `resolveCoderBinaryPath()` now prefers `where.exe coder` on Windows for native paths
- Falls back to Git Bash `command -v coder` + MSYS→Windows path conversion (`toWindowsPath()`) when `where.exe` fails
- Prevents MSYS paths like `/c/Users/.../coder.exe` from reaching `ProxyCommand`, which executes via `cmd.exe`

### Auth Preflight for Existing Workspaces
- Added `coderService.verifyAuthenticatedSession()` — performs a fresh (uncached) `coder whoami` check
- `CoderSSHRuntime.finalizeConfig` now calls auth preflight for **both** new and existing workspace flows, before the `ensureProvisioningSession` gate
- Restores fail-fast behavior: if Coder auth is expired/logged out, workspace creation returns `Err` before metadata is persisted, preventing unusable workspace entries
- `ensureProvisioningSession` remains gated to new workspaces only (token reuse unchanged)

### Integration
- `ensureMuxCoderSSHConfig()` in CoderService writes the config block, with early-return guard when coder binary unavailable
- `serviceContainer.ts` logs background failures via `log.warn` instead of swallowing them silently

### Test Coverage (30+ tests)
- `muxSshConfigWriter.test.ts`: empty config, mode preservation, symlink preservation (single/multi/dangling), append/replace, idempotency, shell metacharacters, double-quote escaping, Windows-style backslash paths, collision-proof temps, marker validation
- `CoderSSHRuntime.test.ts`: auth preflight failure for existing workspaces, `ensureProvisioningSession` not called for existing workspaces
- `coderService.test.ts`: skip-when-null, write-when-resolved, Windows path normalization pass-through, `verifyAuthenticatedSession` success/failure
- `runtimeFactory.test.ts`: regression test verifying legacy `.coder` host + `workspaceName` produces canonical `*.mux--coder` for both runtime config and underlying transport
- `paths.test.ts`: `toWindowsPath` unit tests (MSYS conversion, drive-letter uppercasing, non-MSYS passthrough)

## Risks

- **Low**: atomic write + symlink resolution is well-tested but unusual `~/.ssh/config` setups (e.g., SELinux-restricted paths) could hit edge cases
- **Low**: the host suffix change affects only new SSH connections; existing running sessions are unaffected

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$40.89`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=40.89 -->
