### PR TITLE
🤖 fix(openai): omit service_tier when not configured

### DIFF
--- a/src/browser/features/Settings/Sections/ProvidersSection.tsx
+++ b/src/browser/features/Settings/Sections/ProvidersSection.tsx
@@ -83,6 +83,15 @@ type MuxGatewayLoginStatus = "idle" | "starting" | "waiting" | "success" | "erro
 type CodexOauthFlowStatus = "idle" | "starting" | "waiting" | "error";
 type CopilotLoginStatus = "idle" | "starting" | "waiting" | "success" | "error";
 
+const OPENAI_SERVICE_TIER_UNSET = "unset";
+
+type OpenAIServiceTier = "auto" | "default" | "flex" | "priority";
+type OpenAIServiceTierSelectValue = typeof OPENAI_SERVICE_TIER_UNSET | OpenAIServiceTier;
+
+function isOpenAIServiceTier(value: string): value is OpenAIServiceTier {
+  return value === "auto" || value === "default" || value === "flex" || value === "priority";
+}
+
 interface CodexOauthDeviceFlow {
   flowId: string;
   userCode: string;
@@ -381,6 +390,9 @@ export function ProvidersSection() {
     isLoading: muxGatewayAccountLoading,
     refresh: refreshMuxGatewayAccountStatus,
   } = useMuxGatewayAccountStatus();
+
+  const [openaiServiceTierSelectOverride, setOpenaiServiceTierSelectOverride] =
+    useState<OpenAIServiceTierSelectValue | null>(null);
 
   const routing = useRouting();
 
@@ -2445,18 +2457,32 @@ export function ProvidersSection() {
                               </TooltipProvider>
                             </div>
                             <Select
-                              value={config?.openai?.serviceTier ?? "auto"}
+                              value={
+                                openaiServiceTierSelectOverride ??
+                                config?.openai?.serviceTier ??
+                                OPENAI_SERVICE_TIER_UNSET
+                              }
                               onValueChange={(next) => {
                                 if (!api) return;
-                                if (
-                                  next !== "auto" &&
-                                  next !== "default" &&
-                                  next !== "flex" &&
-                                  next !== "priority"
-                                ) {
+
+                                if (next === OPENAI_SERVICE_TIER_UNSET) {
+                                  setOpenaiServiceTierSelectOverride(OPENAI_SERVICE_TIER_UNSET);
+                                  void api.providers
+                                    .setProviderConfig({
+                                      provider: "openai",
+                                      keyPath: ["serviceTier"],
+                                      value: "",
+                                    })
+                                    .then(() => refresh())
+                                    .finally(() => setOpenaiServiceTierSelectOverride(null));
                                   return;
                                 }
 
+                                if (!isOpenAIServiceTier(next)) {
+                                  return;
+                                }
+
+                                setOpenaiServiceTierSelectOverride(null);
                                 updateOptimistically("openai", { serviceTier: next });
                                 void api.providers.setProviderConfig({
                                   provider: "openai",
@@ -2465,10 +2491,13 @@ export function ProvidersSection() {
                                 });
                               }}
                             >
-                              <SelectTrigger className="w-40">
+                              <SelectTrigger className="w-64">
                                 <SelectValue />
                               </SelectTrigger>
                               <SelectContent>
+                                <SelectItem value={OPENAI_SERVICE_TIER_UNSET}>
+                                  Not configured (omit service_tier)
+                                </SelectItem>
                                 <SelectItem value="auto">auto</SelectItem>
                                 <SelectItem value="default">default</SelectItem>
                                 <SelectItem value="flex">flex</SelectItem>

--- a/src/cli/run.test.ts
+++ b/src/cli/run.test.ts
@@ -167,6 +167,14 @@ describe("mux CLI", () => {
       expect(result.stdout).toContain("anthropic:claude-opus-4-7");
     });
 
+    test("--service-tier has no default auto", async () => {
+      const result = await runCli(["run", "--help"]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("--service-tier");
+      expect(result.stdout).not.toContain("[default: auto]");
+      expect(result.stdout).not.toContain('[default: "auto"]');
+    });
+
     test("no message shows error", async () => {
       const result = await runRunDirect([]);
       expect(result.exitCode).toBe(1);

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -259,7 +259,7 @@ program
   .option("--no-mcp-config", "ignore global + repo MCP config files (use only --mcp servers)")
   .option("-e, --experiment <id>", "enable experiment (can be repeated)", collectExperiments, [])
   .option("-b, --budget <usd>", "stop when session cost exceeds budget (USD)", parseFloat)
-  .option("--service-tier <tier>", "OpenAI service tier: auto, default, flex, priority", "auto")
+  .option("--service-tier <tier>", "OpenAI service tier: auto, default, flex, priority")
   .option("--use-1m", "enable 1M context window for supported Anthropic models")
   .option(
     "--keep-background-processes",
@@ -298,7 +298,7 @@ interface CLIOptions {
   mcpConfig: boolean;
   experiment: string[];
   budget?: number;
-  serviceTier: "auto" | "default" | "flex" | "priority";
+  serviceTier?: "auto" | "default" | "flex" | "priority";
   use1m?: boolean;
   keepBackgroundProcesses?: boolean;
 }
@@ -612,7 +612,7 @@ async function main(): Promise<number> {
     experiments,
     providerOptions: {
       ...(opts.use1m && { anthropic: { use1MContext: true } }),
-      openai: { serviceTier: opts.serviceTier },
+      ...(opts.serviceTier != null && { openai: { serviceTier: opts.serviceTier } }),
     },
     // Disable UI-only tools that have no effect in CLI mode:
     // - status_set: backend no-op, status indicator only visible in desktop UI

--- a/src/common/utils/ai/providerOptions.test.ts
+++ b/src/common/utils/ai/providerOptions.test.ts
@@ -539,6 +539,48 @@ describe("buildProviderOptions - OpenAI", () => {
     });
   });
 
+  describe("serviceTier option", () => {
+    test("should not include serviceTier key when muxProviderOptions is omitted", () => {
+      const result = buildProviderOptions("openai:gpt-5", "medium");
+      const openai = getOpenAIOptions(result);
+
+      expect(openai).toBeDefined();
+      expect("serviceTier" in openai!).toBe(false);
+    });
+
+    test("should not include serviceTier key when muxProviderOptions.openai.serviceTier is undefined", () => {
+      const result = buildProviderOptions("openai:gpt-5", "medium", undefined, undefined, {
+        openai: { serviceTier: undefined },
+      });
+      const openai = getOpenAIOptions(result);
+
+      expect(openai).toBeDefined();
+      expect("serviceTier" in openai!).toBe(false);
+    });
+
+    test("should include serviceTier: auto when explicitly set", () => {
+      const result = buildProviderOptions("openai:gpt-5", "medium", undefined, undefined, {
+        openai: { serviceTier: "auto" },
+      });
+      const openai = getOpenAIOptions(result);
+
+      expect(openai).toBeDefined();
+      expect("serviceTier" in openai!).toBe(true);
+      expect(openai!.serviceTier).toBe("auto");
+    });
+
+    test("should include explicit non-auto serviceTier", () => {
+      const result = buildProviderOptions("openai:gpt-5", "medium", undefined, undefined, {
+        openai: { serviceTier: "flex" },
+      });
+      const openai = getOpenAIOptions(result);
+
+      expect(openai).toBeDefined();
+      expect("serviceTier" in openai!).toBe(true);
+      expect(openai!.serviceTier).toBe("flex");
+    });
+  });
+
   describe("promptCacheKey derivation", () => {
     test("should prefer promptCacheScope over workspaceId for promptCacheKey", () => {
       const result = buildProviderOptions(

--- a/src/common/utils/ai/providerOptions.ts
+++ b/src/common/utils/ai/providerOptions.ts
@@ -358,7 +358,7 @@ export function buildProviderOptions(
     const cacheScope = promptCacheScope ?? workspaceId;
     const promptCacheKey = cacheScope ? `mux-v1-${cacheScope}` : undefined;
 
-    const serviceTier = muxProviderOptions?.openai?.serviceTier ?? "auto";
+    const serviceTier = muxProviderOptions?.openai?.serviceTier;
     const wireFormat = muxProviderOptions?.openai?.wireFormat ?? "responses";
     const store = muxProviderOptions?.openai?.store;
     const isResponses = wireFormat === "responses";
@@ -378,7 +378,7 @@ export function buildProviderOptions(
     const options = {
       openai: {
         parallelToolCalls: true, // Always enable concurrent tool execution
-        serviceTier,
+        ...(serviceTier != null && { serviceTier }),
         ...(store != null && { store }), // ZDR: pass store flag through to OpenAI SDK
         ...(isResponses && {
           // Default to disabled; allow auto truncation for compaction to avoid context errors

--- a/src/node/services/providerModelFactory.ts
+++ b/src/node/services/providerModelFactory.ts
@@ -1248,7 +1248,7 @@ export class ProviderModelFactory {
         const configWireFormat = providerConfig.wireFormat as string | undefined;
         if (configServiceTier || configWireFormat) {
           muxProviderOptions ??= {};
-          if (configServiceTier) {
+          if (configServiceTier && muxProviderOptions.openai?.serviceTier == null) {
             muxProviderOptions.openai = {
               ...muxProviderOptions.openai,
               serviceTier: configServiceTier as "auto" | "default" | "flex" | "priority",

--- a/src/node/services/providerService.test.ts
+++ b/src/node/services/providerService.test.ts
@@ -1226,6 +1226,23 @@ describe("ProviderService.setConfig", () => {
     });
   });
 
+  it("removes OpenAI serviceTier when set to an empty string", async () => {
+    await withTempConfigAsync(async (config, service) => {
+      config.saveProvidersConfig({
+        openai: {
+          apiKey: "sk-test",
+          serviceTier: "auto",
+        },
+      });
+
+      const result = await service.setConfig("openai", ["serviceTier"], "");
+
+      expect(result.success).toBe(true);
+      expect(config.loadProvidersConfig()?.openai?.serviceTier).toBeUndefined();
+      expect(Object.hasOwn(config.loadProvidersConfig()?.openai ?? {}, "serviceTier")).toBe(false);
+    });
+  });
+
   it("stores enabled=false without deleting existing credentials", async () => {
     await withTempConfigAsync(async (config, service) => {
       config.saveProvidersConfig({


### PR DESCRIPTION
## Summary

Stop writing `serviceTier: "auto"` into provider options when the user hasn't configured one, and surface that "unset" state explicitly in the Settings UI and CLI. The provider field is now omitted entirely when no value is selected, letting OpenAI apply its own default routing.

Fixed: #3196 

## Background

Previously the OpenAI service tier silently defaulted to `"auto"` everywhere: in `buildProviderOptions`, in the CLI's `--service-tier` flag, and in the Settings dropdown. That meant requests always sent `service_tier: auto` even when the user never picked a tier, and the UI couldn't represent the actual "no preference" state at all (the dropdown showed `auto` whether the config was missing or explicitly set to `auto`).

## Implementation

- `buildProviderOptions` now reads `muxProviderOptions?.openai?.serviceTier` directly and only spreads `serviceTier` into the OpenAI options when it is set.
- `src/cli/run.ts` drops the `"auto"` default from `--service-tier`; if the flag is omitted, the entire `openai` block is left out of `providerOptions`.
- `ProvidersSection` adds a sentinel `"unset"` Select item labeled `Not configured (omit service_tier)`. Picking it sends `value: ""` through `setProviderConfig`, which the backend treats as a delete, removing the `serviceTier` key from `providers.jsonc`. A short-lived `openaiServiceTierSelectOverride` keeps the trigger label correct between optimistic update and refresh.
- `providerModelFactory` likewise no longer coerces a missing `serviceTier` into `"auto"`.

## Validation

- Sandboxed dev-server walk-through (clean install -> `flex` -> back to unset -> explicit `auto`); each transition verified against `providers.jsonc` on disk and the dropdown trigger label.
- `make static-check` (eslint, tsgo x2, prettier, code-to-docs links, shellcheck, hadolint) clean.
- `bun test src/cli/run.test.ts src/common/utils/ai/providerOptions.test.ts src/node/services/providerService.test.ts` (176 pass).

## Risks

Low. Behavior change is limited to OpenAI requests: when no tier was previously configured, requests will now omit `service_tier` instead of sending `"auto"`. OpenAI treats both as default routing, so live traffic should be unaffected. Existing configs with an explicit value continue to send that value verbatim.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `xhigh` • Cost: `$47.05`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=xhigh costs=47.05 -->
