### PR TITLE
🤖 ci: add gh release upload fallback for stale release reruns

### DIFF
--- a/.github/workflows/_desktop-release.yml
+++ b/.github/workflows/_desktop-release.yml
@@ -60,6 +60,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Upload macOS assets to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # electron-builder's --publish always silently skips uploads when the
+          # release was created >2 hours ago (its internal staleness check),
+          # which breaks reruns. Force-upload all macOS assets with --clobber
+          # so reruns reliably attach artifacts to the release.
+          gh release upload "$RELEASE_TAG" \
+            release/mux-*.dmg \
+            release/mux-*.dmg.blockmap \
+            release/mux-*.zip \
+            release/mux-*.zip.blockmap \
+            release/*-mac.yml \
+            --clobber
+
   build-linux:
     name: Build and Release Linux
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-16' || 'ubuntu-latest' }}
@@ -92,6 +108,16 @@ jobs:
         run: bun x electron-builder --linux --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Linux assets to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Same electron-builder 2-hour staleness workaround as macOS.
+          gh release upload "$RELEASE_TAG" \
+            release/mux-*.AppImage \
+            release/*-linux.yml \
+            --clobber
 
   build-linux-arm64:
     name: Build and Release Linux arm64
@@ -199,6 +225,18 @@ jobs:
           EV_KEY: ${{ vars.EV_KEY }}
           EV_TSA_URL: ${{ vars.EV_TSA_URL }}
           GCLOUD_ACCESS_TOKEN: ${{ steps.signing.outputs.gcloud_access_token }}
+
+      - name: Upload Windows assets to release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Same electron-builder 2-hour staleness workaround as macOS.
+          gh release upload "$RELEASE_TAG" \
+            release/mux-*.exe \
+            release/mux-*.exe.blockmap \
+            release/*.yml \
+            --clobber
 
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
## Summary

Add `gh release upload --clobber` fallback steps after each platform's electron-builder step in `_desktop-release.yml`, fixing silent asset upload failures when rerunning release jobs.

## Background

electron-builder's `--publish always` has a hardcoded 2-hour staleness check — if the GitHub release was created >2h before the upload attempt, it silently skips all uploads. This makes individual job reruns (which don't recreate the release) fail silently while reporting ✅ success.

This was observed on nightly `v0.19.1-nightly.43`: the macOS job rerun completed ~11h after release creation, electron-builder logged `skipped publishing ... reason=existing release published more than 2 hours ago`, and zero macOS assets were attached.

## Implementation

Added three `gh release upload --clobber` steps (macOS, Linux x64, Windows) that run after electron-builder. On first runs within 2h, the upload is a harmless re-upload; on reruns after 2h, it's the actual upload mechanism. The `build-linux-arm64` job already used this pattern.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$2.12`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=2.12 -->
