### PR TITLE
🤖 fix: prevent chat transcript layout flashes

### DIFF
--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -801,20 +801,18 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
     : null;
 
   const hasInterruptedStream = interruption?.hasInterruptedStream ?? false;
+  const shouldShowStreamingBarrier = isStreamStarting || canInterrupt;
   // Keep rendering cached transcript rows during incremental catch-up so workspace switches
-  // feel stable, but a brand-new chat should keep its starting barrier visible instead of
-  // flashing transcript placeholders before the first send reaches the workspace history.
+  // feel stable, but active stream-start/interrupt states should keep their barrier visible
+  // instead of flashing full-height transcript placeholders.
   const showTranscriptHydrationPlaceholder =
-    isHydratingTranscript && deferredMessages.length === 0 && !workspaceState.isStreamStarting;
+    isHydratingTranscript && deferredMessages.length === 0 && !shouldShowStreamingBarrier;
   const showEmptyTranscriptPlaceholder =
     deferredMessages.length === 0 &&
     !showTranscriptHydrationPlaceholder &&
-    !workspaceState.isStreamStarting;
+    !shouldShowStreamingBarrier;
   const showRetryBarrier =
-    !isHydratingTranscript &&
-    !workspaceState.canInterrupt &&
-    !workspaceState.isStreamStarting &&
-    hasInterruptedStream;
+    !isHydratingTranscript && !shouldShowStreamingBarrier && hasInterruptedStream;
   const isAutoRetryActive =
     workspaceState.autoRetryStatus?.type === "auto-retry-scheduled" ||
     workspaceState.autoRetryStatus?.type === "auto-retry-starting";
@@ -840,7 +838,6 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
       interruptedBarrierMessageIds.add(message.id);
     }
   }
-  const shouldShowStreamingBarrier = isStreamStarting || canInterrupt;
   const transcriptTailItems: LayoutStackItem[] = [];
   if (shouldMountRetryBarrier) {
     transcriptTailItems.push({

--- a/src/browser/features/Messages/Mermaid.test.tsx
+++ b/src/browser/features/Messages/Mermaid.test.tsx
@@ -192,6 +192,8 @@ describe("Mermaid layout stability", () => {
       const svg = view.container.querySelector(".mermaid-container svg");
       expect(svg).not.toBeNull();
     });
+    const container = view.container.querySelector<HTMLElement>(".mermaid-container");
+    expect(container?.style.minHeight).toBe("300px");
     expect(view.container.querySelector("script")).toBeNull();
   });
 });

--- a/src/browser/features/Messages/Mermaid.tsx
+++ b/src/browser/features/Messages/Mermaid.tsx
@@ -425,9 +425,9 @@ export const Mermaid: React.FC<{ chart: string }> = ({ chart }) => {
             maxWidth: "70%",
             margin: "0 auto",
             ["--diagram-max-height" as string]: `${diagramMaxHeight}px`,
+            minHeight: `${MIN_HEIGHT}px`,
             ...(showPendingPlaceholder
               ? {
-                  minHeight: `${MIN_HEIGHT}px`,
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",

--- a/src/browser/features/Messages/MessageWindow.test.tsx
+++ b/src/browser/features/Messages/MessageWindow.test.tsx
@@ -17,7 +17,6 @@ void mock.module("@/browser/components/Tooltip/Tooltip", () => ({
   TooltipContent: () => null,
 }));
 
-// Minimal message factory covering the three flag combinations we care about.
 function createAssistantMessage(overrides: {
   isStreaming?: boolean;
   isLastPartOfMessage?: boolean;
@@ -29,11 +28,24 @@ function createAssistantMessage(overrides: {
     historySequence: 1,
     parts: [],
     metadata: { model: "test-model", partial: overrides.isPartial ? true : undefined },
-    // The meta-row gate reads these fields off a DisplayedMessage-like object, but
-    // MessageWindow accepts the broader union. Cast is safe because the consumer
-    // only touches the fields we populate.
     ...(overrides as object),
   } as unknown as MuxMessage;
+}
+
+function renderAssistantWindow(overrides: Parameters<typeof createAssistantMessage>[0]) {
+  const message = createAssistantMessage(overrides);
+  return render(
+    <MessageWindow label="model" message={message} variant="assistant">
+      <div>content</div>
+    </MessageWindow>
+  );
+}
+
+function expectAssistantMeta(container: HTMLElement, visible: boolean) {
+  const block = container.querySelector("[data-message-block]");
+  expect(block).not.toBeNull();
+  expect(block?.querySelector("[data-message-meta]") !== null).toBe(visible);
+  expect(/\bmb-4\b/.test(block?.className ?? "")).toBe(visible);
 }
 
 describe("MessageWindow meta-row stability", () => {
@@ -49,87 +61,46 @@ describe("MessageWindow meta-row stability", () => {
     cleanupDom = null;
   });
 
-  test("hides the meta row while an assistant part is still streaming", () => {
-    // Before the fix, an actively streaming part with isLastPartOfMessage=true
-    // rendered the meta row — which then vanished the moment the part stopped
-    // being last (tool appended). Keeping the meta row hidden throughout active
-    // streaming removes the mid-turn tear.
-    const message = createAssistantMessage({
+  test("hides assistant meta while the stream-start part is still active", () => {
+    // Stream-start rows are often already marked as the last part; wait for the
+    // part to settle so the meta row does not flash in and then tear out.
+    const { container } = renderAssistantWindow({
       isStreaming: true,
       isLastPartOfMessage: true,
       isPartial: false,
     });
-    const { container } = render(
-      <MessageWindow label="model" message={message} variant="assistant">
-        <div>content</div>
-      </MessageWindow>
-    );
 
-    const block = container.querySelector("[data-message-block]");
-    expect(block).not.toBeNull();
-    expect(block?.querySelector("[data-message-meta]")).toBeNull();
-    expect(block?.className).not.toMatch(/\bmb-4\b/);
+    expectAssistantMeta(container, false);
   });
 
-  test("hides the meta row when the part is no longer last (another part displaced it)", () => {
-    // After a tool call appends to an assistant message, the previous text part's
-    // isLastPartOfMessage flips false. We must not keep (or re-render) a meta row
-    // on the displaced part, otherwise the later-arriving tool's own content
-    // would visually duplicate the meta information.
-    const message = createAssistantMessage({
+  test("hides assistant meta when another part displaces the current part", () => {
+    const { container } = renderAssistantWindow({
       isStreaming: false,
       isLastPartOfMessage: false,
       isPartial: false,
     });
-    const { container } = render(
-      <MessageWindow label="model" message={message} variant="assistant">
-        <div>content</div>
-      </MessageWindow>
-    );
 
-    const block = container.querySelector("[data-message-block]");
-    expect(block?.querySelector("[data-message-meta]")).toBeNull();
-    expect(block?.className).not.toMatch(/\bmb-4\b/);
+    expectAssistantMeta(container, false);
   });
 
-  test("shows the meta row and mb-4 only when the last part has settled", () => {
-    // Natural terminal state: stream ended, part is still last, and not a
-    // persisted partial. This is the single moment where the meta row and the
-    // larger bottom margin should appear — one controlled reveal at the end of
-    // the turn rather than a flicker during streaming.
-    const message = createAssistantMessage({
+  test("shows assistant meta only when the last part has settled", () => {
+    const { container } = renderAssistantWindow({
       isStreaming: false,
       isLastPartOfMessage: true,
       isPartial: false,
     });
-    const { container } = render(
-      <MessageWindow label="model" message={message} variant="assistant">
-        <div>content</div>
-      </MessageWindow>
-    );
 
-    const block = container.querySelector("[data-message-block]");
-    expect(block?.querySelector("[data-message-meta]")).not.toBeNull();
-    expect(block?.className).toMatch(/\bmb-4\b/);
+    expectAssistantMeta(container, true);
   });
 
-  test("treats interrupted (isPartial) parts as not-settled even with isLastPartOfMessage", () => {
-    // Partials remain answerable/rewriteable; they should not show the
-    // end-of-turn meta affordances that imply the response is done.
-    const message = createAssistantMessage({
+  test("treats interrupted parts as not-settled even with isLastPartOfMessage", () => {
+    const { container } = renderAssistantWindow({
       isStreaming: false,
       isLastPartOfMessage: true,
       isPartial: true,
     });
-    const { container } = render(
-      <MessageWindow label="model" message={message} variant="assistant">
-        <div>content</div>
-      </MessageWindow>
-    );
 
-    const block = container.querySelector("[data-message-block]");
-    expect(block?.querySelector("[data-message-meta]")).toBeNull();
-    expect(block?.className).not.toMatch(/\bmb-4\b/);
+    expectAssistantMeta(container, false);
   });
 
   test("user messages keep the meta row regardless of part flags", () => {

--- a/src/browser/features/Messages/MessageWindow.tsx
+++ b/src/browser/features/Messages/MessageWindow.tsx
@@ -4,7 +4,7 @@ import { TranscriptQuoteRoot } from "./TranscriptQuoteBoundary";
 import { formatTimestamp } from "@/browser/utils/ui/dateTime";
 import { Code2Icon } from "lucide-react";
 import type { ReactNode } from "react";
-import React, { useMemo, useState } from "react";
+import React, { useState } from "react";
 import { useChatHostContext } from "@/browser/contexts/ChatHostContext";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/browser/components/Tooltip/Tooltip";
 import { Button } from "@/browser/components/Button/Button";
@@ -47,34 +47,20 @@ export const MessageWindow: React.FC<MessageWindowProps> = ({
   const canShowJson = uiSupport.jsonRawView === "supported";
   const isShowingJson = canShowJson && showJson;
 
-  // Get timestamp from message if available
   const timestamp =
     "timestamp" in message && typeof message.timestamp === "number" ? message.timestamp : null;
+  const formattedTimestamp = timestamp ? formatTimestamp(timestamp) : null;
 
-  // Memoize formatted timestamp to avoid recalculating on every render
-  const formattedTimestamp = useMemo(
-    () => (timestamp ? formatTimestamp(timestamp) : null),
-    [timestamp]
-  );
+  // Keep assistant meta chrome hidden until the terminal part is settled. Stream-start rows
+  // are usually both streaming and "last", so rendering the meta row immediately makes it
+  // tear out of the transcript when the next part arrives.
+  const showAssistantMetaRow =
+    "isLastPartOfMessage" in message &&
+    message.isLastPartOfMessage &&
+    !message.isPartial &&
+    !("isStreaming" in message && message.isStreaming);
 
-  // Meta-row visibility must be settled before we commit it, otherwise every new part
-  // arriving mid-turn (text -> tool, reasoning -> text, etc.) flips the previous part's
-  // `isLastPartOfMessage` from true to false and tears ~36-40px of meta-row + margin
-  // out of the transcript in a single commit. Require the part to have also stopped
-  // streaming — that flag flips in the same aggregator snapshot as `isLastPartOfMessage`,
-  // so checking both here keeps the meta row hidden throughout the turn and only reveals
-  // it once, on the genuine terminal part after the turn has completed.
-  const isSettledLastPart = useMemo(() => {
-    if (!("isLastPartOfMessage" in message)) return false;
-    if (!message.isLastPartOfMessage) return false;
-    if (message.isPartial) return false;
-    if ("isStreaming" in message && message.isStreaming) return false;
-    return true;
-  }, [message]);
-
-  // We do not want to display these on every message, otherwise it spams the UI
-  // with buttons and timestamps
-  const showMetaRow = variant === "user" || isSettledLastPart;
+  const showMetaRow = variant === "user" || showAssistantMetaRow;
 
   return (
     <div
@@ -85,7 +71,7 @@ export const MessageWindow: React.FC<MessageWindowProps> = ({
         // Pair the extra bottom margin with the meta row so the surrounding transcript
         // space only changes at the same (settled) moment as the meta row appearing,
         // avoiding a second separate tear step.
-        isSettledLastPart && "mb-4",
+        showAssistantMetaRow && "mb-4",
         // Caller-supplied class — used by side-question rendering to apply
         // the "side branch" left-accent treatment. Previously declared but
         // never spread onto the outer container, so callers couldn't theme

--- a/src/browser/features/Messages/ReasoningMessage.tsx
+++ b/src/browser/features/Messages/ReasoningMessage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useLayoutEffect } from "react";
+import React, { useState, useRef, useLayoutEffect } from "react";
 import type { DisplayedMessage } from "@/common/types/message";
 import { TypewriterMarkdown } from "./TypewriterMarkdown";
 import { normalizeReasoningMarkdown } from "./MarkdownStyles";
@@ -52,10 +52,6 @@ export const ReasoningMessage: React.FC<ReasoningMessageProps> = ({
   workspaceId,
 }) => {
   const [isExpanded, setIsExpanded] = useState(message.isStreaming);
-  // Track the height when expanded to reserve space during collapse transitions
-  const [expandedHeight, setExpandedHeight] = useState<number | null>(null);
-  const contentRef = useRef<HTMLDivElement>(null);
-
   const content = message.content;
   const isStreaming = message.isStreaming;
   const trimmedContent = content?.trim() ?? "";
@@ -72,15 +68,6 @@ export const ReasoningMessage: React.FC<ReasoningMessageProps> = ({
   const isCollapsible = !isStreaming && hasContent && hasAdditionalLines;
   const showEllipsis = isCollapsible && !isExpanded;
   const showExpandedContent = isExpanded && !isSingleLineTrace;
-
-  // Capture expanded height before settled collapse/expand transitions. During live
-  // streaming the container is height:auto and doesn't use this value, so skip the
-  // synchronous scrollHeight read on every token delta.
-  useLayoutEffect(() => {
-    if (!isStreaming && contentRef.current && isExpanded && !isSingleLineTrace) {
-      setExpandedHeight(contentRef.current.scrollHeight);
-    }
-  }, [isStreaming, isExpanded, isSingleLineTrace, content]);
 
   const wasStreamingRef = useRef(isStreaming);
   const isLastPartOfMessage =
@@ -100,7 +87,7 @@ export const ReasoningMessage: React.FC<ReasoningMessageProps> = ({
   // `isStreaming` off, which used to trigger a mid-turn 200ms height→0 animation
   // (a very visible vertical tear). Keeping the reasoning expanded in that case
   // lets the user continue reading it while the assistant moves on.
-  useEffect(() => {
+  useLayoutEffect(() => {
     const wasStreaming = wasStreamingRef.current;
     wasStreamingRef.current = isStreaming;
 
@@ -215,24 +202,21 @@ export const ReasoningMessage: React.FC<ReasoningMessageProps> = ({
         )}
       </div>
 
-      {/* Always render the content container to prevent layout shifts.
-          Use CSS transitions only for user-initiated collapse/expand of *settled*
-          reasoning. During live streaming we leave the container uncontrolled
-          (height: auto, no transition); otherwise each incoming delta re-targets
-          scrollHeight through a 200ms height animation, which clips newly arrived
-          tokens and produces a slow drip-in effect that reads as jitter. */}
+      {/* Always render the content container to prevent layout shifts. Keep live and
+          expanded content height uncontrolled so async markdown growth (Shiki/Mermaid)
+          cannot be clipped by a stale measured height; only collapsed settled content
+          gets height:0. */}
       <div
-        ref={contentRef}
         className={cn(
           REASONING_FONT_CLASSES,
           "italic opacity-85 [&_p]:mt-0 [&_p]:mb-1 [&_p:last-child]:mb-0",
-          !isStreaming && "overflow-hidden transition-[height,opacity] duration-200 ease-in-out"
+          !isStreaming && "overflow-hidden transition-opacity duration-200 ease-in-out"
         )}
         style={
           isStreaming
             ? undefined
             : {
-                height: showExpandedContent ? (expandedHeight ?? "auto") : 0,
+                height: showExpandedContent ? undefined : 0,
                 opacity: showExpandedContent ? 1 : 0,
               }
         }

--- a/src/browser/hooks/useAutoScroll.test.tsx
+++ b/src/browser/hooks/useAutoScroll.test.tsx
@@ -899,11 +899,7 @@ describe("useAutoScroll", () => {
     act(() => {
       result.current.jumpToBottom();
     });
-    act(() => {
-      flushFrames(100);
-    });
     expect(resizeObserverCallback).not.toBeNull();
-    expect(scheduledFrames.length).toBe(0);
 
     metrics.setScrollHeight(1500);
     act(() => {
@@ -911,7 +907,18 @@ describe("useAutoScroll", () => {
     });
 
     expect(metrics.scrollTop).toBe(metrics.maxScrollTop);
-    expect(scheduledFrames.length).toBeGreaterThan(0);
+
+    const queuedResizeObserverCallback = resizeObserverCallback;
+    act(() => {
+      result.current.disableAutoScroll();
+    });
+    metrics.setScrollTop(100);
+    metrics.setScrollHeight(1600);
+    act(() => {
+      queuedResizeObserverCallback?.([], {} as ResizeObserver);
+    });
+
+    expect(metrics.scrollTop).toBe(100);
   });
 
   test("rAF loop is torn down on unmount and stops scheduling new frames", () => {

--- a/src/browser/hooks/useAutoScroll.test.tsx
+++ b/src/browser/hooks/useAutoScroll.test.tsx
@@ -36,6 +36,20 @@ function createWheelEvent(
 
 let scheduledFrames: Array<{ id: number; callback: FrameRequestCallback }> = [];
 let nextFrameId = 1;
+let resizeObserverCallback: ResizeObserverCallback | null = null;
+
+class ResizeObserverMock {
+  constructor(callback: ResizeObserverCallback) {
+    resizeObserverCallback = callback;
+  }
+
+  observe(target: Element): void {
+    void target;
+  }
+  disconnect(): void {
+    resizeObserverCallback = null;
+  }
+}
 
 function flushOneFrame(): void {
   const next = scheduledFrames.shift();
@@ -56,6 +70,8 @@ describe("useAutoScroll", () => {
     cleanupDom = installDom();
     scheduledFrames = [];
     nextFrameId = 1;
+    resizeObserverCallback = null;
+    window.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
 
     // Install the deterministic scheduler on the per-test `window` rather than
     // `globalThis` so this mock never leaks into downstream test files. The
@@ -866,6 +882,36 @@ describe("useAutoScroll", () => {
 
     expect(result.current.autoScroll).toBe(true);
     expect(scheduledFrames.length).toBe(0);
+  });
+
+  test("ResizeObserver pins to bottom before the next rAF", () => {
+    const { result } = renderHook(() => useAutoScroll());
+    const element = document.createElement("div");
+    const metrics = attachScrollMetrics(element, {
+      scrollHeight: 1000,
+      clientHeight: 400,
+    });
+
+    act(() => {
+      (result.current.contentRef as MutableRefObject<HTMLDivElement | null>).current = element;
+      result.current.disableAutoScroll();
+    });
+    act(() => {
+      result.current.jumpToBottom();
+    });
+    act(() => {
+      flushFrames(100);
+    });
+    expect(resizeObserverCallback).not.toBeNull();
+    expect(scheduledFrames.length).toBe(0);
+
+    metrics.setScrollHeight(1500);
+    act(() => {
+      resizeObserverCallback?.([], {} as ResizeObserver);
+    });
+
+    expect(metrics.scrollTop).toBe(metrics.maxScrollTop);
+    expect(scheduledFrames.length).toBeGreaterThan(0);
   });
 
   test("rAF loop is torn down on unmount and stops scheduling new frames", () => {

--- a/src/browser/hooks/useAutoScroll.ts
+++ b/src/browser/hooks/useAutoScroll.ts
@@ -339,6 +339,7 @@ export function useAutoScroll() {
     if (!scrollContainer || !ResizeObserverCtor) return;
 
     const observer = new ResizeObserverCtor(() => {
+      if (!autoScrollRef.current) return;
       stickToBottom();
       startBottomLockFrameLoop();
     });

--- a/src/browser/hooks/useAutoScroll.ts
+++ b/src/browser/hooks/useAutoScroll.ts
@@ -339,6 +339,7 @@ export function useAutoScroll() {
     if (!scrollContainer || !ResizeObserverCtor) return;
 
     const observer = new ResizeObserverCtor(() => {
+      stickToBottom();
       startBottomLockFrameLoop();
     });
     observer.observe(scrollContainer);
@@ -348,7 +349,7 @@ export function useAutoScroll() {
     }
 
     return () => observer.disconnect();
-  }, [autoScroll, startBottomLockFrameLoop]);
+  }, [autoScroll, startBottomLockFrameLoop, stickToBottom]);
 
   return {
     contentRef,


### PR DESCRIPTION
## Summary

Prevent known chat transcript layout flashes while keeping the PR net LoC negative. The change stabilizes assistant meta chrome, active-stream placeholder gating, bottom-lock resize handling, reasoning block growth, and Mermaid diagram frames while simplifying surrounding MessageWindow and ReasoningMessage code.

## Background

Several transcript states can briefly render layout chrome that is immediately removed or resized: stream-start assistant meta rows, active streams hydrating before message rows arrive, ResizeObserver-only async growth after bottom-lock settles, reasoning blocks with stale measured heights, and Mermaid pending frames that shrink after SVG render.

## Implementation

- Gate assistant meta rows and their extra margin on a settled terminal assistant part.
- Suppress full-height transcript placeholders whenever the streaming barrier owns the active stream state, including buffered can-interrupt hydration.
- Pin the transcript synchronously from ResizeObserver callbacks before continuing the bounded rAF settle loop.
- Remove stale measured-height handling from reasoning expansion so async markdown growth is not clipped.
- Keep Mermaid's reserved diagram height after the SVG resolves.
- Refactor tests/helpers around the touched paths; overall diff remains net negative.

## Validation

- `bun test src/browser/features/Messages/MessageWindow.test.tsx src/browser/features/Messages/ReasoningMessage.test.tsx src/browser/features/Messages/Mermaid.test.tsx src/browser/hooks/useAutoScroll.test.tsx src/browser/components/ChatPane/LayoutStackLane.test.tsx src/browser/components/ChatPane/sideQuestionScrollHold.test.ts`
- `bun test src/browser/stores/WorkspaceStore.test.ts --test-name-pattern "prefers buffered stream-start state over stale non-streaming activity during hydration"`
- `bun test ./tests/ui/chat/newChatStreamingFlash.test.ts`
- `bun test ./tests/ui/chat/bottomLayoutShift.test.ts`
- `make fmt-check`
- `make typecheck`
- `make static-check`

## Risks

Moderate-low. The fixes touch central transcript rendering and scroll ownership, but each change is narrowly scoped and backed by targeted coverage for streaming meta rows, active placeholders, ResizeObserver bottom pinning, reasoning collapse/expansion, Mermaid frame reservation, and app-level bottom layout stability.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `1978371{costs}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=11.10 -->
