### PR TITLE
🤖 fix: make SSH sync snapshots branch-authoritative

### DIFF
--- a/src/node/runtime/SSHRuntime.syncContract.test.ts
+++ b/src/node/runtime/SSHRuntime.syncContract.test.ts
@@ -189,11 +189,51 @@ describe("SSHRuntime authoritative sync contract", () => {
   it("pushes pruneable bundle branches separately from shared tags", async () => {
     const runtime = new CommandCaptureSSHRuntime();
     const layout = createLayout();
-    const pushArgs: string[][] = [];
+    const gitCalls: string[][] = [];
 
     spyOn(disposableExec, "execFileAsync").mockImplementation((file, args) => {
       expect(file).toBe("git");
-      pushArgs.push([...args]);
+      gitCalls.push([...args]);
+      const isTagCheck = args.includes("for-each-ref") && args.includes("refs/tags");
+      return createMockExecResult(
+        Promise.resolve({ stdout: isTagCheck ? "refs/tags/v1.0.0\n" : "", stderr: "" })
+      );
+    });
+
+    await (runtime as unknown as GitPushPrivateApi).syncProjectSnapshotViaGitPush(
+      "/local/project",
+      layout,
+      layout.currentSnapshotPath,
+      noopInitLogger
+    );
+
+    const pushCalls = gitCalls.filter((args) => args.includes("push"));
+    const tagCheckCalls = gitCalls.filter((args) => args.includes("for-each-ref"));
+
+    expect(pushCalls).toHaveLength(2);
+    expect(tagCheckCalls).toHaveLength(1);
+    expect(tagCheckCalls[0]).toContain("--count=1");
+    expect(tagCheckCalls[0]).toContain("refs/tags");
+
+    expect(pushCalls[0]).toContain("--prune");
+    expect(pushCalls[0]).toContain("--atomic");
+    expect(pushCalls[0]).toContain("+refs/heads/*:refs/mux-bundle/*");
+    expect(pushCalls[0]).not.toContain("+refs/tags/*:refs/tags/*");
+
+    expect(pushCalls[1]).not.toContain("--prune");
+    expect(pushCalls[1]).not.toContain("--atomic");
+    expect(pushCalls[1]).toContain("+refs/tags/*:refs/tags/*");
+    expect(pushCalls[1]).not.toContain("+refs/heads/*:refs/mux-bundle/*");
+  });
+
+  it("skips the metadata tag push when the local repo has no tags", async () => {
+    const runtime = new CommandCaptureSSHRuntime();
+    const layout = createLayout();
+    const gitCalls: string[][] = [];
+
+    spyOn(disposableExec, "execFileAsync").mockImplementation((file, args) => {
+      expect(file).toBe("git");
+      gitCalls.push([...args]);
       return createMockExecResult(Promise.resolve({ stdout: "", stderr: "" }));
     });
 
@@ -204,16 +244,15 @@ describe("SSHRuntime authoritative sync contract", () => {
       noopInitLogger
     );
 
-    expect(pushArgs).toHaveLength(2);
-    expect(pushArgs[0]).toContain("--prune");
-    expect(pushArgs[0]).toContain("--atomic");
-    expect(pushArgs[0]).toContain("+refs/heads/*:refs/mux-bundle/*");
-    expect(pushArgs[0]).not.toContain("+refs/tags/*:refs/tags/*");
+    const pushCalls = gitCalls.filter((args) => args.includes("push"));
+    const tagCheckCalls = gitCalls.filter((args) => args.includes("for-each-ref"));
 
-    expect(pushArgs[1]).not.toContain("--prune");
-    expect(pushArgs[1]).not.toContain("--atomic");
-    expect(pushArgs[1]).toContain("+refs/tags/*:refs/tags/*");
-    expect(pushArgs[1]).not.toContain("+refs/heads/*:refs/mux-bundle/*");
+    expect(pushCalls).toHaveLength(1);
+    expect(tagCheckCalls).toHaveLength(1);
+    expect(pushCalls[0]).toContain("--prune");
+    expect(pushCalls[0]).toContain("--atomic");
+    expect(pushCalls[0]).toContain("+refs/heads/*:refs/mux-bundle/*");
+    expect(pushCalls[0]).not.toContain("+refs/tags/*:refs/tags/*");
   });
 
   it("fetches pruneable bundle branches separately from shared tags", async () => {

--- a/src/node/runtime/SSHRuntime.syncContract.test.ts
+++ b/src/node/runtime/SSHRuntime.syncContract.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { execSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as disposableExec from "@/node/utils/disposableExec";
+import type { ExecOptions, ExecStream, InitLogger } from "./Runtime";
+import { SSHRuntime } from "./SSHRuntime";
+import type { RemoteProjectLayout } from "./remoteProjectLayout";
+import type { SSHRuntimeConfig } from "./sshConnectionPool";
+import type { PtyHandle, PtySessionParams, SSHTransport } from "./transports";
+
+const noop = (): void => undefined;
+const noopAsync = (): Promise<void> => Promise.resolve();
+const tempDirs: string[] = [];
+
+const noopInitLogger: InitLogger = {
+  logStep: noop,
+  logStdout: noop,
+  logStderr: noop,
+  logComplete: noop,
+};
+
+function createMockTransport(config: SSHRuntimeConfig): SSHTransport {
+  return {
+    spawnRemoteProcess() {
+      return Promise.reject(new Error("Unexpected transport use in SSHRuntime sync contract test"));
+    },
+    isConnectionFailure() {
+      return false;
+    },
+    acquireConnection() {
+      return Promise.resolve();
+    },
+    getConfig() {
+      return config;
+    },
+    createPtySession(_params: PtySessionParams): Promise<PtyHandle> {
+      return Promise.reject(new Error("Unexpected PTY creation in SSHRuntime sync contract test"));
+    },
+  };
+}
+
+function createTextStream(text: string): ReadableStream<Uint8Array> {
+  const encoded = new TextEncoder().encode(text);
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      if (encoded.byteLength > 0) {
+        controller.enqueue(encoded);
+      }
+      controller.close();
+    },
+  });
+}
+
+const discardChunk = (_chunk: Uint8Array): Promise<void> => Promise.resolve();
+
+function createExecStream(stdout: string, stderr = "", exitCode = 0): ExecStream {
+  return {
+    stdout: createTextStream(stdout),
+    stderr: createTextStream(stderr),
+    stdin: new WritableStream<Uint8Array>({
+      write: discardChunk,
+      close: noopAsync,
+      abort: noopAsync,
+    }),
+    exitCode: Promise.resolve(exitCode),
+    duration: Promise.resolve(0),
+  };
+}
+
+function createMockExecResult(
+  result: Promise<{ stdout: string; stderr: string }>
+): ReturnType<typeof disposableExec.execFileAsync> {
+  void result.catch(noop);
+  return {
+    result,
+    get promise() {
+      return result;
+    },
+    child: {},
+    [Symbol.dispose]: noop,
+  } as unknown as ReturnType<typeof disposableExec.execFileAsync>;
+}
+
+class CommandCaptureSSHRuntime extends SSHRuntime {
+  readonly commands: string[] = [];
+
+  constructor() {
+    const config: SSHRuntimeConfig = {
+      host: "example.test",
+      srcBaseDir: "/remote/src",
+    };
+    super(config, createMockTransport(config));
+  }
+
+  override exec(command: string, _options: ExecOptions): Promise<ExecStream> {
+    this.commands.push(command);
+    return Promise.resolve(createExecStream(""));
+  }
+}
+
+interface GitPushPrivateApi {
+  syncProjectSnapshotViaGitPush(
+    projectPath: string,
+    layout: RemoteProjectLayout,
+    currentSnapshotPath: string,
+    initLogger: InitLogger,
+    abortSignal?: AbortSignal
+  ): Promise<void>;
+}
+
+interface BundleSyncPrivateApi {
+  transferBundleToRemote: (
+    projectPath: string,
+    remoteBundlePath: string,
+    initLogger: InitLogger,
+    abortSignal?: AbortSignal
+  ) => Promise<void>;
+  syncProjectSnapshotViaBundle(
+    projectPath: string,
+    layout: RemoteProjectLayout,
+    currentSnapshotPath: string,
+    snapshotDigest: string,
+    baseRepoPathArg: string,
+    initLogger: InitLogger,
+    abortSignal?: AbortSignal
+  ): Promise<void>;
+}
+
+interface SnapshotPrivateApi {
+  computeSnapshotDigest(projectPath: string): Promise<string>;
+  resolveLocalSyncRefManifest(projectPath: string): Promise<string | null>;
+}
+
+function createLayout(): RemoteProjectLayout {
+  return {
+    projectId: "project-id",
+    projectRoot: "/remote/src/project",
+    baseRepoPath: "/remote/src/project/.mux-base.git",
+    currentSnapshotPath: "/remote/src/project/.mux-meta/current-snapshot",
+  };
+}
+
+async function createTempGitRepo(): Promise<string> {
+  const repoPath = await mkdtemp(path.join(os.tmpdir(), "mux-ssh-sync-contract-"));
+  tempDirs.push(repoPath);
+  execSync(
+    [
+      `git -C "${repoPath}" init -b main`,
+      `git -C "${repoPath}" config user.email "test@test.com"`,
+      `git -C "${repoPath}" config user.name "Test"`,
+      `sh -c 'printf initial > "${repoPath}/file.txt"'`,
+      `git -C "${repoPath}" add file.txt`,
+      `git -C "${repoPath}" commit -m "initial"`,
+    ].join(" && "),
+    { stdio: "pipe" }
+  );
+  return repoPath;
+}
+
+afterEach(async () => {
+  mock.restore();
+  await Promise.all(
+    tempDirs.splice(0).map((tempDir) => rm(tempDir, { recursive: true, force: true }))
+  );
+});
+
+describe("SSHRuntime authoritative sync contract", () => {
+  it("derives snapshot identity from branch refs instead of tag-only drift", async () => {
+    const repoPath = await createTempGitRepo();
+    const runtime = new CommandCaptureSSHRuntime();
+    const privateApi = runtime as unknown as SnapshotPrivateApi;
+
+    const initialDigest = await privateApi.computeSnapshotDigest(repoPath);
+    const initialManifest = await privateApi.resolveLocalSyncRefManifest(repoPath);
+
+    execSync(`git -C "${repoPath}" tag v1.0.0`, { stdio: "pipe" });
+
+    expect(await privateApi.computeSnapshotDigest(repoPath)).toBe(initialDigest);
+    expect(await privateApi.resolveLocalSyncRefManifest(repoPath)).toBe(initialManifest);
+
+    execSync(`git -C "${repoPath}" branch feature/snapshot-contract`, { stdio: "pipe" });
+
+    expect(await privateApi.computeSnapshotDigest(repoPath)).not.toBe(initialDigest);
+    expect(await privateApi.resolveLocalSyncRefManifest(repoPath)).not.toBe(initialManifest);
+  });
+
+  it("pushes pruneable bundle branches separately from shared tags", async () => {
+    const runtime = new CommandCaptureSSHRuntime();
+    const layout = createLayout();
+    const pushArgs: string[][] = [];
+
+    spyOn(disposableExec, "execFileAsync").mockImplementation((file, args) => {
+      expect(file).toBe("git");
+      pushArgs.push([...args]);
+      return createMockExecResult(Promise.resolve({ stdout: "", stderr: "" }));
+    });
+
+    await (runtime as unknown as GitPushPrivateApi).syncProjectSnapshotViaGitPush(
+      "/local/project",
+      layout,
+      layout.currentSnapshotPath,
+      noopInitLogger
+    );
+
+    expect(pushArgs).toHaveLength(2);
+    expect(pushArgs[0]).toContain("--prune");
+    expect(pushArgs[0]).toContain("--atomic");
+    expect(pushArgs[0]).toContain("+refs/heads/*:refs/mux-bundle/*");
+    expect(pushArgs[0]).not.toContain("+refs/tags/*:refs/tags/*");
+
+    expect(pushArgs[1]).not.toContain("--prune");
+    expect(pushArgs[1]).not.toContain("--atomic");
+    expect(pushArgs[1]).toContain("+refs/tags/*:refs/tags/*");
+    expect(pushArgs[1]).not.toContain("+refs/heads/*:refs/mux-bundle/*");
+  });
+
+  it("fetches pruneable bundle branches separately from shared tags", async () => {
+    const runtime = new CommandCaptureSSHRuntime();
+    const layout = createLayout();
+    const privateApi = runtime as unknown as BundleSyncPrivateApi;
+    privateApi.transferBundleToRemote = () => Promise.resolve();
+
+    await privateApi.syncProjectSnapshotViaBundle(
+      "/local/project",
+      layout,
+      layout.currentSnapshotPath,
+      "snapshot-digest",
+      '"/remote/src/project/.mux-base.git"',
+      noopInitLogger
+    );
+
+    const fetchCommands = runtime.commands.filter((command) => command.includes(" fetch "));
+    expect(fetchCommands).toHaveLength(2);
+    expect(fetchCommands[0]).toContain("fetch --prune");
+    expect(fetchCommands[0]).toContain("'+refs/heads/*:refs/mux-bundle/*'");
+    expect(fetchCommands[0]).not.toContain("refs/tags");
+    expect(fetchCommands[0]).not.toContain("--prune-tags");
+
+    expect(fetchCommands[1]).not.toContain("--prune");
+    expect(fetchCommands[1]).toContain("'+refs/tags/*:refs/tags/*'");
+    expect(fetchCommands[1]).not.toContain("refs/heads/*:refs/mux-bundle/*");
+  });
+});

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -1209,6 +1209,19 @@ export class SSHRuntime extends RemoteRuntime {
     }
   }
 
+  private async hasLocalTags(projectPath: string): Promise<boolean> {
+    using proc = execFileAsync("git", [
+      "-C",
+      projectPath,
+      "for-each-ref",
+      "--count=1",
+      "--format=%(refname)",
+      "refs/tags",
+    ]);
+    const { stdout } = await proc.result;
+    return stdout.trim().length > 0;
+  }
+
   /**
    * Build a GIT_SSH_COMMAND that mirrors the runtime's SSH config so `git push`
    * reuses the same multiplexed connection and auth settings.
@@ -1383,6 +1396,13 @@ export class SSHRuntime extends RemoteRuntime {
       } catch (retryError) {
         throwPushFailure(retryError);
       }
+    }
+
+    // Metadata propagation is a true no-op when the local repo has no tags.
+    // Guarding the tag push keeps branch sync authoritative instead of failing on
+    // Git's "no refs in common" error for an empty tag refspec.
+    if (!(await this.hasLocalTags(projectPath))) {
+      return;
     }
 
     try {

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -441,8 +441,11 @@ export class SSHRuntime extends RemoteRuntime {
   }
 
   private async computeSnapshotDigest(projectPath: string): Promise<string> {
+    // Workspace materialization only depends on branch tips. Tags are shared repo
+    // metadata that can legitimately drift, so they must not participate in the
+    // authoritative snapshot identity or force a resync on their own.
     const refsOutput = await new Promise<string>((resolve, reject) => {
-      const proc = spawn("git", ["-C", projectPath, "show-ref", "--heads", "--tags"], {
+      const proc = spawn("git", ["-C", projectPath, "show-ref", "--heads"], {
         stdio: ["ignore", "pipe", "pipe"],
         windowsHide: true,
       });
@@ -804,7 +807,7 @@ export class SSHRuntime extends RemoteRuntime {
 
   private async resolveLocalSyncRefManifest(projectPath: string): Promise<string | null> {
     try {
-      using proc = execFileAsync("git", ["-C", projectPath, "show-ref", "--heads", "--tags"]);
+      using proc = execFileAsync("git", ["-C", projectPath, "show-ref", "--heads"]);
       const { stdout } = await proc.result;
       return stdout
         .split("\n")
@@ -823,7 +826,7 @@ export class SSHRuntime extends RemoteRuntime {
   ): Promise<string | null> {
     const result = await execBuffered(
       this,
-      `git -C ${baseRepoPathArg} for-each-ref --format='%(objectname) %(refname)' ${BUNDLE_REF_PREFIX} refs/tags`,
+      `git -C ${baseRepoPathArg} for-each-ref --format='%(objectname) %(refname)' ${BUNDLE_REF_PREFIX}`,
       { cwd: "/tmp", timeout: 20, abortSignal }
     );
     if (result.exitCode !== 0) {
@@ -1165,20 +1168,32 @@ export class SSHRuntime extends RemoteRuntime {
     await this.transferBundleToRemote(projectPath, remoteBundlePath, initLogger, abortSignal);
 
     try {
-      // Import branches and tags from the bundle into the shared bare repo.
-      // Branches land in refs/mux-bundle/* (staging namespace) instead of
-      // refs/heads/* to avoid colliding with branches checked out in existing
-      // worktrees — git refuses to update any ref checked out in a worktree.
-      // Tags go directly to refs/tags/* (they're never checked out).
+      // Import authoritative branches and shared tags from the bundle into the
+      // shared bare repo. Branches land in refs/mux-bundle/* (staging namespace)
+      // instead of refs/heads/* to avoid colliding with branches checked out in
+      // existing worktrees, and they stay pruneable because branch deletion should
+      // invalidate snapshot reuse. Tags go directly to refs/tags/*, but they are
+      // fetched separately without --prune so remote-only metadata tags survive.
       initLogger.logStep("Importing bundle into shared base repository...");
-      const fetchResult = await execBuffered(
+      const branchFetchResult = await execBuffered(
         this,
-        `git -C ${baseRepoPathArg} fetch --prune --prune-tags ${remoteBundlePathArg} '+refs/heads/*:${BUNDLE_REF_PREFIX}*' '+refs/tags/*:refs/tags/*'`,
+        `git -C ${baseRepoPathArg} fetch --prune ${remoteBundlePathArg} '+refs/heads/*:${BUNDLE_REF_PREFIX}*'`,
         { cwd: "/tmp", timeout: 300, abortSignal }
       );
-      if (fetchResult.exitCode !== 0) {
+      if (branchFetchResult.exitCode !== 0) {
         throw new Error(
-          `Failed to import bundle into base repo: ${fetchResult.stderr || fetchResult.stdout}`
+          `Failed to import bundle branches into base repo: ${branchFetchResult.stderr || branchFetchResult.stdout}`
+        );
+      }
+
+      const tagFetchResult = await execBuffered(
+        this,
+        `git -C ${baseRepoPathArg} fetch ${remoteBundlePathArg} '+refs/tags/*:refs/tags/*'`,
+        { cwd: "/tmp", timeout: 300, abortSignal }
+      );
+      if (tagFetchResult.exitCode !== 0) {
+        throw new Error(
+          `Failed to import bundle tags into base repo: ${tagFetchResult.stderr || tagFetchResult.stdout}`
         );
       }
     } finally {
@@ -1297,29 +1312,16 @@ export class SSHRuntime extends RemoteRuntime {
     const remoteUrl = `ssh://${urlHost}${urlPath}`;
     const gitSshCommand = this.buildGitSshCommand();
 
-    // Push local branches and tags to the remote base repo. Branches land in
-    // refs/mux-bundle/* (staging namespace) and tags go to refs/tags/* directly.
-    // --prune keeps the staging refs aligned with local deletions so snapshot
-    // markers remain reusable after local branch/tag cleanup.
+    // Push authoritative branches and shared tags separately. Branches land in
+    // refs/mux-bundle/* (staging namespace) and stay pruneable because branch
+    // deletion should invalidate snapshot reuse. Tags go to refs/tags/* as
+    // shared metadata, but they must not be pruned based on this local clone's
+    // view of the repo.
     //
     // NOTE: This runs `git push` locally (not through the runtime's SSHTransport),
     // so it depends on the local `ssh` CLI being available. On OpenSSH runtimes,
     // the transport already depends on that binary and shares the same ControlPath.
-    const pushArgsBase = [
-      "-C",
-      projectPath,
-      "push",
-      "--force",
-      "--prune",
-      "--no-verify",
-      remoteUrl,
-      `+refs/heads/*:${BUNDLE_REF_PREFIX}*`,
-      "+refs/tags/*:refs/tags/*",
-    ];
-    const runPush = async (useAtomic: boolean): Promise<void> => {
-      const pushArgs = useAtomic
-        ? [...pushArgsBase.slice(0, 4), "--atomic", ...pushArgsBase.slice(4)]
-        : pushArgsBase;
+    const runPush = async (pushArgs: string[]): Promise<void> => {
       using pushProc = execFileAsync("git", pushArgs, {
         env: { GIT_SSH_COMMAND: gitSshCommand },
         onStderrData: (chunk) => {
@@ -1352,9 +1354,23 @@ export class SSHRuntime extends RemoteRuntime {
       }
       throw new Error(`Failed to push to remote: ${errorMsg}`);
     };
+    const branchPushArgsBase = [
+      "-C",
+      projectPath,
+      "push",
+      "--force",
+      "--prune",
+      "--no-verify",
+      remoteUrl,
+      `+refs/heads/*:${BUNDLE_REF_PREFIX}*`,
+    ];
 
     try {
-      await runPush(true);
+      await runPush([
+        ...branchPushArgsBase.slice(0, 4),
+        "--atomic",
+        ...branchPushArgsBase.slice(4),
+      ]);
     } catch (error) {
       const errorMsg = getErrorMessage(error);
       if (!isUnsupportedAtomicPush(errorMsg)) {
@@ -1363,10 +1379,24 @@ export class SSHRuntime extends RemoteRuntime {
 
       initLogger.logStep("Remote git does not support atomic push; retrying without --atomic...");
       try {
-        await runPush(false);
+        await runPush(branchPushArgsBase);
       } catch (retryError) {
         throwPushFailure(retryError);
       }
+    }
+
+    try {
+      await runPush([
+        "-C",
+        projectPath,
+        "push",
+        "--force",
+        "--no-verify",
+        remoteUrl,
+        "+refs/tags/*:refs/tags/*",
+      ]);
+    } catch (error) {
+      throwPushFailure(error);
     }
   }
 
@@ -1377,10 +1407,11 @@ export class SSHRuntime extends RemoteRuntime {
    * transfer automatically. SSH2 runtimes keep the bundle path so sync does not
    * depend on a local OpenSSH CLI or local known_hosts state.
    *
-   * Branches land in a staging namespace (refs/mux-bundle/*) to avoid colliding
-   * with branches checked out in existing worktrees. Tags go to refs/tags/*
-   * directly. Remote tracking refs are excluded by the refspec — only local
-   * branches and tags are synchronized.
+   * Branches are the authoritative workspace-materialization state: they land in
+   * refs/mux-bundle/* so they do not collide with worktree checkouts, and they
+   * remain pruneable so branch deletions invalidate snapshot reuse. Tags still
+   * sync into refs/tags/* when a branch resync happens, but they are treated as
+   * shared metadata instead of authoritative snapshot state.
    */
   protected async syncProjectToRemote(
     projectPath: string,

--- a/tests/runtime/runtime.test.ts
+++ b/tests/runtime/runtime.test.ts
@@ -1941,6 +1941,137 @@ describeIntegration("Runtime integration tests", () => {
       }
     }, 120000);
 
+    test("initWorkspace reuses snapshots and preserves remote-only tags across later resyncs", async () => {
+      const runtime = createSSHRuntime();
+
+      const projectName = `sync-remote-tags-${Date.now()}-${Math.random().toString(36).substring(7)}`;
+      const tmpDir = await import("os").then((os) => os.tmpdir());
+      const localProjectPath = `${tmpDir}/${projectName}`;
+      const layout = buildRemoteProjectLayout(srcBaseDir, localProjectPath);
+      const firstWorkspacePath = getRemoteWorkspacePath(layout, "tags-a");
+      const secondWorkspacePath = getRemoteWorkspacePath(layout, "tags-b");
+      const thirdWorkspacePath = getRemoteWorkspacePath(layout, "tags-c");
+      const baseRepoPath = layout.baseRepoPath;
+
+      const createCapturingInitLogger = (steps: string[]) => ({
+        ...noopInitLogger,
+        logStep(step: string) {
+          steps.push(step);
+        },
+      });
+
+      const { execSync } = await import("child_process");
+      try {
+        execSync(
+          [
+            `mkdir -p "${localProjectPath}"`,
+            `cd "${localProjectPath}"`,
+            `git init -b main`,
+            `git config user.email "test@test.com"`,
+            `git config user.name "Test"`,
+            `echo "version-a" > file.txt`,
+            `git add file.txt`,
+            `git commit -m "initial"`,
+          ].join(" && "),
+          { stdio: "pipe" }
+        );
+
+        const firstInit = await runtime.initWorkspace({
+          projectPath: localProjectPath,
+          branchName: "tags-a",
+          trunkBranch: "main",
+          workspacePath: firstWorkspacePath,
+          initLogger: noopInitLogger,
+        });
+        if (!firstInit.success) {
+          throw new Error(`first initWorkspace failed: ${firstInit.error}`);
+        }
+
+        const initialBaseHead = await execBuffered(
+          runtime,
+          `git -C "${baseRepoPath}" rev-parse refs/mux-bundle/main`,
+          { cwd: "/home/testuser", timeout: 30 }
+        );
+        const initialBaseHeadOid = initialBaseHead.stdout.trim();
+        expect(initialBaseHead.exitCode).toBe(0);
+        expect(initialBaseHeadOid).not.toBe("");
+
+        const addRemoteOnlyTag = await execBuffered(
+          runtime,
+          `git -C "${baseRepoPath}" update-ref refs/tags/remote-only ${initialBaseHeadOid}`,
+          { cwd: "/home/testuser", timeout: 30 }
+        );
+        expect(addRemoteOnlyTag.exitCode).toBe(0);
+
+        const reuseSteps: string[] = [];
+        const secondInit = await runtime.initWorkspace({
+          projectPath: localProjectPath,
+          branchName: "tags-b",
+          trunkBranch: "main",
+          workspacePath: secondWorkspacePath,
+          initLogger: createCapturingInitLogger(reuseSteps),
+        });
+        if (!secondInit.success) {
+          throw new Error(`second initWorkspace failed: ${secondInit.error}`);
+        }
+        expect(reuseSteps).toContain("Reusing existing remote project snapshot");
+
+        const remoteOnlyTagBeforeResync = await execBuffered(
+          runtime,
+          `git -C "${baseRepoPath}" rev-parse refs/tags/remote-only`,
+          { cwd: "/home/testuser", timeout: 30 }
+        );
+        expect(remoteOnlyTagBeforeResync.exitCode).toBe(0);
+        expect(remoteOnlyTagBeforeResync.stdout.trim()).toBe(initialBaseHeadOid);
+
+        execSync(
+          [
+            `cd "${localProjectPath}"`,
+            `echo "version-b" > file.txt`,
+            `git add file.txt`,
+            `git commit -m "second"`,
+          ].join(" && "),
+          { stdio: "pipe" }
+        );
+        const secondCommit = execSync(`git -C "${localProjectPath}" rev-parse HEAD`, {
+          encoding: "utf8",
+        }).trim();
+
+        const thirdInit = await runtime.initWorkspace({
+          projectPath: localProjectPath,
+          branchName: "tags-c",
+          trunkBranch: "main",
+          workspacePath: thirdWorkspacePath,
+          initLogger: noopInitLogger,
+        });
+        if (!thirdInit.success) {
+          throw new Error(`third initWorkspace failed: ${thirdInit.error}`);
+        }
+
+        const updatedBaseHead = await execBuffered(
+          runtime,
+          `git -C "${baseRepoPath}" rev-parse refs/mux-bundle/main`,
+          { cwd: "/home/testuser", timeout: 30 }
+        );
+        expect(updatedBaseHead.exitCode).toBe(0);
+        expect(updatedBaseHead.stdout.trim()).toBe(secondCommit);
+
+        const remoteOnlyTagAfterResync = await execBuffered(
+          runtime,
+          `git -C "${baseRepoPath}" rev-parse refs/tags/remote-only`,
+          { cwd: "/home/testuser", timeout: 30 }
+        );
+        expect(remoteOnlyTagAfterResync.exitCode).toBe(0);
+        expect(remoteOnlyTagAfterResync.stdout.trim()).toBe(initialBaseHeadOid);
+      } finally {
+        execSync(`rm -rf "${localProjectPath}"`);
+        await execBuffered(runtime, `rm -rf "${layout.projectRoot}"`, {
+          cwd: "/home/testuser",
+          timeout: 30,
+        });
+      }
+    }, 120000);
+
     test("initWorkspace strips shared core.bare from pre-existing base repos before checkout", async () => {
       const runtime = createSSHRuntime();
 


### PR DESCRIPTION
## Summary

SSH workspace sync now treats branch refs as the authoritative snapshot contract and treats tags as shared metadata, so tag-only drift no longer forces a resync or deletes remote-only tags during later syncs.

## Background

The shared SSH base repo was previously using heads and tags for snapshot digests, reuse manifests, and prune behavior. That meant incidental tag drift could invalidate snapshot reuse, and a later sync from an arbitrary local clone could delete remote-only tags even though workspace materialization only depends on branch refs.

## Implementation

Native OpenSSH sync now pushes pruneable `refs/mux-bundle/*` branches separately from non-pruneable `refs/tags/*` metadata tags. The bundle import path mirrors that contract with a pruneable branch fetch plus a separate non-pruning tag fetch. Snapshot digests and local/remote sync manifests now compare heads only, so tag-only drift is ignored for reuse decisions. The new unit coverage checks the branch-only digest contract plus the split push/fetch argument shape, and the SSH integration regression proves a remote-only tag survives both snapshot reuse and a later branch-driven resync.

## Validation

I verified the new contract with focused SSHRuntime unit coverage, repo lint and typecheck, and targeted SSH integration scenarios that exercise both the existing stale-remote-ref regression and the new remote-only-tag preservation path.

## Risks

Tag-only local changes no longer trigger a sync on their own, so tags now update opportunistically when a branch resync happens. That is intentional: tags are shared repo metadata, and preserving them is less surprising than treating one local clone as authoritative for deleting them.

---

_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `xhigh` • Cost: `$46.65`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=xhigh costs=46.65 -->
