### PR TITLE
🤖 fix: remove stale promisor markers before SSH sync gc

### DIFF
--- a/src/node/runtime/SSHRuntime.retry.test.ts
+++ b/src/node/runtime/SSHRuntime.retry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { InitLogger } from "./Runtime";
+import type { ExecOptions, ExecStream, InitLogger } from "./Runtime";
 import { SSHRuntime } from "./SSHRuntime";
 import type { RemoteProjectLayout } from "./remoteProjectLayout";
 import type { SSHRuntimeConfig } from "./sshConnectionPool";
@@ -50,6 +50,35 @@ function createMockTransport(config: SSHRuntimeConfig): SSHTransport {
     createPtySession(_params: PtySessionParams): Promise<PtyHandle> {
       return Promise.reject(new Error("Unexpected PTY creation in SSHRuntime retry test"));
     },
+  };
+}
+
+function createTextStream(text: string): ReadableStream<Uint8Array> {
+  const encoded = new TextEncoder().encode(text);
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      if (encoded.byteLength > 0) {
+        controller.enqueue(encoded);
+      }
+      controller.close();
+    },
+  });
+}
+
+const resolveVoid = (): Promise<void> => Promise.resolve();
+const discardChunk = (_chunk: Uint8Array): Promise<void> => Promise.resolve();
+
+function createExecStream(stdout: string, stderr = "", exitCode = 0): ExecStream {
+  return {
+    stdout: createTextStream(stdout),
+    stderr: createTextStream(stderr),
+    stdin: new WritableStream<Uint8Array>({
+      write: discardChunk,
+      close: resolveVoid,
+      abort: resolveVoid,
+    }),
+    exitCode: Promise.resolve(exitCode),
+    duration: Promise.resolve(0),
   };
 }
 
@@ -122,7 +151,46 @@ class TestSSHRuntime extends SSHRuntime {
   }
 }
 
+class CleanupCommandSSHRuntime extends SSHRuntime {
+  readonly commands: string[] = [];
+  readonly timeouts: number[] = [];
+
+  constructor() {
+    const config: SSHRuntimeConfig = {
+      host: "example.test",
+      srcBaseDir: "/remote/src",
+    };
+    super(config, createMockTransport(config));
+  }
+
+  async runCleanup(baseRepoPathArg: string, abortSignal?: AbortSignal): Promise<void> {
+    await this.cleanupRetryableProjectSyncFailure(baseRepoPathArg, 1, 3, abortSignal);
+  }
+
+  override exec(command: string, options: ExecOptions): Promise<ExecStream> {
+    this.commands.push(command);
+    this.timeouts.push(options.timeout ?? -1);
+    const stdout = command.startsWith("find ")
+      ? "/remote/src/project/.mux-base.git/objects/pack/pack-a.promisor\n"
+      : "";
+    return Promise.resolve(createExecStream(stdout));
+  }
+}
+
 describe("SSHRuntime project sync retry orchestration", () => {
+  it("removes stale promisor markers before running git gc", async () => {
+    const runtime = new CleanupCommandSSHRuntime();
+    const baseRepoPathArg = '"/remote/src/project/.mux-base.git"';
+
+    await runtime.runCleanup(baseRepoPathArg);
+
+    expect(runtime.commands).toEqual([
+      `find ${baseRepoPathArg}/objects/pack -name '*.promisor' -print -delete 2>/dev/null || true`,
+      `git -C ${baseRepoPathArg} gc --prune=now`,
+    ]);
+    expect(runtime.timeouts).toEqual([10, 60]);
+  });
+
   it("skips cleanup and backoff when a retryable failure was user-aborted", async () => {
     const runtime = new TestSSHRuntime();
     const abortController = new AbortController();

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -392,10 +392,28 @@ export class SSHRuntime extends RemoteRuntime {
       throw new Error("Operation aborted");
     }
 
+    const promisorPackDirArg = `${baseRepoPathArg}/objects/pack`;
     log.info(
-      `Running remote git gc before retrying sync push (attempt ${attempt + 1}/${maxAttempts})`
+      `Running remote promisor cleanup and git gc before retrying sync push (attempt ${attempt + 1}/${maxAttempts})`
     );
     try {
+      const promisorCleanupResult = await execBuffered(
+        this,
+        `find ${promisorPackDirArg} -name '*.promisor' -print -delete 2>/dev/null || true`,
+        {
+          cwd: "/tmp",
+          timeout: 10,
+          abortSignal,
+        }
+      );
+      const removedPromisorCount = promisorCleanupResult.stdout
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean).length;
+      if (removedPromisorCount > 0) {
+        log.info(`Removed ${removedPromisorCount} stale promisor marker(s) before sync retry`);
+      }
+
       const gcResult = await execBuffered(this, `git -C ${baseRepoPathArg} gc --prune=now`, {
         cwd: "/tmp",
         timeout: 60,
@@ -411,7 +429,7 @@ export class SSHRuntime extends RemoteRuntime {
       if (abortSignal?.aborted || cleanupErrorMsg === "Operation aborted") {
         throw cleanupError instanceof Error ? cleanupError : new Error(cleanupErrorMsg);
       }
-      log.warn(`Remote git gc failed before sync retry: ${cleanupErrorMsg}`);
+      log.warn(`Remote sync retry cleanup failed: ${cleanupErrorMsg}`);
     }
   }
 


### PR DESCRIPTION
## Summary

Remove stale `.promisor` markers from the remote shared base repo before retry-time `git gc` so interrupted SSH sync pushes do not leave the bare repo negotiating as if it were a partial clone.

## Background

PR #3148 fixed the main SSH sync timeout death spiral by retrying timed-out pushes under the project lock and running `git gc --prune=now` between attempts. In follow-up dogfooding on `pog2.coder`, SSH workspace init could still get stuck on `Pushing to remote...` even with that fix deployed.

The missing piece was stale `.promisor` files left behind next to partial packs after interrupted native `git push` attempts. Those markers made the shared bare base repo behave like a partial clone during later negotiation. In practice, manually deleting `objects/pack/*.promisor` on the remote immediately restored push performance.

## Implementation

- Extend `cleanupRetryableProjectSyncFailure()` to remove stale `objects/pack/*.promisor` markers before running the existing retry-time `git gc --prune=now`.
- Keep the cleanup best-effort, abort-aware, and inside the existing project-scoped sync lock.
- Log the retry cleanup as a combined promisor-cleanup + gc step, and keep the existing gc warning path for non-zero exits.
- Add focused unit coverage for the cleanup command ordering so the retry path proves it deletes promisor markers before invoking gc.

## Validation

- `bun test src/node/runtime/SSHRuntime.retry.test.ts`
- `bunx eslint src/node/runtime/SSHRuntime.ts src/node/runtime/SSHRuntime.retry.test.ts`
- `make typecheck`
- `TEST_INTEGRATION=1 bun test ./tests/runtime/runtime.test.ts --filter "initWorkspace does not populate refs/remotes/origin in the base repo from the bundle"`

## Risks

Low. The shared base repo is a Mux-managed bare push target, not an intentional partial clone, so removing stale `.promisor` markers is safe and only affects the retry cleanup path after failed sync attempts.

---

_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `xhigh` • Cost: `$N/A`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=xhigh costs=N/A -->
