### PR TITLE
🤖 fix: enable advisor for default subagents

### DIFF
--- a/src/browser/features/Settings/Sections/TasksSection.tsx
+++ b/src/browser/features/Settings/Sections/TasksSection.tsx
@@ -17,6 +17,7 @@ import { copyToClipboard } from "@/browser/utils/clipboard";
 import { useExperimentValue } from "@/browser/hooks/useExperiments";
 import { getDefaultModel, useModelsFromSettings } from "@/browser/hooks/useModelsFromSettings";
 import { updatePersistedState, usePersistedState } from "@/browser/hooks/usePersistedState";
+import { resolveAdvisorEnabledForAgent } from "@/common/constants/advisor";
 import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import {
   AGENT_AI_DEFAULTS_KEY,
@@ -271,6 +272,23 @@ function renderPolicySummary(agent: AgentDefinitionDescriptor): React.ReactNode 
       ))}
     </>
   );
+}
+
+function getAdvisorSwitchState(
+  agentId: string,
+  advisorEnabledOverride: boolean | undefined
+): { checked: boolean; title: string } {
+  const checked = resolveAdvisorEnabledForAgent(agentId, advisorEnabledOverride);
+  const title =
+    advisorEnabledOverride === undefined
+      ? checked
+        ? "Advisor enabled by default."
+        : "Advisor disabled by default."
+      : advisorEnabledOverride
+        ? "Advisor enabled (local override)."
+        : "Advisor disabled (local override).";
+
+  return { checked, title };
 }
 
 function areTaskSettingsEqual(a: TaskSettings, b: TaskSettings): boolean {
@@ -863,13 +881,7 @@ export function TasksSection() {
     const writesSubagentAiDefaults = agent.subagentRunnable && !agent.uiSelectable;
     const enabledOverride = entry?.enabled;
     const advisorEnabledOverride = entry?.advisorEnabled;
-    const advisorEnabledValue = advisorEnabledOverride ?? false;
-    const advisorEnabledTitle =
-      advisorEnabledOverride === undefined
-        ? "Advisor disabled by default."
-        : advisorEnabledOverride
-          ? "Advisor enabled (local override)."
-          : "Advisor disabled (local override).";
+    const advisorSwitchState = getAdvisorSwitchState(agent.id, advisorEnabledOverride);
 
     const enablementLocked =
       agent.id === "exec" || agent.id === "plan" || agent.id === "compact" || agent.id === "mux";
@@ -994,13 +1006,13 @@ export function TasksSection() {
                     <div className="flex items-center gap-2">
                       <div className="text-muted text-xs">Advisor</div>
                       <Switch
-                        checked={advisorEnabledValue}
+                        checked={advisorSwitchState.checked}
                         onCheckedChange={(checked) => setAgentAdvisorEnabled(agent.id, checked)}
                         aria-label={`Toggle ${agent.id} advisor`}
                       />
                     </div>
                   </TooltipTrigger>
-                  <TooltipContent>{advisorEnabledTitle}</TooltipContent>
+                  <TooltipContent>{advisorSwitchState.title}</TooltipContent>
                 </Tooltip>
                 {advisorEnabledOverride !== undefined ? (
                   <Button
@@ -1094,13 +1106,7 @@ export function TasksSection() {
     const modelValue = entry?.modelString ?? INHERIT;
     const thinkingValue = entry?.thinkingLevel ?? INHERIT;
     const advisorEnabledOverride = entry?.advisorEnabled;
-    const advisorEnabledValue = advisorEnabledOverride ?? false;
-    const advisorEnabledTitle =
-      advisorEnabledOverride === undefined
-        ? "Advisor disabled by default."
-        : advisorEnabledOverride
-          ? "Advisor enabled (local override)."
-          : "Advisor disabled (local override).";
+    const advisorSwitchState = getAdvisorSwitchState(agentId, advisorEnabledOverride);
     const effectiveModel = modelValue !== INHERIT ? modelValue : inheritedEffectiveModel;
 
     return (
@@ -1120,13 +1126,13 @@ export function TasksSection() {
                   <div className="flex items-center gap-2">
                     <div className="text-muted text-xs">Advisor</div>
                     <Switch
-                      checked={advisorEnabledValue}
+                      checked={advisorSwitchState.checked}
                       onCheckedChange={(checked) => setAgentAdvisorEnabled(agentId, checked)}
                       aria-label={`Toggle ${agentId} advisor`}
                     />
                   </div>
                 </TooltipTrigger>
-                <TooltipContent>{advisorEnabledTitle}</TooltipContent>
+                <TooltipContent>{advisorSwitchState.title}</TooltipContent>
               </Tooltip>
               {advisorEnabledOverride !== undefined ? (
                 <Button

--- a/src/browser/features/Settings/Sections/TasksSection.ui.test.tsx
+++ b/src/browser/features/Settings/Sections/TasksSection.ui.test.tsx
@@ -10,6 +10,8 @@ import {
 import { getThinkingOptionLabel } from "@/common/types/thinking";
 import { enforceThinkingPolicy } from "@/common/utils/thinking/policy";
 
+let advisorExperimentEnabled = false;
+
 let apiMock: {
   config: {
     getConfig: ReturnType<typeof mock>;
@@ -26,7 +28,7 @@ void mock.module("@/browser/contexts/WorkspaceContext", () => ({
 }));
 
 void mock.module("@/browser/hooks/useExperiments", () => ({
-  useExperimentValue: () => false,
+  useExperimentValue: () => advisorExperimentEnabled,
 }));
 
 void mock.module("@/browser/hooks/useModelsFromSettings", () => ({
@@ -151,6 +153,7 @@ describe("TasksSection Exec subagent defaults", () => {
 
   beforeEach(() => {
     restoreDom = installDom();
+    advisorExperimentEnabled = false;
     apiMock = null;
   });
 
@@ -168,6 +171,17 @@ describe("TasksSection Exec subagent defaults", () => {
     expect(within(getExecSubagentRow(view)).getByText("Exec")).toBeTruthy();
     expect(view.getByText("UI agents")).toBeTruthy();
     expect(view.getByText("Sub-agents")).toBeTruthy();
+  });
+
+  test("defaults advisor on for Exec and Plan when the experiment is enabled", async () => {
+    advisorExperimentEnabled = true;
+    const view = renderTasksSection();
+
+    const planAdvisorSwitch = await view.findByRole("switch", { name: "Toggle plan advisor" });
+    const execAdvisorSwitch = view.getByRole("switch", { name: "Toggle exec advisor" });
+
+    expect(execAdvisorSwitch.getAttribute("aria-checked")).toBe("true");
+    expect(planAdvisorSwitch.getAttribute("aria-checked")).toBe("true");
   });
 
   test("resetting a mirrored subagent model removes the stale mirrored entry", async () => {

--- a/src/common/constants/advisor.ts
+++ b/src/common/constants/advisor.ts
@@ -1,5 +1,20 @@
+import { normalizeAgentId } from "@/common/utils/agentIds";
+
 /** Default per-turn usage cap for the experimental advisor tool. */
 export const ADVISOR_DEFAULT_MAX_USES_PER_TURN = 3;
+
+const ADVISOR_ENABLED_BY_DEFAULT_AGENT_IDS = new Set(["exec", "plan"]);
+
+export function isAdvisorEnabledByDefaultForAgent(agentId: string): boolean {
+  return ADVISOR_ENABLED_BY_DEFAULT_AGENT_IDS.has(normalizeAgentId(agentId, ""));
+}
+
+export function resolveAdvisorEnabledForAgent(
+  agentId: string,
+  advisorEnabledOverride: boolean | undefined
+): boolean {
+  return advisorEnabledOverride ?? isAdvisorEnabledByDefaultForAgent(agentId);
+}
 
 /** Tail-biased truncation budget for same-step commentary included in advisor handoffs. */
 export const ADVISOR_HANDOFF_MAX_TEXT_CHARS = 4000;

--- a/src/common/schemas/project.ts
+++ b/src/common/schemas/project.ts
@@ -129,6 +129,7 @@ export const WorkspaceConfigSchema = z.object({
     .object({
       programmaticToolCalling: z.boolean().optional(),
       programmaticToolCallingExclusive: z.boolean().optional(),
+      advisorTool: z.boolean().optional(),
       goals: z.boolean().optional(),
       imageGenerationTool: z.boolean().optional(),
       execSubagentHardRestart: z.boolean().optional(),

--- a/src/common/utils/tools/tools.ts
+++ b/src/common/utils/tools/tools.ts
@@ -148,6 +148,7 @@ export interface ToolConfiguration {
   experiments?: {
     programmaticToolCalling?: boolean;
     programmaticToolCallingExclusive?: boolean;
+    advisorTool?: boolean;
     goals?: boolean;
     imageGenerationTool?: boolean;
     execSubagentHardRestart?: boolean;

--- a/src/node/services/agentResolution.test.ts
+++ b/src/node/services/agentResolution.test.ts
@@ -1,0 +1,106 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import type { ProjectsConfig } from "@/common/types/project";
+import type { WorkspaceMetadata } from "@/common/types/workspace";
+import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
+import { LocalRuntime } from "@/node/runtime/LocalRuntime";
+import { DisposableTempDir } from "@/node/services/tempDir";
+import { resolveAgentForStream } from "./agentResolution";
+
+const PARENT_WORKSPACE_ID = "parent-workspace";
+const CHILD_WORKSPACE_ID = "child-workspace";
+
+function createSubagentMetadata(params: {
+  projectPath: string;
+  agentId: string;
+}): WorkspaceMetadata {
+  return {
+    id: CHILD_WORKSPACE_ID,
+    name: CHILD_WORKSPACE_ID,
+    projectName: path.basename(params.projectPath),
+    projectPath: params.projectPath,
+    runtimeConfig: DEFAULT_RUNTIME_CONFIG,
+    parentWorkspaceId: PARENT_WORKSPACE_ID,
+    agentId: params.agentId,
+    agentType: params.agentId,
+  };
+}
+
+async function resolvePolicyForAgent(params: {
+  agentId: string;
+  agentAiDefaults?: ProjectsConfig["agentAiDefaults"];
+}) {
+  using tempDir = new DisposableTempDir("agent-resolution-advisor-defaults");
+  const projectPath = path.join(tempDir.path, "project");
+  await fs.mkdir(projectPath, { recursive: true });
+
+  const metadata = createSubagentMetadata({
+    projectPath,
+    agentId: params.agentId,
+  });
+  const cfg: ProjectsConfig = {
+    projects: new Map([
+      [
+        projectPath,
+        {
+          trusted: true,
+          workspaces: [
+            { id: PARENT_WORKSPACE_ID, name: PARENT_WORKSPACE_ID, path: projectPath },
+            {
+              id: CHILD_WORKSPACE_ID,
+              name: CHILD_WORKSPACE_ID,
+              path: projectPath,
+              parentWorkspaceId: PARENT_WORKSPACE_ID,
+              agentId: params.agentId,
+              agentType: params.agentId,
+            },
+          ],
+        },
+      ],
+    ]),
+    ...(params.agentAiDefaults ? { agentAiDefaults: params.agentAiDefaults } : {}),
+  };
+
+  const result = await resolveAgentForStream({
+    workspaceId: CHILD_WORKSPACE_ID,
+    metadata,
+    runtime: new LocalRuntime(projectPath),
+    workspacePath: projectPath,
+    requestedAgentId: params.agentId,
+    disableWorkspaceAgents: false,
+    callerToolPolicy: undefined,
+    cfg,
+    emitError: () => undefined,
+    isAdvisorExperimentEnabled: true,
+  });
+
+  if (!result.success) {
+    throw new Error("Expected agent resolution to succeed");
+  }
+  return result.data.effectiveToolPolicy ?? [];
+}
+
+describe("resolveAgentForStream advisor defaults", () => {
+  test("enables advisor by default for Exec and Plan sub-agents when the experiment is enabled", async () => {
+    const [execPolicy, planPolicy] = await Promise.all([
+      resolvePolicyForAgent({ agentId: "exec" }),
+      resolvePolicyForAgent({ agentId: "plan" }),
+    ]);
+
+    expect(execPolicy).toContainEqual({ regex_match: "advisor", action: "enable" });
+    expect(planPolicy).toContainEqual({ regex_match: "advisor", action: "enable" });
+  });
+
+  test("keeps explicit advisor disable overrides authoritative for default-enabled agents", async () => {
+    const policy = await resolvePolicyForAgent({
+      agentId: "exec",
+      agentAiDefaults: { exec: { advisorEnabled: false } },
+    });
+
+    expect(policy).toContainEqual({ regex_match: "advisor", action: "disable" });
+    expect(policy).not.toContainEqual({ regex_match: "advisor", action: "enable" });
+  });
+});

--- a/src/node/services/agentResolution.ts
+++ b/src/node/services/agentResolution.ts
@@ -11,6 +11,7 @@
  * - Tool policy composition (agent → caller)
  */
 
+import { resolveAdvisorEnabledForAgent } from "@/common/constants/advisor";
 import { AgentIdSchema } from "@/common/orpc/schemas";
 import type { SendMessageError } from "@/common/types/errors";
 import type { Result } from "@/common/types/result";
@@ -216,7 +217,10 @@ export async function resolveAgentForStream(
   // Caller policy then narrows further if needed.
   const advisorEnabled =
     isAdvisorExperimentEnabled === true &&
-    cfg.agentAiDefaults?.[effectiveAgentId]?.advisorEnabled === true;
+    resolveAdvisorEnabledForAgent(
+      effectiveAgentId,
+      cfg.agentAiDefaults?.[effectiveAgentId]?.advisorEnabled
+    );
   const agentToolPolicy = resolveToolPolicyForAgent({
     agents: agentsForInheritance,
     isSubagent: isSubagentWorkspace,

--- a/src/node/services/aiService.test.ts
+++ b/src/node/services/aiService.test.ts
@@ -1682,13 +1682,6 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
     });
     await harness.config.editConfig((cfg) => {
       cfg.advisorModelString = KNOWN_MODELS.SONNET.id;
-      cfg.agentAiDefaults = {
-        ...cfg.agentAiDefaults,
-        exec: {
-          ...(cfg.agentAiDefaults?.exec ?? {}),
-          advisorEnabled: true,
-        },
-      };
       return cfg;
     });
 

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -12,7 +12,10 @@ import type { WorkspaceMetadata } from "@/common/types/workspace";
 import type { SendMessageOptions, ProvidersConfigMap } from "@/common/orpc/types";
 
 import type { DebugLlmRequestSnapshot } from "@/common/types/debugLlmRequest";
-import { ADVISOR_DEFAULT_MAX_USES_PER_TURN } from "@/common/constants/advisor";
+import {
+  ADVISOR_DEFAULT_MAX_USES_PER_TURN,
+  resolveAdvisorEnabledForAgent,
+} from "@/common/constants/advisor";
 import {
   DEFAULT_IMAGE_GENERATION_MAX_IMAGES,
   DEFAULT_IMAGE_GENERATION_MODEL,
@@ -1167,7 +1170,10 @@ export class AIService extends EventEmitter {
       } = agentResult.data;
       const projectTrusted = isProjectTrusted(this.config, metadata.projectPath);
       const sharedExecutionTrusted = isWorkspaceTrustedForSharedExecution(metadata, cfg.projects);
-      const agentAdvisorEnabled = cfg.agentAiDefaults?.[effectiveAgentId]?.advisorEnabled === true;
+      const agentAdvisorEnabled = resolveAdvisorEnabledForAgent(
+        effectiveAgentId,
+        cfg.agentAiDefaults?.[effectiveAgentId]?.advisorEnabled
+      );
       const advisorModelString = cfg.advisorModelString?.trim() ?? "";
       const advisorToolEligible =
         advisorExperimentEnabled && agentAdvisorEnabled && advisorModelString.length > 0;
@@ -1676,7 +1682,7 @@ export class AIService extends EventEmitter {
           taskService: this.taskService,
           analyticsService: this.analyticsService,
           desktopSessionManager: this.desktopSessionManager,
-          // PTC experiments for inheritance to subagents
+          // Experiments for inheritance to subagents.
           experiments,
           // Dynamic context for tool descriptions (moved from system prompt for better model attention)
           availableSubagents: agentDefinitions,

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -137,6 +137,7 @@ export interface TaskCreateArgs {
   experiments?: {
     programmaticToolCalling?: boolean;
     programmaticToolCallingExclusive?: boolean;
+    advisorTool?: boolean;
     imageGenerationTool?: boolean;
     goals?: boolean;
     execSubagentHardRestart?: boolean;


### PR DESCRIPTION
## Summary
Enable the advisor tool by default for Exec and Plan when the Advisor experiment is enabled, including sub-agent runs, while preserving explicit per-agent advisor overrides.

## Background
The Advisor experiment previously required per-agent opt-in before Exec or Plan sub-agents could see the advisor tool. This makes the experiment behave as expected for the default coding/planning agents without changing override semantics.

## Implementation
- Added shared advisor default resolution for Exec and Plan.
- Reused that resolution in agent tool-policy gating, advisor runtime eligibility, and Tasks settings UI state.
- Persisted inherited task experiment state now includes the Advisor flag for queued/restarted sub-agent workspaces.
- Added backend and UI coverage for default-on behavior and explicit disable overrides.

## Validation
- `make static-check`
- `bun test src/node/services/agentResolution.test.ts`
- `bun test src/browser/features/Settings/Sections/TasksSection.ui.test.tsx`
- `bun test src/node/services/aiService.test.ts --test-name-pattern "rebuilds the stream system context when policy removes advisor guidance"`
- `make typecheck`
- `make fmt-check`

## Risks
Low. The change is gated by the Advisor experiment and explicit per-agent overrides still take precedence.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: $24.57_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=24.57 -->
