### PR TITLE
🤖 fix: default plan sub-agent executor routing to auto

### DIFF
--- a/src/browser/components/Settings/sections/TasksSection.tsx
+++ b/src/browser/components/Settings/sections/TasksSection.tsx
@@ -1037,7 +1037,7 @@ export function TasksSection() {
               <SelectContent>
                 <SelectItem value="exec">Exec</SelectItem>
                 <SelectItem value="orchestrator">Orchestrator</SelectItem>
-                <SelectItem value="auto">Auto (LLM decides)</SelectItem>
+                <SelectItem value="auto">Auto (Agent chooses)</SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/src/common/types/tasks.ts
+++ b/src/common/types/tasks.ts
@@ -48,7 +48,7 @@ export const DEFAULT_TASK_SETTINGS: TaskSettings = {
   maxParallelAgentTasks: TASK_SETTINGS_LIMITS.maxParallelAgentTasks.default,
   maxTaskNestingDepth: TASK_SETTINGS_LIMITS.maxTaskNestingDepth.default,
   proposePlanImplementReplacesChatHistory: false,
-  planSubagentExecutorRouting: "exec",
+  planSubagentExecutorRouting: "auto",
   planSubagentDefaultsToOrchestrator: false,
 
   bashOutputCompactionMinLines:


### PR DESCRIPTION
## Summary
This PR updates the Task Settings executor routing option so Auto is the default behavior and clarifies the Auto label text.

## Implementation
- Changed `DEFAULT_TASK_SETTINGS.planSubagentExecutorRouting` from `"exec"` to `"auto"`.
- Updated the settings dropdown label from `Auto (LLM decides)` to `Auto (Agent chooses)`.

## Validation
- `make static-check`

## Risks
Low risk: this is a targeted configuration/UI text change in the settings screen.

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.48`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.48 -->
