### PR TITLE
🤖 fix: handle zero-budget goals and live cost previews

### DIFF
--- a/src/browser/features/RightSidebar/GoalTab.tsx
+++ b/src/browser/features/RightSidebar/GoalTab.tsx
@@ -92,7 +92,7 @@ export function GoalTab(props: GoalTabProps) {
       if (editingField === "budget") {
         const budgetCents = parseBudgetInput(submittedValue);
         if (budgetCents === undefined) {
-          setError("Enter a budget like $5, 500c, or leave blank for no budget.");
+          setError("Enter a budget like $5 or 500c. Use 0 or blank for no budget.");
           return;
         }
         await props.onUpdateBudget?.(budgetCents);
@@ -330,7 +330,7 @@ export function GoalTab(props: GoalTabProps) {
           />
           <p className="text-muted mt-1 text-xs">
             {editingField === "budget"
-              ? "Use $5, 500c, or blank for no budget."
+              ? "Use $5, 500c, 0, or blank for no budget."
               : "Use a positive whole number, or blank for no cap."}
           </p>
           <div className="mt-2 flex gap-2">

--- a/src/browser/features/RightSidebar/RightSidebar.tsx
+++ b/src/browser/features/RightSidebar/RightSidebar.tsx
@@ -19,6 +19,7 @@ import { useProvidersConfig } from "@/browser/hooks/useProvidersConfig";
 import { useAPI } from "@/browser/contexts/API";
 import { useSendMessageOptions } from "@/browser/hooks/useSendMessageOptions";
 import {
+  hasGoalBudgetLimit,
   modelHasPricingData,
   UNPRICED_CURRENT_MODEL_GOAL_MESSAGE,
 } from "@/common/utils/goals/budgetPricing";
@@ -687,7 +688,10 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
   };
 
   const handleGoalUpdateBudget = async (budgetCents: number | null) => {
-    if (budgetCents != null && !modelHasPricingData(sendMessageOptions.model, providersConfig)) {
+    if (
+      hasGoalBudgetLimit(budgetCents) &&
+      !modelHasPricingData(sendMessageOptions.model, providersConfig)
+    ) {
       throw new Error(UNPRICED_CURRENT_MODEL_GOAL_MESSAGE);
     }
     await setGoalWithSingleConflictRetry({ budgetCents });

--- a/src/browser/features/Settings/Sections/GoalsSection.tsx
+++ b/src/browser/features/Settings/Sections/GoalsSection.tsx
@@ -89,7 +89,7 @@ export function GoalsSection() {
             <label htmlFor="goal-default-budget" className="min-w-0 flex-1">
               <div className="text-foreground text-sm font-medium">Default goal budget</div>
               <div className="text-muted mt-0.5 text-xs">
-                Applied to new goals when no budget flag is provided.
+                Applied to new goals when no budget flag is provided. Use $0.00 for no dollar limit.
               </div>
             </label>
             <div className="flex items-center gap-1">

--- a/src/browser/utils/chatCommands.test.ts
+++ b/src/browser/utils/chatCommands.test.ts
@@ -755,6 +755,35 @@ describe("processSlashCommand - goal budgets", () => {
     });
   });
 
+  test("passes zero-dollar budget updates through on unpriced current model", async () => {
+    enableGoalsExperiment();
+    const currentGoal = {
+      goalId: "11111111-1111-4111-8111-111111111111",
+      objective: "existing objective",
+    };
+    const setGoal = mock().mockResolvedValueOnce({
+      success: true,
+      data: { ...currentGoal, budgetCents: null },
+    });
+    const context = createGoalCommandContext({
+      config: { getConfig: mock(() => Promise.resolve({})) },
+      workspace: {
+        getGoal: mock(() => Promise.resolve({ goal: currentGoal })),
+        setGoal,
+        clearGoal: mock(),
+      },
+    } as unknown as SlashCommandContext["api"]);
+    context.sendMessageOptions.model = "custom-provider:no-price-model";
+
+    await processSlashCommand({ type: "goal-budget", budgetCents: 0 }, context);
+
+    expect(setGoal).toHaveBeenCalledWith({
+      workspaceId: "goal-ws",
+      budgetCents: 0,
+      expectedGoalId: currentGoal.goalId,
+    });
+  });
+
   test("refuses budgeted goals on an unpriced current model", async () => {
     enableGoalsExperiment();
     const setGoal = mock();

--- a/src/browser/utils/chatCommands.ts
+++ b/src/browser/utils/chatCommands.ts
@@ -39,6 +39,7 @@ import type { ParsedCommand } from "@/browser/utils/slashCommands/types";
 import { type GoalDefaults } from "@/constants/goals";
 import {
   hasBudgetedResumableGoal,
+  hasGoalBudgetLimit,
   modelHasPricingData,
   UNPRICED_CURRENT_MODEL_GOAL_MESSAGE,
   UNPRICED_TARGET_MODEL_GOAL_MESSAGE,
@@ -824,7 +825,7 @@ async function handleGoalCommand(
     }
 
     if (parsed.type === "goal-budget") {
-      if (parsed.budgetCents != null && !(await currentModelHasPricingData(context))) {
+      if (hasGoalBudgetLimit(parsed.budgetCents) && !(await currentModelHasPricingData(context))) {
         showUnpricedModelGoalToast(setToast);
         return { clearInput: false, toastShown: true };
       }
@@ -844,7 +845,10 @@ async function handleGoalCommand(
 
     const goalDefaults = await getGoalDefaults(context);
     const goalSetIntent = resolveSlashGoalSetIntent(parsed, goalDefaults);
-    if (goalSetIntent.budgetCents != null && !(await currentModelHasPricingData(context))) {
+    if (
+      hasGoalBudgetLimit(goalSetIntent.budgetCents) &&
+      !(await currentModelHasPricingData(context))
+    ) {
       showUnpricedModelGoalToast(setToast);
       return { clearInput: false, toastShown: true };
     }

--- a/src/browser/utils/commands/sources.test.ts
+++ b/src/browser/utils/commands/sources.test.ts
@@ -519,6 +519,34 @@ test("goal set objective prompt treats blank budget as explicit no-budget", asyn
   });
 });
 
+test("goal set objective prompt allows zero budget on unpriced model", async () => {
+  const setGoal = mock(() => Promise.resolve({ success: true, data: makeGoalRecord("active") }));
+  const actions = getVisibleGoalActions({
+    api: {
+      config: { getConfig: mock(() => Promise.resolve({})) },
+      providers: { getConfig: mock(() => Promise.resolve({})) },
+      workspace: { getGoal: mock(() => Promise.resolve({ goal: null })), setGoal },
+    } as unknown as APIClient,
+    selectedWorkspaceState: {
+      ...makeWorkspaceState(null),
+      currentModel: "custom:unpriced-model",
+    },
+  });
+
+  const setObjectiveAction = actions.find((action) => action.id === "goal:set-objective");
+  await setObjectiveAction!.prompt!.onSubmit({
+    objective: "Track without dollar limit",
+    budget: "0",
+  });
+
+  expect(setGoal).toHaveBeenCalledWith(
+    expect.objectContaining({
+      objective: "Track without dollar limit",
+      budgetCents: null,
+    })
+  );
+});
+
 test("goal set objective prompt submits objective and parsed budget", async () => {
   const getGoal = mock(() => Promise.resolve({ goal: null }));
   const setGoal = mock(() => Promise.resolve({ success: true, data: makeGoalRecord("active") }));

--- a/src/browser/utils/commands/sources.ts
+++ b/src/browser/utils/commands/sources.ts
@@ -49,6 +49,7 @@ import { parseGoalBudgetCents } from "@/browser/utils/slashCommands/registry";
 import { setGoalWithConflictRetry } from "@/browser/utils/goals/setGoalWithConflictRetry";
 import { loadGoalDefaults, resolveGoalSetIntent } from "@/browser/utils/goals/resolveGoalSetIntent";
 import {
+  hasGoalBudgetLimit,
   modelHasPricingData,
   UNPRICED_CURRENT_MODEL_GOAL_MESSAGE,
 } from "@/common/utils/goals/budgetPricing";
@@ -301,7 +302,7 @@ function canSetBudgetedGoalWithCurrentPaletteModel(
   budgetCents: number | null,
   providersConfig: unknown
 ): boolean {
-  if (budgetCents == null) {
+  if (!hasGoalBudgetLimit(budgetCents)) {
     return true;
   }
   const selectedModel =

--- a/src/browser/utils/goals/resolveGoalSetIntent.test.ts
+++ b/src/browser/utils/goals/resolveGoalSetIntent.test.ts
@@ -15,6 +15,11 @@ describe("resolveGoalSetIntent", () => {
     expect(intent.budgetCents).toBe(200);
   });
 
+  test("treats explicit zero budget as no budget", () => {
+    const intent = resolveGoalSetIntent({ objective: "ship", budgetCents: 0 }, baseDefaults);
+    expect(intent.budgetCents).toBeNull();
+  });
+
   test("preserves explicit null budget (user-cleared)", () => {
     const intent = resolveGoalSetIntent({ objective: "ship", budgetCents: null }, baseDefaults);
     expect(intent.budgetCents).toBeNull();
@@ -34,6 +39,14 @@ describe("resolveGoalSetIntent", () => {
       { ...baseDefaults, alwaysRequireExplicitBudget: true }
     );
     expect(intent.budgetCents).toBe(1500);
+  });
+
+  test("treats a zero default budget as no budget", () => {
+    const intent = resolveGoalSetIntent(
+      { objective: "ship" },
+      { ...baseDefaults, defaultBudgetCents: 0, alwaysRequireExplicitBudget: true }
+    );
+    expect(intent.budgetCents).toBeNull();
   });
 
   test("turnCap falls back to defaultTurnCap when omitted", () => {

--- a/src/browser/utils/goals/resolveGoalSetIntent.ts
+++ b/src/browser/utils/goals/resolveGoalSetIntent.ts
@@ -1,3 +1,4 @@
+import { normalizeGoalBudgetCents } from "@/common/utils/goals/budgetPricing";
 import type { APIClient } from "@/browser/contexts/API";
 import { DEFAULT_GOAL_DEFAULTS, normalizeGoalDefaults, type GoalDefaults } from "@/constants/goals";
 
@@ -7,8 +8,8 @@ import { DEFAULT_GOAL_DEFAULTS, normalizeGoalDefaults, type GoalDefaults } from 
  *
  * - `budgetCents` is a discriminated tri-state:
  *   - `undefined` → "user did not specify; apply default"
- *   - `null` → "user explicitly cleared the budget"
- *   - `number` → explicit cents value
+ *   - `null` or `0` → "no budget" (explicit clear)
+ *   - positive `number` → explicit cents value
  */
 export interface GoalSetIntentInput {
   objective: string;
@@ -29,7 +30,7 @@ export interface GoalSetIntent {
  *   - If the caller omitted `budgetCents`:
  *     - `alwaysRequireExplicitBudget` → fall back to `defaultBudgetCents`.
  *     - Otherwise → `null` (no budget).
- *   - `null` is preserved (explicit "no budget" clear).
+ *   - `null` and `0` both become no budget (explicit "no budget" clear).
  *   - If the caller omitted `turnCap`, fall back to `defaultTurnCap`.
  *
  * Coder-agents-review P3 DEREM-27: the slash command path (`/goal`) used to
@@ -44,9 +45,9 @@ export function resolveGoalSetIntent(
 ): GoalSetIntent {
   let budgetCents: number | null;
   if (input.budgetCents !== undefined) {
-    budgetCents = input.budgetCents;
+    budgetCents = normalizeGoalBudgetCents(input.budgetCents);
   } else if (defaults.alwaysRequireExplicitBudget) {
-    budgetCents = defaults.defaultBudgetCents;
+    budgetCents = normalizeGoalBudgetCents(defaults.defaultBudgetCents);
   } else {
     budgetCents = null;
   }

--- a/src/common/utils/goals/budgetParser.test.ts
+++ b/src/common/utils/goals/budgetParser.test.ts
@@ -29,6 +29,13 @@ describe("parseGoalBudgetInputCents", () => {
     expect(parseGoalBudgetInputCents("100C")).toBe(100);
   });
 
+  test("parses zero dollar inputs", () => {
+    expect(parseGoalBudgetInputCents("0")).toBe(0);
+    expect(parseGoalBudgetInputCents("$0")).toBe(0);
+    expect(parseGoalBudgetInputCents("$0.00")).toBe(0);
+    expect(parseGoalBudgetInputCents("0c")).toBe(0);
+  });
+
   test("returns undefined for invalid input", () => {
     expect(parseGoalBudgetInputCents("abc")).toBeUndefined();
     expect(parseGoalBudgetInputCents("$")).toBeUndefined();

--- a/src/common/utils/goals/budgetPricing.test.ts
+++ b/src/common/utils/goals/budgetPricing.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { formatGoalCents, hasBudgetedResumableGoal, modelHasPricingData } from "./budgetPricing";
+import {
+  formatGoalCents,
+  hasBudgetedResumableGoal,
+  hasGoalBudgetLimit,
+  modelHasPricingData,
+  normalizeGoalBudgetCents,
+} from "./budgetPricing";
 
 describe("formatGoalCents", () => {
   test("formats integer cents as a dollar-prefixed two-decimal string", () => {
@@ -31,6 +37,18 @@ describe("modelHasPricingData", () => {
   });
 });
 
+describe("goal budget limit helpers", () => {
+  test("treat zero cents as no dollar budget limit", () => {
+    expect(hasGoalBudgetLimit(0)).toBe(false);
+    expect(normalizeGoalBudgetCents(0)).toBeNull();
+  });
+
+  test("preserve positive budget limits", () => {
+    expect(hasGoalBudgetLimit(1)).toBe(true);
+    expect(normalizeGoalBudgetCents(1)).toBe(1);
+  });
+});
+
 describe("hasBudgetedResumableGoal", () => {
   // Regression: the active-only check let the user pause a budgeted goal,
   // switch to an unpriced model, and resume — the next stream then records
@@ -43,6 +61,12 @@ describe("hasBudgetedResumableGoal", () => {
 
   test("returns false for completed budgeted goals (terminal)", () => {
     expect(hasBudgetedResumableGoal({ status: "complete", budgetCents: 100 })).toBe(false);
+  });
+
+  test("returns false for zero-dollar budgets", () => {
+    expect(hasBudgetedResumableGoal({ status: "active", budgetCents: 0 })).toBe(false);
+    expect(hasBudgetedResumableGoal({ status: "paused", budgetCents: 0 })).toBe(false);
+    expect(hasBudgetedResumableGoal({ status: "budget_limited", budgetCents: 0 })).toBe(false);
   });
 
   test("returns false for any goal without a budget", () => {

--- a/src/common/utils/goals/budgetPricing.ts
+++ b/src/common/utils/goals/budgetPricing.ts
@@ -11,15 +11,33 @@ export function formatGoalCents(cents: number): string {
 
 type GoalBudgetState = Pick<GoalRecordV1 | GoalSnapshot, "status" | "budgetCents">;
 
+/** True when the budget imposes a positive dollar limit; zero cents means no budget. */
+export function hasGoalBudgetLimit(budgetCents: number | null | undefined): boolean {
+  if (budgetCents == null) {
+    return false;
+  }
+  assert(
+    Number.isInteger(budgetCents) && budgetCents >= 0,
+    `goal budget limit requires non-negative integer cents, got ${budgetCents}`
+  );
+  return budgetCents > 0;
+}
+
+/** Collapse zero-cent and nullish budgets to null (no dollar limit). */
+export function normalizeGoalBudgetCents(budgetCents: number | null | undefined): number | null {
+  return budgetCents != null && hasGoalBudgetLimit(budgetCents) ? budgetCents : null;
+}
+
 /**
  * Returns true for any goal whose budget will be debited again if the user
  * continues working — i.e. `active`, `paused`, or `budget_limited` (the
- * non-terminal states with a numeric `budgetCents`). Used to gate model
+ * non-terminal states with a positive `budgetCents`). Used to gate model
  * switches: an unpriced model on such a goal silently records 0 cost on the
- * next stream, breaking budget enforcement after resume.
+ * next stream, breaking budget enforcement after resume. A zero-dollar budget
+ * is treated as "no budget" so users can disable dollar limits from settings.
  */
 export function hasBudgetedResumableGoal(goal: GoalBudgetState | null | undefined): boolean {
-  if (goal?.budgetCents == null) {
+  if (!goal || !hasGoalBudgetLimit(goal.budgetCents)) {
     return false;
   }
   return goal.status === "active" || goal.status === "paused" || goal.status === "budget_limited";

--- a/src/node/services/agentSession.goalAutoPause.test.ts
+++ b/src/node/services/agentSession.goalAutoPause.test.ts
@@ -13,6 +13,7 @@ import { Ok } from "@/common/types/result";
 import type { SendMessageOptions } from "@/common/orpc/types";
 import type { GoalRecordV1, GoalStatus } from "@/common/types/goal";
 import { GOAL_CONTINUATION_IDLE_CONSUMER_NAME } from "@/constants/goals";
+import { waitForCondition } from "./testDispatchHelpers";
 import { IdleDispatcher } from "./idleDispatcher";
 
 const PROJECT_PATH = "/tmp/mux-agent-session-goal-test-project";
@@ -22,6 +23,8 @@ interface SessionHarness {
   historyService: HistoryService;
   session: AgentSession;
   goalService: WorkspaceGoalService;
+  extensionMetadata: ExtensionMetadataService;
+  aiService: AIService & EventEmitter;
   analytics: { recordGoalLifecycleEvent: ReturnType<typeof mock> };
   cleanup: () => Promise<void>;
 }
@@ -38,7 +41,7 @@ async function setGoalOk(
   return result.data;
 }
 
-function createAiService(workspaceId: string): AIService {
+function createAiService(workspaceId: string): AIService & EventEmitter {
   const aiEmitter = new EventEmitter();
   return Object.assign(aiEmitter, {
     isStreaming: mock((_workspaceId: string) => false),
@@ -58,7 +61,7 @@ function createAiService(workspaceId: string): AIService {
       )
     ),
     replayStream: mock((_workspaceId: string) => Promise.resolve()),
-  }) as unknown as AIService;
+  }) as unknown as AIService & EventEmitter;
 }
 
 async function createSessionHarness(workspaceId: string): Promise<SessionHarness> {
@@ -89,17 +92,18 @@ async function createSessionHarness(workspaceId: string): Promise<SessionHarness
     setMessageQueued: mock((_workspaceId: string, _queued: boolean) => undefined),
   } as unknown as BackgroundProcessManager;
 
+  const aiService = createAiService(workspaceId);
   const session = new AgentSession({
     workspaceId,
     config,
     historyService,
-    aiService: createAiService(workspaceId),
+    aiService,
     initStateManager,
     backgroundProcessManager,
     workspaceGoalService: goalService,
   });
 
-  return { historyService, session, goalService, analytics, cleanup };
+  return { historyService, session, goalService, extensionMetadata, aiService, analytics, cleanup };
 }
 
 describe("AgentSession goal safety hooks", () => {
@@ -140,12 +144,21 @@ describe("AgentSession goal safety hooks", () => {
       const workspaceId = `manual-leaves-${status.replace("_", "-")}`;
       const { session, goalService, cleanup } = await createSessionHarness(workspaceId);
       cleanups.push(cleanup);
-      await setGoalOk(goalService, {
+      const seeded = await setGoalOk(goalService, {
         workspaceId,
         objective: `Goal already ${status}`,
         status,
+        ...(status === "budget_limited" ? { budgetCents: 100 } : {}),
         ...(status === "complete" ? { completionSummary: "Finished already." } : {}),
       });
+      if (status === "budget_limited") {
+        await goalService.recordStreamAccounting({
+          workspaceId,
+          costUsd: 1,
+          streamStartedAtMs: seeded.createdAtMs + 1,
+          streamOriginKind: "goal_continuation",
+        });
+      }
 
       const result = await session.sendMessage("Manual follow-up", SEND_OPTIONS);
 
@@ -216,6 +229,57 @@ describe("AgentSession goal safety hooks", () => {
     expect(await goalService.getGoal(workspaceId)).toMatchObject({
       status: "active",
       requireUserAcknowledgmentSinceMs: 66_000,
+    });
+    session.dispose();
+  });
+
+  test("stream errors restore durable goal snapshot after live cost preview", async () => {
+    const workspaceId = "stream-error-restores-goal-preview";
+    const { session, goalService, extensionMetadata, aiService, cleanup } =
+      await createSessionHarness(workspaceId);
+    cleanups.push(cleanup);
+    goalService.registerGoalContinuationConsumer(new IdleDispatcher(), {
+      isGoalExperimentEnabled: () => true,
+      hasActiveDescendantTasks: () => false,
+      getRuntimeState: () => ({ isRuntimeCompatible: true }),
+      executeGoalContinuation: () => Promise.resolve(true),
+    });
+    const created = await setGoalOk(goalService, {
+      workspaceId,
+      objective: "Restore preview on error",
+      budgetCents: 1_000,
+    });
+    await goalService.previewStreamAccounting({
+      workspaceId,
+      costUsd: 1.25,
+      streamStartedAtMs: created.createdAtMs + 1,
+    });
+    expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({
+      goal: { costCents: 125 },
+    });
+
+    aiService.streamMessage = mock(() => {
+      aiService.emit("error", {
+        workspaceId,
+        messageId: "assistant-stream-error",
+        error: "boom",
+        errorType: "unknown",
+      });
+      return Promise.resolve(Ok(undefined));
+    }) as unknown as AIService["streamMessage"];
+    const eventTypes: string[] = [];
+    session.onChatEvent((event) => {
+      eventTypes.push(event.message.type);
+    });
+
+    await session.sendMessage("Synthetic continuation", SEND_OPTIONS, {
+      synthetic: true,
+      goalContinuation: true,
+    });
+    await waitForCondition(() => eventTypes.includes("stream-error"), { timeoutMs: 1_000 });
+
+    expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({
+      goal: { costCents: 0, budgetCents: 1_000 },
     });
     session.dispose();
   });

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -91,6 +91,7 @@ import {
   type StreamLifecycleSnapshot,
 } from "@/common/types/stream";
 import type { GoalStreamOriginKind, WorkspaceGoalService } from "./workspaceGoalService";
+import { resolveModelForMetadata } from "@/common/utils/providers/modelEntries";
 import { getTotalCost } from "@/common/utils/tokens/usageAggregator";
 import { CompactionHandler } from "./compactionHandler";
 import { RetryManager, type RetryFailureError, type RetryStatusEvent } from "./retryManager";
@@ -4093,6 +4094,53 @@ export class AgentSession {
     return true;
   }
 
+  private async previewGoalAccountingFromUsage(input: {
+    model: string;
+    usage: LanguageModelV2Usage | undefined;
+    providerMetadata?: Record<string, unknown>;
+    metadataModel?: string;
+    isCompaction?: boolean;
+  }): Promise<void> {
+    if (this.workspaceGoalService?.isExperimentEnabled() !== true) {
+      return;
+    }
+    const displayUsage = createDisplayUsage(
+      input.usage,
+      input.model,
+      input.providerMetadata,
+      input.metadataModel
+    );
+    const costUsd = getTotalCost(displayUsage) ?? 0;
+    try {
+      await this.workspaceGoalService.previewStreamAccounting({
+        workspaceId: this.workspaceId,
+        costUsd,
+        isCompaction: input.isCompaction === true,
+        streamStartedAtMs: this.activeStreamStartedAtMs ?? null,
+      });
+    } catch (error) {
+      log.warn("Failed to preview goal stream accounting", {
+        workspaceId: this.workspaceId,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+
+  private async restoreGoalAccountingSnapshot(): Promise<void> {
+    if (this.workspaceGoalService?.isExperimentEnabled() !== true) {
+      return;
+    }
+
+    try {
+      await this.workspaceGoalService.getGoal(this.workspaceId);
+    } catch (error) {
+      log.warn("Failed to restore goal accounting snapshot", {
+        workspaceId: this.workspaceId,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+
   private async recordGoalAccountingFromUsage(input: {
     model: string;
     usage: StreamEndEvent["metadata"]["usage"];
@@ -4185,6 +4233,7 @@ export class AgentSession {
     const streamErrorMessage = createStreamErrorMessage(data);
     this.setTerminalStreamLifecycle("failed");
     this.terminalStreamError = streamErrorMessage;
+    await this.restoreGoalAccountingSnapshot();
     this.activeCompactionRequest = undefined;
     this.resetActiveStreamState();
 
@@ -4290,6 +4339,17 @@ export class AgentSession {
         usage: payload.usage,
         providerMetadata: payload.providerMetadata,
         live: true,
+      });
+
+      await this.previewGoalAccountingFromUsage({
+        model: modelForUsage,
+        usage: payload.cumulativeUsage ?? payload.usage,
+        providerMetadata: payload.cumulativeProviderMetadata ?? payload.providerMetadata,
+        metadataModel: resolveModelForMetadata(
+          modelForUsage,
+          this.activeStreamContext?.providersConfig ?? null
+        ),
+        isCompaction: this.activeCompactionRequest !== undefined,
       });
 
       // Never recurse compaction while we're already running a compaction request.

--- a/src/node/services/workspaceGoalService.test.ts
+++ b/src/node/services/workspaceGoalService.test.ts
@@ -128,39 +128,41 @@ describe("WorkspaceGoalService", () => {
     );
   });
 
-  test("rejects zero-budget goals when kickoff model has no pricing", async () => {
+  test("treats zero-budget goals as unbudgeted even when kickoff model has no pricing", async () => {
     const dispatcher = new IdleDispatcher();
     service.registerGoalContinuationConsumer(dispatcher, {
       ...continuationBridge(),
       getKickoffSendOptions: () => ({ model: "custom:unpriced-model", agentId: "exec" }),
     });
 
-    const result = await service.setGoal({
+    const created = await setGoalOk(service, {
       workspaceId,
-      objective: "Do not spend unpriced",
+      objective: "Do not enforce a dollar budget",
       budgetCents: 0,
     });
 
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error).toMatchObject({ type: "invalid_transition" });
-    }
-    expect(await service.getGoal(workspaceId)).toBeNull();
+    await drainPendingDispatches();
+
+    expect(created).toMatchObject({ status: "active", budgetCents: null });
+    expect(await service.getGoal(workspaceId)).toMatchObject({
+      status: "active",
+      budgetCents: null,
+    });
   });
 
-  test("creates zero-budget goals as budget_limited without arming kickoff continuation", async () => {
+  test("creates zero-budget goals as active goals without arming a budget wrap-up", async () => {
     const dispatcher = new IdleDispatcher();
     const execute = mock(() => Promise.resolve(true));
     service.registerGoalContinuationConsumer(dispatcher, continuationBridge(execute));
 
     const created = await setGoalOk(service, {
       workspaceId,
-      objective: "Do not spend",
+      objective: "Track without a dollar limit",
       budgetCents: 0,
     });
     await drainPendingDispatches();
 
-    expect(created).toMatchObject({ status: "budget_limited", budgetCents: 0 });
+    expect(created).toMatchObject({ status: "active", budgetCents: null });
     expect(execute).not.toHaveBeenCalled();
   });
 
@@ -682,6 +684,48 @@ describe("WorkspaceGoalService", () => {
     expect(await restartedService.getGoal(workspaceId)).toMatchObject({
       status: "budget_limited",
       budgetLimitInjectedForGoalId: created.goalId,
+    });
+  });
+
+  test("getGoal normalizes legacy zero-budget goals on read", async () => {
+    const legacy = await setGoalOk(service, {
+      workspaceId,
+      objective: "Legacy read normalization",
+      budgetCents: 100,
+    });
+    await fs.writeFile(
+      path.join(config.getSessionDir(workspaceId), "goal.json"),
+      JSON.stringify({ ...legacy, status: "budget_limited", budgetCents: 0 })
+    );
+
+    expect(await service.getGoal(workspaceId)).toMatchObject({
+      status: "active",
+      budgetCents: null,
+    });
+  });
+
+  test("recoverPendingDispatchAfterRestart migrates legacy zero-budget limited goals", async () => {
+    const legacy = await setGoalOk(service, {
+      workspaceId,
+      objective: "Legacy zero budget",
+      budgetCents: 100,
+    });
+    await fs.writeFile(
+      path.join(config.getSessionDir(workspaceId), "goal.json"),
+      JSON.stringify({ ...legacy, status: "budget_limited", budgetCents: 0 })
+    );
+    const restartedService = new WorkspaceGoalService(
+      config,
+      historyService,
+      extensionMetadata,
+      analytics
+    );
+
+    await restartedService.recoverPendingDispatchAfterRestart(workspaceId);
+
+    expect(await restartedService.getGoal(workspaceId)).toMatchObject({
+      status: "active",
+      budgetCents: null,
     });
   });
 
@@ -1709,6 +1753,114 @@ describe("WorkspaceGoalService", () => {
 
     expect(updated).toBeNull();
     expect(await service.getGoal(workspaceId)).toMatchObject({ costCents: 0, turnsUsed: 0 });
+  });
+
+  test("previews live stream cost without double-counting final accounting", async () => {
+    const created = await setGoalOk(service, {
+      workspaceId,
+      objective: "Preview live cost",
+      budgetCents: 1_000,
+    });
+
+    const firstPreview = await service.previewStreamAccounting({
+      workspaceId,
+      costUsd: 0.5,
+      streamStartedAtMs: created.createdAtMs + 1,
+    });
+    const secondPreview = await service.previewStreamAccounting({
+      workspaceId,
+      costUsd: 1.25,
+      streamStartedAtMs: created.createdAtMs + 1,
+    });
+
+    expect(firstPreview).toMatchObject({ costCents: 50, budgetCents: 1_000 });
+    expect(secondPreview).toMatchObject({ costCents: 125, budgetCents: 1_000 });
+    expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({
+      goal: { costCents: 125, budgetCents: 1_000 },
+    });
+    expect(await service.getGoal(workspaceId)).toMatchObject({ costCents: 0, budgetCents: 1_000 });
+
+    const editedDuringStream = await setGoalOk(service, { workspaceId, budgetCents: 2_000 });
+    const previewAfterEdit = await service.previewStreamAccounting({
+      workspaceId,
+      costUsd: 1.5,
+      streamStartedAtMs: created.createdAtMs + 1,
+    });
+    expect(editedDuringStream).toMatchObject({ budgetCents: 2_000 });
+    expect(previewAfterEdit).toMatchObject({ costCents: 150, budgetCents: 2_000 });
+
+    const final = await service.recordStreamAccounting({
+      workspaceId,
+      costUsd: 1.25,
+      streamStartedAtMs: created.createdAtMs + 1,
+      streamOriginKind: "goal_continuation",
+    });
+
+    expect(final).toMatchObject({ costCents: 125, turnsUsed: 1, status: "active" });
+
+    const previewAfterFinal = await service.previewStreamAccounting({
+      workspaceId,
+      costUsd: 1.25,
+      streamStartedAtMs: created.createdAtMs + 1,
+    });
+    expect(previewAfterFinal).toBeNull();
+    expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({
+      goal: { costCents: 125, budgetCents: 2_000 },
+    });
+  });
+
+  test("previewStreamAccounting skips paused goals, compactions, and stale streams", async () => {
+    const created = await setGoalOk(service, {
+      workspaceId,
+      objective: "Preview guard coverage",
+      budgetCents: 1_000,
+    });
+
+    expect(
+      await service.previewStreamAccounting({
+        workspaceId,
+        costUsd: 5,
+        isCompaction: true,
+        streamStartedAtMs: created.createdAtMs + 1,
+      })
+    ).toBeNull();
+    expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({
+      goal: { costCents: 0 },
+    });
+
+    expect(
+      await service.previewStreamAccounting({
+        workspaceId,
+        costUsd: 5,
+        streamStartedAtMs: created.createdAtMs - 1,
+      })
+    ).toBeNull();
+
+    await setGoalOk(service, { workspaceId, status: "paused" });
+    expect(
+      await service.previewStreamAccounting({
+        workspaceId,
+        costUsd: 5,
+        streamStartedAtMs: created.createdAtMs + 1,
+      })
+    ).toMatchObject({ costCents: 0, status: "paused" });
+  });
+
+  test("does not budget-limit zero-dollar goals after paid streams", async () => {
+    await setGoalOk(service, {
+      workspaceId,
+      objective: "Track paid work without a dollar limit",
+      budgetCents: 0,
+    });
+
+    const updated = await service.recordStreamAccounting({
+      workspaceId,
+      costUsd: 1.24,
+      streamOriginKind: "goal_continuation",
+    });
+
+    expect(updated).toMatchObject({ costCents: 124, turnsUsed: 1, status: "active" });
+    expect(updated?.budgetCents).toBeNull();
   });
 
   test("flips active goals to budget-limited when stream cost reaches the budget", async () => {

--- a/src/node/services/workspaceGoalService.ts
+++ b/src/node/services/workspaceGoalService.ts
@@ -14,7 +14,9 @@ import type { ProvidersConfigMap, SendMessageOptions } from "@/common/orpc/types
 import { isWorkspaceArchived } from "@/common/utils/archive";
 import {
   hasBudgetedResumableGoal,
+  hasGoalBudgetLimit,
   modelHasPricingData,
+  normalizeGoalBudgetCents,
   UNPRICED_TARGET_MODEL_GOAL_MESSAGE,
 } from "@/common/utils/goals/budgetPricing";
 import type { SendMessageError } from "@/common/types/errors";
@@ -160,6 +162,7 @@ interface GoalStreamStamp {
 
 interface StreamAccountingInput {
   workspaceId: string;
+  /** Total cost attributable to this stream from start (cumulative for previews, final for records). */
   costUsd?: number | null;
   isCompaction?: boolean;
   streamStartedAtMs?: number | null;
@@ -291,6 +294,7 @@ export class WorkspaceGoalService {
   private pendingContinuationCandidates = new Map<string, PendingGoalContinuationCandidate>();
   private continuationReRequestTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private lastUserStopAtMsByWorkspace = new Map<string, number>();
+  private recordedStreamStartedAtMsByWorkspace = new Map<string, number>();
   private lastGoalStreamStamps = new Map<string, GoalStreamStamp>();
   private nextGoalStreamStampSequence = 1;
   private goalContinuationBridge: GoalContinuationRuntimeBridge | null = null;
@@ -331,7 +335,7 @@ export class WorkspaceGoalService {
       goalId: crypto.randomUUID(),
       objective: input.objective,
       status,
-      budgetCents: input.budgetCents,
+      budgetCents: normalizeGoalBudgetCents(input.budgetCents),
       turnCap: input.turnCap,
       costCents: 0,
       costMicroCents: 0,
@@ -838,8 +842,10 @@ export class WorkspaceGoalService {
         await this.writeGoal(workspaceId, next);
         await this.pushSnapshot(workspaceId, next);
         this.emitBudgetLimited(next, current.status);
+        return next;
       }
-      return next;
+      await this.pushSnapshot(workspaceId, current);
+      return current;
     });
   }
 
@@ -998,7 +1004,9 @@ export class WorkspaceGoalService {
     const next: GoalRecordV1 = GoalRecordV1Schema.parse({
       ...goal,
       ...(input.status != null ? { status: input.status } : {}),
-      ...(Object.hasOwn(input, "budgetCents") ? { budgetCents: input.budgetCents ?? null } : {}),
+      ...(Object.hasOwn(input, "budgetCents")
+        ? { budgetCents: normalizeGoalBudgetCents(input.budgetCents) }
+        : {}),
       ...(Object.hasOwn(input, "turnCap") ? { turnCap: input.turnCap ?? null } : {}),
       ...(Object.hasOwn(input, "requireUserAcknowledgmentSinceMs")
         ? { requireUserAcknowledgmentSinceMs: input.requireUserAcknowledgmentSinceMs ?? null }
@@ -1010,11 +1018,12 @@ export class WorkspaceGoalService {
   }
 
   private hasReachedBudgetLimit(goal: GoalRecordV1): boolean {
-    if (goal.budgetCents == null) {
+    const { budgetCents } = goal;
+    if (budgetCents == null || !hasGoalBudgetLimit(budgetCents)) {
       return false;
     }
     const costMicroCents = goal.costMicroCents ?? goal.costCents * MICRO_CENTS_PER_CENT;
-    return costMicroCents >= goal.budgetCents * MICRO_CENTS_PER_CENT;
+    return costMicroCents >= budgetCents * MICRO_CENTS_PER_CENT;
   }
 
   private hasReachedTurnLimit(goal: GoalRecordV1): boolean {
@@ -1025,24 +1034,45 @@ export class WorkspaceGoalService {
     return this.hasReachedBudgetLimit(goal) || this.hasReachedTurnLimit(goal);
   }
 
+  private applyCostAccounting(
+    goal: GoalRecordV1,
+    costMicroCentsThisStream: number
+  ): Pick<GoalRecordV1, "costCents" | "costMicroCents"> {
+    const costMicroCents =
+      (goal.costMicroCents ?? goal.costCents * MICRO_CENTS_PER_CENT) + costMicroCentsThisStream;
+    return {
+      costCents: Math.round(costMicroCents / MICRO_CENTS_PER_CENT),
+      costMicroCents,
+    };
+  }
+
   private applyBudgetDrivenStatus(
     next: GoalRecordV1,
     options?: { originKind?: GoalStreamOriginKind }
   ): GoalRecordV1 {
-    const reachedLimit = this.hasReachedAnyLimit(next);
-    const shouldLimitActiveGoal = next.status === "active" && reachedLimit;
-    const shouldRearmBudgetLimitedGoal = next.status === "budget_limited" && !reachedLimit;
+    const normalizedBudgetCents = normalizeGoalBudgetCents(next.budgetCents);
+    const normalized =
+      normalizedBudgetCents === next.budgetCents
+        ? next
+        : GoalRecordV1Schema.parse({
+            ...next,
+            budgetCents: normalizedBudgetCents,
+            updatedAtMs: Date.now(),
+          });
+    const reachedLimit = this.hasReachedAnyLimit(normalized);
+    const shouldLimitActiveGoal = normalized.status === "active" && reachedLimit;
+    const shouldRearmBudgetLimitedGoal = normalized.status === "budget_limited" && !reachedLimit;
     if (!shouldLimitActiveGoal && !shouldRearmBudgetLimitedGoal) {
-      return next;
+      return normalized;
     }
 
     return GoalRecordV1Schema.parse({
-      ...next,
+      ...normalized,
       status: shouldLimitActiveGoal ? "budget_limited" : "active",
       // Raising/removing limits re-arms the one-shot budget wrap-up.
       budgetLimitInjectedForGoalId: shouldRearmBudgetLimitedGoal
         ? null
-        : next.budgetLimitInjectedForGoalId,
+        : normalized.budgetLimitInjectedForGoalId,
       // Persist the origin kind on the active→budget_limited transition so
       // `recoverPendingDispatchAfterRestart` can decide whether to arm a
       // wrap-up after restart (Coder-agents-review P3 DEREM-54). When
@@ -1051,7 +1081,7 @@ export class WorkspaceGoalService {
         ? (options?.originKind ?? null)
         : shouldRearmBudgetLimitedGoal
           ? null
-          : next.budgetLimitOriginKind,
+          : normalized.budgetLimitOriginKind,
       updatedAtMs: Date.now(),
     });
   }
@@ -1160,11 +1190,7 @@ export class WorkspaceGoalService {
   }
 
   async getGoal(workspaceId: string): Promise<GoalRecordV1 | null> {
-    return this.fileLocks.withLock(workspaceId, async () => {
-      const goal = await this.readGoalFile(workspaceId);
-      await this.pushSnapshot(workspaceId, goal);
-      return goal;
-    });
+    return this.normalizeGoalLimits(workspaceId);
   }
 
   /**
@@ -1544,7 +1570,7 @@ export class WorkspaceGoalService {
       workspaceId.trim().length > 0,
       "recoverPendingDispatchAfterRestart requires workspaceId"
     );
-    const goal = await this.getGoal(workspaceId);
+    const goal = await this.normalizeGoalLimits(workspaceId);
     if (!goal) {
       return;
     }
@@ -1694,6 +1720,47 @@ export class WorkspaceGoalService {
     return stamp;
   }
 
+  /**
+   * Push a live cost preview to the activity snapshot without persisting to
+   * goal.json. The cost is the cumulative current-stream cost on top of the
+   * durable base; `recordStreamAccounting` performs final accounting at stream end.
+   */
+  async previewStreamAccounting(input: StreamAccountingInput): Promise<GoalSnapshot | null> {
+    assert(input.workspaceId.trim().length > 0, "previewStreamAccounting requires workspaceId");
+    if (input.isCompaction === true) {
+      return null;
+    }
+
+    const costMicroCentsThisStream = costUsdToMicroCents(input.costUsd);
+    return this.fileLocks.withLock(input.workspaceId, async () => {
+      const current = await this.readGoalFile(input.workspaceId);
+      if (!current) {
+        return null;
+      }
+
+      if (input.streamStartedAtMs != null && current.createdAtMs > input.streamStartedAtMs) {
+        return null;
+      }
+      if (
+        input.streamStartedAtMs != null &&
+        this.recordedStreamStartedAtMsByWorkspace.get(input.workspaceId) === input.streamStartedAtMs
+      ) {
+        return null;
+      }
+
+      if (current.status === "paused" || current.status === "complete") {
+        return toGoalSnapshot(current);
+      }
+
+      const preview = GoalRecordV1Schema.parse({
+        ...current,
+        ...this.applyCostAccounting(current, costMicroCentsThisStream),
+        updatedAtMs: Date.now(),
+      });
+      return this.pushSnapshot(input.workspaceId, preview);
+    });
+  }
+
   async recordStreamAccounting(input: StreamAccountingInput): Promise<GoalRecordV1 | null> {
     assert(input.workspaceId.trim().length > 0, "recordStreamAccounting requires workspaceId");
     const originKind = input.streamOriginKind ?? (input.isCompaction === true ? "other" : "user");
@@ -1703,7 +1770,7 @@ export class WorkspaceGoalService {
       return null;
     }
 
-    const costMicroCentsDelta = costUsdToMicroCents(input.costUsd);
+    const costMicroCentsThisStream = costUsdToMicroCents(input.costUsd);
     return this.fileLocks.withLock(input.workspaceId, async () => {
       const current = await this.readGoalFile(input.workspaceId);
       if (!current) {
@@ -1728,16 +1795,16 @@ export class WorkspaceGoalService {
       // reaches here while still active must not consume a turn against the cap
       // (Coder-agents-review P3 DEREM-24).
       const turnsDelta = originKind === "user" ? 0 : 1;
-      const accumulatedMicroCents =
-        (current.costMicroCents ?? current.costCents * MICRO_CENTS_PER_CENT) + costMicroCentsDelta;
       const accounted = GoalRecordV1Schema.parse({
         ...current,
-        costCents: Math.round(accumulatedMicroCents / MICRO_CENTS_PER_CENT),
-        costMicroCents: accumulatedMicroCents,
+        ...this.applyCostAccounting(current, costMicroCentsThisStream),
         turnsUsed: current.turnsUsed + turnsDelta,
         updatedAtMs: Date.now(),
       });
       const next = this.applyBudgetDrivenStatus(accounted, { originKind });
+      if (input.streamStartedAtMs != null) {
+        this.recordedStreamStartedAtMsByWorkspace.set(input.workspaceId, input.streamStartedAtMs);
+      }
       await this.writeGoal(input.workspaceId, next);
       await this.pushSnapshot(input.workspaceId, next);
       this.recordLastGoalStream(input.workspaceId, originKind, next.goalId);
@@ -1783,13 +1850,9 @@ export class WorkspaceGoalService {
         return skippedChildAttribution(current);
       }
 
-      const accumulatedMicroCents =
-        (current.costMicroCents ?? current.costCents * MICRO_CENTS_PER_CENT) +
-        input.childCostCents * MICRO_CENTS_PER_CENT;
       const accounted = GoalRecordV1Schema.parse({
         ...current,
-        costCents: Math.round(accumulatedMicroCents / MICRO_CENTS_PER_CENT),
-        costMicroCents: accumulatedMicroCents,
+        ...this.applyCostAccounting(current, input.childCostCents * MICRO_CENTS_PER_CENT),
         turnsUsed: current.turnsUsed + 1,
         attributedChildren: [...current.attributedChildren, input.childWorkspaceId],
         updatedAtMs: Date.now(),
@@ -1828,6 +1891,7 @@ export class WorkspaceGoalService {
       const current = await this.readGoalFile(workspaceId);
       this.pendingGoalMutations.delete(workspaceId);
       this.pendingContinuationCandidates.delete(workspaceId);
+      this.recordedStreamStartedAtMsByWorkspace.delete(workspaceId);
       this.lastGoalStreamStamps.delete(workspaceId);
       const timer = this.continuationReRequestTimers.get(workspaceId);
       if (timer != null) {


### PR DESCRIPTION
## Summary

Fixes goal budget handling so a $0 budget disables dollar limits instead of immediately exhausting the goal, and updates goal cost display to preview live stream cost while final accounting remains durable and single-counted.

## Background

A default or explicit goal budget of $0 was treated as an already-exhausted budget. Goal cost also only updated at stream end, leaving the Goal tab and workspace pill stale during multi-step turns.

## Implementation

- Normalize zero-cent goal budgets to no dollar limit across goal creation/defaults and budgeted-model gates.
- Add a live goal accounting preview from cumulative usage deltas that updates activity snapshots without writing final goal accounting.
- Preserve final stream-end accounting as the source of truth to avoid double-counting.

## Validation

- `make static-check`
- `bun test src/common/utils/goals/budgetPricing.test.ts src/browser/utils/goals/resolveGoalSetIntent.test.ts src/node/services/workspaceGoalService.test.ts src/browser/utils/chatCommands.test.ts src/browser/utils/commands/sources.test.ts src/browser/features/RightSidebar/GoalTab.test.tsx src/browser/features/Settings/Sections/GoalsSection.test.tsx`
- `make typecheck`
- `make lint`

## Risks

Low-to-medium: goal accounting touches stream lifecycle and workspace activity snapshots. The live preview path avoids durable writes and final accounting remains unchanged except for zero-budget normalization.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `high` • Cost: `$44.07`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=high costs=44.07 -->
