### PR TITLE
🤖 feat: allow guardless file_edit_insert on empty files

### DIFF
--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -1271,7 +1271,7 @@ export const TOOL_DEFINITIONS = {
     description:
       "Insert content into a file using substring guards. " +
       "Provide exactly one of insert_before or insert_after to anchor the operation when editing an existing file. " +
-      "When the file does not exist, it is created automatically without guards. " +
+      "When the file does not exist or is empty, it is populated automatically without guards. " +
       "Optional before/after substrings must uniquely match surrounding content. " +
       "Avoid short guards like `}` or `}\\n` that match multiple locations — " +
       `use longer patterns like full function signatures or unique comments. ${TOOL_EDIT_WARNING}`,

--- a/src/node/services/tools/file_edit_insert.test.ts
+++ b/src/node/services/tools/file_edit_insert.test.ts
@@ -142,6 +142,20 @@ describe("file_edit_insert tool", () => {
     expect(await fs.readFile(newFile, "utf-8")).toBe("Hello world!\n");
   });
 
+  it("populates an empty existing file without requiring guards", async () => {
+    const emptyFile = path.join(testDir, "empty.txt");
+    await fs.writeFile(emptyFile, "");
+    const tool = createTestTool(testDir);
+    const args: FileEditInsertToolArgs = {
+      path: path.relative(testDir, emptyFile),
+      content: "Hello empty!\n",
+    };
+
+    const result = (await tool.execute!(args, mockToolCallOptions)) as FileEditInsertToolResult;
+    expect(result.success).toBe(true);
+    expect(await fs.readFile(emptyFile, "utf-8")).toBe("Hello empty!\n");
+  });
+
   it("fails when no guards are provided", async () => {
     const tool = createTestTool(testDir);
     const args: FileEditInsertToolArgs = {

--- a/src/node/services/tools/file_edit_insert.ts
+++ b/src/node/services/tools/file_edit_insert.ts
@@ -149,6 +149,15 @@ function insertContent(
   }
 
   if (insert_before == null && insert_after == null) {
+    // Empty existing files have no anchors to match against, so allow guardless
+    // inserts that simply populate the file (mirrors the create-on-missing path).
+    if (originalContent.length === 0) {
+      return {
+        success: true,
+        newContent: contentToInsert,
+        metadata: {},
+      };
+    }
     return guardFailure(
       "Provide either insert_before or insert_after guard when editing existing files."
     );


### PR DESCRIPTION
## Summary

`file_edit_insert` now treats an empty existing file the same as a missing file: callers can populate it without supplying an `insert_before` / `insert_after` guard.

## Background

The tool already creates a brand-new file with no guards required, but if the file existed (even as a 0-byte placeholder) we forced the model to provide an anchor substring. There is nothing inside an empty file to anchor against, so the model had no way to satisfy the requirement and the call always failed with "Provide either insert_before or insert_after guard…".

## Implementation

In `insertContent` (`src/node/services/tools/file_edit_insert.ts`), when neither anchor is supplied and `originalContent` is empty, return success with the new content as-is. The schema-level guard mismatch check is unchanged for non-empty files. Tool description in `toolDefinitions.ts` updated to mention the empty-file case. Added a unit test covering the new path.

## Risks

Low. The new branch only fires when the existing file is exactly empty and no anchors were given — previously a hard error, now a populate. All existing guard validation paths are untouched.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `medium` • Cost: `$0.20`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=medium costs=0.20 -->
