### PR TITLE
🤖 ci: propagate RELEASE_TAG into Docker release builds

### DIFF
--- a/.github/workflows/_docker-release.yml
+++ b/.github/workflows/_docker-release.yml
@@ -67,3 +67,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ inputs.version }}
+            RELEASE_TAG=${{ startsWith(inputs.version, 'v') && inputs.version || format('v{0}', inputs.version) }}


### PR DESCRIPTION
## Summary
Improve Docker release build correctness and address key Depot Dockerfile diagnostics.

## Background
Docker release images were tagged correctly in GHCR, but the in-app/version stamp inside the image did not receive the release/nightly tag because `RELEASE_TAG` was not passed into the Docker build stage. Depot also flagged two low-friction Dockerfile issues worth addressing (`--no-install-recommends` and `A && B || C` fallback scoping).

## Implementation
- Dockerfile
  - Added `--no-install-recommends` to both apt install invocations (builder + runtime stages).
  - Scoped the synthetic git commit fallback to commit only:
    - `(... git commit ... || true)`
  - Added `ARG RELEASE_TAG` in the builder stage.
  - Threaded `RELEASE_TAG` into the build step:
    - `RUN RELEASE_TAG="${RELEASE_TAG}" make verify-docker-runtime-artifacts`
- Reusable Docker release workflow (`.github/workflows/_docker-release.yml`)
  - Added a `RELEASE_TAG` build arg to Depot build-push action.
  - Normalizes input to `v`-prefixed tags so both stable and nightly pipelines stamp the expected tag into `src/version.ts`.

## Validation
- `make static-check`

## Risks
- Low risk: change is limited to Docker build/release wiring and install flags.
- Main behavior change is intentional: release/nightly tag now propagates into generated version metadata used by UI/server surfaces.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.66`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.66 -->
