### PR TITLE
🤖 fix: preserve assistant markdown whitespace

### DIFF
--- a/src/node/services/messagePipeline.test.ts
+++ b/src/node/services/messagePipeline.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import type { AssistantModelMessage, ModelMessage } from "ai";
+
+import { transformModelMessages } from "@/browser/utils/messages/modelMessageTransform";
+import { sanitizeAssistantModelMessages } from "./messagePipeline";
+
+function isAssistantMessage(message: ModelMessage | undefined): message is AssistantModelMessage {
+  return message?.role === "assistant";
+}
+
+describe("sanitizeAssistantModelMessages", () => {
+  it("preserves whitespace-only separators before later text coalescing", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "## Verdict" },
+          { type: "text", text: "\n\n" },
+          { type: "text", text: "This is now **strong evidence**." },
+        ],
+      },
+    ];
+
+    const sanitized = sanitizeAssistantModelMessages(messages);
+    const transformed = transformModelMessages(sanitized, "openai");
+
+    expect(isAssistantMessage(sanitized[0])).toBe(true);
+    if (isAssistantMessage(sanitized[0])) {
+      expect(sanitized[0].content).toEqual([
+        { type: "text", text: "## Verdict\n\nThis is now **strong evidence**." },
+      ]);
+    }
+
+    expect(isAssistantMessage(transformed[0])).toBe(true);
+    if (isAssistantMessage(transformed[0])) {
+      expect(transformed[0].content).toEqual([
+        { type: "text", text: "## Verdict\n\nThis is now **strong evidence**." },
+      ]);
+    }
+  });
+
+  it("still filters assistant messages that contain only whitespace text", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "\n" },
+          { type: "text", text: "\t " },
+        ],
+      },
+    ];
+
+    expect(sanitizeAssistantModelMessages(messages)).toEqual([]);
+  });
+});

--- a/src/node/services/messagePipeline.ts
+++ b/src/node/services/messagePipeline.ts
@@ -8,7 +8,7 @@
  * All contextual data is passed via the options object.
  */
 
-import { convertToModelMessages, type ModelMessage } from "ai";
+import { convertToModelMessages, type AssistantModelMessage, type ModelMessage } from "ai";
 import { applyToolOutputRedaction } from "@/browser/utils/messages/applyToolOutputRedaction";
 import { sanitizeToolInputs } from "@/browser/utils/messages/sanitizeToolInput";
 import { inlineSvgAsTextForProvider } from "@/node/utils/messages/inlineSvgAsTextForProvider";
@@ -210,6 +210,39 @@ export async function prepareMessagesForProvider(
   return finalMessages;
 }
 
+type AssistantContentArray = Exclude<AssistantModelMessage["content"], string>;
+type AssistantContentPart = AssistantContentArray[number];
+
+function isTextPart(
+  part: AssistantContentPart
+): part is Extract<AssistantContentPart, { type: "text" }> {
+  return part.type === "text";
+}
+
+function normalizeAssistantContent(content: AssistantContentArray): AssistantContentArray {
+  let changed = false;
+  const coalesced: AssistantContentArray = [];
+
+  for (const part of content) {
+    const lastPart = coalesced.at(-1);
+    if (isTextPart(part) && lastPart && isTextPart(lastPart)) {
+      // Preserve provider-emitted whitespace separators before filtering whitespace-only
+      // blocks; dropping a standalone "\n\n" delta can corrupt headings in future prompts.
+      lastPart.text += part.text;
+      changed = true;
+      continue;
+    }
+
+    coalesced.push(isTextPart(part) ? { ...part } : part);
+  }
+
+  const filtered = coalesced.filter(
+    (part): part is AssistantContentPart => !isTextPart(part) || part.text.trim().length > 0
+  );
+
+  return changed || filtered.length !== content.length ? filtered : content;
+}
+
 /**
  * Self-healing: filter empty or whitespace-only assistant model messages.
  *
@@ -241,20 +274,18 @@ export function sanitizeAssistantModelMessages(
       return [];
     }
 
-    const filteredContent = msg.content.filter(
-      (part) => part.type !== "text" || part.text.trim().length > 0
-    );
+    const normalizedContent = normalizeAssistantContent(msg.content);
 
-    if (filteredContent.length === 0) {
+    if (normalizedContent.length === 0) {
       return [];
     }
 
     // Avoid mutating the original message (which can be reused in debug logging).
-    if (filteredContent.length === msg.content.length) {
+    if (normalizedContent === msg.content) {
       return [msg];
     }
 
-    return [{ ...msg, content: filteredContent }];
+    return [{ ...msg, content: normalizedContent }];
   });
 
   if (result.length < messages.length) {


### PR DESCRIPTION
Summary
- Preserve assistant text separators when normalizing history for provider requests, preventing prior streamed Markdown from being re-sent as clobbered headings like `## VerdictThis`.

Background
- Streaming stores assistant text as separate deltas. The request sanitizer dropped whitespace-only text deltas before later coalescing, so a prior sequence like `## Verdict`, `\n\n`, `This...` could become `## VerdictThis...` in future prompts.

Implementation
- Coalesce consecutive assistant text parts before filtering whitespace-only blocks.
- Continue filtering assistant messages that are genuinely empty or whitespace-only.
- Add regression coverage for heading separators surviving the full sanitizer + provider transform path.

Validation
- `bun test src/node/services/messagePipeline.test.ts`
- `make typecheck`
- `make static-check`
- post-rebase `make static-check`

Risks
- Low. The change is request-only and preserves existing filtering of whitespace-only assistant messages while avoiding destructive separator deletion between meaningful text chunks.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$7.32`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=7.32 -->
