### PR TITLE
🤖 feat: show other agent-browser sessions

### DIFF
--- a/src/browser/features/RightSidebar/BrowserTab/BrowserTab.test.tsx
+++ b/src/browser/features/RightSidebar/BrowserTab/BrowserTab.test.tsx
@@ -212,7 +212,7 @@ describe("BrowserTab", () => {
     fireEvent.click(view.getByTestId("browser-session-current-alpha"));
 
     await waitFor(() => {
-      expect(connectMock.mock.calls.at(-1)).toEqual(["current-alpha"]);
+      expect(connectMock).toHaveBeenLastCalledWith("current-alpha");
     });
   });
 

--- a/src/browser/features/RightSidebar/BrowserTab/BrowserTab.test.tsx
+++ b/src/browser/features/RightSidebar/BrowserTab/BrowserTab.test.tsx
@@ -181,6 +181,41 @@ describe("BrowserTab", () => {
     expect(view.getByTestId("browser-other-session-other-alpha")).toBeTruthy();
   });
 
+  test("can switch from an explicitly selected other session back to a current session", async () => {
+    listSessionsMock.mockResolvedValue({
+      sessions: [createDiscoveredSession({ sessionName: "current-alpha" })],
+      otherSessions: [
+        {
+          sessionName: "other-alpha",
+          status: "attachable",
+          cwd: "/tmp/other-project",
+        },
+      ],
+    });
+
+    const view = render(<BrowserTab workspaceId="workspace-1" projectPath="/project" />);
+
+    await waitFor(() => {
+      expect(connectMock).toHaveBeenCalledWith("current-alpha");
+    });
+
+    fireEvent.click(view.getByText("current-alpha"));
+    fireEvent.click(view.getByTestId("browser-other-session-other-alpha"));
+
+    await waitFor(() => {
+      expect(connectMock).toHaveBeenCalledWith("other-alpha", {
+        allowOtherWorkspaceSession: true,
+      });
+    });
+
+    fireEvent.click(view.getByText("other-alpha"));
+    fireEvent.click(view.getByTestId("browser-session-current-alpha"));
+
+    await waitFor(() => {
+      expect(connectMock.mock.calls.at(-1)).toEqual(["current-alpha"]);
+    });
+  });
+
   test("attaches to an other running session only after selecting it from the picker", async () => {
     listSessionsMock.mockResolvedValue({
       sessions: [],
@@ -246,6 +281,14 @@ describe("chooseExplicitOtherSession", () => {
         { sessionName: "other-alpha", status: "attachable", cwd: "/tmp/other-project" },
       ])
     ).toBe("other-alpha");
+  });
+
+  test("clears an explicitly selected other session when only a different other session exists", () => {
+    expect(
+      chooseExplicitOtherSession("other-alpha", [
+        { sessionName: "other-beta", status: "attachable", cwd: "/tmp/other-project" },
+      ])
+    ).toBeNull();
   });
 
   test("clears an explicitly selected other session after discovery loses it", () => {

--- a/src/browser/features/RightSidebar/BrowserTab/BrowserTab.test.tsx
+++ b/src/browser/features/RightSidebar/BrowserTab/BrowserTab.test.tsx
@@ -1,12 +1,19 @@
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalWindow } from "happy-dom";
 import { useState } from "react";
 
-import type { BrowserDiscoveredSession, BrowserSession } from "./browserBridgeTypes";
+import type {
+  BrowserDiscoveredOtherSession,
+  BrowserDiscoveredSession,
+  BrowserSession,
+} from "./browserBridgeTypes";
 
 const listSessionsMock = mock(() =>
-  Promise.resolve({ sessions: [] as BrowserDiscoveredSession[] })
+  Promise.resolve({
+    sessions: [] as BrowserDiscoveredSession[],
+    otherSessions: [] as BrowserDiscoveredOtherSession[],
+  })
 );
 const connectMock = mock(() => undefined);
 const disconnectMock = mock(() => undefined);
@@ -88,7 +95,7 @@ describe("BrowserTab", () => {
     globalThis.document = globalThis.window.document;
 
     listSessionsMock.mockReset();
-    listSessionsMock.mockResolvedValue({ sessions: [] });
+    listSessionsMock.mockResolvedValue({ sessions: [], otherSessions: [] });
     connectMock.mockReset();
     disconnectMock.mockReset();
     setPendingUrlMock.mockReset();
@@ -106,6 +113,7 @@ describe("BrowserTab", () => {
   test("connects to missing_stream sessions while showing the activating state", async () => {
     listSessionsMock.mockResolvedValue({
       sessions: [createDiscoveredSession({ status: "missing_stream" })],
+      otherSessions: [],
     });
 
     const view = render(<BrowserTab workspaceId="workspace-1" projectPath="/project" />);
@@ -120,9 +128,64 @@ describe("BrowserTab", () => {
     expect(view.queryByText(/AGENT_BROWSER_STREAM_PORT/)).toBeNull();
   });
 
+  test("shows other running sessions in the session picker without auto-attaching", async () => {
+    listSessionsMock.mockResolvedValue({
+      sessions: [],
+      otherSessions: [
+        {
+          sessionName: "other-alpha",
+          status: "attachable",
+          cwd: "/tmp/other-project",
+        },
+      ],
+    });
+
+    const view = render(<BrowserTab workspaceId="workspace-1" projectPath="/project" />);
+
+    await waitFor(() => {
+      expect(view.getByText("Select session")).toBeTruthy();
+    });
+    expect(view.queryByText("Other running sessions")).toBeNull();
+
+    fireEvent.click(view.getByText("Select session"));
+
+    expect(view.getByText("other-alpha")).toBeTruthy();
+    expect(view.getByText("/tmp/other-project")).toBeTruthy();
+    expect(connectMock).not.toHaveBeenCalled();
+  });
+
+  test("attaches to an other running session only after selecting it from the picker", async () => {
+    listSessionsMock.mockResolvedValue({
+      sessions: [],
+      otherSessions: [
+        {
+          sessionName: "other-alpha",
+          status: "attachable",
+          cwd: "/tmp/other-project",
+        },
+      ],
+    });
+
+    const view = render(<BrowserTab workspaceId="workspace-1" projectPath="/project" />);
+
+    await waitFor(() => {
+      expect(view.getByText("Select session")).toBeTruthy();
+    });
+
+    fireEvent.click(view.getByText("Select session"));
+    fireEvent.click(view.getByTestId("browser-other-session-other-alpha"));
+
+    await waitFor(() => {
+      expect(connectMock).toHaveBeenCalledWith("other-alpha", {
+        allowOtherWorkspaceSession: true,
+      });
+    });
+  });
+
   test("renders the navigation toolbar with the active session URL", async () => {
     listSessionsMock.mockResolvedValue({
       sessions: [createDiscoveredSession()],
+      otherSessions: [],
     });
     mockSession = createSession({
       currentUrl: "https://current.example.com",

--- a/src/browser/features/RightSidebar/BrowserTab/BrowserTab.test.tsx
+++ b/src/browser/features/RightSidebar/BrowserTab/BrowserTab.test.tsx
@@ -52,6 +52,7 @@ void mock.module("./useBrowserBridgeConnection", () => ({
 import {
   BROWSER_PREVIEW_RETRY_INTERVAL_MS,
   BrowserTab,
+  chooseExplicitOtherSession,
   shouldBackOffBrowserReconnect,
 } from "./BrowserTab";
 
@@ -145,13 +146,39 @@ describe("BrowserTab", () => {
     await waitFor(() => {
       expect(view.getByText("Select session")).toBeTruthy();
     });
-    expect(view.queryByText("Other running sessions")).toBeNull();
+    expect(view.queryByText("Other sessions")).toBeNull();
+    expect(view.getByText("Choose a browser session")).toBeTruthy();
+    expect(view.getByText("Select an other session from the picker to connect.")).toBeTruthy();
 
     fireEvent.click(view.getByText("Select session"));
 
     expect(view.getByText("other-alpha")).toBeTruthy();
     expect(view.getByText("/tmp/other-project")).toBeTruthy();
     expect(connectMock).not.toHaveBeenCalled();
+  });
+
+  test("auto-selects current sessions while still listing other sessions in the picker", async () => {
+    listSessionsMock.mockResolvedValue({
+      sessions: [createDiscoveredSession({ sessionName: "current-alpha" })],
+      otherSessions: [
+        {
+          sessionName: "other-alpha",
+          status: "attachable",
+          cwd: "/tmp/other-project",
+        },
+      ],
+    });
+
+    const view = render(<BrowserTab workspaceId="workspace-1" projectPath="/project" />);
+
+    await waitFor(() => {
+      expect(connectMock).toHaveBeenCalledWith("current-alpha");
+    });
+
+    fireEvent.click(view.getByText("current-alpha"));
+
+    expect(view.getByTestId("browser-session-current-alpha")).toBeTruthy();
+    expect(view.getByTestId("browser-other-session-other-alpha")).toBeTruthy();
   });
 
   test("attaches to an other running session only after selecting it from the picker", async () => {
@@ -174,6 +201,10 @@ describe("BrowserTab", () => {
 
     fireEvent.click(view.getByText("Select session"));
     fireEvent.click(view.getByTestId("browser-other-session-other-alpha"));
+
+    await waitFor(() => {
+      expect(view.getByText("Waiting for browser frames")).toBeTruthy();
+    });
 
     await waitFor(() => {
       expect(connectMock).toHaveBeenCalledWith("other-alpha", {
@@ -205,6 +236,20 @@ describe("BrowserTab", () => {
     expect((view.getByLabelText("Forward") as HTMLButtonElement).disabled).toBe(false);
     expect((view.getByLabelText("Reload") as HTMLButtonElement).disabled).toBe(false);
     expect(view.getByTestId("browser-toolbar-loading-icon")).toBeTruthy();
+  });
+});
+
+describe("chooseExplicitOtherSession", () => {
+  test("preserves an explicitly selected other session while it is still discovered", () => {
+    expect(
+      chooseExplicitOtherSession("other-alpha", [
+        { sessionName: "other-alpha", status: "attachable", cwd: "/tmp/other-project" },
+      ])
+    ).toBe("other-alpha");
+  });
+
+  test("clears an explicitly selected other session after discovery loses it", () => {
+    expect(chooseExplicitOtherSession("other-alpha", [])).toBeNull();
   });
 });
 

--- a/src/browser/features/RightSidebar/BrowserTab/BrowserTab.test.tsx
+++ b/src/browser/features/RightSidebar/BrowserTab/BrowserTab.test.tsx
@@ -146,12 +146,12 @@ describe("BrowserTab", () => {
     await waitFor(() => {
       expect(view.getByText("Select session")).toBeTruthy();
     });
-    expect(view.queryByText("Other sessions")).toBeNull();
     expect(view.getByText("Choose a browser session")).toBeTruthy();
-    expect(view.getByText("Select an other session from the picker to connect.")).toBeTruthy();
+    expect(view.getByText("Select another session from the picker to connect.")).toBeTruthy();
 
     fireEvent.click(view.getByText("Select session"));
 
+    expect(view.getByText("Other sessions")).toBeTruthy();
     expect(view.getByText("other-alpha")).toBeTruthy();
     expect(view.getByText("/tmp/other-project")).toBeTruthy();
     expect(connectMock).not.toHaveBeenCalled();

--- a/src/browser/features/RightSidebar/BrowserTab/BrowserTab.tsx
+++ b/src/browser/features/RightSidebar/BrowserTab/BrowserTab.tsx
@@ -101,10 +101,6 @@ function chooseSelectedSession(
     return currentSessionName;
   }
 
-  if (currentSessionName != null && sessions.length === 0) {
-    return currentSessionName;
-  }
-
   return sessions[0]?.sessionName ?? null;
 }
 
@@ -513,8 +509,7 @@ function BrowserViewerState(props: {
     if (props.sessionStatus === "error") {
       return {
         title: "Browser preview unavailable",
-        description:
-          "Mux will keep retrying while a discovered browser session is available for this project.",
+        description: "Mux will keep retrying while the selected browser session is available.",
       };
     }
 

--- a/src/browser/features/RightSidebar/BrowserTab/BrowserTab.tsx
+++ b/src/browser/features/RightSidebar/BrowserTab/BrowserTab.tsx
@@ -5,6 +5,7 @@ import { usePersistedState } from "@/browser/hooks/usePersistedState";
 import { getBrowserSelectedSessionKey } from "@/common/constants/storage";
 import { cn } from "@/common/lib/utils";
 import type {
+  BrowserDiscoveredOtherSession,
   BrowserDiscoveredSession,
   BrowserDiscoveredSessionStatus,
   BrowserSession,
@@ -112,18 +113,25 @@ export function BrowserTab(props: BrowserTabProps) {
   const discoveryRefreshInFlightRef = useRef(false);
   const { api } = useAPI();
   const [discoveredSessions, setDiscoveredSessions] = useState<BrowserDiscoveredSession[]>([]);
-  const [selectedSessionName, setSelectedSessionName] = usePersistedState<string | null>(
-    getBrowserSelectedSessionKey(props.projectPath),
-    null,
-    { listener: true }
-  );
+  const [otherDiscoveredSessions, setOtherDiscoveredSessions] = useState<
+    BrowserDiscoveredOtherSession[]
+  >([]);
+  const [selectedCurrentSessionName, setSelectedCurrentSessionName] = usePersistedState<
+    string | null
+  >(getBrowserSelectedSessionKey(props.projectPath), null, { listener: true });
+  const [explicitOtherSessionName, setExplicitOtherSessionName] = useState<string | null>(null);
   const [discoveryError, setDiscoveryError] = useState<string | null>(null);
   const { session, connect, disconnect, sendInput, setPendingUrl } = useBrowserBridgeConnection(
     props.workspaceId
   );
 
-  const selectedDiscoveredSession =
-    discoveredSessions.find((candidate) => candidate.sessionName === selectedSessionName) ?? null;
+  const selectedSessionName = explicitOtherSessionName ?? selectedCurrentSessionName;
+  const selectedSessionAllowsOther = explicitOtherSessionName != null;
+  const selectedDiscoveredSession = selectedSessionAllowsOther
+    ? (otherDiscoveredSessions.find((candidate) => candidate.sessionName === selectedSessionName) ??
+      null)
+    : (discoveredSessions.find((candidate) => candidate.sessionName === selectedSessionName) ??
+      null);
 
   const isStarting = session?.status === "starting";
   const screenshotSrc =
@@ -141,6 +149,7 @@ export function BrowserTab(props: BrowserTabProps) {
     if (api == null) {
       setDiscoveryError("Browser API client is unavailable.");
       setDiscoveredSessions([]);
+      setOtherDiscoveredSessions([]);
       return;
     }
 
@@ -160,7 +169,14 @@ export function BrowserTab(props: BrowserTabProps) {
 
         setDiscoveryError(null);
         setDiscoveredSessions(result.sessions);
-        setSelectedSessionName((currentSessionName) =>
+        setOtherDiscoveredSessions(result.otherSessions);
+        setExplicitOtherSessionName((currentSessionName) =>
+          currentSessionName != null &&
+          result.otherSessions.some((session) => session.sessionName === currentSessionName)
+            ? currentSessionName
+            : null
+        );
+        setSelectedCurrentSessionName((currentSessionName) =>
           chooseSelectedSession(currentSessionName, result.sessions)
         );
       } catch (error) {
@@ -188,7 +204,7 @@ export function BrowserTab(props: BrowserTabProps) {
       cancelled = true;
       clearInterval(refreshTimer);
     };
-  }, [api, props.workspaceId, setSelectedSessionName]);
+  }, [api, props.workspaceId, setSelectedCurrentSessionName]);
 
   useEffect(() => {
     if (api == null || selectedSessionName == null || selectedDiscoveredSession == null) {
@@ -233,13 +249,18 @@ export function BrowserTab(props: BrowserTabProps) {
       sessionName: selectedSessionName,
       attemptedAtMs: now,
     };
-    connect(selectedSessionName);
+    if (selectedSessionAllowsOther) {
+      connect(selectedSessionName, { allowOtherWorkspaceSession: true });
+    } else {
+      connect(selectedSessionName);
+    }
   }, [
     api,
     connect,
     disconnect,
     selectedDiscoveredSession,
     selectedSessionName,
+    selectedSessionAllowsOther,
     session,
     visibleError,
   ]);
@@ -255,11 +276,17 @@ export function BrowserTab(props: BrowserTabProps) {
             {headerBadge && <BrowserHeaderBadge badge={headerBadge} />}
           </div>
         </div>
-        {discoveredSessions.length > 0 && selectedSessionName != null && (
+        {discoveredSessions.length + otherDiscoveredSessions.length > 0 && (
           <BrowserSessionPicker
-            sessions={discoveredSessions}
+            currentSessions={discoveredSessions}
+            otherSessions={otherDiscoveredSessions}
             selectedSessionName={selectedSessionName}
-            onChange={setSelectedSessionName}
+            selectedSessionAllowsOther={selectedSessionAllowsOther}
+            onSelectCurrent={(sessionName) => {
+              setExplicitOtherSessionName(null);
+              setSelectedCurrentSessionName(sessionName);
+            }}
+            onSelectOther={setExplicitOtherSessionName}
           />
         )}
       </div>
@@ -267,6 +294,7 @@ export function BrowserTab(props: BrowserTabProps) {
       <BrowserToolbar
         workspaceId={props.workspaceId}
         sessionName={selectedSessionName}
+        allowOtherWorkspaceSession={selectedSessionAllowsOther}
         currentUrl={session?.currentUrl ?? null}
         pendingUrl={session?.pendingUrl ?? null}
         isPageLoading={session?.isPageLoading ?? false}
@@ -298,6 +326,7 @@ export function BrowserTab(props: BrowserTabProps) {
               sessionStatus={session?.status ?? null}
               isStarting={isStarting}
               selectedSession={selectedDiscoveredSession}
+              hasOtherSessions={otherDiscoveredSessions.length > 0}
               hasDiscoveredSessions={discoveredSessions.length > 0}
             />
           }
@@ -321,9 +350,12 @@ function BrowserHeaderBadge(props: { badge: { label: string; className: string }
 }
 
 function BrowserSessionPicker(props: {
-  sessions: BrowserDiscoveredSession[];
-  selectedSessionName: string;
-  onChange: (sessionName: string) => void;
+  currentSessions: BrowserDiscoveredSession[];
+  otherSessions: BrowserDiscoveredOtherSession[];
+  selectedSessionName: string | null;
+  selectedSessionAllowsOther: boolean;
+  onSelectCurrent: (sessionName: string) => void;
+  onSelectOther: (sessionName: string) => void;
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -354,7 +386,7 @@ function BrowserSessionPicker(props: {
         aria-haspopup="listbox"
         onClick={() => setIsOpen((current) => !current)}
       >
-        <span className="truncate">{props.selectedSessionName}</span>
+        <span className="truncate">{props.selectedSessionName ?? "Select session"}</span>
         <ChevronDown className="h-3 w-3 shrink-0" />
       </button>
 
@@ -363,33 +395,43 @@ function BrowserSessionPicker(props: {
           <div
             role="listbox"
             aria-label="Browser sessions"
-            className="max-h-[240px] overflow-y-auto p-1"
+            className="max-h-[280px] overflow-y-auto p-1"
           >
-            {props.sessions.map((session) => (
-              <button
+            {props.currentSessions.map((session) => (
+              <BrowserSessionPickerOption
                 key={session.sessionName}
-                type="button"
-                role="option"
-                aria-selected={session.sessionName === props.selectedSessionName}
-                data-testid={`browser-session-${session.sessionName}`}
-                onMouseDown={(event) => event.preventDefault()}
-                onClick={() => {
-                  props.onChange(session.sessionName);
+                session={session}
+                isSelected={
+                  !props.selectedSessionAllowsOther &&
+                  session.sessionName === props.selectedSessionName
+                }
+                testId={`browser-session-${session.sessionName}`}
+                onSelect={() => {
+                  props.onSelectCurrent(session.sessionName);
                   setIsOpen(false);
                 }}
-                className="hover:bg-hover flex w-full items-center gap-1.5 rounded-sm px-2 py-1 text-left text-[11px]"
-              >
-                <Check
-                  className={cn(
-                    "h-3 w-3 shrink-0",
-                    session.sessionName === props.selectedSessionName ? "opacity-100" : "opacity-0"
-                  )}
-                />
-                <span className="min-w-0 flex-1 truncate">{session.sessionName}</span>
-                {session.status === "missing_stream" && (
-                  <span className="text-accent shrink-0 text-[10px]">Activating</span>
-                )}
-              </button>
+              />
+            ))}
+            {props.otherSessions.length > 0 && (
+              <div className="text-muted px-2 pt-1 pb-0.5 text-[10px] font-medium">
+                Other sessions
+              </div>
+            )}
+            {props.otherSessions.map((session) => (
+              <BrowserSessionPickerOption
+                key={session.sessionName}
+                session={session}
+                isSelected={
+                  props.selectedSessionAllowsOther &&
+                  session.sessionName === props.selectedSessionName
+                }
+                testId={`browser-other-session-${session.sessionName}`}
+                cwd={session.cwd}
+                onSelect={() => {
+                  props.onSelectOther(session.sessionName);
+                  setIsOpen(false);
+                }}
+              />
             ))}
           </div>
         </div>
@@ -398,10 +440,46 @@ function BrowserSessionPicker(props: {
   );
 }
 
+function BrowserSessionPickerOption(props: {
+  session: BrowserDiscoveredSession;
+  isSelected: boolean;
+  testId: string;
+  cwd?: string;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={props.isSelected}
+      data-testid={props.testId}
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={props.onSelect}
+      className="hover:bg-hover flex w-full items-start gap-1.5 rounded-sm px-2 py-1 text-left text-[11px]"
+    >
+      <Check
+        className={cn("mt-0.5 h-3 w-3 shrink-0", props.isSelected ? "opacity-100" : "opacity-0")}
+      />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate">{props.session.sessionName}</span>
+        {props.cwd != null && (
+          <span className="text-muted block truncate text-[10px]" title={props.cwd}>
+            {props.cwd}
+          </span>
+        )}
+      </span>
+      {props.session.status === "missing_stream" && (
+        <span className="text-accent mt-0.5 shrink-0 text-[10px]">Activating</span>
+      )}
+    </button>
+  );
+}
+
 function BrowserViewerState(props: {
   sessionStatus: BrowserSessionStatus | null;
   isStarting: boolean;
   selectedSession: BrowserDiscoveredSession | null;
+  hasOtherSessions: boolean;
   hasDiscoveredSessions: boolean;
 }) {
   const content = (() => {
@@ -431,6 +509,13 @@ function BrowserViewerState(props: {
       return {
         title: "Waiting for browser frames",
         description: "Mux found a browser session and is waiting for live preview frames.",
+      };
+    }
+
+    if (props.hasOtherSessions) {
+      return {
+        title: "Choose a browser session",
+        description: "Other running sessions require explicit attachment before Mux connects.",
       };
     }
 

--- a/src/browser/features/RightSidebar/BrowserTab/BrowserTab.tsx
+++ b/src/browser/features/RightSidebar/BrowserTab/BrowserTab.tsx
@@ -15,6 +15,10 @@ import { BrowserToolbar } from "./BrowserToolbar";
 import { BrowserViewport } from "./BrowserViewport";
 import { useBrowserBridgeConnection } from "./useBrowserBridgeConnection";
 
+type BrowserSelectedSession =
+  | { sessionName: string; source: "current" }
+  | { sessionName: string; source: "other" };
+
 interface BrowserTabProps {
   workspaceId: string;
   projectPath: string;
@@ -104,6 +108,16 @@ function chooseSelectedSession(
   return sessions[0]?.sessionName ?? null;
 }
 
+export function chooseExplicitOtherSession(
+  currentSessionName: string | null,
+  otherSessions: BrowserDiscoveredOtherSession[]
+): string | null {
+  return currentSessionName != null &&
+    otherSessions.some((otherSession) => otherSession.sessionName === currentSessionName)
+    ? currentSessionName
+    : null;
+}
+
 export function BrowserTab(props: BrowserTabProps) {
   if (props.workspaceId.trim().length === 0) {
     throw new Error("Browser tab requires a workspaceId");
@@ -125,9 +139,15 @@ export function BrowserTab(props: BrowserTabProps) {
     props.workspaceId
   );
 
-  const selectedSessionName = explicitOtherSessionName ?? selectedCurrentSessionName;
-  const selectedSessionAllowsOther = explicitOtherSessionName != null;
-  const selectedDiscoveredSession = selectedSessionAllowsOther
+  const selectedSession: BrowserSelectedSession | null =
+    explicitOtherSessionName != null
+      ? { sessionName: explicitOtherSessionName, source: "other" }
+      : selectedCurrentSessionName != null
+        ? { sessionName: selectedCurrentSessionName, source: "current" }
+        : null;
+  const selectedSessionName = selectedSession?.sessionName ?? null;
+  const isOtherSessionSelected = selectedSession?.source === "other";
+  const selectedDiscoveredSession = isOtherSessionSelected
     ? (otherDiscoveredSessions.find((candidate) => candidate.sessionName === selectedSessionName) ??
       null)
     : (discoveredSessions.find((candidate) => candidate.sessionName === selectedSessionName) ??
@@ -171,10 +191,7 @@ export function BrowserTab(props: BrowserTabProps) {
         setDiscoveredSessions(result.sessions);
         setOtherDiscoveredSessions(result.otherSessions);
         setExplicitOtherSessionName((currentSessionName) =>
-          currentSessionName != null &&
-          result.otherSessions.some((session) => session.sessionName === currentSessionName)
-            ? currentSessionName
-            : null
+          chooseExplicitOtherSession(currentSessionName, result.otherSessions)
         );
         setSelectedCurrentSessionName((currentSessionName) =>
           chooseSelectedSession(currentSessionName, result.sessions)
@@ -249,7 +266,7 @@ export function BrowserTab(props: BrowserTabProps) {
       sessionName: selectedSessionName,
       attemptedAtMs: now,
     };
-    if (selectedSessionAllowsOther) {
+    if (isOtherSessionSelected) {
       connect(selectedSessionName, { allowOtherWorkspaceSession: true });
     } else {
       connect(selectedSessionName);
@@ -260,7 +277,7 @@ export function BrowserTab(props: BrowserTabProps) {
     disconnect,
     selectedDiscoveredSession,
     selectedSessionName,
-    selectedSessionAllowsOther,
+    isOtherSessionSelected,
     session,
     visibleError,
   ]);
@@ -281,7 +298,7 @@ export function BrowserTab(props: BrowserTabProps) {
             currentSessions={discoveredSessions}
             otherSessions={otherDiscoveredSessions}
             selectedSessionName={selectedSessionName}
-            selectedSessionAllowsOther={selectedSessionAllowsOther}
+            isOtherSessionSelected={isOtherSessionSelected}
             onSelectCurrent={(sessionName) => {
               setExplicitOtherSessionName(null);
               setSelectedCurrentSessionName(sessionName);
@@ -294,7 +311,7 @@ export function BrowserTab(props: BrowserTabProps) {
       <BrowserToolbar
         workspaceId={props.workspaceId}
         sessionName={selectedSessionName}
-        allowOtherWorkspaceSession={selectedSessionAllowsOther}
+        allowOtherWorkspaceSession={isOtherSessionSelected}
         currentUrl={session?.currentUrl ?? null}
         pendingUrl={session?.pendingUrl ?? null}
         isPageLoading={session?.isPageLoading ?? false}
@@ -353,7 +370,7 @@ function BrowserSessionPicker(props: {
   currentSessions: BrowserDiscoveredSession[];
   otherSessions: BrowserDiscoveredOtherSession[];
   selectedSessionName: string | null;
-  selectedSessionAllowsOther: boolean;
+  isOtherSessionSelected: boolean;
   onSelectCurrent: (sessionName: string) => void;
   onSelectOther: (sessionName: string) => void;
 }) {
@@ -402,8 +419,7 @@ function BrowserSessionPicker(props: {
                 key={session.sessionName}
                 session={session}
                 isSelected={
-                  !props.selectedSessionAllowsOther &&
-                  session.sessionName === props.selectedSessionName
+                  !props.isOtherSessionSelected && session.sessionName === props.selectedSessionName
                 }
                 testId={`browser-session-${session.sessionName}`}
                 onSelect={() => {
@@ -422,11 +438,9 @@ function BrowserSessionPicker(props: {
                 key={session.sessionName}
                 session={session}
                 isSelected={
-                  props.selectedSessionAllowsOther &&
-                  session.sessionName === props.selectedSessionName
+                  props.isOtherSessionSelected && session.sessionName === props.selectedSessionName
                 }
                 testId={`browser-other-session-${session.sessionName}`}
-                cwd={session.cwd}
                 onSelect={() => {
                   props.onSelectOther(session.sessionName);
                   setIsOpen(false);
@@ -441,10 +455,9 @@ function BrowserSessionPicker(props: {
 }
 
 function BrowserSessionPickerOption(props: {
-  session: BrowserDiscoveredSession;
+  session: BrowserDiscoveredSession | BrowserDiscoveredOtherSession;
   isSelected: boolean;
   testId: string;
-  cwd?: string;
   onSelect: () => void;
 }) {
   return (
@@ -462,9 +475,9 @@ function BrowserSessionPickerOption(props: {
       />
       <span className="min-w-0 flex-1">
         <span className="block truncate">{props.session.sessionName}</span>
-        {props.cwd != null && (
-          <span className="text-muted block truncate text-[10px]" title={props.cwd}>
-            {props.cwd}
+        {"cwd" in props.session && (
+          <span className="text-muted block truncate text-[10px]" title={props.session.cwd}>
+            {props.session.cwd}
           </span>
         )}
       </span>
@@ -505,7 +518,7 @@ function BrowserViewerState(props: {
       };
     }
 
-    if (props.hasDiscoveredSessions) {
+    if (props.selectedSession != null || props.hasDiscoveredSessions) {
       return {
         title: "Waiting for browser frames",
         description: "Mux found a browser session and is waiting for live preview frames.",
@@ -515,7 +528,7 @@ function BrowserViewerState(props: {
     if (props.hasOtherSessions) {
       return {
         title: "Choose a browser session",
-        description: "Other running sessions require explicit attachment before Mux connects.",
+        description: "Select an other session from the picker to connect.",
       };
     }
 

--- a/src/browser/features/RightSidebar/BrowserTab/BrowserTab.tsx
+++ b/src/browser/features/RightSidebar/BrowserTab/BrowserTab.tsx
@@ -523,7 +523,7 @@ function BrowserViewerState(props: {
     if (props.hasOtherSessions) {
       return {
         title: "Choose a browser session",
-        description: "Select an other session from the picker to connect.",
+        description: "Select another session from the picker to connect.",
       };
     }
 

--- a/src/browser/features/RightSidebar/BrowserTab/BrowserToolbar.test.tsx
+++ b/src/browser/features/RightSidebar/BrowserTab/BrowserToolbar.test.tsx
@@ -191,6 +191,21 @@ describe("BrowserToolbar", () => {
     });
   });
 
+  test("sends explicit other-workspace scope with browser control commands", async () => {
+    const view = renderToolbar({ allowOtherWorkspaceSession: true });
+
+    fireEvent.click(view.getByLabelText("Reload"));
+
+    await waitFor(() => {
+      expect(controlMock).toHaveBeenCalledWith({
+        workspaceId: "workspace-1",
+        sessionName: "session-a",
+        action: "reload",
+        allowOtherWorkspaceSession: true,
+      });
+    });
+  });
+
   test("runs browser navigation shortcuts when the URL input is not focused", async () => {
     let keyDownHandler: ((event: KeyboardEvent) => void) | null = null;
     const originalAddEventListener = window.addEventListener.bind(window);

--- a/src/browser/features/RightSidebar/BrowserTab/BrowserToolbar.tsx
+++ b/src/browser/features/RightSidebar/BrowserTab/BrowserToolbar.tsx
@@ -16,6 +16,7 @@ import assert from "@/common/utils/assert";
 interface BrowserToolbarProps {
   workspaceId: string;
   sessionName: string | null;
+  allowOtherWorkspaceSession?: boolean;
   currentUrl: string | null;
   pendingUrl: string | null;
   isPageLoading: boolean;
@@ -141,6 +142,7 @@ export function BrowserToolbar(props: BrowserToolbarProps) {
         sessionName: targetSession,
         action,
         ...(url != null ? { url } : {}),
+        ...(props.allowOtherWorkspaceSession === true ? { allowOtherWorkspaceSession: true } : {}),
       });
       if (currentSessionNameRef.current !== targetSession) {
         return;

--- a/src/browser/features/RightSidebar/BrowserTab/browserBridgeTypes.ts
+++ b/src/browser/features/RightSidebar/BrowserTab/browserBridgeTypes.ts
@@ -17,6 +17,14 @@ export interface BrowserDiscoveredSession {
   status: BrowserDiscoveredSessionStatus;
 }
 
+export interface BrowserDiscoveredOtherSession extends BrowserDiscoveredSession {
+  cwd: string;
+}
+
+export interface BrowserSessionAttachOptions {
+  allowOtherWorkspaceSession?: boolean;
+}
+
 export type PageStateSource = "bootstrap" | "command" | "poll";
 
 export interface BrowserSession {

--- a/src/browser/features/RightSidebar/BrowserTab/useBrowserBridgeConnection.test.tsx
+++ b/src/browser/features/RightSidebar/BrowserTab/useBrowserBridgeConnection.test.tsx
@@ -173,6 +173,21 @@ describe("useBrowserBridgeConnection", () => {
     expect(result.current.session?.frameMetadata?.deviceWidth).toBe(1280);
   });
 
+  test("passes explicit other-workspace scope to browser bootstrap", async () => {
+    const result = renderHook(() => useBrowserBridgeConnection("workspace-1"));
+
+    act(() => {
+      result.result.current.connect("session-a", { allowOtherWorkspaceSession: true });
+    });
+    await flushAsyncWork();
+
+    expect(getBootstrapMock).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      sessionName: "session-a",
+      allowOtherWorkspaceSession: true,
+    });
+  });
+
   test("initializes new sessions with page state defaults", async () => {
     const { result } = await connectHook();
 

--- a/src/browser/features/RightSidebar/BrowserTab/useBrowserBridgeConnection.ts
+++ b/src/browser/features/RightSidebar/BrowserTab/useBrowserBridgeConnection.ts
@@ -5,6 +5,7 @@ import type {
   BrowserViewportMetadata,
   BrowserInputEvent,
   BrowserSession,
+  BrowserSessionAttachOptions,
   BrowserStreamState,
 } from "./browserBridgeTypes";
 
@@ -174,7 +175,7 @@ function createSession(
 
 export function useBrowserBridgeConnection(workspaceId: string): {
   session: BrowserSession | null;
-  connect: (sessionName: string) => void;
+  connect: (sessionName: string, options?: BrowserSessionAttachOptions) => void;
   disconnect: () => void;
   sendInput: (input: BrowserInputEvent) => void;
   setPendingUrl: (url: string | null) => void;
@@ -216,11 +217,10 @@ export function useBrowserBridgeConnection(workspaceId: string): {
     disconnectSocket(null, { intentionalCloseGeneration: generation });
   };
 
-  const connect = (sessionName: string) => {
+  const connect = (sessionName: string, options?: BrowserSessionAttachOptions) => {
     if (sessionName.trim().length === 0) {
       throw new Error("Browser bridge connection requires a non-empty sessionName");
     }
-
     void (async () => {
       const generation = generationRef.current + 1;
       generationRef.current = generation;
@@ -248,6 +248,9 @@ export function useBrowserBridgeConnection(workspaceId: string): {
         const bootstrap = await api.browser.getBootstrap({
           workspaceId,
           sessionName,
+          ...(options?.allowOtherWorkspaceSession === true
+            ? { allowOtherWorkspaceSession: true }
+            : {}),
         });
         if (generationRef.current !== generation) {
           return;

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -2077,6 +2077,10 @@ const BrowserDiscoveredSessionSchema = z.object({
   status: z.enum(["attachable", "missing_stream"]),
 });
 
+const BrowserDiscoveredOtherSessionSchema = BrowserDiscoveredSessionSchema.extend({
+  cwd: z.string(),
+});
+
 const BrowserControlActionSchema = z.enum(["open", "back", "forward", "reload"]);
 
 export const browser = {
@@ -2088,6 +2092,7 @@ export const browser = {
       .strict(),
     output: z.object({
       sessions: z.array(BrowserDiscoveredSessionSchema),
+      otherSessions: z.array(BrowserDiscoveredOtherSessionSchema),
     }),
   },
   getBootstrap: {
@@ -2095,6 +2100,7 @@ export const browser = {
       .object({
         workspaceId: z.string(),
         sessionName: z.string(),
+        allowOtherWorkspaceSession: z.boolean().nullish(),
       })
       .strict(),
     output: z.object({
@@ -2110,6 +2116,7 @@ export const browser = {
         sessionName: z.string(),
         action: BrowserControlActionSchema,
         url: z.string().nullish(),
+        allowOtherWorkspaceSession: z.boolean().nullish(),
       })
       .strict(),
     output: z.object({
@@ -2122,6 +2129,7 @@ export const browser = {
       .object({
         workspaceId: z.string(),
         sessionName: z.string(),
+        allowOtherWorkspaceSession: z.boolean().nullish(),
       })
       .strict(),
     output: z.object({

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -1181,13 +1181,18 @@ export const router = (authToken?: string) => {
         .input(schemas.browser.listSessions.input)
         .output(schemas.browser.listSessions.output)
         .handler(async ({ context, input }) => {
-          const sessions = await context.browserSessionDiscoveryService.listSessions(
+          const sessionGroups = await context.browserSessionDiscoveryService.listSessionGroups(
             input.workspaceId
           );
           return {
-            sessions: sessions.map((session) => ({
+            sessions: sessionGroups.sessions.map((session) => ({
               sessionName: session.sessionName,
               status: session.status,
+            })),
+            otherSessions: sessionGroups.otherSessions.map((session) => ({
+              sessionName: session.sessionName,
+              status: session.status,
+              cwd: session.cwd,
             })),
           };
         }),
@@ -1200,15 +1205,18 @@ export const router = (authToken?: string) => {
             throw new Error("Browser bridge bootstrap failed: API server unavailable");
           }
 
+          const allowOtherWorkspaceSession = input.allowOtherWorkspaceSession === true;
           const connection = await context.browserSessionDiscoveryService.ensureSessionAttachable(
             input.workspaceId,
-            input.sessionName
+            input.sessionName,
+            { allowOtherWorkspaceSession }
           );
 
           const token = context.browserBridgeTokenManager.mint(
             input.workspaceId,
             connection.sessionName,
-            connection.streamPort
+            connection.streamPort,
+            { allowOtherWorkspaceSession }
           );
 
           return {
@@ -1277,7 +1285,9 @@ export const router = (authToken?: string) => {
         .input(schemas.browser.getUrl.input)
         .output(schemas.browser.getUrl.output)
         .handler(async ({ context, input }) => {
-          return await context.browserControlService.getUrl(input.workspaceId, input.sessionName);
+          return await context.browserControlService.getUrl(input.workspaceId, input.sessionName, {
+            allowOtherWorkspaceSession: input.allowOtherWorkspaceSession === true,
+          });
         }),
     },
     uiLayouts: {

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -1237,6 +1237,7 @@ export const router = (authToken?: string) => {
           try {
             const result = await context.browserControlService.executeControl(input);
             if (result.success) {
+              // executeControl already validated the selected session with the explicit scope flag.
               const urlResult = await context.browserControlService.getUrl(
                 input.workspaceId,
                 input.sessionName,
@@ -1259,6 +1260,7 @@ export const router = (authToken?: string) => {
             return result;
           } catch (error) {
             try {
+              // executeControl already validated the selected session with the explicit scope flag.
               const urlResult = await context.browserControlService.getUrl(
                 input.workspaceId,
                 input.sessionName,

--- a/src/node/services/browser/AgentBrowserSessionDiscoveryService.test.ts
+++ b/src/node/services/browser/AgentBrowserSessionDiscoveryService.test.ts
@@ -454,7 +454,7 @@ describe("AgentBrowserSessionDiscoveryService", () => {
 
     // eslint-disable-next-line @typescript-eslint/await-thenable -- Bun's expect().rejects.toThrow() is thenable at runtime
     await expect(service.ensureSessionAttachable("workspace-1", "other-nostream")).rejects.toThrow(
-      'Session "other-nostream" is unavailable (no sessions discovered for workspace "workspace-1")'
+      'Session "other-nostream" not found for workspace "workspace-1"'
     );
 
     expect(

--- a/src/node/services/browser/AgentBrowserSessionDiscoveryService.test.ts
+++ b/src/node/services/browser/AgentBrowserSessionDiscoveryService.test.ts
@@ -341,6 +341,110 @@ describe("AgentBrowserSessionDiscoveryService", () => {
     expect(await service.listSessions("workspace-1")).toEqual([]);
   });
 
+  test("groups sessions from the current workspace separately from other live sessions", async () => {
+    const projectPath = path.join(tempDir, "project");
+    const otherProjectPath = path.join(tempDir, "different-project");
+    await mkdir(projectPath, { recursive: true });
+    await mkdir(otherProjectPath, { recursive: true });
+    await writeSessionFiles(socketDir, "current", { pid: "100", streamPort: "9100" });
+    await writeSessionFiles(socketDir, "other", { pid: "200", streamPort: "9200" });
+
+    const service = createService({
+      listSessionNamesFn: () => Promise.resolve(["other", "current"]),
+      resolveCandidatePaths: () => Promise.resolve([projectPath]),
+      resolveProcessCwdFn: (pid) => Promise.resolve(pid === 100 ? projectPath : otherProjectPath),
+    });
+
+    expect(await service.listSessionGroups("workspace-1")).toEqual({
+      sessions: [
+        {
+          sessionName: "current",
+          pid: 100,
+          cwd: projectPath,
+          status: "attachable",
+          streamPort: 9100,
+        },
+      ],
+      otherSessions: [
+        {
+          sessionName: "other",
+          pid: 200,
+          cwd: otherProjectPath,
+          status: "attachable",
+          streamPort: 9200,
+        },
+      ],
+    });
+  });
+
+  test("keeps other missing_stream sessions discoverable without adding them to current sessions", async () => {
+    const projectPath = path.join(tempDir, "project");
+    const otherProjectPath = path.join(tempDir, "different-project");
+    await mkdir(projectPath, { recursive: true });
+    await mkdir(otherProjectPath, { recursive: true });
+    await writeSessionFiles(socketDir, "other-nostream", { pid: "201" });
+
+    const service = createService({
+      listSessionNamesFn: () => Promise.resolve(["other-nostream"]),
+      resolveCandidatePaths: () => Promise.resolve([projectPath]),
+      resolveProcessCwdFn: () => Promise.resolve(otherProjectPath),
+    });
+
+    expect(await service.listSessions("workspace-1")).toEqual([]);
+    expect(await service.listSessionGroups("workspace-1")).toEqual({
+      sessions: [],
+      otherSessions: [
+        {
+          sessionName: "other-nostream",
+          pid: 201,
+          cwd: otherProjectPath,
+          status: "missing_stream",
+        },
+      ],
+    });
+  });
+
+  test("explicitly allowed other sessions can be made attachable", async () => {
+    const projectPath = path.join(tempDir, "project");
+    const otherProjectPath = path.join(tempDir, "different-project");
+    await mkdir(projectPath, { recursive: true });
+    await mkdir(otherProjectPath, { recursive: true });
+    await writeSessionFiles(socketDir, "other-nostream", { pid: "202" });
+
+    const statuses = [
+      { enabled: false, port: null },
+      { enabled: true, port: 12345 },
+    ];
+    const getSessionStreamStatusFn = mock(() => Promise.resolve(statuses.shift() ?? null));
+    const enableSessionStreamingFn = mock(() => Promise.resolve({ port: 12345 }));
+    const service = createService({
+      listSessionNamesFn: () => Promise.resolve(["other-nostream"]),
+      getSessionStreamStatusFn,
+      enableSessionStreamingFn,
+      resolveCandidatePaths: () => Promise.resolve([projectPath]),
+      resolveProcessCwdFn: () => Promise.resolve(otherProjectPath),
+    });
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- Bun's expect().rejects.toThrow() is thenable at runtime
+    await expect(service.ensureSessionAttachable("workspace-1", "other-nostream")).rejects.toThrow(
+      'Session "other-nostream" is unavailable (no sessions discovered for workspace "workspace-1")'
+    );
+
+    expect(
+      await service.ensureSessionAttachable("workspace-1", "other-nostream", {
+        allowOtherWorkspaceSession: true,
+      })
+    ).toEqual({
+      sessionName: "other-nostream",
+      pid: 202,
+      cwd: otherProjectPath,
+      status: "attachable",
+      streamPort: 12345,
+    });
+    expect(getSessionStreamStatusFn).toHaveBeenCalledTimes(2);
+    expect(enableSessionStreamingFn).toHaveBeenCalledTimes(1);
+  });
+
   test("skips dead pid sessions when cwd cannot be resolved", async () => {
     await writeSessionFiles(socketDir, "dead", { pid: "404", streamPort: "9300" });
 

--- a/src/node/services/browser/AgentBrowserSessionDiscoveryService.test.ts
+++ b/src/node/services/browser/AgentBrowserSessionDiscoveryService.test.ts
@@ -377,6 +377,33 @@ describe("AgentBrowserSessionDiscoveryService", () => {
     });
   });
 
+  test("getSessionConnection remains strict unless other sessions are explicitly allowed", async () => {
+    const projectPath = path.join(tempDir, "project");
+    const otherProjectPath = path.join(tempDir, "different-project");
+    await mkdir(projectPath, { recursive: true });
+    await mkdir(otherProjectPath, { recursive: true });
+    await writeSessionFiles(socketDir, "other", { pid: "203", streamPort: "9203" });
+
+    const service = createService({
+      listSessionNamesFn: () => Promise.resolve(["other"]),
+      resolveCandidatePaths: () => Promise.resolve([projectPath]),
+      resolveProcessCwdFn: () => Promise.resolve(otherProjectPath),
+    });
+
+    expect(await service.getSessionConnection("workspace-1", "other")).toBeNull();
+    expect(
+      await service.getSessionConnection("workspace-1", "other", {
+        allowOtherWorkspaceSession: true,
+      })
+    ).toEqual({
+      sessionName: "other",
+      pid: 203,
+      cwd: otherProjectPath,
+      status: "attachable",
+      streamPort: 9203,
+    });
+  });
+
   test("keeps other missing_stream sessions discoverable without adding them to current sessions", async () => {
     const projectPath = path.join(tempDir, "project");
     const otherProjectPath = path.join(tempDir, "different-project");

--- a/src/node/services/browser/AgentBrowserSessionDiscoveryService.ts
+++ b/src/node/services/browser/AgentBrowserSessionDiscoveryService.ts
@@ -203,6 +203,15 @@ export type AgentBrowserDiscoveredSession =
   | AgentBrowserDiscoveredSessionConnection
   | AgentBrowserMissingStreamSession;
 
+export interface AgentBrowserSessionGroups {
+  sessions: AgentBrowserDiscoveredSession[];
+  otherSessions: AgentBrowserDiscoveredSession[];
+}
+
+export interface AgentBrowserSessionLookupOptions {
+  allowOtherWorkspaceSession?: boolean;
+}
+
 interface StreamStatusResult {
   enabled: boolean;
   port: number | null;
@@ -564,23 +573,31 @@ export class AgentBrowserSessionDiscoveryService {
 
   async listSessions(workspaceId: string): Promise<AgentBrowserDiscoveredSession[]> {
     assert(workspaceId.trim().length > 0, "listSessions requires a non-empty workspaceId");
-    return await this.discoverSessions(workspaceId);
+    return (await this.discoverSessionGroups(workspaceId)).sessions;
+  }
+
+  async listSessionGroups(workspaceId: string): Promise<AgentBrowserSessionGroups> {
+    assert(workspaceId.trim().length > 0, "listSessionGroups requires a non-empty workspaceId");
+    return await this.discoverSessionGroups(workspaceId);
   }
 
   async getSessionConnection(
     workspaceId: string,
-    sessionName: string
+    sessionName: string,
+    options?: AgentBrowserSessionLookupOptions
   ): Promise<AgentBrowserDiscoveredSessionConnection | null> {
     assert(workspaceId.trim().length > 0, "getSessionConnection requires a non-empty workspaceId");
     assert(sessionName.trim().length > 0, "getSessionConnection requires a non-empty sessionName");
-    const sessions = await this.discoverSessions(workspaceId);
+    const sessionGroups = await this.discoverSessionGroups(workspaceId);
+    const sessions = this.getLookupSessions(sessionGroups, options);
     const session = sessions.find((candidate) => candidate.sessionName === sessionName) ?? null;
     return session?.status === "attachable" ? session : null;
   }
 
   async ensureSessionAttachable(
     workspaceId: string,
-    sessionName: string
+    sessionName: string,
+    options?: AgentBrowserSessionLookupOptions
   ): Promise<AgentBrowserDiscoveredSessionConnection> {
     assert(
       workspaceId.trim().length > 0,
@@ -591,7 +608,8 @@ export class AgentBrowserSessionDiscoveryService {
       "ensureSessionAttachable requires a non-empty sessionName"
     );
 
-    const sessions = await this.discoverSessions(workspaceId);
+    const sessionGroups = await this.discoverSessionGroups(workspaceId);
+    const sessions = this.getLookupSessions(sessionGroups, options);
     const session = sessions.find((candidate) => candidate.sessionName === sessionName) ?? null;
     if (session == null) {
       if (sessions.length === 0) {
@@ -648,16 +666,17 @@ export class AgentBrowserSessionDiscoveryService {
     };
   }
 
-  private async discoverSessions(workspaceId: string): Promise<AgentBrowserDiscoveredSession[]> {
+  private async discoverSessionGroups(workspaceId: string): Promise<AgentBrowserSessionGroups> {
     const candidatePaths = await this.resolveWorkspaceCandidatePathsFn(workspaceId);
     const comparableCandidatePaths = await this.resolveComparableCandidatePaths(candidatePaths);
     if (comparableCandidatePaths.length === 0) {
-      return [];
+      return { sessions: [], otherSessions: [] };
     }
 
     const socketDir = getAgentBrowserSocketDir(this.env);
     const sessionNames = await this.listSessionNamesFn();
     const sessions: AgentBrowserDiscoveredSession[] = [];
+    const otherSessions: AgentBrowserDiscoveredSession[] = [];
 
     for (const sessionName of sessionNames) {
       const pid = await readPositiveIntegerFile(
@@ -673,36 +692,42 @@ export class AgentBrowserSessionDiscoveryService {
         continue;
       }
 
-      const comparableCwd = await this.resolveComparablePath(cwd);
-      if (
-        !comparableCandidatePaths.some((candidatePath) =>
-          isPathInsideDir(candidatePath, comparableCwd)
-        )
-      ) {
-        continue;
-      }
-
       const streamPort = await readPositiveIntegerFile(
         this.readFileFn,
         path.join(socketDir, `${sessionName}.stream`)
       );
-      if (streamPort == null) {
-        sessions.push({ sessionName, pid, cwd, status: "missing_stream" });
-        continue;
-      }
+      const discoveredSession: AgentBrowserDiscoveredSession =
+        streamPort == null
+          ? { sessionName, pid, cwd, status: "missing_stream" }
+          : { sessionName, pid, cwd, status: "attachable", streamPort };
 
-      const attachableSession: AgentBrowserDiscoveredSessionConnection = {
-        sessionName,
-        pid,
-        cwd,
-        status: "attachable",
-        streamPort,
-      };
-      sessions.push(attachableSession);
+      const comparableCwd = await this.resolveComparablePath(cwd);
+      const isCurrentWorkspaceSession = comparableCandidatePaths.some((candidatePath) =>
+        isPathInsideDir(candidatePath, comparableCwd)
+      );
+      if (isCurrentWorkspaceSession) {
+        sessions.push(discoveredSession);
+      } else {
+        otherSessions.push(discoveredSession);
+      }
     }
 
-    sessions.sort((a, b) => a.sessionName.localeCompare(b.sessionName));
-    return sessions;
+    const compareBySessionName = (
+      a: AgentBrowserDiscoveredSession,
+      b: AgentBrowserDiscoveredSession
+    ) => a.sessionName.localeCompare(b.sessionName);
+    sessions.sort(compareBySessionName);
+    otherSessions.sort(compareBySessionName);
+    return { sessions, otherSessions };
+  }
+
+  private getLookupSessions(
+    sessionGroups: AgentBrowserSessionGroups,
+    options?: AgentBrowserSessionLookupOptions
+  ): AgentBrowserDiscoveredSession[] {
+    return options?.allowOtherWorkspaceSession === true
+      ? [...sessionGroups.sessions, ...sessionGroups.otherSessions]
+      : sessionGroups.sessions;
   }
 
   private async resolveComparableCandidatePaths(candidatePaths: string[]): Promise<string[]> {

--- a/src/node/services/browser/AgentBrowserSessionDiscoveryService.ts
+++ b/src/node/services/browser/AgentBrowserSessionDiscoveryService.ts
@@ -203,6 +203,7 @@ export type AgentBrowserDiscoveredSession =
   | AgentBrowserDiscoveredSessionConnection
   | AgentBrowserMissingStreamSession;
 
+/** Sessions split by whether their process CWD is inside the active workspace paths. */
 export interface AgentBrowserSessionGroups {
   sessions: AgentBrowserDiscoveredSession[];
   otherSessions: AgentBrowserDiscoveredSession[];

--- a/src/node/services/browser/AgentBrowserSessionDiscoveryService.ts
+++ b/src/node/services/browser/AgentBrowserSessionDiscoveryService.ts
@@ -613,7 +613,7 @@ export class AgentBrowserSessionDiscoveryService {
     const sessions = this.getLookupSessions(sessionGroups, options);
     const session = sessions.find((candidate) => candidate.sessionName === sessionName) ?? null;
     if (session == null) {
-      if (sessions.length === 0) {
+      if (sessionGroups.sessions.length + sessionGroups.otherSessions.length === 0) {
         throw new Error(
           `Session "${sessionName}" is unavailable (no sessions discovered for workspace "${workspaceId}")`
         );

--- a/src/node/services/browser/BrowserBridgeServer.test.ts
+++ b/src/node/services/browser/BrowserBridgeServer.test.ts
@@ -50,12 +50,16 @@ function createAttachableConnection(sessionName: string, streamPort: number) {
 
 function createBridgeServer(
   options: {
-    validate?: (
-      token: string
-    ) => { workspaceId: string; sessionName: string; streamPort: number } | null;
+    validate?: (token: string) => {
+      workspaceId: string;
+      sessionName: string;
+      streamPort: number;
+      allowOtherWorkspaceSession: boolean;
+    } | null;
     getSessionConnection?: (
       workspaceId: string,
-      sessionName: string
+      sessionName: string,
+      options?: { allowOtherWorkspaceSession?: boolean }
     ) => Promise<{
       sessionName: string;
       pid: number;
@@ -80,6 +84,7 @@ function createBridgeServer(
                 workspaceId: VALID_WORKSPACE_ID,
                 sessionName: VALID_SESSION_NAME,
                 streamPort: VALID_STREAM_PORT,
+                allowOtherWorkspaceSession: false,
               }
             : null
         ),
@@ -260,6 +265,7 @@ describe("BrowserBridgeServer", () => {
               workspaceId: VALID_WORKSPACE_ID,
               sessionName: VALID_SESSION_NAME,
               streamPort: upstreamHarness.port,
+              allowOtherWorkspaceSession: false,
             }
           : null
       ),
@@ -307,6 +313,35 @@ describe("BrowserBridgeServer", () => {
     }
   });
 
+  test("revalidates explicit other-workspace tokens with the same session scope", async () => {
+    const getSessionConnection = mock(() => Promise.resolve(null));
+    const bridgeServer = createBridgeServer({
+      validate: mock(() => ({
+        workspaceId: VALID_WORKSPACE_ID,
+        sessionName: VALID_SESSION_NAME,
+        streamPort: VALID_STREAM_PORT,
+        allowOtherWorkspaceSession: true,
+      })),
+      getSessionConnection,
+    });
+
+    try {
+      const ws = createMockClientSocket();
+      const bridgeServerPrivate = bridgeServer as unknown as BrowserBridgeServerPrivate;
+      await bridgeServerPrivate.handleUpgradedConnection(
+        ws as unknown as WebSocket,
+        { url: `/?token=${VALID_TOKEN}` } as IncomingMessage
+      );
+
+      expect(getSessionConnection).toHaveBeenCalledWith(VALID_WORKSPACE_ID, VALID_SESSION_NAME, {
+        allowOtherWorkspaceSession: true,
+      });
+      expect(ws.close).toHaveBeenCalledWith(4002, "session unavailable");
+    } finally {
+      await bridgeServer.stop();
+    }
+  });
+
   test("closes with 4002 when the live session is missing or mismatched", async () => {
     for (const liveSession of [null, createAttachableConnection(VALID_SESSION_NAME, 9999)]) {
       const bridgeServer = createBridgeServer({
@@ -314,6 +349,7 @@ describe("BrowserBridgeServer", () => {
           workspaceId: VALID_WORKSPACE_ID,
           sessionName: VALID_SESSION_NAME,
           streamPort: VALID_STREAM_PORT,
+          allowOtherWorkspaceSession: false,
         })),
         getSessionConnection: mock(() => Promise.resolve(liveSession)),
       });
@@ -360,6 +396,7 @@ describe("BrowserBridgeServer", () => {
               workspaceId: VALID_WORKSPACE_ID,
               sessionName: VALID_SESSION_NAME,
               streamPort: upstreamHarness.port,
+              allowOtherWorkspaceSession: false,
             }
           : null
       ),
@@ -409,6 +446,7 @@ describe("BrowserBridgeServer", () => {
               workspaceId: VALID_WORKSPACE_ID,
               sessionName: VALID_SESSION_NAME,
               streamPort: upstreamHarness.port,
+              allowOtherWorkspaceSession: false,
             }
           : null
       ),
@@ -468,6 +506,7 @@ describe("BrowserBridgeServer", () => {
               workspaceId: VALID_WORKSPACE_ID,
               sessionName: VALID_SESSION_NAME,
               streamPort: upstreamHarness.port,
+              allowOtherWorkspaceSession: false,
             }
           : null
       ),

--- a/src/node/services/browser/BrowserBridgeServer.test.ts
+++ b/src/node/services/browser/BrowserBridgeServer.test.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from "node:events";
 import { describe, expect, mock, test } from "bun:test";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
 import { BrowserBridgeServer } from "./BrowserBridgeServer";
+import type { BrowserBridgeTokenPayload } from "./BrowserBridgeTokenManager";
 import type { PageState } from "./BrowserSessionStateHub";
 
 const VALID_TOKEN = "valid-token";
@@ -50,12 +51,7 @@ function createAttachableConnection(sessionName: string, streamPort: number) {
 
 function createBridgeServer(
   options: {
-    validate?: (token: string) => {
-      workspaceId: string;
-      sessionName: string;
-      streamPort: number;
-      allowOtherWorkspaceSession: boolean;
-    } | null;
+    validate?: (token: string) => BrowserBridgeTokenPayload | null;
     getSessionConnection?: (
       workspaceId: string,
       sessionName: string,
@@ -284,6 +280,38 @@ describe("BrowserBridgeServer", () => {
 
       upstreamSocket.send('{"type":"frame","data":"abc"}');
       expect(await waitForMessage(ws)).toBe('{"type":"frame","data":"abc"}');
+    } finally {
+      ws.terminate();
+      await upgradeHarness.close();
+      await bridgeServer.stop();
+      await upstreamHarness.close();
+    }
+  });
+
+  test("bridges explicit other-workspace tokens on the success path", async () => {
+    const upstreamHarness = await listenUpstreamServer();
+    const getSessionConnection = mock(() =>
+      Promise.resolve(createAttachableConnection(VALID_SESSION_NAME, upstreamHarness.port))
+    );
+    const bridgeServer = createBridgeServer({
+      getSessionConnection,
+      validate: mock(() => ({
+        workspaceId: VALID_WORKSPACE_ID,
+        sessionName: VALID_SESSION_NAME,
+        streamPort: upstreamHarness.port,
+        allowOtherWorkspaceSession: true,
+      })),
+    });
+    const upgradeHarness = await listenUpgradeServer(bridgeServer);
+
+    const ws = new WebSocket(`ws://127.0.0.1:${upgradeHarness.port}/?token=${VALID_TOKEN}`);
+    try {
+      await waitForWebSocketOpen(ws);
+      await upstreamHarness.connectionPromise;
+
+      expect(getSessionConnection).toHaveBeenCalledWith(VALID_WORKSPACE_ID, VALID_SESSION_NAME, {
+        allowOtherWorkspaceSession: true,
+      });
     } finally {
       ws.terminate();
       await upgradeHarness.close();

--- a/src/node/services/browser/BrowserBridgeServer.ts
+++ b/src/node/services/browser/BrowserBridgeServer.ts
@@ -271,7 +271,8 @@ export class BrowserBridgeServer {
 
     const liveSession = await this.browserSessionDiscoveryService.getSessionConnection(
       payload.workspaceId,
-      payload.sessionName
+      payload.sessionName,
+      { allowOtherWorkspaceSession: payload.allowOtherWorkspaceSession }
     );
     if (
       !liveSession ||

--- a/src/node/services/browser/BrowserBridgeTokenManager.test.ts
+++ b/src/node/services/browser/BrowserBridgeTokenManager.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, setSystemTime } from "bun:test";
 import { AssertionError } from "@/common/utils/assert";
 import { BrowserBridgeTokenManager } from "./BrowserBridgeTokenManager";
 
 const TOKEN_TTL_MS = 30_000;
+
+afterEach(() => {
+  setSystemTime();
+});
 
 describe("BrowserBridgeTokenManager", () => {
   it("mints a 64-character hex token", () => {
@@ -64,18 +68,15 @@ describe("BrowserBridgeTokenManager", () => {
   });
 
   it("returns null for expired tokens", () => {
-    const originalNow = Date.now;
-    let nowMs = new Date("2026-01-01T00:00:00.000Z").getTime();
-    Date.now = () => nowMs;
+    setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
 
     const manager = new BrowserBridgeTokenManager();
     try {
       const token = manager.mint("workspace-1", "session-a", 9222);
-      nowMs += TOKEN_TTL_MS + 1;
+      setSystemTime(Date.now() + TOKEN_TTL_MS + 1);
       expect(manager.validate(token)).toBeNull();
     } finally {
       manager.dispose();
-      Date.now = originalNow;
     }
   });
 });

--- a/src/node/services/browser/BrowserBridgeTokenManager.test.ts
+++ b/src/node/services/browser/BrowserBridgeTokenManager.test.ts
@@ -1,15 +1,10 @@
-import { afterEach, describe, expect, it, setSystemTime, vi } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { AssertionError } from "@/common/utils/assert";
 import { BrowserBridgeTokenManager } from "./BrowserBridgeTokenManager";
 
 const TOKEN_TTL_MS = 30_000;
 
 describe("BrowserBridgeTokenManager", () => {
-  afterEach(() => {
-    setSystemTime();
-    vi.useRealTimers();
-  });
-
   it("mints a 64-character hex token", () => {
     const manager = new BrowserBridgeTokenManager();
 
@@ -42,6 +37,7 @@ describe("BrowserBridgeTokenManager", () => {
         workspaceId: "workspace-1",
         sessionName: "session-a",
         streamPort: 9222,
+        allowOtherWorkspaceSession: false,
       });
       expect(manager.validate(token)).toBeNull();
     } finally {
@@ -49,16 +45,37 @@ describe("BrowserBridgeTokenManager", () => {
     }
   });
 
+  it("preserves explicit other-workspace session scope", () => {
+    const manager = new BrowserBridgeTokenManager();
+
+    try {
+      const token = manager.mint("workspace-1", "session-a", 9222, {
+        allowOtherWorkspaceSession: true,
+      });
+      expect(manager.validate(token)).toEqual({
+        workspaceId: "workspace-1",
+        sessionName: "session-a",
+        streamPort: 9222,
+        allowOtherWorkspaceSession: true,
+      });
+    } finally {
+      manager.dispose();
+    }
+  });
+
   it("returns null for expired tokens", () => {
-    setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const originalNow = Date.now;
+    let nowMs = new Date("2026-01-01T00:00:00.000Z").getTime();
+    Date.now = () => nowMs;
 
     const manager = new BrowserBridgeTokenManager();
     try {
       const token = manager.mint("workspace-1", "session-a", 9222);
-      setSystemTime(Date.now() + TOKEN_TTL_MS + 1);
+      nowMs += TOKEN_TTL_MS + 1;
       expect(manager.validate(token)).toBeNull();
     } finally {
       manager.dispose();
+      Date.now = originalNow;
     }
   });
 });

--- a/src/node/services/browser/BrowserBridgeTokenManager.ts
+++ b/src/node/services/browser/BrowserBridgeTokenManager.ts
@@ -46,6 +46,7 @@ export class BrowserBridgeTokenManager {
       "BrowserBridgeTokenManager.mint requires integer streamPort"
     );
     assert(streamPort > 0, "BrowserBridgeTokenManager.mint requires positive streamPort");
+
     let token = "";
     do {
       token = randomBytes(32).toString("hex");

--- a/src/node/services/browser/BrowserBridgeTokenManager.ts
+++ b/src/node/services/browser/BrowserBridgeTokenManager.ts
@@ -6,7 +6,19 @@ interface TokenRecord {
   workspaceId: string;
   sessionName: string;
   streamPort: number;
+  allowOtherWorkspaceSession: boolean;
   expiresAtMs: number;
+}
+
+interface BrowserBridgeTokenMintOptions {
+  allowOtherWorkspaceSession?: boolean;
+}
+
+export interface BrowserBridgeTokenPayload {
+  workspaceId: string;
+  sessionName: string;
+  streamPort: number;
+  allowOtherWorkspaceSession: boolean;
 }
 
 const BROWSER_BRIDGE_TOKEN_TTL_MS = 30_000;
@@ -21,7 +33,12 @@ export class BrowserBridgeTokenManager {
     this.cleanupTimer.unref?.();
   }
 
-  mint(workspaceId: string, sessionName: string, streamPort: number): string {
+  mint(
+    workspaceId: string,
+    sessionName: string,
+    streamPort: number,
+    options?: BrowserBridgeTokenMintOptions
+  ): string {
     assert(workspaceId.length > 0, "BrowserBridgeTokenManager.mint requires non-empty workspaceId");
     assert(sessionName.length > 0, "BrowserBridgeTokenManager.mint requires non-empty sessionName");
     assert(
@@ -29,7 +46,6 @@ export class BrowserBridgeTokenManager {
       "BrowserBridgeTokenManager.mint requires integer streamPort"
     );
     assert(streamPort > 0, "BrowserBridgeTokenManager.mint requires positive streamPort");
-
     let token = "";
     do {
       token = randomBytes(32).toString("hex");
@@ -39,13 +55,14 @@ export class BrowserBridgeTokenManager {
       workspaceId,
       sessionName,
       streamPort,
+      allowOtherWorkspaceSession: options?.allowOtherWorkspaceSession === true,
       expiresAtMs: Date.now() + BROWSER_BRIDGE_TOKEN_TTL_MS,
     });
 
     return token;
   }
 
-  validate(token: string): { workspaceId: string; sessionName: string; streamPort: number } | null {
+  validate(token: string): BrowserBridgeTokenPayload | null {
     const record = this.tokens.get(token);
     if (!record) {
       return null;
@@ -62,6 +79,7 @@ export class BrowserBridgeTokenManager {
       workspaceId: record.workspaceId,
       sessionName: record.sessionName,
       streamPort: record.streamPort,
+      allowOtherWorkspaceSession: record.allowOtherWorkspaceSession,
     };
   }
 

--- a/src/node/services/browser/BrowserControlService.test.ts
+++ b/src/node/services/browser/BrowserControlService.test.ts
@@ -68,7 +68,8 @@ type SpawnFn = (command: string, args: string[], options: SpawnOptions) => Child
 function createService(options?: {
   getSessionConnection?: (
     workspaceId: string,
-    sessionName: string
+    sessionName: string,
+    options?: { allowOtherWorkspaceSession?: boolean }
   ) => Promise<ReturnType<typeof createAttachableSession> | null>;
   resolveSessionEnvFn?: (workspaceId: string) => Promise<NodeJS.ProcessEnv>;
   spawnFn?: SpawnFn;
@@ -253,6 +254,52 @@ describe("BrowserControlService", () => {
       error: `Session "${SESSION_NAME}" not found for workspace "${WORKSPACE_ID}"`,
     });
     expect(spawnFn).not.toHaveBeenCalled();
+  });
+
+  test("executeControl validates explicitly allowed other sessions with matching scope", async () => {
+    const child = new MockChildProcess();
+    const { spawnFn, waitForSpawn } = createSpawnHarness(child);
+    const getSessionConnection = mock(() => Promise.resolve(createAttachableSession()));
+    const service = createService({
+      getSessionConnection,
+      spawnFn,
+    });
+
+    const executionPromise = service.executeControl({
+      workspaceId: WORKSPACE_ID,
+      sessionName: SESSION_NAME,
+      action: "reload",
+      allowOtherWorkspaceSession: true,
+    });
+    await waitForSpawn();
+    child.close();
+
+    expect(await executionPromise).toEqual({ success: true });
+    expect(getSessionConnection).toHaveBeenCalledWith(WORKSPACE_ID, SESSION_NAME, {
+      allowOtherWorkspaceSession: true,
+    });
+  });
+
+  test("getUrl validates explicitly allowed other sessions with matching scope", async () => {
+    const child = new MockChildProcess();
+    const { spawnFn, waitForSpawn } = createSpawnHarness(child);
+    const getSessionConnection = mock(() => Promise.resolve(createAttachableSession()));
+    const service = createService({
+      getSessionConnection,
+      spawnFn,
+    });
+
+    const resultPromise = service.getUrl(WORKSPACE_ID, SESSION_NAME, {
+      allowOtherWorkspaceSession: true,
+    });
+    await waitForSpawn();
+    child.writeStdout("https://example.com/current\n");
+    child.close();
+
+    expect(await resultPromise).toEqual({ url: "https://example.com/current" });
+    expect(getSessionConnection).toHaveBeenCalledWith(WORKSPACE_ID, SESSION_NAME, {
+      allowOtherWorkspaceSession: true,
+    });
   });
 
   test("getUrl parses stdout from the CLI", async () => {

--- a/src/node/services/browser/BrowserControlService.ts
+++ b/src/node/services/browser/BrowserControlService.ts
@@ -16,6 +16,7 @@ export interface BrowserControlParams {
   sessionName: string;
   action: BrowserControlAction;
   url?: string | null;
+  allowOtherWorkspaceSession?: boolean | null;
 }
 
 export interface BrowserControlResult {
@@ -30,6 +31,7 @@ export interface BrowserGetUrlResult {
 
 export interface BrowserGetUrlOptions {
   skipSessionValidation?: boolean;
+  allowOtherWorkspaceSession?: boolean | null;
 }
 
 interface BrowserCommandExecutionResult {
@@ -70,7 +72,8 @@ export class BrowserControlService {
     try {
       const connection = await this.browserSessionDiscoveryService.getSessionConnection(
         params.workspaceId,
-        params.sessionName
+        params.sessionName,
+        { allowOtherWorkspaceSession: params.allowOtherWorkspaceSession === true }
       );
       if (connection == null) {
         return {
@@ -119,12 +122,18 @@ export class BrowserControlService {
       options?.skipSessionValidation == null || typeof options.skipSessionValidation === "boolean",
       "BrowserControlService getUrl skipSessionValidation must be a boolean when provided"
     );
+    assert(
+      options?.allowOtherWorkspaceSession == null ||
+        typeof options.allowOtherWorkspaceSession === "boolean",
+      "BrowserControlService getUrl allowOtherWorkspaceSession must be a boolean when provided"
+    );
 
     try {
       if (!options?.skipSessionValidation) {
         const connection = await this.browserSessionDiscoveryService.getSessionConnection(
           workspaceId,
-          sessionName
+          sessionName,
+          { allowOtherWorkspaceSession: options?.allowOtherWorkspaceSession === true }
         );
         if (connection == null) {
           return {
@@ -166,6 +175,12 @@ export class BrowserControlService {
     assert(
       BROWSER_CONTROL_ACTIONS.includes(params.action),
       `Unsupported browser control action: ${String(params.action)}`
+    );
+
+    assert(
+      params.allowOtherWorkspaceSession == null ||
+        typeof params.allowOtherWorkspaceSession === "boolean",
+      "BrowserControlService allowOtherWorkspaceSession must be a boolean when provided"
     );
 
     if (params.action === "open") {


### PR DESCRIPTION
Summary

Show agent-browser sessions from other working directories in the Browser tab session picker without auto-attaching to them. Current-workspace sessions remain the only auto-selected sessions; selecting an other session explicitly carries an allow flag through bootstrap, bridge validation, and browser controls.

Background

The Browser tab previously hid live agent-browser sessions whose process CWD was outside the current workspace, making it hard to discover and intentionally attach to a known session started elsewhere.

Implementation

Discovery now returns current-workspace sessions and other live sessions as separate groups. The renderer keeps other sessions in the existing picker with their CWD as secondary text, while backend attach/control paths remain workspace-scoped unless the explicit `allowOtherWorkspaceSession` flag is present.

Validation

- `bun test src/node/services/browser/AgentBrowserSessionDiscoveryService.test.ts src/node/services/browser/BrowserBridgeTokenManager.test.ts src/node/services/browser/BrowserBridgeServer.test.ts src/node/services/browser/BrowserControlService.test.ts src/browser/features/RightSidebar/BrowserTab/BrowserTab.test.tsx src/browser/features/RightSidebar/BrowserTab/useBrowserBridgeConnection.test.tsx src/browser/features/RightSidebar/BrowserTab/BrowserToolbar.test.tsx`
- `make typecheck`
- `make static-check`
- Dogfooded with isolated current/other agent-browser sessions in an Electron sandbox; verified the compact picker and explicit other-session attach flow with screenshots.

Risks

Moderate Browser-tab risk: the renderer selection state, bridge token scope, and control APIs changed together. The default backend paths remain strict and targeted tests cover strict-vs-explicit behavior.

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Show other `agent-browser` sessions in the Browser tab

## Goal

Make the Browser tab less confusing when `agent-browser` sessions are running outside the current workspace by showing them in a clearly separated secondary area, while preserving the existing safe default: current-workspace sessions remain primary, auto-selected, and the only sessions used unless the user explicitly chooses otherwise.

## Evidence from repo investigation

- `src/node/services/browser/AgentBrowserSessionDiscoveryService.ts` currently discovers global agent-browser sessions, reads each session PID/CWD, and **skips** sessions whose process CWD is not inside the current workspace candidate paths in `discoverSessions()`.
- Workspace candidate paths are wired in `src/node/services/serviceContainer.ts` as `workspaceMetadata.projectPath` plus `resolveWorkspaceExecutionPath(...)`.
- `src/node/orpc/router.ts` exposes `browser.listSessions`, but currently maps each discovered session down to only `{ sessionName, status }`, dropping backend `cwd` metadata.
- `src/browser/features/RightSidebar/BrowserTab/BrowserTab.tsx` polls `api.browser.listSessions({ workspaceId })`, stores one `discoveredSessions` array, and auto-selects from that list.
- Explicit attach cannot be implemented only in `getBootstrap`: `BrowserBridgeServer` revalidates the minted token by calling `getSessionConnection(...)`, so cross-workspace attach would bootstrap and then fail unless the allow/scope flag reaches the bridge validation path.
- Browser control/get-url paths also call `getSessionConnection(...)`; if we want an explicitly attached other session to remain usable, those calls need the same explicit scope flag.

## Recommended approach

**Hybrid grouped discovery:** keep the existing `sessions` contract as “current workspace sessions only”, add `otherSessions` to the same `browser.listSessions` response, and require an explicit `allowOtherWorkspaceSession` flag for attach/control paths.

**Net product LoC estimate:** +180 to +260 LoC, excluding tests.

Why this approach:

- One polling API call and one backend discovery pass, so no duplicate PID/CWD work.
- Existing `sessions` semantics remain safe and easy to reason about.
- The frontend gets enough metadata to explain why sessions were hidden before.
- Attach to other sessions is explicit and auditable instead of silently weakening workspace scoping.

<details>
<summary>Rejected alternatives</summary>

- **Flat list with `source` on every session** (+140 to +210 product LoC): simpler schema, but easier to accidentally auto-select/control the wrong session and weakens the existing `sessions` meaning.
- **Separate `listOtherSessions` endpoint** (+190 to +280 product LoC): clear API separation, but creates duplicate polling and repeated PID/CWD resolution with little benefit for this local UI.
- **Show but do not allow attach** (+90 to +140 product LoC): safer, but likely frustrating because users can see a recoverable session and still cannot use it.

</details>

## Implementation phases

### Phase 1 — Backend discovery groups

Files:

- `src/node/services/browser/AgentBrowserSessionDiscoveryService.ts`
- `src/node/services/browser/AgentBrowserSessionDiscoveryService.test.ts`

Plan:

1. Introduce an internal grouped result, e.g.

   ```ts
   interface AgentBrowserSessionGroups {
     sessions: AgentBrowserDiscoveredSession[];
     otherSessions: AgentBrowserDiscoveredSession[];
   }
   ```

2. Refactor the current `discoverSessions(workspaceId)` loop so the CWD mismatch branch pushes to `otherSessions` instead of immediately `continue`-ing.
3. Keep `listSessions(workspaceId)` returning only current-workspace `sessions` so existing internal callers/tests retain strict behavior.
4. Add a new public method such as `listSessionGroups(workspaceId)` for the router/UI discovery response.
5. Add lookup options to strict attach paths:

   ```ts
   interface AgentBrowserSessionLookupOptions {
     allowOtherWorkspaceSession?: boolean;
   }
   ```

   Then update `getSessionConnection(...)` and `ensureSessionAttachable(...)` so they search `otherSessions` only when that option is true.
6. Preserve existing defensive behavior:
   - invalid PID files are skipped;
   - dead/unresolvable CWD sessions are skipped because they cannot be safely classified;
   - malformed/missing stream files still produce `missing_stream` when the session is otherwise live;
   - path matching continues using realpath-normalized comparisons.

Quality gate after Phase 1:

- Add/update service tests for:
  - `listSessions()` still excludes unmatched sessions by default;
  - `listSessionGroups()` returns current and other sessions in deterministic order;
  - unmatched `missing_stream` sessions are included in `otherSessions`;
  - `ensureSessionAttachable(..., { allowOtherWorkspaceSession: true })` can enable streaming for an other session;
  - the same attach without the allow flag still fails.
- Run:

  ```bash
  make test -- src/node/services/browser/AgentBrowserSessionDiscoveryService.test.ts
  ```

### Phase 2 — ORPC schema, router, bridge token, and control scope

Files:

- `src/common/orpc/schemas/api.ts`
- `src/node/orpc/router.ts`
- `src/node/services/browser/BrowserBridgeTokenManager.ts`
- `src/node/services/browser/BrowserBridgeServer.ts`
- `src/node/services/browser/BrowserControlService.ts`
- Relevant tests for router/bridge/control services

Plan:

1. Extend `browser.listSessions.output` to preserve the existing current-workspace field and add secondary sessions:

   ```ts
   {
     sessions: BrowserDiscoveredSession[];
     otherSessions: BrowserDiscoveredOtherSession[];
   }
   ```

   where `BrowserDiscoveredOtherSession` includes at least:

   ```ts
   {
     sessionName: string;
     status: "attachable" | "missing_stream";
     cwd: string;
   }
   ```

   Do not expose `pid` or `streamPort`.

2. Update the router’s `browser.listSessions` handler to call `listSessionGroups(workspaceId)` and map:
   - current sessions to `sessions` without CWD;
   - unmatched sessions to `otherSessions` with CWD.
3. Add `allowOtherWorkspaceSession: z.boolean().nullish()` to browser input schemas that can act on the selected session, at minimum:
   - `browser.getBootstrap.input`;
   - `browser.control.input` if BrowserTab controls use it after attach;
   - `browser.getUrl.input` if BrowserTab reads URL for the attached session.
4. Pass `allowOtherWorkspaceSession === true` into `ensureSessionAttachable(...)` from `getBootstrap`.
5. Store the allow flag in `BrowserBridgeTokenManager` token records when minting bridge tokens, and return it from validation.
6. In `BrowserBridgeServer`, pass the token’s allow flag into `getSessionConnection(...)` during WebSocket upgrade revalidation.
7. In `BrowserControlService`, thread the allow flag through `getSessionConnection(...)` for explicit other-session control/get-url calls. Default remains strict when the flag is absent.

Quality gate after Phase 2:

- Add/update tests for:
  - `browser.listSessions` response includes both `sessions` and `otherSessions`;
  - `getBootstrap` passes the allow flag into `ensureSessionAttachable`;
  - bridge token validation preserves the allow flag;
  - `BrowserBridgeServer` succeeds for an other-session token only when the token allows it;
  - control/get-url remain strict by default and work when called with the explicit allow flag.
- Run targeted backend tests, for example:

  ```bash
  make test -- src/node/services/browser/BrowserBridgeServer.test.ts
  make test -- src/node/services/browser/BrowserControlService.test.ts
  make typecheck
  ```

### Phase 3 — BrowserTab state and UI

Files:

- `src/browser/features/RightSidebar/BrowserTab/BrowserTab.tsx`
- `src/browser/features/RightSidebar/BrowserTab/useBrowserBridgeConnection.ts`
- `src/browser/features/RightSidebar/BrowserTab/browserBridgeTypes.ts`
- `src/browser/features/RightSidebar/BrowserTab/BrowserTab.test.tsx`
- Any existing hook tests for `useBrowserBridgeConnection`

Plan:

1. Extend frontend types to represent:
   - current sessions from `sessions`;
   - other sessions from `otherSessions`, including `cwd`.
2. Replace plain `selectedSessionName` where necessary with a small selection object so the UI knows whether the selected session requires the explicit allow flag:

   ```ts
   type BrowserSessionSelection =
     | { sessionName: string; allowOtherWorkspaceSession: false }
     | { sessionName: string; allowOtherWorkspaceSession: true };
   ```

3. Update selection logic:
   - preserve a currently selected current-workspace session when it still exists;
   - preserve an explicitly selected other session while it still exists;
   - auto-select only from current-workspace sessions;
   - if only `otherSessions` exist, leave the Browser preview unselected and show the secondary section.
4. Update `useBrowserBridgeConnection.connect(...)` to accept/pass `allowOtherWorkspaceSession` to `api.browser.getBootstrap(...)`.
5. Pass the same allow flag into browser control/get-url API calls for the selected other session.
6. Render the UI as two visually distinct areas:
   - **Current workspace**: existing picker/list behavior, eligible for auto-select.
   - **Other running sessions**: secondary section with a warning/subtitle like “Not started from this workspace. Attach only if you recognize it.”
7. For each other session, show:
   - session name;
   - status badge using existing status vocabulary;
   - CWD path in subdued/truncated text;
   - an explicit action label such as **Attach anyway**.
8. Keep the UI minimal: no modal confirmation initially; the secondary section plus “Attach anyway” button is the explicit confirmation.

Quality gate after Phase 3:

- Add/update UI tests for:
  - current sessions still auto-select and connect as before;
  - other sessions render in the secondary area with CWD;
  - other sessions are not auto-selected when no current session exists;
  - clicking **Attach anyway** selects the other session and calls bootstrap/control APIs with `allowOtherWorkspaceSession: true`;
  - current-session actions do not send the allow flag.
- Run:

  ```bash
  make test -- src/browser/features/RightSidebar/BrowserTab/BrowserTab.test.tsx
  make typecheck
  ```

### Phase 4 — Full validation and cleanup

Plan:

1. Run targeted tests from Phases 1–3 again after integration.
2. Run broader repo validation:

   ```bash
   make static-check
   ```

3. Review the diff for minimality:
   - no unrelated refactors;
   - no speculative persistence/localStorage;
   - no `as any`;
   - optional input schema fields use `.nullish()`;
   - assertions document impossible internal states rather than user errors.

## Acceptance criteria

- Browser discovery still shows current-workspace agent-browser sessions exactly as before in the primary area.
- Current-workspace sessions are the only sessions auto-selected.
- Sessions whose CWD is outside the current workspace are shown in a separate **Other running sessions** area with their CWD or an equivalent explanatory path hint.
- Other sessions are never attached automatically; the user must click an explicit **Attach anyway**-style action.
- Explicit attach works for both `attachable` and `missing_stream` other sessions, including stream enablement, bridge token validation, preview streaming, and Browser tab controls.
- Without the explicit allow flag, backend attach/control paths remain workspace-scoped and reject other sessions.
- Dead sessions or sessions with unresolvable CWD remain hidden rather than presented as attachable.
- No PID or stream port is exposed to the renderer API.
- New tests cover backend grouping, strict-vs-explicit attach, token scope propagation, and BrowserTab selection behavior.

## Dogfooding plan

### Setup

1. Start the isolated development server sandbox:

   ```bash
   make dev-server-sandbox
   ```

2. Load the current agent-browser/electron automation guidance before driving the UI:

   ```bash
   agent-browser skills get core
   agent-browser skills get electron
   agent-browser skills get dogfood
   ```

3. Open two Mux workspaces for different project/worktree paths.
4. Start at least two named `agent-browser` sessions from different CWDs:
   - one from the current workspace path;
   - one from a sibling/other project path.

### Manual scenarios to verify

1. **Current + other sessions visible**
   - In workspace A, open the Browser tab.
   - Verify the workspace-A session appears in the primary/current area.
   - Verify the workspace-B session appears only under **Other running sessions** with its CWD.
   - Capture a screenshot of this state.

2. **No accidental attach**
   - Switch to a workspace with no matching sessions but at least one other session.
   - Verify no other session is auto-selected and no bridge connection starts automatically.
   - Capture a screenshot showing the empty primary state plus secondary list.

3. **Explicit attach succeeds**
   - Click **Attach anyway** on an other session.
   - Verify the Browser preview connects and renders frames.
   - Use Browser tab controls such as reload/back/forward or URL refresh if present.
   - Capture a screenshot after attach and a short video recording of the attach flow.

4. **Strict default remains safe**
   - From devtools/logs/tests, verify current-session controls do not send `allowOtherWorkspaceSession`.
   - Verify other-session calls send it only after the explicit attach action.

### Dogfooding artifacts

- Attach or save screenshots for:
  - current + other sessions separated;
  - only-other-session state with no auto-select;
  - successfully attached other session.
- Save a short video recording of the explicit attach flow so reviewers can verify the sequence without reproducing locally.

## Rollout notes and risks

- **Path disclosure:** showing CWD exposes local paths in the renderer. This is already local app state, but keep it scoped to `otherSessions` and do not expose PID/port.
- **Stale sessions:** if an agent-browser process exits between discovery and attach, existing retry/error handling should surface the failure. Do not add timers beyond the existing polling/retry model.
- **Duplicate names:** agent-browser session names are treated as globally unique by the current CLI/session files. If duplicates become possible later, this feature should use a stable backend identifier instead of `sessionName` alone.
- **Performance:** discovery already resolves CWD for listed sessions. Grouping current/other sessions in one pass should avoid extra polling overhead.

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `high` • Cost: `$61.43`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=high costs=61.43 -->
