### PR TITLE
🤖 tests: atomize ToolSelectorInteraction None→All play cycle

### DIFF
--- a/src/browser/stories/mocks/orpc.ts
+++ b/src/browser/stories/mocks/orpc.ts
@@ -1440,7 +1440,10 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
       mcp: {
         get: (input: { workspaceId: string }) =>
           Promise.resolve(mcpOverrides.get(input.workspaceId) ?? {}),
-        set: () => Promise.resolve({ success: true, data: undefined }),
+        set: (input: { workspaceId: string; overrides: MockMcpOverrides }) => {
+          mcpOverrides.set(input.workspaceId, input.overrides);
+          return Promise.resolve({ success: true, data: undefined });
+        },
       },
       getFileCompletions: (input: { workspaceId: string; query: string; limit?: number }) => {
         // Mock file paths for storybook - simulate typical project structure


### PR DESCRIPTION
## Summary

Fix the persistently flaky `ToolSelectorInteraction` Storybook play-test by making the None→All assertion cycle atomic and hardening the mock to persist overrides.

## Background

This test has been the subject of six prior PRs (#2221, #2226, #2235, #2402, #2404, #2444), each addressing different symptoms (timeouts, stale DOM refs, missing dialogs) but none addressing the root cause: **state loss across `modal.assert()` boundaries during Storybook remounts**.

The failure chain:
1. Test clicks "None" → local React state updated (unsaved to backend)
2. Storybook remount occurs between separate `modal.assert()` calls
3. `ensureOpen()` re-opens the modal, triggering `useEffect` which reloads overrides from mock
4. Mock returns `{}` (the `set` handler was a no-op), so `allowedTools` falls back to all tools
5. `All` button is disabled (all tools selected) → `expect(All).toBeEnabled()` fails

## Implementation

Two targeted changes:

1. **Atomic assertion** (`App.projectSettings.stories.tsx`): Merge the three separate `modal.assert()` calls (None click, All-enabled guard, All click) into **one** callback. If a remount happens, `waitFor` retries the entire sequence from scratch. Idempotent guards (`if (!btn.hasAttribute("disabled"))`) prevent double-clicks on retry.

2. **Mock persistence** (`mocks/orpc.ts`): Change `workspace.mcp.set` from a no-op to actually persist overrides in the `mcpOverrides` Map. This is defense-in-depth: even if a remount triggers a re-fetch, the mock now returns realistic saved state.

## Validation

- `make static-check` passes locally

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$2.67`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=2.67 -->
