### PR TITLE
🤖 fix: show unsupported attach_file outputs

### DIFF
--- a/src/browser/features/Tools/AttachFileToolCall.stories.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.stories.tsx
@@ -96,3 +96,16 @@ export const DisplayOnlyGenericFile: Story = {
     </ToolStoryShell>
   ),
 };
+
+export const FailedAttachment: Story = {
+  render: () => (
+    <ToolStoryShell>
+      <AttachFileToolCall
+        toolName="attach_file"
+        args={{ path: "missing.webm" }}
+        result={{ success: false, error: "File not found: /workspace/missing.webm" }}
+        status="failed"
+      />
+    </ToolStoryShell>
+  ),
+};

--- a/src/browser/features/Tools/AttachFileToolCall.stories.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.stories.tsx
@@ -1,0 +1,98 @@
+import type { ReactNode } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { createDisplayOnlyFilePart } from "@/common/utils/attachments/displayOnlyFileParts";
+import { AttachFileToolCall } from "@/browser/features/Tools/AttachFileToolCall";
+import { lightweightMeta } from "@/browser/stories/meta.js";
+
+const meta = {
+  ...lightweightMeta,
+  title: "App/Chat/Tools/AttachFile",
+  component: AttachFileToolCall,
+} satisfies Meta<typeof AttachFileToolCall>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const sampleBytes = "ZGlzcGxheS1vbmx5IGZpbGU=";
+
+function createAttachFileResult(file: ReturnType<typeof createDisplayOnlyFilePart>) {
+  return {
+    type: "content",
+    value: [
+      {
+        type: "text",
+        text: `[File shown to user: ${file.filename ?? file.mediaType}]`,
+      },
+      file,
+    ],
+  };
+}
+
+function ToolStoryShell(props: { children: ReactNode }) {
+  return (
+    <div className="bg-background p-6">
+      <div className="w-full max-w-2xl">{props.children}</div>
+    </div>
+  );
+}
+
+export const DisplayOnlyVideo: Story = {
+  render: () => (
+    <ToolStoryShell>
+      <AttachFileToolCall
+        toolName="attach_file"
+        args={{ path: "recording.webm" }}
+        result={createAttachFileResult(
+          createDisplayOnlyFilePart({
+            data: sampleBytes,
+            mediaType: "video/webm",
+            filename: "recording.webm",
+            size: 17_408,
+          })
+        )}
+        status="completed"
+      />
+    </ToolStoryShell>
+  ),
+};
+
+export const DisplayOnlyAudio: Story = {
+  render: () => (
+    <ToolStoryShell>
+      <AttachFileToolCall
+        toolName="attach_file"
+        args={{ path: "voice-note.mp3" }}
+        result={createAttachFileResult(
+          createDisplayOnlyFilePart({
+            data: sampleBytes,
+            mediaType: "audio/mpeg",
+            filename: "voice-note.mp3",
+            size: 8_192,
+          })
+        )}
+        status="completed"
+      />
+    </ToolStoryShell>
+  ),
+};
+
+export const DisplayOnlyGenericFile: Story = {
+  render: () => (
+    <ToolStoryShell>
+      <AttachFileToolCall
+        toolName="attach_file"
+        args={{ path: "archive.zip", filename: "support-bundle.zip" }}
+        result={createAttachFileResult(
+          createDisplayOnlyFilePart({
+            data: sampleBytes,
+            mediaType: "application/octet-stream",
+            filename: "support-bundle.zip",
+            size: 524_288,
+          })
+        )}
+        status="completed"
+      />
+    </ToolStoryShell>
+  ),
+};

--- a/src/browser/features/Tools/AttachFileToolCall.stories.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.stories.tsx
@@ -14,6 +14,8 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+const samplePng =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
 const sampleBytes = "ZGlzcGxheS1vbmx5IGZpbGU=";
 
 function createAttachFileResult(file: ReturnType<typeof createDisplayOnlyFilePart>) {
@@ -36,6 +38,30 @@ function ToolStoryShell(props: { children: ReactNode }) {
     </div>
   );
 }
+
+export const ImageAttachment: Story = {
+  render: () => (
+    <ToolStoryShell>
+      <AttachFileToolCall
+        toolName="attach_file"
+        args={{ path: "screenshot.png" }}
+        result={{
+          type: "content",
+          value: [
+            { type: "text", text: "[Attachment prepared: screenshot.png]" },
+            {
+              type: "media",
+              data: samplePng,
+              mediaType: "image/png",
+              filename: "screenshot.png",
+            },
+          ],
+        }}
+        status="completed"
+      />
+    </ToolStoryShell>
+  ),
+};
 
 export const DisplayOnlyVideo: Story = {
   render: () => (

--- a/src/browser/features/Tools/AttachFileToolCall.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.tsx
@@ -24,6 +24,7 @@ import {
 } from "./Shared/ToolPrimitives";
 import { useToolExpansion, getStatusDisplay, type ToolStatus } from "./Shared/toolUtils";
 import { JsonHighlight } from "./Shared/HighlightedCode";
+import { redactToolResultAttachmentsForDisplay } from "./Shared/toolResultDisplay";
 import { ToolResultImages, extractImagesFromToolResult } from "./Shared/ToolResultImages";
 
 interface AttachFileToolCallProps {
@@ -47,43 +48,6 @@ function createSafeDataUrl(file: DisplayOnlyFilePart): string | null {
   }
 
   return `data:${normalizeAttachmentMediaType(file.mediaType)};base64,${file.data}`;
-}
-
-function filterResultForDisplay(result: unknown): unknown {
-  if (!isToolContentResult(result)) {
-    return result;
-  }
-
-  const filteredValue = result.value.map((item) => {
-    if (typeof item !== "object" || item === null) {
-      return item;
-    }
-
-    const itemType = (item as { type?: unknown }).type;
-    if (itemType === "media") {
-      const mediaItem = item as { mediaType?: string; filename?: string };
-      return {
-        type: "media",
-        mediaType: mediaItem.mediaType,
-        filename: mediaItem.filename,
-        data: "[attachment data]",
-      };
-    }
-
-    if (isDisplayOnlyFilePart(item)) {
-      return {
-        type: "display_file",
-        mediaType: item.mediaType,
-        filename: item.filename,
-        providerOptions: item.providerOptions,
-        data: "[display-only file data]",
-      };
-    }
-
-    return item;
-  });
-
-  return { ...result, value: filteredValue };
 }
 
 const DisplayOnlyFile: React.FC<{ file: DisplayOnlyFilePart }> = (props) => {
@@ -171,7 +135,7 @@ export const AttachFileToolCall: React.FC<AttachFileToolCallProps> = (props) => 
             <DetailSection>
               <DetailLabel>Result</DetailLabel>
               <DetailContent>
-                <JsonHighlight value={filterResultForDisplay(props.result)} />
+                <JsonHighlight value={redactToolResultAttachmentsForDisplay(props.result)} />
               </DetailContent>
             </DetailSection>
           )}

--- a/src/browser/features/Tools/AttachFileToolCall.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { Download, FileText } from "lucide-react";
 import {
+  getDisplayOnlyFileMetadata,
+  isDisplayOnlyFilePart,
+  type DisplayOnlyFilePart,
+} from "@/common/utils/attachments/displayOnlyFileParts";
+import {
   ToolContainer,
   ToolHeader,
   ExpandIcon,
@@ -24,19 +29,6 @@ interface AttachFileToolCallProps {
   status?: ToolStatus;
 }
 
-interface DisplayFilePart {
-  type: "file-data";
-  data: string;
-  mediaType: string;
-  filename?: string;
-  providerOptions: {
-    mux?: {
-      displayOnly?: boolean;
-      size?: number;
-    };
-  };
-}
-
 interface ContentResult {
   type: "content";
   value: unknown[];
@@ -51,45 +43,12 @@ function isContentResult(result: unknown): result is ContentResult {
   );
 }
 
-function getMuxProviderOptions(value: unknown): { displayOnly?: boolean; size?: number } | null {
-  if (typeof value !== "object" || value === null) {
-    return null;
-  }
-
-  const muxOptions = (value as Record<string, unknown>).mux;
-  if (typeof muxOptions !== "object" || muxOptions === null) {
-    return null;
-  }
-
-  const record = muxOptions as Record<string, unknown>;
-  return {
-    ...(typeof record.displayOnly === "boolean" ? { displayOnly: record.displayOnly } : {}),
-    ...(typeof record.size === "number" ? { size: record.size } : {}),
-  };
-}
-
-function isDisplayFilePart(value: unknown): value is DisplayFilePart {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-
-  const record = value as Record<string, unknown>;
-  const muxOptions = getMuxProviderOptions(record.providerOptions);
-  return (
-    record.type === "file-data" &&
-    typeof record.data === "string" &&
-    typeof record.mediaType === "string" &&
-    (record.filename === undefined || typeof record.filename === "string") &&
-    muxOptions?.displayOnly === true
-  );
-}
-
-function extractDisplayFilesFromToolResult(result: unknown): DisplayFilePart[] {
+function extractDisplayFilesFromToolResult(result: unknown): DisplayOnlyFilePart[] {
   if (!isContentResult(result)) {
     return [];
   }
 
-  return result.value.filter(isDisplayFilePart);
+  return result.value.filter(isDisplayOnlyFilePart);
 }
 
 function isValidBase64(data: string): boolean {
@@ -103,7 +62,7 @@ function getBaseMediaType(mediaType: string): string {
   return mediaType.toLowerCase().trim().split(";")[0] ?? "application/octet-stream";
 }
 
-function createSafeDataUrl(file: DisplayFilePart): string | null {
+function createSafeDataUrl(file: DisplayOnlyFilePart): string | null {
   if (!isValidBase64(file.data)) {
     return null;
   }
@@ -148,7 +107,7 @@ function filterResultForDisplay(result: unknown): unknown {
       };
     }
 
-    if (isDisplayFilePart(item)) {
+    if (isDisplayOnlyFilePart(item)) {
       return {
         type: "file-data",
         mediaType: item.mediaType,
@@ -164,11 +123,11 @@ function filterResultForDisplay(result: unknown): unknown {
   return { ...result, value: filteredValue };
 }
 
-const DisplayOnlyFile: React.FC<{ file: DisplayFilePart }> = (props) => {
+const DisplayOnlyFile: React.FC<{ file: DisplayOnlyFilePart }> = (props) => {
   const dataUrl = createSafeDataUrl(props.file);
   const baseMediaType = getBaseMediaType(props.file.mediaType);
   const label = props.file.filename ?? `Attachment (${baseMediaType})`;
-  const formattedSize = formatBytes(getMuxProviderOptions(props.file.providerOptions)?.size);
+  const formattedSize = formatBytes(getDisplayOnlyFileMetadata(props.file.providerOptions)?.size);
 
   return (
     <div className="border-border-light bg-dark mt-2 max-w-xl rounded border p-3">

--- a/src/browser/features/Tools/AttachFileToolCall.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.tsx
@@ -1,0 +1,274 @@
+import React from "react";
+import { Download, FileText } from "lucide-react";
+import {
+  ToolContainer,
+  ToolHeader,
+  ExpandIcon,
+  ToolIcon,
+  ToolName,
+  StatusIndicator,
+  ToolDetails,
+  DetailSection,
+  DetailLabel,
+  DetailContent,
+  LoadingDots,
+} from "./Shared/ToolPrimitives";
+import { useToolExpansion, getStatusDisplay, type ToolStatus } from "./Shared/toolUtils";
+import { JsonHighlight } from "./Shared/HighlightedCode";
+import { ToolResultImages, extractImagesFromToolResult } from "./Shared/ToolResultImages";
+
+interface AttachFileToolCallProps {
+  toolName: string;
+  args?: unknown;
+  result?: unknown;
+  status?: ToolStatus;
+}
+
+interface DisplayFilePart {
+  type: "file-data";
+  data: string;
+  mediaType: string;
+  filename?: string;
+  providerOptions: {
+    mux?: {
+      displayOnly?: boolean;
+      size?: number;
+    };
+  };
+}
+
+interface ContentResult {
+  type: "content";
+  value: unknown[];
+}
+
+function isContentResult(result: unknown): result is ContentResult {
+  return (
+    typeof result === "object" &&
+    result !== null &&
+    (result as { type?: unknown }).type === "content" &&
+    Array.isArray((result as { value?: unknown }).value)
+  );
+}
+
+function getMuxProviderOptions(value: unknown): { displayOnly?: boolean; size?: number } | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+
+  const muxOptions = (value as Record<string, unknown>).mux;
+  if (typeof muxOptions !== "object" || muxOptions === null) {
+    return null;
+  }
+
+  const record = muxOptions as Record<string, unknown>;
+  return {
+    ...(typeof record.displayOnly === "boolean" ? { displayOnly: record.displayOnly } : {}),
+    ...(typeof record.size === "number" ? { size: record.size } : {}),
+  };
+}
+
+function isDisplayFilePart(value: unknown): value is DisplayFilePart {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  const muxOptions = getMuxProviderOptions(record.providerOptions);
+  return (
+    record.type === "file-data" &&
+    typeof record.data === "string" &&
+    typeof record.mediaType === "string" &&
+    (record.filename === undefined || typeof record.filename === "string") &&
+    muxOptions?.displayOnly === true
+  );
+}
+
+function extractDisplayFilesFromToolResult(result: unknown): DisplayFilePart[] {
+  if (!isContentResult(result)) {
+    return [];
+  }
+
+  return result.value.filter(isDisplayFilePart);
+}
+
+function isValidBase64(data: string): boolean {
+  if (data.length > 15_000_000) {
+    return false;
+  }
+  return /^[A-Za-z0-9+/]*={0,2}$/.test(data);
+}
+
+function getBaseMediaType(mediaType: string): string {
+  return mediaType.toLowerCase().trim().split(";")[0] ?? "application/octet-stream";
+}
+
+function createSafeDataUrl(file: DisplayFilePart): string | null {
+  if (!isValidBase64(file.data)) {
+    return null;
+  }
+
+  return `data:${getBaseMediaType(file.mediaType)};base64,${file.data}`;
+}
+
+function formatBytes(bytes: number | undefined): string | null {
+  if (bytes == null) {
+    return null;
+  }
+
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function filterResultForDisplay(result: unknown): unknown {
+  if (!isContentResult(result)) {
+    return result;
+  }
+
+  const filteredValue = result.value.map((item) => {
+    if (typeof item !== "object" || item === null) {
+      return item;
+    }
+
+    const itemType = (item as { type?: unknown }).type;
+    if (itemType === "media") {
+      const mediaItem = item as { mediaType?: string; filename?: string };
+      return {
+        type: "media",
+        mediaType: mediaItem.mediaType,
+        filename: mediaItem.filename,
+        data: "[attachment data]",
+      };
+    }
+
+    if (isDisplayFilePart(item)) {
+      return {
+        type: "file-data",
+        mediaType: item.mediaType,
+        filename: item.filename,
+        providerOptions: item.providerOptions,
+        data: "[display-only file data]",
+      };
+    }
+
+    return item;
+  });
+
+  return { ...result, value: filteredValue };
+}
+
+const DisplayOnlyFile: React.FC<{ file: DisplayFilePart }> = (props) => {
+  const dataUrl = createSafeDataUrl(props.file);
+  const baseMediaType = getBaseMediaType(props.file.mediaType);
+  const label = props.file.filename ?? `Attachment (${baseMediaType})`;
+  const formattedSize = formatBytes(getMuxProviderOptions(props.file.providerOptions)?.size);
+
+  return (
+    <div className="border-border-light bg-dark mt-2 max-w-xl rounded border p-3">
+      <div className="mb-2 flex items-center gap-2 text-sm text-[var(--color-subtle)]">
+        <FileText className="h-4 w-4 shrink-0" />
+        <span className="truncate font-medium text-[var(--color-text)]">{label}</span>
+        <span className="counter-nums text-xs">{baseMediaType}</span>
+        {formattedSize != null && <span className="counter-nums text-xs">{formattedSize}</span>}
+      </div>
+
+      {dataUrl != null && baseMediaType.startsWith("video/") && (
+        <video controls src={dataUrl} className="max-h-80 max-w-full rounded" />
+      )}
+      {dataUrl != null && baseMediaType.startsWith("audio/") && (
+        <audio controls src={dataUrl} className="w-full" />
+      )}
+
+      <div className="mt-2 flex items-center gap-2 text-xs text-[var(--color-subtle)]">
+        <span>Shown to the user only; not sent to the model as a file attachment.</span>
+        {dataUrl != null && (
+          <a
+            href={dataUrl}
+            download={props.file.filename ?? "attachment"}
+            className="border-border-light hover:bg-surface flex items-center gap-1 rounded border px-2 py-1 text-[var(--color-text)]"
+          >
+            <Download className="h-3 w-3" />
+            Download
+          </a>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const AttachFileToolCall: React.FC<AttachFileToolCallProps> = (props) => {
+  const { expanded, toggleExpanded } = useToolExpansion();
+  const displayFiles = extractDisplayFilesFromToolResult(props.result);
+  const hasDisplayFiles = displayFiles.length > 0;
+  const hasDetails = props.args !== undefined || props.result !== undefined;
+  const images = extractImagesFromToolResult(props.result);
+  const hasImages = images.length > 0;
+  const shouldShowDetails = expanded || hasImages || hasDisplayFiles;
+
+  return (
+    <ToolContainer expanded={shouldShowDetails}>
+      <ToolHeader onClick={() => hasDetails && toggleExpanded()}>
+        {hasDetails && <ExpandIcon expanded={shouldShowDetails}>▶</ExpandIcon>}
+        <ToolIcon toolName={props.toolName} />
+        <ToolName>{props.toolName}</ToolName>
+        <StatusIndicator status={props.status ?? "pending"}>
+          {getStatusDisplay(props.status ?? "pending")}
+        </StatusIndicator>
+      </ToolHeader>
+
+      {hasImages && <ToolResultImages result={props.result} />}
+      {hasDisplayFiles && (
+        <div className="space-y-2">
+          {displayFiles.map((file, index) => (
+            <DisplayOnlyFile key={`${file.filename ?? file.mediaType}-${index}`} file={file} />
+          ))}
+        </div>
+      )}
+
+      {expanded && hasDetails && (
+        <ToolDetails>
+          {props.args !== undefined && (
+            <DetailSection>
+              <DetailLabel>Arguments</DetailLabel>
+              <DetailContent>
+                <JsonHighlight value={props.args} />
+              </DetailContent>
+            </DetailSection>
+          )}
+
+          {props.result !== undefined && (
+            <DetailSection>
+              <DetailLabel>Result</DetailLabel>
+              <DetailContent>
+                <JsonHighlight value={filterResultForDisplay(props.result)} />
+              </DetailContent>
+            </DetailSection>
+          )}
+
+          {props.status === "executing" && props.result === undefined && (
+            <DetailSection>
+              <DetailContent>
+                Waiting for result
+                <LoadingDots />
+              </DetailContent>
+            </DetailSection>
+          )}
+          {props.status === "redacted" && (
+            <DetailSection>
+              <DetailContent className="text-muted italic">
+                Output excluded from shared transcript
+              </DetailContent>
+            </DetailSection>
+          )}
+        </ToolDetails>
+      )}
+    </ToolContainer>
+  );
+};

--- a/src/browser/features/Tools/AttachFileToolCall.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.tsx
@@ -1,5 +1,9 @@
-import React from "react";
+import type React from "react";
 import { Download, FileText } from "lucide-react";
+import { isValidBase64AttachmentData } from "@/common/utils/attachments/base64";
+import { normalizeAttachmentMediaType } from "@/common/utils/attachments/supportedAttachmentMediaTypes";
+import { formatBytes } from "@/common/utils/formatBytes";
+import { isToolContentResult } from "@/common/utils/tools/toolContentResult";
 import {
   getDisplayOnlyFileMetadata,
   isDisplayOnlyFilePart,
@@ -29,65 +33,24 @@ interface AttachFileToolCallProps {
   status?: ToolStatus;
 }
 
-interface ContentResult {
-  type: "content";
-  value: unknown[];
-}
-
-function isContentResult(result: unknown): result is ContentResult {
-  return (
-    typeof result === "object" &&
-    result !== null &&
-    (result as { type?: unknown }).type === "content" &&
-    Array.isArray((result as { value?: unknown }).value)
-  );
-}
-
 function extractDisplayFilesFromToolResult(result: unknown): DisplayOnlyFilePart[] {
-  if (!isContentResult(result)) {
+  if (!isToolContentResult(result)) {
     return [];
   }
 
   return result.value.filter(isDisplayOnlyFilePart);
 }
 
-function isValidBase64(data: string): boolean {
-  if (data.length > 15_000_000) {
-    return false;
-  }
-  return /^[A-Za-z0-9+/]*={0,2}$/.test(data);
-}
-
-function getBaseMediaType(mediaType: string): string {
-  return mediaType.toLowerCase().trim().split(";")[0] ?? "application/octet-stream";
-}
-
 function createSafeDataUrl(file: DisplayOnlyFilePart): string | null {
-  if (!isValidBase64(file.data)) {
+  if (!isValidBase64AttachmentData(file.data)) {
     return null;
   }
 
-  return `data:${getBaseMediaType(file.mediaType)};base64,${file.data}`;
-}
-
-function formatBytes(bytes: number | undefined): string | null {
-  if (bytes == null) {
-    return null;
-  }
-
-  if (bytes < 1024) {
-    return `${bytes} B`;
-  }
-
-  if (bytes < 1024 * 1024) {
-    return `${(bytes / 1024).toFixed(1)} KB`;
-  }
-
-  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+  return `data:${normalizeAttachmentMediaType(file.mediaType)};base64,${file.data}`;
 }
 
 function filterResultForDisplay(result: unknown): unknown {
-  if (!isContentResult(result)) {
+  if (!isToolContentResult(result)) {
     return result;
   }
 
@@ -109,7 +72,7 @@ function filterResultForDisplay(result: unknown): unknown {
 
     if (isDisplayOnlyFilePart(item)) {
       return {
-        type: "file-data",
+        type: "display_file",
         mediaType: item.mediaType,
         filename: item.filename,
         providerOptions: item.providerOptions,
@@ -125,9 +88,10 @@ function filterResultForDisplay(result: unknown): unknown {
 
 const DisplayOnlyFile: React.FC<{ file: DisplayOnlyFilePart }> = (props) => {
   const dataUrl = createSafeDataUrl(props.file);
-  const baseMediaType = getBaseMediaType(props.file.mediaType);
+  const baseMediaType = normalizeAttachmentMediaType(props.file.mediaType);
   const label = props.file.filename ?? `Attachment (${baseMediaType})`;
-  const formattedSize = formatBytes(getDisplayOnlyFileMetadata(props.file.providerOptions)?.size);
+  const metadata = getDisplayOnlyFileMetadata(props.file.providerOptions);
+  const formattedSize = metadata?.size != null ? formatBytes(metadata.size) : null;
 
   return (
     <div className="border-border-light bg-dark mt-2 max-w-xl rounded border p-3">
@@ -139,14 +103,15 @@ const DisplayOnlyFile: React.FC<{ file: DisplayOnlyFilePart }> = (props) => {
       </div>
 
       {dataUrl != null && baseMediaType.startsWith("video/") && (
-        <video controls src={dataUrl} className="max-h-80 max-w-full rounded" />
+        <video controls src={dataUrl} title={label} className="max-h-80 max-w-full rounded" />
       )}
       {dataUrl != null && baseMediaType.startsWith("audio/") && (
-        <audio controls src={dataUrl} className="w-full" />
+        <audio controls src={dataUrl} title={label} className="w-full" />
       )}
 
       <div className="mt-2 flex items-center gap-2 text-xs text-[var(--color-subtle)]">
         <span>Shown to the user only; not sent to the model as a file attachment.</span>
+        {dataUrl == null && <span>File data is unavailable for preview or download.</span>}
         {dataUrl != null && (
           <a
             href={dataUrl}
@@ -174,7 +139,7 @@ export const AttachFileToolCall: React.FC<AttachFileToolCallProps> = (props) => 
   return (
     <ToolContainer expanded={shouldShowDetails}>
       <ToolHeader onClick={() => hasDetails && toggleExpanded()}>
-        {hasDetails && <ExpandIcon expanded={shouldShowDetails}>▶</ExpandIcon>}
+        {hasDetails && <ExpandIcon expanded={expanded}>▶</ExpandIcon>}
         <ToolIcon toolName={props.toolName} />
         <ToolName>{props.toolName}</ToolName>
         <StatusIndicator status={props.status ?? "pending"}>

--- a/src/browser/features/Tools/GenericToolCall.tsx
+++ b/src/browser/features/Tools/GenericToolCall.tsx
@@ -15,6 +15,7 @@ import {
 } from "./Shared/ToolPrimitives";
 import { useToolExpansion, getStatusDisplay, type ToolStatus } from "./Shared/toolUtils";
 import { JsonHighlight } from "./Shared/HighlightedCode";
+import { redactToolResultAttachmentsForDisplay } from "./Shared/toolResultDisplay";
 import { ToolResultImages, extractImagesFromToolResult } from "./Shared/ToolResultImages";
 
 interface GenericToolCallProps {
@@ -22,33 +23,6 @@ interface GenericToolCallProps {
   args?: unknown;
   result?: unknown;
   status?: ToolStatus;
-}
-
-/**
- * Filter out attachment data from result for JSON display (to avoid showing huge payloads).
- * Replaces media content with a placeholder indicator while preserving lightweight metadata.
- */
-function filterResultForDisplay(result: unknown): unknown {
-  if (typeof result !== "object" || result === null) return result;
-
-  const contentResult = result as { type?: string; value?: unknown[] };
-  if (contentResult.type !== "content" || !Array.isArray(contentResult.value)) return result;
-
-  // Replace media entries with placeholder
-  const filteredValue = contentResult.value.map((item) => {
-    if (typeof item === "object" && item !== null && (item as { type?: string }).type === "media") {
-      const mediaItem = item as { mediaType?: string; filename?: string };
-      return {
-        type: "media",
-        mediaType: mediaItem.mediaType,
-        filename: mediaItem.filename,
-        data: "[attachment data]",
-      };
-    }
-    return item;
-  });
-
-  return { ...contentResult, value: filteredValue };
 }
 
 export const GenericToolCall: React.FC<GenericToolCallProps> = ({
@@ -93,7 +67,7 @@ export const GenericToolCall: React.FC<GenericToolCallProps> = ({
             <DetailSection>
               <DetailLabel>Result</DetailLabel>
               <DetailContent>
-                <JsonHighlight value={filterResultForDisplay(result)} />
+                <JsonHighlight value={redactToolResultAttachmentsForDisplay(result)} />
               </DetailContent>
             </DetailSection>
           )}

--- a/src/browser/features/Tools/Shared/ToolResultImages.tsx
+++ b/src/browser/features/Tools/Shared/ToolResultImages.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from "react";
+import { isValidBase64AttachmentData } from "@/common/utils/attachments/base64";
+import { isToolContentResult } from "@/common/utils/tools/toolContentResult";
 import { TooltipIfPresent } from "@/browser/components/Tooltip/Tooltip";
 import {
   Dialog,
@@ -16,12 +18,17 @@ interface MediaContent {
   mediaType: string;
 }
 
-/**
- * Structure of transformed MCP results that contain images
- */
-interface ContentResult {
-  type: "content";
-  value: Array<{ type: string; text?: string; data?: string; mediaType?: string }>;
+function isMediaContent(value: unknown): value is MediaContent {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    record.type === "media" &&
+    typeof record.data === "string" &&
+    typeof record.mediaType === "string"
+  );
 }
 
 /**
@@ -39,17 +46,6 @@ const ALLOWED_IMAGE_TYPES = new Set([
 ]);
 
 /**
- * Validate base64 string contains only valid characters.
- * Prevents injection of malicious content through invalid base64.
- */
-function isValidBase64(str: string): boolean {
-  // Base64 should only contain alphanumeric, +, /, and = for padding
-  // Also allow reasonable length (up to ~10MB decoded = ~13MB base64)
-  if (str.length > 15_000_000) return false;
-  return /^[A-Za-z0-9+/]*={0,2}$/.test(str);
-}
-
-/**
  * Sanitize and validate image data from MCP tool results.
  * Returns a safe data URL or null if validation fails.
  */
@@ -61,7 +57,7 @@ export function sanitizeImageData(mediaType: string, data: string): string | nul
   }
 
   // Validate base64 data
-  if (!isValidBase64(data)) {
+  if (!isValidBase64AttachmentData(data)) {
     return null;
   }
 
@@ -73,15 +69,9 @@ export function sanitizeImageData(mediaType: string, data: string): string | nul
  * Handles the transformed MCP result format: { type: "content", value: [...] }
  */
 export function extractImagesFromToolResult(result: unknown): MediaContent[] {
-  if (typeof result !== "object" || result === null) return [];
+  if (!isToolContentResult(result)) return [];
 
-  const contentResult = result as ContentResult;
-  if (contentResult.type !== "content" || !Array.isArray(contentResult.value)) return [];
-
-  return contentResult.value.filter(
-    (item): item is MediaContent =>
-      item.type === "media" && typeof item.data === "string" && typeof item.mediaType === "string"
-  );
+  return result.value.filter(isMediaContent);
 }
 
 interface ToolResultImagesProps {

--- a/src/browser/features/Tools/Shared/getToolComponent.ts
+++ b/src/browser/features/Tools/Shared/getToolComponent.ts
@@ -9,6 +9,7 @@ import { z, type ZodSchema } from "zod";
 import { TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
 
 import { AnalyticsQueryToolCall } from "../analyticsQuery/AnalyticsQueryToolCall";
+import { AttachFileToolCall } from "../AttachFileToolCall";
 import { AdvisorToolCall } from "../AdvisorToolCall";
 import { GenericToolCall } from "../GenericToolCall";
 import { BashToolCall } from "../BashToolCall";
@@ -71,7 +72,7 @@ const legacyStatusSetSchema = z.object({
 const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
   bash: { component: BashToolCall, schema: TOOL_DEFINITIONS.bash.schema },
   file_read: { component: FileReadToolCall, schema: TOOL_DEFINITIONS.file_read.schema },
-  attach_file: { component: GenericToolCall, schema: TOOL_DEFINITIONS.attach_file.schema },
+  attach_file: { component: AttachFileToolCall, schema: TOOL_DEFINITIONS.attach_file.schema },
   desktop_screenshot: {
     component: DesktopScreenshotToolCall,
     schema: TOOL_DEFINITIONS.desktop_screenshot.schema,

--- a/src/browser/features/Tools/Shared/toolResultDisplay.test.ts
+++ b/src/browser/features/Tools/Shared/toolResultDisplay.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "@jest/globals";
+import { redactToolResultAttachmentsForDisplay } from "./toolResultDisplay";
+
+describe("redactToolResultAttachmentsForDisplay", () => {
+  it("redacts media payloads", () => {
+    const result = redactToolResultAttachmentsForDisplay({
+      type: "content",
+      value: [
+        {
+          type: "media",
+          mediaType: "image/png",
+          filename: "screenshot.png",
+          data: "base64-image",
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      type: "content",
+      value: [
+        {
+          type: "media",
+          mediaType: "image/png",
+          filename: "screenshot.png",
+          data: "[attachment data]",
+        },
+      ],
+    });
+  });
+
+  it("redacts display-only file payloads", () => {
+    const result = redactToolResultAttachmentsForDisplay({
+      type: "content",
+      value: [
+        {
+          type: "display_file",
+          mediaType: "video/webm",
+          filename: "clip.webm",
+          data: "base64-video",
+          providerOptions: { mux: { displayOnly: true, size: 12 } },
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      type: "content",
+      value: [
+        {
+          type: "display_file",
+          mediaType: "video/webm",
+          filename: "clip.webm",
+          data: "[display-only file data]",
+          providerOptions: { mux: { displayOnly: true, size: 12 } },
+        },
+      ],
+    });
+  });
+
+  it("passes through non-attachment content", () => {
+    const input = {
+      type: "content",
+      value: [{ type: "text", text: "hello" }, { success: true }],
+    };
+
+    expect(redactToolResultAttachmentsForDisplay(input)).toEqual(input);
+  });
+});

--- a/src/browser/features/Tools/Shared/toolResultDisplay.ts
+++ b/src/browser/features/Tools/Shared/toolResultDisplay.ts
@@ -1,0 +1,39 @@
+import { isDisplayOnlyFilePart } from "@/common/utils/attachments/displayOnlyFileParts";
+import { isToolContentResult } from "@/common/utils/tools/toolContentResult";
+
+export function redactToolResultAttachmentsForDisplay(result: unknown): unknown {
+  if (!isToolContentResult(result)) {
+    return result;
+  }
+
+  const filteredValue = result.value.map((item) => {
+    if (typeof item !== "object" || item === null) {
+      return item;
+    }
+
+    const itemType = (item as { type?: unknown }).type;
+    if (itemType === "media") {
+      const mediaItem = item as { mediaType?: string; filename?: string };
+      return {
+        type: "media",
+        mediaType: mediaItem.mediaType,
+        filename: mediaItem.filename,
+        data: "[attachment data]",
+      };
+    }
+
+    if (isDisplayOnlyFilePart(item)) {
+      return {
+        type: "display_file",
+        mediaType: item.mediaType,
+        filename: item.filename,
+        providerOptions: item.providerOptions,
+        data: "[display-only file data]",
+      };
+    }
+
+    return item;
+  });
+
+  return { ...result, value: filteredValue };
+}

--- a/src/common/utils/attachments/base64.ts
+++ b/src/common/utils/attachments/base64.ts
@@ -1,0 +1,9 @@
+const MAX_ATTACHMENT_BASE64_CHARS = 15_000_000;
+
+export function isValidBase64AttachmentData(data: string): boolean {
+  if (data.length > MAX_ATTACHMENT_BASE64_CHARS) {
+    return false;
+  }
+
+  return /^[A-Za-z0-9+/]*={0,2}$/.test(data);
+}

--- a/src/common/utils/attachments/displayOnlyFileParts.ts
+++ b/src/common/utils/attachments/displayOnlyFileParts.ts
@@ -1,0 +1,68 @@
+export interface DisplayOnlyFilePart {
+  type: "file-data";
+  data: string;
+  mediaType: string;
+  filename?: string;
+  providerOptions: {
+    mux: {
+      displayOnly: true;
+      size: number;
+    };
+  };
+}
+
+export interface DisplayOnlyFileMetadata {
+  displayOnly: true;
+  size: number;
+}
+
+export function createDisplayOnlyFilePart(args: {
+  data: string;
+  mediaType: string;
+  filename?: string;
+  size: number;
+}): DisplayOnlyFilePart {
+  return {
+    type: "file-data",
+    data: args.data,
+    mediaType: args.mediaType,
+    providerOptions: { mux: { displayOnly: true, size: args.size } },
+    ...(args.filename ? { filename: args.filename } : {}),
+  };
+}
+
+export function getDisplayOnlyFileMetadata(value: unknown): DisplayOnlyFileMetadata | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+
+  const muxOptions = (value as Record<string, unknown>).mux;
+  if (typeof muxOptions !== "object" || muxOptions === null) {
+    return null;
+  }
+
+  const record = muxOptions as Record<string, unknown>;
+  if (record.displayOnly !== true || typeof record.size !== "number") {
+    return null;
+  }
+
+  return {
+    displayOnly: true,
+    size: record.size,
+  };
+}
+
+export function isDisplayOnlyFilePart(value: unknown): value is DisplayOnlyFilePart {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    record.type === "file-data" &&
+    typeof record.data === "string" &&
+    typeof record.mediaType === "string" &&
+    (record.filename === undefined || typeof record.filename === "string") &&
+    getDisplayOnlyFileMetadata(record.providerOptions) != null
+  );
+}

--- a/src/common/utils/attachments/displayOnlyFileParts.ts
+++ b/src/common/utils/attachments/displayOnlyFileParts.ts
@@ -62,6 +62,6 @@ export function isDisplayOnlyFilePart(value: unknown): value is DisplayOnlyFileP
     record.type === "display_file" &&
     typeof record.data === "string" &&
     typeof record.mediaType === "string" &&
-    (record.filename === undefined || typeof record.filename === "string")
+    (record.filename == null || typeof record.filename === "string")
   );
 }

--- a/src/common/utils/attachments/displayOnlyFileParts.ts
+++ b/src/common/utils/attachments/displayOnlyFileParts.ts
@@ -1,5 +1,5 @@
 export interface DisplayOnlyFilePart {
-  type: "file-data";
+  type: "display_file";
   data: string;
   mediaType: string;
   filename?: string;
@@ -23,7 +23,7 @@ export function createDisplayOnlyFilePart(args: {
   size: number;
 }): DisplayOnlyFilePart {
   return {
-    type: "file-data",
+    type: "display_file",
     data: args.data,
     mediaType: args.mediaType,
     providerOptions: { mux: { displayOnly: true, size: args.size } },
@@ -59,7 +59,7 @@ export function isDisplayOnlyFilePart(value: unknown): value is DisplayOnlyFileP
 
   const record = value as Record<string, unknown>;
   return (
-    record.type === "file-data" &&
+    record.type === "display_file" &&
     typeof record.data === "string" &&
     typeof record.mediaType === "string" &&
     (record.filename === undefined || typeof record.filename === "string") &&

--- a/src/common/utils/attachments/displayOnlyFileParts.ts
+++ b/src/common/utils/attachments/displayOnlyFileParts.ts
@@ -3,8 +3,8 @@ export interface DisplayOnlyFilePart {
   data: string;
   mediaType: string;
   filename?: string;
-  providerOptions: {
-    mux: {
+  providerOptions?: {
+    mux?: {
       displayOnly: true;
       size: number;
     };
@@ -62,7 +62,6 @@ export function isDisplayOnlyFilePart(value: unknown): value is DisplayOnlyFileP
     record.type === "display_file" &&
     typeof record.data === "string" &&
     typeof record.mediaType === "string" &&
-    (record.filename === undefined || typeof record.filename === "string") &&
-    getDisplayOnlyFileMetadata(record.providerOptions) != null
+    (record.filename === undefined || typeof record.filename === "string")
   );
 }

--- a/src/common/utils/tokens/safeStringifyForCounting.test.ts
+++ b/src/common/utils/tokens/safeStringifyForCounting.test.ts
@@ -16,6 +16,20 @@ describe("safeStringifyForCounting", () => {
     expect(serialized).not.toContain("A".repeat(1024));
   });
 
+  test("redacts display-only file base64 payloads", () => {
+    const input = {
+      type: "display_file",
+      data: "A".repeat(1024),
+      mediaType: "video/webm",
+      filename: "clip.webm",
+    };
+
+    const serialized = safeStringifyForCounting(input);
+
+    expect(serialized).toContain("[omitted display-only base64 len=1024]");
+    expect(serialized).not.toContain("A".repeat(200));
+  });
+
   test("redacts base64 data URLs", () => {
     const dataUrl = `data:image/png;base64,${"A".repeat(1000)}`;
 

--- a/src/common/utils/tokens/safeStringifyForCounting.ts
+++ b/src/common/utils/tokens/safeStringifyForCounting.ts
@@ -1,3 +1,4 @@
+import { isDisplayOnlyFilePart } from "@/common/utils/attachments/displayOnlyFileParts";
 /**
  * Safe JSON.stringify variant for *local* token counting.
  *
@@ -48,6 +49,13 @@ export function safeStringifyForCounting(data: unknown): string {
     return JSON.stringify(data, (_key, value: unknown) => {
       if (typeof value === "string") {
         return redactDataUrl(value) ?? value;
+      }
+
+      if (isDisplayOnlyFilePart(value)) {
+        return {
+          ...value,
+          data: `[omitted display-only base64 len=${value.data.length}]`,
+        };
       }
 
       if (isAiSdkMediaBlock(value)) {

--- a/src/common/utils/tools/toolContentResult.ts
+++ b/src/common/utils/tools/toolContentResult.ts
@@ -1,0 +1,13 @@
+export interface ToolContentResult {
+  type: "content";
+  value: unknown[];
+}
+
+export function isToolContentResult(result: unknown): result is ToolContentResult {
+  return (
+    typeof result === "object" &&
+    result !== null &&
+    (result as { type?: unknown }).type === "content" &&
+    Array.isArray((result as { value?: unknown }).value)
+  );
+}

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -1831,7 +1831,7 @@ const AttachFileToolMediaPartSchema = z
 
 const AttachFileToolDisplayFilePartSchema = z
   .object({
-    type: z.literal("file-data"),
+    type: z.literal("display_file"),
     data: z.string(),
     mediaType: z.string(),
     filename: z.string().optional(),

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -1842,9 +1842,11 @@ const AttachFileToolDisplayFilePartSchema = z
             displayOnly: z.literal(true),
             size: z.number().int().nonnegative(),
           })
-          .strict(),
+          .strict()
+          .optional(),
       })
-      .strict(),
+      .strict()
+      .optional(),
   })
   .strict();
 

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -929,7 +929,7 @@ export const TOOL_DEFINITIONS = {
     description:
       "Attach a supported file from the filesystem so later model steps receive it as a real attachment instead of a huge base64 JSON blob. " +
       "Accepts absolute or relative paths, including files outside the workspace. " +
-      "Currently supports raster images, SVG, and PDF.",
+      "Currently supports raster images, SVG, and PDF. Unsupported file types are shown to the user in chat when possible, but only a notice is sent to the model.",
     schema: z.preprocess(
       normalizeFilePath,
       z
@@ -1829,10 +1829,32 @@ const AttachFileToolMediaPartSchema = z
   })
   .strict();
 
+const AttachFileToolDisplayFilePartSchema = z
+  .object({
+    type: z.literal("file-data"),
+    data: z.string(),
+    mediaType: z.string(),
+    filename: z.string().optional(),
+    providerOptions: z
+      .object({
+        mux: z
+          .object({
+            displayOnly: z.literal(true),
+            size: z.number().int().nonnegative(),
+          })
+          .strict(),
+      })
+      .strict(),
+  })
+  .strict();
+
 const AttachFileToolSuccessResultSchema = z
   .object({
     type: z.literal("content"),
-    value: z.tuple([AttachFileToolTextPartSchema, AttachFileToolMediaPartSchema]),
+    value: z.union([
+      z.tuple([AttachFileToolTextPartSchema, AttachFileToolMediaPartSchema]),
+      z.tuple([AttachFileToolTextPartSchema, AttachFileToolDisplayFilePartSchema]),
+    ]),
   })
   .strict();
 

--- a/src/node/services/tools/attach_file.test.ts
+++ b/src/node/services/tools/attach_file.test.ts
@@ -276,10 +276,12 @@ describe("attach_file tool", () => {
       (await tool.execute!({ path: "clip.webm" }, mockToolCallOptions)) as AttachFileToolResult
     );
 
-    expect(result.value[0]).toEqual({
-      type: "text",
-      text: "[File shown to user: clip.webm (video/webm). This type is not supported as a model attachment, so the model will only receive this notice. Use another tool to inspect or convert the file if needed.]",
-    });
+    expect(result.value[0].type).toBe("text");
+    if (result.value[0].type !== "text") {
+      throw new Error("Expected display-only status text");
+    }
+    expect(result.value[0].text).toContain("clip.webm");
+    expect(result.value[0].text).toContain("not supported as a model attachment");
     expect(result.value[1]).toEqual({
       type: "display_file",
       data: webmBytes.toString("base64"),

--- a/src/node/services/tools/attach_file.test.ts
+++ b/src/node/services/tools/attach_file.test.ts
@@ -306,11 +306,45 @@ describe("attach_file tool", () => {
     });
   });
 
+  it("rejects unmapped source files so the model can use file_read", async () => {
+    using workspaceDir = new TestTempDir("attach-file-workspace");
+    const tool = createTestAttachFileTool(workspaceDir.path);
+    const sourcePath = path.join(workspaceDir.path, "script.py");
+    await fs.writeFile(sourcePath, "print('hello')\n");
+
+    const result = (await tool.execute!(
+      { path: "script.py" },
+      mockToolCallOptions
+    )) as AttachFileToolResult;
+
+    expect(result).toEqual({
+      success: false,
+      error: `Unsupported attachment type: ${sourcePath}`,
+    });
+  });
+
+  it("rejects extensionless text files so the model can use file_read", async () => {
+    using workspaceDir = new TestTempDir("attach-file-workspace");
+    const tool = createTestAttachFileTool(workspaceDir.path);
+    const makefilePath = path.join(workspaceDir.path, "Makefile");
+    await fs.writeFile(makefilePath, "all:\n\techo hello\n");
+
+    const result = (await tool.execute!(
+      { path: "Makefile" },
+      mockToolCallOptions
+    )) as AttachFileToolResult;
+
+    expect(result).toEqual({
+      success: false,
+      error: `Unsupported attachment type: ${makefilePath}`,
+    });
+  });
+
   it("shows an unmapped binary file with the octet-stream fallback", async () => {
     using workspaceDir = new TestTempDir("attach-file-workspace");
     const tool = createTestAttachFileTool(workspaceDir.path);
     const zipPath = path.join(workspaceDir.path, "bundle.zip");
-    const zipBytes = Buffer.from("zip bytes");
+    const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]);
     await fs.writeFile(zipPath, zipBytes);
 
     const result = expectSuccessfulAttachFileResult(

--- a/src/node/services/tools/attach_file.test.ts
+++ b/src/node/services/tools/attach_file.test.ts
@@ -265,20 +265,27 @@ describe("attach_file tool", () => {
     });
   });
 
-  it("rejects an unsupported type", async () => {
+  it("shows an unsupported file to the user without attaching it to the model", async () => {
     using workspaceDir = new TestTempDir("attach-file-workspace");
     const tool = createTestAttachFileTool(workspaceDir.path);
-    const textPath = path.join(workspaceDir.path, "notes.txt");
-    await fs.writeFile(textPath, "hello");
+    const webmPath = path.join(workspaceDir.path, "clip.webm");
+    const webmBytes = Buffer.from("webm bytes");
+    await fs.writeFile(webmPath, webmBytes);
 
-    const result = (await tool.execute!(
-      { path: "notes.txt" },
-      mockToolCallOptions
-    )) as AttachFileToolResult;
+    const result = expectSuccessfulAttachFileResult(
+      (await tool.execute!({ path: "clip.webm" }, mockToolCallOptions)) as AttachFileToolResult
+    );
 
-    expect(result).toEqual({
-      success: false,
-      error: `Unsupported attachment type: ${textPath}`,
+    expect(result.value[0]).toEqual({
+      type: "text",
+      text: "[File shown to user: clip.webm (video/webm). This type is not supported as a model attachment, so the model will only receive this notice. Use another tool to inspect or convert the file if needed.]",
+    });
+    expect(result.value[1]).toEqual({
+      type: "file-data",
+      data: webmBytes.toString("base64"),
+      mediaType: "video/webm",
+      filename: "clip.webm",
+      providerOptions: { mux: { displayOnly: true, size: webmBytes.length } },
     });
   });
 

--- a/src/node/services/tools/attach_file.test.ts
+++ b/src/node/services/tools/attach_file.test.ts
@@ -281,11 +281,65 @@ describe("attach_file tool", () => {
       text: "[File shown to user: clip.webm (video/webm). This type is not supported as a model attachment, so the model will only receive this notice. Use another tool to inspect or convert the file if needed.]",
     });
     expect(result.value[1]).toEqual({
-      type: "file-data",
+      type: "display_file",
       data: webmBytes.toString("base64"),
       mediaType: "video/webm",
       filename: "clip.webm",
       providerOptions: { mux: { displayOnly: true, size: webmBytes.length } },
+    });
+  });
+
+  it("rejects text-like unsupported files so the model can use file_read", async () => {
+    using workspaceDir = new TestTempDir("attach-file-workspace");
+    const tool = createTestAttachFileTool(workspaceDir.path);
+    const textPath = path.join(workspaceDir.path, "notes.txt");
+    await fs.writeFile(textPath, "hello");
+
+    const result = (await tool.execute!(
+      { path: "notes.txt" },
+      mockToolCallOptions
+    )) as AttachFileToolResult;
+
+    expect(result).toEqual({
+      success: false,
+      error: `Unsupported attachment type: ${textPath}`,
+    });
+  });
+
+  it("shows an unmapped binary file with the octet-stream fallback", async () => {
+    using workspaceDir = new TestTempDir("attach-file-workspace");
+    const tool = createTestAttachFileTool(workspaceDir.path);
+    const zipPath = path.join(workspaceDir.path, "bundle.zip");
+    const zipBytes = Buffer.from("zip bytes");
+    await fs.writeFile(zipPath, zipBytes);
+
+    const result = expectSuccessfulAttachFileResult(
+      (await tool.execute!({ path: "bundle.zip" }, mockToolCallOptions)) as AttachFileToolResult
+    );
+
+    expect(result.value[1]).toEqual({
+      type: "display_file",
+      data: zipBytes.toString("base64"),
+      mediaType: "application/octet-stream",
+      filename: "bundle.zip",
+      providerOptions: { mux: { displayOnly: true, size: zipBytes.length } },
+    });
+  });
+
+  it("rejects oversized unsupported files with both unsupported-type and size context", async () => {
+    using workspaceDir = new TestTempDir("attach-file-workspace");
+    const tool = createTestAttachFileTool(workspaceDir.path);
+    const largePath = path.join(workspaceDir.path, "huge.webm");
+    await fs.writeFile(largePath, Buffer.alloc(MAX_ATTACH_FILE_SIZE_BYTES + 1, 0x61));
+
+    const result = (await tool.execute!(
+      { path: "huge.webm" },
+      mockToolCallOptions
+    )) as AttachFileToolResult;
+
+    expect(result).toEqual({
+      success: false,
+      error: `Unsupported attachment type: ${largePath}. Could not show file to user: Attachment is too large (10.00MB). The maximum supported size is 10.00MB.`,
     });
   });
 

--- a/src/node/services/tools/attach_file.ts
+++ b/src/node/services/tools/attach_file.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import assert from "@/common/utils/assert";
 import { getErrorMessage } from "@/common/utils/errors";
+import { createDisplayOnlyFilePart } from "@/common/utils/attachments/displayOnlyFileParts";
 import type { AttachFileToolResult } from "@/common/types/tools";
 import { TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
 import type { ToolConfiguration, ToolFactory } from "@/common/utils/tools/tools";
@@ -61,8 +62,6 @@ export const createAttachFileTool: ToolFactory = (config: ToolConfiguration) => 
               runtime: config.runtime,
               abortSignal,
             });
-            assert(displayFile.data.length > 0, "attach_file produced empty display file data");
-
             const label = formatDisplayOnlyFileLabel(displayFile);
             return {
               type: "content",
@@ -73,13 +72,7 @@ export const createAttachFileTool: ToolFactory = (config: ToolConfiguration) => 
                     `[File shown to user: ${label}. ` +
                     "This type is not supported as a model attachment, so the model will only receive this notice. Use another tool to inspect or convert the file if needed.]",
                 },
-                {
-                  type: "file-data",
-                  data: displayFile.data,
-                  mediaType: displayFile.mediaType,
-                  providerOptions: { mux: { displayOnly: true, size: displayFile.size } },
-                  ...(displayFile.filename ? { filename: displayFile.filename } : {}),
-                },
+                createDisplayOnlyFilePart(displayFile),
               ],
             };
           } catch (displayError) {

--- a/src/node/services/tools/attach_file.ts
+++ b/src/node/services/tools/attach_file.ts
@@ -40,7 +40,7 @@ export const createAttachFileTool: ToolFactory = (config: ToolConfiguration) => 
                 type: "text",
                 text:
                   `[File shown to user: ${label}. ` +
-                  "This type is not supported as a model attachment, so the model will only receive this notice. Use another tool to inspect or convert the file if needed.]",
+                  "This type is not supported as a model attachment, so the model will receive this notice. Use another tool to inspect or convert the file if needed.]",
               },
               createDisplayOnlyFilePart(result.file),
             ],

--- a/src/node/services/tools/attach_file.ts
+++ b/src/node/services/tools/attach_file.ts
@@ -4,7 +4,15 @@ import { getErrorMessage } from "@/common/utils/errors";
 import type { AttachFileToolResult } from "@/common/types/tools";
 import { TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
 import type { ToolConfiguration, ToolFactory } from "@/common/utils/tools/tools";
-import { readAttachmentFromPath } from "@/node/utils/attachments/readAttachmentFromPath";
+import {
+  UnsupportedAttachmentTypeError,
+  readAttachmentFromPath,
+  readDisplayFileFromPath,
+} from "@/node/utils/attachments/readAttachmentFromPath";
+
+function formatDisplayOnlyFileLabel(file: { filename?: string; mediaType: string }): string {
+  return file.filename != null ? `${file.filename} (${file.mediaType})` : file.mediaType;
+}
 
 export const createAttachFileTool: ToolFactory = (config: ToolConfiguration) => {
   return tool({
@@ -43,6 +51,45 @@ export const createAttachFileTool: ToolFactory = (config: ToolConfiguration) => 
           ],
         };
       } catch (error) {
+        if (error instanceof UnsupportedAttachmentTypeError) {
+          try {
+            const displayFile = await readDisplayFileFromPath({
+              path,
+              mediaType,
+              filename,
+              cwd: config.cwd,
+              runtime: config.runtime,
+              abortSignal,
+            });
+            assert(displayFile.data.length > 0, "attach_file produced empty display file data");
+
+            const label = formatDisplayOnlyFileLabel(displayFile);
+            return {
+              type: "content",
+              value: [
+                {
+                  type: "text",
+                  text:
+                    `[File shown to user: ${label}. ` +
+                    "This type is not supported as a model attachment, so the model will only receive this notice. Use another tool to inspect or convert the file if needed.]",
+                },
+                {
+                  type: "file-data",
+                  data: displayFile.data,
+                  mediaType: displayFile.mediaType,
+                  providerOptions: { mux: { displayOnly: true, size: displayFile.size } },
+                  ...(displayFile.filename ? { filename: displayFile.filename } : {}),
+                },
+              ],
+            };
+          } catch (displayError) {
+            return {
+              success: false,
+              error: getErrorMessage(displayError),
+            };
+          }
+        }
+
         return {
           success: false,
           error: getErrorMessage(error),

--- a/src/node/services/tools/attach_file.ts
+++ b/src/node/services/tools/attach_file.ts
@@ -5,11 +5,7 @@ import { createDisplayOnlyFilePart } from "@/common/utils/attachments/displayOnl
 import type { AttachFileToolResult } from "@/common/types/tools";
 import { TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
 import type { ToolConfiguration, ToolFactory } from "@/common/utils/tools/tools";
-import {
-  UnsupportedAttachmentTypeError,
-  readAttachmentFromPath,
-  readDisplayFileFromPath,
-} from "@/node/utils/attachments/readAttachmentFromPath";
+import { readAttachFileFromPath } from "@/node/utils/attachments/readAttachmentFromPath";
 
 function formatDisplayOnlyFileLabel(file: { filename?: string; mediaType: string }): string {
   return file.filename != null ? `${file.filename} (${file.mediaType})` : file.mediaType;
@@ -26,7 +22,7 @@ export const createAttachFileTool: ToolFactory = (config: ToolConfiguration) => 
       assert(typeof path === "string" && path.trim().length > 0, "attach_file requires a path");
 
       try {
-        const attachment = await readAttachmentFromPath({
+        const result = await readAttachFileFromPath({
           path,
           mediaType,
           filename,
@@ -34,6 +30,24 @@ export const createAttachFileTool: ToolFactory = (config: ToolConfiguration) => 
           runtime: config.runtime,
           abortSignal,
         });
+
+        if (result.type === "display") {
+          const label = formatDisplayOnlyFileLabel(result.file);
+          return {
+            type: "content",
+            value: [
+              {
+                type: "text",
+                text:
+                  `[File shown to user: ${label}. ` +
+                  "This type is not supported as a model attachment, so the model will only receive this notice. Use another tool to inspect or convert the file if needed.]",
+              },
+              createDisplayOnlyFilePart(result.file),
+            ],
+          };
+        }
+
+        const attachment = result.attachment;
         assert(attachment.data.length > 0, "attach_file produced empty attachment data");
 
         return {
@@ -52,37 +66,6 @@ export const createAttachFileTool: ToolFactory = (config: ToolConfiguration) => 
           ],
         };
       } catch (error) {
-        if (error instanceof UnsupportedAttachmentTypeError) {
-          try {
-            const displayFile = await readDisplayFileFromPath({
-              path,
-              mediaType,
-              filename,
-              cwd: config.cwd,
-              runtime: config.runtime,
-              abortSignal,
-            });
-            const label = formatDisplayOnlyFileLabel(displayFile);
-            return {
-              type: "content",
-              value: [
-                {
-                  type: "text",
-                  text:
-                    `[File shown to user: ${label}. ` +
-                    "This type is not supported as a model attachment, so the model will only receive this notice. Use another tool to inspect or convert the file if needed.]",
-                },
-                createDisplayOnlyFilePart(displayFile),
-              ],
-            };
-          } catch (displayError) {
-            return {
-              success: false,
-              error: getErrorMessage(displayError),
-            };
-          }
-        }
-
         return {
           success: false,
           error: getErrorMessage(error),

--- a/src/node/utils/attachments/readAttachmentFromPath.ts
+++ b/src/node/utils/attachments/readAttachmentFromPath.ts
@@ -41,8 +41,6 @@ export interface LoadedAttachmentFromPath {
   size: number;
 }
 
-export type DisplayFileFromPath = LoadedAttachmentFromPath;
-
 const EXTENSION_TO_DISPLAY_MEDIA_TYPE: Record<string, string> = {
   webm: "video/webm",
   mp4: "video/mp4",
@@ -149,7 +147,7 @@ function getDisplayFileMediaType(args: ReadAttachmentFromPathArgs, resolvedPath:
 
 export async function readDisplayFileFromPath(
   args: ReadAttachmentFromPathArgs
-): Promise<DisplayFileFromPath> {
+): Promise<LoadedAttachmentFromPath> {
   assert(
     typeof args.path === "string" && args.path.trim().length > 0,
     "attach_file requires a path"

--- a/src/node/utils/attachments/readAttachmentFromPath.ts
+++ b/src/node/utils/attachments/readAttachmentFromPath.ts
@@ -26,7 +26,7 @@ export interface ReadAttachmentFromPathArgs {
   abortSignal?: AbortSignal;
 }
 
-export interface LoadedAttachmentFromPath {
+export interface LoadedFileFromPath {
   data: string;
   mediaType: string;
   filename?: string;
@@ -35,8 +35,8 @@ export interface LoadedAttachmentFromPath {
 }
 
 export type AttachFileFromPathResult =
-  | { type: "attachment"; attachment: LoadedAttachmentFromPath }
-  | { type: "display"; file: LoadedAttachmentFromPath };
+  | { type: "attachment"; attachment: LoadedFileFromPath }
+  | { type: "display"; file: LoadedFileFromPath };
 
 const EXTENSION_TO_DISPLAY_MEDIA_TYPE: Record<string, string> = {
   webm: "video/webm",
@@ -240,7 +240,7 @@ function createLoadedAttachment(args: {
   mediaType: string;
   filename?: string;
   resolvedPath: string;
-}): LoadedAttachmentFromPath {
+}): LoadedFileFromPath {
   return {
     data: args.data.toString("base64"),
     mediaType: args.mediaType,
@@ -329,7 +329,7 @@ export async function readAttachFileFromPath(
 
 export async function readAttachmentFromPath(
   args: ReadAttachmentFromPathArgs
-): Promise<LoadedAttachmentFromPath> {
+): Promise<LoadedFileFromPath> {
   const result = await readAttachFileFromPath(args);
   if (result.type === "attachment") {
     return result.attachment;

--- a/src/node/utils/attachments/readAttachmentFromPath.ts
+++ b/src/node/utils/attachments/readAttachmentFromPath.ts
@@ -17,13 +17,6 @@ import {
 // chat history never persists unexpectedly large base64 payloads.
 export const MAX_ATTACH_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
 
-class UnsupportedAttachmentTypeError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "UnsupportedAttachmentTypeError";
-  }
-}
-
 export interface ReadAttachmentFromPathArgs {
   path: string;
   mediaType?: string | null;
@@ -180,9 +173,7 @@ function createUnsupportedAttachmentError(
   args: ReadAttachmentFromPathArgs,
   resolvedPath: string
 ): Error {
-  return new UnsupportedAttachmentTypeError(
-    `Unsupported attachment type: ${args.mediaType ?? resolvedPath}`
-  );
+  return new Error(`Unsupported attachment type: ${args.mediaType ?? resolvedPath}`);
 }
 
 function getFallbackFilename(
@@ -344,6 +335,5 @@ export async function readAttachmentFromPath(
     return result.attachment;
   }
 
-  const { resolvedPath } = resolvePathWithinCwd(args.path, args.cwd, args.runtime);
-  throw createUnsupportedAttachmentError(args, resolvedPath);
+  throw createUnsupportedAttachmentError(args, result.file.resolvedPath);
 }

--- a/src/node/utils/attachments/readAttachmentFromPath.ts
+++ b/src/node/utils/attachments/readAttachmentFromPath.ts
@@ -235,7 +235,7 @@ function isLikelyTextFile(bytes: Buffer): boolean {
   return controlCharacterCount / text.length < 0.05;
 }
 
-function createLoadedAttachment(args: {
+function createLoadedFile(args: {
   data: Buffer;
   mediaType: string;
   filename?: string;
@@ -286,7 +286,7 @@ export async function readAttachFileFromPath(
 
     return {
       type: "display",
-      file: createLoadedAttachment({
+      file: createLoadedFile({
         data: bytes,
         mediaType: displayMediaTypeCandidate.mediaType,
         filename,
@@ -318,7 +318,7 @@ export async function readAttachFileFromPath(
 
   return {
     type: "attachment",
-    attachment: createLoadedAttachment({
+    attachment: createLoadedFile({
       data: attachmentBytes,
       mediaType: attachmentMediaType,
       filename,

--- a/src/node/utils/attachments/readAttachmentFromPath.ts
+++ b/src/node/utils/attachments/readAttachmentFromPath.ts
@@ -56,10 +56,17 @@ const EXTENSION_TO_DISPLAY_MEDIA_TYPE: Record<string, string> = {
 };
 
 const TEXT_EXTENSIONS_REQUIRING_FILE_READ = new Set([
+  "c",
+  "cpp",
+  "cs",
   "csv",
   "css",
+  "go",
+  "h",
+  "hpp",
   "html",
   "htm",
+  "java",
   "js",
   "json",
   "jsx",
@@ -67,7 +74,10 @@ const TEXT_EXTENSIONS_REQUIRING_FILE_READ = new Set([
   "md",
   "mdx",
   "mjs",
+  "py",
+  "rs",
   "sh",
+  "toml",
   "ts",
   "tsx",
   "txt",
@@ -182,24 +192,56 @@ function getFallbackFilename(
   return normalizeOptionalString(filename) ?? normalizeOptionalString(path.basename(resolvedPath));
 }
 
-function getDisplayFileMediaType(
+interface DisplayMediaTypeCandidate {
+  mediaType: string;
+  requireBinaryContent: boolean;
+}
+
+function getDisplayFileMediaTypeCandidate(
   args: ReadAttachmentFromPathArgs,
   resolvedPath: string
-): string | null {
+): DisplayMediaTypeCandidate | null {
   const override = normalizeOptionalString(args.mediaType);
   const extension = path.extname(resolvedPath).slice(1).toLowerCase();
-  const rawMediaType =
-    override ?? EXTENSION_TO_DISPLAY_MEDIA_TYPE[extension] ?? "application/octet-stream";
-  const mediaType = normalizeAttachmentMediaType(rawMediaType);
+  const rawMediaType = override ?? EXTENSION_TO_DISPLAY_MEDIA_TYPE[extension];
 
-  if (mediaType.startsWith("text/") || TEXT_MEDIA_TYPES_REQUIRING_FILE_READ.has(mediaType)) {
+  if (rawMediaType != null) {
+    const mediaType = normalizeAttachmentMediaType(rawMediaType);
+    if (mediaType.startsWith("text/") || TEXT_MEDIA_TYPES_REQUIRING_FILE_READ.has(mediaType)) {
+      return null;
+    }
+    return { mediaType, requireBinaryContent: false };
+  }
+
+  if (TEXT_EXTENSIONS_REQUIRING_FILE_READ.has(extension)) {
     return null;
   }
-  if (override == null && TEXT_EXTENSIONS_REQUIRING_FILE_READ.has(extension)) {
-    return null;
+
+  return { mediaType: "application/octet-stream", requireBinaryContent: true };
+}
+
+function isLikelyTextFile(bytes: Buffer): boolean {
+  if (bytes.length === 0) {
+    return true;
+  }
+  if (bytes.includes(0)) {
+    return false;
   }
 
-  return mediaType;
+  const text = bytes.toString("utf8");
+  if (text.includes("\uFFFD")) {
+    return false;
+  }
+
+  let controlCharacterCount = 0;
+  for (const char of text) {
+    const code = char.charCodeAt(0);
+    if (code < 32 && char !== "\n" && char !== "\r" && char !== "\t") {
+      controlCharacterCount++;
+    }
+  }
+
+  return controlCharacterCount / text.length < 0.05;
 }
 
 function createLoadedAttachment(args: {
@@ -236,8 +278,8 @@ export async function readAttachFileFromPath(
   });
 
   if (mediaType == null) {
-    const displayMediaType = getDisplayFileMediaType(args, resolvedPath);
-    if (displayMediaType == null) {
+    const displayMediaTypeCandidate = getDisplayFileMediaTypeCandidate(args, resolvedPath);
+    if (displayMediaTypeCandidate == null) {
       throw createUnsupportedAttachmentError(args, resolvedPath);
     }
     if (fileStat.size > MAX_ATTACH_FILE_SIZE_BYTES) {
@@ -247,11 +289,15 @@ export async function readAttachFileFromPath(
     }
 
     const bytes = await readRegularFileBytes(args, resolvedPath, fileStat.size);
+    if (displayMediaTypeCandidate.requireBinaryContent && isLikelyTextFile(bytes)) {
+      throw createUnsupportedAttachmentError(args, resolvedPath);
+    }
+
     return {
       type: "display",
       file: createLoadedAttachment({
         data: bytes,
-        mediaType: displayMediaType,
+        mediaType: displayMediaTypeCandidate.mediaType,
         filename,
         resolvedPath,
       }),

--- a/src/node/utils/attachments/readAttachmentFromPath.ts
+++ b/src/node/utils/attachments/readAttachmentFromPath.ts
@@ -2,8 +2,11 @@ import * as path from "path";
 import assert from "@/common/utils/assert";
 import { MAX_SVG_TEXT_CHARS, SVG_MEDIA_TYPE } from "@/common/constants/imageAttachments";
 import { getErrorMessage } from "@/common/utils/errors";
-import { getSupportedAttachmentMediaType } from "@/common/utils/attachments/supportedAttachmentMediaTypes";
-import type { Runtime } from "@/node/runtime/Runtime";
+import {
+  getSupportedAttachmentMediaType,
+  normalizeAttachmentMediaType,
+} from "@/common/utils/attachments/supportedAttachmentMediaTypes";
+import type { FileStat, Runtime } from "@/node/runtime/Runtime";
 import { resolvePathWithinCwd } from "@/node/services/tools/fileCommon";
 import {
   isRasterAttachmentMediaType,
@@ -13,6 +16,13 @@ import {
 // Attachment payloads need a larger cap than text-oriented file tools because common
 // screenshots and PDFs regularly exceed 1MB before request-time rewriting runs.
 export const MAX_ATTACH_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
+
+export class UnsupportedAttachmentTypeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsupportedAttachmentTypeError";
+  }
+}
 
 export interface ReadAttachmentFromPathArgs {
   path: string;
@@ -30,6 +40,21 @@ export interface LoadedAttachmentFromPath {
   resolvedPath: string;
   size: number;
 }
+
+export type DisplayFileFromPath = LoadedAttachmentFromPath;
+
+const EXTENSION_TO_DISPLAY_MEDIA_TYPE: Record<string, string> = {
+  webm: "video/webm",
+  mp4: "video/mp4",
+  m4v: "video/mp4",
+  mov: "video/quicktime",
+  mp3: "audio/mpeg",
+  wav: "audio/wav",
+  ogg: "audio/ogg",
+  txt: "text/plain",
+  csv: "text/csv",
+  json: "application/json",
+};
 
 function normalizeOptionalString(value: string | null | undefined): string | undefined {
   const trimmed = value?.trim();
@@ -68,17 +93,11 @@ function buildMissingFileError(resolvedPath: string, error: unknown): Error {
   return new Error(message);
 }
 
-export async function readAttachmentFromPath(
-  args: ReadAttachmentFromPathArgs
-): Promise<LoadedAttachmentFromPath> {
-  assert(
-    typeof args.path === "string" && args.path.trim().length > 0,
-    "attach_file requires a path"
-  );
-
-  const { resolvedPath } = resolvePathWithinCwd(args.path, args.cwd, args.runtime);
-
-  let fileStat;
+async function statRegularFile(
+  args: ReadAttachmentFromPathArgs,
+  resolvedPath: string
+): Promise<FileStat> {
+  let fileStat: FileStat;
   try {
     fileStat = await args.runtime.stat(resolvedPath, args.abortSignal);
   } catch (error) {
@@ -89,22 +108,17 @@ export async function readAttachmentFromPath(
     throw new Error(`Path is a directory, not a file: ${resolvedPath}`);
   }
 
-  const fallbackFilename = path.basename(resolvedPath);
-  const filename =
-    normalizeOptionalString(args.filename) ?? normalizeOptionalString(fallbackFilename);
-  const mediaType = getSupportedAttachmentMediaType({
-    mediaType: args.mediaType,
-    // Infer the attachment type from the source path, not the display filename override.
-    // Callers may intentionally rename the attachment to a presentation-only label.
-    filename: resolvedPath,
-  });
-  if (mediaType == null) {
-    throw new Error(`Unsupported attachment type: ${args.mediaType ?? resolvedPath}`);
-  }
+  return fileStat;
+}
 
-  if (fileStat.size > MAX_ATTACH_FILE_SIZE_BYTES) {
+async function readRegularFileBytes(
+  args: ReadAttachmentFromPathArgs,
+  resolvedPath: string,
+  expectedSize: number
+): Promise<Buffer> {
+  if (expectedSize > MAX_ATTACH_FILE_SIZE_BYTES) {
     throw new Error(
-      `Attachment is too large (${formatBytesAsMegabytes(fileStat.size)}). The maximum supported size is ${formatBytesAsMegabytes(MAX_ATTACH_FILE_SIZE_BYTES)}.`
+      `Attachment is too large (${formatBytesAsMegabytes(expectedSize)}). The maximum supported size is ${formatBytesAsMegabytes(MAX_ATTACH_FILE_SIZE_BYTES)}.`
     );
   }
 
@@ -116,9 +130,78 @@ export async function readAttachmentFromPath(
   }
 
   assert(
-    bytes.length === fileStat.size,
-    `Expected to read ${fileStat.size} bytes from '${resolvedPath}', got ${bytes.length}`
+    bytes.length === expectedSize,
+    `Expected to read ${expectedSize} bytes from '${resolvedPath}', got ${bytes.length}`
   );
+
+  return bytes;
+}
+
+function getDisplayFileMediaType(args: ReadAttachmentFromPathArgs, resolvedPath: string): string {
+  const override = normalizeOptionalString(args.mediaType);
+  if (override != null) {
+    return normalizeAttachmentMediaType(override);
+  }
+
+  const extension = path.extname(resolvedPath).slice(1).toLowerCase();
+  return EXTENSION_TO_DISPLAY_MEDIA_TYPE[extension] ?? "application/octet-stream";
+}
+
+export async function readDisplayFileFromPath(
+  args: ReadAttachmentFromPathArgs
+): Promise<DisplayFileFromPath> {
+  assert(
+    typeof args.path === "string" && args.path.trim().length > 0,
+    "attach_file requires a path"
+  );
+
+  const { resolvedPath } = resolvePathWithinCwd(args.path, args.cwd, args.runtime);
+  const fileStat = await statRegularFile(args, resolvedPath);
+  const bytes = await readRegularFileBytes(args, resolvedPath, fileStat.size);
+  const fallbackFilename = path.basename(resolvedPath);
+  const filename =
+    normalizeOptionalString(args.filename) ?? normalizeOptionalString(fallbackFilename);
+  const mediaType = getDisplayFileMediaType(args, resolvedPath);
+
+  assert(bytes.length > 0, "attach_file display fallback produced empty file data");
+
+  return {
+    data: bytes.toString("base64"),
+    mediaType,
+    filename,
+    resolvedPath,
+    size: bytes.length,
+  };
+}
+
+export async function readAttachmentFromPath(
+  args: ReadAttachmentFromPathArgs
+): Promise<LoadedAttachmentFromPath> {
+  assert(
+    typeof args.path === "string" && args.path.trim().length > 0,
+    "attach_file requires a path"
+  );
+
+  const { resolvedPath } = resolvePathWithinCwd(args.path, args.cwd, args.runtime);
+
+  const fileStat = await statRegularFile(args, resolvedPath);
+
+  const fallbackFilename = path.basename(resolvedPath);
+  const filename =
+    normalizeOptionalString(args.filename) ?? normalizeOptionalString(fallbackFilename);
+  const mediaType = getSupportedAttachmentMediaType({
+    mediaType: args.mediaType,
+    // Infer the attachment type from the source path, not the display filename override.
+    // Callers may intentionally rename the attachment to a presentation-only label.
+    filename: resolvedPath,
+  });
+  if (mediaType == null) {
+    throw new UnsupportedAttachmentTypeError(
+      `Unsupported attachment type: ${args.mediaType ?? resolvedPath}`
+    );
+  }
+
+  const bytes = await readRegularFileBytes(args, resolvedPath, fileStat.size);
 
   if (mediaType === SVG_MEDIA_TYPE) {
     const svgText = bytes.toString("utf8");

--- a/src/node/utils/attachments/readAttachmentFromPath.ts
+++ b/src/node/utils/attachments/readAttachmentFromPath.ts
@@ -13,11 +13,11 @@ import {
   resizeRasterImageAttachmentBufferIfNeeded,
 } from "@/node/utils/attachments/resizeRasterImageAttachment";
 
-// Attachment payloads need a larger cap than text-oriented file tools because common
-// screenshots and PDFs regularly exceed 1MB before request-time rewriting runs.
+// This cap applies to both model attachments and display-only fallback files so
+// chat history never persists unexpectedly large base64 payloads.
 export const MAX_ATTACH_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
 
-export class UnsupportedAttachmentTypeError extends Error {
+class UnsupportedAttachmentTypeError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "UnsupportedAttachmentTypeError";
@@ -41,6 +41,10 @@ export interface LoadedAttachmentFromPath {
   size: number;
 }
 
+export type AttachFileFromPathResult =
+  | { type: "attachment"; attachment: LoadedAttachmentFromPath }
+  | { type: "display"; file: LoadedAttachmentFromPath };
+
 const EXTENSION_TO_DISPLAY_MEDIA_TYPE: Record<string, string> = {
   webm: "video/webm",
   mp4: "video/mp4",
@@ -49,10 +53,35 @@ const EXTENSION_TO_DISPLAY_MEDIA_TYPE: Record<string, string> = {
   mp3: "audio/mpeg",
   wav: "audio/wav",
   ogg: "audio/ogg",
-  txt: "text/plain",
-  csv: "text/csv",
-  json: "application/json",
 };
+
+const TEXT_EXTENSIONS_REQUIRING_FILE_READ = new Set([
+  "csv",
+  "css",
+  "html",
+  "htm",
+  "js",
+  "json",
+  "jsx",
+  "log",
+  "md",
+  "mdx",
+  "mjs",
+  "sh",
+  "ts",
+  "tsx",
+  "txt",
+  "xml",
+  "yaml",
+  "yml",
+]);
+
+const TEXT_MEDIA_TYPES_REQUIRING_FILE_READ = new Set([
+  "application/json",
+  "application/javascript",
+  "application/xml",
+  "text/csv",
+]);
 
 function normalizeOptionalString(value: string | null | undefined): string | undefined {
   const trimmed = value?.trim();
@@ -78,6 +107,10 @@ async function readStreamToBuffer(stream: ReadableStream<Uint8Array>): Promise<B
 
 function formatBytesAsMegabytes(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(2)}MB`;
+}
+
+function buildTooLargeMessage(bytes: number): string {
+  return `Attachment is too large (${formatBytesAsMegabytes(bytes)}). The maximum supported size is ${formatBytesAsMegabytes(MAX_ATTACH_FILE_SIZE_BYTES)}.`;
 }
 
 function buildMissingFileError(resolvedPath: string, error: unknown): Error {
@@ -115,9 +148,7 @@ async function readRegularFileBytes(
   expectedSize: number
 ): Promise<Buffer> {
   if (expectedSize > MAX_ATTACH_FILE_SIZE_BYTES) {
-    throw new Error(
-      `Attachment is too large (${formatBytesAsMegabytes(expectedSize)}). The maximum supported size is ${formatBytesAsMegabytes(MAX_ATTACH_FILE_SIZE_BYTES)}.`
-    );
+    throw new Error(buildTooLargeMessage(expectedSize));
   }
 
   let bytes: Buffer;
@@ -135,68 +166,96 @@ async function readRegularFileBytes(
   return bytes;
 }
 
-function getDisplayFileMediaType(args: ReadAttachmentFromPathArgs, resolvedPath: string): string {
-  const override = normalizeOptionalString(args.mediaType);
-  if (override != null) {
-    return normalizeAttachmentMediaType(override);
-  }
-
-  const extension = path.extname(resolvedPath).slice(1).toLowerCase();
-  return EXTENSION_TO_DISPLAY_MEDIA_TYPE[extension] ?? "application/octet-stream";
+function createUnsupportedAttachmentError(
+  args: ReadAttachmentFromPathArgs,
+  resolvedPath: string
+): Error {
+  return new UnsupportedAttachmentTypeError(
+    `Unsupported attachment type: ${args.mediaType ?? resolvedPath}`
+  );
 }
 
-export async function readDisplayFileFromPath(
-  args: ReadAttachmentFromPathArgs
-): Promise<LoadedAttachmentFromPath> {
-  assert(
-    typeof args.path === "string" && args.path.trim().length > 0,
-    "attach_file requires a path"
-  );
+function getFallbackFilename(
+  resolvedPath: string,
+  filename: string | null | undefined
+): string | undefined {
+  return normalizeOptionalString(filename) ?? normalizeOptionalString(path.basename(resolvedPath));
+}
 
-  const { resolvedPath } = resolvePathWithinCwd(args.path, args.cwd, args.runtime);
-  const fileStat = await statRegularFile(args, resolvedPath);
-  const bytes = await readRegularFileBytes(args, resolvedPath, fileStat.size);
-  const fallbackFilename = path.basename(resolvedPath);
-  const filename =
-    normalizeOptionalString(args.filename) ?? normalizeOptionalString(fallbackFilename);
-  const mediaType = getDisplayFileMediaType(args, resolvedPath);
+function getDisplayFileMediaType(
+  args: ReadAttachmentFromPathArgs,
+  resolvedPath: string
+): string | null {
+  const override = normalizeOptionalString(args.mediaType);
+  const extension = path.extname(resolvedPath).slice(1).toLowerCase();
+  const rawMediaType =
+    override ?? EXTENSION_TO_DISPLAY_MEDIA_TYPE[extension] ?? "application/octet-stream";
+  const mediaType = normalizeAttachmentMediaType(rawMediaType);
 
-  assert(bytes.length > 0, "attach_file display fallback produced empty file data");
+  if (mediaType.startsWith("text/") || TEXT_MEDIA_TYPES_REQUIRING_FILE_READ.has(mediaType)) {
+    return null;
+  }
+  if (override == null && TEXT_EXTENSIONS_REQUIRING_FILE_READ.has(extension)) {
+    return null;
+  }
 
+  return mediaType;
+}
+
+function createLoadedAttachment(args: {
+  data: Buffer;
+  mediaType: string;
+  filename?: string;
+  resolvedPath: string;
+}): LoadedAttachmentFromPath {
   return {
-    data: bytes.toString("base64"),
-    mediaType,
-    filename,
-    resolvedPath,
-    size: bytes.length,
+    data: args.data.toString("base64"),
+    mediaType: args.mediaType,
+    filename: args.filename,
+    resolvedPath: args.resolvedPath,
+    size: args.data.length,
   };
 }
 
-export async function readAttachmentFromPath(
+export async function readAttachFileFromPath(
   args: ReadAttachmentFromPathArgs
-): Promise<LoadedAttachmentFromPath> {
+): Promise<AttachFileFromPathResult> {
   assert(
     typeof args.path === "string" && args.path.trim().length > 0,
     "attach_file requires a path"
   );
 
   const { resolvedPath } = resolvePathWithinCwd(args.path, args.cwd, args.runtime);
-
   const fileStat = await statRegularFile(args, resolvedPath);
-
-  const fallbackFilename = path.basename(resolvedPath);
-  const filename =
-    normalizeOptionalString(args.filename) ?? normalizeOptionalString(fallbackFilename);
+  const filename = getFallbackFilename(resolvedPath, args.filename);
   const mediaType = getSupportedAttachmentMediaType({
     mediaType: args.mediaType,
     // Infer the attachment type from the source path, not the display filename override.
     // Callers may intentionally rename the attachment to a presentation-only label.
     filename: resolvedPath,
   });
+
   if (mediaType == null) {
-    throw new UnsupportedAttachmentTypeError(
-      `Unsupported attachment type: ${args.mediaType ?? resolvedPath}`
-    );
+    const displayMediaType = getDisplayFileMediaType(args, resolvedPath);
+    if (displayMediaType == null) {
+      throw createUnsupportedAttachmentError(args, resolvedPath);
+    }
+    if (fileStat.size > MAX_ATTACH_FILE_SIZE_BYTES) {
+      throw new Error(
+        `${getErrorMessage(createUnsupportedAttachmentError(args, resolvedPath))}. Could not show file to user: ${buildTooLargeMessage(fileStat.size)}`
+      );
+    }
+
+    const bytes = await readRegularFileBytes(args, resolvedPath, fileStat.size);
+    return {
+      type: "display",
+      file: createLoadedAttachment({
+        data: bytes,
+        mediaType: displayMediaType,
+        filename,
+        resolvedPath,
+      }),
+    };
   }
 
   const bytes = await readRegularFileBytes(args, resolvedPath, fileStat.size);
@@ -221,10 +280,24 @@ export async function readAttachmentFromPath(
   }
 
   return {
-    data: attachmentBytes.toString("base64"),
-    mediaType: attachmentMediaType,
-    filename,
-    resolvedPath,
-    size: attachmentBytes.length,
+    type: "attachment",
+    attachment: createLoadedAttachment({
+      data: attachmentBytes,
+      mediaType: attachmentMediaType,
+      filename,
+      resolvedPath,
+    }),
   };
+}
+
+export async function readAttachmentFromPath(
+  args: ReadAttachmentFromPathArgs
+): Promise<LoadedAttachmentFromPath> {
+  const result = await readAttachFileFromPath(args);
+  if (result.type === "attachment") {
+    return result.attachment;
+  }
+
+  const { resolvedPath } = resolvePathWithinCwd(args.path, args.cwd, args.runtime);
+  throw createUnsupportedAttachmentError(args, resolvedPath);
 }

--- a/src/node/utils/messages/extractToolMediaAsUserMessages.test.ts
+++ b/src/node/utils/messages/extractToolMediaAsUserMessages.test.ts
@@ -285,7 +285,7 @@ describe("extractToolMediaAsUserMessages", () => {
               value: [
                 { type: "text", text: "[File shown to user: clip.webm]" },
                 {
-                  type: "file-data",
+                  type: "display_file",
                   mediaType: "video/webm",
                   data: base64,
                   filename: "clip.webm",
@@ -310,7 +310,19 @@ describe("extractToolMediaAsUserMessages", () => {
     const outputText = JSON.stringify(toolPart.output);
     expect(outputText).toContain("File shown to user only");
     expect(outputText).not.toContain(base64);
-    expect(outputText).not.toContain("file-data");
+    if (
+      typeof toolPart.output === "object" &&
+      toolPart.output !== null &&
+      (toolPart.output as { type?: unknown }).type === "content" &&
+      Array.isArray((toolPart.output as { value?: unknown }).value)
+    ) {
+      const rewrittenValue = (toolPart.output as { value: unknown[] }).value;
+      expect(
+        rewrittenValue.some((part) => (part as { type?: unknown }).type === "display_file")
+      ).toBe(false);
+    } else {
+      throw new Error("Expected rewritten content output");
+    }
   });
 
   it("does not rewrite unrelated tool outputs", async () => {

--- a/src/node/utils/messages/extractToolMediaAsUserMessages.test.ts
+++ b/src/node/utils/messages/extractToolMediaAsUserMessages.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@jest/globals";
 import sharp from "sharp";
 import { MAX_IMAGE_DIMENSION } from "@/common/constants/imageAttachments";
 import type { MuxMessage } from "@/common/types/message";
+import { expectContentOutputValue } from "./testToolOutputHelpers";
 import { extractToolMediaAsUserMessages } from "./extractToolMediaAsUserMessages";
 
 describe("extractToolMediaAsUserMessages", () => {
@@ -309,24 +310,13 @@ describe("extractToolMediaAsUserMessages", () => {
 
     const outputText = JSON.stringify(toolPart.output);
     expect(outputText).not.toContain(base64);
-    if (
-      typeof toolPart.output === "object" &&
-      toolPart.output !== null &&
-      (toolPart.output as { type?: unknown }).type === "content" &&
-      Array.isArray((toolPart.output as { value?: unknown }).value)
-    ) {
-      const rewrittenValue = (toolPart.output as { value: unknown[] }).value;
-      const textParts = rewrittenValue.filter(
-        (part) => (part as { type?: unknown }).type === "text"
-      );
-      expect(textParts).toHaveLength(2);
-      expect(JSON.stringify(textParts)).toContain("clip.webm");
-      expect(
-        rewrittenValue.some((part) => (part as { type?: unknown }).type === "display_file")
-      ).toBe(false);
-    } else {
-      throw new Error("Expected rewritten content output");
-    }
+    const rewrittenValue = expectContentOutputValue(toolPart.output);
+    const textParts = rewrittenValue.filter((part) => (part as { type?: unknown }).type === "text");
+    expect(textParts).toHaveLength(2);
+    expect(JSON.stringify(textParts)).toContain("clip.webm");
+    expect(
+      rewrittenValue.some((part) => (part as { type?: unknown }).type === "display_file")
+    ).toBe(false);
   });
 
   it("strips display-only file bytes even when metadata is missing", async () => {
@@ -367,24 +357,14 @@ describe("extractToolMediaAsUserMessages", () => {
       throw new Error("Expected rewritten output-available tool part");
     }
 
-    if (
-      typeof toolPart.output === "object" &&
-      toolPart.output !== null &&
-      (toolPart.output as { type?: unknown }).type === "content" &&
-      Array.isArray((toolPart.output as { value?: unknown }).value)
-    ) {
-      const rewrittenValue = (toolPart.output as { value: unknown[] }).value;
-      const textParts = rewrittenValue.filter(
-        (part) => (part as { type?: unknown }).type === "text"
-      );
-      expect(textParts).toHaveLength(2);
-      expect(JSON.stringify(textParts)).toContain("corrupt.webm");
-      expect(
-        rewrittenValue.some((part) => (part as { type?: unknown }).type === "display_file")
-      ).toBe(false);
-    } else {
-      throw new Error("Expected rewritten content output");
-    }
+    const rewrittenValue = expectContentOutputValue(toolPart.output);
+    const textParts = rewrittenValue.filter((part) => (part as { type?: unknown }).type === "text");
+    expect(textParts).toHaveLength(2);
+    expect(JSON.stringify(textParts)).toContain("corrupt.webm");
+    expect(
+      rewrittenValue.some((part) => (part as { type?: unknown }).type === "display_file")
+    ).toBe(false);
+
     const outputText = JSON.stringify(toolPart.output);
     expect(outputText).not.toContain(base64);
   });

--- a/src/node/utils/messages/extractToolMediaAsUserMessages.test.ts
+++ b/src/node/utils/messages/extractToolMediaAsUserMessages.test.ts
@@ -267,6 +267,51 @@ describe("extractToolMediaAsUserMessages", () => {
     expect(svgTextPart).toBeDefined();
   });
 
+  it("strips display-only file bytes without creating a model attachment", async () => {
+    const base64 = Buffer.from("webm bytes").toString("base64");
+    const input: MuxMessage[] = [
+      {
+        id: "a5",
+        role: "assistant",
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolCallId: "call5",
+            toolName: "attach_file",
+            input: { path: "/tmp/clip.webm" },
+            state: "output-available",
+            output: {
+              type: "content",
+              value: [
+                { type: "text", text: "[File shown to user: clip.webm]" },
+                {
+                  type: "file-data",
+                  mediaType: "video/webm",
+                  data: base64,
+                  filename: "clip.webm",
+                  providerOptions: { mux: { displayOnly: true, size: 10 } },
+                },
+              ],
+            },
+          },
+        ],
+        metadata: { timestamp: 5 },
+      },
+    ];
+
+    const rewritten = await extractToolMediaAsUserMessages(input);
+    expect(rewritten).toHaveLength(1);
+
+    const toolPart = rewritten[0].parts[0];
+    expect(toolPart.type).toBe("dynamic-tool");
+    if (toolPart.type === "dynamic-tool" && toolPart.state === "output-available") {
+      const outputText = JSON.stringify(toolPart.output);
+      expect(outputText).toContain("File shown to user only");
+      expect(outputText).not.toContain(base64);
+      expect(outputText).not.toContain("file-data");
+    }
+  });
+
   it("does not rewrite unrelated tool outputs", async () => {
     const input: MuxMessage[] = [
       {

--- a/src/node/utils/messages/extractToolMediaAsUserMessages.test.ts
+++ b/src/node/utils/messages/extractToolMediaAsUserMessages.test.ts
@@ -308,7 +308,6 @@ describe("extractToolMediaAsUserMessages", () => {
     }
 
     const outputText = JSON.stringify(toolPart.output);
-    expect(outputText).toContain("File shown to user only");
     expect(outputText).not.toContain(base64);
     if (
       typeof toolPart.output === "object" &&
@@ -364,7 +363,6 @@ describe("extractToolMediaAsUserMessages", () => {
     }
 
     const outputText = JSON.stringify(toolPart.output);
-    expect(outputText).toContain("File shown to user only");
     expect(outputText).not.toContain(base64);
   });
 

--- a/src/node/utils/messages/extractToolMediaAsUserMessages.test.ts
+++ b/src/node/utils/messages/extractToolMediaAsUserMessages.test.ts
@@ -303,13 +303,14 @@ describe("extractToolMediaAsUserMessages", () => {
     expect(rewritten).toHaveLength(1);
 
     const toolPart = rewritten[0].parts[0];
-    expect(toolPart.type).toBe("dynamic-tool");
-    if (toolPart.type === "dynamic-tool" && toolPart.state === "output-available") {
-      const outputText = JSON.stringify(toolPart.output);
-      expect(outputText).toContain("File shown to user only");
-      expect(outputText).not.toContain(base64);
-      expect(outputText).not.toContain("file-data");
+    if (toolPart.type !== "dynamic-tool" || toolPart.state !== "output-available") {
+      throw new Error("Expected rewritten output-available tool part");
     }
+
+    const outputText = JSON.stringify(toolPart.output);
+    expect(outputText).toContain("File shown to user only");
+    expect(outputText).not.toContain(base64);
+    expect(outputText).not.toContain("file-data");
   });
 
   it("does not rewrite unrelated tool outputs", async () => {

--- a/src/node/utils/messages/extractToolMediaAsUserMessages.test.ts
+++ b/src/node/utils/messages/extractToolMediaAsUserMessages.test.ts
@@ -316,6 +316,11 @@ describe("extractToolMediaAsUserMessages", () => {
       Array.isArray((toolPart.output as { value?: unknown }).value)
     ) {
       const rewrittenValue = (toolPart.output as { value: unknown[] }).value;
+      const textParts = rewrittenValue.filter(
+        (part) => (part as { type?: unknown }).type === "text"
+      );
+      expect(textParts).toHaveLength(2);
+      expect(JSON.stringify(textParts)).toContain("clip.webm");
       expect(
         rewrittenValue.some((part) => (part as { type?: unknown }).type === "display_file")
       ).toBe(false);
@@ -362,6 +367,24 @@ describe("extractToolMediaAsUserMessages", () => {
       throw new Error("Expected rewritten output-available tool part");
     }
 
+    if (
+      typeof toolPart.output === "object" &&
+      toolPart.output !== null &&
+      (toolPart.output as { type?: unknown }).type === "content" &&
+      Array.isArray((toolPart.output as { value?: unknown }).value)
+    ) {
+      const rewrittenValue = (toolPart.output as { value: unknown[] }).value;
+      const textParts = rewrittenValue.filter(
+        (part) => (part as { type?: unknown }).type === "text"
+      );
+      expect(textParts).toHaveLength(2);
+      expect(JSON.stringify(textParts)).toContain("corrupt.webm");
+      expect(
+        rewrittenValue.some((part) => (part as { type?: unknown }).type === "display_file")
+      ).toBe(false);
+    } else {
+      throw new Error("Expected rewritten content output");
+    }
     const outputText = JSON.stringify(toolPart.output);
     expect(outputText).not.toContain(base64);
   });

--- a/src/node/utils/messages/extractToolMediaAsUserMessages.test.ts
+++ b/src/node/utils/messages/extractToolMediaAsUserMessages.test.ts
@@ -325,6 +325,49 @@ describe("extractToolMediaAsUserMessages", () => {
     }
   });
 
+  it("strips display-only file bytes even when metadata is missing", async () => {
+    const base64 = Buffer.from("webm bytes").toString("base64");
+    const input: MuxMessage[] = [
+      {
+        id: "a6",
+        role: "assistant",
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolCallId: "call6",
+            toolName: "attach_file",
+            input: { path: "/tmp/corrupt.webm" },
+            state: "output-available",
+            output: {
+              type: "content",
+              value: [
+                { type: "text", text: "[File shown to user: corrupt.webm]" },
+                {
+                  type: "display_file",
+                  mediaType: "video/webm",
+                  data: base64,
+                  filename: "corrupt.webm",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+
+    const rewritten = await extractToolMediaAsUserMessages(input);
+    expect(rewritten).toHaveLength(1);
+
+    const toolPart = rewritten[0].parts[0];
+    if (toolPart.type !== "dynamic-tool" || toolPart.state !== "output-available") {
+      throw new Error("Expected rewritten output-available tool part");
+    }
+
+    const outputText = JSON.stringify(toolPart.output);
+    expect(outputText).toContain("File shown to user only");
+    expect(outputText).not.toContain(base64);
+  });
+
   it("does not rewrite unrelated tool outputs", async () => {
     const input: MuxMessage[] = [
       {

--- a/src/node/utils/messages/extractToolMediaAsUserMessagesFromModelMessages.test.ts
+++ b/src/node/utils/messages/extractToolMediaAsUserMessagesFromModelMessages.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@jest/globals";
-import type { ModelMessage } from "ai";
+import type { ModelMessage, ToolResultPart } from "ai";
 import sharp from "sharp";
 import { MAX_IMAGE_DIMENSION } from "@/common/constants/imageAttachments";
 import { extractToolMediaAsUserMessagesFromModelMessages } from "./extractToolMediaAsUserMessagesFromModelMessages";
@@ -233,7 +233,7 @@ describe("extractToolMediaAsUserMessagesFromModelMessages", () => {
       value: [
         { type: "text", text: "[File shown to user: clip.webm]" },
         {
-          type: "file-data",
+          type: "display_file",
           mediaType: "video/webm",
           data: base64,
           filename: "clip.webm",
@@ -250,7 +250,7 @@ describe("extractToolMediaAsUserMessagesFromModelMessages", () => {
             type: "tool-result",
             toolCallId: "call-display",
             toolName: "attach_file",
-            output: attachFileOutput,
+            output: attachFileOutput as unknown as ToolResultPart["output"],
           },
         ],
       },
@@ -266,7 +266,19 @@ describe("extractToolMediaAsUserMessagesFromModelMessages", () => {
     const outputText = JSON.stringify(toolResultPart.output);
     expect(outputText).toContain("File shown to user only");
     expect(outputText).not.toContain(base64);
-    expect(outputText).not.toContain("file-data");
+    if (
+      typeof toolResultPart.output === "object" &&
+      toolResultPart.output !== null &&
+      (toolResultPart.output as { type?: unknown }).type === "content" &&
+      Array.isArray((toolResultPart.output as { value?: unknown }).value)
+    ) {
+      const rewrittenValue = (toolResultPart.output as { value: unknown[] }).value;
+      expect(
+        rewrittenValue.some((part) => (part as { type?: unknown }).type === "display_file")
+      ).toBe(false);
+    } else {
+      throw new Error("Expected rewritten content output");
+    }
   });
 
   it("is a no-op when there is no media", async () => {

--- a/src/node/utils/messages/extractToolMediaAsUserMessagesFromModelMessages.test.ts
+++ b/src/node/utils/messages/extractToolMediaAsUserMessagesFromModelMessages.test.ts
@@ -264,7 +264,6 @@ describe("extractToolMediaAsUserMessagesFromModelMessages", () => {
     const toolResultPart = (rewrittenTool as Extract<ModelMessage, { role: "tool" }>).content[0];
     if (toolResultPart.type !== "tool-result") throw new Error("Expected tool-result part");
     const outputText = JSON.stringify(toolResultPart.output);
-    expect(outputText).toContain("File shown to user only");
     expect(outputText).not.toContain(base64);
     if (
       typeof toolResultPart.output === "object" &&

--- a/src/node/utils/messages/extractToolMediaAsUserMessagesFromModelMessages.test.ts
+++ b/src/node/utils/messages/extractToolMediaAsUserMessagesFromModelMessages.test.ts
@@ -272,6 +272,11 @@ describe("extractToolMediaAsUserMessagesFromModelMessages", () => {
       Array.isArray((toolResultPart.output as { value?: unknown }).value)
     ) {
       const rewrittenValue = (toolResultPart.output as { value: unknown[] }).value;
+      const textParts = rewrittenValue.filter(
+        (part) => (part as { type?: unknown }).type === "text"
+      );
+      expect(textParts).toHaveLength(2);
+      expect(JSON.stringify(textParts)).toContain("clip.webm");
       expect(
         rewrittenValue.some((part) => (part as { type?: unknown }).type === "display_file")
       ).toBe(false);

--- a/src/node/utils/messages/extractToolMediaAsUserMessagesFromModelMessages.test.ts
+++ b/src/node/utils/messages/extractToolMediaAsUserMessagesFromModelMessages.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@jest/globals";
 import type { ModelMessage, ToolResultPart } from "ai";
 import sharp from "sharp";
 import { MAX_IMAGE_DIMENSION } from "@/common/constants/imageAttachments";
+import { expectContentOutputValue } from "./testToolOutputHelpers";
 import { extractToolMediaAsUserMessagesFromModelMessages } from "./extractToolMediaAsUserMessagesFromModelMessages";
 
 describe("extractToolMediaAsUserMessagesFromModelMessages", () => {
@@ -265,24 +266,13 @@ describe("extractToolMediaAsUserMessagesFromModelMessages", () => {
     if (toolResultPart.type !== "tool-result") throw new Error("Expected tool-result part");
     const outputText = JSON.stringify(toolResultPart.output);
     expect(outputText).not.toContain(base64);
-    if (
-      typeof toolResultPart.output === "object" &&
-      toolResultPart.output !== null &&
-      (toolResultPart.output as { type?: unknown }).type === "content" &&
-      Array.isArray((toolResultPart.output as { value?: unknown }).value)
-    ) {
-      const rewrittenValue = (toolResultPart.output as { value: unknown[] }).value;
-      const textParts = rewrittenValue.filter(
-        (part) => (part as { type?: unknown }).type === "text"
-      );
-      expect(textParts).toHaveLength(2);
-      expect(JSON.stringify(textParts)).toContain("clip.webm");
-      expect(
-        rewrittenValue.some((part) => (part as { type?: unknown }).type === "display_file")
-      ).toBe(false);
-    } else {
-      throw new Error("Expected rewritten content output");
-    }
+    const rewrittenValue = expectContentOutputValue(toolResultPart.output);
+    const textParts = rewrittenValue.filter((part) => (part as { type?: unknown }).type === "text");
+    expect(textParts).toHaveLength(2);
+    expect(JSON.stringify(textParts)).toContain("clip.webm");
+    expect(
+      rewrittenValue.some((part) => (part as { type?: unknown }).type === "display_file")
+    ).toBe(false);
   });
 
   it("is a no-op when there is no media", async () => {

--- a/src/node/utils/messages/extractToolMediaAsUserMessagesFromModelMessages.test.ts
+++ b/src/node/utils/messages/extractToolMediaAsUserMessagesFromModelMessages.test.ts
@@ -226,6 +226,49 @@ describe("extractToolMediaAsUserMessagesFromModelMessages", () => {
     expect(svgTextPart).toBeDefined();
   });
 
+  it("strips display-only file bytes without adding a synthetic user message", async () => {
+    const base64 = Buffer.from("webm bytes").toString("base64");
+    const attachFileOutput = {
+      type: "content",
+      value: [
+        { type: "text", text: "[File shown to user: clip.webm]" },
+        {
+          type: "file-data",
+          mediaType: "video/webm",
+          data: base64,
+          filename: "clip.webm",
+          providerOptions: { mux: { displayOnly: true, size: 10 } },
+        },
+      ],
+    } as const satisfies { type: "content"; value: unknown[] };
+
+    const input: ModelMessage[] = [
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-display",
+            toolName: "attach_file",
+            output: attachFileOutput,
+          },
+        ],
+      },
+    ];
+
+    const rewritten = await extractToolMediaAsUserMessagesFromModelMessages(input);
+    expect(rewritten).toHaveLength(1);
+
+    const rewrittenTool = rewritten[0];
+    expect(rewrittenTool.role).toBe("tool");
+    const toolResultPart = (rewrittenTool as Extract<ModelMessage, { role: "tool" }>).content[0];
+    if (toolResultPart.type !== "tool-result") throw new Error("Expected tool-result part");
+    const outputText = JSON.stringify(toolResultPart.output);
+    expect(outputText).toContain("File shown to user only");
+    expect(outputText).not.toContain(base64);
+    expect(outputText).not.toContain("file-data");
+  });
+
   it("is a no-op when there is no media", async () => {
     const input: ModelMessage[] = [
       {

--- a/src/node/utils/messages/testToolOutputHelpers.ts
+++ b/src/node/utils/messages/testToolOutputHelpers.ts
@@ -1,11 +1,8 @@
+import { isToolContentResult } from "@/common/utils/tools/toolContentResult";
+
 export function expectContentOutputValue(output: unknown): unknown[] {
-  if (
-    typeof output === "object" &&
-    output !== null &&
-    (output as { type?: unknown }).type === "content" &&
-    Array.isArray((output as { value?: unknown }).value)
-  ) {
-    return (output as { value: unknown[] }).value;
+  if (isToolContentResult(output)) {
+    return output.value;
   }
 
   throw new Error("Expected rewritten content output");

--- a/src/node/utils/messages/testToolOutputHelpers.ts
+++ b/src/node/utils/messages/testToolOutputHelpers.ts
@@ -1,0 +1,12 @@
+export function expectContentOutputValue(output: unknown): unknown[] {
+  if (
+    typeof output === "object" &&
+    output !== null &&
+    (output as { type?: unknown }).type === "content" &&
+    Array.isArray((output as { value?: unknown }).value)
+  ) {
+    return (output as { value: unknown[] }).value;
+  }
+
+  throw new Error("Expected rewritten content output");
+}

--- a/src/node/utils/messages/toolResultAttachments.ts
+++ b/src/node/utils/messages/toolResultAttachments.ts
@@ -1,3 +1,8 @@
+import {
+  getDisplayOnlyFileMetadata,
+  isDisplayOnlyFilePart,
+  type DisplayOnlyFilePart,
+} from "@/common/utils/attachments/displayOnlyFileParts";
 import { MAX_SVG_TEXT_CHARS, SVG_MEDIA_TYPE } from "@/common/constants/imageAttachments";
 import {
   isSupportedAttachmentMediaType,
@@ -24,19 +29,6 @@ interface AISDKMediaPart {
 interface AISDKTextPart {
   type: "text";
   text: string;
-}
-
-interface DisplayOnlyFilePart {
-  type: "file-data";
-  data: string;
-  mediaType: string;
-  filename?: string;
-  providerOptions: {
-    mux?: {
-      displayOnly?: boolean;
-      size?: number;
-    };
-  };
 }
 
 type AISDKContent =
@@ -87,39 +79,6 @@ function isMediaPart(value: unknown): value is AISDKMediaPart {
   );
 }
 
-function getMuxProviderOptions(value: unknown): { displayOnly?: boolean; size?: number } | null {
-  if (typeof value !== "object" || value === null) {
-    return null;
-  }
-
-  const muxOptions = (value as Record<string, unknown>).mux;
-  if (typeof muxOptions !== "object" || muxOptions === null) {
-    return null;
-  }
-
-  const record = muxOptions as Record<string, unknown>;
-  return {
-    ...(typeof record.displayOnly === "boolean" ? { displayOnly: record.displayOnly } : {}),
-    ...(typeof record.size === "number" ? { size: record.size } : {}),
-  };
-}
-
-function isDisplayOnlyFilePart(value: unknown): value is DisplayOnlyFilePart {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-
-  const record = value as Record<string, unknown>;
-  const muxOptions = getMuxProviderOptions(record.providerOptions);
-  return (
-    record.type === "file-data" &&
-    typeof record.data === "string" &&
-    typeof record.mediaType === "string" &&
-    (record.filename === undefined || typeof record.filename === "string") &&
-    muxOptions?.displayOnly === true
-  );
-}
-
 function normalizeOptionalFilename(filename: string | undefined): string | undefined {
   const trimmed = filename?.trim();
   return trimmed != null && trimmed.length > 0 ? trimmed : undefined;
@@ -139,7 +98,7 @@ function buildDisplayOnlyFilePlaceholder(item: DisplayOnlyFilePart): AISDKTextPa
   const normalizedMediaType = normalizeAttachmentMediaType(item.mediaType);
   const filename = normalizeOptionalFilename(item.filename);
   const label = filename != null ? `${filename} (${normalizedMediaType})` : normalizedMediaType;
-  const sizeValue = getMuxProviderOptions(item.providerOptions)?.size;
+  const sizeValue = getDisplayOnlyFileMetadata(item.providerOptions)?.size;
   const size = typeof sizeValue === "number" ? `, size=${sizeValue} bytes` : "";
   return {
     type: "text",
@@ -186,7 +145,6 @@ export function extractAttachmentsFromToolOutput(
 
     if (isDisplayOnlyFilePart(item)) {
       didChange = true;
-      // Display-only files are for the chat UI. Strip their bytes before any provider request.
       newValue.push(buildDisplayOnlyFilePlaceholder(item));
       continue;
     }

--- a/src/node/utils/messages/toolResultAttachments.ts
+++ b/src/node/utils/messages/toolResultAttachments.ts
@@ -26,7 +26,24 @@ interface AISDKTextPart {
   text: string;
 }
 
-type AISDKContent = AISDKMediaPart | AISDKTextPart | { type: string; [key: string]: unknown };
+interface DisplayOnlyFilePart {
+  type: "file-data";
+  data: string;
+  mediaType: string;
+  filename?: string;
+  providerOptions: {
+    mux?: {
+      displayOnly?: boolean;
+      size?: number;
+    };
+  };
+}
+
+type AISDKContent =
+  | AISDKMediaPart
+  | AISDKTextPart
+  | DisplayOnlyFilePart
+  | { type: string; [key: string]: unknown };
 
 interface AISDKContentContainer {
   type: "content";
@@ -70,6 +87,39 @@ function isMediaPart(value: unknown): value is AISDKMediaPart {
   );
 }
 
+function getMuxProviderOptions(value: unknown): { displayOnly?: boolean; size?: number } | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+
+  const muxOptions = (value as Record<string, unknown>).mux;
+  if (typeof muxOptions !== "object" || muxOptions === null) {
+    return null;
+  }
+
+  const record = muxOptions as Record<string, unknown>;
+  return {
+    ...(typeof record.displayOnly === "boolean" ? { displayOnly: record.displayOnly } : {}),
+    ...(typeof record.size === "number" ? { size: record.size } : {}),
+  };
+}
+
+function isDisplayOnlyFilePart(value: unknown): value is DisplayOnlyFilePart {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  const muxOptions = getMuxProviderOptions(record.providerOptions);
+  return (
+    record.type === "file-data" &&
+    typeof record.data === "string" &&
+    typeof record.mediaType === "string" &&
+    (record.filename === undefined || typeof record.filename === "string") &&
+    muxOptions?.displayOnly === true
+  );
+}
+
 function normalizeOptionalFilename(filename: string | undefined): string | undefined {
   const trimmed = filename?.trim();
   return trimmed != null && trimmed.length > 0 ? trimmed : undefined;
@@ -82,6 +132,18 @@ function buildAttachmentPlaceholder(item: AISDKMediaPart): AISDKTextPart {
   return {
     type: "text",
     text: `[Attachment attached: ${label} (base64 len=${item.data.length})]`,
+  };
+}
+
+function buildDisplayOnlyFilePlaceholder(item: DisplayOnlyFilePart): AISDKTextPart {
+  const normalizedMediaType = normalizeAttachmentMediaType(item.mediaType);
+  const filename = normalizeOptionalFilename(item.filename);
+  const label = filename != null ? `${filename} (${normalizedMediaType})` : normalizedMediaType;
+  const sizeValue = getMuxProviderOptions(item.providerOptions)?.size;
+  const size = typeof sizeValue === "number" ? `, size=${sizeValue} bytes` : "";
+  return {
+    type: "text",
+    text: `[File shown to user only: ${label}${size}. This file type is not supported as a model attachment, so no file bytes were sent to the model.]`,
   };
 }
 
@@ -106,9 +168,11 @@ export function extractAttachmentsFromToolOutput(
 
   const attachments: ExtractedToolAttachment[] = [];
   const newValue: AISDKContent[] = [];
+  let didChange = false;
 
   for (const item of output.value) {
     if (isMediaPart(item) && isSupportedAttachmentMediaType(item.mediaType)) {
+      didChange = true;
       attachments.push({
         data: item.data,
         mediaType: normalizeAttachmentMediaType(item.mediaType),
@@ -120,10 +184,17 @@ export function extractAttachmentsFromToolOutput(
       continue;
     }
 
+    if (isDisplayOnlyFilePart(item)) {
+      didChange = true;
+      // Display-only files are for the chat UI. Strip their bytes before any provider request.
+      newValue.push(buildDisplayOnlyFilePlaceholder(item));
+      continue;
+    }
+
     newValue.push(item);
   }
 
-  if (attachments.length === 0) {
+  if (!didChange) {
     return null;
   }
 


### PR DESCRIPTION
Summary

Shows unsupported `attach_file` outputs (for example `.webm`) in the chat UI instead of failing the tool outright, while preventing those unsupported file bytes from being sent to providers as model attachments.

Background

`attach_file` previously returned an error when a readable file was not one of the model-supported attachment types. This made files such as videos invisible to the user even though Mux could still display them usefully in the transcript.

Implementation

Unsupported readable files now fall back to a display-only `file-data` result tagged with `providerOptions.mux.displayOnly`. The attach-file tool renderer shows display-only files, including inline video/audio playback when the browser supports the media type, and request-time tool-result rewriting strips the bytes before provider calls while leaving a textual notice for the model.

Validation

- `make static-check`
- `make typecheck && make fmt-check && make lint`
- Display-only `attach_file` smoke test for `.webm` fallback and provider-rewrite byte stripping
- Attempted targeted Bun tests for affected files, but this environment cannot load `sharp` because `libstdc++.so.6` is missing.

Risks

Low-to-moderate risk in attach-file rendering and request rewriting paths. Supported attachments keep the existing media path; unsupported display-only files are explicitly marked and stripped before provider requests.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `high` • Cost: `$14.15`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=high costs=14.15 -->
