### PR TITLE
🤖 fix: preempt startup when editing last message

### DIFF
--- a/src/node/services/agentSession.editMessageId.test.ts
+++ b/src/node/services/agentSession.editMessageId.test.ts
@@ -5,12 +5,19 @@ import type { InitStateManager } from "@/node/services/initStateManager";
 import type { BackgroundProcessManager } from "@/node/services/backgroundProcessManager";
 import type { Config } from "@/node/config";
 import { createMuxMessage } from "@/common/types/message";
-import type { MuxMessage } from "@/common/types/message";
 import type { SendMessageError } from "@/common/types/errors";
 import type { Result } from "@/common/types/result";
 import { Ok } from "@/common/types/result";
 import { AgentSession } from "./agentSession";
 import { createTestHistoryService } from "./testHistoryService";
+
+type StreamMessageHandler = AIService["streamMessage"];
+
+const TEST_MODEL = "anthropic:claude-3-5-sonnet-latest";
+const config = {
+  srcDir: "/tmp",
+  getSessionDir: (_workspaceId: string) => "/tmp",
+} as unknown as Config;
 
 async function waitForCondition(condition: () => boolean, timeoutMs = 1000): Promise<boolean> {
   if (condition()) {
@@ -25,56 +32,66 @@ async function waitForCondition(condition: () => boolean, timeoutMs = 1000): Pro
 
 describe("AgentSession.sendMessage (editMessageId)", () => {
   let historyCleanup: (() => Promise<void>) | undefined;
+
+  async function createSessionHarness(
+    workspaceId: string,
+    streamHandler: StreamMessageHandler = () => Promise.resolve(Ok(undefined))
+  ) {
+    const { historyService, cleanup } = await createTestHistoryService();
+    historyCleanup = cleanup;
+
+    const streamMessage = mock(streamHandler);
+    const aiService = Object.assign(new EventEmitter(), {
+      isStreaming: mock((_workspaceId: string) => false),
+      stopStream: mock((_workspaceId: string) => Promise.resolve(Ok(undefined))),
+      streamMessage: streamMessage as unknown as AIService["streamMessage"],
+    }) as unknown as AIService;
+
+    return {
+      historyService,
+      streamMessage,
+      session: new AgentSession({
+        workspaceId,
+        config,
+        historyService,
+        aiService,
+        initStateManager: new EventEmitter() as unknown as InitStateManager,
+        backgroundProcessManager: {
+          cleanup: mock((_workspaceId: string) => Promise.resolve()),
+          setMessageQueued: mock((_workspaceId: string, _queued: boolean) => {
+            void _queued;
+          }),
+        } as unknown as BackgroundProcessManager,
+      }),
+    };
+  }
+
+  async function seedImageMessage(
+    workspaceId: string,
+    historyService: Awaited<ReturnType<typeof createTestHistoryService>>["historyService"],
+    messageId = "user-message-with-image"
+  ): Promise<string> {
+    const originalImageUrl = "data:image/png;base64,AAAA";
+    await historyService.appendToHistory(
+      workspaceId,
+      createMuxMessage(messageId, "user", "original", { historySequence: 0 }, [
+        { type: "file", mediaType: "image/png", url: originalImageUrl },
+      ])
+    );
+    return originalImageUrl;
+  }
+
   afterEach(async () => {
     await historyCleanup?.();
   });
 
   it("treats missing edit target as no-op (allows recovery after compaction)", async () => {
-    const workspaceId = "ws-test";
-
-    const config = {
-      srcDir: "/tmp",
-      getSessionDir: (_workspaceId: string) => "/tmp",
-    } as unknown as Config;
-
-    const { historyService, cleanup } = await createTestHistoryService();
-    historyCleanup = cleanup;
-
+    const { session, historyService, streamMessage } = await createSessionHarness("ws-test");
     const truncateAfterMessage = spyOn(historyService, "truncateAfterMessage");
     const appendToHistory = spyOn(historyService, "appendToHistory");
 
-    const aiEmitter = new EventEmitter();
-    const streamMessage = mock((_messages: MuxMessage[]) => {
-      return Promise.resolve(Ok(undefined));
-    });
-    const aiService = Object.assign(aiEmitter, {
-      isStreaming: mock((_workspaceId: string) => false),
-      stopStream: mock((_workspaceId: string) => Promise.resolve(Ok(undefined))),
-      streamMessage: streamMessage as unknown as (
-        ...args: Parameters<AIService["streamMessage"]>
-      ) => Promise<Result<void, SendMessageError>>,
-    }) as unknown as AIService;
-
-    const initStateManager = new EventEmitter() as unknown as InitStateManager;
-
-    const backgroundProcessManager = {
-      cleanup: mock((_workspaceId: string) => Promise.resolve()),
-      setMessageQueued: mock((_workspaceId: string, _queued: boolean) => {
-        void _queued;
-      }),
-    } as unknown as BackgroundProcessManager;
-
-    const session = new AgentSession({
-      workspaceId,
-      config,
-      historyService,
-      aiService,
-      initStateManager,
-      backgroundProcessManager,
-    });
-
     const result = await session.sendMessage("hello", {
-      model: "anthropic:claude-3-5-sonnet-latest",
+      model: TEST_MODEL,
       agentId: "exec",
       editMessageId: "missing-user-message-id",
     });
@@ -89,61 +106,14 @@ describe("AgentSession.sendMessage (editMessageId)", () => {
 
   it("clears image parts when editing with explicit empty fileParts", async () => {
     const workspaceId = "ws-test";
-
-    const config = {
-      srcDir: "/tmp",
-      getSessionDir: (_workspaceId: string) => "/tmp",
-    } as unknown as Config;
-
+    const { session, historyService } = await createSessionHarness(workspaceId);
     const originalMessageId = "user-message-with-image";
-    const originalImageUrl = "data:image/png;base64,AAAA";
-
-    const { historyService, cleanup } = await createTestHistoryService();
-    historyCleanup = cleanup;
-
-    // Seed original message before setting up spies
-    await historyService.appendToHistory(
-      workspaceId,
-      createMuxMessage(originalMessageId, "user", "original", { historySequence: 0 }, [
-        { type: "file" as const, mediaType: "image/png", url: originalImageUrl },
-      ])
-    );
-
+    await seedImageMessage(workspaceId, historyService, originalMessageId);
     const truncateAfterMessage = spyOn(historyService, "truncateAfterMessage");
     const appendToHistory = spyOn(historyService, "appendToHistory");
 
-    const aiEmitter = new EventEmitter();
-    const streamMessage = mock((_messages: MuxMessage[]) => {
-      return Promise.resolve(Ok(undefined));
-    });
-    const aiService = Object.assign(aiEmitter, {
-      isStreaming: mock((_workspaceId: string) => false),
-      stopStream: mock((_workspaceId: string) => Promise.resolve(Ok(undefined))),
-      streamMessage: streamMessage as unknown as (
-        ...args: Parameters<AIService["streamMessage"]>
-      ) => Promise<Result<void, SendMessageError>>,
-    }) as unknown as AIService;
-
-    const initStateManager = new EventEmitter() as unknown as InitStateManager;
-
-    const backgroundProcessManager = {
-      cleanup: mock((_workspaceId: string) => Promise.resolve()),
-      setMessageQueued: mock((_workspaceId: string, _queued: boolean) => {
-        void _queued;
-      }),
-    } as unknown as BackgroundProcessManager;
-
-    const session = new AgentSession({
-      workspaceId,
-      config,
-      historyService,
-      aiService,
-      initStateManager,
-      backgroundProcessManager,
-    });
-
     const result = await session.sendMessage("edited", {
-      model: "anthropic:claude-3-5-sonnet-latest",
+      model: TEST_MODEL,
       agentId: "exec",
       editMessageId: originalMessageId,
       fileParts: [],
@@ -160,70 +130,21 @@ describe("AgentSession.sendMessage (editMessageId)", () => {
 
     expect(appendedFileParts).toHaveLength(0);
   });
+
   it("preserves image parts when editing and fileParts are omitted", async () => {
     const workspaceId = "ws-test";
-
-    const config = {
-      srcDir: "/tmp",
-      getSessionDir: (_workspaceId: string) => "/tmp",
-    } as unknown as Config;
-
+    const { session, historyService } = await createSessionHarness(workspaceId);
     const originalMessageId = "user-message-with-image";
-    const originalImageUrl = "data:image/png;base64,AAAA";
-
-    const { historyService, cleanup } = await createTestHistoryService();
-    historyCleanup = cleanup;
-
-    // Seed original message before setting up spies
-    await historyService.appendToHistory(
-      workspaceId,
-      createMuxMessage(originalMessageId, "user", "original", { historySequence: 0 }, [
-        { type: "file" as const, mediaType: "image/png", url: originalImageUrl },
-      ])
-    );
-
+    const originalImageUrl = await seedImageMessage(workspaceId, historyService, originalMessageId);
     const truncateAfterMessage = spyOn(historyService, "truncateAfterMessage");
     const appendToHistory = spyOn(historyService, "appendToHistory");
-    const getHistoryFromLatestBoundary = spyOn(historyService, "getHistoryFromLatestBoundary");
-
-    const aiEmitter = new EventEmitter();
-    const streamMessage = mock((_messages: MuxMessage[]) => {
-      return Promise.resolve(Ok(undefined));
-    });
-    const aiService = Object.assign(aiEmitter, {
-      isStreaming: mock((_workspaceId: string) => false),
-      stopStream: mock((_workspaceId: string) => Promise.resolve(Ok(undefined))),
-      streamMessage: streamMessage as unknown as (
-        ...args: Parameters<AIService["streamMessage"]>
-      ) => Promise<Result<void, SendMessageError>>,
-    }) as unknown as AIService;
-
-    const initStateManager = new EventEmitter() as unknown as InitStateManager;
-
-    const backgroundProcessManager = {
-      cleanup: mock((_workspaceId: string) => Promise.resolve()),
-      setMessageQueued: mock((_workspaceId: string, _queued: boolean) => {
-        void _queued;
-      }),
-    } as unknown as BackgroundProcessManager;
-
-    const session = new AgentSession({
-      workspaceId,
-      config,
-      historyService,
-      aiService,
-      initStateManager,
-      backgroundProcessManager,
-    });
-
     const result = await session.sendMessage("edited", {
-      model: "anthropic:claude-3-5-sonnet-latest",
+      model: TEST_MODEL,
       agentId: "exec",
       editMessageId: originalMessageId,
     });
 
     expect(result.success).toBe(true);
-    expect(getHistoryFromLatestBoundary.mock.calls.length).toBeGreaterThan(0);
     expect(truncateAfterMessage.mock.calls).toHaveLength(1);
     expect(appendToHistory.mock.calls).toHaveLength(1);
 
@@ -237,69 +158,83 @@ describe("AgentSession.sendMessage (editMessageId)", () => {
     expect(appendedFileParts[0].mediaType).toBe("image/png");
   });
 
-  it("acknowledges accepted edits before replacement stream startup settles", async () => {
-    const workspaceId = "ws-edit-ack";
-
-    const config = {
-      srcDir: "/tmp",
-      getSessionDir: (_workspaceId: string) => "/tmp",
-    } as unknown as Config;
-
-    const originalMessageId = "user-message-to-edit";
-    const { historyService, cleanup } = await createTestHistoryService();
-    historyCleanup = cleanup;
-
-    await historyService.appendToHistory(
-      workspaceId,
-      createMuxMessage(originalMessageId, "user", "original", { historySequence: 0 })
-    );
-
-    let resolveStreamMessage: ((result: Result<void, SendMessageError>) => void) | undefined;
-    const aiEmitter = new EventEmitter();
-    const streamMessage = mock((_messages: MuxMessage[]) => {
+  it("preempts a still-preparing turn when editing its last user message", async () => {
+    const workspaceId = "ws-edit-preparing";
+    const streamResolves: Array<() => void> = [];
+    const streamHandler: StreamMessageHandler = (opts) => {
       return new Promise<Result<void, SendMessageError>>((resolve) => {
-        resolveStreamMessage = resolve;
+        const resolveOk = () => resolve(Ok(undefined));
+        if (opts.abortSignal?.aborted === true) {
+          resolveOk();
+          return;
+        }
+        opts.abortSignal?.addEventListener("abort", resolveOk, { once: true });
+        streamResolves.push(resolveOk);
       });
-    });
-    const aiService = Object.assign(aiEmitter, {
-      isStreaming: mock((_workspaceId: string) => false),
-      stopStream: mock((_workspaceId: string) => Promise.resolve(Ok(undefined))),
-      streamMessage: streamMessage as unknown as (
-        ...args: Parameters<AIService["streamMessage"]>
-      ) => Promise<Result<void, SendMessageError>>,
-    }) as unknown as AIService;
-
-    const initStateManager = new EventEmitter() as unknown as InitStateManager;
-    const backgroundProcessManager = {
-      cleanup: mock((_workspaceId: string) => Promise.resolve()),
-      setMessageQueued: mock((_workspaceId: string, _queued: boolean) => {
-        void _queued;
-      }),
-    } as unknown as BackgroundProcessManager;
-
-    const session = new AgentSession({
+    };
+    const { session, historyService, streamMessage } = await createSessionHarness(
       workspaceId,
-      config,
-      historyService,
-      aiService,
-      initStateManager,
-      backgroundProcessManager,
-    });
+      streamHandler
+    );
+    const appendToHistory = spyOn(historyService, "appendToHistory");
 
-    const result = await session.sendMessage("edited", {
-      model: "anthropic:claude-3-5-sonnet-latest",
-      agentId: "exec",
-      editMessageId: originalMessageId,
-    });
+    try {
+      const firstSendPromise = session.sendMessage("original", {
+        model: TEST_MODEL,
+        agentId: "exec",
+      });
 
-    expect(result.success).toBe(true);
-    const sawStreamStartup = await waitForCondition(() => {
-      return streamMessage.mock.calls.length === 1 && resolveStreamMessage !== undefined;
-    });
-    expect(sawStreamStartup).toBe(true);
-    expect(session.isPreparingTurn()).toBe(true);
+      const sawPreparingTurn = await waitForCondition(
+        () => streamMessage.mock.calls.length === 1 && session.isPreparingTurn()
+      );
+      expect(sawPreparingTurn).toBe(true);
 
-    resolveStreamMessage?.(Ok(undefined));
-    await session.waitForIdle();
+      const originalMessage = appendToHistory.mock.calls
+        .map((call) => call[1])
+        .find((message) => message.role === "user" && message.parts[0]?.type === "text");
+      const originalMessageId = originalMessage?.id;
+      expect(typeof originalMessageId).toBe("string");
+
+      const editResult = await Promise.race([
+        session.sendMessage("edited", {
+          model: TEST_MODEL,
+          agentId: "exec",
+          editMessageId: originalMessageId,
+        }),
+        new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 250)),
+      ]);
+
+      expect(editResult).not.toBe("timeout");
+      expect(editResult).toEqual(Ok(undefined));
+
+      const sawReplacementStartup = await waitForCondition(
+        () => streamMessage.mock.calls.length === 2 && session.isPreparingTurn()
+      );
+      expect(sawReplacementStartup).toBe(true);
+
+      const history = await historyService.getHistoryFromLatestBoundary(workspaceId);
+      expect(history.success).toBe(true);
+      if (history.success) {
+        const userTexts = history.data
+          .filter((message) => message.role === "user")
+          .map((message) =>
+            message.parts
+              .filter((part) => part.type === "text")
+              .map((part) => part.text)
+              .join("")
+          );
+        expect(userTexts).toEqual(["edited"]);
+      }
+
+      for (const resolve of streamResolves) {
+        resolve();
+      }
+      await firstSendPromise;
+    } finally {
+      session.dispose();
+      for (const resolve of streamResolves) {
+        resolve();
+      }
+    }
   });
 });

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -309,6 +309,7 @@ export class AgentSession {
     [];
   private disposed = false;
   private turnPhase: TurnPhase = TurnPhase.IDLE;
+  private activePreparedTurnAbortController: AbortController | null = null;
   // When true, stream-end skips auto-flushing queued messages so an edit can truncate first.
   private deferQueuedFlushUntilAfterEdit = false;
   /** Guardrail against synthetic switch_agent ping-pong loops. */
@@ -505,6 +506,9 @@ export class AgentSession {
       return;
     }
     this.disposed = true;
+
+    this.activePreparedTurnAbortController?.abort();
+    this.activePreparedTurnAbortController = null;
 
     // Ensure any callers blocked on waitForIdle() can continue during teardown.
     this.setTurnPhase(TurnPhase.IDLE);
@@ -2065,6 +2069,8 @@ export class AgentSession {
     if (editMessageId) {
       // Ensure no in-flight completion code can append after we truncate.
       if (this.isBusy()) {
+        let preemptedPreparing = false;
+
         // If a turn is still PREPARING/STREAMING, interrupt aggressively — history is about to be
         // truncated.
         //
@@ -2085,10 +2091,22 @@ export class AgentSession {
           }
         }
 
+        if (this.turnPhase === TurnPhase.PREPARING && this.activePreparedTurnAbortController) {
+          // Last-message edits can arrive while the previous turn is still in startup.
+          // Abort it and mark idle so the edit can truncate immediately.
+          const abortController = this.activePreparedTurnAbortController;
+          this.activePreparedTurnAbortController = null;
+          abortController.abort();
+          this.setTurnPhase(TurnPhase.IDLE);
+          preemptedPreparing = true;
+        }
+
         // Tell stream-end to skip sendQueuedMessages() so the edit truncates first.
         this.deferQueuedFlushUntilAfterEdit = true;
         try {
-          await this.waitForIdle();
+          if (!preemptedPreparing) {
+            await this.waitForIdle();
+          }
 
           // Workspace teardown does not await in-flight async work; bail out if the session was
           // disposed while waiting for completion cleanup.
@@ -2477,10 +2495,15 @@ export class AgentSession {
     // Same-session retry should resume the exact accepted request we just finalized
     // in history, even if runtime warmup fails before streamWithHistory() starts.
     this.setAutoRetryResumeState(optionsForStream, agentInitiated);
+    const preparedTurnAbortController = new AbortController();
+    this.activePreparedTurnAbortController = preparedTurnAbortController;
     this.setTurnPhase(TurnPhase.PREPARING);
 
     const startPreparedStream = async (): Promise<Result<void, SendMessageError>> => {
       try {
+        if (preparedTurnAbortController.signal.aborted) {
+          return Ok(undefined);
+        }
         // If this is a compaction request, terminate background processes first.
         // They won't be included in the summary, so continuing with orphaned processes would be confusing.
         const isCompactionStreamRequest = isCompactionRequest || autoCompactionMessage !== null;
@@ -2496,7 +2519,7 @@ export class AgentSession {
         // and dispatched via dispatchPendingFollowUp() after compaction completes.
         // This provides crash safety - the follow-up survives app restarts.
 
-        if (this.disposed) {
+        if (this.disposed || preparedTurnAbortController.signal.aborted) {
           return Ok(undefined);
         }
 
@@ -2506,13 +2529,18 @@ export class AgentSession {
           optionsForStream,
           undefined,
           undefined,
-          agentInitiated
+          agentInitiated,
+          preparedTurnAbortController.signal
         );
       } finally {
         // Success should advance via stream events; if startup never emitted any, don't leave the
-        // session stuck in PREPARING.
-        if (this.turnPhase === TurnPhase.PREPARING) {
-          this.setTurnPhase(TurnPhase.IDLE);
+        // session stuck in PREPARING. Guard by controller identity so an aborted startup cannot
+        // mark the replacement edit's new PREPARING turn idle when it unwinds later.
+        if (this.activePreparedTurnAbortController === preparedTurnAbortController) {
+          this.activePreparedTurnAbortController = null;
+          if (this.turnPhase === TurnPhase.PREPARING) {
+            this.setTurnPhase(TurnPhase.IDLE);
+          }
         }
       }
     };
@@ -2996,9 +3024,12 @@ export class AgentSession {
     options?: SendMessageOptions,
     openaiTruncationModeOverride?: "auto" | "disabled",
     disablePostCompactionAttachments?: boolean,
-    agentInitiated?: boolean
+    agentInitiated?: boolean,
+    abortSignal?: AbortSignal
   ): Promise<Result<void, SendMessageError>> {
-    if (this.disposed) {
+    const isStartupAbortRequested = (): boolean => abortSignal?.aborted === true;
+
+    if (this.disposed || isStartupAbortRequested()) {
       return Ok(undefined);
     }
 
@@ -3025,7 +3056,15 @@ export class AgentSession {
       return Err(createUnknownSendMessageError(commitResult.error));
     }
 
+    if (isStartupAbortRequested()) {
+      return Ok(undefined);
+    }
+
     let historyResult = await this.historyService.getHistoryFromLatestBoundary(this.workspaceId);
+    if (isStartupAbortRequested()) {
+      return Ok(undefined);
+    }
+
     if (!historyResult.success) {
       return Err(createUnknownSendMessageError(historyResult.error));
     }
@@ -3070,14 +3109,26 @@ export class AgentSession {
       options
     );
 
+    if (isStartupAbortRequested()) {
+      return Ok(undefined);
+    }
+
     // Check for external file edits (timestamp-based polling)
     const changedFileAttachments = await this.fileChangeTracker.getChangedAttachments();
+
+    if (isStartupAbortRequested()) {
+      return Ok(undefined);
+    }
 
     // Check if post-compaction attachments should be injected.
     const postCompactionAttachments =
       disablePostCompactionAttachments === true
         ? null
         : await this.getPostCompactionAttachmentsIfNeeded();
+    if (isStartupAbortRequested()) {
+      return Ok(undefined);
+    }
+
     this.activeStreamHadPostCompactionInjection =
       postCompactionAttachments !== null && postCompactionAttachments.length > 0;
 
@@ -3100,6 +3151,7 @@ export class AgentSession {
       messages: historyResult.data,
       workspaceId: this.workspaceId,
       modelString,
+      abortSignal,
       thinkingLevel: effectiveThinkingLevel,
       toolPolicy: options?.toolPolicy,
       additionalSystemInstructions: options?.additionalSystemInstructions,


### PR DESCRIPTION
Summary
- Fix last-message edits that could hang while the previous turn was still in pre-stream startup.
- Keep the PR LoC-negative by deduplicating edit-message tests while adding the startup-edit regression coverage.

Background
Editing is implemented as truncate + replacement send. If the previous turn was still PREPARING, the edit path could wait for idle even though the startup was being superseded, leaving the edited message invisible.

Implementation
- Track the active prepared turn with an AbortController.
- When an edit preempts a PREPARING turn, abort that startup, mark the session idle, and proceed with truncation immediately.
- Guard the old startup cleanup by controller identity so it cannot mark the replacement edit turn idle when it unwinds later.
- Thread the abort signal into stream startup so stale pre-stream work exits before launching an obsolete stream.

Validation
- `bun test src/node/services/agentSession.editMessageId.test.ts`
- `bun test ./tests/ipc/streaming/queuedMessages.starting.test.ts ./tests/ipc/streaming/interrupt.test.ts`
- `make static-check`

Risks
- Touches turn-phase/pre-stream startup flow. Risk is mitigated by preserving the existing stream lifecycle behavior for non-edit sends and adding a targeted regression test for PREPARING edit preemption.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `high` • Cost: `$34.11`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=high costs=34.11 -->
