### PR TITLE
🤖 fix: auto-expand advisor while streaming

### DIFF
--- a/src/browser/features/Tools/AdvisorToolCall.test.tsx
+++ b/src/browser/features/Tools/AdvisorToolCall.test.tsx
@@ -86,7 +86,7 @@ describe("AdvisorToolCall", () => {
     globalThis.document = originalDocument;
   });
 
-  test("shows live phase timing in collapsed and expanded executing states", () => {
+  test("auto-expands while executing and shows live phase timing", () => {
     const startedAt = 1_700_000_000_123;
 
     useAdvisorToolLivePhaseMock.mockReturnValue({
@@ -97,22 +97,22 @@ describe("AdvisorToolCall", () => {
     const view = renderAdvisorToolCall({ startedAt });
 
     expect(useAdvisorToolLivePhaseMock).toHaveBeenCalledWith("workspace-1", "advisor-call-1");
-    expect(view.getByText("Waiting for response")).toBeTruthy();
+    expect(view.getAllByText("Waiting for response")).toHaveLength(2);
 
     let timers = view.getAllByTestId("elapsed-time");
-    expect(timers).toHaveLength(1);
-    expect(timers[0]?.dataset.active).toBe("true");
-    expect(timers[0]?.dataset.startedAt).toBe(String(startedAt));
-
-    fireEvent.click(view.getByText("advisor"));
-
-    expect(view.getAllByText("Waiting for response")).toHaveLength(2);
-    timers = view.getAllByTestId("elapsed-time");
     expect(timers).toHaveLength(2);
     for (const timer of timers) {
       expect(timer.dataset.active).toBe("true");
       expect(timer.dataset.startedAt).toBe(String(startedAt));
     }
+
+    fireEvent.click(view.getByText("advisor"));
+
+    expect(view.getAllByText("Waiting for response")).toHaveLength(1);
+    timers = view.getAllByTestId("elapsed-time");
+    expect(timers).toHaveLength(1);
+    expect(timers[0]?.dataset.active).toBe("true");
+    expect(timers[0]?.dataset.startedAt).toBe(String(startedAt));
   });
 
   test("falls back to a generic running state before a live phase arrives", () => {
@@ -120,10 +120,12 @@ describe("AdvisorToolCall", () => {
 
     const view = renderAdvisorToolCall();
 
-    expect(view.getByText("Running")).toBeTruthy();
+    expect(view.getAllByText("Running")).toHaveLength(2);
     const timers = view.getAllByTestId("elapsed-time");
-    expect(timers).toHaveLength(1);
-    expect(timers[0]?.dataset.active).toBe("true");
+    expect(timers).toHaveLength(2);
+    for (const timer of timers) {
+      expect(timer.dataset.active).toBe("true");
+    }
   });
 
   test("renders the advisor question when present", () => {
@@ -146,7 +148,7 @@ describe("AdvisorToolCall", () => {
     expect(view.getByText("Should we split the refactor into smaller commits?")).toBeTruthy();
   });
 
-  test("renders live advisor output while executing", () => {
+  test("renders live advisor output while auto-expanded during execution", () => {
     useAdvisorToolLivePhaseMock.mockReturnValue({
       phase: "waiting_for_response",
       timestamp: 1,
@@ -159,11 +161,105 @@ describe("AdvisorToolCall", () => {
     const view = renderAdvisorToolCall({ status: "executing" });
 
     expect(useAdvisorToolLiveOutputMock).toHaveBeenCalledWith("workspace-1", "advisor-call-1");
+    expect(view.getByText("Advice")).toBeTruthy();
+    expect(view.getByText("Streamed partial advice")).toBeTruthy();
+  });
+
+  test("collapses back to the settled default when execution completes", () => {
+    useAdvisorToolLivePhaseMock.mockReturnValue({
+      phase: "waiting_for_response",
+      timestamp: 1,
+    });
+    useAdvisorToolLiveOutputMock.mockReturnValue({
+      text: "Streamed partial advice",
+      timestamp: 2,
+    });
+
+    const view = renderAdvisorToolCall({ status: "executing" });
+
+    expect(view.getByText("Streamed partial advice")).toBeTruthy();
+
+    useAdvisorToolLivePhaseMock.mockReturnValue(undefined);
+    useAdvisorToolLiveOutputMock.mockReturnValue(null);
+
+    view.rerender(
+      <TooltipProvider>
+        <AdvisorToolCall
+          args={{}}
+          status="completed"
+          workspaceId="workspace-1"
+          toolCallId="advisor-call-1"
+          startedAt={1_700_000_000_000}
+          result={{
+            type: "advice",
+            advice: "Final persisted advice",
+            advisorModel: "openai:gpt-4.1-mini",
+            remainingUses: 1,
+          }}
+        />
+      </TooltipProvider>
+    );
+
+    expect(view.queryByText("Final persisted advice")).toBeNull();
 
     fireEvent.click(view.getByText("advisor"));
 
-    expect(view.getByText("Advice")).toBeTruthy();
-    expect(view.getByText("Streamed partial advice")).toBeTruthy();
+    expect(view.getByText("Final persisted advice")).toBeTruthy();
+  });
+
+  test("does not auto-expand executing rows that already have terminal results", () => {
+    const cases: Array<{
+      name: string;
+      result: unknown;
+      textAfterExpand: string;
+      verifyExpandedDetails?: boolean;
+    }> = [
+      {
+        name: "limit",
+        result: {
+          type: "limit_reached",
+          advisorModel: "openai:gpt-4.1-mini",
+          message: "Unique advisor limit reached message",
+        },
+        textAfterExpand: "Unique advisor limit reached message",
+      },
+      {
+        name: "error",
+        result: {
+          type: "error",
+          message: "Unique advisor failure message",
+        },
+        textAfterExpand: "Unique advisor failure message",
+      },
+      {
+        name: "unrecognized",
+        result: {
+          type: "unexpected",
+          message: "unexpected raw payload",
+        },
+        textAfterExpand: "Unrecognized advisor tool output shape",
+        // Expanding unrecognized output renders JsonHighlight, which needs ThemeProvider;
+        // this case only needs to prove terminal-result rows stay collapsed by default.
+        verifyExpandedDetails: false,
+      },
+    ];
+
+    for (const testCase of cases) {
+      const view = renderAdvisorToolCall({
+        status: "executing",
+        result: testCase.result,
+        toolCallId: `advisor-call-${testCase.name}`,
+      });
+
+      expect(view.queryByText(testCase.textAfterExpand)).toBeNull();
+
+      if (testCase.verifyExpandedDetails !== false) {
+        fireEvent.click(view.getByText("advisor"));
+
+        expect(view.getByText(testCase.textAfterExpand)).toBeTruthy();
+      }
+      view.unmount();
+    }
   });
 
   test("completed advice supersedes live advisor output", () => {

--- a/src/browser/features/Tools/AdvisorToolCall.tsx
+++ b/src/browser/features/Tools/AdvisorToolCall.tsx
@@ -213,23 +213,53 @@ const AdvisorMetadata: React.FC<{ advisorModel: string; reasoningLevel?: string 
   );
 };
 
-export const AdvisorToolCall: React.FC<AdvisorToolCallProps> = ({
-  args,
+export const AdvisorToolCall: React.FC<AdvisorToolCallProps> = (props) => {
+  const toolStatus = isToolStatus(props.status) ? props.status : "pending";
+  const question = getAdvisorQuestion(props.args);
+  const advisorResult = isAdvisorToolResult(props.result) ? props.result : null;
+  const hasUnrecognizedResult =
+    props.result !== undefined && props.result !== null && advisorResult === null;
+  const isExecutingWithoutResult =
+    toolStatus === "executing" && advisorResult === null && !hasUnrecognizedResult;
+
+  // Key change forces remount so expansion resets when the call settles.
+  return (
+    <AdvisorToolCallContent
+      key={isExecutingWithoutResult ? "executing" : "settled"}
+      {...props}
+      toolStatus={toolStatus}
+      question={question}
+      advisorResult={advisorResult}
+      hasUnrecognizedResult={hasUnrecognizedResult}
+      isExecutingWithoutResult={isExecutingWithoutResult}
+    />
+  );
+};
+
+interface AdvisorToolCallContentProps extends AdvisorToolCallProps {
+  toolStatus: ToolStatus;
+  question: string | undefined;
+  advisorResult: AdvisorToolResult | null;
+  hasUnrecognizedResult: boolean;
+  isExecutingWithoutResult: boolean;
+}
+
+const AdvisorToolCallContent: React.FC<AdvisorToolCallContentProps> = ({
   result,
-  status,
   workspaceId,
   toolCallId,
   startedAt,
+  toolStatus,
+  question,
+  advisorResult,
+  hasUnrecognizedResult,
+  isExecutingWithoutResult,
 }) => {
-  const { expanded, toggleExpanded } = useToolExpansion();
-  const toolStatus = isToolStatus(status) ? status : "pending";
+  // Streamed chunks need expansion to be visible.
+  // Remount on settle so completed rows keep their collapsed default.
+  const { expanded, toggleExpanded } = useToolExpansion(isExecutingWithoutResult);
   const livePhase = useAdvisorToolLivePhase(workspaceId, toolCallId);
   const liveOutput = useAdvisorToolLiveOutput(workspaceId, toolCallId);
-  const question = getAdvisorQuestion(args);
-  const advisorResult = isAdvisorToolResult(result) ? result : null;
-  const hasUnrecognizedResult = result !== undefined && result !== null && advisorResult === null;
-  const isExecutingWithoutResult =
-    toolStatus === "executing" && advisorResult === null && !hasUnrecognizedResult;
   const liveAdviceText = isExecutingWithoutResult && liveOutput?.text ? liveOutput.text : undefined;
   const detailsText =
     advisorResult?.type === "advice"


### PR DESCRIPTION
Summary
- Auto-expand advisor tool calls while they are executing so streamed advisor chunks are visible without an extra click.

Background
- Advisor output already streams live into the tool details pane, but the advisor row defaulted to collapsed, making the live chunks easy to miss until the final result arrived.

Implementation
- Initialize advisor tool expansion from the executing/no-result state.
- Keep completed, failed, limited, and unrecognized advisor results on the existing manual expansion behavior.
- Update AdvisorToolCall tests to cover the auto-expanded streaming state.

Validation
- `bun test src/browser/features/Tools/AdvisorToolCall.test.tsx`
- `make typecheck`
- `make fmt-check`
- `make static-check`

Risks
- Low: this changes only the default expansion state for in-flight advisor calls; manual collapse still works, and completed rows retain the prior behavior.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$6.76`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=6.76 -->
