### PR TITLE
🤖 fix: show finalized completed goal accounting

### DIFF
--- a/src/browser/features/Tools/CompleteGoalToolCall.test.ts
+++ b/src/browser/features/Tools/CompleteGoalToolCall.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import type { GoalRecordV1, GoalSnapshot } from "@/common/types/goal";
+import { getCompleteGoalDisplayGoal } from "./CompleteGoalToolCall";
+
+const goalId = "00000000-0000-4000-8000-000000000001";
+
+function resultGoal(overrides: Partial<GoalRecordV1> = {}): GoalRecordV1 {
+  return {
+    version: 1,
+    goalId,
+    objective: "Ship goal accounting UI",
+    status: "complete",
+    budgetCents: 100_000,
+    turnCap: 3,
+    costCents: 0,
+    costMicroCents: 0,
+    turnsUsed: 0,
+    attributedChildren: [],
+    budgetLimitInjectedForGoalId: null,
+    budgetLimitOriginKind: null,
+    requireUserAcknowledgmentSinceMs: null,
+    lastContinuationFiredAtMs: null,
+    completionSummary: "Done.",
+    createdAtMs: 1_000,
+    updatedAtMs: 2_000,
+    ...overrides,
+  };
+}
+
+function liveGoal(overrides: Partial<GoalSnapshot> = {}): GoalSnapshot {
+  return {
+    goalId,
+    objective: "Ship goal accounting UI",
+    status: "complete",
+    budgetCents: 100_000,
+    costCents: 4_040,
+    turnsUsed: 1,
+    turnCap: 3,
+    completionSummary: "Done with final accounting.",
+    startedAtMs: 1_000,
+    ...overrides,
+  };
+}
+
+describe("getCompleteGoalDisplayGoal", () => {
+  test("uses same-goal live accounting over stale complete_goal result accounting", () => {
+    const displayGoal = getCompleteGoalDisplayGoal(resultGoal(), liveGoal());
+
+    expect(displayGoal).toMatchObject({
+      goalId,
+      costCents: 4_040,
+      turnsUsed: 1,
+      completionSummary: "Done with final accounting.",
+    });
+  });
+
+  test("keeps retained same-goal live accounting after the current goal is cleared", () => {
+    const displayGoal = getCompleteGoalDisplayGoal(resultGoal(), null, liveGoal());
+
+    expect(displayGoal).toMatchObject({
+      goalId,
+      costCents: 4_040,
+      turnsUsed: 1,
+      completionSummary: "Done with final accounting.",
+    });
+  });
+
+  test("keeps the tool result when the live sidebar snapshot is for another goal", () => {
+    const displayGoal = getCompleteGoalDisplayGoal(
+      resultGoal({ costCents: 0, turnsUsed: 0 }),
+      liveGoal({
+        goalId: "00000000-0000-4000-8000-000000000002",
+        costCents: 4_040,
+        turnsUsed: 1,
+      })
+    );
+
+    expect(displayGoal).toMatchObject({
+      goalId,
+      costCents: 0,
+      turnsUsed: 0,
+      completionSummary: "Done.",
+    });
+  });
+});

--- a/src/browser/features/Tools/CompleteGoalToolCall.tsx
+++ b/src/browser/features/Tools/CompleteGoalToolCall.tsx
@@ -23,21 +23,103 @@ import {
   goalStatusLabel,
 } from "./Goal/goalToolUtils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/browser/components/Tooltip/Tooltip";
+import { useOptionalWorkspaceSidebarState } from "@/browser/stores/WorkspaceStore";
+import type { GoalRecordV1, GoalSnapshot, GoalStatus } from "@/common/types/goal";
 
 interface CompleteGoalToolCallProps {
   args: { summary: string };
   result?: unknown;
   status?: ToolStatus;
+  workspaceId?: string;
+}
+
+interface CompleteGoalDisplayGoal {
+  goalId: string;
+  status: GoalStatus;
+  objective: string;
+  budgetCents: number | null;
+  costCents: number;
+  turnsUsed: number;
+  turnCap: number | null;
+  completionSummary?: string;
+  startedAtMs: number;
+}
+
+export function getCompleteGoalDisplayGoal(
+  resultGoal: GoalRecordV1 | null,
+  liveGoal: GoalSnapshot | null | undefined,
+  retainedLiveGoal: GoalSnapshot | null | undefined = null
+): CompleteGoalDisplayGoal | null {
+  if (resultGoal == null) {
+    return null;
+  }
+
+  const freshestLiveGoal =
+    liveGoal?.goalId === resultGoal.goalId
+      ? liveGoal
+      : retainedLiveGoal?.goalId === resultGoal.goalId
+        ? retainedLiveGoal
+        : null;
+
+  if (freshestLiveGoal) {
+    return {
+      goalId: freshestLiveGoal.goalId,
+      status: freshestLiveGoal.status,
+      objective: freshestLiveGoal.objective,
+      budgetCents: freshestLiveGoal.budgetCents,
+      costCents: freshestLiveGoal.costCents,
+      turnsUsed: freshestLiveGoal.turnsUsed,
+      turnCap: freshestLiveGoal.turnCap,
+      ...(freshestLiveGoal.completionSummary != null
+        ? { completionSummary: freshestLiveGoal.completionSummary }
+        : resultGoal.completionSummary != null
+          ? { completionSummary: resultGoal.completionSummary }
+          : {}),
+      startedAtMs: freshestLiveGoal.startedAtMs,
+    };
+  }
+
+  return {
+    goalId: resultGoal.goalId,
+    status: resultGoal.status,
+    objective: resultGoal.objective,
+    budgetCents: resultGoal.budgetCents,
+    costCents: resultGoal.costCents,
+    turnsUsed: resultGoal.turnsUsed,
+    turnCap: resultGoal.turnCap,
+    ...(resultGoal.completionSummary != null
+      ? { completionSummary: resultGoal.completionSummary }
+      : {}),
+    startedAtMs: resultGoal.createdAtMs,
+  };
 }
 
 export const CompleteGoalToolCall: React.FC<CompleteGoalToolCallProps> = ({
   args,
   result,
   status = "pending",
+  workspaceId,
 }) => {
   const { expanded, toggleExpanded } = useToolExpansion();
+  const sidebarState = useOptionalWorkspaceSidebarState(workspaceId);
   const errorResult = isToolErrorResult(result) ? result : null;
-  const goal = extractGoalFromResult(result);
+  const resultGoal = extractGoalFromResult(result);
+  const retainedLiveGoalRef = React.useRef<GoalSnapshot | null>(null);
+  if (resultGoal && sidebarState?.goal?.goalId === resultGoal.goalId) {
+    // Preserve the finalized same-goal accounting even if the user clears the
+    // completed goal or starts a new one while this transcript card remains
+    // mounted. Otherwise the card would regress to the stale pre-accounting
+    // tool result.
+    retainedLiveGoalRef.current = sidebarState.goal;
+  }
+  // `complete_goal` returns before the completing stream's final accounting is
+  // known. Prefer the same-goal live snapshot when available so the transcript
+  // card matches the finalized Goal sidebar cost/turn totals.
+  const goal = getCompleteGoalDisplayGoal(
+    resultGoal,
+    sidebarState?.goal,
+    retainedLiveGoalRef.current
+  );
   const summary = (goal?.completionSummary ?? args.summary).trim();
   const succeeded = status === "completed" && !errorResult;
   const iconClassName = succeeded
@@ -104,7 +186,7 @@ export const CompleteGoalToolCall: React.FC<CompleteGoalToolCallProps> = ({
                 <GoalToolStat
                   label="Elapsed"
                   value={
-                    <span className="counter-nums">{formatGoalElapsed(goal.createdAtMs)}</span>
+                    <span className="counter-nums">{formatGoalElapsed(goal.startedAtMs)}</span>
                   }
                 />
               </dl>


### PR DESCRIPTION
## Summary

Fix the completed goal tool call card so it displays finalized goal accounting from the live workspace goal snapshot when it matches the completed goal. This makes the transcript card agree with the Goal sidebar after the completing stream's cost and turn accounting lands.

## Background

`complete_goal` returns before final stream accounting is recorded. The completed tool card rendered that stale result snapshot, so it could show `$0.00 / budget` and `0 turns` while the sidebar correctly showed the finalized cost and turn count.

## Implementation

- Added a small display-goal merge helper for `CompleteGoalToolCall`.
- When the live sidebar goal has the same `goalId` as the tool result, the card uses live `costCents`, `turnsUsed`, limits, status, objective, and start time.
- If the live goal is absent or belongs to a different goal, the card falls back to the immutable tool result so historical transcript rendering remains safe.
- Added regression tests for same-goal live accounting and different-goal fallback behavior.

## Validation

- `bun test src/browser/features/Tools/CompleteGoalToolCall.test.ts`
- `make typecheck`
- `make fmt-check`
- `make lint`
- `make static-check`
- Installed `agent-browser` and dogfooded the Storybook goal tool card:
  - captured collapsed and expanded screenshots
  - recorded `/tmp/mux-goal-dogfood/complete-goal-ui.webm`
  - verified expanded text includes `COST` and `$0.47 / $1.00`

## Risks

Low. The live snapshot is only trusted when `goalId` matches the completed tool result; otherwise existing result-based rendering is preserved.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `high` • Cost: `$19.50`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=high costs=19.50 -->
