### PR TITLE
🤖 feat: add goal intervention policy

### DIFF
--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -151,7 +151,12 @@ import type { FilePart, SendMessageOptions } from "@/common/orpc/types";
 
 import { CreationCenterContent } from "./CreationCenterContent";
 import { cn } from "@/common/lib/utils";
-import type { ChatInputProps, ChatInputAPI, QueueDispatchMode } from "./types";
+import type {
+  ChatInputProps,
+  ChatInputAPI,
+  GoalInterventionPolicy,
+  QueueDispatchMode,
+} from "./types";
 import { CreationControls } from "./CreationControls";
 import { SEND_DISPATCH_MODES } from "./sendDispatchModes";
 import { CodexOauthWarningBanner } from "./CodexOauthWarningBanner";
@@ -178,6 +183,7 @@ import {
   type SkillResolutionTarget,
 } from "./utils";
 import { normalizeAgentId } from "@/common/utils/agentIds";
+import { isGoalRunning } from "@/common/types/goal";
 import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 
 // localStorage quotas are environment-dependent and relatively small.
@@ -988,6 +994,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     !sendInFlightBlocksInput &&
     !coderPresetsLoading &&
     !policyBlocksCreateSend;
+  const runningGoalActive =
+    variant === "workspace" && isGoalRunning(workspaceGoal?.status ?? "paused");
+  const shouldDefaultSteerGoal = runningGoalActive && !editingMessageForUi;
+
   // Send defaults to tool-end on click; advanced dispatch modes remain available via
   // right-click and touch long-press whenever there's a sendable workspace draft.
   const canChooseDispatchMode = variant === "workspace" && canSend;
@@ -1891,7 +1901,11 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const executeParsedCommand = async (
     parsed: ParsedCommand | null,
     restoreInput: string,
-    options?: { skipConfirmation?: boolean; queueDispatchMode?: QueueDispatchMode }
+    options?: {
+      skipConfirmation?: boolean;
+      queueDispatchMode?: QueueDispatchMode;
+      goalInterventionPolicy?: GoalInterventionPolicy;
+    }
   ): Promise<boolean> => {
     if (!parsed) {
       return false;
@@ -1926,6 +1940,9 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     // Thread dispatch mode into send options so queued command sends stay in sync with normal sends.
     const commandSendMessageOptions: SendMessageOptions = {
       ...sendMessageOptions,
+      ...(options?.goalInterventionPolicy
+        ? { goalInterventionPolicy: options.goalInterventionPolicy }
+        : {}),
       ...(dispatchMode === "tool-end" ? {} : { queueDispatchMode: dispatchMode }),
     };
     // Prepare file parts for commands that need to send messages with attachments
@@ -2131,7 +2148,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     [setInput]
   );
 
-  const handleSend = async (overrides?: { queueDispatchMode?: QueueDispatchMode }) => {
+  const handleSend = async (overrides?: {
+    queueDispatchMode?: QueueDispatchMode;
+    goalInterventionPolicy?: GoalInterventionPolicy;
+  }) => {
     if (!canSend) {
       return;
     }
@@ -2245,6 +2265,8 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       const commandHandled = modelOneShot
         ? false
         : await executeParsedCommand(parsed, input, {
+            goalInterventionPolicy:
+              overrides?.goalInterventionPolicy ?? (shouldDefaultSteerGoal ? "steer" : undefined),
             queueDispatchMode: overrides?.queueDispatchMode,
           });
       if (commandHandled) {
@@ -2435,12 +2457,16 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           rawThinkingOverride != null
             ? resolveThinkingInput(rawThinkingOverride, policyModel)
             : undefined;
+        const goalInterventionPolicy =
+          overrides?.goalInterventionPolicy ?? (shouldDefaultSteerGoal ? "steer" : undefined);
+
         const sendOptions = {
           ...sendMessageOptions,
           ...compactionOptions,
           ...(modelOverride ? { model: modelOverride } : {}),
           ...(thinkingOverride ? { thinkingLevel: thinkingOverride } : {}),
           ...(modelOneShot ? { skipAiSettingsPersistence: true } : {}),
+          ...(goalInterventionPolicy ? { goalInterventionPolicy } : {}),
           ...(overrides?.queueDispatchMode
             ? { queueDispatchMode: overrides.queueDispatchMode }
             : {}),
@@ -3042,6 +3068,12 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                           <br />
                           <br />
                           <strong>Right-click or long-press for advanced send modes:</strong>
+                          {runningGoalActive && !editingMessageForUi && (
+                            <>
+                              <br />
+                              Send and pause goal: right-click menu
+                            </>
+                          )}
                           {SEND_DISPATCH_MODES.map((entry) => (
                             <React.Fragment key={entry.mode}>
                               <br />
@@ -3075,6 +3107,18 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                           </kbd>
                         </button>
                       ))}
+                      {runningGoalActive && !editingMessageForUi && (
+                        <button
+                          type="button"
+                          className="hover:bg-hover focus-visible:bg-hover text-foreground flex w-full items-center justify-between gap-2 rounded-sm px-2.5 py-1 text-left text-xs"
+                          onClick={() => {
+                            closeSendModeMenu();
+                            void handleSend({ goalInterventionPolicy: "pause" });
+                          }}
+                        >
+                          <span className="whitespace-nowrap">Send and pause goal</span>
+                        </button>
+                      )}
                     </div>
                   )}
                 </div>

--- a/src/browser/features/ChatInput/types.ts
+++ b/src/browser/features/ChatInput/types.ts
@@ -4,6 +4,7 @@ import type { Review } from "@/common/types/review";
 import type { EditingMessageState, PendingUserMessage } from "@/browser/utils/chatEditing";
 import type { SendMessageOptions } from "@/common/orpc/types";
 
+export type GoalInterventionPolicy = NonNullable<SendMessageOptions["goalInterventionPolicy"]>;
 export type QueueDispatchMode = NonNullable<SendMessageOptions["queueDispatchMode"]>;
 
 export interface ChatInputAPI {

--- a/src/common/orpc/schemas/stream.ts
+++ b/src/common/orpc/schemas/stream.ts
@@ -674,6 +674,8 @@ export const ExperimentsSchema = z.object({
   imageGenerationTool: z.boolean().optional(),
 });
 
+export const GoalInterventionPolicySchema = z.enum(["steer", "pause"]);
+
 // SendMessage options
 export const SendMessageOptionsSchema = z.object({
   editMessageId: z.string().optional(),
@@ -711,6 +713,7 @@ export const SendMessageOptionsSchema = z.object({
    * iterating on agent files - a broken agent in the worktree won't affect message sending.
    */
   disableWorkspaceAgents: z.boolean().optional(),
+  goalInterventionPolicy: GoalInterventionPolicySchema.nullish(),
   queueDispatchMode: z.enum(["tool-end", "turn-end"]).nullish(),
 });
 

--- a/src/common/types/goal.ts
+++ b/src/common/types/goal.ts
@@ -52,9 +52,9 @@ export type GoalLifecycle = "active" | "complete";
  * agent is doing with it right now:
  *
  *   - `running`        — the agent may auto-continue this goal.
- *   - `paused`         — explicit user pause, OR auto-pause (e.g., when the
- *                        user sends a fresh message mid-stream). Continuations
- *                        are suppressed until the user resumes.
+ *   - `paused`         — explicit user pause, explicit send-and-pause, or safety
+ *                        gates such as an interrupted stream. Continuations are
+ *                        suppressed until the user resumes.
  *   - `budget_limited` — internal-only transient state set by the budget
  *                        gate when cost or turn caps are hit.
  *

--- a/src/node/services/agentSession.goalAutoPause.test.ts
+++ b/src/node/services/agentSession.goalAutoPause.test.ts
@@ -118,13 +118,33 @@ describe("AgentSession goal safety hooks", () => {
     }
   });
 
-  test("manual user messages auto-pause active goals before streaming", async () => {
+  test("manual user messages steer active goals by default", async () => {
+    const workspaceId = "manual-steers-active-goal";
+    const { session, goalService, analytics, cleanup } = await createSessionHarness(workspaceId);
+    cleanups.push(cleanup);
+    await setGoalOk(goalService, { workspaceId, objective: "Keep working" });
+
+    const result = await session.sendMessage("I need to steer this goal", SEND_OPTIONS);
+
+    expect(result.success).toBe(true);
+    expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "active" });
+    expect(analytics.recordGoalLifecycleEvent).not.toHaveBeenCalledWith(
+      "goal_paused",
+      expect.anything()
+    );
+    session.dispose();
+  });
+
+  test("manual user messages can explicitly pause active goals", async () => {
     const workspaceId = "manual-pauses-active-goal";
     const { session, goalService, analytics, cleanup } = await createSessionHarness(workspaceId);
     cleanups.push(cleanup);
     await setGoalOk(goalService, { workspaceId, objective: "Keep working" });
 
-    const result = await session.sendMessage("I need to intervene", SEND_OPTIONS);
+    const result = await session.sendMessage("I need to pause this goal", {
+      ...SEND_OPTIONS,
+      goalInterventionPolicy: "pause",
+    });
 
     expect(result.success).toBe(true);
     expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "paused" });
@@ -196,7 +216,7 @@ describe("AgentSession goal safety hooks", () => {
     session.dispose();
   });
 
-  test("manual user messages clear acknowledgment flags before auto-pausing", async () => {
+  test("manual user messages clear acknowledgment flags while steering by default", async () => {
     const workspaceId = "manual-clears-ack";
     const { session, goalService, cleanup } = await createSessionHarness(workspaceId);
     cleanups.push(cleanup);
@@ -207,7 +227,7 @@ describe("AgentSession goal safety hooks", () => {
 
     expect(result.success).toBe(true);
     expect(await goalService.getGoal(workspaceId)).toMatchObject({
-      status: "paused",
+      status: "active",
       requireUserAcknowledgmentSinceMs: null,
     });
     session.dispose();
@@ -332,7 +352,7 @@ describe("AgentSession goal safety hooks", () => {
     session.dispose();
   });
 
-  test("manual acknowledgment plus explicit resume allows a gated continuation to fire after restart", async () => {
+  test("manual acknowledgment clears stale gated continuations after restart", async () => {
     const workspaceId = "restart-gated-continuation";
     const { session, goalService, historyService, cleanup } =
       await createSessionHarness(workspaceId);
@@ -369,14 +389,13 @@ describe("AgentSession goal safety hooks", () => {
     const manualResult = await session.sendMessage("I saw the recovered response", SEND_OPTIONS);
     expect(manualResult.success).toBe(true);
     expect(await goalService.getGoal(workspaceId)).toMatchObject({
-      status: "paused",
+      status: "active",
       requireUserAcknowledgmentSinceMs: null,
     });
 
-    await setGoalOk(goalService, { workspaceId, status: "active" });
     await dispatcher.requestDispatch(workspaceId, GOAL_CONTINUATION_IDLE_CONSUMER_NAME);
 
-    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute).not.toHaveBeenCalled();
     session.dispose();
   });
 });

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -175,6 +175,8 @@ interface CompactionRequestMetadata {
   };
 }
 
+type GoalInterventionPolicy = NonNullable<SendMessageOptions["goalInterventionPolicy"]>;
+
 interface AutoRetryResumeRequest {
   // Same-session auto-retry must preserve the full normalized request because
   // ACP correlation/delegation lives in transient send options that are
@@ -188,6 +190,12 @@ interface SwitchAgentResult {
   agentId: string;
   reason?: string;
   followUp?: string;
+}
+
+function stripGoalInterventionPolicy(options: SendMessageOptions): SendMessageOptions {
+  const streamOptions: SendMessageOptions = { ...options };
+  delete streamOptions.goalInterventionPolicy;
+  return streamOptions;
 }
 
 function getGoalStreamOriginKind(input: {
@@ -1161,16 +1169,26 @@ export class AgentSession {
     }
   }
 
-  private async applyManualUserMessageGoalSafety(): Promise<void> {
+  private async applyManualUserMessageGoalSafety(input: {
+    policy: GoalInterventionPolicy;
+  }): Promise<void> {
     const goalService = this.workspaceGoalService;
     if (!goalService) {
       return;
     }
 
-    // One real user turn acknowledges any /clear or crash-recovery gate, then
-    // pauses active goal automation so the user explicitly resumes after intervening.
+    assert(
+      input.policy === "steer" || input.policy === "pause",
+      `invalid goal intervention policy: ${input.policy}`
+    );
+
+    // Accepted manual user turns acknowledge /clear or crash-recovery gates. Steering
+    // is the default for normal sends: the agent should see the user's intervention
+    // and the active goal may continue afterward. Rejected sends use "pause" below
+    // because the model never saw the steering content.
+    goalService.clearPendingContinuationForManualUserMessage(this.workspaceId);
     const goal = await goalService.acknowledgeUser(this.workspaceId);
-    if (goal?.status !== "active") {
+    if (goal?.status !== "active" || input.policy !== "pause") {
       return;
     }
 
@@ -2198,7 +2216,7 @@ export class AgentSession {
           // payloads (Codex P2 PRRT_kwDOPxxmWM5_tUsx) would otherwise silently
           // disable goal continuation after a blank submit / invalid payload.
           if (persisted) {
-            await this.applyManualUserMessageGoalSafety();
+            await this.applyManualUserMessageGoalSafety({ policy: "pause" });
           }
         }
         return Err(pricingGate.error);
@@ -2216,6 +2234,10 @@ export class AgentSession {
     const trimmedMessage = message.trim();
     const fileParts = options?.fileParts;
     const editMessageId = options?.editMessageId;
+
+    const manualGoalInterventionPolicy: GoalInterventionPolicy | undefined = isManualUserMessage
+      ? (options?.goalInterventionPolicy ?? (editMessageId ? "pause" : "steer"))
+      : undefined;
 
     // Edits are implemented as truncate+replace. If the frontend omits fileParts,
     // preserve the original message's attachments.
@@ -2467,15 +2489,11 @@ export class AgentSession {
     let agentInitiated = internal?.agentInitiated === true;
 
     let modelForStream = options.model;
-    let optionsForStream: SendMessageOptions = {
+    let optionsForStream: SendMessageOptions = stripGoalInterventionPolicy({
       ...options,
       ...(acpPromptId != null ? { acpPromptId } : {}),
       ...(delegatedToolNames != null ? { delegatedToolNames } : {}),
-    };
-
-    if (isManualUserMessage) {
-      await this.applyManualUserMessageGoalSafety();
-    }
+    });
 
     const userMessage = createMuxMessage(
       messageId,
@@ -2601,10 +2619,10 @@ export class AgentSession {
         });
 
         modelForStream = autoCompactionRequest.sendOptions.model;
-        optionsForStream = {
+        optionsForStream = stripGoalInterventionPolicy({
           ...autoCompactionRequest.sendOptions,
           muxMetadata: autoCompactionRequest.metadata,
-        };
+        });
         agentInitiated = autoCompactionRequest.agentInitiated;
       }
     }
@@ -2645,6 +2663,10 @@ export class AgentSession {
         // the orphan via the truncation logic that removes preceding snapshots.
         return Err(createUnknownSendMessageError(appendResult.error));
       }
+    }
+
+    if (manualGoalInterventionPolicy != null) {
+      await this.applyManualUserMessageGoalSafety({ policy: manualGoalInterventionPolicy });
     }
 
     // Workspace may be tearing down while we await filesystem IO.

--- a/src/node/services/messageQueue.test.ts
+++ b/src/node/services/messageQueue.test.ts
@@ -272,6 +272,51 @@ describe("MessageQueue", () => {
     });
   });
 
+  describe("goal intervention policy", () => {
+    it("should preserve steering policy for queued user messages", () => {
+      queue.add("Steer next turn", {
+        model: "gpt-4",
+        agentId: "exec",
+        goalInterventionPolicy: "steer",
+      });
+
+      const { options } = queue.produceMessage();
+
+      expect(options?.goalInterventionPolicy).toBe("steer");
+    });
+
+    it("should keep explicit pause sticky when mixed with steering", () => {
+      queue.add("Pause this goal", {
+        model: "gpt-4",
+        agentId: "exec",
+        goalInterventionPolicy: "pause",
+      });
+      queue.add("Also steer", {
+        model: "gpt-4",
+        agentId: "exec",
+        goalInterventionPolicy: "steer",
+      });
+
+      const { options } = queue.produceMessage();
+
+      expect(options?.goalInterventionPolicy).toBe("pause");
+    });
+
+    it("should reset goal intervention policy when cleared", () => {
+      queue.add("Pause this goal", {
+        model: "gpt-4",
+        agentId: "exec",
+        goalInterventionPolicy: "pause",
+      });
+
+      queue.clear();
+      queue.add("Plain follow-up", { model: "gpt-4", agentId: "exec" });
+
+      const { options } = queue.produceMessage();
+      expect(options?.goalInterventionPolicy).toBeUndefined();
+    });
+  });
+
   describe("addOnce", () => {
     it("should dedupe repeated entries by key", () => {
       const image = { url: "data:image/png;base64,abc", mediaType: "image/png" };

--- a/src/node/services/messageQueue.ts
+++ b/src/node/services/messageQueue.ts
@@ -42,6 +42,8 @@ function hasReviews(meta: unknown): meta is MetadataWithReviews {
   return Array.isArray(obj.reviews);
 }
 
+type GoalInterventionPolicy = NonNullable<SendMessageOptions["goalInterventionPolicy"]>;
+
 // Derive from the Zod schema (SendMessageOptions) to stay in sync automatically.
 type QueueDispatchMode = NonNullable<SendMessageOptions["queueDispatchMode"]>;
 
@@ -75,6 +77,7 @@ export class MessageQueue {
   private latestOptions?: SendMessageOptions;
   private accumulatedFileParts: FilePart[] = [];
   private dedupeKeys: Set<string> = new Set<string>();
+  private goalInterventionPolicy?: GoalInterventionPolicy;
   private queueDispatchMode: QueueDispatchMode = "tool-end";
   private queuedEntryCount = 0;
   private queuedSyntheticCount = 0;
@@ -178,8 +181,15 @@ export class MessageQueue {
       );
     }
 
+    const nextGoalInterventionPolicy =
+      this.goalInterventionPolicy === "pause" || options?.goalInterventionPolicy === "pause"
+        ? "pause"
+        : (options?.goalInterventionPolicy ?? this.goalInterventionPolicy);
+
     // Commit dispatch mode only after validation checks pass
     this.queueDispatchMode = nextQueueDispatchMode;
+
+    this.goalInterventionPolicy = nextGoalInterventionPolicy;
 
     // Add text message if non-empty
     if (trimmedMessage.length > 0) {
@@ -274,6 +284,9 @@ export class MessageQueue {
       ? (() => {
           const restOptions: SendMessageOptions = { ...this.latestOptions };
           delete restOptions.queueDispatchMode;
+          if (this.goalInterventionPolicy != null) {
+            restOptions.goalInterventionPolicy = this.goalInterventionPolicy;
+          }
           return {
             ...restOptions,
             muxMetadata,
@@ -306,6 +319,7 @@ export class MessageQueue {
     this.latestOptions = undefined;
     this.accumulatedFileParts = [];
     this.dedupeKeys.clear();
+    this.goalInterventionPolicy = undefined;
     this.queueDispatchMode = "tool-end";
     this.queuedEntryCount = 0;
     this.queuedSyntheticCount = 0;

--- a/src/node/services/workspaceGoalService.ts
+++ b/src/node/services/workspaceGoalService.ts
@@ -678,6 +678,14 @@ export class WorkspaceGoalService {
     );
   }
 
+  clearPendingContinuationForManualUserMessage(workspaceId: string): void {
+    assert(
+      workspaceId.trim().length > 0,
+      "clearPendingContinuationForManualUserMessage requires workspaceId"
+    );
+    this.pendingContinuationCandidates.delete(workspaceId);
+  }
+
   async recordUserStoppedStream(workspaceId: string, stoppedAtMs = Date.now()): Promise<void> {
     assert(workspaceId.trim().length > 0, "recordUserStoppedStream requires workspaceId");
     assert(Number.isFinite(stoppedAtMs) && stoppedAtMs >= 0, "user stop timestamp must be valid");

--- a/tests/ui/chat/sendModeDropdown.test.ts
+++ b/tests/ui/chat/sendModeDropdown.test.ts
@@ -1,9 +1,16 @@
 import "../dom";
+
+jest.mock("lottie-react", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
 import { fireEvent, waitFor } from "@testing-library/react";
 
 import { preloadTestModules, type TestEnvironment } from "../../ipc/setup";
 
 import { BackgroundProcessManager } from "@/node/services/backgroundProcessManager";
+import { workspaceStore } from "@/browser/stores/WorkspaceStore";
 
 import { createAppHarness, type AppHarness } from "../harness";
 
@@ -120,6 +127,55 @@ describe("Send dispatch modes (mock AI router)", () => {
         'button[aria-label="Send mode options"]'
       );
       expect(modeTrigger).toBeNull();
+    } finally {
+      await app.dispose();
+    }
+  }, 60_000);
+
+  test("running goals steer by default and expose an explicit pause send action", async () => {
+    const app = await createAppHarness({ branchPrefix: "send-mode-goal-policy" });
+
+    try {
+      const created = await app.env.orpc.workspace.setGoal({
+        workspaceId: app.workspaceId,
+        objective: "Keep dogfooding send policy",
+        budgetCents: null,
+      });
+      expect(created.success).toBe(true);
+
+      await waitFor(() => {
+        expect(workspaceStore.getWorkspaceSidebarState(app.workspaceId).goal?.status).toBe(
+          "active"
+        );
+      });
+
+      await app.chat.typeWithoutSending("Steer without pausing");
+      const sendButton = await waitForSendModeMenuTrigger(app.view.container);
+      fireEvent.click(sendButton);
+      await app.chat.expectStreamComplete();
+
+      await waitFor(async () => {
+        const { goal } = await app.env.orpc.workspace.getGoal({ workspaceId: app.workspaceId });
+        expect(goal?.status).toBe("active");
+      });
+
+      await app.chat.typeWithoutSending("Pause after this steering note");
+      await openSendModeMenu(app.view.container);
+      const pauseRow = await waitFor(() => {
+        const rows = Array.from(app.view.container.querySelectorAll("button"));
+        const row = rows.find((button) => button.textContent?.includes("Send and pause goal"));
+        if (!row) {
+          throw new Error("Send and pause goal row not found");
+        }
+        return row;
+      });
+      fireEvent.click(pauseRow);
+      await app.chat.expectStreamComplete();
+
+      await waitFor(async () => {
+        const { goal } = await app.env.orpc.workspace.getGoal({ workspaceId: app.workspaceId });
+        expect(goal?.status).toBe("paused");
+      });
     } finally {
       await app.dispose();
     }


### PR DESCRIPTION
## Summary

Normal user messages now steer active goals by default instead of auto-pausing them, while keeping an explicit **Send and pause goal** path for intentional pauses.

## Background

Running goals previously treated any manual user message as an interruption and auto-paused the goal. This change lets users steer a goal at the next send boundary without disabling goal continuation, while preserving conservative safety behavior for rejected sends, edits, and explicit pause intent.

## Implementation

- Added a typed `goalInterventionPolicy` send option with `"steer"` and `"pause"` policies.
- Default accepted non-edit manual sends to steering; edit sends and rejected pricing-gate sends remain pause/gated.
- Clear stale pending continuation candidates when accepting a manual intervention so old continuations cannot race ahead of the steering turn.
- Preserve sticky explicit pause policy through queued message batching.
- Added the goal-aware **Send and pause goal** menu action in ChatInput.
- Kept policy metadata out of provider/retry stream options.

## Validation

- `bun test src/node/services/agentSession.goalAutoPause.test.ts src/node/services/messageQueue.test.ts src/node/services/agentSession.budgetGate.test.ts --timeout 30000`
- `TEST_INTEGRATION=1 bun x jest tests/ui/chat/sendModeDropdown.test.ts --runInBand`
- `make static-check`

## Dogfooding

Evidence was captured under `dogfood-output/goal-intervention-policy/` in this workspace, including:

- `screenshots/mock-default-steering-sent.png`
- `screenshots/final-explicit-pause-menu-open-2.png`
- `screenshots/final-explicit-pause-sent-paused.png`
- `videos/final-explicit-pause-success.webm`
- `report.md`

The mock-AI dogfood verified normal steering keeps the goal active and **Send and pause goal** transitions the goal to paused.

## Risks

Goal continuation control is safety-sensitive. The main mitigations are backend defaults as the source of truth, explicit tests for accepted steering versus rejected sends, stale-candidate clearing, and not propagating the policy into provider/retry metadata.

---

<details>
<summary>📋 Implementation Plan</summary>

# Implementation plan: explicit goal intervention policy

## Goal

Let a user steer a running goal by sending a normal chat message **without auto-pausing the goal**, while retaining an explicit way to send a message that intentionally pauses the goal.

This implements Option 2 from the investigation: add an explicit goal-intervention policy to send-message options, with two policies:

- `"steer"` — acknowledge any pending goal gate, send the user's message, and leave an active/running goal active so goal continuation may resume after the message turn.
- `"pause"` — preserve today's safety behavior: acknowledge the user, then auto-pause an active/running goal before/around the user intervention.

## Verified context and constraints

- Current auto-pause is centralized in `AgentSession.applyManualUserMessageGoalSafety()` in `src/node/services/agentSession.ts`; it calls `workspaceGoalService.acknowledgeUser(...)` and then pauses active goals via `setGoal({ status: "paused", initiator: "auto" })`.
- `AgentSession.sendMessage(...)` calls that hook for accepted manual sends and for pricing-gate rejections after preserving the rejected user message.
- Busy workspaces already queue sends in `WorkspaceService.sendMessage(...)` (`src/node/services/workspaceService.ts`) and later dispatch via `AgentSession.sendQueuedMessages()`, so a steering message can already wait for a step/turn boundary.
- `MessageQueue` stores latest send options and combines queued messages in `src/node/services/messageQueue.ts`; any policy that must survive queueing should be part of send options and/or explicitly aggregated by the queue.
- `ChatInput` already has access to the current goal snapshot via `useOptionalWorkspaceSidebarState(workspaceId)` and can use `isGoalRunning(...)` from `src/common/types/goal.ts`.
- Mux already exposes send timing modes: `tool-end` (Enter/button, “Send after step”) and `turn-end` (Ctrl/Cmd+Enter, “Send after turn”) via `src/browser/features/ChatInput/sendDispatchModes.ts`.

<details>
<summary>Important semantic distinction</summary>

This plan does **not** attempt true mid-stream prompt injection into an in-flight model request. The existing queue/step/turn boundary behavior remains the steering delivery mechanism. The change is that a normal user message no longer flips the goal status to paused after it is accepted for sending.

Explicit interrupts/stops remain different from steering messages and should continue to gate future goal continuation for safety.

</details>

## Recommended approach

### Approach A — explicit enum + default steering for normal sends + explicit pause override

**Net product LoC estimate:** ~140–260 LoC total.

Breakdown:

- Shared schema/types: ~5–20 LoC
- Backend/session/queue: ~60–110 LoC
- Frontend send-menu/default policy: ~50–100 LoC
- Queued-message policy label, if included: ~25–50 LoC

This is the recommended implementation. It changes normal “send while goal is running” behavior to steering, while preserving an explicit pause path in the send menu and backend API.

### Approach B — same backend enum, plus a persistent user setting for default behavior

**Net product LoC estimate:** ~260–480 LoC total.

This adds a Settings toggle such as “Messages sent during goals: steer / pause”. It is more flexible but adds settings storage, settings UI, copy, tests, and one more behavior axis. Defer unless users actively need to make old auto-pause the default.

### Approach C — backend-only policy support, no UI affordance

**Net product LoC estimate:** ~70–140 LoC total.

This is smaller but weak: normal users would get changed behavior without an obvious way to intentionally pause by sending a message, and the explicit policy would mostly exist for internal callers. Not recommended because the user explicitly liked Option 2.

## Design decisions

1. **Use an enum, not a boolean.**
   - Add `goalInterventionPolicy?: "steer" | "pause"` to send-message options.
   - Avoid `pauseActiveGoal?: boolean`; the negative/optional boolean is harder to reason about and less extensible.

2. **Accepted normal manual sends default to `"steer"`.**
   - This satisfies the desired product behavior: “Sending a message while a goal is running should not pause the goal.”
   - The frontend should explicitly pass `"steer"` when it detects a running goal so transcript/UI intent is easy to reason about.
   - The backend should also resolve omitted policy to `"steer"` for non-edit manual sends so direct frontend callsites do not accidentally retain the old pause behavior.

3. **Explicit `"pause"` remains available.**
   - Add a goal-aware send-menu action such as **Send and pause goal** when a goal is currently running.
   - This action sends the same user message but includes `goalInterventionPolicy: "pause"`.

4. **Rejected/unsent manual interventions should stay safe.**
   - If a message is rejected before a stream can start (notably pricing-gate rejection under a budgeted goal), the agent never saw the steering content.
   - Preserve the current safety behavior on that rejection path: after preserving the user-visible rejected message/error, pause or gate the active goal rather than letting a pending continuation fire blindly.
   - Tests should make this explicit so it is not confused with accepted steering sends.

5. **Edits are not ordinary steering.**
   - Editing/truncating history while a goal is active is a stronger intervention than “steer the next turn.”
   - Default edit sends to `"pause"` unless the product explicitly decides otherwise later.
   - Frontend should not default edit sends to `"steer"` merely because a goal is running.

6. **Explicit user interrupts/stops are unchanged.**
   - `interruptStream(...)` and `WorkspaceGoalService.recordUserStoppedStream(...)` should continue to require acknowledgment / suppress continuation.
   - `goalInterventionPolicy` only applies to sending a chat message, not hard stop semantics.

7. **Queued policy aggregation should be conservative.**
   - If any queued entry explicitly requests `"pause"`, the combined queued message should dispatch with `"pause"`.
   - Otherwise default/steering queued entries dispatch as `"steer"` when appropriate.
   - This avoids losing an explicit pause request when later queued content is added.

## Non-obvious correctness constraints from advisor review

1. **Backend default is the source of truth.**
   - The frontend should pass `"steer"` for clarity, but correctness must not depend on it.
   - Backend resolution must make accepted, non-edit, non-synthetic manual sends steer by default.

2. **Separate attempted sends from accepted sends.**
   - Empty-message validation, model-format validation, attachment validation, and other pre-accept failures should not clear acknowledgment gates or pause active goals just because the user tried to submit.
   - Once the user turn is durably accepted into history, apply the policy.
   - If the accepted turn is represented by an on-send compaction container rather than the original user message, treat that persisted compaction/follow-up container as the acceptance boundary.

3. **Block stale pending goal continuations from racing ahead of steering.**
   - Today auto-pause naturally disqualifies pending continuation candidates. Steering leaves the goal active, so implementation must explicitly prevent an already-armed candidate from firing before the accepted steering turn.
   - Add or reuse a deterministic gate, for example:
     - set the session busy/preparing early enough once a manual send is accepted, and/or
     - add a `WorkspaceGoalService` method that clears/defer pending continuation candidates for an accepted manual steering turn.
   - The steering turn's own stream-end should arm the next continuation normally.

4. **Define accepted pre-stream failure behavior.**
   - If a steering message is persisted but the stream never starts and no retry will process it, do not let goal continuation proceed blindly.
   - Safe default: pause/gate the goal on terminal accepted-pre-stream failure because the model never saw the steering content.
   - If existing auto-retry will process the accepted turn, keep continuation suppressed until retry succeeds or terminally fails.

5. **Policy is control metadata, not model/retry metadata.**
   - `goalInterventionPolicy` should affect only the current manual send's goal-safety behavior.
   - Strip or avoid propagating it into provider request options, active stream context, persisted `retrySendOptions`, startup-recovery options, and synthetic goal-continuation send options.

6. **Steering accounting becomes normal, not rare.**
   - A user-origin stream while a goal remains active should be intentionally defined.
   - Proposed semantics: steering turns may add cost to the active goal budget but do not increment the goal turn cap, matching current `originKind === "user"` behavior.
   - If a steering turn pushes a goal into `budget_limited` with `originKind: "user"`, budget wrap-up suppression must be intentional and covered by tests or comments.

## Implementation phases

### Phase 1 — Shared schema and type plumbing

Files:

- `src/common/orpc/schemas/stream.ts`
- `src/common/orpc/types.ts` (likely type inference only)
- Optionally a small shared helper/type module if schema-local typing becomes awkward.

Steps:

1. Add the option to `SendMessageOptionsSchema`:

   ```ts
   goalInterventionPolicy: z.enum(["steer", "pause"]).optional()
   ```

   Match the surrounding schema style. If this schema is consumed as provider/tool input anywhere strict-null compatibility matters, use the repo convention for nullable optionals.

2. Derive or export a type where needed:

   ```ts
   type GoalInterventionPolicy = NonNullable<SendMessageOptions["goalInterventionPolicy"]>;
   ```

3. Add a tiny resolver/helper if it clarifies semantics:

   ```ts
   function normalizeGoalInterventionPolicy(
     value: SendMessageOptions["goalInterventionPolicy"] | undefined,
     fallback: GoalInterventionPolicy
   ): GoalInterventionPolicy {
     return value ?? fallback;
   }
   ```

Quality gate:

- Run targeted typecheck or relevant schema tests after backend/frontend usage is in place.

### Phase 2 — Backend session behavior

Files:

- `src/node/services/agentSession.ts`
- `src/node/services/workspaceService.ts` if policy resolution should be centralized before queueing.
- `src/node/services/messageQueue.ts`

Steps:

1. Replace `applyManualUserMessageGoalSafety()` with a policy-aware form, e.g.:

   ```ts
   private async applyManualUserMessageGoalSafety(input: {
     policy: GoalInterventionPolicy;
   }): Promise<void> {
     assert(input.policy === "steer" || input.policy === "pause", "invalid goal intervention policy");

     const goal = await goalService.acknowledgeUser(this.workspaceId);
     if (goal?.status !== "active") return;
     if (input.policy !== "pause") return;

     await goalService.setGoal({
       workspaceId: this.workspaceId,
       status: "paused",
       initiator: "auto",
     });
   }
   ```

   Keep the existing try/catch/logging around the pause mutation.

2. In `AgentSession.sendMessage(...)`, resolve policy separately for accepted manual sends:

   - Synthetic sends: no manual safety hook, unchanged.
   - Accepted non-edit manual sends: default to `options.goalInterventionPolicy ?? "steer"`.
   - Accepted edit sends: default to `options.goalInterventionPolicy ?? "pause"`.
   - Explicit `"pause"` always pauses if a goal is active.
   - Explicit `"steer"` acknowledges but does not pause.
   - Do not run the safety hook for empty-message, invalid-model, attachment, or other pre-accept validation failures.

3. Move/apply the accepted-send policy at the durable acceptance boundary:

   - For ordinary sends, after the user message is appended successfully to history.
   - For on-send compaction, after the compaction request/follow-up container is durably appended.
   - Before any pending goal continuation can dispatch ahead of this accepted user turn.

4. Add a deterministic continuation-race mitigation for accepted steering:

   - Add a small `WorkspaceGoalService` method or equivalent session bridge hook to clear/defer pending continuation candidates for an accepted manual steering turn without changing goal status.
   - Call it when a manual steering turn is accepted.
   - Let the steering turn's stream-end arm the next continuation candidate normally.
   - Add a regression test proving an already-pending continuation cannot fire before the accepted steering turn.

5. On pricing-gate rejection paths where `preserveRejectedManualSend(...)` returns true:

   - Apply a safe rejection policy, likely `"pause"`, because the steering message was not accepted by the model.
   - Add a comment explaining this is intentionally different from accepted `"steer"` sends.

6. Define terminal accepted-pre-stream failure handling:

   - If the accepted steering turn will be retried by existing retry machinery, keep goal continuation suppressed until retry resolves.
   - If no retry will process the accepted turn, pause or acknowledgment-gate the goal because the model never saw the steering content.
   - Add tests for the selected path.

7. Ensure queued sends preserve/aggregate policy:

   - Add a queue-level field in `MessageQueue` such as `goalInterventionPolicy?: GoalInterventionPolicy`.
   - Only manual entries should contribute policy; synthetic entries should not accidentally pause a goal.
   - On `addInternal`, compute sticky pause:

     ```ts
     const incomingPolicy = options?.goalInterventionPolicy;
     this.goalInterventionPolicy =
       this.goalInterventionPolicy === "pause" || incomingPolicy === "pause"
         ? "pause"
         : (incomingPolicy ?? this.goalInterventionPolicy);
     ```

   - In `produceMessage()`, reattach `goalInterventionPolicy` to produced options if present.
   - In `clear()`, reset it.

8. Treat policy as control metadata:

   - Strip or omit `goalInterventionPolicy` from provider/model request options.
   - Do not persist it into `retrySendOptions` or startup recovery state.
   - Do not pass it into synthetic goal-continuation or budget-wrap-up send options.

9. Confirm `streamWithHistory(...)` and `aiService.streamMessage(...)` do not need to consume this option. It is a send/session policy, not a model provider option.

Quality gate:

- Run targeted backend tests after adding tests in Phase 4:
  - `bun test src/node/services/agentSession.goalAutoPause.test.ts`
  - `bun test src/node/services/messageQueue.test.ts`
  - relevant `workspaceService.test.ts` slices if touched.

### Phase 3 — Frontend policy selection and UI

Files:

- `src/browser/features/ChatInput/index.tsx`
- `src/browser/features/ChatInput/types.ts`
- `src/browser/features/ChatInput/sendDispatchModes.ts` or a sibling goal-policy config if needed.
- Optional queued-message UI files if displaying policy while queued:
  - `src/browser/features/Messages/QueuedMessage.tsx`
  - `src/common/types/message.ts`
  - `src/common/orpc/schemas/stream.ts` queued-message event schema
  - `src/node/services/agentSession.ts` `emitQueuedMessageChanged()` payload

Steps:

1. Import/use goal helpers in `ChatInput`:

   ```ts
   import { isGoalRunning } from "@/common/types/goal";
   ```

2. Compute default policy only for workspace, running-goal, non-edit sends:

   ```ts
   const runningGoalActive = variant === "workspace" && isGoalRunning(workspaceGoal?.status);
   const shouldDefaultSteerGoal = runningGoalActive && !editingMessageForUi;
   ```

3. Extend `handleSend` overrides:

   ```ts
   const handleSend = async (overrides?: {
     queueDispatchMode?: QueueDispatchMode;
     goalInterventionPolicy?: GoalInterventionPolicy;
   }) => { ... }
   ```

4. Add policy to constructed `sendOptions`:

   ```ts
   const goalInterventionPolicy =
     overrides?.goalInterventionPolicy ?? (shouldDefaultSteerGoal ? "steer" : undefined);

   const sendOptions = {
     ...,
     ...(goalInterventionPolicy ? { goalInterventionPolicy } : {}),
   };
   ```

5. Thread the same override shape through `executeParsedCommand(...)` only for command paths that behave like user-message sends (model one-shots, skills, normal message-producing commands). Do **not** blindly apply it to explicit goal-management commands or compaction commands unless their product semantics are intentionally user-steering.

6. Add a goal-aware send-menu action visible only when `runningGoalActive && !editingMessageForUi`:

   - Label: **Send and pause goal**.
   - Action: `handleSend({ goalInterventionPolicy: "pause" })`.
   - Keep existing send timing entries unchanged.
   - Do not introduce a full timing × policy matrix yet; that is more UI than necessary.

7. Optional/deferable: if reviewers want queued pause intent visible, include policy in queued-message event data and display a small label such as “Will pause goal” for queued pause messages. Defer this if the core behavior is already clear enough; it expands event/schema/UI scope.

Quality gate:

- Run targeted UI tests/stories if existing harness supports `ChatInput`.
- At minimum run TypeScript/lint after schema and UI changes.

### Phase 4 — Tests

Backend tests:

1. Update `src/node/services/agentSession.goalAutoPause.test.ts`:
   - Replace/rename the current “manual user messages auto-pause active goals before streaming” test with default steering expectation:
     - active goal remains `active`
     - `recordGoalLifecycleEvent("goal_paused", ...)` is not called
   - Add explicit policy test:
     - send with `{ goalInterventionPolicy: "pause" }`
     - active goal becomes `paused`
     - lifecycle event records `initiator: "auto"`
   - Keep synthetic-message tests unchanged.
   - Update acknowledgment test:
     - default steering clears `requireUserAcknowledgmentSinceMs` while keeping status `active`.
   - Add rejection-path test:
     - pricing gate rejects and rejected manual message is preserved
     - active goal pauses/gates for safety because the steering was not accepted.

2. Update `src/node/services/messageQueue.test.ts`:
   - queued steering policy survives produce/clear
   - explicit pause policy survives queueing
   - pause is sticky when mixed with later/default steering entries
   - clear resets policy.

3. Update/add `src/node/services/workspaceService.test.ts` only if WorkspaceService gains policy-specific logic:
   - busy send queues policy
   - explicit pause policy is passed to the queue
   - default normal sends do not get blocked by policy logic.

Additional backend regression cases from advisor review:

- Pre-accept validation failures (empty/invalid model/invalid attachment) do not acknowledge, pause, or clear pending goal gates.
- Accepted pre-stream/startup failure follows the defined safe behavior (retry suppression or pause/gate on terminal failure).
- A pending continuation candidate cannot fire before an accepted steering message is processed.
- `goalInterventionPolicy` does not leak into synthetic goal-continuation sends or persisted retry/startup-recovery send options.
- User-origin active-goal accounting expectations are asserted or documented: steering cost may count against budget; steering does not increment turn cap.

Frontend tests/stories:

1. If a `ChatInput` test harness exists or is practical:
   - running goal + normal send includes `goalInterventionPolicy: "steer"`
   - no running goal omits the policy
   - edit send while running goal does not default to `"steer"`
   - explicit menu action sends `"pause"`
   - queue dispatch override still passes through.

2. If no harness exists, add/update a Storybook story for the send menu with a running goal and rely on dogfooding plus type/lint validation rather than creating a large new UI harness.

Test quality guardrails:

- Avoid copy-only assertions on menu prose.
- Prefer behavior assertions on the sent API payload and goal status transitions.

### Phase 5 — Documentation/comments cleanup

Files:

- `src/common/types/goal.ts`
- nearby comments in `AgentSession` / goal tests.

Steps:

1. Update comments that currently describe paused as caused by “fresh message mid-stream” so they do not encode stale behavior.
2. Add a short comment at the policy resolver explaining:
   - accepted normal sends steer by default
   - rejected sends pause/gate because the model never saw the steering content
   - edits/explicit interrupts remain stronger interventions.

Do not add standalone docs unless requested; keep rationale near the code.

## Acceptance criteria

- Normal manual message while a goal is running no longer auto-pauses the goal after the message is accepted for sending.
- The same send still clears any pending user-acknowledgment goal gate.
- Explicit **Send and pause goal** pauses an active goal and records the existing auto-pause lifecycle event.
- Queued steering messages dispatch before the next goal continuation and do not pause the goal.
- Queued explicit pause messages preserve the pause policy until dispatch.
- Pricing-gate rejection or other pre-stream rejection does not let a goal blindly continue as if the user’s steering had been processed.
- Edit sends and explicit interrupts keep safe/pause/gate behavior unless intentionally changed later.
- Pending goal continuation candidates cannot race ahead of an accepted steering message.
- Accepted pre-stream failures either retry the accepted steering turn or pause/gate before continuation can proceed.
- `goalInterventionPolicy` does not leak into provider requests, persisted retry options, startup recovery, or synthetic continuation options.
- Synthetic goal continuations and budget-limit wrap-up messages are unaffected.
- Existing send timing modes (`tool-end`, `turn-end`) continue to work.

## Dogfooding and quality gates

Dogfooding must follow the `dogfood`, `agent-browser`, and `dev-server-sandbox` skills: use the direct `agent-browser` binary (never `npx`), gather screenshots/video evidence, write findings incrementally, and run the app in an isolated sandbox when possible.

### Setup

1. Prepare a dogfood evidence directory, e.g. `./dogfood-output/goal-intervention-policy/`, with `screenshots/`, `videos/`, and a report copied from the dogfood report template.
2. Before browser automation, load the installed agent-browser workflow content so commands match the local CLI version:
   - `agent-browser skills get core`
   - If testing the desktop Electron shell rather than the web/dev UI, also load `agent-browser skills get electron`.
3. Start an isolated Mux dev server with a temporary `MUX_ROOT`:
   - Default seeded sandbox: `make dev-server-sandbox`
   - Clean sandbox when avoiding existing providers/projects: `make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-projects"`
   - Use `KEEP_SANDBOX=1` only when debugging and remember provider config may contain API keys; the sandbox intentionally does not copy `secrets.json`.
4. Use the reported `VITE_PORT`/target URL from the sandbox output as the `agent-browser` target.
5. Start a named browser session and orient:
   - `agent-browser --session goal-intervention open <target-url>`
   - `agent-browser --session goal-intervention wait --load networkidle`
   - `agent-browser --session goal-intervention screenshot --annotate dogfood-output/goal-intervention-policy/screenshots/initial.png`
   - `agent-browser --session goal-intervention snapshot -i`
6. Enable the Goals experiment and configure test providers as needed. If real provider calls are expensive/unavailable, use the lightest available local/test model path that still exercises goal continuation.
7. During dogfooding, use `snapshot -i` before interactions, re-snapshot after every page-changing action, capture `agent-browser console` / `agent-browser errors` periodically, and use `type` rather than `fill` while recording videos so repros are watchable.

### Gate 1 — default steering

1. Create/open a workspace.
2. Start a running goal from the Goal tab or `/goal <objective>`.
3. Capture annotated screenshot: goal status is running/active.
4. Start a repro video before sending steering input:
   - `agent-browser --session goal-intervention record start dogfood-output/goal-intervention-policy/videos/default-steering.webm`
5. While a stream/goal turn is running, type a steering message at human pace and press Enter.
6. Capture step screenshots and final annotated screenshot showing:
   - the message is queued or sent according to current turn state
   - the goal remains running/active, not paused
   - the agent responds to the steering message
   - a later goal continuation can resume.
7. Stop the video and record the exact steps/evidence paths in the dogfood report.

### Gate 2 — explicit pause override

1. Start another running goal or resume the existing one.
2. Start a repro video before opening the send menu.
3. Open the send menu with right-click/long-press on Send.
4. Capture an annotated screenshot showing **Send and pause goal**.
5. Use that action.
6. Capture step screenshots/video showing the goal becomes paused.
7. Stop the video and write the repro/evidence paths into the report.

### Gate 3 — queued policy behavior

1. Trigger a foreground tool or long-running turn.
2. Queue a normal steering message.
3. Capture screenshot/video evidence that queued UI does not imply pausing and goal remains active after dispatch.
4. Queue an explicit pause message.
5. Verify queued UI, if implemented, marks it as pause-intent and the goal pauses after dispatch.
6. Add console/errors output to the report if any warnings or exceptions appear.

### Gate 4 — regression checks

Run:

- targeted backend tests listed above
- targeted frontend/UI tests or stories if added
- `make typecheck`
- `make lint` or `make static-check` if the change is broad enough and runtime allows.

### Gate 5 — wrap-up evidence

1. Re-read the dogfood report and ensure screenshots/videos referenced by each finding exist.
2. Update summary counts if any issues were found.
3. Close the browser session with `agent-browser --session goal-intervention close`.
4. Attach the key screenshots/video files or provide their paths in the final implementation summary.

## Risks and mitigations

- **Rejected steering message blind continuation:** mitigate by keeping rejection path safe/pause/gated.
- **Mixed queued policies:** mitigate with sticky pause aggregation in `MessageQueue`.
- **Edit semantics:** treat edits as pause by default because they rewrite history rather than steer the next turn.
- **UI clutter:** add one conditional pause action instead of a full policy/timing matrix.
- **Hidden direct send callsites:** backend default for accepted manual non-edit sends should be `"steer"`, and implementation should audit direct `api.workspace.sendMessage` callsites.
- **Budget accounting confusion:** user-origin steering turns currently should not increment goal turn count, but may still affect cost/budget. Keep this behavior unless product explicitly wants steering turns to count as goal turns.

## Implementation order

1. Shared schema/type field.
2. Backend policy resolver and `applyManualUserMessageGoalSafety` refactor.
3. Queue policy aggregation.
4. Backend tests.
5. Frontend default steering + explicit pause menu action.
6. Optional queued-message pause label.
7. Frontend tests/stories.
8. Comment cleanup.
9. Dogfood and validation.

## Follow-up plan: commit, PR, and readiness loop

**Mode constraint:** this workspace is currently in Plan Mode, so I must not run mutating git/GitHub commands yet. Switch to Exec mode to execute this plan.

**Net product LoC estimate:** 0 LoC. This follow-up should only commit the already-implemented work, create/update a pull request, and wait for gates.

### Required preflight

1. Read the `pull-requests` skill before any commit or PR action (done for this plan; repeat in Exec if the session has changed).
2. Re-check the worktree:
   - `git status --short`
   - `git diff --stat`
   - ensure dogfood artifacts are intentionally included or intentionally excluded from the commit based on repo policy.
3. Capture attribution values before creating the PR:
   - `printf '%s\n' "$MUX_MODEL_STRING" "$MUX_THINKING_LEVEL" "$MUX_COSTS_USD"`

### Commit plan

1. Review the final diff at a high level:
   - changed product/test files: `src/browser/features/ChatInput/index.tsx`, `src/browser/features/ChatInput/types.ts`, `src/common/orpc/schemas/stream.ts`, `src/common/types/goal.ts`, `src/node/services/agentSession.ts`, `src/node/services/messageQueue.ts`, `src/node/services/workspaceGoalService.ts`, and tests.
   - dogfood report/evidence lives under `dogfood-output/goal-intervention-policy/`; include it only if the repository convention allows generated dogfood artifacts in commits. If not, keep it untracked/out of commit and reference paths in the PR body.
2. Run or confirm validation before committing:
   - `bun test src/node/services/agentSession.goalAutoPause.test.ts src/node/services/messageQueue.test.ts src/node/services/agentSession.budgetGate.test.ts --timeout 30000`
   - `bun test ./tests/ui/chat/sendModeDropdown.test.ts --timeout 120000`
   - `make static-check`
3. Stage the intended files and commit with a concise message, e.g.:
   - `git add <intended files>`
   - `git commit -m "feat: steer active goals from normal user sends"`
4. Push the branch:
   - `git push --set-upstream origin HEAD` if no upstream exists, otherwise `git push`.

### Pull request plan

1. Check whether a PR already exists for the branch:
   - `gh pr view --json number,url,title,state`.
2. If no PR exists, create one with a title following repo convention:
   - `🤖 feat: steer active goals from normal user sends`
3. Build the PR body in a unique temp file from `mktemp`; do not use a hard-coded `/tmp/pr-body.md` path.
4. PR body sections:
   - Summary: normal sends steer active goals by default; explicit send-and-pause remains available.
   - Background: previous auto-pause made it hard to steer running goals.
   - Implementation: shared policy enum, backend default/pause handling, queue aggregation, stale continuation clearing, frontend menu action.
   - Validation: targeted backend/UI tests, `make static-check`, dogfood evidence paths.
   - Risks: goal continuation race handling, rejected-send safety, edit semantics.
   - `<details><summary>📋 Implementation Plan</summary>` containing this plan file’s contents, per repo preference.
   - Attribution footer from the `pull-requests` skill using `$MUX_MODEL_STRING`, `$MUX_THINKING_LEVEL`, and `$MUX_COSTS_USD`.
5. Use `gh pr new --body-file "$PR_BODY"` or `gh pr edit --body-file "$PR_BODY"` as appropriate.

### PR readiness loop

1. Request Codex review with a real multiline body file/heredoc:
   - `gh pr comment <number> --body-file - <<'EOF' ... EOF`
2. Run `./scripts/wait_pr_ready.sh <pr_number>`.
3. If Codex leaves comments:
   - inspect all PR reviews, review comments, and issue comments;
   - fix locally;
   - resolve each thread with `./scripts/resolve_pr_comment.sh <thread_id>`;
   - push and request `@codex review` again.
4. If CI fails, reproduce locally, fix, validate, push, and rerun readiness.
5. Stop only when Codex approves, all Codex threads are resolved, and required CI checks pass.

### Dogfooding / quality gate for this follow-up

No additional product dogfooding is needed for the commit/PR mechanics. Preserve the existing dogfood report and evidence paths in the PR body:

- `dogfood-output/goal-intervention-policy/report.md`
- `dogfood-output/goal-intervention-policy/screenshots/mock-default-steering-sent.png`
- `dogfood-output/goal-intervention-policy/screenshots/final-explicit-pause-menu-open-2.png`
- `dogfood-output/goal-intervention-policy/screenshots/final-explicit-pause-sent-paused.png`
- `dogfood-output/goal-intervention-policy/videos/final-explicit-pause-success.webm`

### Acceptance criteria for this follow-up

- A commit exists containing the intended implementation/test changes.
- A PR exists or the existing PR is updated for the current branch.
- PR body includes validation, dogfood evidence, implementation plan details, and the required attribution footer.
- Branch is pushed to the remote.
- PR readiness loop has run until CI and Codex gates are ready, or any blocker is reported with exact evidence.


</details>

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$79.45`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=79.45 -->
