### PR TITLE
🤖 fix: defer immersive review diff + minimap mount during file loading

### DIFF
--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -1693,7 +1693,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
           )}
         </div>
 
-        {overlayData && !isTouchExperience && (
+        {overlayData && !isTouchExperience && !isActiveFileContentLoading && (
           <ImmersiveMinimap
             content={overlayData.content}
             scrollContainerRef={scrollContainerRef}


### PR DESCRIPTION
## Summary

Defers mounting both the `SelectableDiffRenderer` and `ImmersiveMinimap` while file content is loading in immersive review, preventing visual flashes.

## Background

When switching files in immersive review, `overlayData` transitions from hunk-only content (`buildOverlayFromHunks`) to full-file content (`buildOverlayFromFileContent`). Both the diff renderer and the minimap were rendering the intermediate hunk-only state, causing a visible flash before full content arrived.

## Implementation

- Gate `SelectableDiffRenderer` behind `!isActiveFileContentLoading` so it doesn't mount until file content is settled.
- Gate `ImmersiveMinimap` behind the same `!isActiveFileContentLoading` condition so it doesn't briefly flash hunk-only content.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$4.70`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=4.70 -->
