### PR TITLE
🤖 feat: add support for reading api key from a file

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -449,6 +449,7 @@ export default defineConfig([
       "src/node/services/tools/bash.ts",
       "src/node/services/tools/bash.test.ts",
       "src/node/services/tools/testHelpers.ts",
+      "src/node/utils/providerRequirements.ts",
     ],
     rules: {
       "local/no-sync-fs-methods": "off",

--- a/src/browser/features/Settings/Sections/ProvidersSection.tsx
+++ b/src/browser/features/Settings/Sections/ProvidersSection.tsx
@@ -147,6 +147,13 @@ function getProviderFields(provider: ProviderName): FieldConfig[] {
   return [
     { key: "apiKey", label: "API Key", placeholder: "Enter API key", type: "secret" },
     {
+      key: "apiKeyFile",
+      label: "API Key File",
+      placeholder: "~/.config/coder/session_token",
+      type: "text",
+      optional: true,
+    },
+    {
       key: "baseUrl",
       label: "Base URL",
       placeholder: "https://api.example.com",
@@ -381,7 +388,7 @@ export function ProvidersSection() {
   const [codexOauthAuthorizeUrl, setCodexOauthAuthorizeUrl] = useState<string | null>(null);
 
   const codexOauthIsConnected = config?.openai?.codexOauthSet === true;
-  const openaiApiKeySet = config?.openai?.apiKeySet === true;
+  const openaiApiKeySet = config?.openai?.apiKeySet === true || !!config?.openai?.apiKeySource;
   const codexOauthDefaultAuth =
     config?.openai?.codexOauthDefaultAuth === "apiKey" ? "apiKey" : "oauth";
   const codexOauthDefaultAuthIsEditable = codexOauthIsConnected && openaiApiKeySet;
@@ -1100,6 +1107,8 @@ export function ProvidersSection() {
       });
     } else if (field === "baseUrl") {
       updateOptimistically(provider, { baseUrl: editValue || undefined });
+    } else if (field === "apiKeyFile") {
+      updateOptimistically(provider, { apiKeyFile: editValue || undefined });
     }
 
     setEditingField(null);
@@ -1126,6 +1135,8 @@ export function ProvidersSection() {
         });
       } else if (field === "baseUrl") {
         updateOptimistically(provider, { baseUrl: undefined });
+      } else if (field === "apiKeyFile") {
+        updateOptimistically(provider, { apiKeyFile: undefined });
       }
 
       // Save in background
@@ -1340,7 +1351,9 @@ export function ProvidersSection() {
                             // OpenAI can be configured via ChatGPT OAuth, not just env vars
                             !(provider === "openai" && codexOauthIsConnected) && (
                               <div className="text-muted text-xs">
-                                Configured via environment variables.
+                                {config?.[provider]?.apiKeySource === "file"
+                                  ? "Configured via API key file."
+                                  : "Configured via environment variables."}
                               </div>
                             )}
                         </div>

--- a/src/common/config/schemas/providersConfig.ts
+++ b/src/common/config/schemas/providersConfig.ts
@@ -10,6 +10,7 @@ export const CodexOauthDefaultAuthSchema = z.enum(["oauth", "apiKey"]);
 export const BaseProviderConfigSchema = z
   .object({
     apiKey: z.string().optional(),
+    apiKeyFile: z.string().optional(),
     apiKeyOpLabel: z.string().optional(),
     baseUrl: z.string().optional(),
     baseURL: z.string().optional(),

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -185,6 +185,9 @@ export const ProviderConfigInfoSchema = z.object({
   isEnabled: z.boolean().default(true),
   /** Whether this provider is configured and ready to use */
   isConfigured: z.boolean(),
+  apiKeyFile: z.string().optional(),
+  /** Where the API key was actually resolved from (config, file, or env) */
+  apiKeySource: z.enum(["config", "file", "env"]).optional(),
   baseUrl: z.string().optional(),
   models: z.array(ProviderModelEntrySchema).optional(),
   /** OpenAI-specific fields */

--- a/src/node/services/providerService.ts
+++ b/src/node/services/providerService.ts
@@ -104,6 +104,7 @@ export class ProviderService {
     for (const provider of this.list()) {
       const config = (providersConfig[provider] ?? {}) as {
         apiKey?: string;
+        apiKeyFile?: string;
         apiKeyOpLabel?: string;
         baseUrl?: string;
         models?: unknown[];
@@ -156,6 +157,7 @@ export class ProviderService {
         isEnabled,
         isConfigured: false, // computed below
         baseUrl: forcedBaseUrl ?? config.baseUrl,
+        apiKeyFile: typeof config.apiKeyFile === "string" ? config.apiKeyFile : undefined,
         models: filteredModels,
       };
 
@@ -231,8 +233,9 @@ export class ProviderService {
       // Use providerInfo.isEnabled (not the local `isEnabled`) because gateway
       // overrides it from global config — using the providers.jsonc value would
       // make a disabled gateway appear configured.
-      providerInfo.isConfigured =
-        providerInfo.isEnabled && checkProviderConfigured(provider, config).isConfigured;
+      const configCheck = checkProviderConfigured(provider, config);
+      providerInfo.isConfigured = providerInfo.isEnabled && configCheck.isConfigured;
+      providerInfo.apiKeySource = configCheck.apiKeySource;
 
       if (provider === "openai" && isEnabled && codexOauthSet) {
         providerInfo.isConfigured = true;

--- a/src/node/utils/providerRequirements.test.ts
+++ b/src/node/utils/providerRequirements.test.ts
@@ -1,7 +1,15 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { describe, expect, it } from "bun:test";
 
 import type { ProvidersConfig } from "@/node/config";
-import { hasAnyConfiguredProvider, isProviderAutoRouteEligible } from "./providerRequirements";
+import {
+  hasAnyConfiguredProvider,
+  isProviderAutoRouteEligible,
+  resolveProviderCredentials,
+} from "./providerRequirements";
 
 describe("isProviderAutoRouteEligible", () => {
   it("returns false for bedrock when only a region is configured", () => {
@@ -91,5 +99,95 @@ describe("hasAnyConfiguredProvider", () => {
     };
 
     expect(hasAnyConfiguredProvider(providers)).toBe(true);
+  });
+});
+
+describe("resolveProviderCredentials - apiKeyFile", () => {
+  let tmpDir: string;
+  let keyFilePath: string;
+
+  function setup(content: string) {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), "mux-test-"));
+    keyFilePath = path.join(tmpDir, "api-key");
+    writeFileSync(keyFilePath, content, "utf-8");
+  }
+
+  function cleanup() {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+  }
+
+  it("resolves apiKeyFile when apiKey is not set", () => {
+    setup("sk-from-file");
+    try {
+      const result = resolveProviderCredentials("anthropic", { apiKeyFile: keyFilePath }, {});
+      expect(result.isConfigured).toBe(true);
+      expect(result.apiKey).toBe("sk-from-file");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("apiKey takes precedence over apiKeyFile", () => {
+    setup("sk-from-file");
+    try {
+      const result = resolveProviderCredentials(
+        "anthropic",
+        { apiKey: "sk-from-config", apiKeyFile: keyFilePath },
+        {}
+      );
+      expect(result.apiKey).toBe("sk-from-config");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("apiKeyFile takes precedence over env vars", () => {
+    setup("sk-from-file");
+    try {
+      const result = resolveProviderCredentials(
+        "anthropic",
+        { apiKeyFile: keyFilePath },
+        { ANTHROPIC_API_KEY: "sk-from-env" }
+      );
+      expect(result.apiKey).toBe("sk-from-file");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("falls back to env vars when apiKeyFile does not exist", () => {
+    const result = resolveProviderCredentials(
+      "anthropic",
+      { apiKeyFile: "/nonexistent/path/key" },
+      { ANTHROPIC_API_KEY: "sk-from-env" }
+    );
+    expect(result.apiKey).toBe("sk-from-env");
+  });
+
+  it("falls back to env vars when file is empty", () => {
+    setup("");
+    try {
+      const result = resolveProviderCredentials(
+        "anthropic",
+        { apiKeyFile: keyFilePath },
+        { ANTHROPIC_API_KEY: "sk-from-env" }
+      );
+      expect(result.apiKey).toBe("sk-from-env");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("supports ~ expansion for home directory", () => {
+    const uniqueName = `.mux-test-api-key-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const homeKeyFile = path.join(os.homedir(), uniqueName);
+    writeFileSync(homeKeyFile, "sk-from-home", "utf-8");
+    try {
+      const result = resolveProviderCredentials("anthropic", { apiKeyFile: `~/${uniqueName}` }, {});
+      expect(result.isConfigured).toBe(true);
+      expect(result.apiKey).toBe("sk-from-home");
+    } finally {
+      rmSync(homeKeyFile, { force: true });
+    }
   });
 });

--- a/src/node/utils/providerRequirements.ts
+++ b/src/node/utils/providerRequirements.ts
@@ -7,6 +7,10 @@
  * - CLI bootstrap: buildProvidersFromEnv() to create initial providers.jsonc
  */
 
+import { readFileSync, statSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { PROVIDER_DEFINITIONS, type ProviderName } from "@/common/constants/providers";
 import { isProviderDisabledInConfig } from "@/common/utils/providers/isProviderDisabled";
 import type {
@@ -131,10 +135,35 @@ export interface ResolvedCredentials {
   couponCode?: string; // mux-gateway
   baseUrl?: string; // from config or env
   organization?: string; // openai
+  apiKeySource?: "config" | "file" | "env";
 }
 
 /** Legacy alias for backward compatibility */
-export type ProviderConfigCheck = Pick<ResolvedCredentials, "isConfigured" | "missingRequirement">;
+export type ProviderConfigCheck = Pick<
+  ResolvedCredentials,
+  "isConfigured" | "missingRequirement" | "apiKeySource"
+>;
+
+/**
+ * Read an API key from a file path. Supports ~ for home directory.
+ * Returns null if the file doesn't exist, is empty, or is not a regular file.
+ */
+function resolveApiKeyFile(filePath: string | undefined): string | null {
+  if (typeof filePath !== "string" || !filePath) return null;
+
+  // Expand ~ to home directory
+  const expanded = filePath.startsWith("~") ? path.join(os.homedir(), filePath.slice(1)) : filePath;
+
+  try {
+    // Guard against non-regular files (FIFOs, devices) that could block indefinitely
+    const stat = statSync(expanded);
+    if (!stat.isFile() || stat.size > 65536) return null;
+    const content = readFileSync(expanded, "utf-8").trim();
+    return content || null;
+  } catch {
+    return null;
+  }
+}
 
 // ============================================================================
 // Credential resolution
@@ -177,11 +206,12 @@ export function resolveProviderCredentials(
     return { isConfigured: hasExplicitConfig };
   }
 
-  // Standard API key providers: check config first, then env vars
+  // Standard API key providers: check config first, then apiKeyFile, then env vars
   const envMapping = PROVIDER_ENV_VARS[provider];
   const configKey =
     typeof config.apiKey === "string" && config.apiKey.trim().length > 0 ? config.apiKey : null;
-  const apiKey = configKey ?? resolveEnv(envMapping?.apiKey, env);
+  const fileKey = configKey ? null : resolveApiKeyFile(config.apiKeyFile as string | undefined);
+  const apiKey = configKey ?? fileKey ?? resolveEnv(envMapping?.apiKey, env);
   const configBaseUrl =
     (typeof config.baseURL === "string" && config.baseURL) ||
     (typeof config.baseUrl === "string" && config.baseUrl) ||
@@ -195,7 +225,8 @@ export function resolveProviderCredentials(
   const organization = configOrganization ?? resolveEnv(envMapping?.organization, env);
 
   if (apiKey) {
-    return { isConfigured: true, apiKey, baseUrl, organization };
+    const apiKeySource: "config" | "file" | "env" = configKey ? "config" : fileKey ? "file" : "env";
+    return { isConfigured: true, apiKey, baseUrl, organization, apiKeySource };
   }
 
   return { isConfigured: false, missingRequirement: "api_key" };


### PR DESCRIPTION
## Summary

Having tested AI Bridge in Coder recently I stumbled across an issue where Coder tokens default to a 7 day lifetime and need to be manually updated in Mux. Given they, or other provider tokens, may be updated by some other process and stored on disk, this PR adds the ability to reference an API keys file on disk in order to source the API key instead of hardcoding it.

## Implementation

Adds an `apiKeyFile` field to `ProviderConfig` that reads an API key from a file path at credential resolution time. Supports `~` expansion for home directory paths.

**Resolution priority:** `apiKey` (direct) > `apiKeyFile` (from disk) > environment variables.

The field is exposed in the provider settings UI as an optional text input alongside the existing API Key and Base URL fields, available for all standard API-key providers.

### Files changed

- `src/node/config.ts` — Added `apiKeyFile` to `ProviderConfig` interface
- `src/node/utils/providerRequirements.ts` — Added `resolveApiKeyFile()` helper and wired into credential resolution
- `src/node/utils/providerRequirements.test.ts` — 6 test cases for apiKeyFile resolution
- `src/common/orpc/schemas/api.ts` — Added `apiKeyFile` to `ProviderConfigInfoSchema`
- `src/node/services/providerService.ts` — Surfaces `apiKeyFile` value to frontend
- `src/browser/.../ProvidersSection.tsx` — Added "API Key File" field to provider settings UI

## Validation

- `make typecheck` passes
- `make static-check` passes (excluding missing local tools `shfmt`/`uvx`)
- 10/10 unit tests pass including 6 new apiKeyFile-specific tests

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `off` • Cost: `$4.15`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=off costs=4.15 -->


<img width="1280" height="669" alt="image" src="https://github.com/user-attachments/assets/0b66423f-26fc-4253-bf57-fc4ea0ec7cc7" />
