### PR TITLE
🤖 fix: preserve JSX-like tags in markdown

### DIFF
--- a/src/browser/features/Messages/MarkdownCore.tsx
+++ b/src/browser/features/Messages/MarkdownCore.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 import { Streamdown } from "streamdown";
-import type { Pluggable } from "unified";
+import type { Element, Root, RootContent, Text } from "hast";
+import type { Pluggable, Plugin } from "unified";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import remarkBreaks from "remark-breaks";
@@ -102,7 +103,78 @@ const sanitizeSchema = {
   },
 };
 
+interface RawHtmlNode {
+  type: "raw";
+  value: string;
+  position?: Text["position"];
+}
+
+type MutableHastNode = Root | RootContent | RawHtmlNode;
+
+type MutableHastParent = Element | Root | { children: MutableHastNode[] };
+
+const RAW_HTML_TAG_NAME_PATTERN = /<\/?\s*([A-Za-z][A-Za-z0-9:-]*)\b[^>]*>/g;
+const ALLOWED_RAW_HTML_TAG_NAMES = new Set(
+  (sanitizeSchema.tagNames ?? []).map((tagName) => tagName.toLowerCase())
+);
+
+function isRawHtmlNode(node: unknown): node is RawHtmlNode {
+  const candidate = node as { type?: unknown; value?: unknown };
+  return candidate.type === "raw" && typeof candidate.value === "string";
+}
+
+function isMutableHastParent(node: unknown): node is MutableHastParent {
+  const candidate = node as { children?: unknown };
+  return Array.isArray(candidate.children);
+}
+
+export function rawHtmlUsesOnlyAllowedTags(rawHtml: string): boolean {
+  for (const match of rawHtml.matchAll(RAW_HTML_TAG_NAME_PATTERN)) {
+    const tagName = match[1]?.toLowerCase();
+    if (!tagName || !ALLOWED_RAW_HTML_TAG_NAMES.has(tagName)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function preserveUnknownRawHtmlChildren(parent: MutableHastParent): void {
+  const children = parent.children as MutableHastNode[];
+
+  for (let idx = 0; idx < children.length; idx++) {
+    const child = children[idx];
+
+    if (isRawHtmlNode(child)) {
+      if (!rawHtmlUsesOnlyAllowedTags(child.value)) {
+        // Pasted errors often include JSX/component names like `<SignOutButton/>`.
+        // If we let rehype parse unknown tags as HTML, sanitize strips the whole tag;
+        // treating only unknown raw HTML as text keeps the transcript readable while
+        // preserving supported HTML such as <details>/<summary> below.
+        children[idx] = {
+          type: "text",
+          value: child.value,
+          position: child.position,
+        };
+      }
+
+      continue;
+    }
+
+    if (isMutableHastParent(child)) {
+      preserveUnknownRawHtmlChildren(child);
+    }
+  }
+}
+
+const rehypePreserveUnknownRawHtml: Plugin<[], Root> = () => {
+  return (tree) => {
+    preserveUnknownRawHtmlChildren(tree);
+  };
+};
+
 const REHYPE_PLUGINS: Pluggable[] = [
+  rehypePreserveUnknownRawHtml,
   rehypeRaw, // Parse HTML elements first
   [rehypeSanitize, sanitizeSchema], // Sanitize HTML to prevent XSS (strips dangerous elements/attributes)
   [

--- a/src/browser/features/Messages/MarkdownRenderer.raw-html.test.tsx
+++ b/src/browser/features/Messages/MarkdownRenderer.raw-html.test.tsx
@@ -1,0 +1,41 @@
+import "../../../../tests/ui/dom";
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { installDom } from "../../../../tests/ui/dom";
+import { rawHtmlUsesOnlyAllowedTags } from "./MarkdownCore";
+import { MarkdownRenderer } from "./MarkdownRenderer";
+
+function renderMarkdown(content: string) {
+  return render(<MarkdownRenderer content={content} preserveLineBreaks />);
+}
+
+describe("MarkdownRenderer raw HTML handling", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installDom();
+  });
+
+  afterEach(() => {
+    cleanup();
+    cleanupDom?.();
+    cleanupDom = null;
+  });
+
+  test("renders unknown JSX-like tags as literal text", () => {
+    const view = renderMarkdown(
+      "@clerk/nextjs: You've passed multiple children components to <SignOutButton/>. You can only pass a single child component or text."
+    );
+
+    expect(view.container.textContent).toContain("<SignOutButton/>");
+    expect(view.container.textContent).toContain("You can only pass a single child component");
+    expect(view.container.querySelector("signoutbutton")).toBeNull();
+  });
+
+  test("keeps supported collapsible HTML on the raw HTML path", () => {
+    expect(rawHtmlUsesOnlyAllowedTags("<details><summary>More</summary>Hidden</details>")).toBe(
+      true
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Preserves JSX-like component names in chat markdown so pasted errors like `<SignOutButton/>` remain visible in message history instead of being parsed as unknown HTML and stripped by sanitization.

## Background

Markdown rendering intentionally supports sanitized raw HTML for cases like collapsible `<details>` blocks. That same raw HTML path caused copied React/JSX component names in error text to be parsed as HTML elements and removed by `rehype-sanitize`.

## Implementation

Adds a pre-`rehypeRaw` plugin that converts raw HTML containing tags outside the sanitize allowlist into text. Allowed sanitized HTML still flows through `rehypeRaw`, `rehype-sanitize`, and `rehype-harden` unchanged.

## Validation

- `bun test src/browser/features/Messages/MarkdownRenderer.raw-html.test.tsx`
- `bun test src/browser/features/Messages/InlineSkillMarkdown.test.tsx src/browser/features/Messages/TypewriterMarkdown.test.tsx src/browser/features/Messages/MarkdownComponents.test.tsx`
- `bun x eslint --max-warnings 0 src/browser/features/Messages/MarkdownCore.tsx src/browser/features/Messages/MarkdownRenderer.raw-html.test.tsx`
- `bun x prettier --check src/browser/features/Messages/MarkdownCore.tsx src/browser/features/Messages/MarkdownRenderer.raw-html.test.tsx`
- `nix shell nixpkgs#shfmt nixpkgs#hadolint -c make static-check`

## Risks

Low. The change is limited to raw HTML markdown nodes before sanitization. Unknown tags become escaped text, while supported sanitized HTML remains available.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `2394133{MUX_COSTS_USD:-0.00}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=0.00 -->
