### PR TITLE
🤖 fix: fix review line comment tooltip clipping

### DIFF
--- a/src/browser/components/shared/DiffRenderer.tsx
+++ b/src/browser/components/shared/DiffRenderer.tsx
@@ -11,6 +11,7 @@ import { getLanguageFromPath } from "@/common/utils/git/languageDetector";
 import { useOverflowDetection } from "@/browser/hooks/useOverflowDetection";
 import { MessageSquare } from "lucide-react";
 import { InlineReviewNote, type ReviewActionCallbacks } from "./InlineReviewNote";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import { groupDiffLines } from "@/browser/utils/highlighting/diffChunking";
 import { useTheme, type ThemeMode } from "@/browser/contexts/ThemeContext";
 import {
@@ -1377,19 +1378,25 @@ export const SelectableDiffRenderer = React.memo<SelectableDiffRendererProps>(
                   }}
                   reviewButton={
                     onReviewNote && (
-                      <button
-                        type="button"
-                        className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-sm text-[var(--color-review-accent)]/60 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 hover:text-[var(--color-review-accent)] active:scale-90"
-                        style={{ position: "absolute", inset: 0 }}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleCommentButtonClick(displayIndex, e.shiftKey);
-                        }}
-                        title="Add review comment (Shift-click or drag to select range)"
-                        aria-label="Add review comment"
-                      >
-                        <MessageSquare className="size-3" />
-                      </button>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-sm text-[var(--color-review-accent)]/60 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 hover:text-[var(--color-review-accent)] active:scale-90"
+                            style={{ position: "absolute", inset: 0 }}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleCommentButtonClick(displayIndex, e.shiftKey);
+                            }}
+                            aria-label="Add review comment"
+                          >
+                            <MessageSquare className="size-3" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent align="start" side="top">
+                          Add review comment (Shift-click or drag to select range)
+                        </TooltipContent>
+                      </Tooltip>
                     )
                   }
                 />


### PR DESCRIPTION
## Summary
Replace the Review pane's native-title-based comment icon tooltip with the app's shared Radix tooltip so the tooltip text is no longer clipped at the left edge when Shift-click-to-comment UI hints are shown.

## Background
Shift/drag range-selection guidance was shown via a `title` attribute on the review icon. In dense Review pane layouts, that tooltip was being cut off, reducing discoverability of the Shift-click gesture.

## Implementation
- Updated `src/browser/components/shared/DiffRenderer.tsx` to wrap the inline review action button with shared `<Tooltip>`, `<TooltipTrigger>`, and `<TooltipContent>` components.
- Preserved the existing click behavior and icon rendering while only changing tooltip rendering mechanism.
- Removed direct `title` usage for this control to avoid custom `[title]` pseudo-element clipping behavior.

## Validation
- `bun test src/browser/components/shared/SelectableDiffRenderer.dragSelect.test.tsx`
- `make static-check`

## Risks
- Very low. Behavior change is limited to tooltip rendering for the line comment icon; no diff parsing or review data-path logic was changed.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex-spark` • Thinking: `high` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.3-codex-spark thinking=high costs=0.00 -->
