### PR TITLE
🤖 fix: add ca-certificates to Docker runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,8 +80,9 @@ WORKDIR /app
 # Install runtime dependencies
 # - git: required for workspace operations (clone, worktree, etc.)
 # - openssh-client: required for SSH runtime support
+# - ca-certificates: required for HTTPS (git clone, API calls, etc.)
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git openssh-client && \
+    apt-get install -y --no-install-recommends git openssh-client ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy runtime dependencies first so app-code changes don't invalidate these layers.


### PR DESCRIPTION
## Summary

Add `ca-certificates` to the Docker runtime stage so git clone over HTTPS works.

## Background

The Docker image (`ghcr.io/coder/mux:nightly`) installs `git` and `openssh-client` but not `ca-certificates`. Without a CA bundle, any HTTPS operation (git clone, API calls) fails with `server certificate verification failed. CAfile: none CRLfile: none`.

Fixes #2692

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$0.04`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=0.04 -->
