### PR TITLE
🤖 fix: harden path-app shell loading

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,6 +1,6 @@
 // mux Service Worker for PWA support
-const CACHE_NAME = "mux-v1";
-const urlsToCache = ["/", "/index.html"];
+const CACHE_NAME = "mux-v2";
+const urlsToCache = ["./", "./index.html"];
 
 // Install event - cache core assets
 self.addEventListener("install", (event) => {

--- a/src/node/orpc/server.test.ts
+++ b/src/node/orpc/server.test.ts
@@ -155,6 +155,13 @@ function countOccurrences(value: string, needle: string): number {
   return value.split(needle).length - 1;
 }
 
+function expectSlashlessRootRedirectBeforeBase(html: string, baseHref: string): void {
+  const redirectIndex = html.indexOf("location.replace(location.origin+pathname");
+  const baseIndex = html.indexOf(`<base href="${baseHref}"`);
+  expect(redirectIndex).toBeGreaterThanOrEqual(0);
+  expect(baseIndex).toBeGreaterThan(redirectIndex);
+}
+
 async function createStaticTestServer(
   options: {
     files?: Record<string, string>;
@@ -231,7 +238,7 @@ describe("createOrpcServer", () => {
       expect(uiRes.status).toBe(200);
       const uiText = await uiRes.text();
       expect(uiText).toContain("mux");
-      expect(uiText).toContain('<base href="/"');
+      expect(uiText).toContain('<base href="./../../"');
 
       const apiRes = await fetch(`${server.baseUrl}/api/not-a-real-route`);
       expect(apiRes.status).toBe(404);
@@ -248,7 +255,23 @@ describe("createOrpcServer", () => {
       const rootRes = await fetch(`${server.baseUrl}/`);
       expect(rootRes.status).toBe(200);
       const rootHtml = await rootRes.text();
-      expect(countOccurrences(rootHtml, '<base href="/" />')).toBe(1);
+      expect(countOccurrences(rootHtml, '<base href="./" />')).toBe(1);
+      expectSlashlessRootRedirectBeforeBase(rootHtml, "./");
+
+      const doubleSlashRes = await fetch(`${server.baseUrl}//attacker.example`);
+      expect(doubleSlashRes.status).toBe(200);
+      const doubleSlashHtml = await doubleSlashRes.text();
+      expect(doubleSlashHtml).not.toContain("location.replace(location.origin+pathname");
+
+      const deepRouteRes = await fetch(`${server.baseUrl}/some/spa/route`);
+      expect(deepRouteRes.status).toBe(200);
+      const deepRouteHtml = await deepRouteRes.text();
+      expect(deepRouteHtml).toContain('<base href="./../../" />');
+      expect(deepRouteHtml).not.toContain("location.replace(location.pathname");
+
+      const directoryRouteRes = await fetch(`${server.baseUrl}/some/spa/route/`);
+      expect(directoryRouteRes.status).toBe(200);
+      expect(await directoryRouteRes.text()).toContain('<base href="./../../../" />');
 
       const forwardedPrefixRes = await fetch(`${server.baseUrl}/some/spa/route`, {
         headers: { "X-Forwarded-Prefix": APP_PROXY_BASE_PATH },
@@ -297,6 +320,23 @@ describe("createOrpcServer", () => {
       expect(prefixedAssetRes.status).toBe(200);
       expect(await prefixedAssetRes.text()).toBe(await rootAssetRes.text());
 
+      const prefixedRootRes = await fetch(`${server.baseUrl}${APP_PROXY_BASE_PATH}`);
+      expect(prefixedRootRes.status).toBe(200);
+      const prefixedRootHtml = await prefixedRootRes.text();
+      expect(prefixedRootHtml).toContain(`<base href="${APP_PROXY_BASE_PATH}/" />`);
+      expectSlashlessRootRedirectBeforeBase(prefixedRootHtml, `${APP_PROXY_BASE_PATH}/`);
+
+      const coderUrlRes = await fetch(
+        `${server.baseUrl}/@admin/mux-workspace-095801.main/apps/mux/?token=redacted`
+      );
+      expect(coderUrlRes.status).toBe(200);
+      const coderUrlHtml = await coderUrlRes.text();
+      expect(coderUrlHtml).toContain('<base href="/@admin/mux-workspace-095801.main/apps/mux/" />');
+      expectSlashlessRootRedirectBeforeBase(
+        coderUrlHtml,
+        "/@admin/mux-workspace-095801.main/apps/mux/"
+      );
+
       const prefixedSpaRes = await fetch(`${server.baseUrl}${APP_PROXY_BASE_PATH}/settings`);
       expect(prefixedSpaRes.status).toBe(200);
       expect(await prefixedSpaRes.text()).toContain(`<base href="${APP_PROXY_BASE_PATH}/" />`);
@@ -323,7 +363,7 @@ describe("createOrpcServer", () => {
 
       const falsePositiveRes = await fetch(`${server.baseUrl}/projects/apps/other`);
       expect(falsePositiveRes.status).toBe(200);
-      expect(await falsePositiveRes.text()).toContain('<base href="/" />');
+      expect(await falsePositiveRes.text()).toContain('<base href="./../../" />');
     } finally {
       await close();
     }
@@ -477,8 +517,10 @@ describe("createOrpcServer", () => {
           expect(uiRes.status).toBe(200);
           const uiText = await uiRes.text();
 
+          expect(rootHtml).toContain('<base href="./"');
+          expect(uiText).toContain('<base href="./../../"');
+
           for (const html of [rootHtml, uiText]) {
-            expect(html).toContain('<base href="/"');
             expect(html).toContain("window.__MUX_PROXY_URI_TEMPLATE__ =");
             expect(html).toContain(
               'window.__MUX_PROXY_URI_TEMPLATE__ = "https://proxy-{{port}}.example.test/path\\u003c/script>";'

--- a/src/node/orpc/server.ts
+++ b/src/node/orpc/server.ts
@@ -123,17 +123,30 @@ function escapeHtmlAttribute(value: string): string {
     .replaceAll(">", "&gt;");
 }
 
-function injectBaseHref(indexHtml: string, baseHref: string): string {
+const SLASHLESS_ROOT_REDIRECT_SCRIPT =
+  '<script>(()=>{const pathname=location.pathname;if(pathname.startsWith("//")||pathname.endsWith("/"))return;location.replace(location.origin+pathname+"/"+location.search+location.hash);})();</script>';
+
+function injectBaseHref(
+  indexHtml: string,
+  baseHref: string,
+  options: { includeSlashlessRootRedirect?: boolean } = {}
+): string {
   // Avoid double-injecting if the HTML already has a base tag.
   if (/<base\b/i.test(indexHtml)) {
     return indexHtml;
   }
 
+  // The redirect must precede the base tag so slashless app-root URLs become
+  // directory URLs before the browser resolves relative assets.
+  const slashlessRootRedirect = options.includeSlashlessRootRedirect
+    ? `\n    ${SLASHLESS_ROOT_REDIRECT_SCRIPT}`
+    : "";
+
   // Insert immediately after the opening <head> tag (supports <head> and <head ...attrs>).
   const escapedBaseHref = escapeHtmlAttribute(baseHref);
   return indexHtml.replace(
     /<head[^>]*>/i,
-    (match) => `${match}\n    <base href="${escapedBaseHref}" />`
+    (match) => `${match}${slashlessRootRedirect}\n    <base href="${escapedBaseHref}" />`
   );
 }
 
@@ -579,9 +592,31 @@ function getDirectAppProxyHandlerPrefix(
     : routePrefix;
 }
 
+function getRoutePathnameForBaseHref(req: express.Request): string | null {
+  return getPathnameFromRequestUrl(req.url);
+}
+
+function getRelativeBaseHrefFromRoutePathname(routePathname: string): string {
+  const pathname = routePathname.startsWith("/") ? routePathname : `/${routePathname}`;
+  const segments = pathname.split("/").slice(1);
+  const depth = Math.max(0, segments.length - 1);
+  return depth === 0 ? "./" : `./${"../".repeat(depth)}`;
+}
+
+function shouldInjectSlashlessRootRedirect(req: express.Request): boolean {
+  return getRoutePathnameForBaseHref(req) === "/";
+}
+
 function getPublicBaseHref(req: express.Request, res: express.Response): string {
   const publicBasePath = getPublicBasePathForRequest(req, res, { allowReferer: true });
-  return publicBasePath === "/" ? "/" : `${publicBasePath}/`;
+  if (publicBasePath !== "/") {
+    return `${publicBasePath}/`;
+  }
+
+  // User rationale: when a reverse proxy strips the app prefix without forwarding
+  // headers, a relative climb still lets the browser resolve assets from the
+  // public app root. Root-hosted deep links resolve correctly too.
+  return getRelativeBaseHrefFromRoutePathname(getRoutePathnameForBaseHref(req) ?? "/");
 }
 
 function getPublicAppRootPath(req: express.Request, res: express.Response): string {
@@ -1545,7 +1580,9 @@ export async function createOrpcServer({
 
       if (rawSpaIndexHtml !== null) {
         const spaIndexHtml = injectProxyUriTemplate(
-          injectBaseHref(rawSpaIndexHtml, getPublicBaseHref(req, res)),
+          injectBaseHref(rawSpaIndexHtml, getPublicBaseHref(req, res), {
+            includeSlashlessRootRedirect: shouldInjectSlashlessRootRedirect(req),
+          }),
           getBrowserProxyUriTemplate()
         );
         varyPublicBasePathHeaders(res);


### PR DESCRIPTION
> Mux worked on behalf of Mike.

## Summary

Absorbs the small path-app hardening pieces from #3184 on top of the merged #3194 implementation. This keeps the existing server-side prefix detection, direct prefixed route handling, Scalar rewriting, and terminal popout path support intact.

## Background

#3194 made mux work under Coder path-app iframe URLs. #3184 had a few defensive ideas worth keeping as a focused follow-up: tolerate slashless app-root URLs, avoid stale service worker caches, and keep static shell assets resolving when a proxy strips the app prefix without sending forwarding headers.

## Implementation

- Uses the detected public base path when available, preserving absolute prefixed base hrefs for Coder path-app requests.
- Falls back to a relative base href climb when no public prefix is detected, so root hosting and stripped-prefix proxy paths both resolve static assets from the app root.
- Injects a slashless app-root redirect script before the base tag only for app-root shell responses, with a same-origin redirect target and a double-slash path guard.
- Bumps the service worker cache name to `mux-v2` and precaches relative shell URLs.
- Adds regression coverage for the exact Coder path shape with a token query, for example `/@admin/<workspace>.main/apps/mux/?token=...`, plus a double-slash redirect guard.

## Validation

- `bun test src/node/orpc/server.test.ts`
- `bun test src/common/appProxyBasePath.test.ts src/browser/utils/backendBaseUrl.test.ts`
- `make static-check`

## Risks

Low to moderate. This touches SPA shell HTML generation, but keeps detected Coder path-app base href behavior unchanged and adds tests for relative deep-route fallback, slashless app-root handling, direct prefixed requests, double-slash paths, and false-positive `/apps/` paths.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$78.40`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=78.40 -->
