### PR TITLE
🤖 fix: remove chat input fade

### DIFF
--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -920,16 +920,6 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
                   runtimeConfig={runtimeConfig}
                 />
               </div>
-              {/*
-                Sticky gradient fades content into the input area while staying shallow
-                enough not to wash over the streaming status/token line above the input.
-                Lives inside the scroll container so it never overlaps the browser-painted scrollbar.
-              */}
-              <div
-                aria-hidden="true"
-                className="from-surface-primary pointer-events-none sticky bottom-[-15px]
-                  mx-[-15px] mt-[-1.5rem] mb-[-15px] h-6 bg-linear-to-t to-transparent"
-              />
             </div>
             <PositionedMenu
               open={transcriptMenu.isOpen}


### PR DESCRIPTION
## Summary

Remove the sticky fade gradient above the workspace chat input so the footer no longer needs to account for its visual overlap edge cases.

## Background

We previously narrowed the gradient to avoid covering the streaming status/token line, but there were still too many edge cases around the chat input footer. Removing the fade entirely keeps the footer predictable.

## Implementation

- removed the sticky gradient block above the workspace chat input in `ChatPane.tsx`
- left the surrounding chat pane layout unchanged so this PR only drops the decorative fade

## Validation

- `make static-check`

## Risks

Low risk and isolated to the workspace chat pane presentation. The visible change is that message content now ends cleanly above the input without the fade treatment.

---

_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=xhigh costs=0.00 -->
