### PR TITLE
🤖 fix: forward task-created events through AgentSession

### DIFF
--- a/src/node/services/agentSession.disposeRace.test.ts
+++ b/src/node/services/agentSession.disposeRace.test.ts
@@ -120,6 +120,92 @@ describe("AgentSession disposal race conditions", () => {
     ).not.toThrow();
   });
 
+  test("forwards task-created events to onChatEvent subscribers for the matching workspace", () => {
+    const aiHandlers = new Map<string, (...args: unknown[]) => void>();
+
+    const aiService: AIService = {
+      on(eventName: string | symbol, listener: (...args: unknown[]) => void) {
+        aiHandlers.set(String(eventName), listener);
+        return this;
+      },
+      off(_eventName: string | symbol, _listener: (...args: unknown[]) => void) {
+        return this;
+      },
+      stopStream: mock(() => Promise.resolve(Ok(undefined))),
+      isStreaming: mock(() => false),
+      streamMessage: mock(() => Promise.resolve(Ok(undefined))),
+    } as unknown as AIService;
+
+    const historyService: HistoryService = {
+      appendToHistory: mock(() => Promise.resolve(Ok(undefined))),
+    } as unknown as HistoryService;
+
+    const initStateManager: InitStateManager = {
+      on(_eventName: string | symbol, _listener: (...args: unknown[]) => void) {
+        return this;
+      },
+      off(_eventName: string | symbol, _listener: (...args: unknown[]) => void) {
+        return this;
+      },
+    } as unknown as InitStateManager;
+
+    const backgroundProcessManager: BackgroundProcessManager = {
+      cleanup: mock(() => Promise.resolve()),
+      setMessageQueued: mock(() => undefined),
+    } as unknown as BackgroundProcessManager;
+
+    const config: Config = {
+      srcDir: "/tmp",
+      getSessionDir: mock(() => "/tmp"),
+    } as unknown as Config;
+
+    const session = new AgentSession({
+      workspaceId: "ws",
+      config,
+      historyService,
+      aiService,
+      initStateManager,
+      backgroundProcessManager,
+    });
+
+    const chatEvents: Array<{ workspaceId: string; message: unknown }> = [];
+    session.onChatEvent((event) => {
+      chatEvents.push(event);
+    });
+
+    const taskCreated = aiHandlers.get("task-created");
+    expect(taskCreated).toBeDefined();
+
+    taskCreated?.({
+      type: "task-created",
+      workspaceId: "other-workspace",
+      toolCallId: "tool-call-1",
+      taskId: "task-1",
+      timestamp: 100,
+    });
+    expect(chatEvents).toHaveLength(0);
+
+    taskCreated?.({
+      type: "task-created",
+      workspaceId: "ws",
+      toolCallId: "tool-call-1",
+      taskId: "task-1",
+      timestamp: 101,
+    });
+
+    expect(chatEvents).toHaveLength(1);
+    expect(chatEvents[0]).toEqual({
+      workspaceId: "ws",
+      message: {
+        type: "task-created",
+        workspaceId: "ws",
+        toolCallId: "tool-call-1",
+        taskId: "task-1",
+        timestamp: 101,
+      },
+    });
+  });
+
   test("does not reset auto-retry intent for synthetic or rejected sends", async () => {
     const aiService: AIService = {
       on(_eventName: string | symbol, _listener: (...args: unknown[]) => void) {

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -3489,6 +3489,9 @@ export class AgentSession {
       this.activeStreamHadAnyDelta = true;
       this.emitChatEvent(payload);
     });
+    forward("task-created", (payload) => {
+      this.emitChatEvent(payload);
+    });
     forward("tool-call-delta", (payload) => {
       this.activeStreamHadAnyDelta = true;
       this.emitChatEvent(payload);


### PR DESCRIPTION
## Summary
Fixes a missing backend relay for `task-created` chat events so live sub-agent task links can appear in chat while foreground `task` calls are still running.

## Background
The `task` tool already emits `task-created`, and the frontend store/UI already consume it. The event was being dropped in `AgentSession.attachAiListeners()` because `task-created` was never forwarded to chat subscribers.

## Implementation
- Added `forward("task-created", (payload) => this.emitChatEvent(payload))` in `src/node/services/agentSession.ts` alongside other forwarded AI/tool events.
- Added a regression test in `src/node/services/agentSession.disposeRace.test.ts` asserting:
  - `task-created` is registered,
  - non-matching workspace events are filtered,
  - matching workspace events are forwarded to `onChatEvent` subscribers.

## Validation
- `bun test src/node/services/tools/task.test.ts`
- `bun test src/node/services/agentSession.disposeRace.test.ts`

## Risks
Low risk. Change is a single event-forward passthrough plus focused regression coverage. No schema/frontend behavior changes.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$1.57`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=1.57 -->
