### PR TITLE
🤖 ci: add hadolint Dockerfile linting

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -99,6 +99,15 @@ jobs:
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y shellcheck
+      - name: Install hadolint
+        run: |
+          set -euo pipefail
+          HADOLINT_VERSION="v2.12.0"
+          curl --retry 5 --retry-all-errors --retry-delay 2 -LsSf \
+            "https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
+            -o "$HOME/.local/bin/hadolint"
+          chmod +x "$HOME/.local/bin/hadolint"
+          hadolint --version
       - uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
         with:
           extra_nix_config: |

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/hadolint/hadolint/master/contrib/hadolint.schema.yaml
+# Hadolint configuration — Dockerfile best-practice linter
+# Docs: https://github.com/hadolint/hadolint#configure
+
+# Trusted base image registries (empty = allow all)
+trustedRegistries: []
+
+# Rules to ignore globally (add sparingly, with rationale comments)
+ignored: []

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN npm install -g bun@1.2
 
 # Install git (needed for version generation) and build tools for native modules
 # bzip2 is required for lzma-native to extract its bundled xz source tarball
+# Intentionally keep packages unpinned so Debian security updates flow in without manual version churn.
+# hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends git python3 make g++ bzip2 && rm -rf /var/lib/apt/lists/*
 
 # Copy package files first for better layer caching
@@ -81,6 +83,8 @@ WORKDIR /app
 # - git: required for workspace operations (clone, worktree, etc.)
 # - openssh-client: required for SSH runtime support
 # - ca-certificates: required for HTTPS (git clone, API calls, etc.)
+# Intentionally keep packages unpinned so Debian security updates flow in without manual version churn.
+# hadolint ignore=DL3008
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git openssh-client ca-certificates && \
     rm -rf /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ build/icon.png: docs/img/logo-white.svg scripts/generate-icons.ts
 	@bun scripts/generate-icons.ts png
 
 ## Quality checks (can run in parallel)
-static-check: lint typecheck fmt-check check-eager-imports check-bench-agent check-docs-links check-code-docs-links lint-shellcheck flake-hash-check ## Run all static checks (lint + typecheck + fmt-check)
+static-check: lint typecheck fmt-check check-eager-imports check-bench-agent check-docs-links check-code-docs-links lint-shellcheck lint-hadolint flake-hash-check ## Run all static checks (lint + typecheck + fmt-check)
 
 check-bench-agent: node_modules/.installed src/version.ts $(BUILTIN_SKILLS_GENERATED) ## Verify terminal-bench agent configuration and imports
 	@./scripts/check-bench-agent.sh
@@ -343,6 +343,12 @@ SHELL_SRC_FILES := $(shell find . -not \( -path '*/.git/*' -o -path './node_modu
 
 lint-shellcheck: ## Run shellcheck on shell scripts
 	shellcheck --external-sources $(SHELL_SRC_FILES)
+
+# Dockerfiles to lint (excludes node_modules, build artifacts, .git)
+DOCKERFILES := $(shell find . -not \( -path '*/.git/*' -o -path './node_modules/*' -o -path './mobile/node_modules/*' -o -path './build/*' -o -path './dist/*' -o -path './release/*' -o -path './benchmarks/terminal_bench/.leaderboard_cache/*' \) -type f -name 'Dockerfile' 2>/dev/null)
+
+lint-hadolint: ## Run hadolint on Dockerfiles
+	hadolint $(DOCKERFILES)
 
 pin-actions: ## Pin GitHub Actions to SHA hashes (requires GH_TOKEN or gh CLI)
 	./scripts/pin-actions.sh .github/workflows/*.yml .github/actions/*/action.yml

--- a/flake.nix
+++ b/flake.nix
@@ -183,6 +183,7 @@
 
               # Repo linting (make static-check)
               go
+              hadolint
               shellcheck
               shfmt
               gh

--- a/tests/runtime/test-fixtures/ssh-server/Dockerfile
+++ b/tests/runtime/test-fixtures/ssh-server/Dockerfile
@@ -1,12 +1,18 @@
+# Use latest Alpine in this test fixture to exercise current package behavior in CI.
+# hadolint ignore=DL3007
 FROM alpine:latest
 
 # Install OpenSSH server, git, and bash
 # bash is required for remote command execution (mux forces bash to avoid shell compatibility issues)
+# Intentionally keep APK packages unpinned so security updates flow in test images.
+# hadolint ignore=DL3018
 RUN apk add --no-cache openssh-server git bash
 
 # Create test user
 RUN adduser -D -s /bin/sh testuser && \
-    echo "testuser:testuser" | chpasswd
+    printf 'testuser:testuser\n' > /tmp/chpasswd-input && \
+    chpasswd < /tmp/chpasswd-input && \
+    rm /tmp/chpasswd-input
 
 # Create .ssh directory for authorized_keys
 RUN mkdir -p /home/testuser/.ssh && \


### PR DESCRIPTION
## Summary
Add first-class Dockerfile linting with hadolint across local development and CI static checks.

## Background
The repository already linted shell scripts and GitHub Actions, but Dockerfiles were not covered.
This change closes that gap and prevents Dockerfile issues from slipping into CI builds.

## Implementation
- Added `.hadolint.yaml` with minimal baseline config.
- Added `lint-hadolint` target in `Makefile` and wired it into `static-check`.
- Added `hadolint` to `flake.nix` dev shell lint tooling.
- Added hadolint installation in `.github/workflows/pr.yml` static-check job.
- Addressed current Dockerfile findings with targeted inline ignores plus rationale comments.
- Updated the SSH test fixture Dockerfile to avoid a pipe-in-RUN warning (DL4006).

## Validation
- `make lint-hadolint`
- `make static-check`

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Add hadolint for Dockerfile linting

## Context & Why

The repo has two Dockerfiles (`./Dockerfile` and `./tests/runtime/test-fixtures/ssh-server/Dockerfile`) but no Dockerfile linting. Other infrastructure linters are already well-integrated: `shellcheck` for `.sh` files, `actionlint`/`zizmor` for GitHub Actions. Adding `hadolint` fills this gap, catching Dockerfile best-practice violations and shell antipatterns before they reach CI builds.

## Evidence

| Source | Key takeaway |
|---|---|
| `Makefile:322` | `static-check` aggregates all lint targets; new target goes here |
| `Makefile:342-345` | `lint-shellcheck` is the closest pattern to follow (find files → run linter) |
| `flake.nix:184-190` | "Repo linting" section in `devShells.default.buildInputs` — `hadolint` goes next to `shellcheck` |
| `.github/workflows/pr.yml:73-115` | `static-check` job runs `make -j static-check`; tool install steps precede it |
| Both Dockerfiles | Read and confirmed contents — ready to be linted |

## Implementation

### 1. Add `.hadolint.yaml` config file (repo root)

Create a minimal config so the linter can be tuned without editing the Makefile. Start with no ignores — we'll suppress specific rules only if the existing Dockerfiles trigger false positives.

```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/hadolint/hadolint/master/contrib/hadolint.schema.yaml
# Hadolint configuration — Dockerfile best-practice linter
# Docs: https://github.com/hadolint/hadolint#configure

# Trusted base image registries (empty = allow all)
trustedRegistries: []

# Rules to ignore globally (add sparingly, with rationale comments)
ignored: []
```

We may need to add specific ignores after running hadolint on the existing Dockerfiles (e.g., `DL3008` for pinning apt package versions if we intentionally use unpinned packages). That will be determined at implementation time.

**~8 LoC**

### 2. Add `hadolint` to `flake.nix`

Add `hadolint` to the `devShells.default.buildInputs` list in the "Repo linting" section, next to `shellcheck`:

```nix
# flake.nix, line ~186
# Repo linting (make static-check)
go
hadolint
shellcheck
shfmt
...
```

**~1 LoC**

### 3. Add `lint-hadolint` target to `Makefile`

Follow the `lint-shellcheck` pattern — find Dockerfiles, invoke hadolint:

```makefile
# Dockerfile linting (excludes node_modules, build artifacts, .git)
DOCKERFILES := $(shell find . -not \( -path '*/.git/*' -o -path './node_modules/*' -o -path './mobile/node_modules/*' -o -path './build/*' -o -path './dist/*' -o -path './release/*' \) -type f -name 'Dockerfile' 2>/dev/null)

lint-hadolint: ## Run hadolint on Dockerfiles
	hadolint $(DOCKERFILES)
```

Place this directly after the `lint-shellcheck` block (line ~345).

Then add `lint-hadolint` to the `static-check` dependency list:

```makefile
static-check: lint typecheck fmt-check check-eager-imports check-bench-agent check-docs-links check-code-docs-links lint-shellcheck lint-hadolint flake-hash-check
```

**~5 LoC**

### 4. Install hadolint in CI (`pr.yml`)

Add a step to the `static-check` job to install hadolint, placed after the existing `Install shellcheck` step. Use the official prebuilt binary (fast, no extra dependencies):

```yaml
      - name: Install hadolint
        run: |
          set -euo pipefail
          HADOLINT_VERSION="v2.12.0"
          curl --retry 5 --retry-all-errors --retry-delay 2 -LsSf \
            "https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
            -o "$HOME/.local/bin/hadolint"
          chmod +x "$HOME/.local/bin/hadolint"
          hadolint --version
```

This mirrors the curl-based install pattern already used for `shfmt` and `uv` in the same job. `$HOME/.local/bin` is already on `$GITHUB_PATH` from the shfmt step.

**~9 LoC**

### 5. Fix any existing hadolint violations

After all wiring is done, run `make lint-hadolint` locally and fix any violations in the two Dockerfiles. Common expected warnings:

- `DL3008` (pin apt versions) — decide whether to pin or ignore
- `DL3018` (pin apk versions) — same for the Alpine Dockerfile
- `DL3003` (use WORKDIR instead of cd)

Either fix inline or add justified ignores to `.hadolint.yaml`.

**~0-10 LoC depending on findings**

## Net LoC estimate

~25–35 lines of product code (config + Makefile + CI workflow). No test code changes expected.

## File change summary

| File | Change |
|---|---|
| `.hadolint.yaml` | **New** — hadolint configuration |
| `flake.nix` | Add `hadolint` to devShell buildInputs |
| `Makefile` | Add `DOCKERFILES` var, `lint-hadolint` target, wire into `static-check` |
| `.github/workflows/pr.yml` | Add `Install hadolint` step in `static-check` job |
| `Dockerfile` | Fix any hadolint violations (if needed) |
| `tests/runtime/test-fixtures/ssh-server/Dockerfile` | Fix any hadolint violations (if needed) |


</details>

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$1.34`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=1.34 -->
