### PR TITLE
🤖 feat: move experiment settings inline

### DIFF
--- a/src/browser/contexts/RouterContext.tsx
+++ b/src/browser/contexts/RouterContext.tsx
@@ -30,7 +30,7 @@ export interface RouterContext {
     options?: { replace?: boolean }
   ) => void;
   navigateToHome: () => void;
-  navigateToSettings: (section?: string) => void;
+  navigateToSettings: (section?: string, options?: { replace?: boolean }) => void;
   navigateFromSettings: () => void;
   navigateToAnalytics: () => void;
   navigateFromAnalytics: () => void;
@@ -380,9 +380,11 @@ function RouterContextInner(props: { children: ReactNode }) {
     void navigateRef.current("/");
   }, []);
 
-  const navigateToSettings = useCallback((section?: string) => {
+  const navigateToSettings = useCallback((section?: string, options?: { replace?: boolean }) => {
     const nextSection = section ?? "general";
-    void navigateRef.current(`/settings/${encodeURIComponent(nextSection)}`);
+    void navigateRef.current(`/settings/${encodeURIComponent(nextSection)}`, {
+      replace: options?.replace === true,
+    });
   }, []);
 
   const navigateFromSettings = useCallback(() => {

--- a/src/browser/contexts/SettingsContext.tsx
+++ b/src/browser/contexts/SettingsContext.tsx
@@ -24,7 +24,7 @@ interface SettingsContextValue {
   activeSection: string;
   open: (section?: string, options?: OpenSettingsOptions) => void;
   close: () => void;
-  setActiveSection: (section: string) => void;
+  setActiveSection: (section: string, options?: { replace?: boolean }) => void;
 
   /** Subscribe to settings close events. Returns an unsubscribe function. */
   registerOnClose: (callback: () => void) => () => void;
@@ -116,7 +116,7 @@ export function SettingsProvider(props: { children: ReactNode }) {
   }, [router]);
 
   const setActiveSection = useCallback(
-    (section: string) => {
+    (section: string, options?: { replace?: boolean }) => {
       if (section !== "providers") {
         setProvidersExpandedProvider(null);
       }
@@ -127,7 +127,7 @@ export function SettingsProvider(props: { children: ReactNode }) {
       if (section !== "secrets") {
         setSecretsProjectPath(null);
       }
-      router.navigateToSettings(section);
+      router.navigateToSettings(section, options);
     },
     [router]
   );

--- a/src/browser/features/Settings/Sections/ExperimentsSection.stories.tsx
+++ b/src/browser/features/Settings/Sections/ExperimentsSection.stories.tsx
@@ -104,15 +104,20 @@ export const GoalAndHeartbeatSettingsEnabled: Story = {
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.findByLabelText("Default goal budget in dollars")).resolves.toHaveValue(
-      "3.50"
+    const budgetInput = await canvas.findByLabelText("Default goal budget in dollars");
+    await waitFor(() => expect(budgetInput).toHaveValue("3.50"));
+
+    const turnCapInput = await canvas.findByLabelText("Default goal turn cap");
+    await waitFor(() => expect(turnCapInput).toHaveValue(8));
+
+    const heartbeatThresholdInput = await canvas.findByLabelText(
+      "Default heartbeat threshold in minutes"
     );
-    await expect(canvas.findByLabelText("Default goal turn cap")).resolves.toHaveValue(8);
-    await expect(
-      canvas.findByLabelText("Default heartbeat threshold in minutes")
-    ).resolves.toHaveValue(45);
-    await expect(canvas.findByLabelText("Default heartbeat prompt")).resolves.toHaveValue(
-      "Review pending work before continuing."
+    await waitFor(() => expect(heartbeatThresholdInput).toHaveValue(45));
+
+    const heartbeatPrompt = await canvas.findByLabelText("Default heartbeat prompt");
+    await waitFor(() =>
+      expect(heartbeatPrompt).toHaveValue("Review pending work before continuing.")
     );
   },
 };

--- a/src/browser/features/Settings/Sections/ExperimentsSection.stories.tsx
+++ b/src/browser/features/Settings/Sections/ExperimentsSection.stories.tsx
@@ -2,6 +2,7 @@ import { expect, userEvent, waitFor, within } from "@storybook/test";
 import { lightweightMeta } from "@/browser/stories/meta.js";
 import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { DEFAULT_IMAGE_GENERATION_MODEL } from "@/common/types/imageGeneration";
+import { DEFAULT_GOAL_DEFAULTS } from "@/constants/goals";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { ExperimentsSection } from "./ExperimentsSection.js";
 import { SettingsSectionStory, setupSettingsStory } from "./settingsStoryUtils.js";
@@ -76,6 +77,43 @@ export const ImageGenerationEnabled: Story = {
     await userEvent.clear(maxImagesInput);
     await userEvent.type(maxImagesInput, "2");
     await waitFor(() => expect(maxImagesInput).toHaveValue("2"));
+  },
+};
+
+export const GoalAndHeartbeatSettingsEnabled: Story = {
+  render: () => (
+    <SettingsSectionStory
+      setup={() =>
+        setupSettingsStory({
+          experiments: {
+            [EXPERIMENT_IDS.GOALS]: true,
+            [EXPERIMENT_IDS.WORKSPACE_HEARTBEATS]: true,
+          },
+          goalDefaults: {
+            ...DEFAULT_GOAL_DEFAULTS,
+            defaultBudgetCents: 350,
+            defaultTurnCap: 8,
+          },
+          heartbeatDefaultIntervalMs: 45 * 60_000,
+          heartbeatDefaultPrompt: "Review pending work before continuing.",
+        })
+      }
+    >
+      <ExperimentsSection />
+    </SettingsSectionStory>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.findByLabelText("Default goal budget in dollars")).resolves.toHaveValue(
+      "3.50"
+    );
+    await expect(canvas.findByLabelText("Default goal turn cap")).resolves.toHaveValue(8);
+    await expect(
+      canvas.findByLabelText("Default heartbeat threshold in minutes")
+    ).resolves.toHaveValue(45);
+    await expect(canvas.findByLabelText("Default heartbeat prompt")).resolves.toHaveValue(
+      "Review pending work before continuing."
+    );
   },
 };
 

--- a/src/browser/features/Settings/Sections/ExperimentsSection.test.tsx
+++ b/src/browser/features/Settings/Sections/ExperimentsSection.test.tsx
@@ -13,6 +13,24 @@ interface MockApiClient {
   general: {
     restartApp: () => Promise<{ supported: true } | { supported: false; message: string }>;
   };
+  config?: {
+    getConfig: () => Promise<{
+      goalDefaults?: unknown;
+      heartbeatDefaultPrompt?: string;
+      heartbeatDefaultIntervalMs?: number;
+    }>;
+    updateGoalDefaults: (input: { goalDefaults: unknown }) => Promise<void>;
+    updateHeartbeatDefaultPrompt: (input: { defaultPrompt?: string | null }) => Promise<void>;
+    updateHeartbeatDefaultIntervalMs: (input: { intervalMs?: number | null }) => Promise<void>;
+  };
+  server?: {
+    setApiServerSettings: (input: {
+      bindHost: string | null;
+      port: number | null;
+      serveWebUi: boolean | null;
+    }) => Promise<unknown>;
+    getApiServerStatus: () => Promise<unknown>;
+  };
 }
 
 function createDeferred<T>() {
@@ -25,6 +43,7 @@ function createDeferred<T>() {
 
 let mockApi: MockApiClient;
 let experimentEnabled = false;
+let experimentValues: Record<string, boolean> = {};
 
 void mock.module("@/browser/contexts/API", () => ({
   useAPI: () => ({
@@ -37,10 +56,24 @@ void mock.module("@/browser/contexts/API", () => ({
 }));
 
 void mock.module("@/browser/contexts/ExperimentsContext", () => ({
-  useExperimentValue: () => experimentEnabled,
+  useExperiment: (experimentId: string) => [
+    experimentValues[experimentId] ?? experimentEnabled,
+    (enabled: boolean) => {
+      experimentValues[experimentId] = enabled;
+    },
+  ],
+  useExperimentValue: (experimentId: string) => experimentValues[experimentId] ?? experimentEnabled,
+  useRemoteExperimentValue: () => null,
 }));
 
-import { PortableDesktopExperimentWarning } from "./ExperimentsSection";
+void mock.module("@/browser/hooks/useTelemetry", () => ({
+  useTelemetry: () => ({
+    experimentOverridden: mock(() => undefined),
+  }),
+}));
+
+import { EXPERIMENT_IDS } from "@/common/constants/experiments";
+import { ExperimentsSection, PortableDesktopExperimentWarning } from "./ExperimentsSection";
 
 let originalWindow: typeof globalThis.window;
 let originalDocument: typeof globalThis.document;
@@ -88,12 +121,33 @@ describe("PortableDesktopExperimentWarning", () => {
 
     globalThis.window.api = { platform: "linux", versions: {} };
     experimentEnabled = true;
+    experimentValues = {};
     mockApi = {
       desktop: {
         getPrereqStatus: mock(() => Promise.resolve({ available: true as const })),
       },
       general: {
         restartApp: mock(() => Promise.resolve({ supported: true as const })),
+      },
+      config: {
+        getConfig: mock(() => Promise.resolve({})),
+        updateGoalDefaults: mock(() => Promise.resolve()),
+        updateHeartbeatDefaultPrompt: mock(() => Promise.resolve()),
+        updateHeartbeatDefaultIntervalMs: mock(() => Promise.resolve()),
+      },
+      server: {
+        setApiServerSettings: mock(() => Promise.resolve({})),
+        getApiServerStatus: mock(() =>
+          Promise.resolve({
+            running: false,
+            baseUrl: null,
+            token: null,
+            networkBaseUrls: [],
+            configuredBindHost: null,
+            configuredServeWebUi: false,
+            configuredPort: null,
+          })
+        ),
       },
     };
   });
@@ -111,6 +165,33 @@ describe("PortableDesktopExperimentWarning", () => {
     globalThis.clearTimeout = originalClearTimeout;
     globalThis.setInterval = originalSetInterval;
     globalThis.clearInterval = originalClearInterval;
+  });
+
+  test("shows goal and heartbeat defaults inline only when their experiments are enabled", async () => {
+    experimentEnabled = false;
+    experimentValues = {
+      [EXPERIMENT_IDS.GOALS]: false,
+      [EXPERIMENT_IDS.WORKSPACE_HEARTBEATS]: false,
+    };
+
+    const view = render(<ExperimentsSection />);
+
+    expect(view.queryByLabelText("Default goal budget in dollars")).toBeNull();
+    expect(view.queryByLabelText("Default heartbeat threshold in minutes")).toBeNull();
+
+    experimentValues = {
+      [EXPERIMENT_IDS.GOALS]: true,
+      [EXPERIMENT_IDS.WORKSPACE_HEARTBEATS]: true,
+    };
+    view.rerender(<ExperimentsSection />);
+
+    await waitFor(() => {
+      expect(view.getByLabelText("Default goal budget in dollars")).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(view.getByLabelText("Default heartbeat threshold in minutes")).toBeTruthy();
+    });
+    expect(mockApi.config?.getConfig).toHaveBeenCalledTimes(1);
   });
 
   test("loads prereq status on mount and shows the missing-binary warning when needed", async () => {

--- a/src/browser/features/Settings/Sections/ExperimentsSection.test.tsx
+++ b/src/browser/features/Settings/Sections/ExperimentsSection.test.tsx
@@ -231,6 +231,58 @@ describe("PortableDesktopExperimentWarning", () => {
     });
   });
 
+  test("starts a fresh settings load when the API client changes", async () => {
+    experimentEnabled = false;
+    experimentValues = {
+      [EXPERIMENT_IDS.GOALS]: true,
+      [EXPERIMENT_IDS.WORKSPACE_HEARTBEATS]: true,
+    };
+
+    const staleConfig = createDeferred<{
+      goalDefaults?: unknown;
+      heartbeatDefaultPrompt?: string;
+      heartbeatDefaultIntervalMs?: number;
+    }>();
+    const staleGetConfig = mock(() => staleConfig.promise);
+    mockApi = {
+      ...mockApi,
+      config: {
+        getConfig: staleGetConfig,
+        updateGoalDefaults: mock(() => Promise.resolve()),
+        updateHeartbeatDefaultPrompt: mock(() => Promise.resolve()),
+        updateHeartbeatDefaultIntervalMs: mock(() => Promise.resolve()),
+      },
+    };
+
+    const view = render(<ExperimentsSection />);
+
+    await waitFor(() => {
+      expect(staleGetConfig).toHaveBeenCalledTimes(1);
+    });
+
+    const freshConfig = createDeferred<{
+      goalDefaults?: unknown;
+      heartbeatDefaultPrompt?: string;
+      heartbeatDefaultIntervalMs?: number;
+    }>();
+    const freshGetConfig = mock(() => freshConfig.promise);
+    mockApi = {
+      ...mockApi,
+      config: {
+        getConfig: freshGetConfig,
+        updateGoalDefaults: mock(() => Promise.resolve()),
+        updateHeartbeatDefaultPrompt: mock(() => Promise.resolve()),
+        updateHeartbeatDefaultIntervalMs: mock(() => Promise.resolve()),
+      },
+    };
+
+    view.rerender(<ExperimentsSection />);
+
+    await waitFor(() => {
+      expect(freshGetConfig).toHaveBeenCalledTimes(1);
+    });
+  });
+
   test("loads prereq status on mount and shows the missing-binary warning when needed", async () => {
     const getPrereqStatus = mock(() =>
       Promise.resolve({ available: false as const, reason: "binary_not_found" as const })

--- a/src/browser/features/Settings/Sections/ExperimentsSection.test.tsx
+++ b/src/browser/features/Settings/Sections/ExperimentsSection.test.tsx
@@ -194,6 +194,43 @@ describe("PortableDesktopExperimentWarning", () => {
     expect(mockApi.config?.getConfig).toHaveBeenCalledTimes(1);
   });
 
+  test("reloads experiment settings when inline controls remount", async () => {
+    experimentEnabled = false;
+    experimentValues = {
+      [EXPERIMENT_IDS.GOALS]: true,
+      [EXPERIMENT_IDS.WORKSPACE_HEARTBEATS]: true,
+    };
+
+    const view = render(<ExperimentsSection />);
+
+    await waitFor(() => {
+      expect(view.getByLabelText("Default goal budget in dollars")).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(view.getByLabelText("Default heartbeat threshold in minutes")).toBeTruthy();
+    });
+    expect(mockApi.config?.getConfig).toHaveBeenCalledTimes(1);
+
+    experimentValues = {
+      [EXPERIMENT_IDS.GOALS]: false,
+      [EXPERIMENT_IDS.WORKSPACE_HEARTBEATS]: false,
+    };
+    view.rerender(<ExperimentsSection />);
+
+    expect(view.queryByLabelText("Default goal budget in dollars")).toBeNull();
+    expect(view.queryByLabelText("Default heartbeat threshold in minutes")).toBeNull();
+
+    experimentValues = {
+      [EXPERIMENT_IDS.GOALS]: true,
+      [EXPERIMENT_IDS.WORKSPACE_HEARTBEATS]: true,
+    };
+    view.rerender(<ExperimentsSection />);
+
+    await waitFor(() => {
+      expect(mockApi.config?.getConfig).toHaveBeenCalledTimes(2);
+    });
+  });
+
   test("loads prereq status on mount and shows the missing-binary warning when needed", async () => {
     const getPrereqStatus = mock(() =>
       Promise.resolve({ available: false as const, reason: "binary_not_found" as const })

--- a/src/browser/features/Settings/Sections/ExperimentsSection.tsx
+++ b/src/browser/features/Settings/Sections/ExperimentsSection.tsx
@@ -631,8 +631,25 @@ export function ExperimentsSection() {
       return Promise.reject(new Error("Cannot load settings config before API connection."));
     }
 
-    settingsConfigRequestRef.current ??= api.config.getConfig();
-    return settingsConfigRequestRef.current;
+    if (settingsConfigRequestRef.current) {
+      return settingsConfigRequestRef.current;
+    }
+
+    const request = api.config.getConfig();
+    settingsConfigRequestRef.current = request;
+    request.then(
+      () => {
+        if (settingsConfigRequestRef.current === request) {
+          settingsConfigRequestRef.current = null;
+        }
+      },
+      () => {
+        if (settingsConfigRequestRef.current === request) {
+          settingsConfigRequestRef.current = null;
+        }
+      }
+    );
+    return request;
   }, [api]);
 
   // Only show user-overridable experiments (non-overridable ones are hidden since users can't change them)

--- a/src/browser/features/Settings/Sections/ExperimentsSection.tsx
+++ b/src/browser/features/Settings/Sections/ExperimentsSection.tsx
@@ -25,12 +25,16 @@ import {
 } from "@/browser/components/SelectPrimitive/SelectPrimitive";
 import type { ApiServerStatus, DesktopPrereqStatus } from "@/common/orpc/types";
 import { Input } from "@/browser/components/Input/Input";
-import { useAPI } from "@/browser/contexts/API";
+import { useAPI, type APIClient } from "@/browser/contexts/API";
 import { useTelemetry } from "@/browser/hooks/useTelemetry";
 import { ImageGenerationExperimentConfig } from "./ImageGenerationExperimentConfig";
 import { AdvisorToolExperimentConfig } from "./AdvisorToolExperimentConfig";
+import { GoalDefaultsControls } from "./GoalsSection";
+import { HeartbeatDefaultsControls } from "./HeartbeatSection";
 
 const PORTABLE_DESKTOP_INSTALL_URL = "https://github.com/coder/portabledesktop";
+
+type SettingsConfig = Awaited<ReturnType<APIClient["config"]["getConfig"]>>;
 
 interface ExperimentRowProps {
   experimentId: ExperimentId;
@@ -601,11 +605,35 @@ function ConfigurableBindUrlControls() {
   );
 }
 
+interface ExperimentSettingsPanelProps {
+  children: React.ReactNode;
+}
+
+function ExperimentSettingsPanel(props: ExperimentSettingsPanelProps) {
+  return <div className="bg-background-secondary px-4 py-3">{props.children}</div>;
+}
+
 export function ExperimentsSection() {
   const allExperiments = getExperimentList();
   const { api } = useAPI();
   const advisorToolEnabled = useExperimentValue(EXPERIMENT_IDS.ADVISOR_TOOL);
   const imageGenerationToolEnabled = useExperimentValue(EXPERIMENT_IDS.IMAGE_GENERATION_TOOL);
+  const goalsEnabled = useExperimentValue(EXPERIMENT_IDS.GOALS);
+  const workspaceHeartbeatsEnabled = useExperimentValue(EXPERIMENT_IDS.WORKSPACE_HEARTBEATS);
+  const settingsConfigRequestRef = useRef<Promise<SettingsConfig> | null>(null);
+
+  useEffect(() => {
+    settingsConfigRequestRef.current = null;
+  }, [api]);
+
+  const loadExperimentSettingsConfig = useCallback(() => {
+    if (!api) {
+      return Promise.reject(new Error("Cannot load settings config before API connection."));
+    }
+
+    settingsConfigRequestRef.current ??= api.config.getConfig();
+    return settingsConfigRequestRef.current;
+  }, [api]);
 
   // Only show user-overridable experiments (non-overridable ones are hidden since users can't change them)
   const experiments = useMemo(
@@ -660,6 +688,20 @@ export function ExperimentsSection() {
               )}
               {exp.id === EXPERIMENT_IDS.IMAGE_GENERATION_TOOL && imageGenerationToolEnabled && (
                 <ImageGenerationExperimentConfig enabled={imageGenerationToolEnabled} />
+              )}
+              {exp.id === EXPERIMENT_IDS.WORKSPACE_HEARTBEATS && workspaceHeartbeatsEnabled && (
+                <ExperimentSettingsPanel>
+                  <HeartbeatDefaultsControls
+                    loadConfig={api ? loadExperimentSettingsConfig : undefined}
+                  />
+                </ExperimentSettingsPanel>
+              )}
+              {exp.id === EXPERIMENT_IDS.GOALS && goalsEnabled && (
+                <ExperimentSettingsPanel>
+                  <GoalDefaultsControls
+                    loadConfig={api ? loadExperimentSettingsConfig : undefined}
+                  />
+                </ExperimentSettingsPanel>
               )}
               {exp.id === EXPERIMENT_IDS.PORTABLE_DESKTOP && <PortableDesktopExperimentWarning />}
               {exp.id === EXPERIMENT_IDS.CONFIGURABLE_BIND_URL && <ConfigurableBindUrlControls />}

--- a/src/browser/features/Settings/Sections/ExperimentsSection.tsx
+++ b/src/browser/features/Settings/Sections/ExperimentsSection.tsx
@@ -620,7 +620,10 @@ export function ExperimentsSection() {
   const imageGenerationToolEnabled = useExperimentValue(EXPERIMENT_IDS.IMAGE_GENERATION_TOOL);
   const goalsEnabled = useExperimentValue(EXPERIMENT_IDS.GOALS);
   const workspaceHeartbeatsEnabled = useExperimentValue(EXPERIMENT_IDS.WORKSPACE_HEARTBEATS);
-  const settingsConfigRequestRef = useRef<Promise<SettingsConfig> | null>(null);
+  const settingsConfigRequestRef = useRef<{
+    api: APIClient;
+    request: Promise<SettingsConfig>;
+  } | null>(null);
 
   useEffect(() => {
     settingsConfigRequestRef.current = null;
@@ -631,20 +634,21 @@ export function ExperimentsSection() {
       return Promise.reject(new Error("Cannot load settings config before API connection."));
     }
 
-    if (settingsConfigRequestRef.current) {
-      return settingsConfigRequestRef.current;
+    const cachedRequest = settingsConfigRequestRef.current;
+    if (cachedRequest?.api === api) {
+      return cachedRequest.request;
     }
 
     const request = api.config.getConfig();
-    settingsConfigRequestRef.current = request;
+    settingsConfigRequestRef.current = { api, request };
     request.then(
       () => {
-        if (settingsConfigRequestRef.current === request) {
+        if (settingsConfigRequestRef.current?.request === request) {
           settingsConfigRequestRef.current = null;
         }
       },
       () => {
-        if (settingsConfigRequestRef.current === request) {
+        if (settingsConfigRequestRef.current?.request === request) {
           settingsConfigRequestRef.current = null;
         }
       }

--- a/src/browser/features/Settings/Sections/GoalsSection.tsx
+++ b/src/browser/features/Settings/Sections/GoalsSection.tsx
@@ -24,8 +24,13 @@ function parseTurnCap(value: string): number | null {
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
-export function GoalsSection() {
+interface GoalDefaultsControlsProps {
+  loadConfig?: () => Promise<{ goalDefaults?: Partial<GoalDefaults> | null }>;
+}
+
+export function GoalDefaultsControls(props: GoalDefaultsControlsProps) {
   const { api } = useAPI();
+  const loadConfig = props.loadConfig;
   const [goalDefaults, setGoalDefaults] = useState<GoalDefaults>(() => ({
     ...DEFAULT_GOAL_DEFAULTS,
   }));
@@ -35,12 +40,12 @@ export function GoalsSection() {
   const [turnCapDraft, setTurnCapDraft] = useState("");
 
   useEffect(() => {
-    if (!api?.config?.getConfig) {
+    const configPromise = loadConfig?.() ?? api?.config?.getConfig();
+    if (!configPromise) {
       return;
     }
 
-    void api.config
-      .getConfig()
+    void configPromise
       .then((config) => {
         const defaults = normalizeGoalDefaults(config.goalDefaults);
         setGoalDefaults(defaults);
@@ -50,7 +55,7 @@ export function GoalsSection() {
       .catch(() => {
         // Keep defaults editable if config loading fails; a later edit can still persist.
       });
-  }, [api]);
+  }, [api, loadConfig]);
 
   const persistGoalDefaults = (next: GoalDefaults) => {
     const normalized = normalizeGoalDefaults(next);
@@ -72,6 +77,79 @@ export function GoalsSection() {
   };
 
   return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-4">
+        <label htmlFor="goal-default-budget" className="min-w-0 flex-1">
+          <div className="text-foreground text-sm font-medium">Default goal budget</div>
+          <div className="text-muted mt-0.5 text-xs">
+            Applied to new goals when no budget flag is provided. Use $0.00 for no dollar limit.
+          </div>
+        </label>
+        <div className="flex items-center gap-1">
+          <span className="text-muted text-sm">$</span>
+          <Input
+            id="goal-default-budget"
+            aria-label="Default goal budget in dollars"
+            type="text"
+            inputMode="decimal"
+            value={budgetDraft}
+            onChange={(event) => setBudgetDraft(event.target.value)}
+            onBlur={(event) => saveBudget(event.currentTarget.value)}
+            className="border-border-medium bg-background-secondary h-9 w-24 text-right"
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between gap-4">
+        <label htmlFor="goal-default-turn-cap" className="min-w-0 flex-1">
+          <div className="text-foreground text-sm font-medium">Default turn cap</div>
+          <div className="text-muted mt-0.5 text-xs">
+            Leave empty to disable the turn cap for new goals.
+          </div>
+        </label>
+        <Input
+          id="goal-default-turn-cap"
+          aria-label="Default goal turn cap"
+          type="number"
+          inputMode="numeric"
+          min={1}
+          step={1}
+          value={turnCapDraft}
+          onChange={(event) => setTurnCapDraft(event.target.value)}
+          onBlur={(event) => saveTurnCap(event.currentTarget.value)}
+          className="border-border-medium bg-background-secondary h-9 w-24 text-right"
+        />
+      </div>
+
+      <label className="flex items-start justify-between gap-4">
+        <span className="min-w-0 flex-1">
+          <span className="text-foreground block text-sm font-medium">
+            Always require explicit budget
+          </span>
+          <span className="text-muted mt-0.5 block text-xs">
+            When enabled, omitted budgets use the default budget instead of creating unbudgeted
+            goals.
+          </span>
+        </span>
+        <input
+          aria-label="Always require explicit budget"
+          type="checkbox"
+          checked={goalDefaults.alwaysRequireExplicitBudget}
+          onChange={(event) =>
+            persistGoalDefaults({
+              ...goalDefaults,
+              alwaysRequireExplicitBudget: event.target.checked,
+            })
+          }
+          className="accent-accent mt-1 h-4 w-4"
+        />
+      </label>
+    </div>
+  );
+}
+
+export function GoalsSection() {
+  return (
     <div className="space-y-6">
       <div>
         <h2 className="text-foreground mb-2 text-lg font-semibold">Goals</h2>
@@ -84,74 +162,7 @@ export function GoalsSection() {
           <Target className="h-4 w-4" aria-hidden="true" />
           Goal defaults
         </div>
-        <div className="space-y-4">
-          <div className="flex items-center justify-between gap-4">
-            <label htmlFor="goal-default-budget" className="min-w-0 flex-1">
-              <div className="text-foreground text-sm font-medium">Default goal budget</div>
-              <div className="text-muted mt-0.5 text-xs">
-                Applied to new goals when no budget flag is provided. Use $0.00 for no dollar limit.
-              </div>
-            </label>
-            <div className="flex items-center gap-1">
-              <span className="text-muted text-sm">$</span>
-              <Input
-                id="goal-default-budget"
-                aria-label="Default goal budget in dollars"
-                type="text"
-                inputMode="decimal"
-                value={budgetDraft}
-                onChange={(event) => setBudgetDraft(event.target.value)}
-                onBlur={(event) => saveBudget(event.currentTarget.value)}
-                className="border-border-medium bg-background-secondary h-9 w-24 text-right"
-              />
-            </div>
-          </div>
-
-          <div className="flex items-center justify-between gap-4">
-            <label htmlFor="goal-default-turn-cap" className="min-w-0 flex-1">
-              <div className="text-foreground text-sm font-medium">Default turn cap</div>
-              <div className="text-muted mt-0.5 text-xs">
-                Leave empty to disable the turn cap for new goals.
-              </div>
-            </label>
-            <Input
-              id="goal-default-turn-cap"
-              aria-label="Default goal turn cap"
-              type="number"
-              inputMode="numeric"
-              min={1}
-              step={1}
-              value={turnCapDraft}
-              onChange={(event) => setTurnCapDraft(event.target.value)}
-              onBlur={(event) => saveTurnCap(event.currentTarget.value)}
-              className="border-border-medium bg-background-secondary h-9 w-24 text-right"
-            />
-          </div>
-
-          <label className="flex items-start justify-between gap-4">
-            <span className="min-w-0 flex-1">
-              <span className="text-foreground block text-sm font-medium">
-                Always require explicit budget
-              </span>
-              <span className="text-muted mt-0.5 block text-xs">
-                When enabled, omitted budgets use the default budget instead of creating unbudgeted
-                goals.
-              </span>
-            </span>
-            <input
-              aria-label="Always require explicit budget"
-              type="checkbox"
-              checked={goalDefaults.alwaysRequireExplicitBudget}
-              onChange={(event) =>
-                persistGoalDefaults({
-                  ...goalDefaults,
-                  alwaysRequireExplicitBudget: event.target.checked,
-                })
-              }
-              className="accent-accent mt-1 h-4 w-4"
-            />
-          </label>
-        </div>
+        <GoalDefaultsControls />
       </div>
     </div>
   );

--- a/src/browser/features/Settings/Sections/HeartbeatSection.tsx
+++ b/src/browser/features/Settings/Sections/HeartbeatSection.tsx
@@ -15,8 +15,16 @@ import {
   HEARTBEAT_DEFAULT_MESSAGE_BODY,
 } from "@/constants/heartbeat";
 
-export function HeartbeatSection() {
+interface HeartbeatDefaultsControlsProps {
+  loadConfig?: () => Promise<{
+    heartbeatDefaultPrompt?: string;
+    heartbeatDefaultIntervalMs?: number;
+  }>;
+}
+
+export function HeartbeatDefaultsControls(props: HeartbeatDefaultsControlsProps) {
   const { api } = useAPI();
+  const loadConfig = props.loadConfig;
   const [heartbeatDefaultPrompt, setHeartbeatDefaultPrompt] = useState("");
   const [heartbeatDefaultPromptLoaded, setHeartbeatDefaultPromptLoaded] = useState(false);
   const [heartbeatDefaultPromptLoadedOk, setHeartbeatDefaultPromptLoadedOk] = useState(false);
@@ -33,7 +41,8 @@ export function HeartbeatSection() {
   const heartbeatDefaultIntervalEditedSinceLoadRef = useRef(false);
 
   useEffect(() => {
-    if (!api) {
+    const configPromise = loadConfig?.() ?? api?.config?.getConfig();
+    if (!configPromise) {
       return;
     }
 
@@ -47,8 +56,7 @@ export function HeartbeatSection() {
     const heartbeatDefaultPromptNonce = ++heartbeatDefaultPromptLoadNonceRef.current;
     const heartbeatDefaultIntervalNonce = ++heartbeatDefaultIntervalLoadNonceRef.current;
 
-    void api.config
-      .getConfig()
+    void configPromise
       .then((cfg) => {
         if (heartbeatDefaultPromptNonce === heartbeatDefaultPromptLoadNonceRef.current) {
           setHeartbeatDefaultPrompt(cfg.heartbeatDefaultPrompt ?? "");
@@ -77,7 +85,7 @@ export function HeartbeatSection() {
           setHeartbeatDefaultIntervalLoaded(true);
         }
       });
-  }, [api]);
+  }, [api, loadConfig]);
 
   const handleHeartbeatDefaultPromptBlur = useCallback(() => {
     if (!heartbeatDefaultPromptLoaded || !api?.config?.updateHeartbeatDefaultPrompt) {
@@ -166,7 +174,6 @@ export function HeartbeatSection() {
 
   return (
     <div className="flex flex-col gap-6">
-      {/* Keep global heartbeat defaults grouped together so General stays focused on app basics. */}
       <div>
         <div className="flex items-center justify-between gap-4">
           <label htmlFor="heartbeat-default-threshold" className="min-w-0 flex-1">
@@ -224,4 +231,8 @@ export function HeartbeatSection() {
       </div>
     </div>
   );
+}
+
+export function HeartbeatSection() {
+  return <HeartbeatDefaultsControls />;
 }

--- a/src/browser/features/Settings/Sections/settingsStoryUtils.tsx
+++ b/src/browser/features/Settings/Sections/settingsStoryUtils.tsx
@@ -20,6 +20,7 @@ import type { AgentAiDefaults } from "@/common/types/agentAiDefaults";
 import type { ProjectConfig } from "@/common/types/project";
 import type { ImageGenerationConfig } from "@/common/types/imageGeneration";
 import type { TaskSettings } from "@/common/types/tasks";
+import type { GoalDefaults } from "@/constants/goals";
 import type { LayoutPresetsConfig } from "@/common/types/uiLayouts";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 
@@ -110,6 +111,12 @@ interface SetupSettingsStoryOptions {
   taskSettings?: Partial<TaskSettings>;
   /** Initial image generation config for config.getConfig */
   imageGeneration?: Partial<ImageGenerationConfig>;
+  /** Initial global heartbeat default prompt for config.getConfig */
+  heartbeatDefaultPrompt?: string;
+  /** Initial global heartbeat default interval for config.getConfig */
+  heartbeatDefaultIntervalMs?: number;
+  /** Initial global goal defaults for config.getConfig */
+  goalDefaults?: GoalDefaults;
   /** Sessions shown in Settings → Server Access. */
   serverAuthSessions?: ServerAuthSession[];
   /** Pre-set experiment states in localStorage before render */
@@ -136,6 +143,9 @@ export function setupSettingsStory(options: SetupSettingsStoryOptions): APIClien
     agentAiDefaults: options.agentAiDefaults,
     providersList: options.providersList ?? ["anthropic", "openai", "xai"],
     imageGeneration: options.imageGeneration,
+    heartbeatDefaultPrompt: options.heartbeatDefaultPrompt,
+    heartbeatDefaultIntervalMs: options.heartbeatDefaultIntervalMs,
+    goalDefaults: options.goalDefaults,
     taskSettings: options.taskSettings,
     serverAuthSessions: options.serverAuthSessions,
     layoutPresets: options.layoutPresets,

--- a/src/browser/features/Settings/SettingsPage.test.tsx
+++ b/src/browser/features/Settings/SettingsPage.test.tsx
@@ -1,110 +1,24 @@
-import { cleanup, render, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
-import { ThemeProvider } from "@/browser/contexts/ThemeContext";
-import { installDom } from "../../../../tests/ui/dom";
-
-let activeSection = "general";
-let setActiveSection = mock((section: string, _options?: { replace?: boolean }) => {
-  activeSection = section;
-});
-const close = mock(() => undefined);
-const toggleLeftSidebar = mock(() => undefined);
-
-void mock.module("@/browser/contexts/SettingsContext", () => ({
-  useSettings: () => ({
-    close,
-    activeSection,
-    setActiveSection,
-  }),
-}));
-
-void mock.module("@/browser/features/SplashScreens/SplashScreenProvider", () => ({
-  useOnboardingPause: () => ({ paused: false }),
-}));
-
-const apiMethod = mock(() => Promise.resolve({}));
-
-function createApiSection() {
-  return new Proxy(
-    {},
-    {
-      get: () => apiMethod,
-    }
-  );
-}
-
-void mock.module("@/browser/contexts/API", () => ({
-  useAPI: () => ({
-    api: {
-      config: createApiSection(),
-      providers: createApiSection(),
-      general: createApiSection(),
-      server: createApiSection(),
-      projects: createApiSection(),
-    },
-    status: "connected" as const,
-    error: null,
-    authenticate: () => undefined,
-    retry: () => undefined,
-  }),
-}));
-
-void mock.module("@/browser/hooks/useExperiments", () => ({
-  useExperimentValue: () => true,
-}));
-
-import { SettingsPage } from "./SettingsPage";
-
-function renderSettingsPage() {
-  return render(
-    <ThemeProvider forcedTheme="dark">
-      <SettingsPage leftSidebarCollapsed={false} onToggleLeftSidebarCollapsed={toggleLeftSidebar} />
-    </ThemeProvider>
-  );
-}
+import { getSettingsSectionRedirect, getSettingsSections } from "./SettingsPage";
 
 describe("SettingsPage", () => {
-  let cleanupDom: (() => void) | null = null;
+  test("keeps Goals and Heartbeat out of settings navigation", () => {
+    const labels = getSettingsSections(true).map((section) => section.label);
 
-  beforeEach(() => {
-    cleanupDom = installDom();
-    activeSection = "general";
-    setActiveSection = mock((section: string, _options?: { replace?: boolean }) => {
-      activeSection = section;
+    expect(labels).not.toContain("Goals");
+    expect(labels).not.toContain("Heartbeat");
+    expect(labels).toContain("Experiments");
+  });
+
+  test("normalizes stale Goals and Heartbeat routes to Experiments with replace navigation", () => {
+    expect(getSettingsSectionRedirect("goals", true)).toEqual({
+      section: "experiments",
+      replace: true,
     });
-  });
-
-  afterEach(() => {
-    cleanup();
-    mock.restore();
-    cleanupDom?.();
-    cleanupDom = null;
-  });
-
-  test("keeps Goals and Heartbeat out of settings navigation when their experiments are enabled", () => {
-    const view = renderSettingsPage();
-
-    expect(view.queryByRole("button", { name: "Goals" })).toBeNull();
-    expect(view.queryByRole("button", { name: "Heartbeat" })).toBeNull();
-    expect(view.getAllByRole("button", { name: "Experiments" }).length).toBeGreaterThan(0);
-  });
-
-  test("normalizes stale Goals and Heartbeat routes to Experiments", async () => {
-    activeSection = "goals";
-    const view = renderSettingsPage();
-
-    await waitFor(() => {
-      expect(setActiveSection).toHaveBeenCalledWith("experiments", { replace: true });
-    });
-
-    view.unmount();
-    setActiveSection.mockClear();
-    activeSection = "heartbeat";
-    renderSettingsPage();
-
-    await waitFor(() => {
-      expect(setActiveSection).toHaveBeenCalledWith("experiments", { replace: true });
+    expect(getSettingsSectionRedirect("heartbeat", true)).toEqual({
+      section: "experiments",
+      replace: true,
     });
   });
 });

--- a/src/browser/features/Settings/SettingsPage.test.tsx
+++ b/src/browser/features/Settings/SettingsPage.test.tsx
@@ -5,7 +5,7 @@ import { ThemeProvider } from "@/browser/contexts/ThemeContext";
 import { installDom } from "../../../../tests/ui/dom";
 
 let activeSection = "general";
-let setActiveSection = mock((section: string) => {
+let setActiveSection = mock((section: string, _options?: { replace?: boolean }) => {
   activeSection = section;
 });
 const close = mock(() => undefined);
@@ -70,7 +70,7 @@ describe("SettingsPage", () => {
   beforeEach(() => {
     cleanupDom = installDom();
     activeSection = "general";
-    setActiveSection = mock((section: string) => {
+    setActiveSection = mock((section: string, _options?: { replace?: boolean }) => {
       activeSection = section;
     });
   });
@@ -95,7 +95,7 @@ describe("SettingsPage", () => {
     const view = renderSettingsPage();
 
     await waitFor(() => {
-      expect(setActiveSection).toHaveBeenCalledWith("experiments");
+      expect(setActiveSection).toHaveBeenCalledWith("experiments", { replace: true });
     });
 
     view.unmount();
@@ -104,7 +104,7 @@ describe("SettingsPage", () => {
     renderSettingsPage();
 
     await waitFor(() => {
-      expect(setActiveSection).toHaveBeenCalledWith("experiments");
+      expect(setActiveSection).toHaveBeenCalledWith("experiments", { replace: true });
     });
   });
 });

--- a/src/browser/features/Settings/SettingsPage.test.tsx
+++ b/src/browser/features/Settings/SettingsPage.test.tsx
@@ -1,0 +1,110 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { ThemeProvider } from "@/browser/contexts/ThemeContext";
+import { installDom } from "../../../../tests/ui/dom";
+
+let activeSection = "general";
+let setActiveSection = mock((section: string) => {
+  activeSection = section;
+});
+const close = mock(() => undefined);
+const toggleLeftSidebar = mock(() => undefined);
+
+void mock.module("@/browser/contexts/SettingsContext", () => ({
+  useSettings: () => ({
+    close,
+    activeSection,
+    setActiveSection,
+  }),
+}));
+
+void mock.module("@/browser/features/SplashScreens/SplashScreenProvider", () => ({
+  useOnboardingPause: () => ({ paused: false }),
+}));
+
+const apiMethod = mock(() => Promise.resolve({}));
+
+function createApiSection() {
+  return new Proxy(
+    {},
+    {
+      get: () => apiMethod,
+    }
+  );
+}
+
+void mock.module("@/browser/contexts/API", () => ({
+  useAPI: () => ({
+    api: {
+      config: createApiSection(),
+      providers: createApiSection(),
+      general: createApiSection(),
+      server: createApiSection(),
+      projects: createApiSection(),
+    },
+    status: "connected" as const,
+    error: null,
+    authenticate: () => undefined,
+    retry: () => undefined,
+  }),
+}));
+
+void mock.module("@/browser/hooks/useExperiments", () => ({
+  useExperimentValue: () => true,
+}));
+
+import { SettingsPage } from "./SettingsPage";
+
+function renderSettingsPage() {
+  return render(
+    <ThemeProvider forcedTheme="dark">
+      <SettingsPage leftSidebarCollapsed={false} onToggleLeftSidebarCollapsed={toggleLeftSidebar} />
+    </ThemeProvider>
+  );
+}
+
+describe("SettingsPage", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installDom();
+    activeSection = "general";
+    setActiveSection = mock((section: string) => {
+      activeSection = section;
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    mock.restore();
+    cleanupDom?.();
+    cleanupDom = null;
+  });
+
+  test("keeps Goals and Heartbeat out of settings navigation when their experiments are enabled", () => {
+    const view = renderSettingsPage();
+
+    expect(view.queryByRole("button", { name: "Goals" })).toBeNull();
+    expect(view.queryByRole("button", { name: "Heartbeat" })).toBeNull();
+    expect(view.getAllByRole("button", { name: "Experiments" }).length).toBeGreaterThan(0);
+  });
+
+  test("normalizes stale Goals and Heartbeat routes to Experiments", async () => {
+    activeSection = "goals";
+    const view = renderSettingsPage();
+
+    await waitFor(() => {
+      expect(setActiveSection).toHaveBeenCalledWith("experiments");
+    });
+
+    view.unmount();
+    setActiveSection.mockClear();
+    activeSection = "heartbeat";
+    renderSettingsPage();
+
+    await waitFor(() => {
+      expect(setActiveSection).toHaveBeenCalledWith("experiments");
+    });
+  });
+});

--- a/src/browser/features/Settings/SettingsPage.tsx
+++ b/src/browser/features/Settings/SettingsPage.tsx
@@ -114,6 +114,42 @@ const BASE_SECTIONS: SettingsSection[] = [
   },
 ];
 
+interface SettingsSectionRedirect {
+  section: string;
+  replace?: boolean;
+}
+
+export function getSettingsSections(governorEnabled: boolean): SettingsSection[] {
+  if (!governorEnabled) {
+    return BASE_SECTIONS;
+  }
+
+  return [
+    ...BASE_SECTIONS,
+    {
+      id: "governor",
+      label: "Governor",
+      icon: <ShieldCheck className="h-4 w-4" />,
+      component: GovernorSection,
+    },
+  ];
+}
+
+export function getSettingsSectionRedirect(
+  activeSection: string,
+  governorEnabled: boolean
+): SettingsSectionRedirect | null {
+  if (LEGACY_EXPERIMENT_SETTINGS_SECTION_IDS.has(activeSection)) {
+    return { section: "experiments", replace: true };
+  }
+
+  if (!governorEnabled && activeSection === "governor") {
+    return { section: BASE_SECTIONS[0]?.id ?? "general" };
+  }
+
+  return null;
+}
+
 interface SettingsPageProps {
   leftSidebarCollapsed: boolean;
   onToggleLeftSidebarCollapsed: () => void;
@@ -126,13 +162,17 @@ export function SettingsPage(props: SettingsPageProps) {
 
   // Keep routing on a valid section when experiment-owned settings move or disappear.
   useEffect(() => {
-    if (LEGACY_EXPERIMENT_SETTINGS_SECTION_IDS.has(activeSection)) {
-      setActiveSection("experiments", { replace: true });
+    const redirect = getSettingsSectionRedirect(activeSection, governorEnabled);
+    if (!redirect) {
       return;
     }
-    if (!governorEnabled && activeSection === "governor") {
-      setActiveSection(BASE_SECTIONS[0]?.id ?? "general");
+
+    if (redirect.replace) {
+      setActiveSection(redirect.section, { replace: true });
+      return;
     }
+
+    setActiveSection(redirect.section);
   }, [activeSection, setActiveSection, governorEnabled]);
 
   // Close settings on Escape. Uses bubble phase so inner surfaces (Select dropdowns,
@@ -152,18 +192,7 @@ export function SettingsPage(props: SettingsPageProps) {
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [close]);
-  let sections: SettingsSection[] = BASE_SECTIONS;
-  if (governorEnabled) {
-    sections = [
-      ...sections,
-      {
-        id: "governor",
-        label: "Governor",
-        icon: <ShieldCheck className="h-4 w-4" />,
-        component: GovernorSection,
-      },
-    ];
-  }
+  const sections = getSettingsSections(governorEnabled);
   const currentSection = sections.find((section) => section.id === activeSection) ?? sections[0];
   const SectionComponent = currentSection.component;
 

--- a/src/browser/features/Settings/SettingsPage.tsx
+++ b/src/browser/features/Settings/SettingsPage.tsx
@@ -15,8 +15,6 @@ import {
   ShieldCheck,
   Server,
   Lock,
-  HeartPulse,
-  Target,
 } from "lucide-react";
 import { useSettings } from "@/browser/contexts/SettingsContext";
 import { useOnboardingPause } from "@/browser/features/SplashScreens/SplashScreenProvider";
@@ -37,9 +35,9 @@ import { ExperimentsSection } from "./Sections/ExperimentsSection";
 import { ServerAccessSection } from "./Sections/ServerAccessSection";
 import { KeybindsSection } from "./Sections/KeybindsSection";
 import { SecuritySection } from "./Sections/SecuritySection";
-import { HeartbeatSection } from "./Sections/HeartbeatSection";
-import { GoalsSection } from "./Sections/GoalsSection";
 import type { SettingsSection } from "./types";
+
+const LEGACY_EXPERIMENT_SETTINGS_SECTION_IDS = new Set(["goals", "heartbeat"]);
 
 const BASE_SECTIONS: SettingsSection[] = [
   {
@@ -125,21 +123,17 @@ export function SettingsPage(props: SettingsPageProps) {
   const { close, activeSection, setActiveSection } = useSettings();
   const onboardingPause = useOnboardingPause();
   const governorEnabled = useExperimentValue(EXPERIMENT_IDS.MUX_GOVERNOR);
-  const workspaceHeartbeatsEnabled = useExperimentValue(EXPERIMENT_IDS.WORKSPACE_HEARTBEATS);
-  const goalsEnabled = useExperimentValue(EXPERIMENT_IDS.GOALS);
 
-  // Keep routing on a valid section when an experiment-gated section is disabled.
+  // Keep routing on a valid section when experiment-owned settings move or disappear.
   useEffect(() => {
+    if (LEGACY_EXPERIMENT_SETTINGS_SECTION_IDS.has(activeSection)) {
+      setActiveSection("experiments");
+      return;
+    }
     if (!governorEnabled && activeSection === "governor") {
       setActiveSection(BASE_SECTIONS[0]?.id ?? "general");
     }
-    if (!workspaceHeartbeatsEnabled && activeSection === "heartbeat") {
-      setActiveSection(BASE_SECTIONS[0]?.id ?? "general");
-    }
-    if (!goalsEnabled && activeSection === "goals") {
-      setActiveSection(BASE_SECTIONS[0]?.id ?? "general");
-    }
-  }, [activeSection, setActiveSection, governorEnabled, workspaceHeartbeatsEnabled, goalsEnabled]);
+  }, [activeSection, setActiveSection, governorEnabled]);
 
   // Close settings on Escape. Uses bubble phase so inner surfaces (Select dropdowns,
   // Popover, Dialog) that call stopPropagation/preventDefault on Escape get first
@@ -170,29 +164,6 @@ export function SettingsPage(props: SettingsPageProps) {
       },
     ];
   }
-  if (goalsEnabled) {
-    sections = [
-      ...sections,
-      {
-        id: "goals",
-        label: "Goals",
-        icon: <Target className="h-4 w-4" />,
-        component: GoalsSection,
-      },
-    ];
-  }
-  if (workspaceHeartbeatsEnabled) {
-    sections = [
-      ...sections,
-      {
-        id: "heartbeat",
-        label: "Heartbeat",
-        icon: <HeartPulse className="h-4 w-4" />,
-        component: HeartbeatSection,
-      },
-    ];
-  }
-
   const currentSection = sections.find((section) => section.id === activeSection) ?? sections[0];
   const SectionComponent = currentSection.component;
 

--- a/src/browser/features/Settings/SettingsPage.tsx
+++ b/src/browser/features/Settings/SettingsPage.tsx
@@ -127,7 +127,7 @@ export function SettingsPage(props: SettingsPageProps) {
   // Keep routing on a valid section when experiment-owned settings move or disappear.
   useEffect(() => {
     if (LEGACY_EXPERIMENT_SETTINGS_SECTION_IDS.has(activeSection)) {
-      setActiveSection("experiments");
+      setActiveSection("experiments", { replace: true });
       return;
     }
     if (!governorEnabled && activeSection === "governor") {


### PR DESCRIPTION
## Summary

Moves the Goals and Workspace Heartbeats configuration panels into Settings → Experiments so each feature's defaults appear inline only when its experiment is enabled.

## Background

Goals and Heartbeat were experiment-owned features but still added standalone Settings sidebar entries. This consolidates those controls under the existing experiment rows and keeps stale settings routes from landing on mismatched content.

## Implementation

- Extracted reusable Goals and Heartbeat defaults controls for inline rendering.
- Rendered those controls under their matching Experiments rows when enabled.
- Removed standalone Goals/Heartbeat sidebar entries and normalized legacy `/settings/goals` and `/settings/heartbeat` sections to Experiments.
- Added tests and Storybook coverage for inline controls and navigation behavior.

## Validation

- `bun test src/browser/features/Settings/Sections/GoalsSection.test.tsx src/browser/features/Settings/Sections/HeartbeatSection.test.tsx src/browser/features/Settings/Sections/ExperimentsSection.test.tsx src/browser/features/Settings/Sections/ExperimentsSection.advisor.test.tsx src/browser/features/Settings/SettingsPage.test.tsx`
- `make typecheck`
- `make lint`
- `make static-check`
- Dogfooded with an isolated dev-server sandbox and agent-browser screenshots/video for sidebar removal, inline controls, persistence, toggle visibility, and stale route normalization.

## Risks

Low. The change is scoped to Settings UI composition and preserves the existing config APIs/update paths for goal and heartbeat defaults.

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Move Goals and Heartbeat settings into Experiments

## Goal

Move the standalone **Goals** and **Heartbeat** Settings sidebar tabs into the **Experiments** page so they behave like the other experiment-owned configuration panels:

- Keep the existing `Goals` and `Workspace Heartbeats` experiment toggles in Settings → Experiments.
- Show each feature's configuration controls inline under its experiment row when that experiment is enabled.
- Remove `Goals` and `Heartbeat` from the Settings sidebar, even when their experiments are enabled.
- Preserve the existing config values, persistence APIs, labels, and feature behavior.

## Evidence gathered

Read-only exploration verified these repo facts:

- `src/browser/features/Settings/SettingsPage.tsx`
  - `BASE_SECTIONS` already includes `experiments` and `keybinds`.
  - `Goals` and `Heartbeat` are appended dynamically when `EXPERIMENT_IDS.GOALS` and `EXPERIMENT_IDS.WORKSPACE_HEARTBEATS` are enabled.
  - Current route guard redirects disabled `goals` / `heartbeat` sections to `general`; after removing the tabs, stale `/settings/goals` and `/settings/heartbeat` routes still need explicit handling.
- `src/browser/features/Settings/Sections/ExperimentsSection.tsx`
  - Renders experiment rows from `getExperimentList()`.
  - Already renders nested settings/warnings for experiments such as `ADVISOR_TOOL`, `IMAGE_GENERATION_TOOL`, `PORTABLE_DESKTOP`, and `CONFIGURABLE_BIND_URL`.
  - Nested configs are generally gated by `useExperimentValue(...)` and rendered directly after the corresponding `ExperimentRow`.
- `src/browser/features/Settings/Sections/GoalsSection.tsx`
  - Self-contained UI for goal defaults; uses `api.config.getConfig()` and `api.config.updateGoalDefaults({ goalDefaults })`.
  - Does not depend on the Settings route, but includes a page-like `Goals` heading/intro that should not be embedded raw under an experiment row.
- `src/browser/features/Settings/Sections/HeartbeatSection.tsx`
  - Self-contained UI for heartbeat defaults; uses `api.config.getConfig()`, `api.config.updateHeartbeatDefaultPrompt(...)`, and `api.config.updateHeartbeatDefaultIntervalMs(...)`.
  - Does not depend on the Settings route and is already closer to an embeddable controls block.
- `src/common/constants/experiments.ts`
  - `WORKSPACE_HEARTBEATS` and `GOALS` are already `userOverridable: true` and `showInSettings: true`.
- Existing tests and stories:
  - `src/browser/features/Settings/Sections/GoalsSection.test.tsx`
  - `src/browser/features/Settings/Sections/HeartbeatSection.test.tsx`
  - `src/browser/features/Settings/Sections/ExperimentsSection.test.tsx`
  - `src/browser/features/Settings/Sections/ExperimentsSection.advisor.test.tsx`
  - `src/browser/features/Settings/SettingsPage.stories.tsx` currently smoke-tests only base sections, not dynamic Goals/Heartbeat sidebar entries.
- Storybook/Chromatic follow-up check found **no stories that explicitly test the obsolete standalone Settings → Goals or Settings → Heartbeat tabs/pages**.
  - No `GoalsSection.stories.tsx` or `HeartbeatSection.stories.tsx` files exist under `src/browser/features/Settings/Sections/`.
  - `src/browser/features/Settings/SettingsPage.stories.tsx` story `SectionsSmoke` does not enable Goals or Workspace Heartbeats and does not click/assert those sidebar entries.
  - `src/browser/features/Settings/Sections/ExperimentsSection.stories.tsx` covers generic experiments and image-generation controls only; it is the right place to add migrated inline-config visual coverage, not a deletion target.
  - Keep unrelated stories such as `src/browser/features/Tools/Goal/GoalToolCalls.stories.tsx` and README screenshot fixture stories that mention `Goals`; they do not cover Settings tabs.

- Requested workflow skills were reviewed and incorporated into this plan:
  - `dogfood` requires direct `agent-browser` usage, a report/output directory, screenshots, video for interactive issues, and incremental repro documentation.
  - `agent-browser` is a discovery stub; before executing browser automation, load version-matched CLI instructions with `agent-browser skills get core` (and `agent-browser skills get dogfood` if doing a broader QA pass).
  - `dev-server-sandbox` provides the isolated app workflow via `make dev-server-sandbox`, creating a fresh temporary `MUX_ROOT`, free `BACKEND_PORT`/`VITE_PORT`, and copied seed provider/project config unless disabled.

## Recommended approach

### Approach A — Extract embeddable controls and render them under experiment rows

**Recommendation:** use this approach.

**Product LoC estimate:** net **-10 to +30 LoC** depending on whether compatibility wrappers are kept during the refactor. Tests are not included in this estimate.

Why this is the best fit:

- Keeps the existing settings logic and persistence behavior instead of duplicating it.
- Avoids embedding the standalone Goals page header inside the Experiments list.
- Matches the existing Experiments page pattern for Advisor/Image Tools inline config.
- Minimizes navigation changes to `SettingsPage.tsx`.

Implementation outline:

1. In `GoalsSection.tsx`, extract the current data-loading/persistence/control logic into an embeddable export, e.g. `GoalDefaultsExperimentConfig` or `GoalDefaultsControls`.
   - Keep existing labels and input IDs where possible.
   - Drop the standalone page-level `Goals` heading/intro from the embedded component.
   - Keep the `Goal defaults` grouping text if it still reads well under the `Goals` experiment row.
2. In `HeartbeatSection.tsx`, expose the current controls as an embeddable export, e.g. `HeartbeatExperimentConfig` or `HeartbeatDefaultsControls`.
   - Preserve the existing default threshold and default prompt controls.
   - Keep current defensive parsing/clamping behavior through `heartbeatIntervalMinutes` helpers.
3. In `ExperimentsSection.tsx`, import those embeddable configs and render them directly under the matching experiment rows when enabled:

   ```tsx
   exp.id === EXPERIMENT_IDS.WORKSPACE_HEARTBEATS &&
     workspaceHeartbeatsEnabled && <HeartbeatExperimentConfig />

   exp.id === EXPERIMENT_IDS.GOALS &&
     goalsEnabled && <GoalDefaultsExperimentConfig />
   ```

4. Style the new inline blocks consistently with existing nested experiment panels (`bg-background-secondary`, `px-4`, `py-3`, `space-y-*`).
   - If two new panels would duplicate identical wrapper markup, add a small local wrapper in `ExperimentsSection.tsx`.
   - Do not refactor unrelated existing experiment panels unless needed to keep the diff small.
5. In `SettingsPage.tsx`, remove the dynamic sidebar sections for `goals` and `heartbeat`.
   - Remove now-unused imports: `GoalsSection`, `HeartbeatSection`, `Target`, `HeartPulse`, and the two experiment value reads if they become unused.
   - Keep `governor` behavior unchanged.
6. Add stale route handling for removed sections.
   - If `activeSection` is `"goals"` or `"heartbeat"`, navigate to `"experiments"` rather than silently showing General while the URL remains stale.
   - This is an appropriate effect because it syncs the UI with the external URL/router state; avoid creating per-render `new Set()` objects inside the component.

### Approach B — Embed existing `GoalsSection` / `HeartbeatSection` directly

**Product LoC estimate:** net **-25 to -45 LoC**.

This is the smallest code diff, but it risks awkward UI because `GoalsSection` currently includes a standalone page title and explanatory intro. Use only if speed matters more than polish.

### Approach C — Duplicate controls inline in `ExperimentsSection.tsx`

**Product LoC estimate:** net **+150 to +250 LoC**.

Do not use this approach. It would make `ExperimentsSection.tsx` larger, duplicate config persistence behavior, and increase regression risk.

## Implementation phases and quality gates

### Phase 1 — Refactor controls into embeddable components

- Extract reusable controls from `GoalsSection.tsx` and `HeartbeatSection.tsx` without changing persistence behavior.
- Update direct unit tests to import/render the embeddable components, or keep thin wrappers only where they materially reduce test churn.
- Preserve all existing labels, test IDs/IDs, blur/change persistence semantics, normalization, trimming, and clamping.

**Gate 1 validation:**

```sh
bun test src/browser/features/Settings/Sections/GoalsSection.test.tsx \
  src/browser/features/Settings/Sections/HeartbeatSection.test.tsx
```

### Phase 2 — Wire controls into Experiments

- Add `useExperimentValue(EXPERIMENT_IDS.GOALS)` and `useExperimentValue(EXPERIMENT_IDS.WORKSPACE_HEARTBEATS)` in `ExperimentsSection.tsx`.
- Render each config immediately after its corresponding `ExperimentRow` only when enabled.
- Add focused tests for visibility gating:
  - Goals disabled → goal default controls hidden.
  - Goals enabled → goal default controls visible under Experiments.
  - Workspace Heartbeats disabled → heartbeat controls hidden.
  - Workspace Heartbeats enabled → heartbeat controls visible under Experiments.
- Add/update Storybook visual coverage in `src/browser/features/Settings/Sections/ExperimentsSection.stories.tsx` for the migrated inline Goals and Workspace Heartbeats configs.
- Do **not** delete Storybook/Chromatic stories for standalone Goals/Heartbeat Settings tabs, because none were found.
- Prefer behavioral assertions over tautological prose checks.

**Gate 2 validation:**

```sh
bun test src/browser/features/Settings/Sections/ExperimentsSection.test.tsx \
  src/browser/features/Settings/Sections/ExperimentsSection.advisor.test.tsx
```

### Phase 3 — Remove standalone sidebar tabs and normalize stale routes

- Remove Goals/Heartbeat dynamic sidebar entries from `SettingsPage.tsx`.
- Redirect stale `/settings/goals` and `/settings/heartbeat` routes to `/settings/experiments`.
- Leave command palette behavior unchanged unless a direct Goals/Heartbeat Settings command is found during implementation.
- Leave feature experiment registry entries unchanged.
- Leave unrelated Goal/Heartbeat Storybook stories alone; only update Experiments story coverage if adding visual coverage for the new inline controls.

**Gate 3 validation:**

- Run any updated Settings page test/story smoke coverage available in the repo.
- Manually verify sidebar contents in the running app before final validation.

### Phase 4 — Final validation

Run touched-area checks first, then broader static validation:

```sh
bun test src/browser/features/Settings/Sections/GoalsSection.test.tsx \
  src/browser/features/Settings/Sections/HeartbeatSection.test.tsx \
  src/browser/features/Settings/Sections/ExperimentsSection.test.tsx \
  src/browser/features/Settings/Sections/ExperimentsSection.advisor.test.tsx
make typecheck
make lint
```

If the change touches shared config types or router behavior more broadly than expected, run `make static-check` before declaring completion.

## Dogfooding plan

Use the `dev-server-sandbox`, `agent-browser`, and `dogfood` skill guidance for an isolated, evidence-first manual verification pass.

### Dogfood setup

1. Start an isolated web/dev instance after implementation:

   ```sh
   make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-projects"
   ```

   - Keep the server running and use the emitted `VITE_PORT` / frontend URL as the `TARGET_URL` for browser automation.
   - Use `--clean-projects` to avoid mutating the user's normal project list; decide whether to keep or also clean providers based on what the UI path needs.
   - If a debugging replay is useful, use `KEEP_SANDBOX=1 make dev-server-sandbox ...` so the temporary `MUX_ROOT` remains available after exit.

2. Before browser automation, load version-matched CLI guidance:

   ```sh
   agent-browser skills get core
   agent-browser skills get dogfood
   ```

3. Create a dogfood output area and use the direct `agent-browser` binary, never `npx agent-browser`:

   ```sh
   mkdir -p dogfood-output/settings-experiments/screenshots \
     dogfood-output/settings-experiments/videos
   agent-browser --session settings-experiments open "$TARGET_URL"
   agent-browser --session settings-experiments wait --load networkidle
   agent-browser --session settings-experiments screenshot --annotate \
     dogfood-output/settings-experiments/screenshots/initial.png
   agent-browser --session settings-experiments snapshot -i
   ```

4. For any issue found during dogfooding, document it immediately with reproducible steps and evidence:
   - Static/visible issue: annotated screenshot is enough.
   - Interactive issue: start recording before reproducing, use human-paced actions, capture step screenshots, then stop recording.

### Dogfood script

1. Open **Settings → Experiments** using sidebar navigation or the command palette.
2. Capture a screenshot proving the Settings sidebar does **not** contain standalone **Goals** or **Heartbeat** entries.
3. Toggle **Goals** on.
   - Confirm the goal defaults controls appear inline under the `Goals` experiment row.
   - Edit default budget, default turn cap, and `Always require explicit budget`.
   - Leave Settings and return, or reload the app, and confirm the edited values persist.
   - Capture a screenshot of the inline Goals config.
4. Toggle **Workspace Heartbeats** on.
   - Confirm heartbeat default threshold and prompt controls appear inline under the `Workspace Heartbeats` experiment row.
   - Edit threshold and prompt.
   - Leave Settings and return, or reload the app, and confirm the edited values persist.
   - Capture a screenshot of the inline Heartbeat config.
5. Toggle each experiment off.
   - Confirm its inline config disappears while the experiment row remains visible.
   - Record a short video showing at least one toggle on/off flow and the inline config appearing/disappearing.
6. Navigate or restore stale routes for `/settings/goals` and `/settings/heartbeat` if feasible in the running app.
   - Confirm both land on `/settings/experiments` or visually show the Experiments page.
7. Check browser health after the flow:

   ```sh
   agent-browser --session settings-experiments errors
   agent-browser --session settings-experiments console
   ```

8. Close the automation session after evidence capture:

   ```sh
   agent-browser --session settings-experiments close
   ```

Required evidence to attach or summarize for review:

- Screenshot: Settings sidebar without Goals/Heartbeat entries.
- Screenshot: Experiments page with Goals inline config visible.
- Screenshot: Experiments page with Workspace Heartbeats inline config visible.
- Video: toggling an experiment on/off and seeing inline config appear/disappear.
- Console/error output summary.

## Acceptance criteria

- Settings sidebar no longer shows standalone **Goals** or **Heartbeat** entries in any experiment state.
- Settings → Experiments still shows the **Goals** and **Workspace Heartbeats** experiment rows.
- Enabling **Goals** reveals the goal defaults controls inline under the Goals row; disabling it hides those controls.
- Enabling **Workspace Heartbeats** reveals the heartbeat defaults controls inline under the Workspace Heartbeats row; disabling it hides those controls.
- Existing goal default and heartbeat default persistence behavior is unchanged.
- Stale `/settings/goals` and `/settings/heartbeat` routes no longer display mismatched content; they redirect/normalize to Experiments.
- Targeted tests, updated Storybook/Chromatic coverage where added, typecheck, lint, and dogfooding pass with screenshot/video evidence.

## Risks and mitigations

- **Risk:** Raw embedding could create awkward nested page layout.
  - **Mitigation:** Extract embeddable controls and omit page-level headings in the inline variant.
- **Risk:** Persisted last route can restore removed settings sections.
  - **Mitigation:** Explicitly normalize `goals` and `heartbeat` active sections to `experiments`.
- **Risk:** Tests become tautological if they only assert exact copy.
  - **Mitigation:** Test behavior: visibility gating and config update calls/value persistence.
- **Risk:** Existing user config could be accidentally mutated during dogfooding.
  - **Mitigation:** Use an isolated `MUX_ROOT` / desktop sandbox for manual verification.

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `1617437{MUX_COSTS_USD:-unknown}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=77.34 -->
