### PR TITLE
🤖 feat: preview markdown attach_file outputs

### DIFF
--- a/src/browser/features/Tools/AttachFileToolCall.stories.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.stories.tsx
@@ -103,6 +103,26 @@ export const DisplayOnlyAudio: Story = {
   ),
 };
 
+export const DisplayOnlyMarkdown: Story = {
+  render: () => (
+    <ToolStoryShell>
+      <AttachFileToolCall
+        toolName="attach_file"
+        args={{ path: "release-notes.md" }}
+        result={createAttachFileResult(
+          createDisplayOnlyFilePart({
+            data: "IyBSZWxlYXNlIE5vdGVzCgotIEFkZGVkICoqbWFya2Rvd24qKiBwcmV2aWV3Lgo=",
+            mediaType: "text/markdown",
+            filename: "release-notes.md",
+            size: 47,
+          })
+        )}
+        status="completed"
+      />
+    </ToolStoryShell>
+  ),
+};
+
 export const DisplayOnlyGenericFile: Story = {
   render: () => (
     <ToolStoryShell>

--- a/src/browser/features/Tools/AttachFileToolCall.test.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.test.tsx
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+import { GlobalWindow } from "happy-dom";
+import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
+import { createDisplayOnlyFilePart } from "@/common/utils/attachments/displayOnlyFileParts";
+import { AttachFileToolCall } from "./AttachFileToolCall";
+
+describe("AttachFileToolCall", () => {
+  let originalWindow: typeof globalThis.window;
+  let originalDocument: typeof globalThis.document;
+
+  beforeEach(() => {
+    originalWindow = globalThis.window;
+    originalDocument = globalThis.document;
+
+    globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
+    globalThis.document = globalThis.window.document;
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.window = originalWindow;
+    globalThis.document = originalDocument;
+  });
+
+  test("renders display-only markdown files with preview and download", () => {
+    const markdown = "# Release Notes\n\n- Added **markdown** preview.\n";
+    const data = Buffer.from(markdown).toString("base64");
+
+    const view = render(
+      <TooltipProvider>
+        <AttachFileToolCall
+          toolName="attach_file"
+          args={{ path: "release-notes.md" }}
+          result={{
+            type: "content",
+            value: [
+              { type: "text", text: "[File shown to user: release-notes.md]" },
+              createDisplayOnlyFilePart({
+                data,
+                mediaType: "text/markdown",
+                filename: "release-notes.md",
+                size: Buffer.byteLength(markdown),
+              }),
+            ],
+          }}
+          status="completed"
+        />
+      </TooltipProvider>
+    );
+
+    expect(view.getByText(/Release Notes/)).toBeTruthy();
+    expect(view.getByText(/Added/)).toBeTruthy();
+    expect(view.getByText(/Shown to the user only/)).toBeTruthy();
+
+    const download = view.getByRole("link", { name: /Download/ });
+    expect(download.getAttribute("download")).toBe("release-notes.md");
+    expect(download.getAttribute("href")).toBe(`data:text/markdown;base64,${data}`);
+  });
+});

--- a/src/browser/features/Tools/AttachFileToolCall.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.tsx
@@ -1,7 +1,10 @@
 import type React from "react";
 import { Download, FileText } from "lucide-react";
 import { isValidBase64AttachmentData } from "@/common/utils/attachments/base64";
-import { normalizeAttachmentMediaType } from "@/common/utils/attachments/supportedAttachmentMediaTypes";
+import {
+  MARKDOWN_MEDIA_TYPE,
+  normalizeAttachmentMediaType,
+} from "@/common/utils/attachments/supportedAttachmentMediaTypes";
 import { formatBytes } from "@/common/utils/formatBytes";
 import { isToolContentResult } from "@/common/utils/tools/toolContentResult";
 import {
@@ -9,6 +12,7 @@ import {
   isDisplayOnlyFilePart,
   type DisplayOnlyFilePart,
 } from "@/common/utils/attachments/displayOnlyFileParts";
+import { MarkdownRenderer } from "../Messages/MarkdownRenderer";
 import {
   ToolContainer,
   ToolHeader,
@@ -26,6 +30,9 @@ import { useToolExpansion, getStatusDisplay, type ToolStatus } from "./Shared/to
 import { JsonHighlight } from "./Shared/HighlightedCode";
 import { redactToolResultAttachmentsForDisplay } from "./Shared/toolResultDisplay";
 import { ToolResultImages, extractImagesFromToolResult } from "./Shared/ToolResultImages";
+
+const MARKDOWN_PREVIEW_CHAR_LIMIT = 50_000;
+const MARKDOWN_PREVIEW_MEDIA_TYPES = new Set([MARKDOWN_MEDIA_TYPE, "text/x-markdown"]);
 
 interface AttachFileToolCallProps {
   toolName: string;
@@ -50,12 +57,48 @@ function createSafeDataUrl(file: DisplayOnlyFilePart): string | null {
   return `data:${normalizeAttachmentMediaType(file.mediaType)};base64,${file.data}`;
 }
 
+function isMarkdownPreviewMediaType(mediaType: string): boolean {
+  return MARKDOWN_PREVIEW_MEDIA_TYPES.has(normalizeAttachmentMediaType(mediaType));
+}
+
+function decodeBase64Utf8(data: string): string | null {
+  if (!isValidBase64AttachmentData(data)) {
+    return null;
+  }
+
+  try {
+    const binary = globalThis.atob(data);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index++) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+function createMarkdownPreview(markdown: string): { content: string; truncated: boolean } {
+  if (markdown.length <= MARKDOWN_PREVIEW_CHAR_LIMIT) {
+    return { content: markdown, truncated: false };
+  }
+
+  return {
+    content: markdown.slice(0, MARKDOWN_PREVIEW_CHAR_LIMIT),
+    truncated: true,
+  };
+}
+
 const DisplayOnlyFile: React.FC<{ file: DisplayOnlyFilePart }> = (props) => {
   const dataUrl = createSafeDataUrl(props.file);
   const baseMediaType = normalizeAttachmentMediaType(props.file.mediaType);
   const label = props.file.filename ?? `Attachment (${baseMediaType})`;
   const metadata = getDisplayOnlyFileMetadata(props.file.providerOptions);
   const formattedSize = metadata?.size != null ? formatBytes(metadata.size) : null;
+  const markdownText = isMarkdownPreviewMediaType(baseMediaType)
+    ? decodeBase64Utf8(props.file.data)
+    : null;
+  const markdownPreview = markdownText != null ? createMarkdownPreview(markdownText) : null;
 
   return (
     <div className="border-border-light bg-dark mt-2 max-w-xl rounded border p-3">
@@ -71,6 +114,17 @@ const DisplayOnlyFile: React.FC<{ file: DisplayOnlyFilePart }> = (props) => {
       )}
       {dataUrl != null && baseMediaType.startsWith("audio/") && (
         <audio controls src={dataUrl} title={label} className="w-full" />
+      )}
+
+      {markdownPreview != null && (
+        <div className="border-border-light bg-background max-h-80 overflow-auto rounded border p-3 text-[11px]">
+          <MarkdownRenderer content={markdownPreview.content} />
+          {markdownPreview.truncated && (
+            <div className="text-muted mt-3 border-t border-white/10 pt-2 text-xs">
+              Preview truncated. Download the file to view the full markdown.
+            </div>
+          )}
+        </div>
       )}
 
       <div className="mt-2 flex items-center gap-2 text-xs text-[var(--color-subtle)]">

--- a/src/common/utils/attachments/supportedAttachmentMediaTypes.ts
+++ b/src/common/utils/attachments/supportedAttachmentMediaTypes.ts
@@ -1,6 +1,7 @@
 import { SVG_MEDIA_TYPE } from "@/common/constants/imageAttachments";
 
 export const PDF_MEDIA_TYPE = "application/pdf";
+export const MARKDOWN_MEDIA_TYPE = "text/markdown";
 
 const EXTENSION_TO_MEDIA_TYPE: Record<string, string> = {
   png: "image/png",

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -1031,7 +1031,7 @@ export const TOOL_DEFINITIONS = {
     description:
       "Attach a supported file from the filesystem so later model steps receive it as a real attachment instead of a huge base64 JSON blob. " +
       "Accepts absolute or relative paths, including files outside the workspace. " +
-      "Currently supports raster images, SVG, and PDF. Unsupported file types are shown to the user in chat when possible, but only a notice is sent to the model.",
+      "Currently supports raster images, SVG, and PDF as model attachments. Markdown files are shown to the user for preview/download only. Unsupported file types are shown to the user in chat when possible, but only a notice is sent to the model.",
     schema: z.preprocess(
       normalizeFilePath,
       z

--- a/src/node/services/tools/attach_file.test.ts
+++ b/src/node/services/tools/attach_file.test.ts
@@ -291,6 +291,58 @@ describe("attach_file tool", () => {
     });
   });
 
+  it("shows markdown files to the user without attaching them to the model", async () => {
+    using workspaceDir = new TestTempDir("attach-file-workspace");
+    const tool = createTestAttachFileTool(workspaceDir.path);
+    const markdownPath = path.join(workspaceDir.path, "release-notes.md");
+    const markdown = "# Release Notes\n\n- Added preview/download support.\n";
+    await fs.writeFile(markdownPath, markdown);
+
+    const result = expectSuccessfulAttachFileResult(
+      (await tool.execute!(
+        { path: "release-notes.md" },
+        mockToolCallOptions
+      )) as AttachFileToolResult
+    );
+
+    expect(result.value[0].type).toBe("text");
+    if (result.value[0].type !== "text") {
+      throw new Error("Expected display-only status text");
+    }
+    expect(result.value[0].text).toContain("release-notes.md (text/markdown)");
+    expect(result.value[0].text).toContain("not supported as a model attachment");
+    expect(result.value[1]).toEqual({
+      type: "display_file",
+      data: Buffer.from(markdown).toString("base64"),
+      mediaType: "text/markdown",
+      filename: "release-notes.md",
+      providerOptions: { mux: { displayOnly: true, size: Buffer.byteLength(markdown) } },
+    });
+  });
+
+  it("allows a markdown media type override for generated files with ambiguous extensions", async () => {
+    using workspaceDir = new TestTempDir("attach-file-workspace");
+    const tool = createTestAttachFileTool(workspaceDir.path);
+    const markdownPath = path.join(workspaceDir.path, "release-notes.out");
+    const markdown = "# Release Notes\n";
+    await fs.writeFile(markdownPath, markdown);
+
+    const result = expectSuccessfulAttachFileResult(
+      (await tool.execute!(
+        { path: "release-notes.out", mediaType: "text/markdown; charset=utf-8" },
+        mockToolCallOptions
+      )) as AttachFileToolResult
+    );
+
+    expect(result.value[1]).toEqual({
+      type: "display_file",
+      data: Buffer.from(markdown).toString("base64"),
+      mediaType: "text/markdown",
+      filename: "release-notes.out",
+      providerOptions: { mux: { displayOnly: true, size: Buffer.byteLength(markdown) } },
+    });
+  });
+
   it("rejects text-like unsupported files so the model can use file_read", async () => {
     using workspaceDir = new TestTempDir("attach-file-workspace");
     const tool = createTestAttachFileTool(workspaceDir.path);

--- a/src/node/utils/attachments/readAttachmentFromPath.ts
+++ b/src/node/utils/attachments/readAttachmentFromPath.ts
@@ -4,6 +4,7 @@ import { MAX_SVG_TEXT_CHARS, SVG_MEDIA_TYPE } from "@/common/constants/imageAtta
 import { getErrorMessage } from "@/common/utils/errors";
 import {
   getSupportedAttachmentMediaType,
+  MARKDOWN_MEDIA_TYPE,
   normalizeAttachmentMediaType,
 } from "@/common/utils/attachments/supportedAttachmentMediaTypes";
 import type { FileStat, Runtime } from "@/node/runtime/Runtime";
@@ -46,7 +47,14 @@ const EXTENSION_TO_DISPLAY_MEDIA_TYPE: Record<string, string> = {
   mp3: "audio/mpeg",
   wav: "audio/wav",
   ogg: "audio/ogg",
+  md: MARKDOWN_MEDIA_TYPE,
+  markdown: MARKDOWN_MEDIA_TYPE,
+  mdown: MARKDOWN_MEDIA_TYPE,
 };
+
+// Markdown is intentionally display-only: agents should use file_read when they need
+// the contents, while attach_file gives users a quick preview/download affordance.
+const DISPLAY_ONLY_MARKDOWN_MEDIA_TYPES = new Set([MARKDOWN_MEDIA_TYPE, "text/x-markdown"]);
 
 const TEXT_EXTENSIONS_REQUIRING_FILE_READ = new Set([
   "c",
@@ -198,6 +206,9 @@ function getDisplayFileMediaTypeCandidate(
 
   if (rawMediaType != null) {
     const mediaType = normalizeAttachmentMediaType(rawMediaType);
+    if (DISPLAY_ONLY_MARKDOWN_MEDIA_TYPES.has(mediaType)) {
+      return { mediaType, requireBinaryContent: false };
+    }
     if (mediaType.startsWith("text/") || TEXT_MEDIA_TYPES_REQUIRING_FILE_READ.has(mediaType)) {
       return null;
     }


### PR DESCRIPTION
## Summary

Adds display-only markdown support to `attach_file`, so generated `.md` files can be previewed and downloaded in chat without being sent back to the model as file attachments.

## Background

Agents can already use file read tools when they need markdown contents. This keeps that boundary intact while making agent-generated markdown files easy for users to inspect and save.

## Implementation

- Treat `.md`, `.markdown`, `.mdown`, and explicit `text/markdown` overrides as display-only attach_file outputs.
- Render display-only markdown with the existing sanitized markdown renderer and keep the existing download affordance.
- Document the attach_file tool behavior as model-attachment support for images/PDFs plus display-only markdown.

## Validation

- `bun test src/node/services/tools/attach_file.test.ts src/browser/features/Tools/AttachFileToolCall.test.tsx`
- `make static-check`
- Dogfooded via Storybook with `agent-browser`: opened `app-chat-tools-attachfile--display-only-markdown`, verified the markdown preview and Download link, and captured screenshot/video evidence in chat.

## Risks

Low. The new path reuses the existing display-only file mechanism, so markdown bytes are stripped from provider requests like other display-only files. Non-markdown text-like files still fail and direct the agent toward file_read.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$10.87`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=10.87 -->
