### PR TITLE
🤖 fix: preserve multiline goal prompts

### DIFF
--- a/src/browser/features/ChatInput/ChatInputToast.test.tsx
+++ b/src/browser/features/ChatInput/ChatInputToast.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { GlobalWindow } from "happy-dom";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 
+import { createCommandToast } from "./ChatInputToasts";
 import { ChatInputToast, type Toast } from "./ChatInputToast";
 
 describe("ChatInputToast", () => {
@@ -15,6 +16,18 @@ describe("ChatInputToast", () => {
     cleanup();
     globalThis.window = undefined as unknown as Window & typeof globalThis;
     globalThis.document = undefined as unknown as Document;
+  });
+
+  test("labels known command flag errors without unknown-command wording", () => {
+    const toast = createCommandToast({
+      type: "command-unknown-flag",
+      command: "goal",
+      flag: "--bogus",
+    });
+
+    expect(toast).toMatchObject({ type: "error", title: "Unknown Flag" });
+    expect(toast?.message).toContain("--bogus");
+    expect(toast?.message).not.toContain("Unknown command");
   });
 
   test("resets leaving state when a new toast is shown", async () => {

--- a/src/browser/features/ChatInput/ChatInputToasts.tsx
+++ b/src/browser/features/ChatInput/ChatInputToasts.tsx
@@ -91,6 +91,20 @@ export const createCommandToast = (parsed: ParsedCommand): Toast | null => {
         ),
       };
 
+    case "command-unknown-flag":
+      return {
+        id: Date.now().toString(),
+        type: "error",
+        title: "Unknown Flag",
+        message: `Unknown flag for /${parsed.command}: ${parsed.flag}`,
+        solution: parsed.usage ? (
+          <>
+            <SolutionLabel>Usage:</SolutionLabel>
+            {parsed.usage}
+          </>
+        ) : undefined,
+      };
+
     case "unknown-command": {
       const cmd = "/" + parsed.command + (parsed.subcommand ? " " + parsed.subcommand : "");
       return {

--- a/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
+++ b/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
 import {
   hasProjectScopedSkillRef,
+  parseCommandWithSkillInvocation,
   resolveInlineSkillRefsForSend,
   type SkillInvocation,
 } from "./utils";
@@ -19,6 +20,24 @@ function slashInvocation(skill: AgentSkillDescriptor): SkillInvocation {
     userText: `Using skill ${skill.name}: message`,
   };
 }
+
+describe("parseCommandWithSkillInvocation", () => {
+  test("does not treat known-command flag errors as slash skill invocations", async () => {
+    const result = await parseCommandWithSkillInvocation({
+      messageText: "/goal --bogus\nBody",
+      agentSkillDescriptors: [descriptor("goal")],
+      api: null,
+      discovery: null,
+    });
+
+    expect(result.skillInvocation).toBeNull();
+    expect(result.parsed).toMatchObject({
+      type: "command-unknown-flag",
+      command: "goal",
+      flag: "--bogus",
+    });
+  });
+});
 
 describe("resolveInlineSkillRefsForSend", () => {
   test("returns an empty array for no slash and no inline refs", async () => {

--- a/src/browser/features/RightSidebar/GoalTab.tsx
+++ b/src/browser/features/RightSidebar/GoalTab.tsx
@@ -226,7 +226,9 @@ export function GoalTab(props: GoalTabProps) {
           <Target className="h-3.5 w-3.5" aria-hidden="true" />
           Goal {goalStatusLabel(props.goal.status)}
         </div>
-        <h2 className="text-foreground text-sm leading-5 font-semibold">{props.goal.objective}</h2>
+        <h2 className="text-foreground text-sm leading-5 font-semibold whitespace-pre-wrap">
+          {props.goal.objective}
+        </h2>
       </header>
 
       {props.goal.status === "complete" && props.goal.completionSummary && (

--- a/src/browser/utils/chatCommands.test.ts
+++ b/src/browser/utils/chatCommands.test.ts
@@ -9,6 +9,7 @@ import {
   handleCompactCommand,
   processSlashCommand,
 } from "./chatCommands";
+import { parseCommand } from "./slashCommands/parser";
 import type { CommandHandlerContext, SlashCommandContext } from "./chatCommands";
 import type { ReviewNoteData } from "@/common/types/review";
 import { HEARTBEAT_DEFAULT_INTERVAL_MS } from "@/constants/heartbeat";
@@ -400,6 +401,23 @@ describe("processSlashCommand - goal experiment state", () => {
   });
 });
 
+describe("processSlashCommand - workspace command gating", () => {
+  test("blocks known goal flag errors during workspace creation", async () => {
+    const context = createGoalCommandContext(null);
+    context.variant = "creation";
+
+    const result = await processSlashCommand(
+      { type: "command-unknown-flag", command: "goal", flag: "--bogus" },
+      context
+    );
+
+    expect(result).toEqual({ clearInput: false, toastShown: true });
+    expect(context.setToast).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Command not available during workspace creation" })
+    );
+  });
+});
+
 describe("processSlashCommand - goal optimistic concurrency", () => {
   test("retries once after a goal conflict and reapplies the slash command intent", async () => {
     enableGoalsExperiment();
@@ -648,6 +666,42 @@ describe("processSlashCommand - goal budgets", () => {
       budgetCents: 350,
       turnCap: 25,
     });
+  });
+
+  test("passes parsed multiline goal objectives through to setGoal", async () => {
+    enableGoalsExperiment();
+    const objective = "Implement PRD\n\nRead first:\n- CONTEXT.md\n- PRD.md";
+    const setGoal = mock().mockResolvedValueOnce({
+      success: true,
+      data: { goalId: "33333333-3333-4333-8333-333333333333", objective },
+    });
+    const context = createGoalCommandContext({
+      config: { getConfig: mock(() => Promise.resolve({})) },
+      workspace: {
+        getGoal: mock(() => Promise.resolve({ goal: null })),
+        setGoal,
+        clearGoal: mock(),
+      },
+    } as unknown as SlashCommandContext["api"]);
+
+    const parsed = parseCommand("/goal Implement PRD\n\nRead first:\n- CONTEXT.md\n- PRD.md");
+    if (parsed?.type !== "goal-set") {
+      throw new Error("expected multiline /goal to parse as goal-set");
+    }
+
+    const result = await processSlashCommand(parsed, context);
+
+    expect(result).toEqual({ clearInput: true, toastShown: true });
+    expect(setGoal).toHaveBeenCalledWith({
+      workspaceId: "goal-ws",
+      objective,
+      expectedGoalId: null,
+      budgetCents: 200,
+      turnCap: null,
+    });
+    expect(window.dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "mux:openGoalTab" })
+    );
   });
 
   test("passes explicit no-budget and turn cap through to setGoal", async () => {

--- a/src/browser/utils/chatCommands.ts
+++ b/src/browser/utils/chatCommands.ts
@@ -470,6 +470,7 @@ export async function processSlashCommand(
     switch (parsed.type) {
       case "command-missing-args":
       case "command-invalid-args":
+      case "command-unknown-flag":
       case "unknown-command":
         return parsed.command;
       default:

--- a/src/browser/utils/slashCommands/goal.test.ts
+++ b/src/browser/utils/slashCommands/goal.test.ts
@@ -17,6 +17,13 @@ describe("/goal slash command", () => {
     });
   });
 
+  test("parses multiline objective with Markdown bullets", () => {
+    expect(parseCommand("/goal Implement PRD\n\nRead first:\n- CONTEXT.md\n- PRD.md")).toEqual({
+      type: "goal-set",
+      objective: "Implement PRD\n\nRead first:\n- CONTEXT.md\n- PRD.md",
+    });
+  });
+
   test("parses budget flags on goal creation", () => {
     expect(parseCommand('/goal "ship the slice" --budget $5')).toEqual({
       type: "goal-set",
@@ -50,6 +57,43 @@ describe("/goal slash command", () => {
       type: "goal-set",
       objective: "ship the slice",
       budgetCents: null,
+    });
+  });
+
+  test("preserves a single newline between header objective and body", () => {
+    expect(parseCommand("/goal Ship it\n- bullet")).toEqual({
+      type: "goal-set",
+      objective: "Ship it\n- bullet",
+    });
+  });
+
+  test("parses header flags while preserving flag-looking body prose", () => {
+    expect(
+      parseCommand("/goal --budget $5 --turns 25\nShip it\n--budget stays prose\n- bullet")
+    ).toEqual({
+      type: "goal-set",
+      objective: "Ship it\n--budget stays prose\n- bullet",
+      budgetCents: 500,
+      turnCap: 25,
+    });
+  });
+
+  test("rejects unknown goal creation flags as known-command flag errors", () => {
+    expect(parseCommand("/goal --bogus\nBody")).toMatchObject({
+      type: "command-unknown-flag",
+      command: "goal",
+      flag: "--bogus",
+    });
+  });
+
+  test("rejects lifecycle commands with multiline bodies", () => {
+    expect(parseCommand("/goal clear\nActually a long objective")).toMatchObject({
+      type: "command-invalid-args",
+      command: "goal",
+    });
+    expect(parseCommand("/goal complete\nActually a long objective")).toMatchObject({
+      type: "command-invalid-args",
+      command: "goal",
     });
   });
 

--- a/src/browser/utils/slashCommands/registry.ts
+++ b/src/browser/utils/slashCommands/registry.ts
@@ -20,6 +20,12 @@ import { parseGoalBudgetInputCents } from "@/common/utils/goals/budgetParser";
 import { HEARTBEAT_MAX_INTERVAL_MS, HEARTBEAT_MIN_INTERVAL_MS } from "@/constants/heartbeat";
 import { WORKSPACE_ONLY_COMMAND_KEYS } from "@/constants/slashCommands";
 
+function tokenizeCommandLine(input: string): string[] {
+  return (input.match(/(?:[^\s"]+|"[^"]*")+/g) ?? []).map((token) =>
+    token.replace(/^"(.*)"$/, "$1")
+  );
+}
+
 /**
  * Parse multiline command input into first-line tokens and remaining message.
  * Used by commands that support messages on subsequent lines (/compact, /new).
@@ -35,16 +41,36 @@ function parseMultilineCommand(rawInput: string): {
   const firstLine = lines[0];
   const remainingLines = lines.slice(1).join("\n").trim();
 
-  // Tokenize first line only (preserving quotes)
-  const tokens = (firstLine.match(/(?:[^\s"]+|"[^"]*")+/g) ?? []).map((token) =>
-    token.replace(/^"(.*)"$/, "$1")
-  );
+  const tokens = tokenizeCommandLine(firstLine);
 
   return {
     firstLine,
     tokens,
     message: remainingLines.length > 0 ? remainingLines : undefined,
     hasMultiline,
+  };
+}
+
+interface CommandHeaderBody {
+  headerTokens: string[];
+  body: string | undefined;
+  bodyHadLeadingBlankLine: boolean;
+}
+
+function trimOuterBlankLines(value: string): string {
+  return value.replace(/^(?:[ \t]*\r?\n)+/, "").replace(/(?:\r?\n[ \t]*)+$/, "");
+}
+
+function parseCommandHeaderBody(rawInput: string): CommandHeaderBody {
+  const newlineIndex = rawInput.indexOf("\n");
+  const header = newlineIndex === -1 ? rawInput : rawInput.slice(0, newlineIndex);
+  const rawBody = newlineIndex === -1 ? "" : rawInput.slice(newlineIndex + 1);
+  const body = trimOuterBlankLines(rawBody);
+
+  return {
+    headerTokens: tokenizeCommandLine(header),
+    body: body.trim().length > 0 ? body : undefined,
+    bodyHadLeadingBlankLine: /^\s*\r?\n/.test(rawBody),
   };
 }
 
@@ -471,43 +497,63 @@ function parseGoalTurnCap(value: unknown): number | null {
 const GOAL_USAGE = `/goal ${SLASH_COMMAND_HINTS.goal}`;
 const GOAL_BUDGET_USAGE = "/goal budget $5|500c|--no-budget";
 
+function invalidGoalBodyArgs(
+  body: string
+): Extract<ParsedCommand, { type: "command-invalid-args" }> {
+  return { type: "command-invalid-args", command: "goal", input: body, usage: GOAL_USAGE };
+}
+
+function unknownGoalFlag(flag: string): Extract<ParsedCommand, { type: "command-unknown-flag" }> {
+  return { type: "command-unknown-flag", command: "goal", flag, usage: GOAL_USAGE };
+}
+
 const goalCommandDefinition: SlashCommandDefinition = {
   key: "goal",
   description: `Create, view, or clear a workspace goal. Usage: ${GOAL_USAGE}`,
   inputHint: SLASH_COMMAND_HINTS.goal,
   appendSpace: false,
-  handler: ({ cleanRemainingTokens }): ParsedCommand => {
-    if (cleanRemainingTokens.length === 0) {
+  handler: ({ rawInput }): ParsedCommand => {
+    const { headerTokens, body, bodyHadLeadingBlankLine } = parseCommandHeaderBody(rawInput);
+
+    if (headerTokens.length === 0 && !body) {
       return { type: "goal-show" };
     }
 
-    const action = cleanRemainingTokens[0].toLowerCase();
+    const action = headerTokens[0]?.toLowerCase();
     if (action === "clear") {
+      if (body) {
+        return invalidGoalBodyArgs(body);
+      }
       return { type: "goal-clear" };
     }
 
     if (action === "pause") {
+      if (body) {
+        return invalidGoalBodyArgs(body);
+      }
       return { type: "goal-pause" };
     }
 
     if (action === "resume") {
+      if (body) {
+        return invalidGoalBodyArgs(body);
+      }
       return { type: "goal-resume" };
     }
 
     if (action === "complete") {
-      const parsed = minimist(cleanRemainingTokens.slice(1), {
+      if (body) {
+        return invalidGoalBodyArgs(body);
+      }
+      const parsed = minimist(headerTokens.slice(1), {
         string: ["summary"],
         unknown: (arg: string) => !arg.startsWith("-"),
       });
-      const unknownFlag = cleanRemainingTokens.slice(1).find((token) => {
+      const unknownFlag = headerTokens.slice(1).find((token) => {
         return token.startsWith("-") && token !== "--summary";
       });
       if (unknownFlag) {
-        return {
-          type: "unknown-command",
-          command: "goal",
-          subcommand: `Unknown flag: ${unknownFlag}`,
-        };
+        return unknownGoalFlag(unknownFlag);
       }
       if (parsed._.length > 0) {
         return {
@@ -522,7 +568,10 @@ const goalCommandDefinition: SlashCommandDefinition = {
     }
 
     if (action === "budget") {
-      const budgetTokens = cleanRemainingTokens.slice(1);
+      if (body) {
+        return invalidGoalBodyArgs(body);
+      }
+      const budgetTokens = headerTokens.slice(1);
       if (budgetTokens.length === 0) {
         return {
           type: "command-missing-args",
@@ -553,15 +602,15 @@ const goalCommandDefinition: SlashCommandDefinition = {
       return { type: "goal-budget", budgetCents };
     }
 
-    const noBudget = cleanRemainingTokens.includes("--no-budget");
+    const noBudget = headerTokens.includes("--no-budget");
     const parsed = minimist(
-      cleanRemainingTokens.filter((token) => token !== "--no-budget"),
+      headerTokens.filter((token) => token !== "--no-budget"),
       {
         string: ["budget", "turns"],
         unknown: (arg: string) => !arg.startsWith("-"),
       }
     );
-    const unknownFlag = cleanRemainingTokens.find((token) => {
+    const unknownFlag = headerTokens.find((token) => {
       return (
         token.startsWith("-") &&
         token !== "--budget" &&
@@ -570,14 +619,13 @@ const goalCommandDefinition: SlashCommandDefinition = {
       );
     });
     if (unknownFlag) {
-      return {
-        type: "unknown-command",
-        command: "goal",
-        subcommand: `Unknown flag: ${unknownFlag}`,
-      };
+      return unknownGoalFlag(unknownFlag);
     }
 
-    const objective = parsed._.join(" ").trim();
+    const headerObjective = parsed._.join(" ").trim();
+    const objective = [headerObjective, body]
+      .filter((part): part is string => part != null && part.length > 0)
+      .join(headerObjective && bodyHadLeadingBlankLine ? "\n\n" : "\n");
     if (objective.length === 0) {
       return {
         type: "command-missing-args",

--- a/src/browser/utils/slashCommands/types.ts
+++ b/src/browser/utils/slashCommands/types.ts
@@ -33,6 +33,7 @@ export type ParsedCommand =
   | { type: "plan-open" }
   | { type: "debug-llm-request" }
   | { type: "unknown-command"; command: string; subcommand?: string }
+  | { type: "command-unknown-flag"; command: string; flag: string; usage?: string }
   | { type: "command-missing-args"; command: string; usage: string }
   | { type: "command-invalid-args"; command: string; input: string; usage: string }
   | { type: "idle-compaction"; hours: number | null }


### PR DESCRIPTION
## Summary

Teach `/goal` to parse a structured first-line header while preserving multiline Markdown bodies as the raw goal objective, so pasted implementation prompts with bullets no longer fail as unknown flags.

## Background

Pasting a rich prompt into `/goal` previously tokenized every newline-separated body line as command arguments. Markdown bullets like `- CONTEXT.md` became unknown flags and surfaced as the misleading toast `Unknown command: /goal Unknown flag: -`.

## Implementation

- Added first-line header/body parsing for `/goal` so flags are only read from the header.
- Preserved multiline objective bodies, including bullets and flag-looking prose.
- Added a `command-unknown-flag` parsed-command variant so known-command flag errors no longer masquerade as unknown slash commands or slash-skill invocations.
- Kept lifecycle subcommands body-safe by rejecting `/goal clear|pause|resume|budget|complete` when a multiline body is present.
- Rendered goal objectives with preserved whitespace in the Goal tab.

## Validation

- `bun test src/browser/utils/slashCommands/goal.test.ts src/browser/utils/slashCommands/compact.test.ts src/browser/utils/slashCommands/new.test.ts src/browser/utils/slashCommands/parser.test.ts src/browser/utils/slashCommands/parser_multiline.test.ts src/browser/utils/chatCommands.test.ts src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts src/browser/features/RightSidebar/GoalTab.test.tsx src/browser/features/ChatInput/ChatInputToast.test.tsx`
- `make typecheck`
- `make static-check`
- Browser-bundle parser dogfood with screenshots/video for multiline `/goal` and known flag error parsing.

## Risks

Low-to-moderate parser risk. The change is scoped to `/goal` by consuming the parser’s existing `rawInput` field and sharing tokenization with existing multiline command parsing, leaving global slash command parsing unchanged.

---

<details>
<summary>📋 Implementation Plan</summary>

# Implementation Plan: Rich multiline `/goal` prompts via command-header + raw-body parsing

## Problem statement

A user wants to paste a complete implementation prompt into chat as a workspace goal, e.g.:

```md
/goal Implement the PRD as specified in `.scratch/context-reset-clear-soft/PRD.md`.

Read first:
- `/tmp/handoff-BhvyJQ.md`
- `CONTEXT.md`
- `.scratch/context-reset-clear-soft/PRD.md`
```

Today this fails because the slash command parser tokenizes the entire trimmed input, including newlines, before `/goal` parses it. Markdown bullets become `-` tokens. The `/goal` creation parser treats any `-`-prefixed token that is not one of `--budget`, `--no-budget`, or `--turns` as an unknown flag, returning an `unknown-command` variant that the toast renders as the misleading message:

```text
Unknown command: /goal Unknown flag: -
```

The long-term fix should make rich-text commands parse a small structured command header while preserving the body as raw Markdown text.

## Verified repo evidence

- `src/browser/utils/slashCommands/parser.ts`:
  - `parseCommand(input)` trims the whole input and tokenizes `trimmed.substring(1)` with a whitespace regex, so newlines become token separators.
  - The parser already computes and passes `rawInput` preserving newlines after `/<command>` to command handlers.
  - Unknown slash command parsing is also used by skill invocation fallback, so known-command argument failures should not use `unknown-command` long term.
- `src/browser/utils/slashCommands/registry.ts`:
  - `/compact` already has a localized first-line-only parser via `parseMultilineCommand(rawInput)`.
  - `/goal` currently uses `cleanRemainingTokens`, not `rawInput`, and parses all multiline tokens as CLI-like args.
  - `/goal` unknown flag branches currently return `{ type: "unknown-command", command: "goal", subcommand: "Unknown flag: ..." }`.
- `src/browser/features/ChatInput/ChatInputToasts.tsx`:
  - `createCommandToast()` renders `unknown-command` as `Unknown command: /${command} ${subcommand}`.
- `src/browser/features/ChatInput/utils.ts`:
  - `parseCommandWithSkillInvocation()` treats `unknown-command` as a possible agent-skill invocation path.
- `src/browser/utils/chatCommands.ts`:
  - Parsed `goal-set` commands flow through `processSlashCommand()` → `handleGoalCommand()` → `setGoalWithSingleConflictRetry()`.
  - The command execution path can keep using the same `objective` field if parsing preserves the multiline objective.
- `src/node/services/workspaceGoalService.ts`:
  - `setGoalInternal()` trims only the outer objective (`input.objective?.trim()`) before persistence; no backend schema change is needed for internal newlines.
- `src/constants/goalPrompts.ts`:
  - Goal continuation/budget-limit prompts wrap `goal.objective` in escaped XML-ish tags; internal newlines should survive if persisted.
- `src/browser/features/RightSidebar/GoalTab.tsx`:
  - The goal objective is currently rendered as plain React text in an `<h2>`. This is safe, but normal HTML whitespace may visually collapse multiline Markdown unless the display is adjusted.

## Recommended approach

**Use an incremental, opt-in command-header + raw-body grammar, scoped first to `/goal`.**

Do **not** rewrite the global slash parser. The parser already provides enough raw input for handlers. A scoped change avoids regressions in model one-shot commands, skill fallback, suggestions, `/new`, `/fork`, and `/compact`.

### Net product-code LoC estimate

Recommended scoped approach: **~90-160 product LoC**, excluding tests.

Breakdown:

- `src/browser/utils/slashCommands/types.ts`: +3-8 LoC for a known-command unknown-flag parsed variant.
- `src/browser/utils/slashCommands/registry.ts`: +60-105 LoC for header/body helper(s), `/goal` rewrite, and defensive assertions.
- `src/browser/features/ChatInput/ChatInputToasts.tsx`: +10-25 LoC for specific known-command flag error rendering.
- `src/browser/features/RightSidebar/GoalTab.tsx`: +3-10 LoC to preserve multiline objective display with escaped plain text.
- `src/browser/utils/chatCommands.ts`: expected 0 LoC, unless success-toast formatting needs a tiny guard for very long objectives.

Alternative approaches and estimates:

| Approach | Product LoC | Recommendation |
| --- | ---: | --- |
| Narrow workaround: ignore literal `-` tokens in `/goal` | ~15-35 | Not recommended. Fixes bullets but not code fences, `--flag` prose, whitespace preservation, or misleading errors. |
| Scoped header/body parsing for `/goal` | ~90-160 | Recommended. Robust for rich prompts while limiting blast radius. |
| Global slash parser rewrite with command metadata | ~180-350 | Not recommended for this bug. Higher regression risk for one-shots, skill fallback, suggestions, and existing command semantics. |

## Target grammar

Introduce an explicit convention for rich-text commands:

```md
/<command> [structured header args/flags]
raw body starts after the first newline
```

For `/goal`:

```md
/goal --budget $5 --turns 25
Long Markdown objective:
- bullets
- code fences
- paths
```

Rules:

1. Parse `/goal` flags only from the first line after `/goal`.
2. Treat everything after the first newline as raw objective body, never as flags.
3. Preserve internal body newlines, indentation, bullets, code fences, and `--flag-looking` prose.
4. Trim only outer blank lines from the body; do not strip indentation from the first meaningful body line.
5. Existing one-line commands remain valid:
   - `/goal`
   - `/goal "ship the slice"`
   - `/goal "ship the slice" --budget $5 --turns 25`
   - `/goal budget $5`
   - `/goal pause`
   - `/goal resume`
   - `/goal complete --summary "Done"`
   - `/goal clear`
6. If both a first-line objective and a body exist, combine them as one objective while preserving the newline boundary. Prefer preserving whether the user inserted a blank line after the header:
   - `/goal Title\n- bullet` → objective keeps `Title\n- bullet`.
   - `/goal Title\n\nDetails` → objective keeps `Title\n\nDetails`.
7. If the first header token is a lifecycle subcommand (`clear`, `pause`, `resume`, `budget`, `complete`) and a body is present, reject as invalid instead of executing side effects. This prevents a pasted rich prompt from accidentally clearing, pausing, or completing a goal.
8. Unknown flags in the header still fail; unknown flag-looking text in the body is objective text.

## Non-goals

- Do not render goal objectives as Markdown/HTML. Keep React text escaping intact; use CSS whitespace preservation only.
- Do not redesign slash suggestions or command palette behavior.
- Do not add a broad `/goal set` subcommand in the first pass. It could conflict with existing valid objectives such as `/goal set up CI`. Consider it later only with a separate compatibility design.
- Do not change backend goal schemas or goal prompt trust boundaries.
- Do not change unknown slash command behavior for agent-skill invocation except to stop known-command parse errors from masquerading as unknown commands.

## Implementation phases

### Phase 1 — Pin behavior with failing parser tests

Files:

- `src/browser/utils/slashCommands/goal.test.ts`
- Optionally `src/browser/utils/slashCommands/parser_multiline.test.ts` if a parser-level regression test is clearer.

Add tests before changing parser behavior:

1. **Multiline body with Markdown bullets succeeds**

   ```ts
   parseCommand(`/goal Implement PRD\n\nRead first:\n- CONTEXT.md\n- PRD.md`)
   ```

   Expected `goal-set.objective` preserves the body and bullet lines.

2. **Header flags are parsed; body flags are prose**

   ```ts
   parseCommand(`/goal --budget $5 --turns 25\nShip it\n--budget stays prose\n- bullet`)
   ```

   Expected:
   - `budgetCents: 500`
   - `turnCap: 25`
   - objective includes `--budget stays prose` and `- bullet`.

3. **Header objective plus body preserves newline boundary**

   ```ts
   parseCommand(`/goal Ship it\n- bullet`)
   ```

   Expected objective includes a newline before `- bullet`, not a space-only flattening.

4. **Header unknown flag is still rejected**

   ```ts
   parseCommand(`/goal --bogus\nBody`)
   ```

   Expected the new known-command flag error variant, not `unknown-command`.

5. **Lifecycle commands remain unchanged and body-safe**

   Existing expected behavior stays:

   ```ts
   /goal clear
   /goal pause
   /goal resume
   /goal budget 5
   /goal complete --summary "Done"
   ```

   Add body-safety cases such as:

   ```ts
   parseCommand(`/goal clear\nActually a long objective`)
   parseCommand(`/goal complete\nLong objective`)
   ```

   Expected invalid-args/unsupported-body result, with no lifecycle parsed command.

Quality gate after Phase 1:

```sh
bun test src/browser/utils/slashCommands/goal.test.ts
```

Expected: newly added tests fail before implementation for the multiline cases.

### Phase 2 — Add a known-command unknown-flag parsed variant

Files:

- `src/browser/utils/slashCommands/types.ts`
- `src/browser/features/ChatInput/ChatInputToasts.tsx`
- `src/browser/utils/slashCommands/registry.ts`

Plan:

1. Add a parsed command variant, e.g.:

   ```ts
   | { type: "command-unknown-flag"; command: string; flag: string; usage?: string }
   ```

2. Update `createCommandToast()` with a specific case:
   - Message should clearly say the flag is unknown for a known command.
   - Include usage if supplied.
   - Do not route this through `unknown-command`.

3. Update `/goal` unknown flag returns to use the new variant.

4. Keep `unknown-command` reserved for genuinely unregistered commands and model/skill fallback.

Test additions:

- Parser test that `/goal --bogus` returns `command-unknown-flag`.
- Unit/UI test for `createCommandToast()` if an existing lightweight pattern exists; otherwise ensure command fallback in `chatCommands.test.ts` sets an error toast and does not call goal APIs.
- Regression test for `parseCommandWithSkillInvocation()` if practical: a known `/goal --bogus` parse error must not become a slash skill invocation even if a skill named `goal` exists.

Quality gate after Phase 2:

```sh
bun test src/browser/utils/slashCommands/goal.test.ts src/browser/utils/chatCommands.test.ts
```

### Phase 3 — Introduce a small header/body helper

Preferred location: near the existing `parseMultilineCommand()` helper in `src/browser/utils/slashCommands/registry.ts`.

Keep it private first unless multiple files need it.

Suggested helper shape:

```ts
interface CommandHeaderBody {
  header: string;
  headerTokens: string[];
  rawBody: string;
  body: string;
  hasBody: boolean;
  bodyHadLeadingBlankLine: boolean;
}
```

Behavior:

- Split only on the first newline after the command key.
- Tokenize only `header` with the existing quote-aware one-line tokenizer.
- Strip quote wrappers from header tokens using the existing convention.
- `body` should remove only leading/trailing blank lines, not indentation on meaningful lines.
- Preserve CRLF input where reasonable by normalizing line boundaries in the same way existing parser tests expect.
- Use assertions for impossible helper states, e.g. split indexes within bounds and no empty tokens after tokenization.

Possible helper names:

- `parseCommandHeaderBody(rawInput)`
- `tokenizeCommandHeader(header)`
- `trimOuterBlankLines(value)`

Do **not** change `parseCommand()` global tokenization in this phase.

Quality gate after Phase 3:

```sh
bun test src/browser/utils/slashCommands/compact.test.ts src/browser/utils/slashCommands/new.test.ts src/browser/utils/slashCommands/parser.test.ts src/browser/utils/slashCommands/parser_multiline.test.ts
```

Expected: existing multiline commands and one-shot commands stay unchanged.

### Phase 4 — Rewrite `/goal` creation parsing to use `rawInput`

File:

- `src/browser/utils/slashCommands/registry.ts`

Plan:

1. Change `goalCommandDefinition.handler` to consume `rawInput` through the new helper.
2. Keep lifecycle branches (`clear`, `pause`, `resume`, `budget`, `complete`) header-only.
3. Reject lifecycle subcommands with a body as invalid args instead of executing side effects.
4. For the goal creation branch:
   - Run `minimist` on `headerTokens` only.
   - Allowed header flags: `--budget`, `--no-budget`, `--turns`.
   - Unknown header flags return `command-unknown-flag`.
   - `--budget` plus `--no-budget` remains invalid.
   - `--turns` still requires a positive safe integer.
   - Header positional tokens become `headerObjective`.
   - Body becomes `bodyObjective`.
   - Objective is assembled from header + body while preserving the original newline boundary semantics.
5. Preserve current bare `/goal` behavior:
   - If there is no header objective and no body, return `{ type: "goal-show" }`.
6. Preserve current one-line objective behavior for compatibility:
   - `/goal "ship the slice" --budget $5` still parses as before.
7. Ensure body lines like `- bullet`, `--budget prose`, and code fences are never inspected for flags.

Implementation note:

- Avoid expanding the meaning of single-dash header text in this pass. A one-line `/goal - bullet` can continue to be an invalid header flag because the rich prompt form should use the body:

  ```md
  /goal
  - bullet
  ```

Quality gate after Phase 4:

```sh
bun test src/browser/utils/slashCommands/goal.test.ts
```

### Phase 5 — Preserve multiline readability in the Goal tab

File:

- `src/browser/features/RightSidebar/GoalTab.tsx`

Plan:

1. Keep rendering the objective as React text, not Markdown or raw HTML.
2. Add whitespace-preserving display styling to the objective container, e.g. Tailwind `whitespace-pre-wrap` plus an appropriate wrapping class if consistent with the file.
3. Keep the visual hierarchy simple. Do not introduce Markdown rendering, syntax highlighting, collapse/expand UI, or new affordances unless separately requested.

Test additions:

- If `GoalTab.test.tsx` has a lightweight pattern, add a test that a multiline objective renders text content including both lines/bullets. Avoid tautological exact styling tests unless the existing UI tests already assert classes.

Quality gate after Phase 5:

```sh
bun test src/browser/features/RightSidebar/GoalTab.test.tsx
```

If no targeted GoalTab test exists or the file is not suited to this assertion, document that this phase was visually dogfooded instead.

### Phase 6 — Command execution and skill-fallback regression coverage

Files:

- `src/browser/utils/chatCommands.test.ts`
- `src/browser/features/ChatInput/utils.ts` tests if present or add a focused test near existing ChatInput utility tests.

Plan:

1. Add/adjust a `processSlashCommand()` test proving a parsed multiline `goal-set` objective is passed to `workspace.setGoal` unchanged except intended outer trimming.
2. Assert the success path still:
   - Clears input.
   - Shows success toast.
   - Dispatches `OPEN_GOAL_TAB`.
3. Assert malformed header flags:
   - Restore/keep input.
   - Show an error toast.
   - Do not call `workspace.setGoal`, `clearGoal`, or lifecycle mutation APIs.
4. If practical, test that `command-unknown-flag` does not trigger slash skill invocation fallback.

Quality gate after Phase 6:

```sh
bun test src/browser/utils/chatCommands.test.ts
```

## Full validation plan

Run targeted tests first, then broader static checks.

Recommended command sequence for the implementer:

```sh
run_and_report slash_goal_tests bun test src/browser/utils/slashCommands/goal.test.ts
run_and_report slash_parser_regression_tests bun test src/browser/utils/slashCommands/compact.test.ts src/browser/utils/slashCommands/new.test.ts src/browser/utils/slashCommands/parser.test.ts src/browser/utils/slashCommands/parser_multiline.test.ts
run_and_report chat_command_tests bun test src/browser/utils/chatCommands.test.ts
run_and_report goal_tab_tests bun test src/browser/features/RightSidebar/GoalTab.test.tsx
run_and_report typecheck make typecheck
run_and_report lint make lint
```

If the touched surface remains small and time allows, finish with:

```sh
run_and_report static_check make static-check
```

Validation expectations:

- No existing slash command behavior regresses.
- TypeScript catches all parsed-command exhaustiveness issues.
- Lint stays clean.
- Any unavailable targeted test should be explicitly reported with the reason and replaced by the closest available validation.

## Dogfooding plan

Dogfooding is required because the failure is a user-facing ChatInput flow.

Use an isolated dev profile/workspace. Since this is an Electron app, use the repo’s browser automation guidance (`agent-browser`) and, if needed, the appropriate desktop/dev-server sandbox skill to launch an isolated Mux instance.

### Setup

1. Start the app with the repo-standard dev flow, e.g. `make dev` or the project sandbox workflow used by this repo.
2. Confirm the Goals experiment is enabled. The command path is gated by `isGoalsExperimentEnabledForCommand()` and `EXPERIMENT_IDS.GOALS`.
3. Open a workspace in the app.
4. Start screen recording before interacting with ChatInput.

### Happy-path recording

Paste and send a realistic multiline goal:

```md
/goal --turns 25
Implement the PRD as specified in `.scratch/context-reset-clear-soft/PRD.md`.

Read first:
- `/tmp/handoff-BhvyJQ.md`
- `CONTEXT.md`
- `docs/adr/0002-context-boundaries-for-compaction-and-reset.md`
- `.scratch/context-reset-clear-soft/PRD.md`

Goal:
Add a provider-invisible Context Reset that preserves transcript history, creates a visible `Context reset` boundary when there is context to reset, keeps `/clear` destructive, supports load-older history above the boundary, and updates active-context slicing/context usage accordingly.
```

Capture evidence:

1. Screenshot/video frame before send showing the exact multiline command in ChatInput.
2. Screenshot/video frame after send showing there is no `Unknown command: /goal Unknown flag: -` toast.
3. Screenshot/video frame showing the success toast.
4. Screenshot/video frame showing the Goal tab opened with the full objective visible and line breaks preserved.
5. If goal continuation fires in the dev environment, capture the synthetic `Continuing active goal` message and verify the agent receives the preserved objective. If continuation does not fire quickly due to idle/gating conditions, note that targeted tests covered prompt preservation and record the blocker.

### Error-path recording

Paste and send:

```md
/goal --bogus
Body should not matter here.
```

Expected:

- A known-command flag error toast appears.
- The toast does not say `Unknown command`.
- No goal is created/replaced.
- The input is restored or left available for correction, matching existing command-error behavior.

### Regression spot checks

Exercise these commands in the same recording or a second short recording:

```text
/goal budget 5
/goal pause
/goal resume
/goal complete --summary "Verified and shipped"
/goal clear
```

Also check body flag preservation:

```md
/goal
This is prose, not a flag:
--budget $999
- keep this bullet
```

Expected:

- `--budget $999` appears in the objective text, not as a budget.
- The bullet line appears in the objective text.

### Evidence handoff

Attach screenshots and video recordings to the final implementation report so a reviewer can verify:

- Before/after ChatInput behavior.
- Goal tab preservation.
- Improved malformed-header error.
- No lifecycle regression in basic commands.

## Risks and mitigations

| Risk | Mitigation |
| --- | --- |
| Skill invocation fallback regresses | Keep `unknown-command` only for truly unknown command keys. Add regression coverage around known `/goal` bad flags. |
| Model one-shot parsing regresses | Do not change global `parseCommand()` tokenization. Run parser one-shot regression tests. |
| `/compact` multiline behavior regresses | Do not refactor `/compact` unless exact tests are green. Run existing compact multiline tests. |
| Lifecycle command accidentally executes from pasted body | Reject lifecycle commands with bodies. Add tests that `/goal clear\n...` does not parse as `goal-clear`. |
| Body whitespace/indentation is damaged | Use a helper that trims only outer blank lines, not meaningful indentation. Add tests with bullets/code-ish body text. |
| Goal tab displays preserved data poorly | Add `whitespace-pre-wrap`-style display while keeping React text escaping. Dogfood with screenshots. |
| Long success toast becomes noisy with huge objective | Keep existing toast initially for compatibility; if dogfood shows it is unreadable, make a tiny follow-up to truncate display only, not persisted objective. |
| Header/body grammar introduces ambiguity for objectives beginning with `clear`, `pause`, etc. | Preserve current lifecycle keyword behavior for header-only commands and reject lifecycle+body. Defer explicit `/goal set` or `--` sentinel design to a later change if users need it. |

## Acceptance criteria

### Parser/command semantics

- `/goal\n- bullet` parses as `goal-set` with objective containing `- bullet`.
- `/goal Implement PRD\nRead first:\n- file` parses as `goal-set` with a multiline objective, not flattened tokens.
- `/goal --budget $5 --turns 25\nbody` parses budget/turn cap from the header and body as objective text.
- `--budget`, `--turns`, `-x`, and `-` inside the body are never parsed as flags.
- `/goal --bogus\nbody` fails as a known-command unknown-flag error.
- Existing `/goal clear`, `/goal pause`, `/goal resume`, `/goal budget`, and `/goal complete` behavior remains unchanged.
- Lifecycle subcommands with bodies do not execute side effects.

### UI/error behavior

- Known-command flag errors no longer display `Unknown command`.
- Multiline goal objectives are visible in the Goal tab with line breaks preserved as escaped plain text.
- Sending a valid multiline `/goal` clears the input and opens the Goal tab as existing goal creation does.
- Invalid header flags keep/restore the input and do not mutate the goal.

### Compatibility

- Unknown slash commands still support agent-skill invocation.
- Model one-shot slash commands still preserve multiline messages.
- `/compact` and `/new` multiline tests remain green.
- No backend schema migration is needed.

### Validation/dogfooding

- Targeted parser and command tests pass.
- Typecheck and lint pass.
- Dogfooding screenshots/video demonstrate the pasted prompt from the original failure now succeeds and that malformed header flags produce the improved error.

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `high` • Cost: `$65.45`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=high costs=65.45 -->
