### PR TITLE
🤖 feat: stream advisor output live

### DIFF
--- a/src/browser/features/Tools/AdvisorToolCall.test.tsx
+++ b/src/browser/features/Tools/AdvisorToolCall.test.tsx
@@ -6,6 +6,13 @@ import { GlobalWindow } from "happy-dom";
 
 import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
 
+const useAdvisorToolLiveOutputMock = mock(
+  (
+    _workspaceId: string | undefined,
+    _toolCallId: string | undefined
+  ): WorkspaceStoreModule.AdvisorLiveOutputState | null => null
+);
+
 const useAdvisorToolLivePhaseMock = mock(
   (
     _workspaceId: string | undefined,
@@ -20,6 +27,7 @@ const actualWorkspaceStore =
 
 void mock.module("@/browser/stores/WorkspaceStore", () => ({
   ...actualWorkspaceStore,
+  useAdvisorToolLiveOutput: useAdvisorToolLiveOutputMock,
   useAdvisorToolLivePhase: useAdvisorToolLivePhaseMock,
 }));
 
@@ -67,6 +75,7 @@ describe("AdvisorToolCall", () => {
     globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
     globalThis.document = globalThis.window.document;
 
+    useAdvisorToolLiveOutputMock.mockReset();
     useAdvisorToolLivePhaseMock.mockReset();
   });
 
@@ -135,6 +144,49 @@ describe("AdvisorToolCall", () => {
 
     expect(view.getByText("Question")).toBeTruthy();
     expect(view.getByText("Should we split the refactor into smaller commits?")).toBeTruthy();
+  });
+
+  test("renders live advisor output while executing", () => {
+    useAdvisorToolLivePhaseMock.mockReturnValue({
+      phase: "waiting_for_response",
+      timestamp: 1,
+    });
+    useAdvisorToolLiveOutputMock.mockReturnValue({
+      text: "Streamed partial advice",
+      timestamp: 2,
+    });
+
+    const view = renderAdvisorToolCall({ status: "executing" });
+
+    expect(useAdvisorToolLiveOutputMock).toHaveBeenCalledWith("workspace-1", "advisor-call-1");
+
+    fireEvent.click(view.getByText("advisor"));
+
+    expect(view.getByText("Advice")).toBeTruthy();
+    expect(view.getByText("Streamed partial advice")).toBeTruthy();
+  });
+
+  test("completed advice supersedes live advisor output", () => {
+    useAdvisorToolLivePhaseMock.mockReturnValue(undefined);
+    useAdvisorToolLiveOutputMock.mockReturnValue({
+      text: "Older streamed partial advice",
+      timestamp: 2,
+    });
+
+    const view = renderAdvisorToolCall({
+      status: "completed",
+      result: {
+        type: "advice",
+        advice: "Final persisted advice",
+        advisorModel: "openai:gpt-4.1-mini",
+        remainingUses: 1,
+      },
+    });
+
+    fireEvent.click(view.getByText("advisor"));
+
+    expect(view.getByText("Final persisted advice")).toBeTruthy();
+    expect(view.queryByText("Older streamed partial advice")).toBeNull();
   });
 
   test("continues rendering completed advice results", () => {

--- a/src/browser/features/Tools/AdvisorToolCall.tsx
+++ b/src/browser/features/Tools/AdvisorToolCall.tsx
@@ -5,6 +5,7 @@ import { MarkdownRenderer } from "../Messages/MarkdownRenderer";
 import { cn } from "@/common/lib/utils";
 import {
   type AdvisorLivePhaseState,
+  useAdvisorToolLiveOutput,
   useAdvisorToolLivePhase,
 } from "@/browser/stores/WorkspaceStore";
 import { formatModelDisplayName } from "@/common/utils/ai/modelDisplay";
@@ -223,23 +224,25 @@ export const AdvisorToolCall: React.FC<AdvisorToolCallProps> = ({
   const { expanded, toggleExpanded } = useToolExpansion();
   const toolStatus = isToolStatus(status) ? status : "pending";
   const livePhase = useAdvisorToolLivePhase(workspaceId, toolCallId);
+  const liveOutput = useAdvisorToolLiveOutput(workspaceId, toolCallId);
   const question = getAdvisorQuestion(args);
   const advisorResult = isAdvisorToolResult(result) ? result : null;
   const hasUnrecognizedResult = result !== undefined && result !== null && advisorResult === null;
+  const isExecutingWithoutResult =
+    toolStatus === "executing" && advisorResult === null && !hasUnrecognizedResult;
+  const liveAdviceText = isExecutingWithoutResult && liveOutput?.text ? liveOutput.text : undefined;
   const detailsText =
     advisorResult?.type === "advice"
       ? advisorResult.advice
       : advisorResult?.type === "limit_reached" || advisorResult?.type === "error"
         ? advisorResult.message
-        : undefined;
+        : liveAdviceText;
   const statusPresentation = hasUnrecognizedResult
     ? {
         status: "failed" as const,
         content: getStatusDisplay("failed"),
       }
     : getAdvisorStatusPresentation(advisorResult, toolStatus);
-  const isExecutingWithoutResult =
-    toolStatus === "executing" && advisorResult === null && !hasUnrecognizedResult;
   const executingStatusLabel = livePhase ? ADVISOR_PHASE_LABELS[livePhase.phase] : "Running";
   const headerStatusContent = isExecutingWithoutResult ? (
     <>
@@ -296,6 +299,15 @@ export const AdvisorToolCall: React.FC<AdvisorToolCallProps> = ({
                 </DetailSection>
               )}
             </>
+          )}
+
+          {advisorResult === null && liveAdviceText && (
+            <DetailSection>
+              <DetailLabel>Advice</DetailLabel>
+              <div className="bg-code-bg rounded px-3 py-2 text-[12px] leading-relaxed">
+                <MarkdownRenderer content={liveAdviceText} preserveLineBreaks />
+              </div>
+            </DetailSection>
           )}
 
           {advisorResult?.type === "limit_reached" && (

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -4445,6 +4445,169 @@ describe("WorkspaceStore", () => {
     });
   });
 
+  describe("advisor-output events", () => {
+    it("accumulates live advisor output while the advisor tool is running", async () => {
+      const workspaceId = "advisor-output-workspace-1";
+
+      mockOnChat.mockImplementation(async function* (): AsyncGenerator<
+        WorkspaceChatMessage,
+        void,
+        unknown
+      > {
+        yield { type: "caught-up" };
+        await Promise.resolve();
+        yield {
+          type: "advisor-output",
+          workspaceId,
+          toolCallId: "call-advisor-output-1",
+          text: "first ",
+          timestamp: 1,
+        };
+        yield {
+          type: "advisor-output",
+          workspaceId,
+          toolCallId: "call-advisor-output-1",
+          text: "second",
+          timestamp: 2,
+        };
+      });
+
+      createAndAddWorkspace(store, workspaceId);
+
+      const hasLiveOutput = await waitUntil(
+        () =>
+          store.getAdvisorToolLiveOutput(workspaceId, "call-advisor-output-1")?.text ===
+          "first second"
+      );
+      expect(hasLiveOutput).toBe(true);
+
+      const live = store.getAdvisorToolLiveOutput(workspaceId, "call-advisor-output-1");
+      expect(live).toEqual({ text: "first second", timestamp: 2 });
+      expect(store.getAdvisorToolLiveOutput(workspaceId, "call-advisor-output-1")).toBe(live);
+    });
+
+    it("clears live advisor output on advisor tool-call-end", async () => {
+      const workspaceId = "advisor-output-workspace-2";
+      let releaseToolEnd: (() => void) | undefined;
+      const waitForToolEnd = new Promise<void>((resolve) => {
+        releaseToolEnd = resolve;
+      });
+
+      mockOnChat.mockImplementation(async function* (): AsyncGenerator<
+        WorkspaceChatMessage,
+        void,
+        unknown
+      > {
+        yield { type: "caught-up" };
+        await Promise.resolve();
+        yield {
+          type: "advisor-output",
+          workspaceId,
+          toolCallId: "call-advisor-output-2",
+          text: "partial advice",
+          timestamp: 1,
+        };
+        await waitForToolEnd;
+        yield {
+          type: "tool-call-end",
+          workspaceId,
+          messageId: "m-advisor-output-2",
+          toolCallId: "call-advisor-output-2",
+          toolName: "advisor",
+          result: { type: "advice", advice: "partial advice" },
+          timestamp: 2,
+        };
+      });
+
+      createAndAddWorkspace(store, workspaceId);
+
+      const hasLiveOutput = await waitUntil(
+        () =>
+          store.getAdvisorToolLiveOutput(workspaceId, "call-advisor-output-2")?.text ===
+          "partial advice"
+      );
+      expect(hasLiveOutput).toBe(true);
+
+      releaseToolEnd?.();
+
+      const clearedLiveOutput = await waitUntil(
+        () => store.getAdvisorToolLiveOutput(workspaceId, "call-advisor-output-2") === null
+      );
+      expect(clearedLiveOutput).toBe(true);
+    });
+
+    it("clears stale live advisor output after message deletion", async () => {
+      const workspaceId = "advisor-output-workspace-delete";
+      let releaseDelete: (() => void) | undefined;
+      const waitForDelete = new Promise<void>((resolve) => {
+        releaseDelete = resolve;
+      });
+
+      mockOnChat.mockImplementation(async function* (): AsyncGenerator<
+        WorkspaceChatMessage,
+        void,
+        unknown
+      > {
+        yield { type: "caught-up" };
+        await Promise.resolve();
+        yield {
+          type: "advisor-output",
+          workspaceId,
+          toolCallId: "call-advisor-output-delete",
+          text: "stale partial advice",
+          timestamp: 1,
+        };
+        await waitForDelete;
+        yield { type: "delete", historySequences: [1] };
+      });
+
+      createAndAddWorkspace(store, workspaceId);
+
+      const hasLiveOutput = await waitUntil(
+        () =>
+          store.getAdvisorToolLiveOutput(workspaceId, "call-advisor-output-delete")?.text ===
+          "stale partial advice"
+      );
+      expect(hasLiveOutput).toBe(true);
+
+      releaseDelete?.();
+
+      const clearedLiveOutput = await waitUntil(
+        () => store.getAdvisorToolLiveOutput(workspaceId, "call-advisor-output-delete") === null
+      );
+      expect(clearedLiveOutput).toBe(true);
+    });
+
+    it("replays pre-caught-up advisor output after full replay catches up", async () => {
+      const workspaceId = "advisor-output-workspace-3";
+
+      mockOnChat.mockImplementation(async function* (): AsyncGenerator<
+        WorkspaceChatMessage,
+        void,
+        unknown
+      > {
+        yield {
+          type: "advisor-output",
+          workspaceId,
+          toolCallId: "call-advisor-output-3",
+          text: "buffered advice",
+          timestamp: 1,
+        };
+        await Promise.resolve();
+        yield { type: "caught-up", replay: "full" };
+      });
+
+      createAndAddWorkspace(store, workspaceId);
+
+      const hasLiveOutput = await waitUntil(
+        () =>
+          store.getAdvisorToolLiveOutput(workspaceId, "call-advisor-output-3")?.text ===
+          "buffered advice"
+      );
+      expect(hasLiveOutput).toBe(true);
+    });
+  });
+
   describe("task-created events", () => {
     it("exposes live taskId while the task tool is running", async () => {
       const workspaceId = "task-created-workspace-1";

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -24,7 +24,10 @@ import {
   type ResponseCompleteHandler,
 } from "@/browser/utils/messages/responseCompletionMetadata";
 import { isAbortError } from "@/browser/utils/isAbortError";
-import { BASH_TRUNCATE_MAX_TOTAL_BYTES } from "@/common/constants/toolLimits";
+import {
+  ADVISOR_LIVE_OUTPUT_MAX_CHARS,
+  BASH_TRUNCATE_MAX_TOTAL_BYTES,
+} from "@/common/constants/toolLimits";
 import { CUSTOM_EVENTS, createCustomEvent } from "@/common/constants/events";
 import { useCallback, useSyncExternalStore } from "react";
 import {
@@ -36,6 +39,7 @@ import {
   isInitEnd,
   isInitOutput,
   isInitStart,
+  isAdvisorOutputEvent,
   isAdvisorPhaseEvent,
   isBashOutputEvent,
   isTaskCreatedEvent,
@@ -216,6 +220,11 @@ export interface AdvisorLivePhaseState {
   timestamp: number;
 }
 
+export interface AdvisorLiveOutputState {
+  text: string;
+  timestamp: number;
+}
+
 interface WorkspaceChatTransientState {
   caughtUp: boolean;
   isHydratingTranscript: boolean;
@@ -224,6 +233,7 @@ interface WorkspaceChatTransientState {
   replayingHistory: boolean;
   queuedMessage: QueuedMessage | null;
   liveBashOutput: Map<string, LiveBashOutputInternal>;
+  liveAdvisorOutput: Map<string, AdvisorLiveOutputState>;
   liveAdvisorPhase: Map<string, AdvisorLivePhaseState>;
   liveTaskIds: Map<string, string[]>;
   autoRetryStatus: AutoRetryStatus | null;
@@ -311,6 +321,7 @@ function createInitialChatTransientState(): WorkspaceChatTransientState {
     replayingHistory: false,
     queuedMessage: null,
     liveBashOutput: new Map(),
+    liveAdvisorOutput: new Map(),
     liveAdvisorPhase: new Map(),
     liveTaskIds: new Map(),
     autoRetryStatus: null,
@@ -804,6 +815,7 @@ export class WorkspaceStore {
 
       // Cleanup ephemeral advisor/task state once the actual tool result is available.
       if (toolCallEnd.toolName === "advisor") {
+        transient?.liveAdvisorOutput.delete(toolCallEnd.toolCallId);
         transient?.liveAdvisorPhase.delete(toolCallEnd.toolCallId);
       }
       if (toolCallEnd.toolName === "task") {
@@ -1544,23 +1556,36 @@ export class WorkspaceStore {
     }
   }
 
-  private cleanupStaleLiveBashOutput(
+  private cleanupStaleLiveToolState(
     workspaceId: string,
     aggregator: StreamingMessageAggregator
   ): void {
-    const perWorkspace = this.chatTransientState.get(workspaceId)?.liveBashOutput;
-    if (!perWorkspace || perWorkspace.size === 0) return;
+    const transient = this.chatTransientState.get(workspaceId);
+    if (!transient) return;
+    if (transient.liveBashOutput.size === 0 && transient.liveAdvisorOutput.size === 0) return;
 
-    const activeToolCallIds = new Set<string>();
+    const activeBashToolCallIds = new Set<string>();
+    const activeAdvisorToolCallIds = new Set<string>();
     for (const msg of aggregator.getDisplayedMessages()) {
-      if (msg.type === "tool" && msg.toolName === "bash") {
-        activeToolCallIds.add(msg.toolCallId);
+      if (msg.type !== "tool") continue;
+
+      if (msg.toolName === "bash") {
+        activeBashToolCallIds.add(msg.toolCallId);
+      }
+      if (msg.toolName === "advisor") {
+        activeAdvisorToolCallIds.add(msg.toolCallId);
       }
     }
 
-    for (const toolCallId of Array.from(perWorkspace.keys())) {
-      if (!activeToolCallIds.has(toolCallId)) {
-        perWorkspace.delete(toolCallId);
+    for (const toolCallId of Array.from(transient.liveBashOutput.keys())) {
+      if (!activeBashToolCallIds.has(toolCallId)) {
+        transient.liveBashOutput.delete(toolCallId);
+      }
+    }
+
+    for (const toolCallId of Array.from(transient.liveAdvisorOutput.keys())) {
+      if (!activeAdvisorToolCallIds.has(toolCallId)) {
+        transient.liveAdvisorOutput.delete(toolCallId);
       }
     }
   }
@@ -1590,6 +1615,12 @@ export class WorkspaceStore {
 
     // Important: return the stored object reference so useSyncExternalStore sees a stable snapshot.
     // (Returning a fresh object every call can trigger an infinite re-render loop.)
+    return state ?? null;
+  }
+
+  getAdvisorToolLiveOutput(workspaceId: string, toolCallId: string): AdvisorLiveOutputState | null {
+    const state = this.chatTransientState.get(workspaceId)?.liveAdvisorOutput.get(toolCallId);
+
     return state ?? null;
   }
 
@@ -3705,6 +3736,7 @@ export class WorkspaceStore {
     return (
       data.type in this.bufferedEventHandlers ||
       data.type === "bash-output" ||
+      data.type === "advisor-output" ||
       data.type === "advisor-phase" ||
       data.type === "task-created"
     );
@@ -3780,6 +3812,7 @@ export class WorkspaceStore {
         // Live tool-call UI is tied to the active stream context; clear it when replay
         // replaces history, reports no active stream, or reports a different stream ID.
         transient.liveBashOutput.clear();
+        transient.liveAdvisorOutput.clear();
         transient.liveAdvisorPhase.clear();
         transient.liveTaskIds.clear();
       }
@@ -3937,7 +3970,7 @@ export class WorkspaceStore {
 
     if (isDeleteMessage(data)) {
       applyWorkspaceChatEventToAggregator(aggregator, data);
-      this.cleanupStaleLiveBashOutput(workspaceId, aggregator);
+      this.cleanupStaleLiveToolState(workspaceId, aggregator);
       this.states.bump(workspaceId);
       this.checkAndBumpRecencyIfChanged();
       this.usageStore.bump(workspaceId);
@@ -3964,6 +3997,28 @@ export class WorkspaceStore {
 
       // High-frequency: throttle UI updates like other delta-style events.
       this.scheduleIdleStateBump(workspaceId);
+      return;
+    }
+
+    if (isAdvisorOutputEvent(data)) {
+      if (data.text.length === 0) return;
+
+      const transient = this.assertChatTransientState(workspaceId);
+      const prev = transient.liveAdvisorOutput.get(data.toolCallId);
+      const appendedText = `${prev?.text ?? ""}${data.text}`;
+      const text =
+        appendedText.length > ADVISOR_LIVE_OUTPUT_MAX_CHARS
+          ? appendedText.slice(-ADVISOR_LIVE_OUTPUT_MAX_CHARS)
+          : appendedText;
+
+      if (prev?.text === text && prev.timestamp === data.timestamp) return;
+
+      transient.liveAdvisorOutput.set(data.toolCallId, {
+        text,
+        timestamp: data.timestamp,
+      });
+
+      this.scheduleStreamingStateBump(workspaceId);
       return;
     }
 
@@ -4205,6 +4260,27 @@ export function useBashToolLiveOutput(
     () => {
       if (!workspaceId || !toolCallId) return null;
       return store.getBashToolLiveOutput(workspaceId, toolCallId);
+    }
+  );
+}
+
+/**
+ * Hook to get UI-only live output for a running advisor tool call.
+ */
+export function useAdvisorToolLiveOutput(
+  workspaceId: string | undefined,
+  toolCallId: string | undefined
+): AdvisorLiveOutputState | null {
+  const store = getStoreInstance();
+
+  return useSyncExternalStore(
+    (listener) => {
+      if (!workspaceId) return () => undefined;
+      return store.subscribeKey(workspaceId, listener);
+    },
+    () => {
+      if (!workspaceId || !toolCallId) return null;
+      return store.getAdvisorToolLiveOutput(workspaceId, toolCallId);
     }
   );
 }

--- a/src/common/constants/toolLimits.ts
+++ b/src/common/constants/toolLimits.ts
@@ -10,6 +10,8 @@ export const BASH_MAX_FILE_BYTES = 100 * 1024; // 100KB max to save to temp file
 export const BASH_TRUNCATE_MAX_TOTAL_BYTES = 1024 * 1024; // 1MB total output
 export const BASH_TRUNCATE_MAX_FILE_BYTES = 1024 * 1024; // 1MB file limit (same as total for IPC)
 
+export const ADVISOR_LIVE_OUTPUT_MAX_CHARS = 256 * 1024;
+
 // tmpfile policy limits (AI agent only)
 export const BASH_MAX_LINE_BYTES = 1024; // 1KB per line for AI agent
 

--- a/src/common/orpc/schemas.ts
+++ b/src/common/orpc/schemas.ts
@@ -217,6 +217,7 @@ export {
   ToolCallStartEventSchema,
   BashOutputEventSchema,
   TaskCreatedEventSchema,
+  AdvisorOutputEventSchema,
   AdvisorPhaseEventSchema,
   UpdateStatusSchema,
   UsageDeltaEventSchema,

--- a/src/common/orpc/schemas/stream.ts
+++ b/src/common/orpc/schemas/stream.ts
@@ -376,6 +376,20 @@ export const AdvisorPhaseEventSchema = z.object({
 });
 
 /**
+ * UI-only incremental output from the advisor tool.
+ *
+ * This is intentionally NOT part of the tool result returned to the model.
+ * It is streamed over workspace.onChat so users can read advice while it is generated.
+ */
+export const AdvisorOutputEventSchema = z.object({
+  type: z.literal("advisor-output"),
+  workspaceId: z.string(),
+  toolCallId: z.string(),
+  text: z.string(),
+  timestamp: z.number().meta({ description: "When output was received (Date.now())" }),
+});
+
+/**
  * UI-only notification that a task tool call has created a child workspace.
  *
  * This is intentionally NOT part of the tool result returned to the model.
@@ -586,6 +600,7 @@ export const WorkspaceChatMessageSchema = z.discriminatedUnion("type", [
   ToolCallDeltaEventSchema,
   ToolCallEndEventSchema,
   BashOutputEventSchema,
+  AdvisorOutputEventSchema,
   TaskCreatedEventSchema,
   AdvisorPhaseEventSchema,
   // Reasoning events

--- a/src/common/orpc/types.ts
+++ b/src/common/orpc/types.ts
@@ -15,6 +15,7 @@ import type {
   ToolCallStartEvent,
   ToolCallDeltaEvent,
   ToolCallEndEvent,
+  AdvisorOutputEvent,
   AdvisorPhaseEvent,
   BashOutputEvent,
   TaskCreatedEvent,
@@ -109,6 +110,10 @@ export function isToolCallDelta(msg: WorkspaceChatMessage): msg is ToolCallDelta
 
 export function isBashOutputEvent(msg: WorkspaceChatMessage): msg is BashOutputEvent {
   return (msg as { type?: string }).type === "bash-output";
+}
+
+export function isAdvisorOutputEvent(msg: WorkspaceChatMessage): msg is AdvisorOutputEvent {
+  return (msg as { type?: string }).type === "advisor-output";
 }
 
 export function isTaskCreatedEvent(msg: WorkspaceChatMessage): msg is TaskCreatedEvent {

--- a/src/common/types/stream.ts
+++ b/src/common/types/stream.ts
@@ -25,6 +25,7 @@ import type {
   ToolCallEndEventSchema,
   ToolCallStartEventSchema,
   BashOutputEventSchema,
+  AdvisorOutputEventSchema,
   TaskCreatedEventSchema,
   AdvisorPhaseEventSchema,
   UsageDeltaEventSchema,
@@ -64,6 +65,7 @@ export type StreamAbortEvent = z.infer<typeof StreamAbortEventSchema>;
 export type ErrorEvent = z.infer<typeof ErrorEventSchema>;
 
 export type BashOutputEvent = z.infer<typeof BashOutputEventSchema>;
+export type AdvisorOutputEvent = z.infer<typeof AdvisorOutputEventSchema>;
 export type TaskCreatedEvent = z.infer<typeof TaskCreatedEventSchema>;
 export type AdvisorPhaseEvent = z.infer<typeof AdvisorPhaseEventSchema>;
 export type ToolCallStartEvent = z.infer<typeof ToolCallStartEventSchema>;

--- a/src/common/utils/ai/streamChunks.ts
+++ b/src/common/utils/ai/streamChunks.ts
@@ -1,0 +1,13 @@
+export function extractChunkDeltaText(
+  chunk: Record<string, unknown>,
+  fieldPriority: readonly string[]
+): string {
+  for (const field of fieldPriority) {
+    const value = chunk[field];
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+
+  return "";
+}

--- a/src/node/acp/agent.ts
+++ b/src/node/acp/agent.ts
@@ -1535,6 +1535,7 @@ export class MuxAgent implements Agent {
         event.type === "tool-call-delta" ||
         event.type === "usage-delta" ||
         event.type === "session-usage-delta" ||
+        event.type === "advisor-output" ||
         event.type === "bash-output" ||
         event.type === "init-output" ||
         // Drop replay history messages under saturation, but keep live message

--- a/src/node/acp/streamTranslator.ts
+++ b/src/node/acp/streamTranslator.ts
@@ -181,6 +181,21 @@ export class StreamTranslator {
         ];
       }
 
+      case "advisor-output": {
+        return [
+          {
+            sessionUpdate: "tool_call_update",
+            toolCallId: event.toolCallId,
+            status: "in_progress",
+            content: [textToolContent(event.text)],
+            _meta: {
+              source: "advisor-output",
+              timestamp: event.timestamp,
+            },
+          },
+        ];
+      }
+
       case "error":
         return this.translateToolFailure(sessionId, event.messageId, event.error, event.errorType);
 

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -4302,6 +4302,10 @@ export class AgentSession {
       this.markActiveStreamHadAnyOutput();
       this.emitChatEvent(payload);
     });
+    forward("advisor-output", (payload) => {
+      this.markActiveStreamHadAnyOutput();
+      this.emitChatEvent(payload);
+    });
     forward("task-created", (payload) => {
       this.emitChatEvent(payload);
     });

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -67,6 +67,7 @@ import type { SessionUsageService } from "./sessionUsageService";
 import { sumUsageHistory, getTotalCost } from "@/common/utils/tokens/usageAggregator";
 import { createDisplayUsage } from "@/common/utils/tokens/displayUsage";
 import { normalizeToCanonical } from "@/common/utils/ai/models";
+import { extractChunkDeltaText } from "@/common/utils/ai/streamChunks";
 import { readToolInstructions } from "./systemMessage";
 import {
   effectiveAdditionalSystemContext,
@@ -226,25 +227,6 @@ function markProviderMetadataCostsIncluded(
 interface ToolExecutionContext {
   toolCallId?: string;
   abortSignal?: AbortSignal;
-}
-
-/**
- * Extract the first string-typed value from a chunk object by trying field names
- * in priority order. Different AI SDK chunk types (`text-delta`, `reasoning-delta`)
- * surface the delta text under varying field names; this avoids duplicating the
- * probe logic for each case.
- */
-function extractChunkDeltaText(
-  chunk: Record<string, unknown>,
-  fieldPriority: readonly string[]
-): string {
-  for (const field of fieldPriority) {
-    const value = chunk[field];
-    if (typeof value === "string") {
-      return value;
-    }
-  }
-  return "";
 }
 
 function isToolExecutionContext(value: unknown): value is ToolExecutionContext {

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -64,6 +64,7 @@ import { runLanguageModelCleanup } from "./languageModelCleanup";
 import { shellQuote } from "@/common/utils/shell";
 import { classify429Capacity } from "@/common/utils/errors/classify429Capacity";
 import { normalizeLiteralRequiredToolPattern } from "@/common/utils/agentTools";
+import { extractChunkDeltaText } from "@/common/utils/ai/streamChunks";
 
 // Disable noisy AI SDK warning logging.
 globalThis.AI_SDK_LOG_WARNINGS = false;
@@ -1834,20 +1835,13 @@ export class StreamManager extends EventEmitter {
 
               case "text-delta": {
                 // Providers/SDKs may stream text deltas under different keys.
-                const textDeltaPart = part as {
-                  text?: unknown;
-                  delta?: unknown;
-                  textDelta?: unknown;
-                };
+                const textDeltaPart = part as Record<string, unknown>;
 
-                const deltaText =
-                  typeof textDeltaPart.text === "string"
-                    ? textDeltaPart.text
-                    : typeof textDeltaPart.delta === "string"
-                      ? textDeltaPart.delta
-                      : typeof textDeltaPart.textDelta === "string"
-                        ? textDeltaPart.textDelta
-                        : "";
+                const deltaText = extractChunkDeltaText(textDeltaPart, [
+                  "text",
+                  "delta",
+                  "textDelta",
+                ]);
 
                 if (deltaText.length === 0) {
                   if (

--- a/src/node/services/tools/advisor.test.ts
+++ b/src/node/services/tools/advisor.test.ts
@@ -8,6 +8,7 @@ import {
   ADVISOR_HANDOFF_MAX_TEXT_CHARS,
 } from "@/common/constants/advisor";
 import type { ModelMessage } from "@/common/types/message";
+import type { WorkspaceChatMessage } from "@/common/orpc/types";
 import type { AdvisorToolCallSnapshot, ToolModelUsageEvent } from "@/common/utils/tools/tools";
 import { log } from "@/node/services/log";
 import { createAdvisorTool } from "./advisor";
@@ -41,6 +42,8 @@ function createToolConfig(
     transcript?: ModelMessage[];
     snapshot?: AdvisorToolCallSnapshot | undefined;
     maxOutputTokens?: number;
+    emitChatEvent?: (event: WorkspaceChatMessage) => void;
+    workspaceId?: string;
   }
 ) {
   const createModel = mock(() => Promise.resolve({} as LanguageModel));
@@ -48,7 +51,8 @@ function createToolConfig(
   const getTranscriptSnapshot = mock(() => transcript);
   const takeToolCallSnapshot = mock((_toolCallId: string) => options?.snapshot);
   const config = {
-    ...createTestToolConfig(tempDir),
+    ...createTestToolConfig(tempDir, { workspaceId: options?.workspaceId }),
+    emitChatEvent: options?.emitChatEvent,
     reportModelUsage: options?.reportModelUsage,
     advisorRuntime: {
       advisorModelString: ADVISOR_MODEL,
@@ -65,42 +69,76 @@ function createToolConfig(
   return { config, createModel, getTranscriptSnapshot, takeToolCallSnapshot, transcript };
 }
 
-function mockGenerateTextSuccess(result: {
+type StreamTextArgs = Parameters<typeof ai.streamText>[0];
+type StreamTextResult = ReturnType<typeof ai.streamText>;
+type StreamTextFinishReason = Awaited<StreamTextResult["finishReason"]>;
+
+function mockStreamTextSuccess(result: {
   text: string;
   usage: LanguageModelV2Usage;
   providerMetadata?: Record<string, unknown>;
+  chunks?: Array<{ type: string; text?: string; delta?: string; textDelta?: string }>;
+  finishReason?: StreamTextFinishReason;
+  streamError?: Error;
 }) {
-  return spyOn(ai, "generateText").mockResolvedValue(
-    result as Awaited<ReturnType<typeof ai.generateText>>
+  return spyOn(ai, "streamText").mockImplementation(((args: StreamTextArgs) => {
+    const text = (async () => {
+      for (const chunk of result.chunks ?? []) {
+        await args.onChunk?.({ chunk } as Parameters<NonNullable<typeof args.onChunk>>[0]);
+      }
+      if (result.streamError) {
+        await args.onError?.({ error: result.streamError });
+      }
+      return result.text;
+    })();
+
+    return {
+      text,
+      finishReason: Promise.resolve(result.finishReason ?? "stop"),
+      usage: Promise.resolve(result.usage),
+      providerMetadata: Promise.resolve(result.providerMetadata),
+    } as unknown as StreamTextResult;
+  }) as unknown as typeof ai.streamText);
+}
+
+function mockStreamTextFailure(error: Error) {
+  return spyOn(ai, "streamText").mockImplementation(
+    (() =>
+      ({
+        text: Promise.reject(error),
+        finishReason: Promise.resolve("error"),
+        usage: Promise.resolve(undefined),
+        providerMetadata: Promise.resolve(undefined),
+      }) as unknown as StreamTextResult) as unknown as typeof ai.streamText
   );
 }
 
-function getGenerateTextArgs(
-  generateTextSpy: ReturnType<typeof mockGenerateTextSuccess>
-): Parameters<typeof ai.generateText>[0] {
-  const args = generateTextSpy.mock.calls[0]?.[0];
+function getStreamTextArgs(
+  streamTextSpy: ReturnType<typeof mockStreamTextSuccess>
+): Parameters<typeof ai.streamText>[0] {
+  const args = streamTextSpy.mock.calls[0]?.[0];
   expect(args).toBeDefined();
   if (!args) {
-    throw new Error("Expected generateText to be called");
+    throw new Error("Expected streamText to be called");
   }
 
   return args;
 }
 
-function getGenerateTextMessages(
-  generateTextSpy: ReturnType<typeof mockGenerateTextSuccess>
+function getStreamTextMessages(
+  streamTextSpy: ReturnType<typeof mockStreamTextSuccess>
 ): ModelMessage[] {
-  const { messages } = getGenerateTextArgs(generateTextSpy);
+  const { messages } = getStreamTextArgs(streamTextSpy);
   expect(messages).toBeDefined();
   if (!messages) {
-    throw new Error("Expected generateText to receive messages");
+    throw new Error("Expected streamText to receive messages");
   }
 
   return messages;
 }
 
-function getHandoffText(generateTextSpy: ReturnType<typeof mockGenerateTextSuccess>): string {
-  const handoffMessage = getGenerateTextMessages(generateTextSpy).at(-1);
+function getHandoffText(streamTextSpy: ReturnType<typeof mockStreamTextSuccess>): string {
+  const handoffMessage = getStreamTextMessages(streamTextSpy).at(-1);
   expect(handoffMessage).toBeDefined();
   expect(handoffMessage?.role).toBe("user");
   if (handoffMessage?.role !== "user") {
@@ -145,7 +183,7 @@ describe("advisor tool", () => {
     };
     const reportModelUsage = mock((_event: ToolModelUsageEvent) => undefined);
     const { config, createModel } = createToolConfig(tempDir.path, { reportModelUsage });
-    const generateTextSpy = mockGenerateTextSuccess({
+    const streamTextSpy = mockStreamTextSuccess({
       text: "Focus on the highest-risk dependency edges first.",
       usage,
       providerMetadata,
@@ -155,7 +193,7 @@ describe("advisor tool", () => {
     const rawResult: unknown = await Promise.resolve(tool.execute!({}, mockToolCallOptions));
 
     expect(createModel).toHaveBeenCalledWith(ADVISOR_MODEL);
-    expect(generateTextSpy).toHaveBeenCalledTimes(1);
+    expect(streamTextSpy).toHaveBeenCalledTimes(1);
     expect(rawResult).toEqual({
       type: "advice",
       advice: "Focus on the highest-risk dependency edges first.",
@@ -180,11 +218,65 @@ describe("advisor tool", () => {
     expect(typeof event?.timestamp).toBe("number");
   });
 
+  it("emits live advisor output chunks while preserving the final result", async () => {
+    using tempDir = new TestTempDir("advisor-tool-live-output");
+    const emitChatEvent = mock((_event: WorkspaceChatMessage) => undefined);
+    const { config } = createToolConfig(tempDir.path, {
+      emitChatEvent,
+      workspaceId: "workspace-1",
+    });
+    mockStreamTextSuccess({
+      text: "Start with the risky edge first.",
+      chunks: [
+        { type: "text", text: "Start " },
+        { type: "text-delta", delta: "with " },
+        { type: "text-delta", textDelta: "the risky edge first." },
+        { type: "text-delta", text: "" },
+        { type: "reasoning-delta", delta: "hidden reasoning" },
+      ],
+      usage: {
+        inputTokens: 40,
+        outputTokens: 15,
+        totalTokens: 55,
+      },
+    });
+
+    const tool = createAdvisorTool(config);
+    const rawResult: unknown = await Promise.resolve(tool.execute!({}, mockToolCallOptions));
+
+    expect(rawResult).toEqual({
+      type: "advice",
+      advice: "Start with the risky edge first.",
+      advisorModel: ADVISOR_MODEL,
+      reasoningLevel: "medium",
+      remainingUses: 2,
+    });
+    expect(emitChatEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "advisor-output",
+        workspaceId: "workspace-1",
+        toolCallId: "test-call-id",
+        text: "Start ",
+      })
+    );
+    expect(emitChatEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "advisor-output", text: "with " })
+    );
+    expect(emitChatEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "advisor-output", text: "the risky edge first." })
+    );
+    expect(
+      emitChatEvent.mock.calls
+        .filter((call) => call[0].type === "advisor-output")
+        .map((call) => call[0])
+    ).toHaveLength(3);
+  });
+
   it("falls back to the raw transcript when there is no question or same-step snapshot", async () => {
     using tempDir = new TestTempDir("advisor-tool-transcript-fallback");
     const transcript = createTranscript();
     const { config } = createToolConfig(tempDir.path, { transcript, snapshot: undefined });
-    const generateTextSpy = mockGenerateTextSuccess({
+    const streamTextSpy = mockStreamTextSuccess({
       text: "Proceed with the existing plan.",
       usage: {
         inputTokens: 20,
@@ -196,14 +288,14 @@ describe("advisor tool", () => {
     const tool = createAdvisorTool(config);
     await Promise.resolve(tool.execute!({}, mockToolCallOptions));
 
-    expect(getGenerateTextMessages(generateTextSpy)).toEqual(transcript);
+    expect(getStreamTextMessages(streamTextSpy)).toEqual(transcript);
   });
 
   it("appends a question-only advisor handoff when a normalized question is provided", async () => {
     using tempDir = new TestTempDir("advisor-tool-question-handoff");
     const question = "Should we split this refactor?";
     const { config, transcript } = createToolConfig(tempDir.path, { snapshot: undefined });
-    const generateTextSpy = mockGenerateTextSuccess({
+    const streamTextSpy = mockStreamTextSuccess({
       text: "Split the work if each piece can be reviewed independently.",
       usage: {
         inputTokens: 50,
@@ -215,7 +307,7 @@ describe("advisor tool", () => {
     const tool = createAdvisorTool(config);
     await Promise.resolve(tool.execute!({ question: `  ${question}  ` }, mockToolCallOptions));
 
-    expect(getGenerateTextMessages(generateTextSpy)).toEqual([
+    expect(getStreamTextMessages(streamTextSpy)).toEqual([
       ...transcript,
       {
         role: "user",
@@ -233,7 +325,7 @@ describe("advisor tool", () => {
       stepReasoning: "Internal reasoning about coordination and race conditions.",
     });
     const { config, transcript } = createToolConfig(tempDir.path, { snapshot });
-    const generateTextSpy = mockGenerateTextSuccess({
+    const streamTextSpy = mockStreamTextSuccess({
       text: "Use a write queue around the shared file handle.",
       usage: {
         inputTokens: 60,
@@ -245,7 +337,7 @@ describe("advisor tool", () => {
     const tool = createAdvisorTool(config);
     await Promise.resolve(tool.execute!({ question }, mockToolCallOptions));
 
-    expect(getGenerateTextMessages(generateTextSpy)).toEqual([
+    expect(getStreamTextMessages(streamTextSpy)).toEqual([
       ...transcript,
       {
         role: "user",
@@ -264,7 +356,7 @@ describe("advisor tool", () => {
     const { config, takeToolCallSnapshot } = createToolConfig(tempDir.path, {
       snapshot: createSnapshot(),
     });
-    mockGenerateTextSuccess({
+    mockStreamTextSuccess({
       text: "Continue with the current architecture.",
       usage: {
         inputTokens: 25,
@@ -289,7 +381,7 @@ describe("advisor tool", () => {
       stepReasoning: longStepReasoning,
     });
     const { config } = createToolConfig(tempDir.path, { snapshot });
-    const generateTextSpy = mockGenerateTextSuccess({
+    const streamTextSpy = mockStreamTextSuccess({
       text: "Prefer a deterministic queue.",
       usage: {
         inputTokens: 80,
@@ -301,7 +393,7 @@ describe("advisor tool", () => {
     const tool = createAdvisorTool(config);
     await Promise.resolve(tool.execute!({}, mockToolCallOptions));
 
-    const handoffText = getHandoffText(generateTextSpy);
+    const handoffText = getHandoffText(streamTextSpy);
     const truncatedStepText = extractLabeledBlock(handoffText, "Current-step commentary");
     const truncatedStepReasoning = extractLabeledBlock(handoffText, "Current-step reasoning");
 
@@ -325,7 +417,7 @@ describe("advisor tool", () => {
       transcript,
       snapshot: createSnapshot({ stepText: "", stepReasoning: "" }),
     });
-    const generateTextSpy = mockGenerateTextSuccess({
+    const streamTextSpy = mockStreamTextSuccess({
       text: "No extra context was needed.",
       usage: {
         inputTokens: 15,
@@ -337,13 +429,13 @@ describe("advisor tool", () => {
     const tool = createAdvisorTool(config);
     await Promise.resolve(tool.execute!({}, mockToolCallOptions));
 
-    expect(getGenerateTextMessages(generateTextSpy)).toEqual(transcript);
+    expect(getStreamTextMessages(streamTextSpy)).toEqual(transcript);
   });
 
-  it("passes maxOutputTokens to generateText when the advisor runtime is capped", async () => {
+  it("passes maxOutputTokens to streamText when the advisor runtime is capped", async () => {
     using tempDir = new TestTempDir("advisor-tool-max-output-tokens-limited");
     const { config } = createToolConfig(tempDir.path, { maxOutputTokens: 1000 });
-    const generateTextSpy = mockGenerateTextSuccess({
+    const streamTextSpy = mockStreamTextSuccess({
       text: "Keep the recommendation concise.",
       usage: {
         inputTokens: 24,
@@ -355,15 +447,15 @@ describe("advisor tool", () => {
     const tool = createAdvisorTool(config);
     await Promise.resolve(tool.execute!({}, mockToolCallOptions));
 
-    expect(generateTextSpy).toHaveBeenCalledTimes(1);
-    const generateTextArgs = generateTextSpy.mock.calls[0]?.[0];
-    expect(generateTextArgs?.maxOutputTokens).toBe(1000);
+    expect(streamTextSpy).toHaveBeenCalledTimes(1);
+    const streamTextArgs = streamTextSpy.mock.calls[0]?.[0];
+    expect(streamTextArgs?.maxOutputTokens).toBe(1000);
   });
 
-  it("omits maxOutputTokens from generateText when the advisor runtime is unlimited", async () => {
+  it("omits maxOutputTokens from streamText when the advisor runtime is unlimited", async () => {
     using tempDir = new TestTempDir("advisor-tool-max-output-tokens-unlimited");
     const { config } = createToolConfig(tempDir.path, { maxOutputTokens: undefined });
-    const generateTextSpy = mockGenerateTextSuccess({
+    const streamTextSpy = mockStreamTextSuccess({
       text: "Return the full analysis.",
       usage: {
         inputTokens: 30,
@@ -375,12 +467,10 @@ describe("advisor tool", () => {
     const tool = createAdvisorTool(config);
     await Promise.resolve(tool.execute!({}, mockToolCallOptions));
 
-    expect(generateTextSpy).toHaveBeenCalledTimes(1);
-    const generateTextArgs = generateTextSpy.mock.calls[0]?.[0] as
-      | Record<string, unknown>
-      | undefined;
-    expect(generateTextArgs?.maxOutputTokens).toBeUndefined();
-    expect(Object.prototype.hasOwnProperty.call(generateTextArgs ?? {}, "maxOutputTokens")).toBe(
+    expect(streamTextSpy).toHaveBeenCalledTimes(1);
+    const streamTextArgs = streamTextSpy.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+    expect(streamTextArgs?.maxOutputTokens).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(streamTextArgs ?? {}, "maxOutputTokens")).toBe(
       false
     );
   });
@@ -389,7 +479,7 @@ describe("advisor tool", () => {
     using tempDir = new TestTempDir("advisor-tool-no-usage-on-error");
     const reportModelUsage = mock((_event: ToolModelUsageEvent) => undefined);
     const { config } = createToolConfig(tempDir.path, { reportModelUsage });
-    spyOn(ai, "generateText").mockRejectedValue(new Error("model unavailable"));
+    mockStreamTextFailure(new Error("model unavailable"));
 
     const tool = createAdvisorTool(config);
     const rawResult: unknown = await Promise.resolve(tool.execute!({}, mockToolCallOptions));
@@ -402,12 +492,36 @@ describe("advisor tool", () => {
     expect(reportModelUsage).not.toHaveBeenCalled();
   });
 
+  it("returns an error when streamText reports an error part", async () => {
+    using tempDir = new TestTempDir("advisor-tool-stream-error-part");
+    const reportModelUsage = mock((_event: ToolModelUsageEvent) => undefined);
+    const { config } = createToolConfig(tempDir.path, { reportModelUsage });
+    mockStreamTextSuccess({
+      text: "partial advice",
+      finishReason: "error",
+      streamError: new Error("stream broke"),
+      usage: {
+        inputTokens: 12,
+        outputTokens: 3,
+        totalTokens: 15,
+      },
+    });
+
+    const tool = createAdvisorTool(config);
+    const rawResult: unknown = await Promise.resolve(tool.execute!({}, mockToolCallOptions));
+
+    expect(rawResult).toEqual({
+      type: "error",
+      isError: true,
+      message: "Advisor request failed: stream broke",
+    });
+    expect(reportModelUsage).not.toHaveBeenCalled();
+  });
+
   it("sanitizes binary-like advisor provider failures", async () => {
     using tempDir = new TestTempDir("advisor-tool-sanitized-error");
     const { config } = createToolConfig(tempDir.path);
-    spyOn(ai, "generateText").mockRejectedValue(
-      new Error("Invalid JSON response: \u001b\u0000\ufffdpayload")
-    );
+    mockStreamTextFailure(new Error("Invalid JSON response: \u001b\u0000\ufffdpayload"));
 
     const tool = createAdvisorTool(config);
     const rawResult: unknown = await Promise.resolve(tool.execute!({}, mockToolCallOptions));
@@ -435,7 +549,7 @@ describe("advisor tool", () => {
     });
     const debugSpy = spyOn(log, "debug").mockImplementation(() => undefined);
     const { config } = createToolConfig(tempDir.path, { reportModelUsage });
-    mockGenerateTextSuccess({
+    mockStreamTextSuccess({
       text: "Keep the implementation narrow.",
       usage,
     });

--- a/src/node/services/tools/advisor.ts
+++ b/src/node/services/tools/advisor.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { generateText, tool, type Tool } from "ai";
+import { streamText, tool, type Tool } from "ai";
 
 import {
   ADVISOR_HANDOFF_MAX_REASONING_CHARS,
@@ -10,9 +10,10 @@ import {
 import type { ModelMessage } from "@/common/types/message";
 import { THINKING_LEVEL_OFF, coerceThinkingLevel } from "@/common/types/thinking";
 import { buildProviderOptions } from "@/common/utils/ai/providerOptions";
+import { extractChunkDeltaText } from "@/common/utils/ai/streamChunks";
 import { getErrorMessage } from "@/common/utils/errors";
 import { sanitizeErrorMessageForDisplay } from "@/common/utils/providerOutputSanitization";
-import type { AdvisorPhaseEvent } from "@/common/types/stream";
+import type { AdvisorOutputEvent, AdvisorPhaseEvent } from "@/common/types/stream";
 import { AdvisorToolInputSchema, TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
 import type { AdvisorToolCallSnapshot, ToolConfiguration } from "@/common/utils/tools/tools";
 import { log } from "@/node/services/log";
@@ -91,6 +92,20 @@ function buildAdvisorHandoffMessage(
   };
 }
 
+function getAdvisorTextDelta(chunk: unknown): string | undefined {
+  if (typeof chunk !== "object" || chunk === null) {
+    return undefined;
+  }
+
+  const record = chunk as Record<string, unknown>;
+  if (record.type !== "text-delta" && record.type !== "text") {
+    return undefined;
+  }
+
+  const text = extractChunkDeltaText(record, ["text", "delta", "textDelta"]);
+  return text.length > 0 ? text : undefined;
+}
+
 export function createAdvisorTool(config: ToolConfiguration): Tool {
   assert(config.advisorRuntime, "advisorRuntime must be set when advisor tool is registered");
 
@@ -155,6 +170,21 @@ export function createAdvisorTool(config: ToolConfiguration): Tool {
         } satisfies AdvisorPhaseEvent);
       };
 
+      const emitAdvisorOutput = (text: string): void => {
+        assert(text.length > 0, "advisor output chunks must be non-empty");
+        if (!config.emitChatEvent || !config.workspaceId || !toolCallId) {
+          return;
+        }
+
+        config.emitChatEvent({
+          type: "advisor-output",
+          workspaceId: config.workspaceId,
+          toolCallId,
+          text,
+          timestamp: Date.now(),
+        } satisfies AdvisorOutputEvent);
+      };
+
       emitAdvisorPhase("preparing_context");
 
       if (runtime.maxUsesPerTurn !== null && usesThisTurn >= runtime.maxUsesPerTurn) {
@@ -185,7 +215,9 @@ export function createAdvisorTool(config: ToolConfiguration): Tool {
 
         emitAdvisorPhase("waiting_for_response");
 
-        const result = await generateText({
+        let advisorStreamError: unknown;
+        const streamedAdviceChunks: string[] = [];
+        const result = streamText({
           model,
           system: ADVISOR_SYSTEM_PROMPT,
           messages,
@@ -194,11 +226,38 @@ export function createAdvisorTool(config: ToolConfiguration): Tool {
           providerOptions,
           abortSignal: abortSignal ?? runtime.abortSignal,
           ...(runtime.maxOutputTokens != null ? { maxOutputTokens: runtime.maxOutputTokens } : {}),
+          onError: ({ error }) => {
+            advisorStreamError = error;
+          },
+          onChunk: ({ chunk }) => {
+            const text = getAdvisorTextDelta(chunk);
+            if (text == null) {
+              return;
+            }
+
+            streamedAdviceChunks.push(text);
+            emitAdvisorOutput(text);
+          },
         });
+        const finalAdvice = await result.text;
+        const finishReason = await result.finishReason;
+        if (advisorStreamError != null || finishReason === "error") {
+          return {
+            type: "error" as const,
+            isError: true,
+            message: `Advisor request failed: ${sanitizeErrorMessageForDisplay(
+              getErrorMessage(advisorStreamError ?? new Error("Stream finished with an error."))
+            )}`,
+          };
+        }
+
+        const advice = finalAdvice.length > 0 ? finalAdvice : streamedAdviceChunks.join("");
+        const usage = await result.usage;
+        const providerMetadata = await result.providerMetadata;
 
         emitAdvisorPhase("finalizing_result");
 
-        if (config.reportModelUsage != null && result.usage != null) {
+        if (config.reportModelUsage != null && usage != null) {
           try {
             assert(
               advisorModelString.length > 0,
@@ -210,8 +269,8 @@ export function createAdvisorTool(config: ToolConfiguration): Tool {
               source: "tool",
               toolName: "advisor",
               model: advisorModelString,
-              usage: result.usage,
-              providerMetadata: result.providerMetadata as Record<string, unknown> | undefined,
+              usage,
+              providerMetadata: providerMetadata as Record<string, unknown> | undefined,
               toolCallId,
               timestamp: Date.now(),
             });
@@ -224,7 +283,7 @@ export function createAdvisorTool(config: ToolConfiguration): Tool {
 
         return {
           type: "advice" as const,
-          advice: result.text,
+          advice,
           advisorModel: advisorModelString,
           reasoningLevel,
           remainingUses,

--- a/tests/ipc/acp.todoPlan.test.ts
+++ b/tests/ipc/acp.todoPlan.test.ts
@@ -139,6 +139,43 @@ function getUserTextChunks(sessionUpdates: SessionNotification[]): string[] {
   });
 }
 
+function makeAdvisorOutput(toolCallId: string, text: string): WorkspaceChatMessage {
+  return {
+    type: "advisor-output",
+    workspaceId: "workspace-1",
+    toolCallId,
+    text,
+    timestamp: 3,
+  } as WorkspaceChatMessage;
+}
+
+function getToolUpdateContent(sessionUpdates: SessionNotification[]): string[] {
+  return sessionUpdates.flatMap((notification) => {
+    if (notification.update.sessionUpdate !== "tool_call_update") {
+      return [];
+    }
+
+    const content = notification.update.content ?? [];
+    return content.flatMap((block) => {
+      if (block.type !== "content" || block.content.type !== "text") {
+        return [];
+      }
+      return [block.content.text];
+    });
+  });
+}
+
+describe("ACP advisor output translation", () => {
+  it("forwards live advisor output as tool updates", async () => {
+    const { translator, sessionUpdates } = createHarness();
+
+    await forwardEvents(translator, [makeAdvisorOutput("advisor-call-1", "partial advice")]);
+
+    expect(getUpdateKinds(sessionUpdates)).toEqual(["tool_call_update"]);
+    expect(getToolUpdateContent(sessionUpdates)).toEqual(["partial advice"]);
+  });
+});
+
 describe("ACP todo_write plan translation", () => {
   it("emits ACP plan updates from todo_write tool input", async () => {
     const { translator, sessionUpdates } = createHarness();


### PR DESCRIPTION
Summary

Streams nested advisor model response text into the advisor tool card while the tool is still running, without changing the final advisor tool result contract returned to the parent model.

Background

Advisor calls previously showed phase changes only and withheld the actual advice text until `tool-call-end`. This made long advisor consultations feel opaque even though the nested model was already generating useful text.

Implementation

Adds a UI-only `advisor-output` chat event, emits it from the advisor tool's `streamText()` chunks, forwards it through the workspace chat stream, stores it as bounded transient frontend state, and renders it in the expanded advisor tool card until the final persisted tool result arrives.

Validation

- `env MUX_ESLINT_CONCURRENCY=2 make static-check`
- `bun test src/node/services/tools/advisor.test.ts`
- `bun test src/browser/stores/WorkspaceStore.test.ts`
- `bun test src/browser/features/Tools/AdvisorToolCall.test.tsx`
- `make typecheck`
- targeted eslint over touched files
- `make fmt-check`
- `git diff --check`
- Dogfooded in an isolated dev-server sandbox with GPT-5.5 main model and GPT-5.5 advisor model at low reasoning; captured video and screenshots showing advisor text appearing while the tool remained in `waiting for response`.

Risks

Risk is concentrated in chat stream/transient UI state. The new event is UI-only, bounded, cleared on final advisor tool result and stale-message cleanup, and leaves model-visible tool output unchanged.

Pains

Default lint concurrency was OOM-killed in this workspace, so local lint/static-check was run with `MUX_ESLINT_CONCURRENCY=2`.

---

<details>
<summary>📋 Implementation Plan</summary>

# Stream Advisor Responses to the Client

## Goal

Stream the nested advisor model's response text to the client UI while the advisor tool is still running, without changing what the parent model receives from the tool.

Today the advisor tool is non-streaming from the user's perspective: the backend emits live phase changes (`preparing_context`, `waiting_for_response`, `finalizing_result`), then the UI receives the full advice only when the normal `tool-call-end` result arrives. The desired UX is for the `advisor` tool card to show advice text incrementally as the nested advisor model produces it.

## Current implementation evidence

Verified implementation points from the repo:

- `src/node/services/tools/advisor.ts`
  - `createAdvisorTool()` currently calls `generateText()` for the nested advisor request.
  - It emits only `advisor-phase` UI events during execution.
  - It returns a final tool result shaped like `{ type: "advice", advice, advisorModel, reasoningLevel, remainingUses }`.
  - It reports advisor model usage through `config.reportModelUsage` after the nested call completes.
- `src/node/services/aiService.ts`
  - Advisor eligibility is computed from experiment state, per-agent defaults, and `advisorModelString`.
  - `advisorRuntime` is injected into `getToolsForModel()` only when eligible.
  - Existing `onAdvisorChunk` captures the parent model's same-step text/reasoning before the advisor tool call; it does **not** stream advisor output.
- `src/common/orpc/schemas/stream.ts`
  - `AdvisorPhaseEventSchema` already defines a UI-only advisor event carried over `workspace.onChat`.
  - `WorkspaceChatMessageSchema` is the discriminated union that must include any new chat-stream event.
- `src/node/services/agentSession.ts`
  - AIService events are forwarded into workspace chat subscriptions; `advisor-phase` is already forwarded.
- `src/browser/stores/WorkspaceStore.ts`
  - Transient live state already exists for `liveAdvisorPhase`.
  - The store buffers live stream events until caught-up, updates live phase on `advisor-phase`, and clears advisor phase on `tool-call-end` for `advisor`.
- `src/browser/features/Tools/AdvisorToolCall.tsx`
  - The component renders phase/timer while executing and renders final Markdown advice only after the final result is available.

## Advisor review status

An advisor review was requested after drafting this plan. Two advisor tool calls were attempted with compact review prompts, but both failed before returning advice with a sanitized provider error: `Advisor request failed: Invalid JSON response` with binary-like payload content. No advisor-originated recommendations were available to incorporate.

Because the review tool itself failed, the plan below is conservative and self-reviewed against the verified code paths. If the advisor tool becomes healthy before implementation starts, retry the review using the same summary and incorporate any concrete feedback before coding.

## Recommended approach

### Approach A — UI-only `advisor-output` event + nested `streamText()` (**recommended**)

**Product LoC estimate:** net +300 to +450 product LoC.

Implement a new UI-only chat event, tentatively named `advisor-output`, that carries advisor text deltas from the backend to the renderer while the tool is running. Replace the nested advisor `generateText()` call with `streamText()` and use `onChunk` (or an equivalent `fullStream` loop) to emit output chunks as they arrive. Accumulate those same chunks in the backend and preserve the existing final tool result shape for the parent model.

Why this is the best fit:

- Matches existing patterns (`advisor-phase`, `bash-output`, `task-created`) for UI-only tool progress.
- Does not conflate advisor output with normal assistant `stream-delta` events.
- Does not change the parent model's tool protocol: the parent still receives one final tool result after `execute()` resolves.
- Keeps persistence simple: final advice is still persisted through the normal dynamic-tool output part.
- Allows a small, surgical implementation with low risk to the main stream pipeline.

### Alternatives considered

#### Approach B — Reuse `tool-call-delta` for advisor output

**Product LoC estimate:** net +180 to +280 product LoC, but **not recommended**.

`tool-call-delta` currently means streaming tool **input args** from the parent model, not tool output from a running tool. Reusing it would blur semantics and complicate existing stream processing/tests.

#### Approach C — Persist partial advisor output as mutable tool result state

**Product LoC estimate:** net +500 to +800 product LoC, not needed for the first version.

This would make reconnect/replay show in-progress advisor output exactly, but requires deeper changes to dynamic-tool persistence/partial writes and would risk coupling UI-only progress with model-visible tool output. Consider later only if live-only reconnect behavior is insufficient.

## Scope

In scope:

- Stream advisor final text deltas to the current client session while advisor is running.
- Preserve the existing final advisor result contract.
- Preserve advisor usage reporting and per-turn cap behavior.
- Render live advisor text inside the existing `AdvisorToolCall` UI.
- Clear transient live output once the final `tool-call-end` result is available.
- Add tests for backend streaming, schema/store handling, and UI rendering.

Out of scope for this iteration:

- Streaming advisor reasoning/thinking to the UI.
- Streaming advisor chunks to the parent model as incremental tool output.
- Persisting every advisor chunk in history.
- Replaying missed advisor chunks after disconnect/reload before the final tool result exists.
- Changing advisor model selection, agent gating, or tool policy.

## Detailed implementation plan

### Phase 0 — Pre-flight decisions

Before coding, confirm these defaults unless the implementer discovers a strong reason to change them:

- Event name: `advisor-output`.
- Payload field for chunks: `text` rather than `delta`, matching `bash-output`'s tool-output wording.
- Stream only advisor final text, not reasoning deltas.
- Do not persist partial advisor chunks; final `tool-call-end` remains the durable source of truth.
- Do not add a `messageId` in the first version; `workspaceId + toolCallId` is enough for transient UI state and matches existing `advisor-phase` scoping.

### Phase 1 — Add a UI-only advisor output event contract

**Files likely touched:**

- `src/common/orpc/schemas/stream.ts`
- `src/common/orpc/schemas.ts`
- `src/common/types/stream.ts`
- `src/common/orpc/types.ts`

**Steps:**

1. Add a new schema near `AdvisorPhaseEventSchema`, for example:

   ```ts
   export const AdvisorOutputEventSchema = z.object({
     type: z.literal("advisor-output"),
     workspaceId: z.string(),
     toolCallId: z.string(),
     text: z.string(),
     timestamp: z.number(),
   });
   ```

2. Add `AdvisorOutputEventSchema` to `WorkspaceChatMessageSchema`.
3. Re-export/import the new schema through the aggregate schema module if needed (`src/common/orpc/schemas.ts` currently gathers stream schemas for downstream imports).
4. Export the inferred `AdvisorOutputEvent` type from `src/common/types/stream.ts`.
5. Add `isAdvisorOutputEvent()` to `src/common/orpc/types.ts`.
6. Keep the event UI-only: it should not be transformed into a `MuxMessage` and should not become model-visible history.

**Defensive checks:**

- Only emit non-empty `text` chunks.
- Keep `workspaceId` and `toolCallId` required so the renderer can scope chunks to a single tool card.
- Avoid adding `messageId` unless a later implementation needs replay dedupe; `advisor-phase` and `bash-output` already scope by workspace/toolCallId.

**Quality gate:**

- Run the type/schema tests that cover ORPC stream schemas, or at minimum `make typecheck` after Phase 2 when event producers exist.

### Phase 2 — Stream inside the advisor backend tool

**Files likely touched:**

- `src/node/services/tools/advisor.ts`
- Tests in `src/node/services/tools/advisor.test.ts`

**Steps:**

1. Replace the nested `generateText()` call with `streamText()` from the AI SDK.
2. Keep all existing request inputs the same:
   - `model`
   - `system: ADVISOR_SYSTEM_PROMPT`
   - `messages`
   - `tools: {}`
   - `providerOptions`
   - parent/combined abort signal
   - optional `maxOutputTokens`
3. Use `onChunk` to capture `text-delta` chunks from the advisor stream.
   - Extract text defensively from `text`, `delta`, or `textDelta` because current stream code already handles provider/SDK variation this way.
   - Ignore empty chunks.
4. For every non-empty text delta:
   - append it to a local `adviceText` accumulator,
   - emit `{ type: "advisor-output", workspaceId, toolCallId, text: delta, timestamp: Date.now() }` via `config.emitChatEvent` if available.
5. Await the stream's final text to guarantee completion.
   - Prefer `const streamResult = streamText(...); const finalAdvice = await streamResult.text;` while using `onChunk` for live updates.
   - Assert or reconcile that `finalAdvice` is non-empty or equal to the accumulated text when practical. Do not fail a successful call solely because chunk accumulation differs; use the final SDK text as the source of truth for the returned tool result.
6. Await usage/provider metadata after stream completion and feed them into the existing `reportModelUsage` path.
   - Use `streamResult.usage` or `streamResult.totalUsage` based on what best matches current `generateText()` semantics for a one-step, tool-less advisor call.
   - Keep provider metadata stamping unchanged in `AIService.reportModelUsage`.
7. Preserve existing error handling:
   - Abort returns `Advisor request was aborted.`
   - Other failures return sanitized `Advisor request failed: ...`
   - No usage is reported on failed advisor model calls.
8. Preserve existing phase events:
   - `preparing_context` before transcript/handoff work,
   - `waiting_for_response` immediately before starting `streamText()`/awaiting response,
   - `finalizing_result` after the nested stream finishes and before returning final result.

**Defensive checks:**

- Keep current assertions for `advisorRuntime`, non-empty model string, valid reasoning level, max uses, output token cap, transcript snapshot, and `toolCallId`.
- Add a narrow helper for chunk text extraction with tests, or reuse/extract an existing helper only if it keeps the change smaller than duplicating a few lines.
- Ensure concurrent advisor tool calls still respect `usesThisTurn++` before awaits.

**Quality gate:**

- Update `src/node/services/tools/advisor.test.ts` to mock `streamText()` instead of `generateText()`.
- Add/adjust tests for:
  - successful final result still has the same shape,
  - usage is reported once after completion,
  - `advisor-output` events are emitted for text chunks before final result,
  - empty chunks are ignored,
  - no output events are emitted if `emitChatEvent`, `workspaceId`, or `toolCallId` is unavailable,
  - abort/error behavior remains unchanged,
  - max output tokens are still passed.

### Phase 3 — Forward advisor output events through workspace chat

**Files likely touched:**

- `src/node/services/agentSession.ts`
- Any typed AIService event declarations if present near event emission/listening code

**Steps:**

1. Add a forwarding branch mirroring `advisor-phase`:

   ```ts
   forward("advisor-output", (payload) => {
     this.markActiveStreamHadAnyOutput();
     this.emitChatEvent(payload);
   });
   ```

   If `markActiveStreamHadAnyOutput()` is too broad for UI-only advisor chunks, omit it; however `bash-output` already marks output, and advisor text is user-visible output from a running tool, so marking is reasonable.

2. Confirm the event traverses:
   - advisor tool `config.emitChatEvent`,
   - `AIService.emit(event.type, event)`,
   - `AgentSession` forwarding,
   - `workspace.onChat` ORPC subscription.

**Quality gate:**

- Add/extend tests if there is an existing AgentSession forwarding coverage pattern. Otherwise rely on WorkspaceStore integration tests plus typecheck, since this forwarding path is identical to existing UI-only events.

### Phase 4 — Store live advisor output in renderer transient state

**Files likely touched:**

- `src/browser/stores/WorkspaceStore.ts`
- `src/browser/stores/WorkspaceStore.test.ts`

**Steps:**

1. Add a transient output state type, for example:

   ```ts
   export interface AdvisorLiveOutputState {
     text: string;
     timestamp: number;
   }
   ```

2. Add `liveAdvisorOutput: Map<string, AdvisorLiveOutputState>` to `WorkspaceChatTransientState`.
3. Initialize it in the transient state factory.
4. Add `getAdvisorToolLiveOutput(workspaceId, toolCallId)` and `useAdvisorToolLiveOutput(...)`.
   - Return the stored object reference, not a freshly allocated object, to avoid `useSyncExternalStore` loops.
5. Treat `advisor-output` as a buffered event before caught-up, like `bash-output`, `advisor-phase`, and `task-created`.
6. In `processStreamEvent()`:
   - identify `isAdvisorOutputEvent(data)`,
   - append `data.text` to the previous live output for that `toolCallId`,
   - update timestamp,
   - schedule a throttled/idle state bump rather than immediate re-render on every token.
7. Clear `liveAdvisorOutput`:
   - on `tool-call-end` for `advisor`, alongside `liveAdvisorPhase`,
   - on full replay / no active stream / stream mismatch where `liveAdvisorPhase` is already cleared.

**Defensive checks:**

- Ignore zero-length `text` defensively in the store even if backend filters it.
- Preserve stable snapshots for unchanged events.
- Do not append chunks after the final tool result is processed for the same tool call.

**Quality gate:**

- Extend `WorkspaceStore.test.ts` with tests for:
  - accumulating multiple advisor-output chunks,
  - buffering before caught-up then applying in order,
  - clearing on advisor `tool-call-end`,
  - clearing on full replay/no active stream cleanup.

### Phase 5 — Render live advisor text in the tool UI

**Files likely touched:**

- `src/browser/features/Tools/AdvisorToolCall.tsx`
- `src/browser/features/Tools/AdvisorToolCall.test.tsx`

**Steps:**

1. Import/use `useAdvisorToolLiveOutput(workspaceId, toolCallId)`.
2. Compute a `liveAdviceText` only while the tool is executing and final `advisorResult` is not present.
3. Render live text in the existing expanded details area:
   - show the same `Advice` section when `liveAdviceText` is non-empty,
   - render through `MarkdownRenderer` with `preserveLineBreaks`, matching final advice,
   - optionally show a small `LoadingDots` indicator next to the section label or below the text.
4. Keep final result behavior unchanged:
   - once `advisorResult?.type === "advice"`, render `advisorResult.advice` as today,
   - final result should supersede and clear live text via store cleanup.
5. Use live text as `ToolDetails text` fallback so copy/selection/preview behavior works while streaming, if that prop is intended for that purpose.
6. Keep collapsed header focused on phase/timer. Do not stream full text into the collapsed header.

**Performance guardrail:**

- Because Markdown rendering can be expensive, rely on WorkspaceStore throttling for high-frequency output. If dogfooding shows jank, switch live rendering to a plain text/pre-wrap block and keep Markdown rendering for the final result only.

**Quality gate:**

- Extend `AdvisorToolCall.test.tsx` to verify:
  - live output renders while `status="executing"` and final result is absent,
  - final advice still renders after completion,
  - final advice supersedes live output,
  - the fallback "Running"/phase behavior still works when no live output exists.

### Phase 6 — Validation and dogfooding

#### Automated validation

Run targeted tests first, then broader validation:

1. `bun test src/node/services/tools/advisor.test.ts`
2. `bun test src/browser/features/Tools/AdvisorToolCall.test.tsx`
3. `bun test src/browser/stores/WorkspaceStore.test.ts`
4. `make typecheck`
5. `make lint`
6. If the diff is small and time allows, `make test` or `make static-check`.

Fix failures before claiming success.

#### Manual dogfooding setup

1. Start a development Mux instance in an isolated workspace.
   - Preferred: use the repo's desktop/dev-server sandbox skills if available to avoid interfering with the user's running Mux.
   - Fallback: run the normal dev target from this repo, e.g. `make dev`, following current project instructions.
2. Enable the `advisor-tool` experiment in Settings → Experiments.
3. Configure an advisor model in the advisor settings UI.
4. Ensure the active agent has Advisor enabled in Settings → Tasks.
5. Open a test workspace and ask a prompt that should naturally call `advisor`, for example:
   - "Plan a risky refactor and use advisor before deciding."
6. Use `agent-browser`/Electron automation to capture:
   - an initial screenshot/video frame showing the `advisor` tool card in a running phase,
   - a screenshot/video while advisor text is partially streamed in the expanded card,
   - a final screenshot after `tool-call-end` showing the final advice result.
7. Attach screenshots and the recording artifact for reviewer verification.

#### Real dogfooding continuation request (Plan Mode note)

The user requested a **real** dogfooding session after implementation, specifically:

- read the `dogfood`, `agent-browser`, and `dev-server-sandbox` skills;
- use `agent-browser skills get core` before browser automation;
- start a real isolated Mux dev-server sandbox rather than a synthetic component-only page;
- configure providers using the keys already present, preferably selecting a faster advisor model so streaming chunks are visible quickly;
- record a video of the real advisor tool streaming output and attach that video in chat.

Plan Mode constraints currently prevent executing this request directly: only the plan file may be edited, and bash must remain read-only. A real dogfood session requires non-read-only operations such as starting a sandbox that creates a temporary `MUX_ROOT`, copying provider/project config, changing sandbox settings/provider choices, creating dogfood output directories/artifacts, and recording video files. The next step therefore requires switching back to Exec mode.

**Dogfood-only approach — real sandbox session**

**Product LoC estimate:** net +0 product LoC, unless dogfooding uncovers a bug that must be fixed.

Execution plan once in Exec mode:

1. Re-check working tree and preserve all intentional formatter changes noted in the continuation message.
2. Start an isolated Mux instance with `make dev-server-sandbox`.
   - Use the default sandbox seeding behavior so provider config from the developer root is copied when present.
   - Capture the printed `MUX_ROOT`, backend port, and Vite URL without exposing secrets.
3. Open the sandbox URL with a named `agent-browser` session.
   - Start with `agent-browser skills get core` guidance: `open`, `snapshot -i`, interact by refs, re-snapshot after changes.
4. Configure runtime/settings in the UI:
   - enable the advisor tool experiment if not already enabled;
   - configure/select a provider/model using only keys already present in the sandboxed provider config;
   - choose a fast advisor model when available (for example a fast OpenAI/Anthropic small model) so partial chunks appear quickly;
   - ensure the active agent permits advisor usage.
5. Create or select a disposable workspace in the sandbox UI.
6. Start a video recording before the user-visible advisor interaction:
   - output path under a dogfood artifacts directory outside the repo or in an ignored temp location;
   - record the whole flow from prompt submit through live advisor streaming and final result.
7. Send a prompt that strongly encourages advisor use, e.g. “Plan a risky refactor and use advisor before deciding; keep the advisor answer long enough that streaming is visible.”
8. During recording, expand the advisor tool card and verify:
   - phase/status appears first;
   - text chunks appear before final `tool-call-end`;
   - final completed advice supersedes the live text cleanly;
   - parent assistant continues normally after the advisor result.
9. Capture supporting screenshots at the key states (initial running, partial streamed advice, final result) and check browser console/errors.
10. Stop the video recording, attach the video in chat, and optionally attach the best screenshot.
11. If dogfooding reveals defects, return to implementation with a focused TDD fix, then repeat targeted validation and the real dogfood capture.

**Dogfood quality gates:**

- Real sandbox, not synthetic component page.
- Provider/model settings configured from existing keys only; no keys printed in logs or chat.
- Video artifact attached in chat.
- Screenshots/video show actual advisor tool card streaming text incrementally.
- Console/errors checked and summarized.
- No repo-untracked dogfood artifacts left behind unless intentionally ignored/temp.

#### Dogfooding acceptance checks

- Advisor text appears incrementally before the final tool result.
- The final tool result exactly matches the completed advice shown live.
- The main assistant output does not show advisor text as normal assistant `stream-delta` content.
- The parent assistant continues after the advisor tool completes and can use the final advice.
- Interrupting the stream while advisor is running returns an advisor abort/error result and does not leave stale live output in the next turn.
- Reconnecting/reloading during advisor execution does not crash; at worst, in-progress live chunks are missing until final result arrives.

## Acceptance criteria

- The advisor backend uses streaming for nested advisor model responses.
- UI receives and renders advisor text chunks before the final `tool-call-end`.
- Final advisor tool result shape remains backward-compatible.
- Parent model behavior is unchanged: it receives only the completed advisor result after tool execution.
- No advisor chunks are persisted as normal assistant text or sent to future model calls outside the final tool result.
- Usage/cost reporting for advisor model calls remains correct and isolated under the advisor model/tool bucket.
- Existing advisor phase display still works.
- Live advisor output is transient and cleared when the final advisor result arrives.
- Automated tests cover backend streaming, renderer state accumulation/cleanup, and UI rendering.
- Dogfooding evidence includes screenshots and a video/recording of live advisor output streaming.

## Risks and mitigations

| Risk | Mitigation |
| --- | --- |
| AI SDK `streamText()` result usage/provider metadata differs from `generateText()` | Add focused unit tests around usage reporting; use a one-step tool-less stream to match current semantics. |
| Markdown rendering every chunk causes UI jank | Throttle store bumps; if needed, render live output as plain text and final output as Markdown. |
| Event ordering before caught-up causes missing chunks | Add `advisor-output` to buffered event handling before caught-up. |
| Reconnect during advisor execution loses transient chunks | Accept for first version; final tool result remains authoritative. Document as non-goal. |
| Accidentally exposing advisor text as normal assistant text | Use a distinct UI-only event, never `stream-delta`. Add store/UI tests. |
| Parent model expects final tool result and cannot consume partial output | Preserve `execute()` return shape and treat streaming as UI-only. |
| Duplicated final/live text | Clear transient output on `tool-call-end`; final result supersedes live output. |

## Suggested implementation order

1. Event schema/type guard (`advisor-output`).
2. Backend advisor streaming + unit tests.
3. AgentSession forwarding.
4. WorkspaceStore transient state + tests.
5. AdvisorToolCall rendering + tests.
6. Typecheck/lint/targeted tests.
7. Retry advisor review if the advisor tool has recovered; otherwise proceed with the documented failed-review caveat.
8. Manual dogfooding with screenshots/video.

This order keeps the backend producer and event contract testable before touching UI rendering, then validates the renderer pipeline with transient-state tests before dogfooding the full UX.

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$139.03`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=139.03 -->
