### PR TITLE
🤖 fix: bump streamingStatsStore on stream-start to clear stale TPS

### DIFF
--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -1946,6 +1946,106 @@ describe("WorkspaceStore", () => {
       unsubscribe();
     });
 
+    it("invalidates streaming-stats cache on stream-start so the new turn never displays the prior turn's TPS", async () => {
+      // Repro for "Streaming TPS starts with stale value": reconnect / hydration
+      // paths drop aggregator.activeStreams via clearActiveStreams() WITHOUT
+      // bumping streamingStatsStore. If the next stream-start also doesn't bump,
+      // useWorkspaceStreamingStats keeps returning the previous turn's cached
+      // stats until the first delta of the new turn. The fix is to bump on
+      // stream-start so every new turn forces a fresh recompute.
+      const workspaceId = "stream-start-invalidates-stats";
+      const streamModel = "anthropic:claude-opus-4-6";
+
+      mockOnChat.mockImplementation(async function* (
+        _input?: { workspaceId: string; mode?: unknown },
+        options?: { signal?: AbortSignal }
+      ): AsyncGenerator<WorkspaceChatMessage, void, unknown> {
+        if (options?.signal?.aborted) {
+          yield { type: "caught-up" };
+        }
+        await waitForAbortSignal(options?.signal);
+      });
+
+      recreateStore();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      createAndAddWorkspace(store, workspaceId);
+
+      const rawStore = store as unknown as {
+        handleChatMessage: (workspaceId: string, data: WorkspaceChatMessage) => void;
+      };
+
+      // Stream A: start + delta + caught-up so the streaming-stats cache is
+      // populated with non-null stats reflecting A's TPS / token count.
+      const messageIdA = "stream-a";
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-start",
+        workspaceId,
+        messageId: messageIdA,
+        model: streamModel,
+        historySequence: 1,
+        startTime: 1_000,
+      });
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-delta",
+        workspaceId,
+        messageId: messageIdA,
+        delta: "hello world ",
+        tokens: 3,
+        timestamp: 1_500,
+      });
+      rawStore.handleChatMessage(workspaceId, { type: "caught-up" });
+
+      const beforeA = store.getWorkspaceStreamingStats(workspaceId);
+      expect(beforeA).not.toBeNull();
+      expect(beforeA?.tokenCount).toBe(3);
+
+      // Simulate a reconnect / hydration path: aggregator.clearActiveStreams()
+      // drops the active stream WITHOUT bumping streamingStatsStore (the four
+      // call sites in WorkspaceStore that do this on caught-up / background
+      // streaming-stop / activity-driven generation advance / addWorkspace).
+      const aggregator = store.getAggregator(workspaceId);
+      if (!aggregator) {
+        throw new Error(`Missing aggregator for ${workspaceId}`);
+      }
+      aggregator.clearActiveStreams();
+
+      // Pre-fix: no bump has happened, so the cached A-stats remain visible to
+      // any subscriber that reads at this point — that's the literal "stale TPS"
+      // the user sees during the new turn's first frames.
+      expect(store.getWorkspaceStreamingStats(workspaceId)).toEqual(beforeA);
+
+      // Subscribe so the missing stream-start bump would surface as a missed
+      // notification on regression.
+      let notifications = 0;
+      const unsubscribe = store.subscribeStreamingStats(workspaceId, () => {
+        notifications += 1;
+      });
+
+      // Stream B starts via the buffered handler. With the fix, this bumps
+      // streamingStatsStore and the cache is invalidated.
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-start",
+        workspaceId,
+        messageId: "stream-b",
+        model: streamModel,
+        historySequence: 2,
+        startTime: 2_000,
+      });
+
+      expect(notifications).toBeGreaterThanOrEqual(1);
+
+      // After stream-start, the cache must no longer reflect stream A. B has
+      // received no deltas yet, so the recomputed stats are a fresh zeroed
+      // snapshot — the important property is that A's stats are gone.
+      expect(store.getWorkspaceStreamingStats(workspaceId)).toEqual({
+        tokenCount: 0,
+        tps: 0,
+        charsPerSec: 0,
+      });
+
+      unsubscribe();
+    });
+
     it("prefers buffered stream-start state over stale non-streaming activity during hydration", async () => {
       const workspaceId = "buffered-stream-start-over-activity";
       const staleActivityModel = "openai:gpt-4o-mini";

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -667,6 +667,14 @@ export class WorkspaceStore {
       this.states.bump(workspaceId);
       // Bump usage store so liveUsage is recomputed with new activeStreamId
       this.usageStore.bump(workspaceId);
+      // Invalidate cached streaming stats so the pill never displays the prior
+      // turn's TPS at the start of a new one. Stream-end / stream-abort /
+      // stream-error already bump on terminal events, but those bumps can be
+      // skipped on reconnect/hydration paths that drop activeStreams via
+      // aggregator.clearActiveStreams() without notifying this store. Bumping
+      // on stream-start makes the cache invariant: every new turn forces a
+      // fresh recompute regardless of how the previous one was wound down.
+      this.streamingStatsStore.bump(workspaceId);
     },
     "stream-lifecycle": (workspaceId, aggregator, data) => {
       applyWorkspaceChatEventToAggregator(aggregator, data);
@@ -1393,9 +1401,9 @@ export class WorkspaceStore {
    * Get current live streaming stats for a workspace, or null if no stream is active.
    *
    * Cached per MapStore version: changes only when {@link streamingStatsStore} is
-   * bumped (every coalesced delta + on stream end). Reading uses Date.now() at
-   * the bump point, so the trailing-window TPS is always current relative to the
-   * latest delta.
+   * bumped (stream-start + every coalesced delta + every terminal stream event).
+   * Reading uses Date.now() at the bump point, so the trailing-window TPS is
+   * always current relative to the latest delta.
    */
   getWorkspaceStreamingStats(workspaceId: string): WorkspaceStreamingStats | null {
     return this.streamingStatsStore.get(workspaceId, () => {


### PR DESCRIPTION
## Summary

The streaming TPS pill briefly displayed the prior turn's TPS at the start of a new assistant stream. Fix invalidates the streaming-stats cache when `stream-start` arrives so every new turn forces a fresh recompute.

## Background

User report: _"Streaming TPS starts with stale value."_ Two prior fixes addressed adjacent issues — flooring TPS time-span to 1s + clearing token state on `stream-error`, and invalidating the streaming-stats cache on `stream-error` (both squashed into #3219). Despite those, the stale-TPS flash still happened at stream **start**.

## Implementation

`bufferedEventHandlers["stream-start"]` in `WorkspaceStore` bumped `states` and `usageStore` but never `streamingStatsStore`. In the foreground happy path this was masked because `stream-end` / `stream-abort` / `stream-error` all bump `streamingStatsStore` on terminal events.

The bug surfaces whenever `aggregator.activeStreams` is reset **without** a corresponding stats bump. Four sites in `WorkspaceStore` call `aggregator.clearActiveStreams()` directly:

- caught-up reconnect/hydration
- background streaming-stop
- activity-driven generation advance
- post-`addWorkspace`

After any of those, the cache still holds the prior turn's `WorkspaceStreamingStats` and `useWorkspaceStreamingStats` returns it verbatim until the new turn's first delta fires `scheduleStreamingStateBump`. That window is exactly the "stale TPS" the user saw.

Fix: bump `streamingStatsStore` on `stream-start`. That choke point is invariant to how the previous stream was wound down, so the single bump makes the cache invariant — every new turn forces a fresh recompute regardless of the prior teardown path.

**Rejected alternative:** bumping inside `clearActiveStreams` itself (or at each of the four call sites). That requires four edits today and stays fragile to future call sites; the bug is at the cache layer, not the aggregator's `deltaHistory`.

## Validation

- New regression test `"invalidates streaming-stats cache on stream-start so the new turn never displays the prior turn's TPS"` simulates the reconnect path (`clearActiveStreams()` without a bump), then issues the next `stream-start` and asserts the cache is invalidated. Verified to fail without the fix and pass with it.
- Streaming surface (`WorkspaceStore.test.ts`, `StreamingTPSCalculator.test.ts`, `applyWorkspaceChatEventToAggregator.test.ts`, `StreamingBarrierView.test.tsx`) — 138 pass, 0 fail.

## Risks

Low. The change is a single `streamingStatsStore.bump(workspaceId)` per assistant turn. The cache it invalidates is already bumped on every coalesced delta (~30Hz during streaming), so one extra bump per turn is negligible. No behavioral change for non-streaming callers; leaf-subscribed `useWorkspaceStreamingStats` consumers (`StreamingBarrier`, `TypewriterMarkdown`) just see one additional notification per turn.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `max` • Cost: `$19.03`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=max costs=19.03 -->
