### PR TITLE
🤖 feat: add "Copy link" to transcript right-click menu

### DIFF
--- a/src/browser/features/Messages/useTranscriptContextMenu.tsx
+++ b/src/browser/features/Messages/useTranscriptContextMenu.tsx
@@ -1,15 +1,20 @@
-import React, { useCallback, useRef } from "react";
-import { Clipboard, TextQuote } from "lucide-react";
+import React, { useCallback, useRef, useState } from "react";
+import { Clipboard, Link as LinkIcon, TextQuote } from "lucide-react";
 import { useContextMenuPosition } from "@/browser/hooks/useContextMenuPosition";
 import { copyToClipboard } from "@/browser/utils/clipboard";
 import {
   formatTranscriptTextAsQuote,
+  getTranscriptContextMenuLink,
   getTranscriptContextMenuText,
 } from "@/browser/utils/messages/transcriptContextMenu";
 import {
   PositionedMenu,
   PositionedMenuItem,
 } from "@/browser/components/PositionedMenu/PositionedMenu";
+
+// Discriminated mode so the menu renders link vs text actions based on what
+// the user right-clicked, without redundant conditional rendering paths.
+type TranscriptContextMenuMode = { kind: "link" } | { kind: "text" };
 
 interface UseTranscriptContextMenuOptions {
   transcriptRootRef: React.RefObject<HTMLElement | null>;
@@ -28,12 +33,31 @@ export function useTranscriptContextMenu(
 ): UseTranscriptContextMenuReturn {
   const transcriptMenu = useContextMenuPosition();
   const transcriptMenuTextRef = useRef<string>("");
+  const transcriptMenuLinkRef = useRef<string>("");
+  // Mode drives which menu items render; use state so the menu re-renders
+  // to reflect link vs text actions when it opens.
+  const [mode, setMode] = useState<TranscriptContextMenuMode | null>(null);
   const hasInputTarget = options.hasInputTarget ?? true;
 
   const handleTranscriptContextMenu = useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
       const transcriptRoot = options.transcriptRootRef.current;
       if (!transcriptRoot) {
+        return;
+      }
+
+      // Links get priority: right-clicking an anchor should offer "Copy link"
+      // rather than falling through to text quote/copy actions. Electron has
+      // no native link context menu, so without this the action is unavailable.
+      const link = getTranscriptContextMenuLink({
+        transcriptRoot,
+        target: event.target,
+      });
+      if (link) {
+        transcriptMenuLinkRef.current = link;
+        transcriptMenuTextRef.current = "";
+        setMode({ kind: "link" });
+        transcriptMenu.onContextMenu(event);
         return;
       }
 
@@ -50,6 +74,8 @@ export function useTranscriptContextMenu(
       }
 
       transcriptMenuTextRef.current = text;
+      transcriptMenuLinkRef.current = "";
+      setMode({ kind: "text" });
       transcriptMenu.onContextMenu(event);
     },
     [options.transcriptRootRef, transcriptMenu]
@@ -71,6 +97,12 @@ export function useTranscriptContextMenu(
     transcriptMenu.close();
   }, [options, transcriptMenu]);
 
+  const handleCopyLink = useCallback(() => {
+    const copyText = options.onCopyText ?? copyToClipboard;
+    void copyText(transcriptMenuLinkRef.current);
+    transcriptMenu.close();
+  }, [options, transcriptMenu]);
+
   return {
     onContextMenu: handleTranscriptContextMenu,
     menu: (
@@ -79,14 +111,20 @@ export function useTranscriptContextMenu(
         onOpenChange={transcriptMenu.onOpenChange}
         position={transcriptMenu.position}
       >
-        {hasInputTarget ? (
-          <PositionedMenuItem
-            icon={<TextQuote />}
-            label="Quote in input"
-            onClick={handleQuoteText}
-          />
-        ) : null}
-        <PositionedMenuItem icon={<Clipboard />} label="Copy text" onClick={handleCopyText} />
+        {mode?.kind === "link" ? (
+          <PositionedMenuItem icon={<LinkIcon />} label="Copy link" onClick={handleCopyLink} />
+        ) : (
+          <>
+            {hasInputTarget ? (
+              <PositionedMenuItem
+                icon={<TextQuote />}
+                label="Quote in input"
+                onClick={handleQuoteText}
+              />
+            ) : null}
+            <PositionedMenuItem icon={<Clipboard />} label="Copy text" onClick={handleCopyText} />
+          </>
+        )}
       </PositionedMenu>
     ),
   };

--- a/src/browser/utils/messages/transcriptContextMenu.test.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { GlobalWindow } from "happy-dom";
-import { formatTranscriptTextAsQuote, getTranscriptContextMenuText } from "./transcriptContextMenu";
+import {
+  formatTranscriptTextAsQuote,
+  getTranscriptContextMenuLink,
+  getTranscriptContextMenuText,
+} from "./transcriptContextMenu";
 
 function createTranscriptRoot(markup: string): HTMLElement {
   const transcriptRoot = document.createElement("div");
@@ -386,5 +390,85 @@ describe("transcriptContextMenu", () => {
     expect(formatTranscriptTextAsQuote("\n\nLeading\n\n")).toBe("> Leading\n\n");
     expect(formatTranscriptTextAsQuote("  indented\nline\n")).toBe(">   indented\n> line\n\n");
     expect(formatTranscriptTextAsQuote("\n  \n")).toBe("");
+  });
+
+  describe("getTranscriptContextMenuLink", () => {
+    test("returns the href when target is an anchor inside the transcript", () => {
+      const transcriptRoot = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          `<a id="message-link" href="https://example.com/path?q=1#x">Example</a>`
+        )
+      );
+      const link = transcriptRoot.querySelector("#message-link");
+      expect(link).not.toBeNull();
+
+      expect(getTranscriptContextMenuLink({ transcriptRoot, target: link })).toBe(
+        "https://example.com/path?q=1#x"
+      );
+    });
+
+    test("returns the href when target is a descendant text/element inside the anchor", () => {
+      const transcriptRoot = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          `<a id="message-link" href="https://example.com"><span id="link-label">Example</span></a>`
+        )
+      );
+      const label = transcriptRoot.querySelector("#link-label");
+      expect(label).not.toBeNull();
+
+      const labelTextNode = getFirstTextNode(label);
+
+      expect(getTranscriptContextMenuLink({ transcriptRoot, target: label })).toBe(
+        "https://example.com"
+      );
+      expect(getTranscriptContextMenuLink({ transcriptRoot, target: labelTextNode })).toBe(
+        "https://example.com"
+      );
+    });
+
+    test("returns null when target is outside the transcript", () => {
+      const transcriptRoot = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          `<a id="message-link" href="https://example.com">Example</a>`
+        )
+      );
+
+      const outsideLink = document.createElement("a");
+      outsideLink.href = "https://outside.example.com";
+      outsideLink.textContent = "Outside";
+      document.body.appendChild(outsideLink);
+
+      expect(getTranscriptContextMenuLink({ transcriptRoot, target: outsideLink })).toBeNull();
+    });
+
+    test("returns null when target is not an anchor", () => {
+      const transcriptRoot = createTranscriptRoot(
+        createQuoteableTranscriptMessage(`<p id="message">Plain text</p>`)
+      );
+      const paragraph = transcriptRoot.querySelector("#message");
+      expect(paragraph).not.toBeNull();
+
+      expect(getTranscriptContextMenuLink({ transcriptRoot, target: paragraph })).toBeNull();
+    });
+
+    test("returns null for anchors without an href attribute", () => {
+      const transcriptRoot = createTranscriptRoot(
+        createQuoteableTranscriptMessage(`<a id="anchor-no-href">No link</a>`)
+      );
+      const anchor = transcriptRoot.querySelector("#anchor-no-href");
+      expect(anchor).not.toBeNull();
+
+      expect(getTranscriptContextMenuLink({ transcriptRoot, target: anchor })).toBeNull();
+    });
+
+    test("returns null for anchors with blank href values", () => {
+      const transcriptRoot = createTranscriptRoot(
+        createQuoteableTranscriptMessage(`<a id="empty-href" href="   ">Blank</a>`)
+      );
+      const anchor = transcriptRoot.querySelector("#empty-href");
+      expect(anchor).not.toBeNull();
+
+      expect(getTranscriptContextMenuLink({ transcriptRoot, target: anchor })).toBeNull();
+    });
   });
 });

--- a/src/browser/utils/messages/transcriptContextMenu.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.ts
@@ -240,6 +240,41 @@ export interface TranscriptContextMenuTextOptions {
   selection: Selection | null;
 }
 
+export interface TranscriptContextMenuLinkOptions {
+  transcriptRoot: HTMLElement;
+  target: EventTarget | null;
+}
+
+/**
+ * Resolve an anchor href for right-click link actions (e.g. "Copy link").
+ *
+ * Returns the rendered href string when the right-click target is inside an
+ * anchor within the transcript; otherwise null. This complements
+ * `getTranscriptContextMenuText` so the transcript can offer link-specific
+ * actions on anchors (which would otherwise bypass the text resolver).
+ */
+export function getTranscriptContextMenuLink(
+  options: TranscriptContextMenuLinkOptions
+): string | null {
+  const targetElement = getEventTargetElement(options.target);
+  if (!targetElement || !options.transcriptRoot.contains(targetElement)) {
+    return null;
+  }
+
+  const anchor = targetElement.closest("a[href]");
+  if (!anchor || !options.transcriptRoot.contains(anchor)) {
+    return null;
+  }
+
+  const href = anchor.getAttribute("href");
+  if (href === null) {
+    return null;
+  }
+
+  const trimmedHref = href.trim();
+  return trimmedHref.length > 0 ? trimmedHref : null;
+}
+
 /**
  * Resolve transcript text for right-click actions.
  *


### PR DESCRIPTION
## Summary

Right-clicking a link in the chat transcript now opens the transcript context menu with a **Copy link** option.

## Background

The transcript's right-click menu previously bailed out for anchor (`a[href]`) targets so the native browser context menu could handle them (open link, copy link, etc.). That works in a standard browser, but in the Electron desktop app there is no native link context menu, so right-clicking a link did nothing. There was no way to copy a link address from the chat without manually selecting the visible text (which often differs from the href).

## Implementation

- `getTranscriptContextMenuLink()` is a new helper in `transcriptContextMenu.ts` that resolves the nearest enclosing `a[href]` for a right-click target and returns its raw `href` (or `null` if blank / outside the transcript). The existing text resolver is untouched.
- `useTranscriptContextMenu` now checks for a link first. If the target is inside an anchor, it renders a single **Copy link** item (lucide `Link` icon) and skips the quote/copy text items. Otherwise it falls through to the existing Quote/Copy text menu. Mode is tracked in state so the menu re-renders with the correct items when it opens.
- Clicking **Copy link** copies the raw href via the existing `copyToClipboard` helper (with the `onCopyText` override respected for tests).

## Validation

- 22 tests in `transcriptContextMenu.test.ts` pass (6 new cases covering direct anchor target, descendant text/element inside an anchor, target outside the transcript, non-anchor target, anchor without `href`, and anchor with a blank `href`).
- `make typecheck`, `make lint`, `make fmt-check` all pass.

<img width="286" height="103" alt="image" src="https://github.com/user-attachments/assets/24f394ea-c5ac-4ae8-9f3f-b2d48eec31da" />


## Risks

Low. The change is additive: it only runs when the right-click target resolves to an anchor inside the transcript. Non-link behavior (selection quoting, text copy, interactive element bypass for buttons/inputs) is unchanged, and the existing transcript text test suite continues to pass.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `max` • Cost: `$3.14`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=max costs=3.14 -->
