### PR TITLE
🤖 refactor: consolidate duration formatting utilities

### DIFF
--- a/src/browser/components/Messages/InitMessage.tsx
+++ b/src/browser/components/Messages/InitMessage.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/common/lib/utils";
 import type { DisplayedMessage } from "@/common/types/message";
 import { Loader2, Wrench, CheckCircle2, AlertCircle } from "lucide-react";
 import { Shimmer } from "../ai-elements/shimmer";
-import { formatDurationPrecise } from "@/browser/utils/ui/dateTime";
+import { formatDuration } from "@/common/utils/formatDuration";
 
 interface InitMessageProps {
   message: Extract<DisplayedMessage, { type: "workspace-init" }>;
@@ -24,7 +24,7 @@ export const InitMessage = React.memo<InitMessageProps>(({ message, className })
   }, [isRunning, message.lines.length]);
 
   const durationText =
-    message.durationMs !== null ? ` in ${formatDurationPrecise(message.durationMs)}` : "";
+    message.durationMs !== null ? ` in ${formatDuration(message.durationMs, "precise")}` : "";
 
   return (
     <div

--- a/src/browser/components/RightSidebar/StatsTab.tsx
+++ b/src/browser/components/RightSidebar/StatsTab.tsx
@@ -8,7 +8,7 @@ import { ToggleGroup, type ToggleOption } from "../ToggleGroup";
 import { useTelemetry } from "@/browser/hooks/useTelemetry";
 import { computeTimingPercentages } from "@/browser/utils/timingPercentages";
 import { calculateAverageTPS } from "@/browser/utils/messages/StreamingTPSCalculator";
-import { formatDurationPrecise } from "@/browser/utils/ui/dateTime";
+import { formatDuration } from "@/common/utils/formatDuration";
 
 // Colors for timing components (matching TOKEN_COMPONENT_COLORS style)
 const TIMING_COLORS = {
@@ -289,7 +289,7 @@ export function StatsTab(props: StatsTabProps) {
                   {isClearing ? "Clearing..." : "Clear stats"}
                 </button>
               )}
-              <span className="text-muted text-xs">{formatDurationPrecise(totalDuration)}</span>
+              <span className="text-muted text-xs">{formatDuration(totalDuration, "precise")}</span>
             </div>
           </div>
 
@@ -369,7 +369,7 @@ export function StatsTab(props: StatsTabProps) {
                     <span className="text-muted text-xs">waiting…</span>
                   ) : component.duration !== null ? (
                     <span className="text-muted text-xs">
-                      {formatDurationPrecise(component.duration)}
+                      {formatDuration(component.duration, "precise")}
                     </span>
                   ) : (
                     <span className="text-muted text-xs">—</span>
@@ -422,7 +422,7 @@ export function StatsTab(props: StatsTabProps) {
                       {label}
                     </span>
                     <span className="text-muted shrink-0 text-xs">
-                      {formatDurationPrecise(entry.totalDurationMs)}
+                      {formatDuration(entry.totalDurationMs, "precise")}
                     </span>
                   </div>
                   <div className="text-muted-light mt-1 flex flex-wrap gap-x-2 gap-y-1 text-[11px]">
@@ -430,7 +430,7 @@ export function StatsTab(props: StatsTabProps) {
                     {avgTtft !== null && (
                       <>
                         <span>·</span>
-                        <span>TTFT {formatDurationPrecise(avgTtft)}</span>
+                        <span>TTFT {formatDuration(avgTtft, "precise")}</span>
                       </>
                     )}
                     {entryAvgTPS !== null && entryAvgTPS > 0 && (

--- a/src/browser/components/RightSidebar/tabs/registry.ts
+++ b/src/browser/components/RightSidebar/tabs/registry.ts
@@ -11,6 +11,7 @@
  */
 
 import type { TabType } from "@/browser/types/rightSidebar";
+import { formatDuration } from "@/common/utils/formatDuration";
 import type { ReviewNoteData } from "@/common/types/review";
 
 /** Stats reported by ReviewPanel for tab display */
@@ -148,9 +149,8 @@ export function getTabContentClassName(tab: TabType): string {
 
 /** Format duration for tab display (compact format) */
 export function formatTabDuration(ms: number): string {
-  if (ms < 1000) return `${Math.round(ms)}ms`;
-  if (ms < 60000) return `${Math.round(ms / 1000)}s`;
-  const mins = Math.floor(ms / 60000);
-  const secs = Math.round((ms % 60000) / 1000);
+  if (ms < 60_000) return formatDuration(ms);
+  const mins = Math.floor(ms / 60_000);
+  const secs = Math.round((ms % 60_000) / 1000);
   return secs > 0 ? `${mins}m${secs}s` : `${mins}m`;
 }

--- a/src/browser/components/tools/shared/toolUtils.tsx
+++ b/src/browser/components/tools/shared/toolUtils.tsx
@@ -3,6 +3,8 @@ import { AlertTriangle, Check, CircleDot, EyeOff, X } from "lucide-react";
 import type { ToolErrorResult } from "@/common/types/tools";
 import { LoadingDots } from "./ToolPrimitives";
 
+export { formatDuration } from "@/common/utils/formatDuration";
+
 /**
  * Shared utilities and hooks for tool components
  */
@@ -89,17 +91,6 @@ export function formatValue(value: unknown): string {
     // If JSON.stringify fails (e.g., circular reference), return a safe fallback
     return "[Complex Object - Cannot Stringify]";
   }
-}
-
-/**
- * Format duration in human-readable form (ms, s, m, h)
- */
-export function formatDuration(ms: number): string {
-  if (!Number.isFinite(ms)) return "—";
-  if (ms < 1000) return `${Math.round(ms)}ms`;
-  if (ms < 60000) return `${Math.round(ms / 1000)}s`;
-  if (ms < 3600000) return `${Math.round(ms / 60000)}m`;
-  return `${Math.round(ms / 3600000)}h`;
 }
 
 /**

--- a/src/browser/utils/ui/dateTime.ts
+++ b/src/browser/utils/ui/dateTime.ts
@@ -88,18 +88,3 @@ export function formatRelativeTimeCompact(timestamp: number): string {
   if (elapsed < 86400) return `${Math.floor(elapsed / 3600)}h ago`;
   return `${Math.floor(elapsed / 86400)}d ago`;
 }
-
-/**
- * Formats a duration in milliseconds into a precise, human-readable string.
- * Shows one decimal for durations under 10s, and minutes+seconds for >= 60s.
- * Examples: "42ms", "3.2s", "15s", "2m 30s"
- */
-export function formatDurationPrecise(ms: number): string {
-  if (!Number.isFinite(ms)) return "—";
-  if (ms < 1000) return `${Math.round(ms)}ms`;
-  if (ms < 10000) return `${(ms / 1000).toFixed(1)}s`;
-  if (ms < 60000) return `${Math.round(ms / 1000)}s`;
-  const mins = Math.floor(ms / 60000);
-  const secs = Math.round((ms % 60000) / 1000);
-  return `${mins}m ${secs}s`;
-}

--- a/src/cli/toolFormatters.ts
+++ b/src/cli/toolFormatters.ts
@@ -6,6 +6,7 @@
  */
 
 import { extractToolFilePath } from "@/common/utils/tools/toolInputFilePath";
+import { formatDuration } from "../common/utils/formatDuration";
 import chalk from "chalk";
 import type { ToolCallStartEvent, ToolCallEndEvent } from "@/common/types/stream";
 import type {
@@ -76,13 +77,6 @@ function formatDiff(diff: string): string {
       return line;
     })
     .join("\n");
-}
-
-function formatDuration(ms: number): string {
-  if (!Number.isFinite(ms)) return "—";
-  if (ms < 1000) return `${ms}ms`;
-  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
-  return `${(ms / 60000).toFixed(1)}m`;
 }
 
 function formatBytes(bytes: number): string {
@@ -261,7 +255,7 @@ function formatBashEnd(_toolName: string, _args: unknown, result: unknown): stri
   }
 
   const duration = bashResult.wall_duration_ms
-    ? chalk.dim(` (${formatDuration(bashResult.wall_duration_ms)})`)
+    ? chalk.dim(` (${formatDuration(bashResult.wall_duration_ms, "decimal")})`)
     : "";
   const exitCode = bashResult.exitCode;
   const exitStr = exitCode === 0 ? chalk.green("exit:0") : chalk.red(`exit:${exitCode}`);

--- a/src/common/utils/formatDuration.test.ts
+++ b/src/common/utils/formatDuration.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { formatDuration } from "./formatDuration";
+
+describe("formatDuration", () => {
+  test("coarse style keeps boundary outputs byte-identical", () => {
+    const cases: Array<[number, string]> = [
+      [Number.NaN, "—"],
+      [Infinity, "—"],
+      [-Infinity, "—"],
+      [-42.6, "-43ms"],
+      [0, "0ms"],
+      [427.3, "427ms"],
+      [999.4, "999ms"],
+      [999.5, "1000ms"],
+      [1000, "1s"],
+      [9_999, "10s"],
+      [10_000, "10s"],
+      [59_999, "60s"],
+      [60_000, "1m"],
+      [3_599_999, "60m"],
+      [3_600_000, "1h"],
+    ];
+
+    for (const [ms, expected] of cases) {
+      expect(formatDuration(ms, "coarse")).toBe(expected);
+    }
+  });
+
+  test("precise style keeps boundary outputs byte-identical", () => {
+    const cases: Array<[number, string]> = [
+      [Number.NaN, "—"],
+      [Infinity, "—"],
+      [-Infinity, "—"],
+      [-42.6, "-43ms"],
+      [0, "0ms"],
+      [427.3, "427ms"],
+      [999.4, "999ms"],
+      [999.5, "1000ms"],
+      [1000, "1.0s"],
+      [9_999, "10.0s"],
+      [10_000, "10s"],
+      [59_999, "60s"],
+      [60_000, "1m 0s"],
+      [119_500, "1m 60s"],
+      [3_600_000, "60m 0s"],
+    ];
+
+    for (const [ms, expected] of cases) {
+      expect(formatDuration(ms, "precise")).toBe(expected);
+    }
+  });
+
+  test("decimal style keeps boundary outputs byte-identical", () => {
+    const cases: Array<[number, string]> = [
+      [Number.NaN, "—"],
+      [Infinity, "—"],
+      [-Infinity, "—"],
+      [-42.6, "-42.6ms"],
+      [0, "0ms"],
+      [427.3, "427.3ms"],
+      [999.4, "999.4ms"],
+      [999.5, "999.5ms"],
+      [1000, "1.0s"],
+      [9_999, "10.0s"],
+      [10_000, "10.0s"],
+      [59_999, "60.0s"],
+      [60_000, "1.0m"],
+      [3_600_000, "60.0m"],
+    ];
+
+    for (const [ms, expected] of cases) {
+      expect(formatDuration(ms, "decimal")).toBe(expected);
+    }
+  });
+
+  test("defaults to coarse style", () => {
+    const inputs = [Number.NaN, Infinity, -42.6, 0, 427.3, 999.5, 1000, 60_000, 3_600_000];
+
+    for (const ms of inputs) {
+      expect(formatDuration(ms)).toBe(formatDuration(ms, "coarse"));
+    }
+  });
+});

--- a/src/common/utils/formatDuration.ts
+++ b/src/common/utils/formatDuration.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared duration formatter. Every site that converts ms→human-readable string
+ * should use this instead of rolling its own threshold ladder.
+ *
+ * Styles:
+ * - "coarse"  → 42ms, 5s, 2m, 1h        (replaces toolUtils.tsx formatDuration)
+ * - "precise" → 42ms, 3.2s, 15s, 2m 30s  (replaces dateTime.ts formatDurationPrecise)
+ * - "decimal" → 427.3ms, 3.2s, 1.5m       (replaces toolFormatters.ts formatDuration)
+ */
+export type DurationStyle = "coarse" | "precise" | "decimal";
+
+export function formatDuration(ms: number, style: DurationStyle = "coarse"): string {
+  if (!Number.isFinite(ms)) return "—";
+
+  if (ms < 1000) {
+    // CLI "decimal" preserves raw ms (e.g. "427.3ms"); others round ("427ms").
+    return style === "decimal" ? `${ms}ms` : `${Math.round(ms)}ms`;
+  }
+
+  switch (style) {
+    case "coarse":
+      if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+      if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m`;
+      return `${Math.round(ms / 3_600_000)}h`;
+
+    case "precise":
+      if (ms < 10_000) return `${(ms / 1000).toFixed(1)}s`;
+      if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+      {
+        const mins = Math.floor(ms / 60_000);
+        const secs = Math.round((ms % 60_000) / 1000);
+        // Always show seconds — matches original formatDurationPrecise ("2m 0s" not "2m")
+        return `${mins}m ${secs}s`;
+      }
+
+    case "decimal":
+      if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+      return `${(ms / 60_000).toFixed(1)}m`;
+  }
+}


### PR DESCRIPTION
## Summary
Consolidates duplicate duration-formatting implementations into a single shared utility while preserving existing output behavior at all migrated callsites.

## Background
The codebase had multiple `formatDuration` variants across browser and CLI layers, plus a tab-specific formatter. This made behavior harder to keep consistent and increased maintenance overhead.

## Implementation
- Added `src/common/utils/formatDuration.ts` with three explicit styles:
  - `coarse` (tool UI)
  - `precise` (stats/init message display)
  - `decimal` (CLI output)
- Replaced duplicated implementations in:
  - `src/browser/components/tools/shared/toolUtils.tsx` (now re-exports shared formatter)
  - `src/browser/utils/ui/dateTime.ts` (removed local precise formatter)
  - `src/cli/toolFormatters.ts` (removed local CLI formatter)
- Updated consumers to call the shared formatter with the appropriate style.
- Kept `formatTabDuration` in `registry.ts` as a thin wrapper to preserve its compact tab-specific output (`2m30s` / `2m`).
- Added focused tests in `src/common/utils/formatDuration.test.ts` and removed temporary legacy-oracle helpers after parity confidence.

## Validation
- `bun test src/common/utils/formatDuration.test.ts`
- `make lint`
- `make typecheck`
- `make static-check`

## Risks
Low. This is a refactor with behavior-preserving test expectations across style boundaries and edge cases.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$4.42`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=4.42 -->
