### PR TITLE
🤖 fix: cap timing histogram range at p99

### DIFF
--- a/src/node/services/analytics/queries.ts
+++ b/src/node/services/analytics/queries.ts
@@ -361,20 +361,32 @@ async function queryTimingDistribution(
   // meaningful units and percentile reference lines land correctly.
   //
   // Cap the histogram range at p99 so a single extreme outlier does not flatten
-  // the distribution for the other 99% of responses. Values above p99 are
-  // intentionally folded into the final bucket via LEAST(20, ...).
+  // the distribution for the other 99% of responses. If p99 collapses to min
+  // (for near-constant datasets), fall back to raw max to preserve bucket spread.
   const histogram = await typedQuery(
     conn,
     `
-    WITH stats AS (
+    WITH raw_stats AS (
       SELECT
         MIN(${column}) AS min_value,
-        PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY ${column}) AS max_value
+        PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY ${column}) AS p99_value,
+        MAX(${column}) AS raw_max_value
       FROM events
       WHERE ${column} IS NOT NULL
         AND (? IS NULL OR project_path = ?)
         AND (? IS NULL OR date >= CAST(? AS DATE))
         AND (? IS NULL OR date <= CAST(? AS DATE))
+    ),
+    stats AS (
+      SELECT
+        min_value,
+        CASE
+          -- If p99 collapses to the minimum (e.g. >99% identical values),
+          -- fall back to the raw max so outliers do not get forced into bucket 1.
+          WHEN p99_value = min_value AND raw_max_value > p99_value THEN raw_max_value
+          ELSE p99_value
+        END AS max_value
+      FROM raw_stats
     ),
     bucketed AS (
       SELECT


### PR DESCRIPTION
## Summary
Cap timing distribution histogram bucket range at p99 instead of max value.

## Background
A single extreme duration outlier can stretch histogram bucket widths enough to flatten the chart for the rest of responses, making p50/p90/p99 context harder to read.

## Implementation
- Updated `queryTimingDistribution` in `src/node/services/analytics/queries.ts`
- Replaced histogram stats upper bound from `MAX(${column})` to `PERCENTILE_CONT(0.99) ... AS max_value`
- Added inline rationale comments documenting that values above p99 are intentionally folded into the last bucket by existing `LEAST(20, ...)` bucket clamping

## Risks
- Tail values above p99 are no longer distributed across the full x-axis range and are aggregated into the final bucket.
- This is intentional for chart readability, but it reduces visual resolution in the extreme tail.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.78`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.78 -->
