### PR TITLE
🤖 fix: show mid-stream goals in panel

### DIFF
--- a/src/browser/features/RightSidebar/GoalTab.test.tsx
+++ b/src/browser/features/RightSidebar/GoalTab.test.tsx
@@ -96,6 +96,22 @@ describe("GoalTab", () => {
     expect(getByText("3 / 10")).toBeTruthy();
   });
 
+  test("renders pending goals read-only until they are saved", () => {
+    const { queryByLabelText } = render(
+      <GoalTab
+        goal={goal({ pendingPersistence: true, budgetCents: 500, turnCap: 10 })}
+        onSetStatus={mock()}
+        onClear={mock()}
+      />
+    );
+
+    expect(queryByLabelText("Pause goal")).toBeNull();
+    expect(queryByLabelText("Mark goal complete")).toBeNull();
+    expect(queryByLabelText("Clear goal")).toBeNull();
+    expect(queryByLabelText("Edit goal budget")).toBeNull();
+    expect(queryByLabelText("Edit goal turn cap")).toBeNull();
+  });
+
   test("edits budget inline and restores focus", async () => {
     const onUpdateBudget = mock(() => Promise.resolve(undefined));
     const { getByLabelText, getByText } = render(

--- a/src/browser/features/RightSidebar/GoalTab.tsx
+++ b/src/browser/features/RightSidebar/GoalTab.tsx
@@ -1,6 +1,6 @@
 import { Target } from "lucide-react";
 import { useEffect, useRef, useState, type KeyboardEvent } from "react";
-import type { GoalSnapshot, GoalStatus } from "@/common/types/goal";
+import { isGoalPendingPersistence, type GoalSnapshot, type GoalStatus } from "@/common/types/goal";
 import { formatGoalCents } from "@/common/utils/goals/budgetPricing";
 import { parseGoalBudgetInputCents } from "@/common/utils/goals/budgetParser";
 // Import shared formatters / status labels from goalToolUtils so the GoalTab
@@ -125,7 +125,12 @@ export function GoalTab(props: GoalTabProps) {
       return;
     }
     lastCompleteInputRequestRef.current = request;
-    if (request > 0 && props.goal && props.goal.status !== "complete") {
+    if (
+      request > 0 &&
+      props.goal &&
+      props.goal.status !== "complete" &&
+      !isGoalPendingPersistence(props.goal)
+    ) {
       openSummaryInput(
         document.activeElement instanceof HTMLElement ? document.activeElement : null
       );
@@ -141,9 +146,12 @@ export function GoalTab(props: GoalTabProps) {
     );
   }
 
-  const canPause = props.goal.status === "active";
-  const canResume = props.goal.status === "paused";
-  const canComplete = props.goal.status === "active" || props.goal.status === "budget_limited";
+  const isPendingPersistence = isGoalPendingPersistence(props.goal);
+  const canEdit = !isPendingPersistence;
+  const canPause = canEdit && props.goal.status === "active";
+  const canResume = canEdit && props.goal.status === "paused";
+  const canComplete =
+    canEdit && (props.goal.status === "active" || props.goal.status === "budget_limited");
 
   const setStatus = async (
     status: Exclude<GoalStatus, "budget_limited">,
@@ -231,6 +239,13 @@ export function GoalTab(props: GoalTabProps) {
         </h2>
       </header>
 
+      {isPendingPersistence && (
+        <p className="border-border-light bg-surface-secondary text-muted rounded-md border p-3 text-sm leading-5">
+          This goal is queued while the current stream finishes. It will become editable once it is
+          saved.
+        </p>
+      )}
+
       {props.goal.status === "complete" && props.goal.completionSummary && (
         <section
           className="border-border-light bg-surface-secondary rounded-md border p-3"
@@ -254,14 +269,16 @@ export function GoalTab(props: GoalTabProps) {
                 ? "No budget"
                 : formatGoalCents(props.goal.budgetCents)}
             </span>
-            <button
-              type="button"
-              className="text-muted hover:text-foreground text-xs underline"
-              aria-label="Edit goal budget"
-              onClick={(event) => openBudgetEditor(event.currentTarget)}
-            >
-              Edit
-            </button>
+            {canEdit && (
+              <button
+                type="button"
+                className="text-muted hover:text-foreground text-xs underline"
+                aria-label="Edit goal budget"
+                onClick={(event) => openBudgetEditor(event.currentTarget)}
+              >
+                Edit
+              </button>
+            )}
           </dd>
         </div>
         <div className="bg-surface-secondary rounded-md p-3">
@@ -280,14 +297,16 @@ export function GoalTab(props: GoalTabProps) {
                 ? String(props.goal.turnsUsed)
                 : `${props.goal.turnsUsed} / ${props.goal.turnCap}`}
             </span>
-            <button
-              type="button"
-              className="text-muted hover:text-foreground text-xs underline"
-              aria-label="Edit goal turn cap"
-              onClick={(event) => openTurnCapEditor(event.currentTarget)}
-            >
-              Edit
-            </button>
+            {canEdit && (
+              <button
+                type="button"
+                className="text-muted hover:text-foreground text-xs underline"
+                aria-label="Edit goal turn cap"
+                onClick={(event) => openTurnCapEditor(event.currentTarget)}
+              >
+                Edit
+              </button>
+            )}
           </dd>
         </div>
         <div className="bg-surface-secondary rounded-md p-3">
@@ -356,46 +375,48 @@ export function GoalTab(props: GoalTabProps) {
         </div>
       )}
 
-      <div className="flex flex-wrap gap-2">
-        {canPause && (
+      {canEdit && (
+        <div className="flex flex-wrap gap-2">
+          {canPause && (
+            <button
+              type="button"
+              className="border-border-light bg-surface-secondary text-foreground hover:bg-surface-tertiary rounded-md border px-3 py-1.5 text-sm"
+              aria-label="Pause goal"
+              onClick={() => void setStatus("paused")}
+            >
+              Pause
+            </button>
+          )}
+          {canResume && (
+            <button
+              type="button"
+              className="border-border-light bg-surface-secondary text-foreground hover:bg-surface-tertiary rounded-md border px-3 py-1.5 text-sm"
+              aria-label="Resume goal"
+              onClick={() => void setStatus("active")}
+            >
+              Resume
+            </button>
+          )}
+          {canComplete && (
+            <button
+              type="button"
+              className="border-border-light bg-surface-secondary text-foreground hover:bg-surface-tertiary rounded-md border px-3 py-1.5 text-sm"
+              aria-label="Mark goal complete"
+              onClick={(event) => openSummaryInput(event.currentTarget)}
+            >
+              Mark complete
+            </button>
+          )}
           <button
             type="button"
             className="border-border-light bg-surface-secondary text-foreground hover:bg-surface-tertiary rounded-md border px-3 py-1.5 text-sm"
-            aria-label="Pause goal"
-            onClick={() => void setStatus("paused")}
+            aria-label="Clear goal"
+            onClick={() => void clearGoal()}
           >
-            Pause
+            Clear
           </button>
-        )}
-        {canResume && (
-          <button
-            type="button"
-            className="border-border-light bg-surface-secondary text-foreground hover:bg-surface-tertiary rounded-md border px-3 py-1.5 text-sm"
-            aria-label="Resume goal"
-            onClick={() => void setStatus("active")}
-          >
-            Resume
-          </button>
-        )}
-        {canComplete && (
-          <button
-            type="button"
-            className="border-border-light bg-surface-secondary text-foreground hover:bg-surface-tertiary rounded-md border px-3 py-1.5 text-sm"
-            aria-label="Mark goal complete"
-            onClick={(event) => openSummaryInput(event.currentTarget)}
-          >
-            Mark complete
-          </button>
-        )}
-        <button
-          type="button"
-          className="border-border-light bg-surface-secondary text-foreground hover:bg-surface-tertiary rounded-md border px-3 py-1.5 text-sm"
-          aria-label="Clear goal"
-          onClick={() => void clearGoal()}
-        >
-          Clear
-        </button>
-      </div>
+        </div>
+      )}
 
       {isSummaryInputOpen && (
         <div

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -2605,7 +2605,8 @@ describe("WorkspaceStore", () => {
     it("tracks active goals across workspace activity snapshots", async () => {
       const makeSnapshot = (
         workspaceId: string,
-        status: "active" | "paused"
+        status: "active" | "paused",
+        options: { pendingPersistence?: boolean } = {}
       ): WorkspaceActivitySnapshot => ({
         recency: 1_000,
         streaming: false,
@@ -2620,6 +2621,7 @@ describe("WorkspaceStore", () => {
           turnsUsed: 0,
           turnCap: null,
           startedAtMs: 1_000,
+          ...(options.pendingPersistence === true ? { pendingPersistence: true } : {}),
         },
       });
       mockActivityList.mockResolvedValue({
@@ -2627,6 +2629,7 @@ describe("WorkspaceStore", () => {
         "2": makeSnapshot("2", "active"),
         "3": makeSnapshot("3", "active"),
         "4": makeSnapshot("4", "active"),
+        pending: makeSnapshot("6", "active", { pendingPersistence: true }),
         paused: makeSnapshot("5", "paused"),
       });
       recreateStore();
@@ -2634,6 +2637,55 @@ describe("WorkspaceStore", () => {
       await tick(0);
 
       expect(store.getActiveGoalCount()).toBe(4);
+    });
+
+    it("merges transient goal patches without replaying stale activity fields", () => {
+      const workspaceId = "transient-goal-patch";
+      createAndAddWorkspace(store, workspaceId, { createdAt: new Date(0).toISOString() }, false);
+      const storeAccess = store as unknown as {
+        applyWorkspaceActivitySnapshot: (
+          workspaceId: string,
+          snapshot: WorkspaceActivitySnapshot | null
+        ) => void;
+      };
+      const persistedSnapshot: WorkspaceActivitySnapshot = {
+        recency: 2_000,
+        streaming: false,
+        lastModel: "claude-sonnet-4",
+        lastThinkingLevel: null,
+        goal: {
+          goalId: "00000000-0000-4000-8000-000000000101",
+          status: "active",
+          objective: "Persisted goal",
+          budgetCents: null,
+          costCents: 0,
+          turnsUsed: 0,
+          turnCap: null,
+          startedAtMs: 1_000,
+        },
+      };
+
+      storeAccess.applyWorkspaceActivitySnapshot(workspaceId, persistedSnapshot);
+      storeAccess.applyWorkspaceActivitySnapshot(workspaceId, {
+        ...persistedSnapshot,
+        streaming: true,
+        recency: 1_000,
+        transientGoalOnly: true,
+        goal: {
+          ...persistedSnapshot.goal!,
+          goalId: "00000000-0000-4000-8000-000000000102",
+          objective: "Queued replacement",
+          pendingPersistence: true,
+        },
+      });
+
+      const state = store.getWorkspaceState(workspaceId);
+      expect(state.canInterrupt).toBe(false);
+      expect(state.recencyTimestamp).toBe(2_000);
+      expect(state.goal).toMatchObject({
+        objective: "Queued replacement",
+        pendingPersistence: true,
+      });
     });
 
     it("uses activity snapshots for non-active workspace sidebar fields", async () => {

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -1,7 +1,7 @@
 import assert from "@/common/utils/assert";
 import type { MuxMessage, DisplayedMessage, QueuedMessage } from "@/common/types/message";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
-import type { GoalSnapshot } from "@/common/types/goal";
+import { isGoalPendingPersistence, type GoalSnapshot } from "@/common/types/goal";
 import type {
   WorkspaceActivitySnapshot,
   WorkspaceChatMessage,
@@ -2480,7 +2480,7 @@ export class WorkspaceStore {
 
   private refreshActiveGoalCount(): void {
     const nextCount = Array.from(this.workspaceActivity.values()).filter(
-      (snapshot) => snapshot.goal?.status === "active"
+      (snapshot) => snapshot.goal?.status === "active" && !isGoalPendingPersistence(snapshot.goal)
     ).length;
     if (nextCount === this.activeGoalCount) {
       return;
@@ -2495,6 +2495,12 @@ export class WorkspaceStore {
     snapshot: WorkspaceActivitySnapshot | null
   ): void {
     const previous = this.workspaceActivity.get(workspaceId) ?? null;
+
+    if (snapshot?.transientGoalOnly === true) {
+      const snapshotWithoutHint: WorkspaceActivitySnapshot = { ...snapshot };
+      delete snapshotWithoutHint.transientGoalOnly;
+      snapshot = previous ? { ...previous, goal: snapshot.goal } : snapshotWithoutHint;
+    }
 
     if (snapshot) {
       this.workspaceActivity.set(workspaceId, snapshot);
@@ -2519,7 +2525,8 @@ export class WorkspaceStore {
       previous?.goal?.costCents !== snapshot?.goal?.costCents ||
       previous?.goal?.turnsUsed !== snapshot?.goal?.turnsUsed ||
       previous?.goal?.budgetCents !== snapshot?.goal?.budgetCents ||
-      previous?.goal?.turnCap !== snapshot?.goal?.turnCap;
+      previous?.goal?.turnCap !== snapshot?.goal?.turnCap ||
+      previous?.goal?.pendingPersistence !== snapshot?.goal?.pendingPersistence;
 
     if (!changed) {
       return;

--- a/src/browser/utils/commands/sources.test.ts
+++ b/src/browser/utils/commands/sources.test.ts
@@ -546,7 +546,10 @@ test("project commands exclude system projects from options", async () => {
   expect(archiveOptions.some((option) => option.id === "/repo/system")).toBe(false);
 });
 
-const makeGoalSnapshot = (status: "active" | "paused" | "budget_limited" | "complete") => ({
+const makeGoalSnapshot = (
+  status: "active" | "paused" | "budget_limited" | "complete",
+  overrides: Partial<NonNullable<WorkspaceState["goal"]>> = {}
+) => ({
   goalId: "00000000-0000-4000-8000-000000000001",
   status,
   objective: "Ship palette parity",
@@ -555,6 +558,7 @@ const makeGoalSnapshot = (status: "active" | "paused" | "budget_limited" | "comp
   turnsUsed: 2,
   turnCap: null,
   startedAtMs: 1_700_000_000_000,
+  ...overrides,
 });
 
 const makeGoalRecord = (status: "active" | "paused" | "budget_limited" | "complete") => ({
@@ -640,6 +644,16 @@ test("goal palette commands match the Active lifecycle state", () => {
     "Goal: Pause",
     "Goal: Set objective",
   ]);
+});
+
+test("goal palette hides mutating lifecycle commands for pending goals", () => {
+  expect(
+    getVisibleGoalTitles({
+      selectedWorkspaceState: makeWorkspaceState(
+        makeGoalSnapshot("active", { pendingPersistence: true })
+      ),
+    })
+  ).toEqual(["Goal: Open panel", "Goal: Set objective"]);
 });
 
 test("goal palette commands match the Paused lifecycle state", () => {

--- a/src/browser/utils/commands/sources.ts
+++ b/src/browser/utils/commands/sources.ts
@@ -43,7 +43,7 @@ import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import type { BranchListResult } from "@/common/orpc/types";
 import type { WorkspaceState } from "@/browser/stores/WorkspaceStore";
 import type { RuntimeConfig } from "@/common/types/runtime";
-import type { GoalSetError, GoalStatus } from "@/common/types/goal";
+import { isGoalPendingPersistence, type GoalSetError, type GoalStatus } from "@/common/types/goal";
 import { getErrorMessage } from "@/common/utils/errors";
 import { parseGoalBudgetCents } from "@/browser/utils/slashCommands/registry";
 import { setGoalWithConflictRetry } from "@/browser/utils/goals/setGoalWithConflictRetry";
@@ -906,7 +906,9 @@ export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandActi
       },
     ];
 
-    if (goal?.status === "active") {
+    const isPendingGoalPersistence = isGoalPendingPersistence(goal);
+
+    if (!isPendingGoalPersistence && goal?.status === "active") {
       list.push({
         id: CommandIds.goalPause(),
         title: "Goal: Pause",
@@ -919,7 +921,7 @@ export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandActi
       });
     }
 
-    if (goal?.status === "paused") {
+    if (!isPendingGoalPersistence && goal?.status === "paused") {
       list.push({
         id: CommandIds.goalResume(),
         title: "Goal: Resume",
@@ -932,7 +934,10 @@ export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandActi
       });
     }
 
-    if (goal?.status === "active" || goal?.status === "budget_limited") {
+    if (
+      !isPendingGoalPersistence &&
+      (goal?.status === "active" || goal?.status === "budget_limited")
+    ) {
       list.push({
         id: CommandIds.goalMarkComplete(),
         title: "Goal: Mark complete",
@@ -966,8 +971,8 @@ export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandActi
     }
 
     if (goal) {
-      list.push(
-        {
+      if (!isPendingGoalPersistence) {
+        list.push({
           id: CommandIds.goalClear(),
           title: "Goal: Clear",
           section: section.goals,
@@ -976,15 +981,15 @@ export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandActi
             assert(api, "Goal palette actions require a connected backend");
             await api.workspace.clearGoal({ workspaceId });
           },
-        },
-        {
-          id: CommandIds.goalOpenPanel(),
-          title: "Goal: Open panel",
-          section: section.goals,
-          keywords: ["target", "objective", "sidebar"],
-          run: () => openGoalPanel(workspaceId),
-        }
-      );
+        });
+      }
+      list.push({
+        id: CommandIds.goalOpenPanel(),
+        title: "Goal: Open panel",
+        section: section.goals,
+        keywords: ["target", "objective", "sidebar"],
+        run: () => openGoalPanel(workspaceId),
+      });
     }
 
     return list;

--- a/src/common/orpc/schemas/goal.ts
+++ b/src/common/orpc/schemas/goal.ts
@@ -63,6 +63,7 @@ export const GoalSnapshotSchema = z.object({
   turnCap: z.number().int().positive().nullable(),
   completionSummary: z.string().optional(),
   startedAtMs: z.number().int().nonnegative(),
+  pendingPersistence: z.boolean().optional(),
 });
 
 // Discriminated union so the oRPC handler can return typed errors for the

--- a/src/common/orpc/schemas/workspace.ts
+++ b/src/common/orpc/schemas/workspace.ts
@@ -221,6 +221,10 @@ export const WorkspaceActivitySnapshotSchema = z.object({
   goal: GoalSnapshotSchema.nullable().optional().meta({
     description: "Current workspace goal snapshot for sidebar indicators and the Goal tab",
   }),
+  transientGoalOnly: z.boolean().optional().meta({
+    description:
+      "Internal frontend hint: merge only the goal field from this activity event; do not replace persisted activity fields.",
+  }),
 });
 
 export const PostCompactionStateSchema = z.object({

--- a/src/common/types/goal.ts
+++ b/src/common/types/goal.ts
@@ -12,6 +12,10 @@ export type GoalSnapshot = z.infer<typeof GoalSnapshotSchema>;
 
 export type GoalSetError = z.infer<typeof GoalSetErrorSchema>;
 
+export function isGoalPendingPersistence(goal: GoalSnapshot | null | undefined): boolean {
+  return goal?.pendingPersistence === true;
+}
+
 export function toGoalSnapshot(goal: GoalRecordV1): GoalSnapshot {
   return {
     goalId: goal.goalId,
@@ -24,4 +28,8 @@ export function toGoalSnapshot(goal: GoalRecordV1): GoalSnapshot {
     ...(goal.completionSummary != null ? { completionSummary: goal.completionSummary } : {}),
     startedAtMs: goal.createdAtMs,
   };
+}
+
+export function toPendingGoalSnapshot(goal: GoalRecordV1): GoalSnapshot {
+  return { ...toGoalSnapshot(goal), pendingPersistence: true };
 }

--- a/src/node/services/workspaceGoalService.test.ts
+++ b/src/node/services/workspaceGoalService.test.ts
@@ -19,6 +19,14 @@ import {
   waitForCondition,
 } from "./testDispatchHelpers";
 
+function captureGoalActivity(service: WorkspaceGoalService) {
+  const snapshots: Array<
+    NonNullable<Awaited<ReturnType<ExtensionMetadataService["getSnapshot"]>>>
+  > = [];
+  service.setOnActivityChange((_workspaceId, snapshot) => snapshots.push(snapshot));
+  return snapshots;
+}
+
 async function setGoalOk(
   service: WorkspaceGoalService,
   input: Parameters<WorkspaceGoalService["setGoal"]>[0]
@@ -825,6 +833,7 @@ describe("WorkspaceGoalService", () => {
       objective: "Original objective",
     });
 
+    const activityUpdates = captureGoalActivity(service);
     // Simulate a setGoal arriving mid-stream (this queues a pending
     // mutation in `pendingGoalMutations` because the workspace is streaming).
     // Override the private streaming check so setGoal hits the queueing path.
@@ -840,11 +849,20 @@ describe("WorkspaceGoalService", () => {
         expectedGoalId: created.goalId,
       });
       expect(queued.success).toBe(true);
+      expect(activityUpdates.at(-1)).toMatchObject({
+        goal: { objective: "Should be dropped after user stop", pendingPersistence: true },
+      });
+      expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({
+        goal: { goalId: created.goalId, objective: "Original objective" },
+      });
     } finally {
       serviceAccess.isWorkspaceStreaming = isStreamingOriginal;
     }
 
     await service.recordUserStoppedStream(workspaceId, created.createdAtMs + 5_000);
+    expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({
+      goal: { goalId: created.goalId, objective: "Original objective" },
+    });
 
     // applyPendingAfterStreamEnd should now be a no-op — the queued mutation
     // was discarded along with the continuation candidate.
@@ -1300,7 +1318,7 @@ describe("WorkspaceGoalService", () => {
     // setGoalImmediately, it would surface as an unhandled-rejection
     // process crash under `--unhandled-rejections=throw`. The fix wraps the
     // call in try/catch and logs+returns null so the pipeline stays alive.
-    await setGoalOk(service, { workspaceId, objective: "Original" });
+    const original = await setGoalOk(service, { workspaceId, objective: "Original" });
     await setGoalOk(service, { workspaceId, status: "paused" });
 
     // Force the streaming-branch path so the next setGoal queues a
@@ -1315,6 +1333,9 @@ describe("WorkspaceGoalService", () => {
       status: "paused",
     });
     expect(queueResult.success).toBe(true);
+    expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({
+      goal: { objective: "Original", status: "paused" },
+    });
     await extensionMetadata.setStreaming(workspaceId, false);
 
     // Without the fix, this rejection would propagate out of the async
@@ -1326,21 +1347,106 @@ describe("WorkspaceGoalService", () => {
       objective: "Original",
       status: "paused",
     });
+    expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({
+      goal: { goalId: original.goalId, objective: "Original", status: "paused" },
+    });
   });
 
   test("queues mid-stream objective changes and drains them after stream end", async () => {
     await extensionMetadata.setStreaming(workspaceId, true);
 
+    const activityUpdates = captureGoalActivity(service);
+
     const projected = await setGoalOk(service, { workspaceId, objective: "Queued goal" });
 
     expect(projected.objective).toBe("Queued goal");
+    // Mid-stream goals are not durable until stream accounting drains, but the
+    // activity snapshot feeds the Goal panel and should update immediately.
+    expect(activityUpdates.at(-1)).toMatchObject({
+      goal: { goalId: projected.goalId, objective: "Queued goal", pendingPersistence: true },
+    });
+    expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({ goal: null });
     expect(await service.getGoal(workspaceId)).toBeNull();
+    expect(activityUpdates.at(-1)).toMatchObject({
+      goal: { goalId: projected.goalId, objective: "Queued goal", pendingPersistence: true },
+    });
+    expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({ goal: null });
 
     await extensionMetadata.setStreaming(workspaceId, false);
     const drained = await service.applyPendingAfterStreamEnd(workspaceId);
 
     expect(drained?.objective).toBe("Queued goal");
     expect(await service.getGoal(workspaceId)).toMatchObject({ objective: "Queued goal" });
+    const drainedSnapshot = await extensionMetadata.getSnapshot(workspaceId);
+    expect(drainedSnapshot).toMatchObject({
+      goal: { goalId: drained?.goalId, objective: "Queued goal" },
+    });
+    expect(drainedSnapshot?.goal?.pendingPersistence).toBeUndefined();
+  });
+
+  test("rejects follow-up mutations while a mid-stream goal snapshot is pending", async () => {
+    await extensionMetadata.setStreaming(workspaceId, true);
+    const activityUpdates = captureGoalActivity(service);
+
+    const queued = await service.setGoal({ workspaceId, objective: "Queued goal" });
+    expect(queued.success).toBe(true);
+    expect(activityUpdates.at(-1)).toMatchObject({
+      goal: { objective: "Queued goal", pendingPersistence: true },
+    });
+
+    const budgetResult = await service.setGoal({ workspaceId, budgetCents: 500 });
+    expect(budgetResult.success).toBe(false);
+    if (!budgetResult.success) {
+      expect(budgetResult.error).toMatchObject({ type: "invalid_transition" });
+    }
+    expect(await service.getGoal(workspaceId)).toBeNull();
+    expect(await service.previewStreamAccounting({ workspaceId, costUsd: 1 })).toMatchObject({
+      objective: "Queued goal",
+      pendingPersistence: true,
+    });
+  });
+
+  test("successful no-op queued drains clear the pending snapshot", async () => {
+    const created = await setGoalOk(service, { workspaceId, objective: "Existing goal" });
+    await extensionMetadata.setStreaming(workspaceId, true);
+
+    const activityUpdates = captureGoalActivity(service);
+    const queued = await service.setGoal({ workspaceId, objective: "Existing goal" });
+    expect(queued.success).toBe(true);
+    expect(activityUpdates.at(-1)).toMatchObject({
+      goal: { objective: "Existing goal", pendingPersistence: true },
+    });
+
+    await extensionMetadata.setStreaming(workspaceId, false);
+    const drained = await service.applyPendingAfterStreamEnd(workspaceId);
+
+    expect(drained?.goalId).toBe(created.goalId);
+    const snapshot = await extensionMetadata.getSnapshot(workspaceId);
+    expect(snapshot).toMatchObject({
+      goal: { goalId: created.goalId, objective: "Existing goal" },
+    });
+    expect(snapshot?.goal?.pendingPersistence).toBeUndefined();
+  });
+
+  test("user stop clears queued mid-stream goal snapshot with no persisted goal", async () => {
+    await extensionMetadata.setStreaming(workspaceId, true);
+
+    const activityUpdates = captureGoalActivity(service);
+    const projected = await setGoalOk(service, { workspaceId, objective: "Dropped kickoff goal" });
+    expect(activityUpdates.at(-1)).toMatchObject({
+      goal: {
+        goalId: projected.goalId,
+        objective: "Dropped kickoff goal",
+        pendingPersistence: true,
+      },
+    });
+    expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({ goal: null });
+
+    await service.recordUserStoppedStream(workspaceId, projected.createdAtMs + 5_000);
+
+    expect(await service.applyPendingAfterStreamEnd(workspaceId)).toBeNull();
+    expect(await service.getGoal(workspaceId)).toBeNull();
+    expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({ goal: null });
   });
 
   test("rejects queued mid-stream budgeted goals when kickoff model has no pricing", async () => {
@@ -1807,6 +1913,32 @@ describe("WorkspaceGoalService", () => {
     expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({
       goal: { costCents: 125, budgetCents: 2_000 },
     });
+  });
+
+  test("previewStreamAccounting preserves queued replacement snapshots", async () => {
+    const created = await setGoalOk(service, { workspaceId, objective: "Old goal" });
+    await extensionMetadata.setStreaming(workspaceId, true);
+    const queued = await service.setGoal({
+      workspaceId,
+      objective: "Queued replacement goal",
+      expectedGoalId: created.goalId,
+    });
+    expect(queued.success).toBe(true);
+
+    const preview = await service.previewStreamAccounting({
+      workspaceId,
+      costUsd: 1.25,
+      streamStartedAtMs: created.createdAtMs + 1,
+    });
+
+    expect(preview).toMatchObject({
+      objective: "Queued replacement goal",
+      pendingPersistence: true,
+    });
+    expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({
+      goal: { goalId: created.goalId, objective: "Old goal" },
+    });
+    expect(await service.getGoal(workspaceId)).toMatchObject({ objective: "Old goal" });
   });
 
   test("previewStreamAccounting skips paused goals, compactions, and stale streams", async () => {

--- a/src/node/services/workspaceGoalService.ts
+++ b/src/node/services/workspaceGoalService.ts
@@ -2,8 +2,14 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import writeFileAtomic from "write-file-atomic";
 import assert from "@/common/utils/assert";
-import type { GoalRecordV1, GoalSetError, GoalSnapshot, GoalStatus } from "@/common/types/goal";
-import { toGoalSnapshot } from "@/common/types/goal";
+import {
+  toGoalSnapshot,
+  toPendingGoalSnapshot,
+  type GoalRecordV1,
+  type GoalSetError,
+  type GoalSnapshot,
+  type GoalStatus,
+} from "@/common/types/goal";
 import type { WorkspaceActivitySnapshot } from "@/common/types/workspace";
 import type { Workspace } from "@/common/types/project";
 import type { Result } from "@/common/types/result";
@@ -37,6 +43,9 @@ import type { IdleDispatcher, IdleDispatchPayload } from "./idleDispatcher";
 import { log } from "./log";
 
 const GOAL_FILE = "goal.json";
+const PENDING_GOAL_EDIT_MESSAGE =
+  "Goal is still being saved. Wait for the current stream to finish before editing it.";
+
 const MICRO_CENTS_PER_CENT = 1_000_000;
 
 function costUsdToMicroCents(costUsd: number | null | undefined): number {
@@ -299,6 +308,7 @@ function continuationSendOptions(sendOptions: SendMessageOptions): SendMessageOp
 export class WorkspaceGoalService {
   private readonly fileLocks = workspaceFileLocks;
   private readonly pendingGoalMutations = new Map<string, PendingGoalMutation>();
+  private readonly pendingGoalSnapshots = new Map<string, GoalSnapshot>();
 
   private pendingContinuationCandidates = new Map<string, PendingGoalContinuationCandidate>();
   private continuationReRequestTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -413,6 +423,51 @@ export class WorkspaceGoalService {
     const activity = await this.extensionMetadata.setGoal(workspaceId, snapshot);
     this.onActivityChange?.(workspaceId, activity);
     return snapshot;
+  }
+
+  private async pushTransientGoalSnapshot(
+    workspaceId: string,
+    snapshot: GoalSnapshot
+  ): Promise<void> {
+    const activity = await this.extensionMetadata.getSnapshot(workspaceId);
+    if (activity) {
+      this.onActivityChange?.(workspaceId, {
+        ...activity,
+        goal: snapshot,
+        transientGoalOnly: true,
+      });
+    }
+  }
+
+  private async publishPendingGoalSnapshot(workspaceId: string, goal: GoalRecordV1): Promise<void> {
+    const snapshot = toPendingGoalSnapshot(goal);
+    this.pendingGoalSnapshots.set(workspaceId, snapshot);
+    await this.pushTransientGoalSnapshot(workspaceId, snapshot);
+  }
+
+  private async pushGoalReadSnapshot(
+    workspaceId: string,
+    goal: GoalRecordV1 | null
+  ): Promise<GoalSnapshot | null> {
+    const pendingSnapshot = this.pendingGoalSnapshots.get(workspaceId);
+    if (pendingSnapshot) {
+      // Goal reads keep activity snapshots warm, but mid-stream queued goals
+      // must keep showing the transient replacement until stream-end persistence.
+      await this.pushTransientGoalSnapshot(workspaceId, pendingSnapshot);
+      return pendingSnapshot;
+    }
+    return this.pushSnapshot(workspaceId, goal);
+  }
+
+  private async restorePersistedGoalSnapshot(workspaceId: string): Promise<void> {
+    try {
+      await this.fileLocks.withLock(workspaceId, async () => {
+        const current = await this.readGoalFile(workspaceId);
+        await this.pushSnapshot(workspaceId, current);
+      });
+    } catch (error) {
+      log.warn("Failed to restore persisted goal snapshot", { workspaceId, error });
+    }
   }
 
   private assertParentWorkspace(workspaceId: string): void {
@@ -557,17 +612,25 @@ export class WorkspaceGoalService {
     assert(Number.isFinite(stoppedAtMs) && stoppedAtMs >= 0, "user stop timestamp must be valid");
     this.lastUserStopAtMsByWorkspace.set(workspaceId, stoppedAtMs);
     this.pendingContinuationCandidates.delete(workspaceId);
+    this.pendingGoalSnapshots.delete(workspaceId);
     // Drop queued goal mutations too (Coder-agents-review P2 DEREM-18). If a
     // user sets a goal mid-stream then stops the stream, the mutation would
     // otherwise stay queued and apply on the NEXT stream's stream-end via
     // applyPendingAfterStreamEnd, writing goal.json with createdAtMs > the
     // userStopAtMs gate — auto-continuation would then fire in a context the
     // user did not intend (the stop was meant to discard the goal change).
-    this.pendingGoalMutations.delete(workspaceId);
+    const hadPendingGoalMutation = this.pendingGoalMutations.delete(workspaceId);
 
     await this.fileLocks.withLock(workspaceId, async () => {
       const current = await this.readGoalFile(workspaceId);
       if (current?.status !== "active" && current?.status !== "budget_limited") {
+        // Mid-stream /goal now publishes an optimistic activity snapshot so the
+        // Goal panel opens immediately. If the user aborts that stream, revert
+        // the panel to the persisted goal file (or null) along with dropping the
+        // queued mutation.
+        if (hadPendingGoalMutation) {
+          await this.pushSnapshot(workspaceId, current);
+        }
         return;
       }
       const next = GoalRecordV1Schema.parse({
@@ -843,17 +906,17 @@ export class WorkspaceGoalService {
     return this.fileLocks.withLock(workspaceId, async () => {
       const current = await this.readGoalFile(workspaceId);
       if (!current) {
-        await this.pushSnapshot(workspaceId, null);
+        await this.pushGoalReadSnapshot(workspaceId, null);
         return null;
       }
       const next = this.applyBudgetDrivenStatus(current);
       if (next !== current) {
         await this.writeGoal(workspaceId, next);
-        await this.pushSnapshot(workspaceId, next);
+        await this.pushGoalReadSnapshot(workspaceId, next);
         this.emitBudgetLimited(next, current.status);
         return next;
       }
-      await this.pushSnapshot(workspaceId, current);
+      await this.pushGoalReadSnapshot(workspaceId, current);
       return current;
     });
   }
@@ -1313,6 +1376,13 @@ export class WorkspaceGoalService {
     const objective = input.objective?.trim();
     this.assertParentWorkspace(input.workspaceId);
 
+    if (!objective && this.pendingGoalSnapshots.has(input.workspaceId)) {
+      // Until stream-end persists the queued objective, status/budget-only edits
+      // would target the old durable goal (or no goal) while the panel displays
+      // the optimistic replacement. Reject them instead of mutating the wrong record.
+      return Err({ type: "invalid_transition", message: PENDING_GOAL_EDIT_MESSAGE });
+    }
+
     // -----------------------------------------------------------------------
     // Mid-stream branch: setGoal during an active stream defers the actual
     // disk write until applyPendingAfterStreamEnd. The returned `Ok(projected)`
@@ -1366,6 +1436,11 @@ export class WorkspaceGoalService {
             : {}),
           ...(input.initiator != null ? { initiator: input.initiator } : {}),
         });
+        // A user can run /goal while the first turn is still streaming. The
+        // durable goal write must wait for stream accounting, but the Goal panel
+        // reads activity snapshots, so publish the projected goal immediately
+        // without persisting this crash-unsafe optimistic state.
+        await this.publishPendingGoalSnapshot(input.workspaceId, projected);
         return Ok(projected);
       });
     }
@@ -1738,6 +1813,11 @@ export class WorkspaceGoalService {
       return null;
     }
 
+    const pendingSnapshot = this.pendingGoalSnapshots.get(input.workspaceId);
+    if (pendingSnapshot) {
+      return pendingSnapshot;
+    }
+
     const costMicroCentsThisStream = costUsdToMicroCents(input.costUsd);
     return this.fileLocks.withLock(input.workspaceId, async () => {
       const current = await this.readGoalFile(input.workspaceId);
@@ -1897,6 +1977,7 @@ export class WorkspaceGoalService {
     const cleared = await this.fileLocks.withLock(workspaceId, async () => {
       const current = await this.readGoalFile(workspaceId);
       this.pendingGoalMutations.delete(workspaceId);
+      this.pendingGoalSnapshots.delete(workspaceId);
       this.pendingContinuationCandidates.delete(workspaceId);
       this.recordedStreamStartedAtMsByWorkspace.delete(workspaceId);
       this.lastGoalStreamStamps.delete(workspaceId);
@@ -1953,6 +2034,7 @@ export class WorkspaceGoalService {
     }
 
     this.pendingGoalMutations.delete(workspaceId);
+    this.pendingGoalSnapshots.delete(workspaceId);
     // Mirror the `setGoal` wrapper (DEREM-36) here: `setGoalImmediately`
     // rethrows `WorkspaceGoalTransitionError` / `WorkspaceGoalChildWorkspaceError`
     // for invalid transitions (e.g. a queued `/goal pause` against an
@@ -1970,6 +2052,10 @@ export class WorkspaceGoalService {
         error: error instanceof Error ? error.message : String(error),
       });
       return null;
+    } finally {
+      // Always re-read the durable record: queued snapshots are optimistic, and
+      // drains can succeed as persistence no-ops, reject, or throw.
+      await this.restorePersistedGoalSnapshot(workspaceId);
     }
   }
 }


### PR DESCRIPTION
## Summary

Shows goals set during an active stream in the Goal panel immediately, while keeping the durable `goal.json` write ordered behind stream-end accounting. The optimistic goal is now a transient activity-only snapshot and is read-only until it is persisted.

## Background

When `/goal` was run while the first chat turn was still streaming, the backend queued the goal write and returned success, but the Goal panel read workspace activity snapshots rather than the returned record. Because no snapshot was emitted until stream-end persistence, the panel opened with “No goal is set.”

## Implementation

- Publish a transient, non-persisted pending goal snapshot for mid-stream objective changes so the panel can render immediately without writing crash-unsafe optimistic state to extension metadata.
- Mark pending snapshots with `pendingPersistence`, centralize that check in shared goal helpers, and keep pending goals read-only in the Goal tab, command palette, and active-goal counting.
- Merge transient goal-only activity events into the frontend store without replaying stale streaming/recency fields.
- Preserve the pending snapshot during live cost previews and goal reads, clear it after all stream-end drain outcomes, and reject status/budget-only follow-up mutations while a queued goal replacement is still pending.

## Validation

- `bun test src/node/services/workspaceGoalService.test.ts src/browser/stores/WorkspaceStore.test.ts src/browser/utils/commands/sources.test.ts src/browser/features/RightSidebar/GoalTab.test.tsx`
- `git diff --check`
- `make static-check`

## Risks

Medium regression risk in goal lifecycle/activity synchronization: the change touches backend goal deferral, frontend activity merging, Goal panel controls, and command palette visibility. Tests cover the pending, drain, no-op, preview/read, stale-field merge, and read-only UI paths.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$27.66`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=27.66 -->
