### PR TITLE
fix: bump @coder/mux-md-client to 0.1.0-main.32

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "@ai-sdk/openai-compatible": "^2.0.27",
         "@ai-sdk/xai": "^3.0.47",
         "@aws-sdk/credential-providers": "^3.940.0",
-        "@coder/mux-md-client": "0.1.0-main.29",
+        "@coder/mux-md-client": "0.1.0-main.32",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -562,7 +562,7 @@
 
     "@chevrotain/utils": ["@chevrotain/utils@11.0.3", "", {}, "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="],
 
-    "@coder/mux-md-client": ["@coder/mux-md-client@0.1.0-main.29", "", { "dependencies": { "@noble/curves": "^2.0.1", "@noble/ed25519": "^3.0.0", "@noble/hashes": "^2.0.1" } }, "sha512-TbpDCErMCzi8Dkq9fihMvVQWmpSuvcjoccBQLERymQD+eaWXOUvKJUrADvHix3Jt7TwwrKMpd3sfSnlF88kQUg=="],
+    "@coder/mux-md-client": ["@coder/mux-md-client@0.1.0-main.32", "", { "dependencies": { "@noble/curves": "^2.0.1", "@noble/ed25519": "^3.0.0", "@noble/hashes": "^2.0.1" } }, "sha512-KNCXhnhq1VEr0TbLXm3P5QKGqkUBmjKLfRECviQY3SHJuYC2Pswzi3qz8HR1PIDeysIZ2kP7YJbXr2VbQeos8g=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@ai-sdk/openai-compatible": "^2.0.27",
     "@ai-sdk/xai": "^3.0.47",
     "@aws-sdk/credential-providers": "^3.940.0",
-    "@coder/mux-md-client": "0.1.0-main.29",
+    "@coder/mux-md-client": "0.1.0-main.32",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",


### PR DESCRIPTION
## Summary

Bumps `@coder/mux-md-client` from `0.1.0-main.29` to `0.1.0-main.32`, picking up the `@noble/ed25519` v3 hash config fix from https://github.com/coder/mux-md/pull/38.

## Problem

Mux crashes on startup because `@coder/mux-md-client`'s `signing.ts` uses the v2 `ed.etc.sha512Sync` pattern, which throws on `@noble/ed25519` v3 (frozen `ed.etc` object):

```
TypeError: Cannot add property sha512Sync, object is not extensible
    at Object.<anonymous> (@coder/mux-md-client/src/signing.ts:14:17)
```

Since `signingService.ts` imports `@coder/mux-md-client` at the top level, this takes down the server.

## Fix

Dependency bump only — the actual code fix is in `@coder/mux-md-client@0.1.0-main.32`.