### PR TITLE
🤖 feat: inline $skill references with autocomplete and hover previews

### DIFF
--- a/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
@@ -30,7 +30,6 @@ import * as TooltipModule from "../Tooltip/Tooltip";
 import * as SidebarCollapseButtonModule from "../SidebarCollapseButton/SidebarCollapseButton";
 import * as ConfirmationModalModule from "../ConfirmationModal/ConfirmationModal";
 import * as ProjectDeleteConfirmationModalModule from "../ProjectDeleteConfirmationModal/ProjectDeleteConfirmationModal";
-import * as WorkspaceStatusIndicatorModule from "../WorkspaceStatusIndicator/WorkspaceStatusIndicator";
 import * as PopoverErrorModule from "../PopoverError/PopoverError";
 import * as SectionHeaderModule from "../SectionHeader/SectionHeader";
 import * as WorkspaceSectionDropZoneModule from "../WorkspaceSectionDropZone/WorkspaceSectionDropZone";
@@ -480,9 +479,9 @@ function installProjectSidebarTestDoubles() {
         <div data-testid="project-delete-confirmation-modal">{props.projectName}</div>
       ) : null) as unknown as typeof ProjectDeleteConfirmationModalModule.ProjectDeleteConfirmationModal
   );
-  spyOn(WorkspaceStatusIndicatorModule, "WorkspaceStatusIndicator").mockImplementation((() => (
-    <div data-testid="workspace-status-indicator" />
-  )) as unknown as typeof WorkspaceStatusIndicatorModule.WorkspaceStatusIndicator);
+  void mock.module("../WorkspaceStatusIndicator/WorkspaceStatusIndicator", () => ({
+    WorkspaceStatusIndicator: () => <div data-testid="workspace-status-indicator" />,
+  }));
   spyOn(PopoverErrorModule, "PopoverError").mockImplementation(
     (() => null) as unknown as typeof PopoverErrorModule.PopoverError
   );

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
@@ -38,12 +38,38 @@ import * as SectionDragLayerModule from "../SectionDragLayer/SectionDragLayer";
 import * as DraggableSectionModule from "../DraggableSection/DraggableSection";
 import { updatePersistedState } from "@/browser/hooks/usePersistedState";
 import type ProjectSidebarComponent from "./ProjectSidebar";
+import type * as WorkspaceStatusIndicatorModuleExports from "../WorkspaceStatusIndicator/WorkspaceStatusIndicator";
 
 const agentItemTestId = (workspaceId: string) => `agent-item-${workspaceId}`;
 const toggleButtonLabel = (workspaceId: string) => `toggle-completed-${workspaceId}`;
 
 function TestWrapper(props: PropsWithChildren) {
   return <>{props.children}</>;
+}
+
+const ProviderIconSvgStub = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg data-testid="provider-icon-mock" {...props} />
+);
+
+function installProviderIconSvgMocks() {
+  const providerIconSvgPaths = [
+    "@/browser/assets/icons/anthropic.svg?react",
+    "@/browser/assets/icons/openai.svg?react",
+    "@/browser/assets/icons/google.svg?react",
+    "@/browser/assets/icons/xai.svg?react",
+    "@/browser/assets/icons/openrouter.svg?react",
+    "@/browser/assets/icons/ollama.svg?react",
+    "@/browser/assets/icons/deepseek.svg?react",
+    "@/browser/assets/icons/aws.svg?react",
+    "@/browser/assets/icons/github.svg?react",
+  ] as const;
+
+  for (const svgPath of providerIconSvgPaths) {
+    void mock.module(svgPath, () => ({
+      __esModule: true,
+      default: ProviderIconSvgStub,
+    }));
+  }
 }
 
 const passthroughRef = <T,>(value: T): T => value;
@@ -479,9 +505,14 @@ function installProjectSidebarTestDoubles() {
         <div data-testid="project-delete-confirmation-modal">{props.projectName}</div>
       ) : null) as unknown as typeof ProjectDeleteConfirmationModalModule.ProjectDeleteConfirmationModal
   );
-  void mock.module("../WorkspaceStatusIndicator/WorkspaceStatusIndicator", () => ({
-    WorkspaceStatusIndicator: () => <div data-testid="workspace-status-indicator" />,
-  }));
+  installProviderIconSvgMocks();
+  /* eslint-disable @typescript-eslint/no-require-imports */
+  const WorkspaceStatusIndicatorModule =
+    require("../WorkspaceStatusIndicator/WorkspaceStatusIndicator") as typeof WorkspaceStatusIndicatorModuleExports;
+  /* eslint-enable @typescript-eslint/no-require-imports */
+  spyOn(WorkspaceStatusIndicatorModule, "WorkspaceStatusIndicator").mockImplementation((() => (
+    <div data-testid="workspace-status-indicator" />
+  )) as unknown as typeof WorkspaceStatusIndicatorModule.WorkspaceStatusIndicator);
   spyOn(PopoverErrorModule, "PopoverError").mockImplementation(
     (() => null) as unknown as typeof PopoverErrorModule.PopoverError
   );

--- a/src/browser/components/WorkspaceHeartbeatModal/WorkspaceHeartbeatModal.test.tsx
+++ b/src/browser/components/WorkspaceHeartbeatModal/WorkspaceHeartbeatModal.test.tsx
@@ -1,7 +1,7 @@
 import "../../../../tests/ui/dom";
 
 import type { ReactNode } from "react";
-import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { afterEach, afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { installDom } from "../../../../tests/ui/dom";
 import * as APIModule from "@/browser/contexts/API";
@@ -13,6 +13,20 @@ import {
   HEARTBEAT_DEFAULT_INTERVAL_MS,
   HEARTBEAT_DEFAULT_MESSAGE_BODY,
 } from "@/constants/heartbeat";
+import * as WorkspaceContextModule from "@/browser/contexts/WorkspaceContext";
+const actualWorkspaceContextModule = { ...WorkspaceContextModule };
+const setWorkspaceMetadataMock = mock(() => undefined);
+
+async function installWorkspaceHeartbeatModalMocks() {
+  await mock.module("@/browser/contexts/WorkspaceContext", () => ({
+    ...actualWorkspaceContextModule,
+    useWorkspaceActions: () => ({ setWorkspaceMetadata: setWorkspaceMetadataMock }),
+  }));
+}
+
+async function restoreWorkspaceHeartbeatModalMocks() {
+  await mock.module("@/browser/contexts/WorkspaceContext", () => actualWorkspaceContextModule);
+}
 
 void mock.module("@/browser/components/Dialog/Dialog", () => ({
   Dialog: (props: { open: boolean; children: ReactNode }) =>
@@ -81,7 +95,8 @@ function createConnectedUseAPIResult(api: WorkspaceHeartbeatTestAPI): ConnectedU
 const LONG_HEARTBEAT_MESSAGE = "Review pending work and summarize next steps. ".repeat(30).trim();
 
 describe("WorkspaceHeartbeatModal", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await installWorkspaceHeartbeatModalMocks();
     cleanupDom = installDom();
     settingsByWorkspaceId = new Map<string, HeartbeatFormSettings>();
     saveCalls = [];
@@ -119,7 +134,8 @@ describe("WorkspaceHeartbeatModal", () => {
     });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await restoreWorkspaceHeartbeatModalMocks();
     cleanup();
     mock.restore();
     cleanupDom?.();
@@ -413,4 +429,8 @@ describe("WorkspaceHeartbeatModal", () => {
       ]);
     });
   });
+});
+
+afterAll(async () => {
+  await restoreWorkspaceHeartbeatModalMocks();
 });

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -59,6 +59,8 @@ import {
 import { Button } from "@/browser/components/Button/Button";
 import { CUSTOM_EVENTS } from "@/common/constants/events";
 import { findAtMentionAtCursor } from "@/common/utils/atMentions";
+import { findInlineSkillReferenceAtCursor } from "@/browser/utils/agentSkills/inlineSkillReferences";
+import { getInlineSkillSuggestions } from "@/browser/utils/agentSkills/inlineSkillSuggestions";
 import { getCommandGhostHint } from "@/browser/utils/slashCommands/registry";
 import {
   getSlashCommandSuggestions,
@@ -279,12 +281,16 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const [hideReviewsDuringSend, setHideReviewsDuringSend] = useState(false);
   const [showAtMentionSuggestions, setShowAtMentionSuggestions] = useState(false);
   const [atMentionSuggestions, setAtMentionSuggestions] = useState<SlashSuggestion[]>([]);
+  const [showSkillSuggestions, setShowSkillSuggestions] = useState(false);
+  const [skillSuggestions, setSkillSuggestions] = useState<SlashSuggestion[]>([]);
   const agentSkillsRequestIdRef = useRef(0);
   const atMentionDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const atMentionRequestIdRef = useRef(0);
   const lastAtMentionScopeIdRef = useRef<string | null>(null);
   const lastAtMentionQueryRef = useRef<string | null>(null);
   const lastAtMentionInputRef = useRef<string>(input);
+  const lastSkillInputRef = useRef<string | null>(null);
+  const lastSkillQueryRef = useRef<string | null>(null);
   const [showCommandSuggestions, setShowCommandSuggestions] = useState(false);
 
   const [commandSuggestions, setCommandSuggestions] = useState<SlashSuggestion[]>([]);
@@ -533,6 +539,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     }
   );
   const atMentionListId = useId();
+  const skillListId = useId();
   const commandListId = useId();
   const telemetry = useTelemetry();
   const [vimEnabled, setVimEnabled] = usePersistedState<boolean>(VIM_ENABLED_KEY, false, {
@@ -1322,6 +1329,50 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     atMentionCursorNonce,
   ]);
 
+  // Watch input/cursor for inline $skill references
+  useEffect(() => {
+    if (showAtMentionSuggestions) {
+      // File mentions win precedence if an edge-case token could match both menus.
+      setSkillSuggestions((prev) => (prev.length === 0 ? prev : []));
+      setShowSkillSuggestions(false);
+      lastSkillQueryRef.current = null;
+      return;
+    }
+
+    const inputChanged = lastSkillInputRef.current !== input;
+    lastSkillInputRef.current = input;
+
+    const cursor = Math.min(inputRef.current?.selectionStart ?? input.length, input.length);
+    const match = findInlineSkillReferenceAtCursor(input, cursor);
+
+    if (!match) {
+      setSkillSuggestions([]);
+      setShowSkillSuggestions(false);
+      lastSkillQueryRef.current = null;
+      return;
+    }
+
+    // Avoid recomputing on caret movement within the same partial. Moving out of a token
+    // clears lastSkillQueryRef above, so moving back into an existing token can reopen.
+    if (!inputChanged && lastSkillQueryRef.current === match.partial) {
+      return;
+    }
+
+    lastSkillQueryRef.current = match.partial;
+
+    const nextSuggestions = getInlineSkillSuggestions({
+      partial: match.partial,
+      descriptors: agentSkillDescriptors,
+    });
+    setSkillSuggestions(nextSuggestions);
+    setShowSkillSuggestions(nextSuggestions.length > 0);
+  }, [
+    input,
+    showAtMentionSuggestions,
+    agentSkillDescriptors,
+    atMentionCursorNonce,
+  ]);
+
   // Watch input for slash commands
   useEffect(() => {
     const suggestions = getSlashCommandSuggestions(input, {
@@ -1933,6 +1984,40 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     },
     [input, setInput]
   );
+  const handleSkillSelect = useCallback(
+    (suggestion: SlashSuggestion) => {
+      const cursor = Math.min(inputRef.current?.selectionStart ?? input.length, input.length);
+      const match = findInlineSkillReferenceAtCursor(input, cursor);
+      if (!match) {
+        return;
+      }
+
+      // Add a separating space only when the following text does not already provide one.
+      const after = input.slice(match.endIndex);
+      const trailing = after.length === 0 || /\s/.test(after[0] ?? "") ? "" : " ";
+      const next =
+        input.slice(0, match.startIndex) + suggestion.replacement + trailing + after;
+
+      setInput(next);
+      setSkillSuggestions([]);
+      setShowSkillSuggestions(false);
+      lastSkillQueryRef.current = null;
+
+      requestAnimationFrame(() => {
+        const el = inputRef.current;
+        if (!el || el.disabled) {
+          return;
+        }
+
+        el.focus();
+        const newCursor = match.startIndex + suggestion.replacement.length + trailing.length;
+        el.selectionStart = newCursor;
+        el.selectionEnd = newCursor;
+      });
+    },
+    [input, setInput]
+  );
+
   const handleCommandSelect = useCallback(
     (suggestion: SlashSuggestion) => {
       setInput(suggestion.replacement);
@@ -2407,12 +2492,14 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
     const hasCommandSuggestionMenu = showCommandSuggestions && commandSuggestions.length > 0;
     const hasAtMentionSuggestionMenu = showAtMentionSuggestions && atMentionSuggestions.length > 0;
+    const hasSkillSuggestionMenu = showSkillSuggestions && skillSuggestions.length > 0;
 
     // Don't handle keys if suggestions are visible.
-    // Enter/Tab/arrows/Escape are handled by CommandSuggestions for both slash and @mention menus.
+    // Enter/Tab/arrows/Escape are handled by CommandSuggestions for slash, @file, and $skill menus.
     if (
       (hasCommandSuggestionMenu && COMMAND_SUGGESTION_KEYS.includes(e.key)) ||
-      (hasAtMentionSuggestionMenu && FILE_SUGGESTION_KEYS.includes(e.key))
+      (hasAtMentionSuggestionMenu && FILE_SUGGESTION_KEYS.includes(e.key)) ||
+      (hasSkillSuggestionMenu && FILE_SUGGESTION_KEYS.includes(e.key))
     ) {
       return; // Let CommandSuggestions handle it
     }
@@ -2561,6 +2648,18 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
             isFileSuggestion
           />
 
+          {/* Skill suggestions ($deep-review) */}
+          <CommandSuggestions
+            suggestions={skillSuggestions}
+            onSelectSuggestion={handleSkillSelect}
+            onDismiss={() => setShowSkillSuggestions(false)}
+            isVisible={showSkillSuggestions}
+            ariaLabel="Skill suggestions"
+            listId={skillListId}
+            anchorRef={variant === "creation" ? inputRef : undefined}
+            highlightQuery={lastSkillQueryRef.current ?? ""}
+          />
+
           {/* Slash command suggestions - available in both variants */}
           {/* In creation mode, use portal (anchorRef) to escape overflow:hidden containers */}
           <CommandSuggestions
@@ -2604,9 +2703,11 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                   suppressKeys={
                     showAtMentionSuggestions
                       ? FILE_SUGGESTION_KEYS
-                      : showCommandSuggestions
-                        ? COMMAND_SUGGESTION_KEYS
-                        : undefined
+                      : showSkillSuggestions
+                        ? FILE_SUGGESTION_KEYS
+                        : showCommandSuggestions
+                          ? COMMAND_SUGGESTION_KEYS
+                          : undefined
                   }
                   placeholder={placeholder}
                   disabled={!editingMessageForUi && (disabled || sendInFlightBlocksInput)}
@@ -2615,13 +2716,16 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                   aria-controls={
                     showAtMentionSuggestions && atMentionSuggestions.length > 0
                       ? atMentionListId
-                      : showCommandSuggestions && commandSuggestions.length > 0
-                        ? commandListId
-                        : undefined
+                      : showSkillSuggestions && skillSuggestions.length > 0
+                        ? skillListId
+                        : showCommandSuggestions && commandSuggestions.length > 0
+                          ? commandListId
+                          : undefined
                   }
                   aria-expanded={
                     (showCommandSuggestions && commandSuggestions.length > 0) ||
-                    (showAtMentionSuggestions && atMentionSuggestions.length > 0)
+                    (showAtMentionSuggestions && atMentionSuggestions.length > 0) ||
+                    (showSkillSuggestions && skillSuggestions.length > 0)
                   }
                   className={variant === "creation" ? "min-h-28" : "min-h-16"}
                   trailingAction={

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -1366,12 +1366,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     });
     setSkillSuggestions(nextSuggestions);
     setShowSkillSuggestions(nextSuggestions.length > 0);
-  }, [
-    input,
-    showAtMentionSuggestions,
-    agentSkillDescriptors,
-    atMentionCursorNonce,
-  ]);
+  }, [input, showAtMentionSuggestions, agentSkillDescriptors, atMentionCursorNonce]);
 
   // Watch input for slash commands
   useEffect(() => {
@@ -1995,8 +1990,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       // Add a separating space only when the following text does not already provide one.
       const after = input.slice(match.endIndex);
       const trailing = after.length === 0 || /\s/.test(after[0] ?? "") ? "" : " ";
-      const next =
-        input.slice(0, match.startIndex) + suggestion.replacement + trailing + after;
+      const next = input.slice(0, match.startIndex) + suggestion.replacement + trailing + after;
 
       setInput(next);
       setSkillSuggestions([]);

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -60,7 +60,11 @@ import { Button } from "@/browser/components/Button/Button";
 import { CUSTOM_EVENTS } from "@/common/constants/events";
 import { findAtMentionAtCursor } from "@/common/utils/atMentions";
 import { findInlineSkillReferenceAtCursor } from "@/browser/utils/agentSkills/inlineSkillReferences";
-import { getInlineSkillSuggestions } from "@/browser/utils/agentSkills/inlineSkillSuggestions";
+import {
+  getInlineSkillInsertionTrailingText,
+  getInlineSkillSuggestions,
+  shouldRefreshInlineSkillSuggestions,
+} from "@/browser/utils/agentSkills/inlineSkillSuggestions";
 import { getCommandGhostHint } from "@/browser/utils/slashCommands/registry";
 import {
   getSlashCommandSuggestions,
@@ -291,6 +295,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const lastAtMentionInputRef = useRef<string>(input);
   const lastSkillInputRef = useRef<string | null>(null);
   const lastSkillQueryRef = useRef<string | null>(null);
+  const lastSkillDescriptorsRef = useRef<AgentSkillDescriptor[] | null>(null);
   const [showCommandSuggestions, setShowCommandSuggestions] = useState(false);
 
   const [commandSuggestions, setCommandSuggestions] = useState<SlashSuggestion[]>([]);
@@ -1352,9 +1357,17 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       return;
     }
 
-    // Avoid recomputing on caret movement within the same partial. Moving out of a token
-    // clears lastSkillQueryRef above, so moving back into an existing token can reopen.
-    if (!inputChanged && lastSkillQueryRef.current === match.partial) {
+    // Avoid recomputing on caret movement within the same partial, but still refresh when
+    // skill discovery finishes asynchronously for already-typed `$partial` input.
+    if (
+      !shouldRefreshInlineSkillSuggestions({
+        inputChanged,
+        previousPartial: lastSkillQueryRef.current,
+        partial: match.partial,
+        previousDescriptors: lastSkillDescriptorsRef.current,
+        descriptors: agentSkillDescriptors,
+      })
+    ) {
       return;
     }
 
@@ -1364,6 +1377,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       partial: match.partial,
       descriptors: agentSkillDescriptors,
     });
+    lastSkillDescriptorsRef.current = agentSkillDescriptors;
     setSkillSuggestions(nextSuggestions);
     setShowSkillSuggestions(nextSuggestions.length > 0);
   }, [input, showAtMentionSuggestions, agentSkillDescriptors, atMentionCursorNonce]);
@@ -1989,7 +2003,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
       // Add a separating space only when the following text does not already provide one.
       const after = input.slice(match.endIndex);
-      const trailing = after.length === 0 || /\s/.test(after[0] ?? "") ? "" : " ";
+      const trailing = getInlineSkillInsertionTrailingText(after);
       const next = input.slice(0, match.startIndex) + suggestion.replacement + trailing + after;
 
       setInput(next);

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -106,6 +106,7 @@ import {
   type MuxMessageMetadata,
   type ReviewNoteDataForDisplay,
   prepareUserMessageForSend,
+  withAgentSkillRefs,
 } from "@/common/types/message";
 import type { Review } from "@/common/types/review";
 import {
@@ -138,7 +139,9 @@ import { RecordingOverlay } from "./RecordingOverlay";
 import { AttachedReviewsPanel } from "./AttachedReviewsPanel";
 import {
   buildSkillInvocationMetadata,
+  hasProjectScopedSkillRef,
   parseCommandWithSkillInvocation,
+  resolveInlineSkillRefsForSend,
   validateCreationRuntime,
   filePartsToChatAttachments,
   type SkillResolutionTarget,
@@ -1965,6 +1968,13 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       api,
       discovery: skillDiscovery,
     });
+    const combinedSkillRefs = await resolveInlineSkillRefsForSend({
+      messageText,
+      slashInvocation: skillInvocation,
+      agentSkillDescriptors,
+      api,
+      discovery: skillDiscovery,
+    });
 
     // Route to creation handler for creation variant
     if (variant === "creation") {
@@ -1983,14 +1993,22 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         }
 
         creationMessageTextForSend = skillInvocation.userText;
+      }
+
+      if (combinedSkillRefs.length > 0) {
+        const baseMetadata = skillInvocation
+          ? buildSkillInvocationMetadata(messageText, skillInvocation.descriptor)
+          : undefined;
+        const muxMetadata = withAgentSkillRefs(baseMetadata, combinedSkillRefs);
+        if (!muxMetadata) {
+          throw new Error("Expected skill metadata when skill refs are present");
+        }
+
         creationOptionsOverride = {
-          muxMetadata: buildSkillInvocationMetadata(messageText, skillInvocation.descriptor),
-          // In the creation flow, skills are discovered from the project path. If the skill is
-          // project-scoped (often untracked in git), it may not exist in the new worktree.
+          muxMetadata,
+          // In the creation flow, project-scoped skills may not exist in the new worktree.
           // Force project-path discovery for this send so resolution matches suggestions.
-          ...(skillInvocation.descriptor.scope === "project"
-            ? { disableWorkspaceAgents: true }
-            : {}),
+          ...(hasProjectScopedSkillRef(combinedSkillRefs) ? { disableWorkspaceAgents: true } : {}),
         };
       }
 
@@ -2120,6 +2138,9 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         // When editing a /compact command, regenerate the actual summarization request
         let actualMessageText = messageTextForSend;
         let muxMetadata: MuxMessageMetadata | undefined = skillMuxMetadata;
+        if (combinedSkillRefs.length > 0) {
+          muxMetadata = withAgentSkillRefs(muxMetadata, combinedSkillRefs);
+        }
         let compactionOptions: Partial<SendMessageOptions> = {};
 
         if (editMessageForSend && actualMessageText.startsWith("/")) {

--- a/src/browser/features/ChatInput/useCreationWorkspace.test.tsx
+++ b/src/browser/features/ChatInput/useCreationWorkspace.test.tsx
@@ -1,6 +1,10 @@
 import type { APIClient } from "@/browser/contexts/API";
+import * as APIModule from "@/browser/contexts/API";
+import * as ProjectContextModule from "@/browser/contexts/ProjectContext";
+import * as RouterContextModule from "@/browser/contexts/RouterContext";
 import type { DraftWorkspaceSettings } from "@/browser/hooks/useDraftWorkspaceSettings";
 import * as PersistedStateModule from "@/browser/hooks/usePersistedState";
+import * as DraftWorkspaceSettingsModule from "@/browser/hooks/useDraftWorkspaceSettings";
 import type { ProjectConfig } from "@/common/types/project";
 import {
   GLOBAL_SCOPE_ID,
@@ -25,7 +29,7 @@ import type {
   WorkspaceActivitySnapshot,
 } from "@/common/types/workspace";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { GlobalWindow } from "happy-dom";
 import { useCreationWorkspace, type CreationSendResult } from "./useCreationWorkspace";
 
@@ -126,9 +130,10 @@ const useDraftWorkspaceSettingsMock = mock(
   }
 );
 
-void mock.module("@/browser/hooks/useDraftWorkspaceSettings", () => ({
-  useDraftWorkspaceSettings: useDraftWorkspaceSettingsMock,
-}));
+const actualAPIModule = { ...APIModule };
+const actualDraftWorkspaceSettingsModule = { ...DraftWorkspaceSettingsModule };
+const actualProjectContextModule = { ...ProjectContextModule };
+const actualRouterContextModule = { ...RouterContextModule };
 
 let currentORPCClient: MockOrpcClient | null = null;
 const noop = () => undefined;
@@ -138,67 +143,88 @@ const routerState = {
   pendingDraftId: null as string | null,
 };
 
-void mock.module("@/browser/contexts/RouterContext", () => ({
-  useRouter: () => ({
-    navigateToWorkspace: noop,
-    navigateToProject: noop,
-    navigateToHome: noop,
-    currentWorkspaceId: routerState.currentWorkspaceId,
-    currentProjectId: routerState.currentProjectId,
-    currentProjectPathFromState: null,
-    pendingSectionId: null,
-    pendingDraftId: routerState.pendingDraftId,
-  }),
-}));
-
-void mock.module("@/browser/contexts/API", () => ({
-  useAPI: () => {
-    if (!currentORPCClient) {
-      return { api: null, status: "connecting" as const, error: null };
-    }
-    return {
-      api: currentORPCClient as APIClient,
-      status: "connected" as const,
-      error: null,
-    };
-  },
-}));
-
 // Synchronous mock for useProjectContext — eliminates the async race from
 // ProjectProvider's useEffect → refreshProjects() that caused CI-only hangs.
 // Tests that need untrusted projects set mockProjectConfigMap directly.
 let mockProjectConfigMap = new Map<string, ProjectConfig>();
 
-void mock.module("@/browser/contexts/ProjectContext", () => ({
-  useProjectContext: () => ({
-    loading: false,
-    getProjectConfig: (path: string) => mockProjectConfigMap.get(path),
-    refreshProjects: mock(() => Promise.resolve()),
-    userProjects: mockProjectConfigMap,
-    hasAnyProject: mockProjectConfigMap.size > 0,
-    systemProjectPath: null,
-    resolveProjectPath: () => null,
-    addProject: noop,
-    removeProject: mock(() => Promise.resolve({ success: true })),
-    isProjectCreateModalOpen: false,
-    openProjectCreateModal: noop,
-    closeProjectCreateModal: noop,
-    workspaceModalState: { isOpen: false },
-    openWorkspaceModal: mock(() => Promise.resolve()),
-    closeWorkspaceModal: noop,
-    getBranchesForProject: mock(() => Promise.resolve({ branches: [], recommendedTrunk: null })),
-    getSecrets: mock(() => Promise.resolve([])),
-    updateSecrets: mock(() => Promise.resolve()),
-    updateDisplayName: mock(() => Promise.resolve({ success: true })),
-    createSection: mock(() => Promise.resolve({ success: true })),
-    updateSection: mock(() => Promise.resolve({ success: true })),
-    removeSection: mock(() => Promise.resolve({ success: true })),
-    reorderSections: mock(() => Promise.resolve({ success: true })),
-    assignWorkspaceToSection: mock(() => Promise.resolve({ success: true })),
-    resolveNewChatProjectPath: () => null,
-  }),
-  ProjectProvider: (props: Record<string, unknown>) => props.children,
-}));
+// Keep module mocks inside test hooks: Bun loads test files before afterAll runs, so
+// file-scope mock.module() calls can pollute unrelated files during collection.
+async function installUseCreationWorkspaceModuleMocks() {
+  await mock.module("@/browser/hooks/useDraftWorkspaceSettings", () => ({
+    ...actualDraftWorkspaceSettingsModule,
+    useDraftWorkspaceSettings: useDraftWorkspaceSettingsMock,
+  }));
+  await mock.module("@/browser/contexts/RouterContext", () => ({
+    ...actualRouterContextModule,
+    useRouter: () => ({
+      navigateToWorkspace: noop,
+      navigateToProject: noop,
+      navigateToHome: noop,
+      currentWorkspaceId: routerState.currentWorkspaceId,
+      currentProjectId: routerState.currentProjectId,
+      currentProjectPathFromState: null,
+      pendingSectionId: null,
+      pendingDraftId: routerState.pendingDraftId,
+    }),
+  }));
+  await mock.module("@/browser/contexts/API", () => ({
+    ...actualAPIModule,
+    useAPI: () => {
+      if (!currentORPCClient) {
+        return { api: null, status: "connecting" as const, error: null };
+      }
+      return {
+        api: currentORPCClient as APIClient,
+        status: "connected" as const,
+        error: null,
+      };
+    },
+  }));
+  await mock.module("@/browser/contexts/ProjectContext", () => ({
+    ...actualProjectContextModule,
+    useProjectContext: () => ({
+      loading: false,
+      getProjectConfig: (path: string) => mockProjectConfigMap.get(path),
+      refreshProjects: mock(() => Promise.resolve()),
+      userProjects: mockProjectConfigMap,
+      hasAnyProject: mockProjectConfigMap.size > 0,
+      systemProjectPath: null,
+      resolveProjectPath: () => null,
+      addProject: noop,
+      removeProject: mock(() => Promise.resolve({ success: true })),
+      isProjectCreateModalOpen: false,
+      openProjectCreateModal: noop,
+      closeProjectCreateModal: noop,
+      workspaceModalState: { isOpen: false },
+      openWorkspaceModal: mock(() => Promise.resolve()),
+      closeWorkspaceModal: noop,
+      getBranchesForProject: mock(() => Promise.resolve({ branches: [], recommendedTrunk: null })),
+      getSecrets: mock(() => Promise.resolve([])),
+      updateSecrets: mock(() => Promise.resolve()),
+      updateDisplayName: mock(() => Promise.resolve({ success: true })),
+      createSection: mock(() => Promise.resolve({ success: true })),
+      updateSection: mock(() => Promise.resolve({ success: true })),
+      removeSection: mock(() => Promise.resolve({ success: true })),
+      reorderSections: mock(() => Promise.resolve({ success: true })),
+      assignWorkspaceToSection: mock(() => Promise.resolve({ success: true })),
+      resolveNewChatProjectPath: () => null,
+    }),
+    ProjectProvider: (props: Record<string, unknown>) => props.children,
+  }));
+}
+
+async function restoreUseCreationWorkspaceModuleMocks() {
+  // Bun's mock.module() has no disposer, and mock.restore() does not undo module
+  // mocks. Restore the real exports so these stubs do not leak into later files.
+  await mock.module(
+    "@/browser/hooks/useDraftWorkspaceSettings",
+    () => actualDraftWorkspaceSettingsModule
+  );
+  await mock.module("@/browser/contexts/RouterContext", () => actualRouterContextModule);
+  await mock.module("@/browser/contexts/API", () => actualAPIModule);
+  await mock.module("@/browser/contexts/ProjectContext", () => actualProjectContextModule);
+}
 
 const TEST_PROJECT_PATH = "/projects/demo";
 const FALLBACK_BRANCH = "main";
@@ -484,7 +510,12 @@ const TEST_METADATA: FrontendWorkspaceMetadata = {
 describe("useCreationWorkspace", () => {
   let restorePersistedStateMocks: (() => void) | null = null;
 
-  beforeEach(() => {
+  afterAll(async () => {
+    await restoreUseCreationWorkspaceModuleMocks();
+  });
+
+  beforeEach(async () => {
+    await installUseCreationWorkspaceModuleMocks();
     restorePersistedStateMocks = installPersistedStateMocks();
     mockProjectConfigMap = new Map([[TEST_PROJECT_PATH, { workspaces: [], trusted: true }]]);
     persistedPreferences = {};
@@ -497,10 +528,11 @@ describe("useCreationWorkspace", () => {
     routerState.pendingDraftId = null;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     cleanup();
     restorePersistedStateMocks?.();
     restorePersistedStateMocks = null;
+    await restoreUseCreationWorkspaceModuleMocks();
     mock.restore();
     // Reset global window/document/localStorage between tests
     // @ts-expect-error - test cleanup

--- a/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
+++ b/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
+import {
+  hasProjectScopedSkillRef,
+  resolveInlineSkillRefsForSend,
+  type SkillInvocation,
+} from "./utils";
+
+function descriptor(
+  name: string,
+  scope: AgentSkillDescriptor["scope"] = "global"
+): AgentSkillDescriptor {
+  return { name, description: `${name} description`, scope };
+}
+
+function slashInvocation(skill: AgentSkillDescriptor): SkillInvocation {
+  return {
+    descriptor: skill,
+    userText: `Using skill ${skill.name}: message`,
+  };
+}
+
+describe("resolveInlineSkillRefsForSend", () => {
+  test("returns an empty array for no slash and no inline refs", async () => {
+    await expect(
+      resolveInlineSkillRefsForSend({
+        messageText: "Please help",
+        slashInvocation: null,
+        agentSkillDescriptors: [descriptor("tdd")],
+        api: null,
+        discovery: null,
+      })
+    ).resolves.toEqual([]);
+  });
+
+  test("returns a single slash ref for slash-only invocation", async () => {
+    const tdd = descriptor("tdd", "project");
+
+    await expect(
+      resolveInlineSkillRefsForSend({
+        messageText: "/tdd Please help",
+        slashInvocation: slashInvocation(tdd),
+        agentSkillDescriptors: [tdd],
+        api: null,
+        discovery: null,
+      })
+    ).resolves.toEqual([{ skillName: "tdd", scope: "project", source: "slash" }]);
+  });
+
+  test("returns inline refs in first-appearance order", async () => {
+    await expect(
+      resolveInlineSkillRefsForSend({
+        messageText: "Use $deep-review and then $tdd",
+        slashInvocation: null,
+        agentSkillDescriptors: [descriptor("tdd"), descriptor("deep-review", "project")],
+        api: null,
+        discovery: null,
+      })
+    ).resolves.toEqual([
+      { skillName: "deep-review", scope: "project", source: "inline" },
+      { skillName: "tdd", scope: "global", source: "inline" },
+    ]);
+  });
+
+  test("collapses duplicate inline refs", async () => {
+    await expect(
+      resolveInlineSkillRefsForSend({
+        messageText: "Use $tdd and $tdd again",
+        slashInvocation: null,
+        agentSkillDescriptors: [descriptor("tdd")],
+        api: null,
+        discovery: null,
+      })
+    ).resolves.toEqual([{ skillName: "tdd", scope: "global", source: "inline" }]);
+  });
+
+  test("keeps slash first and appends inline refs for mixed messages", async () => {
+    const deepReview = descriptor("deep-review", "project");
+
+    await expect(
+      resolveInlineSkillRefsForSend({
+        messageText: "/deep-review Please also follow $tdd",
+        slashInvocation: slashInvocation(deepReview),
+        agentSkillDescriptors: [deepReview, descriptor("tdd")],
+        api: null,
+        discovery: null,
+      })
+    ).resolves.toEqual([
+      { skillName: "deep-review", scope: "project", source: "slash" },
+      { skillName: "tdd", scope: "global", source: "inline" },
+    ]);
+  });
+
+  test("keeps only the slash ref when inline repeats the slash skill", async () => {
+    const tdd = descriptor("tdd", "project");
+
+    await expect(
+      resolveInlineSkillRefsForSend({
+        messageText: "/tdd Please also follow $tdd",
+        slashInvocation: slashInvocation(tdd),
+        agentSkillDescriptors: [tdd],
+        api: null,
+        discovery: null,
+      })
+    ).resolves.toEqual([{ skillName: "tdd", scope: "project", source: "slash" }]);
+  });
+
+  test("ignores currency-like dollar tokens", async () => {
+    await expect(
+      resolveInlineSkillRefsForSend({
+        messageText: "This costs $100",
+        slashInvocation: null,
+        agentSkillDescriptors: [descriptor("tdd")],
+        api: null,
+        discovery: null,
+      })
+    ).resolves.toEqual([]);
+  });
+});
+
+describe("hasProjectScopedSkillRef", () => {
+  test("returns true when any ref is project-scoped", () => {
+    expect(
+      hasProjectScopedSkillRef([
+        { skillName: "tdd", scope: "global", source: "inline" },
+        { skillName: "deep-review", scope: "project", source: "slash" },
+      ])
+    ).toBe(true);
+  });
+
+  test("returns false for empty refs", () => {
+    expect(hasProjectScopedSkillRef([])).toBe(false);
+  });
+});

--- a/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
+++ b/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
@@ -22,70 +22,70 @@ function slashInvocation(skill: AgentSkillDescriptor): SkillInvocation {
 
 describe("resolveInlineSkillRefsForSend", () => {
   test("returns an empty array for no slash and no inline refs", async () => {
-    await expect(
-      resolveInlineSkillRefsForSend({
+    expect(
+      await resolveInlineSkillRefsForSend({
         messageText: "Please help",
         slashInvocation: null,
         agentSkillDescriptors: [descriptor("tdd")],
         api: null,
         discovery: null,
       })
-    ).resolves.toEqual([]);
+    ).toEqual([]);
   });
 
   test("returns a single slash ref for slash-only invocation", async () => {
     const tdd = descriptor("tdd", "project");
 
-    await expect(
-      resolveInlineSkillRefsForSend({
+    expect(
+      await resolveInlineSkillRefsForSend({
         messageText: "/tdd Please help",
         slashInvocation: slashInvocation(tdd),
         agentSkillDescriptors: [tdd],
         api: null,
         discovery: null,
       })
-    ).resolves.toEqual([{ skillName: "tdd", scope: "project", source: "slash" }]);
+    ).toEqual([{ skillName: "tdd", scope: "project", source: "slash" }]);
   });
 
   test("returns inline refs in first-appearance order", async () => {
-    await expect(
-      resolveInlineSkillRefsForSend({
+    expect(
+      await resolveInlineSkillRefsForSend({
         messageText: "Use $deep-review and then $tdd",
         slashInvocation: null,
         agentSkillDescriptors: [descriptor("tdd"), descriptor("deep-review", "project")],
         api: null,
         discovery: null,
       })
-    ).resolves.toEqual([
+    ).toEqual([
       { skillName: "deep-review", scope: "project", source: "inline" },
       { skillName: "tdd", scope: "global", source: "inline" },
     ]);
   });
 
   test("collapses duplicate inline refs", async () => {
-    await expect(
-      resolveInlineSkillRefsForSend({
+    expect(
+      await resolveInlineSkillRefsForSend({
         messageText: "Use $tdd and $tdd again",
         slashInvocation: null,
         agentSkillDescriptors: [descriptor("tdd")],
         api: null,
         discovery: null,
       })
-    ).resolves.toEqual([{ skillName: "tdd", scope: "global", source: "inline" }]);
+    ).toEqual([{ skillName: "tdd", scope: "global", source: "inline" }]);
   });
 
   test("keeps slash first and appends inline refs for mixed messages", async () => {
     const deepReview = descriptor("deep-review", "project");
 
-    await expect(
-      resolveInlineSkillRefsForSend({
+    expect(
+      await resolveInlineSkillRefsForSend({
         messageText: "/deep-review Please also follow $tdd",
         slashInvocation: slashInvocation(deepReview),
         agentSkillDescriptors: [deepReview, descriptor("tdd")],
         api: null,
         discovery: null,
       })
-    ).resolves.toEqual([
+    ).toEqual([
       { skillName: "deep-review", scope: "project", source: "slash" },
       { skillName: "tdd", scope: "global", source: "inline" },
     ]);
@@ -94,27 +94,27 @@ describe("resolveInlineSkillRefsForSend", () => {
   test("keeps only the slash ref when inline repeats the slash skill", async () => {
     const tdd = descriptor("tdd", "project");
 
-    await expect(
-      resolveInlineSkillRefsForSend({
+    expect(
+      await resolveInlineSkillRefsForSend({
         messageText: "/tdd Please also follow $tdd",
         slashInvocation: slashInvocation(tdd),
         agentSkillDescriptors: [tdd],
         api: null,
         discovery: null,
       })
-    ).resolves.toEqual([{ skillName: "tdd", scope: "project", source: "slash" }]);
+    ).toEqual([{ skillName: "tdd", scope: "project", source: "slash" }]);
   });
 
   test("ignores currency-like dollar tokens", async () => {
-    await expect(
-      resolveInlineSkillRefsForSend({
+    expect(
+      await resolveInlineSkillRefsForSend({
         messageText: "This costs $100",
         slashInvocation: null,
         agentSkillDescriptors: [descriptor("tdd")],
         api: null,
         discovery: null,
       })
-    ).resolves.toEqual([]);
+    ).toEqual([]);
   });
 });
 

--- a/src/browser/features/ChatInput/utils.ts
+++ b/src/browser/features/ChatInput/utils.ts
@@ -1,9 +1,18 @@
 import type { ParsedCommand } from "@/browser/utils/slashCommands/types";
 import { parseCommand } from "@/browser/utils/slashCommands/parser";
 import type { APIClient } from "@/browser/contexts/API";
+import {
+  extractInlineSkillReferenceCandidates,
+  resolveInlineSkillReferences,
+} from "@/browser/utils/agentSkills/inlineSkillReferences";
 import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
 import type { ParsedRuntime } from "@/common/types/runtime";
-import { buildAgentSkillMetadata, type MuxMessageMetadata } from "@/common/types/message";
+import {
+  buildAgentSkillMetadata,
+  dedupeAgentSkillRefs,
+  type AgentSkillReference,
+  type MuxMessageMetadata,
+} from "@/common/types/message";
 import type { FilePart } from "@/common/orpc/types";
 import type { ChatAttachment } from "@/browser/features/ChatInput/ChatAttachments";
 
@@ -123,6 +132,49 @@ export async function parseCommandWithSkillInvocation(options: {
   });
 
   return { parsed: skillInvocation ? null : parsed, skillInvocation };
+}
+
+/**
+ * Resolve inline `$skill` references found in the user's authored message text.
+ *
+ * - Parses `$skill` candidates from the original user text (not the slash-rewritten userText),
+ *   so a mixed `/deep-review Please also follow $tdd` finds both refs.
+ * - When `slashInvocation` is provided, its skill is included as a `source: "slash"` ref;
+ *   it remains first in the returned list and wins on dedupe (same name → drop inline duplicate).
+ * - Inline refs that don't resolve are silently dropped.
+ * - Output is deduped (first-appearance wins; slash beats inline). Empty array when there are none.
+ */
+export async function resolveInlineSkillRefsForSend(options: {
+  messageText: string;
+  slashInvocation: SkillInvocation | null;
+  agentSkillDescriptors: AgentSkillDescriptor[];
+  api: APIClient | null;
+  discovery: SkillResolutionTarget | null;
+}): Promise<AgentSkillReference[]> {
+  const refs: AgentSkillReference[] = [];
+
+  if (options.slashInvocation) {
+    const descriptor = options.slashInvocation.descriptor;
+    refs.push({ skillName: descriptor.name, scope: descriptor.scope, source: "slash" });
+  }
+
+  const candidates = extractInlineSkillReferenceCandidates(options.messageText);
+  if (candidates.length > 0) {
+    const inlineRefs = await resolveInlineSkillReferences({
+      candidates,
+      agentSkillDescriptors: options.agentSkillDescriptors,
+      api: options.api,
+      discovery: options.discovery,
+    });
+    refs.push(...inlineRefs);
+  }
+
+  return dedupeAgentSkillRefs(refs);
+}
+
+/** Returns true when any ref's scope is "project" (used by creation flow to force disableWorkspaceAgents). */
+export function hasProjectScopedSkillRef(refs: AgentSkillReference[]): boolean {
+  return refs.some((ref) => ref.scope === "project");
 }
 
 export function validateCreationRuntime(

--- a/src/browser/features/Messages/AgentSkillBadge.tsx
+++ b/src/browser/features/Messages/AgentSkillBadge.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { cn } from "@/common/lib/utils";
+
+/** Shared visual badge for slash and inline agent skill references. */
+export const AgentSkillBadge = React.forwardRef<
+  HTMLSpanElement,
+  React.HTMLAttributes<HTMLSpanElement>
+>(({ className, children, ...rest }, ref) => (
+  <span
+    ref={ref}
+    className={cn(
+      "font-mono text-[13px] font-medium text-[var(--color-plan-mode-light)]",
+      className
+    )}
+    data-component="AgentSkillBadge"
+    {...rest}
+  >
+    {children}
+  </span>
+));
+
+AgentSkillBadge.displayName = "AgentSkillBadge";

--- a/src/browser/features/Messages/InlineSkillMarkdown.test.tsx
+++ b/src/browser/features/Messages/InlineSkillMarkdown.test.tsx
@@ -1,0 +1,94 @@
+import "../../../../tests/ui/dom";
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+import type { InlineSkillSnapshotMap } from "@/common/types/message";
+import { MarkdownRenderer } from "./MarkdownRenderer";
+import { installDom } from "../../../../tests/ui/dom";
+
+function createSkillSnapshot(skillName: string): InlineSkillSnapshotMap[string] {
+  return {
+    skillName,
+    scope: "global",
+    snapshot: {
+      frontmatterYaml: `name: ${skillName}`,
+      body: `Skill body for ${skillName}`,
+    },
+  };
+}
+
+function getSkillBadges(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>('[data-component="AgentSkillBadge"]'));
+}
+
+function renderMarkdown(content: string, inlineSkillSnapshots?: InlineSkillSnapshotMap) {
+  return render(
+    <MarkdownRenderer
+      content={content}
+      className="user-message-markdown"
+      inlineSkillSnapshots={inlineSkillSnapshots}
+      preserveLineBreaks
+    />
+  );
+}
+
+describe("Inline skill Markdown rendering", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installDom();
+  });
+
+  afterEach(() => {
+    cleanup();
+    cleanupDom?.();
+    cleanupDom = null;
+  });
+
+  test("renders known inline skill references as badge triggers", () => {
+    const view = renderMarkdown("Please perform a $deep-review and follow $tdd", {
+      "deep-review": createSkillSnapshot("deep-review"),
+      tdd: createSkillSnapshot("tdd"),
+    });
+
+    const badges = getSkillBadges(view.container);
+    expect(badges.map((badge) => badge.textContent)).toEqual(["$deep-review", "$tdd"]);
+  });
+
+  test("does not badge inline code or fenced code block tokens", () => {
+    const view = renderMarkdown("Use `$tdd` here.\n\n```\n$deep-review\n```", {
+      "deep-review": createSkillSnapshot("deep-review"),
+      tdd: createSkillSnapshot("tdd"),
+    });
+
+    expect(getSkillBadges(view.container)).toHaveLength(0);
+  });
+
+  test("does not badge non-skill dollar tokens", () => {
+    const view = renderMarkdown("Keep $100, $PATH, and foo$bar as plain text", {
+      tdd: createSkillSnapshot("tdd"),
+    });
+
+    expect(getSkillBadges(view.container)).toHaveLength(0);
+    expect(view.container.querySelector("a")).toBeNull();
+  });
+
+  test("renders unknown inline skill references as plain text", () => {
+    const view = renderMarkdown("Run $unknown if it exists", {});
+
+    expect(view.container.textContent).toContain("$unknown");
+    expect(getSkillBadges(view.container)).toHaveLength(0);
+    expect(view.container.querySelector("a")).toBeNull();
+  });
+
+  test("renders repeated references from one snapshot entry", () => {
+    const view = renderMarkdown("Run $tdd, then run $tdd again", {
+      tdd: createSkillSnapshot("tdd"),
+    });
+
+    const badges = getSkillBadges(view.container);
+    expect(badges).toHaveLength(2);
+    expect(badges.every((badge) => badge.textContent === "$tdd")).toBe(true);
+  });
+});

--- a/src/browser/features/Messages/InlineSkillPreviewContext.tsx
+++ b/src/browser/features/Messages/InlineSkillPreviewContext.tsx
@@ -1,0 +1,9 @@
+import { createContext, type ReactNode } from "react";
+
+export interface InlineSkillPreviewContextValue {
+  renderInlineSkillPreview: (skillName: string, label: string) => ReactNode;
+}
+
+export const InlineSkillPreviewContext = createContext<InlineSkillPreviewContextValue>({
+  renderInlineSkillPreview: (_skillName, label) => label,
+});

--- a/src/browser/features/Messages/MarkdownComponents.tsx
+++ b/src/browser/features/Messages/MarkdownComponents.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import React, { useState, useEffect } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Play } from "lucide-react";
 import { Mermaid } from "./Mermaid";
 import { useOptionalMessageListContext } from "./MessageListContext";
@@ -9,6 +9,8 @@ import { useTheme } from "@/browser/contexts/ThemeContext";
 import { CopyButton } from "@/browser/components/CopyButton/CopyButton";
 import { resolveBrowserLocalhostProxyTemplate } from "@/browser/utils/browserLocalhostProxyTemplate";
 import { normalizeLocalhostProxyUrl } from "@/common/utils/localhostProxyUrl";
+import { InlineSkillPreviewContext } from "./InlineSkillPreviewContext";
+import { INTERNAL_INLINE_SKILL_HREF_PREFIX } from "./inlineSkillMarkdown";
 
 interface CodeProps {
   node?: unknown;
@@ -224,33 +226,80 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ code, language, highlightLanguage
   );
 };
 
+function getTextFromReactNode(node: ReactNode): string {
+  let text = "";
+
+  React.Children.forEach(node, (child) => {
+    if (typeof child === "string" || typeof child === "number") {
+      text += String(child);
+      return;
+    }
+
+    if (React.isValidElement<{ children?: ReactNode }>(child)) {
+      text += getTextFromReactNode(child.props.children);
+    }
+  });
+
+  return text;
+}
+
+function decodeInlineSkillHref(href: string): string | null {
+  const encodedSkillName = href.slice(INTERNAL_INLINE_SKILL_HREF_PREFIX.length);
+  if (encodedSkillName.length === 0) {
+    return null;
+  }
+
+  try {
+    return decodeURIComponent(encodedSkillName);
+  } catch {
+    return null;
+  }
+}
+
+function InlineSkillAnchor(props: { href: string; children?: ReactNode }): ReactNode {
+  const inlineSkillPreview = useContext(InlineSkillPreviewContext);
+  const label = getTextFromReactNode(props.children);
+  const skillName = decodeInlineSkillHref(props.href);
+  if (!skillName) {
+    return label;
+  }
+
+  return inlineSkillPreview.renderInlineSkillPreview(skillName, label);
+}
+
+function MarkdownAnchor(props: AnchorProps): ReactNode {
+  if (typeof props.href === "string" && props.href.startsWith(INTERNAL_INLINE_SKILL_HREF_PREFIX)) {
+    return <InlineSkillAnchor href={props.href}>{props.children}</InlineSkillAnchor>;
+  }
+
+  const normalizedHref =
+    typeof props.href === "string" && typeof window !== "undefined"
+      ? normalizeLocalhostProxyUrl({
+          url: props.href,
+          localhostProxyTemplate: resolveBrowserLocalhostProxyTemplate({
+            injectedTemplate: window.__MUX_PROXY_URI_TEMPLATE__ ?? null,
+            browserProtocol: window.location.protocol,
+            browserHostname: window.location.hostname,
+            browserPort: window.location.port,
+          }),
+          browserHost: window.location.host,
+        })
+      : props.href;
+
+  return (
+    <a href={normalizedHref} target="_blank" rel="noopener noreferrer">
+      {props.children}
+    </a>
+  );
+}
+
 // Custom components for markdown rendering
 export const markdownComponents = {
   // Pass through pre element - let code component handle the wrapping
   pre: ({ children }: PreProps) => <>{children}</>,
 
   // Custom anchor to open links externally
-  a: ({ href, children }: AnchorProps) => {
-    const normalizedHref =
-      typeof href === "string" && typeof window !== "undefined"
-        ? normalizeLocalhostProxyUrl({
-            url: href,
-            localhostProxyTemplate: resolveBrowserLocalhostProxyTemplate({
-              injectedTemplate: window.__MUX_PROXY_URI_TEMPLATE__ ?? null,
-              browserProtocol: window.location.protocol,
-              browserHostname: window.location.hostname,
-              browserPort: window.location.port,
-            }),
-            browserHost: window.location.host,
-          })
-        : href;
-
-    return (
-      <a href={normalizedHref} target="_blank" rel="noopener noreferrer">
-        {children}
-      </a>
-    );
-  },
+  a: MarkdownAnchor,
 
   // Custom details/summary for collapsible sections
   details: ({ children, open }: DetailsProps) => (

--- a/src/browser/features/Messages/MarkdownCore.tsx
+++ b/src/browser/features/Messages/MarkdownCore.tsx
@@ -11,6 +11,7 @@ import { harden } from "rehype-harden";
 import "katex/dist/katex.min.css";
 import { normalizeMarkdown } from "./MarkdownStyles";
 import { markdownComponents } from "./MarkdownComponents";
+import { INTERNAL_INLINE_SKILL_HREF_PREFIX, remarkInlineSkillLinks } from "./inlineSkillMarkdown";
 
 interface MarkdownCoreProps {
   content: string;
@@ -37,6 +38,7 @@ interface MarkdownCoreProps {
 const REMARK_PLUGINS: Pluggable[] = [
   [remarkGfm, {}],
   [remarkMath, { singleDollarTextMath: false }],
+  remarkInlineSkillLinks,
 ];
 
 // Same as above, but with remarkBreaks to preserve single newlines as <br>.
@@ -45,7 +47,10 @@ const REMARK_PLUGINS_WITH_BREAKS: Pluggable[] = [
   [remarkGfm, {}],
   remarkBreaks,
   [remarkMath, { singleDollarTextMath: false }],
+  remarkInlineSkillLinks,
 ];
+
+const INTERNAL_INLINE_SKILL_SANITIZE_PROTOCOL = INTERNAL_INLINE_SKILL_HREF_PREFIX.slice(0, -1);
 
 // Schema for rehype-sanitize that allows safe HTML elements.
 // Extends the default schema to support KaTeX math and collapsible sections.
@@ -81,6 +86,10 @@ const sanitizeSchema = {
     "details",
     "summary",
   ],
+  protocols: {
+    ...defaultSchema.protocols,
+    href: [...(defaultSchema.protocols?.href ?? []), INTERNAL_INLINE_SKILL_SANITIZE_PROTOCOL],
+  },
   attributes: {
     ...defaultSchema.attributes,
     // KaTeX uses style for coloring and positioning
@@ -104,6 +113,7 @@ const REHYPE_PLUGINS: Pluggable[] = [
       // links). Data images are allowed explicitly below.
       allowedImagePrefixes: ["*", "/"],
       allowedLinkPrefixes: ["*"],
+      allowedProtocols: [INTERNAL_INLINE_SKILL_HREF_PREFIX],
       // rehype-harden requires a defaultOrigin when any allowlist is provided.
       // We use a stable placeholder origin so relative URLs can be resolved.
       defaultOrigin: "https://mux.invalid",

--- a/src/browser/features/Messages/MarkdownRenderer.tsx
+++ b/src/browser/features/Messages/MarkdownRenderer.tsx
@@ -10,7 +10,10 @@ import { MarkdownCore } from "./MarkdownCore";
 import { cn } from "@/common/lib/utils";
 import { AgentSkillBadge } from "./AgentSkillBadge";
 import { buildAgentSkillSnapshotMarkdown } from "./agentSkillSnapshotMarkdown";
-import { InlineSkillPreviewContext } from "./InlineSkillPreviewContext";
+import {
+  InlineSkillPreviewContext,
+  type InlineSkillPreviewContextValue,
+} from "./InlineSkillPreviewContext";
 
 interface MarkdownRendererProps {
   content: string;
@@ -25,6 +28,10 @@ interface MarkdownRendererProps {
   preserveLineBreaks?: boolean;
   inlineSkillSnapshots?: InlineSkillSnapshotMap;
 }
+
+const DISABLED_INLINE_SKILL_PREVIEW_CONTEXT: InlineSkillPreviewContextValue = {
+  renderInlineSkillPreview: (_skillName, label) => label,
+};
 
 export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   content,
@@ -63,7 +70,11 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
                     side="top"
                     className="border-border-medium bg-modal-bg z-[1600] max-h-[360px] w-[520px] max-w-[80vw] overflow-auto border-2 p-3"
                   >
-                    <MarkdownRenderer content={snapshotMarkdown} preserveLineBreaks />
+                    <InlineSkillPreviewContext.Provider
+                      value={DISABLED_INLINE_SKILL_PREVIEW_CONTEXT}
+                    >
+                      <MarkdownRenderer content={snapshotMarkdown} preserveLineBreaks />
+                    </InlineSkillPreviewContext.Provider>
                   </HoverCardContent>
                 </HoverCardPortal>
               </HoverCard>

--- a/src/browser/features/Messages/MarkdownRenderer.tsx
+++ b/src/browser/features/Messages/MarkdownRenderer.tsx
@@ -1,6 +1,16 @@
 import React from "react";
+import type { InlineSkillSnapshotMap } from "@/common/types/message";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardPortal,
+  HoverCardTrigger,
+} from "@/browser/components/HoverCard/HoverCard";
 import { MarkdownCore } from "./MarkdownCore";
 import { cn } from "@/common/lib/utils";
+import { AgentSkillBadge } from "./AgentSkillBadge";
+import { buildAgentSkillSnapshotMarkdown } from "./agentSkillSnapshotMarkdown";
+import { InlineSkillPreviewContext } from "./InlineSkillPreviewContext";
 
 interface MarkdownRendererProps {
   content: string;
@@ -13,6 +23,7 @@ interface MarkdownRendererProps {
    * are intentional. Default: false.
    */
   preserveLineBreaks?: boolean;
+  inlineSkillSnapshots?: InlineSkillSnapshotMap;
 }
 
 export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
@@ -20,10 +31,53 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   className,
   style,
   preserveLineBreaks,
+  inlineSkillSnapshots,
 }) => {
+  const markdownCore = <MarkdownCore content={content} preserveLineBreaks={preserveLineBreaks} />;
+  const markdownContent =
+    inlineSkillSnapshots === undefined ? (
+      markdownCore
+    ) : (
+      <InlineSkillPreviewContext.Provider
+        value={{
+          renderInlineSkillPreview: (skillName, label) => {
+            const snapshot = inlineSkillSnapshots[skillName];
+            if (!snapshot) {
+              return label;
+            }
+
+            const snapshotMarkdown = buildAgentSkillSnapshotMarkdown(snapshot.snapshot);
+            if (!snapshotMarkdown) {
+              return label;
+            }
+
+            return (
+              <HoverCard openDelay={150}>
+                <HoverCardTrigger asChild>
+                  <AgentSkillBadge className="cursor-help">{label}</AgentSkillBadge>
+                </HoverCardTrigger>
+                {/* Keep skill preview above chat chrome and fully opaque while hovering. */}
+                <HoverCardPortal>
+                  <HoverCardContent
+                    align="start"
+                    side="top"
+                    className="border-border-medium bg-modal-bg z-[1600] max-h-[360px] w-[520px] max-w-[80vw] overflow-auto border-2 p-3"
+                  >
+                    <MarkdownRenderer content={snapshotMarkdown} preserveLineBreaks />
+                  </HoverCardContent>
+                </HoverCardPortal>
+              </HoverCard>
+            );
+          },
+        }}
+      >
+        {markdownCore}
+      </InlineSkillPreviewContext.Provider>
+    );
+
   return (
     <div className={cn("markdown-content", className)} style={style}>
-      <MarkdownCore content={content} preserveLineBreaks={preserveLineBreaks} />
+      {markdownContent}
     </div>
   );
 };

--- a/src/browser/features/Messages/TypewriterMarkdown.test.tsx
+++ b/src/browser/features/Messages/TypewriterMarkdown.test.tsx
@@ -1,7 +1,12 @@
 import type { UseSmoothStreamingTextOptions } from "@/browser/hooks/useSmoothStreamingText";
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { useSmoothStreamingText as importedUseSmoothStreamingText } from "@/browser/hooks/useSmoothStreamingText";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, render } from "@testing-library/react";
 import { GlobalWindow } from "happy-dom";
+import { MarkdownCore as ImportedMarkdownCore } from "./MarkdownCore";
+
+const actualMarkdownCore = ImportedMarkdownCore;
+const actualUseSmoothStreamingText = importedUseSmoothStreamingText;
 
 const mockUseSmoothStreamingText = mock(
   (options: UseSmoothStreamingTextOptions): { visibleText: string; isCaughtUp: boolean } => ({
@@ -23,6 +28,17 @@ void mock.module("@/browser/hooks/useSmoothStreamingText", () => ({
 import { TypewriterMarkdown } from "./TypewriterMarkdown";
 
 describe("TypewriterMarkdown", () => {
+  afterAll(async () => {
+    // Bun 1.3.6's mock.module() has no disposer, and mock.restore() does not undo
+    // module mocks. Restore the real exports so these stubs do not leak into later files.
+    await mock.module("./MarkdownCore", () => ({
+      MarkdownCore: actualMarkdownCore,
+    }));
+    await mock.module("@/browser/hooks/useSmoothStreamingText", () => ({
+      useSmoothStreamingText: actualUseSmoothStreamingText,
+    }));
+  });
+
   beforeEach(() => {
     globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
     globalThis.document = globalThis.window.document;

--- a/src/browser/features/Messages/TypewriterMarkdown.test.tsx
+++ b/src/browser/features/Messages/TypewriterMarkdown.test.tsx
@@ -4,6 +4,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "b
 import { cleanup, render } from "@testing-library/react";
 import { GlobalWindow } from "happy-dom";
 import { MarkdownCore as ImportedMarkdownCore } from "./MarkdownCore";
+import { TypewriterMarkdown } from "./TypewriterMarkdown";
 
 const actualMarkdownCore = ImportedMarkdownCore;
 const actualUseSmoothStreamingText = importedUseSmoothStreamingText;
@@ -15,38 +16,47 @@ const mockUseSmoothStreamingText = mock(
   })
 );
 
-void mock.module("./MarkdownCore", () => ({
-  MarkdownCore: (props: { content: string }) => (
-    <div data-testid="markdown-core">{props.content}</div>
-  ),
-}));
+function MarkdownCoreStub(props: { content: string }) {
+  return <div data-testid="markdown-core">{props.content}</div>;
+}
 
-void mock.module("@/browser/hooks/useSmoothStreamingText", () => ({
-  useSmoothStreamingText: mockUseSmoothStreamingText,
-}));
+// Keep module mocks inside test hooks: Bun loads test files before afterAll runs, so
+// file-scope mock.module() calls can pollute unrelated files during collection.
+async function installTypewriterMarkdownModuleMocks() {
+  await mock.module("./MarkdownCore", () => ({
+    MarkdownCore: MarkdownCoreStub,
+  }));
+  await mock.module("@/browser/hooks/useSmoothStreamingText", () => ({
+    useSmoothStreamingText: mockUseSmoothStreamingText,
+  }));
+}
 
-import { TypewriterMarkdown } from "./TypewriterMarkdown";
+async function restoreTypewriterMarkdownModuleMocks() {
+  // Bun 1.3.6's mock.module() has no disposer, and mock.restore() does not undo
+  // module mocks. Restore the real exports so these stubs do not leak into later files.
+  await mock.module("./MarkdownCore", () => ({
+    MarkdownCore: actualMarkdownCore,
+  }));
+  await mock.module("@/browser/hooks/useSmoothStreamingText", () => ({
+    useSmoothStreamingText: actualUseSmoothStreamingText,
+  }));
+}
 
 describe("TypewriterMarkdown", () => {
   afterAll(async () => {
-    // Bun 1.3.6's mock.module() has no disposer, and mock.restore() does not undo
-    // module mocks. Restore the real exports so these stubs do not leak into later files.
-    await mock.module("./MarkdownCore", () => ({
-      MarkdownCore: actualMarkdownCore,
-    }));
-    await mock.module("@/browser/hooks/useSmoothStreamingText", () => ({
-      useSmoothStreamingText: actualUseSmoothStreamingText,
-    }));
+    await restoreTypewriterMarkdownModuleMocks();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
     globalThis.document = globalThis.window.document;
+    await installTypewriterMarkdownModuleMocks();
     mockUseSmoothStreamingText.mockClear();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     cleanup();
+    await restoreTypewriterMarkdownModuleMocks();
     mock.restore();
     globalThis.window = undefined as unknown as Window & typeof globalThis;
     globalThis.document = undefined as unknown as Document;

--- a/src/browser/features/Messages/TypewriterMarkdown.test.tsx
+++ b/src/browser/features/Messages/TypewriterMarkdown.test.tsx
@@ -43,12 +43,19 @@ async function restoreTypewriterMarkdownModuleMocks() {
 }
 
 describe("TypewriterMarkdown", () => {
+  let originalWindow: typeof globalThis.window;
+  let originalDocument: typeof globalThis.document;
+
   afterAll(async () => {
     await restoreTypewriterMarkdownModuleMocks();
   });
 
   beforeEach(async () => {
-    globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
+    originalWindow = globalThis.window;
+    originalDocument = globalThis.document;
+
+    globalThis.window = new GlobalWindow({ url: "http://localhost" }) as unknown as Window &
+      typeof globalThis;
     globalThis.document = globalThis.window.document;
     await installTypewriterMarkdownModuleMocks();
     mockUseSmoothStreamingText.mockClear();
@@ -58,8 +65,8 @@ describe("TypewriterMarkdown", () => {
     cleanup();
     await restoreTypewriterMarkdownModuleMocks();
     mock.restore();
-    globalThis.window = undefined as unknown as Window & typeof globalThis;
-    globalThis.document = undefined as unknown as Document;
+    globalThis.window = originalWindow;
+    globalThis.document = originalDocument;
   });
 
   test("passes smoothed visible text to MarkdownCore when streaming", () => {

--- a/src/browser/features/Messages/UserMessage.tsx
+++ b/src/browser/features/Messages/UserMessage.tsx
@@ -156,6 +156,7 @@ export const UserMessage: React.FC<UserMessageProps> = ({
           content={content}
           commandPrefix={message.commandPrefix}
           agentSkillSnapshot={message.agentSkill?.snapshot}
+          inlineSkillSnapshots={message.inlineSkillSnapshots}
           reviews={message.reviews}
           fileParts={message.fileParts}
           variant="sent"

--- a/src/browser/features/Messages/UserMessageContent.inline-skill.test.tsx
+++ b/src/browser/features/Messages/UserMessageContent.inline-skill.test.tsx
@@ -1,0 +1,100 @@
+import "../../../../tests/ui/dom";
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
+import type { DisplayedUserMessage, InlineSkillSnapshotMap } from "@/common/types/message";
+import type { EditingMessageState } from "@/browser/utils/chatEditing";
+import { UserMessage } from "./UserMessage";
+import { UserMessageContent } from "./UserMessageContent";
+import { installDom } from "../../../../tests/ui/dom";
+
+function createSkillSnapshot(skillName: string): InlineSkillSnapshotMap[string] {
+  return {
+    skillName,
+    scope: "global",
+    snapshot: {
+      frontmatterYaml: `name: ${skillName}`,
+      body: `Skill body for ${skillName}`,
+    },
+  };
+}
+
+function getSkillBadges(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>('[data-component="AgentSkillBadge"]'));
+}
+
+describe("UserMessageContent inline skill rendering", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installDom();
+  });
+
+  afterEach(() => {
+    cleanup();
+    cleanupDom?.();
+    cleanupDom = null;
+  });
+
+  test("renders slash and inline skill badges in sent user messages", () => {
+    const slashSnapshot = createSkillSnapshot("deep-review");
+    const view = render(
+      <UserMessageContent
+        content="/deep-review Please run $tdd"
+        commandPrefix="/deep-review"
+        agentSkillSnapshot={slashSnapshot.snapshot}
+        inlineSkillSnapshots={{ tdd: createSkillSnapshot("tdd") }}
+        variant="sent"
+      />
+    );
+
+    const badgeTexts = getSkillBadges(view.container).map((badge) => badge.textContent);
+    expect(badgeTexts).toEqual(["/deep-review", "$tdd"]);
+  });
+
+  test("keeps edit-mode textarea content as raw text", () => {
+    function EditHarness() {
+      const [editingMessage, setEditingMessage] = React.useState<EditingMessageState | null>(null);
+      const message: DisplayedUserMessage = {
+        type: "user",
+        id: "display-1",
+        historyId: "history-1",
+        historySequence: 1,
+        content: "Please run $tdd",
+        inlineSkillSnapshots: { tdd: createSkillSnapshot("tdd") },
+      };
+
+      if (editingMessage) {
+        return (
+          <textarea
+            aria-label="Edit your last message"
+            readOnly
+            value={editingMessage.pending.content}
+          />
+        );
+      }
+
+      return (
+        <TooltipProvider>
+          <UserMessage message={message} onEdit={(nextEditing) => setEditingMessage(nextEditing)} />
+        </TooltipProvider>
+      );
+    }
+
+    const view = render(<EditHarness />);
+    expect(getSkillBadges(view.container).map((badge) => badge.textContent)).toEqual(["$tdd"]);
+
+    fireEvent.click(view.getByRole("button", { name: "Edit" }));
+
+    const textarea = view.getByLabelText("Edit your last message");
+    if (!(textarea instanceof window.HTMLTextAreaElement)) {
+      throw new Error("Expected edit control to be a textarea");
+    }
+
+    expect(textarea.value).toBe("Please run $tdd");
+    expect(getSkillBadges(view.container)).toHaveLength(0);
+  });
+});

--- a/src/browser/features/Messages/UserMessageContent.tsx
+++ b/src/browser/features/Messages/UserMessageContent.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { FileText } from "lucide-react";
-import type { ReviewNoteDataForDisplay } from "@/common/types/message";
+import type { InlineSkillSnapshotMap, ReviewNoteDataForDisplay } from "@/common/types/message";
 import type { FilePart } from "@/common/orpc/schemas";
-import { cn } from "@/common/lib/utils";
 import { ReviewBlockFromData } from "../Shared/ReviewBlock";
 import {
   HoverCard,
@@ -12,6 +11,8 @@ import {
 } from "@/browser/components/HoverCard/HoverCard";
 import { isDesktopMode } from "@/browser/hooks/useDesktopTitlebar";
 import { MarkdownRenderer } from "./MarkdownRenderer";
+import { AgentSkillBadge } from "./AgentSkillBadge";
+import { buildAgentSkillSnapshotMarkdown } from "./agentSkillSnapshotMarkdown";
 
 interface UserMessageContentProps {
   content: string;
@@ -21,6 +22,7 @@ interface UserMessageContentProps {
    * When present, the command prefix badge shows a hover preview.
    */
   agentSkillSnapshot?: { frontmatterYaml?: string; body?: string };
+  inlineSkillSnapshots?: InlineSkillSnapshotMap;
   reviews?: ReviewNoteDataForDisplay[];
   fileParts?: FilePart[];
   /** Controls styling: "sent" for full styling, "queued" for muted preview */
@@ -50,26 +52,6 @@ const imageContainerStyles = {
 } as const;
 
 const markdownClassName = "user-message-markdown";
-
-function buildAgentSkillSnapshotMarkdown(
-  snapshot: UserMessageContentProps["agentSkillSnapshot"]
-): string | null {
-  if (!snapshot) return null;
-
-  const frontmatterYaml =
-    typeof snapshot.frontmatterYaml === "string" && snapshot.frontmatterYaml.trim().length > 0
-      ? snapshot.frontmatterYaml.trimEnd()
-      : undefined;
-  const body = typeof snapshot.body === "string" ? snapshot.body : undefined;
-
-  if (!frontmatterYaml && !body) {
-    return null;
-  }
-
-  const yamlBlock = frontmatterYaml ? `\`\`\`yaml\n---\n${frontmatterYaml}\n---\n\`\`\`\n\n` : "";
-
-  return `${yamlBlock}${body ?? ""}`;
-}
 
 function dataUrlToBlob(dataUrl: string): Blob | null {
   if (!dataUrl.startsWith("data:")) return null;
@@ -109,24 +91,6 @@ const imageStyles = {
   queued: "border-border-light max-h-[300px] max-w-80 rounded border",
 } as const;
 
-/** Styled command prefix (e.g., "/compact" or "/skill-name") */
-const CommandPrefixBadge = React.forwardRef<
-  HTMLSpanElement,
-  React.HTMLAttributes<HTMLSpanElement> & { prefix: string }
->(({ prefix, className, ...rest }, ref) => (
-  <span
-    ref={ref}
-    className={cn(
-      "font-mono text-[13px] font-medium text-[var(--color-plan-mode-light)]",
-      className
-    )}
-    {...rest}
-  >
-    {prefix}
-  </span>
-));
-CommandPrefixBadge.displayName = "CommandPrefixBadge";
-
 /**
  * Shared content renderer for user messages (sent and queued).
  * Handles reviews, text content, and attachments.
@@ -164,6 +128,7 @@ export const UserMessageContent: React.FC<UserMessageContentProps> = (props) => 
           content={textContent}
           className={markdownClassName}
           style={markdownStyles[props.variant]}
+          inlineSkillSnapshots={props.inlineSkillSnapshots}
           preserveLineBreaks
         />
       );
@@ -179,7 +144,7 @@ export const UserMessageContent: React.FC<UserMessageContentProps> = (props) => 
     const badge = snapshotMarkdown ? (
       <HoverCard openDelay={150}>
         <HoverCardTrigger asChild>
-          <CommandPrefixBadge prefix={shouldHighlightPrefix} className="cursor-help" />
+          <AgentSkillBadge className="cursor-help">{shouldHighlightPrefix}</AgentSkillBadge>
         </HoverCardTrigger>
         {/* Keep skill preview above chat chrome and fully opaque while hovering. */}
         <HoverCardPortal>
@@ -193,7 +158,7 @@ export const UserMessageContent: React.FC<UserMessageContentProps> = (props) => 
         </HoverCardPortal>
       </HoverCard>
     ) : (
-      <CommandPrefixBadge prefix={shouldHighlightPrefix} />
+      <AgentSkillBadge>{shouldHighlightPrefix}</AgentSkillBadge>
     );
 
     // Newline after prefix: block layout (badge on own line)
@@ -207,6 +172,7 @@ export const UserMessageContent: React.FC<UserMessageContentProps> = (props) => 
             content={remainingContent.trim()}
             className={markdownClassName}
             style={markdownStyles[props.variant]}
+            inlineSkillSnapshots={props.inlineSkillSnapshots}
             preserveLineBreaks
           />
         )}

--- a/src/browser/features/Messages/agentSkillSnapshotMarkdown.ts
+++ b/src/browser/features/Messages/agentSkillSnapshotMarkdown.ts
@@ -1,0 +1,28 @@
+import type { DisplayedUserMessage, InlineSkillSnapshotForDisplay } from "@/common/types/message";
+
+type SlashAgentSkillSnapshot = NonNullable<
+  NonNullable<DisplayedUserMessage["agentSkill"]>["snapshot"]
+>;
+type InlineAgentSkillSnapshot = InlineSkillSnapshotForDisplay["snapshot"];
+
+export type AgentSkillSnapshotContent = SlashAgentSkillSnapshot | InlineAgentSkillSnapshot;
+
+export function buildAgentSkillSnapshotMarkdown(
+  snapshot: AgentSkillSnapshotContent | undefined
+): string | null {
+  if (!snapshot) return null;
+
+  const frontmatterYaml =
+    typeof snapshot.frontmatterYaml === "string" && snapshot.frontmatterYaml.trim().length > 0
+      ? snapshot.frontmatterYaml.trimEnd()
+      : undefined;
+  const body = typeof snapshot.body === "string" ? snapshot.body : undefined;
+
+  if (!frontmatterYaml && !body) {
+    return null;
+  }
+
+  const yamlBlock = frontmatterYaml ? `\`\`\`yaml\n---\n${frontmatterYaml}\n---\n\`\`\`\n\n` : "";
+
+  return `${yamlBlock}${body ?? ""}`;
+}

--- a/src/browser/features/Messages/inlineSkillMarkdown.ts
+++ b/src/browser/features/Messages/inlineSkillMarkdown.ts
@@ -1,0 +1,92 @@
+import type { Link, Parent, PhrasingContent, Root, Text } from "mdast";
+import type { Plugin } from "unified";
+import { SKIP, visit } from "unist-util-visit";
+import { extractInlineSkillReferenceCandidates } from "@/browser/utils/agentSkills/inlineSkillReferences";
+
+export const INTERNAL_INLINE_SKILL_HREF_PREFIX = "mux-inline-skill:";
+
+function assertInlineSkillCandidate(condition: boolean, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(`Invalid inline skill candidate: ${message}`);
+  }
+}
+
+function createTextNode(value: string): Text {
+  return { type: "text", value };
+}
+
+function createInlineSkillLink(skillName: string, visibleText: string): Link {
+  return {
+    type: "link",
+    url: `${INTERNAL_INLINE_SKILL_HREF_PREFIX}${encodeURIComponent(skillName)}`,
+    children: [createTextNode(visibleText)],
+  };
+}
+
+function buildInlineSkillReplacementNodes(textNode: Text): PhrasingContent[] | null {
+  const text = textNode.value;
+  const candidates = extractInlineSkillReferenceCandidates(text);
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const replacements: PhrasingContent[] = [];
+  let previousEnd = 0;
+
+  for (const candidate of candidates) {
+    assertInlineSkillCandidate(
+      Number.isInteger(candidate.startIndex) && Number.isInteger(candidate.endIndex),
+      "candidate ranges must be integer offsets"
+    );
+    assertInlineSkillCandidate(candidate.startIndex >= 0, "candidate start is before text start");
+    assertInlineSkillCandidate(
+      candidate.endIndex <= text.length,
+      "candidate end is after text end"
+    );
+    assertInlineSkillCandidate(
+      candidate.startIndex >= previousEnd,
+      "candidate ranges must be monotonic and non-overlapping"
+    );
+    assertInlineSkillCandidate(
+      candidate.startIndex < candidate.endIndex,
+      "candidate range is empty"
+    );
+
+    const visibleText = text.slice(candidate.startIndex, candidate.endIndex);
+    assertInlineSkillCandidate(visibleText.startsWith("$"), "candidate text must start with $");
+
+    if (candidate.startIndex > previousEnd) {
+      replacements.push(createTextNode(text.slice(previousEnd, candidate.startIndex)));
+    }
+
+    replacements.push(createInlineSkillLink(candidate.skillName, visibleText));
+    previousEnd = candidate.endIndex;
+  }
+
+  if (previousEnd < text.length) {
+    replacements.push(createTextNode(text.slice(previousEnd)));
+  }
+
+  return replacements;
+}
+
+export const remarkInlineSkillLinks: Plugin<[], Root> = () => {
+  return (tree) => {
+    visit(tree, "text", (node: Text, index: number | undefined, parent: Parent | undefined) => {
+      if (parent?.type === "link" || parent?.type === "linkReference") {
+        return SKIP;
+      }
+
+      assertInlineSkillCandidate(parent !== undefined, "text node must have a parent");
+      assertInlineSkillCandidate(index !== undefined, "text node must have a sibling index");
+
+      const replacementNodes = buildInlineSkillReplacementNodes(node);
+      if (!replacementNodes) {
+        return undefined;
+      }
+
+      parent.children.splice(index, 1, ...replacementNodes);
+      return SKIP;
+    });
+  };
+};

--- a/src/browser/features/Tools/analyticsQuery/AnalyticsQueryToolCall.test.tsx
+++ b/src/browser/features/Tools/analyticsQuery/AnalyticsQueryToolCall.test.tsx
@@ -1,7 +1,9 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalWindow } from "happy-dom";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
+import * as RouterContextModule from "@/browser/contexts/RouterContext";
+import * as UseAnalyticsModule from "@/browser/hooks/useAnalytics";
 import type { SavedQuery } from "@/common/types/savedQueries";
 
 interface SaveInput {
@@ -53,15 +55,30 @@ const useSavedQueriesMock = mock((_options?: { skipLoad?: boolean }) => ({
   refresh: () => Promise.resolve(undefined),
 }));
 
-void mock.module("@/browser/hooks/useAnalytics", () => ({
-  useSavedQueries: useSavedQueriesMock,
-}));
+const actualRouterContextModule = { ...RouterContextModule };
+const actualUseAnalyticsModule = { ...UseAnalyticsModule };
 
-void mock.module("@/browser/contexts/RouterContext", () => ({
-  useRouter: () => ({
-    navigateToAnalytics: navigateToAnalyticsMock,
-  }),
-}));
+// Keep module mocks inside test hooks: Bun loads test files before afterAll runs, so
+// file-scope mock.module() calls can pollute unrelated files during collection.
+async function installAnalyticsQueryModuleMocks() {
+  await mock.module("@/browser/hooks/useAnalytics", () => ({
+    ...actualUseAnalyticsModule,
+    useSavedQueries: useSavedQueriesMock,
+  }));
+  await mock.module("@/browser/contexts/RouterContext", () => ({
+    ...actualRouterContextModule,
+    useRouter: () => ({
+      navigateToAnalytics: navigateToAnalyticsMock,
+    }),
+  }));
+}
+
+async function restoreAnalyticsQueryModuleMocks() {
+  // Bun's mock.module() has no disposer, and mock.restore() does not undo module
+  // mocks. Restore the real exports so these stubs do not leak into later files.
+  await mock.module("@/browser/hooks/useAnalytics", () => actualUseAnalyticsModule);
+  await mock.module("@/browser/contexts/RouterContext", () => actualRouterContextModule);
+}
 
 import { AnalyticsQueryToolCall } from "./AnalyticsQueryToolCall";
 import type { AnalyticsQueryResult, AnalyticsQueryToolResult } from "./types";
@@ -97,7 +114,11 @@ describe("AnalyticsQueryToolCall", () => {
   let originalDocument: typeof globalThis.document;
   let originalResizeObserver: typeof globalThis.ResizeObserver;
 
-  beforeEach(() => {
+  afterAll(async () => {
+    await restoreAnalyticsQueryModuleMocks();
+  });
+
+  beforeEach(async () => {
     originalWindow = globalThis.window;
     originalDocument = globalThis.document;
     originalResizeObserver = globalThis.ResizeObserver;
@@ -122,6 +143,8 @@ describe("AnalyticsQueryToolCall", () => {
 
     globalThis.ResizeObserver = ResizeObserver;
 
+    await installAnalyticsQueryModuleMocks();
+
     saveBehavior = {
       type: "resolve",
       value: createSavedQuery(),
@@ -131,8 +154,9 @@ describe("AnalyticsQueryToolCall", () => {
     useSavedQueriesMock.mockClear();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     cleanup();
+    await restoreAnalyticsQueryModuleMocks();
     mock.restore();
     globalThis.window = originalWindow;
     globalThis.document = originalDocument;

--- a/src/browser/hooks/useWorkspaceHeartbeat.test.tsx
+++ b/src/browser/hooks/useWorkspaceHeartbeat.test.tsx
@@ -1,6 +1,8 @@
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalWindow } from "happy-dom";
+import * as APIModule from "@/browser/contexts/API";
+import * as WorkspaceContextModule from "@/browser/contexts/WorkspaceContext";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import type { HeartbeatFormSettings } from "./useWorkspaceHeartbeat";
 
@@ -33,15 +35,30 @@ const setWorkspaceMetadataMock = mock((update: WorkspaceMetadataUpdater) => {
   capturedWorkspaceMetadataUpdate = update;
 });
 
-void mock.module("@/browser/contexts/API", () => ({
-  useAPI: () => ({ api: apiMock }),
-}));
+const actualAPIModule = { ...APIModule };
+const actualWorkspaceContextModule = { ...WorkspaceContextModule };
 
-void mock.module("@/browser/contexts/WorkspaceContext", () => ({
-  useWorkspaceActions: () => ({
-    setWorkspaceMetadata: setWorkspaceMetadataMock,
-  }),
-}));
+// Keep module mocks inside test hooks: Bun loads test files before afterAll runs, so
+// file-scope mock.module() calls can pollute unrelated files during collection.
+async function installWorkspaceHeartbeatModuleMocks() {
+  await mock.module("@/browser/contexts/API", () => ({
+    ...actualAPIModule,
+    useAPI: () => ({ api: apiMock }),
+  }));
+  await mock.module("@/browser/contexts/WorkspaceContext", () => ({
+    ...actualWorkspaceContextModule,
+    useWorkspaceActions: () => ({
+      setWorkspaceMetadata: setWorkspaceMetadataMock,
+    }),
+  }));
+}
+
+async function restoreWorkspaceHeartbeatModuleMocks() {
+  // Bun 1.3.6's mock.module() has no disposer, and mock.restore() does not undo
+  // module mocks. Restore the real exports so these stubs do not leak into later files.
+  await mock.module("@/browser/contexts/API", () => actualAPIModule);
+  await mock.module("@/browser/contexts/WorkspaceContext", () => actualWorkspaceContextModule);
+}
 
 import { useWorkspaceHeartbeat } from "./useWorkspaceHeartbeat";
 
@@ -82,17 +99,23 @@ describe("useWorkspaceHeartbeat", () => {
   let originalWindow: typeof globalThis.window;
   let originalDocument: typeof globalThis.document;
 
-  beforeEach(() => {
+  afterAll(async () => {
+    await restoreWorkspaceHeartbeatModuleMocks();
+  });
+
+  beforeEach(async () => {
     originalWindow = globalThis.window;
     originalDocument = globalThis.document;
     globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
     globalThis.document = globalThis.window.document;
+    await installWorkspaceHeartbeatModuleMocks();
     capturedWorkspaceMetadataUpdate = null;
     setWorkspaceMetadataMock.mockClear();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     cleanup();
+    await restoreWorkspaceHeartbeatModuleMocks();
     mock.restore();
     apiMock = null;
     capturedWorkspaceMetadataUpdate = null;

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -2957,6 +2957,13 @@ export class WorkspaceStore {
         ? startupRetryModelResult.data
         : null;
 
+      // Defensive: in some test environments the orpc client mock can be incomplete.
+      // Treat a missing method as a no-op so a single missing mock entry can't cascade
+      // into unrelated test failures.
+      if (typeof client.workspace?.setAutoCompactionThreshold !== "function") {
+        return;
+      }
+
       await client.workspace.setAutoCompactionThreshold({
         workspaceId,
         threshold: this.getStartupAutoCompactionThreshold(workspaceId, startupRetryModel),

--- a/src/browser/utils/agentSkills/inlineSkillReferences.test.ts
+++ b/src/browser/utils/agentSkills/inlineSkillReferences.test.ts
@@ -143,105 +143,103 @@ describe("findInlineSkillReferenceAtCursor", () => {
 
 describe("resolveInlineSkillReferences", () => {
   test("returns an empty list for empty candidates", async () => {
-    await expect(
-      resolveInlineSkillReferences({
+    expect(
+      await resolveInlineSkillReferences({
         candidates: [],
         agentSkillDescriptors: [descriptor("tdd")],
         api: null,
         discovery: null,
       })
-    ).resolves.toEqual([]);
+    ).toEqual([]);
   });
 
   test("resolves known local descriptors", async () => {
-    await expect(
-      resolveInlineSkillReferences({
+    expect(
+      await resolveInlineSkillReferences({
         candidates: [candidate("tdd")],
         agentSkillDescriptors: [descriptor("tdd", "project")],
         api: null,
         discovery: null,
       })
-    ).resolves.toEqual([{ skillName: "tdd", scope: "project", source: "inline" }]);
+    ).toEqual([{ skillName: "tdd", scope: "project", source: "inline" }]);
   });
 
   test("collapses duplicate candidates", async () => {
-    await expect(
-      resolveInlineSkillReferences({
+    expect(
+      await resolveInlineSkillReferences({
         candidates: [candidate("tdd"), candidate("tdd", 5)],
         agentSkillDescriptors: [descriptor("tdd")],
         api: null,
         discovery: null,
       })
-    ).resolves.toEqual([{ skillName: "tdd", scope: "global", source: "inline" }]);
+    ).toEqual([{ skillName: "tdd", scope: "global", source: "inline" }]);
   });
 
   test("silently drops unknown skills without an api", async () => {
-    await expect(
-      resolveInlineSkillReferences({
+    expect(
+      await resolveInlineSkillReferences({
         candidates: [candidate("unknown")],
         agentSkillDescriptors: [],
         api: null,
         discovery: null,
       })
-    ).resolves.toEqual([]);
+    ).toEqual([]);
   });
 
   test("silently drops skills when the api throws", async () => {
-    const api = apiClient(async () => {
-      throw new Error("not found");
-    });
+    const api = apiClient(() => Promise.reject(new Error("not found")));
 
-    await expect(
-      resolveInlineSkillReferences({
+    expect(
+      await resolveInlineSkillReferences({
         candidates: [candidate("unknown")],
         agentSkillDescriptors: [],
         api,
         discovery: { kind: "project", projectPath: "/repo" },
       })
-    ).resolves.toEqual([]);
+    ).toEqual([]);
   });
 
   test("uses backend package name and scope when remote resolution succeeds", async () => {
-    const api = apiClient(async () => skillPackage("backend-skill", "built-in"));
+    const api = apiClient(() => Promise.resolve(skillPackage("backend-skill", "built-in")));
 
-    await expect(
-      resolveInlineSkillReferences({
+    expect(
+      await resolveInlineSkillReferences({
         candidates: [candidate("remote-skill")],
         agentSkillDescriptors: [],
         api,
         discovery: { kind: "project", projectPath: "/repo" },
       })
-    ).resolves.toEqual([{ skillName: "backend-skill", scope: "built-in", source: "inline" }]);
+    ).toEqual([{ skillName: "backend-skill", scope: "built-in", source: "inline" }]);
   });
 
   test("passes project discovery targets to the api", async () => {
     const calls: AgentSkillsGetInput[] = [];
-    const api = apiClient(async (input) => {
+    const api = apiClient((input) => {
       calls.push(input);
-      return skillPackage("remote-skill", "project");
+      return Promise.resolve(skillPackage("remote-skill", "project"));
     });
 
-    await expect(
-      resolveInlineSkillReferences({
+    expect(
+      await resolveInlineSkillReferences({
         candidates: [candidate("remote-skill")],
         agentSkillDescriptors: [],
         api,
         discovery: { kind: "project", projectPath: "/repo" },
       })
-    ).resolves.toEqual([{ skillName: "remote-skill", scope: "project", source: "inline" }]);
+    ).toEqual([{ skillName: "remote-skill", scope: "project", source: "inline" }]);
 
     expect(calls).toEqual([{ projectPath: "/repo", skillName: "remote-skill" }]);
   });
 
   test("passes workspace discovery targets and disableWorkspaceAgents to the api", async () => {
     const calls: AgentSkillsGetInput[] = [];
-    const api = apiClient(async (input) => {
+    const api = apiClient((input) => {
       calls.push(input);
-      return skillPackage("workspace-skill", "global");
+      return Promise.resolve(skillPackage("workspace-skill", "global"));
     });
 
-    await expect(
-      resolveInlineSkillReferences({
+    expect(
+      await resolveInlineSkillReferences({
         candidates: [candidate("workspace-skill")],
         agentSkillDescriptors: [],
         api,
@@ -251,7 +249,7 @@ describe("resolveInlineSkillReferences", () => {
           disableWorkspaceAgents: true,
         },
       })
-    ).resolves.toEqual([{ skillName: "workspace-skill", scope: "global", source: "inline" }]);
+    ).toEqual([{ skillName: "workspace-skill", scope: "global", source: "inline" }]);
 
     expect(calls).toEqual([
       {

--- a/src/browser/utils/agentSkills/inlineSkillReferences.test.ts
+++ b/src/browser/utils/agentSkills/inlineSkillReferences.test.ts
@@ -116,6 +116,25 @@ describe("extractInlineSkillReferenceCandidates", () => {
     expect(extractInlineSkillReferenceCandidates("```\n$tdd\n```")).toEqual([]);
   });
 
+  test("keeps fenced code blocks open when a candidate closer has trailing text", () => {
+    const text = "```\n```notclosing\n$tdd\n```";
+
+    expect(extractInlineSkillReferenceCandidates(text)).toEqual([]);
+  });
+
+  test("closes fenced code blocks when the closing marker has trailing spaces and tabs", () => {
+    const text = "```\n$inside\n``` \t  \n$outside";
+    const outsideIndex = text.indexOf("$outside");
+
+    expect(extractInlineSkillReferenceCandidates(text)).toEqual([
+      {
+        skillName: "outside",
+        startIndex: outsideIndex,
+        endIndex: outsideIndex + "$outside".length,
+      },
+    ]);
+  });
+
   test("skips fenced code blocks indented up to three spaces", () => {
     for (const indentation of [" ", "  ", "   "]) {
       expect(

--- a/src/browser/utils/agentSkills/inlineSkillReferences.test.ts
+++ b/src/browser/utils/agentSkills/inlineSkillReferences.test.ts
@@ -116,6 +116,27 @@ describe("extractInlineSkillReferenceCandidates", () => {
     expect(extractInlineSkillReferenceCandidates("```\n$tdd\n```")).toEqual([]);
   });
 
+  test("skips tilde fenced code blocks", () => {
+    expect(extractInlineSkillReferenceCandidates("~~~ts\n$tdd\n~~~")).toEqual([]);
+  });
+
+  test("skips longer tilde fenced code blocks", () => {
+    expect(extractInlineSkillReferenceCandidates("~~~~\n$tdd\n~~~~")).toEqual([]);
+  });
+
+  test("keeps mismatched tilde fences inside backtick fences", () => {
+    const text = "```\n$tdd\n~~~\n$deep-review\n```\n$outside";
+    const outsideIndex = text.indexOf("$outside");
+
+    expect(extractInlineSkillReferenceCandidates(text)).toEqual([
+      {
+        skillName: "outside",
+        startIndex: outsideIndex,
+        endIndex: outsideIndex + "$outside".length,
+      },
+    ]);
+  });
+
   test("extracts non-code references from mixed text", () => {
     expect(extractInlineSkillReferenceCandidates("$tdd `$nope` $deep-review")).toEqual([
       { skillName: "tdd", startIndex: 0, endIndex: 4 },

--- a/src/browser/utils/agentSkills/inlineSkillReferences.test.ts
+++ b/src/browser/utils/agentSkills/inlineSkillReferences.test.ts
@@ -116,6 +116,36 @@ describe("extractInlineSkillReferenceCandidates", () => {
     expect(extractInlineSkillReferenceCandidates("```\n$tdd\n```")).toEqual([]);
   });
 
+  test("skips fenced code blocks indented up to three spaces", () => {
+    for (const indentation of [" ", "  ", "   "]) {
+      expect(
+        extractInlineSkillReferenceCandidates(`${indentation}\`\`\`\n$tdd\n${indentation}\`\`\``)
+      ).toEqual([]);
+    }
+  });
+
+  test("extracts references when code fence markers are indented four spaces", () => {
+    const text = "    ```\n$tdd\n    ```";
+    const tddIndex = text.indexOf("$tdd");
+
+    expect(extractInlineSkillReferenceCandidates(text)).toEqual([
+      { skillName: "tdd", startIndex: tddIndex, endIndex: tddIndex + "$tdd".length },
+    ]);
+  });
+
+  test("closes fenced code blocks with an indented closing marker", () => {
+    const text = "```\n$tdd\n  ```\n$outside";
+    const outsideIndex = text.indexOf("$outside");
+
+    expect(extractInlineSkillReferenceCandidates(text)).toEqual([
+      {
+        skillName: "outside",
+        startIndex: outsideIndex,
+        endIndex: outsideIndex + "$outside".length,
+      },
+    ]);
+  });
+
   test("skips tilde fenced code blocks", () => {
     expect(extractInlineSkillReferenceCandidates("~~~ts\n$tdd\n~~~")).toEqual([]);
   });

--- a/src/browser/utils/agentSkills/inlineSkillReferences.test.ts
+++ b/src/browser/utils/agentSkills/inlineSkillReferences.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, test } from "bun:test";
+import type { APIClient } from "@/browser/contexts/API";
+import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
+import {
+  extractInlineSkillReferenceCandidates,
+  findInlineSkillReferenceAtCursor,
+  resolveInlineSkillReferences,
+  type InlineSkillCandidate,
+} from "./inlineSkillReferences";
+
+type AgentSkillsGetInput = Parameters<APIClient["agentSkills"]["get"]>[0];
+type AgentSkillsGetOutput = Awaited<ReturnType<APIClient["agentSkills"]["get"]>>;
+
+function descriptor(
+  name: string,
+  scope: AgentSkillDescriptor["scope"] = "global"
+): AgentSkillDescriptor {
+  return { name, description: `${name} description`, scope };
+}
+
+function candidate(skillName: string, startIndex = 0): InlineSkillCandidate {
+  return { skillName, startIndex, endIndex: startIndex + skillName.length + 1 };
+}
+
+function skillPackage(
+  name: string,
+  scope: AgentSkillDescriptor["scope"] = "global"
+): AgentSkillsGetOutput {
+  return {
+    scope,
+    directoryName: name,
+    frontmatter: { name, description: `${name} description` },
+    body: `${name} body`,
+  };
+}
+
+function apiClient(get: APIClient["agentSkills"]["get"]): APIClient {
+  return { agentSkills: { get } } as unknown as APIClient;
+}
+
+describe("extractInlineSkillReferenceCandidates", () => {
+  test("returns an empty list for empty input", () => {
+    expect(extractInlineSkillReferenceCandidates("")).toEqual([]);
+  });
+
+  test("extracts a single skill reference", () => {
+    expect(extractInlineSkillReferenceCandidates("Use $tdd")).toEqual([
+      { skillName: "tdd", startIndex: 4, endIndex: 8 },
+    ]);
+  });
+
+  test("extracts multiple skill references in order", () => {
+    expect(extractInlineSkillReferenceCandidates("$tdd and $deep-review")).toEqual([
+      { skillName: "tdd", startIndex: 0, endIndex: 4 },
+      { skillName: "deep-review", startIndex: 9, endIndex: 21 },
+    ]);
+  });
+
+  test("keeps duplicate parser candidates", () => {
+    expect(extractInlineSkillReferenceCandidates("$tdd $tdd")).toEqual([
+      { skillName: "tdd", startIndex: 0, endIndex: 4 },
+      { skillName: "tdd", startIndex: 5, endIndex: 9 },
+    ]);
+  });
+
+  test("accepts punctuation boundaries", () => {
+    expect(extractInlineSkillReferenceCandidates("($tdd) $tdd, $tdd.")).toEqual([
+      { skillName: "tdd", startIndex: 1, endIndex: 5 },
+      { skillName: "tdd", startIndex: 7, endIndex: 11 },
+      { skillName: "tdd", startIndex: 13, endIndex: 17 },
+    ]);
+  });
+
+  test("rejects unsupported token starts and left boundaries", () => {
+    expect(extractInlineSkillReferenceCandidates("foo$tdd")).toEqual([]);
+    expect(extractInlineSkillReferenceCandidates("$100")).toEqual([]);
+    expect(extractInlineSkillReferenceCandidates("$PATH")).toEqual([]);
+    expect(extractInlineSkillReferenceCandidates("$-bad")).toEqual([]);
+  });
+
+  test("strips one trailing hyphen before validation", () => {
+    expect(extractInlineSkillReferenceCandidates("$bad-")).toEqual([
+      { skillName: "bad", startIndex: 0, endIndex: 4 },
+    ]);
+  });
+
+  test("skips inline code spans", () => {
+    expect(extractInlineSkillReferenceCandidates("use `$tdd` here")).toEqual([]);
+  });
+
+  test("skips fenced code blocks", () => {
+    expect(extractInlineSkillReferenceCandidates("```\n$tdd\n```")).toEqual([]);
+  });
+
+  test("extracts non-code references from mixed text", () => {
+    expect(extractInlineSkillReferenceCandidates("$tdd `$nope` $deep-review")).toEqual([
+      { skillName: "tdd", startIndex: 0, endIndex: 4 },
+      { skillName: "deep-review", startIndex: 13, endIndex: 25 },
+    ]);
+  });
+});
+
+describe("findInlineSkillReferenceAtCursor", () => {
+  test("finds a partial skill reference at the end of input", () => {
+    expect(findInlineSkillReferenceAtCursor("Use $td", 7)).toEqual({
+      partial: "td",
+      startIndex: 4,
+      endIndex: 7,
+    });
+  });
+
+  test("finds an empty partial after a bare dollar sign", () => {
+    expect(findInlineSkillReferenceAtCursor("$", 1)).toEqual({
+      partial: "",
+      startIndex: 0,
+      endIndex: 1,
+    });
+  });
+
+  test("finds the active token when the cursor is inside the skill name", () => {
+    expect(findInlineSkillReferenceAtCursor("Use $tdd more", 6)).toEqual({
+      partial: "tdd",
+      startIndex: 4,
+      endIndex: 8,
+    });
+  });
+
+  test("returns null when the cursor is out of bounds", () => {
+    expect(findInlineSkillReferenceAtCursor("$tdd", -1)).toBeNull();
+    expect(findInlineSkillReferenceAtCursor("$tdd", 5)).toBeNull();
+  });
+
+  test("returns null when the cursor is inside inline code", () => {
+    const text = "use `$td` here";
+    expect(findInlineSkillReferenceAtCursor(text, text.indexOf("$td") + 3)).toBeNull();
+  });
+
+  test("returns null when the cursor is inside a fenced code block", () => {
+    const text = "```\n$td\n```";
+    expect(findInlineSkillReferenceAtCursor(text, text.indexOf("$td") + 3)).toBeNull();
+  });
+});
+
+describe("resolveInlineSkillReferences", () => {
+  test("returns an empty list for empty candidates", async () => {
+    await expect(
+      resolveInlineSkillReferences({
+        candidates: [],
+        agentSkillDescriptors: [descriptor("tdd")],
+        api: null,
+        discovery: null,
+      })
+    ).resolves.toEqual([]);
+  });
+
+  test("resolves known local descriptors", async () => {
+    await expect(
+      resolveInlineSkillReferences({
+        candidates: [candidate("tdd")],
+        agentSkillDescriptors: [descriptor("tdd", "project")],
+        api: null,
+        discovery: null,
+      })
+    ).resolves.toEqual([{ skillName: "tdd", scope: "project", source: "inline" }]);
+  });
+
+  test("collapses duplicate candidates", async () => {
+    await expect(
+      resolveInlineSkillReferences({
+        candidates: [candidate("tdd"), candidate("tdd", 5)],
+        agentSkillDescriptors: [descriptor("tdd")],
+        api: null,
+        discovery: null,
+      })
+    ).resolves.toEqual([{ skillName: "tdd", scope: "global", source: "inline" }]);
+  });
+
+  test("silently drops unknown skills without an api", async () => {
+    await expect(
+      resolveInlineSkillReferences({
+        candidates: [candidate("unknown")],
+        agentSkillDescriptors: [],
+        api: null,
+        discovery: null,
+      })
+    ).resolves.toEqual([]);
+  });
+
+  test("silently drops skills when the api throws", async () => {
+    const api = apiClient(async () => {
+      throw new Error("not found");
+    });
+
+    await expect(
+      resolveInlineSkillReferences({
+        candidates: [candidate("unknown")],
+        agentSkillDescriptors: [],
+        api,
+        discovery: { kind: "project", projectPath: "/repo" },
+      })
+    ).resolves.toEqual([]);
+  });
+
+  test("uses backend package name and scope when remote resolution succeeds", async () => {
+    const api = apiClient(async () => skillPackage("backend-skill", "built-in"));
+
+    await expect(
+      resolveInlineSkillReferences({
+        candidates: [candidate("remote-skill")],
+        agentSkillDescriptors: [],
+        api,
+        discovery: { kind: "project", projectPath: "/repo" },
+      })
+    ).resolves.toEqual([{ skillName: "backend-skill", scope: "built-in", source: "inline" }]);
+  });
+
+  test("passes project discovery targets to the api", async () => {
+    const calls: AgentSkillsGetInput[] = [];
+    const api = apiClient(async (input) => {
+      calls.push(input);
+      return skillPackage("remote-skill", "project");
+    });
+
+    await expect(
+      resolveInlineSkillReferences({
+        candidates: [candidate("remote-skill")],
+        agentSkillDescriptors: [],
+        api,
+        discovery: { kind: "project", projectPath: "/repo" },
+      })
+    ).resolves.toEqual([{ skillName: "remote-skill", scope: "project", source: "inline" }]);
+
+    expect(calls).toEqual([{ projectPath: "/repo", skillName: "remote-skill" }]);
+  });
+
+  test("passes workspace discovery targets and disableWorkspaceAgents to the api", async () => {
+    const calls: AgentSkillsGetInput[] = [];
+    const api = apiClient(async (input) => {
+      calls.push(input);
+      return skillPackage("workspace-skill", "global");
+    });
+
+    await expect(
+      resolveInlineSkillReferences({
+        candidates: [candidate("workspace-skill")],
+        agentSkillDescriptors: [],
+        api,
+        discovery: {
+          kind: "workspace",
+          workspaceId: "workspace-1",
+          disableWorkspaceAgents: true,
+        },
+      })
+    ).resolves.toEqual([{ skillName: "workspace-skill", scope: "global", source: "inline" }]);
+
+    expect(calls).toEqual([
+      {
+        workspaceId: "workspace-1",
+        disableWorkspaceAgents: true,
+        skillName: "workspace-skill",
+      },
+    ]);
+  });
+});

--- a/src/browser/utils/agentSkills/inlineSkillReferences.test.ts
+++ b/src/browser/utils/agentSkills/inlineSkillReferences.test.ts
@@ -88,6 +88,30 @@ describe("extractInlineSkillReferenceCandidates", () => {
     expect(extractInlineSkillReferenceCandidates("use `$tdd` here")).toEqual([]);
   });
 
+  test("skips double-backtick inline code spans", () => {
+    expect(extractInlineSkillReferenceCandidates("use ``$tdd`` here")).toEqual([]);
+  });
+
+  test("skips triple-backtick inline code spans", () => {
+    expect(extractInlineSkillReferenceCandidates("use ```$tdd``` here")).toEqual([]);
+  });
+
+  test("skips multi-backtick inline code containing shorter backtick runs", () => {
+    expect(
+      extractInlineSkillReferenceCandidates("``code with `single` backtick `$tdd` ``")
+    ).toEqual([]);
+  });
+
+  test("skips unterminated multi-backtick spans conservatively", () => {
+    expect(extractInlineSkillReferenceCandidates("``$tdd`")).toEqual([]);
+  });
+
+  test("extracts references between inline code spans", () => {
+    expect(extractInlineSkillReferenceCandidates("`a` $tdd `b`")).toEqual([
+      { skillName: "tdd", startIndex: 4, endIndex: 8 },
+    ]);
+  });
+
   test("skips fenced code blocks", () => {
     expect(extractInlineSkillReferenceCandidates("```\n$tdd\n```")).toEqual([]);
   });

--- a/src/browser/utils/agentSkills/inlineSkillReferences.ts
+++ b/src/browser/utils/agentSkills/inlineSkillReferences.ts
@@ -25,7 +25,14 @@ interface TextRange {
   end: number;
 }
 
-const FENCE_MARKER = "```";
+const MIN_FENCE_MARKER_LENGTH = 3;
+type FenceChar = "`" | "~";
+
+interface FenceMarker {
+  char: FenceChar;
+  length: number;
+}
+
 const LEFT_BOUNDARY_BLOCKED_RE = /[\w$]/;
 
 function isSkillStartChar(ch: string | undefined): boolean {
@@ -44,13 +51,39 @@ function hasSaneLeftBoundary(text: string, dollarIndex: number): boolean {
   return !LEFT_BOUNDARY_BLOCKED_RE.test(text[dollarIndex - 1] ?? "");
 }
 
-function getBacktickRunLength(text: string, start: number): number {
+function getCharRunLength(text: string, start: number, ch: string): number {
   let end = start;
-  while (end < text.length && text[end] === "`") {
+  while (end < text.length && text[end] === ch) {
     end++;
   }
 
   return end - start;
+}
+
+function getBacktickRunLength(text: string, start: number): number {
+  return getCharRunLength(text, start, "`");
+}
+
+function isFenceChar(ch: string | undefined): ch is FenceChar {
+  return ch === "`" || ch === "~";
+}
+
+function isLineStart(text: string, index: number): boolean {
+  return index === 0 || text[index - 1] === "\n" || text[index - 1] === "\r";
+}
+
+function getFenceMarkerAtLineStart(text: string, index: number): FenceMarker | null {
+  const ch = text[index];
+  if (!isLineStart(text, index) || !isFenceChar(ch)) {
+    return null;
+  }
+
+  const length = getCharRunLength(text, index, ch);
+  if (length < MIN_FENCE_MARKER_LENGTH) {
+    return null;
+  }
+
+  return { char: ch, length };
 }
 
 function findLineEnd(text: string, start: number): number {
@@ -60,6 +93,15 @@ function findLineEnd(text: string, start: number): number {
   }
 
   return end;
+}
+
+function findNextLineStart(text: string, start: number): number {
+  const lineEnd = findLineEnd(text, start);
+  if (lineEnd >= text.length) {
+    return text.length;
+  }
+
+  return text[lineEnd] === "\r" && text[lineEnd + 1] === "\n" ? lineEnd + 2 : lineEnd + 1;
 }
 
 function findInlineCodeEnd(text: string, start: number, delimiterLength: number): number | null {
@@ -92,16 +134,23 @@ function collectCodeRanges(text: string): TextRange[] {
   let index = 0;
 
   while (index < text.length) {
-    if (text.startsWith(FENCE_MARKER, index)) {
+    const fenceMarker = getFenceMarkerAtLineStart(text, index);
+    if (fenceMarker) {
       const fenceStart = index;
-      index += FENCE_MARKER.length;
+      index = findNextLineStart(text, index);
 
-      while (index < text.length && !text.startsWith(FENCE_MARKER, index)) {
-        index++;
-      }
+      while (index < text.length) {
+        const closingFenceMarker = getFenceMarkerAtLineStart(text, index);
+        if (
+          closingFenceMarker &&
+          closingFenceMarker.char === fenceMarker.char &&
+          closingFenceMarker.length >= fenceMarker.length
+        ) {
+          index += closingFenceMarker.length;
+          break;
+        }
 
-      if (index < text.length) {
-        index += FENCE_MARKER.length;
+        index = findNextLineStart(text, index);
       }
 
       ranges.push({ start: fenceStart, end: index });

--- a/src/browser/utils/agentSkills/inlineSkillReferences.ts
+++ b/src/browser/utils/agentSkills/inlineSkillReferences.ts
@@ -1,0 +1,280 @@
+import type { APIClient } from "@/browser/contexts/API";
+import type { SkillResolutionTarget } from "@/browser/features/ChatInput/utils";
+import { SkillNameSchema } from "@/common/orpc/schemas/agentSkill";
+import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
+import type { AgentSkillReference } from "@/common/types/message";
+import { dedupeAgentSkillRefs } from "@/common/types/message";
+
+/** Parser-only candidate. The startIndex/endIndex are autocomplete-replacement aids
+ *  and MUST NOT be persisted in metadata (they become ambiguous after edits/reviews/etc.). */
+export interface InlineSkillCandidate {
+  skillName: string;
+  startIndex: number;
+  endIndex: number;
+}
+
+/** Active candidate when the cursor is inside a `$partial` token (used by autocomplete). */
+export interface InlineSkillCursorMatch {
+  partial: string;
+  startIndex: number;
+  endIndex: number;
+}
+
+interface TextRange {
+  start: number;
+  end: number;
+}
+
+const FENCE_MARKER = "```";
+const LEFT_BOUNDARY_BLOCKED_RE = /[\w$]/;
+
+function isSkillStartChar(ch: string | undefined): boolean {
+  return Boolean(ch && ch >= "a" && ch <= "z");
+}
+
+function isSkillContinuationChar(ch: string | undefined): boolean {
+  return Boolean(ch && ((ch >= "a" && ch <= "z") || (ch >= "0" && ch <= "9") || ch === "-"));
+}
+
+function hasSaneLeftBoundary(text: string, dollarIndex: number): boolean {
+  if (dollarIndex === 0) {
+    return true;
+  }
+
+  return !LEFT_BOUNDARY_BLOCKED_RE.test(text[dollarIndex - 1] ?? "");
+}
+
+function collectCodeRanges(text: string): TextRange[] {
+  const ranges: TextRange[] = [];
+  let inlineCodeStart: number | null = null;
+  let index = 0;
+
+  while (index < text.length) {
+    if (text.startsWith(FENCE_MARKER, index)) {
+      const fenceStart = index;
+      inlineCodeStart = null;
+      index += FENCE_MARKER.length;
+
+      while (index < text.length && !text.startsWith(FENCE_MARKER, index)) {
+        index++;
+      }
+
+      if (index < text.length) {
+        index += FENCE_MARKER.length;
+      }
+
+      ranges.push({ start: fenceStart, end: index });
+      continue;
+    }
+
+    const ch = text[index];
+    if (ch === "\n" || ch === "\r") {
+      inlineCodeStart = null;
+      index++;
+      continue;
+    }
+
+    if (ch === "`") {
+      if (inlineCodeStart === null) {
+        inlineCodeStart = index;
+      } else {
+        ranges.push({ start: inlineCodeStart, end: index + 1 });
+        inlineCodeStart = null;
+      }
+    }
+
+    index++;
+  }
+
+  return ranges;
+}
+
+function isPositionInRange(position: number, range: TextRange): boolean {
+  return position >= range.start && position < range.end;
+}
+
+function isCursorInsideCodeRange(cursor: number, range: TextRange): boolean {
+  return cursor > range.start && cursor < range.end;
+}
+
+function isPartialToken(rawPartial: string): boolean {
+  if (rawPartial.length === 0) {
+    return true;
+  }
+
+  if (!isSkillStartChar(rawPartial[0])) {
+    return false;
+  }
+
+  for (let index = 1; index < rawPartial.length; index++) {
+    if (!isSkillContinuationChar(rawPartial[index])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function extractInlineSkillReferenceCandidates(text: string): InlineSkillCandidate[] {
+  if (!text.includes("$")) {
+    return [];
+  }
+
+  const codeRanges = collectCodeRanges(text);
+  const candidates: InlineSkillCandidate[] = [];
+  let codeRangeIndex = 0;
+
+  for (let index = 0; index < text.length; index++) {
+    while (codeRangeIndex < codeRanges.length && index >= codeRanges[codeRangeIndex].end) {
+      codeRangeIndex++;
+    }
+
+    const codeRange = codeRanges[codeRangeIndex];
+    if (codeRange && isPositionInRange(index, codeRange)) {
+      index = codeRange.end - 1;
+      continue;
+    }
+
+    if (text[index] !== "$" || !hasSaneLeftBoundary(text, index)) {
+      continue;
+    }
+
+    if (!isSkillStartChar(text[index + 1])) {
+      continue;
+    }
+
+    let tokenEnd = index + 2;
+    while (tokenEnd < text.length && isSkillContinuationChar(text[tokenEnd])) {
+      tokenEnd++;
+    }
+
+    const rawTokenEnd = tokenEnd;
+    let skillName = text.slice(index + 1, tokenEnd);
+    if (skillName.endsWith("-")) {
+      skillName = skillName.slice(0, -1);
+      tokenEnd--;
+    }
+
+    if (SkillNameSchema.safeParse(skillName).success) {
+      candidates.push({ skillName, startIndex: index, endIndex: tokenEnd });
+    }
+
+    index = rawTokenEnd - 1;
+  }
+
+  return candidates;
+}
+
+export function findInlineSkillReferenceAtCursor(
+  text: string,
+  cursor: number
+): InlineSkillCursorMatch | null {
+  if (!Number.isInteger(cursor) || cursor < 0 || cursor > text.length || !text.includes("$")) {
+    return null;
+  }
+
+  const codeRanges = collectCodeRanges(text);
+  if (codeRanges.some((range) => isCursorInsideCodeRange(cursor, range))) {
+    return null;
+  }
+
+  let tokenStart = cursor;
+  while (tokenStart > 0 && isSkillContinuationChar(text[tokenStart - 1])) {
+    tokenStart--;
+  }
+
+  const dollarIndex = tokenStart > 0 && text[tokenStart - 1] === "$" ? tokenStart - 1 : -1;
+  if (dollarIndex === -1 || !hasSaneLeftBoundary(text, dollarIndex)) {
+    return null;
+  }
+
+  let tokenEnd = cursor;
+  while (tokenEnd < text.length && isSkillContinuationChar(text[tokenEnd])) {
+    tokenEnd++;
+  }
+
+  const partial = text.slice(dollarIndex + 1, tokenEnd);
+  if (!isPartialToken(partial)) {
+    return null;
+  }
+
+  return {
+    partial,
+    startIndex: dollarIndex,
+    endIndex: tokenEnd,
+  };
+}
+
+export interface InlineSkillResolveOptions {
+  candidates: InlineSkillCandidate[];
+  agentSkillDescriptors: AgentSkillDescriptor[];
+  api: APIClient | null;
+  discovery: SkillResolutionTarget | null;
+}
+
+async function resolveRemoteSkill(options: {
+  skillName: string;
+  api: APIClient;
+  discovery: SkillResolutionTarget;
+}): Promise<AgentSkillDescriptor | null> {
+  try {
+    const pkg =
+      options.discovery.kind === "project"
+        ? await options.api.agentSkills.get({
+            projectPath: options.discovery.projectPath,
+            skillName: options.skillName,
+          })
+        : await options.api.agentSkills.get({
+            workspaceId: options.discovery.workspaceId,
+            disableWorkspaceAgents: options.discovery.disableWorkspaceAgents,
+            skillName: options.skillName,
+          });
+
+    return {
+      name: pkg.frontmatter.name,
+      description: pkg.frontmatter.description,
+      scope: pkg.scope,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveInlineSkillReferences(
+  options: InlineSkillResolveOptions
+): Promise<AgentSkillReference[]> {
+  if (options.candidates.length === 0) {
+    return [];
+  }
+
+  const refs: AgentSkillReference[] = [];
+  const seenSkillNames = new Set<string>();
+
+  for (const candidate of options.candidates) {
+    if (seenSkillNames.has(candidate.skillName)) {
+      continue;
+    }
+    seenSkillNames.add(candidate.skillName);
+
+    let skill = options.agentSkillDescriptors.find(
+      (descriptor) => descriptor.name === candidate.skillName
+    );
+
+    if (!skill && options.api && options.discovery) {
+      skill =
+        (await resolveRemoteSkill({
+          skillName: candidate.skillName,
+          api: options.api,
+          discovery: options.discovery,
+        })) ?? undefined;
+    }
+
+    if (!skill) {
+      continue;
+    }
+
+    refs.push({ skillName: skill.name, scope: skill.scope, source: "inline" });
+  }
+
+  return dedupeAgentSkillRefs(refs);
+}

--- a/src/browser/utils/agentSkills/inlineSkillReferences.ts
+++ b/src/browser/utils/agentSkills/inlineSkillReferences.ts
@@ -117,6 +117,18 @@ function findNextLineStart(text: string, start: number): number {
   return text[lineEnd] === "\r" && text[lineEnd + 1] === "\n" ? lineEnd + 2 : lineEnd + 1;
 }
 
+function hasOnlySpacesOrTabsUntilLineEnd(text: string, start: number): boolean {
+  const lineEnd = findLineEnd(text, start);
+  for (let index = start; index < lineEnd; index++) {
+    const ch = text[index];
+    if (ch !== " " && ch !== "\t") {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 function findInlineCodeEnd(text: string, start: number, delimiterLength: number): number | null {
   let index = start;
   while (index < text.length) {
@@ -157,7 +169,11 @@ function collectCodeRanges(text: string): TextRange[] {
         if (
           closingFenceMarker &&
           closingFenceMarker.char === fenceMarker.char &&
-          closingFenceMarker.length >= fenceMarker.length
+          closingFenceMarker.length >= fenceMarker.length &&
+          hasOnlySpacesOrTabsUntilLineEnd(
+            text,
+            closingFenceMarker.markerStart + closingFenceMarker.length
+          )
         ) {
           index = closingFenceMarker.markerStart + closingFenceMarker.length;
           break;

--- a/src/browser/utils/agentSkills/inlineSkillReferences.ts
+++ b/src/browser/utils/agentSkills/inlineSkillReferences.ts
@@ -44,15 +44,56 @@ function hasSaneLeftBoundary(text: string, dollarIndex: number): boolean {
   return !LEFT_BOUNDARY_BLOCKED_RE.test(text[dollarIndex - 1] ?? "");
 }
 
+function getBacktickRunLength(text: string, start: number): number {
+  let end = start;
+  while (end < text.length && text[end] === "`") {
+    end++;
+  }
+
+  return end - start;
+}
+
+function findLineEnd(text: string, start: number): number {
+  let end = start;
+  while (end < text.length && text[end] !== "\n" && text[end] !== "\r") {
+    end++;
+  }
+
+  return end;
+}
+
+function findInlineCodeEnd(text: string, start: number, delimiterLength: number): number | null {
+  let index = start;
+  while (index < text.length) {
+    const ch = text[index];
+    if (ch === "\n" || ch === "\r") {
+      return null;
+    }
+
+    if (ch !== "`") {
+      index++;
+      continue;
+    }
+
+    const runLength = getBacktickRunLength(text, index);
+    index += runLength;
+
+    // Markdown inline code spans close only on the first backtick run of the same length.
+    if (runLength === delimiterLength) {
+      return index;
+    }
+  }
+
+  return null;
+}
+
 function collectCodeRanges(text: string): TextRange[] {
   const ranges: TextRange[] = [];
-  let inlineCodeStart: number | null = null;
   let index = 0;
 
   while (index < text.length) {
     if (text.startsWith(FENCE_MARKER, index)) {
       const fenceStart = index;
-      inlineCodeStart = null;
       index += FENCE_MARKER.length;
 
       while (index < text.length && !text.startsWith(FENCE_MARKER, index)) {
@@ -69,18 +110,29 @@ function collectCodeRanges(text: string): TextRange[] {
 
     const ch = text[index];
     if (ch === "\n" || ch === "\r") {
-      inlineCodeStart = null;
       index++;
       continue;
     }
 
     if (ch === "`") {
-      if (inlineCodeStart === null) {
-        inlineCodeStart = index;
-      } else {
-        ranges.push({ start: inlineCodeStart, end: index + 1 });
-        inlineCodeStart = null;
+      const rangeStart = index;
+      const delimiterLength = getBacktickRunLength(text, index);
+      index += delimiterLength;
+
+      const rangeEnd = findInlineCodeEnd(text, index, delimiterLength);
+      if (rangeEnd !== null) {
+        ranges.push({ start: rangeStart, end: rangeEnd });
+        index = rangeEnd;
+        continue;
       }
+
+      if (delimiterLength > 1) {
+        const lineEnd = findLineEnd(text, index);
+        ranges.push({ start: rangeStart, end: lineEnd });
+        index = lineEnd;
+      }
+
+      continue;
     }
 
     index++;

--- a/src/browser/utils/agentSkills/inlineSkillReferences.ts
+++ b/src/browser/utils/agentSkills/inlineSkillReferences.ts
@@ -26,11 +26,13 @@ interface TextRange {
 }
 
 const MIN_FENCE_MARKER_LENGTH = 3;
+const MAX_FENCE_MARKER_INDENTATION = 3;
 type FenceChar = "`" | "~";
 
 interface FenceMarker {
   char: FenceChar;
   length: number;
+  markerStart: number;
 }
 
 const LEFT_BOUNDARY_BLOCKED_RE = /[\w$]/;
@@ -73,17 +75,28 @@ function isLineStart(text: string, index: number): boolean {
 }
 
 function getFenceMarkerAtLineStart(text: string, index: number): FenceMarker | null {
-  const ch = text[index];
-  if (!isLineStart(text, index) || !isFenceChar(ch)) {
+  if (!isLineStart(text, index)) {
     return null;
   }
 
-  const length = getCharRunLength(text, index, ch);
+  let markerStart = index;
+  let indentation = 0;
+  while (indentation < MAX_FENCE_MARKER_INDENTATION && text[markerStart] === " ") {
+    markerStart++;
+    indentation++;
+  }
+
+  const ch = text[markerStart];
+  if (!isFenceChar(ch)) {
+    return null;
+  }
+
+  const length = getCharRunLength(text, markerStart, ch);
   if (length < MIN_FENCE_MARKER_LENGTH) {
     return null;
   }
 
-  return { char: ch, length };
+  return { char: ch, length, markerStart };
 }
 
 function findLineEnd(text: string, start: number): number {
@@ -146,7 +159,7 @@ function collectCodeRanges(text: string): TextRange[] {
           closingFenceMarker.char === fenceMarker.char &&
           closingFenceMarker.length >= fenceMarker.length
         ) {
-          index += closingFenceMarker.length;
+          index = closingFenceMarker.markerStart + closingFenceMarker.length;
           break;
         }
 

--- a/src/browser/utils/agentSkills/inlineSkillSuggestions.test.ts
+++ b/src/browser/utils/agentSkills/inlineSkillSuggestions.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
+import { getInlineSkillSuggestions } from "./inlineSkillSuggestions";
+
+function descriptor(name: string, description = `${name} description`): AgentSkillDescriptor {
+  return { name, description, scope: "global" };
+}
+
+describe("getInlineSkillSuggestions", () => {
+  test("returns an empty list when no descriptors are loaded", () => {
+    expect(getInlineSkillSuggestions({ partial: "", descriptors: [] })).toEqual([]);
+  });
+
+  test("returns all descriptors for an empty partial", () => {
+    expect(
+      getInlineSkillSuggestions({
+        partial: "",
+        descriptors: [descriptor("tdd"), descriptor("deep-review")],
+      })
+    ).toEqual([
+      {
+        id: "inline-skill:tdd",
+        display: "$tdd",
+        description: "tdd description",
+        replacement: "$tdd",
+      },
+      {
+        id: "inline-skill:deep-review",
+        display: "$deep-review",
+        description: "deep-review description",
+        replacement: "$deep-review",
+      },
+    ]);
+  });
+
+  test("returns only descriptors whose names start with the partial", () => {
+    expect(
+      getInlineSkillSuggestions({
+        partial: "tdd",
+        descriptors: [descriptor("tdd"), descriptor("tdd-review"), descriptor("deep-review")],
+      }).map((suggestion) => suggestion.display)
+    ).toEqual(["$tdd", "$tdd-review"]);
+  });
+
+  test("matches uppercase partials against canonical lowercase names", () => {
+    expect(
+      getInlineSkillSuggestions({
+        partial: "TDD",
+        descriptors: [descriptor("tdd"), descriptor("deep-review")],
+      }).map((suggestion) => suggestion.display)
+    ).toEqual(["$tdd"]);
+  });
+
+  test("maps descriptor fields into the suggestion shape", () => {
+    expect(
+      getInlineSkillSuggestions({
+        partial: "deep",
+        descriptors: [descriptor("deep-review", "Deep review description")],
+      })
+    ).toEqual([
+      {
+        id: "inline-skill:deep-review",
+        display: "$deep-review",
+        description: "Deep review description",
+        replacement: "$deep-review",
+      },
+    ]);
+  });
+
+  test("suggests skills that collide with slash command names", () => {
+    expect(
+      getInlineSkillSuggestions({
+        partial: "clear",
+        descriptors: [descriptor("clear"), descriptor("clear-cache")],
+      }).map((suggestion) => suggestion.display)
+    ).toEqual(["$clear", "$clear-cache"]);
+  });
+
+  test("preserves descriptor input order", () => {
+    expect(
+      getInlineSkillSuggestions({
+        partial: "",
+        descriptors: [descriptor("deep-review"), descriptor("tdd"), descriptor("clear")],
+      }).map((suggestion) => suggestion.display)
+    ).toEqual(["$deep-review", "$tdd", "$clear"]);
+  });
+});

--- a/src/browser/utils/agentSkills/inlineSkillSuggestions.test.ts
+++ b/src/browser/utils/agentSkills/inlineSkillSuggestions.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
-import { getInlineSkillSuggestions } from "./inlineSkillSuggestions";
+import {
+  getInlineSkillInsertionTrailingText,
+  getInlineSkillSuggestions,
+  shouldRefreshInlineSkillSuggestions,
+} from "./inlineSkillSuggestions";
 
 function descriptor(name: string, description = `${name} description`): AgentSkillDescriptor {
   return { name, description, scope: "global" };
@@ -83,5 +87,56 @@ describe("getInlineSkillSuggestions", () => {
         descriptors: [descriptor("deep-review"), descriptor("tdd"), descriptor("clear")],
       }).map((suggestion) => suggestion.display)
     ).toEqual(["$deep-review", "$tdd", "$clear"]);
+  });
+});
+
+describe("shouldRefreshInlineSkillSuggestions", () => {
+  test("refreshes when descriptor discovery updates an unchanged partial", () => {
+    const previousDescriptors: AgentSkillDescriptor[] = [];
+    const descriptors = [descriptor("deep-review")];
+
+    expect(
+      shouldRefreshInlineSkillSuggestions({
+        inputChanged: false,
+        previousPartial: "dee",
+        partial: "dee",
+        previousDescriptors,
+        descriptors,
+      })
+    ).toBe(true);
+  });
+
+  test("skips only when input, partial, and descriptor list identity are unchanged", () => {
+    const descriptors = [descriptor("deep-review")];
+
+    expect(
+      shouldRefreshInlineSkillSuggestions({
+        inputChanged: false,
+        previousPartial: "dee",
+        partial: "dee",
+        previousDescriptors: descriptors,
+        descriptors,
+      })
+    ).toBe(false);
+  });
+});
+
+describe("getInlineSkillInsertionTrailingText", () => {
+  test("does not add a space before punctuation that should bind to the skill", () => {
+    const punctuation = [",", ".", ";", ":", "!", "?", ")", "]", "}", ">", '"', "'", "`"];
+
+    for (const nextCharacter of punctuation) {
+      expect(getInlineSkillInsertionTrailingText(nextCharacter)).toBe("");
+    }
+  });
+
+  test("preserves existing whitespace and end-of-line behavior", () => {
+    expect(getInlineSkillInsertionTrailingText("")).toBe("");
+    expect(getInlineSkillInsertionTrailingText(" next")).toBe("");
+    expect(getInlineSkillInsertionTrailingText("\nnext")).toBe("");
+  });
+
+  test("adds a separator before adjacent text", () => {
+    expect(getInlineSkillInsertionTrailingText("next")).toBe(" ");
   });
 });

--- a/src/browser/utils/agentSkills/inlineSkillSuggestions.ts
+++ b/src/browser/utils/agentSkills/inlineSkillSuggestions.ts
@@ -8,6 +8,34 @@ export interface InlineSkillSuggestionContext {
   descriptors: AgentSkillDescriptor[];
 }
 
+export interface InlineSkillSuggestionRefreshContext {
+  inputChanged: boolean;
+  previousPartial: string | null;
+  partial: string;
+  previousDescriptors: AgentSkillDescriptor[] | null;
+  descriptors: AgentSkillDescriptor[];
+}
+
+const INLINE_SKILL_INSERT_EXISTING_SEPARATOR_RE = /[\s.,;:!?)\]}>"'`]/;
+
+export function shouldRefreshInlineSkillSuggestions(
+  context: InlineSkillSuggestionRefreshContext
+): boolean {
+  return (
+    context.inputChanged ||
+    context.previousPartial !== context.partial ||
+    context.previousDescriptors !== context.descriptors
+  );
+}
+
+export function getInlineSkillInsertionTrailingText(after: string): "" | " " {
+  // Characters where inserting a space before them would be wrong: whitespace,
+  // sentence punctuation, and closers that should bind to the skill reference.
+  return after.length === 0 || INLINE_SKILL_INSERT_EXISTING_SEPARATOR_RE.test(after[0] ?? "")
+    ? ""
+    : " ";
+}
+
 /**
  * Returns suggestions for `$skill` autocomplete.
  *

--- a/src/browser/utils/agentSkills/inlineSkillSuggestions.ts
+++ b/src/browser/utils/agentSkills/inlineSkillSuggestions.ts
@@ -1,0 +1,34 @@
+import type { SlashSuggestion } from "@/browser/utils/slashCommands/types";
+import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
+
+export interface InlineSkillSuggestionContext {
+  /** The token typed after `$`. Empty string is allowed (just typed `$`). */
+  partial: string;
+  /** Already-loaded descriptors for current discovery target. */
+  descriptors: AgentSkillDescriptor[];
+}
+
+/**
+ * Returns suggestions for `$skill` autocomplete.
+ *
+ * - Filter rule: descriptor.name.startsWith(partial). Case-sensitive skill names are
+ *   canonical lowercase IDs (validated by SkillNameSchema), so normalize the user's partial.
+ * - Empty `partial` returns the full descriptor list (so typing just `$` opens the menu).
+ * - Result order: descriptors order from caller (no re-sort). Caller already lists in
+ *   scope-priority order.
+ * - We do NOT filter out skills whose name collides with a slash command (e.g. `clear`):
+ *   `$clear` should reference a skill named `clear` even though `/clear` is a built-in.
+ */
+export function getInlineSkillSuggestions(
+  context: InlineSkillSuggestionContext
+): SlashSuggestion[] {
+  const lowered = context.partial.toLowerCase();
+  return context.descriptors
+    .filter((descriptor) => descriptor.name.startsWith(lowered))
+    .map((descriptor) => ({
+      id: `inline-skill:${descriptor.name}`,
+      display: `$${descriptor.name}`,
+      description: descriptor.description ?? "",
+      replacement: `$${descriptor.name}`,
+    }));
+}

--- a/src/browser/utils/frontendBasePath.ts
+++ b/src/browser/utils/frontendBasePath.ts
@@ -1,7 +1,22 @@
 import { getAppProxyBasePathFromPathname, stripAppProxyBasePath } from "@/common/appProxyBasePath";
 
-export const INITIAL_APP_PROXY_BASE_PATH =
-  typeof window === "undefined" ? null : getAppProxyBasePathFromPathname(window.location.pathname);
+// window.location can be missing in some test, SSR, or embed contexts even when
+// window itself exists. Guard both so module initialization cannot throw and leave
+// downstream importers with a TDZ-poisoned export.
+function readInitialAppProxyBasePath(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const location = (window as { location?: { pathname?: string } }).location;
+  if (!location || typeof location.pathname !== "string") {
+    return null;
+  }
+
+  return getAppProxyBasePathFromPathname(location.pathname);
+}
+
+export const INITIAL_APP_PROXY_BASE_PATH = readInitialAppProxyBasePath();
 
 function normalizeRootRelativePath(pathname: string): string {
   return pathname.startsWith("/") ? pathname : `/${pathname}`;

--- a/src/browser/utils/messages/StreamingMessageAggregator.skills.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.skills.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import type { AgentSkillScope } from "@/common/types/agentSkill";
-import { createMuxMessage } from "@/common/types/message";
+import {
+  createMuxMessage,
+  type AgentSkillReference,
+  type DisplayedUserMessage,
+} from "@/common/types/message";
 import { StreamingMessageAggregator } from "./StreamingMessageAggregator";
 
 const TEST_CREATED_AT = "2024-01-01T00:00:00.000Z";
@@ -166,6 +170,40 @@ const createSkillInvocationMessage = ({
       scope,
     },
   });
+};
+
+const createInlineSkillMessage = ({
+  id = "inline-1",
+  content = "Use inline skills",
+  historySequence,
+  refs,
+}: {
+  id?: string;
+  content?: string;
+  historySequence: number;
+  refs: AgentSkillReference[];
+}) =>
+  createMuxMessage(id, "user", content, {
+    historySequence,
+    timestamp: 0,
+    muxMetadata: {
+      type: "normal",
+      agentSkillRefs: refs,
+    },
+  });
+
+const getSingleDisplayedUserMessage = (
+  aggregator: StreamingMessageAggregator
+): DisplayedUserMessage => {
+  const displayed = aggregator.getDisplayedMessages();
+  expect(displayed).toHaveLength(1);
+
+  const message = displayed[0];
+  if (message?.type !== "user") {
+    throw new Error("Expected displayed user message");
+  }
+
+  return message;
 };
 
 describe("Loaded skills tracking", () => {
@@ -531,6 +569,156 @@ describe("Agent skill snapshot association", () => {
     expect(secondMessage.agentSkill?.snapshot).toEqual({
       frontmatterYaml: secondFrontmatter,
       body: "# Second",
+    });
+  });
+
+  it("attaches prior snapshots for multiple inline skill refs", () => {
+    const aggregator = createAggregator();
+    const deepReviewSnapshot = createSkillSnapshotMessage({
+      id: "snapshot-deep-review",
+      skillName: "deep-review",
+      scope: "global",
+      historySequence: 1,
+      body: "# Deep review",
+      frontmatterYaml: "name: deep-review\ndescription: Review deeply",
+    });
+    const tddSnapshot = createSkillSnapshotMessage({
+      id: "snapshot-tdd",
+      skillName: "tdd",
+      scope: "project",
+      historySequence: 2,
+      body: "# TDD",
+      frontmatterYaml: "name: tdd\ndescription: Test-first changes",
+    });
+    const invocation = createInlineSkillMessage({
+      historySequence: 3,
+      content: "Use $deep-review and $tdd",
+      refs: [
+        { skillName: "deep-review", scope: "global", source: "inline" },
+        { skillName: "tdd", scope: "project", source: "inline" },
+      ],
+    });
+
+    aggregator.loadHistoricalMessages([deepReviewSnapshot, tddSnapshot, invocation]);
+
+    const message = getSingleDisplayedUserMessage(aggregator);
+    expect(Object.keys(message.inlineSkillSnapshots ?? {}).sort()).toEqual(["deep-review", "tdd"]);
+    expect(message.inlineSkillSnapshots?.["deep-review"]).toEqual({
+      skillName: "deep-review",
+      scope: "global",
+      snapshot: {
+        frontmatterYaml: "name: deep-review\ndescription: Review deeply",
+        body: "# Deep review",
+      },
+    });
+    expect(message.inlineSkillSnapshots?.tdd).toEqual({
+      skillName: "tdd",
+      scope: "project",
+      snapshot: {
+        frontmatterYaml: "name: tdd\ndescription: Test-first changes",
+        body: "# TDD",
+      },
+    });
+  });
+
+  it("collapses repeated inline refs for the same skill", () => {
+    const aggregator = createAggregator();
+    const snapshot = createSkillSnapshotMessage({
+      id: "snapshot-tdd",
+      skillName: "tdd",
+      scope: "project",
+      historySequence: 1,
+      body: "# TDD",
+    });
+    const invocation = createInlineSkillMessage({
+      historySequence: 2,
+      content: "Use $tdd and $tdd again",
+      refs: [
+        { skillName: "tdd", scope: "project", source: "inline" },
+        { skillName: "tdd", scope: "project", source: "inline" },
+      ],
+    });
+
+    aggregator.loadHistoricalMessages([snapshot, invocation]);
+
+    const message = getSingleDisplayedUserMessage(aggregator);
+    expect(Object.keys(message.inlineSkillSnapshots ?? {})).toEqual(["tdd"]);
+    expect(message.inlineSkillSnapshots?.tdd).toEqual({
+      skillName: "tdd",
+      scope: "project",
+      snapshot: { frontmatterYaml: undefined, body: "# TDD" },
+    });
+  });
+
+  it("omits inline refs that do not have an available snapshot", () => {
+    const aggregator = createAggregator();
+    const invocation = createInlineSkillMessage({
+      historySequence: 1,
+      content: "Use $missing-skill",
+      refs: [{ skillName: "missing-skill", scope: "project", source: "inline" }],
+    });
+
+    aggregator.loadHistoricalMessages([invocation]);
+
+    const message = getSingleDisplayedUserMessage(aggregator);
+    expect(message.inlineSkillSnapshots).toBeUndefined();
+  });
+
+  it("keeps slash and inline skill snapshots in separate display fields", () => {
+    const aggregator = createAggregator();
+    const slashSnapshot = createSkillSnapshotMessage({
+      id: "snapshot-pull-requests",
+      skillName: "pull-requests",
+      scope: "project",
+      historySequence: 1,
+      body: "# PR workflow",
+      frontmatterYaml: "name: pull-requests\ndescription: PR workflow",
+    });
+    const inlineSnapshot = createSkillSnapshotMessage({
+      id: "snapshot-tdd",
+      skillName: "tdd",
+      scope: "global",
+      historySequence: 2,
+      body: "# TDD global",
+      frontmatterYaml: "name: tdd\ndescription: Test-first changes",
+    });
+    const command = "/pull-requests use $tdd";
+    const invocation = createMuxMessage("mixed-invoke", "user", command, {
+      historySequence: 3,
+      timestamp: 0,
+      muxMetadata: {
+        type: "agent-skill",
+        rawCommand: command,
+        commandPrefix: "/pull-requests",
+        skillName: "pull-requests",
+        scope: "project",
+        agentSkillRefs: [
+          { skillName: "pull-requests", scope: "project", source: "slash" },
+          { skillName: "tdd", scope: "global", source: "inline" },
+        ],
+      },
+    });
+
+    aggregator.loadHistoricalMessages([slashSnapshot, inlineSnapshot, invocation]);
+
+    const message = getSingleDisplayedUserMessage(aggregator);
+    expect(message.agentSkill).toEqual({
+      skillName: "pull-requests",
+      scope: "project",
+      snapshot: {
+        frontmatterYaml: "name: pull-requests\ndescription: PR workflow",
+        body: "# PR workflow",
+      },
+    });
+    expect(message.inlineSkillSnapshots).toEqual({
+      tdd: {
+        skillName: "tdd",
+        scope: "global",
+        snapshot: {
+          frontmatterYaml: "name: tdd\ndescription: Test-first changes",
+          body: "# TDD global",
+        },
+      },
     });
   });
 });

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -350,11 +350,17 @@ function maybeCollectAgentSkillSnapshot(
   });
 }
 
+function isAgentSkillReferenceArray(
+  refs: readonly AgentSkillReference[] | undefined
+): refs is readonly AgentSkillReference[] {
+  return Array.isArray(refs);
+}
+
 function deriveInlineSkillSnapshotDisplayState(
   refs: readonly AgentSkillReference[] | undefined,
   latestAgentSkillSnapshotByKey: ReadonlyMap<string, AgentSkillSnapshotContent>
 ): InlineSkillSnapshotDisplayState {
-  if (!refs || refs.length === 0) {
+  if (!isAgentSkillReferenceArray(refs) || refs.length === 0) {
     return {};
   }
 

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -4,6 +4,8 @@ import type {
   MuxFilePart,
   DisplayedMessage,
   CompactionRequestData,
+  InlineSkillSnapshotMap,
+  AgentSkillReference,
 } from "@/common/types/message";
 import { createMuxMessage, getCompactionFollowUpContent } from "@/common/types/message";
 
@@ -300,7 +302,12 @@ function extractAgentSkillSnapshotBody(snapshotText: string): string | null {
 interface AgentSkillSnapshotContent {
   sha256?: string;
   frontmatterYaml?: string;
-  body: string;
+  body?: string;
+}
+
+interface InlineSkillSnapshotDisplayState {
+  snapshots?: InlineSkillSnapshotMap;
+  cacheKey?: string;
 }
 
 function getTextPartContent(parts: ReadonlyArray<MuxMessage["parts"][number]>): string {
@@ -343,6 +350,56 @@ function maybeCollectAgentSkillSnapshot(
   });
 }
 
+function deriveInlineSkillSnapshotDisplayState(
+  refs: ReadonlyArray<AgentSkillReference> | undefined,
+  latestAgentSkillSnapshotByKey: ReadonlyMap<string, AgentSkillSnapshotContent>
+): InlineSkillSnapshotDisplayState {
+  if (!refs || refs.length === 0) {
+    return {};
+  }
+
+  const snapshotsBySkillName: InlineSkillSnapshotMap = {};
+  const cacheEntryBySkillName = new Map<string, string>();
+
+  for (const ref of refs) {
+    if (ref.source !== "inline") {
+      continue;
+    }
+
+    const snapshot = latestAgentSkillSnapshotByKey.get(
+      getAgentSkillSnapshotKey(ref.scope, ref.skillName)
+    );
+    if (!snapshot || (snapshot.frontmatterYaml === undefined && snapshot.body === undefined)) {
+      continue;
+    }
+
+    snapshotsBySkillName[ref.skillName] = {
+      skillName: ref.skillName,
+      scope: ref.scope,
+      snapshot: {
+        frontmatterYaml: snapshot.frontmatterYaml,
+        body: snapshot.body,
+      },
+    };
+    cacheEntryBySkillName.set(
+      ref.skillName,
+      `${ref.scope}|${ref.skillName}|${snapshot.sha256 ?? ""}`
+    );
+  }
+
+  if (cacheEntryBySkillName.size === 0) {
+    return {};
+  }
+
+  return {
+    snapshots: snapshotsBySkillName,
+    cacheKey: Array.from(cacheEntryBySkillName.entries())
+      .sort(([leftSkillName], [rightSkillName]) => leftSkillName.localeCompare(rightSkillName))
+      .map(([, cacheEntry]) => cacheEntry)
+      .join("\n"),
+  };
+}
+
 export class StreamingMessageAggregator {
   private messages = new Map<string, MuxMessage>();
   private activeStreams = new Map<string, StreamingContext>();
@@ -351,7 +408,12 @@ export class StreamingMessageAggregator {
   // Adding a new cached value? Add it here and it will auto-invalidate.
   private displayedMessageCache = new Map<
     string,
-    { version: number; agentSkillSnapshotCacheKey?: string; messages: DisplayedMessage[] }
+    {
+      version: number;
+      agentSkillSnapshotCacheKey?: string;
+      inlineSkillSnapshotsCacheKey?: string;
+      messages: DisplayedMessage[];
+    }
   >();
   private messageVersions = new Map<string, number>();
   private cache: {
@@ -2708,7 +2770,8 @@ export class StreamingMessageAggregator {
 
   private buildDisplayedMessagesForMessage(
     message: MuxMessage,
-    agentSkillSnapshot?: { frontmatterYaml?: string; body?: string }
+    agentSkillSnapshot?: { frontmatterYaml?: string; body?: string },
+    inlineSkillSnapshots?: InlineSkillSnapshotMap
   ): DisplayedMessage[] {
     const displayedMessages: DisplayedMessage[] = [];
     const baseTimestamp = message.metadata?.timestamp;
@@ -2794,6 +2857,7 @@ export class StreamingMessageAggregator {
         isSynthetic: message.metadata?.synthetic === true ? true : undefined,
         timestamp: baseTimestamp,
         agentSkill,
+        inlineSkillSnapshots,
         compactionRequest,
         reviews,
       });
@@ -3025,8 +3089,8 @@ export class StreamingMessageAggregator {
 
       // Synthetic agent-skill snapshot messages are hidden from the transcript unless
       // debugLlmRequest is enabled. We still want to surface their content in the UI by
-      // attaching the resolved snapshot (frontmatterYaml + body) to the *subsequent*
-      // /{skillName} invocation message.
+      // attaching the resolved snapshot (frontmatterYaml + body) to subsequent user
+      // messages that reference skills via /{skillName} or inline $skillName tokens.
       const latestAgentSkillSnapshotByKey = new Map<string, AgentSkillSnapshotContent>();
 
       for (const message of allMessages) {
@@ -3058,20 +3122,35 @@ export class StreamingMessageAggregator {
           ? `${agentSkillSnapshot.sha256 ?? ""}\n${agentSkillSnapshot.frontmatterYaml ?? ""}`
           : undefined;
 
+        const inlineSkillSnapshotState =
+          message.role === "user"
+            ? deriveInlineSkillSnapshotDisplayState(
+                muxMeta?.agentSkillRefs,
+                latestAgentSkillSnapshotByKey
+              )
+            : undefined;
+        const inlineSkillSnapshotsCacheKey = inlineSkillSnapshotState?.cacheKey;
+
         const version = this.messageVersions.get(message.id) ?? 0;
         const cached = this.displayedMessageCache.get(message.id);
         const canReuse =
           cached?.version === version &&
-          cached.agentSkillSnapshotCacheKey === agentSkillSnapshotCacheKey;
+          cached.agentSkillSnapshotCacheKey === agentSkillSnapshotCacheKey &&
+          cached.inlineSkillSnapshotsCacheKey === inlineSkillSnapshotsCacheKey;
 
         const messageDisplay = canReuse
           ? cached.messages
-          : this.buildDisplayedMessagesForMessage(message, agentSkillSnapshotForDisplay);
+          : this.buildDisplayedMessagesForMessage(
+              message,
+              agentSkillSnapshotForDisplay,
+              inlineSkillSnapshotState?.snapshots
+            );
 
         if (!canReuse) {
           this.displayedMessageCache.set(message.id, {
             version,
             agentSkillSnapshotCacheKey,
+            inlineSkillSnapshotsCacheKey,
             messages: messageDisplay,
           });
         }

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -351,7 +351,7 @@ function maybeCollectAgentSkillSnapshot(
 }
 
 function deriveInlineSkillSnapshotDisplayState(
-  refs: ReadonlyArray<AgentSkillReference> | undefined,
+  refs: readonly AgentSkillReference[] | undefined,
   latestAgentSkillSnapshotByKey: ReadonlyMap<string, AgentSkillSnapshotContent>
 ): InlineSkillSnapshotDisplayState {
   if (!refs || refs.length === 0) {

--- a/src/common/types/message.agentSkillRefs.test.ts
+++ b/src/common/types/message.agentSkillRefs.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildAgentSkillMetadata,
+  dedupeAgentSkillRefs,
+  mergeAgentSkillRefs,
+  withAgentSkillRefs,
+} from "./message";
+import type { AgentSkillReference, MuxMessageMetadata } from "./message";
+import type { ReviewNoteData } from "./review";
+
+function skillRef(
+  skillName: string,
+  source: AgentSkillReference["source"],
+  scope: AgentSkillReference["scope"] = "project"
+): AgentSkillReference {
+  return { skillName, scope, source };
+}
+
+describe("agent skill refs metadata helpers", () => {
+  test("dedupeAgentSkillRefs preserves first-appearance order", () => {
+    expect(
+      dedupeAgentSkillRefs([
+        skillRef("tdd", "inline"),
+        skillRef("react-effects", "inline", "built-in"),
+        skillRef("tdd", "inline"),
+        skillRef("tests", "slash", "project"),
+      ])
+    ).toEqual([
+      skillRef("tdd", "inline"),
+      skillRef("react-effects", "inline", "built-in"),
+      skillRef("tests", "slash", "project"),
+    ]);
+  });
+
+  test("dedupeAgentSkillRefs lets slash refs beat inline refs on name collisions", () => {
+    expect(
+      dedupeAgentSkillRefs([
+        skillRef("tdd", "inline", "project"),
+        skillRef("react-effects", "inline", "built-in"),
+        skillRef("tdd", "slash", "global"),
+      ])
+    ).toEqual([
+      skillRef("tdd", "slash", "global"),
+      skillRef("react-effects", "inline", "built-in"),
+    ]);
+  });
+
+  test("mergeAgentSkillRefs keeps existing refs first, appends new refs, then dedupes", () => {
+    expect(
+      mergeAgentSkillRefs(
+        [skillRef("tdd", "inline"), skillRef("react-effects", "inline", "built-in")],
+        [skillRef("tests", "slash"), skillRef("tdd", "inline"), skillRef("docs", "inline")]
+      )
+    ).toEqual([
+      skillRef("tdd", "inline"),
+      skillRef("react-effects", "inline", "built-in"),
+      skillRef("tests", "slash"),
+      skillRef("docs", "inline"),
+    ]);
+  });
+
+  test("withAgentSkillRefs preserves existing metadata fields and discriminator", () => {
+    const review: ReviewNoteData = {
+      filePath: "src/example.ts",
+      lineRange: "1-2",
+      selectedCode: "const value = true;",
+      userNote: "please review",
+    };
+    const metadata: MuxMessageMetadata = {
+      type: "agent-skill",
+      rawCommand: "/tdd write tests",
+      commandPrefix: "/tdd",
+      skillName: "tdd",
+      scope: "project",
+      reviews: [review],
+      requestedModel: "anthropic/claude-sonnet-4-5",
+      agentSkillRefs: [skillRef("tdd", "slash")],
+    };
+
+    const result = withAgentSkillRefs(metadata, [skillRef("react-effects", "inline", "built-in")]);
+
+    if (!result || result.type !== "agent-skill") {
+      throw new Error("Expected agent-skill metadata");
+    }
+    expect(result.type).toBe("agent-skill");
+    expect(result.rawCommand).toBe("/tdd write tests");
+    expect(result.commandPrefix).toBe("/tdd");
+    expect(result.skillName).toBe("tdd");
+    expect(result.scope).toBe("project");
+    expect(result.reviews).toEqual([review]);
+    expect(result.requestedModel).toBe("anthropic/claude-sonnet-4-5");
+    expect(result.agentSkillRefs).toEqual([
+      skillRef("tdd", "slash"),
+      skillRef("react-effects", "inline", "built-in"),
+    ]);
+  });
+
+  test("withAgentSkillRefs creates normal metadata for undefined metadata and non-empty refs", () => {
+    expect(
+      withAgentSkillRefs(undefined, [skillRef("tdd", "inline"), skillRef("tdd", "slash")])
+    ).toEqual({
+      type: "normal",
+      agentSkillRefs: [skillRef("tdd", "slash")],
+    });
+  });
+
+  test("withAgentSkillRefs returns undefined for undefined metadata and empty refs", () => {
+    expect(withAgentSkillRefs(undefined, [])).toBeUndefined();
+  });
+
+  test("buildAgentSkillMetadata preserves legacy agent-skill fields and adds slash ref", () => {
+    expect(
+      buildAgentSkillMetadata({
+        rawCommand: "/tdd write tests",
+        commandPrefix: "/tdd",
+        skillName: "tdd",
+        scope: "project",
+      })
+    ).toEqual({
+      type: "agent-skill",
+      rawCommand: "/tdd write tests",
+      commandPrefix: "/tdd",
+      skillName: "tdd",
+      scope: "project",
+      agentSkillRefs: [skillRef("tdd", "slash")],
+    });
+  });
+});

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -293,6 +293,14 @@ export function prepareUserMessageForSend(
   return { finalText, metadata };
 }
 
+export type InlineSkillSnapshotForDisplay = {
+  skillName: string;
+  scope: AgentSkillScope;
+  snapshot: { frontmatterYaml?: string; body?: string };
+};
+
+export type InlineSkillSnapshotMap = Record<string, InlineSkillSnapshotForDisplay>;
+
 export interface AgentSkillReference {
   skillName: string;
   scope: AgentSkillScope;
@@ -669,6 +677,11 @@ export type DisplayedMessage =
           body?: string;
         };
       };
+      /**
+       * Inline skill snapshots are derived display state from prior synthetic snapshot messages.
+       * They are not persisted on the user message itself.
+       */
+      inlineSkillSnapshots?: InlineSkillSnapshotMap;
       /** Present when this message is a /compact command */
       compactionRequest?: {
         parsed: CompactionRequestData;

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -293,6 +293,70 @@ export function prepareUserMessageForSend(
   return { finalText, metadata };
 }
 
+export interface AgentSkillReference {
+  skillName: string;
+  scope: AgentSkillScope;
+  source: "slash" | "inline";
+}
+
+export function dedupeAgentSkillRefs(refs: AgentSkillReference[]): AgentSkillReference[] {
+  const dedupedRefs: AgentSkillReference[] = [];
+  const indexBySkillName = new Map<string, number>();
+
+  for (const ref of refs) {
+    const existingIndex = indexBySkillName.get(ref.skillName);
+    if (existingIndex === undefined) {
+      indexBySkillName.set(ref.skillName, dedupedRefs.length);
+      dedupedRefs.push(ref);
+      continue;
+    }
+
+    const existingRef = dedupedRefs[existingIndex];
+    if (!existingRef) {
+      throw new Error(`Missing agent skill ref for index ${existingIndex}`);
+    }
+
+    if (existingRef.source === "inline" && ref.source === "slash") {
+      dedupedRefs[existingIndex] = ref;
+    }
+  }
+
+  return dedupedRefs;
+}
+
+export function mergeAgentSkillRefs(
+  existing: AgentSkillReference[] | undefined,
+  additions: AgentSkillReference[]
+): AgentSkillReference[] {
+  return dedupeAgentSkillRefs([...(existing ?? []), ...additions]);
+}
+
+function getExistingAgentSkillRefs(
+  metadata: MuxMessageMetadata | undefined
+): AgentSkillReference[] | undefined {
+  const refs = metadata?.agentSkillRefs;
+  return Array.isArray(refs) ? refs : undefined;
+}
+
+export function withAgentSkillRefs(
+  metadata: MuxMessageMetadata | undefined,
+  refs: AgentSkillReference[]
+): MuxMessageMetadata | undefined {
+  const existingRefs = getExistingAgentSkillRefs(metadata);
+  if (refs.length === 0 && (!existingRefs || existingRefs.length === 0)) {
+    return metadata;
+  }
+
+  if (!metadata) {
+    return { type: "normal", agentSkillRefs: dedupeAgentSkillRefs(refs) };
+  }
+
+  return {
+    ...metadata,
+    agentSkillRefs: mergeAgentSkillRefs(existingRefs, refs),
+  };
+}
+
 export interface BuildAgentSkillMetadataOptions {
   rawCommand: string;
   skillName: string;
@@ -309,6 +373,7 @@ export function buildAgentSkillMetadata(
     commandPrefix: options.commandPrefix,
     skillName: options.skillName,
     scope: options.scope,
+    agentSkillRefs: [{ skillName: options.skillName, scope: options.scope, source: "slash" }],
   };
 }
 
@@ -325,6 +390,15 @@ interface MuxMessageMetadataBase {
    * and compaction sends instead of whatever happens to be persisted in localStorage.
    */
   requestedModel?: string;
+  /**
+   * All skills referenced in this user message turn (slash and/or inline).
+   * Backend uses this to materialize one synthetic agentSkillSnapshot per ref
+   * before the user message. Persisted refs intentionally exclude parser
+   * ranges (startIndex/endIndex) because reviews, one-shots, edits, retries,
+   * and slash rewrites make those ranges ambiguous. The ORPC schema keeps
+   * muxMetadata loose by design, so this orthogonal field needs no schema change.
+   */
+  agentSkillRefs?: AgentSkillReference[];
 }
 
 /** Status to display in sidebar during background operations */

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -293,11 +293,11 @@ export function prepareUserMessageForSend(
   return { finalText, metadata };
 }
 
-export type InlineSkillSnapshotForDisplay = {
+export interface InlineSkillSnapshotForDisplay {
   skillName: string;
   scope: AgentSkillScope;
   snapshot: { frontmatterYaml?: string; body?: string };
-};
+}
 
 export type InlineSkillSnapshotMap = Record<string, InlineSkillSnapshotForDisplay>;
 

--- a/src/node/services/agentSession.agentSkillSnapshot.test.ts
+++ b/src/node/services/agentSession.agentSkillSnapshot.test.ts
@@ -19,21 +19,98 @@ import { AgentSession } from "./agentSession";
 import { createTestHistoryService } from "./testHistoryService";
 
 describe("AgentSession.sendMessage (agent skill snapshots)", () => {
-  async function createTestWorkspaceWithSkill(args: { skillName: string; skillBody: string }) {
+  async function createTestWorkspaceWithSkills(args: {
+    skills: Array<{ skillName: string; skillBody: string }>;
+  }) {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "mux-agent-skill-"));
-    const skillDir = path.join(tmp, ".mux", "skills", args.skillName);
-    await fs.mkdir(skillDir, { recursive: true });
 
-    const skillMarkdown = `---\nname: ${args.skillName}\ndescription: Test skill\n---\n\n${args.skillBody}\n`;
-    await fs.writeFile(path.join(skillDir, "SKILL.md"), skillMarkdown, "utf-8");
+    for (const skill of args.skills) {
+      const skillDir = path.join(tmp, ".mux", "skills", skill.skillName);
+      await fs.mkdir(skillDir, { recursive: true });
+
+      const skillMarkdown = `---\nname: ${skill.skillName}\ndescription: Test skill\n---\n\n${skill.skillBody}\n`;
+      await fs.writeFile(path.join(skillDir, "SKILL.md"), skillMarkdown, "utf-8");
+    }
 
     return { workspacePath: tmp };
+  }
+
+  async function createTestWorkspaceWithSkill(args: { skillName: string; skillBody: string }) {
+    return createTestWorkspaceWithSkills({ skills: [args] });
   }
 
   let historyCleanup: (() => Promise<void>) | undefined;
   afterEach(async () => {
     await historyCleanup?.();
   });
+
+  function getMessageText(message: MuxMessage): string {
+    const textPart = message.parts.find((part) => part.type === "text");
+    if (textPart?.type !== "text") {
+      throw new Error(`Expected text part for message ${message.id}`);
+    }
+    return textPart.text;
+  }
+
+  async function createSessionHarness(args: { workspacePath: string; workspaceId?: string }) {
+    const workspaceId = args.workspaceId ?? "ws-test";
+    const config = {
+      srcDir: "/tmp",
+      getSessionDir: (_workspaceId: string) => "/tmp",
+    } as unknown as Config;
+
+    const { historyService, cleanup } = await createTestHistoryService();
+    historyCleanup = cleanup;
+
+    const messages: MuxMessage[] = [];
+    const realAppend = historyService.appendToHistory.bind(historyService);
+    const appendToHistory = spyOn(historyService, "appendToHistory").mockImplementation(
+      async (wId: string, message: MuxMessage) => {
+        messages.push(message);
+        return realAppend(wId, message);
+      }
+    );
+
+    const aiEmitter = new EventEmitter();
+    const workspaceMeta: FrontendWorkspaceMetadata = {
+      id: workspaceId,
+      name: "ws",
+      projectName: "proj",
+      projectPath: args.workspacePath,
+      namedWorkspacePath: args.workspacePath,
+      runtimeConfig: { type: "local" },
+    } as unknown as FrontendWorkspaceMetadata;
+
+    const aiService = Object.assign(aiEmitter, {
+      isStreaming: mock((_workspaceId: string) => false),
+      stopStream: mock((_workspaceId: string) => Promise.resolve(Ok(undefined))),
+      getWorkspaceMetadata: mock((_workspaceId: string) => Promise.resolve(Ok(workspaceMeta))),
+      streamMessage: mock((_messages: MuxMessage[]) =>
+        Promise.resolve(Ok(undefined))
+      ) as unknown as (
+        ...args: Parameters<AIService["streamMessage"]>
+      ) => Promise<Result<void, SendMessageError>>,
+    }) as unknown as AIService;
+
+    const initStateManager = new EventEmitter() as unknown as InitStateManager;
+    const backgroundProcessManager = {
+      cleanup: mock((_workspaceId: string) => Promise.resolve()),
+      setMessageQueued: mock((_workspaceId: string, _queued: boolean) => {
+        void _queued;
+      }),
+    } as unknown as BackgroundProcessManager;
+
+    const session = new AgentSession({
+      workspaceId,
+      config,
+      historyService,
+      aiService,
+      initStateManager,
+      backgroundProcessManager,
+    });
+
+    return { session, appendToHistory, messages, historyService };
+  }
 
   it("persists a synthetic agent skill snapshot before the user message", async () => {
     const workspaceId = "ws-test";
@@ -450,6 +527,210 @@ describe("AgentSession.sendMessage (agent skill snapshots)", () => {
 
     const secondFrontmatter = secondSnapshot.metadata?.agentSkillSnapshot?.frontmatterYaml;
     expect(secondFrontmatter ?? "").toContain("Updated description");
+  });
+
+  it("materializes multiple snapshots for plural agentSkillRefs", async () => {
+    const { workspacePath } = await createTestWorkspaceWithSkills({
+      skills: [
+        { skillName: "alpha-skill", skillBody: "Follow alpha." },
+        { skillName: "beta-skill", skillBody: "Follow beta." },
+      ],
+    });
+    const { session, appendToHistory, messages } = await createSessionHarness({ workspacePath });
+
+    const result = await session.sendMessage("do X", {
+      model: "anthropic:claude-3-5-sonnet-latest",
+      agentId: "exec",
+      muxMetadata: {
+        type: "normal",
+        agentSkillRefs: [
+          { skillName: "alpha-skill", scope: "project", source: "inline" },
+          { skillName: "beta-skill", scope: "project", source: "inline" },
+        ],
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(appendToHistory.mock.calls).toHaveLength(3);
+
+    const [alphaSnapshot, betaSnapshot, userMessage] = messages;
+    expect(alphaSnapshot.metadata?.synthetic).toBe(true);
+    expect(alphaSnapshot.metadata?.agentSkillSnapshot?.skillName).toBe("alpha-skill");
+    expect(getMessageText(alphaSnapshot)).toContain("Follow alpha.");
+
+    expect(betaSnapshot.metadata?.synthetic).toBe(true);
+    expect(betaSnapshot.metadata?.agentSkillSnapshot?.skillName).toBe("beta-skill");
+    expect(getMessageText(betaSnapshot)).toContain("Follow beta.");
+
+    expect(userMessage.role).toBe("user");
+    expect(getMessageText(userMessage)).toBe("do X");
+  });
+
+  it("dedupes slash + inline refs for the same skill, slash wins", async () => {
+    const { workspacePath } = await createTestWorkspaceWithSkill({
+      skillName: "test-skill",
+      skillBody: "Follow slash skill.",
+    });
+    const { session, appendToHistory, messages } = await createSessionHarness({ workspacePath });
+
+    const result = await session.sendMessage("do X", {
+      model: "anthropic:claude-3-5-sonnet-latest",
+      agentId: "exec",
+      muxMetadata: {
+        type: "agent-skill",
+        rawCommand: "/test-skill do X",
+        skillName: "test-skill",
+        scope: "project",
+        agentSkillRefs: [{ skillName: "test-skill", scope: "global", source: "inline" }],
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(appendToHistory.mock.calls).toHaveLength(2);
+
+    const [snapshotMessage, userMessage] = messages;
+    expect(snapshotMessage.metadata?.synthetic).toBe(true);
+    expect(snapshotMessage.metadata?.agentSkillSnapshot?.skillName).toBe("test-skill");
+    expect(snapshotMessage.metadata?.agentSkillSnapshot?.scope).toBe("project");
+    expect(getMessageText(snapshotMessage)).toContain("Follow slash skill.");
+    expect(getMessageText(userMessage)).toBe("do X");
+  });
+
+  it("skips inline refs with invalid skill names silently", async () => {
+    const { workspacePath } = await createTestWorkspaceWithSkill({
+      skillName: "valid-skill",
+      skillBody: "Follow valid skill.",
+    });
+    const { session, appendToHistory, messages } = await createSessionHarness({ workspacePath });
+
+    const result = await session.sendMessage("do X", {
+      model: "anthropic:claude-3-5-sonnet-latest",
+      agentId: "exec",
+      muxMetadata: {
+        type: "normal",
+        agentSkillRefs: [
+          { skillName: "Invalid_Name", scope: "project", source: "inline" },
+          { skillName: "valid-skill", scope: "project", source: "inline" },
+        ],
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(appendToHistory.mock.calls).toHaveLength(2);
+    expect(messages[0].metadata?.agentSkillSnapshot?.skillName).toBe("valid-skill");
+    expect(getMessageText(messages[0])).toContain("Follow valid skill.");
+    expect(getMessageText(messages[1])).toBe("do X");
+  });
+
+  it("skips inline refs whose skill cannot be read silently", async () => {
+    const { workspacePath } = await createTestWorkspaceWithSkill({
+      skillName: "alpha-skill",
+      skillBody: "Follow alpha.",
+    });
+    const { session, appendToHistory, messages } = await createSessionHarness({ workspacePath });
+
+    const result = await session.sendMessage("do X", {
+      model: "anthropic:claude-3-5-sonnet-latest",
+      agentId: "exec",
+      muxMetadata: {
+        type: "normal",
+        agentSkillRefs: [
+          { skillName: "alpha-skill", scope: "project", source: "inline" },
+          { skillName: "missing-skill", scope: "project", source: "inline" },
+        ],
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(appendToHistory.mock.calls).toHaveLength(2);
+    expect(messages[0].metadata?.agentSkillSnapshot?.skillName).toBe("alpha-skill");
+    expect(getMessageText(messages[0])).toContain("Follow alpha.");
+    expect(getMessageText(messages[1])).toBe("do X");
+  });
+
+  it("still throws when a slash skill name is invalid", async () => {
+    const { workspacePath } = await createTestWorkspaceWithSkills({ skills: [] });
+    const { session, appendToHistory } = await createSessionHarness({ workspacePath });
+
+    const result = await session.sendMessage("do X", {
+      model: "anthropic:claude-3-5-sonnet-latest",
+      agentId: "exec",
+      muxMetadata: {
+        type: "agent-skill",
+        rawCommand: "/Invalid_Name do X",
+        skillName: "Invalid_Name",
+        scope: "project",
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("Expected invalid slash skill send to fail");
+    }
+    expect(result.error.type).toBe("unknown");
+    if (result.error.type !== "unknown") {
+      throw new Error("Expected invalid slash skill failure to use unknown error shape");
+    }
+    expect(result.error.raw).toContain("Invalid agent skill name");
+    expect(appendToHistory.mock.calls).toHaveLength(0);
+  });
+
+  it("still throws when a slash skill is missing", async () => {
+    const { workspacePath } = await createTestWorkspaceWithSkills({ skills: [] });
+    const { session, appendToHistory } = await createSessionHarness({ workspacePath });
+
+    const result = await session.sendMessage("do X", {
+      model: "anthropic:claude-3-5-sonnet-latest",
+      agentId: "exec",
+      muxMetadata: {
+        type: "agent-skill",
+        rawCommand: "/missing-skill do X",
+        skillName: "missing-skill",
+        scope: "project",
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(appendToHistory.mock.calls).toHaveLength(0);
+  });
+
+  it("dedupes against recent history per-skill", async () => {
+    const { workspacePath } = await createTestWorkspaceWithSkills({
+      skills: [
+        { skillName: "alpha-skill", skillBody: "Follow alpha." },
+        { skillName: "beta-skill", skillBody: "Follow beta." },
+      ],
+    });
+    const { session, appendToHistory, messages } = await createSessionHarness({ workspacePath });
+
+    const first = await session.sendMessage("first", {
+      model: "anthropic:claude-3-5-sonnet-latest",
+      agentId: "exec",
+      muxMetadata: {
+        type: "normal",
+        agentSkillRefs: [{ skillName: "alpha-skill", scope: "project", source: "inline" }],
+      },
+    });
+    expect(first.success).toBe(true);
+    expect(appendToHistory.mock.calls).toHaveLength(2);
+
+    const second = await session.sendMessage("second", {
+      model: "anthropic:claude-3-5-sonnet-latest",
+      agentId: "exec",
+      muxMetadata: {
+        type: "normal",
+        agentSkillRefs: [
+          { skillName: "alpha-skill", scope: "project", source: "inline" },
+          { skillName: "beta-skill", scope: "project", source: "inline" },
+        ],
+      },
+    });
+
+    expect(second.success).toBe(true);
+    expect(appendToHistory.mock.calls).toHaveLength(4);
+    expect(messages[2].metadata?.agentSkillSnapshot?.skillName).toBe("beta-skill");
+    expect(getMessageText(messages[2])).toContain("Follow beta.");
+    expect(getMessageText(messages[3])).toBe("second");
   });
 
   it("truncates edits starting from preceding skill/file snapshots", async () => {

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -188,7 +188,7 @@ const ACP_DELEGATED_TOOLS_METADATA_KEY = "acpDelegatedTools";
 function extractAgentSkillRefs(metadata: MuxMessageMetadata | undefined): AgentSkillReference[] {
   if (!metadata) return [];
 
-  const refs = [...(metadata.agentSkillRefs ?? [])];
+  const refs = Array.isArray(metadata.agentSkillRefs) ? [...metadata.agentSkillRefs] : [];
   if (metadata.type === "agent-skill") {
     const hasLegacySlashRef = refs.some(
       (ref) => ref.skillName === metadata.skillName && ref.source === "slash"

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -52,10 +52,12 @@ import { coerceThinkingLevel } from "@/common/types/thinking";
 import { enforceThinkingPolicy } from "@/common/utils/thinking/policy";
 import {
   createMuxMessage,
+  dedupeAgentSkillRefs,
   isCompactionSummaryMetadata,
   pickPreservedSendOptions,
   pickStartupRetrySendOptions,
   prepareUserMessageForSend,
+  type AgentSkillReference,
   type CompactionFollowUpRequest,
   type MuxMessageMetadata,
   type MuxFilePart,
@@ -182,6 +184,22 @@ const SWITCH_AGENT_TARGET_UNAVAILABLE_ERROR =
 const PDF_MEDIA_TYPE = "application/pdf";
 const ACP_PROMPT_ID_METADATA_KEY = "acpPromptId";
 const ACP_DELEGATED_TOOLS_METADATA_KEY = "acpDelegatedTools";
+
+function extractAgentSkillRefs(metadata: MuxMessageMetadata | undefined): AgentSkillReference[] {
+  if (!metadata) return [];
+
+  const refs = [...(metadata.agentSkillRefs ?? [])];
+  if (metadata.type === "agent-skill") {
+    const hasLegacySlashRef = refs.some(
+      (ref) => ref.skillName === metadata.skillName && ref.source === "slash"
+    );
+    if (!hasLegacySlashRef) {
+      refs.push({ skillName: metadata.skillName, scope: metadata.scope, source: "slash" });
+    }
+  }
+
+  return dedupeAgentSkillRefs(refs);
+}
 
 function normalizeMediaType(mediaType: string): string {
   return mediaType.toLowerCase().trim().split(";")[0];
@@ -2291,9 +2309,9 @@ export class AgentSession {
     // so subsequent turns don't re-read (which would change the prompt prefix if files changed).
     // File changes after this point are surfaced via <system-file-update> diffs instead.
     const snapshotResult = await this.materializeFileAtMentionsSnapshot(trimmedMessage);
-    let skillSnapshotResult: { snapshotMessage: MuxMessage } | null = null;
+    let skillSnapshotMessages: MuxMessage[] = [];
     try {
-      skillSnapshotResult = await this.materializeAgentSkillSnapshot(
+      skillSnapshotMessages = await this.materializeAgentSkillSnapshots(
         typedMuxMetadata,
         options?.disableWorkspaceAgents
       );
@@ -2412,13 +2430,15 @@ export class AgentSession {
       }
     }
 
-    if (shouldPersistTurnSnapshots && skillSnapshotResult?.snapshotMessage) {
-      const skillSnapshotAppendResult = await this.historyService.appendToHistory(
-        this.workspaceId,
-        skillSnapshotResult.snapshotMessage
-      );
-      if (!skillSnapshotAppendResult.success) {
-        return Err(createUnknownSendMessageError(skillSnapshotAppendResult.error));
+    if (shouldPersistTurnSnapshots && skillSnapshotMessages.length > 0) {
+      for (const snapshotMessage of skillSnapshotMessages) {
+        const skillSnapshotAppendResult = await this.historyService.appendToHistory(
+          this.workspaceId,
+          snapshotMessage
+        );
+        if (!skillSnapshotAppendResult.success) {
+          return Err(createUnknownSendMessageError(skillSnapshotAppendResult.error));
+        }
       }
     }
 
@@ -2447,8 +2467,10 @@ export class AgentSession {
       this.emitChatEvent({ ...snapshotResult.snapshotMessage, type: "message" });
     }
 
-    if (shouldPersistTurnSnapshots && skillSnapshotResult?.snapshotMessage) {
-      this.emitChatEvent({ ...skillSnapshotResult.snapshotMessage, type: "message" });
+    if (shouldPersistTurnSnapshots && skillSnapshotMessages.length > 0) {
+      for (const snapshotMessage of skillSnapshotMessages) {
+        this.emitChatEvent({ ...snapshotMessage, type: "message" });
+      }
     }
 
     // When on-send compaction triggers, the original user message is NOT emitted now —
@@ -5150,27 +5172,27 @@ export class AgentSession {
     return { snapshotMessage, materializedTokens: tokens };
   }
 
-  private async materializeAgentSkillSnapshot(
+  private async materializeAgentSkillSnapshots(
     muxMetadata: MuxMessageMetadata | undefined,
     disableWorkspaceAgents: boolean | undefined
-  ): Promise<{ snapshotMessage: MuxMessage } | null> {
-    if (!muxMetadata || muxMetadata.type !== "agent-skill") {
-      return null;
+  ): Promise<MuxMessage[]> {
+    const refs = extractAgentSkillRefs(muxMetadata);
+    if (refs.length === 0) {
+      return [];
     }
 
     // Guard for test mocks that may not implement getWorkspaceMetadata.
     if (typeof this.aiService.getWorkspaceMetadata !== "function") {
-      return null;
-    }
-
-    const parsedName = SkillNameSchema.safeParse(muxMetadata.skillName);
-    if (!parsedName.success) {
-      throw new Error(`Invalid agent skill name: ${muxMetadata.skillName}`);
+      return [];
     }
 
     const metadataResult = await this.aiService.getWorkspaceMetadata(this.workspaceId);
     if (!metadataResult.success) {
-      throw new Error("Cannot materialize agent skill: workspace metadata not found");
+      const hasSlash = refs.some((ref) => ref.source === "slash");
+      if (hasSlash) {
+        throw new Error("Cannot materialize agent skill: workspace metadata not found");
+      }
+      return [];
     }
 
     const metadata = metadataResult.data;
@@ -5180,48 +5202,84 @@ export class AgentSession {
     // the worktree so skill invocation uses the same precedence/discovery root as the UI.
     const skillDiscoveryPath = disableWorkspaceAgents ? metadata.projectPath : workspacePath;
 
-    const resolved = await readAgentSkill(runtime, skillDiscoveryPath, parsedName.data);
-    const skill = resolved.package;
-
-    // Include the parsed YAML frontmatter in the hash so frontmatter-only edits (e.g. description)
-    // generate a new snapshot and keep the UI hover preview in sync.
-    const frontmatterYaml = stringifyAgentSkillFrontmatter(skill.frontmatter);
-    const snapshot = createLoadedSkillSnapshot({
-      name: skill.frontmatter.name,
-      scope: skill.scope,
-      body: skill.body,
-      frontmatterYaml,
-    });
-    const snapshotText = renderAgentSkillSnapshotText(snapshot);
-    const sha256 = snapshot.sha256;
-
-    // Dedupe: if we recently persisted the same snapshot, avoid inserting again.
-    // Only need last 5 messages — avoid full-file read.
-    const historyResult = await this.historyService.getLastMessages(this.workspaceId, 5);
+    // Dedupe per skill against recent persisted snapshots. A wider window keeps multi-skill
+    // turns from reloading snapshots that were persisted together on the previous turn.
+    const recentSnapshots: Array<{ skillName: string; sha256: string }> = [];
+    const historyResult = await this.historyService.getLastMessages(this.workspaceId, 10);
     if (historyResult.success) {
-      const recentSnapshot = [...historyResult.data]
-        .reverse()
-        .find((msg) => msg.metadata?.synthetic && msg.metadata?.agentSkillSnapshot);
-      const recentMeta = recentSnapshot?.metadata?.agentSkillSnapshot;
-
-      if (recentMeta?.skillName === skill.frontmatter.name && recentMeta.sha256 === sha256) {
-        return null;
+      for (const msg of historyResult.data) {
+        const metadata = msg.metadata;
+        if (metadata?.synthetic && metadata.agentSkillSnapshot) {
+          recentSnapshots.push({
+            skillName: metadata.agentSkillSnapshot.skillName,
+            sha256: metadata.agentSkillSnapshot.sha256,
+          });
+        }
       }
     }
 
-    const snapshotId = createAgentSkillSnapshotMessageId();
-    const snapshotMessage = createMuxMessage(snapshotId, "user", snapshotText, {
-      timestamp: Date.now(),
-      synthetic: true,
-      agentSkillSnapshot: {
-        skillName: skill.frontmatter.name,
-        scope: skill.scope,
-        sha256,
-        frontmatterYaml,
-      },
-    });
+    const snapshotMessages: MuxMessage[] = [];
+    for (const ref of refs) {
+      const parsedName = SkillNameSchema.safeParse(ref.skillName);
+      if (!parsedName.success) {
+        if (ref.source === "slash") {
+          throw new Error(`Invalid agent skill name: ${ref.skillName}`);
+        }
+        continue;
+      }
 
-    return { snapshotMessage };
+      let resolved: Awaited<ReturnType<typeof readAgentSkill>>;
+      try {
+        resolved = await readAgentSkill(runtime, skillDiscoveryPath, parsedName.data);
+      } catch (error) {
+        if (ref.source === "slash") {
+          throw error;
+        }
+        continue;
+      }
+
+      const skill = resolved.package;
+
+      // Include the parsed YAML frontmatter in the hash so frontmatter-only edits (e.g. description)
+      // generate a new snapshot and keep the UI hover preview in sync.
+      const frontmatterYaml = stringifyAgentSkillFrontmatter(skill.frontmatter);
+      const snapshot = createLoadedSkillSnapshot({
+        name: skill.frontmatter.name,
+        scope: skill.scope,
+        body: skill.body,
+        frontmatterYaml,
+      });
+      const sha256 = snapshot.sha256;
+
+      if (
+        recentSnapshots.some(
+          (recent) => recent.skillName === skill.frontmatter.name && recent.sha256 === sha256
+        )
+      ) {
+        continue;
+      }
+
+      const snapshotText = renderAgentSkillSnapshotText(snapshot);
+      const snapshotId = createAgentSkillSnapshotMessageId();
+      snapshotMessages.push(
+        createMuxMessage(snapshotId, "user", snapshotText, {
+          timestamp: Date.now(),
+          synthetic: true,
+          agentSkillSnapshot: {
+            skillName: skill.frontmatter.name,
+            scope: skill.scope,
+            sha256,
+            frontmatterYaml,
+          },
+        })
+      );
+
+      // Defense-in-depth: avoid double-loading this skill within the same turn even if
+      // future metadata shapes bypass extractAgentSkillRefs dedupe.
+      recentSnapshots.push({ skillName: skill.frontmatter.name, sha256 });
+    }
+
+    return snapshotMessages;
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds inline `$skill` references so users can write `Please perform a $deep-review on this code and follow $tdd` and Mux loads both skills for that turn — autocomplete suggests skill names while typing, the sent message text is preserved exactly as typed, and inline tokens render with the same hover preview as the existing `/skill` slash badge.

## Background

Today skills are invoked via slash commands (`/deep-review …`), which rewrite the user's text and only allow one skill per turn. Inline `$skill` references address two needs:

- Compose multiple skills in one turn (`$deep-review` and `$tdd` together).
- Reference a skill mid-sentence without committing the whole message to a slash command's rewrite (`Please follow $tdd while you implement this`).

The architecture is intentionally **orthogonal**: a new `agentSkillRefs?: AgentSkillReference[]` field on `MuxMessageMetadataBase` composes with reviews, model one-shots, edits, retries, and on-send auto-compaction without combinatorial union variants. Slash invocations also populate the new field, so the backend has a single plural code path while old persisted `type: "agent-skill"` messages still replay correctly.

## Implementation

The work landed in two phases on top of a 10-commit stack:

**Phase 1 — inline references end-to-end:**
- `agentSkillRefs?: AgentSkillReference[]` added to `MuxMessageMetadataBase` with `dedupeAgentSkillRefs` / `mergeAgentSkillRefs` / `withAgentSkillRefs` helpers (slash beats inline on dedupe). Persisted refs only carry `{skillName, scope, source}` — parser ranges stay autocomplete-only.
- Backend `materializeAgentSkillSnapshots(...)` is plural and order-preserving. Uses resolved `skill.scope` (advisory metadata scope is ignored). Inline refs that fail to resolve are silently skipped; slash refs preserve strict failure. Per-skill dedupe against recent history.
- Inline parser (`extractInlineSkillReferenceCandidates`) is stricter than `SkillNameSchema`: requires lowercase first letter (rejects `$100` currency / `$PATH` env-style), requires sane left boundary, skips inline backticks and fenced code blocks. Resolver mirrors the slash resolver and silently drops unknown skills.
- Send-flow integration handles normal, creation, model one-shot, and mixed slash+inline messages. Creation flow forces `disableWorkspaceAgents: true` when any combined ref is project-scoped.
- Autocomplete UX mirrors the `@file` mention pattern. Precedence: `@file` > `$skill` > slash command. Selecting Enter/Tab/click replaces only the `$partial` token. Reuses `atMentionCursorNonce` for caret-move signals so suggestions reopen when the caret moves into an existing `$partial`.

**Phase 2 — hover preview parity for inline tokens:**
- `StreamingMessageAggregator` derives an `inlineSkillSnapshots` map per displayed user message from the same `latestAgentSkillSnapshotByKey` cache the slash path uses. Not persisted on the user message — derived display state.
- A small remark plugin (`inlineSkillMarkdown.ts`) walks markdown text nodes, calls the existing `extractInlineSkillReferenceCandidates` (so code-fence/inline-code exclusion stays consistent), and rewrites recognized ranges to mdast `link` nodes with internal `mux-inline-skill:` href. The internal protocol passes through the existing markdown sanitizer — no new `dangerouslySetInnerHTML` paths.
- The anchor renderer recognizes the internal href and delegates to a context that returns the same `AgentSkillBadge` + `HoverCard` + `MarkdownRenderer` JSX the slash badge uses. `AgentSkillBadge` and the `frontmatterYaml + body` preview-markdown builder were extracted as shared primitives.

## Validation

| Check | Result |
|---|---|
| `make typecheck` | ✅ |
| `make lint` | ✅ |
| `make fmt-check` | ✅ |
| 90 unit tests across 8 new test files | ✅ |

End-to-end dogfooding against a `make dev-server-sandbox` instance with test skills `deep-review` and `tdd` confirmed:

- Autocomplete suggests `$deep-review` for `$dee` and `$tdd` for `$td`; Tab/Enter replaces only the partial token.
- Sent message text is preserved verbatim.
- Persisted `chat.jsonl` shows two synthetic `agentSkillSnapshot` messages (deep-review then tdd) before the user message; user message metadata round-trips with `agentSkillRefs: [{deep-review, project, inline}, {tdd, project, inline}]`.
- Hovering `$deep-review` and `$tdd` in the sent message body shows skill-snapshot HoverCards identical to the slash hover.
- `` `$tdd` `` inside inline code, `$deep-review` inside a fenced block, `$100`, and `$PATH` are correctly excluded from both autocomplete and rendering.
- Mixed `/deep-review Please follow $tdd` produces both slash and inline badges side-by-side.
- `$unknown-skill-name` falls back to plain text with no badge.

## Risks

- **Metadata composition**: `agentSkillRefs` is added to `MuxMessageMetadataBase`, so any code that spreads `metadata` should preserve it. The send-flow uses the centralized `withAgentSkillRefs` helper to avoid open-coded spreads dropping refs across reviews/one-shots/edits/retries/auto-compaction. Targeted tests cover those paths.
- **Backend trust boundary**: frontend-supplied `scope` is treated as advisory; backend resolves skills from disk and uses the resolved package scope in persisted snapshots. Inline refs fail silently; slash refs keep strict-failure semantics for backwards compatibility.
- **Markdown sanitizer**: the `mux-inline-skill:` protocol is allowlisted by the existing sanitize/harden config. No new HTML escape hatches were introduced. Anchors with the internal protocol decode skill names from the path, never from arbitrary markup.
- **Parser false positives**: stricter inline rule (lowercase first letter) intentionally diverges from `SkillNameSchema` so currency/env-style strings aren't matched. Numeric-named skills remain reachable via slash invocation. Trade-off documented inline.
- **Replay compatibility**: legacy persisted `type: "agent-skill"` messages still materialize exactly one snapshot via the legacy fallback; aggregator-derived `agentSkill.snapshot` continues to drive the slash hover unchanged.

## Pains

- Bun 1.3.6 doesn't undo `mock.module(...)` via `mock.restore()`, which leaked stubs across test files in the markdown render layer. Fixed by scoping `mock.module` calls with snapshot+restore in `TypewriterMarkdown.test.tsx`; flagged inline so other tests can adopt the pattern.
- Radix HoverCard portals don't render in happy-dom, so the new tests assert badge presence and snapshot-map wiring rather than HoverCard contents — visual parity verified manually during dogfooding.


---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: polished inline `$skill` references for Mux skills

## Goal

Add first-class inline skill references so a user can write:

```txt
Please perform a $deep-review on this code and make sure to follow $tdd
```

and Mux loads both skills for that turn, while preserving the exact user-authored message text.

User decisions to honor:

- `$skill` autocomplete is required.
- Sent message text should remain visible exactly as typed.
- Unknown `$skill` references should be ignored, not warned/blocking.
- `$skill` inside inline code or fenced code blocks should not load skills.
- Unadvertised skills should still be loadable.
- Creation flow should support `$skill` references.
- Model one-shots like `/opus+high Please use $deep-review` should support `$skill` references.
- Keep the feature skill-specific for now, but leave the architecture open to future inline reference kinds.

## Evidence from code exploration

- Skill discovery is already syntax-independent:
  - `src/node/services/agentSkills/agentSkillsService.ts`
  - `discoverAgentSkills(...)`
  - `readAgentSkill(...)`
- Slash-command skill invocation currently lives in:
  - `src/browser/features/ChatInput/utils.ts`
  - `parseCommandWithSkillInvocation(...)`
  - `resolveSkillInvocation(...)`
  - `buildSkillInvocationMetadata(...)`
- Current metadata is singular and slash-shaped:
  - `src/common/types/message.ts`
  - `MuxMessageMetadata` has `{ type: "agent-skill", rawCommand, skillName, scope }`
- Backend materialization is singular:
  - `src/node/services/agentSession.ts`
  - `materializeAgentSkillSnapshot(...)` handles only `muxMetadata.type === "agent-skill"`
  - send path stores a single `skillSnapshotResult`
- Synthetic skill snapshots already work and should be reused:
  - `createLoadedSkillSnapshot(...)`
  - `renderAgentSkillSnapshotText(...)`
  - `agentSkillSnapshot` metadata
- Slash suggestions are whole-input and slash-only:
  - `src/browser/utils/slashCommands/suggestions.ts`
  - `getSlashCommandSuggestions(...)` returns nothing unless `input.startsWith("/")`
  - `ChatInput.handleCommandSelect(...)` replaces the whole input
- `@file` mention autocomplete is the closest UI model for `$skill` autocomplete:
  - cursor-aware matching via `selectionStart`
  - token-local replacement in `handleAtMentionSelect(...)`

## Recommended architecture

### Approach A — recommended: orthogonal `agentSkillRefs` metadata field

Add an orthogonal base metadata field instead of creating an `inline-skills` union variant:

```ts
interface AgentSkillReference {
  skillName: SkillName;
  /** Advisory for UI/creation decisions only; backend must resolve the actual scope from disk. */
  scope: AgentSkillScope;
  source: "slash" | "inline";
}

interface MuxMessageMetadataBase {
  agentSkillRefs?: AgentSkillReference[];
  // existing base fields remain: reviews, commandPrefix, requestedModel, ...
}

// Parser/autocomplete results may carry startIndex/endIndex, but persisted metadata should not.
// Ranges are ambiguous once reviews are prepended, slash commands are rewritten, or one-shots strip prefixes.
```

Keep the existing `type: "agent-skill"` slash metadata for backwards compatibility and display/replay behavior, but update `buildAgentSkillMetadata(...)` so slash skill invocations also populate `agentSkillRefs` with `source: "slash"`.

Backend ref extraction:

1. Start with `metadata.agentSkillRefs ?? []`.
2. If `metadata.type === "agent-skill"` and no matching slash ref exists, add a `source: "slash"` ref from the legacy `skillName` / `scope` fields.
3. This merge-style extraction prevents accidental loss if frontend metadata merging drops the new slash ref while legacy slash fields remain.

Why this is the cleanest long-term solution:

- Skill refs are orthogonal to message intent/type.
- They compose with normal messages, model one-shots, reviews, creation sends, and future metadata.
- It avoids a combinatorial metadata union like `normal-with-inline-skills`, `model-oneshot-with-inline-skills`, etc.
- It keeps slash skill behavior backward-compatible while allowing plural references.

**Net product LoC estimate:** ~370–590 LoC.

- Frontend parser/resolver/helpers: ~120–180 LoC
- ChatInput wiring and autocomplete state/selection: ~120–190 LoC
- Shared metadata helpers/types/schemas: ~50–90 LoC
- Backend plural snapshot materialization/persistence loops: ~80–130 LoC

### Approach B — not recommended: new `type: "inline-skills"` metadata variant

Add a separate metadata union member for inline refs.

Pros:

- Slightly smaller first patch if only normal messages are supported.

Cons:

- Poor composition with existing metadata.
- Harder to support model one-shots, reviews, compaction-related metadata, and future command metadata without merge bugs.
- Backend still needs plural materialization.

**Net product LoC estimate:** ~280–430 LoC initially, but likely higher over time due to merge/compatibility fixes.

### Approach C — not recommended for this request: send-time only, no autocomplete

Detect `$skill` references only during send.

Pros:

- Fastest path to functionality.

Cons:

- User explicitly wants autocomplete.
- More typos silently ignored.
- Does not deliver the polished experience.

**Net product LoC estimate:** ~180–300 LoC.

## Advisor review refinements

The advisor approved the core `agentSkillRefs` architecture and recommended tightening these details before implementation:

- Persist only `{ skillName, scope, source }` in `agentSkillRefs`; keep `startIndex` / `endIndex` as parser/autocomplete-only data because persisted offsets become ambiguous after reviews, slash rewrites, model one-shot prefix stripping, edits, and retries.
- Update shared schemas as well as TypeScript types, especially message metadata schemas used for persisted/replayed messages.
- Treat frontend-provided `scope` as advisory on the backend. Backend materialization should resolve by `skillName` with `readAgentSkill(...)` and use the resolved package scope for snapshots.
- Make error behavior source-specific:
  - `source: "inline"` refs: skip invalid/unreadable refs silently.
  - `source: "slash"` refs and legacy `type: "agent-skill"`: preserve existing strict failure behavior.
  - If slash and inline mention the same skill, slash wins during dedupe.
- Numeric skill names, if supported by the shared schema, remain invocable with slash syntax such as `/100`; inline `$100` is intentionally not a skill ref.
- Inline `$` parsing should require the first character after `$` to be a lowercase letter, even though `SkillNameSchema` permits all-numeric skill names. This avoids currency false positives like `$100`; slash invocation remains the path for rare numeric skill names.
- Explicitly support mixed slash + inline messages such as `/deep-review Please also follow $tdd` by parsing inline refs from the original authored text before slash rewrite.
- Autocomplete must cover keyboard/cursor lifecycle, not just rendering suggestions: Enter/Tab selection, Escape dismissal, arrow navigation, and reopening when the caret moves into an existing `$partial` token.
- Ensure `agentSkillRefs` survives metadata lifecycle paths: `prepareUserMessageForSend(...)`, reviews, model one-shots, edit sends, retry send options, and on-send auto-compaction follow-ups.
- Prefer `materializeAgentSkillSnapshots(...): Promise<MuxMessage[]>` over nullable wrapper objects; empty arrays simplify append/emit loops.
- `$skill` suggestions should not filter out names that collide with slash commands. `$clear` should reference a skill named `clear` even though `/clear` is a command.

Adjusted implementation order:

1. Shared metadata + schemas + helper utilities.
2. Backend plural materialization while preserving existing slash behavior.
3. Inline parser/resolver.
4. Frontend send-flow integration, including normal, creation, model one-shot, and slash+inline mixed messages.
5. Autocomplete UX.
6. Dogfooding, docs/comments, and final validation.

## Implementation plan

The sections below are grouped by subsystem. Implement them in the adjusted order above, which intentionally proves backend slash compatibility before wiring new inline frontend behavior.

### Subsystem: Shared metadata and skill-ref utilities

Files likely touched:

- `src/common/types/message.ts`
- `src/common/orpc/schemas/message.ts` and any other persisted/replayed message schema that validates metadata
- possibly new `src/common/types/agentSkillReference.ts` or colocated exports in `message.ts`

Steps:

1. Define a shared `AgentSkillReference` type using existing `SkillName` / `AgentSkillScope` types.
2. Add `agentSkillRefs?: AgentSkillReference[]` to `MuxMessageMetadataBase`.
3. Update relevant Zod/message schemas so persisted/replayed metadata accepts the new field; `SendMessageOptions.muxMetadata` is loose today, but history/replay paths may still validate structured metadata.
4. Add helpers to keep metadata updates centralized:
   - `dedupeAgentSkillRefs(refs)` — dedupe by `skillName`, preserve first appearance order, and let slash refs win over inline refs for the same skill.
   - `withAgentSkillRefs(metadata, refs)` or similar — merge refs into existing metadata without dropping `reviews`, `requestedModel`, `rawCommand`, etc.
5. Update `buildAgentSkillMetadata(...)` to populate both:
   - legacy slash fields: `type: "agent-skill"`, `skillName`, `scope`, `rawCommand`
   - new base refs: `agentSkillRefs: [{ skillName, scope, source: "slash" }]`

Defensive programming:

- Assert/detect invalid helper inputs in shared helpers.
- Keep helpers pure and small so merge behavior is easy to test.

Quality gate:

- Unit tests for dedupe/merge behavior if helper complexity warrants it.
- Typecheck should catch metadata composition errors.

### Subsystem: Inline `$skill` parser and resolver

Files likely touched:

- new `src/browser/utils/agentSkills/inlineSkillReferences.ts` or `src/browser/features/ChatInput/inlineSkillReferences.ts`
- `src/browser/features/ChatInput/utils.ts`

Add parser functions:

```ts
extractInlineSkillReferenceCandidates(text: string): InlineSkillCandidate[]
findInlineSkillReferenceAtCursor(text: string, cursor: number): InlineSkillCursorMatch | null
```

Parser behavior:

- Match only `$` followed by an inline-safe skill-token shape: first character `[a-z]`, then lowercase letters, numbers, and hyphens. This intentionally treats `$100` as currency, not a skill reference, even though slash invocation can still support numeric skill names if the shared schema allows them.
- Validate final candidate names with `SkillNameSchema` or a shared equivalent after applying the stricter inline first-character rule.
- Require a sane left boundary so `foo$bar` does not match.
- Stop at the first non-skill-name character.
- Skip candidates inside inline backticks.
- Skip candidates inside fenced code blocks.
- Preserve `startIndex` / `endIndex` for parser/autocomplete replacement only; do not persist those ranges in `agentSkillRefs`.
- Deduplicate repeated refs while preserving first-appearance order.

Resolver behavior:

- Resolve candidates against `agentSkillDescriptors` first, including descriptors where `advertise === false`.
- Optionally fall back to `api.agentSkills.get(...)` for valid-looking candidates that are not already listed, matching the existing slash path.
- Silently ignore unknown/unresolvable candidates.
- Avoid slow failure paths by deduping candidate names before backend fallback calls.
- Keep result order based on first mention in text.

Quality gate:

- Parser tests for:
  - `$deep-review`
  - multiple refs
  - duplicate refs
  - punctuation boundaries like `($tdd)` and `$tdd,`
  - invalid/non-skill values: `$100` as currency, `$PATH`, `$Bad`, `$bad-`, `$-bad`, `foo$tdd`
  - inline code: `` `$tdd` `` ignored
  - fenced code blocks ignored
  - mixed valid/unknown refs where unknowns are dropped by resolver

### Subsystem: Frontend send-flow integration

Files likely touched:

- `src/browser/features/ChatInput/utils.ts`
- `src/browser/features/ChatInput/index.tsx`

Steps:

1. Extend the existing parse/send preparation path so inline refs are resolved for all relevant sends:
   - normal workspace message
   - creation flow message
   - model one-shot message, e.g. `/opus+high Please use $deep-review`
   - mixed slash + inline message, e.g. `/deep-review Please also follow $tdd`
2. Parse inline refs from the original authored text before slash skill rewrites or model one-shot prefix stripping.
3. Preserve current slash skill behavior:
   - `/deep-review foo` may continue to rewrite backend text to `Using skill deep-review: foo`.
   - Slash metadata should also include `agentSkillRefs`.
4. For inline refs, preserve message text exactly as typed.
5. Merge inline refs into whatever `muxMetadata` exists later in the send path using the shared helper.
6. Ensure later metadata additions do not drop refs:
   - reviews via `prepareUserMessageForSend(...)`
   - requested model labels
   - one-shot `rawCommand` / `commandPrefix`
   - edit sends
   - retry send options
   - on-send auto-compaction follow-up metadata
7. In creation flow, if any resolved referenced skill is project-scoped, set `disableWorkspaceAgents: true`, matching the existing slash skill creation behavior.
8. For model one-shots, parse refs from the user-authored text, but attach them to the final metadata after model override metadata is computed.

Defensive programming:

- Add a local assertion or invariant test around metadata merge helpers rather than open-coding object spreads in multiple places.
- Treat backend/API failures during inline resolution as “unknown skill” and silently continue.

Quality gate:

- Tests proving message text is preserved for inline refs.
- Tests proving one-shot metadata and skill refs compose.
- Tests proving `/deep-review Please also follow $tdd` produces both slash and inline refs.
- Tests proving refs survive review metadata and edit/retry/on-send compaction paths where practical.
- Tests proving creation flow sets `disableWorkspaceAgents` when a project-scoped inline skill is referenced.

### Subsystem: Backend plural skill snapshot materialization

Files likely touched:

- `src/node/services/agentSession.ts`
- possibly `src/node/services/agentSkills/loadedSkillSnapshots.ts` only if helper extraction is useful

Steps:

1. Replace or wrap `materializeAgentSkillSnapshot(...)` with plural logic:

```ts
materializeAgentSkillSnapshots(...): Promise<MuxMessage[]>
```

Return an empty array when there are no refs or all inline refs are skipped; this keeps append/emit loops simple.

2. Convert metadata to refs using a helper:
   - start with `metadata.agentSkillRefs ?? []`
   - merge in legacy `metadata.type === "agent-skill"` fields as a `source: "slash"` ref when no matching slash ref exists
3. Validate each `skillName` with `SkillNameSchema`; invalid inline refs are skipped, while invalid slash/legacy refs keep the current strict error behavior.
4. Deduplicate refs by skill identity while preserving first-appearance order, with slash refs winning over inline refs for the same skill.
5. Read each skill with existing `readAgentSkill(...)` using the same project/workspace discovery path logic as today. Treat metadata `scope` as advisory only; use the resolved package scope in snapshots.
6. Create one synthetic `agentSkillSnapshot` message per resolved skill.
7. Update append and emit sites to loop over the returned snapshot messages.
8. Improve dedupe against recent history:
   - check recent synthetic `agentSkillSnapshot` messages, not just the most recent one
   - skip only refs whose `skillName + sha256` already exists recently
9. Preserve existing slash behavior for invalid/missing slash skills unless intentionally changed:
   - invalid/unreadable inline refs are skipped both before and after `readAgentSkill(...)`
   - slash refs and old slash metadata fallback keep throwing as today for invalid skill names or missing/unreadable skills

Quality gate:

- `src/node/services/agentSession.agentSkillSnapshot.test.ts` additions for:
  - multiple refs create multiple snapshot messages before the user message
  - order is preserved
  - repeated refs load once, with slash winning over inline duplicates
  - recent duplicate snapshots are skipped per skill
  - legacy `type: "agent-skill"` still materializes exactly as before
  - inline skill deleted between frontend resolution and backend read is skipped, while slash/legacy failure remains strict

### Subsystem: `$skill` autocomplete UX

Files likely touched:

- new or existing inline skill suggestion helper, likely near the parser utility
- `src/browser/features/ChatInput/index.tsx`
- `src/browser/features/ChatInput/CommandSuggestions.test.tsx`
- maybe `src/browser/utils/slashCommands/types.ts` only if suggestion type naming needs to stay shared

Design:

- Do not overload `getSlashCommandSuggestions(...)`; it is slash-only and whole-input oriented.
- Add a sibling helper for skill suggestions:

```ts
getInlineSkillSuggestions(partial: string, context): SlashSuggestion[]
```

It can reuse the existing `SlashSuggestion` display shape, but ids should be distinct, e.g. `inline-skill:tdd`.

- Mirror `@file` mention behavior:
  - use `inputRef.current.selectionStart`
  - call `findInlineSkillReferenceAtCursor(input, cursor)`
  - show suggestions while cursor is in a `$partial` token
  - on select with Enter/Tab/click, replace only `[startIndex, endIndex)` with `$skill-name`
  - add trailing space if the following character is absent or not whitespace/punctuation where a space would be wrong
  - support Escape dismissal and arrow-key navigation consistently with existing suggestion popovers
  - restore focus and cursor after insertion
  - use cursor-movement state/nonce similar to `@file` mentions so suggestions reopen when the caret moves into an existing `$partial` token

Suggestion precedence:

1. `@file` suggestions when active.
2. `$skill` suggestions when active.
3. Slash command suggestions when input starts with `/`.

This avoids overlapping popovers and preserves existing slash behavior.

Quality gate:

- Component/unit tests for:
  - `$dee` shows `$deep-review`
  - selecting a skill with Enter/Tab/click replaces only the token, not the whole input
  - Escape dismisses suggestions and arrow keys navigate them
  - moving the caret into an existing `$partial` token opens suggestions
  - typing `$` in the middle of a sentence works
  - suggestions do not appear inside inline/fenced code
  - `$clear` can suggest a skill named `clear` even though `/clear` is a slash command
  - slash suggestions still work
  - `@file` suggestions keep precedence

### Subsystem: Documentation and comments

Files likely touched only if docs already document skill invocation:

- search existing docs for slash skill invocation before adding anything
- if user-facing docs exist, update them in `docs/` and navigation if needed

Guidance:

- Keep docs minimal.
- Do not create free-floating Markdown.
- Add inline code comments only where they explain non-obvious “why”, especially:
  - why `agentSkillRefs` is orthogonal metadata
  - why inline refs ignore code spans/fences
  - why unknown refs are silently ignored

Quality gate:

- If docs changed, run docs/static checks required by repo conventions.

## Acceptance criteria

Functional:

- `Please perform a $deep-review and follow $tdd` loads both skills for the turn.
- Sent message text remains exactly as typed.
- Duplicate refs load once.
- Unknown refs are ignored silently.
- `$skill` inside inline code or fenced code does not load.
- Unadvertised skills are loadable by exact `$skill-name`.
- Creation flow supports `$skill` refs and resolves project-scoped skills from the project path.
- Model one-shots support `$skill` refs while preserving model override behavior.
- Existing `/skill-name` behavior remains compatible.
- Mixed `/deep-review Please also follow $tdd` loads both slash and inline refs.
- `$100` is treated as currency/non-skill in inline parsing.
- A skill named `clear` can be referenced as `$clear` even though `/clear` is a slash command.
- Existing persisted `type: "agent-skill"` messages still replay/materialize correctly.

Autocomplete:

- Typing `$dee` offers `$deep-review`.
- Selecting a suggestion replaces only the current `$...` token.
- Autocomplete works in the middle of a sentence.
- Autocomplete reopens when the caret moves into an existing `$partial` token.
- Enter/Tab/click select suggestions; Escape dismisses; arrow keys navigate.
- Autocomplete does not activate inside inline code/fenced code.
- Slash command and `@file` suggestions continue to work.

Architecture:

- Skill refs live in an orthogonal metadata field, not a combinatorial union variant.
- Persisted refs contain only `{ skillName, scope, source }`; parser ranges remain transient.
- Metadata merge helpers prevent refs from being dropped when reviews/model overrides/command metadata are added.
- Backend snapshot materialization is plural, order-preserving, and uses resolved skill package scope instead of trusting frontend metadata scope.

## Validation plan

Run targeted tests first, then broader checks:

1. Parser/resolver tests:
   - likely new/updated tests near `src/browser/features/ChatInput/utils.test.ts` or `src/browser/utils/agentSkills/*.test.ts`
2. Suggestion/component tests:
   - `bun test src/browser/features/ChatInput/CommandSuggestions.test.tsx`
   - any new inline skill suggestion tests
   - coverage for keyboard selection/dismissal/navigation and cursor movement into `$partial`
3. Backend snapshot tests:
   - `bun test src/node/services/agentSession.agentSkillSnapshot.test.ts`
   - `bun test src/node/services/agentSkills/loadedSkillSnapshots.test.ts` if touched
   - coverage for source-specific skip/fail behavior and slash+inline dedupe
4. Type/lint/static validation:
   - `make typecheck`
   - `make lint` or `make static-check` if the final diff is broad enough / before PR

Do not claim success until the targeted tests and the appropriate static validation pass, or report exact blockers.

## Dogfooding plan with reviewer evidence

Dogfooding should be performed after automated tests pass.

Setup:

1. Start an isolated Mux dev environment using the repo’s sandbox/dev-server guidance if available.
2. Create or use test skills named `deep-review` and `tdd`; include one advertised and one `advertise: false` case if easy.
3. Open the app with `agent-browser`.

Scenarios to record:

1. Autocomplete in normal text:
   - type `Please perform a $dee`
   - verify `$deep-review` suggestion appears
   - select it
   - type ` and follow $td`
   - select `$tdd`
2. Send-time loading:
   - send `Please perform a $deep-review on this code and make sure to follow $tdd`
   - verify visible message text remains unchanged
   - inspect history/debug output to confirm two synthetic `agentSkillSnapshot` messages were inserted before the user message
3. Code exclusion:
   - send a message containing `` `$tdd` `` and a fenced block with `$deep-review`
   - verify no skills are loaded from those code spans/fences
4. Model one-shot and mixed slash + inline:
   - send `/opus+high Please use $deep-review`
   - verify model override metadata still applies and skill snapshot is loaded
   - send `/deep-review Please also follow $tdd`
   - verify both skill snapshots are loaded and slash behavior remains readable
5. False-positive checks:
   - send text with `$100`, `$PATH`, inline-code `` `$tdd` ``, and a fenced block containing `$deep-review`
   - verify only valid non-code skill refs load
6. Creation flow:
   - from creation UI, reference a project-scoped `$skill`
   - verify project-path discovery behavior matches existing slash skill invocation

Evidence to capture:

- Screenshots of autocomplete suggestions and final sent message.
- A short video recording of typing/selecting/sending inline skill refs.
- Terminal/debug output or history inspection showing loaded skill snapshots.
- Attach screenshots/video files for reviewer verification when available.

## Main risks and mitigations

- **Metadata merge bugs:** use centralized merge helper and tests; avoid open-coded spreads that drop `agentSkillRefs`, especially across reviews, edits, retries, model one-shots, and on-send compaction follow-ups.
- **Parser false positives:** validate with `SkillNameSchema`, require the stricter inline first-character rule, require sane boundaries, and skip Markdown code spans/fences.
- **Autocomplete complexity:** mirror existing `@file` cursor-aware flow instead of extending slash suggestions; include keyboard and caret-movement tests.
- **Backend trust boundary:** treat frontend `scope` as advisory, resolve skills from disk, and use resolved package scope for snapshots.
- **Backend duplicate snapshots:** dedupe refs before reading and also check recent synthetic snapshots per skill/hash.
- **Creation path mismatch:** reuse existing `disableWorkspaceAgents` behavior for project-scoped skill refs.
- **Performance:** dedupe candidates before API fallback and cap or avoid excessive backend lookups for many unknown `$...` tokens.

## Recommended delivery shape

Implement as one cohesive feature branch with internal workstreams, not separate architecture-breaking PRs. Use this order:

1. Shared metadata + schemas + helper utilities.
2. Backend plural materialization while proving existing slash behavior still works.
3. Inline parser/resolver.
4. Frontend send-flow integration.
5. Autocomplete UX.
6. Tests, validation, dogfooding evidence.

If scope needs to be reduced, keep the `agentSkillRefs` architecture and defer only visual highlighting/docs polish; do not fall back to `inline-skills` metadata.

</details>

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `max` • Cost: `$188.10`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=max costs=188.10 -->
