### PR TITLE
🤖 fix: clarify advisor prompt boundaries

### DIFF
--- a/src/common/constants/advisor.ts
+++ b/src/common/constants/advisor.ts
@@ -17,14 +17,15 @@ export const ADVISOR_TOOL_DESCRIPTION =
 /**
  * System prompt for the nested advisor model call.
  * Keep the role boundary explicit because the advisor sees the live transcript
- * from the calling agent and should stay consultative rather than sounding
- * like it is about to execute tools itself.
+ * from the calling assistant. The prompt uses capability wording instead of
+ * policy wording so the advisor does not waste effort reasoning about tools or
+ * whether it should answer the end user directly.
  */
-export const ADVISOR_SYSTEM_PROMPT = `You are an internal strategic advisor assisting another software engineering agent.
+export const ADVISOR_SYSTEM_PROMPT = `You are a strategic advisor for the calling assistant.
 
-You are not the agent doing the work.
-You do not execute commands, inspect files, edit code, or call tools.
-You only provide strategic advice to the calling agent.
+Your job is to help the calling assistant decide what to do next based on the live conversation transcript.
+You are not the assistant responding to the end user.
+You have no tools available. You cannot execute commands, inspect files, edit code, browse, or call tools.
 
 Provide concise, actionable guidance grounded in the conversation so far.
 Focus on the highest-leverage advice:
@@ -32,10 +33,11 @@ Focus on the highest-leverage advice:
 - compare tradeoffs between plausible approaches
 - identify key risks, assumptions, and next steps
 
-Advise the calling agent directly.
-Do not ask the user follow-up questions.
+Address the calling assistant directly, not the end user.
+Do not ask the end user follow-up questions.
 Do not speak as if you are about to take actions yourself.
 Do not narrate tool use, file inspection, or implementation steps as your own actions.
+You may suggest user-facing wording when helpful, but keep the response addressed to the calling assistant.
 
 If the current direction already looks sound, confirm it briefly and explain why.
 Keep the response concise and pointed.`;


### PR DESCRIPTION
## Summary
Clarify the nested advisor prompt so it more clearly frames the advisor as a strategic helper for the calling assistant instead of the end user.

## Background
The previous advisor prompt used policy-style wording like "do not call tools" and "assist another software engineering agent," which made it easier for stronger models to reason about role restrictions instead of treating them as hard boundaries.

## Implementation
- rewrote the advisor role description around the calling assistant and the live transcript
- replaced tool restrictions with explicit capability wording that says the advisor has no tools
- made the audience boundary explicit and allowed optional user-facing wording while keeping the response addressed to the calling assistant

## Validation
- `make static-check`

## Risks
Low. This only changes the advisor system prompt text in one shared constant, so regressions are limited to advisor response tone and framing.

---

_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `xhigh` • Cost: `$0.43`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=xhigh costs=0.43 -->
