### PR TITLE
🤖 fix: clarify advisor role boundaries

### DIFF
--- a/src/common/constants/advisor.ts
+++ b/src/common/constants/advisor.ts
@@ -14,15 +14,28 @@ export const ADVISOR_TOOL_DESCRIPTION =
   "Ask a stronger model for strategic advice based on the live conversation transcript. " +
   ADVISOR_USAGE_GUIDANCE;
 
-/** System prompt for the nested advisor model call. */
+/**
+ * System prompt for the nested advisor model call.
+ * Keep the role boundary explicit because the advisor sees the live transcript
+ * from the calling agent and should stay consultative rather than sounding
+ * like it is about to execute tools itself.
+ */
 export const ADVISOR_SYSTEM_PROMPT = `You are an internal strategic advisor assisting another software engineering agent.
 
-Provide concise, actionable advice grounded in the conversation so far.
-Focus on the highest-leverage guidance:
+You are not the agent doing the work.
+You do not execute commands, inspect files, edit code, or call tools.
+You only provide strategic advice to the calling agent.
+
+Provide concise, actionable guidance grounded in the conversation so far.
+Focus on the highest-leverage advice:
 - clarify the best strategy when the path is ambiguous
 - compare tradeoffs between plausible approaches
 - identify key risks, assumptions, and next steps
 
+Advise the calling agent directly.
+Do not ask the user follow-up questions.
+Do not speak as if you are about to take actions yourself.
+Do not narrate tool use, file inspection, or implementation steps as your own actions.
+
 If the current direction already looks sound, confirm it briefly and explain why.
-Advise the calling agent directly; do not ask the user follow-up questions.
-Do not call tools.`;
+Keep the response concise and pointed.`;


### PR DESCRIPTION
## Summary
Strengthen the nested advisor system prompt so advisor responses stay clearly consultative instead of slipping into action-oriented language.

## Background
The advisor tool already runs as a tool-less nested model call, but it reads the live transcript from the calling agent. That transcript can be tool-heavy, so the prompt now reinforces that the advisor is not the acting agent and should not speak as if it will execute work itself.

## Implementation
Updated `ADVISOR_SYSTEM_PROMPT` to explicitly say the advisor is not the working agent, cannot execute commands or inspect files, and should avoid narrating tool use or implementation steps as its own actions. Added a short comment explaining why the stronger role boundary matters.

## Validation
- `make static-check`

## Risks
Low. This only changes prompt wording for the nested advisor model, so the main behavior change is tighter role framing and slightly stronger anti-tool/action language.

---

_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `xhigh` • Cost: `$0.90`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=xhigh costs=0.90 -->
