### PR TITLE
🤖 fix: strip partial-clone config from SSH base repo

### DIFF
--- a/src/node/runtime/SSHRuntime.retry.test.ts
+++ b/src/node/runtime/SSHRuntime.retry.test.ts
@@ -212,7 +212,33 @@ class CleanupCommandSSHRuntime extends SSHRuntime {
   }
 }
 
+// Single-line shell pipeline that strips partial-clone config from a shared
+// bare base repo. The exact text is asserted in tests because order matters:
+// the strip must precede the on-disk `.promisor` marker cleanup so that even
+// a half-completed repair leaves the repo non-promisor (and therefore safe
+// from the upstream `check_connected()` sideband deadlock — see the doc
+// comment on `stripBaseRepoPromisorConfig` in SSHRuntime.ts).
+function expectedStripPromisorCommand(baseRepoPathArg: string): string {
+  return (
+    `git -C ${baseRepoPathArg} config --unset-all remote.origin.promisor; ` +
+    `git -C ${baseRepoPathArg} config --unset-all remote.origin.partialclonefilter; ` +
+    `git -C ${baseRepoPathArg} config --unset-all extensions.partialclone; ` +
+    `true`
+  );
+}
+
 describe("SSHRuntime project sync retry orchestration", () => {
+  it("strips legacy partial-clone keys before any on-disk maintenance", async () => {
+    const runtime = new CleanupCommandSSHRuntime();
+    const baseRepoPathArg = '"/remote/src/project/.mux-base.git"';
+
+    await runtime.runCleanup(baseRepoPathArg);
+
+    // Strip must be the first remote call in repair — see comment above.
+    expect(runtime.commands[0]).toBe(expectedStripPromisorCommand(baseRepoPathArg));
+    expect(runtime.timeouts[0]).toBe(10);
+  });
+
   it("removes stale promisor markers before running git gc", async () => {
     const runtime = new CleanupCommandSSHRuntime();
     const baseRepoPathArg = '"/remote/src/project/.mux-base.git"';
@@ -220,10 +246,11 @@ describe("SSHRuntime project sync retry orchestration", () => {
     await runtime.runCleanup(baseRepoPathArg);
 
     expect(runtime.commands).toEqual([
+      expectedStripPromisorCommand(baseRepoPathArg),
       `find ${baseRepoPathArg}/objects/pack -name '*.promisor' -print -delete 2>/dev/null || true`,
       `git -C ${baseRepoPathArg} gc --prune=now`,
     ]);
-    expect(runtime.timeouts).toEqual([10, 120]);
+    expect(runtime.timeouts).toEqual([10, 10, 120]);
   });
 
   it("proactively repairs fragmented base repos before sync", async () => {
@@ -238,10 +265,11 @@ describe("SSHRuntime project sync retry orchestration", () => {
     ]);
     expect(runtime.commands).toEqual([
       `git -C ${baseRepoPathArg} count-objects -v`,
+      expectedStripPromisorCommand(baseRepoPathArg),
       `find ${baseRepoPathArg}/objects/pack -name '*.promisor' -print -delete 2>/dev/null || true`,
       `git -C ${baseRepoPathArg} gc --prune=now`,
     ]);
-    expect(runtime.timeouts).toEqual([10, 10, 120]);
+    expect(runtime.timeouts).toEqual([10, 10, 10, 120]);
   });
 
   it("skips proactive maintenance for healthy base repos", async () => {
@@ -283,10 +311,11 @@ describe("SSHRuntime project sync retry orchestration", () => {
     ]);
     expect(runtime.commands).toEqual([
       `git -C ${baseRepoPathArg} count-objects -v`,
+      expectedStripPromisorCommand(baseRepoPathArg),
       `find ${baseRepoPathArg}/objects/pack -name '*.promisor' -print -delete 2>/dev/null || true`,
       `git -C ${baseRepoPathArg} gc --prune=now`,
     ]);
-    expect(runtime.timeouts).toEqual([10, 10, 120]);
+    expect(runtime.timeouts).toEqual([10, 10, 10, 120]);
   });
 
   it("propagates aborts during proactive maintenance preflight", async () => {

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -379,6 +379,89 @@ export class SSHRuntime extends RemoteRuntime {
     };
   }
 
+  /**
+   * Remove stale partial-clone / promisor configuration from a shared bare
+   * base repo. Idempotent — absent keys are silently treated as success.
+   *
+   * Why this matters (real, current upstream Git bug):
+   *
+   *   Git's `check_connected()` (`connected.c`) has a fast path that
+   *   activates whenever the receiving repo is a promisor remote, i.e.
+   *   `repo_has_promisor_remote()` returns true. That path was added in
+   *   50033772d ("connected: verify promisor-ness of partial clone",
+   *   2020-01) and is byte-identical on every release from v2.27.0 through
+   *   current `master`. It violates `check_connected_options::err_fd`'s
+   *   documented contract — "The descriptor is closed before
+   *   check_connected returns" (header comment in `connected.h`) — by
+   *   returning 0 directly when all pushed ref tips are already present in
+   *   a promisor pack, without ever calling `close(opt->err_fd)`.
+   *
+   *   On the receive-pack side, `execute_commands()` runs the connectivity
+   *   check with `err_fd = muxer.in`, where `muxer` is an async pthread
+   *   spawned by `start_async()` to relay child stderr over the sideband.
+   *   When the buggy fast path returns, the muxer pipe's write end is
+   *   still held open by receive-pack itself, so the keepalive worker
+   *   thread keeps polling its read end (timing out every 5s and emitting
+   *   `0005\1` sideband keepalives) and never sees EOF. The subsequent
+   *   `finish_async(&muxer)` is `pthread_join`, which then blocks forever.
+   *   The local push hangs in OpenSSH mux-channel I/O even though TCP
+   *   keepalives still flow on the underlying connection.
+   *
+   *   Jeff King already fixed an architecturally identical deadlock years
+   *   ago — 6cdad1f13 ("receive-pack: fix deadlock when we cannot create
+   *   tmpdir", 2017-03) — by adding the missing `close(err_fd)` to an
+   *   early-return path in `unpack()`. The same lesson was never applied
+   *   to the promisor path added three years later.
+   *
+   *   Mux never deliberately turns the shared base repo into a partial
+   *   clone, but legacy bare repos populated by earlier Mux versions, or
+   *   by user-initiated `git fetch --filter` runs on the remote, can
+   *   carry these keys. Stripping them makes `repo_has_promisor_remote()`
+   *   return false, routing `check_connected()` through the slow rev-list
+   *   path that closes its sideband fd correctly. The companion `.promisor`
+   *   marker file cleanup in `repairBaseRepoForSync` handles the on-disk
+   *   side of the same legacy state.
+   */
+  protected async stripBaseRepoPromisorConfig(
+    baseRepoPathArg: string,
+    abortSignal?: AbortSignal
+  ): Promise<void> {
+    if (abortSignal?.aborted) {
+      throw new Error("Operation aborted");
+    }
+
+    // `git config --unset-all` exits 0 (removed) or 5 (key/section absent);
+    // both are idempotent successes. Anything else is a real failure we
+    // want surfaced but not fatal — workspace init must not depend on
+    // remote config writes that may race with concurrent worktrees.
+    //
+    // Three keys cover every way a bare repo can advertise itself as a
+    // partial clone to `repo_has_promisor_remote()`:
+    //   - remote.origin.promisor       (flag set by `clone/fetch --filter`)
+    //   - remote.origin.partialclonefilter  (the filter spec itself)
+    //   - extensions.partialclone      (the repository-format extension)
+    //
+    // Collapsed into one remote shell call to keep workspace init to a
+    // single SSH round trip; `; true` ensures the pipeline as a whole
+    // returns 0 even when every key was already absent.
+    const cmd =
+      `git -C ${baseRepoPathArg} config --unset-all remote.origin.promisor; ` +
+      `git -C ${baseRepoPathArg} config --unset-all remote.origin.partialclonefilter; ` +
+      `git -C ${baseRepoPathArg} config --unset-all extensions.partialclone; ` +
+      `true`;
+
+    const result = await execBuffered(this, cmd, {
+      cwd: "/tmp",
+      timeout: BASE_REPO_PROMISOR_CLEANUP_TIMEOUT_SECONDS,
+      abortSignal,
+    });
+
+    const stderr = result.stderr.trim();
+    if (stderr) {
+      log.warn(`Partial-clone config cleanup reported diagnostics: ${stderr}`);
+    }
+  }
+
   protected async repairBaseRepoForSync(
     baseRepoPathArg: string,
     repairContext: string,
@@ -388,9 +471,15 @@ export class SSHRuntime extends RemoteRuntime {
       throw new Error("Operation aborted");
     }
 
-    const promisorPackDirArg = `${baseRepoPathArg}/objects/pack`;
     log.info(repairContext);
 
+    // Strip partial-clone config before the on-disk cleanup so that even
+    // if `git gc` fails, subsequent pushes no longer route through the
+    // buggy `check_connected()` promisor fast path. See the doc comment
+    // on stripBaseRepoPromisorConfig for the full upstream-bug story.
+    await this.stripBaseRepoPromisorConfig(baseRepoPathArg, abortSignal);
+
+    const promisorPackDirArg = `${baseRepoPathArg}/objects/pack`;
     const promisorCleanupResult = await execBuffered(
       this,
       `find ${promisorPackDirArg} -name '*.promisor' -print -delete 2>/dev/null || true`,
@@ -674,6 +763,12 @@ export class SSHRuntime extends RemoteRuntime {
     if (normalizedConfig) {
       initLogger.logStep("Normalized shared base repository config for worktrees");
     }
+
+    // Defensively neuter partial-clone configuration on every init so that
+    // legacy bare repos populated by older Mux versions stop tripping the
+    // upstream `check_connected()` sideband deadlock on the very first
+    // push (instead of only after a retry-driven repair pass).
+    await this.stripBaseRepoPromisorConfig(baseRepoPathArg, abortSignal);
 
     return baseRepoPathArg;
   }


### PR DESCRIPTION
## Summary

Workspace init pushes over SSH (e.g. to Coder hosts) could hang for the full 300-second push timeout when the shared bare `.mux-base.git` on the remote carried legacy partial-clone configuration (`remote.origin.promisor = true`). The push looked healthy at the TCP layer — keepalives flowed, RTT was in milliseconds — but went silent at the OpenSSH mux-channel layer right after `master session id: N`, and the only recovery was killing the local SSH ControlMaster. This change strips the offending keys from the shared base repo on every init and every retry repair, sidestepping the upstream Git deadlock entirely.

## Background

The deadlock lives in upstream Git, not in Mux. `check_connected()` in `connected.c` has a partial-clone fast path that returns 0 directly when every pushed ref tip is already present in a promisor pack on the receiving side, without honoring `check_connected_options::err_fd`'s own documented contract — _"The descriptor is closed before check_connected returns"_ (header comment in `connected.h`).

On the receive-pack side, `execute_commands()` runs the connectivity check with `err_fd = muxer.in`, where `muxer` is a pthread started by `start_async()` to relay child stderr over the sideband. When the buggy fast path returns without closing that fd, the muxer pipe's write end is still held open by receive-pack itself. The keepalive worker thread keeps polling its read end (timing out every 5s and emitting `0005\1` sideband keepalives) and never sees EOF. The next `finish_async(&muxer)` is a `pthread_join` against that worker — and it blocks forever. Locally the push sits in OpenSSH mux-channel I/O even though TCP keepalives still flow on the underlying socket.

We verified the bug is present and byte-identical on every Git release from **v2.27.0 (June 2020) through current `master`**. It's the same shape of deadlock Jeff King already fixed years ago in `unpack()` — see [6cdad1f13](https://github.com/git/git/commit/6cdad1f13) _"receive-pack: fix deadlock when we cannot create tmpdir"_ (2017-03). The lesson never got applied to the promisor early-return added three years later in [50033772d](https://github.com/git/git/commit/50033772d).

Diagnostic evidence captured from a live hang:

- **Local push:** `wchan=pipe_r`, slave SSH stuck in `do_pol` after `master session id: N`; no `MUX_S_SESSION_OPENED` ever follows in the trace.
- **Remote receive-pack main thread:** instruction pointer in libc's `__nptl_death_event` region (i.e. `pthread_clockjoin_ex`); futex value at the wait address holds the worker thread's TID.
- **Remote keepalive worker:** alive, polling the muxer pipe with a 5-second timeout, writing the 5-byte sideband keepalive `"0005\1"` on every timeout — both ends of that pipe held by the same process, so EOF can never arrive.
- **Remote bare repo config:** `[remote "origin"] ... promisor = true / partialclonefilter = blob:none`.
- **Recovery:** `ssh -O exit -o ControlPath=... <host>` always unsticks; the Mux retry path then succeeds in milliseconds.

### Empirical confirmation in upstream Git

To rule out everything in the Mux/SSH/Coder stack, we reproduced the deadlock against stock Git on the local filesystem and validated the upstream fix in isolation.

- **Reproducer:** `git init src` → three commits → `git clone --bare --filter=blob:none file://src dst.git` → `git -C dst.git config receive.denyCurrentBranch ignore` → `git push file://dst.git +refs/heads/master:refs/test/v1`. No SSH, no Coder, no Mux. The dst repo is itself a partial clone (`remote.origin.promisor=true`) with a populated `.promisor` pack, and the pushed tip oid is already in that pack — exactly the condition that hits the buggy fast path.
- **Builds:** two worktrees at `v2.48.1` (the system Git on the affected hosts) built with `make NO_CURL=1 NO_GETTEXT=1 NO_TCLTK=1 NO_PERL=1 NO_PYTHON=1`. The "fixed" tree carries one patch: a 2-line addition to `connected.c` that closes `opt->err_fd` before the promisor fast-path `return 0;`, matching the existing exit-point style elsewhere in the same function.

Identical repos, identical refspec, identical oids:

| Binary | Outcome | Wall time |
| --- | --- | --- |
| `v2.48.1` (stock) | `timeout` killed at 25s | 25,001 ms |
| `v2.48.1.dirty` (one-patch) | exit 0, ref pushed | 4 ms |

A >6000× speedup from a 2-line change isolates the bug to `connected.c` and confirms the upstream fix is correct. Independently, applying this PR's Mux-side mitigation (unsetting `remote.origin.promisor` on the dst repo) before pushing with stock unpatched Git takes the push from 25s to ~5ms — the same outcome via a different mechanism, and the one this PR ships.

Mux never sets up the shared base repo as a partial clone (`ensureBaseRepo` is `git init --bare` followed by config normalization); the offending keys only show up on bare repos that were populated by older Mux versions or by user-initiated `git fetch --filter` runs on the remote host.

## Implementation

A new `stripBaseRepoPromisorConfig` helper issues a single batched remote shell pipeline that unsets three keys covering every way a bare repo can announce itself as a promisor remote to `repo_has_promisor_remote()`:

- `remote.origin.promisor`
- `remote.origin.partialclonefilter`
- `extensions.partialclone`

`git config --unset-all` returns exit 5 when the key is absent (the common, fresh-repo case), so the operation is silently idempotent. The pipeline ends with `; true` so a fresh repo with none of the three keys present still exits 0.

It's called from two places:

1. `ensureBaseRepo`, after `normalizeBaseRepoSharedConfig`, so the cleanup runs on every workspace init — including the first push that triggers the hang.
2. `repairBaseRepoForSync`, ahead of the existing `find … '*.promisor' -delete` pass, so that even a half-completed repair leaves the repo non-promisor.

The on-disk `.promisor` marker cleanup that already lived in `repairBaseRepoForSync` is the on-disk side of the same legacy state and is preserved unchanged.

Once stripped, `repo_has_promisor_remote()` returns false on receive-pack, which routes `check_connected()` through the slow `rev-list` path that closes its sideband fd correctly, and the muxer pipe sees EOF on schedule.

## Risks

Low. The helper only ever deletes keys Mux does not set itself; on a clean bare repo all three unsets exit 5 and the function is a no-op. Cost is a single SSH round trip per workspace init (sub-100ms over a warm ControlMaster). The change is also fully self-contained to `SSHRuntime.ts`; no contracts with `RemoteRuntime`, callers, or other runtimes change.

There is a small possible behaviour change for users whose shared bare repo was, prior to this change, deliberately operating as a partial clone — for example, anyone who had manually `git fetch --filter=blob:none`-ed inside the bare repo to save disk. After this change, the next `prefetchOriginOnRemote` will fetch unfiltered, restoring full objects. That's the right outcome (the partial state was both unsanctioned and actively harmful), but it does mean the first sync after upgrading might pull a few hundred MB extra on those repos. The bug being fixed is severe enough — multi-minute init hangs with no clear recovery — that this seems worth it.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=xhigh -->

