### PR TITLE
🤖 fix: preserve init logs across reconnect replay

### DIFF
--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -1812,7 +1812,7 @@ describe("WorkspaceStore", () => {
       expect(stayedVisibleAfterCaughtUp).toBe(true);
     });
 
-    it("shows replayed init output before caught-up when switching back to a workspace", async () => {
+    it("keeps existing init logs visible while reconnect replay catches up", async () => {
       const workspaceId = "workspace-init-replay";
       const otherWorkspaceId = "workspace-init-other";
       const firstLine = "Preparing workspace...";
@@ -1866,7 +1866,15 @@ describe("WorkspaceStore", () => {
         yield {
           type: "init-start",
           hookPath: "/tmp/project/.mux/init",
-          timestamp: 2_000,
+          timestamp: 1_000,
+          replay: true,
+        };
+        yield {
+          type: "init-output",
+          line: firstLine,
+          isError: false,
+          timestamp: 1_001,
+          replay: true,
         };
         await new Promise<void>((resolve) => {
           releaseSecondInitOutput = resolve;
@@ -1876,6 +1884,7 @@ describe("WorkspaceStore", () => {
           line: replayedLine,
           isError: false,
           timestamp: 2_001,
+          replay: true,
         };
         await new Promise<void>((resolve) => {
           releaseSecondCaughtUp = resolve;
@@ -1899,21 +1908,7 @@ describe("WorkspaceStore", () => {
       createAndAddWorkspace(store, otherWorkspaceId);
       store.setActiveWorkspaceId(workspaceId);
 
-      const sawEmptyReconnectInit = await waitUntil(() => {
-        const { state, initMessage } = getInitMessage();
-        return (
-          subscriptionCount >= 2 &&
-          state.loading === false &&
-          state.isHydratingTranscript === false &&
-          initMessage?.status === "running" &&
-          initMessage.lines.length === 0
-        );
-      });
-      expect(sawEmptyReconnectInit).toBe(true);
-
-      releaseSecondInitOutput?.();
-
-      const replayedInitBeforeCaughtUp = await waitUntil(() => {
+      const preservedReconnectInit = await waitUntil(() => {
         const { state, initMessage } = getInitMessage();
         return (
           subscriptionCount >= 2 &&
@@ -1921,10 +1916,27 @@ describe("WorkspaceStore", () => {
           state.isHydratingTranscript === false &&
           initMessage?.status === "running" &&
           initMessage.lines.length === 1 &&
-          initMessage.lines[0]?.line === replayedLine
+          initMessage.lines[0]?.line === firstLine
         );
       });
-      expect(replayedInitBeforeCaughtUp).toBe(true);
+      expect(preservedReconnectInit).toBe(true);
+
+      releaseSecondInitOutput?.();
+
+      const replayedTailVisibleBeforeCaughtUp = await waitUntil(() => {
+        const { state, initMessage } = getInitMessage();
+        return (
+          subscriptionCount >= 2 &&
+          releaseSecondCaughtUp !== undefined &&
+          state.loading === false &&
+          state.isHydratingTranscript === false &&
+          initMessage?.status === "running" &&
+          initMessage.lines.length === 2 &&
+          initMessage.lines[0]?.line === firstLine &&
+          initMessage.lines[1]?.line === replayedLine
+        );
+      });
+      expect(replayedTailVisibleBeforeCaughtUp).toBe(true);
 
       releaseSecondCaughtUp?.();
 
@@ -1933,7 +1945,9 @@ describe("WorkspaceStore", () => {
         return (
           !state.loading &&
           initMessage?.status === "running" &&
-          initMessage.lines[0]?.line === replayedLine
+          initMessage.lines.length === 2 &&
+          initMessage.lines[0]?.line === firstLine &&
+          initMessage.lines[1]?.line === replayedLine
         );
       });
       expect(stayedVisibleAfterCaughtUp).toBe(true);

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -3628,17 +3628,19 @@ export class WorkspaceStore {
     }
 
     if (!transient.caughtUp && this.isBufferedEvent(data)) {
-      if (
+      const shouldApplyImmediately =
         isStreamLifecycle(data) ||
         isStreamAbort(data) ||
         isRuntimeStatus(data) ||
         isInitStart(data) ||
         isInitOutput(data) ||
-        isInitEnd(data)
-      ) {
+        isInitEnd(data);
+
+      if (shouldApplyImmediately) {
         // SSH/Coder init replay can be the only transcript content for a new workspace.
-        // Apply it immediately so switching back mid-init shows the latest backend output
-        // instead of only a generic loading placeholder until caught-up lands.
+        // Apply it immediately so reconnects show the latest init snapshot before caught-up;
+        // the aggregator treats replayed init-start/output as idempotent, so the buffered
+        // catch-up pass can reuse the same events without blanking or duplicating the row.
         applyWorkspaceChatEventToAggregator(aggregator, data, { allowSideEffects: false });
         if (isInitOutput(data)) {
           aggregator.flushPendingInitOutput();

--- a/src/browser/utils/messages/StreamingMessageAggregator.init.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.init.test.ts
@@ -60,6 +60,95 @@ describe("Init display after cleanup changes", () => {
     expect((messages[0] as InitDisplayedMessage).exitCode).toBe(0);
   });
 
+  it("should treat replayed init-start/output for the same running init as idempotent", () => {
+    const aggregator = new StreamingMessageAggregator("2024-01-01T00:00:00.000Z");
+
+    aggregator.handleMessage({
+      type: "init-start",
+      hookPath: "/test/.mux/init",
+      timestamp: 1_000,
+    });
+    aggregator.handleMessage({
+      type: "init-output",
+      line: "Installing dependencies...",
+      timestamp: 1_001,
+      isError: false,
+    });
+    aggregator.flushPendingInitOutput();
+
+    aggregator.handleMessage({
+      type: "init-start",
+      hookPath: "/test/.mux/init",
+      timestamp: 1_000,
+      replay: true,
+    });
+    aggregator.handleMessage({
+      type: "init-output",
+      line: "Installing dependencies...",
+      timestamp: 1_001,
+      isError: false,
+      replay: true,
+    });
+    aggregator.handleMessage({
+      type: "init-output",
+      line: "Syncing repository over SSH...",
+      timestamp: 1_002,
+      isError: false,
+      replay: true,
+    });
+    aggregator.flushPendingInitOutput();
+
+    const messages = aggregator.getDisplayedMessages();
+    const initMsg = messages[0] as InitDisplayedMessage;
+
+    expect(initMsg.lines).toEqual([
+      { line: "Installing dependencies...", isError: false },
+      { line: "Syncing repository over SSH...", isError: false },
+    ]);
+  });
+
+  it("should preserve duplicate replayed init lines that share a timestamp", () => {
+    const aggregator = new StreamingMessageAggregator("2024-01-01T00:00:00.000Z");
+
+    aggregator.handleMessage({
+      type: "init-start",
+      hookPath: "/test/.mux/init",
+      timestamp: 1_000,
+    });
+
+    const duplicateReplayLineA = {
+      type: "init-output" as const,
+      line: "duplicate line",
+      timestamp: 1_001,
+      isError: false,
+      replay: true,
+    };
+    const duplicateReplayLineB = {
+      type: "init-output" as const,
+      line: "duplicate line",
+      timestamp: 1_001,
+      isError: false,
+      replay: true,
+    };
+
+    aggregator.handleMessage(duplicateReplayLineA);
+    aggregator.handleMessage(duplicateReplayLineB);
+    aggregator.flushPendingInitOutput();
+
+    // Simulate the buffered catch-up pass reusing the exact same replay event objects.
+    aggregator.handleMessage(duplicateReplayLineA);
+    aggregator.handleMessage(duplicateReplayLineB);
+    aggregator.flushPendingInitOutput();
+
+    const messages = aggregator.getDisplayedMessages();
+    const initMsg = messages[0] as InitDisplayedMessage;
+
+    expect(initMsg.lines).toEqual([
+      { line: "duplicate line", isError: false },
+      { line: "duplicate line", isError: false },
+    ]);
+  });
+
   it("should handle init-output without init-start (defensive)", () => {
     const aggregator = new StreamingMessageAggregator("2024-01-01T00:00:00.000Z");
 

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -423,6 +423,17 @@ export class StreamingMessageAggregator {
     truncatedLines?: number; // Lines dropped from middle when output exceeded limit
   } | null = null;
 
+  // When reconnect replay re-emits init-start for the same running init, keep the existing row and
+  // treat replayed init-output as a continuation. Snapshot the already-visible prefix so replay can
+  // skip only those previously rendered lines without collapsing legitimate duplicates later on.
+  private replayInitVisiblePrefix: Array<{ line: string; isError: boolean }> | null = null;
+  private replayInitVisiblePrefixIndex = 0;
+
+  // Replay reconnects apply the same init events twice: once immediately before caught-up and
+  // once again from the buffered catch-up pass. Track replay event identity so the second pass can
+  // skip the exact same event object without collapsing legitimate duplicate log lines.
+  private appliedReplayInitEvents = new WeakSet<object>();
+
   // Throttle init-output cache invalidation to avoid re-render per line during fast streaming
   private initOutputThrottleTimer: ReturnType<typeof setTimeout> | null = null;
   private static readonly INIT_OUTPUT_THROTTLE_MS = 100;
@@ -2399,9 +2410,69 @@ export class StreamingMessageAggregator {
     this.invalidateCache();
   }
 
+  private clearReplayInitVisiblePrefix(): void {
+    this.replayInitVisiblePrefix = null;
+    this.replayInitVisiblePrefixIndex = 0;
+  }
+
+  private shouldSkipVisibleReplayInitOutput(line: string, isError: boolean): boolean {
+    const prefix = this.replayInitVisiblePrefix;
+    if (!prefix) {
+      return false;
+    }
+
+    const nextVisibleLine = prefix[this.replayInitVisiblePrefixIndex];
+    if (nextVisibleLine?.line !== line || nextVisibleLine?.isError !== isError) {
+      this.clearReplayInitVisiblePrefix();
+      return false;
+    }
+
+    this.replayInitVisiblePrefixIndex += 1;
+    if (this.replayInitVisiblePrefixIndex >= prefix.length) {
+      this.clearReplayInitVisiblePrefix();
+    }
+
+    return true;
+  }
+
+  private shouldSkipReplayInitEvent(data: WorkspaceChatMessage): boolean {
+    if (
+      (data as { replay?: boolean }).replay !== true ||
+      (!isInitStart(data) && !isInitOutput(data) && !isInitEnd(data))
+    ) {
+      return false;
+    }
+
+    if (this.appliedReplayInitEvents.has(data as object)) {
+      return true;
+    }
+
+    this.appliedReplayInitEvents.add(data as object);
+    return false;
+  }
+
   handleMessage(data: WorkspaceChatMessage): void {
     // Handle init hook events (ephemeral, not persisted to history)
+    if (this.shouldSkipReplayInitEvent(data)) {
+      return;
+    }
+
     if (isInitStart(data)) {
+      const isReplay = (data as { replay?: boolean }).replay === true;
+      if (
+        isReplay &&
+        this.initState?.status === "running" &&
+        this.initState.hookPath === data.hookPath &&
+        this.initState.startTime === data.timestamp
+      ) {
+        // Reconnect replay re-emits init-start before replayed lines. Treat the same running init
+        // as a no-op so switching back never clears the visible SSH/setup output mid-replay.
+        this.replayInitVisiblePrefix = [...this.initState.lines];
+        this.replayInitVisiblePrefixIndex = 0;
+        return;
+      }
+
+      this.clearReplayInitVisiblePrefix();
       this.initState = {
         status: "running",
         hookPath: data.hookPath,
@@ -2425,6 +2496,10 @@ export class StreamingMessageAggregator {
       }
       const line = data.line.trimEnd();
       const isError = data.isError === true;
+      const isReplay = (data as { replay?: boolean }).replay === true;
+      if (isReplay && this.shouldSkipVisibleReplayInitOutput(line, isError)) {
+        return;
+      }
 
       // Truncation: keep only the most recent MAX_LINES (matches backend)
       if (this.initState.lines.length >= INIT_HOOK_MAX_LINES) {
@@ -2442,6 +2517,7 @@ export class StreamingMessageAggregator {
     }
 
     if (isInitEnd(data)) {
+      this.clearReplayInitVisiblePrefix();
       if (!this.initState) {
         console.error("Received init-end without init-start", { data });
         return;

--- a/src/common/orpc/schemas/stream.ts
+++ b/src/common/orpc/schemas/stream.ts
@@ -482,6 +482,10 @@ export const InitStartEventSchema = z.object({
   type: z.literal("init-start"),
   hookPath: z.string(),
   timestamp: z.number(),
+  replay: z
+    .boolean()
+    .optional()
+    .meta({ description: "True when this event is emitted during init replay" }),
 });
 
 export const InitOutputEventSchema = z.object({
@@ -489,12 +493,26 @@ export const InitOutputEventSchema = z.object({
   line: z.string(),
   timestamp: z.number(),
   isError: z.boolean().optional(),
+  lineNumber: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .meta({ description: "Monotonic line index within the current init run" }),
+  replay: z
+    .boolean()
+    .optional()
+    .meta({ description: "True when this event is emitted during init replay" }),
 });
 
 export const InitEndEventSchema = z.object({
   type: z.literal("init-end"),
   exitCode: z.number(),
   timestamp: z.number(),
+  replay: z
+    .boolean()
+    .optional()
+    .meta({ description: "True when this event is emitted during init replay" }),
   /** Number of lines dropped from middle when output exceeded limit (omitted if 0) */
   truncatedLines: z.number().optional(),
 });

--- a/src/node/orpc/replayBufferedStreamMessageRelay.test.ts
+++ b/src/node/orpc/replayBufferedStreamMessageRelay.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from "bun:test";
+import type { WorkspaceChatMessage } from "@/common/orpc/types";
+import { createReplayBufferedStreamMessageRelay } from "./replayBufferedStreamMessageRelay";
+
+describe("createReplayBufferedStreamMessageRelay", () => {
+  test("buffers live init events until replay finishes", () => {
+    const pushed: WorkspaceChatMessage[] = [];
+    const relay = createReplayBufferedStreamMessageRelay((message) => {
+      pushed.push(message);
+    });
+
+    relay.handleSessionMessage({
+      type: "init-start",
+      hookPath: "/tmp/project/.mux/init",
+      timestamp: 1_000,
+      replay: true,
+    });
+    relay.handleSessionMessage({
+      type: "init-output",
+      line: "Replayed init output",
+      isError: false,
+      timestamp: 1_001,
+      replay: true,
+    });
+    relay.handleSessionMessage({
+      type: "init-output",
+      line: "Live init output",
+      isError: false,
+      timestamp: 1_002,
+    });
+
+    expect(pushed).toEqual([
+      {
+        type: "init-start",
+        hookPath: "/tmp/project/.mux/init",
+        timestamp: 1_000,
+        replay: true,
+      },
+      {
+        type: "init-output",
+        line: "Replayed init output",
+        isError: false,
+        timestamp: 1_001,
+        replay: true,
+      },
+    ]);
+
+    relay.finishReplay();
+
+    expect(pushed).toEqual([
+      {
+        type: "init-start",
+        hookPath: "/tmp/project/.mux/init",
+        timestamp: 1_000,
+        replay: true,
+      },
+      {
+        type: "init-output",
+        line: "Replayed init output",
+        isError: false,
+        timestamp: 1_001,
+        replay: true,
+      },
+      {
+        type: "init-output",
+        line: "Live init output",
+        isError: false,
+        timestamp: 1_002,
+      },
+    ]);
+  });
+
+  test("keeps buffered init lines with the same text/timestamp when lineNumber differs", () => {
+    const pushed: WorkspaceChatMessage[] = [];
+    const relay = createReplayBufferedStreamMessageRelay((message) => {
+      pushed.push(message);
+    });
+
+    relay.handleSessionMessage({
+      type: "init-start",
+      hookPath: "/tmp/project/.mux/init",
+      timestamp: 1_000,
+      replay: true,
+    });
+    relay.handleSessionMessage({
+      type: "init-output",
+      line: "duplicate line",
+      isError: false,
+      timestamp: 1_001,
+      lineNumber: 0,
+      replay: true,
+    });
+    relay.handleSessionMessage({
+      type: "init-output",
+      line: "duplicate line",
+      isError: false,
+      timestamp: 1_001,
+      lineNumber: 1,
+    });
+
+    relay.finishReplay();
+
+    expect(pushed).toEqual([
+      {
+        type: "init-start",
+        hookPath: "/tmp/project/.mux/init",
+        timestamp: 1_000,
+        replay: true,
+      },
+      {
+        type: "init-output",
+        line: "duplicate line",
+        isError: false,
+        timestamp: 1_001,
+        lineNumber: 0,
+        replay: true,
+      },
+      {
+        type: "init-output",
+        line: "duplicate line",
+        isError: false,
+        timestamp: 1_001,
+        lineNumber: 1,
+      },
+    ]);
+  });
+
+  test("drops buffered init events that replay already covered", () => {
+    const pushed: WorkspaceChatMessage[] = [];
+    const relay = createReplayBufferedStreamMessageRelay((message) => {
+      pushed.push(message);
+    });
+
+    relay.handleSessionMessage({
+      type: "init-start",
+      hookPath: "/tmp/project/.mux/init",
+      timestamp: 1_000,
+      replay: true,
+    });
+    relay.handleSessionMessage({
+      type: "init-output",
+      line: "Replayed init output",
+      isError: false,
+      timestamp: 1_001,
+      replay: true,
+    });
+    relay.handleSessionMessage({
+      type: "init-end",
+      exitCode: 0,
+      timestamp: 1_005,
+      replay: true,
+    });
+
+    relay.handleSessionMessage({
+      type: "init-start",
+      hookPath: "/tmp/project/.mux/init",
+      timestamp: 1_000,
+    });
+    relay.handleSessionMessage({
+      type: "init-output",
+      line: "Replayed init output",
+      isError: false,
+      timestamp: 1_001,
+    });
+    relay.handleSessionMessage({
+      type: "init-output",
+      line: "Live init tail",
+      isError: false,
+      timestamp: 1_002,
+    });
+    relay.handleSessionMessage({
+      type: "init-end",
+      exitCode: 0,
+      timestamp: 1_005,
+    });
+
+    relay.finishReplay();
+
+    expect(pushed).toEqual([
+      {
+        type: "init-start",
+        hookPath: "/tmp/project/.mux/init",
+        timestamp: 1_000,
+        replay: true,
+      },
+      {
+        type: "init-output",
+        line: "Replayed init output",
+        isError: false,
+        timestamp: 1_001,
+        replay: true,
+      },
+      {
+        type: "init-end",
+        exitCode: 0,
+        timestamp: 1_005,
+        replay: true,
+      },
+      {
+        type: "init-output",
+        line: "Live init tail",
+        isError: false,
+        timestamp: 1_002,
+      },
+    ]);
+  });
+});

--- a/src/node/orpc/replayBufferedStreamMessageRelay.ts
+++ b/src/node/orpc/replayBufferedStreamMessageRelay.ts
@@ -1,33 +1,57 @@
 import type { WorkspaceChatMessage } from "@/common/orpc/types";
 
-type ReplayBufferedStreamMessage = Extract<
+type ReplayBufferedSessionMessage = Extract<
   WorkspaceChatMessage,
   {
-    type: "stream-delta" | "reasoning-delta" | "stream-end" | "stream-abort" | "stream-error";
+    type:
+      | "stream-delta"
+      | "reasoning-delta"
+      | "stream-end"
+      | "stream-abort"
+      | "stream-error"
+      | "init-start"
+      | "init-output"
+      | "init-end";
   }
 >;
 
 type ReplayBufferedDeltaMessage = Extract<
-  ReplayBufferedStreamMessage,
+  ReplayBufferedSessionMessage,
   { type: "stream-delta" | "reasoning-delta" }
 >;
 
-function isReplayBufferedStreamMessage(
+function isReplayBufferedSessionMessage(
   message: WorkspaceChatMessage
-): message is ReplayBufferedStreamMessage {
+): message is ReplayBufferedSessionMessage {
   return (
     message.type === "stream-delta" ||
     message.type === "reasoning-delta" ||
     message.type === "stream-end" ||
     message.type === "stream-abort" ||
-    message.type === "stream-error"
+    message.type === "stream-error" ||
+    message.type === "init-start" ||
+    message.type === "init-output" ||
+    message.type === "init-end"
   );
 }
 
 function isReplayBufferedDeltaMessage(
-  message: ReplayBufferedStreamMessage
+  message: ReplayBufferedSessionMessage
 ): message is ReplayBufferedDeltaMessage {
   return message.type === "stream-delta" || message.type === "reasoning-delta";
+}
+
+type ReplayBufferedInitMessage = Extract<
+  ReplayBufferedSessionMessage,
+  { type: "init-start" | "init-output" | "init-end" }
+>;
+
+function isReplayBufferedInitMessage(
+  message: ReplayBufferedSessionMessage
+): message is ReplayBufferedInitMessage {
+  return (
+    message.type === "init-start" || message.type === "init-output" || message.type === "init-end"
+  );
 }
 
 function isReplayMessage(message: WorkspaceChatMessage): boolean {
@@ -38,6 +62,28 @@ function replayBufferedDeltaKey(message: ReplayBufferedDeltaMessage): string {
   return JSON.stringify([message.type, message.messageId, message.timestamp, message.delta]);
 }
 
+function replayBufferedInitKey(message: ReplayBufferedInitMessage): string {
+  switch (message.type) {
+    case "init-start":
+      return JSON.stringify([message.type, message.hookPath, message.timestamp]);
+    case "init-output":
+      return JSON.stringify([
+        message.type,
+        message.lineNumber ?? null,
+        message.line,
+        message.isError === true,
+        message.timestamp,
+      ]);
+    case "init-end":
+      return JSON.stringify([
+        message.type,
+        message.exitCode,
+        message.truncatedLines ?? null,
+        message.timestamp,
+      ]);
+  }
+}
+
 export function createReplayBufferedStreamMessageRelay(
   push: (message: WorkspaceChatMessage) => void
 ): {
@@ -45,14 +91,20 @@ export function createReplayBufferedStreamMessageRelay(
   finishReplay: () => void;
 } {
   let isReplaying = true;
-  const bufferedLiveStreamMessages: ReplayBufferedStreamMessage[] = [];
+  const bufferedLiveSessionMessages: ReplayBufferedSessionMessage[] = [];
 
-  // Counter (not a Set) so we don't drop more buffered events than were replayed.
+  // Counters (not Sets) so we don't drop more buffered events than were replayed.
   const replayedDeltaKeyCounts = new Map<string, number>();
+  const replayedInitKeyCounts = new Map<string, number>();
 
   const noteReplayedDelta = (message: ReplayBufferedDeltaMessage) => {
     const key = replayBufferedDeltaKey(message);
     replayedDeltaKeyCounts.set(key, (replayedDeltaKeyCounts.get(key) ?? 0) + 1);
+  };
+
+  const noteReplayedInit = (message: ReplayBufferedInitMessage) => {
+    const key = replayBufferedInitKey(message);
+    replayedInitKeyCounts.set(key, (replayedInitKeyCounts.get(key) ?? 0) + 1);
   };
 
   const shouldDropBufferedDelta = (message: ReplayBufferedDeltaMessage): boolean => {
@@ -69,19 +121,35 @@ export function createReplayBufferedStreamMessageRelay(
     return true;
   };
 
+  const shouldDropBufferedInit = (message: ReplayBufferedInitMessage): boolean => {
+    const key = replayBufferedInitKey(message);
+    const remaining = replayedInitKeyCounts.get(key) ?? 0;
+    if (remaining <= 0) {
+      return false;
+    }
+    if (remaining === 1) {
+      replayedInitKeyCounts.delete(key);
+    } else {
+      replayedInitKeyCounts.set(key, remaining - 1);
+    }
+    return true;
+  };
+
   const handleSessionMessage = (message: WorkspaceChatMessage) => {
-    if (isReplaying && isReplayBufferedStreamMessage(message)) {
+    if (isReplaying && isReplayBufferedSessionMessage(message)) {
       if (!isReplayMessage(message)) {
-        // Preserve stream event order during replay buffering (P1): if we buffer only deltas,
-        // terminal events like stream-end can overtake them and flip the message back to partial
-        // in the frontend event processor.
-        bufferedLiveStreamMessages.push(message);
+        // Preserve live ordering during replay buffering. Init events need the same isolation as
+        // stream events so reconnect replay cannot blank the row or drop lines due to reordering.
+        bufferedLiveSessionMessages.push(message);
         return;
       }
 
-      // Track replayed deltas so we can skip replay/live duplicates (P2).
+      // Track replayed deltas/init events so buffered live events from the same window do not
+      // double-apply after `caught-up`.
       if (isReplayBufferedDeltaMessage(message)) {
         noteReplayedDelta(message);
+      } else if (isReplayBufferedInitMessage(message)) {
+        noteReplayedInit(message);
       }
     }
 
@@ -89,9 +157,12 @@ export function createReplayBufferedStreamMessageRelay(
   };
 
   const finishReplay = () => {
-    // Flush buffered live stream messages after replay (`caught-up` already queued by replayHistory).
-    for (const message of bufferedLiveStreamMessages) {
+    // Flush buffered live session messages after replay (`caught-up` already queued by replayHistory).
+    for (const message of bufferedLiveSessionMessages) {
       if (isReplayBufferedDeltaMessage(message) && shouldDropBufferedDelta(message)) {
+        continue;
+      }
+      if (isReplayBufferedInitMessage(message) && shouldDropBufferedInit(message)) {
         continue;
       }
       push(message);
@@ -99,9 +170,10 @@ export function createReplayBufferedStreamMessageRelay(
 
     isReplaying = false;
 
-    // Avoid retaining replay delta keys (including delta text) for the lifetime of the subscription.
+    // Avoid retaining replay keys for the lifetime of the subscription.
     replayedDeltaKeyCounts.clear();
-    bufferedLiveStreamMessages.length = 0;
+    replayedInitKeyCounts.clear();
+    bufferedLiveSessionMessages.length = 0;
   };
 
   return { handleSessionMessage, finishReplay };

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -3666,7 +3666,7 @@ export const router = (authToken?: string) => {
           // 1. Subscribe to new events (including those triggered by replay)
           //
           // IMPORTANT: We subscribe before replay so we can receive stream replay (`replayStream()`)
-          // and init replay events (which do not set `replay: true`).
+          // and init replay events (which now set `replay: true` like other replayed payloads).
           //
           // Live stream deltas can overlap with replayed deltas on reconnect. Buffer live stream
           // events during replay and flush after `caught-up`, skipping any deltas already delivered

--- a/src/node/services/initStateManager.ts
+++ b/src/node/services/initStateManager.ts
@@ -111,6 +111,7 @@ export class InitStateManager extends EventEmitter {
       workspaceId,
       hookPath: state.hookPath,
       timestamp: state.startTime,
+      replay: true,
     });
 
     // Emit init-output for each accumulated line with original timestamps
@@ -128,7 +129,7 @@ export class InitStateManager extends EventEmitter {
       );
     }
 
-    for (const timedLine of lines) {
+    for (const [index, timedLine] of lines.entries()) {
       // Skip malformed entries (missing required fields)
       if (typeof timedLine.line !== "string" || typeof timedLine.timestamp !== "number") {
         log.warn(`[InitStateManager] Skipping malformed init-output:`, timedLine);
@@ -140,6 +141,8 @@ export class InitStateManager extends EventEmitter {
         line: timedLine.line,
         isError: timedLine.isError,
         timestamp: timedLine.timestamp, // Use original timestamp for replay
+        lineNumber: truncatedLines + index,
+        replay: true,
       });
     }
 
@@ -150,6 +153,7 @@ export class InitStateManager extends EventEmitter {
         workspaceId,
         exitCode: state.exitCode,
         timestamp: state.endTime ?? state.startTime,
+        replay: true,
         // Include truncation info so frontend can show indicator
         ...(truncatedLines ? { truncatedLines } : {}),
       });
@@ -249,6 +253,7 @@ export class InitStateManager extends EventEmitter {
     }
 
     const timestamp = Date.now();
+    const lineNumber = (state.truncatedLines ?? 0) + state.lines.length;
     const timedLine: TimedLine = { line, isError, timestamp };
 
     // Truncation: keep only the most recent MAX_LINES
@@ -265,6 +270,7 @@ export class InitStateManager extends EventEmitter {
       line,
       isError,
       timestamp,
+      lineNumber,
     } satisfies WorkspaceInitEvent & { workspaceId: string });
   }
 


### PR DESCRIPTION
## Summary

Keep the existing `workspace-init` transcript row visible while reconnect replay catches up, and make replayed init events idempotent so the reconnect path can reuse the same replay buffer without blanking or duplicating SSH/setup output.

## Background

The earlier follow-up fixed replay ordering for init events, but the reconnect path was still carrying store-level state just to avoid replayed `init-start` temporarily clearing the init row. Since the renderer already keeps init state in the aggregator across replay resets, the reconnect special case belongs closer to the init reducer itself.

## Implementation

- keep replayed init events tagged with `replay: true` and continue buffering live init events in the replay relay
- make `StreamingMessageAggregator` treat replayed `init-start` for the same running init as a no-op
- snapshot the already-visible init lines when reconnect replay resumes the same running init, so replay only skips the previously rendered prefix instead of collapsing legitimate duplicate lines that happen to share content/timestamps
- track replay init event identity to skip the exact same replay objects when the buffered catch-up pass replays them after `caught-up`
- give `init-output` a monotonic `lineNumber` so replay/live dedupe in the relay can distinguish real duplicate log lines that share the same text and millisecond timestamp
- remove the `WorkspaceStore` reconnect-only defer flag and simplify the pre-`caught-up` branch back to “apply immediately, then replay through the normal buffered path”
- add aggregator/relay regression coverage for both idempotent replay of the visible prefix and legitimate duplicate replayed lines

## Validation

- `bun test src/browser/utils/messages/StreamingMessageAggregator.init.test.ts`
- `bun test src/browser/stores/WorkspaceStore.test.ts --filter "keeps existing init logs visible while reconnect replay catches up"`
- `bun test src/node/orpc/replayBufferedStreamMessageRelay.test.ts`
- `bun test src/node/services/initStateManager.test.ts`
- `make static-check`

## Risks

Low-to-moderate. This keeps the same reconnect behavior but moves the replay-preservation logic into the init reducer and replay relay. Regressions would most likely affect reconnect-time init rendering rather than general message history or live streaming.

---

_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `xhigh` • Cost: `$52.00`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=xhigh costs=52.00 -->
