### PR TITLE
🤖 fix: give project name more space on mobile by hiding hover-only actions

### DIFF
--- a/src/browser/components/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar.tsx
@@ -1073,7 +1073,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                                 }}
                                 aria-label={`Manage secrets for ${projectName}`}
                                 data-project-path={projectPath}
-                                className="text-muted-dark mr-1 flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded-[3px] border-none bg-transparent text-sm opacity-0 transition-all duration-200 hover:bg-yellow-500/10 hover:text-yellow-500"
+                                className="text-muted-dark mr-1 flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded-[3px] border-none bg-transparent text-sm opacity-0 transition-all duration-200 hover:bg-yellow-500/10 hover:text-yellow-500 [@media(hover:none)_and_(pointer:coarse)]:hidden"
                               >
                                 <KeyRound size={12} />
                               </button>
@@ -1121,6 +1121,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                                 data-project-path={projectPath}
                                 className={cn(
                                   "text-muted-dark mr-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-[3px] border-none bg-transparent text-base opacity-0 transition-all duration-200",
+                                  "[@media(hover:none)_and_(pointer:coarse)]:hidden",
                                   canDelete
                                     ? "cursor-pointer hover:bg-danger-light/10 hover:text-danger-light"
                                     : "cursor-not-allowed"


### PR DESCRIPTION
## Summary

On mobile touch devices, the project name in the sidebar was heavily truncated because hover-only action buttons (secrets and remove) occupied layout space despite being invisible and unreachable.

## Background

The project header row in the sidebar contains a chevron, the project name, and three action buttons: secrets (🔑), remove (×), and new workspace (+). The secrets and remove buttons use `opacity-0` and only appear on `hover:`, which doesn't exist on touch devices. However, they still occupied ~44px of horizontal space (`h-5 w-5 shrink-0 mr-1` × 2), forcing the project name to truncate aggressively.

## Implementation

Added `[@media(hover:none)_and_(pointer:coarse)]:hidden` to the secrets and remove buttons. This uses `display: hidden` on touch-only devices (no hover capability + coarse pointer), which removes them from layout entirely. This follows the exact same pattern already used in `WorkspaceListItem.tsx` for hiding desktop-only delete buttons on touch devices.

The + button for adding a new workspace remains always visible since it's useful on mobile.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$1.42`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=1.42 -->
