### PR TITLE
🤖 feat: track advisor tool usage in session cost totals

### DIFF
--- a/src/common/utils/tools/tools.ts
+++ b/src/common/utils/tools/tools.ts
@@ -1,4 +1,5 @@
 import { type LanguageModel, type Tool } from "ai";
+import type { LanguageModelV2Usage } from "@ai-sdk/provider";
 import { cloneToolPreservingDescriptors } from "@/common/utils/tools/cloneToolPreservingDescriptors";
 import { createFileReadTool } from "@/node/services/tools/file_read";
 import { createAttachFileTool } from "@/node/services/tools/attach_file";
@@ -57,6 +58,16 @@ import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
 import type { ModelMessage } from "@/common/types/message";
 import type { ProjectRef } from "@/common/types/workspace";
 
+export interface ToolModelUsageEvent {
+  source: "tool";
+  toolName: string;
+  model: string;
+  usage: LanguageModelV2Usage;
+  providerMetadata?: Record<string, unknown>;
+  toolCallId?: string;
+  timestamp: number;
+}
+
 /**
  * Configuration for tools that need runtime context
  */
@@ -100,6 +111,8 @@ export interface ToolConfiguration {
   recordFileState?: (filePath: string, state: FileState) => Promise<void>;
   /** Callback to notify that provider/config was written (triggers hot-reload). */
   onConfigChanged?: () => void;
+  /** Best-effort callback for recording tool-initiated model usage in session totals. */
+  reportModelUsage?: (event: ToolModelUsageEvent) => void;
   /** Task orchestration for sub-agent tasks */
   taskService?: TaskService;
   /** Enable agent_report tool (only valid for child task workspaces) */

--- a/src/node/services/agentSession.disposeRace.test.ts
+++ b/src/node/services/agentSession.disposeRace.test.ts
@@ -206,6 +206,102 @@ describe("AgentSession disposal race conditions", () => {
     });
   });
 
+  test("forwards session-usage-delta events to onChatEvent subscribers for the matching workspace", () => {
+    const aiHandlers = new Map<string, (...args: unknown[]) => void>();
+
+    const aiService: AIService = {
+      on(eventName: string | symbol, listener: (...args: unknown[]) => void) {
+        aiHandlers.set(String(eventName), listener);
+        return this;
+      },
+      off(_eventName: string | symbol, _listener: (...args: unknown[]) => void) {
+        return this;
+      },
+      stopStream: mock(() => Promise.resolve(Ok(undefined))),
+      isStreaming: mock(() => false),
+      streamMessage: mock(() => Promise.resolve(Ok(undefined))),
+    } as unknown as AIService;
+
+    const historyService: HistoryService = {
+      appendToHistory: mock(() => Promise.resolve(Ok(undefined))),
+    } as unknown as HistoryService;
+
+    const initStateManager: InitStateManager = {
+      on(_eventName: string | symbol, _listener: (...args: unknown[]) => void) {
+        return this;
+      },
+      off(_eventName: string | symbol, _listener: (...args: unknown[]) => void) {
+        return this;
+      },
+    } as unknown as InitStateManager;
+
+    const backgroundProcessManager: BackgroundProcessManager = {
+      cleanup: mock(() => Promise.resolve()),
+      setMessageQueued: mock(() => undefined),
+    } as unknown as BackgroundProcessManager;
+
+    const config: Config = {
+      srcDir: "/tmp",
+      getSessionDir: mock(() => "/tmp"),
+    } as unknown as Config;
+
+    const session = new AgentSession({
+      workspaceId: "ws",
+      config,
+      historyService,
+      aiService,
+      initStateManager,
+      backgroundProcessManager,
+    });
+
+    const chatEvents: Array<{ workspaceId: string; message: unknown }> = [];
+    session.onChatEvent((event) => {
+      chatEvents.push(event);
+    });
+
+    const usageDeltaPayload = {
+      "anthropic:claude-sonnet-4-20250514": {
+        input: { tokens: 10, cost_usd: 0.005 },
+        cached: { tokens: 0, cost_usd: 0 },
+        cacheCreate: { tokens: 0, cost_usd: 0 },
+        output: { tokens: 5, cost_usd: 0.005 },
+        reasoning: { tokens: 0, cost_usd: 0 },
+      },
+    };
+
+    const sessionUsageDelta = aiHandlers.get("session-usage-delta");
+    expect(sessionUsageDelta).toBeDefined();
+
+    sessionUsageDelta?.({
+      type: "session-usage-delta",
+      workspaceId: "other-workspace",
+      sourceWorkspaceId: "other-workspace",
+      byModelDelta: usageDeltaPayload,
+      timestamp: 100,
+    });
+    expect(chatEvents).toHaveLength(0);
+
+    sessionUsageDelta?.({
+      type: "session-usage-delta",
+      workspaceId: "ws",
+      sourceWorkspaceId: "ws",
+      byModelDelta: usageDeltaPayload,
+      timestamp: 101,
+    });
+
+    expect(chatEvents).toHaveLength(1);
+    expect(chatEvents[0]).toEqual({
+      workspaceId: "ws",
+      message: {
+        type: "session-usage-delta",
+        workspaceId: "ws",
+        sourceWorkspaceId: "ws",
+        byModelDelta: usageDeltaPayload,
+        timestamp: 101,
+      },
+    });
+  });
+
   test("does not reset auto-retry intent for synthetic or rejected sends", async () => {
     const aiService: AIService = {
       on(_eventName: string | symbol, _listener: (...args: unknown[]) => void) {

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -3851,6 +3851,9 @@ export class AgentSession {
     forward("advisor-phase", (payload) => {
       this.emitChatEvent(payload);
     });
+    forward("session-usage-delta", (payload) => {
+      this.emitChatEvent(payload);
+    });
     forward("tool-call-delta", (payload) => {
       this.markActiveStreamHadAnyOutput();
       this.emitChatEvent(payload);

--- a/src/node/services/aiService.test.ts
+++ b/src/node/services/aiService.test.ts
@@ -1888,15 +1888,37 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
       throw new Error("Expected tool usage event to produce display usage");
     }
 
+    const canonicalModel = normalizeToCanonical(event.model);
+    const callSequence: string[] = [];
+    let sessionUsageDeltaEvent: unknown;
+    harness.service.once("session-usage-delta", (payload) => {
+      callSequence.push("emit");
+      sessionUsageDeltaEvent = payload;
+    });
+
+    recordUsage.mockImplementationOnce(() => {
+      callSequence.push("recordUsage");
+      return Promise.resolve(undefined);
+    });
+
     reportModelUsage(event);
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(recordUsage).toHaveBeenCalledWith(
-      workspaceId,
-      normalizeToCanonical(event.model),
-      expectedDisplayUsage
-    );
+    expect(recordUsage).toHaveBeenCalledWith(workspaceId, canonicalModel, expectedDisplayUsage);
+    expect(callSequence).toEqual(["recordUsage", "emit"]);
+    expect(sessionUsageDeltaEvent).toBeDefined();
+    if (typeof sessionUsageDeltaEvent !== "object" || sessionUsageDeltaEvent === null) {
+      throw new Error("Expected session-usage-delta event payload");
+    }
+    const sessionUsageDeltaRecord = sessionUsageDeltaEvent as Record<string, unknown>;
+    expect(sessionUsageDeltaRecord.type).toBe("session-usage-delta");
+    expect(sessionUsageDeltaRecord.workspaceId).toBe(workspaceId);
+    expect(sessionUsageDeltaRecord.sourceWorkspaceId).toBe(workspaceId);
+    expect(sessionUsageDeltaRecord.byModelDelta).toEqual({
+      [canonicalModel]: expectedDisplayUsage,
+    });
+    expect(typeof sessionUsageDeltaRecord.timestamp).toBe("number");
   });
 
   it("logs and swallows tool model usage persistence failures", async () => {

--- a/src/node/services/aiService.test.ts
+++ b/src/node/services/aiService.test.ts
@@ -45,6 +45,8 @@ import type {
   StreamAbortEvent,
   StreamEndEvent,
 } from "@/common/types/stream";
+import { log } from "./log";
+import type { SessionUsageService } from "./sessionUsageService";
 import type { StreamManager } from "./streamManager";
 import { ExperimentsService } from "./experimentsService";
 import type { DevToolsService } from "./devToolsService";
@@ -53,6 +55,9 @@ import * as agentResolution from "./agentResolution";
 import * as streamContextBuilder from "./streamContextBuilder";
 import * as messagePipeline from "./messagePipeline";
 import * as toolAssembly from "./toolAssembly";
+import type { ToolModelUsageEvent } from "@/common/utils/tools/tools";
+import { createDisplayUsage } from "@/common/utils/tokens/displayUsage";
+import { normalizeToCanonical } from "@/common/utils/ai/models";
 import * as toolsModule from "@/common/utils/tools/tools";
 import * as providerOptionsModule from "@/common/utils/ai/providerOptions";
 import * as system1ToolWrapperModule from "./system1ToolWrapper";
@@ -1165,6 +1170,7 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
     preparedToolNamesForSentinel: string[][];
     streamSystemContextMuxScopes: MuxToolScope[];
     startStreamCalls: unknown[][];
+    getToolsForModelSpy: ReturnType<typeof spyOn<typeof toolsModule, "getToolsForModel">>;
   }
 
   function createWorkspaceMetadata(workspaceId: string, projectPath: string): WorkspaceMetadata {
@@ -1226,13 +1232,21 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
       routeProvider?: ProviderName;
       allTools?: Record<string, Tool>;
       postPolicyTools?: Record<string, Tool>;
+      sessionUsageService?: SessionUsageService;
     }
   ): StreamMessageHarness {
     const config = new Config(muxHomePath);
     const historyService = new HistoryService(config);
     const initStateManager = new InitStateManager(config);
     const providerService = new ProviderService(config);
-    const service = new AIService(config, historyService, initStateManager, providerService);
+    const service = new AIService(
+      config,
+      historyService,
+      initStateManager,
+      providerService,
+      undefined,
+      options?.sessionUsageService
+    );
 
     const planPayloadMessageIds: string[][] = [];
     const preparedPayloadMessageIds: string[][] = [];
@@ -1303,7 +1317,7 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
     });
 
     const allTools = options?.allTools ?? {};
-    spyOn(toolsModule, "getToolsForModel").mockResolvedValue(allTools);
+    const getToolsForModelSpy = spyOn(toolsModule, "getToolsForModel").mockResolvedValue(allTools);
     if (options?.postPolicyTools) {
       spyOn(toolAssembly, "applyToolPolicyAndExperiments").mockResolvedValue(
         options.postPolicyTools
@@ -1390,6 +1404,7 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
       preparedToolNamesForSentinel,
       streamSystemContextMuxScopes,
       startStreamCalls,
+      getToolsForModelSpy,
     };
   }
 
@@ -1805,6 +1820,152 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
     expect(openaiOptions.previousResponseId).toBeUndefined();
     expect(openaiOptions.promptCacheKey).toBe(
       `mux-v1-project-under-test-${uniqueSuffix([projectPath])}`
+    );
+  });
+
+  it("persists tool model usage through the tool configuration callback", async () => {
+    using muxHome = new DisposableTempDir("ai-service-tool-model-usage");
+    const projectPath = path.join(muxHome.path, "project");
+    await fs.mkdir(projectPath, { recursive: true });
+
+    const workspaceId = "workspace-tool-model-usage";
+    const metadata = createWorkspaceMetadata(workspaceId, projectPath);
+    const recordUsage = mock(() => Promise.resolve(undefined));
+    const getSessionUsage = mock(() => Promise.resolve(undefined));
+    const sessionUsageService = {
+      recordUsage,
+      getSessionUsage,
+    } as unknown as SessionUsageService;
+    const harness = createHarness(muxHome.path, metadata, { sessionUsageService });
+
+    const result = await harness.service.streamMessage({
+      messages: [createMuxMessage("latest-user", "user", "continue")],
+      workspaceId,
+      modelString: "openai:gpt-5.2",
+      thinkingLevel: "off",
+    });
+
+    expect(result.success).toBe(true);
+    const toolConfig = harness.getToolsForModelSpy.mock.calls[0]?.[1];
+    if (!toolConfig || typeof toolConfig !== "object") {
+      throw new Error("Expected getToolsForModel to receive a tool configuration object");
+    }
+
+    const reportModelUsage = (
+      toolConfig as {
+        reportModelUsage?: (event: ToolModelUsageEvent) => void;
+      }
+    ).reportModelUsage;
+    expect(typeof reportModelUsage).toBe("function");
+    if (!reportModelUsage) {
+      throw new Error("Expected reportModelUsage callback on tool configuration");
+    }
+
+    const event: ToolModelUsageEvent = {
+      source: "tool",
+      toolName: "advisor",
+      model: "anthropic:claude-sonnet-4-20250514",
+      usage: {
+        inputTokens: 120,
+        cachedInputTokens: 10,
+        outputTokens: 45,
+        reasoningTokens: 5,
+        totalTokens: 165,
+      },
+      providerMetadata: {
+        anthropic: { cacheCreationInputTokens: 6 },
+      },
+      toolCallId: "call-1",
+      timestamp: Date.now(),
+    };
+    const expectedDisplayUsage = createDisplayUsage(
+      event.usage,
+      event.model,
+      event.providerMetadata
+    );
+    expect(expectedDisplayUsage).toBeDefined();
+    if (!expectedDisplayUsage) {
+      throw new Error("Expected tool usage event to produce display usage");
+    }
+
+    reportModelUsage(event);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(recordUsage).toHaveBeenCalledWith(
+      workspaceId,
+      normalizeToCanonical(event.model),
+      expectedDisplayUsage
+    );
+  });
+
+  it("logs and swallows tool model usage persistence failures", async () => {
+    using muxHome = new DisposableTempDir("ai-service-tool-model-usage-failure");
+    const projectPath = path.join(muxHome.path, "project");
+    await fs.mkdir(projectPath, { recursive: true });
+
+    const workspaceId = "workspace-tool-model-usage-failure";
+    const metadata = createWorkspaceMetadata(workspaceId, projectPath);
+    const recordUsageError = new Error("write failed");
+    const recordUsage = mock(() => Promise.reject(recordUsageError));
+    const getSessionUsage = mock(() => Promise.resolve(undefined));
+    const sessionUsageService = {
+      recordUsage,
+      getSessionUsage,
+    } as unknown as SessionUsageService;
+    const warnSpy = spyOn(log, "warn").mockImplementation(() => undefined);
+    const harness = createHarness(muxHome.path, metadata, { sessionUsageService });
+
+    const result = await harness.service.streamMessage({
+      messages: [createMuxMessage("latest-user", "user", "continue")],
+      workspaceId,
+      modelString: "openai:gpt-5.2",
+      thinkingLevel: "off",
+    });
+
+    expect(result.success).toBe(true);
+    const toolConfig = harness.getToolsForModelSpy.mock.calls[0]?.[1];
+    if (!toolConfig || typeof toolConfig !== "object") {
+      throw new Error("Expected getToolsForModel to receive a tool configuration object");
+    }
+
+    const reportModelUsage = (
+      toolConfig as {
+        reportModelUsage?: (event: ToolModelUsageEvent) => void;
+      }
+    ).reportModelUsage;
+    if (!reportModelUsage) {
+      throw new Error("Expected reportModelUsage callback on tool configuration");
+    }
+
+    const event: ToolModelUsageEvent = {
+      source: "tool",
+      toolName: "advisor",
+      model: "anthropic:claude-sonnet-4-20250514",
+      usage: {
+        inputTokens: 50,
+        outputTokens: 20,
+        totalTokens: 70,
+      },
+      providerMetadata: {
+        anthropic: { cacheCreationInputTokens: 2 },
+      },
+      toolCallId: "call-2",
+      timestamp: Date.now(),
+    };
+
+    reportModelUsage(event);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Failed to record tool model usage",
+      expect.objectContaining({
+        error: recordUsageError,
+        workspaceId,
+        toolName: "advisor",
+        model: event.model,
+      })
     );
   });
 });

--- a/src/node/services/aiService.test.ts
+++ b/src/node/services/aiService.test.ts
@@ -1823,7 +1823,7 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
     );
   });
 
-  it("persists tool model usage through the tool configuration callback", async () => {
+  it("resolves advisor tool metadata pricing without changing the stored model bucket", async () => {
     using muxHome = new DisposableTempDir("ai-service-tool-model-usage");
     const projectPath = path.join(muxHome.path, "project");
     await fs.mkdir(projectPath, { recursive: true });
@@ -1837,6 +1837,12 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
       getSessionUsage,
     } as unknown as SessionUsageService;
     const harness = createHarness(muxHome.path, metadata, { sessionUsageService });
+    const metadataModel = KNOWN_MODELS.SONNET.id;
+    harness.config.saveProvidersConfig({
+      anthropic: {
+        models: [{ id: "custom-sonnet", mappedToModel: metadataModel }],
+      },
+    });
 
     const result = await harness.service.streamMessage({
       messages: [createMuxMessage("latest-user", "user", "continue")],
@@ -1864,7 +1870,7 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
     const event: ToolModelUsageEvent = {
       source: "tool",
       toolName: "advisor",
-      model: "anthropic:claude-sonnet-4-20250514",
+      model: "anthropic:custom-sonnet",
       usage: {
         inputTokens: 120,
         cachedInputTokens: 10,
@@ -1878,15 +1884,29 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
       toolCallId: "call-1",
       timestamp: Date.now(),
     };
-    const expectedDisplayUsage = createDisplayUsage(
+    const unresolvedDisplayUsage = createDisplayUsage(
       event.usage,
       event.model,
       event.providerMetadata
+    );
+    expect(unresolvedDisplayUsage).toBeDefined();
+    if (!unresolvedDisplayUsage) {
+      throw new Error("Expected unresolved tool usage event to produce display usage");
+    }
+    expect(unresolvedDisplayUsage.input.cost_usd).toBeUndefined();
+
+    const expectedDisplayUsage = createDisplayUsage(
+      event.usage,
+      event.model,
+      event.providerMetadata,
+      metadataModel
     );
     expect(expectedDisplayUsage).toBeDefined();
     if (!expectedDisplayUsage) {
       throw new Error("Expected tool usage event to produce display usage");
     }
+    expect(expectedDisplayUsage.model).toBe(event.model);
+    expect(expectedDisplayUsage.input.cost_usd).toBeDefined();
 
     const canonicalModel = normalizeToCanonical(event.model);
     const callSequence: string[] = [];

--- a/src/node/services/aiService.test.ts
+++ b/src/node/services/aiService.test.ts
@@ -1921,6 +1921,119 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
     expect(typeof sessionUsageDeltaRecord.timestamp).toBe("number");
   });
 
+  it("zeros advisor tool usage costs for costs-included models before persisting", async () => {
+    using muxHome = new DisposableTempDir("ai-service-tool-model-usage-costs-included");
+    const projectPath = path.join(muxHome.path, "project");
+    await fs.mkdir(projectPath, { recursive: true });
+
+    const workspaceId = "workspace-tool-model-usage-costs-included";
+    const metadata = createWorkspaceMetadata(workspaceId, projectPath);
+    const recordUsage = mock(() => Promise.resolve(undefined));
+    const getSessionUsage = mock(() => Promise.resolve(undefined));
+    const sessionUsageService = {
+      recordUsage,
+      getSessionUsage,
+    } as unknown as SessionUsageService;
+    const harness = createHarness(muxHome.path, metadata, { sessionUsageService });
+
+    harness.config.saveProvidersConfig({
+      openai: {
+        codexOauth: {
+          type: "oauth",
+          access: "test-access-token",
+          refresh: "test-refresh-token",
+          expires: Date.now() + 60_000,
+          accountId: "test-account-id",
+        },
+      },
+    });
+    const baseConfig = harness.config.loadConfigOrDefault();
+    await harness.config.saveConfig({
+      ...baseConfig,
+      advisorModelString: KNOWN_MODELS.GPT_53_CODEX.id,
+      agentAiDefaults: {
+        ...baseConfig.agentAiDefaults,
+        exec: {
+          ...baseConfig.agentAiDefaults?.exec,
+          advisorEnabled: true,
+        },
+      },
+    });
+
+    const result = await harness.service.streamMessage({
+      messages: [createMuxMessage("latest-user", "user", "continue")],
+      workspaceId,
+      modelString: "openai:gpt-5.2",
+      thinkingLevel: "off",
+      experiments: { advisorTool: true },
+    });
+
+    expect(result.success).toBe(true);
+    const toolConfig = harness.getToolsForModelSpy.mock.calls[0]?.[1];
+    if (!toolConfig || typeof toolConfig !== "object") {
+      throw new Error("Expected getToolsForModel to receive a tool configuration object");
+    }
+
+    const advisorRuntime = (
+      toolConfig as {
+        advisorRuntime?: {
+          createModel: (modelString: string) => Promise<LanguageModel>;
+        };
+      }
+    ).advisorRuntime;
+    expect(advisorRuntime).toBeDefined();
+    if (!advisorRuntime) {
+      throw new Error("Expected advisorRuntime in tool configuration");
+    }
+    await advisorRuntime.createModel(KNOWN_MODELS.GPT_53_CODEX.id);
+
+    const reportModelUsage = (
+      toolConfig as {
+        reportModelUsage?: (event: ToolModelUsageEvent) => void;
+      }
+    ).reportModelUsage;
+    if (!reportModelUsage) {
+      throw new Error("Expected reportModelUsage callback on tool configuration");
+    }
+
+    const event: ToolModelUsageEvent = {
+      source: "tool",
+      toolName: "advisor",
+      model: KNOWN_MODELS.GPT_53_CODEX.id,
+      usage: {
+        inputTokens: 120,
+        outputTokens: 45,
+        totalTokens: 165,
+      },
+      providerMetadata: {
+        openai: { reasoningTokens: 5 },
+      },
+      timestamp: Date.now(),
+    };
+    const expectedDisplayUsage = createDisplayUsage(event.usage, event.model, {
+      ...(event.providerMetadata ?? {}),
+      mux: { costsIncluded: true },
+    });
+    expect(expectedDisplayUsage).toBeDefined();
+    if (!expectedDisplayUsage) {
+      throw new Error("Expected tool usage event to produce display usage");
+    }
+    expect(expectedDisplayUsage.costsIncluded).toBe(true);
+    expect(expectedDisplayUsage.input.cost_usd).toBe(0);
+    expect(expectedDisplayUsage.output.cost_usd).toBe(0);
+    expect(expectedDisplayUsage.reasoning.cost_usd).toBe(0);
+
+    reportModelUsage(event);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(recordUsage).toHaveBeenCalledWith(
+      workspaceId,
+      normalizeToCanonical(event.model),
+      expectedDisplayUsage
+    );
+  });
+
   it("logs and swallows tool model usage persistence failures", async () => {
     using muxHome = new DisposableTempDir("ai-service-tool-model-usage-failure");
     const projectPath = path.join(muxHome.path, "project");

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1421,7 +1421,16 @@ export class AIService extends EventEmitter {
                   event.providerMetadata,
                   toolModelCostsIncludedByModelString.get(eventModel)
                 );
-                const displayUsage = createDisplayUsage(event.usage, eventModel, providerMetadata);
+                const metadataModel = resolveModelForMetadata(
+                  eventModel,
+                  this.providerService.getConfig()
+                );
+                const displayUsage = createDisplayUsage(
+                  event.usage,
+                  eventModel,
+                  providerMetadata,
+                  metadataModel
+                );
                 if (!displayUsage) {
                   return;
                 }

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1387,11 +1387,19 @@ export class AIService extends EventEmitter {
                 if (!displayUsage) {
                   return;
                 }
+                const canonicalModel = normalizeToCanonical(eventModel);
                 await this.sessionUsageService.recordUsage(
                   workspaceId,
-                  normalizeToCanonical(eventModel),
+                  canonicalModel,
                   displayUsage
                 );
+                this.emit("session-usage-delta", {
+                  type: "session-usage-delta" as const,
+                  workspaceId,
+                  sourceWorkspaceId: workspaceId,
+                  byModelDelta: { [canonicalModel]: displayUsage },
+                  timestamp: Date.now(),
+                });
               } catch (error) {
                 log.warn("Failed to record tool model usage", {
                   error,

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -55,6 +55,8 @@ import { createErrorEvent } from "./utils/sendMessageError";
 import { createAssistantMessageId } from "./utils/messageIds";
 import type { SessionUsageService } from "./sessionUsageService";
 import { sumUsageHistory, getTotalCost } from "@/common/utils/tokens/usageAggregator";
+import { createDisplayUsage } from "@/common/utils/tokens/displayUsage";
+import { normalizeToCanonical } from "@/common/utils/ai/models";
 import { readToolInstructions } from "./systemMessage";
 import type { TelemetryService } from "@/node/services/telemetryService";
 import type { DevToolsService } from "@/node/services/devToolsService";
@@ -1367,6 +1369,39 @@ export class AIService extends EventEmitter {
           enableAgentReport: Boolean(metadata.parentWorkspaceId),
           // External edit detection callback
           recordFileState,
+          reportModelUsage: (event) => {
+            void (async () => {
+              try {
+                if (!this.sessionUsageService) {
+                  return;
+                }
+                const eventModel = event.model.trim();
+                assert(eventModel.length > 0, "tool model usage event model must be non-empty");
+                // Persist tool-side model usage under its own model bucket so session costs keep
+                // advisor/system-side pricing separate from the parent chat model.
+                const displayUsage = createDisplayUsage(
+                  event.usage,
+                  eventModel,
+                  event.providerMetadata
+                );
+                if (!displayUsage) {
+                  return;
+                }
+                await this.sessionUsageService.recordUsage(
+                  workspaceId,
+                  normalizeToCanonical(eventModel),
+                  displayUsage
+                );
+              } catch (error) {
+                log.warn("Failed to record tool model usage", {
+                  error,
+                  workspaceId,
+                  toolName: event.toolName,
+                  model: event.model,
+                });
+              }
+            })();
+          },
           onConfigChanged: () => this.providerService.notifyConfigChanged(),
           taskService: this.taskService,
           analyticsService: this.analyticsService,

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -176,6 +176,29 @@ function mergeProviderExtrasUnderMux(
   return merged;
 }
 
+function markProviderMetadataCostsIncluded(
+  providerMetadata: Record<string, unknown> | undefined,
+  costsIncluded: boolean | undefined
+): Record<string, unknown> | undefined {
+  if (!costsIncluded) {
+    return providerMetadata;
+  }
+
+  const muxMetadata = providerMetadata?.mux;
+  const existingMux =
+    muxMetadata && typeof muxMetadata === "object"
+      ? (muxMetadata as Record<string, unknown>)
+      : undefined;
+
+  return {
+    ...(providerMetadata ?? {}),
+    mux: {
+      ...(existingMux ?? {}),
+      costsIncluded: true,
+    },
+  };
+}
+
 interface ToolExecutionContext {
   toolCallId?: string;
   abortSignal?: AbortSignal;
@@ -1289,6 +1312,10 @@ export class AIService extends EventEmitter {
       // Mutable ref updated by StreamManager.prepareStep so the advisor tool reads the live
       // transcript lazily at execute time instead of capturing a stale snapshot here.
       const advisorTranscriptRef: { messages?: ModelMessage[] } = {};
+      // Tool-side generateText() results do not consistently echo mux.costsIncluded in
+      // providerMetadata, so remember the resolved billing mode from model creation and
+      // re-stamp it before converting usage into display/session costs.
+      const toolModelCostsIncludedByModelString = new Map<string, boolean>();
       // Normalize: undefined -> default, null -> unlimited, positive int -> exact cap.
       const advisorMaxUses =
         advisorToolConfig.advisorMaxUsesPerTurn === null
@@ -1335,12 +1362,23 @@ export class AIService extends EventEmitter {
                     return messages;
                   },
                   createModel: async (ms: string) => {
-                    const advisorModel = await this.createModel(ms, undefined, { workspaceId });
+                    const advisorModelString = ms.trim();
+                    assert(
+                      advisorModelString.length > 0,
+                      "advisor model string must be non-empty when creating an advisor model"
+                    );
+                    const advisorModel = await this.createModel(advisorModelString, undefined, {
+                      workspaceId,
+                    });
                     if (!advisorModel.success) {
                       throw new Error(
                         `Failed to create advisor model: ${getErrorMessage(advisorModel.error)}`
                       );
                     }
+                    toolModelCostsIncludedByModelString.set(
+                      advisorModelString,
+                      modelCostsIncluded(advisorModel.data)
+                    );
                     return advisorModel.data;
                   },
                   abortSignal: combinedAbortSignal,
@@ -1379,11 +1417,11 @@ export class AIService extends EventEmitter {
                 assert(eventModel.length > 0, "tool model usage event model must be non-empty");
                 // Persist tool-side model usage under its own model bucket so session costs keep
                 // advisor/system-side pricing separate from the parent chat model.
-                const displayUsage = createDisplayUsage(
-                  event.usage,
-                  eventModel,
-                  event.providerMetadata
+                const providerMetadata = markProviderMetadataCostsIncluded(
+                  event.providerMetadata,
+                  toolModelCostsIncludedByModelString.get(eventModel)
                 );
+                const displayUsage = createDisplayUsage(event.usage, eventModel, providerMetadata);
                 if (!displayUsage) {
                   return;
                 }

--- a/src/node/services/sessionUsageService.test.ts
+++ b/src/node/services/sessionUsageService.test.ts
@@ -390,6 +390,24 @@ describe("SessionUsageService", () => {
       expect(result!.byModel["claude-opus-4-20250514"].input.tokens).toBe(500);
     });
 
+    it("keeps mixed-model session totals separate while lastRequest follows the latest write", async () => {
+      const workspaceId = "test-workspace";
+      const parentModel = "openai:gpt-5.2";
+      const advisorModel = "anthropic:claude-sonnet-4-20250514";
+      const parentUsage = createUsage(100, 50);
+      const advisorUsage = createUsage(40, 10);
+
+      await service.recordUsage(workspaceId, parentModel, parentUsage);
+      await service.recordUsage(workspaceId, advisorModel, advisorUsage);
+
+      const result = await service.getSessionUsage(workspaceId);
+      expect(result).toBeDefined();
+      expect(result?.byModel[parentModel]).toEqual(parentUsage);
+      expect(result?.byModel[advisorModel]).toEqual(advisorUsage);
+      expect(result?.lastRequest?.model).toBe(advisorModel);
+      expect(result?.lastRequest?.usage).toEqual(advisorUsage);
+    });
+
     it("should update lastRequest with each recordUsage call", async () => {
       const workspaceId = "test-workspace";
       const usage1 = createUsage(100, 50);

--- a/src/node/services/tools/advisor.test.ts
+++ b/src/node/services/tools/advisor.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import type { LanguageModelV2Usage } from "@ai-sdk/provider";
+import * as ai from "ai";
+import type { LanguageModel, ToolExecutionOptions } from "ai";
+
+import type { ToolModelUsageEvent } from "@/common/utils/tools/tools";
+import { log } from "@/node/services/log";
+import type { ModelMessage } from "@/common/types/message";
+import { createAdvisorTool } from "./advisor";
+import { TestTempDir, createTestToolConfig } from "./testHelpers";
+
+const ADVISOR_MODEL = "anthropic:claude-sonnet-4-20250514";
+const mockToolCallOptions: ToolExecutionOptions = {
+  toolCallId: "test-call-id",
+  messages: [],
+};
+
+function createTranscript(): ModelMessage[] {
+  return [{ role: "user", content: "hello" }];
+}
+
+function createToolConfig(
+  tempDir: string,
+  options?: {
+    reportModelUsage?: Parameters<typeof createAdvisorTool>[0]["reportModelUsage"];
+  }
+) {
+  const createModel = mock(() => Promise.resolve({} as LanguageModel));
+  const config = {
+    ...createTestToolConfig(tempDir),
+    reportModelUsage: options?.reportModelUsage,
+    advisorRuntime: {
+      advisorModelString: ADVISOR_MODEL,
+      reasoningLevel: "medium",
+      maxUsesPerTurn: 3,
+      getTranscriptSnapshot: createTranscript,
+      createModel,
+      abortSignal: new AbortController().signal,
+    },
+  };
+
+  return { config, createModel };
+}
+
+function mockGenerateTextSuccess(result: {
+  text: string;
+  usage: LanguageModelV2Usage;
+  providerMetadata?: Record<string, unknown>;
+}) {
+  return spyOn(ai, "generateText").mockResolvedValue(
+    result as Awaited<ReturnType<typeof ai.generateText>>
+  );
+}
+
+describe("advisor tool", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it("reports model usage after a successful advisor call", async () => {
+    using tempDir = new TestTempDir("advisor-tool-report-usage");
+    const usage: LanguageModelV2Usage = {
+      inputTokens: 120,
+      cachedInputTokens: 10,
+      outputTokens: 45,
+      reasoningTokens: 5,
+      totalTokens: 165,
+    };
+    const providerMetadata = {
+      anthropic: { cacheCreationInputTokens: 6 },
+    };
+    const reportModelUsage = mock((_event: ToolModelUsageEvent) => undefined);
+    const { config, createModel } = createToolConfig(tempDir.path, { reportModelUsage });
+    const generateTextSpy = mockGenerateTextSuccess({
+      text: "Focus on the highest-risk dependency edges first.",
+      usage,
+      providerMetadata,
+    });
+
+    const tool = createAdvisorTool(config);
+    const rawResult: unknown = await Promise.resolve(tool.execute!({}, mockToolCallOptions));
+
+    expect(createModel).toHaveBeenCalledWith(ADVISOR_MODEL);
+    expect(generateTextSpy).toHaveBeenCalledTimes(1);
+    expect(rawResult).toEqual({
+      type: "advice",
+      advice: "Focus on the highest-risk dependency edges first.",
+      advisorModel: ADVISOR_MODEL,
+      reasoningLevel: "medium",
+      remainingUses: 2,
+    });
+    expect(reportModelUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "tool",
+        toolName: "advisor",
+        model: ADVISOR_MODEL,
+        usage,
+        providerMetadata,
+        toolCallId: "test-call-id",
+      })
+    );
+
+    const event = reportModelUsage.mock.calls[0]?.[0];
+    expect(event?.toolName).toBe("advisor");
+    expect(event?.model).toBe(ADVISOR_MODEL);
+    expect(typeof event?.timestamp).toBe("number");
+  });
+
+  it("does not report usage when the advisor model call fails", async () => {
+    using tempDir = new TestTempDir("advisor-tool-no-usage-on-error");
+    const reportModelUsage = mock((_event: ToolModelUsageEvent) => undefined);
+    const { config } = createToolConfig(tempDir.path, { reportModelUsage });
+    spyOn(ai, "generateText").mockRejectedValue(new Error("model unavailable"));
+
+    const tool = createAdvisorTool(config);
+    const rawResult: unknown = await Promise.resolve(tool.execute!({}, mockToolCallOptions));
+
+    expect(rawResult).toEqual({
+      type: "error",
+      isError: true,
+      message: "Advisor request failed: model unavailable",
+    });
+    expect(reportModelUsage).not.toHaveBeenCalled();
+  });
+
+  it("swallows synchronous usage reporting failures and logs them", async () => {
+    using tempDir = new TestTempDir("advisor-tool-report-failure");
+    const usage: LanguageModelV2Usage = {
+      inputTokens: 40,
+      outputTokens: 10,
+      totalTokens: 50,
+    };
+    const reportModelUsage = mock((_event: ToolModelUsageEvent) => {
+      throw new Error("report callback failed");
+    });
+    const debugSpy = spyOn(log, "debug").mockImplementation(() => undefined);
+    const { config } = createToolConfig(tempDir.path, { reportModelUsage });
+    mockGenerateTextSuccess({
+      text: "Keep the implementation narrow.",
+      usage,
+    });
+
+    const tool = createAdvisorTool(config);
+    const rawResult: unknown = await Promise.resolve(tool.execute!({}, mockToolCallOptions));
+
+    expect(rawResult).toEqual({
+      type: "advice",
+      advice: "Keep the implementation narrow.",
+      advisorModel: ADVISOR_MODEL,
+      reasoningLevel: "medium",
+      remainingUses: 2,
+    });
+    expect(debugSpy).toHaveBeenCalledWith(
+      "advisor: failed to report model usage",
+      expect.objectContaining({ error: "report callback failed" })
+    );
+  });
+});

--- a/src/node/services/tools/advisor.ts
+++ b/src/node/services/tools/advisor.ts
@@ -9,6 +9,7 @@ import { getErrorMessage } from "@/common/utils/errors";
 import type { AdvisorPhaseEvent } from "@/common/types/stream";
 import { AdvisorToolInputSchema, TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
 import type { ToolConfiguration } from "@/common/utils/tools/tools";
+import { log } from "@/node/services/log";
 
 export function createAdvisorTool(config: ToolConfiguration): Tool {
   assert(config.advisorRuntime, "advisorRuntime must be set when advisor tool is registered");
@@ -96,6 +97,30 @@ export function createAdvisorTool(config: ToolConfiguration): Tool {
         });
 
         emitAdvisorPhase("finalizing_result");
+
+        if (config.reportModelUsage != null && result.usage != null) {
+          try {
+            assert(
+              advisorModelString.length > 0,
+              "advisorModelString must remain non-empty when reporting usage"
+            );
+            // Keep advisor costs under the advisor model bucket instead of folding them into
+            // the parent chat stream's model totals.
+            config.reportModelUsage({
+              source: "tool",
+              toolName: "advisor",
+              model: advisorModelString,
+              usage: result.usage,
+              providerMetadata: result.providerMetadata as Record<string, unknown> | undefined,
+              toolCallId,
+              timestamp: Date.now(),
+            });
+          } catch (error) {
+            log.debug("advisor: failed to report model usage", {
+              error: getErrorMessage(error),
+            });
+          }
+        }
 
         return {
           type: "advice" as const,


### PR DESCRIPTION
## Summary

The advisor tool calls `generateText(...)` internally but previously discarded `result.usage`, meaning advisor model costs never appeared in the right sidebar's session totals. This PR captures advisor usage and persists it under the actual advisor model key so pricing is correct regardless of whether the advisor model is cheaper or more expensive than the parent chat model.

## Background

- The advisor tool is an internal model call that happens during tool execution — it's invisible to the stream-level usage tracking.
- `SessionUsageService.recordUsage()` already supports per-model `byModel` buckets, so the fix is to report advisor usage through the same path with the correct model key.
- The right sidebar (`CostsTab`) reads from session usage totals, so once the backend accounting is correct, the UI becomes correct automatically.

## Implementation

Adds a generic `reportModelUsage` callback to `ToolConfiguration` (following the established `emitChatEvent` pattern), wired through `AIService` to persist tool-initiated model usage via `SessionUsageService`:

1. **`ToolModelUsageEvent` type + `reportModelUsage` callback** on `ToolConfiguration` — reusable by any future tool that calls models internally
2. **`advisor.ts`** captures `result.usage` after `generateText()` and reports it through the callback (non-fatal, try/catch wrapped)
3. **`aiService.ts`** wires the callback: converts raw usage → `ChatUsageDisplay` via `createDisplayUsage()`, persists under the advisor model key via `sessionUsageService.recordUsage()`

### Key design decisions

- **Correct model pricing**: Usage persisted under `normalizeToCanonical(advisorModel)`, not the parent chat model — pricing lookups use the advisor model's rates
- **Best-effort, non-fatal**: Failures at both the tool level and persistence level are caught and logged; advisor results always delivered
- **Defensive assertions**: Non-empty model string asserted before reporting; null checks on `sessionUsageService`
- **`lastRequest` behavior**: Last-writer-wins for v1 — `byModel` session totals are always correct

### Files changed

| File | Change |
|---|---|
| `src/common/utils/tools/tools.ts` | Added `ToolModelUsageEvent` interface + `reportModelUsage` callback |
| `src/node/services/tools/advisor.ts` | Report usage after `generateText()` success |
| `src/node/services/aiService.ts` | Wire callback: convert + persist under advisor model key |
| `src/node/services/tools/advisor.test.ts` | 3 tests: success reporting, no-report on failure, callback failure resilience |
| `src/node/services/aiService.test.ts` | Tool model usage persistence + error swallowing tests |
| `src/node/services/sessionUsageService.test.ts` | Multi-model `byModel` tracking test |

## Validation

- `make typecheck` ✅
- `make lint` ✅
- 80 targeted tests across advisor, aiService, and sessionUsageService — all pass

## Risks

- **Low risk**: The change is additive — a new optional callback on `ToolConfiguration` that only fires when the advisor tool completes successfully. No existing behavior is modified.
- **`lastRequest` display**: In mixed-model turns, `lastRequest` reflects the last `recordUsage()` call (last-writer-wins). The cumulative `byModel` totals are always correct. Evolving `lastRequest` to a mixed-model summary is follow-up work.

---

<details>
<summary>📋 Implementation Plan</summary>

# Advisor Usage Accounting Implementation Plan

## Outcome to deliver

Make **advisor tool internal model calls** count toward the same **session usage/cost totals** that power the right sidebar, while pricing each advisor invocation against the **actual advisor model** rather than the parent chat model. Collect enough structured metadata that we can also answer “how much advisor model usage happened?” without inferring from tool text.

## What investigation already confirmed

- `src/node/services/tools/advisor.ts` calls `generateText(...)` and currently returns only the advice payload; the provider-reported `result.usage` is dropped.
- `src/node/services/sessionUsageService.ts` already persists **per-model** `ChatUsageDisplay` aggregates and is the natural sink for billed usage accounting.
- `src/node/services/streamManager.ts` currently records usage once at the end of the top-level stream; it does **not** separately account for tool-internal model calls.
- `src/browser/features/RightSidebar/CostsTab.tsx` reads workspace usage/session totals; this is the UI surface that should become correct once advisor usage is recorded.
- `src/common/utils/tokens/tokenStatsCalculator.ts` separately estimates token footprint by consumer/tool from chat history. That is **not** equivalent to provider-billed advisor usage and should remain a separate accounting lane.
- `src/node/services/sessionTimingService.ts` / `src/browser/features/RightSidebar/StatsTab.tsx` are adjacent timing/throughput surfaces; they are **optional follow-on work** unless product explicitly wants advisor sub-request timing surfaced there too.

## Guiding decisions

1. **Do not infer advisor cost from tool text.** Use the provider-reported `generateText(...).usage` payload.
2. **Do not charge advisor usage to the parent model.** Persist advisor usage under the actual advisor model key so pricing remains correct even when advisor is much cheaper or more expensive.
3. **Do not expose raw accounting metadata to the model.** Keep billed-usage reporting on an internal side channel, not in the tool result shown to the LLM.
4. **Keep billed usage separate from token consumer breakdown.** Session totals/right-sidebar dollars should use provider-reported usage; token consumer breakdown can continue to describe conversation text footprint.
5. **Accounting must be best-effort and non-fatal to the user flow.** If persistence/telemetry fails, the advisor result should still be delivered.

## Recommended approaches

| Approach | Summary | Recommendation | Net product LoC estimate |
| --- | --- | --- | --- |
| **A. Emergency patch** | Have `advisor.ts` call directly into session usage persistence after `generateText(...)` completes. | Only if we need a same-day hotfix; not ideal as the lasting architecture. | **35–70 LoC** |
| **B. Generic tool-model usage reporting (recommended baseline)** | Add an internal `reportModelUsage(...)` callback to tool runtime plumbing, let advisor report its real usage, aggregate it in the stream layer, and persist it via `SessionUsageService`. | **Recommended**. Correct model pricing, reusable for future tools, minimal UI churn. | **180–260 LoC** |
| **C. Expanded observability** | Approach B plus mixed-model `lastRequest`/live-usage support and optional telemetry or Stats-tab visibility for tool-internal model calls. | Recommended if we want the last-request panel and internal metrics to be fully explicit, not just session totals. | **260–380 LoC** |

<details>
<summary>Why Approach B is the default recommendation</summary>

Approach B solves the correctness bug without coupling tool implementations directly to persistence or UI. It also creates a reusable pattern for any future tools that call models internally. Approach A would fix totals fastest, but it would hardwire accounting into one tool, complicate `lastRequest` semantics, and make future tool-internal billing harder to reason about. Approach C is attractive if product wants richer per-request/per-tool visibility, but it is safest to build it on top of the generic reporting path from Approach B.

</details>

## Primary implementation plan (Approach B baseline, with a decision gate for the richer C follow-up)

### Phase 0 — Confirm the exact right-sidebar surface we must keep correct

**Goal:** land the accounting fix against the right data sink and avoid overbuilding the timing surfaces.

- Reconfirm how `CostsTab` currently renders `sessionTotal`, `lastRequest`, and `liveUsage`, and whether it shows a single model label for the last request.
- Treat `StatsTab` / `SessionTimingService` as **out of scope for the first shipping pass** unless the product requirement explicitly expands from “costs/usage in the right sidebar” to “advisor timing/latency in the stats panel.”
- Decide whether the first pass must make **both** of these correct:
  - cumulative session totals, and
  - the “last request” slice in the sidebar.

**Quality gate before coding:** written note in the PR/implementation summary stating which sidebar surfaces are guaranteed to be correct in v1 (`sessionTotal` only vs `sessionTotal + lastRequest`).

---

### Phase 1 — Add a generic internal usage-reporting side channel for tools

**Goal:** create a reusable plumbing path for any tool that performs a provider-billed model call.

**Files / symbols to touch**
- `src/common/utils/tools/tools.ts` — extend `ToolConfiguration` / tool runtime config with an internal usage-reporting callback.
- The node-side tool/runtime factory that assembles the advisor runtime (follow the existing tool creation path referenced by the investigation reports).
- `src/node/services/tools/advisor.ts` — emit tool-model usage via the new callback after `generateText(...)` resolves.

**Implementation shape**
- Add an optional callback such as:
  ```ts
  reportModelUsage?: (event: ToolModelUsageEvent) => Promise<void> | void;
  ```
- Add an internal event payload type carrying at least:
  - `source: "tool"`
  - `toolName: "advisor"`
  - `model: string`
  - `usage: LanguageModelV2Usage`
  - `providerMetadata?: unknown`
  - `toolCallId?: string`
  - `streamId?: string`
  - `timestamp: number`
- In `advisor.ts`:
  - keep returning the current tool result payload for model-visible behavior,
  - capture `result.usage` (and provider metadata if available),
  - call `runtime.reportModelUsage?.(...)` with the advisor model.

**Defensive programming expectations**
- Assert the event has a non-empty model string before reporting.
- Assert token counts are non-negative if we normalize/transform them ourselves.
- Wrap the callback in best-effort error handling so usage-reporting failures do not break advisor output.
- Add a targeted debug log when usage exists but cannot be recorded.

**Why this phase matters**
- It fixes the root omission where advisor usage is discarded.
- It avoids stuffing raw usage JSON into tool results/history.
- It creates the generic hook needed by any future internal-model tools.

**Quality gate:** targeted unit tests prove that advisor still returns advice normally and invokes the side-channel reporter when `generateText(...)` returns usage.

---

### Phase 2 — Aggregate tool-model usage in the stream layer and persist it by model

**Goal:** account for advisor usage in the same persisted session totals that back the right sidebar.

**Files / symbols to touch**
- `src/node/services/streamManager.ts`
- `src/node/services/sessionUsageService.ts`
- `src/common/utils/tokens/displayUsage.ts` (reuse existing helpers; only modify if a missing helper makes the conversion awkward)
- `src/common/utils/tokens/modelStats.ts` (likely no changes; only verify advisor models resolve correctly)

**Implementation shape**
- In `streamManager`, add stream-scoped accumulation for tool-model usage reported during the active turn.
- Convert each reported tool usage payload into `ChatUsageDisplay` using existing pricing helpers and the **advisor model**, not the parent model.
- Normalize/canonicalize advisor model keys consistently with the rest of session usage accounting.
- Persist the accumulated usage into `SessionUsageService` under `byModel[advisorModel]` at the end of the stream (preferred), or record it eagerly if the current stream lifecycle makes end-of-stream aggregation impractical.
- If the stream already has a helper such as `recordSessionUsage(...)`, extend it so one top-level turn can contribute usage from multiple models instead of assuming only the parent stream model was billed.

**Preferred persistence strategy**
- Add a batch-style persistence helper if needed, e.g. a method that can atomically apply:
  - `session byModel` additions for multiple models, and
  - an updated `lastRequest` summary.
- Keep the old single-model `recordUsage(...)` path as a compatibility wrapper if other callers still rely on it.

**Defensive programming expectations**
- Assert that a reported advisor usage event carries a model string before pricing.
- If pricing metadata for the advisor model is missing, preserve the token counts and log clearly that the cost is unknown/zero-priced instead of silently dropping the usage.
- Do not let a usage persistence failure abort stream completion.

**Quality gate:** unit tests cover multi-model aggregation in one workspace/session and prove advisor usage lands in the advisor-model bucket rather than the parent-model bucket.

---

### Phase 3 — Make the right-sidebar request slices correct for mixed-model turns

**Goal:** ensure the sidebar does not under-report or mislabel a turn that used both the chat model and advisor model.

**Files / symbols to evaluate / touch**
- `src/browser/features/RightSidebar/CostsTab.tsx`
- usage/store plumbing that feeds `CostsTab` (existing hook/store path already used for `sessionTotal`, `liveUsage`, and `lastRequest`)
- `src/node/services/sessionUsageService.ts` data shape if the current `lastRequest` schema is too single-model-centric

**Decision gate inside this phase**
- If `CostsTab` only needs a correct **total** for the last request and does not render a misleading single-model label, the first pass can keep a simplified `lastRequest` summary containing the combined usage total.
- If the current UI renders a model label, or product wants to explicitly expose that a turn used multiple models, evolve `lastRequest` from “single model + usage” to a mixed-model summary:
  - `primaryModel` for the top-level turn label (optional)
  - `total` usage/cost for the request
  - `byModel` breakdown for the request
  - `timestamp`

**Recommended direction**
- Favor the richer mixed-model `lastRequest` summary if the UI already exposes model identity or if reviewers want precise visibility into advisor spend.
- Defer extra UI ornamentation unless required; the minimum correct bar is that totals are right and labels are not misleading.

**Quality gate:** manual or component-level verification shows that after an advisor invocation, the sidebar’s request/session totals increase correctly and do not attribute the spend to the wrong model.

---

### Phase 4 — Add explicit model-usage metrics / telemetry for advisor calls

**Goal:** answer the user’s second concern (“are we also collecting metrics on the model usage?”) with a durable yes.

**Files / symbols to evaluate / touch**
- The internal telemetry/metrics path used for model/tool events in the node layer
- `src/node/services/streamManager.ts` as the likely central sink
- Optional: `src/node/services/sessionTimingService.ts` / `src/browser/features/RightSidebar/StatsTab.tsx` only if product wants advisor sub-request timing/response metrics surfaced there too

**Implementation shape**
- Emit a structured internal event when tool-model usage is recorded, e.g.:
  - `event: "tool_model_usage_recorded"`
  - `toolName: "advisor"`
  - `model`
  - token counts by category (`input`, `output`, `reasoning`, `cached`, `cacheCreate`)
  - computed `costUsd` when known
  - `workspaceId`, `streamId`, `toolCallId`, `timestamp`
- Keep telemetry **best-effort** and separate from billing correctness.
- If product only needs durable session accounting and not analytics, this can be a second PR after the core bug fix ships.

**Quality gate:** a targeted test or log-based verification proves the telemetry event fires exactly once per advisor model call and does not double count chat-stream usage.

---

### Phase 5 — Roll-up / edge cases / polish

**Goal:** close the correctness gaps that will otherwise bite us later.

**Edge cases to cover**
- Multiple advisor calls inside one top-level response
- Advisor using the same model as the parent chat model
- Advisor using a model not present in the pricing table
- Advisor failures / retries
- Parent/child workspace roll-up via `SessionUsageService.rollUpUsageIntoParent()` so sub-agent or child-workspace usage does not get lost

**Polish tasks**
- Add code comments clarifying that “token consumer breakdown” and “provider-billed tool-model usage” are intentionally separate concepts.
- Keep logs actionable: missing pricing, malformed usage, persistence failure.
- Avoid UI flourishes unless requested; correctness comes first.

**Quality gate:** regression suite covers at least one mixed-model session, one repeated-advisor session, and one failure/no-usage path.

## Detailed file-by-file plan

### `src/node/services/tools/advisor.ts`
- Capture `generateText(...)` usage/provider metadata instead of discarding it.
- Report usage through the new internal callback.
- Preserve the existing tool result contract (`type`, `advice`, `advisorModel`, `reasoningLevel`, `remainingUses`).
- Keep reporting non-fatal so the user still receives advice if persistence/telemetry breaks.

### `src/common/utils/tools/tools.ts` and adjacent runtime plumbing
- Add the internal `reportModelUsage(...)` callback to the tool runtime configuration.
- Thread stream/workspace/tool-call identity into the callback payload if that context is already available; otherwise add only the minimal fields required for correct persistence and telemetry.
- Keep the callback internal-only; do not surface it in tool schemas or message content.

### `src/node/services/streamManager.ts`
- Own stream-scoped accumulation for tool-internal model usage.
- Convert raw provider usage to `ChatUsageDisplay` with the correct advisor-model pricing.
- Merge advisor usage into the same end-of-turn persistence path that already records top-level stream usage.
- If live usage deltas are already emitted for the UI, decide whether advisor usage should participate immediately or only after the advisor call completes.

### `src/node/services/sessionUsageService.ts`
- Support multi-model additions from one logical turn.
- If needed, add a batch/aggregate write helper so session totals and request summaries remain atomic.
- Keep backward compatibility where practical so older single-model callers do not need a same-PR refactor.
- Revisit `lastRequest` shape if the current single-model structure makes the sidebar misleading for mixed-model turns.

### `src/browser/features/RightSidebar/CostsTab.tsx` and usage-store plumbing
- Verify the existing UI becomes correct once backend accounting is fixed.
- Only add UI changes if the current `lastRequest` model label would be misleading or if product wants an explicit mixed-model breakdown.
- Prefer the smallest UI diff that prevents incorrect attribution.

### `src/node/services/sessionTimingService.ts` / `src/browser/features/RightSidebar/StatsTab.tsx` (optional follow-on)
- Only touch these if we decide “metrics on model usage” must include advisor timing/TTFT/response counts in the Stats tab, not just usage/cost accounting and telemetry.
- If touched, keep this as a distinct follow-up from the core cost/accounting fix.

## Proposed validation plan

### Automated backend tests

**Primary targets**
- `src/node/services/sessionUsageService.test.ts`
  - add a multi-model session test where the main model and advisor model both contribute usage
  - verify session totals and by-model buckets are correct
  - verify mixed-model `lastRequest` behavior if the schema changes
- `src/node/services/streamManager.test.ts`
  - verify advisor tool usage is recorded under the advisor model
  - verify multiple advisor calls in one turn aggregate correctly
  - verify accounting failures do not abort stream completion
- Advisor tool tests (new or colocated with existing tool tests if present)
  - verify the side-channel callback fires when `generateText(...)` returns usage
  - verify the normal tool result is unchanged

**Secondary targets**
- `src/browser/stores/WorkspaceStore.test.ts`
  - only if store/UI plumbing needs updates for `lastRequest` or live usage
- new `CostsTab` component tests only if the UI render path changes materially

### Automated quality gates between phases

1. **After Phase 1**
   - advisor unit tests pass
   - no regressions in tool execution tests
2. **After Phase 2**
   - `SessionUsageService` + `StreamManager` tests pass
   - mixed-model accounting assertions are green
3. **After Phase 3**
   - any updated usage-store/UI tests pass
   - targeted manual verification confirms sidebar totals
4. **After Phase 4/5**
   - telemetry assertions or logging verification pass
   - regression matrix covers no-usage/failure/repeat-call scenarios

## Dogfooding and reviewer-verifiable evidence

### Local setup
- Launch the app in development mode (`make dev` / the repo’s standard dev path).
- Use the desktop automation route that best matches the workspace setup:
  - preferred: the `electron` skill for driving the Electron app directly,
  - fallback: browser/devtools automation if the right sidebar can be exercised through a browser surface.
- Ensure the advisor feature is enabled with a known advisor model configuration before testing.

### Dogfood scenarios

1. **Cheap main model, expensive advisor model**
   - send a prompt that triggers advisor once
   - verify the right-sidebar total jumps by more than the main-model-only baseline would predict
2. **Expensive main model, cheap advisor model**
   - verify advisor usage is still priced under the advisor model bucket rather than inherited from the parent model
3. **Repeated advisor calls in one session**
   - verify totals accumulate monotonically and the advisor model bucket grows correctly
4. **Advisor failure/no-usage path**
   - verify no bogus billed usage record appears when the advisor call fails before returning usage
5. **Same-model case**
   - set advisor to the same model as the parent chat model and verify aggregation still works without splitting or loss

### Evidence that must be captured
- **Screenshots**
  - before invoking advisor (baseline Costs tab)
  - after one advisor call completes
  - after repeated advisor calls or a mixed-model scenario
- **Video recording**
  - one end-to-end capture showing the advisor tool invocation and the sidebar changing afterward
- **Optional implementation-debug evidence**
  - session usage JSON excerpt or log output showing the advisor model bucket being updated (useful for reviewer confidence, but not a substitute for the UI evidence)

### Reviewer acceptance from dogfooding
A reviewer should be able to look at the screenshots/video and verify all of the following without reading code:
- advisor was invoked,
- the sidebar cost totals changed afterward,
- the totals are not obviously attributed to the wrong model,
- repeated advisor use accumulates as expected.

## Acceptance criteria

### Must-have
- Advisor internal model usage is captured from `generateText(...)` rather than inferred from tool text.
- Advisor usage is persisted under the **advisor model key** in session usage accounting.
- The right sidebar’s session totals include advisor cost.
- Mixed-model requests are not mislabeled as if only the parent model was billed.
- Token consumer breakdown remains separate and does not double count billed advisor usage.
- Usage-reporting/telemetry failures do not break the visible advisor tool result.

### Strongly recommended for the same implementation pass
- The sidebar’s `lastRequest` slice is also correct for mixed-model turns.
- There is a structured internal metric/telemetry event for advisor model usage recording.
- Parent/child workspace roll-up preserves advisor usage.

## Risks and how to manage them

| Risk | Why it matters | Mitigation |
| --- | --- | --- |
| Double counting | Advisor text already appears in token consumer breakdown. | Keep billed usage and token consumer breakdown as separate accounting paths; do not merge them in v1. |
| Wrong model attribution | Advisor may use a materially different-priced model. | Normalize and persist the actual advisor model, not the parent stream model. |
| Misleading `lastRequest` UI | A single-model summary can lie about a mixed-model turn. | Either store a combined total with no misleading model label, or evolve `lastRequest` to a mixed-model shape. |
| Unknown model pricing | Tokens could be present while costs resolve to zero/unknown. | Preserve tokens, surface/log the unknown-cost state, and avoid silently dropping usage. |
| Persistence/telemetry failures breaking tool execution | Users care more about getting advice than perfect metrics. | Make recording best-effort and isolate errors from the tool result path. |
| Future tools needing the same behavior | Advisor will not be the last internal-model tool. | Land generic runtime plumbing rather than an advisor-only hack. |

## Suggested rollout / PR split

### Option 1 — Single focused PR (preferred if scope stays moderate)
- Phase 1 + Phase 2 + the minimum Phase 3 work needed to keep `lastRequest`/sidebar labels honest
- Include targeted backend tests and dogfooding evidence

### Option 2 — Two PRs (preferred if mixed-model `lastRequest` turns into a schema/UI migration)
1. **PR 1:** generic tool-model usage reporting + session total correctness + backend tests
2. **PR 2:** mixed-model `lastRequest` / live-usage UI correctness + telemetry/Stats follow-on if desired

### Stopgap fallback
- If production pressure demands an immediate patch, use Approach A first, but explicitly plan a cleanup follow-up to move to the generic Approach B plumbing.

## Definition of done

This work is done when:
- advisor usage is captured and persisted under the correct model,
- the right sidebar totals include that spend,
- mixed-model turns are not mislabeled,
- automated tests cover the new accounting path,
- manual dogfooding produces screenshots and a video showing the behavior end-to-end,
- and the implementation leaves behind a generic path that future tool-internal model calls can reuse.

</details>

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$13.02`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=13.02 -->
