### PR TITLE
🤖 perf: preview large file edit diffs

### DIFF
--- a/src/browser/features/Tools/FileEditToolCall.test.ts
+++ b/src/browser/features/Tools/FileEditToolCall.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildLargeDiffPreview } from "./FileEditToolCall";
+
+function buildDiff(lineCount: number): string {
+  return Array.from({ length: lineCount }, (_, index) => `+line-${index + 1}`).join("\n");
+}
+
+describe("buildLargeDiffPreview", () => {
+  test("does not preview small diffs", () => {
+    expect(buildLargeDiffPreview(buildDiff(12))).toBeNull();
+  });
+
+  test("caps large diff previews before rendering the full patch", () => {
+    const preview = buildLargeDiffPreview(buildDiff(700));
+
+    expect(preview).not.toBeNull();
+    expect(preview?.totalLines).toBe(700);
+    expect(preview?.displayedLines).toBe(240);
+    expect(preview?.omittedLines).toBe(460);
+    expect(preview?.previewDiff).toContain("+line-240");
+    expect(preview?.previewDiff).not.toContain("+line-241");
+  });
+
+  test("previews character-heavy single-line diffs", () => {
+    const preview = buildLargeDiffPreview(`+${"x".repeat(80_001)}`);
+
+    expect(preview?.totalLines).toBe(1);
+    expect(preview?.omittedLines).toBe(0);
+  });
+});

--- a/src/browser/features/Tools/FileEditToolCall.tsx
+++ b/src/browser/features/Tools/FileEditToolCall.tsx
@@ -40,6 +40,51 @@ type FileEditToolResult =
   | FileEditReplaceLinesToolResult
   | FileEditInsertToolResult;
 
+// Large file-edit patches can create thousands of DOM nodes and trigger expensive layout
+// measurement while opening chats; preview first and let users opt into the full parsed render.
+const LARGE_DIFF_PREVIEW_LINE_THRESHOLD = 600;
+const LARGE_DIFF_PREVIEW_CHAR_THRESHOLD = 80_000;
+const LARGE_DIFF_PREVIEW_LINE_LIMIT = 240;
+
+interface LargeDiffPreview {
+  previewDiff: string;
+  totalLines: number;
+  displayedLines: number;
+  omittedLines: number;
+}
+
+export function buildLargeDiffPreview(diff: string): LargeDiffPreview | null {
+  const lines = diff.split(/\r?\n/);
+  if (lines.length > 0 && lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+
+  const totalLines = lines.length;
+  if (
+    totalLines <= LARGE_DIFF_PREVIEW_LINE_THRESHOLD &&
+    diff.length <= LARGE_DIFF_PREVIEW_CHAR_THRESHOLD
+  ) {
+    return null;
+  }
+
+  const previewLines = lines.slice(0, LARGE_DIFF_PREVIEW_LINE_LIMIT);
+  const omittedLines = Math.max(0, totalLines - previewLines.length);
+  const previewDiff =
+    omittedLines > 0
+      ? [
+          ...previewLines,
+          `... ${omittedLines.toLocaleString()} diff lines omitted from preview ...`,
+        ].join("\n")
+      : previewLines.join("\n");
+
+  return {
+    previewDiff,
+    totalLines,
+    displayedLines: previewLines.length,
+    omittedLines,
+  };
+}
+
 interface FileEditToolCallProps {
   toolName: "file_edit_replace_string" | "file_edit_replace_lines" | "file_edit_insert";
   args: FileEditOperationArgs;
@@ -93,6 +138,16 @@ function renderDiff(
   }
 }
 
+function renderRawDiff(diff: string): React.ReactNode {
+  return (
+    <DiffContainer>
+      <pre className="font-monospace m-0 text-[11px] leading-[1.4] break-words whitespace-pre-wrap">
+        {diff}
+      </pre>
+    </DiffContainer>
+  );
+}
+
 export const FileEditToolCall: React.FC<FileEditToolCallProps> = ({
   toolName,
   args,
@@ -107,10 +162,13 @@ export const FileEditToolCall: React.FC<FileEditToolCallProps> = ({
   const { expanded, toggleExpanded } = useToolExpansion(initialExpanded);
   const [showRaw, setShowRaw] = React.useState(false);
   const [showInvocation, setShowInvocation] = React.useState(false);
+  const [showFullDiff, setShowFullDiff] = React.useState(false);
 
   const uiOnlyDiff = getToolOutputUiOnly(result)?.file_edit?.diff;
   const diff = result && result.success ? (uiOnlyDiff ?? result.diff) : undefined;
   const filePath = extractToolFilePath(args);
+  const largeDiffPreview = diff ? buildLargeDiffPreview(diff) : null;
+  const shouldShowLargeDiffPreview = Boolean(largeDiffPreview && !showRaw && !showFullDiff);
 
   // Copy to clipboard with feedback
   const { copied, copyToClipboard } = useCopyToClipboard();
@@ -182,17 +240,32 @@ export const FileEditToolCall: React.FC<FileEditToolCallProps> = ({
                 </DetailSection>
               )}
 
-              {result.success &&
-                diff &&
-                (showRaw ? (
-                  <DiffContainer>
-                    <pre className="font-monospace m-0 text-[11px] leading-[1.4] break-words whitespace-pre-wrap">
-                      {diff}
-                    </pre>
-                  </DiffContainer>
-                ) : (
-                  renderDiff(diff, filePath, onReviewNote)
-                ))}
+              {result.success && diff && (
+                <>
+                  {shouldShowLargeDiffPreview && largeDiffPreview && (
+                    <DetailSection>
+                      <div className="text-muted text-[11px]">
+                        Large diff preview: showing{" "}
+                        {largeDiffPreview.displayedLines.toLocaleString()} of{" "}
+                        {largeDiffPreview.totalLines.toLocaleString()} lines. Full patch is still
+                        available from the menu.
+                      </div>
+                      <button
+                        type="button"
+                        className="text-accent hover:text-accent-light mt-1 text-left text-[11px] underline underline-offset-2"
+                        onClick={() => setShowFullDiff(true)}
+                      >
+                        Render full parsed diff
+                      </button>
+                    </DetailSection>
+                  )}
+                  {showRaw
+                    ? renderRawDiff(diff)
+                    : shouldShowLargeDiffPreview && largeDiffPreview
+                      ? renderRawDiff(largeDiffPreview.previewDiff)
+                      : renderDiff(diff, filePath, onReviewNote)}
+                </>
+              )}
             </>
           )}
 

--- a/tests/e2e/utils/historyFixture.ts
+++ b/tests/e2e/utils/historyFixture.ts
@@ -2,6 +2,7 @@ import fsPromises from "fs/promises";
 import path from "path";
 import type { DemoProjectConfig } from "./demoProject";
 import { createMuxMessage, type MuxMessage } from "../../../src/common/types/message";
+import { FILE_EDIT_DIFF_OMITTED_MESSAGE } from "../../../src/common/types/tools";
 import { HistoryService } from "../../../src/node/services/historyService";
 
 const BASE_TIMESTAMP_MS = 1_700_000_000_000;
@@ -12,6 +13,7 @@ type HistoryProfileDefinition = {
   assistantChars: number;
   reasoningChars: number;
   toolOutputChars: number;
+  largeDiffLinePairs?: number;
 };
 
 const HISTORY_PROFILE_NAMES = [
@@ -20,6 +22,7 @@ const HISTORY_PROFILE_NAMES = [
   "large",
   "tool-heavy",
   "reasoning-heavy",
+  "large-diff",
 ] as const;
 
 export type HistoryProfileName = (typeof HISTORY_PROFILE_NAMES)[number];
@@ -31,6 +34,7 @@ export interface SeededHistoryProfileSummary {
   estimatedCharacterCount: number;
   hasToolParts: boolean;
   hasReasoningParts: boolean;
+  largeDiffLineCount?: number;
 }
 
 const HISTORY_PROFILES: Record<HistoryProfileName, HistoryProfileDefinition> = {
@@ -69,6 +73,14 @@ const HISTORY_PROFILES: Record<HistoryProfileName, HistoryProfileDefinition> = {
     reasoningChars: 4_400,
     toolOutputChars: 0,
   },
+  "large-diff": {
+    messagePairs: 1,
+    userChars: 220,
+    assistantChars: 300,
+    reasoningChars: 0,
+    toolOutputChars: 0,
+    largeDiffLinePairs: 2_500,
+  },
 };
 
 function buildDeterministicText(label: string, targetLength: number): string {
@@ -84,11 +96,33 @@ function buildDeterministicText(label: string, targetLength: number): string {
   return content.slice(0, targetLength);
 }
 
+function buildLargeFileEditDiff(linePairs: number): string {
+  const normalizedLinePairs = Math.max(1, Math.trunc(linePairs));
+  const lines = [
+    "diff --git a/src/perf-large-diff.ts b/src/perf-large-diff.ts",
+    "index 1111111..2222222 100644",
+    "--- a/src/perf-large-diff.ts",
+    "+++ b/src/perf-large-diff.ts",
+    `@@ -1,${normalizedLinePairs} +1,${normalizedLinePairs} @@`,
+  ];
+
+  for (let lineIndex = 0; lineIndex < normalizedLinePairs; lineIndex++) {
+    const id = String(lineIndex + 1).padStart(4, "0");
+    lines.push(
+      `-export const perfProbe${id} = "before-${id}";`,
+      `+export const perfProbe${id} = "after-${id}";`
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
 function createAssistantParts(args: {
   profile: HistoryProfileName;
   index: number;
   toolOutputChars: number;
   reasoningChars: number;
+  largeDiffLinePairs?: number;
 }): MuxMessage["parts"] {
   const parts: MuxMessage["parts"] = [];
 
@@ -112,6 +146,28 @@ function createAssistantParts(args: {
       output: {
         success: true,
         [outputKey]: toolPayload,
+      },
+      timestamp: BASE_TIMESTAMP_MS + args.index,
+    });
+  }
+
+  if (args.largeDiffLinePairs && args.largeDiffLinePairs > 0) {
+    const diff = buildLargeFileEditDiff(args.largeDiffLinePairs);
+    parts.push({
+      type: "dynamic-tool",
+      state: "output-available",
+      toolCallId: `${args.profile}-large-diff-tool-call-${args.index}`,
+      toolName: "file_edit_replace_string",
+      input: {
+        path: "src/perf-large-diff.ts",
+        old_string: "before",
+        new_string: "after",
+      },
+      output: {
+        success: true,
+        diff: FILE_EDIT_DIFF_OMITTED_MESSAGE,
+        edits_applied: args.largeDiffLinePairs,
+        ui_only: { file_edit: { diff } },
       },
       timestamp: BASE_TIMESTAMP_MS + args.index,
     });
@@ -183,6 +239,7 @@ export async function seedWorkspaceHistoryProfile(args: {
       index: pairIndex,
       toolOutputChars: profileConfig.toolOutputChars,
       reasoningChars: profileConfig.reasoningChars,
+      largeDiffLinePairs: profileConfig.largeDiffLinePairs,
     });
 
     const assistantMessage = createMuxMessage(
@@ -204,18 +261,26 @@ export async function seedWorkspaceHistoryProfile(args: {
     });
   }
 
+  const largeDiffCharacterCount = profileConfig.largeDiffLinePairs
+    ? buildLargeFileEditDiff(profileConfig.largeDiffLinePairs).length
+    : 0;
+
   return {
     profile,
     messageCount: profileConfig.messagePairs * 2,
     assistantMessageCount: profileConfig.messagePairs,
     estimatedCharacterCount:
       profileConfig.messagePairs *
-      (profileConfig.userChars +
-        profileConfig.assistantChars +
-        profileConfig.toolOutputChars +
-        profileConfig.reasoningChars),
-    hasToolParts: profileConfig.toolOutputChars > 0,
+        (profileConfig.userChars +
+          profileConfig.assistantChars +
+          profileConfig.toolOutputChars +
+          profileConfig.reasoningChars) +
+      largeDiffCharacterCount,
+    hasToolParts: profileConfig.toolOutputChars > 0 || largeDiffCharacterCount > 0,
     hasReasoningParts: profileConfig.reasoningChars > 0,
+    largeDiffLineCount: profileConfig.largeDiffLinePairs
+      ? profileConfig.largeDiffLinePairs * 2 + 5
+      : undefined,
   };
 }
 


### PR DESCRIPTION
## Summary

Adds a large-diff chat performance profile and changes file-edit tool cards to show a capped raw preview for very large patches by default, with explicit actions to copy/show the full patch or render the full parsed diff on demand.

## Background

The workspace-open perf harness showed that a chat containing a 5,005-line file-edit diff spent most of its open time mounting and measuring a huge parsed diff DOM tree. Baseline `workspace-open-large-diff` was **3,143 ms** wall time with **2.896 s** Chrome task duration; after this change it is **753 ms** wall time with **0.495 s** task duration.

## Implementation

- Added a `large-diff` history profile that seeds a realistic `file_edit_replace_string` result with the full patch stored in `ui_only.file_edit.diff`.
- Added a large-diff preview gate in `FileEditToolCall` (line/byte thresholds) so huge diffs render a small raw preview first instead of eagerly parsing/rendering every hunk with selectable review UI.
- Kept full fidelity available through the existing patch menu and a new explicit “Render full parsed diff” action.
- Added unit coverage for the preview decision/capping behavior.

## Validation

- `bun test src/browser/features/Tools/FileEditToolCall.test.ts`
- `make typecheck`
- `make build`
- `MUX_E2E_RUN_PERF=1 MUX_PROFILE_REACT=1 MUX_E2E_LOAD_DIST=1 MUX_E2E_SKIP_BUILD=1 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 MUX_E2E_PERF_PROFILES=large-diff xvfb-run -a bun x playwright test --project=electron tests/e2e/scenarios/perf.workspaceOpen.spec.ts --reporter=line`
- `make static-check` (after rebasing onto `origin/main`)

## Risks

Low-to-moderate UI risk: large diffs no longer show the full parsed/selectable view immediately. The full patch remains available, and users can still opt into the full parsed diff when needed.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `n/a`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs= -->
