### PR TITLE
🤖 fix: restore chat input placeholder alignment

### DIFF
--- a/src/browser/components/VimTextArea/VimTextArea.tsx
+++ b/src/browser/components/VimTextArea/VimTextArea.tsx
@@ -252,7 +252,8 @@ export const VimTextArea = React.forwardRef<HTMLTextAreaElement, VimTextAreaProp
       padding: "0.375rem 0.5rem",
       fontSize: "13px",
       ...(rest.style ?? {}),
-      ...(trailingAction ? { scrollbarGutter: "stable both-edges" } : {}),
+      // Reserve scrollbar space on the trailing edge only; both-edges shifts placeholder text right.
+      ...(trailingAction ? { scrollbarGutter: "stable" } : {}),
       // Focus border color from agent definition
       "--focus-border-color": !isEditing ? focusBorderColor : undefined,
     };


### PR DESCRIPTION
## Summary
Restore chat input placeholder alignment by removing the mirrored left scrollbar gutter that was shifting textarea content to the right when trailing actions are present.

## Background
`VimTextArea` applied `scrollbarGutter: "stable both-edges"` whenever `trailingAction` was set. Chat input now always passes trailing actions (attach + voice), so both-edge gutter reservation became always-on and introduced an unintended left offset for placeholder/text.

## Implementation
- Updated `src/browser/components/VimTextArea/VimTextArea.tsx`:
  - `scrollbarGutter: "stable both-edges"` → `scrollbarGutter: "stable"`
- Added an inline comment explaining why both-edges is avoided.

## Validation
- `make static-check`

## Risks
Low. Change is scoped to textarea scrollbar gutter behavior when trailing actions are present. Main regression surface is textarea horizontal layout in chat inputs.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$2.32`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=2.32 -->
