### PR TITLE
🤖 fix: harden /btw side-question retry state

### DIFF
--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -35,6 +35,7 @@ import { computeTaskReportLinking } from "@/browser/utils/messages/taskReportLin
 import { BashOutputCollapsedIndicator } from "@/browser/features/Tools/BashOutputCollapsedIndicator";
 import {
   getInterruptionContext,
+  getLastMainRetryCandidateMessage,
   getLastNonDecorativeMessage,
 } from "@/common/utils/messages/retryEligibility";
 import { TooltipIfPresent } from "@/browser/components/Tooltip/Tooltip";
@@ -818,10 +819,10 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
     workspaceState.autoRetryStatus?.type === "auto-retry-scheduled" ||
     workspaceState.autoRetryStatus?.type === "auto-retry-starting";
 
-  const lastActionableMessage = getLastNonDecorativeMessage(workspaceState.messages);
+  const lastRetryCandidateMessage = getLastMainRetryCandidateMessage(workspaceState.messages);
   const suppressRetryBarrier =
-    lastActionableMessage?.type === "stream-error" &&
-    lastActionableMessage.errorType === "context_exceeded";
+    lastRetryCandidateMessage?.type === "stream-error" &&
+    lastRetryCandidateMessage.errorType === "context_exceeded";
   const shouldMountRetryBarrier = !suppressRetryBarrier;
   const showRetryBarrierUI = showRetryBarrier && !suppressRetryBarrier;
 

--- a/src/browser/features/Messages/ChatBarrier/RetryBarrier.tsx
+++ b/src/browser/features/Messages/ChatBarrier/RetryBarrier.tsx
@@ -3,7 +3,7 @@ import { AlertTriangle, RefreshCw } from "lucide-react";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
 import { useAPI } from "@/browser/contexts/API";
 import { useWorkspaceState } from "@/browser/stores/WorkspaceStore";
-import { getLastNonDecorativeMessage } from "@/common/utils/messages/retryEligibility";
+import { getLastMainRetryCandidateMessage } from "@/common/utils/messages/retryEligibility";
 import { KEYBINDS, formatKeybind } from "@/browser/utils/ui/keybinds";
 import { VIM_ENABLED_KEY } from "@/common/constants/storage";
 import { getSendOptionsFromStorage } from "@/browser/utils/messages/sendOptions";
@@ -239,7 +239,7 @@ export const RetryBarrier: React.FC<RetryBarrierProps> = (props) => {
     void api?.workspace.setAutoRetryEnabled?.({ workspaceId: props.workspaceId, enabled: false });
   };
 
-  const lastMessage = getLastNonDecorativeMessage(workspaceState.messages);
+  const lastMessage = getLastMainRetryCandidateMessage(workspaceState.messages);
   const lastStreamError = lastMessage?.type === "stream-error" ? lastMessage : null;
   const interruptionReason = lastStreamError?.errorType === "rate_limit" ? "Rate limited" : null;
   const isWaitingForInitialResponse =

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -3977,14 +3977,6 @@ export class WorkspaceStore {
     aggregator: StreamingMessageAggregator,
     data: WorkspaceChatMessage
   ): void {
-    this.dispatchProcessStreamEvent(workspaceId, aggregator, data);
-  }
-
-  private dispatchProcessStreamEvent(
-    workspaceId: string,
-    aggregator: StreamingMessageAggregator,
-    data: WorkspaceChatMessage
-  ): void {
     // Handle special events first
     if (isStreamError(data)) {
       const transient = this.assertChatTransientState(workspaceId);

--- a/src/browser/utils/chatCommands.ts
+++ b/src/browser/utils/chatCommands.ts
@@ -77,6 +77,7 @@ import { trackCommandUsed } from "@/common/telemetry";
 import { addEphemeralMessage } from "@/browser/stores/WorkspaceStore";
 import { setGoalWithConflictRetry } from "@/browser/utils/goals/setGoalWithConflictRetry";
 import { loadGoalDefaults, resolveGoalSetIntent } from "@/browser/utils/goals/resolveGoalSetIntent";
+import { SIDE_QUESTION_COMMAND } from "@/common/utils/messages/sideQuestion";
 
 const BUILT_IN_MODEL_SET = new Set<string>(Object.values(KNOWN_MODELS).map((model) => model.id));
 
@@ -591,7 +592,7 @@ export async function processSlashCommand(
           return { clearInput: false, toastShown: true };
         }
         const workspaceId = context.workspaceId;
-        const rawCommand = `/btw ${parsed.question}`;
+        const rawCommand = `${SIDE_QUESTION_COMMAND} ${parsed.question}`;
         const asyncCommandToken = context.asyncCommandToken;
         const isCurrentSideQuestion = (): boolean =>
           asyncCommandToken === undefined ||

--- a/src/common/utils/messages/retryEligibility.test.ts
+++ b/src/common/utils/messages/retryEligibility.test.ts
@@ -202,6 +202,95 @@ describe("hasInterruptedStream", () => {
     expect(hasInterruptedStream(messages, null)).toBe(true);
   });
 
+  it("returns false for a trailing /btw side-question user row", () => {
+    const messages: DisplayedMessage[] = [
+      userMessage(),
+      assistantMessage(),
+      userMessage({
+        id: "side-question-1",
+        historyId: "side-question-1",
+        content: "what file were you editing?",
+        historySequence: 3,
+        isSideQuestion: true,
+      }),
+    ];
+
+    expect(hasInterruptedStream(messages, null)).toBe(false);
+    expect(isEligibleForAutoRetry(messages, null)).toBe(false);
+  });
+
+  it("returns false for a trailing partial /btw side-answer row", () => {
+    const messages: DisplayedMessage[] = [
+      userMessage({
+        id: "side-question-1",
+        historyId: "side-question-1",
+        content: "what file were you editing?",
+        historySequence: 1,
+        isSideQuestion: true,
+      }),
+      assistantMessage({
+        id: "side-answer-1-0",
+        historyId: "side-answer-1",
+        content: "src/config.ts",
+        historySequence: 2,
+        isPartial: true,
+        isStreaming: true,
+        isSideAnswer: true,
+      }),
+    ];
+
+    expect(hasInterruptedStream(messages, null)).toBe(false);
+    expect(isEligibleForAutoRetry(messages, null)).toBe(false);
+  });
+
+  it("ignores trailing /btw rows and still detects an earlier interrupted main response", () => {
+    const messages: DisplayedMessage[] = [
+      userMessage(),
+      assistantMessage({
+        id: "assistant-main-1",
+        historyId: "assistant-main-1",
+        content: "Partial main response",
+        historySequence: 2,
+        isPartial: true,
+        isStreaming: false,
+      }),
+      userMessage({
+        id: "side-question-1",
+        historyId: "side-question-1",
+        content: "what file were you editing?",
+        historySequence: 3,
+        isSideQuestion: true,
+      }),
+      assistantMessage({
+        id: "side-answer-1-0",
+        historyId: "side-answer-1",
+        content: "src/config.ts",
+        historySequence: 4,
+        isSideAnswer: true,
+      }),
+    ];
+
+    expect(hasInterruptedStream(messages, null)).toBe(true);
+    expect(isEligibleForAutoRetry(messages, null)).toBe(true);
+  });
+
+  it("preserves stream-error retry classification before trailing /btw rows", () => {
+    const messages: DisplayedMessage[] = [
+      userMessage(),
+      streamErrorMessage({ errorType: "context_exceeded" }),
+      userMessage({
+        id: "side-question-1",
+        historyId: "side-question-1",
+        content: "what file were you editing?",
+        historySequence: 3,
+        isSideQuestion: true,
+      }),
+    ];
+
+    expect(hasInterruptedStream(messages, null)).toBe(true);
+    expect(isEligibleForAutoRetry(messages, null)).toBe(false);
+  });
+
   it("suppresses retry while runtime startup is still in progress", () => {
     const messages: DisplayedMessage[] = [userMessage()];
 

--- a/src/common/utils/messages/retryEligibility.ts
+++ b/src/common/utils/messages/retryEligibility.ts
@@ -103,6 +103,13 @@ function isDecorativeTranscriptMessage(message: DisplayedMessage): boolean {
   );
 }
 
+function isSideQuestionTranscriptMessage(message: DisplayedMessage): boolean {
+  return (
+    (message.type === "user" && message.isSideQuestion === true) ||
+    (message.type === "assistant" && message.isSideAnswer === true)
+  );
+}
+
 export function getLastNonDecorativeMessage(
   messages: DisplayedMessage[]
 ): DisplayedMessage | undefined {
@@ -111,6 +118,24 @@ export function getLastNonDecorativeMessage(
     if (!isDecorativeTranscriptMessage(candidate)) {
       return candidate;
     }
+  }
+  return undefined;
+}
+
+/**
+ * Latest transcript row that belongs to the main-agent retry lifecycle.
+ * Decorative rows and /btw side-branch rows are persisted in the transcript but
+ * must not become the retry candidate for the main agent.
+ */
+export function getLastMainRetryCandidateMessage(
+  messages: DisplayedMessage[]
+): DisplayedMessage | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const candidate = messages[i];
+    if (isDecorativeTranscriptMessage(candidate) || isSideQuestionTranscriptMessage(candidate)) {
+      continue;
+    }
+    return candidate;
   }
   return undefined;
 }
@@ -145,7 +170,12 @@ function computeHasInterruptedStream(
     if (elapsed < PENDING_STREAM_START_GRACE_PERIOD_MS) return false;
   }
 
-  const lastMessage = getLastNonDecorativeMessage(messages);
+  // /btw rows are persisted into the transcript, but they are a read-only side
+  // branch that intentionally bypasses the main agent stream lifecycle. Ignore
+  // them when deciding whether the main agent has an interrupted stream: an idle
+  // /btw should not flash RetryBarrier, but a partial main-agent response before
+  // the aside must still be retryable after a reload/crash.
+  const lastMessage = getLastMainRetryCandidateMessage(messages);
   if (!lastMessage) return false;
 
   // Don't show retry barrier if workspace init is still running AND no error has occurred yet.
@@ -224,7 +254,7 @@ export function getInterruptionContext(
     return { hasInterruptedStream: false, isEligibleForAutoRetry: false };
   }
 
-  const lastMessage = getLastNonDecorativeMessage(messages);
+  const lastMessage = getLastMainRetryCandidateMessage(messages);
   if (!lastMessage) {
     return { hasInterruptedStream: false, isEligibleForAutoRetry: false };
   }

--- a/src/common/utils/messages/sideQuestion.ts
+++ b/src/common/utils/messages/sideQuestion.ts
@@ -3,6 +3,15 @@ import type { MuxMessage, MuxMetadata } from "@/common/types/message";
 export const SIDE_QUESTION_METADATA_TYPE = "side-question";
 export const SIDE_QUESTION_ANSWER_METADATA_TYPE = "side-question-answer";
 
+/**
+ * The user-facing slash-command literal that triggers a side question. Kept in
+ * one place so the backend (persisting the rendered user row) and the frontend
+ * (parsing input and restoring drafts on RPC failure) cannot drift apart.
+ *
+ * NOTE: includes no trailing space — render as `${SIDE_QUESTION_COMMAND} <q>`.
+ */
+export const SIDE_QUESTION_COMMAND = "/btw";
+
 type SideQuestionMetadata = Extract<
   NonNullable<MuxMetadata["muxMetadata"]>,
   { type: typeof SIDE_QUESTION_METADATA_TYPE }

--- a/src/node/services/sideQuestionService.test.ts
+++ b/src/node/services/sideQuestionService.test.ts
@@ -1,10 +1,14 @@
 import * as aiSdk from "ai";
 import { type LanguageModel } from "ai";
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
-import { askSideQuestion, buildSideQuestionMessages } from "./sideQuestionService";
+import {
+  askSideQuestion,
+  buildSideQuestionMessages,
+  type SideQuestionAIService,
+} from "./sideQuestionService";
 import type { AIService } from "./aiService";
 import { Err, Ok } from "@/common/types/result";
-import { createMuxMessage } from "@/common/types/message";
+import { createMuxMessage, type MuxMessage } from "@/common/types/message";
 import type { WorkspaceChatMessage } from "@/common/orpc/types";
 import { CONTEXT_BOUNDARY_KINDS } from "@/common/utils/messages/compactionBoundary";
 import { createTestHistoryService } from "./testHistoryService";
@@ -34,11 +38,11 @@ function createFakeModel(modelId = "side-question-model"): LanguageModel {
 function createFakeAIService(
   model: LanguageModel,
   streamInfo?: ReturnType<AIService["getStreamInfo"]>
-): AIService {
+): SideQuestionAIService {
   return {
     createModel: () => Promise.resolve(Ok(model)),
     getStreamInfo: () => streamInfo,
-  } as unknown as AIService;
+  };
 }
 
 /** Fake textStream that emits a fixed sequence of chunks. */
@@ -65,14 +69,16 @@ describe("buildSideQuestionMessages", () => {
       "User: change the config\nAssistant: edited src/config.ts"
     );
 
-    expect(system).toContain("No tools are available");
-    expect(system).toContain("clearly-marked side answer");
+    // We deliberately do NOT assert the prompt's wording here — that would be
+    // a tautology against the literal in `buildSideQuestionMessages`. The
+    // tools-denied contract is exercised behaviorally below (the streamText
+    // call asserts `receivedTools === undefined`). What matters structurally
+    // is: exactly one user message, the question shows through, and the
+    // transcript we passed in is present so the model can ground on it.
+    expect(typeof system).toBe("string");
     expect(messages).toHaveLength(1);
     const content = messages[0]?.content as string;
-    expect(content).toContain("<system-reminder>");
-    expect(content).toContain("/btw");
-    expect(content).toContain("No tools are available");
-    expect(content).toContain("Side question: what file did you just edit?");
+    expect(content).toContain("what file did you just edit?");
     expect(content).toContain("Assistant: edited src/config.ts");
   });
 
@@ -263,6 +269,50 @@ describe("askSideQuestion (persisted, streaming)", () => {
       expect(capturedPrompt).toContain("regular answer");
       expect(capturedPrompt).not.toContain("old side q");
       expect(capturedPrompt).not.toContain("old side a");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("keeps legacy tool-* parts visible and skips malformed parts in the transcript", async () => {
+    const { historyService, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "ws-btw-legacy-tool-part";
+      await historyService.appendToHistory(
+        workspaceId,
+        createMuxMessage("u1", "user", "run tests")
+      );
+      const legacyAssistant = {
+        id: "a-legacy-tool",
+        role: "assistant" as const,
+        metadata: { timestamp: 1 },
+        parts: [null, { type: 42 }, { type: "tool-bash" as const }],
+      };
+      // Older or hand-edited chat.jsonl rows can still contain AI SDK
+      // `tool-<name>` parts (or malformed junk) even though current
+      // `MuxMessage` types only model `dynamic-tool`. Preserve that legacy
+      // shape here so /btw transcript generation stays upgrade-safe and
+      // self-healing.
+      await historyService.appendToHistory(workspaceId, legacyAssistant as unknown as MuxMessage);
+
+      let capturedPrompt: string | undefined;
+      spyOn(aiSdk, "streamText").mockImplementation(((opts: unknown) => {
+        const messages = (opts as { messages: Array<{ content: string }> }).messages;
+        capturedPrompt = messages[0]?.content;
+        return fakeTextStream(["ok"]);
+      }) as unknown as typeof aiSdk.streamText);
+
+      const result = await askSideQuestion({
+        workspaceId,
+        question: "what command just ran?",
+        candidates: ["openai:gpt-4.1-mini"],
+        aiService: createFakeAIService(createFakeModel()),
+        historyService,
+        emitChatEvent: () => undefined,
+      });
+
+      expect(result.success).toBe(true);
+      expect(capturedPrompt).toContain("[tool bash]");
     } finally {
       await cleanup();
     }

--- a/src/node/services/sideQuestionService.ts
+++ b/src/node/services/sideQuestionService.ts
@@ -39,6 +39,7 @@ import { createMuxMessage, type MuxMessage } from "@/common/types/message";
 import { sliceMessagesForProviderFromLatestContextBoundary } from "@/common/utils/messages/compactionBoundary";
 import {
   SIDE_QUESTION_ANSWER_METADATA_TYPE,
+  SIDE_QUESTION_COMMAND,
   SIDE_QUESTION_METADATA_TYPE,
   filterSideQuestionMessages,
 } from "@/common/utils/messages/sideQuestion";
@@ -52,12 +53,27 @@ const SIDE_QUESTION_MAX_TRAILING_MESSAGES = 200;
 const SIDE_QUESTION_MAX_MESSAGE_CHARS = 8_000;
 /** Overall character budget for the transcript (defensive against runaway). */
 const SIDE_QUESTION_MAX_TRANSCRIPT_CHARS = 120_000;
+/**
+ * Lower bound on the number of model-creation attempts. Even when the
+ * workspace-preferred candidates fail or look stale, we walk far enough to
+ * exercise at least one entry from `NAME_GEN_PREFERRED_MODELS` so /btw stays
+ * usable. Three matches the historical behavior before this was named.
+ */
+const SIDE_QUESTION_MIN_FALLBACK_ATTEMPTS = 3;
+
+/**
+ * Narrow surface of `AIService` consumed by /btw. The full `AIService` includes
+ * the entire streaming/billing pipeline; /btw only needs to mint a model and
+ * peek at the live-stream registry. Stating the dependency precisely keeps
+ * `askSideQuestion` testable without an `as unknown as AIService` cast.
+ */
+export type SideQuestionAIService = Pick<AIService, "createModel" | "getStreamInfo">;
 
 export interface AskSideQuestionOptions {
   workspaceId: string;
   question: string;
   candidates: readonly string[];
-  aiService: AIService;
+  aiService: SideQuestionAIService;
   historyService: HistoryService;
   /** Optional pre-await snapshot captured by callers that must avoid async race windows. */
   liveStreamSnapshot?: ReturnType<AIService["getStreamInfo"]>;
@@ -202,7 +218,7 @@ export async function askSideQuestion(
   //    up in the chat immediately. Even if the model call fails, the user
   //    can see what they asked.
   // ---------------------------------------------------------------------
-  const rawCommand = `/btw ${trimmedQuestion}`;
+  const rawCommand = `${SIDE_QUESTION_COMMAND} ${trimmedQuestion}`;
   const userMessage: MuxMessage = createMuxMessage(createUserMessageId(), "user", trimmedQuestion, {
     timestamp: Date.now(),
     muxMetadata: {
@@ -210,7 +226,7 @@ export async function askSideQuestion(
       rawCommand,
       // `commandPrefix` is rendered as a small badge before the message
       // body — reuses the existing `/compact` / `/{skillName}` mechanism.
-      commandPrefix: "/btw",
+      commandPrefix: SIDE_QUESTION_COMMAND,
       // Spread the interruption snapshot only when a main-agent stream
       // was actually in flight — otherwise leave the fields off so the
       // renderer treats this as a "normal" side branch at the end of the
@@ -245,7 +261,10 @@ export async function askSideQuestion(
   // live/chat/agent model IDs sit ahead of the fallback list.
   const maxAttempts = Math.min(
     candidates.length,
-    Math.max(3, firstFallbackCandidateIndex >= 0 ? firstFallbackCandidateIndex + 1 : 0)
+    Math.max(
+      SIDE_QUESTION_MIN_FALLBACK_ATTEMPTS,
+      firstFallbackCandidateIndex >= 0 ? firstFallbackCandidateIndex + 1 : 0
+    )
   );
   let lastError: NameGenerationError | null = null;
 
@@ -312,10 +331,12 @@ export async function askSideQuestion(
     // stream-start fires. Without this, the aggregator's handleStreamStart
     // would create a fresh assistant message from the stream-start event
     // payload (which doesn't carry muxMetadata) and the marker that drives
-    // side-answer styling plus WorkspaceStore's main-agent buffering layer
-    // would be lost for the entire streaming window. On reconnect/replay
-    // the placeholder is re-emitted from chat.jsonl, so the marker survives
-    // there too.
+    // side-answer styling plus the aggregator's side-answer-aware lifecycle
+    // guards (skipping main-agent model switch, onResponseComplete, queued
+    // follow-up handling, and the WorkspaceStore stream-end pinned-todo
+    // collapse) would be lost for the entire streaming window. On
+    // reconnect/replay the placeholder is re-emitted from chat.jsonl, so
+    // the marker survives there too.
     emitChatEvent(workspaceId, { ...placeholderAssistant, type: "message" });
 
     // -------------------------------------------------------------------
@@ -494,10 +515,10 @@ export async function askSideQuestion(
  * before the next candidate is tried.
  *
  * Closes the stream with an empty `stream-end` first so side-question
- * terminal-event bookkeeping (including WorkspaceStore's buffered main-agent
- * replay) unwinds while the placeholder still carries side-answer metadata.
- * Then removes the placeholder from chat.jsonl and emits a `delete` chat
- * event so the live aggregator drops any partial failed text.
+ * terminal-event bookkeeping (including the aggregator/store side-answer
+ * terminal guards) unwinds while the placeholder still carries side-answer
+ * metadata. Then removes the placeholder from chat.jsonl and emits a `delete`
+ * chat event so the live aggregator drops any partial failed text.
  *
  * History deletion is best-effort: if the disk write fails we still emit
  * stream-end + delete so the live UI matches user expectations (the failed
@@ -522,11 +543,16 @@ async function deleteSideQuestionPlaceholder(opts: {
   } = opts;
 
   // Close the stream slot while the side-answer placeholder still exists.
-  // WorkspaceStore uses the placeholder's muxMetadata to recognize this as
-  // the side-question terminal event and drain any main-agent deltas that
-  // were buffered while the side answer was streaming. Deleting first would
-  // make the terminal event look like an unknown message and freeze the main
-  // transcript until reload.
+  // The aggregator and WorkspaceStore look up this message by id to check
+  // its muxMetadata before dispatching their side-answer-aware branches
+  // (e.g. WorkspaceStore.bufferedEventHandlers["stream-end"] skips
+  // collapsePinnedTodoOnStreamStop iff the terminal stream belongs to a
+  // side answer; the aggregator's handleStreamEnd skips main-agent
+  // onResponseComplete / lastCompletedStreamStats updates). Deleting the
+  // placeholder first would make those lookups fail, and the terminal
+  // event would fall through to the main-agent code paths — clobbering
+  // pinned-todo state and producing stale completion stats for a stream
+  // that should be invisible to main-agent lifecycle.
   emitChatEvent(workspaceId, {
     type: "stream-end",
     workspaceId,
@@ -629,12 +655,28 @@ async function buildSideQuestionTranscript(
 
 function extractMessageText(message: MuxMessage): string {
   return (message.parts ?? [])
-    .filter((part): part is { type: "text"; text: string } => part.type === "text")
+    .filter(
+      (part): part is { type: "text"; text: string } =>
+        typeof part === "object" &&
+        part !== null &&
+        "type" in part &&
+        part.type === "text" &&
+        "text" in part &&
+        typeof part.text === "string"
+    )
     .map((part) => part.text.trim())
     .filter((text) => text.length > 0)
     .join("\n");
 }
 
+/**
+ * Extract a short `[tool foo]` tag for inclusion in the /btw transcript.
+ * Returns null for non-tool parts (text/reasoning/file are handled by
+ * `extractMessageText`). This accepts `unknown` deliberately: history loading
+ * JSON-parses persisted rows and casts them to `MuxMessage`, so older or
+ * malformed chat.jsonl parts can still reach transcript construction. Skip
+ * unrecognized shapes instead of letting one bad part break /btw.
+ */
 function summarizeToolPart(part: unknown): string | null {
   if (typeof part !== "object" || part === null) return null;
   const record = part as { type?: unknown; toolName?: unknown };
@@ -644,7 +686,7 @@ function summarizeToolPart(part: unknown): string | null {
     typeof record.toolName === "string"
       ? record.toolName
       : type.startsWith("tool-")
-        ? type.slice(5)
+        ? type.slice("tool-".length)
         : null;
   return toolName ? `[tool ${toolName}]` : null;
 }


### PR DESCRIPTION
## Summary

Small follow-up on the `/btw` side-question feature merged in #3293. This keeps the implementation easier to maintain and fixes an idle-chat UI flash where sending `/btw` could momentarily show the main-agent `Stream interrupted` retry banner.

## Background

#3293 landed `/btw` across the backend side-question service, frontend streaming aggregator, transcript rendering, and tests. A focused post-merge cleanup found a few low-risk maintainability wins. While validating the idle `/btw` path, we also found that retry eligibility treated a trailing `/btw` user row like a normal main-agent send with no response yet, which briefly mounted `RetryBarrier` before the side-answer placeholder arrived.

## Implementation

- Inline the dead `WorkspaceStore.processStreamEvent` → `dispatchProcessStreamEvent` wrapper.
- Drop tautological prompt-copy assertions in `sideQuestionService.test.ts`; keep behavioral assertions and rely on the `streamText` test for the tools-denied contract.
- Name `SIDE_QUESTION_MIN_FALLBACK_ATTEMPTS` instead of a bare `3` in the candidate-attempt loop.
- Narrow `/btw`'s AI dependency to `SideQuestionAIService = Pick<AIService, "createModel" | "getStreamInfo">`, removing the test fake's `as unknown as AIService` cast.
- Centralize the `"/btw"` literal as `SIDE_QUESTION_COMMAND` for frontend draft restoration and backend persisted command metadata.
- Realign stale lifecycle comments in `sideQuestionService.ts` with the actual side-answer-aware aggregator/store lookups.
- Keep `/btw` transcript extraction tolerant of persisted history: malformed parts are skipped, current `dynamic-tool` parts are summarized, and legacy AI SDK `tool-<name>` rows from older `chat.jsonl` histories are preserved as `[tool name]` context.
- Add `getLastMainRetryCandidateMessage()` so retry eligibility, `ChatPane` suppression, and `RetryBarrier` copy all skip `/btw` rows consistently while still evaluating any earlier main-agent interruption or stream error.

## Validation

- `make static-check`
- `bun test src/node/services/sideQuestionService.test.ts`
- `bun test src/common/utils/messages/retryEligibility.test.ts`
- `bun test src/browser/features/Messages/ChatBarrier/RetryBarrier.test.tsx`
- `bun run typecheck`

## Risks

Low. The retry behavior change is constrained to retry-barrier eligibility. `/btw` rows are a read-only side branch, not resumable main-agent turns, so they should be skipped when selecting the main retry candidate. The tests cover both sides: idle `/btw` no longer shows retry UI, and an earlier interrupted main response or context-exceeded stream error remains classified through the previous main-agent row even if `/btw` rows appear after it.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$307.29`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=307.29 -->
