### PR TITLE
🤖 fix: tighten chat input banner spacing

### DIFF
--- a/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.tsx
+++ b/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.tsx
@@ -80,7 +80,7 @@ export const BackgroundProcessesBanner: React.FC<BackgroundProcessesBannerProps>
           <button
             type="button"
             onClick={handleToggle}
-            className="group mx-auto flex w-full max-w-4xl items-center gap-2 px-2 py-1 text-xs transition-colors"
+            className="group mx-auto flex w-full max-w-4xl items-center gap-2 px-2 py-1.5 text-xs transition-colors"
           >
             <Terminal className="text-muted group-hover:text-secondary size-3.5 transition-colors" />
             <span className="text-muted group-hover:text-secondary transition-colors">

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -1019,7 +1019,11 @@ const ChatInputPane: React.FC<ChatInputPaneProps> = (props) => {
   const { reviews } = props;
 
   return (
-    <>
+    <div className="flex flex-col gap-2">
+      {/*
+        Keep optional banners/warnings on one shared stack so spacing above the chat input
+        stays consistent as background bash, review, and queue UI appear or disappear.
+      */}
       {props.shouldShowCompactionWarning && (
         <CompactionWarning
           usagePercentage={props.autoCompactionResult.usagePercentage}
@@ -1044,7 +1048,7 @@ const ChatInputPane: React.FC<ChatInputPaneProps> = (props) => {
         />
       )}
       {props.isQueuedAgentTask && (
-        <div className="border-border-medium bg-background-secondary text-muted mb-2 rounded-md border px-3 py-2 text-xs">
+        <div className="border-border-medium bg-background-secondary text-muted rounded-md border px-3 py-2 text-xs">
           This agent task is queued and will start automatically when a parallel slot is available.
         </div>
       )}
@@ -1077,6 +1081,6 @@ const ChatInputPane: React.FC<ChatInputPaneProps> = (props) => {
         onDeleteReview={reviews.removeReview}
         onUpdateReviewNote={reviews.updateReviewNote}
       />
-    </>
+    </div>
   );
 };

--- a/src/browser/components/CompactionWarning/CompactionWarning.tsx
+++ b/src/browser/components/CompactionWarning/CompactionWarning.tsx
@@ -44,7 +44,7 @@ export const CompactionWarning: React.FC<{
 
   return (
     <div
-      className={`mx-4 mt-2 mb-1 text-right text-[10px] ${
+      className={`mx-4 text-right text-[10px] ${
         isUrgent ? "text-plan-mode font-semibold" : "text-muted"
       }`}
     >

--- a/src/browser/components/ContextSwitchWarning/ContextSwitchWarning.tsx
+++ b/src/browser/components/ContextSwitchWarning/ContextSwitchWarning.tsx
@@ -27,7 +27,7 @@ export const ContextSwitchWarning: React.FC<Props> = (props) => {
   return (
     <div
       data-testid="context-switch-warning"
-      className="bg-background-secondary border-plan-mode mx-4 my-2 rounded-md border px-4 py-3"
+      className="bg-background-secondary border-plan-mode mx-4 rounded-md border px-4 py-3"
     >
       <div className="flex items-start justify-between gap-3">
         <div className="flex-1">

--- a/src/browser/components/ReviewsBanner/ReviewsBanner.tsx
+++ b/src/browser/components/ReviewsBanner/ReviewsBanner.tsx
@@ -379,7 +379,7 @@ const ReviewsBannerInner: React.FC<ReviewsBannerInnerProps> = ({ workspaceId }) 
       <button
         type="button"
         onClick={handleToggle}
-        className="group mx-auto flex w-full max-w-4xl items-center gap-2 px-2 py-1 text-xs transition-colors"
+        className="group mx-auto flex w-full max-w-4xl items-center gap-2 px-2 py-1.5 text-xs transition-colors"
       >
         <MessageSquare
           className={cn(

--- a/src/browser/features/Messages/QueuedMessage.tsx
+++ b/src/browser/features/Messages/QueuedMessage.tsx
@@ -62,7 +62,7 @@ export const QueuedMessage: React.FC<QueuedMessageProps> = ({
       <button
         type="button"
         onClick={handleToggle}
-        className="group mx-auto flex w-full max-w-4xl items-center gap-2 px-2 py-1 text-xs transition-colors"
+        className="group mx-auto flex w-full max-w-4xl items-center gap-2 px-2 py-1.5 text-xs transition-colors"
       >
         <Send className="text-muted group-hover:text-secondary size-3.5 transition-colors" />
         <span className="text-muted group-hover:text-secondary transition-colors">


### PR DESCRIPTION
## Summary

Tighten the spacing for optional UI that appears above the workspace chat input so banners and warnings feel more deliberate after removing the input fade.

## Background

After removing the decorative fade above the chat input, the optional UI above it still had inconsistent spacing. Some elements brought their own outer margins, while others sat flush against the input, which made states like the background bash banner feel cramped.

## Implementation

- put the optional chat-input-adjacent UI on a shared vertical stack in `ChatPane.tsx`
- removed one-off outer margins from compaction/context-switch warnings so the stack controls spacing consistently
- slightly increased collapsed banner padding for background bash, reviews, and queued-message rows

## Validation

- `make static-check`

## Risks

Low risk and isolated to workspace chat pane presentation. The main change is layout rhythm for optional banners/warnings above the input.

---

_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=xhigh costs=0.00 -->
