### PR TITLE
🤖 fix: stop Run-button click from crashing the app

### DIFF
--- a/src/browser/features/RightSidebar/RightSidebar.tsx
+++ b/src/browser/features/RightSidebar/RightSidebar.tsx
@@ -18,6 +18,9 @@ import {
 import { useAPI } from "@/browser/contexts/API";
 import { StatsContainer } from "@/browser/features/RightSidebar/StatsContainer";
 import { ErrorBoundary } from "@/browser/components/ErrorBoundary/ErrorBoundary";
+import { usePopoverError } from "@/browser/hooks/usePopoverError";
+import { PopoverError } from "@/browser/components/PopoverError/PopoverError";
+import { getErrorMessage } from "@/common/utils/errors";
 
 import { ReviewPanel } from "@/browser/features/RightSidebar/CodeReview/ReviewPanel";
 import { OutputTab } from "@/browser/components/OutputTab/OutputTab";
@@ -610,6 +613,12 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
     null
   );
 
+  // Surface backend failures from terminal creation (e.g., the markdown Run button kicking off
+  // a session against a transcript-only workspace, or a runtime that isn't connected). Without
+  // this the click silently expands the sidebar with no new tab, which users perceive as a hang
+  // or app crash.
+  const terminalCreateError = usePopoverError();
+
   // Manual collapse state (persisted globally)
   const [collapsed, setCollapsed] = usePersistedState<boolean>(RIGHT_SIDEBAR_COLLAPSED_KEY, false, {
     listener: true,
@@ -1171,21 +1180,33 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
   // Handler to add a new terminal tab.
   // Creates the backend session first, then adds the tab with the real sessionId.
   // This ensures the tabType (and React key) never changes, preventing remounts.
+  //
+  // The promise is given a `.catch` so backend rejections (e.g., transcript-only workspaces
+  // with no projectPath, archived worktrees, or disconnected SSH/Devcontainer runtimes)
+  // surface to the user via PopoverError instead of becoming an unhandled promise rejection
+  // that leaves the sidebar half-expanded and looks like an app crash. The wrapper stays
+  // non-async (`() => void`) so the existing `addTerminalRef` / `onAddTerminal` callsites
+  // (typed as void-returning) don't trip `no-misused-promises`.
   const handleAddTerminal = React.useCallback(
-    (options?: TerminalSessionCreateOptions) => {
+    (options?: TerminalSessionCreateOptions): void => {
       if (!api) return;
 
       // Also expand sidebar if collapsed
       setCollapsed(false);
 
-      void createTerminalSession(api, workspaceId, options).then((session) => {
-        const newTab = makeTerminalTabType(session.sessionId);
-        setLayout((prev) => addTabToFocusedTabset(prev, newTab));
-        // Schedule focus for this terminal (will be consumed when the tab mounts)
-        setAutoFocusTerminalSession(session.sessionId);
-      });
+      void createTerminalSession(api, workspaceId, options)
+        .then((session) => {
+          const newTab = makeTerminalTabType(session.sessionId);
+          setLayout((prev) => addTabToFocusedTabset(prev, newTab));
+          // Schedule focus for this terminal (will be consumed when the tab mounts)
+          setAutoFocusTerminalSession(session.sessionId);
+        })
+        .catch((err: unknown) => {
+          console.error("[RightSidebar] Failed to create terminal session:", err);
+          terminalCreateError.showError("terminal-create", getErrorMessage(err));
+        });
     },
-    [api, workspaceId, setLayout, setCollapsed]
+    [api, workspaceId, setLayout, setCollapsed, terminalCreateError]
   );
 
   // Expose handleAddTerminal to parent via ref (for Cmd/Ctrl+T keybind)
@@ -1453,6 +1474,12 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
           </div>
         ) : null}
       </DragOverlay>
+
+      <PopoverError
+        error={terminalCreateError.error}
+        prefix="Failed to open terminal:"
+        onDismiss={terminalCreateError.clearError}
+      />
     </DndContext>
   );
 };

--- a/src/browser/features/RightSidebar/RightSidebar.tsx
+++ b/src/browser/features/RightSidebar/RightSidebar.tsx
@@ -1246,8 +1246,15 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
       const sessionId = getTerminalSessionId(tab);
       if (!sessionId) return; // Can't pop out without a session
 
-      // Open the pop-out window (handles browser vs Electron modes)
-      openTerminalPopout(api, workspaceId, sessionId);
+      // Open the pop-out window (handles browser vs Electron modes). The promise is
+      // attached a `.catch` so an Electron terminalWindowManager rejection cannot become
+      // an unhandled promise rejection. We surface it via the same PopoverError used by
+      // handleAddTerminal — the user already paid the cost of removing the tab below, so
+      // they need to know if the pop-out itself failed.
+      void openTerminalPopout(api, workspaceId, sessionId).catch((err: unknown) => {
+        console.error("[RightSidebar] Failed to open terminal pop-out:", err);
+        terminalCreateError.showError("terminal-popout", getErrorMessage(err));
+      });
 
       // Remove the tab from the sidebar (terminal now lives in its own window)
       // Don't close the session - the pop-out window takes over
@@ -1261,7 +1268,7 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
         return next;
       });
     },
-    [workspaceId, api, setLayout, terminalTitlesKey]
+    [workspaceId, api, setLayout, terminalTitlesKey, terminalCreateError]
   );
 
   // Configure sensors with distance threshold for click vs drag disambiguation

--- a/src/browser/hooks/useOpenTerminal.ts
+++ b/src/browser/hooks/useOpenTerminal.ts
@@ -39,13 +39,21 @@ export function useOpenTerminal() {
       const isDevcontainer = isDevcontainerRuntime(runtimeConfig);
 
       // SSH/Devcontainer workspaces always use web terminal (in browser popup or Electron window)
-      // because the PTY service handles the SSH/container connection
-      if (isBrowser || isSSH || isDevcontainer) {
-        // Create terminal session first - window needs sessionId to connect
-        const session = await createTerminalSession(api, workspaceId, options);
-        openTerminalPopout(api, workspaceId, session.sessionId);
-      } else {
-        void api.terminal.openNative({ workspaceId });
+      // because the PTY service handles the SSH/container connection.
+      //
+      // Callers (e.g. WorkspaceMenuBar, the markdown Run button's mobile path) discard the
+      // returned promise via `void`, so we must catch rejections here to avoid an unhandled
+      // promise rejection that the user perceives as the app silently freezing/crashing.
+      try {
+        if (isBrowser || isSSH || isDevcontainer) {
+          // Create terminal session first - window needs sessionId to connect
+          const session = await createTerminalSession(api, workspaceId, options);
+          openTerminalPopout(api, workspaceId, session.sessionId);
+        } else {
+          await api.terminal.openNative({ workspaceId });
+        }
+      } catch (err) {
+        console.error("[useOpenTerminal] Failed to open terminal:", err);
       }
     },
     [api]

--- a/src/browser/hooks/useOpenTerminal.ts
+++ b/src/browser/hooks/useOpenTerminal.ts
@@ -46,9 +46,12 @@ export function useOpenTerminal() {
       // promise rejection that the user perceives as the app silently freezing/crashing.
       try {
         if (isBrowser || isSSH || isDevcontainer) {
-          // Create terminal session first - window needs sessionId to connect
+          // Create terminal session first - window needs sessionId to connect.
           const session = await createTerminalSession(api, workspaceId, options);
-          openTerminalPopout(api, workspaceId, session.sessionId);
+          // Awaited so a rejected `terminal.openWindow` (e.g., Electron
+          // terminalWindowManager failure) is observed by this try/catch instead of
+          // becoming an unhandled rejection that looks like a silent freeze.
+          await openTerminalPopout(api, workspaceId, session.sessionId);
         } else {
           await api.terminal.openNative({ workspaceId });
         }

--- a/src/browser/utils/terminal.ts
+++ b/src/browser/utils/terminal.ts
@@ -27,11 +27,21 @@ export const DEFAULT_TERMINAL_SIZE = { cols: 80, rows: 24 };
  * In browser mode, opens the window client-side since the backend can't open windows.
  * In Electron mode, the backend opens a BrowserWindow.
  *
+ * Returns the underlying `api.terminal.openWindow` promise so callers can observe and
+ * surface backend failures. Without this, an Electron-side `terminalWindowManager` reject
+ * would become an unhandled promise rejection — the same silent-freeze symptom we are
+ * trying to fix on the Run-button path. The browser-mode `window.open` call is synchronous
+ * and not part of the returned promise.
+ *
  * @param api - The API client
  * @param workspaceId - Workspace ID
  * @param sessionId - Terminal session ID (required)
  */
-export function openTerminalPopout(api: APIClient, workspaceId: string, sessionId: string): void {
+export function openTerminalPopout(
+  api: APIClient,
+  workspaceId: string,
+  sessionId: string
+): Promise<void> {
   const isBrowser = !window.api;
 
   if (isBrowser) {
@@ -46,8 +56,10 @@ export function openTerminalPopout(api: APIClient, workspaceId: string, sessionI
     );
   }
 
-  // Open via backend (Electron pops up BrowserWindow, browser already opened above)
-  void api.terminal.openWindow({ workspaceId, sessionId });
+  // Open via backend (Electron pops up BrowserWindow, browser already opened above).
+  // Returned to the caller so a backend rejection can be observed instead of vanishing
+  // into an unhandled promise rejection.
+  return api.terminal.openWindow({ workspaceId, sessionId });
 }
 
 /**

--- a/src/node/services/terminalService.test.ts
+++ b/src/node/services/terminalService.test.ts
@@ -417,6 +417,62 @@ describe("TerminalService", () => {
     expect(sendInputMock).toHaveBeenCalledWith("session-1", "ls\n");
   });
 
+  it("isolates emitOutput from throwing output subscribers", async () => {
+    // Repro for the "App crash" reported when clicking the markdown Run button: a downstream
+    // listener throwing inside the PTY data path would propagate up to the libuv tick and hit
+    // process.uncaughtException in the Electron main process, which surfaces as a blocking
+    // "Application Error" dialog. The defense in emitOutput must swallow listener throws so
+    // a single bad subscriber cannot take down the host process.
+    let capturedOnData: ((data: string) => void) | undefined;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockPTYService.createSession as any) = mock(
+      (
+        params: TerminalCreateParams,
+        _runtime: unknown,
+        _path: string,
+        onData: (d: string) => void,
+        _onExit: (code: number) => void
+      ) => {
+        capturedOnData = onData;
+        return Promise.resolve({
+          sessionId: "session-emit-throw",
+          workspaceId: params.workspaceId,
+          cols: params.cols,
+          rows: params.rows,
+        });
+      }
+    );
+
+    await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });
+
+    if (!capturedOnData) {
+      throw new Error("Expected createSession to capture onData callback");
+    }
+
+    // Simulate an orpc-attached subscriber (or any future listener) that throws.
+    let subscriberCalls = 0;
+    const unsubscribe = service.onOutput("session-emit-throw", () => {
+      subscriberCalls += 1;
+      throw new Error("subscriber blew up");
+    });
+
+    // Must NOT throw. Without the try/catch around emitter.emit, this call would propagate
+    // synchronously via EventEmitter and crash the host process.
+    expect(() => capturedOnData!("hello")).not.toThrow();
+    expect(subscriberCalls).toBe(1);
+
+    // A subsequent emission still reaches the (still-subscribed) listener — the defense
+    // isolates the throw without disabling the data path.
+    expect(() => capturedOnData!("world")).not.toThrow();
+    expect(subscriberCalls).toBe(2);
+
+    unsubscribe();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockPTYService.createSession as any) = createSessionMock;
+  });
+
   it("should close workspace sessions via terminateTrackedSessions", async () => {
     // Create real sessions so sessionActivity is populated
     await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });

--- a/src/node/services/terminalService.test.ts
+++ b/src/node/services/terminalService.test.ts
@@ -421,8 +421,10 @@ describe("TerminalService", () => {
     // Repro for the "App crash" reported when clicking the markdown Run button: a downstream
     // listener throwing inside the PTY data path would propagate up to the libuv tick and hit
     // process.uncaughtException in the Electron main process, which surfaces as a blocking
-    // "Application Error" dialog. The defense in emitOutput must swallow listener throws so
-    // a single bad subscriber cannot take down the host process.
+    // "Application Error" dialog. The defense must (a) keep the host process alive AND
+    // (b) keep healthy subscribers receiving output even if an earlier subscriber throws —
+    // EventEmitter.emit aborts dispatch synchronously at the first throwing listener, so the
+    // isolation must happen per-listener inside onOutput, not just around the whole emit.
     //
     // The default createSessionMock already forwards `onData` to its 4th positional arg, so
     // we can inspect mock.calls directly instead of swapping the implementation through a
@@ -435,24 +437,34 @@ describe("TerminalService", () => {
     }
     const capturedOnData = lastCall[3];
 
-    // Simulate an orpc-attached subscriber (or any future listener) that throws.
-    let subscriberCalls = 0;
-    const unsubscribe = service.onOutput(session.sessionId, () => {
-      subscriberCalls += 1;
+    // Register a throwing listener FIRST so EventEmitter dispatches to it before the healthy
+    // listener — this is the order that exposes the abort-mid-broadcast bug.
+    let throwingCalls = 0;
+    const unsubscribeThrowing = service.onOutput(session.sessionId, () => {
+      throwingCalls += 1;
       throw new Error("subscriber blew up");
     });
 
-    // Must NOT throw. Without the try/catch around emitter.emit, this call would propagate
-    // synchronously via EventEmitter and crash the host process.
+    const healthyChunks: string[] = [];
+    const unsubscribeHealthy = service.onOutput(session.sessionId, (data) => {
+      healthyChunks.push(data);
+    });
+
+    // Must NOT throw. Without per-listener isolation, EventEmitter's synchronous loop would
+    // re-throw and (1) crash the host process via uncaughtException, (2) starve the healthy
+    // listener of this chunk.
     expect(() => capturedOnData("hello")).not.toThrow();
-    expect(subscriberCalls).toBe(1);
+    expect(throwingCalls).toBe(1);
+    expect(healthyChunks).toEqual(["hello"]); // the second listener still received it.
 
-    // A subsequent emission still reaches the (still-subscribed) listener — the defense
-    // isolates the throw without disabling the data path.
+    // A subsequent emission also reaches both — the throwing listener stays subscribed and
+    // the healthy listener continues to receive every chunk.
     expect(() => capturedOnData("world")).not.toThrow();
-    expect(subscriberCalls).toBe(2);
+    expect(throwingCalls).toBe(2);
+    expect(healthyChunks).toEqual(["hello", "world"]);
 
-    unsubscribe();
+    unsubscribeThrowing();
+    unsubscribeHealthy();
   });
 
   it("should close workspace sessions via terminateTrackedSessions", async () => {

--- a/src/node/services/terminalService.test.ts
+++ b/src/node/services/terminalService.test.ts
@@ -423,54 +423,36 @@ describe("TerminalService", () => {
     // process.uncaughtException in the Electron main process, which surfaces as a blocking
     // "Application Error" dialog. The defense in emitOutput must swallow listener throws so
     // a single bad subscriber cannot take down the host process.
-    let capturedOnData: ((data: string) => void) | undefined;
+    //
+    // The default createSessionMock already forwards `onData` to its 4th positional arg, so
+    // we can inspect mock.calls directly instead of swapping the implementation through a
+    // typed `as any` cast (banned by AGENTS.md TypeScript Discipline).
+    const session = await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (mockPTYService.createSession as any) = mock(
-      (
-        params: TerminalCreateParams,
-        _runtime: unknown,
-        _path: string,
-        onData: (d: string) => void,
-        _onExit: (code: number) => void
-      ) => {
-        capturedOnData = onData;
-        return Promise.resolve({
-          sessionId: "session-emit-throw",
-          workspaceId: params.workspaceId,
-          cols: params.cols,
-          rows: params.rows,
-        });
-      }
-    );
-
-    await service.create({ workspaceId: "ws-1", cols: 80, rows: 24 });
-
-    if (!capturedOnData) {
-      throw new Error("Expected createSession to capture onData callback");
+    const lastCall = createSessionMock.mock.calls.at(-1);
+    if (!lastCall) {
+      throw new Error("Expected createSession to be invoked");
     }
+    const capturedOnData = lastCall[3];
 
     // Simulate an orpc-attached subscriber (or any future listener) that throws.
     let subscriberCalls = 0;
-    const unsubscribe = service.onOutput("session-emit-throw", () => {
+    const unsubscribe = service.onOutput(session.sessionId, () => {
       subscriberCalls += 1;
       throw new Error("subscriber blew up");
     });
 
     // Must NOT throw. Without the try/catch around emitter.emit, this call would propagate
     // synchronously via EventEmitter and crash the host process.
-    expect(() => capturedOnData!("hello")).not.toThrow();
+    expect(() => capturedOnData("hello")).not.toThrow();
     expect(subscriberCalls).toBe(1);
 
     // A subsequent emission still reaches the (still-subscribed) listener — the defense
     // isolates the throw without disabling the data path.
-    expect(() => capturedOnData!("world")).not.toThrow();
+    expect(() => capturedOnData("world")).not.toThrow();
     expect(subscriberCalls).toBe(2);
 
     unsubscribe();
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (mockPTYService.createSession as any) = createSessionMock;
   });
 
   it("should close workspace sessions via terminateTrackedSessions", async () => {

--- a/src/node/services/terminalService.ts
+++ b/src/node/services/terminalService.ts
@@ -710,8 +710,19 @@ export class TerminalService {
 
     // Note: The attach stream yields screenState first, then live output.
     // This subscription only provides live output from the point of subscription onward.
-
-    const handler = (data: string) => callback(data);
+    //
+    // Wrap the user callback in a per-listener try/catch so a single bad subscriber
+    // (e.g., a stale orpc stream still wired to a closed terminal window) cannot abort
+    // EventEmitter's synchronous dispatch loop and starve healthy subscribers of output.
+    // Without this, a crashy listener would also crash the Electron main process via
+    // process.uncaughtException (see emitOutput's defense-in-depth notes).
+    const handler = (data: string) => {
+      try {
+        callback(data);
+      } catch (err) {
+        log.warn(`[TerminalService] output listener threw for session ${sessionId}:`, err);
+      }
+    };
     emitter.on("data", handler);
 
     return () => {
@@ -874,10 +885,12 @@ export class TerminalService {
       }
     }
 
+    // Listener isolation lives inside onOutput's per-callback wrapper so a throwing subscriber
+    // does not abort EventEmitter's synchronous dispatch and starve later listeners of output.
+    // The try/catch here is defense-in-depth for any future emit-time error path (e.g.,
+    // EventEmitter internals): it must never let an exception escape the libuv tick.
     const emitter = this.outputEmitters.get(sessionId);
     if (emitter) {
-      // EventEmitter rethrows synchronously when a listener throws; isolate listener bugs from
-      // the PTY data path so a single bad subscriber cannot crash the main process.
       try {
         emitter.emit("data", data);
       } catch (err) {

--- a/src/node/services/terminalService.ts
+++ b/src/node/services/terminalService.ts
@@ -859,13 +859,30 @@ export class TerminalService {
   }
 
   private emitOutput(sessionId: string, data: string) {
-    // Write to headless terminal to maintain parsed state (and generate device-query responses)
+    // Write to headless terminal to maintain parsed state (and generate device-query responses).
+    // SAFETY: xterm-headless (like the renderer's xterm WASM build) can throw intermittently on
+    // malformed escape sequences. This handler is invoked from a node-pty `onData` callback that
+    // runs on the libuv tick, so an uncaught throw here propagates to `process.uncaughtException`
+    // in the Electron main process, which turns it into a blocking "Application Error" dialog
+    // (see desktop/main.ts). Mirror the renderer-side defense in TerminalView.tsx.
     const headless = this.headlessTerminals.get(sessionId);
-    headless?.write(data);
+    if (headless) {
+      try {
+        headless.write(data);
+      } catch (err) {
+        log.warn(`[TerminalService] headless.write threw for session ${sessionId}:`, err);
+      }
+    }
 
     const emitter = this.outputEmitters.get(sessionId);
     if (emitter) {
-      emitter.emit("data", data);
+      // EventEmitter rethrows synchronously when a listener throws; isolate listener bugs from
+      // the PTY data path so a single bad subscriber cannot crash the main process.
+      try {
+        emitter.emit("data", data);
+      } catch (err) {
+        log.warn(`[TerminalService] output emitter threw for session ${sessionId}:`, err);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Two contributing causes for the user report *"Play on code blocks sometimes leads to App crash"*: (1) the backend's `TerminalService.emitOutput` was unprotected against `xterm-headless` throws on the libuv tick, which escalated into the Electron main process's "Application Error" dialog; and (2) the frontend Run-button path discarded `createTerminalSession` rejections via `void`, leaving the sidebar half-expanded with no new tab when (e.g.) the workspace was transcript-only or the runtime wasn't ready.

## Background

The Run icon (`<Play>` at `MarkdownComponents.tsx:255`) calls `messageListContext.openTerminal({ initialCommand })`, which threads through `ChatPane → WorkspaceShell.handleOpenTerminal → RightSidebar.handleAddTerminal`, and finally `TerminalService.create` + `sendInput(initialCommand + "\n")`. Two latent failure modes along this chain produce the same user-visible symptom of "the app froze / crashed" after clicking Play:

| Path | Cause | Symptom |
|---|---|---|
| Backend | `TerminalService.emitOutput` writes PTY bytes via `headless.write(data)` and `emitter.emit("data", data)` with no try/catch. The frontend already wraps `term.write` (`TerminalView.tsx:351-355`) because *"xterm WASM can throw 'memory access out of bounds' intermittently"*; the headless build has the same risk. Because `emitOutput` runs from `node-pty`'s `onData` on the libuv tick, an uncaught throw escalates to `process.uncaughtException` in main, which calls `dialog.showErrorBox("Application Error", …)` (`src/desktop/main.ts:151-166`) — the literal blocking crash. | Modal "Application Error" dialog. |
| Frontend | `RightSidebar.handleAddTerminal` (`RightSidebar.tsx:1181-1186`) and `useOpenTerminal` fired `void createTerminalSession(...).then(...)` with no `.catch`. Backend rejections (transcript-only workspaces with no `projectPath`, archived worktrees, disconnected SSH/Devcontainer) became unhandled promise rejections; the sidebar already ran `setCollapsed(false)` before the await, so it visibly twitches open with no new tab. | Sidebar half-expands, no new tab, no error toast → reads as a freeze. |

## Implementation

**Backend — `src/node/services/terminalService.ts`**

`emitOutput` now wraps both the headless write and the listener emission in `try`/`log.warn`. Mirrors the renderer-side defense and isolates a single misbehaving subscriber from taking down the Electron main process. No behavior change on the happy path.

**Frontend — `src/browser/features/RightSidebar/RightSidebar.tsx`**

`handleAddTerminal` chains `.catch` on the create promise and surfaces the message via a new `usePopoverError` (the same pattern `WorkspaceMenuBar` already uses for archive/fork/stop errors), rendered through the existing `<PopoverError>` component. The wrapper is kept non-async (`(): void`) so the existing `addTerminalRef`/`onAddTerminal` callsites still satisfy `@typescript-eslint/no-misused-promises`.

**Frontend — `src/browser/hooks/useOpenTerminal.ts`**

Wrapped both branches (`createTerminalSession` + `openTerminalPopout` for browser/SSH/devcontainer; `api.terminal.openNative` for Electron-local) in a single `try/catch` so the `WorkspaceMenuBar`'s `void openTerminalPopout(...)` call cannot become an unhandled rejection either.

## Validation

- New regression test `TerminalService > isolates emitOutput from throwing output subscribers` registers a deliberately-throwing `onOutput` listener and asserts the captured `onData` callback does not propagate the throw — without the defense this would crash the host process. Tests behavior, not literals.
- `make static-check`, `make typecheck`, `make lint` all green.
- `bun test src/node/services/terminalService.test.ts` — 41/41 pass.
- `bun test src/browser/features/Messages/MarkdownComponents.test.tsx` — 12/12 pass.
- `bun test src/browser/components/WorkspaceShell/WorkspaceShell.test.tsx` — 10/10 pass.

## Risks

Low. The backend change is a pure widening of a previously-uncaught throw path; the only observable behavioral change on a malformed escape sequence is that the host process logs a warning instead of crashing, and the data emission still reaches subscribers (verified by the regression test). The frontend changes are additive — they convert silent failures into a 5-second `PopoverError` toast and don't alter the success path.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `max` • Cost: `$15.61`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=max costs=15.61 -->
