### PR TITLE
🤖 fix: harden clone folder-name sanitization for shell safety

### DIFF
--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -546,7 +546,7 @@ exit 1
 
       try {
         const result = await service.clone({
-          repoUrl: "https://example.com/org/con.git",
+          repoUrl: "https://example.com/org/con.txt.git",
           cloneParentDir,
         });
 
@@ -555,7 +555,7 @@ exit 1
 
         const loggedArgs = (await fs.readFile(fakeGitArgsLogPath, "utf-8")).trim().split("\n");
         const cloneWorkPath = loggedArgs[4] ?? "";
-        const expectedFolderName = "con-repo";
+        const expectedFolderName = "con-repo.txt";
 
         expect(path.basename(cloneWorkPath)).toMatch(
           new RegExp(`^${expectedFolderName}\\.mux-clone-[a-f0-9]{12}$`)

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -116,7 +116,7 @@ function resolveProjectParentDir(
 
 // Windows device names are invalid as path segments (CON/PRN/AUX/NUL/COM1.../LPT9)
 // even when used as a directory name.
-const WINDOWS_RESERVED_BASENAME_PATTERN = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/iu;
+const WINDOWS_RESERVED_BASENAME_PATTERN = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(?=\.|$)/iu;
 
 // Derive a conservative folder name from user-controlled repo input.
 // This path can flow into shell-adjacent commands (for example when opening
@@ -133,8 +133,10 @@ function sanitizeRepoFolderName(name: string): string {
     return "";
   }
 
-  if (WINDOWS_RESERVED_BASENAME_PATTERN.test(sanitized)) {
-    return `${sanitized}-repo`;
+  const reservedStemMatch = WINDOWS_RESERVED_BASENAME_PATTERN.exec(sanitized);
+  if (reservedStemMatch) {
+    const stemLength = reservedStemMatch[1]?.length ?? 0;
+    return `${sanitized.slice(0, stemLength)}-repo${sanitized.slice(stemLength)}`;
   }
 
   return sanitized;


### PR DESCRIPTION
## Summary
Harden clone destination folder derivation so repo names cannot carry shell metacharacters into shell-adjacent paths, and keep behavior resilient for Unicode and edge-case names.

## Implementation
- Switched `sanitizeRepoFolderName` to a conservative allowlist and kept NFKC normalization.
- Preserved Unicode combining marks (`\p{M}`) to avoid corrupting names in scripts that rely on marks.
- Added Windows reserved-name handling (`con`, `prn`, `com1`, etc.) by suffixing with `-repo`.
- Added deterministic fallback folder names (`repo-<sha256-prefix>`) when sanitization would otherwise become empty.
- Added regression tests for:
  - shell-metacharacter payloads,
  - combining-mark script names,
  - empty-sanitization fallback,
  - Windows reserved-name avoidance.

## Validation
- `bun test src/node/services/projectService.test.ts`
- `run_and_report static-check make static-check`

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$0.80`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=0.80 -->
