### PR TITLE
🤖 feat: add analytics worker sync observability + post-sync checkpoint

### DIFF
--- a/src/node/services/analytics/analyticsWorker.ts
+++ b/src/node/services/analytics/analyticsWorker.ts
@@ -3,6 +3,7 @@ import { parentPort } from "node:worker_threads";
 import { DuckDBInstance, type DuckDBConnection } from "@duckdb/node-api";
 import { getErrorMessage } from "@/common/utils/errors";
 import { decideSyncPlan, type SyncAction } from "./backfillDecision";
+import { shouldCheckpointAfterSync } from "./checkpointDecision";
 import { clearWorkspaceAnalyticsState, ingestWorkspace, rebuildAll } from "./etl";
 import { discoverAllWorkspaces } from "./workspaceDiscovery";
 import { executeNamedQuery } from "./queries";
@@ -265,30 +266,6 @@ async function listWatermarkWorkspaceIds(): Promise<Set<string>> {
   }
 
   return watermarkWorkspaceIds;
-}
-
-/** Pure predicate: should we issue a CHECKPOINT after this sync? */
-export function shouldCheckpointAfterSync(
-  action: SyncAction,
-  workspacesIngested: number,
-  workspacesPurged: number
-): boolean {
-  assert(
-    Number.isInteger(workspacesIngested) && workspacesIngested >= 0,
-    "shouldCheckpointAfterSync requires non-negative integer workspacesIngested"
-  );
-  assert(
-    Number.isInteger(workspacesPurged) && workspacesPurged >= 0,
-    "shouldCheckpointAfterSync requires non-negative integer workspacesPurged"
-  );
-
-  // full_rebuild always truncates tables, so always checkpoint even if nothing was re-ingested.
-  if (action === "full_rebuild") {
-    return true;
-  }
-
-  // incremental: only checkpoint if we actually wrote or deleted rows.
-  return action === "incremental" && (workspacesIngested > 0 || workspacesPurged > 0);
 }
 
 async function checkpointIfNeeded(

--- a/src/node/services/analytics/checkpointDecision.test.ts
+++ b/src/node/services/analytics/checkpointDecision.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import { shouldCheckpointAfterSync } from "./checkpointDecision";
+
+describe("shouldCheckpointAfterSync", () => {
+  test("returns false for noop regardless of counts", () => {
+    expect(shouldCheckpointAfterSync("noop", 5, 3)).toBe(false);
+  });
+
+  test("returns false for incremental with zero writes", () => {
+    expect(shouldCheckpointAfterSync("incremental", 0, 0)).toBe(false);
+  });
+
+  test("returns true for full_rebuild with ingested workspaces", () => {
+    expect(shouldCheckpointAfterSync("full_rebuild", 10, 0)).toBe(true);
+  });
+
+  test("returns true for incremental with ingested workspaces", () => {
+    expect(shouldCheckpointAfterSync("incremental", 3, 0)).toBe(true);
+  });
+
+  test("returns true for incremental with purged workspaces only", () => {
+    expect(shouldCheckpointAfterSync("incremental", 0, 2)).toBe(true);
+  });
+
+  test("returns true for full_rebuild even with zero ingested (purge-only rebuild)", () => {
+    // full_rebuild always writes (it clears tables), so always checkpoint
+    expect(shouldCheckpointAfterSync("full_rebuild", 0, 0)).toBe(true);
+  });
+});

--- a/src/node/services/analytics/checkpointDecision.ts
+++ b/src/node/services/analytics/checkpointDecision.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+
+import type { SyncAction } from "./backfillDecision";
+
+/**
+ * Pure predicate: should we issue a CHECKPOINT after this sync?
+ *
+ * full_rebuild always truncates tables, so always checkpoint even if nothing
+ * was re-ingested. incremental only needs a checkpoint when rows were actually
+ * written or deleted.
+ */
+export function shouldCheckpointAfterSync(
+  action: SyncAction,
+  workspacesIngested: number,
+  workspacesPurged: number
+): boolean {
+  assert(
+    Number.isInteger(workspacesIngested) && workspacesIngested >= 0,
+    "shouldCheckpointAfterSync requires non-negative integer workspacesIngested"
+  );
+  assert(
+    Number.isInteger(workspacesPurged) && workspacesPurged >= 0,
+    "shouldCheckpointAfterSync requires non-negative integer workspacesPurged"
+  );
+
+  if (action === "full_rebuild") {
+    return true;
+  }
+
+  return action === "incremental" && (workspacesIngested > 0 || workspacesPurged > 0);
+}


### PR DESCRIPTION
## Summary

Add sync observability logging and post-sync DuckDB checkpointing to the analytics worker. Every `handleSyncCheck` execution now emits a structured log line with the plan action, workspace counts, and elapsed time, making it easy to confirm the sync heuristic is working correctly.

## Background

- `handleSyncCheck` was completely silent on success — no log output for `noop`, `incremental`, or `full_rebuild` outcomes, making it impossible to confirm the sync decision heuristic was working.
- DuckDB's WAL was never explicitly checkpointed after bulk ingestion, which could lead to slow startup WAL replay and potential inconsistency after ungraceful shutdowns.

## Implementation

- **`shouldCheckpointAfterSync`** — new exported pure helper that decides whether to issue a `CHECKPOINT`:
  - `full_rebuild` → always checkpoint (truncates tables even if nothing re-ingested)
  - `incremental` → checkpoint only when ingested or purged count > 0
  - `noop` → never checkpoint
- **`checkpointIfNeeded`** — async wrapper that runs `CHECKPOINT` SQL when the pure predicate returns true; failures are logged as non-fatal
- **Sync logging** — each branch of `handleSyncCheck` now emits exactly one `[analytics-worker] syncCheck: ...` line with plan, counts, and elapsed ms
- **Shutdown logging** — `handleShutdown()` now logs before closing DuckDB
- **6 unit tests** for the pure checkpoint decision helper

## Validation

- `bun test analyticsWorker.test.ts` — 6/6 pass
- `make typecheck` ✅
- `make lint` ✅
- `make fmt-check` ✅

---

<details>
<summary>📋 Implementation Plan</summary>

# Analytics: Add sync observability + post-sync checkpoint

## Context / Why

The DuckDB analytics system has a well-designed `decideSyncPlan()` heuristic that avoids full rebuilds, but **it is completely silent on success** — no log line is emitted when the plan is `noop`, `incremental`, or `full_rebuild`. This makes it impossible to confirm the heuristic is working. Separately, DuckDB's WAL is never explicitly checkpointed after bulk ingestion, which means:
- Startup WAL replay can be slow if the WAL grows large.
- If WAL recovery fails after an ungraceful shutdown, the system falls into an inconsistency state and triggers a `full_rebuild`.

<details><summary>Evidence sources</summary>

| File | Role |
|---|---|
| `src/node/services/analytics/analyticsWorker.ts` | Worker: `handleSyncCheck` (L270–386), `handleShutdown`/`closeDuckDb` (L406–445) |
| `src/node/services/analytics/backfillDecision.ts` | `decideSyncPlan()` — pure function, well-tested |
| `src/node/services/analytics/analyticsService.ts` | Main process: `startWorker()` (L321–357), dispatches `syncCheck` |
| `src/node/services/analytics/etl.ts` | `rebuildAll()`, `ingestWorkspace()` |
| `~/.mux/analytics/analytics.db` (12 KB) + `.wal` (15 MB) | WAL contains virtually all data; main file never checkpointed |
| `src/node/services/analytics/etl.test.ts` | Existing pattern: real in-memory DuckDB + temp dirs |
| `src/node/services/analytics/backfillDecision.test.ts` | Existing pattern: pure unit tests for decision logic |
</details>

## Acceptance criteria

1. Every `handleSyncCheck` execution emits exactly one `[analytics-worker] syncCheck: ...` line to stderr containing: plan action, workspace counts, and elapsed time in ms.
2. After a `full_rebuild` or `incremental` sync that wrote data, a `CHECKPOINT` is issued. Skipped for `noop` or zero-write incremental syncs.
3. Graceful shutdown emits a `[analytics-worker] Shutting down ...` line before closing DuckDB.
4. All existing tests pass. New unit tests cover the checkpoint skip/execute decision.

---

## Phase 1 — Red: write failing tests

**File:** `src/node/services/analytics/analyticsWorker.test.ts` (new)

Extract the checkpoint decision into a **pure, exported helper** `shouldCheckpointAfterSync` so it can be tested without DuckDB. Test cases:

```ts
import { describe, expect, test } from "bun:test";
import { shouldCheckpointAfterSync } from "./analyticsWorker";

describe("shouldCheckpointAfterSync", () => {
  test("returns false for noop regardless of counts", () => {
    expect(shouldCheckpointAfterSync("noop", 5, 3)).toBe(false);
  });

  test("returns false for incremental with zero writes", () => {
    expect(shouldCheckpointAfterSync("incremental", 0, 0)).toBe(false);
  });

  test("returns true for full_rebuild with ingested workspaces", () => {
    expect(shouldCheckpointAfterSync("full_rebuild", 10, 0)).toBe(true);
  });

  test("returns true for incremental with ingested workspaces", () => {
    expect(shouldCheckpointAfterSync("incremental", 3, 0)).toBe(true);
  });

  test("returns true for incremental with purged workspaces only", () => {
    expect(shouldCheckpointAfterSync("incremental", 0, 2)).toBe(true);
  });

  test("returns true for full_rebuild even with zero ingested (purge-only rebuild)", () => {
    // full_rebuild always writes (it clears tables), so always checkpoint
    expect(shouldCheckpointAfterSync("full_rebuild", 0, 0)).toBe(true);
  });
});
```

> **Design note:** `full_rebuild` always truncates + re-inserts, so it should always checkpoint — even if `workspacesIngested === 0` (empty rebuild still cleared tables). This is a stricter condition than the original plan and avoids a subtle edge case.

These tests will fail initially because `shouldCheckpointAfterSync` doesn't exist yet.

## Phase 2 — Green: implement the changes

All changes in **`src/node/services/analytics/analyticsWorker.ts`** unless noted.

### 2a. Extract and export `shouldCheckpointAfterSync` (~5 LoC)

Place above `handleSyncCheck`. Export it for testability.

```ts
export function shouldCheckpointAfterSync(
  action: SyncAction,
  workspacesIngested: number,
  workspacesPurged: number,
): boolean {
  // full_rebuild always truncates tables, so always checkpoint even if nothing was re-ingested.
  if (action === "full_rebuild") {
    return true;
  }
  // incremental: only checkpoint if we actually wrote or deleted rows.
  return action === "incremental" && (workspacesIngested > 0 || workspacesPurged > 0);
}
```

### 2b. Add `checkpointIfNeeded` helper (~10 LoC)

Uses the pure predicate above, then runs the SQL side-effect:

```ts
async function checkpointIfNeeded(
  action: SyncAction,
  workspacesIngested: number,
  workspacesPurged: number,
): Promise<void> {
  if (!shouldCheckpointAfterSync(action, workspacesIngested, workspacesPurged)) {
    return;
  }
  try {
    await getConn().run("CHECKPOINT");
  } catch (error) {
    // Non-fatal: DuckDB will auto-checkpoint eventually or on next clean shutdown.
    process.stderr.write(
      `[analytics-worker] Post-sync checkpoint failed (non-fatal): ${getErrorMessage(error)}\n`
    );
  }
}
```

### 2c. Add sync decision logging + checkpoint call to `handleSyncCheck` (~15 LoC net)

Instrument each branch of `handleSyncCheck` with timing + a summary log. Call `checkpointIfNeeded` before returning from non-noop branches. Structured as:

```ts
async function handleSyncCheck(data: SyncCheckData): Promise<SyncCheckResult> {
  // ... existing assertions ...
  const syncStartMs = performance.now();

  // ... existing DB queries + decideSyncPlan (unchanged) ...

  if (plan.action === "noop") {
    const elapsedMs = Math.round(performance.now() - syncStartMs);
    process.stderr.write(
      `[analytics-worker] syncCheck: plan=noop, workspacesOnDisk=${knownWorkspaceIds.size}, watermarksInDB=${watermarkWorkspaceIds.size} (${elapsedMs}ms)\n`
    );
    return { action: "noop", workspacesIngested: 0, workspacesPurged: 0 };
  }

  if (plan.action === "full_rebuild") {
    const { workspacesIngested } = await rebuildAll(getConn(), data.sessionsDir, data.workspaceMetaById);
    const result: SyncCheckResult = { action: "full_rebuild", workspacesIngested, workspacesPurged: 0 };
    await checkpointIfNeeded(result.action, result.workspacesIngested, result.workspacesPurged);
    const elapsedMs = Math.round(performance.now() - syncStartMs);
    process.stderr.write(
      `[analytics-worker] syncCheck: plan=full_rebuild, workspacesIngested=${workspacesIngested}, workspacesOnDisk=${knownWorkspaceIds.size} (${elapsedMs}ms)\n`
    );
    return result;
  }

  // ... existing incremental ingest + purge loops (unchanged) ...

  const result: SyncCheckResult = { action: "incremental", workspacesIngested, workspacesPurged };
  await checkpointIfNeeded(result.action, result.workspacesIngested, result.workspacesPurged);
  const elapsedMs = Math.round(performance.now() - syncStartMs);
  process.stderr.write(
    `[analytics-worker] syncCheck: plan=incremental, ingested=${workspacesIngested}, purged=${workspacesPurged}, toIngest=${plan.workspaceIdsToIngest.length}, toPurge=${plan.workspaceIdsToPurge.length} (${elapsedMs}ms)\n`
  );
  return result;
}
```

### 2d. Log graceful shutdown (~2 LoC)

In `handleShutdown()`, add one line before `closeDuckDb()`:

```ts
  process.stderr.write("[analytics-worker] Shutting down, closing DuckDB\n");
  closeDuckDb();
```

## Phase 3 — Refactor

After Green, review for:

1. **Log format consistency** — the three `process.stderr.write` calls in `handleSyncCheck` share a prefix and timing suffix. If they look repetitive, extract a small `logSyncResult(plan, counts, elapsedMs)` formatter. Only do this if it improves readability — three one-liners may be clearer than an abstraction.
2. **`SyncCheckResult` construction** — the current code constructs the result object, then unpacks it for the log. Verify the flow reads cleanly; if not, build the log string first, then return.
3. **Existing `process.stderr.write` calls** — check whether the existing error-only stderr writes (L363, L376) should adopt the same `[analytics-worker]` prefix for consistency (they already do — confirm and leave as-is).

## Verification

1. **`make test`** — all existing + new tests pass.
2. **`make typecheck`** — no regressions.
3. **`make lint`** — clean.
4. **Manual log check** — after merging, restart the mux instance and `grep "analytics-worker" ~/.mux/logs/mux.log` to confirm the sync plan line appears. Expected output for a warm start:
   ```
   [analytics-worker] syncCheck: plan=noop, workspacesOnDisk=306, watermarksInDB=306 (45ms)
   ```

## Net LoC estimate

~30 lines product code + ~25 lines test code. All in `analyticsWorker.ts` + new `analyticsWorker.test.ts`.

## Not in scope

- Periodic checkpoint timer — unnecessary; DuckDB auto-checkpoints at 16 MB WAL and we now checkpoint after bulk writes.
- `SessionUsageService` log noise — separate, by-design lazy migration; no change needed.
- Lowering `wal_autocheckpoint` PRAGMA — default is fine for steady-state; the post-sync checkpoint covers the bulk-write case.

</details>

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$7.11`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=7.11 -->
