### PR TITLE
🤖 feat: preserve sub-agent workspaces until archive

### DIFF
--- a/src/browser/features/Settings/Sections/TasksSection.tsx
+++ b/src/browser/features/Settings/Sections/TasksSection.tsx
@@ -179,6 +179,7 @@ function areTaskSettingsEqual(a: TaskSettings, b: TaskSettings): boolean {
     a.maxParallelAgentTasks === b.maxParallelAgentTasks &&
     a.maxTaskNestingDepth === b.maxTaskNestingDepth &&
     a.proposePlanImplementReplacesChatHistory === b.proposePlanImplementReplacesChatHistory &&
+    a.preserveSubagentsUntilArchive === b.preserveSubagentsUntilArchive &&
     a.planSubagentExecutorRouting === b.planSubagentExecutorRouting &&
     a.planSubagentDefaultsToOrchestrator === b.planSubagentDefaultsToOrchestrator &&
     a.bashOutputCompactionMinLines === b.bashOutputCompactionMinLines &&
@@ -504,6 +505,12 @@ export function TasksSection() {
   const setProposePlanImplementReplacesChatHistory = (value: boolean) => {
     setTaskSettings((prev) =>
       normalizeTaskSettings({ ...prev, proposePlanImplementReplacesChatHistory: value })
+    );
+  };
+
+  const setPreserveSubagentsUntilArchive = (value: boolean) => {
+    setTaskSettings((prev) =>
+      normalizeTaskSettings({ ...prev, preserveSubagentsUntilArchive: value })
     );
   };
 
@@ -1017,6 +1024,23 @@ export function TasksSection() {
               checked={taskSettings.proposePlanImplementReplacesChatHistory ?? false}
               onCheckedChange={setProposePlanImplementReplacesChatHistory}
               aria-label="Toggle plan Implement replaces conversation with plan"
+            />
+          </div>
+
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex-1">
+              <div className="text-foreground text-sm">
+                Preserve subagents until the workspace gets archived
+              </div>
+              <div className="text-muted text-xs">
+                Completed sub-agent workspaces stay visible and expandable until an ancestor
+                workspace is archived, then cleanup runs automatically.
+              </div>
+            </div>
+            <Switch
+              checked={taskSettings.preserveSubagentsUntilArchive ?? false}
+              onCheckedChange={setPreserveSubagentsUntilArchive}
+              aria-label="Toggle preserve subagents until archive"
             />
           </div>
 

--- a/src/common/config/schemas/taskSettings.ts
+++ b/src/common/config/schemas/taskSettings.ts
@@ -30,6 +30,7 @@ export const TaskSettingsSchema = z.object({
     .max(TASK_SETTINGS_LIMITS.maxTaskNestingDepth.max)
     .optional(),
   proposePlanImplementReplacesChatHistory: z.boolean().optional(),
+  preserveSubagentsUntilArchive: z.boolean().optional(),
   planSubagentExecutorRouting: PlanSubagentExecutorRoutingSchema.optional(),
   planSubagentDefaultsToOrchestrator: z.boolean().optional(),
   bashOutputCompactionMinLines: z

--- a/src/common/types/tasks.test.ts
+++ b/src/common/types/tasks.test.ts
@@ -13,6 +13,21 @@ describe("normalizeTaskSettings", () => {
     expect(normalizeTaskSettings({})).toEqual(DEFAULT_TASK_SETTINGS);
   });
 
+  test("defaults include preserveSubagentsUntilArchive: false", () => {
+    const normalized = normalizeTaskSettings(undefined);
+    expect(normalized.preserveSubagentsUntilArchive).toBe(false);
+  });
+
+  test("explicit preserveSubagentsUntilArchive true survives normalization", () => {
+    const normalized = normalizeTaskSettings({ preserveSubagentsUntilArchive: true });
+    expect(normalized.preserveSubagentsUntilArchive).toBe(true);
+  });
+
+  test("missing preserveSubagentsUntilArchive falls back to default", () => {
+    const normalized = normalizeTaskSettings({});
+    expect(normalized.preserveSubagentsUntilArchive).toBe(false);
+  });
+
   test("clamps values into valid ranges", () => {
     const normalized = normalizeTaskSettings({
       maxParallelAgentTasks: 999,

--- a/src/common/types/tasks.ts
+++ b/src/common/types/tasks.ts
@@ -29,6 +29,7 @@ export const DEFAULT_TASK_SETTINGS: TaskSettings = {
   maxParallelAgentTasks: TASK_SETTINGS_LIMITS.maxParallelAgentTasks.default,
   maxTaskNestingDepth: TASK_SETTINGS_LIMITS.maxTaskNestingDepth.default,
   proposePlanImplementReplacesChatHistory: false,
+  preserveSubagentsUntilArchive: false,
   planSubagentExecutorRouting: "auto",
   planSubagentDefaultsToOrchestrator: false,
 
@@ -111,6 +112,11 @@ export function normalizeTaskSettings(raw: unknown): TaskSettings {
       ? record.proposePlanImplementReplacesChatHistory
       : (DEFAULT_TASK_SETTINGS.proposePlanImplementReplacesChatHistory ?? false);
 
+  const preserveSubagentsUntilArchive =
+    typeof record.preserveSubagentsUntilArchive === "boolean"
+      ? record.preserveSubagentsUntilArchive
+      : DEFAULT_TASK_SETTINGS.preserveSubagentsUntilArchive;
+
   const normalizedPlanSubagentExecutorRouting = isPlanSubagentExecutorRouting(
     record.planSubagentExecutorRouting
   )
@@ -168,6 +174,7 @@ export function normalizeTaskSettings(raw: unknown): TaskSettings {
     maxParallelAgentTasks,
     maxTaskNestingDepth,
     proposePlanImplementReplacesChatHistory,
+    preserveSubagentsUntilArchive,
     planSubagentExecutorRouting,
     planSubagentDefaultsToOrchestrator,
     bashOutputCompactionMinLines,
@@ -189,6 +196,10 @@ export function normalizeTaskSettings(raw: unknown): TaskSettings {
   assert(
     typeof proposePlanImplementReplacesChatHistory === "boolean",
     "normalizeTaskSettings: proposePlanImplementReplacesChatHistory must be a boolean"
+  );
+  assert(
+    typeof preserveSubagentsUntilArchive === "boolean",
+    "normalizeTaskSettings: preserveSubagentsUntilArchive must be a boolean"
   );
 
   assert(

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -4,8 +4,9 @@ import * as path from "path";
 import * as os from "os";
 import { execSync } from "node:child_process";
 
-import { Config } from "@/node/config";
+import { Config, type Workspace as WorkspaceConfigEntry } from "@/node/config";
 import { HistoryService } from "@/node/services/historyService";
+import * as subagentGitPatchArtifacts from "@/node/services/subagentGitPatchArtifacts";
 import {
   getSubagentGitPatchMboxPath,
   readSubagentGitPatchArtifact,
@@ -8631,6 +8632,322 @@ describe("TaskService", () => {
         .map((workspace) => workspace.id)
     );
     expect(remainingWorkspaceIds).toEqual(new Set([rootWorkspaceId]));
+  });
+
+  describe("preserve subagents until archive", () => {
+    interface ReportedTaskNode {
+      id: string;
+      directoryName: string;
+      name: string;
+      agentType: string;
+      taskStatus?: "reported" | "interrupted";
+      reportedAt?: string;
+    }
+
+    type TaskCleanupEligibility =
+      | { ok: true; parentWorkspaceId: string }
+      | { ok: false; reason: string };
+
+    interface TaskServiceCleanupInternals {
+      canCleanupReportedTask: (workspaceId: string) => Promise<TaskCleanupEligibility>;
+      cleanupReportedLeafTask: (workspaceId: string) => Promise<void>;
+    }
+
+    async function archiveWorkspaceInTestConfig(
+      config: Config,
+      workspaceId: string,
+      archivedAt = "2026-03-10T00:00:00.000Z"
+    ): Promise<void> {
+      let archived = false;
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const workspace = project.workspaces.find((entry) => entry.id === workspaceId);
+          if (!workspace) {
+            continue;
+          }
+
+          workspace.archivedAt = archivedAt;
+          workspace.unarchivedAt = undefined;
+          archived = true;
+          break;
+        }
+        return cfg;
+      });
+      assert(archived, `Expected workspace ${workspaceId} to exist in test config`);
+    }
+
+    async function setupReportedTaskChain(options?: {
+      preserveSubagentsUntilArchive?: boolean;
+      taskChain?: ReportedTaskNode[];
+    }) {
+      const config = await createTestConfig(rootDir);
+
+      const projectPath = path.join(rootDir, "repo");
+      const rootWorkspaceId = "root-111";
+      const taskChain = options?.taskChain ?? [
+        {
+          id: "parent-222",
+          directoryName: "parent-task",
+          name: "agent_exec_parent",
+          agentType: "exec",
+          taskStatus: "reported" as const,
+        },
+        {
+          id: "child-333",
+          directoryName: "child-task",
+          name: "agent_explore_child",
+          agentType: "explore",
+          taskStatus: "reported" as const,
+        },
+      ];
+
+      const workspaces: WorkspaceConfigEntry[] = [
+        { path: path.join(projectPath, "root"), id: rootWorkspaceId, name: "root" },
+      ];
+      let parentWorkspaceId = rootWorkspaceId;
+      for (const task of taskChain) {
+        workspaces.push({
+          path: path.join(projectPath, task.directoryName),
+          id: task.id,
+          name: task.name,
+          parentWorkspaceId,
+          agentType: task.agentType,
+          taskStatus: task.taskStatus ?? "reported",
+          reportedAt: task.reportedAt,
+        });
+        parentWorkspaceId = task.id;
+      }
+
+      await config.saveConfig({
+        projects: new Map([
+          [
+            projectPath,
+            {
+              trusted: true,
+              workspaces,
+            },
+          ],
+        ]),
+        taskSettings: {
+          maxParallelAgentTasks: 3,
+          maxTaskNestingDepth: 5,
+          preserveSubagentsUntilArchive: options?.preserveSubagentsUntilArchive ?? true,
+        },
+      });
+
+      const isStreaming = mock(() => false);
+      const remove = mock(async (workspaceId: string, _force?: boolean): Promise<Result<void>> => {
+        await removeWorkspaceFromTestConfig(config, workspaceId);
+        return Ok(undefined);
+      });
+      const { aiService } = createAIServiceMocks(config, { isStreaming });
+      const { workspaceService } = createWorkspaceServiceMocks({ remove });
+      const { taskService } = createTaskServiceHarness(config, { aiService, workspaceService });
+      const internal = taskService as unknown as TaskServiceCleanupInternals;
+
+      return {
+        config,
+        taskService,
+        remove,
+        rootWorkspaceId,
+        taskChain,
+        internal,
+      };
+    }
+
+    test("cleanup is blocked when toggle is on and no ancestor is archived", async () => {
+      const { config, remove, taskChain, internal } = await setupReportedTaskChain();
+      const childTaskId = taskChain[1]?.id;
+      expect(childTaskId).toBe("child-333");
+      if (!childTaskId) {
+        return;
+      }
+
+      const cleanupEligibility = await internal.canCleanupReportedTask(childTaskId);
+      expect(cleanupEligibility).toEqual({ ok: false, reason: "preserved_until_archive" });
+
+      await internal.cleanupReportedLeafTask(childTaskId);
+
+      expect(remove).not.toHaveBeenCalled();
+      expect(findWorkspaceInConfig(config, childTaskId)).toBeTruthy();
+    });
+
+    test("startup recovery leaves preserved descendants alone before archive", async () => {
+      const { config, taskService, remove, taskChain } = await setupReportedTaskChain();
+      const childTaskId = taskChain[1]?.id;
+      expect(childTaskId).toBe("child-333");
+      if (!childTaskId) {
+        return;
+      }
+
+      await taskService.initialize();
+
+      expect(remove).not.toHaveBeenCalled();
+      expect(findWorkspaceInConfig(config, childTaskId)).toBeTruthy();
+    });
+
+    test("nested descendant becomes eligible once any archived ancestor exists", async () => {
+      const grandparentTaskId = "grandparent-000";
+      const parentTaskId = "parent-222";
+      const childTaskId = "child-333";
+      const { config, remove, internal } = await setupReportedTaskChain({
+        taskChain: [
+          {
+            id: grandparentTaskId,
+            directoryName: "grandparent-task",
+            name: "agent_exec_grandparent",
+            agentType: "exec",
+            taskStatus: "reported",
+          },
+          {
+            id: parentTaskId,
+            directoryName: "parent-task",
+            name: "agent_exec_parent",
+            agentType: "exec",
+            taskStatus: "reported",
+          },
+          {
+            id: childTaskId,
+            directoryName: "child-task",
+            name: "agent_explore_child",
+            agentType: "explore",
+            taskStatus: "reported",
+          },
+        ],
+      });
+
+      await archiveWorkspaceInTestConfig(config, grandparentTaskId);
+
+      const cleanupEligibility = await internal.canCleanupReportedTask(childTaskId);
+      expect(cleanupEligibility).toEqual({ ok: true, parentWorkspaceId: parentTaskId });
+
+      await internal.cleanupReportedLeafTask(childTaskId);
+
+      expect(remove.mock.calls).toEqual([
+        [childTaskId, true],
+        [parentTaskId, true],
+      ]);
+      expect(findWorkspaceInConfig(config, grandparentTaskId)).toBeTruthy();
+    });
+
+    test("pending patch artifacts still defer cleanup after archive", async () => {
+      const { config, remove, rootWorkspaceId, taskChain, internal } =
+        await setupReportedTaskChain();
+      const parentTaskId = taskChain[0]?.id;
+      const childTaskId = taskChain[1]?.id;
+      expect(parentTaskId).toBe("parent-222");
+      expect(childTaskId).toBe("child-333");
+      if (!parentTaskId || !childTaskId) {
+        return;
+      }
+
+      await archiveWorkspaceInTestConfig(config, rootWorkspaceId);
+
+      const pendingArtifact: Awaited<
+        ReturnType<typeof subagentGitPatchArtifacts.readSubagentGitPatchArtifact>
+      > = {
+        childTaskId,
+        parentWorkspaceId: parentTaskId,
+        createdAtMs: 1,
+        status: "pending",
+        projectArtifacts: [
+          {
+            projectPath: path.join(rootDir, "repo"),
+            projectName: "repo",
+            storageKey: "repo",
+            status: "pending",
+          },
+        ],
+        readyProjectCount: 0,
+        failedProjectCount: 0,
+        skippedProjectCount: 0,
+        totalCommitCount: 0,
+      };
+      const patchArtifactSpy = spyOn(
+        subagentGitPatchArtifacts,
+        "readSubagentGitPatchArtifact"
+      ).mockResolvedValue(pendingArtifact);
+
+      try {
+        const cleanupEligibility = await internal.canCleanupReportedTask(childTaskId);
+        expect(cleanupEligibility).toEqual({ ok: false, reason: "patch_pending" });
+
+        await internal.cleanupReportedLeafTask(childTaskId);
+
+        expect(remove).not.toHaveBeenCalled();
+        expect(findWorkspaceInConfig(config, childTaskId)).toBeTruthy();
+      } finally {
+        patchArtifactSpy.mockRestore();
+      }
+    });
+
+    test("with toggle off, current cleanup behavior remains unchanged", async () => {
+      const { config, remove, taskChain, internal } = await setupReportedTaskChain({
+        preserveSubagentsUntilArchive: false,
+      });
+      const parentTaskId = taskChain[0]?.id;
+      const childTaskId = taskChain[1]?.id;
+      expect(parentTaskId).toBe("parent-222");
+      expect(childTaskId).toBe("child-333");
+      if (!parentTaskId || !childTaskId) {
+        return;
+      }
+
+      await internal.cleanupReportedLeafTask(childTaskId);
+
+      expect(remove.mock.calls).toEqual([
+        [childTaskId, true],
+        [parentTaskId, true],
+      ]);
+      expect(findWorkspaceInConfig(config, childTaskId)).toBeUndefined();
+      expect(findWorkspaceInConfig(config, parentTaskId)).toBeUndefined();
+    });
+
+    test("archive-triggered cleanup removes descendants deepest-first", async () => {
+      const childTaskId = "child-222";
+      const grandchildTaskId = "grandchild-333";
+      const { config, taskService, remove, rootWorkspaceId } = await setupReportedTaskChain({
+        taskChain: [
+          {
+            id: childTaskId,
+            directoryName: "child-task",
+            name: "agent_exec_child",
+            agentType: "exec",
+            taskStatus: "reported",
+          },
+          {
+            id: grandchildTaskId,
+            directoryName: "grandchild-task",
+            name: "agent_explore_grandchild",
+            agentType: "explore",
+            taskStatus: "reported",
+          },
+        ],
+      });
+
+      await archiveWorkspaceInTestConfig(config, rootWorkspaceId);
+
+      await taskService.cleanupReportedDescendantsAfterArchive(rootWorkspaceId);
+
+      expect(remove.mock.calls).toEqual([
+        [grandchildTaskId, true],
+        [childTaskId, true],
+      ]);
+    });
+
+    test("hasPreservedCompletedDescendants returns true when descendants exist and toggle is on", async () => {
+      const { taskService, rootWorkspaceId } = await setupReportedTaskChain();
+
+      expect(taskService.hasPreservedCompletedDescendants(rootWorkspaceId)).toBe(true);
+    });
+
+    test("hasPreservedCompletedDescendants returns false when toggle is off", async () => {
+      const { taskService, rootWorkspaceId } = await setupReportedTaskChain({
+        preserveSubagentsUntilArchive: false,
+      });
+
+      expect(taskService.hasPreservedCompletedDescendants(rootWorkspaceId)).toBe(false);
+    });
   });
 
   describe("parent auto-resume flood protection", () => {

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -8935,6 +8935,56 @@ describe("TaskService", () => {
       ]);
     });
 
+    test("hasCompletedDescendants returns true when archived parent has pending-cleanup descendants", async () => {
+      const childTaskId = "child-333";
+      const { config, taskService, rootWorkspaceId } = await setupReportedTaskChain({
+        taskChain: [
+          {
+            id: childTaskId,
+            directoryName: "child-task",
+            name: "agent_explore_child",
+            agentType: "explore",
+            taskStatus: "reported",
+          },
+        ],
+      });
+
+      await archiveWorkspaceInTestConfig(config, rootWorkspaceId);
+
+      const pendingArtifact: Awaited<
+        ReturnType<typeof subagentGitPatchArtifacts.readSubagentGitPatchArtifact>
+      > = {
+        childTaskId,
+        parentWorkspaceId: rootWorkspaceId,
+        createdAtMs: 1,
+        status: "pending",
+        projectArtifacts: [
+          {
+            projectPath: path.join(rootDir, "repo"),
+            projectName: "repo",
+            storageKey: "repo",
+            status: "pending",
+          },
+        ],
+        readyProjectCount: 0,
+        failedProjectCount: 0,
+        skippedProjectCount: 0,
+        totalCommitCount: 0,
+      };
+      const patchArtifactSpy = spyOn(
+        subagentGitPatchArtifacts,
+        "readSubagentGitPatchArtifact"
+      ).mockResolvedValue(pendingArtifact);
+
+      try {
+        await taskService.cleanupReportedDescendantsAfterArchive(rootWorkspaceId);
+
+        expect(taskService.hasCompletedDescendants(rootWorkspaceId)).toBe(true);
+      } finally {
+        patchArtifactSpy.mockRestore();
+      }
+    });
+
     test("hasPreservedCompletedDescendants returns true when descendants exist and toggle is on", async () => {
       const { taskService, rootWorkspaceId } = await setupReportedTaskChain();
 

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -43,6 +43,7 @@ import { stripTrailingSlashes } from "@/node/utils/pathUtils";
 import { Ok, Err, type Result } from "@/common/types/result";
 import {
   DEFAULT_TASK_SETTINGS,
+  normalizeTaskSettings,
   type PlanSubagentExecutorRouting,
   type TaskSettings,
 } from "@/common/types/tasks";
@@ -87,6 +88,7 @@ import { secretsToRecord, type ExternalSecretResolver } from "@/common/types/sec
 import { getErrorMessage } from "@/common/utils/errors";
 import { isNonRetryableStreamError } from "@/common/utils/messages/retryEligibility";
 import { hasCompletedAgentReport } from "@/common/utils/agentTaskCompletion";
+import { isWorkspaceArchived } from "@/common/utils/archive";
 
 export type TaskKind = "agent";
 
@@ -1689,6 +1691,50 @@ export class TaskService {
     return interruptedTaskIds;
   }
 
+  async cleanupReportedDescendantsAfterArchive(workspaceId: string): Promise<void> {
+    assert(
+      workspaceId.length > 0,
+      "cleanupReportedDescendantsAfterArchive: workspaceId must be non-empty"
+    );
+
+    const cfg = this.config.loadConfigOrDefault();
+    const index = this.buildAgentTaskIndex(cfg);
+    const completedDescendants = this.listCompletedDescendantAgentTaskIds(index, workspaceId);
+    if (completedDescendants.length === 0) {
+      return;
+    }
+
+    const depthById = new Map<string, number>();
+    for (const descendantId of completedDescendants) {
+      depthById.set(descendantId, this.getTaskDepthFromParentById(index.parentById, descendantId));
+    }
+    completedDescendants.sort((a, b) => {
+      const depthDelta = (depthById.get(b) ?? 0) - (depthById.get(a) ?? 0);
+      return depthDelta !== 0 ? depthDelta : a.localeCompare(b);
+    });
+
+    log.debug("cleanupReportedDescendantsAfterArchive: rechecking completed descendants", {
+      workspaceId,
+      descendantCount: completedDescendants.length,
+    });
+
+    for (const descendantId of completedDescendants) {
+      try {
+        log.debug("cleanupReportedDescendantsAfterArchive: rechecking descendant", {
+          workspaceId,
+          descendantWorkspaceId: descendantId,
+        });
+        await this.cleanupReportedLeafTask(descendantId);
+      } catch (error: unknown) {
+        log.error("cleanupReportedDescendantsAfterArchive: failed to clean up descendant", {
+          workspaceId,
+          descendantWorkspaceId: descendantId,
+          error,
+        });
+      }
+    }
+  }
+
   private async rollbackFailedTaskCreate(
     runtime: Runtime,
     projectPath: string,
@@ -2132,6 +2178,25 @@ export class TaskService {
     return this.hasActiveDescendantAgentTasks(cfg, workspaceId);
   }
 
+  hasPreservedCompletedDescendants(workspaceId: string): boolean {
+    assert(
+      workspaceId.length > 0,
+      "hasPreservedCompletedDescendants: workspaceId must be non-empty"
+    );
+
+    const cfg = this.config.loadConfigOrDefault();
+    const taskSettings = normalizeTaskSettings(cfg.taskSettings);
+    if (!taskSettings.preserveSubagentsUntilArchive) {
+      return false;
+    }
+
+    const index = this.buildAgentTaskIndex(cfg);
+    const completedDescendants = this.listCompletedDescendantAgentTaskIds(index, workspaceId);
+    return completedDescendants.some(
+      (descendantId) => !this.hasArchivedAncestor(index, cfg, descendantId)
+    );
+  }
+
   listActiveDescendantAgentTaskIds(workspaceId: string): string[] {
     assert(
       workspaceId.length > 0,
@@ -2296,6 +2361,16 @@ export class TaskService {
     return result;
   }
 
+  private listCompletedDescendantAgentTaskIds(
+    index: AgentTaskIndex,
+    workspaceId: string
+  ): string[] {
+    return this.listDescendantAgentTaskIdsFromIndex(index, workspaceId).filter((taskId) => {
+      const entry = index.byId.get(taskId);
+      return entry != null && hasCompletedAgentReport(entry);
+    });
+  }
+
   async isDescendantAgentTask(ancestorWorkspaceId: string, taskId: string): Promise<boolean> {
     assert(ancestorWorkspaceId.length > 0, "isDescendantAgentTask: ancestorWorkspaceId required");
     assert(taskId.length > 0, "isDescendantAgentTask: taskId required");
@@ -2391,6 +2466,24 @@ export class TaskService {
     }
 
     return { byId, childrenByParent, parentById };
+  }
+
+  private hasArchivedAncestor(
+    index: AgentTaskIndex,
+    config: ReturnType<Config["loadConfigOrDefault"]>,
+    workspaceId: string
+  ): boolean {
+    const ancestorWorkspaceIds = this.listAncestorWorkspaceIdsUsingParentById(
+      index.parentById,
+      workspaceId
+    );
+    return ancestorWorkspaceIds.some((ancestorWorkspaceId) => {
+      const entry = findWorkspaceEntry(config, ancestorWorkspaceId);
+      return (
+        entry != null &&
+        isWorkspaceArchived(entry.workspace.archivedAt, entry.workspace.unarchivedAt)
+      );
+    });
   }
 
   private countActiveAgentTasks(config: ReturnType<Config["loadConfigOrDefault"]>): number {
@@ -4759,6 +4852,14 @@ export class TaskService {
         parentWorkspaceId,
       });
       return { ok: false, reason: "patch_pending" };
+    }
+
+    const taskSettings = normalizeTaskSettings(config.taskSettings);
+    if (
+      taskSettings.preserveSubagentsUntilArchive &&
+      !this.hasArchivedAncestor(index, config, workspaceId)
+    ) {
+      return { ok: false, reason: "preserved_until_archive" };
     }
 
     return { ok: true, parentWorkspaceId };

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -2197,6 +2197,28 @@ export class TaskService {
     );
   }
 
+  // This ignores archive state and preserveSubagentsUntilArchive so callers can detect
+  // completed descendants that are still waiting on cleanup prerequisites.
+  hasCompletedDescendants(workspaceId: string): boolean {
+    assert(workspaceId.length > 0, "hasCompletedDescendants: workspaceId must be non-empty");
+
+    const cfg = this.config.loadConfigOrDefault();
+    const index = this.buildAgentTaskIndex(cfg);
+    const stack: string[] = [...(index.childrenByParent.get(workspaceId) ?? [])];
+    while (stack.length > 0) {
+      const next = stack.pop()!;
+      const entry = index.byId.get(next);
+      if (entry && hasCompletedAgentReport(entry)) {
+        return true;
+      }
+      const children = index.childrenByParent.get(next);
+      if (children) {
+        stack.push(...children);
+      }
+    }
+    return false;
+  }
+
   listActiveDescendantAgentTaskIds(workspaceId: string): string[] {
     assert(
       workspaceId.length > 0,

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -7,6 +7,7 @@ import * as fsPromises from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
 import { Err, Ok, type Result } from "@/common/types/result";
+import { DEFAULT_TASK_SETTINGS } from "@/common/types/tasks";
 import type { SendMessageError } from "@/common/types/errors";
 import type { ProjectsConfig } from "@/common/types/project";
 import type { Config } from "@/node/config";
@@ -3222,6 +3223,10 @@ describe("WorkspaceService remove preserved descendants", () => {
           },
         ],
       ]),
+      taskSettings: {
+        ...DEFAULT_TASK_SETTINGS,
+        preserveSubagentsUntilArchive: true,
+      },
     };
 
     const mockAIService: AIService = {
@@ -3329,6 +3334,50 @@ describe("WorkspaceService remove preserved descendants", () => {
       expect(createRuntimeSpy).not.toHaveBeenCalled();
       expect(deleteWorkspaceMock).not.toHaveBeenCalled();
       expect(removeWorkspaceMock).not.toHaveBeenCalled();
+    } finally {
+      createRuntimeSpy.mockRestore();
+    }
+  });
+
+  test("remove() allows removal when preserve toggle is off even with completed descendants", async () => {
+    const workspaceEntry = configState.projects.get(projectPath)?.workspaces[0];
+    expect(workspaceEntry).toBeDefined();
+    if (!workspaceEntry) {
+      return;
+    }
+
+    workspaceEntry.archivedAt = "2026-03-10T00:00:00.000Z";
+    workspaceEntry.unarchivedAt = undefined;
+    configState.taskSettings = {
+      ...DEFAULT_TASK_SETTINGS,
+      preserveSubagentsUntilArchive: false,
+    };
+
+    const hasPreservedCompletedDescendants = mock(() => true);
+    const hasCompletedDescendants = mock(() => true);
+    workspaceService.setTaskService({
+      hasPreservedCompletedDescendants,
+      hasCompletedDescendants,
+    } as unknown as TaskService);
+    const createRuntimeSpy = spyOn(runtimeFactory, "createRuntime").mockReturnValue({
+      deleteWorkspace: deleteWorkspaceMock,
+    } as unknown as ReturnType<typeof runtimeFactory.createRuntime>);
+
+    try {
+      const result = await workspaceService.remove(workspaceId);
+
+      expect(result.success).toBe(true);
+      expect(hasPreservedCompletedDescendants).not.toHaveBeenCalled();
+      expect(hasCompletedDescendants).not.toHaveBeenCalled();
+      expect(stopStreamMock).toHaveBeenCalledTimes(1);
+      expect(deleteWorkspaceMock).toHaveBeenCalledWith(
+        projectPath,
+        "ws-remove-preserved",
+        false,
+        undefined,
+        false
+      );
+      expect(removeWorkspaceMock).toHaveBeenCalledWith(workspaceId);
     } finally {
       createRuntimeSpy.mockRestore();
     }

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -3292,6 +3292,90 @@ describe("WorkspaceService remove preserved descendants", () => {
     }
   });
 
+  test("remove() blocks removal of archived workspace with descendants pending cleanup", async () => {
+    const workspaceEntry = configState.projects.get(projectPath)?.workspaces[0];
+    expect(workspaceEntry).toBeDefined();
+    if (!workspaceEntry) {
+      return;
+    }
+
+    workspaceEntry.archivedAt = "2026-03-10T00:00:00.000Z";
+    workspaceEntry.unarchivedAt = undefined;
+
+    const hasPreservedCompletedDescendants = mock(() => false);
+    const hasCompletedDescendants = mock(() => true);
+    workspaceService.setTaskService({
+      hasPreservedCompletedDescendants,
+      hasCompletedDescendants,
+    } as unknown as TaskService);
+    const createRuntimeSpy = spyOn(runtimeFactory, "createRuntime").mockReturnValue({
+      deleteWorkspace: deleteWorkspaceMock,
+    } as unknown as ReturnType<typeof runtimeFactory.createRuntime>);
+
+    try {
+      const result = await workspaceService.remove(workspaceId);
+
+      expect(result).toEqual(
+        Err(
+          "This workspace still has completed sub-agent workspaces pending cleanup. Wait for cleanup to finish, or force-remove the workspace."
+        )
+      );
+      expect(hasPreservedCompletedDescendants).toHaveBeenCalledTimes(1);
+      expect(hasPreservedCompletedDescendants).toHaveBeenCalledWith(workspaceId);
+      expect(hasCompletedDescendants).toHaveBeenCalledTimes(1);
+      expect(hasCompletedDescendants).toHaveBeenCalledWith(workspaceId);
+      expect(stopStreamMock).not.toHaveBeenCalled();
+      expect(getWorkspaceMetadataMock).not.toHaveBeenCalled();
+      expect(createRuntimeSpy).not.toHaveBeenCalled();
+      expect(deleteWorkspaceMock).not.toHaveBeenCalled();
+      expect(removeWorkspaceMock).not.toHaveBeenCalled();
+    } finally {
+      createRuntimeSpy.mockRestore();
+    }
+  });
+
+  test("remove() allows removal of archived workspace after all descendants cleaned up", async () => {
+    const workspaceEntry = configState.projects.get(projectPath)?.workspaces[0];
+    expect(workspaceEntry).toBeDefined();
+    if (!workspaceEntry) {
+      return;
+    }
+
+    workspaceEntry.archivedAt = "2026-03-10T00:00:00.000Z";
+    workspaceEntry.unarchivedAt = undefined;
+
+    const hasPreservedCompletedDescendants = mock(() => false);
+    const hasCompletedDescendants = mock(() => false);
+    workspaceService.setTaskService({
+      hasPreservedCompletedDescendants,
+      hasCompletedDescendants,
+    } as unknown as TaskService);
+    const createRuntimeSpy = spyOn(runtimeFactory, "createRuntime").mockReturnValue({
+      deleteWorkspace: deleteWorkspaceMock,
+    } as unknown as ReturnType<typeof runtimeFactory.createRuntime>);
+
+    try {
+      const result = await workspaceService.remove(workspaceId);
+
+      expect(result.success).toBe(true);
+      expect(hasPreservedCompletedDescendants).toHaveBeenCalledTimes(1);
+      expect(hasPreservedCompletedDescendants).toHaveBeenCalledWith(workspaceId);
+      expect(hasCompletedDescendants).toHaveBeenCalledTimes(1);
+      expect(hasCompletedDescendants).toHaveBeenCalledWith(workspaceId);
+      expect(stopStreamMock).toHaveBeenCalledTimes(1);
+      expect(deleteWorkspaceMock).toHaveBeenCalledWith(
+        projectPath,
+        "ws-remove-preserved",
+        false,
+        undefined,
+        false
+      );
+      expect(removeWorkspaceMock).toHaveBeenCalledWith(workspaceId);
+    } finally {
+      createRuntimeSpy.mockRestore();
+    }
+  });
+
   test("remove() allows removal when force is true even with preserved descendants", async () => {
     const hasPreservedCompletedDescendants = mock(() => true);
     workspaceService.setTaskService({

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -3128,6 +3128,7 @@ describe("WorkspaceService remove desktop session cleanup", () => {
       getSessionDir: mock((id: string) => path.join(tempRoot, "sessions", id)),
       removeWorkspace: removeWorkspaceMock,
       findWorkspace: mock(() => null),
+      loadConfigOrDefault: mock(() => ({ projects: new Map() })),
     };
 
     workspaceService = new WorkspaceService(
@@ -3269,9 +3270,9 @@ describe("WorkspaceService remove preserved descendants", () => {
   });
 
   test("remove() blocks direct removal of unarchived workspace with preserved completed descendants", async () => {
-    const hasPreservedCompletedDescendants = mock(() => true);
+    const hasCompletedDescendants = mock(() => true);
     workspaceService.setTaskService({
-      hasPreservedCompletedDescendants,
+      hasCompletedDescendants,
     } as unknown as TaskService);
     const createRuntimeSpy = spyOn(runtimeFactory, "createRuntime").mockReturnValue({
       deleteWorkspace: deleteWorkspaceMock,
@@ -3285,8 +3286,50 @@ describe("WorkspaceService remove preserved descendants", () => {
           "This workspace has preserved completed sub-agent workspaces. Archive the workspace first to trigger cleanup, then try removing it."
         )
       );
-      expect(hasPreservedCompletedDescendants).toHaveBeenCalledTimes(1);
-      expect(hasPreservedCompletedDescendants).toHaveBeenCalledWith(workspaceId);
+      expect(hasCompletedDescendants).toHaveBeenCalledTimes(1);
+      expect(hasCompletedDescendants).toHaveBeenCalledWith(workspaceId);
+      expect(stopStreamMock).not.toHaveBeenCalled();
+      expect(getWorkspaceMetadataMock).not.toHaveBeenCalled();
+      expect(createRuntimeSpy).not.toHaveBeenCalled();
+      expect(deleteWorkspaceMock).not.toHaveBeenCalled();
+      expect(removeWorkspaceMock).not.toHaveBeenCalled();
+    } finally {
+      createRuntimeSpy.mockRestore();
+    }
+  });
+
+  test("remove() blocks intermediate ancestor removal when descendants exist", async () => {
+    const workspaceEntry = configState.projects.get(projectPath)?.workspaces[0];
+    expect(workspaceEntry).toBeDefined();
+    if (!workspaceEntry) {
+      return;
+    }
+
+    workspaceEntry.parentWorkspaceId = "ws-grandparent";
+    configState.projects.get(projectPath)?.workspaces.push({
+      path: path.join(tempRoot, "child"),
+      id: "ws-child",
+      parentWorkspaceId: workspaceId,
+    });
+
+    const hasCompletedDescendants = mock(() => true);
+    workspaceService.setTaskService({
+      hasCompletedDescendants,
+    } as unknown as TaskService);
+    const createRuntimeSpy = spyOn(runtimeFactory, "createRuntime").mockReturnValue({
+      deleteWorkspace: deleteWorkspaceMock,
+    } as unknown as ReturnType<typeof runtimeFactory.createRuntime>);
+
+    try {
+      const result = await workspaceService.remove(workspaceId);
+
+      expect(result).toEqual(
+        Err(
+          "This workspace has preserved completed sub-agent workspaces. Archive the workspace first to trigger cleanup, then try removing it."
+        )
+      );
+      expect(hasCompletedDescendants).toHaveBeenCalledTimes(1);
+      expect(hasCompletedDescendants).toHaveBeenCalledWith(workspaceId);
       expect(stopStreamMock).not.toHaveBeenCalled();
       expect(getWorkspaceMetadataMock).not.toHaveBeenCalled();
       expect(createRuntimeSpy).not.toHaveBeenCalled();
@@ -3307,10 +3350,8 @@ describe("WorkspaceService remove preserved descendants", () => {
     workspaceEntry.archivedAt = "2026-03-10T00:00:00.000Z";
     workspaceEntry.unarchivedAt = undefined;
 
-    const hasPreservedCompletedDescendants = mock(() => false);
     const hasCompletedDescendants = mock(() => true);
     workspaceService.setTaskService({
-      hasPreservedCompletedDescendants,
       hasCompletedDescendants,
     } as unknown as TaskService);
     const createRuntimeSpy = spyOn(runtimeFactory, "createRuntime").mockReturnValue({
@@ -3325,8 +3366,6 @@ describe("WorkspaceService remove preserved descendants", () => {
           "This workspace still has completed sub-agent workspaces pending cleanup. Wait for cleanup to finish, or force-remove the workspace."
         )
       );
-      expect(hasPreservedCompletedDescendants).toHaveBeenCalledTimes(1);
-      expect(hasPreservedCompletedDescendants).toHaveBeenCalledWith(workspaceId);
       expect(hasCompletedDescendants).toHaveBeenCalledTimes(1);
       expect(hasCompletedDescendants).toHaveBeenCalledWith(workspaceId);
       expect(stopStreamMock).not.toHaveBeenCalled();
@@ -3353,10 +3392,8 @@ describe("WorkspaceService remove preserved descendants", () => {
       preserveSubagentsUntilArchive: false,
     };
 
-    const hasPreservedCompletedDescendants = mock(() => true);
     const hasCompletedDescendants = mock(() => true);
     workspaceService.setTaskService({
-      hasPreservedCompletedDescendants,
       hasCompletedDescendants,
     } as unknown as TaskService);
     const createRuntimeSpy = spyOn(runtimeFactory, "createRuntime").mockReturnValue({
@@ -3367,7 +3404,6 @@ describe("WorkspaceService remove preserved descendants", () => {
       const result = await workspaceService.remove(workspaceId);
 
       expect(result.success).toBe(true);
-      expect(hasPreservedCompletedDescendants).not.toHaveBeenCalled();
       expect(hasCompletedDescendants).not.toHaveBeenCalled();
       expect(stopStreamMock).toHaveBeenCalledTimes(1);
       expect(deleteWorkspaceMock).toHaveBeenCalledWith(
@@ -3393,10 +3429,8 @@ describe("WorkspaceService remove preserved descendants", () => {
     workspaceEntry.archivedAt = "2026-03-10T00:00:00.000Z";
     workspaceEntry.unarchivedAt = undefined;
 
-    const hasPreservedCompletedDescendants = mock(() => false);
     const hasCompletedDescendants = mock(() => false);
     workspaceService.setTaskService({
-      hasPreservedCompletedDescendants,
       hasCompletedDescendants,
     } as unknown as TaskService);
     const createRuntimeSpy = spyOn(runtimeFactory, "createRuntime").mockReturnValue({
@@ -3407,8 +3441,6 @@ describe("WorkspaceService remove preserved descendants", () => {
       const result = await workspaceService.remove(workspaceId);
 
       expect(result.success).toBe(true);
-      expect(hasPreservedCompletedDescendants).toHaveBeenCalledTimes(1);
-      expect(hasPreservedCompletedDescendants).toHaveBeenCalledWith(workspaceId);
       expect(hasCompletedDescendants).toHaveBeenCalledTimes(1);
       expect(hasCompletedDescendants).toHaveBeenCalledWith(workspaceId);
       expect(stopStreamMock).toHaveBeenCalledTimes(1);
@@ -3426,9 +3458,9 @@ describe("WorkspaceService remove preserved descendants", () => {
   });
 
   test("remove() allows removal when force is true even with preserved descendants", async () => {
-    const hasPreservedCompletedDescendants = mock(() => true);
+    const hasCompletedDescendants = mock(() => true);
     workspaceService.setTaskService({
-      hasPreservedCompletedDescendants,
+      hasCompletedDescendants,
     } as unknown as TaskService);
     const createRuntimeSpy = spyOn(runtimeFactory, "createRuntime").mockReturnValue({
       deleteWorkspace: deleteWorkspaceMock,
@@ -3438,7 +3470,7 @@ describe("WorkspaceService remove preserved descendants", () => {
       const result = await workspaceService.remove(workspaceId, true);
 
       expect(result.success).toBe(true);
-      expect(hasPreservedCompletedDescendants).not.toHaveBeenCalled();
+      expect(hasCompletedDescendants).not.toHaveBeenCalled();
       expect(stopStreamMock).toHaveBeenCalledTimes(1);
       expect(deleteWorkspaceMock).toHaveBeenCalledWith(
         projectPath,

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -3174,6 +3174,153 @@ describe("WorkspaceService remove desktop session cleanup", () => {
   });
 });
 
+describe("WorkspaceService remove preserved descendants", () => {
+  const workspaceId = "ws-remove-preserved";
+  const projectPath = "/tmp/project";
+  const workspacePath = "/tmp/project/ws-remove-preserved";
+
+  let historyService: HistoryService;
+  let cleanupHistory: () => Promise<void>;
+  let workspaceService: WorkspaceService;
+  let tempRoot: string;
+  let removeWorkspaceMock: ReturnType<typeof mock>;
+  let stopStreamMock: ReturnType<typeof mock>;
+  let getWorkspaceMetadataMock: ReturnType<typeof mock>;
+  let deleteWorkspaceMock: ReturnType<typeof mock>;
+  let configState: ProjectsConfig;
+
+  beforeEach(async () => {
+    ({ historyService, cleanup: cleanupHistory } = await createTestHistoryService());
+    tempRoot = await fsPromises.mkdtemp(path.join(tmpdir(), "mux-remove-preserved-"));
+    removeWorkspaceMock = mock(() => Promise.resolve());
+    stopStreamMock = mock(() => Promise.resolve(Ok(undefined)));
+    getWorkspaceMetadataMock = mock(() =>
+      Promise.resolve(
+        Ok({
+          id: workspaceId,
+          name: "ws-remove-preserved",
+          projectPath,
+          projectName: "proj",
+          runtimeConfig: { type: "local" },
+        })
+      )
+    );
+    deleteWorkspaceMock = mock(() =>
+      Promise.resolve({ success: true as const, deletedPath: "/tmp/deleted" })
+    );
+    configState = {
+      projects: new Map([
+        [
+          projectPath,
+          {
+            workspaces: [
+              {
+                path: workspacePath,
+                id: workspaceId,
+              },
+            ],
+          },
+        ],
+      ]),
+    };
+
+    const mockAIService: AIService = {
+      isStreaming: mock(() => false),
+      stopStream: stopStreamMock,
+      getWorkspaceMetadata: getWorkspaceMetadataMock,
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      on: mock(() => {}),
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      off: mock(() => {}),
+    } as unknown as AIService;
+
+    const mockConfig: Partial<Config> = {
+      srcDir: "/tmp/src",
+      getSessionDir: mock((id: string) => path.join(tempRoot, "sessions", id)),
+      removeWorkspace: removeWorkspaceMock,
+      findWorkspace: mock((id: string) => {
+        if (id !== workspaceId) {
+          return null;
+        }
+
+        return { projectPath, workspacePath };
+      }),
+      loadConfigOrDefault: mock(() => configState),
+    };
+
+    workspaceService = new WorkspaceService(
+      mockConfig as Config,
+      historyService,
+      mockAIService,
+      mockInitStateManager as InitStateManager,
+      mockExtensionMetadataService as ExtensionMetadataService,
+      mockBackgroundProcessManager as BackgroundProcessManager
+    );
+  });
+
+  afterEach(async () => {
+    await fsPromises.rm(tempRoot, { recursive: true, force: true });
+    await cleanupHistory();
+  });
+
+  test("remove() blocks direct removal of unarchived workspace with preserved completed descendants", async () => {
+    const hasPreservedCompletedDescendants = mock(() => true);
+    workspaceService.setTaskService({
+      hasPreservedCompletedDescendants,
+    } as unknown as TaskService);
+    const createRuntimeSpy = spyOn(runtimeFactory, "createRuntime").mockReturnValue({
+      deleteWorkspace: deleteWorkspaceMock,
+    } as unknown as ReturnType<typeof runtimeFactory.createRuntime>);
+
+    try {
+      const result = await workspaceService.remove(workspaceId);
+
+      expect(result).toEqual(
+        Err(
+          "This workspace has preserved completed sub-agent workspaces. Archive the workspace first to trigger cleanup, then try removing it."
+        )
+      );
+      expect(hasPreservedCompletedDescendants).toHaveBeenCalledTimes(1);
+      expect(hasPreservedCompletedDescendants).toHaveBeenCalledWith(workspaceId);
+      expect(stopStreamMock).not.toHaveBeenCalled();
+      expect(getWorkspaceMetadataMock).not.toHaveBeenCalled();
+      expect(createRuntimeSpy).not.toHaveBeenCalled();
+      expect(deleteWorkspaceMock).not.toHaveBeenCalled();
+      expect(removeWorkspaceMock).not.toHaveBeenCalled();
+    } finally {
+      createRuntimeSpy.mockRestore();
+    }
+  });
+
+  test("remove() allows removal when force is true even with preserved descendants", async () => {
+    const hasPreservedCompletedDescendants = mock(() => true);
+    workspaceService.setTaskService({
+      hasPreservedCompletedDescendants,
+    } as unknown as TaskService);
+    const createRuntimeSpy = spyOn(runtimeFactory, "createRuntime").mockReturnValue({
+      deleteWorkspace: deleteWorkspaceMock,
+    } as unknown as ReturnType<typeof runtimeFactory.createRuntime>);
+
+    try {
+      const result = await workspaceService.remove(workspaceId, true);
+
+      expect(result.success).toBe(true);
+      expect(hasPreservedCompletedDescendants).not.toHaveBeenCalled();
+      expect(stopStreamMock).toHaveBeenCalledTimes(1);
+      expect(deleteWorkspaceMock).toHaveBeenCalledWith(
+        projectPath,
+        "ws-remove-preserved",
+        true,
+        undefined,
+        false
+      );
+      expect(removeWorkspaceMock).toHaveBeenCalledWith(workspaceId);
+    } finally {
+      createRuntimeSpy.mockRestore();
+    }
+  });
+});
+
 describe("WorkspaceService metadata listeners", () => {
   let historyService: HistoryService;
   let cleanupHistory: () => Promise<void>;
@@ -3532,6 +3679,48 @@ describe("WorkspaceService archive lifecycle hooks", () => {
 
     expect(result.success).toBe(true);
     expect(afterHook).toHaveBeenCalledTimes(1);
+
+    const entry = configState.projects.get(projectPath)?.workspaces[0];
+    expect(entry?.archivedAt).toBeTruthy();
+    expect(entry?.archivedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+  test("archive() invokes descendant cleanup only after archive persistence succeeds", async () => {
+    const callOrder: string[] = [];
+    editConfigSpy.mockImplementation((fn: (config: ProjectsConfig) => ProjectsConfig) => {
+      callOrder.push("persist");
+      configState = fn(configState);
+      return Promise.resolve();
+    });
+
+    const cleanupReportedDescendantsAfterArchive = mock(() => {
+      callOrder.push("cleanup");
+      return Promise.resolve();
+    });
+    workspaceService.setTaskService({
+      cleanupReportedDescendantsAfterArchive,
+    } as unknown as TaskService);
+
+    const result = await workspaceService.archive(workspaceId);
+
+    expect(result.success).toBe(true);
+    expect(cleanupReportedDescendantsAfterArchive).toHaveBeenCalledTimes(1);
+    expect(cleanupReportedDescendantsAfterArchive).toHaveBeenCalledWith(workspaceId);
+    expect(callOrder).toEqual(["persist", "cleanup"]);
+  });
+
+  test("archive() stays successful if descendant cleanup throws after persistence", async () => {
+    const cleanupReportedDescendantsAfterArchive = mock(() =>
+      Promise.reject(new Error("cleanup failed"))
+    );
+    workspaceService.setTaskService({
+      cleanupReportedDescendantsAfterArchive,
+    } as unknown as TaskService);
+
+    const result = await workspaceService.archive(workspaceId);
+
+    expect(result).toEqual(Ok({ kind: "archived" }));
+    expect(cleanupReportedDescendantsAfterArchive).toHaveBeenCalledTimes(1);
+    expect(cleanupReportedDescendantsAfterArchive).toHaveBeenCalledWith(workspaceId);
 
     const entry = configState.projects.get(projectPath)?.workspaces[0];
     expect(entry?.archivedAt).toBeTruthy();

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2729,26 +2729,36 @@ export class WorkspaceService extends EventEmitter {
 
     // Try to remove from runtime (filesystem)
     try {
-      // Block direct removal of unarchived workspaces while preserved completed descendants still exist.
-      // Archiving first persists archivedAt, which lets TaskService descendant cleanup proceed safely.
-      if (
-        !force &&
-        persistedWorkspace &&
-        this.taskService?.hasPreservedCompletedDescendants?.(workspaceId)
-      ) {
-        const config = this.config.loadConfigOrDefault();
-        const projectConfig = config.projects.get(persistedWorkspace.projectPath);
-        const workspaceEntry =
-          projectConfig?.workspaces.find((workspace) => workspace.id === workspaceId) ??
-          projectConfig?.workspaces.find(
-            (workspace) => workspace.path === persistedWorkspace.workspacePath
-          );
-        if (
-          workspaceEntry &&
-          !isWorkspaceArchived(workspaceEntry.archivedAt, workspaceEntry.unarchivedAt)
-        ) {
+      if (!force) {
+        // Block direct removal of unarchived workspaces while preserved completed descendants still exist.
+        // Archiving first persists archivedAt, which lets TaskService descendant cleanup proceed safely.
+        if (this.taskService?.hasPreservedCompletedDescendants?.(workspaceId)) {
+          const config = this.config.loadConfigOrDefault();
+          const projectConfig = persistedWorkspace
+            ? config.projects.get(persistedWorkspace.projectPath)
+            : undefined;
+          const workspaceEntry = persistedWorkspace
+            ? (projectConfig?.workspaces.find((workspace) => workspace.id === workspaceId) ??
+              projectConfig?.workspaces.find(
+                (workspace) => workspace.path === persistedWorkspace.workspacePath
+              ))
+            : undefined;
+          if (
+            workspaceEntry &&
+            !isWorkspaceArchived(workspaceEntry.archivedAt, workspaceEntry.unarchivedAt)
+          ) {
+            return Err(
+              "This workspace has preserved completed sub-agent workspaces. Archive the workspace first to trigger cleanup, then try removing it."
+            );
+          }
+        }
+
+        // Archived parents can still retain completed descendants while cleanup waits on
+        // prerequisites like pending patch artifacts. Keep removal blocked until that cleanup
+        // finishes so descendants do not lose the archived ancestor that makes them eligible.
+        if (this.taskService?.hasCompletedDescendants?.(workspaceId)) {
           return Err(
-            "This workspace has preserved completed sub-agent workspaces. Archive the workspace first to trigger cleanup, then try removing it."
+            "This workspace still has completed sub-agent workspaces pending cleanup. Wait for cleanup to finish, or force-remove the workspace."
           );
         }
       }

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -9,6 +9,7 @@ import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
 import type { Config } from "@/node/config";
 import type { Result } from "@/common/types/result";
 import { Ok, Err } from "@/common/types/result";
+import { normalizeTaskSettings } from "@/common/types/tasks";
 import { askUserQuestionManager } from "@/node/services/askUserQuestionManager";
 import { delegatedToolCallManager } from "@/node/services/delegatedToolCallManager";
 import { log } from "@/node/services/log";
@@ -2729,11 +2730,10 @@ export class WorkspaceService extends EventEmitter {
 
     // Try to remove from runtime (filesystem)
     try {
-      if (!force) {
-        // Block direct removal of unarchived workspaces while preserved completed descendants still exist.
-        // Archiving first persists archivedAt, which lets TaskService descendant cleanup proceed safely.
-        if (this.taskService?.hasPreservedCompletedDescendants?.(workspaceId)) {
-          const config = this.config.loadConfigOrDefault();
+      if (!force && this.taskService) {
+        const config = this.config.loadConfigOrDefault();
+        const taskSettings = normalizeTaskSettings(config.taskSettings);
+        if (taskSettings.preserveSubagentsUntilArchive) {
           const projectConfig = persistedWorkspace
             ? config.projects.get(persistedWorkspace.projectPath)
             : undefined;
@@ -2743,23 +2743,29 @@ export class WorkspaceService extends EventEmitter {
                 (workspace) => workspace.path === persistedWorkspace.workspacePath
               ))
             : undefined;
-          if (
-            workspaceEntry &&
-            !isWorkspaceArchived(workspaceEntry.archivedAt, workspaceEntry.unarchivedAt)
-          ) {
+          const isArchived =
+            workspaceEntry != null &&
+            isWorkspaceArchived(workspaceEntry.archivedAt, workspaceEntry.unarchivedAt);
+
+          // Block direct removal of unarchived workspaces while preserved completed descendants
+          // still exist. Archiving first persists archivedAt, which lets TaskService descendant
+          // cleanup proceed safely.
+          if (this.taskService?.hasPreservedCompletedDescendants?.(workspaceId)) {
+            if (workspaceEntry && !isArchived) {
+              return Err(
+                "This workspace has preserved completed sub-agent workspaces. Archive the workspace first to trigger cleanup, then try removing it."
+              );
+            }
+          }
+
+          // Archived parents can still retain completed descendants while cleanup waits on
+          // prerequisites like pending patch artifacts. Keep removal blocked until that cleanup
+          // finishes so descendants do not lose the archived ancestor that makes them eligible.
+          if (isArchived && this.taskService?.hasCompletedDescendants?.(workspaceId)) {
             return Err(
-              "This workspace has preserved completed sub-agent workspaces. Archive the workspace first to trigger cleanup, then try removing it."
+              "This workspace still has completed sub-agent workspaces pending cleanup. Wait for cleanup to finish, or force-remove the workspace."
             );
           }
-        }
-
-        // Archived parents can still retain completed descendants while cleanup waits on
-        // prerequisites like pending patch artifacts. Keep removal blocked until that cleanup
-        // finishes so descendants do not lose the archived ancestor that makes them eligible.
-        if (this.taskService?.hasCompletedDescendants?.(workspaceId)) {
-          return Err(
-            "This workspace still has completed sub-agent workspaces pending cleanup. Wait for cleanup to finish, or force-remove the workspace."
-          );
         }
       }
 

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2725,8 +2725,34 @@ export class WorkspaceService extends EventEmitter {
       this.initAbortControllers.delete(workspaceId);
     }
 
+    const persistedWorkspace = this.config.findWorkspace(workspaceId);
+
     // Try to remove from runtime (filesystem)
     try {
+      // Block direct removal of unarchived workspaces while preserved completed descendants still exist.
+      // Archiving first persists archivedAt, which lets TaskService descendant cleanup proceed safely.
+      if (
+        !force &&
+        persistedWorkspace &&
+        this.taskService?.hasPreservedCompletedDescendants?.(workspaceId)
+      ) {
+        const config = this.config.loadConfigOrDefault();
+        const projectConfig = config.projects.get(persistedWorkspace.projectPath);
+        const workspaceEntry =
+          projectConfig?.workspaces.find((workspace) => workspace.id === workspaceId) ??
+          projectConfig?.workspaces.find(
+            (workspace) => workspace.path === persistedWorkspace.workspacePath
+          );
+        if (
+          workspaceEntry &&
+          !isWorkspaceArchived(workspaceEntry.archivedAt, workspaceEntry.unarchivedAt)
+        ) {
+          return Err(
+            "This workspace has preserved completed sub-agent workspaces. Archive the workspace first to trigger cleanup, then try removing it."
+          );
+        }
+      }
+
       // Stop any active stream before deleting metadata/config to avoid tool calls racing with removal.
       //
       // IMPORTANT: AIService forwards "stream-abort" asynchronously after partial cleanup. If we roll up
@@ -2807,7 +2833,7 @@ export class WorkspaceService extends EventEmitter {
         const metadata = metadataResult.data;
         const configSnapshot = this.config.loadConfigOrDefault();
 
-        const persistedWorkspacePath = this.config.findWorkspace(workspaceId)?.workspacePath;
+        const persistedWorkspacePath = persistedWorkspace?.workspacePath;
 
         if (isMultiProject(metadata)) {
           const projects = getProjects(metadata);
@@ -4163,6 +4189,13 @@ export class WorkspaceService extends EventEmitter {
           });
           await this.emitCurrentWorkspaceMetadata(workspaceId);
         }
+      }
+
+      // Best-effort cleanup of preserved completed descendants after archive persistence succeeds.
+      try {
+        await this.taskService?.cleanupReportedDescendantsAfterArchive?.(workspaceId);
+      } catch (error) {
+        log.error("Failed to cleanup reported descendants after archive", { workspaceId, error });
       }
 
       return Ok({ kind: "archived" as const });

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -152,6 +152,7 @@ import type { SessionUsageService } from "@/node/services/sessionUsageService";
 import type { BackgroundProcessManager } from "@/node/services/backgroundProcessManager";
 import type { WorkspaceLifecycleHooks } from "@/node/services/workspaceLifecycleHooks";
 import type { TaskService } from "@/node/services/taskService";
+import { findWorkspaceEntry } from "@/node/services/taskUtils";
 import type { WorktreeArchiveSnapshotService } from "@/node/services/worktreeArchiveSnapshotService";
 
 import { DisposableTempDir } from "@/node/services/tempDir";
@@ -2730,42 +2731,35 @@ export class WorkspaceService extends EventEmitter {
 
     // Try to remove from runtime (filesystem)
     try {
-      if (!force && this.taskService) {
+      if (!force) {
         const config = this.config.loadConfigOrDefault();
         const taskSettings = normalizeTaskSettings(config.taskSettings);
-        if (taskSettings.preserveSubagentsUntilArchive) {
-          const projectConfig = persistedWorkspace
-            ? config.projects.get(persistedWorkspace.projectPath)
-            : undefined;
-          const workspaceEntry = persistedWorkspace
-            ? (projectConfig?.workspaces.find((workspace) => workspace.id === workspaceId) ??
-              projectConfig?.workspaces.find(
-                (workspace) => workspace.path === persistedWorkspace.workspacePath
-              ))
-            : undefined;
+        if (
+          taskSettings.preserveSubagentsUntilArchive &&
+          this.taskService?.hasCompletedDescendants?.(workspaceId)
+        ) {
+          const persistedWorkspaceEntry = findWorkspaceEntry(config, workspaceId);
           const isArchived =
-            workspaceEntry != null &&
-            isWorkspaceArchived(workspaceEntry.archivedAt, workspaceEntry.unarchivedAt);
+            persistedWorkspaceEntry != null &&
+            isWorkspaceArchived(
+              persistedWorkspaceEntry.workspace.archivedAt,
+              persistedWorkspaceEntry.workspace.unarchivedAt
+            );
 
-          // Block direct removal of unarchived workspaces while preserved completed descendants
-          // still exist. Archiving first persists archivedAt, which lets TaskService descendant
-          // cleanup proceed safely.
-          if (this.taskService?.hasPreservedCompletedDescendants?.(workspaceId)) {
-            if (workspaceEntry && !isArchived) {
-              return Err(
-                "This workspace has preserved completed sub-agent workspaces. Archive the workspace first to trigger cleanup, then try removing it."
-              );
-            }
+          // Keep the whole parentWorkspaceId chain intact while completed descendants still exist.
+          // Unarchived ancestors must be archived first so descendant cleanup can safely walk that lineage.
+          if (!isArchived) {
+            return Err(
+              "This workspace has preserved completed sub-agent workspaces. Archive the workspace first to trigger cleanup, then try removing it."
+            );
           }
 
           // Archived parents can still retain completed descendants while cleanup waits on
           // prerequisites like pending patch artifacts. Keep removal blocked until that cleanup
           // finishes so descendants do not lose the archived ancestor that makes them eligible.
-          if (isArchived && this.taskService?.hasCompletedDescendants?.(workspaceId)) {
-            return Err(
-              "This workspace still has completed sub-agent workspaces pending cleanup. Wait for cleanup to finish, or force-remove the workspace."
-            );
-          }
+          return Err(
+            "This workspace still has completed sub-agent workspaces pending cleanup. Wait for cleanup to finish, or force-remove the workspace."
+          );
         }
       }
 


### PR DESCRIPTION
> Mux working on behalf of Mike.

## Summary

Adds a global "Preserve subagents until the workspace gets archived" toggle in Settings > Agents. When enabled, completed sub-agent workspaces stay attached to the parent so the sidebar can still surface "Show sub-agents" and expand them. Cleanup runs automatically when an ancestor workspace is archived.

## Background

Completed sub-agent workspaces are currently auto-cleaned shortly after reporting. This makes it impossible to review child workspaces after they finish. Users want completed children to remain visible and expandable until archive, not immediately pruned.

## Implementation

**Config layer** (`taskSettings.ts`, `tasks.ts`): New `preserveSubagentsUntilArchive` boolean, defaults to `false`, survives normalization round-trips.

**UI** (`TasksSection.tsx`): New `Switch` toggle in the Task Settings block with descriptive help text. Wired through the existing debounce auto-save flow.

**TaskService** (`taskService.ts`):
- Extended `canCleanupReportedTask()` with a `preserved_until_archive` gate that checks whether any ancestor in the lineage is archived (via `isWorkspaceArchived`). Gate is skipped when toggle is off, preserving existing behavior.
- Added `cleanupReportedDescendantsAfterArchive()`: discovers completed descendants via DFS, sorts deepest-first, processes each through `cleanupReportedLeafTask()`.
- Added `hasPreservedCompletedDescendants()`: public query used by WorkspaceService remove guard.

**WorkspaceService** (`workspaceService.ts`):
- `archive()` calls `cleanupReportedDescendantsAfterArchive()` best-effort after `archivedAt` is persisted. Archive success is never downgraded by cleanup failure.
- `remove()` blocks non-force removal when the toggle is on, the workspace is unarchived, and preserved completed descendants exist.

## Risks

- **Low risk of regression on default behavior**: the new cleanup gate is only active when `preserveSubagentsUntilArchive` is true (defaults to false). All existing gates (best-of deferral, streaming, structural-leaf, pending patch) remain unchanged.
- **Archive-triggered cleanup is best-effort**: if it fails partway, startup recovery will retry on next launch because `canCleanupReportedTask()` will now see the archived ancestor.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-6` • Thinking: `xhigh` • Cost: `$18.23`_

<!-- mux-attribution: model=anthropic:claude-opus-4-6 thinking=xhigh costs=18.23 -->
