### PR TITLE
🤖 fix: stop reusing OpenAI previous response ids

### DIFF
--- a/src/browser/utils/messages/modelMessageTransform.test.ts
+++ b/src/browser/utils/messages/modelMessageTransform.test.ts
@@ -786,7 +786,7 @@ describe("modelMessageTransform", () => {
   });
 
   describe("reasoning part handling for OpenAI", () => {
-    it("should preserve reasoning parts for OpenAI provider (managed via previousResponseId)", () => {
+    it("should preserve reasoning parts for OpenAI provider (managed via explicit history)", () => {
       const messages: ModelMessage[] = [
         {
           role: "user",

--- a/src/browser/utils/messages/modelMessageTransform.ts
+++ b/src/browser/utils/messages/modelMessageTransform.ts
@@ -1200,7 +1200,7 @@ function ensureAnthropicThinkingBeforeToolCalls(messages: ModelMessage[]): Model
  * 2. Drop orphaned tool calls/results (self-healing)
  * 3. Coalesce consecutive no-progress `task_await` polls - all providers
  * 4. Filter reasoning-only messages:
- *    - OpenAI: Keep reasoning parts (managed via previousResponseId), filter reasoning-only messages
+ *    - OpenAI: Keep reasoning parts in explicit history, filter reasoning-only messages
  *    - Anthropic: Filter out reasoning-only messages (API rejects them)
  * 5. Merge consecutive user messages - all providers
  *
@@ -1232,7 +1232,8 @@ export function transformModelMessages(
   // Pass 4: Provider-specific reasoning handling
   let reasoningHandled: ModelMessage[];
   if (provider === "openai") {
-    // OpenAI: Keep reasoning parts - managed via previousResponseId
+    // OpenAI: Keep reasoning parts in explicit history so later turns can
+    // preserve reasoning context without chaining previous_response_id.
     // Only filter out reasoning-only messages (messages with no text/tool-call content)
     reasoningHandled = filterReasoningOnlyMessages(taskAwaitCoalesced);
   } else if (provider === "anthropic") {

--- a/src/common/utils/ai/providerOptions.test.ts
+++ b/src/common/utils/ai/providerOptions.test.ts
@@ -484,19 +484,19 @@ describe("buildProviderOptions - OpenAI", () => {
     });
   });
 
-  describe("previousResponseId reuse", () => {
-    test("should reuse previousResponseId for gateway OpenAI history", () => {
+  describe("OpenAI conversation state management", () => {
+    test("does not reuse previousResponseId when Mux already sends explicit GPT-5.4 history", () => {
       const messages = [
         createMuxMessage("assistant-1", "assistant", "", {
-          model: "mux-gateway:openai/gpt-5.2",
+          model: "mux-gateway:openai/gpt-5.4",
           providerMetadata: { openai: { responseId: "resp_123" } },
         }),
       ];
-      const result = buildProviderOptions("mux-gateway:openai/gpt-5.2", "medium", messages);
+      const result = buildProviderOptions("mux-gateway:openai/gpt-5.4", "medium", messages);
       const openai = getOpenAIOptions(result);
 
       expect(openai).toBeDefined();
-      expect(openai!.previousResponseId).toBe("resp_123");
+      expect(openai!.previousResponseId).toBeUndefined();
     });
   });
   describe("wireFormat gating", () => {

--- a/src/common/utils/ai/providerOptions.ts
+++ b/src/common/utils/ai/providerOptions.ts
@@ -65,12 +65,12 @@ function supportsOpenAIReasoningSummary(modelName: string): boolean {
  * 1. Enable reasoning traces (transparency into model's thought process)
  * 2. Set reasoning level (control depth of reasoning based on task complexity)
  * 3. Enable parallel tool calls (allow concurrent tool execution)
- * 4. Extract previousResponseId for OpenAI persistence (when available)
+ * 4. Keep provider-specific request knobs consistent with Mux's explicit history model
  *
  * @param modelString - Full model string (e.g., "anthropic:claude-opus-4-1")
  * @param thinkingLevel - Unified thinking level (must be pre-clamped via enforceThinkingPolicy)
- * @param messages - Conversation history to extract previousResponseId from
- * @param lostResponseIds - Optional callback to check if a responseId has been invalidated by OpenAI
+ * @param messages - Conversation history being sent to the provider
+ * @param _lostResponseIds - Reserved for OpenAI response-state recovery filtering
  * @param muxProviderOptions - Optional provider overrides from config
  * @param workspaceId - Optional for non-OpenAI providers
  * @param openaiTruncationMode - Optional truncation mode for OpenAI responses (auto/disabled)
@@ -81,7 +81,7 @@ export function buildProviderOptions(
   modelString: string,
   thinkingLevel: ThinkingLevel,
   messages?: MuxMessage[],
-  lostResponseIds?: (id: string) => boolean,
+  _lostResponseIds?: (id: string) => boolean,
   muxProviderOptions?: MuxProviderOptions,
   workspaceId?: string, // Optional for non-OpenAI providers
   openaiTruncationMode?: OpenAIResponsesProviderOptions["truncation"],
@@ -95,7 +95,7 @@ export function buildProviderOptions(
   const [provider, modelName] = normalizedModel.split(":", 2);
 
   // Resolve aliases to their base model for capability detection while keeping
-  // the original modelString for provider routing and previousResponseId lookups.
+  // the original modelString for provider routing and metadata lookups.
   const capabilityModel = resolveModelForMetadata(normalizedModel, providersConfig ?? null);
   const [, resolvedCapabilityModelName] = capabilityModel.split(":", 2);
   const capModelName = resolvedCapabilityModelName || modelName;
@@ -188,58 +188,10 @@ export function buildProviderOptions(
   if (provider === "openai") {
     const reasoningEffort = OPENAI_REASONING_EFFORT[effectiveThinking];
 
-    // Extract previousResponseId from last assistant message for persistence
-    // IMPORTANT: Only use previousResponseId if:
-    // 1. The previous message used the same model (prevents cross-model contamination)
-    // 2. That model uses reasoning (reasoning effort is set)
-    // 3. The response ID exists
-    // 4. The response ID hasn't been invalidated by OpenAI
-    let previousResponseId: string | undefined;
-    if (messages && messages.length > 0 && reasoningEffort) {
-      // Parse current model name (without provider prefix), normalize gateway format if needed
-      const currentModelName = normalizeGatewayModel(modelString).split(":")[1];
-
-      // Find last assistant message from the same model
-      for (let i = messages.length - 1; i >= 0; i--) {
-        const msg = messages[i];
-        if (msg.role === "assistant") {
-          // Check if this message is from the same model
-          const msgModel = msg.metadata?.model;
-          const msgModelName = msgModel ? normalizeGatewayModel(msgModel).split(":")[1] : undefined;
-
-          if (msgModelName === currentModelName) {
-            const metadata = msg.metadata?.providerMetadata;
-            if (metadata && "openai" in metadata) {
-              const openaiData = metadata.openai as Record<string, unknown> | undefined;
-              previousResponseId = openaiData?.responseId as string | undefined;
-            }
-            if (previousResponseId) {
-              // Check if this responseId has been invalidated by OpenAI
-              if (lostResponseIds?.(previousResponseId)) {
-                log.info("buildProviderOptions: Filtering out lost previousResponseId", {
-                  previousResponseId,
-                  model: currentModelName,
-                });
-                previousResponseId = undefined;
-              } else {
-                log.debug("buildProviderOptions: Found previousResponseId from same model", {
-                  previousResponseId,
-                  model: currentModelName,
-                });
-              }
-              break;
-            }
-          } else if (msgModelName) {
-            // Found assistant message from different model, stop searching
-            log.debug("buildProviderOptions: Skipping previousResponseId - model changed", {
-              previousModel: msgModelName,
-              currentModel: currentModelName,
-            });
-            break;
-          }
-        }
-      }
-    }
+    // Mux always sends the latest conversation history explicitly. OpenAI's
+    // previous_response_id is an alternative state-management path, not an additive one.
+    // Chaining it on top of explicit history double-counts prior turns and caused GPT-5.4
+    // requests to hit context_exceeded far below the documented native window.
 
     // Prompt cache key: derive from workspaceId
     // This helps OpenAI route requests to cached prefixes for improved hit rates
@@ -257,7 +209,7 @@ export function buildProviderOptions(
       reasoningEffort,
       shouldSendReasoningSummary,
       thinkingLevel: effectiveThinking,
-      previousResponseId,
+      historyMessages: messages?.length ?? 0,
       promptCacheKey,
       truncation: truncationMode,
       wireFormat,
@@ -289,9 +241,6 @@ export function buildProviderOptions(
             include: ["reasoning.encrypted_content"],
           }),
         }),
-        // Include previousResponseId for conversation persistence
-        // OpenAI uses this to maintain reasoning state across turns
-        ...(isResponses && previousResponseId && { previousResponseId }),
       },
     };
     log.info("buildProviderOptions: Returning OpenAI options", options);

--- a/src/node/services/aiService.test.ts
+++ b/src/node/services/aiService.test.ts
@@ -1395,7 +1395,7 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
     ]);
 
     const openaiOptions = openAIOptionsFromStartStreamCall(startStreamCall);
-    expect(openaiOptions.previousResponseId).toBe("resp_before_malformed");
+    expect(openaiOptions.previousResponseId).toBeUndefined();
     expect(openaiOptions.promptCacheKey).toBe(`mux-v1-${workspaceId}`);
   });
 });

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -712,10 +712,10 @@ export class AIService extends EventEmitter {
       }
       log.debug_obj(`${workspaceId}/1b_provider_request_messages.json`, providerRequestMessages);
 
-      // OpenAI-specific: Keep reasoning parts in history
-      // OpenAI manages conversation state via previousResponseId
+      // OpenAI-specific: Keep reasoning parts in history so each request can
+      // carry forward reasoning context without relying on previous_response_id.
       if (canonicalProviderName === "openai") {
-        log.debug("Keeping reasoning parts for OpenAI (managed via previousResponseId)");
+        log.debug("Keeping reasoning parts for OpenAI (managed via explicit history)");
       }
       // Add [CONTINUE] sentinel to partial messages (for model context)
       const messagesWithSentinel = addInterruptedSentinel(providerRequestMessages);
@@ -1126,8 +1126,7 @@ export class AIService extends EventEmitter {
       // Build provider options based on thinking level and request-sliced message history.
       const truncationMode = openaiTruncationModeOverride;
       // Use the same boundary-sliced payload history that we send to the provider.
-      // This prevents previousResponseId lookup from reaching pre-compaction epochs.
-      // Also pass callback to filter out lost responseIds (OpenAI invalidated them).
+      // This keeps OpenAI request state aligned with the explicit history Mux sends.
       // Pass workspaceId to derive stable promptCacheKey for OpenAI caching.
       const providerOptions = buildProviderOptions(
         modelString,

--- a/src/node/services/providerModelFactory.ts
+++ b/src/node/services/providerModelFactory.ts
@@ -1099,7 +1099,8 @@ export class ProviderModelFactory {
           // The preconnect method is optional in our implementation but required by the SDK type.
           fetch: providerFetch,
         });
-        // OpenAI manages reasoning state via previousResponseId - no middleware needed
+        // OpenAI reasoning state is preserved via explicit history, so no extra
+        // middleware is needed beyond the provider's standard Responses handling.
         const model =
           effectiveWireFormat === "chatCompletions"
             ? provider.chat(modelId)

--- a/tests/ipc/providers/openaiPreviousResponseIdRecovery.test.ts
+++ b/tests/ipc/providers/openaiPreviousResponseIdRecovery.test.ts
@@ -1,8 +1,8 @@
 /**
- * OpenAI previousResponseId recovery integration test.
+ * OpenAI response-id metadata integration test.
  *
- * This simulates a corrupted previousResponseId and verifies the runtime
- * retries the request without it so the first request succeeds.
+ * This seeds stale responseId metadata in history and verifies the runtime still
+ * succeeds because Mux now sends OpenAI conversation state via explicit history.
  */
 
 import { randomBytes } from "crypto";
@@ -32,11 +32,11 @@ function createInvalidResponseId(): string {
   return `resp_${randomBytes(12).toString("hex")}`;
 }
 
-describeIntegration("OpenAI previousResponseId recovery", () => {
+describeIntegration("OpenAI response-id metadata", () => {
   configureTestRetries(3);
 
   test.concurrent(
-    "recovers from invalid previousResponseId on the first request",
+    "ignores stale previousResponseId metadata on the first request",
     async () => {
       const { env, workspaceId, cleanup } = await setupWorkspace("openai");
 
@@ -45,7 +45,7 @@ describeIntegration("OpenAI previousResponseId recovery", () => {
         const summaryMessage = createMuxMessage(
           `summary-${Date.now()}`,
           "assistant",
-          "Summary placeholder for previousResponseId recovery.",
+          "Summary placeholder for stale responseId metadata.",
           {
             timestamp: Date.now(),
             model: OPENAI_MODEL,


### PR DESCRIPTION
## Summary

Stop attaching OpenAI `previousResponseId` when Mux already sends the full conversation history explicitly. This keeps GPT-5.4 request state aligned with the explicit payload history, updates the related tests/comments, and avoids premature `context_exceeded` failures from double-counting prior turns.

## Background

GPT-5.4 chats were hitting `context_exceeded` around ~230k input tokens and then falling into the existing context-exceeded compaction path. The root cause was that Mux was preserving OpenAI reasoning parts in explicit history while also chaining `previous_response_id`, which made the OpenAI Responses request state additive instead of alternative.

## Implementation

- Remove `previousResponseId` extraction/reuse from `buildProviderOptions()` for OpenAI requests.
- Keep prompt cache keys, truncation controls, and reasoning-encrypted content handling unchanged.
- Update OpenAI request-path tests to assert that explicit GPT-5.4 history does **not** reuse stale response IDs.
- Refresh comments in the model transform and AI service layers so they describe explicit-history reasoning preservation instead of `previousResponseId` chaining.
- Keep the lower-level stream recovery path for externally-supplied invalid `previousResponseId` values intact.

## Validation

- `make static-check`
- `bun test src/common/utils/ai/providerOptions.test.ts`
- `bun test src/browser/utils/messages/modelMessageTransform.test.ts`
- `bun test src/node/services/aiService.test.ts`
- `env TEST_INTEGRATION=1 bun x jest tests/ipc/providers/openaiPreviousResponseIdRecovery.test.ts --runInBand`
- One-time live GPT-5.4 large-context verification via temporary IPC integration test:
  - seeded ~300k estimated history tokens after a real GPT-5.4 seed turn
  - final request completed with `inputTokens: 240263`
  - response text was `PASS`
  - emitted `0` `auto-compaction-triggered` events

## Risks

Low to moderate for OpenAI Responses requests only. This intentionally changes how OpenAI conversation state is carried between turns, but the change is narrowly scoped to removing `previousResponseId` reuse when Mux already sends explicit history. The defensive stream-level recovery logic remains available if some other path still supplies an invalid response ID.

---

_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `xhigh` • Cost: `$8.16`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=xhigh costs=8.16 -->
