### PR TITLE
🤖 fix: convert data URI file parts before model conversion

### DIFF
--- a/src/node/services/messagePipeline.ts
+++ b/src/node/services/messagePipeline.ts
@@ -14,6 +14,7 @@ import { sanitizeToolInputs } from "@/browser/utils/messages/sanitizeToolInput";
 import { inlineSvgAsTextForProvider } from "@/node/utils/messages/inlineSvgAsTextForProvider";
 import { extractToolMediaAsUserMessages } from "@/node/utils/messages/extractToolMediaAsUserMessages";
 import { sanitizeAnthropicPdfFilenames } from "@/node/utils/messages/sanitizeAnthropicDocumentFilename";
+import { convertDataUriFilePartsForSdk } from "@/node/utils/messages/convertDataUriFilePartsForSdk";
 import type { MuxMessage } from "@/common/types/message";
 import type { EditedFileAttachment } from "@/node/services/agentSession";
 import type { PostCompactionAttachment } from "@/common/types/attachment";
@@ -77,11 +78,12 @@ export interface PrepareMessagesOptions {
  * 7. Inlining SVG attachments as text
  * 8. Sanitizing PDF filenames for Anthropic
  * 9. Extracting tool-result media as user message attachments
- * 10. Converting to Vercel AI SDK ModelMessage format
- * 11. Self-healing: filtering empty/whitespace assistant messages
- * 12. Applying provider-specific message transforms
- * 13. Applying cache control headers
- * 14. Validating Anthropic compliance (logs warnings only)
+ * 10. Rewriting data-URI file parts to SDK-safe inline base64
+ * 11. Converting to Vercel AI SDK ModelMessage format
+ * 12. Self-healing: filtering empty/whitespace assistant messages
+ * 13. Applying provider-specific message transforms
+ * 14. Applying cache control headers
+ * 15. Validating Anthropic compliance (logs warnings only)
  */
 export async function prepareMessagesForProvider(
   opts: PrepareMessagesOptions
@@ -161,11 +163,18 @@ export async function prepareMessagesForProvider(
   // Prevents providers from treating large base64 payloads as text/JSON context.
   const messagesWithToolMediaExtracted = extractToolMediaAsUserMessages(messagesWithSanitizedPdf);
 
+  // Rewrite user file-part data URIs to raw base64 payloads before SDK conversion.
+  // convertToModelMessages maps FileUIPart.url -> FilePart.data; keeping data: URLs here
+  // can trigger URL-download validation in downstream provider utilities.
+  const messagesWithSdkSafeFileParts = convertDataUriFilePartsForSdk(
+    messagesWithToolMediaExtracted
+  );
+
   // --- Convert to ModelMessage format ---
 
   // Type assertion needed because MuxMessage has custom tool parts for interrupted tools
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-  const rawModelMessages = await convertToModelMessages(messagesWithToolMediaExtracted as any, {
+  const rawModelMessages = await convertToModelMessages(messagesWithSdkSafeFileParts as any, {
     // Drop unfinished tool calls (input-streaming/input-available) so downstream
     // transforms only see tool calls that actually produced outputs.
     ignoreIncompleteToolCalls: true,

--- a/src/node/utils/messages/convertDataUriFilePartsForSdk.test.ts
+++ b/src/node/utils/messages/convertDataUriFilePartsForSdk.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "@jest/globals";
+import type { MuxMessage } from "@/common/types/message";
+import { convertDataUriFilePartsForSdk } from "./convertDataUriFilePartsForSdk";
+
+describe("convertDataUriFilePartsForSdk", () => {
+  it("converts base64 data URI file parts to raw base64 payloads", () => {
+    const base64 = Buffer.from("png-bytes", "utf8").toString("base64");
+    const input: MuxMessage[] = [
+      {
+        id: "u1",
+        role: "user",
+        parts: [
+          { type: "text", text: "look" },
+          {
+            type: "file",
+            mediaType: "image/png",
+            url: `data:image/png;base64,${base64}`,
+          },
+        ],
+      },
+    ];
+
+    const converted = convertDataUriFilePartsForSdk(input);
+
+    expect(converted).not.toBe(input);
+    const filePart = converted[0].parts.find((part) => part.type === "file");
+    expect(filePart).toBeDefined();
+    if (filePart?.type === "file") {
+      expect(filePart.mediaType).toBe("image/png");
+      expect(filePart.url).toBe(base64);
+    }
+  });
+
+  it("returns the original array when there are no data URI file parts", () => {
+    const input: MuxMessage[] = [
+      {
+        id: "u2",
+        role: "user",
+        parts: [
+          { type: "text", text: "look" },
+          { type: "file", mediaType: "image/png", url: "https://example.com/image.png" },
+        ],
+      },
+    ];
+
+    const converted = convertDataUriFilePartsForSdk(input);
+    expect(converted).toBe(input);
+  });
+
+  it("does not rewrite assistant messages", () => {
+    const base64 = Buffer.from("assistant", "utf8").toString("base64");
+    const input: MuxMessage[] = [
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [{ type: "file", mediaType: "image/png", url: `data:image/png;base64,${base64}` }],
+      },
+    ];
+
+    const converted = convertDataUriFilePartsForSdk(input);
+    expect(converted).toBe(input);
+  });
+
+  it("converts multiple user file parts and keeps non-data URLs unchanged", () => {
+    const pngBase64 = Buffer.from("png", "utf8").toString("base64");
+    const pdfBase64 = Buffer.from("pdf", "utf8").toString("base64");
+
+    const input: MuxMessage[] = [
+      {
+        id: "u3",
+        role: "user",
+        parts: [
+          { type: "text", text: "files" },
+          { type: "file", mediaType: "image/png", url: `data:image/png;base64,${pngBase64}` },
+          {
+            type: "file",
+            mediaType: "application/pdf",
+            url: `data:application/pdf;base64,${pdfBase64}`,
+          },
+          { type: "file", mediaType: "image/jpeg", url: "https://example.com/photo.jpg" },
+        ],
+      },
+    ];
+
+    const converted = convertDataUriFilePartsForSdk(input);
+    const convertedFileParts = converted[0].parts.filter((part) => part.type === "file");
+
+    expect(convertedFileParts).toHaveLength(3);
+    expect(convertedFileParts[0].url).toBe(pngBase64);
+    expect(convertedFileParts[1].url).toBe(pdfBase64);
+    expect(convertedFileParts[2].url).toBe("https://example.com/photo.jpg");
+  });
+
+  it("converts URL-encoded SVG data URIs to base64", () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><text>hello</text></svg>';
+    const encodedSvg = encodeURIComponent(svg);
+
+    const input: MuxMessage[] = [
+      {
+        id: "u4",
+        role: "user",
+        parts: [
+          {
+            type: "file",
+            mediaType: "image/svg+xml",
+            url: `data:image/svg+xml,${encodedSvg}`,
+          },
+        ],
+      },
+    ];
+
+    const converted = convertDataUriFilePartsForSdk(input);
+    const filePart = converted[0].parts[0];
+
+    expect(filePart.type).toBe("file");
+    if (filePart.type === "file") {
+      expect(filePart.mediaType).toBe("image/svg+xml");
+      expect(filePart.url).toBe(Buffer.from(svg, "utf8").toString("base64"));
+    }
+  });
+
+  it("throws for malformed data URIs missing a comma separator", () => {
+    const input: MuxMessage[] = [
+      {
+        id: "u5",
+        role: "user",
+        parts: [
+          {
+            type: "file",
+            mediaType: "image/png",
+            url: "data:image/png;base64not-a-valid-data-url",
+          },
+        ],
+      },
+    ];
+
+    expect(() => convertDataUriFilePartsForSdk(input)).toThrow(
+      "Malformed data URI in file part: missing comma"
+    );
+  });
+});

--- a/src/node/utils/messages/convertDataUriFilePartsForSdk.ts
+++ b/src/node/utils/messages/convertDataUriFilePartsForSdk.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert";
+import type { MuxMessage } from "@/common/types/message";
+
+const DATA_URI_PREFIX = "data:";
+
+interface ParsedDataUri {
+  mediaType?: string;
+  base64Data: string;
+}
+
+function parseDataUriToBase64(dataUri: string): ParsedDataUri {
+  assert(dataUri.toLowerCase().startsWith(DATA_URI_PREFIX), "Expected a data URI file part");
+
+  const commaIndex = dataUri.indexOf(",");
+  assert(commaIndex !== -1, "Malformed data URI in file part: missing comma");
+
+  const metadata = dataUri.slice(DATA_URI_PREFIX.length, commaIndex);
+  const payload = dataUri.slice(commaIndex + 1);
+
+  const metadataTokens = metadata
+    .split(";")
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0);
+
+  const mediaType = metadataTokens.find((token) => token.includes("/"));
+  const hasBase64Flag = metadataTokens.some((token) => token.toLowerCase() === "base64");
+
+  if (hasBase64Flag) {
+    return {
+      mediaType,
+      base64Data: payload,
+    };
+  }
+
+  let decodedPayload: string;
+  try {
+    decodedPayload = decodeURIComponent(payload);
+  } catch (error) {
+    assert.fail(
+      `Malformed data URI in file part: invalid URL encoding (${error instanceof Error ? error.message : String(error)})`
+    );
+  }
+
+  return {
+    mediaType,
+    base64Data: Buffer.from(decodedPayload, "utf8").toString("base64"),
+  };
+}
+
+/**
+ * Rewrites user file-part data URIs into raw base64 payloads in `url`.
+ *
+ * convertToModelMessages() maps FileUIPart.url -> FilePart.data. If url remains a data:
+ * URI string, downstream prompt prep can treat it as a URL and attempt to download it.
+ * Converting to raw base64 keeps the payload inline and avoids URL download validation.
+ */
+export function convertDataUriFilePartsForSdk(messages: MuxMessage[]): MuxMessage[] {
+  let changedAnyMessage = false;
+
+  const convertedMessages = messages.map((message) => {
+    if (message.role !== "user") {
+      return message;
+    }
+
+    let changedMessage = false;
+
+    const convertedParts: MuxMessage["parts"] = message.parts.map((part) => {
+      if (part.type !== "file" || !part.url.toLowerCase().startsWith(DATA_URI_PREFIX)) {
+        return part;
+      }
+
+      const { mediaType, base64Data } = parseDataUriToBase64(part.url);
+
+      changedMessage = true;
+      return {
+        ...part,
+        mediaType: mediaType ?? part.mediaType,
+        url: base64Data,
+      };
+    });
+
+    if (!changedMessage) {
+      return message;
+    }
+
+    changedAnyMessage = true;
+    return {
+      ...message,
+      parts: convertedParts,
+    };
+  });
+
+  return changedAnyMessage ? convertedMessages : messages;
+}


### PR DESCRIPTION
## Summary
Fixes provider-request handling for user file attachments so `data:` URIs are converted to inline base64 payloads before `convertToModelMessages`, preventing downstream URL-download validation failures.

## Background
Recent SDK-side URL validation rejects non-HTTP(S) URLs during asset download planning. Our message pipeline forwarded `file.url` values that can contain `data:` URIs, which could be interpreted as URL inputs in downstream conversion.

## Implementation
- Added `convertDataUriFilePartsForSdk` to rewrite user `file` parts from `data:...` URLs to raw base64 payloads in request-time message data.
- Integrated the transform in `prepareMessagesForProvider` immediately before `convertToModelMessages`.
- Added focused unit tests for base64 URIs, URL-encoded data URIs, mixed attachments, and malformed data URIs.

## Validation
- `bun test src/node/utils/messages/convertDataUriFilePartsForSdk.test.ts`
- `make typecheck`
- `make static-check`

## Risks
Low risk: this is a request-time transform scoped to user `file` parts and does not alter persisted history or UI attachment rendering.

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix: "URL scheme must be http or https, got data:" — image attachments broken

## Context & Why

The Vercel AI SDK (`@ai-sdk/provider-utils@4.0.19`) introduced SSRF-protection validation in `validateDownloadUrl` that rejects any URL with a non-`http`/`https` scheme. Mux stores all image attachments (user-attached and tool-generated) as `data:` URIs in a `url` field on `MuxFilePart`. When `convertToModelMessages` processes these, the SDK parses the `data:` string as a URL and tries to "download" it, hitting the new validation.

**Impact:** All image attachments are broken — user screenshots, pasted images, Chrome tool screenshots, ACP images.

## Evidence

| Source | Finding |
|---|---|
| `@ai-sdk/provider-utils/dist/index.js` | `validateDownloadUrl` throws `"URL scheme must be http or https, got ${parsed.protocol}"` |
| `@ai-sdk/provider-utils/dist/index.d.ts` | SDK `FilePart` expects `data: DataContent \| URL` (not `url: string`) |
| `src/common/orpc/schemas/message.ts:7-11` | Mux `FilePartSchema` has `url: z.string()` — stores data URIs |
| `src/node/services/messagePipeline.ts:168` | `convertToModelMessages(messagesWithToolMediaExtracted as any, ...)` — the boundary where the mismatch hits |
| `src/node/utils/messages/extractToolMediaAsUserMessages.ts:148` | Tool images create `url: \`data:${mediaType};base64,...\`` |
| `src/node/acp/agent.ts:2347,2358` | ACP images also use `url: \`data:...\`` |

The SDK's correct inline format: `{ type: "file", data: "raw_base64_string", mediaType: "image/png" }` — raw base64 without the `data:` prefix, in a `data` field.

## Approach: Transform at the SDK boundary

Add a transform step in `messagePipeline.ts` that converts `data:` URIs in file parts to the SDK's expected `{ data, mediaType }` format, immediately before calling `convertToModelMessages`.

**Why this approach over changing Mux's internal schema:**
- Minimal blast radius — Mux's internal `MuxFilePart` format (`url` field with data URIs) continues working for storage, IPC, and UI display
- Single choke-point fix — all file parts flow through `prepareMessagesForProvider`
- No schema migration needed for persisted `chat.jsonl` history
- Defensive assertions in `agentSession.ts` (line 1881) already validate `url.startsWith("data:")` — no changes needed there

**~40 net LoC** (utility function + pipeline integration + tests)

## Implementation

### 1. New utility: `convertDataUriFilePartsForSdk`

**File:** `src/node/utils/messages/convertDataUriFileParts.ts` (~25 LoC)

Parse data URIs and rewrite `{ url: "data:mime;base64,..." }` → `{ data: "raw_base64", mediaType: "mime" }`.

```typescript
import type { MuxMessage } from "@/common/types/message";
import assert from "node:assert";

/**
 * Rewrites file parts that use data: URIs into the AI SDK's expected format
 * (raw base64 in `data` field) so the SDK doesn't attempt to "download" them.
 *
 * @ai-sdk/provider-utils@4.0.19 added SSRF validation that rejects data: URLs.
 * This transform runs immediately before convertToModelMessages.
 */
export function convertDataUriFilePartsForSdk(messages: MuxMessage[]): MuxMessage[] {
  return messages.map((msg) => {
    if (msg.role !== "user" || !Array.isArray(msg.parts)) return msg;

    let changed = false;
    const newParts = msg.parts.map((part) => {
      if (part.type !== "file" || !part.url.startsWith("data:")) return part;

      const commaIdx = part.url.indexOf(",");
      assert(commaIdx !== -1, `Malformed data URI in file part: missing comma`);

      const header = part.url.slice(0, commaIdx); // "data:image/png;base64"
      const rawBase64 = part.url.slice(commaIdx + 1);

      // Extract mediaType from the data URI header (more reliable than part.mediaType
      // if they ever diverge).
      const mediaType = header.slice("data:".length).replace(";base64", "").trim();

      changed = true;
      return {
        ...part,
        // Replace `url` with `data` — the field the AI SDK actually reads for inline content.
        url: undefined,
        data: rawBase64,
        mediaType: mediaType || part.mediaType,
      };
    });

    return changed ? { ...msg, parts: newParts } : msg;
  });
}
```

### 2. Integrate into pipeline

**File:** `src/node/services/messagePipeline.ts`

Insert the transform between `extractToolMediaAsUserMessages` and `convertToModelMessages`:

```typescript
// At top — add import:
import { convertDataUriFilePartsForSdk } from "@/node/utils/messages/convertDataUriFileParts";

// ...

// After line 162 (extractToolMediaAsUserMessages), before convertToModelMessages:
const messagesWithSdkFileParts = convertDataUriFilePartsForSdk(messagesWithToolMediaExtracted);

// Update line 168 to use the new variable:
const rawModelMessages = await convertToModelMessages(messagesWithSdkFileParts as any, {
  ignoreIncompleteToolCalls: true,
});
```

### 3. Tests

**File:** `src/node/utils/messages/convertDataUriFileParts.test.ts`

Cover:
- User message with data URI file part → rewritten to `{ data, mediaType }`, `url` removed
- User message with no file parts → passed through unchanged
- Assistant/tool messages → passed through unchanged
- Multiple file parts in one message (mix of images + PDFs)
- SVG data URIs (`data:image/svg+xml,...` without `;base64`)
- Malformed data URI (missing comma) → assertion throws

### 4. Verify `mergeConsecutiveUserMessages` compatibility

**File:** `src/browser/utils/messages/modelMessageTransform.ts:1068-1074`

This function filters for `c.type === "file"` on `ModelMessage` content parts (post-SDK-conversion). Since the SDK's `convertToModelMessages` will produce `ModelMessage` file parts with `type: "file"` regardless of whether the input used `url` or `data`, **no changes are needed here**. The merger operates on the SDK's output format, not Mux's input format.

## Files changed (summary)

| File | Change |
|---|---|
| `src/node/utils/messages/convertDataUriFileParts.ts` | **New** — data URI → SDK format transform |
| `src/node/utils/messages/convertDataUriFileParts.test.ts` | **New** — unit tests |
| `src/node/services/messagePipeline.ts` | Add import + one transform step (3 lines) |

## Not changed (and why)

| File | Why unchanged |
|---|---|
| `src/common/orpc/schemas/message.ts` | Internal `MuxFilePart` schema stays as-is; data URIs are fine for IPC/storage/UI |
| `src/browser/utils/attachmentsHandling.ts` | Frontend continues producing data URIs for display |
| `src/node/utils/messages/extractToolMediaAsUserMessages.ts` | Continues producing data URIs; the pipeline transform handles conversion |
| `src/node/acp/agent.ts` | Same — pipeline transform handles it |
| `src/node/services/agentSession.ts` | Defensive assertions (`url.startsWith("data:")`) remain valid |

</details>

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.3-codex` • Thinking: `xhigh` • Cost: `$4.61`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=xhigh costs=4.61 -->
