### PR TITLE
🤖 fix: tell advisor callers they must supply context

### DIFF
--- a/src/common/constants/advisor.ts
+++ b/src/common/constants/advisor.ts
@@ -23,18 +23,29 @@ export const ADVISOR_HANDOFF_MAX_TEXT_CHARS = 4000;
 export const ADVISOR_HANDOFF_MAX_REASONING_CHARS = 4000;
 
 /**
- * Shared guidance for when the advisor tool is appropriate.
- * Reused by the tool description now and future system-prompt wiring later.
+ * Shared guidance for when and how to use the advisor tool.
+ * Reused by the tool description and the system-prompt advisor-guidance section.
+ *
+ * The "no tools / supply context" sentences exist because calling agents
+ * frequently invoke the advisor with insufficient context, as if it could
+ * investigate on its own. The advisor only sees the existing transcript plus
+ * the `question`, so the caller is responsible for surfacing the relevant
+ * files, errors, and options before (or inside) the call.
  */
 export const ADVISOR_USAGE_GUIDANCE =
   "Use this when you need help with planning ambiguity or high-impact architectural decisions, " +
-  "when weighing tradeoffs between approaches, or after repeated failures when the strategy is unclear.";
+  "when weighing tradeoffs between approaches, or after repeated failures when the strategy is unclear. " +
+  "The advisor has no tools — it cannot read files, run commands, search code, or browse — and only " +
+  "sees the existing conversation transcript plus your `question`. Before calling, make sure the " +
+  "relevant files, errors, and options are already visible in the transcript (read them first) or paste " +
+  "the essential excerpts into `question`. Frame a specific decision or tradeoff; do not ask the advisor " +
+  "to investigate something it cannot see.";
 
 /** Description shown to the model when the advisor tool is registered. */
 export const ADVISOR_TOOL_DESCRIPTION =
   "Ask a stronger model for strategic advice based on the live conversation transcript. " +
   ADVISOR_USAGE_GUIDANCE +
-  " When you call this tool, pass a brief `question` summarizing the decision or ambiguity you need help with.";
+  " Pass a brief `question` summarizing the decision or ambiguity.";
 
 /**
  * System prompt for the nested advisor model call.


### PR DESCRIPTION
## Summary

Tell advisor callers they must supply their own context. The advisor tool sees only the existing conversation transcript plus the caller's `question` — it has no tools and cannot investigate on its own — and callers were routinely invoking it as if it could.

## Background

The advisor is a nested strategic-consultation call that runs against a fresh `streamText` with `tools: {}`. Its description and the inline `<advisor-guidance>` system-prompt section both consume `ADVISOR_USAGE_GUIDANCE` (`src/common/constants/advisor.ts`), so that constant is the single lever for steering caller behavior. Previously it said only *when* to call the advisor, not *how* — leaving parent agents free to assume the advisor could read files, run commands, or search code on its own. The result was advisor calls landing with insufficient context.

## Implementation

Extended `ADVISOR_USAGE_GUIDANCE` to spell out:

- The advisor has no tools — cannot read files, run commands, search code, or browse.
- It only sees the existing transcript plus the caller's `question`.
- Before calling, make relevant files/errors/options visible in the transcript (read them first) or paste essential excerpts into `question`.
- Frame a specific decision or tradeoff; do not ask the advisor to investigate something it cannot see.

Because the constant is reused by both `ADVISOR_TOOL_DESCRIPTION` (which `TOOL_DEFINITIONS.advisor.description` exposes to the model) and `buildAdvisorGuidanceSection()` in `streamContextBuilder.ts`, the caller sees the same clarification in two reinforcing places — the tool description it reads when deciding to call, and the inline system-prompt guidance.

Also trimmed the now-redundant trailing sentence of `ADVISOR_TOOL_DESCRIPTION` from "When you call this tool, pass a brief `question` summarizing the decision or ambiguity you need help with." to "Pass a brief `question` summarizing the decision or ambiguity."

## Validation

- `make static-check` ✅
- `bun test src/node/services/tools/advisor.test.ts src/common/utils/tools/toolDefinitions.test.ts` → 54/54 pass
- `bun test src/node/services/streamContextBuilder` → 11/11 pass

No tests pinned the prior wording, so nothing else needed updating.

## Risks

Low. Prose-only change to one shared constant; behavior, schema, and runtime paths are untouched. Worst case is the lengthier guidance bloats the system prompt slightly; the added text is ~70 words and only injected when the advisor tool is actually available for the agent.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `max` • Cost: `$1.51`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=max costs=1.51 -->
