### PR TITLE
🤖 fix: increase advisor question limit

### DIFF
--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -155,7 +155,8 @@ export const AskUserQuestionToolResultSchema = z.union([
 
 export const AdvisorToolInputSchema = z
   .object({
-    question: z.string().min(1).max(500).nullish(),
+    // Advisor prompts often need tradeoff context; keep bounded while allowing a compact brief.
+    question: z.string().min(1).max(2000).nullish(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

Increase the advisor tool `question` input limit from 500 to 2000 characters so agents can include enough context for strategic tradeoff questions while keeping the field bounded.

## Background

The advisor tool is meant for planning ambiguity and architectural decisions, where a short one-line prompt can omit important constraints. The previous 500-character cap was tighter than needed for a compact brief.

## Implementation

Updated the shared advisor tool input schema to allow up to 2000 characters and documented why the bound is intentionally roomier than before.

## Validation

- `make static-check`

## Risks

Low. This only changes validation for advisor tool input length; the field remains bounded and the added context is small relative to the advisor transcript.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$0.39`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=0.39 -->
