### PR TITLE
🤖 ci: add optional coder-agents-review gate

### DIFF
--- a/.mux/skills/pull-requests/SKILL.md
+++ b/.mux/skills/pull-requests/SKILL.md
@@ -84,6 +84,18 @@ When a PR exists, stay in this loop until it is fully ready:
 4. Run `./scripts/wait_pr_ready.sh <pr_number>`.
 5. If Codex or checks fail, fix locally, push, and repeat.
 
+## Coder Agents Review Workflow
+
+When `/coder-agents-review` is used or the `coder-agents-review` bot has participated:
+
+1. Address each substantive finding.
+2. Reply to the bot before resolving threads: either inline on each finding or with a PR comment that explicitly lists the finding IDs and your response.
+3. Resolve addressed review threads.
+4. Re-request review with `/coder-agents-review`.
+5. Run `./scripts/wait_pr_ready.sh <pr_number>`.
+
+Do not silently resolve `coder-agents-review` threads. The bot treats resolved-but-unanswered findings as blocked review rounds.
+
 ## PR Title Conventions
 
 - Title prefixes: `perf|refactor|fix|feat|ci|tests|bench`

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -65,7 +65,7 @@ Core workflow:
 3. `agent-browser click @e1` / `fill @e2 "text"` - Interact using refs
 4. Re-snapshot after page changes
 
-## PR Workflow (Codex)
+## PR Workflow
 
 - When checking PR readiness, audit **all** PR reviews, review comments, and issue comments from every reviewer/bot (including `coder-agents-review`), not just Codex; address or explicitly resolve them before declaring readiness.
 - If a PR has `coder-agents-review` feedback, address it and reply before resolving: either reply inline on each finding or leave a PR comment that explicitly lists each finding and your response. Do not silently resolve those threads.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -68,6 +68,7 @@ Core workflow:
 ## PR Workflow (Codex)
 
 - When checking PR readiness, audit **all** PR reviews, review comments, and issue comments from every reviewer/bot (including `coder-agents-review`), not just Codex; address or explicitly resolve them before declaring readiness.
+- If a PR has `coder-agents-review` feedback, address it and reply before resolving: either reply inline on each finding or leave a PR comment that explicitly lists each finding and your response. Do not silently resolve those threads.
 - If a PR has Codex review comments, address + resolve them, then re-request review by commenting `@codex review` on the PR.
 - Prefer `gh` CLI for GitHub interactions over manual web/curl flows.
 

--- a/scripts/check_coder_agents_review_comments.sh
+++ b/scripts/check_coder_agents_review_comments.sh
@@ -23,32 +23,6 @@ source "$SCRIPT_DIR/lib/coder_agents_review.sh"
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
 UNRESOLVED=""
 
-resolve_repo_context() {
-  if [[ -n "${MUX_GH_OWNER:-}" || -n "${MUX_GH_REPO:-}" ]]; then
-    if [[ -z "${MUX_GH_OWNER:-}" || -z "${MUX_GH_REPO:-}" ]]; then
-      echo "❌ assertion failed: MUX_GH_OWNER and MUX_GH_REPO must both be set when one is provided" >&2
-      return 1
-    fi
-
-    OWNER="$MUX_GH_OWNER"
-    REPO="$MUX_GH_REPO"
-  else
-    local repo_info
-    if ! repo_info=$(gh repo view --json owner,name --jq '{owner: .owner.login, name: .name}'); then
-      echo "❌ Failed to resolve repository owner/name via 'gh repo view'." >&2
-      return 1
-    fi
-
-    OWNER=$(echo "$repo_info" | jq -r '.owner // empty')
-    REPO=$(echo "$repo_info" | jq -r '.name // empty')
-  fi
-
-  if [[ -z "$OWNER" || -z "$REPO" ]]; then
-    echo "❌ assertion failed: owner/repo must be non-empty" >&2
-    return 1
-  fi
-}
-
 append_unresolved_records() {
   local records="$1"
 
@@ -61,38 +35,6 @@ append_unresolved_records() {
   fi
 
   UNRESOLVED+="$records"
-}
-
-MAX_ATTEMPTS=5
-BACKOFF_SECS=2
-
-graphql_with_retries() {
-  local query="$1"
-  local cursor="$2"
-  local attempt
-  local backoff="$BACKOFF_SECS"
-  local response
-
-  for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
-    if response=$(gh api graphql \
-      -f query="$query" \
-      -F owner="$OWNER" \
-      -F repo="$REPO" \
-      -F pr="$PR_NUMBER" \
-      -F cursor="$cursor"); then
-      printf '%s\n' "$response"
-      return 0
-    fi
-
-    if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
-      echo "❌ GraphQL query failed after ${MAX_ATTEMPTS} attempts" >&2
-      return 1
-    fi
-
-    echo "⚠️ GraphQL query failed (attempt ${attempt}/${MAX_ATTEMPTS}); retrying in ${backoff}s..." >&2
-    sleep "$backoff"
-    backoff=$((backoff * 2))
-  done
 }
 
 fetch_unresolved_via_api() {

--- a/scripts/check_coder_agents_review_comments.sh
+++ b/scripts/check_coder_agents_review_comments.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Check for unresolved coder-agents-review review comments.
+# Check for unresolved review comments from coder-agents-review.
 # Usage: ./scripts/check_coder_agents_review_comments.sh <pr_number>
 # Exits 0 if all bot-authored review threads are resolved, 1 otherwise.
 
@@ -119,9 +119,7 @@ if [ -n "$UNRESOLVED" ]; then
   coder_agents_print_unresolved_threads "$UNRESOLVED"
   echo ""
 
-  VIEW_OWNER="${OWNER:-${MUX_GH_OWNER:-coder}}"
-  VIEW_REPO="${REPO:-${MUX_GH_REPO:-mux}}"
-  echo "View PR: https://github.com/${VIEW_OWNER}/${VIEW_REPO}/pull/$PR_NUMBER"
+  echo "View PR: https://github.com/${OWNER}/${REPO}/pull/$PR_NUMBER"
   exit 1
 fi
 

--- a/scripts/check_coder_agents_review_comments.sh
+++ b/scripts/check_coder_agents_review_comments.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Check for unresolved coder-agents-review review comments.
+# Usage: ./scripts/check_coder_agents_review_comments.sh <pr_number>
+# Exits 0 if all bot-authored review threads are resolved, 1 otherwise.
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <pr_number>" >&2
+  exit 1
+fi
+
+PR_NUMBER="$1"
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "❌ PR number must be numeric. Got: '$PR_NUMBER'" >&2
+  exit 1
+fi
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=./lib/coder_agents_review.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/coder_agents_review.sh"
+BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
+UNRESOLVED=""
+
+resolve_repo_context() {
+  if [[ -n "${MUX_GH_OWNER:-}" || -n "${MUX_GH_REPO:-}" ]]; then
+    if [[ -z "${MUX_GH_OWNER:-}" || -z "${MUX_GH_REPO:-}" ]]; then
+      echo "❌ assertion failed: MUX_GH_OWNER and MUX_GH_REPO must both be set when one is provided" >&2
+      return 1
+    fi
+
+    OWNER="$MUX_GH_OWNER"
+    REPO="$MUX_GH_REPO"
+  else
+    local repo_info
+    if ! repo_info=$(gh repo view --json owner,name --jq '{owner: .owner.login, name: .name}'); then
+      echo "❌ Failed to resolve repository owner/name via 'gh repo view'." >&2
+      return 1
+    fi
+
+    OWNER=$(echo "$repo_info" | jq -r '.owner // empty')
+    REPO=$(echo "$repo_info" | jq -r '.name // empty')
+  fi
+
+  if [[ -z "$OWNER" || -z "$REPO" ]]; then
+    echo "❌ assertion failed: owner/repo must be non-empty" >&2
+    return 1
+  fi
+}
+
+append_unresolved_records() {
+  local records="$1"
+
+  if [[ -z "$records" ]]; then
+    return 0
+  fi
+
+  if [[ -n "$UNRESOLVED" ]]; then
+    UNRESOLVED+=$'\n'
+  fi
+
+  UNRESOLVED+="$records"
+}
+
+MAX_ATTEMPTS=5
+BACKOFF_SECS=2
+
+graphql_with_retries() {
+  local query="$1"
+  local cursor="$2"
+  local attempt
+  local backoff="$BACKOFF_SECS"
+  local response
+
+  for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+    if response=$(gh api graphql \
+      -f query="$query" \
+      -F owner="$OWNER" \
+      -F repo="$REPO" \
+      -F pr="$PR_NUMBER" \
+      -F cursor="$cursor"); then
+      printf '%s\n' "$response"
+      return 0
+    fi
+
+    if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+      echo "❌ GraphQL query failed after ${MAX_ATTEMPTS} attempts" >&2
+      return 1
+    fi
+
+    echo "⚠️ GraphQL query failed (attempt ${attempt}/${MAX_ATTEMPTS}); retrying in ${backoff}s..." >&2
+    sleep "$backoff"
+    backoff=$((backoff * 2))
+  done
+}
+
+fetch_unresolved_via_api() {
+  # Query all review-thread pages so older unresolved bot feedback cannot be missed.
+  # shellcheck disable=SC2016 # Single quotes are intentional - this is a GraphQL query.
+  local graphql_query='query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100, after: $cursor) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+            id
+            isResolved
+            comments(first: 100) {
+              nodes {
+                author { login }
+                body
+                createdAt
+                path
+                line
+              }
+            }
+          }
+        }
+      }
+    }
+  }'
+
+  resolve_repo_context
+
+  local cursor="null"
+  local page_data
+  local page_threads
+  local unresolved_page
+  local has_next
+  local end_cursor
+
+  while true; do
+    if ! page_data=$(graphql_with_retries "$graphql_query" "$cursor"); then
+      return 1
+    fi
+
+    if [ "$(echo "$page_data" | jq -r '.data.repository.pullRequest == null')" = "true" ]; then
+      echo "❌ PR #$PR_NUMBER does not exist in ${OWNER}/${REPO}." >&2
+      return 1
+    fi
+
+    page_threads=$(echo "$page_data" | jq -c '.data.repository.pullRequest.reviewThreads.nodes // []')
+    unresolved_page=$(coder_agents_unresolved_threads_from_json "$page_threads" "$BOT_LOGIN_REGEX")
+    append_unresolved_records "$unresolved_page"
+
+    has_next=$(echo "$page_data" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+    end_cursor=$(echo "$page_data" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // empty')
+
+    case "$has_next" in
+      false)
+        break
+        ;;
+      true)
+        if [[ -z "$end_cursor" ]]; then
+          echo "❌ assertion failed: reviewThreads hasNextPage=true with empty endCursor" >&2
+          return 1
+        fi
+        cursor="$end_cursor"
+        ;;
+      *)
+        echo "❌ assertion failed: unexpected reviewThreads hasNextPage value '$has_next'" >&2
+        return 1
+        ;;
+    esac
+  done
+}
+
+echo "Checking for unresolved coder-agents-review comments in PR #${PR_NUMBER}..."
+
+fetch_unresolved_via_api
+
+if [ -n "$UNRESOLVED" ]; then
+  coder_agents_print_unresolved_threads "$UNRESOLVED"
+  echo ""
+
+  VIEW_OWNER="${OWNER:-${MUX_GH_OWNER:-coder}}"
+  VIEW_REPO="${REPO:-${MUX_GH_REPO:-mux}}"
+  echo "View PR: https://github.com/${VIEW_OWNER}/${VIEW_REPO}/pull/$PR_NUMBER"
+  exit 1
+fi
+
+echo "✅ No unresolved coder-agents-review comments found"
+exit 0

--- a/scripts/lib/coder_agents_review.sh
+++ b/scripts/lib/coder_agents_review.sh
@@ -96,6 +96,8 @@ coder_agents_print_unresolved_threads() {
   echo "❌ Unresolved coder-agents-review comments found:"
   echo "$unresolved" | jq -r '"  - [\(.created_at)] thread=\(.thread_id) \(.path):\(.line)\n    \(.user): \(.body)\n"'
   echo ""
+  echo "Reply inline to the finding(s), or leave a PR comment summarizing each response, before resolving."
+  echo ""
   echo "To resolve a comment thread, use:"
   echo "$unresolved" | jq -r '"  ./scripts/resolve_pr_comment.sh \(.thread_id)"'
 }

--- a/scripts/lib/coder_agents_review.sh
+++ b/scripts/lib/coder_agents_review.sh
@@ -1,6 +1,75 @@
 #!/usr/bin/env bash
 # Shared helpers for the optional coder-agents-review PR gate.
 
+MAX_ATTEMPTS=${MAX_ATTEMPTS:-5}
+BACKOFF_SECS=${BACKOFF_SECS:-2}
+
+resolve_repo_context() {
+  if [[ -n "${MUX_GH_OWNER:-}" || -n "${MUX_GH_REPO:-}" ]]; then
+    if [[ -z "${MUX_GH_OWNER:-}" || -z "${MUX_GH_REPO:-}" ]]; then
+      echo "❌ assertion failed: MUX_GH_OWNER and MUX_GH_REPO must both be set when one is provided" >&2
+      return 1
+    fi
+
+    OWNER="$MUX_GH_OWNER"
+    REPO="$MUX_GH_REPO"
+  else
+    local repo_info
+    if ! repo_info=$(gh repo view --json owner,name --jq '{owner: .owner.login, name: .name}'); then
+      echo "❌ Failed to resolve repository owner/name via 'gh repo view'." >&2
+      return 1
+    fi
+
+    OWNER=$(echo "$repo_info" | jq -r '.owner // empty')
+    REPO=$(echo "$repo_info" | jq -r '.name // empty')
+  fi
+
+  if [[ -z "$OWNER" || -z "$REPO" ]]; then
+    echo "❌ assertion failed: owner/repo must be non-empty" >&2
+    return 1
+  fi
+}
+
+graphql_with_retries() {
+  local query="$1"
+  local cursor="${2-}"
+  local attempt
+  local backoff="$BACKOFF_SECS"
+  local response
+
+  for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+    if [[ -n "$cursor" ]]; then
+      response=$(gh api graphql \
+        -f query="$query" \
+        -F owner="$OWNER" \
+        -F repo="$REPO" \
+        -F pr="$PR_NUMBER" \
+        -F cursor="$cursor") && {
+        printf '%s\n' "$response"
+        return 0
+      }
+    else
+      response=$(gh api graphql \
+        -f query="$query" \
+        -F owner="$OWNER" \
+        -F repo="$REPO" \
+        -F pr="$PR_NUMBER") && {
+        printf '%s\n' "$response"
+        return 0
+      }
+    fi
+
+    if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+      echo "❌ GraphQL query failed after ${MAX_ATTEMPTS} attempts" >&2
+      return 1
+    fi
+
+    echo "⚠️ GraphQL query failed (attempt ${attempt}/${MAX_ATTEMPTS}); retrying in ${backoff}s..." >&2
+    sleep "$backoff"
+    backoff=$((backoff * 2))
+  done
+}
+
 coder_agents_unresolved_threads_from_json() {
   local threads_json="$1"
   local bot_regex="$2"

--- a/scripts/lib/coder_agents_review.sh
+++ b/scripts/lib/coder_agents_review.sh
@@ -4,6 +4,7 @@
 MAX_ATTEMPTS=${MAX_ATTEMPTS:-5}
 BACKOFF_SECS=${BACKOFF_SECS:-2}
 
+# Sets OWNER and REPO from MUX_GH_* or gh repo view.
 resolve_repo_context() {
   if [[ -n "${MUX_GH_OWNER:-}" || -n "${MUX_GH_REPO:-}" ]]; then
     if [[ -z "${MUX_GH_OWNER:-}" || -z "${MUX_GH_REPO:-}" ]]; then
@@ -30,6 +31,7 @@ resolve_repo_context() {
   fi
 }
 
+# Runs a PR GraphQL query with optional cursor using OWNER, REPO, and PR_NUMBER.
 graphql_with_retries() {
   local query="$1"
   local cursor="${2-}"
@@ -70,6 +72,7 @@ graphql_with_retries() {
   done
 }
 
+# Emits unresolved coder-agents-review thread records as newline-delimited JSON.
 coder_agents_unresolved_threads_from_json() {
   local threads_json="$1"
   local bot_regex="$2"
@@ -90,6 +93,7 @@ coder_agents_unresolved_threads_from_json() {
   '
 }
 
+# Prints records emitted by coder_agents_unresolved_threads_from_json.
 coder_agents_print_unresolved_threads() {
   local unresolved="$1"
 

--- a/scripts/lib/coder_agents_review.sh
+++ b/scripts/lib/coder_agents_review.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Shared helpers for the optional coder-agents-review PR gate.
+
+coder_agents_unresolved_threads_from_json() {
+  local threads_json="$1"
+  local bot_regex="$2"
+
+  jq -rn --argjson threads "$threads_json" --arg bot_regex "$bot_regex" '
+    $threads[]
+    | select(.isResolved == false and any(.comments.nodes[]?; ((.author.login // "") | test($bot_regex))))
+    | . as $thread
+    | ([.comments.nodes[]? | select((.author.login // "") | test($bot_regex))] | first) as $bot_comment
+    | {
+        thread_id: $thread.id,
+        user: ($bot_comment.author.login // "unknown"),
+        body: ($bot_comment.body // ""),
+        path: ($bot_comment.path // "comment"),
+        line: ($bot_comment.line // ""),
+        created_at: ($bot_comment.createdAt // "")
+      }
+  '
+}
+
+coder_agents_print_unresolved_threads() {
+  local unresolved="$1"
+
+  echo "❌ Unresolved coder-agents-review comments found:"
+  echo "$unresolved" | jq -r '"  - [\(.created_at)] thread=\(.thread_id) \(.path):\(.line)\n    \(.user): \(.body)\n"'
+  echo ""
+  echo "To resolve a comment thread, use:"
+  echo "$unresolved" | jq -r '"  ./scripts/resolve_pr_comment.sh \(.thread_id)"'
+}

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -36,7 +36,7 @@ fi
 REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
-CODER_AGENTS_BOT_APPROVAL_REGEX="^(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|review complete(d)?[.]?|zero open findings[.]?|zero open findings across .* review complete[.]?|Round [0-9]+[.] .*zero open findings across .* review complete[.]?)$"
+CODER_AGENTS_BOT_APPROVAL_REGEX="^(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|review complete(d)?[.]?|zero open findings[.]?|zero open findings across .* review complete[.]?|Round [0-9]+[.] zero open findings across .* review complete[.]?)$"
 CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX="^(Round [0-9]+ is blocked|Review failed|Failed to review|Unable to review|Cannot review|Could not review|Review timed out|Request timed out|Review cancelled|Request cancelled)"
 CODER_AGENTS_BOT_PROGRESS_REGEX="^(queued|started|running|in progress|reviewing|will review)[[:space:][:punct:]]*$"
 POLL_INTERVAL_SECS=30

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -36,7 +36,7 @@ fi
 REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
-CODER_AGENTS_BOT_APPROVAL_REGEX="^[[:space:]]*(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|review complete(d)?[.]?)[[:space:]]*$|(^|[[:space:]])zero open findings([.]|[[:space:]]+across[[:space:]].*)?$"
+CODER_AGENTS_BOT_APPROVAL_REGEX="^[[:space:]]*(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|review complete(d)?[.]?|zero open findings([.]|[[:space:]]+across[[:space:]].*)?)[[:space:]]*$"
 CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX="^[[:space:]]*(Round [0-9]+ is blocked|Review failed|Failed to review|Unable to review|Cannot review|Could not review|Review timed out|Request timed out|Review cancelled|Request cancelled)"
 CODER_AGENTS_BOT_PROGRESS_REGEX="^[[:space:]]*(queued|started|running|in progress|reviewing|will review)[[:space:][:punct:]]*$"
 POLL_INTERVAL_SECS=30

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -36,7 +36,7 @@ fi
 REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
-CODER_AGENTS_BOT_APPROVAL_REGEX="no (issues|problems)|no major issues|looks good|lgtm|didn.t find|(^|[[:space:][:punct:]])approved([[:space:][:punct:]]|$)"
+CODER_AGENTS_BOT_APPROVAL_REGEX="no (issues|problems)|no major issues|looks good|lgtm|didn.t find|review complete|(^|[[:space:][:punct:]])approved([[:space:][:punct:]]|$)"
 CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX="not approved|not yet approved|review failed|failed to review|unable to review|cannot review|could not review|review timed out|request timed out|review cancelled|request cancelled|is blocked|blocked until|needs changes|changes requested( for|:)|without author response|unaddressed findings|to unblock"
 CODER_AGENTS_BOT_PROGRESS_REGEX="^[[:space:]]*(queued|started|running|in progress|reviewing|will review)[[:space:][:punct:]]*$"
 POLL_INTERVAL_SECS=30

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -32,6 +32,8 @@ fi
 REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
+CODER_AGENTS_ISSUE_COMMENT_APPROVAL_REGEX="no (issues|problems)|no major issues|looks good|lgtm|approved|didn.t find"
+CODER_AGENTS_ISSUE_COMMENT_PROGRESS_REGEX="queued|started|running|in progress|reviewing|will review|working"
 POLL_INTERVAL_SECS=30
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 SKIP_FETCH_SYNC="${MUX_SKIP_FETCH_SYNC:-0}"
@@ -467,6 +469,8 @@ check_coder_agents_status_once() {
   local response_count
   local latest_review_state
   local latest_review_at
+  local latest_issue_comment_body
+  local latest_issue_comment_at
 
   resolve_repo_context || return 1
   if load_pr_data; then
@@ -566,6 +570,31 @@ check_coder_agents_status_once() {
       return 10
     fi
 
+    latest_issue_comment_body=$(jq -rn \
+      --argjson comments "$COMMENTS_JSON" \
+      --arg bot_regex "$BOT_LOGIN_REGEX" \
+      --arg request_at "$request_at" '
+        [
+          $comments[]
+          | select(((.author.login // "") | test($bot_regex)) and (.createdAt > $request_at))
+        ]
+        | sort_by(.createdAt)
+        | last
+        | .body // empty
+      ')
+    latest_issue_comment_at=$(jq -rn \
+      --argjson comments "$COMMENTS_JSON" \
+      --arg bot_regex "$BOT_LOGIN_REGEX" \
+      --arg request_at "$request_at" '
+        [
+          $comments[]
+          | select(((.author.login // "") | test($bot_regex)) and (.createdAt > $request_at))
+        ]
+        | sort_by(.createdAt)
+        | last
+        | .createdAt // empty
+      ')
+
     latest_review_state=$(jq -rn \
       --argjson reviews "$REVIEWS_JSON" \
       --arg bot_regex "$BOT_LOGIN_REGEX" \
@@ -602,6 +631,29 @@ check_coder_agents_status_once() {
       ')
   else
     response_count="$bot_activity_count"
+    latest_issue_comment_body=$(jq -rn \
+      --argjson comments "$COMMENTS_JSON" \
+      --arg bot_regex "$BOT_LOGIN_REGEX" '
+        [
+          $comments[]
+          | select((.author.login // "") | test($bot_regex))
+        ]
+        | sort_by(.createdAt)
+        | last
+        | .body // empty
+      ')
+    latest_issue_comment_at=$(jq -rn \
+      --argjson comments "$COMMENTS_JSON" \
+      --arg bot_regex "$BOT_LOGIN_REGEX" '
+        [
+          $comments[]
+          | select((.author.login // "") | test($bot_regex))
+        ]
+        | sort_by(.createdAt)
+        | last
+        | .createdAt // empty
+      ')
+
     latest_review_state=$(jq -rn \
       --argjson reviews "$REVIEWS_JSON" \
       --arg bot_regex "$BOT_LOGIN_REGEX" '
@@ -643,9 +695,33 @@ check_coder_agents_status_once() {
       return 0
       ;;
     "")
+      if [[ -z "$latest_issue_comment_body" ]]; then
+        echo ""
+        echo "✅ coder-agents-review gate passed for PR #$PR_NUMBER"
+        return 0
+      fi
+
+      if printf '%s\n' "$latest_issue_comment_body" | grep -Eiq "$CODER_AGENTS_ISSUE_COMMENT_APPROVAL_REGEX"; then
+        echo ""
+        echo "✅ coder-agents-review gate passed for PR #$PR_NUMBER via issue comment"
+        if [[ -n "$latest_issue_comment_at" ]]; then
+          echo "Comment timestamp: $latest_issue_comment_at"
+        fi
+        return 0
+      fi
+
+      if printf '%s\n' "$latest_issue_comment_body" | grep -Eiq "$CODER_AGENTS_ISSUE_COMMENT_PROGRESS_REGEX"; then
+        return 10
+      fi
+
       echo ""
-      echo "✅ coder-agents-review gate passed for PR #$PR_NUMBER"
-      return 0
+      echo "❌ coder-agents-review responded with an unclassified issue comment on PR #$PR_NUMBER."
+      if [[ -n "$latest_issue_comment_at" ]]; then
+        echo "Comment timestamp: $latest_issue_comment_at"
+      fi
+      echo ""
+      echo "$latest_issue_comment_body"
+      return 1
       ;;
     CHANGES_REQUESTED)
       echo ""

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -68,64 +68,6 @@ if [ "$SKIP_FETCH_SYNC" = "0" ]; then
   assert_branch_synced || exit 1
 fi
 
-resolve_repo_context() {
-  if [[ -n "${MUX_GH_OWNER:-}" || -n "${MUX_GH_REPO:-}" ]]; then
-    if [[ -z "${MUX_GH_OWNER:-}" || -z "${MUX_GH_REPO:-}" ]]; then
-      echo "❌ assertion failed: MUX_GH_OWNER and MUX_GH_REPO must both be set when one is provided" >&2
-      return 1
-    fi
-
-    OWNER="$MUX_GH_OWNER"
-    REPO="$MUX_GH_REPO"
-  else
-    local repo_info
-    if ! repo_info=$(gh repo view --json owner,name --jq '{owner: .owner.login, name: .name}'); then
-      echo "❌ Failed to resolve repository owner/name via 'gh repo view'." >&2
-      return 1
-    fi
-
-    OWNER=$(echo "$repo_info" | jq -r '.owner // empty')
-    REPO=$(echo "$repo_info" | jq -r '.name // empty')
-  fi
-
-  if [[ -z "$OWNER" || -z "$REPO" ]]; then
-    echo "❌ assertion failed: owner/repo must be non-empty" >&2
-    return 1
-  fi
-}
-
-MAX_ATTEMPTS=5
-BACKOFF_SECS=2
-
-graphql_with_retries() {
-  local query="$1"
-  local cursor="$2"
-  local attempt
-  local backoff="$BACKOFF_SECS"
-  local response
-
-  for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
-    if response=$(gh api graphql \
-      -f query="$query" \
-      -F owner="$OWNER" \
-      -F repo="$REPO" \
-      -F pr="$PR_NUMBER" \
-      -F cursor="$cursor"); then
-      printf '%s\n' "$response"
-      return 0
-    fi
-
-    if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
-      echo "❌ GraphQL query failed after ${MAX_ATTEMPTS} attempts" >&2
-      return 1
-    fi
-
-    echo "⚠️ GraphQL query failed (attempt ${attempt}/${MAX_ATTEMPTS}); retrying in ${backoff}s..." >&2
-    sleep "$backoff"
-    backoff=$((backoff * 2))
-  done
-}
-
 fetch_pr_snapshot() {
   # shellcheck disable=SC2016 # Single quotes are intentional - this is a GraphQL query.
   local graphql_query='query($owner: String!, $repo: String!, $pr: Int!) {
@@ -171,29 +113,7 @@ fetch_pr_snapshot() {
     }
   }'
 
-  local attempt
-  local backoff="$BACKOFF_SECS"
-  local response
-
-  for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
-    if response=$(gh api graphql \
-      -f query="$graphql_query" \
-      -F owner="$OWNER" \
-      -F repo="$REPO" \
-      -F pr="$PR_NUMBER"); then
-      printf '%s\n' "$response"
-      return 0
-    fi
-
-    if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
-      echo "❌ GraphQL query failed after ${MAX_ATTEMPTS} attempts" >&2
-      return 1
-    fi
-
-    echo "⚠️ GraphQL query failed (attempt ${attempt}/${MAX_ATTEMPTS}); retrying in ${backoff}s..." >&2
-    sleep "$backoff"
-    backoff=$((backoff * 2))
-  done
+  graphql_with_retries "$graphql_query"
 }
 
 fetch_all_comments_via_api() {

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -33,8 +33,8 @@ REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
 CODER_AGENTS_ISSUE_COMMENT_APPROVAL_REGEX="no (issues|problems)|no major issues|looks good|lgtm|didn.t find|(^|[[:space:][:punct:]])approved([[:space:][:punct:]]|$)"
-CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_BEFORE_APPROVAL_REGEX="not approved|not yet approved"
-CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_REGEX="review failed|failed to|unable to|cannot review|could not review|timed out|cancelled|blocked|needs changes|changes requested|without author response|unaddressed|to unblock"
+CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_BEFORE_APPROVAL_REGEX="not approved|not yet approved|review failed|failed to review|unable to review|cannot review|could not review|timed out|cancelled|blocked|needs changes|changes requested|without author response|unaddressed|to unblock"
+CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_REGEX="a^"
 CODER_AGENTS_ISSUE_COMMENT_PROGRESS_REGEX="queued|started|running|in progress|reviewing|will review|working"
 POLL_INTERVAL_SECS=30
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -33,7 +33,8 @@ REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
 CODER_AGENTS_ISSUE_COMMENT_APPROVAL_REGEX="no (issues|problems)|no major issues|looks good|lgtm|didn.t find|(^|[[:space:][:punct:]])approved([[:space:][:punct:]]|$)"
-CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_REGEX="not approved|not yet approved|review failed|failed to|unable to|cannot review|could not review|timed out|cancelled|blocked|needs changes|changes requested"
+CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_BEFORE_APPROVAL_REGEX="not approved|not yet approved"
+CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_REGEX="review failed|failed to|unable to|cannot review|could not review|timed out|cancelled|blocked|needs changes|changes requested"
 CODER_AGENTS_ISSUE_COMMENT_PROGRESS_REGEX="queued|started|running|in progress|reviewing|will review|working"
 POLL_INTERVAL_SECS=30
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
@@ -384,7 +385,7 @@ classify_issue_comment_response() {
   local body="$1"
   local created_at="$2"
 
-  if printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_REGEX"; then
+  if printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_BEFORE_APPROVAL_REGEX"; then
     echo ""
     echo "❌ coder-agents-review responded with a negative issue comment on PR #$PR_NUMBER."
   elif printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_ISSUE_COMMENT_APPROVAL_REGEX"; then
@@ -394,6 +395,9 @@ classify_issue_comment_response() {
       echo "Comment timestamp: $created_at"
     fi
     return 0
+  elif printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_REGEX"; then
+    echo ""
+    echo "❌ coder-agents-review responded with a negative issue comment on PR #$PR_NUMBER."
   elif printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_ISSUE_COMMENT_PROGRESS_REGEX"; then
     return 10
   else

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -33,7 +33,7 @@ REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
 CODER_AGENTS_ISSUE_COMMENT_APPROVAL_REGEX="no (issues|problems)|no major issues|looks good|lgtm|didn.t find|(^|[[:space:][:punct:]])approved([[:space:][:punct:]]|$)"
-CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_REGEX="not approved|not yet approved|failed|failure|error|unable|cannot|could not|timed out|cancelled|blocked|needs changes|changes requested"
+CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_REGEX="not approved|not yet approved|review failed|failed to|unable to|cannot review|could not review|timed out|cancelled|blocked|needs changes|changes requested"
 CODER_AGENTS_ISSUE_COMMENT_PROGRESS_REGEX="queued|started|running|in progress|reviewing|will review|working"
 POLL_INTERVAL_SECS=30
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -36,7 +36,7 @@ fi
 REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
-CODER_AGENTS_BOT_APPROVAL_REGEX="^[[:space:]]*(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|review complete(d)?[.]?)[[:space:]]*$|(^|[[:space:]])zero open findings"
+CODER_AGENTS_BOT_APPROVAL_REGEX="^[[:space:]]*(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|review complete(d)?[.]?)[[:space:]]*$|(^|[[:space:]])zero open findings([.]|[[:space:]]+across[[:space:]].*)?$"
 CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX="^[[:space:]]*(Round [0-9]+ is blocked|Review failed|Failed to review|Unable to review|Cannot review|Could not review|Review timed out|Request timed out|Review cancelled|Request cancelled)"
 CODER_AGENTS_BOT_PROGRESS_REGEX="^[[:space:]]*(queued|started|running|in progress|reviewing|will review)[[:space:][:punct:]]*$"
 POLL_INTERVAL_SECS=30

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -34,7 +34,7 @@ REQUEST_COMMAND="/coder-agents-review"
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
 CODER_AGENTS_ISSUE_COMMENT_APPROVAL_REGEX="no (issues|problems)|no major issues|looks good|lgtm|didn.t find|(^|[[:space:][:punct:]])approved([[:space:][:punct:]]|$)"
 CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_BEFORE_APPROVAL_REGEX="not approved|not yet approved"
-CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_REGEX="review failed|failed to|unable to|cannot review|could not review|timed out|cancelled|blocked|needs changes|changes requested"
+CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_REGEX="review failed|failed to|unable to|cannot review|could not review|timed out|cancelled|blocked|needs changes|changes requested|without author response|unaddressed|to unblock"
 CODER_AGENTS_ISSUE_COMMENT_PROGRESS_REGEX="queued|started|running|in progress|reviewing|will review|working"
 POLL_INTERVAL_SECS=30
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
@@ -381,35 +381,38 @@ load_pr_data() {
   esac
 }
 
-classify_issue_comment_response() {
+classify_bot_text_response() {
   local body="$1"
   local created_at="$2"
+  local source_label="$3"
 
   if printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_BEFORE_APPROVAL_REGEX"; then
     echo ""
-    echo "❌ coder-agents-review responded with a negative issue comment on PR #$PR_NUMBER."
+    echo "❌ coder-agents-review responded with a negative ${source_label} on PR #$PR_NUMBER."
   elif printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_ISSUE_COMMENT_APPROVAL_REGEX"; then
     echo ""
-    echo "✅ coder-agents-review gate passed for PR #$PR_NUMBER via issue comment"
+    echo "✅ coder-agents-review gate passed for PR #$PR_NUMBER via ${source_label}"
     if [[ -n "$created_at" ]]; then
-      echo "Comment timestamp: $created_at"
+      echo "Timestamp: $created_at"
     fi
     return 0
   elif printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_REGEX"; then
     echo ""
-    echo "❌ coder-agents-review responded with a negative issue comment on PR #$PR_NUMBER."
+    echo "❌ coder-agents-review responded with a negative ${source_label} on PR #$PR_NUMBER."
   elif printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_ISSUE_COMMENT_PROGRESS_REGEX"; then
     return 10
   else
     echo ""
-    echo "❌ coder-agents-review responded with an unclassified issue comment on PR #$PR_NUMBER."
+    echo "❌ coder-agents-review responded with an unclassified ${source_label} on PR #$PR_NUMBER."
   fi
 
   if [[ -n "$created_at" ]]; then
-    echo "Comment timestamp: $created_at"
+    echo "Timestamp: $created_at"
   fi
   echo ""
   echo "$body"
+  echo ""
+  echo "Reply inline to the coder-agents-review finding(s), or leave a PR comment summarizing each response, before resolving/re-requesting review."
   return 1
 }
 
@@ -423,6 +426,7 @@ check_coder_agents_status_once() {
   local response_count
   local latest_review_state
   local latest_review_at
+  local latest_review_body
   local latest_issue_comment_body
   local latest_issue_comment_at
 
@@ -549,6 +553,23 @@ check_coder_agents_status_once() {
         | .createdAt // empty
       ')
 
+    latest_review_body=$(jq -rn \
+      --argjson reviews "$REVIEWS_JSON" \
+      --arg bot_regex "$BOT_LOGIN_REGEX" \
+      --arg request_at "$request_at" '
+        [
+          $reviews[]
+          | select(
+              ((.author.login // "") | test($bot_regex))
+              and (.state != "DISMISSED")
+              and ((.submittedAt // .createdAt // "") > $request_at)
+            )
+          | . + {reviewedAt: (.submittedAt // .createdAt // "")}
+        ]
+        | sort_by(.reviewedAt)
+        | last
+        | .body // empty
+      ')
     latest_review_state=$(jq -rn \
       --argjson reviews "$REVIEWS_JSON" \
       --arg bot_regex "$BOT_LOGIN_REGEX" \
@@ -608,6 +629,18 @@ check_coder_agents_status_once() {
         | .createdAt // empty
       ')
 
+    latest_review_body=$(jq -rn \
+      --argjson reviews "$REVIEWS_JSON" \
+      --arg bot_regex "$BOT_LOGIN_REGEX" '
+        [
+          $reviews[]
+          | select(((.author.login // "") | test($bot_regex)) and (.state != "DISMISSED"))
+          | . + {reviewedAt: (.submittedAt // .createdAt // "")}
+        ]
+        | sort_by(.reviewedAt)
+        | last
+        | .body // empty
+      ')
     latest_review_state=$(jq -rn \
       --argjson reviews "$REVIEWS_JSON" \
       --arg bot_regex "$BOT_LOGIN_REGEX" '
@@ -640,7 +673,12 @@ check_coder_agents_status_once() {
   fi
 
   if [[ -n "$latest_issue_comment_body" && (-z "$latest_review_at" || "$latest_issue_comment_at" > "$latest_review_at") ]]; then
-    classify_issue_comment_response "$latest_issue_comment_body" "$latest_issue_comment_at"
+    classify_bot_text_response "$latest_issue_comment_body" "$latest_issue_comment_at" "issue comment"
+    return $?
+  fi
+
+  if [[ "$latest_review_state" = "COMMENTED" && -n "$latest_review_body" ]]; then
+    classify_bot_text_response "$latest_review_body" "$latest_review_at" "review body"
     return $?
   fi
 

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -36,7 +36,7 @@ fi
 REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
-CODER_AGENTS_BOT_APPROVAL_REGEX="^(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|review complete(d)?[.]?|zero open findings[.]?|zero open findings across .* review complete[.]?|Round [0-9]+[.] zero open findings across .* review complete[.]?)$"
+CODER_AGENTS_BOT_APPROVAL_REGEX="^(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|review complete(d)?[.]?|zero open findings[.]?|zero open findings across .* review complete[.]?|Round [0-9]+[.] zero open findings across .* review complete[.]?|Round [0-9]+[.] .*[[:space:]]zero open findings[.] .*review complete[.]?)$"
 CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX="^(Round [0-9]+ is blocked|Review failed|Failed to review|Unable to review|Cannot review|Could not review|Review timed out|Request timed out|Review cancelled|Request cancelled)"
 CODER_AGENTS_BOT_PROGRESS_REGEX="^(queued|started|running|in progress|reviewing|will review)[[:space:][:punct:]]*$"
 POLL_INTERVAL_SECS=30

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -36,7 +36,7 @@ fi
 REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
-CODER_AGENTS_BOT_APPROVAL_REGEX="^(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|review complete(d)?[.]?|zero open findings[.]?|zero open findings across .* review complete[.]?|Round [0-9]+[.] zero open findings across .* review complete[.]?|Round [0-9]+[.] .*[[:space:]]zero open findings[.] .*review complete[.]?)$"
+CODER_AGENTS_BOT_APPROVAL_REGEX="^(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|review complete(d)?[.]?|zero open findings[.]?|zero open findings across .* (coder-agents-review |review )?complete[.]?|Round [0-9]+[.] zero open findings across .* (coder-agents-review |review )?complete[.]?|Round [0-9]+[.] .*[[:space:]]zero open findings[.] .*(coder-agents-review |review )?complete[.]?)$"
 CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX="^(Round [0-9]+ is blocked|Review failed|Failed to review|Unable to review|Cannot review|Could not review|Review timed out|Request timed out|Review cancelled|Request cancelled)"
 CODER_AGENTS_BOT_PROGRESS_REGEX="^(queued|started|running|in progress|reviewing|will review)[[:space:][:punct:]]*$"
 POLL_INTERVAL_SECS=30

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -667,7 +667,7 @@ check_coder_agents_status_once() {
       ')
   fi
 
-  if [[ "$latest_review_state" = "CHANGES_REQUESTED" ]]; then
+  if [[ "$latest_review_state" = "CHANGES_REQUESTED" && (-z "$latest_issue_comment_at" || ! "$latest_review_at" < "$latest_issue_comment_at") ]]; then
     echo ""
     echo "❌ coder-agents-review requested changes on PR #$PR_NUMBER."
     if [[ -n "$latest_review_at" ]]; then

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -18,6 +18,10 @@ fi
 
 PR_NUMBER="$1"
 MODE="wait"
+RC_PASSED=0
+RC_FAILED=1
+RC_PENDING=10
+RC_SKIPPED=20
 
 if [ $# -eq 2 ]; then
   if [ "$2" = "--once" ]; then
@@ -32,10 +36,9 @@ fi
 REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
-CODER_AGENTS_ISSUE_COMMENT_APPROVAL_REGEX="no (issues|problems)|no major issues|looks good|lgtm|didn.t find|(^|[[:space:][:punct:]])approved([[:space:][:punct:]]|$)"
-CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_BEFORE_APPROVAL_REGEX="not approved|not yet approved|review failed|failed to review|unable to review|cannot review|could not review|timed out|cancelled|blocked|needs changes|changes requested|without author response|unaddressed|to unblock"
-CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_REGEX="a^"
-CODER_AGENTS_ISSUE_COMMENT_PROGRESS_REGEX="queued|started|running|in progress|reviewing|will review|working"
+CODER_AGENTS_BOT_APPROVAL_REGEX="no (issues|problems)|no major issues|looks good|lgtm|didn.t find|(^|[[:space:][:punct:]])approved([[:space:][:punct:]]|$)"
+CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX="not approved|not yet approved|review failed|failed to review|unable to review|cannot review|could not review|timed out|cancelled|blocked|needs changes|changes requested|without author response|unaddressed|to unblock"
+CODER_AGENTS_BOT_PROGRESS_REGEX="^[[:space:]]*(queued|started|running|in progress|reviewing|will review)[[:space:][:punct:]]*$"
 POLL_INTERVAL_SECS=30
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 SKIP_FETCH_SYNC="${MUX_SKIP_FETCH_SYNC:-0}"
@@ -320,7 +323,7 @@ load_pr_data() {
   case "$pr_state" in
     MERGED)
       echo "✅ PR #$PR_NUMBER has been merged!"
-      return 20
+      return "$RC_SKIPPED"
       ;;
     CLOSED)
       echo "❌ PR #$PR_NUMBER is closed (not merged)!"
@@ -386,24 +389,21 @@ classify_bot_text_response() {
   local created_at="$2"
   local source_label="$3"
 
-  if printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_BEFORE_APPROVAL_REGEX"; then
+  if printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX"; then
     echo ""
     echo "❌ coder-agents-review responded with a negative ${source_label} on PR #$PR_NUMBER."
-  elif printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_ISSUE_COMMENT_APPROVAL_REGEX"; then
+  elif printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_BOT_APPROVAL_REGEX"; then
     echo ""
     echo "✅ coder-agents-review gate passed for PR #$PR_NUMBER via ${source_label}"
     if [[ -n "$created_at" ]]; then
       echo "Timestamp: $created_at"
     fi
     return 0
-  elif printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_REGEX"; then
-    echo ""
-    echo "❌ coder-agents-review responded with a negative ${source_label} on PR #$PR_NUMBER."
-  elif printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_ISSUE_COMMENT_PROGRESS_REGEX"; then
-    return 10
+  elif printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_BOT_PROGRESS_REGEX"; then
+    return "$RC_PENDING"
   else
     echo ""
-    echo "❌ coder-agents-review responded with an unclassified ${source_label} on PR #$PR_NUMBER."
+    echo "❌ coder-agents-review responded with an unrecognized ${source_label} on PR #$PR_NUMBER."
   fi
 
   if [[ -n "$created_at" ]]; then
@@ -412,7 +412,7 @@ classify_bot_text_response() {
   echo ""
   echo "$body"
   echo ""
-  echo "Reply inline to the coder-agents-review finding(s), or leave a PR comment summarizing each response, before resolving/re-requesting review."
+  echo "Review the bot response, then reply inline or leave a PR comment summarizing each response before resolving/re-requesting review."
   return 1
 }
 
@@ -435,7 +435,7 @@ check_coder_agents_status_once() {
     :
   else
     local load_rc=$?
-    if [ "$load_rc" -eq 20 ]; then
+    if [ "$load_rc" -eq "$RC_SKIPPED" ]; then
       return 0
     fi
     return "$load_rc"
@@ -483,7 +483,7 @@ check_coder_agents_status_once() {
 
   if [[ -z "$request_at" && "$bot_activity_count" -eq 0 ]]; then
     echo "ℹ️ coder-agents-review gate skipped: no '$REQUEST_COMMAND' comment and no bot review activity found."
-    return 20
+    return "$RC_SKIPPED"
   fi
 
   unresolved_threads=$(coder_agents_unresolved_threads_from_json "$THREADS_JSON" "$BOT_LOGIN_REGEX")
@@ -525,7 +525,7 @@ check_coder_agents_status_once() {
       ')
 
     if [ "$response_count" -eq 0 ]; then
-      return 10
+      return "$RC_PENDING"
     fi
 
     latest_issue_comment_body=$(jq -rn \
@@ -667,9 +667,14 @@ check_coder_agents_status_once() {
       ')
   fi
 
-  if [ "$response_count" -eq 0 ]; then
-    echo "ℹ️ coder-agents-review gate skipped: no bot review activity found."
-    return 20
+  if [[ "$latest_review_state" = "CHANGES_REQUESTED" ]]; then
+    echo ""
+    echo "❌ coder-agents-review requested changes on PR #$PR_NUMBER."
+    if [[ -n "$latest_review_at" ]]; then
+      echo "Review timestamp: $latest_review_at"
+    fi
+    echo "Resolve/address the feedback and request another review with '$REQUEST_COMMAND'."
+    return "$RC_FAILED"
   fi
 
   if [[ -n "$latest_issue_comment_body" && (-z "$latest_review_at" || "$latest_issue_comment_at" > "$latest_review_at") ]]; then
@@ -696,17 +701,8 @@ check_coder_agents_status_once() {
       echo "✅ coder-agents-review gate passed for PR #$PR_NUMBER"
       return 0
       ;;
-    CHANGES_REQUESTED)
-      echo ""
-      echo "❌ coder-agents-review requested changes on PR #$PR_NUMBER."
-      if [[ -n "$latest_review_at" ]]; then
-        echo "Review timestamp: $latest_review_at"
-      fi
-      echo "Resolve/address the feedback and request another review with '$REQUEST_COMMAND'."
-      return 1
-      ;;
     PENDING)
-      return 10
+      return "$RC_PENDING"
       ;;
     DISMISSED)
       echo "❌ assertion failed: dismissed reviews should be filtered before state classification" >&2
@@ -727,7 +723,7 @@ if [ "$MODE" = "once" ]; then
   fi
 
   case "$rc" in
-    0 | 1 | 10 | 20)
+    "$RC_PASSED" | "$RC_FAILED" | "$RC_PENDING" | "$RC_SKIPPED")
       exit "$rc"
       ;;
     *)
@@ -751,17 +747,17 @@ while true; do
   fi
 
   case "$rc" in
-    0)
+    "$RC_PASSED")
       exit 0
       ;;
-    1)
+    "$RC_FAILED")
       exit 1
       ;;
-    10)
+    "$RC_PENDING")
       echo -ne "\r⏳ Waiting for coder-agents-review response... (requested at ${LAST_REQUEST_AT})  "
       sleep "$POLL_INTERVAL_SECS"
       ;;
-    20)
+    "$RC_SKIPPED")
       echo "ℹ️ Optional coder-agents-review gate is inactive; skipping."
       exit 0
       ;;

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -36,7 +36,7 @@ fi
 REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
-CODER_AGENTS_BOT_APPROVAL_REGEX="^(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|review complete(d)?[.]?|zero open findings[.]?|zero open findings across .* (coder-agents-review |review )?complete[.]?|Round [0-9]+[.] zero open findings across .* (coder-agents-review |review )?complete[.]?|Round [0-9]+[.] .*[[:space:]]zero open findings[.] .*(coder-agents-review |review )?complete[.]?)$"
+CODER_AGENTS_BOT_APPROVAL_REGEX="^(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|review complete(d)?[.]?|zero open findings[.]?|zero open findings across .* (coder-agents-review |review )?complete[.]?|Round [0-9]+[.] zero open findings[.] (coder-agents-review |review )?complete[.]?|Round [0-9]+[.] zero open findings across .* (coder-agents-review |review )?complete[.]?|Round [0-9]+[.] .*[[:space:]]zero open findings[.] .*(coder-agents-review |review )?complete[.]?)$"
 CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX="^(Round [0-9]+ is blocked|Review failed|Failed to review|Unable to review|Cannot review|Could not review|Review timed out|Request timed out|Review cancelled|Request cancelled)"
 CODER_AGENTS_BOT_PROGRESS_REGEX="^(queued|started|running|in progress|reviewing|will review)[[:space:][:punct:]]*$"
 POLL_INTERVAL_SECS=30

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -687,13 +687,22 @@ check_coder_agents_status_once() {
   fi
 
   case "$latest_review_state" in
-    APPROVED | COMMENTED)
+    APPROVED)
       echo ""
       echo "✅ coder-agents-review gate passed for PR #$PR_NUMBER"
       if [[ -n "$latest_review_at" ]]; then
         echo "Review timestamp: $latest_review_at"
       fi
       return 0
+      ;;
+    COMMENTED)
+      echo ""
+      echo "❌ coder-agents-review left a commented review without approval text on PR #$PR_NUMBER."
+      if [[ -n "$latest_review_at" ]]; then
+        echo "Review timestamp: $latest_review_at"
+      fi
+      echo "Reply to the finding(s) and request another review with '$REQUEST_COMMAND'."
+      return "$RC_FAILED"
       ;;
     "")
       echo ""

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -36,7 +36,7 @@ fi
 REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
-CODER_AGENTS_BOT_APPROVAL_REGEX="^(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|review complete(d)?[.]?|zero open findings[.]?|.*zero open findings across .* review complete[.]?)$"
+CODER_AGENTS_BOT_APPROVAL_REGEX="^(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|review complete(d)?[.]?|zero open findings[.]?|((.*[[:space:]])?zero open findings across .* review complete[.]?))$"
 CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX="^(Round [0-9]+ is blocked|Review failed|Failed to review|Unable to review|Cannot review|Could not review|Review timed out|Request timed out|Review cancelled|Request cancelled)"
 CODER_AGENTS_BOT_PROGRESS_REGEX="^(queued|started|running|in progress|reviewing|will review)[[:space:][:punct:]]*$"
 POLL_INTERVAL_SECS=30

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -32,7 +32,8 @@ fi
 REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
-CODER_AGENTS_ISSUE_COMMENT_APPROVAL_REGEX="no (issues|problems)|no major issues|looks good|lgtm|approved|didn.t find"
+CODER_AGENTS_ISSUE_COMMENT_APPROVAL_REGEX="no (issues|problems)|no major issues|looks good|lgtm|didn.t find|(^|[[:space:][:punct:]])approved([[:space:][:punct:]]|$)"
+CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_REGEX="not approved|not yet approved|failed|failure|error|unable|cannot|could not|timed out|cancelled|blocked|needs changes|changes requested"
 CODER_AGENTS_ISSUE_COMMENT_PROGRESS_REGEX="queued|started|running|in progress|reviewing|will review|working"
 POLL_INTERVAL_SECS=30
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
@@ -459,6 +460,35 @@ load_pr_data() {
   esac
 }
 
+classify_issue_comment_response() {
+  local body="$1"
+  local created_at="$2"
+
+  if printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_ISSUE_COMMENT_NEGATIVE_REGEX"; then
+    echo ""
+    echo "❌ coder-agents-review responded with a negative issue comment on PR #$PR_NUMBER."
+  elif printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_ISSUE_COMMENT_APPROVAL_REGEX"; then
+    echo ""
+    echo "✅ coder-agents-review gate passed for PR #$PR_NUMBER via issue comment"
+    if [[ -n "$created_at" ]]; then
+      echo "Comment timestamp: $created_at"
+    fi
+    return 0
+  elif printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_ISSUE_COMMENT_PROGRESS_REGEX"; then
+    return 10
+  else
+    echo ""
+    echo "❌ coder-agents-review responded with an unclassified issue comment on PR #$PR_NUMBER."
+  fi
+
+  if [[ -n "$created_at" ]]; then
+    echo "Comment timestamp: $created_at"
+  fi
+  echo ""
+  echo "$body"
+  return 1
+}
+
 LAST_REQUEST_AT="none"
 
 check_coder_agents_status_once() {
@@ -685,6 +715,11 @@ check_coder_agents_status_once() {
     return 20
   fi
 
+  if [[ -n "$latest_issue_comment_body" && (-z "$latest_review_at" || "$latest_issue_comment_at" > "$latest_review_at") ]]; then
+    classify_issue_comment_response "$latest_issue_comment_body" "$latest_issue_comment_at"
+    return $?
+  fi
+
   case "$latest_review_state" in
     APPROVED | COMMENTED)
       echo ""
@@ -695,33 +730,9 @@ check_coder_agents_status_once() {
       return 0
       ;;
     "")
-      if [[ -z "$latest_issue_comment_body" ]]; then
-        echo ""
-        echo "✅ coder-agents-review gate passed for PR #$PR_NUMBER"
-        return 0
-      fi
-
-      if printf '%s\n' "$latest_issue_comment_body" | grep -Eiq "$CODER_AGENTS_ISSUE_COMMENT_APPROVAL_REGEX"; then
-        echo ""
-        echo "✅ coder-agents-review gate passed for PR #$PR_NUMBER via issue comment"
-        if [[ -n "$latest_issue_comment_at" ]]; then
-          echo "Comment timestamp: $latest_issue_comment_at"
-        fi
-        return 0
-      fi
-
-      if printf '%s\n' "$latest_issue_comment_body" | grep -Eiq "$CODER_AGENTS_ISSUE_COMMENT_PROGRESS_REGEX"; then
-        return 10
-      fi
-
       echo ""
-      echo "❌ coder-agents-review responded with an unclassified issue comment on PR #$PR_NUMBER."
-      if [[ -n "$latest_issue_comment_at" ]]; then
-        echo "Comment timestamp: $latest_issue_comment_at"
-      fi
-      echo ""
-      echo "$latest_issue_comment_body"
-      return 1
+      echo "✅ coder-agents-review gate passed for PR #$PR_NUMBER"
+      return 0
       ;;
     CHANGES_REQUESTED)
       echo ""

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -36,7 +36,7 @@ fi
 REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
-CODER_AGENTS_BOT_APPROVAL_REGEX="no (issues|problems)|no major issues|didn.t find|zero open findings|(^|[[:space:][:punct:]])review complete(d)?([[:space:][:punct:]]|$)"
+CODER_AGENTS_BOT_APPROVAL_REGEX="^[[:space:]]*(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|zero open findings.*|review complete(d)?[.]?)[[:space:]]*$"
 CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX="^[[:space:]]*(Round [0-9]+ is blocked|Review failed|Failed to review|Unable to review|Cannot review|Could not review|Review timed out|Request timed out|Review cancelled|Request cancelled)"
 CODER_AGENTS_BOT_PROGRESS_REGEX="^[[:space:]]*(queued|started|running|in progress|reviewing|will review)[[:space:][:punct:]]*$"
 POLL_INTERVAL_SECS=30

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -1,0 +1,712 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Optionally wait for coder-agents-review to respond to a `/coder-agents-review` request.
+#
+# Usage: ./scripts/wait_pr_coder_agents_review.sh <pr_number> [--once]
+#
+# Exits:
+#   0 - coder-agents-review gate passed, or skipped in wait mode
+#   1 - coder-agents-review left blocking feedback or the PR is terminally invalid
+#  10 - still waiting for coder-agents-review response (only in --once mode)
+#  20 - optional gate is inactive/skipped (only in --once mode)
+
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+  echo "Usage: $0 <pr_number> [--once]" >&2
+  exit 1
+fi
+
+PR_NUMBER="$1"
+MODE="wait"
+
+if [ $# -eq 2 ]; then
+  if [ "$2" = "--once" ]; then
+    MODE="once"
+  else
+    echo "❌ Unknown argument: '$2'" >&2
+    echo "Usage: $0 <pr_number> [--once]" >&2
+    exit 1
+  fi
+fi
+
+REQUEST_COMMAND="/coder-agents-review"
+# Match both the app slug and GitHub's bot-login form.
+BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
+POLL_INTERVAL_SECS=30
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+SKIP_FETCH_SYNC="${MUX_SKIP_FETCH_SYNC:-0}"
+# shellcheck source=./lib/coder_agents_review.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/coder_agents_review.sh"
+# shellcheck source=./lib/branch_sync_guard.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/branch_sync_guard.sh"
+
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "❌ PR number must be numeric. Got: '$PR_NUMBER'" >&2
+  exit 1
+fi
+
+if [ "$SKIP_FETCH_SYNC" != "0" ] && [ "$SKIP_FETCH_SYNC" != "1" ]; then
+  echo "❌ assertion failed: MUX_SKIP_FETCH_SYNC must be '0' or '1' (got '$SKIP_FETCH_SYNC')" >&2
+  exit 1
+fi
+
+if [ "$SKIP_FETCH_SYNC" = "0" ]; then
+  if ! git diff-index --quiet HEAD --; then
+    echo "❌ Error: You have uncommitted changes in your working directory." >&2
+    echo "" >&2
+    git status --short >&2
+    echo "" >&2
+    echo "Please commit or stash your changes before checking PR status." >&2
+    exit 1
+  fi
+
+  assert_branch_synced || exit 1
+fi
+
+resolve_repo_context() {
+  if [[ -n "${MUX_GH_OWNER:-}" || -n "${MUX_GH_REPO:-}" ]]; then
+    if [[ -z "${MUX_GH_OWNER:-}" || -z "${MUX_GH_REPO:-}" ]]; then
+      echo "❌ assertion failed: MUX_GH_OWNER and MUX_GH_REPO must both be set when one is provided" >&2
+      return 1
+    fi
+
+    OWNER="$MUX_GH_OWNER"
+    REPO="$MUX_GH_REPO"
+  else
+    local repo_info
+    if ! repo_info=$(gh repo view --json owner,name --jq '{owner: .owner.login, name: .name}'); then
+      echo "❌ Failed to resolve repository owner/name via 'gh repo view'." >&2
+      return 1
+    fi
+
+    OWNER=$(echo "$repo_info" | jq -r '.owner // empty')
+    REPO=$(echo "$repo_info" | jq -r '.name // empty')
+  fi
+
+  if [[ -z "$OWNER" || -z "$REPO" ]]; then
+    echo "❌ assertion failed: owner/repo must be non-empty" >&2
+    return 1
+  fi
+}
+
+MAX_ATTEMPTS=5
+BACKOFF_SECS=2
+
+graphql_with_retries() {
+  local query="$1"
+  local cursor="$2"
+  local attempt
+  local backoff="$BACKOFF_SECS"
+  local response
+
+  for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+    if response=$(gh api graphql \
+      -f query="$query" \
+      -F owner="$OWNER" \
+      -F repo="$REPO" \
+      -F pr="$PR_NUMBER" \
+      -F cursor="$cursor"); then
+      printf '%s\n' "$response"
+      return 0
+    fi
+
+    if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+      echo "❌ GraphQL query failed after ${MAX_ATTEMPTS} attempts" >&2
+      return 1
+    fi
+
+    echo "⚠️ GraphQL query failed (attempt ${attempt}/${MAX_ATTEMPTS}); retrying in ${backoff}s..." >&2
+    sleep "$backoff"
+    backoff=$((backoff * 2))
+  done
+}
+
+fetch_pr_snapshot() {
+  # shellcheck disable=SC2016 # Single quotes are intentional - this is a GraphQL query.
+  local graphql_query='query($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        state
+        comments(last: 100) {
+          pageInfo { hasPreviousPage }
+          nodes {
+            author { login }
+            body
+            createdAt
+            isMinimized
+          }
+        }
+        reviews(last: 100) {
+          pageInfo { hasPreviousPage }
+          nodes {
+            author { login }
+            body
+            state
+            createdAt
+            submittedAt
+          }
+        }
+        reviewThreads(last: 100) {
+          pageInfo { hasPreviousPage }
+          nodes {
+            id
+            isResolved
+            comments(first: 100) {
+              nodes {
+                author { login }
+                body
+                createdAt
+                path
+                line
+              }
+            }
+          }
+        }
+      }
+    }
+  }'
+
+  local attempt
+  local backoff="$BACKOFF_SECS"
+  local response
+
+  for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+    if response=$(gh api graphql \
+      -f query="$graphql_query" \
+      -F owner="$OWNER" \
+      -F repo="$REPO" \
+      -F pr="$PR_NUMBER"); then
+      printf '%s\n' "$response"
+      return 0
+    fi
+
+    if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+      echo "❌ GraphQL query failed after ${MAX_ATTEMPTS} attempts" >&2
+      return 1
+    fi
+
+    echo "⚠️ GraphQL query failed (attempt ${attempt}/${MAX_ATTEMPTS}); retrying in ${backoff}s..." >&2
+    sleep "$backoff"
+    backoff=$((backoff * 2))
+  done
+}
+
+fetch_all_comments_via_api() {
+  # shellcheck disable=SC2016 # Single quotes are intentional - this is a GraphQL query.
+  local graphql_query='query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        comments(first: 100, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            author { login }
+            body
+            createdAt
+            isMinimized
+          }
+        }
+      }
+    }
+  }'
+
+  local all_comments='[]'
+  local cursor="null"
+  local page_data
+  local page_comments
+  local has_next
+  local end_cursor
+
+  while true; do
+    page_data=$(graphql_with_retries "$graphql_query" "$cursor") || return 1
+
+    if [ "$(echo "$page_data" | jq -r '.data.repository.pullRequest == null')" = "true" ]; then
+      echo "❌ PR #$PR_NUMBER does not exist in ${OWNER}/${REPO}." >&2
+      return 1
+    fi
+
+    page_comments=$(echo "$page_data" | jq -c '.data.repository.pullRequest.comments.nodes // []')
+    all_comments=$(jq -cn --argjson existing "$all_comments" --argjson page "$page_comments" '$existing + $page')
+    has_next=$(echo "$page_data" | jq -r '.data.repository.pullRequest.comments.pageInfo.hasNextPage')
+    end_cursor=$(echo "$page_data" | jq -r '.data.repository.pullRequest.comments.pageInfo.endCursor // empty')
+
+    case "$has_next" in
+      false)
+        break
+        ;;
+      true)
+        if [[ -z "$end_cursor" ]]; then
+          echo "❌ assertion failed: comments hasNextPage=true with empty endCursor" >&2
+          return 1
+        fi
+        cursor="$end_cursor"
+        ;;
+      *)
+        echo "❌ assertion failed: unexpected comments hasNextPage value '$has_next'" >&2
+        return 1
+        ;;
+    esac
+  done
+
+  COMMENTS_JSON="$all_comments"
+}
+
+fetch_all_reviews_via_api() {
+  # shellcheck disable=SC2016 # Single quotes are intentional - this is a GraphQL query.
+  local graphql_query='query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviews(first: 100, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            author { login }
+            body
+            state
+            createdAt
+            submittedAt
+          }
+        }
+      }
+    }
+  }'
+
+  local all_reviews='[]'
+  local cursor="null"
+  local page_data
+  local page_reviews
+  local has_next
+  local end_cursor
+
+  while true; do
+    page_data=$(graphql_with_retries "$graphql_query" "$cursor") || return 1
+
+    if [ "$(echo "$page_data" | jq -r '.data.repository.pullRequest == null')" = "true" ]; then
+      echo "❌ PR #$PR_NUMBER does not exist in ${OWNER}/${REPO}." >&2
+      return 1
+    fi
+
+    page_reviews=$(echo "$page_data" | jq -c '.data.repository.pullRequest.reviews.nodes // []')
+    all_reviews=$(jq -cn --argjson existing "$all_reviews" --argjson page "$page_reviews" '$existing + $page')
+    has_next=$(echo "$page_data" | jq -r '.data.repository.pullRequest.reviews.pageInfo.hasNextPage')
+    end_cursor=$(echo "$page_data" | jq -r '.data.repository.pullRequest.reviews.pageInfo.endCursor // empty')
+
+    case "$has_next" in
+      false)
+        break
+        ;;
+      true)
+        if [[ -z "$end_cursor" ]]; then
+          echo "❌ assertion failed: reviews hasNextPage=true with empty endCursor" >&2
+          return 1
+        fi
+        cursor="$end_cursor"
+        ;;
+      *)
+        echo "❌ assertion failed: unexpected reviews hasNextPage value '$has_next'" >&2
+        return 1
+        ;;
+    esac
+  done
+
+  REVIEWS_JSON="$all_reviews"
+}
+
+fetch_all_threads_via_api() {
+  # shellcheck disable=SC2016 # Single quotes are intentional - this is a GraphQL query.
+  local graphql_query='query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            isResolved
+            comments(first: 100) {
+              nodes {
+                author { login }
+                body
+                createdAt
+                path
+                line
+              }
+            }
+          }
+        }
+      }
+    }
+  }'
+
+  local all_threads='[]'
+  local cursor="null"
+  local page_data
+  local page_threads
+  local has_next
+  local end_cursor
+
+  while true; do
+    page_data=$(graphql_with_retries "$graphql_query" "$cursor") || return 1
+
+    if [ "$(echo "$page_data" | jq -r '.data.repository.pullRequest == null')" = "true" ]; then
+      echo "❌ PR #$PR_NUMBER does not exist in ${OWNER}/${REPO}." >&2
+      return 1
+    fi
+
+    page_threads=$(echo "$page_data" | jq -c '.data.repository.pullRequest.reviewThreads.nodes // []')
+    all_threads=$(jq -cn --argjson existing "$all_threads" --argjson page "$page_threads" '$existing + $page')
+    has_next=$(echo "$page_data" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+    end_cursor=$(echo "$page_data" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // empty')
+
+    case "$has_next" in
+      false)
+        break
+        ;;
+      true)
+        if [[ -z "$end_cursor" ]]; then
+          echo "❌ assertion failed: reviewThreads hasNextPage=true with empty endCursor" >&2
+          return 1
+        fi
+        cursor="$end_cursor"
+        ;;
+      *)
+        echo "❌ assertion failed: unexpected reviewThreads hasNextPage value '$has_next'" >&2
+        return 1
+        ;;
+    esac
+  done
+
+  THREADS_JSON="$all_threads"
+}
+
+load_pr_data() {
+  local pr_data
+  local pr_state
+  local comments_has_previous
+  local reviews_has_previous
+  local threads_has_previous
+
+  pr_data=$(fetch_pr_snapshot) || return 1
+
+  if [ "$(echo "$pr_data" | jq -r '.data.repository.pullRequest == null')" = "true" ]; then
+    echo "❌ PR #$PR_NUMBER does not exist in ${OWNER}/${REPO}." >&2
+    return 1
+  fi
+
+  pr_state=$(echo "$pr_data" | jq -r '.data.repository.pullRequest.state // empty')
+  case "$pr_state" in
+    MERGED)
+      echo "✅ PR #$PR_NUMBER has been merged!"
+      return 20
+      ;;
+    CLOSED)
+      echo "❌ PR #$PR_NUMBER is closed (not merged)!"
+      return 1
+      ;;
+    OPEN) ;;
+    *)
+      echo "❌ assertion failed: unexpected PR state '$pr_state' for PR #$PR_NUMBER" >&2
+      return 1
+      ;;
+  esac
+
+  COMMENTS_JSON=$(echo "$pr_data" | jq -c '.data.repository.pullRequest.comments.nodes // []')
+  REVIEWS_JSON=$(echo "$pr_data" | jq -c '.data.repository.pullRequest.reviews.nodes // []')
+  THREADS_JSON=$(echo "$pr_data" | jq -c '.data.repository.pullRequest.reviewThreads.nodes // []')
+
+  comments_has_previous=$(echo "$pr_data" | jq -r '(.data.repository.pullRequest.comments.pageInfo.hasPreviousPage | if . == null then "unknown" else tostring end)')
+  reviews_has_previous=$(echo "$pr_data" | jq -r '(.data.repository.pullRequest.reviews.pageInfo.hasPreviousPage | if . == null then "unknown" else tostring end)')
+  threads_has_previous=$(echo "$pr_data" | jq -r '(.data.repository.pullRequest.reviewThreads.pageInfo.hasPreviousPage | if . == null then "unknown" else tostring end)')
+
+  case "$comments_has_previous" in
+    false) ;;
+    true) fetch_all_comments_via_api || return 1 ;;
+    unknown)
+      echo "❌ assertion failed: comments pageInfo.hasPreviousPage is missing" >&2
+      return 1
+      ;;
+    *)
+      echo "❌ assertion failed: unexpected comments hasPreviousPage value '$comments_has_previous'" >&2
+      return 1
+      ;;
+  esac
+
+  case "$reviews_has_previous" in
+    false) ;;
+    true) fetch_all_reviews_via_api || return 1 ;;
+    unknown)
+      echo "❌ assertion failed: reviews pageInfo.hasPreviousPage is missing" >&2
+      return 1
+      ;;
+    *)
+      echo "❌ assertion failed: unexpected reviews hasPreviousPage value '$reviews_has_previous'" >&2
+      return 1
+      ;;
+  esac
+
+  case "$threads_has_previous" in
+    false) ;;
+    true) fetch_all_threads_via_api || return 1 ;;
+    unknown)
+      echo "❌ assertion failed: reviewThreads pageInfo.hasPreviousPage is missing" >&2
+      return 1
+      ;;
+    *)
+      echo "❌ assertion failed: unexpected reviewThreads hasPreviousPage value '$threads_has_previous'" >&2
+      return 1
+      ;;
+  esac
+}
+
+LAST_REQUEST_AT="none"
+
+check_coder_agents_status_once() {
+  local request_at
+  local bot_activity_count
+  local unresolved_threads
+  local unresolved_count
+  local response_count
+  local latest_review_state
+  local latest_review_at
+
+  resolve_repo_context || return 1
+  if load_pr_data; then
+    :
+  else
+    local load_rc=$?
+    if [ "$load_rc" -eq 20 ]; then
+      return 0
+    fi
+    return "$load_rc"
+  fi
+
+  request_at=$(jq -rn \
+    --argjson comments "$COMMENTS_JSON" \
+    --arg command "$REQUEST_COMMAND" \
+    --arg bot_regex "$BOT_LOGIN_REGEX" '
+      [
+        $comments[]
+        | select((((.author.login // "") | test($bot_regex)) | not) and ((.body // "") | contains($command)))
+      ]
+      | sort_by(.createdAt)
+      | last
+      | .createdAt // empty
+    ')
+
+  if [[ -n "$request_at" ]]; then
+    LAST_REQUEST_AT="$request_at"
+  else
+    LAST_REQUEST_AT="none"
+  fi
+
+  bot_activity_count=$(jq -rn \
+    --argjson reviews "$REVIEWS_JSON" \
+    --argjson threads "$THREADS_JSON" \
+    --arg bot_regex "$BOT_LOGIN_REGEX" '
+      ([
+        $reviews[]
+        | select(((.author.login // "") | test($bot_regex)) and (.state != "DISMISSED"))
+      ] | length)
+      +
+      ([
+        $threads[].comments.nodes[]?
+        | select((.author.login // "") | test($bot_regex))
+      ] | length)
+    ')
+
+  if [[ -z "$request_at" && "$bot_activity_count" -eq 0 ]]; then
+    echo "ℹ️ coder-agents-review gate skipped: no '$REQUEST_COMMAND' comment and no bot review activity found."
+    return 20
+  fi
+
+  unresolved_threads=$(coder_agents_unresolved_threads_from_json "$THREADS_JSON" "$BOT_LOGIN_REGEX")
+  unresolved_count=$(printf '%s' "$unresolved_threads" | jq -s 'length')
+
+  if [ "$unresolved_count" -gt 0 ]; then
+    echo ""
+    echo "❌ coder-agents-review has ${unresolved_count} unresolved review thread(s)."
+    echo ""
+    coder_agents_print_unresolved_threads "$unresolved_threads"
+    return 1
+  fi
+
+  if [[ -n "$request_at" ]]; then
+    response_count=$(jq -rn \
+      --argjson reviews "$REVIEWS_JSON" \
+      --argjson threads "$THREADS_JSON" \
+      --arg bot_regex "$BOT_LOGIN_REGEX" \
+      --arg request_at "$request_at" '
+        ([
+          $reviews[]
+          | select(
+              ((.author.login // "") | test($bot_regex))
+              and (.state != "DISMISSED")
+              and ((.submittedAt // .createdAt // "") > $request_at)
+            )
+        ] | length)
+        +
+        ([
+          $threads[].comments.nodes[]?
+          | select(((.author.login // "") | test($bot_regex)) and (.createdAt > $request_at))
+        ] | length)
+      ')
+
+    if [ "$response_count" -eq 0 ]; then
+      return 10
+    fi
+
+    latest_review_state=$(jq -rn \
+      --argjson reviews "$REVIEWS_JSON" \
+      --arg bot_regex "$BOT_LOGIN_REGEX" \
+      --arg request_at "$request_at" '
+        [
+          $reviews[]
+          | select(
+              ((.author.login // "") | test($bot_regex))
+              and (.state != "DISMISSED")
+              and ((.submittedAt // .createdAt // "") > $request_at)
+            )
+          | . + {reviewedAt: (.submittedAt // .createdAt // "")}
+        ]
+        | sort_by(.reviewedAt)
+        | last
+        | .state // empty
+      ')
+    latest_review_at=$(jq -rn \
+      --argjson reviews "$REVIEWS_JSON" \
+      --arg bot_regex "$BOT_LOGIN_REGEX" \
+      --arg request_at "$request_at" '
+        [
+          $reviews[]
+          | select(
+              ((.author.login // "") | test($bot_regex))
+              and (.state != "DISMISSED")
+              and ((.submittedAt // .createdAt // "") > $request_at)
+            )
+          | . + {reviewedAt: (.submittedAt // .createdAt // "")}
+        ]
+        | sort_by(.reviewedAt)
+        | last
+        | .reviewedAt // empty
+      ')
+  else
+    response_count="$bot_activity_count"
+    latest_review_state=$(jq -rn \
+      --argjson reviews "$REVIEWS_JSON" \
+      --arg bot_regex "$BOT_LOGIN_REGEX" '
+        [
+          $reviews[]
+          | select(((.author.login // "") | test($bot_regex)) and (.state != "DISMISSED"))
+          | . + {reviewedAt: (.submittedAt // .createdAt // "")}
+        ]
+        | sort_by(.reviewedAt)
+        | last
+        | .state // empty
+      ')
+    latest_review_at=$(jq -rn \
+      --argjson reviews "$REVIEWS_JSON" \
+      --arg bot_regex "$BOT_LOGIN_REGEX" '
+        [
+          $reviews[]
+          | select(((.author.login // "") | test($bot_regex)) and (.state != "DISMISSED"))
+          | . + {reviewedAt: (.submittedAt // .createdAt // "")}
+        ]
+        | sort_by(.reviewedAt)
+        | last
+        | .reviewedAt // empty
+      ')
+  fi
+
+  if [ "$response_count" -eq 0 ]; then
+    echo "ℹ️ coder-agents-review gate skipped: no bot review activity found."
+    return 20
+  fi
+
+  case "$latest_review_state" in
+    APPROVED | COMMENTED)
+      echo ""
+      echo "✅ coder-agents-review gate passed for PR #$PR_NUMBER"
+      if [[ -n "$latest_review_at" ]]; then
+        echo "Review timestamp: $latest_review_at"
+      fi
+      return 0
+      ;;
+    "")
+      echo ""
+      echo "✅ coder-agents-review gate passed for PR #$PR_NUMBER"
+      return 0
+      ;;
+    CHANGES_REQUESTED)
+      echo ""
+      echo "❌ coder-agents-review requested changes on PR #$PR_NUMBER."
+      if [[ -n "$latest_review_at" ]]; then
+        echo "Review timestamp: $latest_review_at"
+      fi
+      echo "Resolve/address the feedback and request another review with '$REQUEST_COMMAND'."
+      return 1
+      ;;
+    PENDING)
+      return 10
+      ;;
+    DISMISSED)
+      echo "❌ assertion failed: dismissed reviews should be filtered before state classification" >&2
+      return 1
+      ;;
+    *)
+      echo "❌ assertion failed: unexpected coder-agents-review state '$latest_review_state'" >&2
+      return 1
+      ;;
+  esac
+}
+
+if [ "$MODE" = "once" ]; then
+  if check_coder_agents_status_once; then
+    rc=0
+  else
+    rc=$?
+  fi
+
+  case "$rc" in
+    0 | 1 | 10 | 20)
+      exit "$rc"
+      ;;
+    *)
+      echo "❌ assertion failed: unexpected coder-agents-review status code '$rc'" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+echo "⏳ Waiting for optional coder-agents-review gate on PR #$PR_NUMBER..."
+echo ""
+echo "Tip: comment '$REQUEST_COMMAND' to opt this PR into the optional coder-agents-review gate."
+echo "If the bot has already reviewed the PR, this script checks that feedback even without a request comment."
+echo ""
+
+while true; do
+  if check_coder_agents_status_once; then
+    rc=0
+  else
+    rc=$?
+  fi
+
+  case "$rc" in
+    0)
+      exit 0
+      ;;
+    1)
+      exit 1
+      ;;
+    10)
+      echo -ne "\r⏳ Waiting for coder-agents-review response... (requested at ${LAST_REQUEST_AT})  "
+      sleep "$POLL_INTERVAL_SECS"
+      ;;
+    20)
+      echo "ℹ️ Optional coder-agents-review gate is inactive; skipping."
+      exit 0
+      ;;
+    *)
+      echo "❌ assertion failed: unexpected coder-agents-review status code '$rc'" >&2
+      exit 1
+      ;;
+  esac
+done

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -36,9 +36,9 @@ fi
 REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
-CODER_AGENTS_BOT_APPROVAL_REGEX="^[[:space:]]*(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|review complete(d)?[.]?|zero open findings([.]|[[:space:]]+across[[:space:]].*)?)[[:space:]]*$"
-CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX="^[[:space:]]*(Round [0-9]+ is blocked|Review failed|Failed to review|Unable to review|Cannot review|Could not review|Review timed out|Request timed out|Review cancelled|Request cancelled)"
-CODER_AGENTS_BOT_PROGRESS_REGEX="^[[:space:]]*(queued|started|running|in progress|reviewing|will review)[[:space:][:punct:]]*$"
+CODER_AGENTS_BOT_APPROVAL_REGEX="^(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|review complete(d)?[.]?|zero open findings[.]?|.*zero open findings across .* review complete[.]?)$"
+CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX="^(Round [0-9]+ is blocked|Review failed|Failed to review|Unable to review|Cannot review|Could not review|Review timed out|Request timed out|Review cancelled|Request cancelled)"
+CODER_AGENTS_BOT_PROGRESS_REGEX="^(queued|started|running|in progress|reviewing|will review)[[:space:][:punct:]]*$"
 POLL_INTERVAL_SECS=30
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 SKIP_FETCH_SYNC="${MUX_SKIP_FETCH_SYNC:-0}"
@@ -388,18 +388,21 @@ classify_bot_text_response() {
   local body="$1"
   local created_at="$2"
   local source_label="$3"
+  local normalized_body
 
-  if printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX"; then
+  normalized_body=$(printf '%s' "$body" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')
+
+  if printf '%s\n' "$normalized_body" | grep -Eiq "$CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX"; then
     echo ""
     echo "❌ coder-agents-review responded with a negative ${source_label} on PR #$PR_NUMBER."
-  elif printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_BOT_APPROVAL_REGEX"; then
+  elif printf '%s\n' "$normalized_body" | grep -Eiq "$CODER_AGENTS_BOT_APPROVAL_REGEX"; then
     echo ""
     echo "✅ coder-agents-review gate passed for PR #$PR_NUMBER via ${source_label}"
     if [[ -n "$created_at" ]]; then
       echo "Timestamp: $created_at"
     fi
     return 0
-  elif printf '%s\n' "$body" | grep -Eiq "$CODER_AGENTS_BOT_PROGRESS_REGEX"; then
+  elif printf '%s\n' "$normalized_body" | grep -Eiq "$CODER_AGENTS_BOT_PROGRESS_REGEX"; then
     return "$RC_PENDING"
   else
     echo ""
@@ -447,7 +450,7 @@ check_coder_agents_status_once() {
     --arg bot_regex "$BOT_LOGIN_REGEX" '
       [
         $comments[]
-        | select((((.author.login // "") | test($bot_regex)) | not) and ((.body // "") | contains($command)))
+        | select((((.author.login // "") | test($bot_regex)) | not) and ((.body // "") | test("(?m)^\\s*/coder-agents-review\\s*$")))
       ]
       | sort_by(.createdAt)
       | last

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -36,7 +36,7 @@ fi
 REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
-CODER_AGENTS_BOT_APPROVAL_REGEX="^(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|review complete(d)?[.]?|zero open findings[.]?|zero open findings across .* (coder-agents-review |review )?complete[.]?|Round [0-9]+[.] zero open findings[.] (coder-agents-review |review )?complete[.]?|Round [0-9]+[.] zero open findings across .* (coder-agents-review |review )?complete[.]?|Round [0-9]+[.] .*[[:space:]]zero open findings[.] .*(coder-agents-review |review )?complete[.]?)$"
+CODER_AGENTS_BOT_APPROVAL_REGEX="^(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|review complete(d)?[.]?|zero open findings[.]?|zero open findings across .* (coder-agents-review |review )?complete[.]?|Round [0-9]+[.] zero open findings[.] (coder-agents-review |review )?complete[.]?|Round [0-9]+[.] zero open findings across .* (coder-agents-review |review )?complete[.]?)$"
 CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX="^(Round [0-9]+ is blocked|Review failed|Failed to review|Unable to review|Cannot review|Could not review|Review timed out|Request timed out|Review cancelled|Request cancelled)"
 CODER_AGENTS_BOT_PROGRESS_REGEX="^(queued|started|running|in progress|reviewing|will review)[[:space:][:punct:]]*$"
 POLL_INTERVAL_SECS=30

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -37,7 +37,7 @@ REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
 CODER_AGENTS_BOT_APPROVAL_REGEX="no (issues|problems)|no major issues|looks good|lgtm|didn.t find|(^|[[:space:][:punct:]])approved([[:space:][:punct:]]|$)"
-CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX="not approved|not yet approved|review failed|failed to review|unable to review|cannot review|could not review|timed out|cancelled|blocked|needs changes|changes requested|without author response|unaddressed|to unblock"
+CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX="not approved|not yet approved|review failed|failed to review|unable to review|cannot review|could not review|review timed out|request timed out|review cancelled|request cancelled|is blocked|blocked until|needs changes|changes requested( for|:)|without author response|unaddressed findings|to unblock"
 CODER_AGENTS_BOT_PROGRESS_REGEX="^[[:space:]]*(queued|started|running|in progress|reviewing|will review)[[:space:][:punct:]]*$"
 POLL_INTERVAL_SECS=30
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
@@ -605,7 +605,6 @@ check_coder_agents_status_once() {
         | .reviewedAt // empty
       ')
   else
-    response_count="$bot_activity_count"
     latest_issue_comment_body=$(jq -rn \
       --argjson comments "$COMMENTS_JSON" \
       --arg bot_regex "$BOT_LOGIN_REGEX" '
@@ -673,7 +672,7 @@ check_coder_agents_status_once() {
     if [[ -n "$latest_review_at" ]]; then
       echo "Review timestamp: $latest_review_at"
     fi
-    echo "Resolve/address the feedback and request another review with '$REQUEST_COMMAND'."
+    echo "Resolve/address the feedback, reply to the finding(s), and request another review with '$REQUEST_COMMAND'."
     return "$RC_FAILED"
   fi
 

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -36,7 +36,7 @@ fi
 REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
-CODER_AGENTS_BOT_APPROVAL_REGEX="^[[:space:]]*(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|zero open findings.*|review complete(d)?[.]?)[[:space:]]*$"
+CODER_AGENTS_BOT_APPROVAL_REGEX="^[[:space:]]*(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|review complete(d)?[.]?)[[:space:]]*$|(^|[[:space:]])zero open findings"
 CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX="^[[:space:]]*(Round [0-9]+ is blocked|Review failed|Failed to review|Unable to review|Cannot review|Could not review|Review timed out|Request timed out|Review cancelled|Request cancelled)"
 CODER_AGENTS_BOT_PROGRESS_REGEX="^[[:space:]]*(queued|started|running|in progress|reviewing|will review)[[:space:][:punct:]]*$"
 POLL_INTERVAL_SECS=30

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -36,7 +36,7 @@ fi
 REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
-CODER_AGENTS_BOT_APPROVAL_REGEX="^(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|review complete(d)?[.]?|zero open findings[.]?|((.*[[:space:]])?zero open findings across .* review complete[.]?))$"
+CODER_AGENTS_BOT_APPROVAL_REGEX="^(no (issues|problems)( found)?[.]?|no major issues( found)?[.]?|didn.t find (any )?(major )?(issues|problems)[.]?|review complete(d)?[.]?|zero open findings[.]?|zero open findings across .* review complete[.]?|Round [0-9]+[.] .*zero open findings across .* review complete[.]?)$"
 CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX="^(Round [0-9]+ is blocked|Review failed|Failed to review|Unable to review|Cannot review|Could not review|Review timed out|Request timed out|Review cancelled|Request cancelled)"
 CODER_AGENTS_BOT_PROGRESS_REGEX="^(queued|started|running|in progress|reviewing|will review)[[:space:][:punct:]]*$"
 POLL_INTERVAL_SECS=30

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -36,8 +36,8 @@ fi
 REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
-CODER_AGENTS_BOT_APPROVAL_REGEX="no (issues|problems)|no major issues|looks good|lgtm|didn.t find|(^|[[:space:][:punct:]])review complete(d)?([[:space:][:punct:]]|$)|(^|[[:space:][:punct:]])approved([[:space:][:punct:]]|$)"
-CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX="not approved|not yet approved|review failed|failed to review|unable to review|cannot review|could not review|review timed out|request timed out|review cancelled|request cancelled|is blocked|blocked until|needs changes|changes requested( for|:)|without author response|unaddressed findings|to unblock"
+CODER_AGENTS_BOT_APPROVAL_REGEX="no (issues|problems)|no major issues|didn.t find|zero open findings|(^|[[:space:][:punct:]])review complete(d)?([[:space:][:punct:]]|$)"
+CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX="^[[:space:]]*(Round [0-9]+ is blocked|Review failed|Failed to review|Unable to review|Cannot review|Could not review|Review timed out|Request timed out|Review cancelled|Request cancelled)"
 CODER_AGENTS_BOT_PROGRESS_REGEX="^[[:space:]]*(queued|started|running|in progress|reviewing|will review)[[:space:][:punct:]]*$"
 POLL_INTERVAL_SECS=30
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -36,7 +36,7 @@ fi
 REQUEST_COMMAND="/coder-agents-review"
 # Match both the app slug and GitHub's bot-login form.
 BOT_LOGIN_REGEX="${CODER_AGENTS_REVIEW_BOT_LOGIN_REGEX:-^coder-agents-review(\[bot\])?$}"
-CODER_AGENTS_BOT_APPROVAL_REGEX="no (issues|problems)|no major issues|looks good|lgtm|didn.t find|review complete|(^|[[:space:][:punct:]])approved([[:space:][:punct:]]|$)"
+CODER_AGENTS_BOT_APPROVAL_REGEX="no (issues|problems)|no major issues|looks good|lgtm|didn.t find|(^|[[:space:][:punct:]])review complete(d)?([[:space:][:punct:]]|$)|(^|[[:space:][:punct:]])approved([[:space:][:punct:]]|$)"
 CODER_AGENTS_BOT_NEGATIVE_BEFORE_APPROVAL_REGEX="not approved|not yet approved|review failed|failed to review|unable to review|cannot review|could not review|review timed out|request timed out|review cancelled|request cancelled|is blocked|blocked until|needs changes|changes requested( for|:)|without author response|unaddressed findings|to unblock"
 CODER_AGENTS_BOT_PROGRESS_REGEX="^[[:space:]]*(queued|started|running|in progress|reviewing|will review)[[:space:][:punct:]]*$"
 POLL_INTERVAL_SECS=30

--- a/scripts/wait_pr_coder_agents_review.sh
+++ b/scripts/wait_pr_coder_agents_review.sh
@@ -499,9 +499,15 @@ check_coder_agents_status_once() {
   fi
 
   bot_activity_count=$(jq -rn \
+    --argjson comments "$COMMENTS_JSON" \
     --argjson reviews "$REVIEWS_JSON" \
     --argjson threads "$THREADS_JSON" \
     --arg bot_regex "$BOT_LOGIN_REGEX" '
+      ([
+        $comments[]
+        | select((.author.login // "") | test($bot_regex))
+      ] | length)
+      +
       ([
         $reviews[]
         | select(((.author.login // "") | test($bot_regex)) and (.state != "DISMISSED"))
@@ -531,10 +537,16 @@ check_coder_agents_status_once() {
 
   if [[ -n "$request_at" ]]; then
     response_count=$(jq -rn \
+      --argjson comments "$COMMENTS_JSON" \
       --argjson reviews "$REVIEWS_JSON" \
       --argjson threads "$THREADS_JSON" \
       --arg bot_regex "$BOT_LOGIN_REGEX" \
       --arg request_at "$request_at" '
+        ([
+          $comments[]
+          | select(((.author.login // "") | test($bot_regex)) and (.createdAt > $request_at))
+        ] | length)
+        +
         ([
           $reviews[]
           | select(

--- a/scripts/wait_pr_ready.sh
+++ b/scripts/wait_pr_ready.sh
@@ -4,13 +4,14 @@ set -euo pipefail
 # Wait for a PR to become merge-ready by enforcing the Codex + CI loop.
 # Usage: ./scripts/wait_pr_ready.sh <pr_number>
 #
-# This script orchestrates Codex + checks in one polling loop:
+# This script orchestrates Codex + optional coder-agents-review + checks in one polling loop:
 #   1) wait_pr_codex.sh --once
-#   2) wait_pr_checks.sh --once
-#   3) check_codex_comments.sh (only when both gates pass)
+#   2) wait_pr_coder_agents_review.sh --once (skips unless explicitly requested/active)
+#   3) wait_pr_checks.sh --once
+#   4) check_codex_comments.sh (only when all active gates pass)
 #
 # It exits immediately on the first terminal failure and succeeds only when
-# all gates report success.
+# all required and active optional gates report success.
 
 if [ $# -ne 1 ]; then
   echo "Usage: $0 <pr_number>" >&2
@@ -28,13 +29,14 @@ POLL_INTERVAL_SECS=30
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 WAIT_CODEX_SCRIPT="$SCRIPT_DIR/wait_pr_codex.sh"
+WAIT_CODER_AGENTS_REVIEW_SCRIPT="$SCRIPT_DIR/wait_pr_coder_agents_review.sh"
 WAIT_CHECKS_SCRIPT="$SCRIPT_DIR/wait_pr_checks.sh"
 CHECK_CODEX_COMMENTS_SCRIPT="$SCRIPT_DIR/check_codex_comments.sh"
 # shellcheck source=./lib/branch_sync_guard.sh
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/branch_sync_guard.sh"
 
-for required in "$WAIT_CODEX_SCRIPT" "$WAIT_CHECKS_SCRIPT" "$CHECK_CODEX_COMMENTS_SCRIPT"; do
+for required in "$WAIT_CODEX_SCRIPT" "$WAIT_CODER_AGENTS_REVIEW_SCRIPT" "$WAIT_CHECKS_SCRIPT" "$CHECK_CODEX_COMMENTS_SCRIPT"; do
   if [ ! -x "$required" ]; then
     echo "❌ Required executable script is missing or not executable: $required" >&2
     exit 1
@@ -66,6 +68,25 @@ status_from_rc() {
       return 1
       ;;
   esac
+}
+
+status_from_optional_rc() {
+  local rc="$1"
+
+  case "$rc" in
+    20)
+      echo "skipped"
+      ;;
+    *)
+      status_from_rc "$rc"
+      ;;
+  esac
+}
+
+optional_gate_allows_ready() {
+  local rc="$1"
+
+  [ "$rc" -eq 0 ] || [ "$rc" -eq 20 ]
 }
 
 load_repo_context() {
@@ -118,7 +139,7 @@ trap cleanup EXIT
 export MUX_PR_DATA_FILE="$PR_DATA_FILE"
 export MUX_REACTIONS_SCAN_CACHE_FILE="$REACTIONS_SCAN_CACHE_FILE"
 
-echo "🚦 Waiting for PR #$PR_NUMBER to become ready (Codex + CI, fail-fast)..."
+echo "🚦 Waiting for PR #$PR_NUMBER to become ready (Codex + optional coder-agents-review + CI, fail-fast)..."
 echo ""
 
 while true; do
@@ -131,9 +152,9 @@ while true; do
   CODEX_STATUS=$(status_from_rc "$CODEX_RC") || exit 1
 
   # True fail-fast behavior: if Codex is already terminal-failed, exit immediately
-  # without waiting for the checks gate.
+  # without waiting for the optional bot or checks gates.
   if [ "$CODEX_RC" -eq 1 ]; then
-    echo -ne "\r⏳ Gate status: Codex=${CODEX_STATUS} | Checks=skipped    "
+    echo -ne "\r⏳ Gate status: Codex=${CODEX_STATUS} | Coder Agents=skipped | Checks=skipped    "
     echo ""
     echo ""
     echo "❌ PR #$PR_NUMBER is not ready."
@@ -155,6 +176,33 @@ while true; do
     exit 1
   fi
 
+  if CODER_AGENTS_OUT=$("$WAIT_CODER_AGENTS_REVIEW_SCRIPT" "$PR_NUMBER" --once 2>&1); then
+    CODER_AGENTS_RC=0
+  else
+    CODER_AGENTS_RC=$?
+  fi
+
+  CODER_AGENTS_STATUS=$(status_from_optional_rc "$CODER_AGENTS_RC") || exit 1
+
+  if [ "$CODER_AGENTS_RC" -eq 1 ]; then
+    echo -ne "\r⏳ Gate status: Codex=${CODEX_STATUS} | Coder Agents=${CODER_AGENTS_STATUS} | Checks=skipped    "
+    echo ""
+    echo ""
+    echo "❌ PR #$PR_NUMBER is not ready."
+    echo ""
+    echo "--- coder-agents-review gate output ---"
+    if [ -n "$CODER_AGENTS_OUT" ]; then
+      echo "$CODER_AGENTS_OUT"
+    else
+      echo "(no output)"
+    fi
+    echo ""
+    echo "Address coder-agents-review feedback, push, and request another optional review if desired:"
+    echo ""
+    echo "  gh pr comment $PR_NUMBER --body '/coder-agents-review'"
+    exit 1
+  fi
+
   if CHECKS_OUT=$("$WAIT_CHECKS_SCRIPT" "$PR_NUMBER" --once 2>&1); then
     CHECKS_RC=0
   else
@@ -162,7 +210,7 @@ while true; do
   fi
 
   CHECKS_STATUS=$(status_from_rc "$CHECKS_RC") || exit 1
-  echo -ne "\r⏳ Gate status: Codex=${CODEX_STATUS} | Checks=${CHECKS_STATUS}    "
+  echo -ne "\r⏳ Gate status: Codex=${CODEX_STATUS} | Coder Agents=${CODER_AGENTS_STATUS} | Checks=${CHECKS_STATUS}    "
 
   if [ "$CHECKS_RC" -eq 1 ]; then
     echo ""
@@ -180,7 +228,7 @@ while true; do
     exit 1
   fi
 
-  if [ "$CODEX_RC" -eq 0 ] && [ "$CHECKS_RC" -eq 0 ]; then
+  if [ "$CODEX_RC" -eq 0 ] && optional_gate_allows_ready "$CODER_AGENTS_RC" && [ "$CHECKS_RC" -eq 0 ]; then
     # Avoid a false "not ready" result for already-merged PRs: historical unresolved
     # Codex threads should not block a merged terminal state.
     PR_STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state' 2>/dev/null || echo "error")
@@ -201,10 +249,61 @@ while true; do
         ;;
     esac
 
+    # Re-check the optional bot gate after checks pass so a newer
+    # /coder-agents-review request posted during this loop cannot be missed.
+    if optional_gate_allows_ready "$CODER_AGENTS_RC"; then
+      if CODER_AGENTS_FINAL_OUT=$("$WAIT_CODER_AGENTS_REVIEW_SCRIPT" "$PR_NUMBER" --once 2>&1); then
+        CODER_AGENTS_FINAL_RC=0
+      else
+        CODER_AGENTS_FINAL_RC=$?
+      fi
+
+      case "$CODER_AGENTS_FINAL_RC" in
+        0)
+          CODER_AGENTS_RC=0
+          ;;
+        10)
+          CODER_AGENTS_STATUS=$(status_from_optional_rc "$CODER_AGENTS_FINAL_RC") || exit 1
+          echo -ne "\r⏳ Gate status: Codex=${CODEX_STATUS} | Coder Agents=${CODER_AGENTS_STATUS} | Checks=${CHECKS_STATUS}    "
+          sleep "$POLL_INTERVAL_SECS"
+          continue
+          ;;
+        20)
+          CODER_AGENTS_RC=20
+          CODER_AGENTS_STATUS=$(status_from_optional_rc "$CODER_AGENTS_FINAL_RC") || exit 1
+          ;;
+        1)
+          echo ""
+          echo ""
+          echo "❌ PR #$PR_NUMBER is not ready."
+          echo ""
+          echo "--- coder-agents-review gate output ---"
+          if [ -n "$CODER_AGENTS_FINAL_OUT" ]; then
+            echo "$CODER_AGENTS_FINAL_OUT"
+          else
+            echo "(no output)"
+          fi
+          echo ""
+          echo "Address coder-agents-review feedback, push, and rerun this script."
+          exit 1
+          ;;
+        *)
+          echo "❌ assertion failed: unexpected coder-agents-review status code '$CODER_AGENTS_FINAL_RC'" >&2
+          exit 1
+          ;;
+      esac
+    fi
+
+    if [ "$CODER_AGENTS_RC" -eq 0 ]; then
+      CODER_AGENTS_READY_SUMMARY="coder-agents-review gate passed"
+    else
+      CODER_AGENTS_READY_SUMMARY="optional coder-agents-review gate skipped"
+    fi
+
     if CODEX_COMMENTS_OUT=$("$CHECK_CODEX_COMMENTS_SCRIPT" "$PR_NUMBER" 2>&1); then
       echo ""
       echo ""
-      echo "🎉 PR #$PR_NUMBER is ready: Codex approved, required checks passed, and no unresolved Codex comments remain."
+      echo "🎉 PR #$PR_NUMBER is ready: Codex approved, ${CODER_AGENTS_READY_SUMMARY}, required checks passed, and no unresolved Codex comments remain."
       exit 0
     fi
 

--- a/scripts/wait_pr_ready.sh
+++ b/scripts/wait_pr_ready.sh
@@ -8,7 +8,9 @@ set -euo pipefail
 #   1) wait_pr_codex.sh --once
 #   2) wait_pr_coder_agents_review.sh --once (skips unless explicitly requested/active)
 #   3) wait_pr_checks.sh --once
-#   4) check_codex_comments.sh (only when all active gates pass)
+#   4) wait_pr_coder_agents_review.sh --once after checks pass
+#   5) check_coder_agents_review_comments.sh (only when the optional gate is active)
+#   6) check_codex_comments.sh (only when all active gates pass)
 #
 # It exits immediately on the first terminal failure and succeeds only when
 # all required and active optional gates report success.

--- a/scripts/wait_pr_ready.sh
+++ b/scripts/wait_pr_ready.sh
@@ -202,7 +202,7 @@ while true; do
       echo "(no output)"
     fi
     echo ""
-    echo "Address coder-agents-review feedback, push, and request another optional review if desired:"
+    echo "Address coder-agents-review feedback, reply to the finding(s), push, and request another optional review:"
     echo ""
     echo "  gh pr comment $PR_NUMBER --body '/coder-agents-review'"
     exit 1

--- a/scripts/wait_pr_ready.sh
+++ b/scripts/wait_pr_ready.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Wait for a PR to become merge-ready by enforcing the Codex + CI loop.
+# Wait for a PR to become merge-ready by enforcing the Codex + optional coder-agents-review + CI loop.
 # Usage: ./scripts/wait_pr_ready.sh <pr_number>
 #
 # This script orchestrates Codex + optional coder-agents-review + checks in one polling loop:
@@ -26,17 +26,22 @@ fi
 
 # Polling every 30s reduces GitHub API churn while still giving timely readiness updates.
 POLL_INTERVAL_SECS=30
+RC_PASSED=0
+RC_FAILED=1
+RC_PENDING=10
+RC_SKIPPED=20
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 WAIT_CODEX_SCRIPT="$SCRIPT_DIR/wait_pr_codex.sh"
 WAIT_CODER_AGENTS_REVIEW_SCRIPT="$SCRIPT_DIR/wait_pr_coder_agents_review.sh"
 WAIT_CHECKS_SCRIPT="$SCRIPT_DIR/wait_pr_checks.sh"
 CHECK_CODEX_COMMENTS_SCRIPT="$SCRIPT_DIR/check_codex_comments.sh"
+CHECK_CODER_AGENTS_COMMENTS_SCRIPT="$SCRIPT_DIR/check_coder_agents_review_comments.sh"
 # shellcheck source=./lib/branch_sync_guard.sh
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/branch_sync_guard.sh"
 
-for required in "$WAIT_CODEX_SCRIPT" "$WAIT_CODER_AGENTS_REVIEW_SCRIPT" "$WAIT_CHECKS_SCRIPT" "$CHECK_CODEX_COMMENTS_SCRIPT"; do
+for required in "$WAIT_CODEX_SCRIPT" "$WAIT_CODER_AGENTS_REVIEW_SCRIPT" "$WAIT_CHECKS_SCRIPT" "$CHECK_CODEX_COMMENTS_SCRIPT" "$CHECK_CODER_AGENTS_COMMENTS_SCRIPT"; do
   if [ ! -x "$required" ]; then
     echo "❌ Required executable script is missing or not executable: $required" >&2
     exit 1
@@ -54,13 +59,13 @@ status_from_rc() {
   local rc="$1"
 
   case "$rc" in
-    0)
+    "$RC_PASSED")
       echo "passed"
       ;;
-    10)
+    "$RC_PENDING")
       echo "pending"
       ;;
-    1)
+    "$RC_FAILED")
       echo "failed"
       ;;
     *)
@@ -74,7 +79,7 @@ status_from_optional_rc() {
   local rc="$1"
 
   case "$rc" in
-    20)
+    "$RC_SKIPPED")
       echo "skipped"
       ;;
     *)
@@ -86,7 +91,7 @@ status_from_optional_rc() {
 optional_gate_allows_ready() {
   local rc="$1"
 
-  [ "$rc" -eq 0 ] || [ "$rc" -eq 20 ]
+  [ "$rc" -eq "$RC_PASSED" ] || [ "$rc" -eq "$RC_SKIPPED" ]
 }
 
 load_repo_context() {
@@ -153,7 +158,7 @@ while true; do
 
   # True fail-fast behavior: if Codex is already terminal-failed, exit immediately
   # without waiting for the optional bot or checks gates.
-  if [ "$CODEX_RC" -eq 1 ]; then
+  if [ "$CODEX_RC" -eq "$RC_FAILED" ]; then
     echo -ne "\r⏳ Gate status: Codex=${CODEX_STATUS} | Coder Agents=skipped | Checks=skipped    "
     echo ""
     echo ""
@@ -184,7 +189,7 @@ while true; do
 
   CODER_AGENTS_STATUS=$(status_from_optional_rc "$CODER_AGENTS_RC") || exit 1
 
-  if [ "$CODER_AGENTS_RC" -eq 1 ]; then
+  if [ "$CODER_AGENTS_RC" -eq "$RC_FAILED" ]; then
     echo -ne "\r⏳ Gate status: Codex=${CODEX_STATUS} | Coder Agents=${CODER_AGENTS_STATUS} | Checks=skipped    "
     echo ""
     echo ""
@@ -212,7 +217,7 @@ while true; do
   CHECKS_STATUS=$(status_from_rc "$CHECKS_RC") || exit 1
   echo -ne "\r⏳ Gate status: Codex=${CODEX_STATUS} | Coder Agents=${CODER_AGENTS_STATUS} | Checks=${CHECKS_STATUS}    "
 
-  if [ "$CHECKS_RC" -eq 1 ]; then
+  if [ "$CHECKS_RC" -eq "$RC_FAILED" ]; then
     echo ""
     echo ""
     echo "❌ PR #$PR_NUMBER is not ready."
@@ -228,7 +233,7 @@ while true; do
     exit 1
   fi
 
-  if [ "$CODEX_RC" -eq 0 ] && optional_gate_allows_ready "$CODER_AGENTS_RC" && [ "$CHECKS_RC" -eq 0 ]; then
+  if [ "$CODEX_RC" -eq "$RC_PASSED" ] && optional_gate_allows_ready "$CODER_AGENTS_RC" && [ "$CHECKS_RC" -eq "$RC_PASSED" ]; then
     # Avoid a false "not ready" result for already-merged PRs: historical unresolved
     # Codex threads should not block a merged terminal state.
     PR_STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state' 2>/dev/null || echo "error")
@@ -259,20 +264,20 @@ while true; do
       fi
 
       case "$CODER_AGENTS_FINAL_RC" in
-        0)
-          CODER_AGENTS_RC=0
+        "$RC_PASSED")
+          CODER_AGENTS_RC="$RC_PASSED"
           ;;
-        10)
+        "$RC_PENDING")
           CODER_AGENTS_STATUS=$(status_from_optional_rc "$CODER_AGENTS_FINAL_RC") || exit 1
           echo -ne "\r⏳ Gate status: Codex=${CODEX_STATUS} | Coder Agents=${CODER_AGENTS_STATUS} | Checks=${CHECKS_STATUS}    "
           sleep "$POLL_INTERVAL_SECS"
           continue
           ;;
-        20)
-          CODER_AGENTS_RC=20
+        "$RC_SKIPPED")
+          CODER_AGENTS_RC="$RC_SKIPPED"
           CODER_AGENTS_STATUS=$(status_from_optional_rc "$CODER_AGENTS_FINAL_RC") || exit 1
           ;;
-        1)
+        "$RC_FAILED")
           echo ""
           echo ""
           echo "❌ PR #$PR_NUMBER is not ready."
@@ -284,7 +289,9 @@ while true; do
             echo "(no output)"
           fi
           echo ""
-          echo "Address coder-agents-review feedback, push, and rerun this script."
+          echo "Address coder-agents-review feedback, reply to the finding(s), push, and request another optional review:"
+          echo ""
+          echo "  gh pr comment $PR_NUMBER --body '/coder-agents-review'"
           exit 1
           ;;
         *)
@@ -294,7 +301,24 @@ while true; do
       esac
     fi
 
-    if [ "$CODER_AGENTS_RC" -eq 0 ]; then
+    if [ "$CODER_AGENTS_RC" -eq "$RC_PASSED" ]; then
+      if ! CODER_AGENTS_COMMENTS_OUT=$("$CHECK_CODER_AGENTS_COMMENTS_SCRIPT" "$PR_NUMBER" 2>&1); then
+        echo ""
+        echo ""
+        echo "❌ PR #$PR_NUMBER is not ready."
+        echo ""
+        echo "--- coder-agents-review comment gate output ---"
+        if [ -n "$CODER_AGENTS_COMMENTS_OUT" ]; then
+          echo "$CODER_AGENTS_COMMENTS_OUT"
+        else
+          echo "(no output)"
+        fi
+        echo ""
+        echo "Address coder-agents-review feedback, reply to the finding(s), push, and request another optional review:"
+        echo ""
+        echo "  gh pr comment $PR_NUMBER --body '/coder-agents-review'"
+        exit 1
+      fi
       CODER_AGENTS_READY_SUMMARY="coder-agents-review gate passed"
     else
       CODER_AGENTS_READY_SUMMARY="optional coder-agents-review gate skipped"

--- a/src/node/services/agentSkills/builtInSkillContent.generated.ts
+++ b/src/node/services/agentSkills/builtInSkillContent.generated.ts
@@ -471,7 +471,7 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
       '3. `agent-browser click @e1` / `fill @e2 "text"` - Interact using refs',
       "4. Re-snapshot after page changes",
       "",
-      "## PR Workflow (Codex)",
+      "## PR Workflow",
       "",
       "- When checking PR readiness, audit **all** PR reviews, review comments, and issue comments from every reviewer/bot (including `coder-agents-review`), not just Codex; address or explicitly resolve them before declaring readiness.",
       "- If a PR has `coder-agents-review` feedback, address it and reply before resolving: either reply inline on each finding or leave a PR comment that explicitly lists each finding and your response. Do not silently resolve those threads.",

--- a/src/node/services/agentSkills/builtInSkillContent.generated.ts
+++ b/src/node/services/agentSkills/builtInSkillContent.generated.ts
@@ -474,6 +474,7 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
       "## PR Workflow (Codex)",
       "",
       "- When checking PR readiness, audit **all** PR reviews, review comments, and issue comments from every reviewer/bot (including `coder-agents-review`), not just Codex; address or explicitly resolve them before declaring readiness.",
+      "- If a PR has `coder-agents-review` feedback, address it and reply before resolving: either reply inline on each finding or leave a PR comment that explicitly lists each finding and your response. Do not silently resolve those threads.",
       "- If a PR has Codex review comments, address + resolve them, then re-request review by commenting `@codex review` on the PR.",
       "- Prefer `gh` CLI for GitHub interactions over manual web/curl flows.",
       "",


### PR DESCRIPTION
## Summary

Adds an optional coder-agents-review PR gate to the existing readiness scripts. PRs continue to skip the new gate unless a user comments `/coder-agents-review` or the coder-agents-review bot has already participated.

## Background

We already wait on Codex and CI in `wait_pr_ready.sh`. This change lets teams opt into an additional bot review without making that review mandatory for every PR.

## Implementation

- Added `wait_pr_coder_agents_review.sh` with `--once` support and a skipped status for inactive PRs.
- Added `check_coder_agents_review_comments.sh` plus shared coder-agents review-thread formatting helpers.
- Wired the optional gate into `wait_pr_ready.sh` and its status line.

## Validation

- `make static-check`
- `make lint-shellcheck`
- `git diff --check`
- Fake `gh`/`git` dogfood scenarios for skipped, pending, passing, changes-requested, unresolved-thread, and full readiness paths.

## Risks

Low-to-medium. The new gate is opt-in and should skip by default, but the readiness script now performs one additional optional-gate query per polling iteration.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$19.19`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=19.19 -->
