### PR TITLE
🤖 feat: add explicit file attachment picker button in chat input

### DIFF
--- a/src/browser/components/ChatInput/AttachFileButton.tsx
+++ b/src/browser/components/ChatInput/AttachFileButton.tsx
@@ -1,0 +1,71 @@
+/**
+ * Attach file button - floats inside the chat input textarea next to the voice input button.
+ * Opens a native file picker for images, SVGs, and PDFs.
+ */
+
+import React, { useRef } from "react";
+import { Paperclip } from "lucide-react";
+import { Tooltip, TooltipTrigger, TooltipContent } from "../ui/tooltip";
+import { cn } from "@/common/lib/utils";
+
+/** Accept filter for the file picker: images, SVGs, and PDFs */
+const FILE_ACCEPT = "image/*,.svg,.pdf";
+
+interface AttachFileButtonProps {
+  onFiles: (files: File[]) => void;
+  disabled?: boolean;
+}
+
+export const AttachFileButton: React.FC<AttachFileButtonProps> = (props) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function handleClick() {
+    // Reset so re-selecting the same file still triggers onChange
+    if (inputRef.current) {
+      inputRef.current.value = "";
+    }
+    inputRef.current?.click();
+  }
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = Array.from(e.target.files ?? []);
+    if (files.length > 0) {
+      props.onFiles(files);
+    }
+  }
+
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={handleClick}
+            disabled={props.disabled ?? false}
+            aria-label="Attach file"
+            className={cn(
+              "inline-flex items-center justify-center rounded p-0.5 transition-colors duration-150",
+              "disabled:cursor-not-allowed disabled:opacity-40",
+              "text-muted/50 hover:text-muted"
+            )}
+          >
+            <Paperclip className="h-4 w-4" strokeWidth={1.5} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <strong>Attach file</strong> — images, SVGs, PDFs
+        </TooltipContent>
+      </Tooltip>
+      {/* Hidden file input — kept outside Tooltip to avoid stray DOM children */}
+      <input
+        ref={inputRef}
+        type="file"
+        accept={FILE_ACCEPT}
+        multiple
+        className="hidden"
+        onChange={handleChange}
+        tabIndex={-1}
+      />
+    </>
+  );
+};

--- a/src/browser/components/VimTextArea.tsx
+++ b/src/browser/components/VimTextArea.tsx
@@ -294,7 +294,7 @@ export const VimTextArea = React.forwardRef<HTMLTextAreaElement, VimTextAreaProp
               vimEnabled ? "font-monospace" : "font-sans",
               "placeholder:text-placeholder",
               "focus:outline-none",
-              trailingAction && "pr-10",
+              trailingAction && "pr-16",
               isEditing
                 ? "bg-editing-mode-alpha border-editing-mode focus:border-editing-mode"
                 : "bg-dark border-border-light focus:border-[var(--focus-border-color)]",


### PR DESCRIPTION
Adds an explicit file attachment picker button (paperclip icon) next to the microphone icon in the chat input textarea. Clicking it opens a native file picker that accepts images, SVGs, and PDFs.

### Implementation
- New `AttachFileButton` component in `src/browser/components/ChatInput/AttachFileButton.tsx` — styled identically to `VoiceInputButton` (same icon size, padding, colors, disabled state)
- Uses a hidden `<input type="file" accept="image/*,.svg,.pdf" multiple>` triggered by button click
- Feeds selected files through the existing `processAttachmentFiles` → `setAttachments` pipeline (same as paste/drop)
- Each file processed individually so unsupported files don't reject the entire batch
- Both buttons rendered via VimTextArea's `trailingAction` prop (positions them inside the textarea's `position: relative` wrapper at `right-3.5 bottom-2.5`)
- VimTextArea trailing action padding increased from `pr-10` to `pr-16` to accommodate dual-button layout
- Shortcut hint clearance widened from `right-12` to `right-18` to avoid overlap with trailing action buttons
- File picker disabled during message editing to match existing paste/drop behavior

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$1.22`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=1.22 -->
