### PR TITLE
🤖 tests: lock alias-based OpenAI reasoning summary gating

### DIFF
--- a/src/common/utils/ai/providerOptions.test.ts
+++ b/src/common/utils/ai/providerOptions.test.ts
@@ -364,6 +364,29 @@ describe("buildProviderOptions - mappedToModel resolution", () => {
     expect(anthropic.effort).toBe("high");
   });
 
+  test("resolves custom alias to gpt-5.3-codex-spark for reasoning summary gating", () => {
+    const providersConfig = createMockProvidersConfig({
+      "openai:custom-spark": "openai:gpt-5.3-codex-spark",
+    });
+
+    const result = buildProviderOptions(
+      "openai:custom-spark",
+      "medium",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      providersConfig
+    ) as Record<string, unknown>;
+    const openai = result.openai as Record<string, unknown> | undefined;
+
+    expect(openai).toBeDefined();
+    expect(openai?.reasoningEffort).toBe("medium");
+    expect(openai?.reasoningSummary).toBeUndefined();
+    expect(openai?.include).toEqual(["reasoning.encrypted_content"]);
+  });
+
   test("works without providersConfig (backward compat)", () => {
     const result = buildProviderOptions("anthropic:claude-sonnet-4-5-20250514", "medium");
 


### PR DESCRIPTION
> Mux is acting on Mike's behalf.

## Summary
Add a regression test that locks OpenAI reasoning summary compatibility to the mapped alias target, so aliases that Treat as `gpt-5.3-codex-spark` continue to omit `reasoningSummary` while preserving encrypted reasoning content.

## Background
The previous PR draft described a revert that did not exist and used a test that did not actually depend on alias resolution. This update narrows the PR to the OpenAI behavior that `mappedToModel` really changes today.

## Implementation
Added a `buildProviderOptions()` regression test for `openai:custom-spark` mapped to `openai:gpt-5.3-codex-spark`. The test verifies the mapped model drives the `reasoningSummary` gate while leaving the rest of the OpenAI reasoning payload intact. There are no production code changes in this PR.

## Validation
- `bun test src/common/utils/ai/providerOptions.test.ts`
- `make static-check`

## Risks
Low. Test-only change that documents existing alias resolution behavior.

---

_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `xhigh` • Cost: `$7.53`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=xhigh costs=7.53 -->
