### PR TITLE
🤖 fix: restore starlark code block highlighting

### DIFF
--- a/src/browser/utils/highlighting/shiki-shared.test.ts
+++ b/src/browser/utils/highlighting/shiki-shared.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from "bun:test";
 
-import { extractShikiLines } from "./shiki-shared";
+import { extractShikiLines, mapToShikiLang } from "./shiki-shared";
+
+describe("mapToShikiLang", () => {
+  test("maps unsupported Bazel/Starlark fences to Python highlighting", () => {
+    expect(mapToShikiLang("starlark")).toBe("python");
+    expect(mapToShikiLang("bazel")).toBe("python");
+    expect(mapToShikiLang("bzl")).toBe("python");
+  });
+});
 
 describe("extractShikiLines", () => {
   test("removes trailing visually-empty Shiki line (e.g. <span></span>)", () => {

--- a/src/browser/utils/highlighting/shiki-shared.ts
+++ b/src/browser/utils/highlighting/shiki-shared.ts
@@ -15,7 +15,11 @@ export function mapToShikiLang(detectedLang: string): string {
   const mapping: Record<string, string> = {
     text: "plaintext",
     sh: "bash",
-    // Add more mappings as needed
+    // Shiki does not bundle a Starlark/Bazel grammar, so use Python's close-enough
+    // grammar to keep fenced code blocks highlighted instead of warning and falling back.
+    starlark: "python",
+    bazel: "python",
+    bzl: "python",
   };
   return mapping[detectedLang] || detectedLang;
 }

--- a/src/browser/workers/highlightWorker.ts
+++ b/src/browser/workers/highlightWorker.ts
@@ -5,7 +5,11 @@
 
 import * as Comlink from "comlink";
 import { createHighlighter, type Highlighter } from "shiki";
-import { SHIKI_DARK_THEME, SHIKI_LIGHT_THEME } from "../utils/highlighting/shiki-shared";
+import {
+  mapToShikiLang,
+  SHIKI_DARK_THEME,
+  SHIKI_LIGHT_THEME,
+} from "../utils/highlighting/shiki-shared";
 
 // Singleton highlighter instance within worker
 let highlighter: Highlighter | null = null;
@@ -23,15 +27,6 @@ async function getHighlighter(): Promise<Highlighter> {
   }
   highlighter = await highlighterPromise;
   return highlighter;
-}
-
-// Map detected language to Shiki language ID
-function mapToShikiLang(detectedLang: string): string {
-  const mapping: Record<string, string> = {
-    text: "plaintext",
-    sh: "bash",
-  };
-  return mapping[detectedLang] || detectedLang;
 }
 
 const api = {


### PR DESCRIPTION
## Summary
Use a shared Shiki language fallback so Starlark/Bazel fenced code blocks stay highlighted instead of logging an unsupported-language warning and falling back to plain text.

## Background
Closes #3117. The shipped Shiki bundle does not include a native `starlark` grammar, so attempting to highlight those fences throws at runtime.

## Implementation
- map `starlark`, `bazel`, and `bzl` to Python in the shared Shiki language mapper
- reuse that shared mapper in the highlight worker instead of maintaining a duplicate copy
- add a regression test for the fallback mapping

## Validation
- `bun test src/browser/utils/highlighting/shiki-shared.test.ts`
- `make typecheck`
- `make lint`
- `make static-check`

## Risks
Low. This only changes how unsupported Bazel/Starlark fences are mapped for syntax highlighting, and it keeps the existing plain-text fallback if highlighting still fails for another reason.

---

_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=xhigh costs=0.00 -->
