### PR TITLE
🤖 ci: pin git identity in auto-cleanup workflows

### DIFF
--- a/.github/workflows/auto-cleanup-fixup.yml
+++ b/.github/workflows/auto-cleanup-fixup.yml
@@ -72,6 +72,13 @@ jobs:
       - uses: oven-sh/setup-bun@b7a1c7ccf290d58743029c4f6903da283811b979 # v2.1.0
         if: ${{ steps.precheck.outputs.enabled == 'true' }}
 
+      # Pin the git identity so the AI agent doesn't invent its own.
+      - name: Configure git identity
+        if: ${{ steps.precheck.outputs.enabled == 'true' }}
+        run: |
+          git config user.name "mux-bot[bot]"
+          git config user.email "264182336+mux-bot[bot]@users.noreply.github.com"
+
       # Circuit breaker: if the last commit is already a fixup, we already
       # retried once and should stop to prevent an infinite failure loop.
       - name: Circuit breaker - skip if already retried

--- a/.github/workflows/auto-cleanup.yml
+++ b/.github/workflows/auto-cleanup.yml
@@ -52,6 +52,15 @@ jobs:
       - uses: oven-sh/setup-bun@b7a1c7ccf290d58743029c4f6903da283811b979 # v2.1.0
         if: ${{ steps.precheck.outputs.enabled == 'true' }}
 
+      # Pin the git identity so the AI agent doesn't invent its own.
+      # Without this, commits end up as "mux-auto-cleanup[bot]" while the
+      # PR itself (created via the app token) is authored by "mux-bot[bot]".
+      - name: Configure git identity
+        if: ${{ steps.precheck.outputs.enabled == 'true' }}
+        run: |
+          git config user.name "mux-bot[bot]"
+          git config user.email "264182336+mux-bot[bot]@users.noreply.github.com"
+
       - name: Cleanup with mux
         if: ${{ steps.precheck.outputs.enabled == 'true' }}
         env:

--- a/docs/guides/github-actions.mdx
+++ b/docs/guides/github-actions.mdx
@@ -95,6 +95,15 @@ jobs:
       - uses: oven-sh/setup-bun@b7a1c7ccf290d58743029c4f6903da283811b979 # v2.1.0
         if: ${{ steps.precheck.outputs.enabled == 'true' }}
 
+      # Pin the git identity so the AI agent doesn't invent its own.
+      # Without this, commits end up as "mux-auto-cleanup[bot]" while the
+      # PR itself (created via the app token) is authored by "mux-bot[bot]".
+      - name: Configure git identity
+        if: ${{ steps.precheck.outputs.enabled == 'true' }}
+        run: |
+          git config user.name "mux-bot[bot]"
+          git config user.email "264182336+mux-bot[bot]@users.noreply.github.com"
+
       - name: Cleanup with mux
         if: ${{ steps.precheck.outputs.enabled == 'true' }}
         env:


### PR DESCRIPTION
The auto-cleanup workflows let the AI agent decide its own git identity. The
agent picks `mux-auto-cleanup[bot]`, but the PR itself is opened (and
squash-merged) as `mux-bot[bot]` via the GitHub App token. This shows up as a
confusing dual-author attribution in the merge commit.

## Fix

Add an explicit `git config user.name/email` step in both
`auto-cleanup.yml` and `auto-cleanup-fixup.yml` before the `mux run`
step, pinning the identity to `mux-bot[bot]` so branch commits match
the PR author.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$1.28`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=1.28 -->
