### PR TITLE
🤖 fix: serve UI at / in bundled Docker server mode

### DIFF
--- a/src/node/orpc/server.ts
+++ b/src/node/orpc/server.ts
@@ -444,7 +444,8 @@ export async function createOrpcServer({
   context,
   serveStatic = false,
   allowHttpOrigin = false,
-  // From dist/node/orpc/, go up 2 levels to reach dist/ where index.html lives
+  // Default for non-bundled mode: from dist/node/orpc/, go up 2 levels to dist/.
+  // In bundled mode (dist/runtime/), serverService computes the static dir.
   staticDir = path.join(__dirname, "../.."),
   onOrpcError = (error, options) => {
     // Auth failures are expected in browser mode while the user enters the token.


### PR DESCRIPTION
Summary
Fix static asset directory resolution for server mode so Docker-bundled runtime serves the frontend UI at `/` instead of returning 404.

Background
In bundled Docker runtime, `__dirname` resolves to `dist/runtime/`, but static path resolution assumed non-bundled layout and pointed one directory too high, disabling static serving when `index.html` was not found.

Implementation
- Updated `ServerService.startServer` to probe static dir candidates for both non-bundled and bundled runtime layouts.
- Kept defensive behavior: static serving remains disabled (with warning) when `index.html` is missing.
- Clarified `createOrpcServer` default static dir comment to distinguish non-bundled default from bundled behavior delegated to server service.

Validation
- `make static-check`
- `bun test src/node/services/serverService.test.ts`
- `bun test src/cli/server.test.ts`
- `docker buildx build --load -t mux-ui-root-fix .`
- Container endpoint checks:
  - `GET /` returns 200 and includes `<!doctype html` + `id="root"`
  - `GET /health` returns 200
  - `GET /api/docs` returns 200

Risks
Low risk. Change is isolated to static-dir detection during server startup and only affects static UI enablement logic. API routing behavior is unchanged.

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Serve Frontend UI at `/` in Docker Server Mode

## Context & Why

The Docker image runs `node dist/runtime/server-bundle.js` — an esbuild-bundled CJS file.
API routes work (`/health`, `/api/docs`) but `GET /` returns 404 because the server
**silently disables** static file serving due to an incorrect path computation.

## Root Cause

In `src/node/services/serverService.ts` (line 242):

```ts
const staticDir = path.join(__dirname, "../..");
```

| Mode | `__dirname` resolves to | `../..` resolves to | `index.html` at | Result |
|---|---|---|---|---|
| **Non-bundled** (Electron) | `dist/node/services/` | `dist/` | `dist/index.html` | ✅ Found |
| **Bundled** (Docker) | `dist/runtime/` | project root (`/app/`) | `/app/dist/index.html` | ❌ Not found |

When `fs.access(path.join(staticDir, "index.html"))` fails, line 249 logs a warning and
sets `serveStatic = false`, so no `express.static()` middleware and no SPA fallback are registered.

The same incorrect comment+path exists in `createOrpcServer`'s default parameter (line 447–448),
though it's always overridden by `serverService` in production.

## Fix

**File: `src/node/services/serverService.ts`** (~+10 LoC net)

Replace the fixed two-level `__dirname` walk with a candidate search that handles both layouts:

```ts
// Resolve the static assets directory (dist/) containing the frontend build.
// Non-bundled (Electron):  __dirname = dist/node/services/ → 2 levels up
// Bundled (Docker):        __dirname = dist/runtime/       → 1 level up
const staticDirCandidates = [
  path.join(__dirname, "../.."), // non-bundled: dist/node/services/ → dist/
  path.join(__dirname, ".."),    // bundled:     dist/runtime/       → dist/
];

let staticDir: string | undefined;
if (options.serveStatic) {
  for (const candidate of staticDirCandidates) {
    try {
      await fs.access(path.join(candidate, "index.html"));
      staticDir = candidate;
      break;
    } catch {
      // try next candidate
    }
  }
  if (!staticDir) {
    log.warn(
      `Static UI requested but index.html not found near ${__dirname}. Disabling.`
    );
  }
}
const serveStatic = !!staticDir;
```

**File: `src/node/orpc/server.ts`** (line 447–448, comment-only fix, ~0 net LoC)

Fix the misleading comment on the default `staticDir` parameter:

```ts
// Default for non-bundled mode: from dist/node/orpc/, go up 2 levels to dist/.
// In bundled mode (dist/runtime/), serverService computes the correct path.
staticDir = path.join(__dirname, "../.."),
```

## What Does NOT Change

- All existing API routes (`/api/*`, `/orpc/*`, `/health`, `/version`, `/api/docs`).
- Tokenizer worker resolution (uses its own `__dirname`-based logic in `workerPool.ts`).
- SPA fallback middleware logic (already correctly skips `/api` and `/orpc` prefixes).
- Dockerfile, Makefile, or build pipeline — no changes needed.
- Electron (non-bundled) mode — the first candidate (`../..`) still matches.

## Validation

```bash
# 1. Static checks
make static-check

# 2. Build Docker image
docker buildx build --load -t mux-ui-root-fix .

# 3. Run container, verify endpoints
docker run --rm -d -p 3000:3000 --name mux-test mux-ui-root-fix
curl -s -o /dev/null -w '%{http_code}' http://localhost:3000/          # expect 200
curl -s -o /dev/null -w '%{http_code}' http://localhost:3000/health    # expect 200
curl -s -o /dev/null -w '%{http_code}' http://localhost:3000/api/docs  # expect 200
# Check container logs for MODULE_NOT_FOUND (should be absent)
docker logs mux-test 2>&1 | grep -i 'MODULE_NOT_FOUND' || echo "No tokenizer errors"
docker stop mux-test

# 4. Run existing server tests
bun test src/cli/server.test.ts
bun test src/node/services/serverService.test.ts
```

## Estimated Impact

- **~10 LoC** net change (product code only)
- 2 files touched, both in server-side path resolution


</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh`_

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$1.59`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=1.59 -->
