### PR TITLE
🤖 fix: make `make start` work on NixOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,11 @@
       let
         pkgs = import nixpkgs {
           inherit system;
+          # package.json pins Electron 38.x, but nixpkgs marks that branch
+          # end-of-life ("insecure"). Let any electron* package evaluate so
+          # the devShell and production build keep working until we bump
+          # Electron upstream in package.json.
+          config.allowInsecurePredicate = attrs: builtins.match "electron.*" (attrs.pname or "") != null;
         };
 
         mux = pkgs.stdenv.mkDerivation rec {
@@ -35,7 +40,10 @@
           ];
 
           buildInputs = with pkgs; [
-            electron
+            # Pin the major Electron version explicitly so `pkgs.electron`
+            # floating to a new major doesn't silently ship the wrong
+            # Node.js ABI for our prebuilt native modules.
+            electron_38
             stdenv.cc.cc.lib # Provides libstdc++ for native modules like sharp
           ];
 
@@ -121,7 +129,7 @@
                         # Create wrapper script. When running in Nix, mux doesn't know that
                         # it's packaged. Use MUX_E2E_LOAD_DIST to force using compiled
                         # assets instead of a dev server.
-                        makeWrapper ${pkgs.electron}/bin/electron $out/bin/mux \
+                        makeWrapper ${pkgs.electron_38}/bin/electron $out/bin/mux \
                           --add-flags "$out/lib/mux/dist/cli/index.js" \
                           --set MUX_E2E_LOAD_DIST "1" \
                           --prefix LD_LIBRARY_PATH : "${pkgs.stdenv.cc.cc.lib}/lib" \
@@ -207,11 +215,27 @@
               asciinema
               ffmpeg
             ]
-            ++ lib.optionals stdenv.isLinux [ docker ];
+            ++ lib.optionals stdenv.isLinux [
+              docker
+              # The Electron binary shipped in node_modules/electron/dist
+              # is dynamically linked against standard FHS paths
+              # (libglib-2.0.so.0, libnss3.so, etc.) that don't exist on
+              # NixOS, so `make start` / `make dev` fail with "error while
+              # loading shared libraries". Expose Nix's autoPatchelf'd
+              # Electron and redirect the npm wrapper to it via
+              # ELECTRON_OVERRIDE_DIST_PATH below.
+              electron_38
+            ];
 
           # Bun does not carry libstdc++ on Linux, so native modules like @duckdb/node-bindings
           # fail to dlopen during tests unless we expose the GCC runtime in the shell.
           LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ pkgs.stdenv.cc.cc.lib ];
+
+          # Point `node_modules/electron/cli.js` at the Nix-patched Electron
+          # binary on Linux so `bunx electron` (used by `make start`/`make dev`)
+          # finds its shared libraries on NixOS without needing an FHS wrapper.
+          # Left unset on Darwin where the npm-shipped binary runs as-is.
+          ELECTRON_OVERRIDE_DIST_PATH = pkgs.lib.optionalString pkgs.stdenv.isLinux "${pkgs.electron_38}/libexec/electron";
         };
       }
     );


### PR DESCRIPTION
## Summary

On NixOS, `make start` and `make dev` fail immediately with `libglib-2.0.so.0: cannot open shared object file` because Electron's npm-shipped binary is linked against FHS paths that don't exist in the Nix store. This PR fixes the devShell to run Electron via Nix's autoPatchelf'd build, and hardens the production derivation against nixpkgs' floating `electron` attribute.

## Background

`bunx electron` (invoked by the `start` target in the Makefile) runs `node_modules/electron/dist/electron`, which is a plain dynamically-linked ELF built for FHS distros. On NixOS it fails at load time:

```
$ make start
.../node_modules/electron/dist/electron: error while loading shared libraries: libglib-2.0.so.0: cannot open shared object file: No such file or directory
make: *** [Makefile:206: start] Error 127
```

The npm Electron wrapper (`node_modules/electron/cli.js`) honors the `ELECTRON_OVERRIDE_DIST_PATH` env var; pointing it at Nix's `electron_38` package — whose binary is autoPatchelf'd against `/nix/store/*/lib` — sidesteps the missing FHS libraries without needing `steam-run`, an FHS wrapper, or a brittle `LD_LIBRARY_PATH` cocktail.

While we're in the flake, two related issues were also addressed:

1. The production derivation's `buildInputs` referenced `pkgs.electron`, which nixpkgs-unstable now resolves to **Electron 41**. `package.json` still pins `^38.2.1`, so the Nix-built app was running with a different Node.js ABI than the one our prebuilt native modules (`node-pty`, `@duckdb/node-bindings`) were built against.
2. `electron_38` is marked EOL in nixpkgs and refuses to evaluate without an `allowInsecurePredicate` or `permittedInsecurePackages` entry.

## Implementation

All changes are scoped to `flake.nix`:

- **Pin `electron_38` across the flake.** Replaced every use of `pkgs.electron` (production `buildInputs` + `makeWrapper` target) with `pkgs.electron_38`, matching `package.json`. This also isolates us from future nixpkgs-unstable churn bumping the default `electron` major.
- **Whitelist `electron*` through the EOL gate.** Added `config.allowInsecurePredicate = attrs: builtins.match "electron.*" (attrs.pname or "") != null;` to the `import nixpkgs` call so `electron_38` (and any other future pinned variant) evaluates cleanly. Predicate is name-scoped rather than a blanket `permittedInsecurePackages = ["electron-38.8.4"]` so we don't have to edit the flake every time nixpkgs bumps the patch version.
- **Expose Electron to the Linux devShell.** Added `electron_38` to the Linux-only branch of `devShells.default.buildInputs` and set `ELECTRON_OVERRIDE_DIST_PATH = "${pkgs.electron_38}/libexec/electron"` (gated on `stdenv.isLinux` so macOS still uses the npm binary as-is).

## Validation

Inside the freshly-updated devShell:

```
$ nix flake check --impure --all-systems   # passes on all four systems
$ make fmt-nix-check                        # passes
$ make fmt-check                            # passes

$ echo "$ELECTRON_OVERRIDE_DIST_PATH"
/nix/store/.../electron-38.7.1/libexec/electron

$ bunx electron --version
v38.7.1

# Control: unset the override and reproduce the original error exactly:
$ unset ELECTRON_OVERRIDE_DIST_PATH && bunx electron --version
.../node_modules/electron/dist/electron: error while loading shared libraries:
libglib-2.0.so.0: cannot open shared object file: No such file or directory
```

## Risks

Low and NixOS-scoped:

- **Linux devShell:** only meaningful change is the new `ELECTRON_OVERRIDE_DIST_PATH` env var — no existing consumer of the devShell relies on the npm-shipped binary (if they did, it would already be broken on NixOS). Non-NixOS Linux users who enter the devShell will now also get the Nix-patched electron, which is identical behaviorally.
- **macOS devShell:** `optionalString stdenv.isLinux` keeps the env var empty and skips the `electron_38` buildInput → identical to before.
- **Production derivation:** `pkgs.electron` → `pkgs.electron_38` is a version *pin*, not a change in intent. The previously-used `pkgs.electron` already floated to 41 silently, so this actually *reduces* drift risk.
- **EOL gate:** the `allowInsecurePredicate` only matches packages whose `pname` starts with `electron`; it's not a global insecure escape hatch.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `max` • Cost: `$3.30`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=max costs=3.30 -->
