### PR TITLE
🤖 ci: add duckdb to nix flake dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -186,6 +186,7 @@
               shfmt
               gh
               jq
+              duckdb
 
               # Documentation
               mdbook


### PR DESCRIPTION
## Summary
Add the DuckDB CLI to the Nix flake development shell so contributors can inspect local analytics databases directly from `nix develop`.

## Implementation
- Added `duckdb` to `devShells.default.buildInputs` in `flake.nix`.

## Validation
- `make static-check`
- `nix flake check --no-build`

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.37`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.37 -->
