### PR TITLE
🤖 perf: speed up large review chat open

### DIFF
--- a/src/browser/features/RightSidebar/CodeReview/HunkViewer.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/HunkViewer.tsx
@@ -49,6 +49,8 @@ interface HunkViewerProps {
   includeUncommitted: boolean;
   /** Action callbacks for inline review notes */
   reviewActions?: ReviewActionCallbacks;
+  /** Prefer a collapsed default for huge reviews so opening Review doesn't mount every diff line. */
+  preferCollapsed?: boolean;
 }
 
 function renderHighlightedFilePath(
@@ -126,6 +128,7 @@ export const HunkViewer = React.memo<HunkViewerProps>(
     diffBase,
     reviewActions,
     includeUncommitted,
+    preferCollapsed = false,
   }) => {
     // Ref for the hunk container to track visibility
     const hunkRef = React.useRef<HTMLDivElement>(null);
@@ -202,28 +205,26 @@ export const HunkViewer = React.memo<HunkViewerProps>(
     const hasManualState = hunkId in expandStateMap;
     const manualExpandState = expandStateMap[hunkId];
 
-    // Determine initial expand state (priority: manual > read status > size)
+    const shouldAutoExpand = !isRead && !isLargeHunk && (!preferCollapsed || Boolean(isSelected));
+
+    // Determine initial expand state (priority: manual > read status > size/review scale)
     const [isExpanded, setIsExpanded] = useState(() => {
       if (hasManualState) {
         return manualExpandState;
       }
-      return !isRead && !isLargeHunk;
+      return shouldAutoExpand;
     });
 
-    // Auto-collapse when marked as read, auto-expand when unmarked (unless user manually set)
+    // Auto-collapse when marked as read or when a huge review keeps only the selected hunk open.
     React.useEffect(() => {
       // Don't override manual expand/collapse choices
       if (hasManualState) {
         return;
       }
 
-      if (isRead) {
-        setIsExpanded(false);
-      } else if (!isLargeHunk) {
-        setIsExpanded(true);
-      }
-      // Note: When unmarking as read, large hunks remain collapsed
-    }, [isRead, isLargeHunk, hasManualState]);
+      setIsExpanded(shouldAutoExpand);
+      // Note: When unmarking as read, large hunks remain collapsed unless selected.
+    }, [shouldAutoExpand, hasManualState]);
 
     // Sync local state with persisted state when it changes
     React.useEffect(() => {

--- a/src/browser/features/RightSidebar/CodeReview/ReviewPanel.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ReviewPanel.tsx
@@ -135,6 +135,9 @@ type DiffState =
   | { status: "loaded"; hunks: DiffHunk[]; truncationWarning: string | null }
   | { status: "error"; message: string };
 
+const LARGE_REVIEW_COLLAPSE_HUNK_THRESHOLD = 200;
+const LARGE_REVIEW_COLLAPSE_OUTPUT_BYTES = 250_000;
+
 const REVIEW_PANEL_CACHE_MAX_ENTRIES = 20;
 const REVIEW_PANEL_CACHE_MAX_SIZE_BYTES = 20 * 1024 * 1024; // 20MB
 
@@ -1242,6 +1245,16 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
     firstSeenMap,
   ]);
 
+  // Huge reviews are useful for navigation, but eagerly expanding every hunk can mount
+  // tens of thousands of diff-line nodes next to the transcript. Keep the list scannable
+  // by expanding only the selected hunk once review scale crosses this threshold.
+  const preferCollapsedHunks =
+    hunks.length >= LARGE_REVIEW_COLLAPSE_HUNK_THRESHOLD ||
+    (diagnosticInfo?.outputLength ?? 0) >= LARGE_REVIEW_COLLAPSE_OUTPUT_BYTES ||
+    (diffState.status === "loaded" || diffState.status === "refreshing"
+      ? diffState.truncationWarning !== null
+      : false);
+
   // Keep ref in sync so callbacks can access current filtered list without dependency
   filteredHunksRef.current = filteredHunks;
 
@@ -1745,6 +1758,7 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
                       onComposingChange={handleHunkComposingChange}
                       diffBase={filters.diffBase}
                       includeUncommitted={filters.includeUncommitted}
+                      preferCollapsed={preferCollapsedHunks}
                       reviewActions={reviewActions}
                     />
                   );

--- a/tests/e2e/scenarios/perf.reviewChatOpen.spec.ts
+++ b/tests/e2e/scenarios/perf.reviewChatOpen.spec.ts
@@ -1,0 +1,117 @@
+import { type Page } from "@playwright/test";
+import { electronTest as test, electronExpect as expect } from "../electronTest";
+import {
+  REVIEW_SORT_ORDER_KEY,
+  RIGHT_SIDEBAR_COLLAPSED_KEY,
+  RIGHT_SIDEBAR_TAB_KEY,
+} from "../../../src/common/constants/storage";
+import { STORAGE_KEYS } from "../../../src/constants/workspaceDefaults";
+import { seedWorkspaceHistoryProfile } from "../utils/historyFixture";
+import {
+  readReactProfileSnapshot,
+  resetReactProfileSamples,
+  withChromeProfiles,
+  writePerfArtifacts,
+} from "../utils/perfProfile";
+import { disableReviewTutorial, seedLargeReviewDiff } from "../utils/reviewPerfFixture";
+
+const shouldRunPerfScenarios = process.env.MUX_E2E_RUN_PERF === "1";
+const REVIEW_CHANGED_LINES_PER_FILE = 50;
+const MIN_REVIEW_FILE_COUNT = 1_000;
+const MIN_REVIEW_CHANGED_LINES = 50_000;
+
+async function primeReviewSidebarForWorkspace(page: Page, workspaceId: string): Promise<void> {
+  const reviewDiffBaseKey = STORAGE_KEYS.reviewDiffBase(workspaceId);
+
+  await page.evaluate(
+    ({ collapsedKey, diffBaseKey, sidebarTabKey, sortOrderKey }) => {
+      // The cold-open scenario should mount the Review tab next to the transcript immediately.
+      window.localStorage.setItem(sidebarTabKey, JSON.stringify("review"));
+      window.localStorage.setItem(collapsedKey, JSON.stringify(false));
+      window.localStorage.setItem(diffBaseKey, JSON.stringify("HEAD"));
+      window.localStorage.setItem("review-show-read", JSON.stringify(true));
+      window.localStorage.setItem(sortOrderKey, JSON.stringify("file-order"));
+    },
+    {
+      collapsedKey: RIGHT_SIDEBAR_COLLAPSED_KEY,
+      diffBaseKey: reviewDiffBaseKey,
+      sidebarTabKey: RIGHT_SIDEBAR_TAB_KEY,
+      sortOrderKey: REVIEW_SORT_ORDER_KEY,
+    }
+  );
+}
+
+async function waitForChatAndReviewReady(page: Page): Promise<void> {
+  await expect(page.getByTestId("message-window")).toHaveAttribute("data-loaded", "true", {
+    timeout: 30_000,
+  });
+
+  const reviewPanel = page.getByTestId("review-panel");
+  await expect(reviewPanel).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("review-file-tree")).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator("[data-hunk-id]").first()).toBeVisible({ timeout: 30_000 });
+}
+
+test.skip(
+  ({ browserName }) => browserName !== "chromium",
+  "Electron scenario runs on chromium only"
+);
+
+test.describe("chat open with review sidebar performance profiling", () => {
+  test.skip(!shouldRunPerfScenarios, "Set MUX_E2E_RUN_PERF=1 to run perf profiling scenarios");
+
+  test("perf: open large chat with a huge review already selected", async ({
+    page,
+    ui,
+    workspace,
+  }, testInfo) => {
+    await disableReviewTutorial(page);
+
+    const historySummary = await seedWorkspaceHistoryProfile({
+      demoProject: workspace.demoProject,
+      profile: "large",
+    });
+    const diffSummary = seedLargeReviewDiff(workspace.demoProject.workspacePath, {
+      changedLinesPerFile: REVIEW_CHANGED_LINES_PER_FILE,
+    });
+
+    expect(diffSummary.fileCount).toBeGreaterThanOrEqual(MIN_REVIEW_FILE_COUNT);
+    expect(diffSummary.addedLines).toBeGreaterThanOrEqual(MIN_REVIEW_CHANGED_LINES);
+    expect(diffSummary.deletedLines).toBeGreaterThanOrEqual(MIN_REVIEW_CHANGED_LINES);
+
+    await primeReviewSidebarForWorkspace(page, workspace.demoProject.workspaceId);
+    await resetReactProfileSamples(page);
+
+    const runLabel = `chat-open-review-${diffSummary.fileCount}-files-${diffSummary.addedLines}-added-lines`;
+    const chromeProfile = await withChromeProfiles(page, { label: runLabel }, async () => {
+      await ui.projects.openFirstWorkspace();
+      await waitForChatAndReviewReady(page);
+    });
+
+    const reactProfileSnapshot = await readReactProfileSnapshot(page);
+    if (!reactProfileSnapshot) {
+      throw new Error("React profile snapshot was not captured");
+    }
+
+    const artifactDirectory = await writePerfArtifacts({
+      testInfo,
+      runLabel,
+      chromeProfile,
+      reactProfile: reactProfileSnapshot,
+      historyProfile: {
+        kind: "chat-open-with-review-sidebar",
+        history: historySummary,
+        review: diffSummary,
+      },
+    });
+
+    expect(chromeProfile.wallTimeMs).toBeLessThan(8_000);
+    expect(chromeProfile.cpuProfile).not.toBeNull();
+    expect(reactProfileSnapshot.enabled).toBe(true);
+
+    testInfo.annotations.push({
+      type: "perf-artifact",
+      description: artifactDirectory,
+    });
+  });
+});

--- a/tests/e2e/scenarios/perf.reviewOpen.spec.ts
+++ b/tests/e2e/scenarios/perf.reviewOpen.spec.ts
@@ -1,6 +1,6 @@
 import { type Page } from "@playwright/test";
 import { electronTest as test, electronExpect as expect } from "../electronTest";
-import { REVIEW_SORT_ORDER_KEY, TUTORIAL_STATE_KEY } from "../../../src/common/constants/storage";
+import { REVIEW_SORT_ORDER_KEY } from "../../../src/common/constants/storage";
 import { STORAGE_KEYS } from "../../../src/constants/workspaceDefaults";
 import {
   readReactProfileSnapshot,
@@ -8,31 +8,9 @@ import {
   withChromeProfiles,
   writePerfArtifacts,
 } from "../utils/perfProfile";
-import { seedLargeReviewDiff } from "../utils/reviewPerfFixture";
+import { disableReviewTutorial, seedLargeReviewDiff } from "../utils/reviewPerfFixture";
 
 const shouldRunPerfScenarios = process.env.MUX_E2E_RUN_PERF === "1";
-
-async function disableReviewTutorial(page: Page): Promise<void> {
-  await page.evaluate((tutorialStateKey) => {
-    const raw = window.localStorage.getItem(tutorialStateKey);
-    const parsed = raw
-      ? (JSON.parse(raw) as { disabled?: boolean; completed?: Record<string, boolean> })
-      : null;
-    window.localStorage.setItem(
-      tutorialStateKey,
-      JSON.stringify({
-        disabled: parsed?.disabled ?? false,
-        completed: {
-          ...(parsed?.completed ?? {}),
-          review: true,
-        },
-      })
-    );
-  }, TUTORIAL_STATE_KEY);
-
-  await page.reload();
-  await page.waitForLoadState("domcontentloaded");
-}
 
 async function waitForRegularReviewReady(page: Page, hunkCount: number): Promise<void> {
   const reviewPanel = page.getByTestId("review-panel");

--- a/tests/e2e/utils/reviewPerfFixture.ts
+++ b/tests/e2e/utils/reviewPerfFixture.ts
@@ -1,6 +1,8 @@
 import fs from "fs";
 import path from "path";
 import { spawnSync } from "child_process";
+import { type Page } from "@playwright/test";
+import { TUTORIAL_STATE_KEY } from "../../../src/common/constants/storage";
 
 export const LARGE_CHANGE_ROOT = "src/review/perf-large-change";
 const LARGE_CHANGE_GROUP_COUNT = 20;
@@ -16,6 +18,11 @@ export interface LargeReviewDiffSummary {
   hunkCount: number;
   addedLines: number;
   deletedLines: number;
+  changedLinesPerFile: number;
+}
+
+interface LargeReviewDiffOptions {
+  changedLinesPerFile?: number;
 }
 
 function runGitCommand(cwd: string, args: string[]): string {
@@ -30,22 +37,57 @@ function runGitCommand(cwd: string, args: string[]): string {
   );
 }
 
-function buildLargeReviewFixtureSource(fileIndex: number, variant: "base" | "modified"): string {
+function buildLargeReviewFixtureSource(
+  fileIndex: number,
+  variant: "base" | "modified",
+  changedLinesPerFile: number
+): string {
   const fileId = String(fileIndex + 1).padStart(3, "0");
   const status = variant === "base" ? "pending" : "ready";
+  const normalizedChangedLines = Math.max(1, Math.trunc(changedLinesPerFile));
+  const probeLines = Array.from({ length: normalizedChangedLines }, (_, lineIndex) => {
+    const lineId = String(lineIndex + 1).padStart(3, "0");
+    return `  probeLine${lineId}: "${status}-${fileId}-${lineId}",`;
+  });
 
   return [
     `export const reviewProbe${fileId} = {`,
     `  id: ${fileIndex + 1},`,
-    `  status: "${status}",`,
     `  checksum: ${5_000 + fileIndex},`,
     `  summary: "Perf review probe ${fileId}",`,
+    ...probeLines,
     "};",
     "",
   ].join("\n");
 }
 
-export function seedLargeReviewDiff(workspacePath: string): LargeReviewDiffSummary {
+export async function disableReviewTutorial(page: Page): Promise<void> {
+  await page.evaluate((tutorialStateKey) => {
+    const raw = window.localStorage.getItem(tutorialStateKey);
+    const parsed = raw
+      ? (JSON.parse(raw) as { disabled?: boolean; completed?: Record<string, boolean> })
+      : null;
+    window.localStorage.setItem(
+      tutorialStateKey,
+      JSON.stringify({
+        disabled: parsed?.disabled ?? false,
+        completed: {
+          ...(parsed?.completed ?? {}),
+          review: true,
+        },
+      })
+    );
+  }, TUTORIAL_STATE_KEY);
+
+  await page.reload();
+  await page.waitForLoadState("domcontentloaded");
+}
+
+export function seedLargeReviewDiff(
+  workspacePath: string,
+  options: LargeReviewDiffOptions = {}
+): LargeReviewDiffSummary {
+  const changedLinesPerFile = Math.max(1, Math.trunc(options.changedLinesPerFile ?? 1));
   const filePaths: string[] = [];
   let fileIndex = 0;
 
@@ -66,7 +108,11 @@ export function seedLargeReviewDiff(workspacePath: string): LargeReviewDiffSumma
         ].join("/");
         const filePath = path.join(workspacePath, ...relativePath.split("/"));
         fs.mkdirSync(path.dirname(filePath), { recursive: true });
-        fs.writeFileSync(filePath, buildLargeReviewFixtureSource(fileIndex, "base"), "utf-8");
+        fs.writeFileSync(
+          filePath,
+          buildLargeReviewFixtureSource(fileIndex, "base", changedLinesPerFile),
+          "utf-8"
+        );
         filePaths.push(relativePath);
         fileIndex += 1;
       }
@@ -84,19 +130,25 @@ export function seedLargeReviewDiff(workspacePath: string): LargeReviewDiffSumma
 
   for (const [index, relativePath] of filePaths.entries()) {
     const filePath = path.join(workspacePath, ...relativePath.split("/"));
-    fs.writeFileSync(filePath, buildLargeReviewFixtureSource(index, "modified"), "utf-8");
+    fs.writeFileSync(
+      filePath,
+      buildLargeReviewFixtureSource(index, "modified", changedLinesPerFile),
+      "utf-8"
+    );
   }
 
-  const diffOutput = runGitCommand(workspacePath, ["diff", "HEAD"]);
-  const hunkCount = (diffOutput.match(/^@@/gm) ?? []).length;
-  if (hunkCount !== filePaths.length) {
-    throw new Error(`Expected ${filePaths.length} hunks in seeded diff, received ${hunkCount}`);
-  }
-
+  const hunkCount = filePaths.length;
   let addedLines = 0;
   let deletedLines = 0;
   const numstatOutput = runGitCommand(workspacePath, ["diff", "HEAD", "--numstat"]).trim();
-  for (const line of numstatOutput.split("\n").filter(Boolean)) {
+  const numstatLines = numstatOutput.split("\n").filter(Boolean);
+  if (numstatLines.length !== filePaths.length) {
+    throw new Error(
+      `Expected ${filePaths.length} changed files in seeded diff, received ${numstatLines.length}`
+    );
+  }
+
+  for (const line of numstatLines) {
     const [addedText = "0", deletedText = "0"] = line.split("\t");
     addedLines += Number.parseInt(addedText, 10) || 0;
     deletedLines += Number.parseInt(deletedText, 10) || 0;
@@ -110,5 +162,6 @@ export function seedLargeReviewDiff(workspacePath: string): LargeReviewDiffSumma
     hunkCount,
     addedLines,
     deletedLines,
+    changedLinesPerFile,
   };
 }


### PR DESCRIPTION
## Summary

Adds a cold-open perf scenario for a large chat transcript with Review already selected, scaling the review fixture to 1,000 changed files and 50k added / 50k deleted lines. The Review panel now defaults huge review renders to collapsed hunks, expanding only the selected hunk unless the user has manually chosen an expansion state, so opening a transcript no longer mounts every diff line at once.

## Background

Opening a workspace with a large transcript and a large Review tab was dominated by Review diff DOM/layout work. A baseline run of the new scenario took 13,894ms and produced ~375,800 DOM nodes with 6.68s spent in layout.

## Implementation

- Extended `seedLargeReviewDiff()` so perf scenarios can request many changed lines per file without materializing a giant `git diff` in the fixture process.
- Added `perf.reviewChatOpen.spec.ts`, which opens a large transcript with Review preselected and asserts a 1,000-file / 50k+ LoC review fixture stays under the perf threshold.
- Added large-review collapse heuristics based on parsed hunk count, diff output size, and truncation. Huge reviews keep the selected hunk open and preserve manual user expand/collapse choices.

## Validation

- `make build`
- `MUX_E2E_RUN_PERF=1 MUX_E2E_ENABLE_REACT_PROFILE=1 MUX_E2E_LOAD_DIST=1 MUX_E2E_SKIP_BUILD=1 bun x playwright test tests/e2e/scenarios/perf.reviewChatOpen.spec.ts --project=electron --reporter=line`
  - Final: 1,450ms wall time, ~13,195 DOM nodes, 0.113s layout, 0.828s script.
  - Baseline before the fix: 13,894ms wall time, ~375,800 DOM nodes, 6.68s layout, 4.12s script.
- `make static-check`

## Risks

Large reviews now initially show a collapsed overview instead of expanding every hunk. The selected hunk still auto-expands, and any manual expand/collapse state remains authoritative.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$43.96`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=43.96 -->
