### PR TITLE
🤖 fix: hide desktop immersive review button on mobile

### DIFF
--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
@@ -567,7 +567,7 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
               onOpenTouchFullscreenReview={
                 isTouchMobileScreen ? handleOpenTouchFullscreenReview : null
               }
-              onEnterImmersiveReview={handleEnterImmersiveReview}
+              onEnterImmersiveReview={isTouchMobileScreen ? null : handleEnterImmersiveReview}
               onForkChat={(anchorEl) => {
                 void handleForkChat(anchorEl);
               }}


### PR DESCRIPTION
## Summary

Hide the desktop "Immersive review" button on mobile touch screens. The workspace header menu was rendering both the mobile-specific and desktop review buttons on mobile — now only the mobile one appears.

## Implementation

Gate the `onEnterImmersiveReview` prop with the existing `isTouchMobileScreen` check, matching the pattern already used for `onOpenTouchFullscreenReview`.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$0.79`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=0.79 -->
