### PR TITLE
🤖 ci: install Python 3.12 for terminal-bench CI

### DIFF
--- a/.github/workflows/terminal-bench.yml
+++ b/.github/workflows/terminal-bench.yml
@@ -136,10 +136,15 @@ jobs:
       - uses: ./.github/actions/setup-mux
 
       - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Add uv to PATH
-        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Install Python 3.12 (Harbor requires >=3.12)
+        run: |
+          uv python install 3.12
+          uv --version
+          uvx --version
 
       - name: Generate version file
         run: ./scripts/generate-version.sh
@@ -171,6 +176,7 @@ jobs:
       - name: Run Terminal-Bench
         run: make benchmark-terminal 2>&1 | tee benchmark.log
         env:
+          UV_PYTHON: "3.12"
           TB_DATASET: ${{ inputs.dataset }}
           TB_CONCURRENCY: ${{ inputs.concurrency }}
           TB_ENV: ${{ inputs.env }}


### PR DESCRIPTION
The terminal-bench CI jobs fail on `depot-ubuntu-22.04-16` runners because:

1. **Python 3.10 vs Harbor >=3.12** — the runner ships Python 3.10.12 but `harbor` requires >=3.12, causing `uvx harbor run` to fail at dependency resolution.
2. **`uvx: command not found`** — the uv install and PATH update were split across two steps; if install failed silently, `uvx` was unavailable.

**Fix:**
- Combine uv install + `$GITHUB_PATH` update into one step
- Add `uv python install 3.12` with version verification
- Set `UV_PYTHON=3.12` on the benchmark run step so `uvx` uses managed Python 3.12

Failed runs: [job 1](https://github.com/coder/mux/actions/runs/22482087245/job/65123537137), [job 2](https://github.com/coder/mux/actions/runs/22482087245/job/65130662637)

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$0.90`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=0.90 -->
