### PR TITLE
🤖 fix: reduce chat input fade overlap

### DIFF
--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -920,12 +920,15 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
                   runtimeConfig={runtimeConfig}
                 />
               </div>
-              {/* Sticky gradient fades content into the input area. Lives inside the
-                  scroll container so it never overlaps the browser-painted scrollbar. */}
+              {/*
+                Sticky gradient fades content into the input area while staying shallow
+                enough not to wash over the streaming status/token line above the input.
+                Lives inside the scroll container so it never overlaps the browser-painted scrollbar.
+              */}
               <div
                 aria-hidden="true"
                 className="from-surface-primary pointer-events-none sticky bottom-[-15px]
-                  mx-[-15px] mt-[-2rem] mb-[-15px] h-8 bg-linear-to-t to-transparent"
+                  mx-[-15px] mt-[-1.5rem] mb-[-15px] h-6 bg-linear-to-t to-transparent"
               />
             </div>
             <PositionedMenu


### PR DESCRIPTION
## Summary

Reduce the sticky fade above the workspace chat input so it no longer overlaps the streaming status/token line.

## Background

A recent UI update added a shadow/fade above the ChatInput, but the fade was tall enough to wash over the live streaming indicator directly above it.

## Implementation

- reduced the sticky fade height from `h-8` to `h-6`
- reduced the paired negative top margin from `-2rem` to `-1.5rem`
- documented why the fade should stay shallow in `ChatPane.tsx`

## Validation

- `make static-check`

## Risks

Low risk and isolated to the chat pane footer fade styling in the workspace view.

---

_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=xhigh costs=0.00 -->
