### PR TITLE
fix: watch providers.jsonc for external edits so UI refreshes without restart

### DIFF
--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -1886,10 +1886,18 @@ export class Config {
    * creates (first-time manual edit) are also detected on all platforms.
    */
   watchProvidersFile(callback: () => void): () => void {
+    // The mux home directory may not exist on a fresh install. Create it so
+    // fs.watch doesn't throw ENOENT; the directory being empty is fine.
+    if (!fs.existsSync(this.rootDir)) {
+      ensurePrivateDirSync(this.rootDir);
+    }
+
     const filename = path.basename(this.providersFile);
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
-    const watcher = fs.watch(this.rootDir, (_eventType, changedFilename) => {
+    // persistent: false so the watcher doesn't prevent the process (or Jest)
+    // from exiting when nothing else is keeping the event loop alive.
+    const watcher = fs.watch(this.rootDir, { persistent: false }, (_eventType, changedFilename) => {
       if (changedFilename !== filename) return;
       if (debounceTimer) clearTimeout(debounceTimer);
       debounceTimer = setTimeout(() => {

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -1886,12 +1886,6 @@ export class Config {
    * creates (first-time manual edit) are also detected on all platforms.
    */
   watchProvidersFile(callback: () => void): () => void {
-    // The mux home directory may not exist on a fresh install. Create it so
-    // fs.watch doesn't throw ENOENT; the directory being empty is fine.
-    if (!fs.existsSync(this.rootDir)) {
-      ensurePrivateDirSync(this.rootDir);
-    }
-
     const filename = path.basename(this.providersFile);
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -1903,13 +1897,22 @@ export class Config {
       }, 300);
     };
 
-    // fs.watch can throw for reasons beyond ENOENT — network filesystems
-    // (NFS/SMB) and watch-limit exhaustion (ENOSPC on Linux) are the common
-    // ones. Degrade gracefully: log once, return a no-op cleanup, and let
-    // the rest of provider config keep working. The UI just won't auto-
-    // refresh on manual edits in that environment (same as before this PR).
+    // Anything inside this block can fail in restricted environments:
+    //   - ensurePrivateDirSync: read-only filesystem, unwritable MUX_ROOT
+    //   - fs.watch: ENOENT, network filesystems (NFS/SMB), watch-limit
+    //     exhaustion (ENOSPC on Linux), unsupported virtualized mounts.
+    // We degrade gracefully in every case: log once, return a no-op
+    // cleanup, and let the rest of provider config keep working. The UI
+    // just won't auto-refresh on manual edits in that environment (same
+    // as the pre-PR behaviour).
     let watcher: fs.FSWatcher;
     try {
+      // The mux home directory may not exist on a fresh install. Create it
+      // so fs.watch doesn't throw ENOENT; the directory being empty is fine.
+      if (!fs.existsSync(this.rootDir)) {
+        ensurePrivateDirSync(this.rootDir);
+      }
+
       // persistent: false so the watcher doesn't prevent the process (or
       // Jest) from exiting when nothing else is keeping the event loop alive.
       watcher = fs.watch(this.rootDir, { persistent: false }, (_eventType, changedFilename) => {
@@ -1927,7 +1930,7 @@ export class Config {
         error
       );
       const noop = (): void => {
-        // Nothing to clean up — fs.watch never started.
+        // Nothing to clean up — watcher setup never completed.
       };
       return noop;
     }

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -1879,6 +1879,32 @@ export class Config {
   }
 
   /**
+   * Watch providers.jsonc for external edits. Fires callback (debounced 300 ms)
+   * on any create/modify/delete event. Returns a cleanup function.
+   *
+   * We watch the parent directory rather than the file directly so that
+   * creates (first-time manual edit) are also detected on all platforms.
+   */
+  watchProvidersFile(callback: () => void): () => void {
+    const filename = path.basename(this.providersFile);
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const watcher = fs.watch(this.rootDir, (_eventType, changedFilename) => {
+      if (changedFilename !== filename) return;
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        debounceTimer = null;
+        callback();
+      }, 300);
+    });
+
+    return () => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      watcher.close();
+    };
+  }
+
+  /**
    * Save providers configuration to JSONC file
    * @param config The providers configuration to save
    */

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -1879,15 +1879,23 @@ export class Config {
   }
 
   /**
-   * Return the providers.jsonc mtime in ms, or null if the file doesn't
-   * exist or can't be stat'd. Used as a per-write fingerprint so callers
-   * can distinguish between watcher events triggered by their own saves
-   * versus genuine external edits without resorting to a blanket time
-   * window.
+   * Return a content fingerprint (sha256) of providers.jsonc, or null if
+   * the file doesn't exist or can't be read. Used by callers to
+   * distinguish between watcher events triggered by their own saves
+   * versus genuine external edits.
+   *
+   * We hash the file contents rather than comparing mtime: filesystems
+   * with coarse timestamp granularity (FAT, some network mounts) can
+   * bucket two distinct writes into the same `mtimeMs`, which would let
+   * a real external edit be silently suppressed. If two writes happen
+   * to produce byte-identical content, suppressing the refresh is a
+   * no-op anyway, so content equality is the safest possible self-
+   * write signal.
    */
-  getProvidersFileMtimeMs(): number | null {
+  getProvidersFileFingerprint(): string | null {
     try {
-      return fs.statSync(this.providersFile).mtimeMs;
+      const contents = fs.readFileSync(this.providersFile);
+      return crypto.createHash("sha256").update(contents).digest("hex");
     } catch {
       return null;
     }

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -1895,16 +1895,42 @@ export class Config {
     const filename = path.basename(this.providersFile);
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
-    // persistent: false so the watcher doesn't prevent the process (or Jest)
-    // from exiting when nothing else is keeping the event loop alive.
-    const watcher = fs.watch(this.rootDir, { persistent: false }, (_eventType, changedFilename) => {
-      if (changedFilename !== filename) return;
+    const fire = (): void => {
       if (debounceTimer) clearTimeout(debounceTimer);
       debounceTimer = setTimeout(() => {
         debounceTimer = null;
         callback();
       }, 300);
-    });
+    };
+
+    // fs.watch can throw for reasons beyond ENOENT — network filesystems
+    // (NFS/SMB) and watch-limit exhaustion (ENOSPC on Linux) are the common
+    // ones. Degrade gracefully: log once, return a no-op cleanup, and let
+    // the rest of provider config keep working. The UI just won't auto-
+    // refresh on manual edits in that environment (same as before this PR).
+    let watcher: fs.FSWatcher;
+    try {
+      // persistent: false so the watcher doesn't prevent the process (or
+      // Jest) from exiting when nothing else is keeping the event loop alive.
+      watcher = fs.watch(this.rootDir, { persistent: false }, (_eventType, changedFilename) => {
+        // changedFilename can be null on some platforms/kernels (notably
+        // older macOS FSEvents). When we can't tell which file changed,
+        // assume providers.jsonc might have and let the consumer re-fetch
+        // — better an extra refresh than a missed one, since this is the
+        // exact scenario the feature is meant to fix.
+        if (changedFilename != null && changedFilename !== filename) return;
+        fire();
+      });
+    } catch (error) {
+      log.warn(
+        `Could not watch providers.jsonc for external edits (${this.rootDir}); manual edits will require a restart to take effect:`,
+        error
+      );
+      const noop = (): void => {
+        // Nothing to clean up — fs.watch never started.
+      };
+      return noop;
+    }
 
     return () => {
       if (debounceTimer) clearTimeout(debounceTimer);

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -1879,6 +1879,21 @@ export class Config {
   }
 
   /**
+   * Return the providers.jsonc mtime in ms, or null if the file doesn't
+   * exist or can't be stat'd. Used as a per-write fingerprint so callers
+   * can distinguish between watcher events triggered by their own saves
+   * versus genuine external edits without resorting to a blanket time
+   * window.
+   */
+  getProvidersFileMtimeMs(): number | null {
+    try {
+      return fs.statSync(this.providersFile).mtimeMs;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * Watch providers.jsonc for external edits. Fires callback (debounced 300 ms)
    * on any create/modify/delete event. Returns a cleanup function.
    *
@@ -1923,6 +1938,29 @@ export class Config {
         // exact scenario the feature is meant to fix.
         if (changedFilename != null && changedFilename !== filename) return;
         fire();
+      });
+
+      // Without an 'error' listener, FSWatcher errors emit on the global
+      // 'uncaughtException' path and can terminate the process (e.g. if the
+      // mux home directory is removed or unmounted after startup). Handle
+      // it locally: degrade to "no live refresh" the same way we do when
+      // setup itself fails. The watcher is dead after an error, so we
+      // close it defensively and clear any pending debounce so the
+      // cleanup function returned below remains a safe no-op.
+      watcher.on("error", (error) => {
+        log.warn(
+          `providers.jsonc watcher error (${this.rootDir}); live refresh disabled until restart:`,
+          error
+        );
+        if (debounceTimer) {
+          clearTimeout(debounceTimer);
+          debounceTimer = null;
+        }
+        try {
+          watcher.close();
+        } catch {
+          // Watcher may already be torn down by the OS — nothing to do.
+        }
       });
     } catch (error) {
       log.warn(

--- a/src/node/services/providerService.ts
+++ b/src/node/services/providerService.ts
@@ -132,6 +132,7 @@ export class ProviderService {
   private readonly policyService: PolicyService | null;
   private readonly emitter = new EventEmitter();
   private lastWarnedShadowedCustomProviderIds: Set<string> | null = null;
+  private readonly stopWatchingProvidersFile: () => void;
 
   constructor(
     private readonly config: Config,
@@ -142,7 +143,18 @@ export class ProviderService {
     // Avoid noisy MaxListenersExceededWarning for normal usage.
     this.emitter.setMaxListeners(50);
     // Notify subscribers when providers.jsonc is edited externally (e.g. manual edits).
-    this.config.watchProvidersFile(() => this.notifyConfigChanged());
+    this.stopWatchingProvidersFile = this.config.watchProvidersFile(() =>
+      this.notifyConfigChanged()
+    );
+  }
+
+  /**
+   * Release long-lived OS handles (e.g. the providers.jsonc file watcher).
+   * Called by ServiceContainer.dispose() during shutdown and by tests.
+   */
+  dispose(): void {
+    this.stopWatchingProvidersFile();
+    this.emitter.removeAllListeners();
   }
 
   /**

--- a/src/node/services/providerService.ts
+++ b/src/node/services/providerService.ts
@@ -141,6 +141,8 @@ export class ProviderService {
     // The provider config subscription may have many concurrent listeners (e.g. multiple windows).
     // Avoid noisy MaxListenersExceededWarning for normal usage.
     this.emitter.setMaxListeners(50);
+    // Notify subscribers when providers.jsonc is edited externally (e.g. manual edits).
+    this.config.watchProvidersFile(() => this.notifyConfigChanged());
   }
 
   /**

--- a/src/node/services/providerService.ts
+++ b/src/node/services/providerService.ts
@@ -133,12 +133,15 @@ export class ProviderService {
   private readonly emitter = new EventEmitter();
   private lastWarnedShadowedCustomProviderIds: Set<string> | null = null;
   private readonly stopWatchingProvidersFile: () => void;
-  // Fingerprint of providers.jsonc immediately after the last in-app save.
-  // The file watcher uses this to distinguish its own write (mtime matches)
-  // from an external edit (mtime differs). Time-based suppression would
-  // silently drop external edits made within the dedupe window; mtime
-  // comparison only suppresses the exact event we caused.
-  private lastSelfWriteMtimeMs: number | null = null;
+  // Content-hash fingerprint of providers.jsonc immediately after the last
+  // in-app save. The watcher callback re-hashes the file when it fires and
+  // skips notification only when the hash still matches — i.e. nothing
+  // changed on disk relative to our last known write. Content equality is
+  // a stronger signal than mtime: filesystems with coarse timestamp
+  // granularity (FAT, some network mounts) can collide on mtimeMs across
+  // distinct writes, and an external edit that produces byte-identical
+  // contents is a no-op anyway.
+  private lastSelfWriteFingerprint: string | null = null;
 
   constructor(
     private readonly config: Config,
@@ -152,18 +155,18 @@ export class ProviderService {
     // manual edits). Skip the redundant watcher event that fires ~300 ms
     // after every in-app save — mutation paths already invoke
     // notifyConfigChanged() directly. We identify a self-write by
-    // comparing the file's current mtime against the mtime captured by
-    // notifyFromMutation(); a genuine external edit between the in-app
-    // save and the watcher fire will always change mtime, so it still
-    // gets through.
+    // comparing the file's current content fingerprint (sha256) against
+    // the fingerprint captured by notifyFromMutation(); any external
+    // edit that changes the bytes between the in-app save and the
+    // watcher fire produces a different fingerprint and is forwarded.
     this.stopWatchingProvidersFile = this.config.watchProvidersFile(() => {
-      const expected = this.lastSelfWriteMtimeMs;
-      const current = this.config.getProvidersFileMtimeMs();
+      const expected = this.lastSelfWriteFingerprint;
+      const current = this.config.getProvidersFileFingerprint();
       if (expected !== null && current !== null && current === expected) {
-        // This watcher fire corresponds to our own write. Clear the
-        // fingerprint so the next event (whether self or external)
-        // is evaluated freshly.
-        this.lastSelfWriteMtimeMs = null;
+        // This watcher fire corresponds to our own write (or a benign
+        // no-op external save with identical bytes). Clear the
+        // fingerprint so the next event is evaluated freshly.
+        this.lastSelfWriteFingerprint = null;
         return;
       }
       this.notifyConfigChanged();
@@ -200,13 +203,14 @@ export class ProviderService {
 
   /**
    * Called by in-app mutation methods after writing providers.jsonc.
-   * Captures the file's post-write mtime so the watcher callback can
-   * recognise — and skip — the redundant notification it would
-   * otherwise fire ~300 ms later. External edits change mtime and
-   * therefore are never accidentally suppressed.
+   * Captures a content-hash fingerprint of the file we just wrote so
+   * the watcher callback can recognise — and skip — the redundant
+   * notification it would otherwise fire ~300 ms later. Any external
+   * edit produces a different fingerprint and is therefore never
+   * accidentally suppressed.
    */
   private notifyFromMutation(): void {
-    this.lastSelfWriteMtimeMs = this.config.getProvidersFileMtimeMs();
+    this.lastSelfWriteFingerprint = this.config.getProvidersFileFingerprint();
     this.notifyConfigChanged();
   }
 

--- a/src/node/services/providerService.ts
+++ b/src/node/services/providerService.ts
@@ -133,10 +133,12 @@ export class ProviderService {
   private readonly emitter = new EventEmitter();
   private lastWarnedShadowedCustomProviderIds: Set<string> | null = null;
   private readonly stopWatchingProvidersFile: () => void;
-  // Tracks when the last in-app mutation wrote to providers.jsonc and fired
-  // notifyConfigChanged(). Used to suppress the redundant watcher event that
-  // arrives ~300 ms later for that same write.
-  private lastMutationNotifyTime = 0;
+  // Fingerprint of providers.jsonc immediately after the last in-app save.
+  // The file watcher uses this to distinguish its own write (mtime matches)
+  // from an external edit (mtime differs). Time-based suppression would
+  // silently drop external edits made within the dedupe window; mtime
+  // comparison only suppresses the exact event we caused.
+  private lastSelfWriteMtimeMs: number | null = null;
 
   constructor(
     private readonly config: Config,
@@ -146,12 +148,24 @@ export class ProviderService {
     // The provider config subscription may have many concurrent listeners (e.g. multiple windows).
     // Avoid noisy MaxListenersExceededWarning for normal usage.
     this.emitter.setMaxListeners(50);
-    // Notify subscribers when providers.jsonc is edited externally (e.g. manual
-    // edits). Skip when the event was triggered by our own in-app save — the
-    // mutation already called notifyConfigChanged() directly, so the watcher
-    // firing ~300 ms later would be a duplicate refresh.
+    // Notify subscribers when providers.jsonc is edited externally (e.g.
+    // manual edits). Skip the redundant watcher event that fires ~300 ms
+    // after every in-app save — mutation paths already invoke
+    // notifyConfigChanged() directly. We identify a self-write by
+    // comparing the file's current mtime against the mtime captured by
+    // notifyFromMutation(); a genuine external edit between the in-app
+    // save and the watcher fire will always change mtime, so it still
+    // gets through.
     this.stopWatchingProvidersFile = this.config.watchProvidersFile(() => {
-      if (Date.now() - this.lastMutationNotifyTime < 1500) return;
+      const expected = this.lastSelfWriteMtimeMs;
+      const current = this.config.getProvidersFileMtimeMs();
+      if (expected !== null && current !== null && current === expected) {
+        // This watcher fire corresponds to our own write. Clear the
+        // fingerprint so the next event (whether self or external)
+        // is evaluated freshly.
+        this.lastSelfWriteMtimeMs = null;
+        return;
+      }
       this.notifyConfigChanged();
     });
   }
@@ -186,11 +200,13 @@ export class ProviderService {
 
   /**
    * Called by in-app mutation methods after writing providers.jsonc.
-   * Records the time so the file-watcher callback can suppress the
-   * redundant notification it would otherwise fire ~300 ms later.
+   * Captures the file's post-write mtime so the watcher callback can
+   * recognise — and skip — the redundant notification it would
+   * otherwise fire ~300 ms later. External edits change mtime and
+   * therefore are never accidentally suppressed.
    */
   private notifyFromMutation(): void {
-    this.lastMutationNotifyTime = Date.now();
+    this.lastSelfWriteMtimeMs = this.config.getProvidersFileMtimeMs();
     this.notifyConfigChanged();
   }
 

--- a/src/node/services/providerService.ts
+++ b/src/node/services/providerService.ts
@@ -133,6 +133,10 @@ export class ProviderService {
   private readonly emitter = new EventEmitter();
   private lastWarnedShadowedCustomProviderIds: Set<string> | null = null;
   private readonly stopWatchingProvidersFile: () => void;
+  // Tracks when the last in-app mutation wrote to providers.jsonc and fired
+  // notifyConfigChanged(). Used to suppress the redundant watcher event that
+  // arrives ~300 ms later for that same write.
+  private lastMutationNotifyTime = 0;
 
   constructor(
     private readonly config: Config,
@@ -142,10 +146,14 @@ export class ProviderService {
     // The provider config subscription may have many concurrent listeners (e.g. multiple windows).
     // Avoid noisy MaxListenersExceededWarning for normal usage.
     this.emitter.setMaxListeners(50);
-    // Notify subscribers when providers.jsonc is edited externally (e.g. manual edits).
-    this.stopWatchingProvidersFile = this.config.watchProvidersFile(() =>
-      this.notifyConfigChanged()
-    );
+    // Notify subscribers when providers.jsonc is edited externally (e.g. manual
+    // edits). Skip when the event was triggered by our own in-app save — the
+    // mutation already called notifyConfigChanged() directly, so the watcher
+    // firing ~300 ms later would be a duplicate refresh.
+    this.stopWatchingProvidersFile = this.config.watchProvidersFile(() => {
+      if (Date.now() - this.lastMutationNotifyTime < 1500) return;
+      this.notifyConfigChanged();
+    });
   }
 
   /**
@@ -174,6 +182,16 @@ export class ProviderService {
   notifyConfigChanged(): void {
     this.lastWarnedShadowedCustomProviderIds = null;
     this.emitter.emit("configChanged");
+  }
+
+  /**
+   * Called by in-app mutation methods after writing providers.jsonc.
+   * Records the time so the file-watcher callback can suppress the
+   * redundant notification it would otherwise fire ~300 ms later.
+   */
+  private notifyFromMutation(): void {
+    this.lastMutationNotifyTime = Date.now();
+    this.notifyConfigChanged();
   }
 
   private listBuiltInProviders(): ProviderName[] {
@@ -570,7 +588,7 @@ export class ProviderService {
         };
       }
 
-      this.notifyConfigChanged();
+      this.notifyFromMutation();
       return { success: true, data: providerInfo };
     } catch (error) {
       return {
@@ -667,7 +685,7 @@ export class ProviderService {
     } catch (error) {
       // The provider is already deleted from providers.jsonc. Notify subscribers so they
       // re-sync even when durable model reference cleanup needs another attempt.
-      this.notifyConfigChanged();
+      this.notifyFromMutation();
       return {
         success: false,
         error: addErrorReason(
@@ -680,7 +698,7 @@ export class ProviderService {
       };
     }
 
-    this.notifyConfigChanged();
+    this.notifyFromMutation();
     return { success: true, data: undefined };
   }
 
@@ -800,7 +818,7 @@ export class ProviderService {
 
       providersConfig[provider].models = normalizedModels;
       this.config.saveProvidersConfig(providersConfig);
-      this.notifyConfigChanged();
+      this.notifyFromMutation();
 
       return { success: true, data: undefined };
     } catch (error) {
@@ -930,7 +948,7 @@ export class ProviderService {
 
       // Save updated config
       this.config.saveProvidersConfig(providersConfig);
-      this.notifyConfigChanged();
+      this.notifyFromMutation();
       await this.syncGatewayLifecycle(provider);
 
       return { success: true, data: undefined };
@@ -1040,7 +1058,7 @@ export class ProviderService {
 
       // Save updated config
       this.config.saveProvidersConfig(providersConfig);
-      this.notifyConfigChanged();
+      this.notifyFromMutation();
       await this.syncGatewayLifecycle(provider);
 
       return { success: true, data: undefined };

--- a/src/node/services/serviceContainer.ts
+++ b/src/node/services/serviceContainer.ts
@@ -543,6 +543,7 @@ export class ServiceContainer {
 
     this.copilotOauthService.dispose();
     this.serverAuthService.dispose();
+    this.providerService.dispose();
     await this.backgroundProcessManager.terminateAll();
   }
 }


### PR DESCRIPTION
## Summary

- Custom providers added manually to `~/.mux/providers.jsonc` never appeared in the UI because `notifyConfigChanged()` was only called after API mutations, not on external file changes
- Added `Config.watchProvidersFile()` — watches the mux home directory with `fs.watch`, debounced 300 ms, returns a cleanup fn
- Wired it into `ProviderService` constructor so any external edit to `providers.jsonc` immediately propagates to all `onConfigChanged` frontend subscribers

## Root cause

`ProviderService.list()` and `getConfig()` already read `providers.jsonc` fresh on every call, so the backend always had the right data. The missing piece was a signal to the frontend to re-fetch. `notifyConfigChanged()` emits that signal — but it was only called after in-app edits, leaving manual file edits invisible until restart.

## Test plan

- [ ] Add a custom provider entry to `~/.mux/providers.jsonc` while the app is running — it should appear in Settings → Providers within ~300 ms, no restart needed
- [ ] Remove the entry from the file — it should disappear from the UI within ~300 ms
- [ ] Verify built-in provider changes via the UI still work as before
- [ ] Confirm no `MaxListenersExceededWarning` noise in dev logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)