### PR TITLE
🤖 fix: remove goal set success toast

### DIFF
--- a/src/browser/utils/chatCommands.test.ts
+++ b/src/browser/utils/chatCommands.test.ts
@@ -495,10 +495,11 @@ describe("processSlashCommand - goal experiment state", () => {
       context
     );
 
-    expect(result).toEqual({ clearInput: true, toastShown: true });
+    expect(result).toEqual({ clearInput: true, toastShown: false });
     expect(setGoal).toHaveBeenCalledWith(
       expect.objectContaining({ objective: "remote objective" })
     );
+    expect(context.setToast).not.toHaveBeenCalled();
   });
 });
 
@@ -560,7 +561,7 @@ describe("processSlashCommand - goal optimistic concurrency", () => {
       context
     );
 
-    expect(result).toEqual({ clearInput: true, toastShown: true });
+    expect(result).toEqual({ clearInput: true, toastShown: false });
     expect(getGoal).toHaveBeenCalledTimes(2);
     expect(setGoal).toHaveBeenNthCalledWith(1, {
       workspaceId: "goal-ws",
@@ -576,9 +577,7 @@ describe("processSlashCommand - goal optimistic concurrency", () => {
       turnCap: null,
       expectedGoalId: "22222222-2222-4222-8222-222222222222",
     });
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "success", message: "Goal set: new objective" })
-    );
+    expect(context.setToast).not.toHaveBeenCalled();
   });
 
   test("surfaces a toast and stops after two consecutive goal conflicts", async () => {
@@ -792,7 +791,7 @@ describe("processSlashCommand - goal budgets", () => {
 
     const result = await processSlashCommand(parsed, context);
 
-    expect(result).toEqual({ clearInput: true, toastShown: true });
+    expect(result).toEqual({ clearInput: true, toastShown: false });
     expect(setGoal).toHaveBeenCalledWith({
       workspaceId: "goal-ws",
       objective,
@@ -800,6 +799,7 @@ describe("processSlashCommand - goal budgets", () => {
       budgetCents: 200,
       turnCap: null,
     });
+    expect(context.setToast).not.toHaveBeenCalled();
     expect(window.dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({ type: "mux:openGoalTab" })
     );

--- a/src/browser/utils/chatCommands.ts
+++ b/src/browser/utils/chatCommands.ts
@@ -863,14 +863,9 @@ async function handleGoalCommand(
       showGoalSetErrorToast(setToast, result.error);
       return { clearInput: false, toastShown: true };
     }
-    setToast({
-      id: Date.now().toString(),
-      type: "success",
-      message: `Goal set: ${result.goal.objective}`,
-    });
     window.dispatchEvent(createCustomEvent(CUSTOM_EVENTS.OPEN_GOAL_TAB, { workspaceId }));
     trackCommandUsed("goal");
-    return { clearInput: true, toastShown: true };
+    return { clearInput: true, toastShown: false };
   } catch (error) {
     setToast({
       id: Date.now().toString(),


### PR DESCRIPTION
## Summary

Remove the blue `Goal set: ...` success toast after successful slash-command goal submission while preserving goal setting, Goal tab opening, telemetry, and error/warning toasts.

## Background

Successful `/goal ...` submissions already update the Goal tab, so the extra blue success popup was redundant and distracting. Command-palette goal submission did not show the success toast, so this aligns slash-command behavior with that flow.

## Implementation

- Removed the success `setToast(...)` call from the `goal-set` success path.
- Returned `toastShown: false` for successful `goal-set` results to keep the command result semantically accurate.
- Updated goal command tests to assert no toast appears on successful goal submission while retaining error-toast coverage.

## Validation

- `bun test src/browser/utils/chatCommands.test.ts`
- `make typecheck`
- `make fmt-check`
- `make lint`
- `make static-check`
- Dogfooded in `make dev-server-sandbox` with `agent-browser`: submitted a slash goal, verified the Goal tab updated to `Final recorded no toast`, and verified the page text did not contain `Goal set:`. Evidence saved under `/tmp/mux-goal-toast-dogfood/`, including `/tmp/mux-goal-toast-dogfood/videos/final-success-no-goal-set-toast.webm` and `/tmp/mux-goal-toast-dogfood/screenshots/final-after-success.png`.

## Risks

Low. The production change removes only the success toast for the `goal-set` success path. Existing goal persistence, conflict retry, Goal tab opening, telemetry, and error/warning toasts remain unchanged.

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Remove the `Goal set: ...` success popup after goal submission

## Goal

Remove the blue success popup/toast that says `Goal set: ...` after a goal is successfully submitted, while preserving the actual goal-setting behavior and existing error feedback.

## Evidence from repo investigation

- The success popup is triggered in `src/browser/utils/chatCommands.ts` inside `handleGoalCommand(...)`, in the `goal-set` success path.
- That path currently:
  1. Calls `setGoalWithSingleConflictRetry(context, goalSetIntent)`.
  2. Calls `setToast({ type: "success", message: `Goal set: ${result.goal.objective}` })`.
  3. Dispatches `CUSTOM_EVENTS.OPEN_GOAL_TAB`.
  4. Calls `trackCommandUsed("goal")`.
  5. Returns `{ clearInput: true, toastShown: true }`.
- `ChatInputToast` renders success toasts with the blue success styling, so removing this success `setToast(...)` call is the narrow fix.
- Command-palette goal submission already opens the goal panel without showing this success toast, so this change aligns slash-command submission with that behavior.
- Existing test coverage in `src/browser/utils/chatCommands.test.ts` currently asserts the success toast is shown and will need updating.

## Recommended approach — remove only the successful goal toast

**Net production LoC estimate:** about **-4 to -5 LoC**.

1. In `src/browser/utils/chatCommands.ts`, remove the successful `setToast(...)` call that emits `Goal set: ${result.goal.objective}`.
2. Keep these behaviors unchanged:
   - Conflict retry via `setGoalWithSingleConflictRetry(...)`.
   - Opening the Goal tab via `CUSTOM_EVENTS.OPEN_GOAL_TAB`.
   - Command telemetry via `trackCommandUsed("goal")`.
   - Error and warning toasts, including `showGoalSetErrorToast(...)` and unpriced-model feedback.
3. Change the successful `goal-set` return value from:

   ```ts
   { clearInput: true, toastShown: true }
   ```

   to:

   ```ts
   { clearInput: true, toastShown: false }
   ```

   This keeps the command result semantically accurate for any caller or test that checks whether a toast was actually shown.

## Test updates

1. Update `src/browser/utils/chatCommands.test.ts` in the `goal` optimistic-concurrency coverage:
   - Preserve assertions that the command retries correctly and sets the goal.
   - Replace the success-toast assertion with an assertion that `context.setToast` is not called on successful goal submission.
   - Update the expected command result to `{ clearInput: true, toastShown: false }`.
2. Do **not** remove tests for error toasts; the user asked only to remove the successful blue `Goal set: ...` popup.

## Quality gates by phase

### Phase 1: Surgical implementation

- Make the minimal code change in `src/browser/utils/chatCommands.ts`.
- Gate: inspect the diff and confirm the only production behavior removed is the successful `Goal set: ...` toast.

### Phase 2: Targeted automated validation

Run:

```bash
bun test src/browser/utils/chatCommands.test.ts
```

If command-related behavior appears affected, also run:

```bash
bun test src/browser/utils/commands/sources.test.ts
```

Then run the standard static checks that are practical for the touched files:

```bash
make typecheck
make fmt-check
```

### Phase 3: Dogfooding / self-verification

Use the `dogfood`, `agent-browser`, and `dev-server-sandbox` skill guidance so the verification is isolated, reproducible, and reviewable.

1. Start an isolated web/dev instance rather than reusing the user’s normal Mux state:

   ```bash
   make dev-server-sandbox
   ```

   Notes from the sandbox skill:
   - This creates a temporary `MUX_ROOT`, picks free `BACKEND_PORT`/`VITE_PORT`, and allows forwarded hosts.
   - Use `DEV_SERVER_SANDBOX_ARGS="--clean-providers --clean-projects"` if the dogfood should avoid copying local providers/projects.
   - If the sandbox output prints the chosen URL/ports, use that exact URL for `agent-browser`.

2. Before browser automation, load the installed CLI’s current workflow reference:

   ```bash
   agent-browser skills get core
   ```

   Use the direct `agent-browser` binary, never `npx agent-browser`.

3. Create a dogfood output directory with screenshots and videos, then open a named browser session against the sandbox URL:

   ```bash
   agent-browser --session goal-toast open <sandbox-url>
   agent-browser --session goal-toast wait --load networkidle
   agent-browser --session goal-toast screenshot --annotate dogfood-output/screenshots/initial.png
   agent-browser --session goal-toast snapshot -i
   ```

4. Record the actual success-path repro at human pace:
   - Start video recording before the interaction.
   - Submit a goal from ChatInput using the same flow that previously showed the blue popup.
   - Pause briefly after submission so any popup would be visible if it still appeared.
   - Capture an annotated screenshot of the post-submit state.
   - Stop the video.

5. Verify and document:
   - The input clears after submission.
   - The Goal tab opens or updates with the submitted objective.
   - No blue `Goal set: ...` popup appears after successful submission.
   - `agent-browser --session goal-toast errors` and `agent-browser --session goal-toast console` do not reveal new relevant client errors.

6. Negative/regression check:
   - Trigger or simulate a goal-submission error path if practical.
   - Verify error/warning toasts still appear, since only the success toast should be removed.

7. Close the browser session when done:

   ```bash
   agent-browser --session goal-toast close
   ```

## Acceptance criteria

- Successful goal submission no longer shows a blue `Goal set: ...` popup.
- Goal submission still succeeds and opens/updates the Goal tab.
- The chat input still clears after successful submission.
- Error and warning toasts related to goal submission still appear.
- Targeted tests pass after updating expectations.
- Typecheck and formatting checks pass, or any blocker is documented with exact command output.
- Dogfooding evidence includes at least one screenshot and one video recording of the fixed success path.

## Risks and mitigations

- **Risk:** A caller may rely on `toastShown: true` rather than the actual toast call.
  - **Mitigation:** Return `toastShown: false` to match the new behavior and update tests accordingly.
- **Risk:** Accidentally removing useful error feedback.
  - **Mitigation:** Only remove the success `setToast(...)` block and keep error/warning toast helpers untouched.

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$22.95`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=22.95 -->
