### PR TITLE
🤖 feat: add saved analytics panel SQL editor

### DIFF
--- a/src/browser/features/Analytics/SavedQueryPanel.test.tsx
+++ b/src/browser/features/Analytics/SavedQueryPanel.test.tsx
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { GlobalWindow } from "happy-dom";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
+import type { SavedQuery } from "@/common/types/savedQueries";
+
+const executeQueryMock = mock(() => Promise.resolve());
+const useAnalyticsRawQueryMock = mock(() => ({
+  data: null,
+  loading: false,
+  error: null,
+  executeQuery: executeQueryMock,
+}));
+
+void mock.module("@/browser/hooks/useAnalytics", () => ({
+  useAnalyticsRawQuery: useAnalyticsRawQueryMock,
+}));
+
+void mock.module("./SavedQuerySqlDialog", () => ({
+  SavedQuerySqlDialog: (props: {
+    open: boolean;
+    label: string;
+    sql: string;
+    saveDisabled: boolean;
+    error: string | null;
+    onSqlChange: (nextSql: string) => void;
+    onOpenChange: (open: boolean) => void;
+    onSave: () => void;
+  }) =>
+    props.open ? (
+      <div>
+        <h2>{`Edit SQL — ${props.label}`}</h2>
+        <textarea aria-label="Saved query SQL" readOnly value={props.sql} />
+        {props.error ? <div>{props.error}</div> : null}
+        <button type="button" onClick={() => props.onSqlChange("\n  SELECT 1;  \n")}>
+          Use valid SQL
+        </button>
+        <button type="button" onClick={() => props.onSqlChange("   ")}>
+          Use blank SQL
+        </button>
+        <button type="button" onClick={() => props.onSqlChange("SELECT broken FROM events")}>
+          Use broken SQL
+        </button>
+        <button type="button" onClick={() => props.onOpenChange(false)}>
+          Cancel
+        </button>
+        <button type="button" onClick={props.onSave}>
+          Submit via keyboard
+        </button>
+        <button type="button" disabled={props.saveDisabled} onClick={props.onSave}>
+          Save
+        </button>
+      </div>
+    ) : null,
+}));
+
+import { SavedQueryPanel } from "./SavedQueryPanel";
+
+function createSavedQuery(overrides: Partial<SavedQuery> = {}): SavedQuery {
+  return {
+    id: "saved-query-1",
+    label: "Spend by model",
+    sql: "SELECT model, sum(total_cost_usd) AS total_cost_usd\nFROM events\nGROUP BY model",
+    chartType: "table",
+    order: 0,
+    createdAt: "2026-03-06T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function renderPanel(
+  overrides: Partial<{
+    query: SavedQuery;
+    onDelete: (id: string) => Promise<void> | void;
+    onUpdate: (input: {
+      id: string;
+      label?: string;
+      sql?: string;
+      chartType?: string | null;
+    }) => Promise<unknown> | void;
+  }> = {}
+) {
+  const query = overrides.query ?? createSavedQuery();
+  const onDelete = overrides.onDelete ?? mock(() => Promise.resolve());
+  const onUpdate = overrides.onUpdate ?? mock(() => Promise.resolve(null));
+
+  const view = render(
+    <TooltipProvider>
+      <SavedQueryPanel query={query} onDelete={onDelete} onUpdate={onUpdate} />
+    </TooltipProvider>
+  );
+
+  return { ...view, query, onDelete, onUpdate };
+}
+
+describe("SavedQueryPanel", () => {
+  let originalWindow: typeof globalThis.window;
+  let originalDocument: typeof globalThis.document;
+
+  beforeEach(() => {
+    originalWindow = globalThis.window;
+    originalDocument = globalThis.document;
+
+    globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
+    globalThis.document = globalThis.window.document;
+
+    executeQueryMock.mockClear();
+    useAnalyticsRawQueryMock.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.window = originalWindow;
+    globalThis.document = originalDocument;
+  });
+
+  test("renders a panel-level SQL button and opens the dialog with the saved SQL", () => {
+    const view = renderPanel();
+
+    const openSqlDialogButton = view.getByRole("button", { name: "View or edit SQL" });
+    fireEvent.click(openSqlDialogButton);
+
+    const sqlInput = view.getByRole("textbox", { name: "Saved query SQL" }) as HTMLTextAreaElement;
+    expect(sqlInput.value).toBe(view.query.sql);
+    const saveButton = view.getByRole("button", { name: "Save" }) as HTMLButtonElement;
+    expect(saveButton.disabled).toBe(true);
+  });
+
+  test("trims edited SQL and saves it through onUpdate", async () => {
+    const onUpdate = mock(() => Promise.resolve(null));
+    const view = renderPanel({ onUpdate });
+
+    fireEvent.click(view.getByRole("button", { name: "View or edit SQL" }));
+    fireEvent.click(view.getByRole("button", { name: "Use valid SQL" }));
+
+    const saveButton = view.getByRole("button", { name: "Save" }) as HTMLButtonElement;
+    await waitFor(() => expect(saveButton.disabled).toBe(false));
+    fireEvent.click(saveButton);
+
+    await waitFor(() =>
+      expect(onUpdate).toHaveBeenCalledWith({ id: view.query.id, sql: "SELECT 1;" })
+    );
+    await waitFor(() =>
+      expect(view.queryByRole("textbox", { name: "Saved query SQL" })).toBeNull()
+    );
+  });
+
+  test("shows an inline validation error when keyboard-save is attempted with blank SQL", async () => {
+    const onUpdate = mock(() => Promise.resolve(null));
+    const view = renderPanel({ onUpdate });
+
+    fireEvent.click(view.getByRole("button", { name: "View or edit SQL" }));
+    fireEvent.click(view.getByRole("button", { name: "Use blank SQL" }));
+    fireEvent.click(view.getByRole("button", { name: "Submit via keyboard" }));
+
+    await waitFor(() => expect(view.getByText("SQL cannot be empty.")).toBeTruthy());
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  test("shows an inline error instead of crashing when a saved panel id is blank", async () => {
+    const onUpdate = mock(() => Promise.resolve(null));
+    const view = renderPanel({ query: createSavedQuery({ id: "   " }), onUpdate });
+
+    fireEvent.click(view.getByRole("button", { name: "View or edit SQL" }));
+    fireEvent.click(view.getByRole("button", { name: "Use valid SQL" }));
+    fireEvent.click(view.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(
+        view.getByText("This saved panel is missing its ID and cannot be updated.")
+      ).toBeTruthy()
+    );
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  test("keeps the dialog open and shows the backend error when saving fails", async () => {
+    const onUpdate = mock(() => Promise.reject(new Error("DuckDB parse error")));
+    const view = renderPanel({ onUpdate });
+
+    fireEvent.click(view.getByRole("button", { name: "View or edit SQL" }));
+    fireEvent.click(view.getByRole("button", { name: "Use broken SQL" }));
+
+    const saveButton = view.getByRole("button", { name: "Save" }) as HTMLButtonElement;
+    await waitFor(() => expect(saveButton.disabled).toBe(false));
+    fireEvent.click(saveButton);
+
+    await waitFor(() => expect(view.getByText("DuckDB parse error")).toBeTruthy());
+    expect(view.getByRole("textbox", { name: "Saved query SQL" })).toBeTruthy();
+  });
+
+  test("cancelling discards unsaved SQL edits before the next open", () => {
+    const view = renderPanel();
+
+    fireEvent.click(view.getByRole("button", { name: "View or edit SQL" }));
+    fireEvent.click(view.getByRole("button", { name: "Use broken SQL" }));
+    fireEvent.click(view.getByRole("button", { name: "Cancel" }));
+
+    expect(view.queryByRole("textbox", { name: "Saved query SQL" })).toBeNull();
+
+    fireEvent.click(view.getByRole("button", { name: "View or edit SQL" }));
+    const reopenedSqlInput = view.getByRole("textbox", {
+      name: "Saved query SQL",
+    }) as HTMLTextAreaElement;
+    expect(reopenedSqlInput.value).toBe(view.query.sql);
+  });
+});

--- a/src/browser/features/Analytics/SavedQueryPanel.tsx
+++ b/src/browser/features/Analytics/SavedQueryPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { AlertTriangle, Check, RefreshCw, Trash2, X } from "lucide-react";
+import { AlertTriangle, Check, Code, RefreshCw, Trash2, X } from "lucide-react";
 import { Button } from "@/browser/components/Button/Button";
 import { Skeleton } from "@/browser/components/Skeleton/Skeleton";
 import { useAnalyticsRawQuery } from "@/browser/hooks/useAnalytics";
@@ -11,6 +11,7 @@ import { cn } from "@/common/lib/utils";
 import type { SavedQuery } from "@/common/types/savedQueries";
 import { getErrorMessage } from "@/common/utils/errors";
 import { ChartTypePicker } from "./ChartTypePicker";
+import { SavedQuerySqlDialog } from "./SavedQuerySqlDialog";
 
 interface SavedQueryPanelProps {
   query: SavedQuery;
@@ -145,7 +146,15 @@ function EditableLabel(props: EditableLabelProps) {
 export function SavedQueryPanel(props: SavedQueryPanelProps) {
   const { data, loading, error, executeQuery } = useAnalyticsRawQuery();
   const [actionError, setActionError] = useState<string | null>(null);
+  const [isSqlDialogOpen, setIsSqlDialogOpen] = useState(false);
+  const [draftSql, setDraftSql] = useState(props.query.sql);
+  const [sqlDialogError, setSqlDialogError] = useState<string | null>(null);
+  const [savingSql, setSavingSql] = useState(false);
   const executeQueryRef = useRef(executeQuery);
+  const normalizedSavedSql = props.query.sql.trim();
+  const normalizedDraftSql = draftSql.trim();
+  const saveSqlDisabled =
+    savingSql || normalizedDraftSql.length === 0 || normalizedDraftSql === normalizedSavedSql;
 
   useEffect(() => {
     executeQueryRef.current = executeQuery;
@@ -164,6 +173,22 @@ export function SavedQueryPanel(props: SavedQueryPanelProps) {
   const explicitChartType = normalizeChartType(props.query.chartType);
   const effectiveChartType = explicitChartType ?? inferredChartType;
   const axes = data ? inferAxes(data.columns) : { xAxis: "", yAxes: [] };
+
+  const openSqlDialog = () => {
+    setDraftSql(props.query.sql);
+    setSqlDialogError(null);
+    setIsSqlDialogOpen(true);
+  };
+
+  const closeSqlDialog = () => {
+    if (savingSql) {
+      return;
+    }
+
+    setDraftSql(props.query.sql);
+    setSqlDialogError(null);
+    setIsSqlDialogOpen(false);
+  };
 
   const handleRefresh = () => {
     if (loading) {
@@ -205,11 +230,50 @@ export function SavedQueryPanel(props: SavedQueryPanelProps) {
     }
   };
 
+  const handleSaveSql = async () => {
+    const normalizedSavedQueryId = props.query.id.trim();
+
+    if (!normalizedSavedQueryId) {
+      setSqlDialogError("This saved panel is missing its ID and cannot be updated.");
+      return;
+    }
+
+    if (!normalizedDraftSql) {
+      setSqlDialogError("SQL cannot be empty.");
+      return;
+    }
+
+    if (normalizedDraftSql === normalizedSavedSql) {
+      closeSqlDialog();
+      return;
+    }
+
+    setSavingSql(true);
+    setSqlDialogError(null);
+    try {
+      await props.onUpdate({ id: normalizedSavedQueryId, sql: normalizedDraftSql });
+      closeSqlDialog();
+    } catch (updateError) {
+      setSqlDialogError(getErrorMessage(updateError));
+    } finally {
+      setSavingSql(false);
+    }
+  };
+
   return (
     <div className="bg-background-secondary border-border-medium rounded-lg border p-4">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <EditableLabel label={props.query.label} onCommit={handleRename} />
         <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={openSqlDialog}
+            aria-label="View or edit SQL"
+            className="text-muted hover:text-foreground h-7 w-7"
+          >
+            <Code className="size-3.5" />
+          </Button>
           <Button
             variant="ghost"
             size="icon"
@@ -282,6 +346,27 @@ export function SavedQueryPanel(props: SavedQueryPanelProps) {
       ) : (
         <p className="text-muted mt-3 text-xs">Run the saved query to view results.</p>
       )}
+
+      <SavedQuerySqlDialog
+        open={isSqlDialogOpen}
+        label={props.query.label}
+        sql={draftSql}
+        saving={savingSql}
+        saveDisabled={saveSqlDisabled}
+        error={sqlDialogError}
+        onSqlChange={setDraftSql}
+        onOpenChange={(open) => {
+          if (open) {
+            openSqlDialog();
+            return;
+          }
+
+          closeSqlDialog();
+        }}
+        onSave={() => {
+          void handleSaveSql();
+        }}
+      />
     </div>
   );
 }

--- a/src/browser/features/Analytics/SavedQuerySqlDialog.test.tsx
+++ b/src/browser/features/Analytics/SavedQuerySqlDialog.test.tsx
@@ -1,0 +1,80 @@
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { GlobalWindow } from "happy-dom";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+void mock.module("@/browser/components/Dialog/Dialog", () => ({
+  Dialog: (props: { open: boolean; children: ReactNode }) =>
+    props.open ? <div>{props.children}</div> : null,
+  DialogContent: (props: { children: ReactNode }) => <div>{props.children}</div>,
+  DialogHeader: (props: { children: ReactNode }) => <div>{props.children}</div>,
+  DialogTitle: (props: { children: ReactNode }) => <h2>{props.children}</h2>,
+  DialogDescription: (props: { children: ReactNode }) => <p>{props.children}</p>,
+  DialogFooter: (props: { children: ReactNode }) => <div>{props.children}</div>,
+}));
+
+import { SavedQuerySqlDialog } from "./SavedQuerySqlDialog";
+
+function renderDialog(overrides: Partial<React.ComponentProps<typeof SavedQuerySqlDialog>> = {}) {
+  const onSave = overrides.onSave ?? mock(() => undefined);
+  const onOpenChange = overrides.onOpenChange ?? mock(() => undefined);
+  const onSqlChange = overrides.onSqlChange ?? mock(() => undefined);
+
+  const view = render(
+    <SavedQuerySqlDialog
+      open
+      label="Saved panel"
+      sql="SELECT 1"
+      saving={false}
+      saveDisabled={false}
+      error={null}
+      onSqlChange={onSqlChange}
+      onOpenChange={onOpenChange}
+      onSave={onSave}
+      {...overrides}
+    />
+  );
+
+  return { ...view, onSave, onOpenChange, onSqlChange };
+}
+
+describe("SavedQuerySqlDialog", () => {
+  let originalWindow: typeof globalThis.window;
+  let originalDocument: typeof globalThis.document;
+
+  beforeEach(() => {
+    originalWindow = globalThis.window;
+    originalDocument = globalThis.document;
+
+    globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
+    globalThis.document = globalThis.window.document;
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.window = originalWindow;
+    globalThis.document = originalDocument;
+  });
+
+  test("does not trigger keyboard save while saving is disabled", () => {
+    const view = renderDialog({ saveDisabled: true });
+
+    fireEvent.keyDown(view.getByRole("textbox", { name: "Saved query SQL" }), {
+      key: "Enter",
+      ctrlKey: true,
+    });
+
+    expect(view.onSave).not.toHaveBeenCalled();
+  });
+
+  test("triggers keyboard save when saving is enabled", () => {
+    const view = renderDialog();
+
+    fireEvent.keyDown(view.getByRole("textbox", { name: "Saved query SQL" }), {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    expect(view.onSave).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/browser/features/Analytics/SavedQuerySqlDialog.tsx
+++ b/src/browser/features/Analytics/SavedQuerySqlDialog.tsx
@@ -1,0 +1,78 @@
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/browser/components/Button/Button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/browser/components/Dialog/Dialog";
+
+interface SavedQuerySqlDialogProps {
+  open: boolean;
+  label: string;
+  sql: string;
+  saving: boolean;
+  saveDisabled: boolean;
+  error: string | null;
+  onSqlChange: (nextSql: string) => void;
+  onOpenChange: (open: boolean) => void;
+  onSave: () => void;
+}
+
+export function SavedQuerySqlDialog(props: SavedQuerySqlDialogProps) {
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent maxWidth="900px" maxHeight="80vh" showCloseButton={!props.saving}>
+        <DialogHeader>
+          <DialogTitle>{`Edit SQL — ${props.label}`}</DialogTitle>
+          <DialogDescription>
+            Saving updates this panel and reruns it with the edited query.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-2">
+          <textarea
+            aria-label="Saved query SQL"
+            value={props.sql}
+            onChange={(event) => props.onSqlChange(event.target.value)}
+            spellCheck={false}
+            autoFocus
+            className="border-border-medium bg-background text-foreground focus:border-accent focus:ring-accent min-h-[220px] w-full resize-y rounded-lg border p-3 font-mono text-xs leading-relaxed focus:ring-1 focus:outline-none"
+            placeholder="SELECT * FROM events LIMIT 10;"
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+                event.preventDefault();
+                if (!props.saveDisabled) {
+                  props.onSave();
+                }
+              }
+            }}
+          />
+          <div className="text-muted text-[10px]">Ctrl/Cmd+Enter to save</div>
+        </div>
+
+        {props.error && (
+          <div className="border-danger-soft bg-danger-soft/10 text-danger flex items-start gap-2 rounded-lg border p-3 text-xs">
+            <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+            <div className="flex-1 font-mono whitespace-pre-wrap">{props.error}</div>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            variant="secondary"
+            onClick={() => props.onOpenChange(false)}
+            disabled={props.saving}
+          >
+            Cancel
+          </Button>
+          <Button onClick={props.onSave} disabled={props.saveDisabled}>
+            {props.saving ? "Saving..." : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/browser/hooks/useAnalytics.test.tsx
+++ b/src/browser/hooks/useAnalytics.test.tsx
@@ -81,11 +81,18 @@ function createHttpClient(baseUrl: string): RouterClient<AppRouter> {
 function createFakeAnalyticsApiClient(
   overrides: {
     getSavedQueries?: () => Promise<{ queries: SavedQuery[] }>;
+    updateSavedQuery?: (input: {
+      id: string;
+      label?: string;
+      sql?: string;
+      chartType?: string | null;
+      order?: number;
+    }) => Promise<SavedQuery>;
   } = {}
 ): RouterClient<AppRouter> {
   // Regression guard: getAnalyticsNamespace validates a full analytics namespace before exposing
   // saved-query helpers, so this fake includes the required surface even though these tests only
-  // exercise getSavedQueries.
+  // exercise saved-query loading/update flows.
   const analyticsNamespace = {
     getSummary: () => Promise.resolve(summaryFixture),
     getSpendOverTime: () => Promise.resolve([]),
@@ -324,6 +331,41 @@ describe("useAnalytics hooks", () => {
 
     expect(getSavedQueriesMock).toHaveBeenCalledTimes(1);
     expect(result.current.queries).toEqual(savedQueriesFixture);
+  });
+
+  test("useSavedQueries forwards SQL updates and refreshes the saved-query list", async () => {
+    const updatedQuery: SavedQuery = {
+      ...savedQueriesFixture[0],
+      sql: "SELECT 2",
+    };
+    let loadCount = 0;
+    const getSavedQueriesMock = mock(() => {
+      loadCount += 1;
+      return Promise.resolve({
+        queries: loadCount === 1 ? savedQueriesFixture : [updatedQuery],
+      });
+    });
+    const updateSavedQueryMock = mock(() => Promise.resolve(updatedQuery));
+    currentApiClient = createFakeAnalyticsApiClient({
+      getSavedQueries: getSavedQueriesMock,
+      updateSavedQuery: updateSavedQueryMock,
+    });
+
+    const { result } = renderHook(() => useSavedQueries());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.queries).toEqual(savedQueriesFixture);
+
+    await act(async () => {
+      await result.current.update({ id: updatedQuery.id, sql: updatedQuery.sql });
+    });
+
+    expect(updateSavedQueryMock).toHaveBeenCalledWith({
+      id: updatedQuery.id,
+      sql: updatedQuery.sql,
+    });
+    await waitFor(() => expect(getSavedQueriesMock).toHaveBeenCalledTimes(2));
+    expect(result.current.queries).toEqual([updatedQuery]);
   });
 
   test("executeRawQuery surfaces backend error message instead of generic 500", async () => {


### PR DESCRIPTION
Summary
- add a panel-level SQL editor action for saved analytics panels so users can inspect and update pinned queries without recreating the panel

Background
- saved analytics panels already persist their SQL, but the dashboard no longer exposed a way to inspect or modify it after pinning
- this change restores that workflow while keeping edits on the existing saved-query update path

Implementation
- add a focused SavedQuerySqlDialog component for editing saved query SQL with dialog-local validation, keyboard save support, and inline mutation errors
- wire SavedQueryPanel to open the dialog, trim SQL before save, assert persisted ids, and rely on the existing saved-query refresh flow to rerun panels after updates
- add regression tests for panel editing behavior and for useSavedQueries().update() refreshing after SQL updates

Validation
- `make static-check`
- `bun test src/browser/features/Analytics/SavedQueryPanel.test.tsx`
- `bun test src/browser/hooks/useAnalytics.test.tsx`

Risks
- low to medium: the change is scoped to saved analytics panels, but it touches panel-local state and dialog flows, so regressions would most likely affect saved-panel editing rather than the broader analytics dashboard

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: add a panel-level “View/Edit SQL” action for saved analytics panels

## Context / Why
Saved analytics panels already keep the underlying query in `SavedQuery.sql`, but the saved-panel UI no longer exposes any way to inspect or change that SQL after the panel is pinned. Today the panel chrome only supports rename, chart-type changes, refresh, and delete, so any SQL tweak effectively forces the user to recreate the panel from scratch. The goal is to add a clear panel-local affordance that lets the user open the query, edit it safely, save it through the existing saved-query update path, and immediately see the panel rerun with the new SQL.

## Evidence
- `src/browser/features/Analytics/SavedQueryPanel.tsx:145-287` renders the exact panel from the screenshot, owns the header action buttons, and already calls `props.onUpdate(...)` for label/chart-type changes while auto-running `props.query.sql` through `useAnalyticsRawQuery()`.
- `src/browser/features/Analytics/AnalyticsDashboard.tsx:318-330` maps each saved query into `SavedQueryPanel` and already passes `onUpdate={updateSavedQuery}` and `onDelete={removeSavedQuery}`; no parent wiring is missing.
- `src/common/types/savedQueries.ts:1-8` confirms every saved panel already carries `id`, `label`, `sql`, `chartType`, `order`, and `createdAt`.
- `src/browser/hooks/useAnalytics.ts:528-547` already exposes `update({ id, sql, ... })` and refreshes the saved-query list after a successful mutation.
- `src/common/orpc/schemas/analytics.ts:324-337` and `src/node/services/analytics/analyticsService.ts:532-585` already support `updateSavedQuery({ id, sql })`, with backend assertions for non-empty IDs/SQL.
- `src/browser/features/Analytics/SqlExplorer.tsx:151-202` contains the existing SQL textarea, keyboard handling, and alert styling that should be mirrored rather than reinvented.
- `src/browser/components/Dialog/Dialog.tsx:37-91` provides the standard modal shell and already stops Escape from leaking into global handlers.
- The nearest UI-test patterns are `src/browser/components/ShareTranscriptDialog/ShareTranscriptDialog.test.tsx:13-21` (mocking Dialog inline for happy-dom) and `src/browser/features/Tools/analyticsQuery/AnalyticsQueryToolCall.test.tsx:1-260` (analytics-result rendering patterns).

## Assumptions that keep the plan executable
- The request applies to **saved analytics panels** rendered by `SavedQueryPanel`, not to ad-hoc analytics tool-call cards or other chart surfaces elsewhere in the app.
- v1 should solve the inability to inspect/edit saved SQL; it does **not** need a live preview runner, chart-type migration UI, or a reroute into the full `SqlExplorer` workflow.
- After a SQL edit, the existing chart-type heuristics/fallback behavior in `SavedQueryPanel` remain the safety net if the saved visualization type no longer matches the result shape.
- The existing saved-query ORPC/service surface is sufficient unless the Red-phase tests prove otherwise.

## Recommended approach A — add a dedicated SQL dialog launched from the panel header (preferred, net product LoC: +120 to +180)
**Why this is the best default:**
- Keeps the fix local to the saved-panel surface the user is already interacting with.
- Reuses the existing saved-query mutation path; no backend, schema, or routing work is required.
- Avoids lifting editor state into `AnalyticsDashboard` or overloading `SqlExplorer` with “edit an existing saved panel” responsibilities.
- Lets the user inspect the current SQL even if they decide not to change it.

**User-visible behavior:**
- Add a new icon button to the panel header action group, ordered as **Edit SQL → Refresh → Delete**.
- Clicking it opens a modal titled with the panel label (for example, `Edit SQL — TPS quantiles by model`).
- The modal shows the current SQL in a monospace textarea, plus **Cancel** and **Save** actions.
- `Ctrl/Cmd+Enter` saves; `Escape` closes via the existing dialog behavior.
- Save is disabled for blank SQL, unchanged SQL, or while a save is already in flight.
- On success, the modal closes and the existing `SavedQueryPanel` effect reruns the updated SQL once `useSavedQueries().update()` refreshes the list.
- On failure, the modal stays open and shows the error inline using the same alert pattern already used elsewhere in analytics.

**Deliberate scope cut for v1:**
- Do **not** add inline preview/live execution inside the dialog on the first pass. The panel itself already becomes the preview surface after save, and skipping preview keeps the first implementation small, predictable, and easy to test.

## Phase 1 — Red (write the failing tests first)
1. **Define the panel-editing contract in a new UI test**
   - **New file:** `src/browser/features/Analytics/SavedQueryPanel.test.tsx`
   - Use a deterministic `SavedQuery` fixture and mock `useAnalyticsRawQuery()` so the panel chrome can render without involving DuckDB.
   - Mock `@/browser/components/Dialog/Dialog` inline or query the portal via `document.body`—whichever produces the smallest reliable failing test in happy-dom. Leave a short comment explaining the harness choice.
   - Start with explicit failing specs that define the feature before implementation:
     - renders a new header button with an accessible name such as `View or edit SQL`;
     - clicking the button opens a dialog seeded with the current `query.sql`;
     - Save is disabled while the draft is unchanged;
     - editing the SQL and saving trims the draft and calls `onUpdate({ id, sql })`;
     - blank SQL shows an inline validation error and does not call `onUpdate`;
     - a rejected save keeps the dialog open and renders the backend error;
     - cancel/close resets the draft so reopening shows the last saved SQL, not abandoned edits.

2. **Lock down the saved-query update path with a hook test**
   - **Edit file:** `src/browser/hooks/useAnalytics.test.tsx`
   - Extend the fake analytics client helper to implement `updateSavedQuery` in addition to `getSavedQueries`.
   - Add a failing test that calls `useSavedQueries().update({ id, sql })` and proves two behaviors: the SQL update is forwarded to the analytics namespace, and the hook refreshes the saved-query list afterward.

3. **Decide whether story coverage needs a regression guard**
   - During Red, verify whether an existing full-app `App.*.stories.tsx` entry already reaches the analytics dashboard with saved panels. If none exists, treat story coverage as part of Verification rather than inventing a new isolated story target mid-implementation.

## Phase 2 — Green (implement the smallest change set that satisfies the red tests)
1. **Add a focused dialog component for saved-query SQL editing**
   - **New file:** `src/browser/features/Analytics/SavedQuerySqlDialog.tsx`
   - **New symbol:** `SavedQuerySqlDialog`
   - Keep this component mostly presentational so `SavedQueryPanel` remains the owner of mutation logic and reset behavior.
   - Props should be explicit and narrow, for example:

   ```tsx
   interface SavedQuerySqlDialogProps {
     open: boolean;
     label: string;
     sql: string;
     saving: boolean;
     saveDisabled: boolean;
     error: string | null;
     onSqlChange: (nextSql: string) => void;
     onOpenChange: (open: boolean) => void;
     onSave: () => void;
   }

   export function SavedQuerySqlDialog(props: SavedQuerySqlDialogProps) {
     return (
       <Dialog open={props.open} onOpenChange={props.onOpenChange}>
         <DialogContent maxWidth="900px" maxHeight="80vh" showCloseButton={!props.saving}>
           <DialogHeader>
             <DialogTitle>{`Edit SQL — ${props.label}`}</DialogTitle>
             <DialogDescription>
               Saving updates this panel and reruns it with the edited query.
             </DialogDescription>
           </DialogHeader>

           <textarea
             value={props.sql}
             onChange={(event) => props.onSqlChange(event.target.value)}
             spellCheck={false}
             autoFocus
             className="border-border-medium bg-background text-foreground focus:border-accent focus:ring-accent min-h-[220px] w-full resize-y rounded-lg border p-3 font-mono text-xs leading-relaxed focus:ring-1 focus:outline-none"
             onKeyDown={(event) => {
               if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
                 event.preventDefault();
                 props.onSave();
               }
             }}
           />

           {props.error && (
             <div className="border-danger-soft bg-danger-soft/10 text-danger flex items-start gap-2 rounded-lg border p-3 text-xs">
               <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
               <div className="flex-1 font-mono whitespace-pre-wrap">{props.error}</div>
             </div>
           )}

           <DialogFooter>
             <Button variant="secondary" onClick={() => props.onOpenChange(false)} disabled={props.saving}>
               Cancel
             </Button>
             <Button onClick={props.onSave} disabled={props.saveDisabled}>
               {props.saving ? "Saving..." : "Save"}
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
     );
   }
   ```

   - Mirror the textarea styling and `Ctrl/Cmd+Enter` shortcut from `SqlExplorer.tsx` so the SQL-edit affordance feels native to the existing analytics experience.
   - Keep dialog errors local to the dialog instead of reusing `SavedQueryPanel`’s broader `actionError`, so SQL-save failures do not spill into the panel body after the user closes the modal.

2. **Wire the new action into `SavedQueryPanel` and keep the state event-driven**
   - **Edit file:** `src/browser/features/Analytics/SavedQueryPanel.tsx`
   - Add a new icon import (likely `Code` from `lucide-react`) and the dialog import.
   - Add local state for `isSqlDialogOpen`, `draftSql`, `sqlDialogError`, and `savingSql`.
   - Prefer event-driven state resets over an extra `useEffect`: seed `draftSql` from `props.query.sql` when opening the dialog, and reset it again when closing. This keeps the component aligned with the repo’s “avoid effects for prop-reset logic” guidance.
   - Import `assert` from `@/common/utils/assert` and assert that `props.query.id` is non-empty before attempting to save; a saved panel without a persisted ID is a programmer error, not a recoverable user state.
   - Implement a dedicated save handler that validates client-side before calling the existing mutation callback.

   ```tsx
   const [isSqlDialogOpen, setIsSqlDialogOpen] = useState(false);
   const [draftSql, setDraftSql] = useState(props.query.sql);
   const [sqlDialogError, setSqlDialogError] = useState<string | null>(null);
   const [savingSql, setSavingSql] = useState(false);
   const saveDisabled =
     savingSql || draftSql.trim().length === 0 || draftSql.trim() === props.query.sql.trim();

   const openSqlDialog = () => {
     setDraftSql(props.query.sql);
     setSqlDialogError(null);
     setIsSqlDialogOpen(true);
   };

   const closeSqlDialog = () => {
     if (savingSql) {
       return;
     }
     setDraftSql(props.query.sql);
     setSqlDialogError(null);
     setIsSqlDialogOpen(false);
   };

   const handleSaveSql = async () => {
     assert(props.query.id.trim().length > 0, "SavedQueryPanel requires a persisted id before editing SQL");
     const normalizedSql = draftSql.trim();
     if (!normalizedSql) {
       setSqlDialogError("SQL cannot be empty.");
       return;
     }
     if (normalizedSql === props.query.sql.trim()) {
       setIsSqlDialogOpen(false);
       return;
     }

     setSavingSql(true);
     setSqlDialogError(null);
     try {
       await props.onUpdate({ id: props.query.id, sql: normalizedSql });
       setIsSqlDialogOpen(false);
     } catch (updateError) {
       setSqlDialogError(getErrorMessage(updateError));
     } finally {
       setSavingSql(false);
     }
   };
   ```

   - Insert the button directly into the existing header action group at `SavedQueryPanel.tsx:212-234`, before Refresh/Delete:

   ```tsx
   <Button
     variant="ghost"
     size="icon"
     onClick={openSqlDialog}
     aria-label="View or edit SQL"
     className="text-muted hover:text-foreground h-7 w-7"
   >
     <Code className="size-3.5" />
   </Button>
   ```

   - Render the dialog from `SavedQueryPanel`, passing `draftSql`, `saveDisabled`, `savingSql`, and the local handlers, so no `AnalyticsDashboard` changes are needed beyond the existing `onUpdate={updateSavedQuery}` contract.
   - Keep the current data flow authoritative: do **not** optimistically mutate the panel’s displayed SQL or query result; let `useSavedQueries().update()` refresh the saved-query list and let the existing `useEffect` rerun the panel from the refreshed source of truth.

3. **Leave the existing analytics data plumbing unchanged unless implementation proves otherwise**
   - **No planned changes:** `src/browser/features/Analytics/AnalyticsDashboard.tsx`, `src/browser/hooks/useAnalytics.ts`, `src/common/orpc/schemas/analytics.ts`, and `src/node/services/analytics/analyticsService.ts`.
   - The current stack already supports the needed round-trip:

   ```text
   SavedQueryPanel.onSaveSql
     -> props.onUpdate({ id, sql })
     -> useSavedQueries().update(...)
     -> analytics.updateSavedQuery ORPC endpoint
     -> AnalyticsService.updateSavedQuery(...)
     -> hook refresh()
     -> SavedQueryPanel rerenders and re-executes props.query.sql
   ```

   - Only revisit this if testing exposes a real gap (for example, if the hook refreshes but the panel fails to re-execute, which would indicate a regression outside the intended design).

## Phase 3 — Refactor (mandatory cleanup after the feature works)
1. **Simplify any state/control flow that became awkward during Green**
   - Re-read `SavedQueryPanel.tsx` and the new dialog component once the tests pass, then rename handlers/props for intent clarity (`openSqlDialog`, `closeSqlDialog`, `handleSaveSql`, `saveDisabled`) and delete any temporary branching introduced only to get to green.

2. **Extract only the right amount of shared UI**
   - Compare the new dialog’s textarea/error markup against `SqlExplorer.tsx` and `SavedQueryPanel.tsx`.
   - If the exact 10+ lines are now repeated in three places, extract a small analytics-local helper component or render helper; otherwise keep the duplication to avoid a brittle abstraction.

3. **Reconfirm defensive invariants after cleanup**
   - Preserve the non-empty saved-query ID assertion before save.
   - Preserve the client-side blank-SQL guard and in-flight-save disablement.
   - Preserve the authoritative refresh flow (no optimistic mutation of panel SQL/results).

## Phase 4 — Verification (automated + manual)
1. **Re-run the Red-phase tests and keep them green**
   - `bun test src/browser/features/Analytics/SavedQueryPanel.test.tsx src/browser/hooks/useAnalytics.test.tsx`
   - Confirm the new UI test and hook test both pass without loosening the assertions introduced in Red.

2. **Run repo-level safety checks for the touched code paths**
   - `make typecheck`
   - `make lint`
   - If the UI test environment proves brittle, fall back to the narrowest passing command set and document the exact blocker; do not silently skip validation.

3. **Add visual/manual verification for reviewer confidence**
   - Preferred Storybook path: extend the nearest existing **full-app** `App.*.stories.tsx` flow so the analytics dashboard can be opened with at least one saved panel and the new header action visible.
   - If there is no practical full-app analytics story hook yet, explicitly document that gap and, at minimum, update the existing analytics dashboard visual harness so reviewers can inspect the button and dialog state.
   - Manual smoke checklist:
     - open Analytics with at least one saved panel;
     - click the new SQL action and confirm the current SQL appears;
     - change the SQL to a harmless variant and save;
     - confirm the dialog closes, the panel reruns, and errors stay localized if the update fails.

## Definition of done
- Every saved analytics panel exposes a visible SQL affordance in the header, with a clear accessible name.
- Opening the affordance shows the current saved SQL even if the user never edits it.
- Save is disabled for unchanged or blank SQL, and `Ctrl/Cmd+Enter` triggers save when the draft is valid.
- Users can replace the SQL and save it without recreating the panel.
- Cancel/close discards only unsaved dialog edits; reopening shows the last persisted SQL.
- Blank SQL is blocked client-side with a clear inline error.
- Failed saves are surfaced inside the dialog without breaking the panel.
- Successful saves preserve the existing saved-query source of truth and cause the panel to rerun from refreshed data.
- Existing rename, chart-type, refresh, and delete behaviors remain unchanged.

<details>
<summary>Alternative approach B — push the saved panel back into <code>SqlExplorer</code> for editing (net product LoC: +190 to +280)</summary>

This alternative would add an “Edit in SQL Explorer” button that scrolls/focuses the bottom-of-page `SqlExplorer`, hydrates it with the saved panel’s SQL and label, and then updates the existing saved query instead of creating a new one.

**Pros**
- Reuses the richer SQL authoring surface that already exists.
- Leaves room for future preview/sample-query features in one place.

**Why it is not the default**
- `SqlExplorer` is currently built for ad-hoc queries plus “Save as Panel,” not “edit an existing panel.” Reusing it cleanly would require lifting state into `AnalyticsDashboard`, adding an edit mode, and deciding how save/cancel semantics interact with the current “pin as panel” flow.
- The user’s click target is the panel header, but the editing surface would move them elsewhere on the page, which is a worse fit for the stated problem (“I cannot modify it anymore”).
- The implementation surface is materially larger: `AnalyticsDashboard`, `SqlExplorer`, saved-query editing semantics, focus/scroll behavior, and more tests.

Use this route only if you explicitly want saved-panel editing to grow into a full-page query-workbench workflow rather than a quick panel-local repair/edit action.
</details>

<details>
<summary>Edge cases / defensive behavior to preserve</summary>

- **Corrupted or blank saved SQL:** still allow the dialog to open so the user can repair the query; only block Save when the trimmed draft is empty.
- **Unchanged SQL:** treat Save as a no-op and close the dialog rather than issuing a redundant update.
- **Chart compatibility after an edit:** leave the existing chart-type logic untouched. If the saved chart type no longer matches the new result shape, the current `SavedQueryPanel` fallback-to-table behavior already protects the UI.
- **Concurrent clicks:** disable Save while a mutation is in flight to avoid double-submission races.
- **Escape handling:** rely on the existing `Dialog` primitive, which already stops Escape from bubbling into global handlers.
- **No optimistic cache writes:** the hook already refreshes after update, which keeps the saved-query list authoritative and avoids split-brain UI state.

If the first version lands well, the next incremental enhancement would be a secondary **Copy SQL** button inside the dialog or an opt-in **Run Preview** action; neither is required to solve the current inability to edit saved-panel SQL.
</details>

</details>

---
_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `high` • Cost: `1415735{MUX_COSTS_USD:-unknown}`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=high costs=8.31 -->
