### PR TITLE
🤖 ci: trigger CI for auto-cleanup PRs via GitHub App token

### DIFF
--- a/.github/workflows/auto-cleanup.yml
+++ b/.github/workflows/auto-cleanup.yml
@@ -17,8 +17,27 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
+      - name: Check required secrets
+        id: precheck
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          MUX_APP_ID: ${{ secrets.MUX_APP_ID }}
+          MUX_APP_PRIVATE_KEY: ${{ secrets.MUX_APP_PRIVATE_KEY }}
+        run: |
+          missing=0
+          [ -z "$ANTHROPIC_API_KEY" ] && echo "Skipping (missing ANTHROPIC_API_KEY)." && missing=1
+          [ -z "$MUX_APP_ID" ] && echo "Skipping (missing MUX_APP_ID)." && missing=1
+          [ -z "$MUX_APP_PRIVATE_KEY" ] && echo "Skipping (missing MUX_APP_PRIVATE_KEY)." && missing=1
+
+          if [ "$missing" -eq 1 ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: app-token
+        if: ${{ steps.precheck.outputs.enabled == 'true' }}
         with:
           # Use a GitHub App token so PR events trigger CI. PRs opened via
           # GITHUB_TOKEN intentionally do not trigger other workflows.
@@ -26,18 +45,19 @@ jobs:
           private-key: ${{ secrets.MUX_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        if: ${{ steps.precheck.outputs.enabled == 'true' }}
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
       - uses: oven-sh/setup-bun@b7a1c7ccf290d58743029c4f6903da283811b979 # v2.1.0
+        if: ${{ steps.precheck.outputs.enabled == 'true' }}
 
       - name: Cleanup with mux
+        if: ${{ steps.precheck.outputs.enabled == 'true' }}
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          [ -z "$ANTHROPIC_API_KEY" ] && echo "Skipping (no API key)" && exit 0
-
           bunx mux@next run \
             --model anthropic:claude-opus-4-6 \
             --thinking xhigh \

--- a/docs/guides/github-actions.mdx
+++ b/docs/guides/github-actions.mdx
@@ -60,8 +60,27 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
+      - name: Check required secrets
+        id: precheck
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          MUX_APP_ID: ${{ secrets.MUX_APP_ID }}
+          MUX_APP_PRIVATE_KEY: ${{ secrets.MUX_APP_PRIVATE_KEY }}
+        run: |
+          missing=0
+          [ -z "$ANTHROPIC_API_KEY" ] && echo "Skipping (missing ANTHROPIC_API_KEY)." && missing=1
+          [ -z "$MUX_APP_ID" ] && echo "Skipping (missing MUX_APP_ID)." && missing=1
+          [ -z "$MUX_APP_PRIVATE_KEY" ] && echo "Skipping (missing MUX_APP_PRIVATE_KEY)." && missing=1
+
+          if [ "$missing" -eq 1 ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: app-token
+        if: ${{ steps.precheck.outputs.enabled == 'true' }}
         with:
           # Use a GitHub App token so PR events trigger CI. PRs opened via
           # GITHUB_TOKEN intentionally do not trigger other workflows.
@@ -69,18 +88,19 @@ jobs:
           private-key: ${{ secrets.MUX_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        if: ${{ steps.precheck.outputs.enabled == 'true' }}
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
       - uses: oven-sh/setup-bun@b7a1c7ccf290d58743029c4f6903da283811b979 # v2.1.0
+        if: ${{ steps.precheck.outputs.enabled == 'true' }}
 
       - name: Cleanup with mux
+        if: ${{ steps.precheck.outputs.enabled == 'true' }}
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          [ -z "$ANTHROPIC_API_KEY" ] && echo "Skipping (no API key)" && exit 0
-
           bunx mux@next run \
             --model anthropic:claude-opus-4-6 \
             --thinking xhigh \


### PR DESCRIPTION
## Summary
Switch the auto-cleanup workflow from `GITHUB_TOKEN` to a GitHub App token so PRs opened by the scheduled action trigger normal `pull_request` CI workflows.

## Background
PRs created by `GITHUB_TOKEN` do not trigger additional workflows by design, which left auto-cleanup PRs without CI runs.

## Implementation
- Added `actions/create-github-app-token` to `.github/workflows/auto-cleanup.yml`.
- Wired the generated app token into both:
  - `actions/checkout` (`with.token`) so pushes use the app identity
  - `GH_TOKEN` for the mux run step
- Updated workflow setup comments to document required secrets.
- Synced `docs/guides/github-actions.mdx` with the workflow update.

## Validation
- `make static-check`

## Risks
Low risk, scoped to the auto-cleanup workflow auth path. The main regression risk is misconfigured app credentials, which would fail the scheduled job early.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$1.13`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=1.13 -->
