### PR TITLE
🤖 fix: workaround katex@0.16.34 ESM __VERSION__ crash in check-docs-links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -521,7 +521,7 @@ check-docs-links: ## Check documentation for broken links
 	@echo "🔗 Checking documentation links..."
 	# Workaround: katex@0.16.34 ships broken ESM with unreplaced __VERSION__ placeholder.
 	# Remove this NODE_OPTIONS prefix once katex publishes a fixed build.
-	@cd docs && NODE_OPTIONS='--import data:text/javascript,globalThis.__VERSION__=%220.16.34%22' bun x mintlify broken-links
+	@cd docs && NODE_OPTIONS="$${NODE_OPTIONS:+$$NODE_OPTIONS }--import data:text/javascript,globalThis.__VERSION__=%220.16.34%22" bun x mintlify broken-links
 
 check-code-docs-links: ## Validate code references to docs paths
 	@./scripts/check-code-docs-links.sh


### PR DESCRIPTION
## Summary

Fix `make check-docs-links` crash caused by katex@0.16.34 shipping broken ESM with an unreplaced `__VERSION__` build-time placeholder.

## Background

`bun x mintlify broken-links` transitively loads katex@0.16.34, which contains `const version = __VERSION__;` in its ESM build. Since the placeholder was never replaced at build time, this throws a `ReferenceError` at runtime under Node.js. Versions 0.16.29–0.16.34 are automated npm-only publishes with this incomplete build.

## Implementation

Use `NODE_OPTIONS='--import data:...'` to define `globalThis.__VERSION__` before any module loads. The mintlify process runs under Node.js (even via `bun x`), so `NODE_OPTIONS` is honoured. Harmless to remove once katex publishes a fixed build.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$1.47`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=1.47 -->
