### PR TITLE
🤖 fix: prevent SSH base repo runaway tmp packs

### DIFF
--- a/src/node/runtime/Runtime.ts
+++ b/src/node/runtime/Runtime.ts
@@ -530,14 +530,6 @@ export interface Runtime {
   postCreateSetup?(params: WorkspaceInitParams): Promise<void>;
 
   /**
-   * Optional compensating cleanup after workspace initialization fails or is aborted.
-   * Used by runtimes that create shared cache state during init (for example SSH
-   * base repos and remote worktrees) so canceling creation does not leave hidden
-   * partial state behind.
-   */
-  cleanupFailedInit?(params: WorkspaceInitParams, reason: string): Promise<void>;
-
-  /**
    * Initialize workspace asynchronously (may be slow, streams progress)
    * - LocalRuntime: Runs init hook if present
    * - SSHRuntime: Syncs files, checks out branch, runs init hook

--- a/src/node/runtime/Runtime.ts
+++ b/src/node/runtime/Runtime.ts
@@ -530,6 +530,14 @@ export interface Runtime {
   postCreateSetup?(params: WorkspaceInitParams): Promise<void>;
 
   /**
+   * Optional compensating cleanup after workspace initialization fails or is aborted.
+   * Used by runtimes that create shared cache state during init (for example SSH
+   * base repos and remote worktrees) so canceling creation does not leave hidden
+   * partial state behind.
+   */
+  cleanupFailedInit?(params: WorkspaceInitParams, reason: string): Promise<void>;
+
+  /**
    * Initialize workspace asynchronously (may be slow, streams progress)
    * - LocalRuntime: Runs init hook if present
    * - SSHRuntime: Syncs files, checks out branch, runs init hook

--- a/src/node/runtime/SSHRuntime.retry.test.ts
+++ b/src/node/runtime/SSHRuntime.retry.test.ts
@@ -318,6 +318,20 @@ function expectCommandMatching(
   return index;
 }
 
+function expectPartialWorkspaceCleanupOrder(
+  command: string,
+  workspacePath: string,
+  workspaceName: string
+): void {
+  const removeIndex = command.indexOf(`rm -rf "${workspacePath}"`);
+  const pruneIndex = command.indexOf("worktree prune");
+  const branchIndex = command.indexOf(`branch -D -- '${workspaceName}'`);
+
+  expect(removeIndex).toBeGreaterThanOrEqual(0);
+  expect(pruneIndex).toBeGreaterThan(removeIndex);
+  expect(branchIndex).toBeGreaterThan(pruneIndex);
+}
+
 function isTmpPackCleanupCommand(command: string): boolean {
   return command.startsWith("pack_dir=") && command.includes("tmp_pack_*");
 }
@@ -498,8 +512,11 @@ describe("SSHRuntime project sync retry orchestration", () => {
       (command) => command.includes("worktree prune") && command.includes("rm -rf")
     );
     expect(cleanupCommand).toBeDefined();
-    expect(cleanupCommand ?? "").toContain("branch -D -- 'feature-cancelled'");
-    expect(cleanupCommand ?? "").toContain('rm -rf "/remote/src/project/feature-cancelled"');
+    expectPartialWorkspaceCleanupOrder(
+      cleanupCommand ?? "",
+      "/remote/src/project/feature-cancelled",
+      "feature-cancelled"
+    );
   });
 
   it("cleans only partial state when slow worktree materialization fails", async () => {
@@ -516,8 +533,11 @@ describe("SSHRuntime project sync retry orchestration", () => {
       (command) => command.includes("worktree prune") && command.includes("rm -rf")
     );
     expect(cleanupCommand).toBeDefined();
-    expect(cleanupCommand ?? "").toContain("branch -D -- 'feature-materialize'");
-    expect(cleanupCommand ?? "").toContain('rm -rf "/remote/src/project/feature-materialize"');
+    expectPartialWorkspaceCleanupOrder(
+      cleanupCommand ?? "",
+      "/remote/src/project/feature-materialize",
+      "feature-materialize"
+    );
   });
 
   it("preserves materialized workspaces when submodule initialization fails", async () => {

--- a/src/node/runtime/SSHRuntime.retry.test.ts
+++ b/src/node/runtime/SSHRuntime.retry.test.ts
@@ -159,6 +159,7 @@ class CleanupCommandSSHRuntime extends SSHRuntime {
   countObjectsStdout = "count: 0\npacks: 0\n";
   countObjectsStderr = "";
   countObjectsExitCode = 0;
+  tmpCleanupStdout = "";
   promisorStdout = "/remote/src/project/.mux-base.git/objects/pack/pack-a.promisor\n";
   gcStdout = "";
   gcStderr = "";
@@ -189,6 +190,21 @@ class CleanupCommandSSHRuntime extends SSHRuntime {
     );
   }
 
+  async runPartialCleanup(
+    projectPath: string,
+    workspaceName: string,
+    workspacePath: string,
+    trusted?: boolean
+  ): Promise<void> {
+    await this.cleanupPartialWorkspaceState(
+      projectPath,
+      workspaceName,
+      workspacePath,
+      "test cleanup",
+      trusted
+    );
+  }
+
   override exec(command: string, options: ExecOptions): Promise<ExecStream> {
     this.commands.push(command);
     this.timeouts.push(options.timeout ?? -1);
@@ -202,6 +218,9 @@ class CleanupCommandSSHRuntime extends SSHRuntime {
         )
       );
     }
+    if (command.startsWith("pack_dir=")) {
+      return Promise.resolve(createExecStream(this.tmpCleanupStdout));
+    }
     if (command.startsWith("find ")) {
       return Promise.resolve(createExecStream(this.promisorStdout));
     }
@@ -212,12 +231,50 @@ class CleanupCommandSSHRuntime extends SSHRuntime {
   }
 }
 
+function expectCommandMatching(
+  commands: string[],
+  predicate: (command: string) => boolean
+): number {
+  const index = commands.findIndex(predicate);
+  expect(index).toBeGreaterThanOrEqual(0);
+  return index;
+}
+
+function isTmpPackCleanupCommand(command: string): boolean {
+  return command.startsWith("pack_dir=") && command.includes("tmp_pack_*");
+}
+
 // Single-line shell pipeline that strips partial-clone config from a shared
 // bare base repo. The exact text is asserted in tests because order matters:
 // the strip must precede the on-disk `.promisor` marker cleanup so that even
 // a half-completed repair leaves the repo non-promisor (and therefore safe
 // from the upstream `check_connected()` sideband deadlock — see the doc
 // comment on `stripBaseRepoPromisorConfig` in SSHRuntime.ts).
+function isHealthProbeCommand(command: string): boolean {
+  return command.includes("count-objects -v") && command.includes("MUX_HEALTH_TMP_PACK_COUNT");
+}
+
+function expectMaintenanceCommands(
+  runtime: { commands: string[]; timeouts: number[] },
+  baseRepoPathArg: string
+): void {
+  const stripIndex = runtime.commands.indexOf(expectedStripPromisorCommand(baseRepoPathArg));
+  const tmpCleanupIndex = expectCommandMatching(runtime.commands, isTmpPackCleanupCommand);
+  const promisorCleanupIndex = runtime.commands.indexOf(
+    `find ${baseRepoPathArg}/objects/pack -name '*.promisor' -print -delete 2>/dev/null || true`
+  );
+  const gcIndex = runtime.commands.indexOf(`git -C ${baseRepoPathArg} gc --prune=now`);
+
+  expect(stripIndex).toBeGreaterThanOrEqual(0);
+  expect(stripIndex).toBeLessThan(tmpCleanupIndex);
+  expect(tmpCleanupIndex).toBeLessThan(promisorCleanupIndex);
+  expect(promisorCleanupIndex).toBeLessThan(gcIndex);
+  expect(runtime.timeouts[stripIndex]).toBe(10);
+  expect(runtime.timeouts[tmpCleanupIndex]).toBe(10);
+  expect(runtime.timeouts[promisorCleanupIndex]).toBe(10);
+  expect(runtime.timeouts[gcIndex]).toBe(120);
+}
+
 function expectedStripPromisorCommand(baseRepoPathArg: string): string {
   return (
     `git -C ${baseRepoPathArg} config --unset-all remote.origin.promisor; ` +
@@ -234,9 +291,18 @@ describe("SSHRuntime project sync retry orchestration", () => {
 
     await runtime.runCleanup(baseRepoPathArg);
 
-    // Strip must be the first remote call in repair — see comment above.
-    expect(runtime.commands[0]).toBe(expectedStripPromisorCommand(baseRepoPathArg));
-    expect(runtime.timeouts[0]).toBe(10);
+    const stripIndex = runtime.commands.indexOf(expectedStripPromisorCommand(baseRepoPathArg));
+    expect(stripIndex).toBeGreaterThanOrEqual(0);
+    expect(stripIndex).toBeLessThan(
+      expectCommandMatching(runtime.commands, isTmpPackCleanupCommand)
+    );
+    expect(stripIndex).toBeLessThan(
+      expectCommandMatching(runtime.commands, (command) => command.startsWith("find "))
+    );
+    expect(stripIndex).toBeLessThan(
+      expectCommandMatching(runtime.commands, (command) => command.includes(" gc --prune=now"))
+    );
+    expect(runtime.timeouts[stripIndex]).toBe(10);
   });
 
   it("removes stale promisor markers before running git gc", async () => {
@@ -245,12 +311,17 @@ describe("SSHRuntime project sync retry orchestration", () => {
 
     await runtime.runCleanup(baseRepoPathArg);
 
-    expect(runtime.commands).toEqual([
-      expectedStripPromisorCommand(baseRepoPathArg),
-      `find ${baseRepoPathArg}/objects/pack -name '*.promisor' -print -delete 2>/dev/null || true`,
-      `git -C ${baseRepoPathArg} gc --prune=now`,
-    ]);
-    expect(runtime.timeouts).toEqual([10, 10, 120]);
+    const tmpCleanupIndex = expectCommandMatching(runtime.commands, isTmpPackCleanupCommand);
+    const promisorCleanupIndex = runtime.commands.indexOf(
+      `find ${baseRepoPathArg}/objects/pack -name '*.promisor' -print -delete 2>/dev/null || true`
+    );
+    const gcIndex = runtime.commands.indexOf(`git -C ${baseRepoPathArg} gc --prune=now`);
+
+    expect(promisorCleanupIndex).toBeGreaterThan(tmpCleanupIndex);
+    expect(gcIndex).toBeGreaterThan(promisorCleanupIndex);
+    expect(runtime.timeouts[tmpCleanupIndex]).toBe(10);
+    expect(runtime.timeouts[promisorCleanupIndex]).toBe(10);
+    expect(runtime.timeouts[gcIndex]).toBe(120);
   });
 
   it("proactively repairs fragmented base repos before sync", async () => {
@@ -260,16 +331,35 @@ describe("SSHRuntime project sync retry orchestration", () => {
 
     await runtime.runEnsureHealthy(baseRepoPathArg);
 
-    expect(runtime.steps).toEqual([
-      "Shared base repository is fragmented (50 pack files); running maintenance before sync...",
-    ]);
-    expect(runtime.commands).toEqual([
-      `git -C ${baseRepoPathArg} count-objects -v`,
-      expectedStripPromisorCommand(baseRepoPathArg),
-      `find ${baseRepoPathArg}/objects/pack -name '*.promisor' -print -delete 2>/dev/null || true`,
-      `git -C ${baseRepoPathArg} gc --prune=now`,
-    ]);
-    expect(runtime.timeouts).toEqual([10, 10, 10, 120]);
+    expect(runtime.steps).toHaveLength(1);
+    expect(runtime.steps[0]).toContain("50 pack files");
+    expect(runtime.steps[0]).toContain("running maintenance before sync");
+    expect(isHealthProbeCommand(runtime.commands[0] ?? "")).toBe(true);
+    expectMaintenanceCommands(runtime, baseRepoPathArg);
+  });
+
+  it("proactively repairs base repos with stale tmp packs before sync", async () => {
+    const runtime = new CleanupCommandSSHRuntime();
+    const baseRepoPathArg = '"/remote/src/project/.mux-base.git"';
+    runtime.countObjectsStdout = [
+      "count: 0",
+      "packs: 5",
+      "size-pack: 10",
+      "MUX_HEALTH_TMP_PACK_COUNT=3",
+      "MUX_HEALTH_TMP_PACK_BYTES=4096",
+      "MUX_HEALTH_STALE_TMP_PACK_COUNT=2",
+      "MUX_HEALTH_STALE_TMP_PACK_BYTES=2048",
+      "MUX_HEALTH_FREE_BYTES=9999999999",
+      "",
+    ].join("\n");
+    runtime.tmpCleanupStdout = "1024\t/tmp/tmp_pack_a\n1024\t/tmp/tmp_idx_a\n";
+
+    await runtime.runEnsureHealthy(baseRepoPathArg);
+
+    expect(runtime.steps).toHaveLength(1);
+    expect(runtime.steps[0]).toContain("2 stale tmp packs");
+    expect(isHealthProbeCommand(runtime.commands[0] ?? "")).toBe(true);
+    expectMaintenanceCommands(runtime, baseRepoPathArg);
   });
 
   it("skips proactive maintenance for healthy base repos", async () => {
@@ -280,7 +370,8 @@ describe("SSHRuntime project sync retry orchestration", () => {
     await runtime.runEnsureHealthy(baseRepoPathArg);
 
     expect(runtime.steps).toEqual([]);
-    expect(runtime.commands).toEqual([`git -C ${baseRepoPathArg} count-objects -v`]);
+    expect(runtime.commands).toHaveLength(1);
+    expect(isHealthProbeCommand(runtime.commands[0] ?? "")).toBe(true);
     expect(runtime.timeouts).toEqual([10]);
   });
 
@@ -293,7 +384,8 @@ describe("SSHRuntime project sync retry orchestration", () => {
     await runtime.runEnsureHealthy(baseRepoPathArg);
 
     expect(runtime.steps).toEqual([]);
-    expect(runtime.commands).toEqual([`git -C ${baseRepoPathArg} count-objects -v`]);
+    expect(runtime.commands).toHaveLength(1);
+    expect(isHealthProbeCommand(runtime.commands[0] ?? "")).toBe(true);
     expect(runtime.timeouts).toEqual([10]);
   });
 
@@ -306,16 +398,30 @@ describe("SSHRuntime project sync retry orchestration", () => {
 
     await runtime.runEnsureHealthy(baseRepoPathArg);
 
-    expect(runtime.steps).toEqual([
-      "Shared base repository is fragmented (50 pack files); running maintenance before sync...",
-    ]);
-    expect(runtime.commands).toEqual([
-      `git -C ${baseRepoPathArg} count-objects -v`,
-      expectedStripPromisorCommand(baseRepoPathArg),
-      `find ${baseRepoPathArg}/objects/pack -name '*.promisor' -print -delete 2>/dev/null || true`,
-      `git -C ${baseRepoPathArg} gc --prune=now`,
-    ]);
-    expect(runtime.timeouts).toEqual([10, 10, 10, 120]);
+    expect(runtime.steps).toHaveLength(1);
+    expect(runtime.steps[0]).toContain("50 pack files");
+    expect(runtime.steps[0]).toContain("running maintenance before sync");
+    expect(isHealthProbeCommand(runtime.commands[0] ?? "")).toBe(true);
+    expectMaintenanceCommands(runtime, baseRepoPathArg);
+  });
+
+  it("cleans partial SSH workspace state after failed init or cancel", async () => {
+    const runtime = new CleanupCommandSSHRuntime();
+
+    await runtime.runPartialCleanup(
+      "/local/project",
+      "feature-cancelled",
+      "/remote/src/project/feature-cancelled",
+      true
+    );
+
+    expectCommandMatching(runtime.commands, isTmpPackCleanupCommand);
+    const cleanupCommand = runtime.commands.find(
+      (command) => command.includes("worktree prune") && command.includes("rm -rf")
+    );
+    expect(cleanupCommand).toBeDefined();
+    expect(cleanupCommand ?? "").toContain("branch -D -- 'feature-cancelled'");
+    expect(cleanupCommand ?? "").toContain('rm -rf "/remote/src/project/feature-cancelled"');
   });
 
   it("propagates aborts during proactive maintenance preflight", async () => {

--- a/src/node/runtime/SSHRuntime.retry.test.ts
+++ b/src/node/runtime/SSHRuntime.retry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { ExecOptions, ExecStream, InitLogger } from "./Runtime";
+import type { ExecOptions, ExecStream, InitLogger, WorkspaceInitParams } from "./Runtime";
 import { SSHRuntime } from "./SSHRuntime";
 import type { RemoteProjectLayout } from "./remoteProjectLayout";
 import type { SSHRuntimeConfig } from "./sshConnectionPool";
@@ -196,13 +196,13 @@ class CleanupCommandSSHRuntime extends SSHRuntime {
     workspacePath: string,
     trusted?: boolean
   ): Promise<void> {
-    await this.cleanupPartialWorkspaceState(
+    await this.cleanupPartialWorkspaceState({
       projectPath,
       workspaceName,
       workspacePath,
-      "test cleanup",
-      trusted
-    );
+      reason: "test cleanup",
+      trusted,
+    });
   }
 
   override exec(command: string, options: ExecOptions): Promise<ExecStream> {
@@ -227,6 +227,84 @@ class CleanupCommandSSHRuntime extends SSHRuntime {
     if (command.includes(" gc --prune=now")) {
       return Promise.resolve(createExecStream(this.gcStdout, this.gcStderr, this.gcExitCode));
     }
+    return Promise.resolve(createExecStream(""));
+  }
+}
+
+class InitMaterializationSSHRuntime extends SSHRuntime {
+  readonly commands: string[] = [];
+  worktreeAddExitCode = 0;
+  worktreeAddStderr = "";
+  gitmodulesPresent = false;
+  submoduleUpdateExitCode = 0;
+
+  constructor() {
+    const config: SSHRuntimeConfig = {
+      host: "example.test",
+      srcBaseDir: "/remote/src",
+    };
+    super(config, createMockTransport(config));
+  }
+
+  protected override syncProjectToRemote(
+    _projectPath: string,
+    _initLogger: InitLogger,
+    _abortSignal?: AbortSignal
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  createInitParams(workspaceName: string): WorkspaceInitParams {
+    return {
+      projectPath: "/local/project",
+      branchName: workspaceName,
+      trunkBranch: "main",
+      workspacePath: `/remote/src/project/${workspaceName}`,
+      initLogger: noopInitLogger,
+      trusted: true,
+    };
+  }
+
+  override exec(command: string, _options: ExecOptions): Promise<ExecStream> {
+    this.commands.push(command);
+
+    if (command.includes("STATUS_CREATED=")) {
+      return Promise.resolve(createExecStream("STATUS_CREATED=existed\nSTATUS_CORE_BARE=absent\n"));
+    }
+    if (command.startsWith("test -d ")) {
+      return Promise.resolve(createExecStream("", "", 1));
+    }
+    if (command.includes(" fetch origin ")) {
+      return Promise.resolve(createExecStream("", "origin unavailable", 1));
+    }
+    if (command.includes("rev-parse --verify 'refs/mux-bundle/main'")) {
+      return Promise.resolve(createExecStream("refs/mux-bundle/main\n"));
+    }
+    if (command.includes(" worktree add ")) {
+      return Promise.resolve(
+        createExecStream("", this.worktreeAddStderr, this.worktreeAddExitCode)
+      );
+    }
+    if (command.startsWith("pack_dir=")) {
+      return Promise.resolve(createExecStream(""));
+    }
+    if (command.includes("worktree prune")) {
+      return Promise.resolve(createExecStream(""));
+    }
+    if (command.startsWith("if [ -f .gitmodules ]")) {
+      return this.gitmodulesPresent
+        ? Promise.resolve(createExecStream("present"))
+        : Promise.resolve(createExecStream("missing", "", 2));
+    }
+    if (command === "git submodule sync --recursive") {
+      return Promise.resolve(createExecStream(""));
+    }
+    if (command === "git submodule update --init --recursive") {
+      return Promise.resolve(
+        createExecStream("", "submodule update failed", this.submoduleUpdateExitCode)
+      );
+    }
+
     return Promise.resolve(createExecStream(""));
   }
 }
@@ -405,7 +483,7 @@ describe("SSHRuntime project sync retry orchestration", () => {
     expectMaintenanceCommands(runtime, baseRepoPathArg);
   });
 
-  it("cleans partial SSH workspace state after failed init or cancel", async () => {
+  it("cleans partial SSH workspace state when materialization cleanup is requested", async () => {
     const runtime = new CleanupCommandSSHRuntime();
 
     await runtime.runPartialCleanup(
@@ -422,6 +500,41 @@ describe("SSHRuntime project sync retry orchestration", () => {
     expect(cleanupCommand).toBeDefined();
     expect(cleanupCommand ?? "").toContain("branch -D -- 'feature-cancelled'");
     expect(cleanupCommand ?? "").toContain('rm -rf "/remote/src/project/feature-cancelled"');
+  });
+
+  it("cleans only partial state when slow worktree materialization fails", async () => {
+    const runtime = new InitMaterializationSSHRuntime();
+    runtime.worktreeAddExitCode = 1;
+    runtime.worktreeAddStderr = "fatal: worktree add failed";
+
+    const result = await runtime.initWorkspace(runtime.createInitParams("feature-materialize"));
+
+    expect(result.success).toBe(false);
+    expect(result.error ?? "").toContain("Failed to create worktree");
+    expectCommandMatching(runtime.commands, isTmpPackCleanupCommand);
+    const cleanupCommand = runtime.commands.find(
+      (command) => command.includes("worktree prune") && command.includes("rm -rf")
+    );
+    expect(cleanupCommand).toBeDefined();
+    expect(cleanupCommand ?? "").toContain("branch -D -- 'feature-materialize'");
+    expect(cleanupCommand ?? "").toContain('rm -rf "/remote/src/project/feature-materialize"');
+  });
+
+  it("preserves materialized workspaces when submodule initialization fails", async () => {
+    const runtime = new InitMaterializationSSHRuntime();
+    runtime.gitmodulesPresent = true;
+    runtime.submoduleUpdateExitCode = 1;
+
+    const result = await runtime.initWorkspace(runtime.createInitParams("feature-submodule"));
+
+    expect(result.success).toBe(false);
+    expect(result.error ?? "").toContain("Failed to initialize git submodules");
+    expect(runtime.commands.some(isTmpPackCleanupCommand)).toBe(false);
+    expect(
+      runtime.commands.some(
+        (command) => command.includes("worktree prune") && command.includes("rm -rf")
+      )
+    ).toBe(false);
   });
 
   it("propagates aborts during proactive maintenance preflight", async () => {

--- a/src/node/runtime/SSHRuntime.retry.test.ts
+++ b/src/node/runtime/SSHRuntime.retry.test.ts
@@ -1,3 +1,6 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "bun:test";
 import type { ExecOptions, ExecStream, InitLogger, WorkspaceInitParams } from "./Runtime";
 import { SSHRuntime } from "./SSHRuntime";
@@ -229,6 +232,70 @@ class CleanupCommandSSHRuntime extends SSHRuntime {
     }
     return Promise.resolve(createExecStream(""));
   }
+}
+
+class WarmPathCommandSSHRuntime extends SSHRuntime {
+  readonly commands: string[] = [];
+  readonly steps: string[] = [];
+
+  constructor() {
+    const config: SSHRuntimeConfig = {
+      host: "example.test",
+      srcBaseDir: "/remote/src",
+    };
+    super(config, createMockTransport(config));
+  }
+
+  createInitParams(projectPath: string, workspaceName: string): WorkspaceInitParams {
+    return {
+      projectPath,
+      branchName: workspaceName,
+      trunkBranch: "main",
+      workspacePath: `/remote/src/project/${workspaceName}`,
+      initLogger: {
+        ...noopInitLogger,
+        logStep: (step) => {
+          this.steps.push(step);
+        },
+      },
+      trusted: true,
+    };
+  }
+
+  override exec(command: string, _options: ExecOptions): Promise<ExecStream> {
+    this.commands.push(command);
+
+    if (command.includes("WARM_MISS:")) {
+      return Promise.resolve(createExecStream("GITMODULES=missing\nWARM_OK\n"));
+    }
+
+    return Promise.resolve(createExecStream(""));
+  }
+}
+
+async function createLocalRepoWithOrigin(): Promise<string> {
+  const projectPath = await mkdtemp(path.join(os.tmpdir(), "mux-ssh-warm-path-"));
+  await mkdir(path.join(projectPath, ".git", "objects"), { recursive: true });
+  await mkdir(path.join(projectPath, ".git", "refs", "heads"), { recursive: true });
+  await writeFile(path.join(projectPath, ".git", "HEAD"), "ref: refs/heads/main\n");
+  await writeFile(
+    path.join(projectPath, ".git", "refs", "heads", "main"),
+    "1111111111111111111111111111111111111111\n"
+  );
+  await writeFile(
+    path.join(projectPath, ".git", "config"),
+    [
+      "[core]",
+      "\trepositoryformatversion = 0",
+      "\tfilemode = true",
+      "\tbare = false",
+      '[remote "origin"]',
+      "\turl = https://example.test/repo.git",
+      "\tfetch = +refs/heads/*:refs/remotes/origin/*",
+      "",
+    ].join("\n")
+  );
+  return projectPath;
 }
 
 class InitMaterializationSSHRuntime extends SSHRuntime {
@@ -495,6 +562,34 @@ describe("SSHRuntime project sync retry orchestration", () => {
     expect(runtime.steps[0]).toContain("running maintenance before sync");
     expect(isHealthProbeCommand(runtime.commands[0] ?? "")).toBe(true);
     expectMaintenanceCommands(runtime, baseRepoPathArg);
+  });
+
+  it("gates warm-path origin fetch on remote disk headroom", async () => {
+    const projectPath = await createLocalRepoWithOrigin();
+    try {
+      const runtime = new WarmPathCommandSSHRuntime();
+
+      const result = await runtime.initWorkspace(
+        runtime.createInitParams(projectPath, "feature-warm-headroom")
+      );
+
+      expect(result.success).toBe(true);
+      const warmCommand = runtime.commands.find((command) =>
+        command.includes("fetch --quiet origin")
+      );
+      expect(warmCommand).toBeDefined();
+      const command = warmCommand ?? "";
+      const diskCheckIndex = command.indexOf("df -Pk");
+      const lowDiskBranchIndex = command.indexOf('if [ "$can_fetch_origin" = "0" ]');
+      const fetchIndex = command.indexOf("fetch --quiet origin");
+
+      expect(diskCheckIndex).toBeGreaterThanOrEqual(0);
+      expect(lowDiskBranchIndex).toBeGreaterThan(diskCheckIndex);
+      expect(fetchIndex).toBeGreaterThan(lowDiskBranchIndex);
+      expect(command).toContain("WARM_ORIGIN_FETCH_SKIPPED_LOW_DISK");
+    } finally {
+      await rm(projectPath, { recursive: true, force: true });
+    }
   });
 
   it("cleans partial SSH workspace state when materialization cleanup is requested", async () => {

--- a/src/node/runtime/SSHRuntime.retry.test.ts
+++ b/src/node/runtime/SSHRuntime.retry.test.ts
@@ -300,6 +300,8 @@ async function createLocalRepoWithOrigin(): Promise<string> {
 
 class InitMaterializationSSHRuntime extends SSHRuntime {
   readonly commands: string[] = [];
+  readonly steps: string[] = [];
+  remoteFreeBytes = 10 * 1024 * 1024 * 1024;
   worktreeAddExitCode = 0;
   worktreeAddStderr = "";
   gitmodulesPresent = false;
@@ -327,7 +329,12 @@ class InitMaterializationSSHRuntime extends SSHRuntime {
       branchName: workspaceName,
       trunkBranch: "main",
       workspacePath: `/remote/src/project/${workspaceName}`,
-      initLogger: noopInitLogger,
+      initLogger: {
+        ...noopInitLogger,
+        logStep: (step) => {
+          this.steps.push(step);
+        },
+      },
       trusted: true,
     };
   }
@@ -340,6 +347,16 @@ class InitMaterializationSSHRuntime extends SSHRuntime {
     }
     if (command.startsWith("test -d ")) {
       return Promise.resolve(createExecStream("", "", 1));
+    }
+    if (command.includes("rev-parse --path-format=absolute --git-common-dir")) {
+      return Promise.resolve(createExecStream("/remote/src/project/.mux-base.git\n"));
+    }
+    if (command.includes("count-objects -v")) {
+      return Promise.resolve(
+        createExecStream(
+          ["count: 0", "packs: 0", `MUX_HEALTH_FREE_BYTES=${this.remoteFreeBytes}`, ""].join("\n")
+        )
+      );
     }
     if (command.includes(" fetch origin ")) {
       return Promise.resolve(createExecStream("", "origin unavailable", 1));
@@ -590,6 +607,18 @@ describe("SSHRuntime project sync retry orchestration", () => {
     } finally {
       await rm(projectPath, { recursive: true, force: true });
     }
+  });
+
+  it("skips post-sync origin fetch when shared object store headroom is low", async () => {
+    const runtime = new InitMaterializationSSHRuntime();
+    runtime.remoteFreeBytes = 1024 * 1024;
+
+    const result = await runtime.initWorkspace(runtime.createInitParams("feature-low-disk-fetch"));
+
+    expect(result.success).toBe(true);
+    expect(runtime.commands.some((command) => command.includes(" fetch origin "))).toBe(false);
+    expect(runtime.commands.some((command) => command.includes("count-objects -v"))).toBe(true);
+    expect(runtime.steps.some((step) => step.includes("Skipping origin/main fetch"))).toBe(true);
   });
 
   it("cleans partial SSH workspace state when materialization cleanup is requested", async () => {

--- a/src/node/runtime/SSHRuntime.syncContract.test.ts
+++ b/src/node/runtime/SSHRuntime.syncContract.test.ts
@@ -86,6 +86,7 @@ function createMockExecResult(
 class CommandCaptureSSHRuntime extends SSHRuntime {
   readonly commands: string[] = [];
 
+  healthStdout = "count: 0\npacks: 0\nMUX_HEALTH_FREE_BYTES=9999999999\n";
   constructor() {
     const config: SSHRuntimeConfig = {
       host: "example.test",
@@ -96,6 +97,9 @@ class CommandCaptureSSHRuntime extends SSHRuntime {
 
   override exec(command: string, _options: ExecOptions): Promise<ExecStream> {
     this.commands.push(command);
+    if (command.includes("count-objects -v")) {
+      return Promise.resolve(createExecStream(this.healthStdout));
+    }
     return Promise.resolve(createExecStream(""));
   }
 }
@@ -244,6 +248,38 @@ describe("SSHRuntime authoritative sync contract", () => {
     expect(pushCalls[1]).not.toContain("+refs/heads/*:refs/mux-bundle/*");
   });
 
+  it("blocks git-push sync before transfer when remote disk headroom is low", async () => {
+    const runtime = new CommandCaptureSSHRuntime();
+    runtime.healthStdout = "count: 0\npacks: 0\nMUX_HEALTH_FREE_BYTES=1\n";
+    const layout = createLayout();
+    const gitCalls: string[][] = [];
+
+    spyOn(disposableExec, "execFileAsync").mockImplementation((file, args) => {
+      gitCalls.push([file, ...args]);
+      return createMockExecResult(Promise.resolve({ stdout: "", stderr: "" }));
+    });
+
+    let failure: unknown;
+    try {
+      await (runtime as unknown as GitPushPrivateApi).syncProjectSnapshotViaGitPush(
+        "/local/project",
+        layout,
+        layout.currentSnapshotPath,
+        noopInitLogger
+      );
+      throw new Error("Expected low remote disk headroom to fail before git push");
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(Error);
+    if (!(failure instanceof Error)) {
+      throw new Error("Expected low headroom failure to surface as an Error");
+    }
+    expect(failure.message).toContain("Remote disk headroom too low");
+    expect(gitCalls).toEqual([]);
+  });
+
   it("skips the metadata tag push when the local repo has no tags", async () => {
     const runtime = new CommandCaptureSSHRuntime();
     const layout = createLayout();
@@ -327,6 +363,40 @@ describe("SSHRuntime authoritative sync contract", () => {
     expect(runtime.commands).toContain(
       "git fetch origin '+refs/heads/main:refs/remotes/origin/main'"
     );
+  });
+
+  it("blocks bundle sync before upload when remote disk headroom is low", async () => {
+    const runtime = new CommandCaptureSSHRuntime();
+    runtime.healthStdout = "count: 0\npacks: 0\nMUX_HEALTH_FREE_BYTES=1\n";
+    const layout = createLayout();
+    const privateApi = runtime as unknown as BundleSyncPrivateApi;
+    let transferCalled = false;
+    privateApi.transferBundleToRemote = () => {
+      transferCalled = true;
+      return Promise.resolve();
+    };
+
+    let failure: unknown;
+    try {
+      await privateApi.syncProjectSnapshotViaBundle(
+        "/local/project",
+        layout,
+        layout.currentSnapshotPath,
+        "snapshot-digest",
+        '"/remote/src/project/.mux-base.git"',
+        noopInitLogger
+      );
+      throw new Error("Expected low remote disk headroom to fail before bundle upload");
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(Error);
+    if (!(failure instanceof Error)) {
+      throw new Error("Expected low headroom failure to surface as an Error");
+    }
+    expect(failure.message).toContain("Remote disk headroom too low");
+    expect(transferCalled).toBe(false);
   });
 
   it("fetches pruneable bundle branches separately from shared tags", async () => {

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -2418,11 +2418,16 @@ export class SSHRuntime extends RemoteRuntime {
       const cleanupResult = await execBuffered(
         this,
         [
+          // Partial materialization cleanup is ordered by Git's ownership model:
+          // remove the path first, prune stale worktree metadata second, then
+          // delete the branch after Git no longer records it as checked out.
+          "cleanup_exit=0",
+          `${workspaceDirectoryCleanup} || cleanup_exit=$?`,
           `if test -d ${baseRepoPathArg}; then`,
           `  ${nhp}git -C ${baseRepoPathArg} worktree prune 2>/dev/null || true`,
           `  ${branchCleanup}`,
           "fi",
-          workspaceDirectoryCleanup,
+          'exit "$cleanup_exit"',
         ].join("\n"),
         { cwd: "/tmp", timeout: 30 }
       );

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -109,6 +109,16 @@ interface BaseRepoHealth {
   freeBytes: number | null;
 }
 
+interface PartialWorkspaceCleanupParams {
+  projectPath: string;
+  workspaceName: string;
+  workspacePath: string;
+  reason: string;
+  trusted?: boolean;
+  deleteWorkspaceBranch?: boolean;
+  removeWorkspaceDirectory?: boolean;
+}
+
 interface BaseRepoTmpCleanupStats {
   removedCount: number;
   removedBytes: number;
@@ -2355,24 +2365,18 @@ export class SSHRuntime extends RemoteRuntime {
     });
   }
 
-  async cleanupFailedInit(params: WorkspaceInitParams, reason: string): Promise<void> {
-    await this.cleanupPartialWorkspaceState(
-      params.projectPath,
-      params.branchName,
-      params.workspacePath,
-      reason,
-      params.trusted
-    );
-  }
-
   protected async cleanupPartialWorkspaceState(
-    projectPath: string,
-    workspaceName: string,
-    workspacePath: string,
-    reason: string,
-    trusted?: boolean,
-    deleteWorkspaceBranch = true
+    params: PartialWorkspaceCleanupParams
   ): Promise<void> {
+    const {
+      projectPath,
+      workspaceName,
+      workspacePath,
+      reason,
+      trusted,
+      deleteWorkspaceBranch = true,
+      removeWorkspaceDirectory = true,
+    } = params;
     const layout = this.getProjectLayout(projectPath);
     const baseRepoPathArg = expandTildeForSSH(layout.baseRepoPath);
     const workspacePathArg = expandTildeForSSH(workspacePath);
@@ -2381,12 +2385,19 @@ export class SSHRuntime extends RemoteRuntime {
       !deleteWorkspaceBranch || isProtectedWorkspaceBranch(workspaceName)
         ? "true"
         : `${nhp}git -C ${baseRepoPathArg} branch -D -- ${shescape.quote(workspaceName)} 2>/dev/null || true`;
+    const workspaceDirectoryCleanup = removeWorkspaceDirectory
+      ? // SAFETY: workspacePath is the exact runtime-computed directory for this workspace.
+        // Callers pass removeWorkspaceDirectory only when this init/delete path owns the path.
+        `rm -rf ${workspacePathArg}`
+      : "true";
 
     log.info("Cleaning partial SSH workspace state", {
       projectPath,
       workspaceName,
       workspacePath,
       reason,
+      deleteWorkspaceBranch,
+      removeWorkspaceDirectory,
     });
 
     try {
@@ -2411,9 +2422,7 @@ export class SSHRuntime extends RemoteRuntime {
           `  ${nhp}git -C ${baseRepoPathArg} worktree prune 2>/dev/null || true`,
           `  ${branchCleanup}`,
           "fi",
-          // SAFETY: workspacePath is the exact runtime-computed directory for this workspace.
-          // Failed init/cancel cleanup must remove partial materialization so a retry starts cleanly.
-          `rm -rf ${workspacePathArg}`,
+          workspaceDirectoryCleanup,
         ].join("\n"),
         { cwd: "/tmp", timeout: 30 }
       );
@@ -2616,13 +2625,13 @@ export class SSHRuntime extends RemoteRuntime {
       const missMatch = /WARM_MISS:(\S+)/.exec(stdout);
       const reason = missMatch ? missMatch[1] : "unknown";
       if (reason === "worktree-add-failed") {
-        await this.cleanupPartialWorkspaceState(
+        await this.cleanupPartialWorkspaceState({
           projectPath,
-          branchName,
+          workspaceName: branchName,
           workspacePath,
-          "warm fast-path worktree add failed",
-          params.trusted
-        );
+          reason: "warm fast-path worktree add failed",
+          trusted: params.trusted,
+        });
       }
       initLogger.logStep(`Warm fast-path miss (${reason}); using slow path`);
       return null;
@@ -2641,67 +2650,17 @@ export class SSHRuntime extends RemoteRuntime {
     return { gitmodulesPresent };
   }
 
-  private async prepareWorkspaceCheckout(params: WorkspaceInitParams, nhp: string): Promise<void> {
-    const { projectPath, branchName, trunkBranch, workspacePath, initLogger, abortSignal, env } =
-      params;
-
-    // STARTUP-PERF (warm fast-path): try to materialize the workspace in a
-    // single fused SSH command. See `tryWarmWorktreeAdd()` for the contract
-    // and miss reasons. When this succeeds, we skip the entire multi-call
-    // slow path (test-d → git-check → ensureBaseRepo → snapshot check →
-    // manifest check → refreshOrigin → fetchOrigin → resolveBundleTrunkRef →
-    // resolveFreshWorkspaceSourceBase → worktree-add), collapsing ~9 sequential
-    // SSH round-trips into one.
-    const warmHit = await this.tryWarmWorktreeAdd(params, nhp);
-    if (warmHit) {
-      // STARTUP-PERF: The warm SSH command already reported whether
-      // `.gitmodules` exists in the freshly-materialized worktree, so we can
-      // skip the (otherwise unavoidable) probe-RTT inside
-      // `hasRuntimeGitmodules()` when the answer is "missing". On a typical
-      // single-package project this saves one full SSH round-trip on every
-      // warm workspace create.
-      if (warmHit.gitmodulesPresent) {
-        await syncRuntimeGitSubmodules({
-          runtime: this,
-          workspacePath,
-          initLogger,
-          abortSignal,
-          env,
-          trusted: params.trusted,
-        });
-      }
-      return;
-    }
-
-    // If the workspace directory already exists and contains a git repo (e.g. forked from
-    // another SSH workspace via worktree add or legacy cp), skip the expensive sync step.
+  private async materializeFreshWorkspaceCheckout(
+    params: WorkspaceInitParams,
+    nhp: string,
+    removeWorkspaceDirectoryOnFailure: boolean
+  ): Promise<void> {
+    const { projectPath, branchName, trunkBranch, workspacePath, initLogger, abortSignal } = params;
     const workspacePathArg = expandTildeForSSH(workspacePath);
-    let needsWorktreeCheckout = true;
+    let attemptedWorktreeAdd = false;
+    let worktreeCreated = false;
 
     try {
-      const dirCheck = await execBuffered(this, `test -d ${workspacePathArg}`, {
-        cwd: "/tmp",
-        timeout: 10,
-        abortSignal,
-      });
-      if (dirCheck.exitCode === 0) {
-        const gitCheck = await execBuffered(
-          this,
-          `git -C ${workspacePathArg} rev-parse --is-inside-work-tree`,
-          {
-            cwd: "/tmp",
-            timeout: 20,
-            abortSignal,
-          }
-        );
-        needsWorktreeCheckout = gitCheck.exitCode !== 0;
-      }
-    } catch {
-      // Default to materializing the workspace on unexpected errors.
-      needsWorktreeCheckout = true;
-    }
-
-    if (needsWorktreeCheckout) {
       // SSH workspace initialization owns repo materialization: it syncs the project into
       // the shared base repo, checks out the worktree, and then materializes submodules
       // before repo-controlled init hooks run.
@@ -2749,6 +2708,7 @@ export class SSHRuntime extends RemoteRuntime {
       initLogger.logStep(`Creating worktree for branch: ${branchName}`);
       const worktreeCmd = `${nhp}git -C ${baseRepoPathArg} worktree add ${workspacePathArg} -B ${shescape.quote(branchName)} ${shescape.quote(newBranchBase)}`;
 
+      attemptedWorktreeAdd = true;
       const worktreeResult = await execBuffered(this, worktreeCmd, {
         cwd: "/tmp",
         timeout: 300,
@@ -2760,7 +2720,93 @@ export class SSHRuntime extends RemoteRuntime {
           `Failed to create worktree: ${worktreeResult.stderr || worktreeResult.stdout}`
         );
       }
+
+      worktreeCreated = true;
       initLogger.logStep("Worktree created successfully");
+    } catch (error) {
+      if (!worktreeCreated) {
+        // Cleanup belongs at the materialization boundary. After a worktree is
+        // created, later submodule or init-hook failures should preserve the
+        // usable checkout so the persisted workspace remains repairable.
+        await this.cleanupPartialWorkspaceState({
+          projectPath,
+          workspaceName: branchName,
+          workspacePath,
+          reason: `workspace materialization failed: ${getErrorMessage(error)}`,
+          trusted: params.trusted,
+          deleteWorkspaceBranch: attemptedWorktreeAdd,
+          removeWorkspaceDirectory: removeWorkspaceDirectoryOnFailure,
+        });
+      }
+      throw error;
+    }
+  }
+
+  private async prepareWorkspaceCheckout(params: WorkspaceInitParams, nhp: string): Promise<void> {
+    const { trunkBranch, workspacePath, initLogger, abortSignal, env } = params;
+
+    // STARTUP-PERF (warm fast-path): try to materialize the workspace in a
+    // single fused SSH command. See `tryWarmWorktreeAdd()` for the contract
+    // and miss reasons. When this succeeds, we skip the entire multi-call
+    // slow path (test-d → git-check → ensureBaseRepo → snapshot check →
+    // manifest check → refreshOrigin → fetchOrigin → resolveBundleTrunkRef →
+    // resolveFreshWorkspaceSourceBase → worktree-add), collapsing ~9 sequential
+    // SSH round-trips into one.
+    const warmHit = await this.tryWarmWorktreeAdd(params, nhp);
+    if (warmHit) {
+      // STARTUP-PERF: The warm SSH command already reported whether
+      // `.gitmodules` exists in the freshly-materialized worktree, so we can
+      // skip the (otherwise unavoidable) probe-RTT inside
+      // `hasRuntimeGitmodules()` when the answer is "missing". On a typical
+      // single-package project this saves one full SSH round-trip on every
+      // warm workspace create.
+      if (warmHit.gitmodulesPresent) {
+        await syncRuntimeGitSubmodules({
+          runtime: this,
+          workspacePath,
+          initLogger,
+          abortSignal,
+          env,
+          trusted: params.trusted,
+        });
+      }
+      return;
+    }
+
+    // If the workspace directory already exists and contains a git repo (e.g. forked from
+    // another SSH workspace via worktree add or legacy cp), skip the expensive sync step.
+    const workspacePathArg = expandTildeForSSH(workspacePath);
+    let needsWorktreeCheckout = true;
+    let workspacePathWasMissing = false;
+
+    try {
+      const dirCheck = await execBuffered(this, `test -d ${workspacePathArg}`, {
+        cwd: "/tmp",
+        timeout: 10,
+        abortSignal,
+      });
+      workspacePathWasMissing = dirCheck.exitCode !== 0;
+      if (dirCheck.exitCode === 0) {
+        const gitCheck = await execBuffered(
+          this,
+          `git -C ${workspacePathArg} rev-parse --is-inside-work-tree`,
+          {
+            cwd: "/tmp",
+            timeout: 20,
+            abortSignal,
+          }
+        );
+        needsWorktreeCheckout = gitCheck.exitCode !== 0;
+      }
+    } catch {
+      // Default to materializing the workspace on unexpected errors, but do
+      // not later rm -rf a path whose pre-existing state we could not verify.
+      needsWorktreeCheckout = true;
+      workspacePathWasMissing = false;
+    }
+
+    if (needsWorktreeCheckout) {
+      await this.materializeFreshWorkspaceCheckout(params, nhp, workspacePathWasMissing);
     } else {
       initLogger.logStep("Remote workspace already contains a git repo; skipping sync");
 
@@ -3109,13 +3155,13 @@ export class SSHRuntime extends RemoteRuntime {
         // `git worktree add` fully materialized the path. Still prune the base
         // repo and stale tmp packs so the invisible partial state cannot grow.
         if (force) {
-          await this.cleanupPartialWorkspaceState(
+          await this.cleanupPartialWorkspaceState({
             projectPath,
             workspaceName,
-            deletedPath,
-            "force delete missing workspace path",
-            trusted
-          );
+            workspacePath: deletedPath,
+            reason: "force delete missing workspace path",
+            trusted,
+          });
         }
         return { success: true, deletedPath };
       }
@@ -3226,14 +3272,15 @@ export class SSHRuntime extends RemoteRuntime {
       }
 
       if (force) {
-        await this.cleanupPartialWorkspaceState(
+        await this.cleanupPartialWorkspaceState({
           projectPath,
           workspaceName,
-          deletedPath,
-          "force delete post-cleanup",
+          workspacePath: deletedPath,
+          reason: "force delete post-cleanup",
           trusted,
-          false
-        );
+          deleteWorkspaceBranch: false,
+          removeWorkspaceDirectory: false,
+        });
       }
 
       return { success: true, deletedPath };

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -74,6 +74,7 @@ const BASE_REPO_PROMISOR_CLEANUP_TIMEOUT_SECONDS = 10;
 const BASE_REPO_TMP_PACK_MIN_AGE_MINUTES = 30;
 const BASE_REPO_TMP_PACK_SWEEP_TIMEOUT_SECONDS = 10;
 const BASE_REPO_MIN_FREE_BYTES = 5 * 1024 * 1024 * 1024;
+const BASE_REPO_MIN_FREE_KIB = BASE_REPO_MIN_FREE_BYTES / 1024;
 /** Git config keys that announce a bare repo as a promisor remote to
  *  `repo_has_promisor_remote()`. Unsetting all three is what makes
  *  receive-pack's `check_connected()` skip the buggy partial-clone fast
@@ -2566,7 +2567,11 @@ export class SSHRuntime extends RemoteRuntime {
     //      the rare case where the user changed origin between syncs. Both
     //      `remote set-url` and the fallback `remote add` are idempotent and
     //      cost no network I/O.
-    //   2. Best-effort `git fetch origin +refs/heads/<trunk>:refs/remotes/origin/<trunk>`.
+    //   2. Gate the best-effort remote fetch on the same free-space invariant
+    //      as the slow-path origin prefetch. The warm path is deliberately
+    //      fused into one SSH command, so the headroom check lives beside the
+    //      fetch instead of adding a separate probe round-trip.
+    //   3. Best-effort `git fetch origin +refs/heads/<trunk>:refs/remotes/origin/<trunk>`.
     //      This mirrors `fetchOriginTrunk()` in the slow path: failure is
     //      tolerated (logged via `fo=0`) and the worktree falls back to the
     //      bundle ref, exactly like `resolveFreshWorkspaceSourceBase()` does
@@ -2576,7 +2581,9 @@ export class SSHRuntime extends RemoteRuntime {
     const originPreamble = originUrlArg
       ? [
           `git -C ${baseRepoPathArg} remote set-url origin ${originUrlArg} 2>/dev/null || git -C ${baseRepoPathArg} remote add origin ${originUrlArg} >/dev/null 2>&1 || true`,
-          `if ${nhp}git -C ${baseRepoPathArg} fetch --quiet origin ${trunkRefspecArg} 2>/dev/null; then fo=1; else fo=0; fi`,
+          `free_kib=$(df -Pk ${baseRepoPathArg} 2>/dev/null | awk 'NR==2 {print $4}')`,
+          `case "$free_kib" in ""|*[!0-9]*) can_fetch_origin=1 ;; *) [ "$free_kib" -ge ${BASE_REPO_MIN_FREE_KIB} ] && can_fetch_origin=1 || can_fetch_origin=0 ;; esac`,
+          `if [ "$can_fetch_origin" = "0" ]; then echo WARM_ORIGIN_FETCH_SKIPPED_LOW_DISK:$free_kib; fo=0; elif ${nhp}git -C ${baseRepoPathArg} fetch --quiet origin ${trunkRefspecArg} 2>/dev/null; then fo=1; else fo=0; fi`,
         ]
       : ["fo=0"];
 
@@ -2626,6 +2633,14 @@ export class SSHRuntime extends RemoteRuntime {
     }
 
     const stdout = result.stdout;
+    const lowDiskFetchSkipMatch = /WARM_ORIGIN_FETCH_SKIPPED_LOW_DISK:(\d+)/.exec(stdout);
+    if (lowDiskFetchSkipMatch) {
+      const freeBytes = Number.parseInt(lowDiskFetchSkipMatch[1], 10) * 1024;
+      initLogger.logStep(
+        `Skipping warm fast-path origin fetch: ${formatBytes(freeBytes)} free, need at least ${formatBytes(BASE_REPO_MIN_FREE_BYTES)}`
+      );
+    }
+
     if (!stdout.includes("WARM_OK")) {
       const missMatch = /WARM_MISS:(\S+)/.exec(stdout);
       const reason = missMatch ? missMatch[1] : "unknown";

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -2857,6 +2857,43 @@ export class SSHRuntime extends RemoteRuntime {
     });
   }
 
+  private async resolveRemoteGitCommonDir(
+    repoPath: string,
+    abortSignal?: AbortSignal
+  ): Promise<string> {
+    try {
+      const result = await execBuffered(
+        this,
+        `git -C ${this.quoteForRemote(repoPath)} rev-parse --path-format=absolute --git-common-dir`,
+        { cwd: "/tmp", timeout: 10, abortSignal }
+      );
+      const commonDir = result.stdout.trim();
+      if (result.exitCode === 0 && commonDir.length > 0) {
+        return commonDir;
+      }
+    } catch {
+      // Fall back to the requested repo path. The disk probe is best-effort and
+      // should not make origin freshness mandatory when Git metadata is odd.
+    }
+
+    return repoPath;
+  }
+
+  private async hasGitObjectStoreHeadroomForBestEffortTransfer(
+    repoPath: string,
+    operationName: string,
+    initLogger: InitLogger,
+    abortSignal?: AbortSignal
+  ): Promise<boolean> {
+    const gitCommonDir = await this.resolveRemoteGitCommonDir(repoPath, abortSignal);
+    return this.hasRemoteDiskHeadroomForBestEffortTransfer(
+      this.quoteForRemote(gitCommonDir),
+      operationName,
+      initLogger,
+      abortSignal
+    );
+  }
+
   /**
    * Fetch trunk branch from origin into its remote-tracking ref before checkout.
    * Returns true if fetch succeeded (origin is available for branching).
@@ -2868,6 +2905,18 @@ export class SSHRuntime extends RemoteRuntime {
     abortSignal?: AbortSignal,
     nhp = ""
   ): Promise<boolean> {
+    const operationName = `origin/${trunkBranch} fetch`;
+    if (
+      !(await this.hasGitObjectStoreHeadroomForBestEffortTransfer(
+        workspacePath,
+        operationName,
+        initLogger,
+        abortSignal
+      ))
+    ) {
+      return false;
+    }
+
     try {
       initLogger.logStep(`Fetching latest from origin/${trunkBranch}...`);
 

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -39,6 +39,7 @@ import { expandTildeForSSH, cdCommandForSSH } from "./tildeExpansion";
 import { sleepWithAbort } from "@/node/utils/abort";
 import { execBuffered } from "@/node/utils/runtime/helpers";
 import { getErrorMessage } from "@/common/utils/errors";
+import { formatBytes } from "@/common/utils/formatBytes";
 import {
   type SSHRuntimeConfig,
   getControlPath,
@@ -70,6 +71,9 @@ const BUNDLE_REF_PREFIX = "refs/mux-bundle/";
 const BASE_REPO_CONFIG_LOCK_RETRY_DELAYS_MS = [50, 100, 200];
 const BASE_REPO_HEALTH_PROBE_TIMEOUT_SECONDS = 10;
 const BASE_REPO_PROMISOR_CLEANUP_TIMEOUT_SECONDS = 10;
+const BASE_REPO_TMP_PACK_MIN_AGE_MINUTES = 30;
+const BASE_REPO_TMP_PACK_SWEEP_TIMEOUT_SECONDS = 10;
+const BASE_REPO_MIN_FREE_BYTES = 5 * 1024 * 1024 * 1024;
 /** Git config keys that announce a bare repo as a promisor remote to
  *  `repo_has_promisor_remote()`. Unsetting all three is what makes
  *  receive-pack's `check_connected()` skip the buggy partial-clone fast
@@ -89,7 +93,26 @@ const PROJECT_SYNC_RETRYABLE_ERRORS = [
   "Broken pipe",
   "EPIPE",
   "Command killed by signal",
+  "No space left on device",
+  "ENOSPC",
 ] as const;
+
+const PROTECTED_WORKSPACE_BRANCHES = ["main", "master", "trunk", "develop", "default"] as const;
+
+interface BaseRepoHealth {
+  packCount: number | null;
+  packBytes: number | null;
+  tmpPackCount: number;
+  tmpPackBytes: number;
+  staleTmpPackCount: number;
+  staleTmpPackBytes: number;
+  freeBytes: number | null;
+}
+
+interface BaseRepoTmpCleanupStats {
+  removedCount: number;
+  removedBytes: number;
+}
 
 const sharedProjectSyncTails = new Map<string, Promise<void>>();
 
@@ -151,6 +174,60 @@ function isGitConfigLockConflict(message: string): boolean {
 function logSSHBackoffWait(initLogger: InitLogger, waitMs: number): void {
   const secs = Math.max(1, Math.ceil(waitMs / 1000));
   initLogger.logStep(`SSH unavailable; retrying in ${secs}s...`);
+}
+
+function parseNumber(value: string | undefined): number | null {
+  if (value === undefined || value.trim().length === 0) {
+    return null;
+  }
+  const parsed = Number.parseInt(value.trim(), 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseCountObjectsValue(stdout: string, key: string): number | null {
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`^${escapedKey}:\\s*(\\d+)\\s*$`, "m").exec(stdout);
+  return parseNumber(match?.[1]);
+}
+
+function parseHealthLabel(stdout: string, label: string): number | null {
+  const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`^${escapedLabel}=(\\d*)\\s*$`, "m").exec(stdout);
+  return parseNumber(match?.[1]);
+}
+
+function parseTmpCleanupStats(stdout: string): BaseRepoTmpCleanupStats {
+  let removedCount = 0;
+  let removedBytes = 0;
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const [rawBytes] = trimmed.split(/\s+/, 1);
+    const bytes = parseNumber(rawBytes) ?? 0;
+    removedCount += 1;
+    removedBytes += bytes;
+  }
+  return { removedCount, removedBytes };
+}
+
+function baseRepoHealthFields(health: BaseRepoHealth): Record<string, unknown> {
+  return {
+    packCount: health.packCount,
+    packBytes: health.packBytes,
+    tmpPackCount: health.tmpPackCount,
+    tmpPackBytes: health.tmpPackBytes,
+    staleTmpPackCount: health.staleTmpPackCount,
+    staleTmpPackBytes: health.staleTmpPackBytes,
+    freeBytes: health.freeBytes,
+  };
+}
+
+function isProtectedWorkspaceBranch(branchName: string): boolean {
+  return PROTECTED_WORKSPACE_BRANCHES.includes(
+    branchName as (typeof PROTECTED_WORKSPACE_BRANCHES)[number]
+  );
 }
 
 async function pipeReadableToWebWritable(
@@ -512,22 +589,189 @@ export class SSHRuntime extends RemoteRuntime {
   private async probeBaseRepoHealth(
     baseRepoPathArg: string,
     abortSignal?: AbortSignal
-  ): Promise<{ packCount: number | null }> {
-    const result = await execBuffered(this, `git -C ${baseRepoPathArg} count-objects -v`, {
-      cwd: "/tmp",
-      timeout: BASE_REPO_HEALTH_PROBE_TIMEOUT_SECONDS,
-      abortSignal,
-    });
+  ): Promise<BaseRepoHealth> {
+    const tmpFindExpression = "\\( -name 'tmp_pack_*' -o -name 'tmp_idx_*' \\)";
+    const result = await execBuffered(
+      this,
+      [
+        `base=${baseRepoPathArg}`,
+        'pack_dir="$base/objects/pack"',
+        'git -C "$base" count-objects -v',
+        `tmp_stats=$(find "$pack_dir" -maxdepth 1 ${tmpFindExpression} -type f -exec du -sk {} + 2>/dev/null | awk 'BEGIN { count=0; bytes=0 } { count += 1; bytes += $1 * 1024 } END { printf "%d %d", count, bytes }')`,
+        `stale_tmp_stats=$(find "$pack_dir" -maxdepth 1 ${tmpFindExpression} -type f -mmin +${BASE_REPO_TMP_PACK_MIN_AGE_MINUTES} -exec du -sk {} + 2>/dev/null | awk 'BEGIN { count=0; bytes=0 } { count += 1; bytes += $1 * 1024 } END { printf "%d %d", count, bytes }')`,
+        'free_bytes=$(df -Pk "$base" 2>/dev/null | awk \'NR==2 { printf "%d", $4 * 1024 }\')',
+        "printf 'MUX_HEALTH_TMP_PACK_COUNT=%s\\n' \"$(printf '%s' \"$tmp_stats\" | awk '{ print $1 + 0 }')\"",
+        "printf 'MUX_HEALTH_TMP_PACK_BYTES=%s\\n' \"$(printf '%s' \"$tmp_stats\" | awk '{ print $2 + 0 }')\"",
+        "printf 'MUX_HEALTH_STALE_TMP_PACK_COUNT=%s\\n' \"$(printf '%s' \"$stale_tmp_stats\" | awk '{ print $1 + 0 }')\"",
+        "printf 'MUX_HEALTH_STALE_TMP_PACK_BYTES=%s\\n' \"$(printf '%s' \"$stale_tmp_stats\" | awk '{ print $2 + 0 }')\"",
+        "printf 'MUX_HEALTH_FREE_BYTES=%s\\n' \"$free_bytes\"",
+      ].join("\n"),
+      {
+        cwd: "/tmp",
+        timeout: BASE_REPO_HEALTH_PROBE_TIMEOUT_SECONDS,
+        abortSignal,
+      }
+    );
     if (result.exitCode !== 0) {
       throw new Error(
         `Failed to inspect shared base repository health: ${result.stderr || result.stdout}`
       );
     }
 
-    const packCountMatch = /^packs:\s*(\d+)\s*$/m.exec(result.stdout);
+    const sizePackKiB = parseCountObjectsValue(result.stdout, "size-pack");
     return {
-      packCount: packCountMatch ? Number.parseInt(packCountMatch[1], 10) : null,
+      packCount: parseCountObjectsValue(result.stdout, "packs"),
+      packBytes: sizePackKiB == null ? null : sizePackKiB * 1024,
+      tmpPackCount: parseHealthLabel(result.stdout, "MUX_HEALTH_TMP_PACK_COUNT") ?? 0,
+      tmpPackBytes: parseHealthLabel(result.stdout, "MUX_HEALTH_TMP_PACK_BYTES") ?? 0,
+      staleTmpPackCount: parseHealthLabel(result.stdout, "MUX_HEALTH_STALE_TMP_PACK_COUNT") ?? 0,
+      staleTmpPackBytes: parseHealthLabel(result.stdout, "MUX_HEALTH_STALE_TMP_PACK_BYTES") ?? 0,
+      freeBytes: parseHealthLabel(result.stdout, "MUX_HEALTH_FREE_BYTES"),
     };
+  }
+
+  private async probeBaseRepoHealthForLogging(
+    baseRepoPathArg: string,
+    context: string,
+    abortSignal?: AbortSignal
+  ): Promise<BaseRepoHealth | null> {
+    try {
+      return await this.probeBaseRepoHealth(baseRepoPathArg, abortSignal);
+    } catch (error) {
+      const message = getErrorMessage(error);
+      if (abortSignal?.aborted || message === "Operation aborted") {
+        throw error instanceof Error ? error : new Error(message);
+      }
+      log.warn(`Shared base repository health probe failed during ${context}: ${message}`);
+      return null;
+    }
+  }
+
+  private logBaseRepoHealth(context: string, health: BaseRepoHealth): void {
+    log.info(`Shared base repository health (${context})`, baseRepoHealthFields(health));
+  }
+
+  private shouldRepairBaseRepoForSync(health: BaseRepoHealth): boolean {
+    return (
+      (health.packCount != null && health.packCount >= BASE_REPO_FRAGMENTED_PACK_THRESHOLD) ||
+      health.staleTmpPackCount > 0
+    );
+  }
+
+  private describeBaseRepoMaintenanceReason(health: BaseRepoHealth): string {
+    const reasons: string[] = [];
+    if (health.packCount != null && health.packCount >= BASE_REPO_FRAGMENTED_PACK_THRESHOLD) {
+      const packFileLabel = health.packCount === 1 ? "pack file" : "pack files";
+      reasons.push(`${health.packCount} ${packFileLabel}`);
+    }
+    if (health.staleTmpPackCount > 0) {
+      const tmpFileLabel = health.staleTmpPackCount === 1 ? "stale tmp pack" : "stale tmp packs";
+      reasons.push(
+        `${health.staleTmpPackCount} ${tmpFileLabel} (${formatBytes(health.staleTmpPackBytes)})`
+      );
+    }
+    return reasons.join(", ");
+  }
+
+  protected async sweepStaleBaseRepoTmpPacks(
+    baseRepoPathArg: string,
+    cleanupContext: string,
+    abortSignal?: AbortSignal
+  ): Promise<BaseRepoTmpCleanupStats> {
+    if (abortSignal?.aborted) {
+      throw new Error("Operation aborted");
+    }
+
+    const packDirArg = `${baseRepoPathArg}/objects/pack`;
+    const tmpFindExpression = "\\( -name 'tmp_pack_*' -o -name 'tmp_idx_*' \\)";
+    const cleanupResult = await execBuffered(
+      this,
+      [
+        `pack_dir=${packDirArg}`,
+        `find "$pack_dir" -maxdepth 1 ${tmpFindExpression} -type f -mmin +${BASE_REPO_TMP_PACK_MIN_AGE_MINUTES} -print 2>/dev/null | while IFS= read -r file; do`,
+        '  bytes=$(du -sk "$file" 2>/dev/null | awk \'{ printf "%d", $1 * 1024 }\')',
+        '  printf \'%s\\t%s\\n\' "${bytes:-0}" "$file"',
+        '  rm -f -- "$file" 2>/dev/null || true',
+        "done",
+      ].join("\n"),
+      {
+        cwd: "/tmp",
+        timeout: BASE_REPO_TMP_PACK_SWEEP_TIMEOUT_SECONDS,
+        abortSignal,
+      }
+    );
+
+    if (cleanupResult.exitCode !== 0) {
+      log.warn(
+        `Stale tmp-pack cleanup exited ${cleanupResult.exitCode} during ${cleanupContext}: ${cleanupResult.stderr || cleanupResult.stdout}`
+      );
+    }
+
+    const stats = parseTmpCleanupStats(cleanupResult.stdout);
+    if (stats.removedCount > 0) {
+      log.info("Removed stale shared base repository tmp-pack files", {
+        context: cleanupContext,
+        removedCount: stats.removedCount,
+        removedBytes: stats.removedBytes,
+        minAgeMinutes: BASE_REPO_TMP_PACK_MIN_AGE_MINUTES,
+      });
+    }
+    return stats;
+  }
+
+  private async checkRemoteDiskHeadroom(
+    baseRepoPathArg: string,
+    operationName: string,
+    abortSignal?: AbortSignal
+  ): Promise<
+    | { ok: true; health: BaseRepoHealth | null }
+    | { ok: false; message: string; health: BaseRepoHealth }
+  > {
+    const health = await this.probeBaseRepoHealthForLogging(
+      baseRepoPathArg,
+      `disk headroom check for ${operationName}`,
+      abortSignal
+    );
+    if (!health) {
+      return { ok: true, health: null };
+    }
+
+    this.logBaseRepoHealth(`before ${operationName}`, health);
+    if (health.freeBytes == null || health.freeBytes >= BASE_REPO_MIN_FREE_BYTES) {
+      return { ok: true, health };
+    }
+
+    const message =
+      `Remote disk headroom too low before ${operationName}: ` +
+      `${formatBytes(health.freeBytes)} free, need at least ${formatBytes(BASE_REPO_MIN_FREE_BYTES)}. ` +
+      "Clean remote disk space or stale .mux-base.git tmp packs before retrying.";
+    log.warn(message, baseRepoHealthFields(health));
+    return { ok: false, message, health };
+  }
+
+  private async ensureRemoteDiskHeadroom(
+    baseRepoPathArg: string,
+    operationName: string,
+    abortSignal?: AbortSignal
+  ): Promise<void> {
+    const result = await this.checkRemoteDiskHeadroom(baseRepoPathArg, operationName, abortSignal);
+    if (!result.ok) {
+      throw new Error(result.message);
+    }
+  }
+
+  private async hasRemoteDiskHeadroomForBestEffortTransfer(
+    baseRepoPathArg: string,
+    operationName: string,
+    initLogger: InitLogger,
+    abortSignal?: AbortSignal
+  ): Promise<boolean> {
+    const result = await this.checkRemoteDiskHeadroom(baseRepoPathArg, operationName, abortSignal);
+    if (result.ok) {
+      return true;
+    }
+    initLogger.logStep(`Skipping ${operationName}: ${result.message}`);
+    return false;
   }
 
   /**
@@ -615,7 +859,8 @@ export class SSHRuntime extends RemoteRuntime {
   protected async repairBaseRepoForSync(
     baseRepoPathArg: string,
     repairContext: string,
-    abortSignal?: AbortSignal
+    abortSignal?: AbortSignal,
+    knownBeforeHealth?: BaseRepoHealth
   ): Promise<void> {
     if (abortSignal?.aborted) {
       throw new Error("Operation aborted");
@@ -623,11 +868,31 @@ export class SSHRuntime extends RemoteRuntime {
 
     log.info(repairContext);
 
+    const beforeHealth =
+      knownBeforeHealth ??
+      (await this.probeBaseRepoHealthForLogging(
+        baseRepoPathArg,
+        `${repairContext} preflight`,
+        abortSignal
+      ));
+    if (beforeHealth) {
+      this.logBaseRepoHealth(`${repairContext} (before maintenance)`, beforeHealth);
+    }
+
     // Strip partial-clone config before the on-disk cleanup so that even
     // if `git gc` fails, subsequent pushes no longer route through the
     // buggy `check_connected()` promisor fast path. See the doc comment
     // on stripBaseRepoPromisorConfig for the full upstream-bug story.
     await this.stripBaseRepoPromisorConfig(baseRepoPathArg, abortSignal);
+
+    // Product cleanup must never blindly delete Git's active temp files.
+    // The age gate turns the incident's manual tmp_pack_* cleanup into a
+    // safe self-healing path for orphaned files left by killed fetch/push/index-pack.
+    const tmpCleanupStats = await this.sweepStaleBaseRepoTmpPacks(
+      baseRepoPathArg,
+      repairContext,
+      abortSignal
+    );
 
     const promisorPackDirArg = `${baseRepoPathArg}/objects/pack`;
     const promisorCleanupResult = await execBuffered(
@@ -659,6 +924,21 @@ export class SSHRuntime extends RemoteRuntime {
         `Remote git gc exited ${gcResult.exitCode} during base repo maintenance: ${gcResult.stderr || gcResult.stdout}`
       );
     }
+
+    const afterHealth = await this.probeBaseRepoHealthForLogging(
+      baseRepoPathArg,
+      `${repairContext} postflight`,
+      abortSignal
+    );
+    if (afterHealth) {
+      log.info("Shared base repository maintenance complete", {
+        context: repairContext,
+        reclaimedTmpBytes: tmpCleanupStats.removedBytes,
+        removedTmpPackCount: tmpCleanupStats.removedCount,
+        removedPromisorCount,
+        ...baseRepoHealthFields(afterHealth),
+      });
+    }
   }
 
   protected async ensureHealthyBaseRepoForSync(
@@ -671,19 +951,21 @@ export class SSHRuntime extends RemoteRuntime {
     }
 
     try {
-      const { packCount } = await this.probeBaseRepoHealth(baseRepoPathArg, abortSignal);
-      if (packCount == null || packCount < BASE_REPO_FRAGMENTED_PACK_THRESHOLD) {
+      const health = await this.probeBaseRepoHealth(baseRepoPathArg, abortSignal);
+      this.logBaseRepoHealth("pre-sync", health);
+      if (!this.shouldRepairBaseRepoForSync(health)) {
         return;
       }
 
-      const packFileLabel = packCount === 1 ? "pack file" : "pack files";
+      const reason = this.describeBaseRepoMaintenanceReason(health);
       initLogger.logStep(
-        `Shared base repository is fragmented (${packCount} ${packFileLabel}); running maintenance before sync...`
+        `Shared base repository needs maintenance (${reason}); running maintenance before sync...`
       );
       await this.repairBaseRepoForSync(
         baseRepoPathArg,
-        `Running shared base repository maintenance before sync (${packCount} ${packFileLabel})`,
-        abortSignal
+        `Running shared base repository maintenance before sync (${reason})`,
+        abortSignal,
+        health
       );
     } catch (healthError) {
       const healthErrorMsg = getErrorMessage(healthError);
@@ -707,7 +989,7 @@ export class SSHRuntime extends RemoteRuntime {
     try {
       await this.repairBaseRepoForSync(
         baseRepoPathArg,
-        `Running remote promisor cleanup and git gc before retrying sync push (attempt ${attempt + 1}/${maxAttempts})`,
+        `Running remote base repo cleanup before retrying sync push (attempt ${attempt + 1}/${maxAttempts})`,
         abortSignal
       );
     } catch (cleanupError) {
@@ -1267,6 +1549,17 @@ export class SSHRuntime extends RemoteRuntime {
     // below has somewhere to pull from.
     await this.refreshBaseRepoOrigin(projectPath, baseRepoPathArg, initLogger, abortSignal);
 
+    if (
+      !(await this.hasRemoteDiskHeadroomForBestEffortTransfer(
+        baseRepoPathArg,
+        "remote origin prefetch",
+        initLogger,
+        abortSignal
+      ))
+    ) {
+      return { refreshedOrigin: false };
+    }
+
     try {
       initLogger.logStep("Pre-fetching from origin on remote host...");
       const result = await execBuffered(
@@ -1526,6 +1819,12 @@ export class SSHRuntime extends RemoteRuntime {
       );
     }
 
+    await this.ensureRemoteDiskHeadroom(
+      baseRepoPathArg,
+      "remote bundle upload/import",
+      abortSignal
+    );
+
     await this.transferBundleToRemote(projectPath, remoteBundlePath, initLogger, abortSignal);
 
     try {
@@ -1641,6 +1940,12 @@ export class SSHRuntime extends RemoteRuntime {
         `Failed to prepare remote snapshot directory: ${prepareSnapshotDir.stderr || prepareSnapshotDir.stdout}`
       );
     }
+
+    await this.ensureRemoteDiskHeadroom(
+      expandTildeForSSH(layout.baseRepoPath),
+      "remote git push sync",
+      abortSignal
+    );
 
     await this.transport.acquireConnection({
       abortSignal,
@@ -2050,6 +2355,90 @@ export class SSHRuntime extends RemoteRuntime {
     });
   }
 
+  async cleanupFailedInit(params: WorkspaceInitParams, reason: string): Promise<void> {
+    await this.cleanupPartialWorkspaceState(
+      params.projectPath,
+      params.branchName,
+      params.workspacePath,
+      reason,
+      params.trusted
+    );
+  }
+
+  protected async cleanupPartialWorkspaceState(
+    projectPath: string,
+    workspaceName: string,
+    workspacePath: string,
+    reason: string,
+    trusted?: boolean,
+    deleteWorkspaceBranch = true
+  ): Promise<void> {
+    const layout = this.getProjectLayout(projectPath);
+    const baseRepoPathArg = expandTildeForSSH(layout.baseRepoPath);
+    const workspacePathArg = expandTildeForSSH(workspacePath);
+    const nhp = gitNoHooksPrefix(trusted);
+    const branchCleanup =
+      !deleteWorkspaceBranch || isProtectedWorkspaceBranch(workspaceName)
+        ? "true"
+        : `${nhp}git -C ${baseRepoPathArg} branch -D -- ${shescape.quote(workspaceName)} 2>/dev/null || true`;
+
+    log.info("Cleaning partial SSH workspace state", {
+      projectPath,
+      workspaceName,
+      workspacePath,
+      reason,
+    });
+
+    try {
+      await this.sweepStaleBaseRepoTmpPacks(
+        baseRepoPathArg,
+        `partial workspace cleanup (${reason})`
+      );
+    } catch (error) {
+      log.warn("Partial SSH workspace tmp-pack cleanup failed", {
+        projectPath,
+        workspaceName,
+        reason,
+        error: getErrorMessage(error),
+      });
+    }
+
+    try {
+      const cleanupResult = await execBuffered(
+        this,
+        [
+          `if test -d ${baseRepoPathArg}; then`,
+          `  ${nhp}git -C ${baseRepoPathArg} worktree prune 2>/dev/null || true`,
+          `  ${branchCleanup}`,
+          "fi",
+          // SAFETY: workspacePath is the exact runtime-computed directory for this workspace.
+          // Failed init/cancel cleanup must remove partial materialization so a retry starts cleanly.
+          `rm -rf ${workspacePathArg}`,
+        ].join("\n"),
+        { cwd: "/tmp", timeout: 30 }
+      );
+
+      if (cleanupResult.exitCode !== 0) {
+        log.warn("Partial SSH workspace cleanup exited non-zero", {
+          projectPath,
+          workspaceName,
+          workspacePath,
+          reason,
+          exitCode: cleanupResult.exitCode,
+          output: cleanupResult.stderr || cleanupResult.stdout,
+        });
+      }
+    } catch (error) {
+      log.warn("Partial SSH workspace cleanup failed", {
+        projectPath,
+        workspaceName,
+        workspacePath,
+        reason,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+
   /**
    * Try to create the workspace via a single fused SSH command (warm fast-path).
    *
@@ -2226,6 +2615,15 @@ export class SSHRuntime extends RemoteRuntime {
     if (!stdout.includes("WARM_OK")) {
       const missMatch = /WARM_MISS:(\S+)/.exec(stdout);
       const reason = missMatch ? missMatch[1] : "unknown";
+      if (reason === "worktree-add-failed") {
+        await this.cleanupPartialWorkspaceState(
+          projectPath,
+          branchName,
+          workspacePath,
+          "warm fast-path worktree add failed",
+          params.trusted
+        );
+      }
       initLogger.logStep(`Warm fast-path miss (${reason}); using slow path`);
       return null;
     }
@@ -2707,7 +3105,18 @@ export class SSHRuntime extends RemoteRuntime {
 
       // Handle check results
       if (checkExitCode === 3) {
-        // Directory doesn't exist - deletion is idempotent (success).
+        // Directory doesn't exist, but force-cancel may have aborted before
+        // `git worktree add` fully materialized the path. Still prune the base
+        // repo and stale tmp packs so the invisible partial state cannot grow.
+        if (force) {
+          await this.cleanupPartialWorkspaceState(
+            projectPath,
+            workspaceName,
+            deletedPath,
+            "force delete missing workspace path",
+            trusted
+          );
+        }
         return { success: true, deletedPath };
       }
 
@@ -2789,11 +3198,10 @@ export class SSHRuntime extends RemoteRuntime {
         // that re-forking with the same workspace name can use the fast worktree
         // path (git worktree add -b fails if the branch already exists).
         // Skip protected trunk branch names to avoid accidental deletion.
-        const PROTECTED_BRANCHES = ["main", "master", "trunk", "develop", "default"];
-        if (branchToDelete && !PROTECTED_BRANCHES.includes(branchToDelete)) {
+        if (branchToDelete && !isProtectedWorkspaceBranch(branchToDelete)) {
           await execBuffered(
             this,
-            `${nhp}git -C ${baseRepoPathArg} branch -D ${shescape.quote(branchToDelete)} 2>/dev/null || true`,
+            `${nhp}git -C ${baseRepoPathArg} branch -D -- ${shescape.quote(branchToDelete)} 2>/dev/null || true`,
             { cwd: "/tmp", timeout: 10 }
           ).catch(() => undefined);
         }
@@ -2815,6 +3223,17 @@ export class SSHRuntime extends RemoteRuntime {
             error: `Failed to delete directory: ${stderr.trim() || "Unknown error"}`,
           };
         }
+      }
+
+      if (force) {
+        await this.cleanupPartialWorkspaceState(
+          projectPath,
+          workspaceName,
+          deletedPath,
+          "force delete post-cleanup",
+          trusted,
+          false
+        );
       }
 
       return { success: true, deletedPath };

--- a/src/node/runtime/runtimeFactory.test.ts
+++ b/src/node/runtime/runtimeFactory.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "bun:test";
 import { isIncompatibleRuntimeConfig } from "@/common/utils/runtimeCompatibility";
-import { createRuntime, IncompatibleRuntimeError } from "./runtimeFactory";
+import { createRuntime, IncompatibleRuntimeError, runBackgroundInit } from "./runtimeFactory";
 import type { RuntimeConfig } from "@/common/types/runtime";
 import { LocalRuntime } from "./LocalRuntime";
 import { WorktreeRuntime } from "./WorktreeRuntime";
 import { CoderSSHRuntime } from "./CoderSSHRuntime";
+import type { Runtime } from "./Runtime";
 import type { CoderService } from "@/node/services/coderService";
+
+const noop = (): void => undefined;
 
 describe("isIncompatibleRuntimeConfig", () => {
   it("returns false for undefined config", () => {
@@ -84,6 +87,51 @@ describe("createRuntime", () => {
     const config = { type: "future-runtime" } as unknown as RuntimeConfig;
     expect(() => createRuntime(config)).toThrow(IncompatibleRuntimeError);
     expect(() => createRuntime(config)).toThrow(/newer version of mux/);
+  });
+});
+
+describe("runBackgroundInit", () => {
+  it("runs runtime cleanup when background init returns failure", async () => {
+    let cleanupReason: string | null = null;
+    let cleanupResolve: (() => void) | undefined;
+    const cleanupDone = new Promise<void>((resolve) => {
+      cleanupResolve = resolve;
+    });
+    const initLogger = {
+      logStep: noop,
+      logStdout: noop,
+      logStderr: noop,
+      logComplete: noop,
+    };
+    const runtime = {
+      initWorkspace: () => Promise.resolve({ success: false, error: "checkout failed" }),
+      cleanupFailedInit: (_params: unknown, reason: string) => {
+        cleanupReason = reason;
+        cleanupResolve?.();
+        return Promise.resolve();
+      },
+    };
+
+    runBackgroundInit(
+      runtime as unknown as Runtime,
+      {
+        projectPath: "/project",
+        branchName: "workspace-branch",
+        trunkBranch: "main",
+        workspacePath: "/remote/workspace",
+        initLogger,
+      },
+      "workspace-id"
+    );
+
+    await Promise.race([
+      cleanupDone,
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("cleanupFailedInit was not called")), 100)
+      ),
+    ]);
+
+    expect(cleanupReason ?? "").toBe("checkout failed");
   });
 });
 

--- a/src/node/runtime/runtimeFactory.test.ts
+++ b/src/node/runtime/runtimeFactory.test.ts
@@ -91,11 +91,11 @@ describe("createRuntime", () => {
 });
 
 describe("runBackgroundInit", () => {
-  it("runs runtime cleanup when background init returns failure", async () => {
-    let cleanupReason: string | null = null;
-    let cleanupResolve: (() => void) | undefined;
-    const cleanupDone = new Promise<void>((resolve) => {
-      cleanupResolve = resolve;
+  it("does not run runtime cleanup when init returns failure after materialization", async () => {
+    let cleanupCalled = false;
+    let loggedFailureResolve: (() => void) | undefined;
+    const loggedFailure = new Promise<void>((resolve) => {
+      loggedFailureResolve = resolve;
     });
     const initLogger = {
       logStep: noop,
@@ -104,10 +104,9 @@ describe("runBackgroundInit", () => {
       logComplete: noop,
     };
     const runtime = {
-      initWorkspace: () => Promise.resolve({ success: false, error: "checkout failed" }),
-      cleanupFailedInit: (_params: unknown, reason: string) => {
-        cleanupReason = reason;
-        cleanupResolve?.();
+      initWorkspace: () => Promise.resolve({ success: false, error: "submodule failed" }),
+      cleanupFailedInit: () => {
+        cleanupCalled = true;
         return Promise.resolve();
       },
     };
@@ -121,17 +120,23 @@ describe("runBackgroundInit", () => {
         workspacePath: "/remote/workspace",
         initLogger,
       },
-      "workspace-id"
+      "workspace-id",
+      {
+        error: () => {
+          loggedFailureResolve?.();
+        },
+      }
     );
 
     await Promise.race([
-      cleanupDone,
+      loggedFailure,
       new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("cleanupFailedInit was not called")), 100)
+        setTimeout(() => reject(new Error("init failure was not logged")), 100)
       ),
     ]);
+    await Promise.resolve();
 
-    expect(cleanupReason ?? "").toBe("checkout failed");
+    expect(cleanupCalled).toBe(false);
   });
 });
 

--- a/src/node/runtime/runtimeFactory.ts
+++ b/src/node/runtime/runtimeFactory.ts
@@ -57,12 +57,36 @@ export function runBackgroundInit(
   workspaceId: string,
   logger?: { error: (msg: string, ctx: object) => void }
 ): void {
-  void runFullInit(runtime, params).catch((error: unknown) => {
-    const errorMsg = getErrorMessage(error);
-    logger?.error(`Workspace init failed for ${workspaceId}:`, { error });
-    params.initLogger.logStderr(`Initialization failed: ${errorMsg}`);
-    params.initLogger.logComplete(-1);
-  });
+  const cleanupFailedInit = async (reason: string): Promise<void> => {
+    if (!runtime.cleanupFailedInit) {
+      return;
+    }
+    try {
+      params.initLogger.logStep("Cleaning up partial workspace initialization...");
+      await runtime.cleanupFailedInit(params, reason);
+    } catch (cleanupError: unknown) {
+      logger?.error(`Workspace init cleanup failed for ${workspaceId}:`, { error: cleanupError });
+      params.initLogger.logStderr(
+        `Initialization cleanup failed: ${getErrorMessage(cleanupError)}`
+      );
+    }
+  };
+
+  void runFullInit(runtime, params)
+    .then(async (result) => {
+      if (!result.success) {
+        const reason = result.error ?? "Initialization failed";
+        logger?.error(`Workspace init failed for ${workspaceId}:`, { error: reason });
+        await cleanupFailedInit(reason);
+      }
+    })
+    .catch(async (error: unknown) => {
+      const errorMsg = getErrorMessage(error);
+      logger?.error(`Workspace init failed for ${workspaceId}:`, { error });
+      params.initLogger.logStderr(`Initialization failed: ${errorMsg}`);
+      await cleanupFailedInit(errorMsg);
+      params.initLogger.logComplete(-1);
+    });
 }
 
 function shouldUseSSH2Runtime(): boolean {

--- a/src/node/runtime/runtimeFactory.ts
+++ b/src/node/runtime/runtimeFactory.ts
@@ -57,34 +57,17 @@ export function runBackgroundInit(
   workspaceId: string,
   logger?: { error: (msg: string, ctx: object) => void }
 ): void {
-  const cleanupFailedInit = async (reason: string): Promise<void> => {
-    if (!runtime.cleanupFailedInit) {
-      return;
-    }
-    try {
-      params.initLogger.logStep("Cleaning up partial workspace initialization...");
-      await runtime.cleanupFailedInit(params, reason);
-    } catch (cleanupError: unknown) {
-      logger?.error(`Workspace init cleanup failed for ${workspaceId}:`, { error: cleanupError });
-      params.initLogger.logStderr(
-        `Initialization cleanup failed: ${getErrorMessage(cleanupError)}`
-      );
-    }
-  };
-
   void runFullInit(runtime, params)
-    .then(async (result) => {
+    .then((result) => {
       if (!result.success) {
         const reason = result.error ?? "Initialization failed";
         logger?.error(`Workspace init failed for ${workspaceId}:`, { error: reason });
-        await cleanupFailedInit(reason);
       }
     })
-    .catch(async (error: unknown) => {
+    .catch((error: unknown) => {
       const errorMsg = getErrorMessage(error);
       logger?.error(`Workspace init failed for ${workspaceId}:`, { error });
       params.initLogger.logStderr(`Initialization failed: ${errorMsg}`);
-      await cleanupFailedInit(errorMsg);
       params.initLogger.logComplete(-1);
     });
 }


### PR DESCRIPTION
## Summary

This PR hardens the plain SSH runtime's shared `.mux-base.git` cache so interrupted remote git object transfers cannot silently accumulate unbounded temporary pack files. It adds explicit base-repo health telemetry, age-gated stale `tmp_pack_*` / `tmp_idx_*` cleanup, low-disk headroom checks before object transfer, and compensating cleanup when SSH workspace init is canceled or fails partway through.

## Background

The issue presented as a remote SSH workspace host filling its disk even though the user-facing workspaces were much smaller. The large directory was the SSH runtime's per-project shared bare repository, `<srcBaseDir>/<projectId>/.mux-base.git`, which backs all remote worktrees for a project. In the observed incident, `.mux-base.git` reached roughly 104G, with `objects/pack` containing thousands of Git temporary pack/index files: 2,234 `tmp_pack_*` files and 18 `tmp_idx_*` files totaling about 72G. `git count-objects -vH` emitted repeated `warning: garbage found: ./objects/pack/tmp_pack_*` messages, and the host filesystem reached 100% usage.

The failure mode was especially bad because those files are not normal refs, worktrees, or packs. They are partial files left behind by interrupted `git fetch`, `git push`, or `index-pack` work against the shared bare repo. Once the remote host is low or out of disk, subsequent sync attempts become more likely to fail and leave additional partial packs, creating a feedback loop. Canceling workspace creation can also contribute: init may already be syncing or adding a worktree when the user cancels, and the old cleanup path did not consistently prune base-repo state when the workspace directory was absent or only partially materialized.

This is intentionally fixed in `SSHRuntime`, not in the Coder-specific runtime. A plain SSH runtime pointed at `<name>.coder` uses `SSHRuntime` directly, and the Coder wrapper inherits the same SSH sync/init machinery for shared base-repo operations.

## Implementation

`SSHRuntime` now treats the shared bare repo as a managed cache with lightweight health signals. The health probe still reads Git's pack count, but now also reports pack bytes, temporary pack/index counts and bytes, stale temporary pack/index counts and bytes, and available filesystem bytes. These values are logged around maintenance and transfer decisions so future incidents have direct evidence in normal mux logs instead of requiring manual shell forensics.

Maintenance now handles stale temporary pack files explicitly. `repairBaseRepoForSync()` still strips legacy promisor config and removes `.promisor` marker files before `git gc`, but it now also sweeps `tmp_pack_*` and `tmp_idx_*` files older than a safety age gate. The age gate is important: active Git processes legitimately use these names while fetching or indexing, so Mux only removes stale files that are old enough to be orphaned by an interrupted transfer.

The proactive maintenance trigger now includes stale temporary packs, not just fragmented pack count. Previously the code only repaired when `packs >= 25`, which meant a repo could contain tens of gigabytes of orphaned `tmp_pack_*` files while still looking healthy if the normal pack count was low. Now stale tmp packs are a first-class health signal.

Object transfer paths now check remote disk headroom before doing more work that can write into `.mux-base.git`. Best-effort origin prefetch is skipped when headroom is low, while required git-push and bundle sync paths fail fast with a clear error before starting large transfers. This prevents the low-disk feedback loop from continuing to create more partial pack files.

Workspace init/cancel cleanup is now compensating and generic for SSH. `Runtime` exposes an optional `cleanupFailedInit()` hook, `runBackgroundInit()` invokes it when init fails, and `SSHRuntime` implements it by sweeping stale tmp packs, pruning worktrees, removing the failed workspace branch when safe, and deleting the partial workspace path. `SSHRuntime.deleteWorkspace(force=true)` also invokes this cleanup path even when the workspace directory is already missing, because that is exactly when hidden base-repo state could otherwise be left behind after a canceled create.

## Validation

The focused tests cover the new incident-specific behavior: stale temporary packs trigger maintenance even when pack count is low, tmp-pack cleanup runs before `git gc`, low disk headroom blocks git-push and bundle transfers before upload/push starts, partial SSH init cleanup prunes base-repo/worktree state, and background init failures invoke the runtime cleanup hook. I also ran the required local static checks before pushing.

## Risks

The main risk is deleting a Git temporary pack that is still active. The implementation mitigates that by only deleting `tmp_pack_*` / `tmp_idx_*` files older than the configured safety window, and by limiting this cleanup to maintenance/cancel/failure paths instead of sweeping on every command. Required transfer paths fail fast on low headroom rather than attempting risky cleanup of young files.

Another risk is cleanup removing a useful branch after a failed init. The cleanup only targets the workspace branch name and skips protected trunk-like names. Normal force deletion after an existing worktree was successfully removed prunes worktree metadata and stale tmp packs but does not delete the branch a second time.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$N/A`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=N/A -->
