### PR TITLE
🤖 fix: remove GPT-5.2 Codex from built-in models

### DIFF
--- a/docs/config/models.mdx
+++ b/docs/config/models.mdx
@@ -18,7 +18,6 @@ Mux ships with curated models kept up to date with the frontier. Use any custom 
 | Haiku 4.5              | anthropic:claude-haiku-4-5    | `haiku`                                  |         |
 | GPT-5.4                | openai:gpt-5.4                | `gpt`                                    |         |
 | GPT-5.4 Pro            | openai:gpt-5.4-pro            | `gpt-pro`                                |         |
-| Codex 5.2              | openai:gpt-5.2-codex          | `codex-5.2`                              |         |
 | Codex 5.3              | openai:gpt-5.3-codex          | `codex`, `codex-5.3`                     |         |
 | Spark 5.3              | openai:gpt-5.3-codex-spark    | `spark`                                  |         |
 | Codex Mini 5.1         | openai:gpt-5.1-codex-mini     | `codex-mini`                             |         |

--- a/src/browser/hooks/useModelsFromSettings.test.ts
+++ b/src/browser/hooks/useModelsFromSettings.test.ts
@@ -129,8 +129,8 @@ describe("useModelsFromSettings OpenAI Codex OAuth gating", () => {
     const { result } = renderHook(() => useModelsFromSettings());
 
     expect(result.current.models).toContain(KNOWN_MODELS.GPT.id);
-    expect(result.current.models).toContain("openai:gpt-5.2-codex");
-    expect(result.current.models).toContain("openai:gpt-5.3-codex");
+    expect(result.current.models).not.toContain("openai:gpt-5.2-codex");
+    expect(result.current.models).toContain(KNOWN_MODELS.GPT_53_CODEX.id);
     expect(result.current.models).toContain("openai:gpt-5.3-codex-spark");
     expect(result.current.models).not.toContain("openai:gpt-5.2-pro");
   });
@@ -143,8 +143,8 @@ describe("useModelsFromSettings OpenAI Codex OAuth gating", () => {
     const { result } = renderHook(() => useModelsFromSettings());
 
     expect(result.current.models).toContain(KNOWN_MODELS.GPT_PRO.id);
-    expect(result.current.models).toContain("openai:gpt-5.2-codex");
-    expect(result.current.models).toContain("openai:gpt-5.3-codex");
+    expect(result.current.models).not.toContain("openai:gpt-5.2-codex");
+    expect(result.current.models).toContain(KNOWN_MODELS.GPT_53_CODEX.id);
     expect(result.current.models).not.toContain("openai:gpt-5.3-codex-spark");
   });
 
@@ -156,8 +156,8 @@ describe("useModelsFromSettings OpenAI Codex OAuth gating", () => {
     const { result } = renderHook(() => useModelsFromSettings());
 
     expect(result.current.models).toContain(KNOWN_MODELS.GPT_PRO.id);
-    expect(result.current.models).toContain("openai:gpt-5.2-codex");
-    expect(result.current.models).toContain("openai:gpt-5.3-codex");
+    expect(result.current.models).not.toContain("openai:gpt-5.2-codex");
+    expect(result.current.models).toContain(KNOWN_MODELS.GPT_53_CODEX.id);
     expect(result.current.models).toContain("openai:gpt-5.3-codex-spark");
   });
 
@@ -169,8 +169,8 @@ describe("useModelsFromSettings OpenAI Codex OAuth gating", () => {
     const { result } = renderHook(() => useModelsFromSettings());
 
     expect(result.current.models).toContain(KNOWN_MODELS.GPT_PRO.id);
-    expect(result.current.models).toContain("openai:gpt-5.2-codex");
-    expect(result.current.models).toContain("openai:gpt-5.3-codex");
+    expect(result.current.models).not.toContain("openai:gpt-5.2-codex");
+    expect(result.current.models).toContain(KNOWN_MODELS.GPT_53_CODEX.id);
     expect(result.current.models).not.toContain("openai:gpt-5.3-codex-spark");
   });
 

--- a/src/common/constants/knownModels.ts
+++ b/src/common/constants/knownModels.ts
@@ -61,13 +61,6 @@ const MODEL_DEFINITIONS = {
     providerModelId: "gpt-5.4-pro",
     aliases: ["gpt-pro"],
   },
-  GPT_52_CODEX: {
-    provider: "openai",
-    providerModelId: "gpt-5.2-codex",
-    aliases: ["codex-5.2"],
-    warm: true,
-    tokenizerOverride: "openai/gpt-5",
-  },
   // GPT-5.3-Codex is the released API model id.
   GPT_53_CODEX: {
     provider: "openai",

--- a/src/node/services/aiService.test.ts
+++ b/src/node/services/aiService.test.ts
@@ -795,7 +795,7 @@ describe("AIService.createModel (Codex OAuth routing)", () => {
       const responseBody = {
         id: "resp_test",
         created_at: 0,
-        model: "gpt-5.2-codex",
+        model: "gpt-5.3-codex",
         output: [
           {
             type: "message",
@@ -850,7 +850,7 @@ describe("AIService.createModel (Codex OAuth routing)", () => {
         }),
     } as CodexOauthService);
 
-    const modelResult = await service.createModel(KNOWN_MODELS.GPT_52_CODEX.id);
+    const modelResult = await service.createModel(KNOWN_MODELS.GPT_53_CODEX.id);
     expect(modelResult.success).toBe(true);
     if (!modelResult.success) return;
 
@@ -944,7 +944,7 @@ describe("AIService.createModel (Codex OAuth routing)", () => {
       const responseBody = {
         id: "resp_test",
         created_at: 0,
-        model: "gpt-5.2-codex",
+        model: "gpt-5.3-codex",
         output: [
           {
             type: "message",
@@ -992,7 +992,7 @@ describe("AIService.createModel (Codex OAuth routing)", () => {
         }),
     } as CodexOauthService);
 
-    const modelResult = await service.createModel(KNOWN_MODELS.GPT_52_CODEX.id);
+    const modelResult = await service.createModel(KNOWN_MODELS.GPT_53_CODEX.id);
     expect(modelResult.success).toBe(true);
     if (!modelResult.success) return;
 

--- a/src/node/services/providerService.test.ts
+++ b/src/node/services/providerService.test.ts
@@ -249,6 +249,21 @@ describe("ProviderService model normalization", () => {
 });
 
 describe("ProviderService.setConfig", () => {
+  it("seeds first-time mux-gateway defaults without GPT-5.2 Codex", () => {
+    withTempConfig((config, service) => {
+      const result = service.setConfig("mux-gateway", ["couponCode"], "gateway-token");
+      expect(result.success).toBe(true);
+
+      const providersConfig = config.loadProvidersConfig();
+      expect(providersConfig?.["mux-gateway"]?.models).toEqual([
+        "anthropic/claude-sonnet-4-6",
+        "anthropic/claude-opus-4-6",
+        "openai/gpt-5.4",
+      ]);
+      expect(providersConfig?.["mux-gateway"]?.models).not.toContain("openai/gpt-5.2-codex");
+    });
+  });
+
   it("stores enabled=false without deleting existing credentials", () => {
     withTempConfig((config, service) => {
       config.saveProvidersConfig({

--- a/src/node/services/providerService.ts
+++ b/src/node/services/providerService.ts
@@ -423,7 +423,6 @@ export class ProviderService {
             "anthropic/claude-sonnet-4-6",
             "anthropic/claude-opus-4-6",
             "openai/gpt-5.4",
-            "openai/gpt-5.2-codex",
           ];
         }
       }


### PR DESCRIPTION
## Summary

Remove `openai:gpt-5.2-codex` from Mux's curated built-in model surfaces while keeping lower-level compatibility support intact for manual custom model use.

## Background

The built-in model registry still exposed GPT-5.2 Codex in Settings and other built-in model lists even though GPT-5.3 Codex is the current built-in Codex family entry. This change narrows the removal to built-in discovery surfaces rather than retiring all compatibility hooks for the model.

## Implementation

- deleted the `GPT_52_CODEX` entry from `KNOWN_MODELS`
- removed `openai/gpt-5.2-codex` from first-run mux-gateway seeded defaults
- updated selector and provider tests to assert GPT-5.2 Codex is no longer built in while GPT-5.3 Codex remains available
- refreshed generated model docs from the source-of-truth registry

## Validation

- `make static-check`
- `make test -- src/browser/hooks/useModelsFromSettings.test.ts`
- `make test -- src/node/services/providerService.test.ts`
- `make test -- src/node/services/aiService.test.ts`
- `bun scripts/gen_docs.ts check`
- `make typecheck`
- `bun scripts/gen_builtin_skills.ts check`

## Risks

This is low risk because the change is scoped to curated built-in surfaces and first-run defaults. Existing lower-level compatibility entries for `gpt-5.2-codex` remain in place, so manual custom-model usage should continue to work.

---

<details>
<summary>📋 Implementation Plan</summary>

# Remove `gpt-5.2-codex` from built-in models

## Context / Why
The request is to remove `openai:gpt-5.2-codex` from Mux’s **built-in** model surfaces, especially the Settings → Models table shown in the screenshot.

This plan assumes **built-in demotion, not full retirement**:
- `src/common/constants/knownModels.ts` is the curated built-in registry.
- Custom `provider:model_id` entries remain allowed, so users can still add `openai:gpt-5.2-codex` manually if they want.
- Lower-level compatibility data (`tokens`, `thinking`, OAuth allow-list) stays in place unless the product decision changes to “remove support everywhere.”

**Recommended approach net product-code LoC:** **~-8 to -14**

## Evidence
- `src/common/constants/knownModels.ts:29-123` — `MODEL_DEFINITIONS` is the source of truth for built-in models. `GPT_52_CODEX` is the only built-in entry for `gpt-5.2-codex`, and `GPT_53_CODEX` already owns the bare `codex` alias.
- `src/browser/features/Settings/Sections/ModelsSection.tsx:96-105,353-363` — the Built-in Models table renders `Object.values(KNOWN_MODELS)`, so removing the registry entry removes the row without a direct UI edit.
- `src/browser/hooks/useModelsFromSettings.ts:21-23,89-92,231-277` — picker/suggested-model state also derives from `KNOWN_MODELS`, so built-in selection lists heal automatically after the registry edit.
- `src/node/services/providerService.ts:417-427` — first-time mux-gateway setup still seeds `openai/gpt-5.2-codex`, so the onboarding default list must be updated to match the curated built-in set.
- `docs/config/models.mdx:12-31` + `scripts/gen_docs.ts:175-181` — the built-in model docs table is generated from `knownModels.ts`, so docs should be regenerated rather than hand-edited.
- `Makefile:210-217` + `src/node/services/agentSkills/builtInSkillDefinitions.ts:10-15` — docs changes can flow into generated built-in skill content, so the plan should include the docs/skill generation check.
- `src/browser/hooks/useModelsFromSettings.test.ts:124-175`, `src/node/services/aiService.test.ts:853,995`, and `src/node/services/providerService.test.ts:251-349` identify the most relevant test surfaces to codify the scoped behavior change.

## Acceptance criteria
- `KNOWN_MODELS` no longer includes `GPT_52_CODEX`, and the `codex-5.2` built-in alias disappears.
- Settings/picker built-in lists no longer include `openai:gpt-5.2-codex`.
- Fresh mux-gateway setup no longer seeds `openai/gpt-5.2-codex`.
- `codex` continues to resolve to `openai:gpt-5.3-codex`.
- Generated built-in docs no longer list “Codex 5.2”.
- Manual custom-model usage of `openai:gpt-5.2-codex` still works because compatibility helpers are intentionally left alone.

## Phase 1 — Red (define the change in tests first)
1. **Update `src/browser/hooks/useModelsFromSettings.test.ts` to codify the desired selector behavior.**
   - In the four OpenAI auth-state cases (`codex oauth only`, `api key only`, `api key + codex oauth`, `neither`), change expectations so `openai:gpt-5.2-codex` is **absent** and `openai:gpt-5.3-codex` remains **present**.
   - This makes the built-in-list removal explicit before the registry edit.

   ```ts
   expect(result.current.models).not.toContain("openai:gpt-5.2-codex");
   expect(result.current.models).toContain(KNOWN_MODELS.GPT_53_CODEX.id);
   ```

2. **Add/extend a focused regression test in `src/node/services/providerService.test.ts` for first-time mux-gateway seeding.**
   - Exercise the path that populates default mux-gateway models on first setup.
   - Assert the seeded list contains the curated defaults and does **not** include `openai/gpt-5.2-codex`.

   ```ts
   const result = service.setConfig("mux-gateway", ["couponCode"], "gateway-token");
   expect(result.success).toBe(true);
   expect(config.loadProvidersConfig()?.["mux-gateway"]?.models).toEqual([
     "anthropic/claude-sonnet-4-6",
     "anthropic/claude-opus-4-6",
     "openai/gpt-5.4",
   ]);
   ```

3. **Update `src/node/services/aiService.test.ts` fixtures before the implementation edit removes the symbol.**
   - Replace `KNOWN_MODELS.GPT_52_CODEX` with `KNOWN_MODELS.GPT_53_CODEX` in the two Codex OAuth request-shaping tests.
   - These tests are about Codex OAuth behavior, not 5.2-specific support, so keeping them tied to a still-built-in Codex model preserves coverage while avoiding a compile-time break after the registry edit.

## Phase 2 — Green (minimal implementation to satisfy the tests)
1. **Remove the built-in registry entry from `src/common/constants/knownModels.ts`.**
   - Delete the `GPT_52_CODEX` block from `MODEL_DEFINITIONS`.
   - Leave `GPT_53_CODEX` unchanged so the bare `codex` alias still points at the current Codex family.

   ```ts
   const MODEL_DEFINITIONS = {
     ...
-    GPT_52_CODEX: {
-      provider: "openai",
-      providerModelId: "gpt-5.2-codex",
-      aliases: ["codex-5.2"],
-      warm: true,
-      tokenizerOverride: "openai/gpt-5",
-    },
     GPT_53_CODEX: {
       provider: "openai",
       providerModelId: "gpt-5.3-codex",
       aliases: ["codex", "codex-5.3"],
       ...
   ```

2. **Trim the first-run mux-gateway defaults in `src/node/services/providerService.ts`.**
   - Remove `"openai/gpt-5.2-codex"` from the seeded default model array so onboarding matches the curated built-in list.

   ```ts
   if (existingModels.length === 0) {
     providerConfig.models = [
       "anthropic/claude-sonnet-4-6",
       "anthropic/claude-opus-4-6",
       "openai/gpt-5.4",
-      "openai/gpt-5.2-codex",
     ];
   }
   ```

3. **Regenerate generated docs/artifacts from the source-of-truth change.**
   - Run `bun scripts/gen_docs.ts` so `docs/config/models.mdx` drops the “Codex 5.2” row.
   - If the docs update causes built-in skill snapshots to drift, run the existing built-in-skill generation path as part of the same change set.

## Phase 3 — Refactor (mandatory cleanup after Green)
1. **Prune stale 5.2-specific naming/comments introduced only by old built-in assumptions.**
   - Prefer generic wording like “Codex OAuth routing” in tests unless the test is intentionally about literal `gpt-5.2-codex` compatibility.
   - Remove dead imports/references left behind by deleting `GPT_52_CODEX`.

2. **Run targeted searches to confirm the scoped change stayed scoped.**
   - `rg -n 'GPT_52_CODEX|codex-5\.2' src docs` should be empty after the demotion.
   - Remaining `gpt-5.2-codex` hits should be the intentional compatibility paths (for example token stats or thinking policy), not built-in registry/docs/default-seeding paths.

## Verification
- **Targeted tests first:**
  - `make test -- src/browser/hooks/useModelsFromSettings.test.ts`
  - `make test -- src/node/services/providerService.test.ts`
  - `make test -- src/node/services/aiService.test.ts`
- **Then broader safety checks:**
  - `make typecheck`
  - `make test`
  - `bun scripts/gen_docs.ts check`
  - `bun scripts/gen_builtin_skills.ts check` if docs-fed built-in skill output is part of the checked-in state
- **Manual spot-check:**
  - Open Settings → Models and confirm `gpt-5.2-codex` is gone from **Built-in Models** while `gpt-5.3-codex` remains.
  - Optionally verify `openai:gpt-5.2-codex` can still be added under **Custom Models**, confirming this was a built-in demotion rather than full support removal.

<details>
<summary>Optional broader cleanup if the real goal is full retirement, not just built-in demotion</summary>

Only do this if the requirement changes from “remove from built-ins” to “stop first-party support entirely.”

**Broader-cleanup net product-code LoC:** **~-35 to -60**

That wider pass would also remove/update:
- `src/common/constants/codexOAuth.ts`
- `src/common/utils/thinking/policy.ts`
- `src/common/utils/tokens/models-extra.ts`
- `src/common/utils/tokens/models.json`
- literal-string tests that intentionally target `gpt-5.2-codex`
- policy/docs examples such as `docs/config/policy-file.mdx`

That is a different product decision: it turns the model from “not built in” into “not supported by first-party compatibility helpers.”
</details>


</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.4` • Thinking: `high` • Cost: `$3.66`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=high costs=3.66 -->
