### PR TITLE
🤖 fix: extract shared branch-sync guard for PR wait scripts

### DIFF
--- a/scripts/lib/branch_sync_guard.sh
+++ b/scripts/lib/branch_sync_guard.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Shared branch-sync guard for wait_pr_*.sh scripts.
+# Resolves the correct remote comparison target, fetches it,
+# and optionally bootstraps a first push when no upstream exists.
+#
+# Usage: source this file, then call assert_branch_synced.
+# Returns 0 if local HEAD matches remote; non-zero otherwise.
+# Callers set CURRENT_BRANCH and REMOTE_BRANCH before proceeding.
+
+set -euo pipefail
+
+# Resolve which remote ref to compare HEAD against.
+# Sets two variables in the caller's scope:
+#   CURRENT_BRANCH  — local branch name
+#   REMOTE_BRANCH   — remote tracking ref to compare against (e.g. origin/feature)
+#
+# Policy:
+#   1. If @{u} exists and points to a non-default branch, honor it.
+#      (Supports intentional cross-name tracking like local A -> origin/B.)
+#   2. If @{u} points to origin/<default> but we're on a non-default branch
+#      AND origin/<current_branch> exists on remote, use origin/<current_branch>.
+#      (Worktree protection: branches created from origin/main inherit origin/main
+#      as upstream, but the agent has already pushed origin/<feature>.)
+#   3. If no upstream is configured, use origin/<current_branch>.
+resolve_branch_sync_target() {
+  local upstream_branch
+  local default_branch
+
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+  upstream_branch=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo "")
+  default_branch=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || echo "")
+  default_branch=${default_branch#origin/}
+
+  # Default: compare against same-named remote branch.
+  REMOTE_BRANCH="origin/$CURRENT_BRANCH"
+  _BRANCH_SYNC_HAS_UPSTREAM=0
+
+  if [[ -n "$upstream_branch" ]]; then
+    _BRANCH_SYNC_HAS_UPSTREAM=1
+    REMOTE_BRANCH="$upstream_branch"
+
+    # Worktree protection: if upstream is origin/<default> but we're on a
+    # non-default branch and origin/<current_branch> exists, prefer that.
+    if [[ -n "$default_branch" ]] \
+      && [[ "$upstream_branch" == "origin/$default_branch" ]] \
+      && [[ "$CURRENT_BRANCH" != "$default_branch" ]] \
+      && git ls-remote --exit-code --heads origin "$CURRENT_BRANCH" >/dev/null 2>&1; then
+      REMOTE_BRANCH="origin/$CURRENT_BRANCH"
+    fi
+  fi
+}
+
+# Fetch the resolved remote ref. If the branch doesn't exist on the remote
+# AND no upstream is configured, bootstrap with git push -u.
+# If an upstream IS configured and fetch fails, error out (never auto-push
+# over an intentionally configured upstream).
+fetch_or_bootstrap() {
+  local remote_name
+  local remote_ref
+
+  remote_name="${REMOTE_BRANCH%%/*}"
+  remote_ref="${REMOTE_BRANCH#*/}"
+
+  if git fetch "$remote_name" "$remote_ref" --quiet 2>/dev/null; then
+    return 0
+  fi
+
+  # Upstream exists but fetch failed — do not auto-push; the user configured
+  # this tracking relationship intentionally.
+  if [[ "$_BRANCH_SYNC_HAS_UPSTREAM" == "1" ]]; then
+    echo "❌ Error: Failed to fetch upstream '$REMOTE_BRANCH'." >&2
+    echo "This branch has a configured upstream; refusing to auto-push." >&2
+    echo "You may need to push manually: git push -u origin $CURRENT_BRANCH" >&2
+    return 1
+  fi
+
+  # No upstream — bootstrap first push.
+  echo "⚠️  Branch '$CURRENT_BRANCH' has no upstream and does not exist on remote." >&2
+  echo "Pushing to origin/$CURRENT_BRANCH..." >&2
+
+  if git push -u origin "$CURRENT_BRANCH" 2>&1; then
+    echo "✅ Pushed and upstream set successfully!" >&2
+    REMOTE_BRANCH="origin/$CURRENT_BRANCH"
+  else
+    echo "❌ Error: Failed to push branch." >&2
+    echo "You may need to push manually: git push -u origin $CURRENT_BRANCH" >&2
+    return 1
+  fi
+}
+
+# Full sync assertion: resolve target, fetch, compare hashes.
+# Returns 0 if in sync, 1 otherwise (with diagnostic messages).
+assert_branch_synced() {
+  local local_hash
+  local remote_hash
+
+  resolve_branch_sync_target
+  fetch_or_bootstrap || return 1
+
+  local_hash=$(git rev-parse HEAD)
+  remote_hash=$(git rev-parse "$REMOTE_BRANCH")
+
+  if [[ "$local_hash" != "$remote_hash" ]]; then
+    echo "❌ Error: Local branch is not in sync with remote." >&2
+    echo "" >&2
+    echo "Local:  $local_hash" >&2
+    echo "Remote: $remote_hash" >&2
+    echo "" >&2
+
+    if git merge-base --is-ancestor "$remote_hash" HEAD 2>/dev/null; then
+      local ahead
+      ahead=$(git rev-list --count "$REMOTE_BRANCH"..HEAD)
+      echo "Your branch is $ahead commit(s) ahead of '$REMOTE_BRANCH'." >&2
+      echo "Push your changes with: git push" >&2
+    elif git merge-base --is-ancestor HEAD "$remote_hash" 2>/dev/null; then
+      local behind
+      behind=$(git rev-list --count HEAD.."$REMOTE_BRANCH")
+      echo "Your branch is $behind commit(s) behind '$REMOTE_BRANCH'." >&2
+      echo "Pull the latest changes with: git pull" >&2
+    else
+      echo "Your branch has diverged from '$REMOTE_BRANCH'." >&2
+      echo "You may need to rebase or merge." >&2
+    fi
+
+    return 1
+  fi
+}

--- a/scripts/wait_pr_checks.sh
+++ b/scripts/wait_pr_checks.sh
@@ -33,6 +33,9 @@ POLL_INTERVAL_SECS=30
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 CHECK_REVIEWS_SCRIPT="$SCRIPT_DIR/check_pr_reviews.sh"
 SKIP_FETCH_SYNC="${MUX_SKIP_FETCH_SYNC:-0}"
+# shellcheck source=./lib/branch_sync_guard.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/branch_sync_guard.sh"
 
 if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
   echo "❌ PR number must be numeric. Got: '$PR_NUMBER'" >&2
@@ -60,55 +63,7 @@ if [ "$SKIP_FETCH_SYNC" = "0" ]; then
     exit 1
   fi
 
-  # Get current branch name
-  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-
-  # Always compare against origin/<current-branch>, not @{u}.
-  # Worktrees created from origin/main inherit origin/main as their upstream,
-  # which causes false "not in sync" errors on feature branches.
-  REMOTE_BRANCH="origin/$CURRENT_BRANCH"
-
-  # Fetch latest remote state before comparing
-  if ! git fetch origin "$CURRENT_BRANCH" --quiet 2>/dev/null; then
-    echo "⚠️  Branch '$CURRENT_BRANCH' does not exist on remote." >&2
-    echo "Pushing to origin/$CURRENT_BRANCH..." >&2
-
-    if git push -u origin "$CURRENT_BRANCH" 2>&1; then
-      echo "✅ Pushed and upstream set successfully!" >&2
-    else
-      echo "❌ Error: Failed to push branch." >&2
-      echo "You may need to push manually: git push -u origin $CURRENT_BRANCH" >&2
-      exit 1
-    fi
-  fi
-
-  # Check if local and remote are in sync
-  LOCAL_HASH=$(git rev-parse HEAD)
-  REMOTE_HASH=$(git rev-parse "$REMOTE_BRANCH")
-
-  if [[ "$LOCAL_HASH" != "$REMOTE_HASH" ]]; then
-    echo "❌ Error: Local branch is not in sync with remote." >&2
-    echo "" >&2
-    echo "Local:  $LOCAL_HASH" >&2
-    echo "Remote: $REMOTE_HASH" >&2
-    echo "" >&2
-
-    # Check if we're ahead, behind, or diverged
-    if git merge-base --is-ancestor "$REMOTE_HASH" HEAD 2>/dev/null; then
-      AHEAD=$(git rev-list --count "$REMOTE_BRANCH"..HEAD)
-      echo "Your branch is $AHEAD commit(s) ahead of '$REMOTE_BRANCH'." >&2
-      echo "Push your changes with: git push" >&2
-    elif git merge-base --is-ancestor HEAD "$REMOTE_HASH" 2>/dev/null; then
-      BEHIND=$(git rev-list --count HEAD.."$REMOTE_BRANCH")
-      echo "Your branch is $BEHIND commit(s) behind '$REMOTE_BRANCH'." >&2
-      echo "Pull the latest changes with: git pull" >&2
-    else
-      echo "Your branch has diverged from '$REMOTE_BRANCH'." >&2
-      echo "You may need to rebase or merge." >&2
-    fi
-
-    exit 1
-  fi
+  assert_branch_synced || exit 1
 fi
 
 LAST_MERGE_STATE="UNKNOWN"

--- a/scripts/wait_pr_codex.sh
+++ b/scripts/wait_pr_codex.sh
@@ -35,6 +35,9 @@ BOT_LOGIN_GRAPHQL="chatgpt-codex-connector"
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 CHECK_CODEX_COMMENTS_SCRIPT="$SCRIPT_DIR/check_codex_comments.sh"
 SKIP_FETCH_SYNC="${MUX_SKIP_FETCH_SYNC:-0}"
+# shellcheck source=./lib/branch_sync_guard.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/branch_sync_guard.sh"
 PR_DATA_FILE="${MUX_PR_DATA_FILE:-}"
 REACTIONS_SCAN_CACHE_FILE="${MUX_REACTIONS_SCAN_CACHE_FILE:-}"
 if [[ -z "$REACTIONS_SCAN_CACHE_FILE" && -n "$PR_DATA_FILE" ]]; then
@@ -95,55 +98,7 @@ if [ "$SKIP_FETCH_SYNC" = "0" ]; then
     exit 1
   fi
 
-  # Get current branch name
-  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-
-  # Always compare against origin/<current-branch>, not @{u}.
-  # Worktrees created from origin/main inherit origin/main as their upstream,
-  # which causes false "not in sync" errors on feature branches.
-  REMOTE_BRANCH="origin/$CURRENT_BRANCH"
-
-  # Fetch latest remote state before comparing
-  if ! git fetch origin "$CURRENT_BRANCH" --quiet 2>/dev/null; then
-    echo "⚠️  Branch '$CURRENT_BRANCH' does not exist on remote." >&2
-    echo "Pushing to origin/$CURRENT_BRANCH..." >&2
-
-    if git push -u origin "$CURRENT_BRANCH" 2>&1; then
-      echo "✅ Pushed and upstream set successfully!" >&2
-    else
-      echo "❌ Error: Failed to push branch." >&2
-      echo "You may need to push manually: git push -u origin $CURRENT_BRANCH" >&2
-      exit 1
-    fi
-  fi
-
-  # Check if local and remote are in sync
-  LOCAL_HASH=$(git rev-parse HEAD)
-  REMOTE_HASH=$(git rev-parse "$REMOTE_BRANCH")
-
-  if [[ "$LOCAL_HASH" != "$REMOTE_HASH" ]]; then
-    echo "❌ Error: Local branch is not in sync with remote." >&2
-    echo "" >&2
-    echo "Local:  $LOCAL_HASH" >&2
-    echo "Remote: $REMOTE_HASH" >&2
-    echo "" >&2
-
-    # Check if we're ahead, behind, or diverged
-    if git merge-base --is-ancestor "$REMOTE_HASH" HEAD 2>/dev/null; then
-      AHEAD=$(git rev-list --count "$REMOTE_BRANCH"..HEAD)
-      echo "Your branch is $AHEAD commit(s) ahead of '$REMOTE_BRANCH'." >&2
-      echo "Push your changes with: git push" >&2
-    elif git merge-base --is-ancestor HEAD "$REMOTE_HASH" 2>/dev/null; then
-      BEHIND=$(git rev-list --count HEAD.."$REMOTE_BRANCH")
-      echo "Your branch is $BEHIND commit(s) behind '$REMOTE_BRANCH'." >&2
-      echo "Pull the latest changes with: git pull" >&2
-    else
-      echo "Your branch has diverged from '$REMOTE_BRANCH'." >&2
-      echo "You may need to rebase or merge." >&2
-    fi
-
-    exit 1
-  fi
+  assert_branch_synced || exit 1
 fi
 
 # shellcheck disable=SC2016 # Single quotes are intentional - these are GraphQL queries.

--- a/scripts/wait_pr_ready.sh
+++ b/scripts/wait_pr_ready.sh
@@ -30,6 +30,9 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 WAIT_CODEX_SCRIPT="$SCRIPT_DIR/wait_pr_codex.sh"
 WAIT_CHECKS_SCRIPT="$SCRIPT_DIR/wait_pr_checks.sh"
 CHECK_CODEX_COMMENTS_SCRIPT="$SCRIPT_DIR/check_codex_comments.sh"
+# shellcheck source=./lib/branch_sync_guard.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/branch_sync_guard.sh"
 
 for required in "$WAIT_CODEX_SCRIPT" "$WAIT_CHECKS_SCRIPT" "$CHECK_CODEX_COMMENTS_SCRIPT"; do
   if [ ! -x "$required" ]; then
@@ -84,11 +87,6 @@ load_repo_context() {
 }
 
 assert_clean_and_synced_branch() {
-  local current_branch
-  local remote_branch
-  local local_hash
-  local remote_hash
-
   if ! git diff-index --quiet HEAD --; then
     echo "❌ Error: You have uncommitted changes in your working directory." >&2
     echo "" >&2
@@ -98,54 +96,7 @@ assert_clean_and_synced_branch() {
     return 1
   fi
 
-  current_branch=$(git rev-parse --abbrev-ref HEAD)
-
-  # Always compare against origin/<current-branch>, not @{u}.
-  # Worktrees created from origin/main inherit origin/main as their upstream,
-  # which causes false "not in sync" errors on feature branches.
-  remote_branch="origin/$current_branch"
-
-  # Perform one fetch per orchestrator iteration context and let child scripts reuse it.
-  if ! git fetch origin "$current_branch" --quiet 2>/dev/null; then
-    echo "⚠️  Branch '$current_branch' does not exist on remote." >&2
-    echo "Pushing to origin/$current_branch..." >&2
-
-    if git push -u origin "$current_branch" 2>&1; then
-      echo "✅ Pushed and upstream set successfully!" >&2
-    else
-      echo "❌ Error: Failed to push branch." >&2
-      echo "You may need to push manually: git push -u origin $current_branch" >&2
-      return 1
-    fi
-  fi
-
-  local_hash=$(git rev-parse HEAD)
-  remote_hash=$(git rev-parse "$remote_branch")
-
-  if [[ "$local_hash" != "$remote_hash" ]]; then
-    echo "❌ Error: Local branch is not in sync with remote." >&2
-    echo "" >&2
-    echo "Local:  $local_hash" >&2
-    echo "Remote: $remote_hash" >&2
-    echo "" >&2
-
-    if git merge-base --is-ancestor "$remote_hash" HEAD 2>/dev/null; then
-      local ahead
-      ahead=$(git rev-list --count "$remote_branch"..HEAD)
-      echo "Your branch is $ahead commit(s) ahead of '$remote_branch'." >&2
-      echo "Push your changes with: git push" >&2
-    elif git merge-base --is-ancestor HEAD "$remote_hash" 2>/dev/null; then
-      local behind
-      behind=$(git rev-list --count HEAD.."$remote_branch")
-      echo "Your branch is $behind commit(s) behind '$remote_branch'." >&2
-      echo "Pull the latest changes with: git pull" >&2
-    else
-      echo "Your branch has diverged from '$remote_branch'." >&2
-      echo "You may need to rebase or merge." >&2
-    fi
-
-    return 1
-  fi
+  assert_branch_synced || return 1
 }
 
 load_repo_context


### PR DESCRIPTION
## Summary

Extracts the duplicated branch-sync guard from `wait_pr_checks.sh`, `wait_pr_ready.sh`, and `wait_pr_codex.sh` into a shared `scripts/lib/branch_sync_guard.sh` helper, fixing two bugs in the process:

1. **False "not in sync" on worktree-created feature branches** — worktrees inherit `origin/main` as upstream; the old `@{u}` comparison always diverged after pushing a feature branch.
2. **Unsafe auto-push on fetch failure** — any `git fetch` failure was treated as "branch missing" and triggered `git push -u`, which could create unintended remote branches when a local branch intentionally tracks a differently named upstream.

## Background

Mux creates worktrees via `git worktree add -b <feature-branch> <path> origin/main`. Git auto-configures the upstream to `origin/main`. When an agent pushes a feature branch and runs any `wait_pr_*.sh` script, the sync check compared against the wrong remote ref.

The initial fix hardcoded `origin/$CURRENT_BRANCH` but conflated fetch errors with "branch missing," triggering auto-push even when a configured upstream existed.

## Implementation

New shared helper `scripts/lib/branch_sync_guard.sh` with three functions:

- **`resolve_branch_sync_target`** — determines comparison ref with explicit policy:
  - If `@{u}` exists and points to a non-default branch → honor it (supports cross-name tracking)
  - If `@{u}` points to `origin/<default>` but `origin/<current_branch>` exists → use that (worktree protection)
  - If no upstream → use `origin/<current_branch>`
- **`fetch_or_bootstrap`** — fetches the resolved ref; only auto-pushes when no upstream is configured
- **`assert_branch_synced`** — full sync assertion with ahead/behind/diverged diagnostics

All three wait scripts now source this helper and call `assert_branch_synced`, replacing ~50 duplicated lines each.

## Validation

- `shellcheck` passes clean on all 4 scripts
- Net -11 lines (140 added in shared helper, 151 removed from 3 scripts)

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$0.79`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=0.79 -->
