### PR TITLE
🤖 ci: move macOS workflows to GitHub-hosted runners

### DIFF
--- a/.github/workflows/_desktop-release.yml
+++ b/.github/workflows/_desktop-release.yml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       contents: write # Upload release assets
     env:
+      NODE_OPTIONS: --max-old-space-size=4096
       RELEASE_TAG: ${{ inputs.release_tag }}
       VERSION_OVERRIDE: ${{ inputs.version_override }}
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -269,6 +269,8 @@ jobs:
           ELECTRON_DISABLE_SANDBOX: 1
       - name: Run tests
         if: matrix.os == 'macos'
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
         run: make test-e2e PLAYWRIGHT_ARGS="tests/e2e/scenarios/windowLifecycle.spec.ts"
 
   test-windows:
@@ -397,6 +399,8 @@ jobs:
     needs: [changes]
     if: ${{ needs.changes.outputs.src == 'true' || needs.changes.outputs.config == 'true' }}
     runs-on: macos-15
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:


### PR DESCRIPTION
Summary
This PR moves the repository's macOS GitHub Actions jobs off Depot onto GitHub-hosted runners and adds a 4 GB Node heap override for the GitHub-hosted macOS E2E/build paths so renderer-heavy Vite builds do not OOM.

Background
Depot macOS capacity is under heavy load for this repo, so we want the macOS PR and release jobs off Depot without changing non-macOS workflows. After the initial runner swap, the GitHub-hosted macOS E2E job OOMed during the renderer build path, so the macOS-only workflows also need an explicit Node heap override.

Implementation
- use `macos-latest` for the `test-e2e` macOS matrix entry in `.github/workflows/pr.yml`
- use `macos-15` for the PR `build-macos` job in `.github/workflows/pr.yml`
- use `macos-15` for the reusable desktop release `build-macos` job in `.github/workflows/_desktop-release.yml`
- add `NODE_OPTIONS=--max-old-space-size=4096` to the macOS-only E2E and macOS build workflows so GitHub-hosted macOS runners keep enough heap for the Vite renderer build/package path

Validation
- `make lint-actions`
- `nix shell nixpkgs#hadolint --command make static-check`
- PR CI surfaced the original macOS E2E OOM, which this follow-up addresses before re-running the gates

Risks
Low. The diff is limited to macOS workflow runner selection and macOS-only Node heap settings. The next green GitHub Actions run is the main runtime confirmation.

---

<details>
<summary>📋 Implementation Plan</summary>

# Switch macOS GitHub Actions jobs from Depot to GitHub-hosted runners

## Context / Why
Depot.dev is under heavy load on this repo's macOS capacity. The requested change is to stop using Depot **only for macOS jobs** while leaving Linux and Windows runner selection unchanged.

## Evidence
- User request: move macOS GitHub pipelines to GitHub-hosted runners only.
- `.github/workflows/pr.yml:241-253` — `test-e2e` uses a Linux/macOS matrix; only the macOS entry points at `depot-macos-latest`, while Linux stays on Depot-backed Ubuntu.
- `.github/workflows/pr.yml:395-415` — PR `build-macos` currently uses `depot-macos-15` for the `coder` repo.
- `.github/workflows/_desktop-release.yml:20-23` — reusable `build-macos` also uses `depot-macos-15`; `nightly.yml:109-121` and `release.yml:44-54` call this reusable workflow, so changing it updates both release paths without touching Linux/Windows jobs.
- Official GitHub Actions runner docs were checked to confirm GitHub-hosted macOS labels are available, including `macos-latest` and `macos-15`.

## Recommended approach — direct runner-label swap _(net LoC: ~0; three one-line YAML edits)_
1. **PR E2E workflow:** in `.github/workflows/pr.yml`, replace the macOS matrix runner expression with a direct `macos-latest` label.
2. **PR macOS build job:** in `.github/workflows/pr.yml`, replace the `build-macos` runner expression with `macos-15` so the job stays on the same major macOS version it already targets today, just on GitHub-hosted infrastructure.
3. **Reusable desktop release workflow:** in `.github/workflows/_desktop-release.yml`, replace the macOS build runner expression with `macos-15` for the same reason. No caller changes should be needed in `nightly.yml` or `release.yml`.
4. **Do not touch** any Linux Depot labels or the existing Windows GitHub-hosted jobs.

```yaml
# .github/workflows/pr.yml
strategy:
  matrix:
    include:
      - os: linux
        runner: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-16' || 'ubuntu-latest' }}
      - os: macos
        runner: macos-latest
...
build-macos:
  runs-on: macos-15
```

```yaml
# .github/workflows/_desktop-release.yml
build-macos:
  runs-on: macos-15
```

<details>
<summary>Why not use <code>macos-latest</code> everywhere?</summary>

That would also remove Depot, but it would silently change the build/release jobs from the currently explicit macOS 15 intent (`depot-macos-15`) to whatever GitHub maps `macos-latest` to over time. Keeping `macos-latest` for the E2E matrix entry and `macos-15` for build/release is the smallest change that preserves the repo's current macOS version split.
</details>

## Validation
- Run `make lint-actions` to catch workflow syntax/security issues (`actionlint` + `zizmor`).
- Run `make fmt-check` if the YAML formatter/linter is part of the normal local validation flow for workflow edits.
- Inspect the final diff to confirm only the three macOS runner lines changed and that all Linux/Windows labels remained untouched.

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.4` • Thinking: `xhigh` • Cost: `$0.92`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=xhigh costs=0.92 -->
