### PR TITLE
🤖 fix: update heartbeat indicator immediately when heartbeats are toggled

### DIFF
--- a/src/browser/hooks/useWorkspaceHeartbeat.test.tsx
+++ b/src/browser/hooks/useWorkspaceHeartbeat.test.tsx
@@ -1,0 +1,206 @@
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { GlobalWindow } from "happy-dom";
+import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
+import type { HeartbeatFormSettings } from "./useWorkspaceHeartbeat";
+
+interface HeartbeatApi {
+  workspace: {
+    heartbeat: {
+      get: (input: { workspaceId: string }) => Promise<HeartbeatFormSettings | null>;
+      set: (input: { workspaceId: string } & HeartbeatFormSettings) => Promise<{
+        success: boolean;
+        error?: string;
+      }>;
+    };
+  };
+  config: {
+    getConfig: () => Promise<{
+      heartbeatDefaultIntervalMs?: number;
+      heartbeatDefaultPrompt?: string;
+    }>;
+  };
+}
+
+const TEST_WORKSPACE_ID = "workspace-1";
+
+type WorkspaceMetadataMap = Map<string, FrontendWorkspaceMetadata>;
+type WorkspaceMetadataUpdater = (prev: WorkspaceMetadataMap) => WorkspaceMetadataMap;
+
+let apiMock: HeartbeatApi | null = null;
+let capturedWorkspaceMetadataUpdate: WorkspaceMetadataUpdater | null = null;
+const setWorkspaceMetadataMock = mock((update: WorkspaceMetadataUpdater) => {
+  capturedWorkspaceMetadataUpdate = update;
+});
+
+void mock.module("@/browser/contexts/API", () => ({
+  useAPI: () => ({ api: apiMock }),
+}));
+
+void mock.module("@/browser/contexts/WorkspaceContext", () => ({
+  useWorkspaceActions: () => ({
+    setWorkspaceMetadata: setWorkspaceMetadataMock,
+  }),
+}));
+
+import { useWorkspaceHeartbeat } from "./useWorkspaceHeartbeat";
+
+function createMetadata(
+  overrides: Partial<FrontendWorkspaceMetadata> = {}
+): FrontendWorkspaceMetadata {
+  return {
+    id: TEST_WORKSPACE_ID,
+    name: "workspace-1",
+    title: "Workspace 1",
+    projectName: "Project",
+    projectPath: "/tmp/project",
+    namedWorkspacePath: "/tmp/project/workspace-1",
+    runtimeConfig: { type: "local" },
+    createdAt: "2026-04-09T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function applyCapturedMetadataUpdate(
+  metadata: FrontendWorkspaceMetadata
+): FrontendWorkspaceMetadata {
+  const update = capturedWorkspaceMetadataUpdate;
+  if (!update) {
+    throw new Error("Expected workspace metadata update to be captured");
+  }
+
+  const nextMap = update(new Map([[metadata.id, metadata]]));
+  const nextMetadata = nextMap.get(metadata.id);
+  if (!nextMetadata) {
+    throw new Error("Expected updated workspace metadata to exist");
+  }
+
+  return nextMetadata;
+}
+
+describe("useWorkspaceHeartbeat", () => {
+  let originalWindow: typeof globalThis.window;
+  let originalDocument: typeof globalThis.document;
+
+  beforeEach(() => {
+    originalWindow = globalThis.window;
+    originalDocument = globalThis.document;
+    globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
+    globalThis.document = globalThis.window.document;
+    capturedWorkspaceMetadataUpdate = null;
+    setWorkspaceMetadataMock.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    mock.restore();
+    apiMock = null;
+    capturedWorkspaceMetadataUpdate = null;
+    globalThis.window = originalWindow;
+    globalThis.document = originalDocument;
+  });
+
+  test("optimistically enables heartbeat metadata after a successful save", async () => {
+    const saveHeartbeat = mock(() => Promise.resolve({ success: true }));
+    apiMock = {
+      workspace: {
+        heartbeat: {
+          get: () => Promise.resolve(null),
+          set: saveHeartbeat,
+        },
+      },
+      config: {
+        getConfig: () => Promise.resolve({}),
+      },
+    };
+
+    const { result } = renderHook(() => useWorkspaceHeartbeat({ workspaceId: TEST_WORKSPACE_ID }));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const nextSettings: HeartbeatFormSettings = {
+      enabled: true,
+      intervalMs: 120000,
+      contextMode: "normal",
+      message: "Status update",
+    };
+
+    let saveSucceeded = false;
+    await act(async () => {
+      saveSucceeded = await result.current.save(nextSettings);
+    });
+
+    expect(saveSucceeded).toBe(true);
+    expect(saveHeartbeat).toHaveBeenCalledWith({
+      workspaceId: TEST_WORKSPACE_ID,
+      ...nextSettings,
+    });
+    expect(setWorkspaceMetadataMock).toHaveBeenCalledTimes(1);
+
+    const updatedMetadata = applyCapturedMetadataUpdate(
+      createMetadata({
+        heartbeat: {
+          enabled: false,
+          intervalMs: 60000,
+          contextMode: "normal",
+        },
+      })
+    );
+
+    expect(updatedMetadata.heartbeat).toEqual(nextSettings);
+  });
+
+  test("optimistically disables heartbeat metadata after a successful save", async () => {
+    const initialSettings: HeartbeatFormSettings = {
+      enabled: true,
+      intervalMs: 120000,
+      contextMode: "compact",
+      message: "Keep watching",
+    };
+    apiMock = {
+      workspace: {
+        heartbeat: {
+          get: () => Promise.resolve(initialSettings),
+          set: () => Promise.resolve({ success: true }),
+        },
+      },
+      config: {
+        getConfig: () => Promise.resolve({}),
+      },
+    };
+
+    const { result } = renderHook(() => useWorkspaceHeartbeat({ workspaceId: TEST_WORKSPACE_ID }));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const nextSettings: HeartbeatFormSettings = {
+      enabled: false,
+      intervalMs: initialSettings.intervalMs,
+      contextMode: initialSettings.contextMode,
+      message: initialSettings.message,
+    };
+
+    let saveSucceeded = false;
+    await act(async () => {
+      saveSucceeded = await result.current.save(nextSettings);
+    });
+
+    expect(saveSucceeded).toBe(true);
+    expect(setWorkspaceMetadataMock).toHaveBeenCalledTimes(1);
+
+    const updatedMetadata = applyCapturedMetadataUpdate(
+      createMetadata({
+        heartbeat: initialSettings,
+      })
+    );
+
+    expect(updatedMetadata.heartbeat?.enabled).toBe(false);
+    expect(updatedMetadata.heartbeat?.intervalMs).toBe(initialSettings.intervalMs);
+    expect(updatedMetadata.heartbeat?.contextMode).toBe(initialSettings.contextMode);
+    expect(updatedMetadata.heartbeat?.message).toBe(initialSettings.message);
+  });
+});

--- a/src/browser/hooks/useWorkspaceHeartbeat.ts
+++ b/src/browser/hooks/useWorkspaceHeartbeat.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAPI } from "@/browser/contexts/API";
+import { useWorkspaceActions } from "@/browser/contexts/WorkspaceContext";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import {
   HEARTBEAT_DEFAULT_CONTEXT_MODE,
@@ -83,6 +84,7 @@ export function useWorkspaceHeartbeat(
 ): UseWorkspaceHeartbeatResult {
   const { workspaceId } = params;
   const { api } = useAPI();
+  const { setWorkspaceMetadata } = useWorkspaceActions();
   const [settings, setSettings] = useState<HeartbeatFormSettings>(() =>
     getDefaultHeartbeatSettings()
   );
@@ -180,7 +182,21 @@ export function useWorkspaceHeartbeat(
           return true;
         }
 
-        setSettings(normalizeHeartbeatSettings(next));
+        const normalizedSettings = normalizeHeartbeatSettings(next);
+        setWorkspaceMetadata((prev) => {
+          const existingMetadata = prev.get(workspaceIdAtCall);
+          if (!existingMetadata) {
+            return prev;
+          }
+
+          const updated = new Map(prev);
+          updated.set(workspaceIdAtCall, {
+            ...existingMetadata,
+            heartbeat: normalizedSettings,
+          });
+          return updated;
+        });
+        setSettings(normalizedSettings);
         setIsSaving(false);
         return true;
       } catch (saveError) {
@@ -199,7 +215,7 @@ export function useWorkspaceHeartbeat(
         return false;
       }
     },
-    [api, workspaceId]
+    [api, setWorkspaceMetadata, workspaceId]
   );
 
   return { settings, isLoading, isSaving, error, save, globalDefaultPrompt };

--- a/src/browser/utils/workspace.test.ts
+++ b/src/browser/utils/workspace.test.ts
@@ -5,7 +5,7 @@ import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import { getWorkspaceSidebarKey } from "./workspace";
 
 function createWorkspaceMeta(
-  taskStatus: FrontendWorkspaceMetadata["taskStatus"]
+  overrides: Partial<FrontendWorkspaceMetadata> = {}
 ): FrontendWorkspaceMetadata {
   return {
     id: "workspace-1",
@@ -14,15 +14,34 @@ function createWorkspaceMeta(
     projectPath: "/tmp/repo",
     runtimeConfig: { type: "local" },
     namedWorkspacePath: "/tmp/repo/feature-branch",
-    taskStatus,
+    ...overrides,
   };
 }
 
 describe("getWorkspaceSidebarKey", () => {
   test("changes when taskStatus changes", () => {
-    const running = createWorkspaceMeta("running");
-    const reported = createWorkspaceMeta("reported");
+    const running = createWorkspaceMeta({ taskStatus: "running" });
+    const reported = createWorkspaceMeta({ taskStatus: "reported" });
 
     expect(getWorkspaceSidebarKey(running)).not.toBe(getWorkspaceSidebarKey(reported));
+  });
+
+  test("changes when heartbeat enabled changes", () => {
+    const disabled = createWorkspaceMeta({
+      heartbeat: {
+        enabled: false,
+        intervalMs: 1_800_000,
+        contextMode: "normal",
+      },
+    });
+    const enabled = createWorkspaceMeta({
+      heartbeat: {
+        enabled: true,
+        intervalMs: 1_800_000,
+        contextMode: "normal",
+      },
+    });
+
+    expect(getWorkspaceSidebarKey(disabled)).not.toBe(getWorkspaceSidebarKey(enabled));
   });
 });

--- a/src/browser/utils/workspace.ts
+++ b/src/browser/utils/workspace.ts
@@ -10,6 +10,7 @@ import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 export function getWorkspaceSidebarKey(meta: FrontendWorkspaceMetadata): string {
   const initKey = meta.isInitializing === true ? "initializing" : "";
   const removingKey = meta.isRemoving === true ? "removing" : "";
+  const heartbeatEnabledKey = meta.heartbeat?.enabled === true ? "heartbeat-enabled" : "";
 
   return [
     meta.id,
@@ -17,6 +18,7 @@ export function getWorkspaceSidebarKey(meta: FrontendWorkspaceMetadata): string 
     meta.title ?? "", // Display title (falls back to name in UI)
     initKey,
     removingKey,
+    heartbeatEnabledKey, // Heartbeat icon replaces the seen-state archive affordance in the sidebar.
     meta.parentWorkspaceId ?? "", // Nested sidebar indentation/order
     meta.taskStatus ?? "", // Task lifecycle label/state for sub-agent rows
     meta.agentType ?? "", // Agent preset badge/label (future)


### PR DESCRIPTION
> Mux opened this PR on Mike's behalf.

## Summary
Update workspace heartbeat saves so the sidebar heartbeat indicator appears and disappears immediately when heartbeats are toggled.

## Background
The heartbeat modal was successfully persisting workspace heartbeat settings, but dogfooding the feature in a dev-server sandbox showed the sidebar still lagged behind. On a seen workspace with persisted heartbeat settings, the heart icon did not rerender immediately after toggling heartbeats.

## Implementation
- update `useWorkspaceHeartbeat` to optimistically write the normalized heartbeat settings into `WorkspaceContext` after a successful save
- include heartbeat enabled state in `getWorkspaceSidebarKey` so `sortedWorkspacesByProject` invalidates and the sidebar rerenders when the heartbeat icon should change
- add focused tests for the optimistic metadata update and the sidebar key change

## Validation
- dogfooded the feature with `make dev-server-sandbox` and `agent-browser`, reproducing the missing immediate rerender on a seen workspace with persisted heartbeat settings
- `bun test src/browser/hooks/useWorkspaceHeartbeat.test.tsx src/browser/utils/workspace.test.ts`
- `bun x eslint src/browser/hooks/useWorkspaceHeartbeat.ts src/browser/hooks/useWorkspaceHeartbeat.test.tsx src/browser/utils/workspace.ts src/browser/utils/workspace.test.ts`
- `make static-check` reached the `hadolint` step, but this environment does not have `hadolint` installed locally

## Risks
Low. The follow-up change only broadens the sidebar comparison key for a display-relevant field that already controls heartbeat icon rendering.

---

_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `xhigh` • Cost: `$6.27`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=xhigh costs=6.27 -->
