### PR TITLE
🤖 fix: bump @coder/mux-md-client to 0.1.0-main.32

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "@ai-sdk/openai-compatible": "^2.0.27",
         "@ai-sdk/xai": "^3.0.47",
         "@aws-sdk/credential-providers": "^3.940.0",
-        "@coder/mux-md-client": "0.1.0-main.29",
+        "@coder/mux-md-client": "0.1.0-main.32",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -562,7 +562,7 @@
 
     "@chevrotain/utils": ["@chevrotain/utils@11.0.3", "", {}, "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="],
 
-    "@coder/mux-md-client": ["@coder/mux-md-client@0.1.0-main.29", "", { "dependencies": { "@noble/curves": "^2.0.1", "@noble/ed25519": "^3.0.0", "@noble/hashes": "^2.0.1" } }, "sha512-TbpDCErMCzi8Dkq9fihMvVQWmpSuvcjoccBQLERymQD+eaWXOUvKJUrADvHix3Jt7TwwrKMpd3sfSnlF88kQUg=="],
+    "@coder/mux-md-client": ["@coder/mux-md-client@0.1.0-main.32", "", { "dependencies": { "@noble/curves": "^2.0.1", "@noble/ed25519": "^3.0.0", "@noble/hashes": "^2.0.1" } }, "sha512-KNCXhnhq1VEr0TbLXm3P5QKGqkUBmjKLfRECviQY3SHJuYC2Pswzi3qz8HR1PIDeysIZ2kP7YJbXr2VbQeos8g=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 

--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,7 @@
 
             outputHashMode = "recursive";
             # Marker used by scripts/update_flake_hash.sh to update this hash in place.
-            outputHash = "sha256-cXdonGfzNOz7GiAOyigGjKekRd/9ndy+0u6F7TxWd5E="; # mux-offline-cache-hash
+            outputHash = "sha256-WvzB3zFWrWA2mPCWIg/vVlDZbUFTWNTgL52TumiWvyM="; # mux-offline-cache-hash
           };
 
           configurePhase = ''

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@ai-sdk/openai-compatible": "^2.0.27",
     "@ai-sdk/xai": "^3.0.47",
     "@aws-sdk/credential-providers": "^3.940.0",
-    "@coder/mux-md-client": "0.1.0-main.29",
+    "@coder/mux-md-client": "0.1.0-main.32",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",


### PR DESCRIPTION
## Summary
Bump `@coder/mux-md-client` from `0.1.0-main.29` to `0.1.0-main.32`, update `bun.lock`, and refresh the Nix offline cache hash so CI matches the new lockfile contents.

## Background
Mux uses `@coder/mux-md-client` for Markdown/signing helpers. This keeps the app aligned with the newer client release without changing local integration code.

## Implementation
- update the dependency version in `package.json`
- refresh the corresponding `bun.lock` entry for `@coder/mux-md-client`
- update the `flake.nix` offline cache hash after the CI flake hash check reported drift from the new lockfile contents

## Validation
- `make static-check`
- `bun test src/node/services/signingService.test.ts`
- CI `Flake Hash Check` output used to refresh the offline cache hash, then `make static-check` rerun locally

## Risks
Low. This is a dependency-only bump plus the corresponding `flake.nix` hash refresh required by CI.

---

_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `high` • Cost: `$0.29`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=high costs=0.29 -->
