### PR TITLE
🤖 fix: MCP SSE/HTTP closure detection & mid-stream error recovery

### DIFF
--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -500,9 +500,14 @@ describe("MCPServerManager", () => {
         close: mock(() => Promise.resolve(undefined)),
       };
 
-      instance.tools = wrapMCPTools({ failTool: dummyTool }, undefined, () => {
-        instance.isClosed = true;
-      });
+      instance.tools = wrapMCPTools(
+        { failTool: dummyTool },
+        {
+          onClosed: () => {
+            instance.isClosed = true;
+          },
+        }
+      );
 
       return Promise.resolve(new Map([["test-server", instance]]));
     });
@@ -607,7 +612,7 @@ describe("wrapMCPTools", () => {
       parameters: {},
     } as unknown as Tool;
 
-    const wrapped = wrapMCPTools({ myTool: tool }, undefined, onClosed);
+    const wrapped = wrapMCPTools({ myTool: tool }, { onClosed });
 
     let executeError: unknown;
     try {
@@ -628,7 +633,7 @@ describe("wrapMCPTools", () => {
       parameters: {},
     } as unknown as Tool;
 
-    const wrapped = wrapMCPTools({ myTool: tool }, undefined, onClosed);
+    const wrapped = wrapMCPTools({ myTool: tool }, { onClosed });
 
     let executeError: unknown;
     try {
@@ -654,7 +659,7 @@ describe("wrapMCPTools", () => {
       parameters: {},
     } as unknown as Tool;
 
-    const wrapped = wrapMCPTools({ failTool, okTool }, undefined, onClosed);
+    const wrapped = wrapMCPTools({ failTool, okTool }, { onClosed });
 
     // failTool should throw and trigger onClosed
     try {
@@ -680,7 +685,7 @@ describe("wrapMCPTools", () => {
       parameters: {},
     } as unknown as Tool;
 
-    const wrapped = wrapMCPTools({ myTool: tool }, undefined, onClosed);
+    const wrapped = wrapMCPTools({ myTool: tool }, { onClosed });
     try {
       await wrapped.myTool.execute!({}, {} as never);
       throw new Error("Expected to throw");
@@ -702,7 +707,7 @@ describe("wrapMCPTools", () => {
       parameters: {},
     } as unknown as Tool;
 
-    const wrapped = wrapMCPTools({ myTool: tool }, onActivity, onClosed);
+    const wrapped = wrapMCPTools({ myTool: tool }, { onActivity, onClosed });
 
     let didThrow = false;
     try {

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -42,9 +42,9 @@ export function isClosedClientError(error: unknown): boolean {
  */
 export function wrapMCPTools(
   tools: Record<string, Tool>,
-  onActivity?: () => void,
-  onClosed?: () => void
+  options?: { onActivity?: () => void; onClosed?: () => void }
 ): Record<string, Tool> {
+  const { onActivity, onClosed } = options ?? {};
   const wrapped: Record<string, Tool> = {};
   for (const [name, tool] of Object.entries(tools)) {
     // Only wrap tools that have an execute function
@@ -1236,8 +1236,11 @@ export class MCPServerManager {
       await transport.start();
       const client = await createMCPClient({ transport });
       const rawTools = await client.tools();
-      const tools = wrapMCPTools(rawTools as unknown as Record<string, Tool>, onActivity, () => {
-        if (instanceRef.current) instanceRef.current.isClosed = true;
+      const tools = wrapMCPTools(rawTools as unknown as Record<string, Tool>, {
+        onActivity,
+        onClosed: () => {
+          if (instanceRef.current) instanceRef.current.isClosed = true;
+        },
       });
 
       log.info("[MCP] Server ready", {
@@ -1289,6 +1292,9 @@ export class MCPServerManager {
     let transportErrored = false;
 
     const onUncaughtError = (error: unknown) => {
+      if (transportErrored) {
+        return;
+      }
       log.error("[MCP] Uncaught transport error", { name, error: getErrorMessage(error) });
       if (isClosedClientError(error)) {
         transportErrored = true;
@@ -1351,8 +1357,11 @@ export class MCPServerManager {
     let clientClosed = false;
 
     const rawTools = await client.tools();
-    const tools = wrapMCPTools(rawTools as unknown as Record<string, Tool>, onActivity, () => {
-      if (instanceRef.current) instanceRef.current.isClosed = true;
+    const tools = wrapMCPTools(rawTools as unknown as Record<string, Tool>, {
+      onActivity,
+      onClosed: () => {
+        if (instanceRef.current) instanceRef.current.isClosed = true;
+      },
     });
 
     log.info("[MCP] Server ready", {


### PR DESCRIPTION
## Summary

Fix MCP SSE/HTTP connection closure detection and mid-stream error recovery. When an SSE/HTTP MCP server (e.g. Chrome MCP) drops its connection, Mux previously failed with "Attempted to send a request from a closed client" and never recovered — even across new streams.

## Background

Two bugs caused this:
1. **SSE/HTTP transports lacked closure detection.** Stdio transports hook `transport.onclose` to set `instance.isClosed = true`, enabling `getToolsForWorkspace` to detect and restart dead servers. The SSE/HTTP path never set `isClosed` because the SDK creates the transport internally and Mux had no `onclose` hook.
2. **`wrapMCPTools` had no error handling.** If a server died mid-stream (after tools were fetched), every subsequent tool call failed. The error wasn't caught, `instance.isClosed` was never set, and recovery didn't trigger.

## Implementation

### Production (`mcpServerManager.ts`, +72 lines)
- **`isClosedClientError(error)`** — Exported helper detecting SDK closed-client errors by matching known message patterns: "closed client", "connection closed", "not connected". Uses `getErrorMessage()` which walks `.cause` chains.
- **`wrapMCPTools(tools, options?)`** — Refactored to options object `{ onActivity?, onClosed? }`. Wraps tool execute in try/catch; calls `onClosed` (itself in a protective try/catch) on closed-client errors, then re-throws.
- **Stdio path** — Wires `onClosed` to mark `instanceRef.current.isClosed = true`; fixes logging consistency (`getErrorMessage`); breaks reference cycle (`instanceRef.current = null` in close).
- **SSE/HTTP path** — Adds `instanceRef` + `transportErrored` flag with idempotency guard; `onUncaughtError` callback (passed to `createMCPClient`) filtered by `isClosedClientError`; instance initialized with `isClosed: transportErrored || clientClosed`; same reference cycle fix.

### Tests (`mcpServerManager.test.ts`, +270 lines)
- `isClosedClientError`: 8 tests — all patterns, chained `.cause`, false negatives, non-Error values
- `wrapMCPTools`: 7 tests — onClosed called/not-called, multi-tool isolation, onClosed-throws doesn't mask original error, onActivity fires on failure, success passthrough, no-execute passthrough
- Integration: 1 test — closed-client error → `isClosed` flag → `getToolsForWorkspace` triggers restart

## Risks

Low risk. Changes are confined to the MCP server management layer:
- Error detection uses string matching on SDK messages (no exported error class available). False positives are limited to the error path and would only cause an unnecessary (but safe) server restart.
- The `instanceRef` pattern mirrors the existing stdio implementation.
- All changes are backwards-compatible with no IPC or UI surface changes.


---

<details>
<summary>📋 Implementation Plan</summary>

# Fix: MCP SSE/HTTP closure detection & mid-stream error recovery

## Context / Why

When an SSE/HTTP MCP server (e.g. Chrome MCP) drops its connection, Mux fails with
`"Attempted to send a request from a closed client"` and **never recovers** — even across new streams.
Two bugs cause this:

1. **SSE/HTTP transports lack closure detection.** Stdio transports hook `transport.onclose` to set
   `instance.isClosed = true`, enabling `getToolsForWorkspace` to detect and restart dead servers.
   The SSE/HTTP path never sets `isClosed` because the SDK creates the transport internally and
   Mux has no `onclose` hook.

2. **`wrapMCPTools` has no error handling.** If a server dies mid-stream (after tools were fetched),
   every subsequent tool call in that stream fails. The error isn't caught, `instance.isClosed`
   is never set, and recovery doesn't trigger even on the next stream (for SSE/HTTP).

**Desired behavior:** When any MCP server drops mid-session, Mux should (a) detect the
closure immediately, (b) mark the instance dead so the existing reconnect logic in
`getToolsForWorkspace` triggers on the next stream, and (c) surface the error to the LLM
as a `tool-error` so the current turn degrades gracefully.

<details>
<summary>Evidence</summary>

| File | Role |
|---|---|
| `src/node/services/mcpServerManager.ts:1193–1203` | Stdio path — hooks `transport.onclose` → sets `isClosed` ✅ |
| `src/node/services/mcpServerManager.ts:1306–1338` | SSE/HTTP path — no `onclose` hook, `isClosed` only set on explicit `close()` ❌ |
| `src/node/services/mcpServerManager.ts:31–54` | `wrapMCPTools` — no try/catch around `originalExecute` ❌ |
| `src/node/services/mcpServerManager.ts:773–886` | `getToolsForWorkspace` — reconnects when `instance.isClosed` is true ✅ (but never triggered for SSE/HTTP) |
| `node_modules/@ai-sdk/mcp/dist/index.js:1624–1638` | SDK constructor — hooks `transport.onclose` internally, sets SDK-level `isClosed`. Exposes `onUncaughtError` config option. |
| `node_modules/@ai-sdk/mcp/dist/index.js:1744–1745` | SDK throws "Attempted to send a request from a closed client" when `isClosed` is true |
| SDK exports | `MCPClientError` is **not exported** — detection must use error message string matching |
| `src/node/services/mcpServerManager.test.ts` | Existing tests use `MCPServerManagerTestAccess` pattern to test internals |

</details>

<details>
<summary>Alternatives considered</summary>

- **Mid-stream restart + retry**: `wrapMCPTools` could restart the dead server and retry the tool call transparently. Rejected for now — requires async restart machinery in the wrapper, risks timeout/deadlock, and the existing "reconnect on next stream" behavior is acceptable UX. Can be a follow-up.
- **Custom transport wrapper**: Create our own SSE transport to access `onclose` directly. Rejected — the SDK's built-in transports are well-maintained and `onUncaughtError` + reactive detection in `wrapMCPTools` achieves the same goal with less code.
- **Periodic health checks / keepalive pings**: Poll MCP servers to detect closure proactively. Rejected — adds complexity and load for marginal benefit over reactive detection.

</details>

---

## Phase 1 — Red: Write Failing Tests

**File:** `src/node/services/mcpServerManager.test.ts`

Export `isClosedClientError` and `wrapMCPTools` from the production module (they are currently
module-private). Minimal export surface — `isClosedClientError` is a pure function and
`wrapMCPTools` is stateless; exporting them is low-risk and avoids brittle internal-cast testing.

### Test 1: `isClosedClientError` matches known SDK messages

```typescript
describe("isClosedClientError", () => {
  test("returns true for 'Attempted to send a request from a closed client'", () => {
    const error = new Error("Attempted to send a request from a closed client");
    expect(isClosedClientError(error)).toBe(true);
  });

  test("returns true for 'Connection closed'", () => {
    const error = new Error("Connection closed");
    expect(isClosedClientError(error)).toBe(true);
  });

  test("returns true for 'MCP SSE Transport Error: Connection closed unexpectedly'", () => {
    const error = new Error("MCP SSE Transport Error: Connection closed unexpectedly");
    expect(isClosedClientError(error)).toBe(true);
  });

  test("returns false for unrelated errors", () => {
    expect(isClosedClientError(new Error("timeout"))).toBe(false);
    expect(isClosedClientError(new Error("ECONNREFUSED"))).toBe(false);
    expect(isClosedClientError(null)).toBe(false);
  });
});
```

### Test 2: `wrapMCPTools` calls `onClosed` on closed-client error, re-throws

```typescript
describe("wrapMCPTools", () => {
  test("calls onClosed when execute throws a closed-client error", async () => {
    const onClosed = mock(() => {});
    const closedError = new Error("Attempted to send a request from a closed client");
    const tool = {
      execute: mock(() => Promise.reject(closedError)),
      parameters: z.object({}),
    } as unknown as Tool;

    const wrapped = wrapMCPTools({ myTool: tool }, undefined, onClosed);
    await expect(wrapped.myTool.execute!({}, {})).rejects.toThrow(closedError);
    expect(onClosed).toHaveBeenCalledTimes(1);
  });

  test("does NOT call onClosed for non-closed-client errors", async () => {
    const onClosed = mock(() => {});
    const otherError = new Error("some other failure");
    const tool = {
      execute: mock(() => Promise.reject(otherError)),
      parameters: z.object({}),
    } as unknown as Tool;

    const wrapped = wrapMCPTools({ myTool: tool }, undefined, onClosed);
    await expect(wrapped.myTool.execute!({}, {})).rejects.toThrow(otherError);
    expect(onClosed).toHaveBeenCalledTimes(0);
  });

  test("calls onActivity before execute and still calls it on failure", async () => {
    const onActivity = mock(() => {});
    const tool = {
      execute: mock(() => Promise.reject(new Error("Attempted to send a request from a closed client"))),
      parameters: z.object({}),
    } as unknown as Tool;

    const wrapped = wrapMCPTools({ myTool: tool }, onActivity, mock(() => {}));
    await expect(wrapped.myTool.execute!({}, {})).rejects.toThrow();
    expect(onActivity).toHaveBeenCalledTimes(1);
  });

  test("passes through result from transformMCPResult on success", async () => {
    const tool = {
      execute: mock(() => Promise.resolve({ content: [{ type: "text", text: "ok" }] })),
      parameters: z.object({}),
    } as unknown as Tool;

    const wrapped = wrapMCPTools({ myTool: tool });
    const result = await wrapped.myTool.execute!({}, {});
    // transformMCPResult passes through non-image content as-is
    expect(result).toBeTruthy();
  });
});
```

### Test 3: Integration — closed-client error during tool exec marks instance for restart

This test verifies the full loop: tool call fails → `instance.isClosed` flipped → next
`getToolsForWorkspace` triggers restart. Uses the existing `MCPServerManagerTestAccess`
pattern already in the file.

```typescript
test("tool execution failure with closed-client error marks instance isClosed for restart", async () => {
  const workspaceId = "ws-tool-closed";
  // ... setup with startServersMock returning an instance whose tool.execute
  // rejects with "Attempted to send a request from a closed client"
  // After calling getToolsForWorkspace and executing the tool (which fails),
  // verify the cached instance.isClosed === true
  // Then call getToolsForWorkspace again and verify startServersMock is called
  // a second time (reconnect triggered).
});
```

**~65 net LoC test code. All tests should fail initially** since `isClosedClientError` and
the `onClosed` callback don't exist yet.

---

## Phase 2 — Green: Make Tests Pass

### Step 1: Add `isClosedClientError` helper (export it)

**File:** `src/node/services/mcpServerManager.ts` — after line 25 (constants), before `wrapMCPTools`.

```typescript
/** Detect errors from the @ai-sdk/mcp SDK indicating the client/transport is closed.
 *  MCPClientError is not exported from the SDK, so we match on known message patterns.
 *  Known patterns: "closed client", "Connection closed", "Connection closed unexpectedly". */
export function isClosedClientError(error: unknown): boolean {
  const msg = getErrorMessage(error).toLowerCase();
  return msg.includes("closed client") || msg.includes("connection closed");
}
```

**~5 net LoC**

### Step 2: Add `onClosed` param to `wrapMCPTools` + try/catch (export it)

**File:** `src/node/services/mcpServerManager.ts` — `wrapMCPTools` (lines 31–54).

```typescript
export function wrapMCPTools(
  tools: Record<string, Tool>,
  onActivity?: () => void,
  onClosed?: () => void,
): Record<string, Tool> {
  const wrapped: Record<string, Tool> = {};
  for (const [name, tool] of Object.entries(tools)) {
    if (!tool.execute) {
      wrapped[name] = tool;
      continue;
    }
    const originalExecute = tool.execute;
    wrapped[name] = {
      ...tool,
      execute: async (args: Parameters<typeof originalExecute>[0], options) => {
        onActivity?.();
        try {
          const result: unknown = await originalExecute(args, options);
          return transformMCPResult(result as MCPCallToolResult);
        } catch (error) {
          if (isClosedClientError(error)) {
            onClosed?.();
          }
          throw error;
        }
      },
    };
  }
  return wrapped;
}
```

**~8 net LoC** (diff over existing function: add `onClosed` param, add try/catch/re-throw).

### Step 3: Wire `onClosed` at both call sites

Both call sites set `instanceRef.current.isClosed = true` on closed-client errors, feeding
the existing `getToolsForWorkspace` restart detection.

**Stdio path** (~line 1212) — `instanceRef` already exists:
```typescript
const tools = wrapMCPTools(
  rawTools as unknown as Record<string, Tool>,
  onActivity,
  () => { if (instanceRef.current) instanceRef.current.isClosed = true; },
);
```

**SSE/HTTP path** (~line 1309) — requires adding `instanceRef` (see Step 4):
```typescript
const tools = wrapMCPTools(
  rawTools as unknown as Record<string, Tool>,
  onActivity,
  () => { if (instanceRef.current) instanceRef.current.isClosed = true; },
);
```

**~4 net LoC** (two call-site changes).

### Step 4: Add `onUncaughtError` + `instanceRef` for SSE/HTTP path

**File:** `src/node/services/mcpServerManager.ts` — `startSingleServer` SSE/HTTP section (~lines 1248–1340).

Mirrors the stdio path's `instanceRef` pattern. Also passes `onUncaughtError` to
`createMCPClient` so that transport-level errors (SSE stream dropped, network failure)
proactively mark the instance as closed.

```typescript
// Before transportBase (~line 1258):
const instanceRef: { current: MCPServerInstance | null } = { current: null };

const onUncaughtError = (error: unknown) => {
  log.error("[MCP] Uncaught transport error", { name, error });
  if (instanceRef.current) {
    instanceRef.current.isClosed = true;
  }
};

// Modify tryHttp/trySse to pass onUncaughtError:
const tryHttp = async () =>
  createMCPClient({
    transport: { type: "http", ...transportBase },
    onUncaughtError,
  });

const trySse = async () =>
  createMCPClient({
    transport: { type: "sse", ...transportBase },
    onUncaughtError,
  });

// After instance creation (~line 1338):
instanceRef.current = instance;
return instance;
```

**~15 net LoC.**

### Run tests → all green

```bash
bun test src/node/services/mcpServerManager.test.ts
```

---

## Phase 3 — Refactor

After both fixes are working and tests pass, review for cleanup:

1. **DRY the `onClosed` callback.** Both call sites (stdio, SSE/HTTP) create an identical
   `() => { if (instanceRef.current) instanceRef.current.isClosed = true; }` closure. Extract
   a shared helper `markInstanceClosed(instanceRef)` if the duplication feels noisy (borderline
   — only 2 sites, may not warrant extraction). Evaluate after seeing the diff.

2. **Consistent `instanceRef` usage in SSE/HTTP path.** Verify the new `instanceRef` variable
   doesn't shadow or conflict with anything. The stdio path already uses this exact pattern
   (lines 1191–1201), so the SSE/HTTP path should look structurally identical.

3. **Audit error message strings.** Confirm the three known SDK error messages are the only
   patterns we need. Grep `node_modules/@ai-sdk/mcp/dist/index.js` for all `MCPClientError`
   construction sites that indicate a closed/dead connection. Add any we missed.

4. **Run full validation:**

```bash
run_and_report typecheck make typecheck
run_and_report lint make lint
run_and_report test bun test src/node/services/mcpServerManager.test.ts
run_and_report test-mcp-transform bun test src/node/services/mcpResultTransform.test.ts
```

---

## Summary

| Phase | File | Change | Net LoC |
|---|---|---|---|
| Red | `mcpServerManager.test.ts` | 3 test groups (7 cases) | ~65 |
| Green | `mcpServerManager.ts` | `isClosedClientError` helper (exported) | ~5 |
| Green | `mcpServerManager.ts` | `wrapMCPTools` try/catch + `onClosed` param (exported) | ~8 |
| Green | `mcpServerManager.ts` | Wire `onClosed` at stdio + SSE/HTTP call sites | ~4 |
| Green | `mcpServerManager.ts` | `onUncaughtError` + `instanceRef` for SSE/HTTP | ~15 |
| Refactor | `mcpServerManager.ts` | DRY cleanup, audit error patterns | ~0 |
| | | **Total product** | **~32** |
| | | **Total test** | **~65** |

</details>

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$11.30`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=11.30 -->
