### PR TITLE
🤖 fix: clarify weekly bucket labels in analytics spend chart

### DIFF
--- a/src/browser/features/Analytics/AnalyticsDashboard.tsx
+++ b/src/browser/features/Analytics/AnalyticsDashboard.tsx
@@ -274,6 +274,7 @@ export function AnalyticsDashboard(props: AnalyticsDashboardProps) {
             data={spendOverTime.data}
             loading={spendOverTime.loading}
             error={spendOverTime.error}
+            granularity={dateRange.granularity}
           />
           <ModelBreakdown spendByProject={spendByProject} spendByModel={spendByModel} />
           <TokensByModelChart

--- a/src/browser/features/Analytics/SpendChart.tsx
+++ b/src/browser/features/Analytics/SpendChart.tsx
@@ -16,6 +16,7 @@ import {
   CHART_AXIS_TICK,
   CHART_TOOLTIP_CONTENT_STYLE,
   formatBucketLabel,
+  formatBucketTooltipLabel,
   formatUsd,
 } from "./analyticsUtils";
 
@@ -23,6 +24,7 @@ interface SpendChartProps {
   data: SpendOverTimeItem[] | null;
   loading: boolean;
   error: string | null;
+  granularity: "hour" | "day" | "week";
 }
 
 interface SpendChartRow {
@@ -68,7 +70,13 @@ export function SpendChart(props: SpendChartProps) {
   return (
     <div className="bg-background-secondary border-border-medium rounded-lg border p-4">
       <h2 className="text-foreground text-sm font-semibold">Spend over time</h2>
-      <p className="text-muted mt-1 text-xs">Model-attributed spend per time bucket.</p>
+      <p className="text-muted mt-1 text-xs">
+        {props.granularity === "week"
+          ? "Model-attributed weekly spend."
+          : props.granularity === "hour"
+            ? "Model-attributed hourly spend."
+            : "Model-attributed daily spend."}
+      </p>
 
       {props.loading ? (
         <div className="mt-3">
@@ -97,7 +105,9 @@ export function SpendChart(props: SpendChartProps) {
                 stroke={CHART_AXIS_STROKE}
               />
               <Tooltip
-                labelFormatter={(value) => formatBucketLabel(String(value))}
+                labelFormatter={(value) =>
+                  formatBucketTooltipLabel(String(value), props.granularity)
+                }
                 formatter={(value: number, key: string) => [formatUsd(Number(value)), key]}
                 cursor={{ fill: "var(--color-hover)" }}
                 contentStyle={CHART_TOOLTIP_CONTENT_STYLE}

--- a/src/browser/features/Analytics/analyticsUtils.test.ts
+++ b/src/browser/features/Analytics/analyticsUtils.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { formatBucketLabel, formatBucketTooltipLabel } from "./analyticsUtils";
+
+describe("formatBucketLabel", () => {
+  test("formats date-only bucket as short date", () => {
+    expect(formatBucketLabel("2026-02-23")).toBe("Feb 23");
+  });
+
+  test("formats time-containing bucket with hour", () => {
+    const result = formatBucketLabel("2026-02-23 14:00:00");
+    expect(result).toContain("Feb");
+    expect(result).toContain("23");
+  });
+
+  test("returns raw string for unparseable input", () => {
+    expect(formatBucketLabel("not-a-date")).toBe("not-a-date");
+  });
+});
+
+describe("formatBucketTooltipLabel", () => {
+  test("renders week range for weekly buckets", () => {
+    const result = formatBucketTooltipLabel("2026-02-23", "week");
+    // Start of week → end of week (Mon–Sun): Feb 23 – Mar 1
+    expect(result).toContain("Feb 23");
+    expect(result).toContain("Mar 1");
+    expect(result).toContain("–");
+  });
+
+  test("renders range spanning same month for weekly buckets", () => {
+    const result = formatBucketTooltipLabel("2026-02-02", "week");
+    expect(result).toContain("Feb 2");
+    expect(result).toContain("Feb 8");
+    expect(result).toContain("–");
+  });
+
+  test("falls back to single bucket label for daily granularity", () => {
+    expect(formatBucketTooltipLabel("2026-02-23", "day")).toBe("Feb 23");
+  });
+
+  test("falls back to single bucket label for hourly granularity", () => {
+    const result = formatBucketTooltipLabel("2026-02-23 14:00:00", "hour");
+    expect(result).toContain("Feb");
+    expect(result).toContain("23");
+  });
+
+  test("returns raw string for unparseable input in week mode", () => {
+    expect(formatBucketTooltipLabel("not-a-date", "week")).toBe("not-a-date");
+  });
+});

--- a/src/browser/features/Analytics/analyticsUtils.ts
+++ b/src/browser/features/Analytics/analyticsUtils.ts
@@ -104,3 +104,22 @@ export function formatBucketLabel(bucket: string): string {
     timeZone: "UTC",
   });
 }
+
+/** Granularity-aware label for tooltip headers.
+ *  Weekly buckets render as a date range (e.g. "Feb 23 – Mar 1");
+ *  all other granularities delegate to `formatBucketLabel`. */
+export function formatBucketTooltipLabel(
+  bucket: string,
+  granularity: "hour" | "day" | "week"
+): string {
+  if (granularity !== "week") return formatBucketLabel(bucket);
+
+  const start = new Date(bucket);
+  if (!Number.isFinite(start.getTime())) return bucket;
+
+  const end = new Date(start);
+  end.setUTCDate(end.getUTCDate() + 6);
+
+  const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric", timeZone: "UTC" };
+  return `${start.toLocaleDateString(undefined, opts)} – ${end.toLocaleDateString(undefined, opts)}`;
+}


### PR DESCRIPTION
## Summary

When viewing 90D or All time ranges, the "Spend over time" chart uses weekly buckets but labels them with just the start date (e.g. "Feb 23"), making a 7-day aggregate look like a single-day cost. This clarifies the tooltip and subtitle so users understand the bucket scope.

## Implementation

- Thread `granularity` from `AnalyticsDashboard` → `SpendChart` as a new prop.
- Add `formatBucketTooltipLabel(bucket, granularity)` in `analyticsUtils.ts` — weekly buckets render as a date range (`"Feb 23 – Mar 1"`); other granularities delegate to the existing `formatBucketLabel`.
- X-axis labels remain compact single dates to avoid crowding.
- Subtitle is now granularity-aware: "Model-attributed weekly spend." / "…daily…" / "…hourly…".

## Validation

- New `analyticsUtils.test.ts` — 8 tests covering both formatters (week range across month boundary, same-month range, day/hour fallback, invalid input).

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$1.91`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=1.91 -->
