### PR TITLE
🤖 fix: mobile plan action buttons right-aligned with white text

### DIFF
--- a/src/browser/components/tools/ProposePlanToolCall.tsx
+++ b/src/browser/components/tools/ProposePlanToolCall.tsx
@@ -772,14 +772,6 @@ export const ProposePlanToolCall: React.FC<ProposePlanToolCallProps> = (props) =
             <IconActionButton key={index} button={button} />
           ))}
 
-          {isNarrowScreen && (implementButton ?? orchestratorButton ?? autoButton) && (
-            <>
-              {implementButton && <IconActionButton button={implementButton} />}
-              {orchestratorButton && <IconActionButton button={orchestratorButton} />}
-              {autoButton && <IconActionButton button={autoButton} />}
-            </>
-          )}
-
           {/* Edit button rendered with ref for error popover positioning */}
           {editButton && (
             <div ref={editButtonRef}>
@@ -787,6 +779,15 @@ export const ProposePlanToolCall: React.FC<ProposePlanToolCallProps> = (props) =
             </div>
           )}
         </div>
+
+        {/* Mobile: icon-only plan actions, right-aligned, white */}
+        {isNarrowScreen && (implementButton ?? orchestratorButton ?? autoButton) && (
+          <div className="[&_button]:text-foreground ml-auto flex items-center gap-0.5">
+            {implementButton && <IconActionButton button={implementButton} />}
+            {orchestratorButton && <IconActionButton button={orchestratorButton} />}
+            {autoButton && <IconActionButton button={autoButton} />}
+          </div>
+        )}
 
         {!isNarrowScreen && (implementButton ?? orchestratorButton ?? autoButton) && (
           <div className="ml-auto flex items-center gap-1">


### PR DESCRIPTION
## Summary

Move mobile plan action buttons (Implement, Start Orchestrator, Continue in Auto) to be right-aligned with white (`text-foreground`) text, matching the visual weight of desktop plan buttons.

## Background

On narrow screens, plan action buttons were rendered as icon-only buttons inside the left container alongside copy/edit actions. This caused two problems:
- They used `text-placeholder` color (dim gray), making them hard to see
- They sat on the left side, visually buried among utility actions

## Implementation

Moved the `isNarrowScreen` plan button block out of the left `<div>` container and into its own right-aligned block at the same level as the desktop buttons. Applied `[&_button]:text-foreground` to override the `IconActionButton` default dim color to white.

The edit button remains in the left container. Desktop full-labeled buttons are unchanged.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$0.97`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=0.97 -->
