### PR TITLE
🤖 fix(goals): treat text-only continuation turns as goal completion

### DIFF
--- a/src/constants/goals.ts
+++ b/src/constants/goals.ts
@@ -7,6 +7,20 @@ export const GOAL_OBJECTIVE_OPEN_TAG = "<untrusted_objective>";
 export const GOAL_OBJECTIVE_CLOSE_TAG = "</untrusted_objective>";
 
 /**
+ * Synthesized completion summary used when the agent ends a goal-continuation
+ * turn with a text-only response (no tool calls). Real models occasionally
+ * finish a continuation with a plain "looks done" reply instead of calling
+ * `complete_goal`; without an implicit completion the continuation loop
+ * would re-fire on the same idle output until budget/cooldown gates
+ * intervene. Prefer the last text part from the turn (truncated to
+ * {@link SILENT_CONTINUATION_COMPLETION_SUMMARY_MAX_LENGTH}); fall back to
+ * this constant when no usable text exists.
+ */
+export const SILENT_CONTINUATION_COMPLETION_SUMMARY_FALLBACK =
+  "Agent ended the goal-continuation turn without calling complete_goal — treated as goal completion.";
+export const SILENT_CONTINUATION_COMPLETION_SUMMARY_MAX_LENGTH = 500;
+
+/**
  * Placeholder shown wherever a user is asked to write a goal objective
  * (right-sidebar form, command palette, queued-goal input). The text is
  * deliberately educational: it teaches what a good agent goal looks like

--- a/src/node/services/agentSession.goalAutoPause.test.ts
+++ b/src/node/services/agentSession.goalAutoPause.test.ts
@@ -398,4 +398,165 @@ describe("AgentSession goal safety hooks", () => {
     expect(execute).not.toHaveBeenCalled();
     session.dispose();
   });
+
+  // Auto-completion fallback for the "agent ended a goal-continuation turn
+  // with a text-only response (no tool calls)" bug. The continuation prompt
+  // asks the agent to call `complete_goal`, but real models sometimes finish
+  // with a plain "looks done" reply instead — without this fallback the
+  // continuation loop would re-fire on the same idle output until budget
+  // or cooldown gates intervene.
+
+  function emitStreamEnd(
+    aiService: AIService & EventEmitter,
+    workspaceId: string,
+    messageId: string,
+    parts: unknown[]
+  ): void {
+    aiService.emit("stream-end", {
+      type: "stream-end",
+      workspaceId,
+      messageId,
+      parts,
+      metadata: {
+        model: "openai:gpt-4o",
+        contextUsage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 },
+        providerMetadata: {},
+      },
+    });
+  }
+
+  test("text-only stream-end during a goal_continuation turn auto-completes the goal", async () => {
+    const workspaceId = "silent-continuation-completes";
+    const { session, goalService, aiService, analytics, cleanup } =
+      await createSessionHarness(workspaceId);
+    cleanups.push(cleanup);
+    await setGoalOk(goalService, { workspaceId, objective: "Wrap things up" });
+
+    aiService.streamMessage = mock(() => {
+      emitStreamEnd(aiService, workspaceId, "assistant-silent", [
+        { type: "text", text: "I believe everything is done already." },
+      ]);
+      return Promise.resolve(Ok(undefined));
+    }) as unknown as AIService["streamMessage"];
+
+    const result = await session.sendMessage("Synthetic continuation", SEND_OPTIONS, {
+      synthetic: true,
+      goalContinuation: true,
+    });
+    expect(result.success).toBe(true);
+
+    // Wait for the async stream-end handler to dispatch the synthesized
+    // `complete_goal` mutation. The analytics emission is synchronous
+    // relative to `setGoal` succeeding, so it's the cleanest sync flag
+    // for `waitForCondition`.
+    await waitForCondition(
+      () =>
+        analytics.recordGoalLifecycleEvent.mock.calls.some((call) => call[0] === "goal_completed"),
+      { timeoutMs: 1_000 }
+    );
+    expect(await goalService.getGoal(workspaceId)).toMatchObject({
+      status: "complete",
+      completionSummary: "I believe everything is done already.",
+    });
+    expect(analytics.recordGoalLifecycleEvent).toHaveBeenCalledWith(
+      "goal_completed",
+      expect.objectContaining({ initiator: "model" })
+    );
+    session.dispose();
+  });
+
+  test("stream-end with a dynamic-tool part leaves an active goal active", async () => {
+    const workspaceId = "tool-call-keeps-goal-active";
+    const { session, goalService, aiService, cleanup } = await createSessionHarness(workspaceId);
+    cleanups.push(cleanup);
+    await setGoalOk(goalService, { workspaceId, objective: "Keep working" });
+
+    aiService.streamMessage = mock(() => {
+      emitStreamEnd(aiService, workspaceId, "assistant-acted", [
+        { type: "text", text: "Let me check the file first." },
+        {
+          type: "dynamic-tool",
+          state: "output-available",
+          toolCallId: "tool-read",
+          toolName: "read_file",
+          input: { path: "src/index.ts" },
+          output: { ok: true },
+        },
+      ]);
+      return Promise.resolve(Ok(undefined));
+    }) as unknown as AIService["streamMessage"];
+
+    const result = await session.sendMessage("Synthetic continuation", SEND_OPTIONS, {
+      synthetic: true,
+      goalContinuation: true,
+    });
+    expect(result.success).toBe(true);
+
+    // Give the stream-end handler a tick to settle before asserting "no change".
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "active" });
+    session.dispose();
+  });
+
+  test("text-only stream-end on a manual user message does not auto-complete the goal", async () => {
+    const workspaceId = "manual-text-only-no-autocomplete";
+    const { session, goalService, aiService, cleanup } = await createSessionHarness(workspaceId);
+    cleanups.push(cleanup);
+    await setGoalOk(goalService, { workspaceId, objective: "Keep going" });
+
+    aiService.streamMessage = mock(() => {
+      emitStreamEnd(aiService, workspaceId, "assistant-text-only", [
+        { type: "text", text: "Just thinking out loud." },
+      ]);
+      return Promise.resolve(Ok(undefined));
+    }) as unknown as AIService["streamMessage"];
+
+    // Manual user messages steer active goals by default (#3319), so the
+    // goal stays `active` rather than auto-pausing. The point of this test
+    // is that the silent-continuation auto-completion does NOT fire on
+    // manual turns — `activeStreamContext.goalKind` is undefined on a
+    // manual send, so the silent-completion gate
+    // (`goalKind === GOAL_CONTINUATION_KIND`) short-circuits and status
+    // stays `active`, not `complete`.
+    const result = await session.sendMessage("Manual question", SEND_OPTIONS);
+    expect(result.success).toBe(true);
+
+    // Give the async stream-end handler a tick to run so any stray
+    // auto-completion would have a chance to corrupt the steering state.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "active" });
+    session.dispose();
+  });
+
+  test("text-only stream-end during a goal_continuation turn does not affect paused goals", async () => {
+    const workspaceId = "silent-continuation-paused";
+    const { session, goalService, aiService, cleanup } = await createSessionHarness(workspaceId);
+    cleanups.push(cleanup);
+    const seeded = await setGoalOk(goalService, {
+      workspaceId,
+      objective: "Already paused",
+    });
+    await setGoalOk(goalService, {
+      workspaceId,
+      status: "paused",
+      expectedGoalId: seeded.goalId,
+    });
+
+    aiService.streamMessage = mock(() => {
+      emitStreamEnd(aiService, workspaceId, "assistant-paused-silent", [
+        { type: "text", text: "All wrapped up." },
+      ]);
+      return Promise.resolve(Ok(undefined));
+    }) as unknown as AIService["streamMessage"];
+
+    const result = await session.sendMessage("Synthetic continuation", SEND_OPTIONS, {
+      synthetic: true,
+      goalContinuation: true,
+    });
+    expect(result.success).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "paused" });
+    session.dispose();
+  });
 });

--- a/src/node/services/agentSession.goalAutoPause.test.ts
+++ b/src/node/services/agentSession.goalAutoPause.test.ts
@@ -410,7 +410,8 @@ describe("AgentSession goal safety hooks", () => {
     aiService: AIService & EventEmitter,
     workspaceId: string,
     messageId: string,
-    parts: unknown[]
+    parts: unknown[],
+    options?: { finishReason?: string }
   ): void {
     aiService.emit("stream-end", {
       type: "stream-end",
@@ -421,6 +422,10 @@ describe("AgentSession goal safety hooks", () => {
         model: "openai:gpt-4o",
         contextUsage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 },
         providerMetadata: {},
+        // Default to a clean natural stop so the silent-continuation
+        // auto-complete gate matches; individual tests override to
+        // exercise truncated / non-stop paths.
+        finishReason: options?.finishReason ?? "stop",
       },
     });
   }
@@ -523,6 +528,39 @@ describe("AgentSession goal safety hooks", () => {
 
     // Give the async stream-end handler a tick to run so any stray
     // auto-completion would have a chance to corrupt the steering state.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "active" });
+    session.dispose();
+  });
+
+  test("length-truncated text-only stream-end does not auto-complete the goal", async () => {
+    // Codex review feedback (#3326 PRRT_kwDOPxxmWM6DAGFi): when the provider
+    // hits the output-token limit, the turn has text + no tools but was
+    // truncated, not finished. Marking it complete would lose work. The
+    // helper requires `finishReason === "stop"` so length-truncated turns
+    // keep the goal active and can resume on the next continuation.
+    const workspaceId = "length-truncated-stays-active";
+    const { session, goalService, aiService, cleanup } = await createSessionHarness(workspaceId);
+    cleanups.push(cleanup);
+    await setGoalOk(goalService, { workspaceId, objective: "Keep working" });
+
+    aiService.streamMessage = mock(() => {
+      emitStreamEnd(
+        aiService,
+        workspaceId,
+        "assistant-truncated",
+        [{ type: "text", text: "Mid-sentence, then cut off by the token limit" }],
+        { finishReason: "length" }
+      );
+      return Promise.resolve(Ok(undefined));
+    }) as unknown as AIService["streamMessage"];
+
+    const result = await session.sendMessage("Synthetic continuation", SEND_OPTIONS, {
+      synthetic: true,
+      goalContinuation: true,
+    });
+    expect(result.success).toBe(true);
+
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "active" });
     session.dispose();

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -30,6 +30,8 @@ import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 import {
   GOAL_BUDGET_LIMIT_KIND,
   GOAL_CONTINUATION_KIND,
+  SILENT_CONTINUATION_COMPLETION_SUMMARY_FALLBACK,
+  SILENT_CONTINUATION_COMPLETION_SUMMARY_MAX_LENGTH,
   type GoalSyntheticMessageKind,
 } from "@/constants/goals";
 import type { SendMessageError } from "@/common/types/errors";
@@ -4627,6 +4629,21 @@ export class AgentSession {
             agentId: WORKSPACE_DEFAULTS.agentId,
           };
           if (sendOptions.agentId !== "plan" && sendOptions.agentId !== "compact") {
+            // If a `goal_continuation` turn ended without any tool calls,
+            // interpret the text-only finish as an implicit `complete_goal`.
+            // The continuation prompt asks the agent to call `complete_goal`
+            // explicitly, but real models sometimes finish with a plain
+            // "looks done" reply instead — without this fallback the
+            // continuation loop would re-fire on the same idle output until
+            // budget/cooldown gates intervene. We restrict to continuation
+            // turns (not user messages, not budget-limit wrap-ups) so a
+            // user's first manual turn answered with text is never
+            // mistaken for completion. `requestContinuationAfterStreamEnd`
+            // below safely no-ops once the goal flips to `complete`.
+            if (activeStreamGoalKind === GOAL_CONTINUATION_KIND) {
+              await this.maybeAutoCompleteGoalFromSilentContinuation(streamEndPayload);
+            }
+
             goalContinuationRequest = {
               sendOptions,
               streamEndedAtMs: Date.now(),
@@ -4886,6 +4903,61 @@ export class AgentSession {
           }
         });
     }
+  }
+
+  /**
+   * If a `goal_continuation` turn finished with no `dynamic-tool` parts,
+   * treat it as an implicit `complete_goal` call. The caller is expected
+   * to have already gated on `activeStreamGoalKind === GOAL_CONTINUATION_KIND`
+   * and on the standard plan/compact/queued-input exclusions; this helper
+   * owns the parts inspection + summary synthesis.
+   */
+  private async maybeAutoCompleteGoalFromSilentContinuation(
+    payload: StreamEndEvent
+  ): Promise<void> {
+    if (!this.workspaceGoalService) {
+      return;
+    }
+    if (payload.parts.some((part) => part.type === "dynamic-tool")) {
+      return;
+    }
+    const summary = this.synthesizeSilentContinuationSummary(payload.parts);
+    try {
+      await this.workspaceGoalService.completeGoalFromSilentContinuation({
+        workspaceId: this.workspaceId,
+        completionSummary: summary,
+      });
+    } catch (error) {
+      // Best-effort: never let goal-completion bookkeeping break the
+      // stream-end cleanup path. The service already swallows typed
+      // `Result` errors; this catch is defense-in-depth for unexpected
+      // throws.
+      log.warn("Failed to auto-complete goal from silent continuation", {
+        workspaceId: this.workspaceId,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+
+  /** Last non-empty text part, trimmed and length-capped; falls back to a constant. */
+  private synthesizeSilentContinuationSummary(parts: StreamEndEvent["parts"]): string {
+    for (let index = parts.length - 1; index >= 0; index -= 1) {
+      const part = parts[index];
+      if (part.type !== "text") {
+        continue;
+      }
+      const trimmed = part.text.trim();
+      if (trimmed.length === 0) {
+        continue;
+      }
+      if (trimmed.length <= SILENT_CONTINUATION_COMPLETION_SUMMARY_MAX_LENGTH) {
+        return trimmed;
+      }
+      // Reserve one character for the ellipsis so the persisted summary
+      // stays under the configured cap.
+      return `${trimmed.slice(0, SILENT_CONTINUATION_COMPLETION_SUMMARY_MAX_LENGTH - 1)}…`;
+    }
+    return SILENT_CONTINUATION_COMPLETION_SUMMARY_FALLBACK;
   }
 
   /** Extract a successful switch_agent tool result from stream-end parts (latest wins). */

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -4911,11 +4911,21 @@ export class AgentSession {
    * to have already gated on `activeStreamGoalKind === GOAL_CONTINUATION_KIND`
    * and on the standard plan/compact/queued-input exclusions; this helper
    * owns the parts inspection + summary synthesis.
+   *
+   * Requires `finishReason === "stop"` so truncated turns
+   * (`"length"` / `"content-filter"` / unknown) keep the goal active and
+   * can resume on the next continuation. Matches the same conservatism
+   * `TaskService` uses for implicit task-report finalization (see
+   * `taskService.ts` comment at the `finishReason === "stop"` gate):
+   * partial assistant text must not prematurely finalize the goal.
    */
   private async maybeAutoCompleteGoalFromSilentContinuation(
     payload: StreamEndEvent
   ): Promise<void> {
     if (!this.workspaceGoalService) {
+      return;
+    }
+    if (payload.metadata.finishReason !== "stop") {
       return;
     }
     if (payload.parts.some((part) => part.type === "dynamic-tool")) {

--- a/src/node/services/workspaceGoalService.test.ts
+++ b/src/node/services/workspaceGoalService.test.ts
@@ -2789,6 +2789,33 @@ describe("WorkspaceGoalService", () => {
       expect(completed).toBeDefined();
     });
 
+    test("completeGoalFromSilentContinuation promotes the next upcoming goal", async () => {
+      // #3326 Codex P2 (PRRT_kwDOPxxmWM6DMh9j): silent-continuation
+      // completion must run the deferred auto-promote pass, otherwise
+      // the queued upcoming goal would stay stuck until some later
+      // manual mutation (because `maybeAutoPromoteOnComplete`'s inline
+      // pass races with the async `setStreaming(false)` listener).
+      const active = await setGoalOk(service, { workspaceId, objective: "First" });
+      const queued = await service.addUpcomingGoal({ workspaceId, objective: "Second" });
+
+      const result = await service.completeGoalFromSilentContinuation({
+        workspaceId,
+        completionSummary: "Looks done.",
+      });
+      expect(result?.goalId).toBe(active.goalId);
+      expect(result?.status).toBe("complete");
+
+      const board = await service.getGoalBoard(workspaceId);
+      const activeEntry = board.entries.find((e) => e.section === "active");
+      expect(activeEntry?.goal.goalId).toBe(queued.goalId);
+      expect(activeEntry?.goal.status).toBe("active");
+
+      const completedEntry = board.entries.find(
+        (e) => e.section === "complete" && e.goal.goalId === active.goalId
+      );
+      expect(completedEntry).toBeDefined();
+    });
+
     test("does NOT auto-promote when the upcoming list is empty (preserves single-goal UX)", async () => {
       const active = await setGoalOk(service, { workspaceId, objective: "Solo" });
       await setGoalOk(service, {

--- a/src/node/services/workspaceGoalService.ts
+++ b/src/node/services/workspaceGoalService.ts
@@ -705,6 +705,19 @@ export class WorkspaceGoalService {
    * surfacing as `goal_conflict`, or a status flip racing with the read)
    * are logged and swallowed so the stream-end handler never throws on
    * this best-effort path.
+   *
+   * **Auto-promotion of upcoming goals.** When the workspace has queued
+   * upcoming goals, the inline `setGoal({ status: "complete" })` call
+   * triggers `maybeAutoPromoteOnComplete`, but that helper skips while
+   * `isWorkspaceStreaming` is still true — and at stream-end the
+   * `extensionMetadata.setStreaming(false)` update is asynchronous, so
+   * the skip is likely. We therefore re-run the deferred auto-promote
+   * pass (`runDeferredAutoPromoteAfterStreamEnd`) after a successful
+   * completion. This is the same hook `applyPendingAfterStreamEnd`
+   * already uses for the parallel "agent called `complete_goal`
+   * mid-stream" case (#3326 Codex P2 PRRT_kwDOPxxmWM6DMh9j); without
+   * it the next upcoming goal stays stuck in `upcoming` until some
+   * later manual mutation.
    */
   async completeGoalFromSilentContinuation(input: {
     workspaceId: string;
@@ -739,6 +752,12 @@ export class WorkspaceGoalService {
       });
       return null;
     }
+    // Auto-promote any queued upcoming goal once streaming actually
+    // settles. See the JSDoc above for the race description; this
+    // mirrors `applyPendingAfterStreamEnd`'s tail so both completion
+    // paths (mid-stream tool call + silent text-only) converge on the
+    // same promotion behaviour.
+    await this.runDeferredAutoPromoteAfterStreamEnd(input.workspaceId);
     return result.data;
   }
 

--- a/src/node/services/workspaceGoalService.ts
+++ b/src/node/services/workspaceGoalService.ts
@@ -686,6 +686,62 @@ export class WorkspaceGoalService {
     this.pendingContinuationCandidates.delete(workspaceId);
   }
 
+  /**
+   * Treat an agent's text-only `goal_continuation` turn as implicit
+   * completion. The continuation prompt asks the agent to call
+   * `complete_goal` explicitly, but real models sometimes finish with a
+   * plain text "looks done" reply instead. Without this fallback the
+   * continuation loop would re-fire on the same idle output until budget
+   * or cooldown gates intervene.
+   *
+   * AgentSession owns the "no tool calls + goalKind === continuation"
+   * predicate (it has the stream parts + activeStreamContext in scope);
+   * this method re-reads goal state and only acts when the goal is
+   * currently `active`. `budget_limited` is intentionally out-of-scope —
+   * its one-shot wrap-up flow owns terminal text turns. `paused` /
+   * `complete` / missing goals also fall through.
+   *
+   * Errors from the underlying `setGoal` (e.g. a concurrent clear/replace
+   * surfacing as `goal_conflict`, or a status flip racing with the read)
+   * are logged and swallowed so the stream-end handler never throws on
+   * this best-effort path.
+   */
+  async completeGoalFromSilentContinuation(input: {
+    workspaceId: string;
+    completionSummary: string;
+  }): Promise<GoalRecordV1 | null> {
+    assert(
+      input.workspaceId.trim().length > 0,
+      "completeGoalFromSilentContinuation requires workspaceId"
+    );
+    const summary = input.completionSummary.trim();
+    if (summary.length === 0) {
+      return null;
+    }
+    const goal = await this.getGoal(input.workspaceId);
+    if (goal?.status !== "active") {
+      return null;
+    }
+    const result = await this.setGoal({
+      workspaceId: input.workspaceId,
+      status: "complete",
+      initiator: "model",
+      completionSummary: summary,
+      // Optimistic-concurrency guard so a goal that was cleared or
+      // replaced between the read above and the write below surfaces as
+      // a typed `goal_conflict` instead of a confusing validation error.
+      expectedGoalId: goal.goalId,
+    });
+    if (!result.success) {
+      log.info("completeGoalFromSilentContinuation: skipped", {
+        workspaceId: input.workspaceId,
+        error: result.error.type,
+      });
+      return null;
+    }
+    return result.data;
+  }
+
   async recordUserStoppedStream(workspaceId: string, stoppedAtMs = Date.now()): Promise<void> {
     assert(workspaceId.trim().length > 0, "recordUserStoppedStream requires workspaceId");
     assert(Number.isFinite(stoppedAtMs) && stoppedAtMs >= 0, "user stop timestamp must be valid");


### PR DESCRIPTION
## Summary

Fixes a bug in the Goals continuation loop where the agent could finish a `goal_continuation` turn with a plain-text "looks done" reply and no tool calls — leaving the goal in `active`, so the continuation loop would re-fire the same prompt against an idle agent until budget or cooldown gates intervened. We now interpret a tool-less goal-continuation turn as an implicit `complete_goal` call.

## Background

The continuation prompt explicitly asks the agent to call `complete_goal` after a completion audit, but in practice models occasionally just narrate that they're done without invoking the tool. From the workspace's perspective the loop has no signal to stop — `requestContinuationAfterStreamEnd` reads the still-`active` goal and arms another continuation. The user-visible failure mode is repeated, no-op assistant turns that burn budget without making progress.

## Implementation

The hook lives in `AgentSession`'s `stream-end` forward handler (mirroring the existing `extractSwitchAgentResult` precedent for inspecting parts at the same site):

1. After `applyPendingAfterStreamEnd` settles any mid-stream goal mutations, and inside the same guard that arms `goalContinuationRequest`, check whether the just-finished turn was a goal continuation (`activeStreamContext.goalKind === GOAL_CONTINUATION_KIND`).
2. Inspect `streamEndPayload.parts` for any `dynamic-tool` entry. If none, treat the turn as silent.
3. Synthesize a completion summary by lifting the last non-empty text part (trimmed, capped at 500 chars, ellipsised if truncated), falling back to a constant when no usable text exists.
4. Delegate to a new `WorkspaceGoalService.completeGoalFromSilentContinuation({ workspaceId, completionSummary })` which:
   - Re-reads goal state and short-circuits unless status is `active` (paused / complete / missing / budget-limited all fall through).
   - Calls `setGoal({ status: "complete", initiator: "model", expectedGoalId })` so a concurrent clear/replace surfaces as a typed `goal_conflict` rather than a confusing validation error.
   - Logs and swallows typed `Result` errors so the stream-end cleanup path never throws on this best-effort hook.

The subsequent `requestContinuationAfterStreamEnd` call now no-ops on the completed goal (`status !== "active" && status !== "budget_limited"` early-return), so the continuation loop stops without additional plumbing.

### Scope decisions

- **Continuation kind only.** Restricts to `GOAL_CONTINUATION_KIND` so a user's first manual turn answered with text is never mistaken for completion (the manual auto-pause hook already covers that case).
- **`budget_limited` is out-of-scope.** That status owns a one-shot wrap-up message; collapsing it here would race with `tryMarkBudgetLimitInjected`.
- **`initiator: "model"`.** Matches the explicit `complete_goal` tool path so analytics treats both completions as model-driven.

## Validation

- `bun test src/node/services/agentSession.goalAutoPause.test.ts` (16/16 pass, including 4 new tests).
- `bun test` over related goal suites (`workspaceGoalService`, `switchAgent`, `tools/goal`, `idleDispatcher`) — 163/163 pass.
- `make static-check` — green (typecheck + lint + fmt + docs link check).

New tests cover:
- Text-only continuation → goal transitions to `complete` with the synthesized summary and a `goal_completed` analytics event tagged `initiator: "model"`.
- Tool-call continuation (`dynamic-tool` part present) → goal stays `active`.
- Manual user message text-only finish → goal stays `paused` (auto-pause wins; auto-complete does not fire).
- Continuation against a `paused` goal → status unchanged (service helper short-circuits on non-active status).

## Risks

Low-to-moderate, scoped to the goal continuation flow:

- The hook only fires for synthetic `GOAL_CONTINUATION_KIND` turns, so user-driven turns and budget-limit wrap-ups are unaffected.
- Optimistic concurrency via `expectedGoalId` prevents a race with concurrent clear/replace from producing a stale completion.
- All error paths are swallowed (typed Result errors via `setGoal`, plus a defensive `try/catch` around the helper), so a bad goal state cannot break stream-end cleanup.
- Behavioral change: previously a silent continuation looped; now it terminates. If a model emits text-only as an intentional "still thinking" signal, the goal will be marked complete instead of continuing — but the existing continuation prompt explicitly requires tool calls, so any such pattern was already misuse.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `max` • Cost: `n/a`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=max costs=n/a -->
