### PR TITLE
🤖 fix: restore Cmd+. agent cycling on macOS

### DIFF
--- a/src/browser/contexts/AgentContext.test.tsx
+++ b/src/browser/contexts/AgentContext.test.tsx
@@ -331,7 +331,7 @@ describe("AgentContext", () => {
 
     fireEvent.keyDown(window, {
       key: ".",
-      ctrlKey: true,
+      code: "Period",
       metaKey: true,
     });
 
@@ -358,7 +358,7 @@ describe("AgentContext", () => {
 
     fireEvent.keyDown(window, {
       key: ".",
-      ctrlKey: true,
+      code: "Period",
       metaKey: true,
     });
 
@@ -409,13 +409,12 @@ describe("AgentContext", () => {
       // Cycle and secondary shortcut actions should no-op as well.
       fireEvent.keyDown(window, {
         key: ".",
-        ctrlKey: true,
+        code: "Period",
         metaKey: true,
       });
       fireEvent.keyDown(window, {
         key: ">",
         code: "Period",
-        ctrlKey: true,
         metaKey: true,
         shiftKey: true,
       });
@@ -464,7 +463,7 @@ describe("AgentContext", () => {
 
       fireEvent.keyDown(window, {
         key: ".",
-        ctrlKey: true,
+        code: "Period",
         metaKey: true,
       });
 

--- a/src/browser/utils/ui/keybinds.test.ts
+++ b/src/browser/utils/ui/keybinds.test.ts
@@ -71,6 +71,20 @@ describe("CYCLE_MODEL keybind (Ctrl+/)", () => {
   });
 });
 
+describe("CYCLE_AGENT keybind (Ctrl/Cmd+.)", () => {
+  it("matches Cmd+. on macOS via the Period key code", () => {
+    globalThis.window = { api: { platform: "darwin" } } as unknown as Window & typeof globalThis;
+    const event = createEvent({ key: ".", code: "Period", metaKey: true });
+    expect(matchesKeybind(event, KEYBINDS.CYCLE_AGENT)).toBe(true);
+  });
+
+  it("matches Cmd+Shift+Period on layouts where Period requires Shift", () => {
+    globalThis.window = { api: { platform: "darwin" } } as unknown as Window & typeof globalThis;
+    const event = createEvent({ key: ">", code: "Period", metaKey: true, shiftKey: true });
+    expect(matchesKeybind(event, KEYBINDS.CYCLE_AGENT)).toBe(true);
+  });
+});
+
 test("removed auto agent toggle keybind", () => {
   const removedKey = ["TOGGLE", "AUTO", "AGENT"].join("_");
   expect(KEYBINDS).not.toHaveProperty(removedKey);

--- a/src/browser/utils/ui/keybinds.ts
+++ b/src/browser/utils/ui/keybinds.ts
@@ -286,7 +286,9 @@ export const KEYBINDS = {
   TOGGLE_AGENT: { key: "A", ctrl: true, shift: true },
 
   /** Cycle to next manual agent without opening picker */
-  CYCLE_AGENT: { key: ".", ctrl: true },
+  // Use the physical Period key so Cmd+. keeps working on macOS and layouts
+  // where KeyboardEvent.key varies for this shortcut.
+  CYCLE_AGENT: { key: ".", code: "Period", ctrl: true, allowShift: true },
 
   /** Send message / Submit form */
   SEND_MESSAGE: { key: "Enter" },


### PR DESCRIPTION
> Mux is working on behalf of Mike.

## Summary
Restore Cmd+. agent cycling on macOS by matching the physical Period key instead of relying only on `KeyboardEvent.key`.

## Implementation
- update `CYCLE_AGENT` to match `code: "Period"`
- allow shifted Period layouts so the shortcut still matches when the key reports `>`
- add matcher coverage and update the agent context tests to use the macOS Period event shape

## Validation
- `bun test src/browser/utils/ui/keybinds.test.ts src/browser/contexts/AgentContext.test.tsx`
- `make typecheck`
- `bun x eslint src/browser/utils/ui/keybinds.ts src/browser/utils/ui/keybinds.test.ts src/browser/contexts/AgentContext.test.tsx`
- `make static-check` (using a temporary `hadolint` binary because `hadolint` is not installed in this workspace)

---

_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `xhigh` • Cost: `$2.00`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=xhigh costs=2.00 -->
