### PR TITLE
🤖 fix: show task_await elapsed timing

### DIFF
--- a/src/browser/features/Tools/Shared/ElapsedTimeDisplay.tsx
+++ b/src/browser/features/Tools/Shared/ElapsedTimeDisplay.tsx
@@ -3,13 +3,20 @@ import React, { useEffect, useRef } from "react";
 interface ElapsedTimeDisplayProps {
   startedAt: number | undefined;
   isActive: boolean;
+  prefix?: string;
+  separator?: string;
 }
 
 /**
  * Shared elapsed time display for tool headers.
  * Keeps requestAnimationFrame + per-second updates at the leaf so parent tool calls do not re-render.
  */
-export const ElapsedTimeDisplay: React.FC<ElapsedTimeDisplayProps> = ({ startedAt, isActive }) => {
+export const ElapsedTimeDisplay: React.FC<ElapsedTimeDisplayProps> = ({
+  startedAt,
+  isActive,
+  prefix = "",
+  separator = " • ",
+}) => {
   const elapsedRef = useRef(0);
   const frameRef = useRef<number | null>(null);
   const [, forceUpdate] = React.useReducer((x: number) => x + 1, 0);
@@ -57,5 +64,11 @@ export const ElapsedTimeDisplay: React.FC<ElapsedTimeDisplayProps> = ({ startedA
     return null;
   }
 
-  return <> • {Math.round(elapsedRef.current / 1000)}s</>;
+  return (
+    <>
+      {separator}
+      {prefix}
+      {Math.round(elapsedRef.current / 1000)}s
+    </>
+  );
 };

--- a/src/browser/features/Tools/TaskToolCall.test.tsx
+++ b/src/browser/features/Tools/TaskToolCall.test.tsx
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+import { GlobalWindow } from "happy-dom";
+
+import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
+
+void mock.module("./SubagentTranscriptDialog", () => ({
+  SubagentTranscriptDialog: () => null,
+}));
+
+void mock.module("./Shared/ElapsedTimeDisplay", () => ({
+  ElapsedTimeDisplay: ({
+    startedAt,
+    isActive,
+    prefix,
+    separator,
+  }: {
+    startedAt: number | undefined;
+    isActive: boolean;
+    prefix?: string;
+    separator?: string;
+  }) => (
+    <span
+      data-testid="elapsed-time"
+      data-active={String(isActive)}
+      data-prefix={prefix ?? ""}
+      data-separator={separator ?? " • "}
+      data-started-at={startedAt == null ? "missing" : String(startedAt)}
+    />
+  ),
+}));
+
+import { getToolComponent } from "./Shared/getToolComponent";
+
+const taskAwaitArgs = { task_ids: ["task-1"], timeout_secs: 70 };
+const TaskAwaitToolCall = getToolComponent("task_await", taskAwaitArgs);
+
+function renderTaskAwaitToolCall(props: Record<string, unknown> = {}) {
+  return render(
+    <TooltipProvider>
+      <TaskAwaitToolCall
+        args={taskAwaitArgs}
+        status="executing"
+        startedAt={1_700_000_000_000}
+        {...props}
+      />
+    </TooltipProvider>
+  );
+}
+
+describe("TaskAwaitToolCall", () => {
+  let originalWindow: typeof globalThis.window;
+  let originalDocument: typeof globalThis.document;
+
+  beforeEach(() => {
+    originalWindow = globalThis.window;
+    originalDocument = globalThis.document;
+
+    globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
+    globalThis.document = globalThis.window.document;
+  });
+
+  afterEach(() => {
+    cleanup();
+    mock.restore();
+    globalThis.window = originalWindow;
+    globalThis.document = originalDocument;
+  });
+
+  test("shows elapsed time while task_await is executing", () => {
+    const startedAt = 1_700_000_000_123;
+
+    const view = renderTaskAwaitToolCall({ startedAt });
+
+    const timer = view.getByTestId("elapsed-time");
+    expect(timer.dataset.active).toBe("true");
+    expect(timer.dataset.startedAt).toBe(String(startedAt));
+    expect(timer.dataset.prefix).toBe("elapsed ");
+    expect(timer.dataset.separator).toBe("");
+  });
+});

--- a/src/browser/features/Tools/TaskToolCall.tsx
+++ b/src/browser/features/Tools/TaskToolCall.tsx
@@ -55,6 +55,8 @@ import {
   normalizeTaskGroupLabel,
   type TaskGroupKind,
 } from "@/common/utils/tools/taskGroups";
+import { formatDuration } from "@/common/utils/formatDuration";
+import { ElapsedTimeDisplay } from "./Shared/ElapsedTimeDisplay";
 
 /**
  * Clean SVG icon for task tools - represents spawning/branching work
@@ -201,8 +203,34 @@ interface TaskRowProps {
   agentType?: string;
   title?: string;
   depth?: number;
+  startedAtMs?: number;
   className?: string;
 }
+
+function isTaskRowElapsedActive(status: string): boolean {
+  return status === "queued" || status === "running" || status === "awaiting_report";
+}
+
+const TaskRowElapsed: React.FC<{ startedAtMs: number | undefined; status: string }> = (props) => {
+  if (props.startedAtMs == null) {
+    return null;
+  }
+
+  if (isTaskRowElapsedActive(props.status)) {
+    return (
+      <span className="text-muted counter-nums text-[10px]">
+        <ElapsedTimeDisplay
+          startedAt={props.startedAtMs}
+          isActive={true}
+          separator=""
+          prefix="elapsed "
+        />
+      </span>
+    );
+  }
+
+  return null;
+};
 
 const TaskRow: React.FC<TaskRowProps> = (props) => (
   <div
@@ -217,6 +245,7 @@ const TaskRow: React.FC<TaskRowProps> = (props) => (
     {typeof props.depth === "number" && props.depth > 0 && (
       <span className="text-muted text-[10px]">depth: {props.depth}</span>
     )}
+    <TaskRowElapsed startedAtMs={props.startedAtMs} status={props.status} />
   </div>
 );
 
@@ -944,6 +973,7 @@ interface TaskAwaitToolCallProps {
   args: TaskAwaitToolArgs;
   result?: TaskAwaitToolSuccessResult;
   status?: ToolStatus;
+  startedAt?: number;
   taskReportLinking?: TaskReportLinking;
 }
 
@@ -951,6 +981,7 @@ export const TaskAwaitToolCall: React.FC<TaskAwaitToolCallProps> = ({
   args,
   result,
   status = "pending",
+  startedAt,
   taskReportLinking,
 }) => {
   const taskIds = args.task_ids;
@@ -986,6 +1017,7 @@ export const TaskAwaitToolCall: React.FC<TaskAwaitToolCallProps> = ({
           status: proc ? toTaskStatusFromBackgroundProcessStatus(proc.status) : "waiting",
           title: proc?.displayName ?? proc?.id,
           depth: 1,
+          startedAtMs: proc?.startTime,
         });
         continue;
       }
@@ -1008,6 +1040,7 @@ export const TaskAwaitToolCall: React.FC<TaskAwaitToolCallProps> = ({
           workspaceId && workspaceMetadata
             ? computeWorkspaceDepthFromRoot(workspaceId, taskId, workspaceMetadata)
             : undefined,
+        startedAtMs: parseWorkspaceCreatedAtMs(metadata.createdAt),
       });
     }
   }
@@ -1027,6 +1060,16 @@ export const TaskAwaitToolCall: React.FC<TaskAwaitToolCallProps> = ({
         <ExpandIcon expanded={expanded}>▶</ExpandIcon>
         <TaskIcon toolName="task_await" />
         <ToolName>task_await</ToolName>
+        {status === "executing" && (
+          <span className="text-pending counter-nums ml-2 text-[10px] whitespace-nowrap [@container(max-width:500px)]:hidden">
+            <ElapsedTimeDisplay
+              startedAt={startedAt}
+              isActive={true}
+              separator=""
+              prefix="elapsed "
+            />
+          </span>
+        )}
         {totalCount > 0 && (
           <span className="text-muted text-[10px]">
             {completedCount}/{totalCount} completed
@@ -1128,7 +1171,11 @@ const TaskAwaitResult: React.FC<{
         <TaskStatusBadge status={result.status} />
         {title && <span className="text-foreground text-[11px] font-medium">{title}</span>}
         {exitCode !== undefined && <span className="text-muted text-[10px]">exit {exitCode}</span>}
-        {elapsedMs !== undefined && <span className="text-muted text-[10px]">{elapsedMs}ms</span>}
+        {elapsedMs !== undefined && (
+          <span className="text-muted counter-nums text-[10px]">
+            took {formatDuration(elapsedMs)}
+          </span>
+        )}
         {note && (
           <Tooltip>
             <TooltipTrigger asChild>

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -93,6 +93,11 @@ export interface AgentTaskStatusLookup {
   taskStatus: AgentTaskStatus | null;
 }
 
+export interface AgentTaskTimestamps {
+  createdAt?: string;
+  reportedAt?: string;
+}
+
 export interface TaskCreateArgs {
   parentWorkspaceId: string;
   kind: TaskKind;
@@ -1905,6 +1910,21 @@ export class TaskService {
     const entry = findWorkspaceEntry(cfg, taskId);
     const status = entry?.workspace.taskStatus;
     return status ?? null;
+  }
+
+  getAgentTaskTimestamps(taskId: string): AgentTaskTimestamps | null {
+    assert(taskId.length > 0, "getAgentTaskTimestamps: taskId must be non-empty");
+
+    const cfg = this.config.loadConfigOrDefault();
+    const entry = findWorkspaceEntry(cfg, taskId);
+    if (!entry) {
+      return null;
+    }
+
+    return {
+      createdAt: entry.workspace.createdAt,
+      reportedAt: entry.workspace.reportedAt,
+    };
   }
 
   getAgentTaskStatuses(taskIds: string[]): Map<string, AgentTaskStatusLookup> {

--- a/src/node/services/tools/task_await.test.ts
+++ b/src/node/services/tools/task_await.test.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 
-import { describe, it, expect, mock } from "bun:test";
+import { describe, it, expect, mock, spyOn } from "bun:test";
 import type { ToolExecutionOptions } from "ai";
 
 import { createTaskAwaitTool } from "./task_await";
@@ -184,6 +184,74 @@ describe("task_await tool", () => {
         backgroundOnMessageQueued: true,
       })
     );
+  });
+
+  it("includes elapsed_ms for completed agent task results when timestamps are available", async () => {
+    using tempDir = new TestTempDir("test-task-await-tool-agent-elapsed-completed");
+    const baseConfig = createTestToolConfig(tempDir.path, { workspaceId: "parent-workspace" });
+
+    const taskService = {
+      listActiveDescendantAgentTaskIds: mock(() => ["t1"]),
+      isDescendantAgentTask: mock(() => Promise.resolve(true)),
+      waitForAgentReport: mock(() => Promise.resolve({ reportMarkdown: "ok" })),
+      getAgentTaskTimestamps: mock(() => ({
+        createdAt: "2026-01-01T00:00:00.000Z",
+        reportedAt: "2026-01-01T00:00:02.500Z",
+      })),
+    } as unknown as TaskService;
+
+    const tool = createTaskAwaitTool({ ...baseConfig, taskService });
+
+    const result: unknown = await Promise.resolve(
+      tool.execute!({ task_ids: ["t1"] }, mockToolCallOptions)
+    );
+
+    expect(result).toEqual({
+      results: [
+        {
+          status: "completed",
+          taskId: "t1",
+          reportMarkdown: "ok",
+          title: undefined,
+          elapsed_ms: 2500,
+        },
+      ],
+    });
+  });
+
+  it("includes elapsed_ms for active agent task results when timestamps are available", async () => {
+    using tempDir = new TestTempDir("test-task-await-tool-agent-elapsed-active");
+    const baseConfig = createTestToolConfig(tempDir.path, { workspaceId: "parent-workspace" });
+    const nowMs = Date.parse("2026-01-01T00:00:05.000Z");
+    const dateNowSpy = spyOn(Date, "now").mockReturnValue(nowMs);
+
+    try {
+      const waitForAgentReport = mock(() => {
+        throw new Error("waitForAgentReport should not be called for timeout_secs=0");
+      });
+      const taskService = {
+        listActiveDescendantAgentTaskIds: mock(() => ["t1"]),
+        isDescendantAgentTask: mock(() => Promise.resolve(true)),
+        getAgentTaskStatus: mock(() => "running" as const),
+        getAgentTaskTimestamps: mock(() => ({
+          createdAt: "2026-01-01T00:00:02.000Z",
+        })),
+        waitForAgentReport,
+      } as unknown as TaskService;
+
+      const tool = createTaskAwaitTool({ ...baseConfig, taskService });
+
+      const result: unknown = await Promise.resolve(
+        tool.execute!({ timeout_secs: 0 }, mockToolCallOptions)
+      );
+
+      expect(result).toEqual({
+        results: [{ status: "running", taskId: "t1", elapsed_ms: 3000 }],
+      });
+      expect(waitForAgentReport).toHaveBeenCalledTimes(0);
+    } finally {
+      dateNowSpy.mockRestore();
+    }
   });
 
   it("does not list background bash tasks when explicit agent task IDs are valid", async () => {

--- a/src/node/services/tools/task_await.ts
+++ b/src/node/services/tools/task_await.ts
@@ -16,6 +16,7 @@ import { getErrorMessage } from "@/common/utils/errors";
 import {
   ForegroundWaitBackgroundedError,
   type AgentTaskStatusLookup,
+  type AgentTaskTimestamps,
 } from "@/node/services/taskService";
 
 function coerceTimeoutMs(timeoutSecs: unknown): number | undefined {
@@ -23,6 +24,31 @@ function coerceTimeoutMs(timeoutSecs: unknown): number | undefined {
   if (timeoutSecs < 0) return undefined;
   const timeoutMs = Math.floor(timeoutSecs * 1000);
   return timeoutMs;
+}
+
+function parseTimestampMs(value: string | undefined): number | undefined {
+  if (value == null) {
+    return undefined;
+  }
+
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
+function getAgentTaskElapsedMs(
+  timestamps: AgentTaskTimestamps | null | undefined
+): number | undefined {
+  const createdAtMs = parseTimestampMs(timestamps?.createdAt);
+  if (createdAtMs == null) {
+    return undefined;
+  }
+
+  const endAtMs = parseTimestampMs(timestamps?.reportedAt) ?? Date.now();
+  return Math.max(0, endAtMs - createdAtMs);
+}
+
+function withElapsedMs(elapsedMs: number | undefined): { elapsed_ms?: number } {
+  return elapsedMs == null ? {} : { elapsed_ms: elapsedMs };
 }
 
 function buildTaskAwaitSequencingError(taskId: string, suggestedTaskIds: string[]) {
@@ -103,6 +129,11 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
         if (!config.workspaceSessionDir) return null;
         return await readSubagentGitPatchArtifact(config.workspaceSessionDir, childTaskId);
       };
+
+      // Agent task records currently store creation/report timestamps, but not a separate
+      // running-start timestamp, so this elapsed value intentionally includes queued time.
+      const getAgentTaskElapsedField = (taskId: string) =>
+        withElapsedMs(getAgentTaskElapsedMs(taskService.getAgentTaskTimestamps?.(taskId)));
 
       const descendantAgentTaskIds =
         typeof bulkFilter === "function"
@@ -217,7 +248,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
           if (timeoutMs === 0) {
             const status = taskService.getAgentTaskStatus(taskId);
             if (status === "queued" || status === "running" || status === "awaiting_report") {
-              return { status, taskId };
+              return { status, taskId, ...getAgentTaskElapsedField(taskId) };
             }
 
             // Best-effort: the task might already have a cached report (even if its workspace was
@@ -236,6 +267,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
                 taskId,
                 reportMarkdown: report.reportMarkdown,
                 title: report.title,
+                ...getAgentTaskElapsedField(taskId),
                 ...(gitFormatPatch ? { artifacts: { gitFormatPatch } } : {}),
               };
             } catch (error: unknown) {
@@ -261,6 +293,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
               taskId,
               reportMarkdown: report.reportMarkdown,
               title: report.title,
+              ...getAgentTaskElapsedField(taskId),
               ...(gitFormatPatch ? { artifacts: { gitFormatPatch } } : {}),
             };
           } catch (error: unknown) {
@@ -275,6 +308,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
               return {
                 status: normalizedStatus,
                 taskId,
+                ...getAgentTaskElapsedField(taskId),
                 note: "Task sent to background because a new message was queued. Use task_await to monitor progress.",
               };
             }
@@ -290,7 +324,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
             if (/timed out/i.test(message)) {
               const status = taskService.getAgentTaskStatus(taskId);
               if (status === "queued" || status === "running" || status === "awaiting_report") {
-                return { status, taskId };
+                return { status, taskId, ...getAgentTaskElapsedField(taskId) };
               }
               if (!status) {
                 return { status: "not_found" as const, taskId };


### PR DESCRIPTION
Summary

Add elapsed timing to task_await so users can see how long an await call has been running and how long completed sub-agent waits took.

Background

Bash tool calls already expose elapsed timing, but task_await only showed a generic executing state while waiting. That made long waits look stuck even when the task was still running.

Implementation

The task_await backend now surfaces elapsed_ms for sub-agent results from existing task timestamps. The task_await UI now shows live elapsed time while executing, shows row-level elapsed time for active awaited tasks when start timestamps are known, and formats completed elapsed values with the shared duration formatter.

Risks

Low. The backend change is additive because elapsed_ms was already accepted by the task_await result schema, and the UI change only adds optional timing labels around existing task_await rendering.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$17.34`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=17.34 -->
