### PR TITLE
🤖 fix: preserve subagent retention setting on partial saves

### DIFF
--- a/src/node/orpc/router.test.ts
+++ b/src/node/orpc/router.test.ts
@@ -67,4 +67,39 @@ describe("router config.saveConfig", () => {
     expect(saved.agentAiDefaults?.foo?.advisorEnabled).toBe(true);
     expect(saved.subagentAiDefaults?.foo).toBeUndefined();
   });
+
+  test("preserves optional task settings when a save omits them", async () => {
+    await config.editConfig((current) => ({
+      ...current,
+      taskSettings: {
+        ...DEFAULT_TASK_SETTINGS,
+        preserveSubagentsUntilArchive: true,
+        proposePlanImplementReplacesChatHistory: true,
+      },
+    }));
+
+    const client = createRouterClient(router(), { context: createContext() });
+
+    await client.config.saveConfig({
+      // Simulate an older/unrelated settings client that only sends the originally required
+      // task limits. Optional task flags must stay sticky, or the sub-agent preservation toggle
+      // silently turns itself off before cleanup evaluates it.
+      taskSettings: {
+        maxParallelAgentTasks: 4,
+        maxTaskNestingDepth: 5,
+      },
+      advisorModelString: null,
+    });
+
+    const saved = config.loadConfigOrDefault();
+    const savedTaskSettings = saved.taskSettings;
+    if (!savedTaskSettings) {
+      throw new Error("Expected saved task settings");
+    }
+
+    expect(savedTaskSettings.maxParallelAgentTasks).toBe(4);
+    expect(savedTaskSettings.maxTaskNestingDepth).toBe(5);
+    expect(savedTaskSettings.preserveSubagentsUntilArchive).toBe(true);
+    expect(savedTaskSettings.proposePlanImplementReplacesChatHistory).toBe(true);
+  });
 });

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -188,6 +188,22 @@ function normalizeAdvisorMaxOutputTokens(value: number | null | undefined): numb
   return value;
 }
 
+function mergeTaskSettingsForConfigSave(current: unknown, input: unknown) {
+  const inputRecord = input && typeof input === "object" ? (input as Record<string, unknown>) : {};
+  const definedInput: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(inputRecord)) {
+    if (value !== undefined) {
+      definedInput[key] = value;
+    }
+  }
+
+  // saveConfig predates optional task flags. Preserve existing values when a client only sends
+  // the required numeric limits; otherwise unrelated settings saves can silently disable toggles
+  // like preserveSubagentsUntilArchive before task cleanup evaluates them.
+  return normalizeTaskSettings({ ...normalizeTaskSettings(current), ...definedInput });
+}
+
 function normalizeMuxMessageFromDisk(value: unknown): MuxMessage | null {
   if (!value || typeof value !== "object") {
     return null;
@@ -927,7 +943,10 @@ export const router = (authToken?: string) => {
         .output(schemas.config.saveConfig.output)
         .handler(async ({ context, input }) => {
           await context.config.editConfig((config) => {
-            const normalizedTaskSettings = normalizeTaskSettings(input.taskSettings);
+            const normalizedTaskSettings = mergeTaskSettingsForConfigSave(
+              config.taskSettings,
+              input.taskSettings
+            );
             const result = { ...config, taskSettings: normalizedTaskSettings };
 
             if (input.advisorModelString !== undefined) {


### PR DESCRIPTION
## Summary

Preserves optional task settings across partial `config.saveConfig` calls so enabling “Preserve subagents until the workspace gets archived” no longer gets silently reset by unrelated settings saves.

## Background

The task cleanup path already respects `preserveSubagentsUntilArchive` when the setting remains true. The bug was that the API schema allows clients to save only the required numeric task limits, and the router normalized that partial payload as a full task-settings replacement. Missing optional flags therefore defaulted back to `false`, allowing completed subagents to be cleaned up before archive.

## Implementation

- Merge incoming task settings over the current normalized task settings before saving.
- Add a router regression test that seeds both optional task flags to true, performs a schema-minimum task-settings save, and verifies the optional flags stay true while numeric limits still update.

## Validation

- Confirmed the new regression test failed before the fix, then passed after merging current task settings before normalization.
- `bun test src/node/orpc/router.test.ts`
- `bun test src/node/services/taskService.test.ts -t "preserve subagents until archive"`
- `make typecheck`
- `make lint`
- `make fmt-check`
- `make static-check`

## Risks

Low. The change is scoped to `config.saveConfig` task settings persistence and only preserves existing optional values when a client omits them. Explicit task-setting changes still win.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=0.00 -->
