### PR TITLE
🤖 ci: bump actions/upload-artifact to v7.0.0 and use direct single-file uploads

### DIFF
--- a/.github/workflows/_desktop-release.yml
+++ b/.github/workflows/_desktop-release.yml
@@ -201,7 +201,7 @@ jobs:
           GCLOUD_ACCESS_TOKEN: ${{ steps.signing.outputs.gcloud_access_token }}
 
       - name: Upload Windows artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: windows-release
           path: |

--- a/.github/workflows/perf-profiles.yml
+++ b/.github/workflows/perf-profiles.yml
@@ -35,7 +35,7 @@ jobs:
           MUX_E2E_PERF_PROFILES: ${{ github.event.inputs.perf_profiles || '' }}
       - name: Upload perf artifacts
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: perf-artifacts-${{ github.run_id }}
           path: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -320,7 +320,7 @@ jobs:
           # shellcheck disable=SC2012 # ls is fine here - known filename pattern in controlled directory
           TARBALL=$(ls mux-*.tgz | head -1)
           PACKAGE_TARBALL="$TARBALL" ./scripts/smoke-test.sh
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: failure()
         with:
           name: smoke-server-logs
@@ -376,12 +376,12 @@ jobs:
       - uses: ./.github/actions/setup-mux
       - run: bun run build
       - run: make dist-linux
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: build-linux
           path: release/*.AppImage
           retention-days: 30
           if-no-files-found: error
+          archive: false
 
   build-macos:
     name: Build / macOS
@@ -405,19 +405,19 @@ jobs:
           AC_APIKEY_ISSUER_ID: ${{ secrets.AC_APIKEY_ISSUER_ID }}
       - run: make dist-mac
       - name: Upload x64 artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: build-macos-x64
           path: release/*-x64.dmg
           retention-days: 30
           if-no-files-found: error
+          archive: false
       - name: Upload arm64 artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: build-macos-arm64
           path: release/*-arm64.dmg
           retention-days: 30
           if-no-files-found: error
+          archive: false
 
   build-windows:
     name: Build / Windows
@@ -464,7 +464,7 @@ jobs:
           EV_KEY: ${{ vars.EV_KEY }}
           EV_TSA_URL: ${{ vars.EV_TSA_URL }}
           GCLOUD_ACCESS_TOKEN: ${{ steps.signing.outputs.gcloud_access_token }}
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: build-windows
           path: release/*.exe
@@ -483,12 +483,12 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-mux
       - uses: ./.github/actions/build-vscode-extension
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: build-vscode
           path: vscode/mux-*.vsix
           retention-days: 30
           if-no-files-found: error
+          archive: false
 
   codex-comments:
     name: Codex Comments

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload server logs on smoke test failure
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: smoke-test-logs
           path: |
@@ -130,7 +130,7 @@ jobs:
 
       - name: Upload server logs on no-shrinkwrap smoke test failure
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: smoke-test-no-shrinkwrap-logs
           path: |

--- a/.github/workflows/terminal-bench.yml
+++ b/.github/workflows/terminal-bench.yml
@@ -305,7 +305,7 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
-          # actions/upload-artifact@v4 requires artifact names to be unique per workflow run.
+          # actions/upload-artifact@v7 requires artifact names to be unique per workflow run.
           # Nightly workflows can run multiple jobs with the same model (e.g. Harbor smoke tests),
           # so include dataset + task selection in the artifact name.
           sanitize() { printf "%s" "$1" | tr ' :/@' '-' | tr -cd 'A-Za-z0-9._-'; }
@@ -360,7 +360,7 @@ jobs:
 
       - name: Upload benchmark results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ steps.artifact-name.outputs.name }}
           path: |


### PR DESCRIPTION
## Summary
Bump all pinned `actions/upload-artifact` references from v4.6.2 to v7.0.0, and enable direct single-file uploads for our single-file release artifacts.

## Background
`actions/upload-artifact` v7 adds support for direct (unzipped) single-file uploads via `archive: false`. We already upload several single-file artifacts (Linux AppImage, macOS DMGs, VSIX), so we can avoid wrapping those files in zip archives.

## Implementation
- Updated every `actions/upload-artifact` usage in workflows to:
  - `actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0`
- In `.github/workflows/pr.yml`, switched single-file upload steps to direct uploads by:
  - adding `archive: false`
  - removing `name` for those steps (ignored by v7 when `archive: false` is set)
- Kept multi-file/directory uploads unchanged (still using archive mode)
- Updated one stale inline comment in `terminal-bench.yml` from `@v4` to `@v7`

## Validation
- `make static-check`
- YAML parse validation for edited workflow files

## Risks
Low. Changes are limited to GitHub Actions workflow config. Multi-file uploads retain previous behavior; only known single-file uploads switched to direct mode.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$1.19`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=1.19 -->
