### PR TITLE
🤖 fix: retry agent sidebar status updates

### DIFF
--- a/src/constants/agentStatus.ts
+++ b/src/constants/agentStatus.ts
@@ -28,6 +28,24 @@ export const AGENT_STATUS_IDLE_UNFOCUSED_INTERVAL_MS = 2 * 60 * 1000;
  */
 export const AGENT_STATUS_TICK_INTERVAL_MS = 10 * 1000;
 
+/**
+ * Retry budget for provider-side status generation failures on an unchanged
+ * transcript. A single missed tool call or transient provider hiccup should not
+ * freeze the sidebar until the next chat turn. After that, retry on a bounded
+ * cooldown so transient provider outages still recover without hammering the
+ * small-model path indefinitely.
+ */
+export const AGENT_STATUS_PROVIDER_FAILURE_RETRY_ATTEMPTS = 2;
+
+/**
+ * Cooldowns after the immediate provider-failure retry budget is exhausted.
+ * Active streams recover faster because visible status freshness matters most;
+ * idle workspaces back off harder because the transcript is not changing.
+ */
+export const AGENT_STATUS_PROVIDER_FAILURE_ACTIVE_COOLDOWN_MS = 60 * 1000;
+export const AGENT_STATUS_PROVIDER_FAILURE_IDLE_COOLDOWN_MS = 5 * 60 * 1000;
+export const AGENT_STATUS_PROVIDER_FAILURE_MAX_COOLDOWN_MS = 30 * 60 * 1000;
+
 /** Token budget for the trailing chat-transcript window we feed the model. */
 export const AGENT_STATUS_MAX_TRANSCRIPT_TOKENS = 8000;
 

--- a/src/node/services/agentStatusService.test.ts
+++ b/src/node/services/agentStatusService.test.ts
@@ -5,6 +5,10 @@ import { join } from "path";
 import type { ProjectsConfig, ProjectConfig, Workspace } from "@/common/types/project";
 import { Ok, Err } from "@/common/types/result";
 import { createMuxMessage } from "@/common/types/message";
+import {
+  AGENT_STATUS_PROVIDER_FAILURE_IDLE_COOLDOWN_MS,
+  AGENT_STATUS_PROVIDER_FAILURE_RETRY_ATTEMPTS,
+} from "@/constants/agentStatus";
 import type { Config } from "@/node/config";
 import type { AIService } from "./aiService";
 import { ExtensionMetadataService } from "./ExtensionMetadataService";
@@ -973,48 +977,60 @@ describe("AgentStatusService", () => {
     expect(emitWorkspaceActivityMock).toHaveBeenCalledTimes(1);
   });
 
-  test("post-provider failure advances dedup so we don't resend the same transcript every tick", async () => {
-    // Codex review: when status generation fails AFTER reaching the
-    // provider (e.g., the chosen model refuses to call propose_status, or
-    // hits a persistent provider error), leaving lastInputHash unchanged
-    // would let the scheduler resend the exact same trailing transcript on
-    // every focused/idle interval, burning tokens against a workspace that
-    // is stuck. Once we've attempted generation against the provider, the
-    // only retry signal that matters is a real transcript change.
+  test("provider failures retry the same transcript on cooldown until recovery", async () => {
+    // User rationale: sidebar status updates felt flaky when a small model
+    // occasionally ignored propose_status. A single provider-side miss should
+    // retry on the same transcript instead of freezing until the next chat turn,
+    // and even repeated transient provider misses must eventually recover.
     await historyHandle.historyService.appendToHistory(
       workspaceId,
       createMuxMessage("u1", "user", "kick off a task")
     );
 
-    generateSpy.mockResolvedValueOnce(
-      Err({
-        error: { type: "unknown", raw: "model did not call propose_status" },
-        reachedProvider: true,
+    generateSpy.mockReset();
+    generateSpy.mockResolvedValue(
+      Ok({
+        status: { emoji: "🛠️", message: "Editing source" },
+        modelUsed: "anthropic:claude-haiku-4-5",
       })
     );
+    for (let i = 0; i < AGENT_STATUS_PROVIDER_FAILURE_RETRY_ATTEMPTS + 1; i += 1) {
+      generateSpy.mockResolvedValueOnce(
+        Err({
+          error: { type: "unknown", raw: "model did not call propose_status" },
+          reachedProvider: true,
+        })
+      );
+    }
 
-    const service = createService();
-    await getInternals(service).runForWorkspace(workspaceId);
+    let now = 1_000_000;
+    const service = createService({ clock: () => now });
+    const internals = getInternals(service);
 
-    // Generator was called and failed; nothing reached the sidebar.
-    expect(generateSpy).toHaveBeenCalledTimes(1);
+    // First failures call the provider because the immediate same-input retry
+    // budget is not exhausted yet.
+    for (let i = 0; i < AGENT_STATUS_PROVIDER_FAILURE_RETRY_ATTEMPTS; i += 1) {
+      await internals.runForWorkspace(workspaceId);
+    }
+    expect(generateSpy).toHaveBeenCalledTimes(AGENT_STATUS_PROVIDER_FAILURE_RETRY_ATTEMPTS);
     expect(setSidebarStatusMock).not.toHaveBeenCalled();
     expect(emitWorkspaceActivityMock).not.toHaveBeenCalled();
 
-    // Same transcript again: dedup must skip — we already learned that this
-    // input fails, no point retrying until something changes.
-    await getInternals(service).runForWorkspace(workspaceId);
-    expect(generateSpy).toHaveBeenCalledTimes(1);
-    expect(setSidebarStatusMock).not.toHaveBeenCalled();
+    // One more provider-side failure starts a cooldown. Same-input attempts
+    // before the cooldown expires are skipped to avoid hammering the provider.
+    await internals.runForWorkspace(workspaceId);
+    expect(generateSpy).toHaveBeenCalledTimes(AGENT_STATUS_PROVIDER_FAILURE_RETRY_ATTEMPTS + 1);
+    await internals.runForWorkspace(workspaceId);
+    expect(generateSpy).toHaveBeenCalledTimes(AGENT_STATUS_PROVIDER_FAILURE_RETRY_ATTEMPTS + 1);
+    now += AGENT_STATUS_PROVIDER_FAILURE_IDLE_COOLDOWN_MS - 1;
+    await internals.runForWorkspace(workspaceId);
+    expect(generateSpy).toHaveBeenCalledTimes(AGENT_STATUS_PROVIDER_FAILURE_RETRY_ATTEMPTS + 1);
 
-    // After a genuine transcript change, we try again. This time the
-    // generator returns a fresh result and it gets persisted normally.
-    await historyHandle.historyService.appendToHistory(
-      workspaceId,
-      createMuxMessage("u2", "user", "follow-up message")
-    );
-    await getInternals(service).runForWorkspace(workspaceId);
-    expect(generateSpy).toHaveBeenCalledTimes(2);
+    // Once the cooldown expires, the same unchanged transcript is retried and
+    // can recover without requiring the user to send another message.
+    now += 1;
+    await internals.runForWorkspace(workspaceId);
+    expect(generateSpy).toHaveBeenCalledTimes(AGENT_STATUS_PROVIDER_FAILURE_RETRY_ATTEMPTS + 2);
     expect(setSidebarStatusMock).toHaveBeenCalledTimes(1);
     expect(emitWorkspaceActivityMock).toHaveBeenCalledTimes(1);
   });

--- a/src/node/services/agentStatusService.ts
+++ b/src/node/services/agentStatusService.ts
@@ -9,6 +9,10 @@ import {
   AGENT_STATUS_MAX_MESSAGE_CHARS,
   AGENT_STATUS_MAX_TRAILING_MESSAGES,
   AGENT_STATUS_MAX_TRANSCRIPT_TOKENS,
+  AGENT_STATUS_PROVIDER_FAILURE_ACTIVE_COOLDOWN_MS,
+  AGENT_STATUS_PROVIDER_FAILURE_IDLE_COOLDOWN_MS,
+  AGENT_STATUS_PROVIDER_FAILURE_MAX_COOLDOWN_MS,
+  AGENT_STATUS_PROVIDER_FAILURE_RETRY_ATTEMPTS,
   AGENT_STATUS_TICK_INTERVAL_MS,
 } from "@/constants/agentStatus";
 import type { Config } from "@/node/config";
@@ -41,8 +45,6 @@ interface State {
    * changes. That covers:
    *   - successful persists (Ok result, status written),
    *   - post-generation placeholder rejection,
-   *   - generation failures that reached the provider (model refused tool,
-   *     rate limit, persistent provider error, etc.).
    *
    * Pre-provider failures (no API key, OAuth not connected, provider
    * disabled, model not available, policy denied — anything that fails
@@ -70,6 +72,12 @@ interface State {
    * normal idle/active cadence has not elapsed yet.
    */
   lastObservedRecency: number | null;
+  /** Transcript+streaming hash that last hit a retryable provider-side failure. */
+  lastProviderFailureHash: string | null;
+  /** Number of consecutive provider-side failures for lastProviderFailureHash. */
+  providerFailureCount: number;
+  /** Earliest wall-clock time to retry lastProviderFailureHash after cooldown. */
+  providerFailureRetryAfter: number | null;
   /** Whether a generation is currently in flight. */
   inFlight: boolean;
 }
@@ -260,6 +268,7 @@ export class AgentStatusService {
       const settleOnTranscript = () => {
         markRecencyObserved();
         state.lastInputHash = dedupHash;
+        resetProviderFailureTracking(state);
       };
 
       if (
@@ -306,9 +315,23 @@ export class AgentStatusService {
         markRecencyObserved();
         return;
       }
+      if (isWaitingForProviderFailureCooldown(state, dedupHash, this.clock())) {
+        // Provider-side failures are not permanently settled: after the
+        // immediate retry budget, retry on a cost-aware cooldown so transient
+        // outages can still recover without a new chat turn.
+        markRecencyObserved();
+        return;
+      }
 
       const candidates = await this.workspaceService.getWorkspaceTitleModelCandidates(workspaceId);
-      if (candidates.length === 0) return;
+      if (candidates.length === 0) {
+        // No configured small-model path is a config state, not a transcript result.
+        // Consume recency priority so one workspace cannot starve the scheduler, but
+        // keep the dedup hash open so a later config/provider change can recover.
+        resetProviderFailureTracking(state);
+        markRecencyObserved();
+        return;
+      }
 
       // Skip the expensive provider call if stop() fired during any of the
       // earlier awaits (transcript build, candidates fetch). The generator
@@ -322,22 +345,33 @@ export class AgentStatusService {
       // await boundary.
       if (this.stopped) return;
       if (!result.success) {
-        // Only advance the dedup hash when at least one candidate actually
-        // reached the provider. If every candidate failed during model
-        // construction (no API key, OAuth not connected, provider disabled,
-        // model not available, policy denied, etc.), the failure is about
-        // the user's *config* rather than the transcript — caching it would
-        // permanently skip this workspace until they happen to send another
-        // message, even after they fix credentials. Post-provider failures
-        // (model refused tool, rate limit, persistent provider error) are
-        // properties of the transcript and should defer until the chat
-        // changes.
+        // Do not let provider-side misses freeze the sidebar until the next
+        // chat turn. Models occasionally ignore propose_status or hit transient
+        // provider failures for an otherwise valid transcript. Retry a small
+        // number of times immediately, then switch to a cost-aware cooldown so
+        // the same transcript still eventually recovers.
         if (result.error.reachedProvider) {
-          log.debug(
-            "AgentStatusService: status generation failed at provider; deferring until transcript changes",
-            { workspaceId, error: result.error.error }
-          );
-          settleOnTranscript();
+          const failureAttempt = recordProviderFailureAttempt(state, dedupHash);
+          if (hasProviderFailureRetryBudget(failureAttempt)) {
+            log.debug(
+              "AgentStatusService: status generation failed at provider; will retry on cadence",
+              {
+                workspaceId,
+                error: result.error.error,
+                failureAttempt,
+                retryBudget: AGENT_STATUS_PROVIDER_FAILURE_RETRY_ATTEMPTS,
+              }
+            );
+            markRecencyObserved();
+          } else {
+            const retryDelayMs = computeProviderFailureRetryDelayMs(failureAttempt, streaming);
+            state.providerFailureRetryAfter = this.clock() + retryDelayMs;
+            log.debug(
+              "AgentStatusService: status generation failed at provider; cooling down before retry",
+              { workspaceId, error: result.error.error, failureAttempt, retryDelayMs }
+            );
+            markRecencyObserved();
+          }
         } else {
           log.debug(
             "AgentStatusService: status generation failed before reaching provider; will retry on cadence",
@@ -347,6 +381,7 @@ export class AgentStatusService {
           // fixes should still retry the same transcript, but a misconfigured
           // workspace must not retain permanent recency-advanced priority and
           // starve other workspaces under max concurrency 1.
+          resetProviderFailureTracking(state);
           markRecencyObserved();
         }
         return;
@@ -414,6 +449,9 @@ export class AgentStatusService {
         lastInputHash: null,
         lastSeenInputHash: null,
         lastObservedRecency: null,
+        lastProviderFailureHash: null,
+        providerFailureCount: 0,
+        providerFailureRetryAfter: null,
         inFlight: false,
       };
       this.tracked.set(id, state);
@@ -595,6 +633,50 @@ function isRecentRecencyAheadOfHistory(
     (state.lastSeenInputHash === null || state.lastSeenInputHash === inputHash) &&
     observedRecency !== null &&
     now - observedRecency < historyCatchupWindowMs
+  );
+}
+
+function resetProviderFailureTracking(state: State): void {
+  state.lastProviderFailureHash = null;
+  state.providerFailureCount = 0;
+  state.providerFailureRetryAfter = null;
+}
+
+function recordProviderFailureAttempt(state: State, inputHash: string): number {
+  if (state.lastProviderFailureHash !== inputHash) {
+    state.lastProviderFailureHash = inputHash;
+    state.providerFailureCount = 0;
+    state.providerFailureRetryAfter = null;
+  }
+  state.providerFailureCount += 1;
+  state.providerFailureRetryAfter = null;
+  return state.providerFailureCount;
+}
+
+function hasProviderFailureRetryBudget(attempt: number): boolean {
+  return attempt <= AGENT_STATUS_PROVIDER_FAILURE_RETRY_ATTEMPTS;
+}
+
+function isWaitingForProviderFailureCooldown(
+  state: State,
+  inputHash: string,
+  now: number
+): boolean {
+  return (
+    state.lastProviderFailureHash === inputHash &&
+    state.providerFailureRetryAfter !== null &&
+    now < state.providerFailureRetryAfter
+  );
+}
+
+function computeProviderFailureRetryDelayMs(attempt: number, streaming: boolean): number {
+  const baseDelay = streaming
+    ? AGENT_STATUS_PROVIDER_FAILURE_ACTIVE_COOLDOWN_MS
+    : AGENT_STATUS_PROVIDER_FAILURE_IDLE_COOLDOWN_MS;
+  const exhaustedAttempts = Math.max(0, attempt - AGENT_STATUS_PROVIDER_FAILURE_RETRY_ATTEMPTS - 1);
+  return Math.min(
+    baseDelay * 2 ** exhaustedAttempts,
+    AGENT_STATUS_PROVIDER_FAILURE_MAX_COOLDOWN_MS
   );
 }
 


### PR DESCRIPTION
## Summary
Fix flaky agent sidebar status updates by giving provider-side status-generation misses immediate same-transcript retries, followed by bounded cooldown retries so unchanged transcripts can still recover after transient provider/model issues.

## Background
The sidebar status generator previously deduped a transcript immediately after any post-provider failure, including cases where the small model simply missed the required `propose_status` call once. That made status updates appear flaky because the workspace would not retry until the chat transcript changed. The first patch added bounded immediate retries; this update closes the remaining recovery gap by continuing to retry on cooldown instead of permanently settling provider-side failures.

## Implementation
- Added `AGENT_STATUS_PROVIDER_FAILURE_RETRY_ATTEMPTS` for immediate retries on unchanged transcripts.
- Added active/idle provider-failure cooldown constants so active streams recover faster while idle chats back off harder for cost control.
- Tracked provider-side failure counts and retry-after timestamps per transcript+streaming hash in `AgentStatusService`.
- Reset provider failure tracking on successful settle paths and config/pre-provider paths so stale retry counters do not leak across inputs.
- Updated regression coverage to prove provider failures retry first, pause during cooldown, then recover on the same unchanged transcript without a new user turn.

## Validation
- `bun test src/node/services/agentStatusService.test.ts --timeout 20000`
- `make typecheck`
- `make lint`
- `make static-check`
- Reproduced unrelated transient CI failure locally: `TEST_INTEGRATION=1 bun x jest tests/ui/chat/sendModeDropdown.test.ts --runInBand --detectOpenHandles`

## Risks
Low-to-medium: this only changes the background AI-generated sidebar status path, but repeated provider-side failures can now retry indefinitely on cooldown. The retry budget, active/idle cooldown split, exponential backoff, and max cooldown bound provider cost while preserving eventual recovery.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `off` • Cost: `1050807{MUX_COSTS_USD:-unknown}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=off costs=34.01 -->
