### PR TITLE
🤖 refactor: unify DevTools expansion cards

### DIFF
--- a/src/browser/features/RightSidebar/DevToolsTab/DevToolsStepCard.tsx
+++ b/src/browser/features/RightSidebar/DevToolsTab/DevToolsStepCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import {
   AlertCircle,
   BarChart3,
@@ -19,6 +19,7 @@ import type {
 import { getTokenTotal } from "@/common/types/devtools";
 import { assertNever } from "@/common/utils/assertNever";
 import { formatDuration } from "@/common/utils/formatDuration";
+import { truncateToFirstLine } from "./devToolsStepCardHelpers";
 
 const PRE_CLASS_NAME =
   "whitespace-pre-wrap break-all text-[10px] text-muted bg-background-primary rounded border border-border-light p-2 mt-1 max-h-[220px] overflow-auto";
@@ -570,27 +571,35 @@ function JsonBlock(props: { data: unknown; emptyMessage?: string; maxHeight?: st
   );
 }
 
-function ToolCallCard(props: { toolCall: unknown }) {
+/**
+ * Keep DevTools expansion affordances consistent: tool calls, prompt messages, and
+ * reasoning blocks all use the same chevron + preview interaction pattern.
+ */
+function CollapsibleCard(props: {
+  icon: ReactNode;
+  label?: ReactNode;
+  preview: string;
+  borderColorClass: string;
+  children: ReactNode;
+}) {
   const [expanded, setExpanded] = useState(false);
-  const toolCallRecord = isRecord(props.toolCall) ? props.toolCall : null;
-  const toolName =
-    toolCallRecord != null && typeof toolCallRecord.toolName === "string"
-      ? toolCallRecord.toolName
-      : "unknown";
-  const args = toolCallRecord?.args;
-  const argsPreview = formatArgsPreview(args);
 
   return (
-    <div className="bg-background-primary rounded border border-l-2 border-violet-500/30 px-2 py-1">
+    <div
+      className={cn(
+        "bg-background-primary rounded border border-l-2 px-2 py-1",
+        props.borderColorClass
+      )}
+    >
       <button
         type="button"
         onClick={() => setExpanded(!expanded)}
         className="hover:bg-hover/50 flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-left"
       >
-        <Wrench className="h-3 w-3 shrink-0 text-violet-500" />
-        <span className="text-foreground text-[10px] font-semibold">{toolName}</span>
-        {!expanded && argsPreview.length > 0 && (
-          <span className="text-muted truncate text-[10px]">{argsPreview}</span>
+        {props.icon}
+        {props.label}
+        {!expanded && props.preview.length > 0 && (
+          <span className="text-muted truncate text-[10px]">{props.preview}</span>
         )}
         <ChevronRight
           className={cn(
@@ -600,40 +609,45 @@ function ToolCallCard(props: { toolCall: unknown }) {
         />
       </button>
 
-      {expanded && (
-        <div className="mt-1">
-          <JsonBlock data={args} emptyMessage="No arguments" maxHeight="150px" />
-        </div>
-      )}
+      {expanded && <div className="mt-1">{props.children}</div>}
     </div>
   );
 }
 
-function MessagePreview(props: { message: unknown }) {
-  const [expanded, setExpanded] = useState(false);
-  const role = getPromptRole(props.message);
-  const content = extractDisplayContent(getPromptContent(props.message));
-  const isTruncated = content.length > 350;
-  const displayContent = !expanded && isTruncated ? `${content.slice(0, 350)}…` : content;
+function ToolCallCard(props: { toolCall: unknown }) {
+  const toolCallRecord = isRecord(props.toolCall) ? props.toolCall : null;
+  const toolName =
+    toolCallRecord != null && typeof toolCallRecord.toolName === "string"
+      ? toolCallRecord.toolName
+      : "unknown";
+  const args = toolCallRecord?.args;
 
   return (
-    <div className="border-border-light overflow-hidden rounded border">
-      <div className="bg-hover/40 flex items-center px-2 py-1">
-        <RoleBadge role={role} />
-      </div>
-      <pre className="text-muted max-h-[160px] overflow-auto p-2 text-[10px] break-words whitespace-pre-wrap">
-        {displayContent}
+    <CollapsibleCard
+      icon={<Wrench className="h-3 w-3 shrink-0 text-violet-500" />}
+      label={<span className="text-foreground text-[10px] font-semibold">{toolName}</span>}
+      preview={formatArgsPreview(args)}
+      borderColorClass="border-violet-500/30"
+    >
+      <JsonBlock data={args} emptyMessage="No arguments" maxHeight="150px" />
+    </CollapsibleCard>
+  );
+}
+
+function MessagePreview(props: { message: unknown }) {
+  const role = getPromptRole(props.message);
+  const content = extractDisplayContent(getPromptContent(props.message));
+
+  return (
+    <CollapsibleCard
+      icon={<RoleBadge role={role} />}
+      preview={truncateToFirstLine(content, 80)}
+      borderColorClass="border-border-light"
+    >
+      <pre className="text-muted max-h-[220px] overflow-auto text-[10px] break-words whitespace-pre-wrap">
+        {content}
       </pre>
-      {isTruncated && (
-        <button
-          type="button"
-          onClick={() => setExpanded(!expanded)}
-          className="text-link px-2 pb-1 text-[10px] hover:underline"
-        >
-          {expanded ? "Show less" : "Show more"}
-        </button>
-      )}
-    </div>
+    </CollapsibleCard>
   );
 }
 
@@ -649,30 +663,17 @@ function RoleBadge(props: { role: string }) {
 }
 
 function ReasoningBlock(props: { text: string }) {
-  const [expanded, setExpanded] = useState(false);
-  const isLongText = props.text.length > 180;
-  const preview = isLongText ? `${props.text.slice(0, 180)}…` : props.text;
-
   return (
-    <div className="bg-background-primary rounded border border-l-2 border-amber-500/30 px-2 py-1">
-      <button
-        type="button"
-        onClick={() => setExpanded(!expanded)}
-        className="hover:bg-hover/50 flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-left"
-      >
-        <Brain className="h-3 w-3 shrink-0 text-amber-500" />
-        <span className="text-foreground text-[10px] font-medium">Thinking</span>
-        <ChevronRight
-          className={cn(
-            "text-muted ml-auto h-2.5 w-2.5 shrink-0 transition-transform",
-            expanded && "rotate-90"
-          )}
-        />
-      </button>
-      <pre className="text-muted mt-1 max-h-[220px] overflow-auto text-[10px] break-words whitespace-pre-wrap">
-        {expanded ? props.text : preview}
+    <CollapsibleCard
+      icon={<Brain className="h-3 w-3 shrink-0 text-amber-500" />}
+      label={<span className="text-foreground text-[10px] font-medium">Thinking</span>}
+      preview={truncateToFirstLine(props.text, 80)}
+      borderColorClass="border-amber-500/30"
+    >
+      <pre className="text-muted max-h-[220px] overflow-auto text-[10px] break-words whitespace-pre-wrap">
+        {props.text}
       </pre>
-    </div>
+    </CollapsibleCard>
   );
 }
 

--- a/src/browser/features/RightSidebar/DevToolsTab/__tests__/devToolsStepCardHelpers.test.ts
+++ b/src/browser/features/RightSidebar/DevToolsTab/__tests__/devToolsStepCardHelpers.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { truncateToFirstLine } from "../devToolsStepCardHelpers";
+
+describe("truncateToFirstLine", () => {
+  test("returns full first line when under max length", () => {
+    expect(truncateToFirstLine("short text", 80)).toBe("short text");
+  });
+
+  test("truncates first line at maxLen with ellipsis", () => {
+    const long = "a".repeat(100);
+    const result = truncateToFirstLine(long, 80);
+    expect(result).toBe(`${"a".repeat(80)}…`);
+  });
+
+  test("uses only first line of multiline input", () => {
+    expect(truncateToFirstLine("line one\nline two\nline three", 80)).toBe("line one");
+  });
+
+  test("truncates long first line of multiline input", () => {
+    const long = `${"b".repeat(100)}\nsecond line`;
+    expect(truncateToFirstLine(long, 80)).toBe(`${"b".repeat(80)}…`);
+  });
+
+  test("returns empty string for empty input", () => {
+    expect(truncateToFirstLine("", 80)).toBe("");
+  });
+
+  test("preserves whitespace on a whitespace-only first line", () => {
+    expect(truncateToFirstLine("   \nactual content", 80)).toBe("   ");
+  });
+
+  test("handles first line exactly at maxLen boundary", () => {
+    const exact = "c".repeat(80);
+    expect(truncateToFirstLine(exact, 80)).toBe(exact);
+  });
+});

--- a/src/browser/features/RightSidebar/DevToolsTab/devToolsStepCardHelpers.ts
+++ b/src/browser/features/RightSidebar/DevToolsTab/devToolsStepCardHelpers.ts
@@ -1,0 +1,20 @@
+import assert from "@/common/utils/assert";
+
+/**
+ * Extract the first line of text, truncated to maxLen characters.
+ * DevTools cards use this for a compact collapsed-state preview.
+ */
+export function truncateToFirstLine(text: string, maxLen: number): string {
+  assert(typeof text === "string", "truncateToFirstLine: text must be a string");
+  assert(
+    Number.isInteger(maxLen) && maxLen >= 0,
+    "truncateToFirstLine: maxLen must be a non-negative integer"
+  );
+
+  const firstLine = text.split("\n")[0] ?? "";
+  if (firstLine.length <= maxLen) {
+    return firstLine;
+  }
+
+  return `${firstLine.slice(0, maxLen)}…`;
+}


### PR DESCRIPTION
## Summary
Unifies the DevTools step-card expansion UX so prompt messages, tool calls, and reasoning blocks all use the same chevron-based collapsed/expanded interaction pattern.

## Background
The DevTools panel previously mixed two interaction styles side-by-side: text links for message truncation and chevron headers for other expandable content. This inconsistency made equivalent interactions feel unrelated and increased maintenance overhead.

## Implementation
- Added a shared `truncateToFirstLine` helper for collapsed preview text.
- Introduced a reusable `CollapsibleCard` primitive in `DevToolsStepCard.tsx`.
- Migrated `MessagePreview` from show more/show less links to the chevron pattern.
- Updated `ReasoningBlock` to render expanded content conditionally, matching tool-call behavior.
- Added focused unit coverage for the preview helper.

## Validation
- `bun test src/browser/features/RightSidebar/DevToolsTab/__tests__/devToolsStepCardHelpers.test.ts`
- `make typecheck`
- `make lint`
- `make static-check`

## Risks
Low risk and tightly scoped to DevTools right-sidebar presentation logic. The refactor centralizes repeated collapse/expand behavior, which should reduce divergence risk across card types.

---

<details>
<summary>📋 Implementation Plan</summary>

# Consolidate DevTools Expansion UI: Replace "Show more/less" with Chevron Pattern

## Context & Why

The DevTools panel (`DevToolsStepCard.tsx`) uses two visually distinct expand/collapse patterns side-by-side:

1. **INPUT panel** — `MessagePreview` uses a "Show more"/"Show less" text link below truncated content
2. **OUTPUT panel** — `ReasoningBlock` and `ToolCallCard` use a clickable header row with a rotating `ChevronRight` icon

Both serve the same purpose ("let me see the rest"), but look and behave differently.
This plan unifies `MessagePreview` onto the chevron pattern already used by `ToolCallCard` and `ReasoningBlock`, and tightens `ReasoningBlock` to match `ToolCallCard`'s conditional-render behavior — creating a single consistent interaction model within the DevTools panel.

## Evidence

- All UI changes scoped to **one file**: `src/browser/features/RightSidebar/DevToolsTab/DevToolsStepCard.tsx`
- New test file: `src/browser/features/RightSidebar/DevToolsTab/__tests__/devToolsStepCardHelpers.test.ts`
- No existing UI tests for these components — helpers are currently unexported internal functions

| Component | Lines | Current Pattern | Target Pattern |
|---|---|---|---|
| `ToolCallCard` | 573–610 | ✅ Chevron row + conditional expanded content | (no change — this is the reference) |
| `MessagePreview` | 612–638 | ❌ "Show more"/"Show less" link | → Chevron row |
| `ReasoningBlock` | 651–677 | ⚠️ Chevron header but always renders `<pre>` | → Conditional content |

## Phase 1 — Red: Define Tests

No existing tests cover these components. Add a unit test file for the extracted preview helper.

### Test file: `src/browser/features/RightSidebar/DevToolsTab/__tests__/devToolsStepCardHelpers.test.ts`

All three card types will share a `truncateToFirstLine(text, maxLen)` helper for generating inline previews. Export it and test:

```ts
import { describe, test, expect } from "bun:test";
import { truncateToFirstLine } from "../devToolsStepCardHelpers";

describe("truncateToFirstLine", () => {
  test("returns full first line when under max length", () => {
    expect(truncateToFirstLine("short text", 80)).toBe("short text");
  });

  test("truncates first line at maxLen with ellipsis", () => {
    const long = "a".repeat(100);
    const result = truncateToFirstLine(long, 80);
    expect(result).toBe("a".repeat(80) + "…");
  });

  test("uses only first line of multiline input", () => {
    expect(truncateToFirstLine("line one\nline two\nline three", 80)).toBe("line one");
  });

  test("truncates long first line of multiline input", () => {
    const long = "b".repeat(100) + "\nsecond line";
    expect(truncateToFirstLine(long, 80)).toBe("b".repeat(80) + "…");
  });

  test("returns empty string for empty input", () => {
    expect(truncateToFirstLine("", 80)).toBe("");
  });

  test("returns empty string for whitespace-only first line", () => {
    expect(truncateToFirstLine("   \nactual content", 80)).toBe("   ");
  });

  test("handles first line exactly at maxLen boundary", () => {
    const exact = "c".repeat(80);
    expect(truncateToFirstLine(exact, 80)).toBe(exact); // no ellipsis needed
  });
});
```

**Run**: `bun test src/browser/features/RightSidebar/DevToolsTab/__tests__/devToolsStepCardHelpers.test.ts`
Tests will fail (module doesn't exist yet) — this is the Red state.

## Phase 2 — Green: Make Tests Pass + Unify Components

### Step 1: Extract shared helper — new file `devToolsStepCardHelpers.ts`

```ts
// src/browser/features/RightSidebar/DevToolsTab/devToolsStepCardHelpers.ts

/**
 * Extract the first line of text, truncated to maxLen characters.
 * Used by all DevTools card types for inline preview in collapsed state.
 */
export function truncateToFirstLine(text: string, maxLen: number): string {
  const firstLine = text.split("\n")[0] ?? "";
  if (firstLine.length <= maxLen) {
    return firstLine;
  }
  return `${firstLine.slice(0, maxLen)}…`;
}
```

Run the test — should now pass (Green).

### Step 2: Rewrite `MessagePreview` to use chevron pattern (lines 612–638)

Replace the "Show more"/"Show less" button with a clickable header row matching `ToolCallCard`:

```tsx
function MessagePreview(props: { message: unknown }) {
  const [expanded, setExpanded] = useState(false);
  const role = getPromptRole(props.message);
  const content = extractDisplayContent(getPromptContent(props.message));
  const preview = truncateToFirstLine(content, 80);

  return (
    <div className="bg-background-primary rounded border border-l-2 border-border-light px-2 py-1">
      <button
        type="button"
        onClick={() => setExpanded(!expanded)}
        className="hover:bg-hover/50 flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-left"
      >
        <RoleBadge role={role} />
        {!expanded && preview.length > 0 && (
          <span className="text-muted truncate text-[10px]">{preview}</span>
        )}
        <ChevronRight
          className={cn(
            "text-muted ml-auto h-2.5 w-2.5 shrink-0 transition-transform",
            expanded && "rotate-90"
          )}
        />
      </button>
      {expanded && (
        <pre className="text-muted mt-1 max-h-[220px] overflow-auto text-[10px] break-words whitespace-pre-wrap">
          {content}
        </pre>
      )}
    </div>
  );
}
```

Changes vs. current:
- **Remove**: `isTruncated`, `displayContent` (350-char slice), the "Show more"/"Show less" `<button>`
- **Add**: `truncateToFirstLine` import, `preview`, `ChevronRight` in header, conditional `<pre>`
- **Restyle**: swap outer container to match `ToolCallCard`/`ReasoningBlock` card style (`bg-background-primary`, `border-l-2`)

### Step 3: Harmonize `ReasoningBlock` collapsed state (lines 651–677)

Currently always renders a `<pre>` below the header. Align with `ToolCallCard`: inline preview in header, conditional `<pre>`.

```tsx
function ReasoningBlock(props: { text: string }) {
  const [expanded, setExpanded] = useState(false);
  const preview = truncateToFirstLine(props.text, 80);

  return (
    <div className="bg-background-primary rounded border border-l-2 border-amber-500/30 px-2 py-1">
      <button
        type="button"
        onClick={() => setExpanded(!expanded)}
        className="hover:bg-hover/50 flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-left"
      >
        <Brain className="h-3 w-3 shrink-0 text-amber-500" />
        <span className="text-foreground text-[10px] font-medium">Thinking</span>
        {!expanded && preview.length > 0 && (
          <span className="text-muted truncate text-[10px]">{preview}</span>
        )}
        <ChevronRight
          className={cn(
            "text-muted ml-auto h-2.5 w-2.5 shrink-0 transition-transform",
            expanded && "rotate-90"
          )}
        />
      </button>
      {expanded && (
        <pre className="text-muted mt-1 max-h-[220px] overflow-auto text-[10px] break-words whitespace-pre-wrap">
          {props.text}
        </pre>
      )}
    </div>
  );
}
```

Changes vs. current:
- **Remove**: `isLongText`, 180-char `preview`, always-rendered `<pre>`
- **Add**: `truncateToFirstLine` import, inline preview span, conditional `<pre>`

All three card types now follow the identical collapsed layout:
```
[icon/badge] [label/preview text] .................. [>]
```

## Phase 3 — Refactor: Extract Shared Card Primitive

After Green, all three components share nearly identical structure. Extract a shared `CollapsibleCard` to eliminate duplication.

### Extract `CollapsibleCard` in `DevToolsStepCard.tsx`

```tsx
/** Shared collapsible card used by ToolCallCard, MessagePreview, and ReasoningBlock. */
function CollapsibleCard(props: {
  icon: React.ReactNode;
  label: React.ReactNode;
  preview: string;
  borderColorClass: string; // e.g. "border-violet-500/30", "border-amber-500/30", "border-border-light"
  children: React.ReactNode; // expanded content
}) {
  const [expanded, setExpanded] = useState(false);

  return (
    <div className={cn("bg-background-primary rounded border border-l-2 px-2 py-1", props.borderColorClass)}>
      <button
        type="button"
        onClick={() => setExpanded(!expanded)}
        className="hover:bg-hover/50 flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-left"
      >
        {props.icon}
        {props.label}
        {!expanded && props.preview.length > 0 && (
          <span className="text-muted truncate text-[10px]">{props.preview}</span>
        )}
        <ChevronRight
          className={cn(
            "text-muted ml-auto h-2.5 w-2.5 shrink-0 transition-transform",
            expanded && "rotate-90"
          )}
        />
      </button>
      {expanded && <div className="mt-1">{props.children}</div>}
    </div>
  );
}
```

Then simplify consumers:

```tsx
function ToolCallCard(props: { toolCall: unknown }) {
  const toolCallRecord = isRecord(props.toolCall) ? props.toolCall : null;
  const toolName = /* ... existing logic ... */;
  const args = toolCallRecord?.args;

  return (
    <CollapsibleCard
      icon={<Wrench className="h-3 w-3 shrink-0 text-violet-500" />}
      label={<span className="text-foreground text-[10px] font-semibold">{toolName}</span>}
      preview={formatArgsPreview(args)}
      borderColorClass="border-violet-500/30"
    >
      <JsonBlock data={args} emptyMessage="No arguments" maxHeight="150px" />
    </CollapsibleCard>
  );
}

function MessagePreview(props: { message: unknown }) {
  const role = getPromptRole(props.message);
  const content = extractDisplayContent(getPromptContent(props.message));

  return (
    <CollapsibleCard
      icon={<RoleBadge role={role} />}
      label={null}
      preview={truncateToFirstLine(content, 80)}
      borderColorClass="border-border-light"
    >
      <pre className="text-muted max-h-[220px] overflow-auto text-[10px] break-words whitespace-pre-wrap">
        {content}
      </pre>
    </CollapsibleCard>
  );
}

function ReasoningBlock(props: { text: string }) {
  return (
    <CollapsibleCard
      icon={<Brain className="h-3 w-3 shrink-0 text-amber-500" />}
      label={<span className="text-foreground text-[10px] font-medium">Thinking</span>}
      preview={truncateToFirstLine(props.text, 80)}
      borderColorClass="border-amber-500/30"
    >
      <pre className="text-muted max-h-[220px] overflow-auto text-[10px] break-words whitespace-pre-wrap">
        {props.text}
      </pre>
    </CollapsibleCard>
  );
}
```

**Criteria for extraction**: The exact same 15+ line `<div><button>...<ChevronRight/></button>{expanded && ...}</div>` block is repeated 3 times. The "rule of three" applies, and the abstraction boundary is clean (icon, label, preview, border color, children).

After refactoring, re-run all validation to confirm nothing broke.

## Verification

1. `bun test src/browser/features/RightSidebar/DevToolsTab/__tests__/devToolsStepCardHelpers.test.ts` — unit tests pass
2. `make typecheck` — no type errors
3. `make lint` — no lint issues
4. Visual smoke test in DevTools tab — all three card types collapse/expand consistently

## Out of Scope

- **"Show all N messages"** link in `StepInputPanel` — pagination (controls *which* items appear), not content expansion
- **Main chat** tool calls (`ToolPrimitives.tsx`) and thinking (`ReasoningMessage.tsx`) — separate, larger effort
- **`<details>`/`<summary>`** in markdown — author-controlled content

## Estimate

~**+30 net LoC** (new test file ~35, new helper file ~10, `CollapsibleCard` primitive ~25, minus ~40 removed from inlined duplications in the three card components)

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$3.95`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=3.95 -->
