### PR TITLE
🤖 fix: show provider error details in AI debug logs

### DIFF
--- a/src/common/utils/errors.test.ts
+++ b/src/common/utils/errors.test.ts
@@ -9,6 +9,48 @@ describe("getErrorMessage", () => {
     expect(getErrorMessage(undefined)).toBe("undefined");
   });
 
+  it("returns .message from a plain object with a message property", () => {
+    expect(getErrorMessage({ message: "rate limit exceeded", code: 429 })).toBe(
+      "rate limit exceeded"
+    );
+  });
+
+  it("falls back to String() when reading message throws", () => {
+    const obj = {};
+    Object.defineProperty(obj, "message", {
+      get() {
+        throw new Error("getter boom");
+      },
+    });
+
+    expect(getErrorMessage(obj)).toBe("[object Object]");
+  });
+
+  it("returns JSON for a plain object without a message property", () => {
+    expect(getErrorMessage({ code: 429, status: "error" })).toBe('{"code":429,"status":"error"}');
+  });
+
+  it("returns JSON for a plain object with empty message", () => {
+    expect(getErrorMessage({ message: "", code: 500 })).toBe('{"message":"","code":500}');
+  });
+
+  it("returns JSON for an array error value", () => {
+    expect(getErrorMessage(["error1", "error2"])).toBe('["error1","error2"]');
+  });
+
+  it("falls back to String() when JSON serialization returns undefined", () => {
+    const obj = {
+      toJSON: () => undefined,
+    };
+    expect(getErrorMessage(obj)).toBe("[object Object]");
+  });
+
+  it("falls back to String() for circular plain objects", () => {
+    const obj: Record<string, unknown> = { code: 500 };
+    obj.self = obj;
+    expect(getErrorMessage(obj)).toBe("[object Object]");
+  });
+
   it("returns .message for a plain Error", () => {
     expect(getErrorMessage(new Error("something failed"))).toBe("something failed");
   });

--- a/src/common/utils/errors.ts
+++ b/src/common/utils/errors.ts
@@ -6,7 +6,31 @@
  * filesystem ENOENT) is surfaced rather than silently dropped.
  */
 export function getErrorMessage(error: unknown): string {
-  if (!(error instanceof Error)) return String(error);
+  if (!(error instanceof Error)) {
+    if (typeof error === "object" && error !== null) {
+      try {
+        const errorRecord = error as Record<string, unknown>;
+        const message = errorRecord.message;
+        if (typeof message === "string" && message.length > 0) {
+          return message;
+        }
+
+        const serializedError = JSON.stringify(error);
+        if (typeof serializedError === "string") {
+          return serializedError;
+        }
+        // `JSON.stringify` can return undefined (for example when toJSON returns
+        // undefined), so keep the string-return contract by falling back below.
+      } catch {
+        // Accessing properties on arbitrary thrown values (for example Proxies or
+        // throwing getters) can itself throw. Keep this helper non-throwing and
+        // fall back to String(error) below.
+      }
+    }
+
+    return String(error);
+  }
+
   let msg = error.message;
   // Guard against cyclic cause chains (e.g. err.cause = err) with a visited set.
   const seen = new WeakSet<Error>();

--- a/src/node/services/devToolsMiddleware.ts
+++ b/src/node/services/devToolsMiddleware.ts
@@ -15,6 +15,7 @@ import type {
   DevToolsUsage,
 } from "@/common/types/devtools";
 import assert from "@/common/utils/assert";
+import { getErrorMessage } from "@/common/utils/errors";
 import { log } from "@/node/services/log";
 import {
   DEVTOOLS_RUN_METADATA_ID_HEADER,
@@ -26,14 +27,6 @@ import type { DevToolsService } from "./devToolsService";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
-}
-
-function extractErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message.length > 0) {
-    return error.message;
-  }
-
-  return String(error);
 }
 
 function extractFinishReason(reason: unknown): string | undefined {
@@ -446,7 +439,7 @@ export function createDevToolsMiddleware(
         await finalizeStep({
           output: null,
           usage: null,
-          error: extractErrorMessage(error),
+          error: getErrorMessage(error),
           rawRequest: null,
           requestHeaders: capturedRequestHeaders,
           responseHeaders: null,
@@ -578,7 +571,7 @@ export function createDevToolsMiddleware(
         await finalizeStep({
           output: null,
           usage: null,
-          error: extractErrorMessage(error),
+          error: getErrorMessage(error),
           rawRequest: null,
           requestHeaders: capturedRequestHeaders,
           responseHeaders: null,
@@ -653,7 +646,7 @@ export function createDevToolsMiddleware(
           case "error": {
             finishReason ??= "error";
             // Capture the error payload so the step is marked as failed in DevTools.
-            streamError = extractErrorMessage(chunk.error);
+            streamError = getErrorMessage(chunk.error);
             break;
           }
           default:
@@ -696,7 +689,7 @@ export function createDevToolsMiddleware(
             await finalizeStep({
               output: buildOutput(),
               usage,
-              error: extractErrorMessage(error),
+              error: getErrorMessage(error),
               rawRequest,
               requestHeaders: capturedRequestHeaders,
               responseHeaders,


### PR DESCRIPTION
## Summary
Fix AI Debug Logs error rendering so provider object payloads no longer appear as `Error: [object Object]`.

## Background
Some providers return structured error objects rather than `Error` instances. The middleware's local helper and the shared utility previously fell back to `String(error)` for non-`Error` values, collapsing useful payloads into `[object Object]`.

## Implementation
- Enhanced `getErrorMessage` to:
  - Prefer non-empty `message` from plain objects
  - Fallback to `JSON.stringify` for object/array payloads
  - Gracefully fallback to `String(error)` when serialization fails (e.g. circular refs)
- Added regression tests covering plain objects, arrays, and circular object fallback.
- Removed duplicate `extractErrorMessage` from `devToolsMiddleware` and reused shared `getErrorMessage` at all middleware callsites.

## Validation
- `bun test src/common/utils/errors.test.ts`
- `bun test src/node/services/__tests__/devToolsMiddleware.test.ts`
- `make typecheck`
- `make static-check`

## Risks
Low risk. The change is scoped to error-message normalization and covered by targeted tests plus existing middleware tests.

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix "Error: [object Object]" in AI Debug Logs

## Context

The DevTools debug logs panel shows `Error: [object Object]` instead of the actual error message when an AI provider returns an error. LLM providers return plain objects (e.g. `{ message: "rate limit exceeded", code: 429 }`), not `Error` instances, and two utility functions naively call `String(error)` on them — producing `"[object Object]"`.

## Root Cause

Two functions with the same bug:

1. **`extractErrorMessage`** in `src/node/services/devToolsMiddleware.ts:30–36` — private helper, 4 call sites within the file (lines 433, 565, 640, 683). Direct cause of the screenshot.
2. **`getErrorMessage`** in `src/common/utils/errors.ts:8–9` — shared utility, ~387 call sites app-wide. Same `String(error)` fallback for non-`Error` values.

`extractErrorMessage` is strictly a worse duplicate of `getErrorMessage` (no cause-chain walking). After fixing `getErrorMessage`, we can eliminate `extractErrorMessage` entirely.

---

## Phase 1 — Red: Write Failing Tests

**File:** `src/common/utils/errors.test.ts`

Add test cases that capture the exact behavior we want. These will fail against the current `String(error)` fallback:

```ts
it("returns .message from a plain object with a message property", () => {
  expect(getErrorMessage({ message: "rate limit exceeded", code: 429 })).toBe(
    "rate limit exceeded",
  );
});

it("returns JSON for a plain object without a message property", () => {
  expect(getErrorMessage({ code: 429, status: "error" })).toBe(
    '{"code":429,"status":"error"}',
  );
});

it("returns JSON for a plain object with empty message", () => {
  expect(getErrorMessage({ message: "", code: 500 })).toBe(
    '{"message":"","code":500}',
  );
});

it("returns JSON for an array error value", () => {
  expect(getErrorMessage(["error1", "error2"])).toBe('["error1","error2"]');
});

it("falls back to String() for circular plain objects", () => {
  const obj: Record<string, unknown> = { code: 500 };
  obj.self = obj;
  // JSON.stringify would throw, so we must fall back gracefully
  expect(getErrorMessage(obj)).toBe("[object Object]");
});
```

**Verify:** `bun test src/common/utils/errors.test.ts` — expect 3+ failures (plain object, JSON, array tests fail with `"[object Object]"` instead of expected values).

## Phase 2 — Green: Fix `getErrorMessage`

**File:** `src/common/utils/errors.ts` — replace the early return for non-`Error` values (~8 LoC net).

```ts
export function getErrorMessage(error: unknown): string {
  if (!(error instanceof Error)) {
    // Plain objects with a .message string (common for LLM provider errors)
    if (typeof error === "object" && error !== null) {
      if (
        "message" in error &&
        typeof (error as Record<string, unknown>).message === "string" &&
        ((error as Record<string, unknown>).message as string).length > 0
      ) {
        return (error as Record<string, unknown>).message as string;
      }
      try {
        return JSON.stringify(error);
      } catch {
        // Circular references, etc. — fall through to String()
      }
    }
    return String(error);
  }
  // ... existing cause-chain walking unchanged ...
}
```

Key behaviors:
- `{ message: "rate limit" }` → `"rate limit"` (extract `.message`)
- `{ code: 429 }` → `'{"code":429}'` (JSON stringify for objects without `.message`)
- `{ message: "", code: 500 }` → `'{"message":"","code":500}'` (empty `.message` treated as absent)
- Circular objects → `"[object Object]"` (graceful fallback via try/catch around `JSON.stringify`)
- Primitives like `"boom"`, `42`, `null` → unchanged (`String()`)

**Verify:** `bun test src/common/utils/errors.test.ts` — all tests pass, including the existing ones (no regressions on Error instances, cause chains, etc.).

## Phase 3 — Refactor: Eliminate `extractErrorMessage`

`extractErrorMessage` in devToolsMiddleware.ts is now a strictly worse duplicate. Replace all 4 call sites with the shared utility and delete the private function.

**File:** `src/node/services/devToolsMiddleware.ts`

1. Add import at top: `import { getErrorMessage } from "@/common/utils/errors";`
2. Delete `extractErrorMessage` function (lines 30–36, ~7 LoC removed)
3. Replace 4 call sites:
   - Line 433: `error: extractErrorMessage(error)` → `error: getErrorMessage(error)`
   - Line 565: same
   - Line 640: `streamError = extractErrorMessage(chunk.error)` → `streamError = getErrorMessage(chunk.error)`
   - Line 683: same as 433

**Verify:**
- `bun test src/common/utils/errors.test.ts` — still green
- `bun test src/node/services/__tests__/devToolsMiddleware.test.ts` — no regressions
- `make typecheck` — clean

## Net LoC: ~+15 (product: ~+5, tests: ~+20)

Adds ~12 lines to `getErrorMessage` + tests, removes ~7 lines (`extractErrorMessage` + its call-site differences).

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$1.95`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=1.95 -->
