### PR TITLE
🤖 fix: allow initial workspace goal command

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -1188,7 +1188,7 @@ function AppInner() {
                         // against its latest ref, so by the time setSelectedWorkspace() returns we
                         // know whether this creation actually won and can safely mark the
                         // optimistic starting barrier outside the updater callback.
-                        if (createdSelection) {
+                        if (createdSelection && options?.markPendingInitialSend !== false) {
                           workspaceStore.markPendingInitialSend(
                             metadata.id,
                             options?.pendingStreamModel ?? null

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -56,6 +56,7 @@ import {
   getWorkspaceLastReadKey,
 } from "@/common/constants/storage";
 import {
+  isGoalsExperimentEnabledForCommand,
   prepareCompactionMessage,
   processSlashCommand,
   type SlashCommandContext,
@@ -804,13 +805,22 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
   // Creation-specific state (hook always called, but only used when variant === "creation")
   // This avoids conditional hook calls which violate React rules
+  const creationNameMessage =
+    variant === "creation"
+      ? (() => {
+          const parsedCreationCommand = parseCommand(input.trim());
+          return parsedCreationCommand?.type === "goal-set"
+            ? parsedCreationCommand.objective
+            : input;
+        })()
+      : "";
   const creationState = useCreationWorkspace(
     variant === "creation"
       ? {
           projectPath: creationParentProjectPath,
           subProjectPath: creationSubProjectPath,
           onWorkspaceCreated: props.onWorkspaceCreated,
-          message: input,
+          message: creationNameMessage,
           draftId: props.pendingDraftId,
           userModel: preferredModel,
         }
@@ -2113,12 +2123,23 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
     // Route to creation handler for creation variant
     if (variant === "creation") {
-      const commandHandled = await executeParsedCommand(parsed, input);
-      if (commandHandled) {
+      const initialGoalCommand = parsed?.type === "goal-set" ? parsed : undefined;
+      if (initialGoalCommand && !(await isGoalsExperimentEnabledForCommand({ api }))) {
+        setToast({
+          id: Date.now().toString(),
+          type: "error",
+          message: "Goal commands require the Goals experiment to be enabled",
+        });
         return;
       }
+      if (!initialGoalCommand) {
+        const commandHandled = await executeParsedCommand(parsed, input);
+        if (commandHandled) {
+          return;
+        }
+      }
 
-      let creationMessageTextForSend = messageText;
+      let creationMessageTextForSend = initialGoalCommand?.objective ?? messageText;
       let creationOptionsOverride: Partial<SendMessageOptions> | undefined;
 
       if (skillInvocation) {
@@ -2162,7 +2183,8 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       const creationResult = await creationState.handleSend(
         creationMessageTextForSend,
         creationFileParts.length > 0 ? creationFileParts : undefined,
-        creationOptionsOverride
+        creationOptionsOverride,
+        initialGoalCommand
       );
 
       if (creationResult.success) {

--- a/src/browser/features/ChatInput/types.ts
+++ b/src/browser/features/ChatInput/types.ts
@@ -20,6 +20,8 @@ export interface WorkspaceCreatedOptions {
   autoNavigate?: boolean;
   /** Pending model for the optimistic startup barrier when navigation actually occurs. */
   pendingStreamModel?: string | null;
+  /** Set false when creation does not immediately enqueue an initial user send. */
+  markPendingInitialSend?: boolean;
 }
 
 // Workspace variant: full functionality for existing workspaces

--- a/src/browser/features/ChatInput/useCreationWorkspace.test.tsx
+++ b/src/browser/features/ChatInput/useCreationWorkspace.test.tsx
@@ -18,6 +18,7 @@ import {
   getThinkingLevelKey,
 } from "@/common/constants/storage";
 import type { WorkspaceChatMessage } from "@/common/orpc/types";
+import { EXPERIMENT_IDS, getExperimentKey } from "@/common/constants/experiments";
 import {
   CODER_RUNTIME_PLACEHOLDER,
   type CoderWorkspaceConfig,
@@ -241,6 +242,10 @@ type WorkspaceUpdateAgentAISettingsArgs = Parameters<
 type WorkspaceUpdateAgentAISettingsResult = Awaited<
   ReturnType<APIClient["workspace"]["updateAgentAISettings"]>
 >;
+type WorkspaceGetGoalArgs = Parameters<APIClient["workspace"]["getGoal"]>[0];
+type WorkspaceGetGoalResult = Awaited<ReturnType<APIClient["workspace"]["getGoal"]>>;
+type WorkspaceSetGoalArgs = Parameters<APIClient["workspace"]["setGoal"]>[0];
+type WorkspaceSetGoalResult = Awaited<ReturnType<APIClient["workspace"]["setGoal"]>>;
 type WorkspaceCreateResult = Awaited<ReturnType<APIClient["workspace"]["create"]>>;
 type NameGenerationArgs = Parameters<APIClient["nameGeneration"]["generate"]>[0];
 type NameGenerationResult = Awaited<ReturnType<APIClient["nameGeneration"]["generate"]>>;
@@ -250,7 +255,7 @@ type MockOrpcProjectsClient = Pick<
 >;
 type MockOrpcWorkspaceClient = Pick<
   APIClient["workspace"],
-  "sendMessage" | "create" | "updateAgentAISettings"
+  "sendMessage" | "create" | "updateAgentAISettings" | "getGoal" | "setGoal"
 >;
 type MockOrpcNameGenerationClient = Pick<APIClient["nameGeneration"], "generate">;
 type WindowWithApi = Window & typeof globalThis;
@@ -284,6 +289,12 @@ interface SetupWindowOptions {
       (args: WorkspaceUpdateAgentAISettingsArgs) => Promise<WorkspaceUpdateAgentAISettingsResult>
     >
   >;
+  getGoal?: ReturnType<
+    typeof mock<(args: WorkspaceGetGoalArgs) => Promise<WorkspaceGetGoalResult>>
+  >;
+  setGoal?: ReturnType<
+    typeof mock<(args: WorkspaceSetGoalArgs) => Promise<WorkspaceSetGoalResult>>
+  >;
   create?: ReturnType<typeof mock<(args: WorkspaceCreateArgs) => Promise<WorkspaceCreateResult>>>;
   nameGeneration?: ReturnType<
     typeof mock<(args: NameGenerationArgs) => Promise<NameGenerationResult>>
@@ -296,6 +307,8 @@ const setupWindow = ({
   sendMessage,
   create,
   updateAgentAISettings,
+  getGoal,
+  setGoal,
   nameGeneration,
 }: SetupWindowOptions = {}) => {
   // Sync the useProjectContext mock with the default trusted config.
@@ -334,6 +347,25 @@ const setupWindow = ({
         data: {},
       };
       return Promise.resolve(result);
+    });
+
+  const getGoalMock =
+    getGoal ??
+    mock<(args: WorkspaceGetGoalArgs) => Promise<WorkspaceGetGoalResult>>(() => {
+      return Promise.resolve({ goal: null } as WorkspaceGetGoalResult);
+    });
+
+  const setGoalMock =
+    setGoal ??
+    mock<(args: WorkspaceSetGoalArgs) => Promise<WorkspaceSetGoalResult>>(() => {
+      return Promise.resolve({
+        success: true,
+        data: {
+          goalId: "33333333-3333-4333-8333-333333333333",
+          objective: "test goal",
+          status: "active",
+        },
+      } as WorkspaceSetGoalResult);
     });
 
   const createMock =
@@ -387,6 +419,8 @@ const setupWindow = ({
       create: (input: WorkspaceCreateArgs) => createMock(input),
       updateAgentAISettings: (input: WorkspaceUpdateAgentAISettingsArgs) =>
         updateAgentAISettingsMock(input),
+      getGoal: (input: WorkspaceGetGoalArgs) => getGoalMock(input),
+      setGoal: (input: WorkspaceSetGoalArgs) => setGoalMock(input),
     },
     nameGeneration: {
       generate: (input: NameGenerationArgs) => nameGenerationMock(input),
@@ -493,6 +527,9 @@ const setupWindow = ({
     workspaceApi: {
       sendMessage: sendMessageMock,
       create: createMock,
+      updateAgentAISettings: updateAgentAISettingsMock,
+      getGoal: getGoalMock,
+      setGoal: setGoalMock,
     },
     nameGenerationApi: { generate: nameGenerationMock },
   };
@@ -697,6 +734,77 @@ describe("useCreationWorkspace", () => {
     // Thinking is workspace-scoped, but this test doesn't set a project-scoped thinking preference.
     expect(updatePersistedStateCalls).toContainEqual([pendingInputKey, ""]);
     expect(updatePersistedStateCalls).toContainEqual([pendingImagesKey, undefined]);
+  });
+
+  test("handleSend creates workspace and applies initial goal command without sending chat text", async () => {
+    const setGoalMock = mock(
+      (_args: WorkspaceSetGoalArgs): Promise<WorkspaceSetGoalResult> =>
+        Promise.resolve({
+          success: true,
+          data: {
+            goalId: "33333333-3333-4333-8333-333333333333",
+            objective: "ship the feature",
+            status: "active",
+          },
+        } as WorkspaceSetGoalResult)
+    );
+    const sendMessageMock = mock(
+      (_args: WorkspaceSendMessageArgs): Promise<WorkspaceSendMessageResult> =>
+        Promise.resolve({ success: true, data: {} } as WorkspaceSendMessageResult)
+    );
+    const { workspaceApi } = setupWindow({ setGoal: setGoalMock, sendMessage: sendMessageMock });
+    localStorage.setItem(getExperimentKey(EXPERIMENT_IDS.GOALS), JSON.stringify(true));
+
+    const onWorkspaceCreated = mock(
+      (
+        metadata: FrontendWorkspaceMetadata,
+        options?: {
+          autoNavigate?: boolean;
+          pendingStreamModel?: string | null;
+          markPendingInitialSend?: boolean;
+        }
+      ) => ({ metadata, options })
+    );
+    const getHook = renderUseCreationWorkspace({
+      projectPath: TEST_PROJECT_PATH,
+      onWorkspaceCreated,
+      message: "/goal ship the feature --no-budget",
+    });
+
+    await waitFor(() => expect(getHook().branches).toEqual([FALLBACK_BRANCH]));
+
+    let handleSendResult: CreationSendResult | undefined;
+    await act(async () => {
+      handleSendResult = await getHook().handleSend("ship the feature", undefined, undefined, {
+        type: "goal-set",
+        objective: "ship the feature",
+        budgetCents: null,
+      });
+    });
+
+    expect(handleSendResult).toEqual({ success: true });
+    expect(workspaceApi.create.mock.calls.length).toBe(1);
+    expect(workspaceApi.sendMessage.mock.calls.length).toBe(0);
+    expect(workspaceApi.updateAgentAISettings.mock.calls.length).toBe(1);
+    expect(workspaceApi.updateAgentAISettings).toHaveBeenCalledWith({
+      workspaceId: TEST_WORKSPACE_ID,
+      agentId: "exec",
+      aiSettings: { model: "gpt-4", thinkingLevel: "medium" },
+      persistSelectedAgentId: true,
+    });
+    expect(workspaceApi.getGoal.mock.calls.length).toBe(1);
+    expect(workspaceApi.setGoal).toHaveBeenCalledWith({
+      workspaceId: TEST_WORKSPACE_ID,
+      objective: "ship the feature",
+      budgetCents: null,
+      turnCap: null,
+      expectedGoalId: null,
+    });
+    expect(onWorkspaceCreated.mock.calls[0][1]).toEqual({
+      autoNavigate: true,
+      pendingStreamModel: "anthropic:claude-opus-4-7",
+      markPendingInitialSend: false,
+    });
   });
 
   test("handleSend shows trust dialog for untrusted projects", async () => {
@@ -988,7 +1096,11 @@ describe("useCreationWorkspace", () => {
     const onWorkspaceCreated = mock(
       (
         metadata: FrontendWorkspaceMetadata,
-        options?: { autoNavigate?: boolean; pendingStreamModel?: string | null }
+        options?: {
+          autoNavigate?: boolean;
+          pendingStreamModel?: string | null;
+          markPendingInitialSend?: boolean;
+        }
       ) => ({
         metadata,
         options,
@@ -1014,6 +1126,7 @@ describe("useCreationWorkspace", () => {
     expect(onWorkspaceCreated.mock.calls[0][1]).toEqual({
       autoNavigate: false,
       pendingStreamModel: null,
+      markPendingInitialSend: true,
     });
   });
 
@@ -1058,7 +1171,11 @@ describe("useCreationWorkspace", () => {
     const onWorkspaceCreated = mock(
       (
         metadata: FrontendWorkspaceMetadata,
-        options?: { autoNavigate?: boolean; pendingStreamModel?: string | null }
+        options?: {
+          autoNavigate?: boolean;
+          pendingStreamModel?: string | null;
+          markPendingInitialSend?: boolean;
+        }
       ) => ({ metadata, options })
     );
 
@@ -1081,6 +1198,7 @@ describe("useCreationWorkspace", () => {
     expect(onWorkspaceCreated.mock.calls[0][1]).toEqual({
       autoNavigate: true,
       pendingStreamModel: "anthropic:claude-opus-4-7",
+      markPendingInitialSend: true,
     });
   });
 
@@ -1249,7 +1367,11 @@ interface HookOptions {
   projectPath: string;
   onWorkspaceCreated: (
     metadata: FrontendWorkspaceMetadata,
-    options?: { autoNavigate?: boolean }
+    options?: {
+      autoNavigate?: boolean;
+      pendingStreamModel?: string | null;
+      markPendingInitialSend?: boolean;
+    }
   ) => void;
   message?: string;
   draftId?: string | null;

--- a/src/browser/features/ChatInput/useCreationWorkspace.ts
+++ b/src/browser/features/ChatInput/useCreationWorkspace.ts
@@ -39,6 +39,9 @@ import { ConfirmationModal } from "@/browser/components/ConfirmationModal/Confir
 import { useProvidersConfig } from "@/browser/hooks/useProvidersConfig";
 import type { FilePart, SendMessageOptions } from "@/common/orpc/types";
 import type { WorkspaceCreatedOptions } from "@/browser/features/ChatInput/types";
+import type { ParsedCommand } from "@/browser/utils/slashCommands/types";
+import { processSlashCommand, type SlashCommandContext } from "@/browser/utils/chatCommands";
+import { CUSTOM_EVENTS, createCustomEvent } from "@/common/constants/events";
 import {
   useWorkspaceName,
   type WorkspaceNameState,
@@ -58,6 +61,7 @@ import { workspaceStore } from "@/browser/stores/WorkspaceStore";
 import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 
 export type CreationSendResult = { success: true } | { success: false; error?: SendMessageError };
+export type CreationInitialSlashCommand = Extract<ParsedCommand, { type: "goal-set" }>;
 
 interface UseCreationWorkspaceOptions {
   projectPath: string;
@@ -173,7 +177,8 @@ interface UseCreationWorkspaceReturn {
   handleSend: (
     message: string,
     fileParts?: FilePart[],
-    optionsOverride?: Partial<SendMessageOptions>
+    optionsOverride?: Partial<SendMessageOptions>,
+    initialSlashCommand?: CreationInitialSlashCommand
   ) => Promise<CreationSendResult>;
   /** Workspace name/title generation state and actions (for CreationControls) */
   nameState: WorkspaceNameState;
@@ -346,7 +351,8 @@ export function useCreationWorkspace({
     async (
       messageText: string,
       fileParts?: FilePart[],
-      optionsOverride?: Partial<SendMessageOptions>
+      optionsOverride?: Partial<SendMessageOptions>,
+      initialSlashCommand?: CreationInitialSlashCommand
     ): Promise<CreationSendResult> => {
       if (!messageText.trim() || isSending || !api) {
         return { success: false };
@@ -512,8 +518,10 @@ export function useCreationWorkspace({
         createdWorkspaceId = metadata.id;
 
         // Best-effort: persist the initial AI settings to the backend immediately so this workspace
-        // is portable across devices even before the first stream starts.
-        api.workspace
+        // is portable across devices even before the first stream starts. Initial /goal commands do
+        // not send a normal user message, so they await this write before setting the goal; that lets
+        // the backend kickoff continuation use the same model/agent selected in creation.
+        const initialAiSettingsPersisted = api.workspace
           .updateAgentAISettings({
             workspaceId: metadata.id,
             agentId: settings.agentId,
@@ -521,10 +529,9 @@ export function useCreationWorkspace({
               model: settings.model,
               thinkingLevel: settings.thinkingLevel,
             },
+            persistSelectedAgentId: true,
           })
-          .catch(() => {
-            // Ignore - sendMessage will persist AI settings as a fallback.
-          });
+          .catch(() => null);
 
         const isDraftScope = typeof draftId === "string" && draftId.trim().length > 0;
         const pendingScopeId = projectPath
@@ -566,6 +573,7 @@ export function useCreationWorkspace({
         onWorkspaceCreated(metadata, {
           autoNavigate: shouldAutoNavigate,
           pendingStreamModel: shouldAutoNavigate ? baseModel : null,
+          markPendingInitialSend: initialSlashCommand == null,
         });
 
         if (typeof draftId === "string" && draftId.trim().length > 0 && promoteWorkspaceDraft) {
@@ -576,6 +584,43 @@ export function useCreationWorkspace({
         // Persistently clear the draft as soon as the workspace exists so a refresh
         // during the initial send can't resurrect the draft entry in the sidebar.
         clearPendingDraft();
+
+        if (initialSlashCommand) {
+          await initialAiSettingsPersisted;
+          const commandContext: SlashCommandContext = {
+            api,
+            workspaceId: metadata.id,
+            variant: "workspace",
+            projectPath,
+            sendMessageOptions,
+            setInput: () => undefined,
+            setAttachments: () => undefined,
+            setSendingState: () => undefined,
+            setToast,
+            setPreferredModel: () => undefined,
+            setVimEnabled: () => undefined,
+            resetInputHeight: () => undefined,
+          };
+          const commandResult = await processSlashCommand(initialSlashCommand, commandContext);
+          setIsSending(false);
+
+          if (!commandResult.clearInput) {
+            workspaceStore.clearPendingInitialSendState(metadata.id);
+            return { success: false };
+          }
+
+          const openGoalTab = () => {
+            window.dispatchEvent(
+              createCustomEvent(CUSTOM_EVENTS.OPEN_GOAL_TAB, { workspaceId: metadata.id })
+            );
+          };
+          if (typeof window.requestAnimationFrame === "function") {
+            window.requestAnimationFrame(openGoalTab);
+          } else {
+            openGoalTab();
+          }
+          return { success: true };
+        }
 
         setIsSending(false);
 

--- a/src/browser/utils/chatCommands.test.ts
+++ b/src/browser/utils/chatCommands.test.ts
@@ -504,7 +504,7 @@ describe("processSlashCommand - goal experiment state", () => {
 });
 
 describe("processSlashCommand - workspace command gating", () => {
-  test("blocks known goal flag errors during workspace creation", async () => {
+  test("shows goal parse errors during workspace creation", async () => {
     const context = createGoalCommandContext(null);
     context.variant = "creation";
 
@@ -515,7 +515,7 @@ describe("processSlashCommand - workspace command gating", () => {
 
     expect(result).toEqual({ clearInput: false, toastShown: true });
     expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({ message: "Command not available during workspace creation" })
+      expect.objectContaining({ message: "Unknown flag for /goal: --bogus" })
     );
   });
 });

--- a/src/browser/utils/chatCommands.ts
+++ b/src/browser/utils/chatCommands.ts
@@ -640,7 +640,7 @@ function resolveSlashGoalSetIntent(
   );
 }
 
-async function isGoalsExperimentEnabledForCommand(context: {
+export async function isGoalsExperimentEnabledForCommand(context: {
   api: CommandHandlerContext["api"] | SlashCommandContext["api"];
 }): Promise<boolean> {
   const localOverride = isExperimentEnabled(EXPERIMENT_IDS.GOALS);

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -1046,6 +1046,7 @@ export const workspace = {
       workspaceId: z.string(),
       agentId: AgentIdSchema,
       aiSettings: WorkspaceAISettingsSchema,
+      persistSelectedAgentId: z.boolean().nullish(),
     }),
     output: ResultSchema(z.void(), z.string()),
   },

--- a/src/constants/slashCommands.ts
+++ b/src/constants/slashCommands.ts
@@ -14,7 +14,6 @@ export const WORKSPACE_ONLY_COMMAND_KEYS: ReadonlySet<string> = new Set([
   "new",
   "plan",
   "heartbeat",
-  "goal",
 ]);
 
 /**

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -3237,7 +3237,8 @@ export const router = (authToken?: string) => {
           return context.workspaceService.updateAgentAISettings(
             input.workspaceId,
             input.agentId,
-            input.aiSettings
+            input.aiSettings,
+            { persistSelectedAgentId: input.persistSelectedAgentId === true }
           );
         }),
       rename: t

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -8105,6 +8105,74 @@ describe("WorkspaceService.getGoalContinuationRuntimeState", () => {
       expect(result?.agentId).toBe("exec");
     });
 
+    test("uses the persisted selected agent for initial goal kickoff options", async () => {
+      const projectPath = "/tmp/proj";
+      const workspaceId = "ws-selected-agent";
+      const projects = new Map([
+        [
+          projectPath,
+          {
+            workspaces: [
+              {
+                id: workspaceId,
+                path: "/tmp/proj/ws",
+                agentId: "review",
+                aiSettingsByAgent: {
+                  review: { model: "anthropic:claude-sonnet-4-6", thinkingLevel: "off" as const },
+                  exec: { model: "openai:gpt-4o", thinkingLevel: "off" as const },
+                },
+              },
+            ],
+          },
+        ],
+      ]);
+      const service = await makeServiceWithConfig({
+        findWorkspace: mock(() => ({ projectPath, workspacePath: "/tmp/proj/ws" })),
+        loadConfigOrDefault: mock(() => ({ projects })),
+      });
+
+      const result = service.getGoalContinuationKickoffSendOptions(workspaceId);
+
+      expect(result).toEqual({
+        model: "anthropic:claude-sonnet-4-6",
+        agentId: "review",
+      });
+    });
+
+    test("falls back to exec when the selected agent cannot run goal continuations", async () => {
+      const projectPath = "/tmp/proj";
+      const workspaceId = "ws-plan-agent";
+      const projects = new Map([
+        [
+          projectPath,
+          {
+            workspaces: [
+              {
+                id: workspaceId,
+                path: "/tmp/proj/ws",
+                agentId: "plan",
+                aiSettingsByAgent: {
+                  plan: { model: "anthropic:claude-sonnet-4-6", thinkingLevel: "off" as const },
+                  exec: { model: "openai:gpt-4o", thinkingLevel: "off" as const },
+                },
+              },
+            ],
+          },
+        ],
+      ]);
+      const service = await makeServiceWithConfig({
+        findWorkspace: mock(() => ({ projectPath, workspacePath: "/tmp/proj/ws" })),
+        loadConfigOrDefault: mock(() => ({ projects })),
+      });
+
+      const result = service.getGoalContinuationKickoffSendOptions(workspaceId);
+
+      expect(result).toEqual({
+        model: "openai:gpt-4o",
+        agentId: "exec",
+      });
+    });
+
     test("falls through to workspace default model when per-agent is missing", async () => {
       const projectPath = "/tmp/proj";
       const workspaceId = "ws-1";

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -5069,7 +5069,8 @@ export class WorkspaceService extends EventEmitter {
   async updateAgentAISettings(
     workspaceId: string,
     agentId: string,
-    aiSettings: WorkspaceAISettings
+    aiSettings: WorkspaceAISettings,
+    options?: { persistSelectedAgentId?: boolean }
   ): Promise<Result<void, string>> {
     try {
       const normalized = this.normalizeWorkspaceAISettings(aiSettings);
@@ -5103,6 +5104,7 @@ export class WorkspaceService extends EventEmitter {
         normalized.data,
         {
           emitMetadata: true,
+          ...(options?.persistSelectedAgentId === true ? { persistSelectedAgentId: true } : {}),
         }
       );
       if (!persistResult.success) {
@@ -7245,10 +7247,29 @@ export class WorkspaceService extends EventEmitter {
       project?.workspaces.find((w) => w.id === workspaceId) ??
       project?.workspaces.find((w) => w.path === workspaceMatch.workspacePath);
 
+    // Initial workspace `/goal` creation can arm a continuation before any normal
+    // sendMessage call runs, so resolve kickoff options from the persisted selected
+    // agent instead of assuming the default exec agent. Plan/compact are UI modes,
+    // not continuation-capable agents, so fall back to exec for the actual kickoff.
+    const persistedAgentId = normalizeAgentId(workspaceEntry?.agentId, WORKSPACE_DEFAULTS.agentId);
+    const agentId =
+      persistedAgentId === "plan" || persistedAgentId === "compact"
+        ? WORKSPACE_DEFAULTS.agentId
+        : persistedAgentId;
+    const selectedAgentSettings = workspaceEntry?.aiSettingsByAgent?.[agentId];
+    const execAgentSettings =
+      agentId !== WORKSPACE_DEFAULTS.agentId
+        ? workspaceEntry?.aiSettingsByAgent?.[WORKSPACE_DEFAULTS.agentId]
+        : undefined;
+
     const candidates: Array<string | undefined> = [
-      workspaceEntry?.aiSettingsByAgent?.[WORKSPACE_DEFAULTS.agentId]?.model,
+      selectedAgentSettings?.model,
       workspaceEntry?.aiSettings?.model,
-      config.agentAiDefaults?.[WORKSPACE_DEFAULTS.agentId]?.modelString,
+      config.agentAiDefaults?.[agentId]?.modelString,
+      execAgentSettings?.model,
+      agentId !== WORKSPACE_DEFAULTS.agentId
+        ? config.agentAiDefaults?.[WORKSPACE_DEFAULTS.agentId]?.modelString
+        : undefined,
       DEFAULT_MODEL,
     ];
 
@@ -7260,7 +7281,7 @@ export class WorkspaceService extends EventEmitter {
       if (isValidModelFormat(normalized)) {
         return {
           model: normalized,
-          agentId: WORKSPACE_DEFAULTS.agentId,
+          agentId,
         };
       }
     }


### PR DESCRIPTION
## Summary

Allow `/goal <objective>` from the initial workspace creation composer. The creation flow now creates the workspace, persists the selected AI settings, then routes the parsed goal command through the same `processSlashCommand` goal-set path used after creation instead of sending `/goal` as normal chat text.

## Implementation

- Treat creation-mode `goal-set` as an initial workspace command rather than a workspace-only rejection.
- Keep `/goal` available in creation suggestions while leaving goal lifecycle commands workspace-only.
- Skip the optimistic initial-send barrier for initial `/goal` because no normal user message is enqueued; the goal continuation loop can start naturally after the goal is set.
- Generate the workspace name from the goal objective instead of the literal `/goal ...` command text.

## Validation

- `make static-check`
- `make typecheck`
- `bun test src/browser/utils/chatCommands.test.ts`
- `bun test src/browser/utils/slashCommands/suggestions.test.ts`
- `bun test src/browser/features/ChatInput/useCreationWorkspace.test.tsx`

## Risks

Low. The change is narrowly scoped to creation-mode `/goal` handling and reuses the existing post-creation goal command path for validation, defaults, conflict retry, and side effects.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `high` • Cost: `$unknown`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=high costs=unknown -->
