### PR TITLE
🤖 perf: speed up local static-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,13 +352,15 @@ lint-zizmor: ## Run zizmor security analysis on GitHub Actions workflows
 SHELL_SRC_FILES := $(shell find . -not \( -path '*/.git/*' -o -path './node_modules/*' -o -path './mobile/node_modules/*' -o -path './build/*' -o -path './dist/*' -o -path './release/*' -o -path './benchmarks/terminal_bench/.leaderboard_cache/*' \) -type f -name '*.sh' 2>/dev/null)
 
 lint-shellcheck: ## Run shellcheck on shell scripts
-	shellcheck --external-sources $(SHELL_SRC_FILES)
+	@echo "Running shellcheck on $(words $(SHELL_SRC_FILES)) shell scripts..."
+	@shellcheck --external-sources $(SHELL_SRC_FILES)
 
 # Dockerfiles to lint (excludes node_modules, build artifacts, .git)
 DOCKERFILES := $(shell find . -not \( -path '*/.git/*' -o -path './node_modules/*' -o -path './mobile/node_modules/*' -o -path './build/*' -o -path './dist/*' -o -path './release/*' -o -path './benchmarks/terminal_bench/.leaderboard_cache/*' \) -type f -name 'Dockerfile' 2>/dev/null)
 
 lint-hadolint: ## Run hadolint on Dockerfiles
-	hadolint $(DOCKERFILES)
+	@echo "Running hadolint on $(words $(DOCKERFILES)) Dockerfiles..."
+	@hadolint $(DOCKERFILES)
 
 pin-actions: ## Pin GitHub Actions to SHA hashes (requires GH_TOKEN or gh CLI)
 	./scripts/pin-actions.sh .github/workflows/*.yml .github/actions/*/action.yml

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -23,9 +23,48 @@ if [ -n "$PNG_FILES" ]; then
 fi
 
 ESLINT_PATTERN='src/**/*.{ts,tsx}'
-# Keep cold lint responsive without letting ESLint's auto concurrency over-commit memory.
-# CI can raise this via MUX_ESLINT_CONCURRENCY=4 on larger runners.
-ESLINT_CONCURRENCY="${MUX_ESLINT_CONCURRENCY:-2}"
+
+get_cpu_count() {
+  local cpu_count=""
+
+  if command -v getconf >/dev/null 2>&1; then
+    cpu_count="$(getconf _NPROCESSORS_ONLN 2>/dev/null || true)"
+  fi
+
+  if [ -z "$cpu_count" ] && command -v nproc >/dev/null 2>&1; then
+    cpu_count="$(nproc 2>/dev/null || true)"
+  fi
+
+  if [ -z "$cpu_count" ] && command -v sysctl >/dev/null 2>&1; then
+    cpu_count="$(sysctl -n hw.ncpu 2>/dev/null || true)"
+  fi
+
+  if [[ "$cpu_count" =~ ^[0-9]+$ ]] && [ "$cpu_count" -gt 0 ]; then
+    echo "$cpu_count"
+  else
+    echo 2
+  fi
+}
+
+get_default_eslint_concurrency() {
+  local cpu_count
+  local concurrency
+
+  cpu_count="$(get_cpu_count)"
+  concurrency=$(((cpu_count + 1) / 2))
+
+  # User rationale: local static-check should scale up on agent/desktop machines
+  # without letting ESLint's auto concurrency spawn one worker per core.
+  if [ "$concurrency" -lt 2 ]; then
+    concurrency=2
+  elif [ "$concurrency" -gt 8 ]; then
+    concurrency=8
+  fi
+
+  echo "$concurrency"
+}
+
+ESLINT_CONCURRENCY="${MUX_ESLINT_CONCURRENCY:-$(get_default_eslint_concurrency)}"
 ESLINT_ARGS=(
   --concurrency "$ESLINT_CONCURRENCY"
   --cache


### PR DESCRIPTION
Summary
- Speeds up the local static-check path by choosing an ESLint concurrency level from available CPU count, capped to avoid ESLint auto-concurrency overcommit.
- Keeps `MUX_ESLINT_CONCURRENCY` as an explicit override for CI or local tuning.
- Shortens shellcheck/hadolint output so static-check logs stay readable.

Background
- The local static-check workflow was bottlenecked by ESLint running at a fixed concurrency of 2 on larger agent/dev machines.
- Baseline measurement in this workspace was 85s before optimization; after the change, the same `make --no-print-directory static-check` path completed in 10s.

Implementation
- `scripts/lint.sh` now derives the default ESLint concurrency from `getconf`, `nproc`, or `sysctl`, clamps it between 2 and 8, and leaves the environment override unchanged.
- `Makefile` now prints concise shellcheck/hadolint summaries instead of echoing long full command lines.

Validation
- `shellcheck scripts/lint.sh`
- `MUX_ESLINT_CONCURRENCY=4 ./scripts/lint.sh` override check
- `make --no-print-directory static-check`

Risks
- Low. The validation coverage is unchanged; this only changes default local ESLint parallelism and log verbosity. Machines that need a different concurrency can continue using `MUX_ESLINT_CONCURRENCY`.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `off` • Cost: `$4.67`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=off costs=4.67 -->
