### PR TITLE
🤖 fix: humanize timing distribution duration labels

### DIFF
--- a/src/browser/components/analytics/TimingChart.tsx
+++ b/src/browser/components/analytics/TimingChart.tsx
@@ -41,16 +41,41 @@ interface TimingChartProps {
   onMetricChange: (metric: TimingMetric) => void;
 }
 
+// Keep timing labels readable for long responses; raw millisecond counts become hard to parse.
+function formatDurationForChart(ms: number): string {
+  if (!Number.isFinite(ms)) {
+    return "0ms";
+  }
+
+  const normalizedMs = Math.max(0, ms);
+  if (normalizedMs < 1_000) {
+    return `${Math.round(normalizedMs)}ms`;
+  }
+
+  if (normalizedMs < 10_000) {
+    return `${(normalizedMs / 1_000).toFixed(1)}s`;
+  }
+
+  if (normalizedMs < 60_000) {
+    return `${Math.round(normalizedMs / 1_000)}s`;
+  }
+
+  if (normalizedMs < 3_600_000) {
+    const minutes = normalizedMs / 60_000;
+    return minutes < 10 ? `${minutes.toFixed(1)}m` : `${Math.round(minutes)}m`;
+  }
+
+  const hours = normalizedMs / 3_600_000;
+  return hours < 10 ? `${hours.toFixed(1)}h` : `${Math.round(hours)}h`;
+}
+
 function formatMetricValue(value: number, metric: TimingMetric): string {
-  if (!Number.isFinite(value)) {
-    return `0${METRIC_LABELS[metric].unitSuffix}`;
-  }
-
   if (metric === "tps") {
-    return `${value.toFixed(2)}${METRIC_LABELS[metric].unitSuffix}`;
+    const normalizedTps = Number.isFinite(value) ? Math.max(0, value) : 0;
+    return `${normalizedTps.toFixed(2)}${METRIC_LABELS[metric].unitSuffix}`;
   }
 
-  return `${Math.round(value)}${METRIC_LABELS[metric].unitSuffix}`;
+  return formatDurationForChart(value);
 }
 
 export function TimingChart(props: TimingChartProps) {


### PR DESCRIPTION
## Summary
Switch analytics Timing distribution labels for TTFT/Duration from raw milliseconds to adaptive human-readable units (`ms`/`s`/`m`/`h`).

## Background
Very large response durations were shown as values like `1870915ms` and `10000000ms`, which are difficult to parse quickly in chart axes and percentile summaries.

## Implementation
- Added `formatDurationForChart` in `src/browser/components/analytics/TimingChart.tsx`.
- Updated `formatMetricValue` to route TTFT/Duration through the new formatter while keeping TPS formatting unchanged.
- Reused the formatter for:
  - x-axis tick labels
  - tooltip bucket labels
  - p50/p90/p99 summary values

## Validation
- `make static-check`

## Risks
Low risk and isolated to analytics display formatting in `TimingChart`. No data model or IPC changes.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.46`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.46 -->
