### PR TITLE
🤖 tests: stabilize web-app ordering in MacOS titlebar story

### DIFF
--- a/src/browser/stories/App.titlebar.stories.tsx
+++ b/src/browser/stories/App.titlebar.stories.tsx
@@ -21,11 +21,34 @@ export default {
 // ─────────────────────────────────────────────────────────────────────────────
 
 function createPopulatedClient() {
+  // Keep createdAt deterministic so recency tie-breakers can't reorder sibling
+  // workspaces between Storybook/Chromatic runs.
+  const stableCreatedAt = "2023-11-14T22:13:20.000Z";
   const workspaces = [
-    createWorkspace({ id: "tb-1", name: "feature/dark-mode", projectName: "web-app" }),
-    createWorkspace({ id: "tb-2", name: "fix/nav-overflow", projectName: "web-app" }),
-    createWorkspace({ id: "tb-3", name: "main", projectName: "api-server" }),
-    createWorkspace({ id: "tb-4", name: "refactor/auth", projectName: "api-server" }),
+    createWorkspace({
+      id: "tb-1",
+      name: "feature/dark-mode",
+      projectName: "web-app",
+      createdAt: stableCreatedAt,
+    }),
+    createWorkspace({
+      id: "tb-2",
+      name: "fix/nav-overflow",
+      projectName: "web-app",
+      createdAt: stableCreatedAt,
+    }),
+    createWorkspace({
+      id: "tb-3",
+      name: "main",
+      projectName: "api-server",
+      createdAt: stableCreatedAt,
+    }),
+    createWorkspace({
+      id: "tb-4",
+      name: "refactor/auth",
+      projectName: "api-server",
+      createdAt: stableCreatedAt,
+    }),
   ];
   const projects = groupWorkspacesByProject(workspaces);
 


### PR DESCRIPTION
## Summary
Pin `createdAt` in `App/TitleBar` story fixtures so the `web-app` workspace list renders in a deterministic order in `MacOSDesktop`.

## Background
Workspace sorting uses recency first, then `createdAt`, then name/id tie-breakers. In this story, both `web-app` workspaces start with equal recency, while `createWorkspace()` defaulted `createdAt` to `new Date().toISOString()`. Depending on whether both fixtures landed in the same millisecond, ordering could flip between runs.

The flake was introduced when this story was added in PR #2035.

## Implementation
- Added a shared `stableCreatedAt` timestamp inside `createPopulatedClient()`
- Passed that timestamp to all four story workspaces (including the two under `web-app`)
- Left an inline rationale comment documenting why this is required for deterministic Storybook/Chromatic output

## Validation
- `make static-check`

## Risks
Low risk; this only affects Storybook fixture data and does not change production runtime logic.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$unknown`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=unknown -->
