### PR TITLE
🤖 fix: release settled /btw transcript holds

### DIFF
--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -89,6 +89,8 @@ import {
 import {
   findActiveSideQuestionScrollHoldTarget,
   findSideQuestionScrollHoldTarget,
+  getSideQuestionScrollHoldScrollportStartTop,
+  isSideQuestionScrollHoldBottomClamped,
   type SideQuestionScrollHoldState,
 } from "./sideQuestionScrollHold";
 import { recordSyntheticReactRenderSample } from "@/browser/utils/perf/reactProfileCollector";
@@ -464,33 +466,52 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
       return;
     }
 
-    const alignSideBranchStart = (): void => {
-      findTranscriptMessageElement(scrollContainer, targetHistoryId)?.scrollIntoView({
+    const alignSideBranchStart = (): HTMLElement | undefined => {
+      const targetElement = findTranscriptMessageElement(scrollContainer, targetHistoryId);
+      targetElement?.scrollIntoView({
         block: "start",
         inline: "nearest",
       });
+      return targetElement;
+    };
+
+    const currentHold = findActiveSideQuestionScrollHoldTarget(deferredMessages, targetHistoryId);
+    const releaseSettledHoldIfAligned = (targetElement: HTMLElement | undefined): void => {
+      if (
+        currentHold.keepActive ||
+        activeSideQuestionScrollHoldTargetRef.current !== targetHistoryId
+      ) {
+        return;
+      }
+
+      // If the first settled-render alignment is still clamped to the transcript
+      // bottom, keep the /btw hold alive for later main-stream growth. Otherwise
+      // the side branch can sit on the viewport bottom forever with newer main
+      // content accumulating below it off-screen.
+      if (
+        targetElement &&
+        isSideQuestionScrollHoldBottomClamped(scrollContainer, targetElement, {
+          scrollportStartTop: getSideQuestionScrollHoldScrollportStartTop(scrollContainer),
+        })
+      ) {
+        return;
+      }
+
+      activeSideQuestionScrollHoldTargetRef.current = null;
     };
 
     // The main stream can now keep rendering below an active /btw branch. Once
     // that happens, bottom-lock would otherwise follow the main tail and yank
     // the user away from the aside they just requested. Release bottom-lock once
-    // per side branch and keep the side-question row readable; Jump to bottom is
-    // then the explicit opt-in to resume watching the live tail. Keep re-aligning
-    // while the side answer grows because the first scroll may clamp at the old
-    // bottom before enough below-branch content exists to place the aside higher.
+    // per side branch and keep the side-question row readable. Keep re-aligning
+    // while the side answer grows and, after it settles, only while the attempted
+    // start alignment is still bottom-clamped. That prevents the side Q/A from
+    // becoming permanent visual clutter at the transcript bottom.
     if (shouldStartHold) {
       activeSideQuestionScrollHoldTargetRef.current = targetHistoryId;
       disableAutoScroll();
     }
-    alignSideBranchStart();
-
-    const currentHold = findActiveSideQuestionScrollHoldTarget(deferredMessages, targetHistoryId);
-    if (
-      !currentHold.keepActive &&
-      activeSideQuestionScrollHoldTargetRef.current === targetHistoryId
-    ) {
-      activeSideQuestionScrollHoldTargetRef.current = null;
-    }
+    releaseSettledHoldIfAligned(alignSideBranchStart());
 
     const win = typeof window !== "undefined" ? window : undefined;
     const raf = win?.requestAnimationFrame?.bind(win);
@@ -499,7 +520,7 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
       return;
     }
 
-    const frameId = raf(alignSideBranchStart);
+    const frameId = raf(() => releaseSettledHoldIfAligned(alignSideBranchStart()));
     return () => cancelRaf(frameId);
   }, [autoScroll, contentRef, deferredMessages, disableAutoScroll, isHydratingTranscript, loading]);
 

--- a/src/browser/components/ChatPane/sideQuestionScrollHold.test.ts
+++ b/src/browser/components/ChatPane/sideQuestionScrollHold.test.ts
@@ -3,6 +3,7 @@ import type { DisplayedMessage } from "@/common/types/message";
 import {
   findActiveSideQuestionScrollHoldTarget,
   findSideQuestionScrollHoldTarget,
+  isSideQuestionScrollHoldBottomClamped,
 } from "./sideQuestionScrollHold";
 
 function userMessage(
@@ -203,12 +204,12 @@ describe("findSideQuestionScrollHoldTarget", () => {
     expect(result.targetHistoryId).toBeUndefined();
   });
 
-  test("keeps an active side-question hold aligned while its answer grows", () => {
+  test("keeps an active side-question hold aligned while its answer streams", () => {
     const withoutAnswer = findActiveSideQuestionScrollHoldTarget(
       [assistantMessage("main-1"), userMessage("btw-q", { isSideQuestion: true })],
       "btw-q"
     );
-    expect(withoutAnswer).toEqual({ targetHistoryId: "btw-q", keepActive: true });
+    expect(withoutAnswer).toEqual({ targetHistoryId: "btw-q", keepActive: false });
 
     const streamingAnswer = findActiveSideQuestionScrollHoldTarget(
       [
@@ -231,6 +232,91 @@ describe("findSideQuestionScrollHoldTarget", () => {
       "btw-q"
     );
     expect(settledAnswer).toEqual({ targetHistoryId: "btw-q", keepActive: false });
+  });
+
+  test("keeps an active fallback answer-row hold while the side answer streams", () => {
+    const streamingAnswer = findActiveSideQuestionScrollHoldTarget(
+      [
+        assistantMessage("main-1"),
+        assistantMessage("btw-a", { isSideAnswer: true, isStreaming: true }),
+        assistantMessage("main-1-post"),
+      ],
+      "btw-a"
+    );
+    expect(streamingAnswer).toEqual({ targetHistoryId: "btw-a", keepActive: true });
+
+    const settledAnswer = findActiveSideQuestionScrollHoldTarget(
+      [
+        assistantMessage("main-1"),
+        assistantMessage("btw-a", { isSideAnswer: true, isStreaming: false }),
+        assistantMessage("main-1-post"),
+      ],
+      "btw-a"
+    );
+    expect(settledAnswer).toEqual({ targetHistoryId: "btw-a", keepActive: false });
+  });
+
+  test("detects a side-question alignment that is still clamped to transcript bottom", () => {
+    const scrollContainer: Parameters<typeof isSideQuestionScrollHoldBottomClamped>[0] = {
+      scrollTop: 500,
+      scrollHeight: 900,
+      clientHeight: 400,
+      getBoundingClientRect: () => ({ top: 100 }),
+    };
+    const targetElement: Parameters<typeof isSideQuestionScrollHoldBottomClamped>[1] = {
+      getBoundingClientRect: () => ({ top: 280 }),
+    };
+
+    expect(isSideQuestionScrollHoldBottomClamped(scrollContainer, targetElement)).toBe(true);
+  });
+
+  test("accounts for transcript padding when detecting a clamped side-question alignment", () => {
+    const scrollContainer: Parameters<typeof isSideQuestionScrollHoldBottomClamped>[0] = {
+      scrollTop: 500,
+      scrollHeight: 900,
+      clientHeight: 400,
+      getBoundingClientRect: () => ({ top: 100 }),
+    };
+    const targetElement: Parameters<typeof isSideQuestionScrollHoldBottomClamped>[1] = {
+      getBoundingClientRect: () => ({ top: 115 }),
+    };
+
+    expect(
+      isSideQuestionScrollHoldBottomClamped(scrollContainer, targetElement, {
+        scrollportStartTop: 115,
+      })
+    ).toBe(false);
+  });
+
+  test("releases settled side-question holds once the target can align at transcript start", () => {
+    const scrollContainer: Parameters<typeof isSideQuestionScrollHoldBottomClamped>[0] = {
+      // This can still be max scrollTop when the target itself is at the top of
+      // the scrollport; geometry, not scrollTop alone, distinguishes the safe
+      // release from the bottom-clamped clutter case.
+      scrollTop: 500,
+      scrollHeight: 900,
+      clientHeight: 400,
+      getBoundingClientRect: () => ({ top: 100 }),
+    };
+    const targetElement: Parameters<typeof isSideQuestionScrollHoldBottomClamped>[1] = {
+      getBoundingClientRect: () => ({ top: 101 }),
+    };
+
+    expect(isSideQuestionScrollHoldBottomClamped(scrollContainer, targetElement)).toBe(false);
+  });
+
+  test("does not treat manual reading positions as bottom-clamped side-question holds", () => {
+    const scrollContainer: Parameters<typeof isSideQuestionScrollHoldBottomClamped>[0] = {
+      scrollTop: 300,
+      scrollHeight: 900,
+      clientHeight: 400,
+      getBoundingClientRect: () => ({ top: 100 }),
+    };
+    const targetElement: Parameters<typeof isSideQuestionScrollHoldBottomClamped>[1] = {
+      getBoundingClientRect: () => ({ top: 280 }),
+    };
+
+    expect(isSideQuestionScrollHoldBottomClamped(scrollContainer, targetElement)).toBe(false);
   });
 
   test("falls back to the answer row when the side-question user row is unavailable", () => {

--- a/src/browser/components/ChatPane/sideQuestionScrollHold.ts
+++ b/src/browser/components/ChatPane/sideQuestionScrollHold.ts
@@ -17,12 +17,76 @@ export interface ActiveSideQuestionScrollHoldResult {
   targetHistoryId?: string;
 }
 
+interface ScrollHoldViewportGeometry {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+  getBoundingClientRect(): Pick<DOMRectReadOnly, "top">;
+}
+
+interface ScrollHoldTargetGeometry {
+  getBoundingClientRect(): Pick<DOMRectReadOnly, "top">;
+}
+
+interface ScrollHoldBottomClampOptions {
+  scrollportStartTop?: number;
+}
+
+const BOTTOM_CLAMP_EPSILON_PX = 1;
+const TARGET_START_ALIGNMENT_EPSILON_PX = 2;
+
+function readCssPixelValue(value: string): number {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function getSideQuestionScrollHoldScrollportStartTop(scrollContainer: HTMLElement): number {
+  const containerTop = scrollContainer.getBoundingClientRect().top;
+  const style = scrollContainer.ownerDocument.defaultView?.getComputedStyle(scrollContainer);
+  if (!style) {
+    return containerTop;
+  }
+
+  // scrollIntoView aligns to the scrollport's padding edge. The transcript
+  // scroller has padding, so comparing against the border box would mistake a
+  // correctly aligned /btw row for a bottom-clamped row and keep the hold alive.
+  return (
+    containerTop + readCssPixelValue(style.borderTopWidth) + readCssPixelValue(style.paddingTop)
+  );
+}
+
+/**
+ * `scrollIntoView({ block: "start" })` silently degrades to bottom-clamping when
+ * there is not yet enough transcript content below a /btw branch. Keep the
+ * short-lived hold only in that clamped state; once the target can actually sit
+ * at the transcript scrollport start, the side branch must stop owning scroll so
+ * it cannot become permanent bottom clutter.
+ */
+export function isSideQuestionScrollHoldBottomClamped(
+  scrollContainer: ScrollHoldViewportGeometry,
+  targetElement: ScrollHoldTargetGeometry,
+  options: ScrollHoldBottomClampOptions = {}
+): boolean {
+  const maxScrollTop = Math.max(0, scrollContainer.scrollHeight - scrollContainer.clientHeight);
+  const isAtScrollBottom = maxScrollTop - scrollContainer.scrollTop <= BOTTOM_CLAMP_EPSILON_PX;
+  if (!isAtScrollBottom) {
+    return false;
+  }
+
+  const scrollportStartTop =
+    options.scrollportStartTop ?? scrollContainer.getBoundingClientRect().top;
+  const targetTop = targetElement.getBoundingClientRect().top;
+  return targetTop > scrollportStartTop + TARGET_START_ALIGNMENT_EPSILON_PX;
+}
+
 /**
  * Continue aligning a side-question branch after the first hand-off from
  * bottom-lock. The first scroll can happen before there is enough content below
  * the branch for the browser to place it in a readable position, so active side
  * holds keep re-aligning on subsequent stream updates until the side answer has
- * produced one final settled render.
+ * produced one final settled render. If no answer row is currently rendered
+ * (model setup lag, retry, or failure), the ChatPane keeps that target alive
+ * only while DOM geometry says the attempted alignment is still bottom-clamped.
  */
 export function findActiveSideQuestionScrollHoldTarget(
   messages: readonly DisplayedMessage[],
@@ -39,7 +103,20 @@ export function findActiveSideQuestionScrollHoldTarget(
       message.historyId === activeTargetHistoryId
   );
   if (sideQuestionIndex === -1) {
-    return { keepActive: false };
+    const sideAnswer = messages.find(
+      (message): message is Extract<DisplayedMessage, { type: "assistant" }> =>
+        message.type === "assistant" &&
+        message.isSideAnswer === true &&
+        message.historyId === activeTargetHistoryId
+    );
+    if (!sideAnswer) {
+      return { keepActive: false };
+    }
+
+    return {
+      targetHistoryId: activeTargetHistoryId,
+      keepActive: sideAnswer.isStreaming === true,
+    };
   }
 
   const nextMessage = messages[sideQuestionIndex + 1];
@@ -50,7 +127,7 @@ export function findActiveSideQuestionScrollHoldTarget(
     };
   }
 
-  return { targetHistoryId: activeTargetHistoryId, keepActive: true };
+  return { targetHistoryId: activeTargetHistoryId, keepActive: false };
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes `/btw` side-question scroll holds so the side Q&A can no longer remain stuck to the bottom of the transcript as permanent visual clutter.

## Background

`/btw` intentionally hands scroll ownership from bottom-lock to the side branch when main-agent output continues below the aside. The previous hold kept re-aligning through the answer lifecycle, but did not distinguish a real start-aligned branch from a browser bottom-clamp caused by insufficient content below it.

## Implementation

- Detect whether `scrollIntoView({ block: "start" })` is still bottom-clamped using transcript/target geometry.
- Keep the temporary side-question hold only while the side answer is streaming or while the attempted start alignment is still clamped to the bottom.
- Release settled holds once the branch can align at the transcript viewport start.
- Preserve fallback answer-row handling for side answers whose user row is unavailable.

## Validation

- `bun test src/browser/components/ChatPane/sideQuestionScrollHold.test.ts`
- `bun test src/browser/utils/messages/StreamingMessageAggregator.sideQuestion.test.ts src/browser/stores/WorkspaceStore.test.ts --test-name-pattern "/btw|side-question|Side question|side answer"`
- `bun run typecheck`
- `make fmt-check`
- `make lint`
- `make static-check`

## Risks

Low-to-moderate. The change touches transcript scroll ownership, but it is limited to `/btw` side-question hold release logic and covered by targeted unit tests for streaming, settled, fallback-row, and geometry cases.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$7.88`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=7.88 -->
