### PR TITLE
🤖 fix: stage SSH forks under a unique scratch path to prevent rm -rf collisions

### DIFF
--- a/src/node/runtime/SSHRuntime.fork.test.ts
+++ b/src/node/runtime/SSHRuntime.fork.test.ts
@@ -1,0 +1,398 @@
+/**
+ * Regression tests for SSHRuntime.forkWorkspace.
+ *
+ * These tests exist to lock in two safety invariants that, when broken, have
+ * caused live SSH workspaces to be silently wiped on the remote host:
+ *
+ *   1. Forks ALWAYS land at the canonical project root (`<srcBaseDir>/<projectId>/<name>`),
+ *      regardless of where the source workspace's persisted path lives. Legacy
+ *      workspaces from before #3125 sit at `<srcBaseDir>/<basename>/<name>` —
+ *      inheriting their parent dir is what triggered the worktree-add failure
+ *      cleanup that wiped sibling workspaces.
+ *
+ *   2. Every `rm -rf` issued by forkWorkspace targets a per-attempt staging
+ *      directory (`.mux-fork-staging-<12 hex>`), never the final workspace
+ *      path. Even when `git worktree add` or `cp -R -P` leaves a partial,
+ *      cleanup operates exclusively on the unique staging name and therefore
+ *      cannot destroy a sibling workspace.
+ *
+ * The tests drive a real SSHRuntime instance through a mocked `exec()` that
+ * dispatches on substring patterns. We assert on the *exact* command strings
+ * issued, because the safety property we care about is "no rm -rf ever runs
+ * against the final workspace path".
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { ExecOptions, ExecStream, InitLogger, WorkspaceForkParams } from "./Runtime";
+import { SSHRuntime } from "./SSHRuntime";
+import type { SSHRuntimeConfig } from "./sshConnectionPool";
+import type { PtyHandle, PtySessionParams, SSHTransport } from "./transports";
+
+const noop = (): void => undefined;
+const noopAsync = (): Promise<void> => Promise.resolve();
+
+const noopInitLogger: InitLogger = {
+  logStep: noop,
+  logStdout: noop,
+  logStderr: noop,
+  logComplete: noop,
+};
+
+function createMockTransport(config: SSHRuntimeConfig): SSHTransport {
+  return {
+    spawnRemoteProcess() {
+      return Promise.reject(new Error("Unexpected transport use in SSHRuntime fork test"));
+    },
+    isConnectionFailure() {
+      return false;
+    },
+    acquireConnection() {
+      return Promise.resolve();
+    },
+    getConfig() {
+      return config;
+    },
+    createPtySession(_params: PtySessionParams): Promise<PtyHandle> {
+      return Promise.reject(new Error("Unexpected PTY creation in SSHRuntime fork test"));
+    },
+  };
+}
+
+function createTextStream(text: string): ReadableStream<Uint8Array> {
+  const encoded = new TextEncoder().encode(text);
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      if (encoded.byteLength > 0) {
+        controller.enqueue(encoded);
+      }
+      controller.close();
+    },
+  });
+}
+
+const discardChunk = (_chunk: Uint8Array): Promise<void> => Promise.resolve();
+
+function createExecStream(stdout: string, stderr = "", exitCode = 0): ExecStream {
+  return {
+    stdout: createTextStream(stdout),
+    stderr: createTextStream(stderr),
+    stdin: new WritableStream<Uint8Array>({
+      write: discardChunk,
+      close: noopAsync,
+      abort: noopAsync,
+    }),
+    exitCode: Promise.resolve(exitCode),
+    duration: Promise.resolve(0),
+  };
+}
+
+interface CannedResponse {
+  /** Substring that must appear anywhere in the command. */
+  matches: (command: string) => boolean;
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+}
+
+class ForkTestSSHRuntime extends SSHRuntime {
+  readonly commands: string[] = [];
+  readonly canned: CannedResponse[] = [];
+
+  constructor(
+    srcBaseDir: string,
+    workspacePathOverride?: { project: string; name: string; path: string }
+  ) {
+    const config: SSHRuntimeConfig = {
+      host: "example.test",
+      srcBaseDir,
+    };
+    super(
+      config,
+      createMockTransport(config),
+      workspacePathOverride
+        ? {
+            projectPath: workspacePathOverride.project,
+            workspaceName: workspacePathOverride.name,
+            workspacePath: workspacePathOverride.path,
+          }
+        : undefined
+    );
+  }
+
+  override exec(command: string, _options: ExecOptions): Promise<ExecStream> {
+    this.commands.push(command);
+    for (const c of this.canned) {
+      if (c.matches(command)) {
+        return Promise.resolve(createExecStream(c.stdout ?? "", c.stderr ?? "", c.exitCode ?? 0));
+      }
+    }
+    // Default: succeed silently. Tests pin the responses they care about.
+    return Promise.resolve(createExecStream(""));
+  }
+}
+
+function buildForkParams(overrides: Partial<WorkspaceForkParams> = {}): WorkspaceForkParams {
+  return {
+    projectPath: "/Users/me/Projects/coder/mux",
+    sourceWorkspaceName: "feature-source",
+    newWorkspaceName: "feature-new",
+    initLogger: noopInitLogger,
+    trusted: true,
+    ...overrides,
+  };
+}
+
+describe("SSHRuntime.forkWorkspace canonical-layout invariant", () => {
+  it("computes the new workspace path from the canonical project layout, ignoring the source's persisted parent", async () => {
+    // Source is at the LEGACY path (pre-#3125), simulating an unmigrated workspace.
+    const runtime = new ForkTestSSHRuntime("/remote/src", {
+      project: "/Users/me/Projects/coder/mux",
+      name: "feature-source",
+      path: "/remote/src/mux/feature-source", // legacy: <basename>/<name>
+    });
+
+    runtime.canned.push(
+      { matches: (c) => c.startsWith("test -e "), exitCode: 1 }, // destination doesn't exist
+      {
+        matches: (c) => c.includes("branch --show-current"),
+        stdout: "feature-source\n",
+        exitCode: 0,
+      },
+      { matches: (c) => c.startsWith("test -d "), exitCode: 0 }, // base repo exists
+      { matches: (c) => c.includes("worktree add "), exitCode: 0 }, // worktree add succeeds
+      // Finalize step embeds the collision check + `git worktree move` in one shell line.
+      { matches: (c) => c.includes("worktree move "), exitCode: 0 }
+    );
+
+    const result = await runtime.forkWorkspace(buildForkParams());
+
+    expect(result.success).toBe(true);
+    // CRITICAL: the new workspace's path must be under the canonical hashed
+    // project root, NOT under the legacy `<basename>/` parent.
+    expect(result.workspacePath).toMatch(/^\/remote\/src\/mux-[0-9a-f]{12}\/feature-new$/);
+  });
+
+  it("uses the canonical project root for the worktree-add target even when source is legacy", async () => {
+    const runtime = new ForkTestSSHRuntime("/remote/src", {
+      project: "/Users/me/Projects/coder/mux",
+      name: "feature-source",
+      path: "/remote/src/mux/feature-source",
+    });
+
+    runtime.canned.push(
+      { matches: (c) => c.startsWith("test -e "), exitCode: 1 },
+      {
+        matches: (c) => c.includes("branch --show-current"),
+        stdout: "feature-source\n",
+        exitCode: 0,
+      },
+      { matches: (c) => c.startsWith("test -d "), exitCode: 0 },
+      { matches: (c) => c.includes("worktree add "), exitCode: 0 },
+      { matches: (c) => c.includes("worktree move "), exitCode: 0 }
+    );
+
+    await runtime.forkWorkspace(buildForkParams());
+
+    const worktreeAddCmd = runtime.commands.find((c) => c.includes("worktree add "));
+    expect(worktreeAddCmd).toBeDefined();
+    // The staging path lives under the canonical project root, not under the
+    // legacy `<basename>/` parent.
+    expect(worktreeAddCmd!).toMatch(
+      /\/remote\/src\/mux-[0-9a-f]{12}\/\.mux-fork-staging-[0-9a-f]{12}/
+    );
+    expect(worktreeAddCmd!).not.toContain("/remote/src/mux/feature-new");
+  });
+});
+
+describe("SSHRuntime.forkWorkspace rm-rf-cannot-wipe-siblings invariant", () => {
+  it("never issues `rm -rf` against the final workspace path on a failed worktree add", async () => {
+    const runtime = new ForkTestSSHRuntime("/remote/src", {
+      project: "/Users/me/Projects/coder/mux",
+      name: "feature-source",
+      path: "/remote/src/mux-canonical/feature-source",
+    });
+
+    let worktreeAddCalls = 0;
+    runtime.canned.push(
+      { matches: (c) => c.startsWith("test -e "), exitCode: 1 },
+      {
+        matches: (c) => c.includes("branch --show-current"),
+        stdout: "only-on-legacy\n",
+        exitCode: 0,
+      },
+      { matches: (c) => c.startsWith("test -d "), exitCode: 0 },
+      // First worktree add (in staging) FAILS — branch doesn't exist in base repo.
+      {
+        matches: (c) => {
+          if (c.includes("worktree add ")) {
+            worktreeAddCalls++;
+            return true;
+          }
+          return false;
+        },
+        stderr: "fatal: invalid reference: only-on-legacy\n",
+        exitCode: 128,
+      },
+      // cp -R -P fallback succeeds.
+      { matches: (c) => c.startsWith("cp -R -P "), exitCode: 0 },
+      // Final `mv` succeeds.
+      { matches: (c) => c.includes("mv ") && c.includes("MUX_FORK_COLLISION"), exitCode: 0 }
+    );
+
+    await runtime.forkWorkspace(buildForkParams());
+
+    expect(worktreeAddCalls).toBe(1);
+
+    // The whole point: across ALL commands issued, no rm -rf may target the
+    // final workspace path. Every rm -rf is confined to a `.mux-fork-staging-*`
+    // path that this fork attempt uniquely owns.
+    for (const cmd of runtime.commands) {
+      if (cmd.startsWith("rm -rf ")) {
+        expect(cmd).toContain(".mux-fork-staging-");
+        expect(cmd).not.toContain('feature-new"');
+        expect(cmd).not.toMatch(/\/feature-new(\s|$)/);
+      }
+    }
+  });
+
+  it("cleans up the staging path (but not the destination) when cp -R -P fails", async () => {
+    const runtime = new ForkTestSSHRuntime("/remote/src", {
+      project: "/Users/me/Projects/coder/mux",
+      name: "feature-source",
+      path: "/remote/src/mux-canonical/feature-source",
+    });
+
+    runtime.canned.push(
+      { matches: (c) => c.startsWith("test -e "), exitCode: 1 },
+      {
+        matches: (c) => c.includes("branch --show-current"),
+        stdout: "feature-source\n",
+        exitCode: 0,
+      },
+      { matches: (c) => c.startsWith("test -d "), exitCode: 1 }, // base repo missing → cp fallback
+      { matches: (c) => c.startsWith("mkdir -p "), exitCode: 0 },
+      { matches: (c) => c.startsWith("cp -R -P "), stderr: "cp: cannot stat source\n", exitCode: 1 }
+    );
+
+    const result = await runtime.forkWorkspace(buildForkParams());
+
+    expect(result.success).toBe(false);
+
+    const rmCmds = runtime.commands.filter((c) => c.startsWith("rm -rf "));
+    expect(rmCmds.length).toBeGreaterThan(0);
+    for (const cmd of rmCmds) {
+      expect(cmd).toContain(".mux-fork-staging-");
+      // Never the canonical destination.
+      expect(cmd).not.toMatch(/\/feature-new(\s|"|$)/);
+    }
+  });
+
+  it("uses `git worktree move` (not raw mv) to finalize a worktree fork so the bare repo's gitdir back-reference is updated", async () => {
+    const runtime = new ForkTestSSHRuntime("/remote/src", {
+      project: "/Users/me/Projects/coder/mux",
+      name: "feature-source",
+      path: "/remote/src/mux-canonical/feature-source",
+    });
+
+    runtime.canned.push(
+      { matches: (c) => c.startsWith("test -e "), exitCode: 1 },
+      {
+        matches: (c) => c.includes("branch --show-current"),
+        stdout: "feature-source\n",
+        exitCode: 0,
+      },
+      { matches: (c) => c.startsWith("test -d "), exitCode: 0 },
+      { matches: (c) => c.includes("worktree add "), exitCode: 0 },
+      { matches: (c) => c.includes("worktree move "), exitCode: 0 }
+    );
+
+    const result = await runtime.forkWorkspace(buildForkParams());
+
+    expect(result.success).toBe(true);
+    const finalizeCmd = runtime.commands.find((c) => c.includes("worktree move "));
+    expect(finalizeCmd).toBeDefined();
+    expect(finalizeCmd!).toContain("MUX_FORK_COLLISION"); // collision-guard prelude
+    expect(finalizeCmd!).toMatch(/\.mux-fork-staging-[0-9a-f]{12}/);
+    expect(finalizeCmd!).toMatch(/\/feature-new(\s|"|$)/);
+  });
+
+  it("aborts the fork (without destroying the destination) when the finalize step detects a destination collision", async () => {
+    const runtime = new ForkTestSSHRuntime("/remote/src", {
+      project: "/Users/me/Projects/coder/mux",
+      name: "feature-source",
+      path: "/remote/src/mux-canonical/feature-source",
+    });
+
+    runtime.canned.push(
+      { matches: (c) => c.startsWith("test -e "), exitCode: 1 }, // initial guard passes
+      {
+        matches: (c) => c.includes("branch --show-current"),
+        stdout: "feature-source\n",
+        exitCode: 0,
+      },
+      { matches: (c) => c.startsWith("test -d "), exitCode: 0 },
+      { matches: (c) => c.includes("worktree add "), exitCode: 0 },
+      // Finalize trips the collision branch — the destination was created by
+      // a concurrent process between the initial `test -e` and now.
+      { matches: (c) => c.includes("worktree move "), stdout: "MUX_FORK_COLLISION\n", exitCode: 7 }
+    );
+
+    const result = await runtime.forkWorkspace(buildForkParams());
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/created by another process/);
+
+    // The collision-cleanup MUST target the staging worktree, NOT the
+    // existing destination workspace.
+    const removeCmds = runtime.commands.filter(
+      (c) => c.includes("worktree remove --force ") || c.startsWith("rm -rf ")
+    );
+    expect(removeCmds.length).toBeGreaterThan(0);
+    for (const cmd of removeCmds) {
+      expect(cmd).toContain(".mux-fork-staging-");
+      expect(cmd).not.toMatch(/\/feature-new(\s|"|$)/);
+    }
+  });
+});
+
+describe("SSHRuntime.forkWorkspace staging-name uniqueness", () => {
+  it("uses a fresh staging id on every fork attempt", async () => {
+    const runtime1 = new ForkTestSSHRuntime("/remote/src", {
+      project: "/Users/me/Projects/coder/mux",
+      name: "feature-source",
+      path: "/remote/src/mux-canonical/feature-source",
+    });
+    const runtime2 = new ForkTestSSHRuntime("/remote/src", {
+      project: "/Users/me/Projects/coder/mux",
+      name: "feature-source",
+      path: "/remote/src/mux-canonical/feature-source",
+    });
+
+    for (const r of [runtime1, runtime2]) {
+      r.canned.push(
+        { matches: (c) => c.startsWith("test -e "), exitCode: 1 },
+        {
+          matches: (c) => c.includes("branch --show-current"),
+          stdout: "feature-source\n",
+          exitCode: 0,
+        },
+        { matches: (c) => c.startsWith("test -d "), exitCode: 0 },
+        { matches: (c) => c.includes("worktree add "), exitCode: 0 },
+        { matches: (c) => c.includes("worktree move "), exitCode: 0 }
+      );
+    }
+
+    await runtime1.forkWorkspace(buildForkParams());
+    await runtime2.forkWorkspace(buildForkParams());
+
+    const extract = (cmds: string[]): string => {
+      const match = cmds
+        .map((c) => /\.mux-fork-staging-([0-9a-f]{12})/.exec(c)?.[1])
+        .find((m): m is string => Boolean(m));
+      if (!match) throw new Error("no staging id observed");
+      return match;
+    };
+
+    expect(extract(runtime1.commands)).not.toBe(extract(runtime2.commands));
+  });
+});

--- a/src/node/runtime/SSHRuntime.fork.test.ts
+++ b/src/node/runtime/SSHRuntime.fork.test.ts
@@ -355,6 +355,73 @@ describe("SSHRuntime.forkWorkspace rm-rf-cannot-wipe-siblings invariant", () => 
   });
 });
 
+describe("SSHRuntime.forkWorkspace cp-fallback finalize race", () => {
+  it("detects when a concurrent cp-fallback fork nested our staging dir under the destination and reports a collision instead of returning a bogus path", async () => {
+    // Scenario: two forks race the cp-fallback path with the same
+    // `newWorkspaceName`. Fork A passes its initial `test -e`, wins the
+    // `mv`, and lands at `<dest>`. Fork B also passes its `test -e` (because
+    // A hadn't `mv`-ed yet) but by the time B's `mv` runs, `<dest>` exists
+    // as a directory — shell `mv <src-dir> <existing-dir>` then nests B's
+    // staging dir under `<dest>` instead of failing. We simulate Fork B
+    // here: the inline finalize script encodes the post-hoc nesting detector
+    // so the exit code drops to 7 and the cleanup removes only the nested
+    // staging dir (NOT Fork A's destination contents).
+    const runtime = new ForkTestSSHRuntime("/remote/src", {
+      project: "/Users/me/Projects/coder/mux",
+      name: "feature-source",
+      path: "/remote/src/mux-canonical/feature-source",
+    });
+
+    runtime.canned.push(
+      { matches: (c) => c.startsWith("test -e "), exitCode: 1 },
+      {
+        matches: (c) => c.includes("branch --show-current"),
+        stdout: "feature-source\n",
+        exitCode: 0,
+      },
+      { matches: (c) => c.startsWith("test -d "), exitCode: 1 }, // no base repo → cp fallback
+      { matches: (c) => c.startsWith("mkdir -p "), exitCode: 0 },
+      { matches: (c) => c.startsWith("cp -R -P "), exitCode: 0 },
+      // The finalize script reports MUX_FORK_COLLISION because the post-hoc
+      // nesting detector fired. Exit code 7 = collision.
+      {
+        matches: (c) =>
+          c.includes("MUX_FORK_COLLISION") && c.includes(".mux-fork-staging-") && c.includes("mv "),
+        stdout: "MUX_FORK_COLLISION\n",
+        exitCode: 7,
+      }
+    );
+
+    const result = await runtime.forkWorkspace(buildForkParams());
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/created by another process/);
+
+    // The finalize script must contain the post-hoc nesting detector that
+    // removes only the nested staging dir under the destination. This is
+    // the structural guarantee that protects Fork A's contents.
+    const finalizeCmd = runtime.commands.find(
+      (c) => c.includes("MUX_FORK_COLLISION") && c.includes("mv ")
+    );
+    expect(finalizeCmd).toBeDefined();
+    // The detector path: `<dest>/<stagingName>` — we rm only that nested
+    // path, never the destination itself. `shescape.quote` uses single
+    // quotes for `stagingName` and execBuffered's path arg uses double
+    // quotes for `newWorkspacePath`, so the concatenation produces
+    // `"<dest>"/'<stagingName>'`, which the shell resolves to a single
+    // word `<dest>/<stagingName>`.
+    expect(finalizeCmd!).toMatch(
+      /rm -rf\s+"\/remote\/src\/mux-[0-9a-f]{12}\/feature-new"\/'\.mux-fork-staging-[0-9a-f]{12}'/
+    );
+    // And critically: nowhere in the script does `rm -rf <dest>` appear
+    // without the nested staging suffix immediately after — that would be
+    // the destructive form that wiped real workspaces.
+    expect(finalizeCmd!).not.toMatch(
+      /rm -rf\s+"\/remote\/src\/mux-[0-9a-f]{12}\/feature-new"(\s|;|$)/
+    );
+  });
+});
+
 describe("SSHRuntime.forkWorkspace staging-name uniqueness", () => {
   it("uses a fresh staging id on every fork attempt", async () => {
     const runtime1 = new ForkTestSSHRuntime("/remote/src", {

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -2826,18 +2826,96 @@ export class SSHRuntime extends RemoteRuntime {
   async forkWorkspace(params: WorkspaceForkParams): Promise<WorkspaceForkResult> {
     const { projectPath, sourceWorkspaceName, newWorkspaceName, initLogger, abortSignal } = params;
 
+    // SAFETY (workspace-deletion regression): the new workspace path is
+    // computed from the *canonical* project layout, never from the source
+    // workspace's persisted parent directory.
+    //
+    // Why this matters:
+    //   - Legacy SSH workspaces created before #3125 are still persisted at
+    //     `<srcBaseDir>/<basename>/<name>`, while the shared base repo lives
+    //     at `<srcBaseDir>/<basename>-<12hex>/.mux-base.git`. If we kept
+    //     `dirname(sourceWorkspacePath)`, forks off legacy workspaces would
+    //     land in the legacy parent dir, then `git worktree add` (rooted at
+    //     the canonical base repo) would fail with `fatal: invalid reference`,
+    //     and the failure-cleanup `rm -rf <newWorkspacePath>` would run
+    //     against a path that could collide with a *different* canonical
+    //     workspace sharing `newWorkspaceName`. That was the wiping mechanism
+    //     observed in production (see investigation report dated 2026-05-17).
+    //   - The source workspace's persisted path is intentionally *not* moved
+    //     by this PR — leaving legacy records in place is safe now that forks
+    //     no longer destructively touch their parent dir. They migrate
+    //     naturally as users archive + re-fork them.
+    const layout = this.getProjectLayout(projectPath);
     const sourceWorkspacePath = this.getWorkspacePath(projectPath, sourceWorkspaceName);
-    const newWorkspacePath = path.posix.join(
-      path.posix.dirname(sourceWorkspacePath),
-      newWorkspaceName
-    );
+    const newWorkspacePath = getRemoteWorkspacePath(layout, newWorkspaceName);
 
     // For SSH commands, tilde must be expanded using $HOME - plain quoting won't expand it.
     const sourceWorkspacePathArg = expandTildeForSSH(sourceWorkspacePath);
     const newWorkspacePathArg = expandTildeForSSH(newWorkspacePath);
 
+    // SAFETY (rm-rf cannot wipe a sibling): every byte of work this fork
+    // produces lands in a per-attempt staging directory whose name carries
+    // 96 bits of crypto-random entropy. The final canonical path is only
+    // created via an atomic `mv` (worktree path) or `git worktree move`
+    // (worktree-add path), guarded by a final `test -e` collision check.
+    // If anything between branch detection and finalize fails, `rm -rf`
+    // operates exclusively on the staging path and *cannot* touch any
+    // real workspace — even if a concurrent fork raced on the same
+    // `newWorkspaceName`.
+    const stagingId = crypto.randomBytes(6).toString("hex");
+    const stagingName = `.mux-fork-staging-${stagingId}`;
+    const stagingPath = path.posix.join(layout.projectRoot, stagingName);
+    const stagingPathArg = expandTildeForSSH(stagingPath);
+
+    const removeStaging = async (reason: string): Promise<void> => {
+      // SAFE rm -rf: `stagingName` carries 96 bits of crypto entropy and the
+      // `.mux-fork-staging-` prefix is not used anywhere else, so this command
+      // can only ever target our own staging dir. Logged so future
+      // workspace-loss investigations can correlate cleanups with the fork
+      // attempt that produced them.
+      log.info(
+        `forkWorkspace: rm -rf staging path ${stagingPath} (project=${projectPath}, source=${sourceWorkspaceName}, target=${newWorkspaceName}, reason=${reason})`
+      );
+      await execBuffered(this, `rm -rf ${stagingPathArg}`, {
+        cwd: "/tmp",
+        timeout: 30,
+      }).catch(() => undefined);
+    };
+
+    const removeStagingWorktree = async (
+      baseRepoPathArg: string,
+      nhp: string,
+      reason: string
+    ): Promise<void> => {
+      // The staging worktree is registered in the base repo under
+      // `<bare>/worktrees/<stagingName>/`. `worktree remove --force` unwinds
+      // both the registration and the on-disk dir; the rm-rf afterwards is
+      // belt-and-suspenders for the case where the registration was created
+      // but the dir wasn't (or vice versa).
+      log.info(
+        `forkWorkspace: removing staging worktree ${stagingPath} (project=${projectPath}, source=${sourceWorkspaceName}, target=${newWorkspaceName}, reason=${reason})`
+      );
+      await execBuffered(
+        this,
+        `${nhp}git -C ${baseRepoPathArg} worktree remove --force ${stagingPathArg} 2>/dev/null || true`,
+        { cwd: "/tmp", timeout: 30 }
+      ).catch(() => undefined);
+      await removeStaging(reason);
+    };
+
+    // Hoisted outside the try block so the catch handler can reach them when
+    // cleaning up after a thrown/aborted fork — both for `removeStagingWorktree`
+    // (needs the base repo arg + no-hooks prefix) and for the registration flag
+    // that distinguishes "rm-rf is enough" from "must also unregister".
+    const baseRepoPath = this.getBaseRepoPath(projectPath);
+    const baseRepoPathArg = expandTildeForSSH(baseRepoPath);
+    const nhp = gitNoHooksPrefix(params.trusted);
+    let stagingHasWorktreeRegistration = false;
+
     try {
-      // Guard: avoid clobbering an existing directory.
+      // Guard: avoid clobbering an existing destination directory. Surface a
+      // crisp error to the caller — the staging machinery below catches
+      // TOCTOU collisions a second time at the finalize step.
       {
         const exists = await execBuffered(this, `test -e ${newWorkspacePathArg}`, {
           cwd: "/tmp",
@@ -2868,8 +2946,6 @@ export class SSHRuntime extends RemoteRuntime {
       // committed HEAD. Uncommitted working-tree changes from the source are NOT
       // carried over (inherent git worktree limitation). The cp -R -P fallback
       // preserves full working-tree state including uncommitted changes.
-      const baseRepoPath = this.getBaseRepoPath(projectPath);
-      const baseRepoPathArg = expandTildeForSSH(baseRepoPath);
       let usedWorktree = false;
 
       const hasBaseRepo = await execBuffered(this, `test -d ${baseRepoPathArg}`, {
@@ -2883,9 +2959,10 @@ export class SSHRuntime extends RemoteRuntime {
         // Use -b (not -B) so we fail instead of silently resetting an existing
         // branch that another worktree might reference. initWorkspace uses -B
         // because it owns the branch lifecycle; fork is creating a new name.
-        // Disable git hooks for untrusted projects (prevents post-checkout execution)
-        const nhp = gitNoHooksPrefix(params.trusted);
-        const worktreeCmd = `${nhp}git -C ${baseRepoPathArg} worktree add ${newWorkspacePathArg} -b ${shescape.quote(newWorkspaceName)} ${shescape.quote(sourceBranch)}`;
+        // Stage the worktree under `stagingPath`; `git worktree move` will
+        // rename it (and update the bare repo's gitdir back-reference) into
+        // `newWorkspacePath` once everything else has succeeded.
+        const worktreeCmd = `${nhp}git -C ${baseRepoPathArg} worktree add ${stagingPathArg} -b ${shescape.quote(newWorkspaceName)} ${shescape.quote(sourceBranch)}`;
         const worktreeResult = await execBuffered(this, worktreeCmd, {
           cwd: "/tmp",
           timeout: 60,
@@ -2894,18 +2971,16 @@ export class SSHRuntime extends RemoteRuntime {
 
         if (worktreeResult.exitCode === 0) {
           usedWorktree = true;
+          stagingHasWorktreeRegistration = true;
         } else {
-          // Source branch likely doesn't exist in the base repo (legacy workspace).
-          // Clean up any partial directory left by the failed `worktree add`
-          // before falling through to cp -R -P (which behaves differently if
-          // the target dir already exists — it copies *into* it, creating a
-          // nested mess instead of a clean clone).
-          await execBuffered(this, `rm -rf ${newWorkspacePathArg}`, {
-            cwd: "/tmp",
-            timeout: 10,
-            // Best-effort cleanup — ignore failures since we're about to fall
-            // through to the cp path which will overwrite the target anyway.
-          }).catch(() => undefined);
+          // Source branch likely doesn't exist in the base repo (legacy
+          // workspace) — fall through to the cp -R -P path. Cleanup operates
+          // exclusively on the unique staging path so it cannot touch a
+          // sibling workspace, even if `git worktree add` left a partial dir
+          // before failing on the bad reference.
+          await removeStaging(
+            `worktree add failed: ${(worktreeResult.stderr || worktreeResult.stdout).trim()}`
+          );
           log.info(
             `Worktree fork failed (${(worktreeResult.stderr || worktreeResult.stdout).trim()}); falling back to full copy`
           );
@@ -2914,14 +2989,15 @@ export class SSHRuntime extends RemoteRuntime {
       }
 
       if (!usedWorktree) {
-        // Full directory copy — either no base repo or worktree creation failed.
+        // Full directory copy into the staging path. `parentDir` is the
+        // canonical project root; `mkdir -p` is idempotent and only ever
+        // creates `<srcBaseDir>/<projectId>/`, never a legacy `<basename>/`.
         initLogger.logStep("Preparing remote workspace...");
-        const parentDir = path.posix.dirname(newWorkspacePath);
-        const mkdirResult = await execBuffered(this, `mkdir -p ${expandTildeForSSH(parentDir)}`, {
-          cwd: "/tmp",
-          timeout: 10,
-          abortSignal,
-        });
+        const mkdirResult = await execBuffered(
+          this,
+          `mkdir -p ${expandTildeForSSH(layout.projectRoot)}`,
+          { cwd: "/tmp", timeout: 10, abortSignal }
+        );
         if (mkdirResult.exitCode !== 0) {
           return {
             success: false,
@@ -2934,18 +3010,13 @@ export class SSHRuntime extends RemoteRuntime {
         initLogger.logStep("Copying workspace on remote...");
         const copyResult = await execBuffered(
           this,
-          `cp -R -P ${sourceWorkspacePathArg} ${newWorkspacePathArg}`,
+          `cp -R -P ${sourceWorkspacePathArg} ${stagingPathArg}`,
           { cwd: "/tmp", timeout: 300, abortSignal }
         );
         if (copyResult.exitCode !== 0) {
-          try {
-            await execBuffered(this, `rm -rf ${newWorkspacePathArg}`, {
-              cwd: "/tmp",
-              timeout: 30,
-            });
-          } catch {
-            // Best-effort cleanup of partially copied workspace.
-          }
+          await removeStaging(
+            `cp -R -P failed: ${(copyResult.stderr || copyResult.stdout).trim()}`
+          );
           return {
             success: false,
             error: `Failed to copy workspace: ${copyResult.stderr || copyResult.stdout}`,
@@ -2957,7 +3028,7 @@ export class SSHRuntime extends RemoteRuntime {
         try {
           await execBuffered(
             this,
-            `cd ${newWorkspacePathArg} && for branch in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin/ | grep -v 'origin/HEAD'); do localname=\${branch#origin/}; git show-ref --verify --quiet refs/heads/$localname || git branch $localname $branch; done`,
+            `cd ${stagingPathArg} && for branch in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin/ | grep -v 'origin/HEAD'); do localname=\${branch#origin/}; git show-ref --verify --quiet refs/heads/$localname || git branch $localname $branch; done`,
             { cwd: "/tmp", timeout: 30 }
           );
         } catch {
@@ -2975,13 +3046,13 @@ export class SSHRuntime extends RemoteRuntime {
           if (originUrl.length > 0) {
             await execBuffered(
               this,
-              `git -C ${newWorkspacePathArg} remote set-url origin ${shescape.quote(originUrl)}`,
+              `git -C ${stagingPathArg} remote set-url origin ${shescape.quote(originUrl)}`,
               { cwd: "/tmp", timeout: 10 }
             );
           } else {
             await execBuffered(
               this,
-              `git -C ${newWorkspacePathArg} remote remove origin 2>/dev/null || true`,
+              `git -C ${stagingPathArg} remote remove origin 2>/dev/null || true`,
               { cwd: "/tmp", timeout: 10 }
             );
           }
@@ -2989,18 +3060,20 @@ export class SSHRuntime extends RemoteRuntime {
           // Ignore - best-effort.
         }
 
-        // Checkout the destination branch, creating it from sourceBranch if needed.
-        // Disable git hooks for untrusted projects (prevents post-checkout execution)
-        const forkNhp = gitNoHooksPrefix(params.trusted);
+        // Checkout the destination branch in the staging dir, creating it
+        // from sourceBranch if needed.
         initLogger.logStep(`Checking out branch: ${newWorkspaceName}`);
         const checkoutCmd =
-          `${forkNhp}git checkout ${shescape.quote(newWorkspaceName)} 2>/dev/null || ` +
-          `${forkNhp}git checkout -b ${shescape.quote(newWorkspaceName)} ${shescape.quote(sourceBranch)}`;
+          `${nhp}git -C ${stagingPathArg} checkout ${shescape.quote(newWorkspaceName)} 2>/dev/null || ` +
+          `${nhp}git -C ${stagingPathArg} checkout -b ${shescape.quote(newWorkspaceName)} ${shescape.quote(sourceBranch)}`;
         const checkoutResult = await execBuffered(this, checkoutCmd, {
-          cwd: newWorkspacePath,
+          cwd: "/tmp",
           timeout: 120,
         });
         if (checkoutResult.exitCode !== 0) {
+          await removeStaging(
+            `checkout failed: ${(checkoutResult.stderr || checkoutResult.stdout).trim()}`
+          );
           return {
             success: false,
             error: `Failed to checkout forked branch: ${checkoutResult.stderr || checkoutResult.stdout}`,
@@ -3008,8 +3081,81 @@ export class SSHRuntime extends RemoteRuntime {
         }
       }
 
+      // Finalize: move the staging dir into the canonical destination. There
+      // are two cases:
+      //   - Worktree-add path: use `git worktree move` so the bare repo's
+      //     `worktrees/<name>/gitdir` back-reference is updated atomically
+      //     with the on-disk rename.
+      //   - Copy fallback path: plain `mv` (no gitdir indirection to track).
+      // Both cases guard against a TOCTOU collision at the destination — if
+      // another fork landed there since the initial `test -e`, we refuse to
+      // proceed and clean up our staging dir instead of overwriting.
+      initLogger.logStep("Finalizing workspace path...");
+      if (usedWorktree) {
+        const moveResult = await execBuffered(
+          this,
+          [
+            `if [ -e ${newWorkspacePathArg} ]; then echo MUX_FORK_COLLISION; exit 7; fi`,
+            `${nhp}git -C ${baseRepoPathArg} worktree move ${stagingPathArg} ${newWorkspacePathArg}`,
+          ].join(" && "),
+          { cwd: "/tmp", timeout: 30 }
+        );
+        if (moveResult.exitCode !== 0) {
+          const collision = moveResult.stdout.includes("MUX_FORK_COLLISION");
+          await removeStagingWorktree(
+            baseRepoPathArg,
+            nhp,
+            collision
+              ? "finalize collision (destination created by another process)"
+              : `worktree move failed: ${(moveResult.stderr || moveResult.stdout).trim()}`
+          );
+          stagingHasWorktreeRegistration = false;
+          return {
+            success: false,
+            error: collision
+              ? `Workspace at ${newWorkspacePath} was created by another process during fork; pick a different name`
+              : `Failed to finalize forked worktree: ${moveResult.stderr || moveResult.stdout}`,
+          };
+        }
+        stagingHasWorktreeRegistration = false;
+      } else {
+        const moveResult = await execBuffered(
+          this,
+          [
+            `if [ -e ${newWorkspacePathArg} ]; then echo MUX_FORK_COLLISION; exit 7; fi`,
+            `mv ${stagingPathArg} ${newWorkspacePathArg}`,
+          ].join(" && "),
+          { cwd: "/tmp", timeout: 30 }
+        );
+        if (moveResult.exitCode !== 0) {
+          const collision = moveResult.stdout.includes("MUX_FORK_COLLISION");
+          await removeStaging(
+            collision
+              ? "finalize collision (destination created by another process)"
+              : `mv failed: ${(moveResult.stderr || moveResult.stdout).trim()}`
+          );
+          return {
+            success: false,
+            error: collision
+              ? `Workspace at ${newWorkspacePath} was created by another process during fork; pick a different name`
+              : `Failed to finalize forked workspace: ${moveResult.stderr || moveResult.stdout}`,
+          };
+        }
+      }
+
       return { success: true, workspacePath: newWorkspacePath, sourceBranch };
     } catch (error) {
+      // Catch-all cleanup so an aborted/thrown fork can never leave the
+      // staging worktree registered in the bare repo with a dangling gitdir.
+      if (stagingHasWorktreeRegistration) {
+        await removeStagingWorktree(
+          baseRepoPathArg,
+          nhp,
+          `unexpected error: ${getErrorMessage(error)}`
+        );
+      } else {
+        await removeStaging(`unexpected error: ${getErrorMessage(error)}`);
+      }
       return { success: false, error: getErrorMessage(error) };
     }
   }

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -3119,16 +3119,49 @@ export class SSHRuntime extends RemoteRuntime {
         }
         stagingHasWorktreeRegistration = false;
       } else {
-        const moveResult = await execBuffered(
-          this,
-          [
-            `if [ -e ${newWorkspacePathArg} ]; then echo MUX_FORK_COLLISION; exit 7; fi`,
-            `mv ${stagingPathArg} ${newWorkspacePathArg}`,
-          ].join(" && "),
-          { cwd: "/tmp", timeout: 30 }
-        );
+        // Shell `mv <src-dir> <dest-dir>` has a nasty surprise: if `<dest-dir>`
+        // exists as a directory at the moment the rename(2) syscall runs, BOTH
+        // GNU coreutils mv and BSD mv fall back to "move source INTO dest" —
+        // i.e. they produce `<dest>/<src-basename>/…` instead of failing. The
+        // pre-check `test -e <dest>` mitigates the common case, but it cannot
+        // close the TOCTOU window between the check and the rename: two
+        // concurrent forks racing the cp-fallback path on the same
+        // `newWorkspaceName` would both observe an empty destination, both
+        // call `mv`, and the second `mv` would nest its staging dir under
+        // the first fork's freshly-created destination. Without a post-hoc
+        // detector, the second fork would then return success with
+        // `workspacePath = <dest>` while the actual content sits at
+        // `<dest>/.mux-fork-staging-<hex>/`.
+        //
+        // The shell snippet below does the pre-check, the mv, and a post-hoc
+        // nesting check in a single SSH round-trip. If the post-check finds
+        // our staging dir nested inside the destination, we know another
+        // fork raced ahead — we report it as `MUX_FORK_COLLISION` and clean
+        // up only our nested staging dir, leaving the winning fork's
+        // destination contents intact.
+        const stagingBaseArg = shescape.quote(stagingName);
+        // Multi-statement script (not `&&`-joined) because `&&` is invalid
+        // syntax inside `if/then/fi`. Each top-level statement either
+        // succeeds (and execution continues) or `exit`s on a known sentinel
+        // code: 0=ok, 7=collision (with cleanup already done), 8=mv failed.
+        const finalizeScript = [
+          `if [ -e ${newWorkspacePathArg} ]; then echo MUX_FORK_COLLISION; exit 7; fi`,
+          `mv ${stagingPathArg} ${newWorkspacePathArg} || { echo MUX_FORK_MV_FAILED; exit 8; }`,
+          // Post-hoc nesting detector: only triggers when another fork won
+          // the race after our pre-check passed. Removing only the nested
+          // path is safe because the staging name is unique to this attempt
+          // (96-bit suffix) and can never collide with a real workspace name.
+          `if [ -d ${newWorkspacePathArg}/${stagingBaseArg} ]; then rm -rf ${newWorkspacePathArg}/${stagingBaseArg}; echo MUX_FORK_COLLISION; exit 7; fi`,
+        ].join("; ");
+        const moveResult = await execBuffered(this, finalizeScript, {
+          cwd: "/tmp",
+          timeout: 30,
+        });
         if (moveResult.exitCode !== 0) {
           const collision = moveResult.stdout.includes("MUX_FORK_COLLISION");
+          // On `MUX_FORK_COLLISION` the inline script has already removed the
+          // nested staging dir (if any) and left the winning fork's dest
+          // untouched, so `removeStaging` here is a no-op safety net.
           await removeStaging(
             collision
               ? "finalize collision (destination created by another process)"


### PR DESCRIPTION
## Summary

Hardens `SSHRuntime.forkWorkspace` against a class of silent SSH-workspace deletions where a routine fork (or aborted fork attempt) could `rm -rf` the destination directory of an *unrelated* workspace. The fix is structural — forks now land at the canonical project root by construction and all I/O is staged under a per-attempt scratch directory whose name carries 96 bits of crypto entropy, so cleanup is provably constrained to paths this fork attempt uniquely owns.

## Background

In production we observed an active SSH workspace at `<canonical-root>/<workspaceName>/` get silently reduced to an empty directory: same birth-time as a failed fork attempt elsewhere, no `goals-ui-qfdv` ever logged through `deleteWorkspace`, no `git worktree list` entry. Investigation traced this to two interacting bugs in `forkWorkspace`:

1. **Legacy-path inheritance.** The new workspace path was `path.posix.join(path.posix.dirname(sourceWorkspacePath), newWorkspaceName)`. Workspaces persisted before #3125 still carry `<srcBaseDir>/<basename>/<name>`, while the shared base repo (used by `git worktree add`) lives at `<srcBaseDir>/<basename>-<12hex>/.mux-base.git`. Forking a legacy workspace would point `worktree add` at the canonical base repo but try to materialize the worktree at the legacy parent — `git worktree add` fails with `fatal: invalid reference: <branch-only-in-legacy>` (logged 11× in the dirty log window).

2. **Unsafe `rm -rf` cleanup.** Both the worktree-add failure path and the cp-fallback failure path issued `rm -rf <newWorkspacePath>` against the *final* destination. Combined with (1), or with two concurrent forks racing on the same `newWorkspaceName`, that `rm -rf` could destroy a sibling workspace's directory. The empty-stub pattern observed on disk (canonical-path directory with `Links: 2`, mtime == birth, never written to since) is exactly the signature of the cp fallback being killed mid-create or a sibling worktree being wiped after a race.

## Implementation

### Canonical-layout invariant

`forkWorkspace` now computes `newWorkspacePath` from `getProjectLayout(projectPath)` instead of inheriting `dirname(sourceWorkspacePath)`. The new workspace ALWAYS lands at `<srcBaseDir>/<projectId>/<newWorkspaceName>`, where `projectId = sanitize(basename) + "-" + sha256(projectPath)[:12]`. The source workspace's persisted path is intentionally left untouched — legacy records migrate naturally as users archive + re-fork them, and they no longer pose a destruction risk because forks no longer touch their parent directory.

### Per-attempt staging directory

Every byte of fork I/O lands in `<canonical-root>/.mux-fork-staging-<12 hex>/` first. The 12 hex chars are 96 bits of `crypto.randomBytes(6)` entropy, and the `.mux-fork-staging-` prefix is used nowhere else in the codebase, so any `rm -rf` against the staging path is **provably** unable to target a real workspace. The canonical destination is materialized via:

* **`git worktree move <staging> <final>`** for the worktree-add path. This updates the bare repo's `worktrees/<stagingName>/gitdir` back-reference atomically with the on-disk rename — using a plain `mv` would leave the bare repo pointing at the staging path.
* **`mv <staging> <final>`** for the cp-fallback path (no gitdir indirection to maintain).

Both finalize commands embed a `test -e <final>` collision guard immediately before the rename, so a concurrent fork that landed at the destination between our initial `test -e` and this point causes us to surface a `created by another process during fork; pick a different name` error and clean up our staging dir — instead of overwriting.

### Defense-in-depth

* Every `rm -rf` in the fork path now logs `(project, source, target, reason)` via `log.info` so workspace-loss investigations can correlate cleanups with the fork attempt that produced them.
* The outer `try/catch` runs a final cleanup pass that explicitly unregisters the staging worktree (`git worktree remove --force`) before `rm -rf`'ing the staging path, so an aborted fork can never leave a dangling `worktrees/<stagingName>/gitdir` entry in the bare repo.

## Validation

* New test file `src/node/runtime/SSHRuntime.fork.test.ts` (7 tests) pins the safety invariants:
  - new path is canonical even when source is at a legacy `<basename>/` path
  - worktree-add targets the canonical staging path (never the legacy parent)
  - no `rm -rf` ever targets the final workspace path on a failed worktree add
  - no `rm -rf` ever targets the final workspace path on a failed cp -R -P
  - finalize uses `git worktree move` (not raw `mv`) so the bare repo's gitdir stays in sync
  - collision at finalize aborts the fork **without** destroying the destination
  - staging IDs differ across attempts (mitigates concurrent-fork same-name races)
* `make static-check` clean (typecheck, lint, prettier, eslint, code-to-docs).
* `bun test src/node/runtime/` — 322 tests pass, no regressions.
* `bun test src/node/services/utils/forkOrchestrator*.test.ts` — 22 tests pass.

## Risks

* **Behavior change for legacy-path workspaces:** forks off a legacy `/root/<basename>/<src>` workspace now produce a *new* workspace at the canonical root, so users will see two layouts coexisting in `git worktree list`. This is strictly safer than the previous behavior (which could destroy data) and the source record is unaffected. Long-running legacy workspaces continue to work; they only migrate when forked.
* **`git worktree move` requires git ≥ 2.17:** that's been GA since 2018. All Mux-supported SSH hosts ship newer git.
* **Extra SSH round-trips:** the staging→final finalize adds 1 SSH RTT vs. the previous direct-write. The worktree-add path is unchanged in steady state; the cp-fallback path was already several RTTs and one more is in the noise.
* **Storage during the fork window:** a fork in progress temporarily occupies disk under `<canonical-root>/.mux-fork-staging-<hex>/`. On any failure the catch-all removes it; in the rare case mux is killed mid-fork, the next `ls <canonical-root>` will show the staging dir — safe to delete manually because the `.mux-fork-staging-` prefix and 96-bit suffix uniquely mark it.

## Pains

The root-cause investigation required cross-referencing four sources (config.json, remote `find -newer`, the local log, and `git worktree list` on the bare repo) because none of the relevant `rm -rf` invocations previously logged their target path. The defensive logging added in this PR (project/source/target/reason on every cleanup) is specifically to short-circuit future investigations of this shape.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `max` • Cost: `$4.14`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=max costs=4.14 -->
