### PR TITLE
🤖 fix: extend the streaming status debounce to 2s

### DIFF
--- a/src/browser/features/Messages/ChatBarrier/StreamingBarrier.test.tsx
+++ b/src/browser/features/Messages/ChatBarrier/StreamingBarrier.test.tsx
@@ -37,7 +37,7 @@ function createWorkspaceState(overrides: Partial<MockWorkspaceState> = {}): Mock
   return state;
 }
 
-const STREAMING_STATUS_TRANSITION_DEBOUNCE_MS = 200;
+const STREAMING_STATUS_TRANSITION_DEBOUNCE_MS = 2000;
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 let currentWorkspaceState = createWorkspaceState();

--- a/src/browser/features/Messages/ChatBarrier/StreamingBarrier.tsx
+++ b/src/browser/features/Messages/ChatBarrier/StreamingBarrier.tsx
@@ -36,7 +36,7 @@ interface StreamingBarrierProps {
   onCancelCompaction?: () => void;
 }
 
-const STREAMING_STATUS_TRANSITION_DEBOUNCE_MS = 200;
+const STREAMING_STATUS_TRANSITION_DEBOUNCE_MS = 2000;
 const DEBOUNCED_STREAMING_PHASES: ReadonlySet<StreamingPhase> = new Set([
   "starting",
   "streaming",


### PR DESCRIPTION
## Summary

Increase the chat transcript streaming-status debounce from 200ms to 2 seconds so the barrier text stays calmer during fast startup-to-streaming handoffs.

## Background

PR #3147 introduced a small debounce to smooth status-label churn in the transcript tail. This follow-up intentionally makes that hold much longer so the `streaming...` area is noticeably less flashy when stages advance in quick succession.

## Implementation

- changed `STREAMING_STATUS_TRANSITION_DEBOUNCE_MS` from `200` to `2000`
- updated the component test constant so the debounce assertions still verify the intended hold window

## Validation

- `bun test src/browser/features/Messages/ChatBarrier/StreamingBarrier.test.tsx`
- `make static-check`

## Risks

Low-to-moderate UX risk. The implementation is unchanged, but users will now see startup/streaming labels lag by up to 2 seconds during phase handoffs, so the transcript may feel calmer at the cost of more stale status text.

---

_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `xhigh` • Cost: `$7.79`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=xhigh costs=7.79 -->
