### PR TITLE
🤖 fix: remove sidebar goal target pill

### DIFF
--- a/src/browser/components/AgentListItem/AgentListItem.stories.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.stories.tsx
@@ -20,8 +20,6 @@ import {
   getWorkspaceLastReadKey,
 } from "@/common/constants/storage";
 import type { AgentRowRenderMeta } from "@/browser/utils/ui/workspaceFiltering";
-import { EXPERIMENT_IDS, getExperimentKey } from "@/common/constants/experiments";
-import type { GoalStatus } from "@/common/types/goal";
 import type { WorkspaceActivitySnapshot } from "@/common/orpc/types";
 
 const meta: Meta<typeof AgentListItem> = {
@@ -298,49 +296,6 @@ function renderIdleState(isUnread: boolean) {
   return renderSingleWorkspaceState(2);
 }
 
-function renderGoalState(
-  status: GoalStatus,
-  accounting?: { budgetCents: number | null; costCents: number }
-) {
-  const workspace = STORY_WORKSPACES[2];
-  updatePersistedState(getExperimentKey(EXPERIMENT_IDS.GOALS), true);
-  return (
-    <StoryScaffold
-      activeWorkspaceId={workspace.id}
-      workspaceActivitySnapshots={{
-        [workspace.id]: {
-          recency: NOW,
-          streaming: false,
-          lastModel: null,
-          lastThinkingLevel: null,
-          goal: {
-            goalId: "11111111-1111-4111-8111-111111111111",
-            status,
-            objective: "Ship the goal primitive",
-            budgetCents: accounting?.budgetCents ?? null,
-            costCents: accounting?.costCents ?? 0,
-            turnsUsed: 0,
-            turnCap: null,
-            completionSummary: status === "complete" ? "The goal primitive shipped." : undefined,
-            startedAtMs: NOW,
-          },
-        },
-      }}
-    >
-      <AgentListItem
-        metadata={workspace}
-        projectPath={PROJECT_PATH}
-        projectName={PROJECT_NAME}
-        isSelected={false}
-        onSelectWorkspace={() => undefined}
-        onForkWorkspace={() => Promise.resolve()}
-        onArchiveWorkspace={() => Promise.resolve()}
-        onCancelCreation={() => Promise.resolve()}
-      />
-    </StoryScaffold>
-  );
-}
-
 function renderDraftState() {
   return (
     <StoryScaffold>
@@ -576,37 +531,6 @@ export const Archiving: Story = {
 export const Question: Story = {
   args: undefined as never,
   render: () => renderSingleWorkspaceState(4),
-};
-
-export const GoalActive: Story = {
-  args: undefined as never,
-  render: () => renderGoalState("active"),
-};
-
-export const GoalActiveBudgeted: Story = {
-  args: undefined as never,
-  render: () => renderGoalState("active", { budgetCents: 500, costCents: 123 }),
-};
-
-export const GoalActiveUnbudgeted: Story = {
-  args: undefined as never,
-  render: () => renderGoalState("active", { budgetCents: null, costCents: 123 }),
-};
-
-export const GoalPaused: Story = {
-  args: undefined as never,
-  render: () => renderGoalState("paused"),
-};
-
-export const GoalBudgetLimited: Story = {
-  args: undefined as never,
-  name: "Goal/Budget Limited",
-  render: () => renderGoalState("budget_limited", { budgetCents: 500, costCents: 525 }),
-};
-
-export const GoalComplete: Story = {
-  args: undefined as never,
-  render: () => renderGoalState("complete"),
 };
 
 export const Draft: Story = {

--- a/src/browser/components/AgentListItem/AgentListItem.test.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.test.tsx
@@ -1,7 +1,7 @@
 import "../../../../tests/ui/dom";
 
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
-import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import { cleanup, render, within } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { installDom } from "../../../../tests/ui/dom";
 import type * as ReactDndModuleType from "react-dnd";
@@ -17,8 +17,6 @@ import type * as RuntimeStatusStoreModuleType from "@/browser/stores/RuntimeStat
 import type * as WorkspaceStoreModule from "@/browser/stores/WorkspaceStore";
 import * as TooltipModule from "../Tooltip/Tooltip";
 import * as WorkspaceStatusIndicatorModule from "../WorkspaceStatusIndicator/WorkspaceStatusIndicator";
-import { parseRightSidebarLayoutState } from "@/browser/utils/rightSidebarLayout";
-import { getRightSidebarLayoutKey, RIGHT_SIDEBAR_COLLAPSED_KEY } from "@/common/constants/storage";
 import type { AgentRowRenderMeta } from "@/browser/utils/ui/workspaceFiltering";
 import type { StreamAbortReasonSnapshot } from "@/common/types/stream";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
@@ -293,15 +291,15 @@ describe("AgentListItem", () => {
     expect(rowView.queryByTestId(`workspace-secondary-row-${TEST_WORKSPACE_ID}`)).toBeNull();
   });
 
-  test("renders budget-limited goal pill with stateful aria label", () => {
+  test("does not render a goal target pill in the workspace row", () => {
     mockWorkspaceHeartbeatsEnabled = true;
     mockWorkspaceSidebarState = createWorkspaceSidebarState({
       goal: {
         goalId: "11111111-1111-4111-8111-111111111111",
-        status: "budget_limited",
+        status: "active",
         objective: "Ship goal budgets",
         budgetCents: 500,
-        costCents: 525,
+        costCents: 125,
         turnsUsed: 4,
         turnCap: null,
         startedAtMs: Date.now(),
@@ -309,54 +307,8 @@ describe("AgentListItem", () => {
     });
 
     const { row } = renderWorkspaceItem();
-    const pill = within(row).getByTestId(`workspace-goal-pill-${TEST_WORKSPACE_ID}`);
 
-    expect(pill.textContent).toContain("Target  budget limited");
-    expect(pill.getAttribute("aria-label")).toBe("Goal budget limited, $5.25 of $5.00 spent");
-  });
-
-  test("goal pill selects the workspace, expands the sidebar, and opens the Goal tab", () => {
-    mockWorkspaceHeartbeatsEnabled = true;
-    mockWorkspaceSidebarState = createWorkspaceSidebarState({
-      goal: {
-        goalId: "22222222-2222-4222-8222-222222222222",
-        status: "active",
-        objective: "Open the goal tab",
-        budgetCents: 100_000,
-        costCents: 5_294,
-        turnsUsed: 2,
-        turnCap: null,
-        startedAtMs: Date.now(),
-      },
-    });
-    window.localStorage.setItem(RIGHT_SIDEBAR_COLLAPSED_KEY, JSON.stringify(true));
-    const onSelectWorkspace = mock((_: WorkspaceSelection) => undefined);
-
-    const { row, metadata } = renderWorkspaceItem({ onSelectWorkspace });
-    const pill = within(row).getByTestId(`workspace-goal-pill-${TEST_WORKSPACE_ID}`);
-
-    fireEvent.click(pill);
-
-    expect(onSelectWorkspace).toHaveBeenCalledTimes(1);
-    expect(onSelectWorkspace).toHaveBeenCalledWith({
-      projectPath: metadata.projectPath,
-      projectName: metadata.projectName,
-      namedWorkspacePath: metadata.namedWorkspacePath,
-      workspaceId: metadata.id,
-    });
-    expect(window.localStorage.getItem(RIGHT_SIDEBAR_COLLAPSED_KEY)).toBe("false");
-    const persistedLayout = window.localStorage.getItem(getRightSidebarLayoutKey(metadata.id));
-    if (persistedLayout === null) {
-      throw new Error("expected target workspace right sidebar layout to be persisted");
-    }
-    const rawLayout: unknown = JSON.parse(persistedLayout);
-    const layout = parseRightSidebarLayoutState(rawLayout, "costs");
-    expect(layout.root.type).toBe("tabset");
-    if (layout.root.type !== "tabset") {
-      throw new Error("expected default right sidebar layout to be a tabset");
-    }
-    expect(layout.root.activeTab).toBe("goal");
-    expect(layout.root.tabs).toContain("goal");
+    expect(within(row).queryByTestId(`workspace-goal-pill-${TEST_WORKSPACE_ID}`)).toBeNull();
   });
 
   test("renders a heartbeat icon directly in the leading slot for seen rows when the heartbeat experiment is enabled", () => {

--- a/src/browser/components/AgentListItem/AgentListItem.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.tsx
@@ -1,6 +1,5 @@
 import { useTitleEdit } from "@/browser/contexts/WorkspaceTitleEditContext";
 import { updatePersistedState } from "@/browser/hooks/usePersistedState";
-import { focusRightSidebarTab } from "@/browser/utils/rightSidebarTabFocus";
 import { useContextMenuPosition } from "@/browser/hooks/useContextMenuPosition";
 import { useExperimentValue } from "@/browser/hooks/useExperiments";
 import {
@@ -14,7 +13,6 @@ import { useWorkspaceSidebarState } from "@/browser/stores/WorkspaceStore";
 import { stopKeyboardPropagation } from "@/browser/utils/events";
 import type { AgentRowRenderMeta } from "@/browser/utils/ui/workspaceFiltering";
 import { cn } from "@/common/lib/utils";
-import { formatGoalCents } from "@/common/utils/goals/budgetPricing";
 import {
   TASK_GROUP_KIND,
   getTaskGroupKindFromMetadata,
@@ -22,8 +20,7 @@ import {
 } from "@/common/utils/tools/taskGroups";
 import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { isDevcontainerRuntime } from "@/common/types/runtime";
-import { getWorkspaceLastReadKey, RIGHT_SIDEBAR_COLLAPSED_KEY } from "@/common/constants/storage";
-import type { GoalSnapshot } from "@/common/types/goal";
+import { getWorkspaceLastReadKey } from "@/common/constants/storage";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { useDrag } from "react-dnd";
@@ -53,7 +50,6 @@ import {
   EyeOff,
   ChevronDown,
   HeartPulse,
-  Target,
 } from "lucide-react";
 import { WorkspaceStatusIndicator } from "../WorkspaceStatusIndicator/WorkspaceStatusIndicator";
 import { ArchiveIcon } from "../icons/ArchiveIcon/ArchiveIcon";
@@ -421,36 +417,6 @@ function DraftAgentListItemInner(props: DraftAgentListItemProps) {
   );
 }
 
-function getGoalPillAriaLabel(goal: GoalSnapshot, fallbackText: string): string {
-  if (goal.status === "budget_limited") {
-    const budgetText =
-      goal.budgetCents == null ? "no budget" : `${formatGoalCents(goal.budgetCents)} spent`;
-    return `Goal budget limited, ${formatGoalCents(goal.costCents)} of ${budgetText}`;
-  }
-  return fallbackText;
-}
-
-function getGoalPillText(goal: GoalSnapshot): string {
-  if (goal.status === "paused") {
-    return "Target  paused";
-  }
-  if (goal.status === "complete") {
-    return "Target  done";
-  }
-  if (goal.status === "budget_limited") {
-    return "Target  budget limited";
-  }
-  if (goal.budgetCents != null) {
-    return `Target  ${formatGoalCents(goal.costCents)} / ${formatGoalCents(goal.budgetCents)}`;
-  }
-  return `Target  ${formatGoalCents(goal.costCents)}`;
-}
-
-function openGoalTabForWorkspace(workspaceId: string): void {
-  updatePersistedState(RIGHT_SIDEBAR_COLLAPSED_KEY, false);
-  focusRightSidebarTab(workspaceId, "goal");
-}
-
 // ─────────────────────────────────────────────────────────────────────────────
 // Regular Workspace Item (persisted workspace)
 // ─────────────────────────────────────────────────────────────────────────────
@@ -478,7 +444,6 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
   // Destructure metadata for convenience
   const { id: workspaceId, namedWorkspacePath } = metadata;
   const workspaceHeartbeatsEnabled = useExperimentValue(EXPERIMENT_IDS.WORKSPACE_HEARTBEATS);
-  const goalsEnabled = useExperimentValue(EXPERIMENT_IDS.GOALS);
   const isInitializing = metadata.isInitializing === true;
   const isRemoving = isRemovingProp === true || metadata.isRemoving === true;
   const isDisabled = isRemoving || isArchiving === true;
@@ -626,10 +591,7 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
     agentStatus,
     terminalActiveCount,
     lastAbortReason,
-    goal,
   } = useWorkspaceSidebarState(workspaceId);
-
-  const goalPillText = goal ? getGoalPillText(goal) : null;
 
   const fallbackModel = useWorkspaceFallbackModel(workspaceId);
   const streamingStatusPhase = getWorkspaceStreamingStatusPhase({
@@ -1083,23 +1045,6 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
 
             {!isInitializing && !isEditing && (
               <div className="flex items-center gap-1">
-                {goalsEnabled && goal && goalPillText && (
-                  <button
-                    type="button"
-                    className="border-border-light bg-surface-secondary text-muted hover:text-foreground focus-visible:ring-accent inline-flex shrink-0 items-center gap-0.5 rounded-full border px-1.5 py-0.5 text-[11px] leading-none focus-visible:ring-1 focus-visible:outline-none"
-                    aria-label={getGoalPillAriaLabel(goal, goalPillText)}
-                    data-testid={`workspace-goal-pill-${workspaceId}`}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      openGoalTabForWorkspace(workspaceId);
-                      onSelectWorkspace(workspaceSelection);
-                    }}
-                    onKeyDown={stopKeyboardPropagation}
-                  >
-                    <Target aria-hidden="true" className="h-3 w-3" />
-                    <span>{goalPillText}</span>
-                  </button>
-                )}
                 {shouldShowInlineArchivingStatus ? (
                   <div
                     className="text-muted flex shrink-0 items-center gap-1 text-xs whitespace-nowrap"


### PR DESCRIPTION
## Summary

Removes the goal target pill from workspace rows in the left sidebar so goal-running workspaces no longer show the extra mobile-unfriendly pill.

## Background

The target pill made goal-running rows look crowded in the left sidebar, especially on mobile. Once the pill was removed, the goal-specific `AgentListItem` Storybook stories no longer demonstrated distinct visual states, so this PR also removes those dead stories.

## Implementation

- Removed goal pill rendering and click handling from `AgentListItem`.
- Dropped the unused pill formatting helpers/imports.
- Replaced the old pill behavior tests with coverage that a goal-backed workspace does not render a sidebar target pill.
- Removed obsolete goal-specific `AgentListItem` stories that no longer rendered unique sidebar UI.

## Validation

- `bun test src/browser/components/AgentListItem/AgentListItem.test.tsx`
- `make typecheck`
- `make lint`
- `make fmt-check`
- `make static-check`
- Rebased onto `origin/main`, then reran `make static-check`
- After removing the dead stories, reran `bun test src/browser/components/AgentListItem/AgentListItem.test.tsx` and `make static-check`
- Dogfooded the pre-cleanup `Components/AgentListItem / GoalActiveBudgeted` Storybook story at a 390x844 mobile viewport and verified no visible `Target` text or `workspace-goal-pill-*` element rendered.

## Risks

Low. This removes a single optional inline affordance from the sidebar row and deletes now-redundant Storybook variants; the goal data and right-sidebar goal tab remain unchanged.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `high` • Cost: `$12.81`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=high costs=12.81 -->
