### PR TITLE
🤖 refactor: move ChatInput attach/voice icons out of textarea overlay

### DIFF
--- a/src/browser/components/VimTextArea/VimTextArea.tsx
+++ b/src/browser/components/VimTextArea/VimTextArea.tsx
@@ -31,7 +31,6 @@ export interface VimTextAreaProps extends Omit<
   onChange: (next: string, caretIndex?: number) => void;
   isEditing?: boolean;
   suppressKeys?: string[]; // keys for which Vim should not interfere (e.g. ["Tab","ArrowUp","ArrowDown","Escape"]) when popovers are open
-  trailingAction?: React.ReactNode;
   ghostHint?: string | null;
   /** Called when Escape is pressed in normal mode (vim) - useful for cancel edit */
   onEscapeInNormalMode?: () => void;
@@ -49,7 +48,6 @@ export const VimTextArea = React.forwardRef<HTMLTextAreaElement, VimTextAreaProp
       isEditing,
       suppressKeys,
       onKeyDown,
-      trailingAction,
       ghostHint,
       onEscapeInNormalMode,
       focusBorderColor,
@@ -252,8 +250,6 @@ export const VimTextArea = React.forwardRef<HTMLTextAreaElement, VimTextAreaProp
       padding: "0.375rem 0.5rem",
       fontSize: "13px",
       ...(rest.style ?? {}),
-      // Reserve scrollbar space on the trailing edge only; both-edges shifts placeholder text right.
-      ...(trailingAction ? { scrollbarGutter: "stable" } : {}),
       // Focus border color from agent definition
       "--focus-border-color": !isEditing ? focusBorderColor : undefined,
     };
@@ -295,7 +291,6 @@ export const VimTextArea = React.forwardRef<HTMLTextAreaElement, VimTextAreaProp
               vimEnabled ? "font-monospace" : "font-sans",
               "placeholder:text-placeholder",
               "focus:outline-none",
-              trailingAction && "pr-16",
               isEditing
                 ? "bg-editing-mode-alpha border-editing-mode focus:border-editing-mode"
                 : "bg-dark border-border-light focus:border-[var(--focus-border-color)]",
@@ -323,11 +318,6 @@ export const VimTextArea = React.forwardRef<HTMLTextAreaElement, VimTextAreaProp
               {/* Invisible spacer occupies the same width as the typed text. */}
               <span style={{ visibility: "hidden" }}>{value}</span>
               <span className="text-placeholder">{ghostHint}</span>
-            </div>
-          )}
-          {trailingAction && (
-            <div className="pointer-events-none absolute right-3.5 bottom-2.5 flex items-center">
-              <div className="pointer-events-auto">{trailingAction}</div>
             </div>
           )}
           {vimEnabled && vimMode === "normal" && value.length === 0 && (

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -2738,27 +2738,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                     (showSkillSuggestions && skillSuggestions.length > 0)
                   }
                   className={variant === "creation" ? "min-h-28" : "min-h-16"}
-                  trailingAction={
-                    <div className="flex items-center gap-1">
-                      <AttachFileButton
-                        onFiles={handleAttachFiles}
-                        disabled={disabled || sendInFlightBlocksInput || !!editingMessageForUi}
-                      />
-                      <VoiceInputButton
-                        state={voiceInput.state}
-                        isAvailable={voiceInput.isAvailable}
-                        shouldShowUI={voiceInput.shouldShowUI}
-                        requiresSecureContext={voiceInput.requiresSecureContext}
-                        onToggle={voiceInput.toggle}
-                        disabled={disabled || sendInFlightBlocksInput}
-                        agentColor={focusBorderColor}
-                      />
-                    </div>
-                  }
                 />
                 {/* Keep shortcuts visible in both creation + workspace without bloating the footer or crowding it. */}
                 {input.trim() === "" && !editingMessageForUi && (
-                  <div className="mobile-hide-shortcut-hints text-muted @container pointer-events-none absolute right-18 bottom-3 left-2 flex flex-nowrap items-center gap-4 overflow-hidden text-[11px] whitespace-nowrap">
+                  <div className="mobile-hide-shortcut-hints text-muted @container pointer-events-none absolute right-2 bottom-3 left-2 flex flex-nowrap items-center gap-4 overflow-hidden text-[11px] whitespace-nowrap">
                     <span className="shrink-0">
                       <span className="font-mono">{formatKeybind(KEYBINDS.FOCUS_CHAT)}</span>
                       <span> - focus chat</span>
@@ -2794,6 +2777,31 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
             <div className="@container flex min-w-[340px] flex-nowrap items-center gap-1.5">
               <div className="flex min-w-0 flex-1 items-center gap-1.5">
+                {/*
+                  Input-method icons (attach, voice) live in the controls row rather than
+                  overlaying the textarea. An overlay forced reserved right-padding on every
+                  line and still allowed the bottom line of wrapped text to ride under the
+                  icons; placing them here guarantees they never intersect typed text.
+                */}
+                <div
+                  className="flex shrink-0 items-center gap-0.5"
+                  data-component="InputMethodGroup"
+                >
+                  <AttachFileButton
+                    onFiles={handleAttachFiles}
+                    disabled={disabled || sendInFlightBlocksInput || !!editingMessageForUi}
+                  />
+                  <VoiceInputButton
+                    state={voiceInput.state}
+                    isAvailable={voiceInput.isAvailable}
+                    shouldShowUI={voiceInput.shouldShowUI}
+                    requiresSecureContext={voiceInput.requiresSecureContext}
+                    onToggle={voiceInput.toggle}
+                    disabled={disabled || sendInFlightBlocksInput}
+                    agentColor={focusBorderColor}
+                  />
+                </div>
+
                 <div
                   className="flex min-w-0 items-center gap-1.5"
                   data-component="ModelSelectorGroup"

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -2777,31 +2777,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
             <div className="@container flex min-w-[340px] flex-nowrap items-center gap-1.5">
               <div className="flex min-w-0 flex-1 items-center gap-1.5">
-                {/*
-                  Input-method icons (attach, voice) live in the controls row rather than
-                  overlaying the textarea. An overlay forced reserved right-padding on every
-                  line and still allowed the bottom line of wrapped text to ride under the
-                  icons; placing them here guarantees they never intersect typed text.
-                */}
-                <div
-                  className="flex shrink-0 items-center gap-0.5"
-                  data-component="InputMethodGroup"
-                >
-                  <AttachFileButton
-                    onFiles={handleAttachFiles}
-                    disabled={disabled || sendInFlightBlocksInput || !!editingMessageForUi}
-                  />
-                  <VoiceInputButton
-                    state={voiceInput.state}
-                    isAvailable={voiceInput.isAvailable}
-                    shouldShowUI={voiceInput.shouldShowUI}
-                    requiresSecureContext={voiceInput.requiresSecureContext}
-                    onToggle={voiceInput.toggle}
-                    disabled={disabled || sendInFlightBlocksInput}
-                    agentColor={focusBorderColor}
-                  />
-                </div>
-
                 <div
                   className="flex min-w-0 items-center gap-1.5"
                   data-component="ModelSelectorGroup"
@@ -2873,7 +2848,34 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                   />
                 </div>
 
-                <div ref={sendModeMenuContainerRef} className="relative">
+                {/*
+                  Input-method icons (attach, voice) cluster tightly with the Send button so
+                  the trailing actions read as one unit, rather than as small icons stranded
+                  inside the row's gap-1.5 cadence. They live below the textarea (not as an
+                  absolute overlay) so they can never visually intersect typed/wrapped text.
+                */}
+                <div className="flex shrink-0 items-center gap-0" data-component="InputMethodGroup">
+                  <AttachFileButton
+                    onFiles={handleAttachFiles}
+                    disabled={disabled || sendInFlightBlocksInput || !!editingMessageForUi}
+                  />
+                  <VoiceInputButton
+                    state={voiceInput.state}
+                    isAvailable={voiceInput.isAvailable}
+                    shouldShowUI={voiceInput.shouldShowUI}
+                    requiresSecureContext={voiceInput.requiresSecureContext}
+                    onToggle={voiceInput.toggle}
+                    disabled={disabled || sendInFlightBlocksInput}
+                    agentColor={focusBorderColor}
+                  />
+                </div>
+
+                {/*
+                  Pull the Send button flush against the input-method icons (override the
+                  parent's gap-1.5 with a negative margin) so they form a single trailing
+                  cluster.
+                */}
+                <div ref={sendModeMenuContainerRef} className="relative -ml-1.5">
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button


### PR DESCRIPTION
## Summary

Move the attach (📎) and voice (🎙️) input buttons from the absolute overlay inside the chat textarea into the controls row directly to the left of the Send button, so they can never visually intersect typed text and read as a single trailing action cluster.

## Background

The previous design positioned both buttons absolutely at the bottom-right corner of the textarea and reserved a fixed `pr-16` (4rem) right padding to keep text out of their way. This had two problems:

1. **Text could still ride under the icons.** The reserved gutter is a fixed pixel value, but font metrics, focus rings, and the icon group's effective width could push glyphs into the icon zone — most visibly the bottom line of multi-line wrapped input.
2. **Wasted horizontal space.** Every line in the textarea lost 4rem on the right even when the input was short.

## Implementation

- `VimTextArea`: removed the `trailingAction` prop and its associated machinery (`pr-16` conditional padding, `scrollbarGutter: "stable"`, the absolute overlay div). The component had a single consumer, so removing the surface area is a net cleanup.
- `ChatInput`: relocated `<AttachFileButton>` and `<VoiceInputButton>` into a new `InputMethodGroup` that sits in the right half of the existing controls row, between the agent mode picker (`Exec ▾`) and the Send button. Internal `gap-0` and a `-ml-1.5` on the Send container override the parent's `gap-1.5` cadence so the trailing actions form one tight cluster `[Exec ▾] 📎 🎙 ➤` rather than three small icons stranded in a wide-spaced row.
- Reclaimed the right-side gutter for the empty-input keyboard hints (`right-18` → `right-2`) since the textarea no longer has icons floating over its bottom-right corner.

## Validation

- Verified empty / short / multi-line wrapped inputs in Storybook (`App/Chat/Input → VoiceInputNoApiKey`); the bottom line of wrapped text never intersects either icon.
- Recording overlay still replaces the textarea correctly while the controls row (with the voice button) stays put.
- `make static-check` passes locally.

## Risks

Low. The change is purely visual layout: button props, callbacks, and disabled states are unchanged, and no logic in `ChatInput` was altered. The `trailingAction` prop on `VimTextArea` had a single caller, so removing it is safe.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `high` • Cost: `$1.53`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=high costs=1.53 -->
