### PR TITLE
🤖 perf: speed up SSH stream startup

### DIFF
--- a/src/node/runtime/CoderSSHRuntime.test.ts
+++ b/src/node/runtime/CoderSSHRuntime.test.ts
@@ -970,6 +970,40 @@ describe("CoderSSHRuntime.ensureReady", () => {
     expect(getWorkspaceStatus).toHaveBeenCalledTimes(1);
   });
 
+  it("expires the cross-runtime activity cache after the fast-path window", async () => {
+    let now = 1_700_000_000_000;
+    const nowSpy = spyOn(Date, "now").mockImplementation(() => now);
+    try {
+      const getWorkspaceStatus = mock(() =>
+        Promise.resolve({ kind: "ok" as const, status: "running" as const })
+      );
+      const coderService = createMockCoderService({ getWorkspaceStatus });
+
+      const firstRuntime = createRuntime(
+        { existingWorkspace: true, workspaceName: "my-ws-expiring" },
+        coderService
+      );
+      expect(await firstRuntime.ensureReady()).toEqual({ ready: true });
+
+      const cachedRuntime = createRuntime(
+        { existingWorkspace: true, workspaceName: "my-ws-expiring" },
+        coderService
+      );
+      expect(await cachedRuntime.ensureReady()).toEqual({ ready: true });
+      expect(getWorkspaceStatus).toHaveBeenCalledTimes(1);
+
+      now += 5 * 60 * 1000 + 1;
+      const expiredRuntime = createRuntime(
+        { existingWorkspace: true, workspaceName: "my-ws-expiring" },
+        coderService
+      );
+      expect(await expiredRuntime.ensureReady()).toEqual({ ready: true });
+      expect(getWorkspaceStatus).toHaveBeenCalledTimes(2);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
   it("connects via waitForStartupScripts when status is stopped (auto-starts)", async () => {
     const getWorkspaceStatus = mock(() =>
       Promise.resolve({ kind: "ok" as const, status: "stopped" as const })

--- a/src/node/runtime/CoderSSHRuntime.test.ts
+++ b/src/node/runtime/CoderSSHRuntime.test.ts
@@ -949,6 +949,27 @@ describe("CoderSSHRuntime.ensureReady", () => {
     expect(events[0]?.runtimeType).toBe("ssh");
   });
 
+  it("reuses recent activity across recreated runtime instances", async () => {
+    const getWorkspaceStatus = mock(() =>
+      Promise.resolve({ kind: "ok" as const, status: "running" as const })
+    );
+    const coderService = createMockCoderService({ getWorkspaceStatus });
+
+    const firstRuntime = createRuntime(
+      { existingWorkspace: true, workspaceName: "my-ws-recreated" },
+      coderService
+    );
+    const secondRuntime = createRuntime(
+      { existingWorkspace: true, workspaceName: "my-ws-recreated" },
+      coderService
+    );
+
+    expect(await firstRuntime.ensureReady()).toEqual({ ready: true });
+    expect(await secondRuntime.ensureReady()).toEqual({ ready: true });
+
+    expect(getWorkspaceStatus).toHaveBeenCalledTimes(1);
+  });
+
   it("connects via waitForStartupScripts when status is stopped (auto-starts)", async () => {
     const getWorkspaceStatus = mock(() =>
       Promise.resolve({ kind: "ok" as const, status: "stopped" as const })

--- a/src/node/runtime/CoderSSHRuntime.ts
+++ b/src/node/runtime/CoderSSHRuntime.ts
@@ -66,6 +66,14 @@ const CODER_STATUS_POLL_INTERVAL_MS = 2_000;
 
 const coderLastActivityByService = new WeakMap<CoderService, Map<string, number>>();
 
+function pruneCoderActivityMap(activityByWorkspace: Map<string, number>, now: number): void {
+  for (const [workspaceName, lastActivityAtMs] of activityByWorkspace) {
+    if (now - lastActivityAtMs >= CODER_INACTIVITY_THRESHOLD_MS) {
+      activityByWorkspace.delete(workspaceName);
+    }
+  }
+}
+
 function getCoderActivityMap(coderService: CoderService): Map<string, number> {
   let activityByWorkspace = coderLastActivityByService.get(coderService);
   if (!activityByWorkspace) {
@@ -127,7 +135,10 @@ export class CoderSSHRuntime extends SSHRuntime {
       return;
     }
 
-    getCoderActivityMap(this.coderService).set(workspaceName, Date.now());
+    const now = Date.now();
+    const activityByWorkspace = getCoderActivityMap(this.coderService);
+    pruneCoderActivityMap(activityByWorkspace, now);
+    activityByWorkspace.set(workspaceName, now);
   }
 
   /** In-flight ensureReady promise to avoid duplicate start/wait sequences */
@@ -157,10 +168,12 @@ export class CoderSSHRuntime extends SSHRuntime {
 
     const now = Date.now();
     const activityByWorkspace = getCoderActivityMap(this.coderService);
+    pruneCoderActivityMap(activityByWorkspace, now);
     const lastActivityAtMs = activityByWorkspace.get(workspaceName) ?? 0;
 
     // Fast path: recently active, skip expensive status check. This cache intentionally lives
-    // outside the runtime instance because existing-workspace stream startup recreates runtimes.
+    // outside the runtime instance because existing-workspace stream startup recreates runtimes,
+    // and it prunes entries after the same 5-minute window to avoid unbounded workspace-name growth.
     if (lastActivityAtMs !== 0 && now - lastActivityAtMs < CODER_INACTIVITY_THRESHOLD_MS) {
       return { ready: true };
     }

--- a/src/node/runtime/CoderSSHRuntime.ts
+++ b/src/node/runtime/CoderSSHRuntime.ts
@@ -64,6 +64,17 @@ const CODER_INACTIVITY_THRESHOLD_MS = 5 * 60 * 1000;
 const CODER_ENSURE_READY_TIMEOUT_MS = 120_000;
 const CODER_STATUS_POLL_INTERVAL_MS = 2_000;
 
+const coderLastActivityByService = new WeakMap<CoderService, Map<string, number>>();
+
+function getCoderActivityMap(coderService: CoderService): Map<string, number> {
+  let activityByWorkspace = coderLastActivityByService.get(coderService);
+  if (!activityByWorkspace) {
+    activityByWorkspace = new Map();
+    coderLastActivityByService.set(coderService, activityByWorkspace);
+  }
+  return activityByWorkspace;
+}
+
 /**
  * SSH runtime that handles Coder workspace provisioning.
  *
@@ -74,14 +85,6 @@ const CODER_STATUS_POLL_INTERVAL_MS = 2_000;
 export class CoderSSHRuntime extends SSHRuntime {
   private coderConfig: CoderWorkspaceConfig;
   private readonly coderService: CoderService;
-
-  /**
-   * Timestamp of last time we (a) successfully used the runtime or (b) decided not
-   * to block the user (unknown Coder CLI error).
-   * Used to avoid running expensive status checks on every message while still
-   * catching auto-stopped workspaces after long inactivity.
-   */
-  private lastActivityAtMs = 0;
 
   /**
    * Flags for WorkspaceService to customize create flow:
@@ -119,6 +122,14 @@ export class CoderSSHRuntime extends SSHRuntime {
     this.coderService = coderService;
   }
 
+  private markActivity(workspaceName = this.coderConfig.workspaceName): void {
+    if (!workspaceName) {
+      return;
+    }
+
+    getCoderActivityMap(this.coderService).set(workspaceName, Date.now());
+  }
+
   /** In-flight ensureReady promise to avoid duplicate start/wait sequences */
   private ensureReadyPromise: Promise<EnsureReadyResult> | null = null;
 
@@ -145,12 +156,12 @@ export class CoderSSHRuntime extends SSHRuntime {
     }
 
     const now = Date.now();
+    const activityByWorkspace = getCoderActivityMap(this.coderService);
+    const lastActivityAtMs = activityByWorkspace.get(workspaceName) ?? 0;
 
-    // Fast path: recently active, skip expensive status check
-    if (
-      this.lastActivityAtMs !== 0 &&
-      now - this.lastActivityAtMs < CODER_INACTIVITY_THRESHOLD_MS
-    ) {
+    // Fast path: recently active, skip expensive status check. This cache intentionally lives
+    // outside the runtime instance because existing-workspace stream startup recreates runtimes.
+    if (lastActivityAtMs !== 0 && now - lastActivityAtMs < CODER_INACTIVITY_THRESHOLD_MS) {
       return { ready: true };
     }
 
@@ -214,7 +225,7 @@ export class CoderSSHRuntime extends SSHRuntime {
         return repoCheck;
       }
 
-      this.lastActivityAtMs = Date.now();
+      this.markActivity(workspaceName);
       emitStatus("ready");
       return { ready: true };
     }
@@ -274,7 +285,7 @@ export class CoderSSHRuntime extends SSHRuntime {
             return repoCheck;
           }
 
-          this.lastActivityAtMs = Date.now();
+          this.markActivity(workspaceName);
           emitStatus("ready");
           return { ready: true };
         }
@@ -331,7 +342,7 @@ export class CoderSSHRuntime extends SSHRuntime {
         return repoCheck;
       }
 
-      this.lastActivityAtMs = Date.now();
+      this.markActivity(workspaceName);
       emitStatus("ready");
       return { ready: true };
     } catch (error) {
@@ -843,7 +854,5 @@ export class CoderSSHRuntime extends SSHRuntime {
       initLogger.logStderr(`Failed to prepare workspace directory: ${errorMsg}`);
       throw new Error(`Failed to prepare workspace directory: ${errorMsg}`);
     }
-
-    this.lastActivityAtMs = Date.now();
   }
 }

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -1007,12 +1007,36 @@ export class SSHRuntime extends RemoteRuntime {
     );
     const gitDir = path.posix.join(workspacePath, ".git");
     const gitDirProbe = this.quoteForRemote(gitDir);
-
-    let testResult: { exitCode: number; stderr: string };
-    try {
+    const workspacePathArg = this.quoteForRemote(workspacePath);
+    const verifyWorkspaceCommand = [
       // .git is a file for worktrees; accept either file or directory so existing SSH/Coder
-      // worktree checkouts don't get flagged as setup failures.
-      testResult = await execBuffered(this, `test -d ${gitDirProbe} || test -f ${gitDirProbe}`, {
+      // worktree checkouts don't get flagged as setup failures. Keep this as one remote shell
+      // invocation because stream startup runs it before every first SSH use for a workspace.
+      `if ! (test -d ${gitDirProbe} || test -f ${gitDirProbe}); then`,
+      `  echo ${shescape.quote(`missing .git at ${gitDir}`)} >&2`,
+      "  exit 10",
+      "fi",
+      `git_dir_output=$(git -C ${workspacePathArg} rev-parse --git-dir 2>&1)`,
+      "git_dir_status=$?",
+      'if [ "$git_dir_status" -ne 0 ]; then',
+      '  printf "%s\\n" "$git_dir_output" >&2',
+      '  exit "$git_dir_status"',
+      "fi",
+      `inside_output=$(git -C ${workspacePathArg} rev-parse --is-inside-work-tree 2>&1)`,
+      "inside_status=$?",
+      'if [ "$inside_status" -ne 0 ]; then',
+      '  printf "%s\\n" "$inside_output" >&2',
+      '  exit "$inside_status"',
+      "fi",
+      'if [ "$inside_output" != "true" ]; then',
+      '  printf "not inside worktree: %s\\n" "$inside_output" >&2',
+      "  exit 11",
+      "fi",
+    ].join("\n");
+
+    let verifyResult: { exitCode: number; stderr: string; stdout: string };
+    try {
+      verifyResult = await execBuffered(this, verifyWorkspaceCommand, {
         cwd: "~",
         timeout: 10,
         abortSignal: options?.signal,
@@ -1025,51 +1049,22 @@ export class SSHRuntime extends RemoteRuntime {
       };
     }
 
-    if (testResult.exitCode !== 0) {
-      if (this.transport.isConnectionFailure(testResult.exitCode, testResult.stderr)) {
+    if (verifyResult.exitCode !== 0) {
+      const stderr = verifyResult.stderr.trim();
+      const stdout = verifyResult.stdout.trim();
+      const errorDetail = stderr || stdout || "git unavailable";
+      const isCommandMissing =
+        verifyResult.exitCode === 127 || /command not found/i.test(stderr || stdout);
+
+      if (this.transport.isConnectionFailure(verifyResult.exitCode, verifyResult.stderr)) {
         return {
           ready: false,
-          error: `Failed to reach SSH host: ${testResult.stderr || "connection failure"}`,
+          error: `Failed to reach SSH host: ${errorDetail || "connection failure"}`,
           errorType: "runtime_start_failed",
         };
       }
 
-      return {
-        ready: false,
-        error: WORKSPACE_REPO_MISSING_ERROR,
-        errorType: "runtime_not_ready",
-      };
-    }
-
-    let revResult: { exitCode: number; stderr: string; stdout: string };
-    try {
-      revResult = await execBuffered(
-        this,
-        `git -C ${this.quoteForRemote(workspacePath)} rev-parse --git-dir`,
-        {
-          cwd: "~",
-          timeout: 10,
-          abortSignal: options?.signal,
-        }
-      );
-    } catch (error) {
-      return {
-        ready: false,
-        error: `Failed to verify repository: ${getErrorMessage(error)}`,
-        errorType: "runtime_start_failed",
-      };
-    }
-
-    if (revResult.exitCode !== 0) {
-      const stderr = revResult.stderr.trim();
-      const stdout = revResult.stdout.trim();
-      const errorDetail = stderr || stdout || "git unavailable";
-      const isCommandMissing =
-        revResult.exitCode === 127 || /command not found/i.test(stderr || stdout);
-      if (
-        isCommandMissing ||
-        this.transport.isConnectionFailure(revResult.exitCode, revResult.stderr)
-      ) {
+      if (isCommandMissing) {
         return {
           ready: false,
           error: `Failed to verify repository: ${errorDetail}`,
@@ -1077,57 +1072,6 @@ export class SSHRuntime extends RemoteRuntime {
         };
       }
 
-      return {
-        ready: false,
-        error: WORKSPACE_REPO_MISSING_ERROR,
-        errorType: "runtime_not_ready",
-      };
-    }
-
-    let worktreeResult: { exitCode: number; stderr: string; stdout: string };
-    try {
-      worktreeResult = await execBuffered(
-        this,
-        `git -C ${this.quoteForRemote(workspacePath)} rev-parse --is-inside-work-tree`,
-        {
-          cwd: "~",
-          timeout: 10,
-          abortSignal: options?.signal,
-        }
-      );
-    } catch (error) {
-      return {
-        ready: false,
-        error: `Failed to verify worktree: ${getErrorMessage(error)}`,
-        errorType: "runtime_start_failed",
-      };
-    }
-
-    if (worktreeResult.exitCode !== 0) {
-      const stderr = worktreeResult.stderr.trim();
-      const stdout = worktreeResult.stdout.trim();
-      const errorDetail = stderr || stdout || "git unavailable";
-      const isCommandMissing =
-        worktreeResult.exitCode === 127 || /command not found/i.test(stderr || stdout);
-      if (
-        isCommandMissing ||
-        this.transport.isConnectionFailure(worktreeResult.exitCode, worktreeResult.stderr)
-      ) {
-        return {
-          ready: false,
-          error: `Failed to verify worktree: ${errorDetail}`,
-          errorType: "runtime_start_failed",
-        };
-      }
-
-      return {
-        ready: false,
-        error: WORKSPACE_REPO_MISSING_ERROR,
-        errorType: "runtime_not_ready",
-      };
-    }
-
-    if (worktreeResult.stdout.trim() !== "true") {
       return {
         ready: false,
         error: WORKSPACE_REPO_MISSING_ERROR,

--- a/src/node/services/aiService.test.ts
+++ b/src/node/services/aiService.test.ts
@@ -1193,6 +1193,7 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
     preparedPayloadMessageIds: string[][];
     preparedToolNamesForSentinel: string[][];
     streamSystemContextMuxScopes: MuxToolScope[];
+    streamSystemContextAdvisorFlags: Array<boolean | undefined>;
     startStreamCalls: unknown[][];
     getToolsForModelSpy: ReturnType<typeof spyOn<typeof toolsModule, "getToolsForModel">>;
   }
@@ -1276,6 +1277,7 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
     const preparedPayloadMessageIds: string[][] = [];
     const preparedToolNamesForSentinel: string[][] = [];
     const streamSystemContextMuxScopes: MuxToolScope[] = [];
+    const streamSystemContextAdvisorFlags: Array<boolean | undefined> = [];
     const startStreamCalls: unknown[][] = [];
 
     const resolvedAgentResult: Awaited<ReturnType<typeof agentResolution.resolveAgentForStream>> = {
@@ -1321,6 +1323,7 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
         throw new Error("Expected muxScope in stream system context build args");
       }
       streamSystemContextMuxScopes.push(args.muxScope);
+      streamSystemContextAdvisorFlags.push(args.advisorToolAvailable);
       return Promise.resolve({
         agentSystemPrompt: "test-agent-prompt",
         systemMessage: "test-system-message",
@@ -1427,6 +1430,7 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
       preparedPayloadMessageIds,
       preparedToolNamesForSentinel,
       streamSystemContextMuxScopes,
+      streamSystemContextAdvisorFlags,
       startStreamCalls,
       getToolsForModelSpy,
     };
@@ -1434,6 +1438,7 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
 
   const START_STREAM_ON_CHUNK_INDEX = 22;
   const START_STREAM_ON_STEP_MESSAGES_INDEX = 23;
+  const START_STREAM_RUNTIME_TEMP_DIR_INDEX = 24;
 
   interface AdvisorRuntimeForTests {
     createModel: (modelString: string) => Promise<LanguageModel>;
@@ -1608,6 +1613,66 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
         runtimeType: "local",
       },
     ]);
+  });
+
+  it("reuses the pre-policy stream system context when advisor availability is unchanged", async () => {
+    using muxHome = new DisposableTempDir("ai-service-reuse-system-context");
+    const projectPath = path.join(muxHome.path, "project");
+    await fs.mkdir(projectPath, { recursive: true });
+
+    const workspaceId = "workspace-reuse-system-context";
+    const metadata = createWorkspaceMetadata(workspaceId, projectPath);
+    const harness = createHarness(muxHome.path, metadata);
+
+    const result = await harness.service.streamMessage({
+      messages: [createMuxMessage("latest-user", "user", "hello")],
+      workspaceId,
+      modelString: "openai:gpt-5.2",
+      thinkingLevel: "off",
+    });
+
+    expect(result.success).toBe(true);
+    expect(harness.streamSystemContextAdvisorFlags).toEqual([false]);
+    expect(harness.startStreamCalls[0]?.[START_STREAM_RUNTIME_TEMP_DIR_INDEX]).toBe(
+      path.join(metadata.projectPath, ".tmp-stream")
+    );
+  });
+
+  it("rebuilds the stream system context when policy removes advisor guidance", async () => {
+    using muxHome = new DisposableTempDir("ai-service-rebuild-system-context-advisor");
+    const projectPath = path.join(muxHome.path, "project");
+    await fs.mkdir(projectPath, { recursive: true });
+
+    const workspaceId = "workspace-rebuild-system-context-advisor";
+    const metadata = createWorkspaceMetadata(workspaceId, projectPath);
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- stub for advisor availability gating
+    const stubTool: Tool = {} as never;
+    const harness = createHarness(muxHome.path, metadata, {
+      allTools: { advisor: stubTool },
+      postPolicyTools: {},
+    });
+    await harness.config.editConfig((cfg) => {
+      cfg.advisorModelString = KNOWN_MODELS.SONNET.id;
+      cfg.agentAiDefaults = {
+        ...cfg.agentAiDefaults,
+        exec: {
+          ...(cfg.agentAiDefaults?.exec ?? {}),
+          advisorEnabled: true,
+        },
+      };
+      return cfg;
+    });
+
+    const result = await harness.service.streamMessage({
+      messages: [createMuxMessage("latest-user", "user", "hello")],
+      workspaceId,
+      modelString: "openai:gpt-5.2",
+      thinkingLevel: "off",
+      experiments: { advisorTool: true },
+    });
+
+    expect(result.success).toBe(true);
+    expect(harness.streamSystemContextAdvisorFlags).toEqual([true, false]);
   });
 
   it("keeps legacy system workspaces on the global mux tool scope", async () => {

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1617,7 +1617,19 @@ export class AIService extends EventEmitter {
 
       const advisorToolAvailable = tools.advisor !== undefined;
       const finalStreamSystemContext =
-        await buildStreamSystemContextForAdvisor(advisorToolAvailable);
+        advisorToolAvailable === advisorToolEligible
+          ? prePolicyStreamSystemContext
+          : await (async () => {
+              // Rebuild only when policy/experiments changed advisor availability. On SSH this
+              // context build scans agents, skills, and instruction files over many small remote ops.
+              const rebuildStreamSystemContextStartedAt = Date.now();
+              const rebuiltContext = await buildStreamSystemContextForAdvisor(advisorToolAvailable);
+              recordStartupPhaseTiming(
+                "rebuildStreamSystemContextMs",
+                rebuildStreamSystemContextStartedAt
+              );
+              return rebuiltContext;
+            })();
       systemMessageTokens = finalStreamSystemContext.systemMessageTokens;
       systemMessage = finalStreamSystemContext.systemMessage;
 
@@ -1960,7 +1972,8 @@ export class AIService extends EventEmitter {
               advisorStepCaptureRef.currentStepReasoning = "";
               advisorStepCaptureRef.frozenSnapshotsByToolCallId.clear();
             }
-          : undefined
+          : undefined,
+        runtimeTempDir
       );
       recordStartupPhaseTiming("startStreamMs", startStreamStartedAt);
 

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -2897,7 +2897,8 @@ export class StreamManager extends EventEmitter {
     forceToolChoice?: boolean,
     callSettingsOverrides?: ResolvedCallSettingsOverrides,
     onChunk?: StreamTextOnChunk,
-    onStepMessages?: (messages: ModelMessage[]) => void
+    onStepMessages?: (messages: ModelMessage[]) => void,
+    providedRuntimeTempDir?: string
   ): Promise<Result<StreamToken, SendMessageError>> {
     const typedWorkspaceId = workspaceId as WorkspaceId;
 
@@ -2944,9 +2945,11 @@ export class StreamManager extends EventEmitter {
           return Ok(streamToken);
         }
 
-        // Step 3: Create temp directory for this stream using runtime
-        // If token was provided, temp dir might already exist - mkdir -p handles this
-        runtimeTempDir = await this.createTempDirForStream(streamToken, runtime);
+        // Step 3: Create temp directory for this stream using runtime.
+        // AIService pre-creates this dir so tool configuration can reference the same stable path;
+        // once startStream receives it, StreamManager owns cleanup for both success and abort paths.
+        runtimeTempDir =
+          providedRuntimeTempDir ?? (await this.createTempDirForStream(streamToken, runtime));
 
         if (streamAbortController.signal.aborted) {
           return Ok(streamToken);


### PR DESCRIPTION
## Summary
Speeds up stream startup for existing SSH workspaces by removing repeated pre-stream remote work: system-context discovery is no longer rebuilt unless advisor availability changes, the stream temp directory is created once and transferred into `StreamManager`, Coder SSH readiness caching now survives runtime recreation, and SSH repository readiness checks are batched into a single remote command.

## Background
Sending a follow-up message in an existing SSH workspace pays for a large amount of setup before `stream-start` can be emitted. The slow path was dominated by many small SSH executions and a duplicated context-build pass that rescanned agent definitions, skills, and instruction files.

## Implementation
- Reuse the pre-policy stream system context when advisor availability is unchanged; rebuild only when policy/experiments alter advisor guidance.
- Pass AIService's pre-created stream temp dir into `StreamManager.startStream()` so SSH does not repeat `resolvePath` + `mkdir -p` for the same token.
- Move Coder SSH recent-activity tracking into a `WeakMap<CoderService, Map<workspaceName, timestamp>>`, preserving the existing five-minute fast path across per-stream runtime instances.
- Combine SSH `.git`, `rev-parse --git-dir`, and `rev-parse --is-inside-work-tree` readiness probes into one remote shell invocation while preserving `runtime_not_ready` vs `runtime_start_failed` behavior.

## Estimated performance impact
This removes at least **4 fixed short SSH round trips per existing SSH send** on the common path:

- SSH repo readiness: **3 remote commands → 1 remote command** (**2 fewer**)
- Stream temp directory setup: duplicated `resolvePath` + `ensureDir` removed (**2 fewer**)
- Stream system context: **2 builds → 1 build** whenever advisor availability is unchanged, avoiding a second pass over agent definitions, skills, and instruction files.

Because each short OpenSSH operation typically costs a process spawn plus a remote round trip, the fixed-command reduction alone should save roughly **0.6–1.6s** on a common 150–400ms SSH round-trip/worktree-probe path. Avoiding the duplicate context build should save another **~1–4s** in workspaces with project/global agents, skills, or instruction files. Overall expected improvement for the common existing-SSH follow-up send is therefore **~1.5–5.5s faster pre-stream startup**, or roughly **35–65% lower stream-start latency** when the prior startup was in the ~4–10s range. This estimate is command-count based; the sandbox cannot benchmark a real remote SSH host, and existing `[stream-startup]` phase logs should confirm the exact per-workspace gain.

## Validation
- `bun test src/node/services/aiService.test.ts`
- `bun test src/node/services/streamManager.test.ts`
- `bun test src/node/runtime/CoderSSHRuntime.test.ts`
- `bun test src/node/runtime/SSHRuntime.retry.test.ts src/node/runtime/SSHRuntime.syncContract.test.ts`
- `make typecheck`
- `make fmt-check`
- `make lint`
- `make static-check`

## Risks
Moderate regression risk because this touches stream startup and SSH readiness checks. The changes are scoped to removing duplicate work or batching equivalent probes; error classification and temp-dir cleanup ownership are covered by targeted tests.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `high` • Cost: `$33.13`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=high costs=33.13 -->
