### PR TITLE
🤖 fix: generate patch artifacts for orchestrator-applied patches

### DIFF
--- a/src/common/utils/agentTools.test.ts
+++ b/src/common/utils/agentTools.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  isExecLikeEditingCapableInResolvedChain,
+  isToolEnabledInResolvedChain,
+} from "./agentTools";
+
+describe("isExecLikeEditingCapableInResolvedChain", () => {
+  it("returns true when exec chain enables file_edit_insert", () => {
+    const agents = [{ id: "exec", tools: { add: ["file_edit_insert"] } }];
+
+    expect(isExecLikeEditingCapableInResolvedChain(agents)).toBe(true);
+  });
+
+  it("returns true when exec chain enables file_edit_replace_string", () => {
+    const agents = [{ id: "exec", tools: { add: ["file_edit_replace_string"] } }];
+
+    expect(isExecLikeEditingCapableInResolvedChain(agents)).toBe(true);
+  });
+
+  it("returns false when exec chain enables neither edit nor patch-apply tools", () => {
+    const agents = [{ id: "exec", tools: { add: ["task"] } }];
+
+    expect(isExecLikeEditingCapableInResolvedChain(agents)).toBe(false);
+  });
+
+  it("returns false when chain does not inherit exec", () => {
+    const agents = [{ id: "orchestrator", tools: { add: ["file_edit_insert"] } }];
+
+    expect(isExecLikeEditingCapableInResolvedChain(agents)).toBe(false);
+  });
+
+  it("returns true for orchestrator-style chains that remove file_edit tools but keep patch apply", () => {
+    const agents = [
+      {
+        id: "orchestrator",
+        tools: {
+          add: ["ask_user_question"],
+          remove: ["propose_plan", "file_edit_.*"],
+        },
+      },
+      {
+        id: "exec",
+        tools: {
+          add: [".*"],
+          remove: ["propose_plan", "ask_user_question", "system1_keep_ranges"],
+        },
+      },
+    ];
+
+    expect(isToolEnabledInResolvedChain("file_edit_insert", agents)).toBe(false);
+    expect(isToolEnabledInResolvedChain("file_edit_replace_string", agents)).toBe(false);
+    expect(isToolEnabledInResolvedChain("task_apply_git_patch", agents)).toBe(true);
+    expect(isExecLikeEditingCapableInResolvedChain(agents)).toBe(true);
+  });
+
+  it("returns false when task_apply_git_patch is enabled without exec inheritance", () => {
+    const agents = [{ id: "orchestrator", tools: { add: ["task_apply_git_patch"] } }];
+
+    expect(isExecLikeEditingCapableInResolvedChain(agents)).toBe(false);
+  });
+});

--- a/src/common/utils/agentTools.ts
+++ b/src/common/utils/agentTools.ts
@@ -137,6 +137,8 @@ export function isExecLikeEditingCapableInResolvedChain(
 
   return (
     isToolEnabledInResolvedChain("file_edit_insert", agents, maxDepth) ||
-    isToolEnabledInResolvedChain("file_edit_replace_string", agents, maxDepth)
+    isToolEnabledInResolvedChain("file_edit_replace_string", agents, maxDepth) ||
+    // Orchestrator-like agents can still modify their workspace by applying child patches.
+    isToolEnabledInResolvedChain("task_apply_git_patch", agents, maxDepth)
   );
 }


### PR DESCRIPTION
Summary
This PR fixes a patch-artifact generation gap for orchestrator-style agents that apply child patches instead of editing files directly.

Background
`isExecLikeEditingCapableInResolvedChain` only treated direct file-edit tools as workspace-modifying capabilities. Orchestrator agents remove `file_edit_.*` by design, so they were incorrectly excluded even though they can mutate worktrees via `task_apply_git_patch`, causing patch artifacts to be skipped.

Implementation
- Extended `isExecLikeEditingCapableInResolvedChain` to treat `task_apply_git_patch` as an editing-capable signal (while still requiring exec inheritance).
- Added targeted unit tests in `src/common/utils/agentTools.test.ts` covering direct-edit, patch-apply, and non-exec combinations.

Validation
- `bun test src/common/utils/agentTools.test.ts`
- `make typecheck`
- `make static-check`

Risks
Low risk and narrowly scoped to agent tool-capability detection logic; test coverage now asserts the intended orchestrator behavior.

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix: Orchestrator sub-agents silently lose patch artifacts

## Context / Why

When a **plan** sub-agent hands off to an **orchestrator** (via `propose_plan` → auto-handoff), the orchestrator applies patches from its exec children into its own worktree using `task_apply_git_patch`. However, when the orchestrator itself reports completion, **no patch artifact is generated** for its parent workspace. The worktree is then cleaned up, and all accumulated commits are permanently lost.

This has been observed at least twice in production plan-agent workflows. The parent agent receives a successful report but has no patch to apply — the implementation is simply gone.

## Root Cause

Three pieces combine to create the bug:

1. **In-place handoff** (`taskService.ts:2719`): `handleSuccessfulProposePlanAutoHandoff` mutates the workspace `agentId` from `"plan"` → `"orchestrator"` on the *same* workspace. No new sub-agent is spawned.

2. **Orchestrator removes editing tools** (`orchestrator.md`): The agent config has `remove: [file_edit_.*]` to enforce delegation — correct for its coordination role.

3. **Patch generation gate is too narrow** (`agentTools.ts:129`): `isExecLikeEditingCapableInResolvedChain` requires `file_edit_insert` or `file_edit_replace_string` to be enabled. Orchestrator fails this check → `maybeStartGeneration` returns early → no `.mbox` artifact.

## Evidence

| File | Line(s) | Finding |
|---|---|---|
| `src/common/utils/agentTools.ts` | 129-142 | Gate checks only `file_edit_insert` / `file_edit_replace_string` |
| `src/node/services/gitPatchArtifactService.ts` | 107, 150, 159 | `shouldGeneratePatch` defaults false; only set true by the gate |
| `src/node/builtinAgents/orchestrator.md` | tools section | `remove: [file_edit_.*]` strips all editing tools |
| `src/node/services/taskService.ts` | ~2719 | In-place handoff: `workspace.agentId = targetAgentId` |
| `src/node/services/agentSession.ts` | 3255 | Second callsite: context-limit hard-restart also gated |

## Fix

### Approach: Expand the gate to include `task_apply_git_patch`

The predicate `isExecLikeEditingCapableInResolvedChain` should also consider agents that have `task_apply_git_patch` enabled, since those agents modify the worktree through patch application even without direct file editing tools.

**~3 LoC change** (product code), plus tests.

### 1. `src/common/utils/agentTools.ts` — expand `isExecLikeEditingCapableInResolvedChain`

```typescript
export function isExecLikeEditingCapableInResolvedChain(
  agents: ReadonlyArray<ToolsConfigCarrier & { id: AgentId }>,
  maxDepth = 10
): boolean {
  const inheritsExec = agents.some((agent) => agent.id === "exec");
  if (!inheritsExec) {
    return false;
  }

  return (
    isToolEnabledInResolvedChain("file_edit_insert", agents, maxDepth) ||
    isToolEnabledInResolvedChain("file_edit_replace_string", agents, maxDepth) ||
    // Orchestrator-type agents modify the worktree by applying patches from
    // child sub-agents. They need patch artifacts generated for their parent
    // just like direct-editing agents do.
    isToolEnabledInResolvedChain("task_apply_git_patch", agents, maxDepth)
  );
}
```

This is the minimal fix. Both callsites benefit automatically:
- **`gitPatchArtifactService.ts:150`** — orchestrator will now get patch artifacts generated → parent can apply them.
- **`agentSession.ts:3255`** — orchestrator hitting context limits will get hard-restarted instead of silently failing.

### 2. Add unit tests

No test file currently exists for `isExecLikeEditingCapableInResolvedChain`. Create one:

**`src/common/utils/agentTools.test.ts`**

Test cases:
- `exec` agent with `file_edit_insert` → `true` (existing behavior)
- `exec` agent with `file_edit_replace_string` → `true` (existing behavior)
- `exec` agent with neither editing tool → `false` (existing behavior)
- Agent not inheriting `exec` → `false` regardless of tools
- **Orchestrator case: `exec`-based agent with `file_edit_.*` removed but `task_apply_git_patch` enabled → `true`** (the new behavior)
- Agent with `task_apply_git_patch` but not inheriting `exec` → `false`

### 3. Validate

- `make typecheck` — no type errors
- `bun test src/common/utils/agentTools.test.ts` — new tests pass
- `make test` — no regressions

<details>
<summary>Alternatives considered</summary>

### Alt A: Check for actual commits instead of tool config

`maybeStartGeneration` could compare `HEAD` against `taskBaseCommitSha` to see if commits exist, regardless of agent type. This is more robust but changes the semantics of the function (which is intentionally config-based to avoid I/O). The tool-based check is consistent with the existing pattern and cheaper.

### Alt B: Rename the function

Could rename to `isExecLikeWorkspaceModifyingInResolvedChain` for clarity, but this touches two callsites and all imports for a cosmetic change. Not worth the churn — the comment on the new line explains the intent.

### Alt C: Make orchestrator not remove `file_edit_.*`

This would fix the gate but break the orchestrator's coordination-only design. The whole point is that orchestrators delegate editing to sub-agents.

</details>


</details>

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$1.80`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=1.80 -->
