### PR TITLE
🤖 fix: align /goal budget syntax

### DIFF
--- a/src/browser/features/ChatInput/useCreationWorkspace.test.tsx
+++ b/src/browser/features/ChatInput/useCreationWorkspace.test.tsx
@@ -768,7 +768,7 @@ describe("useCreationWorkspace", () => {
     const getHook = renderUseCreationWorkspace({
       projectPath: TEST_PROJECT_PATH,
       onWorkspaceCreated,
-      message: "/goal ship the feature --no-budget",
+      message: "/goal -b 5 ship the feature",
     });
 
     await waitFor(() => expect(getHook().branches).toEqual([FALLBACK_BRANCH]));
@@ -778,7 +778,7 @@ describe("useCreationWorkspace", () => {
       handleSendResult = await getHook().handleSend("ship the feature", undefined, undefined, {
         type: "goal-set",
         objective: "ship the feature",
-        budgetCents: null,
+        budgetCents: 500,
       });
     });
 
@@ -796,7 +796,7 @@ describe("useCreationWorkspace", () => {
     expect(workspaceApi.setGoal).toHaveBeenCalledWith({
       workspaceId: TEST_WORKSPACE_ID,
       objective: "ship the feature",
-      budgetCents: null,
+      budgetCents: 500,
       turnCap: null,
       expectedGoalId: null,
     });

--- a/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
+++ b/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
@@ -22,7 +22,7 @@ function slashInvocation(skill: AgentSkillDescriptor): SkillInvocation {
 }
 
 describe("parseCommandWithSkillInvocation", () => {
-  test("does not treat known-command flag errors as slash skill invocations", async () => {
+  test("does not treat known-command goal text as slash skill invocation", async () => {
     const result = await parseCommandWithSkillInvocation({
       messageText: "/goal --bogus\nBody",
       agentSkillDescriptors: [descriptor("goal")],
@@ -31,10 +31,9 @@ describe("parseCommandWithSkillInvocation", () => {
     });
 
     expect(result.skillInvocation).toBeNull();
-    expect(result.parsed).toMatchObject({
-      type: "command-unknown-flag",
-      command: "goal",
-      flag: "--bogus",
+    expect(result.parsed).toEqual({
+      type: "goal-set",
+      objective: "--bogus\nBody",
     });
   });
 });

--- a/src/browser/utils/chatCommands.test.ts
+++ b/src/browser/utils/chatCommands.test.ts
@@ -399,8 +399,7 @@ describe("processSlashCommand - model-set", () => {
     expect(context.setToast).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "error",
-        message:
-          "Target model has no pricing data. Pick a priced model or remove the active goal budget with /goal budget --no-budget before switching.",
+        message: "Target model has no pricing data. Pick a priced model before switching.",
       })
     );
   });
@@ -725,7 +724,7 @@ describe("processSlashCommand - goal lifecycle commands", () => {
       expect.objectContaining({
         type: "error",
         message:
-          "Current model has no pricing data. Pick a priced model, set --no-budget, or rely on --turns N only.",
+          "Current model has no pricing data. Pick a priced model, use -b 0 with a turn cap, or change goal budget defaults in Settings.",
       })
     );
   });
@@ -954,7 +953,7 @@ describe("processSlashCommand - goal budgets", () => {
       expect.objectContaining({
         type: "error",
         message:
-          "Current model has no pricing data. Pick a priced model, set --no-budget, or rely on --turns N only.",
+          "Current model has no pricing data. Pick a priced model, use -b 0 with a turn cap, or change goal budget defaults in Settings.",
       })
     );
   });

--- a/src/browser/utils/slashCommands/goal.test.ts
+++ b/src/browser/utils/slashCommands/goal.test.ts
@@ -24,13 +24,13 @@ describe("/goal slash command", () => {
     });
   });
 
-  test("parses budget flags on goal creation", () => {
-    expect(parseCommand('/goal "ship the slice" --budget $5')).toEqual({
+  test("parses a leading budget flag on goal creation", () => {
+    expect(parseCommand('/goal -b $5 "ship the slice"')).toEqual({
       type: "goal-set",
       objective: "ship the slice",
       budgetCents: 500,
     });
-    expect(parseCommand('/goal "ship the slice" --budget $5.00')).toEqual({
+    expect(parseCommand('/goal -b $5.00 "ship the slice"')).toEqual({
       type: "goal-set",
       objective: "ship the slice",
       budgetCents: 500,
@@ -38,25 +38,20 @@ describe("/goal slash command", () => {
     // Bare numbers accept dollar amounts (Coder-agents-review P3 DEREM-21).
     // `5` and `5.00` parse identically to `$5` / `$5.00` so the GoalTab
     // editor and the slash command behave the same.
-    expect(parseCommand('/goal "ship the slice" --budget 5')).toEqual({
+    expect(parseCommand("/goal -b 5 ship the slice")).toEqual({
       type: "goal-set",
       objective: "ship the slice",
       budgetCents: 500,
     });
-    expect(parseCommand('/goal "ship the slice" --budget 5.00')).toEqual({
+    expect(parseCommand("/goal -b 5.00 ship the slice")).toEqual({
       type: "goal-set",
       objective: "ship the slice",
       budgetCents: 500,
     });
-    expect(parseCommand('/goal "ship the slice" --budget 500c')).toEqual({
+    expect(parseCommand("/goal -b 500c ship the slice")).toEqual({
       type: "goal-set",
       objective: "ship the slice",
       budgetCents: 500,
-    });
-    expect(parseCommand('/goal "ship the slice" --no-budget')).toEqual({
-      type: "goal-set",
-      objective: "ship the slice",
-      budgetCents: null,
     });
   });
 
@@ -67,22 +62,38 @@ describe("/goal slash command", () => {
     });
   });
 
-  test("parses header flags while preserving flag-looking body prose", () => {
-    expect(
-      parseCommand("/goal --budget $5 --turns 25\nShip it\n--budget stays prose\n- bullet")
-    ).toEqual({
+  test("uses leading budget flag while preserving flag-looking body prose", () => {
+    expect(parseCommand("/goal -b $5\nShip it\n--budget stays prose\n- bullet")).toEqual({
       type: "goal-set",
       objective: "Ship it\n--budget stays prose\n- bullet",
       budgetCents: 500,
-      turnCap: 25,
     });
   });
 
-  test("rejects unknown goal creation flags as known-command flag errors", () => {
-    expect(parseCommand("/goal --bogus\nBody")).toMatchObject({
-      type: "command-unknown-flag",
-      command: "goal",
-      flag: "--bogus",
+  test("treats non-leading flag-looking tokens as goal text", () => {
+    expect(parseCommand('/goal "ship the slice" --budget $5')).toEqual({
+      type: "goal-set",
+      objective: "ship the slice --budget $5",
+    });
+    expect(parseCommand("/goal ship the slice -b 5")).toEqual({
+      type: "goal-set",
+      objective: "ship the slice -b 5",
+    });
+    expect(parseCommand("/goal --no-budget ship the slice")).toEqual({
+      type: "goal-set",
+      objective: "--no-budget ship the slice",
+    });
+    expect(parseCommand("/goal ship the slice --no-budget")).toEqual({
+      type: "goal-set",
+      objective: "ship the slice --no-budget",
+    });
+    expect(parseCommand('/goal "ship the slice" --turns 25')).toEqual({
+      type: "goal-set",
+      objective: "ship the slice --turns 25",
+    });
+    expect(parseCommand("/goal --bogus\nBody")).toEqual({
+      type: "goal-set",
+      objective: "--bogus\nBody",
     });
   });
 
@@ -97,27 +108,30 @@ describe("/goal slash command", () => {
     });
   });
 
-  test("parses turn cap on goal creation", () => {
-    expect(parseCommand('/goal "ship the slice" --turns 25')).toEqual({
+  test("parses turn cap in the leading flag prefix", () => {
+    expect(parseCommand('/goal --turns 25 "ship the slice"')).toEqual({
       type: "goal-set",
       objective: "ship the slice",
       turnCap: 25,
     });
+    expect(parseCommand('/goal -b $5 --turns 25 "ship the slice"')).toEqual({
+      type: "goal-set",
+      objective: "ship the slice",
+      budgetCents: 500,
+      turnCap: 25,
+    });
   });
 
-  test("rejects invalid budget and turn flags", () => {
-    // DEREM-21 unified the parser; bare numbers (e.g. `--budget 5`) are
-    // now valid. The remaining invalid forms are: non-numeric garbage,
-    // conflicting `--budget` + `--no-budget`, and zero/negative turn caps.
-    expect(parseCommand('/goal "ship" --budget abc')).toMatchObject({
+  test("rejects invalid leading flags", () => {
+    expect(parseCommand("/goal -b abc ship")).toMatchObject({
       type: "command-invalid-args",
       command: "goal",
     });
-    expect(parseCommand('/goal "ship" --budget $5 --no-budget')).toMatchObject({
-      type: "command-invalid-args",
+    expect(parseCommand("/goal -b")).toMatchObject({
+      type: "command-missing-args",
       command: "goal",
     });
-    expect(parseCommand('/goal "ship" --turns 0')).toMatchObject({
+    expect(parseCommand("/goal --turns 0 ship")).toMatchObject({
       type: "command-invalid-args",
       command: "goal",
     });
@@ -143,15 +157,15 @@ describe("/goal slash command", () => {
     expect(parseCommand("/goal budget 5")).toEqual({ type: "goal-budget", budgetCents: 500 });
     expect(parseCommand("/goal budget 5.00")).toEqual({ type: "goal-budget", budgetCents: 500 });
     expect(parseCommand("/goal budget 500c")).toEqual({ type: "goal-budget", budgetCents: 500 });
-    expect(parseCommand("/goal budget --no-budget")).toEqual({
-      type: "goal-budget",
-      budgetCents: null,
-    });
   });
 
   test("rejects invalid budget update command", () => {
     // Non-numeric / malformed input still rejects after DEREM-21 — the
     // unified parser only loosened the dollar-prefix requirement.
+    expect(parseCommand("/goal budget --no-budget")).toMatchObject({
+      type: "command-invalid-args",
+      command: "goal",
+    });
     expect(parseCommand("/goal budget abc")).toMatchObject({
       type: "command-invalid-args",
       command: "goal",

--- a/src/browser/utils/slashCommands/registry.ts
+++ b/src/browser/utils/slashCommands/registry.ts
@@ -501,7 +501,7 @@ function parseGoalTurnCap(value: unknown): number | null {
 }
 
 const GOAL_USAGE = `/goal ${SLASH_COMMAND_HINTS.goal}`;
-const GOAL_BUDGET_USAGE = "/goal budget $5|500c|--no-budget";
+const GOAL_BUDGET_USAGE = "/goal budget <amount>";
 
 function invalidGoalBodyArgs(
   body: string
@@ -595,9 +595,6 @@ const goalCommandDefinition: SlashCommandDefinition = {
           usage: GOAL_BUDGET_USAGE,
         };
       }
-      if (budgetTokens[0] === "--no-budget") {
-        return { type: "goal-budget", budgetCents: null };
-      }
       const budgetCents = parseGoalBudgetCents(budgetTokens[0]);
       if (budgetCents == null) {
         return {
@@ -610,27 +607,55 @@ const goalCommandDefinition: SlashCommandDefinition = {
       return { type: "goal-budget", budgetCents };
     }
 
-    const noBudget = headerTokens.includes("--no-budget");
-    const parsed = minimist(
-      headerTokens.filter((token) => token !== "--no-budget"),
-      {
-        string: ["budget", "turns"],
-        unknown: (arg: string) => !arg.startsWith("-"),
+    let budgetCents: number | undefined;
+    let turnCap: number | undefined;
+    let objectiveStartIndex = 0;
+
+    if (headerTokens[0] === "-b") {
+      const budgetInput = headerTokens[1];
+      if (budgetInput == null) {
+        return {
+          type: "command-missing-args",
+          command: "goal",
+          usage: GOAL_USAGE,
+        };
       }
-    );
-    const unknownFlag = headerTokens.find((token) => {
-      return (
-        token.startsWith("-") &&
-        token !== "--budget" &&
-        token !== "--no-budget" &&
-        token !== "--turns"
-      );
-    });
-    if (unknownFlag) {
-      return unknownGoalFlag(unknownFlag);
+
+      const parsedBudgetCents = parseGoalBudgetCents(budgetInput);
+      if (parsedBudgetCents == null) {
+        return {
+          type: "command-invalid-args",
+          command: "goal",
+          input: budgetInput,
+          usage: GOAL_USAGE,
+        };
+      }
+
+      budgetCents = parsedBudgetCents;
+      objectiveStartIndex = 2;
     }
 
-    const headerObjective = parsed._.join(" ").trim();
+    if (headerTokens[objectiveStartIndex] === "--turns") {
+      const turnInput = headerTokens[objectiveStartIndex + 1];
+      const parsedTurnCap = parseGoalTurnCap(turnInput);
+      if (parsedTurnCap == null) {
+        return {
+          type: "command-invalid-args",
+          command: "goal",
+          input: String(turnInput),
+          usage: GOAL_USAGE,
+        };
+      }
+
+      turnCap = parsedTurnCap;
+      objectiveStartIndex += 2;
+    }
+
+    // Only a leading budget/turn flag prefix is command syntax; everything
+    // after that is user-authored goal text so objectives can mention
+    // flag-looking strings (including deprecated-looking budget flags).
+    const objectiveTokens = headerTokens.slice(objectiveStartIndex);
+    const headerObjective = objectiveTokens.join(" ").trim();
     const objective = [headerObjective, body]
       .filter((part): part is string => part != null && part.length > 0)
       .join(headerObjective && bodyHadLeadingBlankLine ? "\n\n" : "\n");
@@ -642,41 +667,11 @@ const goalCommandDefinition: SlashCommandDefinition = {
       };
     }
 
-    if (parsed.budget != null && noBudget) {
-      return {
-        type: "command-invalid-args",
-        command: "goal",
-        input: "--budget --no-budget",
-        usage: GOAL_USAGE,
-      };
-    }
-
     const result: Extract<ParsedCommand, { type: "goal-set" }> = { type: "goal-set", objective };
-    if (parsed.budget != null) {
-      const budgetCents = parseGoalBudgetCents(parsed.budget);
-      if (budgetCents == null) {
-        return {
-          type: "command-invalid-args",
-          command: "goal",
-          input: String(parsed.budget),
-          usage: GOAL_USAGE,
-        };
-      }
+    if (budgetCents !== undefined) {
       result.budgetCents = budgetCents;
-    } else if (noBudget) {
-      result.budgetCents = null;
     }
-
-    if (parsed.turns != null) {
-      const turnCap = parseGoalTurnCap(parsed.turns);
-      if (turnCap == null) {
-        return {
-          type: "command-invalid-args",
-          command: "goal",
-          input: String(parsed.turns),
-          usage: GOAL_USAGE,
-        };
-      }
+    if (turnCap !== undefined) {
       result.turnCap = turnCap;
     }
 

--- a/src/common/constants/slashCommandHints.ts
+++ b/src/common/constants/slashCommandHints.ts
@@ -11,5 +11,5 @@ export const SLASH_COMMAND_HINTS = {
   new: "[start message]",
   idle: "<hours>|off",
   heartbeat: "<minutes>|off",
-  goal: "<objective>|budget <amount>|clear",
+  goal: "[-b <amount>] [--turns <n>] <objective>|budget <amount>|clear",
 } as const satisfies Readonly<Record<string, string>>;

--- a/src/common/utils/goals/budgetPricing.ts
+++ b/src/common/utils/goals/budgetPricing.ts
@@ -64,7 +64,7 @@ export function modelHasPricingData(model: string, providersConfig: unknown = nu
 }
 
 export const UNPRICED_CURRENT_MODEL_GOAL_MESSAGE =
-  "Current model has no pricing data. Pick a priced model, set --no-budget, or rely on --turns N only.";
+  "Current model has no pricing data. Pick a priced model, use -b 0 with a turn cap, or change goal budget defaults in Settings.";
 
 export const UNPRICED_TARGET_MODEL_GOAL_MESSAGE =
-  "Target model has no pricing data. Pick a priced model or remove the active goal budget with /goal budget --no-budget before switching.";
+  "Target model has no pricing data. Pick a priced model before switching.";

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -3575,8 +3575,7 @@ describe("WorkspaceService maybePersistAISettingsFromOptions", () => {
 
     expect(result).toEqual({
       success: false,
-      error:
-        "Target model has no pricing data. Pick a priced model or remove the active goal budget with /goal budget --no-budget before switching.",
+      error: "Target model has no pricing data. Pick a priced model before switching.",
     });
   });
 


### PR DESCRIPTION
Summary
- Aligns `/goal` creation parsing with leading flag syntax: only a leading `-b <amount>` is consumed as budget intent.
- Removes `--no-budget` slash syntax; omitted goal budgets continue to resolve through configured defaults, and users can set a very high budget when they want an effectively non-binding dollar limit.
- Treats non-leading flag-looking tokens such as `--budget`, `--no-budget`, or `-b` as part of the goal text.
- Keeps existing leading `--turns <n>` support and updates `/goal` hints plus related tests. Unpriced-model guidance now points to `-b 0` with a turn cap or settings rather than `--no-budget`.

Validation
- `bun test src/browser/utils/slashCommands/goal.test.ts src/browser/utils/chatCommands.test.ts src/node/services/workspaceService.test.ts`
- `bun test src/browser/utils/chatCommands.test.ts`
- `make static-check`

Risks
- Low. This intentionally changes `/goal` creation parsing for the old non-leading `--budget` / `--no-budget` forms and removes `/goal budget --no-budget`; `/goal budget <amount>` remains available for updating an active goal budget.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$13.08`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=13.08 -->
