### PR TITLE
🤖 docs: document send-after-turn and send-after-step dispatch modes

### DIFF
--- a/docs/agents/prompting-tips.mdx
+++ b/docs/agents/prompting-tips.mdx
@@ -36,6 +36,22 @@ A simple pattern is to compact and immediately continue:
 
 Mux will run compaction and then automatically send your follow-up message.
 
+## Queue messages while the agent is working
+
+When an agent is mid-stream you can still type and send a follow-up. The message gets queued and delivered automatically — the **dispatch mode** controls _when_:
+
+| Mode                          | Shortcut     | Behavior                                                             |
+| ----------------------------- | ------------ | -------------------------------------------------------------------- |
+| **Send after step** (default) | `Enter`      | Your message is delivered as soon as the current tool call finishes. |
+| **Send after turn**           | `Ctrl+Enter` | Your message is delivered after the agent's entire turn completes.   |
+
+You can also pick the mode from the context menu on the send button.
+
+**When to use each:**
+
+- **After step** is useful when you want to course-correct early — the agent will see your message before it starts the next tool call.
+- **After turn** is useful when you want to let the agent finish its current line of thought uninterrupted, then pivot.
+
 ## Keep code clean
 
 Prompts that often lead to better long-term code:

--- a/docs/config/keybinds.mdx
+++ b/docs/config/keybinds.mdx
@@ -32,6 +32,7 @@ When documentation shows `Ctrl`, it means:
 | ---------------------- | --------------------- |
 | Focus chat input       | `a`, `i`, or `Ctrl+I` |
 | Send message           | `Enter`               |
+| Send after turn        | `Ctrl+Enter`          |
 | New line in message    | `Shift+Enter`         |
 | Cancel editing message | `Esc`                 |
 | Jump to bottom of chat | `Shift+G`             |


### PR DESCRIPTION
## Summary

Documents the "Send after step" and "Send after turn" message dispatch modes, which were previously undocumented.

## Changes

- **`docs/config/keybinds.mdx`**: Added the missing `Ctrl+Enter` → "Send after turn" shortcut to the Chat & Messages table.
- **`docs/agents/prompting-tips.mdx`**: Added a new "Queue messages while the agent is working" section explaining both dispatch modes, when each fires, how to access them, and when to use each.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$1.16`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=1.16 -->
