### PR TITLE
🤖 fix: relax OpenAI WebSocket transport gating

### DIFF
--- a/src/browser/features/Settings/Sections/ProvidersSection.test.tsx
+++ b/src/browser/features/Settings/Sections/ProvidersSection.test.tsx
@@ -380,7 +380,7 @@ describe("ProvidersSection", () => {
     });
   });
 
-  test("hides the OpenAI WebSocket transport toggle when Codex OAuth is the active default", async () => {
+  test("shows the OpenAI WebSocket transport toggle when Codex OAuth is the active default", async () => {
     const view = renderProvidersSection();
     view.providersConfig.openai.codexOauthSet = true;
     view.providersConfig.openai.apiKeySet = false;
@@ -391,14 +391,14 @@ describe("ProvidersSection", () => {
 
     const openAiCard = getProviderCard(openAiButton);
     expect(
-      within(openAiCard).queryByRole("switch", {
+      within(openAiCard).getByRole("switch", {
         name: /WebSocket transport/i,
       })
-    ).toBeNull();
+    ).toBeTruthy();
     expect(view.providersConfig.openai.webSocketTransportEnabled).toBe(true);
   });
 
-  test("hides the OpenAI WebSocket transport toggle when OpenAI uses a custom base URL", async () => {
+  test("shows the OpenAI WebSocket transport toggle when OpenAI uses a custom base URL", async () => {
     const view = renderProvidersSection();
     view.providersConfig.openai.baseUrl = "https://proxy.openai.test/v1";
     view.providersConfig.openai.webSocketTransportEnabled = true;
@@ -408,10 +408,10 @@ describe("ProvidersSection", () => {
 
     const openAiCard = getProviderCard(openAiButton);
     expect(
-      within(openAiCard).queryByRole("switch", {
+      within(openAiCard).getByRole("switch", {
         name: /WebSocket transport/i,
       })
-    ).toBeNull();
+    ).toBeTruthy();
     expect(view.providersConfig.openai.webSocketTransportEnabled).toBe(true);
   });
 

--- a/src/browser/features/Settings/Sections/ProvidersSection.tsx
+++ b/src/browser/features/Settings/Sections/ProvidersSection.tsx
@@ -2248,23 +2248,7 @@ export function ProvidersSection() {
                       {provider === "openai" &&
                         (() => {
                           const openAIWireFormat = providerInfo?.wireFormat ?? "responses";
-                          const openAIBaseUrl =
-                            typeof providerInfo?.baseUrl === "string"
-                              ? providerInfo.baseUrl.trim()
-                              : "";
-                          const openAIResolvedBaseUrl =
-                            typeof providerInfo?.baseUrlResolved === "string"
-                              ? providerInfo.baseUrlResolved.trim()
-                              : "";
-                          const openAICodexOAuthIsDefault =
-                            providerInfo?.codexOauthSet === true &&
-                            (providerInfo.apiKeySet !== true ||
-                              providerInfo.codexOauthDefaultAuth !== "apiKey");
-                          const openAIWebSocketTransportVisible =
-                            openAIWireFormat === "responses" &&
-                            openAIBaseUrl.length === 0 &&
-                            openAIResolvedBaseUrl.length === 0 &&
-                            !openAICodexOAuthIsDefault;
+                          const openAIWebSocketTransportVisible = openAIWireFormat === "responses";
                           return (
                             <div className="border-border-light space-y-3 border-t pt-3">
                               <div>

--- a/src/node/services/providerModelFactory.test.ts
+++ b/src/node/services/providerModelFactory.test.ts
@@ -852,7 +852,7 @@ describe("ProviderModelFactory OpenAI WebSocket transport", () => {
     });
   });
 
-  it("does not attach cleanup when a custom OpenAI base URL is configured", async () => {
+  it("attaches cleanup when a custom OpenAI base URL is configured", async () => {
     await withTempConfig(async (config, factory) => {
       config.saveProvidersConfig({
         openai: {
@@ -868,7 +868,7 @@ describe("ProviderModelFactory OpenAI WebSocket transport", () => {
       if (!result.success) {
         return;
       }
-      expect(hasLanguageModelCleanup(result.data)).toBe(false);
+      expect(hasLanguageModelCleanup(result.data)).toBe(true);
     });
   });
 

--- a/src/node/services/providerModelFactory.ts
+++ b/src/node/services/providerModelFactory.ts
@@ -1303,11 +1303,9 @@ export class ProviderModelFactory {
 
         const baseFetch = getProviderFetch(providerConfig);
         const codexOauthService = this.codexOauthService;
-        const openAIHasCustomBaseURL =
-          providerConfig.baseURL != null || providerConfig.baseUrl != null || creds.baseUrl != null;
         const webSocketTransportEnabled =
           (providerConfig as { webSocketTransportEnabled?: unknown }).webSocketTransportEnabled ===
-            true && !openAIHasCustomBaseURL;
+          true;
 
         // Wrap fetch so Codex OAuth Responses requests are normalized before
         // they are rerouted from api.openai.com to chatgpt.com's Codex backend.
@@ -1391,6 +1389,8 @@ export class ProviderModelFactory {
         );
 
         const webSocketTransport = createOpenAIWebSocketTransportFetch({
+          // Codex OAuth requests must keep using the HTTP fetch wrapper above so
+          // Mux can rewrite the endpoint and attach ChatGPT OAuth headers.
           enabled:
             webSocketTransportEnabled &&
             effectiveWireFormat === "responses" &&

--- a/src/node/utils/main/workerPool.ts
+++ b/src/node/utils/main/workerPool.ts
@@ -82,7 +82,7 @@ worker.on("message", (response: WorkerResponse) => {
 });
 
 // Handle worker errors
-worker.on("error", (error) => {
+worker.on("error", (error: Error) => {
   log.error("Worker error:", error);
   workerError = error;
   // Reject all pending promises


### PR DESCRIPTION
Summary
- Relax OpenAI WebSocket transport settings visibility so the UI shows the toggle whenever the OpenAI wire format is `responses`.
- Let runtime attempt the WebSocket transport with custom OpenAI base URLs instead of preemptively disabling it.
- Preserve the existing HTTP routing path for Codex OAuth requests so Mux can still rewrite the endpoint and attach ChatGPT OAuth headers.
- Fix an unrelated Worker error handler type annotation so `make static-check` remains green.

Background
The previous UI hid the WebSocket transport toggle whenever OpenAI had any configured/resolved base URL or Codex OAuth was the active default. That blocked users from enabling the experimental transport even in cases where it may work. The only UI-level hard requirement is the Responses wire format.

Implementation
- Simplified provider settings visibility to `wireFormat === "responses"`.
- Removed the custom Base URL exclusion from OpenAI WebSocket transport activation.
- Kept Codex OAuth requests on the existing HTTP fetch wrapper because those requests require endpoint rewriting and ChatGPT OAuth headers before dispatch.
- Updated tests to assert the toggle remains available with custom OpenAI base URLs and Codex OAuth, while runtime still protects Codex OAuth routing.

Validation
- `bun test src/browser/features/Settings/Sections/ProvidersSection.test.tsx`
- `bun test src/node/services/providerModelFactory.test.ts`
- `make static-check`

Risks
This makes an experimental transport easier to enable for endpoints that may not support it. Failures for unsupported custom endpoints should surface at request time instead of being blocked by settings visibility.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `high` • Cost: `$4.05`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=high costs=4.05 -->
