### PR TITLE
🤖 fix: align gpt-5.5 pricing tiers while keeping 400K OAuth routable cap

### DIFF
--- a/src/common/utils/tokens/models-extra.ts
+++ b/src/common/utils/tokens/models-extra.ts
@@ -134,20 +134,33 @@ export const modelsExtra: Record<string, ModelData> = {
     knowledge_cutoff: "2025-08-31",
   },
 
-  // GPT-5.5 - currently reachable via the Codex route with a 400K context window.
-  // Published pricing: $5/M input, $30/M output, $0.50/M cached input.
+  // GPT-5.5
+  // Native model window is 1.05M context with 128K max output, but today Mux can only
+  // route GPT-5.5 through the Codex OAuth path and that route caps prompts at 400K.
+  // Keep max_input_tokens aligned to the routable cap, not the underlying model window,
+  // so pre-send compaction triggers before the OAuth route rejects 400K+ requests; when
+  // a non-OAuth API route becomes available, we can raise this to the published window.
+  // Base pricing: $5/M input, $30/M output, $0.50/M cached input.
+  // Above 272K prompt tokens (still reachable within the 400K OAuth cap): $10/M input,
+  // $45/M output, $1/M cached input.
   "gpt-5.5": {
     max_input_tokens: 400000,
     max_output_tokens: 128000,
-    input_cost_per_token: 0.000005, // $5 per million input tokens
-    output_cost_per_token: 0.00003, // $30 per million output tokens
-    cache_read_input_token_cost: 0.0000005, // $0.50 per million cached input tokens
+    input_cost_per_token: 0.000005, // $5 per million input tokens (<272K prompt tokens)
+    input_cost_per_token_above_200k_tokens: 0.00001, // $10 per million input tokens (>272K)
+    output_cost_per_token: 0.00003, // $30 per million output tokens (<272K prompt tokens)
+    output_cost_per_token_above_200k_tokens: 0.000045, // $45 per million output tokens (>272K)
+    cache_read_input_token_cost: 0.0000005, // $0.50 per million cached input tokens (<272K)
+    cache_read_input_token_cost_above_200k_tokens: 0.000001, // $1 per million cached input tokens (>272K)
+    // OpenAI's published long-context boundary is 272K even though LiteLLM's field names say 200K.
+    tiered_pricing_threshold_tokens: 272000,
     litellm_provider: "openai",
     mode: "chat",
     supports_function_calling: true,
     supports_vision: true,
     supports_reasoning: true,
     supports_response_schema: true,
+    knowledge_cutoff: "2025-08-31",
   },
 
   // GPT-5.4 mini - Released March 11, 2026


### PR DESCRIPTION
## Summary

Follow-up to #3190. Adds the missing 272K tiered pricing fields to the `gpt-5.5` record in `src/common/utils/tokens/models-extra.ts` while keeping `max_input_tokens` at the Codex OAuth route's 400K routable cap (required for correct pre-send compaction).

## Background

#3190 introduced `gpt-5.5` as an OAuth-required built-in, but its metadata entry was flat-priced and didn't include the 272K tiered pricing boundary that the rest of the GPT-5.x family uses. Published OpenAI pricing for GPT-5.5 is `$5/M` input, `$30/M` output, `$0.50/M` cached input at the base tier, rising to `$10/M · $45/M · $1/M` above the 272K long-context boundary (2× input, 1.5× output, 2× cached — same ratios as GPT-5.4).

An earlier revision of this PR also bumped `max_input_tokens` to `1,050,000` to reflect the published API context window. Codex review correctly flagged that as a regression: `gpt-5.5` is still OAuth-only via Codex (`CODEX_OAUTH_REQUIRED_MODELS`) and the Codex route caps prompts at 400K today. Because `agentSession.checkBeforeSend` compacts only after crossing a percentage of `max_input_tokens`, advertising 1.05M would let chats in the 400K–735K range through to the route and fail with `context_exceeded` instead of being pre-compacted. The accepted plan's Phase 1 prescribes the same 400K routable cap for exactly this reason.

So this PR keeps `max_input_tokens` pinned to the route's cap and only picks up the missing pricing tiers.

## Implementation

Only `src/common/utils/tokens/models-extra.ts` changes — single `gpt-5.5` record + leading comment block.

- **`max_input_tokens: 400000`** — tracks the Codex OAuth route's cap so pre-send compaction triggers correctly. Can be raised when a non-OAuth API route lands.
- **Added tiered pricing fields:**
  - `input_cost_per_token_above_200k_tokens: 0.00001` (`$10/M`)
  - `output_cost_per_token_above_200k_tokens: 0.000045` (`$45/M`)
  - `cache_read_input_token_cost_above_200k_tokens: 0.000001` (`$1/M`)
  - `tiered_pricing_threshold_tokens: 272000`
- **Added `knowledge_cutoff: "2025-08-31"`** — matches the GPT-5.x family.
- The leading comment block now explains that `max_input_tokens` intentionally tracks the routable cap (not the underlying 1M model window) until a non-OAuth route is available, and notes that the 272K pricing boundary is still reachable within the 400K OAuth cap.

## What did NOT change

- `src/common/constants/knownModels.ts` — `GPT_55` entry, alias, tokenizer override, `warm` flag untouched.
- `src/common/constants/codexOAuth.ts` — `gpt-5.5` remains in both `CODEX_OAUTH_ALLOWED_MODELS` and `CODEX_OAUTH_REQUIRED_MODELS`. API-key-only users still don't see GPT-5.5.
- `src/common/utils/thinking/policy.ts` — reasoning policy unchanged; `gpt-5.5` continues to match the GPT-5.x 5-tier envelope.
- No `GPT` / `GPT_PRO` alias repointing; no `gpt-5.5-pro` work (both still deferred per the staged rollout plan).

## Validation

- `make typecheck` — pass.
- `bun test src/common/constants/knownModels.test.ts src/common/constants/codexOAuth.test.ts src/browser/features/Settings/Sections/ModelsSection.test.ts` — 17/17 pass.
- `bun scripts/gen_docs.ts` — runs clean; no generated-doc diff (docs table doesn't yet surface context/tier fields, out of scope here).

## Risks

Low. Metadata-only change to a single record. `max_input_tokens` is unchanged from `main`, so compaction behavior is identical to post-#3190. The new pricing tier fields affect cost estimation only when prompts cross the 272K boundary within the 400K OAuth cap — previously those would have been under-billed.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `max` • Cost: `$30.93`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=max costs=30.93 -->
