### PR TITLE
🤖 fix: add X-Initiator header for Copilot premium request billing

### DIFF
--- a/src/node/services/providerModelFactory.test.ts
+++ b/src/node/services/providerModelFactory.test.ts
@@ -10,7 +10,6 @@ import {
   classifyCopilotInitiator,
   modelCostsIncluded,
   MUX_AI_PROVIDER_USER_AGENT,
-  resolveAIProviderBodySource,
   resolveAIProviderHeaderSource,
 } from "./providerModelFactory";
 import { ProviderService } from "./providerService";
@@ -241,37 +240,6 @@ describe("classifyCopilotInitiator", () => {
 
   it("returns 'user' when body has no messages field", () => {
     expect(classifyCopilotInitiator(JSON.stringify({ model: "gpt-4o" }))).toBe("user");
-  });
-});
-
-describe("resolveAIProviderBodySource", () => {
-  it("prefers init.body when provided", () => {
-    const input = new Request("https://example.com", {
-      method: "POST",
-      body: JSON.stringify({ messages: [{ role: "tool", content: "from request" }] }),
-    });
-    const initBody = JSON.stringify({ messages: [{ role: "user", content: "from init" }] });
-
-    const result = resolveAIProviderBodySource(input, { body: initBody });
-
-    expect(result).toBe(initBody);
-  });
-
-  it("uses Request.body when init.body is missing", () => {
-    const input = new Request("https://example.com", {
-      method: "POST",
-      body: JSON.stringify({ messages: [{ role: "user", content: "hello" }] }),
-    });
-
-    const result = resolveAIProviderBodySource(input, undefined);
-
-    expect(result).toBe(input.body);
-  });
-
-  it("returns undefined for non-Request inputs without init body", () => {
-    const result = resolveAIProviderBodySource("https://example.com", undefined);
-
-    expect(result).toBeUndefined();
   });
 });
 

--- a/src/node/services/providerModelFactory.ts
+++ b/src/node/services/providerModelFactory.ts
@@ -95,19 +95,6 @@ export function resolveAIProviderHeaderSource(
 }
 
 /**
- * Resolve the request body source for provider fetch calls.
- *
- * fetch(Request) stores payload on the Request object rather than init.body.
- * Prefer init.body when present, then fall back to Request.body.
- */
-export function resolveAIProviderBodySource(
-  input: RequestInfo | URL,
-  init?: RequestInit
-): BodyInit | null | undefined {
-  return init?.body ?? (input instanceof Request ? input.body : undefined);
-}
-
-/**
  * Build request headers for provider fetch calls.
  *
  * Always includes Mux attribution in User-Agent while preserving provider SDK info
@@ -443,10 +430,10 @@ export function parseModelString(modelString: string): [string, string] {
  * this is a user-initiated turn. Everything else (tool results, assistant
  * continuations) is agent-initiated.
  */
-export function classifyCopilotInitiator(body: BodyInit | null | undefined): "user" | "agent" {
+export function classifyCopilotInitiator(body: string | null | undefined): "user" | "agent" {
   try {
     if (typeof body !== "string") return "user"; // can't parse → safe default
-    const parsed = JSON.parse(body) as { messages?: unknown };
+    const parsed = JSON.parse(body) as { messages?: unknown[] };
     const messages = parsed.messages;
     if (!Array.isArray(messages) || messages.length === 0) return "user";
     const last = messages[messages.length - 1] as { role?: string } | undefined;
@@ -1384,13 +1371,28 @@ export class ProviderModelFactory {
           const headers = new Headers(init?.headers);
           headers.set("Authorization", `Bearer ${creds.apiKey ?? ""}`);
           headers.set("Openai-Intent", "conversation-edits");
+
+          // Resolve request body text for billing classification.
+          // Standard AI SDK path: init.body is a JSON string.
+          // Request object path: clone + read body text so the original stream
+          // remains intact for the real network request.
+          let bodyText: string | undefined;
+          if (typeof init?.body === "string") {
+            bodyText = init.body;
+          } else if (input instanceof Request) {
+            try {
+              bodyText = await input.clone().text();
+            } catch {
+              // Fall back to undefined so classifyCopilotInitiator defaults to "user".
+            }
+          }
+
           // GitHub Copilot uses X-Initiator to determine premium request billing.
           // "user" = consumes a premium request; "agent" = free (tool/agent work).
           // We inspect the last message role: only a genuine user message at the
           // end of the messages array indicates a user-initiated turn. Tool results
           // (role "tool") and assistant continuations are agent-initiated.
-          const body = resolveAIProviderBodySource(input, init);
-          headers.set("X-Initiator", classifyCopilotInitiator(body));
+          headers.set("X-Initiator", classifyCopilotInitiator(bodyText));
           headers.delete("x-api-key");
           return baseFetch(input, { ...init, headers });
         };


### PR DESCRIPTION
## Summary

Adds the `X-Initiator` header to GitHub Copilot API requests so that tool-call continuations are billed as free agent work instead of burning premium requests. Fixes: https://github.com/coder/mux/issues/2489

## Background

GitHub Copilot uses the `X-Initiator` header to decide billing: `user` consumes a premium request, `agent` is free. Without this header (Mux today), every API call defaults to `user` billing. In a typical agentic session, a single user prompt triggers 10–60+ API calls (tool calls, continuations), all of which were burning premium requests.

## Implementation

Added an exported `classifyCopilotInitiator(body)` helper that inspects the last message role in the request body:
- `role: "user"` → `X-Initiator: user` (genuine user turn, 1 premium request)
- `role: "tool"` / `role: "assistant"` → `X-Initiator: agent` (free)
- Parse failures / empty body → defaults to `"user"` (conservative, don't hide usage)

Wired into the existing `copilotFetchFn` in `providerModelFactory.ts`.

## Validation

- 7 unit tests covering all classification paths (user, tool, assistant, empty, null, malformed, missing messages)

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$5.71`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=5.71 -->
