### PR TITLE
🤖 fix: allow parallel in-progress todo items

### DIFF
--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -998,8 +998,8 @@ export const TOOL_DEFINITIONS = {
       "The TODO list is displayed to the user at all times. " +
       "Replace the entire list on each call - the AI tracks which tasks are completed.\n" +
       "\n" +
-      "Mark ONE task as in_progress at a time. " +
-      "Order tasks as: completed first, then in_progress (max 1), then pending last. " +
+      "Mark tasks as in_progress when actively being worked on (multiple allowed for parallel work). " +
+      "Order tasks as: completed first, then in_progress, then pending last. " +
       "Use appropriate tense in content: past tense for completed (e.g., 'Added tests'), " +
       "present progressive for in_progress (e.g., 'Adding tests'), " +
       "and imperative/infinitive for pending (e.g., 'Add tests').\n" +

--- a/src/node/services/tools/todo.test.ts
+++ b/src/node/services/tools/todo.test.ts
@@ -130,33 +130,27 @@ describe("Todo Storage", () => {
       expect(await getTodosForSessionDir(workspaceSessionDir)).toEqual(maxTodos);
     });
 
-    it("should reject multiple in_progress tasks", async () => {
-      const validTodos: TodoItem[] = [
-        {
-          content: "Step 1",
-          status: "pending",
-        },
+    it("should accept multiple in_progress tasks", async () => {
+      const todos: TodoItem[] = [
+        { content: "Step 1", status: "in_progress" },
+        { content: "Step 2", status: "in_progress" },
       ];
 
-      await setTodosForSessionDir(workspaceId, workspaceSessionDir, validTodos);
+      await setTodosForSessionDir(workspaceId, workspaceSessionDir, todos);
+      expect(await getTodosForSessionDir(workspaceSessionDir)).toEqual(todos);
+    });
 
-      const invalidTodos: TodoItem[] = [
-        {
-          content: "Step 1",
-          status: "in_progress",
-        },
-        {
-          content: "Step 2",
-          status: "in_progress",
-        },
+    it("should accept mixed completed + multiple in_progress + pending", async () => {
+      const todos: TodoItem[] = [
+        { content: "Done task", status: "completed" },
+        { content: "Parallel task A", status: "in_progress" },
+        { content: "Parallel task B", status: "in_progress" },
+        { content: "Parallel task C", status: "in_progress" },
+        { content: "Next up", status: "pending" },
       ];
 
-      await expect(
-        setTodosForSessionDir(workspaceId, workspaceSessionDir, invalidTodos)
-      ).rejects.toThrow(/only one task can be marked as in_progress/i);
-
-      // Original todos should remain unchanged on failure
-      expect(await getTodosForSessionDir(workspaceSessionDir)).toEqual(validTodos);
+      await setTodosForSessionDir(workspaceId, workspaceSessionDir, todos);
+      expect(await getTodosForSessionDir(workspaceSessionDir)).toEqual(todos);
     });
 
     it("should reject when in_progress tasks appear after pending", async () => {

--- a/src/node/services/tools/todo.ts
+++ b/src/node/services/tools/todo.ts
@@ -31,14 +31,13 @@ function validateTodos(todos: TodoItem[]): void {
         `Keep high precision at the center: ` +
         `summarize old completed work (e.g., 'Setup phase (3 tasks)'), ` +
         `keep recent completions detailed (1-2), ` +
-        `one in_progress, ` +
+        `in_progress tasks in the middle, ` +
         `immediate pending detailed (2-3), ` +
         `and summarize far future work (e.g., 'Testing phase (4 items)').`
     );
   }
 
   let phase: "completed" | "in_progress" | "pending" = "completed";
-  let inProgressCount = 0;
 
   todos.forEach((todo, index) => {
     const status = todo.status;
@@ -57,12 +56,6 @@ function validateTodos(todos: TodoItem[]): void {
         if (phase === "pending") {
           throw new Error(
             `Invalid todo order at index ${index}: in-progress tasks must appear before pending tasks`
-          );
-        }
-        inProgressCount += 1;
-        if (inProgressCount > 1) {
-          throw new Error(
-            "Invalid todo list: only one task can be marked as in_progress at a time"
           );
         }
         // Transition to in_progress phase (from completed or stay in in_progress)


### PR DESCRIPTION
## Summary
Allow the TODO tool pipeline to represent parallel active work by permitting multiple `in_progress` items.

## Background
Orchestrator workflows can run multiple sub-agents at once, but TODO validation enforced a hard single `in_progress` item. That mismatch forced inaccurate task state.

## Implementation
- Replaced the test that expected rejection of multiple `in_progress` tasks with positive coverage for:
  - multiple `in_progress` items
  - mixed `completed` + multiple `in_progress` + `pending`
- Removed `inProgressCount` enforcement from `validateTodos` and kept ordering validation via the phase machine (`completed -> in_progress -> pending`).
- Updated TODO guidance copy in:
  - backend max-items error hint
  - `todo_write` tool description

## Validation
- `bun test src/node/services/tools/todo.test.ts` (red phase: 2 expected failures before backend update)
- `bun test src/node/services/tools/todo.test.ts` (green phase: 15 pass)
- `make static-check`

## Risks
Low risk. Changes are localized to TODO validation and matching test/tool text. Ordering constraints are unchanged.

---

<details>
<summary>📋 Implementation Plan</summary>

# Allow multiple `in_progress` items in the TODO list

## Context / Why

In orchestrator mode, agents spawn parallel sub-agents (e.g., two independent implementation tasks). The todo list should reflect this by allowing multiple items to be `in_progress` simultaneously. Today, a hard "max 1" constraint is enforced at three layers — tool description, backend validation, and tests — which forces the model to pick a single active item even when multiple are genuinely running in parallel.

<details><summary>Evidence</summary>

| Layer | File | Lines | What |
|---|---|---|---|
| Tool description | `src/common/utils/tools/toolDefinitions.ts` | 1001–1002 | `"Mark ONE task as in_progress at a time. Order tasks as: completed first, then in_progress (max 1), then pending last."` |
| Backend validation | `src/node/services/tools/todo.ts` | 41, 62–67 | `let inProgressCount = 0` … `if (inProgressCount > 1) throw …` |
| Error hint | `src/node/services/tools/todo.ts` | 34 | `"one in_progress"` in MAX_TODOS error message |
| Test | `src/node/services/tools/todo.test.ts` | 133–160 | `"should reject multiple in_progress tasks"` |
| UI rendering | `src/browser/components/TodoList.tsx` | 73–139 | Per-item status styling — already works with N > 1 (spinner + ellipsis per item) |

</details>

## Phase 1 — Red: Write/update tests (~+20 LoC, −28 LoC)

File: `src/node/services/tools/todo.test.ts`

**Replace** the existing "should reject multiple in_progress tasks" test (lines 133–160) with these two new tests:

```ts
it("should accept multiple in_progress tasks", async () => {
  const todos: TodoItem[] = [
    { content: "Step 1", status: "in_progress" },
    { content: "Step 2", status: "in_progress" },
  ];

  await setTodosForSessionDir(workspaceId, workspaceSessionDir, todos);
  expect(await getTodosForSessionDir(workspaceSessionDir)).toEqual(todos);
});

it("should accept mixed completed + multiple in_progress + pending", async () => {
  const todos: TodoItem[] = [
    { content: "Done task", status: "completed" },
    { content: "Parallel task A", status: "in_progress" },
    { content: "Parallel task B", status: "in_progress" },
    { content: "Parallel task C", status: "in_progress" },
    { content: "Next up", status: "pending" },
  ];

  await setTodosForSessionDir(workspaceId, workspaceSessionDir, todos);
  expect(await getTodosForSessionDir(workspaceSessionDir)).toEqual(todos);
});
```

These tests will **fail** against the current validation (the `inProgressCount > 1` guard). Existing ordering tests (`"should reject when in_progress tasks appear after pending"`, `"should reject when completed tasks appear after in_progress"`) remain unchanged — ordering rules still apply.

**Run tests, confirm the two new tests fail:**
```sh
bun test src/node/services/tools/todo.test.ts
```

## Phase 2 — Green: Remove the constraint (~−10 LoC)

### 2a. Backend validation — `src/node/services/tools/todo.ts`

Remove `inProgressCount` variable and the `> 1` guard. The `phase` state machine already enforces ordering.

```diff
  let phase: "completed" | "in_progress" | "pending" = "completed";
- let inProgressCount = 0;

  todos.forEach((todo, index) => {
    ...
      case "in_progress": {
        if (phase === "pending") {
          throw new Error(
            `Invalid todo order at index ${index}: in-progress tasks must appear before pending tasks`
          );
        }
-       inProgressCount += 1;
-       if (inProgressCount > 1) {
-         throw new Error(
-           "Invalid todo list: only one task can be marked as in_progress at a time"
-         );
-       }
        phase = "in_progress";
        break;
      }
```

Update the MAX_TODOS error hint (line 34):

```diff
- `one in_progress, ` +
+ `in_progress tasks in the middle, ` +
```

### 2b. Tool description — `src/common/utils/tools/toolDefinitions.ts`

Lines 1001–1002:

```diff
- "Mark ONE task as in_progress at a time. " +
- "Order tasks as: completed first, then in_progress (max 1), then pending last. " +
+ "Mark tasks as in_progress when actively being worked on (multiple allowed for parallel work). " +
+ "Order tasks as: completed first, then in_progress, then pending last. " +
```

**Run tests, confirm all pass:**
```sh
bun test src/node/services/tools/todo.test.ts
```

## Phase 3 — Refactor

Review `validateTodos` after the removal. The function is already clean — the `phase` state machine handles ordering, and removing `inProgressCount` simplifies it. No further refactoring expected, but verify:
- The `validateTodos` doc comment (line 15: `"Enforces order: completed → in_progress → pending"`) is still accurate — **yes**, no change needed.
- No dead code left from the removal.

## Verification

```sh
# Unit tests for the changed file
bun test src/node/services/tools/todo.test.ts

# Typecheck (tool description is typed)
make typecheck

# Full static checks
make lint
```

## Out of scope

- **UI** (`src/browser/components/TodoList.tsx`): Already renders per-item — spinner + animated ellipsis for each `in_progress` item. No changes needed.
- **AGENTS.md**: The inline instruction `"Mark ONE task as in_progress at a time"` lives in the tool description (which is the model's actual instruction). AGENTS.md does not duplicate this rule.

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$1.20`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=1.20 -->
