### PR TITLE
🤖 fix: prevent stale goal autocomplete send

### DIFF
--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -1,4 +1,12 @@
-import React, { useState, useRef, useCallback, useEffect, useId, useMemo } from "react";
+import React, {
+  useState,
+  useRef,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useLayoutEffect,
+} from "react";
 import {
   CommandSuggestions,
   COMMAND_SUGGESTION_KEYS,
@@ -1400,8 +1408,8 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     setShowSkillSuggestions(nextSuggestions.length > 0);
   }, [input, showAtMentionSuggestions, agentSkillDescriptors, atMentionCursorNonce]);
 
-  // Watch input for slash commands
-  useEffect(() => {
+  // Keep slash suggestions current before Enter can accept a stale item.
+  useLayoutEffect(() => {
     const suggestions = getSlashCommandSuggestions(input, {
       agentSkills: agentSkillDescriptors,
       variant,

--- a/tests/ui/chat/goalSlashCommand.test.ts
+++ b/tests/ui/chat/goalSlashCommand.test.ts
@@ -1,0 +1,63 @@
+import "../dom";
+
+jest.mock("lottie-react", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+import { fireEvent, waitFor } from "@testing-library/react";
+
+import { preloadTestModules } from "../../ipc/setup";
+import { createAppHarness } from "../harness";
+import { EXPERIMENT_IDS, getExperimentKey } from "@/common/constants/experiments";
+
+describe("Goal slash command", () => {
+  beforeAll(async () => {
+    await preloadTestModules();
+  });
+
+  test("sets a new goal from a completed goal when Enter follows a stale /goal suggestion", async () => {
+    const app = await createAppHarness({
+      branchPrefix: "goal-slash",
+      beforeRender: () => {
+        localStorage.setItem(getExperimentKey(EXPERIMENT_IDS.GOALS), JSON.stringify(true));
+      },
+    });
+
+    try {
+      const created = await app.env.orpc.workspace.setGoal({
+        workspaceId: app.workspaceId,
+        objective: "old completed goal",
+        budgetCents: null,
+      });
+      expect(created.success).toBe(true);
+      const completed = await app.env.orpc.workspace.setGoal({
+        workspaceId: app.workspaceId,
+        status: "complete",
+        completionSummary: "Done.",
+      });
+      expect(completed.success).toBe(true);
+
+      await app.chat.typeWithoutSending("/goal");
+      await waitFor(() => {
+        const suggestions = app.view.container.querySelector("[data-command-suggestions]");
+        expect(suggestions).not.toBeNull();
+      });
+
+      await app.chat.typeWithoutSending("/goal this is your new goal,");
+      const textarea = app.view.container.querySelector(
+        'textarea[aria-label="Message Claude"]'
+      ) as HTMLTextAreaElement | null;
+      expect(textarea).not.toBeNull();
+      fireEvent.keyDown(textarea!, { key: "Enter" });
+
+      await waitFor(async () => {
+        const { goal } = await app.env.orpc.workspace.getGoal({ workspaceId: app.workspaceId });
+        expect(goal?.objective).toBe("this is your new goal,");
+        expect(goal?.status).toBe("active");
+      });
+    } finally {
+      await app.dispose();
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

Fixes a stale slash-command autocomplete race where quickly submitting `/goal <objective>` could accept an older bare `/goal` suggestion, erase the objective, and open the Goal tab instead of replacing a completed goal.

## Background

When a completed goal existed, bare `/goal` correctly opened the Goal tab. The bug was that the command suggestion menu could lag behind the textarea value long enough for Enter to accept the old bare `/goal` suggestion after the user had typed a new objective.

## Implementation

The ChatInput slash suggestion watcher now runs in a layout effect so suggestions are updated before Enter can accept a stale item. A focused regression test covers replacing a completed goal via `/goal this is your new goal,`.

## Validation

- `make .SHELLFLAGS='-eo pipefail -c' static-check`
- `make .SHELLFLAGS='-eo pipefail -c' test`
- `bun test src/browser/features/ChatInput/ChatInput.goal.test.tsx src/browser/features/ChatInput/CommandSuggestions.test.tsx src/browser/utils/slashCommands/suggestions.test.ts src/browser/utils/slashCommands/goal.test.ts src/browser/utils/chatCommands.test.ts`

## Risks

Low. The change only moves the existing slash-suggestion recomputation earlier in the render lifecycle; it does not alter slash parsing or command execution.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$53.45`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=53.45 -->
