### PR TITLE
🤖 fix: show pre-stream sidebar status as streaming

### DIFF
--- a/src/browser/components/WorkspaceStatusIndicator/WorkspaceStatusIndicator.test.tsx
+++ b/src/browser/components/WorkspaceStatusIndicator/WorkspaceStatusIndicator.test.tsx
@@ -89,9 +89,49 @@ describe("WorkspaceStatusIndicator", () => {
     expect(view.container.textContent?.toLowerCase()).toContain("streaming");
   });
 
-  test("holds the starting layout through a brief idle gap before streaming lands", async () => {
+  test("keeps provisioning-only startup distinct from active streaming through teardown", () => {
+    mockSidebarState({
+      isStarting: false,
+      pendingStreamModel: "openai:gpt-4o-mini",
+    });
+
+    const workspaceId = "workspace-provisioning";
+    const fallbackModel = "anthropic:claude-sonnet-4-5";
+    const view = render(
+      <WorkspaceStatusIndicator
+        workspaceId={workspaceId}
+        fallbackModel={fallbackModel}
+        isCreating
+      />
+    );
+
+    const expectProvisioningChrome = () => {
+      const phaseSlot = view.container.querySelector("[data-phase-slot]");
+      expect(phaseSlot).toBeTruthy();
+      expect(phaseSlot?.querySelector("svg")?.getAttribute("class") ?? "").toContain(
+        "animate-spin"
+      );
+      expect(view.container.textContent?.toLowerCase()).toContain("starting");
+      expect(view.container.textContent?.toLowerCase()).not.toContain("streaming");
+    };
+
+    expectProvisioningChrome();
+
+    view.rerender(
+      <WorkspaceStatusIndicator
+        workspaceId={workspaceId}
+        fallbackModel={fallbackModel}
+        isCreating={false}
+      />
+    );
+
+    expectProvisioningChrome();
+  });
+
+  test("uses the steady streaming layout during pre-stream startup and the idle handoff gap", () => {
     const pendingModel = "openai:gpt-4o-mini";
     const fallbackModel = "anthropic:claude-sonnet-4-5";
+    const pendingDisplayName = formatModelDisplayName(getModelName(pendingModel));
     const state: WorkspaceStoreModule.WorkspaceSidebarState = {
       canInterrupt: false,
       isStarting: true,
@@ -114,11 +154,15 @@ describe("WorkspaceStatusIndicator", () => {
     );
 
     const getPhaseSlot = () => view.container.querySelector("[data-phase-slot]");
-    const getPhaseIcon = () => getPhaseSlot()?.querySelector("svg");
+    const getModelDisplay = () => view.container.querySelector("[data-model-display]");
+    const expectStreamingChrome = () => {
+      expect(getPhaseSlot()).toBeNull();
+      expect(getModelDisplay()?.textContent ?? "").toContain(pendingDisplayName);
+      expect(view.container.textContent?.toLowerCase()).toContain("streaming");
+      expect(view.container.textContent?.toLowerCase()).not.toContain("starting");
+    };
 
-    expect(getPhaseSlot()?.getAttribute("class") ?? "").toContain("w-3");
-    expect(getPhaseIcon()?.getAttribute("class") ?? "").toContain("animate-spin");
-    expect(view.container.textContent?.toLowerCase()).toContain("starting");
+    expectStreamingChrome();
 
     state.isStarting = false;
     view.rerender(
@@ -129,9 +173,7 @@ describe("WorkspaceStatusIndicator", () => {
       />
     );
 
-    expect(getPhaseSlot()?.getAttribute("class") ?? "").toContain("w-3");
-    expect(getPhaseIcon()?.getAttribute("class") ?? "").toContain("animate-spin");
-    expect(view.container.textContent?.toLowerCase()).toContain("starting");
+    expectStreamingChrome();
 
     state.canInterrupt = true;
     state.currentModel = pendingModel;
@@ -140,13 +182,10 @@ describe("WorkspaceStatusIndicator", () => {
       <WorkspaceStatusIndicator workspaceId={workspaceId} fallbackModel={fallbackModel} />
     );
 
-    await waitFor(() => {
-      expect(view.container.textContent?.toLowerCase()).toContain("streaming");
-      expect(getPhaseIcon()?.getAttribute("class") ?? "").not.toContain("animate-spin");
-    });
+    expectStreamingChrome();
   });
 
-  test("keeps the model label anchored when starting hands off to streaming", async () => {
+  test("keeps the model label anchored when pre-stream startup hands off to streaming", async () => {
     const pendingModel = "openai:gpt-4o-mini";
     const fallbackModel = "anthropic:claude-sonnet-4-5";
     const pendingDisplayName = formatModelDisplayName(getModelName(pendingModel));
@@ -172,16 +211,13 @@ describe("WorkspaceStatusIndicator", () => {
       <WorkspaceStatusIndicator workspaceId={workspaceId} fallbackModel={fallbackModel} />
     );
 
-    const getPhaseSlot = () => view.container.querySelector("[data-phase-slot]");
-    const getPhaseIcon = () => getPhaseSlot()?.querySelector("svg");
     const getModelDisplay = () => view.container.querySelector("[data-model-display]");
 
-    expect(getPhaseSlot()?.getAttribute("class") ?? "").toContain("w-3");
-    expect(getPhaseSlot()?.getAttribute("class") ?? "").toContain("mr-1.5");
-    expect(getPhaseIcon()?.getAttribute("class") ?? "").toContain("animate-spin");
+    expect(view.container.querySelector("[data-phase-slot]")).toBeNull();
     expect(getModelDisplay()?.textContent ?? "").toContain(pendingDisplayName);
     expect(getModelDisplay()?.textContent ?? "").not.toContain(fallbackDisplayName);
-    expect(view.container.textContent?.toLowerCase()).toContain("starting");
+    expect(view.container.textContent?.toLowerCase()).toContain("streaming");
+    expect(view.container.textContent?.toLowerCase()).not.toContain("starting");
 
     state.isStarting = false;
     state.canInterrupt = true;
@@ -198,8 +234,9 @@ describe("WorkspaceStatusIndicator", () => {
     await waitFor(() => {
       expect(getModelDisplay()?.textContent ?? "").toContain(pendingDisplayName);
       expect(getModelDisplay()?.textContent ?? "").not.toContain(fallbackDisplayName);
-      expect(getPhaseIcon()?.getAttribute("class") ?? "").not.toContain("animate-spin");
+      expect(view.container.querySelector("[data-phase-slot]")).toBeNull();
       expect(view.container.textContent?.toLowerCase()).toContain("streaming");
+      expect(view.container.textContent?.toLowerCase()).not.toContain("starting");
     });
   });
 });

--- a/src/browser/components/WorkspaceStatusIndicator/WorkspaceStatusIndicator.tsx
+++ b/src/browser/components/WorkspaceStatusIndicator/WorkspaceStatusIndicator.tsx
@@ -12,8 +12,8 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "../Tooltip/Tooltip";
 export const WorkspaceStatusIndicator = memo<{
   workspaceId: string;
   fallbackModel: string;
-  /** When true the workspace is still being provisioned (show "starting…"). Passed as
-   *  a prop so this component doesn't need to subscribe to the full WorkspaceContext. */
+  /** When true the workspace is still being provisioned. Passed as a prop so this
+   *  component doesn't need to subscribe to the full WorkspaceContext. */
   isCreating?: boolean;
 }>(({ workspaceId, fallbackModel, isCreating }) => {
   const {
@@ -30,7 +30,14 @@ export const WorkspaceStatusIndicator = memo<{
     isStarting,
     isCreating,
   });
-  const { displayPhase, shouldCollapsePhaseSlot } = useWorkspaceStreamingStatusPhase(phase);
+  const phaseSource = canInterrupt
+    ? "streaming"
+    : isStarting
+      ? "pre-stream"
+      : isCreating === true
+        ? "provisioning"
+        : null;
+  const { displayPhase, displayPhaseSource } = useWorkspaceStreamingStatusPhase(phase, phaseSource);
 
   // Show prompt when ask_user_question is pending - make it prominent
   if (awaitingUserQuestion) {
@@ -92,58 +99,31 @@ export const WorkspaceStatusIndicator = memo<{
     displayPhase === "starting"
       ? (pendingStreamModel ?? fallbackModel)
       : (currentModel ?? pendingStreamModel ?? fallbackModel);
-  const suffix = displayPhase === "starting" ? "- starting..." : "- streaming...";
-
-  if (displayPhase === "streaming" && !shouldCollapsePhaseSlot) {
-    return (
-      <div className="text-muted flex min-w-0 items-center gap-1.5 text-xs">
-        {modelToShow ? (
-          <>
-            <span className="min-w-0 truncate">
-              <ModelDisplay modelString={modelToShow} showTooltip={false} />
-            </span>
-            <span className="shrink-0 opacity-70">{suffix}</span>
-          </>
-        ) : (
-          <span className="min-w-0 truncate">Assistant - streaming...</span>
-        )}
-      </div>
-    );
-  }
+  // displayPhaseSource is held alongside displayPhase, so the provisioning teardown hold
+  // stays labeled "starting" instead of being re-derived from live isCreating=false.
+  const isProvisioningOnlyStartup =
+    displayPhase === "starting" && displayPhaseSource === "provisioning";
+  // User-facing sidebar state should look like active streaming during pre-stream send
+  // startup, but keep workspace provisioning distinct because no assistant turn is running yet.
+  const suffix = isProvisioningOnlyStartup ? "- starting..." : "- streaming...";
 
   return (
-    <div className="text-muted flex min-w-0 items-center text-xs">
-      {/* Keep the old steady-state layout, but hold the spinner slot just long enough to
-          animate the start -> stream handoff instead of flashing the label left. */}
-      {(displayPhase === "starting" || shouldCollapsePhaseSlot) && (
-        <span
-          className={
-            displayPhase === "starting"
-              ? "mr-1.5 inline-flex w-3 shrink-0 overflow-hidden opacity-100"
-              : "mr-0 inline-flex w-0 shrink-0 overflow-hidden opacity-0 transition-[margin,width,opacity] duration-150 ease-out"
-          }
-          data-phase-slot
-        >
-          <Loader2
-            aria-hidden="true"
-            className={
-              displayPhase === "starting"
-                ? "h-3 w-3 shrink-0 animate-spin opacity-70"
-                : "h-3 w-3 shrink-0"
-            }
-          />
+    <div className="text-muted flex min-w-0 items-center gap-1.5 text-xs">
+      {isProvisioningOnlyStartup && (
+        <span className="inline-flex w-3 shrink-0 overflow-hidden opacity-100" data-phase-slot>
+          <Loader2 aria-hidden="true" className="h-3 w-3 shrink-0 animate-spin opacity-70" />
         </span>
       )}
       {modelToShow ? (
-        <div className="flex min-w-0 items-center gap-1.5">
+        <>
           <span className="min-w-0 truncate">
             <ModelDisplay modelString={modelToShow} showTooltip={false} />
           </span>
           <span className="shrink-0 opacity-70">{suffix}</span>
-        </div>
+        </>
       ) : (
         <span className="min-w-0 truncate">
-          {displayPhase === "starting" ? "Assistant - starting..." : "Assistant - streaming..."}
+          {isProvisioningOnlyStartup ? "Assistant - starting..." : "Assistant - streaming..."}
         </span>
       )}
     </div>

--- a/src/browser/hooks/useWorkspaceStreamingStatusPhase.ts
+++ b/src/browser/hooks/useWorkspaceStreamingStatusPhase.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState, type MutableRefObject } from "react";
 import { WORKSPACE_STREAMING_STATUS_TRANSITION_MS } from "@/constants/streaming";
 
 export type WorkspaceStreamingStatusPhase = "starting" | "streaming";
+export type WorkspaceStreamingStatusPhaseSource = "streaming" | "pre-stream" | "provisioning";
 
 interface WorkspaceStreamingStatusPhaseOptions {
   canInterrupt: boolean;
@@ -33,37 +34,36 @@ function clearTimer(timerIdRef: MutableRefObject<number | null>): void {
  * Keep the sidebar's streaming label mounted across brief state handoffs so the row
  * does not blink out when startup and active-stream flags settle on adjacent renders.
  */
-export function useWorkspaceStreamingStatusPhase(phase: WorkspaceStreamingStatusPhase | null): {
+export function useWorkspaceStreamingStatusPhase(
+  phase: WorkspaceStreamingStatusPhase | null,
+  phaseSource: WorkspaceStreamingStatusPhaseSource | null = null
+): {
   displayPhase: WorkspaceStreamingStatusPhase | null;
-  shouldCollapsePhaseSlot: boolean;
+  displayPhaseSource: WorkspaceStreamingStatusPhaseSource | null;
 } {
   const [heldPhaseSnapshot, setHeldPhaseSnapshot] = useState<WorkspaceStreamingStatusPhase | null>(
     phase
   );
+  const [heldPhaseSourceSnapshot, setHeldPhaseSourceSnapshot] =
+    useState<WorkspaceStreamingStatusPhaseSource | null>(phaseSource);
   const heldPhaseSnapshotRef = useRef(heldPhaseSnapshot);
-  const [isCollapsingPhaseSlot, setIsCollapsingPhaseSlot] = useState(false);
-  const previousDisplayPhaseRef = useRef<WorkspaceStreamingStatusPhase | null>(phase);
+  const heldPhaseSourceSnapshotRef = useRef(heldPhaseSourceSnapshot);
   const hideTimerIdRef = useRef<number | null>(null);
-  const collapseTimerIdRef = useRef<number | null>(null);
 
   const displayPhase = phase ?? heldPhaseSnapshot;
-  const shouldCollapsePhaseSlot =
-    phase !== null &&
-    (isCollapsingPhaseSlot ||
-      (previousDisplayPhaseRef.current === "starting" && displayPhase === "streaming"));
+  const displayPhaseSource = phase !== null ? phaseSource : heldPhaseSourceSnapshot;
 
   useEffect(() => {
     heldPhaseSnapshotRef.current = heldPhaseSnapshot;
   }, [heldPhaseSnapshot]);
 
   useEffect(() => {
-    previousDisplayPhaseRef.current = displayPhase;
-  }, [displayPhase]);
+    heldPhaseSourceSnapshotRef.current = heldPhaseSourceSnapshot;
+  }, [heldPhaseSourceSnapshot]);
 
   useEffect(() => {
     return () => {
       clearTimer(hideTimerIdRef);
-      clearTimer(collapseTimerIdRef);
     };
   }, []);
 
@@ -71,9 +71,6 @@ export function useWorkspaceStreamingStatusPhase(phase: WorkspaceStreamingStatus
     clearTimer(hideTimerIdRef);
 
     if (phase === null) {
-      clearTimer(collapseTimerIdRef);
-      setIsCollapsingPhaseSlot(false);
-
       if (heldPhaseSnapshotRef.current === null) {
         return;
       }
@@ -81,7 +78,9 @@ export function useWorkspaceStreamingStatusPhase(phase: WorkspaceStreamingStatus
       hideTimerIdRef.current = window.setTimeout(() => {
         hideTimerIdRef.current = null;
         heldPhaseSnapshotRef.current = null;
+        heldPhaseSourceSnapshotRef.current = null;
         setHeldPhaseSnapshot(null);
+        setHeldPhaseSourceSnapshot(null);
       }, WORKSPACE_STREAMING_STATUS_TRANSITION_MS);
       return;
     }
@@ -90,22 +89,14 @@ export function useWorkspaceStreamingStatusPhase(phase: WorkspaceStreamingStatus
       heldPhaseSnapshotRef.current = phase;
       setHeldPhaseSnapshot(phase);
     }
-
-    clearTimer(collapseTimerIdRef);
-    const shouldCollapse = previousDisplayPhaseRef.current === "starting" && phase === "streaming";
-    setIsCollapsingPhaseSlot(shouldCollapse);
-    if (!shouldCollapse) {
-      return;
+    if (heldPhaseSourceSnapshotRef.current !== phaseSource) {
+      heldPhaseSourceSnapshotRef.current = phaseSource;
+      setHeldPhaseSourceSnapshot(phaseSource);
     }
-
-    collapseTimerIdRef.current = window.setTimeout(() => {
-      collapseTimerIdRef.current = null;
-      setIsCollapsingPhaseSlot(false);
-    }, WORKSPACE_STREAMING_STATUS_TRANSITION_MS);
-  }, [phase]);
+  }, [phase, phaseSource]);
 
   return {
     displayPhase,
-    shouldCollapsePhaseSlot,
+    displayPhaseSource,
   };
 }

--- a/tests/ui/workspaces/intermediateStatus.test.ts
+++ b/tests/ui/workspaces/intermediateStatus.test.ts
@@ -1,8 +1,8 @@
 /**
  * UI integration test for the “working but no todo-derived status yet” intermediate state.
  *
- * Expectation: While a stream is starting and the agent has not written a todo list yet,
- * the workspace sidebar row should show provider icon + model name + starting label.
+ * Expectation: While a send is in pre-stream startup and the agent has not written a todo
+ * list yet, the workspace sidebar row should show provider icon + model name + streaming label.
  */
 
 import "../dom";
@@ -15,7 +15,9 @@ import { createAppHarness } from "../harness";
 import { workspaceStore } from "@/browser/stores/WorkspaceStore";
 
 function getWorkspaceElement(container: HTMLElement, workspaceId: string): HTMLElement {
-  const el = container.querySelector(`[data-workspace-id="${workspaceId}"]`) as HTMLElement | null;
+  const el = container.querySelector(
+    `[role="button"][data-workspace-id="${workspaceId}"]`
+  ) as HTMLElement | null;
   if (!el) {
     throw new Error(`Workspace element not found for ${workspaceId}`);
   }
@@ -27,7 +29,7 @@ describe("Workspace intermediate status (mock AI router)", () => {
     await preloadTestModules();
   });
 
-  test("shows model + starting while stream is starting and before todos appear", async () => {
+  test("shows model + streaming while send is starting and before todos appear", async () => {
     const app = await createAppHarness({ branchPrefix: "status-intermediate" });
 
     const collector = createStreamCollector(app.env.orpc, app.workspaceId);
@@ -67,7 +69,8 @@ describe("Workspace intermediate status (mock AI router)", () => {
           }
 
           const text = wsEl.textContent ?? "";
-          expect(text.toLowerCase()).toContain("starting");
+          expect(text.toLowerCase()).toContain("streaming");
+          expect(text.toLowerCase()).not.toContain("starting");
         },
         { timeout: 10_000 }
       );


### PR DESCRIPTION
Summary
- Shows the LeftSidebar workspace status as streaming during the pre-stream send startup window instead of rendering a separate starting/spinner state.

Background
- The pre-stream send state is an internal startup phase before stream-start lands, but to users the assistant turn is already running. This keeps sidebar status consistent with the active streaming state while preserving the separate provisioning-only startup label.

Implementation
- Reuses the existing pending model selection for pre-stream send startup, but renders the steady streaming label/chrome when a send is starting.
- Keeps workspace provisioning-only startup labeled as starting with its spinner because no assistant turn is running yet, including the brief held teardown window.
- Tracks the held status phase source so the sidebar can distinguish pre-stream send startup from provisioning-only startup while avoiding row flicker.
- Updates the UI integration coverage for the intermediate pre-stream sidebar status.

Validation
- `bun test src/browser/components/WorkspaceStatusIndicator/WorkspaceStatusIndicator.test.tsx src/browser/components/AgentListItem/AgentListItem.test.tsx`
- `bun test ./tests/ui/workspaces/intermediateStatus.test.ts`
- `make static-check`

Risks
- Low. The change is limited to sidebar status presentation and matching tests; interrupt/startup state derivation remains unchanged.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `high` • Cost: `n/a`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=high costs=n/a -->
