### PR TITLE
🤖 fix: expose libstdc++ in nix devShell for DuckDB ETL tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -172,6 +172,7 @@
               # Node + build tooling
               nodejs
               gnumake
+              stdenv.cc.cc.lib # Provides libstdc++.so.6 for DuckDB native bindings under Bun
 
               # Common CLIs
               git
@@ -199,6 +200,10 @@
               asciinema
             ]
             ++ lib.optionals stdenv.isLinux [ docker ];
+
+          # Bun does not carry libstdc++ on Linux, so native modules like @duckdb/node-bindings
+          # fail to dlopen during tests unless we expose the GCC runtime in the shell.
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ pkgs.stdenv.cc.cc.lib ];
         };
       }
     );


### PR DESCRIPTION
## Summary
Fix Nix dev-shell runtime linking so Bun can load DuckDB native bindings when running analytics ETL tests.

## Background
`bun test src/node/services/analytics/etl.test.ts` failed on Linux with:

`libstdc++.so.6: cannot open shared object file`

The ETL tests import `@duckdb/node-api`, which loads a native `.node` binding that depends on `libstdc++.so.6`. Our `flake.nix` package derivation already included this runtime library, but the developer shell did not.

## Implementation
- Added `stdenv.cc.cc.lib` to `devShells.default.buildInputs` in `flake.nix`.
- Exported `LD_LIBRARY_PATH` in `devShells.default` via:
  - `pkgs.lib.makeLibraryPath [ pkgs.stdenv.cc.cc.lib ]`
- Added an inline comment describing why this is required for Bun + DuckDB native module loading.

## Validation
- `make static-check`
- `nix develop --command bun test src/node/services/analytics/etl.test.ts`
  - Result: 11 passing tests, 0 failures

## Risks
Low risk. Change is limited to dev-shell environment wiring and only affects runtime library discovery for native modules.

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh`_

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.70`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.70 -->
