### PR TITLE
🤖 feat: web-only splash screen during workspace switch hydration

### DIFF
--- a/src/browser/components/WorkspaceShell/WorkspaceShell.tsx
+++ b/src/browser/components/WorkspaceShell/WorkspaceShell.tsx
@@ -146,6 +146,15 @@ export const WorkspaceShell: React.FC<WorkspaceShellProps> = (props) => {
     );
   }
 
+  // Web-only: during workspace switches, the WebSocket subscription needs time to
+  // catch up. Show a splash instead of flashing stale cached messages.
+  // Electron's MessageChannel is near-instant so this gate is unnecessary there.
+  if (workspaceState.isHydratingTranscript && !window.api) {
+    return (
+      <WorkspacePlaceholder title="Catching up with the agent..." className={props.className} />
+    );
+  }
+
   if (!props.projectName || !props.workspaceName) {
     return (
       <WorkspacePlaceholder


### PR DESCRIPTION
## Summary

Adds a web-only splash screen ("Catching up with the agent...") during workspace switches to prevent flashing stale cached messages.

## Background

When switching workspaces in web mode (WebSocket transport), the aggregator caches messages from prior visits. This means `hasMessages = true` → `loading = false`, so `WorkspaceShell` immediately renders stale `ChatPane` content. The `onChat` subscription then catches up, clears the aggregator, and replays history — causing a visible flash. Electron's MessageChannel is near-instant so this is imperceptible there.

## Implementation

Single gate in `WorkspaceShell.tsx`: when `isHydratingTranscript` is true and we're in web mode (`!window.api`), show a `WorkspacePlaceholder` instead of stale content. Reuses existing `isHydratingTranscript` from the store — no backend changes needed.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$2.16`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=2.16 -->
