### PR TITLE
🤖 fix: gate slash command visibility by experiment

### DIFF
--- a/src/browser/components/CommandPalette/CommandPalette.tsx
+++ b/src/browser/components/CommandPalette/CommandPalette.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useSta
 import { Command } from "cmdk";
 import { useCommandRegistry } from "@/browser/contexts/CommandRegistryContext";
 import { useAPI } from "@/browser/contexts/API";
+import { useExperimentValue } from "@/browser/hooks/useExperiments";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
 import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
 import type { CommandAction } from "@/browser/contexts/CommandRegistryContext";
@@ -12,8 +13,10 @@ import {
   matchesKeybind,
 } from "@/browser/utils/ui/keybinds";
 import { stopKeyboardPropagation } from "@/browser/utils/events";
+import { resolveSlashCommandExperimentValue } from "@/browser/utils/slashCommands/experimentVisibility";
 import { getSlashCommandSuggestions } from "@/browser/utils/slashCommands/suggestions";
 import { CUSTOM_EVENTS, createCustomEvent } from "@/common/constants/events";
+import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { getDisableWorkspaceAgentsKey, GLOBAL_SCOPE_ID } from "@/common/constants/storage";
 import { filterCommandsByPrefix } from "@/browser/utils/commandPaletteFiltering";
 import { rankByPaletteQuery } from "@/browser/utils/commandPaletteRanking";
@@ -57,6 +60,10 @@ interface PaletteGroup {
 export const CommandPalette: React.FC<CommandPaletteProps> = ({ getSlashContext }) => {
   const { api } = useAPI();
 
+  const goalsExperimentEnabled = useExperimentValue(EXPERIMENT_IDS.GOALS);
+  const workspaceHeartbeatsExperimentEnabled = useExperimentValue(
+    EXPERIMENT_IDS.WORKSPACE_HEARTBEATS
+  );
   const slashContext = getSlashContext?.();
   const slashWorkspaceId = slashContext?.workspaceId;
 
@@ -284,6 +291,11 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ getSlashContext 
       const suggestions = getSlashCommandSuggestions(q, {
         agentSkills,
         variant: ctx.workspaceId ? "workspace" : "creation",
+        isExperimentEnabled: (experimentId) =>
+          resolveSlashCommandExperimentValue(experimentId, {
+            goals: goalsExperimentEnabled,
+            workspaceHeartbeats: workspaceHeartbeatsExperimentEnabled,
+          }),
       });
       const section = "Slash Commands";
       const groups: PaletteGroup[] = [
@@ -350,7 +362,15 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ getSlashContext 
       groups,
       emptyText: filtered.length ? undefined : "No results",
     } satisfies { groups: PaletteGroup[]; emptyText: string | undefined };
-  }, [query, rawActions, recentIndex, getSlashContext, agentSkills]);
+  }, [
+    query,
+    rawActions,
+    recentIndex,
+    getSlashContext,
+    agentSkills,
+    goalsExperimentEnabled,
+    workspaceHeartbeatsExperimentEnabled,
+  ]);
 
   useEffect(() => {
     if (!activePrompt) return;

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -29,6 +29,7 @@ import {
 import { usePolicy } from "@/browser/contexts/PolicyContext";
 import { useAPI } from "@/browser/contexts/API";
 import { useThinkingLevel } from "@/browser/hooks/useThinkingLevel";
+import { useExperimentValue } from "@/browser/hooks/useExperiments";
 import { normalizeSelectedModel } from "@/common/utils/ai/models";
 import {
   useAdditionalSystemContextHydrated,
@@ -62,6 +63,7 @@ import {
 } from "@/browser/utils/chatCommands";
 import { Button } from "@/browser/components/Button/Button";
 import { CUSTOM_EVENTS } from "@/common/constants/events";
+import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { findAtMentionAtCursor } from "@/common/utils/atMentions";
 import { findInlineSkillReferenceAtCursor } from "@/browser/utils/agentSkills/inlineSkillReferences";
 import {
@@ -75,6 +77,7 @@ import {
   getSlashCommandSuggestions,
   type SlashSuggestion,
 } from "@/browser/utils/slashCommands/suggestions";
+import { resolveSlashCommandExperimentValue } from "@/browser/utils/slashCommands/experimentVisibility";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/browser/components/Tooltip/Tooltip";
 import { AgentModePicker } from "@/browser/components/AgentModePicker/AgentModePicker";
 import { ContextUsageIndicatorButton } from "@/browser/components/ContextUsageIndicatorButton/ContextUsageIndicatorButton";
@@ -224,6 +227,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const creationProject =
     variant === "creation" ? userProjects.get(creationParentProjectPath) : undefined;
   const [thinkingLevel] = useThinkingLevel();
+  const goalsExperimentEnabled = useExperimentValue(EXPERIMENT_IDS.GOALS);
+  const workspaceHeartbeatsExperimentEnabled = useExperimentValue(
+    EXPERIMENT_IDS.WORKSPACE_HEARTBEATS
+  );
   const atMentionProjectPath = variant === "creation" ? props.projectPath : null;
   const workspaceId = variant === "workspace" ? props.workspaceId : null;
 
@@ -1387,14 +1394,32 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     const suggestions = getSlashCommandSuggestions(input, {
       agentSkills: agentSkillDescriptors,
       variant,
+      isExperimentEnabled: (experimentId) =>
+        resolveSlashCommandExperimentValue(experimentId, {
+          goals: goalsExperimentEnabled,
+          workspaceHeartbeats: workspaceHeartbeatsExperimentEnabled,
+        }),
     });
     setCommandSuggestions((prev) => replaceSuggestions(prev, suggestions));
     setShowCommandSuggestions(suggestions.length > 0);
-  }, [input, agentSkillDescriptors, variant]);
+  }, [
+    input,
+    agentSkillDescriptors,
+    variant,
+    goalsExperimentEnabled,
+    workspaceHeartbeatsExperimentEnabled,
+  ]);
 
   // Derive ghost hint for slash-command argument syntax.
   // Show only when suggestions are hidden and the input is exactly "/command " with no args yet.
-  const commandGhostHint = getCommandGhostHint(input, showCommandSuggestions, variant);
+  const commandGhostHint = getCommandGhostHint(input, showCommandSuggestions, {
+    variant,
+    isExperimentEnabled: (experimentId) =>
+      resolveSlashCommandExperimentValue(experimentId, {
+        goals: goalsExperimentEnabled,
+        workspaceHeartbeats: workspaceHeartbeatsExperimentEnabled,
+      }),
+  });
 
   // Load agent skills for suggestions
   useEffect(() => {

--- a/src/browser/utils/slashCommands/experimentVisibility.ts
+++ b/src/browser/utils/slashCommands/experimentVisibility.ts
@@ -1,0 +1,20 @@
+import { EXPERIMENT_IDS, type ExperimentId } from "@/common/constants/experiments";
+
+export interface SlashCommandExperimentSnapshot {
+  goals: boolean;
+  workspaceHeartbeats: boolean;
+}
+
+export function resolveSlashCommandExperimentValue(
+  experimentId: ExperimentId,
+  snapshot: SlashCommandExperimentSnapshot
+): boolean | undefined {
+  switch (experimentId) {
+    case EXPERIMENT_IDS.GOALS:
+      return snapshot.goals;
+    case EXPERIMENT_IDS.WORKSPACE_HEARTBEATS:
+      return snapshot.workspaceHeartbeats;
+    default:
+      return undefined;
+  }
+}

--- a/src/browser/utils/slashCommands/ghostHint.test.ts
+++ b/src/browser/utils/slashCommands/ghostHint.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { EXPERIMENT_IDS, type ExperimentId } from "@/common/constants/experiments";
 import { SLASH_COMMAND_HINTS } from "@/common/constants/slashCommandHints";
 import { getCommandGhostHint } from "./registry";
 
@@ -37,6 +38,24 @@ describe("getCommandGhostHint", () => {
 
   it("returns null for workspace-only commands in creation mode", () => {
     expect(getCommandGhostHint("/compact ", false, "creation")).toBeNull();
+  });
+
+  it("returns null for experiment-gated command hints when disabled", () => {
+    expect(
+      getCommandGhostHint("/goal ", false, {
+        isExperimentEnabled: () => false,
+      })
+    ).toBeNull();
+  });
+
+  it("returns hints for experiment-gated commands when enabled", () => {
+    const enabledExperiments = new Set<ExperimentId>([EXPERIMENT_IDS.GOALS]);
+
+    expect(
+      getCommandGhostHint("/goal ", false, {
+        isExperimentEnabled: (experimentId) => enabledExperiments.has(experimentId),
+      })
+    ).toBe(SLASH_COMMAND_HINTS.goal);
   });
 
   it("still returns hints for creation-available commands in creation mode", () => {

--- a/src/browser/utils/slashCommands/registry.ts
+++ b/src/browser/utils/slashCommands/registry.ts
@@ -8,13 +8,14 @@ import type {
   SlashSuggestion,
   SuggestionDefinition,
   SlashSuggestionContext,
+  SlashCommandVisibilityContext,
 } from "./types";
 import minimist from "minimist";
-import { EXPERIMENT_IDS, type ExperimentId } from "@/common/constants/experiments";
+import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { MODEL_ABBREVIATIONS } from "@/common/constants/knownModels";
 import { SLASH_COMMAND_HINTS } from "@/common/constants/slashCommandHints";
 import { assert } from "@/common/utils/assert";
-import { isExperimentEnabled } from "@/browser/hooks/useExperiments";
+import { isExperimentEnabled as readExperimentEnabled } from "@/browser/hooks/useExperiments";
 import { normalizeModelInput } from "@/browser/utils/models/normalizeModelInput";
 import { parseGoalBudgetInputCents } from "@/common/utils/goals/budgetParser";
 import { HEARTBEAT_MAX_INTERVAL_MS, HEARTBEAT_MIN_INTERVAL_MS } from "@/constants/heartbeat";
@@ -418,6 +419,7 @@ const idleCommandDefinition: SlashCommandDefinition = {
 
 const heartbeatCommandDefinition: SlashCommandDefinition = {
   key: "heartbeat",
+  experimentGate: EXPERIMENT_IDS.WORKSPACE_HEARTBEATS,
   description: `Configure workspace heartbeats. Usage: ${HEARTBEAT_USAGE}`,
   inputHint: SLASH_COMMAND_HINTS.heartbeat,
   appendSpace: false,
@@ -528,6 +530,7 @@ const SIMPLE_GOAL_LIFECYCLE_TYPES: Record<string, SimpleGoalLifecycleType> = {
 
 const goalCommandDefinition: SlashCommandDefinition = {
   key: "goal",
+  experimentGate: EXPERIMENT_IDS.GOALS,
   description: `Create, view, or clear a workspace goal. Usage: ${GOAL_USAGE}`,
   inputHint: SLASH_COMMAND_HINTS.goal,
   appendSpace: false,
@@ -710,22 +713,44 @@ export const SLASH_COMMAND_DEFINITION_MAP = new Map(
 
 const COMMAND_GHOST_HINT_PATTERN = /^\/(\S+) +$/;
 
+function normalizeVisibilityContext(
+  contextOrVariant?: SlashCommandVisibilityContext | SlashSuggestionContext["variant"]
+): SlashCommandVisibilityContext {
+  return typeof contextOrVariant === "string"
+    ? { variant: contextOrVariant }
+    : (contextOrVariant ?? {});
+}
+
 /**
- * Slash commands gated behind a single experiment flag — their ghost-hint is
- * suppressed when the experiment is off. Hiding on a thrown experiment check
- * (e.g., test environments where the hook is unavailable) is the safer
- * default. Adding a new gated command is a one-line entry here instead of a
- * duplicated try/catch block in `getCommandGhostHint`.
+ * Single visibility gate for every slash-command discovery surface. Keeping the
+ * experiment on the command definition prevents one surface from forgetting to
+ * hide a gated command when another surface already does.
  */
-const COMMAND_GHOST_HINT_EXPERIMENT_GATES: Readonly<Record<string, ExperimentId>> = {
-  goal: EXPERIMENT_IDS.GOALS,
-  heartbeat: EXPERIMENT_IDS.WORKSPACE_HEARTBEATS,
-};
+export function isSlashCommandVisible(
+  definition: SlashCommandDefinition,
+  context: SlashCommandVisibilityContext = {}
+): boolean {
+  if (context.variant === "creation" && WORKSPACE_ONLY_COMMAND_KEYS.has(definition.key)) {
+    return false;
+  }
+
+  if (definition.experimentGate == null) {
+    return true;
+  }
+
+  try {
+    const resolveExperiment = context.isExperimentEnabled ?? readExperimentEnabled;
+    return resolveExperiment(definition.experimentGate) === true;
+  } catch {
+    // Experiment check unavailable (e.g., test environments without window) — hide by default.
+    return false;
+  }
+}
 
 export function getCommandGhostHint(
   input: string,
   showCommandSuggestions: boolean,
-  variant?: SlashSuggestionContext["variant"]
+  contextOrVariant?: SlashCommandVisibilityContext | SlashSuggestionContext["variant"]
 ): string | null {
   if (showCommandSuggestions) {
     return null;
@@ -737,21 +762,13 @@ export function getCommandGhostHint(
   }
 
   const commandKey = match[1];
-  if (variant === "creation" && WORKSPACE_ONLY_COMMAND_KEYS.has(commandKey)) {
+  const definition = SLASH_COMMAND_DEFINITION_MAP.get(commandKey);
+  if (
+    !definition ||
+    !isSlashCommandVisible(definition, normalizeVisibilityContext(contextOrVariant))
+  ) {
     return null;
   }
 
-  const gateExperimentId = COMMAND_GHOST_HINT_EXPERIMENT_GATES[commandKey];
-  if (gateExperimentId != null) {
-    try {
-      if (!isExperimentEnabled(gateExperimentId)) {
-        return null;
-      }
-    } catch {
-      // Experiment check unavailable (e.g., test environment) — hide by default.
-      return null;
-    }
-  }
-
-  return SLASH_COMMAND_DEFINITION_MAP.get(commandKey)?.inputHint ?? null;
+  return definition.inputHint ?? null;
 }

--- a/src/browser/utils/slashCommands/suggestions.test.ts
+++ b/src/browser/utils/slashCommands/suggestions.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "bun:test";
+import { EXPERIMENT_IDS, type ExperimentId } from "@/common/constants/experiments";
 import { getSlashCommandSuggestions } from "./suggestions";
 
 describe("getSlashCommandSuggestions", () => {
@@ -19,6 +20,30 @@ describe("getSlashCommandSuggestions", () => {
     const suggestions = getSlashCommandSuggestions("/plan ", { variant: "creation" });
     expect(suggestions).toEqual([]);
   });
+  it("hides experiment-gated commands when their experiments are disabled", () => {
+    const suggestions = getSlashCommandSuggestions("/", {
+      isExperimentEnabled: () => false,
+    });
+    const labels = suggestions.map((s) => s.display);
+
+    expect(labels).not.toContain("/goal");
+    expect(labels).not.toContain("/heartbeat");
+  });
+
+  it("shows experiment-gated commands when their experiments are enabled", () => {
+    const enabledExperiments = new Set<ExperimentId>([
+      EXPERIMENT_IDS.GOALS,
+      EXPERIMENT_IDS.WORKSPACE_HEARTBEATS,
+    ]);
+    const suggestions = getSlashCommandSuggestions("/", {
+      isExperimentEnabled: (experimentId) => enabledExperiments.has(experimentId),
+    });
+    const labels = suggestions.map((s) => s.display);
+
+    expect(labels).toContain("/goal");
+    expect(labels).toContain("/heartbeat");
+  });
+
   it("suggests top level commands when starting with slash", () => {
     const suggestions = getSlashCommandSuggestions("/");
     const labels = suggestions.map((s) => s.display);

--- a/src/browser/utils/slashCommands/suggestions.ts
+++ b/src/browser/utils/slashCommands/suggestions.ts
@@ -4,11 +4,9 @@
 
 import { matchesNameBySegmentPrefix } from "@/browser/utils/suggestionMatching";
 import { MODEL_ABBREVIATIONS } from "@/common/constants/knownModels";
-import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { formatModelDisplayName } from "@/common/utils/ai/modelDisplay";
-import { isExperimentEnabled } from "@/browser/hooks/useExperiments";
 import { getSlashCommandDefinitions } from "./parser";
-import { SLASH_COMMAND_DEFINITION_MAP } from "./registry";
+import { isSlashCommandVisible, SLASH_COMMAND_DEFINITION_MAP } from "./registry";
 import type {
   SlashCommandDefinition,
   SlashSuggestion,
@@ -17,8 +15,6 @@ import type {
 } from "./types";
 
 export type { SlashSuggestion } from "./types";
-
-import { WORKSPACE_ONLY_COMMAND_KEYS } from "@/constants/slashCommands";
 
 const COMMAND_DEFINITIONS = getSlashCommandDefinitions();
 
@@ -40,8 +36,6 @@ function buildTopLevelSuggestions(
   partial: string,
   context: SlashSuggestionContext
 ): SlashSuggestion[] {
-  const isCreation = context.variant === "creation";
-
   const commandSuggestions = filterAndMapSuggestions(
     COMMAND_DEFINITIONS,
     partial,
@@ -55,24 +49,7 @@ function buildTopLevelSuggestions(
         replacement,
       };
     },
-    (definition) => {
-      if (definition.key === "heartbeat") {
-        try {
-          if (!isExperimentEnabled(EXPERIMENT_IDS.WORKSPACE_HEARTBEATS)) {
-            return false;
-          }
-        } catch {
-          // Experiment check unavailable (e.g., test environment) — hide by default.
-          return false;
-        }
-      }
-
-      if (isCreation && WORKSPACE_ONLY_COMMAND_KEYS.has(definition.key)) {
-        return false;
-      }
-
-      return true;
-    }
+    (definition) => isSlashCommandVisible(definition, context)
   );
 
   const formatScopeLabel = (scope: string): string => {
@@ -129,21 +106,27 @@ function buildTopLevelSuggestions(
 function buildSubcommandSuggestions(
   commandDefinition: SlashCommandDefinition,
   partial: string,
-  prefixTokens: string[]
+  prefixTokens: string[],
+  context: SlashSuggestionContext
 ): SlashSuggestion[] {
   const subcommands = commandDefinition.children ?? [];
 
-  return filterAndMapSuggestions(subcommands, partial, (definition) => {
-    const appendSpace = definition.appendSpace ?? true;
-    const replacementTokens = [...prefixTokens, definition.key];
-    const replacementBase = `/${replacementTokens.join(" ")}`;
-    return {
-      id: `command:${replacementTokens.join(":")}`,
-      display: definition.key,
-      description: definition.description,
-      replacement: `${replacementBase}${appendSpace ? " " : ""}`,
-    };
-  });
+  return filterAndMapSuggestions(
+    subcommands,
+    partial,
+    (definition) => {
+      const appendSpace = definition.appendSpace ?? true;
+      const replacementTokens = [...prefixTokens, definition.key];
+      const replacementBase = `/${replacementTokens.join(" ")}`;
+      return {
+        id: `command:${replacementTokens.join(":")}`,
+        display: definition.key,
+        description: definition.description,
+        replacement: `${replacementBase}${appendSpace ? " " : ""}`,
+      };
+    },
+    (definition) => isSlashCommandVisible(definition, context)
+  );
 }
 
 export function getSlashCommandSuggestions(
@@ -180,8 +163,7 @@ export function getSlashCommandSuggestions(
     return [];
   }
 
-  // In creation mode, don't show subcommand suggestions for workspace-only commands
-  if (context.variant === "creation" && WORKSPACE_ONLY_COMMAND_KEYS.has(rootKey)) {
+  if (!isSlashCommandVisible(rootDefinition, context)) {
     return [];
   }
 
@@ -194,6 +176,9 @@ export function getSlashCommandSuggestions(
 
     if (!nextDefinition) {
       break;
+    }
+    if (!isSlashCommandVisible(nextDefinition, context)) {
+      return [];
     }
 
     definitionPath.push(nextDefinition);
@@ -223,7 +208,12 @@ export function getSlashCommandSuggestions(
 
     if (definitionForSuggestions && (definitionForSuggestions.children ?? []).length > 0) {
       const prefixTokens = completedTokens.slice(0, stage);
-      return buildSubcommandSuggestions(definitionForSuggestions, partialToken, prefixTokens);
+      return buildSubcommandSuggestions(
+        definitionForSuggestions,
+        partialToken,
+        prefixTokens,
+        context
+      );
     }
   }
 

--- a/src/browser/utils/slashCommands/types.ts
+++ b/src/browser/utils/slashCommands/types.ts
@@ -9,6 +9,7 @@
  * for new commands.
  */
 
+import type { ExperimentId } from "@/common/constants/experiments";
 import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
 import type { ParsedThinkingInput } from "@/common/types/thinking";
 
@@ -57,11 +58,23 @@ export interface SuggestionsHandlerArgs {
 
 export type SuggestionsHandler = (args: SuggestionsHandlerArgs) => SlashSuggestion[] | null;
 
+export interface SlashCommandVisibilityContext {
+  /** Variant determines which commands are available */
+  variant?: "workspace" | "creation";
+  /**
+   * Optional resolver for experiment state. Tests and React callers can inject
+   * hook-derived values instead of reading from localStorage directly.
+   */
+  isExperimentEnabled?: (experimentId: ExperimentId) => boolean | undefined;
+}
+
 export interface SlashCommandDefinition {
   key: string;
   description: string;
   inputHint?: string;
   appendSpace?: boolean;
+  /** Required experiment for visibility in suggestions, palette results, and ghost hints. */
+  experimentGate?: ExperimentId;
   handler?: SlashCommandHandler;
   children?: readonly SlashCommandDefinition[];
   suggestions?: SuggestionsHandler;
@@ -84,10 +97,8 @@ export interface SlashSuggestion {
   replacement: string;
 }
 
-export interface SlashSuggestionContext {
+export interface SlashSuggestionContext extends SlashCommandVisibilityContext {
   agentSkills?: AgentSkillDescriptor[];
-  /** Variant determines which commands are available */
-  variant?: "workspace" | "creation";
 }
 
 export interface SuggestionDefinition {


### PR DESCRIPTION
Summary
- Centralizes slash-command visibility so commands with experiment gates are hidden consistently from suggestions and ghost hints.
- Gates `/goal` behind the Goals experiment and `/heartbeat` behind Workspace Heartbeats.
- Preserves remotely enabled experiment assignments by passing hook-resolved experiment values from React discovery surfaces.
- Adds coverage for both disabled and enabled experiment-gated command visibility.

Background
`/goal` could appear in command discovery even when its experiment was disabled. The visibility rules now live on the command definition so future gated commands have one place to declare their experiment requirement.

Implementation
- Added `experimentGate` to `SlashCommandDefinition`.
- Added `isSlashCommandVisible()` as the shared visibility predicate for workspace/creation and experiment gates.
- Routed slash suggestions, subcommand suggestions, and ghost hints through that shared predicate.
- Added a small experiment visibility resolver used by ChatInput and CommandPalette so discovery respects the same remote/local experiment state as the rest of the UI.

Validation
- `bun test src/browser/utils/slashCommands/suggestions.test.ts src/browser/utils/slashCommands/ghostHint.test.ts`
- `bun test src/browser/utils/slashCommands`
- `make typecheck`
- `make lint`
- `make static-check`
- `git diff --check`

Risks
Low. The change is scoped to slash-command discovery/ghost-hint visibility and keeps command parsing/execution behavior unchanged; existing execution gates remain in place.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$9.78`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=9.78 -->
