### PR TITLE
🤖 ci: fix Terminal-Bench Harbor drift

### DIFF
--- a/.github/workflows/terminal-bench.yml
+++ b/.github/workflows/terminal-bench.yml
@@ -166,16 +166,31 @@ jobs:
             exit 0
           fi
           pip install --quiet daytona
-          python3 -c "
+          python3 <<'PY' > /tmp/daytona-pre-existing.txt
           from daytona import Daytona
+
+          def list_all_sandboxes(daytona):
+              # Daytona returns paginated results. Snapshot every page so cleanup
+              # can distinguish old sandboxes from ones this run created.
+              page = 1
+              while True:
+                  result = daytona.list(page=page)
+                  yield from result.items
+                  total_pages = result.total_pages or 1
+                  if page >= total_pages:
+                      break
+                  page += 1
+
           d = Daytona()
-          ids = [sb.id for sb in d.list()]
+          ids = [sb.id for sb in list_all_sandboxes(d)]
           print('\n'.join(ids))
-          " > /tmp/daytona-pre-existing.txt
+          PY
           echo "Snapshot $(wc -l < /tmp/daytona-pre-existing.txt) pre-existing sandbox(es)"
 
       - name: Run Terminal-Bench
-        run: make benchmark-terminal 2>&1 | tee benchmark.log
+        run: |
+          set -o pipefail
+          make benchmark-terminal 2>&1 | tee benchmark.log
         env:
           UV_PYTHON: "3.12"
           TB_DATASET: ${{ inputs.dataset }}
@@ -216,15 +231,28 @@ jobs:
             exit 0
           fi
           pip install --quiet daytona
-          python3 -c "
+          python3 <<'PY'
           from daytona import Daytona
+
+          def list_all_sandboxes(daytona):
+              # Daytona returns paginated results. Cleanup must inspect every
+              # page so stopped sandboxes from high-concurrency runs do not leak.
+              page = 1
+              while True:
+                  result = daytona.list(page=page)
+                  yield from result.items
+                  total_pages = result.total_pages or 1
+                  if page >= total_pages:
+                      break
+                  page += 1
+
           with open('/tmp/daytona-pre-existing.txt') as f:
               pre_existing = {line.strip() for line in f if line.strip()}
           d = Daytona()
           # Only consider sandboxes created after our snapshot (not pre-existing)
           # and only delete ones that are no longer running (safe for parallel jobs).
           ACTIVE_STATES = {'started', 'creating', 'starting'}
-          candidates = [sb for sb in d.list() if sb.id not in pre_existing]
+          candidates = [sb for sb in list_all_sandboxes(d) if sb.id not in pre_existing]
           to_delete = [sb for sb in candidates if str(sb.state).lower() not in ACTIVE_STATES]
           skipped = len(candidates) - len(to_delete)
           if skipped:
@@ -240,7 +268,7 @@ jobs:
                       print(f'  Deleted {sb.id}')
                   except Exception as e:
                       print(f'  Failed to delete {sb.id}: {e}')
-          "
+          PY
 
       - name: Print results summary
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -563,8 +563,11 @@ chromatic: node_modules/.installed ## Run Chromatic for visual regression testin
 	@bun x chromatic --exit-zero-on-changes
 
 ## Benchmarks
-benchmark-terminal: ## Run Terminal-Bench 2.0 with Harbor (use TB_DATASET/TB_CONCURRENCY/TB_TIMEOUT/TB_ENV/TB_MODEL/TB_ARGS to customize)
-	@TB_DATASET=$${TB_DATASET:-terminal-bench@2.0}; \
+benchmark-terminal: ## Run Terminal-Bench 2.0 with Harbor (use TB_HARBOR_PACKAGE/TB_DATASET/TB_CONCURRENCY/TB_TIMEOUT/TB_ENV/TB_MODEL/TB_ARGS to customize)
+	@# Pin Harbor with the Daytona extra so scheduled ingestion does not break on future CLI or adapter API drift.
+	@# Harbor removed --task-name, so keep smoke-test task filtering on the current dataset filter flag.
+	@HARBOR_PACKAGE=$${TB_HARBOR_PACKAGE:-harbor[daytona]==0.6.4}; \
+	TB_DATASET=$${TB_DATASET:-terminal-bench@2.0}; \
 	TB_TIMEOUT=$${TB_TIMEOUT:-1800}; \
 	TB_CONCURRENCY=$${TB_CONCURRENCY:-4}; \
 	ENV_FLAG=$${TB_ENV:+--env $$TB_ENV}; \
@@ -572,13 +575,14 @@ benchmark-terminal: ## Run Terminal-Bench 2.0 with Harbor (use TB_DATASET/TB_CON
 	TASK_NAME_FLAGS=""; \
 	if [ -n "$$TB_TASK_NAMES" ]; then \
 		for task_name in $$TB_TASK_NAMES; do \
-			TASK_NAME_FLAGS="$$TASK_NAME_FLAGS --task-name $$task_name"; \
+			TASK_NAME_FLAGS="$$TASK_NAME_FLAGS --include-task-name $$task_name"; \
 		done; \
 	fi; \
+	echo "Using Harbor package: $$HARBOR_PACKAGE"; \
 	echo "Using timeout: $$TB_TIMEOUT seconds"; \
 	echo "Running Terminal-Bench with dataset $$TB_DATASET (concurrency: $$TB_CONCURRENCY)"; \
 	export MUX_TIMEOUT_MS=$$((TB_TIMEOUT * 1000)); \
-	uvx harbor run \
+	uvx --from "$$HARBOR_PACKAGE" harbor run \
 		--dataset "$$TB_DATASET" \
 		--agent-import-path benchmarks.terminal_bench.mux_agent:MuxAgent \
 		--agent-kwarg timeout=$$TB_TIMEOUT \

--- a/benchmarks/terminal_bench/mux_agent.py
+++ b/benchmarks/terminal_bench/mux_agent.py
@@ -4,14 +4,23 @@ import json
 import os
 import shlex
 from collections.abc import Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from harbor.agents.installed.base import BaseInstalledAgent, ExecInput
+from harbor.agents.installed.base import BaseInstalledAgent
 from harbor.environments.base import BaseEnvironment
 from harbor.models.agent.context import AgentContext
 
 from .mux_payload import build_app_archive
+
+
+@dataclass(frozen=True)
+class _AgentCommand:
+    command: str
+    env: dict[str, str]
+    cwd: str | None = None
+    timeout_sec: int | None = None
 
 
 class MuxAgent(BaseInstalledAgent):
@@ -22,6 +31,7 @@ class MuxAgent(BaseInstalledAgent):
 
     _ARCHIVE_NAME = "mux-app.tar.gz"
     _RUNNER_NAME = "mux-run.sh"
+    _SETUP_SCRIPT_NAME = "mux_setup.sh"
     _DEFAULT_MODEL = "anthropic:claude-sonnet-4-5"
     _DEFAULT_PROJECT_CANDIDATES = "/workspace:/app:/workspaces:/root/project"
     _INCLUDE_PATHS: Sequence[str] = (
@@ -194,22 +204,51 @@ class MuxAgent(BaseInstalledAgent):
             target_path=target_path,
         )
 
+    def _agent_version(self) -> str:
+        version_method = getattr(self, "version", None)
+        if callable(version_method):
+            return version_method() or ""
+        version_value = getattr(self, "_version", "")
+        return version_value if isinstance(version_value, str) else ""
+
+    def _write_setup_script(self) -> Path:
+        setup_script = self._install_agent_template_path.read_text().replace(
+            "{{ version if version is not none else '' }}",
+            self._agent_version(),
+        )
+        setup_path = self.logs_dir / self._SETUP_SCRIPT_NAME
+        setup_path.write_text(setup_script)
+        return setup_path
+
+    async def install(self, environment: BaseEnvironment) -> None:
+        """Run the staged mux setup script inside the task environment."""
+        # The setup script may install apt packages and writes under /opt, so run
+        # it as root even if Harbor's default agent user changes.
+        result = await environment.exec(
+            command=f"bash /installed-agent/{self._SETUP_SCRIPT_NAME}",
+            env=self._env,
+            user="root",
+        )
+        if result.return_code != 0:
+            raise RuntimeError(
+                "mux setup failed "
+                f"(exit {result.return_code}):\nstdout: {result.stdout}\nstderr: {result.stderr}"
+            )
+
     async def setup(self, environment: BaseEnvironment) -> None:
-        """Override setup to stage payload first, then run install template."""
+        """Stage the mux payload before installing it in the task environment."""
         env = self._env
 
-        # Create /installed-agent directory (normally done by super().setup(),
-        # but we need it to exist before uploading files)
-        await environment.exec(command="mkdir -p /installed-agent")
+        # Harbor no longer renders installed-agent templates for custom agents.
+        # Stage the rendered script ourselves so scheduled tbench runs are not
+        # coupled to Harbor internals that have changed over time.
+        await environment.exec(command="mkdir -p /installed-agent", user="root")
 
-        # Build and stage the mux app archive BEFORE super().setup() runs the
-        # install template, which extracts the archive and runs chmod on runner
         if not self._archive_bytes:
             self._archive_bytes = build_app_archive(
                 self._repo_root, self._INCLUDE_PATHS
             )
 
-        # Write archive to logs_dir and upload
         archive_path = self.logs_dir / self._ARCHIVE_NAME
         archive_path.write_bytes(self._archive_bytes)
         await environment.upload_file(
@@ -217,32 +256,29 @@ class MuxAgent(BaseInstalledAgent):
             target_path=f"/installed-agent/{self._ARCHIVE_NAME}",
         )
 
-        # Upload runner script
         await environment.upload_file(
             source_path=self._runner_path,
             target_path=f"/installed-agent/{self._RUNNER_NAME}",
         )
 
-        # Now run parent setup which executes mux_setup.sh.j2 template
-        # (extracts archive, installs bun/deps, chmod +x runner)
-        await super().setup(environment)
+        await environment.upload_file(
+            source_path=self._write_setup_script(),
+            target_path=f"/installed-agent/{self._SETUP_SCRIPT_NAME}",
+        )
+
+        await self.install(environment)
 
         # Optionally seed the sandbox with providers.jsonc from the host machine.
         # This is required for OAuth-only configs where env var API keys are absent.
         await self._stage_providers_config(environment, env)
 
-        # Store environment reference for token extraction later
+        # Store environment reference for token extraction later.
         self._last_environment = environment
 
-    def create_run_agent_commands(self, instruction: str) -> list[ExecInput]:
+    def create_run_agent_commands(self, instruction: str) -> list[_AgentCommand]:
         escaped = shlex.quote(instruction)
         command = f"bash /installed-agent/{self._RUNNER_NAME} {escaped}"
-        return [
-            ExecInput(
-                command=command,
-                env=self._env,
-            )
-        ]
+        return [_AgentCommand(command=command, env=self._env)]
 
     async def run(
         self,


### PR DESCRIPTION
> Mux working on behalf of Mike.

## Summary
Fixes the scheduled Terminal-Bench CI path so it can run against the current Harbor and Daytona APIs instead of failing before results are produced.

## Background
Nightly Terminal-Bench has been failing in the smoke job before benchmark output is written. The workflow picked up upstream Harbor changes through an unpinned `uvx harbor run`: `--task-name` was removed, `ExecInput` is no longer exported, and installed-agent setup templates are no longer rendered by the base class. A real smoke dispatch on this PR also showed the pinned package must include Harbor's Daytona extra, and that the workflow must preserve `make` failures through `tee`.

## Implementation
- Pins `benchmark-terminal` to `harbor[daytona]==0.6.4` by default while leaving `TB_HARBOR_PACKAGE` as an override.
- Preserves `make benchmark-terminal` failures through `tee` with `set -o pipefail`.
- Uses Harbor's current `--include-task-name` dataset filter for smoke task selection.
- Stages and runs the mux setup script directly from `MuxAgent.setup()` so the agent no longer depends on Harbor's removed template hook.
- Runs the setup script as root because it may install apt packages and write under `/opt`.
- Replaces the removed `ExecInput` import with a tiny local command shape.
- Paginates Daytona sandbox listing in snapshot and cleanup steps so high-concurrency runs do not leak stopped sandboxes.

## Validation
- `python3 -m py_compile benchmarks/terminal_bench/mux_agent.py`
- Stub import test for the current Harbor installed-agent shape without `ExecInput`
- `make -n benchmark-terminal TB_TASK_NAMES='chess-best-move' TB_MODEL='anthropic/claude-sonnet-4-5' TB_ENV=daytona TB_CONCURRENCY=1 TB_TIMEOUT=1800`
- `UV_PYTHON=3.12 /home/coder/.local/bin/uvx --from 'harbor[daytona]==0.6.4' harbor run -h`
- `make fmt-check`
- `make static-check`
- GitHub Actions smoke: `Terminal-Bench` workflow_dispatch on `mike/fix-tbench-harbor-ci`, run `25373484832`, `terminal-bench@2.0`, `chess-best-move`, `env=daytona`, `anthropic/claude-sonnet-4-5`, completed successfully and uploaded 1 row to `mux-benchmarks.benchmarks.tbench_results`.

## Risks
Low to moderate. This touches only the benchmark workflow and Terminal-Bench adapter path. The main product runtime is not affected. The direct smoke run confirms the one-task Daytona benchmark and BigQuery upload path work on this branch.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$6.49`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=6.49 -->
