### PR TITLE
🤖 ci: retry macOS builds to handle transient Apple timestamp failures

### DIFF
--- a/.github/workflows/_desktop-release.yml
+++ b/.github/workflows/_desktop-release.yml
@@ -56,26 +56,8 @@ jobs:
           AC_APIKEY_ISSUER_ID: ${{ secrets.AC_APIKEY_ISSUER_ID }}
 
       - name: Package and publish for macOS
-        shell: bash
-        run: |
-          # Retry up to 3× — Apple's timestamp server used by codesign --timestamp
-          # is occasionally unreachable, causing transient "The timestamp service is
-          # not available" failures during code signing.
-          max_attempts=3
-          for attempt in $(seq 1 $max_attempts); do
-            echo "::group::Attempt $attempt of $max_attempts"
-            if make dist-mac-release; then
-              echo "::endgroup::"
-              exit 0
-            fi
-            echo "::endgroup::"
-            if [ "$attempt" -lt "$max_attempts" ]; then
-              echo "⚠️ Attempt $attempt failed — retrying in 30s..."
-              sleep 30
-            fi
-          done
-          echo "::error::All $max_attempts attempts failed"
-          exit 1
+        # Retry for transient Apple timestamp-server failures during code signing.
+        run: ./scripts/retry.sh 3 30 make dist-mac-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -404,26 +404,8 @@ jobs:
           AC_APIKEY_ID: ${{ secrets.AC_APIKEY_ID }}
           AC_APIKEY_ISSUER_ID: ${{ secrets.AC_APIKEY_ISSUER_ID }}
       - name: Build macOS distributables
-        shell: bash
-        run: |
-          # Retry up to 3× — Apple's timestamp server used by codesign --timestamp
-          # is occasionally unreachable, causing transient "The timestamp service is
-          # not available" failures during code signing.
-          max_attempts=3
-          for attempt in $(seq 1 $max_attempts); do
-            echo "::group::Attempt $attempt of $max_attempts"
-            if make dist-mac; then
-              echo "::endgroup::"
-              exit 0
-            fi
-            echo "::endgroup::"
-            if [ "$attempt" -lt "$max_attempts" ]; then
-              echo "⚠️ Attempt $attempt failed — retrying in 30s..."
-              sleep 30
-            fi
-          done
-          echo "::error::All $max_attempts attempts failed"
-          exit 1
+        # Retry for transient Apple timestamp-server failures during code signing.
+        run: ./scripts/retry.sh 3 30 make dist-mac
       - name: Upload x64 artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:

--- a/scripts/retry.sh
+++ b/scripts/retry.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Retry a command with backoff between attempts.
+# Usage: scripts/retry.sh <max_attempts> <backoff_secs> <command...>
+#
+# Designed for CI (GitHub Actions): uses ::group:: markers for log folding
+# and ::error:: annotations on final failure.
+set -euo pipefail
+
+max_attempts="${1:?Usage: retry.sh <max_attempts> <backoff_secs> <command...>}"
+backoff_secs="${2:?Usage: retry.sh <max_attempts> <backoff_secs> <command...>}"
+shift 2
+
+for attempt in $(seq 1 "$max_attempts"); do
+  echo "::group::Attempt $attempt of $max_attempts"
+  if "$@"; then
+    echo "::endgroup::"
+    exit 0
+  fi
+  echo "::endgroup::"
+  if [ "$attempt" -lt "$max_attempts" ]; then
+    echo "⚠️ Attempt $attempt failed — retrying in ${backoff_secs}s..."
+    sleep "$backoff_secs"
+  fi
+done
+
+echo "::error::All $max_attempts attempts failed"
+exit 1


### PR DESCRIPTION
## Summary

Adds a reusable retry script (`scripts/retry.sh`) and wires it into macOS code signing steps so transient Apple timestamp server outages don't fail the entire build.

## Background

The nightly macOS build ([run 22660852909](https://github.com/coder/mux/actions/runs/22660852909/job/65680534226)) failed at the "Package and publish for macOS" step with `The timestamp service is not available`. This is Apple's `codesign --timestamp` server going down briefly — a known intermittent issue. All other platforms succeeded.

electron-builder has no built-in retry for codesign operations, so the fix is at the CI layer.

## Implementation

New `scripts/retry.sh` — a generic retry wrapper with no external dependencies:
```
Usage: scripts/retry.sh <max_attempts> <backoff_secs> <command...>
```
- GitHub Actions `::group::`/`::endgroup::` markers for clean log folding per attempt
- `::error::` annotation on final failure
- Both workflow files call it with `./scripts/retry.sh 3 30 make dist-mac...`

Retrying the full make target is safe because vite caching makes the `build` dep near-instant on re-run, electron-builder overwrites its `release/` output, and the subsequent `gh release upload --clobber` handles upload conflicts.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$2.68`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=2.68 -->
