### PR TITLE
🤖 tests: stabilize flaky signing and best-of task tests

### DIFF
--- a/src/node/services/signingService.test.ts
+++ b/src/node/services/signingService.test.ts
@@ -97,14 +97,23 @@ describe("SigningService", () => {
   });
 
   describe("with Ed25519 key", () => {
-    it("should load key and return capabilities", () =>
-      withoutSshAgent(async () => {
-        const service = new SigningService([ed25519KeyPath]);
-        const capabilities = await service.getCapabilities();
+    it(
+      "should load key and return capabilities",
+      () =>
+        withoutSshAgent(async () => {
+          const service = new SigningService([ed25519KeyPath]);
+          const capabilities = await service.getCapabilities();
 
-        expect(capabilities.publicKey).toBeDefined();
-        expect(capabilities.publicKey).toStartWith("ssh-ed25519 ");
-      }));
+          expect(capabilities.publicKey).toBeDefined();
+          expect(capabilities.publicKey).toStartWith("ssh-ed25519 ");
+        }),
+      // SigningService.getCapabilities() shells out to `gh auth status` to detect
+      // GitHub identity. `gh` can take several seconds (network/credential lookup),
+      // so under CI load this comfortably exceeds Bun's default 5s per-test
+      // timeout even though the actual key-loading work is fast. See PR for the
+      // discovery context; production-side timeout is a follow-up.
+      { timeout: 15_000 }
+    );
 
     it("should sign messages", () =>
       withoutSshAgent(async () => {

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -4837,82 +4837,90 @@ describe("TaskService", () => {
     expect(serializedOutput).toContain('"label":"backend"');
   });
 
-  test("agent_report finalizes interrupted best-of parent output after partial best-of spawn failure", async () => {
-    const parentId = "parent-best-of-partial-spawn";
-    const childOneId = "child-best-of-partial-1";
-    const childTwoId = "child-best-of-partial-2";
-    const bestOf = { groupId: "best-of-partial-group", index: 0, total: 3 } as const;
+  // Test exercises real config + history + partial-on-disk I/O across many
+  // sequential awaits. Under CI parallel-test contention this can momentarily
+  // exceed Bun's default 5s per-test timeout even though it completes in
+  // ~250ms locally; bump the budget for headroom.
+  test(
+    "agent_report finalizes interrupted best-of parent output after partial best-of spawn failure",
+    async () => {
+      const parentId = "parent-best-of-partial-spawn";
+      const childOneId = "child-best-of-partial-1";
+      const childTwoId = "child-best-of-partial-2";
+      const bestOf = { groupId: "best-of-partial-group", index: 0, total: 3 } as const;
 
-    const { config, historyService, partialService, taskService, remove } =
-      await createBestOfTaskServiceTestHarness({
+      const { config, historyService, partialService, taskService, remove } =
+        await createBestOfTaskServiceTestHarness({
+          parentId,
+          children: [
+            {
+              id: childOneId,
+              name: "agent_explore_child_1",
+              taskStatus: "running",
+              bestOf,
+            },
+            {
+              id: childTwoId,
+              name: "agent_explore_child_2",
+              taskStatus: "running",
+              bestOf: { ...bestOf, index: 1 },
+            },
+          ],
+        });
+
+      await writePendingBestOfParentPartial({
+        partialService,
         parentId,
-        children: [
-          {
-            id: childOneId,
-            name: "agent_explore_child_1",
-            taskStatus: "running",
-            bestOf,
-          },
-          {
-            id: childTwoId,
-            name: "agent_explore_child_2",
-            taskStatus: "running",
-            bestOf: { ...bestOf, index: 1 },
-          },
-        ],
+        messageId: "assistant-parent-best-of-partial-spawn",
+        toolCallId: "task-best-of-partial-call",
+        title: "Best of 3",
+        n: 3,
+        timestamp: Date.now(),
       });
 
-    await writePendingBestOfParentPartial({
-      partialService,
-      parentId,
-      messageId: "assistant-parent-best-of-partial-spawn",
-      toolCallId: "task-best-of-partial-call",
-      title: "Best of 3",
-      n: 3,
-      timestamp: Date.now(),
-    });
+      await finalizeReportedChildTaskForTest({
+        historyService,
+        partialService,
+        taskService,
+        childId: childOneId,
+        reportMarkdown: "Report from child one",
+        title: "Option one",
+      });
 
-    await finalizeReportedChildTaskForTest({
-      historyService,
-      partialService,
-      taskService,
-      childId: childOneId,
-      reportMarkdown: "Report from child one",
-      title: "Option one",
-    });
+      const parentHistoryAfterFirst = await collectFullHistory(historyService, parentId);
+      expect(JSON.stringify(parentHistoryAfterFirst)).not.toContain("Report from child one");
 
-    const parentHistoryAfterFirst = await collectFullHistory(historyService, parentId);
-    expect(JSON.stringify(parentHistoryAfterFirst)).not.toContain("Report from child one");
+      const afterFirstParentPartial = await partialService.readPartial(parentId);
+      expect(afterFirstParentPartial).not.toBeNull();
+      expect(getTaskToolPart(afterFirstParentPartial)?.state).toBe("input-available");
+      expect(remove).not.toHaveBeenCalled();
 
-    const afterFirstParentPartial = await partialService.readPartial(parentId);
-    expect(afterFirstParentPartial).not.toBeNull();
-    expect(getTaskToolPart(afterFirstParentPartial)?.state).toBe("input-available");
-    expect(remove).not.toHaveBeenCalled();
+      await finalizeReportedChildTaskForTest({
+        historyService,
+        partialService,
+        taskService,
+        childId: childTwoId,
+        reportMarkdown: "Report from child two",
+        title: "Option two",
+      });
 
-    await finalizeReportedChildTaskForTest({
-      historyService,
-      partialService,
-      taskService,
-      childId: childTwoId,
-      reportMarkdown: "Report from child two",
-      title: "Option two",
-    });
+      const afterSecondParentPartial = await partialService.readPartial(parentId);
+      expect(afterSecondParentPartial).not.toBeNull();
+      const toolPart = getTaskToolPart(afterSecondParentPartial);
+      expect(toolPart?.state).toBe("output-available");
+      expect(toolPart?.output && typeof toolPart.output === "object").toBe(true);
+      const serializedOutput = JSON.stringify(toolPart?.output);
+      expect(serializedOutput).toContain(childOneId);
+      expect(serializedOutput).toContain(childTwoId);
+      expect(serializedOutput).toContain("Report from child one");
+      expect(serializedOutput).toContain("Report from child two");
 
-    const afterSecondParentPartial = await partialService.readPartial(parentId);
-    expect(afterSecondParentPartial).not.toBeNull();
-    const toolPart = getTaskToolPart(afterSecondParentPartial);
-    expect(toolPart?.state).toBe("output-available");
-    expect(toolPart?.output && typeof toolPart.output === "object").toBe(true);
-    const serializedOutput = JSON.stringify(toolPart?.output);
-    expect(serializedOutput).toContain(childOneId);
-    expect(serializedOutput).toContain(childTwoId);
-    expect(serializedOutput).toContain("Report from child one");
-    expect(serializedOutput).toContain("Report from child two");
-
-    const remainingTaskIds = getConfiguredWorkspaceIds(config);
-    expect(remainingTaskIds).not.toContain(childOneId);
-    expect(remainingTaskIds).not.toContain(childTwoId);
-  });
+      const remainingTaskIds = getConfiguredWorkspaceIds(config);
+      expect(remainingTaskIds).not.toContain(childOneId);
+      expect(remainingTaskIds).not.toContain(childTwoId);
+    },
+    { timeout: 15_000 }
+  );
 
   test("agent_report avoids duplicate synthetic parent reports after grouped partial finalization", async () => {
     const parentId = "parent-best-of-no-duplicate";


### PR DESCRIPTION
## Summary

Two unit tests have been intermittently timing out at exactly the `bun:test` default 5000ms budget in CI, even though both pass in well under 1s locally. Bumps each test's timeout to 15s with an explanatory comment about the source of the slowness. Pure tests-only change.

- `SigningService > with Ed25519 key > should load key and return capabilities`
- `TaskService > agent_report finalizes interrupted best-of parent output after partial best-of spawn failure`

## Background

`Test / Unit` started failing on unrelated PRs with these two tests reporting `[5001.02ms]` and `[5002.02ms]` — i.e. they were actively running when bun's per-test 5s deadline fired. Local runs of either test individually finish in 250ms–1s.

### `SigningService` test

The test only asserts that `capabilities.publicKey` starts with `"ssh-ed25519 "`, but `getCapabilities()` internally calls `detectIdentity()`, which shells out to `gh auth status 2>&1` via `execAsync` (`src/node/services/signingService.ts` line 533). I confirmed on this machine that `gh auth status` alone takes ~4.7s, which leaves no headroom under CI load.

A real production-side fix would be to add a timeout to that subprocess (so a slow `gh` never blocks the app), but that touches the shared `execAsync` helper and is a behavior change. I'm deliberately deferring that to a follow-up so this PR stays tests-only and low-risk.

### `TaskService` best-of test

The test body exercises real config, history, and partial-on-disk I/O across many sequential `await`s (`saveWorkspaces`, `writePartial`, `finalizeReportedChildTaskForTest`, multiple `readPartial`s, etc.). Locally it lands ~250ms; in parallel CI runs, disk contention from the other ~7800 tests blows past the 5s budget. No single slow call jumped out from profiling locally, so the pragmatic fix is to give this test enough slack.

## Implementation

- `signingService.test.ts`: convert the single failing `it(...)` to the three-argument form with `{ timeout: 15_000 }` and a comment pointing at `gh auth status` as the culprit.
- `taskService.test.ts`: same treatment for the single failing `test(...)`, with a comment about CI disk contention.

Both use the `{ timeout: 15_000 }` option form already established in `backgroundProcessManager.test.ts` and the code-execution integration tests.

## Validation

- `bun test src/node/services/signingService.test.ts src/node/services/taskService.test.ts` — 137/137 pass locally.
- `make static-check` — passes.

## Risks

Tests-only change with the maximum possible scope of a longer wait when the test would have failed under the old budget. The two adjusted tests still complete in well under 1s under normal conditions, so the new headroom only matters when CI is genuinely slow; in steady state nothing changes.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `max` • Cost: `$10.11`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=max costs=10.11 -->
