### PR TITLE
🤖 perf: improve large-chat typing responsiveness

### DIFF
--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -158,6 +158,16 @@ import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 // localStorage quotas are environment-dependent and relatively small.
 // Be conservative here so we can warn the user before writes start failing.
 
+// Normal typing usually has no active suggestion menu. Reuse the existing empty array
+// so suggestion effects do not schedule an avoidable second render on every keypress.
+function clearSuggestions(prev: SlashSuggestion[]): SlashSuggestion[] {
+  return prev.length === 0 ? prev : [];
+}
+
+function replaceSuggestions(prev: SlashSuggestion[], next: SlashSuggestion[]): SlashSuggestion[] {
+  return prev.length === 0 && next.length === 0 ? prev : next;
+}
+
 const PDF_MEDIA_TYPE = "application/pdf";
 
 function getBaseMediaType(mediaType: string): string {
@@ -1180,7 +1190,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       atMentionRequestIdRef.current++;
       lastAtMentionScopeIdRef.current = null;
       lastAtMentionQueryRef.current = null;
-      setAtMentionSuggestions([]);
+      setAtMentionSuggestions(clearSuggestions);
       setShowAtMentionSuggestions(false);
       return;
     }
@@ -1193,7 +1203,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       atMentionRequestIdRef.current++;
       lastAtMentionScopeIdRef.current = null;
       lastAtMentionQueryRef.current = null;
-      setAtMentionSuggestions([]);
+      setAtMentionSuggestions(clearSuggestions);
       setShowAtMentionSuggestions(false);
       return;
     }
@@ -1264,7 +1274,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           setShowAtMentionSuggestions(nextSuggestions.length > 0);
         } catch {
           if (atMentionRequestIdRef.current === requestId) {
-            setAtMentionSuggestions([]);
+            setAtMentionSuggestions(clearSuggestions);
             setShowAtMentionSuggestions(false);
           }
         }
@@ -1301,7 +1311,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     const match = findInlineSkillReferenceAtCursor(input, cursor);
 
     if (!match) {
-      setSkillSuggestions([]);
+      setSkillSuggestions(clearSuggestions);
       setShowSkillSuggestions(false);
       lastSkillQueryRef.current = null;
       return;
@@ -1338,7 +1348,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       agentSkills: agentSkillDescriptors,
       variant,
     });
-    setCommandSuggestions(suggestions);
+    setCommandSuggestions((prev) => replaceSuggestions(prev, suggestions));
     setShowCommandSuggestions(suggestions.length > 0);
   }, [input, agentSkillDescriptors, variant]);
 
@@ -1925,7 +1935,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         input.slice(match.endIndex);
 
       setInput(next);
-      setAtMentionSuggestions([]);
+      setAtMentionSuggestions(clearSuggestions);
       setShowAtMentionSuggestions(false);
 
       requestAnimationFrame(() => {
@@ -1957,7 +1967,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       const next = input.slice(0, match.startIndex) + suggestion.replacement + trailing + after;
 
       setInput(next);
-      setSkillSuggestions([]);
+      setSkillSuggestions(clearSuggestions);
       setShowSkillSuggestions(false);
       lastSkillQueryRef.current = null;
 

--- a/src/browser/hooks/useAutoResizeTextarea.test.tsx
+++ b/src/browser/hooks/useAutoResizeTextarea.test.tsx
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+import { GlobalWindow } from "happy-dom";
+import type { RefObject } from "react";
+import { useAutoResizeTextarea } from "./useAutoResizeTextarea";
+
+function createFakeTextarea(initialScrollHeight: number): {
+  ref: RefObject<HTMLTextAreaElement>;
+  assignments: string[];
+  setScrollHeight: (value: number) => void;
+} {
+  let height = "";
+  let scrollHeight = initialScrollHeight;
+  const assignments: string[] = [];
+  const style = {
+    get height() {
+      return height;
+    },
+    set height(value: string) {
+      height = value;
+      assignments.push(value);
+    },
+  };
+
+  const textarea = {
+    style,
+    get scrollHeight() {
+      return scrollHeight;
+    },
+  } as unknown as HTMLTextAreaElement;
+
+  return {
+    ref: { current: textarea },
+    assignments,
+    setScrollHeight: (value) => {
+      scrollHeight = value;
+    },
+  };
+}
+
+describe("useAutoResizeTextarea", () => {
+  beforeEach(() => {
+    const domWindow = new GlobalWindow() as unknown as Window & typeof globalThis;
+    globalThis.window = domWindow;
+    globalThis.document = domWindow.document;
+    Object.defineProperty(globalThis.window, "innerHeight", {
+      configurable: true,
+      value: 1000,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.window = undefined as unknown as Window & typeof globalThis;
+    globalThis.document = undefined as unknown as Document;
+  });
+
+  it("does not reset height to auto for pure typing that does not change composer height", () => {
+    const textarea = createFakeTextarea(40);
+    const { rerender } = renderHook(({ value }) => useAutoResizeTextarea(textarea.ref, value, 50), {
+      initialProps: { value: "" },
+    });
+
+    expect(textarea.assignments).toEqual(["auto", "40px"]);
+    textarea.assignments.length = 0;
+
+    // This is the hot path for typing in a large chat: keep the existing height when
+    // scrollHeight is unchanged so the transcript flex sibling does not get re-laid out.
+    rerender({ value: "a" });
+
+    expect(textarea.assignments).toEqual([]);
+  });
+
+  it("grows on insertion without the shrink-to-auto reset, but still shrinks on deletion", () => {
+    const textarea = createFakeTextarea(40);
+    const { rerender } = renderHook(({ value }) => useAutoResizeTextarea(textarea.ref, value, 50), {
+      initialProps: { value: "" },
+    });
+    textarea.assignments.length = 0;
+
+    textarea.setScrollHeight(64);
+    rerender({ value: "line one\nline two" });
+
+    expect(textarea.assignments).toEqual(["64px"]);
+    textarea.assignments.length = 0;
+
+    textarea.setScrollHeight(40);
+    rerender({ value: "line one" });
+
+    expect(textarea.assignments).toEqual(["auto", "40px"]);
+  });
+
+  it("shrinks when a longer replacement does not preserve the previous text", () => {
+    const textarea = createFakeTextarea(84);
+    const { rerender } = renderHook(({ value }) => useAutoResizeTextarea(textarea.ref, value, 50), {
+      initialProps: { value: "line one\nline two\nline three" },
+    });
+    textarea.assignments.length = 0;
+
+    textarea.setScrollHeight(40);
+    rerender({ value: "one visually shorter replacement" });
+
+    expect(textarea.assignments).toEqual(["auto", "40px"]);
+  });
+});

--- a/src/browser/hooks/useAutoResizeTextarea.ts
+++ b/src/browser/hooks/useAutoResizeTextarea.ts
@@ -1,4 +1,29 @@
-import { useLayoutEffect, type RefObject } from "react";
+import { useLayoutEffect, useRef, type RefObject } from "react";
+
+function preservesPreviousValueAsInsertion(previousValue: string, nextValue: string): boolean {
+  if (nextValue.length <= previousValue.length) {
+    return false;
+  }
+
+  let sharedPrefixLength = 0;
+  while (
+    sharedPrefixLength < previousValue.length &&
+    previousValue[sharedPrefixLength] === nextValue[sharedPrefixLength]
+  ) {
+    sharedPrefixLength += 1;
+  }
+
+  let sharedSuffixLength = 0;
+  while (
+    sharedSuffixLength < previousValue.length - sharedPrefixLength &&
+    previousValue[previousValue.length - 1 - sharedSuffixLength] ===
+      nextValue[nextValue.length - 1 - sharedSuffixLength]
+  ) {
+    sharedSuffixLength += 1;
+  }
+
+  return sharedPrefixLength + sharedSuffixLength === previousValue.length;
+}
 
 /**
  * Auto-resize a textarea to fit its content.
@@ -9,15 +34,47 @@ export function useAutoResizeTextarea(
   value: string,
   maxHeightVh = 30
 ): void {
+  const previousValueRef = useRef<string | null>(null);
+  const previousMaxRef = useRef<number | null>(null);
+  const appliedHeightRef = useRef<number | null>(null);
+
   useLayoutEffect(() => {
     const el = ref.current;
     if (!el) return;
 
-    // Always measure to avoid layout shift when placeholder disappears.
-    // Placeholder text doesn't contribute to scrollHeight, so we need
-    // consistent measurement whether content is empty or not.
-    el.style.height = "auto";
     const max = window.innerHeight * (maxHeightVh / 100);
-    el.style.height = Math.min(el.scrollHeight, max) + "px";
+    const previousValue = previousValueRef.current;
+    const previousMax = previousMaxRef.current;
+    const canOnlyGrow =
+      previousValue !== null &&
+      previousMax === max &&
+      preservesPreviousValueAsInsertion(previousValue, value);
+
+    let nextHeight: number;
+    if (canOnlyGrow) {
+      // User typing in a large transcript should not reset the textarea to "auto" on
+      // every key. That temporary height mutation forces the surrounding flex column
+      // (including all chat rows) through layout even when the composer height is
+      // unchanged. For pure insertions we only need to grow if scrollHeight exceeds
+      // the currently applied height; shrinking paths still use the full reset below.
+      const appliedHeight = appliedHeightRef.current ?? Number.parseFloat(el.style.height);
+      const scrollHeight = Math.min(el.scrollHeight, max);
+      nextHeight = Number.isFinite(appliedHeight)
+        ? Math.max(appliedHeight, scrollHeight)
+        : scrollHeight;
+    } else {
+      // Deletions, same-length replacements, viewport changes, and first render may
+      // shrink the textarea, so measure from its intrinsic content height.
+      el.style.height = "auto";
+      nextHeight = Math.min(el.scrollHeight, max);
+    }
+
+    if (appliedHeightRef.current !== nextHeight) {
+      el.style.height = `${nextHeight}px`;
+      appliedHeightRef.current = nextHeight;
+    }
+
+    previousValueRef.current = value;
+    previousMaxRef.current = max;
   }, [ref, value, maxHeightVh]);
 }

--- a/tests/e2e/scenarios/perf.chatTyping.spec.ts
+++ b/tests/e2e/scenarios/perf.chatTyping.spec.ts
@@ -1,0 +1,75 @@
+import { electronTest as test, electronExpect as expect } from "../electronTest";
+import { seedWorkspaceHistoryProfile } from "../utils/historyFixture";
+import {
+  readReactProfileSnapshot,
+  resetReactProfileSamples,
+  withChromeProfiles,
+  writePerfArtifacts,
+} from "../utils/perfProfile";
+
+const shouldRunPerfScenarios = process.env.MUX_E2E_RUN_PERF === "1";
+
+const TYPING_SAMPLE =
+  "Diagnose typing latency in a large chat transcript while keeping input responsive.";
+
+test.skip(
+  ({ browserName }) => browserName !== "chromium",
+  "Electron scenario runs on chromium only"
+);
+
+test.describe("chat typing performance profiling", () => {
+  test.skip(!shouldRunPerfScenarios, "Set MUX_E2E_RUN_PERF=1 to run perf profiling scenarios");
+
+  test("perf: type in composer with large chat history", async ({
+    page,
+    ui,
+    workspace,
+  }, testInfo) => {
+    const historySummary = await seedWorkspaceHistoryProfile({
+      demoProject: workspace.demoProject,
+      profile: "large",
+    });
+
+    await ui.projects.openFirstWorkspace();
+    await expect(page.getByTestId("message-window")).toHaveAttribute("data-loaded", "true", {
+      timeout: 20_000,
+    });
+
+    const input = page.getByRole("textbox", { name: "Message Claude" });
+    await expect(input).toBeVisible({ timeout: 20_000 });
+    await input.fill("");
+
+    await resetReactProfileSamples(page);
+
+    const runLabel = "chat-typing-large-history";
+    const chromeProfile = await withChromeProfiles(page, { label: runLabel }, async () => {
+      await input.click();
+      await input.pressSequentially(TYPING_SAMPLE, { delay: 0 });
+      await expect(input).toHaveValue(TYPING_SAMPLE);
+    });
+
+    const reactProfileSnapshot = await readReactProfileSnapshot(page);
+    if (!reactProfileSnapshot) {
+      throw new Error("React profile snapshot was not captured");
+    }
+
+    const artifactDirectory = await writePerfArtifacts({
+      testInfo,
+      runLabel,
+      chromeProfile,
+      reactProfile: reactProfileSnapshot,
+      historyProfile: historySummary,
+    });
+
+    // The composer owns draft text locally; typing must not re-render the large transcript.
+    expect(reactProfileSnapshot.byProfilerId["chat-pane.transcript"]?.sampleCount ?? 0).toBe(0);
+    expect(chromeProfile.wallTimeMs).toBeLessThan(2_500);
+    expect(chromeProfile.cpuProfile).not.toBeNull();
+    expect(reactProfileSnapshot.enabled).toBe(true);
+
+    testInfo.annotations.push({
+      type: "perf-artifact",
+      description: artifactDirectory,
+    });
+  });
+});


### PR DESCRIPTION
Summary
- Improves chat composer typing responsiveness on large transcripts by avoiding unnecessary layout and render work during the hot typing path.

Background
- The new perf scenario profiles sequential typing into a composer after seeding the existing `large` chat history fixture (180 messages, ~884k deterministic transcript characters).
- Baseline profiling showed typing was spending avoidable time in layout/style recalculation while the composer reset its textarea height to `auto` on every keypress, making the large transcript flex sibling participate in layout even when composer height did not change.

Implementation
- `useAutoResizeTextarea` now keeps the applied height for true insertions and only grows when `scrollHeight` exceeds the current height; shrink-capable paths (deletion, replacement, viewport changes, first render) still reset to intrinsic height.
- Chat input suggestion state now preserves stable empty arrays so ordinary typing without an active suggestion menu does not schedule avoidable follow-up renders.
- Added a focused hook test for grow/shrink behavior, including longer replacements that should shrink, and a perf harness scenario for typing into a large chat with a guard that transcript render markers remain untouched while typing.

Validation
- `bun test src/browser/hooks/useAutoResizeTextarea.test.tsx`
- `TEST_INTEGRATION=1 bun x jest tests/ui/chat/fileMentionsWithSlashCommands.test.ts`
- `MUX_E2E_RUN_PERF=1 MUX_PROFILE_REACT=1 MUX_E2E_LOAD_DIST=1 MUX_E2E_SKIP_BUILD=1 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 xvfb-run -a bun x playwright test --project=electron tests/e2e/scenarios/perf.chatTyping.spec.ts --workers=1`
  - Latest repeat: 528ms total wall time for the full 82-character typing scenario (~6.4ms/character), 0 transcript render samples, layout duration ~0.017s.
  - Initial baseline before the fix: 705ms total wall time for the same full scenario (~8.6ms/character), layout duration ~0.035s.
  - Note: the E2E wall time includes Playwright `pressSequentially` dispatch and Chrome profiling overhead; it is not a per-keystroke latency metric.
- `make static-check`
- Post-rebase/post-review `make static-check`

Risks
- Low-to-moderate: textarea resize behavior is user-visible. The hook keeps the previous full reset behavior for shrink cases and adds focused unit coverage to guard insertion growth, deletion shrinkage, and longer replacement shrinkage.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `n/a`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=n/a -->
