### PR TITLE
🤖 fix: preserve descendant partial progress on cascade interrupt

### DIFF
--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -1905,12 +1905,12 @@ describe("TaskService", () => {
     expect(stopStream).toHaveBeenNthCalledWith(
       1,
       childTaskId,
-      expect.objectContaining({ abandonPartial: true })
+      expect.objectContaining({ abandonPartial: false })
     );
     expect(stopStream).toHaveBeenNthCalledWith(
       2,
       parentTaskId,
-      expect.objectContaining({ abandonPartial: true })
+      expect.objectContaining({ abandonPartial: false })
     );
     expect(callOrder).toEqual([
       `clear:${childTaskId}`,

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -1214,9 +1214,10 @@ export class TaskService {
           log.debug("terminateAllDescendantAgentTasks: clearQueue threw", { taskId: id, error });
         }
 
-        // Best-effort: stop any active stream immediately to avoid further token usage.
+        // Best-effort: stop any active stream immediately to avoid further token usage
+        // while preserving commit-worthy partial progress for inspection/resume.
         try {
-          const stopResult = await this.aiService.stopStream(id, { abandonPartial: true });
+          const stopResult = await this.aiService.stopStream(id, { abandonPartial: false });
           if (!stopResult.success) {
             log.debug("terminateAllDescendantAgentTasks: stopStream failed", { taskId: id });
           }


### PR DESCRIPTION
## Summary

Preserve descendant subagent partial progress when a parent workspace is cascade-interrupted, instead of silently discarding all in-stream work.

## Background

When a user hard-interrupts a parent workspace, `terminateAllDescendantAgentTasks` cascades to all descendant subagents. The cascade was originally introduced as destructive termination (stop + remove workspaces), and used `abandonPartial: true` to discard in-flight work.

A follow-up commit (`e2bfd1912`) changed the cascade to preserve interrupted workspaces on disk for inspection/resume, but left the `abandonPartial: true` flag unchanged. This created a mismatch: the workspace is preserved, but all in-stream partial progress (completed tool calls, text output) in `partial.json` is silently deleted without being committed to `chat.jsonl`.

In practice, a subagent that had completed many tool calls within a single stream (before any stream-end) would lose *all* of that work when the parent was interrupted — only the initial prompt survived.

## Implementation

Single-flag change in `terminateAllDescendantAgentTasks`: `abandonPartial: true` → `abandonPartial: false`.

With `abandonPartial: false`, the existing `stream-abort` handler in `aiService.ts` calls `commitPartial()` before `deletePartial()`, which persists any commit-worthy parts (completed tool calls, text/reasoning content) to `chat.jsonl`.

The destructive `terminateDescendantAgentTask` path (which removes workspaces entirely) is unchanged and still uses `abandonPartial: true`.

## Risks

Low. The `commitPartial` path is already exercised by normal user interrupts (Escape) and is well-tested. The only behavioral change is that cascade-interrupted descendants now retain their partial progress, which aligns with the existing intent of preserving interrupted workspaces.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$10.80`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=10.80 -->
