### PR TITLE
🤖 fix: switch Copilot OAuth client ID

### DIFF
--- a/src/node/services/copilotOauthService.ts
+++ b/src/node/services/copilotOauthService.ts
@@ -7,7 +7,7 @@ import { log } from "@/node/services/log";
 import { createDeferred } from "@/node/utils/oauthUtils";
 import { getErrorMessage } from "@/common/utils/errors";
 
-const GITHUB_COPILOT_CLIENT_ID = "Ov23liCVKFN3jOo9R7HS";
+const GITHUB_COPILOT_CLIENT_ID = "Ov23li8tweQw6odWQebz";
 const SCOPE = "read:user";
 const POLLING_SAFETY_MARGIN_MS = 3000;
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;


### PR DESCRIPTION
Switch the GitHub Copilot OAuth client ID from `Ov23liCVKFN3jOo9R7HS` to `Ov23li8tweQw6odWQebz` in `copilotOauthService.ts`.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$0.34`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=0.34 -->
