### PR TITLE
🤖 fix: allow editing AUTO user messages

### DIFF
--- a/src/browser/features/Messages/UserMessage.tsx
+++ b/src/browser/features/Messages/UserMessage.tsx
@@ -69,7 +69,8 @@ export const UserMessage: React.FC<UserMessageProps> = ({
   const { copied, copyToClipboard } = useCopyToClipboard(clipboardWriteText);
 
   const handleEdit = () => {
-    if (onEdit && !isLocalCommandOutput && !isSynthetic) {
+    // Allow users to take ownership of AUTO (synthetic) prompts by editing them.
+    if (onEdit && !isLocalCommandOutput) {
       onEdit(buildEditingStateFromDisplayed(message));
     }
   };
@@ -111,7 +112,7 @@ export const UserMessage: React.FC<UserMessageProps> = ({
           },
         ]
       : []),
-    ...(onEdit && !isLocalCommandOutput && !isSynthetic
+    ...(onEdit && !isLocalCommandOutput
       ? [
           {
             label: "Edit",


### PR DESCRIPTION
## Summary
Allow users to edit visible AUTO (synthetic) user messages from the message action bar.

## Background
AUTO messages are synthetic system-authored prompts, but users may want to take ownership and revise them. The UI previously hid edit affordances for synthetic messages even though backend edit/truncate flow already supports editing by history ID.

## Implementation
- Updated `UserMessage` edit gating to remove the synthetic-only restriction.
- Kept local command output messages non-editable.
- Left AUTO badge and styling unchanged; this is only an edit affordance change.

## Validation
- `make static-check`
- `make typecheck`

## Risks
Low risk and scoped to user-message action rendering. Existing local-command output guard is preserved.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$4.37`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=4.37 -->
