### PR TITLE
🤖 perf: speed up immersive review typing and line selection

### DIFF
--- a/src/browser/components/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/components/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -1111,12 +1111,20 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
       const anchorIndex = shiftKey
         ? (selectedLineRangeRef.current?.startIndex ?? activeLineIndexRef.current ?? lineIndex)
         : lineIndex;
-      setActiveLineIndex(lineIndex);
+      setActiveLineIndex((previousLineIndex) =>
+        previousLineIndex === lineIndex ? previousLineIndex : lineIndex
+      );
 
       if (shiftKey) {
-        setSelectedLineRange({ startIndex: anchorIndex, endIndex: lineIndex });
+        setSelectedLineRange((previousRange) => {
+          if (previousRange?.startIndex === anchorIndex && previousRange?.endIndex === lineIndex) {
+            return previousRange;
+          }
+
+          return { startIndex: anchorIndex, endIndex: lineIndex };
+        });
       } else {
-        setSelectedLineRange(null);
+        setSelectedLineRange((previousRange) => (previousRange === null ? previousRange : null));
       }
 
       if (isTouchExperience && !shiftKey && resolvedHunk) {

--- a/src/browser/components/shared/DiffRenderer.tsx
+++ b/src/browser/components/shared/DiffRenderer.tsx
@@ -1013,12 +1013,60 @@ export const SelectableDiffRenderer = React.memo<SelectableDiffRendererProps>(
     onComposerCancel,
   }) => {
     const dragAnchorRef = React.useRef<number | null>(null);
+    const dragUpdateFrameRef = React.useRef<number | null>(null);
+    const pendingDragLineIndexRef = React.useRef<number | null>(null);
     const [isDragging, setIsDragging] = React.useState(false);
+    const [selection, setSelection] = React.useState<LineSelection | null>(null);
+    const [selectionInitialNoteText, setSelectionInitialNoteText] = React.useState("");
+
+    const flushPendingDragSelection = React.useCallback(() => {
+      const anchorIndex = dragAnchorRef.current;
+      const pendingLineIndex = pendingDragLineIndexRef.current;
+      if (anchorIndex === null || pendingLineIndex === null) {
+        return;
+      }
+
+      pendingDragLineIndexRef.current = null;
+      onLineIndexSelect?.(pendingLineIndex, true);
+      setSelection((previousSelection) => {
+        if (
+          previousSelection?.startIndex === anchorIndex &&
+          previousSelection?.endIndex === pendingLineIndex
+        ) {
+          return previousSelection;
+        }
+
+        return { startIndex: anchorIndex, endIndex: pendingLineIndex };
+      });
+    }, [onLineIndexSelect]);
+
+    const scheduleDragSelectionUpdate = React.useCallback(
+      (lineIndex: number) => {
+        pendingDragLineIndexRef.current = lineIndex;
+
+        if (dragUpdateFrameRef.current !== null) {
+          return;
+        }
+
+        dragUpdateFrameRef.current = window.requestAnimationFrame(() => {
+          dragUpdateFrameRef.current = null;
+          flushPendingDragSelection();
+        });
+      },
+      [flushPendingDragSelection]
+    );
 
     React.useEffect(() => {
       const stopDragging = () => {
+        if (dragUpdateFrameRef.current !== null) {
+          cancelAnimationFrame(dragUpdateFrameRef.current);
+          dragUpdateFrameRef.current = null;
+        }
+
+        flushPendingDragSelection();
         setIsDragging(false);
         dragAnchorRef.current = null;
+        pendingDragLineIndexRef.current = null;
       };
 
       window.addEventListener("mouseup", stopDragging);
@@ -1028,10 +1076,17 @@ export const SelectableDiffRenderer = React.memo<SelectableDiffRendererProps>(
         window.removeEventListener("mouseup", stopDragging);
         window.removeEventListener("blur", stopDragging);
       };
+    }, [flushPendingDragSelection]);
+
+    React.useEffect(() => {
+      return () => {
+        if (dragUpdateFrameRef.current !== null) {
+          cancelAnimationFrame(dragUpdateFrameRef.current);
+        }
+      };
     }, []);
+
     const { theme } = useTheme();
-    const [selection, setSelection] = React.useState<LineSelection | null>(null);
-    const [selectionInitialNoteText, setSelectionInitialNoteText] = React.useState("");
 
     const lastExternalSelectionRequestIdRef = React.useRef<number | null>(null);
     const dismissedExternalSelectionRequestIdRef = React.useRef<number | null>(null);
@@ -1236,12 +1291,27 @@ export const SelectableDiffRenderer = React.memo<SelectableDiffRendererProps>(
         onLineClick?.();
         onLineIndexSelect?.(lineIndex, shiftKey);
 
+        if (dragUpdateFrameRef.current !== null) {
+          cancelAnimationFrame(dragUpdateFrameRef.current);
+          dragUpdateFrameRef.current = null;
+        }
+        pendingDragLineIndexRef.current = null;
+
         const anchor =
           shiftKey && renderSelectionStartIndex !== null ? renderSelectionStartIndex : lineIndex;
         dragAnchorRef.current = anchor;
         setIsDragging(true);
         setSelectionInitialNoteText("");
-        setSelection({ startIndex: anchor, endIndex: lineIndex });
+        setSelection((previousSelection) => {
+          if (
+            previousSelection?.startIndex === anchor &&
+            previousSelection?.endIndex === lineIndex
+          ) {
+            return previousSelection;
+          }
+
+          return { startIndex: anchor, endIndex: lineIndex };
+        });
       },
       [onLineClick, onLineIndexSelect, onReviewNote, renderSelectionStartIndex]
     );
@@ -1252,10 +1322,11 @@ export const SelectableDiffRenderer = React.memo<SelectableDiffRendererProps>(
           return;
         }
 
-        onLineIndexSelect?.(lineIndex, true);
-        setSelection({ startIndex: dragAnchorRef.current, endIndex: lineIndex });
+        // Dragging can emit dozens of mouseenter events per second; coalesce updates
+        // to one per animation frame so immersive line-range selection stays responsive.
+        scheduleDragSelectionUpdate(lineIndex);
       },
-      [isDragging, onLineIndexSelect]
+      [isDragging, scheduleDragSelectionUpdate]
     );
 
     const handleCommentButtonClick = (lineIndex: number, shiftKey: boolean) => {


### PR DESCRIPTION
## Summary

This PR improves immersive review responsiveness by removing per-keystroke React churn from the inline note composer and by smoothing line-range selection updates.

## Background

In immersive review, two interactions felt laggy on large diffs:

1. Typing into the review note box.
2. Dragging/selecting line ranges.

Both paths were triggering frequent state updates that cascaded through large diff render trees.

## Implementation

### 1) Note composer typing perf (`DiffRenderer`)

- Switched `ReviewNoteInput` textarea from controlled (`value` + state update per keypress) to uncontrolled (`defaultValue` + ref read on submit).
- Preserved parent-driven prefill behavior by syncing `initialNoteText` into the textarea via effect.
- Moved autosize updates behind requestAnimationFrame scheduling via `onInput`.
- Added rAF cleanup on unmount.

### 2) Line-range selection perf (`DiffRenderer` + `ImmersiveReviewView`)

- Coalesced drag selection updates to one per animation frame in `SelectableDiffRenderer`.
- Flushed pending drag updates on mouseup/blur to keep final selection accurate.
- Added guards to skip redundant selection/cursor state updates when indices are unchanged.

## Validation

- `make static-check`
- `make typecheck`
- `bun run eslint src/browser/components/shared/DiffRenderer.tsx`
- `bun test src/browser/components/shared/DiffRenderer.test.tsx`

## Risks

- **Low**: changes are scoped to immersive review input/selection interaction paths.
- Main regression risk is subtle behavior around selection synchronization timing; mitigated by flushing queued drag updates on drag termination and retaining existing callback contracts.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.00 -->
