### PR TITLE
🤖 fix: clarify math delimiter instructions

### DIFF
--- a/docs/agents/system-prompt.mdx
+++ b/docs/agents/system-prompt.mdx
@@ -26,7 +26,7 @@ Always verify repo facts before making correctness claims; trusted tool output a
   
 <markdown>
 Your Assistant messages display in Markdown with extensions for mermaidjs and katex.
-For math expressions, prefer \`$$...$$\` delimiters for the most reliable rendering.
+For math expressions, use double-dollar delimiters: inline math like \`$$2^n$$\`, or display math with \`$$\` fences on their own lines. Do not use single-dollar \`$...$\` math delimiters; they are treated as plain text or currency and may not render reliably.
 
 When creating mermaid diagrams, load the built-in "mux-diagram" skill via agent_skill_read for best practices.
 

--- a/src/node/services/agentSkills/builtInSkillContent.generated.ts
+++ b/src/node/services/agentSkills/builtInSkillContent.generated.ts
@@ -1540,7 +1540,7 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
       "  ",
       "<markdown>",
       "Your Assistant messages display in Markdown with extensions for mermaidjs and katex.",
-      "For math expressions, prefer \\`$$...$$\\` delimiters for the most reliable rendering.",
+      "For math expressions, use double-dollar delimiters: inline math like \\`$$2^n$$\\`, or display math with \\`$$\\` fences on their own lines. Do not use single-dollar \\`$...$\\` math delimiters; they are treated as plain text or currency and may not render reliably.",
       "",
       'When creating mermaid diagrams, load the built-in "mux-diagram" skill via agent_skill_read for best practices.',
       "",

--- a/src/node/services/systemMessage.ts
+++ b/src/node/services/systemMessage.ts
@@ -52,7 +52,7 @@ Always verify repo facts before making correctness claims; trusted tool output a
   
 <markdown>
 Your Assistant messages display in Markdown with extensions for mermaidjs and katex.
-For math expressions, prefer \`$$...$$\` delimiters for the most reliable rendering.
+For math expressions, use double-dollar delimiters: inline math like \`$$2^n$$\`, or display math with \`$$\` fences on their own lines. Do not use single-dollar \`$...$\` math delimiters; they are treated as plain text or currency and may not render reliably.
 
 When creating mermaid diagrams, load the built-in "mux-diagram" skill via agent_skill_read for best practices.
 


### PR DESCRIPTION
Summary

Clarifies Mux's base markdown instructions so agents emit KaTeX math with double-dollar delimiters, including an explicit inline example and a warning that single-dollar `$...$` delimiters are treated as plain text or currency.

Background

Mux intentionally keeps broad single-dollar math parsing disabled because it conflicts with regular currency text and Mux's `$skill` inline references. This avoids adding heuristic markdown parsing while steering future model output toward the delimiter format the renderer already supports reliably.

Validation

- `bun test src/browser/features/Messages/MarkdownStyles.test.ts src/node/services/systemMessage.test.ts`
- `make static-check`

Risks

Low. This only changes prompt text and regenerated documentation/skill snapshot content; it does not alter markdown rendering behavior.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$4.24`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=4.24 -->
