### PR TITLE
🤖 fix: allow agent_skill_read_file to read symlinked skill directories

### DIFF
--- a/src/node/services/tools/agent_skill_read_file.test.ts
+++ b/src/node/services/tools/agent_skill_read_file.test.ts
@@ -276,7 +276,7 @@ describe("agent_skill_read_file", () => {
       }
     });
 
-    it("rejects symlinked skill directories through the runtime probe", async () => {
+    it("allows symlinked skill directories when containment still passes (runtime probe)", async () => {
       using tempDir = new TestTempDir("test-agent-skill-read-file-remote-runtime-symlinked-dir");
 
       const skillsRoot = path.join(tempDir.path, ".mux", "skills");
@@ -310,9 +310,9 @@ describe("agent_skill_read_file", () => {
       }
 
       const result = parsed.data;
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error).toMatch(/symbolic link/i);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.content).toMatch(/top secret/i);
       }
     });
 
@@ -414,7 +414,7 @@ describe("agent_skill_read_file", () => {
   });
 
   describe("symlink safety", () => {
-    it("rejects reads from a symlinked skill directory", async () => {
+    it("allows reads from a symlinked skill directory when containment still passes", async () => {
       using tempDir = new TestTempDir("test-agent-skill-read-file-symlinked-dir");
 
       const skillsRoot = path.join(tempDir.path, ".mux", "skills");
@@ -450,9 +450,9 @@ describe("agent_skill_read_file", () => {
       }
 
       const result = parsed.data;
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error).toMatch(/symbolic link/i);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.content).toMatch(/top secret/i);
       }
     });
 

--- a/src/node/services/tools/runtimeSkillPathUtils.ts
+++ b/src/node/services/tools/runtimeSkillPathUtils.ts
@@ -181,10 +181,9 @@ export async function resolveContainedSkillFilePathOnRuntime(
   const resolvedTarget = resolveSkillFilePathForRuntime(runtime, skillDir, filePath);
   const probe = await inspectContainmentOnRuntime(runtime, skillDir, resolvedTarget.resolvedPath);
 
-  if (probe.skillDirSymlink) {
-    throw new Error("Skill directory is a symbolic link and cannot be accessed.");
-  }
-
+  // Do not reject symlinked skill directories here.
+  // Skill discovery intentionally supports symlinked skill dirs; containment is enforced by
+  // comparing fully-resolved real paths to ensure the target stays inside the resolved root.
   if (!probe.withinRoot) {
     throw new Error(
       `Invalid filePath (path escapes skill directory after symlink resolution): ${filePath}`


### PR DESCRIPTION
## Summary
Allow `agent_skill_read_file` to read files from skills whose **skill directory itself** is a symlink (while preserving containment and leaf-symlink protections).

## Background
Skill discovery already supports symlinked directories (common for external skill installers and linked skill repos), but `agent_skill_read_file` still rejected them with:

- `Skill directory is a symbolic link and cannot be accessed.`

That made skill metadata readable via `agent_skill_read` but blocked referenced files via `agent_skill_read_file`.

## Implementation
- Removed the symlinked-skill-directory rejection from runtime containment resolution:
  - `src/node/services/tools/runtimeSkillPathUtils.ts`
- Kept existing security protections:
  - resolved-path containment (`withinRoot`)
  - leaf symlink rejection (`leafSymlink`)
- Updated tests to reflect intended behavior:
  - `src/node/services/tools/agent_skill_read_file.test.ts`
  - symlinked skill directories now expected to read successfully when containment passes

## Validation
- `bun test src/node/services/tools/agent_skill_read_file.test.ts`
- `make typecheck`
- `make static-check`

## Risk
Low. Change is narrowly scoped to read-file behavior for symlinked skill roots and retains existing anti-traversal/leaf-symlink protections.

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$4.33`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=4.33 -->
