### PR TITLE
🤖 fix: use mktemp for PR body files to avoid race conditions

### DIFF
--- a/.mux/skills/pull-requests/SKILL.md
+++ b/.mux/skills/pull-requests/SKILL.md
@@ -119,8 +119,19 @@ PR bodies should generally follow this structure; omit sections that are N/A or 
 
 ### Edits
 
-Prefer storing the body in an out-of-tree file such as `/tmp/pr-<num>.txt`, using
-file edit tools to modify it, and then `gh pr edit [num] --body-file <file>` to update it.
+Always use `mktemp` to create a unique temp file for the PR body — never use a
+hard-coded path like `/tmp/pr-body.md` (concurrent agents will race):
+
+```bash
+PR_BODY=$(mktemp /tmp/pr-XXXXXX.md)
+```
+
+Use file edit tools to build the body in `$PR_BODY`, then:
+
+```bash
+gh pr edit <num> --body-file "$PR_BODY"
+rm -f "$PR_BODY"
+```
 
 When updating the PR body, consider condensing information that is no longer important
 into a toggle.


### PR DESCRIPTION
## Summary

Use `mktemp` instead of hard-coded paths for PR body temp files in the `pull-requests` skill, preventing race conditions when multiple agents create/edit PRs concurrently.

## Background

The skill previously guided agents to use predictable paths like `/tmp/pr-<num>.txt`. In practice, agents interpret this loosely and use singleton paths like `/tmp/pr-body.md`. When multiple agents run concurrently, they overwrite each other's files → wrong PR descriptions.

Ironically, `scripts/edit_issue_body.ts` already does this correctly with `mkdtempSync`.

## Implementation

~5 LoC doc-only change in `.mux/skills/pull-requests/SKILL.md` — replaced the "Edits" subsection guidance with `mktemp`-based examples.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$1.31`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=1.31 -->
