### PR TITLE
🤖 fix: wire Shift+M (mark file read) in ImmersiveReviewView

### DIFF
--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -56,6 +56,7 @@ interface ImmersiveReviewViewProps {
   isLoading?: boolean;
   isRead: (hunkId: string) => boolean;
   onToggleRead: (hunkId: string) => void;
+  onMarkFileAsRead: (hunkId: string) => void;
   selectedHunkId: string | null;
   onSelectHunk: (hunkId: string | null) => void;
   /** Whether immersive review should use touch/mobile UX affordances. */
@@ -389,6 +390,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     selectedHunkId,
     onSelectHunk,
     onToggleRead,
+    onMarkFileAsRead,
     onExit,
     onReviewNote,
     isTouchImmersive,
@@ -1332,6 +1334,14 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
         return;
       }
 
+      // Mark entire file as read (Shift+M) — check before TOGGLE_HUNK_READ
+      // since matchesKeybind for 'm' could match if shift isn't checked first
+      if (matchesKeybind(e, KEYBINDS.MARK_FILE_READ)) {
+        e.preventDefault();
+        if (selectedHunkId) onMarkFileAsRead(selectedHunkId);
+        return;
+      }
+
       // Toggle hunk read
       if (matchesKeybind(e, KEYBINDS.TOGGLE_HUNK_READ)) {
         e.preventDefault();
@@ -1356,6 +1366,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     openComposer,
     selectedHunkId,
     onToggleRead,
+    onMarkFileAsRead,
     isTouchExperience,
   ]);
 

--- a/src/browser/features/RightSidebar/CodeReview/ReviewPanel.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ReviewPanel.tsx
@@ -1563,6 +1563,7 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
               isLoading={diffState.status === "loading" || isLoadingTree}
               isRead={isRead}
               onToggleRead={handleToggleRead}
+              onMarkFileAsRead={handleMarkFileAsRead}
               selectedHunkId={selectedHunkId}
               onSelectHunk={setSelectedHunkId}
               onExit={toggleImmersive}


### PR DESCRIPTION
## Summary

Wire the `Shift+M` (MARK_FILE_READ) keyboard shortcut in ImmersiveReviewView so it actually marks all hunks in the current file as read.

## Background

The shortcut was defined in the keybinds registry and handled in `ReviewPanel`, but when immersive mode is active, `ReviewPanel`'s keyboard handler bails out early (`if (isImmersive) return`). `ImmersiveReviewView` has its own keyboard handler that never checked for `MARK_FILE_READ` — so pressing `Shift+M` did nothing despite the help bar at the bottom advertising it.

## Implementation

- Added `onMarkFileAsRead` prop to `ImmersiveReviewViewProps`
- Added `MARK_FILE_READ` handler in the immersive keydown listener, placed **before** `TOGGLE_HUNK_READ` to ensure the shift key is checked first
- Passed `handleMarkFileAsRead` from `ReviewPanel` when rendering `ImmersiveReviewView`

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$1.38`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=1.38 -->
