### PR TITLE
🤖 fix: preflight SSH base repo maintenance before sync

### DIFF
--- a/src/node/runtime/SSHRuntime.retry.test.ts
+++ b/src/node/runtime/SSHRuntime.retry.test.ts
@@ -154,6 +154,15 @@ class TestSSHRuntime extends SSHRuntime {
 class CleanupCommandSSHRuntime extends SSHRuntime {
   readonly commands: string[] = [];
   readonly timeouts: number[] = [];
+  readonly steps: string[] = [];
+
+  countObjectsStdout = "count: 0\npacks: 0\n";
+  countObjectsStderr = "";
+  countObjectsExitCode = 0;
+  promisorStdout = "/remote/src/project/.mux-base.git/objects/pack/pack-a.promisor\n";
+  gcStdout = "";
+  gcStderr = "";
+  gcExitCode = 0;
 
   constructor() {
     const config: SSHRuntimeConfig = {
@@ -167,13 +176,39 @@ class CleanupCommandSSHRuntime extends SSHRuntime {
     await this.cleanupRetryableProjectSyncFailure(baseRepoPathArg, 1, 3, abortSignal);
   }
 
+  async runEnsureHealthy(baseRepoPathArg: string, abortSignal?: AbortSignal): Promise<void> {
+    await this.ensureHealthyBaseRepoForSync(
+      baseRepoPathArg,
+      {
+        ...noopInitLogger,
+        logStep: (step) => {
+          this.steps.push(step);
+        },
+      },
+      abortSignal
+    );
+  }
+
   override exec(command: string, options: ExecOptions): Promise<ExecStream> {
     this.commands.push(command);
     this.timeouts.push(options.timeout ?? -1);
-    const stdout = command.startsWith("find ")
-      ? "/remote/src/project/.mux-base.git/objects/pack/pack-a.promisor\n"
-      : "";
-    return Promise.resolve(createExecStream(stdout));
+
+    if (command.includes("count-objects -v")) {
+      return Promise.resolve(
+        createExecStream(
+          this.countObjectsStdout,
+          this.countObjectsStderr,
+          this.countObjectsExitCode
+        )
+      );
+    }
+    if (command.startsWith("find ")) {
+      return Promise.resolve(createExecStream(this.promisorStdout));
+    }
+    if (command.includes(" gc --prune=now")) {
+      return Promise.resolve(createExecStream(this.gcStdout, this.gcStderr, this.gcExitCode));
+    }
+    return Promise.resolve(createExecStream(""));
   }
 }
 
@@ -188,7 +223,93 @@ describe("SSHRuntime project sync retry orchestration", () => {
       `find ${baseRepoPathArg}/objects/pack -name '*.promisor' -print -delete 2>/dev/null || true`,
       `git -C ${baseRepoPathArg} gc --prune=now`,
     ]);
-    expect(runtime.timeouts).toEqual([10, 60]);
+    expect(runtime.timeouts).toEqual([10, 120]);
+  });
+
+  it("proactively repairs fragmented base repos before sync", async () => {
+    const runtime = new CleanupCommandSSHRuntime();
+    const baseRepoPathArg = '"/remote/src/project/.mux-base.git"';
+    runtime.countObjectsStdout = "count: 0\npacks: 50\n";
+
+    await runtime.runEnsureHealthy(baseRepoPathArg);
+
+    expect(runtime.steps).toEqual([
+      "Shared base repository is fragmented (50 pack files); running maintenance before sync...",
+    ]);
+    expect(runtime.commands).toEqual([
+      `git -C ${baseRepoPathArg} count-objects -v`,
+      `find ${baseRepoPathArg}/objects/pack -name '*.promisor' -print -delete 2>/dev/null || true`,
+      `git -C ${baseRepoPathArg} gc --prune=now`,
+    ]);
+    expect(runtime.timeouts).toEqual([10, 10, 120]);
+  });
+
+  it("skips proactive maintenance for healthy base repos", async () => {
+    const runtime = new CleanupCommandSSHRuntime();
+    const baseRepoPathArg = '"/remote/src/project/.mux-base.git"';
+    runtime.countObjectsStdout = "count: 0\npacks: 5\n";
+
+    await runtime.runEnsureHealthy(baseRepoPathArg);
+
+    expect(runtime.steps).toEqual([]);
+    expect(runtime.commands).toEqual([`git -C ${baseRepoPathArg} count-objects -v`]);
+    expect(runtime.timeouts).toEqual([10]);
+  });
+
+  it("treats base repo health probe failures as best-effort", async () => {
+    const runtime = new CleanupCommandSSHRuntime();
+    const baseRepoPathArg = '"/remote/src/project/.mux-base.git"';
+    runtime.countObjectsExitCode = 128;
+    runtime.countObjectsStderr = "fatal: not a git repository";
+
+    await runtime.runEnsureHealthy(baseRepoPathArg);
+
+    expect(runtime.steps).toEqual([]);
+    expect(runtime.commands).toEqual([`git -C ${baseRepoPathArg} count-objects -v`]);
+    expect(runtime.timeouts).toEqual([10]);
+  });
+
+  it("keeps proactive maintenance best-effort when git gc exits non-zero", async () => {
+    const runtime = new CleanupCommandSSHRuntime();
+    const baseRepoPathArg = '"/remote/src/project/.mux-base.git"';
+    runtime.countObjectsStdout = "count: 0\npacks: 50\n";
+    runtime.gcExitCode = 1;
+    runtime.gcStderr = "warning: gc skipped";
+
+    await runtime.runEnsureHealthy(baseRepoPathArg);
+
+    expect(runtime.steps).toEqual([
+      "Shared base repository is fragmented (50 pack files); running maintenance before sync...",
+    ]);
+    expect(runtime.commands).toEqual([
+      `git -C ${baseRepoPathArg} count-objects -v`,
+      `find ${baseRepoPathArg}/objects/pack -name '*.promisor' -print -delete 2>/dev/null || true`,
+      `git -C ${baseRepoPathArg} gc --prune=now`,
+    ]);
+    expect(runtime.timeouts).toEqual([10, 10, 120]);
+  });
+
+  it("propagates aborts during proactive maintenance preflight", async () => {
+    const runtime = new CleanupCommandSSHRuntime();
+    const baseRepoPathArg = '"/remote/src/project/.mux-base.git"';
+    const abortController = new AbortController();
+    abortController.abort();
+
+    let failure: unknown;
+    try {
+      await runtime.runEnsureHealthy(baseRepoPathArg, abortController.signal);
+      throw new Error("Expected preflight maintenance to stop when aborted");
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(Error);
+    if (!(failure instanceof Error)) {
+      throw new Error("Expected aborted preflight maintenance to throw an Error");
+    }
+    expect(failure.message).toBe("Operation aborted");
+    expect(runtime.commands).toEqual([]);
+    expect(runtime.timeouts).toEqual([]);
   });
 
   it("skips cleanup and backoff when a retryable failure was user-aborted", async () => {

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -67,6 +67,10 @@ const BUNDLE_REF_PREFIX = "refs/mux-bundle/";
 
 /** Small backoff for concurrent writers healing the same shared base repo config. */
 const BASE_REPO_CONFIG_LOCK_RETRY_DELAYS_MS = [50, 100, 200];
+const BASE_REPO_HEALTH_PROBE_TIMEOUT_SECONDS = 10;
+const BASE_REPO_PROMISOR_CLEANUP_TIMEOUT_SECONDS = 10;
+const BASE_REPO_MAINTENANCE_TIMEOUT_SECONDS = 120;
+const BASE_REPO_FRAGMENTED_PACK_THRESHOLD = 25;
 const PROJECT_SYNC_MAX_ATTEMPTS = 3;
 const PROJECT_SYNC_RETRYABLE_ERRORS = [
   "pack-objects died",
@@ -382,6 +386,103 @@ export class SSHRuntime extends RemoteRuntime {
     return PROJECT_SYNC_RETRYABLE_ERRORS.some((pattern) => errorMsg.includes(pattern));
   }
 
+  private async probeBaseRepoHealth(
+    baseRepoPathArg: string,
+    abortSignal?: AbortSignal
+  ): Promise<{ packCount: number | null }> {
+    const result = await execBuffered(this, `git -C ${baseRepoPathArg} count-objects -v`, {
+      cwd: "/tmp",
+      timeout: BASE_REPO_HEALTH_PROBE_TIMEOUT_SECONDS,
+      abortSignal,
+    });
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Failed to inspect shared base repository health: ${result.stderr || result.stdout}`
+      );
+    }
+
+    const packCountMatch = /^packs:\s*(\d+)\s*$/m.exec(result.stdout);
+    return {
+      packCount: packCountMatch ? Number.parseInt(packCountMatch[1], 10) : null,
+    };
+  }
+
+  protected async repairBaseRepoForSync(
+    baseRepoPathArg: string,
+    repairContext: string,
+    abortSignal?: AbortSignal
+  ): Promise<void> {
+    if (abortSignal?.aborted) {
+      throw new Error("Operation aborted");
+    }
+
+    const promisorPackDirArg = `${baseRepoPathArg}/objects/pack`;
+    log.info(repairContext);
+
+    const promisorCleanupResult = await execBuffered(
+      this,
+      `find ${promisorPackDirArg} -name '*.promisor' -print -delete 2>/dev/null || true`,
+      {
+        cwd: "/tmp",
+        timeout: BASE_REPO_PROMISOR_CLEANUP_TIMEOUT_SECONDS,
+        abortSignal,
+      }
+    );
+    const removedPromisorCount = promisorCleanupResult.stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean).length;
+    if (removedPromisorCount > 0) {
+      log.info(
+        `Removed ${removedPromisorCount} stale promisor marker(s) during base repo maintenance`
+      );
+    }
+
+    const gcResult = await execBuffered(this, `git -C ${baseRepoPathArg} gc --prune=now`, {
+      cwd: "/tmp",
+      timeout: BASE_REPO_MAINTENANCE_TIMEOUT_SECONDS,
+      abortSignal,
+    });
+    if (gcResult.exitCode !== 0) {
+      log.warn(
+        `Remote git gc exited ${gcResult.exitCode} during base repo maintenance: ${gcResult.stderr || gcResult.stdout}`
+      );
+    }
+  }
+
+  protected async ensureHealthyBaseRepoForSync(
+    baseRepoPathArg: string,
+    initLogger: InitLogger,
+    abortSignal?: AbortSignal
+  ): Promise<void> {
+    if (abortSignal?.aborted) {
+      throw new Error("Operation aborted");
+    }
+
+    try {
+      const { packCount } = await this.probeBaseRepoHealth(baseRepoPathArg, abortSignal);
+      if (packCount == null || packCount < BASE_REPO_FRAGMENTED_PACK_THRESHOLD) {
+        return;
+      }
+
+      const packFileLabel = packCount === 1 ? "pack file" : "pack files";
+      initLogger.logStep(
+        `Shared base repository is fragmented (${packCount} ${packFileLabel}); running maintenance before sync...`
+      );
+      await this.repairBaseRepoForSync(
+        baseRepoPathArg,
+        `Running shared base repository maintenance before sync (${packCount} ${packFileLabel})`,
+        abortSignal
+      );
+    } catch (healthError) {
+      const healthErrorMsg = getErrorMessage(healthError);
+      if (abortSignal?.aborted || healthErrorMsg === "Operation aborted") {
+        throw healthError instanceof Error ? healthError : new Error(healthErrorMsg);
+      }
+      log.warn(`Shared base repository maintenance preflight failed: ${healthErrorMsg}`);
+    }
+  }
+
   protected async cleanupRetryableProjectSyncFailure(
     baseRepoPathArg: string,
     attempt: number,
@@ -392,38 +493,12 @@ export class SSHRuntime extends RemoteRuntime {
       throw new Error("Operation aborted");
     }
 
-    const promisorPackDirArg = `${baseRepoPathArg}/objects/pack`;
-    log.info(
-      `Running remote promisor cleanup and git gc before retrying sync push (attempt ${attempt + 1}/${maxAttempts})`
-    );
     try {
-      const promisorCleanupResult = await execBuffered(
-        this,
-        `find ${promisorPackDirArg} -name '*.promisor' -print -delete 2>/dev/null || true`,
-        {
-          cwd: "/tmp",
-          timeout: 10,
-          abortSignal,
-        }
+      await this.repairBaseRepoForSync(
+        baseRepoPathArg,
+        `Running remote promisor cleanup and git gc before retrying sync push (attempt ${attempt + 1}/${maxAttempts})`,
+        abortSignal
       );
-      const removedPromisorCount = promisorCleanupResult.stdout
-        .split("\n")
-        .map((line) => line.trim())
-        .filter(Boolean).length;
-      if (removedPromisorCount > 0) {
-        log.info(`Removed ${removedPromisorCount} stale promisor marker(s) before sync retry`);
-      }
-
-      const gcResult = await execBuffered(this, `git -C ${baseRepoPathArg} gc --prune=now`, {
-        cwd: "/tmp",
-        timeout: 60,
-        abortSignal,
-      });
-      if (gcResult.exitCode !== 0) {
-        log.warn(
-          `Remote git gc exited ${gcResult.exitCode} before sync retry: ${gcResult.stderr || gcResult.stdout}`
-        );
-      }
     } catch (cleanupError) {
       const cleanupErrorMsg = getErrorMessage(cleanupError);
       if (abortSignal?.aborted || cleanupErrorMsg === "Operation aborted") {
@@ -1504,6 +1579,10 @@ export class SSHRuntime extends RemoteRuntime {
     const useNativeGitPush = this.transport instanceof OpenSSHTransport;
     const snapshotDigest = await this.computeSnapshotDigest(projectPath);
     const baseRepoPathArg = await this.ensureBaseRepo(projectPath, initLogger, abortSignal);
+
+    // Treat the shared bare repo as a managed cache: verify its health before
+    // we ask Git to negotiate another sync against a fragmented object store.
+    await this.ensureHealthyBaseRepoForSync(baseRepoPathArg, initLogger, abortSignal);
 
     const snapshotStatusCheck = await execBuffered(
       this,


### PR DESCRIPTION
## Summary

This makes SSH sync treat the shared `.mux-base.git` as a managed cache whose health is checked before the first transfer, so fragmented base repos get repaired up front instead of spending five minutes timing out and only then healing on retry.

## Background

Latest `main` already fixes the ref-contract issue by making branch refs authoritative and tags non-authoritative metadata. During follow-up testing on `pog2.coder`, however, workspace init still spent about 5 minutes in `Pushing to remote...` before succeeding on retry. Remote inspection showed the shared base repo had about 50 pack files, zero `.promisor` markers, and had grown to roughly 1.5G. That pointed to pack fragmentation in the long-lived bare cache, not ref churn, as the reason the first attempt stalled until the hardcoded 300s push timeout fired.

## Implementation

`SSHRuntime` now has an explicit base-repo health preflight. Before snapshot reuse checks or transfer begin, it probes the shared base repo with `git count-objects -v` and looks at pack count. When the repo is fragmented enough to be unhealthy, it logs the reason in the init logger and runs the same repair primitive we already trusted on the retry path: delete stale `.promisor` markers and run `git gc --prune=now`. The retry cleanup now delegates to that same shared repair helper, so proactive and reactive maintenance stay aligned. I also raised the maintenance timeout from 60s to 120s, which is safer for the 1G+ shared repos we observed in practice.

## Validation

I ran `make static-check`, `bun test src/node/runtime/SSHRuntime.retry.test.ts`, `bun test src/node/runtime/SSHRuntime.syncContract.test.ts`, `make typecheck`, and the focused SSH integration slices for the stale remote-tracking-ref regression and the remote-only-tag preservation regression.

## Risks

The main tradeoff is that a degraded shared base repo now pays some maintenance cost before the first sync attempt instead of after a 300s timeout. That is intentional and should be a much better UX. The maintenance remains non-destructive: it does not recreate `.mux-base.git`, runs under the existing per-project sync lock, and keeps retry-time cleanup as a fallback if the preflight misses a case or the repair itself fails.

---

_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `xhigh` • Cost: `$11.02`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=xhigh costs=11.02 -->
