### PR TITLE
🤖 fix: keep main workspace agent selection on metadata sync

### DIFF
--- a/src/browser/contexts/WorkspaceContext.test.tsx
+++ b/src/browser/contexts/WorkspaceContext.test.tsx
@@ -11,6 +11,7 @@ import {
   LAST_VISITED_ROUTE_KEY,
   LAUNCH_BEHAVIOR_KEY,
   SELECTED_WORKSPACE_KEY,
+  getAgentIdKey,
   getModelKey,
   getRightSidebarLayoutKey,
   getTerminalTitlesKey,
@@ -488,6 +489,80 @@ describe("WorkspaceContext", () => {
       "xhigh"
     );
   });
+  test("stale metadata does not override a main workspace agent selection", async () => {
+    const workspaceId = "ws-agent-main";
+    let emitMetadata:
+      | ((event: { workspaceId: string; metadata: FrontendWorkspaceMetadata | null }) => void)
+      | null = null;
+
+    createMockAPI({
+      workspace: {
+        list: () => Promise.resolve([createWorkspaceMetadata({ id: workspaceId })]),
+        onMetadata: () =>
+          Promise.resolve(
+            (async function* () {
+              const event = await new Promise<{
+                workspaceId: string;
+                metadata: FrontendWorkspaceMetadata | null;
+              }>((resolve) => {
+                emitMetadata = resolve;
+              });
+              yield event;
+            })() as unknown as Awaited<ReturnType<APIClient["workspace"]["onMetadata"]>>
+          ),
+      },
+      localStorage: {
+        [getAgentIdKey(workspaceId)]: JSON.stringify("exec"),
+      },
+    });
+
+    const ctx = await setup();
+
+    await waitFor(() => expect(ctx().workspaceMetadata.size).toBe(1));
+    await waitFor(() => expect(emitMetadata).toBeTruthy());
+
+    act(() => {
+      emitMetadata?.({
+        workspaceId,
+        metadata: createWorkspaceMetadata({ id: workspaceId, agentId: "plan" }),
+      });
+    });
+
+    await waitFor(() =>
+      expect(readPersistedState<string | undefined>(getAgentIdKey(workspaceId), undefined)).toBe(
+        "exec"
+      )
+    );
+  });
+
+  test("child workspace metadata still seeds the locked backend agent", async () => {
+    const workspaceId = "ws-agent-child";
+
+    createMockAPI({
+      workspace: {
+        list: () =>
+          Promise.resolve([
+            createWorkspaceMetadata({
+              id: workspaceId,
+              parentWorkspaceId: "ws-parent",
+              agentType: "plan",
+            }),
+          ]),
+      },
+      localStorage: {
+        [getAgentIdKey(workspaceId)]: JSON.stringify("exec"),
+      },
+    });
+
+    const ctx = await setup();
+
+    await waitFor(() => expect(ctx().workspaceMetadata.size).toBe(1));
+
+    expect(readPersistedState<string | undefined>(getAgentIdKey(workspaceId), undefined)).toBe(
+      "plan"
+    );
+  });
+
   test("loads workspace metadata on mount", async () => {
     const initialWorkspaces: FrontendWorkspaceMetadata[] = [
       createWorkspaceMetadata({

--- a/src/browser/contexts/WorkspaceContext.test.tsx
+++ b/src/browser/contexts/WorkspaceContext.test.tsx
@@ -520,6 +520,7 @@ describe("WorkspaceContext", () => {
 
     await waitFor(() => expect(ctx().workspaceMetadata.size).toBe(1));
     await waitFor(() => expect(emitMetadata).toBeTruthy());
+    expect(ctx().workspaceMetadata.get(workspaceId)?.agentId).toBeUndefined();
 
     act(() => {
       emitMetadata?.({
@@ -528,10 +529,9 @@ describe("WorkspaceContext", () => {
       });
     });
 
-    await waitFor(() =>
-      expect(readPersistedState<string | undefined>(getAgentIdKey(workspaceId), undefined)).toBe(
-        "exec"
-      )
+    await waitFor(() => expect(ctx().workspaceMetadata.get(workspaceId)?.agentId).toBe("plan"));
+    expect(readPersistedState<string | undefined>(getAgentIdKey(workspaceId), undefined)).toBe(
+      "exec"
     );
   });
 

--- a/src/browser/contexts/WorkspaceContext.tsx
+++ b/src/browser/contexts/WorkspaceContext.tsx
@@ -157,6 +157,12 @@ function migrateLocalGatewayPrefsToBackend(
   }
 }
 
+function shouldSeedWorkspaceAgentIdFromBackend(metadata: FrontendWorkspaceMetadata): boolean {
+  // Main workspaces own their live agent selection in localStorage. Child/task
+  // workspaces are backend-defined and locked, so they must re-seed from metadata.
+  return metadata.parentWorkspaceId != null;
+}
+
 /**
  * Seed per-workspace localStorage from backend workspace metadata.
  *
@@ -170,10 +176,12 @@ function seedWorkspaceLocalStorageFromBackend(metadata: FrontendWorkspaceMetadat
 
   const workspaceId = metadata.id;
 
-  // Seed the workspace agentId (tasks/subagents) so the UI renders correctly on reload.
-  // Main workspaces default to the locally-selected agentId (stored in localStorage).
   const metadataAgentId = metadata.agentId ?? metadata.agentType;
-  if (typeof metadataAgentId === "string" && metadataAgentId.trim().length > 0) {
+  if (
+    shouldSeedWorkspaceAgentIdFromBackend(metadata) &&
+    typeof metadataAgentId === "string" &&
+    metadataAgentId.trim().length > 0
+  ) {
     const key = getAgentIdKey(workspaceId);
     const normalized = normalizeAgentId(metadataAgentId);
     const existing = readPersistedState<string | undefined>(key, undefined);


### PR DESCRIPTION
## Summary
Prevent model-change metadata syncs from reverting a main workspace back to a stale backend agent selection.

## Background
Main workspaces treat the current agent as a local UI preference, but metadata updates from backend model-sync paths were still re-seeding `agentId` from persisted config. That meant a stale backend `agentId` like `plan` could overwrite a newer local `exec` selection when the user changed models. Child workspaces are different: their agent is backend-owned and intentionally locked.

## Implementation
Add a `shouldSeedWorkspaceAgentIdFromBackend` guard in `WorkspaceContext` and only apply backend `agentId` / `agentType` seeding for child workspaces with `parentWorkspaceId`. Keep the existing model/thinking reconciliation logic unchanged. Add focused `WorkspaceContext` regression tests that verify stale metadata no longer overrides main-workspace agent selection while child workspaces still seed their locked backend agent.

## Validation
The new regression coverage exercises the reported main-workspace path where stale metadata arrives after local agent selection, and separately confirms child workspaces still honor backend agent locking. Local `make static-check` and the focused `WorkspaceContext` test file passed before opening this PR.

## Risks
Low and front-end scoped. The change only narrows when backend metadata is allowed to overwrite persisted `agentId`, and it uses the same `parentWorkspaceId != null` lock boundary that `AgentContext` already trusts for child workspaces.

---

_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `xhigh` • Cost: `$11.54`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=xhigh costs=11.54 -->
