### PR TITLE
🤖 fix: route crash diagnostics through log service and enable minidumps

### DIFF
--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -29,6 +29,7 @@ import "disposablestack/auto";
 import type { MenuItemConstructorOptions, MessageBoxOptions } from "electron";
 import {
   app,
+  crashReporter,
   BrowserWindow,
   ipcMain as electronIpcMain,
   Menu,
@@ -39,6 +40,11 @@ import {
   screen,
   shell,
 } from "electron";
+
+// Enable local crash dump collection so renderer SIGSEGV produces a minidump
+// at ~/.config/mux/Crashpad/completed/*.dmp — no data leaves the machine.
+// Must be called as early as possible, before app.whenReady().
+crashReporter.start({ uploadToServer: false });
 
 // Increase renderer V8 heap limit from default ~4GB to 8GB.
 // At ~3.9GB usage, the default limit causes frequent Mark-Compact GC cycles
@@ -64,6 +70,7 @@ import windowStateKeeper from "electron-window-state";
 import { getTitleBarOptions } from "./titleBarOptions";
 import { isUpdateInstallInProgress } from "./updateInstallState";
 import { getErrorMessage } from "@/common/utils/errors";
+import { log } from "@/node/services/log";
 
 // React DevTools for development profiling
 // Using dynamic import() to avoid loading electron-devtools-installer at module init time
@@ -913,8 +920,9 @@ function createWindow() {
 
   // Diagnostic crash hooks — log only, no recovery side effects.
   // Crash behavior is left unmodified so the root cause can be observed.
+  // Uses log.* (not console.*) so entries reach the log file and Output Tab.
   mainWindow.webContents.on("render-process-gone", (_event, details) => {
-    console.error("[diag] render-process-gone", {
+    log.error("[diag] render-process-gone", {
       reason: details.reason,
       exitCode: details.exitCode,
       url: mainWindow?.webContents.getURL(),
@@ -925,7 +933,7 @@ function createWindow() {
     "did-fail-load",
     (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
       if (isMainFrame) {
-        console.error("[diag] did-fail-load", {
+        log.error("[diag] did-fail-load", {
           errorCode,
           errorDescription,
           url: validatedURL,
@@ -935,7 +943,24 @@ function createWindow() {
   );
 
   mainWindow.webContents.on("unresponsive", () => {
-    console.warn("[diag] renderer unresponsive");
+    log.warn("[diag] renderer unresponsive");
+  });
+
+  // Forward renderer console errors to the log service so they reach the log
+  // file (~/.mux/logs/mux.log) and Output Tab even when the UI is white/blank.
+  // The renderer's global error handlers (window.addEventListener("error")) log
+  // to console.error, but that stays in renderer memory only — the main process
+  // never sees it without this hook.
+  mainWindow.webContents.on("console-message", (_event, level, message, line, sourceId) => {
+    // level: 0=debug, 1=info, 2=warning, 3=error
+    if (level >= 2) {
+      const source = sourceId ? `${sourceId}:${line}` : undefined;
+      if (level >= 3) {
+        log.error("[renderer]", message, ...(source ? [{ source }] : []));
+      } else {
+        log.warn("[renderer]", message, ...(source ? [{ source }] : []));
+      }
+    }
   });
 
   mainWindow.on("closed", () => {
@@ -1048,7 +1073,7 @@ if (gotTheLock) {
 
   app.on("child-process-gone", (_event, details) => {
     if (details.type === "GPU") {
-      console.error(
+      log.error(
         `[window] GPU process gone: reason=${details.reason}, exitCode=${details.exitCode}`
       );
     }


### PR DESCRIPTION
## Summary

Make renderer/GPU crash diagnostics visible in the log file and Output Tab, and enable local minidump collection for native crash stack traces.

## Background

PR #2629 added crash lifecycle hooks (`render-process-gone`, `did-fail-load`, `unresponsive`, GPU `child-process-gone`) but they used raw `console.*` which only goes to stdout. When a renderer SIGSEGV (exit code 139) was observed on Linux, the log appeared in the terminal but not in the Output Tab or `~/.mux/logs/mux.log` — making it invisible to users who aren't watching a terminal.

Additionally, Electron's `crashReporter` was never started, so the SIGSEGV didn't produce a minidump — the crash reason was logged but the native stack trace was lost.

## Implementation

All changes in `src/desktop/main.ts`:

- **Route crash hooks through `log.*`** instead of `console.*` so entries reach the log file (`~/.mux/logs/mux.log`) and the Output Tab via the log buffer subscription
- **Forward renderer console errors** to the log service via `webContents.on("console-message")` — the renderer's global error handlers (`window.addEventListener("error")` in `main.tsx`) write to `console.error` which stays in renderer memory; this hook bridges that to the main process log service
- **Enable `crashReporter.start({ uploadToServer: false })`** so renderer segfaults write `.dmp` minidumps to `~/.config/mux/Crashpad/completed/` — no data leaves the machine

## Risks

Low. Logging-only changes with no behavioral side effects on crash flow. The `console-message` hook filters to level ≥ 2 (warnings + errors) to avoid noise.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$N/A`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh -->
