### PR TITLE
🤖 feat: add ACP editor integrations docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -116,6 +116,7 @@
             "group": "Integrations",
             "pages": [
               "integrations/vscode-extension",
+              "integrations/acp",
               "integrations/mux-governor"
             ]
           },
@@ -177,6 +178,7 @@
     { "source": "/vim-mode", "destination": "/config/vim-mode" },
     { "source": "/guides/vim-mode", "destination": "/config/vim-mode" },
     { "source": "/vscode-extension", "destination": "/integrations/vscode-extension" },
+    { "source": "/acp", "destination": "/integrations/acp" },
     { "source": "/telemetry", "destination": "/reference/telemetry" },
     { "source": "/storybook", "destination": "/reference/storybook" },
     { "source": "/benchmarking", "destination": "/reference/benchmarking" },

--- a/docs/integrations/acp.mdx
+++ b/docs/integrations/acp.mdx
@@ -1,0 +1,175 @@
+---
+title: ACP (Editor Integrations)
+sidebarTitle: ACP (Editors)
+description: Connect Mux to Zed, Neovim, and JetBrains via the Agent Client Protocol
+---
+
+Mux implements the [Agent Client Protocol (ACP)](https://agentclientprotocol.org/) to integrate
+with editors that support it. The `mux acp` command starts a stdio bridge that any
+ACP-compatible editor can spawn as a subprocess.
+
+<Info>
+  ACP is the "LSP for agents" and provides session management, tool delegation, and streaming. Mux
+  uses ACP (not MCP) for its editor bridge.
+</Info>
+
+## Zed
+
+Zed has native ACP support and does not require a plugin.
+
+Open **Settings** (`Cmd+,`) and add:
+
+```json
+{
+  "agent_servers": {
+    "Mux": {
+      "type": "custom",
+      "command": "mux",
+      "args": ["acp"]
+    }
+  }
+}
+```
+
+<Accordion title="Using npx (no global install)">
+
+```json
+{
+  "agent_servers": {
+    "Mux": {
+      "type": "custom",
+      "command": "npx",
+      "args": ["-y", "mux", "acp"]
+    }
+  }
+}
+```
+
+</Accordion>
+
+### Connect to a remote server
+
+Pass `--server-url` and `--auth-token` in `args`:
+
+```json
+{
+  "agent_servers": {
+    "Mux": {
+      "type": "custom",
+      "command": "mux",
+      "args": ["acp", "--server-url", "https://mux.example.com", "--auth-token", "<token>"]
+    }
+  }
+}
+```
+
+Or set environment variables for any `mux acp` process:
+
+```bash
+MUX_SERVER_URL=https://mux.example.com \
+MUX_SERVER_AUTH_TOKEN=<token> \
+mux acp
+```
+
+## Neovim
+
+Two plugins currently support ACP in Neovim.
+
+### codecompanion.nvim (recommended)
+
+[codecompanion.nvim](https://github.com/olimorris/codecompanion.nvim) added ACP support in
+v17.18. Add the adapter in your `lazy.nvim` config:
+
+```lua
+require("codecompanion").setup({
+  adapters = {
+    mux = function()
+      return require("codecompanion.adapters").extend("acp", {
+        name = "mux",
+        schema = {
+          model = { default = "mux" },
+        },
+        args = { "mux", "acp" },
+      })
+    end,
+  },
+  strategies = {
+    chat = { adapter = "mux" },
+    inline = { adapter = "mux" },
+  },
+})
+```
+
+See the
+[codecompanion ACP adapter docs](https://codecompanion.olimorris.dev/configuration/adapters-acp)
+for full options.
+
+### agentic.nvim
+
+[agentic.nvim](https://github.com/carlos-algms/agentic.nvim) is a dedicated ACP client.
+Requires Neovim 0.11 or newer. Add via `lazy.nvim`:
+
+```lua
+{
+  "carlos-algms/agentic.nvim",
+  opts = {
+    agents = {
+      mux = {
+        cmd = "mux",
+        args = { "acp" },
+      },
+    },
+  },
+}
+```
+
+## JetBrains
+
+JetBrains ACP support requires the **AI Assistant** plugin (2025.3 or newer).
+
+1. Open the **AI Chat** tool window
+2. Click **More** (`...`) then **Add Custom Agent**
+3. Add the Mux entry to the `acp.json` that opens:
+
+```json
+{
+  "agent_servers": {
+    "Mux": {
+      "command": "mux",
+      "args": ["acp"]
+    }
+  }
+}
+```
+
+<Note>ACP is not supported in WSL-backed JetBrains projects.</Note>
+
+See the [JetBrains ACP docs](https://www.jetbrains.com/help/ai-assistant/acp.html) for more
+information.
+
+## Flags and environment variables
+
+| Flag                   | Environment variable    | Description                                                                |
+| ---------------------- | ----------------------- | -------------------------------------------------------------------------- |
+| `--server-url <url>`   | `MUX_SERVER_URL`        | URL of a running Mux server                                                |
+| `--auth-token <token>` | `MUX_SERVER_AUTH_TOKEN` | Bearer token for authenticated connections                                 |
+| `--log-file <path>`    | —                       | Write ACP logs to a file (useful when your editor hides subprocess stderr) |
+
+<Warning>`MUX_AUTH_TOKEN` is not read by `mux acp`. Use `MUX_SERVER_AUTH_TOKEN`.</Warning>
+
+If no `--server-url` is provided, `mux acp` first attempts to discover a running server via the
+lockfile in `~/.mux/`, then starts an in-process server automatically when needed.
+
+## Troubleshooting
+
+- **Logs hidden by your editor:** use `--log-file /tmp/mux-acp.log` to capture ACP stderr output.
+- **Connection refused:** ensure Mux is running (`mux server` or the desktop app), or omit
+  `--server-url` to let ACP auto-start in-process.
+- **Tool calls are not delegated:** the editor must advertise filesystem or terminal capabilities,
+  and the workspace must use `local` runtime mode.
+
+## Related
+
+- [CLI Reference — `mux acp`](/reference/cli#mux-acp)
+- [VS Code Extension](/integrations/vscode-extension)
+- [Workspaces](/workspaces)

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -136,76 +136,14 @@ Start the ACP (Agent-Client Protocol) stdio bridge used by editor integrations:
 mux acp
 ```
 
-Options:
+| Option                 | Description                                       |
+| ---------------------- | ------------------------------------------------- |
+| `--server-url <url>`   | URL of a running mux server                       |
+| `--auth-token <token>` | Bearer token for authenticated server connections |
+| `--log-file <path>`    | Write ACP logs to a file instead of stderr        |
 
-- `--server-url <url>` - URL of a running mux server
-- `--auth-token <token>` - Optional bearer token for authenticated server connections
-- `--log-file <path>` - Write ACP logs to a file instead of console stderr (helpful when your editor hides subprocess logs)
-
-Environment variable equivalents:
-
-- `MUX_SERVER_URL` - Same as `--server-url`
-- `MUX_SERVER_AUTH_TOKEN` - Same as `--auth-token`
-
-Use `MUX_SERVER_AUTH_TOKEN` for ACP auth; `MUX_AUTH_TOKEN` is not read by `mux acp`.
-
-### Set up Zed
-
-Add a custom agent server in Zed that runs the ACP subcommand.
-
-If `mux` is installed globally:
-
-```json
-{
-  "agent_servers": {
-    "Mux": {
-      "type": "custom",
-      "command": "mux",
-      "args": ["acp"]
-    }
-  }
-}
-```
-
-If you prefer an ephemeral install:
-
-```json
-{
-  "agent_servers": {
-    "Mux": {
-      "type": "custom",
-      "command": "npx",
-      "args": ["-y", "mux", "acp"]
-    }
-  }
-}
-```
-
-### Connect Zed to a remote mux server
-
-You can point ACP at a remote mux server either with flags or environment variables.
-
-Using flags:
-
-```json
-{
-  "agent_servers": {
-    "Mux": {
-      "type": "custom",
-      "command": "mux",
-      "args": ["acp", "--server-url", "https://mux.example.com", "--auth-token", "<token>"]
-    }
-  }
-}
-```
-
-Using environment variables (for any `mux acp` process):
-
-```bash
-MUX_SERVER_URL=https://mux.example.com \
-MUX_SERVER_AUTH_TOKEN=<token> \
-mux acp
-```
+For editor-specific setup (Zed, Neovim, JetBrains), see the
+[ACP Editor Integrations](/integrations/acp) guide.
 
 ## `mux desktop`
 

--- a/src/node/builtinSkills/mux-docs.md
+++ b/src/node/builtinSkills/mux-docs.md
@@ -98,6 +98,7 @@ Use this index to find a page's:
     - Prompting Tips (`/agents/prompting-tips`) → `references/docs/agents/prompting-tips.mdx` — Tips and tricks for getting the most out of your AI agents
   - **Integrations**
     - VS Code Extension (`/integrations/vscode-extension`) → `references/docs/integrations/vscode-extension.mdx` — Pair Mux workspaces with VS Code and Cursor editors
+    - ACP (Editor Integrations) (`/integrations/acp`) → `references/docs/integrations/acp.mdx` — Connect Mux to Zed, Neovim, and JetBrains via the Agent Client Protocol
     - Mux Governor (`/integrations/mux-governor`) → `references/docs/integrations/mux-governor.mdx` — Our upcoming enterprise platform for Mux.
   - **Reference**
     - Debugging (`/reference/debugging`) → `references/docs/reference/debugging.mdx` — View live backend logs and diagnose issues


### PR DESCRIPTION
## Summary
Add a dedicated ACP editor integrations page and move editor-specific setup details out of the CLI reference.

## Background
ACP setup guidance for Zed was embedded in `docs/reference/cli.mdx`, and Neovim/JetBrains ACP setup was undocumented. This made editor onboarding harder to find in the docs hierarchy.

## Implementation
- Added `docs/integrations/acp.mdx` covering:
  - Zed (global + npx setup)
  - Neovim (`codecompanion.nvim` and `agentic.nvim`)
  - JetBrains ACP setup
  - Flags/env vars and troubleshooting
- Trimmed `docs/reference/cli.mdx` `mux acp` section to command + flags + link to integrations guide.
- Updated `docs/docs.json`:
  - Added `integrations/acp` to navigation
  - Added `/acp` redirect to `/integrations/acp`
- Regenerated synced docs index output in `src/node/builtinSkills/mux-docs.md`.

## Validation
- `run_and_report static-check make static-check`
- `make check-docs-links`
- `make fmt-check`

## Risks
Low risk. Changes are docs/navigation-only plus generated docs index sync output.

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: ACP Editor Integrations Documentation Page

## Context & Why

ACP (Agent Client Protocol) setup for Zed is currently buried in the CLI reference (`docs/reference/cli.mdx`), and Neovim/JetBrains support isn't documented at all. Users looking for "how to use Mux in my editor" won't find it in CLI docs. A dedicated page under **Integrations** (where the VS Code Extension already lives) is the natural home.

**Goal:** Create `docs/integrations/acp.mdx` covering Zed, Neovim, and JetBrains setup. Trim the CLI reference to just command synopsis + flags with a cross-link.

## Evidence

| Source | What it tells us |
|---|---|
| `docs/docs.json` (lines 116-121) | Integrations group has `vscode-extension` and `mux-governor` — new page slots in here |
| `docs/reference/cli.mdx` (lines 131-208) | Current `mux acp` section with Zed configs to migrate |
| `docs/STYLE.md` | Assume technical competence, document gotchas/mechanics, state things once |
| `docs/integrations/vscode-extension.mdx` | Pattern: frontmatter → intro → per-section setup → Related links |
| `src/node/acp/adapter.ts` | Stdout isolation (logs → stderr), stdio bridge, server discovery |
| `src/node/acp/capabilities.ts` | fs + terminal capability delegation |
| Conversation research | Neovim: `codecompanion.nvim` (v17.18+) and `agentic.nvim`; JetBrains: AI Assistant plugin + `acp.json` |

## Changes (3 files, ~170 LoC net)

### 1. Create `docs/integrations/acp.mdx` (~150 lines)

New page with this structure:

```mdx
---
title: ACP (Editor Integrations)
sidebarTitle: ACP (Editors)
description: Connect Mux to Zed, Neovim, and JetBrains via the Agent Client Protocol
---

Mux implements the [Agent Client Protocol (ACP)](https://agentclientprotocol.org/)
to integrate with editors that support it. The `mux acp` command starts a stdio
bridge that any ACP-compatible editor can spawn as a subprocess.

<Info>
  ACP is the "LSP for agents" — it provides session management, tool delegation,
  and streaming. Mux uses ACP (not MCP) for its editor bridge.
</Info>

## Zed

Zed has native ACP support — no plugin required.

Open **Settings** (`Cmd+,`) and add:

{/* global install */}
```json
{
  "agent_servers": {
    "Mux": {
      "type": "custom",
      "command": "mux",
      "args": ["acp"]
    }
  }
}
```

{/* ephemeral variant callout */}
<Accordion title="Using npx (no global install)">
```json
{
  "agent_servers": {
    "Mux": {
      "type": "custom",
      "command": "npx",
      "args": ["-y", "mux", "acp"]
    }
  }
}
```
</Accordion>

### Connect to a remote server

Pass `--server-url` and `--auth-token` in `args`:

```json
{
  "agent_servers": {
    "Mux": {
      "type": "custom",
      "command": "mux",
      "args": ["acp", "--server-url", "https://mux.example.com", "--auth-token", "<token>"]
    }
  }
}
```

Or set environment variables for any `mux acp` process:

```bash
MUX_SERVER_URL=https://mux.example.com \
MUX_SERVER_AUTH_TOKEN=<token> \
mux acp
```

## Neovim

Two plugins support ACP in Neovim:

### codecompanion.nvim (recommended)

[codecompanion.nvim](https://github.com/olimorris/codecompanion.nvim) added ACP
support in v17.18. Add the adapter in your lazy.nvim config:

```lua
require("codecompanion").setup({
  adapters = {
    mux = function()
      return require("codecompanion.adapters").extend("acp", {
        name = "mux",
        schema = {
          model = { default = "mux" },
        },
        args = { "mux", "acp" },
      })
    end,
  },
  strategies = {
    chat = { adapter = "mux" },
    inline = { adapter = "mux" },
  },
})
```

See the [codecompanion ACP adapter docs](https://codecompanion.olimorris.dev/configuration/adapters-acp)
for full options.

### agentic.nvim

[agentic.nvim](https://github.com/carlos-algms/agentic.nvim) is a dedicated ACP
client. Requires Neovim ≥ 0.11. Add via lazy.nvim:

```lua
{
  "carlos-algms/agentic.nvim",
  opts = {
    agents = {
      mux = {
        cmd = "mux",
        args = { "acp" },
      },
    },
  },
}
```

## JetBrains

Requires the **AI Assistant** plugin (2025.3+).

1. Open the **AI Chat** tool window
2. Click **More** (⋯) → **Add Custom Agent**
3. Add the Mux entry to the `acp.json` that opens:

```json
{
  "agent_servers": {
    "Mux": {
      "command": "mux",
      "args": ["acp"]
    }
  }
}
```

<Note>
  ACP is not supported in WSL-backed JetBrains projects.
</Note>

See the [JetBrains ACP docs](https://www.jetbrains.com/help/ai-assistant/acp.html)
for more details.

## Flags & environment variables

| Flag | Env var | Description |
|---|---|---|
| `--server-url <url>` | `MUX_SERVER_URL` | URL of a running Mux server |
| `--auth-token <token>` | `MUX_SERVER_AUTH_TOKEN` | Bearer token for authenticated connections |
| `--log-file <path>` | — | Write ACP logs to a file (useful when your editor hides subprocess stderr) |

<Warning>
  `MUX_AUTH_TOKEN` is **not** read by `mux acp`. Use `MUX_SERVER_AUTH_TOKEN`.
</Warning>

If no `--server-url` is provided, `mux acp` discovers a running Mux server via
the lockfile in `~/.mux/`, or starts a headless server in-process automatically.

## Troubleshooting

- **Logs hidden by editor?** Use `--log-file /tmp/mux-acp.log` to capture ACP
  stderr output.
- **Connection refused?** Ensure Mux is running (`mux server` or the desktop app)
  or let ACP auto-start by omitting `--server-url`.
- **Tool calls not delegated?** The editor must advertise filesystem/terminal
  capabilities, and the workspace must use `local` runtime mode.

## Related

- [CLI Reference — `mux acp`](/reference/cli#mux-acp)
- [VS Code Extension](/integrations/vscode-extension)
- [Workspaces](/workspaces)
```

### 2. Update `docs/reference/cli.mdx` (~-50 lines)

Replace the `## mux acp` section (lines 131-208) with a trimmed synopsis + cross-link:

```mdx
## `mux acp`

Start the ACP (Agent-Client Protocol) stdio bridge used by editor integrations:

```bash
mux acp
```

| Option | Description |
|---|---|
| `--server-url <url>` | URL of a running mux server |
| `--auth-token <token>` | Bearer token for authenticated server connections |
| `--log-file <path>` | Write ACP logs to a file instead of stderr |

For editor-specific setup (Zed, Neovim, JetBrains), see the
[ACP Editor Integrations](/integrations/acp) guide.
```

This removes the Zed setup subsections that are now on the dedicated page, keeping only the command reference.

### 3. Update `docs/docs.json` (~3 lines)

**Navigation** — add the page to the Integrations group:

```jsonc
// In navigation.tabs[0].groups → Integrations → pages
"pages": [
  "integrations/vscode-extension",
  "integrations/acp",          // ← new
  "integrations/mux-governor"
]
```

**Redirects** — add a short-path redirect:

```jsonc
{ "source": "/acp", "destination": "/integrations/acp" }
```

## Design Decisions

<details>
<summary>Why one page instead of a sub-group per editor?</summary>

Each editor section is 15-30 lines. A sub-group with 3+ pages would fragment small content, add nav clicks, and force boilerplate frontmatter. One page with anchor-linked sections is scannable and easy to maintain. If any section grows past ~80 lines, it can be extracted later.
</details>

<details>
<summary>Why recommend codecompanion.nvim over agentic.nvim?</summary>

codecompanion.nvim is more widely adopted in the Neovim ecosystem and has dedicated ACP adapter documentation. agentic.nvim is ACP-native but newer. We document both with codecompanion as the recommended option; users can choose based on their setup.
</details>

<details>
<summary>Why include the npx ephemeral variant?</summary>

It mirrors what's already in the CLI docs and is the recommended approach for CI/quick-start. Placed in an accordion to avoid cluttering the primary flow.
</details>

<details>
<summary>Why keep a slim `mux acp` in cli.mdx?</summary>

The CLI page is a reference for all subcommands. Removing `mux acp` entirely would break the pattern. Keeping the synopsis + flags table (without editor setup) maintains completeness while the integration page owns the "how to configure" content.
</details>

## Validation

- `make lint` — confirm no Mintlify frontmatter/link issues
- `mintlify broken-links` (part of `make static-check`) — verify cross-links between cli.mdx ↔ acp.mdx resolve
- Manual review: confirm `docs.json` navigation renders correctly

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$2.61`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=2.61 -->
