### PR TITLE
🤖 feat: include advisor (and tool-level) model costs in analytics

### DIFF
--- a/src/common/analytics/schemaSql.ts
+++ b/src/common/analytics/schemaSql.ts
@@ -9,6 +9,7 @@ CREATE TABLE IF NOT EXISTS events (
   timestamp BIGINT,
   date DATE,
   model VARCHAR,
+  tool_name TEXT,
   thinking_level VARCHAR,
   input_tokens INTEGER DEFAULT 0,
   output_tokens INTEGER DEFAULT 0,

--- a/src/common/analytics/schemaSql.ts
+++ b/src/common/analytics/schemaSql.ts
@@ -9,7 +9,6 @@ CREATE TABLE IF NOT EXISTS events (
   timestamp BIGINT,
   date DATE,
   model VARCHAR,
-  tool_name TEXT,
   thinking_level VARCHAR,
   input_tokens INTEGER DEFAULT 0,
   output_tokens INTEGER DEFAULT 0,
@@ -27,7 +26,8 @@ CREATE TABLE IF NOT EXISTS events (
   tool_execution_ms DOUBLE,
   output_tps DOUBLE,
   response_index INTEGER,
-  is_sub_agent BOOLEAN DEFAULT false
+  is_sub_agent BOOLEAN DEFAULT false,
+  tool_name TEXT
 )
 `;
 

--- a/src/common/orpc/schemas/analytics.ts
+++ b/src/common/orpc/schemas/analytics.ts
@@ -143,6 +143,7 @@ export const EventRowSchema = z.object({
   agent_id: z.string().nullable(),
   timestamp: z.number().nullable(), // unix ms
   model: z.string().nullable(),
+  tool_name: z.string().nullable(),
   thinking_level: z.string().nullable(),
   input_tokens: z.number().default(0),
   output_tokens: z.number().default(0),

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -408,6 +408,17 @@ export function isCompactionSummaryMetadata(
   return metadata?.type === "compaction-summary";
 }
 
+export interface PersistedToolModelUsage {
+  toolName: string;
+  toolCallId?: string;
+  timestamp?: number;
+  model: string;
+  /** Resolved pricing model for token/cost metadata lookups when the tool model uses Treat as mapping. */
+  metadataModel?: string;
+  usage: LanguageModelV2Usage;
+  providerMetadata?: Record<string, unknown>;
+}
+
 // Our custom metadata type
 export interface MuxMetadata {
   historySequence?: number; // Assigned by backend for global message ordering (required when writing to history)
@@ -436,6 +447,8 @@ export interface MuxMetadata {
   contextUsage?: LanguageModelV2Usage;
   // Aggregated provider metadata across all steps (for cost calculation)
   providerMetadata?: Record<string, unknown>;
+  // Per-tool invocation usage snapshots recorded during this assistant turn.
+  toolModelUsages?: PersistedToolModelUsage[];
   // Last step's provider metadata (for context window cache display)
   contextProviderMetadata?: Record<string, unknown>;
   systemMessageTokens?: number; // Token count for system message sent with this request (calculated by AIService)

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1409,6 +1409,11 @@ export class AIService extends EventEmitter {
           costsUsd: sessionCostsUsd,
         }
       );
+
+      // Create assistant message ID early so tool-side usage reporting and nested tool events
+      // stay scoped to this specific assistant turn. The placeholder is appended to history below
+      // (after the abort check).
+      const assistantMessageId = createAssistantMessageId();
       const allTools = await getToolsForModel(
         modelString,
         {
@@ -1499,54 +1504,72 @@ export class AIService extends EventEmitter {
           // External edit detection callback
           recordFileState,
           reportModelUsage: (event) => {
-            void (async () => {
-              try {
-                if (!this.sessionUsageService) {
-                  return;
+            try {
+              const eventModel = event.model.trim();
+              assert(eventModel.length > 0, "tool model usage event model must be non-empty");
+              // Persist tool-side model usage under its own model bucket so session costs keep
+              // advisor/system-side pricing separate from the parent chat model.
+              const providerMetadata = markProviderMetadataCostsIncluded(
+                event.providerMetadata,
+                toolModelCostsIncludedByModelString.get(eventModel)
+              );
+              const metadataModel = resolveModelForMetadata(
+                eventModel,
+                this.providerService.getConfig()
+              );
+              this.streamManager.recordToolModelUsage(workspaceId, assistantMessageId, {
+                toolName: event.toolName,
+                toolCallId: event.toolCallId,
+                timestamp: event.timestamp,
+                model: eventModel,
+                metadataModel,
+                usage: event.usage,
+                ...(providerMetadata != null ? { providerMetadata } : {}),
+              });
+              void (async () => {
+                try {
+                  if (!this.sessionUsageService) {
+                    return;
+                  }
+                  const displayUsage = createDisplayUsage(
+                    event.usage,
+                    eventModel,
+                    providerMetadata,
+                    metadataModel
+                  );
+                  if (!displayUsage) {
+                    return;
+                  }
+                  const canonicalModel = normalizeToCanonical(eventModel);
+                  await this.sessionUsageService.recordUsage(
+                    workspaceId,
+                    canonicalModel,
+                    displayUsage
+                  );
+                  this.emit("session-usage-delta", {
+                    type: "session-usage-delta" as const,
+                    workspaceId,
+                    sourceWorkspaceId: workspaceId,
+                    byModelDelta: { [canonicalModel]: displayUsage },
+                    timestamp: Date.now(),
+                  });
+                } catch (error) {
+                  log.warn("Failed to record tool model usage", {
+                    error,
+                    workspaceId,
+                    toolName: event.toolName,
+                    model: event.model,
+                  });
                 }
-                const eventModel = event.model.trim();
-                assert(eventModel.length > 0, "tool model usage event model must be non-empty");
-                // Persist tool-side model usage under its own model bucket so session costs keep
-                // advisor/system-side pricing separate from the parent chat model.
-                const providerMetadata = markProviderMetadataCostsIncluded(
-                  event.providerMetadata,
-                  toolModelCostsIncludedByModelString.get(eventModel)
-                );
-                const metadataModel = resolveModelForMetadata(
-                  eventModel,
-                  this.providerService.getConfig()
-                );
-                const displayUsage = createDisplayUsage(
-                  event.usage,
-                  eventModel,
-                  providerMetadata,
-                  metadataModel
-                );
-                if (!displayUsage) {
-                  return;
-                }
-                const canonicalModel = normalizeToCanonical(eventModel);
-                await this.sessionUsageService.recordUsage(
-                  workspaceId,
-                  canonicalModel,
-                  displayUsage
-                );
-                this.emit("session-usage-delta", {
-                  type: "session-usage-delta" as const,
-                  workspaceId,
-                  sourceWorkspaceId: workspaceId,
-                  byModelDelta: { [canonicalModel]: displayUsage },
-                  timestamp: Date.now(),
-                });
-              } catch (error) {
-                log.warn("Failed to record tool model usage", {
-                  error,
-                  workspaceId,
-                  toolName: event.toolName,
-                  model: event.model,
-                });
-              }
-            })();
+              })();
+            } catch (error) {
+              log.warn("Failed to record tool model usage", {
+                error,
+                workspaceId,
+                toolName: event.toolName,
+                model: event.model,
+              });
+            }
           },
           onConfigChanged: () => this.providerService.notifyConfigChanged(),
           taskService: this.taskService,
@@ -1571,10 +1594,6 @@ export class AIService extends EventEmitter {
         allTools,
         delegatedToolNames
       );
-
-      // Create assistant message ID early so the PTC callback closure captures it.
-      // The placeholder is appended to history below (after abort check).
-      const assistantMessageId = createAssistantMessageId();
 
       // Apply tool policy and PTC experiments (lazy-loads PTC dependencies only when needed).
       const applyToolPolicyAndExperimentsStartedAt = Date.now();

--- a/src/node/services/analytics/analyticsWorker.ts
+++ b/src/node/services/analytics/analyticsWorker.ts
@@ -84,6 +84,10 @@ interface RawQueryData {
   sql: string;
 }
 
+const EVENTS_COLUMN_MIGRATIONS_SQL = [
+  "ALTER TABLE events ADD COLUMN IF NOT EXISTS tool_name TEXT",
+] as const;
+
 const DELEGATION_ROLLUPS_COLUMN_MIGRATIONS_SQL = [
   "ALTER TABLE delegation_rollups ADD COLUMN IF NOT EXISTS input_tokens INTEGER DEFAULT 0",
   "ALTER TABLE delegation_rollups ADD COLUMN IF NOT EXISTS output_tokens INTEGER DEFAULT 0",
@@ -127,6 +131,9 @@ async function handleInit(data: InitData): Promise<void> {
   await activeConn.run(CREATE_EVENTS_TABLE_SQL);
   await activeConn.run(CREATE_WATERMARK_TABLE_SQL);
   await activeConn.run(CREATE_DELEGATION_ROLLUPS_TABLE_SQL);
+  for (const migrationSql of EVENTS_COLUMN_MIGRATIONS_SQL) {
+    await activeConn.run(migrationSql);
+  }
   for (const migrationSql of DELEGATION_ROLLUPS_COLUMN_MIGRATIONS_SQL) {
     await activeConn.run(migrationSql);
   }

--- a/src/node/services/analytics/etl.test.ts
+++ b/src/node/services/analytics/etl.test.ts
@@ -18,6 +18,7 @@ import {
   CREATE_EVENTS_TABLE_SQL,
   CREATE_WATERMARK_TABLE_SQL,
 } from "./schemaSql";
+import { createDisplayUsage } from "@/common/utils/tokens/displayUsage";
 
 const SUBAGENT_TRANSCRIPTS_DIR_NAME = "subagent-transcripts";
 
@@ -61,6 +62,10 @@ function makeAssistantLine(
     timestamp?: number;
     inputTokens?: number;
     outputTokens?: number;
+    durationMs?: number;
+    ttftMs?: number;
+    providerMetadata?: Record<string, unknown>;
+    toolModelUsages?: unknown[];
   } = {}
 ): string {
   return JSON.stringify({
@@ -75,6 +80,10 @@ function makeAssistantLine(
       },
       historySequence: opts.sequence ?? 1,
       timestamp: opts.timestamp ?? 1700000000000,
+      ...(opts.durationMs != null ? { duration: opts.durationMs } : {}),
+      ...(opts.ttftMs != null ? { ttftMs: opts.ttftMs } : {}),
+      ...(opts.providerMetadata != null ? { providerMetadata: opts.providerMetadata } : {}),
+      ...(opts.toolModelUsages != null ? { toolModelUsages: opts.toolModelUsages } : {}),
     },
   });
 }
@@ -313,6 +322,167 @@ describe("appendEvents", () => {
     expect(Number(rows[0].input_cost_usd)).toBeGreaterThan(0);
     expect(Number(rows[0].output_cost_usd)).toBeGreaterThan(0);
     expect(Number(rows[0].total_cost_usd)).toBeGreaterThan(0);
+  });
+
+
+  test("emits one assistant row plus one row per tool model usage with inherited context", async () => {
+    const sessionDir = await createTempSessionDir();
+    const parentTimestamp = 1_700_000_000_000;
+    const parentUsage = { inputTokens: 180, outputTokens: 72, totalTokens: 252 };
+    const sameModelToolUsage = {
+      toolName: "bash",
+      toolCallId: "tool-call-1",
+      timestamp: parentTimestamp + 25,
+      model: "openai:gpt-4",
+      usage: { inputTokens: 36, outputTokens: 12, totalTokens: 48 },
+      providerMetadata: { openai: { reasoningTokens: 3 } },
+    };
+    const otherModelToolUsage = {
+      toolName: "advisor",
+      toolCallId: "tool-call-2",
+      model: "anthropic:claude-sonnet-4-20250514",
+      usage: {
+        inputTokens: 96,
+        cachedInputTokens: 10,
+        outputTokens: 18,
+        totalTokens: 114,
+      },
+      providerMetadata: { anthropic: {} },
+    };
+
+    await writeMetadataJson(sessionDir, {
+      projectPath: "/proj",
+      projectName: "my-proj",
+      name: "workspace-name",
+      parentWorkspaceId: "parent-workspace",
+    });
+    await writeChatJsonl(sessionDir, [
+      makeUserLine(),
+      makeAssistantLine({
+        model: "openai:gpt-4",
+        inputTokens: parentUsage.inputTokens,
+        outputTokens: parentUsage.outputTokens,
+        timestamp: parentTimestamp,
+        durationMs: 400,
+        ttftMs: 40,
+        toolModelUsages: [sameModelToolUsage, otherModelToolUsage],
+      }),
+    ]);
+
+    const parsed = await parseWorkspaceFromDisk("ws-tool-rows", sessionDir, {});
+    expect(parsed).not.toBeNull();
+    assert(parsed, "tool row test expected parseWorkspaceFromDisk to parse workspace");
+    expect(parsed.events).toHaveLength(3);
+
+    const rows = parsed.events
+      .map((event) => event.row as Record<string, unknown>)
+      .sort((left, right) => {
+        const leftToolName = typeof left.tool_name === "string" ? left.tool_name : "";
+        const rightToolName = typeof right.tool_name === "string" ? right.tool_name : "";
+        return leftToolName.localeCompare(rightToolName) || Number(left.timestamp) - Number(right.timestamp);
+      });
+
+    const expectedAssistantUsage = createDisplayUsage(parentUsage, "openai:gpt-4");
+    const expectedSameModelToolUsage = createDisplayUsage(
+      sameModelToolUsage.usage,
+      sameModelToolUsage.model,
+      sameModelToolUsage.providerMetadata
+    );
+    const expectedOtherModelToolUsage = createDisplayUsage(
+      otherModelToolUsage.usage,
+      otherModelToolUsage.model,
+      otherModelToolUsage.providerMetadata
+    );
+    expect(expectedAssistantUsage).toBeDefined();
+    expect(expectedSameModelToolUsage).toBeDefined();
+    expect(expectedOtherModelToolUsage).toBeDefined();
+    if (!expectedAssistantUsage || !expectedSameModelToolUsage || !expectedOtherModelToolUsage) {
+      throw new Error("Expected tool row ETL test to compute display usage");
+    }
+
+    const assistantRow = rows.find((row) => row.tool_name == null);
+    const bashRow = rows.find((row) => row.tool_name === "bash");
+    const advisorRow = rows.find((row) => row.tool_name === "advisor");
+    expect(assistantRow).toBeDefined();
+    expect(bashRow).toBeDefined();
+    expect(advisorRow).toBeDefined();
+    if (!assistantRow || !bashRow || !advisorRow) {
+      throw new Error("Expected assistant, bash, and advisor analytics rows");
+    }
+
+    for (const row of [assistantRow, bashRow, advisorRow]) {
+      expect(row.project_path).toBe("/proj");
+      expect(row.project_name).toBe("my-proj");
+      expect(row.workspace_name).toBe("workspace-name");
+      expect(row.parent_workspace_id).toBe("parent-workspace");
+      expect(row.is_sub_agent).toBe(true);
+    }
+
+    expect(parseInteger(assistantRow.timestamp, "assistant timestamp")).toBe(parentTimestamp);
+    expect(assistantRow.model).toBe("openai:gpt-4");
+    expect(parseInteger(assistantRow.input_tokens, "assistant input_tokens")).toBe(
+      expectedAssistantUsage.input.tokens
+    );
+    expect(parseInteger(assistantRow.output_tokens, "assistant output_tokens")).toBe(
+      expectedAssistantUsage.output.tokens
+    );
+    expect(Number(assistantRow.total_cost_usd)).toBeCloseTo(
+      (expectedAssistantUsage.input.cost_usd ?? 0) +
+        (expectedAssistantUsage.output.cost_usd ?? 0) +
+        (expectedAssistantUsage.reasoning.cost_usd ?? 0) +
+        (expectedAssistantUsage.cached.cost_usd ?? 0) +
+        (expectedAssistantUsage.cacheCreate.cost_usd ?? 0),
+      12
+    );
+    expect(Number(assistantRow.duration_ms)).toBe(400);
+    expect(Number(assistantRow.ttft_ms)).toBe(40);
+    expect(Number(assistantRow.output_tps)).toBeCloseTo(180, 12);
+
+    expect(parseInteger(bashRow.timestamp, "bash timestamp")).toBe(parentTimestamp + 25);
+    expect(bashRow.model).toBe("openai:gpt-4");
+    expect(parseInteger(bashRow.input_tokens, "bash input_tokens")).toBe(
+      expectedSameModelToolUsage.input.tokens
+    );
+    expect(parseInteger(bashRow.output_tokens, "bash output_tokens")).toBe(
+      expectedSameModelToolUsage.output.tokens
+    );
+    expect(parseInteger(bashRow.reasoning_tokens, "bash reasoning_tokens")).toBe(
+      expectedSameModelToolUsage.reasoning.tokens
+    );
+    expect(Number(bashRow.total_cost_usd)).toBeCloseTo(
+      (expectedSameModelToolUsage.input.cost_usd ?? 0) +
+        (expectedSameModelToolUsage.output.cost_usd ?? 0) +
+        (expectedSameModelToolUsage.reasoning.cost_usd ?? 0) +
+        (expectedSameModelToolUsage.cached.cost_usd ?? 0) +
+        (expectedSameModelToolUsage.cacheCreate.cost_usd ?? 0),
+      12
+    );
+    expect(bashRow.duration_ms).toBeNull();
+    expect(bashRow.ttft_ms).toBeNull();
+    expect(bashRow.output_tps).toBeNull();
+
+    expect(parseInteger(advisorRow.timestamp, "advisor timestamp")).toBe(parentTimestamp);
+    expect(advisorRow.model).toBe("anthropic:claude-sonnet-4-20250514");
+    expect(parseInteger(advisorRow.input_tokens, "advisor input_tokens")).toBe(
+      expectedOtherModelToolUsage.input.tokens
+    );
+    expect(parseInteger(advisorRow.cached_tokens, "advisor cached_tokens")).toBe(
+      expectedOtherModelToolUsage.cached.tokens
+    );
+    expect(parseInteger(advisorRow.cache_create_tokens, "advisor cache_create_tokens")).toBe(
+      expectedOtherModelToolUsage.cacheCreate.tokens
+    );
+    expect(Number(advisorRow.total_cost_usd)).toBeCloseTo(
+      (expectedOtherModelToolUsage.input.cost_usd ?? 0) +
+        (expectedOtherModelToolUsage.output.cost_usd ?? 0) +
+        (expectedOtherModelToolUsage.reasoning.cost_usd ?? 0) +
+        (expectedOtherModelToolUsage.cached.cost_usd ?? 0) +
+        (expectedOtherModelToolUsage.cacheCreate.cost_usd ?? 0),
+      12
+    );
+    expect(advisorRow.duration_ms).toBeNull();
+    expect(advisorRow.ttft_ms).toBeNull();
+    expect(advisorRow.output_tps).toBeNull();
   });
 
   test("is a no-op when events is empty", async () => {

--- a/src/node/services/analytics/etl.test.ts
+++ b/src/node/services/analytics/etl.test.ts
@@ -22,6 +22,13 @@ import { createDisplayUsage } from "@/common/utils/tokens/displayUsage";
 
 const SUBAGENT_TRANSCRIPTS_DIR_NAME = "subagent-transcripts";
 
+const CREATE_EVENTS_TABLE_WITHOUT_TOOL_NAME_SQL = CREATE_EVENTS_TABLE_SQL.replace(
+  "\n  tool_name TEXT,",
+  ""
+)
+  .replace("\n  tool_name TEXT", "")
+  .replace(",\n)", "\n)");
+
 const tempDirsToClean: string[] = [];
 const duckDbHandlesToClose: Array<{ instance: DuckDBInstance; conn: DuckDBConnection }> = [];
 
@@ -123,12 +130,20 @@ async function createTempSessionDir(): Promise<string> {
   return sessionDir;
 }
 
-async function createTestConn(): Promise<DuckDBConnection> {
+async function createTestConn(
+  params: {
+    createEventsTableSql?: string;
+    postCreateEventsSql?: string[];
+  } = {}
+): Promise<DuckDBConnection> {
   const instance = await DuckDBInstance.create(":memory:");
   const conn = await instance.connect();
   duckDbHandlesToClose.push({ instance, conn });
 
-  await conn.run(CREATE_EVENTS_TABLE_SQL);
+  await conn.run(params.createEventsTableSql ?? CREATE_EVENTS_TABLE_SQL);
+  for (const sql of params.postCreateEventsSql ?? []) {
+    await conn.run(sql);
+  }
   await conn.run(CREATE_WATERMARK_TABLE_SQL);
   await conn.run(CREATE_DELEGATION_ROLLUPS_TABLE_SQL);
 
@@ -322,6 +337,73 @@ describe("appendEvents", () => {
     expect(Number(rows[0].input_cost_usd)).toBeGreaterThan(0);
     expect(Number(rows[0].output_cost_usd)).toBeGreaterThan(0);
     expect(Number(rows[0].total_cost_usd)).toBeGreaterThan(0);
+  });
+
+  test("keeps tool_name aligned across fresh and migrated events tables", async () => {
+    const freshConn = await createTestConn();
+    const migratedConn = await createTestConn({
+      createEventsTableSql: CREATE_EVENTS_TABLE_WITHOUT_TOOL_NAME_SQL,
+      postCreateEventsSql: ["ALTER TABLE events ADD COLUMN IF NOT EXISTS tool_name TEXT"],
+    });
+    const sessionDir = await createTempSessionDir();
+    const workspaceId = "ws-tool-column-order";
+
+    await writeChatJsonl(sessionDir, [
+      makeUserLine(),
+      makeAssistantLine({
+        model: "openai:gpt-4",
+        inputTokens: 180,
+        outputTokens: 72,
+        timestamp: 1_700_000_000_000,
+        toolModelUsages: [
+          {
+            toolName: "bash",
+            toolCallId: "tool-call-1",
+            timestamp: 1_700_000_000_025,
+            model: "openai:gpt-4",
+            usage: { inputTokens: 36, outputTokens: 12, totalTokens: 48 },
+            providerMetadata: { openai: { reasoningTokens: 3 } },
+          },
+        ],
+      }),
+    ]);
+
+    const parsed = await parseWorkspaceFromDisk(workspaceId, sessionDir, {});
+    expect(parsed).not.toBeNull();
+    assert(parsed, "column-order test expected parseWorkspaceFromDisk to parse workspace");
+
+    const toolEvents = parsed.events.filter((event) => event.row.tool_name != null);
+    expect(toolEvents).toHaveLength(1);
+
+    await appendEvents(freshConn, toolEvents);
+    await appendEvents(migratedConn, toolEvents);
+
+    const normalizeSelectedRow = (row: Record<string, unknown>) => ({
+      workspaceId: typeof row.workspace_id === "string" ? row.workspace_id : null,
+      toolName: typeof row.tool_name === "string" ? row.tool_name : null,
+      thinkingLevel: typeof row.thinking_level === "string" ? row.thinking_level : null,
+      inputTokens:
+        row.input_tokens == null ? null : parseInteger(row.input_tokens, "selected input_tokens"),
+    });
+
+    const selectedSql =
+      "SELECT workspace_id, tool_name, thinking_level, input_tokens FROM events WHERE workspace_id = ?";
+    const freshRows = (await queryRows(freshConn, selectedSql, [workspaceId])).map(
+      normalizeSelectedRow
+    );
+    const migratedRows = (await queryRows(migratedConn, selectedSql, [workspaceId])).map(
+      normalizeSelectedRow
+    );
+
+    expect(freshRows).toEqual([
+      {
+        workspaceId,
+        toolName: "bash",
+        thinkingLevel: null,
+        inputTokens: 36,
+      },
+    ]);
+    expect(migratedRows).toEqual(freshRows);
   });
 
   test("emits one assistant row plus one row per tool model usage with inherited context", async () => {

--- a/src/node/services/analytics/etl.test.ts
+++ b/src/node/services/analytics/etl.test.ts
@@ -487,6 +487,144 @@ describe("appendEvents", () => {
     expect(advisorRow.output_tps).toBeNull();
   });
 
+  test("emits tool rows when assistant usage is missing", async () => {
+    const sessionDir = await createTempSessionDir();
+    const assistantTimestamp = 1_700_000_000_000;
+    const bashToolUsage = {
+      toolName: "bash",
+      toolCallId: "tool-call-1",
+      timestamp: assistantTimestamp + 25,
+      model: "openai:gpt-4",
+      usage: { inputTokens: 36, outputTokens: 12, totalTokens: 48 },
+      providerMetadata: { openai: { reasoningTokens: 3 } },
+    };
+    const advisorToolUsage = {
+      toolName: "advisor",
+      toolCallId: "tool-call-2",
+      model: "anthropic:claude-sonnet-4-20250514",
+      usage: {
+        inputTokens: 96,
+        cachedInputTokens: 10,
+        outputTokens: 18,
+        totalTokens: 114,
+      },
+      providerMetadata: { anthropic: { cacheCreationInputTokens: 4 } },
+    };
+
+    await writeMetadataJson(sessionDir, {
+      projectPath: "/proj",
+      projectName: "my-proj",
+      name: "workspace-name",
+      parentWorkspaceId: "parent-workspace",
+    });
+    await writeChatJsonl(sessionDir, [
+      makeUserLine(),
+      JSON.stringify({
+        role: "assistant",
+        content: "response",
+        metadata: {
+          model: "openai:gpt-4",
+          historySequence: 1,
+          timestamp: assistantTimestamp,
+          agentId: "exec",
+          toolModelUsages: [bashToolUsage, advisorToolUsage],
+        },
+      }),
+    ]);
+
+    const parsed = await parseWorkspaceFromDisk("ws-tool-only-rows", sessionDir, {});
+    expect(parsed).not.toBeNull();
+    assert(parsed, "tool-only row test expected parseWorkspaceFromDisk to parse workspace");
+    expect(parsed.events).toHaveLength(2);
+
+    const rows = parsed.events
+      .map((event) => event.row as Record<string, unknown>)
+      .sort((left, right) => {
+        const leftToolName = typeof left.tool_name === "string" ? left.tool_name : "";
+        const rightToolName = typeof right.tool_name === "string" ? right.tool_name : "";
+        return (
+          leftToolName.localeCompare(rightToolName) ||
+          Number(left.timestamp) - Number(right.timestamp)
+        );
+      });
+
+    expect(rows.filter((row) => row.tool_name == null)).toHaveLength(0);
+
+    const expectedBashToolUsage = createDisplayUsage(
+      bashToolUsage.usage,
+      bashToolUsage.model,
+      bashToolUsage.providerMetadata
+    );
+    const expectedAdvisorToolUsage = createDisplayUsage(
+      advisorToolUsage.usage,
+      advisorToolUsage.model,
+      advisorToolUsage.providerMetadata
+    );
+    expect(expectedBashToolUsage).toBeDefined();
+    expect(expectedAdvisorToolUsage).toBeDefined();
+    if (!expectedBashToolUsage || !expectedAdvisorToolUsage) {
+      throw new Error("Expected tool-only ETL test to compute display usage");
+    }
+
+    const bashRow = rows.find((row) => row.tool_name === "bash");
+    const advisorRow = rows.find((row) => row.tool_name === "advisor");
+    expect(bashRow).toBeDefined();
+    expect(advisorRow).toBeDefined();
+    if (!bashRow || !advisorRow) {
+      throw new Error("Expected bash and advisor analytics rows when assistant usage is missing");
+    }
+
+    for (const row of [bashRow, advisorRow]) {
+      expect(row.workspace_id).toBe("ws-tool-only-rows");
+      expect(row.project_path).toBe("/proj");
+      expect(row.project_name).toBe("my-proj");
+      expect(row.workspace_name).toBe("workspace-name");
+      expect(row.parent_workspace_id).toBe("parent-workspace");
+      expect(row.agent_id).toBe("exec");
+      expect(row.is_sub_agent).toBe(true);
+    }
+
+    expect(parseInteger(bashRow.timestamp, "bash timestamp")).toBe(assistantTimestamp + 25);
+    expect(bashRow.model).toBe("openai:gpt-4");
+    expect(parseInteger(bashRow.input_tokens, "bash input_tokens")).toBe(
+      expectedBashToolUsage.input.tokens
+    );
+    expect(parseInteger(bashRow.output_tokens, "bash output_tokens")).toBe(
+      expectedBashToolUsage.output.tokens
+    );
+    expect(parseInteger(bashRow.reasoning_tokens, "bash reasoning_tokens")).toBe(
+      expectedBashToolUsage.reasoning.tokens
+    );
+    expect(Number(bashRow.total_cost_usd)).toBeCloseTo(
+      (expectedBashToolUsage.input.cost_usd ?? 0) +
+        (expectedBashToolUsage.output.cost_usd ?? 0) +
+        (expectedBashToolUsage.reasoning.cost_usd ?? 0) +
+        (expectedBashToolUsage.cached.cost_usd ?? 0) +
+        (expectedBashToolUsage.cacheCreate.cost_usd ?? 0),
+      12
+    );
+
+    expect(parseInteger(advisorRow.timestamp, "advisor timestamp")).toBe(assistantTimestamp);
+    expect(advisorRow.model).toBe("anthropic:claude-sonnet-4-20250514");
+    expect(parseInteger(advisorRow.input_tokens, "advisor input_tokens")).toBe(
+      expectedAdvisorToolUsage.input.tokens
+    );
+    expect(parseInteger(advisorRow.cached_tokens, "advisor cached_tokens")).toBe(
+      expectedAdvisorToolUsage.cached.tokens
+    );
+    expect(parseInteger(advisorRow.cache_create_tokens, "advisor cache_create_tokens")).toBe(
+      expectedAdvisorToolUsage.cacheCreate.tokens
+    );
+    expect(Number(advisorRow.total_cost_usd)).toBeCloseTo(
+      (expectedAdvisorToolUsage.input.cost_usd ?? 0) +
+        (expectedAdvisorToolUsage.output.cost_usd ?? 0) +
+        (expectedAdvisorToolUsage.reasoning.cost_usd ?? 0) +
+        (expectedAdvisorToolUsage.cached.cost_usd ?? 0) +
+        (expectedAdvisorToolUsage.cacheCreate.cost_usd ?? 0),
+      12
+    );
+  });
+
   test("is a no-op when events is empty", async () => {
     const conn = await createTestConn();
 

--- a/src/node/services/analytics/etl.test.ts
+++ b/src/node/services/analytics/etl.test.ts
@@ -11,6 +11,7 @@ import {
   clearWorkspaceAnalyticsState,
   ingestWorkspace,
   parseWorkspaceFromDisk,
+  readPersistedWorkspaceHeadSignature,
   rebuildAll,
 } from "./etl";
 import {
@@ -122,6 +123,48 @@ function parseBooleanFromInteger(value: unknown, fieldName: string): boolean {
   const parsed = parseInteger(value, fieldName);
   assert(parsed === 0 || parsed === 1, `${fieldName} should be 0 or 1`);
   return parsed === 1;
+}
+
+function serializeHeadSignatureValue(value: string | number | null): string {
+  if (value === null) {
+    return "null";
+  }
+
+  return `${typeof value}:${String(value)}`;
+}
+
+function parseNullableFiniteNumber(value: unknown, fieldName: string): number | null {
+  if (value === null) {
+    return null;
+  }
+
+  if (typeof value === "number") {
+    assert(Number.isFinite(value), `${fieldName} should be a finite number`);
+    return value;
+  }
+
+  if (typeof value === "bigint") {
+    const coerced = Number(value);
+    assert(Number.isFinite(coerced), `${fieldName} should coerce to a finite number`);
+    return coerced;
+  }
+
+  throw new TypeError(`${fieldName} should be numeric or null`);
+}
+
+function createHeadSignatureFromRow(row: {
+  timestamp: unknown;
+  model: unknown;
+  total_cost_usd: unknown;
+}): string {
+  const model = row.model;
+  assert(model === null || typeof model === "string", "model should be a string or null");
+
+  return [
+    serializeHeadSignatureValue(parseNullableFiniteNumber(row.timestamp, "timestamp")),
+    serializeHeadSignatureValue(model),
+    serializeHeadSignatureValue(parseNullableFiniteNumber(row.total_cost_usd, "total_cost_usd")),
+  ].join("|");
 }
 
 async function createTempSessionDir(): Promise<string> {
@@ -713,6 +756,135 @@ describe("appendEvents", () => {
     await appendEvents(conn, []);
 
     expect(await queryEventCount(conn)).toBe(0);
+  });
+});
+
+describe("ingestWorkspace", () => {
+  test("repairs stale tool-only head rows when head signature drift forces a rebuild", async () => {
+    const conn = await createTestConn();
+    const sessionDir = await createTempSessionDir();
+    const workspaceId = "ws-tool-only-head-signature";
+    const headTimestamp = 1_700_000_000_000;
+    const headToolUsage = {
+      toolName: "bash",
+      toolCallId: "tool-call-1",
+      timestamp: headTimestamp + 25,
+      model: "openai:gpt-4",
+      usage: { inputTokens: 36, outputTokens: 12, totalTokens: 48 },
+      providerMetadata: { openai: { reasoningTokens: 3 } },
+    };
+    const secondToolUsage = {
+      toolName: "advisor",
+      toolCallId: "tool-call-2",
+      timestamp: headTimestamp + 1_025,
+      model: "anthropic:claude-sonnet-4-20250514",
+      usage: {
+        inputTokens: 96,
+        cachedInputTokens: 10,
+        outputTokens: 18,
+        totalTokens: 114,
+      },
+      providerMetadata: { anthropic: { cacheCreationInputTokens: 4 } },
+    };
+
+    await writeChatJsonl(sessionDir, [
+      makeUserLine(),
+      JSON.stringify({
+        role: "assistant",
+        content: "tool-only response",
+        metadata: {
+          model: "openai:gpt-4",
+          historySequence: 1,
+          timestamp: headTimestamp,
+          toolModelUsages: [headToolUsage],
+        },
+      }),
+      makeUserLine(),
+      JSON.stringify({
+        role: "assistant",
+        content: "second tool-only response",
+        metadata: {
+          model: "anthropic:claude-sonnet-4-20250514",
+          historySequence: 2,
+          timestamp: headTimestamp + 1_000,
+          toolModelUsages: [secondToolUsage],
+        },
+      }),
+    ]);
+
+    await ingestWorkspace(conn, workspaceId, sessionDir, { projectPath: "/proj" });
+
+    expect(await queryEventCount(conn, workspaceId)).toBe(2);
+    const headRows = await queryRows(
+      conn,
+      "SELECT tool_name, total_cost_usd FROM events WHERE workspace_id = ? AND response_index = 0",
+      [workspaceId]
+    );
+    expect(headRows).toHaveLength(1);
+    expect(headRows[0].tool_name).toBe("bash");
+
+    const originalHeadTotalCostUsd = Number(headRows[0].total_cost_usd);
+    expect(Number.isFinite(originalHeadTotalCostUsd)).toBe(true);
+    const mutatedHeadTotalCostUsd = originalHeadTotalCostUsd + 123;
+
+    await conn.run(
+      "UPDATE events SET total_cost_usd = ? WHERE workspace_id = ? AND response_index = 0 AND tool_name = ?",
+      [mutatedHeadTotalCostUsd, workspaceId, "bash"]
+    );
+
+    await bumpChatMtime(sessionDir);
+    await ingestWorkspace(conn, workspaceId, sessionDir, { projectPath: "/proj" });
+
+    expect(await queryEventCount(conn, workspaceId)).toBe(2);
+    const refreshedHeadRows = await queryRows(
+      conn,
+      "SELECT tool_name, total_cost_usd FROM events WHERE workspace_id = ? AND response_index = 0",
+      [workspaceId]
+    );
+    expect(refreshedHeadRows).toHaveLength(1);
+    expect(refreshedHeadRows[0].tool_name).toBe("bash");
+    expect(Number(refreshedHeadRows[0].total_cost_usd)).toBeCloseTo(originalHeadTotalCostUsd, 12);
+  });
+});
+
+describe("readPersistedWorkspaceHeadSignature", () => {
+  test("prefers the assistant row before tool rows at the same response index", async () => {
+    const conn = await createTestConn();
+    const sessionDir = await createTempSessionDir();
+    const workspaceId = "ws-head-signature-order";
+    const toolUsage = {
+      toolName: "bash",
+      toolCallId: "tool-call-1",
+      timestamp: 1_700_000_000_025,
+      model: "openai:gpt-4",
+      usage: { inputTokens: 36, outputTokens: 12, totalTokens: 48 },
+      providerMetadata: { openai: { reasoningTokens: 3 } },
+    };
+
+    await writeChatJsonl(sessionDir, [
+      makeUserLine(),
+      makeAssistantLine({
+        model: "openai:gpt-4",
+        sequence: 1,
+        timestamp: 1_700_000_000_000,
+        inputTokens: 180,
+        outputTokens: 72,
+        toolModelUsages: [toolUsage],
+      }),
+    ]);
+
+    const parsed = await parseWorkspaceFromDisk(workspaceId, sessionDir, {});
+    expect(parsed).not.toBeNull();
+    assert(parsed, "head signature order test expected parseWorkspaceFromDisk to parse workspace");
+    expect(parsed.events).toHaveLength(2);
+    expect(parsed.events.map((event) => event.row.tool_name)).toEqual([null, "bash"]);
+    expect(parsed.events.map((event) => event.row.response_index)).toEqual([0, 0]);
+
+    await appendEvents(conn, parsed.events);
+
+    const persistedHeadSignature = await readPersistedWorkspaceHeadSignature(conn, workspaceId);
+    expect(persistedHeadSignature).toBe(createHeadSignatureFromRow(parsed.events[0].row));
+    expect(persistedHeadSignature).not.toBe(createHeadSignatureFromRow(parsed.events[1].row));
   });
 });
 

--- a/src/node/services/analytics/etl.test.ts
+++ b/src/node/services/analytics/etl.test.ts
@@ -324,7 +324,6 @@ describe("appendEvents", () => {
     expect(Number(rows[0].total_cost_usd)).toBeGreaterThan(0);
   });
 
-
   test("emits one assistant row plus one row per tool model usage with inherited context", async () => {
     const sessionDir = await createTempSessionDir();
     const parentTimestamp = 1_700_000_000_000;
@@ -379,7 +378,10 @@ describe("appendEvents", () => {
       .sort((left, right) => {
         const leftToolName = typeof left.tool_name === "string" ? left.tool_name : "";
         const rightToolName = typeof right.tool_name === "string" ? right.tool_name : "";
-        return leftToolName.localeCompare(rightToolName) || Number(left.timestamp) - Number(right.timestamp);
+        return (
+          leftToolName.localeCompare(rightToolName) ||
+          Number(left.timestamp) - Number(right.timestamp)
+        );
       });
 
     const expectedAssistantUsage = createDisplayUsage(parentUsage, "openai:gpt-4");

--- a/src/node/services/analytics/etl.ts
+++ b/src/node/services/analytics/etl.ts
@@ -559,10 +559,6 @@ function extractIngestEvents(params: {
   }
 
   const usage = parseUsage(metadata.usage);
-  if (!usage) {
-    return [];
-  }
-
   const sequence = toFiniteInteger(metadata.historySequence) ?? params.lineNumber;
   const timestamp =
     toFiniteNumber(metadata.timestamp) ?? parseCreatedAtTimestamp(params.message.createdAt) ?? null;
@@ -575,39 +571,42 @@ function extractIngestEvents(params: {
     responseIndex: params.responseIndex,
     isSubAgent: (params.workspaceMeta.parentWorkspaceId ?? "").length > 0,
   };
+  const events: IngestEvent[] = [];
 
-  const parentRow = buildIngestEventRow({
-    inheritedContext,
-    model: toOptionalString(metadata.model) ?? null,
-    metadataModel: toOptionalString(metadata.metadataModel),
-    usage,
-    providerMetadata: isRecord(metadata.providerMetadata) ? metadata.providerMetadata : undefined,
-    toolName: null,
-    timestamp,
-    durationMs,
-    ttftMs: extractTtftMs(metadata),
-    outputTps: null,
-  });
-  if (!parentRow.parsed.success) {
-    log.warn("[analytics-etl] Skipping invalid analytics row", {
-      workspaceId: params.workspaceId,
-      lineNumber: params.lineNumber,
-      issues: parentRow.parsed.error.issues,
+  // Tool usage snapshots can survive even when the parent assistant usage payload is missing.
+  // Keep ingesting those rows so malformed or partial history does not drop tool costs.
+  if (usage) {
+    const parentRow = buildIngestEventRow({
+      inheritedContext,
+      model: toOptionalString(metadata.model) ?? null,
+      metadataModel: toOptionalString(metadata.metadataModel),
+      usage,
+      providerMetadata: isRecord(metadata.providerMetadata) ? metadata.providerMetadata : undefined,
+      toolName: null,
+      timestamp,
+      durationMs,
+      ttftMs: extractTtftMs(metadata),
+      outputTps: null,
     });
-    return [];
-  }
+    if (!parentRow.parsed.success) {
+      log.warn("[analytics-etl] Skipping invalid analytics row", {
+        workspaceId: params.workspaceId,
+        lineNumber: params.lineNumber,
+        issues: parentRow.parsed.error.issues,
+      });
+    } else {
+      if (durationMs !== null && durationMs > 0) {
+        parentRow.parsed.data.output_tps =
+          parentRow.parsed.data.output_tokens / (durationMs / 1000);
+      }
 
-  if (durationMs !== null && durationMs > 0) {
-    parentRow.parsed.data.output_tps = parentRow.parsed.data.output_tokens / (durationMs / 1000);
+      events.push({
+        row: parentRow.parsed.data,
+        sequence,
+        date: parentRow.date,
+      });
+    }
   }
-
-  const events: IngestEvent[] = [
-    {
-      row: parentRow.parsed.data,
-      sequence,
-      date: parentRow.date,
-    },
-  ];
 
   const toolModelUsages = metadata.toolModelUsages;
   if (!Array.isArray(toolModelUsages)) {

--- a/src/node/services/analytics/etl.ts
+++ b/src/node/services/analytics/etl.ts
@@ -131,7 +131,6 @@ export async function appendEvents(conn: DuckDBConnection, events: IngestEvent[]
       appendBigIntOrNull(appender, row.timestamp);
       appendDateOrNull(appender, event.date);
       appendVarcharOrNull(appender, row.model);
-      appendVarcharOrNull(appender, row.tool_name);
       appendVarcharOrNull(appender, row.thinking_level);
       appender.appendInteger(row.input_tokens);
       appender.appendInteger(row.output_tokens);
@@ -150,6 +149,7 @@ export async function appendEvents(conn: DuckDBConnection, events: IngestEvent[]
       appendDoubleOrNull(appender, row.output_tps);
       appendIntegerOrNull(appender, row.response_index);
       appender.appendBoolean(row.is_sub_agent);
+      appendVarcharOrNull(appender, row.tool_name);
       appender.endRow();
     }
 

--- a/src/node/services/analytics/etl.ts
+++ b/src/node/services/analytics/etl.ts
@@ -188,6 +188,78 @@ interface IngestEvent {
   date: string | null;
 }
 
+interface IngestEventContext {
+  workspaceId: string;
+  workspaceMeta: WorkspaceMeta;
+  agentId: string | null;
+  thinkingLevel: string | null;
+  responseIndex: number;
+  isSubAgent: boolean;
+}
+
+function buildIngestEventRow(params: {
+  inheritedContext: IngestEventContext;
+  model: string | null;
+  metadataModel?: string;
+  usage: LanguageModelV2Usage;
+  providerMetadata?: Record<string, unknown>;
+  toolName: string | null;
+  timestamp: number | null;
+  durationMs: number | null;
+  ttftMs: number | null;
+  outputTps: number | null;
+}): {
+  parsed: ReturnType<typeof EventRowSchema.safeParse>;
+  date: string | null;
+} {
+  const displayUsage = createDisplayUsage(
+    params.usage,
+    params.model ?? "unknown",
+    params.providerMetadata,
+    params.metadataModel
+  );
+  assert(displayUsage, "createDisplayUsage should return data for parsed usage payloads");
+
+  const cachedCostUsd =
+    (displayUsage.cached.cost_usd ?? 0) + (displayUsage.cacheCreate.cost_usd ?? 0);
+  return {
+    parsed: EventRowSchema.safeParse({
+      workspace_id: params.inheritedContext.workspaceId,
+      project_path: params.inheritedContext.workspaceMeta.projectPath ?? null,
+      project_name: params.inheritedContext.workspaceMeta.projectName ?? null,
+      workspace_name: params.inheritedContext.workspaceMeta.workspaceName ?? null,
+      parent_workspace_id: params.inheritedContext.workspaceMeta.parentWorkspaceId ?? null,
+      agent_id: params.inheritedContext.agentId,
+      timestamp: params.timestamp,
+      model: params.model,
+      tool_name: params.toolName,
+      thinking_level: params.inheritedContext.thinkingLevel,
+      input_tokens: displayUsage.input.tokens,
+      output_tokens: displayUsage.output.tokens,
+      reasoning_tokens: displayUsage.reasoning.tokens,
+      cached_tokens: displayUsage.cached.tokens,
+      cache_create_tokens: displayUsage.cacheCreate.tokens,
+      input_cost_usd: displayUsage.input.cost_usd ?? 0,
+      output_cost_usd: displayUsage.output.cost_usd ?? 0,
+      reasoning_cost_usd: displayUsage.reasoning.cost_usd ?? 0,
+      cached_cost_usd: cachedCostUsd,
+      total_cost_usd:
+        (displayUsage.input.cost_usd ?? 0) +
+        (displayUsage.output.cost_usd ?? 0) +
+        (displayUsage.reasoning.cost_usd ?? 0) +
+        cachedCostUsd,
+      duration_ms: params.durationMs,
+      ttft_ms: params.ttftMs,
+      streaming_ms: null,
+      tool_execution_ms: null,
+      output_tps: params.outputTps,
+      response_index: params.inheritedContext.responseIndex,
+      is_sub_agent: params.inheritedContext.isSubAgent,
+    }),
+    date: dateBucketFromTimestamp(params.timestamp),
+  };
+}
+
 interface DelegationRollupRaw {
   usageData: Record<string, unknown> | null;
   reportTokenByChildId: Map<string, number>;
@@ -492,87 +564,48 @@ function extractIngestEvents(params: {
   }
 
   const sequence = toFiniteInteger(metadata.historySequence) ?? params.lineNumber;
-
-  const model = toOptionalString(metadata.model);
-  const metadataModel = toOptionalString(metadata.metadataModel);
-  const providerMetadata = isRecord(metadata.providerMetadata)
-    ? metadata.providerMetadata
-    : undefined;
-
-  const displayUsage = createDisplayUsage(
-    usage,
-    model ?? "unknown",
-    providerMetadata,
-    metadataModel
-  );
-  assert(displayUsage, "createDisplayUsage should return data for parsed usage payloads");
-
   const timestamp =
     toFiniteNumber(metadata.timestamp) ?? parseCreatedAtTimestamp(params.message.createdAt) ?? null;
-  const dateBucket = dateBucketFromTimestamp(timestamp);
-
-  const inputTokens = displayUsage.input.tokens;
-  const outputTokens = displayUsage.output.tokens;
-  const reasoningTokens = displayUsage.reasoning.tokens;
-  const cachedTokens = displayUsage.cached.tokens;
-  const cacheCreateTokens = displayUsage.cacheCreate.tokens;
-
-  const inputCostUsd = displayUsage.input.cost_usd ?? 0;
-  const outputCostUsd = displayUsage.output.cost_usd ?? 0;
-  const reasoningCostUsd = displayUsage.reasoning.cost_usd ?? 0;
-  const cachedCostUsd =
-    (displayUsage.cached.cost_usd ?? 0) + (displayUsage.cacheCreate.cost_usd ?? 0);
-
   const durationMs = toFiniteNumber(metadata.duration);
-  const ttftMs = extractTtftMs(metadata);
-  const outputTps =
-    durationMs !== null && durationMs > 0 ? outputTokens / (durationMs / 1000) : null;
-
-  const maybeEvent = {
-    workspace_id: params.workspaceId,
-    project_path: params.workspaceMeta.projectPath ?? null,
-    project_name: params.workspaceMeta.projectName ?? null,
-    workspace_name: params.workspaceMeta.workspaceName ?? null,
-    parent_workspace_id: params.workspaceMeta.parentWorkspaceId ?? null,
-    agent_id: toOptionalString(metadata.agentId) ?? null,
-    timestamp,
-    model: model ?? null,
-    tool_name: null,
-    thinking_level: toOptionalString(metadata.thinkingLevel) ?? null,
-    input_tokens: inputTokens,
-    output_tokens: outputTokens,
-    reasoning_tokens: reasoningTokens,
-    cached_tokens: cachedTokens,
-    cache_create_tokens: cacheCreateTokens,
-    input_cost_usd: inputCostUsd,
-    output_cost_usd: outputCostUsd,
-    reasoning_cost_usd: reasoningCostUsd,
-    cached_cost_usd: cachedCostUsd,
-    total_cost_usd: inputCostUsd + outputCostUsd + reasoningCostUsd + cachedCostUsd,
-    duration_ms: durationMs,
-    ttft_ms: ttftMs,
-    streaming_ms: null,
-    tool_execution_ms: null,
-    output_tps: outputTps,
-    response_index: params.responseIndex,
-    is_sub_agent: (params.workspaceMeta.parentWorkspaceId ?? "").length > 0,
+  const inheritedContext: IngestEventContext = {
+    workspaceId: params.workspaceId,
+    workspaceMeta: params.workspaceMeta,
+    agentId: toOptionalString(metadata.agentId) ?? null,
+    thinkingLevel: toOptionalString(metadata.thinkingLevel) ?? null,
+    responseIndex: params.responseIndex,
+    isSubAgent: (params.workspaceMeta.parentWorkspaceId ?? "").length > 0,
   };
 
-  const parsedEvent = EventRowSchema.safeParse(maybeEvent);
-  if (!parsedEvent.success) {
+  const parentRow = buildIngestEventRow({
+    inheritedContext,
+    model: toOptionalString(metadata.model) ?? null,
+    metadataModel: toOptionalString(metadata.metadataModel),
+    usage,
+    providerMetadata: isRecord(metadata.providerMetadata) ? metadata.providerMetadata : undefined,
+    toolName: null,
+    timestamp,
+    durationMs,
+    ttftMs: extractTtftMs(metadata),
+    outputTps: null,
+  });
+  if (!parentRow.parsed.success) {
     log.warn("[analytics-etl] Skipping invalid analytics row", {
       workspaceId: params.workspaceId,
       lineNumber: params.lineNumber,
-      issues: parsedEvent.error.issues,
+      issues: parentRow.parsed.error.issues,
     });
     return [];
   }
 
+  if (durationMs !== null && durationMs > 0) {
+    parentRow.parsed.data.output_tps = parentRow.parsed.data.output_tokens / (durationMs / 1000);
+  }
+
   const events: IngestEvent[] = [
     {
-      row: parsedEvent.data,
+      row: parentRow.parsed.data,
       sequence,
-      date: dateBucket,
+      date: parentRow.date,
     },
   ];
 
@@ -593,71 +626,33 @@ function extractIngestEvents(params: {
       continue;
     }
 
-    const toolProviderMetadata = isRecord(rawToolModelUsage.providerMetadata)
-      ? rawToolModelUsage.providerMetadata
-      : undefined;
-    const toolMetadataModel = toOptionalString(rawToolModelUsage.metadataModel);
-    const toolDisplayUsage = createDisplayUsage(
-      toolUsage,
-      toolModel,
-      toolProviderMetadata,
-      toolMetadataModel
-    );
-    if (!toolDisplayUsage) {
-      continue;
-    }
-
-    const toolTimestamp = toFiniteNumber(rawToolModelUsage.timestamp) ?? timestamp;
-    const toolCachedCostUsd =
-      (toolDisplayUsage.cached.cost_usd ?? 0) + (toolDisplayUsage.cacheCreate.cost_usd ?? 0);
-    const maybeToolEvent = {
-      workspace_id: params.workspaceId,
-      project_path: params.workspaceMeta.projectPath ?? null,
-      project_name: params.workspaceMeta.projectName ?? null,
-      workspace_name: params.workspaceMeta.workspaceName ?? null,
-      parent_workspace_id: params.workspaceMeta.parentWorkspaceId ?? null,
-      agent_id: toOptionalString(metadata.agentId) ?? null,
-      timestamp: toolTimestamp,
+    const toolRow = buildIngestEventRow({
+      inheritedContext,
       model: toolModel,
-      tool_name: toolName,
-      thinking_level: toOptionalString(metadata.thinkingLevel) ?? null,
-      input_tokens: toolDisplayUsage.input.tokens,
-      output_tokens: toolDisplayUsage.output.tokens,
-      reasoning_tokens: toolDisplayUsage.reasoning.tokens,
-      cached_tokens: toolDisplayUsage.cached.tokens,
-      cache_create_tokens: toolDisplayUsage.cacheCreate.tokens,
-      input_cost_usd: toolDisplayUsage.input.cost_usd ?? 0,
-      output_cost_usd: toolDisplayUsage.output.cost_usd ?? 0,
-      reasoning_cost_usd: toolDisplayUsage.reasoning.cost_usd ?? 0,
-      cached_cost_usd: toolCachedCostUsd,
-      total_cost_usd:
-        (toolDisplayUsage.input.cost_usd ?? 0) +
-        (toolDisplayUsage.output.cost_usd ?? 0) +
-        (toolDisplayUsage.reasoning.cost_usd ?? 0) +
-        toolCachedCostUsd,
-      duration_ms: null,
-      ttft_ms: null,
-      streaming_ms: null,
-      tool_execution_ms: null,
-      output_tps: null,
-      response_index: params.responseIndex,
-      is_sub_agent: (params.workspaceMeta.parentWorkspaceId ?? "").length > 0,
-    };
-
-    const parsedToolEvent = EventRowSchema.safeParse(maybeToolEvent);
-    if (!parsedToolEvent.success) {
+      metadataModel: toOptionalString(rawToolModelUsage.metadataModel),
+      usage: toolUsage,
+      providerMetadata: isRecord(rawToolModelUsage.providerMetadata)
+        ? rawToolModelUsage.providerMetadata
+        : undefined,
+      toolName,
+      timestamp: toFiniteNumber(rawToolModelUsage.timestamp) ?? timestamp,
+      durationMs: null,
+      ttftMs: null,
+      outputTps: null,
+    });
+    if (!toolRow.parsed.success) {
       log.warn("[analytics-etl] Skipping invalid tool analytics row", {
         workspaceId: params.workspaceId,
         lineNumber: params.lineNumber,
-        issues: parsedToolEvent.error.issues,
+        issues: toolRow.parsed.error.issues,
       });
       continue;
     }
 
     events.push({
-      row: parsedToolEvent.data,
+      row: toolRow.parsed.data,
       sequence,
-      date: dateBucketFromTimestamp(toolTimestamp),
+      date: toolRow.date,
     });
   }
 

--- a/src/node/services/analytics/etl.ts
+++ b/src/node/services/analytics/etl.ts
@@ -33,6 +33,7 @@ INSERT INTO events (
   timestamp,
   date,
   model,
+  tool_name,
   thinking_level,
   input_tokens,
   output_tokens,
@@ -52,9 +53,9 @@ INSERT INTO events (
   response_index,
   is_sub_agent
 ) VALUES (
-  ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-  ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-  ?, ?, ?, ?, ?, ?, ?
+  ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+  ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+  ?, ?, ?, ?, ?, ?
 )
 `;
 
@@ -130,6 +131,7 @@ export async function appendEvents(conn: DuckDBConnection, events: IngestEvent[]
       appendBigIntOrNull(appender, row.timestamp);
       appendDateOrNull(appender, event.date);
       appendVarcharOrNull(appender, row.model);
+      appendVarcharOrNull(appender, row.tool_name);
       appendVarcharOrNull(appender, row.thinking_level);
       appender.appendInteger(row.input_tokens);
       appender.appendInteger(row.output_tokens);
@@ -468,25 +470,25 @@ function parsePersistedMessage(
   }
 }
 
-function extractIngestEvent(params: {
+function extractIngestEvents(params: {
   workspaceId: string;
   workspaceMeta: WorkspaceMeta;
   message: PersistedMessage;
   lineNumber: number;
   responseIndex: number;
-}): IngestEvent | null {
+}): IngestEvent[] {
   if (params.message.role !== "assistant") {
-    return null;
+    return [];
   }
 
   const metadata = isRecord(params.message.metadata) ? params.message.metadata : null;
   if (!metadata) {
-    return null;
+    return [];
   }
 
   const usage = parseUsage(metadata.usage);
   if (!usage) {
-    return null;
+    return [];
   }
 
   const sequence = toFiniteInteger(metadata.historySequence) ?? params.lineNumber;
@@ -535,6 +537,7 @@ function extractIngestEvent(params: {
     agent_id: toOptionalString(metadata.agentId) ?? null,
     timestamp,
     model: model ?? null,
+    tool_name: null,
     thinking_level: toOptionalString(metadata.thinkingLevel) ?? null,
     input_tokens: inputTokens,
     output_tokens: outputTokens,
@@ -562,14 +565,103 @@ function extractIngestEvent(params: {
       lineNumber: params.lineNumber,
       issues: parsedEvent.error.issues,
     });
-    return null;
+    return [];
   }
 
-  return {
-    row: parsedEvent.data,
-    sequence,
-    date: dateBucket,
-  };
+  const events: IngestEvent[] = [
+    {
+      row: parsedEvent.data,
+      sequence,
+      date: dateBucket,
+    },
+  ];
+
+  const toolModelUsages = metadata.toolModelUsages;
+  if (!Array.isArray(toolModelUsages)) {
+    return events;
+  }
+
+  for (const rawToolModelUsage of toolModelUsages) {
+    if (!isRecord(rawToolModelUsage)) {
+      continue;
+    }
+
+    const toolName = toOptionalString(rawToolModelUsage.toolName);
+    const toolModel = toOptionalString(rawToolModelUsage.model);
+    const toolUsage = parseUsage(rawToolModelUsage.usage);
+    if (!toolName || !toolModel || !toolUsage) {
+      continue;
+    }
+
+    const toolProviderMetadata = isRecord(rawToolModelUsage.providerMetadata)
+      ? rawToolModelUsage.providerMetadata
+      : undefined;
+    const toolMetadataModel = toOptionalString(rawToolModelUsage.metadataModel);
+    const toolDisplayUsage = createDisplayUsage(
+      toolUsage,
+      toolModel,
+      toolProviderMetadata,
+      toolMetadataModel
+    );
+    if (!toolDisplayUsage) {
+      continue;
+    }
+
+    const toolTimestamp = toFiniteNumber(rawToolModelUsage.timestamp) ?? timestamp;
+    const toolCachedCostUsd =
+      (toolDisplayUsage.cached.cost_usd ?? 0) + (toolDisplayUsage.cacheCreate.cost_usd ?? 0);
+    const maybeToolEvent = {
+      workspace_id: params.workspaceId,
+      project_path: params.workspaceMeta.projectPath ?? null,
+      project_name: params.workspaceMeta.projectName ?? null,
+      workspace_name: params.workspaceMeta.workspaceName ?? null,
+      parent_workspace_id: params.workspaceMeta.parentWorkspaceId ?? null,
+      agent_id: toOptionalString(metadata.agentId) ?? null,
+      timestamp: toolTimestamp,
+      model: toolModel,
+      tool_name: toolName,
+      thinking_level: toOptionalString(metadata.thinkingLevel) ?? null,
+      input_tokens: toolDisplayUsage.input.tokens,
+      output_tokens: toolDisplayUsage.output.tokens,
+      reasoning_tokens: toolDisplayUsage.reasoning.tokens,
+      cached_tokens: toolDisplayUsage.cached.tokens,
+      cache_create_tokens: toolDisplayUsage.cacheCreate.tokens,
+      input_cost_usd: toolDisplayUsage.input.cost_usd ?? 0,
+      output_cost_usd: toolDisplayUsage.output.cost_usd ?? 0,
+      reasoning_cost_usd: toolDisplayUsage.reasoning.cost_usd ?? 0,
+      cached_cost_usd: toolCachedCostUsd,
+      total_cost_usd:
+        (toolDisplayUsage.input.cost_usd ?? 0) +
+        (toolDisplayUsage.output.cost_usd ?? 0) +
+        (toolDisplayUsage.reasoning.cost_usd ?? 0) +
+        toolCachedCostUsd,
+      duration_ms: null,
+      ttft_ms: null,
+      streaming_ms: null,
+      tool_execution_ms: null,
+      output_tps: null,
+      response_index: params.responseIndex,
+      is_sub_agent: (params.workspaceMeta.parentWorkspaceId ?? "").length > 0,
+    };
+
+    const parsedToolEvent = EventRowSchema.safeParse(maybeToolEvent);
+    if (!parsedToolEvent.success) {
+      log.warn("[analytics-etl] Skipping invalid tool analytics row", {
+        workspaceId: params.workspaceId,
+        lineNumber: params.lineNumber,
+        issues: parsedToolEvent.error.issues,
+      });
+      continue;
+    }
+
+    events.push({
+      row: parsedToolEvent.data,
+      sequence,
+      date: dateBucketFromTimestamp(toolTimestamp),
+    });
+  }
+
+  return events;
 }
 
 async function readWatermark(
@@ -672,6 +764,7 @@ async function readPersistedWorkspaceHeadSignature(
     SELECT timestamp, model, total_cost_usd
     FROM events
     WHERE workspace_id = ?
+      AND tool_name IS NULL
     ORDER BY response_index ASC NULLS LAST
     LIMIT 1
     `,
@@ -793,6 +886,7 @@ async function replaceEventsByResponseIndex(
         row.timestamp,
         event.date,
         row.model,
+        row.tool_name,
         row.thinking_level,
         row.input_tokens,
         row.output_tokens,
@@ -846,6 +940,7 @@ async function replaceWorkspaceEvents(
         row.timestamp,
         event.date,
         row.model,
+        row.tool_name,
         row.thinking_level,
         row.input_tokens,
         row.output_tokens,
@@ -957,24 +1052,26 @@ export async function ingestWorkspace(
       continue;
     }
 
-    const event = extractIngestEvent({
+    const events = extractIngestEvents({
       workspaceId,
       workspaceMeta,
       message,
       lineNumber,
       responseIndex,
     });
-    if (!event) {
+    if (events.length === 0) {
       continue;
     }
 
-    assert(
-      Number.isInteger(event.sequence),
-      "ingestWorkspace: expected assistant event sequence to be an integer"
-    );
+    for (const event of events) {
+      assert(
+        Number.isInteger(event.sequence),
+        "ingestWorkspace: expected assistant event sequence to be an integer"
+      );
+      parsedEvents.push(event);
+    }
 
     responseIndex += 1;
-    parsedEvents.push(event);
   }
 
   const parsedMaxSequence = getMaxSequence(parsedEvents);
@@ -1385,19 +1482,19 @@ export async function parseWorkspaceFromDisk(
       continue;
     }
 
-    const event = extractIngestEvent({
+    const extractedEvents = extractIngestEvents({
       workspaceId,
       workspaceMeta,
       message,
       lineNumber: i + 1,
       responseIndex,
     });
-    if (!event) {
+    if (extractedEvents.length === 0) {
       continue;
     }
 
     responseIndex += 1;
-    events.push(event);
+    events.push(...extractedEvents);
   }
 
   const delegationRollupRaw = await readDelegationRollupFilesFromDisk(sessionDir);

--- a/src/node/services/analytics/etl.ts
+++ b/src/node/services/analytics/etl.ts
@@ -749,7 +749,7 @@ function createEventHeadSignatureFromParsedEvent(event: IngestEvent): string {
   });
 }
 
-async function readPersistedWorkspaceHeadSignature(
+export async function readPersistedWorkspaceHeadSignature(
   conn: DuckDBConnection,
   workspaceId: string
 ): Promise<string | null> {
@@ -758,8 +758,10 @@ async function readPersistedWorkspaceHeadSignature(
     SELECT timestamp, model, total_cost_usd
     FROM events
     WHERE workspace_id = ?
-      AND tool_name IS NULL
-    ORDER BY response_index ASC NULLS LAST
+    ORDER BY
+      response_index ASC NULLS LAST,
+      CASE WHEN tool_name IS NULL THEN 0 ELSE 1 END ASC,
+      timestamp ASC
     LIMIT 1
     `,
     [workspaceId]

--- a/src/node/services/analytics/queries.test.ts
+++ b/src/node/services/analytics/queries.test.ts
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, expect, test } from "bun:test";
+import { DuckDBInstance, type DuckDBConnection } from "@duckdb/node-api";
+import { z } from "zod";
+import {
+  HistogramBucketSchema,
+  SpendByModelRowSchema,
+  SummaryRowSchema,
+  TimingPercentilesRowSchema,
+  TokensByModelRowSchema,
+} from "@/common/orpc/schemas/analytics";
+import { executeNamedQuery } from "./queries";
+import { CREATE_EVENTS_TABLE_SQL } from "./schemaSql";
+
+const duckDbHandlesToClose: Array<{ instance: DuckDBInstance; conn: DuckDBConnection }> = [];
+
+interface EventSeed {
+  workspaceId: string;
+  date: string;
+  timestamp: number;
+  model: string;
+  toolName?: string | null;
+  inputTokens: number;
+  outputTokens: number;
+  reasoningTokens?: number;
+  cachedTokens?: number;
+  cacheCreateTokens?: number;
+  totalCostUsd: number;
+  durationMs?: number | null;
+  ttftMs?: number | null;
+  outputTps?: number | null;
+}
+
+async function createTestConn(): Promise<DuckDBConnection> {
+  const instance = await DuckDBInstance.create(":memory:");
+  const conn = await instance.connect();
+  duckDbHandlesToClose.push({ instance, conn });
+
+  await conn.run(CREATE_EVENTS_TABLE_SQL);
+  await conn.run("ALTER TABLE events ADD COLUMN IF NOT EXISTS tool_name VARCHAR");
+
+  return conn;
+}
+
+async function insertEvent(conn: DuckDBConnection, seed: EventSeed): Promise<void> {
+  await conn.run(
+    `INSERT INTO events (
+      workspace_id,
+      date,
+      timestamp,
+      model,
+      tool_name,
+      input_tokens,
+      output_tokens,
+      reasoning_tokens,
+      cached_tokens,
+      cache_create_tokens,
+      total_cost_usd,
+      duration_ms,
+      ttft_ms,
+      output_tps,
+      is_sub_agent
+    ) VALUES (
+      ?, CAST(? AS DATE), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+    )`,
+    [
+      seed.workspaceId,
+      seed.date,
+      seed.timestamp,
+      seed.model,
+      seed.toolName ?? null,
+      seed.inputTokens,
+      seed.outputTokens,
+      seed.reasoningTokens ?? 0,
+      seed.cachedTokens ?? 0,
+      seed.cacheCreateTokens ?? 0,
+      seed.totalCostUsd,
+      seed.durationMs ?? null,
+      seed.ttftMs ?? null,
+      seed.outputTps ?? null,
+      false,
+    ]
+  );
+}
+
+afterEach(async () => {
+  for (const { conn, instance } of duckDbHandlesToClose.splice(0).reverse()) {
+    try {
+      conn.closeSync();
+    } catch {
+      // Ignore close failures in test cleanup.
+    }
+
+    try {
+      instance.closeSync();
+    } catch {
+      // Ignore close failures in test cleanup.
+    }
+  }
+});
+
+describe("analytics queries", () => {
+  test("includes tool rows in spend and token totals while excluding them from response counts and timing", async () => {
+    const conn = await createTestConn();
+    const workspaceId = "ws-tool-query-analytics";
+    const date = "2026-04-20";
+
+    await insertEvent(conn, {
+      workspaceId,
+      date,
+      timestamp: 1,
+      model: "openai:gpt-4",
+      inputTokens: 10,
+      outputTokens: 5,
+      totalCostUsd: 1,
+      durationMs: 100,
+      ttftMs: 20,
+      outputTps: 50,
+    });
+    await insertEvent(conn, {
+      workspaceId,
+      date,
+      timestamp: 2,
+      model: "openai:gpt-4",
+      toolName: "bash",
+      inputTokens: 3,
+      outputTokens: 2,
+      totalCostUsd: 0.2,
+      durationMs: 900,
+      ttftMs: 500,
+      outputTps: 2,
+    });
+    await insertEvent(conn, {
+      workspaceId,
+      date,
+      timestamp: 3,
+      model: "anthropic:claude-sonnet-4-20250514",
+      inputTokens: 20,
+      outputTokens: 10,
+      totalCostUsd: 2,
+      durationMs: 300,
+      ttftMs: 60,
+      outputTps: 100 / 3,
+    });
+    await insertEvent(conn, {
+      workspaceId,
+      date,
+      timestamp: 4,
+      model: "anthropic:claude-opus-4-20250514",
+      toolName: "advisor",
+      inputTokens: 7,
+      outputTokens: 1,
+      totalCostUsd: 0.7,
+      durationMs: 1_200,
+      ttftMs: 800,
+      outputTps: 0.5,
+    });
+
+    const summary = SummaryRowSchema.parse(await executeNamedQuery(conn, "getSummary", {}));
+    expect(summary.total_spend_usd).toBeCloseTo(3.9, 12);
+    expect(summary.total_tokens).toBe(58);
+    expect(summary.total_responses).toBe(2);
+
+    const spendByModel = z
+      .array(SpendByModelRowSchema)
+      .parse(await executeNamedQuery(conn, "getSpendByModel", {}));
+    const spendByModelMap = new Map(spendByModel.map((row) => [row.model, row]));
+    expect(spendByModelMap.get("openai:gpt-4")).toMatchObject({
+      cost_usd: 1.2,
+      token_count: 20,
+      response_count: 1,
+    });
+    expect(spendByModelMap.get("anthropic:claude-sonnet-4-20250514")).toMatchObject({
+      cost_usd: 2,
+      token_count: 30,
+      response_count: 1,
+    });
+    expect(spendByModelMap.get("anthropic:claude-opus-4-20250514")).toMatchObject({
+      cost_usd: 0.7,
+      token_count: 8,
+      response_count: 0,
+    });
+
+    const tokensByModel = z
+      .array(TokensByModelRowSchema)
+      .parse(await executeNamedQuery(conn, "getTokensByModel", {}));
+    const tokensByModelMap = new Map(tokensByModel.map((row) => [row.model, row]));
+    expect(tokensByModelMap.get("openai:gpt-4")).toMatchObject({
+      total_tokens: 20,
+      request_count: 1,
+    });
+    expect(tokensByModelMap.get("anthropic:claude-sonnet-4-20250514")).toMatchObject({
+      total_tokens: 30,
+      request_count: 1,
+    });
+    expect(tokensByModelMap.get("anthropic:claude-opus-4-20250514")).toMatchObject({
+      total_tokens: 8,
+      request_count: 0,
+    });
+
+    const timing = z
+      .object({
+        percentiles: TimingPercentilesRowSchema,
+        histogram: z.array(HistogramBucketSchema),
+      })
+      .parse(await executeNamedQuery(conn, "getTimingDistribution", { metric: "duration" }));
+    expect(timing.percentiles.p50).toBeCloseTo(200, 12);
+
+    const histogramCount = timing.histogram.reduce((sum, bucket) => {
+      return sum + bucket.count;
+    }, 0);
+    assert(Number.isInteger(histogramCount), "histogramCount should remain integral");
+    expect(histogramCount).toBe(2);
+  });
+});

--- a/src/node/services/analytics/queries.test.ts
+++ b/src/node/services/analytics/queries.test.ts
@@ -83,7 +83,7 @@ async function insertEvent(conn: DuckDBConnection, seed: EventSeed): Promise<voi
   );
 }
 
-afterEach(async () => {
+afterEach(() => {
   for (const { conn, instance } of duckDbHandlesToClose.splice(0).reverse()) {
     try {
       conn.closeSync();

--- a/src/node/services/analytics/queries.ts
+++ b/src/node/services/analytics/queries.ts
@@ -177,7 +177,7 @@ async function querySummary(
         SUM(input_tokens + output_tokens + reasoning_tokens + cached_tokens + cache_create_tokens),
         0
       ) AS total_tokens,
-      COALESCE(COUNT(*), 0) AS total_responses
+      COALESCE(COUNT(*) FILTER (WHERE tool_name IS NULL), 0) AS total_responses
     FROM events
     WHERE (? IS NULL OR project_path = ?)
       AND (? IS NULL OR date >= CAST(? AS DATE))
@@ -278,7 +278,7 @@ async function querySpendByModel(
         SUM(input_tokens + output_tokens + reasoning_tokens + cached_tokens + cache_create_tokens),
         0
       ) AS token_count,
-      COALESCE(COUNT(*), 0) AS response_count
+      COALESCE(COUNT(*) FILTER (WHERE tool_name IS NULL), 0) AS response_count
     FROM events
     WHERE (? IS NULL OR project_path = ?)
       AND (? IS NULL OR date >= CAST(? AS DATE))
@@ -311,7 +311,7 @@ async function queryTokensByModel(
         COALESCE(input_tokens, 0) + COALESCE(cached_tokens, 0) + COALESCE(cache_create_tokens, 0)
         + COALESCE(output_tokens, 0) + COALESCE(reasoning_tokens, 0)
       ), 0) AS total_tokens,
-      COALESCE(COUNT(*), 0) AS request_count
+      COALESCE(COUNT(*) FILTER (WHERE tool_name IS NULL), 0) AS request_count
     FROM events
     WHERE (? IS NULL OR project_path = ?)
       AND (? IS NULL OR date >= CAST(? AS DATE))
@@ -349,6 +349,7 @@ async function queryTimingDistribution(
       COALESCE(PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY ${column}), 0) AS p99
     FROM events
     WHERE ${column} IS NOT NULL
+      AND tool_name IS NULL
       AND (? IS NULL OR project_path = ?)
       AND (? IS NULL OR date >= CAST(? AS DATE))
       AND (? IS NULL OR date <= CAST(? AS DATE))
@@ -374,6 +375,7 @@ async function queryTimingDistribution(
         MAX(${column}) AS raw_max_value
       FROM events
       WHERE ${column} IS NOT NULL
+        AND tool_name IS NULL
         AND (? IS NULL OR project_path = ?)
         AND (? IS NULL OR date >= CAST(? AS DATE))
         AND (? IS NULL OR date <= CAST(? AS DATE))
@@ -409,6 +411,7 @@ async function queryTimingDistribution(
       FROM events
       CROSS JOIN stats
       WHERE events.${column} IS NOT NULL
+        AND events.tool_name IS NULL
         AND (? IS NULL OR events.project_path = ?)
         AND (? IS NULL OR events.date >= CAST(? AS DATE))
         AND (? IS NULL OR events.date <= CAST(? AS DATE))
@@ -458,7 +461,7 @@ async function queryAgentCostBreakdown(
         SUM(input_tokens + output_tokens + reasoning_tokens + cached_tokens + cache_create_tokens),
         0
       ) AS token_count,
-      COALESCE(COUNT(*), 0) AS response_count
+      COALESCE(COUNT(*) FILTER (WHERE tool_name IS NULL), 0) AS response_count
     FROM events
     WHERE (? IS NULL OR project_path = ?)
       AND (? IS NULL OR date >= CAST(? AS DATE))
@@ -484,7 +487,7 @@ async function queryCacheHitRatioByProvider(
       COALESCE(model, 'unknown') AS model,
       COALESCE(SUM(cached_tokens), 0) AS cached_tokens,
       COALESCE(SUM(input_tokens + cached_tokens + cache_create_tokens), 0) AS total_prompt_tokens,
-      COALESCE(COUNT(*), 0) AS response_count
+      COALESCE(COUNT(*) FILTER (WHERE tool_name IS NULL), 0) AS response_count
     FROM events
     WHERE (? IS NULL OR project_path = ?)
       AND (? IS NULL OR date >= CAST(? AS DATE))

--- a/src/node/services/analytics/queries.ts
+++ b/src/node/services/analytics/queries.ts
@@ -33,6 +33,8 @@ const MIN_SAFE_BIGINT = BigInt(Number.MIN_SAFE_INTEGER);
 type Granularity = "hour" | "day" | "week";
 type TimingMetric = "ttft" | "duration" | "tps";
 
+const NON_TOOL_EVENTS_PREDICATE = "tool_name IS NULL";
+
 interface TimingDistributionResult {
   percentiles: TimingPercentilesRow;
   histogram: HistogramBucket[];
@@ -177,7 +179,7 @@ async function querySummary(
         SUM(input_tokens + output_tokens + reasoning_tokens + cached_tokens + cache_create_tokens),
         0
       ) AS total_tokens,
-      COALESCE(COUNT(*) FILTER (WHERE tool_name IS NULL), 0) AS total_responses
+      COALESCE(COUNT(*) FILTER (WHERE ${NON_TOOL_EVENTS_PREDICATE}), 0) AS total_responses
     FROM events
     WHERE (? IS NULL OR project_path = ?)
       AND (? IS NULL OR date >= CAST(? AS DATE))
@@ -278,7 +280,7 @@ async function querySpendByModel(
         SUM(input_tokens + output_tokens + reasoning_tokens + cached_tokens + cache_create_tokens),
         0
       ) AS token_count,
-      COALESCE(COUNT(*) FILTER (WHERE tool_name IS NULL), 0) AS response_count
+      COALESCE(COUNT(*) FILTER (WHERE ${NON_TOOL_EVENTS_PREDICATE}), 0) AS response_count
     FROM events
     WHERE (? IS NULL OR project_path = ?)
       AND (? IS NULL OR date >= CAST(? AS DATE))
@@ -311,7 +313,7 @@ async function queryTokensByModel(
         COALESCE(input_tokens, 0) + COALESCE(cached_tokens, 0) + COALESCE(cache_create_tokens, 0)
         + COALESCE(output_tokens, 0) + COALESCE(reasoning_tokens, 0)
       ), 0) AS total_tokens,
-      COALESCE(COUNT(*) FILTER (WHERE tool_name IS NULL), 0) AS request_count
+      COALESCE(COUNT(*) FILTER (WHERE ${NON_TOOL_EVENTS_PREDICATE}), 0) AS request_count
     FROM events
     WHERE (? IS NULL OR project_path = ?)
       AND (? IS NULL OR date >= CAST(? AS DATE))
@@ -349,7 +351,7 @@ async function queryTimingDistribution(
       COALESCE(PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY ${column}), 0) AS p99
     FROM events
     WHERE ${column} IS NOT NULL
-      AND tool_name IS NULL
+      AND ${NON_TOOL_EVENTS_PREDICATE}
       AND (? IS NULL OR project_path = ?)
       AND (? IS NULL OR date >= CAST(? AS DATE))
       AND (? IS NULL OR date <= CAST(? AS DATE))
@@ -375,7 +377,7 @@ async function queryTimingDistribution(
         MAX(${column}) AS raw_max_value
       FROM events
       WHERE ${column} IS NOT NULL
-        AND tool_name IS NULL
+        AND ${NON_TOOL_EVENTS_PREDICATE}
         AND (? IS NULL OR project_path = ?)
         AND (? IS NULL OR date >= CAST(? AS DATE))
         AND (? IS NULL OR date <= CAST(? AS DATE))
@@ -411,7 +413,7 @@ async function queryTimingDistribution(
       FROM events
       CROSS JOIN stats
       WHERE events.${column} IS NOT NULL
-        AND events.tool_name IS NULL
+        AND ${NON_TOOL_EVENTS_PREDICATE}
         AND (? IS NULL OR events.project_path = ?)
         AND (? IS NULL OR events.date >= CAST(? AS DATE))
         AND (? IS NULL OR events.date <= CAST(? AS DATE))
@@ -461,7 +463,7 @@ async function queryAgentCostBreakdown(
         SUM(input_tokens + output_tokens + reasoning_tokens + cached_tokens + cache_create_tokens),
         0
       ) AS token_count,
-      COALESCE(COUNT(*) FILTER (WHERE tool_name IS NULL), 0) AS response_count
+      COALESCE(COUNT(*) FILTER (WHERE ${NON_TOOL_EVENTS_PREDICATE}), 0) AS response_count
     FROM events
     WHERE (? IS NULL OR project_path = ?)
       AND (? IS NULL OR date >= CAST(? AS DATE))
@@ -487,7 +489,7 @@ async function queryCacheHitRatioByProvider(
       COALESCE(model, 'unknown') AS model,
       COALESCE(SUM(cached_tokens), 0) AS cached_tokens,
       COALESCE(SUM(input_tokens + cached_tokens + cache_create_tokens), 0) AS total_prompt_tokens,
-      COALESCE(COUNT(*) FILTER (WHERE tool_name IS NULL), 0) AS response_count
+      COALESCE(COUNT(*) FILTER (WHERE ${NON_TOOL_EVENTS_PREDICATE}), 0) AS response_count
     FROM events
     WHERE (? IS NULL OR project_path = ?)
       AND (? IS NULL OR date >= CAST(? AS DATE))

--- a/src/node/services/sessionUsageService.test.ts
+++ b/src/node/services/sessionUsageService.test.ts
@@ -555,7 +555,6 @@ describe("SessionUsageService", () => {
       expect(result!.byModel["claude-sonnet-4-20250514"].input.tokens).toBe(100);
     });
 
-
     it("should rebuild same-model totals from assistant usage and tool model usages", async () => {
       const workspaceId = "tool-usage-rebuild-workspace";
       const model = "anthropic:claude-sonnet-4-20250514";
@@ -591,7 +590,7 @@ describe("SessionUsageService", () => {
         usage: parentUsage,
         providerMetadata: parentProviderMetadata,
       });
-      Object.assign(assistantMessage.metadata ??= {}, {
+      Object.assign((assistantMessage.metadata ??= {}), {
         toolModelUsages: [toolUsage],
       });
 
@@ -603,7 +602,11 @@ describe("SessionUsageService", () => {
       expect(Object.keys(result?.byModel ?? {})).toEqual([canonicalModel]);
 
       const expectedParentUsage = createDisplayUsage(parentUsage, model, parentProviderMetadata);
-      const expectedToolUsage = createDisplayUsage(toolUsage.usage, toolUsage.model, toolUsage.providerMetadata);
+      const expectedToolUsage = createDisplayUsage(
+        toolUsage.usage,
+        toolUsage.model,
+        toolUsage.providerMetadata
+      );
       expect(expectedParentUsage).toBeDefined();
       expect(expectedToolUsage).toBeDefined();
       if (!expectedParentUsage || !expectedToolUsage || !result) {

--- a/src/node/services/sessionUsageService.test.ts
+++ b/src/node/services/sessionUsageService.test.ts
@@ -625,6 +625,88 @@ describe("SessionUsageService", () => {
       );
     });
 
+    it("should skip malformed tool model usage entries during rebuild", async () => {
+      const workspaceId = "tool-usage-rebuild-skips-malformed";
+      const sameModel = "openai:gpt-4";
+      const otherModel = "anthropic:claude-sonnet-4-20250514";
+      const validSameModelToolUsage = {
+        toolName: "bash",
+        toolCallId: "tool-call-valid-1",
+        timestamp: 1_700_000_000_025,
+        model: sameModel,
+        usage: {
+          inputTokens: 36,
+          outputTokens: 12,
+          totalTokens: 48,
+        },
+        providerMetadata: {
+          openai: { reasoningTokens: 3 },
+        },
+      };
+      const validOtherModelToolUsage = {
+        toolName: "advisor",
+        toolCallId: "tool-call-valid-2",
+        timestamp: 1_700_000_000_050,
+        model: otherModel,
+        usage: {
+          inputTokens: 96,
+          cachedInputTokens: 10,
+          outputTokens: 18,
+          totalTokens: 114,
+        },
+        providerMetadata: {
+          anthropic: { cacheCreationInputTokens: 4 },
+        },
+      };
+
+      const assistantMessage = createMuxMessage("msg-tool-usage-malformed", "assistant", "Hello", {
+        historySequence: 1,
+        timestamp: 1_700_000_000_000,
+      });
+      Object.assign((assistantMessage.metadata ??= {}), {
+        toolModelUsages: [
+          validSameModelToolUsage,
+          null,
+          42,
+          {},
+          { model: "m" },
+          { model: "m", usage: null },
+          validOtherModelToolUsage,
+        ],
+      });
+
+      await service.rebuildFromMessages(workspaceId, [assistantMessage]);
+
+      const result = await service.getSessionUsage(workspaceId);
+      expect(result).toBeDefined();
+      expect(result?.lastRequest).toBeUndefined();
+
+      const canonicalSameModel = normalizeToCanonical(sameModel);
+      const canonicalOtherModel = normalizeToCanonical(otherModel);
+      expect(Object.keys(result?.byModel ?? {}).sort()).toEqual(
+        [canonicalOtherModel, canonicalSameModel].sort()
+      );
+
+      const expectedSameModelUsage = createDisplayUsage(
+        validSameModelToolUsage.usage,
+        validSameModelToolUsage.model,
+        validSameModelToolUsage.providerMetadata
+      );
+      const expectedOtherModelUsage = createDisplayUsage(
+        validOtherModelToolUsage.usage,
+        validOtherModelToolUsage.model,
+        validOtherModelToolUsage.providerMetadata
+      );
+      expect(expectedSameModelUsage).toBeDefined();
+      expect(expectedOtherModelUsage).toBeDefined();
+      if (!expectedSameModelUsage || !expectedOtherModelUsage || !result) {
+        throw new Error("Expected malformed tool usage rebuild test to compute display usage");
+      }
+
+      expect(result.byModel[canonicalSameModel]).toEqual(expectedSameModelUsage);
+      expect(result.byModel[canonicalOtherModel]).toEqual(expectedOtherModelUsage);
+    });
+
     it("should include historicalUsage from legacy compaction summaries", async () => {
       const workspaceId = "test-workspace";
 

--- a/src/node/services/sessionUsageService.test.ts
+++ b/src/node/services/sessionUsageService.test.ts
@@ -3,7 +3,13 @@ import { SessionUsageService, type SessionUsageTokenStatsCacheV1 } from "./sessi
 import type { HistoryService } from "./historyService";
 import type { Config } from "@/node/config";
 import { createMuxMessage } from "@/common/types/message";
-import type { ChatUsageDisplay } from "@/common/utils/tokens/usageAggregator";
+import {
+  getTotalCost,
+  sumUsageHistory,
+  type ChatUsageDisplay,
+} from "@/common/utils/tokens/usageAggregator";
+import { createDisplayUsage } from "@/common/utils/tokens/displayUsage";
+import { normalizeToCanonical } from "@/common/utils/ai/models";
 import { createTestHistoryService } from "./testHistoryService";
 import * as fs from "fs/promises";
 import * as path from "path";
@@ -547,6 +553,73 @@ describe("SessionUsageService", () => {
       // Should have rebuilt from messages
       expect(result!.byModel["claude-sonnet-4-20250514"]).toBeDefined();
       expect(result!.byModel["claude-sonnet-4-20250514"].input.tokens).toBe(100);
+    });
+
+
+    it("should rebuild same-model totals from assistant usage and tool model usages", async () => {
+      const workspaceId = "tool-usage-rebuild-workspace";
+      const model = "anthropic:claude-sonnet-4-20250514";
+      const parentUsage = {
+        inputTokens: 140,
+        cachedInputTokens: 20,
+        outputTokens: 48,
+        totalTokens: 188,
+      };
+      const parentProviderMetadata = {
+        anthropic: { cacheCreationInputTokens: 10 },
+      };
+      const toolUsage = {
+        toolName: "advisor",
+        toolCallId: "tool-call-1",
+        timestamp: Date.now(),
+        model,
+        usage: {
+          inputTokens: 70,
+          cachedInputTokens: 8,
+          outputTokens: 24,
+          totalTokens: 94,
+        },
+        providerMetadata: {
+          anthropic: { cacheCreationInputTokens: 4 },
+        },
+      };
+
+      const assistantMessage = createMuxMessage("msg-tool-usage", "assistant", "Hello", {
+        historySequence: 1,
+        timestamp: Date.now(),
+        model,
+        usage: parentUsage,
+        providerMetadata: parentProviderMetadata,
+      });
+      Object.assign(assistantMessage.metadata ??= {}, {
+        toolModelUsages: [toolUsage],
+      });
+
+      await service.rebuildFromMessages(workspaceId, [assistantMessage]);
+
+      const result = await service.getSessionUsage(workspaceId);
+      expect(result).toBeDefined();
+      const canonicalModel = normalizeToCanonical(model);
+      expect(Object.keys(result?.byModel ?? {})).toEqual([canonicalModel]);
+
+      const expectedParentUsage = createDisplayUsage(parentUsage, model, parentProviderMetadata);
+      const expectedToolUsage = createDisplayUsage(toolUsage.usage, toolUsage.model, toolUsage.providerMetadata);
+      expect(expectedParentUsage).toBeDefined();
+      expect(expectedToolUsage).toBeDefined();
+      if (!expectedParentUsage || !expectedToolUsage || !result) {
+        throw new Error("Expected tool usage rebuild test to compute display usage and result");
+      }
+      const expectedMergedUsage = sumUsageHistory([expectedParentUsage, expectedToolUsage]);
+      expect(expectedMergedUsage).toBeDefined();
+      if (!expectedMergedUsage) {
+        throw new Error("Expected merged tool usage to be defined");
+      }
+
+      expect(result.byModel[canonicalModel]).toEqual(expectedMergedUsage);
+      expect(getTotalCost(result.byModel[canonicalModel])).toBeCloseTo(
+        getTotalCost(expectedMergedUsage) ?? 0,
+        12
+      );
     });
 
     it("should include historicalUsage from legacy compaction summaries", async () => {

--- a/src/node/services/sessionUsageService.ts
+++ b/src/node/services/sessionUsageService.ts
@@ -78,6 +78,14 @@ export interface SessionUsageFile {
  * per-model usage breakdowns. Usage is accumulated on stream-end, never
  * subtracted, making costs immune to message deletion.
  */
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPersistedToolModelUsage(value: unknown): value is PersistedToolModelUsage {
+  return isPlainRecord(value) && typeof value.model === "string" && isPlainRecord(value.usage);
+}
+
 export class SessionUsageService {
   private readonly SESSION_USAGE_FILE = "session-usage.json";
   private readonly fileLocks = workspaceFileLocks;
@@ -411,17 +419,28 @@ export class SessionUsageService {
       result.byModel[model] = existing ? sumUsageHistory([existing, usage])! : usage;
     };
 
-    const rebuildToolModelUsage = (toolModelUsage: PersistedToolModelUsage): void => {
-      const rawModel = toolModelUsage.model?.trim();
+    const rebuildToolModelUsage = (toolModelUsage: unknown): void => {
+      // History on disk is not schema-validated, so skip malformed tool snapshots instead of
+      // letting one bad entry abort the entire rebuild.
+      if (!isPersistedToolModelUsage(toolModelUsage)) {
+        return;
+      }
+
+      const rawModel = toolModelUsage.model.trim();
       if (!rawModel) {
         return;
       }
 
+      const providerMetadata = isPlainRecord(toolModelUsage.providerMetadata)
+        ? toolModelUsage.providerMetadata
+        : undefined;
+      const metadataModel =
+        typeof toolModelUsage.metadataModel === "string" ? toolModelUsage.metadataModel : undefined;
       const usage = createDisplayUsage(
         toolModelUsage.usage,
         rawModel,
-        toolModelUsage.providerMetadata,
-        toolModelUsage.metadataModel
+        providerMetadata,
+        metadataModel
       );
       if (!usage) {
         return;

--- a/src/node/services/sessionUsageService.ts
+++ b/src/node/services/sessionUsageService.ts
@@ -10,7 +10,7 @@ import { sumUsageHistory } from "@/common/utils/tokens/usageAggregator";
 import { createDisplayUsage } from "@/common/utils/tokens/displayUsage";
 import type { RolledUpChildEntry } from "@/common/orpc/schemas/chatStats";
 import type { TokenConsumer } from "@/common/types/chatStats";
-import type { MuxMessage } from "@/common/types/message";
+import type { MuxMessage, PersistedToolModelUsage } from "@/common/types/message";
 import { normalizeToCanonical } from "@/common/utils/ai/models";
 import { log } from "./log";
 
@@ -405,6 +405,31 @@ export class SessionUsageService {
     const result: SessionUsageFile = this.createEmptyUsageFile();
     let lastAssistantUsage: { model: string; usage: ChatUsageDisplay } | undefined;
 
+    const mergeUsageForModel = (rawModel: string, usage: ChatUsageDisplay): void => {
+      const model = normalizeToCanonical(rawModel);
+      const existing = result.byModel[model];
+      result.byModel[model] = existing ? sumUsageHistory([existing, usage])! : usage;
+    };
+
+    const rebuildToolModelUsage = (toolModelUsage: PersistedToolModelUsage): void => {
+      const rawModel = toolModelUsage.model?.trim();
+      if (!rawModel) {
+        return;
+      }
+
+      const usage = createDisplayUsage(
+        toolModelUsage.usage,
+        rawModel,
+        toolModelUsage.providerMetadata,
+        toolModelUsage.metadataModel
+      );
+      if (!usage) {
+        return;
+      }
+
+      mergeUsageForModel(rawModel, usage);
+    };
+
     for (const msg of messages) {
       if (msg.role === "assistant") {
         // Include historicalUsage from legacy compaction summaries.
@@ -422,17 +447,23 @@ export class SessionUsageService {
         // Extract current message's usage
         if (msg.metadata?.usage) {
           const rawModel = msg.metadata.model ?? "unknown";
-          const model = normalizeToCanonical(rawModel);
           const usage = createDisplayUsage(
             msg.metadata.usage,
             rawModel,
-            msg.metadata.providerMetadata
+            msg.metadata.providerMetadata,
+            msg.metadata.metadataModel
           );
 
           if (usage) {
-            const existing = result.byModel[model];
-            result.byModel[model] = existing ? sumUsageHistory([existing, usage])! : usage;
-            lastAssistantUsage = { model, usage };
+            mergeUsageForModel(rawModel, usage);
+            lastAssistantUsage = { model: normalizeToCanonical(rawModel), usage };
+          }
+        }
+
+        const toolModelUsages = msg.metadata?.toolModelUsages;
+        if (Array.isArray(toolModelUsages)) {
+          for (const toolModelUsage of toolModelUsages) {
+            rebuildToolModelUsage(toolModelUsage);
           }
         }
       }

--- a/src/node/services/streamManager.modelOnlyNotifications.test.ts
+++ b/src/node/services/streamManager.modelOnlyNotifications.test.ts
@@ -80,6 +80,7 @@ describe("StreamManager - model-only tool notifications", () => {
       cumulativeProviderMetadata: undefined,
       lastStepUsage: undefined,
       lastStepProviderMetadata: undefined,
+      toolModelUsages: [],
     };
 
     const method = Reflect.get(streamManager, "processStreamWithCleanup") as unknown;
@@ -158,6 +159,7 @@ describe("StreamManager - model-only tool notifications", () => {
       cumulativeProviderMetadata: undefined,
       lastStepUsage: undefined,
       lastStepProviderMetadata: undefined,
+      toolModelUsages: [],
     };
 
     const method = Reflect.get(streamManager, "processStreamWithCleanup") as unknown;

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -1732,6 +1732,7 @@ describe("StreamManager - TTFT metadata persistence", () => {
       metadataModel: params.metadataModel ?? params.model ?? KNOWN_MODELS.SONNET.id,
       historySequence: params.historySequence,
       initialMetadata: params.initialMetadata,
+      toolModelUsages: [],
       parts: params.parts,
       lastPartialWriteTime: 0,
       partialWriteTimer: undefined,

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -1904,7 +1904,6 @@ describe("StreamManager - TTFT metadata persistence", () => {
     expect(updatedMessage.metadata?.routedThroughGateway).toBe(true);
   });
 
-
   test("persists per-invocation tool model usages on the final assistant message", async () => {
     const startTime = Date.now() - 1000;
     const firstToolUsage = createToolModelUsageEvent({
@@ -1970,9 +1969,9 @@ describe("StreamManager - TTFT metadata persistence", () => {
     });
 
     expect(readToolModelUsages(updatedMessage)).toBeUndefined();
-    expect(Object.prototype.hasOwnProperty.call(updatedMessage.metadata ?? {}, "toolModelUsages")).toBe(
-      false
-    );
+    expect(
+      Object.prototype.hasOwnProperty.call(updatedMessage.metadata ?? {}, "toolModelUsages")
+    ).toBe(false);
   });
 
   test("scopes tool model usage accumulation to the active assistant turn", async () => {

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -1616,7 +1616,7 @@ describe("StreamManager - TTFT metadata persistence", () => {
     recordToolModelUsage.call(streamManager, workspaceId, messageId, event);
   }
 
-  function readToolModelUsages(message: { metadata?: Record<string, unknown> }): unknown[] | undefined {
+  function readToolModelUsages(message: { metadata?: unknown }): unknown[] | undefined {
     const metadata = message.metadata;
     if (metadata == null || typeof metadata !== "object") {
       return undefined;
@@ -1748,7 +1748,7 @@ describe("StreamManager - TTFT metadata persistence", () => {
       stepTracker: {},
     };
 
-    const workspaceStreamsValue = Reflect.get(streamManager, "workspaceStreams");
+    const workspaceStreamsValue: unknown = Reflect.get(streamManager, "workspaceStreams");
     expect(workspaceStreamsValue instanceof Map).toBe(true);
     if (!(workspaceStreamsValue instanceof Map)) {
       throw new Error("Expected StreamManager.workspaceStreams to be a Map");

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -1585,6 +1585,65 @@ describe("StreamManager - empty stream completions", () => {
 describe("StreamManager - TTFT metadata persistence", () => {
   const runtime = createRuntime({ type: "local", srcBaseDir: "/tmp" });
 
+  interface ToolModelUsageEventForTests {
+    toolName: string;
+    toolCallId?: string;
+    timestamp?: number;
+    model: string;
+    usage: {
+      inputTokens: number;
+      outputTokens: number;
+      totalTokens: number;
+      reasoningTokens?: number;
+      cachedInputTokens?: number;
+    };
+    providerMetadata?: Record<string, unknown>;
+    metadataModel?: string;
+  }
+
+  function recordToolModelUsageForTests(
+    streamManager: StreamManager,
+    workspaceId: string,
+    messageId: string,
+    event: ToolModelUsageEventForTests
+  ): void {
+    const recordToolModelUsage = Reflect.get(streamManager, "recordToolModelUsage");
+    expect(typeof recordToolModelUsage).toBe("function");
+    if (typeof recordToolModelUsage !== "function") {
+      throw new Error("Expected StreamManager.recordToolModelUsage to exist");
+    }
+
+    recordToolModelUsage.call(streamManager, workspaceId, messageId, event);
+  }
+
+  function readToolModelUsages(message: { metadata?: Record<string, unknown> }): unknown[] | undefined {
+    const metadata = message.metadata;
+    if (metadata == null || typeof metadata !== "object") {
+      return undefined;
+    }
+
+    const toolModelUsages = (metadata as Record<string, unknown>).toolModelUsages;
+    return Array.isArray(toolModelUsages) ? toolModelUsages : undefined;
+  }
+
+  function createToolModelUsageEvent(
+    overrides: Partial<ToolModelUsageEventForTests> = {}
+  ): ToolModelUsageEventForTests {
+    return {
+      toolName: overrides.toolName ?? "advisor",
+      toolCallId: overrides.toolCallId ?? "tool-call-1",
+      timestamp: overrides.timestamp ?? Date.now(),
+      model: overrides.model ?? "anthropic:claude-sonnet-4-20250514",
+      usage: overrides.usage ?? {
+        inputTokens: 40,
+        outputTokens: 12,
+        totalTokens: 52,
+      },
+      providerMetadata: overrides.providerMetadata,
+      ...(overrides.metadataModel != null ? { metadataModel: overrides.metadataModel } : {}),
+    };
+  }
+
   async function finalizeStreamAndReadMessage(params: {
     workspaceId: string;
     messageId: string;
@@ -1603,8 +1662,14 @@ describe("StreamManager - TTFT metadata persistence", () => {
     };
     model?: string;
     metadataModel?: string;
+    streamManager?: StreamManager;
+    beforeProcess?: (params: {
+      streamManager: StreamManager;
+      workspaceId: string;
+      messageId: string;
+    }) => Promise<void> | void;
   }) {
-    const streamManager = new StreamManager(historyService);
+    const streamManager = params.streamManager ?? new StreamManager(historyService);
     // Suppress error events from bubbling up as uncaught exceptions during tests
     streamManager.on("error", () => undefined);
 
@@ -1681,6 +1746,22 @@ describe("StreamManager - TTFT metadata persistence", () => {
       currentStepStartIndex: 0,
       stepTracker: {},
     };
+
+    const workspaceStreamsValue = Reflect.get(streamManager, "workspaceStreams");
+    expect(workspaceStreamsValue instanceof Map).toBe(true);
+    if (!(workspaceStreamsValue instanceof Map)) {
+      throw new Error("Expected StreamManager.workspaceStreams to be a Map");
+    }
+    const workspaceStreams = workspaceStreamsValue as Map<string, unknown>;
+    workspaceStreams.set(params.workspaceId, streamInfo);
+
+    if (params.beforeProcess) {
+      await params.beforeProcess({
+        streamManager,
+        workspaceId: params.workspaceId,
+        messageId: params.messageId,
+      });
+    }
 
     if (params.emitStartEvent) {
       const emitStreamStart = Reflect.get(streamManager, "emitStreamStart") as (
@@ -1820,6 +1901,157 @@ describe("StreamManager - TTFT metadata persistence", () => {
     });
     expect(updatedMessage.metadata?.routeProvider).toBe("openrouter");
     expect(updatedMessage.metadata?.routedThroughGateway).toBe(true);
+  });
+
+
+  test("persists per-invocation tool model usages on the final assistant message", async () => {
+    const startTime = Date.now() - 1000;
+    const firstToolUsage = createToolModelUsageEvent({
+      toolName: "advisor",
+      toolCallId: "tool-call-1",
+      timestamp: startTime + 50,
+      model: "openai:gpt-4",
+      usage: {
+        inputTokens: 60,
+        outputTokens: 18,
+        totalTokens: 78,
+      },
+      providerMetadata: { openai: { reasoningTokens: 4 } },
+    });
+    const secondToolUsage = createToolModelUsageEvent({
+      toolName: "advisor",
+      toolCallId: "tool-call-2",
+      timestamp: startTime + 90,
+      model: "openai:gpt-4",
+      usage: {
+        inputTokens: 30,
+        outputTokens: 9,
+        totalTokens: 39,
+      },
+      providerMetadata: { anthropic: { cacheCreationInputTokens: 3 } },
+    });
+
+    const updatedMessage = await finalizeStreamAndReadMessage({
+      workspaceId: "tool-usage-persist-workspace",
+      messageId: "tool-usage-persist-message",
+      historySequence: 1,
+      startTime,
+      beforeProcess: ({ streamManager, workspaceId, messageId }) => {
+        recordToolModelUsageForTests(streamManager, workspaceId, messageId, firstToolUsage);
+        recordToolModelUsageForTests(streamManager, workspaceId, messageId, secondToolUsage);
+      },
+      parts: [
+        {
+          type: "text",
+          text: "final response",
+          timestamp: startTime + 200,
+        },
+      ],
+    });
+
+    expect(readToolModelUsages(updatedMessage)).toMatchObject([firstToolUsage, secondToolUsage]);
+  });
+
+  test("omits toolModelUsages when the assistant turn has no tool model usage", async () => {
+    const startTime = Date.now() - 1000;
+    const updatedMessage = await finalizeStreamAndReadMessage({
+      workspaceId: "tool-usage-empty-workspace",
+      messageId: "tool-usage-empty-message",
+      historySequence: 1,
+      startTime,
+      parts: [
+        {
+          type: "text",
+          text: "no tool usage here",
+          timestamp: startTime + 150,
+        },
+      ],
+    });
+
+    expect(readToolModelUsages(updatedMessage)).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(updatedMessage.metadata ?? {}, "toolModelUsages")).toBe(
+      false
+    );
+  });
+
+  test("scopes tool model usage accumulation to the active assistant turn", async () => {
+    const workspaceId = "tool-usage-scope-workspace";
+    const streamManager = new StreamManager(historyService);
+    const firstStartTime = Date.now() - 2000;
+    const firstMessage = await finalizeStreamAndReadMessage({
+      workspaceId,
+      messageId: "tool-usage-first-message",
+      historySequence: 1,
+      startTime: firstStartTime,
+      streamManager,
+      beforeProcess: ({ streamManager: activeStreamManager, workspaceId, messageId }) => {
+        recordToolModelUsageForTests(
+          activeStreamManager,
+          workspaceId,
+          messageId,
+          createToolModelUsageEvent({
+            toolName: "advisor",
+            toolCallId: "tool-call-first",
+            timestamp: firstStartTime + 25,
+            model: "anthropic:claude-sonnet-4-20250514",
+            usage: {
+              inputTokens: 24,
+              outputTokens: 6,
+              totalTokens: 30,
+            },
+          })
+        );
+      },
+      parts: [
+        {
+          type: "text",
+          text: "first response",
+          timestamp: firstStartTime + 100,
+        },
+      ],
+    });
+
+    expect(readToolModelUsages(firstMessage)).toMatchObject([
+      {
+        toolName: "advisor",
+        toolCallId: "tool-call-first",
+      },
+    ]);
+
+    const secondMessage = await finalizeStreamAndReadMessage({
+      workspaceId,
+      messageId: "tool-usage-second-message",
+      historySequence: 2,
+      startTime: firstStartTime + 500,
+      streamManager,
+      beforeProcess: ({ streamManager: activeStreamManager, workspaceId }) => {
+        recordToolModelUsageForTests(
+          activeStreamManager,
+          workspaceId,
+          "tool-usage-first-message",
+          createToolModelUsageEvent({
+            toolName: "advisor",
+            toolCallId: "tool-call-stale",
+            timestamp: firstStartTime + 525,
+            model: "anthropic:claude-sonnet-4-20250514",
+            usage: {
+              inputTokens: 12,
+              outputTokens: 3,
+              totalTokens: 15,
+            },
+          })
+        );
+      },
+      parts: [
+        {
+          type: "text",
+          text: "second response",
+          timestamp: firstStartTime + 700,
+        },
+      ],
+    });
+
+    expect(readToolModelUsages(secondMessage)).toBeUndefined();
   });
 
   describe("StreamManager - reasoning token backfill", () => {

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -469,7 +469,7 @@ export class StreamManager extends EventEmitter {
     event: PersistedToolModelUsage
   ): void {
     const streamInfo = this.workspaceStreams.get(workspaceId as WorkspaceId);
-    if (!streamInfo || streamInfo.messageId !== messageId) {
+    if (streamInfo?.messageId !== messageId) {
       return;
     }
 

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -25,7 +25,7 @@ import type {
 } from "@/common/types/stream";
 
 import type { SendMessageError, StreamErrorType } from "@/common/types/errors";
-import type { MuxMetadata, MuxMessage } from "@/common/types/message";
+import type { MuxMetadata, MuxMessage, PersistedToolModelUsage } from "@/common/types/message";
 import type { ThinkingLevel } from "@/common/types/thinking";
 import type { NestedToolCall } from "@/common/orpc/schemas/message";
 import type { ProvidersConfigMap } from "@/common/orpc/types";
@@ -350,6 +350,7 @@ interface WorkspaceStreamInfo {
   /** Effective thinking level after model policy clamping */
   thinkingLevel?: string;
   initialMetadata?: Partial<MuxMetadata>;
+  toolModelUsages: PersistedToolModelUsage[];
   request: StreamRequestConfig;
   // Track last prepared step messages for safe retries after tool steps
   stepTracker: StepMessageTracker;
@@ -460,6 +461,23 @@ export class StreamManager extends EventEmitter {
 
   setMCPServerManager(manager: MCPServerManager | undefined): void {
     this.mcpServerManager = manager;
+  }
+
+  recordToolModelUsage(
+    workspaceId: string,
+    messageId: string,
+    event: PersistedToolModelUsage
+  ): void {
+    const streamInfo = this.workspaceStreams.get(workspaceId as WorkspaceId);
+    if (!streamInfo || streamInfo.messageId !== messageId) {
+      return;
+    }
+
+    streamInfo.toolModelUsages.push({
+      ...event,
+      usage: { ...event.usage },
+      ...(event.providerMetadata != null ? { providerMetadata: event.providerMetadata } : {}),
+    });
   }
 
   /**
@@ -1404,6 +1422,7 @@ export class StreamManager extends EventEmitter {
       metadataModel,
       thinkingLevel,
       initialMetadata,
+      toolModelUsages: [],
       didRetryPreviousResponseIdAtStep: false,
       didRetryAfterEmptyOutput: false,
       stepTracker,
@@ -2176,6 +2195,16 @@ export class StreamManager extends EventEmitter {
             const routedThroughGateway =
               streamInfo.initialMetadata?.routedThroughGateway ??
               streamInfo.model.startsWith("mux-gateway:");
+            const toolModelUsages =
+              streamInfo.toolModelUsages.length > 0
+                ? streamInfo.toolModelUsages.map((toolModelUsage) => ({
+                    ...toolModelUsage,
+                    usage: { ...toolModelUsage.usage },
+                    ...(toolModelUsage.providerMetadata != null
+                      ? { providerMetadata: toolModelUsage.providerMetadata }
+                      : {}),
+                  }))
+                : undefined;
 
             // Emit stream end event with parts preserved in temporal order
             const streamEndEvent: StreamEndEvent = {
@@ -2197,6 +2226,7 @@ export class StreamManager extends EventEmitter {
                 contextUsage, // Last step only (for context window display)
                 providerMetadata, // Aggregated (for cost calculation)
                 contextProviderMetadata, // Last step (for context window display)
+                ...(toolModelUsages != null ? { toolModelUsages } : {}),
                 ...(finishReason !== undefined && { finishReason }),
                 duration,
                 ...(ttftMs !== undefined && { ttftMs }),


### PR DESCRIPTION
## Summary

Extend analytics so advisor (and future tool-level) model costs flow durably into the analytics DB. Each assistant turn now records per-invocation tool model usage on the message, which the ETL emits as separate `events` rows alongside the base assistant row.

> Mux is working on this on behalf of Mike.

## Background

- `advisor.ts` already reports advisor usage via `reportModelUsage(...)`, which `aiService.ts` forwards into `SessionUsageService.recordUsage(...)`.
- `session-usage.json` only persists `byModel` totals with no source/tool dimension.
- Analytics ETL reads `chat.jsonl` usage plus `session-usage.json` for `rolledUpFrom` only, so advisor usage never reached DuckDB.
- There was no durable per-invocation field on messages, so advisor costs were session-only and analytics-invisible.

## Implementation

**New durable shape (tool-agnostic).**
- `MuxMetadata.toolModelUsages?: PersistedToolModelUsage[]` on assistant messages. Each entry carries `toolName`, `toolCallId`, `timestamp`, `model`, `usage`, `providerMetadata`, and an optional `metadataModel` for pricing resolution.

**Live capture, durable persistence.**
- `aiService.ts`: `reportModelUsage` snapshots synchronously onto the active stream via `StreamManager.recordToolModelUsage(...)` before the existing live-usage forward to `SessionUsageService`. Assistant message id creation moved earlier so it is available at callback time. Live session usage behavior unchanged.
- `streamManager.ts`: per-stream accumulator on `WorkspaceStreamInfo`, gated by message id so stale prior-turn events are ignored. The accumulator is persisted to `metadata.toolModelUsages` only when non-empty on final message write.

**Session usage rebuild.**
- `sessionUsageService.ts` rebuild folds both `metadata.usage` and every `metadata.toolModelUsages[]` entry into `byModel`, tolerating absence and partial `providerMetadata`, so rebuild matches live totals.

**Analytics schema, ETL, queries.**
- Nullable `tool_name TEXT` on `events` (schema + ingest/row schemas). Startup `ALTER TABLE events ADD COLUMN IF NOT EXISTS tool_name TEXT` keeps existing DBs working.
- ETL emits one base assistant row (`tool_name = NULL`) plus one row per tool invocation, inheriting `workspace_id`, `parent_workspace_id`, `agent_id`, `is_sub_agent` from the parent turn. Tool rows prefer the tool timestamp and leave timing metrics null. Pricing uses the tool's model, not the parent's.
- Spend and token aggregations include tool rows. `total_responses`, `response_count`, `request_count`, and timing queries exclude tool rows via a shared non-tool predicate.

**Refactor.**
- Shared row builder used by both assistant and tool paths so they cannot drift.
- Centralized non-tool filter for count and timing queries.

## Validation

- `bun test src/node/services/streamManager.test.ts src/node/services/sessionUsageService.test.ts src/node/services/analytics/etl.test.ts src/node/services/analytics/queries.test.ts`: 92 pass / 2 skip / 0 fail.
- `bun test src/node/services/tools/advisor.test.ts src/node/services/aiService.test.ts`: 77 pass / 0 fail.
- `make typecheck` and `make lint`: clean.

New behavioral tests locked in:
- Per-invocation tool model usages persist on the final assistant message; scoped to the active turn; omitted when empty.
- Analytics emits one assistant row plus one row per tool invocation with inherited context.
- Spend and token totals include tool rows; response counts and timing exclude them.
- Session usage rebuild restores advisor costs from the new durable field.

## Risks

- Schema change to `events` is additive via `ADD COLUMN IF NOT EXISTS`; old rows keep `tool_name = NULL` and flow through unchanged.
- Query changes are scoped: spend and token aggregations broadened to include tool rows; response/timing queries explicitly filter `tool_name IS NULL`. Any existing query that relied on implicit one-row-per-turn semantics could double-count, so all count/timing paths were audited and updated to the shared predicate.
- Live session usage recording (`SessionUsageService.recordUsage(...)`) is unchanged. Only the rebuild path was extended.

## Non-goals / follow-ups

- No historical backfill of advisor spend. An opt-in audit showed residuals are partially recoverable at session-aggregate granularity (distinct-model case only) but lose per-invocation timestamps and cannot separate same-model collisions, so forward-only was chosen.
- No advisor-specific UI badges or tooltips. Same-model parent + advisor rows roll into the same `by_model` slice today. Explicit source splitting is a follow-up if product wants it.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `xhigh` • Cost: `$31.19`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=xhigh costs=31.19 -->
