### PR TITLE
🤖 fix: process carriage returns in git clone progress output

### DIFF
--- a/src/browser/components/ProjectCreateModal.tsx
+++ b/src/browser/components/ProjectCreateModal.tsx
@@ -344,7 +344,12 @@ function processTerminalOutput(raw: string): string {
     .split("\n")
     .map((line) => {
       const segments = line.split("\r");
-      return segments[segments.length - 1];
+      // When a chunk ends with \r, the last segment is empty — use the
+      // last non-empty segment so in-flight progress lines stay visible.
+      for (let i = segments.length - 1; i >= 0; i--) {
+        if (segments[i] !== "") return segments[i];
+      }
+      return "";
     })
     .join("\n");
 }


### PR DESCRIPTION
## Summary

Fix the "Add Project" → "Clone repo" dialog to properly handle terminal carriage returns (`\r`) in git clone progress output, replacing the unreadable wall of concatenated percentage updates with clean, human-readable progress lines.

## Background

Git uses `\r` (carriage return) to overwrite the current terminal line with updated percentages during clone operations. In HTML `<pre>` blocks, `\r` has no effect — so every progress tick concatenates instead of replacing the previous one. The result is an unreadable wall of text like `Resolving deltas: 93% (134787/146506)Resolving deltas: 94% (136251/...`.

## Implementation

All changes are in `src/browser/components/ProjectCreateModal.tsx`:

- Added `processTerminalOutput()` utility that simulates terminal CR handling: splits on `\n`, then for each line keeps only the text after the last `\r`.
- Replaced the `progressLines: string[]` chunk-array state with a single `cloneOutput: string` state and a `rawOutputRef` accumulator ref.
- On each streamed progress chunk, append to the ref and derive the display string through `processTerminalOutput()`.
- Removed the 1000-chunk cap (no longer needed — single string accumulation is bounded by git's total stderr output).

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$0.67`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=0.67 -->
