### PR TITLE
🤖 fix: populate sub-agent workspace analytics metadata

### DIFF
--- a/src/node/services/analytics/etl.test.ts
+++ b/src/node/services/analytics/etl.test.ts
@@ -287,10 +287,11 @@ describe("ingestArchivedSubagentTranscripts", () => {
 
     const childRows = await queryRows(
       conn,
-      "SELECT parent_workspace_id, CAST(is_sub_agent AS INTEGER) AS is_sub_agent_int FROM events WHERE workspace_id = ?",
+      "SELECT workspace_name, parent_workspace_id, CAST(is_sub_agent AS INTEGER) AS is_sub_agent_int FROM events WHERE workspace_id = ?",
       [childWorkspaceId]
     );
     expect(childRows).toHaveLength(1);
+    expect(childRows[0].workspace_name).toBe("child-workspace");
     expect(childRows[0].parent_workspace_id).toBe(parentWorkspaceId);
     expect(parseBooleanFromInteger(childRows[0].is_sub_agent_int, "is_sub_agent_int")).toBe(true);
   });

--- a/src/node/services/analytics/etl.ts
+++ b/src/node/services/analytics/etl.ts
@@ -952,6 +952,7 @@ async function ingestArchivedSubagentTranscripts(
       const overrideMeta: WorkspaceMeta = {
         projectPath: parentMeta.projectPath,
         projectName: parentMeta.projectName,
+        workspaceName: archivedWorkspaceMeta.workspaceName,
       };
 
       // Archived transcripts created before workspace metadata persisted

--- a/src/node/services/serviceContainer.ts
+++ b/src/node/services/serviceContainer.ts
@@ -261,11 +261,15 @@ export class ServiceContainer {
 
       const workspaceLookup = this.config.findWorkspace(data.workspaceId);
       const sessionDir = this.config.getSessionDir(data.workspaceId);
+      // Newly created sub-agent workspaces are ingested here before a full rebuild,
+      // so keep workspaceName + parentWorkspaceId to avoid NULL analytics attribution.
       this.analyticsService.ingestWorkspace(data.workspaceId, sessionDir, {
         projectPath: workspaceLookup?.projectPath,
         projectName: workspaceLookup?.projectPath
           ? path.basename(workspaceLookup.projectPath)
           : undefined,
+        workspaceName: workspaceLookup?.workspaceName,
+        parentWorkspaceId: workspaceLookup?.parentWorkspaceId,
       });
     });
     // WorkspaceService emits metadata:null after successful remove().


### PR DESCRIPTION
## Summary
Populate sub-agent workspace analytics metadata on incremental ingest so `workspace_name` and `parent_workspace_id` are no longer silently dropped for post-startup child workspaces.

## Background
Startup rebuilds already include complete workspace metadata from `config.json`, but incremental `stream-end` ingest only passed project-level fields. Because sub-agent workspaces are usually created after startup, they were first ingested via the incremental path and persisted `NULL` values that never self-corrected.

## Implementation
- Expanded `Config.findWorkspace()` to return `workspaceName` and `parentWorkspaceId` in addition to paths.
- Threaded those fields through `ServiceContainer`'s `stream-end` analytics ingest call.
- Preserved archived child `workspaceName` when ingesting rolled-up sub-agent transcripts in ETL.
- Tightened analytics ingest meta typing to require explicit field threading (including intentional `undefined`) so future metadata additions surface as compile-time updates instead of silent omissions.
- Added an ETL regression assertion verifying archived child `workspace_name` is recorded.

## Validation
- `make static-check`
- `bun test src/node/services/analytics/analyticsService.test.ts`
- `bun test src/node/services/serviceContainer.test.ts`

## Risks
Low-to-moderate. Changes are narrowly scoped to metadata plumbing and analytics ingest inputs, but they touch a widely used config lookup method and metadata typing, so regressions would likely appear as type errors or missing analytics attribution rather than runtime crashes.

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix: Populate `workspace_name` for sub-agent analytics events

## Context & Why

Sub-agent workspaces always have `NULL` `workspace_name` in the analytics DB.
The root cause is a gap between two ingestion paths:

- **Startup `rebuildAll`** iterates `config.json` and correctly populates `workspaceName`
  and `parentWorkspaceId` for every workspace.
- **Incremental `stream-end`** handler in `serviceContainer.ts` calls `config.findWorkspace()`
  which only returns `{ workspacePath, projectPath }`, so the downstream
  `ingestWorkspace()` call never receives the name or parent.

Sub-agents are created *after* startup, so the incremental path is their first (and only)
ingestion trigger — resulting in permanent NULLs.

A secondary instance of the same bug exists in `ingestArchivedSubagentTranscripts` in `etl.ts`,
which also constructs an `overrideMeta` without `workspaceName`.

## Evidence

| Source | Observation |
|---|---|
| `src/node/config.ts:731-738` | `findWorkspace` returns only `{ workspacePath, projectPath }` |
| `src/node/services/serviceContainer.ts:259-269` | `stream-end` handler passes only `projectPath`/`projectName` to `ingestWorkspace` |
| `src/node/services/analytics/analyticsService.ts:246-251` | `buildRebuildWorkspaceMetaById` correctly includes `workspaceName` and `parentWorkspaceId` |
| `src/node/services/analytics/etl.ts:952-955` | `ingestArchivedSubagentTranscripts` also omits `workspaceName` from `overrideMeta` |
| `src/common/orpc/schemas/project.ts:42-44` | Workspace config schema has `name` field (the workspace name) |

## Implementation

### 1. Expand `findWorkspace` return type (~+5 LoC)

**File:** `src/node/config.ts`

Add `workspaceName` and `parentWorkspaceId` to the return type. The method already iterates
workspace entries that have these fields — it just doesn't expose them.

```typescript
// Before:
findWorkspace(workspaceId: string): { workspacePath: string; projectPath: string } | null {
  // ...
  if (workspace.id === workspaceId) {
    return { workspacePath: workspace.path, projectPath };
  }

// After:
findWorkspace(workspaceId: string): {
  workspacePath: string;
  projectPath: string;
  workspaceName: string | undefined;
  parentWorkspaceId: string | undefined;
} | null {
  // ...
  if (workspace.id === workspaceId) {
    return {
      workspacePath: workspace.path,
      projectPath,
      workspaceName: workspace.name,
      parentWorkspaceId: workspace.parentWorkspaceId,
    };
  }
```

The legacy-format fallback paths (metadata.json + legacyId) should also return
`workspaceName: undefined, parentWorkspaceId: undefined` for type consistency.

### 2. Pass the new fields through in `stream-end` handler (~+2 LoC)

**File:** `src/node/services/serviceContainer.ts`

```typescript
// Before (line 264):
this.analyticsService.ingestWorkspace(data.workspaceId, sessionDir, {
  projectPath: workspaceLookup?.projectPath,
  projectName: workspaceLookup?.projectPath
    ? path.basename(workspaceLookup.projectPath)
    : undefined,
});

// After:
this.analyticsService.ingestWorkspace(data.workspaceId, sessionDir, {
  projectPath: workspaceLookup?.projectPath,
  projectName: workspaceLookup?.projectPath
    ? path.basename(workspaceLookup.projectPath)
    : undefined,
  workspaceName: workspaceLookup?.workspaceName,
  parentWorkspaceId: workspaceLookup?.parentWorkspaceId,
});
```

### 3. Fix `ingestArchivedSubagentTranscripts` (~+1 LoC)

**File:** `src/node/services/analytics/etl.ts`

The archived transcript function reads `archivedWorkspaceMeta` from disk but then
constructs a separate `overrideMeta` that drops the workspace name. Fix:

```typescript
// Before (line ~952):
const overrideMeta: WorkspaceMeta = {
  projectPath: parentMeta.projectPath,
  projectName: parentMeta.projectName,
};

// After — carry forward the disk-read name so it isn't lost:
const overrideMeta: WorkspaceMeta = {
  projectPath: parentMeta.projectPath,
  projectName: parentMeta.projectName,
  workspaceName: archivedWorkspaceMeta.workspaceName,
};
```

### 4. Prevent this class of bug in the future (~+12 LoC)

The underlying issue is that `IngestWorkspaceMeta` / `WorkspaceMeta` have all fields
optional, so TypeScript is perfectly happy when a caller forgets to pass `workspaceName`.
There's no compile-time signal that something was omitted.

**Approach: require explicit `undefined` for intentional omissions.**

Make the analytics-relevant fields **required** (but nullable) in the meta type used at
the `stream-end` callsite. This way, if someone adds a new field to `IngestWorkspaceMeta`,
every construction site will get a compile error until they explicitly provide it.

```typescript
// src/node/services/analytics/analyticsService.ts

// The "full" meta that callers who have config access MUST fully populate:
type RequiredIngestWorkspaceMeta = {
  [K in keyof IngestWorkspaceMeta]-?: IngestWorkspaceMeta[K];
};

// ingestWorkspace overload/parameter change:
ingestWorkspace(
  workspaceId: string,
  sessionDir: string,
  meta?: RequiredIngestWorkspaceMeta,  // <-- forces all fields
): void { ... }
```

This means the `stream-end` handler would fail to compile if it omitted any field.
The `rebuildAll` path (which already supplies all fields) wouldn't need changes.

For the `etl.ts` internal paths (e.g. `ingestArchivedSubagentTranscripts`) that legitimately
may not have all fields, they call the internal `ingestWorkspace` function (not the service
method), so they can keep using the looser `WorkspaceMeta` type.

**Net effect:** Any future field added to `IngestWorkspaceMeta` will produce a compile error
at every callsite that doesn't supply it — exactly the class of bug we're fixing.

## Estimated LoC

~+20 product code (across 3 files).

## Validation

- `make typecheck` — confirms the expanded return type propagates cleanly
- `make test` — existing analytics/ETL tests still pass
- Manual: verify a sub-agent workspace gets a non-NULL `workspace_name` in `analytics.db`

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$2.24`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=2.24 -->
