### PR TITLE
🤖 feat: release goals into GA

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -188,7 +188,6 @@ function AppInner() {
   );
 
   const [isMultiProjectWorkspaceModalOpen, setMultiProjectWorkspaceModalOpen] = useState(false);
-  const goalsEnabled = useExperimentValue(EXPERIMENT_IDS.GOALS);
   const multiProjectWorkspacesEnabled = useExperimentValue(EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES);
 
   // Left sidebar is drag-resizable (mirrors RightSidebar). Width is persisted globally;
@@ -717,7 +716,6 @@ function AppInner() {
     onStartWorkspaceCreation: openNewWorkspaceFromPalette,
     onStartMultiProjectWorkspaceCreation: openNewMultiProjectWorkspaceFromPalette,
     multiProjectWorkspacesEnabled,
-    goalsEnabled,
     onArchiveMergedWorkspacesInProject: archiveMergedWorkspacesInProjectFromPalette,
     getBranchesForProject,
     onSelectWorkspace: selectWorkspaceFromPalette,
@@ -1220,7 +1218,7 @@ function AppInner() {
             )}
           </div>
         </div>
-        <WorkspaceActiveGoalsWarningToast enabled={goalsEnabled} />
+        <WorkspaceActiveGoalsWarningToast />
         <CommandPalette getSlashContext={() => ({ workspaceId: selectedWorkspace?.workspaceId })} />
         <ProjectCreateModal
           initialPath={projectCreateInitialPath}

--- a/src/browser/components/ActiveGoalsWarningToast/ActiveGoalsWarningToast.test.tsx
+++ b/src/browser/components/ActiveGoalsWarningToast/ActiveGoalsWarningToast.test.tsx
@@ -46,26 +46,4 @@ describe("ActiveGoalsWarningToast", () => {
 
     await waitFor(() => expect(getByRole("status").getAttribute("aria-live")).toBe("polite"));
   });
-
-  test("does not fire when the GOALS experiment is disabled", () => {
-    // Coder-agents-review P3 DEREM-49: pin the experiment-off short-circuit
-    // so a regression that removed the `enabled === false` guard would fail.
-    // Without it, users who toggled the experiment off mid-session would get
-    // spurious warnings whenever active goals exceed the threshold.
-    const { queryByRole } = render(<ActiveGoalsWarningToast activeGoalCount={5} enabled={false} />);
-
-    expect(queryByRole("status")).toBeNull();
-  });
-
-  test("clears any showing toast when the experiment is toggled off mid-session", async () => {
-    // The experiment-off branch also clears a *currently showing* warning,
-    // not just suppresses new ones. Render with enabled=true above the
-    // threshold (which fires the toast), then flip to enabled=false and
-    // assert the toast disappears.
-    const { queryByRole, rerender } = render(<ActiveGoalsWarningToast activeGoalCount={4} />);
-    await waitFor(() => expect(queryByRole("status")?.textContent).toContain("4 active goals"));
-
-    rerender(<ActiveGoalsWarningToast activeGoalCount={4} enabled={false} />);
-    await waitFor(() => expect(queryByRole("status")).toBeNull());
-  });
 });

--- a/src/browser/components/ActiveGoalsWarningToast/ActiveGoalsWarningToast.tsx
+++ b/src/browser/components/ActiveGoalsWarningToast/ActiveGoalsWarningToast.tsx
@@ -8,7 +8,6 @@ const wrapperClassName =
 
 interface ActiveGoalsWarningToastProps {
   activeGoalCount: number;
-  enabled?: boolean;
 }
 
 export function ActiveGoalsWarningToast(props: ActiveGoalsWarningToastProps) {
@@ -16,12 +15,6 @@ export function ActiveGoalsWarningToast(props: ActiveGoalsWarningToastProps) {
   const wasAboveThresholdRef = useRef(false);
 
   useEffect(() => {
-    if (props.enabled === false) {
-      wasAboveThresholdRef.current = false;
-      setToastCount(null);
-      return;
-    }
-
     const isAboveThreshold = props.activeGoalCount > ACTIVE_GOAL_WARNING_THRESHOLD;
     if (!isAboveThreshold) {
       wasAboveThresholdRef.current = false;
@@ -37,7 +30,7 @@ export function ActiveGoalsWarningToast(props: ActiveGoalsWarningToastProps) {
 
     wasAboveThresholdRef.current = true;
     setToastCount(props.activeGoalCount);
-  }, [props.activeGoalCount, props.enabled]);
+  }, [props.activeGoalCount]);
 
   useEffect(() => {
     if (toastCount == null || typeof window === "undefined") {
@@ -69,8 +62,8 @@ export function ActiveGoalsWarningToast(props: ActiveGoalsWarningToastProps) {
   );
 }
 
-export function WorkspaceActiveGoalsWarningToast(props: { enabled?: boolean }) {
+export function WorkspaceActiveGoalsWarningToast() {
   const activeGoalCount = useActiveGoalCount();
 
-  return <ActiveGoalsWarningToast activeGoalCount={activeGoalCount} enabled={props.enabled} />;
+  return <ActiveGoalsWarningToast activeGoalCount={activeGoalCount} />;
 }

--- a/src/browser/components/CommandPalette/CommandPalette.tsx
+++ b/src/browser/components/CommandPalette/CommandPalette.tsx
@@ -60,7 +60,6 @@ interface PaletteGroup {
 export const CommandPalette: React.FC<CommandPaletteProps> = ({ getSlashContext }) => {
   const { api } = useAPI();
 
-  const goalsExperimentEnabled = useExperimentValue(EXPERIMENT_IDS.GOALS);
   const workspaceHeartbeatsExperimentEnabled = useExperimentValue(
     EXPERIMENT_IDS.WORKSPACE_HEARTBEATS
   );
@@ -293,7 +292,6 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ getSlashContext 
         variant: ctx.workspaceId ? "workspace" : "creation",
         isExperimentEnabled: (experimentId) =>
           resolveSlashCommandExperimentValue(experimentId, {
-            goals: goalsExperimentEnabled,
             workspaceHeartbeats: workspaceHeartbeatsExperimentEnabled,
           }),
       });
@@ -368,7 +366,6 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ getSlashContext 
     recentIndex,
     getSlashContext,
     agentSkills,
-    goalsExperimentEnabled,
     workspaceHeartbeatsExperimentEnabled,
   ]);
 

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -65,7 +65,6 @@ import {
   getWorkspaceLastReadKey,
 } from "@/common/constants/storage";
 import {
-  isGoalsExperimentEnabledForCommand,
   prepareCompactionMessage,
   processSlashCommand,
   type SlashCommandContext,
@@ -237,7 +236,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const creationProject =
     variant === "creation" ? userProjects.get(creationParentProjectPath) : undefined;
   const [thinkingLevel] = useThinkingLevel();
-  const goalsExperimentEnabled = useExperimentValue(EXPERIMENT_IDS.GOALS);
   const workspaceHeartbeatsExperimentEnabled = useExperimentValue(
     EXPERIMENT_IDS.WORKSPACE_HEARTBEATS
   );
@@ -1415,19 +1413,12 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       variant,
       isExperimentEnabled: (experimentId) =>
         resolveSlashCommandExperimentValue(experimentId, {
-          goals: goalsExperimentEnabled,
           workspaceHeartbeats: workspaceHeartbeatsExperimentEnabled,
         }),
     });
     setCommandSuggestions((prev) => replaceSuggestions(prev, suggestions));
     setShowCommandSuggestions(suggestions.length > 0);
-  }, [
-    input,
-    agentSkillDescriptors,
-    variant,
-    goalsExperimentEnabled,
-    workspaceHeartbeatsExperimentEnabled,
-  ]);
+  }, [input, agentSkillDescriptors, variant, workspaceHeartbeatsExperimentEnabled]);
 
   // Derive ghost hint for slash-command argument syntax.
   // Show only when suggestions are hidden and the input is exactly "/command " with no args yet.
@@ -1435,7 +1426,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     variant,
     isExperimentEnabled: (experimentId) =>
       resolveSlashCommandExperimentValue(experimentId, {
-        goals: goalsExperimentEnabled,
         workspaceHeartbeats: workspaceHeartbeatsExperimentEnabled,
       }),
   });
@@ -2158,14 +2148,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     // Route to creation handler for creation variant
     if (variant === "creation") {
       const initialGoalCommand = parsed?.type === "goal-set" ? parsed : undefined;
-      if (initialGoalCommand && !(await isGoalsExperimentEnabledForCommand({ api }))) {
-        setToast({
-          id: Date.now().toString(),
-          type: "error",
-          message: "Goal commands require the Goals experiment to be enabled",
-        });
-        return;
-      }
       if (!initialGoalCommand) {
         const commandHandled = await executeParsedCommand(parsed, input);
         if (commandHandled) {

--- a/src/browser/features/ChatInput/useCreationWorkspace.test.tsx
+++ b/src/browser/features/ChatInput/useCreationWorkspace.test.tsx
@@ -18,7 +18,7 @@ import {
   getThinkingLevelKey,
 } from "@/common/constants/storage";
 import type { WorkspaceChatMessage } from "@/common/orpc/types";
-import { EXPERIMENT_IDS, getExperimentKey } from "@/common/constants/experiments";
+
 import {
   CODER_RUNTIME_PLACEHOLDER,
   type CoderWorkspaceConfig,
@@ -753,7 +753,6 @@ describe("useCreationWorkspace", () => {
         Promise.resolve({ success: true, data: {} } as WorkspaceSendMessageResult)
     );
     const { workspaceApi } = setupWindow({ setGoal: setGoalMock, sendMessage: sendMessageMock });
-    localStorage.setItem(getExperimentKey(EXPERIMENT_IDS.GOALS), JSON.stringify(true));
 
     const onWorkspaceCreated = mock(
       (

--- a/src/browser/features/RightSidebar/RightSidebar.tsx
+++ b/src/browser/features/RightSidebar/RightSidebar.tsx
@@ -655,7 +655,6 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
   const api = apiState.api;
   const desktopExperimentEnabled = useExperimentValue(EXPERIMENT_IDS.PORTABLE_DESKTOP);
   const browserExperimentEnabled = useExperimentValue(EXPERIMENT_IDS.AGENT_BROWSER);
-  const goalsExperimentEnabled = useExperimentValue(EXPERIMENT_IDS.GOALS);
   // Child task workspaces can't run goal actions — backend rejects them
   // via `WorkspaceGoalService.assertParentWorkspace`. We use this flag
   // both to hide the Goal tab below and to gate any inline goal UX.
@@ -948,14 +947,12 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
     setLayoutRaw((prevRaw) => {
       const prev = parseRightSidebarLayoutState(prevRaw, initialActiveTab);
       const hasGoal = collectAllTabs(prev.root).includes("goal");
-      // Goal tab is always visible when the GOALS experiment is enabled
-      // AND the workspace is a top-level workspace. Child task
+      // Goal tab is always visible on top-level workspaces. Child task
       // workspaces can't use any goal action — every backend write goes
       // through `assertParentWorkspace()` which throws for workspaces
       // with `parentWorkspaceId`. Showing the tab there would surface
       // a create/queue UI whose submits fail.
-      const isChildWorkspace = isChildWorkspaceForGoal;
-      const goalTabShouldExist = goalsExperimentEnabled && !isChildWorkspace;
+      const goalTabShouldExist = !isChildWorkspaceForGoal;
       if (goalTabShouldExist && !hasGoal) {
         return addTabToFocusedTabset(prev, "goal", false);
       }
@@ -966,7 +963,7 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
 
       return prev;
     });
-  }, [goalsExperimentEnabled, initialActiveTab, setLayoutRaw, isChildWorkspaceForGoal]);
+  }, [initialActiveTab, setLayoutRaw, isChildWorkspaceForGoal]);
 
   React.useEffect(() => {
     if (!desktopExperimentEnabled) {

--- a/src/browser/features/RightSidebar/Tabs/tabConfig.ts
+++ b/src/browser/features/RightSidebar/Tabs/tabConfig.ts
@@ -50,7 +50,6 @@ const TAB_CONFIG_DEF = {
   goal: {
     name: "Goal",
     contentClassName: "overflow-y-auto p-0",
-    featureFlag: EXPERIMENT_IDS.GOALS,
     defaultOrder: 35,
     paletteKeywords: ["goal", "target", "objective"],
   },

--- a/src/browser/features/Settings/Sections/ExperimentsSection.stories.tsx
+++ b/src/browser/features/Settings/Sections/ExperimentsSection.stories.tsx
@@ -80,18 +80,15 @@ export const ImageGenerationEnabled: Story = {
   },
 };
 
-export const GoalAndHeartbeatSettingsEnabled: Story = {
-  // Goal-defaults editing moved to the in-tab `GoalDefaultsSection` in
-  // the workspace sidebar (see `src/browser/features/RightSidebar/`),
-  // so the Experiments panel no longer mounts the budget / turn-cap
-  // inputs. Heartbeat defaults still render inline here. This story
-  // now asserts the new pointer copy + the heartbeat fields.
+export const HeartbeatSettingsEnabled: Story = {
+  // Goals graduated to GA, so they no longer appear in the Experiments
+  // panel at all (configuration lives in the Goal tab's
+  // `GoalDefaultsSection`). Heartbeat defaults still render inline here.
   render: () => (
     <SettingsSectionStory
       setup={() =>
         setupSettingsStory({
           experiments: {
-            [EXPERIMENT_IDS.GOALS]: true,
             [EXPERIMENT_IDS.WORKSPACE_HEARTBEATS]: true,
           },
           goalDefaults: {

--- a/src/browser/features/Settings/Sections/ExperimentsSection.test.tsx
+++ b/src/browser/features/Settings/Sections/ExperimentsSection.test.tsx
@@ -167,14 +167,12 @@ describe("PortableDesktopExperimentWarning", () => {
     globalThis.clearInterval = originalClearInterval;
   });
 
-  test("shows heartbeat defaults inline only when its experiment is enabled; goal defaults point to the Goal tab", async () => {
+  test("shows heartbeat defaults inline only when its experiment is enabled", async () => {
     // Goal defaults moved out of ExperimentsSection into the Goal tab
-    // (`GoalDefaultsSection`). The experiments panel now only renders a
-    // pointer to the new home for goal configuration. Heartbeat defaults
-    // remain inline here for now.
+    // (`GoalDefaultsSection`); goals graduated to GA so it is no longer
+    // shown here at all. Heartbeat defaults remain inline here for now.
     experimentEnabled = false;
     experimentValues = {
-      [EXPERIMENT_IDS.GOALS]: false,
       [EXPERIMENT_IDS.WORKSPACE_HEARTBEATS]: false,
     };
 
@@ -184,7 +182,6 @@ describe("PortableDesktopExperimentWarning", () => {
     expect(view.queryByLabelText("Default heartbeat threshold in minutes")).toBeNull();
 
     experimentValues = {
-      [EXPERIMENT_IDS.GOALS]: true,
       [EXPERIMENT_IDS.WORKSPACE_HEARTBEATS]: true,
     };
     view.rerender(<ExperimentsSection />);
@@ -192,19 +189,15 @@ describe("PortableDesktopExperimentWarning", () => {
     await waitFor(() => {
       expect(view.getByLabelText("Default heartbeat threshold in minutes")).toBeTruthy();
     });
-    // Goal defaults are no longer rendered inline in the Experiments
-    // panel — they live in the Goal tab now.
+    // Goal defaults are no longer rendered in the Experiments panel —
+    // they live in the Goal tab now.
     expect(view.queryByLabelText("Default goal budget in dollars")).toBeNull();
-    // Pointer copy should mention the Goal tab as the new home.
-    expect(view.getByText(/Goal/, { selector: "span" })).toBeTruthy();
   });
 
   test("reloads experiment settings when inline controls remount", async () => {
-    // Only the heartbeat panel still triggers an inline `getConfig` —
-    // the goal panel was removed in favor of the Goal tab.
+    // Only the heartbeat panel still triggers an inline `getConfig`.
     experimentEnabled = false;
     experimentValues = {
-      [EXPERIMENT_IDS.GOALS]: true,
       [EXPERIMENT_IDS.WORKSPACE_HEARTBEATS]: true,
     };
 
@@ -216,7 +209,6 @@ describe("PortableDesktopExperimentWarning", () => {
     expect(mockApi.config?.getConfig).toHaveBeenCalledTimes(1);
 
     experimentValues = {
-      [EXPERIMENT_IDS.GOALS]: false,
       [EXPERIMENT_IDS.WORKSPACE_HEARTBEATS]: false,
     };
     view.rerender(<ExperimentsSection />);
@@ -224,7 +216,6 @@ describe("PortableDesktopExperimentWarning", () => {
     expect(view.queryByLabelText("Default heartbeat threshold in minutes")).toBeNull();
 
     experimentValues = {
-      [EXPERIMENT_IDS.GOALS]: true,
       [EXPERIMENT_IDS.WORKSPACE_HEARTBEATS]: true,
     };
     view.rerender(<ExperimentsSection />);
@@ -237,7 +228,6 @@ describe("PortableDesktopExperimentWarning", () => {
   test("starts a fresh settings load when the API client changes", async () => {
     experimentEnabled = false;
     experimentValues = {
-      [EXPERIMENT_IDS.GOALS]: true,
       [EXPERIMENT_IDS.WORKSPACE_HEARTBEATS]: true,
     };
 

--- a/src/browser/features/Settings/Sections/ExperimentsSection.tsx
+++ b/src/browser/features/Settings/Sections/ExperimentsSection.tsx
@@ -617,7 +617,6 @@ export function ExperimentsSection() {
   const { api } = useAPI();
   const advisorToolEnabled = useExperimentValue(EXPERIMENT_IDS.ADVISOR_TOOL);
   const imageGenerationToolEnabled = useExperimentValue(EXPERIMENT_IDS.IMAGE_GENERATION_TOOL);
-  const goalsEnabled = useExperimentValue(EXPERIMENT_IDS.GOALS);
   const workspaceHeartbeatsEnabled = useExperimentValue(EXPERIMENT_IDS.WORKSPACE_HEARTBEATS);
   const settingsConfigRequestRef = useRef<{
     api: APIClient;
@@ -714,20 +713,6 @@ export function ExperimentsSection() {
                   <HeartbeatDefaultsControls
                     loadConfig={api ? loadExperimentSettingsConfig : undefined}
                   />
-                </ExperimentSettingsPanel>
-              )}
-              {exp.id === EXPERIMENT_IDS.GOALS && goalsEnabled && (
-                // Goal-defaults editing has moved to the Goal tab — see
-                // `src/browser/features/RightSidebar/GoalDefaultsSection.tsx`.
-                // The tab is the long-lived home for goal configuration
-                // (workspace overrides + global defaults), so we no longer
-                // duplicate the controls here. Leaving a tiny pointer in the
-                // experiment panel for users who learned the old location.
-                <ExperimentSettingsPanel>
-                  <p className="text-muted text-xs">
-                    Configure goal defaults (budget, turn cap, explicit-budget) from the{" "}
-                    <span className="text-foreground">Goal</span> tab in the workspace sidebar.
-                  </p>
                 </ExperimentSettingsPanel>
               )}
               {exp.id === EXPERIMENT_IDS.PORTABLE_DESKTOP && <PortableDesktopExperimentWarning />}

--- a/src/browser/hooks/useSendMessageOptions.ts
+++ b/src/browser/hooks/useSendMessageOptions.ts
@@ -58,7 +58,6 @@ export function useSendMessageOptions(workspaceId: string): SendMessageOptionsWi
     EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING_EXCLUSIVE
   );
   const advisorTool = useExperimentOverrideValue(EXPERIMENT_IDS.ADVISOR_TOOL);
-  const goals = useExperimentOverrideValue(EXPERIMENT_IDS.GOALS);
   const execSubagentHardRestart = useExperimentOverrideValue(
     EXPERIMENT_IDS.EXEC_SUBAGENT_HARD_RESTART
   );
@@ -83,7 +82,6 @@ export function useSendMessageOptions(workspaceId: string): SendMessageOptionsWi
       programmaticToolCalling,
       programmaticToolCallingExclusive,
       advisorTool,
-      goals,
       execSubagentHardRestart,
       imageGenerationTool,
     },

--- a/src/browser/utils/chatCommands.test.ts
+++ b/src/browser/utils/chatCommands.test.ts
@@ -105,8 +105,7 @@ describe("parseRuntimeString", () => {
   });
 });
 
-function enableGoalsExperiment(): void {
-  localStorage.setItem(getExperimentKey(EXPERIMENT_IDS.GOALS), JSON.stringify(true));
+function ensureWindowDispatchEvent(): void {
   Object.defineProperty(window, "dispatchEvent", { value: mock(() => true), configurable: true });
 }
 
@@ -271,7 +270,7 @@ describe("processSlashCommand - model-set", () => {
   });
 
   test("refuses switching budgeted active goals to an unpriced model", async () => {
-    enableGoalsExperiment();
+    ensureWindowDispatchEvent();
     const setPreferredModel = mock(() => undefined);
     const context = createModelSetContext({
       providers: {
@@ -307,36 +306,6 @@ describe("processSlashCommand - model-set", () => {
     );
   });
 
-  test("allows unpriced model switch with stale budgeted goal when goals experiment is disabled", async () => {
-    const setPreferredModel = mock(() => undefined);
-    const getGoal = mock(() =>
-      Promise.resolve({
-        goal: {
-          goalId: "11111111-1111-4111-8111-111111111111",
-          status: "active",
-          budgetCents: 500,
-        },
-      })
-    );
-    const context = createModelSetContext({
-      providers: {
-        getConfig: mock(() => Promise.resolve({})),
-        setModels: mock(() => Promise.resolve(undefined)),
-      },
-      workspace: { getGoal },
-    } as unknown as SlashCommandContext["api"]);
-    context.setPreferredModel = setPreferredModel;
-
-    const result = await processSlashCommand(
-      { type: "model-set", modelString: "openai:not-priced-model" },
-      context
-    );
-
-    expect(result).toEqual({ clearInput: true, toastShown: true });
-    expect(getGoal).not.toHaveBeenCalled();
-    expect(setPreferredModel).toHaveBeenCalledWith("openai:not-priced-model");
-  });
-
   test("allows switching unbudgeted active goals to an unpriced model", async () => {
     const setPreferredModel = mock(() => undefined);
     const context = createModelSetContext({
@@ -368,43 +337,6 @@ describe("processSlashCommand - model-set", () => {
   });
 });
 
-describe("processSlashCommand - goal experiment state", () => {
-  test("allows goal commands when backend experiment assignment enables Goals", async () => {
-    const setGoal = mock(() =>
-      Promise.resolve({
-        success: true,
-        data: {
-          goalId: "33333333-3333-4333-8333-333333333333",
-          objective: "remote objective",
-        },
-      })
-    );
-    const context = createGoalCommandContext({
-      experiments: {
-        getAll: mock(() =>
-          Promise.resolve({ [EXPERIMENT_IDS.GOALS]: { value: true, source: "posthog" } })
-        ),
-      },
-      workspace: {
-        getGoal: mock(() => Promise.resolve({ goal: null })),
-        setGoal,
-        clearGoal: mock(),
-      },
-    } as unknown as SlashCommandContext["api"]);
-
-    const result = await processSlashCommand(
-      { type: "goal-set", objective: "remote objective" },
-      context
-    );
-
-    expect(result).toEqual({ clearInput: true, toastShown: false });
-    expect(setGoal).toHaveBeenCalledWith(
-      expect.objectContaining({ objective: "remote objective" })
-    );
-    expect(context.setToast).not.toHaveBeenCalled();
-  });
-});
-
 describe("processSlashCommand - workspace command gating", () => {
   test("shows goal parse errors during workspace creation", async () => {
     const context = createGoalCommandContext(null);
@@ -424,7 +356,7 @@ describe("processSlashCommand - workspace command gating", () => {
 
 describe("processSlashCommand - goal optimistic concurrency", () => {
   test("retries once after a goal conflict and reapplies the slash command intent", async () => {
-    enableGoalsExperiment();
+    ensureWindowDispatchEvent();
     const getGoal = mock()
       .mockResolvedValueOnce({
         goal: {
@@ -483,7 +415,7 @@ describe("processSlashCommand - goal optimistic concurrency", () => {
   });
 
   test("surfaces a toast and stops after two consecutive goal conflicts", async () => {
-    enableGoalsExperiment();
+    ensureWindowDispatchEvent();
     const getGoal = mock()
       .mockResolvedValueOnce({
         goal: {
@@ -537,7 +469,7 @@ describe("processSlashCommand - goal optimistic concurrency", () => {
 
 describe("processSlashCommand - goal lifecycle commands", () => {
   test("surfaces invalid transition messages for lifecycle commands", async () => {
-    enableGoalsExperiment();
+    ensureWindowDispatchEvent();
     const context = createGoalCommandContext({
       workspace: {
         getGoal: mock(() => Promise.resolve({ goal: null })),
@@ -560,7 +492,7 @@ describe("processSlashCommand - goal lifecycle commands", () => {
   });
 
   test("dispatches pause, resume, and complete goal commands", async () => {
-    enableGoalsExperiment();
+    ensureWindowDispatchEvent();
     const setGoal = mock(() =>
       Promise.resolve({
         success: true,
@@ -599,7 +531,7 @@ describe("processSlashCommand - goal lifecycle commands", () => {
   });
 
   test("refuses to resume a budgeted goal on an unpriced current model", async () => {
-    enableGoalsExperiment();
+    ensureWindowDispatchEvent();
     const setGoal = mock(() => Promise.resolve({ success: true, data: {} }));
     const context = createGoalCommandContext({
       providers: { getConfig: mock(() => Promise.resolve({})) },
@@ -635,7 +567,7 @@ describe("processSlashCommand - goal lifecycle commands", () => {
 
 describe("processSlashCommand - goal budgets", () => {
   test("applies configured defaults when budget and turn cap are omitted", async () => {
-    enableGoalsExperiment();
+    ensureWindowDispatchEvent();
     const setGoal = mock().mockResolvedValueOnce({
       success: true,
       data: { goalId: "33333333-3333-4333-8333-333333333333", objective: "new objective" },
@@ -671,7 +603,7 @@ describe("processSlashCommand - goal budgets", () => {
   });
 
   test("passes parsed multiline goal objectives through to setGoal", async () => {
-    enableGoalsExperiment();
+    ensureWindowDispatchEvent();
     const objective = "Implement PRD\n\nRead first:\n- CONTEXT.md\n- PRD.md";
     const setGoal = mock().mockResolvedValueOnce({
       success: true,
@@ -708,7 +640,7 @@ describe("processSlashCommand - goal budgets", () => {
   });
 
   test("passes explicit no-budget and turn cap through to setGoal", async () => {
-    enableGoalsExperiment();
+    ensureWindowDispatchEvent();
     const setGoal = mock().mockResolvedValueOnce({
       success: true,
       data: { goalId: "33333333-3333-4333-8333-333333333333", objective: "new objective" },
@@ -737,7 +669,7 @@ describe("processSlashCommand - goal budgets", () => {
   });
 
   test("updates an existing goal budget without applying defaults", async () => {
-    enableGoalsExperiment();
+    ensureWindowDispatchEvent();
     const currentGoal = {
       goalId: "11111111-1111-4111-8111-111111111111",
       objective: "existing objective",
@@ -775,7 +707,7 @@ describe("processSlashCommand - goal budgets", () => {
   });
 
   test("passes no-budget budget updates through on unpriced current model", async () => {
-    enableGoalsExperiment();
+    ensureWindowDispatchEvent();
     const currentGoal = {
       goalId: "11111111-1111-4111-8111-111111111111",
       objective: "existing objective",
@@ -804,7 +736,7 @@ describe("processSlashCommand - goal budgets", () => {
   });
 
   test("passes zero-dollar budget updates through on unpriced current model", async () => {
-    enableGoalsExperiment();
+    ensureWindowDispatchEvent();
     const currentGoal = {
       goalId: "11111111-1111-4111-8111-111111111111",
       objective: "existing objective",
@@ -833,7 +765,7 @@ describe("processSlashCommand - goal budgets", () => {
   });
 
   test("refuses budgeted goals on an unpriced current model", async () => {
-    enableGoalsExperiment();
+    ensureWindowDispatchEvent();
     const setGoal = mock();
     const context = createGoalCommandContext({
       config: { getConfig: mock(() => Promise.resolve({})) },

--- a/src/browser/utils/chatCommands.ts
+++ b/src/browser/utils/chatCommands.ts
@@ -642,32 +642,9 @@ function resolveSlashGoalSetIntent(
   );
 }
 
-export async function isGoalsExperimentEnabledForCommand(context: {
-  api: CommandHandlerContext["api"] | SlashCommandContext["api"];
-}): Promise<boolean> {
-  const localOverride = isExperimentEnabled(EXPERIMENT_IDS.GOALS);
-  if (localOverride != null) {
-    return localOverride;
-  }
-
-  if (!context.api) {
-    return false;
-  }
-
-  try {
-    const allExperiments = await context.api.experiments.getAll();
-    return allExperiments[EXPERIMENT_IDS.GOALS]?.value === true;
-  } catch {
-    return false;
-  }
-}
-
 async function hasBudgetedResumableGoalForWorkspaceModelSwitch(
   context: SlashCommandContext
 ): Promise<boolean> {
-  if (!(await isGoalsExperimentEnabledForCommand(context))) {
-    return false;
-  }
   if (context.variant !== "workspace" || !context.api || !context.workspaceId) {
     return false;
   }
@@ -736,15 +713,6 @@ async function handleGoalCommand(
   context: CommandHandlerContext
 ): Promise<CommandHandlerResult> {
   const { api, workspaceId, setInput, setToast } = context;
-
-  if (!(await isGoalsExperimentEnabledForCommand(context))) {
-    setToast({
-      id: Date.now().toString(),
-      type: "error",
-      message: "Goal commands require the Goals experiment to be enabled",
-    });
-    return { clearInput: false, toastShown: true };
-  }
 
   setInput("");
 

--- a/src/browser/utils/commands/sources.test.ts
+++ b/src/browser/utils/commands/sources.test.ts
@@ -47,7 +47,6 @@ const mk = (over: Partial<Parameters<typeof buildCoreSources>[0]> = {}) => {
     onSetThinkingLevel: () => undefined,
     onStartWorkspaceCreation: () => undefined,
     onStartMultiProjectWorkspaceCreation: () => undefined,
-    goalsEnabled: false,
     multiProjectWorkspacesEnabled: true,
     onArchiveMergedWorkspacesInProject: () => Promise.resolve(),
     onSelectWorkspace: () => undefined,
@@ -546,7 +545,7 @@ function makeWorkspaceState(goal: WorkspaceState["goal"]): WorkspaceState {
 }
 
 const getVisibleGoalActions = (over: Partial<Parameters<typeof buildCoreSources>[0]> = {}) => {
-  const sources = mk({ goalsEnabled: true, ...over });
+  const sources = mk(over);
   return sources
     .flatMap((source) => source())
     .filter((action) => action.visible?.() ?? true)
@@ -558,8 +557,33 @@ const getVisibleGoalTitles = (over: Partial<Parameters<typeof buildCoreSources>[
     .map((action) => action.title)
     .sort();
 
-test("goal palette commands are hidden when the experiment is disabled", () => {
-  expect(getVisibleGoalTitles({ goalsEnabled: false })).toEqual([]);
+test("goal palette commands are hidden when no workspace is selected", () => {
+  expect(getVisibleGoalTitles({ selectedWorkspace: null })).toEqual([]);
+});
+
+test("goal palette commands are hidden for child task workspaces", () => {
+  const childMetadata = new Map<string, FrontendWorkspaceMetadata>();
+  childMetadata.set("child-ws", {
+    id: "child-ws",
+    name: "child-task",
+    projectName: "a",
+    projectPath: "/repo/a",
+    namedWorkspacePath: "/repo/a/child-task",
+    runtimeConfig: DEFAULT_RUNTIME_CONFIG,
+    parentWorkspaceId: "parent-ws",
+  });
+
+  expect(
+    getVisibleGoalTitles({
+      workspaceMetadata: childMetadata,
+      selectedWorkspace: {
+        projectPath: "/repo/a",
+        projectName: "a",
+        namedWorkspacePath: "/repo/a/child-task",
+        workspaceId: "child-ws",
+      },
+    })
+  ).toEqual([]);
 });
 
 test("goal palette commands only show set objective with no current goal", () => {
@@ -623,7 +647,6 @@ test("goal set objective prompt treats blank budget as explicit no-budget", asyn
   // slash-command path, there is no separate --no-budget flag in this prompt.
   const setGoalCalls: Array<Record<string, unknown>> = [];
   const sources = mk({
-    goalsEnabled: true,
     selectedWorkspaceState: {
       lifecycle: "active",
       goal: null,

--- a/src/browser/utils/commands/sources.ts
+++ b/src/browser/utils/commands/sources.ts
@@ -78,7 +78,6 @@ export interface BuildSourcesParams {
   onStartWorkspaceCreation: (projectPath: string) => void;
   onStartMultiProjectWorkspaceCreation: () => void;
   multiProjectWorkspacesEnabled: boolean;
-  goalsEnabled: boolean;
   onArchiveMergedWorkspacesInProject: (projectPath: string) => Promise<void>;
   getBranchesForProject: (projectPath: string) => Promise<BranchListResult>;
   onSelectWorkspace: (sel: {
@@ -819,11 +818,19 @@ export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandActi
   // Goals
   actions.push(() => {
     const selected = p.selectedWorkspace;
-    if (!p.goalsEnabled || !selected) {
+    if (!selected) {
       return [];
     }
 
     const workspaceId = selected.workspaceId;
+    const selectedMetadata = p.workspaceMetadata.get(workspaceId);
+    // Goal writes are rejected for child task workspaces by
+    // WorkspaceGoalService.assertParentWorkspace(), so keep palette actions
+    // hidden there just like the Goal tab.
+    if (selectedMetadata?.parentWorkspaceId != null) {
+      return [];
+    }
+
     const api = p.api;
     const goal = p.selectedWorkspaceState?.goal ?? null;
     const list: CommandAction[] = [

--- a/src/browser/utils/messages/buildSendMessageOptions.ts
+++ b/src/browser/utils/messages/buildSendMessageOptions.ts
@@ -7,7 +7,6 @@ export interface ExperimentValues {
   programmaticToolCalling: boolean | undefined;
   programmaticToolCallingExclusive: boolean | undefined;
   advisorTool: boolean | undefined;
-  goals: boolean | undefined;
   execSubagentHardRestart: boolean | undefined;
   imageGenerationTool: boolean | undefined;
 }

--- a/src/browser/utils/messages/sendOptions.ts
+++ b/src/browser/utils/messages/sendOptions.ts
@@ -83,7 +83,6 @@ export function getSendOptionsFromStorage(workspaceId: string): SendMessageOptio
         EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING_EXCLUSIVE
       ),
       advisorTool: isExperimentEnabled(EXPERIMENT_IDS.ADVISOR_TOOL),
-      goals: isExperimentEnabled(EXPERIMENT_IDS.GOALS),
       execSubagentHardRestart: isExperimentEnabled(EXPERIMENT_IDS.EXEC_SUBAGENT_HARD_RESTART),
       imageGenerationTool: isExperimentEnabled(EXPERIMENT_IDS.IMAGE_GENERATION_TOOL),
     },

--- a/src/browser/utils/slashCommands/experimentVisibility.ts
+++ b/src/browser/utils/slashCommands/experimentVisibility.ts
@@ -1,7 +1,6 @@
 import { EXPERIMENT_IDS, type ExperimentId } from "@/common/constants/experiments";
 
 export interface SlashCommandExperimentSnapshot {
-  goals: boolean;
   workspaceHeartbeats: boolean;
 }
 
@@ -10,8 +9,6 @@ export function resolveSlashCommandExperimentValue(
   snapshot: SlashCommandExperimentSnapshot
 ): boolean | undefined {
   switch (experimentId) {
-    case EXPERIMENT_IDS.GOALS:
-      return snapshot.goals;
     case EXPERIMENT_IDS.WORKSPACE_HEARTBEATS:
       return snapshot.workspaceHeartbeats;
     default:

--- a/src/browser/utils/slashCommands/ghostHint.test.ts
+++ b/src/browser/utils/slashCommands/ghostHint.test.ts
@@ -42,18 +42,26 @@ describe("getCommandGhostHint", () => {
 
   it("returns null for experiment-gated command hints when disabled", () => {
     expect(
-      getCommandGhostHint("/goal ", false, {
+      getCommandGhostHint("/heartbeat ", false, {
         isExperimentEnabled: () => false,
       })
     ).toBeNull();
   });
 
   it("returns hints for experiment-gated commands when enabled", () => {
-    const enabledExperiments = new Set<ExperimentId>([EXPERIMENT_IDS.GOALS]);
+    const enabledExperiments = new Set<ExperimentId>([EXPERIMENT_IDS.WORKSPACE_HEARTBEATS]);
 
     expect(
-      getCommandGhostHint("/goal ", false, {
+      getCommandGhostHint("/heartbeat ", false, {
         isExperimentEnabled: (experimentId) => enabledExperiments.has(experimentId),
+      })
+    ).toBe(SLASH_COMMAND_HINTS.heartbeat);
+  });
+
+  it("returns goal hints regardless of experiment state after GA", () => {
+    expect(
+      getCommandGhostHint("/goal ", false, {
+        isExperimentEnabled: () => false,
       })
     ).toBe(SLASH_COMMAND_HINTS.goal);
   });

--- a/src/browser/utils/slashCommands/registry.ts
+++ b/src/browser/utils/slashCommands/registry.ts
@@ -530,7 +530,6 @@ const SIMPLE_GOAL_LIFECYCLE_TYPES: Record<string, SimpleGoalLifecycleType> = {
 
 const goalCommandDefinition: SlashCommandDefinition = {
   key: "goal",
-  experimentGate: EXPERIMENT_IDS.GOALS,
   description: `Create, view, or clear a workspace goal. Usage: ${GOAL_USAGE}`,
   inputHint: SLASH_COMMAND_HINTS.goal,
   appendSpace: false,

--- a/src/browser/utils/slashCommands/suggestions.test.ts
+++ b/src/browser/utils/slashCommands/suggestions.test.ts
@@ -26,22 +26,21 @@ describe("getSlashCommandSuggestions", () => {
     });
     const labels = suggestions.map((s) => s.display);
 
-    expect(labels).not.toContain("/goal");
     expect(labels).not.toContain("/heartbeat");
+    // `/goal` graduated to GA — it must surface regardless of experiment state.
+    expect(labels).toContain("/goal");
   });
 
   it("shows experiment-gated commands when their experiments are enabled", () => {
-    const enabledExperiments = new Set<ExperimentId>([
-      EXPERIMENT_IDS.GOALS,
-      EXPERIMENT_IDS.WORKSPACE_HEARTBEATS,
-    ]);
+    const enabledExperiments = new Set<ExperimentId>([EXPERIMENT_IDS.WORKSPACE_HEARTBEATS]);
     const suggestions = getSlashCommandSuggestions("/", {
       isExperimentEnabled: (experimentId) => enabledExperiments.has(experimentId),
     });
     const labels = suggestions.map((s) => s.display);
 
-    expect(labels).toContain("/goal");
     expect(labels).toContain("/heartbeat");
+    // `/goal` is always available post-GA.
+    expect(labels).toContain("/goal");
   });
 
   it("suggests top level commands when starting with slash", () => {

--- a/src/common/constants/experiments.ts
+++ b/src/common/constants/experiments.ts
@@ -16,7 +16,6 @@ export const EXPERIMENT_IDS = {
   ADVISOR_TOOL: "advisor-tool",
   IMAGE_GENERATION_TOOL: "image-generation-tool",
   WORKSPACE_HEARTBEATS: "workspace-heartbeats",
-  GOALS: "goals",
   PORTABLE_DESKTOP: "portable-desktop",
 } as const;
 
@@ -129,14 +128,6 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     id: EXPERIMENT_IDS.WORKSPACE_HEARTBEATS,
     name: "Workspace Heartbeats",
     description: "Persist per-workspace heartbeat settings for future background follow-ups",
-    enabledByDefault: false,
-    userOverridable: true,
-    showInSettings: true,
-  },
-  [EXPERIMENT_IDS.GOALS]: {
-    id: EXPERIMENT_IDS.GOALS,
-    name: "Goals",
-    description: "Enable workspace goals for tracking an objective across turns",
     enabledByDefault: false,
     userOverridable: true,
     showInSettings: true,

--- a/src/common/orpc/schemas/stream.ts
+++ b/src/common/orpc/schemas/stream.ts
@@ -659,12 +659,15 @@ export const ToolPolicySchema = z.array(ToolPolicyFilterSchema).meta({
     "Tool policy - array of filters applied in order. Default behavior is allow all tools.",
 });
 
-// Experiments schema for feature gating
+// Experiments schema for feature gating.
+//
+// Unknown keys (e.g. `goals` from older persisted send-options written
+// before the Goals experiment graduated to GA) are stripped by Zod's
+// default behavior, so we do not need to retain a deprecated field.
 export const ExperimentsSchema = z.object({
   programmaticToolCalling: z.boolean().optional(),
   programmaticToolCallingExclusive: z.boolean().optional(),
   advisorTool: z.boolean().optional(),
-  goals: z.boolean().optional(),
   execSubagentHardRestart: z.boolean().optional(),
   imageGenerationTool: z.boolean().optional(),
 });

--- a/src/common/schemas/project.ts
+++ b/src/common/schemas/project.ts
@@ -135,7 +135,6 @@ export const WorkspaceConfigSchema = z.object({
       programmaticToolCalling: z.boolean().optional(),
       programmaticToolCallingExclusive: z.boolean().optional(),
       advisorTool: z.boolean().optional(),
-      goals: z.boolean().optional(),
       imageGenerationTool: z.boolean().optional(),
       execSubagentHardRestart: z.boolean().optional(),
     })

--- a/src/common/utils/tools/toolAvailability.test.ts
+++ b/src/common/utils/tools/toolAvailability.test.ts
@@ -17,12 +17,10 @@ const execBaseForExplore = {
 };
 
 function availableGoalToolNames(input: {
-  goalsExperimentEnabled: boolean;
   goalStatus: GoalStatus | null;
   editingCapable: boolean;
 }): string[] {
   const availability = getGoalToolAvailability({
-    goalsExperimentEnabled: input.goalsExperimentEnabled,
     goalStatus: input.goalStatus,
     agentInheritanceChain: input.editingCapable ? [execAgent] : [exploreAgent, execBaseForExplore],
   });
@@ -34,20 +32,9 @@ function availableGoalToolNames(input: {
 }
 
 describe("goal tool availability", () => {
-  test("omits goal tools when the experiment is off", () => {
-    expect(
-      availableGoalToolNames({
-        goalsExperimentEnabled: false,
-        goalStatus: "active",
-        editingCapable: true,
-      })
-    ).toEqual([]);
-  });
-
   test("omits goal tools when no goal is set", () => {
     expect(
       availableGoalToolNames({
-        goalsExperimentEnabled: true,
         goalStatus: null,
         editingCapable: true,
       })
@@ -57,7 +44,6 @@ describe("goal tool availability", () => {
   test.each(["paused", "complete"] as const)("omits goal tools for %s goals", (goalStatus) => {
     expect(
       availableGoalToolNames({
-        goalsExperimentEnabled: true,
         goalStatus,
         editingCapable: true,
       })
@@ -67,7 +53,6 @@ describe("goal tool availability", () => {
   test("allows get_goal only for active goals with a non-editing agent", () => {
     expect(
       availableGoalToolNames({
-        goalsExperimentEnabled: true,
         goalStatus: "active",
         editingCapable: false,
       })
@@ -77,7 +62,6 @@ describe("goal tool availability", () => {
   test("allows both goal tools for active goals with an editing agent", () => {
     expect(
       availableGoalToolNames({
-        goalsExperimentEnabled: true,
         goalStatus: "active",
         editingCapable: true,
       })
@@ -87,7 +71,6 @@ describe("goal tool availability", () => {
   test("allows both goal tools for budget-limited goals with an editing agent", () => {
     expect(
       availableGoalToolNames({
-        goalsExperimentEnabled: true,
         goalStatus: "budget_limited",
         editingCapable: true,
       })

--- a/src/common/utils/tools/toolAvailability.ts
+++ b/src/common/utils/tools/toolAvailability.ts
@@ -16,7 +16,6 @@ export interface GoalToolAvailability {
 }
 
 export interface GoalToolAvailabilityContext {
-  goalsExperimentEnabled: boolean;
   goalStatus: GoalStatus | null;
   agentInheritanceChain: ReadonlyArray<ToolsConfigCarrier & { id: AgentId }>;
 }
@@ -26,7 +25,7 @@ const GOAL_TOOL_ACTIVE_STATUSES: ReadonlySet<GoalStatus> = new Set(["active", "b
 export function getGoalToolAvailability(
   context: GoalToolAvailabilityContext
 ): GoalToolAvailability {
-  if (!context.goalsExperimentEnabled || !context.goalStatus) {
+  if (!context.goalStatus) {
     return { getGoal: false, completeGoal: false };
   }
 

--- a/src/common/utils/tools/tools.ts
+++ b/src/common/utils/tools/tools.ts
@@ -137,7 +137,7 @@ export interface ToolConfiguration {
   taskService?: TaskService;
   /** Workspace goal lifecycle service for model-facing goal tools. */
   goalService?: WorkspaceGoalService;
-  /** Per-request goal tool gates derived from experiment, goal status, and agent capabilities. */
+  /** Per-request goal tool gates derived from goal status and agent capabilities. */
   enableGoalTools?: {
     getGoal: boolean;
     completeGoal: boolean;
@@ -149,7 +149,6 @@ export interface ToolConfiguration {
     programmaticToolCalling?: boolean;
     programmaticToolCallingExclusive?: boolean;
     advisorTool?: boolean;
-    goals?: boolean;
     imageGenerationTool?: boolean;
     execSubagentHardRestart?: boolean;
   };

--- a/src/node/services/agentSession.budgetGate.test.ts
+++ b/src/node/services/agentSession.budgetGate.test.ts
@@ -8,11 +8,11 @@ import type { InitStateManager } from "./initStateManager";
 import { AgentSession } from "./agentSession";
 import { createTestHistoryService } from "./testHistoryService";
 import { WorkspaceGoalService } from "./workspaceGoalService";
-// Shared helper that registers a no-op goal-continuation consumer with
-// `isGoalExperimentEnabled: () => true` so the in-AS pricing gate fires
-// (DEREM-52). Extracted from a duplicate copy in `workspaceGoalService.test.ts`
-// per Coder-agents-review nit DEREM-55.
-import { enableGoalsExperimentForTest } from "./testDispatchHelpers";
+// Registers a no-op goal-continuation consumer so the in-AS pricing gate
+// path runs end-to-end (DEREM-52). Bridge registration alone is now
+// sufficient — goals graduated to GA, so there is no longer an experiment
+// flag to flip.
+import { registerNoopContinuationBridgeForTest } from "./testDispatchHelpers";
 import { Ok } from "@/common/types/result";
 import type { SendMessageOptions } from "@/common/orpc/types";
 import type { GoalRecordV1 } from "@/common/types/goal";
@@ -80,9 +80,9 @@ async function createSessionHarness(workspaceId: string): Promise<SessionHarness
     `${config.rootDir}/agent-session-budget-gate-extension-metadata.json`
   );
   const goalService = new WorkspaceGoalService(config, historyService, extensionMetadata);
-  // Enable the GOALS experiment via the shared helper so the in-AS pricing
-  // gate exercises the live path (DEREM-52 / DEREM-55).
-  enableGoalsExperimentForTest(goalService);
+  // Register a no-op continuation bridge so any continuation-bridge-dependent
+  // codepath has a registered consumer to talk to (DEREM-52).
+  registerNoopContinuationBridgeForTest(goalService);
   const initStateManager = Object.assign(new EventEmitter(), {
     replayInit: mock((_workspaceId: string) => Promise.resolve()),
   }) as unknown as InitStateManager;

--- a/src/node/services/agentSession.goalAutoPause.test.ts
+++ b/src/node/services/agentSession.goalAutoPause.test.ts
@@ -239,7 +239,6 @@ describe("AgentSession goal safety hooks", () => {
       await createSessionHarness(workspaceId);
     cleanups.push(cleanup);
     goalService.registerGoalContinuationConsumer(new IdleDispatcher(), {
-      isGoalExperimentEnabled: () => true,
       hasActiveDescendantTasks: () => false,
       getRuntimeState: () => ({ isRuntimeCompatible: true }),
       executeGoalContinuation: () => Promise.resolve(true),
@@ -355,7 +354,6 @@ describe("AgentSession goal safety hooks", () => {
     const dispatcher = new IdleDispatcher();
     const execute = mock(() => Promise.resolve(true));
     goalService.registerGoalContinuationConsumer(dispatcher, {
-      isGoalExperimentEnabled: () => true,
       hasActiveDescendantTasks: () => false,
       getRuntimeState: () => ({ isRuntimeCompatible: true }),
       executeGoalContinuation: execute,

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -4112,7 +4112,7 @@ export class AgentSession {
     metadataModel?: string;
     isCompaction?: boolean;
   }): Promise<void> {
-    if (this.workspaceGoalService?.isExperimentEnabled() !== true) {
+    if (!this.workspaceGoalService) {
       return;
     }
     const displayUsage = createDisplayUsage(
@@ -4138,7 +4138,7 @@ export class AgentSession {
   }
 
   private async restoreGoalAccountingSnapshot(): Promise<void> {
-    if (this.workspaceGoalService?.isExperimentEnabled() !== true) {
+    if (!this.workspaceGoalService) {
       return;
     }
 
@@ -4162,14 +4162,6 @@ export class AgentSession {
     agentInitiated?: boolean;
   }): Promise<void> {
     if (!this.workspaceGoalService) {
-      return;
-    }
-    // Hot-path gate: when the GOALS experiment is off, skip the goal-record
-    // disk I/O entirely so the off-experiment runtime really is identical to
-    // main (Coder-agents-review P3 DEREM-19). Without this short-circuit,
-    // every stream-end pays a goal.json read (ENOENT for users without
-    // goals) + an extensionMetadata write to push a null goal snapshot.
-    if (!this.workspaceGoalService.isExperimentEnabled()) {
       return;
     }
 

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1160,15 +1160,13 @@ export class AIService extends EventEmitter {
       const advisorToolEligible =
         advisorExperimentEnabled && agentAdvisorEnabled && advisorModelString.length > 0;
 
-      const goalsExperimentEnabled =
-        experiments?.goals ??
-        this.experimentsService?.isExperimentEnabled(EXPERIMENT_IDS.GOALS) === true;
+      // Goals graduated to GA: tools are gated solely on the workspace's
+      // current goal status + agent capability, not on an experiment flag.
       let currentGoalForTools: GoalRecordV1 | null = null;
-      if (goalsExperimentEnabled && workspaceGoalService) {
+      if (workspaceGoalService) {
         currentGoalForTools = await workspaceGoalService.getGoal(workspaceId);
       }
       const goalToolAvailability = getGoalToolAvailability({
-        goalsExperimentEnabled,
         goalStatus: currentGoalForTools?.status ?? null,
         agentInheritanceChain,
       });

--- a/src/node/services/coreServices.ts
+++ b/src/node/services/coreServices.ts
@@ -4,7 +4,6 @@
 
 import * as os from "os";
 import * as path from "path";
-import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import type { Config } from "@/node/config";
 import { HistoryService } from "@/node/services/historyService";
 import { IdleDispatcher } from "@/node/services/idleDispatcher";
@@ -167,8 +166,6 @@ export function createCoreServices(opts: CoreServicesOptions): CoreServices {
   // also exposed so ServiceContainer can share it with HeartbeatService.
   const idleDispatcher = new IdleDispatcher();
   workspaceGoalService.registerGoalContinuationConsumer(idleDispatcher, {
-    isGoalExperimentEnabled: () =>
-      opts.experimentsService?.isExperimentEnabled(EXPERIMENT_IDS.GOALS) ?? false,
     hasActiveDescendantTasks: (workspaceId) =>
       taskService.hasActiveDescendantAgentTasksForWorkspace(workspaceId),
     getRuntimeState: (workspaceId) => workspaceService.getGoalContinuationRuntimeState(workspaceId),

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -6067,7 +6067,6 @@ describe("TaskService", () => {
       extensionMetadata
     );
     workspaceGoalService.registerGoalContinuationConsumer(new IdleDispatcher(), {
-      isGoalExperimentEnabled: () => true,
       hasActiveDescendantTasks: () => false,
       getRuntimeState: () => ({ isRuntimeCompatible: true }),
       executeGoalContinuation: () => Promise.resolve(true),

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -139,7 +139,6 @@ export interface TaskCreateArgs {
     programmaticToolCallingExclusive?: boolean;
     advisorTool?: boolean;
     imageGenerationTool?: boolean;
-    goals?: boolean;
     execSubagentHardRestart?: boolean;
   };
 }
@@ -3821,7 +3820,7 @@ export class TaskService {
       childWorkspaceId.trim().length > 0,
       "attributeChildReportToParentGoal requires childWorkspaceId"
     );
-    if (!this.workspaceGoalService?.isExperimentEnabled()) {
+    if (!this.workspaceGoalService) {
       return;
     }
 

--- a/src/node/services/testDispatchHelpers.ts
+++ b/src/node/services/testDispatchHelpers.ts
@@ -54,21 +54,20 @@ export async function waitForCondition(
 }
 
 /**
- * Flip the GOALS experiment ON for `WorkspaceGoalService` instances created
- * in tests. Many goal-service tests need the experiment-on path because the
- * pricing gate (DEREM-52) and other hot-path predicates short-circuit when
- * the bridge is missing. Registering a no-op continuation consumer with
- * `isGoalExperimentEnabled: () => true` is the canonical way to do that.
+ * Register a no-op continuation consumer on a test `WorkspaceGoalService`
+ * instance so paths that require an active continuation bridge (e.g. the
+ * idle dispatcher / kickoff send-options lookup) can run end-to-end. Used by
+ * goal-service, agent-session, and task-service tests that need to exercise
+ * production-like behavior without standing up the full ServiceContainer.
  *
- * Coder-agents-review nit DEREM-55: previously duplicated byte-for-byte in
- * `workspaceGoalService.test.ts` and `agentSession.budgetGate.test.ts`.
+ * Previously this helper also flipped the (now-removed) GOALS experiment
+ * flag; goals are GA, so the bridge registration alone is sufficient.
  */
-export function enableGoalsExperimentForTest(
+export function registerNoopContinuationBridgeForTest(
   service: WorkspaceGoalService,
   dispatcher: IdleDispatcher = new IdleDispatcher()
 ): () => void {
   return service.registerGoalContinuationConsumer(dispatcher, {
-    isGoalExperimentEnabled: () => true,
     hasActiveDescendantTasks: () => false,
     getRuntimeState: () => ({ isRuntimeCompatible: true }),
     executeGoalContinuation: () => Promise.resolve(true),

--- a/src/node/services/workspaceGoalService.test.ts
+++ b/src/node/services/workspaceGoalService.test.ts
@@ -11,11 +11,7 @@ import type { GoalRecordV1, GoalStatus } from "@/common/types/goal";
 import { GOAL_BUDGET_LIMIT_KIND, GOAL_CONTINUATION_IDLE_CONSUMER_NAME } from "@/constants/goals";
 // Shared dispatch helpers live in `./testDispatchHelpers` instead of local
 // copies so future callers cannot drift.
-import {
-  drainPendingDispatches,
-  enableGoalsExperimentForTest,
-  waitForCondition,
-} from "./testDispatchHelpers";
+import { drainPendingDispatches, waitForCondition } from "./testDispatchHelpers";
 
 function captureGoalActivity(service: WorkspaceGoalService) {
   const snapshots: Array<
@@ -60,7 +56,6 @@ function continuationBridge(
     Promise.resolve(true)
 ): GoalContinuationRuntimeBridge {
   return {
-    isGoalExperimentEnabled: () => true,
     hasActiveDescendantTasks: () => false,
     getRuntimeState: () => ({ isRuntimeCompatible: true }),
     executeGoalContinuation,
@@ -94,6 +89,19 @@ describe("WorkspaceGoalService", () => {
 
   afterEach(async () => {
     await cleanup();
+  });
+
+  test("does not write null activity snapshots for ordinary no-goal reads", async () => {
+    // Goals are GA, so tool availability asks for the current goal on every
+    // turn. No-goal reads must stay read-only; lifecycle paths that actually
+    // clear/corrupt-repair a goal still publish explicit null snapshots.
+    const setGoalSpy = spyOn(extensionMetadata, "setGoal");
+
+    const goal = await service.getGoal(workspaceId);
+
+    expect(goal).toBeNull();
+    expect(setGoalSpy).not.toHaveBeenCalled();
+    setGoalSpy.mockRestore();
   });
 
   test("creates, reads, and clears a goal while updating snapshots", async () => {
@@ -313,7 +321,6 @@ describe("WorkspaceGoalService", () => {
     const dispatcher = new IdleDispatcher();
     const executed: Array<{ message: string; kind: string | undefined }> = [];
     service.registerGoalContinuationConsumer(dispatcher, {
-      isGoalExperimentEnabled: () => true,
       hasActiveDescendantTasks: () => false,
       getRuntimeState: () => ({ isRuntimeCompatible: true }),
       executeGoalContinuation: (input) => {
@@ -334,7 +341,6 @@ describe("WorkspaceGoalService", () => {
     const dispatcher = new IdleDispatcher();
     const executed: Array<{ message: string }> = [];
     service.registerGoalContinuationConsumer(dispatcher, {
-      isGoalExperimentEnabled: () => true,
       hasActiveDescendantTasks: () => false,
       getRuntimeState: () => ({ isRuntimeCompatible: true }),
       executeGoalContinuation: (input) => {
@@ -357,7 +363,6 @@ describe("WorkspaceGoalService", () => {
     const dispatcher = new IdleDispatcher();
     const executed: Array<{ message: string }> = [];
     service.registerGoalContinuationConsumer(dispatcher, {
-      isGoalExperimentEnabled: () => true,
       hasActiveDescendantTasks: () => false,
       getRuntimeState: () => ({ isRuntimeCompatible: true }),
       executeGoalContinuation: (input) => {
@@ -372,37 +377,6 @@ describe("WorkspaceGoalService", () => {
     await setGoalOk(service, { workspaceId, objective: "No kickoff defaults" });
 
     expect(executed).toHaveLength(0);
-  });
-
-  test("requestContinuationAfterStreamEnd is a no-op when the GOALS experiment is disabled", async () => {
-    // Pin the experiment-off short-circuit so a regression that removed or
-    // inverted the gate would be caught. Without the gate, every
-    // non-compaction stream-end pays a `goal.json` ENOENT read +
-    // `extensionMetadata.json` write for users with the experiment off.
-    await setGoalOk(service, { workspaceId, objective: "Should never dispatch" });
-    const dispatcher = new IdleDispatcher();
-    const execute = mock(() => Promise.resolve(true));
-    const getGoalSpy = spyOn(service, "getGoal");
-    service.registerGoalContinuationConsumer(dispatcher, {
-      isGoalExperimentEnabled: () => false,
-      hasActiveDescendantTasks: () => false,
-      getRuntimeState: () => ({ isRuntimeCompatible: true }),
-      executeGoalContinuation: execute,
-    });
-
-    // Reset the spy *after* registration so we can prove the
-    // request-continuation call below does not read goal.json again.
-    getGoalSpy.mockClear();
-
-    await service.requestContinuationAfterStreamEnd({
-      workspaceId,
-      sendOptions: { model: "openai:gpt-4o", agentId: "exec" },
-      streamEndedAtMs: 10_000,
-    });
-
-    expect(getGoalSpy).not.toHaveBeenCalled();
-    expect(execute).not.toHaveBeenCalled();
-    getGoalSpy.mockRestore();
   });
 
   test("falls back to priced kickoff options when stream options are unpriced for budgeted goals", async () => {
@@ -806,7 +780,6 @@ describe("WorkspaceGoalService", () => {
     const dispatcher = new IdleDispatcher();
     const executed: Array<{ kind: string | undefined; message: string }> = [];
     restartedService.registerGoalContinuationConsumer(dispatcher, {
-      isGoalExperimentEnabled: () => true,
       hasActiveDescendantTasks: () => false,
       getRuntimeState: () => ({ isRuntimeCompatible: true }),
       executeGoalContinuation: (input) => {
@@ -907,7 +880,6 @@ describe("WorkspaceGoalService", () => {
     const dispatcher = new IdleDispatcher();
     const execute = mock(() => Promise.resolve(true));
     restartedService.registerGoalContinuationConsumer(dispatcher, {
-      isGoalExperimentEnabled: () => true,
       hasActiveDescendantTasks: () => false,
       getRuntimeState: () => ({ isRuntimeCompatible: true }),
       executeGoalContinuation: execute,
@@ -1902,7 +1874,6 @@ describe("WorkspaceGoalService", () => {
     const dispatcher = new IdleDispatcher();
     const execute = mock(() => Promise.resolve(true));
     service.registerGoalContinuationConsumer(dispatcher, {
-      isGoalExperimentEnabled: () => true,
       hasActiveDescendantTasks: () => hasActiveDescendantTasks,
       getRuntimeState: () => ({ isRuntimeCompatible: true }),
       executeGoalContinuation: execute,
@@ -1941,7 +1912,6 @@ describe("WorkspaceGoalService", () => {
     const dispatcher = new IdleDispatcher();
     const executed: Array<{ kind: string | undefined }> = [];
     service.registerGoalContinuationConsumer(dispatcher, {
-      isGoalExperimentEnabled: () => true,
       hasActiveDescendantTasks: () => false,
       getRuntimeState: () => ({ isRuntimeCompatible: true }),
       executeGoalContinuation: (input) => {
@@ -1982,7 +1952,6 @@ describe("WorkspaceGoalService", () => {
     const dispatcher = new IdleDispatcher();
     const executed: Array<{ kind: string | undefined }> = [];
     service.registerGoalContinuationConsumer(dispatcher, {
-      isGoalExperimentEnabled: () => true,
       hasActiveDescendantTasks: () => false,
       getRuntimeState: () => ({ isRuntimeCompatible: true }),
       executeGoalContinuation: (input) => {
@@ -2681,15 +2650,7 @@ describe("WorkspaceGoalService", () => {
     const UNPRICED = "openai:not-priced-model";
     const PRICED = "openai:gpt-4o-mini";
 
-    // the gate now short-circuits when the
-    // GOALS experiment is off (default in headless tests). Use the shared
-    // `enableGoalsExperimentForTest` helper to register a no-op continuation
-    // consumer with `isGoalExperimentEnabled: () => true` per test so the
-    // gate exercises the live path ().
-    const enableGoalsExperiment = enableGoalsExperimentForTest;
-
     test("rejects unpriced model on a resumable budgeted goal", async () => {
-      enableGoalsExperiment(service);
       await setGoalOk(service, {
         workspaceId,
         objective: "ship",
@@ -2707,7 +2668,6 @@ describe("WorkspaceGoalService", () => {
     });
 
     test("rejects on paused budgeted goals (would resume on un-pause)", async () => {
-      enableGoalsExperiment(service);
       await setGoalOk(service, {
         workspaceId,
         objective: "ship",
@@ -2717,21 +2677,6 @@ describe("WorkspaceGoalService", () => {
 
       const result = await service.assertPricedModelForBudgetedGoal(workspaceId, UNPRICED);
       expect(result.success).toBe(false);
-    });
-
-    test("short-circuits when the GOALS experiment is disabled (no disk read)", async () => {
-      // don't pay `getGoal`'s disk cost on every send/resume for
-      // users who never used the GOALS feature. With no bridge registered,
-      // `isExperimentEnabled` returns false and the gate returns Ok without
-      // consulting goal.json (which would crash because no goal exists in
-      // this test setup with an unpriced model).
-      const getGoalSpy = spyOn(service, "getGoal");
-
-      const result = await service.assertPricedModelForBudgetedGoal(workspaceId, UNPRICED);
-
-      expect(result.success).toBe(true);
-      expect(getGoalSpy).not.toHaveBeenCalled();
-      getGoalSpy.mockRestore();
     });
 
     test("priced models short-circuit before reading goal.json", async () => {

--- a/src/node/services/workspaceGoalService.ts
+++ b/src/node/services/workspaceGoalService.ts
@@ -117,7 +117,6 @@ export interface SetGoalInput {
 export type GoalContinuationSkipReason =
   | "not_registered"
   | "no_pending_candidate"
-  | "experiment_disabled"
   | "workspace_not_found"
   | "archived"
   | "transcript_only"
@@ -148,7 +147,6 @@ export interface GoalContinuationRuntimeState {
 }
 
 export interface GoalContinuationRuntimeBridge {
-  isGoalExperimentEnabled(): boolean;
   hasActiveDescendantTasks(workspaceId: string): boolean;
   getRuntimeState(workspaceId: string): GoalContinuationRuntimeState;
   executeGoalContinuation(input: {
@@ -531,6 +529,13 @@ export class WorkspaceGoalService {
       await this.pushTransientGoalSnapshot(workspaceId, pendingSnapshot);
       return pendingSnapshot;
     }
+    if (!goal) {
+      // Goals are GA, so normal model/tool-availability paths call getGoal()
+      // for every turn. Avoid writing `goal: null` on every no-goal read;
+      // explicit lifecycle operations (clear/corrupt repair/etc.) still push
+      // null snapshots when state actually changes.
+      return null;
+    }
     return this.pushSnapshot(workspaceId, goal);
   }
 
@@ -577,20 +582,6 @@ export class WorkspaceGoalService {
       if (delay > 0) await new Promise((resolve) => setTimeout(resolve, delay));
       if (!(await this.isWorkspaceStreaming(workspaceId))) return;
     }
-  }
-
-  /**
-   * Returns true when the GOALS experiment is enabled at the bridge layer.
-   * Used as a hot-path short-circuit so users with the experiment off do
-   * not pay disk I/O cost (goal.json read + extensionMetadata write) on
-   * every stream-end.
-   *
-   * Returns false when no bridge is registered yet (e.g. headless tests
-   * that never wire continuations); callers should default-deny in that
-   * case to keep the off-experiment runtime cost truly identical to main.
-   */
-  isExperimentEnabled(): boolean {
-    return this.goalContinuationBridge?.isGoalExperimentEnabled() ?? false;
   }
 
   registerGoalContinuationConsumer(
@@ -655,13 +646,6 @@ export class WorkspaceGoalService {
       "requestContinuationAfterStreamEnd requires workspaceId"
     );
     if (this.goalContinuationDispatcher == null) {
-      return;
-    }
-    // Hot-path experiment gate: without this, every non-compaction
-    // stream-end pays the disk cost of `getGoal` even for users with the
-    // GOALS experiment off. The bridge is the source of truth for whether
-    // the experiment is on; default-deny when unset.
-    if (!this.isExperimentEnabled()) {
       return;
     }
 
@@ -841,10 +825,6 @@ export class WorkspaceGoalService {
     const bridge = this.goalContinuationBridge;
     if (!bridge) {
       return { eligible: false, reason: "not_registered" };
-    }
-    if (!bridge.isGoalExperimentEnabled()) {
-      this.pendingContinuationCandidates.delete(workspaceId);
-      return { eligible: false, reason: "experiment_disabled" };
     }
 
     const workspace = this.findWorkspaceConfigEntry(workspaceId);
@@ -1400,15 +1380,6 @@ export class WorkspaceGoalService {
     workspaceId: string,
     model: string | undefined
   ): Promise<Result<void, SendMessageError>> {
-    // Hot-path gate: every sendMessage / resumeStream lands here, so an
-    // experiment-off short-circuit avoids paying `getGoal`'s disk cost on
-    // workspaces that never used the GOALS feature (sibling to /
-    // / — ). Defaults to
-    // false when no bridge is registered (matches the existing
-    // `isExperimentEnabled` contract for headless tests).
-    if (!this.isExperimentEnabled()) {
-      return Ok(undefined);
-    }
     if (!model || modelHasPricingData(model, this.getProvidersConfigForPricing())) {
       return Ok(undefined);
     }
@@ -1576,7 +1547,7 @@ export class WorkspaceGoalService {
   }
 
   private canRunBudgetedGoalOnKickoffModel(workspaceId: string, goal: GoalRecordV1): boolean {
-    if (!this.isExperimentEnabled() || !hasBudgetedResumableGoal(goal)) {
+    if (!hasBudgetedResumableGoal(goal)) {
       return true;
     }
     const model = this.goalContinuationBridge?.getKickoffSendOptions?.(workspaceId)?.model;
@@ -2052,7 +2023,6 @@ export class WorkspaceGoalService {
       const current = await this.readGoalFile(input.workspaceId);
       if (!current) {
         this.recordLastGoalStream(input.workspaceId, originKind, null);
-        await this.pushSnapshot(input.workspaceId, null);
         return null;
       }
 
@@ -2112,7 +2082,6 @@ export class WorkspaceGoalService {
     return this.fileLocks.withLock(input.parentWorkspaceId, async () => {
       const current = await this.readGoalFile(input.parentWorkspaceId);
       if (!current) {
-        await this.pushSnapshot(input.parentWorkspaceId, null);
         return null;
       }
 

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -3582,7 +3582,6 @@ describe("WorkspaceService maybePersistAISettingsFromOptions", () => {
 
   test("refuses unpriced model persistence for budgeted active goals", async () => {
     workspaceService.setWorkspaceGoalService({
-      isExperimentEnabled: mock(() => true),
       getGoal: mock(() => Promise.resolve({ status: "active", budgetCents: 500 })),
     } as unknown as WorkspaceGoalService);
 
@@ -3597,11 +3596,11 @@ describe("WorkspaceService maybePersistAISettingsFromOptions", () => {
     });
   });
 
-  test("allows unpriced model persistence when goals experiment is disabled", async () => {
+  test("allows unpriced model persistence when no budgeted goal is active", async () => {
     const persistSpy = mock(() => Promise.resolve({ success: true as const, data: true }));
     workspaceService.setWorkspaceGoalService({
-      isExperimentEnabled: mock(() => false),
-      getGoal: mock(() => Promise.resolve({ status: "active", budgetCents: 500 })),
+      // No goal record (or one without a budget) — the gate must pass through.
+      getGoal: mock(() => Promise.resolve(null)),
     } as unknown as WorkspaceGoalService);
     (
       workspaceService as unknown as {
@@ -7990,7 +7989,6 @@ describe("WorkspaceService.getGoalContinuationRuntimeState", () => {
       const dispatcher = new IdleDispatcher();
       const execute = mock(() => Promise.resolve(true));
       goalService.registerGoalContinuationConsumer(dispatcher, {
-        isGoalExperimentEnabled: () => true,
         hasActiveDescendantTasks: () => false,
         getRuntimeState: (id) => service.getGoalContinuationRuntimeState(id),
         executeGoalContinuation: execute,

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -5214,7 +5214,7 @@ export class WorkspaceService extends EventEmitter {
         return Err(normalized.error);
       }
 
-      if (this.workspaceGoalService?.isExperimentEnabled() === true) {
+      if (this.workspaceGoalService) {
         const goal = await this.workspaceGoalService.getGoal(workspaceId);
         // Use the resumable check rather than active-only: a paused or
         // budget-limited budgeted goal will resume accounting when the user

--- a/tests/ui/chat/goalSlashCommand.test.ts
+++ b/tests/ui/chat/goalSlashCommand.test.ts
@@ -9,7 +9,6 @@ import { fireEvent, waitFor } from "@testing-library/react";
 
 import { preloadTestModules } from "../../ipc/setup";
 import { createAppHarness } from "../harness";
-import { EXPERIMENT_IDS, getExperimentKey } from "@/common/constants/experiments";
 
 describe("Goal slash command", () => {
   beforeAll(async () => {
@@ -19,9 +18,6 @@ describe("Goal slash command", () => {
   test("sets a new goal from a completed goal when Enter follows a stale /goal suggestion", async () => {
     const app = await createAppHarness({
       branchPrefix: "goal-slash",
-      beforeRender: () => {
-        localStorage.setItem(getExperimentKey(EXPERIMENT_IDS.GOALS), JSON.stringify(true));
-      },
     });
 
     try {

--- a/tests/ui/layout/rightSidebar.test.ts
+++ b/tests/ui/layout/rightSidebar.test.ts
@@ -133,7 +133,6 @@ describeIntegration("RightSidebar (UI)", () => {
     updatePersistedState(RIGHT_SIDEBAR_TAB_KEY, null);
     updatePersistedState(RIGHT_SIDEBAR_COLLAPSED_KEY, null);
     updatePersistedState(getExperimentKey(EXPERIMENT_IDS.AGENT_BROWSER), null);
-    updatePersistedState(getExperimentKey(EXPERIMENT_IDS.GOALS), null);
     updatePersistedState(RIGHT_SIDEBAR_WIDTH_KEY, null);
     updatePersistedState(getRightSidebarLayoutKey(workspaceId), null);
     updatePersistedState(getTerminalTitlesKey(workspaceId), null);
@@ -233,48 +232,9 @@ describeIntegration("RightSidebar (UI)", () => {
     }
   }, 60_000);
 
-  test("does not show the goal tab when the GOALS experiment is disabled", async () => {
+  test("always shows the goal tab on top-level workspaces (even without an active goal)", async () => {
     const cleanupDom = installDom();
 
-    updatePersistedState(getExperimentKey(EXPERIMENT_IDS.GOALS), null);
-    updatePersistedState(RIGHT_SIDEBAR_TAB_KEY, null);
-    updatePersistedState(getRightSidebarLayoutKey(workspaceId), null);
-
-    const view = renderApp({
-      apiClient: env.orpc,
-      metadata,
-    });
-
-    try {
-      await setupWorkspaceView(view, metadata, workspaceId);
-
-      const sidebar = await waitFor(
-        () => {
-          const el = view.container.querySelector(
-            '[role="complementary"][aria-label="Workspace insights"]'
-          );
-          if (!el) throw new Error("RightSidebar not found");
-          return el as HTMLElement;
-        },
-        { timeout: 10_000 }
-      );
-
-      // Wait long enough for layout effects to flush, then assert the
-      // goal tab stays hidden — the experiment is what gates visibility,
-      // not the presence of a workspace goal.
-      await waitFor(() => {
-        const goalTab = sidebar.querySelector('[role="tab"][aria-controls*="goal"]');
-        expect(goalTab).toBeNull();
-      });
-    } finally {
-      await cleanupView(view, cleanupDom);
-    }
-  }, 60_000);
-
-  test("always shows the goal tab when the GOALS experiment is enabled (even without an active goal)", async () => {
-    const cleanupDom = installDom();
-
-    updatePersistedState(getExperimentKey(EXPERIMENT_IDS.GOALS), true);
     updatePersistedState(RIGHT_SIDEBAR_TAB_KEY, null);
     updatePersistedState(getRightSidebarLayoutKey(workspaceId), null);
 
@@ -299,19 +259,18 @@ describeIntegration("RightSidebar (UI)", () => {
 
       // Regression guard: the tab used to be gated on `goal != null ||
       // goalHistory.length > 0`, so a brand-new workspace (no goal, no
-      // history) hid the tab entirely. The current contract is "always
-      // visible when the experiment is on" so the tab can surface the
+      // history) hid the tab entirely. Now that goals are GA the tab is
+      // always visible on top-level workspaces so it can surface the
       // in-tab create form for new workspaces.
       await waitFor(() => {
         const goalTab = sidebar.querySelector(
           '[role="tab"][aria-controls*="goal"]'
         ) as HTMLElement | null;
         if (!goalTab) {
-          throw new Error("Goal tab should be present when the experiment is enabled");
+          throw new Error("Goal tab should always be present on top-level workspaces");
         }
       });
     } finally {
-      updatePersistedState(getExperimentKey(EXPERIMENT_IDS.GOALS), null);
       await cleanupView(view, cleanupDom);
     }
   }, 60_000);


### PR DESCRIPTION
## Summary

Releases Goals from the experiment system into GA. Goals are now always available: the experiment registry entry, settings toggle, slash-command gate, send-option plumbing, backend continuation gates, and model-facing tool experiment checks are removed.

## Implementation

- Removed `EXPERIMENT_IDS.GOALS`, `experiments.goals`, and the corresponding ORPC / persisted-workspace schemas.
- Made `/goal` available regardless of experiment state and removed the command-handler experiment checks.
- Auto-add the Goal tab for top-level workspaces while preserving the child-workspace hide behavior (backend goal writes still require parent workspaces).
- Kept goal command-palette actions hidden for child task workspaces for the same parent-only backend constraint.
- Kept goal tools gated by actual goal state and agent capability only.
- Kept ordinary no-goal reads read-only so GA tool-availability checks do not write null activity snapshots every turn.
- Updated tests and layout expectations for GA behavior, including stale persisted send options with the old `goals` experiment key being stripped by schema parsing.

## Validation

- `bun test src/browser/utils/slashCommands/suggestions.test.ts src/browser/utils/slashCommands/ghostHint.test.ts src/browser/utils/chatCommands.test.ts tests/ui/chat/goalSlashCommand.test.ts`
- `bun test src/common/utils/tools/toolAvailability.test.ts`
- `bun test src/node/services/workspaceGoalService.test.ts`
- `bun test src/node/services/agentSession.budgetGate.test.ts src/node/services/agentSession.goalAutoPause.test.ts`
- `bun test src/node/services/workspaceService.test.ts src/node/services/taskService.test.ts`
- `bun test src/browser/contexts/WorkspaceContext.test.tsx tests/ui/layout/rightSidebar.test.ts`
- `bun test src/browser/utils/commands/sources.test.ts`
- `bun test ./tests/ipc/runtime/runtimeExecuteBash.test.ts ./tests/ipc/runtime/runtimeFileEditing.test.ts`
- `bun test ./tests/ipc/streaming/sendMessage.basic.test.ts ./tests/ipc/streaming/sendMessage.errors.test.ts ./tests/ipc/streaming/sendMessage.reasoning.test.ts`
- `make static-check`

## Risks

Moderate risk because the change removes feature gates across UI, send-option schemas, and backend goal accounting paths. The remaining gating should now be product/business logic only: child workspaces cannot show Goal UI/actions, goal tools require an active/budget-limited goal, and completion still requires an editing-capable agent.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$1.65`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=1.65 -->
