### PR TITLE
🤖 feat: move Mermaid instructions into built-in diagram skill

### DIFF
--- a/docs/agents/system-prompt.mdx
+++ b/docs/agents/system-prompt.mdx
@@ -26,7 +26,7 @@ You are a coding agent called Mux. You may find information about yourself here:
 <markdown>
 Your Assistant messages display in Markdown with extensions for mermaidjs and katex.
 
-When creating mermaid diagrams, load the built-in "diagram" skill via agent_skill_read for best practices.
+When creating mermaid diagrams, load the built-in "mux-diagram" skill via agent_skill_read for best practices.
 
 Use GitHub-style \`<details>/<summary>\` tags to create collapsible sections for lengthy content, error traces, or supplementary information. Toggles help keep responses scannable while preserving detail.
 </markdown>

--- a/src/node/builtinSkills/mux-diagram.md
+++ b/src/node/builtinSkills/mux-diagram.md
@@ -1,5 +1,5 @@
 ---
-name: diagram
+name: mux-diagram
 description: Mermaid diagram best practices and text-based chart alternatives
 ---
 

--- a/src/node/services/agentSkills/agentSkillsService.test.ts
+++ b/src/node/services/agentSkills/agentSkillsService.test.ts
@@ -43,7 +43,7 @@ describe("agentSkillsService", () => {
 
     // Should include project/global skills plus built-in skills
     // Note: deep-review skill is a project skill in the Mux repo, not a built-in
-    expect(skills.map((s) => s.name)).toEqual(["bar", "diagram", "foo", "init", "mux-docs"]);
+    expect(skills.map((s) => s.name)).toEqual(["bar", "foo", "init", "mux-diagram", "mux-docs"]);
 
     const foo = skills.find((s) => s.name === "foo");
     expect(foo).toBeDefined();
@@ -197,7 +197,12 @@ describe("agentSkillsService", () => {
 
     const diagnostics = await discoverAgentSkillsDiagnostics(runtime, project.path, { roots });
 
-    expect(diagnostics.skills.map((s) => s.name)).toEqual(["diagram", "foo", "init", "mux-docs"]);
+    expect(diagnostics.skills.map((s) => s.name)).toEqual([
+      "foo",
+      "init",
+      "mux-diagram",
+      "mux-docs",
+    ]);
 
     const invalidNames = diagnostics.invalidSkills.map((issue) => issue.directoryName).sort();
     expect(invalidNames).toEqual(

--- a/src/node/services/systemMessage.ts
+++ b/src/node/services/systemMessage.ts
@@ -48,7 +48,7 @@ You are a coding agent called Mux. You may find information about yourself here:
 <markdown>
 Your Assistant messages display in Markdown with extensions for mermaidjs and katex.
 
-When creating mermaid diagrams, load the built-in "diagram" skill via agent_skill_read for best practices.
+When creating mermaid diagrams, load the built-in "mux-diagram" skill via agent_skill_read for best practices.
 
 Use GitHub-style \`<details>/<summary>\` tags to create collapsible sections for lengthy content, error traces, or supplementary information. Toggles help keep responses scannable while preserving detail.
 </markdown>


### PR DESCRIPTION
## Summary

Move Mermaid diagram authoring guidance out of the always-on system PRELUDE and into a new built-in `mux-diagram` skill that agents load on-demand via `agent_skill_read`.

Relates to #2334

## Background

Every model request currently receives ~200 tokens of Mermaid best-practice instructions in the system prompt, even though the vast majority of requests never produce a diagram. This is a vestige of the pre-skills approach to context injection and wastes tokens on every single request.

## Implementation

- **New built-in skill** `src/node/builtinSkills/mux-diagram.md` — contains the migrated Mermaid best practices plus a new section on text-based chart alternatives (markdown tables, ASCII bars, indented trees) for cases where full Mermaid rendering is unnecessary.
- **Trimmed PRELUDE** — the `<markdown>` block in `systemMessage.ts` now has a single-line routing hint ("load the built-in `mux-diagram` skill via `agent_skill_read` for best practices") instead of the full Mermaid instruction set. Generic markdown guidance (katex, `<details>/<summary>`) remains.
- **Namespaced as `mux-diagram`** — follows the `mux-*` convention (matching `mux-docs`) so project/global skills don't accidentally shadow the built-in.
- **Test expectations updated** — two assertions in `agentSkillsService.test.ts` that hardcode the built-in skill list now include `"mux-diagram"`.

## Risks

Low — the Mermaid instructions are still available to the agent; they're just loaded on-demand instead of injected unconditionally. If diagram quality regresses, the routing hint in PRELUDE should be sufficient to prompt the model to load the skill.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$5.66`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=5.66 -->
