### PR TITLE
🤖 feat: truthful advisor running-state UX with live phase + elapsed timer

### DIFF
--- a/src/browser/features/Tools/AdvisorToolCall.test.tsx
+++ b/src/browser/features/Tools/AdvisorToolCall.test.tsx
@@ -1,0 +1,133 @@
+import type { ComponentProps } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { GlobalWindow } from "happy-dom";
+
+import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
+
+vi.mock("@/browser/stores/WorkspaceStore", () => ({
+  useAdvisorToolLivePhase: vi.fn(),
+}));
+
+vi.mock("./Shared/ElapsedTimeDisplay", () => ({
+  ElapsedTimeDisplay: ({
+    startedAt,
+    isActive,
+  }: {
+    startedAt: number | undefined;
+    isActive: boolean;
+  }) => (
+    <span
+      data-testid="elapsed-time"
+      data-active={String(isActive)}
+      data-started-at={startedAt == null ? "missing" : String(startedAt)}
+    />
+  ),
+}));
+
+import { useAdvisorToolLivePhase } from "@/browser/stores/WorkspaceStore";
+import { AdvisorToolCall } from "./AdvisorToolCall";
+
+type MockedAdvisorPhaseHook = typeof useAdvisorToolLivePhase & {
+  mockReset(): void;
+  mockReturnValue(value: ReturnType<typeof useAdvisorToolLivePhase>): void;
+};
+
+const mockedUseAdvisorToolLivePhase = useAdvisorToolLivePhase as MockedAdvisorPhaseHook;
+
+function renderAdvisorToolCall(props: Partial<ComponentProps<typeof AdvisorToolCall>> = {}) {
+  return render(
+    <TooltipProvider>
+      <AdvisorToolCall
+        args={{}}
+        status="executing"
+        workspaceId="workspace-1"
+        toolCallId="advisor-call-1"
+        startedAt={1_700_000_000_000}
+        {...props}
+      />
+    </TooltipProvider>
+  );
+}
+
+describe("AdvisorToolCall", () => {
+  let originalWindow: typeof globalThis.window;
+  let originalDocument: typeof globalThis.document;
+
+  beforeEach(() => {
+    originalWindow = globalThis.window;
+    originalDocument = globalThis.document;
+
+    globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
+    globalThis.document = globalThis.window.document;
+
+    mockedUseAdvisorToolLivePhase.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.window = originalWindow;
+    globalThis.document = originalDocument;
+  });
+
+  test("shows live phase timing in collapsed and expanded executing states", () => {
+    const startedAt = 1_700_000_000_123;
+
+    mockedUseAdvisorToolLivePhase.mockReturnValue({
+      phase: "waiting_for_response",
+      timestamp: startedAt + 250,
+    });
+
+    const view = renderAdvisorToolCall({ startedAt });
+
+    expect(mockedUseAdvisorToolLivePhase).toHaveBeenCalledWith("workspace-1", "advisor-call-1");
+    expect(view.getByText("Waiting for response")).toBeTruthy();
+
+    let timers = view.getAllByTestId("elapsed-time");
+    expect(timers).toHaveLength(1);
+    expect(timers[0]?.dataset.active).toBe("true");
+    expect(timers[0]?.dataset.startedAt).toBe(String(startedAt));
+
+    fireEvent.click(view.getByText("advisor"));
+
+    expect(view.getAllByText("Waiting for response")).toHaveLength(2);
+    timers = view.getAllByTestId("elapsed-time");
+    expect(timers).toHaveLength(2);
+    for (const timer of timers) {
+      expect(timer.dataset.active).toBe("true");
+      expect(timer.dataset.startedAt).toBe(String(startedAt));
+    }
+  });
+
+  test("falls back to a generic running state before a live phase arrives", () => {
+    mockedUseAdvisorToolLivePhase.mockReturnValue(undefined);
+
+    const view = renderAdvisorToolCall();
+
+    expect(view.getByText("Running")).toBeTruthy();
+    const timers = view.getAllByTestId("elapsed-time");
+    expect(timers).toHaveLength(1);
+    expect(timers[0]?.dataset.active).toBe("true");
+  });
+
+  test("continues rendering completed advice results", () => {
+    mockedUseAdvisorToolLivePhase.mockReturnValue(undefined);
+
+    const view = renderAdvisorToolCall({
+      status: "completed",
+      result: {
+        type: "advice",
+        advice: "Prefer the smaller diff so reviewers can verify it quickly.",
+        advisorModel: "openai:gpt-4.1-mini",
+        remainingUses: 1,
+      },
+    });
+
+    fireEvent.click(view.getByText("advisor"));
+
+    expect(
+      view.getByText("Prefer the smaller diff so reviewers can verify it quickly.")
+    ).toBeTruthy();
+    expect(view.queryByTestId("elapsed-time")).toBeNull();
+  });
+});

--- a/src/browser/features/Tools/AdvisorToolCall.test.tsx
+++ b/src/browser/features/Tools/AdvisorToolCall.test.tsx
@@ -1,15 +1,23 @@
 import type { ComponentProps } from "react";
-import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import type { AdvisorLivePhaseState } from "@/browser/stores/WorkspaceStore";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { GlobalWindow } from "happy-dom";
 
 import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
 
-vi.mock("@/browser/stores/WorkspaceStore", () => ({
-  useAdvisorToolLivePhase: vi.fn(),
+const useAdvisorToolLivePhaseMock = mock(
+  (
+    _workspaceId: string | undefined,
+    _toolCallId: string | undefined
+  ): AdvisorLivePhaseState | undefined => undefined
+);
+
+void mock.module("@/browser/stores/WorkspaceStore", () => ({
+  useAdvisorToolLivePhase: useAdvisorToolLivePhaseMock,
 }));
 
-vi.mock("./Shared/ElapsedTimeDisplay", () => ({
+void mock.module("./Shared/ElapsedTimeDisplay", () => ({
   ElapsedTimeDisplay: ({
     startedAt,
     isActive,
@@ -25,15 +33,7 @@ vi.mock("./Shared/ElapsedTimeDisplay", () => ({
   ),
 }));
 
-import { useAdvisorToolLivePhase } from "@/browser/stores/WorkspaceStore";
 import { AdvisorToolCall } from "./AdvisorToolCall";
-
-type MockedAdvisorPhaseHook = typeof useAdvisorToolLivePhase & {
-  mockReset(): void;
-  mockReturnValue(value: ReturnType<typeof useAdvisorToolLivePhase>): void;
-};
-
-const mockedUseAdvisorToolLivePhase = useAdvisorToolLivePhase as MockedAdvisorPhaseHook;
 
 function renderAdvisorToolCall(props: Partial<ComponentProps<typeof AdvisorToolCall>> = {}) {
   return render(
@@ -61,11 +61,12 @@ describe("AdvisorToolCall", () => {
     globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
     globalThis.document = globalThis.window.document;
 
-    mockedUseAdvisorToolLivePhase.mockReset();
+    useAdvisorToolLivePhaseMock.mockReset();
   });
 
   afterEach(() => {
     cleanup();
+    mock.restore();
     globalThis.window = originalWindow;
     globalThis.document = originalDocument;
   });
@@ -73,14 +74,14 @@ describe("AdvisorToolCall", () => {
   test("shows live phase timing in collapsed and expanded executing states", () => {
     const startedAt = 1_700_000_000_123;
 
-    mockedUseAdvisorToolLivePhase.mockReturnValue({
+    useAdvisorToolLivePhaseMock.mockReturnValue({
       phase: "waiting_for_response",
       timestamp: startedAt + 250,
     });
 
     const view = renderAdvisorToolCall({ startedAt });
 
-    expect(mockedUseAdvisorToolLivePhase).toHaveBeenCalledWith("workspace-1", "advisor-call-1");
+    expect(useAdvisorToolLivePhaseMock).toHaveBeenCalledWith("workspace-1", "advisor-call-1");
     expect(view.getByText("Waiting for response")).toBeTruthy();
 
     let timers = view.getAllByTestId("elapsed-time");
@@ -100,7 +101,7 @@ describe("AdvisorToolCall", () => {
   });
 
   test("falls back to a generic running state before a live phase arrives", () => {
-    mockedUseAdvisorToolLivePhase.mockReturnValue(undefined);
+    useAdvisorToolLivePhaseMock.mockReturnValue(undefined);
 
     const view = renderAdvisorToolCall();
 
@@ -111,7 +112,7 @@ describe("AdvisorToolCall", () => {
   });
 
   test("continues rendering completed advice results", () => {
-    mockedUseAdvisorToolLivePhase.mockReturnValue(undefined);
+    useAdvisorToolLivePhaseMock.mockReturnValue(undefined);
 
     const view = renderAdvisorToolCall({
       status: "completed",

--- a/src/browser/features/Tools/AdvisorToolCall.tsx
+++ b/src/browser/features/Tools/AdvisorToolCall.tsx
@@ -3,9 +3,14 @@ import { AlertTriangle } from "lucide-react";
 
 import { MarkdownRenderer } from "../Messages/MarkdownRenderer";
 import { cn } from "@/common/lib/utils";
+import {
+  type AdvisorLivePhaseState,
+  useAdvisorToolLivePhase,
+} from "@/browser/stores/WorkspaceStore";
 import { formatModelDisplayName } from "@/common/utils/ai/modelDisplay";
 import { getModelName } from "@/common/utils/ai/models";
 import { JsonHighlight } from "./Shared/HighlightedCode";
+import { ElapsedTimeDisplay } from "./Shared/ElapsedTimeDisplay";
 import {
   DetailContent,
   DetailLabel,
@@ -26,6 +31,9 @@ interface AdvisorToolCallProps {
   args: Record<string, unknown>;
   result?: unknown;
   status?: string;
+  workspaceId?: string;
+  toolCallId?: string;
+  startedAt?: number;
 }
 
 type AdvisorToolResult =
@@ -54,6 +62,11 @@ interface AdvisorStatusPresentation {
 }
 
 const TRAILING_MODEL_DATE_SUFFIX = /-(?:\d{8}|\d{4}-\d{2}-\d{2})$/;
+const ADVISOR_PHASE_LABELS: Record<AdvisorLivePhaseState["phase"], string> = {
+  preparing_context: "Preparing context",
+  waiting_for_response: "Waiting for response",
+  finalizing_result: "Finalizing result",
+};
 
 function isToolStatus(value: string | undefined): value is ToolStatus {
   switch (value) {
@@ -193,9 +206,13 @@ export const AdvisorToolCall: React.FC<AdvisorToolCallProps> = ({
   args: _args,
   result,
   status,
+  workspaceId,
+  toolCallId,
+  startedAt,
 }) => {
   const { expanded, toggleExpanded } = useToolExpansion();
   const toolStatus = isToolStatus(status) ? status : "pending";
+  const livePhase = useAdvisorToolLivePhase(workspaceId, toolCallId);
   const advisorResult = isAdvisorToolResult(result) ? result : null;
   const hasUnrecognizedResult = result !== undefined && result !== null && advisorResult === null;
   const detailsText =
@@ -210,6 +227,17 @@ export const AdvisorToolCall: React.FC<AdvisorToolCallProps> = ({
         content: getStatusDisplay("failed"),
       }
     : getAdvisorStatusPresentation(advisorResult, toolStatus);
+  const isExecutingWithoutResult =
+    toolStatus === "executing" && advisorResult === null && !hasUnrecognizedResult;
+  const executingStatusLabel = livePhase ? ADVISOR_PHASE_LABELS[livePhase.phase] : "Running";
+  const headerStatusContent = isExecutingWithoutResult ? (
+    <>
+      <span>{executingStatusLabel}</span>
+      <ElapsedTimeDisplay startedAt={startedAt} isActive={true} />
+    </>
+  ) : (
+    statusPresentation.content
+  );
 
   return (
     <ToolContainer expanded={expanded} className="@container">
@@ -221,7 +249,7 @@ export const AdvisorToolCall: React.FC<AdvisorToolCallProps> = ({
           status={statusPresentation.status}
           className={statusPresentation.className}
         >
-          {statusPresentation.content}
+          {headerStatusContent}
         </StatusIndicator>
       </ToolHeader>
 
@@ -291,11 +319,12 @@ export const AdvisorToolCall: React.FC<AdvisorToolCallProps> = ({
             </>
           )}
 
-          {toolStatus === "executing" && advisorResult === null && !hasUnrecognizedResult && (
+          {isExecutingWithoutResult && (
             <DetailSection>
               <div className="text-secondary text-[11px]">
-                Consulting advisor
+                {executingStatusLabel}
                 <LoadingDots />
+                <ElapsedTimeDisplay startedAt={startedAt} isActive={true} />
               </div>
             </DetailSection>
           )}

--- a/src/browser/features/Tools/BashToolCall.tsx
+++ b/src/browser/features/Tools/BashToolCall.tsx
@@ -18,6 +18,7 @@ import {
 import { useToolExpansion, getStatusDisplay, type ToolStatus } from "./Shared/toolUtils";
 import { formatDuration } from "@/common/utils/formatDuration";
 import { cn } from "@/common/lib/utils";
+import { ElapsedTimeDisplay } from "./Shared/ElapsedTimeDisplay";
 import { useBashToolLiveOutput, useLatestStreamingBashId } from "@/browser/stores/WorkspaceStore";
 import { useForegroundBashToolCallIds } from "@/browser/stores/BackgroundBashStore";
 import { useBackgroundBashActions } from "@/browser/contexts/BackgroundBashContext";
@@ -32,64 +33,6 @@ interface BashToolCallProps {
   status?: ToolStatus;
   startedAt?: number;
 }
-
-/**
- * Isolated component for elapsed time display.
- * Uses requestAnimationFrame + local state to avoid re-rendering parent component.
- */
-const ElapsedTimeDisplay: React.FC<{ startedAt: number | undefined; isActive: boolean }> = ({
-  startedAt,
-  isActive,
-}) => {
-  const elapsedRef = useRef(0);
-  const frameRef = useRef<number | null>(null);
-  const [, forceUpdate] = React.useReducer((x: number) => x + 1, 0);
-  const baseStart = useRef(startedAt ?? Date.now());
-
-  useEffect(() => {
-    if (!isActive) {
-      elapsedRef.current = 0;
-      if (frameRef.current !== null) {
-        cancelAnimationFrame(frameRef.current);
-        frameRef.current = null;
-      }
-      return;
-    }
-
-    baseStart.current = startedAt ?? Date.now();
-    let lastSecond = -1;
-
-    const tick = () => {
-      const now = Date.now();
-      const elapsed = now - baseStart.current;
-      const currentSecond = Math.floor(elapsed / 1000);
-
-      // Only update when second changes to minimize renders
-      if (currentSecond !== lastSecond) {
-        lastSecond = currentSecond;
-        elapsedRef.current = elapsed;
-        forceUpdate();
-      }
-
-      frameRef.current = requestAnimationFrame(tick);
-    };
-
-    tick();
-
-    return () => {
-      if (frameRef.current !== null) {
-        cancelAnimationFrame(frameRef.current);
-        frameRef.current = null;
-      }
-    };
-  }, [isActive, startedAt]);
-
-  if (!isActive || elapsedRef.current === 0) {
-    return null;
-  }
-
-  return <> • {Math.round(elapsedRef.current / 1000)}s</>;
-};
 
 type BashLiveOutputView = NonNullable<ReturnType<typeof useBashToolLiveOutput>>;
 

--- a/src/browser/features/Tools/Shared/ElapsedTimeDisplay.tsx
+++ b/src/browser/features/Tools/Shared/ElapsedTimeDisplay.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useRef } from "react";
+
+interface ElapsedTimeDisplayProps {
+  startedAt: number | undefined;
+  isActive: boolean;
+}
+
+/**
+ * Shared elapsed time display for tool headers.
+ * Keeps requestAnimationFrame + per-second updates at the leaf so parent tool calls do not re-render.
+ */
+export const ElapsedTimeDisplay: React.FC<ElapsedTimeDisplayProps> = ({ startedAt, isActive }) => {
+  const elapsedRef = useRef(0);
+  const frameRef = useRef<number | null>(null);
+  const [, forceUpdate] = React.useReducer((x: number) => x + 1, 0);
+  const baseStart = useRef(startedAt ?? Date.now());
+
+  useEffect(() => {
+    if (!isActive) {
+      elapsedRef.current = 0;
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current);
+        frameRef.current = null;
+      }
+      return;
+    }
+
+    baseStart.current = startedAt ?? Date.now();
+    let lastSecond = -1;
+
+    const tick = () => {
+      const now = Date.now();
+      const elapsed = now - baseStart.current;
+      const currentSecond = Math.floor(elapsed / 1000);
+
+      // Only update when second changes to minimize renders
+      if (currentSecond !== lastSecond) {
+        lastSecond = currentSecond;
+        elapsedRef.current = elapsed;
+        forceUpdate();
+      }
+
+      frameRef.current = requestAnimationFrame(tick);
+    };
+
+    tick();
+
+    return () => {
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current);
+        frameRef.current = null;
+      }
+    };
+  }, [isActive, startedAt]);
+
+  if (!isActive || elapsedRef.current === 0) {
+    return null;
+  }
+
+  return <> • {Math.round(elapsedRef.current / 1000)}s</>;
+};

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -3978,6 +3978,167 @@ describe("WorkspaceStore", () => {
       expect(live.stdout).toContain("buffered");
     });
   });
+  describe("advisor-phase events", () => {
+    it("tracks the latest live advisor phase while the advisor tool is running", async () => {
+      const workspaceId = "advisor-phase-workspace-1";
+
+      mockOnChat.mockImplementation(async function* (): AsyncGenerator<
+        WorkspaceChatMessage,
+        void,
+        unknown
+      > {
+        yield { type: "caught-up" };
+        await Promise.resolve();
+        yield {
+          type: "advisor-phase",
+          workspaceId,
+          toolCallId: "call-advisor-1",
+          phase: "preparing_context",
+          timestamp: 1,
+        };
+        yield {
+          type: "advisor-phase",
+          workspaceId,
+          toolCallId: "call-advisor-1",
+          phase: "waiting_for_response",
+          timestamp: 2,
+        };
+      });
+
+      createAndAddWorkspace(store, workspaceId);
+
+      const hasLatestPhase = await waitUntil(
+        () =>
+          store.getAdvisorToolLivePhase(workspaceId, "call-advisor-1")?.phase ===
+          "waiting_for_response"
+      );
+      expect(hasLatestPhase).toBe(true);
+
+      const live = store.getAdvisorToolLivePhase(workspaceId, "call-advisor-1");
+      expect(live).toEqual({
+        phase: "waiting_for_response",
+        timestamp: 2,
+      });
+
+      const liveAgain = store.getAdvisorToolLivePhase(workspaceId, "call-advisor-1");
+      expect(liveAgain).toBe(live);
+    });
+
+    it("clears live advisor phase on advisor tool-call-end", async () => {
+      const workspaceId = "advisor-phase-workspace-2";
+      let releaseToolEnd: (() => void) | undefined;
+      const waitForToolEnd = new Promise<void>((resolve) => {
+        releaseToolEnd = resolve;
+      });
+
+      mockOnChat.mockImplementation(async function* (): AsyncGenerator<
+        WorkspaceChatMessage,
+        void,
+        unknown
+      > {
+        yield { type: "caught-up" };
+        await Promise.resolve();
+        yield {
+          type: "advisor-phase",
+          workspaceId,
+          toolCallId: "call-advisor-2",
+          phase: "finalizing_result",
+          timestamp: 1,
+        };
+        await waitForToolEnd;
+        yield {
+          type: "tool-call-end",
+          workspaceId,
+          messageId: "m-advisor-2",
+          toolCallId: "call-advisor-2",
+          toolName: "advisor",
+          result: { success: true },
+          timestamp: 2,
+        };
+      });
+
+      createAndAddWorkspace(store, workspaceId);
+
+      const hasLivePhase = await waitUntil(
+        () =>
+          store.getAdvisorToolLivePhase(workspaceId, "call-advisor-2")?.phase ===
+          "finalizing_result"
+      );
+      expect(hasLivePhase).toBe(true);
+
+      releaseToolEnd?.();
+
+      const clearedLivePhase = await waitUntil(
+        () => store.getAdvisorToolLivePhase(workspaceId, "call-advisor-2") === undefined
+      );
+      expect(clearedLivePhase).toBe(true);
+    });
+
+    it("ignores duplicate advisor phases for the same tool call", async () => {
+      const workspaceId = "advisor-phase-workspace-3";
+      let releaseDuplicate: (() => void) | undefined;
+      const waitForDuplicate = new Promise<void>((resolve) => {
+        releaseDuplicate = resolve;
+      });
+
+      mockOnChat.mockImplementation(async function* (): AsyncGenerator<
+        WorkspaceChatMessage,
+        void,
+        unknown
+      > {
+        yield { type: "caught-up" };
+        await Promise.resolve();
+        yield {
+          type: "advisor-phase",
+          workspaceId,
+          toolCallId: "call-advisor-3",
+          phase: "waiting_for_response",
+          timestamp: 1,
+        };
+        await waitForDuplicate;
+        yield {
+          type: "advisor-phase",
+          workspaceId,
+          toolCallId: "call-advisor-3",
+          phase: "waiting_for_response",
+          timestamp: 2,
+        };
+      });
+
+      createAndAddWorkspace(store, workspaceId);
+
+      const hasInitialPhase = await waitUntil(
+        () => store.getAdvisorToolLivePhase(workspaceId, "call-advisor-3")?.timestamp === 1
+      );
+      expect(hasInitialPhase).toBe(true);
+
+      const live = store.getAdvisorToolLivePhase(workspaceId, "call-advisor-3");
+      expect(live).toEqual({
+        phase: "waiting_for_response",
+        timestamp: 1,
+      });
+      if (!live) throw new Error("Expected live advisor phase");
+
+      let notificationCount = 0;
+      const unsubscribe = store.subscribeKey(workspaceId, () => {
+        notificationCount += 1;
+      });
+
+      releaseDuplicate?.();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const liveAfterDuplicate = store.getAdvisorToolLivePhase(workspaceId, "call-advisor-3");
+      expect(liveAfterDuplicate).toBe(live);
+      expect(liveAfterDuplicate).toEqual({
+        phase: "waiting_for_response",
+        timestamp: 1,
+      });
+      expect(notificationCount).toBe(0);
+
+      unsubscribe();
+    });
+  });
+
   describe("task-created events", () => {
     it("exposes live taskId while the task tool is running", async () => {
       const workspaceId = "task-created-workspace-1";

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -43,6 +43,7 @@ import {
   isRuntimeStatus,
 } from "@/common/orpc/types";
 import {
+  type AdvisorPhaseEvent,
   type StreamAbortEvent,
   type StreamAbortReasonSnapshot,
   type StreamEndEvent,
@@ -185,6 +186,11 @@ export interface WorkspaceConsumersState {
   topFilePaths?: Array<{ path: string; tokens: number }>; // Top 10 files aggregated across all file tools
 }
 
+export interface AdvisorLivePhaseState {
+  phase: AdvisorPhaseEvent["phase"];
+  timestamp: number;
+}
+
 interface WorkspaceChatTransientState {
   caughtUp: boolean;
   isHydratingTranscript: boolean;
@@ -193,6 +199,7 @@ interface WorkspaceChatTransientState {
   replayingHistory: boolean;
   queuedMessage: QueuedMessage | null;
   liveBashOutput: Map<string, LiveBashOutputInternal>;
+  liveAdvisorPhase: Map<string, AdvisorLivePhaseState>;
   liveTaskIds: Map<string, string[]>;
   autoRetryStatus: AutoRetryStatus | null;
 }
@@ -243,6 +250,7 @@ function createInitialChatTransientState(): WorkspaceChatTransientState {
     replayingHistory: false,
     queuedMessage: null,
     liveBashOutput: new Map(),
+    liveAdvisorPhase: new Map(),
     liveTaskIds: new Map(),
     autoRetryStatus: null,
   };
@@ -675,35 +683,35 @@ export class WorkspaceStore {
     },
     "tool-call-end": (workspaceId, aggregator, data) => {
       const toolCallEnd = data as Extract<WorkspaceChatMessage, { type: "tool-call-end" }>;
+      const transient = this.chatTransientState.get(workspaceId);
 
       // Cleanup live bash output once the real tool result contains output.
       // If output is missing (e.g. tmpfile overflow), keep the tail buffer so the UI still shows something.
-      if (toolCallEnd.toolName === "bash") {
-        const transient = this.chatTransientState.get(workspaceId);
-        if (transient) {
-          const output = (toolCallEnd.result as { output?: unknown } | undefined)?.output;
-          if (typeof output === "string") {
-            transient.liveBashOutput.delete(toolCallEnd.toolCallId);
-          } else {
-            // If we keep the tail buffer, ensure we don't get stuck in "filtering" UI state.
-            const prev = transient.liveBashOutput.get(toolCallEnd.toolCallId);
-            if (prev?.phase === "filtering") {
-              const next = appendLiveBashOutputChunk(
-                prev,
-                { text: "", isError: false, phase: "output" },
-                BASH_TRUNCATE_MAX_TOTAL_BYTES
-              );
-              if (next !== prev) {
-                transient.liveBashOutput.set(toolCallEnd.toolCallId, next);
-              }
+      if (toolCallEnd.toolName === "bash" && transient) {
+        const output = (toolCallEnd.result as { output?: unknown } | undefined)?.output;
+        if (typeof output === "string") {
+          transient.liveBashOutput.delete(toolCallEnd.toolCallId);
+        } else {
+          // If we keep the tail buffer, ensure we don't get stuck in "filtering" UI state.
+          const prev = transient.liveBashOutput.get(toolCallEnd.toolCallId);
+          if (prev?.phase === "filtering") {
+            const next = appendLiveBashOutputChunk(
+              prev,
+              { text: "", isError: false, phase: "output" },
+              BASH_TRUNCATE_MAX_TOTAL_BYTES
+            );
+            if (next !== prev) {
+              transient.liveBashOutput.set(toolCallEnd.toolCallId, next);
             }
           }
         }
       }
 
-      // Cleanup ephemeral taskId storage once the actual tool result is available.
+      // Cleanup ephemeral advisor/task state once the actual tool result is available.
+      if (toolCallEnd.toolName === "advisor") {
+        transient?.liveAdvisorPhase.delete(toolCallEnd.toolCallId);
+      }
       if (toolCallEnd.toolName === "task") {
-        const transient = this.chatTransientState.get(workspaceId);
         transient?.liveTaskIds.delete(toolCallEnd.toolCallId);
       }
       applyWorkspaceChatEventToAggregator(aggregator, data);
@@ -1450,6 +1458,13 @@ export class WorkspaceStore {
     // Important: return the stored object reference so useSyncExternalStore sees a stable snapshot.
     // (Returning a fresh object every call can trigger an infinite re-render loop.)
     return state ?? null;
+  }
+
+  getAdvisorToolLivePhase(
+    workspaceId: string,
+    toolCallId: string
+  ): AdvisorLivePhaseState | undefined {
+    return this.chatTransientState.get(workspaceId)?.liveAdvisorPhase.get(toolCallId);
   }
 
   getTaskToolLiveTaskIds(workspaceId: string, toolCallId: string): string[] | null {
@@ -3425,11 +3440,12 @@ export class WorkspaceStore {
       return false;
     }
 
-    // Buffer high-frequency stream events (including bash/task live updates) until
+    // Buffer high-frequency stream events (including bash/task/advisor live updates) until
     // caught-up so full-replay reconnects can deterministically rebuild transient state.
     return (
       data.type in this.bufferedEventHandlers ||
       data.type === "bash-output" ||
+      data.type === "advisor-phase" ||
       data.type === "task-created"
     );
   }
@@ -3502,6 +3518,7 @@ export class WorkspaceStore {
         // Live tool-call UI is tied to the active stream context; clear it when replay
         // replaces history, reports no active stream, or reports a different stream ID.
         transient.liveBashOutput.clear();
+        transient.liveAdvisorPhase.clear();
         transient.liveTaskIds.clear();
       }
 
@@ -3670,6 +3687,24 @@ export class WorkspaceStore {
 
       // High-frequency: throttle UI updates like other delta-style events.
       this.scheduleIdleStateBump(workspaceId);
+      return;
+    }
+
+    if ("type" in data && data.type === "advisor-phase") {
+      const advisorPhase: AdvisorPhaseEvent = data;
+      const transient = this.assertChatTransientState(workspaceId);
+      const prev = transient.liveAdvisorPhase.get(advisorPhase.toolCallId);
+
+      // Avoid unnecessary re-renders if the phase is unchanged.
+      if (prev?.phase === advisorPhase.phase) return;
+
+      transient.liveAdvisorPhase.set(advisorPhase.toolCallId, {
+        phase: advisorPhase.phase,
+        timestamp: advisorPhase.timestamp,
+      });
+
+      // Low-frequency: bump immediately so advisor progress updates feel responsive.
+      this.states.bump(workspaceId);
       return;
     }
 
@@ -3854,6 +3889,27 @@ export function useBashToolLiveOutput(
     () => {
       if (!workspaceId || !toolCallId) return null;
       return store.getBashToolLiveOutput(workspaceId, toolCallId);
+    }
+  );
+}
+
+/**
+ * Hook to get UI-only live advisor phase for a running advisor tool call.
+ */
+export function useAdvisorToolLivePhase(
+  workspaceId: string | undefined,
+  toolCallId: string | undefined
+): AdvisorLivePhaseState | undefined {
+  const store = getStoreInstance();
+
+  return useSyncExternalStore(
+    (listener) => {
+      if (!workspaceId) return () => undefined;
+      return store.subscribeKey(workspaceId, listener);
+    },
+    () => {
+      if (!workspaceId || !toolCallId) return undefined;
+      return store.getAdvisorToolLivePhase(workspaceId, toolCallId);
     }
   );
 }

--- a/src/common/orpc/schemas.ts
+++ b/src/common/orpc/schemas.ts
@@ -194,6 +194,7 @@ export {
   ToolCallStartEventSchema,
   BashOutputEventSchema,
   TaskCreatedEventSchema,
+  AdvisorPhaseEventSchema,
   UpdateStatusSchema,
   UsageDeltaEventSchema,
   WorkspaceChatMessageSchema,

--- a/src/common/orpc/schemas/stream.ts
+++ b/src/common/orpc/schemas/stream.ts
@@ -366,6 +366,20 @@ export const BashOutputEventSchema = z.object({
 });
 
 /**
+ * UI-only advisor progress update for live phase display.
+ *
+ * This is intentionally NOT part of the tool result returned to the model.
+ * It is streamed over workspace.onChat so the UI can show honest advisor progress.
+ */
+export const AdvisorPhaseEventSchema = z.object({
+  type: z.literal("advisor-phase"),
+  workspaceId: z.string(),
+  toolCallId: z.string(),
+  phase: z.enum(["preparing_context", "waiting_for_response", "finalizing_result"]),
+  timestamp: z.number().meta({ description: "When the phase changed (Date.now())" }),
+});
+
+/**
  * UI-only notification that a task tool call has created a child workspace.
  *
  * This is intentionally NOT part of the tool result returned to the model.
@@ -550,6 +564,7 @@ export const WorkspaceChatMessageSchema = z.discriminatedUnion("type", [
   ToolCallEndEventSchema,
   BashOutputEventSchema,
   TaskCreatedEventSchema,
+  AdvisorPhaseEventSchema,
   // Reasoning events
   ReasoningDeltaEventSchema,
   ReasoningEndEventSchema,

--- a/src/common/types/stream.ts
+++ b/src/common/types/stream.ts
@@ -26,6 +26,7 @@ import type {
   ToolCallStartEventSchema,
   BashOutputEventSchema,
   TaskCreatedEventSchema,
+  AdvisorPhaseEventSchema,
   UsageDeltaEventSchema,
   RuntimeStatusEventSchema,
 } from "../orpc/schemas";
@@ -64,6 +65,7 @@ export type ErrorEvent = z.infer<typeof ErrorEventSchema>;
 
 export type BashOutputEvent = z.infer<typeof BashOutputEventSchema>;
 export type TaskCreatedEvent = z.infer<typeof TaskCreatedEventSchema>;
+export type AdvisorPhaseEvent = z.infer<typeof AdvisorPhaseEventSchema>;
 export type ToolCallStartEvent = z.infer<typeof ToolCallStartEventSchema>;
 export type ToolCallDeltaEvent = z.infer<typeof ToolCallDeltaEventSchema>;
 export type ToolCallEndEvent = z.infer<typeof ToolCallEndEventSchema>;

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -3848,6 +3848,9 @@ export class AgentSession {
     forward("task-created", (payload) => {
       this.emitChatEvent(payload);
     });
+    forward("advisor-phase", (payload) => {
+      this.emitChatEvent(payload);
+    });
     forward("tool-call-delta", (payload) => {
       this.markActiveStreamHadAnyOutput();
       this.emitChatEvent(payload);

--- a/src/node/services/tools/advisor.ts
+++ b/src/node/services/tools/advisor.ts
@@ -6,6 +6,7 @@ import { ADVISOR_SYSTEM_PROMPT } from "@/common/constants/advisor";
 import { THINKING_LEVEL_OFF, coerceThinkingLevel } from "@/common/types/thinking";
 import { buildProviderOptions } from "@/common/utils/ai/providerOptions";
 import { getErrorMessage } from "@/common/utils/errors";
+import type { AdvisorPhaseEvent } from "@/common/types/stream";
 import { AdvisorToolInputSchema, TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
 import type { ToolConfiguration } from "@/common/utils/tools/tools";
 
@@ -43,8 +44,24 @@ export function createAdvisorTool(config: ToolConfiguration): Tool {
   return tool({
     description: TOOL_DEFINITIONS.advisor.description,
     inputSchema: AdvisorToolInputSchema,
-    execute: async (args, execOptions) => {
+    execute: async (args, { abortSignal, toolCallId }) => {
       assert(Object.keys(args).length === 0, "advisor tool does not accept input");
+
+      const emitAdvisorPhase = (phase: AdvisorPhaseEvent["phase"]): void => {
+        if (!config.emitChatEvent || !config.workspaceId || !toolCallId) {
+          return;
+        }
+
+        config.emitChatEvent({
+          type: "advisor-phase",
+          workspaceId: config.workspaceId,
+          toolCallId,
+          phase,
+          timestamp: Date.now(),
+        } satisfies AdvisorPhaseEvent);
+      };
+
+      emitAdvisorPhase("preparing_context");
 
       if (runtime.maxUsesPerTurn !== null && usesThisTurn >= runtime.maxUsesPerTurn) {
         return {
@@ -66,6 +83,8 @@ export function createAdvisorTool(config: ToolConfiguration): Tool {
       try {
         const model = await runtime.createModel(advisorModelString);
 
+        emitAdvisorPhase("waiting_for_response");
+
         const result = await generateText({
           model,
           system: ADVISOR_SYSTEM_PROMPT,
@@ -73,8 +92,10 @@ export function createAdvisorTool(config: ToolConfiguration): Tool {
           // Advisor requests are intentionally tool-less strategic consultations.
           tools: {},
           providerOptions,
-          abortSignal: execOptions?.abortSignal ?? runtime.abortSignal,
+          abortSignal: abortSignal ?? runtime.abortSignal,
         });
+
+        emitAdvisorPhase("finalizing_result");
 
         return {
           type: "advice" as const,


### PR DESCRIPTION
## Summary

Add truthful, advisor-specific running-state UX so the advisor tool no longer feels stuck during execution. While the advisor runs, both collapsed and expanded views now show a live phase label (`Preparing context` → `Waiting for response` → `Finalizing result`) alongside an elapsed timer.

## Background

The advisor tool previously showed a generic "Consulting advisor..." with loading dots during execution, with no indication of what phase it was in or how long it had been running. This made long advisor calls feel hung, especially since the advisor involves a full `generateText()` round-trip to a stronger model.

## Implementation

**Architecture: advisor-specific transient phase events + shared elapsed timer**

```
Backend (advisor.ts)                    Schema (stream.ts)
  emit("advisor-phase", {          ──>  AdvisorPhaseEventSchema
    phase: preparing_context |          included in WorkspaceChatMessageSchema
           waiting_for_response |
           finalizing_result,
    toolCallId, workspaceId
  })
        │
        ▼  (workspace.onChat)
Store (WorkspaceStore.ts)               UI (AdvisorToolCall.tsx)
  liveAdvisorPhase Map<toolCallId,  ──> useAdvisorToolLivePhase()
    { phase, timestamp }>               + ElapsedTimeDisplay (shared)
  cleanup on tool-call-end              Phase label + timer in header + details
```

**Key design decisions:**
- Phase events are **UI-only** — they travel over `workspace.onChat` but are never persisted in history or the advisor result schema
- Reuses the existing `bash-output` / `task-created` transient state pattern in WorkspaceStore
- Timer runs entirely on the frontend from the existing `startedAt` timestamp (no backend churn for per-second updates)
- Extracted `ElapsedTimeDisplay` from `BashToolCall` into a shared component to avoid duplication
- Phase emission is **guarded**: the advisor tool remains fully functional when `emitChatEvent`, `workspaceId`, or `toolCallId` are unavailable
- Fallback label (`Running`) shown when the first phase event hasn't arrived yet

**What does NOT happen:**
- No auto-expand
- No fake progress bar or synthetic token stream
- No persisted phase breadcrumbs
- No changes to the advisor result schema

## File changes

| File | Change |
|---|---|
| `src/browser/features/Tools/Shared/ElapsedTimeDisplay.tsx` | **New** — extracted shared timer from BashToolCall |
| `src/browser/features/Tools/BashToolCall.tsx` | Import shared timer instead of local definition |
| `src/common/orpc/schemas/stream.ts` | `AdvisorPhaseEventSchema` + inclusion in `WorkspaceChatMessageSchema` |
| `src/common/orpc/schemas.ts` | Re-export new schema |
| `src/common/types/stream.ts` | Export `AdvisorPhaseEvent` type |
| `src/node/services/tools/advisor.ts` | Emit phase events at 3 execution points |
| `src/browser/stores/WorkspaceStore.ts` | Transient `liveAdvisorPhase` state, event handling, cleanup, getter, hook |
| `src/browser/features/Tools/AdvisorToolCall.tsx` | Widen props, render phase + timer while executing |
| `src/browser/stores/WorkspaceStore.test.ts` | Store tests for phase ingest + cleanup |
| `src/browser/features/Tools/AdvisorToolCall.test.tsx` | **New** — UI tests for running state rendering |

## Validation

- `make typecheck` ✅
- `make lint` ✅
- `bun test src/browser/features/Tools/AdvisorToolCall.test.tsx` — 3/3 pass (executing+phase, fallback, completed regression)
- `bun test src/browser/stores/WorkspaceStore.test.ts` — 96/96 pass (includes new advisor phase ingest + cleanup tests)
- Sandbox dogfooding attempted but the advisor tool was not available to the model in the sandbox (experiment gate is server-side); UI rendering verified through unit tests

## Risks

- **Low risk:** Phase event arrives late or not at all → mitigated by fallback `Running` label and independent timer from `startedAt`
- **Low risk:** Stale phase leaks into later runs → mitigated by cleanup on `tool-call-end` and stream reset paths
- **Low risk:** Timer re-renders → mitigated by leaf-level `ElapsedTimeDisplay` that doesn't re-render the parent tool card


---

<details>
<summary>📋 Implementation Plan</summary>

# Advisor tool while-running UX plan

## Objective

Implement a **truthful advisor-specific running state** so the advisor no longer feels hung while it executes.

### Locked product decisions
- Scope is **advisor only**; do not generalize this to all tools in this change set.
- Show only **current phase + elapsed timer** while the advisor is running.
- Preserve the existing **collapsed vs. expanded** affordance, but **do not auto-expand**.
- Keep the UX **truthful**: no fake progress bar, no synthetic token river, no invented chunk counts.
- Post-run UX is mostly fine; only take **small, low-churn polish** if it falls out naturally.

## Success criteria

1. **Collapsed advisor row** shows a live phase label plus elapsed time during execution.
2. **Expanded advisor view** shows the same live phase label plus elapsed time during execution, without extra fake detail.
3. Advisor phases advance through a small real set:
   - `Preparing context`
   - `Waiting for response`
   - `Finalizing result`
4. The advisor **never auto-expands**.
5. Live phase state is **cleaned up** on completion, failure, or interruption so stale state does not bleed into later runs.
6. No persisted chat/result schema is bloated with ephemeral UI-only telemetry unless implementation discovery proves that is strictly necessary.

## Evidence and repo seams already verified

- `src/browser/features/Tools/AdvisorToolCall.tsx` currently renders a generic running state (`Consulting advisor` + `LoadingDots`) and does **not** display phase or elapsed time.
- `src/browser/features/Messages/ToolMessage.tsx` already passes `workspaceId`, `toolCallId`, and `startedAt={message.timestamp}` to tool components. The advisor tool component simply does not declare/use those props yet.
- `src/node/services/tools/advisor.ts` performs one `generateText()` call and currently returns only a final result (`advice`, `limit_reached`, or `error`).
- `src/common/orpc/schemas/stream.ts` already has the repo’s pattern for **UI-only live tool events** (`bash-output`, `task-created`) that travel over `workspace.onChat` without becoming part of the model-visible tool result.
- `src/browser/stores/WorkspaceStore.ts` already keeps **transient per-tool UI state** (`liveBashOutput`, `liveTaskIds`) and cleans that state on `tool-call-end`.
- `src/browser/features/Tools/BashToolCall.tsx` already contains a proven `ElapsedTimeDisplay` pattern using `requestAnimationFrame` + per-second updates, which is the best starting point for advisor timing.
- `src/browser/stores/WorkspaceStore.test.ts` already contains targeted tests for live bash-output state and cleanup, which provides a strong template for advisor live-phase tests.

## Recommended approach (chosen)

### A. Advisor-specific transient phase event + shared elapsed timer
**Net product-code LoC estimate:** **+100 to +170 LoC**

Use the existing `emitChatEvent` + transient store pattern to stream a tiny advisor-only phase event while the tool runs, then render that phase alongside the already-available tool `startedAt` timestamp.

**Why this is the best fit**
- Keeps the UI **truthful** without pretending we have advisor-internal token/chunk streaming.
- Reuses existing patterns already proven by `bash-output` and `task-created`.
- Avoids persisting UI-only phase breadcrumbs into history.
- Keeps the change set small and advisor-specific.
- Lets the timer run entirely on the frontend from an existing timestamp, which avoids backend churn for per-second updates.

<details>
<summary>Alternatives considered</summary>

### B. Persist phase/timing fields into the final advisor result only
**Net product-code LoC estimate:** **+70 to +120 LoC**

This is smaller on paper, but it is the wrong fit for the requested UX because it only improves replay/final-state data, not the live “is this stuck?” problem. It also stores UI-only breadcrumbs in history.

### C. Hybrid live event + persisted phase summary
**Net product-code LoC estimate:** **+160 to +240 LoC**

This would give both live UX and replayable phase history, but it is over-scoped for the current ask. Defer unless reviewers explicitly want post-run phase history after the live UX lands.

</details>

## Technical design

### Data model choice
Add a new **UI-only** streamed event, e.g. `advisor-phase`, rather than modifying `AdvisorToolResult`.

Proposed wire shape:

```ts
{
  type: "advisor-phase",
  workspaceId: string,
  toolCallId: string,
  phase: "preparing_context" | "waiting_for_response" | "finalizing_result",
  timestamp: number,
}
```

### Why this shape
- `toolCallId` lets the frontend attach live phase state to the correct advisor card.
- `timestamp` matches every other streamed event shape in `src/common/orpc/schemas/stream.ts`.
- `startedAt` does **not** need to be added here because `ToolMessage.tsx` already passes `message.timestamp` to tool components as `startedAt`.
- The event remains UI-only, so no history/schema churn is needed in the persisted advisor result.

### Phase semantics
Backend/internal enum:
- `preparing_context`
- `waiting_for_response`
- `finalizing_result`

Frontend/user-facing labels:
- `Preparing context`
- `Waiting for response`
- `Finalizing result`

Keep the wire enum stable and backend-centric; keep human copy mapped in the UI so copy tweaks do not require protocol changes.

## File-by-file implementation plan

| File | Planned change | Notes |
| --- | --- | --- |
| `src/node/services/tools/advisor.ts` | Emit advisor phase events during execution. | Destructure `toolCallId` from execute options; emit `preparing_context`, then `waiting_for_response`, then `finalizing_result` via `config.emitChatEvent` when `config.workspaceId`, `toolCallId`, and `emitChatEvent` are present. Keep the tool fully functional if live event emission is unavailable. |
| `src/common/orpc/schemas/stream.ts` | Add `AdvisorPhaseEventSchema` and include it in `WorkspaceChatMessageSchema`. | Mirror the existing `bash-output` / `task-created` pattern; keep schema advisor-specific and minimal. |
| `src/common/orpc/schemas.ts` | Re-export the new schema. | Required so downstream imports from the schema barrel stay consistent. |
| `src/common/types/stream.ts` | Export `AdvisorPhaseEvent` inferred type. | Keeps shared stream event typing aligned with schema exports. |
| `src/browser/stores/WorkspaceStore.ts` | Add transient advisor live-phase storage, event handling, getter, cleanup, and hook. | Follow the existing `liveBashOutput` / `useBashToolLiveOutput` pattern: add `liveAdvisorPhase: Map<string, AdvisorLivePhaseState>`, update it on `advisor-phase`, clear it on advisor `tool-call-end`, and expose `useAdvisorToolLivePhase(workspaceId, toolCallId)`. |
| `src/browser/features/Tools/Shared/ElapsedTimeDisplay.tsx` (new) | Extract the reusable timer component out of `BashToolCall.tsx`. | Preserve the current low-overhead behavior: self-contained, leaf-level updates, second-based refreshes. |
| `src/browser/features/Tools/BashToolCall.tsx` | Swap to the extracted shared timer component. | No intended behavior change; this is a refactor-only safety step that reduces duplication before advisor adopts the same timer. |
| `src/browser/features/Tools/AdvisorToolCall.tsx` | Widen props to accept already-supplied `workspaceId`, `toolCallId`, and `startedAt`; render phase + timer while executing. | Keep existing completed/error/limit-reached rendering. During execution, prefer live phase from the store; if phase has not arrived yet, fall back to a minimal truthful label such as `Running`. No auto-expand. |
| `src/browser/stores/WorkspaceStore.test.ts` | Add store tests for advisor-phase event ingest + cleanup. | Use the nearby `bash-output events` tests as the template. |
| `src/browser/features/Tools/AdvisorToolCall.test.tsx` (new) | Add focused UI tests for running-state rendering. | Cover executing with live phase, executing fallback without phase, and completed state regression. Avoid tautological exact-copy tests unless they prove behavior. |

## Execution phases and quality gates

### Phase 1 — Extract the shared elapsed timer
**Goal:** make the timer reusable before touching advisor UI.

**Work**
- Move the `ElapsedTimeDisplay` logic from `src/browser/features/Tools/BashToolCall.tsx` into `src/browser/features/Tools/Shared/ElapsedTimeDisplay.tsx`.
- Keep the implementation leaf-local so the parent tool card does not re-render every tick.
- Keep the current low-noise rendering behavior (second-based updates; hide when inactive).
- Update `BashToolCall.tsx` to import the shared timer with no visual/behavioral regression.

**Acceptance**
- Bash still shows elapsed time exactly as before.
- No new prop threading is needed outside the tool components.

**Quality gate**
- Run the targeted bash/tool component tests that cover shared tool rendering.
- Run `make typecheck` or at minimum targeted type-check validation if the extraction is done before broader changes.

### Phase 2 — Add advisor-phase streaming events
**Goal:** give the advisor truthful live runtime state.

**Work**
- In `src/node/services/tools/advisor.ts`, update the execute signature to destructure `{ abortSignal, toolCallId }`.
- Add a tiny helper (local to the file) that emits `advisor-phase` events only when all required runtime pieces exist (`config.emitChatEvent`, `config.workspaceId`, and `toolCallId`).
- Emit phases at these points:
  1. **Immediately after slot reservation / before transcript work** → `preparing_context`
  2. **Immediately before `generateText()`** → `waiting_for_response`
  3. **Immediately after `generateText()` resolves and before returning the result object** → `finalizing_result`
- Preserve abort/error handling: if the tool fails or is aborted after any phase has been emitted, the final `tool-call-end` cleanup must still remove live phase state.

**Acceptance**
- Advisor emits live phase updates over `workspace.onChat` during a real run.
- No advisor result schema changes are required.
- The tool still works even if UI event emission is unavailable.

**Quality gate**
- Run targeted tests for any new advisor tool helper logic if the file already has tool-level tests; otherwise rely on store/UI tests plus typecheck.
- Run `make typecheck` after schema additions.

### Phase 3 — Store advisor live-phase state in the frontend
**Goal:** ingest the new event with the same transient pattern already used for bash/task.

**Work**
- Extend `WorkspaceChatTransientState` in `src/browser/stores/WorkspaceStore.ts` with a `liveAdvisorPhase` map keyed by `toolCallId`.
- Add a small state shape, e.g.:

```ts
interface AdvisorLivePhaseState {
  phase: "preparing_context" | "waiting_for_response" | "finalizing_result";
  timestamp: number;
}
```

- Handle `advisor-phase` events near the existing `isBashOutputEvent` / `isTaskCreatedEvent` branches.
- Follow the same performance pattern as other low-frequency live events:
  - update transient state only if the phase actually changed
  - trigger a normal state bump (no need for high-frequency buffering)
- Clean up `liveAdvisorPhase` on advisor `tool-call-end`, mirroring the existing bash/task cleanup branches.
- Expose:
  - `getAdvisorToolLivePhase(workspaceId, toolCallId)`
  - `useAdvisorToolLivePhase(workspaceId, toolCallId)`

**Acceptance**
- A running advisor tool call can be queried by `toolCallId` for its current phase.
- The state disappears on completion/failure/interruption.
- No stale advisor phase remains after stream resets or new runs.

**Quality gate**
- Add/extend `WorkspaceStore.test.ts` with:
  - event ingestion test
  - cleanup on advisor `tool-call-end`
  - replay/no-op behavior if duplicate phase arrives
- Run the targeted store test file before moving to the UI.

### Phase 4 — Render phase + timer in the advisor tool UI
**Goal:** replace the generic “Consulting advisor …” feel with concrete, truthful liveness.

**Work**
- Update `AdvisorToolCallProps` in `src/browser/features/Tools/AdvisorToolCall.tsx` to declare the props already passed in by `ToolMessage.tsx`:
  - `workspaceId?: string`
  - `toolCallId?: string`
  - `startedAt?: number`
- Add a local label map from internal phase enum → human copy.
- Read live phase via `useAdvisorToolLivePhase(workspaceId, toolCallId)`.
- Render rules while `status === "executing"`:
  - Use the live phase label if present.
  - Otherwise use a safe fallback label such as `Running` until the first phase event arrives.
  - Show the shared `ElapsedTimeDisplay` beside the phase in the collapsed header.
  - In expanded mode, replace the existing `Consulting advisor <LoadingDots />` block with the same phase + timer presenter.
- Keep the rest of the advisor card intact:
  - completed advice rendering
  - error rendering
  - limit reached rendering
  - no auto-expand logic

**Acceptance**
- Collapsed and expanded views show the same truthful running information.
- There is no fake percentage, no fake token flow, and no auto-expand.
- Completed/error states still render as they do today.

**Quality gate**
- Add `src/browser/features/Tools/AdvisorToolCall.test.tsx` with behavior-focused assertions:
  - executing + live phase renders running info
  - executing + no phase falls back safely
  - completed result path still renders advice metadata/content
- Run the targeted advisor UI test file.

### Phase 5 — Small after-run polish (optional, only if nearly free)
**Goal:** allow tiny cleanup improvements without expanding scope.

**Possible low-churn polish**
- If `startedAt` and completion timing are already conveniently available, show a subtle `Completed in <duration>` treatment in the completed header.
- If this introduces new data plumbing or schema churn, **defer it** and ship the live-running improvement first.

**Acceptance**
- Post-run polish is optional and must not delay the live-running UX fix.

## Testing and validation plan

### Targeted automated tests
- `src/browser/stores/WorkspaceStore.test.ts`
  - advisor-phase ingest
  - advisor-phase cleanup on `tool-call-end`
  - duplicate phase no-op / referential stability where appropriate
- `src/browser/features/Tools/AdvisorToolCall.test.tsx`
  - executing phase rendering
  - timer presence while active
  - fallback label when no live phase is available
  - no completed-state regression
- If the shared timer extraction is substantial, add a small focused test for `ElapsedTimeDisplay` or ensure existing tool tests exercise it indirectly.

### Final validation commands
Run at least:
- targeted Bun tests for the touched files
- `make typecheck`
- `make lint`

If the extraction or store changes ripple unexpectedly into shared tool behavior, expand validation to `make test` before landing.

## Dogfooding plan

Because this is a running-state UX change, manual dogfooding matters as much as unit tests.

### Preferred tooling (updated after reading the skills)
- Use **`make dev-server-sandbox`** for the primary dogfooding environment so the run gets its own temporary `MUX_ROOT`, its own backend/Vite ports, and no `server.lock` conflict with other local mux instances.
- Use **`agent-browser` directly** for browser automation evidence gathering; do **not** use `npx agent-browser`.
- Follow the `agent-browser` ref lifecycle strictly:
  1. `open`
  2. `snapshot -i`
  3. interact with `@eN` refs
  4. re-snapshot after navigation or major DOM changes
- Use a **named browser session** so repeated dogfooding commands share state and can be cleaned up reliably.
- Use **annotated screenshots** for UI proof and **`record start` / `record stop`** for a single watchable end-to-end run video.
- If the Vite/browser surface proves materially different from the final Electron shell for this advisor card, do one last manual confirmation in Electron before sign-off; the sandbox + browser flow remains the primary reproducible path.

### Setup
1. Start an isolated mux instance with the sandbox skill workflow:
   - default path: `make dev-server-sandbox`
   - if you need to inspect sandbox files after exit: `KEEP_SANDBOX=1 make dev-server-sandbox`
   - if you need a cleaner environment for dogfooding noise reduction: `make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-projects"`
2. Capture the printed dev URLs/ports from the sandbox output, especially the **Vite** URL that serves the UI under test.
3. Start a named browser session against that UI, using `agent-browser` directly.
4. Prepare a workspace/chat that can trigger a **non-trivial advisor run** naturally:
   - prefer a larger transcript or a slower advisor model/reasoning setting
   - do **not** add artificial sleeps or fake delays in product code
   - do **not** use fake progress scaffolding just to make the demo easier to capture
5. Create an artifact directory for review evidence (screenshots + video) before you start recording.

### Suggested command shape

```bash
make dev-server-sandbox
# note the Vite URL from the output, then:
agent-browser --session advisor-running open http://127.0.0.1:<VITE_PORT>
agent-browser --session advisor-running snapshot -i
```

Use `agent-browser batch ...` for multi-step sequences when you do not need to inspect intermediate output first. When you need element refs, run `snapshot -i` as a separate command, then use those refs in subsequent commands.

### Manual scenarios
1. **Normal long-ish advisor run**
   - Trigger the advisor from the collapsed state.
   - Confirm the advisor row stays collapsed.
   - Confirm the phase labels appear in order: `Preparing context` → `Waiting for response` → `Finalizing result`.
   - Confirm the timer increments while running.
   - Manually expand the advisor card and verify the same phase + timer information is shown there.
2. **Fast advisor run**
   - Trigger an advisor call that completes quickly.
   - Confirm the UI does not flicker or auto-expand.
3. **Interrupted advisor run**
   - Start advisor, then interrupt/abort it if the surrounding UX allows.
   - Confirm the live phase/timer stop and stale phase state does not remain.
4. **Back-to-back advisor runs**
   - Trigger advisor twice in the same workspace.
   - Confirm the second run starts fresh and does not inherit the first run’s phase.

### Evidence workflow (dogfood-style, but scoped to verification rather than bug-hunting)
1. Before the main run, take an initial annotated screenshot of the relevant chat/tool area.
2. Start a repro video **before** triggering the long-ish advisor run:
   - `agent-browser --session advisor-running record start <artifacts>/advisor-running.webm`
3. Move at human-review pace while capturing evidence:
   - capture the collapsed `Preparing context` state
   - capture the collapsed `Waiting for response` state with a visible timer
   - expand the advisor card and capture the expanded running state
4. Stop the recording after the run completes:
   - `agent-browser --session advisor-running record stop`
5. Close the browser session when done:
   - `agent-browser --session advisor-running close`

### Required review artifacts
Capture and attach:
- **Screenshot 1:** collapsed advisor row in `Preparing context`
- **Screenshot 2:** collapsed advisor row in `Waiting for response` with a visible timer
- **Screenshot 3:** expanded advisor view showing the same phase + timer while still running
- **Video recording:** one full advisor run from start to completion showing:
  - no auto-expand
  - timer incrementing
  - phase transitions in order
  - live state disappearing once the tool completes

Use `attach_file` for the screenshots and the recording so reviewers can verify the live behavior directly.

### Dogfooding acceptance criteria
- The evidence comes from the real running UI, not storybook/static mocks.
- The advisor is shown in both collapsed and expanded running states.
- The captured run demonstrates truthful behavior only: phase + timer, no fake progress constructs.
- The sandbox/browser workflow is reproducible by another reviewer with the same repo checkout.
- Browser automation sessions are closed cleanly at the end.

## Risks and mitigations

- **Risk: phase event arrives late or not at all**
  - **Mitigation:** keep a truthful fallback label (`Running`) and render the timer from `startedAt` independently of phase availability.
- **Risk: stale transient phase leaks into later runs**
  - **Mitigation:** clear `liveAdvisorPhase` on advisor `tool-call-end` and on any broader stream/reset cleanup paths already used for transient state.
- **Risk: timer re-renders too much**
  - **Mitigation:** reuse the existing leaf-level `ElapsedTimeDisplay` pattern rather than updating the whole tool card every frame.
- **Risk: protocol churn spreads beyond the advisor path**
  - **Mitigation:** keep the new event advisor-specific and UI-only; avoid changes to persisted advisor result schemas.
- **Risk: ACP-specific tool update paths differ from direct workspace events**
  - **Mitigation:** verify during implementation that advisor runs in the target desktop flow use the same `workspace.onChat` event path as bash/task live events; only widen ACP translator scope if real testing proves it is necessary.

## Out of scope / explicit defers

- Streaming advisor partial text or advisor-internal token/chunk flow.
- Generic long-running-tool UX cleanup.
- Fake progress percentages or estimated completion.
- Auto-expand logic.
- Major post-run redesign.

## Handoff notes for implementation

- Prefer **minimal product code** and keep the change advisor-specific.
- Treat live phase events as **UI hints**, not durable history.
- Keep defensive programming in place:
  - assert required advisor runtime invariants as the file already does
  - use guard clauses, not crashes, around optional UI-only event emission
- Avoid tautological tests; test behavior and cleanup semantics instead of exact wording unless the wording itself is the behavior.

</details>

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$15.10`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=15.10 -->
