### PR TITLE
🤖 fix: handle OpenAI image edit responses

### DIFF
--- a/src/common/utils/imageGenerationToolResult.test.ts
+++ b/src/common/utils/imageGenerationToolResult.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import { stripImageToolOutputForModel } from "./imageGenerationToolResult";
+
+describe("stripImageToolOutputForModel", () => {
+  it("bounds huge binary-looking failed image tool errors without mutating history objects", () => {
+    const hugeBinaryText = `${"\u0000\u0001\ufffd".repeat(20_000)}trailing detail`;
+    const output = {
+      success: false,
+      error: `Image editing failed: Invalid JSON response. Text: ${hugeBinaryText}`,
+      setupHint: "Check credentials.",
+    };
+
+    const stripped = stripImageToolOutputForModel(output);
+
+    expect(output.error).toContain("trailing detail");
+    expect(stripped).toMatchObject({
+      success: false,
+      setupHint: "Check credentials.",
+    });
+    if (typeof (stripped as { error?: unknown }).error !== "string") {
+      throw new Error("Expected stripped image error to remain a string");
+    }
+    const strippedError = (stripped as { error: string }).error;
+    expect(strippedError).toContain("omitted binary image tool error");
+    expect(strippedError.length).toBeLessThan(1_000);
+  });
+
+  it("keeps short failed image tool errors readable", () => {
+    const output = { success: false, error: "Image edit prompt is required." };
+
+    expect(stripImageToolOutputForModel(output)).toEqual(output);
+  });
+});

--- a/src/common/utils/imageGenerationToolResult.ts
+++ b/src/common/utils/imageGenerationToolResult.ts
@@ -6,6 +6,49 @@ function isUnknownArray(value: unknown): value is unknown[] {
   return Array.isArray(value);
 }
 
+const IMAGE_TOOL_ERROR_MAX_CHARS = 4_096;
+const IMAGE_TOOL_ERROR_PREFIX_CHARS = 700;
+
+function isProbablyBinaryText(value: string): boolean {
+  let suspiciousCharacters = 0;
+  const sample = value.slice(0, IMAGE_TOOL_ERROR_MAX_CHARS);
+  for (const char of sample) {
+    const codePoint = char.codePointAt(0);
+    if (codePoint == null) {
+      continue;
+    }
+    if (char === "\ufffd" || (codePoint < 32 && char !== "\n" && char !== "\r" && char !== "\t")) {
+      suspiciousCharacters += 1;
+    }
+  }
+  return suspiciousCharacters >= 8;
+}
+
+// Provider/SDK response-shape bugs can decode image bytes as text; never replay
+// megabyte-scale binary-looking errors back into model context or persisted tool output.
+export function sanitizeImageToolErrorForModel(error: string): string {
+  if (error.length <= IMAGE_TOOL_ERROR_MAX_CHARS) {
+    return error;
+  }
+
+  const prefix = error.slice(0, IMAGE_TOOL_ERROR_PREFIX_CHARS).trimEnd();
+  const reason = isProbablyBinaryText(error) ? "binary" : "oversized";
+  return `${prefix}\n[omitted ${reason} image tool error: original length ${error.length} characters]`;
+}
+
+function stripFailedImageToolError(output: Record<string, unknown>): Record<string, unknown> {
+  if (output.success !== false || typeof output.error !== "string") {
+    return output;
+  }
+
+  const sanitizedError = sanitizeImageToolErrorForModel(output.error);
+  if (sanitizedError === output.error) {
+    return output;
+  }
+
+  return { ...output, error: sanitizedError };
+}
+
 function stripThumbnailFromImage(image: unknown): unknown {
   if (!isRecord(image)) {
     return image;
@@ -44,13 +87,15 @@ export function stripImageToolOutputForModel(output: unknown): unknown {
 
   const images = output.images;
   const stripsCurrentImageResult = output.success === true && isUnknownArray(images);
-  const record: Record<string, unknown> = stripsCurrentImageResult
-    ? {
-        ...output,
-        images: images.map(stripThumbnailFromImage),
-        ...(isRecord(output.source) ? { source: stripResolvedSourcePath(output.source) } : {}),
-      }
-    : output;
+  const record: Record<string, unknown> = stripFailedImageToolError(
+    stripsCurrentImageResult
+      ? {
+          ...output,
+          images: images.map(stripThumbnailFromImage),
+          ...(isRecord(output.source) ? { source: stripResolvedSourcePath(output.source) } : {}),
+        }
+      : output
+  );
   const stripped: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(record)) {
     stripped[key] =

--- a/src/node/services/providerModelFactory.test.ts
+++ b/src/node/services/providerModelFactory.test.ts
@@ -19,6 +19,7 @@ import {
   normalizeCodexResponsesBody,
   resolveAIProviderHeaderSource,
   wrapFetchWithAnthropicCacheControl,
+  wrapFetchWithOpenAIImageResponseNormalization,
 } from "./providerModelFactory";
 import { MUX_ANTHROPIC_EFFORT_OVERRIDE_HEADER } from "@/common/utils/ai/providerOptions";
 import { hasLanguageModelCleanup } from "./languageModelCleanup";
@@ -151,6 +152,90 @@ describe("normalizeCodexResponsesBody", () => {
 
     expect(normalized.truncation).toBeUndefined();
     expect(normalized.store).toBe(false);
+  });
+});
+
+describe("wrapFetchWithOpenAIImageResponseNormalization", () => {
+  it("normalizes successful binary OpenAI image edit responses into AI SDK JSON", async () => {
+    const pngBytes = Buffer.from("tiny-png-bytes");
+    const calls: Array<{
+      input: Parameters<typeof fetch>[0];
+      init?: Parameters<typeof fetch>[1];
+    }> = [];
+    const baseFetch = Object.assign(
+      (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        calls.push({ input, init });
+        return Promise.resolve(
+          new Response(pngBytes, {
+            status: 200,
+            statusText: "OK",
+            headers: {
+              "content-type": "image/png",
+              "content-length": String(pngBytes.length),
+            },
+          })
+        );
+      },
+      fetch
+    ) as typeof fetch;
+    const wrappedFetch = wrapFetchWithOpenAIImageResponseNormalization(baseFetch);
+    const form = new FormData();
+    form.set("model", "gpt-image-2");
+    form.set("n", "1");
+    form.set("output_format", "png");
+
+    const response = await wrappedFetch("https://api.openai.com/v1/images/edits", {
+      method: "POST",
+      body: form,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(response.headers.get("content-length")).toBeNull();
+    const body = (await response.json()) as {
+      created: number;
+      output_format: string;
+      data: Array<{ b64_json: string }>;
+    };
+    expect(Number.isInteger(body.created)).toBe(true);
+    expect(body.output_format).toBe("png");
+    expect(body.data).toEqual([{ b64_json: pngBytes.toString("base64") }]);
+  });
+
+  it("adds filenames to OpenAI image edit uploads before sending multipart requests", async () => {
+    let capturedImage: FormDataEntryValue | null = null;
+    const baseFetch = Object.assign(
+      (_input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        if (init?.body instanceof FormData) {
+          capturedImage = init.body.get("image");
+        }
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ data: [{ b64_json: Buffer.from("png").toString("base64") }] }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }
+          )
+        );
+      },
+      fetch
+    ) as typeof fetch;
+    const wrappedFetch = wrapFetchWithOpenAIImageResponseNormalization(baseFetch);
+    const form = new FormData();
+    form.set("model", "gpt-image-1.5");
+    form.set("prompt", "make it blue");
+    form.set("image", new Blob([Buffer.from("png")], { type: "image/png" }));
+
+    await wrappedFetch("https://api.openai.com/v1/images/edits", {
+      method: "POST",
+      body: form,
+    });
+
+    if (capturedImage == null || typeof capturedImage === "string") {
+      throw new Error("Expected OpenAI image edit upload to be a file-like object");
+    }
+    expect((capturedImage as { name?: unknown }).name).toBe("image.png");
   });
 });
 

--- a/src/node/services/providerModelFactory.ts
+++ b/src/node/services/providerModelFactory.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert";
+import { Buffer } from "node:buffer";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import type { XaiProviderOptions } from "@ai-sdk/xai";
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
@@ -498,6 +499,183 @@ function getProviderFetch(providerConfig: ProviderConfig): typeof fetch {
   };
 
   return Object.assign(wrappedFetch, customFetch) as typeof fetch;
+}
+
+function getFormString(body: BodyInit | null | undefined, name: string): string | null {
+  if (!(body instanceof FormData)) {
+    return null;
+  }
+  const value = body.get(name);
+  return typeof value === "string" ? value : null;
+}
+
+function getImageOutputFormat(contentType: string, body: BodyInit | null | undefined): string {
+  const mediaType = contentType.split(";", 1)[0]?.trim().toLowerCase();
+  switch (mediaType) {
+    case "image/jpeg":
+    case "image/jpg":
+      return "jpeg";
+    case "image/webp":
+      return "webp";
+    case "image/png":
+      return "png";
+  }
+
+  const requestedFormat = getFormString(body, "output_format");
+  if (requestedFormat === "jpeg" || requestedFormat === "png" || requestedFormat === "webp") {
+    return requestedFormat;
+  }
+  return "png";
+}
+
+function getRequestedImageCount(body: BodyInit | null | undefined): number {
+  const value = getFormString(body, "n");
+  if (value == null || value.trim() === "") {
+    return 1;
+  }
+  const count = Number(value);
+  return Number.isInteger(count) && count > 0 ? count : 1;
+}
+
+function createOpenAIImageToolErrorResponse(message: string): Response {
+  return new Response(JSON.stringify({ error: { message, type: "mux_image_response_error" } }), {
+    status: 502,
+    statusText: "Bad Gateway",
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function isOpenAIImageEditEndpoint(input: Parameters<typeof fetch>[0]): boolean {
+  const url = getFetchInputUrl(input);
+  if (!url) {
+    return false;
+  }
+  try {
+    return new URL(url).pathname.endsWith("/images/edits");
+  } catch {
+    return false;
+  }
+}
+
+function getOpenAIImageEditFileName(key: string, mediaType: string): string {
+  const prefix = key === "mask" ? "mask" : "image";
+  switch (mediaType.toLowerCase().trim()) {
+    case "image/jpeg":
+    case "image/jpg":
+      return `${prefix}.jpg`;
+    case "image/webp":
+      return `${prefix}.webp`;
+    default:
+      return `${prefix}.png`;
+  }
+}
+
+function isOpenAIImageEditUploadKey(key: string): boolean {
+  return key === "image" || key === "image[]" || key === "mask";
+}
+
+function hasUploadFileName(value: Blob): boolean {
+  const name = (value as { name?: unknown }).name;
+  return typeof name === "string" && name.length > 0;
+}
+
+function normalizeOpenAIImageEditFormData(
+  init: Parameters<typeof fetch>[1]
+): Parameters<typeof fetch>[1] {
+  if (!(init?.body instanceof FormData)) {
+    return init;
+  }
+
+  const entries = Array.from(init.body.entries());
+  const hasNamelessUpload = entries.some(
+    ([key, formValue]) =>
+      isOpenAIImageEditUploadKey(key) &&
+      typeof formValue !== "string" &&
+      !hasUploadFileName(formValue)
+  );
+  if (!hasNamelessUpload) {
+    return init;
+  }
+
+  const formData = new FormData();
+  for (const [key, formValue] of entries) {
+    if (
+      isOpenAIImageEditUploadKey(key) &&
+      typeof formValue !== "string" &&
+      !hasUploadFileName(formValue)
+    ) {
+      const upload = formValue as unknown as Blob;
+      formData.append(
+        key,
+        upload,
+        getOpenAIImageEditFileName(key === "image[]" ? "image" : key, upload.type ?? "image/png")
+      );
+    } else {
+      formData.append(key, formValue);
+    }
+  }
+
+  const headers = init.headers == null ? undefined : new Headers(init.headers);
+  if (headers?.get("content-type")?.toLowerCase().startsWith("multipart/form-data")) {
+    headers.delete("content-type");
+  }
+
+  return { ...init, body: formData, ...(headers != null ? { headers } : {}) };
+}
+
+// Some OpenAI-compatible image edit deployments return a successful image/* body
+// instead of the JSON shape AI SDK expects. Normalize only that narrow success path.
+export function wrapFetchWithOpenAIImageResponseNormalization(
+  baseFetch: typeof fetch
+): typeof fetch {
+  const wrappedFetch = async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1]
+  ): Promise<Response> => {
+    const isImageEditRequest = isOpenAIImageEditEndpoint(input);
+    const requestInit = isImageEditRequest ? normalizeOpenAIImageEditFormData(init) : init;
+    const response = await baseFetch(input, requestInit);
+    if (!isImageEditRequest || !response.ok) {
+      return response;
+    }
+
+    const contentType = response.headers.get("content-type") ?? "";
+    if (!contentType.toLowerCase().startsWith("image/")) {
+      return response;
+    }
+
+    const requestedCount = getRequestedImageCount(requestInit?.body);
+    if (requestedCount !== 1) {
+      return createOpenAIImageToolErrorResponse(
+        `OpenAI returned one binary image for an edit request that asked for ${requestedCount} images.`
+      );
+    }
+
+    const imageBuffer = await response.arrayBuffer();
+    if (imageBuffer.byteLength === 0) {
+      return createOpenAIImageToolErrorResponse("OpenAI returned an empty binary image response.");
+    }
+
+    const headers = new Headers(response.headers);
+    headers.set("content-type", "application/json");
+    headers.delete("content-length");
+    headers.delete("content-encoding");
+
+    return new Response(
+      JSON.stringify({
+        created: Math.floor(Date.now() / 1_000),
+        data: [{ b64_json: Buffer.from(imageBuffer).toString("base64") }],
+        output_format: getImageOutputFormat(contentType, requestInit?.body),
+      }),
+      {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+      }
+    );
+  };
+
+  return Object.assign(wrappedFetch, baseFetch) as typeof fetch;
 }
 
 // ---------------------------------------------------------------------------
@@ -1000,7 +1178,7 @@ export class ProviderModelFactory {
       const { createOpenAI } = await PROVIDER_REGISTRY.openai();
       const provider = createOpenAI({
         ...configWithCreds,
-        fetch: getProviderFetch(providerConfig),
+        fetch: wrapFetchWithOpenAIImageResponseNormalization(getProviderFetch(providerConfig)),
       });
       return Ok(provider.image(modelId));
     } catch (error) {

--- a/src/node/services/tools/imageArtifacts.ts
+++ b/src/node/services/tools/imageArtifacts.ts
@@ -72,6 +72,18 @@ export function formatImageModelError(
   }
 }
 
+export function buildOpenAIImageProviderOptions(
+  quality: string | null | undefined,
+  outputFormat: string | null | undefined
+): { openai: { quality?: string; outputFormat: string } } {
+  return {
+    openai: {
+      ...(quality != null ? { quality } : {}),
+      outputFormat: outputFormat ?? "png",
+    },
+  };
+}
+
 export interface ImageDimensions {
   width: number;
   height: number;

--- a/src/node/services/tools/image_edit.test.ts
+++ b/src/node/services/tools/image_edit.test.ts
@@ -351,6 +351,45 @@ describe("image_edit tool", () => {
     expect(result.error).toContain("only supports OpenAI");
   });
 
+  test("passes OpenAI image edit options using AI SDK option names", async () => {
+    using workspaceDir = new TestTempDir("image-edit-workspace");
+    const sourcePath = path.join(workspaceDir.path, "source.png");
+    await fs.writeFile(sourcePath, testPngBytes);
+    let capturedProviderOptions: unknown;
+    const tool = createImageEditTool({
+      ...createImageEditTestConfig(workspaceDir.path),
+      imageEditingEnabled: true,
+      imageGenerationRuntime: {
+        modelString: "openai:gpt-image-2",
+        maxImagesPerCall: 2,
+        createImageModel: () =>
+          Promise.resolve(
+            Ok(
+              createMockImageModel((options) => {
+                capturedProviderOptions = options.providerOptions;
+                return Promise.resolve({
+                  images: [testPngBase64],
+                  warnings: [],
+                  response: { timestamp: new Date(), modelId: "test-image-model", headers: {} },
+                  providerMetadata: {},
+                });
+              })
+            )
+          ),
+      },
+    });
+
+    const result = (await tool.execute!(
+      { sourcePath, prompt: "Make it blue", quality: "high", outputFormat: "webp" },
+      createMockToolCallOptions()
+    )) as ImageEditToolResult;
+
+    expect(result.success).toBe(true);
+    expect(capturedProviderOptions).toEqual({
+      openai: { quality: "high", outputFormat: "webp" },
+    });
+  });
+
   test("returns provider errors when image editing generation fails", async () => {
     using workspaceDir = new TestTempDir("image-edit-workspace");
     const sourcePath = path.join(workspaceDir.path, "source.png");

--- a/src/node/services/tools/image_edit.ts
+++ b/src/node/services/tools/image_edit.ts
@@ -5,7 +5,10 @@ import { generateImage, tool } from "ai";
 import sharp from "sharp";
 
 import type { ImageEditToolResult } from "@/common/types/tools";
-import { stripImageToolOutputForModel } from "@/common/utils/imageGenerationToolResult";
+import {
+  sanitizeImageToolErrorForModel,
+  stripImageToolOutputForModel,
+} from "@/common/utils/imageGenerationToolResult";
 import { getErrorMessage } from "@/common/utils/errors";
 import { TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
 import type { ToolFactory } from "@/common/utils/tools/tools";
@@ -13,6 +16,7 @@ import { LocalBaseRuntime } from "@/node/runtime/LocalBaseRuntime";
 import { streamToUint8Array } from "@/node/runtime/streamUtils";
 import type { ImageDimensions } from "./imageArtifacts";
 import {
+  buildOpenAIImageProviderOptions,
   formatImageModelError,
   getImageDimensions,
   getImageDimensionsFromMetadata,
@@ -155,12 +159,7 @@ export const createImageEditTool: ToolFactory = (config) => {
           prompt: { text: trimmedPrompt, images: [sourceBytes] },
           n: requestedCount,
           abortSignal,
-          providerOptions: {
-            openai: {
-              ...(quality != null ? { quality } : {}),
-              output_format: outputFormat ?? "png",
-            },
-          },
+          providerOptions: buildOpenAIImageProviderOptions(quality, outputFormat),
         });
 
         reportImageToolUsage(
@@ -223,7 +222,7 @@ export const createImageEditTool: ToolFactory = (config) => {
       } catch (error) {
         return {
           success: false,
-          error: `Image editing failed: ${getErrorMessage(error)}`,
+          error: `Image editing failed: ${sanitizeImageToolErrorForModel(getErrorMessage(error))}`,
           setupHint: "Check OpenAI provider credentials, billing, rate limits, and content policy.",
         } satisfies ImageEditToolResult;
       }

--- a/src/node/services/tools/image_generate.test.ts
+++ b/src/node/services/tools/image_generate.test.ts
@@ -62,6 +62,42 @@ describe("image_generate tool", () => {
     expect(createImageModelCalled).toBe(false);
   });
 
+  test("passes OpenAI image options using AI SDK option names", async () => {
+    using workspaceDir = new TestTempDir("image-generate-workspace");
+    let capturedProviderOptions: unknown;
+    const tool = createImageGenerateTool({
+      ...createTestToolConfig(workspaceDir.path),
+      imageGenerationRuntime: {
+        modelString: "openai:gpt-image-2",
+        maxImagesPerCall: 2,
+        createImageModel: () =>
+          Promise.resolve(
+            Ok(
+              createMockImageModel((options) => {
+                capturedProviderOptions = options.providerOptions;
+                return Promise.resolve({
+                  images: [testPngBase64],
+                  warnings: [],
+                  response: { timestamp: new Date(), modelId: "test-image-model", headers: {} },
+                  providerMetadata: {},
+                });
+              })
+            )
+          ),
+      },
+    });
+
+    const result = (await tool.execute!(
+      { prompt: "A tiny square", quality: "high", outputFormat: "webp" },
+      mockToolCallOptions
+    )) as ImageGenerateToolResult;
+
+    expect(result.success).toBe(true);
+    expect(capturedProviderOptions).toEqual({
+      openai: { quality: "high", outputFormat: "webp" },
+    });
+  });
+
   test("reports OpenAI image token usage through the tool usage path", async () => {
     using workspaceDir = new TestTempDir("image-generate-workspace");
     const reportedUsage: Array<{

--- a/src/node/services/tools/image_generate.ts
+++ b/src/node/services/tools/image_generate.ts
@@ -3,11 +3,15 @@ import type { JSONValue } from "@ai-sdk/provider";
 import { generateImage, tool } from "ai";
 
 import type { ImageGenerateToolResult } from "@/common/types/tools";
-import { stripImageToolOutputForModel } from "@/common/utils/imageGenerationToolResult";
+import {
+  sanitizeImageToolErrorForModel,
+  stripImageToolOutputForModel,
+} from "@/common/utils/imageGenerationToolResult";
 import { getErrorMessage } from "@/common/utils/errors";
 import { TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
 import type { ToolFactory } from "@/common/utils/tools/tools";
 import {
+  buildOpenAIImageProviderOptions,
   formatImageModelError,
   getImageOutputDir,
   processImageArtifacts,
@@ -63,12 +67,7 @@ export const createImageGenerateTool: ToolFactory = (config) => {
           prompt: trimmedPrompt,
           n: requestedCount,
           abortSignal,
-          providerOptions: {
-            openai: {
-              ...(quality != null ? { quality } : {}),
-              output_format: outputFormat ?? "png",
-            },
-          },
+          providerOptions: buildOpenAIImageProviderOptions(quality, outputFormat),
         });
 
         reportImageToolUsage(
@@ -114,7 +113,7 @@ export const createImageGenerateTool: ToolFactory = (config) => {
       } catch (error) {
         return {
           success: false,
-          error: `Image generation failed: ${getErrorMessage(error)}`,
+          error: `Image generation failed: ${sanitizeImageToolErrorForModel(getErrorMessage(error))}`,
           setupHint: "Check OpenAI provider credentials, billing, rate limits, and content policy.",
         } satisfies ImageGenerateToolResult;
       }


### PR DESCRIPTION
## Summary

Fixes OpenAI Image Tools edit handling so successful image edit responses can be converted into Mux artifacts reliably, including OpenAI-compatible binary image responses and real OpenAI multipart edit uploads.

## Background

The original failure surfaced as `Image editing failed: Invalid JSON response` with binary image bytes stored in failed tool output, which inflated session history and could break later provider requests. Real OpenAI dogfooding also showed AI SDK image edit uploads needed deterministic filenames for the edits endpoint to accept GPT image models.

## Implementation

- Normalize successful OpenAI image edit `image/*` responses into the AI SDK JSON shape before parsing.
- Add deterministic filenames to nameless OpenAI image edit multipart uploads.
- Bound oversized/binary-looking failed image tool errors before they are persisted or replayed to providers.
- Use AI SDK OpenAI image option names for generation/edit requests.
- Add regression coverage for response normalization, upload filename normalization, failed-output redaction, and option shape.

## Validation

- `bun test src/common/utils/imageGenerationToolResult.test.ts src/node/services/tools/image_generate.test.ts src/node/services/tools/image_edit.test.ts src/node/services/providerModelFactory.test.ts`
- `make test`
- `make static-check`
- Real OpenAI dogfood with `OPENAI_API_KEY` configured Mux OpenAI provider: `openai:gpt-image-2` image edit returned `success: true` and wrote an artifact plus thumbnail.
- Mock OpenAI-compatible dogfood: local `/v1/images/edits` returned raw `image/png`, Mux normalized it, and `image_edit` wrote an artifact plus thumbnail.

## Risks

Low-to-medium risk in OpenAI image edit request/response transport only. The wrapper is scoped to OpenAI image edit endpoints and leaves non-image responses and non-OK provider errors untouched.

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix plan: `image_edit` OpenAI response-format failure and history bloat

## Context and evidence

- Workspace `cc99f57d1e` had four `image_edit` calls fail with `Image editing failed: Invalid JSON response`; the parsed `Text:` payload was binary-looking image data, roughly 0.94–1.06M chars per failure.
- The source file was valid: `/tmp/mux-voice-mockups/baseline-workspace.png`, PNG, 1600×1000, ~55 KB.
- Image Tools were configured for `openai:gpt-image-2`; earlier `image_generate` calls with the same model succeeded and wrote artifacts, so credentials/model access were not the immediate failure.
- `~/.mux/edited_images/cc99f57d1e` was empty; the edit artifacts were never written.
- The failed tool outputs were persisted into `chat.jsonl`, inflating the session to ~24.9 MB and causing later context-limit failures.
- OpenAI’s current Images docs still describe GPT image edit/generation outputs as base64 image data inside API response objects/events, while the observed call path received non-JSON binary bytes. Treat this as an SDK/API response-shape compatibility issue plus an error-sanitization gap.

## Goal

Make `image_edit` succeed for `openai:gpt-image-2` when OpenAI/AI SDK returns a successful binary image response, and ensure any future provider response/body errors cannot poison persisted or provider-bound history with megabytes of binary text.

## Recommended approach: verify dependency/API behavior, then choose the narrowest fix

**Net product LoC estimate:** ~75–225 LoC.

Advisor review status:

- I attempted to consult the advisor twice for this plan review, but the advisor tool itself failed with the same class of `Invalid JSON response` / binary-body parse error. Since no usable advisor text was returned, the plan below reflects a conservative self-review rather than external advisor recommendations.
- The failure reinforces the need for bounded binary-response errors, but it should not be treated as additional repo evidence unless reproduced through normal Mux logs.

Why this approach:

- The history-bloat/sanitization fix is mandatory regardless of the provider-response fix: dependency upgrades do not repair existing poisoned histories or protect future malformed/binary provider errors.
- The provider-response fix should start with verification. If a current `ai` / `@ai-sdk/openai` version already handles `gpt-image-2` binary edit responses, prefer a dependency update over a local wrapper.
- If the installed/current SDK still expects JSON and OpenAI can return successful `image/*` bytes, the narrowest robust Mux seam is before AI SDK parses the response: an image-model-only fetch wrapper that normalizes successful binary edit responses, plus request-only redaction for historical/future large image tool errors.

## Implementation phases

### Phase 0 — Verify SDK/API behavior before choosing wrapper vs dependency update

**Net product LoC estimate:** 0 LoC unless the dependency path is chosen.

**Work:**

1. Inspect the installed and latest compatible `ai` / `@ai-sdk/openai` image edit code for `gpt-image-2` response handling and SDK option keys.
2. Confirm whether a dependency update already fixes successful binary `image/*` edit responses and the `outputFormat` option naming issue.
3. If a dependency update fixes the response-shape issue with acceptable lockfile churn, choose that path and skip Phase 3.
4. If the SDK still cannot handle successful binary edit responses, keep Phase 3’s wrapper path.
5. Preserve the user/linter’s intentional edit to `src/browser/utils/messages/applyToolOutputRedaction.test.ts`; do not blindly resurrect deleted tests unless the implementer explicitly chooses that test file as the best current seam.

**Quality gate after Phase 0:** record the chosen path in the implementation summary: dependency update or local wrapper, with the exact SDK/version evidence.

### Phase 1 — Add regression coverage for the failure mode

**Files:**

- `src/node/services/tools/image_edit.test.ts`
- `src/browser/utils/messages/applyToolOutputRedaction.test.ts` if still the best seam after the intentional user/linter edit
- Optional focused utility tests near `src/common/utils/imageGenerationToolResult.ts`
- `src/node/services/providerModelFactory.test.ts` or a new helper test if the wrapper path is chosen

**Work:**

1. Add an `image_edit` test that simulates the chosen provider fix:
   - dependency path: assert the upgraded SDK-facing behavior and provider options are correct;
   - wrapper path: simulate the OpenAI image model receiving a successful binary response through the fetch/model seam selected in Phase 3.
   - Assert the tool returns `success: true`.
   - Assert an edited image artifact is written under `edited_images/<workspace>/<toolCallId>/image-1.<ext>`.
   - Assert dimensions, media type, source metadata, and thumbnail behavior remain intact.
2. Add request-only history redaction tests at the least disruptive current seam:
   - Prefer focused utility coverage for `stripImageToolOutputForModel()` plus one provider-bound redaction test if needed.
   - Only re-add tests to `applyToolOutputRedaction.test.ts` if that is still the best current seam; the user/linter intentionally removed two candidate tests, so avoid mechanically restoring the exact deleted block.
   - Cover a persisted assistant `dynamic-tool` part with `toolName: "image_edit"`, `output: { success: false, error: <huge binary-looking string> }` being shortened before provider conversion/redaction output.
   - Prove the original message object remains unchanged, so UI/persisted history is not mutated.
   - Prove normal short errors, such as `Image edit prompt is required.`, remain unchanged.
   - Include nested tool output coverage if practical, because `applyToolOutputRedaction()` also handles nested calls.
3. Add a provider-options regression test that captures AI SDK-facing OpenAI options and fails if Mux passes only `output_format` instead of the SDK-consumed `outputFormat` key.

**Quality gate after Phase 1:** run the targeted tests and confirm the new tests fail for the intended reasons before production changes.

### Phase 2 — Prevent future and existing history bloat

**Files:**

- `src/common/utils/imageGenerationToolResult.ts`
- `src/browser/utils/messages/applyToolOutputRedaction.ts` only if tool-name-aware gating is needed
- `src/node/services/tools/image_edit.ts`
- `src/node/services/tools/image_generate.ts`
- Possibly `src/node/services/tools/imageArtifacts.ts` for shared image-tool error formatting

**Work:**

1. Extend the image-tool model-output redaction path so failed image tool outputs are bounded, not just successful thumbnails/resolved paths.
   - Existing gap: `stripImageToolOutputForModel()` strips thumbnails only when `success === true`; failed `{ success: false, error: hugeString }` passes through unchanged.
   - Add a helper that detects huge or binary-looking error strings and replaces/truncates them to a short summary, e.g. preserve the leading actionable message plus `[omitted binary image tool error: original length N]`.
   - Use a conservative threshold so ordinary provider diagnostics remain readable.
2. Reuse the same formatter in `image_edit.ts` and `image_generate.ts` catch blocks so new persisted tool outputs are also small.
3. Keep the sanitization scoped to image tools/request assembly; do **not** globally truncate `getErrorMessage()` and do **not** rewrite `HistoryService` reads. This preserves user-visible history while making provider-bound history self-healing.
4. Assert/document why the binary detection threshold exists: provider response bodies can be image bytes decoded as text, and those must never be returned to the model/history unbounded.

**Quality gate after Phase 2:** targeted redaction tests pass, and a synthetic old poisoned `image_edit` result no longer appears as a megabyte-scale provider-bound message.

### Phase 3 — If needed, normalize successful binary OpenAI image responses before AI SDK JSON parsing

**Net product LoC estimate for wrapper path:** ~70–130 LoC.

**Files:**

- `src/node/services/providerModelFactory.ts`
- New small helper module if cleaner, e.g. `src/node/services/openAIImageResponseNormalization.ts`
- `src/node/services/providerModelFactory.test.ts` or image-tool tests, depending on easiest seam

**Work:**

1. Implement this phase only if Phase 0 shows a dependency update is insufficient or too risky.
2. In `ProviderModelFactory.createImageModel()`, wrap the fetch passed to `createOpenAI()` for image models only.
3. In the wrapper:
   - Call the existing provider fetch first so credentials, base URL, proxy behavior, timeouts, DevTools header stripping, and custom fetch behavior are preserved.
   - Only intercept successful responses for OpenAI image endpoints, especially `/images/edits`, where the response `Content-Type` is `image/*` or otherwise clearly non-JSON binary.
   - Do **not** intercept `application/json` responses, event streams, or non-OK responses; provider error JSON should continue to flow through AI SDK’s failed response handler.
   - Read the response bytes, assert they are non-empty, base64 encode them, and return a new JSON `Response` shaped like the AI SDK OpenAI image schema expects: `{ created, data: [{ b64_json }], output_format, quality?, size?, background? }`.
   - Preserve status/statusText and safe headers, changing `content-type` to `application/json` and dropping binary-specific `content-length`/`content-encoding` headers that would be stale.
   - Derive `output_format` from response content type first, then request `FormData`/provider options fallback, then default to `png`.
   - If request metadata says `n > 1` but the provider returns a single binary body, return a bounded explicit error or bypass normalization rather than inventing multiple images.
4. Guard impossible helper states with assertions where appropriate, but return normal bounded tool errors for provider/network failures.
5. Keep the wrapper narrow and removable. Do not reimplement the whole OpenAI image client unless this approach proves impossible.

**Quality gate after Phase 3:** the binary-response regression test passes, existing JSON-response image generation/edit behavior still passes, and non-OK provider errors remain unchanged.

### Phase 4 — Fix OpenAI image provider option naming

**Files:**

- `src/node/services/tools/image_edit.ts`
- `src/node/services/tools/image_generate.ts`
- Optional shared helper in `src/node/services/tools/imageArtifacts.ts` or a tiny sibling module

**Work:**

1. Replace duplicate inline provider option objects with a tiny shared helper that emits the AI SDK’s OpenAI image option keys.
2. Pass `outputFormat` rather than `output_format` to AI SDK provider options; preserve `quality != null` and `outputFormat ?? "png"` behavior.
3. If adding image-edit-specific options later, use SDK keys (`inputFidelity`, etc.) rather than raw OpenAI wire keys.
4. Keep request body wire-key normalization inside AI SDK/fetch wrapper; tool handlers should speak SDK option names.

**Quality gate after Phase 4:** image generate/edit tests prove the SDK-facing option shape and still write PNG artifacts by default.

### Phase 5 — Dependency-update path, if Phase 0 selects it

**Net product LoC estimate if chosen instead of Phase 3:** ~55–95 LoC product code plus dependency/lockfile changes.

1. If a current `ai` / `@ai-sdk/openai` version fixes `gpt-image-2` edit responses and option naming, upgrade instead of maintaining a local wrapper.
2. Keep Phase 2 sanitization even on the dependency path; dependency upgrades do not repair existing poisoned histories and do not protect future large provider error bodies.
3. Keep Phase 4’s provider-option cleanup if the upgraded SDK expects camelCase options.
4. Run the full static/test gate after any dependency update.

## Acceptance criteria

- `image_edit` with `openai:gpt-image-2` and a valid PNG source can produce at least one edited artifact under `~/.mux/edited_images/<workspace>/<callId>/`.
- Successful binary image responses from OpenAI image edit endpoints are converted to normal Mux image artifacts, not surfaced as JSON parse failures.
- Successful JSON image responses continue to work.
- Failed image tool outputs are bounded before being returned to the model and before replayed history is sent to providers.
- Existing poisoned histories like `cc99f57d1e` no longer cause provider-bound messages to include megabyte-scale binary error strings, even if the persisted `chat.jsonl` remains unchanged.
- Short, actionable provider errors remain visible to the user/model.
- No broad refactors, no global `getErrorMessage()` truncation, and no automatic history rewriting.

## Validation plan

Targeted tests first:

```sh
bun test src/node/services/tools/image_edit.test.ts
bun test src/node/services/tools/image_generate.test.ts
bun test src/browser/utils/messages/applyToolOutputRedaction.test.ts
bun test src/node/services/providerModelFactory.test.ts
```

Then repo gates:

```sh
make typecheck
make lint
make fmt-check
```

If provider-model or dependency behavior changes, also run:

```sh
make test
```

## Dogfooding plan

This section incorporates the `dogfood`, `agent-browser`, and `dev-server-sandbox` skills.

1. Start an isolated Mux dev server sandbox.
   - Use `make dev-server-sandbox` so the run gets a fresh temporary `MUX_ROOT`, a unique `server.lock`, and free `BACKEND_PORT`/`VITE_PORT` values.
   - By default the sandbox copies `providers.jsonc` and `config.json` from the seed root if present; verify this is acceptable because `providers.jsonc` may contain API keys.
   - If testing without real provider credentials, start with `make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-providers"` and use mocked/local regression tests only.
   - Use `KEEP_SANDBOX=1 make dev-server-sandbox` when the sandbox root should be preserved for inspecting `chat.jsonl`, `edited_images`, and generated evidence after the run.
2. Prepare browser automation.
   - Use the direct `agent-browser` binary, never `npx agent-browser`.
   - Before executing browser commands, load the installed CLI workflow with `agent-browser skills get core` so command syntax matches the installed version.
   - Use a named session such as `--session image-edit-fix` and an evidence directory such as `dogfood-output/image-edit-fix/` with `screenshots/` and `videos/` subdirectories.
   - Open the sandbox Vite URL with `agent-browser --session image-edit-fix open <sandbox-url>` and wait for network idle.
   - Capture an initial annotated screenshot and interactive snapshot to orient: `screenshot --annotate` and `snapshot -i`.
3. Happy-path image edit dogfood.
   - Configure Image Tools to `openai:gpt-image-2` and confirm OpenAI credentials are available in the sandbox.
   - In a disposable workspace, create or capture a small PNG source image.
   - Start a repro video before triggering the edit, then ask the assistant to run `image_edit` on that image with `n: 1`, `quality: high`, `outputFormat: png`.
   - Pace the video for reviewers: pause briefly between actions, capture step screenshots, and take an annotated result screenshot after the tool completes.
   - Confirm the tool returns `success: true`, writes an artifact under `~/.mux/edited_images/<workspace>/<callId>/`, and the generated image can be opened/attached for review.
4. History-bloat regression dogfood.
   - Create or reuse a disposable workspace with a synthetic large failed image tool output in history, or use a copied fixture based on the `cc99f57d1e` failure shape.
   - Send a follow-up message and confirm the provider request no longer includes megabyte-scale binary text and no longer fails solely due to that poisoned history.
   - Capture screenshots/video showing the follow-up completing or failing only for an unrelated bounded reason.
5. Dogfood reporting discipline.
   - Store screenshots/videos under the dogfood output directory and never delete evidence mid-session.
   - For interactive issues, record a video plus step-by-step screenshots; for static visible-on-load issues, a single annotated screenshot is enough.
   - Check `agent-browser errors` and `agent-browser console` periodically and include relevant findings in the dogfood report.
   - Close the browser session at the end with `agent-browser --session image-edit-fix close`.

## Risks and mitigations

- **Risk: binary response normalization hides a real provider error.** Mitigation: only intercept `response.ok` and image/non-JSON content types; leave non-OK responses untouched.
- **Risk: multiple edited images with binary responses are ambiguous.** Mitigation: support the observed `n: 1` path first; if `n > 1` returns a single binary body, surface a bounded explicit error rather than inventing multiple images.
- **Risk: wrapper duplicates AI SDK behavior.** Mitigation: keep it endpoint/content-type gated and remove it later if an AI SDK upgrade provides equivalent support.
- **Risk: output metadata is incomplete for normalized binary responses.** Mitigation: preserve required artifact fields and derive optional fields best-effort; do not block artifact creation on optional usage/quality/size metadata.
- **Risk: sanitization hides useful diagnostics.** Mitigation: only truncate huge/binary-looking strings and preserve the leading human-readable provider error.


</details>

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$293.72`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=293.72 -->
