### PR TITLE
🤖 fix: change Electron appId to com.coder.mux

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
     "LICENSE"
   ],
   "build": {
-    "appId": "com.mux.app",
+    "appId": "com.coder.mux",
     "productName": "mux",
     "protocols": [
       {


### PR DESCRIPTION
## Summary

Change the Electron Builder application identifier from `com.mux.app` to `com.coder.mux`.

## Background

The current app ID uses the legacy `com.mux.app` identifier. This PR updates branding alignment to `com.coder.mux`.

## Implementation

- Updated `build.appId` in `package.json`:
  - `com.mux.app` → `com.coder.mux`

## Validation

- `make static-check`

## Risks

**Potentially breaking for existing installs.** Changing Electron Builder `appId` can affect OS-level app identity and update continuity:
- macOS: bundle identifier (`CFBundleIdentifier`)
- Windows: AUMID / NSIS identity

Existing installations that were distributed with `com.mux.app` may require reinstall/migration handling instead of seamless in-place updates.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.28`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.28 -->
