### PR TITLE
🤖 fix: preserve plan on soft clear

### DIFF
--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -33,6 +33,7 @@ import type { DesktopSessionManager } from "@/node/services/desktop/DesktopSessi
 import type { WorktreeArchiveSnapshot } from "@/common/schemas/project";
 import type { BashToolResult } from "@/common/types/tools";
 import { createMuxMessage } from "@/common/types/message";
+import { getPlanFilePath } from "@/common/utils/planStorage";
 import * as todoStorageModule from "@/node/services/todos/todoStorage";
 import * as runtimeFactory from "@/node/runtime/runtimeFactory";
 import * as bashToolModule from "@/node/services/tools/bash";
@@ -88,9 +89,8 @@ async function writePlanFile(
   projectName: string,
   workspaceName: string
 ): Promise<string> {
-  const planDir = path.join(root, "plans", projectName);
-  await fsPromises.mkdir(planDir, { recursive: true });
-  const planFile = path.join(planDir, `${workspaceName}.md`);
+  const planFile = getPlanFilePath(workspaceName, projectName, root);
+  await fsPromises.mkdir(path.dirname(planFile), { recursive: true });
   await fsPromises.writeFile(planFile, "# Plan\n");
   return planFile;
 }
@@ -433,6 +433,37 @@ describe("WorkspaceService truncateHistory goal acknowledgment", () => {
       } finally {
         pendingSpy.mockRestore();
       }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("context reset preserves plan files", async () => {
+    const { config, historyService, workspaceService, cleanup } = await createServices();
+    const workspaceId = "context-reset-preserves-plan-file";
+    const projectName = "context-reset-preserves-plan-project";
+    try {
+      await config.addWorkspace(`/tmp/${projectName}`, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName,
+        projectPath: `/tmp/${projectName}`,
+        runtimeConfig: { type: "local" },
+      });
+      const planFile = await writePlanFile(config.rootDir, projectName, workspaceId);
+      expect(
+        (
+          await historyService.appendToHistory(
+            workspaceId,
+            createMuxMessage("pre-reset-user", "user", "before reset", {})
+          )
+        ).success
+      ).toBe(true);
+
+      const result = await workspaceService.resetContext(workspaceId);
+
+      expect(result).toEqual({ success: true, data: "reset" });
+      await fsPromises.access(planFile);
     } finally {
       await cleanup();
     }

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -6444,11 +6444,6 @@ export class WorkspaceService extends EventEmitter {
         this.emit("chat", { workspaceId, message: typedBoundaryMessage });
       }
 
-      const metadata = await this.getInfo(workspaceId);
-      if (metadata) {
-        await this.deletePlanFilesForWorkspace(workspaceId, metadata);
-      }
-
       try {
         await this.workspaceGoalService?.requireUserAcknowledgment(workspaceId);
       } catch (error) {


### PR DESCRIPTION
Summary
- Preserve plan files when a workspace context reset is triggered through /clear --soft.
- Keep full history clears responsible for deleting plan files.

Background
Soft clear resets provider-visible context without destroying chat history. Plan files are user-authored working artifacts, so preserving them keeps the plan available after a context reset.

Implementation
- Removed resetContext's plan-file deletion call.
- Added regression coverage proving a context reset leaves the plan file present.
- Updated the test helper to use the shared plan path utility.

Validation
- bun test src/node/services/workspaceService.test.ts -t "context reset"
- make typecheck
- make fmt-check
- make static-check

Risks
Low. The change is scoped to context reset cleanup; full hard clears and explicit replace-history plan deletion still use the existing deletion path.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `1432327{MUX_COSTS_USD:-unknown}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=17.66 -->
