### PR TITLE
🤖 fix: background foreground waits on queued messages

### DIFF
--- a/src/node/services/messageQueue.ts
+++ b/src/node/services/messageQueue.ts
@@ -100,8 +100,8 @@ export class MessageQueue {
     message: string,
     options?: SendMessageOptions & { fileParts?: FilePart[] },
     internal?: QueuedMessageInternalOptions
-  ): void {
-    this.addInternal(message, options, internal);
+  ): boolean {
+    return this.addInternal(message, options, internal);
   }
 
   /**

--- a/src/node/services/tools/task_await.ts
+++ b/src/node/services/tools/task_await.ts
@@ -13,6 +13,7 @@ import {
   requireWorkspaceId,
 } from "./toolUtils";
 import { getErrorMessage } from "@/common/utils/errors";
+import { ForegroundWaitBackgroundedError } from "@/node/services/taskService";
 
 function coerceTimeoutMs(timeoutSecs: unknown): number | undefined {
   if (typeof timeoutSecs !== "number" || !Number.isFinite(timeoutSecs)) return undefined;
@@ -176,6 +177,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
                 timeoutMs: 1,
                 abortSignal,
                 requestingWorkspaceId: workspaceId,
+                backgroundOnMessageQueued: true,
               });
 
               const gitFormatPatch = await readGitFormatPatchArtifact(taskId);
@@ -200,6 +202,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
               timeoutMs,
               abortSignal,
               requestingWorkspaceId: workspaceId,
+              backgroundOnMessageQueued: true,
             });
 
             const gitFormatPatch = await readGitFormatPatchArtifact(taskId);
@@ -211,6 +214,21 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
               ...(gitFormatPatch ? { artifacts: { gitFormatPatch } } : {}),
             };
           } catch (error: unknown) {
+            if (error instanceof ForegroundWaitBackgroundedError) {
+              const currentStatus = taskService.getAgentTaskStatus(taskId);
+              const normalizedStatus =
+                currentStatus === "queued" ||
+                currentStatus === "running" ||
+                currentStatus === "awaiting_report"
+                  ? currentStatus
+                  : ("running" as const);
+              return {
+                status: normalizedStatus,
+                taskId,
+                note: "Task sent to background because a new message was queued. Use task_await to monitor progress.",
+              };
+            }
+
             if (abortSignal?.aborted) {
               return { status: "error" as const, taskId, error: "Interrupted" };
             }


### PR DESCRIPTION
## Summary

This PR fixes queue-triggered foreground `task_await` behavior so queued user messages can continue immediately, and parent stream-end nudges only target descendants that are still truly blocking.

It also closes a follow-up gap by making queue-background exemptions one-shot: the first stream-end after queue-background may suppress nudges, and later stream-ends nudge again if tasks remain active.

## Background

The original queue-background fix correctly rejected foreground waits, but suppression state could remain sticky across later voluntary stream-ends. That caused missing nudges even when no new queued message explained the suppression.

## Implementation

- Removed persisted task-await policy plumbing and moved queue-background tracking to runtime `TaskService` state.
- Updated `task_await` wait registration so workspace-scoped waits opt into queue-backgrounding and map `ForegroundWaitBackgroundedError` to active task statuses (not terminal errors).
- Made queue dispatch mode decisions use the queue’s effective mode (including sticky `tool-end`) instead of only the incoming message option.
- Prevented no-op queue insertions from backgrounding waits by returning `null` when nothing is enqueued.
- Added explicit stale-state clearing when a task is foreground-waited again.
- Updated `handleStreamEnd` to consume queue-background exemptions after each stream-end decision (one-shot semantics).
- Expanded regressions to cover:
  - one-shot cross-stream behavior (first suppressed, second nudged), and
  - multi-task-at-once waits from a single parent workspace.

## Validation

- `bun run typecheck`
- `bun test src/node/services/taskService.test.ts -t "queue-backgrounded|cross-stream|foreground|renewed|multiple|one-shot"`
- `bun test src/node/services/tools/task_await.test.ts -t "returns completed results for all awaited tasks|ForegroundWaitBackgroundedError|task_await"`

## Risks

- Queue-background exemption tracking is runtime-only. After process restart, active tasks are conservatively treated as blocking until fresh runtime state is established.
- One-shot consumption now depends on `handleStreamEnd` as the observe-and-consume boundary; regressions would most likely appear in parent nudge timing.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$37.57`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=37.57 -->
