### PR TITLE
🤖 feat: add dashboard save action for chat analytics results

### DIFF
--- a/src/browser/features/Tools/analyticsQuery/AnalyticsQueryToolCall.test.tsx
+++ b/src/browser/features/Tools/analyticsQuery/AnalyticsQueryToolCall.test.tsx
@@ -44,16 +44,17 @@ const saveMock = mock((_input: SaveInput) => {
 });
 
 const navigateToAnalyticsMock = mock(() => undefined);
+const useSavedQueriesMock = mock((_options?: { skipLoad?: boolean }) => ({
+  queries: [],
+  loading: false,
+  save: saveMock,
+  update: () => Promise.resolve(null),
+  remove: () => Promise.resolve(undefined),
+  refresh: () => Promise.resolve(undefined),
+}));
 
 void mock.module("@/browser/hooks/useAnalytics", () => ({
-  useSavedQueries: () => ({
-    queries: [],
-    loading: false,
-    save: saveMock,
-    update: () => Promise.resolve(null),
-    remove: () => Promise.resolve(undefined),
-    refresh: () => Promise.resolve(undefined),
-  }),
+  useSavedQueries: useSavedQueriesMock,
 }));
 
 void mock.module("@/browser/contexts/RouterContext", () => ({
@@ -127,6 +128,7 @@ describe("AnalyticsQueryToolCall", () => {
     };
     saveMock.mockClear();
     navigateToAnalyticsMock.mockClear();
+    useSavedQueriesMock.mockClear();
   });
 
   afterEach(() => {
@@ -151,6 +153,18 @@ describe("AnalyticsQueryToolCall", () => {
     );
 
     expect(view.getByText("Spend by model")).toBeTruthy();
+  });
+
+  test("opts into the save-only saved-query hook path", () => {
+    renderWithTooltip(
+      <AnalyticsQueryToolCall
+        args={{ sql: "SELECT model, total_cost_usd FROM events" }}
+        result={createSuccessResult()}
+        status="completed"
+      />
+    );
+
+    expect(useSavedQueriesMock).toHaveBeenCalledWith({ skipLoad: true });
   });
 
   test("displays row count and query duration", () => {

--- a/src/browser/features/Tools/analyticsQuery/AnalyticsQueryToolCall.tsx
+++ b/src/browser/features/Tools/analyticsQuery/AnalyticsQueryToolCall.tsx
@@ -94,7 +94,8 @@ function escapeDoubleQuotes(value: string): string {
 
 export function AnalyticsQueryToolCall(props: AnalyticsQueryToolCallProps): JSX.Element {
   const { expanded, toggleExpanded } = useToolExpansion(true);
-  const { save } = useSavedQueries();
+  // Rationale: chat cards only use save(), so skip the saved-query preload until the user opts in.
+  const { save } = useSavedQueries({ skipLoad: true });
   const { navigateToAnalytics } = useRouter();
   const [chartTypeOverride, setChartTypeOverride] = useState<ChartType | null>(null);
   const [showSql, setShowSql] = useState(false);

--- a/src/browser/hooks/useAnalytics.test.tsx
+++ b/src/browser/hooks/useAnalytics.test.tsx
@@ -7,12 +7,14 @@ import type { RouterClient } from "@orpc/server";
 import type { AppRouter } from "@/node/orpc/router";
 import type { OrpcServer } from "@/node/orpc/server";
 import type { ORPCContext } from "@/node/orpc/context";
+import type { SavedQuery } from "@/common/types/savedQueries";
 import type { AnalyticsService } from "@/node/services/analytics/analyticsService";
 import {
   useAnalyticsProviderCacheHitRatio,
   useAnalyticsRawQuery,
   useAnalyticsSpendByModel,
   useAnalyticsSummary,
+  useSavedQueries,
   type Summary,
 } from "./useAnalytics";
 
@@ -26,6 +28,17 @@ const summaryFixture: Summary = {
   totalTokens: 4200,
   totalResponses: 84,
 };
+
+const savedQueriesFixture: SavedQuery[] = [
+  {
+    id: "saved-query-1",
+    label: "Saved query",
+    sql: "SELECT 1",
+    chartType: "table",
+    order: 0,
+    createdAt: "2026-03-06T00:00:00.000Z",
+  },
+];
 
 interface AnalyticsServiceCalls {
   summary: Array<{
@@ -52,6 +65,10 @@ void mock.module("@/browser/contexts/API", () => ({
   useAPI: () => ({ api: currentApiClient }),
 }));
 
+void mock.module("@/version", () => ({
+  VERSION: "test-version",
+}));
+
 function createHttpClient(baseUrl: string): RouterClient<AppRouter> {
   const link = new HTTPRPCLink({
     url: `${baseUrl}/orpc`,
@@ -59,6 +76,40 @@ function createHttpClient(baseUrl: string): RouterClient<AppRouter> {
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- typed test helper
   return createORPCClient(link) as RouterClient<AppRouter>;
+}
+
+function createFakeAnalyticsApiClient(
+  overrides: {
+    getSavedQueries?: () => Promise<{ queries: SavedQuery[] }>;
+  } = {}
+): RouterClient<AppRouter> {
+  // Regression guard: getAnalyticsNamespace validates a full analytics namespace before exposing
+  // saved-query helpers, so this fake includes the required surface even though these tests only
+  // exercise getSavedQueries.
+  const analyticsNamespace = {
+    getSummary: () => Promise.resolve(summaryFixture),
+    getSpendOverTime: () => Promise.resolve([]),
+    getSpendByProject: () => Promise.resolve([]),
+    getSpendByModel: () => Promise.resolve([]),
+    getTokensByModel: () => Promise.resolve([]),
+    getTimingDistribution: () => Promise.resolve({ p50: 0, p90: 0, p99: 0, histogram: [] }),
+    getAgentCostBreakdown: () => Promise.resolve([]),
+    getCacheHitRatioByProvider: () => Promise.resolve([]),
+    getDelegationSummary: () =>
+      Promise.resolve({
+        totalChildren: 0,
+        totalTokensConsumed: 0,
+        totalReportTokens: 0,
+        compressionRatio: 0,
+        totalCostDelegated: 0,
+        byAgentType: [],
+      }),
+    ...overrides,
+  };
+
+  return {
+    analytics: analyticsNamespace,
+  } as unknown as RouterClient<AppRouter>;
 }
 
 type AnalyticsServiceStub = Pick<
@@ -242,6 +293,37 @@ describe("useAnalytics hooks", () => {
     expect(latest.projectPath).toBe("/tmp/project");
     expect(latest.from.toISOString()).toBe(from.toISOString());
     expect(latest.to.toISOString()).toBe(to.toISOString());
+  });
+
+  test("useSavedQueries eagerly loads queries by default", async () => {
+    const getSavedQueriesMock = mock(() => Promise.resolve({ queries: savedQueriesFixture }));
+    currentApiClient = createFakeAnalyticsApiClient({ getSavedQueries: getSavedQueriesMock });
+
+    const { result } = renderHook(() => useSavedQueries());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(getSavedQueriesMock).toHaveBeenCalledTimes(1);
+    expect(result.current.queries).toEqual(savedQueriesFixture);
+  });
+
+  test("useSavedQueries skips the mount load when requested and can still refresh", async () => {
+    const getSavedQueriesMock = mock(() => Promise.resolve({ queries: savedQueriesFixture }));
+    currentApiClient = createFakeAnalyticsApiClient({ getSavedQueries: getSavedQueriesMock });
+
+    const { result } = renderHook(() => useSavedQueries({ skipLoad: true }));
+
+    expect(result.current.loading).toBe(false);
+    expect(getSavedQueriesMock).toHaveBeenCalledTimes(0);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(getSavedQueriesMock).toHaveBeenCalledTimes(1);
+    expect(result.current.queries).toEqual(savedQueriesFixture);
   });
 
   test("executeRawQuery surfaces backend error message instead of generic 500", async () => {

--- a/src/browser/hooks/useAnalytics.ts
+++ b/src/browser/hooks/useAnalytics.ts
@@ -479,18 +479,36 @@ async function loadSavedQueries(
   }
 }
 
-export function useSavedQueries() {
+interface UseSavedQueriesOptions {
+  // Rationale: chat analytics cards may only need save(), so skipping the mount load avoids
+  // one getSavedQueries IPC round-trip per card until the caller explicitly refreshes.
+  skipLoad?: boolean;
+}
+
+export function useSavedQueries(options: UseSavedQueriesOptions = {}) {
+  const skipLoadOption = options.skipLoad;
+  assert(
+    skipLoadOption == null || typeof skipLoadOption === "boolean",
+    "useSavedQueries skipLoad must be a boolean when provided"
+  );
+
+  const skipLoad = skipLoadOption ?? false;
   const { api } = useAPI();
   const [queries, setQueries] = useState<SavedQuery[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!skipLoad);
 
   const refresh = async () => {
     await loadSavedQueries(api, setQueries, setLoading);
   };
 
   useEffect(() => {
+    if (skipLoad) {
+      setLoading(false);
+      return;
+    }
+
     void loadSavedQueries(api, setQueries, setLoading);
-  }, [api]);
+  }, [api, skipLoad]);
 
   const save = async (input: { label: string; sql: string; chartType?: string | null }) => {
     if (!api) {


### PR DESCRIPTION
Summary
- Adds an "Add to analytics dashboard" action to successful chat analytics results so users can save the rendered title, SQL, and current chart selection without leaving chat.

Background
- Chat analytics results already expose the payload the dashboard needs, but users had to manually copy SQL into the dashboard to reuse a query.

Implementation
- Reuses the existing saved-query flow from the chat renderer, adds inline save states, and exposes an explicit Open dashboard follow-up action after a successful save.
- Resets stale saved state when the chart selection changes so users can deliberately save a new visualization choice.
- Adds focused UI coverage for save payloads, navigation behavior, error handling, unavailable analytics state, and saved-state reset on chart changes.

Validation
- `bun test src/browser/features/Tools/analyticsQuery/AnalyticsQueryToolCall.test.tsx`
- `bun x eslint src/browser/features/Tools/analyticsQuery/AnalyticsQueryToolCall.tsx src/browser/features/Tools/analyticsQuery/AnalyticsQueryToolCall.test.tsx`
- `make typecheck`
- `make static-check`

Risks
- Low risk: the change is scoped to the successful `analytics_query` tool renderer and reuses the existing dashboard saved-query path without schema or IPC changes.

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: add an “Add to analytics dashboard” shortcut from chat analytics results

## Context / Why
- Add an **“Add to analytics dashboard”** action to analytics results rendered inside workspace chat so the user can save the current result without manually copying SQL into the dashboard.
- The chat renderer already has the exact payload the dashboard needs:
  1. SQL from `props.args.sql`,
  2. label/title from `props.args.title ?? successResult?.title ?? "Query results"`,
  3. the **currently selected** chart type from `effectiveChartType`.
- The dashboard already persists reusable panels as saved queries, so the lowest-risk implementation is to reuse that path from the client.

## Evidence
- `src/browser/features/Tools/analyticsQuery/AnalyticsQueryToolCall.tsx`
  - Owns the successful chat analytics renderer and already computes `title`, `chartTypeOverride`, `effectiveChartType`, and the existing **Show SQL** affordance.
- `src/browser/hooks/useAnalytics.ts`
  - `useSavedQueries().save({ label, sql, chartType })` already exists and returns the saved query after refreshing dashboard state.
- `src/browser/features/Analytics/AnalyticsDashboard.tsx`
  - The dashboard already reads `savedQueries` from `useSavedQueries()` and renders them via `SavedQueryPanel`.
- `src/browser/features/Analytics/SavedQueryPanel.tsx`
  - Saved panels only need `label`, `sql`, and `chartType`; the dashboard re-runs the SQL and re-infers axes on load.
- `src/browser/contexts/RouterContext.tsx`
  - `navigateToAnalytics()` already exists for an optional post-save **Open dashboard** affordance.
- Existing coverage already exercises the persistence path:
  - `src/browser/features/Tools/analyticsQuery/AnalyticsQueryToolCall.test.tsx`
  - `src/node/services/analytics/savedQueries.test.ts`
  - `tests/ipc/savedQueries.test.ts`

## Scope assumptions
- Scope this to **`analytics_query` tool results rendered by `AnalyticsQueryToolCall`**. If product later wants non-SQL diagram renderers to save into the dashboard, that is a follow-up.
- Reuse the existing saved-query hook/API; **no new backend contract** is required for MVP.
- Save **in place** and keep the user in chat; offer an explicit **Open dashboard** action after success instead of auto-navigating.
- If the result has no agent-provided title, reuse the current fallback label and let the user rename later in the dashboard.

## Definition of done
- Successful analytics results in chat show an **Add to analytics dashboard** button.
- Clicking the button saves:
  - the exact SQL exposed by **Show SQL**,
  - the label currently rendered in the tool header,
  - the **current** chart selection (`effectiveChartType`), including user overrides.
- The user remains in chat after saving.
- A successful save exposes a clear confirmation and an optional **Open dashboard** action.
- Save failures and unavailable analytics state are shown inline and do not break the chart/table view.
- If the user changes chart type after saving, the local success state resets so they can save the new selection deliberately.
- New UI tests cover the button flow before implementation and still pass after refactoring.

## Recommended approach — reuse the existing saved-query flow directly from the chat renderer
**Net product LoC estimate:** **+70 to +110 LoC** (primarily `AnalyticsQueryToolCall.tsx`; backend/schema unchanged)

## Phase 1 — Red: add failing tests first
**Primary edit:** `src/browser/features/Tools/analyticsQuery/AnalyticsQueryToolCall.test.tsx`

Add test coverage that pins down the exact UX before touching production code.

Required test cases:
1. **renders the dashboard action for successful analytics results**
   - Successful `AnalyticsQueryResult` renders a visible **Add to analytics dashboard** button.
2. **saves the current chart selection, not just the backend hint**
   - Switch from the default chart type to another one (for example, Line).
   - Click **Add to analytics dashboard**.
   - Assert `save()` receives `{ label, sql, chartType: "line" }`.
3. **stays in chat after a successful save**
   - Mock a successful `save()`.
   - Assert the tool result remains rendered and `navigateToAnalytics()` is **not** called automatically.
4. **offers navigation only when the follow-up action is clicked**
   - After a successful save, click **Open dashboard**.
   - Assert `navigateToAnalytics()` fires only then.
5. **shows inline error and re-enables the CTA on failure**
   - Mock `save()` rejecting.
   - Assert an inline error appears and the primary action becomes usable again.
6. **resets saved state when the user changes chart type after saving**
   - Save once successfully.
   - Change chart type.
   - Assert the component no longer shows the stale saved state.
7. **handles unavailable analytics namespace gracefully**
   - Mock `save()` returning `null`.
   - Assert an inline unavailable-state message is shown.

Test harness notes:
- Mock `useSavedQueries()` and `useRouter()` directly; no backend changes are needed to define the behavior.
- Keep these as focused UI tests in the existing `AnalyticsQueryToolCall.test.tsx` file.

## Phase 2 — Green: implement the minimum production change
**Primary edit:** `src/browser/features/Tools/analyticsQuery/AnalyticsQueryToolCall.tsx`

Concrete implementation steps:
- Import `useSavedQueries()` and `useRouter()`.
- Add local save state, e.g. `idle | saving | saved | error`.
- Add a guarded `handleAddToDashboard()` that:
  - trims SQL/title,
  - calls `save({ label, sql, chartType: effectiveChartType })`,
  - sets inline success/error state.
- Add `canAddToDashboard` so the CTA only activates when the current result is saveable.
- Route chart-type selection through a tiny helper that also clears stale saved state.
- Render the CTA beside the existing **Show SQL** control.
- After success, render an **Open dashboard** follow-up action that calls `navigateToAnalytics()`.

Focused implementation shape:

```tsx
const { save } = useSavedQueries();
const { navigateToAnalytics } = useRouter();
const [dashboardSaveState, setDashboardSaveState] = useState<
  | { kind: "idle" }
  | { kind: "saving" }
  | { kind: "saved" }
  | { kind: "error"; message: string }
>({ kind: "idle" });

const canAddToDashboard =
  successResult !== null && props.args.sql.trim().length > 0 && title.trim().length > 0;

async function handleAddToDashboard() {
  if (!successResult) {
    return;
  }

  const normalizedSql = props.args.sql.trim();
  const normalizedTitle = title.trim();
  if (!normalizedSql || !normalizedTitle) {
    setDashboardSaveState({
      kind: "error",
      message: "This result is missing the SQL or title needed to save it.",
    });
    return;
  }

  setDashboardSaveState({ kind: "saving" });
  try {
    const saved = await save({
      label: normalizedTitle,
      sql: normalizedSql,
      chartType: effectiveChartType,
    });

    if (!saved) {
      setDashboardSaveState({
        kind: "error",
        message: "Analytics dashboard is unavailable in this build.",
      });
      return;
    }

    setDashboardSaveState({ kind: "saved" });
  } catch (error) {
    setDashboardSaveState({ kind: "error", message: getErrorMessage(error) });
  }
}
```

And for the chart-selection/reset behavior:

```tsx
const handleChartTypeSelect = (nextType: ChartType) => {
  setChartTypeOverride(nextType);
  setDashboardSaveState({ kind: "idle" });
};
```

Recommended action row:

```tsx
<div className="mt-2 flex flex-wrap items-center gap-2">
  <button
    type="button"
    onClick={() => setShowSql(!showSql)}
    className="text-muted hover:text-foreground text-[10px] transition-colors"
  >
    {showSql ? "Hide SQL" : "Show SQL"}
  </button>

  <Button
    variant="secondary"
    size="sm"
    disabled={!canAddToDashboard || dashboardSaveState.kind === "saving"}
    onClick={() => {
      void handleAddToDashboard();
    }}
    className="h-7 px-2.5 text-[11px]"
  >
    {dashboardSaveState.kind === "saving" ? "Adding…" : "Add to analytics dashboard"}
  </Button>

  {dashboardSaveState.kind === "saved" && (
    <Button variant="ghost" size="sm" onClick={navigateToAnalytics} className="h-7 px-2 text-[11px]">
      Open dashboard
    </Button>
  )}
</div>
```

Implementation guardrails:
- Do **not** add a new save dialog for MVP.
- Do **not** auto-navigate on save.
- Do **not** change saved-query schema or dashboard data flow.
- Do **not** add crash-on-user-state assertions here; malformed tool data should degrade gracefully in the renderer.

## Phase 3 — Refactor: simplify after tests pass
**Mandatory refactor checkpoint**

Once the Red tests pass with the smallest working implementation, do one cleanup pass.

Refactor targets:
- If `AnalyticsQueryToolCall.tsx` gets noisy, extract tiny local helpers such as:
  - `buildDashboardSaveInput()`
  - `resetDashboardSaveState()`
- Keep those helpers local unless the same logic is repeated elsewhere.
- Only extract shared chart-type constants/normalizers if the exact duplication now crosses the “rule of three”; otherwise keep the current local structure and avoid a wrong abstraction.
- Re-check naming so the save state reads clearly (`dashboardSaveState`, `handleAddToDashboard`, `canAddToDashboard`).

The refactor phase is complete only if:
- all new tests still pass,
- the component remains easy to scan,
- no extra feature scope was added.

## Phase 4 — Verification
### Automated
- Run the targeted UI test file for the touched renderer.
- Run the most relevant type-level/static validation for the touched codepath.
- Re-run any analytics saved-query tests only if the implementation unexpectedly touches shared save helpers or types.

### Manual
1. In a workspace chat, run an analytics query that renders a result card.
2. Switch to a non-default chart type.
3. Click **Add to analytics dashboard**.
4. Confirm the card stays in chat and shows success.
5. Click **Open dashboard** and verify a new saved panel appears with:
   - the same title,
   - the same SQL,
   - the chosen chart type.
6. Return to chat, change chart type again, and confirm the CTA resets instead of showing stale success.
7. Verify a failed save path shows inline error without breaking **Show SQL** or the current chart/table.

<details>
<summary>Alternative considered (not recommended for MVP): route into Analytics with a prefilled draft instead of saving immediately</summary>

**Net product LoC estimate:** **+140 to +220 LoC**

This would navigate to `/analytics`, prefill `SqlExplorer`, and still require the user to finish the save there.

Why it is weaker for this request:
- It keeps the manual “finish the workflow” step.
- It introduces transient draft plumbing that the current dashboard does not need.
- It is strictly more work than calling the existing `saveQuery` path directly from chat.
</details>

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `xhigh` • Cost: `$4.02`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=xhigh costs=4.02 -->
