### PR TITLE
🤖 fix: accept description as alias for display_name in bash tool

### DIFF
--- a/src/common/utils/tools/toolDefinitions.test.ts
+++ b/src/common/utils/tools/toolDefinitions.test.ts
@@ -152,6 +152,37 @@ describe("TOOL_DEFINITIONS", () => {
     expect(parsed.success).toBe(false);
   });
 
+  it("accepts bash tool calls using description (alias for display_name)", () => {
+    // DeepSeek v4 emits `description` instead of `display_name`; ensure it normalizes.
+    const parsed = TOOL_DEFINITIONS.bash.schema.safeParse({
+      script: "ls",
+      timeout_secs: 60,
+      run_in_background: false,
+      description: "List files",
+    });
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.display_name).toBe("List files");
+      expect("description" in parsed.data).toBe(false);
+    }
+  });
+
+  it("prefers display_name when both display_name and description are provided", () => {
+    const parsed = TOOL_DEFINITIONS.bash.schema.safeParse({
+      script: "ls",
+      timeout_secs: 60,
+      run_in_background: false,
+      display_name: "Real Name",
+      description: "Alias Name",
+    });
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.display_name).toBe("Real Name");
+    }
+  });
+
   const filePathAliasCases = [
     {
       toolName: "file_read",

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -852,16 +852,22 @@ export const TOOL_DEFINITIONS = {
         // Normalize to `script` so downstream code (tool runner + UI) stays consistent.
         if (typeof value !== "object" || value === null || Array.isArray(value)) return value;
 
-        const obj = value as Record<string, unknown>;
-        if (typeof obj.script === "string") return value;
+        let obj = value as Record<string, unknown>;
 
-        if (typeof obj.command === "string") {
+        if (typeof obj.script !== "string" && typeof obj.command === "string") {
           // Drop the legacy field to keep tool args canonical (and avoid confusing downstream consumers).
           const { command, ...rest } = obj as Record<string, unknown> & { command: string };
-          return { ...rest, script: command };
+          obj = { ...rest, script: command };
         }
 
-        return value;
+        // Compatibility: DeepSeek v4 emits `description` instead of `display_name`.
+        // Treat `description` as an undocumented alias so the call still validates.
+        if (typeof obj.display_name !== "string" && typeof obj.description === "string") {
+          const { description, ...rest } = obj as Record<string, unknown> & { description: string };
+          obj = { ...rest, display_name: description };
+        }
+
+        return obj;
       },
       z.object({
         script: z.string().describe("The bash script/command to execute"),


### PR DESCRIPTION
## Summary

DeepSeek V4 emits `description` instead of `display_name` for the bash tool, causing every bash invocation to fail validation. Normalize `description` as an undocumented alias for `display_name` in the schema preprocess so calls validate without changing the public tool surface.

## Background

The `bash` tool requires `display_name` for every invocation. DeepSeek V4 reliably emits `description` instead, so we add an alias mirroring the existing `command` → `script` normalization. The alias is intentionally **undocumented** in the tool description: we don't want to invite other models to use the wrong field.

## Implementation

Refactored the bash schema's `preprocess` from a single `if/else if/else` chain into chained mutations on a local `obj` reference, so multiple normalizations can compose:

1. `command` → `script` (existing).
2. `description` → `display_name` (new, with a comment noting DeepSeek V4 as the reason).

Canonical fields always win when both are provided, mirroring the existing `command`/`script` precedence.

## Validation

- New unit tests in `toolDefinitions.test.ts` cover the alias and the precedence behavior.
- `bun test src/common/utils/tools/toolDefinitions.test.ts`: 36 pass.
- `make static-check`: passed locally.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `max` • Cost: `$0.62`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=max costs=0.62 -->
