### PR TITLE
🤖 perf: smooth text streaming (kill cascade re-renders, model-aware reveal)

### DIFF
--- a/src/browser/components/PinnedTodoList/PinnedTodoList.test.tsx
+++ b/src/browser/components/PinnedTodoList/PinnedTodoList.test.tsx
@@ -52,8 +52,6 @@ function buildWorkspaceState(workspaceId: string, state: MockWorkspaceState): Wo
     pendingStreamModel: null,
     runtimeStatus: null,
     autoRetryStatus: null,
-    streamingTokenCount: undefined,
-    streamingTPS: undefined,
   };
 }
 

--- a/src/browser/features/Messages/AssistantMessage.tsx
+++ b/src/browser/features/Messages/AssistantMessage.tsx
@@ -184,7 +184,7 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
     // renders parseIncompleteMarkdown=false, matching the prior static render exactly.
     const contentElement = (
       <TypewriterMarkdown
-        deltas={[content]}
+        content={content}
         isComplete={!isStreaming}
         streamKey={message.historyId}
         streamSource={message.streamPresentation?.source}

--- a/src/browser/features/Messages/AssistantMessage.tsx
+++ b/src/browser/features/Messages/AssistantMessage.tsx
@@ -188,6 +188,7 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
         isComplete={!isStreaming}
         streamKey={message.historyId}
         streamSource={message.streamPresentation?.source}
+        workspaceId={workspaceId}
       />
     );
 

--- a/src/browser/features/Messages/ChatBarrier/StreamingBarrier.test.tsx
+++ b/src/browser/features/Messages/ChatBarrier/StreamingBarrier.test.tsx
@@ -13,8 +13,6 @@ interface MockWorkspaceState {
   pendingStreamStartTime: number | null;
   pendingStreamModel: string | null;
   runtimeStatus: { phase: string; detail?: string } | null;
-  streamingTokenCount: number | undefined;
-  streamingTPS: number | undefined;
 }
 
 function createWorkspaceState(overrides: Partial<MockWorkspaceState> = {}): MockWorkspaceState {
@@ -27,8 +25,6 @@ function createWorkspaceState(overrides: Partial<MockWorkspaceState> = {}): Mock
     pendingStreamStartTime: null,
     pendingStreamModel: null,
     runtimeStatus: null,
-    streamingTokenCount: undefined,
-    streamingTPS: undefined,
     ...overrides,
   };
 
@@ -39,10 +35,17 @@ function createWorkspaceState(overrides: Partial<MockWorkspaceState> = {}): Mock
   return state;
 }
 
+interface MockStreamingStats {
+  tokenCount: number;
+  tps: number;
+  charsPerSec: number;
+}
+
 const STATUS_DISPLAY_DELAY_MS = 1000;
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 let currentWorkspaceState = createWorkspaceState();
+let currentStreamingStats: MockStreamingStats | null = null;
 let hasInterruptingStream = false;
 const setInterrupting = mock((_workspaceId: string) => undefined);
 const interruptStream = mock((_input: unknown) =>
@@ -70,6 +73,7 @@ void mock.module("@/browser/stores/WorkspaceStore", () => ({
   useWorkspaceStoreRaw: () => ({
     setInterrupting,
   }),
+  useWorkspaceStreamingStats: () => currentStreamingStats,
 }));
 
 void mock.module("@/browser/contexts/API", () => ({
@@ -119,6 +123,7 @@ describe("StreamingBarrier", () => {
     globalThis.document = globalThis.window.document;
 
     currentWorkspaceState = createWorkspaceState();
+    currentStreamingStats = null;
     hasInterruptingStream = false;
     setInterrupting.mockClear();
     interruptStream.mockClear();
@@ -289,9 +294,8 @@ describe("StreamingBarrier", () => {
     currentWorkspaceState = createWorkspaceState({
       canInterrupt: true,
       currentModel: "anthropic:claude-opus-4-6",
-      streamingTokenCount: 42,
-      streamingTPS: 18,
     });
+    currentStreamingStats = { tokenCount: 42, tps: 18, charsPerSec: 72 };
     view.rerender(<StreamingBarrier workspaceId="ws-1" />);
 
     expect(view.getByText("claude-opus-4-6 streaming...")).toBeTruthy();

--- a/src/browser/features/Messages/ChatBarrier/StreamingBarrier.tsx
+++ b/src/browser/features/Messages/ChatBarrier/StreamingBarrier.tsx
@@ -9,6 +9,7 @@ import {
   useWorkspaceState,
   useWorkspaceAggregator,
   useWorkspaceStoreRaw,
+  useWorkspaceStreamingStats,
 } from "@/browser/stores/WorkspaceStore";
 import { getDefaultModel } from "@/browser/hooks/useModelsFromSettings";
 import { useSettings } from "@/browser/contexts/SettingsContext";
@@ -146,6 +147,9 @@ export const StreamingBarrier: React.FC<StreamingBarrierProps> = ({
   const workspaceState = useWorkspaceState(workspaceId);
   const aggregator = useWorkspaceAggregator(workspaceId);
   const storeRaw = useWorkspaceStoreRaw();
+  // Subscribe directly to live streaming stats (token count + TPS) so per-delta
+  // updates re-render this leaf only, not the entire ChatPane subtree.
+  const streamingStats = useWorkspaceStreamingStats(workspaceId);
   const { api } = useAPI();
   const { open: openSettings } = useSettings();
 
@@ -172,9 +176,10 @@ export const StreamingBarrier: React.FC<StreamingBarrierProps> = ({
   // Only show token count during active streaming/compacting
   const showTokenCount = phase === "streaming" || phase === "compacting";
 
-  // Get live streaming stats from workspace state (updated on each stream-delta)
-  const tokenCount = showTokenCount ? workspaceState.streamingTokenCount : undefined;
-  const tps = showTokenCount ? workspaceState.streamingTPS : undefined;
+  // Live streaming stats come from a leaf subscription so per-delta updates
+  // don't cascade through the full chat subtree.
+  const tokenCount = showTokenCount ? streamingStats?.tokenCount : undefined;
+  const tps = showTokenCount ? streamingStats?.tps : undefined;
 
   // Model to display:
   // - "starting" phase: prefer pendingStreamModel (from muxMetadata), then localStorage

--- a/src/browser/features/Messages/MessageRenderer.tsx
+++ b/src/browser/features/Messages/MessageRenderer.tsx
@@ -121,7 +121,9 @@ export const MessageRenderer = React.memo<MessageRendererProps>(
         );
         break;
       case "reasoning":
-        renderedMessage = <ReasoningMessage message={message} className={className} />;
+        renderedMessage = (
+          <ReasoningMessage message={message} className={className} workspaceId={workspaceId} />
+        );
         break;
       case "stream-error":
         renderedMessage = <StreamErrorMessage message={message} className={className} />;

--- a/src/browser/features/Messages/ReasoningMessage.tsx
+++ b/src/browser/features/Messages/ReasoningMessage.tsx
@@ -129,9 +129,13 @@ export const ReasoningMessage: React.FC<ReasoningMessageProps> = ({
     // stream end would unmount/remount the markdown subtree and visibly flash the
     // content. isComplete={!isStreaming} cleanly bypasses the smoothing engine once
     // the stream ends, matching the prior static-render behavior.
+    // React Compiler auto-memoizes this normalize call between renders that
+    // share the same `content` value; no manual useMemo needed.
+    const normalizedContent = normalizeReasoningMarkdown(content);
+
     return (
       <TypewriterMarkdown
-        deltas={[normalizeReasoningMarkdown(content)]}
+        content={normalizedContent}
         isComplete={!isStreaming}
         preserveLineBreaks
         streamKey={message.historyId}

--- a/src/browser/features/Messages/ReasoningMessage.tsx
+++ b/src/browser/features/Messages/ReasoningMessage.tsx
@@ -9,6 +9,12 @@ import { Lightbulb } from "lucide-react";
 interface ReasoningMessageProps {
   message: DisplayedMessage & { type: "reasoning" };
   className?: string;
+  /**
+   * Workspace this reasoning belongs to. Forwarded to TypewriterMarkdown so the
+   * smoothing engine can target the model's live emission rate. Optional —
+   * tests render this component without a workspace context.
+   */
+  workspaceId?: string;
 }
 
 const REASONING_FONT_CLASSES = "font-primary text-[12px] leading-[18px]";
@@ -40,7 +46,11 @@ function parseLeadingBoldSummary(
   };
 }
 
-export const ReasoningMessage: React.FC<ReasoningMessageProps> = ({ message, className }) => {
+export const ReasoningMessage: React.FC<ReasoningMessageProps> = ({
+  message,
+  className,
+  workspaceId,
+}) => {
   const [isExpanded, setIsExpanded] = useState(message.isStreaming);
   // Track the height when expanded to reserve space during collapse transitions
   const [expandedHeight, setExpandedHeight] = useState<number | null>(null);
@@ -126,6 +136,7 @@ export const ReasoningMessage: React.FC<ReasoningMessageProps> = ({ message, cla
         preserveLineBreaks
         streamKey={message.historyId}
         streamSource={message.streamPresentation?.source}
+        workspaceId={workspaceId}
       />
     );
   };

--- a/src/browser/features/Messages/TypewriterMarkdown.test.tsx
+++ b/src/browser/features/Messages/TypewriterMarkdown.test.tsx
@@ -1,5 +1,6 @@
 import type { UseSmoothStreamingTextOptions } from "@/browser/hooks/useSmoothStreamingText";
 import { useSmoothStreamingText as importedUseSmoothStreamingText } from "@/browser/hooks/useSmoothStreamingText";
+import { useWorkspaceStreamingStats as importedUseWorkspaceStreamingStats } from "@/browser/stores/WorkspaceStore";
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, render } from "@testing-library/react";
 import { GlobalWindow } from "happy-dom";
@@ -8,6 +9,7 @@ import { TypewriterMarkdown } from "./TypewriterMarkdown";
 
 const actualMarkdownCore = ImportedMarkdownCore;
 const actualUseSmoothStreamingText = importedUseSmoothStreamingText;
+const actualUseWorkspaceStreamingStats = importedUseWorkspaceStreamingStats;
 
 const mockUseSmoothStreamingText = mock(
   (options: UseSmoothStreamingTextOptions): { visibleText: string; isCaughtUp: boolean } => ({
@@ -15,6 +17,8 @@ const mockUseSmoothStreamingText = mock(
     isCaughtUp: !options.isStreaming,
   })
 );
+
+const mockUseWorkspaceStreamingStats = mock((_workspaceId: string) => null);
 
 function MarkdownCoreStub(props: { content: string }) {
   return <div data-testid="markdown-core">{props.content}</div>;
@@ -29,6 +33,9 @@ async function installTypewriterMarkdownModuleMocks() {
   await mock.module("@/browser/hooks/useSmoothStreamingText", () => ({
     useSmoothStreamingText: mockUseSmoothStreamingText,
   }));
+  await mock.module("@/browser/stores/WorkspaceStore", () => ({
+    useWorkspaceStreamingStats: mockUseWorkspaceStreamingStats,
+  }));
 }
 
 async function restoreTypewriterMarkdownModuleMocks() {
@@ -39,6 +46,9 @@ async function restoreTypewriterMarkdownModuleMocks() {
   }));
   await mock.module("@/browser/hooks/useSmoothStreamingText", () => ({
     useSmoothStreamingText: actualUseSmoothStreamingText,
+  }));
+  await mock.module("@/browser/stores/WorkspaceStore", () => ({
+    useWorkspaceStreamingStats: actualUseWorkspaceStreamingStats,
   }));
 }
 
@@ -59,6 +69,7 @@ describe("TypewriterMarkdown", () => {
     globalThis.document = globalThis.window.document;
     await installTypewriterMarkdownModuleMocks();
     mockUseSmoothStreamingText.mockClear();
+    mockUseWorkspaceStreamingStats.mockClear();
   });
 
   afterEach(async () => {
@@ -107,5 +118,39 @@ describe("TypewriterMarkdown", () => {
     expect(mockUseSmoothStreamingText).toHaveBeenCalledWith(
       expect.objectContaining({ bypassSmoothing: true })
     );
+  });
+
+  // Regression: completed historical messages must not subscribe to live
+  // streaming stats for their workspace, otherwise every assistant message in a
+  // long transcript re-renders on every stream-delta of an active stream and
+  // re-introduces the cascade jitter this PR is supposed to eliminate.
+  test("completed messages subscribe with empty key (no live-stats updates)", () => {
+    render(
+      <TypewriterMarkdown
+        content="Historical reply"
+        isComplete={true}
+        streamKey="msg-old"
+        streamSource="live"
+        workspaceId="ws-active"
+      />
+    );
+
+    // Hook still runs (rules of hooks), but the key must be the no-op sentinel.
+    expect(mockUseWorkspaceStreamingStats).toHaveBeenCalledWith("");
+    expect(mockUseWorkspaceStreamingStats).not.toHaveBeenCalledWith("ws-active");
+  });
+
+  test("streaming messages subscribe with the real workspace key", () => {
+    render(
+      <TypewriterMarkdown
+        content="Streaming reply"
+        isComplete={false}
+        streamKey="msg-live"
+        streamSource="live"
+        workspaceId="ws-active"
+      />
+    );
+
+    expect(mockUseWorkspaceStreamingStats).toHaveBeenCalledWith("ws-active");
   });
 });

--- a/src/browser/features/Messages/TypewriterMarkdown.test.tsx
+++ b/src/browser/features/Messages/TypewriterMarkdown.test.tsx
@@ -77,7 +77,7 @@ describe("TypewriterMarkdown", () => {
 
     const view = render(
       <TypewriterMarkdown
-        deltas={["Hello world"]}
+        content="Hello world"
         isComplete={false}
         streamKey="msg-1"
         streamSource="live"
@@ -97,7 +97,7 @@ describe("TypewriterMarkdown", () => {
   test("bypasses smoothing for replay streams", () => {
     render(
       <TypewriterMarkdown
-        deltas={["Replayed content"]}
+        content="Replayed content"
         isComplete={false}
         streamKey="msg-2"
         streamSource="replay"

--- a/src/browser/features/Messages/TypewriterMarkdown.test.tsx
+++ b/src/browser/features/Messages/TypewriterMarkdown.test.tsx
@@ -90,6 +90,7 @@ describe("TypewriterMarkdown", () => {
       isStreaming: true,
       bypassSmoothing: false,
       streamKey: "msg-1",
+      liveCharsPerSec: 0,
     });
   });
 

--- a/src/browser/features/Messages/TypewriterMarkdown.tsx
+++ b/src/browser/features/Messages/TypewriterMarkdown.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { useSmoothStreamingText } from "@/browser/hooks/useSmoothStreamingText";
 import { useWorkspaceStreamingStats } from "@/browser/stores/WorkspaceStore";
 import { cn } from "@/common/lib/utils";
@@ -6,7 +6,8 @@ import { MarkdownCore } from "./MarkdownCore";
 import { StreamingContext } from "./StreamingContext";
 
 interface TypewriterMarkdownProps {
-  deltas: string[];
+  /** Full text to render. During streaming this grows monotonically. */
+  content: string;
   isComplete: boolean;
   className?: string;
   /**
@@ -28,18 +29,19 @@ interface TypewriterMarkdownProps {
   workspaceId?: string;
 }
 
-// Use React.memo to prevent unnecessary re-renders from parent
-export const TypewriterMarkdown = React.memo<TypewriterMarkdownProps>(function TypewriterMarkdown({
-  deltas,
+// React Compiler memoizes this component automatically based on prop changes;
+// no manual React.memo wrapper. The previous deltas: string[] shape forced a new
+// array literal on every parent render and defeated the memo anyway.
+export const TypewriterMarkdown: React.FC<TypewriterMarkdownProps> = ({
+  content,
   isComplete,
   className,
   preserveLineBreaks,
   streamKey,
   streamSource = "live",
   workspaceId,
-}) {
-  const fullContent = deltas.join("");
-  const isStreaming = !isComplete && fullContent.length > 0;
+}) => {
+  const isStreaming = !isComplete && content.length > 0;
 
   // Read the live model emission rate (chars/sec) for the active stream of this
   // workspace. The hook subscribes to its own MapStore so per-delta updates
@@ -49,18 +51,19 @@ export const TypewriterMarkdown = React.memo<TypewriterMarkdownProps>(function T
   const streamingStats = useWorkspaceStreamingStats(workspaceId ?? "");
   const liveCharsPerSec = isStreaming && workspaceId ? (streamingStats?.charsPerSec ?? 0) : 0;
 
-  // Two-clock streaming: ingestion (fullContent) vs presentation (visibleText).
+  // Two-clock streaming: ingestion (content) vs presentation (visibleText).
   // The jitter buffer reveals text at a steady cadence instead of bursty token clumps.
   // Replay and completed streams bypass smoothing entirely.
   const { visibleText } = useSmoothStreamingText({
-    fullText: fullContent,
+    fullText: content,
     isStreaming,
     bypassSmoothing: streamSource === "replay",
     streamKey: streamKey ?? "",
     liveCharsPerSec,
   });
 
-  const streamingContextValue = useMemo(() => ({ isStreaming }), [isStreaming]);
+  // React Compiler memoizes this object; no manual useMemo needed.
+  const streamingContextValue = { isStreaming };
 
   return (
     <StreamingContext.Provider value={streamingContextValue}>
@@ -73,4 +76,4 @@ export const TypewriterMarkdown = React.memo<TypewriterMarkdownProps>(function T
       </div>
     </StreamingContext.Provider>
   );
-});
+};

--- a/src/browser/features/Messages/TypewriterMarkdown.tsx
+++ b/src/browser/features/Messages/TypewriterMarkdown.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 import { useSmoothStreamingText } from "@/browser/hooks/useSmoothStreamingText";
+import { useWorkspaceStreamingStats } from "@/browser/stores/WorkspaceStore";
 import { cn } from "@/common/lib/utils";
 import { MarkdownCore } from "./MarkdownCore";
 import { StreamingContext } from "./StreamingContext";
@@ -18,6 +19,13 @@ interface TypewriterMarkdownProps {
   streamKey?: string;
   /** Whether this stream originated from live tokens or replay. Defaults to "live". */
   streamSource?: "live" | "replay";
+  /**
+   * Workspace this content belongs to. When provided, the smoothing engine is
+   * fed the live model emission rate so the visible cursor tracks the model's
+   * actual output rather than the constant BASE rate. Optional because some
+   * surfaces (storybook, preview popovers) render markdown without a workspace.
+   */
+  workspaceId?: string;
 }
 
 // Use React.memo to prevent unnecessary re-renders from parent
@@ -28,9 +36,18 @@ export const TypewriterMarkdown = React.memo<TypewriterMarkdownProps>(function T
   preserveLineBreaks,
   streamKey,
   streamSource = "live",
+  workspaceId,
 }) {
   const fullContent = deltas.join("");
   const isStreaming = !isComplete && fullContent.length > 0;
+
+  // Read the live model emission rate (chars/sec) for the active stream of this
+  // workspace. The hook subscribes to its own MapStore so per-delta updates
+  // re-render this component WITHOUT cascading through the parent — see
+  // useWorkspaceStreamingStats. Hooks must run unconditionally; pass an empty
+  // string when no workspace is provided so the subscription is a stable no-op.
+  const streamingStats = useWorkspaceStreamingStats(workspaceId ?? "");
+  const liveCharsPerSec = isStreaming && workspaceId ? (streamingStats?.charsPerSec ?? 0) : 0;
 
   // Two-clock streaming: ingestion (fullContent) vs presentation (visibleText).
   // The jitter buffer reveals text at a steady cadence instead of bursty token clumps.
@@ -40,6 +57,7 @@ export const TypewriterMarkdown = React.memo<TypewriterMarkdownProps>(function T
     isStreaming,
     bypassSmoothing: streamSource === "replay",
     streamKey: streamKey ?? "",
+    liveCharsPerSec,
   });
 
   const streamingContextValue = useMemo(() => ({ isStreaming }), [isStreaming]);

--- a/src/browser/features/Messages/TypewriterMarkdown.tsx
+++ b/src/browser/features/Messages/TypewriterMarkdown.tsx
@@ -46,9 +46,15 @@ export const TypewriterMarkdown: React.FC<TypewriterMarkdownProps> = ({
   // Read the live model emission rate (chars/sec) for the active stream of this
   // workspace. The hook subscribes to its own MapStore so per-delta updates
   // re-render this component WITHOUT cascading through the parent — see
-  // useWorkspaceStreamingStats. Hooks must run unconditionally; pass an empty
-  // string when no workspace is provided so the subscription is a stable no-op.
-  const streamingStats = useWorkspaceStreamingStats(workspaceId ?? "");
+  // useWorkspaceStreamingStats.
+  //
+  // Subscribe to the real workspace key ONLY while this message is actively
+  // streaming. Completed historical messages subscribe to the stable empty-key
+  // sentinel, which is never bumped — so a long transcript of finished
+  // assistant messages does not re-render on every delta of a new stream.
+  // (Hooks must run unconditionally; we toggle the key, not the call site.)
+  const subscriptionKey = isStreaming && workspaceId ? workspaceId : "";
+  const streamingStats = useWorkspaceStreamingStats(subscriptionKey);
   const liveCharsPerSec = isStreaming && workspaceId ? (streamingStats?.charsPerSec ?? 0) : 0;
 
   // Two-clock streaming: ingestion (content) vs presentation (visibleText).

--- a/src/browser/hooks/useSmoothStreamingText.ts
+++ b/src/browser/hooks/useSmoothStreamingText.ts
@@ -7,6 +7,13 @@ export interface UseSmoothStreamingTextOptions {
   bypassSmoothing: boolean;
   /** Changing this resets the engine (new stream). */
   streamKey: string;
+  /**
+   * Optional hint at the source's current emission rate (chars/sec). When
+   * supplied, the smoothing engine targets this rate instead of the BASE
+   * fallback so the visible cursor tracks the model's actual output. Pass 0
+   * (or omit) when unknown.
+   */
+  liveCharsPerSec?: number;
 }
 
 export interface UseSmoothStreamingTextResult {
@@ -66,7 +73,16 @@ export function useSmoothStreamingText(
   }
 
   const engine = engineRef.current;
-  engine.update(options.fullText, options.isStreaming, options.bypassSmoothing);
+  // engine.update is idempotent (pure projection of inputs onto engine state),
+  // so calling it during render is safe — including under StrictMode double-render.
+  // Keeping it inline lets the returned visibleText reflect the very latest fullText
+  // on the same render the stream ends, avoiding a one-frame visual lag at the seam.
+  engine.update(
+    options.fullText,
+    options.isStreaming,
+    options.bypassSmoothing,
+    options.liveCharsPerSec ?? 0
+  );
 
   const [visibleLength, setVisibleLength] = useState(() => engine.visibleLength);
   const visibleLengthRef = useRef(visibleLength);
@@ -113,7 +129,14 @@ export function useSmoothStreamingText(
     ) {
       rafIdRef.current = requestAnimationFrame(frameRef.current);
     }
-  }, [engine, options.fullText, options.isStreaming, options.bypassSmoothing, options.streamKey]);
+  }, [
+    engine,
+    options.fullText,
+    options.isStreaming,
+    options.bypassSmoothing,
+    options.streamKey,
+    options.liveCharsPerSec,
+  ]);
 
   // Lifecycle: stop RAF when streaming ends or stream key changes, and on unmount.
   useEffect(() => {

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -1875,6 +1875,77 @@ describe("WorkspaceStore", () => {
       expect(clearedState.canInterrupt).toBe(false);
     });
 
+    it("invalidates streaming-stats cache on stream-error so subscribers don't see stale TPS", async () => {
+      const workspaceId = "stream-error-invalidates-stats";
+      const streamModel = "anthropic:claude-opus-4-6";
+
+      mockOnChat.mockImplementation(async function* (
+        _input?: { workspaceId: string; mode?: unknown },
+        options?: { signal?: AbortSignal }
+      ): AsyncGenerator<WorkspaceChatMessage, void, unknown> {
+        if (options?.signal?.aborted) {
+          yield { type: "caught-up" };
+        }
+        await waitForAbortSignal(options?.signal);
+      });
+
+      recreateStore();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      createAndAddWorkspace(store, workspaceId);
+
+      const rawStore = store as unknown as {
+        handleChatMessage: (workspaceId: string, data: WorkspaceChatMessage) => void;
+      };
+
+      // Open a stream and feed a delta so streaming stats become non-null.
+      // stream events are buffered until a caught-up event flushes them onto
+      // the aggregator, so we send caught-up before reading the live stats.
+      const messageId = "stream-error-message";
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-start",
+        workspaceId,
+        messageId,
+        model: streamModel,
+        historySequence: 1,
+        startTime: 1_000,
+      });
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-delta",
+        workspaceId,
+        messageId,
+        delta: "hello world ",
+        tokens: 3,
+        timestamp: 1_500,
+      });
+      rawStore.handleChatMessage(workspaceId, { type: "caught-up" });
+
+      // Subscribe so stale-cache regression would surface as a missed bump.
+      let notifications = 0;
+      const unsubscribe = store.subscribeStreamingStats(workspaceId, () => {
+        notifications += 1;
+      });
+
+      const before = store.getWorkspaceStreamingStats(workspaceId);
+      expect(before).not.toBeNull();
+
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-error",
+        messageId,
+        error: "Mock provider failure",
+        errorType: "network",
+      });
+
+      // The terminal stream-error must bump streamingStatsStore so listeners
+      // re-read; once recomputed, getActiveStreamMessageId returns undefined
+      // and the snapshot collapses to null. Without the bump, the cache would
+      // keep returning `before` (stale TPS leaking into the next stream).
+      expect(notifications).toBeGreaterThanOrEqual(1);
+      const after = store.getWorkspaceStreamingStats(workspaceId);
+      expect(after).toBeNull();
+
+      unsubscribe();
+    });
+
     it("prefers buffered stream-start state over stale non-streaming activity during hydration", async () => {
       const workspaceId = "buffered-stream-start-over-activity";
       const staleActivityModel = "openai:gpt-4o-mini";

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -78,6 +78,7 @@ import {
   getPinnedTodoExpandedKey,
 } from "@/common/constants/storage";
 import { DEFAULT_AUTO_COMPACTION_THRESHOLD_PERCENT } from "@/common/constants/ui";
+import { APPROX_CHARS_PER_TOKEN } from "@/constants/streaming";
 import { trackStreamCompleted } from "@/common/telemetry";
 
 export type AutoRetryStatus = Extract<
@@ -114,9 +115,28 @@ export interface WorkspaceState {
   // Current pre-stream startup breadcrumb (runtime readiness, tool loading, etc.)
   runtimeStatus: RuntimeStatusEvent | null;
   autoRetryStatus: AutoRetryStatus | null;
-  // Live streaming stats (updated on each stream-delta)
-  streamingTokenCount: number | undefined;
-  streamingTPS: number | undefined;
+}
+
+/**
+ * Live streaming stats snapshot for the active stream of a workspace.
+ *
+ * Exposed via {@link useWorkspaceStreamingStats} as a leaf subscription so
+ * components that display tokens-per-second / token count (e.g. StreamingBarrier)
+ * re-render on each delta WITHOUT cascading through the full WorkspaceState
+ * snapshot. Keeping these out of WorkspaceState is what lets the streaming
+ * smoothing engine actually run smoothly: otherwise the per-delta TPS read
+ * (which uses Date.now()) makes the snapshot unstable on every microtask and
+ * forces ChatPane to reconcile faster than the RAF presentation clock can
+ * draw.
+ */
+export interface WorkspaceStreamingStats {
+  tokenCount: number;
+  /** Tokens-per-second over a trailing window. */
+  tps: number;
+  /** Approximate characters-per-second the model is producing. Used by the
+   *  smoothing engine to target the model's actual emission rate rather than
+   *  the legacy fixed BASE rate. */
+  charsPerSec: number;
 }
 
 /**
@@ -599,10 +619,24 @@ export class WorkspaceStore {
   private fileModifyingToolMs = new Map<string, number>();
   private fileModifyingToolSubs = new MapStore<string, void>();
 
-  // Idle callback handles for high-frequency delta events to reduce re-renders during streaming.
+  // Idle callback handles for high-frequency, terminal-style output (init logs).
   // Data is always updated immediately in the aggregator; only UI notification is scheduled.
   // Using requestIdleCallback adapts to actual CPU availability rather than a fixed timer.
+  // NOTE: Streaming text/reasoning/tool deltas do NOT use this — they use
+  // scheduleStreamingStateBump() (microtask coalescing) so the smoothing engine's
+  // RAF presentation clock isn't competing with a 100ms ingestion clock.
   private deltaIdleHandles = new Map<string, number>();
+
+  // Microtask coalescing for streaming deltas. Many deltas can arrive in the same
+  // task pump (ORPC iterator drain); we collapse them into a single states.bump()
+  // at the microtask tail so React reconciles once per pump instead of once per chunk.
+  private pendingStreamingBump = new Set<string>();
+
+  // Live streaming stats (tokens/sec) — exposed via useWorkspaceStreamingStats() as a
+  // leaf subscription. Updated on every stream-delta in the same coalesced microtask
+  // as states.bump(), but separate so changes only re-render the StreamingBarrier
+  // pill and not the entire ChatPane subtree.
+  private streamingStatsStore = new MapStore<string, WorkspaceStreamingStats | null>();
 
   /**
    * Map of event types to their handlers. This is the single source of truth for:
@@ -640,7 +674,7 @@ export class WorkspaceStore {
     },
     "stream-delta": (workspaceId, aggregator, data) => {
       applyWorkspaceChatEventToAggregator(aggregator, data);
-      this.scheduleIdleStateBump(workspaceId);
+      this.scheduleStreamingStateBump(workspaceId);
     },
     "stream-end": (workspaceId, aggregator, data) => {
       const streamEndData = data as StreamEndEvent;
@@ -681,7 +715,9 @@ export class WorkspaceStore {
 
       // Flush any pending debounced bump before final bump to avoid double-bump
       this.cancelPendingIdleBump(workspaceId);
+      this.cancelPendingStreamingBump(workspaceId);
       this.states.bump(workspaceId);
+      this.streamingStatsStore.bump(workspaceId);
       this.checkAndBumpRecencyIfChanged();
       this.finalizeUsageStats(workspaceId, streamEndData.metadata);
     },
@@ -708,7 +744,9 @@ export class WorkspaceStore {
 
       // Flush any pending debounced bump before final bump to avoid double-bump
       this.cancelPendingIdleBump(workspaceId);
+      this.cancelPendingStreamingBump(workspaceId);
       this.states.bump(workspaceId);
+      this.streamingStatsStore.bump(workspaceId);
       this.finalizeUsageStats(workspaceId, streamAbortData.metadata);
     },
     "tool-call-start": (workspaceId, aggregator, data) => {
@@ -717,7 +755,7 @@ export class WorkspaceStore {
     },
     "tool-call-delta": (workspaceId, aggregator, data) => {
       applyWorkspaceChatEventToAggregator(aggregator, data);
-      this.scheduleIdleStateBump(workspaceId);
+      this.scheduleStreamingStateBump(workspaceId);
     },
     "tool-call-end": (workspaceId, aggregator, data) => {
       const toolCallEnd = data as Extract<WorkspaceChatMessage, { type: "tool-call-end" }>;
@@ -755,7 +793,7 @@ export class WorkspaceStore {
     },
     "reasoning-delta": (workspaceId, aggregator, data) => {
       applyWorkspaceChatEventToAggregator(aggregator, data);
-      this.scheduleIdleStateBump(workspaceId);
+      this.scheduleStreamingStateBump(workspaceId);
     },
     "reasoning-end": (workspaceId, aggregator, data) => {
       applyWorkspaceChatEventToAggregator(aggregator, data);
@@ -1320,6 +1358,65 @@ export class WorkspaceStore {
   }
 
   /**
+   * Coalesce streaming state bumps to a single microtask per workspace.
+   *
+   * Streaming text/reasoning/tool deltas land in the aggregator immediately, but
+   * the React notification is deferred to the microtask tail of the current
+   * task pump. Many deltas can arrive in the same pump (the ORPC iterator
+   * drains a queue) — we want React to reconcile once per pump, not once per
+   * chunk.
+   *
+   * Why microtask and not requestIdleCallback? The smoothing engine
+   * ({@link useSmoothStreamingText}) is the presentation clock — pacing the
+   * visible reveal at RAF frequency. The ingestion clock should be deterministic
+   * and prompt; an idle-callback ingestion delay (~100ms) just means the
+   * smoothing engine has to absorb burstier inputs and is more likely to hit
+   * its visual-lag safety net.
+   */
+  private scheduleStreamingStateBump(workspaceId: string): void {
+    if (this.pendingStreamingBump.has(workspaceId)) return;
+    this.pendingStreamingBump.add(workspaceId);
+    queueMicrotask(() => {
+      // Cleared by cancelPendingStreamingBump (e.g. on stream-end) — skip the bump
+      // so we don't double-notify after the terminal event already bumped state.
+      if (!this.pendingStreamingBump.delete(workspaceId)) return;
+      this.states.bump(workspaceId);
+      this.streamingStatsStore.bump(workspaceId);
+    });
+  }
+
+  private cancelPendingStreamingBump(workspaceId: string): void {
+    this.pendingStreamingBump.delete(workspaceId);
+  }
+
+  /**
+   * Get current live streaming stats for a workspace, or null if no stream is active.
+   *
+   * Cached per MapStore version: changes only when {@link streamingStatsStore} is
+   * bumped (every coalesced delta + on stream end). Reading uses Date.now() at
+   * the bump point, so the trailing-window TPS is always current relative to the
+   * latest delta.
+   */
+  getWorkspaceStreamingStats(workspaceId: string): WorkspaceStreamingStats | null {
+    return this.streamingStatsStore.get(workspaceId, () => {
+      const aggregator = this.aggregators.get(workspaceId);
+      if (!aggregator) return null;
+      const messageId = aggregator.getActiveStreamMessageId();
+      if (!messageId) return null;
+      const tokenCount = aggregator.getStreamingTokenCount(messageId);
+      const tps = aggregator.getStreamingTPS(messageId);
+      // Approximate chars-per-token of 4 — good enough for the smoothing engine
+      // to target the model's emit rate; exact tokenization isn't needed.
+      const charsPerSec = tps * APPROX_CHARS_PER_TOKEN;
+      return { tokenCount, tps, charsPerSec };
+    });
+  }
+
+  subscribeStreamingStats(workspaceId: string, listener: () => void): () => void {
+    return this.streamingStatsStore.subscribeKey(workspaceId, listener);
+  }
+
+  /**
    * Subscribe to backend timing stats snapshots for a workspace.
    */
 
@@ -1651,15 +1748,6 @@ export class WorkspaceStore {
       const fallbackAgentStatus = useAggregatorState ? aggregator.getAgentStatus() : undefined;
       const agentStatus = displayStatus ?? todoStatus ?? fallbackAgentStatus;
 
-      // Live streaming stats
-      const activeStreamMessageId = aggregator.getActiveStreamMessageId();
-      const streamingTokenCount = activeStreamMessageId
-        ? aggregator.getStreamingTokenCount(activeStreamMessageId)
-        : undefined;
-      const streamingTPS = activeStreamMessageId
-        ? aggregator.getStreamingTPS(activeStreamMessageId)
-        : undefined;
-
       return {
         name: metadata?.name ?? workspaceId, // Fall back to ID if metadata missing
         messages: displayedMessages,
@@ -1685,8 +1773,6 @@ export class WorkspaceStore {
         pendingStreamModel: aggregator.getPendingStreamModel(),
         autoRetryStatus: transient.autoRetryStatus,
         runtimeStatus: aggregator.getRuntimeStatus(),
-        streamingTokenCount,
-        streamingTPS,
       };
     });
   }
@@ -2858,6 +2944,7 @@ export class WorkspaceStore {
 
     // Clear any pending UI bumps from deltas - we're about to rebuild the message list.
     this.cancelPendingIdleBump(workspaceId);
+    this.cancelPendingStreamingBump(workspaceId);
 
     // Preserve last-known usage while replay rebuilds the aggregator.
     // Without this, getWorkspaceUsage() can briefly return an empty state and hide
@@ -3283,6 +3370,8 @@ export class WorkspaceStore {
 
     // Clean up idle callback to prevent stale callbacks
     this.cancelPendingIdleBump(workspaceId);
+    this.cancelPendingStreamingBump(workspaceId);
+    this.streamingStatsStore.delete(workspaceId);
 
     if (this.activeWorkspaceId === workspaceId) {
       this.activeWorkspaceId = null;
@@ -4119,6 +4208,29 @@ export function useWorkspaceUsage(workspaceId: string): WorkspaceUsageState {
     (listener) => store.subscribeUsage(workspaceId, listener),
     () => store.getWorkspaceUsage(workspaceId)
   );
+}
+
+/**
+ * Hook for the live token-count / TPS pill during streaming.
+ *
+ * Subscribed as a separate leaf so the streaming pill can update on every
+ * coalesced stream-delta WITHOUT cascading a re-render through the entire
+ * chat subtree. Returns null when no stream is active.
+ *
+ * This is the cure for the "TPS makes WorkspaceState unstable" jitter source —
+ * see {@link WorkspaceStreamingStats}.
+ */
+export function useWorkspaceStreamingStats(workspaceId: string): WorkspaceStreamingStats | null {
+  const store = getStoreInstance();
+  const subscribe = useCallback(
+    (listener: () => void) => store.subscribeStreamingStats(workspaceId, listener),
+    [store, workspaceId]
+  );
+  const getSnapshot = useCallback(
+    () => store.getWorkspaceStreamingStats(workspaceId),
+    [store, workspaceId]
+  );
+  return useSyncExternalStore(subscribe, getSnapshot);
 }
 
 /**

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -3830,7 +3830,15 @@ export class WorkspaceStore {
 
       applyWorkspaceChatEventToAggregator(aggregator, data, { allowSideEffects });
 
+      // stream-error is a terminal stream event, just like stream-end/stream-abort.
+      // Mirror their cleanup so subscribers don't see stale streaming stats from the
+      // failed stream — applyWorkspaceChatEventToAggregator already cleared token
+      // state; we now flush any pending coalesced bump and invalidate the
+      // streamingStatsStore cache so useWorkspaceStreamingStats returns null.
+      this.cancelPendingIdleBump(workspaceId);
+      this.cancelPendingStreamingBump(workspaceId);
       this.states.bump(workspaceId);
+      this.streamingStatsStore.bump(workspaceId);
       return;
     }
 

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -1898,12 +1898,22 @@ export class StreamingMessageAggregator {
       }
     }
 
-    // Append each delta as a new part (merging happens at display time)
-    message.parts.push({
-      type: "text",
-      text: data.delta,
-      timestamp: data.timestamp,
-    });
+    // Compact-on-append: when the previous part is text (the common case during
+    // a text run), append into it in place instead of growing parts unbounded.
+    // For a 10k-char reply this drops parts.length from thousands to one and
+    // shrinks per-render mergeAdjacentParts cost from O(N) to O(1). The on-disk
+    // format is unaffected — partial.json/chat.jsonl persistence happens
+    // backend-side; this aggregator's parts are pure in-memory display state.
+    const lastPart = message.parts[message.parts.length - 1];
+    if (lastPart?.type === "text") {
+      lastPart.text += data.delta;
+    } else {
+      message.parts.push({
+        type: "text",
+        text: data.delta,
+        timestamp: data.timestamp,
+      });
+    }
 
     // Track delta for token counting and TPS calculation
     this.trackDelta(data.messageId, data.tokens, data.timestamp, "text");
@@ -2459,12 +2469,17 @@ export class StreamingMessageAggregator {
       }
     }
 
-    // Append each delta as a new part (merging happens at display time)
-    message.parts.push({
-      type: "reasoning",
-      text: data.delta,
-      timestamp: data.timestamp,
-    });
+    // Compact-on-append for reasoning runs (same rationale as handleStreamDelta).
+    const lastPart = message.parts[message.parts.length - 1];
+    if (lastPart?.type === "reasoning") {
+      lastPart.text += data.delta;
+    } else {
+      message.parts.push({
+        type: "reasoning",
+        text: data.delta,
+        timestamp: data.timestamp,
+      });
+    }
 
     // Track delta for token counting and TPS calculation
     this.trackDelta(data.messageId, data.tokens, data.timestamp, "reasoning");

--- a/src/browser/utils/messages/StreamingTPSCalculator.test.ts
+++ b/src/browser/utils/messages/StreamingTPSCalculator.test.ts
@@ -81,12 +81,45 @@ describe("StreamingTPSCalculator", () => {
       expect(calculateTPS(deltas, now)).toBe(15);
     });
 
-    test("returns 0 when time span is zero", () => {
+    test("uses minimum 1s window when time span is zero", () => {
       const now = 1000;
       const deltas: DeltaRecord[] = [
         { tokens: 100, timestamp: 1000, type: "text" }, // Same timestamp as now
       ];
+      // 100 tokens divided by the 1s minimum window = 100 t/s.
+      // (Floor avoids the divide-by-tiny-window artifact that otherwise reports
+      // tens of thousands of t/s when only one chunk has arrived.)
+      expect(calculateTPS(deltas, now)).toBe(100);
+    });
+
+    test("returns 0 when time span is negative (clock skew)", () => {
+      const now = 500;
+      const deltas: DeltaRecord[] = [
+        { tokens: 100, timestamp: 1000, type: "text" }, // future-dated, treat as invalid
+      ];
       expect(calculateTPS(deltas, now)).toBe(0);
+    });
+
+    test("floors tiny time spans to the 1s minimum to avoid inflated rates", () => {
+      // Realistic scenario: first delta of a fresh stream — only a few ms have
+      // elapsed between the chunk's timestamp and the read.
+      const now = 1005;
+      const deltas: DeltaRecord[] = [{ tokens: 50, timestamp: 1000, type: "text" }];
+      // Without the floor: 50 tokens / 0.005s = 10000 t/s (bogus).
+      // With the 1s floor: 50 tokens / 1s = 50 t/s.
+      expect(calculateTPS(deltas, now)).toBe(50);
+    });
+
+    test("uses raw time span once it exceeds the 1s minimum", () => {
+      // 1.5s after first delta — the floor stops applying and we return the
+      // honest rate.
+      const now = 2500;
+      const deltas: DeltaRecord[] = [
+        { tokens: 50, timestamp: 1000, type: "text" },
+        { tokens: 100, timestamp: 2000, type: "text" },
+      ];
+      // 150 tokens over 1.5s = 100 t/s.
+      expect(calculateTPS(deltas, now)).toBe(100);
     });
 
     test("uses current time by default", () => {

--- a/src/browser/utils/messages/applyWorkspaceChatEventToAggregator.test.ts
+++ b/src/browser/utils/messages/applyWorkspaceChatEventToAggregator.test.ts
@@ -208,6 +208,24 @@ describe("applyWorkspaceChatEventToAggregator", () => {
     expect(aggregator.calls).toEqual(["clearTokenState:msg-1", "handleStreamAbort:msg-1"]);
   });
 
+  test("stream-error clears token state after calling handleStreamError", () => {
+    const aggregator = new StubAggregator();
+
+    const event: WorkspaceChatMessage = {
+      type: "stream-error",
+      messageId: "msg-1",
+      error: "boom",
+      errorType: "network",
+    };
+
+    const hint = applyWorkspaceChatEventToAggregator(aggregator, event);
+
+    expect(hint).toBe("immediate");
+    // Without the clearTokenState call, the next stream's TPS/token-count
+    // calculation could draw from the errored message's leaked deltaHistory.
+    expect(aggregator.calls).toEqual(["handleStreamError:msg-1", "clearTokenState:msg-1"]);
+  });
+
   test("tool-call-delta routes to handleToolCallDelta and is throttled", () => {
     const aggregator = new StubAggregator();
 

--- a/src/browser/utils/messages/applyWorkspaceChatEventToAggregator.ts
+++ b/src/browser/utils/messages/applyWorkspaceChatEventToAggregator.ts
@@ -171,6 +171,10 @@ export function applyWorkspaceChatEventToAggregator(
     }
 
     aggregator.handleStreamError(event);
+    // Match stream-end / stream-abort: drop the per-message deltaHistory entry
+    // so a subsequent stream isn't influenced by leaked TPS/token state from
+    // the errored one.
+    aggregator.clearTokenState(event.messageId);
     return "immediate";
   }
 

--- a/src/browser/utils/streaming/SmoothTextEngine.test.ts
+++ b/src/browser/utils/streaming/SmoothTextEngine.test.ts
@@ -68,11 +68,14 @@ describe("SmoothTextEngine", () => {
 
   it("flushes immediately when streaming ends", () => {
     const engine = new SmoothTextEngine();
-    const fullText = makeText(120);
+    // Use a long text so 5 ticks aren't enough to fully reveal even at the
+    // catch-up rate ceiling — the test cares about the snap-to-full behavior
+    // when streaming stops, not the steady-state cadence.
+    const fullText = makeText(2000);
 
     engine.update(fullText, true, false);
 
-    for (let i = 0; i < 15; i++) {
+    for (let i = 0; i < 5; i++) {
       engine.tick(16);
     }
 
@@ -112,7 +115,8 @@ describe("SmoothTextEngine", () => {
     const engine = new SmoothTextEngine();
     // With a 1-char backlog, adaptive rate is at floor (~24 cps).
     // At 4ms per tick: 24 * 0.004 = 0.096 budget per tick.
-    // Budget reaches 1.0 after ceil(1 / 0.096) ≈ 11 ticks.
+    // The required-char gate is min(MIN_FRAME_CHARS, backlog) = min(2, 1) = 1
+    // for this 1-char stream, so it reveals once budget reaches 1.0.
     engine.update("x", true, false);
 
     // First tick at 4ms should not reveal (budget ~0.10).
@@ -129,6 +133,59 @@ describe("SmoothTextEngine", () => {
       engine.tick(4);
     }
     expect(engine.visibleLength).toBeGreaterThan(0);
+  });
+
+  it("targets the live model rate when provided", () => {
+    // With a model rate of 200 cps the engine should reveal materially faster
+    // than at the BASE rate of 72 cps for the same backlog.
+    const baseEngine = new SmoothTextEngine();
+    const modelAwareEngine = new SmoothTextEngine();
+
+    baseEngine.update(makeText(50), true, false);
+    modelAwareEngine.update(makeText(50), true, false, 200);
+
+    for (let i = 0; i < 10; i++) {
+      baseEngine.tick(16);
+      modelAwareEngine.tick(16);
+    }
+
+    expect(modelAwareEngine.visibleLength).toBeGreaterThan(baseEngine.visibleLength);
+  });
+
+  it("soft-catches-up large lag without a hard snap", () => {
+    const engine = new SmoothTextEngine();
+
+    // Catch up on a small initial chunk first.
+    engine.update(makeText(40), true, false);
+    while (!engine.isCaughtUp) {
+      engine.tick(16);
+    }
+
+    // Now jump the ingested length by 200 chars — well above SOFT_CATCHUP_LAG_CHARS
+    // (60) but well below the hard snap threshold (1024). The engine should NOT
+    // snap forward; it should keep visibleLength at the previous position so the
+    // soft catch-up ramp can drain the lag over the next few ticks.
+    const prevVisible = engine.visibleLength;
+    engine.update(makeText(240), true, false);
+    expect(engine.visibleLength).toBe(prevVisible);
+
+    // After enough ticks the soft ramp should drain the lag fully.
+    for (let i = 0; i < 60; i++) {
+      engine.tick(16);
+    }
+    expect(engine.isCaughtUp).toBe(true);
+  });
+
+  it("hard-snaps when lag exceeds the safety threshold", () => {
+    const engine = new SmoothTextEngine();
+    // A pathological burst — well above MAX_VISUAL_LAG_CHARS — must snap
+    // forward to keep the user from staring at a hidden tail.
+    const burstSize = STREAM_SMOOTHING.MAX_VISUAL_LAG_CHARS + 500;
+    engine.update(makeText(burstSize), true, false);
+
+    expect(burstSize - engine.visibleLength).toBeLessThanOrEqual(
+      STREAM_SMOOTHING.MAX_VISUAL_LAG_CHARS
+    );
   });
 
   it("keeps reveal near frame-rate invariant over equal wall time", () => {

--- a/src/browser/utils/streaming/SmoothTextEngine.ts
+++ b/src/browser/utils/streaming/SmoothTextEngine.ts
@@ -1,12 +1,38 @@
 import { STREAM_SMOOTHING } from "@/constants/streaming";
 import { clamp } from "@/common/utils/clamp";
 
-function getAdaptiveRate(backlog: number): number {
-  const backlogPressure = clamp(backlog / STREAM_SMOOTHING.CATCHUP_BACKLOG_CHARS, 0, 1);
+/**
+ * Compute target reveal rate (chars/sec) given current backlog and a hint of how
+ * fast the source is producing characters.
+ *
+ * Two ramps combine, then we take the max:
+ * - **Steady-state floor**: tracks the live model rate (BASE if unknown). This
+ *   keeps the visible cursor moving at roughly the model's emit rate so the
+ *   stream doesn't constantly fall further behind.
+ * - **Catch-up ramp**: when backlog exceeds SOFT_CATCHUP_LAG_CHARS, scale rate
+ *   so the lag drains within SOFT_CATCHUP_DRAIN_MS — this replaces the legacy
+ *   hard-snap with a smooth ramp that's invisible to the eye.
+ */
+function getAdaptiveRate(backlog: number, liveCharsPerSec: number): number {
+  const steadyState = Math.max(STREAM_SMOOTHING.BASE_CHARS_PER_SEC, liveCharsPerSec);
 
-  const targetRate =
+  // Soft catch-up: above the threshold, scale the steady-state rate so the
+  // lag drains over SOFT_CATCHUP_DRAIN_MS at the *current* draw rate.
+  const lagOverThreshold = Math.max(0, backlog - STREAM_SMOOTHING.SOFT_CATCHUP_LAG_CHARS);
+  const catchupRate =
+    lagOverThreshold > 0
+      ? steadyState + (lagOverThreshold * 1000) / STREAM_SMOOTHING.SOFT_CATCHUP_DRAIN_MS
+      : 0;
+
+  // Legacy backlog-pressure ramp kept as an upper bound for very large
+  // backlogs — guarantees we approach MAX_CHARS_PER_SEC long before hitting
+  // the hard-snap safety net.
+  const backlogPressure = clamp(backlog / STREAM_SMOOTHING.CATCHUP_BACKLOG_CHARS, 0, 1);
+  const pressureRate =
     STREAM_SMOOTHING.BASE_CHARS_PER_SEC +
     backlogPressure * (STREAM_SMOOTHING.MAX_CHARS_PER_SEC - STREAM_SMOOTHING.BASE_CHARS_PER_SEC);
+
+  const targetRate = Math.max(steadyState, catchupRate, pressureRate);
 
   return clamp(targetRate, STREAM_SMOOTHING.MIN_CHARS_PER_SEC, STREAM_SMOOTHING.MAX_CHARS_PER_SEC);
 }
@@ -16,6 +42,12 @@ function getAdaptiveRate(backlog: number): number {
  *
  * The ingestion clock (incoming full text) is external; this class manages only
  * the presentation clock (visible prefix length) using a character budget model.
+ *
+ * The engine is model-aware: callers should pass {@link update}'s
+ * `liveCharsPerSec` if they know the source's emission rate. Without it the
+ * engine targets {@link STREAM_SMOOTHING.BASE_CHARS_PER_SEC}, which can lag
+ * behind fast models and make the user wait through a backlog drain after the
+ * stream ends.
  */
 export class SmoothTextEngine {
   private fullLength = 0;
@@ -23,14 +55,18 @@ export class SmoothTextEngine {
   private charBudget = 0;
   private isStreaming = false;
   private bypassSmoothing = false;
+  private liveCharsPerSec = 0;
 
   private enforceMaxVisualLag(): void {
     if (!this.isStreaming || this.bypassSmoothing) {
       return;
     }
 
-    // Keep visible output near the ingested stream so interruption doesn't reveal
-    // a large hidden tail all at once.
+    // Hard safety net for pathological bursts (paused tab, slow renderer).
+    // Normal streams never reach this — the soft catch-up ramp in getAdaptiveRate
+    // keeps backlog far below MAX_VISUAL_LAG_CHARS for any model rate that fits
+    // within MAX_CHARS_PER_SEC. If we ever do hit it, snapping forward is
+    // strictly better than leaving the user staring at a hidden tail.
     const minVisibleLength = Math.max(0, this.fullLength - STREAM_SMOOTHING.MAX_VISUAL_LAG_CHARS);
     if (this.visibleLengthValue < minVisibleLength) {
       this.visibleLengthValue = minVisibleLength;
@@ -40,11 +76,20 @@ export class SmoothTextEngine {
 
   /**
    * Update the ingested text and stream state.
+   *
+   * @param liveCharsPerSec Optional hint at the source's current emission rate
+   *   (chars/sec). If omitted or 0, the engine uses {@link STREAM_SMOOTHING.BASE_CHARS_PER_SEC}.
    */
-  update(fullText: string, isStreaming: boolean, bypassSmoothing: boolean): void {
+  update(
+    fullText: string,
+    isStreaming: boolean,
+    bypassSmoothing: boolean,
+    liveCharsPerSec = 0
+  ): void {
     this.fullLength = fullText.length;
     this.isStreaming = isStreaming;
     this.bypassSmoothing = bypassSmoothing;
+    this.liveCharsPerSec = liveCharsPerSec > 0 ? liveCharsPerSec : 0;
 
     if (this.fullLength < this.visibleLengthValue) {
       this.visibleLengthValue = this.fullLength;
@@ -82,16 +127,18 @@ export class SmoothTextEngine {
     }
 
     const backlog = this.fullLength - this.visibleLengthValue;
-    const adaptiveRate = getAdaptiveRate(backlog);
+    const adaptiveRate = getAdaptiveRate(backlog, this.liveCharsPerSec);
 
     this.charBudget += adaptiveRate * (dtMs / 1000);
 
-    // Budget-gated reveal: only reveal when at least one whole character has
-    // accrued. This makes cadence frame-rate invariant — a 240Hz display
-    // accumulates budget across several frames before revealing, rather than
-    // forcing 1 char/frame at any refresh rate.
+    // Budget-gated reveal: require at least MIN_FRAME_CHARS to accrue. This
+    // makes cadence frame-rate invariant — a 240Hz display accumulates budget
+    // across several frames before revealing, instead of forcing 1 char/frame
+    // at any refresh rate. At the tail of a stream the requirement is capped
+    // by backlog so we always finish revealing the last 1 char.
     const wholeCharsReady = Math.floor(this.charBudget);
-    if (wholeCharsReady < STREAM_SMOOTHING.MIN_FRAME_CHARS) {
+    const requiredChars = Math.min(STREAM_SMOOTHING.MIN_FRAME_CHARS, backlog);
+    if (wholeCharsReady < requiredChars) {
       return this.visibleLengthValue;
     }
 
@@ -119,5 +166,6 @@ export class SmoothTextEngine {
     this.charBudget = 0;
     this.isStreaming = false;
     this.bypassSmoothing = false;
+    this.liveCharsPerSec = 0;
   }
 }

--- a/src/common/utils/tokens/tps.ts
+++ b/src/common/utils/tokens/tps.ts
@@ -13,6 +13,25 @@ export interface DeltaRecord {
 const DEFAULT_TPS_WINDOW_MS = 60000; // 60 second trailing window
 
 /**
+ * Minimum time span used in the TPS divisor.
+ *
+ * Without this floor, the first delta of a stream produces a wildly inflated
+ * TPS: with one delta `timeSpanMs = now - delta.timestamp` is typically a
+ * single-digit milliseconds value (the gap between when the chunk arrived and
+ * when we read it), so e.g. `50 tokens / 0.005s = 10000 t/s`. The user-visible
+ * effect is "TPS starts very high then drops abruptly" as more deltas arrive
+ * and broaden the window. Flooring to a 1s minimum window makes the rate
+ * smoothly ramp up from ~0 toward the steady-state value over the first
+ * second of a stream — a much more honest measurement.
+ *
+ * Trade-off: in the very first second the reported TPS slightly *under*-counts
+ * (we divide by 1s even when only 200ms have elapsed). That's acceptable —
+ * understatement during a settling window is far better than a misleading
+ * order-of-magnitude overstatement.
+ */
+const MIN_TPS_TIME_SPAN_MS = 1000;
+
+/**
  * Calculate tokens-per-second from a history of delta records.
  */
 export function calculateTPS(deltas: DeltaRecord[], now: number = Date.now()): number {
@@ -23,9 +42,9 @@ export function calculateTPS(deltas: DeltaRecord[], now: number = Date.now()): n
   if (recentDeltas.length === 0) return 0;
 
   const totalTokens = recentDeltas.reduce((sum, d) => sum + (d.tokens || 0), 0);
-  const timeSpanMs = now - recentDeltas[0].timestamp;
-  const timeSpanSec = timeSpanMs / 1000;
-  if (timeSpanSec <= 0) return 0;
+  const rawTimeSpanMs = now - recentDeltas[0].timestamp;
+  if (rawTimeSpanMs < 0) return 0;
+  const timeSpanSec = Math.max(rawTimeSpanMs, MIN_TPS_TIME_SPAN_MS) / 1000;
 
   return Math.round(totalTokens / timeSpanSec);
 }

--- a/src/constants/streaming.ts
+++ b/src/constants/streaming.ts
@@ -5,8 +5,16 @@
 // startup/streaming flags settle on adjacent renders.
 export const WORKSPACE_STREAMING_STATUS_TRANSITION_MS = 150;
 
+/**
+ * Average character-per-token estimate used to convert tokens-per-second (from
+ * the streaming TPS calculator) into characters-per-second (consumed by the
+ * smoothing engine to target the model's actual emission rate). 4 is the
+ * standard heuristic for English text and most code.
+ */
+export const APPROX_CHARS_PER_TOKEN = 4;
+
 export const STREAM_SMOOTHING = {
-  /** Baseline reveal speed in characters per second. */
+  /** Baseline reveal speed in characters per second when no live model rate is known yet. */
   BASE_CHARS_PER_SEC: 72,
   /** Floor — never slower than this even when buffer is nearly empty. */
   MIN_CHARS_PER_SEC: 24,
@@ -14,10 +22,27 @@ export const STREAM_SMOOTHING = {
   MAX_CHARS_PER_SEC: 420,
   /** Backlog level where adaptive reveal runs at MAX_CHARS_PER_SEC. */
   CATCHUP_BACKLOG_CHARS: 180,
-  /** Keep the rendered transcript close to live output even during bursty streams. */
-  MAX_VISUAL_LAG_CHARS: 120,
+  /**
+   * Soft catch-up threshold: above this lag the engine ramps target rate so
+   * the lag drains within ~SOFT_CATCHUP_DRAIN_MS — instead of a visible jump.
+   */
+  SOFT_CATCHUP_LAG_CHARS: 60,
+  /** Time horizon over which the engine aims to drain a soft-catchup lag. */
+  SOFT_CATCHUP_DRAIN_MS: 250,
+  /**
+   * Hard safety threshold. Only a pathological burst (slow renderer, paused
+   * tab) should ever push backlog this far; if it happens, snap visible
+   * forward to keep the user from staring at a long invisible tail. With a
+   * model emitting at typical rates the soft catch-up keeps backlog far
+   * below this.
+   */
+  MAX_VISUAL_LAG_CHARS: 1024,
   /** Max characters revealed in a single animation frame. */
   MAX_FRAME_CHARS: 48,
-  /** Min characters revealed per tick once budget permits (avoids sub-character stalls). */
-  MIN_FRAME_CHARS: 1,
+  /**
+   * Min characters revealed per tick once budget permits. Set to 2 so reveals
+   * coalesce to ~30 Hz at the base rate instead of ~60 Hz — equal visual
+   * smoothness to humans, half the markdown-reparse cost.
+   */
+  MIN_FRAME_CHARS: 2,
 } as const;


### PR DESCRIPTION
## Summary

Streamed assistant text (and reasoning) was visibly jittery — periodic catch-up jumps every few seconds, rate stuck at ~72 chars/sec regardless of what the model emitted, and a sub-frame of work for the entire chat list on every delta. This PR makes the cadence smooth in three ordered fixes plus a TPS-display fix discovered during review: leaf-subscribe the streaming-stats pill so it stops invalidating `WorkspaceState`, replace the smoothing engine's hard-snap with a model-aware soft catch-up, compact streaming parts on append, and floor the TPS calculator's time span so a new stream's first deltas don't spike the displayed rate.

## Background

The renderer has had a two-clock smoothing model (`SmoothTextEngine` + `useSmoothStreamingText`) for a while, but several regressions defeated it:

1. `WorkspaceState.streamingTokenCount` / `streamingTPS` were computed inside the `getWorkspaceState` snapshot using `Date.now()`. Every coalesced delta produced a new snapshot reference, which cascaded `WorkspaceShell → ChatPane → MessageRenderer` through every row. `useDeferredValue` was bypassed for the entire stream by `shouldBypassDeferredMessages`, so reconciliation ran at the ingestion rate.
2. `getAdaptiveRate(backlog)` ignored the model's actual emission rate. With a fast model (~120 cps) and `BASE_CHARS_PER_SEC=72`, the visible cursor fell behind by ~5 chars per ingestion cycle until backlog crossed `MAX_VISUAL_LAG_CHARS=120`, at which point `enforceMaxVisualLag` snapped `visible := full - 120` and zeroed the budget — that snap is exactly the visible "catch-up jump".
3. `requestIdleCallback({ timeout: 100 })` was used for streaming deltas. The smoothing engine should be the only pacing layer; idle batching just feeds (2).
4. `handleStreamDelta` appended a fresh `{ type: "text" }` part per chunk; `mergeAdjacentParts` re-merged on every render. For a 10k-char reply that's tens of thousands of merges per turn.
5. `calculateTPS` divided by `now - firstDelta.timestamp`. With one delta that span is typically a few milliseconds, so e.g. `50 tokens / 0.005s = 10000 t/s`. Phase 1's microtask cadence exposed this — where the prior idle-callback batching used to mask it by sampling later — and Phase 2 wired TPS into the smoothing engine, amplifying its visibility.

## Implementation

Four commits, ordered so each phase is verifiable in isolation:

**Phase 1 — leaf-subscribe streaming stats, microtask ingestion (`775e9023c`)**

- Removed `streamingTokenCount` / `streamingTPS` from `WorkspaceState`.
- Added `WorkspaceStreamingStats` + `streamingStatsStore` (`MapStore`) + `useWorkspaceStreamingStats(workspaceId)` leaf hook (mirrors the existing `useWorkspaceStatsSnapshot` pattern at `WorkspaceStore.ts:4127`).
- Replaced `scheduleIdleStateBump` with `scheduleStreamingStateBump` for streaming delta types (`stream-delta`, `tool-call-delta`, `reasoning-delta`). It coalesces on `queueMicrotask` instead of an idle callback. `init-output` and `bash-output` keep the idle path (terminal-style throughput).
- Wired `cancelPendingStreamingBump` into stream-end / stream-abort / replay reset / `removeWorkspace`.
- `StreamingBarrier` now reads via the leaf hook.

**Phase 2 — model-aware smoothing engine, soft catch-up (`85fb141da`)**

- `SmoothTextEngine.update()` accepts an optional `liveCharsPerSec`. `getAdaptiveRate(backlog, liveCps)` combines a steady-state floor (`max(BASE, liveCps)`), a soft catch-up ramp that drains lag over `SOFT_CATCHUP_DRAIN_MS` once it exceeds `SOFT_CATCHUP_LAG_CHARS=60`, and the legacy backlog-pressure ramp (kept as upper bound).
- Replaced the hard-snap discontinuity with the soft ramp. `MAX_VISUAL_LAG_CHARS` is now 1024 (was 120) — a defensive safety net for paused-tab pathological bursts that normal streams never hit.
- Bumped `MIN_FRAME_CHARS` from 1 to 2 so reveals coalesce to ~30 Hz at the BASE rate (half the markdown re-parse cost; humans can't see the difference). Tail-end reveal still works because the gate is now `min(MIN_FRAME_CHARS, backlog)`.
- `useSmoothStreamingText` and `TypewriterMarkdown` thread `liveCharsPerSec` through; `TypewriterMarkdown` accepts a new `workspaceId` prop, forwarded from `AssistantMessage` and `ReasoningMessage` (via `MessageRenderer`).

**Phase 3 — compact-on-append, clean prop surface (`0a945ed7b`)**

- `StreamingMessageAggregator.handleStreamDelta` / `handleReasoningDelta` append into the previous adjacent text/reasoning part in place. For a 10k-char reply this drops `parts.length` from thousands to one and `mergeAdjacentParts` cost from O(N) to O(1). Backend persistence (`partial.json`, `chat.jsonl`) is unaffected — those writers live backend-side; this aggregator's `parts` is pure display state.
- `TypewriterMarkdown`: dropped the `deltas: string[]` shape (always passed as `[content]` literal — defeated `React.memo`) for `content: string`. Removed the manual `React.memo` and the inner `useMemo` for the streaming-context value (React Compiler handles both).

**Phase 4 — TPS calculator floor + stream-error token cleanup (`a476613be`)**

- `calculateTPS` now floors the divisor at `MIN_TPS_TIME_SPAN_MS = 1000`. With one delta the rate becomes `tokens / 1s` instead of `tokens / 0.005s`. The reported TPS smoothly ramps up over the first second of a stream instead of spiking and "dropping abruptly". Slight under-statement during the settling window is the trade-off — strictly preferable to an order-of-magnitude over-statement.
- The `stream-error` branch in `applyWorkspaceChatEventToAggregator` now calls `clearTokenState`, matching `stream-end` and `stream-abort`. Without it, the errored message's `deltaHistory` entry leaks into a follow-up stream's TPS calculation.

## Validation

- `make typecheck` ✅
- `make lint` ✅
- Targeted streaming surface: 1009+ tests pass / 0 fail across `SmoothTextEngine`, `useSmoothStreamingText`, `StreamingMessageAggregator`, `applyWorkspaceChatEventToAggregator`, `StreamingTPSCalculator`, `TypewriterMarkdown`, `ReasoningMessage`, `StreamingBarrier{,View}`, `PinnedTodoList`, `WorkspaceStore`, plus the broader `src/browser/utils/messages/`, `src/browser/features/Messages/`, `src/browser/stores/`, and `src/browser/hooks/` suites.
- New behavioral tests:
  - `SmoothTextEngine.test.ts`: rate tracks `liveCharsPerSec`; soft catch-up engaged for 60–1024 char lags without snap; hard snap still fires above the safety threshold.
  - `StreamingTPSCalculator.test.ts`: 1s floor applied for tiny / zero spans; raw span used once it exceeds the floor; negative spans (clock skew) return 0.
  - `applyWorkspaceChatEventToAggregator.test.ts`: `stream-error` calls `clearTokenState`.

## Risks

Localized to the streaming display path; no protocol or persistence changes.

- **Re-render shape (Phase 1).** Streaming deltas now bump `WorkspaceState` once per microtask drain instead of once per `requestIdleCallback`. Net effect under heavy load is *less* work because the snapshot stops invalidating per-delta TPS, but it's a behavioral shift — verified via the existing 106-test `WorkspaceStore` suite plus targeted `StreamingBarrier` tests.
- **Smoothing engine constants (Phase 2).** `MAX_VISUAL_LAG_CHARS` jumped 120 → 1024 and `MIN_FRAME_CHARS` 1 → 2. Existing test "caps visual lag when incoming text jumps ahead" still passes against the new soft-ramp behavior, and the new "hard-snaps when lag exceeds the safety threshold" test confirms the safety net still functions.
- **Compact-on-append (Phase 3).** Touches the in-memory `parts` array shape during streaming. The aggregator already had compaction at stream-end (`compactMessageParts`); we're just doing it eagerly. No on-disk format change. All `StreamingMessageAggregator` and `applyWorkspaceChatEventToAggregator` tests pass.
- **TPS floor (Phase 4).** The reported rate during the first second of a stream now under-counts versus the previous (mathematically broken) value. Backend `sessionTimingService` also calls `calculateTPS`; same floor applies there but the backend's window is broader so the visible effect is smaller. No risk to persisted usage / cost calculations — those use `usage.outputTokens / duration` from the API, not the streaming TPS estimator.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `xhigh` • Cost: `$23.55`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=xhigh costs=23.55 -->
