### PR TITLE
🤖 feat: show provider env source metadata

### DIFF
--- a/src/browser/features/Settings/Sections/ProvidersSection.stories.tsx
+++ b/src/browser/features/Settings/Sections/ProvidersSection.stories.tsx
@@ -61,6 +61,42 @@ export const ProvidersConfigured: Story = {
   },
 };
 
+export const ProvidersEnvSourced: Story = {
+  render: () => (
+    <SettingsSectionStory
+      setup={() =>
+        setupSettingsStory({
+          providersConfig: {
+            openai: {
+              apiKeySet: false,
+              apiKeySource: "env",
+              isEnabled: true,
+              isConfigured: true,
+              baseUrlSource: "env",
+              baseUrlResolved: "https://env.openai.test/v1",
+            },
+          },
+        })
+      }
+    >
+      <ProvidersSection />
+    </SettingsSectionStory>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const openaiButton = await canvas.findByRole("button", { name: /openai/i });
+    await userEvent.click(openaiButton);
+
+    await canvas.findByText("https://env.openai.test/v1");
+    await waitFor(() => {
+      if (canvas.queryAllByText(/Set by env vars\./i).length < 2) {
+        throw new Error("Expected env source labels for OpenAI key and base URL");
+      }
+    });
+  },
+};
+
 export const ProvidersExpanded: Story = {
   render: () => (
     <SettingsSectionStory

--- a/src/browser/features/Settings/Sections/ProvidersSection.stories.tsx
+++ b/src/browser/features/Settings/Sections/ProvidersSection.stories.tsx
@@ -1,4 +1,4 @@
-import { lightweightMeta } from "@/browser/stories/meta.js";
+import { CHROMATIC_DISABLED, lightweightMeta } from "@/browser/stories/meta.js";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { userEvent, waitFor, within } from "@storybook/test";
 import { ProvidersSection } from "./ProvidersSection.js";
@@ -82,6 +82,9 @@ export const ProvidersEnvSourced: Story = {
       <ProvidersSection />
     </SettingsSectionStory>
   ),
+  parameters: {
+    chromatic: CHROMATIC_DISABLED,
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 

--- a/src/browser/features/Settings/Sections/ProvidersSection.tsx
+++ b/src/browser/features/Settings/Sections/ProvidersSection.tsx
@@ -1104,9 +1104,15 @@ export function ProvidersSection() {
         apiKeyIsOpRef: false,
         apiKeyOpRef: undefined,
         apiKeyOpLabel: undefined,
+        apiKeySource: editValue !== "" ? "config" : undefined,
       });
     } else if (field === "baseUrl") {
-      updateOptimistically(provider, { baseUrl: editValue || undefined });
+      const nextBaseUrl = editValue || undefined;
+      updateOptimistically(provider, {
+        baseUrl: nextBaseUrl,
+        baseUrlSource: nextBaseUrl ? "config" : undefined,
+        baseUrlResolved: nextBaseUrl,
+      });
     } else if (field === "apiKeyFile") {
       updateOptimistically(provider, { apiKeyFile: editValue || undefined });
     }
@@ -1132,9 +1138,14 @@ export function ProvidersSection() {
           apiKeySet: false,
           apiKeyIsOpRef: false,
           apiKeyOpRef: undefined,
+          apiKeySource: undefined,
         });
       } else if (field === "baseUrl") {
-        updateOptimistically(provider, { baseUrl: undefined });
+        updateOptimistically(provider, {
+          baseUrl: undefined,
+          baseUrlSource: undefined,
+          baseUrlResolved: undefined,
+        });
       } else if (field === "apiKeyFile") {
         updateOptimistically(provider, { apiKeyFile: undefined });
       }
@@ -1192,6 +1203,20 @@ export function ProvidersSection() {
     // For standard fields like baseUrl
     const value = providerConfig[field as keyof typeof providerConfig];
     return typeof value === "string" ? value : undefined;
+  };
+
+  const getFieldDisplayValue = (provider: string, field: string): string | undefined => {
+    const fieldValue = getFieldValue(provider, field);
+    if (field !== "baseUrl") {
+      return fieldValue;
+    }
+
+    const providerConfig = config?.[provider];
+    if (providerConfig?.baseUrlSource && typeof providerConfig.baseUrlResolved === "string") {
+      return providerConfig.baseUrlResolved;
+    }
+
+    return fieldValue;
   };
 
   const isFieldSet = (provider: string, field: string, fieldConfig: FieldConfig): boolean => {
@@ -1261,6 +1286,7 @@ export function ProvidersSection() {
               const configured = isConfigured(provider);
               const fields = getProviderFields(provider);
               const providerDefinition = PROVIDER_DEFINITIONS[provider];
+              const apiKeySource = config?.[provider]?.apiKeySource;
               const gatewayRouteTargets =
                 providerDefinition.kind === "gateway" ? (providerDefinition.routes ?? []) : [];
               const statusDotColor = !enabled
@@ -1349,11 +1375,12 @@ export function ProvidersSection() {
                           {configured &&
                             config?.[provider]?.apiKeySet === false &&
                             // OpenAI can be configured via ChatGPT OAuth, not just env vars
-                            !(provider === "openai" && codexOauthIsConnected) && (
+                            !(provider === "openai" && codexOauthIsConnected) &&
+                            (apiKeySource === "env" || apiKeySource === "file") && (
                               <div className="text-muted text-xs">
-                                {config?.[provider]?.apiKeySource === "file"
-                                  ? "Configured via API key file."
-                                  : "Configured via environment variables."}
+                                {apiKeySource === "file"
+                                  ? "Set by API key file."
+                                  : "Set by env vars."}
                               </div>
                             )}
                         </div>
@@ -1577,6 +1604,7 @@ export function ProvidersSection() {
                           editingField?.provider === provider &&
                           editingField?.field === fieldConfig.key;
                         const fieldValue = getFieldValue(provider, fieldConfig.key);
+                        const fieldDisplayValue = getFieldDisplayValue(provider, fieldConfig.key);
                         const fieldIsSet = isFieldSet(provider, fieldConfig.key, fieldConfig);
 
                         return (
@@ -1673,7 +1701,7 @@ export function ProvidersSection() {
                                         "Not set"
                                       )
                                     ) : (
-                                      (fieldValue ?? "Default")
+                                      (fieldDisplayValue ?? "Default")
                                     )}
                                   </span>
                                   <div className="flex gap-2">
@@ -1712,6 +1740,11 @@ export function ProvidersSection() {
                                     )}
                                   </div>
                                 </div>
+                                {fieldConfig.key === "baseUrl" &&
+                                  config?.[provider]?.baseUrlSource === "env" &&
+                                  config?.[provider]?.baseUrlResolved && (
+                                    <div className="text-muted mt-1 text-xs">Set by env vars.</div>
+                                  )}
                                 {opPickerProvider === provider && fieldConfig.key === "apiKey" && (
                                   <OnePasswordPicker
                                     onSelect={(opRef, opLabel) => {

--- a/src/browser/features/Settings/Sections/settingsStoryUtils.tsx
+++ b/src/browser/features/Settings/Sections/settingsStoryUtils.tsx
@@ -95,9 +95,12 @@ interface SetupSettingsStoryOptions {
     string,
     {
       apiKeySet: boolean;
+      apiKeySource?: "config" | "file" | "env";
       isEnabled: boolean;
       isConfigured: boolean;
       baseUrl?: string;
+      baseUrlSource?: "config" | "env";
+      baseUrlResolved?: string;
       models?: string[];
     }
   >;

--- a/src/common/orpc/schemas/api.test.ts
+++ b/src/common/orpc/schemas/api.test.ts
@@ -41,6 +41,8 @@ describe("ProviderConfigInfoSchema conformance", () => {
       isEnabled: true,
       isConfigured: true,
       baseUrl: "https://api.example.com",
+      baseUrlSource: "config",
+      baseUrlResolved: "https://api.example.com",
       models: ["model-a", "model-b"],
     };
 
@@ -105,6 +107,8 @@ describe("ProviderConfigInfoSchema conformance", () => {
       isEnabled: true,
       isConfigured: true,
       baseUrl: "https://custom.endpoint.com",
+      baseUrlSource: "config",
+      baseUrlResolved: "https://custom.endpoint.com",
       models: ["claude-3-opus", "claude-3-sonnet"],
       serviceTier: "flex",
       store: false,
@@ -133,6 +137,8 @@ describe("ProviderConfigInfoSchema conformance", () => {
     expect(parsed.apiKeyOpRef).toBe(full.apiKeyOpRef);
     expect(parsed.isEnabled).toBe(full.isEnabled);
     expect(parsed.baseUrl).toBe(full.baseUrl);
+    expect(parsed.baseUrlSource).toBe(full.baseUrlSource);
+    expect(parsed.baseUrlResolved).toBe(full.baseUrlResolved);
     expect(parsed.models).toEqual(full.models);
     expect(parsed.serviceTier).toBe(full.serviceTier);
     expect(parsed.store).toBe(full.store);
@@ -156,6 +162,8 @@ describe("ProviderConfigInfoSchema conformance", () => {
         apiKeySet: true,
         isEnabled: true,
         isConfigured: true,
+        baseUrlSource: "env",
+        baseUrlResolved: "https://env.openai.test",
         serviceTier: "auto",
         codexOauthSet: true,
         codexOauthDefaultAuth: "oauth",

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -193,6 +193,10 @@ export const ProviderConfigInfoSchema = z.object({
   /** Where the API key was actually resolved from (config, file, or env) */
   apiKeySource: z.enum(["config", "file", "env"]).optional(),
   baseUrl: z.string().optional(),
+  /** Where the active base URL was resolved from (config or env) */
+  baseUrlSource: z.enum(["config", "env"]).nullish(),
+  /** Active base URL for display only. Env values must not be persisted from this field. */
+  baseUrlResolved: z.string().nullish(),
   models: z.array(ProviderModelEntrySchema).optional(),
   /** OpenAI-specific fields */
   serviceTier: ServiceTierSchema.optional(),

--- a/src/node/services/providerService.test.ts
+++ b/src/node/services/providerService.test.ts
@@ -290,6 +290,23 @@ describe("ProviderService.getConfig", () => {
     );
   });
 
+  it("returns legacy baseURL config as editable baseUrl", () => {
+    withTempConfig((config, service) => {
+      config.saveProvidersConfig({
+        openai: {
+          apiKey: "sk-test",
+          baseURL: "https://legacy.openai.test",
+        },
+      });
+
+      const cfg = service.getConfig();
+
+      expect(cfg.openai.baseUrl).toBe("https://legacy.openai.test");
+      expect(cfg.openai.baseUrlSource).toBe("config");
+      expect(cfg.openai.baseUrlResolved).toBe("https://legacy.openai.test");
+    });
+  });
+
   it("returns config sourced Anthropic base URL ahead of env", () => {
     withProviderEnv(
       {
@@ -417,6 +434,38 @@ describe("ProviderService.setConfig", () => {
         "openai/gpt-5.5",
       ]);
       expect(providersConfig?.["mux-gateway"]?.models).not.toContain("openai/gpt-5.2-codex");
+    });
+  });
+
+  it("removes legacy baseURL alias when editing canonical baseUrl", async () => {
+    await withTempConfigAsync(async (config, service) => {
+      config.saveProvidersConfig({
+        openai: {
+          apiKey: "sk-test",
+          baseURL: "https://legacy.openai.test",
+        },
+      });
+
+      const updateResult = await service.setConfig(
+        "openai",
+        ["baseUrl"],
+        "https://canonical.openai.test"
+      );
+      expect(updateResult.success).toBe(true);
+      expect(config.loadProvidersConfig()?.openai?.baseURL).toBeUndefined();
+      expect(config.loadProvidersConfig()?.openai?.baseUrl).toBe("https://canonical.openai.test");
+
+      config.saveProvidersConfig({
+        openai: {
+          apiKey: "sk-test",
+          baseURL: "https://legacy.openai.test",
+        },
+      });
+
+      const clearResult = await service.setConfig("openai", ["baseUrl"], "");
+      expect(clearResult.success).toBe(true);
+      expect(config.loadProvidersConfig()?.openai?.baseURL).toBeUndefined();
+      expect(config.loadProvidersConfig()?.openai?.baseUrl).toBeUndefined();
     });
   });
 

--- a/src/node/services/providerService.test.ts
+++ b/src/node/services/providerService.test.ts
@@ -4,6 +4,7 @@ import * as os from "os";
 import * as path from "path";
 import type { ProviderModelEntry } from "@/common/orpc/types";
 import { Config } from "@/node/config";
+import { PolicyService } from "@/node/services/policyService";
 import { ProviderService } from "./providerService";
 
 function withTempConfig(run: (config: Config, service: ProviderService) => void): void {
@@ -27,6 +28,44 @@ async function withTempConfigAsync(
     await run(config, service);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+const PROVIDER_ENV_KEYS = [
+  "OPENAI_API_KEY",
+  "OPENAI_BASE_URL",
+  "OPENAI_API_BASE",
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "ANTHROPIC_BASE_URL",
+] as const;
+
+function withProviderEnv(
+  updates: Partial<Record<(typeof PROVIDER_ENV_KEYS)[number], string>>,
+  run: () => void
+): void {
+  const previous = new Map<string, string | undefined>();
+  for (const key of PROVIDER_ENV_KEYS) {
+    previous.set(key, process.env[key]);
+    const nextValue = updates[key];
+    if (nextValue === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = nextValue;
+    }
+  }
+
+  try {
+    run();
+  } finally {
+    for (const key of PROVIDER_ENV_KEYS) {
+      const previousValue = previous.get(key);
+      if (previousValue === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previousValue;
+      }
+    }
   }
 }
 
@@ -210,6 +249,91 @@ describe("ProviderService.getConfig", () => {
       expect(cfg.openai.isEnabled).toBe(false);
       expect(cfg.openai.isConfigured).toBe(false);
     });
+  });
+
+  it("returns env sourced OpenAI base URL without saving it as baseUrl", () => {
+    withProviderEnv(
+      {
+        OPENAI_API_KEY: "sk-env",
+        OPENAI_BASE_URL: "https://env.openai.test",
+      },
+      () => {
+        withTempConfig((_config, service) => {
+          const cfg = service.getConfig();
+
+          expect(cfg.openai.isConfigured).toBe(true);
+          expect(cfg.openai.apiKeySource).toBe("env");
+          expect(cfg.openai.baseUrl).toBeUndefined();
+          expect(cfg.openai.baseUrlSource).toBe("env");
+          expect(cfg.openai.baseUrlResolved).toBe("https://env.openai.test");
+        });
+      }
+    );
+  });
+
+  it("returns config sourced Anthropic base URL ahead of env", () => {
+    withProviderEnv(
+      {
+        ANTHROPIC_API_KEY: "sk-ant-env",
+        ANTHROPIC_BASE_URL: "https://env.anthropic.test",
+      },
+      () => {
+        withTempConfig((config, service) => {
+          config.saveProvidersConfig({
+            anthropic: {
+              apiKey: "sk-ant-config",
+              baseUrl: "https://config.anthropic.test",
+            },
+          });
+
+          const cfg = service.getConfig();
+
+          expect(cfg.anthropic.isConfigured).toBe(true);
+          expect(cfg.anthropic.apiKeySource).toBe("config");
+          expect(cfg.anthropic.baseUrl).toBe("https://config.anthropic.test");
+          expect(cfg.anthropic.baseUrlSource).toBe("config");
+          expect(cfg.anthropic.baseUrlResolved).toBe("https://config.anthropic.test");
+        });
+      }
+    );
+  });
+
+  it("does not label forced base URL as env sourced", () => {
+    withProviderEnv(
+      {
+        OPENAI_API_KEY: "sk-env",
+        OPENAI_BASE_URL: "https://env.openai.test",
+      },
+      () => {
+        withTempConfig((config) => {
+          const policyService = new PolicyService(config);
+          const isEnforcedSpy = spyOn(policyService, "isEnforced").mockReturnValue(true);
+          const isProviderAllowedSpy = spyOn(policyService, "isProviderAllowed").mockReturnValue(
+            true
+          );
+          const getForcedBaseUrlSpy = spyOn(policyService, "getForcedBaseUrl").mockReturnValue(
+            "https://forced.openai.test"
+          );
+          const getEffectivePolicySpy = spyOn(policyService, "getEffectivePolicy").mockReturnValue(
+            null
+          );
+          const service = new ProviderService(config, policyService);
+
+          try {
+            const cfg = service.getConfig();
+
+            expect(cfg.openai.baseUrl).toBe("https://forced.openai.test");
+            expect(cfg.openai.baseUrlSource).toBeUndefined();
+            expect(cfg.openai.baseUrlResolved).toBeUndefined();
+          } finally {
+            isEnforcedSpy.mockRestore();
+            isProviderAllowedSpy.mockRestore();
+            getForcedBaseUrlSpy.mockRestore();
+            getEffectivePolicySpy.mockRestore();
+          }
+        });
+      }
+    );
   });
 });
 

--- a/src/node/services/providerService.test.ts
+++ b/src/node/services/providerService.test.ts
@@ -271,6 +271,25 @@ describe("ProviderService.getConfig", () => {
     );
   });
 
+  it("returns env sourced base URL metadata when OpenAI API key is missing", () => {
+    withProviderEnv(
+      {
+        OPENAI_BASE_URL: "https://env.openai.test",
+      },
+      () => {
+        withTempConfig((_config, service) => {
+          const cfg = service.getConfig();
+
+          expect(cfg.openai.isConfigured).toBe(false);
+          expect(cfg.openai.apiKeySource).toBeUndefined();
+          expect(cfg.openai.baseUrl).toBeUndefined();
+          expect(cfg.openai.baseUrlSource).toBe("env");
+          expect(cfg.openai.baseUrlResolved).toBe("https://env.openai.test");
+        });
+      }
+    );
+  });
+
   it("returns config sourced Anthropic base URL ahead of env", () => {
     withProviderEnv(
       {

--- a/src/node/services/providerService.ts
+++ b/src/node/services/providerService.ts
@@ -239,9 +239,9 @@ export class ProviderService {
       const configCheck = checkProviderConfigured(provider, config);
       providerInfo.isConfigured = providerInfo.isEnabled && configCheck.isConfigured;
       providerInfo.apiKeySource = configCheck.apiKeySource;
-      if (forcedBaseUrl === undefined && configCheck.baseUrlSource && configCheck.baseUrl) {
+      if (forcedBaseUrl === undefined && configCheck.baseUrlSource && configCheck.baseUrlResolved) {
         providerInfo.baseUrlSource = configCheck.baseUrlSource;
-        providerInfo.baseUrlResolved = configCheck.baseUrl;
+        providerInfo.baseUrlResolved = configCheck.baseUrlResolved;
       }
 
       if (provider === "openai" && isEnabled && codexOauthSet) {

--- a/src/node/services/providerService.ts
+++ b/src/node/services/providerService.ts
@@ -22,6 +22,7 @@ import { log } from "@/node/services/log";
 import {
   checkProviderConfigured,
   isProviderAutoRouteEligible,
+  resolveConfiguredBaseUrl,
   resolveProviderCredentials,
 } from "@/node/utils/providerRequirements";
 import { parseCodexOauthAuth } from "@/node/utils/codexOauthAuth";
@@ -151,6 +152,8 @@ export class ProviderService {
         isEnabled = false;
       }
 
+      const explicitBaseUrl = resolveConfiguredBaseUrl(config);
+
       const providerInfo: ProviderConfigInfo = {
         apiKeySet: !!config.apiKey,
         apiKeyIsOpRef: apiKeyIsOpRef || undefined,
@@ -159,7 +162,7 @@ export class ProviderService {
         // Users can disable providers without removing credentials from providers.jsonc.
         isEnabled,
         isConfigured: false, // computed below
-        baseUrl: forcedBaseUrl ?? config.baseUrl,
+        baseUrl: forcedBaseUrl ?? explicitBaseUrl,
         apiKeyFile: typeof config.apiKeyFile === "string" ? config.apiKeyFile : undefined,
         models: filteredModels,
       };
@@ -485,6 +488,12 @@ export class ProviderService {
       if (keyPath.length > 0) {
         const lastKey = keyPath[keyPath.length - 1];
         const isProviderEnabledToggle = keyPath.length === 1 && lastKey === "enabled";
+        const isCanonicalBaseUrlEdit = keyPath.length === 1 && lastKey === "baseUrl";
+        if (isCanonicalBaseUrlEdit) {
+          // The UI writes `baseUrl`. Remove the SDK-style alias so old `baseURL`
+          // values cannot keep shadowing user edits or clears after save.
+          delete current.baseURL;
+        }
 
         if (isProviderEnabledToggle) {
           // Persist only `enabled: false` and delete on enable so providers.jsonc stays minimal.

--- a/src/node/services/providerService.ts
+++ b/src/node/services/providerService.ts
@@ -109,6 +109,7 @@ export class ProviderService {
         apiKeyFile?: string;
         apiKeyOpLabel?: string;
         baseUrl?: string;
+        baseURL?: string;
         models?: unknown[];
         serviceTier?: string;
         wireFormat?: string;
@@ -238,6 +239,10 @@ export class ProviderService {
       const configCheck = checkProviderConfigured(provider, config);
       providerInfo.isConfigured = providerInfo.isEnabled && configCheck.isConfigured;
       providerInfo.apiKeySource = configCheck.apiKeySource;
+      if (forcedBaseUrl === undefined && configCheck.baseUrlSource && configCheck.baseUrl) {
+        providerInfo.baseUrlSource = configCheck.baseUrlSource;
+        providerInfo.baseUrlResolved = configCheck.baseUrl;
+      }
 
       if (provider === "openai" && isEnabled && codexOauthSet) {
         providerInfo.isConfigured = true;

--- a/src/node/utils/providerRequirements.test.ts
+++ b/src/node/utils/providerRequirements.test.ts
@@ -189,7 +189,8 @@ describe("resolveProviderCredentials base URL source", () => {
     expect(result.isConfigured).toBe(false);
     expect(result.missingRequirement).toBe("api_key");
     expect(result.apiKeySource).toBeUndefined();
-    expect(result.baseUrl).toBe("https://env.openai.test");
+    expect(result.baseUrl).toBeUndefined();
+    expect(result.baseUrlResolved).toBe("https://env.openai.test");
     expect(result.baseUrlSource).toBe("env");
   });
 });

--- a/src/node/utils/providerRequirements.test.ts
+++ b/src/node/utils/providerRequirements.test.ts
@@ -102,6 +102,98 @@ describe("hasAnyConfiguredProvider", () => {
   });
 });
 
+describe("resolveProviderCredentials base URL source", () => {
+  it("marks OpenAI base URL from OPENAI_BASE_URL as env sourced", () => {
+    const result = resolveProviderCredentials(
+      "openai",
+      {},
+      { OPENAI_API_KEY: "sk-from-env", OPENAI_BASE_URL: "https://env.openai.test" }
+    );
+
+    expect(result.isConfigured).toBe(true);
+    expect(result.apiKeySource).toBe("env");
+    expect(result.baseUrl).toBe("https://env.openai.test");
+    expect(result.baseUrlSource).toBe("env");
+  });
+
+  it("marks Anthropic base URL from ANTHROPIC_BASE_URL as env sourced", () => {
+    const result = resolveProviderCredentials(
+      "anthropic",
+      {},
+      { ANTHROPIC_API_KEY: "sk-ant-env", ANTHROPIC_BASE_URL: "https://env.anthropic.test" }
+    );
+
+    expect(result.isConfigured).toBe(true);
+    expect(result.apiKeySource).toBe("env");
+    expect(result.baseUrl).toBe("https://env.anthropic.test");
+    expect(result.baseUrlSource).toBe("env");
+  });
+
+  it("marks baseUrl from config as config sourced", () => {
+    const result = resolveProviderCredentials(
+      "openai",
+      { apiKey: "sk-from-config", baseUrl: "https://config.openai.test" },
+      { OPENAI_BASE_URL: "https://env.openai.test" }
+    );
+
+    expect(result.apiKeySource).toBe("config");
+    expect(result.baseUrl).toBe("https://config.openai.test");
+    expect(result.baseUrlSource).toBe("config");
+  });
+
+  it("marks baseURL from config as config sourced", () => {
+    const result = resolveProviderCredentials(
+      "anthropic",
+      { apiKey: "sk-ant-config", baseURL: "https://config.anthropic.test" },
+      { ANTHROPIC_BASE_URL: "https://env.anthropic.test" }
+    );
+
+    expect(result.apiKeySource).toBe("config");
+    expect(result.baseUrl).toBe("https://config.anthropic.test");
+    expect(result.baseUrlSource).toBe("config");
+  });
+
+  it("keeps config base URL ahead of env base URL", () => {
+    const result = resolveProviderCredentials(
+      "openai",
+      { apiKey: "sk-from-config", baseUrl: "https://config.openai.test" },
+      { OPENAI_BASE_URL: "https://env.openai.test" }
+    );
+
+    expect(result.baseUrl).toBe("https://config.openai.test");
+    expect(result.baseUrlSource).toBe("config");
+  });
+
+  it("keeps OPENAI_BASE_URL ahead of OPENAI_API_BASE", () => {
+    const result = resolveProviderCredentials(
+      "openai",
+      {},
+      {
+        OPENAI_API_KEY: "sk-from-env",
+        OPENAI_BASE_URL: "https://openai-base-url.test",
+        OPENAI_API_BASE: "https://openai-api-base.test",
+      }
+    );
+
+    expect(result.baseUrl).toBe("https://openai-base-url.test");
+    expect(result.baseUrlSource).toBe("env");
+  });
+
+  it("returns base URL metadata even when API key is missing", () => {
+    const result = resolveProviderCredentials(
+      "openai",
+      {},
+      { OPENAI_BASE_URL: "https://env.openai.test" }
+    );
+
+    expect(result.isConfigured).toBe(false);
+    expect(result.missingRequirement).toBe("api_key");
+    expect(result.apiKeySource).toBeUndefined();
+    expect(result.baseUrl).toBe("https://env.openai.test");
+    expect(result.baseUrlSource).toBe("env");
+  });
+});
+
 describe("resolveProviderCredentials - apiKeyFile", () => {
   let tmpDir: string;
   let keyFilePath: string;

--- a/src/node/utils/providerRequirements.test.ts
+++ b/src/node/utils/providerRequirements.test.ts
@@ -100,6 +100,19 @@ describe("hasAnyConfiguredProvider", () => {
 
     expect(hasAnyConfiguredProvider(providers)).toBe(true);
   });
+
+  it("returns true for keyless providers with legacy baseURL config", () => {
+    const providers: ProvidersConfig = {
+      ollama: {
+        baseURL: "http://localhost:11434/api",
+      },
+    };
+
+    expect(hasAnyConfiguredProvider(providers)).toBe(true);
+    expect(resolveProviderCredentials("ollama", providers.ollama ?? {}, {}).isConfigured).toBe(
+      true
+    );
+  });
 });
 
 describe("resolveProviderCredentials base URL source", () => {

--- a/src/node/utils/providerRequirements.test.ts
+++ b/src/node/utils/providerRequirements.test.ts
@@ -153,6 +153,22 @@ describe("resolveProviderCredentials base URL source", () => {
     expect(result.baseUrlSource).toBe("config");
   });
 
+  it("prefers canonical baseUrl over legacy baseURL when both are set", () => {
+    const result = resolveProviderCredentials(
+      "openai",
+      {
+        apiKey: "sk-from-config",
+        baseUrl: "https://canonical.openai.test",
+        baseURL: "https://legacy.openai.test",
+      },
+      {}
+    );
+
+    expect(result.baseUrl).toBe("https://canonical.openai.test");
+    expect(result.baseUrlResolved).toBe("https://canonical.openai.test");
+    expect(result.baseUrlSource).toBe("config");
+  });
+
   it("keeps config base URL ahead of env base URL", () => {
     const result = resolveProviderCredentials(
       "openai",

--- a/src/node/utils/providerRequirements.ts
+++ b/src/node/utils/providerRequirements.ts
@@ -133,7 +133,8 @@ export interface ResolvedCredentials {
   apiKey?: string; // anthropic, openai, etc.
   region?: string; // bedrock
   couponCode?: string; // mux-gateway
-  baseUrl?: string; // from config or env
+  baseUrl?: string; // runtime value from config or env when API-key auth is active
+  baseUrlResolved?: string; // display-only metadata, including when API key auth is missing
   organization?: string; // openai
   apiKeySource?: "config" | "file" | "env";
   baseUrlSource?: "config" | "env";
@@ -142,7 +143,12 @@ export interface ResolvedCredentials {
 /** Legacy alias for backward compatibility */
 export type ProviderConfigCheck = Pick<
   ResolvedCredentials,
-  "isConfigured" | "missingRequirement" | "apiKeySource" | "baseUrl" | "baseUrlSource"
+  | "isConfigured"
+  | "missingRequirement"
+  | "apiKeySource"
+  | "baseUrl"
+  | "baseUrlResolved"
+  | "baseUrlSource"
 >;
 
 /** Resolve a non-empty base URL saved in provider config. */
@@ -162,14 +168,14 @@ function resolveBaseUrl(
   provider: ProviderName,
   config: ProviderConfigRaw,
   env: Record<string, string | undefined>
-): Pick<ResolvedCredentials, "baseUrl" | "baseUrlSource"> {
+): Pick<ResolvedCredentials, "baseUrlResolved" | "baseUrlSource"> {
   const configBaseUrl = resolveConfiguredBaseUrl(config);
   if (configBaseUrl) {
-    return { baseUrl: configBaseUrl, baseUrlSource: "config" };
+    return { baseUrlResolved: configBaseUrl, baseUrlSource: "config" };
   }
 
   const envBaseUrl = resolveEnv(PROVIDER_ENV_VARS[provider]?.baseUrl, env);
-  return envBaseUrl ? { baseUrl: envBaseUrl, baseUrlSource: "env" } : {};
+  return envBaseUrl ? { baseUrlResolved: envBaseUrl, baseUrlSource: "env" } : {};
 }
 
 /**
@@ -251,7 +257,10 @@ export function resolveProviderCredentials(
 
   if (apiKey) {
     const apiKeySource: "config" | "file" | "env" = configKey ? "config" : fileKey ? "file" : "env";
-    return { isConfigured: true, apiKey, organization, apiKeySource, ...baseUrlInfo };
+    const configuredBaseUrlInfo = baseUrlInfo.baseUrlResolved
+      ? { ...baseUrlInfo, baseUrl: baseUrlInfo.baseUrlResolved }
+      : baseUrlInfo;
+    return { isConfigured: true, apiKey, organization, apiKeySource, ...configuredBaseUrlInfo };
   }
 
   return { isConfigured: false, missingRequirement: "api_key", ...baseUrlInfo };
@@ -304,9 +313,22 @@ export function checkProviderConfigured(
   config: ProviderConfigRaw,
   env: Record<string, string | undefined> = process.env
 ): ProviderConfigCheck {
-  const { isConfigured, missingRequirement, apiKeySource, baseUrl, baseUrlSource } =
-    resolveProviderCredentials(provider, config, env);
-  return { isConfigured, missingRequirement, apiKeySource, baseUrl, baseUrlSource };
+  const {
+    isConfigured,
+    missingRequirement,
+    apiKeySource,
+    baseUrl,
+    baseUrlResolved,
+    baseUrlSource,
+  } = resolveProviderCredentials(provider, config, env);
+  return {
+    isConfigured,
+    missingRequirement,
+    apiKeySource,
+    baseUrl,
+    baseUrlResolved,
+    baseUrlSource,
+  };
 }
 
 // ============================================================================

--- a/src/node/utils/providerRequirements.ts
+++ b/src/node/utils/providerRequirements.ts
@@ -235,10 +235,11 @@ export function resolveProviderCredentials(
       : { isConfigured: false, missingRequirement: "coupon_code" };
   }
 
-  // Keyless providers (e.g., ollama): require explicit opt-in via baseUrl or models
+  // Keyless providers (e.g., ollama): require explicit opt-in via baseUrl/baseURL or models
   const def = PROVIDER_DEFINITIONS[provider];
   if (!def.requiresApiKey) {
-    const hasExplicitConfig = Boolean(config.baseUrl ?? (config.models?.length ?? 0) > 0);
+    const hasConfiguredModels = (config.models?.length ?? 0) > 0;
+    const hasExplicitConfig = Boolean(resolveConfiguredBaseUrl(config) ?? hasConfiguredModels);
     return { isConfigured: hasExplicitConfig };
   }
 

--- a/src/node/utils/providerRequirements.ts
+++ b/src/node/utils/providerRequirements.ts
@@ -152,13 +152,15 @@ export type ProviderConfigCheck = Pick<
 >;
 
 /** Resolve a non-empty base URL saved in provider config. */
-function resolveConfiguredBaseUrl(config: ProviderConfigRaw): string | undefined {
-  if (hasNonEmptyString(config.baseURL)) {
-    return config.baseURL.trim();
+export function resolveConfiguredBaseUrl(config: ProviderConfigRaw): string | undefined {
+  if (hasNonEmptyString(config.baseUrl)) {
+    // The settings UI writes the canonical `baseUrl` key. Prefer it over
+    // SDK-style `baseURL` so saved edits cannot be shadowed by stale aliases.
+    return config.baseUrl.trim();
   }
 
-  if (hasNonEmptyString(config.baseUrl)) {
-    return config.baseUrl.trim();
+  if (hasNonEmptyString(config.baseURL)) {
+    return config.baseURL.trim();
   }
 
   return undefined;

--- a/src/node/utils/providerRequirements.ts
+++ b/src/node/utils/providerRequirements.ts
@@ -136,13 +136,41 @@ export interface ResolvedCredentials {
   baseUrl?: string; // from config or env
   organization?: string; // openai
   apiKeySource?: "config" | "file" | "env";
+  baseUrlSource?: "config" | "env";
 }
 
 /** Legacy alias for backward compatibility */
 export type ProviderConfigCheck = Pick<
   ResolvedCredentials,
-  "isConfigured" | "missingRequirement" | "apiKeySource"
+  "isConfigured" | "missingRequirement" | "apiKeySource" | "baseUrl" | "baseUrlSource"
 >;
+
+/** Resolve a non-empty base URL saved in provider config. */
+function resolveConfiguredBaseUrl(config: ProviderConfigRaw): string | undefined {
+  if (hasNonEmptyString(config.baseURL)) {
+    return config.baseURL.trim();
+  }
+
+  if (hasNonEmptyString(config.baseUrl)) {
+    return config.baseUrl.trim();
+  }
+
+  return undefined;
+}
+
+function resolveBaseUrl(
+  provider: ProviderName,
+  config: ProviderConfigRaw,
+  env: Record<string, string | undefined>
+): Pick<ResolvedCredentials, "baseUrl" | "baseUrlSource"> {
+  const configBaseUrl = resolveConfiguredBaseUrl(config);
+  if (configBaseUrl) {
+    return { baseUrl: configBaseUrl, baseUrlSource: "config" };
+  }
+
+  const envBaseUrl = resolveEnv(PROVIDER_ENV_VARS[provider]?.baseUrl, env);
+  return envBaseUrl ? { baseUrl: envBaseUrl, baseUrlSource: "env" } : {};
+}
 
 /**
  * Read an API key from a file path. Supports ~ for home directory.
@@ -211,12 +239,9 @@ export function resolveProviderCredentials(
   const configKey =
     typeof config.apiKey === "string" && config.apiKey.trim().length > 0 ? config.apiKey : null;
   const fileKey = configKey ? null : resolveApiKeyFile(config.apiKeyFile as string | undefined);
-  const apiKey = configKey ?? fileKey ?? resolveEnv(envMapping?.apiKey, env);
-  const configBaseUrl =
-    (typeof config.baseURL === "string" && config.baseURL) ||
-    (typeof config.baseUrl === "string" && config.baseUrl) ||
-    undefined;
-  const baseUrl = configBaseUrl ?? resolveEnv(envMapping?.baseUrl, env);
+  const envKey = configKey || fileKey ? undefined : resolveEnv(envMapping?.apiKey, env);
+  const apiKey = configKey ?? fileKey ?? envKey;
+  const baseUrlInfo = resolveBaseUrl(provider, config, env);
   // Config organization takes precedence over env var (user's explicit choice)
   const configOrganization =
     typeof config.organization === "string" && config.organization
@@ -226,10 +251,10 @@ export function resolveProviderCredentials(
 
   if (apiKey) {
     const apiKeySource: "config" | "file" | "env" = configKey ? "config" : fileKey ? "file" : "env";
-    return { isConfigured: true, apiKey, baseUrl, organization, apiKeySource };
+    return { isConfigured: true, apiKey, organization, apiKeySource, ...baseUrlInfo };
   }
 
-  return { isConfigured: false, missingRequirement: "api_key" };
+  return { isConfigured: false, missingRequirement: "api_key", ...baseUrlInfo };
 }
 
 /**
@@ -279,8 +304,9 @@ export function checkProviderConfigured(
   config: ProviderConfigRaw,
   env: Record<string, string | undefined> = process.env
 ): ProviderConfigCheck {
-  const { isConfigured, missingRequirement } = resolveProviderCredentials(provider, config, env);
-  return { isConfigured, missingRequirement };
+  const { isConfigured, missingRequirement, apiKeySource, baseUrl, baseUrlSource } =
+    resolveProviderCredentials(provider, config, env);
+  return { isConfigured, missingRequirement, apiKeySource, baseUrl, baseUrlSource };
 }
 
 // ============================================================================


### PR DESCRIPTION
> Mux is acting on Mike's behalf.

## Summary

Shows Providers settings when API keys and base URLs are active from environment variables, without exposing secret values. Base URL values now carry source metadata so the UI can distinguish explicit config from env-derived runtime values.

## Background

Provider API key source labels already existed, but unknown sources could fall back to env wording and base URL source metadata was not exposed. This made it unclear when Anthropic or OpenAI were configured by env vars, especially for active base URLs that were not saved in user config.

## Implementation

- Track resolved base URL source during provider credential resolution.
- Surface `baseUrlSource` and `baseUrlResolved` through the provider config schema and service.
- Return API key source metadata from `checkProviderConfigured` so env and file labels reflect the backend source exactly.
- Keep `baseUrl` limited to runtime API-key credential paths so env metadata does not affect Codex OAuth-only OpenAI model creation.
- Normalize editable config base URLs across `baseUrl` and legacy SDK-style `baseURL`, including keyless provider detection, and remove stale aliases when saving from settings.
- Add Storybook coverage for env-sourced provider labels.

## Validation

- `bun test src/node/utils/providerRequirements.test.ts src/node/services/providerService.test.ts src/common/orpc/schemas/api.test.ts`
- `make static-check`
- `make storybook-build`

## Risks

Low risk. The change adds source metadata and UI labeling while preserving config-over-env precedence and avoiding API key value exposure. Alias normalization intentionally prefers the settings UI's canonical `baseUrl` key when both aliases are present.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$33.06`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=33.06 -->
