### PR TITLE
🤖 perf: prefetch origin on SSH host before local→remote push

### DIFF
--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -920,6 +920,50 @@ export class SSHRuntime extends RemoteRuntime {
     );
   }
 
+  /**
+   * Pre-fetch from origin on the remote host to reduce local→remote push size.
+   *
+   * When the remote bare repo has an origin configured, runs `git fetch origin`
+   * on the SSH host. The host's datacenter connection to the upstream is
+   * typically much faster than the local machine's (e.g., hotel wifi vs
+   * datacenter). After this, the subsequent local→remote `git push` only needs
+   * to transfer objects that don't exist on origin — usually just unpushed
+   * local commits.
+   *
+   * Best-effort: failures are swallowed because the push still works without
+   * the pre-populated cache (it just transfers more data).
+   */
+  private async prefetchOriginOnRemote(
+    projectPath: string,
+    baseRepoPathArg: string,
+    initLogger: InitLogger,
+    abortSignal?: AbortSignal
+  ): Promise<void> {
+    // Ensure the remote base repo knows where origin is before fetching.
+    await this.refreshBaseRepoOrigin(projectPath, baseRepoPathArg, initLogger, abortSignal);
+
+    try {
+      initLogger.logStep("Pre-fetching from origin on remote host...");
+      const result = await execBuffered(
+        this,
+        // Fetch all branches from origin into the base repo's object store.
+        // This runs entirely on the remote — only the SSH control channel
+        // traverses the local link, so it's fast even on slow connections.
+        `git -C ${baseRepoPathArg} fetch --prune origin`,
+        { cwd: "/tmp", timeout: 120, abortSignal }
+      );
+      if (result.exitCode === 0) {
+        initLogger.logStep("Pre-fetched from origin on remote host");
+      } else {
+        initLogger.logStep("Pre-fetch from origin skipped (fetch failed)");
+      }
+    } catch {
+      // Best-effort — if origin is unreachable or not configured, the local
+      // push will still transfer all required objects.
+      initLogger.logStep("Pre-fetch from origin skipped (not reachable)");
+    }
+  }
+
   override async ensureReady(options?: EnsureReadyOptions): Promise<EnsureReadyResult> {
     const repoCheck = await this.checkWorkspaceRepo(options);
     if (repoCheck) {
@@ -1599,6 +1643,15 @@ export class SSHRuntime extends RemoteRuntime {
     }
 
     if (useNativeGitPush) {
+      // Pre-populate the remote base repo with objects from origin before the
+      // local→remote push. The SSH host's datacenter connection is typically
+      // orders of magnitude faster than the local machine's (e.g., hotel wifi),
+      // so fetching origin on the remote first turns the subsequent push into a
+      // small incremental transfer instead of a full repo upload.
+      // Only useful for git-push sync — bundle sync uploads a fresh local bundle
+      // that can't reuse remote objects, so the prefetch would be wasted I/O.
+      await this.prefetchOriginOnRemote(projectPath, baseRepoPathArg, initLogger, abortSignal);
+
       await this.syncProjectSnapshotViaGitPush(
         projectPath,
         layout,


### PR DESCRIPTION
## Summary

Pre-fetch from origin on the SSH host before the local→remote git push during workspace creation. The host's datacenter connection is typically orders of magnitude faster than the local machine's (e.g. hotel wifi), so this turns the subsequent push into a small incremental transfer instead of a full repo upload.

## Background

SSH workspace creation pushes the entire local git object graph to the remote bare repo via `git push`. On slow connections (hotel wifi, tethering, etc.), this is the dominant bottleneck — potentially minutes for a large repo. Meanwhile, the SSH host usually has a fast datacenter connection to GitHub/origin.

## Implementation

Added a `prefetchOriginOnRemote()` method that runs before the local→remote push in `syncProjectToRemoteOnce()`:

1. Sets the origin URL on the remote bare repo (moved earlier from after the push)
2. Runs `git fetch origin` on the SSH host (datacenter→GitHub, fast)
3. The subsequent `git push` from local only transfers objects not on origin (incremental)

The prefetch is **best-effort** — if origin is unreachable (no internet on SSH host, no origin configured, private repo without deploy key), it silently fails and the push proceeds as before, transferring all objects.

**Before:**
```
local machine ──(full push)──▶ SSH host bare repo    [slow: hotel wifi]
SSH host ──(fetch trunk)──▶ origin                   [fast: datacenter]
```

**After:**
```
SSH host ──(fetch all)──▶ origin                     [fast: datacenter]
local machine ──(incremental push)──▶ SSH host       [fast: only local-only commits]
SSH host ──(fetch trunk)──▶ origin                   [fast: mostly a no-op now]
```

## Risks

Low — the prefetch is entirely best-effort with failure swallowed. The existing push path is unchanged; it just transfers less data when the prefetch succeeds. The `refreshBaseRepoOrigin()` call after the push is kept as an idempotent safety net.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$4.42`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=4.42 -->
