### PR TITLE
🤖 feat: add GPT-5.5 as OAuth-required built-in model

### DIFF
--- a/docs/config/models.mdx
+++ b/docs/config/models.mdx
@@ -17,6 +17,7 @@ Mux ships with curated models kept up to date with the frontier. Use any custom 
 | Sonnet 4.6             | anthropic:claude-sonnet-4-6   | `sonnet`                                 |         |
 | Haiku 4.5              | anthropic:claude-haiku-4-5    | `haiku`                                  |         |
 | GPT-5.4                | openai:gpt-5.4                | `gpt`                                    |         |
+| GPT-5.5                | openai:gpt-5.5                | `gpt-5.5`                                |         |
 | GPT-5.4 Pro            | openai:gpt-5.4-pro            | `gpt-pro`                                |         |
 | GPT-5.4 Mini           | openai:gpt-5.4-mini           | `gpt-mini`                               |         |
 | GPT-5.4 Nano           | openai:gpt-5.4-nano           | `gpt-nano`                               |         |

--- a/src/browser/features/Settings/Sections/ModelsSection.test.ts
+++ b/src/browser/features/Settings/Sections/ModelsSection.test.ts
@@ -11,6 +11,14 @@ describe("shouldShowModelInSettings", () => {
     expect(shouldShowModelInSettings(KNOWN_MODELS.GPT_53_CODEX_SPARK.id, true)).toBe(true);
   });
 
+  test("hides GPT-5.5 when OpenAI OAuth is not configured", () => {
+    expect(shouldShowModelInSettings(KNOWN_MODELS.GPT_55.id, false)).toBe(false);
+  });
+
+  test("shows GPT-5.5 when OpenAI OAuth is configured", () => {
+    expect(shouldShowModelInSettings(KNOWN_MODELS.GPT_55.id, true)).toBe(true);
+  });
+
   test("does not gate non-OpenAI models that share the same model id", () => {
     expect(shouldShowModelInSettings("openrouter:gpt-5.3-codex-spark", false)).toBe(true);
   });

--- a/src/browser/hooks/useModelsFromSettings.test.ts
+++ b/src/browser/hooks/useModelsFromSettings.test.ts
@@ -275,6 +275,7 @@ describe("useModelsFromSettings OpenAI Codex OAuth gating", () => {
     const { result } = renderHook(() => useModelsFromSettings());
 
     expect(result.current.models).toContain(KNOWN_MODELS.GPT.id);
+    expect(result.current.models).toContain(KNOWN_MODELS.GPT_55.id);
     expect(result.current.models).not.toContain(KNOWN_MODELS.GPT_PRO.id);
     expect(result.current.models).toContain("openai:gpt-5.2-codex");
     expect(result.current.models).toContain(KNOWN_MODELS.GPT_53_CODEX.id);
@@ -299,6 +300,7 @@ describe("useModelsFromSettings OpenAI Codex OAuth gating", () => {
     expect(result.current.models).toContain("openai:gpt-5.2-codex");
     expect(result.current.models).toContain("openai:gpt-5.2-pro");
     expect(result.current.models).toContain(KNOWN_MODELS.GPT_53_CODEX.id);
+    expect(result.current.models).not.toContain(KNOWN_MODELS.GPT_55.id);
     expect(result.current.models).not.toContain("openai:gpt-5.3-codex-spark");
   });
 
@@ -319,6 +321,7 @@ describe("useModelsFromSettings OpenAI Codex OAuth gating", () => {
     expect(result.current.models).toContain("openai:gpt-5.2-codex");
     expect(result.current.models).toContain("openai:gpt-5.2-pro");
     expect(result.current.models).toContain(KNOWN_MODELS.GPT_53_CODEX.id);
+    expect(result.current.models).toContain(KNOWN_MODELS.GPT_55.id);
     expect(result.current.models).toContain("openai:gpt-5.3-codex-spark");
   });
 
@@ -339,6 +342,7 @@ describe("useModelsFromSettings OpenAI Codex OAuth gating", () => {
     expect(result.current.models).toContain("openai:gpt-5.2-codex");
     expect(result.current.models).toContain("openai:gpt-5.2-pro");
     expect(result.current.models).toContain(KNOWN_MODELS.GPT_53_CODEX.id);
+    expect(result.current.models).not.toContain(KNOWN_MODELS.GPT_55.id);
     expect(result.current.models).not.toContain("openai:gpt-5.3-codex-spark");
   });
 

--- a/src/common/constants/codexOAuth.test.ts
+++ b/src/common/constants/codexOAuth.test.ts
@@ -7,9 +7,19 @@ describe("codexOAuth model gating", () => {
     expect(isCodexOauthAllowedModelId("openai:gpt-5.4-mini")).toBe(true);
   });
 
+  it("allows GPT-5.5 through the Codex OAuth route", () => {
+    expect(isCodexOauthAllowedModelId("gpt-5.5")).toBe(true);
+    expect(isCodexOauthAllowedModelId("openai:gpt-5.5")).toBe(true);
+  });
+
   it("does not allow GPT-5.4 nano through the Codex OAuth route", () => {
     expect(isCodexOauthAllowedModelId("gpt-5.4-nano")).toBe(false);
     expect(isCodexOauthAllowedModelId("openai:gpt-5.4-nano")).toBe(false);
+  });
+
+  it("marks GPT-5.5 as OAuth-required", () => {
+    expect(isCodexOauthRequiredModelId("gpt-5.5")).toBe(true);
+    expect(isCodexOauthRequiredModelId("openai:gpt-5.5")).toBe(true);
   });
 
   it("does not mark GPT-5.4 mini or nano as OAuth-required", () => {

--- a/src/common/constants/codexOAuth.ts
+++ b/src/common/constants/codexOAuth.ts
@@ -94,6 +94,7 @@ export const CODEX_OAUTH_ALLOWED_MODELS = new Set<string>([
   "gpt-5.2",
   "gpt-5.4-mini",
   "gpt-5.4",
+  "gpt-5.5",
   "gpt-5.2-codex",
   "gpt-5.3-codex",
   "gpt-5.3-codex-spark",
@@ -111,6 +112,8 @@ export const CODEX_OAUTH_ALLOWED_MODELS = new Set<string>([
 export const CODEX_OAUTH_REQUIRED_MODELS = new Set<string>([
   // Spark variants still require ChatGPT OAuth routing.
   "gpt-5.3-codex-spark",
+  // GPT-5.5 remains OAuth-required until OpenAI exposes API support.
+  "gpt-5.5",
 ]);
 
 function normalizeCodexOauthModelId(modelId: string): string {

--- a/src/common/constants/knownModels.ts
+++ b/src/common/constants/knownModels.ts
@@ -57,6 +57,13 @@ const MODEL_DEFINITIONS = {
     warm: true,
     tokenizerOverride: "openai/gpt-5",
   },
+  GPT_55: {
+    provider: "openai",
+    providerModelId: "gpt-5.5",
+    aliases: ["gpt-5.5"],
+    warm: true,
+    tokenizerOverride: "openai/gpt-5",
+  },
   // GPT Pro alias tracks the latest GPT-5 Pro tier.
   GPT_PRO: {
     provider: "openai",

--- a/src/common/utils/thinking/policy.test.ts
+++ b/src/common/utils/thinking/policy.test.ts
@@ -176,6 +176,16 @@ describe("getThinkingPolicyForModel", () => {
     ]);
   });
 
+  test("returns 5 levels including xhigh for gpt-5.5", () => {
+    expect(getThinkingPolicyForModel("openai:gpt-5.5")).toEqual([
+      "off",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+  });
+
   test("returns 5 levels including xhigh for gpt-5.4-mini", () => {
     expect(getThinkingPolicyForModel("openai:gpt-5.4-mini")).toEqual([
       "off",

--- a/src/common/utils/thinking/policy.ts
+++ b/src/common/utils/thinking/policy.ts
@@ -82,10 +82,10 @@ export function getThinkingPolicyForModel(modelString: string): ThinkingPolicy {
     return ["medium", "high", "xhigh"];
   }
 
-  // gpt-5.2, gpt-5.4, and GPT-5.4 mini/nano support 5 reasoning levels including xhigh.
+  // gpt-5.2, gpt-5.4, gpt-5.5 and their mini/nano variants support 5 reasoning levels including xhigh.
   if (
     /^gpt-5\.2(?!-[a-z])/.test(withoutProviderNamespace) ||
-    /^gpt-5\.4(?:-(?:mini|nano))?(?!-[a-z])/.test(withoutProviderNamespace)
+    /^gpt-5\.(?:4|5)(?:-(?:mini|nano))?(?!-[a-z])/.test(withoutProviderNamespace)
   ) {
     return ["off", "low", "medium", "high", "xhigh"];
   }

--- a/src/common/utils/tokens/models-extra.ts
+++ b/src/common/utils/tokens/models-extra.ts
@@ -134,6 +134,22 @@ export const modelsExtra: Record<string, ModelData> = {
     knowledge_cutoff: "2025-08-31",
   },
 
+  // GPT-5.5 - currently reachable via the Codex route with a 400K context window.
+  // Published pricing: $5/M input, $30/M output, $0.50/M cached input.
+  "gpt-5.5": {
+    max_input_tokens: 400000,
+    max_output_tokens: 128000,
+    input_cost_per_token: 0.000005, // $5 per million input tokens
+    output_cost_per_token: 0.00003, // $30 per million output tokens
+    cache_read_input_token_cost: 0.0000005, // $0.50 per million cached input tokens
+    litellm_provider: "openai",
+    mode: "chat",
+    supports_function_calling: true,
+    supports_vision: true,
+    supports_reasoning: true,
+    supports_response_schema: true,
+  },
+
   // GPT-5.4 mini - Released March 11, 2026
   // Smaller/faster GPT-5.4 tier with 400K context, 128K max output, and published
   // pricing of $0.75/M input, $4.50/M output, and $0.075/M cached input.

--- a/src/node/services/agentSkills/builtInSkillContent.generated.ts
+++ b/src/node/services/agentSkills/builtInSkillContent.generated.ts
@@ -2293,6 +2293,7 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
       "| Sonnet 4.6             | anthropic:claude-sonnet-4-6   | `sonnet`                                 |         |",
       "| Haiku 4.5              | anthropic:claude-haiku-4-5    | `haiku`                                  |         |",
       "| GPT-5.4                | openai:gpt-5.4                | `gpt`                                    |         |",
+      "| GPT-5.5                | openai:gpt-5.5                | `gpt-5.5`                                |         |",
       "| GPT-5.4 Pro            | openai:gpt-5.4-pro            | `gpt-pro`                                |         |",
       "| GPT-5.4 Mini           | openai:gpt-5.4-mini           | `gpt-mini`                               |         |",
       "| GPT-5.4 Nano           | openai:gpt-5.4-nano           | `gpt-nano`                               |         |",

--- a/src/node/services/aiService.test.ts
+++ b/src/node/services/aiService.test.ts
@@ -639,6 +639,30 @@ describe("AIService.createModel (Codex OAuth routing)", () => {
     }
   });
 
+  it("returns oauth_not_connected for gpt-5.5 when OAuth and API key are missing", async () => {
+    using muxHome = new DisposableTempDir("codex-gpt-5-5-missing-auth");
+
+    await writeProvidersConfig(muxHome.path, {
+      openai: {},
+    });
+
+    const savedKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    try {
+      const service = createService(muxHome.path);
+      const result = await service.createModel(KNOWN_MODELS.GPT_55.id);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toEqual({ type: "oauth_not_connected", provider: "openai" });
+      }
+    } finally {
+      if (savedKey !== undefined) {
+        process.env.OPENAI_API_KEY = savedKey;
+      }
+    }
+  });
+
   it("falls back to API key for required Codex models when OAuth is missing but API key is present", async () => {
     using muxHome = new DisposableTempDir("codex-oauth-missing-apikey-present");
 


### PR DESCRIPTION
## Summary

Adds **GPT-5.5** as a first-class OAuth-required built-in model for OpenAI. This is **Phase 1 of a staged rollout**: GPT-5.5 is exposed only where Mux already has a working access path today (ChatGPT Codex OAuth). The `gpt` alias and first-run defaults still point at `gpt-5.4`, and no GPT-5.5 Pro entry is introduced.

## Background

OpenAI recently announced GPT-5.5 and GPT-5.5 Pro. At the time of this change:

- GPT-5.5 is available in ChatGPT and Codex now; **API support is coming soon**.
- On the Codex route today the context window is **400K**, while the future API is advertised at **1M**.
- GPT-5.5 Pro is scoped to **ChatGPT only** — there is **no evidence** it is reachable via Codex today (see reconnaissance notes at the bottom of the plan).
- Mux's OpenAI OAuth path (`src/common/constants/codexOAuth.ts`) routes through `https://chatgpt.com/backend-api/codex/responses`, so it already has a plausible transport for the standard GPT-5.5 model.

If we had repointed the `gpt` alias to `gpt-5.5` in one shot, we would have had to lie about either today's OAuth context window (400K) or the future API one (1M), and we would have had to decide about GPT-5.5 Pro without a verified access path. Instead, this PR adds a temporary `GPT_55` registry entry gated by `CODEX_OAUTH_REQUIRED_MODELS`; a follow-up can collapse it into the `GPT` alias once the API ships with stable metadata.

## Implementation

- **Registry** (`src/common/constants/knownModels.ts`): new `GPT_55` entry mirroring the shape of `GPT` (alias `gpt-5.5`, `warm`, tokenizer `openai/gpt-5`). `GPT` is unchanged.
- **OAuth gating** (`src/common/constants/codexOAuth.ts`): `gpt-5.5` added to both `CODEX_OAUTH_ALLOWED_MODELS` and `CODEX_OAUTH_REQUIRED_MODELS`, with an inline comment explaining that the required-set membership is temporary until OpenAI ships API access.
- **Token metadata** (`src/common/utils/tokens/models-extra.ts`): conservative entry using the currently reachable Codex-route limits — 400K input, 128K output, published pricing ($5 / $0.50 cached / $30 per million), GPT-5.4-parity capability flags, `mode: "chat"`. No tiered-pricing, no `knowledge_cutoff`, no Fast-mode metadata.
- **Thinking policy** (`src/common/utils/thinking/policy.ts`): regex extended from `gpt-5\.4(?:-mini|-nano)?` to `gpt-5\.(?:4|5)(?:-mini|-nano)?` so GPT-5.5 (and future mini/nano variants) inherit the full `off / low / medium / high / xhigh` ladder.
- **Behavioral tests** added in `codexOAuth.test.ts`, `ModelsSection.test.ts`, `useModelsFromSettings.test.ts`, `aiService.test.ts`, and `policy.test.ts`. No tautological tests — each assertion exercises a gating, routing, or policy branch that would fail if the intended behavior regressed.
- **Generated docs** refreshed via `bun scripts/gen_docs.ts`: `docs/config/models.mdx` and `src/node/services/agentSkills/builtInSkillContent.generated.ts`.

Intentionally **not** changed: `GPT` alias target, `providerService.ts` first-run default, `ProvidersSection.tsx` example text, and any GPT-5.5 Pro surface.

## Validation

End-to-end dogfood run against the real ChatGPT Codex OAuth backend using a throwaway sandbox that copied only `openai.codexOauth` out of `~/.mux/providers.jsonc` (sandbox was deleted afterwards):

1. **Gating — OAuth not configured** (API-key-only, mock state): GPT-5.5 is hidden in both Settings → Models and the model picker. `gpt` still resolves to GPT-5.4.
2. **Gating — OAuth configured** (real token): GPT-5.5 appears with `400k` context and `Direct` route; the model picker offers it right after `GPT-5.4`.
3. **Thinking ladder**: from GPT-5.5 selected, cycling Increase walks `off → low → medium → high → xhigh` and caps correctly.
4. **Live request** with `GPT-5.5 + MED` thinking + Exec mode:
   - Prompt: _"Please respond with exactly the phrase DOGFOOD-GPT55-OK-MARKER-7F2A and nothing else."_
   - Response from the model: `DOGFOOD-GPT55-OK-MARKER-7F2A`
   - Stats panel: `Context 8.3k / 400.0k (2.1%)`, `Cost $0.00` (OAuth subscription billing).
   - Backend log: `AIService.streamMessage: tool configuration {"model":"openai:gpt-5.5", ...}`.
   - Transport proof from an earlier name-gen call surfaced `Domain=chatgpt.com` Set-Cookie and `"The 'gpt-5.1-codex-mini' model is not supported when using Codex with a ChatGPT account."`, confirming the OpenAI traffic is going through `chatgpt.com/backend-api/codex/responses`.

Local static checks: `make typecheck`, targeted `bun test` across all touched test files, and `make static-check` all green.

## Risks

Low. The registry change is additive, the alias target is unchanged, and `CODEX_OAUTH_REQUIRED_MODELS` gating means only users with a configured ChatGPT OAuth session can see or pick the new model. If GPT-5.5 is temporarily unavailable on the Codex backend, the failure surface is the same existing Codex-responses request path used by other OAuth-only models (e.g. Spark). The thinking-policy regex change could theoretically over-match a future `gpt-5.5-<variant>` name — mitigated by the existing `(?!-[a-z])` negative lookahead pattern used throughout the file, which blocks arbitrary suffixes.

## Follow-ups (deliberately out of scope)

- **Phase 2** once OpenAI ships GPT-5.5 on the API with stable metadata: collapse `GPT_55` into `GPT`, remove it from `CODEX_OAUTH_REQUIRED_MODELS`, bump context/pricing to API values, update `providerService.ts` default and `ProvidersSection.tsx` example.
- **Phase 3** (GPT-5.5 Pro) only after verified access path — strong evidence today indicates Pro is ChatGPT-only, not Codex-routable. The full reconnaissance notes live in the plan below.

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Integrate GPT-5.5 and GPT-5.5 Pro into Mux known models

## Recommendation
Use a **staged rollout**, not a one-shot alias flip.

1. **Ship GPT-5.5 now as an explicit OpenAI built-in that is OAuth-first**.
   - Add a temporary `GPT_55` entry for `openai:gpt-5.5`.
   - Keep bare `gpt` pointing at `gpt-5.4` for now.
   - Gate `gpt-5.5` behind Codex OAuth until the API release is real.
2. **Do not add GPT-5.5 Pro yet**.
   - Wait for either official API model docs/metadata or proof that the Codex backend accepts it.
3. **After API launch, collapse the temporary GPT-5.5 entry into the existing `GPT` alias**.
   - Repoint `KNOWN_MODELS.GPT` to `gpt-5.5`.
   - Remove the temporary `GPT_55` entry so `KNOWN_MODELS` does not contain duplicate model IDs.
4. **Only then decide whether to repoint `GPT_PRO` to `gpt-5.5-pro`**.

### Approach options and net product-code LoC
| Approach | Net product-code LoC | Recommendation | Why |
| --- | ---: | --- | --- |
| **A. Staged rollout**: add temporary `GPT_55` now, defer `GPT_55_PRO`, flip aliases later | **~50-80 total**, split across follow-ups (`~30-45` now, `~0-8` later to collapse `GPT_55` into `GPT`, `~18-28` later for Pro) | **Recommended** | Matches repo history and current auth/routing constraints with the least risk. |
| **B. Immediate speculative rollout**: add GPT-5.5 + GPT-5.5 Pro and repoint `gpt` / `gpt-pro` now | **~35-60** | Not recommended | Smallest diff, but it would likely misstate availability/context and could surface a broken Pro model. |
| **C. Route-aware metadata first**: teach Mux that the same model ID has different limits on OAuth vs API routes | **~80-140** | Only if product insists on exposing the same `gpt-5.5` ID on both routes before API parity exists | Solves the 400K-vs-1M mismatch cleanly, but it is too much architecture for this model add. |

## Why this fits the repo

<details>
<summary>Verified repo evidence and release constraints</summary>

### Repo history patterns
- **`55b88f42f` — `feat: add gpt-5.3-codex as known model for OpenAI OAuth`**
  - Added a temporary/explicit built-in when Mux already had a working ChatGPT/Codex OAuth route.
  - Touched `src/common/constants/knownModels.ts`, `src/common/utils/tokens/models-extra.ts`, `src/common/utils/thinking/policy.ts`, and generated model docs.
- **`67a0c64fd` — `feat: add GPT-5.4 aliases and native extended context`**
  - Repointed the generic `gpt` / `gpt-pro` aliases once model metadata and defaults were ready.
  - Also touched `src/common/constants/codexOAuth.ts`, `src/common/utils/compaction/contextLimit.ts`, `src/node/services/providerService.ts`, tests, and docs.
- **`39e0a8781` — `fix: remove GPT-5.2 Codex from built-in models`**
  - Confirms that `KNOWN_MODELS` is the curated built-in surface and older models can remain supported below that layer.

### Current code paths that matter
- **`src/common/constants/knownModels.ts`** is the source of truth for curated built-ins, aliases, tokenizer overrides, and warm-tokenizer preloads.
- **`src/common/constants/codexOAuth.ts`** only routes OpenAI OAuth traffic to `https://chatgpt.com/backend-api/codex/responses`.
  - That means today’s OAuth path is **Codex-specific**, not generic ChatGPT model access.
- **`src/browser/hooks/useModelsFromSettings.ts`** uses:
  - `CODEX_OAUTH_ALLOWED_MODELS` to decide what appears for OAuth-only OpenAI setups.
  - `CODEX_OAUTH_REQUIRED_MODELS` to hide models from API-key-only / unauthenticated surfaces.
- **`src/node/services/providerService.ts`** still seeds first-run mux-gateway defaults with `openai/gpt-5.4`.
- **`docs/config/models.mdx`** is generated from the curated registry and is mirrored into generated built-in skill content.

### Release constraints from OpenAI
- GPT-5.5 is available in **ChatGPT and Codex now**, but API support is still described as **coming soon**.
- GPT-5.5 Pro is available in **ChatGPT now**, but the announcement does **not** say it is in Codex today.
- GPT-5.5 has **400K context in Codex today** but **1M context in the API when that arrives**.
- GPT-5.5 pricing is published at **$5/M input, $0.50/M cached input, $30/M output**.
- GPT-5.5 Pro pricing is published at **$30/M input, $180/M output**, but the release material does **not** fully pin down the same metadata set Mux usually stores for released API models (notably current route availability and complete pricing/context details).

### Key consequence
Mux’s metadata is currently keyed by model ID, not by auth route. If we flip `gpt` to `gpt-5.5` **before** API parity exists, Mux would have to choose between:
- publishing **400K** to stay correct for today’s OAuth/Codex path, or
- publishing **1M** to stay correct for the upcoming API path.

That is the core reason to stage the rollout.
</details>

## Phase 1 — Add GPT-5.5 now as a temporary OAuth-first built-in
**Goal:** expose GPT-5.5 in Mux only where Mux already has a plausible access path today.

### Product-code changes
1. **`src/common/constants/knownModels.ts`**
   - Add a temporary `GPT_55` entry for `providerModelId: "gpt-5.5"`.
   - Give it a versioned alias so it is selectable without a provider prefix.
     - Recommended alias: **`gpt-5.5`**.
   - Reuse `tokenizerOverride: "openai/gpt-5"`.
   - Keep `GPT` / `GPT_PRO` unchanged for now.
2. **`src/common/constants/codexOAuth.ts`**
   - Add `"gpt-5.5"` to **`CODEX_OAUTH_ALLOWED_MODELS`**.
   - Also add `"gpt-5.5"` to **`CODEX_OAUTH_REQUIRED_MODELS`**.
     - This is the key staging lever: it keeps GPT-5.5 off API-key-only surfaces until the API is actually live, while still letting OAuth-connected users access it now.
3. **`src/common/utils/tokens/models-extra.ts`**
   - Add `"gpt-5.5"` metadata.
   - Use the **currently reachable route’s published limit** for Phase 1: **400K context**.
   - Set pricing from the published public pricing page: input, cached input, and output.
   - Mirror GPT-5.4 capability flags unless official docs contradict them:
     - `supports_function_calling`
     - `supports_vision`
     - `supports_reasoning`
     - `supports_response_schema`
   - Keep the entry conservative:
     - **do not invent** long-context tier fields,
     - **do not invent** undocumented endpoint restrictions,
     - **do not model Fast mode** unless OpenAI exposes a stable model ID or request parameter for it.
4. **`src/common/utils/thinking/policy.ts`**
   - Extend the GPT-5 base-model regex/policy so `gpt-5.5` gets the same policy as `gpt-5.4` unless official docs say otherwise.
   - That likely means `off/low/medium/high/xhigh`, but the implementation should follow the existing GPT-5.4 pattern rather than creating a special case object.

### Generated outputs and coupled files
- Refresh **`docs/config/models.mdx`**.
- Check whether the docs regeneration also updates **`src/node/services/agentSkills/builtInSkillContent.generated.ts`**; regenerate it if needed.

### Targeted tests to update or add
- **`src/common/constants/knownModels.test.ts`** — new known model is backed by token metadata and aliases stay unique.
- **`src/common/constants/codexOAuth.test.ts`** — `gpt-5.5` is both allowed and required.
- **`src/browser/hooks/useModelsFromSettings.test.ts`** — auth-state matrix for OAuth-only / API-key-only / both / neither.
- **`src/browser/features/Settings/Sections/ModelsSection.test.ts`** — required-model gating in Settings.
- **`src/node/services/aiService.test.ts`** — required-model behavior when OAuth is absent/present.
- **`src/common/utils/thinking/policy.test.ts`** — GPT-5.5 inherits the expected reasoning levels.
- If a new version alias is added, keep **`src/browser/utils/models/normalizeModelInput.test.ts`** green.

### Phase-1 acceptance criteria
- OAuth-only OpenAI users can see/select **GPT-5.5**.
- API-key-only OpenAI users do **not** see/select GPT-5.5 yet.
- `gpt` still resolves to **GPT-5.4**, not GPT-5.5.
- `gpt-pro` still resolves to **GPT-5.4 Pro**.
- No GPT-5.5 Pro entry is exposed yet.

## Phase 2 — Collapse GPT-5.5 into the existing `gpt` alias after API launch
**Precondition:** OpenAI’s API docs/pricing/model pages clearly publish GPT-5.5 as a released API model with stable metadata that Mux can encode.

### Product-code changes
1. **`src/common/constants/knownModels.ts`**
   - Repoint `KNOWN_MODELS.GPT` to `gpt-5.5`.
   - Remove the temporary `GPT_55` entry so the curated registry does not contain duplicate IDs for the same model.
2. **`src/common/utils/tokens/models-extra.ts`**
   - Update `gpt-5.5` metadata from the Phase-1 OAuth-first values to the released API values.
   - If the API really uses the published **1M** context window, encode that here.
3. **`src/common/constants/codexOAuth.ts`**
   - Remove `gpt-5.5` from `CODEX_OAUTH_REQUIRED_MODELS` once API-key access is real.
   - Keep it in `CODEX_OAUTH_ALLOWED_MODELS` if the Codex route remains valid.
4. **`src/node/services/providerService.ts`**
   - Update first-run mux-gateway seeded default from `openai/gpt-5.4` to `openai/gpt-5.5`.
5. **`src/browser/features/Settings/Sections/ProvidersSection.tsx`**
   - Update any pinned example text that still cites `gpt-5.4` as the representative model for “supports both ChatGPT OAuth and API keys”.

### Phase-2 acceptance criteria
- `gpt` resolves to **GPT-5.5**.
- GPT-5.5 is visible for API-key OpenAI users.
- First-run mux-gateway defaults seed `openai/gpt-5.5`.
- No duplicate built-in rows exist for GPT-5.5.

## Phase 3 — Add or repoint GPT-5.5 Pro only after route metadata is real
**Precondition:** one of the following is true:
- OpenAI publishes enough API model metadata for `gpt-5.5-pro`, or
- we verify that Mux’s Codex OAuth backend actually accepts `gpt-5.5-pro`.

### Recommended product decision
- **Do not assume GPT-5.5 Pro is OAuth-routable today.**
- If the first reliable access path is the API, the simplest follow-up is to **repoint `GPT_PRO` directly** instead of introducing a temporary `GPT_55_PRO` preview entry.

### Likely code changes once the precondition is satisfied
1. **`src/common/constants/knownModels.ts`**
   - Repoint `GPT_PRO` to `gpt-5.5-pro`, or add a temporary `GPT_55_PRO` only if product explicitly wants a preview period before alias movement.
2. **`src/common/utils/tokens/models-extra.ts`**
   - Add released metadata for `gpt-5.5-pro`.
   - Keep the entry conservative unless the docs explicitly publish:
     - context window,
     - cached-input pricing,
     - endpoint restrictions,
     - reasoning-effort constraints.
3. **`src/common/utils/thinking/policy.ts`**
   - Mirror the correct Pro policy only after official docs support it.
   - Do **not** blindly assume GPT-5.5 Pro keeps GPT-5.4 Pro’s exact reasoning envelope.
4. **`src/common/constants/codexOAuth.ts`**
   - Only touch this if the Codex backend is confirmed to support GPT-5.5 Pro.
   - Otherwise leave Pro out of the OAuth allow-list so OAuth-only users do not see a broken entry.

### Phase-3 acceptance criteria
- `gpt-pro` points at GPT-5.5 Pro **only when Mux has a verified access path**.
- OAuth-only OpenAI users do not see GPT-5.5 Pro unless the Codex route is verified.
- Mux does not invent missing pricing/context metadata just to fill out `models-extra.ts`.

## Validation / quality gates
Run these in between phases, not only at the end:

1. **Registry + alias integrity**
   - `bun test src/common/constants/knownModels.test.ts`
   - `bun test src/browser/utils/models/normalizeModelInput.test.ts`
2. **OAuth gating**
   - `bun test src/common/constants/codexOAuth.test.ts`
   - `bun test src/browser/hooks/useModelsFromSettings.test.ts`
   - `bun test src/browser/features/Settings/Sections/ModelsSection.test.ts`
   - `bun test src/node/services/aiService.test.ts`
3. **Thinking/capability metadata**
   - `bun test src/common/utils/thinking/policy.test.ts`
   - Add any model-stats or cost-display tests only if the metadata shape actually changes.
4. **Repo-wide safety net**
   - `make static-check`

## Dogfooding plan
Use this to prove the staged behavior matches the intent.

### Setup
- Launch the app in dev mode (`make dev`).
- Use the desktop automation path appropriate for Mux:
  - **preferred:** Electron automation via the `electron` skill,
  - fallback: the `dogfood` skill if a broader exploratory pass is desired.
- Perform the checks with fresh provider states so auth gating is easy to reason about:
  1. OpenAI OAuth only
  2. OpenAI API key only
  3. Both OAuth + API key
  4. Neither auth mode

### Phase-1 dogfood scenarios
1. **OAuth only**
   - Open Settings → Models.
   - Verify GPT-5.5 is visible.
   - Verify GPT-5.5 Pro is absent.
   - Open the model picker and verify the new versioned alias/model row is selectable.
2. **API key only**
   - Verify GPT-5.5 is absent while still unreleased in the API.
   - Verify `gpt` still targets GPT-5.4.
3. **Both OAuth + API key**
   - Verify GPT-5.5 remains selectable and routes successfully.
4. **Send-path smoke test**
   - Send one prompt with GPT-5.5.
   - Confirm it does not fail with `oauth_not_connected`, `api_key_not_found`, or obvious request-shape incompatibilities.

### Artifacts reviewers should expect
- **Screenshots**
  - Settings → Models with OAuth only.
  - Model picker showing GPT-5.5.
  - Provider settings showing the OpenAI auth mode used for the test.
- **Short video recording**
  - A brief capture that toggles between OAuth-only and API-key-only states and shows GPT-5.5 appearing/disappearing accordingly.
- Attach all screenshots/videos to the implementation handoff so reviewers can verify the claim without rerunning the flow.

## Risks / watchpoints
- **Do not model GPT-5.5 Fast mode yet.** The release notes describe a Codex product mode, not a stable Mux-known-model ID.
- **Do not flip `gpt` early.** That would force Mux to lie about either today’s 400K OAuth path or the future 1M API path.
- **Do not add GPT-5.5 Pro early.** Mux’s OAuth path is Codex-specific, and the announcement does not place Pro in Codex.
- If OpenAI ships `gpt-5.5` into LiteLLM/model metadata before implementation lands, prefer the repo’s normal metadata-refresh flow and keep `models-extra.ts` as the conservative override layer.

</details>

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `max` • Cost: `$19.84`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=max costs=19.84 -->
