### PR TITLE
🤖 fix: include universal skill roots in project-runtime discovery

### DIFF
--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -1192,7 +1192,7 @@ export const TOOL_DEFINITIONS = {
   },
   agent_skill_list: {
     description:
-      "List available skills. In a project workspace, lists both project skills (.mux/skills/) and global skills (~/.mux/skills/), each tagged with its scope. In the system workspace, lists global skills only.",
+      "List available skills. In a project workspace, lists project skills from .mux/skills/ and legacy/universal .agents/skills/, plus global skills from ~/.mux/skills/ and legacy/universal ~/.agents/skills/, each tagged with its scope. In the system workspace, lists global skills only.",
     schema: z
       .object({
         includeUnadvertised: z

--- a/src/node/services/tools/agent_skill_list.test.ts
+++ b/src/node/services/tools/agent_skill_list.test.ts
@@ -76,6 +76,29 @@ async function withMuxRoot(muxRoot: string, callback: () => Promise<void>): Prom
   }
 }
 
+async function withHomeDir(homeDir: string, callback: () => Promise<void>): Promise<void> {
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  process.env.HOME = homeDir;
+  process.env.USERPROFILE = homeDir;
+
+  try {
+    await callback();
+  } finally {
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+
+    if (previousUserProfile === undefined) {
+      delete process.env.USERPROFILE;
+    } else {
+      process.env.USERPROFILE = previousUserProfile;
+    }
+  }
+}
+
 function getSkill(skills: AgentSkillDescriptor[], name: string): AgentSkillDescriptor {
   const skill = skills.find((candidate) => candidate.name === name);
   expect(skill).toBeDefined();
@@ -616,112 +639,114 @@ describe("agent_skill_list", () => {
 
       const remoteWorkspaceRoot = "/remote/workspace";
 
-      await withMuxRoot(muxHome.path, async () => {
-        await writeSkill(path.join(project.path, ".mux", "skills"), "project-remote", {
-          description: "from remote workspace",
+      await withHomeDir(muxHome.path, async () => {
+        await withMuxRoot(muxHome.path, async () => {
+          await writeSkill(path.join(project.path, ".mux", "skills"), "project-remote", {
+            description: "from remote workspace",
+          });
+          await writeGlobalSkill(muxHome.path, "host-global", {
+            description: "from host mux home",
+          });
+
+          // Must use a RemoteRuntime subclass (not LocalRuntime) so the global-root
+          // fallback to host-local kicks in via instanceof RemoteRuntime.
+          const remoteRuntime = new TrueRemotePathMappedRuntime(project.path, remoteWorkspaceRoot);
+          const config = createTestToolConfig(project.path, {
+            workspaceId: "regular-workspace",
+            runtime: remoteRuntime,
+            muxScope: {
+              type: "project",
+              muxHome: muxHome.path,
+              projectRoot: project.path,
+              projectStorageAuthority: "runtime",
+            },
+          });
+
+          const tool = createAgentSkillListTool({
+            ...config,
+            cwd: remoteWorkspaceRoot,
+          });
+
+          const result = (await tool.execute!(
+            { includeUnadvertised: true },
+            mockToolCallOptions
+          )) as AgentSkillListToolResult;
+
+          expect(result.success).toBe(true);
+          if (!result.success) {
+            return;
+          }
+
+          expect(result.skills.map((skill) => skill.name)).toEqual([
+            "host-global",
+            "project-remote",
+          ]);
+          expect(result.skills.find((skill) => skill.name === "host-global")?.scope).toBe("global");
+          expect(result.skills.find((skill) => skill.name === "project-remote")?.scope).toBe(
+            "project"
+          );
         });
-        await writeGlobalSkill(muxHome.path, "host-global", {
-          description: "from host mux home",
-        });
-
-        // Must use a RemoteRuntime subclass (not LocalRuntime) so the global-root
-        // fallback to host-local kicks in via instanceof RemoteRuntime.
-        const remoteRuntime = new TrueRemotePathMappedRuntime(project.path, remoteWorkspaceRoot);
-        const config = createTestToolConfig(project.path, {
-          workspaceId: "regular-workspace",
-          runtime: remoteRuntime,
-          muxScope: {
-            type: "project",
-            muxHome: muxHome.path,
-            projectRoot: project.path,
-            projectStorageAuthority: "runtime",
-          },
-        });
-
-        const tool = createAgentSkillListTool({
-          ...config,
-          cwd: remoteWorkspaceRoot,
-        });
-
-        const result = (await tool.execute!(
-          { includeUnadvertised: true },
-          mockToolCallOptions
-        )) as AgentSkillListToolResult;
-
-        expect(result.success).toBe(true);
-        if (!result.success) {
-          return;
-        }
-
-        expect(result.skills.map((skill) => skill.name)).toEqual(["host-global", "project-remote"]);
-        expect(result.skills.find((skill) => skill.name === "host-global")?.scope).toBe("global");
-        expect(result.skills.find((skill) => skill.name === "project-remote")?.scope).toBe(
-          "project"
-        );
       });
     });
 
-    it("uses runtime mux home for global roots in project-runtime mode", async () => {
+    it("uses runtime mux home and lists ~/.agents/skills in project-runtime mode", async () => {
       using tempDir = new TestTempDir("test-agent-skill-list-split-root-runtime-mux-home");
-      using legacyMuxRoot = new TestTempDir("test-agent-skill-list-split-root-legacy-mux-home");
+      using legacyHome = new TestTempDir("test-agent-skill-list-split-root-legacy-home");
 
       const runtimeGlobalSkill = "runtime-mux-home-global-skill";
       const legacyGlobalSkill = "legacy-tilde-global-skill";
       const remoteWorkspaceRoot = "/var/workspace";
-      const previousMuxRoot = process.env.MUX_ROOT;
 
-      process.env.MUX_ROOT = legacyMuxRoot.path;
+      await withHomeDir(legacyHome.path, async () => {
+        await withMuxRoot(legacyHome.path, async () => {
+          await writeGlobalSkill(path.join(tempDir.path, "mux"), runtimeGlobalSkill, {
+            description: "from runtime mux home",
+          });
+          await writeSkill(path.join(legacyHome.path, ".agents", "skills"), legacyGlobalSkill, {
+            description: "from legacy tilde root",
+          });
 
-      try {
-        await writeGlobalSkill(path.join(tempDir.path, "mux"), runtimeGlobalSkill, {
-          description: "from runtime mux home",
+          const remoteRuntime = new RemotePathMappedRuntime(tempDir.path, "/var", {
+            muxHome: "/var/mux",
+            resolveToRemotePath: false,
+          });
+
+          const config = createTestToolConfig(tempDir.path, {
+            workspaceId: "regular-workspace",
+            runtime: remoteRuntime,
+            muxScope: {
+              type: "project",
+              muxHome: legacyHome.path,
+              projectRoot: tempDir.path,
+              projectStorageAuthority: "runtime",
+            },
+          });
+
+          const tool = createAgentSkillListTool({
+            ...config,
+            cwd: remoteWorkspaceRoot,
+          });
+
+          const result = (await tool.execute!(
+            { includeUnadvertised: true },
+            mockToolCallOptions
+          )) as AgentSkillListToolResult;
+
+          expect(result.success).toBe(true);
+          if (result.success) {
+            expect(
+              result.skills.some(
+                (skill) => skill.name === runtimeGlobalSkill && skill.scope === "global"
+              )
+            ).toBe(true);
+            expect(getSkill(result.skills, legacyGlobalSkill)).toMatchObject({
+              name: legacyGlobalSkill,
+              description: "from legacy tilde root",
+              scope: "global",
+            });
+          }
         });
-        await writeGlobalSkill(legacyMuxRoot.path, legacyGlobalSkill, {
-          description: "from legacy tilde root",
-        });
-
-        const remoteRuntime = new RemotePathMappedRuntime(tempDir.path, "/var", {
-          muxHome: "/var/mux",
-          resolveToRemotePath: false,
-        });
-
-        const config = createTestToolConfig(tempDir.path, {
-          workspaceId: "regular-workspace",
-          runtime: remoteRuntime,
-          muxScope: {
-            type: "project",
-            muxHome: tempDir.path,
-            projectRoot: tempDir.path,
-            projectStorageAuthority: "runtime",
-          },
-        });
-
-        const tool = createAgentSkillListTool({
-          ...config,
-          cwd: remoteWorkspaceRoot,
-        });
-
-        const result = (await tool.execute!(
-          { includeUnadvertised: true },
-          mockToolCallOptions
-        )) as AgentSkillListToolResult;
-
-        expect(result.success).toBe(true);
-        if (result.success) {
-          expect(
-            result.skills.some(
-              (skill) => skill.name === runtimeGlobalSkill && skill.scope === "global"
-            )
-          ).toBe(true);
-          expect(result.skills.find((skill) => skill.name === legacyGlobalSkill)).toBeUndefined();
-        }
-      } finally {
-        if (previousMuxRoot === undefined) {
-          delete process.env.MUX_ROOT;
-        } else {
-          process.env.MUX_ROOT = previousMuxRoot;
-        }
-      }
+      });
     });
 
     it("lists project and global skills with the same name in project-runtime mode", async () => {
@@ -776,41 +801,149 @@ describe("agent_skill_list", () => {
       }
     });
 
-    it("excludes skills from legacy .agents/skills roots in project-runtime mode", async () => {
-      using tempDir = new TestTempDir("test-agent-skill-list-split-root-legacy-root-exclusion");
+    it("lists skills from legacy .agents/skills roots in project-runtime mode", async () => {
+      using projectDir = new TestTempDir("test-agent-skill-list-split-root-legacy-root-inclusion");
+      using homeDir = new TestTempDir("test-agent-skill-list-split-root-legacy-root-home");
       const writableSkillName = "runtime-writable-project-skill";
       const legacySkillName = "runtime-legacy-project-universal-skill";
 
-      await withMuxRoot(tempDir.path, async () => {
-        await writeGlobalSkill(path.join(tempDir.path, ".mux"), writableSkillName);
-        await writeSkill(path.join(tempDir.path, ".agents", "skills"), legacySkillName);
+      await withHomeDir(homeDir.path, async () => {
+        await withMuxRoot(homeDir.path, async () => {
+          await writeGlobalSkill(path.join(projectDir.path, ".mux"), writableSkillName);
+          await writeSkill(path.join(projectDir.path, ".agents", "skills"), legacySkillName);
 
-        const config = createTestToolConfig(tempDir.path, {
-          workspaceId: "regular-workspace",
-          muxScope: {
-            type: "project",
-            muxHome: tempDir.path,
-            projectRoot: tempDir.path,
-            projectStorageAuthority: "runtime",
-          },
+          const config = createTestToolConfig(projectDir.path, {
+            workspaceId: "regular-workspace",
+            muxScope: {
+              type: "project",
+              muxHome: homeDir.path,
+              projectRoot: projectDir.path,
+              projectStorageAuthority: "runtime",
+            },
+          });
+
+          const tool = createAgentSkillListTool(config);
+
+          const result = (await tool.execute!(
+            { includeUnadvertised: true },
+            mockToolCallOptions
+          )) as AgentSkillListToolResult;
+
+          expect(result.success).toBe(true);
+          if (result.success) {
+            expect(
+              result.skills.some(
+                (skill) => skill.name === writableSkillName && skill.scope === "project"
+              )
+            ).toBe(true);
+            expect(getSkill(result.skills, legacySkillName)).toMatchObject({
+              name: legacySkillName,
+              scope: "project",
+            });
+          }
         });
+      });
+    });
 
-        const tool = createAgentSkillListTool(config);
+    it("filters hidden project .agents/skills entries unless includeUnadvertised is true in project-runtime mode", async () => {
+      using projectDir = new TestTempDir(
+        "test-agent-skill-list-split-root-hidden-project-universal"
+      );
+      using homeDir = new TestTempDir("test-agent-skill-list-split-root-hidden-project-home");
+      const hiddenSkillName = "runtime-hidden-project-universal-skill";
 
-        const result = (await tool.execute!(
-          { includeUnadvertised: true },
-          mockToolCallOptions
-        )) as AgentSkillListToolResult;
+      await withHomeDir(homeDir.path, async () => {
+        await withMuxRoot(homeDir.path, async () => {
+          await writeSkill(path.join(projectDir.path, ".agents", "skills"), hiddenSkillName, {
+            advertise: false,
+          });
 
-        expect(result.success).toBe(true);
-        if (result.success) {
-          expect(
-            result.skills.some(
-              (skill) => skill.name === writableSkillName && skill.scope === "project"
-            )
-          ).toBe(true);
-          expect(result.skills.find((skill) => skill.name === legacySkillName)).toBeUndefined();
-        }
+          const config = createTestToolConfig(projectDir.path, {
+            workspaceId: "regular-workspace",
+            muxScope: {
+              type: "project",
+              muxHome: homeDir.path,
+              projectRoot: projectDir.path,
+              projectStorageAuthority: "runtime",
+            },
+          });
+
+          const tool = createAgentSkillListTool(config);
+
+          const defaultResult = (await tool.execute!(
+            {},
+            mockToolCallOptions
+          )) as AgentSkillListToolResult;
+          expect(defaultResult.success).toBe(true);
+          if (defaultResult.success) {
+            expect(defaultResult.skills.some((skill) => skill.name === hiddenSkillName)).toBe(
+              false
+            );
+          }
+
+          const includeAllResult = (await tool.execute!(
+            { includeUnadvertised: true },
+            mockToolCallOptions
+          )) as AgentSkillListToolResult;
+          expect(includeAllResult.success).toBe(true);
+          if (includeAllResult.success) {
+            expect(getSkill(includeAllResult.skills, hiddenSkillName)).toMatchObject({
+              name: hiddenSkillName,
+              scope: "project",
+              advertise: false,
+            });
+          }
+        });
+      });
+    });
+
+    it("filters hidden ~/.agents/skills entries unless includeUnadvertised is true in project-runtime mode", async () => {
+      using projectDir = new TestTempDir("test-agent-skill-list-split-root-hidden-global-project");
+      using homeDir = new TestTempDir("test-agent-skill-list-split-root-hidden-global-home");
+      const hiddenSkillName = "runtime-hidden-global-universal-skill";
+
+      await withHomeDir(homeDir.path, async () => {
+        await withMuxRoot(homeDir.path, async () => {
+          await writeSkill(path.join(homeDir.path, ".agents", "skills"), hiddenSkillName, {
+            advertise: false,
+          });
+
+          const config = createTestToolConfig(projectDir.path, {
+            workspaceId: "regular-workspace",
+            muxScope: {
+              type: "project",
+              muxHome: homeDir.path,
+              projectRoot: projectDir.path,
+              projectStorageAuthority: "runtime",
+            },
+          });
+
+          const tool = createAgentSkillListTool(config);
+
+          const defaultResult = (await tool.execute!(
+            {},
+            mockToolCallOptions
+          )) as AgentSkillListToolResult;
+          expect(defaultResult.success).toBe(true);
+          if (defaultResult.success) {
+            expect(defaultResult.skills.some((skill) => skill.name === hiddenSkillName)).toBe(
+              false
+            );
+          }
+
+          const includeAllResult = (await tool.execute!(
+            { includeUnadvertised: true },
+            mockToolCallOptions
+          )) as AgentSkillListToolResult;
+          expect(includeAllResult.success).toBe(true);
+          if (includeAllResult.success) {
+            expect(getSkill(includeAllResult.skills, hiddenSkillName)).toMatchObject({
+              name: hiddenSkillName,
+              scope: "global",
+              advertise: false,
+            });
+          }
+        });
       });
     });
 

--- a/src/node/services/tools/agent_skill_list.test.ts
+++ b/src/node/services/tools/agent_skill_list.test.ts
@@ -369,6 +369,67 @@ describe("agent_skill_list", () => {
     });
   });
 
+  it("lists skills from all four local roots in project workspaces", async () => {
+    using homeDir = new TestTempDir("test-agent-skill-list-local-roots-home");
+    using project = new TestTempDir("test-agent-skill-list-local-roots-project");
+    const muxHome = path.join(homeDir.path, ".mux");
+
+    await fs.mkdir(muxHome, { recursive: true });
+
+    await withMuxRoot(muxHome, async () => {
+      await writeSkill(path.join(project.path, ".mux", "skills"), "project-only", {
+        description: "from project mux root",
+      });
+      await writeSkill(path.join(project.path, ".agents", "skills"), "project-universal", {
+        description: "from project universal root",
+      });
+      await writeGlobalSkill(muxHome, "global-only", {
+        description: "from global mux root",
+      });
+      await writeSkill(path.join(homeDir.path, ".agents", "skills"), "global-universal", {
+        description: "from global universal root",
+      });
+
+      const tool = createAgentSkillListTool(
+        createTestToolConfig(project.path, {
+          muxScope: {
+            type: "project",
+            muxHome,
+            projectRoot: project.path,
+            projectStorageAuthority: "host-local",
+          },
+        })
+      );
+      const result = (await tool.execute!({}, mockToolCallOptions)) as AgentSkillListToolResult;
+
+      expect(result.success).toBe(true);
+      if (!result.success) {
+        return;
+      }
+
+      expect(getSkill(result.skills, "project-only")).toMatchObject({
+        name: "project-only",
+        description: "from project mux root",
+        scope: "project",
+      });
+      expect(getSkill(result.skills, "project-universal")).toMatchObject({
+        name: "project-universal",
+        description: "from project universal root",
+        scope: "project",
+      });
+      expect(getSkill(result.skills, "global-only")).toMatchObject({
+        name: "global-only",
+        description: "from global mux root",
+        scope: "global",
+      });
+      expect(getSkill(result.skills, "global-universal")).toMatchObject({
+        name: "global-universal",
+        description: "from global universal root",
+        scope: "global",
+      });
+    });
+  });
+
   it("returns only the winning descriptor when project skills shadow global skills", async () => {
     using project = new TestTempDir("test-agent-skill-list-shadow-project");
     using muxHome = new TestTempDir("test-agent-skill-list-shadow-home");
@@ -447,6 +508,66 @@ describe("agent_skill_list", () => {
       expect(result.skills.some((skill) => skill.name === "visible-project")).toBe(true);
       expect(result.skills.some((skill) => skill.name === "hidden-project")).toBe(false);
       expect(result.skills.some((skill) => skill.name === "hidden-global")).toBe(false);
+    });
+  });
+
+  it("filters hidden skills from local legacy .agents/skills roots unless includeUnadvertised is true", async () => {
+    using homeDir = new TestTempDir("test-agent-skill-list-local-hidden-legacy-home");
+    using project = new TestTempDir("test-agent-skill-list-local-hidden-legacy-project");
+    const muxHome = path.join(homeDir.path, ".mux");
+    const hiddenProjectSkill = "hidden-project-universal";
+    const hiddenGlobalSkill = "hidden-global-universal";
+
+    await fs.mkdir(muxHome, { recursive: true });
+
+    await withMuxRoot(muxHome, async () => {
+      await writeSkill(path.join(project.path, ".agents", "skills"), hiddenProjectSkill, {
+        advertise: false,
+      });
+      await writeSkill(path.join(homeDir.path, ".agents", "skills"), hiddenGlobalSkill, {
+        advertise: false,
+      });
+
+      const tool = createAgentSkillListTool(
+        createTestToolConfig(project.path, {
+          muxScope: {
+            type: "project",
+            muxHome,
+            projectRoot: project.path,
+            projectStorageAuthority: "host-local",
+          },
+        })
+      );
+
+      const defaultResult = (await tool.execute!(
+        {},
+        mockToolCallOptions
+      )) as AgentSkillListToolResult;
+      expect(defaultResult.success).toBe(true);
+      if (defaultResult.success) {
+        expect(defaultResult.skills.some((skill) => skill.name === hiddenProjectSkill)).toBe(false);
+        expect(defaultResult.skills.some((skill) => skill.name === hiddenGlobalSkill)).toBe(false);
+      }
+
+      const includeAllResult = (await tool.execute!(
+        { includeUnadvertised: true },
+        mockToolCallOptions
+      )) as AgentSkillListToolResult;
+      expect(includeAllResult.success).toBe(true);
+      if (!includeAllResult.success) {
+        return;
+      }
+
+      expect(getSkill(includeAllResult.skills, hiddenProjectSkill)).toMatchObject({
+        name: hiddenProjectSkill,
+        scope: "project",
+        advertise: false,
+      });
+      expect(getSkill(includeAllResult.skills, hiddenGlobalSkill)).toMatchObject({
+        name: hiddenGlobalSkill,
+        scope: "global",
+        advertise: false,
+      });
     });
   });
 

--- a/src/node/services/tools/agent_skill_list.test.ts
+++ b/src/node/services/tools/agent_skill_list.test.ts
@@ -1,7 +1,8 @@
 import * as fs from "node:fs/promises";
+import os from "node:os";
 import * as path from "node:path";
 
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 import type { ToolExecutionOptions } from "ai";
 
 import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
@@ -79,12 +80,17 @@ async function withMuxRoot(muxRoot: string, callback: () => Promise<void>): Prom
 async function withHomeDir(homeDir: string, callback: () => Promise<void>): Promise<void> {
   const previousHome = process.env.HOME;
   const previousUserProfile = process.env.USERPROFILE;
+  const homedirSpy = spyOn(os, "homedir");
+
+  homedirSpy.mockReturnValue(homeDir);
   process.env.HOME = homeDir;
   process.env.USERPROFILE = homeDir;
 
   try {
     await callback();
   } finally {
+    homedirSpy.mockRestore();
+
     if (previousHome === undefined) {
       delete process.env.HOME;
     } else {
@@ -372,60 +378,60 @@ describe("agent_skill_list", () => {
   it("lists skills from all four local roots in project workspaces", async () => {
     using homeDir = new TestTempDir("test-agent-skill-list-local-roots-home");
     using project = new TestTempDir("test-agent-skill-list-local-roots-project");
-    const muxHome = path.join(homeDir.path, ".mux");
+    using muxHomeDir = new TestTempDir("test-agent-skill-list-local-roots-mux-home");
 
-    await fs.mkdir(muxHome, { recursive: true });
+    await withHomeDir(homeDir.path, async () => {
+      await withMuxRoot(muxHomeDir.path, async () => {
+        await writeSkill(path.join(project.path, ".mux", "skills"), "project-only", {
+          description: "from project mux root",
+        });
+        await writeSkill(path.join(project.path, ".agents", "skills"), "project-universal", {
+          description: "from project universal root",
+        });
+        await writeGlobalSkill(muxHomeDir.path, "global-only", {
+          description: "from global mux root",
+        });
+        await writeSkill(path.join(homeDir.path, ".agents", "skills"), "global-universal", {
+          description: "from global universal root",
+        });
 
-    await withMuxRoot(muxHome, async () => {
-      await writeSkill(path.join(project.path, ".mux", "skills"), "project-only", {
-        description: "from project mux root",
-      });
-      await writeSkill(path.join(project.path, ".agents", "skills"), "project-universal", {
-        description: "from project universal root",
-      });
-      await writeGlobalSkill(muxHome, "global-only", {
-        description: "from global mux root",
-      });
-      await writeSkill(path.join(homeDir.path, ".agents", "skills"), "global-universal", {
-        description: "from global universal root",
-      });
+        const tool = createAgentSkillListTool(
+          createTestToolConfig(project.path, {
+            muxScope: {
+              type: "project",
+              muxHome: muxHomeDir.path,
+              projectRoot: project.path,
+              projectStorageAuthority: "host-local",
+            },
+          })
+        );
+        const result = (await tool.execute!({}, mockToolCallOptions)) as AgentSkillListToolResult;
 
-      const tool = createAgentSkillListTool(
-        createTestToolConfig(project.path, {
-          muxScope: {
-            type: "project",
-            muxHome,
-            projectRoot: project.path,
-            projectStorageAuthority: "host-local",
-          },
-        })
-      );
-      const result = (await tool.execute!({}, mockToolCallOptions)) as AgentSkillListToolResult;
+        expect(result.success).toBe(true);
+        if (!result.success) {
+          return;
+        }
 
-      expect(result.success).toBe(true);
-      if (!result.success) {
-        return;
-      }
-
-      expect(getSkill(result.skills, "project-only")).toMatchObject({
-        name: "project-only",
-        description: "from project mux root",
-        scope: "project",
-      });
-      expect(getSkill(result.skills, "project-universal")).toMatchObject({
-        name: "project-universal",
-        description: "from project universal root",
-        scope: "project",
-      });
-      expect(getSkill(result.skills, "global-only")).toMatchObject({
-        name: "global-only",
-        description: "from global mux root",
-        scope: "global",
-      });
-      expect(getSkill(result.skills, "global-universal")).toMatchObject({
-        name: "global-universal",
-        description: "from global universal root",
-        scope: "global",
+        expect(getSkill(result.skills, "project-only")).toMatchObject({
+          name: "project-only",
+          description: "from project mux root",
+          scope: "project",
+        });
+        expect(getSkill(result.skills, "project-universal")).toMatchObject({
+          name: "project-universal",
+          description: "from project universal root",
+          scope: "project",
+        });
+        expect(getSkill(result.skills, "global-only")).toMatchObject({
+          name: "global-only",
+          description: "from global mux root",
+          scope: "global",
+        });
+        expect(getSkill(result.skills, "global-universal")).toMatchObject({
+          name: "global-universal",
+          description: "from global universal root",
+          scope: "global",
+        });
       });
     });
   });
@@ -514,59 +520,63 @@ describe("agent_skill_list", () => {
   it("filters hidden skills from local legacy .agents/skills roots unless includeUnadvertised is true", async () => {
     using homeDir = new TestTempDir("test-agent-skill-list-local-hidden-legacy-home");
     using project = new TestTempDir("test-agent-skill-list-local-hidden-legacy-project");
-    const muxHome = path.join(homeDir.path, ".mux");
+    using muxHomeDir = new TestTempDir("test-agent-skill-list-local-hidden-legacy-mux-home");
     const hiddenProjectSkill = "hidden-project-universal";
     const hiddenGlobalSkill = "hidden-global-universal";
 
-    await fs.mkdir(muxHome, { recursive: true });
+    await withHomeDir(homeDir.path, async () => {
+      await withMuxRoot(muxHomeDir.path, async () => {
+        await writeSkill(path.join(project.path, ".agents", "skills"), hiddenProjectSkill, {
+          advertise: false,
+        });
+        await writeSkill(path.join(homeDir.path, ".agents", "skills"), hiddenGlobalSkill, {
+          advertise: false,
+        });
 
-    await withMuxRoot(muxHome, async () => {
-      await writeSkill(path.join(project.path, ".agents", "skills"), hiddenProjectSkill, {
-        advertise: false,
-      });
-      await writeSkill(path.join(homeDir.path, ".agents", "skills"), hiddenGlobalSkill, {
-        advertise: false,
-      });
+        const tool = createAgentSkillListTool(
+          createTestToolConfig(project.path, {
+            muxScope: {
+              type: "project",
+              muxHome: muxHomeDir.path,
+              projectRoot: project.path,
+              projectStorageAuthority: "host-local",
+            },
+          })
+        );
 
-      const tool = createAgentSkillListTool(
-        createTestToolConfig(project.path, {
-          muxScope: {
-            type: "project",
-            muxHome,
-            projectRoot: project.path,
-            projectStorageAuthority: "host-local",
-          },
-        })
-      );
+        const defaultResult = (await tool.execute!(
+          {},
+          mockToolCallOptions
+        )) as AgentSkillListToolResult;
+        expect(defaultResult.success).toBe(true);
+        if (defaultResult.success) {
+          expect(defaultResult.skills.some((skill) => skill.name === hiddenProjectSkill)).toBe(
+            false
+          );
+          expect(defaultResult.skills.some((skill) => skill.name === hiddenGlobalSkill)).toBe(
+            false
+          );
+        }
 
-      const defaultResult = (await tool.execute!(
-        {},
-        mockToolCallOptions
-      )) as AgentSkillListToolResult;
-      expect(defaultResult.success).toBe(true);
-      if (defaultResult.success) {
-        expect(defaultResult.skills.some((skill) => skill.name === hiddenProjectSkill)).toBe(false);
-        expect(defaultResult.skills.some((skill) => skill.name === hiddenGlobalSkill)).toBe(false);
-      }
+        const includeAllResult = (await tool.execute!(
+          { includeUnadvertised: true },
+          mockToolCallOptions
+        )) as AgentSkillListToolResult;
+        expect(includeAllResult.success).toBe(true);
+        if (!includeAllResult.success) {
+          return;
+        }
 
-      const includeAllResult = (await tool.execute!(
-        { includeUnadvertised: true },
-        mockToolCallOptions
-      )) as AgentSkillListToolResult;
-      expect(includeAllResult.success).toBe(true);
-      if (!includeAllResult.success) {
-        return;
-      }
-
-      expect(getSkill(includeAllResult.skills, hiddenProjectSkill)).toMatchObject({
-        name: hiddenProjectSkill,
-        scope: "project",
-        advertise: false,
-      });
-      expect(getSkill(includeAllResult.skills, hiddenGlobalSkill)).toMatchObject({
-        name: hiddenGlobalSkill,
-        scope: "global",
-        advertise: false,
+        expect(getSkill(includeAllResult.skills, hiddenProjectSkill)).toMatchObject({
+          name: hiddenProjectSkill,
+          scope: "project",
+          advertise: false,
+        });
+        expect(getSkill(includeAllResult.skills, hiddenGlobalSkill)).toMatchObject({
+          name: hiddenGlobalSkill,
+          scope: "global",
+          advertise: false,
+        });
       });
     });
   });
@@ -657,64 +667,74 @@ describe("agent_skill_list", () => {
   it("operates on global skills root when scope is global", async () => {
     using tempDir = new TestTempDir("test-agent-skill-list-global");
 
-    const workspaceSessionDir = await createWorkspaceSessionDir(tempDir.path, GLOBAL_WORKSPACE_ID);
+    await withHomeDir(tempDir.path, async () => {
+      const workspaceSessionDir = await createWorkspaceSessionDir(
+        tempDir.path,
+        GLOBAL_WORKSPACE_ID
+      );
 
-    await writeGlobalSkill(tempDir.path, "alpha-skill");
-    await writeGlobalSkill(tempDir.path, "zeta-skill");
+      await writeGlobalSkill(tempDir.path, "alpha-skill");
+      await writeGlobalSkill(tempDir.path, "zeta-skill");
 
-    const config = createTestToolConfig(tempDir.path, {
-      workspaceId: GLOBAL_WORKSPACE_ID,
-      sessionsDir: workspaceSessionDir,
-      muxScope: {
-        type: "global",
-        muxHome: tempDir.path,
-      },
+      const config = createTestToolConfig(tempDir.path, {
+        workspaceId: GLOBAL_WORKSPACE_ID,
+        sessionsDir: workspaceSessionDir,
+        muxScope: {
+          type: "global",
+          muxHome: tempDir.path,
+        },
+      });
+
+      const tool = createAgentSkillListTool(config);
+      const result = (await tool.execute!({}, mockToolCallOptions)) as AgentSkillListToolResult;
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.skills.map((skill) => skill.name)).toEqual(["alpha-skill", "zeta-skill"]);
+        expect(result.skills.every((skill) => skill.scope === "global")).toBe(true);
+      }
     });
-
-    const tool = createAgentSkillListTool(config);
-    const result = (await tool.execute!({}, mockToolCallOptions)) as AgentSkillListToolResult;
-
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.skills.map((skill) => skill.name)).toEqual(["alpha-skill", "zeta-skill"]);
-      expect(result.skills.every((skill) => skill.scope === "global")).toBe(true);
-    }
   });
 
   it("operates on project skills root when scope is project", async () => {
     using tempDir = new TestTempDir("test-agent-skill-list-project");
 
-    const workspaceSessionDir = await createWorkspaceSessionDir(tempDir.path, GLOBAL_WORKSPACE_ID);
+    await withHomeDir(tempDir.path, async () => {
+      const workspaceSessionDir = await createWorkspaceSessionDir(
+        tempDir.path,
+        GLOBAL_WORKSPACE_ID
+      );
 
-    const projectRoot = path.join(tempDir.path, "my-project");
-    await fs.mkdir(path.join(projectRoot, ".mux", "skills"), { recursive: true });
+      const projectRoot = path.join(tempDir.path, "my-project");
+      await fs.mkdir(path.join(projectRoot, ".mux", "skills"), { recursive: true });
 
-    await writeGlobalSkill(tempDir.path, "global-skill");
-    await writeGlobalSkill(path.join(projectRoot, ".mux"), "project-skill");
+      await writeGlobalSkill(tempDir.path, "global-skill");
+      await writeGlobalSkill(path.join(projectRoot, ".mux"), "project-skill");
 
-    const projectScope: MuxToolScope = {
-      type: "project",
-      muxHome: tempDir.path,
-      projectRoot,
-      projectStorageAuthority: "host-local",
-    };
+      const projectScope: MuxToolScope = {
+        type: "project",
+        muxHome: tempDir.path,
+        projectRoot,
+        projectStorageAuthority: "host-local",
+      };
 
-    const config = createTestToolConfig(tempDir.path, {
-      workspaceId: GLOBAL_WORKSPACE_ID,
-      sessionsDir: workspaceSessionDir,
-      muxScope: projectScope,
+      const config = createTestToolConfig(tempDir.path, {
+        workspaceId: GLOBAL_WORKSPACE_ID,
+        sessionsDir: workspaceSessionDir,
+        muxScope: projectScope,
+      });
+
+      const tool = createAgentSkillListTool(config);
+      const result = (await tool.execute!({}, mockToolCallOptions)) as AgentSkillListToolResult;
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        // Project scope lists both project and global skills, each tagged with scope
+        expect(result.skills.map((skill) => skill.name)).toEqual(["global-skill", "project-skill"]);
+        expect(result.skills.find((s) => s.name === "project-skill")?.scope).toBe("project");
+        expect(result.skills.find((s) => s.name === "global-skill")?.scope).toBe("global");
+      }
     });
-
-    const tool = createAgentSkillListTool(config);
-    const result = (await tool.execute!({}, mockToolCallOptions)) as AgentSkillListToolResult;
-
-    expect(result.success).toBe(true);
-    if (result.success) {
-      // Project scope lists both project and global skills, each tagged with scope
-      expect(result.skills.map((skill) => skill.name)).toEqual(["global-skill", "project-skill"]);
-      expect(result.skills.find((s) => s.name === "project-skill")?.scope).toBe("project");
-      expect(result.skills.find((s) => s.name === "global-skill")?.scope).toBe("global");
-    }
   });
   describe("split-root (project-runtime)", () => {
     it("routes through project-runtime when runtime is non-local", async () => {
@@ -1138,275 +1158,304 @@ describe("agent_skill_list", () => {
   it("filters unadvertised skills unless includeUnadvertised is true", async () => {
     using tempDir = new TestTempDir("test-agent-skill-list-advertise");
 
-    const workspaceSessionDir = await createWorkspaceSessionDir(tempDir.path, GLOBAL_WORKSPACE_ID);
+    await withHomeDir(tempDir.path, async () => {
+      const workspaceSessionDir = await createWorkspaceSessionDir(
+        tempDir.path,
+        GLOBAL_WORKSPACE_ID
+      );
 
-    await writeGlobalSkill(tempDir.path, "advertised-skill");
-    await writeGlobalSkill(tempDir.path, "hidden-skill", { advertise: false });
+      await writeGlobalSkill(tempDir.path, "advertised-skill");
+      await writeGlobalSkill(tempDir.path, "hidden-skill", { advertise: false });
 
-    const config = createTestToolConfig(tempDir.path, {
-      workspaceId: GLOBAL_WORKSPACE_ID,
-      sessionsDir: workspaceSessionDir,
-      muxScope: {
-        type: "global",
-        muxHome: tempDir.path,
-      },
+      const config = createTestToolConfig(tempDir.path, {
+        workspaceId: GLOBAL_WORKSPACE_ID,
+        sessionsDir: workspaceSessionDir,
+        muxScope: {
+          type: "global",
+          muxHome: tempDir.path,
+        },
+      });
+
+      const tool = createAgentSkillListTool(config);
+
+      const defaultResult = (await tool.execute!(
+        {},
+        mockToolCallOptions
+      )) as AgentSkillListToolResult;
+      expect(defaultResult.success).toBe(true);
+      if (defaultResult.success) {
+        expect(defaultResult.skills.map((skill) => skill.name)).toEqual(["advertised-skill"]);
+      }
+
+      const includeAllResult = (await tool.execute!(
+        { includeUnadvertised: true },
+        mockToolCallOptions
+      )) as AgentSkillListToolResult;
+      expect(includeAllResult.success).toBe(true);
+      if (includeAllResult.success) {
+        expect(includeAllResult.skills.map((skill) => skill.name)).toEqual([
+          "advertised-skill",
+          "hidden-skill",
+        ]);
+      }
     });
-
-    const tool = createAgentSkillListTool(config);
-
-    const defaultResult = (await tool.execute!(
-      {},
-      mockToolCallOptions
-    )) as AgentSkillListToolResult;
-    expect(defaultResult.success).toBe(true);
-    if (defaultResult.success) {
-      expect(defaultResult.skills.map((skill) => skill.name)).toEqual(["advertised-skill"]);
-    }
-
-    const includeAllResult = (await tool.execute!(
-      { includeUnadvertised: true },
-      mockToolCallOptions
-    )) as AgentSkillListToolResult;
-    expect(includeAllResult.success).toBe(true);
-    if (includeAllResult.success) {
-      expect(includeAllResult.skills.map((skill) => skill.name)).toEqual([
-        "advertised-skill",
-        "hidden-skill",
-      ]);
-    }
   });
 
   it("skips symlinked project skill directories inside contained skills root", async () => {
     using tempDir = new TestTempDir("test-agent-skill-list-project-entry-symlink");
 
-    const workspaceSessionDir = await createWorkspaceSessionDir(tempDir.path, GLOBAL_WORKSPACE_ID);
+    await withHomeDir(tempDir.path, async () => {
+      const workspaceSessionDir = await createWorkspaceSessionDir(
+        tempDir.path,
+        GLOBAL_WORKSPACE_ID
+      );
 
-    const projectRoot = path.join(tempDir.path, "project");
-    const skillsDir = path.join(projectRoot, ".mux", "skills");
-    await fs.mkdir(skillsDir, { recursive: true });
+      const projectRoot = path.join(tempDir.path, "project");
+      const skillsDir = path.join(projectRoot, ".mux", "skills");
+      await fs.mkdir(skillsDir, { recursive: true });
 
-    // Legitimate project skill directory.
-    await writeGlobalSkill(path.join(projectRoot, ".mux"), "real-skill");
+      // Legitimate project skill directory.
+      await writeGlobalSkill(path.join(projectRoot, ".mux"), "real-skill");
 
-    // External skill directory linked into project skills root.
-    const externalSkillDir = path.join(tempDir.path, "external", "sneaky-skill");
-    await fs.mkdir(externalSkillDir, { recursive: true });
-    await fs.writeFile(
-      path.join(externalSkillDir, "SKILL.md"),
-      "---\nname: sneaky-skill\ndescription: should not appear\n---\nBody\n",
-      "utf-8"
-    );
-    await fs.symlink(externalSkillDir, path.join(skillsDir, "sneaky-skill"));
+      // External skill directory linked into project skills root.
+      const externalSkillDir = path.join(tempDir.path, "external", "sneaky-skill");
+      await fs.mkdir(externalSkillDir, { recursive: true });
+      await fs.writeFile(
+        path.join(externalSkillDir, "SKILL.md"),
+        "---\nname: sneaky-skill\ndescription: should not appear\n---\nBody\n",
+        "utf-8"
+      );
+      await fs.symlink(externalSkillDir, path.join(skillsDir, "sneaky-skill"));
 
-    // Also create a real global skill.
-    await writeGlobalSkill(tempDir.path, "global-skill");
+      // Also create a real global skill.
+      await writeGlobalSkill(tempDir.path, "global-skill");
 
-    const projectScope: MuxToolScope = {
-      type: "project",
-      muxHome: tempDir.path,
-      projectRoot,
-      projectStorageAuthority: "host-local",
-    };
+      const projectScope: MuxToolScope = {
+        type: "project",
+        muxHome: tempDir.path,
+        projectRoot,
+        projectStorageAuthority: "host-local",
+      };
 
-    const config = createTestToolConfig(tempDir.path, {
-      workspaceId: GLOBAL_WORKSPACE_ID,
-      sessionsDir: workspaceSessionDir,
-      muxScope: projectScope,
+      const config = createTestToolConfig(tempDir.path, {
+        workspaceId: GLOBAL_WORKSPACE_ID,
+        sessionsDir: workspaceSessionDir,
+        muxScope: projectScope,
+      });
+
+      const tool = createAgentSkillListTool(config);
+      const result = (await tool.execute!({}, mockToolCallOptions)) as AgentSkillListToolResult;
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        // Symlinked entry should be skipped.
+        expect(result.skills.map((s) => s.name)).toEqual(["global-skill", "real-skill"]);
+        expect(result.skills.find((s) => s.name === "real-skill")?.scope).toBe("project");
+        expect(result.skills.find((s) => s.name === "sneaky-skill")).toBeUndefined();
+      }
     });
-
-    const tool = createAgentSkillListTool(config);
-    const result = (await tool.execute!({}, mockToolCallOptions)) as AgentSkillListToolResult;
-
-    expect(result.success).toBe(true);
-    if (result.success) {
-      // Symlinked entry should be skipped.
-      expect(result.skills.map((s) => s.name)).toEqual(["global-skill", "real-skill"]);
-      expect(result.skills.find((s) => s.name === "real-skill")?.scope).toBe("project");
-      expect(result.skills.find((s) => s.name === "sneaky-skill")).toBeUndefined();
-    }
   });
 
   it("skips project skill when SKILL.md symlink target escapes project root", async () => {
     using tempDir = new TestTempDir("test-agent-skill-list-skillmd-symlink-escape");
 
-    const workspaceSessionDir = await createWorkspaceSessionDir(tempDir.path, GLOBAL_WORKSPACE_ID);
+    await withHomeDir(tempDir.path, async () => {
+      const workspaceSessionDir = await createWorkspaceSessionDir(
+        tempDir.path,
+        GLOBAL_WORKSPACE_ID
+      );
 
-    const projectRoot = path.join(tempDir.path, "project");
-    const skillsDir = path.join(projectRoot, ".mux", "skills");
+      const projectRoot = path.join(tempDir.path, "project");
+      const skillsDir = path.join(projectRoot, ".mux", "skills");
 
-    // Create a legitimate project skill.
-    await writeGlobalSkill(path.join(projectRoot, ".mux"), "legit-skill");
+      // Create a legitimate project skill.
+      await writeGlobalSkill(path.join(projectRoot, ".mux"), "legit-skill");
 
-    // Create a skill directory with SKILL.md symlinked to an external file.
-    const leakySkillDir = path.join(skillsDir, "leaky-skill");
-    await fs.mkdir(leakySkillDir, { recursive: true });
+      // Create a skill directory with SKILL.md symlinked to an external file.
+      const leakySkillDir = path.join(skillsDir, "leaky-skill");
+      await fs.mkdir(leakySkillDir, { recursive: true });
 
-    const externalDir = path.join(tempDir.path, "external");
-    const externalFile = path.join(externalDir, "secret.md");
-    await fs.mkdir(externalDir, { recursive: true });
-    await fs.writeFile(
-      externalFile,
-      "---\nname: leaky-skill\ndescription: should not be read\n---\nSecret body\n",
-      "utf-8"
-    );
-    await fs.symlink(externalFile, path.join(leakySkillDir, "SKILL.md"));
+      const externalDir = path.join(tempDir.path, "external");
+      const externalFile = path.join(externalDir, "secret.md");
+      await fs.mkdir(externalDir, { recursive: true });
+      await fs.writeFile(
+        externalFile,
+        "---\nname: leaky-skill\ndescription: should not be read\n---\nSecret body\n",
+        "utf-8"
+      );
+      await fs.symlink(externalFile, path.join(leakySkillDir, "SKILL.md"));
 
-    // Also create a global skill.
-    await writeGlobalSkill(tempDir.path, "global-skill");
+      // Also create a global skill.
+      await writeGlobalSkill(tempDir.path, "global-skill");
 
-    const projectScope: MuxToolScope = {
-      type: "project",
-      muxHome: tempDir.path,
-      projectRoot,
-      projectStorageAuthority: "host-local",
-    };
+      const projectScope: MuxToolScope = {
+        type: "project",
+        muxHome: tempDir.path,
+        projectRoot,
+        projectStorageAuthority: "host-local",
+      };
 
-    const config = createTestToolConfig(tempDir.path, {
-      workspaceId: GLOBAL_WORKSPACE_ID,
-      sessionsDir: workspaceSessionDir,
-      muxScope: projectScope,
+      const config = createTestToolConfig(tempDir.path, {
+        workspaceId: GLOBAL_WORKSPACE_ID,
+        sessionsDir: workspaceSessionDir,
+        muxScope: projectScope,
+      });
+
+      const tool = createAgentSkillListTool(config);
+      const result = (await tool.execute!({}, mockToolCallOptions)) as AgentSkillListToolResult;
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.skills.map((s) => s.name)).toEqual(["global-skill", "legit-skill"]);
+        expect(result.skills.find((s) => s.name === "leaky-skill")).toBeUndefined();
+      }
     });
-
-    const tool = createAgentSkillListTool(config);
-    const result = (await tool.execute!({}, mockToolCallOptions)) as AgentSkillListToolResult;
-
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.skills.map((s) => s.name)).toEqual(["global-skill", "legit-skill"]);
-      expect(result.skills.find((s) => s.name === "leaky-skill")).toBeUndefined();
-    }
   });
 
   it("skips skill with oversized SKILL.md", async () => {
     using tempDir = new TestTempDir("test-agent-skill-list-oversized-skillmd");
 
-    const workspaceSessionDir = await createWorkspaceSessionDir(tempDir.path, GLOBAL_WORKSPACE_ID);
+    await withHomeDir(tempDir.path, async () => {
+      const workspaceSessionDir = await createWorkspaceSessionDir(
+        tempDir.path,
+        GLOBAL_WORKSPACE_ID
+      );
 
-    await writeGlobalSkill(tempDir.path, "normal-skill");
+      await writeGlobalSkill(tempDir.path, "normal-skill");
 
-    const oversizedSkillDir = path.join(tempDir.path, "skills", "big-skill");
-    await fs.mkdir(oversizedSkillDir, { recursive: true });
-    const oversizedContent =
-      "---\nname: big-skill\ndescription: too large\n---\n" + "x".repeat(MAX_FILE_SIZE + 1);
-    await fs.writeFile(path.join(oversizedSkillDir, "SKILL.md"), oversizedContent, "utf-8");
+      const oversizedSkillDir = path.join(tempDir.path, "skills", "big-skill");
+      await fs.mkdir(oversizedSkillDir, { recursive: true });
+      const oversizedContent =
+        "---\nname: big-skill\ndescription: too large\n---\n" + "x".repeat(MAX_FILE_SIZE + 1);
+      await fs.writeFile(path.join(oversizedSkillDir, "SKILL.md"), oversizedContent, "utf-8");
 
-    const config = createTestToolConfig(tempDir.path, {
-      workspaceId: GLOBAL_WORKSPACE_ID,
-      sessionsDir: workspaceSessionDir,
-      muxScope: {
-        type: "global",
-        muxHome: tempDir.path,
-      },
+      const config = createTestToolConfig(tempDir.path, {
+        workspaceId: GLOBAL_WORKSPACE_ID,
+        sessionsDir: workspaceSessionDir,
+        muxScope: {
+          type: "global",
+          muxHome: tempDir.path,
+        },
+      });
+
+      const tool = createAgentSkillListTool(config);
+      const result = (await tool.execute!({}, mockToolCallOptions)) as AgentSkillListToolResult;
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.skills.map((s) => s.name)).toEqual(["normal-skill"]);
+        expect(result.skills.find((s) => s.name === "big-skill")).toBeUndefined();
+      }
     });
-
-    const tool = createAgentSkillListTool(config);
-    const result = (await tool.execute!({}, mockToolCallOptions)) as AgentSkillListToolResult;
-
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.skills.map((s) => s.name)).toEqual(["normal-skill"]);
-      expect(result.skills.find((s) => s.name === "big-skill")).toBeUndefined();
-    }
   });
 
   it("continues listing global skills when project skills root is not a directory", async () => {
     using project = new TestTempDir("test-agent-skill-list-project-root-not-directory");
     using muxHome = new TestTempDir("test-agent-skill-list-global-root-valid");
 
-    await fs.mkdir(path.join(project.path, ".mux"), { recursive: true });
-    await fs.writeFile(path.join(project.path, ".mux", "skills"), "not a directory", "utf-8");
-    await writeGlobalSkill(muxHome.path, "global-skill", {
-      description: "from global",
+    await withHomeDir(muxHome.path, async () => {
+      await fs.mkdir(path.join(project.path, ".mux"), { recursive: true });
+      await fs.writeFile(path.join(project.path, ".mux", "skills"), "not a directory", "utf-8");
+      await writeGlobalSkill(muxHome.path, "global-skill", {
+        description: "from global",
+      });
+
+      const tool = createAgentSkillListTool(
+        createTestToolConfig(project.path, {
+          muxScope: {
+            type: "project",
+            muxHome: muxHome.path,
+            projectRoot: project.path,
+            projectStorageAuthority: "host-local",
+          },
+        })
+      );
+      const result = (await tool.execute!({}, mockToolCallOptions)) as AgentSkillListToolResult;
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.skills.map((s) => s.name)).toEqual(["global-skill"]);
+      }
     });
-
-    const tool = createAgentSkillListTool(
-      createTestToolConfig(project.path, {
-        muxScope: {
-          type: "project",
-          muxHome: muxHome.path,
-          projectRoot: project.path,
-          projectStorageAuthority: "host-local",
-        },
-      })
-    );
-    const result = (await tool.execute!({}, mockToolCallOptions)) as AgentSkillListToolResult;
-
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.skills.map((s) => s.name)).toEqual(["global-skill"]);
-    }
   });
 
   it("returns no skills when both project and global roots are not directories", async () => {
     using project = new TestTempDir("test-agent-skill-list-both-roots-not-directories-project");
     using muxHome = new TestTempDir("test-agent-skill-list-both-roots-not-directories-home");
 
-    await fs.mkdir(path.join(project.path, ".mux"), { recursive: true });
-    await fs.writeFile(path.join(project.path, ".mux", "skills"), "not a directory", "utf-8");
-    await fs.writeFile(path.join(muxHome.path, "skills"), "not a directory", "utf-8");
+    await withHomeDir(muxHome.path, async () => {
+      await fs.mkdir(path.join(project.path, ".mux"), { recursive: true });
+      await fs.writeFile(path.join(project.path, ".mux", "skills"), "not a directory", "utf-8");
+      await fs.writeFile(path.join(muxHome.path, "skills"), "not a directory", "utf-8");
 
-    const tool = createAgentSkillListTool(
-      createTestToolConfig(project.path, {
-        muxScope: {
-          type: "project",
-          muxHome: muxHome.path,
-          projectRoot: project.path,
-          projectStorageAuthority: "host-local",
-        },
-      })
-    );
-    const result = (await tool.execute!({}, mockToolCallOptions)) as AgentSkillListToolResult;
+      const tool = createAgentSkillListTool(
+        createTestToolConfig(project.path, {
+          muxScope: {
+            type: "project",
+            muxHome: muxHome.path,
+            projectRoot: project.path,
+            projectStorageAuthority: "host-local",
+          },
+        })
+      );
+      const result = (await tool.execute!({}, mockToolCallOptions)) as AgentSkillListToolResult;
 
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.skills).toEqual([]);
-    }
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.skills).toEqual([]);
+      }
+    });
   });
 
   it("skips project skills when .mux is a symlink to external directory", async () => {
     using tempDir = new TestTempDir("test-agent-skill-list-project-mux-symlink");
 
-    const workspaceSessionDir = await createWorkspaceSessionDir(tempDir.path, GLOBAL_WORKSPACE_ID);
+    await withHomeDir(tempDir.path, async () => {
+      const workspaceSessionDir = await createWorkspaceSessionDir(
+        tempDir.path,
+        GLOBAL_WORKSPACE_ID
+      );
 
-    const projectRoot = path.join(tempDir.path, "project");
-    await fs.mkdir(projectRoot, { recursive: true });
+      const projectRoot = path.join(tempDir.path, "project");
+      await fs.mkdir(projectRoot, { recursive: true });
 
-    // Create external directory with skill content
-    const externalDir = path.join(tempDir.path, "external");
-    await fs.mkdir(path.join(externalDir, "skills", "external-skill"), { recursive: true });
-    await fs.writeFile(
-      path.join(externalDir, "skills", "external-skill", "SKILL.md"),
-      "---\nname: external-skill\ndescription: should not appear\n---\nBody\n",
-      "utf-8"
-    );
+      // Create external directory with skill content
+      const externalDir = path.join(tempDir.path, "external");
+      await fs.mkdir(path.join(externalDir, "skills", "external-skill"), { recursive: true });
+      await fs.writeFile(
+        path.join(externalDir, "skills", "external-skill", "SKILL.md"),
+        "---\nname: external-skill\ndescription: should not appear\n---\nBody\n",
+        "utf-8"
+      );
 
-    // Symlink .mux to external
-    await fs.symlink(externalDir, path.join(projectRoot, ".mux"));
+      // Symlink .mux to external
+      await fs.symlink(externalDir, path.join(projectRoot, ".mux"));
 
-    // Also create a real global skill
-    await writeGlobalSkill(tempDir.path, "global-skill");
+      // Also create a real global skill
+      await writeGlobalSkill(tempDir.path, "global-skill");
 
-    const projectScope: MuxToolScope = {
-      type: "project",
-      muxHome: tempDir.path,
-      projectRoot,
-      projectStorageAuthority: "host-local",
-    };
+      const projectScope: MuxToolScope = {
+        type: "project",
+        muxHome: tempDir.path,
+        projectRoot,
+        projectStorageAuthority: "host-local",
+      };
 
-    const config = createTestToolConfig(tempDir.path, {
-      workspaceId: GLOBAL_WORKSPACE_ID,
-      sessionsDir: workspaceSessionDir,
-      muxScope: projectScope,
+      const config = createTestToolConfig(tempDir.path, {
+        workspaceId: GLOBAL_WORKSPACE_ID,
+        sessionsDir: workspaceSessionDir,
+        muxScope: projectScope,
+      });
+
+      const tool = createAgentSkillListTool(config);
+      const result = (await tool.execute!({}, mockToolCallOptions)) as AgentSkillListToolResult;
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        // External skill should NOT appear; only real global skill should be listed
+        expect(result.skills.map((s) => s.name)).toEqual(["global-skill"]);
+        expect(result.skills.every((s) => s.scope === "global")).toBe(true);
+      }
     });
-
-    const tool = createAgentSkillListTool(config);
-    const result = (await tool.execute!({}, mockToolCallOptions)) as AgentSkillListToolResult;
-
-    expect(result.success).toBe(true);
-    if (result.success) {
-      // External skill should NOT appear; only real global skill should be listed
-      expect(result.skills.map((s) => s.name)).toEqual(["global-skill"]);
-      expect(result.skills.every((s) => s.scope === "global")).toBe(true);
-    }
   });
 });

--- a/src/node/services/tools/agent_skill_list.ts
+++ b/src/node/services/tools/agent_skill_list.ts
@@ -188,6 +188,8 @@ export const createAgentSkillListTool: ToolFactory = (config: ToolConfiguration)
           throw new Error("agent_skill_list requires muxScope");
         }
 
+        const userHome = path.dirname(muxScope.muxHome);
+
         // Always list global skills; also list project skills when in a project workspace.
         const roots: Array<{
           skillsRoot: string;
@@ -199,14 +201,26 @@ export const createAgentSkillListTool: ToolFactory = (config: ToolConfiguration)
             containmentRoot: muxScope.muxHome,
             scope: "global",
           },
+          {
+            skillsRoot: path.join(userHome, ".agents", "skills"),
+            containmentRoot: userHome,
+            scope: "global",
+          },
         ];
         if (muxScope.type === "project") {
-          // Project skills listed first so they appear before global ones
-          roots.unshift({
-            skillsRoot: path.join(muxScope.projectRoot, ".mux", "skills"),
-            containmentRoot: muxScope.projectRoot,
-            scope: "project",
-          });
+          roots.unshift(
+            {
+              // Project skills listed first so they appear before global ones.
+              skillsRoot: path.join(muxScope.projectRoot, ".mux", "skills"),
+              containmentRoot: muxScope.projectRoot,
+              scope: "project",
+            },
+            {
+              skillsRoot: path.join(muxScope.projectRoot, ".agents", "skills"),
+              containmentRoot: muxScope.projectRoot,
+              scope: "project",
+            }
+          );
         }
 
         const skills: AgentSkillDescriptor[] = [];

--- a/src/node/services/tools/agent_skill_list.ts
+++ b/src/node/services/tools/agent_skill_list.ts
@@ -11,7 +11,6 @@ import type { ToolConfiguration, ToolFactory } from "@/common/utils/tools/tools"
 import {
   discoverAgentSkills,
   getDefaultAgentSkillsRoots,
-  type AgentSkillsRoots,
 } from "@/node/services/agentSkills/agentSkillsService";
 import { parseSkillMarkdown } from "@/node/services/agentSkills/parseSkillMarkdown";
 import { resolveSkillStorageContext } from "@/node/services/agentSkills/skillStorageContext";
@@ -164,16 +163,12 @@ export const createAgentSkillListTool: ToolFactory = (config: ToolConfiguration)
         });
 
         if (skillCtx.kind === "project-runtime") {
-          // Only enumerate roots that paired mutation tools (write/delete) can target.
-          // Excludes .agents/skills and ~/.agents/skills which are read-only legacy roots.
-          const writableRoots: AgentSkillsRoots = {
-            projectRoot: skillCtx.runtime.normalizePath(".mux/skills", skillCtx.workspacePath),
-            globalRoot: getDefaultAgentSkillsRoots(skillCtx.runtime, skillCtx.workspacePath)
-              .globalRoot,
-          };
+          // Runtime discovery mirrors the shared default roots contract so project-runtime
+          // listings include .mux/skills and .agents/skills plus ~/.mux/skills and ~/.agents/skills.
+          const roots = getDefaultAgentSkillsRoots(skillCtx.runtime, skillCtx.workspacePath);
 
           const discovered = await discoverAgentSkills(skillCtx.runtime, skillCtx.workspacePath, {
-            roots: writableRoots,
+            roots,
             containment: skillCtx.containment,
             dedupeByName: false,
           });

--- a/src/node/services/tools/agent_skill_list.ts
+++ b/src/node/services/tools/agent_skill_list.ts
@@ -1,4 +1,5 @@
 import * as fsPromises from "fs/promises";
+import os from "node:os";
 import * as path from "path";
 import { tool } from "ai";
 
@@ -188,7 +189,7 @@ export const createAgentSkillListTool: ToolFactory = (config: ToolConfiguration)
           throw new Error("agent_skill_list requires muxScope");
         }
 
-        const userHome = path.dirname(muxScope.muxHome);
+        const userHome = os.homedir();
 
         // Always list global skills; also list project skills when in a project workspace.
         const roots: Array<{


### PR DESCRIPTION
## Summary

Broadens `project-runtime` skill discovery so `agent_skill_list` discovers skills from all four standard roots — `.mux/skills`, `.agents/skills`, `~/.mux/skills`, and `~/.agents/skills` — instead of only the two `.mux/skills` roots. Hidden (`advertise: false`) skills from the newly-included legacy roots follow the same filter: omitted by default, included with `includeUnadvertised: true`.

## Background

The `project-runtime` branch in `agent_skill_list.ts` constructed a custom root object containing only `.mux/skills` and `~/.mux/skills`, deliberately excluding the legacy/universal `.agents/skills` and `~/.agents/skills` roots. This meant skills placed under those legacy roots were invisible to `agent_skill_list` in runtime mode, even with `includeUnadvertised: true`. The shared root model (`getDefaultAgentSkillsRoots()`) already included all four roots, so the runtime branch was an undocumented narrower fork.

## Implementation

**Production code** (`agent_skill_list.ts`): Replaced the hand-built runtime root object with `getDefaultAgentSkillsRoots(skillCtx.runtime, skillCtx.workspacePath)` (~net -6 LoC). This aligns runtime discovery with the shared root contract while keeping `dedupeByName: false` and containment unchanged.

**Tests** (`agent_skill_list.test.ts`):
- Flipped the two existing exclusion tests (lines ~664-717 and ~779-815) to inclusion tests, asserting that `.agents/skills` and `~/.agents/skills` skills are now present with correct scope tags.
- Added 4 new test cases for hidden-skill coverage in both legacy roots (absent by default, present with `includeUnadvertised: true`).

**Tool description** (`toolDefinitions.ts`): Updated to document all four discovery roots.

## Validation

- All 22 `agent_skill_list` tests pass (82 expect() calls)
- `make typecheck` ✅
- `make lint` ✅
- `make test` — 87 pre-existing failures in unrelated files (HeartbeatSection, GeneralSection, RetryBarrier, BrowserToolbar, etc.), none in changed files
- Integration dogfood script exercising actual production discovery with real filesystem operations confirmed correct behavior

## Risks

Low risk. The change unifies an already-divergent code path with the shared root model. All existing containment, deduplication, and scope-tagging behavior is preserved. The only behavioral change is that skills under `.agents/skills` and `~/.agents/skills` are now visible in runtime mode.


---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Make `agent_skill_list({ includeUnadvertised: true })` discover legacy project and global universal skills

## Objective

Broaden `project-runtime` discovery so hidden legacy skills from both:

- project universal root `.agents/skills`
- global universal root `~/.agents/skills`

are discovered and then filtered consistently alongside `.mux/skills` and `~/.mux/skills`, while keeping the tool description and tests aligned with that broader contract.

## Verified current state

- `src/node/services/tools/agent_skill_list.ts:166-183` has a special `project-runtime` branch that constructs a custom root set containing only:
  - `projectRoot = .mux/skills`
  - `globalRoot = ~/.mux/skills`
- That branch **does not include** `projectUniversalRoot = .agents/skills` or `universalRoot = ~/.agents/skills`, even though `src/node/services/agentSkills/agentSkillsService.ts:39-52` defines both as standard discovery roots.
- `src/node/services/tools/agent_skill_list.test.ts:664-717` currently codifies exclusion of `~/.agents/skills` in `project-runtime` by expecting the legacy tilde global skill to be missing.
- `src/node/services/tools/agent_skill_list.test.ts:779-815` currently codifies exclusion of `.agents/skills` in `project-runtime` by expecting the legacy project-universal skill to be missing.
- The advertise filter itself is already correct for discovered skills:
  - `src/node/services/tools/agent_skill_list.ts:182`
  - it only decides whether discovered `advertise: false` skills are filtered out.
- The repo already contains an unadvertised project skill at `.mux/skills/deep-review/SKILL.md`, and local invocation returns it when `includeUnadvertised: true`, which confirms the issue is about **discovery scope**, not the `advertise` filter.

<details>
<summary>Why the current behavior is surprising</summary>

The tool description in `src/common/utils/tools/toolDefinitions.ts:1189-1198` says:

- project workspaces list project skills from `.mux/skills/` and global skills from `~/.mux/skills/`
- `includeUnadvertised: true` includes skills with `advertise: false`

A caller can reasonably infer that hidden project and global legacy skills should appear whenever they are part of the runtime-visible skill surface. In practice, `project-runtime` has an additional, undocumented root restriction, so `.agents/skills` and `~/.agents/skills` entries never reach the filter stage.

</details>

## Recommended approach

### Approach B — Broader compatibility fix (**recommended per requested scope**)
**Net product-code estimate:** **~-2 to +4 LoC**  
**Expected test-only delta:** ~35-65 LoC

Replace the hand-built runtime root object with `getDefaultAgentSkillsRoots(skillCtx.runtime, skillCtx.workspacePath)` so `project-runtime` discovers the full standard set of roots:

- `.mux/skills`
- `.agents/skills`
- `~/.mux/skills`
- `~/.agents/skills`

#### Why this is now the right tradeoff
- Matches the requested scope expansion instead of stopping at project-only legacy skills.
- Reuses the existing shared source of truth for skill roots rather than maintaining a partial runtime-only fork.
- Makes `includeUnadvertised` behavior easier to explain: it affects all discovered roots, including both universal roots.

#### Concrete code change
In `src/node/services/tools/agent_skill_list.ts:169-177`, remove the custom runtime-only root object and instead call:

```ts
const roots = getDefaultAgentSkillsRoots(skillCtx.runtime, skillCtx.workspacePath);
```

Then pass `roots` into `discoverAgentSkills(...)`.

#### Required comment update
Update the nearby comment so it no longer claims runtime mode excludes `.agents/skills` / `~/.agents/skills`. The comment should say runtime mode now aligns with the shared discovery root model while paired mutation tools may still target a narrower subset of those roots.

## Alternative approaches

### Approach A — Smaller project-only fix
**Net product-code estimate:** **~4-8 LoC**  
**Expected test-only delta:** ~25-45 LoC

Keep the runtime-specific root object, but add only `projectUniversalRoot = .agents/skills` and continue excluding `~/.agents/skills`.

#### Pros
- Smaller behavior change.
- Lower risk of surfacing unexpected legacy global skills in remote/runtime sessions.

#### Cons
- No longer matches the requested broader scope.
- Leaves runtime discovery split across two subtly different root definitions.

### Approach C — Doc-only clarification
**Net product-code estimate:** **~1-4 LoC**  
**Expected test-only delta:** 0-10 LoC

Leave behavior unchanged and only update `src/common/utils/tools/toolDefinitions.ts` to clarify that:
- `includeUnadvertised` affects only **discovered** skills, and
- `project-runtime` may exclude legacy read-only roots.

#### Pros
- Lowest implementation risk.

#### Cons
- Does not solve the reported issue.
- Leaves an existing behavior mismatch in place for anyone expecting hidden legacy skills to appear.

## Implementation plan

### Phase 1 — Unify `project-runtime` with the shared root model
**Files:**
- `src/node/services/tools/agent_skill_list.ts`

**Steps:**
1. Replace the hand-built runtime root object with `getDefaultAgentSkillsRoots(skillCtx.runtime, skillCtx.workspacePath)`.
2. Keep `dedupeByName: false` unchanged so same-name skills from different scopes/roots continue surfacing as separate descriptors.
3. Keep the existing runtime-aware path normalization and global-runtime handling intact by relying on `discoverAgentSkills(...)` plus the shared root helper.
4. Update the inline comment to describe the new contract precisely: runtime listing now includes both universal roots even if mutation tools remain narrower.

**Phase gate:**
- Run the targeted unit file immediately after this edit and confirm the old exclusion tests fail before rewriting expectations.

### Phase 2 — Recast tests around the broader runtime contract
**Files:**
- `src/node/services/tools/agent_skill_list.test.ts`

**Steps:**
1. Update the test at `:664-717` so `~/.agents/skills` is intentionally included in `project-runtime` rather than excluded.
2. Update the test at `:779-815` so `.agents/skills` is intentionally included in `project-runtime` rather than excluded.
3. Add a `project-runtime` hidden-skill case for `.agents/skills`:
   - create `.agents/skills/<name>/SKILL.md` with `advertise: false`
   - call `agent_skill_list({})` and assert the skill is **absent**
   - call `agent_skill_list({ includeUnadvertised: true })` and assert the skill is **present** with `advertise: false`
4. Add a parallel `project-runtime` hidden-skill case for `~/.agents/skills` with the same default-hidden / include-when-requested assertions.
5. Preserve or extend existing coverage for duplicate names, host-global skills, and containment behavior so the broader root set does not regress those paths.

**Phase gate:**
- Re-run the targeted test file until the new runtime contract is fully green.

### Phase 3 — Update the tool description to match the broader discovery surface
**Files:**
- `src/common/utils/tools/toolDefinitions.ts`

**Steps:**
1. Update the `agent_skill_list` description so project workspaces mention both modern and legacy roots:
   - project: `.mux/skills/`, `.agents/skills/`
   - global: `~/.mux/skills/`, `~/.agents/skills/`
2. Keep the `includeUnadvertised` wording explicit that it applies to discovered skills with `advertise: false`.
3. Avoid duplicating too much implementation detail; a brief legacy-root note is enough.

**Phase gate:**
- Re-run lint/typecheck/static checks after the description update.

## Acceptance criteria

### For the recommended Approach B
- In `project-runtime`, a visible skill located at `.agents/skills/<name>/SKILL.md` is listed with `scope: "project"`.
- In `project-runtime`, a visible skill located at `~/.agents/skills/<name>/SKILL.md` is listed with `scope: "global"`.
- Hidden skills under both `.agents/skills` and `~/.agents/skills` are omitted by default.
- The same hidden skills under both universal roots appear when `includeUnadvertised: true` is passed.
- Existing `.mux/skills` and `~/.mux/skills` behavior remains unchanged.
- Duplicate-name project/global behavior remains unchanged.
- Existing containment protections continue blocking escaped/symlinked project roots.

### If Approach A is chosen instead
- Same as above, except only `.agents/skills` is newly included and `~/.agents/skills` remains intentionally excluded.

### If Approach C is chosen instead
- The tool description makes the discovery-vs-filter distinction explicit and no longer implies that `includeUnadvertised` broadens which roots are scanned.

## Validation plan

### Fast feedback loop
- Run the focused unit file first:
  - `bun test src/node/services/tools/agent_skill_list.test.ts`

### Required local validation before calling the work complete
- `make static-check`
- `make test`

### If runtime-root behavior or shared discovery code is refactored more broadly than planned
- Re-run:
  - `make typecheck`
  - `make lint`
- If `toolDefinitions.ts` changes, keep `make static-check` in the required set.

## Dogfooding and reviewer-verifiable evidence

### Setup
1. Launch an isolated desktop environment using the existing sandbox workflow (prefer the `dev-desktop-sandbox` skill or an equivalent isolated `make dev` setup).
2. Prepare a project workspace whose storage authority resolves to `project-runtime`.
3. Seed the workspace with:
   - one visible project skill under `.mux/skills`
   - one hidden project skill under `.agents/skills` (`advertise: false`)
   - one hidden global legacy skill under `~/.agents/skills` (`advertise: false`)
   - optionally one visible global legacy skill under `~/.agents/skills` to prove the broader root is actually scanned

### Manual dogfood flow
1. Invoke `agent_skill_list({})` and confirm both hidden legacy skills are absent.
2. Invoke `agent_skill_list({ includeUnadvertised: true })` and confirm the hidden `.agents/skills` project skill is present.
3. In the same invocation, confirm the hidden `~/.agents/skills` global skill is also present.
4. Confirm same-name project/global skills still appear as separate entries if that scenario is seeded.

### Evidence to capture
- **Screenshot 1:** tool result without `includeUnadvertised`, showing both hidden universal-root skills absent.
- **Screenshot 2:** tool result with `includeUnadvertised: true`, showing the hidden `.agents/skills` project skill present.
- **Screenshot 3:** tool result with `includeUnadvertised: true`, highlighting the hidden `~/.agents/skills` global skill present.
- **Video recording:** short end-to-end capture of the desktop/app interaction from workspace setup to the two tool invocations and result inspection.
- Attach the screenshots (and video, if supported) in the final handoff so a reviewer can verify the behavioral contract without rerunning the environment.

## Risks and watchpoints

- The current code comments and two existing tests encode the old exclusion behavior; update them together or the repo will contain contradictory intent.
- Broadening runtime discovery to `~/.agents/skills` is intentional in this plan; verify that remote/runtime sessions still present a sensible skill list and do not regress existing host-global behavior.
- Preserve runtime path normalization for both universal roots; using host-local path joins in the runtime branch would break SSH/remote behavior.
- Preserve containment coverage so project-controlled paths cannot escape the workspace boundary.

## Recommended execution order

1. Implement Approach B in `agent_skill_list.ts` by switching the runtime branch to `getDefaultAgentSkillsRoots(...)`.
2. Update the runtime-specific exclusion tests and add hidden-skill coverage for both universal roots.
3. Run the targeted unit file.
4. Update `toolDefinitions.ts` so the public description matches the broader behavior.
5. Run `make static-check` and `make test`.
6. Dogfood in an isolated desktop sandbox and capture screenshots + video.
7. Hand off with the captured evidence and note that `project-runtime` now treats both `.agents/skills` and `~/.agents/skills` as part of its discovery surface.

</details>

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$6.20`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=6.20 -->
