### PR TITLE
🤖 fix: inject User-Agent into AI provider requests

### DIFF
--- a/src/node/services/providerModelFactory.test.ts
+++ b/src/node/services/providerModelFactory.test.ts
@@ -9,6 +9,7 @@ import {
   buildAIProviderRequestHeaders,
   modelCostsIncluded,
   MUX_AI_PROVIDER_USER_AGENT,
+  resolveAIProviderHeaderSource,
 } from "./providerModelFactory";
 import { ProviderService } from "./providerService";
 
@@ -189,6 +190,44 @@ describe("ProviderModelFactory.resolveGatewayModelString", () => {
         });
       }
     });
+  });
+});
+
+describe("resolveAIProviderHeaderSource", () => {
+  it("uses Request headers when init.headers is not provided", () => {
+    const input = new Request("https://example.com", {
+      headers: {
+        Authorization: "Bearer test-token",
+      },
+    });
+
+    const result = resolveAIProviderHeaderSource(input, undefined);
+    const headers = new Headers(result);
+
+    expect(headers.get("authorization")).toBe("Bearer test-token");
+  });
+
+  it("prefers init.headers over Request headers", () => {
+    const input = new Request("https://example.com", {
+      headers: {
+        Authorization: "Bearer test-token",
+      },
+    });
+
+    const result = resolveAIProviderHeaderSource(input, {
+      headers: {
+        "x-custom": "value",
+      },
+    });
+    const headers = new Headers(result);
+
+    expect(headers.get("x-custom")).toBe("value");
+    expect(headers.get("authorization")).toBeNull();
+  });
+
+  it("returns undefined for non-Request inputs without init headers", () => {
+    const result = resolveAIProviderHeaderSource("https://example.com", undefined);
+    expect(result).toBeUndefined();
   });
 });
 

--- a/src/node/services/providerModelFactory.ts
+++ b/src/node/services/providerModelFactory.ts
@@ -76,6 +76,24 @@ assert(
 );
 
 /**
+ * Resolve the header source for provider fetch calls.
+ *
+ * When fetch is called with a Request object, that Request may already carry
+ * auth/content headers. Preserve those unless init.headers is explicitly provided,
+ * matching fetch override semantics.
+ */
+export function resolveAIProviderHeaderSource(
+  input: RequestInfo | URL,
+  init?: RequestInit
+): HeadersInit | undefined {
+  if (init?.headers != null) {
+    return init.headers;
+  }
+
+  return input instanceof Request ? input.headers : undefined;
+}
+
+/**
  * Build request headers for provider fetch calls, ensuring a User-Agent is always present.
  * Exported for testing.
  */
@@ -105,7 +123,8 @@ const defaultFetchWithUnlimitedTimeout = (async (
   input: RequestInfo | URL,
   init?: RequestInit
 ): Promise<Response> => {
-  const headers = buildAIProviderRequestHeaders(init?.headers);
+  const headerSource = resolveAIProviderHeaderSource(input, init);
+  const headers = buildAIProviderRequestHeaders(headerSource);
 
   // dispatcher is a Node.js undici-specific property for custom HTTP agents
   const requestInit: RequestInitWithDispatcher = {


### PR DESCRIPTION
## Summary
Add a centralized `User-Agent` header for AI provider HTTP requests by injecting it in the shared provider fetch wrapper.

## Background
Mux already set provider attribution headers for compatible platforms, but AI provider calls did not consistently identify Mux via `User-Agent`. We wanted to scope this change only to provider calls and avoid per-provider wiring.

## Implementation
- Added `MUX_AI_PROVIDER_USER_AGENT` in `src/node/services/providerModelFactory.ts`.
  - Version source preference: `MUX_VERSION` env var, then `package.json` version, then `dev` fallback.
- Added `buildAIProviderRequestHeaders(existingHeaders)` helper.
  - Injects `User-Agent` only when absent.
  - Preserves existing headers and respects caller overrides.
- Updated `defaultFetchWithUnlimitedTimeout` to always apply the helper before dispatching requests.
- Added defensive assertion to ensure generated default UA always includes a non-empty version.
- Added unit tests in `src/node/services/providerModelFactory.test.ts` for:
  - injection when missing,
  - preservation of existing User-Agent,
  - preservation of unrelated headers.

## Validation
- `make static-check`
- `bun test src/node/services/providerModelFactory.test.ts`
- `make typecheck`
- `make fmt-check`

## Risks
Low risk and narrowly scoped. This only affects requests that use the default provider fetch wrapper. Custom provider fetch implementations remain unchanged by design.

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$1.15`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=1.15 -->
