### PR TITLE
🤖 fix: sanitize NoOutputGeneratedError workspace naming message

### DIFF
--- a/src/node/services/workspaceTitleGenerator.test.ts
+++ b/src/node/services/workspaceTitleGenerator.test.ts
@@ -1,4 +1,4 @@
-import { APICallError, NoObjectGeneratedError, RetryError } from "ai";
+import { APICallError, NoObjectGeneratedError, NoOutputGeneratedError, RetryError } from "ai";
 import { describe, expect, test } from "bun:test";
 import {
   buildWorkspaceIdentityPrompt,
@@ -409,6 +409,17 @@ describe("workspaceTitleGenerator error mappers", () => {
       expect(mapNameGenerationError(parseFailure, "openai:gpt-4.1-mini")).toEqual({
         type: "unknown",
         raw: "The model returned an unexpected format while generating a workspace name.",
+      });
+    });
+
+    test("maps NoOutputGeneratedError to a user-friendly message", () => {
+      const noOutput = new NoOutputGeneratedError({
+        message: "No output generated. Check the stream for errors.",
+      });
+
+      expect(mapNameGenerationError(noOutput, "openai:gpt-4.1-mini")).toEqual({
+        type: "unknown",
+        raw: "No output generated from the AI provider.",
       });
     });
 

--- a/src/node/services/workspaceTitleGenerator.ts
+++ b/src/node/services/workspaceTitleGenerator.ts
@@ -1,4 +1,11 @@
-import { APICallError, NoObjectGeneratedError, Output, RetryError, streamText } from "ai";
+import {
+  APICallError,
+  NoObjectGeneratedError,
+  NoOutputGeneratedError,
+  Output,
+  RetryError,
+  streamText,
+} from "ai";
 import { z } from "zod";
 import type { AIService } from "./aiService";
 import { log } from "./log";
@@ -222,6 +229,13 @@ export function mapNameGenerationError(error: unknown, modelString: string): Nam
     return {
       type: "unknown",
       raw: "The model returned an unexpected format while generating a workspace name.",
+    };
+  }
+
+  if (NoOutputGeneratedError.isInstance(error)) {
+    return {
+      type: "unknown",
+      raw: "No output generated from the AI provider.",
     };
   }
 


### PR DESCRIPTION
## Summary
Handle AI SDK `NoOutputGeneratedError` during workspace name generation so users see a clear, actionable message instead of the raw SDK copy.

## Background
When the provider returns no output, the AI SDK throws `NoOutputGeneratedError` with the default message `No output generated. Check the stream for errors.`. We were not classifying that error explicitly in the workspace name-generation mapper, so it fell through the generic `unknown` path and surfaced verbatim in the UI.

## Implementation
- Added `NoOutputGeneratedError` handling in `mapNameGenerationError` (`src/node/services/workspaceTitleGenerator.ts`)
  - maps to `{ type: "unknown", raw: "No output generated from the AI provider." }`
- Added focused mapper coverage in `src/node/services/workspaceTitleGenerator.test.ts`
  - asserts `NoOutputGeneratedError` is sanitized to the user-friendly message.

## Validation
- `make static-check`
- `bun test src/node/services/workspaceTitleGenerator.test.ts`

## Risks
Low risk. Change is isolated to workspace name-generation error mapping and a corresponding unit test. No schema/API contract changes were made.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$1.49`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=1.49 -->
