### PR TITLE
🤖 fix: eliminate dev-server startup crash from tsgo/tsc-alias race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,8 +183,9 @@ dev-server: node_modules/.installed build-main ## Start server mode with hot rel
 	@echo "  Frontend (with HMR):     http://$(or $(VITE_HOST),localhost):$(or $(VITE_PORT),5173)"
 	@echo ""
 	@echo "For remote access: make dev-server VITE_HOST=0.0.0.0 VITE_ALLOWED_HOSTS=<public-host>"
+	@# Keep tsgo -> tsc-alias sequential to avoid transient unresolved @/ imports in dist during restarts.
 	@bun x concurrently -k \
-		"bun x concurrently \"$(TSGO) -w -p tsconfig.main.json\" \"bun x tsc-alias -w -p tsconfig.main.json\"" \
+		"bun x nodemon --watch src --watch tsconfig.main.json --watch tsconfig.json --ext ts,tsx,json --ignore dist --ignore node_modules --exec 'node scripts/build-main-watch.js'" \
 		'bun x esbuild src/cli/api.ts $(ESBUILD_CLI_FLAGS) --watch' \
 		"bun x nodemon --watch dist/cli/index.js --watch dist/cli/server.js --delay 500ms --exec 'NODE_ENV=development node dist/cli/index.js server --no-auth --host $(or $(BACKEND_HOST),127.0.0.1) --port $(or $(BACKEND_PORT),3000)'" \
 		"MUX_VITE_HOST=$(or $(VITE_HOST),127.0.0.1) MUX_VITE_PORT=$(or $(VITE_PORT),5173) MUX_VITE_ALLOWED_HOSTS=$(VITE_ALLOWED_HOSTS) MUX_BACKEND_PORT=$(or $(BACKEND_PORT),3000) vite"


### PR DESCRIPTION
## Summary

Fix the `make dev-server` startup crash (`Cannot find module '@/node/config'`) that occurs on every cold start on non-Windows platforms.

## Background

The non-Windows `dev-server` target launches `tsgo -w` and `tsc-alias -w` as **independent parallel watchers**. On startup, tsgo immediately rebuilds `dist/` with unresolved `@/` path aliases, and nodemon restarts the server after its 500ms delay — before tsc-alias finishes rewriting all ~415 files. This produces a transient `MODULE_NOT_FOUND` crash every time.

The Windows `dev-server` target already avoids this by using `scripts/build-main-watch.js`, which runs tsgo → tsc-alias **sequentially**.

## Implementation

Replace the parallel watcher pair with a source-watching nodemon that executes the existing sequential `build-main-watch.js` script on each change — the same approach Windows already uses. This is a one-line Makefile change (plus a comment).

## Validation

- `make build-main` passes
- `make dev-server` starts without the `Cannot find module '@/node/config'` crash
- Source file changes trigger sequential rebuild → clean server restart

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$2.23`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=2.23 -->
