### PR TITLE
🤖 feat(goals-tab): differentiate paused state with amber tone + lifecycle icons

### DIFF
--- a/src/browser/features/RightSidebar/GoalTab.test.tsx
+++ b/src/browser/features/RightSidebar/GoalTab.test.tsx
@@ -120,6 +120,61 @@ describe("GoalTab", () => {
     expect(queryByLabelText("Resume goal")).toBeNull();
   });
 
+  test("header tone differentiates running vs paused / budget-limited", () => {
+    // Running goals get the success/green band; paused + budget_limited
+    // share the warning/amber band so the user can spot a stalled
+    // workspace at a glance instead of every active goal looking the
+    // same. Complete falls back to the muted surface tone. The
+    // `aria-label="Workspace goal"` section wraps the colored header,
+    // so we look up the header element via its tone classes — that's
+    // the actual user-visible cue and the contract we want to lock in.
+    const { container, rerender } = render(
+      <GoalTab goal={goal({ status: "active" })} onSetStatus={mock()} onClear={mock()} />
+    );
+    expect(container.querySelector("header")?.className).toContain("border-success");
+    expect(container.querySelector("header")?.className).not.toContain("border-warning");
+
+    rerender(<GoalTab goal={goal({ status: "paused" })} onSetStatus={mock()} onClear={mock()} />);
+    // Paused: amber tone replaces the green band so the lifecycle is
+    // legible without reading the badge text.
+    expect(container.querySelector("header")?.className).toContain("border-warning");
+    expect(container.querySelector("header")?.className).not.toContain("border-success");
+
+    rerender(
+      <GoalTab
+        goal={goal({ status: "budget_limited", budgetCents: 100, costCents: 100 })}
+        onSetStatus={mock()}
+        onClear={mock()}
+      />
+    );
+    // Budget-limited shares the amber tone with paused: both mean
+    // "active but not auto-running".
+    expect(container.querySelector("header")?.className).toContain("border-warning");
+    expect(container.querySelector("header")?.className).not.toContain("border-success");
+  });
+
+  test("lifecycle action buttons surface their semantic icon", () => {
+    // The lifecycle row (Pause / Resume / Reopen / Mark complete) now
+    // carries semantic icons in addition to the text label. The icons
+    // are inside the button DOM with `aria-hidden`, so we assert on the
+    // button containing an SVG to guard against accidentally regressing
+    // back to the text-only buttons. This is the user-visible cue that
+    // distinguishes "Pause" from "Resume" in the pre-mouse-hover
+    // glance, which is the whole point of this UX iteration.
+    const { rerender, getByLabelText } = render(
+      <GoalTab goal={goal({ status: "active" })} onSetStatus={mock()} onClear={mock()} />
+    );
+    expect(getByLabelText("Pause goal").querySelector("svg")).not.toBeNull();
+    expect(getByLabelText("Mark goal complete").querySelector("svg")).not.toBeNull();
+
+    rerender(<GoalTab goal={goal({ status: "paused" })} onSetStatus={mock()} onClear={mock()} />);
+    // Resume is the success-tinted primary action when paused so the
+    // user knows what to click next; the icon confirms the affordance.
+    const resume = getByLabelText("Resume goal");
+    expect(resume.querySelector("svg")).not.toBeNull();
+    expect(resume.className).toContain("text-success");
+  });
+
   test("renders accounting breakdown", () => {
     const startedAtMs = Date.now() - 90_000;
     const { getByText } = render(

--- a/src/browser/features/RightSidebar/GoalTab.tsx
+++ b/src/browser/features/RightSidebar/GoalTab.tsx
@@ -1,4 +1,4 @@
-import { Pencil, Settings2, Target } from "lucide-react";
+import { CheckCircle2, Pause, Pencil, Play, RotateCcw, Settings2, Target } from "lucide-react";
 import { useContext, useEffect, useRef, useState, type KeyboardEvent } from "react";
 import {
   goalActiveMode,
@@ -377,16 +377,24 @@ export function GoalTab(props: GoalTabProps) {
     }
   };
 
-  // Accent-green styling when the goal is lifecycle-active: the panel
-  // header should communicate "this is the active goal" at a glance,
-  // visually distinct from the muted "Set a goal" empty-state form.
-  // Sub-status (paused / budget-limited) shifts the label text but keeps
-  // the green band so the user sees the lifecycle, not the mode.
+  // Header tone keys off `activeMode` (not just lifecycle) so the user
+  // can tell at a glance whether the active goal is actually progressing
+  // (`running` → success/green) or stalled waiting for them (`paused` /
+  // `budget_limited` → warning/amber). Complete + read-only fall back to
+  // the muted surface tone. Amber consistently means "lifecycle-active
+  // but not auto-running" across the header band, the lifecycle status
+  // badge (`GoalStatusBadge` in `goalToolUtils.tsx`), and the sidebar
+  // tab label accent so the cue is reinforced wherever the workspace's
+  // goal status surfaces.
+  const isStalledActive = activeMode === "paused" || activeMode === "budget_limited";
   const headerToneClass =
-    lifecycle === "active"
+    activeMode === "running"
       ? "border-success/40 bg-success/5"
-      : "border-border-light bg-surface-secondary";
-  const headerLabelClass = lifecycle === "active" ? "text-success" : "text-muted";
+      : isStalledActive
+        ? "border-warning/40 bg-warning-overlay"
+        : "border-border-light bg-surface-secondary";
+  const headerLabelClass =
+    activeMode === "running" ? "text-success" : isStalledActive ? "text-warning" : "text-muted";
 
   return (
     <section className="flex h-full flex-col gap-4 overflow-y-auto p-4" aria-label="Workspace goal">
@@ -591,20 +599,33 @@ export function GoalTab(props: GoalTabProps) {
           {canPause && (
             <button
               type="button"
-              className="border-border-light bg-surface-secondary text-foreground hover:bg-surface-tertiary rounded-md border px-3 py-1.5 text-sm"
+              className="border-border-light bg-surface-secondary text-foreground hover:bg-surface-tertiary inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm"
               aria-label="Pause goal"
               onClick={() => void setStatus("paused")}
             >
+              <Pause className="h-3.5 w-3.5" aria-hidden="true" />
               Pause
             </button>
           )}
           {canResume && (
+            // Resume / Reopen tints with the goal-green accent so the
+            // primary "get this goal running again" action is the
+            // obvious next step when the header is amber. The same
+            // styling covers both `paused → resume` and `complete →
+            // reopen`; the icon swaps (`Play` vs `RotateCcw`) to make
+            // the difference between resuming an in-flight goal and
+            // reviving a closed one explicit.
             <button
               type="button"
-              className="border-border-light bg-surface-secondary text-foreground hover:bg-surface-tertiary rounded-md border px-3 py-1.5 text-sm"
+              className="border-success/40 bg-success/10 text-success hover:bg-success/20 inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm"
               aria-label={lifecycle === "complete" ? "Reopen goal" : "Resume goal"}
               onClick={() => void setStatus("active")}
             >
+              {lifecycle === "complete" ? (
+                <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
+              ) : (
+                <Play className="h-3.5 w-3.5" aria-hidden="true" />
+              )}
               {/* "Reopen" reads better than "Resume" when the goal was
                   marked complete — the user is reviving a goal the
                   agent decided was done, not resuming a paused one. */}
@@ -614,10 +635,11 @@ export function GoalTab(props: GoalTabProps) {
           {canComplete && (
             <button
               type="button"
-              className="border-border-light bg-surface-secondary text-foreground hover:bg-surface-tertiary rounded-md border px-3 py-1.5 text-sm"
+              className="border-border-light bg-surface-secondary text-foreground hover:bg-surface-tertiary inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm"
               aria-label="Mark goal complete"
               onClick={(event) => openSummaryInput(event.currentTarget)}
             >
+              <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
               Mark complete
             </button>
           )}

--- a/src/browser/features/RightSidebar/Tabs/TabLabels.goal.test.tsx
+++ b/src/browser/features/RightSidebar/Tabs/TabLabels.goal.test.tsx
@@ -75,11 +75,30 @@ describe("GoalTabLabel", () => {
     expect(container.querySelector(".text-success")).not.toBeNull();
   });
 
-  test("does not accent paused goals", () => {
+  test("uses warning amber accent for paused goals (active but not auto-running)", () => {
+    // Paused is a lifecycle-active sub-status: the goal is still the
+    // workspace's active goal but won't progress without user action.
+    // The tab label surfaces this with the warning amber accent
+    // (matching the Goals-tab header band + `GoalStatusBadge` paused
+    // color) so the workspace shows "needs attention" without claiming
+    // the goal-green "running" cue.
     mockedSidebarState = makeSidebarState(makeGoal({ status: "paused" }));
 
     const { container } = render(<GoalTabLabel workspaceId="w1" />);
 
+    expect(container.querySelector(".text-warning")).not.toBeNull();
+    expect(container.querySelector(".text-success")).toBeNull();
+  });
+
+  test("uses warning amber accent for budget-limited goals", () => {
+    // budget_limited shares the "active but not auto-running" semantics
+    // with paused — the goal hit its cost or turn cap and is waiting
+    // for the user to raise the cap or wrap up. Same amber accent.
+    mockedSidebarState = makeSidebarState(makeGoal({ status: "budget_limited" }));
+
+    const { container } = render(<GoalTabLabel workspaceId="w1" />);
+
+    expect(container.querySelector(".text-warning")).not.toBeNull();
     expect(container.querySelector(".text-success")).toBeNull();
   });
 
@@ -91,6 +110,7 @@ describe("GoalTabLabel", () => {
     const { container } = render(<GoalTabLabel workspaceId="w1" />);
 
     expect(container.querySelector(".text-success")).toBeNull();
+    expect(container.querySelector(".text-warning")).toBeNull();
   });
 
   test("does not accent pending-persistence goals (mid-stream / unsaved)", () => {

--- a/src/browser/features/RightSidebar/Tabs/TabLabels.tsx
+++ b/src/browser/features/RightSidebar/Tabs/TabLabels.tsx
@@ -31,7 +31,7 @@ import {
   useOptionalWorkspaceSidebarState,
   useWorkspaceUsage,
 } from "@/browser/stores/WorkspaceStore";
-import { isGoalPendingPersistence } from "@/common/types/goal";
+import { goalActiveMode, isGoalPendingPersistence } from "@/common/types/goal";
 import { sumUsageHistory, type ChatUsageDisplay } from "@/common/utils/tokens/usageAggregator";
 
 interface StatsTabLabelProps {
@@ -131,24 +131,46 @@ interface GoalTabLabelProps {
  * Goal tab label.
  *
  * Subscribes directly to the workspace's sidebar state so the label can apply
- * the canonical goal-green accent (`text-success`, the same token used by
- * `CompleteGoalToolCall` and the TodoList completion cue) when the workspace
- * has a *live* goal in chat. The accent is intentionally restricted to the
- * `status === "active"` && non-pending case so paused, complete, history-only,
- * and mid-stream pending goals don't claim the success cue. This mirrors the
- * `useActiveGoalCount` / `ActiveGoalsWarningToast` predicate, so a workspace
- * that contributes to the global "active goals" toast is also the one that
- * lights up its Goal tab.
+ * a semantic accent (`text-success` or `text-warning`) when the workspace
+ * has a *live* goal in chat:
+ *
+ *   • `text-success` — the goal is running (`status === "active"` &&
+ *     non-pending). Mirrors the `useActiveGoalCount` /
+ *     `ActiveGoalsWarningToast` predicate so a workspace that contributes
+ *     to the global "active goals" toast is also the one that lights up
+ *     green here.
+ *   • `text-warning` — the goal is lifecycle-active but stalled (paused
+ *     or budget-limited). Surfaces a glanceable cue that the workspace
+ *     needs the user's attention even though no agent is currently
+ *     burning turns. This mirrors the amber tinting on the Goals-tab
+ *     header band and the `GoalStatusBadge` paused/budget-limited
+ *     color.
+ *
+ * Pending-persistence goals (mid-stream / unsaved) stay unaccented so
+ * the accent doesn't flicker during a stream — same gating as before.
  */
 export const GoalTabLabel: React.FC<GoalTabLabelProps> = ({ workspaceId }) => {
   const sidebarState = useOptionalWorkspaceSidebarState(workspaceId);
   const goal = sidebarState?.goal ?? null;
-  const isGoalActive = goal?.status === "active" && !isGoalPendingPersistence(goal);
+  const activeMode = goal && !isGoalPendingPersistence(goal) ? goalActiveMode(goal.status) : null;
+  const isRunning = activeMode === "running";
+  const isStalled = activeMode === "paused" || activeMode === "budget_limited";
+  const ariaLabel = isRunning
+    ? "Goal (active)"
+    : activeMode === "paused"
+      ? "Goal (paused)"
+      : activeMode === "budget_limited"
+        ? "Goal (budget limited)"
+        : "Goal";
 
   return (
     <span
-      className={cn("inline-flex items-center gap-1", isGoalActive && "text-success")}
-      aria-label={isGoalActive ? "Goal (active)" : "Goal"}
+      className={cn(
+        "inline-flex items-center gap-1",
+        isRunning && "text-success",
+        isStalled && "text-warning"
+      )}
+      aria-label={ariaLabel}
     >
       <Target className="h-3 w-3 shrink-0" />
       Goal

--- a/src/browser/features/Tools/Goal/goalToolUtils.tsx
+++ b/src/browser/features/Tools/Goal/goalToolUtils.tsx
@@ -51,14 +51,17 @@ export function goalStatusLabel(status: GoalStatus): string {
   return STATUS_LABELS[status];
 }
 
-// All "Active" sub-statuses share the success-tinted badge so the goal-
-// tab header reads as "this is the active goal" at a glance — paused /
-// budget-limited only modify the inner mode label, not the band color.
-// Complete keeps the success color too because it represents a successful
-// terminal state.
+// Color semantics:
+//   success/green — the active goal is running (or terminally complete).
+//   warning/amber — the active goal is paused or budget-limited
+//     (lifecycle-active but NOT auto-running). Amber consistently means
+//     "this goal is the workspace's active goal but won't progress until
+//     you act" so users can spot a stalled workspace at a glance — the
+//     band color matches the Goals-tab header tone and the sidebar tab
+//     label accent for the same status.
 const STATUS_BADGE_CLASSES: Record<GoalStatus, string> = {
   active: "bg-success/10 text-success border-success/40",
-  paused: "bg-success/10 text-success border-success/40",
+  paused: "bg-warning-overlay text-warning border-warning/40",
   budget_limited: "bg-warning-overlay text-warning border-warning/40",
   complete: "bg-success/10 text-success border-success/40",
 };


### PR DESCRIPTION
## Summary

Make the Goals tab visually distinguish a paused/budget-limited goal from a running one. Adds semantic icons to the lifecycle actions and gives the sidebar Goal tab + chat status badge the same amber accent so a stalled workspace is glanceable across every surface.

## Background

Before this change the Goals tab treated all lifecycle-active states the same: paused and budget-limited goals rendered with the same green header band as running goals, the Pause / Resume / Mark complete buttons were neutral and text-only (no icon affordance, no semantic cue for the primary "get this goal moving again" action), and the sidebar Goal tab label dropped its accent entirely when the goal was paused — making a stalled workspace look identical to one with no goal at all. In a multi-workspace session that needed the user's attention, paused goals were easy to miss.

## Implementation

Introduces a single color semantic shared across the goal status surfaces:

- **`success/green`** — the goal is running, or terminally complete.
- **`warning/amber`** — the goal is lifecycle-active but stalled (`paused` or `budget_limited`) and won't progress until the user acts.

Touches three surfaces so the cue is reinforced wherever a goal status appears:

- `goalToolUtils.tsx` — `STATUS_BADGE_CLASSES` now uses amber for `paused`, matching `budget_limited`. This propagates to chat tool-call cards (e.g. `GetGoalToolCall`) so the badge color you see in chat agrees with what the sidebar shows.
- `GoalTab.tsx` — header tone keys off `activeMode` (instead of just lifecycle) so `running` is green, `paused` / `budget_limited` are amber, and `complete` falls back to the muted surface tone. Pause / Resume / Reopen / Mark complete gain semantic icons (`Pause`, `Play`, `RotateCcw`, `CheckCircle2`). Resume / Reopen is tinted with the goal-green accent so the primary "get this goal moving again" action is the obvious next step when the header is amber.
- `TabLabels.tsx` (`GoalTabLabel`) — paused + budget-limited workspaces now carry the amber accent on the sidebar tab (previously: no accent at all when paused). Running stays green, pending-persistence stays unaccented so the accent doesn't flicker during a stream.

## Validation

- `bun test src/browser/features/RightSidebar/ src/browser/features/Tools/Goal/` → 126 pass.
- `make static-check` → passed (lint, typecheck, fmt-check, etc.).
- Behavioral tests added: header tone differentiation across running / paused / budget-limited, lifecycle buttons rendering an SVG icon, and Resume carrying the success accent so the primary action is visually distinct.

## Risks

Low. Changes are CSS/icon additions and the existing lifecycle behavior (state transitions, button gating, focus handling) is untouched. The shared `GoalStatusBadge` color update reaches chat tool-call cards too, which is the intended consistency — paused goals now look the same color wherever they surface.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `max` • Cost: `$N/A`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=max costs=N/A -->
