### PR TITLE
🤖 fix: add gap between code execution and pinned todos

### DIFF
--- a/src/browser/components/PinnedTodoList/PinnedTodoList.tsx
+++ b/src/browser/components/PinnedTodoList/PinnedTodoList.tsx
@@ -34,7 +34,7 @@ export const PinnedTodoList: React.FC<PinnedTodoListProps> = ({ workspaceId }) =
   }
 
   return (
-    <div className="bg-panel-background m-0 max-h-[300px] overflow-y-auto border-t border-dashed border-[hsl(0deg_0%_28.64%)]">
+    <div className="bg-panel-background mt-2 max-h-[300px] overflow-y-auto border-t border-dashed border-[hsl(0deg_0%_28.64%)]">
       <div
         className="text-secondary flex cursor-pointer items-center gap-1 px-2 pt-1 pb-0.5 font-mono text-[10px] font-semibold tracking-wider select-none hover:opacity-80"
         onClick={() => setExpanded(!expanded)}

--- a/src/browser/stories/App.codeExecution.stories.tsx
+++ b/src/browser/stories/App.codeExecution.stories.tsx
@@ -14,6 +14,8 @@ import type {
   CodeExecutionResult,
   NestedToolCall,
 } from "@/browser/features/Tools/Shared/codeExecutionTypes";
+import { TodoList } from "@/browser/components/TodoList/TodoList";
+import type { TodoItem } from "@/common/types/tools";
 import { lightweightMeta } from "./meta.js";
 
 const meta = {
@@ -76,6 +78,33 @@ function renderCodeExecutionCard(props: ComponentProps<typeof CodeExecutionToolC
       <div className="bg-background flex min-h-screen items-start p-6">
         <div className="w-full max-w-3xl">
           <CodeExecutionToolCallCard {...props} />
+        </div>
+      </div>
+    </BackgroundBashProvider>
+  );
+}
+
+const executingTodos: TodoItem[] = [
+  { content: "Updated config defaults", status: "completed" },
+  { content: "Running integration tests", status: "in_progress" },
+  { content: "Update documentation", status: "pending" },
+];
+
+function renderCodeExecutionCardWithTodos(
+  props: ComponentProps<typeof CodeExecutionToolCallCard>,
+  todos: TodoItem[]
+) {
+  return (
+    <BackgroundBashProvider workspaceId={STORYBOOK_WORKSPACE_ID}>
+      <div className="bg-background flex min-h-screen items-start p-6">
+        <div className="w-full max-w-3xl">
+          <CodeExecutionToolCallCard {...props} />
+          <div className="bg-panel-background mt-2 max-h-[300px] overflow-y-auto border-t border-dashed border-[hsl(0deg_0%_28.64%)]">
+            <div className="text-secondary flex items-center gap-1 px-2 pt-1 pb-0.5 font-mono text-[10px] font-semibold tracking-wider select-none">
+              TODO:
+            </div>
+            <TodoList todos={todos} />
+          </div>
         </div>
       </div>
     </BackgroundBashProvider>
@@ -219,37 +248,40 @@ export const Completed: Story = {
   },
 };
 
-/** Code execution in progress with some completed nested tools */
+/** Code execution in progress with completed/pending nested tools and TODOs below */
 export const Executing: Story = {
   render: () =>
-    renderCodeExecutionCard({
-      args: { code: SAMPLE_CODE },
-      status: "executing",
-      nestedCalls: [
-        {
-          toolCallId: "nested-1",
-          toolName: "file_read",
-          input: { path: "src/config.ts" },
-          output: {
-            success: true,
-            file_size: 1024,
-            lines_read: 42,
-            content: "export const config = {...};",
+    renderCodeExecutionCardWithTodos(
+      {
+        args: { code: SAMPLE_CODE },
+        status: "executing",
+        nestedCalls: [
+          {
+            toolCallId: "nested-1",
+            toolName: "file_read",
+            input: { path: "src/config.ts" },
+            output: {
+              success: true,
+              file_size: 1024,
+              lines_read: 42,
+              content: "export const config = {...};",
+            },
+            state: "output-available",
           },
-          state: "output-available",
-        },
-        {
-          toolCallId: "nested-2",
-          toolName: "file_edit_replace_string",
-          input: {
-            path: "src/config.ts",
-            old_string: "debug: false",
-            new_string: "debug: true",
+          {
+            toolCallId: "nested-2",
+            toolName: "file_edit_replace_string",
+            input: {
+              path: "src/config.ts",
+              old_string: "debug: false",
+              new_string: "debug: true",
+            },
+            state: "input-available",
           },
-          state: "input-available",
-        },
-      ],
-    }),
+        ],
+      },
+      executingTodos
+    ),
 };
 
 /** Code execution with no nested tools yet (just started) */


### PR DESCRIPTION
## Summary
Add vertical separation between the streaming code execution block and the pinned TODO section, and update the Code Execution `Executing` story to render TODOs directly below the executing tool state.

## Background
The chat stream had no visual gap between code execution output and pinned TODOs, while other stream-adjacent elements already had spacing. The storybook `Executing` state also needed to represent this layout so the spacing can be reviewed in isolation.

## Implementation
- Updated `PinnedTodoList` root spacing from `m-0` to `mt-2` to create an explicit top gap before the pinned TODO panel.
- Extended `App.codeExecution.stories.tsx`:
  - Added an `executingTodos` fixture.
  - Added `renderCodeExecutionCardWithTodos(...)` to compose the executing code-execution card with a TODO section below it (matching pinned TODO styling).
  - Switched the `Executing` story to use this composed renderer while preserving nested tool progression (`nested-1` complete, `nested-2` executing).

## Validation
- `make typecheck`
- `make static-check`

## Risks
Low risk. Changes are scoped to presentation/storybook wiring and a single spacing class update. No runtime data flow or backend logic changes.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$4.62`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=4.62 -->
