### PR TITLE
🤖 fix: improve analytics top bar layout on mobile

### DIFF
--- a/src/browser/components/analytics/AnalyticsDashboard.tsx
+++ b/src/browser/components/analytics/AnalyticsDashboard.tsx
@@ -162,16 +162,16 @@ export function AnalyticsDashboard(props: AnalyticsDashboardProps) {
       <div
         data-testid="analytics-header"
         className={cn(
-          "bg-sidebar border-border-light titlebar-safe-right titlebar-safe-right-gutter-3 flex shrink-0 flex-wrap items-center gap-2 border-b px-3",
+          "bg-sidebar border-border-light titlebar-safe-right titlebar-safe-right-gutter-3 flex shrink-0 items-center gap-2 border-b px-3",
           desktopMode
-            ? `${DESKTOP_TITLEBAR_HEIGHT_CLASS} titlebar-drag`
-            : "py-2 md:h-8 md:flex-nowrap md:py-0"
+            ? `${DESKTOP_TITLEBAR_HEIGHT_CLASS} titlebar-drag flex-nowrap`
+            : "flex-wrap py-2 md:h-8 md:flex-nowrap md:py-0"
         )}
       >
         <div
           className={cn(
-            "flex min-w-0 w-full items-center gap-2 md:w-auto",
-            desktopMode && "titlebar-no-drag"
+            "flex min-w-0 items-center gap-2",
+            desktopMode ? "w-auto titlebar-no-drag" : "w-full md:w-auto"
           )}
         >
           {props.leftSidebarCollapsed && (
@@ -202,8 +202,9 @@ export function AnalyticsDashboard(props: AnalyticsDashboardProps) {
 
         <div
           className={cn(
-            "flex w-full min-w-0 flex-wrap items-center gap-2 md:ml-auto md:w-auto md:min-w-fit md:flex-nowrap",
-            desktopMode && "titlebar-no-drag"
+            desktopMode
+              ? "titlebar-no-drag ml-auto flex min-w-fit items-center gap-2"
+              : "flex w-full min-w-0 flex-wrap items-center gap-2 md:ml-auto md:w-auto md:min-w-fit md:flex-nowrap"
           )}
         >
           {/* Keep the project control labeled on mobile for screen readers while

--- a/tests/ui/layout/analyticsHeader.test.ts
+++ b/tests/ui/layout/analyticsHeader.test.ts
@@ -74,6 +74,7 @@ describe("Analytics header titlebar contract", () => {
       expect(header.classList.contains("titlebar-safe-right")).toBe(true);
       expect(header.classList.contains("titlebar-safe-right-gutter-3")).toBe(true);
       expect(header.classList.contains("h-9")).toBe(true);
+      expect(header.classList.contains("flex-nowrap")).toBe(true);
       expect(header.classList.contains("titlebar-drag")).toBe(true);
     } finally {
       clearDesktopApi();
@@ -92,6 +93,7 @@ describe("Analytics header titlebar contract", () => {
       expect(header.classList.contains("titlebar-safe-right")).toBe(true);
       expect(header.classList.contains("titlebar-safe-right-gutter-3")).toBe(true);
       expect(header.classList.contains("h-9")).toBe(true);
+      expect(header.classList.contains("flex-nowrap")).toBe(true);
       expect(header.classList.contains("titlebar-drag")).toBe(true);
     } finally {
       clearDesktopApi();


### PR DESCRIPTION
## Summary
Improve the analytics/stats header layout on small screens so controls no longer overlap, while preserving desktop header behavior and accessibility.

## Background
The previous header forced back navigation, title, project filter, and range controls into a single fixed-height row. On mobile widths, these controls collided and rendered unreadably.

## Implementation
- Enabled wrapping on the analytics header container for non-desktop mode.
- Replaced fixed browser/mobile header height with responsive vertical padding on small screens.
- Made the left section (`Back` + `Analytics`) occupy full width on browser/mobile to push filters to a second line.
- Kept desktop mode single-row by explicitly applying `flex-nowrap` and desktop-only width behavior for header sections.
- Made the right controls row responsive with wrapping and constrained sizing only in browser/mobile mode.
- Kept the `Project` label available to assistive tech on mobile via `sr-only` (and visible again at `md+`).
- Updated analytics header UI contract tests to reflect the new responsive classes and desktop single-row behavior.

## Validation
- `make static-check`
- `TEST_INTEGRATION=1 bun x jest --silent tests/ui/layout/analyticsHeader.test.ts`

## Risks
Low. This change is scoped to analytics header layout classes and corresponding UI test expectations in one area. Desktop titlebar contracts (`h-9`, drag classes, single-row layout) remain explicitly asserted.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.49`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.49 -->
