### PR TITLE
🤖 feat: support Coder path-app iframe embedding

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,9 @@
     />
     <meta name="description" content="Parallel agentic development with Electron + React" />
     <meta name="theme-color" content="#1e1e1e" />
-    <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" vite-ignore />
-    <link rel="icon" href="/favicon.ico" data-theme-icon vite-ignore />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" vite-ignore />
+    <link rel="manifest" href="manifest.json" crossorigin="use-credentials" vite-ignore />
+    <link rel="icon" href="favicon.ico" data-theme-icon vite-ignore />
+    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" vite-ignore />
     <title>mux - coder multiplexer</title>
     <style>
       body {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,20 +2,20 @@
   "name": "mux - coder multiplexer",
   "short_name": "mux",
   "description": "Parallel agentic development with Electron + React",
-  "start_url": "/",
+  "start_url": ".",
   "display": "standalone",
   "background_color": "#1e1e1e",
   "theme_color": "#1e1e1e",
   "orientation": "any",
   "icons": [
     {
-      "src": "/icon-192.png",
+      "src": "icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icon-512.png",
+      "src": "icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"
@@ -27,7 +27,7 @@
       "name": "New Workspace",
       "short_name": "New",
       "description": "Create a new workspace",
-      "url": "/?action=new",
+      "url": "?action=new",
       "icons": []
     }
   ]

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -27,7 +27,7 @@
       "name": "New Workspace",
       "short_name": "New",
       "description": "Create a new workspace",
-      "url": "?action=new",
+      "url": "./?action=new",
       "icons": []
     }
   ]

--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -100,6 +100,7 @@ import { createProjectRefs } from "@/common/utils/multiProject";
 import { MULTI_PROJECT_SIDEBAR_SECTION_ID } from "@/common/constants/multiProject";
 import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 import { isDesktopMode } from "@/browser/hooks/useDesktopTitlebar";
+import { prependInitialAppProxyBasePath } from "@/browser/utils/frontendBasePath";
 import { LoadingScreen } from "@/browser/components/LoadingScreen/LoadingScreen";
 
 function RootRouteShell(props: {
@@ -871,7 +872,10 @@ function AppInner() {
     const handlePopState = () => {
       // Re-push the correct URL from MemoryRouter, not the popped browser URL
       const { pathname, search, hash } = locationRef.current;
-      const correctUrl = `${window.location.origin}${pathname}${search}${hash}`;
+      const correctUrl = new URL(
+        prependInitialAppProxyBasePath(`${pathname}${search}${hash}`),
+        window.location.origin
+      );
       window.history.pushState({ mux: true }, "", correctUrl);
     };
 

--- a/src/browser/contexts/RouterContext.tsx
+++ b/src/browser/contexts/RouterContext.tsx
@@ -10,6 +10,10 @@ import {
 import { MemoryRouter, useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { readPersistedState, updatePersistedState } from "@/browser/hooks/usePersistedState";
 import {
+  prependInitialAppProxyBasePath,
+  stripInitialAppProxyBasePathFromPathname,
+} from "@/browser/utils/frontendBasePath";
+import {
   LAST_VISITED_ROUTE_KEY,
   LAUNCH_BEHAVIOR_KEY,
   SELECTED_WORKSPACE_KEY,
@@ -177,7 +181,8 @@ function isRestorableRoute(route: unknown): route is string {
 
 /** Get the initial route, falling back to the compatibility root entrypoint when needed. */
 function getInitialRoute(): string {
-  const isStorybook = window.location.pathname.endsWith("iframe.html");
+  const routePathname = stripInitialAppProxyBasePathFromPathname(window.location.pathname);
+  const isStorybook = routePathname.endsWith("iframe.html");
   const isStandalone = isStandalonePwa();
   const navigationType = getStartupNavigationType();
   const launchBehavior = !isStandalone
@@ -195,7 +200,7 @@ function getInitialRoute(): string {
   // routes are special: fresh launches may ignore them, but explicit restore-style navigations
   // such as hard reload/back-forward should reopen the same chat.
   if (window.location.protocol !== "file:" && !isStorybook) {
-    const url = window.location.pathname + window.location.search;
+    const url = routePathname + window.location.search;
     // Only use URL if it's a valid route (starts with /, not just "/" or empty)
     if (url.startsWith("/") && url !== "/") {
       if (!url.startsWith("/workspace/")) {
@@ -254,13 +259,15 @@ function useUrlSync(): void {
       updatePersistedState(LAST_VISITED_ROUTE_KEY, url);
     }
 
+    const currentRoutePathname = stripInitialAppProxyBasePathFromPathname(window.location.pathname);
     // Skip in Storybook (conflicts with story navigation)
-    if (window.location.pathname.endsWith("iframe.html")) return;
+    if (currentRoutePathname.endsWith("iframe.html")) return;
     // Skip in Electron (file:// reloads always boot through index.html; we restore via localStorage above)
     if (window.location.protocol === "file:") return;
 
-    if (url !== window.location.pathname + window.location.search + window.location.hash) {
-      window.history.replaceState(null, "", url);
+    const browserUrl = prependInitialAppProxyBasePath(url);
+    if (browserUrl !== window.location.pathname + window.location.search + window.location.hash) {
+      window.history.replaceState(null, "", browserUrl);
     }
   }, [location.pathname, location.search, location.hash]);
 }

--- a/src/browser/contexts/ThemeContext.tsx
+++ b/src/browser/contexts/ThemeContext.tsx
@@ -66,9 +66,10 @@ const THEME_COLORS: Record<ThemeMode, string> = {
   "flexoki-dark": "#100f0f",
 };
 
+// Keep hrefs relative so a server-injected <base> preserves path-app prefixes.
 const FAVICON_BY_SCHEME: Record<"light" | "dark", string> = {
-  light: "/favicon.ico",
-  dark: "/favicon-dark.ico",
+  light: "favicon.ico",
+  dark: "favicon-dark.ico",
 };
 
 /** Map theme mode to CSS color-scheme value */

--- a/src/browser/main.tsx
+++ b/src/browser/main.tsx
@@ -5,6 +5,7 @@ import { installWindowOpenLocalhostProxyNormalization } from "@/browser/utils/wi
 import { AppLoader } from "@/browser/components/AppLoader/AppLoader";
 import { initTelemetry, trackAppStarted } from "@/common/telemetry";
 import { initTitlebarInsets } from "@/browser/hooks/useDesktopTitlebar";
+import { resolveBrowserAssetUrl } from "@/browser/utils/frontendBasePath";
 
 // Initialize telemetry on app startup
 try {
@@ -56,7 +57,7 @@ if ("serviceWorker" in navigator) {
   if (isHttpProtocol) {
     window.addEventListener("load", () => {
       navigator.serviceWorker
-        .register("/service-worker.js")
+        .register(resolveBrowserAssetUrl("service-worker.js"))
         .then((registration) => {
           console.log("Service Worker registered:", registration);
         })

--- a/src/browser/utils/backendBaseUrl.ts
+++ b/src/browser/utils/backendBaseUrl.ts
@@ -10,25 +10,9 @@
  * prefix, so the frontend must include it when constructing URLs.
  */
 
-// Non-greedy so we match the *first* "/apps/<slug>" segment in nested routes.
-const APP_PROXY_BASE_PATH_RE = /(.*?\/apps\/[^/]+)(?:\/|$)/;
+import { getAppProxyBasePathFromPathname } from "@/common/appProxyBasePath";
 
-/**
- * Returns the path prefix up to and including `/apps/<slug>`.
- *
- * Examples:
- * - "/@u/ws/apps/mux/" -> "/@u/ws/apps/mux"
- * - "/@u/ws/apps/mux/settings" -> "/@u/ws/apps/mux"
- */
-export function getAppProxyBasePathFromPathname(pathname: string): string | null {
-  const match = APP_PROXY_BASE_PATH_RE.exec(pathname);
-  if (!match) {
-    return null;
-  }
-
-  const basePath = match[1];
-  return basePath.endsWith("/") ? basePath.slice(0, -1) : basePath;
-}
+export { getAppProxyBasePathFromPathname } from "@/common/appProxyBasePath";
 
 function stripTrailingSlashes(url: string): string {
   return url.replace(/\/+$/, "");

--- a/src/browser/utils/frontendBasePath.ts
+++ b/src/browser/utils/frontendBasePath.ts
@@ -1,0 +1,33 @@
+import { getAppProxyBasePathFromPathname, stripAppProxyBasePath } from "@/common/appProxyBasePath";
+
+export const INITIAL_APP_PROXY_BASE_PATH =
+  typeof window === "undefined" ? null : getAppProxyBasePathFromPathname(window.location.pathname);
+
+function normalizeRootRelativePath(pathname: string): string {
+  return pathname.startsWith("/") ? pathname : `/${pathname}`;
+}
+
+export function stripInitialAppProxyBasePathFromPathname(pathname: string): string {
+  if (!INITIAL_APP_PROXY_BASE_PATH) {
+    return pathname;
+  }
+
+  const strippedPathname = stripAppProxyBasePath(pathname);
+  return strippedPathname.basePath === INITIAL_APP_PROXY_BASE_PATH
+    ? strippedPathname.routePathname
+    : pathname;
+}
+
+export function prependInitialAppProxyBasePath(pathname: string): string {
+  const rootRelativePathname = normalizeRootRelativePath(pathname);
+  return INITIAL_APP_PROXY_BASE_PATH
+    ? `${INITIAL_APP_PROXY_BASE_PATH}${rootRelativePathname}`
+    : rootRelativePathname;
+}
+
+export function resolveBrowserAssetUrl(pathname: string): string {
+  const proxiedPathname = prependInitialAppProxyBasePath(pathname);
+  return typeof document === "undefined"
+    ? proxiedPathname
+    : new URL(proxiedPathname, document.baseURI).toString();
+}

--- a/src/browser/utils/terminal.ts
+++ b/src/browser/utils/terminal.ts
@@ -8,6 +8,7 @@
 
 import type { RouterClient } from "@orpc/server";
 import type { AppRouter } from "@/node/orpc/router";
+import { resolveBrowserAssetUrl } from "@/browser/utils/frontendBasePath";
 
 type APIClient = RouterClient<AppRouter>;
 
@@ -37,8 +38,9 @@ export function openTerminalPopout(api: APIClient, workspaceId: string, sessionI
     // In browser mode, we must open the window client-side
     // The backend cannot open a window on the user's client
     const params = new URLSearchParams({ workspaceId, sessionId });
+    const terminalUrl = resolveBrowserAssetUrl(`terminal.html?${params.toString()}`);
     window.open(
-      `/terminal.html?${params.toString()}`,
+      terminalUrl,
       `terminal-${workspaceId}-${Date.now()}`,
       "width=1000,height=600,popup=yes"
     );

--- a/src/common/appProxyBasePath.test.ts
+++ b/src/common/appProxyBasePath.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+
+import { getAppProxyBasePathFromPathname, stripAppProxyBasePath } from "./appProxyBasePath";
+
+describe("appProxyBasePath", () => {
+  test("detects the app proxy base path", () => {
+    expect(getAppProxyBasePathFromPathname("/@u/ws/apps/mux/")).toBe("/@u/ws/apps/mux");
+    expect(getAppProxyBasePathFromPathname("/@u/ws/apps/mux/settings/general")).toBe(
+      "/@u/ws/apps/mux"
+    );
+    expect(getAppProxyBasePathFromPathname("/@u/ws.agent/apps/mux/")).toBe("/@u/ws.agent/apps/mux");
+    expect(getAppProxyBasePathFromPathname("/@u/ws/agent/apps/mux/foo")).toBe(
+      "/@u/ws/agent/apps/mux"
+    );
+    expect(getAppProxyBasePathFromPathname("/@u/ws/apps/mux")).toBe("/@u/ws/apps/mux");
+  });
+
+  test("rejects root routes and unanchored app segments", () => {
+    expect(getAppProxyBasePathFromPathname("/projects/apps/other")).toBeNull();
+    expect(getAppProxyBasePathFromPathname("/")).toBeNull();
+    expect(getAppProxyBasePathFromPathname("/settings")).toBeNull();
+    expect(getAppProxyBasePathFromPathname("//bad.example/@u/ws/apps/mux")).toBeNull();
+  });
+
+  test("strips the app proxy base path from prefix-only requests", () => {
+    expect(stripAppProxyBasePath("/@u/ws/apps/mux/")).toEqual({
+      basePath: "/@u/ws/apps/mux",
+      routePathname: "/",
+    });
+    expect(stripAppProxyBasePath("/@u/ws/apps/mux")).toEqual({
+      basePath: "/@u/ws/apps/mux",
+      routePathname: "/",
+    });
+  });
+
+  test("strips the app proxy base path and preserves the route suffix", () => {
+    expect(stripAppProxyBasePath("/@u/ws/apps/mux/settings/general")).toEqual({
+      basePath: "/@u/ws/apps/mux",
+      routePathname: "/settings/general",
+    });
+    expect(stripAppProxyBasePath("/@u/ws.agent/apps/mux/")).toEqual({
+      basePath: "/@u/ws.agent/apps/mux",
+      routePathname: "/",
+    });
+    expect(stripAppProxyBasePath("/@u/ws/agent/apps/mux/foo")).toEqual({
+      basePath: "/@u/ws/agent/apps/mux",
+      routePathname: "/foo",
+    });
+  });
+
+  test("returns the original pathname when no app proxy base path is present", () => {
+    expect(stripAppProxyBasePath("/projects/apps/other")).toEqual({
+      basePath: null,
+      routePathname: "/projects/apps/other",
+    });
+    expect(stripAppProxyBasePath("/")).toEqual({ basePath: null, routePathname: "/" });
+    expect(stripAppProxyBasePath("/settings")).toEqual({
+      basePath: null,
+      routePathname: "/settings",
+    });
+    expect(stripAppProxyBasePath("//bad.example/@u/ws/apps/mux")).toEqual({
+      basePath: null,
+      routePathname: "//bad.example/@u/ws/apps/mux",
+    });
+  });
+});

--- a/src/common/appProxyBasePath.ts
+++ b/src/common/appProxyBasePath.ts
@@ -1,0 +1,38 @@
+const APP_PROXY_BASE_PATH_RE = /^\/@[^/]+\/[^/]+(?:\/[^/]+)?\/apps\/[^/]+(?:\/|$)/;
+
+function hasUnsafeLeadingDoubleSlash(pathname: string): boolean {
+  return pathname.startsWith("//");
+}
+
+function stripTrailingSlash(pathname: string): string {
+  return pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+}
+
+export function getAppProxyBasePathFromPathname(pathname: string): string | null {
+  if (hasUnsafeLeadingDoubleSlash(pathname)) {
+    return null;
+  }
+
+  const match = APP_PROXY_BASE_PATH_RE.exec(pathname);
+  if (!match) {
+    return null;
+  }
+
+  return stripTrailingSlash(match[0]);
+}
+
+export function stripAppProxyBasePath(pathname: string): {
+  basePath: string | null;
+  routePathname: string;
+} {
+  const basePath = getAppProxyBasePathFromPathname(pathname);
+  if (!basePath) {
+    return { basePath: null, routePathname: pathname };
+  }
+
+  const routePathname = pathname.slice(basePath.length);
+  return {
+    basePath,
+    routePathname: routePathname.length === 0 ? "/" : routePathname,
+  };
+}

--- a/src/node/orpc/server.test.ts
+++ b/src/node/orpc/server.test.ts
@@ -148,6 +148,62 @@ async function withProxyUriTemplateEnv<T>(
   }
 }
 
+const APP_PROXY_BASE_PATH = "/@u/ws/apps/mux";
+const APP_PROXY_BASE_PATH_ALT = "/@alice/dev/apps/mux";
+
+function countOccurrences(value: string, needle: string): number {
+  return value.split(needle).length - 1;
+}
+
+async function createStaticTestServer(
+  options: {
+    files?: Record<string, string>;
+    context?: Partial<ORPCContext>;
+    authToken?: string;
+  } = {}
+): Promise<{
+  server: Awaited<ReturnType<typeof createOrpcServer>>;
+  tempDir: string;
+  close: () => Promise<void>;
+}> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-static-app-proxy-"));
+  const files = {
+    "index.html":
+      "<!doctype html><html><head><title>mux</title></head><body><div>ok</div></body></html>",
+    ...options.files,
+  };
+
+  for (const [filePath, contents] of Object.entries(files)) {
+    const absolutePath = path.join(tempDir, filePath);
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, contents, "utf-8");
+  }
+
+  let server: Awaited<ReturnType<typeof createOrpcServer>> | null = null;
+  try {
+    server = await createOrpcServer({
+      host: "127.0.0.1",
+      port: 0,
+      context: (options.context ?? {}) as ORPCContext,
+      authToken: options.authToken,
+      serveStatic: true,
+      staticDir: tempDir,
+    });
+  } catch (error) {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    throw error;
+  }
+
+  return {
+    server,
+    tempDir,
+    close: async () => {
+      await server?.close();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    },
+  };
+}
+
 describe("createOrpcServer", () => {
   test("serveStatic fallback does not swallow /api routes", async () => {
     // Minimal context stub - router won't be exercised by this test.
@@ -182,6 +238,212 @@ describe("createOrpcServer", () => {
     } finally {
       await server?.close();
       await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("serves SPA base href from the detected public base path per request", async () => {
+    const { server, close } = await createStaticTestServer();
+
+    try {
+      const rootRes = await fetch(`${server.baseUrl}/`);
+      expect(rootRes.status).toBe(200);
+      const rootHtml = await rootRes.text();
+      expect(countOccurrences(rootHtml, '<base href="/" />')).toBe(1);
+
+      const forwardedPrefixRes = await fetch(`${server.baseUrl}/some/spa/route`, {
+        headers: { "X-Forwarded-Prefix": APP_PROXY_BASE_PATH },
+      });
+      expect(forwardedPrefixRes.status).toBe(200);
+      const forwardedPrefixHtml = await forwardedPrefixRes.text();
+      expect(forwardedPrefixHtml).toContain(`<base href="${APP_PROXY_BASE_PATH}/" />`);
+
+      const originalUriRes = await fetch(`${server.baseUrl}/`, {
+        headers: { "X-Original-Uri": `${APP_PROXY_BASE_PATH}/` },
+      });
+      expect(originalUriRes.status).toBe(200);
+      const originalUriHtml = await originalUriRes.text();
+      expect(originalUriHtml).toContain(`<base href="${APP_PROXY_BASE_PATH}/" />`);
+
+      const firstPrefixRes = await fetch(`${server.baseUrl}/one`, {
+        headers: { "X-Forwarded-Prefix": APP_PROXY_BASE_PATH },
+      });
+      const secondPrefixRes = await fetch(`${server.baseUrl}/two`, {
+        headers: { "X-Forwarded-Prefix": APP_PROXY_BASE_PATH_ALT },
+      });
+      expect(await firstPrefixRes.text()).toContain(`<base href="${APP_PROXY_BASE_PATH}/" />`);
+      expect(await secondPrefixRes.text()).toContain(`<base href="${APP_PROXY_BASE_PATH_ALT}/" />`);
+    } finally {
+      await close();
+    }
+  });
+
+  test("routes direct app-proxy HTTP requests to root-mounted handlers", async () => {
+    const mainJs = "console.log('prefixed asset');";
+    const authContext: Partial<ORPCContext> = {
+      serverAuthService: {
+        isGithubDeviceFlowEnabled: () => true,
+      } as unknown as ORPCContext["serverAuthService"],
+    };
+    const { server, close } = await createStaticTestServer({
+      files: { "assets/main.js": mainJs },
+      context: authContext,
+    });
+
+    try {
+      const rootAssetRes = await fetch(`${server.baseUrl}/assets/main.js`);
+      const prefixedAssetRes = await fetch(
+        `${server.baseUrl}${APP_PROXY_BASE_PATH}/assets/main.js`
+      );
+      expect(prefixedAssetRes.status).toBe(200);
+      expect(await prefixedAssetRes.text()).toBe(await rootAssetRes.text());
+
+      const prefixedSpaRes = await fetch(`${server.baseUrl}${APP_PROXY_BASE_PATH}/settings`);
+      expect(prefixedSpaRes.status).toBe(200);
+      expect(await prefixedSpaRes.text()).toContain(`<base href="${APP_PROXY_BASE_PATH}/" />`);
+
+      const specRes = await fetch(`${server.baseUrl}${APP_PROXY_BASE_PATH}/api/spec.json`);
+      expect(specRes.status).toBe(200);
+      expect(specRes.headers.get("content-type")).toContain("application/json");
+      const spec = (await specRes.json()) as { servers?: Array<{ url?: string }> };
+      expect(spec.servers?.[0]?.url).toBe(`${APP_PROXY_BASE_PATH}/api`);
+
+      const docsRes = await fetch(`${server.baseUrl}${APP_PROXY_BASE_PATH}/api/docs`);
+      expect(docsRes.status).toBe(200);
+      expect(await docsRes.text()).toContain(`${APP_PROXY_BASE_PATH}/api/spec.json`);
+
+      const authRes = await fetch(
+        `${server.baseUrl}${APP_PROXY_BASE_PATH}/auth/server-login/options`
+      );
+      expect(authRes.status).toBe(200);
+      expect(await authRes.json()).toEqual({ githubDeviceFlowEnabled: true });
+
+      const client = createHttpClient(`${server.baseUrl}${APP_PROXY_BASE_PATH}`);
+      const pingResult = await Promise.resolve(client.general.ping("app-proxy"));
+      expect(pingResult).toBe("Pong: app-proxy");
+
+      const falsePositiveRes = await fetch(`${server.baseUrl}/projects/apps/other`);
+      expect(falsePositiveRes.status).toBe(200);
+      expect(await falsePositiveRes.text()).toContain('<base href="/" />');
+    } finally {
+      await close();
+    }
+  });
+
+  test("keeps origin validation active after direct app-proxy prefix stripping", async () => {
+    const stubContext: Partial<ORPCContext> = {};
+    let server: Awaited<ReturnType<typeof createOrpcServer>> | null = null;
+
+    try {
+      server = await createOrpcServer({
+        host: "127.0.0.1",
+        port: 0,
+        context: stubContext as ORPCContext,
+      });
+
+      const rootResponse = await fetch(`${server.baseUrl}/orpc`, {
+        headers: { Origin: "https://evil.example.com" },
+      });
+      const prefixedResponse = await fetch(`${server.baseUrl}${APP_PROXY_BASE_PATH}/orpc`, {
+        headers: { Origin: "https://evil.example.com" },
+      });
+
+      expect(rootResponse.status).toBe(403);
+      expect(prefixedResponse.status).toBe(rootResponse.status);
+    } finally {
+      await server?.close();
+    }
+  });
+
+  test("serves Scalar docs with request-specific spec URLs", async () => {
+    const { server, close } = await createStaticTestServer();
+
+    try {
+      const rootDocsRes = await fetch(`${server.baseUrl}/api/docs`);
+      expect(rootDocsRes.status).toBe(200);
+      expect(await rootDocsRes.text()).toContain('url: "/api/spec.json"');
+
+      const forwardedDocsRes = await fetch(`${server.baseUrl}/api/docs`, {
+        headers: { "X-Forwarded-Prefix": APP_PROXY_BASE_PATH },
+      });
+      expect(forwardedDocsRes.status).toBe(200);
+      expect(await forwardedDocsRes.text()).toContain(
+        `url: "${APP_PROXY_BASE_PATH}/api/spec.json"`
+      );
+
+      const directDocsRes = await fetch(`${server.baseUrl}${APP_PROXY_BASE_PATH}/api/docs`);
+      expect(directDocsRes.status).toBe(200);
+      expect(await directDocsRes.text()).toContain(`url: "${APP_PROXY_BASE_PATH}/api/spec.json"`);
+    } finally {
+      await close();
+    }
+  });
+
+  test("accepts direct app-proxy WebSocket upgrades", async () => {
+    const stubContext: Partial<ORPCContext> = {};
+    let server: Awaited<ReturnType<typeof createOrpcServer>> | null = null;
+    let ws: WebSocket | null = null;
+
+    try {
+      server = await createOrpcServer({
+        host: "127.0.0.1",
+        port: 0,
+        context: stubContext as ORPCContext,
+      });
+
+      ws = new WebSocket(
+        `${server.baseUrl.replace(/^http/, "ws")}${APP_PROXY_BASE_PATH}/orpc/ws?token=test-token`
+      );
+
+      await waitForWebSocketOpen(ws);
+      await closeWebSocket(ws);
+      ws = null;
+    } finally {
+      ws?.terminate();
+      await server?.close();
+    }
+  });
+
+  test("includes app-proxy base paths in OAuth redirect and callback return URLs", async () => {
+    let muxGatewayRedirectUri = "";
+    const stubContext: Partial<ORPCContext> = {
+      muxGatewayOauthService: {
+        startServerFlow: (input: { redirectUri: string }) => {
+          muxGatewayRedirectUri = input.redirectUri;
+          return { authorizeUrl: "https://gateway.example.com/auth", state: "state-gateway" };
+        },
+        handleServerCallbackAndExchange: () => Promise.resolve({ success: true, data: undefined }),
+      } as unknown as ORPCContext["muxGatewayOauthService"],
+    };
+    let server: Awaited<ReturnType<typeof createOrpcServer>> | null = null;
+
+    try {
+      server = await createOrpcServer({
+        host: "127.0.0.1",
+        port: 0,
+        context: stubContext as ORPCContext,
+        authToken: "test-token",
+      });
+
+      const startResponse = await fetch(`${server.baseUrl}/auth/mux-gateway/start`, {
+        headers: {
+          Authorization: "Bearer test-token",
+          "X-Forwarded-Prefix": APP_PROXY_BASE_PATH,
+        },
+      });
+      expect(startResponse.status).toBe(200);
+      expect(muxGatewayRedirectUri).toBe(
+        `${server.baseUrl}${APP_PROXY_BASE_PATH}/auth/mux-gateway/callback`
+      );
+
+      const callbackResponse = await fetch(
+        `${server.baseUrl}${APP_PROXY_BASE_PATH}/auth/mux-gateway/callback?state=test&code=test`
+      );
+      expect(callbackResponse.status).toBe(200);
+      const callbackHtml = await callbackResponse.text();
+      expect(callbackHtml).toContain(`href="${APP_PROXY_BASE_PATH}/"`);
+      expect(callbackHtml).toContain(`window.location.replace("${APP_PROXY_BASE_PATH}/")`);
+    } finally {
+      await server?.close();
     }
   });
 

--- a/src/node/orpc/server.ts
+++ b/src/node/orpc/server.ts
@@ -31,6 +31,7 @@ import { attachStreamErrorHandler, isIgnorableStreamError } from "@/node/utils/s
 import { getErrorMessage } from "@/common/utils/errors";
 import { escapeHtml } from "@/node/utils/oauthUtils";
 import { assert } from "@/common/utils/assert";
+import { getAppProxyBasePathFromPathname, stripAppProxyBasePath } from "@/common/appProxyBasePath";
 
 type AliveWebSocket = WebSocket & { isAlive?: boolean };
 
@@ -113,6 +114,15 @@ function extractBearerToken(header: string | undefined): string | null {
   const token = header.slice(7).trim();
   return token.length ? token : null;
 }
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
 function injectBaseHref(indexHtml: string, baseHref: string): string {
   // Avoid double-injecting if the HTML already has a base tag.
   if (/<base\b/i.test(indexHtml)) {
@@ -120,7 +130,11 @@ function injectBaseHref(indexHtml: string, baseHref: string): string {
   }
 
   // Insert immediately after the opening <head> tag (supports <head> and <head ...attrs>).
-  return indexHtml.replace(/<head[^>]*>/i, (match) => `${match}\n    <base href="${baseHref}" />`);
+  const escapedBaseHref = escapeHtmlAttribute(baseHref);
+  return indexHtml.replace(
+    /<head[^>]*>/i,
+    (match) => `${match}\n    <base href="${escapedBaseHref}" />`
+  );
 }
 
 function escapeJsonForHtmlScript(value: unknown): string {
@@ -150,7 +164,10 @@ type OriginValidationRequest = Pick<http.IncomingMessage, "headers" | "socket"> 
   protocol?: string;
 };
 
-function getFirstHeaderValue(req: OriginValidationRequest, headerName: string): string | null {
+function getFirstHeaderValue(
+  req: Pick<http.IncomingMessage, "headers">,
+  headerName: string
+): string | null {
   const rawValue = req.headers[headerName.toLowerCase()];
   const value = Array.isArray(rawValue) ? rawValue[0] : rawValue;
 
@@ -412,20 +429,250 @@ function isOriginAllowed(
   );
 }
 
-function getPathnameFromRequestUrl(requestUrl: string | undefined): string | null {
-  if (!requestUrl) {
+const URL_PATHNAME_RE = /^[A-Za-z0-9._~!$&'()*+,;=:@%/-]+$/;
+const PUBLIC_BASE_PATH_VARY_HEADERS = [
+  "X-Forwarded-Prefix",
+  "X-Forwarded-Uri",
+  "X-Original-Uri",
+  "X-Original-Url",
+  "Referer",
+] as const;
+
+interface PublicBasePathLocals {
+  publicBasePath?: string;
+}
+
+type PublicBasePathRequest = Pick<http.IncomingMessage, "headers" | "url"> & {
+  originalUrl?: string;
+};
+
+function isValidUrlPathname(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value.startsWith("/") &&
+    !value.startsWith("//") &&
+    URL_PATHNAME_RE.test(value)
+  );
+}
+
+function normalizePublicBasePath(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.startsWith("//")) {
+    return null;
+  }
+
+  const withLeadingSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  const withoutTrailingSlash =
+    withLeadingSlash === "/" ? withLeadingSlash : withLeadingSlash.replace(/\/+$/, "");
+
+  return isValidUrlPathname(withoutTrailingSlash) ? withoutTrailingSlash : null;
+}
+
+function parsePathnameFromRequestValue(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.startsWith("//")) {
     return null;
   }
 
   try {
-    return new URL(requestUrl, "http://localhost").pathname;
+    const pathname = trimmed.startsWith("/")
+      ? new URL(trimmed, "http://localhost").pathname
+      : new URL(trimmed).pathname;
+    return isValidUrlPathname(pathname) ? pathname : null;
   } catch {
     return null;
   }
 }
 
-// Non-greedy so we match the first "/apps/<slug>" segment in nested routes.
-const APP_PROXY_BASE_PATH_RE = /(.*?\/apps\/[^/]+)(?:\/|$)/;
+function getPathnameFromRequestUrl(requestUrl: string | undefined): string | null {
+  return parsePathnameFromRequestValue(requestUrl);
+}
+
+function getRequestPublicBasePath(
+  req: PublicBasePathRequest,
+  options: { allowReferer?: boolean } = {}
+): string {
+  const forwardedPrefix = normalizePublicBasePath(getFirstHeaderValue(req, "x-forwarded-prefix"));
+  if (forwardedPrefix) {
+    return forwardedPrefix;
+  }
+
+  for (const headerName of ["x-forwarded-uri", "x-original-uri", "x-original-url"] as const) {
+    const headerPathname = parsePathnameFromRequestValue(getFirstHeaderValue(req, headerName));
+    const headerBasePath = headerPathname ? getAppProxyBasePathFromPathname(headerPathname) : null;
+    if (headerBasePath) {
+      return headerBasePath;
+    }
+  }
+
+  for (const requestValue of [req.originalUrl, req.url]) {
+    const requestPathname = parsePathnameFromRequestValue(requestValue);
+    const requestBasePath = requestPathname
+      ? getAppProxyBasePathFromPathname(requestPathname)
+      : null;
+    if (requestBasePath) {
+      return requestBasePath;
+    }
+  }
+
+  // Browser mode requests include Referer by default, so this keeps cookie scope
+  // and generated app links aligned when a proxy strips the public prefix.
+  if (options.allowReferer) {
+    const refererPathname = parsePathnameFromRequestValue(getFirstHeaderValue(req, "referer"));
+    const refererBasePath = refererPathname
+      ? getAppProxyBasePathFromPathname(refererPathname)
+      : null;
+    if (refererBasePath) {
+      return refererBasePath;
+    }
+  }
+
+  return "/";
+}
+
+function setResponsePublicBasePath(res: express.Response, publicBasePath: string): void {
+  (res.locals as PublicBasePathLocals).publicBasePath = publicBasePath;
+}
+
+function getResponsePublicBasePath(res: express.Response): string | null {
+  const publicBasePath = (res.locals as PublicBasePathLocals).publicBasePath;
+  return typeof publicBasePath === "string" ? publicBasePath : null;
+}
+
+function getPublicBasePathForRequest(
+  req: express.Request,
+  res: express.Response,
+  options: { allowReferer?: boolean } = {}
+): string {
+  return getResponsePublicBasePath(res) ?? getRequestPublicBasePath(req, options);
+}
+
+function joinPublicBasePath(publicBasePath: string, routePathname: string): string {
+  const normalizedBasePath = normalizePublicBasePath(publicBasePath) ?? "/";
+  const normalizedRoutePathname = routePathname.startsWith("/")
+    ? routePathname
+    : `/${routePathname}`;
+
+  return normalizedBasePath === "/"
+    ? normalizedRoutePathname
+    : `${normalizedBasePath}${normalizedRoutePathname}`;
+}
+
+function getDirectAppProxyHandlerPrefix(
+  req: express.Request,
+  routePrefix: `/${string}`
+): `/${string}` {
+  const originalPathname = parsePathnameFromRequestValue(req.originalUrl);
+  const directBasePath = originalPathname
+    ? getAppProxyBasePathFromPathname(originalPathname)
+    : null;
+  return directBasePath
+    ? (joinPublicBasePath(directBasePath, routePrefix) as `/${string}`)
+    : routePrefix;
+}
+
+function getPublicBaseHref(req: express.Request, res: express.Response): string {
+  const publicBasePath = getPublicBasePathForRequest(req, res, { allowReferer: true });
+  return publicBasePath === "/" ? "/" : `${publicBasePath}/`;
+}
+
+function getPublicAppRootPath(req: express.Request, res: express.Response): string {
+  return joinPublicBasePath(getPublicBasePathForRequest(req, res, { allowReferer: true }), "/");
+}
+
+function varyPublicBasePathHeaders(res: express.Response): void {
+  for (const header of PUBLIC_BASE_PATH_VARY_HEADERS) {
+    res.vary(header);
+  }
+}
+
+function splitRequestUrlPathAndQuery(
+  requestUrl: string | undefined
+): { pathname: string; querySuffix: string } | null {
+  if (!requestUrl) {
+    return null;
+  }
+
+  const queryStart = requestUrl.indexOf("?");
+  if (queryStart === -1) {
+    return { pathname: requestUrl, querySuffix: "" };
+  }
+
+  return {
+    pathname: requestUrl.slice(0, queryStart),
+    querySuffix: requestUrl.slice(queryStart),
+  };
+}
+
+function getNormalizedUpgradeRoute(
+  requestUrl: string | undefined
+): { routePathname: string; routeUrl: string } | null {
+  const publicPathname = getPathnameFromRequestUrl(requestUrl);
+  if (!publicPathname) {
+    return null;
+  }
+
+  const { routePathname } = stripAppProxyBasePath(publicPathname);
+  const querySuffix = splitRequestUrlPathAndQuery(requestUrl)?.querySuffix ?? "";
+  return { routePathname, routeUrl: `${routePathname}${querySuffix}` };
+}
+
+function isSafeHttpHostHeader(host: string): boolean {
+  if (host.trim().length === 0 || host.includes("/") || host.includes("\\")) {
+    return false;
+  }
+
+  for (const character of host) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint !== undefined && (codePoint < 0x20 || codePoint === 0x7f)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function getValidatedPublicHost(req: express.Request, protocol: "http" | "https"): string | null {
+  for (const headerName of ["x-forwarded-host", "host"] as const) {
+    const host = getFirstHeaderValue(req, headerName);
+    if (!host || !isSafeHttpHostHeader(host)) {
+      continue;
+    }
+
+    const normalizedHost = normalizeHostForProtocol(host, protocol);
+    if (normalizedHost) {
+      return normalizedHost;
+    }
+  }
+
+  return null;
+}
+
+function buildPublicAbsoluteUrl(
+  req: express.Request,
+  routePathname: string,
+  allowHttpOrigin: boolean
+): string | null {
+  const protocol = getPreferredPublicProtocol(req, allowHttpOrigin);
+  const host = getValidatedPublicHost(req, protocol);
+  if (!host) {
+    return null;
+  }
+
+  const publicRoutePathname = joinPublicBasePath(
+    getRequestPublicBasePath(req, { allowReferer: true }),
+    routePathname
+  );
+  return `${protocol}://${host}${publicRoutePathname}`;
+}
 
 const OAUTH_CALLBACK_ORIGIN_BYPASS_PATHS = new Set<string>([
   "/auth/mux-gateway/callback",
@@ -490,6 +737,26 @@ export async function createOrpcServer({
 }: OrpcServerOptions): Promise<OrpcServer> {
   // Express app setup
   const app = express();
+  app.use((req, res, next) => {
+    const requestPath = splitRequestUrlPathAndQuery(req.url);
+    if (requestPath && isValidUrlPathname(requestPath.pathname)) {
+      const { basePath, routePathname } = stripAppProxyBasePath(requestPath.pathname);
+      if (basePath) {
+        setResponsePublicBasePath(res, basePath);
+        req.url = `${routePathname}${requestPath.querySuffix}`;
+        next();
+        return;
+      }
+    }
+
+    const publicBasePath = getRequestPublicBasePath(req);
+    if (publicBasePath !== "/") {
+      setResponsePublicBasePath(res, publicBasePath);
+    }
+
+    next();
+  });
+
   app.use((req, res, next) => {
     if (!shouldEnforceOriginValidation(req)) {
       next();
@@ -560,15 +827,13 @@ export async function createOrpcServer({
   app.use(express.json({ limit: "50mb" }));
   app.use(express.urlencoded({ extended: false }));
 
-  let spaIndexHtml: string | null = null;
+  let rawSpaIndexHtml: string | null = null;
 
   // Static file serving (optional)
   if (serveStatic) {
     try {
       const indexHtmlPath = path.join(staticDir, "index.html");
-      const indexHtml = await fs.readFile(indexHtmlPath, "utf8");
-      const indexHtmlWithBaseHref = injectBaseHref(indexHtml, "/");
-      spaIndexHtml = injectProxyUriTemplate(indexHtmlWithBaseHref, getBrowserProxyUriTemplate());
+      rawSpaIndexHtml = await fs.readFile(indexHtmlPath, "utf8");
     } catch (error) {
       log.error("Failed to read index.html for SPA fallback:", error);
     }
@@ -611,88 +876,8 @@ export async function createOrpcServer({
     return getPreferredPublicProtocol(req, allowHttpOrigin) === "https";
   }
 
-  function parsePathnameFromRequestValue(value: string | null | undefined): string | null {
-    if (!value) {
-      return null;
-    }
-
-    const trimmed = value.trim();
-    if (!trimmed) {
-      return null;
-    }
-
-    try {
-      if (trimmed.startsWith("/")) {
-        return new URL(trimmed, "http://localhost").pathname;
-      }
-
-      return new URL(trimmed).pathname;
-    } catch {
-      return null;
-    }
-  }
-
-  function normalizeCookiePath(pathname: string | null): string | null {
-    if (!pathname) {
-      return null;
-    }
-
-    const trimmed = pathname.trim();
-    if (!trimmed) {
-      return null;
-    }
-
-    const withLeadingSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
-    const withoutTrailing = withLeadingSlash.replace(/\/+$/, "");
-
-    return withoutTrailing.length > 0 ? withoutTrailing : "/";
-  }
-
-  function getAppProxyBasePathFromPathname(pathname: string | null): string | null {
-    if (!pathname) {
-      return null;
-    }
-
-    const match = APP_PROXY_BASE_PATH_RE.exec(pathname);
-    if (!match) {
-      return null;
-    }
-
-    return normalizeCookiePath(match[1]);
-  }
-
   function getServerSessionCookiePath(req: express.Request): string {
-    const forwardedPrefix = normalizeCookiePath(getFirstHeaderValue(req, "x-forwarded-prefix"));
-    if (forwardedPrefix) {
-      return forwardedPrefix;
-    }
-
-    const forwardedUriPath = parsePathnameFromRequestValue(
-      getFirstHeaderValue(req, "x-forwarded-uri") ?? getFirstHeaderValue(req, "x-original-uri")
-    );
-    const forwardedUriBasePath = getAppProxyBasePathFromPathname(forwardedUriPath);
-    if (forwardedUriBasePath) {
-      return forwardedUriBasePath;
-    }
-
-    const originalUrlBasePath = getAppProxyBasePathFromPathname(
-      parsePathnameFromRequestValue(req.originalUrl)
-    );
-    if (originalUrlBasePath) {
-      return originalUrlBasePath;
-    }
-
-    // Browser mode requests include Referer by default; this keeps cookie scope
-    // aligned with app-proxy base paths even when the reverse proxy strips prefixes
-    // before forwarding to mux.
-    const refererBasePath = getAppProxyBasePathFromPathname(
-      parsePathnameFromRequestValue(req.header("referer"))
-    );
-    if (refererBasePath) {
-      return refererBasePath;
-    }
-
-    return "/";
+    return getRequestPublicBasePath(req, { allowReferer: true });
   }
 
   function buildServerSessionCookie(
@@ -834,19 +1019,11 @@ export async function createOrpcServer({
       return;
     }
 
-    const hostHeader = req.get("x-forwarded-host") ?? req.get("host");
-    const host = hostHeader?.split(",")[0]?.trim();
-    if (!host) {
-      res.status(400).json({ error: "Missing Host header" });
+    const redirectUri = buildPublicAbsoluteUrl(req, "/auth/mux-gateway/callback", allowHttpOrigin);
+    if (!redirectUri) {
+      res.status(400).json({ error: "Missing or invalid Host header" });
       return;
     }
-
-    // Keep callback scheme selection aligned with origin compatibility handling.
-    // Some proxy chains overwrite X-Forwarded-Proto to http on the final hop
-    // even when the browser-visible origin is https.
-    const protocol = getPreferredPublicProtocol(req, allowHttpOrigin);
-    const callbackHost = normalizeHostForProtocol(host, protocol) ?? host;
-    const redirectUri = `${protocol}://${callbackHost}/auth/mux-gateway/callback`;
     const { authorizeUrl, state } = context.muxGatewayOauthService.startServerFlow({ redirectUri });
     res.json({ authorizeUrl, state });
   });
@@ -885,6 +1062,9 @@ export async function createOrpcServer({
       : payload.error
         ? escapeHtml(payload.error)
         : "An unknown error occurred.";
+    const returnPath = getPublicAppRootPath(req, res);
+    const returnPathJson = escapeJsonForHtmlScript(returnPath);
+    const returnPathHref = escapeHtmlAttribute(returnPath);
 
     const html = `<!doctype html>
 <html lang="en">
@@ -910,7 +1090,7 @@ export async function createOrpcServer({
             <h1>${title}</h1>
             <p>${description}</p>
             ${result.success ? '<p class="muted">This tab should close automatically.</p>' : ""}
-            <p><a class="btn primary" href="/">Return to Mux</a></p>
+            <p><a class="btn primary" href="${returnPathHref}">Return to Mux</a></p>
           </div>
         </div>
       </main>
@@ -957,7 +1137,7 @@ export async function createOrpcServer({
 
         setTimeout(() => {
           try {
-            window.location.replace("/");
+            window.location.replace(${returnPathJson});
           } catch {
             // Ignore navigation failures.
           }
@@ -986,16 +1166,11 @@ export async function createOrpcServer({
       return;
     }
 
-    const hostHeader = req.get("x-forwarded-host") ?? req.get("host");
-    const host = hostHeader?.split(",")[0]?.trim();
-    if (!host) {
-      res.status(400).json({ error: "Missing Host header" });
+    const redirectUri = buildPublicAbsoluteUrl(req, "/auth/mux-governor/callback", allowHttpOrigin);
+    if (!redirectUri) {
+      res.status(400).json({ error: "Missing or invalid Host header" });
       return;
     }
-
-    const protocol = getPreferredPublicProtocol(req, allowHttpOrigin);
-    const callbackHost = normalizeHostForProtocol(host, protocol) ?? host;
-    const redirectUri = `${protocol}://${callbackHost}/auth/mux-governor/callback`;
     const result = context.muxGovernorOauthService.startServerFlow({
       governorOrigin: governorUrl,
       redirectUri,
@@ -1050,6 +1225,9 @@ export async function createOrpcServer({
       : payload.error
         ? escapeHtml(payload.error)
         : "An unknown error occurred.";
+    const returnPath = getPublicAppRootPath(req, res);
+    const returnPathJson = escapeJsonForHtmlScript(returnPath);
+    const returnPathHref = escapeHtmlAttribute(returnPath);
 
     const html = `<!doctype html>
 <html lang="en">
@@ -1069,7 +1247,7 @@ export async function createOrpcServer({
     <h1>${title}</h1>
     <p>${description}</p>
     ${result.success ? '<p class="muted">This tab should close automatically.</p>' : ""}
-    <p><a class="btn" href="/">Return to Mux</a></p>
+    <p><a class="btn" href="${returnPathHref}">Return to Mux</a></p>
 
     <script>
       (() => {
@@ -1112,7 +1290,7 @@ export async function createOrpcServer({
 
         setTimeout(() => {
           try {
-            window.location.replace("/");
+            window.location.replace(${returnPathJson});
           } catch {
             // Ignore navigation failures.
           }
@@ -1163,6 +1341,9 @@ export async function createOrpcServer({
       : payload.error
         ? escapeHtml(payload.error)
         : "An unknown error occurred.";
+    const returnPath = getPublicAppRootPath(req, res);
+    const returnPathJson = escapeJsonForHtmlScript(returnPath);
+    const returnPathHref = escapeHtmlAttribute(returnPath);
 
     const html = `<!doctype html>
 <html lang="en">
@@ -1188,7 +1369,7 @@ export async function createOrpcServer({
             <h1>${title}</h1>
             <p>${description}</p>
             ${result.success ? '<p class="muted">This tab should close automatically.</p>' : ""}
-            <p><a class="btn primary" href="/">Return to Mux</a></p>
+            <p><a class="btn primary" href="${returnPathHref}">Return to Mux</a></p>
           </div>
         </div>
       </main>
@@ -1235,7 +1416,7 @@ export async function createOrpcServer({
 
         setTimeout(() => {
           try {
-            window.location.replace("/");
+            window.location.replace(${returnPathJson});
           } catch {
             // Ignore navigation failures.
           }
@@ -1258,10 +1439,14 @@ export async function createOrpcServer({
   });
 
   // OpenAPI spec endpoint
-  app.get("/api/spec.json", async (_req, res) => {
+  app.get("/api/spec.json", async (req, res) => {
     const versionRecord = VERSION as Record<string, unknown>;
     const gitDescribe =
       typeof versionRecord.git_describe === "string" ? versionRecord.git_describe : "unknown";
+    const publicApiPath = joinPublicBasePath(
+      getPublicBasePathForRequest(req, res, { allowReferer: true }),
+      "/api"
+    );
 
     const spec = await openAPIGenerator.generate(orpcRouter, {
       info: {
@@ -1269,7 +1454,7 @@ export async function createOrpcServer({
         version: gitDescribe,
         description: "API for Mux",
       },
-      servers: [{ url: "/api" }],
+      servers: [{ url: publicApiPath }],
       security: authToken ? [{ bearerAuth: [] }] : undefined,
       components: authToken
         ? {
@@ -1282,11 +1467,17 @@ export async function createOrpcServer({
           }
         : undefined,
     });
+    varyPublicBasePathHeaders(res);
     res.json(spec);
   });
 
   // Scalar API reference UI
-  app.get("/api/docs", (_req, res) => {
+  app.get("/api/docs", (req, res) => {
+    const specPath = joinPublicBasePath(
+      getPublicBasePathForRequest(req, res, { allowReferer: true }),
+      "/api/spec.json"
+    );
+    const specPathJson = escapeJsonForHtmlScript(specPath);
     const html = `<!doctype html>
 <html>
   <head>
@@ -1299,13 +1490,15 @@ export async function createOrpcServer({
     <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
     <script>
       Scalar.createApiReference('#app', {
-        url: '/api/spec.json',
+        url: ${specPathJson},
         ${authToken ? "authentication: { securitySchemes: { bearerAuth: { token: '' } } }," : ""}
       })
     </script>
   </body>
 </html>`;
+    varyPublicBasePathHeaders(res);
     res.setHeader("Content-Type", "text/html");
+    res.setHeader("Cache-Control", "no-store");
     res.send(html);
   });
 
@@ -1320,7 +1513,7 @@ export async function createOrpcServer({
       return next();
     }
     const { matched } = await openAPIHandler.handle(req, res, {
-      prefix: "/api",
+      prefix: getDirectAppProxyHandlerPrefix(req, "/api"),
       context: { ...context, headers: req.headers },
     });
     if (matched) return;
@@ -1335,7 +1528,7 @@ export async function createOrpcServer({
   // Mount ORPC handler on /orpc and all subpaths
   app.use("/orpc", async (req, res, next) => {
     const { matched } = await orpcHandler.handle(req, res, {
-      prefix: "/orpc",
+      prefix: getDirectAppProxyHandlerPrefix(req, "/orpc"),
       context: { ...context, headers: req.headers },
     });
     if (matched) return;
@@ -1350,8 +1543,14 @@ export async function createOrpcServer({
         return next();
       }
 
-      if (spaIndexHtml !== null) {
+      if (rawSpaIndexHtml !== null) {
+        const spaIndexHtml = injectProxyUriTemplate(
+          injectBaseHref(rawSpaIndexHtml, getPublicBaseHref(req, res)),
+          getBrowserProxyUriTemplate()
+        );
+        varyPublicBasePathHeaders(res);
         res.setHeader("Content-Type", "text/html");
+        res.setHeader("Cache-Control", "no-store");
         res.send(spaIndexHtml);
         return;
       }
@@ -1394,8 +1593,15 @@ export async function createOrpcServer({
   const wsServer = new WebSocketServer({ noServer: true });
 
   httpServer.on("upgrade", (req, socket, head) => {
-    const pathname = getPathnameFromRequestUrl(req.url);
-    if (pathname === ORPC_WS_PATH) {
+    const normalizedRoute = getNormalizedUpgradeRoute(req.url);
+    if (!normalizedRoute) {
+      socket.destroy();
+      return;
+    }
+
+    const { routePathname, routeUrl } = normalizedRoute;
+    if (routePathname === ORPC_WS_PATH) {
+      req.url = routeUrl;
       const expectedOrigins = getExpectedOrigins(req, allowHttpOrigin);
       if (!isOriginAllowed(req, expectedOrigins)) {
         log.warn("Blocked cross-origin WebSocket upgrade request", {
@@ -1419,9 +1625,10 @@ export async function createOrpcServer({
       return;
     }
 
-    if (pathname === BROWSER_BRIDGE_WS_PATH) {
+    if (routePathname === BROWSER_BRIDGE_WS_PATH) {
+      req.url = routeUrl;
       assert(
-        pathname === BROWSER_BRIDGE_WS_PATH,
+        routePathname === BROWSER_BRIDGE_WS_PATH,
         "Browser relay upgrades must use BROWSER_BRIDGE_WS_PATH"
       );
       assert(
@@ -1432,8 +1639,9 @@ export async function createOrpcServer({
       return;
     }
 
-    if (pathname === DESKTOP_WS_PATH) {
-      assert(pathname === DESKTOP_WS_PATH, "Desktop relay upgrades must use DESKTOP_WS_PATH");
+    if (routePathname === DESKTOP_WS_PATH) {
+      req.url = routeUrl;
+      assert(routePathname === DESKTOP_WS_PATH, "Desktop relay upgrades must use DESKTOP_WS_PATH");
       assert(
         desktopBridgeServer,
         "createOrpcServer requires desktopBridgeServer for desktop relay upgrades"

--- a/terminal.html
+++ b/terminal.html
@@ -19,6 +19,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/browser/terminal-window.tsx"></script>
+    <script type="module" src="src/browser/terminal-window.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
> Mux is working on behalf of Mike.

## Summary

Adds path-app iframe support for Mux when it is served behind a Coder app prefix such as `/@user/workspace/apps/mux/`. Built assets, static web app metadata, API routes, docs, auth redirects, router paths, and WebSocket upgrades now resolve through the detected public prefix instead of assuming origin root.

## Background

Mux's production HTML injected `<base href="/" />`, which caused relative Vite bundle paths to resolve from origin root. That breaks when Coder serves Mux under a path prefix inside an iframe. The backend also matched HTTP and WebSocket routes only at root paths, so deployments where the proxy forwards prefixed paths could miss `/api`, `/orpc`, `/auth`, and WS upgrade routes.

## Implementation

- Added `src/common/appProxyBasePath.ts` to centralize Coder app-proxy path parsing and stripping.
- Changed the server to compute `<base href>` per request from forwarded headers or direct prefixed paths, with validated and escaped path values.
- Added early server middleware that strips a detected app-proxy prefix from HTTP route matching while preserving the public base path for generated URLs.
- Normalized WebSocket upgrade paths before matching `/orpc/ws`, `/browser/ws`, and `/desktop/ws`.
- Made Scalar docs, OpenAPI server URLs, and OAuth redirect URLs prefix-aware.
- Updated browser routing and URL helpers so MemoryRouter sync, service worker registration, terminal popouts, and frontend asset resolution preserve the prefix.
- Converted manifest, favicon, apple-touch-icon, PWA icon, and PWA shortcut URLs to relative app-root paths so they respect the injected `<base href>` and manifest location.

## Validation

Before opening the PR:

- `make static-check`
- `bun test src/common/appProxyBasePath.test.ts src/browser/utils/backendBaseUrl.test.ts src/node/orpc/server.test.ts`
- `make typecheck`
- `make lint`
- Production build and `dist/cli/index.js server --no-auth` smoke checks:
  - Root request serves `<base href="/" />`.
  - Prefixed request serves `<base href="/@u/ws/apps/mux/" />`.
  - Sequential prefixed requests for different tenants get distinct base href values.
  - Prefixed bundle, manifest, favicon, font, and icon requests all return 200 under the prefix.
  - Prefixed `/api/docs` emits `/@u/ws/apps/mux/api/spec.json`.
- agent-browser iframe smoke:
  - Loaded a wrapper page containing an iframe pointed at `/@u/ws/apps/mux/`.
  - Verified the Mux provider onboarding dialog renders inside the iframe.
  - Captured HAR showing the app's HTML, JS, CSS, manifest, font, favicon, and icon requests resolve under `/@u/ws/apps/mux/`.

After Codex approval on head `52f9524bf4dbd6e1bea2d6eaab953b09b3b8e908`:

- `bun test src/common/appProxyBasePath.test.ts src/browser/utils/backendBaseUrl.test.ts src/node/orpc/server.test.ts`
- `make static-check`
- `make build`
- Production curl smoke on a fresh `dist/cli/index.js server --no-auth`:
  - Root base href: `<base href="/" />`.
  - Prefix base href: `<base href="/@u/ws/apps/mux/" />`.
  - Alternate prefix base href: `<base href="/@a/b/apps/mux/" />`.
  - Manifest shortcut URL: `./?action=new`.
  - Manifest icon URL: `icon-192.png`.
  - Prefixed `/api/spec.json`: `200`.
  - Prefixed `/api/docs` spec URL: `/@u/ws/apps/mux/api/spec.json`.
  - Prefixed main JS asset: `200`.
- agent-browser root and prefix smoke:
  - Root app loads and registers service worker at root scope.
  - Prefixed app loads and registers service worker at `/@u/ws/apps/mux/` scope.
  - `document.baseURI`, manifest href, and favicon href all resolve under `/@u/ws/apps/mux/`.
- agent-browser iframe smoke:
  - Wrapper page loaded an iframe pointed at `/@u/ws/apps/mux/`.
  - Provider onboarding dialog rendered inside the iframe.
  - HAR showed no Mux app requests escaping to origin root.

Artifacts from local dogfood are under `dogfood-output/mux-path-app/`.

## Review status

Codex initially flagged the PWA shortcut URL. The shortcut now uses `./?action=new`, the review thread was resolved, and Codex approved the updated head. Required checks passed.

## Risks

The main risk is route rewriting affecting root-hosted deployments or normal app routes that contain `/apps/`. The parser is anchored to Coder-shaped path-app prefixes, and tests cover root mode, direct-prefixed mode, forwarded-header mode, non-prefix `/apps/` paths, sequential tenant prefixes, origin validation, WebSocket upgrade normalization, docs URLs, and OAuth URL generation.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$56.00`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=56.00 -->
