### PR TITLE
🤖 fix: gate imagegen skill behind experiment

### DIFF
--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -63,7 +63,11 @@ import {
 import {
   discoverAgentSkills,
   discoverAgentSkillsDiagnostics,
+  filterUnavailableImagegenSkills,
+  IMAGEGEN_SKILL_DISABLED_MESSAGE,
+  isBuiltInImagegenSkillPackage,
   readAgentSkill,
+  type ResolvedAgentSkill,
 } from "@/node/services/agentSkills/agentSkillsService";
 import {
   discoverAgentDefinitions,
@@ -148,6 +152,23 @@ async function resolveAgentDiscoveryContext(
     { projectPath: input.projectPath! }
   );
   return { runtime, discoveryPath: input.projectPath! };
+}
+
+function isImageGenerationToolExperimentEnabled(context: ORPCContext): boolean {
+  return context.experimentsService.isExperimentEnabled(EXPERIMENT_IDS.IMAGE_GENERATION_TOOL);
+}
+
+function assertImagegenSkillAvailable(
+  context: ORPCContext,
+  resolvedSkill: ResolvedAgentSkill
+): void {
+  if (!isBuiltInImagegenSkillPackage(resolvedSkill.package)) {
+    return;
+  }
+
+  if (!isImageGenerationToolExperimentEnabled(context)) {
+    throw new Error(IMAGEGEN_SKILL_DISABLED_MESSAGE);
+  }
 }
 
 function isTrustedProjectPath(context: ORPCContext, projectPath?: string | null): boolean {
@@ -1505,7 +1526,11 @@ export const router = (authToken?: string) => {
             await context.aiService.waitForInit(input.workspaceId);
           }
           const { runtime, discoveryPath } = await resolveAgentDiscoveryContext(context, input);
-          return discoverAgentSkills(runtime, discoveryPath);
+          const skills = await discoverAgentSkills(runtime, discoveryPath);
+          return filterUnavailableImagegenSkills(
+            skills,
+            isImageGenerationToolExperimentEnabled(context)
+          );
         }),
       listDiagnostics: t
         .input(schemas.agentSkills.listDiagnostics.input)
@@ -1516,7 +1541,14 @@ export const router = (authToken?: string) => {
             await context.aiService.waitForInit(input.workspaceId);
           }
           const { runtime, discoveryPath } = await resolveAgentDiscoveryContext(context, input);
-          return discoverAgentSkillsDiagnostics(runtime, discoveryPath);
+          const diagnostics = await discoverAgentSkillsDiagnostics(runtime, discoveryPath);
+          return {
+            ...diagnostics,
+            skills: filterUnavailableImagegenSkills(
+              diagnostics.skills,
+              isImageGenerationToolExperimentEnabled(context)
+            ),
+          };
         }),
       get: t
         .input(schemas.agentSkills.get.input)
@@ -1528,6 +1560,7 @@ export const router = (authToken?: string) => {
           }
           const { runtime, discoveryPath } = await resolveAgentDiscoveryContext(context, input);
           const result = await readAgentSkill(runtime, discoveryPath, input.skillName);
+          assertImagegenSkillAvailable(context, result);
           return result.package;
         }),
     },

--- a/src/node/services/agentSession.agentSkillSnapshot.test.ts
+++ b/src/node/services/agentSession.agentSkillSnapshot.test.ts
@@ -214,6 +214,25 @@ describe("AgentSession.sendMessage (agent skill snapshots)", () => {
     expect(userText).toBe("do X");
   });
 
+  it("skips built-in imagegen snapshots when image generation is disabled", async () => {
+    const { workspacePath } = await createTestWorkspaceWithSkills({ skills: [] });
+    const { session, appendToHistory, messages } = await createSessionHarness({ workspacePath });
+
+    const result = await session.sendMessage("retry image generation", {
+      model: "anthropic:claude-3-5-sonnet-latest",
+      agentId: "exec",
+      experiments: { imageGenerationTool: false },
+      muxMetadata: {
+        agentSkillRefs: [{ skillName: "imagegen", scope: "built-in", source: "inline" }],
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(appendToHistory.mock.calls).toHaveLength(1);
+    expect(messages[0]?.metadata?.agentSkillSnapshot).toBeUndefined();
+    expect(getMessageText(messages[0])).toBe("retry image generation");
+  });
+
   it("honors disableWorkspaceAgents when resolving skill snapshots", async () => {
     const workspaceId = "ws-test";
 

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -13,6 +13,7 @@ import type { InitStateManager } from "@/node/services/initStateManager";
 import type { FrontendWorkspaceMetadata, WorkspaceMetadata } from "@/common/types/workspace";
 import type { RuntimeConfig } from "@/common/types/runtime";
 import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
+import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { DEFAULT_MODEL } from "@/common/constants/knownModels";
 import { computePriorHistoryFingerprint } from "@/common/orpc/onChatCursorFingerprint";
 import type {
@@ -97,6 +98,7 @@ import { CompactionHandler } from "./compactionHandler";
 import { RetryManager, type RetryFailureError, type RetryStatusEvent } from "./retryManager";
 import type { TelemetryService } from "./telemetryService";
 import type { BackgroundProcessManager } from "./backgroundProcessManager";
+import type { ExperimentsService } from "./experimentsService";
 
 import { AttachmentService } from "./attachmentService";
 import type { TodoItem } from "@/common/types/tools";
@@ -129,7 +131,11 @@ import {
   isNonRetryableStreamError,
 } from "@/common/utils/messages/retryEligibility";
 import { createDisplayUsage } from "@/common/utils/tokens/displayUsage";
-import { readAgentSkill } from "@/node/services/agentSkills/agentSkillsService";
+import {
+  IMAGEGEN_SKILL_DISABLED_MESSAGE,
+  isBuiltInImagegenSkillPackage,
+  readAgentSkill,
+} from "@/node/services/agentSkills/agentSkillsService";
 import {
   createLoadedSkillSnapshot,
   extractLoadedSkillSnapshotsFromMessages,
@@ -320,6 +326,7 @@ interface AgentSessionOptions {
   aiService: AIService;
   initStateManager: InitStateManager;
   telemetryService?: TelemetryService;
+  experimentsService?: ExperimentsService;
   backgroundProcessManager: BackgroundProcessManager;
   workspaceGoalService?: WorkspaceGoalService;
   /** When true, skip terminating background processes on dispose/compaction (for bench/CI) */
@@ -346,6 +353,7 @@ export class AgentSession {
   private readonly aiService: AIService;
   private readonly initStateManager: InitStateManager;
   private readonly backgroundProcessManager: BackgroundProcessManager;
+  private readonly experimentsService?: ExperimentsService;
   private readonly workspaceGoalService?: WorkspaceGoalService;
   private readonly keepBackgroundProcesses: boolean;
   private readonly onCompactionComplete?: () => void;
@@ -508,6 +516,7 @@ export class AgentSession {
       initStateManager,
       telemetryService,
       backgroundProcessManager,
+      experimentsService,
       workspaceGoalService,
       keepBackgroundProcesses,
       onCompactionComplete,
@@ -523,6 +532,7 @@ export class AgentSession {
     this.historyService = historyService;
     this.aiService = aiService;
     this.initStateManager = initStateManager;
+    this.experimentsService = experimentsService;
     this.backgroundProcessManager = backgroundProcessManager;
     this.workspaceGoalService = workspaceGoalService;
     this.keepBackgroundProcesses = keepBackgroundProcesses ?? false;
@@ -2494,7 +2504,8 @@ export class AgentSession {
     try {
       skillSnapshotMessages = await this.materializeAgentSkillSnapshots(
         typedMuxMetadata,
-        options?.disableWorkspaceAgents
+        options?.disableWorkspaceAgents,
+        this.isImageGenerationToolEnabled(options?.experiments)
       );
     } catch (error) {
       return Err(createUnknownSendMessageError(getErrorMessage(error)));
@@ -5672,9 +5683,17 @@ export class AgentSession {
     return { snapshotMessage, materializedTokens: tokens };
   }
 
+  private isImageGenerationToolEnabled(experiments: SendMessageOptions["experiments"]): boolean {
+    return (
+      experiments?.imageGenerationTool ??
+      this.experimentsService?.isExperimentEnabled(EXPERIMENT_IDS.IMAGE_GENERATION_TOOL) === true
+    );
+  }
+
   private async materializeAgentSkillSnapshots(
     muxMetadata: MuxMessageMetadata | undefined,
-    disableWorkspaceAgents: boolean | undefined
+    disableWorkspaceAgents: boolean | undefined,
+    imageGenerationToolEnabled: boolean
   ): Promise<MuxMessage[]> {
     const refs = extractAgentSkillRefs(muxMetadata);
     if (refs.length === 0) {
@@ -5734,6 +5753,13 @@ export class AgentSession {
       } catch (error) {
         if (ref.source === "slash") {
           throw error;
+        }
+        continue;
+      }
+
+      if (isBuiltInImagegenSkillPackage(resolved.package) && !imageGenerationToolEnabled) {
+        if (ref.source === "slash") {
+          throw new Error(IMAGEGEN_SKILL_DISABLED_MESSAGE);
         }
         continue;
       }

--- a/src/node/services/agentSkills/agentSkillsService.ts
+++ b/src/node/services/agentSkills/agentSkillsService.ts
@@ -27,6 +27,34 @@ import { AgentSkillParseError, parseSkillMarkdown } from "./parseSkillMarkdown";
 import { getBuiltInSkillByName, getBuiltInSkillDescriptors } from "./builtInSkillDefinitions";
 import type { ProjectSkillContainment } from "./skillStorageContext";
 
+export const IMAGEGEN_BUILT_IN_SKILL_NAME = "imagegen" satisfies SkillName;
+
+export const IMAGEGEN_SKILL_DISABLED_MESSAGE =
+  "Built-in imagegen skill is only available when the Image Generation Tool experiment is enabled.";
+
+export function isBuiltInImagegenSkill(
+  skill: Pick<AgentSkillDescriptor, "name" | "scope">
+): boolean {
+  return skill.scope === "built-in" && skill.name === IMAGEGEN_BUILT_IN_SKILL_NAME;
+}
+
+export function isBuiltInImagegenSkillPackage(skillPackage: AgentSkillPackage): boolean {
+  return (
+    skillPackage.scope === "built-in" &&
+    skillPackage.frontmatter.name === IMAGEGEN_BUILT_IN_SKILL_NAME
+  );
+}
+
+export function filterUnavailableImagegenSkills<
+  T extends Pick<AgentSkillDescriptor, "name" | "scope">,
+>(skills: T[], imageGenerationToolAvailable: boolean | undefined): T[] {
+  if (imageGenerationToolAvailable === true) {
+    return skills;
+  }
+
+  return skills.filter((skill) => !isBuiltInImagegenSkill(skill));
+}
+
 const UNIVERSAL_SKILLS_ROOT = "~/.agents/skills";
 
 export interface AgentSkillsRoots {

--- a/src/node/services/streamContextBuilder.test.ts
+++ b/src/node/services/streamContextBuilder.test.ts
@@ -269,6 +269,36 @@ describe("buildStreamSystemContext", () => {
     expect(result.availableSkills?.some((skill) => skill.name === "imagegen")).toBe(false);
   });
 
+  test("omits built-in imagegen skill by default", async () => {
+    using tempRoot = new DisposableTempDir("stream-system-context");
+
+    const projectPath = path.join(tempRoot.path, "project");
+    const muxHome = path.join(tempRoot.path, "mux-home");
+    await fs.mkdir(projectPath, { recursive: true });
+    await fs.mkdir(muxHome, { recursive: true });
+
+    const metadata = createWorkspaceMetadata({
+      id: "top-level-ws",
+      name: "top-level-workspace",
+      projectName: "project",
+      projectPath,
+    });
+    const cfg = createProjectsConfig({
+      projectPath,
+      workspaces: [{ id: metadata.id, name: metadata.name }],
+    });
+
+    const result = await buildSystemContextForTest({
+      runtime: new TestRuntime(projectPath, muxHome),
+      metadata,
+      workspacePath: projectPath,
+      cfg,
+      isSubagentWorkspace: false,
+    });
+
+    expect(result.availableSkills?.some((skill) => skill.name === "imagegen")).toBe(false);
+  });
+
   test("includes built-in imagegen skill when image generation tool is available", async () => {
     using tempRoot = new DisposableTempDir("stream-system-context");
 

--- a/src/node/services/streamContextBuilder.ts
+++ b/src/node/services/streamContextBuilder.ts
@@ -41,7 +41,10 @@ import {
 } from "@/node/services/agentDefinitions/agentDefinitionsService";
 import { isAgentEffectivelyDisabled } from "@/node/services/agentDefinitions/agentEnablement";
 import { resolveAgentInheritanceChain } from "@/node/services/agentDefinitions/resolveAgentInheritanceChain";
-import { discoverAgentSkills } from "@/node/services/agentSkills/agentSkillsService";
+import {
+  discoverAgentSkills,
+  filterUnavailableImagegenSkills,
+} from "@/node/services/agentSkills/agentSkillsService";
 import { resolveSkillStorageContext } from "@/node/services/agentSkills/skillStorageContext";
 import { buildSystemMessage } from "./systemMessage";
 import { getTokenizerForModel } from "@/node/utils/main/tokenizer";
@@ -540,9 +543,10 @@ export async function buildStreamSystemContext(
     workspaceLog.warn("Failed to discover agent skills for tool description", { error });
   }
 
-  if (imageGenerationToolAvailable === false) {
-    availableSkills = availableSkills?.filter(
-      (skill) => !(skill.scope === "built-in" && skill.name === "imagegen")
+  if (availableSkills) {
+    availableSkills = filterUnavailableImagegenSkills(
+      availableSkills,
+      imageGenerationToolAvailable
     );
   }
 

--- a/src/node/services/tools/agent_skill_read.test.ts
+++ b/src/node/services/tools/agent_skill_read.test.ts
@@ -148,6 +148,30 @@ describe("agent_skill_read", () => {
     }
   });
 
+  it("blocks the built-in imagegen skill when the image generation tool is unavailable", async () => {
+    using tempDir = new TestTempDir("test-agent-skill-read-imagegen-disabled");
+    const baseConfig = createTestToolConfig(tempDir.path, {
+      workspaceId: GLOBAL_WORKSPACE_ID,
+    });
+
+    const tool = createAgentSkillReadTool(baseConfig);
+
+    const raw: unknown = await Promise.resolve(
+      tool.execute!({ name: "imagegen" }, mockToolCallOptions)
+    );
+
+    const parsed = AgentSkillReadToolResultSchema.safeParse(raw);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) {
+      throw new Error(parsed.error.message);
+    }
+
+    expect(parsed.data.success).toBe(false);
+    if (!parsed.data.success) {
+      expect(parsed.data.error).toContain("Image Generation Tool experiment");
+    }
+  });
+
   it("allows reading global skills on disk in global-scope workspace", async () => {
     using tempDir = new TestTempDir("test-agent-skill-read-global");
     const previousMuxRoot = process.env.MUX_ROOT;

--- a/src/node/services/tools/agent_skill_read.ts
+++ b/src/node/services/tools/agent_skill_read.ts
@@ -5,7 +5,12 @@ import type { ToolConfiguration, ToolFactory } from "@/common/utils/tools/tools"
 import { TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
 import { SkillNameSchema } from "@/common/orpc/schemas";
 import { getErrorMessage } from "@/common/utils/errors";
-import { readAgentSkill } from "@/node/services/agentSkills/agentSkillsService";
+import {
+  filterUnavailableImagegenSkills,
+  IMAGEGEN_SKILL_DISABLED_MESSAGE,
+  isBuiltInImagegenSkillPackage,
+  readAgentSkill,
+} from "@/node/services/agentSkills/agentSkillsService";
 import { resolveSkillStorageContext } from "@/node/services/agentSkills/skillStorageContext";
 
 /**
@@ -17,7 +22,10 @@ function buildSkillReadDescription(config: ToolConfiguration): string {
   const baseDescription = TOOL_DEFINITIONS.agent_skill_read.description;
   // Filter out unadvertised skills from the tool description.
   // Unadvertised skills can still be invoked via /skill-name or agent_skill_read.
-  const skills = (config.availableSkills ?? []).filter((s) => s.advertise !== false);
+  const skills = filterUnavailableImagegenSkills(
+    config.availableSkills ?? [],
+    config.imageGenerationRuntime != null
+  ).filter((s) => s.advertise !== false);
 
   if (skills.length === 0) {
     return baseDescription;
@@ -80,6 +88,13 @@ export const createAgentSkillReadTool: ToolFactory = (config: ToolConfiguration)
             containment: skillCtx.containment,
           }
         );
+        if (isBuiltInImagegenSkillPackage(resolved.package) && !config.imageGenerationRuntime) {
+          return {
+            success: false,
+            error: IMAGEGEN_SKILL_DISABLED_MESSAGE,
+          };
+        }
+
         return {
           success: true,
           skill: resolved.package,

--- a/src/node/services/tools/agent_skill_read_file.test.ts
+++ b/src/node/services/tools/agent_skill_read_file.test.ts
@@ -301,6 +301,33 @@ describe("agent_skill_read_file", () => {
     }
   });
 
+  it("blocks built-in imagegen skill files when the image generation tool is unavailable", async () => {
+    using tempDir = new TestTempDir("test-agent-skill-read-file-imagegen-disabled");
+    const baseConfig = createTestToolConfig(tempDir.path, {
+      workspaceId: GLOBAL_WORKSPACE_ID,
+    });
+
+    const tool = createAgentSkillReadFileTool(baseConfig);
+
+    const raw: unknown = await Promise.resolve(
+      tool.execute!(
+        { name: "imagegen", filePath: "SKILL.md", offset: 1, limit: 25 },
+        mockToolCallOptions
+      )
+    );
+
+    const parsed = AgentSkillReadFileToolResultSchema.safeParse(raw);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) {
+      throw new Error(parsed.error.message);
+    }
+
+    expect(parsed.data.success).toBe(false);
+    if (!parsed.data.success) {
+      expect(parsed.data.error).toContain("Image Generation Tool experiment");
+    }
+  });
+
   it("allows reading global skill files on disk in global-scope workspace", async () => {
     using tempDir = new TestTempDir("test-agent-skill-read-file-global");
     const previousMuxRoot = process.env.MUX_ROOT;

--- a/src/node/services/tools/agent_skill_read_file.ts
+++ b/src/node/services/tools/agent_skill_read_file.ts
@@ -5,7 +5,11 @@ import type { ToolConfiguration, ToolFactory } from "@/common/utils/tools/tools"
 import { TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
 import { getErrorMessage } from "@/common/utils/errors";
 import { SkillNameSchema } from "@/common/orpc/schemas";
-import { readAgentSkill } from "@/node/services/agentSkills/agentSkillsService";
+import {
+  IMAGEGEN_SKILL_DISABLED_MESSAGE,
+  isBuiltInImagegenSkillPackage,
+  readAgentSkill,
+} from "@/node/services/agentSkills/agentSkillsService";
 import { resolveSkillStorageContext } from "@/node/services/agentSkills/skillStorageContext";
 import { MAX_FILE_SIZE, validateFileSize } from "@/node/services/tools/fileCommon";
 import { readBuiltInSkillFile } from "@/node/services/agentSkills/builtInSkillDefinitions";
@@ -140,6 +144,16 @@ export const createAgentSkillReadFileTool: ToolFactory = (config: ToolConfigurat
             containment: skillCtx.containment,
           }
         );
+
+        if (
+          isBuiltInImagegenSkillPackage(resolvedSkill.package) &&
+          !config.imageGenerationRuntime
+        ) {
+          return {
+            success: false,
+            error: IMAGEGEN_SKILL_DISABLED_MESSAGE,
+          };
+        }
 
         // Built-in skills are embedded in the app bundle (no filesystem access).
         if (resolvedSkill.package.scope === "built-in") {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -1863,6 +1863,7 @@ export class WorkspaceService extends EventEmitter {
       aiService: this.aiService,
       telemetryService: this.telemetryService,
       initStateManager: this.initStateManager,
+      experimentsService: this.experimentsService,
       workspaceGoalService: this.workspaceGoalService,
       backgroundProcessManager: this.backgroundProcessManager,
       onCompactionComplete: () => {


### PR DESCRIPTION
Summary

Gate the built-in imagegen skill behind the Image Generation Tool experiment so agents only see or load it when the corresponding image_generate tool is available.

Background

The imagegen skill instructs agents to call image_generate, which is confusing when the experiment is off and the tool is not registered for the turn.

Implementation

Filtered the built-in imagegen skill from stream tool descriptions and agent skill discovery when image generation is unavailable. Direct built-in imagegen reads through skill APIs/tools are blocked, and persisted inline skill refs no longer materialize built-in imagegen snapshots after the experiment is disabled; user-provided project/global skills are left untouched.

Validation

- `make static-check`
- `bun test src/node/services/agentSession.agentSkillSnapshot.test.ts`
- `bun test src/node/services/streamContextBuilder.test.ts`
- `bun test src/node/services/tools/agent_skill_read.test.ts src/node/services/tools/agent_skill_read_file.test.ts`
- `bun run typecheck`
- `make fmt-check`
- `make lint`

Risks

Low risk: the gate only filters the built-in imagegen skill and preserves project/global skill shadowing behavior.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `high` • Cost: `$18.28`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=high costs=18.28 -->
