### PR TITLE
🤖 fix: show env vars indicator for all providers

### DIFF
--- a/src/browser/features/Settings/Sections/ProvidersSection.tsx
+++ b/src/browser/features/Settings/Sections/ProvidersSection.tsx
@@ -1147,9 +1147,10 @@ export function ProvidersSection() {
                       Get API Key
                       <ExternalLink className="h-2.5 w-2.5" />
                     </a>
-                    {provider === "anthropic" &&
-                      configured &&
-                      config?.[provider]?.apiKeySet === false && (
+                    {configured &&
+                      config?.[provider]?.apiKeySet === false &&
+                      // OpenAI can be configured via ChatGPT OAuth, not just env vars
+                      !(provider === "openai" && codexOauthIsConnected) && (
                         <div className="text-muted text-xs">
                           Configured via environment variables.
                         </div>


### PR DESCRIPTION
## Summary

The "Configured via environment variables" indicator in provider settings was hardcoded to only appear for Anthropic. This removes the `provider === "anthropic"` guard so the indicator displays for any provider whose credentials come from environment variables (e.g., `OPENAI_API_KEY`, `GOOGLE_API_KEY`, etc.).

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$0.80`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=0.80 -->
