### PR TITLE
🤖 fix: align best-of-N group label with workspace title in sidebar

### DIFF
--- a/src/browser/components/AgentListItem/AgentListItem.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.tsx
@@ -1025,9 +1025,11 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
                 data-workspace-id={workspaceId}
               />
             ) : (
-              <div className="flex min-w-0 items-center gap-1">
+              <div className="flex min-w-0 items-baseline gap-1">
                 {/* Group label (variant name or A/B/C letter) rendered as a non-shrinkable
-                    badge so it stays visible even when the sidebar is narrow. */}
+                    badge so it stays visible even when the sidebar is narrow.
+                    items-baseline keeps the 12px label on the same text baseline as the
+                    14px title so they look naturally aligned despite the size difference. */}
                 {groupLabel && (
                   <span className="text-muted shrink-0 text-[12px] leading-6">{groupLabel}</span>
                 )}


### PR DESCRIPTION
## Summary

Fixes misaligned best-of-N group labels (variant names or A/B/C letters) in the left sidebar by switching from center-aligned to baseline-aligned flex layout.

## Background

When a workspace is a sub-agent in a best-of-N fleet, a group label (either an explicit variant name or a letter like A, B, C) is rendered to the left of the workspace title. The label uses `text-[12px]` while the title uses `text-[14px]`. With `items-center`, both elements center-align their line boxes, but the different font sizes cause the text baselines to sit at slightly different vertical positions — the smaller label appears to float relative to the title.

## Implementation

Changed the flex container from `items-center` to `items-baseline` so both the 12px label and 14px title share the same text baseline, making them look naturally aligned as if they were typed on the same line.

**One-line change** in `AgentListItem.tsx`.

## Validation

- `make typecheck` ✅
- `make lint` ✅
- `make static-check` ✅
- AgentListItem tests match baseline (pre-existing failures unrelated to this change)

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$--`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=-- -->
