### PR TITLE
🤖 fix: stabilize transcript hydration seams

### DIFF
--- a/src/browser/components/ChatPane/ChatInputDecorationStack.test.tsx
+++ b/src/browser/components/ChatPane/ChatInputDecorationStack.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, render, waitFor } from "@testing-library/react";
 import { installDom } from "../../../../tests/ui/dom";
 
 import { ChatInputDecorationStack } from "./ChatInputDecorationStack";
+import type { LayoutStackItem } from "./layoutStack";
 
 let cleanupDom: (() => void) | null = null;
 let originalResizeObserver: typeof ResizeObserver | undefined;
@@ -111,6 +112,20 @@ async function waitForHydratingStack(
   });
 }
 
+function createTextDecoration(key: string, text: string): LayoutStackItem {
+  return {
+    key,
+    node: <div>{text}</div>,
+  };
+}
+
+function createHiddenDecoration(key = "idle-decoration"): LayoutStackItem {
+  return {
+    key,
+    node: <span hidden />,
+  };
+}
+
 describe("ChatInputDecorationStack", () => {
   beforeEach(() => {
     cleanupDom = installDom();
@@ -146,7 +161,7 @@ describe("ChatInputDecorationStack", () => {
         workspaceId="workspace-a"
         isHydrating={false}
         dataComponent="stable-stack"
-        items={[<div key="workspace-a">workspace A</div>]}
+        items={[createTextDecoration("workspace-a", "workspace A")]}
       />
     );
 
@@ -171,7 +186,7 @@ describe("ChatInputDecorationStack", () => {
         workspaceId="workspace-b"
         isHydrating={false}
         dataComponent="stable-stack"
-        items={[<div key="workspace-b">workspace B</div>]}
+        items={[createTextDecoration("workspace-b", "workspace B")]}
       />
     );
 
@@ -186,7 +201,7 @@ describe("ChatInputDecorationStack", () => {
         workspaceId="workspace-a"
         isHydrating={false}
         dataComponent="stable-stack"
-        items={[<div key="workspace-a">workspace A</div>]}
+        items={[createTextDecoration("workspace-a", "workspace A")]}
       />
     );
 
@@ -199,7 +214,7 @@ describe("ChatInputDecorationStack", () => {
         workspaceId="workspace-b"
         isHydrating={true}
         dataComponent="stable-stack"
-        items={[<span key="idle-decoration" hidden />]}
+        items={[createHiddenDecoration()]}
       />
     );
 
@@ -212,7 +227,7 @@ describe("ChatInputDecorationStack", () => {
         workspaceId="workspace-b"
         isHydrating={true}
         dataComponent="stable-stack"
-        items={[<span key="idle-decoration" hidden />]}
+        items={[createHiddenDecoration()]}
       />
     );
 
@@ -224,7 +239,7 @@ describe("ChatInputDecorationStack", () => {
         workspaceId="workspace-b"
         isHydrating={false}
         dataComponent="stable-stack"
-        items={[<span key="idle-decoration" hidden />]}
+        items={[createHiddenDecoration()]}
       />
     );
 
@@ -237,7 +252,7 @@ describe("ChatInputDecorationStack", () => {
         workspaceId="workspace-c"
         isHydrating={true}
         dataComponent="stable-stack"
-        items={[<span key="idle-decoration" hidden />]}
+        items={[createHiddenDecoration()]}
       />
     );
 
@@ -252,7 +267,7 @@ describe("ChatInputDecorationStack", () => {
         workspaceId="workspace-a"
         isHydrating={false}
         dataComponent="stable-stack"
-        items={[<div key="workspace-a">workspace A</div>]}
+        items={[createTextDecoration("workspace-a", "workspace A")]}
       />
     );
 
@@ -265,7 +280,7 @@ describe("ChatInputDecorationStack", () => {
         workspaceId="workspace-a"
         isHydrating={false}
         dataComponent="stable-stack"
-        items={[<span key="idle-decoration" hidden />]}
+        items={[createHiddenDecoration()]}
       />
     );
 
@@ -278,7 +293,7 @@ describe("ChatInputDecorationStack", () => {
         workspaceId="workspace-a"
         isHydrating={true}
         dataComponent="stable-stack"
-        items={[<span key="idle-decoration" hidden />]}
+        items={[createHiddenDecoration()]}
       />
     );
 
@@ -291,7 +306,7 @@ describe("ChatInputDecorationStack", () => {
         workspaceId="workspace-b"
         isHydrating={true}
         dataComponent="stable-stack"
-        items={[<span key="idle-decoration" hidden />]}
+        items={[createHiddenDecoration()]}
       />
     );
 
@@ -307,7 +322,7 @@ describe("ChatInputDecorationStack", () => {
           workspaceId="workspace-a"
           isHydrating={false}
           dataComponent="stable-stack"
-          items={[<div key="workspace-a">workspace A</div>]}
+          items={[createTextDecoration("workspace-a", "workspace A")]}
         />
         <div data-component="ChatInputSection">Input</div>
       </div>

--- a/src/browser/components/ChatPane/ChatInputDecorationStack.tsx
+++ b/src/browser/components/ChatPane/ChatInputDecorationStack.tsx
@@ -1,5 +1,11 @@
 import React, { useLayoutEffect, useRef } from "react";
-import type { LayoutStackItem } from "./layoutStack";
+import {
+  clearLayoutStackHeight,
+  getReservedLayoutStackHeightPx,
+  measureLayoutStackHeightPx,
+  rememberLayoutStackHeight,
+  type LayoutStackItem,
+} from "./layoutStack";
 
 interface ChatInputDecorationStackProps {
   workspaceId: string;
@@ -8,27 +14,12 @@ interface ChatInputDecorationStackProps {
   dataComponent?: string;
 }
 
-function getReservedStackHeightPx(props: {
-  workspaceId: string;
-  isHydrating: boolean;
-  stackHeightByWorkspaceId: Map<string, number>;
-  fallbackStackHeightPx: number;
-}): number | null {
-  if (!props.isHydrating) {
-    return null;
-  }
-
-  const reservedStackHeight =
-    props.stackHeightByWorkspaceId.get(props.workspaceId) ?? props.fallbackStackHeightPx;
-  return reservedStackHeight > 0 ? reservedStackHeight : null;
-}
-
 export const ChatInputDecorationStack: React.FC<ChatInputDecorationStackProps> = (props) => {
   const contentRef = useRef<HTMLDivElement>(null);
   const stackHeightByWorkspaceIdRef = useRef(new Map<string, number>());
   const lastMeasuredStackHeightRef = useRef(0);
-  const hasDecorationEntries = props.items.length > 0;
-  const reservedStackHeightPx = getReservedStackHeightPx({
+  const hasItems = props.items.length > 0;
+  const reservedStackHeightPx = getReservedLayoutStackHeightPx({
     workspaceId: props.workspaceId,
     isHydrating: props.isHydrating,
     stackHeightByWorkspaceId: stackHeightByWorkspaceIdRef.current,
@@ -37,19 +28,19 @@ export const ChatInputDecorationStack: React.FC<ChatInputDecorationStackProps> =
 
   useLayoutEffect(() => {
     const content = contentRef.current;
-    if (!content || !hasDecorationEntries) {
+    if (!content || !hasItems) {
       return;
     }
 
     const observer = new ResizeObserver((entries) => {
-      const nextHeight = Math.max(
-        0,
-        Math.round(entries[0]?.contentRect.height ?? content.getBoundingClientRect().height)
-      );
+      const nextHeight = measureLayoutStackHeightPx(content, entries[0]?.contentRect.height);
       if (nextHeight === 0) {
         if (!props.isHydrating) {
-          lastMeasuredStackHeightRef.current = 0;
-          stackHeightByWorkspaceIdRef.current.set(props.workspaceId, 0);
+          clearLayoutStackHeight(
+            props.workspaceId,
+            stackHeightByWorkspaceIdRef.current,
+            lastMeasuredStackHeightRef
+          );
         }
         return;
       }
@@ -58,24 +49,31 @@ export const ChatInputDecorationStack: React.FC<ChatInputDecorationStackProps> =
       // background process dialogs). Ignore zero-height observations during hydration so a
       // transient empty lane cannot overwrite the last real measurement and drop the temporary
       // reservation early, but still remember settled zero-height states after hydration ends.
-      lastMeasuredStackHeightRef.current = nextHeight;
-      stackHeightByWorkspaceIdRef.current.set(props.workspaceId, nextHeight);
+      rememberLayoutStackHeight(
+        props.workspaceId,
+        nextHeight,
+        stackHeightByWorkspaceIdRef.current,
+        lastMeasuredStackHeightRef
+      );
     });
 
     observer.observe(content);
     return () => {
       observer.disconnect();
     };
-  }, [hasDecorationEntries, props.isHydrating, props.workspaceId]);
+  }, [hasItems, props.isHydrating, props.workspaceId]);
 
   useLayoutEffect(() => {
     if (props.isHydrating) {
       return;
     }
 
-    if (!hasDecorationEntries) {
-      lastMeasuredStackHeightRef.current = 0;
-      stackHeightByWorkspaceIdRef.current.set(props.workspaceId, 0);
+    if (!hasItems) {
+      clearLayoutStackHeight(
+        props.workspaceId,
+        stackHeightByWorkspaceIdRef.current,
+        lastMeasuredStackHeightRef
+      );
       return;
     }
 
@@ -84,18 +82,21 @@ export const ChatInputDecorationStack: React.FC<ChatInputDecorationStackProps> =
       return;
     }
 
-    const settledHeightPx = Math.max(0, Math.round(content.getBoundingClientRect().height));
+    const settledHeightPx = measureLayoutStackHeightPx(content);
     if (settledHeightPx === 0) {
-      lastMeasuredStackHeightRef.current = 0;
-      stackHeightByWorkspaceIdRef.current.set(props.workspaceId, 0);
+      clearLayoutStackHeight(
+        props.workspaceId,
+        stackHeightByWorkspaceIdRef.current,
+        lastMeasuredStackHeightRef
+      );
     }
-  }, [hasDecorationEntries, props.isHydrating, props.workspaceId]);
+  }, [hasItems, props.isHydrating, props.workspaceId]);
 
   // Keep the workspace-specific decoration lane steady while hydration catches up. Reserving the
   // whole composer pane let the textarea float inside a tall wrapper, which still looked like a
   // vertical tear. Scope the reservation to the lane above the input and keep the lane bottom-
   // aligned so the textarea seam stays put while TODO/review/queued banners repopulate.
-  if (!hasDecorationEntries && reservedStackHeightPx === null) {
+  if (!hasItems && reservedStackHeightPx === null) {
     return null;
   }
 

--- a/src/browser/components/ChatPane/ChatInputDecorationStack.tsx
+++ b/src/browser/components/ChatPane/ChatInputDecorationStack.tsx
@@ -1,9 +1,10 @@
 import React, { useLayoutEffect, useRef } from "react";
+import type { LayoutStackItem } from "./layoutStack";
 
 interface ChatInputDecorationStackProps {
   workspaceId: string;
   isHydrating: boolean;
-  items: React.ReactNode[];
+  items: readonly LayoutStackItem[];
   dataComponent?: string;
 }
 
@@ -106,7 +107,11 @@ export const ChatInputDecorationStack: React.FC<ChatInputDecorationStackProps> =
         reservedStackHeightPx !== null ? { minHeight: `${reservedStackHeightPx}px` } : undefined
       }
     >
-      <div ref={contentRef}>{props.items}</div>
+      <div ref={contentRef}>
+        {props.items.map((item) => (
+          <React.Fragment key={item.key}>{item.node}</React.Fragment>
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -20,6 +20,8 @@ import { StreamingBarrier } from "@/browser/features/Messages/ChatBarrier/Stream
 import { RetryBarrier } from "@/browser/features/Messages/ChatBarrier/RetryBarrier";
 import { PinnedTodoList } from "../PinnedTodoList/PinnedTodoList";
 import { ChatInputDecorationStack } from "./ChatInputDecorationStack";
+import { TranscriptTailStack } from "./TranscriptTailStack";
+import { getLayoutStackSignature, type LayoutStackItem } from "./layoutStack";
 import { VIM_ENABLED_KEY } from "@/common/constants/storage";
 import { ChatInput, type ChatInputAPI } from "@/browser/features/ChatInput/index";
 import type { QueueDispatchMode } from "@/browser/features/ChatInput/types";
@@ -54,7 +56,10 @@ import { useAIViewKeybinds } from "@/browser/hooks/useAIViewKeybinds";
 import { QueuedMessage } from "@/browser/features/Messages/QueuedMessage";
 import { CompactionWarning } from "../CompactionWarning/CompactionWarning";
 import { ContextSwitchWarning as ContextSwitchWarningBanner } from "../ContextSwitchWarning/ContextSwitchWarning";
-import { ConcurrentLocalWarning } from "../ConcurrentLocalWarning/ConcurrentLocalWarning";
+import {
+  ConcurrentLocalWarningView,
+  useConcurrentLocalStreamingWorkspaceName,
+} from "../ConcurrentLocalWarning/ConcurrentLocalWarning";
 import { BackgroundProcessesBanner } from "../BackgroundProcessesBanner/BackgroundProcessesBanner";
 import { checkAutoCompaction } from "@/common/utils/compaction/autoCompactionCheck";
 import { cancelCompaction } from "@/browser/utils/compaction/handler";
@@ -203,6 +208,11 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
       : null;
   const shouldShowQueuedAgentTaskPrompt =
     Boolean(queuedAgentTaskPrompt) && (workspaceState?.messages.length ?? 0) === 0;
+  const concurrentLocalStreamingWorkspaceName = useConcurrentLocalStreamingWorkspaceName({
+    workspaceId,
+    projectPath,
+    runtimeConfig,
+  });
 
   const { has1MContext } = useProviderOptions();
   // Resolve 1M context per-model (uses the pending model for the current workspace)
@@ -677,26 +687,83 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
   const shouldMountRetryBarrier = !suppressRetryBarrier;
   const showRetryBarrierUI = showRetryBarrier && !suppressRetryBarrier;
 
-  // Keep the transcript bottom pinned before paint when the tail changes.
-  // Sending a message can append a new user row and mount footer UI (streaming/retry/TODO)
-  // in the same turn; synchronizing here avoids a visible jump before the async
-  // ResizeObserver / streaming auto-scroll path runs.
+  // Derive inline transcript chrome once so row rendering and layout pinning share the exact same
+  // visibility decision. This keeps late interrupted markers from sneaking in through a second code
+  // path after hydration or auto-retry state changes.
+  const interruptedBarrierMessageIds = new Set<string>();
+  for (const message of deferredMessages) {
+    if (
+      shouldShowInterruptedBarrier(message, {
+        isHydratingTranscript,
+        isAutoRetryActive,
+      })
+    ) {
+      interruptedBarrierMessageIds.add(message.id);
+    }
+  }
+  const interruptedBarrierLayoutSignature = Array.from(interruptedBarrierMessageIds).join("|");
+
+  const shouldShowStreamingBarrier = isStreamStarting || canInterrupt;
+  const transcriptTailItems: LayoutStackItem[] = [];
+  if (shouldMountRetryBarrier) {
+    transcriptTailItems.push({
+      key: "retry-barrier",
+      layoutKey: `retry-barrier:${showRetryBarrierUI ? "visible" : "hidden"}`,
+      node: <RetryBarrier workspaceId={workspaceId} visible={showRetryBarrierUI} />,
+    });
+  }
+  if (shouldShowStreamingBarrier) {
+    transcriptTailItems.push({
+      key: "streaming-barrier",
+      node: (
+        <StreamingBarrier
+          workspaceId={workspaceId}
+          vimEnabled={vimEnabled}
+          onCancelCompaction={handleCancelCompactionFromBarrier}
+        />
+      ),
+    });
+  }
+  if (shouldShowQueuedAgentTaskPrompt) {
+    transcriptTailItems.push({
+      key: "queued-agent-prompt",
+      node: (
+        <div className="mt-4 mb-1 ml-auto w-fit max-w-full">
+          <div className="rounded-lg border border-[var(--color-user-border)] bg-[var(--color-user-surface)] px-3 py-2 text-sm">
+            <div className="text-muted mb-1 text-[11px] font-medium">Queued</div>
+            <MarkdownRenderer
+              content={queuedAgentTaskPrompt ?? ""}
+              className="user-message-markdown text-foreground"
+              preserveLineBreaks
+              style={{ overflowWrap: "break-word", wordBreak: "break-word" }}
+            />
+          </div>
+        </div>
+      ),
+    });
+  }
+  if (concurrentLocalStreamingWorkspaceName) {
+    transcriptTailItems.push({
+      key: "concurrent-local-warning",
+      layoutKey: `concurrent-local-warning:${concurrentLocalStreamingWorkspaceName}`,
+      node: (
+        <ConcurrentLocalWarningView
+          streamingWorkspaceName={concurrentLocalStreamingWorkspaceName}
+        />
+      ),
+    });
+  }
+
+  // Keep inline transcript rows pinned before paint when they change height inside the viewport.
+  // The tail and composer decoration lanes own their own layout signatures; this effect only covers
+  // layout that is inserted directly between message rows (new transcript rows, interrupted markers).
   useLayoutEffect(() => {
     if (!autoScroll || !contentRef.current) {
       return;
     }
 
     contentRef.current.scrollTop = contentRef.current.scrollHeight;
-  }, [
-    autoScroll,
-    contentRef,
-    latestMessageId,
-    workspaceState?.todos.length,
-    showRetryBarrierUI,
-    workspaceState?.isStreamStarting,
-    workspaceState?.canInterrupt,
-    shouldShowQueuedAgentTaskPrompt,
-  ]);
+  }, [autoScroll, contentRef, latestMessageId, interruptedBarrierLayoutSignature]);
 
   const handleLoadOlderHistory = useCallback(() => {
     if (!shouldRenderLoadOlderMessagesButton || loadingOlderHistory) {
@@ -950,49 +1017,21 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
                               />
                             )}
                             {isAtCutoff && <EditCutoffBarrier />}
-                            {shouldShowInterruptedBarrier(msg, {
-                              isHydratingTranscript,
-                              isAutoRetryActive,
-                            }) && <InterruptedBarrier />}
+                            {interruptedBarrierMessageIds.has(msg.id) && <InterruptedBarrier />}
                           </React.Fragment>
                         );
                       })}
                     </>
                   </MessageListProvider>
                 )}
-                <div style={{ overflowAnchor: "none" }}>
-                  {/*
-                    Keep the dynamic transcript tail out of the browser's scroll-anchoring heuristics.
-                    ChatPane explicitly pins the bottom when auto-scroll is enabled, so anchoring to
-                    the streaming/retry barrier chrome causes a brief visible jump on send.
-                  */}
-                  {shouldMountRetryBarrier && (
-                    <RetryBarrier workspaceId={workspaceId} visible={showRetryBarrierUI} />
-                  )}
-                  <StreamingBarrier
-                    workspaceId={workspaceId}
-                    vimEnabled={vimEnabled}
-                    onCancelCompaction={handleCancelCompactionFromBarrier}
-                  />
-                  {shouldShowQueuedAgentTaskPrompt && (
-                    <div className="mt-4 mb-1 ml-auto w-fit max-w-full">
-                      <div className="rounded-lg border border-[var(--color-user-border)] bg-[var(--color-user-surface)] px-3 py-2 text-sm">
-                        <div className="text-muted mb-1 text-[11px] font-medium">Queued</div>
-                        <MarkdownRenderer
-                          content={queuedAgentTaskPrompt ?? ""}
-                          className="user-message-markdown text-foreground"
-                          preserveLineBreaks
-                          style={{ overflowWrap: "break-word", wordBreak: "break-word" }}
-                        />
-                      </div>
-                    </div>
-                  )}
-                  <ConcurrentLocalWarning
-                    workspaceId={workspaceId}
-                    projectPath={projectPath}
-                    runtimeConfig={runtimeConfig}
-                  />
-                </div>
+                <TranscriptTailStack
+                  workspaceId={workspaceId}
+                  isHydrating={isHydratingTranscript}
+                  autoScroll={autoScroll}
+                  transcriptViewportRef={contentRef}
+                  dataComponent="TranscriptTailStack"
+                  items={transcriptTailItems}
+                />
               </div>
             </div>
             {transcriptContextMenu.menu}
@@ -1028,6 +1067,8 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
               shouldShowPinnedTodoList={shouldShowPinnedTodoList}
               shouldShowReviewsBanner={shouldShowReviewsBanner}
               canInterrupt={canInterrupt}
+              autoScroll={autoScroll}
+              transcriptViewportRef={contentRef}
               autoCompactionResult={autoCompactionResult}
               shouldShowCompactionWarning={shouldShowCompactionWarning}
               contextSwitchWarning={contextSwitchWarning}
@@ -1079,6 +1120,8 @@ interface ChatInputPaneProps {
   shouldShowPinnedTodoList: boolean;
   shouldShowReviewsBanner: boolean;
   canInterrupt: boolean;
+  autoScroll: boolean;
+  transcriptViewportRef: React.RefObject<HTMLDivElement | null>;
   autoCompactionResult: ReturnType<typeof checkAutoCompaction>;
   shouldShowCompactionWarning: boolean;
   contextSwitchWarning: ContextSwitchWarning | null;
@@ -1104,47 +1147,85 @@ const ChatInputPane: React.FC<ChatInputPaneProps> = (props) => {
   // Keep optional banners/warnings on one shared lane so the seam right above the textarea is
   // owned by a single component boundary. That lets hydration reserve only the volatile
   // workspace-specific decoration stack instead of the whole composer pane.
-  const decorationItems: React.ReactNode[] = [
-    props.shouldShowCompactionWarning ? (
-      <CompactionWarning
-        key="compaction-warning"
-        usagePercentage={props.autoCompactionResult.usagePercentage}
-        thresholdPercentage={props.autoCompactionResult.thresholdPercentage}
-        isStreaming={props.canInterrupt}
-      />
-    ) : null,
-    props.contextSwitchWarning ? (
-      <ContextSwitchWarningBanner
-        key="context-switch-warning"
-        warning={props.contextSwitchWarning}
-        onCompact={props.onContextSwitchCompact}
-        onDismiss={props.onContextSwitchDismiss}
-      />
-    ) : null,
-    props.shouldShowPinnedTodoList ? (
-      <PinnedTodoList key="pinned-todo-list" workspaceId={props.workspaceId} />
-    ) : null,
-    <BackgroundProcessesBanner key="background-processes" workspaceId={props.workspaceId} />,
-    props.shouldShowReviewsBanner ? (
-      <ReviewsBanner key="reviews-banner" workspaceId={props.workspaceId} />
-    ) : null,
-    props.queuedMessage ? (
-      <QueuedMessage
-        key="queued-message"
-        message={props.queuedMessage}
-        onEdit={() => void props.onEditQueuedMessage()}
-        onSendImmediately={props.onSendQueuedImmediately}
-      />
-    ) : null,
-    props.isQueuedAgentTask ? (
-      <div
-        key="queued-agent-task"
-        className="border-border-medium bg-background-secondary text-muted rounded-md border px-3 py-2 text-xs"
-      >
-        This agent task is queued and will start automatically when a parallel slot is available.
-      </div>
-    ) : null,
-  ].filter((value) => value !== null);
+  const decorationEntries: LayoutStackItem[] = [];
+  if (props.shouldShowCompactionWarning) {
+    decorationEntries.push({
+      key: "compaction-warning",
+      node: (
+        <CompactionWarning
+          usagePercentage={props.autoCompactionResult.usagePercentage}
+          thresholdPercentage={props.autoCompactionResult.thresholdPercentage}
+          isStreaming={props.canInterrupt}
+        />
+      ),
+    });
+  }
+  if (props.contextSwitchWarning) {
+    decorationEntries.push({
+      key: "context-switch-warning",
+      node: (
+        <ContextSwitchWarningBanner
+          warning={props.contextSwitchWarning}
+          onCompact={props.onContextSwitchCompact}
+          onDismiss={props.onContextSwitchDismiss}
+        />
+      ),
+    });
+  }
+  if (props.shouldShowPinnedTodoList) {
+    decorationEntries.push({
+      key: "pinned-todo-list",
+      node: <PinnedTodoList workspaceId={props.workspaceId} />,
+    });
+  }
+  decorationEntries.push({
+    key: "background-processes",
+    node: <BackgroundProcessesBanner workspaceId={props.workspaceId} />,
+  });
+  if (props.shouldShowReviewsBanner) {
+    decorationEntries.push({
+      key: "reviews-banner",
+      node: <ReviewsBanner workspaceId={props.workspaceId} />,
+    });
+  }
+  if (props.queuedMessage) {
+    decorationEntries.push({
+      key: "queued-message",
+      node: (
+        <QueuedMessage
+          message={props.queuedMessage}
+          onEdit={() => void props.onEditQueuedMessage()}
+          onSendImmediately={props.onSendQueuedImmediately}
+        />
+      ),
+    });
+  }
+  if (props.isQueuedAgentTask) {
+    decorationEntries.push({
+      key: "queued-agent-task",
+      node: (
+        <div className="border-border-medium bg-background-secondary text-muted rounded-md border px-3 py-2 text-xs">
+          This agent task is queued and will start automatically when a parallel slot is available.
+        </div>
+      ),
+    });
+  }
+  const decorationLayoutSignature = getLayoutStackSignature(decorationEntries);
+
+  // The decoration lane changes the transcript viewport height from below, so let the lane owner
+  // report one layout signature instead of teaching ChatPane about every individual banner.
+  useLayoutEffect(() => {
+    if (!props.autoScroll) {
+      return;
+    }
+
+    const transcriptViewport = props.transcriptViewportRef.current;
+    if (!transcriptViewport) {
+      return;
+    }
+
+    transcriptViewport.scrollTop = transcriptViewport.scrollHeight;
+  }, [decorationLayoutSignature, props.autoScroll, props.transcriptViewportRef]);
 
   return (
     <>
@@ -1152,7 +1233,7 @@ const ChatInputPane: React.FC<ChatInputPaneProps> = (props) => {
         workspaceId={props.workspaceId}
         isHydrating={props.isHydratingTranscript}
         dataComponent="ChatInputDecorationStack"
-        items={decorationItems}
+        items={decorationEntries.map((entry) => entry.node)}
       />
       <ChatInput
         key={props.workspaceId}

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -285,7 +285,8 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
     hasOlderHistory,
     loadingOlderHistory,
   } = workspaceState;
-  const shouldShowPinnedTodoList = workspaceState.todos.length > 0;
+  const todoCount = workspaceState.todos.length;
+  const shouldShowPinnedTodoList = todoCount > 0;
   const shouldShowReviewsBanner = reviews.reviews.length > 0;
   const shouldRenderLoadOlderMessagesButton = hasOlderHistory && !isChromaticStorybookEnvironment();
   const loadOlderMessagesShortcutLabel = formatKeybind(KEYBINDS.LOAD_OLDER_MESSAGES);
@@ -1065,6 +1066,7 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
               isQueuedAgentTask={isQueuedAgentTask}
               isCompacting={isCompacting}
               shouldShowPinnedTodoList={shouldShowPinnedTodoList}
+              todoCount={todoCount}
               shouldShowReviewsBanner={shouldShowReviewsBanner}
               canInterrupt={canInterrupt}
               autoScroll={autoScroll}
@@ -1118,6 +1120,7 @@ interface ChatInputPaneProps {
   isStreamStarting: boolean;
   isHydratingTranscript: boolean;
   shouldShowPinnedTodoList: boolean;
+  todoCount: number;
   shouldShowReviewsBanner: boolean;
   canInterrupt: boolean;
   autoScroll: boolean;
@@ -1175,6 +1178,7 @@ const ChatInputPane: React.FC<ChatInputPaneProps> = (props) => {
   if (props.shouldShowPinnedTodoList) {
     decorationEntries.push({
       key: "pinned-todo-list",
+      layoutKey: `pinned-todo-list:${props.todoCount}`,
       node: <PinnedTodoList workspaceId={props.workspaceId} />,
     });
   }
@@ -1185,12 +1189,14 @@ const ChatInputPane: React.FC<ChatInputPaneProps> = (props) => {
   if (props.shouldShowReviewsBanner) {
     decorationEntries.push({
       key: "reviews-banner",
+      layoutKey: `reviews-banner:${reviews.reviews.length}`,
       node: <ReviewsBanner workspaceId={props.workspaceId} />,
     });
   }
   if (props.queuedMessage) {
     decorationEntries.push({
       key: "queued-message",
+      layoutKey: `queued-message:${props.queuedMessage.id}`,
       node: (
         <QueuedMessage
           message={props.queuedMessage}
@@ -1233,7 +1239,7 @@ const ChatInputPane: React.FC<ChatInputPaneProps> = (props) => {
         workspaceId={props.workspaceId}
         isHydrating={props.isHydratingTranscript}
         dataComponent="ChatInputDecorationStack"
-        items={decorationEntries.map((entry) => entry.node)}
+        items={decorationEntries}
       />
       <ChatInput
         key={props.workspaceId}

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -21,7 +21,11 @@ import { RetryBarrier } from "@/browser/features/Messages/ChatBarrier/RetryBarri
 import { PinnedTodoList } from "../PinnedTodoList/PinnedTodoList";
 import { ChatInputDecorationStack } from "./ChatInputDecorationStack";
 import { TranscriptTailStack } from "./TranscriptTailStack";
-import { getLayoutStackSignature, type LayoutStackItem } from "./layoutStack";
+import {
+  getLayoutStackSignature,
+  scrollElementToBottom,
+  type LayoutStackItem,
+} from "./layoutStack";
 import { VIM_ENABLED_KEY } from "@/common/constants/storage";
 import { ChatInput, type ChatInputAPI } from "@/browser/features/ChatInput/index";
 import type { QueueDispatchMode } from "@/browser/features/ChatInput/types";
@@ -621,7 +625,7 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
         return;
       }
 
-      transcriptViewport.scrollTop = transcriptViewport.scrollHeight;
+      scrollElementToBottom(transcriptViewport);
     });
 
     observer.observe(transcriptViewport);
@@ -763,7 +767,7 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
       return;
     }
 
-    contentRef.current.scrollTop = contentRef.current.scrollHeight;
+    scrollElementToBottom(contentRef.current);
   }, [autoScroll, contentRef, latestMessageId, interruptedBarrierLayoutSignature]);
 
   const handleLoadOlderHistory = useCallback(() => {
@@ -1230,7 +1234,7 @@ const ChatInputPane: React.FC<ChatInputPaneProps> = (props) => {
       return;
     }
 
-    transcriptViewport.scrollTop = transcriptViewport.scrollHeight;
+    scrollElementToBottom(transcriptViewport);
   }, [decorationLayoutSignature, props.autoScroll, props.transcriptViewportRef]);
 
   return (

--- a/src/browser/components/ChatPane/TranscriptTailStack.test.tsx
+++ b/src/browser/components/ChatPane/TranscriptTailStack.test.tsx
@@ -1,0 +1,275 @@
+import React from "react";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { installDom } from "../../../../tests/ui/dom";
+
+import { TranscriptTailStack } from "./TranscriptTailStack";
+import type { LayoutStackItem } from "./layoutStack";
+
+let cleanupDom: (() => void) | null = null;
+let originalResizeObserver: typeof ResizeObserver | undefined;
+const resizeCallbacks = new Map<Element, ResizeObserverCallback[]>();
+
+class ResizeObserverMock implements ResizeObserver {
+  public readonly callback: ResizeObserverCallback;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+  }
+
+  observe(target: Element) {
+    resizeCallbacks.set(target, [...(resizeCallbacks.get(target) ?? []), this.callback]);
+  }
+
+  unobserve(target: Element) {
+    const callbacks = (resizeCallbacks.get(target) ?? []).filter(
+      (callback) => callback !== this.callback
+    );
+    if (callbacks.length === 0) {
+      resizeCallbacks.delete(target);
+      return;
+    }
+    resizeCallbacks.set(target, callbacks);
+  }
+
+  disconnect() {
+    for (const [target, callbacks] of resizeCallbacks.entries()) {
+      const remainingCallbacks = callbacks.filter((callback) => callback !== this.callback);
+      if (remainingCallbacks.length === 0) {
+        resizeCallbacks.delete(target);
+        continue;
+      }
+      resizeCallbacks.set(target, remainingCallbacks);
+    }
+  }
+
+  takeRecords(): ResizeObserverEntry[] {
+    return [];
+  }
+}
+
+function emitResize(target: Element, height: number) {
+  const callbacks = resizeCallbacks.get(target) ?? [];
+  const contentRect: DOMRectReadOnly = {
+    x: 0,
+    y: 0,
+    width: 0,
+    height,
+    top: 0,
+    right: 0,
+    bottom: height,
+    left: 0,
+    toJSON: () => ({}),
+  };
+  const entry: ResizeObserverEntry = {
+    target,
+    contentRect,
+    borderBoxSize: [],
+    contentBoxSize: [],
+    devicePixelContentBoxSize: [],
+  };
+  for (const callback of callbacks) {
+    callback([entry], {} as ResizeObserver);
+  }
+}
+
+function createTranscriptViewportRef(): React.RefObject<HTMLDivElement | null> {
+  return { current: document.createElement("div") };
+}
+
+function defineScrollProperties(
+  transcriptViewport: HTMLDivElement,
+  options?: { scrollHeight?: number }
+) {
+  let scrollTop = 0;
+  const scrollHeight = options?.scrollHeight ?? 320;
+
+  Object.defineProperty(transcriptViewport, "scrollTop", {
+    configurable: true,
+    get: () => scrollTop,
+    set: (value: number) => {
+      scrollTop = value;
+    },
+  });
+  Object.defineProperty(transcriptViewport, "scrollHeight", {
+    configurable: true,
+    get: () => scrollHeight,
+  });
+
+  return {
+    getScrollTop: () => scrollTop,
+    resetScrollTop() {
+      scrollTop = 0;
+    },
+    getScrollHeight: () => scrollHeight,
+  };
+}
+
+function getRenderedStack(container: HTMLElement): HTMLDivElement {
+  const stack = container.querySelector('[data-component="stable-tail"]');
+  expect(stack).toBeTruthy();
+  if (stack?.tagName !== "DIV") {
+    throw new Error("Expected tail stack to exist");
+  }
+  return stack as HTMLDivElement;
+}
+
+function getStackContent(container: HTMLElement): HTMLDivElement {
+  const content = getRenderedStack(container).firstElementChild;
+  expect(content).toBeTruthy();
+  if (content?.tagName !== "DIV") {
+    throw new Error("Expected tail content wrapper to exist");
+  }
+  return content as HTMLDivElement;
+}
+
+async function waitForResizeObservation(target: Element): Promise<void> {
+  await waitFor(() => {
+    const callbacks = resizeCallbacks.get(target);
+    if (!callbacks || callbacks.length === 0) {
+      throw new Error("Resize observer is not attached yet");
+    }
+  });
+}
+
+describe("TranscriptTailStack", () => {
+  beforeEach(() => {
+    cleanupDom = installDom();
+    originalResizeObserver = globalThis.ResizeObserver;
+    resizeCallbacks.clear();
+    (globalThis as typeof globalThis & { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+      ResizeObserverMock as unknown as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    cleanup();
+    resizeCallbacks.clear();
+    cleanupDom?.();
+    cleanupDom = null;
+    if (originalResizeObserver) {
+      (
+        globalThis as typeof globalThis & {
+          ResizeObserver: typeof ResizeObserver;
+        }
+      ).ResizeObserver = originalResizeObserver;
+    }
+    originalResizeObserver = undefined;
+  });
+
+  it("holds the last measured tail height while switching to a hydrating workspace", async () => {
+    const transcriptViewportRef = createTranscriptViewportRef();
+    const view = render(
+      <TranscriptTailStack
+        workspaceId="workspace-a"
+        isHydrating={false}
+        autoScroll={false}
+        transcriptViewportRef={transcriptViewportRef}
+        dataComponent="stable-tail"
+        items={[{ key: "workspace-a", node: <div>workspace A</div> }]}
+      />
+    );
+
+    const content = getStackContent(view.container);
+    await waitForResizeObservation(content);
+    emitResize(content, 184);
+
+    view.rerender(
+      <TranscriptTailStack
+        workspaceId="workspace-b"
+        isHydrating={true}
+        autoScroll={false}
+        transcriptViewportRef={transcriptViewportRef}
+        dataComponent="stable-tail"
+        items={[]}
+      />
+    );
+
+    await waitFor(() => {
+      expect(getRenderedStack(view.container).style.minHeight).toBe("184px");
+    });
+
+    view.rerender(
+      <TranscriptTailStack
+        workspaceId="workspace-b"
+        isHydrating={false}
+        autoScroll={false}
+        transcriptViewportRef={transcriptViewportRef}
+        dataComponent="stable-tail"
+        items={[{ key: "workspace-b", node: <div>workspace B</div> }]}
+      />
+    );
+
+    await waitFor(() => {
+      expect(getRenderedStack(view.container).style.minHeight).toBe("");
+    });
+  });
+
+  it("pins the transcript when a mounted tail item changes from hidden to visible", () => {
+    const transcriptViewportRef = createTranscriptViewportRef();
+    const scrollState = defineScrollProperties(transcriptViewportRef.current!, {
+      scrollHeight: 480,
+    });
+    const hiddenRetryItem: LayoutStackItem = {
+      key: "retry-barrier",
+      layoutKey: "retry-barrier:hidden",
+      node: null,
+    };
+    const visibleRetryItem: LayoutStackItem = {
+      key: "retry-barrier",
+      layoutKey: "retry-barrier:visible",
+      node: <div>Retry</div>,
+    };
+
+    const view = render(
+      <TranscriptTailStack
+        workspaceId="workspace-a"
+        isHydrating={false}
+        autoScroll={true}
+        transcriptViewportRef={transcriptViewportRef}
+        dataComponent="stable-tail"
+        items={[hiddenRetryItem]}
+      />
+    );
+
+    expect(scrollState.getScrollTop()).toBe(scrollState.getScrollHeight());
+    scrollState.resetScrollTop();
+
+    view.rerender(
+      <TranscriptTailStack
+        workspaceId="workspace-a"
+        isHydrating={false}
+        autoScroll={true}
+        transcriptViewportRef={transcriptViewportRef}
+        dataComponent="stable-tail"
+        items={[visibleRetryItem]}
+      />
+    );
+
+    expect(scrollState.getScrollTop()).toBe(scrollState.getScrollHeight());
+  });
+
+  it("pins the transcript when visible tail content changes height after mount", async () => {
+    const transcriptViewportRef = createTranscriptViewportRef();
+    const scrollState = defineScrollProperties(transcriptViewportRef.current!, {
+      scrollHeight: 640,
+    });
+    const view = render(
+      <TranscriptTailStack
+        workspaceId="workspace-a"
+        isHydrating={false}
+        autoScroll={true}
+        transcriptViewportRef={transcriptViewportRef}
+        dataComponent="stable-tail"
+        items={[{ key: "streaming-barrier", node: <div>Streaming</div> }]}
+      />
+    );
+
+    const content = getStackContent(view.container);
+    await waitForResizeObservation(content);
+    emitResize(content, 40);
+
+    scrollState.resetScrollTop();
+    emitResize(content, 88);
+
+    expect(scrollState.getScrollTop()).toBe(scrollState.getScrollHeight());
+  });
+});

--- a/src/browser/components/ChatPane/TranscriptTailStack.tsx
+++ b/src/browser/components/ChatPane/TranscriptTailStack.tsx
@@ -1,5 +1,13 @@
 import React, { useLayoutEffect, useRef } from "react";
-import { getLayoutStackSignature, type LayoutStackItem } from "./layoutStack";
+import {
+  clearLayoutStackHeight,
+  getLayoutStackSignature,
+  getReservedLayoutStackHeightPx,
+  measureLayoutStackHeightPx,
+  rememberLayoutStackHeight,
+  scrollElementToBottom,
+  type LayoutStackItem,
+} from "./layoutStack";
 
 interface TranscriptTailStackProps {
   workspaceId: string;
@@ -10,21 +18,6 @@ interface TranscriptTailStackProps {
   dataComponent?: string;
 }
 
-function getReservedStackHeightPx(props: {
-  workspaceId: string;
-  isHydrating: boolean;
-  stackHeightByWorkspaceId: Map<string, number>;
-  fallbackStackHeightPx: number;
-}): number | null {
-  if (!props.isHydrating) {
-    return null;
-  }
-
-  const reservedStackHeight =
-    props.stackHeightByWorkspaceId.get(props.workspaceId) ?? props.fallbackStackHeightPx;
-  return reservedStackHeight > 0 ? reservedStackHeight : null;
-}
-
 export const TranscriptTailStack: React.FC<TranscriptTailStackProps> = (props) => {
   const contentRef = useRef<HTMLDivElement>(null);
   const stackHeightByWorkspaceIdRef = useRef(new Map<string, number>());
@@ -33,7 +26,7 @@ export const TranscriptTailStack: React.FC<TranscriptTailStackProps> = (props) =
   const previousLayoutSignatureRef = useRef<string | null>(null);
   const hasItems = props.items.length > 0;
   const layoutSignature = `${props.workspaceId}:${getLayoutStackSignature(props.items)}`;
-  const reservedStackHeightPx = getReservedStackHeightPx({
+  const reservedStackHeightPx = getReservedLayoutStackHeightPx({
     workspaceId: props.workspaceId,
     isHydrating: props.isHydrating,
     stackHeightByWorkspaceId: stackHeightByWorkspaceIdRef.current,
@@ -50,12 +43,7 @@ export const TranscriptTailStack: React.FC<TranscriptTailStackProps> = (props) =
       return;
     }
 
-    const transcriptViewport = props.transcriptViewportRef.current;
-    if (!transcriptViewport) {
-      return;
-    }
-
-    transcriptViewport.scrollTop = transcriptViewport.scrollHeight;
+    scrollElementToBottom(props.transcriptViewportRef.current);
   }, [layoutSignature, props.autoScroll, props.transcriptViewportRef]);
 
   useLayoutEffect(() => {
@@ -66,21 +54,25 @@ export const TranscriptTailStack: React.FC<TranscriptTailStackProps> = (props) =
     }
 
     const observer = new ResizeObserver((entries) => {
-      const nextHeight = Math.max(
-        0,
-        Math.round(entries[0]?.contentRect.height ?? content.getBoundingClientRect().height)
-      );
+      const nextHeight = measureLayoutStackHeightPx(content, entries[0]?.contentRect.height);
       const previousObservedHeight = observedHeightRef.current;
       observedHeightRef.current = nextHeight;
 
       if (nextHeight === 0) {
         if (!props.isHydrating) {
-          lastMeasuredStackHeightRef.current = 0;
-          stackHeightByWorkspaceIdRef.current.set(props.workspaceId, 0);
+          clearLayoutStackHeight(
+            props.workspaceId,
+            stackHeightByWorkspaceIdRef.current,
+            lastMeasuredStackHeightRef
+          );
         }
       } else {
-        lastMeasuredStackHeightRef.current = nextHeight;
-        stackHeightByWorkspaceIdRef.current.set(props.workspaceId, nextHeight);
+        rememberLayoutStackHeight(
+          props.workspaceId,
+          nextHeight,
+          stackHeightByWorkspaceIdRef.current,
+          lastMeasuredStackHeightRef
+        );
       }
 
       if (
@@ -91,25 +83,14 @@ export const TranscriptTailStack: React.FC<TranscriptTailStackProps> = (props) =
         return;
       }
 
-      const transcriptViewport = props.transcriptViewportRef.current;
-      if (!transcriptViewport) {
-        return;
-      }
-
-      transcriptViewport.scrollTop = transcriptViewport.scrollHeight;
+      scrollElementToBottom(props.transcriptViewportRef.current);
     });
 
     observer.observe(content);
     return () => {
       observer.disconnect();
     };
-  }, [
-    hasItems,
-    props.autoScroll,
-    props.isHydrating,
-    props.transcriptViewportRef,
-    props.workspaceId,
-  ]);
+  }, [props.autoScroll, props.isHydrating, props.transcriptViewportRef, props.workspaceId]);
 
   useLayoutEffect(() => {
     if (props.isHydrating) {
@@ -118,8 +99,11 @@ export const TranscriptTailStack: React.FC<TranscriptTailStackProps> = (props) =
 
     if (!hasItems) {
       observedHeightRef.current = 0;
-      lastMeasuredStackHeightRef.current = 0;
-      stackHeightByWorkspaceIdRef.current.set(props.workspaceId, 0);
+      clearLayoutStackHeight(
+        props.workspaceId,
+        stackHeightByWorkspaceIdRef.current,
+        lastMeasuredStackHeightRef
+      );
       return;
     }
 
@@ -128,11 +112,14 @@ export const TranscriptTailStack: React.FC<TranscriptTailStackProps> = (props) =
       return;
     }
 
-    const settledHeightPx = Math.max(0, Math.round(content.getBoundingClientRect().height));
+    const settledHeightPx = measureLayoutStackHeightPx(content);
     observedHeightRef.current = settledHeightPx;
     if (settledHeightPx === 0) {
-      lastMeasuredStackHeightRef.current = 0;
-      stackHeightByWorkspaceIdRef.current.set(props.workspaceId, 0);
+      clearLayoutStackHeight(
+        props.workspaceId,
+        stackHeightByWorkspaceIdRef.current,
+        lastMeasuredStackHeightRef
+      );
     }
   }, [hasItems, props.isHydrating, props.workspaceId]);
 

--- a/src/browser/components/ChatPane/TranscriptTailStack.tsx
+++ b/src/browser/components/ChatPane/TranscriptTailStack.tsx
@@ -1,0 +1,163 @@
+import React, { useLayoutEffect, useRef } from "react";
+import { getLayoutStackSignature, type LayoutStackItem } from "./layoutStack";
+
+interface TranscriptTailStackProps {
+  workspaceId: string;
+  isHydrating: boolean;
+  autoScroll: boolean;
+  transcriptViewportRef: React.RefObject<HTMLDivElement | null>;
+  items: readonly LayoutStackItem[];
+  dataComponent?: string;
+}
+
+function getReservedStackHeightPx(props: {
+  workspaceId: string;
+  isHydrating: boolean;
+  stackHeightByWorkspaceId: Map<string, number>;
+  fallbackStackHeightPx: number;
+}): number | null {
+  if (!props.isHydrating) {
+    return null;
+  }
+
+  const reservedStackHeight =
+    props.stackHeightByWorkspaceId.get(props.workspaceId) ?? props.fallbackStackHeightPx;
+  return reservedStackHeight > 0 ? reservedStackHeight : null;
+}
+
+export const TranscriptTailStack: React.FC<TranscriptTailStackProps> = (props) => {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const stackHeightByWorkspaceIdRef = useRef(new Map<string, number>());
+  const lastMeasuredStackHeightRef = useRef(0);
+  const observedHeightRef = useRef<number | null>(null);
+  const previousLayoutSignatureRef = useRef<string | null>(null);
+  const hasItems = props.items.length > 0;
+  const layoutSignature = `${props.workspaceId}:${getLayoutStackSignature(props.items)}`;
+  const reservedStackHeightPx = getReservedStackHeightPx({
+    workspaceId: props.workspaceId,
+    isHydrating: props.isHydrating,
+    stackHeightByWorkspaceId: stackHeightByWorkspaceIdRef.current,
+    fallbackStackHeightPx: lastMeasuredStackHeightRef.current,
+  });
+
+  useLayoutEffect(() => {
+    if (previousLayoutSignatureRef.current === layoutSignature) {
+      return;
+    }
+    previousLayoutSignatureRef.current = layoutSignature;
+
+    if (!props.autoScroll) {
+      return;
+    }
+
+    const transcriptViewport = props.transcriptViewportRef.current;
+    if (!transcriptViewport) {
+      return;
+    }
+
+    transcriptViewport.scrollTop = transcriptViewport.scrollHeight;
+  }, [layoutSignature, props.autoScroll, props.transcriptViewportRef]);
+
+  useLayoutEffect(() => {
+    const content = contentRef.current;
+    if (!content) {
+      observedHeightRef.current = null;
+      return;
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      const nextHeight = Math.max(
+        0,
+        Math.round(entries[0]?.contentRect.height ?? content.getBoundingClientRect().height)
+      );
+      const previousObservedHeight = observedHeightRef.current;
+      observedHeightRef.current = nextHeight;
+
+      if (nextHeight === 0) {
+        if (!props.isHydrating) {
+          lastMeasuredStackHeightRef.current = 0;
+          stackHeightByWorkspaceIdRef.current.set(props.workspaceId, 0);
+        }
+      } else {
+        lastMeasuredStackHeightRef.current = nextHeight;
+        stackHeightByWorkspaceIdRef.current.set(props.workspaceId, nextHeight);
+      }
+
+      if (
+        !props.autoScroll ||
+        previousObservedHeight === null ||
+        previousObservedHeight === nextHeight
+      ) {
+        return;
+      }
+
+      const transcriptViewport = props.transcriptViewportRef.current;
+      if (!transcriptViewport) {
+        return;
+      }
+
+      transcriptViewport.scrollTop = transcriptViewport.scrollHeight;
+    });
+
+    observer.observe(content);
+    return () => {
+      observer.disconnect();
+    };
+  }, [
+    hasItems,
+    props.autoScroll,
+    props.isHydrating,
+    props.transcriptViewportRef,
+    props.workspaceId,
+  ]);
+
+  useLayoutEffect(() => {
+    if (props.isHydrating) {
+      return;
+    }
+
+    if (!hasItems) {
+      observedHeightRef.current = 0;
+      lastMeasuredStackHeightRef.current = 0;
+      stackHeightByWorkspaceIdRef.current.set(props.workspaceId, 0);
+      return;
+    }
+
+    const content = contentRef.current;
+    if (!content) {
+      return;
+    }
+
+    const settledHeightPx = Math.max(0, Math.round(content.getBoundingClientRect().height));
+    observedHeightRef.current = settledHeightPx;
+    if (settledHeightPx === 0) {
+      lastMeasuredStackHeightRef.current = 0;
+      stackHeightByWorkspaceIdRef.current.set(props.workspaceId, 0);
+    }
+  }, [hasItems, props.isHydrating, props.workspaceId]);
+
+  // Keep all volatile transcript-tail chrome on one seam owner. The message list sits above this
+  // lane, so top-align the contents inside any reserved hydration space to keep the seam under the
+  // last transcript row stationary while retry/streaming/warning rows repopulate.
+  if (!hasItems && reservedStackHeightPx === null) {
+    return null;
+  }
+
+  return (
+    <div
+      className="flex flex-col justify-start"
+      data-component={props.dataComponent}
+      style={
+        reservedStackHeightPx !== null
+          ? { minHeight: `${reservedStackHeightPx}px`, overflowAnchor: "none" }
+          : { overflowAnchor: "none" }
+      }
+    >
+      <div ref={contentRef}>
+        {props.items.map((item) => (
+          <React.Fragment key={item.key}>{item.node}</React.Fragment>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/browser/components/ChatPane/layoutStack.ts
+++ b/src/browser/components/ChatPane/layoutStack.ts
@@ -1,0 +1,18 @@
+import type { ReactNode } from "react";
+
+export interface LayoutStackItem {
+  key: string;
+  node: ReactNode;
+  /**
+   * Optional layout-specific signature.
+   * Use when an item stays mounted for state continuity but its rendered height can toggle
+   * between zero and non-zero (for example, a hidden RetryBarrier that still tracks rollback).
+   */
+  layoutKey?: string;
+}
+
+export function getLayoutStackSignature(
+  items: ReadonlyArray<Pick<LayoutStackItem, "key" | "layoutKey">>
+): string {
+  return items.map((item) => item.layoutKey ?? item.key).join("|");
+}

--- a/src/browser/components/ChatPane/layoutStack.ts
+++ b/src/browser/components/ChatPane/layoutStack.ts
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { MutableRefObject, ReactNode } from "react";
 
 export interface LayoutStackItem {
   key: string;
@@ -11,8 +11,61 @@ export interface LayoutStackItem {
   layoutKey?: string;
 }
 
+interface ReservedLayoutStackHeightProps {
+  workspaceId: string;
+  isHydrating: boolean;
+  stackHeightByWorkspaceId: Map<string, number>;
+  fallbackStackHeightPx: number;
+}
+
 export function getLayoutStackSignature(
   items: ReadonlyArray<Pick<LayoutStackItem, "key" | "layoutKey">>
 ): string {
   return items.map((item) => item.layoutKey ?? item.key).join("|");
+}
+
+export function getReservedLayoutStackHeightPx(
+  props: ReservedLayoutStackHeightProps
+): number | null {
+  if (!props.isHydrating) {
+    return null;
+  }
+
+  const reservedStackHeight =
+    props.stackHeightByWorkspaceId.get(props.workspaceId) ?? props.fallbackStackHeightPx;
+  return reservedStackHeight > 0 ? reservedStackHeight : null;
+}
+
+export function measureLayoutStackHeightPx(
+  content: HTMLElement,
+  observedHeightPx?: number | null
+): number {
+  return Math.max(0, Math.round(observedHeightPx ?? content.getBoundingClientRect().height));
+}
+
+export function rememberLayoutStackHeight(
+  workspaceId: string,
+  heightPx: number,
+  stackHeightByWorkspaceId: Map<string, number>,
+  lastMeasuredStackHeightRef: MutableRefObject<number>
+): void {
+  lastMeasuredStackHeightRef.current = heightPx;
+  stackHeightByWorkspaceId.set(workspaceId, heightPx);
+}
+
+export function clearLayoutStackHeight(
+  workspaceId: string,
+  stackHeightByWorkspaceId: Map<string, number>,
+  lastMeasuredStackHeightRef: MutableRefObject<number>
+): void {
+  lastMeasuredStackHeightRef.current = 0;
+  stackHeightByWorkspaceId.set(workspaceId, 0);
+}
+
+export function scrollElementToBottom(element: HTMLElement | null): void {
+  if (!element) {
+    return;
+  }
+
+  element.scrollTop = element.scrollHeight;
 }

--- a/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.tsx
+++ b/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.tsx
@@ -6,43 +6,48 @@ import { isLocalProjectRuntime } from "@/common/types/runtime";
 import type { RuntimeConfig } from "@/common/types/runtime";
 import { useSyncExternalStore } from "react";
 
-/**
- * Subtle indicator shown when a local project-dir workspace has another workspace
- * for the same project that is currently streaming.
- */
-export const ConcurrentLocalWarning: React.FC<{
+interface ConcurrentLocalWarningProps {
   workspaceId: string;
   projectPath: string;
   runtimeConfig?: RuntimeConfig;
-}> = (props) => {
-  // Only show for local project-dir runtimes (not worktree or SSH)
-  const isLocalProject = isLocalProjectRuntime(props.runtimeConfig);
+}
 
+/**
+ * Returns the name of another local-project workspace that is actively streaming in the same
+ * project directory, or null when there is no conflicting local stream to warn about.
+ */
+export function useConcurrentLocalStreamingWorkspaceName(
+  props: ConcurrentLocalWarningProps
+): string | null {
+  const isLocalProject = isLocalProjectRuntime(props.runtimeConfig);
   const { workspaceMetadata } = useWorkspaceContext();
   const store = useWorkspaceStoreRaw();
 
-  // Find other local project-dir workspaces for the same project
   const otherLocalWorkspaceIds = useMemo(() => {
-    if (!isLocalProject) return [];
+    if (!isLocalProject) {
+      return [];
+    }
 
     const result: string[] = [];
     for (const [id, meta] of workspaceMetadata) {
-      // Skip current workspace
-      if (id === props.workspaceId) continue;
-      // Must be same project
-      if (meta.projectPath !== props.projectPath) continue;
-      // Must also be local project-dir runtime
-      if (!isLocalProjectRuntime(meta.runtimeConfig)) continue;
+      if (id === props.workspaceId) {
+        continue;
+      }
+      if (meta.projectPath !== props.projectPath) {
+        continue;
+      }
+      if (!isLocalProjectRuntime(meta.runtimeConfig)) {
+        continue;
+      }
       result.push(id);
     }
     return result;
-  }, [isLocalProject, workspaceMetadata, props.workspaceId, props.projectPath]);
+  }, [isLocalProject, props.projectPath, props.workspaceId, workspaceMetadata]);
 
-  // Subscribe to streaming state of other local workspaces
-  const streamingWorkspaceName = useSyncExternalStore(
+  return useSyncExternalStore(
     (listener) => {
       const unsubscribers = otherLocalWorkspaceIds.map((id) => store.subscribeKey(id, listener));
-      return () => unsubscribers.forEach((unsub) => unsub());
+      return () => unsubscribers.forEach((unsubscribe) => unsubscribe());
     },
     () => {
       for (const id of otherLocalWorkspaceIds) {
@@ -53,22 +58,34 @@ export const ConcurrentLocalWarning: React.FC<{
             return meta?.name ?? id;
           }
         } catch {
-          // Workspace may not be registered yet, skip
+          // Workspace may not be registered yet, skip.
         }
       }
       return null;
-    }
+    },
+    () => null
   );
+}
 
-  if (!isLocalProject || !streamingWorkspaceName) {
-    return null;
-  }
-
+export const ConcurrentLocalWarningView: React.FC<{ streamingWorkspaceName: string }> = (props) => {
   return (
     <div className="text-center text-xs text-yellow-600/80">
       <AlertTriangle aria-hidden="true" className="mr-1 inline-block h-3 w-3 align-[-2px]" />
-      <span className="text-yellow-500">{streamingWorkspaceName}</span> is also running in this
-      project directory — agents may interfere
+      <span className="text-yellow-500">{props.streamingWorkspaceName}</span> is also running in
+      this project directory — agents may interfere
     </div>
   );
+};
+
+/**
+ * Subtle indicator shown when a local project-dir workspace has another workspace
+ * for the same project that is currently streaming.
+ */
+export const ConcurrentLocalWarning: React.FC<ConcurrentLocalWarningProps> = (props) => {
+  const streamingWorkspaceName = useConcurrentLocalStreamingWorkspaceName(props);
+  if (!streamingWorkspaceName) {
+    return null;
+  }
+
+  return <ConcurrentLocalWarningView streamingWorkspaceName={streamingWorkspaceName} />;
 };

--- a/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.tsx
+++ b/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.tsx
@@ -1,10 +1,9 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useSyncExternalStore } from "react";
 import { AlertTriangle } from "lucide-react";
 import { useWorkspaceContext } from "@/browser/contexts/WorkspaceContext";
 import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
 import { isLocalProjectRuntime } from "@/common/types/runtime";
 import type { RuntimeConfig } from "@/common/types/runtime";
-import { useSyncExternalStore } from "react";
 
 interface ConcurrentLocalWarningProps {
   workspaceId: string;

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -1720,6 +1720,116 @@ describe("WorkspaceStore", () => {
       releaseCaughtUp();
     });
 
+    it("surfaces buffered stream-start state before caught-up during hydration", async () => {
+      const workspaceId = "buffered-stream-start-before-caught-up";
+      const streamModel = "anthropic:claude-opus-4-6";
+      const thinkingLevel = "high";
+      let releaseCaughtUp!: () => void;
+      const caughtUpReady = new Promise<void>((resolve) => {
+        releaseCaughtUp = resolve;
+      });
+
+      mockOnChat.mockImplementation(async function* (
+        input?: { workspaceId: string; mode?: unknown },
+        options?: { signal?: AbortSignal }
+      ): AsyncGenerator<WorkspaceChatMessage, void, unknown> {
+        if (input?.workspaceId !== workspaceId) {
+          await waitForAbortSignal(options?.signal);
+          return;
+        }
+
+        yield {
+          type: "stream-start",
+          workspaceId,
+          messageId: "buffered-stream-start-message",
+          model: streamModel,
+          thinkingLevel,
+          historySequence: 1,
+          startTime: 1_000,
+        };
+        await caughtUpReady;
+        yield { type: "caught-up", replay: "full" };
+        await waitForAbortSignal(options?.signal);
+      });
+
+      createAndAddWorkspace(store, workspaceId);
+
+      const showedStreamingStateDuringHydration = await waitUntil(() => {
+        const state = store.getWorkspaceState(workspaceId);
+        return (
+          state.loading === true &&
+          state.isHydratingTranscript === true &&
+          state.canInterrupt === true &&
+          state.currentModel === streamModel &&
+          state.currentThinkingLevel === thinkingLevel
+        );
+      });
+      expect(showedStreamingStateDuringHydration).toBe(true);
+      expect(store.getWorkspaceState(workspaceId).messages).toHaveLength(0);
+
+      releaseCaughtUp();
+    });
+
+    it("prefers buffered stream-start state over stale non-streaming activity during hydration", async () => {
+      const workspaceId = "buffered-stream-start-over-activity";
+      const staleActivityModel = "openai:gpt-4o-mini";
+      const streamModel = "anthropic:claude-opus-4-6";
+      const thinkingLevel = "high";
+      let releaseCaughtUp!: () => void;
+      const caughtUpReady = new Promise<void>((resolve) => {
+        releaseCaughtUp = resolve;
+      });
+
+      mockActivityList.mockResolvedValue({
+        [workspaceId]: {
+          recency: 3_000,
+          streaming: false,
+          lastModel: staleActivityModel,
+          lastThinkingLevel: null,
+        },
+      });
+      recreateStore();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      mockOnChat.mockImplementation(async function* (
+        input?: { workspaceId: string; mode?: unknown },
+        options?: { signal?: AbortSignal }
+      ): AsyncGenerator<WorkspaceChatMessage, void, unknown> {
+        if (input?.workspaceId !== workspaceId) {
+          await waitForAbortSignal(options?.signal);
+          return;
+        }
+
+        yield {
+          type: "stream-start",
+          workspaceId,
+          messageId: "buffered-stream-start-over-activity-message",
+          model: streamModel,
+          thinkingLevel,
+          historySequence: 1,
+          startTime: 1_000,
+        };
+        await caughtUpReady;
+        yield { type: "caught-up", replay: "full" };
+        await waitForAbortSignal(options?.signal);
+      });
+
+      createAndAddWorkspace(store, workspaceId);
+
+      const preferredBufferedStreamState = await waitUntil(() => {
+        const state = store.getWorkspaceState(workspaceId);
+        return (
+          state.loading === true &&
+          state.canInterrupt === true &&
+          state.currentModel === streamModel &&
+          state.currentThinkingLevel === thinkingLevel
+        );
+      });
+      expect(preferredBufferedStreamState).toBe(true);
+
+      releaseCaughtUp();
+    });
+
     it("replays runtime-status before caught-up when switching back to a preparing workspace", async () => {
       const workspaceId = "stream-starting-runtime-status-replay";
       const otherWorkspaceId = "stream-starting-runtime-status-other";

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -2467,6 +2467,36 @@ describe("WorkspaceStore", () => {
       expect(state.recencyTimestamp).toBe(activitySnapshot.recency);
     });
 
+    it("keeps activity snapshots authoritative for non-active stream state", async () => {
+      const workspaceId = "activity-false-over-stale-aggregator";
+      const activitySnapshot: WorkspaceActivitySnapshot = {
+        recency: new Date("2024-01-04T08:00:00.000Z").getTime(),
+        streaming: false,
+        lastModel: "claude-sonnet-4",
+        lastThinkingLevel: null,
+      };
+
+      recreateStore();
+      mockActivityList.mockResolvedValue({ [workspaceId]: activitySnapshot });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      createAndAddWorkspace(store, workspaceId, { createdAt: "2020-01-01T00:00:00.000Z" }, false);
+
+      const aggregator = store.getAggregator(workspaceId);
+      expect(aggregator).toBeDefined();
+      aggregator?.handleStreamStart({
+        type: "stream-start",
+        workspaceId,
+        messageId: "stale-active-stream",
+        model: "claude-sonnet-4",
+        historySequence: 1,
+        startTime: 1_000,
+      });
+
+      const state = store.getWorkspaceState(workspaceId);
+      expect(state.canInterrupt).toBe(false);
+    });
+
     it("falls back to persisted activity todoStatus for active workspaces when replayed todos are absent", async () => {
       const workspaceId = "active-activity-todo-fallback";
       const activitySnapshot: WorkspaceActivitySnapshot = {

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -1828,6 +1828,53 @@ describe("WorkspaceStore", () => {
       releaseCaughtUp();
     });
 
+    it("refreshes cached state when replayed stream-error clears buffered stream-start during hydration", async () => {
+      const workspaceId = "buffered-stream-error-clears-stream-start";
+      const streamModel = "anthropic:claude-opus-4-6";
+
+      mockOnChat.mockImplementation(async function* (
+        _input?: { workspaceId: string; mode?: unknown },
+        options?: { signal?: AbortSignal }
+      ): AsyncGenerator<WorkspaceChatMessage, void, unknown> {
+        if (options?.signal?.aborted) {
+          yield { type: "caught-up" };
+        }
+        await waitForAbortSignal(options?.signal);
+      });
+
+      recreateStore();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      createAndAddWorkspace(store, workspaceId);
+
+      const rawStore = store as unknown as {
+        handleChatMessage: (workspaceId: string, data: WorkspaceChatMessage) => void;
+      };
+
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-start",
+        workspaceId,
+        messageId: "buffered-stream-error-message",
+        model: streamModel,
+        historySequence: 1,
+        startTime: 1_000,
+      });
+
+      const initialState = store.getWorkspaceState(workspaceId);
+      expect(initialState.canInterrupt).toBe(true);
+      expect(initialState.currentModel).toBe(streamModel);
+
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-error",
+        messageId: "buffered-stream-error-message",
+        error: "Mock replayed failure",
+        errorType: "unknown",
+        replay: true,
+      });
+
+      const clearedState = store.getWorkspaceState(workspaceId);
+      expect(clearedState.canInterrupt).toBe(false);
+    });
+
     it("prefers buffered stream-start state over stale non-streaming activity during hydration", async () => {
       const workspaceId = "buffered-stream-start-over-activity";
       const staleActivityModel = "openai:gpt-4o-mini";

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -1770,6 +1770,64 @@ describe("WorkspaceStore", () => {
       releaseCaughtUp();
     });
 
+    it("refreshes cached state when buffered stream-start arrives during hydration", async () => {
+      const workspaceId = "buffered-stream-start-cache-bump";
+      const streamModel = "anthropic:claude-opus-4-6";
+      let releaseStreamStart!: () => void;
+      const streamStartReady = new Promise<void>((resolve) => {
+        releaseStreamStart = resolve;
+      });
+      let releaseCaughtUp!: () => void;
+      const caughtUpReady = new Promise<void>((resolve) => {
+        releaseCaughtUp = resolve;
+      });
+
+      mockOnChat.mockImplementation(async function* (
+        input?: { workspaceId: string; mode?: unknown },
+        options?: { signal?: AbortSignal }
+      ): AsyncGenerator<WorkspaceChatMessage, void, unknown> {
+        if (input?.workspaceId !== workspaceId) {
+          await waitForAbortSignal(options?.signal);
+          return;
+        }
+
+        await streamStartReady;
+        yield {
+          type: "stream-start",
+          workspaceId,
+          messageId: "buffered-stream-start-cache-bump-message",
+          model: streamModel,
+          historySequence: 1,
+          startTime: 1_000,
+        };
+        await caughtUpReady;
+        yield { type: "caught-up", replay: "full" };
+        await waitForAbortSignal(options?.signal);
+      });
+
+      createAndAddWorkspace(store, workspaceId);
+
+      const initialState = store.getWorkspaceState(workspaceId);
+      expect(initialState.loading).toBe(true);
+      expect(initialState.canInterrupt).toBe(false);
+      expect(initialState.currentModel).toBeNull();
+
+      releaseStreamStart();
+
+      const updatedStreamingState = await waitUntil(() => {
+        const state = store.getWorkspaceState(workspaceId);
+        return (
+          state.loading === true &&
+          state.isHydratingTranscript === true &&
+          state.canInterrupt === true &&
+          state.currentModel === streamModel
+        );
+      });
+      expect(updatedStreamingState).toBe(true);
+
+      releaseCaughtUp();
+    });
+
     it("prefers buffered stream-start state over stale non-streaming activity during hydration", async () => {
       const workspaceId = "buffered-stream-start-over-activity";
       const staleActivityModel = "openai:gpt-4o-mini";

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -3687,8 +3687,10 @@ export class WorkspaceStore {
       // failure classification/copy as the live session, then replay them again after
       // history loads so full-replay replacement does not wipe the error back out.
       applyWorkspaceChatEventToAggregator(aggregator, data, { allowSideEffects: false });
-      this.states.bump(workspaceId);
       transient.pendingStreamEvents.push(data);
+      // WorkspaceState may now clear its buffered active-stream fallback based on the appended
+      // terminal error, so invalidate after the pending-events snapshot is up to date.
+      this.states.bump(workspaceId);
       return;
     }
 

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -3502,6 +3502,19 @@ export class WorkspaceStore {
     return this.aggregators.get(workspaceId)!;
   }
 
+  private shouldBumpStateForBufferedStreamFallback(data: WorkspaceChatMessage): boolean {
+    if (!("type" in data)) {
+      return false;
+    }
+
+    return (
+      data.type === "stream-start" ||
+      data.type === "stream-end" ||
+      data.type === "stream-abort" ||
+      data.type === "stream-error"
+    );
+  }
+
   /**
    * Check if data is a buffered event type by checking the handler map.
    * This ensures isStreamEvent() and processStreamEvent() can never fall out of sync.
@@ -3703,6 +3716,11 @@ export class WorkspaceStore {
       }
 
       transient.pendingStreamEvents.push(data);
+      if (this.shouldBumpStateForBufferedStreamFallback(data)) {
+        // WorkspaceState now derives the streaming barrier fallback from pending stream events,
+        // so buffered start/terminal transitions must invalidate the memoized hydration snapshot.
+        this.states.bump(workspaceId);
+      }
       return;
     }
 

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -1615,9 +1615,9 @@ export class WorkspaceStore {
       const useAggregatorState = isActiveWorkspace && transient.caughtUp;
       const canInterrupt = useAggregatorState
         ? activeStreams.length > 0
-        : bufferedActiveStreamStart !== null ||
-          activity?.streaming === true ||
-          activeStreams.length > 0;
+        : bufferedActiveStreamStart !== null
+          ? true
+          : (activity?.streaming ?? activeStreams.length > 0);
       const currentModel = useAggregatorState
         ? (aggregator.getCurrentModel() ?? null)
         : (bufferedActiveStreamStart?.model ??

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -48,6 +48,7 @@ import {
   type StreamAbortEvent,
   type StreamAbortReasonSnapshot,
   type StreamEndEvent,
+  type StreamStartEvent,
   type RuntimeStatusEvent,
 } from "@/common/types/stream";
 import { MapStore } from "./MapStore";
@@ -239,6 +240,42 @@ function createInitialHistoryPaginationState(): WorkspaceHistoryPaginationState 
     nextCursor: null,
     hasOlder: false,
     loading: false,
+  };
+}
+
+function getBufferedActiveStreamStart(
+  events: WorkspaceChatMessage[]
+): Pick<StreamStartEvent, "model" | "thinkingLevel"> | null {
+  let activeStreamStart: StreamStartEvent | null = null;
+
+  for (const event of events) {
+    if (!("type" in event)) {
+      continue;
+    }
+
+    if (event.type === "stream-start") {
+      activeStreamStart = event;
+      continue;
+    }
+
+    if (
+      activeStreamStart !== null &&
+      (event.type === "stream-end" ||
+        event.type === "stream-abort" ||
+        event.type === "stream-error") &&
+      event.messageId === activeStreamStart.messageId
+    ) {
+      activeStreamStart = null;
+    }
+  }
+
+  if (!activeStreamStart) {
+    return null;
+  }
+
+  return {
+    model: activeStreamStart.model,
+    thinkingLevel: activeStreamStart.thinkingLevel,
   };
 }
 
@@ -1558,11 +1595,18 @@ export class WorkspaceStore {
       const metadata = this.workspaceMetadata.get(workspaceId);
       const pendingStreamStartTime = aggregator.getPendingStreamStartTime();
       const streamLifecycle = aggregator.getStreamLifecycle();
+      const bufferedActiveStreamStart =
+        isActiveWorkspace && !transient.caughtUp
+          ? getBufferedActiveStreamStart(transient.pendingStreamEvents)
+          : null;
       // Trust the live aggregator only when it is both active AND has finished
       // replaying historical events (caughtUp). During the replay window after a
       // workspace switch, the aggregator is cleared and re-hydrating; fall back to
-      // the activity snapshot so the UI continues to reflect the last known state
-      // (e.g., canInterrupt stays true for a workspace that is still streaming).
+      // the activity snapshot so the UI continues to reflect the last known state.
+      //
+      // Replayed stream-start events arrive on onChat before the authoritative caught-up marker.
+      // Surface that buffered active-stream context immediately so the transcript tail can show the
+      // live streaming barrier during hydration instead of inserting it a moment later.
       //
       // For non-active workspaces, the aggregator's activeStreams may be stale since
       // they don't receive stream-end events when unsubscribed from onChat. Prefer the
@@ -1571,13 +1615,21 @@ export class WorkspaceStore {
       const useAggregatorState = isActiveWorkspace && transient.caughtUp;
       const canInterrupt = useAggregatorState
         ? activeStreams.length > 0
-        : (activity?.streaming ?? activeStreams.length > 0);
+        : bufferedActiveStreamStart !== null ||
+          activity?.streaming === true ||
+          activeStreams.length > 0;
       const currentModel = useAggregatorState
         ? (aggregator.getCurrentModel() ?? null)
-        : (activity?.lastModel ?? aggregator.getCurrentModel() ?? null);
+        : (bufferedActiveStreamStart?.model ??
+          activity?.lastModel ??
+          aggregator.getCurrentModel() ??
+          null);
       const currentThinkingLevel = useAggregatorState
         ? (aggregator.getCurrentThinkingLevel() ?? null)
-        : (activity?.lastThinkingLevel ?? aggregator.getCurrentThinkingLevel() ?? null);
+        : (bufferedActiveStreamStart?.thinkingLevel ??
+          activity?.lastThinkingLevel ??
+          aggregator.getCurrentThinkingLevel() ??
+          null);
       const hasAuthoritativeStreamLifecycle =
         streamLifecycle !== null && streamLifecycle.phase !== "idle";
       const activePendingStreamStartTime = isActiveWorkspace ? pendingStreamStartTime : null;


### PR DESCRIPTION
## Summary

This PR now addresses the remaining transcript hydration tears from both sides: it still surfaces replay-buffered active-stream state early enough for the streaming barrier to render immediately, and it now restructures the volatile transcript/layout seams so tail chrome, inline interruption markers, and composer-adjacent transcript resizing are stabilized by explicit lane owners instead of ad hoc `ChatPane` conditionals.

## Background

`#3152` and `#3173` removed the biggest startup/workspace-switch tears by keeping `ChatPane` mounted and stabilizing the decoration lane above `ChatInput`. The remaining follow-up that opened this PR was the transcript-tail streaming barrier: reopened streaming workspaces could still hydrate first and only later discover that a stream was already active.

Once that state-layer fix landed, a broader audit still found two architectural seams in the transcript itself:

- tail chrome (`RetryBarrier`, `StreamingBarrier`, queued-agent prompt, concurrent-local warning) was still rendered as ad hoc footer JSX in `ChatPane`
- inline interrupted markers were rendered from a second visibility path that `ChatPane` also had to remember in its bottom-pinning dependency list

That kept transcript stability dependent on a hand-maintained list of booleans instead of on the actual layout boundaries that can change height.

## Implementation

- keep the original `WorkspaceStore` hydration fix in place so replay-buffered `stream-start` events drive `canInterrupt`, `currentModel`, and `currentThinkingLevel` before `caught-up`
- add `TranscriptTailStack`, a dedicated tail-lane owner that:
  - renders all volatile transcript-tail chrome from a single item list
  - reserves per-workspace tail height during hydration
  - pins the transcript bottom when a tail item's layout signature changes or its measured height changes
- introduce a small shared `LayoutStackItem`/signature helper so lane owners can describe layout-affecting seams directly instead of teaching `ChatPane` about individual banner booleans
- move concurrent-local warning visibility into a hook + presentational view so `ChatPane` can model it as part of the tail lane, rather than as a self-subscribing child that appears out-of-band
- let `ChatInputPane` own transcript pinning for its decoration lane via one derived layout signature, instead of relying on `ChatPane` to remember which banner/todo states might resize the viewport from below
- derive interrupted-barrier visibility once per render and reuse that same decision for both row rendering and pre-paint transcript pinning, so inline interruption markers can no longer bypass the stabilization path

## Validation

- `bun test src/browser/components/ChatPane/TranscriptTailStack.test.tsx src/browser/components/ChatPane/ChatInputDecorationStack.test.tsx src/browser/stores/WorkspaceStore.test.ts`
- `bun test ./tests/ui/chat/bottomLayoutShift.test.ts ./tests/ui/chat/newChatStreamingFlash.test.ts ./tests/ui/chat/streamInterrupt.test.ts`
- `make static-check`

## Risks

The main regression risk is over-eager bottom pinning when the user has intentionally scrolled away from the tail. The new lane owners all gate their pinning on `autoScroll`, and the retry barrier still stays mounted behind a `visible` layout key so its rollback/auto-retry bookkeeping is preserved even while its rendered height drops to zero.

---

_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `xhigh` • Cost: `$330.21`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=xhigh costs=330.21 -->
