### PR TITLE
🤖 tests: fix ExperimentsSection storybook flake

### DIFF
--- a/src/browser/features/Settings/Sections/ExperimentsSection.stories.tsx
+++ b/src/browser/features/Settings/Sections/ExperimentsSection.stories.tsx
@@ -1,5 +1,6 @@
 import { expect, userEvent, waitFor, within } from "@storybook/test";
 import { lightweightMeta } from "@/browser/stories/meta.js";
+import { replaceInputValue } from "@/browser/stories/storyPlayHelpers.js";
 import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { DEFAULT_IMAGE_GENERATION_MODEL } from "@/common/types/imageGeneration";
 import { DEFAULT_GOAL_DEFAULTS } from "@/constants/goals";
@@ -68,15 +69,17 @@ export const ImageGenerationEnabled: Story = {
     await waitFor(() => expect(uploadConsentSwitch).toHaveAttribute("aria-checked", "false"));
 
     const maxImagesInput = await canvas.findByDisplayValue("4");
-    await userEvent.clear(maxImagesInput);
-    await userEvent.type(maxImagesInput, "11");
+    // Use replaceInputValue (focus + select-all + type) instead of clear+type.
+    // The max-images input has an onBlur that normalizes invalid drafts back
+    // to the default; raw clear+type can interleave a spurious blur that
+    // resets the value and produces flaky assertions. See replaceInputValue
+    // for details.
+    await replaceInputValue(maxImagesInput, "11");
     await expect(
       canvas.findByText("Enter a whole number from 1 to 10.")
     ).resolves.toBeInTheDocument();
 
-    await userEvent.clear(maxImagesInput);
-    await userEvent.type(maxImagesInput, "2");
-    await waitFor(() => expect(maxImagesInput).toHaveValue("2"));
+    await replaceInputValue(maxImagesInput, "2");
   },
 };
 

--- a/src/browser/features/Settings/Sections/ImageGenerationExperimentConfig.tsx
+++ b/src/browser/features/Settings/Sections/ImageGenerationExperimentConfig.tsx
@@ -265,6 +265,14 @@ export function ImageGenerationExperimentConfig(props: ImageGenerationExperiment
     };
   }, [api, loaded, loadFailed]);
 
+  // NOTE: This blur handler resets invalid drafts back to a default. That
+  // interacts badly with naive Storybook play sequences like
+  // `userEvent.clear(...)` followed by `userEvent.type(...)`, because an
+  // interleaved blur can reset the field mid-sequence and produce flaky
+  // assertions (e.g. "42" instead of "2"). Story authors interacting with
+  // this input should use `replaceInputValue` from `storyPlayHelpers`, which
+  // overwrites via focus+select-all+type and never produces a transient
+  // empty/invalid value that this handler would clobber.
   const handleMaxImagesBlur = () => {
     const parsed = parseMaxImages(maxImagesDraft) ?? DEFAULT_IMAGE_GENERATION_MAX_IMAGES;
     setMaxImagesDraft(String(parsed));

--- a/src/browser/stories/storyPlayHelpers.ts
+++ b/src/browser/stories/storyPlayHelpers.ts
@@ -1,4 +1,4 @@
-import { waitFor } from "@storybook/test";
+import { userEvent, waitFor } from "@storybook/test";
 
 /**
  * Wait for chat messages to finish loading.
@@ -39,6 +39,61 @@ export async function waitForChatInputAutofocusDone(canvasElement: HTMLElement):
 
 export function blurActiveElement(): void {
   (document.activeElement as HTMLElement | null)?.blur?.();
+}
+
+/**
+ * Replace the contents of a controlled `<input>` / `<textarea>` deterministically.
+ *
+ * Why this exists: in play functions, the naive sequence
+ *
+ *     await userEvent.clear(input);
+ *     await userEvent.type(input, "2");
+ *
+ * is a classic flake source for controlled inputs. `userEvent.clear` (and
+ * the implicit click that `userEvent.type` performs before keystrokes) can
+ * leave the field transiently empty between the two steps. When the input
+ * has an `onBlur` handler that normalizes/resets the value (a very common
+ * pattern for numeric settings), any blur landing in that window resets
+ * the draft to a default; the subsequent `type("2")` then appends to it
+ * ("42" instead of "2"), and `toHaveValue("2")` fails non-deterministically.
+ *
+ * This helper avoids that by overwriting the existing contents atomically:
+ *
+ *   1. Click the input (explicit focus + matches user-event's normal click
+ *      semantics, so no surprise implicit click happens later that would
+ *      collapse our selection).
+ *   2. `setSelectionRange(0, length)` so the entire current value is selected
+ *      AFTER the click. (We can't `input.select()` before the click — the
+ *      click would collapse that selection. We also can't rely on
+ *      `userEvent.type`'s `initialSelectionStart`/`End` options being
+ *      preserved across user-event versions.)
+ *   3. `userEvent.keyboard(value)` — keyboard dispatches to the focused
+ *      element without performing another click, so the selection persists
+ *      and the typed value replaces it in one shot. No transient empty
+ *      state, no opportunity for an onBlur normalizer to reset the field.
+ *   4. Wait for the DOM to settle on the expected value.
+ *
+ * Prefer this over raw `clear` + `type` whenever you need to assert the final
+ * input value or trigger validation tied to a specific value.
+ */
+export async function replaceInputValue(
+  input: HTMLElement,
+  value: string,
+  expectedValue: string = value
+): Promise<void> {
+  if (!(input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement)) {
+    throw new Error("replaceInputValue: element is not an input or textarea");
+  }
+  await userEvent.click(input);
+  input.setSelectionRange(0, input.value.length);
+  await userEvent.keyboard(value);
+  await waitFor(() => {
+    if (input.value !== expectedValue) {
+      throw new Error(
+        `replaceInputValue: expected value ${JSON.stringify(expectedValue)}, got ${JSON.stringify(input.value)}`
+      );
+    }
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

Fix a flaky `userEvent.clear` + `userEvent.type` sequence in the `ExperimentsSection.ImageGenerationEnabled` Storybook play function, and introduce a shared `replaceInputValue` helper so this class of flake is harder to reintroduce.

## Background

`ExperimentsSection.stories.tsx` exercises the image-generation settings UI by clearing and retyping the **Max images per call** input twice:

```ts
await userEvent.clear(maxImagesInput);
await userEvent.type(maxImagesInput, "11");
// ...
await userEvent.clear(maxImagesInput);
await userEvent.type(maxImagesInput, "2");
await waitFor(() => expect(maxImagesInput).toHaveValue("2"));
```

That input has an `onBlur` handler (`handleMaxImagesBlur` in `ImageGenerationExperimentConfig.tsx`) that normalizes invalid drafts back to `DEFAULT_IMAGE_GENERATION_MAX_IMAGES` (4). Any blur that lands between `clear` (which transiently sets the value to `""`) and the subsequent `type` will reset the draft to `"4"` — so `type("2")` appends to that and you get `"42"`, failing `toHaveValue("2")` non-deterministically.

## Implementation

- Add `replaceInputValue(input, value, expectedValue?)` to `src/browser/stories/storyPlayHelpers.ts`. It focuses the input, selects its current contents, types the new value, and waits for the DOM to settle on the expected value. Because the existing contents are replaced atomically by the next keystroke, there is no transient empty/invalid draft for an interleaved blur to clobber.
- Switch `ExperimentsSection.stories.tsx` to use `replaceInputValue` for both max-images mutations. Drop the dangling `waitFor`/`userEvent.clear`/`userEvent.type` lines those replaced.
- Add a `NOTE` comment beside `handleMaxImagesBlur` pointing future story authors at `replaceInputValue`, so the next person editing this file does not unintentionally reintroduce the racy pattern.

## Validation

- `make static-check` — passes locally.
- `bun test src/browser/features/Settings/Sections/ExperimentsSection.test.tsx` — 9/9 pass.

## Risks

Very low. Production code is touched only by a comment in `ImageGenerationExperimentConfig.tsx`; the rest is Storybook test-only.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `max` • Cost: `$2.21`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=max costs=2.21 -->
