### PR TITLE
🤖 fix: silence goal continuation skip log spam during streams

### DIFF
--- a/src/node/services/workspaceGoalService.ts
+++ b/src/node/services/workspaceGoalService.ts
@@ -733,7 +733,13 @@ export class WorkspaceGoalService {
   async buildGoalContinuationPayload(workspaceId: string): Promise<IdleDispatchPayload | null> {
     const eligibility = await this.checkGoalContinuationEligibility(workspaceId, Date.now());
     if (!eligibility.eligible) {
-      log.info("WorkspaceGoalService: skipped goal continuation", {
+      // Self-deferring reasons (e.g. `currently_streaming`, `initializing`)
+      // re-request dispatch on a ~1s timer, so logging at info level produces
+      // one line per retry for the entire duration of an active stream. Drop
+      // those to debug; keep terminal reasons at info since they fire once
+      // and are useful diagnostic signal.
+      const logFn = eligibility.deferUntilMs != null ? log.debug : log.info;
+      logFn("WorkspaceGoalService: skipped goal continuation", {
         workspaceId,
         reason: eligibility.reason,
       });


### PR DESCRIPTION
## Summary

Demote the `WorkspaceGoalService: skipped goal continuation` log to `debug` when eligibility is self-deferring, so we no longer spam one info line per second for the entire duration of every active stream.

## Background

`WorkspaceGoalService.buildGoalContinuationPayload` runs whenever the idle dispatcher invokes the goal continuation consumer. For transient reasons (`currently_streaming`, `initializing`), `checkGoalContinuationEligibility` returns `deferUntilMs = nowMs + 1_000` and `scheduleContinuationReRequest` re-arms a dispatch one second later. That self-rescheduling loop produced an `info`-level log every ~1s for the entire duration of a stream:

```
5:43.787PM workspaceGoalService.ts:736 WorkspaceGoalService: skipped goal continuation { workspaceId: '300037293d', reason: 'currently_streaming' }
```

## Implementation

In `buildGoalContinuationPayload`, route the skip log through `log.debug` when `eligibility.deferUntilMs != null` (the self-retrying transient states) and keep `log.info` for terminal reasons (`goal_mismatch`, `user_stop`, `plan_mode`, `archived`, …) that fire at most once and remain useful diagnostic signal. A short comment near the log explains the policy so future edits don't accidentally re-promote these reasons.

## Risks

Very low. Only changes log verbosity on one site; no eligibility logic, dispatch behavior, or persisted state is affected. Debug entries still surface when `MUX_DEBUG=1` / `MUX_LOG_LEVEL=debug` or when an Output tab subscriber requests them, so on-demand diagnosis is preserved.

## Validation

- `make static-check` — clean
- `bun test src/node/services/workspaceGoalService.test.ts` — 117/117 pass (no test asserted on this log line)

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `max` • Cost: `$0.94`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=max costs=0.94 -->
