### PR TITLE
🤖 fix: attribute session usage sources and dedupe abort cleanup

### DIFF
--- a/src/browser/components/RightSidebar/CostsTab.tsx
+++ b/src/browser/components/RightSidebar/CostsTab.tsx
@@ -2,9 +2,11 @@ import React from "react";
 import { useWorkspaceUsage, useWorkspaceConsumers } from "@/browser/stores/WorkspaceStore";
 import { getModelStatsResolved } from "@/common/utils/tokens/modelStats";
 import {
+  getTotalCost,
   sumUsageHistory,
   formatCostWithDollar,
   type ChatUsageDisplay,
+  type SessionUsageSource,
 } from "@/common/utils/tokens/usageAggregator";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
 import { PREFERRED_COMPACTION_MODEL_KEY } from "@/common/constants/storage";
@@ -51,6 +53,23 @@ const VIEW_MODE_OPTIONS: Array<ToggleOption<ViewMode>> = [
   { value: "session", label: "Session" },
   { value: "last-request", label: "Last Request" },
 ];
+
+const SOURCE_LABELS: Record<SessionUsageSource, string> = {
+  main: "Main",
+  system1: "System 1",
+  plan: "Plan",
+  subagent: "Sub-agent",
+};
+
+function getUsageTotalTokens(usage: ChatUsageDisplay): number {
+  return (
+    usage.input.tokens +
+    usage.cached.tokens +
+    usage.cacheCreate.tokens +
+    usage.output.tokens +
+    usage.reasoning.tokens
+  );
+}
 
 interface CostsTabProps {
   workspaceId: string;
@@ -119,6 +138,22 @@ const CostsTabComponent: React.FC<CostsTabProps> = ({ workspaceId }) => {
 
   // Cost and Details table use viewMode
   const displayUsage = viewMode === "last-request" ? lastRequestUsage : sessionUsage;
+
+  const sourceRows =
+    viewMode === "session" && usage.sourceTotals
+      ? Object.entries(usage.sourceTotals)
+          .map(([source, sourceUsage]) => {
+            const typedSource = source as SessionUsageSource;
+            return {
+              source,
+              label: SOURCE_LABELS[typedSource] ?? source,
+              tokens: getUsageTotalTokens(sourceUsage),
+              cost: getTotalCost(sourceUsage),
+            };
+          })
+          .filter((row) => row.tokens > 0)
+          .sort((a, b) => b.tokens - a.tokens)
+      : [];
 
   return (
     <div className="text-light font-primary text-[13px] leading-relaxed">
@@ -423,6 +458,36 @@ const CostsTabComponent: React.FC<CostsTabProps> = ({ workspaceId }) => {
                       })}
                     </tbody>
                   </table>
+
+                  {sourceRows.length > 0 && (
+                    <div data-testid="cost-source-breakdown" className="mt-3">
+                      <h3 className="text-subtle m-0 mb-1 text-[11px] font-semibold tracking-wide uppercase">
+                        Source Breakdown
+                      </h3>
+                      <table className="w-full border-collapse text-[11px]">
+                        <thead>
+                          <tr className="border-border-light border-b">
+                            <th className="text-muted py-1 pr-2 text-left font-medium">Source</th>
+                            <th className="text-muted py-1 pr-2 text-right font-medium">Tokens</th>
+                            <th className="text-muted py-1 text-right font-medium">Cost</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {sourceRows.map((row) => (
+                            <tr key={row.source}>
+                              <td className="text-foreground py-1 pr-2">{row.label}</td>
+                              <td className="text-foreground py-1 pr-2 text-right">
+                                {formatTokens(row.tokens)}
+                              </td>
+                              <td className="text-foreground py-1 text-right">
+                                {formatCostWithDollar(row.cost)}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
                 </>
               );
             })()}

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -15,7 +15,7 @@ interface LoadMoreResponse {
 
 // Mock client
 // eslint-disable-next-line require-yield
-const mockOnChat = mock(async function* (
+const defaultOnChatImplementation = async function* (
   _input?: { workspaceId: string; mode?: unknown },
   options?: { signal?: AbortSignal }
 ): AsyncGenerator<WorkspaceChatMessage, void, unknown> {
@@ -27,7 +27,9 @@ const mockOnChat = mock(async function* (
     }
     options.signal.addEventListener("abort", () => resolve(), { once: true });
   });
-});
+};
+
+const mockOnChat = mock(defaultOnChatImplementation);
 
 const mockGetSessionUsage = mock((_input: { workspaceId: string }) =>
   Promise.resolve<unknown>(undefined)
@@ -178,6 +180,16 @@ function createHistoryMessageEvent(id: string, historySequence: number): Workspa
   };
 }
 
+function createUsageDisplay(inputTokens: number, outputTokens: number) {
+  return {
+    input: { tokens: inputTokens },
+    cached: { tokens: 0 },
+    cacheCreate: { tokens: 0 },
+    output: { tokens: outputTokens },
+    reasoning: { tokens: 0 },
+  };
+}
+
 async function waitForAbortSignal(signal?: AbortSignal): Promise<void> {
   await new Promise<void>((resolve) => {
     if (!signal) {
@@ -194,6 +206,7 @@ describe("WorkspaceStore", () => {
 
   beforeEach(() => {
     mockOnChat.mockClear();
+    mockOnChat.mockImplementation(defaultOnChatImplementation);
     mockGetSessionUsage.mockClear();
     mockHistoryLoadMore.mockClear();
     mockActivityList.mockClear();
@@ -723,6 +736,96 @@ describe("WorkspaceStore", () => {
       const usage = store.getWorkspaceUsage("workspace-2");
       expect(usage.sessionTotal).toBeDefined();
       expect(usage.sessionTotal!.input.tokens).toBe(1000);
+    });
+
+    it("hydrates source totals from persisted session usage", async () => {
+      const workspaceId = "workspace-source-totals";
+      const sessionUsageData = {
+        byModel: {
+          "claude-sonnet-4": createUsageDisplay(1000, 100),
+        },
+        bySource: {
+          main: createUsageDisplay(900, 90),
+          system1: createUsageDisplay(100, 10),
+        },
+        version: 1 as const,
+      };
+
+      mockGetSessionUsage.mockImplementation(
+        ({ workspaceId: requestedWorkspaceId }: { workspaceId: string }) => {
+          if (requestedWorkspaceId === workspaceId) {
+            return Promise.resolve(sessionUsageData);
+          }
+          return Promise.resolve(undefined);
+        }
+      );
+
+      createAndAddWorkspace(store, workspaceId, {}, false);
+      store.setActiveWorkspaceId(workspaceId);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const usage = store.getWorkspaceUsage(workspaceId);
+      expect(usage.sourceTotals?.main?.input.tokens).toBe(900);
+      expect(usage.sourceTotals?.system1?.output.tokens).toBe(10);
+    });
+
+    it("merges source totals when session-usage-delta events arrive", async () => {
+      const workspaceId = "workspace-source-delta";
+      mockGetSessionUsage.mockImplementation(
+        ({ workspaceId: requestedWorkspaceId }: { workspaceId: string }) => {
+          if (requestedWorkspaceId === workspaceId) {
+            return Promise.resolve({
+              byModel: {
+                "claude-sonnet-4": createUsageDisplay(100, 50),
+              },
+              bySource: {
+                main: createUsageDisplay(100, 50),
+              },
+              version: 1 as const,
+            });
+          }
+          return Promise.resolve(undefined);
+        }
+      );
+
+      mockOnChat.mockImplementation(async function* (
+        _input?: { workspaceId: string; mode?: unknown },
+        options?: { signal?: AbortSignal }
+      ): AsyncGenerator<WorkspaceChatMessage, void, unknown> {
+        yield { type: "caught-up" };
+        yield {
+          type: "session-usage-delta",
+          workspaceId,
+          sourceWorkspaceId: "child-subagent",
+          byModelDelta: {
+            "claude-sonnet-4": createUsageDisplay(20, 10),
+          },
+          bySourceDelta: {
+            main: createUsageDisplay(5, 2),
+            subagent: createUsageDisplay(15, 8),
+          },
+          timestamp: Date.now(),
+        };
+
+        await waitForAbortSignal(options?.signal);
+      });
+
+      createAndAddWorkspace(store, workspaceId);
+
+      const deadline = Date.now() + 1_000;
+      while (Date.now() < deadline) {
+        const usage = store.getWorkspaceUsage(workspaceId);
+        if (usage.sourceTotals?.subagent?.input.tokens === 15) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+
+      const usage = store.getWorkspaceUsage(workspaceId);
+      expect(usage.sourceTotals?.main?.input.tokens).toBe(105);
+      expect(usage.sourceTotals?.main?.output.tokens).toBe(52);
+      expect(usage.sourceTotals?.subagent?.input.tokens).toBe(15);
+      expect(usage.sourceTotals?.subagent?.output.tokens).toBe(8);
     });
 
     it("ignores stale session-usage fetch when a newer refresh supersedes it", async () => {

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -44,8 +44,11 @@ import { resolveModelForMetadata } from "@/common/utils/providers/modelEntries";
 import { computeProvidersConfigFingerprint } from "@/common/utils/providers/configFingerprint";
 import { isDurableCompactionBoundaryMarker } from "@/common/utils/messages/compactionBoundary";
 import { WorkspaceConsumerManager } from "./WorkspaceConsumerManager";
-import type { ChatUsageDisplay } from "@/common/utils/tokens/usageAggregator";
-import { sumUsageHistory } from "@/common/utils/tokens/usageAggregator";
+import {
+  sumUsageHistory,
+  type ChatUsageDisplay,
+  type SessionUsageSource,
+} from "@/common/utils/tokens/usageAggregator";
 import type { TokenConsumer } from "@/common/types/chatStats";
 import { normalizeGatewayModel } from "@/common/utils/ai/models";
 import type { z } from "zod";
@@ -138,6 +141,8 @@ type DerivedState = Record<string, number>;
 export interface WorkspaceUsageState {
   /** Pre-computed session total (sum of all models) */
   sessionTotal?: ChatUsageDisplay;
+  /** Session totals grouped by usage source category (main/system1/plan/subagent). */
+  sourceTotals?: Partial<Record<SessionUsageSource, ChatUsageDisplay>>;
   /** Last completed request (persisted) */
   lastRequest?: {
     model: string;
@@ -324,6 +329,8 @@ function getMaxHistorySequence(messages: MuxMessage[]): number | undefined {
   return max;
 }
 
+const USAGE_COMPONENT_KEYS = ["input", "cached", "cacheCreate", "output", "reasoning"] as const;
+
 /**
  * Detect gateway-billed (costs-included) usage entries.
  * `createDisplayUsage` sets `costsIncluded: true` when
@@ -367,9 +374,8 @@ function isCostsIncludedEntry(
     return false;
   }
 
-  const components = ["input", "cached", "cacheCreate", "output", "reasoning"] as const;
   let hasTokens = false;
-  for (const key of components) {
+  for (const key of USAGE_COMPONENT_KEYS) {
     const component = usage[key];
     if (component.tokens > 0) {
       hasTokens = true;
@@ -380,6 +386,52 @@ function isCostsIncludedEntry(
   }
 
   return hasTokens;
+}
+
+function repriceSourceUsageWithSessionBlend(
+  sourceUsage: ChatUsageDisplay,
+  repricedSessionTotal: ChatUsageDisplay
+): ChatUsageDisplay {
+  if (sourceUsage.costsIncluded === true) {
+    return sourceUsage;
+  }
+
+  const repricedSource: ChatUsageDisplay = {
+    ...sourceUsage,
+    input: { ...sourceUsage.input },
+    cached: { ...sourceUsage.cached },
+    cacheCreate: { ...sourceUsage.cacheCreate },
+    output: { ...sourceUsage.output },
+    reasoning: { ...sourceUsage.reasoning },
+  };
+
+  let hasUnknownCosts = false;
+  for (const key of USAGE_COMPONENT_KEYS) {
+    const sessionComponent = repricedSessionTotal[key];
+    const sourceComponent = repricedSource[key];
+
+    if (sessionComponent.cost_usd === undefined) {
+      sourceComponent.cost_usd = undefined;
+      hasUnknownCosts = true;
+      continue;
+    }
+
+    if (sessionComponent.tokens <= 0) {
+      sourceComponent.cost_usd = 0;
+      continue;
+    }
+
+    const blendedRate = sessionComponent.cost_usd / sessionComponent.tokens;
+    sourceComponent.cost_usd = sourceComponent.tokens * blendedRate;
+  }
+
+  if (hasUnknownCosts) {
+    repricedSource.hasUnknownCosts = true;
+  } else {
+    delete repricedSource.hasUnknownCosts;
+  }
+
+  return repricedSource;
 }
 
 /**
@@ -409,6 +461,26 @@ function repriceSessionUsage(
   ) {
     const resolved = resolveModelForMetadata(usage.lastRequest.model, config);
     usage.lastRequest.usage = recomputeUsageCosts(usage.lastRequest.usage, resolved);
+  }
+
+  if (!usage.bySource) {
+    return;
+  }
+
+  // Source buckets aggregate multiple models, so we reprice them using the
+  // repriced session-level blended component rates to keep source breakdown
+  // costs aligned with the canonical byModel totals.
+  const repricedSessionTotal = sumUsageHistory(Object.values(usage.byModel));
+  if (!repricedSessionTotal) {
+    return;
+  }
+
+  for (const source of Object.keys(usage.bySource) as SessionUsageSource[]) {
+    const sourceUsage = usage.bySource[source];
+    if (!sourceUsage) {
+      continue;
+    }
+    usage.bySource[source] = repriceSourceUsageWithSessionBlend(sourceUsage, repricedSessionTotal);
   }
 }
 
@@ -744,6 +816,17 @@ export class WorkspaceStore {
       for (const [model, usage] of Object.entries(usageDelta.byModelDelta)) {
         const existing = current.byModel[model];
         current.byModel[model] = existing ? sumUsageHistory([existing, usage])! : usage;
+      }
+
+      if (usageDelta.bySourceDelta) {
+        const mergedBySource = { ...(current.bySource ?? {}) };
+        for (const [source, usage] of Object.entries(usageDelta.bySourceDelta)) {
+          const existing = mergedBySource[source as SessionUsageSource];
+          mergedBySource[source as SessionUsageSource] = existing
+            ? sumUsageHistory([existing, usage])!
+            : usage;
+        }
+        current.bySource = mergedBySource;
       }
 
       this.sessionUsage.set(workspaceId, current);
@@ -1993,6 +2076,7 @@ export class WorkspaceStore {
 
       // Last request from persisted data
       const lastRequest = sessionData?.lastRequest;
+      const sourceTotals = sessionData?.bySource;
 
       // Calculate total tokens from session total
       const totalTokens = sessionTotal
@@ -2082,7 +2166,15 @@ export class WorkspaceStore {
             )
           : undefined;
 
-      return { sessionTotal, lastRequest, lastContextUsage, totalTokens, liveUsage, liveCostUsage };
+      return {
+        sessionTotal,
+        sourceTotals,
+        lastRequest,
+        lastContextUsage,
+        totalTokens,
+        liveUsage,
+        liveCostUsage,
+      };
     });
   }
 

--- a/src/common/orpc/schemas/chatStats.test.ts
+++ b/src/common/orpc/schemas/chatStats.test.ts
@@ -17,6 +17,16 @@ describe("SessionUsageFileSchema conformance", () => {
           model: "gpt-4",
         },
       },
+      bySource: {
+        main: {
+          input: { tokens: 1, cost_usd: 0.01 },
+          cached: { tokens: 0, cost_usd: 0 },
+          cacheCreate: { tokens: 0, cost_usd: 0 },
+          output: { tokens: 2, cost_usd: 0.02 },
+          reasoning: { tokens: 0, cost_usd: 0 },
+          model: "gpt-4",
+        },
+      },
       lastRequest: {
         model: "gpt-4",
         usage: {
@@ -59,6 +69,7 @@ describe("SessionUsageFileSchema conformance", () => {
     const parsed = SessionUsageFileSchema.parse(legacy);
     expect(parsed.byModel).toEqual({});
     expect(parsed.version).toBe(1);
+    expect(parsed.bySource).toBeUndefined();
     expect(parsed.rolledUpFrom).toBeUndefined();
     expect(parsed.tokenStatsCache).toBeUndefined();
   });

--- a/src/common/orpc/schemas/chatStats.ts
+++ b/src/common/orpc/schemas/chatStats.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { SESSION_USAGE_SOURCES } from "@/common/utils/tokens/usageAggregator";
 
 /** Top file path entry for file_read/file_edit consumers */
 export const TopFilePathSchema = z.object({
@@ -86,6 +87,10 @@ export const SessionUsageTokenStatsCacheSchema = z.object({
  */
 export const SessionUsageFileSchema = z.object({
   byModel: z.record(z.string(), ChatUsageDisplaySchema),
+  bySource: z
+    .partialRecord(z.enum(SESSION_USAGE_SOURCES), ChatUsageDisplaySchema)
+    .optional()
+    .meta({ description: "Aggregated usage by source category (main/system1/plan/subagent)" }),
   lastRequest: z
     .object({
       model: z.string(),

--- a/src/common/orpc/schemas/stream.ts
+++ b/src/common/orpc/schemas/stream.ts
@@ -13,6 +13,7 @@ import {
 } from "./message";
 import { MuxProviderOptionsSchema } from "./providerOptions";
 import { RuntimeModeSchema } from "./runtime";
+import { SESSION_USAGE_SOURCES } from "@/common/utils/tokens/usageAggregator";
 
 // Chat Events
 
@@ -409,6 +410,12 @@ export const SessionUsageDeltaEventSchema = z.object({
   workspaceId: z.string().meta({ description: "Parent workspace ID" }),
   sourceWorkspaceId: z.string().meta({ description: "Deleted child workspace ID" }),
   byModelDelta: z.record(z.string(), ChatUsageDisplaySchema),
+  bySourceDelta: z
+    .partialRecord(z.enum(SESSION_USAGE_SOURCES), ChatUsageDisplaySchema)
+    .optional()
+    .meta({
+      description: "Optional source-level usage rolled up from the deleted child workspace",
+    }),
   timestamp: z.number(),
 });
 export const UsageDeltaEventSchema = z.object({

--- a/src/common/utils/tokens/usageAggregator.ts
+++ b/src/common/utils/tokens/usageAggregator.ts
@@ -13,6 +13,15 @@ export interface ChatUsageComponent {
 }
 
 /**
+ * High-level source categories for accumulated session usage.
+ *
+ * Used for attribution/debugging in session-usage.json and Costs tab.
+ */
+export const SESSION_USAGE_SOURCES = ["main", "system1", "plan", "subagent"] as const;
+export type SessionUsageSource = (typeof SESSION_USAGE_SOURCES)[number];
+export const DEFAULT_SESSION_USAGE_SOURCE: SessionUsageSource = "main";
+
+/**
  * Enhanced usage type for display that includes provider-specific cache stats
  */
 export interface ChatUsageDisplay {

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -41,7 +41,11 @@ import { delegatedToolCallManager } from "./delegatedToolCallManager";
 import { createErrorEvent } from "./utils/sendMessageError";
 import { createAssistantMessageId } from "./utils/messageIds";
 import type { SessionUsageService } from "./sessionUsageService";
-import { sumUsageHistory, getTotalCost } from "@/common/utils/tokens/usageAggregator";
+import {
+  sumUsageHistory,
+  getTotalCost,
+  type SessionUsageSource,
+} from "@/common/utils/tokens/usageAggregator";
 import { readToolInstructions } from "./systemMessage";
 import type { TelemetryService } from "@/node/services/telemetryService";
 
@@ -1081,6 +1085,9 @@ export class AIService extends EventEmitter {
             })
           : tools;
 
+      const sessionUsageSource: SessionUsageSource =
+        effectiveMode === "plan" ? "plan" : isSubagentWorkspace ? "subagent" : "main";
+
       const streamResult = await this.streamManager.startStream(
         workspaceId,
         finalMessages,
@@ -1110,7 +1117,8 @@ export class AIService extends EventEmitter {
         effectiveThinkingLevel,
         requestHeaders,
         effectiveMuxProviderOptions.anthropic?.cacheTtl ?? undefined,
-        stopAfterSuccessfulProposePlan
+        stopAfterSuccessfulProposePlan,
+        sessionUsageSource
       );
 
       if (!streamResult.success) {

--- a/src/node/services/sessionUsageService.test.ts
+++ b/src/node/services/sessionUsageService.test.ts
@@ -118,6 +118,42 @@ describe("SessionUsageService", () => {
       expect(result!.byModel[model].output.tokens).toBe(5);
       expect(result!.rolledUpFrom?.[childWorkspaceId]).toBe(true);
     });
+
+    it("should merge child source attribution into parent", async () => {
+      const projectPath = "/tmp/mux-session-usage-test-project";
+      const model = "claude-sonnet-4-20250514";
+      const parentWorkspaceId = "parent-workspace";
+      const childWorkspaceId = "child-workspace";
+
+      await config.addWorkspace(projectPath, {
+        id: parentWorkspaceId,
+        name: "parent-branch",
+        projectName: "test-project",
+        projectPath,
+        runtimeConfig: { type: "local" },
+      });
+
+      await service.recordUsage(parentWorkspaceId, model, createUsage(100, 50), "main");
+
+      const rollup = await service.rollUpUsageIntoParent(
+        parentWorkspaceId,
+        childWorkspaceId,
+        { [model]: createUsage(10, 5) },
+        {
+          subagent: createUsage(8, 4),
+          system1: createUsage(2, 1),
+        }
+      );
+
+      expect(rollup.didRollUp).toBe(true);
+
+      const result = await service.getSessionUsage(parentWorkspaceId);
+      expect(result).toBeDefined();
+      expect(result!.bySource).toBeDefined();
+      expect(result!.bySource?.main?.input.tokens).toBe(100);
+      expect(result!.bySource?.subagent?.input.tokens).toBe(8);
+      expect(result!.bySource?.system1?.input.tokens).toBe(2);
+    });
   });
   describe("recordUsage", () => {
     it("should accumulate usage for same model (not overwrite)", async () => {
@@ -135,6 +171,22 @@ describe("SessionUsageService", () => {
       expect(result!.byModel[model].output.tokens).toBe(125); // 50 + 75
     });
 
+    it("should accumulate usage by source for attribution", async () => {
+      const workspaceId = "test-workspace";
+      const model = "claude-sonnet-4-20250514";
+
+      await service.recordUsage(workspaceId, model, createUsage(100, 50), "main");
+      await service.recordUsage(workspaceId, model, createUsage(20, 5), "system1");
+      await service.recordUsage(workspaceId, model, createUsage(30, 10), "main");
+
+      const result = await service.getSessionUsage(workspaceId);
+      expect(result).toBeDefined();
+      expect(result!.bySource).toBeDefined();
+      expect(result!.bySource?.main?.input.tokens).toBe(130);
+      expect(result!.bySource?.main?.output.tokens).toBe(60);
+      expect(result!.bySource?.system1?.input.tokens).toBe(20);
+      expect(result!.bySource?.system1?.output.tokens).toBe(5);
+    });
     it("should track separate usage per model", async () => {
       const workspaceId = "test-workspace";
       const sonnet = createUsage(100, 50);

--- a/src/node/services/sessionUsageService.ts
+++ b/src/node/services/sessionUsageService.ts
@@ -5,8 +5,12 @@ import assert from "@/common/utils/assert";
 import type { Config } from "@/node/config";
 import type { HistoryService } from "./historyService";
 import { workspaceFileLocks } from "@/node/utils/concurrency/workspaceFileLocks";
-import type { ChatUsageDisplay } from "@/common/utils/tokens/usageAggregator";
-import { sumUsageHistory } from "@/common/utils/tokens/usageAggregator";
+import {
+  DEFAULT_SESSION_USAGE_SOURCE,
+  sumUsageHistory,
+  type ChatUsageDisplay,
+  type SessionUsageSource,
+} from "@/common/utils/tokens/usageAggregator";
 import { createDisplayUsage } from "@/common/utils/tokens/displayUsage";
 import { normalizeGatewayModel } from "@/common/utils/ai/models";
 import type { TokenConsumer } from "@/common/types/chatStats";
@@ -47,6 +51,13 @@ export interface SessionUsageTokenStatsCacheV1 {
 
 export interface SessionUsageFile {
   byModel: Record<string, ChatUsageDisplay>;
+  /**
+   * Cumulative usage grouped by source category (main/system1/plan/subagent).
+   *
+   * This is additive metadata for attribution/debugging and does not replace
+   * byModel, which remains the canonical aggregation for cost totals.
+   */
+  bySource?: Partial<Record<SessionUsageSource, ChatUsageDisplay>>;
   lastRequest?: {
     model: string;
     usage: ChatUsageDisplay;
@@ -128,12 +139,22 @@ export class SessionUsageService {
    * AND updates lastRequest in a single atomic write.
    * Model should already be normalized via normalizeGatewayModel().
    */
-  async recordUsage(workspaceId: string, model: string, usage: ChatUsageDisplay): Promise<void> {
+  async recordUsage(
+    workspaceId: string,
+    model: string,
+    usage: ChatUsageDisplay,
+    source: SessionUsageSource = DEFAULT_SESSION_USAGE_SOURCE
+  ): Promise<void> {
     return this.fileLocks.withLock(workspaceId, async () => {
       const current = await this.readFile(workspaceId);
       const existing = current.byModel[model];
       // CRITICAL: Accumulate, don't overwrite
       current.byModel[model] = existing ? sumUsageHistory([existing, usage])! : usage;
+
+      const existingBySource = current.bySource?.[source];
+      const nextBySource = existingBySource ? sumUsageHistory([existingBySource, usage])! : usage;
+      current.bySource = { ...(current.bySource ?? {}), [source]: nextBySource };
+
       current.lastRequest = { model, usage, timestamp: Date.now() };
       await this.writeFile(workspaceId, current);
     });
@@ -203,7 +224,8 @@ export class SessionUsageService {
   async rollUpUsageIntoParent(
     parentWorkspaceId: string,
     childWorkspaceId: string,
-    childUsageByModel: Record<string, ChatUsageDisplay>
+    childUsageByModel: Record<string, ChatUsageDisplay>,
+    childUsageBySource?: Partial<Record<SessionUsageSource, ChatUsageDisplay>>
   ): Promise<{ didRollUp: boolean }> {
     assert(parentWorkspaceId.trim().length > 0, "rollUpUsageIntoParent: parentWorkspaceId empty");
     assert(childWorkspaceId.trim().length > 0, "rollUpUsageIntoParent: childWorkspaceId empty");
@@ -217,8 +239,9 @@ export class SessionUsageService {
       return { didRollUp: false };
     }
 
-    const entries = Object.entries(childUsageByModel);
-    if (entries.length === 0) {
+    const modelEntries = Object.entries(childUsageByModel);
+    const sourceEntries = Object.entries(childUsageBySource ?? {});
+    if (modelEntries.length === 0 && sourceEntries.length === 0) {
       return { didRollUp: false };
     }
 
@@ -244,9 +267,20 @@ export class SessionUsageService {
         return { didRollUp: false };
       }
 
-      for (const [model, usage] of entries) {
+      for (const [model, usage] of modelEntries) {
         const existing = current.byModel[model];
         current.byModel[model] = existing ? sumUsageHistory([existing, usage])! : usage;
+      }
+
+      if (sourceEntries.length > 0) {
+        const mergedBySource = { ...(current.bySource ?? {}) };
+        for (const [source, usage] of sourceEntries) {
+          const existing = mergedBySource[source as SessionUsageSource];
+          mergedBySource[source as SessionUsageSource] = existing
+            ? sumUsageHistory([existing, usage])!
+            : usage;
+        }
+        current.bySource = mergedBySource;
       }
 
       current.rolledUpFrom = { ...(current.rolledUpFrom ?? {}), [childWorkspaceId]: true };

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -1165,7 +1165,13 @@ describe("StreamManager - previousResponseId recovery", () => {
         model,
         messages: [{ role: "user", content: "original" }],
         system: "system",
-        providerOptions: { openai: { previousResponseId: "resp_abc123" } },
+        providerOptions: {
+          openai: {
+            previousResponseId: "resp_abc123",
+            // Keep prompt cache routing stable when we recover from a lost response ID.
+            promptCacheKey: "mux-v1-ws-step",
+          },
+        },
       },
       parts: [
         {
@@ -1219,6 +1225,7 @@ describe("StreamManager - previousResponseId recovery", () => {
       openai?: Record<string, unknown>;
     };
     expect(openaiOptions.openai?.previousResponseId).toBeUndefined();
+    expect(openaiOptions.openai?.promptCacheKey).toBe("mux-v1-ws-step");
   });
 
   test("resolveTotalUsageForStreamEnd prefers cumulative usage after step retry", () => {
@@ -1731,6 +1738,101 @@ describe("StreamManager - ask_user_question Partial Persistence", () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const flushMethod = Reflect.get(streamManager, "flushPartialWrite");
     expect(typeof flushMethod).toBe("function");
+  });
+});
+
+describe("StreamManager - abort cleanup deduplication", () => {
+  test("soft interrupt only schedules abort cleanup once", async () => {
+    const streamManager = new StreamManager(historyService);
+
+    let flushCalls = 0;
+    const replaceFlush = Reflect.set(streamManager, "flushPartialWrite", () => {
+      flushCalls += 1;
+      return Promise.resolve();
+    });
+    expect(replaceFlush).toBe(true);
+
+    let cleanupCalls = 0;
+    const replaceCleanup = Reflect.set(streamManager, "cleanupAbortedStream", () => {
+      cleanupCalls += 1;
+      return Promise.resolve();
+    });
+    expect(replaceCleanup).toBe(true);
+
+    const checkSoftCancelStream = Reflect.get(streamManager, "checkSoftCancelStream") as
+      | ((workspaceId: string, streamInfo: unknown) => void)
+      | undefined;
+    expect(typeof checkSoftCancelStream).toBe("function");
+
+    const streamInfo = {
+      state: "streaming",
+      abortController: new AbortController(),
+      softInterrupt: {
+        pending: true,
+        abandonPartial: false,
+        abortReason: "user",
+      },
+      abortCleanupPromise: undefined,
+    };
+
+    checkSoftCancelStream?.call(streamManager, "workspace-soft-interrupt", streamInfo);
+    checkSoftCancelStream?.call(streamManager, "workspace-soft-interrupt", streamInfo);
+
+    // Allow detached cleanup promise to run.
+    await Promise.resolve();
+
+    expect(flushCalls).toBe(1);
+    expect(cleanupCalls).toBe(1);
+    expect(streamInfo.softInterrupt.pending).toBe(false);
+    expect(streamInfo.abortController.signal.aborted).toBe(true);
+  });
+
+  test("signals abort immediately even when partial flush is blocked", async () => {
+    const streamManager = new StreamManager(historyService);
+
+    let resolveFlush: (() => void) | undefined;
+    const flushGate = new Promise<void>((resolve) => {
+      resolveFlush = resolve;
+    });
+
+    const replaceFlush = Reflect.set(streamManager, "flushPartialWrite", () => flushGate);
+    expect(replaceFlush).toBe(true);
+
+    let cleanupCalls = 0;
+    const replaceCleanup = Reflect.set(streamManager, "cleanupAbortedStream", () => {
+      cleanupCalls += 1;
+      return Promise.resolve();
+    });
+    expect(replaceCleanup).toBe(true);
+
+    const checkSoftCancelStream = Reflect.get(streamManager, "checkSoftCancelStream") as
+      | ((workspaceId: string, streamInfo: unknown) => void)
+      | undefined;
+    expect(typeof checkSoftCancelStream).toBe("function");
+
+    const streamInfo = {
+      state: "streaming",
+      abortController: new AbortController(),
+      softInterrupt: {
+        pending: true,
+        abandonPartial: false,
+        abortReason: "user",
+      },
+      abortCleanupPromise: undefined,
+    };
+
+    checkSoftCancelStream?.call(streamManager, "workspace-soft-interrupt-window", streamInfo);
+
+    // Abort should be signaled before waiting on flushPartialWrite.
+    expect(streamInfo.softInterrupt.pending).toBe(false);
+    expect(streamInfo.abortController.signal.aborted).toBe(true);
+    expect(cleanupCalls).toBe(0);
+
+    resolveFlush?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(cleanupCalls).toBe(1);
   });
 });
 

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -51,6 +51,10 @@ import {
 } from "@/common/utils/ai/cacheStrategy";
 import type { SessionUsageService } from "./sessionUsageService";
 import { createDisplayUsage } from "@/common/utils/tokens/displayUsage";
+import {
+  DEFAULT_SESSION_USAGE_SOURCE,
+  type SessionUsageSource,
+} from "@/common/utils/tokens/usageAggregator";
 import { extractToolMediaAsUserMessagesFromModelMessages } from "@/node/utils/messages/extractToolMediaAsUserMessagesFromModelMessages";
 import { normalizeGatewayModel } from "@/common/utils/ai/models";
 import { MUX_GATEWAY_SESSION_EXPIRED_MESSAGE } from "@/common/constants/muxGatewayOAuth";
@@ -278,6 +282,8 @@ interface WorkspaceStreamInfo {
   unlinkAbortSignal?: () => void;
   abortController: AbortController;
   workspaceName?: string;
+  /** Usage source category persisted in session-usage.json for attribution. */
+  usageSource: SessionUsageSource;
   messageId: string;
   token: StreamToken;
   startTime: number;
@@ -321,6 +327,9 @@ interface WorkspaceStreamInfo {
   softInterrupt:
     | { pending: false }
     | { pending: true; abandonPartial: boolean; abortReason: StreamAbortReason };
+  // Tracks in-flight abort cleanup so multiple interrupt paths don't duplicate
+  // session usage recording or stream-abort events.
+  abortCleanupPromise?: Promise<void>;
   // Temporary directory for tool outputs (auto-cleaned when stream ends)
   runtimeTempDir: string;
   // Runtime for temp directory cleanup
@@ -865,6 +874,31 @@ export class StreamManager extends EventEmitter {
     }
   }
 
+  private beginAbortCleanup(
+    workspaceId: WorkspaceId,
+    streamInfo: WorkspaceStreamInfo,
+    abortReason: StreamAbortReason,
+    abandonPartial?: boolean
+  ): Promise<void> {
+    // Deduplicate abort cleanup across concurrent/overlapping interrupt paths.
+    // Without this guard, soft interrupts can schedule multiple cleanup tasks,
+    // causing duplicate session usage recording and duplicate stream-abort events.
+    streamInfo.abortCleanupPromise ??= (async () => {
+      // Signal abort immediately so the stream loop stops before we do any
+      // remaining cleanup work (including waiting on partial-write flushing).
+      streamInfo.abortController.abort();
+      streamInfo.softInterrupt = { pending: false };
+
+      // Flush any pending partial write after signaling abort to preserve
+      // already-produced content without allowing additional stream work.
+      await this.flushPartialWrite(workspaceId, streamInfo);
+
+      await this.cleanupAbortedStream(workspaceId, streamInfo, abortReason, abandonPartial);
+    })();
+
+    return streamInfo.abortCleanupPromise;
+  }
+
   private async cancelStreamSafely(
     workspaceId: WorkspaceId,
     streamInfo: WorkspaceStreamInfo,
@@ -887,13 +921,8 @@ export class StreamManager extends EventEmitter {
 
     try {
       streamInfo.state = StreamState.STOPPING;
-      // Flush any pending partial write immediately (preserves work on interruption)
-      await this.flushPartialWrite(workspaceId, streamInfo);
-
-      streamInfo.abortController.abort();
-
       // Unlike checkSoftCancelStream, await cleanup (blocking)
-      await this.cleanupAbortedStream(workspaceId, streamInfo, abortReason, abandonPartial);
+      await this.beginAbortCleanup(workspaceId, streamInfo, abortReason, abandonPartial);
     } catch (error) {
       log.error("Error during stream cancellation:", error);
       // Force cleanup even if cancellation fails
@@ -903,23 +932,25 @@ export class StreamManager extends EventEmitter {
 
   // Checks if a soft interrupt is necessary, and performs one if so
   // Similar to cancelStreamSafely but performs cleanup without blocking
-  private async checkSoftCancelStream(
-    workspaceId: WorkspaceId,
-    streamInfo: WorkspaceStreamInfo
-  ): Promise<void> {
-    if (!streamInfo.softInterrupt.pending) return;
+  private checkSoftCancelStream(workspaceId: WorkspaceId, streamInfo: WorkspaceStreamInfo): void {
+    if (!streamInfo.softInterrupt.pending || streamInfo.abortCleanupPromise) return;
     try {
       streamInfo.state = StreamState.STOPPING;
 
-      // Flush any pending partial write immediately (preserves work on interruption)
-      await this.flushPartialWrite(workspaceId, streamInfo);
-
-      streamInfo.abortController.abort();
+      // Capture the pending interrupt metadata. Keep pending=true until
+      // beginAbortCleanup actually signals abort so other guards still observe
+      // interruption while flushPartialWrite is in-flight.
+      const { abandonPartial, abortReason } = streamInfo.softInterrupt;
 
       // Return back to the stream loop so we can wait for it to finish before
       // sending the stream abort event.
-      const { abandonPartial, abortReason } = streamInfo.softInterrupt;
-      void this.cleanupAbortedStream(workspaceId, streamInfo, abortReason, abandonPartial);
+      void this.beginAbortCleanup(workspaceId, streamInfo, abortReason, abandonPartial).catch(
+        (error) => {
+          log.error("Error during stream cancellation:", error);
+          // Force cleanup even if cancellation fails
+          this.workspaceStreams.delete(workspaceId);
+        }
+      );
     } catch (error) {
       log.error("Error during stream cancellation:", error);
       // Force cleanup even if cancellation fails
@@ -989,7 +1020,7 @@ export class StreamManager extends EventEmitter {
     providerMetadata: Record<string, unknown> | undefined,
     logMessage: string,
     logLevel: "warn" | "error",
-    streamInfo?: Pick<WorkspaceStreamInfo, "workspaceName" | "metadataModel">
+    streamInfo?: Pick<WorkspaceStreamInfo, "workspaceName" | "metadataModel" | "usageSource">
   ): Promise<void> {
     if (!this.sessionUsageService || !usage) {
       return;
@@ -1008,7 +1039,8 @@ export class StreamManager extends EventEmitter {
       await this.sessionUsageService.recordUsage(
         workspaceId as string,
         normalizeGatewayModel(model),
-        messageUsage
+        messageUsage,
+        streamInfo?.usageSource ?? DEFAULT_SESSION_USAGE_SOURCE
       );
     } catch (error) {
       (logLevel === "error" ? workspaceLog.error : workspaceLog.warn)(logMessage, { error });
@@ -1252,7 +1284,8 @@ export class StreamManager extends EventEmitter {
     thinkingLevel?: string,
     headers?: Record<string, string | undefined>,
     anthropicCacheTtlOverride?: AnthropicCacheTtl,
-    stopAfterSuccessfulProposePlan?: boolean
+    stopAfterSuccessfulProposePlan?: boolean,
+    usageSource: SessionUsageSource = DEFAULT_SESSION_USAGE_SOURCE
   ): WorkspaceStreamInfo {
     // abortController is created and linked to the caller-provided abortSignal in startStream().
 
@@ -1290,6 +1323,7 @@ export class StreamManager extends EventEmitter {
       state: StreamState.STARTING,
       streamResult,
       workspaceName,
+      usageSource,
       abortController,
       messageId,
       token: streamToken,
@@ -1310,6 +1344,7 @@ export class StreamManager extends EventEmitter {
       partialWritePromise: undefined, // No write in flight initially
       processingPromise: Promise.resolve(), // Placeholder, overwritten in startStream
       softInterrupt: { pending: false },
+      abortCleanupPromise: undefined,
       runtimeTempDir, // Stream-scoped temp directory for tool outputs
       runtime, // Runtime for temp directory cleanup
       // Initialize cumulative tracking for multi-step streams
@@ -1395,7 +1430,7 @@ export class StreamManager extends EventEmitter {
     output: unknown
   ): Promise<void> {
     await this.completeToolCall(workspaceId, streamInfo, toolCalls, toolCallId, toolName, output);
-    await this.checkSoftCancelStream(workspaceId, streamInfo);
+    this.checkSoftCancelStream(workspaceId, streamInfo);
   }
 
   private logOrphanToolResult(
@@ -1728,7 +1763,7 @@ export class StreamManager extends EventEmitter {
                   workspaceId: workspaceId as string,
                   messageId: streamInfo.messageId,
                 });
-                await this.checkSoftCancelStream(workspaceId, streamInfo);
+                this.checkSoftCancelStream(workspaceId, streamInfo);
                 break;
               }
 
@@ -1937,12 +1972,12 @@ export class StreamManager extends EventEmitter {
                 };
                 streamInfo.currentStepStartIndex = streamInfo.parts.length;
                 this.emit("usage-delta", usageEvent);
-                await this.checkSoftCancelStream(workspaceId, streamInfo);
+                this.checkSoftCancelStream(workspaceId, streamInfo);
                 break;
               }
 
               case "text-end": {
-                await this.checkSoftCancelStream(workspaceId, streamInfo);
+                this.checkSoftCancelStream(workspaceId, streamInfo);
                 break;
               }
             }
@@ -2660,7 +2695,8 @@ export class StreamManager extends EventEmitter {
     thinkingLevel?: string,
     headers?: Record<string, string | undefined>,
     anthropicCacheTtlOverride?: AnthropicCacheTtl,
-    stopAfterSuccessfulProposePlan?: boolean
+    stopAfterSuccessfulProposePlan?: boolean,
+    usageSource: SessionUsageSource = DEFAULT_SESSION_USAGE_SOURCE
   ): Promise<Result<StreamToken, SendMessageError>> {
     const typedWorkspaceId = workspaceId as WorkspaceId;
 
@@ -2738,7 +2774,8 @@ export class StreamManager extends EventEmitter {
           thinkingLevel,
           headers,
           anthropicCacheTtlOverride,
-          stopAfterSuccessfulProposePlan
+          stopAfterSuccessfulProposePlan,
+          usageSource
         );
 
         // Guard against a narrow race:

--- a/src/node/services/system1ToolWrapper.ts
+++ b/src/node/services/system1ToolWrapper.ts
@@ -406,7 +406,8 @@ async function maybeFilterBashOutput(
             void opts.sessionUsageService.recordUsage(
               opts.workspaceId,
               normalizedModel,
-              displayUsage
+              displayUsage,
+              "system1"
             );
           }
         }

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -1982,7 +1982,8 @@ export class WorkspaceService extends EventEmitter {
               const rollup = await this.sessionUsageService.rollUpUsageIntoParent(
                 parentWorkspaceId,
                 workspaceId,
-                childUsage.byModel
+                childUsage.byModel,
+                childUsage.bySource
               );
 
               if (rollup.didRollUp) {
@@ -1992,6 +1993,7 @@ export class WorkspaceService extends EventEmitter {
                   workspaceId: parentWorkspaceId,
                   sourceWorkspaceId: workspaceId,
                   byModelDelta: childUsage.byModel,
+                  bySourceDelta: childUsage.bySource,
                   timestamp: Date.now(),
                 });
               }


### PR DESCRIPTION
## Summary
Add source-level session usage attribution and harden stream abort cleanup so interrupted streams cannot double-count token usage or continue consuming work after a soft interrupt.

## Background
We needed clearer attribution for high input-token sessions (main chat vs. system overhead) and identified interrupt-path races that could overcount usage during abort handling.

## Implementation
- Added `SessionUsageSource` categories (`main`, `system1`, `plan`, `subagent`) and threaded attribution through:
  - usage persistence (`SessionUsageService`)
  - stream/session schemas
  - workspace rollup delta events
  - AI request entry points (`AIService`, `System1ToolWrapper`)
  - renderer state hydration/merge logic (`WorkspaceStore`)
  - Costs tab source breakdown UI
- Hardened StreamManager abort teardown:
  - deduplicate overlapping cleanup paths with a shared abort-cleanup promise
  - signal abort immediately before awaiting partial-write flushing, preventing extra stream/tool work after a soft interrupt
  - added regression coverage for cleanup dedupe and blocked-flush interrupt ordering
- Updated WorkspaceStore repricing to keep `bySource` costs aligned with repriced `byModel` totals using blended session component rates, preventing stale source-cost displays after pricing/mapping changes.

## Validation
- `make static-check`
- `bun test src/node/services/streamManager.test.ts src/node/services/sessionUsageService.test.ts src/browser/stores/WorkspaceStore.test.ts src/common/orpc/schemas/chatStats.test.ts`

## Risks
- Low-to-moderate: touches stream interrupt teardown and usage accounting paths. Regressions would most likely appear as incorrect source-level cost attribution or interrupt edge-case behavior; both paths now have focused regression tests.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$13.74`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=13.74 -->
