### PR TITLE
🤖 fix: backfill Anthropic reasoning tokens into usage metadata

### DIFF
--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -8,6 +8,7 @@ import { APICallError, RetryError, type ModelMessage } from "ai";
 import type { HistoryService } from "./historyService";
 import { createTestHistoryService } from "./testHistoryService";
 import { createAnthropic } from "@ai-sdk/anthropic";
+import { countTokens } from "@/node/utils/main/tokenizer";
 import { shouldRunIntegrationTests, validateApiKeys } from "../../../tests/testUtils";
 import { DisposableTempDir } from "@/node/services/tempDir";
 import { createRuntime } from "@/node/runtime/runtimeFactory";
@@ -938,7 +939,6 @@ describe("StreamManager - TTFT metadata persistence", () => {
       totalTokens: number;
       reasoningTokens?: number;
     };
-    reasoningTokensByDelta?: number;
   }) {
     const streamManager = new StreamManager(historyService);
     // Suppress error events from bubbling up as uncaught exceptions during tests
@@ -1003,7 +1003,6 @@ describe("StreamManager - TTFT metadata persistence", () => {
       runtimeTempDir: "",
       runtime,
       cumulativeUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-      reasoningTokensByDelta: params.reasoningTokensByDelta ?? 0,
       cumulativeProviderMetadata: undefined,
       didRetryPreviousResponseIdAtStep: false,
       currentStepStartIndex: 0,
@@ -1078,20 +1077,30 @@ describe("StreamManager - TTFT metadata persistence", () => {
   });
 
   describe("StreamManager - reasoning token backfill", () => {
-    test("backfills reasoningTokens from delta count when provider reports undefined", async () => {
+    test("backfills reasoningTokens from concatenated reasoning text when provider reports undefined", async () => {
       const startTime = Date.now() - 1000;
+      const reasoningSegments = ["Thinking through ", "tradeoffs"];
+      const expectedReasoningTokens = await countTokens(
+        KNOWN_MODELS.SONNET.id,
+        reasoningSegments.join("")
+      );
+
       const updatedMessage = await finalizeStreamAndReadMessage({
         workspaceId: "reasoning-backfill-workspace",
         messageId: "reasoning-backfill-message",
         historySequence: 1,
         startTime,
         usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
-        reasoningTokensByDelta: 42,
         parts: [
           {
             type: "reasoning",
-            text: "Thinking through tradeoffs",
+            text: reasoningSegments[0],
             timestamp: startTime + 100,
+          },
+          {
+            type: "reasoning",
+            text: reasoningSegments[1],
+            timestamp: startTime + 150,
           },
           {
             type: "text",
@@ -1101,7 +1110,7 @@ describe("StreamManager - TTFT metadata persistence", () => {
         ],
       });
 
-      expect(updatedMessage.metadata?.usage?.reasoningTokens).toBe(42);
+      expect(updatedMessage.metadata?.usage?.reasoningTokens).toBe(expectedReasoningTokens);
     });
 
     test("preserves provider-reported reasoningTokens when present", async () => {
@@ -1112,7 +1121,6 @@ describe("StreamManager - TTFT metadata persistence", () => {
         historySequence: 1,
         startTime,
         usage: { inputTokens: 100, outputTokens: 250, totalTokens: 350, reasoningTokens: 200 },
-        reasoningTokensByDelta: 190,
         parts: [
           {
             type: "reasoning",
@@ -1138,7 +1146,6 @@ describe("StreamManager - TTFT metadata persistence", () => {
         historySequence: 1,
         startTime,
         usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
-        reasoningTokensByDelta: 0,
         parts: [
           {
             type: "text",

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -330,10 +330,6 @@ interface WorkspaceStreamInfo {
   runtime: Runtime;
   // Cumulative usage across all steps (for live cost display during streaming)
   cumulativeUsage: LanguageModelV2Usage;
-  // Tokenizer-counted reasoning tokens accumulated during streaming.
-  // Used to backfill usage.reasoningTokens when the provider SDK doesn't report it
-  // (e.g., @ai-sdk/anthropic sets reasoning: undefined).
-  reasoningTokensByDelta: number;
   // Cumulative provider metadata across all steps (for live cost display with cache tokens)
   cumulativeProviderMetadata?: Record<string, unknown>;
   // Last step's usage (for context window display during streaming)
@@ -684,6 +680,35 @@ export class StreamManager extends EventEmitter {
     return totalUsage;
   }
 
+  private async backfillReasoningTokensFromParts(
+    streamInfo: Pick<WorkspaceStreamInfo, "parts" | "metadataModel" | "model">,
+    usage: LanguageModelV2Usage | undefined
+  ): Promise<void> {
+    // Backfill reasoningTokens from the full reasoning text when the provider
+    // doesn't report them. @ai-sdk/anthropic sets reasoning: undefined even for
+    // extended-thinking models. Tokenizing concatenated text (not per-delta
+    // sums) avoids BPE chunk-boundary inflation.
+    if (!usage || usage.reasoningTokens) {
+      return;
+    }
+
+    const reasoningText = streamInfo.parts
+      .filter(
+        (part): part is Extract<CompletedMessagePart, { type: "reasoning" }> =>
+          part.type === "reasoning"
+      )
+      .map((part) => part.text)
+      .join("");
+    if (!reasoningText) {
+      return;
+    }
+
+    usage.reasoningTokens = await countTokens(
+      streamInfo.metadataModel ?? streamInfo.model,
+      reasoningText
+    );
+  }
+
   private resolveTtftMsForStreamEnd(streamInfo: WorkspaceStreamInfo): number | undefined {
     const firstTokenPart = streamInfo.parts.find(
       (
@@ -809,17 +834,6 @@ export class StreamManager extends EventEmitter {
       });
     } else if (part.type === "reasoning") {
       const tokens = await this.tokenTracker.countTokens(part.text);
-      if (!isReplay) {
-        const streamInfo = this.workspaceStreams.get(workspaceId);
-        if (streamInfo) {
-          // Use metadataModel (provider-mapped model) when available for accurate
-          // tokenizer selection, matching how StreamingTokenTracker.setModel resolves.
-          streamInfo.reasoningTokensByDelta += await countTokens(
-            streamInfo.metadataModel ?? streamInfo.model,
-            part.text
-          );
-        }
-      }
       this.emit("reasoning-delta", {
         type: "reasoning-delta",
         workspaceId: workspaceId as string,
@@ -963,9 +977,7 @@ export class StreamManager extends EventEmitter {
     const duration = Date.now() - streamInfo.startTime;
     const hasCumulativeUsage = (streamInfo.cumulativeUsage.totalTokens ?? 0) > 0;
     const usage = hasCumulativeUsage ? streamInfo.cumulativeUsage : undefined;
-    if (usage && !usage.reasoningTokens && streamInfo.reasoningTokensByDelta > 0) {
-      usage.reasoningTokens = streamInfo.reasoningTokensByDelta;
-    }
+    await this.backfillReasoningTokensFromParts(streamInfo, usage);
 
     // For context window display, use last step's usage (inputTokens = current context size)
     const contextUsage = streamInfo.lastStepUsage;
@@ -1315,7 +1327,6 @@ export class StreamManager extends EventEmitter {
       runtime, // Runtime for temp directory cleanup
       // Initialize cumulative tracking for multi-step streams
       cumulativeUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-      reasoningTokensByDelta: 0,
       cumulativeProviderMetadata: undefined,
     };
 
@@ -1972,17 +1983,7 @@ export class StreamManager extends EventEmitter {
               streamInfo,
               streamMeta.totalUsage
             );
-            // Backfill reasoningTokens from tokenizer-counted deltas when provider
-            // doesn't report them. @ai-sdk/anthropic sets reasoning: undefined even
-            // for extended-thinking models; our per-delta tokenizer count is the best
-            // available signal.
-            if (
-              totalUsage &&
-              !totalUsage.reasoningTokens &&
-              streamInfo.reasoningTokensByDelta > 0
-            ) {
-              totalUsage.reasoningTokens = streamInfo.reasoningTokensByDelta;
-            }
+            await this.backfillReasoningTokensFromParts(streamInfo, totalUsage);
             const contextUsage = streamMeta.contextUsage ?? streamInfo.lastStepUsage;
             const contextProviderMetadata =
               streamMeta.contextProviderMetadata ?? streamInfo.lastStepProviderMetadata;
@@ -2348,7 +2349,6 @@ export class StreamManager extends EventEmitter {
 
     if (!preserveUsage) {
       streamInfo.cumulativeUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
-      streamInfo.reasoningTokensByDelta = 0;
       streamInfo.cumulativeProviderMetadata = undefined;
       streamInfo.lastStepUsage = undefined;
       streamInfo.lastStepProviderMetadata = undefined;


### PR DESCRIPTION
## Summary

Backfill `reasoningTokens` into usage metadata for Anthropic Claude models. The `@ai-sdk/anthropic` SDK (v3.0.37) sets `reasoning: undefined` in its `convertAnthropicMessagesUsage`, so `usage.reasoningTokens` is always missing for Anthropic — causing the analytics dashboard to show "Reasoning: 0" even for extended-thinking models.

## Background

- The Cost tab works correctly because `tokenStatsCalculator.ts` runs a tokenizer over the actual reasoning content block text, bypassing the broken SDK field.
- The analytics ETL reads `usage.reasoningTokens` from persisted `chat.jsonl` metadata → gets `undefined` → records `0`.

## Implementation

Track reasoning tokens directly on `WorkspaceStreamInfo` as they stream in (`reasoningTokensByDelta` field), then backfill into `totalUsage` before persisting to `chat.jsonl`. This fixes all downstream consumers (analytics ETL, displayUsage) at the recording layer.

Key changes in `src/node/services/streamManager.ts`:
- Added `reasoningTokensByDelta: number` to `WorkspaceStreamInfo` interface
- Accumulate tokenizer-counted tokens during reasoning-delta emission (skip replay to avoid double-counting)
- Backfill at stream-end and abort paths: if `!totalUsage.reasoningTokens && streamInfo.reasoningTokensByDelta > 0`, set `totalUsage.reasoningTokens`
- Guard uses `!totalUsage.reasoningTokens` to catch `undefined`, `null`, and `0` — preserves provider-reported values (e.g., OpenAI)

Tests in `src/node/services/streamManager.test.ts`:
1. Backfills when provider reports undefined (Anthropic case)
2. Preserves provider-reported value when present (OpenAI case)
3. Does not inject when no reasoning deltas occurred (text-only case)

## Risks

- **Low risk**: The backfill only fires when the provider didn't report reasoning tokens AND reasoning deltas were observed. Provider-reported values are always preserved.
- Upstream `@ai-sdk/anthropic` may eventually fix this, at which point our backfill becomes a no-op.
- Historical `chat.jsonl` entries are not retroactively fixed (out of scope).

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix: Backfill reasoning tokens into usage metadata for Anthropic Claude

## Context / Why

The analytics dashboard shows **"Reasoning: 0"** for Anthropic Claude models (e.g., `claude-opus-4.6` with max thinking), even though the Cost tab correctly shows thinking token counts.

**Root cause:** `@ai-sdk/anthropic` (v3.0.37) sets `reasoning: undefined` in its `convertAnthropicMessagesUsage` function, so `usage.reasoningTokens` is always undefined for Anthropic. The analytics ETL reads `usage.reasoningTokens` from persisted `chat.jsonl` metadata → gets `undefined` → records `0`.

**Why the Cost tab works:** The Cost tab's consumer breakdown uses `tokenStatsCalculator.ts`, which runs a tokenizer over the actual reasoning content block text — bypassing the broken SDK field entirely.

**Solution:** Track reasoning tokens directly on `WorkspaceStreamInfo` as they stream in, then backfill `reasoningTokens` into the `totalUsage` object before persisting to `chat.jsonl`. This fixes all downstream consumers at the recording layer.

<details>
<summary>Architecture constraint: StreamManager ↔ SessionTimingService are event-decoupled</summary>

`StreamManager` emits events (`reasoning-delta`, `stream-end`, etc.) and `SessionTimingService` listens via `ServiceContainer` wiring (line 247). StreamManager has **no reference** to SessionTimingService. Rather than introducing coupling, we track the count directly on `WorkspaceStreamInfo` — the same pattern SessionTimingService already uses with `state.reasoningTokensByDelta`.
</details>

## Evidence

| File | Role |
|---|---|
| `src/node/services/streamManager.ts:277-338` | `WorkspaceStreamInfo` interface — add `reasoningTokensByDelta` field here |
| `src/node/services/streamManager.ts:806` | `tokenTracker.countTokens(part.text)` already runs per reasoning delta — accumulate result |
| `src/node/services/streamManager.ts:1951` | `resolveTotalUsageForStreamEnd` — backfill point before persist |
| `src/node/services/streamManager.ts:1985` | `totalUsage` flows into `streamEndEvent.metadata.usage` → `chat.jsonl` |
| `src/common/utils/tokens/displayUsage.ts:46-49` | `createDisplayUsage` reads `usage.reasoningTokens` — fixed by backfill |
| `src/node/services/analytics/etl.ts:185` | ETL reads `rawUsage.reasoningTokens` — fixed by backfill |
| `src/node/services/streamManager.test.ts:926-1070` | Existing `finalizeStreamAndReadMessage` test helper — reuse pattern |
| `node_modules/@ai-sdk/anthropic` | `convertAnthropicMessagesUsage` always returns `reasoning: void 0` |

## Implementation (Red → Green → Refactor)

### Phase 1: Red — Write failing tests

All tests in `src/node/services/streamManager.test.ts`, within a new `describe("StreamManager - reasoning token backfill", ...)` block. Reuse the existing `finalizeStreamAndReadMessage` helper pattern from the TTFT tests (line 929).

**Test 1: Backfills reasoning tokens when provider reports undefined**

Simulates Anthropic: `totalUsage` has `reasoningTokens: undefined`, but `streamInfo.parts` contains reasoning parts and `streamInfo.reasoningTokensByDelta` is non-zero.

```ts
test("backfills reasoningTokens from delta count when provider reports undefined", async () => {
  const startTime = Date.now() - 1000;
  const updatedMessage = await finalizeStreamAndReadMessage({
    workspaceId: "reasoning-backfill-workspace",
    messageId: "reasoning-backfill-message",
    historySequence: 1,
    startTime,
    parts: [
      { type: "reasoning", text: "thinking...", timestamp: startTime + 100 },
      { type: "text", text: "hello", timestamp: startTime + 200 },
    ],
    // Simulate Anthropic: no reasoning tokens in usage
    usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
    reasoningTokensByDelta: 42,
  });

  expect(updatedMessage.metadata?.usage?.reasoningTokens).toBe(42);
});
```

**Test 2: Does NOT overwrite when provider already reports reasoning tokens**

Simulates OpenAI: `totalUsage` already has `reasoningTokens: 200`.

```ts
test("preserves provider-reported reasoningTokens when present", async () => {
  const startTime = Date.now() - 1000;
  const updatedMessage = await finalizeStreamAndReadMessage({
    workspaceId: "reasoning-preserve-workspace",
    messageId: "reasoning-preserve-message",
    historySequence: 1,
    startTime,
    parts: [
      { type: "reasoning", text: "thinking...", timestamp: startTime + 100 },
      { type: "text", text: "hello", timestamp: startTime + 200 },
    ],
    // Provider reported reasoning tokens (e.g. OpenAI)
    usage: { inputTokens: 100, outputTokens: 250, totalTokens: 350, reasoningTokens: 200 },
    reasoningTokensByDelta: 190, // Slightly different due to tokenizer approximation
  });

  // Must use provider value, not delta count
  expect(updatedMessage.metadata?.usage?.reasoningTokens).toBe(200);
});
```

**Test 3: No backfill when no reasoning deltas occurred**

Simulates a text-only response (no thinking).

```ts
test("does not inject reasoningTokens when no reasoning deltas occurred", async () => {
  const startTime = Date.now() - 1000;
  const updatedMessage = await finalizeStreamAndReadMessage({
    workspaceId: "reasoning-none-workspace",
    messageId: "reasoning-none-message",
    historySequence: 1,
    startTime,
    parts: [
      { type: "text", text: "hello", timestamp: startTime + 100 },
    ],
    usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
    reasoningTokensByDelta: 0,
  });

  // Should remain undefined/0, not set to 0 explicitly
  expect(updatedMessage.metadata?.usage?.reasoningTokens).toBeUndefined();
});
```

These tests require `finalizeStreamAndReadMessage` to accept optional `usage` and `reasoningTokensByDelta` params. Extend its interface:

```ts
async function finalizeStreamAndReadMessage(params: {
  workspaceId: string;
  messageId: string;
  historySequence: number;
  startTime: number;
  parts: unknown[];
  usage?: { inputTokens: number; outputTokens: number; totalTokens: number; reasoningTokens?: number };
  reasoningTokensByDelta?: number;
}) {
  // ... existing setup ...
  const streamInfo = {
    // ... existing fields ...
    cumulativeUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
    // NEW: allow tests to set reasoning delta count
    reasoningTokensByDelta: params.reasoningTokensByDelta ?? 0,
  };
  // ...
}
```

### Phase 2: Green — Make tests pass

#### Step 1: Add `reasoningTokensByDelta` to `WorkspaceStreamInfo`

**File:** `src/node/services/streamManager.ts` (line ~331, before closing `}` of interface)

```ts
interface WorkspaceStreamInfo {
  // ... existing fields ...

  // Tokenizer-counted reasoning tokens accumulated during streaming.
  // Used to backfill usage.reasoningTokens when the provider SDK doesn't report it
  // (e.g., @ai-sdk/anthropic sets reasoning: undefined).
  reasoningTokensByDelta: number;
}
```

#### Step 2: Initialize to 0 when creating streamInfo

**File:** `src/node/services/streamManager.ts` (line ~1298, alongside `cumulativeUsage` init)

```ts
cumulativeUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
cumulativeProviderMetadata: undefined,
reasoningTokensByDelta: 0,
```

#### Step 3: Accumulate during reasoning delta processing

**File:** `src/node/services/streamManager.ts` (line ~806, in `appendPartAndEmit` where reasoning tokens are already counted)

Find the existing code at line 805-814:
```ts
} else if (part.type === "reasoning") {
  const tokens = await this.tokenTracker.countTokens(part.text);
  this.emit("reasoning-delta", { ... });
}
```

After the `countTokens` call, add accumulation. The `streamInfo` is available via the `workspaceId` lookup (check calling context — `appendPartAndEmit` receives it):

```ts
} else if (part.type === "reasoning") {
  const tokens = await this.tokenTracker.countTokens(part.text);
  streamInfo.reasoningTokensByDelta += tokens;
  this.emit("reasoning-delta", { ... });
}
```

> **Note:** `appendPartAndEmit` needs access to `streamInfo` to increment the counter. Check the method signature — if it doesn't receive `streamInfo`, it receives `workspaceId` and can look it up via `this.workspaceStreams.get(workspaceId)`. Verify at implementation time.

#### Step 4: Backfill at stream end

**File:** `src/node/services/streamManager.ts` (line ~1954, after `totalUsage` is resolved)

```ts
const totalUsage = this.resolveTotalUsageForStreamEnd(
  streamInfo,
  streamMeta.totalUsage
);

// Backfill reasoningTokens from tokenizer-counted deltas when provider
// doesn't report them. @ai-sdk/anthropic sets reasoning: undefined even
// for extended-thinking models; our per-delta tokenizer count is the best
// available signal. Uses loose `== null` to catch both undefined and null.
if (
  totalUsage &&
  totalUsage.reasoningTokens == null &&
  streamInfo.reasoningTokensByDelta > 0
) {
  totalUsage.reasoningTokens = streamInfo.reasoningTokensByDelta;
}
```

#### Step 5: Also backfill on `cumulativeUsage` (retry path)

`resolveTotalUsageForStreamEnd` may return `cumulativeUsage` instead of `totalUsage` when step retries occurred (line 675-676). Since `cumulativeUsage` is built via `addUsage` which propagates `reasoningTokens` from the provider, it will also be `undefined` for Anthropic. The backfill on `totalUsage` (Step 4) handles both cases since it operates on the **resolved** value.

Verify: `addUsage` in `usageHelpers.ts` sums `reasoningTokens` — `(a?.reasoningTokens ?? 0) + (b.reasoningTokens ?? 0)` → `0 + undefined = 0`. So `cumulativeUsage.reasoningTokens` would be `0`, not `undefined`. Adjust the guard to also catch `0`:

```ts
if (
  totalUsage &&
  !totalUsage.reasoningTokens &&
  streamInfo.reasoningTokensByDelta > 0
) {
  totalUsage.reasoningTokens = streamInfo.reasoningTokensByDelta;
}
```

Using `!totalUsage.reasoningTokens` catches `undefined`, `null`, and `0` — all cases where the provider didn't meaningfully report reasoning tokens.

### Phase 3: Refactor

After tests pass, review for:

1. **Consolidate with `cumulativeUsage` init** — ensure `reasoningTokensByDelta: 0` is set in all places where `cumulativeUsage` is reset (search for `cumulativeUsage: {` assignments, there are at least two: line 1298 and line 2319).

2. **Check abort path** — `streamManager.ts:943-949` uses `cumulativeUsage` directly on abort. Verify the backfill also applies there. If the abort handler constructs usage separately, add the same backfill guard.

3. **Verify `appendPartAndEmit` has `streamInfo` access** — if the method signature doesn't include it, check if it's accessed via `this.workspaceStreams.get(workspaceId)`. If adding a parameter is cleaner, do that.

4. **All tests still pass** — `make test` must pass after refactoring.

## Verification

1. `bun test src/node/services/streamManager.test.ts` — new reasoning backfill tests pass.
2. `make typecheck` — no type errors from new field.
3. `make lint` — clean.
4. `make test` — full suite passes (no regressions).

## LoC Estimate

~15 lines product code (1 field + 1 init + 1 accumulation + 1 backfill guard), ~80 lines test code.

## Out of Scope

- **Backfilling historical data** — existing `chat.jsonl` entries won't be retroactively fixed. The analytics dashboard will show correct values only for new streams. A separate ETL migration could address old data.
- **Upstream SDK fix** — `@ai-sdk/anthropic` may eventually populate `reasoningTokens` natively, at which point our backfill becomes a no-op (the `!totalUsage.reasoningTokens` guard ensures we only inject when the provider didn't report it).

</details>

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$6.38`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=6.38 -->
