### PR TITLE
🤖 fix: stabilize chat input auto-resize height

### DIFF
--- a/src/browser/hooks/useAutoResizeTextarea.test.tsx
+++ b/src/browser/hooks/useAutoResizeTextarea.test.tsx
@@ -8,6 +8,7 @@ function createFakeTextarea(initialScrollHeight: number): {
   ref: RefObject<HTMLTextAreaElement>;
   assignments: string[];
   setScrollHeight: (value: number) => void;
+  setInlineHeight: (value: string) => void;
 } {
   let height = "";
   let scrollHeight = initialScrollHeight;
@@ -34,6 +35,9 @@ function createFakeTextarea(initialScrollHeight: number): {
     assignments,
     setScrollHeight: (value) => {
       scrollHeight = value;
+    },
+    setInlineHeight: (value) => {
+      height = value;
     },
   };
 }
@@ -88,6 +92,33 @@ describe("useAutoResizeTextarea", () => {
     rerender({ value: "line one" });
 
     expect(textarea.assignments).toEqual(["auto", "40px"]);
+  });
+
+  it("restores the capped height when a deletion keeps the same measured height", () => {
+    const textarea = createFakeTextarea(800);
+    const { rerender } = renderHook(({ value }) => useAutoResizeTextarea(textarea.ref, value, 50), {
+      initialProps: { value: "line one\nline two\nline three" },
+    });
+    expect(textarea.assignments).toEqual(["auto", "500px"]);
+    textarea.assignments.length = 0;
+
+    rerender({ value: "line one\nline two" });
+
+    expect(textarea.assignments).toEqual(["auto", "500px"]);
+  });
+
+  it("repairs the inline height after another caller clears it", () => {
+    const textarea = createFakeTextarea(800);
+    const { rerender } = renderHook(({ value }) => useAutoResizeTextarea(textarea.ref, value, 50), {
+      initialProps: { value: "line one\nline two" },
+    });
+    expect(textarea.assignments).toEqual(["auto", "500px"]);
+    textarea.assignments.length = 0;
+
+    textarea.setInlineHeight("");
+    rerender({ value: "line one\nline two!" });
+
+    expect(textarea.assignments).toEqual(["500px"]);
   });
 
   it("shrinks when a longer replacement does not preserve the previous text", () => {

--- a/src/browser/hooks/useAutoResizeTextarea.ts
+++ b/src/browser/hooks/useAutoResizeTextarea.ts
@@ -69,7 +69,14 @@ export function useAutoResizeTextarea(
       nextHeight = Math.min(el.scrollHeight, max);
     }
 
-    if (appliedHeightRef.current !== nextHeight) {
+    // The cached height can match even after this effect temporarily set `auto`, or
+    // after callers cleared the inline style. Verify the DOM still has the px height
+    // before skipping the write; otherwise large drafts collapse to the CSS min-height.
+    const currentInlineHeight = Number.parseFloat(el.style.height);
+    const inlineHeightMatches =
+      Number.isFinite(currentInlineHeight) && Math.abs(currentInlineHeight - nextHeight) < 0.5;
+
+    if (appliedHeightRef.current !== nextHeight || !inlineHeightMatches) {
       el.style.height = `${nextHeight}px`;
       appliedHeightRef.current = nextHeight;
     }


### PR DESCRIPTION
Summary
- Fixes the workspace chat input collapsing to a tiny height while editing large drafts by making the auto-resize hook verify the DOM inline height before it skips a resize write.

Background
- The recent typing-performance optimization cached the last applied textarea height. On shrink-capable updates, the hook can temporarily set the textarea height to `auto`; if the measured height matches the cache, the old guard skipped restoring the pixel height. Large inputs then fell back to the CSS minimum until another resize path repaired them.

Implementation
- Keep the no-op fast path for normal insertions, but also compare the actual inline height against the desired pixel height before skipping the write.
- Added regression coverage for capped large-text deletion and callers clearing the inline height outside the hook.

Validation
- `bun test src/browser/hooks/useAutoResizeTextarea.test.tsx`
- `make static-check`

Risks
- Low. The change is scoped to the textarea resize hook and preserves the existing optimization when the DOM already has the expected inline height.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `1787684{MUX_COSTS_USD:-n/a}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=n/a -->
