### PR TITLE
🤖 tests: colocate AnalyticsDashboard story

### DIFF
--- a/src/browser/features/Analytics/AnalyticsDashboard.stories.tsx
+++ b/src/browser/features/Analytics/AnalyticsDashboard.stories.tsx
@@ -18,7 +18,7 @@ import { lightweightMeta } from "@/browser/stories/meta.js";
 import { createWorkspace, groupWorkspacesByProject } from "@/browser/stories/mockFactory";
 import { createMockORPCClient } from "@/browser/stories/mocks/orpc";
 import assert from "@/common/utils/assert";
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { waitFor, within } from "@storybook/test";
 import React from "react";
 import { AnalyticsDashboard } from "./AnalyticsDashboard.js";
@@ -951,7 +951,9 @@ function AnalyticsDashboardStory() {
         <ProjectProvider>
           <AnalyticsDashboard
             leftSidebarCollapsed={false}
-            onToggleLeftSidebarCollapsed={() => {}}
+            onToggleLeftSidebarCollapsed={() => {
+              /* noop */
+            }}
           />
         </ProjectProvider>
       </RouterProvider>


### PR DESCRIPTION
## Summary

Relocates the analytics dashboard story from the centralized `src/browser/stories/` directory to be colocated with its component at `src/browser/features/Analytics/AnalyticsDashboard.stories.tsx`. The story now renders `AnalyticsDashboard` directly with minimal context providers instead of booting the entire App shell and navigating via titlebar click.

## Background

The old `App.analytics.stories.tsx` wrapped the analytics dashboard inside `AppWithMocks`, rendering the full App shell and navigating to the analytics page via a play-function click on the titlebar button. This was heavyweight — it tested the navigation path more than the dashboard itself and made the story slow to render.

## Implementation

- **New story** uses `lightweightMeta` (Theme + Tooltip only) instead of `appMeta` (full App shell)
- **Minimal context tree**: `APIProvider` → `RouterProvider` → `ProjectProvider` → `AnalyticsDashboard`
- **No navigation step**: Dashboard renders directly — removed `openAnalyticsDashboard` helper
- **No workspace preselection**: Removed `selectWorkspace()` call (dashboard doesn't depend on it)
- **All ~800 lines of mock data and assertions preserved** verbatim — same fixtures, same play-function checks
- **Removed imports**: `appMeta`, `AppWithMocks`, `AppStory`, `selectWorkspace`, `userEvent`
- **Story title**: `"Analytics/AnalyticsDashboard"` (was `"App/Analytics"`)

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$3.13`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=3.13 -->
