### PR TITLE
🤖 fix: resolve false-positive unavailable-global errors for locally shadowed names

### DIFF
--- a/src/node/services/ptc/staticAnalysis.test.ts
+++ b/src/node/services/ptc/staticAnalysis.test.ts
@@ -200,6 +200,51 @@ const env = process.env;`);
     });
   });
 
+  describe("local variable shadowing", () => {
+    test("local variable shadowing fetch does not error", async () => {
+      const result = await analyzeCode(`
+        const fetch = mux.file_read({ path: "a.txt" });
+        return fetch.content;
+      `);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    test("function declaration shadowing fetch does not error", async () => {
+      const result = await analyzeCode(`
+        function fetch() { return 1; }
+        return fetch();
+      `);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    test("parameter shadowing process does not error", async () => {
+      const result = await analyzeCode(`
+        function run(process) { return process.id; }
+        return run({ id: 1 });
+      `);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    test("unshadowed fetch still errors", async () => {
+      const result = await analyzeCode(`fetch("https://example.com")`);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.message.includes("fetch"))).toBe(true);
+    });
+
+    test("multiple variables shadowing different globals", async () => {
+      const result = await analyzeCode(`
+        const fetch = mux.file_read({ path: "a.txt" });
+        const process = { id: 1 };
+        return { content: fetch.content, id: process.id };
+      `);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
   describe("allowed constructs (work in QuickJS)", () => {
     test("eval() is allowed", async () => {
       const result = await analyzeCode(`

--- a/src/node/services/ptc/staticAnalysis.ts
+++ b/src/node/services/ptc/staticAnalysis.ts
@@ -307,16 +307,19 @@ function detectUnavailableGlobals(code: string, sourceFile?: ts.SourceFile): Ana
 
     // Skip variable declarations (e.g., const process = ...)
     if (parent && ts.isVariableDeclaration(parent) && parent.name === node) {
+      seen.add(name);
       return;
     }
 
     // Skip function declarations (e.g., function process() {})
     if (parent && ts.isFunctionDeclaration(parent) && parent.name === node) {
+      seen.add(name);
       return;
     }
 
     // Skip parameter declarations
     if (parent && ts.isParameter(parent) && parent.name === node) {
+      seen.add(name);
       return;
     }
 


### PR DESCRIPTION
## Summary

Fix false-positive `'fetch' is not available in the sandbox` errors when `fetch` (or any other blocked global name) is used as a **local variable**.

## Background

The sandbox static analyzer (`detectUnavailableGlobals`) uses TypeScript AST to flag references to globals that don't exist in QuickJS (`fetch`, `process`, `window`, etc.). It correctly skips **declaration sites** (e.g., `const fetch = ...`) but doesn't remember the name was locally declared — so subsequent **uses** like `fetch.content` still get flagged.

This causes valid sandbox code like the following to fail preflight analysis:

```js
const fetch = mux.file_read({ path: "src/foo.ts" });
return fetch.content; // ❌ 'fetch' is not available in the sandbox
```

## Implementation

When a declaration-site identifier is skipped (variable declaration, function declaration, or parameter), add it to the existing `seen` set so all subsequent references to that name are also suppressed. This is a 3-line production change that leverages the existing deduplication mechanism.

The `seen` set already prevented duplicate reports for the same global — now it also prevents reports for locally-shadowed names.

## Validation

- All 44 static analysis tests pass (39 existing + 5 new)
- New tests cover: variable shadowing, function shadowing, parameter shadowing, unshadowed globals still error, multiple shadowed globals

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$0.71`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=0.71 -->
