### PR TITLE
🤖 feat: add advisor max output tokens experiment setting

### DIFF
--- a/src/browser/features/Settings/Sections/AdvisorToolExperimentConfig.tsx
+++ b/src/browser/features/Settings/Sections/AdvisorToolExperimentConfig.tsx
@@ -25,10 +25,15 @@ import { getErrorMessage } from "@/common/utils/errors";
 import { enforceThinkingPolicy, getThinkingPolicyForModel } from "@/common/utils/thinking/policy";
 
 const DEFAULT_LIMITED_MAX_USES = ADVISOR_DEFAULT_MAX_USES_PER_TURN;
+const DEFAULT_LIMITED_MAX_OUTPUT_TOKENS = 16000;
 
 assert(
   Number.isInteger(DEFAULT_LIMITED_MAX_USES) && DEFAULT_LIMITED_MAX_USES > 0,
   "Advisor limited mode must seed a positive default"
+);
+assert(
+  Number.isInteger(DEFAULT_LIMITED_MAX_OUTPUT_TOKENS) && DEFAULT_LIMITED_MAX_OUTPUT_TOKENS > 0,
+  "Advisor limited output tokens mode must seed a positive default"
 );
 
 type AdvisorMode = "limited" | "unlimited";
@@ -37,6 +42,7 @@ interface AdvisorSettingsState {
   advisorModelString: string | null;
   advisorThinkingLevel: ThinkingLevel;
   advisorMaxUsesPerTurn: number | null;
+  advisorMaxOutputTokens: number | null;
 }
 
 interface AdvisorSavePayload extends AdvisorSettingsState {
@@ -53,6 +59,14 @@ function normalizeAdvisorModelString(value: string | null | undefined): string |
 }
 
 function normalizeAdvisorMaxUsesPerTurn(value: number | null | undefined): number | null {
+  if (!Number.isInteger(value) || value == null || value <= 0) {
+    return null;
+  }
+
+  return value;
+}
+
+function normalizeAdvisorMaxOutputTokens(value: number | null | undefined): number | null {
   if (!Number.isInteger(value) || value == null || value <= 0) {
     return null;
   }
@@ -80,6 +94,9 @@ function normalizeAdvisorDraft(params: {
   maxUsesMode: AdvisorMode;
   limitedDraft: string;
   lastValidLimitedValue: number;
+  maxOutputTokensMode: AdvisorMode;
+  outputTokensDraft: string;
+  lastValidOutputTokensValue: number;
 }): AdvisorSettingsState {
   const normalizedModelString = normalizeAdvisorModelString(params.advisorModelString);
   const normalizedThinkingLevel = enforceThinkingPolicy(
@@ -87,24 +104,31 @@ function normalizeAdvisorDraft(params: {
     params.advisorThinkingLevel
   );
 
-  if (params.maxUsesMode === "unlimited") {
-    return {
-      advisorModelString: normalizedModelString,
-      advisorThinkingLevel: normalizedThinkingLevel,
-      advisorMaxUsesPerTurn: null,
-    };
+  let normalizedMaxUsesPerTurn: number | null = null;
+  if (params.maxUsesMode === "limited") {
+    assert(
+      Number.isInteger(params.lastValidLimitedValue) && params.lastValidLimitedValue > 0,
+      "Advisor limited mode must keep a positive saved value"
+    );
+    normalizedMaxUsesPerTurn =
+      parsePositiveInteger(params.limitedDraft) ?? params.lastValidLimitedValue;
   }
 
-  assert(
-    Number.isInteger(params.lastValidLimitedValue) && params.lastValidLimitedValue > 0,
-    "Advisor limited mode must keep a positive saved value"
-  );
+  let normalizedMaxOutputTokens: number | null = null;
+  if (params.maxOutputTokensMode === "limited") {
+    assert(
+      Number.isInteger(params.lastValidOutputTokensValue) && params.lastValidOutputTokensValue > 0,
+      "Advisor limited max output tokens mode must keep a positive saved value"
+    );
+    normalizedMaxOutputTokens =
+      parsePositiveInteger(params.outputTokensDraft) ?? params.lastValidOutputTokensValue;
+  }
 
   return {
     advisorModelString: normalizedModelString,
     advisorThinkingLevel: normalizedThinkingLevel,
-    advisorMaxUsesPerTurn:
-      parsePositiveInteger(params.limitedDraft) ?? params.lastValidLimitedValue,
+    advisorMaxUsesPerTurn: normalizedMaxUsesPerTurn,
+    advisorMaxOutputTokens: normalizedMaxOutputTokens,
   };
 }
 
@@ -112,7 +136,8 @@ function areAdvisorSettingsEqual(a: AdvisorSettingsState, b: AdvisorSettingsStat
   return (
     a.advisorModelString === b.advisorModelString &&
     a.advisorThinkingLevel === b.advisorThinkingLevel &&
-    a.advisorMaxUsesPerTurn === b.advisorMaxUsesPerTurn
+    a.advisorMaxUsesPerTurn === b.advisorMaxUsesPerTurn &&
+    a.advisorMaxOutputTokens === b.advisorMaxOutputTokens
   );
 }
 
@@ -126,6 +151,13 @@ export function AdvisorToolExperimentConfig() {
   const [maxUsesMode, setMaxUsesMode] = useState<AdvisorMode>("limited");
   const [limitedDraft, setLimitedDraft] = useState(String(DEFAULT_LIMITED_MAX_USES));
   const [lastValidLimitedValue, setLastValidLimitedValue] = useState(DEFAULT_LIMITED_MAX_USES);
+  const [maxOutputTokensMode, setMaxOutputTokensMode] = useState<AdvisorMode>("unlimited");
+  const [outputTokensDraft, setOutputTokensDraft] = useState(
+    String(DEFAULT_LIMITED_MAX_OUTPUT_TOKENS)
+  );
+  const [lastValidOutputTokensValue, setLastValidOutputTokensValue] = useState(
+    DEFAULT_LIMITED_MAX_OUTPUT_TOKENS
+  );
 
   const [loaded, setLoaded] = useState(false);
   const [loadFailed, setLoadFailed] = useState(false);
@@ -167,12 +199,21 @@ export function AdvisorToolExperimentConfig() {
         const normalizedThinkingLevel =
           coerceThinkingLevel(cfg.advisorThinkingLevel) ?? THINKING_LEVEL_OFF;
         const normalizedMaxUsesPerTurn = normalizeAdvisorMaxUsesPerTurn(cfg.advisorMaxUsesPerTurn);
+        const normalizedMaxOutputTokens = normalizeAdvisorMaxOutputTokens(
+          cfg.advisorMaxOutputTokens
+        );
         // Match the backend starter cap when the setting is unset; only an explicit null is
         // the user's Unlimited opt-in.
         const nextMaxUsesMode: AdvisorMode =
           cfg.advisorMaxUsesPerTurn === null ? "unlimited" : "limited";
         const nextLimitedValue = normalizedMaxUsesPerTurn ?? DEFAULT_LIMITED_MAX_USES;
         const nextMaxUsesPerTurn = nextMaxUsesMode === "unlimited" ? null : nextLimitedValue;
+        const nextMaxOutputTokensMode: AdvisorMode =
+          cfg.advisorMaxOutputTokens == null ? "unlimited" : "limited";
+        const nextOutputTokensValue =
+          normalizedMaxOutputTokens ?? DEFAULT_LIMITED_MAX_OUTPUT_TOKENS;
+        const nextMaxOutputTokens =
+          nextMaxOutputTokensMode === "unlimited" ? null : nextOutputTokensValue;
 
         taskSettingsRef.current = normalizedTaskSettings;
         setAdvisorModelString(normalizedModelString ?? "");
@@ -180,10 +221,14 @@ export function AdvisorToolExperimentConfig() {
         setMaxUsesMode(nextMaxUsesMode);
         setLimitedDraft(String(nextLimitedValue));
         setLastValidLimitedValue(nextLimitedValue);
+        setMaxOutputTokensMode(nextMaxOutputTokensMode);
+        setOutputTokensDraft(String(nextOutputTokensValue));
+        setLastValidOutputTokensValue(nextOutputTokensValue);
         lastSyncedRef.current = {
           advisorModelString: normalizedModelString,
           advisorThinkingLevel: normalizedThinkingLevel,
           advisorMaxUsesPerTurn: nextMaxUsesPerTurn,
+          advisorMaxOutputTokens: nextMaxOutputTokens,
         };
         setLoadFailed(false);
         setLoaded(true);
@@ -226,6 +271,9 @@ export function AdvisorToolExperimentConfig() {
       maxUsesMode,
       limitedDraft,
       lastValidLimitedValue,
+      maxOutputTokensMode,
+      outputTokensDraft,
+      lastValidOutputTokensValue,
     });
     const lastSynced = lastSyncedRef.current;
 
@@ -264,12 +312,14 @@ export function AdvisorToolExperimentConfig() {
             advisorModelString: payload.advisorModelString,
             advisorThinkingLevel: payload.advisorThinkingLevel,
             advisorMaxUsesPerTurn: payload.advisorMaxUsesPerTurn,
+            advisorMaxOutputTokens: payload.advisorMaxOutputTokens,
           })
           .then(() => {
             lastSyncedRef.current = {
               advisorModelString: payload.advisorModelString,
               advisorThinkingLevel: payload.advisorThinkingLevel,
               advisorMaxUsesPerTurn: payload.advisorMaxUsesPerTurn,
+              advisorMaxOutputTokens: payload.advisorMaxOutputTokens,
             };
             if (isMountedRef.current) {
               setSaveError(null);
@@ -304,6 +354,9 @@ export function AdvisorToolExperimentConfig() {
     loaded,
     maxUsesMode,
     lastValidLimitedValue,
+    maxOutputTokensMode,
+    outputTokensDraft,
+    lastValidOutputTokensValue,
   ]);
 
   useEffect(() => {
@@ -342,6 +395,7 @@ export function AdvisorToolExperimentConfig() {
           advisorModelString: payload.advisorModelString,
           advisorThinkingLevel: payload.advisorThinkingLevel,
           advisorMaxUsesPerTurn: payload.advisorMaxUsesPerTurn,
+          advisorMaxOutputTokens: payload.advisorMaxOutputTokens,
         })
         .catch(() => undefined)
         .finally(() => {
@@ -386,6 +440,41 @@ export function AdvisorToolExperimentConfig() {
     );
     setLimitedDraft(String(normalizedValue));
     setLastValidLimitedValue(normalizedValue);
+  };
+
+  const setAdvisorMaxOutputTokensMode = (value: string) => {
+    if (value !== "unlimited" && value !== "limited") {
+      return;
+    }
+    if (value === "limited") {
+      const nextValue = parsePositiveInteger(outputTokensDraft) ?? lastValidOutputTokensValue;
+      assert(
+        Number.isInteger(nextValue) && nextValue > 0,
+        "Advisor limited max output tokens needs a positive restored value"
+      );
+      setLastValidOutputTokensValue(nextValue);
+      setOutputTokensDraft(String(nextValue));
+    }
+    setMaxOutputTokensMode(value);
+  };
+
+  const handleOutputTokensDraftChange = (rawValue: string) => {
+    setOutputTokensDraft(rawValue);
+    const parsedValue = parsePositiveInteger(rawValue);
+    if (parsedValue == null) {
+      return;
+    }
+    setLastValidOutputTokensValue(parsedValue);
+  };
+
+  const handleOutputTokensDraftBlur = () => {
+    const normalizedValue = parsePositiveInteger(outputTokensDraft) ?? lastValidOutputTokensValue;
+    assert(
+      Number.isInteger(normalizedValue) && normalizedValue > 0,
+      "Advisor output tokens draft must resolve to a positive integer"
+    );
+    setOutputTokensDraft(String(normalizedValue));
+    setLastValidOutputTokensValue(normalizedValue);
   };
 
   const effectiveAdvisorModelStringForThinking =
@@ -501,6 +590,38 @@ export function AdvisorToolExperimentConfig() {
                 handleLimitedDraftChange(event.target.value)
               }
               onBlur={handleLimitedDraftBlur}
+              className="border-border-medium bg-modal-bg h-9 w-28"
+            />
+          ) : null}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex-1">
+          <div className="text-foreground text-sm">Max Output Tokens</div>
+          <div className="text-muted text-xs">Per advisor response.</div>
+        </div>
+        <div className="flex items-center justify-end gap-2">
+          <Select value={maxOutputTokensMode} onValueChange={setAdvisorMaxOutputTokensMode}>
+            <SelectTrigger className="border-border-medium bg-modal-bg h-9 w-32">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="unlimited">Unlimited</SelectItem>
+              <SelectItem value="limited">Limited</SelectItem>
+            </SelectContent>
+          </Select>
+          {maxOutputTokensMode === "limited" ? (
+            <Input
+              aria-label="Advisor max output tokens"
+              type="number"
+              min={1}
+              step={1}
+              value={outputTokensDraft}
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                handleOutputTokensDraftChange(event.target.value)
+              }
+              onBlur={handleOutputTokensDraftBlur}
               className="border-border-medium bg-modal-bg h-9 w-28"
             />
           ) : null}

--- a/src/browser/features/Settings/Sections/ExperimentsSection.advisor.test.tsx
+++ b/src/browser/features/Settings/Sections/ExperimentsSection.advisor.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import * as ActualSelectPrimitiveModule from "@/browser/components/SelectPrimitive/SelectPrimitive";
@@ -14,6 +14,7 @@ interface MockConfig {
   advisorModelString: string | null;
   advisorThinkingLevel: ThinkingLevel | null | undefined;
   advisorMaxUsesPerTurn: number | null | undefined;
+  advisorMaxOutputTokens: number | null | undefined;
 }
 
 interface SaveConfigInput {
@@ -21,6 +22,7 @@ interface SaveConfigInput {
   advisorModelString?: string | null;
   advisorThinkingLevel?: ThinkingLevel | null;
   advisorMaxUsesPerTurn?: number | null;
+  advisorMaxOutputTokens?: number | null;
 }
 
 interface MockAPIClient {
@@ -204,6 +206,7 @@ function createMockAPI(configOverrides: Partial<MockConfig> = {}) {
     advisorModelString: null,
     advisorThinkingLevel: undefined,
     advisorMaxUsesPerTurn: undefined,
+    advisorMaxOutputTokens: undefined,
     ...configOverrides,
   };
 
@@ -213,6 +216,7 @@ function createMockAPI(configOverrides: Partial<MockConfig> = {}) {
       advisorModelString: config.advisorModelString,
       advisorThinkingLevel: config.advisorThinkingLevel,
       advisorMaxUsesPerTurn: config.advisorMaxUsesPerTurn,
+      advisorMaxOutputTokens: config.advisorMaxOutputTokens,
     })
   );
 
@@ -223,6 +227,7 @@ function createMockAPI(configOverrides: Partial<MockConfig> = {}) {
       : null;
     config.advisorThinkingLevel = input.advisorThinkingLevel ?? null;
     config.advisorMaxUsesPerTurn = input.advisorMaxUsesPerTurn ?? null;
+    config.advisorMaxOutputTokens = input.advisorMaxOutputTokens ?? null;
     return Promise.resolve();
   });
 
@@ -297,8 +302,21 @@ describe("ExperimentsSection advisor config", () => {
 
   function chooseSelectOption(view: ReturnType<typeof render>, label: string, optionText: string) {
     const trigger = getSelectTrigger(view, label);
+    const row = trigger.parentElement?.parentElement;
+    if (!(row instanceof window.HTMLElement)) {
+      throw new Error(`Could not find row for ${label}`);
+    }
+
     fireEvent.pointerDown(trigger);
-    fireEvent.click(view.getByText(optionText));
+
+    const option = within(row)
+      .getAllByRole("button", { name: optionText })
+      .find((element) => element !== trigger);
+    if (!(option instanceof window.HTMLElement)) {
+      throw new Error(`Could not find ${optionText} option for ${label}`);
+    }
+
+    fireEvent.click(option);
   }
 
   test("keeps the advisor row toggle-only when the experiment is disabled", async () => {
@@ -340,6 +358,7 @@ describe("ExperimentsSection advisor config", () => {
         advisorModelString: null,
         advisorThinkingLevel: THINKING_LEVEL_OFF,
         advisorMaxUsesPerTurn: null,
+        advisorMaxOutputTokens: null,
       });
     });
 
@@ -357,6 +376,7 @@ describe("ExperimentsSection advisor config", () => {
         advisorModelString: null,
         advisorThinkingLevel: THINKING_LEVEL_OFF,
         advisorMaxUsesPerTurn: 3,
+        advisorMaxOutputTokens: null,
       });
     });
   });
@@ -380,6 +400,7 @@ describe("ExperimentsSection advisor config", () => {
         advisorModelString: null,
         advisorThinkingLevel: THINKING_LEVEL_OFF,
         advisorMaxUsesPerTurn: null,
+        advisorMaxOutputTokens: null,
       });
     });
 

--- a/src/common/config/schemas/appConfigOnDisk.ts
+++ b/src/common/config/schemas/appConfigOnDisk.ts
@@ -65,6 +65,7 @@ export const AppConfigOnDiskSchema = z
     advisorModelString: z.string().optional(),
     advisorThinkingLevel: ThinkingLevelSchema.optional(),
     advisorMaxUsesPerTurn: z.number().int().positive().nullable().optional(),
+    advisorMaxOutputTokens: z.number().int().positive().nullable().optional(),
     hiddenModels: z.array(z.string()).optional(),
     preferredCompactionModel: z.string().optional(),
     agentAiDefaults: AgentAiDefaultsSchema.optional(),

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -1744,6 +1744,7 @@ const ResolvedTaskSettingsSchema = TaskSettingsSchema.required({
 const AdvisorModelStringSchema = z.string().nullable();
 const AdvisorThinkingLevelSchema = ThinkingLevelSchema.nullable();
 const AdvisorMaxUsesPerTurnSchema = z.number().int().positive().nullable();
+const AdvisorMaxOutputTokensSchema = z.number().int().positive().nullable();
 
 export const config = {
   getConfig: {
@@ -1758,6 +1759,7 @@ export const config = {
       advisorModelString: AdvisorModelStringSchema,
       advisorThinkingLevel: AdvisorThinkingLevelSchema,
       advisorMaxUsesPerTurn: AdvisorMaxUsesPerTurnSchema.optional(),
+      advisorMaxOutputTokens: AdvisorMaxOutputTokensSchema.optional(),
       hiddenModels: z.array(z.string()).optional(),
       coderWorkspaceArchiveBehavior: z.enum(CODER_ARCHIVE_BEHAVIORS),
       worktreeArchiveBehavior: z.enum(WORKTREE_ARCHIVE_BEHAVIORS),
@@ -1781,6 +1783,7 @@ export const config = {
       advisorModelString: AdvisorModelStringSchema.nullish(),
       advisorThinkingLevel: AdvisorThinkingLevelSchema.nullish(),
       advisorMaxUsesPerTurn: AdvisorMaxUsesPerTurnSchema.nullish(),
+      advisorMaxOutputTokens: AdvisorMaxOutputTokensSchema.nullish(),
       agentAiDefaults: AgentAiDefaultsSchema.optional(),
       // Legacy field (downgrade compatibility)
       subagentAiDefaults: SubagentAiDefaultsSchema.optional(),

--- a/src/common/types/project.ts
+++ b/src/common/types/project.ts
@@ -107,6 +107,8 @@ export interface ProjectsConfig {
   advisorThinkingLevel?: ThinkingLevel;
   /** Positive per-turn advisor cap; null/undefined means unlimited. */
   advisorMaxUsesPerTurn?: number | null;
+  /** Positive max-output-tokens cap for advisor responses; null/undefined means unlimited. */
+  advisorMaxOutputTokens?: number | null;
   /**
    * Hidden model IDs (shared via ~/.mux/config.json).
    * Mirrors the browser localStorage cache (HIDDEN_MODELS_KEY).

--- a/src/common/utils/tools/tools.ts
+++ b/src/common/utils/tools/tools.ts
@@ -141,6 +141,8 @@ export interface ToolConfiguration {
     reasoningLevel?: string;
     /** Normalized max uses per turn: null = unlimited, positive integer = exact cap */
     maxUsesPerTurn: number | null;
+    /** Normalized max output tokens cap for advisor responses: undefined = unlimited, positive integer = explicit cap */
+    maxOutputTokens?: number;
     /** Returns the live conversation transcript up to the current tool call */
     getTranscriptSnapshot: () => ModelMessage[];
     /** Creates a LanguageModel from a model string (delegates to providerModelFactory) */

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -695,6 +695,10 @@ export class Config {
           parsed.advisorMaxUsesPerTurn === null
             ? null
             : parseOptionalPositiveInteger(parsed.advisorMaxUsesPerTurn);
+        const advisorMaxOutputTokens =
+          parsed.advisorMaxOutputTokens === null
+            ? null
+            : parseOptionalPositiveInteger(parsed.advisorMaxOutputTokens);
         const hiddenModels = normalizeOptionalModelStringArray(parsed.hiddenModels);
         const legacySubagentAiDefaults = normalizeSubagentAiDefaults(parsed.subagentAiDefaults);
 
@@ -752,6 +756,7 @@ export class Config {
           advisorModelString,
           advisorThinkingLevel,
           advisorMaxUsesPerTurn,
+          advisorMaxOutputTokens,
           hiddenModels,
           agentAiDefaults,
           // Legacy fields are still parsed and returned for downgrade compatibility.
@@ -852,6 +857,15 @@ export class Config {
         const advisorMaxUsesPerTurn = parseOptionalPositiveInteger(config.advisorMaxUsesPerTurn);
         if (advisorMaxUsesPerTurn !== undefined) {
           data.advisorMaxUsesPerTurn = advisorMaxUsesPerTurn;
+        }
+      }
+
+      if (config.advisorMaxOutputTokens === null) {
+        data.advisorMaxOutputTokens = null;
+      } else {
+        const advisorMaxOutputTokens = parseOptionalPositiveInteger(config.advisorMaxOutputTokens);
+        if (advisorMaxOutputTokens !== undefined) {
+          data.advisorMaxOutputTokens = advisorMaxOutputTokens;
         }
       }
 

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -615,6 +615,7 @@ export const router = (authToken?: string) => {
             advisorModelString: config.advisorModelString ?? null,
             advisorThinkingLevel: config.advisorThinkingLevel ?? null,
             advisorMaxUsesPerTurn: config.advisorMaxUsesPerTurn,
+            advisorMaxOutputTokens: config.advisorMaxOutputTokens,
             hiddenModels: config.hiddenModels,
             coderWorkspaceArchiveBehavior:
               config.coderWorkspaceArchiveBehavior ?? DEFAULT_CODER_ARCHIVE_BEHAVIOR,

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -177,6 +177,16 @@ function normalizeAdvisorMaxUsesPerTurn(value: number | null | undefined): numbe
   return value;
 }
 
+function normalizeAdvisorMaxOutputTokens(value: number | null | undefined): number | null {
+  if (value == null) {
+    return null;
+  }
+
+  assert(Number.isInteger(value), "Advisor max output tokens must be an integer");
+  assert(value > 0, "Advisor max output tokens must be positive");
+  return value;
+}
+
 function normalizeMuxMessageFromDisk(value: unknown): MuxMessage | null {
   if (!value || typeof value !== "object") {
     return null;
@@ -927,6 +937,12 @@ export const router = (authToken?: string) => {
             if (input.advisorMaxUsesPerTurn !== undefined) {
               result.advisorMaxUsesPerTurn = normalizeAdvisorMaxUsesPerTurn(
                 input.advisorMaxUsesPerTurn
+              );
+            }
+
+            if (input.advisorMaxOutputTokens !== undefined) {
+              result.advisorMaxOutputTokens = normalizeAdvisorMaxOutputTokens(
+                input.advisorMaxOutputTokens
               );
             }
 

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1308,6 +1308,15 @@ export class AIService extends EventEmitter {
         cfg.advisorMaxUsesPerTurn === null
           ? null
           : (cfg.advisorMaxUsesPerTurn ?? ADVISOR_DEFAULT_MAX_USES_PER_TURN);
+      assert(
+        cfg.advisorMaxOutputTokens == null ||
+          (Number.isInteger(cfg.advisorMaxOutputTokens) && cfg.advisorMaxOutputTokens > 0),
+        "AIService advisorMaxOutputTokens must be null, undefined, or a positive integer"
+      );
+      const advisorMaxOutputTokens =
+        cfg.advisorMaxOutputTokens != null && cfg.advisorMaxOutputTokens > 0
+          ? cfg.advisorMaxOutputTokens
+          : undefined;
       // Clamp the persisted advisor thinking level so the tool metadata matches the
       // providerOptions actually sent to generateText().
       const advisorReasoningLevel = enforceThinkingPolicy(
@@ -1340,6 +1349,7 @@ export class AIService extends EventEmitter {
                   advisorModelString,
                   reasoningLevel: advisorReasoningLevel,
                   maxUsesPerTurn: advisorMaxUses,
+                  maxOutputTokens: advisorMaxOutputTokens,
                   getTranscriptSnapshot: () => {
                     const messages = advisorTranscriptRef.messages;
                     assert(

--- a/src/node/services/tools/advisor.test.ts
+++ b/src/node/services/tools/advisor.test.ts
@@ -23,6 +23,7 @@ function createToolConfig(
   tempDir: string,
   options?: {
     reportModelUsage?: Parameters<typeof createAdvisorTool>[0]["reportModelUsage"];
+    maxOutputTokens?: number;
   }
 ) {
   const createModel = mock(() => Promise.resolve({} as LanguageModel));
@@ -33,6 +34,7 @@ function createToolConfig(
       advisorModelString: ADVISOR_MODEL,
       reasoningLevel: "medium",
       maxUsesPerTurn: 3,
+      maxOutputTokens: options?.maxOutputTokens,
       getTranscriptSnapshot: createTranscript,
       createModel,
       abortSignal: new AbortController().signal,
@@ -104,6 +106,51 @@ describe("advisor tool", () => {
     expect(event?.toolName).toBe("advisor");
     expect(event?.model).toBe(ADVISOR_MODEL);
     expect(typeof event?.timestamp).toBe("number");
+  });
+
+  it("passes maxOutputTokens to generateText when the advisor runtime is capped", async () => {
+    using tempDir = new TestTempDir("advisor-tool-max-output-tokens-limited");
+    const { config } = createToolConfig(tempDir.path, { maxOutputTokens: 1000 });
+    const generateTextSpy = mockGenerateTextSuccess({
+      text: "Keep the recommendation concise.",
+      usage: {
+        inputTokens: 24,
+        outputTokens: 12,
+        totalTokens: 36,
+      },
+    });
+
+    const tool = createAdvisorTool(config);
+    await Promise.resolve(tool.execute!({}, mockToolCallOptions));
+
+    expect(generateTextSpy).toHaveBeenCalledTimes(1);
+    const generateTextArgs = generateTextSpy.mock.calls[0]?.[0];
+    expect(generateTextArgs?.maxOutputTokens).toBe(1000);
+  });
+
+  it("omits maxOutputTokens from generateText when the advisor runtime is unlimited", async () => {
+    using tempDir = new TestTempDir("advisor-tool-max-output-tokens-unlimited");
+    const { config } = createToolConfig(tempDir.path, { maxOutputTokens: undefined });
+    const generateTextSpy = mockGenerateTextSuccess({
+      text: "Return the full analysis.",
+      usage: {
+        inputTokens: 30,
+        outputTokens: 18,
+        totalTokens: 48,
+      },
+    });
+
+    const tool = createAdvisorTool(config);
+    await Promise.resolve(tool.execute!({}, mockToolCallOptions));
+
+    expect(generateTextSpy).toHaveBeenCalledTimes(1);
+    const generateTextArgs = generateTextSpy.mock.calls[0]?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(generateTextArgs?.maxOutputTokens).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(generateTextArgs ?? {}, "maxOutputTokens")).toBe(
+      false
+    );
   });
 
   it("does not report usage when the advisor model call fails", async () => {

--- a/src/node/services/tools/advisor.ts
+++ b/src/node/services/tools/advisor.ts
@@ -34,6 +34,11 @@ export function createAdvisorTool(config: ToolConfiguration): Tool {
     "advisor maxUsesPerTurn must be null or a positive integer"
   );
   assert(
+    runtime.maxOutputTokens === undefined ||
+      (Number.isInteger(runtime.maxOutputTokens) && runtime.maxOutputTokens > 0),
+    "advisor maxOutputTokens must be undefined or a positive integer"
+  );
+  assert(
     typeof runtime.getTranscriptSnapshot === "function",
     "advisor getTranscriptSnapshot must be a function"
   );
@@ -94,6 +99,7 @@ export function createAdvisorTool(config: ToolConfiguration): Tool {
           tools: {},
           providerOptions,
           abortSignal: abortSignal ?? runtime.abortSignal,
+          ...(runtime.maxOutputTokens != null ? { maxOutputTokens: runtime.maxOutputTokens } : {}),
         });
 
         emitAdvisorPhase("finalizing_result");


### PR DESCRIPTION
## Summary

Add an **Advisor Max Output Tokens** experiment setting that lets users cap the advisor tool's response length via `maxOutputTokens` in the `generateText()` call. Users can choose **Unlimited** (no cap, today's behavior) or **Limited** with a positive integer value.

## Background

The advisor tool currently has no output length control — it generates responses of arbitrary length. For cost management and response-time tuning, users need a way to limit how many tokens the advisor model produces per invocation.

## Implementation

Mirrors the existing `advisorMaxUsesPerTurn` pattern end-to-end:

- **Config contract:** `advisorMaxOutputTokens` added to `ProjectsConfig`, on-disk schema, and oRPC API schemas with `number | null | undefined` semantics (null = explicit Unlimited, undefined = unset/legacy).
- **Runtime plumbing:** `aiService.ts` reads the config, normalizes to `number | undefined`, and passes through `advisorRuntime.maxOutputTokens`. The advisor tool conditionally spreads `maxOutputTokens` into `generateText()`.
- **Settings UI:** New "Max Output Tokens" row in `AdvisorToolExperimentConfig` with Unlimited/Limited select + numeric input, matching the Max Uses / Turn control.
- **Router fix:** Two bugs caught during dogfooding — `saveConfig` handler wasn't persisting the field, and `getConfig` handler wasn't returning it. Both fixed by adding the field to the oRPC router.

## Validation

- Typecheck, lint, and all 5 advisor tool tests pass (2 new: limited + unlimited propagation)
- UI dogfooding in sandbox: Limited 1000 → reload → restored; Unlimited → reload → restored
- Config file inspection confirmed `"advisorMaxOutputTokens": 1000` (limited) and `null` (unlimited)
- Advisor tool successfully invoked with 128-token cap (65 tokens produced)

## Risks

Low — the feature is additive and gated behind the existing advisor experiment toggle. Existing configs remain valid with no migration. `undefined`/`null` both map to "do not pass `maxOutputTokens`", preserving today's behavior.

---

<details>
<summary>📋 Implementation Plan</summary>

# Advisor tool max output tokens — implementation plan

## Goal

Add an **Advisor Max Output Tokens** experiment setting that lets users choose either:

- **Unlimited** (preserve today’s behavior: advisor responses are not explicitly capped), or
- **Limited** with a **free-text numeric value** such as `1000` or `2000`

Then propagate that setting through config persistence and runtime plumbing so the advisor tool passes it to the `generateText(...)` call in `src/node/services/tools/advisor.ts`.

## Recommended approach

### Approach A — mirror the existing advisor “Max Uses / Turn” pattern end-to-end
- **Recommendation:** Yes — this should be the default implementation path.
- **Why:** The repo already has the same UX and persistence pattern for advisor max uses, plus an existing `generateText({ maxOutputTokens })` precedent elsewhere.
- **Net product-code LoC estimate:** **~80–120 LoC** across UI, schema/runtime plumbing, and advisor tool wiring.
- **Testing LoC (separate from estimate above):** **~25–45 LoC**.
- **Estimated lift:** **small feature / low-risk**, usually **0.5–1 engineer day** including tests and dogfooding.

### Optional fallback slice — backend plumbing first, UI second
- **Recommendation:** Only use this if scheduling forces a split rollout.
- **What ships first:** persist + plumb `advisorMaxOutputTokens` into the advisor tool, but do not expose it in Settings yet.
- **Net product-code LoC estimate:** **~20–35 LoC** for backend-only plumbing.
- **Tradeoff:** lower immediate lift, but incomplete for the user story because the setting is not discoverable/editable in the app.

## Evidence already gathered

Confirmed touchpoints from repo investigation:

- `src/browser/features/Settings/Sections/AdvisorToolExperimentConfig.tsx`
  - already owns advisor model, reasoning level, and **Max Uses / Turn** UI/state/save flow.
  - contains the closest copyable pattern for **Unlimited / Limited + numeric input**.
- `src/common/config/schemas/appConfigOnDisk.ts`
  - already persists `advisorMaxUsesPerTurn` as nullable optional config.
- `src/common/orpc/schemas/api.ts`
  - already carries advisor config through config get/save schemas.
- `src/common/types/project.ts`
  - already defines advisor-related config shape.
- `src/node/config.ts`
  - already parses and serializes advisor config.
- `src/node/services/aiService.ts`
  - already reads advisor config and assembles `advisorRuntime` for the tool layer.
- `src/common/utils/tools/tools.ts`
  - defines the `advisorRuntime` contract used by the advisor tool.
- `src/node/services/tools/advisor.ts`
  - contains the advisor tool’s `generateText(...)` call site.
- `src/node/services/system1/system1AgentRunner.ts`
  - already demonstrates that `generateText(...)` accepts `maxOutputTokens` in this codebase.
- Likely adjacent tests:
  - `src/browser/features/Settings/Sections/ExperimentsSection.advisor.test.tsx`
  - `src/node/services/tools/advisor.test.ts`

## Recommended product/technical semantics

Use a new persisted field named:

- `advisorMaxOutputTokens`

Recommended meaning:

- `undefined` = **unset / older config / default path**
- `null` = **user explicitly selected Unlimited**
- positive integer = **explicit max output token cap**

### Runtime interpretation

To preserve today’s behavior, treat **both `undefined` and `null` as “do not pass `maxOutputTokens`”** when invoking the advisor model.

That gives us:

- no surprise regression for existing users/configs
- a clean explicit “Unlimited” state in the UI/config
- future flexibility if we ever decide to add a default cap later

### Validation recommendation

- Accept **positive integers only**.
- Do **not** add a hard-coded upper bound in v1 unless an existing shared constraint already exists.
- If a provider rejects an excessively high value, let provider/runtime validation surface that naturally rather than guessing a provider-agnostic max in the UI.

## Suggested agent breakdown

### Lane 1 — Config contract + persistence agent
**Owner:** backend/config-focused exec agent  
**Depends on:** none

Deliverables:
- Add `advisorMaxOutputTokens` to shared config types/schemas.
- Preserve backward compatibility for existing configs.
- Ensure config get/save round-trip works.

Files to update:
- `src/common/types/project.ts`
- `src/common/config/schemas/appConfigOnDisk.ts`
- `src/common/orpc/schemas/api.ts`
- `src/node/config.ts`

Implementation notes:
- Mirror the existing nullable optional advisor setting conventions.
- Reuse existing positive-integer parsing/normalization helpers where possible.
- Apply defensive programming: assert parsed values are either `null`, `undefined`, or a positive integer before storing/emitting.

Quality gate:
- Run targeted config/schema tests if they already exist.
- Confirm no type drift in the config API surface.

### Lane 2 — Advisor runtime plumbing agent
**Owner:** backend/runtime-focused exec agent  
**Depends on:** Lane 1 field definition merged or rebased

Deliverables:
- Read the new config field from runtime config.
- Extend the advisor runtime contract.
- Pass `maxOutputTokens` into the advisor tool’s `generateText(...)` call only when limited.

Files to update:
- `src/node/services/aiService.ts`
- `src/common/utils/tools/tools.ts`
- `src/node/services/tools/advisor.ts`

Implementation notes:
- Prefer normalizing `null`/`undefined` before the tool call so `advisor.ts` only sees either:
  - `undefined` (unlimited / omit field), or
  - a validated positive integer.
- Add lightweight assertions near the normalization boundary, e.g. impossible states should fail fast in development/tests.
- Keep the change minimal: this should be a parameter pass-through, not a refactor.

Quality gate:
- Add/extend a unit test proving:
  - limited config passes `maxOutputTokens: <n>` into `generateText(...)`
  - unlimited/unset config omits that parameter

### Lane 3 — Experiments settings UI agent
**Owner:** frontend/settings-focused exec agent  
**Depends on:** Lane 1 schema name locked; can work in parallel once naming/semantics are stable

Deliverables:
- Add the new setting row to the advisor experiment config UI.
- Keep the interaction model aligned with **Max Uses / Turn**.
- Persist `null` for Unlimited and a positive integer for Limited.

Primary file:
- `src/browser/features/Settings/Sections/AdvisorToolExperimentConfig.tsx`

Likely test file:
- `src/browser/features/Settings/Sections/ExperimentsSection.advisor.test.tsx`

Implementation notes:
- Follow the existing pattern already in the file:
  - mode state: `"unlimited" | "limited"`
  - draft string state for the input
  - last-known-valid integer
  - shared positive-integer parsing helper
  - save-on-change / debounced save flow already used for advisor settings
- Recommended UI copy:
  - Label: `Max Output Tokens`
  - Helper text: `Per advisor response.`
- On initial load:
  - if config is `null` or `undefined`, show **Unlimited**
  - if config is a number, show **Limited** and that value
- On blur / invalid draft handling:
  - snap back to the last valid integer rather than persisting garbage
- Avoid introducing a separate custom component unless the file becomes noticeably harder to read; minimal duplication is acceptable here because an existing pattern already exists.

Quality gate:
- Add/extend UI coverage for:
  - initial Unlimited render from unset/null config
  - switching to Limited and entering `1000`
  - switching back to Unlimited
  - invalid input recovery on blur
  - correct `saveConfig` payload shape

### Lane 4 — Integration + regression test agent
**Owner:** test-focused exec agent  
**Depends on:** Lanes 1–3 available locally

Deliverables:
- Harden unit/integration coverage so the feature is safe to iterate on later.
- Verify no regressions to the existing advisor settings save flow.

Suggested test matrix:
- **Node / advisor tool unit test**
  - `advisorRuntime.maxOutputTokens = 1000` -> `generateText` called with `maxOutputTokens: 1000`
  - `advisorRuntime.maxOutputTokens = undefined` -> `maxOutputTokens` omitted
- **Config persistence / round-trip**
  - serialize + deserialize `null`
  - serialize + deserialize `2000`
  - old config with missing field remains valid
- **Settings UI test**
  - render + persist Unlimited
  - render + persist Limited value
  - preserve other advisor settings when only this field changes

Quality gate:
- Run the narrowest targeted tests first, then one broader suite covering touched layers.

## Execution sequence

### Phase 0 — Lock semantics and file ownership
1. Confirm the feature name is `advisorMaxOutputTokens` everywhere.
2. Lock the runtime rule: **omit `maxOutputTokens` when Unlimited/unset**.
3. Decide that v1 uses **positive integer only** with **no hard-coded provider-agnostic max**.

**Exit criteria:** all lanes use the same naming and runtime semantics.

### Phase 1 — Land shared config contract
1. Extend shared types and schemas.
2. Add node config parse/serialize support.
3. Ensure config APIs can carry the field.

**Dogfood / quality gate after Phase 1:**
- Run schema/config-focused tests.
- Manually inspect a saved config payload in tests/logs to confirm `null` vs number semantics are preserved.

### Phase 2 — Land advisor runtime plumbing
1. Extend `advisorRuntime` shape.
2. Normalize the new field in `aiService`.
3. Pass it into `generateText(...)` only when limited.
4. Add a focused unit test around the advisor tool call.

**Dogfood / quality gate after Phase 2:**
- Capture a terminal screenshot of the focused advisor unit test passing.
- If easy in a local sandbox, temporarily set a very small cap and verify the advisor response becomes visibly short; otherwise rely on the unit test here and perform full UI dogfood in Phase 4.

### Phase 3 — Land the experiments UI
1. Add the new row to `AdvisorToolExperimentConfig`.
2. Wire initial-load state from persisted config.
3. Wire save payload updates.
4. Add UI tests.

**Dogfood / quality gate after Phase 3:**
- Start the app in a sandbox and capture:
  - one annotated screenshot showing the new control on the Experiments page
  - one repro video for switching Unlimited -> Limited (`1000`) -> save/reload
  - one repro video for switching Limited -> Unlimited -> save/reload

### Phase 4 — Final regression + end-to-end verification
1. Re-run targeted tests for config, UI, and advisor tool behavior.
2. Run broader repo validation.
3. Perform one end-to-end advisor exercise with the setting enabled.
4. Package dogfood artifacts for reviewer handoff.

**Exit criteria:** feature works in UI, persists across reload, and reaches the `generateText(...)` call.

## Concrete implementation checklist

### 1) Shared config and IPC
- Add `advisorMaxOutputTokens?: number | null` to the shared project/config type.
- Add nullable-positive-int schema support in on-disk config schema.
- Add the field to config get/save API schemas using the repo’s `.nullish()` convention for tool/input-like API payloads where applicable.
- Ensure `getConfig()` exposes the field and `saveConfig()` accepts it.

### 2) Node config handling
- Parse the field from disk using the same family of helpers used for advisor numeric config today.
- Serialize `null` and numbers faithfully.
- Leave missing/legacy configs untouched.

### 3) Runtime plumbing
- Read `cfg.advisorMaxOutputTokens` where advisor runtime values are assembled in `src/node/services/aiService.ts`.
- Normalize to either `undefined` or a positive integer.
- Extend `ToolConfiguration["advisorRuntime"]` so the tool layer can receive the value.

### 4) Advisor tool execution
- Thread `maxOutputTokens` into `src/node/services/tools/advisor.ts`.
- Keep the generate call shape minimal; do not add provider-specific branching.
- Assert impossible values early in development/test builds.

### 5) Settings UI
- Mirror the existing “Max Uses / Turn” control structure.
- Use the same free-text numeric input pattern rather than a hard-coded preset list.
- Ensure the setting does not clobber model/thinking/max-uses fields when saved.
- Keep helper copy short and parallel with the existing advisor controls.

### 6) Tests
- UI test for render/edit/save/reload semantics.
- Backend unit test for `generateText(...)` arg propagation.
- Config round-trip coverage for number/null/missing.

## Dogfooding plan

This feature touches the settings UI and advisor execution path, so dogfooding must include both **UI evidence** and **one runtime behavior check**.

### Sandbox setup
Use the repo’s sandboxed dev server flow so testing does not collide with other local mux instances.

Recommended command:

```bash
BACKEND_PORT=3001 VITE_PORT=5174 make dev-server-sandbox
```

Notes derived from the skill:
- this gives the run its own temporary `MUX_ROOT`
- default behavior copies provider/config state if present, which is helpful for advisor testing
- pinning ports makes browser automation deterministic

### Browser automation setup
Use `agent-browser` directly (not `npx`). Prefer named sessions and `batch` for simple multi-step sequences.

Suggested session name:
- `advisor-max-output-tokens`

Suggested evidence directory:
- `./dogfood-output/advisor-max-output-tokens/`

### UI dogfood flow (must capture screenshots + video)
1. Open the sandboxed app with `agent-browser`.
2. Navigate to **Settings -> Experiments -> Advisor Tool**.
3. Take an **annotated screenshot** of the page showing the new control.
4. Start a **repro video** before interacting.
5. Switch to **Limited**, enter `1000`, blur/save, and reload the settings view.
6. Take screenshots for each major step plus the final persisted state.
7. Stop the video.
8. Repeat with **Unlimited** and verify reload persistence.
9. Check browser console/errors after both flows.

Reviewer artifacts required:
- annotated screenshot of the control in context
- video: Unlimited -> Limited (`1000`) -> persisted after reload
- video: Limited -> Unlimited -> persisted after reload
- step screenshots referenced by the videos

### Runtime dogfood flow (must capture screenshots + video)
1. Set `Max Output Tokens` to a visibly small value such as `64` or `128`.
2. Trigger the advisor tool with a prompt that would normally produce a long answer.
3. Record the full interaction from before submit through the advisor response.
4. Capture screenshots of:
   - the setting value in Experiments
   - the prompt before submission
   - the resulting short advisor answer
5. Repeat with **Unlimited** and verify the response is materially longer / no cap behavior resumes.

If live-provider dogfooding is blocked by credentials or cost concerns:
- still capture the UI dogfood artifacts above, and
- capture a terminal screenshot of the focused backend test proving `generateText(...)` receives `maxOutputTokens` when limited and omits it when Unlimited.

### agent-browser usage notes to follow
- Use `snapshot -i` to discover refs.
- Re-snapshot after navigation or DOM changes.
- Prefer `wait <selector>`, `wait --text`, or a short fixed wait over `wait --load networkidle`.
- Use `record start/stop` for interactive repros.
- For human-readable repro videos, pause briefly between actions and capture step screenshots.

## Validation plan

### Targeted validation during development
- run focused advisor tool unit tests
- run focused settings UI tests
- run any existing config round-trip tests that cover advisor settings

### Final validation before handoff
Run the repo-standard broader checks appropriate for touched code:

```bash
make typecheck
make test
make lint
```

If time and environment allow, finish with:

```bash
make static-check
```

## Risks and mitigations

### Risk: silently changing existing behavior
- **Mitigation:** treat missing/unset config as Unlimited so existing users keep current behavior.

### Risk: provider-specific max-token quirks
- **Mitigation:** keep v1 validation to “positive integer only” and rely on provider/runtime errors rather than inventing an arbitrary shared max.

### Risk: UI state drift / saving invalid drafts
- **Mitigation:** copy the existing advisor numeric-input pattern, including last-valid-value recovery on blur.

### Risk: accidentally clobbering other advisor settings on save
- **Mitigation:** extend the existing advisor save payload rather than introducing a separate save path.

## Acceptance criteria

### Functional
- Experiments settings show a new **Max Output Tokens** control for the advisor tool.
- Users can choose **Unlimited** or **Limited**.
- Limited mode accepts a positive integer typed as free text.
- The selected value persists across reloads.
- Unlimited mode persists explicitly and restores correctly.
- The advisor tool passes `maxOutputTokens` into `generateText(...)` only when Limited.

### Non-functional
- Existing configs remain valid with no migration required.
- Existing advisor settings behavior is unchanged except for the new option.
- No new console/runtime errors in dogfood flows.
- Focused tests cover UI persistence and backend propagation.

## Handoff notes for the implementation team

- Keep the implementation intentionally boring: this should look like a sibling of the existing advisor max-uses feature, not a new subsystem.
- Favor small stacked commits/PR slices in the order above so regressions are easy to isolate.
- Preserve defensive programming practices: validate/normalize once, assert impossible states, and avoid hiding bad assumptions.
- When handing back for review, include the dogfood screenshot/video artifacts alongside the test results so reviewers can verify the flow without re-running it.

</details>

---
_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$26.93`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=26.93 -->
