### PR TITLE
🤖 fix: disable ask_user_question in mux run

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -703,11 +703,13 @@ async function main(): Promise<number> {
       ...(opts.use1m && { anthropic: { use1MContext: true } }),
       ...(opts.serviceTier != null && { openai: { serviceTier: opts.serviceTier } }),
     },
-    // Disable UI-only tools that have no effect in CLI mode:
+    // Disable UI-only tools that either no-op or require UI interaction in CLI mode:
+    // - ask_user_question: waits for a desktop/mobile answer UI; headless `mux run` cannot answer it
     // - status_set: backend no-op, status indicator only visible in desktop UI
     // - todo_write/todo_read: TODO list only visible in desktop UI
     // - notify: sends OS notifications via Electron, silently swallowed in CLI
     toolPolicy: [
+      { regex_match: "ask_user_question", action: "disable" as const },
       { regex_match: "status_set", action: "disable" as const },
       { regex_match: "todo_write", action: "disable" as const },
       { regex_match: "todo_read", action: "disable" as const },


### PR DESCRIPTION
## Summary

Disable `ask_user_question` for headless `mux run` sessions so CLI runs cannot stall waiting for a desktop/mobile answer UI.

## Background

`mux run` already disables UI-only tools such as TODO/status/notify. `ask_user_question` is also UI-dependent unless prefilled answers are supplied, so exposing it in headless CLI runs can leave the session waiting for an answer path the CLI does not provide.

## Implementation

Adds `ask_user_question` to the CLI `toolPolicy` disable list used by `mux run`, with an inline comment explaining the headless interaction constraint.

## Validation

- `bun run typecheck`
- `bun test src/cli/run.test.ts`
- `make fmt-check`
- `make lint`
- `make static-check`

## Risks

Low. This only narrows the tool set for `mux run`; desktop/mobile and normal plan-mode UI flows are unchanged.

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$9.14`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=9.14 -->
