### PR TITLE
🤖 fix: remove missing README screenshot

### DIFF
--- a/.mux/skills/generate-readme-screenshots/SKILL.md
+++ b/.mux/skills/generate-readme-screenshots/SKILL.md
@@ -92,7 +92,6 @@ If **any** of these fail:
 | `CostsTabRich`            | `costs-tab.webp`          | No                              |
 | `ContextManagementDialog` | `context-management.webp` | Yes (open settings dialog)      |
 | `MobileServerMode`        | `mobile-server-mode.webp` | No                              |
-| `OrchestrateAgents`       | `orchestrate-agents.webp` | No                              |
 
 ### Key Files
 
@@ -141,7 +140,7 @@ bun run scripts/capture-readme-screenshots.ts --storybook-url http://localhost:6
 
 The script:
 
-- Iterates all 8 stories sequentially
+- Iterates all 7 stories sequentially
 - Opens a fresh Playwright page per story
 - Waits for `networkidle` + 2s stabilization
 - Runs `playInteraction` if defined (with up to 3 retries for flaky interactions)
@@ -163,8 +162,8 @@ bun run scripts/capture-readme-screenshots.ts --story ContextManagementDialog
 ### 5. Verify & Commit
 
 ```bash
-# Check all 8 files are present and 3800px wide
-for f in code-review agent-status git-status plan-mermaid costs-tab context-management mobile-server-mode orchestrate-agents; do
+# Check all 7 generated files are present
+for f in code-review agent-status git-status plan-mermaid costs-tab context-management mobile-server-mode; do
   bun -e "const s = require('sharp'); const m = await s('docs/img/${f}.webp').metadata(); console.log('${f}:', m.width + 'x' + m.height)"
 done
 
@@ -209,6 +208,6 @@ The retry logic handles most cases. If persistent:
 
 ### Why there is no ProductHero screenshot story
 
-Intentional — README now uses `mux-demo.gif` as the hero media. The README
-screenshot pipeline covers only the 9 `docs/img/*.webp` assets that remain in
+Intentional. README now uses `mux-demo.gif` as the hero media. The README
+screenshot pipeline covers only the 7 generated WebP assets that remain in
 README, starting with `code-review.webp`.

--- a/README.md
+++ b/README.md
@@ -74,13 +74,9 @@ macOS and Linux.
 </td>
 </tr>
 <tr>
-<td align="center" width="50%">
-<img src="./docs/img/context-management.webp" alt="Screenshot of context management dialog" width="100%" /><br>
+<td align="center" colspan="2">
+<img src="./docs/img/context-management.webp" alt="Screenshot of context management dialog" width="50%" /><br>
 <sub>Context management dialog keeps compaction controls in one place</sub>
-</td>
-<td align="center" width="50%">
-<img src="./docs/img/orchestrate-agents.webp" alt="Screenshot of orchestrate agents" width="100%" /><br>
-<sub>Orchestrate parallel agent tasks with plan mode</sub>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
> Mux is working on behalf of Mike.

## Summary
Removes the missing orchestration screenshot from the README and updates the README screenshot generation skill to match the seven remaining generated assets.

## Background
The README referenced `docs/img/orchestrate-agents.webp`, but that asset is no longer present, so the image rendered as a 404. The orchestration screenshot is no longer needed in the README screenshot workflow.

## Implementation
- Removed the orchestration screenshot table cell from `README.md`.
- Updated the `generate-readme-screenshots` skill mapping, capture count, verification loop, and process notes to omit `orchestrate-agents.webp`.

## Validation
- make static-check

## Risks
Low. This only removes a broken documentation image reference and updates the local screenshot-process instructions.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$2.93`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=2.93 -->
