### PR TITLE
🤖 fix: sidebar status link icon inflating row height on mobile

### DIFF
--- a/src/browser/components/WorkspaceStatusIndicator/WorkspaceStatusIndicator.tsx
+++ b/src/browser/components/WorkspaceStatusIndicator/WorkspaceStatusIndicator.tsx
@@ -4,7 +4,6 @@ import { EmojiIcon } from "@/browser/components/icons/EmojiIcon/EmojiIcon";
 import { CircleHelp, ExternalLinkIcon, Loader2 } from "lucide-react";
 import { memo } from "react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "../Tooltip/Tooltip";
-import { Button } from "../Button/Button";
 
 export const WorkspaceStatusIndicator = memo<{
   workspaceId: string;
@@ -34,15 +33,22 @@ export const WorkspaceStatusIndicator = memo<{
         {agentStatus.url && (
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="flex h-4 w-4 shrink-0 items-center justify-center [&_svg]:size-3"
+              {/* Plain <a> instead of Button to keep the icon compact.
+                  !min-h-0 !min-w-0 override the global 44px mobile touch-target
+                  rule (globals.css) that forces all <a>/<button> to min 44×44px
+                  on pointer:coarse — this inline icon doesn't need a full tap target.
+                  stopPropagation prevents the parent workspace-select and DnD
+                  handlers from swallowing the tap. */}
+              <a
+                href={agentStatus.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex h-4 !min-h-0 w-4 !min-w-0 shrink-0 items-center justify-center [&_svg]:size-3"
+                onClick={(e) => e.stopPropagation()}
+                onPointerDown={(e) => e.stopPropagation()}
               >
-                <a href={agentStatus.url} target="_blank" rel="noopener noreferrer">
-                  <ExternalLinkIcon />
-                </a>
-              </Button>
+                <ExternalLinkIcon />
+              </a>
             </TooltipTrigger>
             <TooltipContent align="center">{agentStatus.url}</TooltipContent>
           </Tooltip>


### PR DESCRIPTION
The external link icon (↗) next to agent status messages in the sidebar was wrapped in a `<Button>` component whose base classes (`h-9`, `gap-2`, `text-sm`, `rounded-md`, etc.) inflated the row height on mobile, even though `h-4 w-4` was applied as an override.

Replaced `<Button>` with a plain `<a>` tag carrying only the minimal layout classes needed for a 16×16 inline icon. Also added `stopPropagation` on `onClick`/`onPointerDown` so tapping the link doesn't trigger workspace selection or drag-and-drop.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$3.12`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=3.12 -->
