### PR TITLE
🤖 feat(goals): teach what a good goal looks like via placeholder

### DIFF
--- a/src/browser/features/RightSidebar/GoalBoardSections.tsx
+++ b/src/browser/features/RightSidebar/GoalBoardSections.tsx
@@ -31,6 +31,7 @@ import { useAPI } from "@/browser/contexts/API";
 import { useGoalDefaults } from "@/browser/utils/goals/useGoalDefaults";
 import { loadGoalDefaults, resolveGoalSetIntent } from "@/browser/utils/goals/resolveGoalSetIntent";
 import { cn } from "@/common/lib/utils";
+import { GOAL_OBJECTIVE_PLACEHOLDER } from "@/constants/goals";
 import type { GoalBoardEntry, GoalBoardSnapshot, GoalRecordV1 } from "@/common/types/goal";
 import { formatGoalCents } from "@/common/utils/goals/budgetPricing";
 import {
@@ -691,7 +692,7 @@ function UpcomingAdder(props: UpcomingAdderProps) {
       <input
         ref={objectiveRef}
         aria-label="Queued goal objective"
-        placeholder="Describe the next goal"
+        placeholder={GOAL_OBJECTIVE_PLACEHOLDER}
         className="border-border bg-surface-primary text-foreground focus:border-accent rounded-md border p-1.5 text-sm outline-none"
         autoFocus
         onKeyDown={(event) => {

--- a/src/browser/features/RightSidebar/GoalTab.tsx
+++ b/src/browser/features/RightSidebar/GoalTab.tsx
@@ -7,6 +7,7 @@ import {
   type GoalSnapshot,
   type GoalStatus,
 } from "@/common/types/goal";
+import { GOAL_OBJECTIVE_PLACEHOLDER } from "@/constants/goals";
 import { formatGoalCents } from "@/common/utils/goals/budgetPricing";
 import {
   parseGoalBudgetInputCents,
@@ -1057,9 +1058,14 @@ function GoalCreateForm(props: GoalCreateFormProps) {
         <textarea
           ref={objectiveRef}
           id="goal-create-objective"
-          className="border-border bg-surface-primary text-foreground focus:border-accent min-h-20 w-full rounded-md border p-2 text-sm outline-none"
+          // `min-h-28` (7rem) keeps the multi-sentence educational
+          // placeholder (`GOAL_OBJECTIVE_PLACEHOLDER`) fully visible at
+          // typical sidebar widths. Textareas don't scroll placeholder
+          // text, so dropping below ~5 lines starts truncating the
+          // example phrases the placeholder is meant to teach.
+          className="border-border bg-surface-primary text-foreground focus:border-accent min-h-28 w-full rounded-md border p-2 text-sm outline-none"
           aria-label="Goal objective"
-          placeholder="Ship the goal lifecycle slice"
+          placeholder={GOAL_OBJECTIVE_PLACEHOLDER}
           defaultValue=""
           onKeyDown={(event) => {
             // Cmd/Ctrl+Enter mirrors the inline objective editor. Plain

--- a/src/browser/utils/commands/sources.ts
+++ b/src/browser/utils/commands/sources.ts
@@ -44,6 +44,7 @@ import type { BranchListResult } from "@/common/orpc/types";
 import type { WorkspaceState } from "@/browser/stores/WorkspaceStore";
 import type { RuntimeConfig } from "@/common/types/runtime";
 import { isGoalPendingPersistence, type GoalSetError, type GoalStatus } from "@/common/types/goal";
+import { GOAL_OBJECTIVE_PLACEHOLDER } from "@/constants/goals";
 import { getErrorMessage } from "@/common/utils/errors";
 import { parseGoalBudgetCents } from "@/browser/utils/slashCommands/registry";
 import { setGoalWithConflictRetry } from "@/browser/utils/goals/setGoalWithConflictRetry";
@@ -840,7 +841,7 @@ export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandActi
               type: "text",
               name: "objective",
               label: "Goal objective",
-              placeholder: "Describe the goal…",
+              placeholder: GOAL_OBJECTIVE_PLACEHOLDER,
               validate: (value) => (!value.trim() ? "Goal objective is required" : null),
             },
             {

--- a/src/constants/goals.ts
+++ b/src/constants/goals.ts
@@ -5,6 +5,18 @@ export const GOAL_CONTINUATION_KIND = "goal_continuation";
 export const GOAL_BUDGET_LIMIT_KIND = "goal_budget_limit";
 export const GOAL_OBJECTIVE_OPEN_TAG = "<untrusted_objective>";
 export const GOAL_OBJECTIVE_CLOSE_TAG = "</untrusted_objective>";
+
+/**
+ * Placeholder shown wherever a user is asked to write a goal objective
+ * (right-sidebar form, command palette, queued-goal input). The text is
+ * deliberately educational: it teaches what a good agent goal looks like
+ * (concrete + measurable + constraints) so the agent has a verifiable
+ * definition of "done". Keep this to <=3 sentences so it stays readable
+ * as placeholder copy and doesn't dwarf the surrounding form chrome.
+ */
+export const GOAL_OBJECTIVE_PLACEHOLDER =
+  'Good goals are concrete and measurable. Try "Improve the performance of this function by 30% given X, Y constraints" or "Find one critical security vulnerability." Specific, quantitative targets help the agent know when it\'s done.';
+
 export type GoalSyntheticMessageKind =
   | typeof GOAL_CONTINUATION_KIND
   | typeof GOAL_BUDGET_LIMIT_KIND;


### PR DESCRIPTION
## Summary

Replace the trivial goal-objective placeholders (`Describe the goal…`, `Ship the goal lifecycle slice`, `Describe the next goal`) with a single shared, educational placeholder that teaches users what a good agent goal looks like: concrete, measurable, and constraint-aware.

## Background

The previous placeholders described _how_ to fill in the field (`Describe the goal…`) or were just lorem-ipsum-style example objectives (`Ship the goal lifecycle slice`). Neither tells a first-time user what makes a goal _good_ — i.e. one the agent can verifiably finish. New users frequently set vague goals like "make this faster" that the agent has no way to know it has completed.

This change uses the placeholder space to do a small piece of in-product teaching, in three sentences:

> Good goals are concrete and measurable. Try "Improve the performance of this function by 30% given X, Y constraints" or "Find one critical security vulnerability." Specific, quantitative targets help the agent know when it's done.

## Implementation

- New `GOAL_OBJECTIVE_PLACEHOLDER` constant in `src/constants/goals.ts` (with a `<= 3 sentences` invariant documented in the JSDoc) is the single source of truth.
- Reused across every goal-objective entry point:
  - `GoalTab.tsx` — primary "Set a goal" textarea in the right sidebar.
  - `GoalBoardSections.tsx` — "Queue another goal" input.
  - `commands/sources.ts` — Command palette `Goal: Set objective` prompt.
- The right-sidebar textarea also bumps `min-h-20` → `min-h-28` so the multi-sentence placeholder stays fully visible at typical sidebar widths. (Textarea placeholders don't scroll — dropping below ~5 lines starts truncating the examples the copy is meant to teach.)

## Validation

- `make static-check` — passed (typecheck + lint + fmt-check + docs link check).
- Focused tests passed: `GoalTab.test.tsx`, `TabLabels.goal.test.tsx`, `CommandPalette.prompt.test.tsx`, `sources.test.ts`.

## Risks

Minimal. This is a copy-only change to placeholder text plus a small CSS `min-h` bump on one textarea. No behavior changes, no schema changes, no IPC changes. The only user-visible regression risk is that the right-sidebar `Set a goal` form is now ~32px taller when empty, which is well within existing layout slack.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `max`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=max -->
