### PR TITLE
🤖 fix: prepend mux attribution to provider user-agent

### DIFF
--- a/src/node/services/providerModelFactory.test.ts
+++ b/src/node/services/providerModelFactory.test.ts
@@ -237,9 +237,15 @@ describe("buildAIProviderRequestHeaders", () => {
     expect(result.get("user-agent")).toBe(MUX_AI_PROVIDER_USER_AGENT);
   });
 
-  it("does not overwrite an existing User-Agent", () => {
+  it("prepends Mux attribution to an existing User-Agent", () => {
     const result = buildAIProviderRequestHeaders({ "User-Agent": "custom-agent/1.0" });
-    expect(result.get("user-agent")).toBe("custom-agent/1.0");
+    expect(result.get("user-agent")).toBe(`${MUX_AI_PROVIDER_USER_AGENT} custom-agent/1.0`);
+  });
+
+  it("does not duplicate Mux attribution when already present", () => {
+    const existing = `${MUX_AI_PROVIDER_USER_AGENT} ai-sdk/anthropic/3.0.37`;
+    const result = buildAIProviderRequestHeaders({ "User-Agent": existing });
+    expect(result.get("user-agent")).toBe(existing);
   });
 
   it("preserves existing headers while injecting User-Agent", () => {


### PR DESCRIPTION
## Summary
Prepend Mux attribution to outbound provider `User-Agent` values while preserving SDK-provided metadata.

## Background
Anthropic requests currently preserve provider SDK `User-Agent` values. We want Mux attribution to be present first without losing the downstream SDK/runtime detail used for diagnostics.

## Implementation
- Updated `buildAIProviderRequestHeaders` in `src/node/services/providerModelFactory.ts` to:
  - set `User-Agent` to `mux/<version>` when absent,
  - prepend `mux/<version>` when a non-empty `User-Agent` already exists,
  - avoid duplicating the Mux prefix if already present.
- Added a defensive assertion after trim to enforce non-empty invariants when entering the prepend path.
- Updated `src/node/services/providerModelFactory.test.ts`:
  - changed existing-header expectation to prepend semantics,
  - added coverage for no-duplication when prefix already exists.

## Validation
- `bun test src/node/services/providerModelFactory.test.ts`
- `make static-check`

## Risks
Low risk and scoped to request header composition. Main regression surface is user-agent formatting across providers; covered with focused unit tests.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$1.72`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=1.72 -->
