### PR TITLE
🤖 fix: detach SSH base repo gc

### DIFF
--- a/src/node/runtime/SSHRuntime.retry.test.ts
+++ b/src/node/runtime/SSHRuntime.retry.test.ts
@@ -206,6 +206,9 @@ class CleanupCommandSSHRuntime extends SSHRuntime {
       return Promise.resolve(createExecStream(this.promisorStdout));
     }
     if (command.includes(" gc --prune=now")) {
+      // Spawn-only call: production code returns as soon as the remote shell
+      // has detached `git gc`. The mock mirrors that shape (stdout/stderr/exit
+      // here represent the detached spawn, not gc itself).
       return Promise.resolve(createExecStream(this.gcStdout, this.gcStderr, this.gcExitCode));
     }
     return Promise.resolve(createExecStream(""));
@@ -218,6 +221,16 @@ class CleanupCommandSSHRuntime extends SSHRuntime {
 // a half-completed repair leaves the repo non-promisor (and therefore safe
 // from the upstream `check_connected()` sideband deadlock — see the doc
 // comment on `stripBaseRepoPromisorConfig` in SSHRuntime.ts).
+// Detached gc invocation: `setsid -f` puts gc in its own session/PGID before
+// execing git so that neither the SSH channel closing nor the `timeout -s KILL`
+// process-group kill that `RemoteRuntime.exec` wraps every command in can
+// SIGKILL gc mid-finalization. A mid-finalization kill between
+// `tmp_pack_X → pack-<sha>.pack` and `tmp_idx_X → pack-<sha>.idx` would
+// corrupt the object store — see the doc comment in `repairBaseRepoForSync`.
+function expectedDetachedGcCommand(baseRepoPathArg: string): string {
+  return `setsid -f git -C ${baseRepoPathArg} gc --prune=now </dev/null >>/tmp/.mux-base-repo-gc.log 2>&1`;
+}
+
 function expectedStripPromisorCommand(baseRepoPathArg: string): string {
   return (
     `git -C ${baseRepoPathArg} config --unset-all remote.origin.promisor; ` +
@@ -248,9 +261,11 @@ describe("SSHRuntime project sync retry orchestration", () => {
     expect(runtime.commands).toEqual([
       expectedStripPromisorCommand(baseRepoPathArg),
       `find ${baseRepoPathArg}/objects/pack -name '*.promisor' -print -delete 2>/dev/null || true`,
-      `git -C ${baseRepoPathArg} gc --prune=now`,
+      expectedDetachedGcCommand(baseRepoPathArg),
     ]);
-    expect(runtime.timeouts).toEqual([10, 10, 120]);
+    // Last timeout is the SSH spawn round-trip, NOT gc itself. gc is detached
+    // on the remote and we intentionally do not bound it client-side.
+    expect(runtime.timeouts).toEqual([10, 10, 10]);
   });
 
   it("proactively repairs fragmented base repos before sync", async () => {
@@ -267,9 +282,10 @@ describe("SSHRuntime project sync retry orchestration", () => {
       `git -C ${baseRepoPathArg} count-objects -v`,
       expectedStripPromisorCommand(baseRepoPathArg),
       `find ${baseRepoPathArg}/objects/pack -name '*.promisor' -print -delete 2>/dev/null || true`,
-      `git -C ${baseRepoPathArg} gc --prune=now`,
+      expectedDetachedGcCommand(baseRepoPathArg),
     ]);
-    expect(runtime.timeouts).toEqual([10, 10, 10, 120]);
+    // Last timeout is the SSH spawn round-trip, NOT gc itself.
+    expect(runtime.timeouts).toEqual([10, 10, 10, 10]);
   });
 
   it("skips proactive maintenance for healthy base repos", async () => {
@@ -297,12 +313,12 @@ describe("SSHRuntime project sync retry orchestration", () => {
     expect(runtime.timeouts).toEqual([10]);
   });
 
-  it("keeps proactive maintenance best-effort when git gc exits non-zero", async () => {
+  it("keeps proactive maintenance best-effort when the gc spawn fails", async () => {
     const runtime = new CleanupCommandSSHRuntime();
     const baseRepoPathArg = '"/remote/src/project/.mux-base.git"';
     runtime.countObjectsStdout = "count: 0\npacks: 50\n";
     runtime.gcExitCode = 1;
-    runtime.gcStderr = "warning: gc skipped";
+    runtime.gcStderr = "setsid: command not found";
 
     await runtime.runEnsureHealthy(baseRepoPathArg);
 
@@ -313,9 +329,9 @@ describe("SSHRuntime project sync retry orchestration", () => {
       `git -C ${baseRepoPathArg} count-objects -v`,
       expectedStripPromisorCommand(baseRepoPathArg),
       `find ${baseRepoPathArg}/objects/pack -name '*.promisor' -print -delete 2>/dev/null || true`,
-      `git -C ${baseRepoPathArg} gc --prune=now`,
+      expectedDetachedGcCommand(baseRepoPathArg),
     ]);
-    expect(runtime.timeouts).toEqual([10, 10, 10, 120]);
+    expect(runtime.timeouts).toEqual([10, 10, 10, 10]);
   });
 
   it("propagates aborts during proactive maintenance preflight", async () => {

--- a/src/node/runtime/SSHRuntime.retry.test.ts
+++ b/src/node/runtime/SSHRuntime.retry.test.ts
@@ -224,11 +224,15 @@ class CleanupCommandSSHRuntime extends SSHRuntime {
 // Detached gc invocation: `setsid -f` puts gc in its own session/PGID before
 // execing git so that neither the SSH channel closing nor the `timeout -s KILL`
 // process-group kill that `RemoteRuntime.exec` wraps every command in can
-// SIGKILL gc mid-finalization. A mid-finalization kill between
-// `tmp_pack_X → pack-<sha>.pack` and `tmp_idx_X → pack-<sha>.idx` would
-// corrupt the object store — see the doc comment in `repairBaseRepoForSync`.
-function expectedDetachedGcCommand(baseRepoPathArg: string): string {
-  return `setsid -f git -C ${baseRepoPathArg} gc --prune=now </dev/null >>/tmp/.mux-base-repo-gc.log 2>&1`;
+// SIGKILL gc mid-finalization. Retry cleanup uses `setsid -w` to wait for
+// the detached child; proactive preflight only waits for the detached spawn.
+function expectedGcCommand(baseRepoPathArg: string, waitForGc: boolean): string {
+  const setsidArgs = waitForGc ? "-f -w" : "-f";
+  return [
+    `base_repo=${baseRepoPathArg}`,
+    "command -v setsid >/dev/null 2>&1 || { echo 'setsid command not found; cannot detach git gc' >&2; exit 127; }",
+    `setsid ${setsidArgs} sh -c 'exec git -C "$1" gc --prune=now >>/tmp/.mux-base-repo-gc.log 2>&1' sh "$base_repo" </dev/null`,
+  ].join("\n");
 }
 
 function expectedStripPromisorCommand(baseRepoPathArg: string): string {
@@ -261,11 +265,11 @@ describe("SSHRuntime project sync retry orchestration", () => {
     expect(runtime.commands).toEqual([
       expectedStripPromisorCommand(baseRepoPathArg),
       `find ${baseRepoPathArg}/objects/pack -name '*.promisor' -print -delete 2>/dev/null || true`,
-      expectedDetachedGcCommand(baseRepoPathArg),
+      expectedGcCommand(baseRepoPathArg, true),
     ]);
-    // Last timeout is the SSH spawn round-trip, NOT gc itself. gc is detached
-    // on the remote and we intentionally do not bound it client-side.
-    expect(runtime.timeouts).toEqual([10, 10, 10]);
+    // Last timeout waits for `setsid -w`. It can stop waiting without killing
+    // the detached gc process itself.
+    expect(runtime.timeouts).toEqual([10, 10, 30 * 60]);
   });
 
   it("proactively repairs fragmented base repos before sync", async () => {
@@ -282,7 +286,7 @@ describe("SSHRuntime project sync retry orchestration", () => {
       `git -C ${baseRepoPathArg} count-objects -v`,
       expectedStripPromisorCommand(baseRepoPathArg),
       `find ${baseRepoPathArg}/objects/pack -name '*.promisor' -print -delete 2>/dev/null || true`,
-      expectedDetachedGcCommand(baseRepoPathArg),
+      expectedGcCommand(baseRepoPathArg, false),
     ]);
     // Last timeout is the SSH spawn round-trip, NOT gc itself.
     expect(runtime.timeouts).toEqual([10, 10, 10, 10]);
@@ -329,7 +333,7 @@ describe("SSHRuntime project sync retry orchestration", () => {
       `git -C ${baseRepoPathArg} count-objects -v`,
       expectedStripPromisorCommand(baseRepoPathArg),
       `find ${baseRepoPathArg}/objects/pack -name '*.promisor' -print -delete 2>/dev/null || true`,
-      expectedDetachedGcCommand(baseRepoPathArg),
+      expectedGcCommand(baseRepoPathArg, false),
     ]);
     expect(runtime.timeouts).toEqual([10, 10, 10, 10]);
   });

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -71,11 +71,17 @@ const BASE_REPO_CONFIG_LOCK_RETRY_DELAYS_MS = [50, 100, 200];
 const BASE_REPO_HEALTH_PROBE_TIMEOUT_SECONDS = 10;
 const BASE_REPO_PROMISOR_CLEANUP_TIMEOUT_SECONDS = 10;
 /**
- * Timeout for *spawning* the remote detached gc, not for gc itself. The
- * remote shell returns as soon as it has started `git gc` in the background,
- * so this only needs to cover one SSH round-trip.
+ * Timeout for *spawning* remote detached gc, not for gc itself. The remote
+ * shell returns as soon as it has started `git gc` in the background, so this
+ * only needs to cover one SSH round-trip.
  */
 const BASE_REPO_MAINTENANCE_SPAWN_TIMEOUT_SECONDS = 10;
+/**
+ * Retry-time maintenance should still wait for gc so the next sync attempt can
+ * benefit from the repair. The gc process itself is detached, so this timeout
+ * can stop waiting without SIGKILLing Git mid-pack-finalization.
+ */
+const BASE_REPO_MAINTENANCE_WAIT_TIMEOUT_SECONDS = 30 * 60;
 /** Git config keys that announce a bare repo as a promisor remote to
  *  `repo_has_promisor_remote()`. Unsetting all three is what makes
  *  receive-pack's `check_connected()` skip the buggy partial-clone fast
@@ -620,7 +626,8 @@ export class SSHRuntime extends RemoteRuntime {
   protected async repairBaseRepoForSync(
     baseRepoPathArg: string,
     repairContext: string,
-    abortSignal?: AbortSignal
+    abortSignal?: AbortSignal,
+    options: { waitForGc?: boolean } = {}
   ): Promise<void> {
     if (abortSignal?.aborted) {
       throw new Error("Operation aborted");
@@ -654,38 +661,38 @@ export class SSHRuntime extends RemoteRuntime {
       );
     }
 
-    // Spawn `git gc` detached on the remote and return immediately. We must NOT
-    // hold a client-side timeout over gc itself: a SIGKILL between
+    // Always detach `git gc` from mux's SSH command timeout. A SIGKILL between
     // `tmp_pack_X → pack-<sha>.pack` and `tmp_idx_X → pack-<sha>.idx` leaves a
-    // .pack with no .idx, which silently hides every object inside that pack
-    // and makes thin pushes fail with `unresolved deltas left after unpacking`.
+    // .pack with no .idx, hiding every object inside that pack and making thin
+    // pushes fail with `unresolved deltas left after unpacking`.
     //
-    // `setsid -f` forks gc into its own session (and therefore its own process
-    // group) before execing git, which is what makes gc survive the SSH channel
-    // closing AND the `timeout -s KILL` group-kill that `RemoteRuntime.exec`
-    // wraps every remote command in. `nohup` + `&` + `disown` would not be
-    // enough: timeout(1) by default sends SIGKILL to its whole child process
-    // group, and SIGKILL ignores SIGHUP-disposition tricks. Git's own `gc.pid`
-    // lock prevents concurrent gcs from racing on the same repo.
+    // `setsid -f` forks gc into its own session/process group before execing
+    // Git, so gc survives SSH channel shutdown and the `timeout -s KILL` group
+    // kill that `RemoteRuntime.exec` wraps every remote command in. `nohup` is
+    // not enough because SIGKILL ignores SIGHUP-disposition tricks. Git's own
+    // `gc.pid` lock prevents concurrent gcs from racing on the same repo.
     //
-    // We deliberately do not capture gc's exit code: the maintenance is
-    // advisory (it keeps pushes fast on long-lived repos) and any real
-    // failure surfaces on the next push, which falls back to the normal
-    // retry/cleanup path. Logs land in /tmp/.mux-base-repo-gc.log on the
-    // remote for postmortems.
-    const gcSpawnResult = await execBuffered(
-      this,
-      `setsid -f git -C ${baseRepoPathArg} gc --prune=now </dev/null >>/tmp/.mux-base-repo-gc.log 2>&1`,
-      {
-        cwd: "/tmp",
-        timeout: BASE_REPO_MAINTENANCE_SPAWN_TIMEOUT_SECONDS,
-        abortSignal,
-      }
-    );
-    if (gcSpawnResult.exitCode !== 0) {
-      log.warn(
-        `Failed to spawn remote git gc during base repo maintenance: ${gcSpawnResult.stderr || gcSpawnResult.stdout}`
-      );
+    // Proactive preflight is advisory and only waits for the detached spawn.
+    // Retry cleanup uses `setsid -w` to wait for the detached child, so the
+    // retry can benefit from completed maintenance without ever putting gc
+    // itself under a client-side kill timeout. Logs land in
+    // /tmp/.mux-base-repo-gc.log.
+    const setsidArgs = options.waitForGc ? "-f -w" : "-f";
+    const gcCommand = [
+      `base_repo=${baseRepoPathArg}`,
+      "command -v setsid >/dev/null 2>&1 || { echo 'setsid command not found; cannot detach git gc' >&2; exit 127; }",
+      `setsid ${setsidArgs} sh -c 'exec git -C "$1" gc --prune=now >>/tmp/.mux-base-repo-gc.log 2>&1' sh "$base_repo" </dev/null`,
+    ].join("\n");
+    const gcResult = await execBuffered(this, gcCommand, {
+      cwd: "/tmp",
+      timeout: options.waitForGc
+        ? BASE_REPO_MAINTENANCE_WAIT_TIMEOUT_SECONDS
+        : BASE_REPO_MAINTENANCE_SPAWN_TIMEOUT_SECONDS,
+      abortSignal,
+    });
+    if (gcResult.exitCode !== 0) {
+      const detail = (gcResult.stderr || gcResult.stdout).trim() || `exit ${gcResult.exitCode}`;
+      log.warn(`Remote git gc maintenance failed: ${detail}`);
     }
   }
 
@@ -736,7 +743,8 @@ export class SSHRuntime extends RemoteRuntime {
       await this.repairBaseRepoForSync(
         baseRepoPathArg,
         `Running remote promisor cleanup and git gc before retrying sync push (attempt ${attempt + 1}/${maxAttempts})`,
-        abortSignal
+        abortSignal,
+        { waitForGc: true }
       );
     } catch (cleanupError) {
       const cleanupErrorMsg = getErrorMessage(cleanupError);

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -70,6 +70,12 @@ const BUNDLE_REF_PREFIX = "refs/mux-bundle/";
 const BASE_REPO_CONFIG_LOCK_RETRY_DELAYS_MS = [50, 100, 200];
 const BASE_REPO_HEALTH_PROBE_TIMEOUT_SECONDS = 10;
 const BASE_REPO_PROMISOR_CLEANUP_TIMEOUT_SECONDS = 10;
+/**
+ * Timeout for *spawning* the remote detached gc, not for gc itself. The
+ * remote shell returns as soon as it has started `git gc` in the background,
+ * so this only needs to cover one SSH round-trip.
+ */
+const BASE_REPO_MAINTENANCE_SPAWN_TIMEOUT_SECONDS = 10;
 /** Git config keys that announce a bare repo as a promisor remote to
  *  `repo_has_promisor_remote()`. Unsetting all three is what makes
  *  receive-pack's `check_connected()` skip the buggy partial-clone fast
@@ -79,7 +85,6 @@ const BASE_REPO_PROMISOR_CONFIG_KEYS = [
   "remote.origin.partialclonefilter",
   "extensions.partialclone",
 ] as const;
-const BASE_REPO_MAINTENANCE_TIMEOUT_SECONDS = 120;
 const BASE_REPO_FRAGMENTED_PACK_THRESHOLD = 25;
 const PROJECT_SYNC_MAX_ATTEMPTS = 3;
 const PROJECT_SYNC_RETRYABLE_ERRORS = [
@@ -649,14 +654,37 @@ export class SSHRuntime extends RemoteRuntime {
       );
     }
 
-    const gcResult = await execBuffered(this, `git -C ${baseRepoPathArg} gc --prune=now`, {
-      cwd: "/tmp",
-      timeout: BASE_REPO_MAINTENANCE_TIMEOUT_SECONDS,
-      abortSignal,
-    });
-    if (gcResult.exitCode !== 0) {
+    // Spawn `git gc` detached on the remote and return immediately. We must NOT
+    // hold a client-side timeout over gc itself: a SIGKILL between
+    // `tmp_pack_X → pack-<sha>.pack` and `tmp_idx_X → pack-<sha>.idx` leaves a
+    // .pack with no .idx, which silently hides every object inside that pack
+    // and makes thin pushes fail with `unresolved deltas left after unpacking`.
+    //
+    // `setsid -f` forks gc into its own session (and therefore its own process
+    // group) before execing git, which is what makes gc survive the SSH channel
+    // closing AND the `timeout -s KILL` group-kill that `RemoteRuntime.exec`
+    // wraps every remote command in. `nohup` + `&` + `disown` would not be
+    // enough: timeout(1) by default sends SIGKILL to its whole child process
+    // group, and SIGKILL ignores SIGHUP-disposition tricks. Git's own `gc.pid`
+    // lock prevents concurrent gcs from racing on the same repo.
+    //
+    // We deliberately do not capture gc's exit code: the maintenance is
+    // advisory (it keeps pushes fast on long-lived repos) and any real
+    // failure surfaces on the next push, which falls back to the normal
+    // retry/cleanup path. Logs land in /tmp/.mux-base-repo-gc.log on the
+    // remote for postmortems.
+    const gcSpawnResult = await execBuffered(
+      this,
+      `setsid -f git -C ${baseRepoPathArg} gc --prune=now </dev/null >>/tmp/.mux-base-repo-gc.log 2>&1`,
+      {
+        cwd: "/tmp",
+        timeout: BASE_REPO_MAINTENANCE_SPAWN_TIMEOUT_SECONDS,
+        abortSignal,
+      }
+    );
+    if (gcSpawnResult.exitCode !== 0) {
       log.warn(
-        `Remote git gc exited ${gcResult.exitCode} during base repo maintenance: ${gcResult.stderr || gcResult.stdout}`
+        `Failed to spawn remote git gc during base repo maintenance: ${gcSpawnResult.stderr || gcSpawnResult.stdout}`
       );
     }
   }


### PR DESCRIPTION
## Summary

Detach shared SSH base-repo gc from mux's SSH command timeout so maintenance can keep long-lived bare repos defragmented without mux killing Git mid-pack-finalization.

## Background

The existing base repo maintenance path ran `git gc --prune=now` through mux's timed SSH command wrapper. On large shared bare repos, that timeout can fire while Git is finalizing packs, leaving a `.pack` without its matching `.idx`. Git then cannot see the objects in that pack, and later sync pushes can fail with unresolved remote deltas.

## Implementation

This keeps the existing maintenance triggers and retry flow, but runs gc through `setsid` so the actual Git process is in its own session/process group. Proactive preflight uses `setsid -f` and only waits for the remote spawn because that maintenance is advisory. Retry cleanup uses `setsid -f -w`, which waits for the detached child to exit and returns its status, so the next retry can benefit from completed maintenance without putting gc itself under mux's kill timeout. Missing `setsid` is checked before redirecting gc output, so local logs preserve actionable spawn diagnostics; gc's own output still goes to `/tmp/.mux-base-repo-gc.log` on the SSH host.

## Risks

The behavior depends on util-linux `setsid` with `-f`/`-w` support on the SSH host. If it is missing, maintenance logs a warning and sync proceeds through the existing best-effort path; correctness is preserved, but base-repo defragmentation may not run on that host.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$29.50`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=29.50 -->
