### PR TITLE
🤖 fix: show preserved subagents in sidebar

### DIFF
--- a/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
@@ -11,6 +11,7 @@ import { EXPANDED_PROJECTS_KEY } from "@/common/constants/storage";
 import { getDraftScopeId, getInputKey } from "@/common/constants/storage";
 import { MULTI_PROJECT_SIDEBAR_SECTION_ID } from "@/common/constants/multiProject";
 import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
+import { DEFAULT_TASK_SETTINGS } from "@/common/types/tasks";
 import type { AgentRowRenderMeta } from "@/browser/utils/ui/workspaceFiltering";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import * as DesktopTitlebarModule from "@/browser/hooks/useDesktopTitlebar";
@@ -668,6 +669,81 @@ describe("ProjectSidebar multi-project completed-subagent toggles", () => {
     expect(expandedParentRow.dataset.completedExpanded).toBe("true");
     expect(childRow.dataset.rowKind).toBe("subagent");
     expect(childRow.dataset.depth).toBe("1");
+  });
+
+  test("shows completed child rows by default when sub-agent preservation is enabled", async () => {
+    const getConfig = mock(() =>
+      Promise.resolve({
+        taskSettings: {
+          ...DEFAULT_TASK_SETTINGS,
+          preserveSubagentsUntilArchive: true,
+        },
+      })
+    );
+    spyOn(APIModule, "useAPI").mockImplementation(() => ({
+      api: {
+        config: {
+          getConfig,
+          onConfigChanged: async function* () {
+            // No-op stream for this test; the initial config load is enough.
+          },
+        },
+      } as unknown as APIModule.APIClient,
+      status: "connected",
+      error: null,
+      authenticate: () => undefined,
+      retry: () => undefined,
+    }));
+
+    window.localStorage.setItem(EXPANDED_PROJECTS_KEY, JSON.stringify(["/projects/demo-project"]));
+
+    const singleProjectRefs = [
+      { projectPath: "/projects/demo-project", projectName: "demo-project" },
+    ];
+    const parentWorkspace = {
+      ...createWorkspace("parent", { title: "Parent workspace" }),
+      projects: singleProjectRefs,
+    };
+    const completedChildWorkspace = {
+      ...createWorkspace("child", {
+        parentWorkspaceId: "parent",
+        taskStatus: "reported",
+        title: "Completed child workspace",
+      }),
+      projects: singleProjectRefs,
+    };
+
+    const sortedWorkspacesByProject = new Map([
+      ["/projects/demo-project", [parentWorkspace, completedChildWorkspace]],
+    ]);
+    projectContextValue = createProjectContextValue({
+      userProjects: new Map([["/projects/demo-project", { workspaces: [] }]]),
+      hasAnyProject: true,
+      resolveNewChatProjectPath: () => "/projects/demo-project",
+    });
+
+    const view = render(
+      <ProjectSidebar
+        collapsed={false}
+        onToggleCollapsed={() => undefined}
+        sortedWorkspacesByProject={sortedWorkspacesByProject}
+        workspaceRecency={{ parent: Date.now(), child: Date.now() }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(view.getByTestId(agentItemTestId("child"))).toBeTruthy();
+    });
+
+    expect(getConfig).toHaveBeenCalled();
+    expect(view.getByTestId(agentItemTestId("parent")).dataset.completedExpanded).toBe("true");
+
+    fireEvent.click(view.getByRole("button", { name: toggleButtonLabel("parent") }));
+
+    await waitFor(() => {
+      expect(view.queryByTestId(agentItemTestId("child"))).toBeNull();
+    });
+    expect(view.getByTestId(agentItemTestId("parent")).dataset.completedExpanded).toBe("false");
   });
 
   test("coalesces best-of sub-agents into a single sidebar row until expanded", async () => {

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
@@ -67,6 +67,7 @@ import {
 } from "@/browser/utils/archiveConfirmation";
 import { ProjectDeleteConfirmationModal } from "../ProjectDeleteConfirmationModal/ProjectDeleteConfirmationModal";
 import { useSettings } from "@/browser/contexts/SettingsContext";
+import { normalizeTaskSettings } from "@/common/types/tasks";
 
 import { AgentListItem, type WorkspaceSelection } from "../AgentListItem/AgentListItem";
 import { getTaskGroupMemberDepth } from "../sidebarItemLayout";
@@ -621,6 +622,66 @@ function didUntrackedPathSetChange(
   return latestUntrackedPaths.some((path) => !acknowledgedSet.has(path));
 }
 
+function usePreserveSubagentsUntilArchiveSetting(api: ReturnType<typeof useAPI>["api"]): boolean {
+  const [preserveSubagentsUntilArchive, setPreserveSubagentsUntilArchive] = useState(false);
+
+  useEffect(() => {
+    if (!api) {
+      return;
+    }
+
+    const abortController = new AbortController();
+    const { signal } = abortController;
+    let iterator: AsyncIterator<unknown> | null = null;
+    let refreshVersion = 0;
+
+    const refresh = async () => {
+      const version = (refreshVersion += 1);
+      try {
+        const cfg = await api.config.getConfig();
+        if (signal.aborted || version !== refreshVersion) {
+          return;
+        }
+        setPreserveSubagentsUntilArchive(
+          normalizeTaskSettings(cfg.taskSettings).preserveSubagentsUntilArchive === true
+        );
+      } catch {
+        // Best-effort: keep the last known setting instead of hiding preserved rows on a
+        // transient config fetch failure.
+      }
+    };
+
+    void refresh();
+
+    void (async () => {
+      try {
+        const subscribedIterator = await api.config.onConfigChanged(undefined, { signal });
+        if (signal.aborted) {
+          void subscribedIterator.return?.();
+          return;
+        }
+
+        iterator = subscribedIterator;
+        for await (const _ of subscribedIterator) {
+          if (signal.aborted) {
+            break;
+          }
+          void refresh();
+        }
+      } catch {
+        // Subscription cancellation is expected during unmount/API reconnects.
+      }
+    })();
+
+    return () => {
+      abortController.abort();
+      void iterator?.return?.();
+    };
+  }, [api]);
+
+  return preserveSubagentsUntilArchive;
+}
+
 const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
   collapsed,
   onToggleCollapsed,
@@ -651,6 +712,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
   const runtimeStatusStore = useRuntimeStatusStoreRaw();
   const { navigateToProject } = useRouter();
   const { api } = useAPI();
+  const preserveSubagentsUntilArchive = usePreserveSubagentsUntilArchiveSetting(api);
   const { confirm: confirmDialog } = useConfirmDialog();
   const settings = useSettings();
 
@@ -801,18 +863,28 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
   >("expandedCompletedSubAgents", {});
   const toggleCompletedChildrenExpansion = useCallback(
     (workspaceId: string) => {
-      setExpandedCompletedSubAgents((prev) => ({
-        ...prev,
-        [workspaceId]: !prev[workspaceId],
-      }));
+      setExpandedCompletedSubAgents((prev) => {
+        const current = prev[workspaceId] ?? preserveSubagentsUntilArchive;
+        const next = !current;
+        const updated = { ...prev };
+        if (next === preserveSubagentsUntilArchive) {
+          delete updated[workspaceId];
+        } else {
+          updated[workspaceId] = next;
+        }
+        return updated;
+      });
     },
-    [setExpandedCompletedSubAgents]
+    [preserveSubagentsUntilArchive, setExpandedCompletedSubAgents]
   );
-  const expandedCompletedParentIds = new Set(
-    Object.entries(expandedCompletedSubAgents)
-      .filter(([, expanded]) => expanded)
-      .map(([workspaceId]) => workspaceId)
-  );
+  const expandedCompletedParentIds = new Set<string>();
+  for (const workspaces of sortedWorkspacesByProject.values()) {
+    for (const workspace of workspaces) {
+      if (expandedCompletedSubAgents[workspace.id] ?? preserveSubagentsUntilArchive) {
+        expandedCompletedParentIds.add(workspace.id);
+      }
+    }
+  }
 
   const [expandedTaskGroups, setExpandedTaskGroups] = useState<Record<string, boolean>>({});
   const toggleTaskGroupExpansion = (groupId: string) => {
@@ -1730,9 +1802,9 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                                 0
                               }
                               rowRenderMeta={rowRenderMeta}
-                              completedChildrenExpanded={
-                                expandedCompletedSubAgents[metadata.id] ?? false
-                              }
+                              completedChildrenExpanded={expandedCompletedParentIds.has(
+                                metadata.id
+                              )}
                               onToggleCompletedChildren={toggleCompletedChildrenExpansion}
                             />
                           );
@@ -2091,9 +2163,9 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                                     sectionId={sectionId}
                                     rowRenderMeta={rowRenderMeta}
                                     subAgentConnectorLayout={subAgentConnectorLayout}
-                                    completedChildrenExpanded={
-                                      expandedCompletedSubAgents[metadata.id] ?? false
-                                    }
+                                    completedChildrenExpanded={expandedCompletedParentIds.has(
+                                      metadata.id
+                                    )}
                                     onToggleCompletedChildren={toggleCompletedChildrenExpansion}
                                   />
                                 );


### PR DESCRIPTION
## Summary

Shows completed subagent rows in the sidebar by default when “Preserve subagents until the workspace gets archived” is enabled, so preserved subagents no longer appear to disappear after completion.

## Background

The backend now preserves completed subagent workspaces correctly, but the sidebar still used the existing completed-subagent collapse behavior. That meant the workspace remained in config but was hidden unless the parent row was manually expanded, making preservation look broken.

## Implementation

- Subscribe `ProjectSidebar` to config task settings.
- Default completed-subagent expansion to `preserveSubagentsUntilArchive`.
- Keep per-parent manual toggles, so users can still hide/show completed subagents for individual parents.
- Guard overlapping config refreshes so stale responses cannot overwrite the latest preserve setting.
- Add a regression test that proves a reported child row is visible by default when preservation is enabled and can still be toggled hidden.

## Validation

- Confirmed the new sidebar test failed before the fix and passed after the fix.
- `bun test src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx -t "shows completed child rows by default"`
- `bun test src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx -t "completed-subagent toggles"`
- `bun test src/browser/utils/ui/workspaceFiltering.test.ts -t "reported children|interrupted children"`
- `make typecheck`
- `make lint`
- `make fmt-check`
- `make static-check`

## Risks

Low-to-moderate. The change is scoped to sidebar visibility and config subscription behavior. Users with preservation disabled keep the existing collapsed-by-default behavior; users with preservation enabled get completed subagents shown by default, with manual per-parent toggles still honored.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=0.00 -->
