### PR TITLE
🤖 feat: add /btw side-question command

### DIFF
--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -85,6 +85,11 @@ import {
   normalizeQueuedMessage,
   type EditingMessageState,
 } from "@/browser/utils/chatEditing";
+import {
+  findActiveSideQuestionScrollHoldTarget,
+  findSideQuestionScrollHoldTarget,
+  type SideQuestionScrollHoldState,
+} from "./sideQuestionScrollHold";
 import { recordSyntheticReactRenderSample } from "@/browser/utils/perf/reactProfileCollector";
 
 // Perf e2e runs load the production bundle where React's onRender profiler callbacks may not
@@ -154,6 +159,15 @@ interface ChatPaneProps {
 type ReviewsState = ReturnType<typeof useReviews>;
 
 const AUTO_SCROLL_TRANSCRIPT_STYLE = { overflowAnchor: "none" } as const;
+
+function findTranscriptMessageElement(
+  scrollContainer: HTMLElement,
+  historyId: string
+): HTMLElement | undefined {
+  return Array.from(scrollContainer.querySelectorAll<HTMLElement>("[data-message-id]")).find(
+    (element) => element.getAttribute("data-message-id") === historyId
+  );
+}
 
 export const ChatPane: React.FC<ChatPaneProps> = (props) => {
   const {
@@ -395,14 +409,147 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
     handleScrollContainerKeyDown,
   } = useAutoScroll();
 
+  const sideQuestionScrollHoldRef = useRef<SideQuestionScrollHoldState>({
+    initialized: false,
+    heldSideQuestionIds: new Set<string>(),
+    previouslyStreamingSideAnswerIds: new Set<string>(),
+    heldSideAnswerIds: new Set<string>(),
+  });
+
+  const activeSideQuestionScrollHoldTargetRef = useRef<string | null>(null);
+
+  const clearActiveSideQuestionScrollHold = useCallback(() => {
+    activeSideQuestionScrollHoldTargetRef.current = null;
+  }, []);
+
+  useLayoutEffect(() => {
+    sideQuestionScrollHoldRef.current = {
+      initialized: false,
+      heldSideQuestionIds: new Set<string>(),
+      previouslyStreamingSideAnswerIds: new Set<string>(),
+      heldSideAnswerIds: new Set<string>(),
+    };
+    activeSideQuestionScrollHoldTargetRef.current = null;
+  }, [workspaceId]);
+
+  useLayoutEffect(() => {
+    if (loading || isHydratingTranscript || deferredMessages.length === 0) {
+      return;
+    }
+
+    const { nextState, targetHistoryId: detectedTargetHistoryId } =
+      findSideQuestionScrollHoldTarget(deferredMessages, sideQuestionScrollHoldRef.current);
+    sideQuestionScrollHoldRef.current = nextState;
+
+    const activeTargetHistoryId = activeSideQuestionScrollHoldTargetRef.current;
+    const activeHold = findActiveSideQuestionScrollHoldTarget(
+      deferredMessages,
+      activeTargetHistoryId
+    );
+    const continuingTargetHistoryId =
+      activeHold.targetHistoryId === activeTargetHistoryId ? activeHold.targetHistoryId : undefined;
+    const shouldStartHold = detectedTargetHistoryId !== undefined && autoScroll;
+    const targetHistoryId = shouldStartHold ? detectedTargetHistoryId : continuingTargetHistoryId;
+
+    if (!targetHistoryId) {
+      if (!activeHold.keepActive) {
+        activeSideQuestionScrollHoldTargetRef.current = null;
+      }
+      return;
+    }
+
+    const scrollContainer = contentRef.current;
+    if (!scrollContainer) {
+      return;
+    }
+
+    const alignSideBranchStart = (): void => {
+      findTranscriptMessageElement(scrollContainer, targetHistoryId)?.scrollIntoView({
+        block: "start",
+        inline: "nearest",
+      });
+    };
+
+    // The main stream can now keep rendering below an active /btw branch. Once
+    // that happens, bottom-lock would otherwise follow the main tail and yank
+    // the user away from the aside they just requested. Release bottom-lock once
+    // per side branch and keep the side-question row readable; Jump to bottom is
+    // then the explicit opt-in to resume watching the live tail. Keep re-aligning
+    // while the side answer grows because the first scroll may clamp at the old
+    // bottom before enough below-branch content exists to place the aside higher.
+    if (shouldStartHold) {
+      activeSideQuestionScrollHoldTargetRef.current = targetHistoryId;
+      disableAutoScroll();
+    }
+    alignSideBranchStart();
+
+    const currentHold = findActiveSideQuestionScrollHoldTarget(deferredMessages, targetHistoryId);
+    if (
+      !currentHold.keepActive &&
+      activeSideQuestionScrollHoldTargetRef.current === targetHistoryId
+    ) {
+      activeSideQuestionScrollHoldTargetRef.current = null;
+    }
+
+    const win = typeof window !== "undefined" ? window : undefined;
+    const raf = win?.requestAnimationFrame?.bind(win);
+    const cancelRaf = win?.cancelAnimationFrame?.bind(win);
+    if (!raf || !cancelRaf) {
+      return;
+    }
+
+    const frameId = raf(alignSideBranchStart);
+    return () => cancelRaf(frameId);
+  }, [autoScroll, contentRef, deferredMessages, disableAutoScroll, isHydratingTranscript, loading]);
+
+  const handleTranscriptWheel = useCallback(
+    (event: React.WheelEvent<HTMLDivElement>) => {
+      if (event.deltaX !== 0 || event.deltaY !== 0) {
+        clearActiveSideQuestionScrollHold();
+      }
+      handleScrollContainerWheel(event);
+    },
+    [clearActiveSideQuestionScrollHold, handleScrollContainerWheel]
+  );
+
+  const handleTranscriptMouseDown = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      clearActiveSideQuestionScrollHold();
+      handleScrollContainerMouseDown(event);
+    },
+    [clearActiveSideQuestionScrollHold, handleScrollContainerMouseDown]
+  );
+
+  const handleTranscriptTouchMove = useCallback(() => {
+    clearActiveSideQuestionScrollHold();
+    markUserScrollIntent();
+  }, [clearActiveSideQuestionScrollHold, markUserScrollIntent]);
+
+  const handleTranscriptKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      clearActiveSideQuestionScrollHold();
+      handleScrollContainerKeyDown(event);
+    },
+    [clearActiveSideQuestionScrollHold, handleScrollContainerKeyDown]
+  );
+
+  const handleJumpToBottom = useCallback(() => {
+    clearActiveSideQuestionScrollHold();
+    jumpToBottom();
+  }, [clearActiveSideQuestionScrollHold, jumpToBottom]);
+
   // Handler to navigate (scroll) to a specific message by historyId
   const handleNavigateToMessage = useCallback(
     (historyId: string) => {
       // Disable auto-scroll so the navigation isn't undone by streaming content
       disableAutoScroll();
       requestAnimationFrame(() => {
-        const element = contentRef.current?.querySelector(`[data-message-id="${historyId}"]`);
-        element?.scrollIntoView({ behavior: "smooth", block: "center" });
+        const scrollContainer = contentRef.current;
+        if (!scrollContainer) return;
+        findTranscriptMessageElement(scrollContainer, historyId)?.scrollIntoView({
+          behavior: "smooth",
+          block: "center",
+        });
       });
     },
     [contentRef, disableAutoScroll]
@@ -559,10 +706,12 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
 
     // Scroll to the message being edited
     requestAnimationFrame(() => {
-      const element = contentRef.current?.querySelector(
-        `[data-message-id="${lastUserMessage.historyId}"]`
-      );
-      element?.scrollIntoView({ behavior: "smooth", block: "center" });
+      const scrollContainer = contentRef.current;
+      if (!scrollContainer) return;
+      findTranscriptMessageElement(scrollContainer, lastUserMessage.historyId)?.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
     });
   }, [restoreQueuedDraft, contentRef, disableAutoScroll, setEditingMessage, transcriptOnly]);
 
@@ -579,8 +728,8 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
     // send success can be too late because the backend may not resolve until the
     // stream has already produced rows, leaving the first deltas offscreen when the
     // user had previously scrolled up.
-    jumpToBottom();
-  }, [jumpToBottom]);
+    handleJumpToBottom();
+  }, [handleJumpToBottom]);
 
   const handleMessageSent = useCallback(
     (dispatchMode: QueueDispatchMode = "tool-end") => {
@@ -593,31 +742,31 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
 
       // Slash-command send paths still report after backend success; keep this
       // harmless duplicate pin so those paths also re-arm auto-scroll.
-      jumpToBottom();
+      handleJumpToBottom();
     },
-    [autoBackgroundOnSend, jumpToBottom]
+    [autoBackgroundOnSend, handleJumpToBottom]
   );
 
   const handleClearHistory = useCallback(
     async (percentage = 1.0) => {
       // Re-arm the tail before clearing so the empty/starting state owns the bottom.
-      jumpToBottom();
+      handleJumpToBottom();
 
       // Truncate history in backend
       await api?.workspace.truncateHistory({ workspaceId, percentage });
     },
-    [workspaceId, jumpToBottom, api]
+    [workspaceId, handleJumpToBottom, api]
   );
 
   const handleResetContext = useCallback(async (): Promise<"reset" | "noop"> => {
-    jumpToBottom();
+    handleJumpToBottom();
 
     const result = await api?.workspace.resetContext({ workspaceId });
     if (!result?.success) {
       throw new Error(result?.error ?? "Failed to reset context");
     }
     return result.data;
-  }, [workspaceId, jumpToBottom, api]);
+  }, [workspaceId, handleJumpToBottom, api]);
 
   const openInEditor = useOpenInEditor();
   const handleOpenInEditor = useCallback(() => {
@@ -636,8 +785,8 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
   // the ref-backed auto-scroll flag and pins any cached rows before paint; if rows are still
   // hydrating, the next content resize owns the tail instead of showing the prior workspace's state.
   useLayoutEffect(() => {
-    jumpToBottom();
-  }, [hasLoadedTranscriptRows, jumpToBottom, workspaceId]);
+    handleJumpToBottom();
+  }, [hasLoadedTranscriptRows, handleJumpToBottom, workspaceId]);
 
   // Compute showRetryBarrier once for both keybinds and UI.
   // Track if last message was interrupted or errored (for RetryBarrier).
@@ -757,7 +906,7 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
       (workspaceState?.canInterrupt ?? false) || (workspaceState?.isStreamStarting ?? false),
     showRetryBarrier,
     chatInputAPI,
-    jumpToBottom,
+    jumpToBottom: handleJumpToBottom,
     loadOlderHistory: shouldRenderLoadOlderMessagesButton ? handleLoadOlderHistory : null,
     handleOpenTerminal: onOpenTerminal,
     handleOpenInEditor,
@@ -852,12 +1001,12 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
           <div className="mobile-header-spacer relative flex-1 overflow-hidden">
             <div
               ref={contentRef}
-              onWheel={handleScrollContainerWheel}
-              onMouseDown={handleScrollContainerMouseDown}
+              onWheel={handleTranscriptWheel}
+              onMouseDown={handleTranscriptMouseDown}
               onMouseMove={handleScrollContainerMouseMove}
               onMouseUp={handleScrollContainerMouseUp}
-              onTouchMove={markUserScrollIntent}
-              onKeyDown={handleScrollContainerKeyDown}
+              onTouchMove={handleTranscriptTouchMove}
+              onKeyDown={handleTranscriptKeyDown}
               onScroll={handleScroll}
               onContextMenu={transcriptContextMenu.onContextMenu}
               role="log"
@@ -1012,7 +1161,7 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
             {transcriptContextMenu.menu}
             {!autoScroll && (
               <button
-                onClick={jumpToBottom}
+                onClick={handleJumpToBottom}
                 type="button"
                 className="assistant-chip font-primary text-foreground hover:assistant-chip-hover absolute bottom-2 left-1/2 z-20 -translate-x-1/2 cursor-pointer rounded-[20px] px-2 py-1 text-xs font-medium shadow-[0_4px_12px_rgba(0,0,0,0.3)] backdrop-blur-[1px] transition-all duration-200 hover:scale-105 active:scale-95"
               >

--- a/src/browser/components/ChatPane/sideQuestionScrollHold.test.ts
+++ b/src/browser/components/ChatPane/sideQuestionScrollHold.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, test } from "bun:test";
+import type { DisplayedMessage } from "@/common/types/message";
+import {
+  findActiveSideQuestionScrollHoldTarget,
+  findSideQuestionScrollHoldTarget,
+} from "./sideQuestionScrollHold";
+
+function userMessage(
+  historyId: string,
+  opts: { isSideQuestion?: boolean } = {}
+): Extract<DisplayedMessage, { type: "user" }> {
+  return {
+    type: "user",
+    id: `${historyId}-0`,
+    historyId,
+    content: historyId,
+    historySequence: 1,
+    isSideQuestion: opts.isSideQuestion,
+  };
+}
+
+function assistantMessage(
+  historyId: string,
+  opts: { isSideAnswer?: boolean; isStreaming?: boolean } = {}
+): Extract<DisplayedMessage, { type: "assistant" }> {
+  return {
+    type: "assistant",
+    id: `${historyId}-0`,
+    historyId,
+    content: historyId,
+    historySequence: 1,
+    isStreaming: opts.isStreaming ?? false,
+    isPartial: false,
+    isCompacted: false,
+    isIdleCompacted: false,
+    isSideAnswer: opts.isSideAnswer,
+  };
+}
+
+function state(overrides: Partial<Parameters<typeof findSideQuestionScrollHoldTarget>[1]> = {}) {
+  return {
+    initialized: true,
+    heldSideQuestionIds: new Set<string>(),
+    previouslyStreamingSideAnswerIds: new Set<string>(),
+    heldSideAnswerIds: new Set<string>(),
+    ...overrides,
+  };
+}
+
+describe("findSideQuestionScrollHoldTarget", () => {
+  test("targets a newly visible side question when transcript rows already exist below it", () => {
+    const messages: DisplayedMessage[] = [
+      assistantMessage("main-1"),
+      userMessage("btw-q", { isSideQuestion: true }),
+      assistantMessage("main-1-post"),
+    ];
+
+    const result = findSideQuestionScrollHoldTarget(messages, state());
+
+    expect(result.targetHistoryId).toBe("btw-q");
+    expect([...result.nextState.heldSideQuestionIds]).toEqual(["btw-q"]);
+  });
+
+  test("waits to target a new side question until rows appear below it", () => {
+    const first = findSideQuestionScrollHoldTarget(
+      [assistantMessage("main-1"), userMessage("btw-q", { isSideQuestion: true })],
+      state()
+    );
+    expect(first.targetHistoryId).toBeUndefined();
+    expect([...first.nextState.heldSideQuestionIds]).toEqual([]);
+
+    const second = findSideQuestionScrollHoldTarget(
+      [
+        assistantMessage("main-1"),
+        userMessage("btw-q", { isSideQuestion: true }),
+        assistantMessage("main-1-post"),
+      ],
+      first.nextState
+    );
+
+    expect(second.targetHistoryId).toBe("btw-q");
+    expect([...second.nextState.heldSideQuestionIds]).toEqual(["btw-q"]);
+  });
+
+  test("does not target a standalone side question when only its answer is below it", () => {
+    const messages: DisplayedMessage[] = [
+      assistantMessage("main-1"),
+      userMessage("btw-q", { isSideQuestion: true }),
+      assistantMessage("btw-a", { isSideAnswer: true, isStreaming: true }),
+    ];
+
+    const result = findSideQuestionScrollHoldTarget(messages, state());
+
+    expect(result.targetHistoryId).toBeUndefined();
+    expect([...result.nextState.heldSideQuestionIds]).toEqual([]);
+  });
+
+  test("targets the side question when a streaming side answer has transcript rows below it", () => {
+    const messages: DisplayedMessage[] = [
+      assistantMessage("main-1"),
+      userMessage("btw-q", { isSideQuestion: true }),
+      assistantMessage("btw-a", { isSideAnswer: true, isStreaming: true }),
+      assistantMessage("main-1-post"),
+    ];
+
+    const result = findSideQuestionScrollHoldTarget(
+      messages,
+      state({ heldSideQuestionIds: new Set(["btw-q"]) })
+    );
+
+    expect(result.targetHistoryId).toBe("btw-q");
+    expect([...result.nextState.previouslyStreamingSideAnswerIds]).toEqual(["btw-a"]);
+    expect([...result.nextState.heldSideAnswerIds]).toEqual(["btw-a"]);
+  });
+
+  test("does not target while the side answer is still the transcript tail", () => {
+    const messages: DisplayedMessage[] = [
+      assistantMessage("main-1"),
+      userMessage("btw-q", { isSideQuestion: true }),
+      assistantMessage("btw-a", { isSideAnswer: true, isStreaming: true }),
+    ];
+
+    const result = findSideQuestionScrollHoldTarget(
+      messages,
+      state({ heldSideQuestionIds: new Set(["btw-q"]) })
+    );
+
+    expect(result.targetHistoryId).toBeUndefined();
+    expect([...result.nextState.previouslyStreamingSideAnswerIds]).toEqual(["btw-a"]);
+    expect([...result.nextState.heldSideAnswerIds]).toEqual([]);
+  });
+
+  test("targets a side answer that just settled when transcript rows now exist below it", () => {
+    const messages: DisplayedMessage[] = [
+      assistantMessage("main-1"),
+      userMessage("btw-q", { isSideQuestion: true }),
+      assistantMessage("btw-a", { isSideAnswer: true, isStreaming: false }),
+      assistantMessage("main-1-post"),
+    ];
+
+    const result = findSideQuestionScrollHoldTarget(
+      messages,
+      state({
+        heldSideQuestionIds: new Set(["btw-q"]),
+        previouslyStreamingSideAnswerIds: new Set(["btw-a"]),
+      })
+    );
+
+    expect(result.targetHistoryId).toBe("btw-q");
+    expect([...result.nextState.previouslyStreamingSideAnswerIds]).toEqual([]);
+    expect([...result.nextState.heldSideAnswerIds]).toEqual(["btw-a"]);
+  });
+
+  test("does not target the same side answer more than once", () => {
+    const messages: DisplayedMessage[] = [
+      assistantMessage("main-1"),
+      userMessage("btw-q", { isSideQuestion: true }),
+      assistantMessage("btw-a", { isSideAnswer: true, isStreaming: true }),
+      assistantMessage("main-1-post"),
+    ];
+
+    const result = findSideQuestionScrollHoldTarget(
+      messages,
+      state({
+        heldSideQuestionIds: new Set(["btw-q"]),
+        previouslyStreamingSideAnswerIds: new Set(["btw-a"]),
+        heldSideAnswerIds: new Set(["btw-a"]),
+      })
+    );
+
+    expect(result.targetHistoryId).toBeUndefined();
+    expect([...result.nextState.previouslyStreamingSideAnswerIds]).toEqual(["btw-a"]);
+    expect([...result.nextState.heldSideAnswerIds]).toEqual(["btw-a"]);
+  });
+
+  test("does not target side questions already present on initial render", () => {
+    const messages: DisplayedMessage[] = [
+      assistantMessage("main-1"),
+      userMessage("btw-q", { isSideQuestion: true }),
+      assistantMessage("btw-a", { isSideAnswer: true, isStreaming: false }),
+      assistantMessage("main-2"),
+    ];
+
+    const result = findSideQuestionScrollHoldTarget(messages, state({ initialized: false }));
+
+    expect(result.targetHistoryId).toBeUndefined();
+    expect([...result.nextState.heldSideQuestionIds]).toEqual(["btw-q"]);
+  });
+
+  test("does not target settled historical side answers after initial render", () => {
+    const messages: DisplayedMessage[] = [
+      assistantMessage("main-1"),
+      userMessage("btw-q", { isSideQuestion: true }),
+      assistantMessage("btw-a", { isSideAnswer: true, isStreaming: false }),
+      assistantMessage("main-2"),
+    ];
+
+    const result = findSideQuestionScrollHoldTarget(
+      messages,
+      state({ heldSideQuestionIds: new Set(["btw-q"]) })
+    );
+
+    expect(result.targetHistoryId).toBeUndefined();
+  });
+
+  test("keeps an active side-question hold aligned while its answer grows", () => {
+    const withoutAnswer = findActiveSideQuestionScrollHoldTarget(
+      [assistantMessage("main-1"), userMessage("btw-q", { isSideQuestion: true })],
+      "btw-q"
+    );
+    expect(withoutAnswer).toEqual({ targetHistoryId: "btw-q", keepActive: true });
+
+    const streamingAnswer = findActiveSideQuestionScrollHoldTarget(
+      [
+        assistantMessage("main-1"),
+        userMessage("btw-q", { isSideQuestion: true }),
+        assistantMessage("btw-a", { isSideAnswer: true, isStreaming: true }),
+        assistantMessage("main-1-post"),
+      ],
+      "btw-q"
+    );
+    expect(streamingAnswer).toEqual({ targetHistoryId: "btw-q", keepActive: true });
+
+    const settledAnswer = findActiveSideQuestionScrollHoldTarget(
+      [
+        assistantMessage("main-1"),
+        userMessage("btw-q", { isSideQuestion: true }),
+        assistantMessage("btw-a", { isSideAnswer: true, isStreaming: false }),
+        assistantMessage("main-1-post"),
+      ],
+      "btw-q"
+    );
+    expect(settledAnswer).toEqual({ targetHistoryId: "btw-q", keepActive: false });
+  });
+
+  test("falls back to the answer row when the side-question user row is unavailable", () => {
+    const messages: DisplayedMessage[] = [
+      assistantMessage("main-1"),
+      assistantMessage("btw-a", { isSideAnswer: true, isStreaming: true }),
+      assistantMessage("main-1-post"),
+    ];
+
+    const result = findSideQuestionScrollHoldTarget(messages, state());
+
+    expect(result.targetHistoryId).toBe("btw-a");
+  });
+});

--- a/src/browser/components/ChatPane/sideQuestionScrollHold.ts
+++ b/src/browser/components/ChatPane/sideQuestionScrollHold.ts
@@ -1,0 +1,134 @@
+import type { DisplayedMessage } from "@/common/types/message";
+
+export interface SideQuestionScrollHoldState {
+  initialized: boolean;
+  heldSideQuestionIds: ReadonlySet<string>;
+  previouslyStreamingSideAnswerIds: ReadonlySet<string>;
+  heldSideAnswerIds: ReadonlySet<string>;
+}
+
+export interface SideQuestionScrollHoldResult {
+  nextState: SideQuestionScrollHoldState;
+  targetHistoryId?: string;
+}
+
+export interface ActiveSideQuestionScrollHoldResult {
+  keepActive: boolean;
+  targetHistoryId?: string;
+}
+
+/**
+ * Continue aligning a side-question branch after the first hand-off from
+ * bottom-lock. The first scroll can happen before there is enough content below
+ * the branch for the browser to place it in a readable position, so active side
+ * holds keep re-aligning on subsequent stream updates until the side answer has
+ * produced one final settled render.
+ */
+export function findActiveSideQuestionScrollHoldTarget(
+  messages: readonly DisplayedMessage[],
+  activeTargetHistoryId: string | null | undefined
+): ActiveSideQuestionScrollHoldResult {
+  if (!activeTargetHistoryId) {
+    return { keepActive: false };
+  }
+
+  const sideQuestionIndex = messages.findIndex(
+    (message) =>
+      message.type === "user" &&
+      message.isSideQuestion === true &&
+      message.historyId === activeTargetHistoryId
+  );
+  if (sideQuestionIndex === -1) {
+    return { keepActive: false };
+  }
+
+  const nextMessage = messages[sideQuestionIndex + 1];
+  if (nextMessage?.type === "assistant" && nextMessage.isSideAnswer === true) {
+    return {
+      targetHistoryId: activeTargetHistoryId,
+      keepActive: nextMessage.isStreaming === true,
+    };
+  }
+
+  return { targetHistoryId: activeTargetHistoryId, keepActive: true };
+}
+
+/**
+ * Detect when a live /btw branch gains transcript rows below it while
+ * bottom-lock is still active. The user asked for the aside, so the first
+ * post-aside main-agent delta must transfer scroll ownership to the side branch
+ * instead of yanking the viewport down to the live transcript tail.
+ */
+export function findSideQuestionScrollHoldTarget(
+  messages: readonly DisplayedMessage[],
+  state: SideQuestionScrollHoldState
+): SideQuestionScrollHoldResult {
+  const nextHeldSideQuestionIds = new Set<string>();
+  const nextStreamingSideAnswerIds = new Set<string>();
+  const nextHeldSideAnswerIds = new Set<string>();
+  let targetHistoryId: string | undefined;
+
+  for (let index = 0; index < messages.length; index++) {
+    const message = messages[index];
+
+    if (message.type === "user" && message.isSideQuestion === true) {
+      const wasHeld = state.heldSideQuestionIds.has(message.historyId);
+      const nextMessage = messages[index + 1];
+      const branchEndIndex =
+        nextMessage?.type === "assistant" && nextMessage.isSideAnswer === true ? index + 1 : index;
+      const hasTranscriptRowsBelow = branchEndIndex < messages.length - 1;
+      if (!state.initialized || wasHeld) {
+        nextHeldSideQuestionIds.add(message.historyId);
+        continue;
+      }
+      if (hasTranscriptRowsBelow) {
+        nextHeldSideQuestionIds.add(message.historyId);
+        targetHistoryId = message.historyId;
+      }
+      continue;
+    }
+
+    if (message.type !== "assistant" || message.isSideAnswer !== true) {
+      continue;
+    }
+
+    if (message.isStreaming) {
+      nextStreamingSideAnswerIds.add(message.historyId);
+    }
+
+    const wasHeld = state.heldSideAnswerIds.has(message.historyId);
+    if (wasHeld) {
+      nextHeldSideAnswerIds.add(message.historyId);
+      continue;
+    }
+
+    const hasTranscriptRowsBelow = index < messages.length - 1;
+    if (!hasTranscriptRowsBelow) {
+      continue;
+    }
+
+    const wasStreaming = state.previouslyStreamingSideAnswerIds.has(message.historyId);
+    const shouldHold = message.isStreaming || wasStreaming;
+    if (!shouldHold) {
+      continue;
+    }
+
+    nextHeldSideAnswerIds.add(message.historyId);
+
+    const sideQuestion = messages[index - 1];
+    targetHistoryId =
+      sideQuestion?.type === "user" && sideQuestion.isSideQuestion === true
+        ? sideQuestion.historyId
+        : message.historyId;
+  }
+
+  return {
+    nextState: {
+      initialized: true,
+      heldSideQuestionIds: nextHeldSideQuestionIds,
+      previouslyStreamingSideAnswerIds: nextStreamingSideAnswerIds,
+      heldSideAnswerIds: nextHeldSideAnswerIds,
+    },
+    targetHistoryId,
+  };
+}

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
@@ -1058,7 +1058,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
           const metadata = workspaceStore.getWorkspaceMetadata(workspaceId);
           const displayTitle = metadata?.title ?? metadata?.name ?? workspaceId;
           const aggregator = workspaceStore.getAggregator(workspaceId);
-          const hasActiveStreams = (aggregator?.getActiveStreams().length ?? 0) > 0;
+          const hasActiveStreams = aggregator?.hasInterruptibleActiveStream() ?? false;
           const pendingStreamStartTime = aggregator?.getPendingStreamStartTime();
           const isStarting = pendingStreamStartTime != null && !hasActiveStreams;
           const awaitingUserQuestion = aggregator?.hasAwaitingUserQuestion() ?? false;
@@ -1095,7 +1095,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                   isStreaming: (() => {
                     const aggregator = workspaceStore.getAggregator(workspaceId);
                     if (!aggregator) return false;
-                    const hasActiveStreams = aggregator.getActiveStreams().length > 0;
+                    const hasActiveStreams = aggregator.hasInterruptibleActiveStream();
                     const isStarting =
                       aggregator.getPendingStreamStartTime() !== null && !hasActiveStreams;
                     const awaitingUserQuestion = aggregator.hasAwaitingUserQuestion();
@@ -1130,7 +1130,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
     (workspaceId: string) => {
       const aggregator = workspaceStore.getAggregator(workspaceId);
       if (!aggregator) return false;
-      const hasActiveStreams = aggregator.getActiveStreams().length > 0;
+      const hasActiveStreams = aggregator.hasInterruptibleActiveStream();
       const isStarting = aggregator.getPendingStreamStartTime() !== null && !hasActiveStreams;
       const awaitingUserQuestion = aggregator.hasAwaitingUserQuestion();
       return (hasActiveStreams || isStarting) && !awaitingUserQuestion;
@@ -1142,7 +1142,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
     (workspace: FrontendWorkspaceMetadata) => {
       const workspaceId = workspace.id;
       const aggregator = workspaceStore.getAggregator(workspaceId);
-      const hasActiveStreams = aggregator ? aggregator.getActiveStreams().length > 0 : false;
+      const hasActiveStreams = aggregator?.hasInterruptibleActiveStream() ?? false;
       const isStarting = aggregator?.getPendingStreamStartTime() != null && !hasActiveStreams;
       const awaitingUserQuestion = aggregator?.hasAwaitingUserQuestion() ?? false;
       const isWorking = (hasActiveStreams || isStarting) && !awaitingUserQuestion;

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -87,7 +87,6 @@ import {
   type SlashSuggestion,
 } from "@/browser/utils/slashCommands/suggestions";
 import { resolveSlashCommandExperimentValue } from "@/browser/utils/slashCommands/experimentVisibility";
-import { getPlaceholderTip } from "./placeholderTips";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/browser/components/Tooltip/Tooltip";
 import { AgentModePicker } from "@/browser/components/AgentModePicker/AgentModePicker";
 import { ContextUsageIndicatorButton } from "@/browser/components/ContextUsageIndicatorButton/ContextUsageIndicatorButton";
@@ -95,6 +94,7 @@ import {
   useOptionalWorkspaceSidebarState,
   useWorkspaceUsage,
 } from "@/browser/stores/WorkspaceStore";
+import { getPlaceholderTip } from "./placeholderTips";
 import { useProviderOptions } from "@/browser/hooks/useProviderOptions";
 import { useProvidersConfig } from "@/browser/hooks/useProvidersConfig";
 import { useAutoCompactionSettings } from "@/browser/hooks/useAutoCompactionSettings";
@@ -242,7 +242,16 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     EXPERIMENT_IDS.WORKSPACE_HEARTBEATS
   );
   const atMentionProjectPath = variant === "creation" ? props.projectPath : null;
+  const asyncCommandScopeRef = useRef<{ variant: typeof variant; workspaceId: string | null }>({
+    variant,
+    workspaceId: variant === "workspace" ? props.workspaceId : null,
+  });
+  const asyncCommandTokenRef = useRef(0);
   const workspaceId = variant === "workspace" ? props.workspaceId : null;
+
+  useEffect(() => {
+    asyncCommandScopeRef.current = { variant, workspaceId };
+  }, [variant, workspaceId]);
 
   const workspaceSidebarState = useOptionalWorkspaceSidebarState(workspaceId);
   const workspaceGoal = workspaceSidebarState?.goal ?? null;
@@ -1931,6 +1940,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     };
     // Prepare file parts for commands that need to send messages with attachments
     const commandFileParts = chatAttachmentsToFileParts(attachments, { validate: true });
+    const asyncCommandToken = ++asyncCommandTokenRef.current;
     const commandContext: SlashCommandContext = {
       api,
       variant,
@@ -1939,12 +1949,22 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       openSettings: open,
       currentModel: workspaceSidebarState?.currentModel ?? null,
       sendMessageOptions: commandSendMessageOptions,
+      getInput: () => getDraft().text,
       setInput,
       setAttachments,
       setSendingState: (increment: boolean) => setSendingCount((c) => c + (increment ? 1 : -1)),
       setToast,
       setPreferredModel,
       setVimEnabled,
+      asyncCommandToken,
+      isAsyncCommandCurrent: (token, originWorkspaceId) => {
+        const scope = asyncCommandScopeRef.current;
+        return (
+          token === asyncCommandTokenRef.current &&
+          scope.variant === "workspace" &&
+          scope.workspaceId === originWorkspaceId
+        );
+      },
       onResetContext: variant === "workspace" ? props.onResetContext : undefined,
       onTruncateHistory: variant === "workspace" ? props.onTruncateHistory : undefined,
       resetInputHeight: () => {
@@ -2248,6 +2268,12 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       if (commandHandled) {
         return;
       }
+
+      // A normal workspace send supersedes any pending fire-and-forget slash
+      // command completion (notably /btw). If that older async command fails
+      // after this send clears the composer, it must not restore stale command
+      // text over the newer turn.
+      asyncCommandTokenRef.current++;
 
       const modelOverride = modelOneShot?.modelString;
 

--- a/src/browser/features/ChatInput/placeholderTips.test.ts
+++ b/src/browser/features/ChatInput/placeholderTips.test.ts
@@ -7,6 +7,30 @@ interface StorybookGlobal {
 
 const TWENTY_MIN_MS = 20 * 60 * 1000;
 
+describe("PLACEHOLDER_TIPS", () => {
+  test("every tip references a slash command", () => {
+    for (const tip of PLACEHOLDER_TIPS) {
+      expect(tip).toMatch(/\/[A-Za-z+]/);
+    }
+  });
+
+  test("tips are unique", () => {
+    const unique = new Set(PLACEHOLDER_TIPS);
+    expect(unique.size).toBe(PLACEHOLDER_TIPS.length);
+  });
+
+  test("leads with the /orchestrate tip so the pinned Storybook slot promotes the new skill", () => {
+    // /orchestrate is unadvertised in the system-prompt skill index, so the
+    // tip carousel is one of the few discovery surfaces users will see it on.
+    // Placing it at the lead slot has two consequences this assertion locks in:
+    //   1) It's the tip a user sees on degenerate-timer fallback.
+    //   2) It's the tip every Chromatic story renders via the Storybook pin.
+    // Demoting it from index 0 would silently regress both surfaces, so we
+    // assert the position rather than just the presence.
+    expect(PLACEHOLDER_TIPS[0]).toMatch(/\/orchestrate\b/);
+  });
+});
+
 describe("getPlaceholderTip", () => {
   afterEach(() => {
     // Always clear the storybook flag so one test's pin-mode doesn't leak
@@ -67,16 +91,5 @@ describe("getPlaceholderTip", () => {
     const before = getPlaceholderTip(bucketStart);
     const after = getPlaceholderTip(bucketStart + TWENTY_MIN_MS);
     expect(after).not.toBe(before);
-  });
-
-  test("leads with the /orchestrate tip so the pinned Storybook slot promotes the new skill", () => {
-    // /orchestrate is unadvertised in the system-prompt skill index, so the
-    // tip carousel is one of the few discovery surfaces users will see it on.
-    // Placing it at the lead slot has two consequences this assertion locks in:
-    //   1) It's the tip a user sees on degenerate-timer fallback.
-    //   2) It's the tip every Chromatic story renders via the Storybook pin.
-    // Demoting it from index 0 would silently regress both surfaces, so we
-    // assert the position rather than just the presence.
-    expect(PLACEHOLDER_TIPS[0]).toMatch(/\/orchestrate\b/);
   });
 });

--- a/src/browser/features/ChatInput/placeholderTips.ts
+++ b/src/browser/features/ChatInput/placeholderTips.ts
@@ -41,6 +41,7 @@ const STORYBOOK_PINNED_TIP_INDEX = 0;
 
 export const PLACEHOLDER_TIPS: readonly string[] = [
   "Try /orchestrate to coordinate sub-agents and integrate their patches",
+  "Try /btw <question> to ask a side question without nudging the agent",
   "Try /haiku <msg> to send just this message on a different model",
   "Try /+high <msg> to crank up reasoning for this message only",
   "Try /compact to summarize the conversation when context gets tight",

--- a/src/browser/features/Messages/AssistantMessage.tsx
+++ b/src/browser/features/Messages/AssistantMessage.tsx
@@ -12,6 +12,11 @@ import {
   Moon,
   Package,
 } from "lucide-react";
+import { cn } from "@/common/lib/utils";
+import {
+  SIDE_QUESTION_ANSWER_BLOCK_CLASS,
+  SIDE_QUESTION_MESSAGE_WINDOW_CLASS,
+} from "./sideQuestionStyles";
 import { ShareMessagePopover } from "@/browser/components/ShareMessagePopover/ShareMessagePopover";
 import { PopoverError } from "@/browser/components/PopoverError/PopoverError";
 import { useAPI } from "@/browser/contexts/API";
@@ -56,6 +61,7 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
   const isCompacted = message.isCompacted;
   const isBeforeLatestContextBoundary = message.isBeforeLatestContextBoundary === true;
   const isStreamingCompaction = isStreaming && isCompacting;
+  const isSideAnswer = message.isSideAnswer === true;
 
   // Use Start Here hook for final assistant messages
   const {
@@ -110,7 +116,12 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
 
   const buttons: ButtonConfig[] = isStreaming ? [] : [copyButton];
 
-  if (!isStreaming) {
+  if (!isStreaming && !isSideAnswer) {
+    // Side answers intentionally show only Copy. The /btw side branch is
+    // meant to feel lightweight: Start Here / Fork / Share / Show Text
+    // would imply the message is a fork point in the main agent thread,
+    // which it isn't. Keeping the action set minimal also keeps the pair
+    // visually quiet against the main transcript.
     buttons.push({
       label: startHereLabel,
       onClick: openStartHereModal,
@@ -230,18 +241,35 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
     );
   };
 
+  const messageWindow = (
+    <MessageWindow
+      label={renderLabel()}
+      variant="assistant"
+      message={message}
+      buttons={buttons}
+      // For /btw answers the outer wrapper owns spacing around the pair.
+      className={cn(className, isSideAnswer && SIDE_QUESTION_MESSAGE_WINDOW_CLASS)}
+      backgroundEffect={isStreamingCompaction ? <CompactionBackground /> : undefined}
+    >
+      {renderContent()}
+    </MessageWindow>
+  );
+
+  // /btw side-answer: wrap the normal assistant bubble in the same
+  // thin-stripe block as the user question above it. Do not add another
+  // header here: the "Side question" label on the user row already marks
+  // the whole Q/A branch, and repeating it on the answer felt noisy.
+  const wrappedMessageWindow = isSideAnswer ? (
+    <div className={cn(SIDE_QUESTION_ANSWER_BLOCK_CLASS, className)} data-side-answer>
+      {messageWindow}
+    </div>
+  ) : (
+    messageWindow
+  );
+
   return (
     <>
-      <MessageWindow
-        label={renderLabel()}
-        variant="assistant"
-        message={message}
-        buttons={buttons}
-        className={className}
-        backgroundEffect={isStreamingCompaction ? <CompactionBackground /> : undefined}
-      >
-        {renderContent()}
-      </MessageWindow>
+      {wrappedMessageWindow}
 
       <PopoverError
         error={forkError.error}

--- a/src/browser/features/Messages/MessageWindow.tsx
+++ b/src/browser/features/Messages/MessageWindow.tsx
@@ -37,6 +37,7 @@ export const MessageWindow: React.FC<MessageWindowProps> = ({
   message,
   buttons = [],
   children,
+  className,
   rightLabel,
   backgroundEffect,
 }) => {
@@ -84,7 +85,12 @@ export const MessageWindow: React.FC<MessageWindowProps> = ({
         // Pair the extra bottom margin with the meta row so the surrounding transcript
         // space only changes at the same (settled) moment as the meta row appearing,
         // avoiding a second separate tear step.
-        isSettledLastPart && "mb-4"
+        isSettledLastPart && "mb-4",
+        // Caller-supplied class — used by side-question rendering to apply
+        // the "side branch" left-accent treatment. Previously declared but
+        // never spread onto the outer container, so callers couldn't theme
+        // a message block at all.
+        className
       )}
       data-message-block
     >

--- a/src/browser/features/Messages/UserMessage.tsx
+++ b/src/browser/features/Messages/UserMessage.tsx
@@ -16,7 +16,20 @@ import {
 } from "@/browser/utils/chatEditing";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
 import { VIM_ENABLED_KEY } from "@/common/constants/storage";
-import { ChevronLeft, ChevronRight, Clipboard, ClipboardCheck, Pencil, Target } from "lucide-react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Clipboard,
+  ClipboardCheck,
+  MessageCircleQuestion,
+  Pencil,
+  Target,
+} from "lucide-react";
+import {
+  SIDE_QUESTION_HEADER_CLASS,
+  SIDE_QUESTION_MESSAGE_WINDOW_CLASS,
+  SIDE_QUESTION_USER_BLOCK_CLASS,
+} from "./sideQuestionStyles";
 
 /** Navigation info for navigating between user messages */
 export interface UserMessageNavigation {
@@ -162,6 +175,12 @@ export const UserMessage: React.FC<UserMessageProps> = ({
       </span>
     );
   }
+  // /btw side-question rows keep the normal user bubble (background,
+  // border, right-alignment) and add a small "Side question" header above
+  // it plus a thin left stripe on the wrapper. We deliberately do NOT
+  // bypass MessageWindow here — the user feedback was that an aside
+  // should read inline with the chat aesthetic, not as a distinct block.
+  const isSideQuestion = message.isSideQuestion === true;
   const syntheticClassName = cn(
     className,
     isSynthetic && "opacity-70",
@@ -192,15 +211,37 @@ export const UserMessage: React.FC<UserMessageProps> = ({
     );
   }
 
-  return (
+  const messageWindow = (
     <MessageWindow
       label={label}
       message={message}
       buttons={buttons}
-      className={syntheticClassName}
+      // For /btw rows the outer wrapper owns spacing around the pair.
+      className={cn(syntheticClassName, isSideQuestion && SIDE_QUESTION_MESSAGE_WINDOW_CLASS)}
       variant="user"
     >
       {renderedContent}
     </MessageWindow>
   );
+
+  // /btw side-question: wrap the normal user bubble in a thin-stripe block
+  // and prepend a small "Side question" header. The bubble's right-align
+  // and styling is unchanged — only the surrounding chrome differs.
+  if (isSideQuestion) {
+    return (
+      <div
+        className={cn(SIDE_QUESTION_USER_BLOCK_CLASS, className)}
+        data-message-block
+        data-side-question
+      >
+        <div className={SIDE_QUESTION_HEADER_CLASS}>
+          <MessageCircleQuestion aria-hidden="true" className="h-3 w-3" />
+          Side question
+        </div>
+        {messageWindow}
+      </div>
+    );
+  }
+
+  return messageWindow;
 };

--- a/src/browser/features/Messages/sideQuestionStyles.ts
+++ b/src/browser/features/Messages/sideQuestionStyles.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared visual treatment for the persisted /btw Q/A pair. The normal user
+ * and assistant bubbles stay intact; these classes add only a light left
+ * stripe, paired spacing, and the single "Side question" header.
+ */
+const SIDE_QUESTION_STRIPE = "border-l border-muted/30 pl-3 ml-1";
+
+/** MessageWindow margins are owned by the side-branch wrapper for paired spacing. */
+export const SIDE_QUESTION_MESSAGE_WINDOW_CLASS = "!mt-0 !mb-0";
+
+/**
+ * Visual treatment for the user-side /btw question row.
+ *
+ * `mb-0` collapses the bottom margin so the assistant answer tucks flush
+ * against this row — tailwind-merge will resolve this against the default
+ * `mb-1` / `mb-4` baked into MessageWindow.
+ */
+export const SIDE_QUESTION_USER_BLOCK_CLASS = `${SIDE_QUESTION_STRIPE} mt-4 mb-0`;
+
+/**
+ * Visual treatment for the assistant-side /btw answer row.
+ *
+ * `mt-0` overrides MessageWindow's default `mt-4` so the answer abuts the
+ * user question above with no visible gap. The bottom margin is left to
+ * MessageWindow (default mb-1 / settled mb-4) so the side branch still
+ * has breathing room before the next main-agent turn.
+ */
+export const SIDE_QUESTION_ANSWER_BLOCK_CLASS = `${SIDE_QUESTION_STRIPE} mt-0`;
+
+/**
+ * Tailwind classes for the small uppercase "Side question" header label
+ * that introduces the side-branch user bubble.
+ *
+ * The header is placed BEFORE the MessageWindow so it can introduce the
+ * bubble — MessageWindow's existing `label` slot only renders into its
+ * bottom meta row, which is the wrong affordance here (we want a header,
+ * not a footer caption).
+ */
+export const SIDE_QUESTION_HEADER_CLASS =
+  "text-muted mb-1 flex items-center gap-1 text-[10px] font-medium tracking-wide uppercase";

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -747,6 +747,52 @@ describe("WorkspaceStore", () => {
       expect(collapsed).toBe(true);
     });
 
+    it("does not collapse the pinned todo panel when an overlapping /btw answer ends", () => {
+      const workspaceId = "pinned-todo-side-answer-end";
+      const pinnedTodoKey = getPinnedTodoExpandedKey(workspaceId);
+
+      createAndAddWorkspace(store, workspaceId);
+      localStorageBacking.set(pinnedTodoKey, JSON.stringify(true));
+      seedPinnedTodos(store, workspaceId, pinnedTodos);
+
+      const rawStore = getInternal<{
+        handleChatMessage: (workspaceId: string, data: WorkspaceChatMessage) => void;
+      }>(store);
+      rawStore.handleChatMessage(workspaceId, {
+        type: "message",
+        id: "btw-answer-with-main-todos",
+        role: "assistant",
+        parts: [],
+        metadata: {
+          historySequence: 2,
+          timestamp: 2_000,
+          model: "claude-haiku-3.5",
+          muxMetadata: { type: "side-question-answer" },
+        },
+      });
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-start",
+        workspaceId,
+        messageId: "btw-answer-with-main-todos",
+        model: "claude-haiku-3.5",
+        historySequence: 2,
+        startTime: 2_100,
+      });
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-end",
+        workspaceId,
+        messageId: "btw-answer-with-main-todos",
+        parts: [{ type: "text", text: "side done" }],
+        metadata: {
+          model: "claude-haiku-3.5",
+          historySequence: 2,
+          muxMetadata: { type: "side-question-answer" },
+        },
+      });
+
+      expect(localStorageBacking.get(pinnedTodoKey)).toBe(JSON.stringify(true));
+    });
+
     it("persists a collapsed panel when an active workspace stream aborts with todos", async () => {
       const workspaceId = "pinned-todo-stream-abort";
       const pinnedTodoKey = getPinnedTodoExpandedKey(workspaceId);
@@ -5024,6 +5070,311 @@ describe("WorkspaceStore", () => {
       expect(usage.lastContextUsage?.input.tokens).toBe(42);
       expect(usage.lastContextUsage?.output.tokens).toBe(0);
       expect(usage.lastContextUsage?.model).toBe("claude-3-5-sonnet-20241022");
+    });
+  });
+
+  describe("/btw side-question interruption flow", () => {
+    /**
+     * The contract under test: while a /btw answer is streaming, the side
+     * branch stays at the captured interruption point instead of sticking to
+     * the transcript tail. Main-agent deltas keep flowing into the post-aside
+     * segment below the /btw pair.
+     */
+    it("renders main-agent stream-deltas below /btw while the side answer streams", async () => {
+      const workspaceId = "btw-tail-flow";
+      recreateStore();
+      await tick(0);
+      createAndAddWorkspace(store, workspaceId);
+
+      const rawStore = getInternal<{
+        handleChatMessage: (workspaceId: string, data: WorkspaceChatMessage) => void;
+      }>(store);
+
+      // Catch up so live events flow through processStreamEvent instead of
+      // queueing into pendingStreamEvents.
+      rawStore.handleChatMessage(workspaceId, { type: "caught-up" });
+
+      // Open a main agent stream and seed one delta as the baseline. After
+      // this, the visible text for `main-1` is "hi ".
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-start",
+        workspaceId,
+        messageId: "main-1",
+        model: TEST_MODEL,
+        historySequence: 1,
+        startTime: 1_000,
+      });
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-delta",
+        workspaceId,
+        messageId: "main-1",
+        delta: "hi ",
+        tokens: 1,
+        timestamp: 1_100,
+      });
+
+      const aggregator = store.getAggregator(workspaceId);
+      if (!aggregator) throw new Error("aggregator missing");
+
+      const readMainText = (): string => {
+        const msg = aggregator.getAllMessages().find((m: { id: string }) => m.id === "main-1");
+        if (!msg) return "";
+        const firstPart = (msg as { parts: Array<{ type: string; text?: string }> }).parts[0];
+        return firstPart?.type === "text" ? (firstPart.text ?? "") : "";
+      };
+      expect(readMainText()).toBe("hi ");
+
+      // /btw kicks off. The pipeline persists a user envelope (with the
+      // interruption snapshot — see sideQuestionService's `interruption`
+      // capture), a placeholder envelope, then opens stream-start.
+      rawStore.handleChatMessage(workspaceId, {
+        type: "message",
+        id: "btw-user-1",
+        role: "user",
+        parts: [{ type: "text", text: "/btw what's 2+2" }],
+        metadata: {
+          historySequence: 2,
+          timestamp: 1_200,
+          muxMetadata: {
+            type: "side-question",
+            rawCommand: "/btw what's 2+2",
+            // The pre-aside half ends at text length 3 ("hi ") — the renderer
+            // splits main-1's content there in the transcript.
+            interruptedMessageId: "main-1",
+            interruptedTextLength: 3,
+            interruptedHistorySequence: 1,
+          },
+        },
+      });
+      rawStore.handleChatMessage(workspaceId, {
+        type: "message",
+        id: "btw-ans-1",
+        role: "assistant",
+        parts: [],
+        metadata: {
+          historySequence: 3,
+          timestamp: 1_300,
+          model: "claude-haiku-3.5",
+          muxMetadata: { type: "side-question-answer" },
+        },
+      });
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-start",
+        workspaceId,
+        messageId: "btw-ans-1",
+        model: "claude-haiku-3.5",
+        historySequence: 3,
+        startTime: 1_400,
+      });
+
+      // Main agent emits a delta while /btw is in flight. It should keep
+      // flowing into the interrupted main message so the side branch does
+      // not remain pinned to the transcript tail for the whole side stream.
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-delta",
+        workspaceId,
+        messageId: "main-1",
+        delta: "there ",
+        tokens: 1,
+        timestamp: 1_500,
+      });
+      expect(readMainText()).toBe("hi there ");
+
+      // The side answer streams normally and lands on its own message.
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-delta",
+        workspaceId,
+        messageId: "btw-ans-1",
+        delta: "four",
+        tokens: 1,
+        timestamp: 1_600,
+      });
+      const sideMsg = aggregator
+        .getAllMessages()
+        .find((m: { id: string }) => m.id === "btw-ans-1") as
+        | { parts: Array<{ type: string; text?: string }> }
+        | undefined;
+      const sidePart = sideMsg?.parts[0];
+      expect(sidePart?.type === "text" ? sidePart.text : undefined).toBe("four");
+
+      // While the side answer is still streaming, the /btw pair is already
+      // inserted at the interruption point with post-aside main content below.
+      const readVisibleHistoryIds = (): string[] =>
+        aggregator
+          .getDisplayedMessages()
+          .filter((m) => m.type === "assistant" || m.type === "user")
+          .map((m) => m.historyId);
+      expect(readVisibleHistoryIds()).toEqual(["main-1", "btw-user-1", "btw-ans-1", "main-1"]);
+
+      // After /btw settles, the underlying main message still has the full
+      // text and the displayed rows keep the same split order.
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-end",
+        workspaceId,
+        messageId: "btw-ans-1",
+        parts: [{ type: "text", text: "four" }],
+        metadata: {
+          model: "claude-haiku-3.5",
+          timestamp: 1_700,
+          duration: 300,
+          historySequence: 3,
+        },
+      });
+      expect(readMainText()).toBe("hi there ");
+      expect(readVisibleHistoryIds()).toEqual(["main-1", "btw-user-1", "btw-ans-1", "main-1"]);
+      const mainRows = aggregator
+        .getDisplayedMessages()
+        .filter(
+          (m): m is Extract<typeof m, { type: "assistant"; content: string }> =>
+            m.type === "assistant" && m.historyId === "main-1"
+        );
+      expect(mainRows.map((m) => m.content)).toEqual(["hi ", "there "]);
+    });
+    it("keeps standalone /btw answer streams out of workspace interrupt state", async () => {
+      const workspaceId = "btw-standalone-not-busy";
+      recreateStore();
+      await tick(0);
+      createAndAddWorkspace(store, workspaceId);
+
+      const rawStore = getInternal<{
+        handleChatMessage: (workspaceId: string, data: WorkspaceChatMessage) => void;
+      }>(store);
+      rawStore.handleChatMessage(workspaceId, { type: "caught-up" });
+
+      rawStore.handleChatMessage(workspaceId, {
+        type: "message",
+        id: "btw-user-standalone",
+        role: "user",
+        parts: [{ type: "text", text: "/btw what's next?" }],
+        metadata: {
+          historySequence: 1,
+          timestamp: 1_000,
+          muxMetadata: {
+            type: "side-question",
+            rawCommand: "/btw what's next?",
+            commandPrefix: "/btw",
+          },
+        },
+      });
+      rawStore.handleChatMessage(workspaceId, {
+        type: "message",
+        id: "btw-answer-standalone",
+        role: "assistant",
+        parts: [],
+        metadata: {
+          historySequence: 2,
+          timestamp: 1_100,
+          model: "claude-haiku-3.5",
+          muxMetadata: { type: "side-question-answer" },
+        },
+      });
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-start",
+        workspaceId,
+        messageId: "btw-answer-standalone",
+        model: "claude-haiku-3.5",
+        historySequence: 2,
+        startTime: 1_200,
+      });
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-delta",
+        workspaceId,
+        messageId: "btw-answer-standalone",
+        delta: "side answer",
+        tokens: 1,
+        timestamp: 1_300,
+      });
+
+      const aggregator = store.getAggregator(workspaceId);
+      expect(aggregator?.isSideQuestionStreaming()).toBe(true);
+      const state = store.getWorkspaceState(workspaceId);
+      expect(state.canInterrupt).toBe(false);
+      expect(state.isStreamStarting).toBe(false);
+      expect(
+        aggregator
+          ?.getAllMessages()
+          .find((message) => message.id === "btw-answer-standalone")
+          ?.parts.some((part) => part.type === "text" && part.text === "side answer")
+      ).toBe(true);
+    });
+    it("keeps replayed /btw answer streams out of workspace interrupt state", async () => {
+      const workspaceId = "btw-replay-side-only-not-busy";
+      recreateStore();
+      await tick(0);
+      createAndAddWorkspace(store, workspaceId);
+
+      const rawStore = getInternal<{
+        handleChatMessage: (workspaceId: string, data: WorkspaceChatMessage) => void;
+      }>(store);
+
+      rawStore.handleChatMessage(workspaceId, {
+        type: "message",
+        id: "btw-answer-replay",
+        role: "assistant",
+        parts: [],
+        metadata: {
+          historySequence: 1,
+          timestamp: 1_000,
+          model: "claude-haiku-3.5",
+          muxMetadata: { type: "side-question-answer" },
+        },
+      });
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-start",
+        workspaceId,
+        messageId: "btw-answer-replay",
+        model: "claude-haiku-3.5",
+        historySequence: 1,
+        startTime: 1_100,
+      });
+
+      const state = store.getWorkspaceState(workspaceId);
+      expect(state.canInterrupt).toBe(false);
+      expect(state.isStreamStarting).toBe(false);
+    });
+
+    it("preserves buffered main-stream interrupt state when /btw starts during replay", async () => {
+      const workspaceId = "btw-buffered-main-stays-busy";
+      recreateStore();
+      await tick(0);
+      createAndAddWorkspace(store, workspaceId);
+
+      const rawStore = getInternal<{
+        handleChatMessage: (workspaceId: string, data: WorkspaceChatMessage) => void;
+      }>(store);
+
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-start",
+        workspaceId,
+        messageId: "main-buffered",
+        model: TEST_MODEL,
+        historySequence: 1,
+        startTime: 1_000,
+      });
+      expect(store.getWorkspaceState(workspaceId).canInterrupt).toBe(true);
+
+      rawStore.handleChatMessage(workspaceId, {
+        type: "message",
+        id: "btw-answer-buffered",
+        role: "assistant",
+        parts: [],
+        metadata: {
+          historySequence: 2,
+          timestamp: 1_100,
+          model: "claude-haiku-3.5",
+          muxMetadata: { type: "side-question-answer" },
+        },
+      });
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-start",
+        workspaceId,
+        messageId: "btw-answer-buffered",
+        model: "claude-haiku-3.5",
+        historySequence: 2,
+        startTime: 1_200,
+      });
+
+      expect(store.getWorkspaceState(workspaceId).canInterrupt).toBe(true);
     });
   });
 });

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -63,6 +63,7 @@ import { getModelStats } from "@/common/utils/tokens/modelStats";
 import { resolveModelForMetadata } from "@/common/utils/providers/modelEntries";
 import { computeProvidersConfigFingerprint } from "@/common/utils/providers/configFingerprint";
 import { isDurableCompactionBoundaryMarker } from "@/common/utils/messages/compactionBoundary";
+import { isSideQuestionAnswerMessage as isSideQuestionAnswerMuxMessage } from "@/common/utils/messages/sideQuestion";
 import { WorkspaceConsumerManager } from "./WorkspaceConsumerManager";
 import type { ChatUsageDisplay } from "@/common/utils/tokens/usageAggregator";
 import { sumUsageHistory } from "@/common/utils/tokens/usageAggregator";
@@ -277,16 +278,35 @@ function createInitialHistoryPaginationState(): WorkspaceHistoryPaginationState 
 }
 
 function getBufferedActiveStreamStart(
-  events: WorkspaceChatMessage[]
+  events: WorkspaceChatMessage[],
+  historicalMessages: readonly MuxMessage[],
+  isSideQuestionAnswerMessageId: (messageId: string) => boolean
 ): Pick<StreamStartEvent, "model" | "thinkingLevel"> | null {
   let activeStreamStart: StreamStartEvent | null = null;
+  const sideQuestionAnswerMessageIds = new Set<string>();
+
+  for (const message of historicalMessages) {
+    if (isSideQuestionAnswerMuxMessage(message)) {
+      sideQuestionAnswerMessageIds.add(message.id);
+    }
+  }
 
   for (const event of events) {
+    if (isMuxMessage(event) && isSideQuestionAnswerMuxMessage(event)) {
+      sideQuestionAnswerMessageIds.add(event.id);
+    }
+
     if (!("type" in event)) {
       continue;
     }
 
     if (event.type === "stream-start") {
+      if (
+        sideQuestionAnswerMessageIds.has(event.messageId) ||
+        isSideQuestionAnswerMessageId(event.messageId)
+      ) {
+        continue;
+      }
       activeStreamStart = event;
       continue;
     }
@@ -754,7 +774,12 @@ export class WorkspaceStore {
         }
       }
 
-      collapsePinnedTodoOnStreamStop(workspaceId, aggregator.getCurrentTodos().length > 0);
+      const isSideQuestionAnswerStream = aggregator.isSideQuestionAnswerMessage(
+        streamEndData.messageId
+      );
+      if (!isSideQuestionAnswerStream) {
+        collapsePinnedTodoOnStreamStop(workspaceId, aggregator.getCurrentTodos().length > 0);
+      }
 
       // Flush any pending debounced bump before final bump to avoid double-bump
       this.cancelPendingIdleBump(workspaceId);
@@ -1714,7 +1739,7 @@ export class WorkspaceStore {
       const transient = this.assertChatTransientState(workspaceId);
       const historyPagination =
         this.historyPagination.get(workspaceId) ?? createInitialHistoryPaginationState();
-      const activeStreams = aggregator.getActiveStreams();
+      const hasInterruptibleActiveStream = aggregator.hasInterruptibleActiveStream();
       const activity = this.workspaceActivity.get(workspaceId);
       const isActiveWorkspace = this.activeOnChatWorkspaceId === workspaceId;
       const messages = aggregator.getAllMessages();
@@ -1723,7 +1748,11 @@ export class WorkspaceStore {
       const streamLifecycle = aggregator.getStreamLifecycle();
       const bufferedActiveStreamStart =
         isActiveWorkspace && !transient.caughtUp
-          ? getBufferedActiveStreamStart(transient.pendingStreamEvents)
+          ? getBufferedActiveStreamStart(
+              transient.pendingStreamEvents,
+              transient.historicalMessages,
+              (messageId) => aggregator.isSideQuestionAnswerMessage(messageId)
+            )
           : null;
       // Trust the live aggregator only when it is both active AND has finished
       // replaying historical events (caughtUp). During the replay window after a
@@ -1740,10 +1769,10 @@ export class WorkspaceStore {
       // subscription for all workspaces.
       const useAggregatorState = isActiveWorkspace && transient.caughtUp;
       const canInterrupt = useAggregatorState
-        ? activeStreams.length > 0
+        ? hasInterruptibleActiveStream
         : bufferedActiveStreamStart !== null
           ? true
-          : (activity?.streaming ?? activeStreams.length > 0);
+          : (activity?.streaming ?? hasInterruptibleActiveStream);
       const currentModel = useAggregatorState
         ? (aggregator.getCurrentModel() ?? null)
         : (bufferedActiveStreamStart?.model ??
@@ -3751,11 +3780,15 @@ export class WorkspaceStore {
     if (isCaughtUpMessage(data)) {
       const replay = data.replay ?? "full";
 
-      // Check if there's an active stream in buffered events (reconnection scenario)
+      // Check if there's an active main-agent stream in buffered events
+      // (reconnection scenario). Side-answer markers may still be buffered in
+      // historicalMessages at this point, before loadHistoricalMessages teaches
+      // the aggregator about them, so use the historical-aware classifier.
       const pendingEvents = transient.pendingStreamEvents;
-      const hasActiveStream = pendingEvents.some(
-        (event) => "type" in event && event.type === "stream-start"
-      );
+      const hasActiveStream =
+        getBufferedActiveStreamStart(pendingEvents, transient.historicalMessages, (messageId) =>
+          aggregator.isSideQuestionAnswerMessage(messageId)
+        ) !== null;
 
       const serverActiveStreamMessageId = data.cursor?.stream?.messageId;
       const localActiveStreamMessageId = aggregator.getActiveStreamMessageId();
@@ -3944,7 +3977,15 @@ export class WorkspaceStore {
     aggregator: StreamingMessageAggregator,
     data: WorkspaceChatMessage
   ): void {
-    // Handle non-buffered special events first
+    this.dispatchProcessStreamEvent(workspaceId, aggregator, data);
+  }
+
+  private dispatchProcessStreamEvent(
+    workspaceId: string,
+    aggregator: StreamingMessageAggregator,
+    data: WorkspaceChatMessage
+  ): void {
+    // Handle special events first
     if (isStreamError(data)) {
       const transient = this.assertChatTransientState(workspaceId);
 

--- a/src/browser/utils/chatCommands.test.ts
+++ b/src/browser/utils/chatCommands.test.ts
@@ -146,6 +146,125 @@ function createGoalCommandContext(api: SlashCommandContext["api"]): SlashCommand
   });
 }
 
+describe("processSlashCommand - side-question", () => {
+  function createSideQuestionContext(
+    sideQuestion: (input: {
+      workspaceId: string;
+      question: string;
+    }) => Promise<{ success: boolean; error?: string }>,
+    overrides: Partial<SlashCommandContext> = {}
+  ): SlashCommandContext {
+    return {
+      api: {
+        workspace: { sideQuestion },
+      } as unknown as SlashCommandContext["api"],
+      workspaceId: "side-ws",
+      variant: "workspace",
+      projectPath: "/tmp/project",
+      sendMessageOptions: {
+        model: "anthropic:claude-sonnet-4-6",
+        thinkingLevel: "off",
+        toolPolicy: [],
+        agentId: "exec",
+      },
+      setPreferredModel: mock(() => undefined),
+      setVimEnabled: mock((cb: (prev: boolean) => boolean) => cb(false)),
+      resetInputHeight: mock(() => undefined),
+      getInput: mock(() => ""),
+      onTruncateHistory: mock(() => Promise.resolve(undefined)),
+      setInput: mock(() => undefined),
+      setToast: mock(() => undefined),
+      setAttachments: mock(() => undefined),
+      onDetachAllReviews: mock(() => undefined),
+      setSendingState: mock(() => undefined),
+      ...overrides,
+    };
+  }
+
+  test("clears input and launches the side question without awaiting the stream", async () => {
+    const sideQuestion = mock(() => Promise.resolve({ success: true }));
+    const context = createSideQuestionContext(sideQuestion);
+
+    const result = await processSlashCommand(
+      { type: "side-question", question: "what changed?" },
+      context
+    );
+
+    expect(result).toEqual({ clearInput: true, toastShown: false });
+    expect(context.setInput).toHaveBeenCalledWith("");
+    expect(context.setAttachments).toHaveBeenCalledWith([]);
+    expect(context.onDetachAllReviews).toHaveBeenCalled();
+    expect(sideQuestion).toHaveBeenCalledWith({
+      workspaceId: "side-ws",
+      question: "what changed?",
+    });
+  });
+
+  test("restores the command text when the side-question RPC fails", async () => {
+    let resolveSideQuestion: ((value: { success: false; error: string }) => void) | undefined;
+    const sideQuestion = mock(
+      () =>
+        new Promise<{ success: false; error: string }>((resolve) => {
+          resolveSideQuestion = resolve;
+        })
+    );
+    const context = createSideQuestionContext(sideQuestion);
+
+    await processSlashCommand({ type: "side-question", question: "will fail?" }, context);
+    resolveSideQuestion?.({ success: false, error: "disk full" });
+    await Promise.resolve();
+
+    expect(context.setInput).toHaveBeenCalledWith("");
+    expect(context.setInput).toHaveBeenCalledWith("/btw will fail?");
+    expect(context.setToast).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Side question failed: disk full", type: "error" })
+    );
+  });
+
+  test("does not restore the command text over a newer draft", async () => {
+    let resolveSideQuestion: ((value: { success: false; error: string }) => void) | undefined;
+    const sideQuestion = mock(
+      () =>
+        new Promise<{ success: false; error: string }>((resolve) => {
+          resolveSideQuestion = resolve;
+        })
+    );
+    const context = createSideQuestionContext(sideQuestion, {
+      getInput: mock(() => "new draft"),
+    });
+
+    await processSlashCommand({ type: "side-question", question: "will fail?" }, context);
+    resolveSideQuestion?.({ success: false, error: "disk full" });
+    await Promise.resolve();
+
+    expect(context.setInput).toHaveBeenCalledWith("");
+    expect(context.setInput).not.toHaveBeenCalledWith("/btw will fail?");
+    expect(context.setToast).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Side question failed: disk full", type: "error" })
+    );
+  });
+
+  test("ignores stale side-question failures", async () => {
+    let resolveSideQuestion: ((value: { success: false; error: string }) => void) | undefined;
+    const sideQuestion = mock(
+      () =>
+        new Promise<{ success: false; error: string }>((resolve) => {
+          resolveSideQuestion = resolve;
+        })
+    );
+    const context = createSideQuestionContext(sideQuestion, {
+      asyncCommandToken: 1,
+      isAsyncCommandCurrent: mock(() => false),
+    });
+
+    await processSlashCommand({ type: "side-question", question: "will fail?" }, context);
+    resolveSideQuestion?.({ success: false, error: "disk full" });
+    await Promise.resolve();
+
+    expect(context.setToast).not.toHaveBeenCalled();
+  });
+});
+
 describe("processSlashCommand - clear", () => {
   function createClearContext(overrides: Partial<SlashCommandContext> = {}): SlashCommandContext {
     return createSlashCommandContext({

--- a/src/browser/utils/chatCommands.ts
+++ b/src/browser/utils/chatCommands.ts
@@ -165,6 +165,12 @@ export interface SlashCommandContext extends Omit<CommandHandlerContext, "worksp
   onResetContext?: () => Promise<"reset" | "noop">;
   onTruncateHistory?: (percentage?: number) => Promise<void>;
   resetInputHeight: () => void;
+  /** Read the latest composer text so async command failures don't overwrite newer drafts. */
+  getInput?: () => string;
+  /** Token identifying the command invocation that launched async follow-up work. */
+  asyncCommandToken?: number;
+  /** Return false when an async command completion belongs to a stale workspace/input. */
+  isAsyncCommandCurrent?: (token: number, workspaceId: string) => boolean;
   /** Callback to trigger message-sent side effects (auto-scroll, auto-background) */
   onMessageSent?: (dispatchMode: QueueDispatchMode) => void;
   /** Callback to detach review context from the composer without marking it checked */
@@ -568,6 +574,63 @@ export async function processSlashCommand(
           api: client,
           workspaceId: context.workspaceId,
         } as CommandHandlerContext);
+      case "side-question": {
+        // /btw: forked, single-turn, read-only side question.
+        //
+        // The backend persists both the question and the answer to chat
+        // history with side-question metadata, and streams the answer
+        // through the normal onChat events — so the rendered output uses
+        // the standard TypewriterMarkdown / smooth-text path. The RPC
+        // itself only resolves once the side question is fully streamed,
+        // but we don't await it inline: the chat events drive the UI in
+        // parallel, and a long-running side question shouldn't pin the
+        // chat input handler.
+        if (!context.workspaceId) throw new Error("Workspace ID required");
+        const activeClient = requireClient();
+        if (!activeClient) {
+          return { clearInput: false, toastShown: true };
+        }
+        const workspaceId = context.workspaceId;
+        const rawCommand = `/btw ${parsed.question}`;
+        const asyncCommandToken = context.asyncCommandToken;
+        const isCurrentSideQuestion = (): boolean =>
+          asyncCommandToken === undefined ||
+          context.isAsyncCommandCurrent?.(asyncCommandToken, workspaceId) !== false;
+        const showSideQuestionError = (message: string): void => {
+          if (!isCurrentSideQuestion()) {
+            return;
+          }
+          const currentInput = context.getInput?.();
+          // Restore the consumed command text only if the composer is still
+          // empty. /btw runs asynchronously; if the user typed a new draft while
+          // it was pending, surfacing the error must not overwrite that draft.
+          if (currentInput === undefined || currentInput.trim().length === 0) {
+            setInput(rawCommand);
+          }
+          setToast({
+            id: Date.now().toString(),
+            type: "error",
+            message,
+          });
+        };
+        setInput("");
+        context.setAttachments([]);
+        context.onDetachAllReviews?.();
+        void activeClient.workspace
+          .sideQuestion({ workspaceId, question: parsed.question })
+          .then((result) => {
+            if (!result.success) {
+              showSideQuestionError(`Side question failed: ${result.error}`);
+            }
+          })
+          .catch((err: unknown) => {
+            showSideQuestionError(
+              err instanceof Error ? err.message : "Side question failed unexpectedly"
+            );
+          });
+        trackCommandUsed("btw");
+        return { clearInput: true, toastShown: false };
+      }
     }
   }
 

--- a/src/browser/utils/chatEditing.test.ts
+++ b/src/browser/utils/chatEditing.test.ts
@@ -33,6 +33,10 @@ describe("canEditDisplayedUserMessage", () => {
     );
   });
 
+  test("excludes side-question rows from edit paths", () => {
+    expect(canEditDisplayedUserMessage(userMessage({ isSideQuestion: true }))).toBe(false);
+  });
+
   test("allows normal user messages", () => {
     expect(canEditDisplayedUserMessage(userMessage())).toBe(true);
   });

--- a/src/browser/utils/chatEditing.ts
+++ b/src/browser/utils/chatEditing.ts
@@ -32,6 +32,10 @@ const LOCAL_COMMAND_STDOUT_CLOSE_TAG = "</local-command-stdout>";
 
 export const canEditDisplayedUserMessage = (message: DisplayedUserMessage): boolean => {
   if (message.isBeforeLatestContextBoundary === true) return false;
+  // /btw rows are persisted read-only side branches. Editing one would route the
+  // edited text through the normal main-thread send path and truncate history
+  // from the aside instead of re-running the side-question flow.
+  if (message.isSideQuestion === true) return false;
   if (message.isGoalContinuation === true || message.isBudgetLimitWrapup === true) return false;
   if (message.content.startsWith(LOCAL_COMMAND_STDOUT_OPEN_TAG)) {
     return !message.content.endsWith(LOCAL_COMMAND_STDOUT_CLOSE_TAG);

--- a/src/browser/utils/messages/StreamingMessageAggregator.sideQuestion.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.sideQuestion.test.ts
@@ -1,0 +1,688 @@
+import { describe, it, expect } from "bun:test";
+import { StreamingMessageAggregator } from "./StreamingMessageAggregator";
+import type { WorkspaceChatMessage } from "@/common/orpc/types";
+
+const WORKSPACE_CREATED_AT = "2026-05-01T00:00:00.000Z";
+
+/**
+ * Append a normal main-agent assistant message via the same code path the
+ * live system uses: a `type: "message"` envelope routed through
+ * `handleMessage`. We deliberately do NOT poke private state — the test
+ * must exercise the same `muxMetadata` round-trip as a real chat event.
+ */
+function appendMainAssistant(
+  aggregator: StreamingMessageAggregator,
+  id: string,
+  historySequence: number,
+  text = ""
+): void {
+  const envelope: WorkspaceChatMessage = {
+    type: "message",
+    id,
+    role: "assistant",
+    parts: text ? [{ type: "text", text }] : [],
+    metadata: { historySequence, timestamp: historySequence, model: "claude-sonnet-4" },
+  };
+  aggregator.handleMessage(envelope);
+}
+
+/**
+ * Append a /btw user question with the interruption snapshot the backend
+ * stamps onto its muxMetadata. The renderer uses these fields to split
+ * the interrupted main-agent message visually.
+ */
+function appendSideUser(
+  aggregator: StreamingMessageAggregator,
+  id: string,
+  historySequence: number,
+  question: string,
+  interruption?: {
+    interruptedMessageId: string;
+    interruptedTextLength: number;
+    interruptedPartIndex?: number;
+    interruptedHistorySequence?: number;
+  }
+): void {
+  const envelope: WorkspaceChatMessage = {
+    type: "message",
+    id,
+    role: "user",
+    parts: [{ type: "text", text: question }],
+    metadata: {
+      historySequence,
+      timestamp: historySequence,
+      muxMetadata: {
+        type: "side-question",
+        rawCommand: `/btw ${question}`,
+        commandPrefix: "/btw",
+        ...interruption,
+      },
+    },
+  };
+  aggregator.handleMessage(envelope);
+}
+
+/**
+ * Append a /btw assistant placeholder/final. The side-question pipeline
+ * persists this row first (so stream-start has a real historySequence to
+ * attach to), then emits stream-start against the same messageId.
+ */
+function appendSideAnswer(
+  aggregator: StreamingMessageAggregator,
+  id: string,
+  historySequence: number,
+  text = "",
+  questionMessageId?: string
+): void {
+  const envelope: WorkspaceChatMessage = {
+    type: "message",
+    id,
+    role: "assistant",
+    parts: text ? [{ type: "text", text }] : [],
+    metadata: {
+      historySequence,
+      timestamp: historySequence,
+      model: "claude-haiku-3.5",
+      muxMetadata: {
+        type: "side-question-answer",
+        ...(questionMessageId ? { questionMessageId } : {}),
+      },
+    },
+  };
+  aggregator.handleMessage(envelope);
+}
+
+describe("StreamingMessageAggregator /btw rendering", () => {
+  it("marks side-question-answer rows with isSideAnswer in displayed messages", () => {
+    // Regression: the renderer derives `isSideAnswer` from the
+    // assistant message's muxMetadata. If muxMetadata is lost (e.g.,
+    // dropped across stream-start), the badge and split-rendering both
+    // break. We assert the displayed-row marker rather than poking
+    // private predicates.
+    const aggregator = new StreamingMessageAggregator(WORKSPACE_CREATED_AT);
+
+    appendMainAssistant(aggregator, "main-1", 1, "hello");
+    appendSideAnswer(aggregator, "side-1", 2, "two");
+
+    const rows = aggregator.getDisplayedMessages();
+    const mainRow = rows.find((r) => r.type === "assistant" && r.historyId === "main-1");
+    const sideRow = rows.find((r) => r.type === "assistant" && r.historyId === "side-1");
+    expect(mainRow && "isSideAnswer" in mainRow ? mainRow.isSideAnswer : undefined).toBeFalsy();
+    expect(sideRow && "isSideAnswer" in sideRow ? sideRow.isSideAnswer : undefined).toBe(true);
+  });
+
+  it("carries side-question-answer muxMetadata across stream-start", () => {
+    // Regression coverage: stream-start replaces the existing message
+    // with a fresh envelope built from the event payload. The
+    // side-question pipeline emits the placeholder `message` event
+    // (with muxMetadata) BEFORE stream-start so the marker is in the
+    // aggregator first; the carry-forward logic in handleStreamStart
+    // then preserves it across the fresh envelope. Without that
+    // carry-forward, the displayed row loses isSideAnswer and the
+    // "side answer" header + split rendering both break.
+    const aggregator = new StreamingMessageAggregator(WORKSPACE_CREATED_AT);
+
+    appendSideAnswer(aggregator, "side-1", 1);
+
+    aggregator.handleStreamStart({
+      type: "stream-start",
+      workspaceId: "ws",
+      messageId: "side-1",
+      model: "claude-haiku-3.5",
+      historySequence: 1,
+      startTime: 1_000,
+    });
+
+    aggregator.handleStreamDelta({
+      type: "stream-delta",
+      workspaceId: "ws",
+      messageId: "side-1",
+      delta: "two",
+      tokens: 1,
+      timestamp: 1_100,
+    });
+
+    const rows = aggregator.getDisplayedMessages();
+    const sideRow = rows.find((r) => r.type === "assistant" && r.historyId === "side-1");
+    expect(sideRow && "isSideAnswer" in sideRow ? sideRow.isSideAnswer : undefined).toBe(true);
+  });
+
+  it("does not let side-answer models replace the workspace current model", () => {
+    const aggregator = new StreamingMessageAggregator(WORKSPACE_CREATED_AT);
+
+    appendMainAssistant(aggregator, "main-1", 1, "main answer");
+    appendSideAnswer(aggregator, "btw-a", 2, "side answer");
+    expect(aggregator.getCurrentModel()).toBe("claude-sonnet-4");
+
+    aggregator.handleStreamStart({
+      type: "stream-start",
+      workspaceId: "ws",
+      messageId: "btw-a",
+      model: "claude-haiku-3.5",
+      historySequence: 2,
+      startTime: 1_000,
+    });
+    expect(aggregator.getCurrentModel()).toBe("claude-sonnet-4");
+  });
+
+  it("returns the main-agent active stream when a side answer started first", () => {
+    const aggregator = new StreamingMessageAggregator(WORKSPACE_CREATED_AT);
+
+    appendSideAnswer(aggregator, "btw-a", 1, "side answer");
+    aggregator.handleStreamStart({
+      type: "stream-start",
+      workspaceId: "ws",
+      messageId: "btw-a",
+      model: "claude-haiku-3.5",
+      historySequence: 1,
+      startTime: 1_000,
+    });
+
+    appendMainAssistant(aggregator, "main-1", 2, "main answer");
+    aggregator.handleStreamStart({
+      type: "stream-start",
+      workspaceId: "ws",
+      messageId: "main-1",
+      model: "claude-sonnet-4",
+      historySequence: 2,
+      startTime: 1_100,
+    });
+
+    expect(aggregator.getActiveStreamMessageId()).toBe("main-1");
+    expect(aggregator.getActiveStreamTimingStats()?.model).toBe("claude-sonnet-4");
+
+    aggregator.setInterrupting();
+    expect(aggregator.isInterrupting("main-1")).toBe(true);
+    expect(aggregator.isInterrupting("btw-a")).toBe(false);
+  });
+
+  it("treats main-agent completion as final while a side answer is still streaming", () => {
+    const aggregator = new StreamingMessageAggregator(WORKSPACE_CREATED_AT, "ws");
+    const completions: Array<{
+      messageId: string | undefined;
+      isFinal: boolean;
+      completedAt: number | null | undefined;
+    }> = [];
+    aggregator.onResponseComplete = (event) => {
+      completions.push({
+        messageId: event.messageId,
+        isFinal: event.isFinal,
+        completedAt: event.completedAt,
+      });
+    };
+
+    appendSideAnswer(aggregator, "btw-a", 1);
+    aggregator.handleStreamStart({
+      type: "stream-start",
+      workspaceId: "ws",
+      messageId: "btw-a",
+      model: "claude-haiku-3.5",
+      historySequence: 1,
+      startTime: 1_000,
+    });
+
+    appendMainAssistant(aggregator, "main-1", 2);
+    aggregator.handleStreamStart({
+      type: "stream-start",
+      workspaceId: "ws",
+      messageId: "main-1",
+      model: "claude-sonnet-4",
+      historySequence: 2,
+      startTime: 1_100,
+    });
+    aggregator.handleStreamDelta({
+      type: "stream-delta",
+      workspaceId: "ws",
+      messageId: "main-1",
+      delta: "main done",
+      tokens: 2,
+      timestamp: 1_200,
+    });
+    aggregator.handleStreamEnd({
+      type: "stream-end",
+      workspaceId: "ws",
+      messageId: "main-1",
+      parts: [{ type: "text", text: "main done" }],
+      metadata: { model: "claude-sonnet-4", duration: 200, historySequence: 2 },
+    });
+
+    expect(completions).toHaveLength(1);
+    expect(completions[0]?.messageId).toBe("main-1");
+    expect(completions[0]?.isFinal).toBe(true);
+    expect(completions[0]?.completedAt).not.toBeNull();
+
+    aggregator.handleStreamEnd({
+      type: "stream-end",
+      workspaceId: "ws",
+      messageId: "btw-a",
+      parts: [{ type: "text", text: "side done" }],
+      metadata: { model: "claude-haiku-3.5", duration: 300, historySequence: 1 },
+    });
+    expect(completions).toHaveLength(1);
+  });
+
+  it("keeps queued follow-up suppression when a side answer starts", () => {
+    const aggregator = new StreamingMessageAggregator(WORKSPACE_CREATED_AT, "ws");
+    const completions: Array<{ hasAutoFollowUp: boolean | undefined }> = [];
+    aggregator.onResponseComplete = (event) => {
+      completions.push({ hasAutoFollowUp: event.completion?.hasAutoFollowUp });
+    };
+
+    appendMainAssistant(aggregator, "main-1", 1);
+    aggregator.handleStreamStart({
+      type: "stream-start",
+      workspaceId: "ws",
+      messageId: "main-1",
+      model: "claude-sonnet-4",
+      historySequence: 1,
+      startTime: 1_000,
+    });
+    aggregator.setActiveQueuedFollowUp(true);
+
+    appendSideAnswer(aggregator, "btw-a", 2);
+    aggregator.handleStreamStart({
+      type: "stream-start",
+      workspaceId: "ws",
+      messageId: "btw-a",
+      model: "claude-haiku-3.5",
+      historySequence: 2,
+      startTime: 1_100,
+    });
+
+    aggregator.handleStreamDelta({
+      type: "stream-delta",
+      workspaceId: "ws",
+      messageId: "main-1",
+      delta: "main done",
+      tokens: 2,
+      timestamp: 1_200,
+    });
+    aggregator.handleStreamEnd({
+      type: "stream-end",
+      workspaceId: "ws",
+      messageId: "main-1",
+      parts: [{ type: "text", text: "main done" }],
+      metadata: { model: "claude-sonnet-4", duration: 200, historySequence: 1 },
+    });
+
+    expect(completions).toEqual([{ hasAutoFollowUp: true }]);
+  });
+
+  it("places the /btw question at the interruption point before the answer row exists", () => {
+    // The side-answer placeholder is emitted after the user row, so the user
+    // question itself must own the interruption anchor. Otherwise the question
+    // can sit at the live tail until model setup finishes and the first answer
+    // token arrives.
+    const aggregator = new StreamingMessageAggregator(WORKSPACE_CREATED_AT);
+
+    appendMainAssistant(aggregator, "main-1", 1, "hello world");
+    appendSideUser(aggregator, "btw-q", 2, "what's 2+2", {
+      interruptedMessageId: "main-1",
+      interruptedTextLength: 5,
+      interruptedHistorySequence: 1,
+    });
+
+    const visibleHistoryIds = aggregator
+      .getDisplayedMessages()
+      .filter((r) => r.type === "assistant" || r.type === "user")
+      .map((r) => r.historyId);
+
+    expect(visibleHistoryIds).toEqual(["main-1", "btw-q", "main-1"]);
+  });
+
+  it("places /btw at the interruption point while the side answer streams", () => {
+    // The side branch should not stay pinned to the transcript tail for the
+    // entire side-answer stream. As soon as the side answer exists, split the
+    // interrupted main-agent message so subsequent main text appears below the
+    // /btw pair.
+    const aggregator = new StreamingMessageAggregator(WORKSPACE_CREATED_AT);
+
+    appendMainAssistant(aggregator, "main-1", 1, "hello world");
+    appendSideUser(aggregator, "btw-q", 2, "what's 2+2", {
+      interruptedMessageId: "main-1",
+      interruptedTextLength: 5,
+      interruptedHistorySequence: 1,
+    });
+    appendSideAnswer(aggregator, "btw-a", 3);
+
+    aggregator.handleStreamStart({
+      type: "stream-start",
+      workspaceId: "ws",
+      messageId: "btw-a",
+      model: "claude-haiku-3.5",
+      historySequence: 3,
+      startTime: 1_000,
+    });
+    aggregator.handleStreamDelta({
+      type: "stream-delta",
+      workspaceId: "ws",
+      messageId: "btw-a",
+      delta: "four",
+      tokens: 1,
+      timestamp: 1_100,
+    });
+
+    const readVisibleHistoryIds = (): string[] =>
+      aggregator
+        .getDisplayedMessages()
+        .filter((r) => r.type === "assistant" || r.type === "user")
+        .map((r) => r.historyId);
+
+    // Still streaming: the side branch is already inserted at the captured
+    // interruption point instead of sticking to the transcript tail.
+    expect(readVisibleHistoryIds()).toEqual(["main-1", "btw-q", "btw-a", "main-1"]);
+
+    aggregator.handleStreamEnd({
+      type: "stream-end",
+      workspaceId: "ws",
+      messageId: "btw-a",
+      parts: [{ type: "text", text: "four" }],
+      metadata: {
+        model: "claude-haiku-3.5",
+        timestamp: 1_200,
+        duration: 200,
+        historySequence: 3,
+      },
+    });
+
+    // Settling preserves the same split order.
+    expect(readVisibleHistoryIds()).toEqual(["main-1", "btw-q", "btw-a", "main-1"]);
+  });
+
+  it("does not reset main-agent lifecycle when a /btw user row arrives", () => {
+    const aggregator = new StreamingMessageAggregator(WORKSPACE_CREATED_AT);
+
+    aggregator.handleStreamLifecycle({
+      type: "stream-lifecycle",
+      workspaceId: "ws",
+      phase: "streaming",
+      hadAnyOutput: true,
+    });
+    appendSideUser(aggregator, "btw-q", 2, "what is this?", {
+      interruptedMessageId: "main-1",
+      interruptedTextLength: 5,
+    });
+
+    expect(aggregator.getStreamLifecycle()?.phase).toBe("streaming");
+    expect(aggregator.getPendingStreamStartTime()).toBeNull();
+  });
+
+  it("preserves pending main-agent startup when a side answer starts first", () => {
+    const aggregator = new StreamingMessageAggregator(WORKSPACE_CREATED_AT);
+
+    aggregator.handleMessage({
+      type: "message",
+      id: "main-user",
+      role: "user",
+      parts: [{ type: "text", text: "do the main work" }],
+      metadata: {
+        historySequence: 1,
+        timestamp: 1,
+        muxMetadata: { type: "normal", requestedModel: "claude-sonnet-4" },
+      },
+    });
+    aggregator.handleRuntimeStatus({
+      type: "runtime-status",
+      workspaceId: "ws",
+      phase: "starting",
+      runtimeType: "local",
+      detail: "Starting main turn...",
+    });
+    const pendingStart = aggregator.getPendingStreamStartTime();
+    expect(pendingStart).not.toBeNull();
+
+    appendSideAnswer(aggregator, "btw-a", 2);
+    aggregator.handleStreamStart({
+      type: "stream-start",
+      workspaceId: "ws",
+      messageId: "btw-a",
+      model: "claude-haiku-3.5",
+      historySequence: 2,
+      startTime: 1_000,
+    });
+
+    expect(aggregator.getPendingStreamStartTime()).toBe(pendingStart);
+    expect(aggregator.getRuntimeStatus()?.phase).toBe("starting");
+
+    aggregator.handleStreamEnd({
+      type: "stream-end",
+      workspaceId: "ws",
+      messageId: "btw-a",
+      parts: [{ type: "text", text: "side answer" }],
+      metadata: { model: "claude-haiku-3.5", duration: 200, historySequence: 2 },
+    });
+
+    expect(aggregator.getPendingStreamStartTime()).toBe(pendingStart);
+    expect(aggregator.getRuntimeStatus()?.phase).toBe("starting");
+  });
+
+  it("splits the interrupted main-agent message around the /btw pair", () => {
+    // Visual ordering contract: the side branch must appear BETWEEN the
+    // pre-aside and post-aside halves of the main agent's reply, not
+    // below the entire reply. We assert the order of historyIds in the
+    // displayed-message stream: main-1 (pre), side user, side answer,
+    // main-1 (post). Both main-1 halves use the same historyId so
+    // action handlers still resolve to the persisted message.
+    const aggregator = new StreamingMessageAggregator(WORKSPACE_CREATED_AT);
+
+    // Main agent has produced "hello world" (11 chars) before /btw fired
+    // at text length 5 ("hello").
+    appendMainAssistant(aggregator, "main-1", 1, "hello world");
+    appendSideUser(aggregator, "btw-q", 2, "what's 2+2", {
+      interruptedMessageId: "main-1",
+      interruptedTextLength: 5,
+      interruptedHistorySequence: 1,
+    });
+    appendSideAnswer(aggregator, "btw-a", 3, "four");
+
+    const rows = aggregator.getDisplayedMessages();
+    const visibleHistoryIds = rows
+      .filter((r) => r.type === "assistant" || r.type === "user")
+      .map((r) => r.historyId);
+
+    // Pre-aside main row, side question, side answer, post-aside main row.
+    expect(visibleHistoryIds).toEqual(["main-1", "btw-q", "btw-a", "main-1"]);
+
+    // The pre and post halves carry the split text content.
+    const mainRows = rows.filter(
+      (r): r is Extract<typeof r, { type: "assistant"; content: string }> =>
+        r.type === "assistant" && r.historyId === "main-1"
+    );
+    expect(mainRows).toHaveLength(2);
+    expect(mainRows[0].content).toBe("hello");
+    expect(mainRows[1].content).toBe(" world");
+  });
+
+  it("pairs concurrent /btw answers by question id instead of adjacency", () => {
+    // Two side questions can be persisted before either answer placeholder is
+    // appended. The answer metadata links back to its question so delayed
+    // placeholders do not get paired with whichever /btw row happens to sit
+    // immediately above them in history order.
+    const aggregator = new StreamingMessageAggregator(WORKSPACE_CREATED_AT);
+
+    appendMainAssistant(aggregator, "main-1", 1, "alpha beta gamma");
+    appendSideUser(aggregator, "btw-q1", 2, "earlier", {
+      interruptedMessageId: "main-1",
+      interruptedTextLength: 5,
+    });
+    appendSideUser(aggregator, "btw-q2", 3, "later", {
+      interruptedMessageId: "main-1",
+      interruptedTextLength: 10,
+    });
+    appendSideAnswer(aggregator, "btw-a1", 4, "answer-1", "btw-q1");
+    appendSideAnswer(aggregator, "btw-a2", 5, "answer-2", "btw-q2");
+
+    const rows = aggregator.getDisplayedMessages();
+    const visibleHistoryIds = rows
+      .filter((r) => r.type === "assistant" || r.type === "user")
+      .map((r) => r.historyId);
+
+    expect(visibleHistoryIds).toEqual([
+      "main-1",
+      "btw-q1",
+      "btw-a1",
+      "main-1",
+      "btw-q2",
+      "btw-a2",
+      "main-1",
+    ]);
+  });
+
+  it("keeps pre-existing non-text parts before the side branch at the same text offset", () => {
+    const aggregator = new StreamingMessageAggregator(WORKSPACE_CREATED_AT);
+
+    aggregator.handleMessage({
+      type: "message",
+      id: "main-1",
+      role: "assistant",
+      parts: [
+        { type: "text", text: "hello" },
+        { type: "reasoning", text: "thinking that was already visible" },
+        { type: "text", text: " world" },
+      ],
+      metadata: { historySequence: 1, timestamp: 1, model: "claude-sonnet-4" },
+    });
+    appendSideUser(aggregator, "btw-q", 2, "question after reasoning", {
+      interruptedMessageId: "main-1",
+      interruptedTextLength: 5,
+      interruptedPartIndex: 2,
+      interruptedHistorySequence: 1,
+    });
+    appendSideAnswer(aggregator, "btw-a", 3, "side answer");
+
+    const visibleRows = aggregator
+      .getDisplayedMessages()
+      .filter((row) => row.type === "reasoning" || row.type === "assistant" || row.type === "user")
+      .map((row) => `${row.type}:${row.historyId}`);
+
+    expect(visibleRows).toEqual([
+      "assistant:main-1",
+      "reasoning:main-1",
+      "user:btw-q",
+      "assistant:btw-a",
+      "assistant:main-1",
+    ]);
+  });
+
+  it("puts reasoning emitted after a zero-offset /btw below the side branch", () => {
+    const aggregator = new StreamingMessageAggregator(WORKSPACE_CREATED_AT);
+
+    aggregator.handleMessage({
+      type: "message",
+      id: "main-1",
+      role: "assistant",
+      parts: [
+        { type: "reasoning", text: "thinking after the aside" },
+        { type: "text", text: "answer after the aside" },
+      ],
+      metadata: { historySequence: 1, timestamp: 1, model: "claude-sonnet-4" },
+    });
+    appendSideUser(aggregator, "btw-q", 2, "question before output", {
+      interruptedMessageId: "main-1",
+      interruptedTextLength: 0,
+      interruptedHistorySequence: 1,
+    });
+    appendSideAnswer(aggregator, "btw-a", 3, "side answer");
+
+    const visibleRows = aggregator
+      .getDisplayedMessages()
+      .filter((row) => row.type === "reasoning" || row.type === "assistant" || row.type === "user")
+      .map((row) => `${row.type}:${row.historyId}`);
+
+    expect(visibleRows).toEqual([
+      "user:btw-q",
+      "assistant:btw-a",
+      "reasoning:main-1",
+      "assistant:main-1",
+    ]);
+  });
+
+  it("interleaves multiple /btw pairs in sorted text-length order", () => {
+    // Two /btw fired during the same main-agent turn. The renderer
+    // must order them by their captured interruptedTextLength so the
+    // earlier one sits above the later one (matching the order they
+    // were fired in real time).
+    const aggregator = new StreamingMessageAggregator(WORKSPACE_CREATED_AT);
+
+    appendMainAssistant(aggregator, "main-1", 1, "alpha beta gamma");
+    // Second /btw was fired earlier (lower text length anchor) but
+    // arrived after the first in iteration order — splitting must sort
+    // by `interruptedTextLength`, not insertion order, to render them
+    // where they actually belong in the main agent's stream.
+    appendSideUser(aggregator, "btw-q2", 2, "later", {
+      interruptedMessageId: "main-1",
+      interruptedTextLength: 10, // After "alpha beta"
+    });
+    appendSideAnswer(aggregator, "btw-a2", 3, "answer-2");
+    appendSideUser(aggregator, "btw-q1", 4, "earlier", {
+      interruptedMessageId: "main-1",
+      interruptedTextLength: 5, // After "alpha"
+    });
+    appendSideAnswer(aggregator, "btw-a1", 5, "answer-1");
+
+    const rows = aggregator.getDisplayedMessages();
+    const visibleHistoryIds = rows
+      .filter((r) => r.type === "assistant" || r.type === "user")
+      .map((r) => r.historyId);
+
+    // Earlier interrupt (text length 5) renders first, later one second.
+    expect(visibleHistoryIds).toEqual([
+      "main-1",
+      "btw-q1",
+      "btw-a1",
+      "main-1",
+      "btw-q2",
+      "btw-a2",
+      "main-1",
+    ]);
+
+    const mainRows = rows.filter(
+      (r): r is Extract<typeof r, { type: "assistant"; content: string }> =>
+        r.type === "assistant" && r.historyId === "main-1"
+    );
+    expect(mainRows.map((r) => r.content)).toEqual(["alpha", " beta", " gamma"]);
+  });
+
+  it("places /btw at the start when fired before any main-agent text", () => {
+    // Edge case: /btw fires immediately after stream-start, before any
+    // text deltas arrive. interruptedTextLength is 0, so the pre-aside
+    // half is empty. The side branch should still render above the
+    // main agent's content rather than below it.
+    const aggregator = new StreamingMessageAggregator(WORKSPACE_CREATED_AT);
+
+    appendMainAssistant(aggregator, "main-1", 1, "all the text");
+    appendSideUser(aggregator, "btw-q", 2, "quick", {
+      interruptedMessageId: "main-1",
+      interruptedTextLength: 0,
+    });
+    appendSideAnswer(aggregator, "btw-a", 3, "answer");
+
+    const rows = aggregator.getDisplayedMessages();
+    const visibleHistoryIds = rows
+      .filter((r) => r.type === "assistant" || r.type === "user")
+      .map((r) => r.historyId);
+
+    // Empty pre-aside is omitted (no parts -> no row). Side branch
+    // renders, then the entire main-agent reply.
+    expect(visibleHistoryIds).toEqual(["btw-q", "btw-a", "main-1"]);
+  });
+
+  it("falls back to a normal end-of-transcript render when no main-agent stream was in flight", () => {
+    // Without interruptedMessageId, the /btw user message has no anchor
+    // to split against — it should render at the end of the transcript
+    // in sequence order. (This is what happens when /btw is fired
+    // between turns rather than during a stream.)
+    const aggregator = new StreamingMessageAggregator(WORKSPACE_CREATED_AT);
+
+    appendMainAssistant(aggregator, "main-1", 1, "done.");
+    appendSideUser(aggregator, "btw-q", 2, "follow-up"); // no interruption fields
+    appendSideAnswer(aggregator, "btw-a", 3, "follow-up answer");
+
+    const rows = aggregator.getDisplayedMessages();
+    const visibleHistoryIds = rows
+      .filter((r) => r.type === "assistant" || r.type === "user")
+      .map((r) => r.historyId);
+
+    expect(visibleHistoryIds).toEqual(["main-1", "btw-q", "btw-a"]);
+  });
+});

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -72,6 +72,11 @@ import {
   CONTEXT_BOUNDARY_KINDS,
   getContextBoundaryKind,
 } from "@/common/utils/messages/compactionBoundary";
+import {
+  SIDE_QUESTION_ANSWER_METADATA_TYPE,
+  isSideQuestionAnswerMessage as isSideQuestionAnswerMuxMessage,
+  isSideQuestionUserMessage as isSideQuestionUserMuxMessage,
+} from "@/common/utils/messages/sideQuestion";
 
 // Maximum number of messages to display in the DOM for performance
 // Full history is still maintained internally for token counting and stats
@@ -413,6 +418,18 @@ function deriveInlineSkillSnapshotDisplayState(
       .map(([, cacheEntry]) => cacheEntry)
       .join("\n"),
   };
+}
+
+interface MessagePartSplitCut {
+  textLength: number;
+  partIndex?: number;
+}
+
+interface SideQuestionInterrupt {
+  atTextLength: number;
+  atPartIndex?: number;
+  sideQuestionUserMsg: MuxMessage;
+  sideQuestionAnswerMsg?: MuxMessage;
 }
 
 export class StreamingMessageAggregator {
@@ -1455,6 +1472,19 @@ export class StreamingMessageAggregator {
     }
   }
 
+  private getActiveMainStreamEntry(): [string, StreamingContext] | undefined {
+    for (const entry of this.activeStreams) {
+      const [messageId] = entry;
+      // /btw side-answer streams render through the same event channel but do
+      // not belong to StreamManager. Active-stream callers such as interrupt,
+      // live usage, and stats must keep pointing at the real main-agent stream.
+      if (!this.isSideQuestionAnswerMessage(messageId)) {
+        return entry;
+      }
+    }
+    return undefined;
+  }
+
   /**
    * Get timing statistics for the active stream (if any).
    * Returns null if no active stream exists.
@@ -1472,10 +1502,9 @@ export class StreamingMessageAggregator {
     /** Mode (plan/exec) for this stream */
     mode?: string;
   } | null {
-    // Get the first (and typically only) active stream
-    const entries = Array.from(this.activeStreams.entries());
-    if (entries.length === 0) return null;
-    const [messageId, context] = entries[0];
+    const activeMainStream = this.getActiveMainStreamEntry();
+    if (!activeMainStream) return null;
+    const [messageId, context] = activeMainStream;
 
     const now = Date.now();
 
@@ -1657,11 +1686,11 @@ export class StreamingMessageAggregator {
   }
 
   /**
-   * Get the messageId of the first active stream (for token tracking)
-   * Returns undefined if no streams are active
+   * Get the active main-agent stream id (for interrupt, live usage, and token tracking).
+   * Returns undefined when no interruptible main-agent stream is active.
    */
   getActiveStreamMessageId(): string | undefined {
-    return this.activeStreams.keys().next().value;
+    return this.getActiveMainStreamEntry()?.[0];
   }
 
   /**
@@ -1700,17 +1729,62 @@ export class StreamingMessageAggregator {
     return false;
   }
 
-  getCurrentModel(): string | undefined {
-    // If there's an active stream, return its model
-    for (const context of this.activeStreams.values()) {
-      return context.model;
+  /** Is the /btw side-question pipeline currently streaming an answer? */
+  isSideQuestionStreaming(): boolean {
+    for (const messageId of this.activeStreams.keys()) {
+      if (this.isSideQuestionAnswerMessage(messageId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Active streams that can be interrupted via the backend StreamManager. */
+  hasInterruptibleActiveStream(): boolean {
+    return this.getActiveMainStreamEntry() !== undefined;
+  }
+
+  /** Is `messageId` a /btw side-question answer? */
+  isSideQuestionAnswerMessage(messageId: string): boolean {
+    const message = this.messages.get(messageId);
+    return message !== undefined && isSideQuestionAnswerMuxMessage(message);
+  }
+
+  private isSideQuestionAnswerStreamEvent(event: {
+    messageId: string;
+    metadata?: { muxMetadata?: unknown };
+  }): boolean {
+    if (this.isSideQuestionAnswerMessage(event.messageId)) {
+      return true;
     }
 
-    // Otherwise, return the model from the most recent assistant message
+    const muxMetadata = event.metadata?.muxMetadata;
+    return (
+      typeof muxMetadata === "object" &&
+      muxMetadata !== null &&
+      "type" in muxMetadata &&
+      muxMetadata.type === SIDE_QUESTION_ANSWER_METADATA_TYPE
+    );
+  }
+
+  getCurrentModel(): string | undefined {
+    // If there's an active main-agent stream, return its model. /btw streams
+    // are read-only asides and must not become the workspace's current model.
+    for (const [messageId, context] of this.activeStreams) {
+      if (!this.isSideQuestionAnswerMessage(messageId)) {
+        return context.model;
+      }
+    }
+
+    // Otherwise, return the model from the most recent non-side-answer assistant message.
     const messages = this.getAllMessages();
     for (let i = messages.length - 1; i >= 0; i--) {
       const message = messages[i];
-      if (message.role === "assistant" && message.metadata?.model) {
+      if (
+        message.role === "assistant" &&
+        !isSideQuestionAnswerMuxMessage(message) &&
+        message.metadata?.model
+      ) {
         return message.metadata.model;
       }
     }
@@ -1724,19 +1798,22 @@ export class StreamingMessageAggregator {
    * user-configured level.
    */
   getCurrentThinkingLevel(): string | undefined {
-    // If there's an active stream, return its thinking level
-    for (const context of this.activeStreams.values()) {
-      return context.thinkingLevel;
+    // If there's an active main-agent stream, return its thinking level.
+    // /btw streams are read-only asides and must not become workspace state.
+    for (const [messageId, context] of this.activeStreams) {
+      if (!this.isSideQuestionAnswerMessage(messageId)) {
+        return context.thinkingLevel;
+      }
     }
 
-    // Only check the most recent assistant message to avoid returning
-    // stale values from older turns where settings may have differed.
+    // Only check the most recent non-side-answer assistant message to avoid
+    // returning stale values from older turns where settings may have differed.
     // If it lacks thinkingLevel (e.g. error/abort), return undefined so
     // callers fall back to localStorage.
     const messages = this.getAllMessages();
     for (let i = messages.length - 1; i >= 0; i--) {
       const message = messages[i];
-      if (message.role === "assistant") {
+      if (message.role === "assistant" && !isSideQuestionAnswerMuxMessage(message)) {
         return message.metadata?.thinkingLevel;
       }
     }
@@ -1840,21 +1917,29 @@ export class StreamingMessageAggregator {
   handleStreamStart(data: StreamStartEvent): void {
     const { isCompacting, isIdleCompaction, hasCompactionContinue } =
       this.resolveStreamStartCompaction(data);
+    const isSideQuestionAnswerStream = this.isSideQuestionAnswerStreamEvent(data);
 
-    // Clear pending "starting..." UI now that the assistant turn is live.
-    this.clearPendingStreamLifecycleState();
-    this.lastAbortReason = null;
+    // Clear pending "starting..." UI once a main-agent turn is live. /btw
+    // side-answer streams can start while a normal turn is still waiting for
+    // its own stream-start, so they must not hide the main startup barrier.
+    if (!isSideQuestionAnswerStream) {
+      this.clearPendingStreamLifecycleState();
+      this.lastAbortReason = null;
+    }
 
     // NOTE: We do NOT clear agentStatus or currentTodos here.
     // They are cleared when a new user message arrives (see handleMessage),
     // ensuring consistent behavior whether loading from history or processing live events.
 
-    for (const activeStream of this.activeStreams.values()) {
-      // A queued follow-up belongs to the handoff into the next stream. Once that next
-      // stream starts, older contexts must not keep suppressing later completions.
-      activeStream.hasQueuedFollowUp = false;
+    if (!isSideQuestionAnswerStream) {
+      for (const activeStream of this.activeStreams.values()) {
+        // A queued follow-up belongs to the handoff into the next main stream.
+        // /btw side-answer streams are independent asides, so they must not
+        // clear the main stream's queued-follow-up suppression state.
+        activeStream.hasQueuedFollowUp = false;
+      }
+      this.backgroundHandoffCompletion = undefined;
     }
-    this.backgroundHandoffCompletion = undefined;
     const routeProvider = resolveRouteProvider(data.routeProvider, data.routedThroughGateway);
 
     const suppressNotification =
@@ -1920,6 +2005,16 @@ export class StreamingMessageAggregator {
     // If called twice, second call safely overwrites first
     this.activeStreams.set(data.messageId, context);
 
+    // Carry forward any muxMetadata that was attached when the message was
+    // first seen (e.g., the side-question pipeline emits a placeholder
+    // `message` event with `muxMetadata.type === "side-question-answer"`
+    // immediately before this stream-start). Without this, the fresh
+    // createMuxMessage below would silently drop the marker for the
+    // duration of the stream — breaking the "side answer" badge and the
+    // /btw split rendering, both of which key off this metadata when
+    // `buildDisplayedMessagesForMessage` runs.
+    const carriedMuxMetadata = existingMessage?.metadata?.muxMetadata;
+
     // Create initial streaming message with empty parts (deltas will append)
     const streamingMessage = createMuxMessage(data.messageId, "assistant", "", {
       historySequence: data.historySequence,
@@ -1929,6 +2024,7 @@ export class StreamingMessageAggregator {
       routeProvider,
       mode: data.mode,
       thinkingLevel: data.thinkingLevel,
+      ...(carriedMuxMetadata !== undefined ? { muxMetadata: carriedMuxMetadata } : {}),
     });
 
     this.messages.set(data.messageId, streamingMessage);
@@ -1975,9 +2071,14 @@ export class StreamingMessageAggregator {
   }
 
   handleStreamEnd(data: StreamEndEvent): void {
-    // A terminal event means any locally preserved "starting..." state is stale,
-    // even if reconnect delivered stream-end without the earlier stream-start.
-    this.clearPendingStreamLifecycleState();
+    const isSideQuestionAnswerStream = this.isSideQuestionAnswerStreamEvent(data);
+    // A terminal event for the main agent means any locally preserved
+    // "starting..." state is stale, even if reconnect delivered stream-end
+    // without the earlier stream-start. /btw side-answer streams are separate
+    // and must not hide a still-pending main startup barrier.
+    if (!isSideQuestionAnswerStream) {
+      this.clearPendingStreamLifecycleState();
+    }
 
     // Direct lookup by messageId - O(1) instead of O(n) find
     const activeStream = this.activeStreams.get(data.messageId);
@@ -2036,21 +2137,23 @@ export class StreamingMessageAggregator {
       // Clean up stream-scoped state for this stream.
       this.cleanupStreamState(data.messageId);
 
-      const isFinal = this.activeStreams.size === 0;
+      const isFinal = this.getActiveMainStreamEntry() === undefined;
 
-      // Completion timestamp for ALL final streams — the "stream ended" fact.
-      // Read-marking uses this to keep the active workspace current.
-      const completedAt = isFinal ? Date.now() : null;
+      // Completion timestamp for final main-agent streams — the "stream ended"
+      // fact. Side answers can overlap with the main stream but should not
+      // suppress the main final completion or emit replacement notifications.
+      const completedAt = isFinal && !isSideQuestionAnswerStream ? Date.now() : null;
 
-      // Recency policy: only non-compaction finals inflate lastResponseCompletedAt.
+      // Recency policy: only non-compaction main finals inflate lastResponseCompletedAt.
       // Compaction recency comes from the compacted summary's own timestamp.
       if (completedAt !== null && !activeStream.isCompacting) {
         this.lastResponseCompletedAt = completedAt;
       }
 
-      // Notify on normal stream completion (skip replay-only reconstruction)
-      // isFinal = true when this was the last active stream (assistant done with all work)
-      if (this.workspaceId && this.onResponseComplete) {
+      // Notify on normal stream completion (skip replay-only reconstruction and
+      // /btw side-answer streams).
+      // isFinal = true when the main agent is done with all work.
+      if (this.workspaceId && this.onResponseComplete && !isSideQuestionAnswerStream) {
         this.onResponseComplete({
           workspaceId: this.workspaceId,
           messageId: data.messageId,
@@ -2721,7 +2824,7 @@ export class StreamingMessageAggregator {
     this.addMessage(incomingMessage);
     this.maybeTrackLoadedSkillFromAgentSkillSnapshot(incomingMessage.metadata?.agentSkillSnapshot);
 
-    if (incomingMessage.role !== "user") {
+    if (incomingMessage.role !== "user" || isSideQuestionUserMuxMessage(incomingMessage)) {
       return;
     }
 
@@ -2829,6 +2932,191 @@ export class StreamingMessageAggregator {
   }
 
   /**
+   * Split a list of message parts at one or more cumulative-text-length
+   * boundaries.
+   *
+   * Only `text` parts contribute to the cumulative length — reasoning and
+   * tool parts pass through to whichever segment is currently being filled.
+   * Non-text parts always land in the segment that owns the cumulative
+   * text position immediately before they appear in `parts`, which keeps
+   * "the reasoning that happened before the user fired /btw" anchored on
+   * the pre-aside side of the split.
+   *
+   * Returns `cutPoints.length + 1` segments. Each segment may be empty
+   * (no parts) if the boundaries coincide or the message has no content
+   * before/after a boundary.
+   */
+  private splitMessagePartsAtTextLengths(
+    parts: MuxMessage["parts"],
+    cutPoints: readonly MessagePartSplitCut[]
+  ): Array<MuxMessage["parts"]> {
+    const sortedCuts = [...cutPoints].sort(
+      (a, b) => a.textLength - b.textLength || (a.partIndex ?? Infinity) - (b.partIndex ?? Infinity)
+    );
+    const segments: Array<MuxMessage["parts"]> = sortedCuts.map(() => []);
+    segments.push([]);
+
+    let cumulativeText = 0;
+    let currentSegment = 0;
+
+    const advanceThroughCuts = (newCumulative: number, nextPartIndex: number): void => {
+      while (currentSegment < sortedCuts.length) {
+        const cut = sortedCuts[currentSegment];
+        if (newCumulative < cut.textLength) {
+          return;
+        }
+        if (cut.partIndex !== undefined && nextPartIndex < cut.partIndex) {
+          return;
+        }
+        currentSegment++;
+      }
+    };
+
+    for (let partIndex = 0; partIndex < parts.length; partIndex++) {
+      const part = parts[partIndex];
+      advanceThroughCuts(cumulativeText, partIndex);
+      if (part.type !== "text") {
+        // Reasoning / tool / file parts ride with the current segment.
+        // interruptedPartIndex keeps non-text parts already visible at the
+        // same cumulative text offset on the pre-aside side after reload.
+        segments[currentSegment].push(part);
+        advanceThroughCuts(cumulativeText, partIndex + 1);
+        continue;
+      }
+
+      // Walk this text part across as many boundaries as it crosses. Each
+      // boundary peels off a prefix into the current segment, advances
+      // currentSegment, and leaves the remainder to be considered against
+      // the next boundary.
+      let remaining = part.text;
+      while (currentSegment < sortedCuts.length) {
+        const cut = sortedCuts[currentSegment];
+        if (cut.partIndex !== undefined && partIndex + 1 < cut.partIndex) {
+          // This split point is after a later non-text part at the same text
+          // offset; keep this whole text part in the current segment for now.
+          break;
+        }
+        const charsLeftInCurrentSegment = cut.textLength - cumulativeText;
+        if (charsLeftInCurrentSegment >= remaining.length) {
+          // This part fits entirely inside the current segment.
+          break;
+        }
+        if (charsLeftInCurrentSegment <= 0) {
+          advanceThroughCuts(cumulativeText, partIndex + 1);
+          continue;
+        }
+        const prefix = remaining.slice(0, charsLeftInCurrentSegment);
+        if (prefix.length > 0) {
+          // Preserve part metadata (e.g. timestamp) on each half.
+          segments[currentSegment].push({ ...part, text: prefix });
+        }
+        cumulativeText = cut.textLength;
+        remaining = remaining.slice(charsLeftInCurrentSegment);
+        advanceThroughCuts(cumulativeText, partIndex + 1);
+      }
+
+      if (remaining.length > 0) {
+        segments[currentSegment].push({ ...part, text: remaining });
+        cumulativeText += remaining.length;
+        advanceThroughCuts(cumulativeText, partIndex + 1);
+      }
+    }
+
+    return segments;
+  }
+
+  /**
+   * Build displayed rows for a main-agent assistant message that was
+   * interrupted by one or more /btw side questions.
+   *
+   * The interrupted message is split at each captured text-length
+   * boundary; the side-question Q+A pair for each interrupt is inserted
+   * between the surrounding segments. The result is a continuous run of
+   * displayed rows that reads:
+   *
+   *   [M1 pre-aside]
+   *   [Q1]
+   *   [A1]
+   *   [M1 middle (if multiple /btw interrupted the same turn)]
+   *   ...
+   *   [M1 post-aside]
+   *
+   * The LAST segment keeps M1's original message id so an active stream
+   * lookup (`activeStreams.has(M1.id)`) still surfaces the streaming
+   * indicator on the right row. Earlier segments use `${M1.id}#seg<i>`
+   * suffixes for React key stability; their `historyId` is rewritten
+   * back to `M1.id` so action handlers (Copy / Start Here / etc.) still
+   * target the persisted message.
+   */
+  private buildInterruptedMessageDisplay(
+    message: MuxMessage,
+    interrupts: readonly SideQuestionInterrupt[],
+    agentSkillSnapshot?: { frontmatterYaml?: string; body?: string },
+    inlineSkillSnapshots?: InlineSkillSnapshotMap
+  ): DisplayedMessage[] {
+    const sorted = [...interrupts].sort((a, b) => a.atTextLength - b.atTextLength);
+    const segments = this.splitMessagePartsAtTextLengths(
+      message.parts,
+      sorted.map((interrupt) => ({
+        textLength: interrupt.atTextLength,
+        partIndex: interrupt.atPartIndex,
+      }))
+    );
+
+    const result: DisplayedMessage[] = [];
+
+    for (let i = 0; i < segments.length; i++) {
+      const isLastSegment = i === segments.length - 1;
+      const segParts = segments[i];
+
+      // Always render the last segment even if empty — it owns the
+      // streaming-indicator anchor and the meta row. Earlier segments
+      // skip when empty to avoid emitting hollow blocks.
+      if (segParts.length > 0 || isLastSegment) {
+        // Last segment keeps the original id so activeStreams lookup hits;
+        // earlier segments get a suffixed id for React key uniqueness.
+        const segMessageId = isLastSegment ? message.id : `${message.id}#seg${i}`;
+        const segMessage: MuxMessage = {
+          ...message,
+          id: segMessageId,
+          parts: segParts,
+        };
+
+        const segRows = this.buildDisplayedMessagesForMessage(
+          segMessage,
+          agentSkillSnapshot,
+          inlineSkillSnapshots
+        );
+
+        // Rewrite `historyId` on each emitted row back to the original
+        // message id. Without this rewrite, action handlers that resolve
+        // a row to its backend message (Start Here, Fork, etc.) would
+        // hit "message not found" because no real history row exists
+        // under the suffixed segment id.
+        if (!isLastSegment) {
+          for (const row of segRows) {
+            if ("historyId" in row && row.historyId === segMessageId) {
+              (row as { historyId: string }).historyId = message.id;
+            }
+          }
+        }
+
+        result.push(...segRows);
+      }
+
+      if (i < sorted.length) {
+        const interrupt = sorted[i];
+        result.push(...this.buildDisplayedMessagesForMessage(interrupt.sideQuestionUserMsg));
+        if (interrupt.sideQuestionAnswerMsg) {
+          result.push(...this.buildDisplayedMessagesForMessage(interrupt.sideQuestionAnswerMsg));
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
    * After filtering older tool/reasoning parts, recompute which part is the
    * last visible block for each assistant message. This keeps meta rows and
    * interrupted barriers accurate after truncation.
@@ -2877,6 +3165,87 @@ export class StreamingMessageAggregator {
       // messages that reference skills via /{skillName} or inline $skillName tokens.
       const latestAgentSkillSnapshotByKey = new Map<string, AgentSkillSnapshotContent>();
 
+      // ---------------------------------------------------------------
+      // /btw side-question splitting:
+      //
+      // When a /btw fires WHILE a main-agent assistant message is mid-
+      // stream, the backend stamps the user `/btw` row with
+      // `interruptedMessageId` + `interruptedTextLength`. The frontend
+      // uses those anchors to visually split the interrupted message so
+      // the side branch appears between the pre-aside and post-aside
+      // halves of the main agent's reply — without this, sequence-order
+      // rendering would shove the side branch below the entire reply
+      // (lower historySequence => higher in the transcript), defeating
+      // the "main chat continues after the aside" UX.
+      //
+      // We pre-walk allMessages to build:
+      //   - interruptionsByInterruptedId: which main-agent messages get
+      //     split, and at which text offsets.
+      //   - emittedAsSplitChildren: side-question user + answer rows
+      //     that the split path will emit inline. The main walk must
+      //     SKIP these to avoid double-rendering.
+      // ---------------------------------------------------------------
+      const interruptionsByInterruptedId = new Map<string, SideQuestionInterrupt[]>();
+      const emittedAsSplitChildren = new Set<string>();
+
+      const isRenderableSideQuestionAnswer = (answer: MuxMessage): boolean =>
+        this.activeStreams.has(answer.id) || answer.parts.length > 0;
+      const linkedSideAnswerByQuestionId = new Map<string, MuxMessage>();
+      for (const message of allMessages) {
+        if (!isSideQuestionAnswerMuxMessage(message)) {
+          continue;
+        }
+        const questionMessageId = message.metadata.muxMetadata.questionMessageId;
+        if (typeof questionMessageId === "string") {
+          linkedSideAnswerByQuestionId.set(questionMessageId, message);
+        }
+      }
+
+      // A /btw answer (side-question-answer) normally follows its user
+      // /btw row in history, but model setup can lag behind the user row.
+      // Pair by the stable questionMessageId when present, falling back to
+      // adjacency only for legacy history rows that predate that link.
+      for (let i = 0; i < allMessages.length; i++) {
+        const msg = allMessages[i];
+        if (!isSideQuestionUserMuxMessage(msg)) {
+          continue;
+        }
+        const muxMeta = msg.metadata.muxMetadata;
+        if (
+          typeof muxMeta.interruptedMessageId !== "string" ||
+          typeof muxMeta.interruptedTextLength !== "number"
+        ) {
+          continue;
+        }
+
+        const linkedAnswer = linkedSideAnswerByQuestionId.get(msg.id);
+        const next = allMessages[i + 1];
+        const adjacentAnswer =
+          next !== undefined && isSideQuestionAnswerMuxMessage(next) ? next : undefined;
+        const adjacentAnswerQuestionId = adjacentAnswer?.metadata.muxMetadata.questionMessageId;
+        const legacyAdjacentAnswer =
+          adjacentAnswer !== undefined && adjacentAnswerQuestionId === undefined
+            ? adjacentAnswer
+            : undefined;
+        const answer = linkedAnswer ?? legacyAdjacentAnswer;
+        const answerIsRenderable = answer !== undefined && isRenderableSideQuestionAnswer(answer);
+        const existing = interruptionsByInterruptedId.get(muxMeta.interruptedMessageId);
+        const entry = {
+          atTextLength: muxMeta.interruptedTextLength,
+          atPartIndex:
+            typeof muxMeta.interruptedPartIndex === "number"
+              ? muxMeta.interruptedPartIndex
+              : undefined,
+          sideQuestionUserMsg: msg,
+          sideQuestionAnswerMsg: answerIsRenderable ? answer : undefined,
+        };
+        if (existing) {
+          existing.push(entry);
+        } else {
+          interruptionsByInterruptedId.set(muxMeta.interruptedMessageId, [entry]);
+        }
+      }
+
       for (const message of allMessages) {
         maybeCollectAgentSkillSnapshot(message, latestAgentSkillSnapshotByKey);
         const isSynthetic = message.metadata?.synthetic === true;
@@ -2914,6 +3283,40 @@ export class StreamingMessageAggregator {
               )
             : undefined;
         const inlineSkillSnapshotsCacheKey = inlineSkillSnapshotState?.cacheKey;
+
+        // Skip /btw rows that the split path is going to render INLINE
+        // inside the interrupted message's display block. Without this
+        // guard the side-question pair would render twice — once between
+        // the split halves and once at its natural sequence position
+        // (below the interrupted message).
+        if (emittedAsSplitChildren.has(message.id)) {
+          continue;
+        }
+
+        const interrupts = interruptionsByInterruptedId.get(message.id);
+        if (interrupts && message.role === "assistant") {
+          // Interrupted main-agent message: build its display rows with
+          // the /btw pair(s) interleaved in the middle. We bypass the
+          // displayedMessageCache here because the split output is a
+          // function of *multiple* messages' state — caching it under
+          // one message id would miss invalidations on the children.
+          const splitRows = this.buildInterruptedMessageDisplay(
+            message,
+            interrupts,
+            agentSkillSnapshotForDisplay,
+            inlineSkillSnapshotState?.snapshots
+          );
+          for (const interrupt of interrupts) {
+            emittedAsSplitChildren.add(interrupt.sideQuestionUserMsg.id);
+            if (interrupt.sideQuestionAnswerMsg) {
+              emittedAsSplitChildren.add(interrupt.sideQuestionAnswerMsg.id);
+            }
+          }
+          if (splitRows.length > 0) {
+            displayedMessages.push(...splitRows);
+          }
+          continue;
+        }
 
         const version = this.messageVersions.get(message.id) ?? 0;
         const cached = this.displayedMessageCache.get(message.id);

--- a/src/browser/utils/messages/displayedMessageBuilder.ts
+++ b/src/browser/utils/messages/displayedMessageBuilder.ts
@@ -21,6 +21,10 @@ import {
   getContextBoundaryKind,
 } from "@/common/utils/messages/compactionBoundary";
 import { isDynamicToolPart, type DynamicToolPart } from "@/common/types/toolParts";
+import {
+  isSideQuestionAnswerMessage,
+  isSideQuestionUserMessage,
+} from "@/common/utils/messages/sideQuestion";
 
 function isSuccessfulImageGenerateResult(
   result: unknown
@@ -350,6 +354,7 @@ function buildUserDisplayedMessages(options: {
       inlineSkillSnapshots,
       compactionRequest,
       reviews: muxMeta?.reviews,
+      isSideQuestion: isSideQuestionUserMessage(message) ? true : undefined,
     },
   ];
 }
@@ -447,6 +452,7 @@ function appendAssistantTextRow(
     // Support both new enum ("user"|"idle") and legacy boolean (true).
     isCompacted: !!message.metadata?.compacted,
     isIdleCompacted: message.metadata?.compacted === "idle",
+    isSideAnswer: isSideQuestionAnswerMessage(message) ? true : undefined,
     model: message.metadata?.model,
     routedThroughGateway: message.metadata?.routedThroughGateway,
     routeProvider: resolveRouteProvider(

--- a/src/browser/utils/slashCommands/btw.test.ts
+++ b/src/browser/utils/slashCommands/btw.test.ts
@@ -1,0 +1,35 @@
+import { parseCommand } from "./parser";
+
+describe("/btw command", () => {
+  it("parses /btw with a question", () => {
+    const result = parseCommand("/btw what file did you just edit?");
+    expect(result).toEqual({
+      type: "side-question",
+      question: "what file did you just edit?",
+    });
+  });
+
+  it("preserves spaces, quotes, and punctuation in the question", () => {
+    const result = parseCommand('/btw why "exec-only" mode? Is it costlier?');
+    expect(result).toEqual({
+      type: "side-question",
+      question: 'why "exec-only" mode? Is it costlier?',
+    });
+  });
+
+  it("returns command-missing-args when no question is provided", () => {
+    const result = parseCommand("/btw");
+    expect(result).toMatchObject({
+      type: "command-missing-args",
+      command: "btw",
+    });
+  });
+
+  it("treats whitespace-only input as missing args", () => {
+    const result = parseCommand("/btw    ");
+    expect(result).toMatchObject({
+      type: "command-missing-args",
+      command: "btw",
+    });
+  });
+});

--- a/src/browser/utils/slashCommands/registry.ts
+++ b/src/browser/utils/slashCommands/registry.ts
@@ -679,6 +679,27 @@ const goalCommandDefinition: SlashCommandDefinition = {
   },
 };
 
+const BTW_USAGE = `/btw ${SLASH_COMMAND_HINTS.btw}`;
+
+const btwCommandDefinition: SlashCommandDefinition = {
+  key: "btw",
+  description:
+    "Ask a quick side question about the current conversation. The inline answer is saved in chat but kept out of future agent context.",
+  inputHint: SLASH_COMMAND_HINTS.btw,
+  appendSpace: true,
+  handler: ({ rawInput }): ParsedCommand => {
+    const trimmed = rawInput.trim();
+    if (trimmed.length === 0) {
+      return {
+        type: "command-missing-args",
+        command: "btw",
+        usage: BTW_USAGE,
+      };
+    }
+    return { type: "side-question", question: trimmed };
+  },
+};
+
 const debugLlmRequestCommandDefinition: SlashCommandDefinition = {
   key: "debug-llm-request",
   description: "Show the last LLM request sent (debug)",
@@ -699,6 +720,7 @@ export const SLASH_COMMAND_DEFINITIONS: readonly SlashCommandDefinition[] = [
   idleCommandDefinition,
   heartbeatCommandDefinition,
   goalCommandDefinition,
+  btwCommandDefinition,
   debugLlmRequestCommandDefinition,
 ];
 

--- a/src/browser/utils/slashCommands/types.ts
+++ b/src/browser/utils/slashCommands/types.ts
@@ -46,6 +46,7 @@ export type ParsedCommand =
   | { type: "goal-resume" }
   | { type: "goal-complete"; summary?: string }
   | { type: "goal-clear" }
+  | { type: "side-question"; question: string }
   | null;
 
 export interface SuggestionsHandlerArgs {

--- a/src/common/constants/slashCommandHints.ts
+++ b/src/common/constants/slashCommandHints.ts
@@ -12,4 +12,5 @@ export const SLASH_COMMAND_HINTS = {
   idle: "<hours>|off",
   heartbeat: "<minutes>|off",
   goal: "[-b <amount>] [--turns <n>] <objective>|budget <amount>|clear",
+  btw: "<question>",
 } as const satisfies Readonly<Record<string, string>>;

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -1160,6 +1160,28 @@ export const workspace = {
     }),
     output: ResultSchema(z.object({}), SendMessageErrorSchema),
   },
+  sideQuestion: {
+    // `/btw` — forked, single-turn, read-only side question over the
+    // current conversation. Tools are denied client-side and prompt-side.
+    //
+    // The actual question + answer flow to the frontend through the normal
+    // `onChat` stream events (so they animate with TypewriterMarkdown and
+    // persist to chat.jsonl). This RPC only returns success/error so the
+    // caller can surface a toast on failure.
+    input: z
+      .object({
+        workspaceId: z.string(),
+        question: z.string().min(1),
+      })
+      .strict(),
+    output: z.discriminatedUnion("success", [
+      z.object({
+        success: z.literal(true),
+        modelUsed: z.string(),
+      }),
+      z.object({ success: z.literal(false), error: z.string() }),
+    ]),
+  },
   answerAskUserQuestion: {
     input: z
       .object({

--- a/src/common/orpc/schemas/stream.ts
+++ b/src/common/orpc/schemas/stream.ts
@@ -11,6 +11,7 @@ import {
   MuxTextPartSchema,
   MuxToolPartSchema,
 } from "./message";
+import type { MuxMessageMetadata } from "../../types/message";
 import { MuxProviderOptionsSchema } from "./providerOptions";
 import { RuntimeModeSchema } from "./runtime";
 
@@ -244,6 +245,7 @@ export const StreamEndEventSchema = z.object({
       duration: z.number().optional(),
       ttftMs: z.number().optional(),
       systemMessageTokens: z.number().optional(),
+      muxMetadata: z.custom<MuxMessageMetadata>().optional(),
       historySequence: z.number().optional().meta({
         description: "Present when loading from history",
       }),

--- a/src/common/orpc/schemas/telemetry.ts
+++ b/src/common/orpc/schemas/telemetry.ts
@@ -45,6 +45,7 @@ const TelemetryCommandTypeSchema = z.enum([
   "plan",
   "providers",
   "goal",
+  "btw",
 ]);
 
 // Individual event payload schemas

--- a/src/common/telemetry/payload.ts
+++ b/src/common/telemetry/payload.ts
@@ -299,7 +299,8 @@ export type TelemetryCommandType =
   | "mode"
   | "plan"
   | "providers"
-  | "goal";
+  | "goal"
+  | "btw";
 
 /**
  * Command usage event - tracks slash command usage patterns

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -370,6 +370,68 @@ export type MuxMessageMetadata = MuxMessageMetadataBase &
         /** Original user input for one-shot overrides (e.g., "/opus+high do something") — used as display content so the command prefix remains visible. */
         rawCommand?: string;
       }
+    | {
+        // /btw — user-side marker for a side question.
+        //
+        // The forked, single-turn, read-only side branch is created by the
+        // side-question pipeline (see sideQuestionService). We persist the
+        // user message so /btw exchanges are durable across reloads, but tag
+        // it so the renderer can distinguish a side question from a normal
+        // turn, and so request builders can omit the aside from future
+        // main-agent provider context.
+        type: "side-question";
+        /** Original "/btw <question>" command as typed (for display). */
+        rawCommand: string;
+        /**
+         * `messageId` of the main-agent assistant message that was in the
+         * middle of streaming when this /btw fired. Used by the renderer
+         * to visually split the interrupted message so the side branch
+         * appears between the pre-aside and post-aside halves of the
+         * main agent's reply — otherwise the side branch sits below the
+         * full M1 reply (sequence ordering) and the "main chat continues
+         * after the aside" reading is lost.
+         *
+         * Absent when /btw fires with no main-agent stream in flight
+         * (e.g. between turns); in that case the side branch renders
+         * normally at the bottom of the transcript.
+         */
+        interruptedMessageId?: string;
+        /**
+         * Length (in characters) of the interrupted message's accumulated
+         * text at the moment /btw fired. The renderer splits at this
+         * offset across the merged text parts. Reasoning / tool parts
+         * before the split point fall into the pre-aside half by
+         * position in the message's `parts` array.
+         *
+         * Captured synchronously on the backend via
+         * `aiService.getStreamInfo` before the user `/btw` row is
+         * persisted, so it's stable across reloads.
+         */
+        interruptedTextLength?: number;
+        /**
+         * Number of message parts that were already visible when /btw fired.
+         * This disambiguates non-text parts (reasoning/tool/file) that share
+         * the same cumulative text offset as the split boundary.
+         */
+        interruptedPartIndex?: number;
+        /**
+         * `historySequence` of the interrupted main-agent message,
+         * captured at /btw-fire time. Stored alongside `interruptedMessageId`
+         * so the renderer can disambiguate if a future compaction epoch
+         * recycles the id; currently informational.
+         */
+        interruptedHistorySequence?: number;
+      }
+    | {
+        // /btw — assistant-side marker for the answer to a side question.
+        type: "side-question-answer";
+        /**
+         * Stable link back to the user /btw row. The answer placeholder may be
+         * appended after later side-question user rows, so renderers must not
+         * rely on adjacency to pair concurrent side-question Q/A branches.
+         */
+        questionMessageId?: string;
+      }
   );
 
 export function getCompactionFollowUpContent(
@@ -606,6 +668,8 @@ export type DisplayedMessage =
       };
       /** Structured review data for rich UI display (from muxMetadata) */
       reviews?: ReviewNoteDataForDisplay[];
+      /** True when this user message is a /btw side question. */
+      isSideQuestion?: boolean;
     }
   | {
       type: "assistant";
@@ -621,6 +685,8 @@ export type DisplayedMessage =
       isIdleCompacted: boolean; // Whether this compaction was auto-triggered due to inactivity
       /** True when this assistant row predates the latest Context Boundary. */
       isBeforeLatestContextBoundary?: boolean;
+      /** True when this assistant row is the answer to a /btw side question. */
+      isSideAnswer?: boolean;
       model?: string;
       routedThroughGateway?: boolean;
       routeProvider?: string;

--- a/src/common/utils/messages/sideQuestion.ts
+++ b/src/common/utils/messages/sideQuestion.ts
@@ -1,0 +1,61 @@
+import type { MuxMessage, MuxMetadata } from "@/common/types/message";
+
+export const SIDE_QUESTION_METADATA_TYPE = "side-question";
+export const SIDE_QUESTION_ANSWER_METADATA_TYPE = "side-question-answer";
+
+type SideQuestionMetadata = Extract<
+  NonNullable<MuxMetadata["muxMetadata"]>,
+  { type: typeof SIDE_QUESTION_METADATA_TYPE }
+>;
+
+type SideQuestionAnswerMetadata = Extract<
+  NonNullable<MuxMetadata["muxMetadata"]>,
+  { type: typeof SIDE_QUESTION_ANSWER_METADATA_TYPE }
+>;
+
+export type SideQuestionUserMuxMessage = MuxMessage & {
+  role: "user";
+  metadata: MuxMetadata & { muxMetadata: SideQuestionMetadata };
+};
+
+export type SideQuestionAnswerMuxMessage = MuxMessage & {
+  role: "assistant";
+  metadata: MuxMetadata & { muxMetadata: SideQuestionAnswerMetadata };
+};
+
+export function isSideQuestionUserMessage(
+  message: MuxMessage
+): message is SideQuestionUserMuxMessage {
+  return (
+    message.role === "user" && message.metadata?.muxMetadata?.type === SIDE_QUESTION_METADATA_TYPE
+  );
+}
+
+export function isSideQuestionAnswerMessage(
+  message: MuxMessage
+): message is SideQuestionAnswerMuxMessage {
+  return (
+    message.role === "assistant" &&
+    message.metadata?.muxMetadata?.type === SIDE_QUESTION_ANSWER_METADATA_TYPE
+  );
+}
+
+export function isSideQuestionMessage(message: MuxMessage): boolean {
+  const type = message.metadata?.muxMetadata?.type;
+  return type === SIDE_QUESTION_METADATA_TYPE || type === SIDE_QUESTION_ANSWER_METADATA_TYPE;
+}
+
+/**
+ * Remove durable /btw side-question rows from provider-bound transcripts.
+ *
+ * /btw exchanges are persisted so the UI can reload them, but they are a
+ * forked read-only aside and must not pollute future main-agent requests.
+ * Preserve array identity when nothing is removed so diagnostics can tell
+ * ordinary context-boundary slicing apart from /btw filtering.
+ */
+export function filterSideQuestionMessages(messages: MuxMessage[]): MuxMessage[] {
+  if (!messages.some(isSideQuestionMessage)) {
+    return messages;
+  }
+  return messages.filter((message) => !isSideQuestionMessage(message));
+}

--- a/src/constants/slashCommands.ts
+++ b/src/constants/slashCommands.ts
@@ -14,6 +14,7 @@ export const WORKSPACE_ONLY_COMMAND_KEYS: ReadonlySet<string> = new Set([
   "new",
   "plan",
   "heartbeat",
+  "btw",
 ]);
 
 /**
@@ -35,4 +36,5 @@ export const WORKSPACE_ONLY_COMMAND_TYPES: ReadonlySet<string> = new Set([
   "goal-resume",
   "goal-complete",
   "goal-clear",
+  "side-question",
 ]);

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -3408,6 +3408,12 @@ export const router = (authToken?: string) => {
 
           return { success: true, data: {} };
         }),
+      sideQuestion: t
+        .input(schemas.workspace.sideQuestion.input)
+        .output(schemas.workspace.sideQuestion.output)
+        .handler(async ({ context, input }) => {
+          return context.workspaceService.askSideQuestion(input.workspaceId, input.question);
+        }),
       answerAskUserQuestion: t
         .input(schemas.workspace.answerAskUserQuestion.input)
         .output(schemas.workspace.answerAskUserQuestion.output)

--- a/src/node/services/aiService.test.ts
+++ b/src/node/services/aiService.test.ts
@@ -398,6 +398,42 @@ describe("prepareProviderRequestMessages", () => {
     expect(result.activeContextMessages.map((message) => message.id)).toEqual(["new-user"]);
     expect(result.providerRequestMessages.map((message) => message.id)).toEqual(["new-user"]);
   });
+
+  it("filters /btw side-question rows out of provider-bound context", () => {
+    const mainUser = createMuxMessage("main-user", "user", "normal follow-up", {
+      historySequence: 1,
+    });
+    const sideQuestion = createMuxMessage("btw-user", "user", "what is 1+1?", {
+      historySequence: 2,
+      muxMetadata: {
+        type: "side-question",
+        rawCommand: "/btw what is 1+1?",
+        commandPrefix: "/btw",
+      },
+    });
+    const sideAnswer = createMuxMessage("btw-answer", "assistant", "2", {
+      historySequence: 3,
+      muxMetadata: { type: "side-question-answer" },
+    });
+    const nextUser = createMuxMessage("next-user", "user", "continue normal work", {
+      historySequence: 4,
+    });
+
+    const result = prepareProviderRequestMessages(
+      [mainUser, sideQuestion, sideAnswer, nextUser],
+      "openai",
+      "off"
+    );
+
+    expect(result.activeContextMessages.map((message) => message.id)).toEqual([
+      "main-user",
+      "next-user",
+    ]);
+    expect(result.providerRequestMessages.map((message) => message.id)).toEqual([
+      "main-user",
+      "next-user",
+    ]);
+  });
 });
 
 describe("AIService", () => {

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -122,6 +122,7 @@ import {
 } from "./streamSimulation";
 import { applyToolPolicyAndExperiments, captureMcpToolTelemetry } from "./toolAssembly";
 import { getErrorMessage } from "@/common/utils/errors";
+import { filterSideQuestionMessages } from "@/common/utils/messages/sideQuestion";
 import { isProjectTrusted } from "@/node/utils/projectTrust";
 
 const STREAM_STARTUP_DIAGNOSTIC_THRESHOLD_MS = 1_000;
@@ -133,8 +134,19 @@ export function prepareProviderRequestMessages(
 ): {
   activeContextMessages: MuxMessage[];
   providerRequestMessages: MuxMessage[];
+  sideQuestionFilteredCount: number;
+  contextBoundarySlicedCount: number;
 } {
-  const activeContextMessages = sliceMessagesForProviderFromLatestContextBoundary(messages);
+  // /btw side questions are durable UI history, not main-agent context.
+  // Filter them before boundary slicing so future normal turns don't see
+  // side-question Q/A pairs and accidentally continue from an aside.
+  const messagesWithoutSideQuestions = filterSideQuestionMessages(messages);
+  const sideQuestionFilteredCount = messages.length - messagesWithoutSideQuestions.length;
+  const activeContextMessages = sliceMessagesForProviderFromLatestContextBoundary(
+    messagesWithoutSideQuestions
+  );
+  const contextBoundarySlicedCount =
+    messagesWithoutSideQuestions.length - activeContextMessages.length;
   const preserveReasoningOnly =
     canonicalProviderName === "anthropic" && effectiveThinkingLevel !== "off";
   return {
@@ -143,6 +155,8 @@ export function prepareProviderRequestMessages(
       activeContextMessages,
       preserveReasoningOnly
     ),
+    sideQuestionFilteredCount,
+    contextBoundarySlicedCount,
   };
 }
 
@@ -864,16 +878,19 @@ export class AIService extends EventEmitter {
 
       // Context Boundary request slicing happens before empty-assistant filtering so
       // provider-invisible reset rows can still bound the active context window.
-      const { activeContextMessages, providerRequestMessages } = prepareProviderRequestMessages(
-        messages,
-        canonicalProviderName,
-        effectiveThinkingLevel
-      );
-      if (activeContextMessages !== messages) {
-        log.debug("Sliced provider history from latest context boundary", {
+      const {
+        activeContextMessages,
+        providerRequestMessages,
+        sideQuestionFilteredCount,
+        contextBoundarySlicedCount,
+      } = prepareProviderRequestMessages(messages, canonicalProviderName, effectiveThinkingLevel);
+      if (sideQuestionFilteredCount > 0 || contextBoundarySlicedCount > 0) {
+        log.debug("Prepared provider history window", {
           workspaceId,
           originalCount: messages.length,
-          slicedCount: activeContextMessages.length,
+          sideQuestionFilteredCount,
+          contextBoundarySlicedCount,
+          activeContextCount: activeContextMessages.length,
         });
       }
       log.debug_obj(`${workspaceId}/1a_active_context_messages.json`, activeContextMessages);

--- a/src/node/services/sideQuestionService.test.ts
+++ b/src/node/services/sideQuestionService.test.ts
@@ -1,0 +1,617 @@
+import * as aiSdk from "ai";
+import { type LanguageModel } from "ai";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { askSideQuestion, buildSideQuestionMessages } from "./sideQuestionService";
+import type { AIService } from "./aiService";
+import { Err, Ok } from "@/common/types/result";
+import { createMuxMessage } from "@/common/types/message";
+import type { WorkspaceChatMessage } from "@/common/orpc/types";
+import { CONTEXT_BOUNDARY_KINDS } from "@/common/utils/messages/compactionBoundary";
+import { createTestHistoryService } from "./testHistoryService";
+import { NAME_GEN_PREFERRED_MODELS } from "@/common/constants/nameGeneration";
+
+afterEach(() => {
+  mock.restore();
+});
+
+function createFakeModel(modelId = "side-question-model"): LanguageModel {
+  return {
+    specificationVersion: "v3",
+    provider: "test",
+    modelId,
+    supportedUrls: {},
+    doGenerate: () => Promise.reject(new Error("doGenerate unused in side-question tests")),
+    doStream: () => Promise.reject(new Error("doStream unused in side-question tests")),
+  };
+}
+
+/**
+ * Fake AIService for side-question tests. `getStreamInfo` defaults to
+ * "no main-agent stream is in flight" so the side question records no
+ * interruption metadata; callers that want to exercise the split path
+ * override it with a `streamInfo` arg.
+ */
+function createFakeAIService(
+  model: LanguageModel,
+  streamInfo?: ReturnType<AIService["getStreamInfo"]>
+): AIService {
+  return {
+    createModel: () => Promise.resolve(Ok(model)),
+    getStreamInfo: () => streamInfo,
+  } as unknown as AIService;
+}
+
+/** Fake textStream that emits a fixed sequence of chunks. */
+function fakeTextStream(chunks: readonly string[]) {
+  async function* gen() {
+    for (const c of chunks) {
+      // The await is purely formal — bun-test's async generator typing
+      // requires at least one await for `require-await`, and yielding to
+      // the microtask queue here also exercises the consumer's `for await`
+      // back-pressure handling the way a real provider stream would.
+      await Promise.resolve();
+      yield c;
+    }
+  }
+  return {
+    textStream: gen(),
+  } as unknown as ReturnType<typeof aiSdk.streamText>;
+}
+
+describe("buildSideQuestionMessages", () => {
+  test("wraps the question in a <system-reminder> and exposes the transcript", () => {
+    const { system, messages } = buildSideQuestionMessages(
+      "what file did you just edit?",
+      "User: change the config\nAssistant: edited src/config.ts"
+    );
+
+    expect(system).toContain("No tools are available");
+    expect(system).toContain("clearly-marked side answer");
+    expect(messages).toHaveLength(1);
+    const content = messages[0]?.content as string;
+    expect(content).toContain("<system-reminder>");
+    expect(content).toContain("/btw");
+    expect(content).toContain("No tools are available");
+    expect(content).toContain("Side question: what file did you just edit?");
+    expect(content).toContain("Assistant: edited src/config.ts");
+  });
+
+  test("handles an empty transcript gracefully", () => {
+    const { messages } = buildSideQuestionMessages("hi", "");
+    const content = messages[0]?.content as string;
+    expect(content).toContain("(empty transcript)");
+  });
+});
+
+describe("askSideQuestion (persisted, streaming)", () => {
+  test("persists user + assistant messages and emits stream-start/delta/end", async () => {
+    const { historyService, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "ws-btw-stream";
+      await historyService.appendToHistory(
+        workspaceId,
+        createMuxMessage("m1", "user", "what is 2+2")
+      );
+      await historyService.appendToHistory(workspaceId, createMuxMessage("m2", "assistant", "4"));
+
+      let receivedTools: unknown;
+      spyOn(aiSdk, "streamText").mockImplementation(((opts: unknown) => {
+        receivedTools = (opts as { tools?: unknown }).tools;
+        return fakeTextStream(["Yes — ", "**4**", ", as I said."]);
+      }) as unknown as typeof aiSdk.streamText);
+
+      const emitted: WorkspaceChatMessage[] = [];
+      const result = await askSideQuestion({
+        workspaceId,
+        question: "are you sure?",
+        candidates: ["openai:gpt-4.1-mini"],
+        aiService: createFakeAIService(createFakeModel()),
+        historyService,
+        emitChatEvent: (_wsId, message) => emitted.push(message),
+      });
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.answer).toBe("Yes — **4**, as I said.");
+
+      // Tool-blocking contract: no tools were passed to the model.
+      expect(receivedTools).toBeUndefined();
+
+      // Chat events: user message + assistant placeholder + stream-start +
+      // N deltas + stream-end. The assistant placeholder is emitted as a
+      // `message` event so the frontend aggregator sees the
+      // side-question-answer muxMetadata BEFORE stream-start — without
+      // that, the badge and the main-agent suspension layer (which both
+      // key off muxMetadata) lose the marker for the entire stream.
+      const types = emitted.map((m) => m.type);
+      expect(types[0]).toBe("message"); // user /btw
+      expect(types[1]).toBe("message"); // assistant placeholder
+      expect(types[2]).toBe("stream-start");
+      expect(types[types.length - 1]).toBe("stream-end");
+      // At least one stream-delta in between (one per non-empty chunk).
+      expect(types.filter((t) => t === "stream-delta").length).toBe(3);
+
+      // The placeholder envelope carries the side-question-answer marker
+      // so the live aggregator can pick it up before any text streams in.
+      const placeholder = emitted[1];
+      // Narrow defensively — the test's `WorkspaceChatMessage` type covers
+      // many shapes; muxMetadata only lives on `message` envelopes.
+      const placeholderMuxMeta =
+        placeholder.type === "message"
+          ? (placeholder.metadata?.muxMetadata as { type?: string } | undefined)
+          : undefined;
+      expect(placeholderMuxMeta?.type).toBe("side-question-answer");
+
+      const terminalEvent = emitted.at(-1);
+      const terminalMuxMeta =
+        terminalEvent?.type === "stream-end"
+          ? (terminalEvent.metadata.muxMetadata as { type?: string } | undefined)
+          : undefined;
+      expect(terminalMuxMeta?.type).toBe("side-question-answer");
+
+      // History: m1, m2, user /btw, assistant /btw answer.
+      const after = await historyService.getLastMessages(workspaceId, 10);
+      expect(after.success).toBe(true);
+      if (!after.success) return;
+      expect(after.data).toHaveLength(4);
+      const user = after.data[2];
+      const assistant = after.data[3];
+      expect(user.role).toBe("user");
+      expect(user.metadata?.muxMetadata?.type).toBe("side-question");
+      expect(user.metadata?.muxMetadata?.commandPrefix).toBe("/btw");
+      expect(assistant.role).toBe("assistant");
+      expect(assistant.metadata?.muxMetadata?.type).toBe("side-question-answer");
+      // The assistant's text part should contain the full streamed answer.
+      const textPart = assistant.parts.find(
+        (p): p is Extract<typeof p, { type: "text" }> => p.type === "text"
+      );
+      expect(textPart?.text).toBe("Yes — **4**, as I said.");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("emits the live answer but returns an error when persistence fails", async () => {
+    const { historyService, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "ws-btw-persist-fails";
+      spyOn(aiSdk, "streamText").mockImplementation((() =>
+        fakeTextStream(["visible answer"])) as unknown as typeof aiSdk.streamText);
+      spyOn(historyService, "updateHistory").mockResolvedValueOnce(Err("disk full"));
+
+      const emitted: WorkspaceChatMessage[] = [];
+      const result = await askSideQuestion({
+        workspaceId,
+        question: "will this persist?",
+        candidates: ["openai:gpt-4.1-mini"],
+        aiService: createFakeAIService(createFakeModel()),
+        historyService,
+        emitChatEvent: (_wsId, message) => emitted.push(message),
+      });
+
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error.raw).toBe("disk full");
+
+      const streamEnd = emitted.find((message) => message.type === "stream-end");
+      expect(streamEnd?.type).toBe("stream-end");
+      if (streamEnd?.type !== "stream-end") return;
+      expect(streamEnd.parts).toEqual([{ type: "text", text: "visible answer" }]);
+
+      const after = await historyService.getLastMessages(workspaceId, 10);
+      expect(after.success).toBe(true);
+      if (!after.success) return;
+      const assistantRows = after.data.filter((message) => message.role === "assistant");
+      expect(assistantRows).toHaveLength(1);
+      expect(assistantRows[0].parts).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("excludes prior side-question turns from the transcript", async () => {
+    const { historyService, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "ws-btw-skip-prior";
+      // Real turn + a prior /btw exchange that should NOT leak into the
+      // transcript for the next /btw.
+      await historyService.appendToHistory(
+        workspaceId,
+        createMuxMessage("u1", "user", "regular question")
+      );
+      await historyService.appendToHistory(
+        workspaceId,
+        createMuxMessage("a1", "assistant", "regular answer")
+      );
+      await historyService.appendToHistory(
+        workspaceId,
+        createMuxMessage("u2", "user", "old side q", {
+          muxMetadata: { type: "side-question", rawCommand: "/btw old", commandPrefix: "/btw" },
+        })
+      );
+      await historyService.appendToHistory(
+        workspaceId,
+        createMuxMessage("a2", "assistant", "old side a", {
+          muxMetadata: { type: "side-question-answer" },
+        })
+      );
+
+      let capturedPrompt: string | undefined;
+      spyOn(aiSdk, "streamText").mockImplementation(((opts: unknown) => {
+        const messages = (opts as { messages: Array<{ content: string }> }).messages;
+        capturedPrompt = messages[0]?.content;
+        return fakeTextStream(["ok"]);
+      }) as unknown as typeof aiSdk.streamText);
+
+      const result = await askSideQuestion({
+        workspaceId,
+        question: "new question",
+        candidates: ["openai:gpt-4.1-mini"],
+        aiService: createFakeAIService(createFakeModel()),
+        historyService,
+        // No-op emitter: this test only inspects the prompt the model
+        // receives. We intentionally drop chat events here so any
+        // accidental dependence on emit ordering would surface as a test
+        // failure rather than a silent pass.
+        emitChatEvent: () => undefined,
+      });
+
+      expect(result.success).toBe(true);
+      expect(capturedPrompt).toBeDefined();
+      // Regular turn included, side-question artifacts excluded.
+      expect(capturedPrompt).toContain("regular question");
+      expect(capturedPrompt).toContain("regular answer");
+      expect(capturedPrompt).not.toContain("old side q");
+      expect(capturedPrompt).not.toContain("old side a");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("keeps recent main-chat context even after many prior /btw rows", async () => {
+    const { historyService, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "ws-btw-many-prior";
+      await historyService.appendToHistory(
+        workspaceId,
+        createMuxMessage("main-context", "user", "main context should survive")
+      );
+      for (let i = 0; i < 120; i++) {
+        await historyService.appendToHistory(
+          workspaceId,
+          createMuxMessage(`prior-side-q-${i}`, "user", `prior side question ${i}`, {
+            muxMetadata: {
+              type: "side-question",
+              rawCommand: `/btw prior side question ${i}`,
+              commandPrefix: "/btw",
+            },
+          })
+        );
+        await historyService.appendToHistory(
+          workspaceId,
+          createMuxMessage(`prior-side-a-${i}`, "assistant", `prior side answer ${i}`, {
+            muxMetadata: { type: "side-question-answer" },
+          })
+        );
+      }
+
+      let capturedPrompt: string | undefined;
+      spyOn(aiSdk, "streamText").mockImplementation(((opts: unknown) => {
+        const messages = (opts as { messages: Array<{ content: string }> }).messages;
+        capturedPrompt = messages[0]?.content;
+        return fakeTextStream(["ok"]);
+      }) as unknown as typeof aiSdk.streamText);
+
+      const result = await askSideQuestion({
+        workspaceId,
+        question: "what context is active?",
+        candidates: ["openai:gpt-4.1-mini"],
+        aiService: createFakeAIService(createFakeModel()),
+        historyService,
+        emitChatEvent: () => undefined,
+      });
+
+      expect(result.success).toBe(true);
+      expect(capturedPrompt).toContain("main context should survive");
+      expect(capturedPrompt).not.toContain("prior side answer 119");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("honors durable context resets when building the transcript", async () => {
+    const { historyService, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "ws-btw-context-reset";
+      await historyService.appendToHistory(
+        workspaceId,
+        createMuxMessage("pre-reset-user", "user", "forget this old topic")
+      );
+      await historyService.appendToHistory(
+        workspaceId,
+        createMuxMessage("reset-boundary", "assistant", "", {
+          contextBoundaryKind: CONTEXT_BOUNDARY_KINDS.RESET,
+        })
+      );
+      await historyService.appendToHistory(
+        workspaceId,
+        createMuxMessage("post-reset-user", "user", "keep this new topic")
+      );
+
+      let capturedPrompt: string | undefined;
+      spyOn(aiSdk, "streamText").mockImplementation(((opts: unknown) => {
+        const messages = (opts as { messages: Array<{ content: string }> }).messages;
+        capturedPrompt = messages[0]?.content;
+        return fakeTextStream(["ok"]);
+      }) as unknown as typeof aiSdk.streamText);
+
+      const result = await askSideQuestion({
+        workspaceId,
+        question: "what context is active?",
+        candidates: ["openai:gpt-4.1-mini"],
+        aiService: createFakeAIService(createFakeModel()),
+        historyService,
+        emitChatEvent: () => undefined,
+      });
+
+      expect(result.success).toBe(true);
+      expect(capturedPrompt).toBeDefined();
+      expect(capturedPrompt).not.toContain("forget this old topic");
+      expect(capturedPrompt).toContain("keep this new topic");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("includes the latest visible main-agent stream text in the transcript", async () => {
+    const { historyService, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "ws-btw-live-stream-context";
+      await historyService.appendToHistory(
+        workspaceId,
+        createMuxMessage("u1", "user", "what are you drafting?")
+      );
+
+      const liveHistoryMessage = createMuxMessage("live-main-answer", "assistant", "", {
+        model: "openai:gpt-live",
+      });
+      await historyService.appendToHistory(workspaceId, liveHistoryMessage);
+      const liveHistorySequence = liveHistoryMessage.metadata?.historySequence;
+      if (typeof liveHistorySequence !== "number") {
+        throw new Error("expected history sequence for live main answer");
+      }
+      const partialWrite = await historyService.writePartial(workspaceId, {
+        ...liveHistoryMessage,
+        metadata: {
+          ...liveHistoryMessage.metadata,
+          historySequence: liveHistorySequence,
+        },
+        parts: [{ type: "text", text: "older flushed partial text" }],
+      });
+      expect(partialWrite.success).toBe(true);
+
+      const liveParts = [{ type: "text" as const, text: "latest visible streamed sentence" }];
+      const appendToHistory = historyService.appendToHistory.bind(historyService);
+      let appendCount = 0;
+      spyOn(historyService, "appendToHistory").mockImplementation(
+        async (appendWorkspaceId, message) => {
+          const appendResult = await appendToHistory(appendWorkspaceId, message);
+          appendCount += 1;
+          if (appendCount === 1) {
+            liveParts[0].text = "future text after /btw fired";
+          }
+          return appendResult;
+        }
+      );
+
+      let capturedPrompt: string | undefined;
+      spyOn(aiSdk, "streamText").mockImplementation(((opts: unknown) => {
+        const messages = (opts as { messages: Array<{ content: string }> }).messages;
+        capturedPrompt = messages[0]?.content;
+        return fakeTextStream(["ok"]);
+      }) as unknown as typeof aiSdk.streamText);
+
+      const result = await askSideQuestion({
+        workspaceId,
+        question: "what did you just say?",
+        candidates: ["openai:gpt-4.1-mini"],
+        aiService: createFakeAIService(createFakeModel(), {
+          messageId: "live-main-answer",
+          model: "openai:gpt-live",
+          historySequence: liveHistorySequence,
+          startTime: 1_000,
+          parts: liveParts,
+          toolCompletionTimestamps: new Map(),
+        }),
+        historyService,
+        emitChatEvent: () => undefined,
+      });
+
+      expect(result.success).toBe(true);
+      expect(capturedPrompt).toContain("what are you drafting?");
+      expect(capturedPrompt).toContain("latest visible streamed sentence");
+      expect(capturedPrompt).not.toContain("older flushed partial text");
+      expect(capturedPrompt).not.toContain("future text after /btw fired");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("rejects empty questions before contacting the model", async () => {
+    const { historyService, cleanup } = await createTestHistoryService();
+    try {
+      const streamTextSpy = spyOn(aiSdk, "streamText");
+      const result = await askSideQuestion({
+        workspaceId: "ws-btw-empty-q",
+        question: "   ",
+        candidates: ["openai:gpt-4.1-mini"],
+        aiService: createFakeAIService(createFakeModel()),
+        historyService,
+        // No-op emitter — empty-question path short-circuits before any
+        // chat event would be emitted, so we don't capture them.
+        emitChatEvent: () => undefined,
+      });
+
+      expect(result.success).toBe(false);
+      // Defense-in-depth: an empty question must not burn an API call or
+      // pollute history with an empty user row.
+      expect(streamTextSpy).not.toHaveBeenCalled();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("returns an error, deletes the placeholder, and closes the stream when the model produces empty text", async () => {
+    const { historyService, cleanup } = await createTestHistoryService();
+    try {
+      spyOn(aiSdk, "streamText").mockImplementation((() =>
+        fakeTextStream(["   "])) as unknown as typeof aiSdk.streamText);
+
+      const emitted: WorkspaceChatMessage[] = [];
+      const result = await askSideQuestion({
+        workspaceId: "ws-btw-empty",
+        question: "anything?",
+        candidates: ["openai:gpt-4.1-mini"],
+        aiService: createFakeAIService(createFakeModel()),
+        historyService,
+        emitChatEvent: (_wsId, m) => emitted.push(m),
+      });
+
+      expect(result.success).toBe(false);
+
+      // The placeholder must be removed so a retry on the next candidate
+      // doesn't render alongside the empty failed row. We assert both
+      // sides of the contract: the live `delete` chat event AND the
+      // chat.jsonl removal.
+      const deleteEvents = emitted.filter((m) => m.type === "delete");
+      expect(deleteEvents).toHaveLength(1);
+
+      const after = await historyService.getLastMessages("ws-btw-empty", 10);
+      expect(after.success).toBe(true);
+      if (!after.success) return;
+      // Only the /btw user question survives; the empty assistant
+      // placeholder was wiped.
+      const assistantRows = after.data.filter((m) => m.role === "assistant");
+      expect(assistantRows).toHaveLength(0);
+
+      // Stream-end must fire before delete while the side-answer row still
+      // exists, so WorkspaceStore can recognize the /btw terminal event and
+      // drain any buffered main-agent deltas. Delete then removes the failed
+      // row from the live transcript.
+      const eventTypes = emitted.map((m) => m.type);
+      const streamEndIndex = eventTypes.indexOf("stream-end");
+      const deleteIndex = eventTypes.indexOf("delete");
+      expect(streamEndIndex).toBeGreaterThanOrEqual(0);
+      expect(deleteIndex).toBeGreaterThan(streamEndIndex);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("tries through the first fallback model when configured candidates fail creation", async () => {
+    const { historyService, cleanup } = await createTestHistoryService();
+    try {
+      spyOn(aiSdk, "streamText").mockImplementation((() =>
+        fakeTextStream(["fallback answer"])) as unknown as typeof aiSdk.streamText);
+
+      const fallbackModel = NAME_GEN_PREFERRED_MODELS[0];
+      const staleCandidates = ["stale-live", "stale-chat", "stale-agent"];
+      const createModel = mock((modelString: string) => {
+        if (modelString === fallbackModel) {
+          return Promise.resolve(Ok(createFakeModel(modelString)));
+        }
+        return Promise.resolve(Err({ type: "model_not_available", modelId: modelString } as const));
+      });
+
+      const result = await askSideQuestion({
+        workspaceId: "ws-btw-fallback-after-stale-models",
+        question: "can you still answer?",
+        candidates: [...staleCandidates, fallbackModel],
+        aiService: {
+          createModel,
+          getStreamInfo: () => undefined,
+        } as unknown as AIService,
+        historyService,
+        emitChatEvent: () => undefined,
+      });
+
+      expect(result.success).toBe(true);
+      expect(createModel.mock.calls.map((call) => call[0])).toEqual([
+        ...staleCandidates,
+        fallbackModel,
+      ]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("on retry: discards the failed candidate's partial output before the next candidate streams", async () => {
+    // Regression coverage for the Codex P2 review thread:
+    //   When candidate A streams some text and then throws, the next
+    //   candidate B must NOT render alongside A's partial output. The
+    //   service deletes A's placeholder + emits a `delete` chat event so
+    //   both the live aggregator and chat.jsonl forget A entirely.
+    const { historyService, cleanup } = await createTestHistoryService();
+    try {
+      let callCount = 0;
+      spyOn(aiSdk, "streamText").mockImplementation((() => {
+        callCount += 1;
+        if (callCount === 1) {
+          // Candidate A: stream a chunk, then explode mid-stream.
+          async function* failingGen() {
+            await Promise.resolve();
+            yield "partial-A-";
+            throw new Error("candidate A fell over");
+          }
+          return { textStream: failingGen() } as unknown as ReturnType<typeof aiSdk.streamText>;
+        }
+        // Candidate B: clean stream.
+        return fakeTextStream(["final-B"]);
+      }) as unknown as typeof aiSdk.streamText);
+
+      const emitted: WorkspaceChatMessage[] = [];
+      const workspaceId = "ws-btw-retry";
+      const result = await askSideQuestion({
+        workspaceId,
+        question: "explain something",
+        candidates: ["bad-candidate", "good-candidate"],
+        aiService: createFakeAIService(createFakeModel()),
+        historyService,
+        emitChatEvent: (_wsId, m) => emitted.push(m),
+      });
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      // Only the second candidate's text survives.
+      expect(result.data.answer).toBe("final-B");
+
+      // The failed candidate must close its side stream before deleting the
+      // placeholder, and delete BEFORE the second candidate's stream-start.
+      // Closing first drains WorkspaceStore's side-question buffer; deleting
+      // before the retry ensures the live aggregator drops partial-A before
+      // any new content arrives.
+      const eventTypes = emitted.map((m) => m.type);
+      const firstStreamEnd = eventTypes.indexOf("stream-end");
+      const firstDelete = eventTypes.indexOf("delete");
+      const lastStreamStart = eventTypes.lastIndexOf("stream-start");
+      expect(firstStreamEnd).toBeGreaterThanOrEqual(0);
+      expect(firstDelete).toBeGreaterThan(firstStreamEnd);
+      expect(firstDelete).toBeLessThan(lastStreamStart);
+
+      // chat.jsonl ends with exactly one user row + one assistant answer
+      // (the failed placeholder was deleted; the second candidate's
+      // placeholder was updated in place to hold "final-B").
+      const after = await historyService.getLastMessages(workspaceId, 10);
+      expect(after.success).toBe(true);
+      if (!after.success) return;
+      const assistantRows = after.data.filter((m) => m.role === "assistant");
+      expect(assistantRows).toHaveLength(1);
+      const textPart = assistantRows[0].parts.find(
+        (p): p is Extract<typeof p, { type: "text" }> => p.type === "text"
+      );
+      expect(textPart?.text).toBe("final-B");
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/node/services/sideQuestionService.ts
+++ b/src/node/services/sideQuestionService.ts
@@ -1,0 +1,664 @@
+/**
+ * Side-question (/btw) service: a forked, single-turn, read-only side branch
+ * of the current conversation.
+ *
+ * /btw lets a user ask a quick question against the current chat. Because
+ * the answer is useful to keep visible across reloads (so the user can scroll
+ * back and re-read it), we PERSIST both the user question and the assistant
+ * answer to chat.jsonl, with metadata that marks them as side-question
+ * artifacts. The renderer uses that metadata to style them distinctly, and
+ * request builders filter the side branch out of future main-agent context.
+ *
+ * What still makes /btw "forked":
+ *   - No tools — the model is told tools are unavailable AND the schema-side
+ *     `tools` argument is omitted from the streamText call.
+ *   - Single turn — we do not loop the agent; one streamText call, one
+ *     committed assistant message.
+ *   - No workspace busy state — we do not flip the workspace's "streaming"
+ *     flag, so the user can still send normal messages, fire another /btw,
+ *     or interrupt the main agent while a side question is answering.
+ *
+ * Streaming:
+ *   - We emit `stream-start` / `stream-delta` / `stream-end` chat events
+ *     directly via `session.emitChatEvent` (bypassing StreamManager). The
+ *     frontend's existing StreamingMessageAggregator handles these events
+ *     identically to a real agent stream, which means TypewriterMarkdown,
+ *     smooth-text animation, and stream replay all work out of the box.
+ */
+
+import { streamText, type ModelMessage } from "ai";
+import type { AIService } from "./aiService";
+import type { HistoryService } from "./historyService";
+import { log } from "./log";
+import { mapModelCreationError, mapNameGenerationError } from "./workspaceTitleGenerator";
+import { runLanguageModelCleanup } from "./languageModelCleanup";
+import type { Result } from "@/common/types/result";
+import { Ok, Err } from "@/common/types/result";
+import type { NameGenerationError } from "@/common/types/errors";
+import { createMuxMessage, type MuxMessage } from "@/common/types/message";
+import { sliceMessagesForProviderFromLatestContextBoundary } from "@/common/utils/messages/compactionBoundary";
+import {
+  SIDE_QUESTION_ANSWER_METADATA_TYPE,
+  SIDE_QUESTION_METADATA_TYPE,
+  filterSideQuestionMessages,
+} from "@/common/utils/messages/sideQuestion";
+import type { WorkspaceChatMessage } from "@/common/orpc/types";
+import { createUserMessageId, createAssistantMessageId } from "@/node/services/utils/messageIds";
+import { NAME_GEN_PREFERRED_MODELS } from "@/common/constants/nameGeneration";
+
+/** Max non-/btw messages from the active context window we keep in a /btw transcript. */
+const SIDE_QUESTION_MAX_TRAILING_MESSAGES = 200;
+/** Max characters per message we keep in the transcript (per role). */
+const SIDE_QUESTION_MAX_MESSAGE_CHARS = 8_000;
+/** Overall character budget for the transcript (defensive against runaway). */
+const SIDE_QUESTION_MAX_TRANSCRIPT_CHARS = 120_000;
+
+export interface AskSideQuestionOptions {
+  workspaceId: string;
+  question: string;
+  candidates: readonly string[];
+  aiService: AIService;
+  historyService: HistoryService;
+  /** Optional pre-await snapshot captured by callers that must avoid async race windows. */
+  liveStreamSnapshot?: ReturnType<AIService["getStreamInfo"]>;
+  /**
+   * Emit a chat event so the frontend's `onChat` subscription sees the new
+   * message / stream lifecycle. Provided by WorkspaceService so this module
+   * stays free of any direct dependency on AgentSession.
+   */
+  emitChatEvent: (workspaceId: string, message: WorkspaceChatMessage) => void;
+}
+
+export interface AskSideQuestionSuccess {
+  /** Final answer text (also persisted to history). */
+  answer: string;
+  /** Model that successfully produced the answer. */
+  modelUsed: string;
+  /** ID of the assistant message appended to history. */
+  assistantMessageId: string;
+}
+
+/**
+ * Build the model messages for a side question. Exported for testability —
+ * the wording of the reminder is the load-bearing part of the "no tools,
+ * conversation-grounded" contract.
+ */
+export function buildSideQuestionMessages(
+  question: string,
+  transcript: string
+): { system: string; messages: ModelMessage[] } {
+  const trimmedQuestion = question.trim();
+  const renderedTranscript = transcript.trim().length > 0 ? transcript : "(empty transcript)";
+
+  const system = [
+    "You are answering a quick side question about an ongoing AI coding chat.",
+    "This is a forked, single-turn branch. Your answer will be appended to the",
+    "chat as a clearly-marked side answer so the user can re-read it later,",
+    "but no follow-up turn is possible on this branch.",
+    "",
+    "Rules:",
+    "- Answer directly from the conversation context provided below.",
+    "- No tools are available on this turn. Do not pretend to call tools,",
+    "  do not emit tool-call JSON, and do not promise future actions.",
+    "- If the conversation does not contain enough information to answer,",
+    "  say so plainly instead of guessing or fabricating details.",
+    "- Keep the answer concise and use markdown when it improves clarity.",
+  ].join("\n");
+
+  const userPrompt = [
+    "Current conversation (oldest first, newest last):",
+    "<conversation>",
+    renderedTranscript,
+    "</conversation>",
+    "",
+    "<system-reminder>",
+    "The user just asked a side question (/btw). Answer directly using the",
+    "conversation above. No tools are available. This is a one-shot response;",
+    "no follow-up turn will reach you.",
+    "</system-reminder>",
+    "",
+    `Side question: ${trimmedQuestion}`,
+  ].join("\n");
+
+  return {
+    system,
+    messages: [{ role: "user", content: userPrompt }],
+  };
+}
+
+/**
+ * Run a /btw side question. Persists the user question, streams the answer,
+ * and persists the final assistant message. The orpc caller only needs to
+ * know success/failure — actual content flows to the renderer through the
+ * existing `onChat` subscription.
+ */
+export function snapshotSideQuestionLiveStream(
+  liveStream: ReturnType<AIService["getStreamInfo"]>
+): ReturnType<AIService["getStreamInfo"]> {
+  return liveStream
+    ? {
+        ...liveStream,
+        // Freeze the visible-at-/btw part list before any awaited I/O.
+        // StreamManager mutates this array as new main-agent chunks arrive;
+        // the side-question prompt must line up with the interruption offset
+        // captured at this exact moment.
+        parts: liveStream.parts.map((part) => ({ ...part })),
+      }
+    : undefined;
+}
+
+export async function askSideQuestion(
+  opts: AskSideQuestionOptions
+): Promise<Result<AskSideQuestionSuccess, NameGenerationError>> {
+  const { workspaceId, question, candidates, aiService, historyService, emitChatEvent } = opts;
+
+  const trimmedQuestion = question.trim();
+  if (trimmedQuestion.length === 0) {
+    return Err({ type: "unknown", raw: "Side question is empty" });
+  }
+
+  if (candidates.length === 0) {
+    return Err({ type: "unknown", raw: "No model candidates available for side question" });
+  }
+
+  // ---------------------------------------------------------------------
+  // 0. Snapshot any in-flight MAIN-AGENT stream so the renderer can later
+  //    split the interrupted message into pre-aside + post-aside halves
+  //    around this /btw pair.
+  //
+  // Two structural guarantees make this safe to read synchronously:
+  //  - `aiService.getStreamInfo` is a sync getter over an in-memory map
+  //    (StreamManager.workspaceStreams), so no race with disk I/O.
+  //  - The /btw pipeline bypasses StreamManager entirely (no
+  //    `streamManager.startStream` call), so `getStreamInfo` can ONLY
+  //    return a main-agent stream — never a concurrent /btw. The
+  //    "side question must not interrupt itself" filter is therefore
+  //    structural rather than a runtime check.
+  //
+  // MUST run before the first `await` below: any awaited work between
+  // this read and the user-message append widens the racy window where
+  // the main agent could finish streaming (StreamingMessageAggregator
+  // would then no longer have the interruption anchor we promise).
+  // ---------------------------------------------------------------------
+  const liveStreamSnapshot =
+    opts.liveStreamSnapshot ?? snapshotSideQuestionLiveStream(aiService.getStreamInfo(workspaceId));
+  const interruption = liveStreamSnapshot
+    ? {
+        interruptedMessageId: liveStreamSnapshot.messageId,
+        // Text length anchors the split across text parts; part index keeps
+        // non-text parts (reasoning/tool/file) that were already visible at
+        // the same text offset on the pre-aside side after reload.
+        interruptedTextLength: liveStreamSnapshot.parts.reduce(
+          (sum, p) => (p.type === "text" ? sum + p.text.length : sum),
+          0
+        ),
+        interruptedPartIndex: liveStreamSnapshot.parts.length,
+        interruptedHistorySequence: liveStreamSnapshot.historySequence,
+      }
+    : undefined;
+
+  // ---------------------------------------------------------------------
+  // 1. Persist + emit the user's /btw message FIRST so the question shows
+  //    up in the chat immediately. Even if the model call fails, the user
+  //    can see what they asked.
+  // ---------------------------------------------------------------------
+  const rawCommand = `/btw ${trimmedQuestion}`;
+  const userMessage: MuxMessage = createMuxMessage(createUserMessageId(), "user", trimmedQuestion, {
+    timestamp: Date.now(),
+    muxMetadata: {
+      type: SIDE_QUESTION_METADATA_TYPE,
+      rawCommand,
+      // `commandPrefix` is rendered as a small badge before the message
+      // body — reuses the existing `/compact` / `/{skillName}` mechanism.
+      commandPrefix: "/btw",
+      // Spread the interruption snapshot only when a main-agent stream
+      // was actually in flight — otherwise leave the fields off so the
+      // renderer treats this as a "normal" side branch at the end of the
+      // transcript.
+      ...interruption,
+    },
+  });
+
+  const appendUserResult = await historyService.appendToHistory(workspaceId, userMessage);
+  if (!appendUserResult.success) {
+    return Err({ type: "unknown", raw: appendUserResult.error });
+  }
+  emitChatEvent(workspaceId, { ...userMessage, type: "message" });
+
+  // Persist first so the UI shows the side branch immediately, but do not
+  // read the current /btw row back into model context: the transcript helper
+  // filters side-question rows and buildSideQuestionMessages adds the current
+  // question explicitly below the transcript.
+  const transcript = await buildSideQuestionTranscript(
+    workspaceId,
+    historyService,
+    liveStreamSnapshot
+  );
+  const { system, messages } = buildSideQuestionMessages(trimmedQuestion, transcript);
+
+  const fallbackModels = new Set<string>(NAME_GEN_PREFERRED_MODELS);
+  const firstFallbackCandidateIndex = candidates.findIndex((candidate) =>
+    fallbackModels.has(candidate)
+  );
+  // Try the first few workspace-preferred candidates, but keep going far enough
+  // to exercise at least one known fallback. This keeps /btw usable when stale
+  // live/chat/agent model IDs sit ahead of the fallback list.
+  const maxAttempts = Math.min(
+    candidates.length,
+    Math.max(3, firstFallbackCandidateIndex >= 0 ? firstFallbackCandidateIndex + 1 : 0)
+  );
+  let lastError: NameGenerationError | null = null;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const modelString = candidates[attempt];
+
+    const modelResult = await aiService.createModel(modelString, undefined, {
+      agentInitiated: false,
+    });
+    if (!modelResult.success) {
+      lastError = mapModelCreationError(modelResult.error, modelString);
+      log.debug(`Side question: skipping ${modelString} (${modelResult.error.type})`);
+      continue;
+    }
+
+    // Each attempt uses a fresh assistant message id so a retried candidate
+    // never reuses a partially-streamed stale id.
+    const assistantMessageId = createAssistantMessageId();
+    const streamStartedAt = Date.now();
+    let accumulatedText = "";
+
+    // Append a placeholder assistant row FIRST so historyService allocates
+    // a historySequence we can attach to stream-start. The frontend's
+    // StreamingMessageAggregator keys streams by both messageId and
+    // historySequence, so this number needs to be real and stable.
+    const placeholderAssistant: MuxMessage = {
+      id: assistantMessageId,
+      role: "assistant",
+      metadata: {
+        timestamp: streamStartedAt,
+        model: modelString,
+        muxMetadata: {
+          type: SIDE_QUESTION_ANSWER_METADATA_TYPE,
+          questionMessageId: userMessage.id,
+        },
+      },
+      parts: [],
+    };
+    const placeholderResult = await historyService.appendToHistory(
+      workspaceId,
+      placeholderAssistant
+    );
+    if (!placeholderResult.success) {
+      lastError = { type: "unknown", raw: placeholderResult.error };
+      log.warn("Side question: failed to append assistant placeholder", {
+        workspaceId,
+        error: placeholderResult.error,
+      });
+      runLanguageModelCleanup(modelResult.data);
+      continue;
+    }
+    const assistantHistorySequence = placeholderAssistant.metadata?.historySequence;
+    if (typeof assistantHistorySequence !== "number") {
+      lastError = {
+        type: "unknown",
+        raw: "appendToHistory did not assign a historySequence to the side-question placeholder",
+      };
+      runLanguageModelCleanup(modelResult.data);
+      continue;
+    }
+
+    // Surface the placeholder to the live chat stream so the frontend
+    // aggregator sees the side-question-answer's muxMetadata BEFORE
+    // stream-start fires. Without this, the aggregator's handleStreamStart
+    // would create a fresh assistant message from the stream-start event
+    // payload (which doesn't carry muxMetadata) and the marker that drives
+    // side-answer styling plus WorkspaceStore's main-agent buffering layer
+    // would be lost for the entire streaming window. On reconnect/replay
+    // the placeholder is re-emitted from chat.jsonl, so the marker survives
+    // there too.
+    emitChatEvent(workspaceId, { ...placeholderAssistant, type: "message" });
+
+    // -------------------------------------------------------------------
+    // 2. Open the streaming envelope so the frontend can render the
+    //    assistant slot immediately and animate text as it arrives.
+    // -------------------------------------------------------------------
+    emitChatEvent(workspaceId, {
+      type: "stream-start",
+      workspaceId,
+      messageId: assistantMessageId,
+      model: modelString,
+      historySequence: assistantHistorySequence,
+      startTime: streamStartedAt,
+    });
+
+    try {
+      try {
+        // streamText (not generateText): we want token-by-token UX.
+        // No `tools` key: tools are denied client-side AND prompt-side per the
+        // /btw spec.
+        const stream = streamText({
+          model: modelResult.data,
+          system,
+          messages,
+        });
+
+        for await (const chunk of stream.textStream) {
+          if (chunk.length === 0) continue;
+          accumulatedText += chunk;
+          emitChatEvent(workspaceId, {
+            type: "stream-delta",
+            workspaceId,
+            messageId: assistantMessageId,
+            delta: chunk,
+            // Token count is best-effort — we don't tokenize per chunk here
+            // because /btw isn't billed against the main agent's token budget
+            // UI. The frontend uses this only for its live "tokens/sec" stat,
+            // which is non-critical for an ephemeral side question.
+            tokens: 0,
+            timestamp: Date.now(),
+          });
+        }
+      } catch (error) {
+        lastError = mapNameGenerationError(error, modelString);
+        log.warn("Side question failed; trying next candidate", {
+          modelString,
+          workspaceId,
+          error: lastError,
+        });
+        // Tear down the failed candidate's partial output so the retry on the
+        // next candidate doesn't leave the failed turn's accumulated text
+        // sitting in the chat next to the successful answer.
+        //
+        // Live aggregator: stream-end does NOT replace already-accumulated
+        // delta text with `data.parts` (it only merges metadata + compacts).
+        // So an empty stream-end here would still leave the partial failed
+        // text visible until a reload. A `delete` event keyed off the
+        // placeholder's historySequence removes the row entirely, which is
+        // what users actually want when the answer they were watching
+        // collapsed mid-stream.
+        //
+        // History: the placeholder row is deleted to match; without this,
+        // reloading would resurrect the partial text from chat.jsonl. The
+        // empty stream-end is emitted before delete so WorkspaceStore can
+        // identify the terminal side-answer event while the placeholder still
+        // carries side-answer metadata.
+        await deleteSideQuestionPlaceholder({
+          workspaceId,
+          assistantMessageId,
+          assistantHistorySequence,
+          modelString,
+          historyService,
+          emitChatEvent,
+        });
+        continue;
+      }
+
+      const trimmedAnswer = accumulatedText.trim();
+      if (trimmedAnswer.length === 0) {
+        lastError = { type: "unknown", raw: "Model produced an empty response" };
+        log.warn("Side question: empty response", { modelString, workspaceId });
+        // Same rationale as the catch above: an empty-response retry must
+        // remove the placeholder so the next candidate's answer doesn't
+        // render alongside a stale blank row.
+        await deleteSideQuestionPlaceholder({
+          workspaceId,
+          assistantMessageId,
+          assistantHistorySequence,
+          modelString,
+          historyService,
+          emitChatEvent,
+        });
+        continue;
+      }
+
+      // -------------------------------------------------------------------
+      // 3. Fill in the placeholder with the final answer and close the
+      //    stream. updateHistory (not appendToHistory) because the row is
+      //    already there from the placeholder step.
+      // -------------------------------------------------------------------
+      const duration = Date.now() - streamStartedAt;
+      // Narrow to a single text part. The stream-end event schema only allows
+      // reasoning/text/tool parts (no MuxFilePart) — using a concrete tuple
+      // keeps both the history write and the chat-event emit type-checked
+      // without needing a cast.
+      const finalParts = [{ type: "text" as const, text: accumulatedText }];
+      const assistantMessage: MuxMessage = {
+        id: assistantMessageId,
+        role: "assistant",
+        metadata: {
+          historySequence: assistantHistorySequence,
+          timestamp: streamStartedAt,
+          duration,
+          model: modelString,
+          muxMetadata: {
+            type: SIDE_QUESTION_ANSWER_METADATA_TYPE,
+            questionMessageId: userMessage.id,
+          },
+        },
+        parts: finalParts,
+      };
+
+      const updateResult = await historyService.updateHistory(workspaceId, assistantMessage);
+      if (!updateResult.success) {
+        // History write failed but the model produced an answer. Emit
+        // stream-end first so the live UI still shows what the user saw, then
+        // return Err so callers can toast that the durable /btw answer was not
+        // persisted and would be lost on reload.
+        log.warn("Side question: failed to update placeholder with final answer", {
+          workspaceId,
+          error: updateResult.error,
+        });
+      }
+
+      emitChatEvent(workspaceId, {
+        type: "stream-end",
+        workspaceId,
+        messageId: assistantMessageId,
+        metadata: {
+          model: modelString,
+          duration,
+          timestamp: streamStartedAt,
+          historySequence: assistantHistorySequence,
+          muxMetadata: {
+            type: SIDE_QUESTION_ANSWER_METADATA_TYPE,
+            questionMessageId: userMessage.id,
+          },
+        },
+        parts: finalParts,
+      });
+
+      if (!updateResult.success) {
+        return Err({ type: "unknown", raw: updateResult.error });
+      }
+
+      return Ok({
+        answer: trimmedAnswer,
+        modelUsed: modelString,
+        assistantMessageId,
+      });
+    } finally {
+      runLanguageModelCleanup(modelResult.data);
+    }
+  }
+
+  return Err(
+    lastError ?? {
+      type: "configuration",
+      raw: "No working model candidates were available for side question.",
+    }
+  );
+}
+
+/**
+ * Tear down a /btw placeholder whose stream failed or produced empty text
+ * before the next candidate is tried.
+ *
+ * Closes the stream with an empty `stream-end` first so side-question
+ * terminal-event bookkeeping (including WorkspaceStore's buffered main-agent
+ * replay) unwinds while the placeholder still carries side-answer metadata.
+ * Then removes the placeholder from chat.jsonl and emits a `delete` chat
+ * event so the live aggregator drops any partial failed text.
+ *
+ * History deletion is best-effort: if the disk write fails we still emit
+ * stream-end + delete so the live UI matches user expectations (the failed
+ * text vanishes); next reload may then re-show the placeholder from
+ * chat.jsonl, which is the same outcome we used to ship anyway.
+ */
+async function deleteSideQuestionPlaceholder(opts: {
+  workspaceId: string;
+  assistantMessageId: string;
+  assistantHistorySequence: number;
+  modelString: string;
+  historyService: HistoryService;
+  emitChatEvent: (workspaceId: string, message: WorkspaceChatMessage) => void;
+}): Promise<void> {
+  const {
+    workspaceId,
+    assistantMessageId,
+    assistantHistorySequence,
+    modelString,
+    historyService,
+    emitChatEvent,
+  } = opts;
+
+  // Close the stream slot while the side-answer placeholder still exists.
+  // WorkspaceStore uses the placeholder's muxMetadata to recognize this as
+  // the side-question terminal event and drain any main-agent deltas that
+  // were buffered while the side answer was streaming. Deleting first would
+  // make the terminal event look like an unknown message and freeze the main
+  // transcript until reload.
+  emitChatEvent(workspaceId, {
+    type: "stream-end",
+    workspaceId,
+    messageId: assistantMessageId,
+    metadata: { model: modelString, historySequence: assistantHistorySequence },
+    parts: [],
+  });
+
+  const deleteResult = await historyService.deleteMessage(workspaceId, assistantMessageId);
+  if (!deleteResult.success) {
+    log.warn("Side question: failed to delete placeholder for retry", {
+      workspaceId,
+      assistantMessageId,
+      error: deleteResult.error,
+    });
+  }
+
+  emitChatEvent(workspaceId, {
+    type: "delete",
+    historySequences: [assistantHistorySequence],
+  });
+}
+
+async function buildSideQuestionTranscript(
+  workspaceId: string,
+  historyService: HistoryService,
+  liveStream: ReturnType<AIService["getStreamInfo"]>
+): Promise<string> {
+  // Read the active history window before applying the /btw cap. Prior side
+  // questions are filtered below; capping the raw tail first would let many
+  // side-question rows crowd out recent main-chat context.
+  const result = await historyService.getHistoryFromLatestBoundary(workspaceId);
+  if (!result.success) return "";
+
+  const messages: MuxMessage[] = [...result.data];
+  const partial = await historyService.readPartial(workspaceId);
+  if (partial) messages.push(partial);
+
+  // Partial files are throttled; merge the synchronous StreamManager snapshot
+  // so /btw sees the main-agent text already visible in the UI.
+  if (liveStream) {
+    const liveMessage: MuxMessage = {
+      id: liveStream.messageId,
+      role: "assistant",
+      metadata: {
+        historySequence: liveStream.historySequence,
+        model: liveStream.model,
+      },
+      parts: liveStream.parts,
+    };
+    const isLiveStreamMessage = (message: MuxMessage): boolean =>
+      message.id === liveStream.messageId ||
+      message.metadata?.historySequence === liveStream.historySequence;
+    const existingIndex = messages.findIndex(isLiveStreamMessage);
+    if (existingIndex === -1) {
+      messages.push(liveMessage);
+    } else {
+      const existing = messages[existingIndex];
+      messages[existingIndex] = {
+        ...existing,
+        metadata: {
+          ...existing.metadata,
+          historySequence: liveStream.historySequence,
+          model: existing.metadata?.model ?? liveStream.model,
+        },
+        parts: liveStream.parts,
+      };
+      // Drop older partial.json copies for the same active stream; the live
+      // snapshot above is the single source of truth for visible streamed text.
+      for (let i = messages.length - 1; i >= 0; i--) {
+        if (i !== existingIndex && isLiveStreamMessage(messages[i])) {
+          messages.splice(i, 1);
+        }
+      }
+    }
+  }
+
+  // Exclude PRIOR side-question exchanges from the transcript so /btw answers
+  // don't pollute the context the model uses to answer the current side
+  // question. Each /btw is independent — chained /btw turns would otherwise
+  // amplify their own (potentially-wrong) prior answers. Then honor the same
+  // durable context-boundary window as normal provider requests (e.g. soft
+  // clears) so /btw does not resurrect content the user removed from context.
+  const filtered = sliceMessagesForProviderFromLatestContextBoundary(
+    filterSideQuestionMessages(messages)
+  ).slice(-SIDE_QUESTION_MAX_TRAILING_MESSAGES);
+
+  const formatted = filtered.map(formatMessageForSideQuestion).filter((s) => s.length > 0);
+  if (formatted.length === 0) return "";
+
+  // Trim from the front (oldest) until we fit the char budget.
+  let drop = 0;
+  let totalChars = formatted.reduce((sum, s) => sum + s.length, 0);
+  while (totalChars > SIDE_QUESTION_MAX_TRANSCRIPT_CHARS && drop < formatted.length - 1) {
+    totalChars -= formatted[drop].length;
+    drop += 1;
+  }
+  return formatted.slice(drop).join("\n\n");
+}
+
+function extractMessageText(message: MuxMessage): string {
+  return (message.parts ?? [])
+    .filter((part): part is { type: "text"; text: string } => part.type === "text")
+    .map((part) => part.text.trim())
+    .filter((text) => text.length > 0)
+    .join("\n");
+}
+
+function summarizeToolPart(part: unknown): string | null {
+  if (typeof part !== "object" || part === null) return null;
+  const record = part as { type?: unknown; toolName?: unknown };
+  const type = typeof record.type === "string" ? record.type : null;
+  if (!type) return null;
+  const toolName =
+    typeof record.toolName === "string"
+      ? record.toolName
+      : type.startsWith("tool-")
+        ? type.slice(5)
+        : null;
+  return toolName ? `[tool ${toolName}]` : null;
+}
+
+function formatMessageForSideQuestion(message: MuxMessage): string {
+  const role = message.role === "user" ? "User" : message.role === "assistant" ? "Assistant" : null;
+  if (!role) return "";
+
+  const segments: string[] = [];
+  const text = extractMessageText(message).slice(0, SIDE_QUESTION_MAX_MESSAGE_CHARS);
+  if (text) segments.push(text);
+
+  const tools = (message.parts ?? []).map(summarizeToolPart).filter((s): s is string => s !== null);
+  if (tools.length > 0) segments.push(tools.join(" "));
+
+  return segments.length === 0 ? "" : `${role}: ${segments.join("\n")}`;
+}

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -8244,3 +8244,53 @@ describe("WorkspaceService.getGoalContinuationRuntimeState", () => {
     });
   });
 });
+
+describe("getSideQuestionModelCandidates", () => {
+  function makeServiceForSideQuestionCandidates(aiService: AIService): WorkspaceService {
+    return new WorkspaceService(
+      {} as Config,
+      {} as HistoryService,
+      aiService,
+      { on: mock(() => undefined) } as unknown as InitStateManager,
+      {} as ExtensionMetadataService,
+      {} as BackgroundProcessManager
+    );
+  }
+
+  test("prefers the live parent stream model before persisted chat settings", async () => {
+    const liveModel = "openai:gpt-live-override";
+    const configuredModel = "openai:gpt-configured";
+    const agentModel = "anthropic:claude-configured-agent";
+    const aiService = Object.assign(new EventEmitter(), {
+      getStreamInfo: mock(() => ({
+        messageId: "main-message",
+        model: liveModel,
+        historySequence: 1,
+        startTime: 1_000,
+        parts: [],
+        toolCompletionTimestamps: new Map(),
+      })),
+      getWorkspaceMetadata: mock(() =>
+        Promise.resolve(
+          Ok({
+            id: "ws-side-models",
+            name: "ws-side-models",
+            projectName: "project",
+            projectPath: "/tmp/project",
+            runtimeConfig: { type: "local" },
+            aiSettings: { model: configuredModel, thinkingLevel: "off" },
+            aiSettingsByAgent: { exec: { model: agentModel, thinkingLevel: "off" } },
+          } as WorkspaceMetadata)
+        )
+      ),
+    }) as unknown as AIService;
+
+    const service = makeServiceForSideQuestionCandidates(aiService);
+    const candidates = await service.getSideQuestionModelCandidates("ws-side-models");
+
+    expect(candidates[0]).toBe(liveModel);
+    expect(candidates).toContain(configuredModel);
+    expect(candidates).toContain(agentModel);
+    expect(candidates.filter((candidate) => candidate === liveModel)).toHaveLength(1);
+  });
+});

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -70,6 +70,10 @@ import {
   ADDITIONAL_SYSTEM_CONTEXT_FILENAME,
 } from "@/node/services/additionalSystemContext";
 import { generateWorkspaceIdentity } from "@/node/services/workspaceTitleGenerator";
+import {
+  askSideQuestion,
+  snapshotSideQuestionLiveStream,
+} from "@/node/services/sideQuestionService";
 import { NAME_GEN_PREFERRED_MODELS } from "@/common/constants/nameGeneration";
 import type { DevcontainerRuntime } from "@/node/runtime/DevcontainerRuntime";
 import { WorktreeRuntime } from "@/node/runtime/WorktreeRuntime";
@@ -4063,6 +4067,107 @@ export class WorkspaceService extends EventEmitter {
     }
 
     return candidates;
+  }
+
+  /**
+   * Build the candidate-model list for a /btw side question.
+   *
+   * Unlike title generation, /btw should prefer the live parent stream's
+   * actual model first (important for one-shot overrides like /opus), then the
+   * workspace's configured chat models. The title-gen list is appended as a
+   * last-resort fallback so a misconfigured chat model can still produce an
+   * answer.
+   */
+  public async getSideQuestionModelCandidates(
+    workspaceId: string,
+    liveStreamModelOverride?: string
+  ): Promise<string[]> {
+    const candidates: string[] = [];
+    const liveStreamModel =
+      liveStreamModelOverride ?? this.aiService.getStreamInfo(workspaceId)?.model;
+    if (liveStreamModel) {
+      candidates.push(liveStreamModel);
+    }
+
+    const metadataResult = await this.aiService.getWorkspaceMetadata(workspaceId);
+    if (metadataResult.success) {
+      const preferred = [
+        metadataResult.data.aiSettings?.model,
+        ...Object.values(metadataResult.data.aiSettingsByAgent ?? {}).map((s) => s.model),
+      ];
+      for (const model of preferred) {
+        if (model && !candidates.includes(model)) {
+          candidates.push(model);
+        }
+      }
+    }
+
+    // Fallback: small-model preference list (same set used by title/status
+    // generation). Keeps /btw working when no chat model has been chosen yet
+    // (e.g. brand-new workspace before the first send).
+    for (const model of NAME_GEN_PREFERRED_MODELS) {
+      if (!candidates.includes(model)) {
+        candidates.push(model);
+      }
+    }
+    return candidates;
+  }
+
+  /**
+   * Run a /btw side question over the workspace's current conversation.
+   *
+   * Both the user question and the assistant answer are persisted to
+   * chat.jsonl with side-question metadata, and stream lifecycle events
+   * are emitted through the standard chat-event channel so the renderer
+   * animates the response with TypewriterMarkdown.
+   *
+   * The workspace's "streaming" flag is intentionally NOT toggled here —
+   * /btw runs alongside the main agent without claiming busy state, so the
+   * user can fire a side question while the agent is mid-turn (or vice
+   * versa) without interfering with either.
+   */
+  public async askSideQuestion(
+    workspaceId: string,
+    question: string
+  ): Promise<{ success: true; modelUsed: string } | { success: false; error: string }> {
+    // Match other workspace ops: refuse on missing/in-flight workspaces so
+    // the user gets a clear error instead of a confusing model failure
+    // downstream.
+    const workspaceConfig = this.config.findWorkspace(workspaceId);
+    if (!workspaceConfig) {
+      return { success: false, error: "Workspace not found." };
+    }
+
+    const liveStreamSnapshot = snapshotSideQuestionLiveStream(
+      this.aiService.getStreamInfo(workspaceId)
+    );
+    const candidates = await this.getSideQuestionModelCandidates(
+      workspaceId,
+      liveStreamSnapshot?.model
+    );
+    const result = await askSideQuestion({
+      workspaceId,
+      question,
+      candidates,
+      aiService: this.aiService,
+      historyService: this.historyService,
+      liveStreamSnapshot,
+      // Re-use the session's existing chat-event emitter; this is the same
+      // path agentSession / streamManager use, so the frontend's onChat
+      // subscription handles side-question events identically to a normal
+      // agent stream (TypewriterMarkdown, smooth-text, replay all "just
+      // work").
+      emitChatEvent: (wsId, message) => {
+        this.sessions.get(wsId)?.emitChatEvent(message);
+      },
+    });
+    if (!result.success) {
+      return {
+        success: false,
+        error: result.error.raw ?? `Side question failed: ${result.error.type}`,
+      };
+    }
+    return { success: true, modelUsed: result.data.modelUsed };
   }
 
   private async maybeRunPendingAutoTitleFromMessage(


### PR DESCRIPTION
## Summary

Adds the `/btw` slash command — a forked, single-turn, read-only side question over the current conversation. Tools are denied on both the prompt and schema sides; the question and answer are persisted to chat history with distinct metadata and stream through the existing `TypewriterMarkdown` path so the side branch reads as one offset Q/A cycle in the transcript.

`/btw` is modeled on Claude Code 2.1.73's command of the same name: a quick "by the way, what was that file you mentioned?" question that runs against the current transcript without invoking tools and without re-anchoring the main agent loop.

## Implementation

**Backend (`src/node/services/sideQuestionService.ts`)**

- Builds a side-question transcript from history (latest context boundary forward), merges any in-flight live-stream snapshot, filters prior `/btw` rows so the model never grounds on its own earlier answers, and feeds it to `streamText` with **no `tools` argument**.
- Persists a placeholder assistant row first (so `historyService` allocates a real `historySequence`), emits it as a `message` chat event with `side-question-answer` muxMetadata (including `questionMessageId`), then drives `stream-start`/`stream-delta`/`stream-end` through `session.emitChatEvent`. The frontend aggregator handles these identically to a regular agent stream — `TypewriterMarkdown`, smooth-text animation, and replay all just work.
- Tries the live-parent-stream model, then the configured chat/agent model, then `NAME_GEN_PREFERRED_MODELS`. `maxAttempts` reaches at least the first preferred fallback so three stale configured candidates can't disable the feature.
- `aiService` filters side-question rows out of provider context via `filterSideQuestionMessages`, so `/btw` never pollutes the main agent's prompt.

**Frontend rendering: inline side branch, not below**

- The `/btw` user row stamps `interruptedMessageId` + `interruptedTextLength` + `interruptedPartIndex` against whatever main-agent stream was live when it fired. `StreamingMessageAggregator.getDisplayedMessages()` pre-walks history to build an `interruptionsByInterruptedId` map and, for any interrupted main message, calls `buildInterruptedMessageDisplay()` which splits the main reply at the captured offset(s) and inserts the Q/A pair between segments. The last segment keeps the original message id so the streaming-indicator anchor and Start-Here/Fork/etc. action handlers still target the right row.
- `splitMessagePartsAtTextLengths` honors `partIndex` so non-text parts (reasoning, tool calls) that were already visible at the same text offset stay on the pre-aside side after reload — text length alone misordered them.
- Side-question user rows render with a "Side question" header and a continuous left accent stripe; side-answer rows share the stripe but skip the redundant label. Side answers expose only Copy in their action set — Start Here / Fork / Share / Show Text don't make sense for an off-main-thread message.
- `findActiveSideQuestionScrollHoldTarget` keeps the side branch in view while its answer streams and the main reply continues underneath; user wheel/touch/key/mouse and Jump-to-bottom clear the hold.

**Frontend lifecycle: `/btw` doesn't hijack main state**

- `aggregator.hasInterruptibleActiveStream()`, `getActiveStreamMessageId()`, `getActiveStreamTimingStats()`, `getCurrentModel()`, and `getCurrentThinkingLevel()` skip side-answer streams via a `getActiveMainStreamEntry()` helper — so interrupt UI, live stats, the workspace model display, and `setInterrupting()` all target the main stream when both are active.
- `handleMessage`/`handleStreamStart`/`handleStreamEnd` detect side-answer events and skip the bits that would clobber the main turn: don't clear pending main startup state, don't clear `hasQueuedFollowUp` or `backgroundHandoffCompletion`, don't fire `onResponseComplete`, and don't replace main `lastCompletedStreamStats`. Main completion is computed as final via `getActiveMainStreamEntry() === undefined`, so the main reply can finalize while a side answer is still streaming.
- `WorkspaceStore.handleChatMessage` uses `getBufferedActiveStreamStart(... isSideQuestionAnswerMessageId)` so side-only replay never looks like an active main stream, and the `stream-end` side-effect path skips `collapsePinnedTodoOnStreamStop` for side answers (Codex caught the pinned-TODO collapse regression).

**Slash command (`/btw <question>`)**

- `processSlashCommand` fire-and-forgets the `workspace.sideQuestion` RPC, clears input + attachments + attached reviews immediately. On RPC failure it restores the raw command text **only** if the command is still current (`asyncCommandToken`/`isAsyncCommandCurrent`) and the input hasn't been replaced by a newer draft.
- `placeholderTips.ts` gains one entry — `Try /btw <question> to ask a side question without nudging the agent` — surfacing the new command through main's existing wall-clock tip carousel. (The carousel itself already lives on main; this PR just adds a tip.)

## Validation

- `make static-check` ✅
- Targeted tests: `aggregator-side`, `chat-commands-side`, `scroll-hold`, `workspace-store-side` — all green.
- Notable coverage: `StreamingMessageAggregator.sideQuestion.test.ts` (split ordering with same-offset non-text parts, pairing by `questionMessageId`, main-stream-aware active stream selection, main `isFinal` while side answer streams), `WorkspaceStore.test.ts` (replayed side streams don't set interrupt state, pinned TODO panel doesn't collapse on side-answer end), `sideQuestionScrollHold.test.ts` (standalone /btw with only its answer below stays bottom-locked, hold realigns while the answer grows), `chatCommands.test.ts` (RPC failure restores `/btw …` but never over a newer draft, stale failures suppressed), `sideQuestionService.test.ts` (no tools passed to `streamText`, prior side questions filtered, fallback model selection after stale candidates).

## Risks

`/btw` deliberately bypasses the main `streamMessage` pipeline — it emits chat events through `session.emitChatEvent` directly so the workspace's main-stream lifecycle, idle-compaction recency, and post-compaction attachments all skip it. That's the intentional product behavior, but it's worth a careful eye on any `StreamingMessageAggregator` interaction that assumes one active stream per workspace.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `high` • Cost: `$291.60`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=high costs=291.60 -->
