### PR TITLE
🤖 fix: sanitize provider error contamination

### DIFF
--- a/scripts/prototypes/openai-responses-probe.ts
+++ b/scripts/prototypes/openai-responses-probe.ts
@@ -1,0 +1,397 @@
+#!/usr/bin/env bun
+/**
+ * PROTOTYPE — throwaway diagnostic for OpenAI Responses transport behavior.
+ *
+ * Question: do gpt-5.5-pro Responses calls fail only through Mux/AI SDK wiring,
+ * or also through direct HTTP / WebSocket calls? Keep all output sanitized: this
+ * probe never prints provider bodies or raw exception text because the observed
+ * failure mode can include binary-looking bytes.
+ *
+ * Run:
+ *   bun scripts/prototypes/openai-responses-probe.ts
+ * Optional:
+ *   PROBE_MODEL=gpt-5.5-pro PROBE_REASONING=medium PROBE_MAX_OUTPUT_TOKENS=64 \
+ *     bun scripts/prototypes/openai-responses-probe.ts
+ */
+
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+
+import { createOpenAI } from "@ai-sdk/openai";
+import { createWebSocketFetch } from "@vercel/ai-sdk-openai-websocket-fetch";
+import { generateText, streamText } from "ai";
+
+import { coerceThinkingLevel, type ThinkingLevel } from "@/common/types/thinking";
+import { buildProviderOptions } from "@/common/utils/ai/providerOptions";
+import { createOpenAIWebSocketTransportFetch } from "@/node/services/openAIWebSocketTransportFetch";
+import { resolveOpenAIWebSocketResponsesUrl } from "@/node/services/providerModelFactory";
+
+const MODEL = process.env.PROBE_MODEL?.trim() || "gpt-5.5-pro";
+const REASONING_EFFORT_RAW = process.env.PROBE_REASONING?.trim() || "medium";
+const REASONING_EFFORT = coerceThinkingLevel(REASONING_EFFORT_RAW);
+const MAX_OUTPUT_TOKENS = Number.parseInt(process.env.PROBE_MAX_OUTPUT_TOKENS || "64", 10);
+const REQUEST_TIMEOUT_MS = Number.parseInt(process.env.PROBE_TIMEOUT_MS || "120000", 10);
+const API_KEY = process.env.OPENAI_API_KEY?.trim();
+const ENV_OPENAI_BASE_URL = process.env.OPENAI_BASE_URL?.trim();
+const OFFICIAL_OPENAI_BASE_URL = "https://api.openai.com/v1";
+
+// The AI SDK can emit provider errors to stderr from internal async streams.
+// Keep prototype output safe for contaminated/binary provider failures.
+const originalConsoleError = console.error.bind(console);
+console.error = (...args: unknown[]) => {
+  originalConsoleError(
+    JSON.stringify({
+      interceptedConsoleError: args.map((arg) => summarizeText(String(arg), 80)),
+    })
+  );
+};
+
+process.on("unhandledRejection", (reason) => {
+  originalConsoleError(JSON.stringify({ unhandledRejection: summarizeError(reason) }));
+});
+process.on("uncaughtException", (error) => {
+  originalConsoleError(JSON.stringify({ uncaughtException: summarizeError(error) }));
+  process.exitCode = 1;
+});
+
+assert(MODEL.length > 0, "PROBE_MODEL must be non-empty");
+assert(REASONING_EFFORT != null, `Unsupported PROBE_REASONING: ${REASONING_EFFORT_RAW}`);
+assert(Number.isInteger(MAX_OUTPUT_TOKENS) && MAX_OUTPUT_TOKENS > 0, "max tokens must be positive");
+assert(Number.isInteger(REQUEST_TIMEOUT_MS) && REQUEST_TIMEOUT_MS > 0, "timeout must be positive");
+
+if (!API_KEY) {
+  console.error("OPENAI_API_KEY is not set; cannot run probe.");
+  process.exit(1);
+}
+
+interface SafeTextSummary {
+  length: number;
+  sha256: string;
+  nulCount: number;
+  controlCount: number;
+  replacementCount: number;
+  printablePrefix: string;
+}
+
+interface BodySummary extends SafeTextSummary {
+  firstBytesHex: string;
+  contentType: string | null;
+  contentEncoding: string | null;
+  status: number;
+  ok: boolean;
+}
+
+function sha256(value: string | Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 16);
+}
+
+function summarizeText(value: string, maxPrefix = 160): SafeTextSummary {
+  let nulCount = 0;
+  let controlCount = 0;
+  let replacementCount = 0;
+  let printablePrefix = "";
+
+  for (const char of value) {
+    const code = char.codePointAt(0)!;
+    if (code === 0) nulCount++;
+    if ((code >= 0 && code < 32 && code !== 9 && code !== 10 && code !== 13) || code === 127) {
+      controlCount++;
+    }
+    if (code === 0xfffd) replacementCount++;
+    if (printablePrefix.length < maxPrefix) {
+      if (code === 10) printablePrefix += "\\n";
+      else if (code === 13) printablePrefix += "\\r";
+      else if (code === 9) printablePrefix += "\\t";
+      else if (code >= 32 && code !== 127 && code !== 0xfffd) printablePrefix += char;
+      else printablePrefix += `\\x${code.toString(16).padStart(2, "0")}`;
+    }
+  }
+
+  return {
+    length: value.length,
+    sha256: sha256(value),
+    nulCount,
+    controlCount,
+    replacementCount,
+    printablePrefix,
+  };
+}
+
+function summarizeError(error: unknown): SafeTextSummary & { name: string } {
+  const name = error instanceof Error ? error.name : typeof error;
+  const message = error instanceof Error ? error.message : String(error);
+  return { name, ...summarizeText(message) };
+}
+
+async function summarizeResponse(response: Response): Promise<BodySummary> {
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  const text = new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+  return {
+    ...summarizeText(text),
+    firstBytesHex: Array.from(bytes.slice(0, 24), (byte) =>
+      byte.toString(16).padStart(2, "0")
+    ).join(" "),
+    contentType: response.headers.get("content-type"),
+    contentEncoding: response.headers.get("content-encoding"),
+    status: response.status,
+    ok: response.ok,
+  };
+}
+
+async function withTimeout<T>(
+  name: string,
+  callback: (signal: AbortSignal) => Promise<T>
+): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(`probe timeout after ${REQUEST_TIMEOUT_MS}ms`),
+    REQUEST_TIMEOUT_MS
+  );
+  try {
+    return await callback(controller.signal);
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(`${name} timed out after ${REQUEST_TIMEOUT_MS}ms`, { cause: error });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function rawResponsesBody(stream: boolean): Record<string, unknown> {
+  return {
+    model: MODEL,
+    instructions: "Reply with exactly: probe-ok",
+    input: [{ role: "user", content: "Say probe-ok." }],
+    max_output_tokens: MAX_OUTPUT_TOKENS,
+    reasoning: { effort: REASONING_EFFORT, summary: "detailed" },
+    include: ["reasoning.encrypted_content"],
+    truncation: "disabled",
+    stream,
+  };
+}
+
+function openAIHeaders(): Headers {
+  return new Headers({
+    authorization: `Bearer ${API_KEY}`,
+    "content-type": "application/json",
+  });
+}
+
+async function rawHttp(
+  baseURL: string,
+  stream: boolean,
+  signal: AbortSignal
+): Promise<BodySummary> {
+  const response = await fetch(`${baseURL.replace(/\/+$/, "")}/responses`, {
+    method: "POST",
+    headers: openAIHeaders(),
+    body: JSON.stringify(rawResponsesBody(stream)),
+    signal,
+  });
+  return summarizeResponse(response);
+}
+
+async function websocketPackageRaw(signal: AbortSignal): Promise<BodySummary> {
+  const wsFetch = createWebSocketFetch();
+  try {
+    const response = await wsFetch("https://api.openai.com/v1/responses", {
+      method: "POST",
+      headers: openAIHeaders(),
+      body: JSON.stringify(rawResponsesBody(true)),
+      signal,
+    });
+    return summarizeResponse(response);
+  } finally {
+    wsFetch.close();
+  }
+}
+
+async function websocketMuxWrapperRaw(
+  signal: AbortSignal,
+  baseURL = OFFICIAL_OPENAI_BASE_URL
+): Promise<BodySummary> {
+  const webSocketUrl = resolveOpenAIWebSocketResponsesUrl(baseURL);
+  assert(webSocketUrl != null, "probe WebSocket URL must resolve from baseURL");
+  const transport = createOpenAIWebSocketTransportFetch({
+    enabled: true,
+    baseFetch: fetch,
+    webSocketUrl,
+  });
+  try {
+    const response = await transport.fetch("https://api.openai.com/v1/responses", {
+      method: "POST",
+      headers: openAIHeaders(),
+      body: JSON.stringify(rawResponsesBody(true)),
+      signal,
+    });
+    return summarizeResponse(response);
+  } finally {
+    transport.close();
+  }
+}
+
+function openaiProvider(options?: { fetchImpl?: typeof fetch; baseURL?: string }) {
+  return createOpenAI({ apiKey: API_KEY, fetch: options?.fetchImpl, baseURL: options?.baseURL });
+}
+
+function probeProviderOptions(
+  thinkingLevel: ThinkingLevel
+): ReturnType<typeof buildProviderOptions> {
+  return buildProviderOptions(`openai:${MODEL}`, thinkingLevel);
+}
+
+async function aiSdkGenerateTextMuxOptions(
+  signal: AbortSignal,
+  baseURL?: string
+): Promise<Record<string, unknown>> {
+  const providerOptions = probeProviderOptions(REASONING_EFFORT);
+  const result = await generateText({
+    model: openaiProvider({ baseURL }).responses(MODEL),
+    system: "Reply with exactly: probe-ok",
+    messages: [{ role: "user", content: "Say probe-ok." }],
+    providerOptions,
+    maxOutputTokens: MAX_OUTPUT_TOKENS,
+    abortSignal: signal,
+  });
+  return {
+    textSummary: summarizeText(result.text),
+    usage: result.usage,
+    providerMetadataKeys: Object.keys(result.providerMetadata ?? {}),
+  };
+}
+
+async function aiSdkStreamTextHttp(
+  signal: AbortSignal,
+  baseURL?: string
+): Promise<Record<string, unknown>> {
+  const result = streamText({
+    model: openaiProvider({ baseURL }).responses(MODEL),
+    system: "Reply with exactly: probe-ok",
+    messages: [{ role: "user", content: "Say probe-ok." }],
+    providerOptions: probeProviderOptions(REASONING_EFFORT),
+    maxOutputTokens: MAX_OUTPUT_TOKENS,
+    abortSignal: signal,
+  });
+  let text = "";
+  for await (const delta of result.textStream) {
+    text += delta;
+  }
+  return {
+    textSummary: summarizeText(text),
+    usage: await result.usage,
+    providerMetadataKeys: Object.keys((await result.providerMetadata) ?? {}),
+  };
+}
+
+async function aiSdkStreamTextWebsocket(
+  signal: AbortSignal,
+  baseURL?: string
+): Promise<Record<string, unknown>> {
+  const transport = createOpenAIWebSocketTransportFetch({
+    enabled: true,
+    baseFetch: fetch,
+    webSocketUrl: resolveOpenAIWebSocketResponsesUrl(baseURL),
+  });
+  try {
+    const result = streamText({
+      model: openaiProvider({ fetchImpl: transport.fetch, baseURL }).responses(MODEL),
+      system: "Reply with exactly: probe-ok",
+      messages: [{ role: "user", content: "Say probe-ok." }],
+      providerOptions: probeProviderOptions(REASONING_EFFORT),
+      maxOutputTokens: MAX_OUTPUT_TOKENS,
+      abortSignal: signal,
+    });
+    let text = "";
+    for await (const delta of result.textStream) {
+      text += delta;
+    }
+    return {
+      textSummary: summarizeText(text),
+      usage: await result.usage,
+      providerMetadataKeys: Object.keys((await result.providerMetadata) ?? {}),
+    };
+  } finally {
+    transport.close();
+  }
+}
+
+const probes: Array<[string, (signal: AbortSignal) => Promise<unknown>]> = [
+  ["raw-http-official-non-stream", (signal) => rawHttp(OFFICIAL_OPENAI_BASE_URL, false, signal)],
+  ["raw-http-official-stream-sse", (signal) => rawHttp(OFFICIAL_OPENAI_BASE_URL, true, signal)],
+  ...(ENV_OPENAI_BASE_URL
+    ? ([
+        [
+          "raw-http-env-base-url-non-stream",
+          (signal) => rawHttp(ENV_OPENAI_BASE_URL, false, signal),
+        ],
+        [
+          "raw-http-env-base-url-stream-sse",
+          (signal) => rawHttp(ENV_OPENAI_BASE_URL, true, signal),
+        ],
+      ] satisfies Array<[string, (signal: AbortSignal) => Promise<unknown>]>)
+    : []),
+  ["websocket-package-raw", websocketPackageRaw],
+  [
+    "websocket-mux-wrapper-raw-official",
+    (signal) => websocketMuxWrapperRaw(signal, OFFICIAL_OPENAI_BASE_URL),
+  ],
+  ...(ENV_OPENAI_BASE_URL
+    ? ([
+        [
+          "websocket-mux-wrapper-raw-env-base-url",
+          (signal) => websocketMuxWrapperRaw(signal, ENV_OPENAI_BASE_URL),
+        ],
+      ] satisfies Array<[string, (signal: AbortSignal) => Promise<unknown>]>)
+    : []),
+  ["ai-sdk-generateText-env-base-url", (signal) => aiSdkGenerateTextMuxOptions(signal)],
+  [
+    "ai-sdk-generateText-official-base-url",
+    (signal) => aiSdkGenerateTextMuxOptions(signal, OFFICIAL_OPENAI_BASE_URL),
+  ],
+  ["ai-sdk-streamText-http-env-base-url", (signal) => aiSdkStreamTextHttp(signal)],
+  [
+    "ai-sdk-streamText-http-official-base-url",
+    (signal) => aiSdkStreamTextHttp(signal, OFFICIAL_OPENAI_BASE_URL),
+  ],
+  ["ai-sdk-streamText-websocket-env-base-url", (signal) => aiSdkStreamTextWebsocket(signal)],
+  [
+    "ai-sdk-streamText-websocket-official-base-url",
+    (signal) => aiSdkStreamTextWebsocket(signal, OFFICIAL_OPENAI_BASE_URL),
+  ],
+];
+
+console.log(
+  JSON.stringify(
+    {
+      prototype: "openai-responses-probe",
+      model: MODEL,
+      reasoningEffort: REASONING_EFFORT,
+      maxOutputTokens: MAX_OUTPUT_TOKENS,
+      timeoutMs: REQUEST_TIMEOUT_MS,
+      envOpenAIBaseURL: ENV_OPENAI_BASE_URL ? new URL(ENV_OPENAI_BASE_URL).origin : null,
+      probes: probes.map(([name]) => name),
+    },
+    null,
+    2
+  )
+);
+
+for (const [name, probe] of probes) {
+  const start = Date.now();
+  try {
+    const result = await withTimeout(name, probe);
+    console.log(
+      JSON.stringify({ name, ok: true, durationMs: Date.now() - start, result }, null, 2)
+    );
+  } catch (error) {
+    console.log(
+      JSON.stringify(
+        { name, ok: false, durationMs: Date.now() - start, error: summarizeError(error) },
+        null,
+        2
+      )
+    );
+  }
+}

--- a/src/browser/utils/messages/applyToolOutputRedaction.test.ts
+++ b/src/browser/utils/messages/applyToolOutputRedaction.test.ts
@@ -147,4 +147,56 @@ describe("applyToolOutputRedaction", () => {
       images: [{ path: "/tmp/image.png", filename: "image.png", mediaType: "image/png" }],
     });
   });
+
+  it("redacts binary-like provider error strings from tool output sent to models", () => {
+    const messages: MuxMessage[] = [
+      {
+        id: "assistant-1",
+        role: "assistant" as const,
+        parts: [
+          {
+            type: "dynamic-tool" as const,
+            toolCallId: "image-edit-1",
+            toolName: "image_edit",
+            input: {},
+            state: "output-available" as const,
+            output: {
+              success: false,
+              error: "Invalid JSON response: \u001b\u0000\ufffdpayload",
+            },
+            nestedCalls: [
+              {
+                toolCallId: "nested-image-edit-1",
+                toolName: "image_edit",
+                input: {},
+                state: "output-available" as const,
+                output: {
+                  success: false,
+                  error: "Nested bad body \u0000",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const result = applyToolOutputRedaction(messages);
+    const part = result[0]?.parts[0];
+    if (part?.type !== "dynamic-tool" || part.state !== "output-available") {
+      throw new Error("Expected image edit tool output");
+    }
+
+    const output = part.output as { success?: unknown; error?: unknown };
+    expect(output.success).toBe(false);
+    expect(output.error).not.toBe("Invalid JSON response: \u001b\u0000\ufffdpayload");
+    expect(output.error).toEqual(expect.stringContaining("nul=1"));
+
+    const nestedOutput = part.nestedCalls?.[0]?.output as
+      | { success?: unknown; error?: unknown }
+      | undefined;
+    expect(nestedOutput?.success).toBe(false);
+    expect(nestedOutput?.error).not.toBe("Nested bad body \u0000");
+    expect(nestedOutput?.error).toEqual(expect.stringContaining("nul=1"));
+  });
 });

--- a/src/browser/utils/messages/applyToolOutputRedaction.ts
+++ b/src/browser/utils/messages/applyToolOutputRedaction.ts
@@ -4,6 +4,7 @@
  */
 import type { MuxMessage } from "@/common/types/message";
 import { stripImageToolOutputForModel } from "@/common/utils/imageGenerationToolResult";
+import { sanitizeUnknownForProviderOutput } from "@/common/utils/providerOutputSanitization";
 import { stripToolOutputUiOnly } from "@/common/utils/tools/toolOutputUiOnly";
 
 export function applyToolOutputRedaction(messages: MuxMessage[]): MuxMessage[] {
@@ -15,19 +16,25 @@ export function applyToolOutputRedaction(messages: MuxMessage[]): MuxMessage[] {
       if (part.state !== "output-available") return part;
 
       const outputWithoutUiOnly = stripToolOutputUiOnly(part.output);
+      const sanitizedOutput = sanitizeUnknownForProviderOutput(
+        stripImageToolOutputForModel(outputWithoutUiOnly)
+      );
       const nestedCalls = part.nestedCalls?.map((nestedCall) => {
         if (nestedCall.state !== "output-available") {
           return nestedCall;
         }
+        const nestedOutputWithoutUiOnly = stripToolOutputUiOnly(nestedCall.output);
         return {
           ...nestedCall,
-          output: stripImageToolOutputForModel(stripToolOutputUiOnly(nestedCall.output)),
+          output: sanitizeUnknownForProviderOutput(
+            stripImageToolOutputForModel(nestedOutputWithoutUiOnly)
+          ),
         };
       });
       return {
         ...part,
         ...(nestedCalls ? { nestedCalls } : {}),
-        output: stripImageToolOutputForModel(outputWithoutUiOnly),
+        output: sanitizedOutput,
       };
     });
 

--- a/src/common/utils/providerOutputSanitization.test.ts
+++ b/src/common/utils/providerOutputSanitization.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  sanitizeErrorMessageForDisplay,
+  sanitizeStringForProviderOutput,
+  sanitizeUnknownForProviderOutput,
+} from "./providerOutputSanitization";
+
+describe("provider output sanitization", () => {
+  it("leaves normal provider errors intact", () => {
+    expect(sanitizeErrorMessageForDisplay("Forbidden")).toBe("Forbidden");
+  });
+
+  it("redacts binary-like error messages with bounded diagnostics", () => {
+    const sanitized = sanitizeErrorMessageForDisplay(
+      "Invalid JSON response: \u001b\u0000\ufffdpayload"
+    );
+
+    expect(sanitized).not.toBe("Invalid JSON response: \u001b\u0000\ufffdpayload");
+    expect(sanitized).toContain("nul=1");
+    expect(sanitized).toContain("replacement=1");
+    expect(sanitized).toContain("preview=");
+    expect(sanitized).not.toContain("\u0000");
+    expect(sanitized).not.toContain("�");
+  });
+
+  it("truncates very large non-binary strings", () => {
+    const sanitized = sanitizeStringForProviderOutput("x".repeat(12_010));
+
+    expect(sanitized.length).toBeLessThan(12_100);
+    expect(sanitized).toContain("[truncated provider-output;");
+  });
+
+  it("preserves supported media payloads for attachment extraction", () => {
+    const media = {
+      type: "media",
+      mediaType: "image/png",
+      data: "a".repeat(20_000),
+    };
+
+    expect(sanitizeUnknownForProviderOutput(media)).toBe(media);
+  });
+
+  it("keeps unchanged tool output references", () => {
+    const output = { ok: true, nested: ["still useful"] };
+
+    expect(sanitizeUnknownForProviderOutput(output)).toBe(output);
+  });
+
+  it("does not coerce non-plain objects into records", () => {
+    const date = new Date("2026-05-14T00:00:00Z");
+
+    expect(sanitizeUnknownForProviderOutput(date)).toBe(date);
+  });
+
+  it("recursively sanitizes nested tool output strings", () => {
+    const sanitized = sanitizeUnknownForProviderOutput({
+      ok: false,
+      error: "bad\u0000body",
+      nested: [{ message: "still useful" }],
+    });
+
+    expect(typeof sanitized).toBe("object");
+    expect(sanitized).not.toBeNull();
+    const sanitizedRecord = sanitized as {
+      ok?: unknown;
+      error?: unknown;
+      nested?: unknown;
+    };
+    expect(sanitizedRecord.ok).toBe(false);
+    expect(sanitizedRecord.error).not.toBe("bad\u0000body");
+    expect(sanitizedRecord.error).toEqual(expect.stringContaining("nul=1"));
+    expect(sanitizedRecord.nested).toEqual([{ message: "still useful" }]);
+  });
+});

--- a/src/common/utils/providerOutputSanitization.ts
+++ b/src/common/utils/providerOutputSanitization.ts
@@ -1,0 +1,198 @@
+import assert from "@/common/utils/assert";
+import { isSupportedAttachmentMediaType } from "@/common/utils/attachments/supportedAttachmentMediaTypes";
+
+const DEFAULT_MAX_SAFE_STRING_CHARS = 12_000;
+const DEFAULT_MAX_ERROR_MESSAGE_CHARS = 2_000;
+const DEFAULT_PROVIDER_PREVIEW_CHARS = 64;
+const DEFAULT_ERROR_PREVIEW_CHARS = 240;
+const MAX_RECURSION_DEPTH = 8;
+
+interface TextSafetyStats {
+  length: number;
+  nulCount: number;
+  controlCount: number;
+  replacementCount: number;
+}
+
+interface SanitizeStringOptions {
+  maxChars?: number;
+  reason?: "provider-output" | "error-message";
+}
+
+function isPlainRecord(value: object): value is Record<string, unknown> {
+  const prototype: unknown = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function hasUnsafeText(value: string): boolean {
+  for (const char of value) {
+    const code = char.codePointAt(0)!;
+    if (
+      (code < 32 && code !== 9 && code !== 10 && code !== 13) ||
+      code === 127 ||
+      code === 0xfffd
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isSupportedMediaPart(value: Record<string, unknown>): boolean {
+  return (
+    value.type === "media" &&
+    typeof value.data === "string" &&
+    typeof value.mediaType === "string" &&
+    isSupportedAttachmentMediaType(value.mediaType)
+  );
+}
+
+function getTextSafetyStats(value: string): TextSafetyStats {
+  let nulCount = 0;
+  let controlCount = 0;
+  let replacementCount = 0;
+
+  for (const char of value) {
+    const code = char.codePointAt(0)!;
+    if (code === 0) {
+      nulCount += 1;
+    }
+    if ((code < 32 && code !== 9 && code !== 10 && code !== 13) || code === 127) {
+      controlCount += 1;
+    }
+    if (code === 0xfffd) {
+      replacementCount += 1;
+    }
+  }
+
+  return {
+    length: value.length,
+    nulCount,
+    controlCount,
+    replacementCount,
+  };
+}
+
+function isBinaryLikeText(value: string, stats: TextSafetyStats): boolean {
+  if (stats.nulCount > 0 || stats.replacementCount > 0) {
+    return true;
+  }
+
+  if (value.length === 0) {
+    return false;
+  }
+
+  return stats.controlCount / value.length > 0.02;
+}
+
+function escapePreview(value: string, maxChars: number): string {
+  assert(Number.isInteger(maxChars) && maxChars > 0, "preview maxChars must be positive");
+
+  let escaped = "";
+  for (const char of value) {
+    if (escaped.length >= maxChars) {
+      break;
+    }
+    const code = char.codePointAt(0)!;
+    if (char === "\n") {
+      escaped += "\\n";
+    } else if (char === "\r") {
+      escaped += "\\r";
+    } else if (char === "\t") {
+      escaped += "\\t";
+    } else if (code >= 32 && code !== 127 && code !== 0xfffd) {
+      escaped += char;
+    } else {
+      escaped += `\\u{${code.toString(16)}}`;
+    }
+  }
+  return escaped;
+}
+
+/** Bound and redact provider-visible strings so binary response bodies cannot poison history. */
+export function sanitizeStringForProviderOutput(
+  value: string,
+  options: SanitizeStringOptions = {}
+): string {
+  const maxChars = options.maxChars ?? DEFAULT_MAX_SAFE_STRING_CHARS;
+  assert(Number.isInteger(maxChars) && maxChars > 0, "sanitize maxChars must be positive");
+
+  if (value.length <= maxChars && !hasUnsafeText(value)) {
+    return value;
+  }
+
+  const stats = getTextSafetyStats(value);
+  const binaryLike = isBinaryLikeText(value, stats);
+  if (!binaryLike && value.length <= maxChars) {
+    return value;
+  }
+
+  const reason = options.reason ?? "provider-output";
+  const previewChars =
+    reason === "error-message" ? DEFAULT_ERROR_PREVIEW_CHARS : DEFAULT_PROVIDER_PREVIEW_CHARS;
+  const preview = escapePreview(value, previewChars);
+  const counts = `length=${stats.length}, nul=${stats.nulCount}, control=${stats.controlCount}, replacement=${stats.replacementCount}`;
+
+  if (binaryLike) {
+    return `[redacted binary-like ${reason}; ${counts}; preview="${preview}"]`;
+  }
+
+  return `${value.slice(0, maxChars)}\n[truncated ${reason}; ${counts}]`;
+}
+
+export function sanitizeErrorMessageForDisplay(message: string): string {
+  return sanitizeStringForProviderOutput(message, {
+    maxChars: DEFAULT_MAX_ERROR_MESSAGE_CHARS,
+    reason: "error-message",
+  });
+}
+
+export function sanitizeUnknownForProviderOutput(value: unknown, depth = 0): unknown {
+  if (typeof value === "string") {
+    return sanitizeStringForProviderOutput(value);
+  }
+
+  if (value == null || typeof value !== "object") {
+    return value;
+  }
+
+  if (depth >= MAX_RECURSION_DEPTH) {
+    return "[redacted deeply nested provider output]";
+  }
+
+  if (Array.isArray(value)) {
+    const arrayValue = value as readonly unknown[];
+    let sanitizedItems: unknown[] | undefined;
+    for (let index = 0; index < arrayValue.length; index += 1) {
+      const item = arrayValue[index];
+      const sanitizedItem = sanitizeUnknownForProviderOutput(item, depth + 1);
+      if (sanitizedItems) {
+        sanitizedItems[index] = sanitizedItem;
+      } else if (sanitizedItem !== item) {
+        sanitizedItems = arrayValue.slice(0, index);
+        sanitizedItems[index] = sanitizedItem;
+      }
+    }
+    return sanitizedItems ?? value;
+  }
+
+  if (!isPlainRecord(value)) {
+    return value;
+  }
+
+  if (isSupportedMediaPart(value)) {
+    return value;
+  }
+
+  let sanitizedRecord: Record<string, unknown> | undefined;
+  for (const [key, nestedValue] of Object.entries(value)) {
+    const sanitizedValue = sanitizeUnknownForProviderOutput(nestedValue, depth + 1);
+    if (sanitizedRecord) {
+      sanitizedRecord[key] = sanitizedValue;
+    } else if (sanitizedValue !== nestedValue) {
+      sanitizedRecord = { ...value };
+      sanitizedRecord[key] = sanitizedValue;
+    }
+  }
+  return sanitizedRecord ?? value;
+}

--- a/src/node/services/openAIWebSocketTransportFetch.test.ts
+++ b/src/node/services/openAIWebSocketTransportFetch.test.ts
@@ -101,6 +101,26 @@ describe("createOpenAIWebSocketTransportFetch", () => {
     expect(transport.active).toBe(true);
   });
 
+  test("passes custom WebSocket endpoint to the WebSocket fetch factory", async () => {
+    let capturedOptions: { url?: string } | undefined;
+    const transport = createOpenAIWebSocketTransportFetch({
+      enabled: true,
+      baseFetch: createTestFetch(() => Promise.resolve(new Response("base"))),
+      webSocketUrl: "wss://proxy.openai.test/v1/responses",
+      createWebSocketFetch: (options) => {
+        capturedOptions = options;
+        return createTestWebSocketFetch(() => Promise.resolve(new Response("ws")));
+      },
+    });
+
+    await transport.fetch("https://proxy.openai.test/v1/responses", {
+      method: "POST",
+      body: JSON.stringify({ stream: true }),
+    });
+
+    expect(capturedOptions).toEqual({ url: "wss://proxy.openai.test/v1/responses" });
+  });
+
   test("enabled transport keeps non-eligible requests on the base fetch", async () => {
     const baseCalls: string[] = [];
     const wsCalls: string[] = [];

--- a/src/node/services/openAIWebSocketTransportFetch.ts
+++ b/src/node/services/openAIWebSocketTransportFetch.ts
@@ -5,11 +5,16 @@ import { createWebSocketFetch as createOpenAIWebSocketFetch } from "@vercel/ai-s
 type WebSocketFetch = ((input: RequestInfo | URL, init?: RequestInit) => Promise<Response>) & {
   close: () => void;
 };
-type WebSocketFetchFactory = () => WebSocketFetch;
+interface WebSocketFetchOptions {
+  url?: string;
+}
+
+type WebSocketFetchFactory = (options?: WebSocketFetchOptions) => WebSocketFetch;
 
 interface CreateOpenAIWebSocketTransportFetchOptions {
   enabled: boolean;
   baseFetch: typeof fetch;
+  webSocketUrl?: string;
   createWebSocketFetch?: WebSocketFetchFactory;
 }
 
@@ -75,7 +80,9 @@ export function createOpenAIWebSocketTransportFetch(
   let webSocketFetch: WebSocketFetch | null = null;
 
   const getWebSocketFetch = (): WebSocketFetch => {
-    webSocketFetch ??= webSocketFetchFactory();
+    webSocketFetch ??= webSocketFetchFactory(
+      options.webSocketUrl ? { url: options.webSocketUrl } : undefined
+    );
     assert(
       typeof webSocketFetch.close === "function",
       "OpenAI WebSocket fetch must expose close()"

--- a/src/node/services/providerModelFactory.test.ts
+++ b/src/node/services/providerModelFactory.test.ts
@@ -18,6 +18,7 @@ import {
   MUX_AI_PROVIDER_USER_AGENT,
   normalizeCodexResponsesBody,
   resolveAIProviderHeaderSource,
+  resolveOpenAIWebSocketResponsesUrl,
   wrapFetchWithAnthropicCacheControl,
   wrapFetchWithOpenAIImageResponseNormalization,
 } from "./providerModelFactory";
@@ -97,6 +98,21 @@ async function withTempPolicyProviderFactory(
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 }
+
+describe("resolveOpenAIWebSocketResponsesUrl", () => {
+  it("uses the official default when no base URL is configured", () => {
+    expect(resolveOpenAIWebSocketResponsesUrl(undefined)).toBeUndefined();
+  });
+
+  it("maps HTTPS and HTTP OpenAI base URLs to Responses WebSocket URLs", () => {
+    expect(resolveOpenAIWebSocketResponsesUrl("https://api.openai.com/v1")).toBe(
+      "wss://api.openai.com/v1/responses"
+    );
+    expect(resolveOpenAIWebSocketResponsesUrl("http://localhost:8080/openai/v1/")).toBe(
+      "ws://localhost:8080/openai/v1/responses"
+    );
+  });
+});
 
 describe("normalizeCodexResponsesBody", () => {
   it("enforces Codex-compatible fields, strips truncation, and lifts system prompts into instructions", () => {

--- a/src/node/services/providerModelFactory.ts
+++ b/src/node/services/providerModelFactory.ts
@@ -24,6 +24,7 @@ import type { MuxProviderOptions } from "@/common/types/providerOptions";
 import type { ServiceTier } from "@/common/config/schemas/providersConfig";
 import type { ExternalSecretResolver } from "@/common/types/secrets";
 import { isOpReference } from "@/common/utils/opRef";
+import { resolveConfigBaseUrl } from "@/common/utils/providers/baseUrl";
 import { isProviderDisabledInConfig } from "@/common/utils/providers/isProviderDisabled";
 import {
   isBuiltInProvider,
@@ -190,6 +191,26 @@ const defaultFetchWithUnlimitedTimeout = (async (
   };
   return fetch(input, requestInit);
 }) as typeof fetch;
+
+export function resolveOpenAIWebSocketResponsesUrl(baseURL: unknown): string | undefined {
+  const resolvedBaseURL = resolveConfigBaseUrl({ baseURL });
+  if (resolvedBaseURL == null) {
+    return undefined;
+  }
+
+  const url = new URL(resolvedBaseURL);
+  if (url.protocol === "https:") {
+    url.protocol = "wss:";
+  } else if (url.protocol === "http:") {
+    url.protocol = "ws:";
+  } else {
+    throw new Error(`Unsupported OpenAI WebSocket base URL protocol: ${url.protocol}`);
+  }
+  url.pathname = `${url.pathname.replace(/\/+$/, "")}/responses`;
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
 
 type FetchWithBunExtensions = typeof fetch & {
   preconnect?: typeof fetch extends { preconnect: infer P } ? P : unknown;
@@ -1654,6 +1675,9 @@ export class ProviderModelFactory {
             effectiveWireFormat === "responses" &&
             !shouldRouteThroughCodexOauth,
           baseFetch: fetchWithOpenAICodexNormalization as typeof fetch,
+          // The upstream WebSocket fetch defaults to api.openai.com. Pass Mux's
+          // resolved base URL so custom/proxied OpenAI endpoints are not bypassed.
+          webSocketUrl: resolveOpenAIWebSocketResponsesUrl(configWithCreds.baseURL),
         });
 
         // Lazy-load OpenAI provider to reduce startup time

--- a/src/node/services/tools/advisor.test.ts
+++ b/src/node/services/tools/advisor.test.ts
@@ -402,6 +402,27 @@ describe("advisor tool", () => {
     expect(reportModelUsage).not.toHaveBeenCalled();
   });
 
+  it("sanitizes binary-like advisor provider failures", async () => {
+    using tempDir = new TestTempDir("advisor-tool-sanitized-error");
+    const { config } = createToolConfig(tempDir.path);
+    spyOn(ai, "generateText").mockRejectedValue(
+      new Error("Invalid JSON response: \u001b\u0000\ufffdpayload")
+    );
+
+    const tool = createAdvisorTool(config);
+    const rawResult: unknown = await Promise.resolve(tool.execute!({}, mockToolCallOptions));
+
+    expect(typeof rawResult).toBe("object");
+    expect(rawResult).not.toBeNull();
+    const result = rawResult as { type?: unknown; isError?: unknown; message?: unknown };
+    expect(result.type).toBe("error");
+    expect(result.isError).toBe(true);
+    expect(result.message).toEqual(expect.stringContaining("Advisor request failed:"));
+    expect(result.message).toEqual(expect.stringContaining("nul=1"));
+    expect(JSON.stringify(rawResult)).not.toContain("\u0000");
+    expect(JSON.stringify(rawResult)).not.toContain("�");
+  });
+
   it("swallows synchronous usage reporting failures and logs them", async () => {
     using tempDir = new TestTempDir("advisor-tool-report-failure");
     const usage: LanguageModelV2Usage = {

--- a/src/node/services/tools/advisor.ts
+++ b/src/node/services/tools/advisor.ts
@@ -11,6 +11,7 @@ import type { ModelMessage } from "@/common/types/message";
 import { THINKING_LEVEL_OFF, coerceThinkingLevel } from "@/common/types/thinking";
 import { buildProviderOptions } from "@/common/utils/ai/providerOptions";
 import { getErrorMessage } from "@/common/utils/errors";
+import { sanitizeErrorMessageForDisplay } from "@/common/utils/providerOutputSanitization";
 import type { AdvisorPhaseEvent } from "@/common/types/stream";
 import { AdvisorToolInputSchema, TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
 import type { AdvisorToolCallSnapshot, ToolConfiguration } from "@/common/utils/tools/tools";
@@ -240,7 +241,7 @@ export function createAdvisorTool(config: ToolConfiguration): Tool {
         return {
           type: "error" as const,
           isError: true,
-          message: `Advisor request failed: ${getErrorMessage(error)}`,
+          message: `Advisor request failed: ${sanitizeErrorMessageForDisplay(getErrorMessage(error))}`,
         };
       }
     },

--- a/src/node/services/tools/imageArtifacts.ts
+++ b/src/node/services/tools/imageArtifacts.ts
@@ -6,6 +6,7 @@ import type { LanguageModelV2Usage } from "@ai-sdk/provider";
 import type { ToolConfiguration } from "@/common/utils/tools/tools";
 import { DEFAULT_IMAGE_GENERATION_MODEL } from "@/common/types/imageGeneration";
 import { getErrorMessage } from "@/common/utils/errors";
+import { sanitizeErrorMessageForDisplay } from "@/common/utils/providerOutputSanitization";
 import { shellQuote } from "@/common/utils/shell";
 import { log } from "@/node/services/log";
 import { getRasterImageDimensionsFromMetadata } from "@/node/utils/attachments/resizeRasterImageAttachment";
@@ -61,12 +62,14 @@ export function formatImageModelError(
       };
     case "unknown":
       return {
-        error: typeof record.raw === "string" ? record.raw : getErrorMessage(error),
+        error: sanitizeErrorMessageForDisplay(
+          typeof record.raw === "string" ? record.raw : getErrorMessage(error)
+        ),
         setupHint: "Check OpenAI provider credentials, billing, rate limits, and content policy.",
       };
     default:
       return {
-        error: getErrorMessage(error),
+        error: sanitizeErrorMessageForDisplay(getErrorMessage(error)),
         setupHint: "Check OpenAI provider credentials, billing, rate limits, and content policy.",
       };
   }

--- a/src/node/services/tools/image_edit.test.ts
+++ b/src/node/services/tools/image_edit.test.ts
@@ -420,6 +420,42 @@ describe("image_edit tool", () => {
     expect(result.error).toContain("provider exploded");
   });
 
+  test("sanitizes binary-like provider errors when image editing fails", async () => {
+    using workspaceDir = new TestTempDir("image-edit-workspace");
+    const sourcePath = path.join(workspaceDir.path, "source.png");
+    await fs.writeFile(sourcePath, testPngBytes);
+    const tool = createImageEditTool({
+      ...createImageEditTestConfig(workspaceDir.path),
+      imageEditingEnabled: true,
+      imageGenerationRuntime: {
+        modelString: "openai:gpt-image-1.5",
+        maxImagesPerCall: 2,
+        createImageModel: () =>
+          Promise.resolve(
+            Ok(
+              createMockImageModel(() =>
+                Promise.reject(new Error("Invalid JSON response: \u001b\u0000\ufffdpayload"))
+              )
+            )
+          ),
+      },
+    });
+
+    const result = (await tool.execute!(
+      { sourcePath, prompt: "Make it blue" },
+      createMockToolCallOptions()
+    )) as ImageEditToolResult;
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("Expected provider generation failure");
+    }
+    expect(result.error).toContain("Image editing failed:");
+    expect(result.error).toContain("nul=1");
+    expect(result.error).not.toContain("\u0000");
+    expect(result.error).not.toContain("�");
+  });
+
   test("does not write edited artifacts when output dimensions cannot be read", async () => {
     using workspaceDir = new TestTempDir("image-edit-workspace");
     const sourcePath = path.join(workspaceDir.path, "source.png");

--- a/src/node/services/tools/image_edit.ts
+++ b/src/node/services/tools/image_edit.ts
@@ -5,11 +5,9 @@ import { generateImage, tool } from "ai";
 import sharp from "sharp";
 
 import type { ImageEditToolResult } from "@/common/types/tools";
-import {
-  sanitizeImageToolErrorForModel,
-  stripImageToolOutputForModel,
-} from "@/common/utils/imageGenerationToolResult";
+import { stripImageToolOutputForModel } from "@/common/utils/imageGenerationToolResult";
 import { getErrorMessage } from "@/common/utils/errors";
+import { sanitizeErrorMessageForDisplay } from "@/common/utils/providerOutputSanitization";
 import { TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
 import type { ToolFactory } from "@/common/utils/tools/tools";
 import { LocalBaseRuntime } from "@/node/runtime/LocalBaseRuntime";
@@ -222,7 +220,7 @@ export const createImageEditTool: ToolFactory = (config) => {
       } catch (error) {
         return {
           success: false,
-          error: `Image editing failed: ${sanitizeImageToolErrorForModel(getErrorMessage(error))}`,
+          error: `Image editing failed: ${sanitizeErrorMessageForDisplay(getErrorMessage(error))}`,
           setupHint: "Check OpenAI provider credentials, billing, rate limits, and content policy.",
         } satisfies ImageEditToolResult;
       }

--- a/src/node/services/tools/image_generate.test.ts
+++ b/src/node/services/tools/image_generate.test.ts
@@ -248,6 +248,39 @@ describe("image_generate tool", () => {
     expect(result.setupHint).toContain(DEFAULT_IMAGE_GENERATION_MODEL);
   });
 
+  test("sanitizes binary-like provider errors when image generation fails", async () => {
+    using workspaceDir = new TestTempDir("image-generate-workspace");
+    const tool = createImageGenerateTool({
+      ...createTestToolConfig(workspaceDir.path),
+      imageGenerationRuntime: {
+        modelString: "openai:gpt-image-1.5",
+        maxImagesPerCall: 2,
+        createImageModel: () =>
+          Promise.resolve(
+            Ok(
+              createMockImageModel(() =>
+                Promise.reject(new Error("Invalid JSON response: \u001b\u0000\ufffdpayload"))
+              )
+            )
+          ),
+      },
+    });
+
+    const result = (await tool.execute!(
+      { prompt: "A small square" },
+      mockToolCallOptions
+    )) as ImageGenerateToolResult;
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("Expected provider generation failure");
+    }
+    expect(result.error).toContain("Image generation failed:");
+    expect(result.error).toContain("nul=1");
+    expect(result.error).not.toContain("\u0000");
+    expect(result.error).not.toContain("�");
+  });
+
   test("writes generated artifacts outside the stream temp directory", async () => {
     using workspaceDir = new TestTempDir("image-generate-workspace");
     const tool = createImageGenerateTool({

--- a/src/node/services/tools/image_generate.ts
+++ b/src/node/services/tools/image_generate.ts
@@ -3,11 +3,9 @@ import type { JSONValue } from "@ai-sdk/provider";
 import { generateImage, tool } from "ai";
 
 import type { ImageGenerateToolResult } from "@/common/types/tools";
-import {
-  sanitizeImageToolErrorForModel,
-  stripImageToolOutputForModel,
-} from "@/common/utils/imageGenerationToolResult";
+import { stripImageToolOutputForModel } from "@/common/utils/imageGenerationToolResult";
 import { getErrorMessage } from "@/common/utils/errors";
+import { sanitizeErrorMessageForDisplay } from "@/common/utils/providerOutputSanitization";
 import { TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
 import type { ToolFactory } from "@/common/utils/tools/tools";
 import {
@@ -113,7 +111,7 @@ export const createImageGenerateTool: ToolFactory = (config) => {
       } catch (error) {
         return {
           success: false,
-          error: `Image generation failed: ${sanitizeImageToolErrorForModel(getErrorMessage(error))}`,
+          error: `Image generation failed: ${sanitizeErrorMessageForDisplay(getErrorMessage(error))}`,
           setupHint: "Check OpenAI provider credentials, billing, rate limits, and content policy.",
         } satisfies ImageGenerateToolResult;
       }


### PR DESCRIPTION
## Summary

Sanitizes binary-like and oversized provider/tool error output before it is persisted or sent back to models, so failed image/advisor/provider calls cannot poison transcript history and break later advisor requests. Also preserves configured OpenAI base URLs when WebSocket transport is enabled and adds a diagnostic prototype for comparing official HTTP, SSE, AI SDK, and WebSocket Responses paths.

## Background

Advisor failures were reproducible when provider errors contained binary-looking response bodies. The investigation showed clean official OpenAI Responses calls can succeed, while Mux needed stronger containment around provider error strings and provider-bound historical tool output.

## Implementation

- Added shared provider output sanitization for binary-like strings and large strings.
- Applied sanitization to advisor errors, image generation/editing errors, image model setup errors, and provider-bound tool output redaction.
- Taught OpenAI WebSocket transport to receive a custom WebSocket URL derived from the resolved OpenAI base URL.
- Added a throwaway diagnostic probe under scripts/prototypes for reproducing Responses transport behavior.

## Validation

- make static-check
- bun test src/common/utils/providerOutputSanitization.test.ts src/browser/utils/messages/applyToolOutputRedaction.test.ts src/node/services/tools/advisor.test.ts src/node/services/tools/image_generate.test.ts src/node/services/tools/image_edit.test.ts src/node/services/openAIWebSocketTransportFetch.test.ts src/node/services/providerModelFactory.test.ts
- make lint
- make typecheck
- make fmt-check
- git diff --check

## Risks

Low-to-moderate. The sanitizer only changes provider-visible output and user-facing error strings for binary-like or oversized values; normal provider errors are preserved. WebSocket changes are scoped to passing the already-resolved OpenAI base URL through to the upstream WebSocket fetch.

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `1258387{MUX_COSTS_USD:-0}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=137.68 -->
