### PR TITLE
🤖 feat: add full-width chat transcript setting

### DIFF
--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -73,6 +73,7 @@ import { useProvidersConfig } from "@/browser/hooks/useProvidersConfig";
 import { useSendMessageOptions } from "@/browser/hooks/useSendMessageOptions";
 import type { TerminalSessionCreateOptions } from "@/browser/utils/terminal";
 import { useAPI } from "@/browser/contexts/API";
+import { useChatTranscriptFullWidth } from "@/browser/hooks/useChatTranscriptFullWidth";
 import { useReviews } from "@/browser/hooks/useReviews";
 import { ReviewsBanner } from "../ReviewsBanner/ReviewsBanner";
 import type { ReviewNoteData } from "@/common/types/review";
@@ -187,6 +188,7 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
     workspaceState,
     immersiveHidden = false,
   } = props;
+  const chatTranscriptFullWidth = useChatTranscriptFullWidth();
   const { api } = useAPI();
   const { workspaceMetadata } = useWorkspaceContext();
   const chatAreaRef = useRef<HTMLDivElement>(null);
@@ -1044,7 +1046,7 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
             >
               <div
                 className={cn(
-                  "max-w-4xl mx-auto",
+                  chatTranscriptFullWidth ? "w-full" : "max-w-4xl mx-auto",
                   (showTranscriptHydrationPlaceholder || showEmptyTranscriptPlaceholder) && "h-full"
                 )}
               >

--- a/src/browser/components/SshPromptDialog/SshPromptDialog.test.tsx
+++ b/src/browser/components/SshPromptDialog/SshPromptDialog.test.tsx
@@ -3,6 +3,10 @@ import "../../../../tests/ui/dom";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import type { SshPromptEvent, SshPromptRequest } from "@/common/orpc/schemas/ssh";
+import {
+  createControllableAsyncIterable,
+  type ControllableAsyncIterable,
+} from "@/browser/testUtils";
 import type { ReactNode } from "react";
 import { installDom } from "../../../../tests/ui/dom";
 
@@ -25,79 +29,15 @@ void mock.module("@/browser/components/Dialog/Dialog", () => ({
 
 import { SshPromptDialog } from "../SshPromptDialog/SshPromptDialog";
 
-interface ControlledSubscription<T> {
-  iterable: AsyncIterable<T>;
-  push: (value: T) => void;
-  close: () => void;
+interface ControlledSubscription<T> extends ControllableAsyncIterable<T> {
   returnSpy: ReturnType<typeof mock>;
 }
 
 function createMockIterableSubscription<T>(): ControlledSubscription<T> {
-  const buffered: T[] = [];
-  const pending: Array<(result: IteratorResult<T>) => void> = [];
-  let closed = false;
-
-  const doneResult = (): IteratorResult<T> => ({
-    value: undefined as unknown as T,
-    done: true,
-  });
-
-  const flushDone = () => {
-    while (pending.length > 0) {
-      const resolve = pending.shift();
-      resolve?.(doneResult());
-    }
-  };
-
-  const returnSpy = mock((_value?: unknown) => {
-    closed = true;
-    flushDone();
-    return Promise.resolve(doneResult());
-  });
-
-  const iterator: AsyncIterator<T> = {
-    next() {
-      if (closed) {
-        return Promise.resolve(doneResult());
-      }
-
-      if (buffered.length > 0) {
-        return Promise.resolve({ value: buffered.shift()!, done: false });
-      }
-
-      return new Promise((resolve) => {
-        pending.push(resolve);
-      });
-    },
-    return: returnSpy,
-  };
-
+  const returnSpy = mock(() => undefined);
   return {
-    iterable: {
-      [Symbol.asyncIterator]: () => iterator,
-    },
+    ...createControllableAsyncIterable<T>({ onReturn: returnSpy }),
     returnSpy,
-    push(value: T) {
-      if (closed) {
-        return;
-      }
-
-      const resolve = pending.shift();
-      if (resolve) {
-        resolve({ value, done: false });
-        return;
-      }
-
-      buffered.push(value);
-    },
-    close() {
-      if (closed) {
-        return;
-      }
-
-      closed = true;
-      flushDone();
-    },
   };
 }
 

--- a/src/browser/features/Settings/Sections/GeneralSection.test.tsx
+++ b/src/browser/features/Settings/Sections/GeneralSection.test.tsx
@@ -17,6 +17,7 @@ import {
 interface MockConfig {
   coderWorkspaceArchiveBehavior: CoderWorkspaceArchiveBehavior;
   worktreeArchiveBehavior: WorktreeArchiveBehavior;
+  chatTranscriptFullWidth: boolean;
   llmDebugLogs: boolean;
 }
 
@@ -27,6 +28,7 @@ interface MockAPIClient {
       coderWorkspaceArchiveBehavior: CoderWorkspaceArchiveBehavior;
       worktreeArchiveBehavior: WorktreeArchiveBehavior;
     }) => Promise<void>;
+    updateChatTranscriptFullWidth: (input: { enabled: boolean }) => Promise<void>;
     updateLlmDebugLogs: (input: { enabled: boolean }) => Promise<void>;
   };
   server: {
@@ -168,6 +170,7 @@ import { GeneralSection } from "./GeneralSection";
 interface RenderGeneralSectionOptions {
   coderWorkspaceArchiveBehavior?: CoderWorkspaceArchiveBehavior;
   worktreeArchiveBehavior?: WorktreeArchiveBehavior;
+  chatTranscriptFullWidth?: boolean;
 }
 
 interface MockAPISetup {
@@ -181,12 +184,16 @@ interface MockAPISetup {
       }) => Promise<void>
     >
   >;
+  updateChatTranscriptFullWidthMock: ReturnType<
+    typeof mock<(input: { enabled: boolean }) => Promise<void>>
+  >;
 }
 
 function createMockAPI(configOverrides: Partial<MockConfig> = {}): MockAPISetup {
   const config: MockConfig = {
     coderWorkspaceArchiveBehavior: DEFAULT_CODER_ARCHIVE_BEHAVIOR,
     worktreeArchiveBehavior: DEFAULT_WORKTREE_ARCHIVE_BEHAVIOR,
+    chatTranscriptFullWidth: false,
     llmDebugLogs: false,
     ...configOverrides,
   };
@@ -204,11 +211,18 @@ function createMockAPI(configOverrides: Partial<MockConfig> = {}): MockAPISetup 
     }
   );
 
+  const updateChatTranscriptFullWidthMock = mock(({ enabled }: { enabled: boolean }) => {
+    config.chatTranscriptFullWidth = enabled;
+
+    return Promise.resolve();
+  });
+
   return {
     api: {
       config: {
         getConfig: getConfigMock,
         updateCoderPrefs: updateCoderPrefsMock,
+        updateChatTranscriptFullWidth: updateChatTranscriptFullWidthMock,
         updateLlmDebugLogs: mock(({ enabled }: { enabled: boolean }) => {
           config.llmDebugLogs = enabled;
 
@@ -226,6 +240,7 @@ function createMockAPI(configOverrides: Partial<MockConfig> = {}): MockAPISetup 
     },
     getConfigMock,
     updateCoderPrefsMock,
+    updateChatTranscriptFullWidthMock,
   };
 }
 
@@ -248,7 +263,8 @@ describe("GeneralSection", () => {
   });
 
   function renderGeneralSection(options: RenderGeneralSectionOptions = {}) {
-    const { api, updateCoderPrefsMock } = createMockAPI({
+    const { api, updateCoderPrefsMock, updateChatTranscriptFullWidthMock } = createMockAPI({
+      chatTranscriptFullWidth: options.chatTranscriptFullWidth,
       coderWorkspaceArchiveBehavior: options.coderWorkspaceArchiveBehavior,
       worktreeArchiveBehavior: options.worktreeArchiveBehavior,
     });
@@ -260,7 +276,7 @@ describe("GeneralSection", () => {
       </ThemeProvider>
     );
 
-    return { updateCoderPrefsMock, view };
+    return { updateCoderPrefsMock, updateChatTranscriptFullWidthMock, view };
   }
 
   function getSelectTrigger(view: ReturnType<typeof render>, label: string): HTMLElement {
@@ -317,6 +333,24 @@ describe("GeneralSection", () => {
     expect(window.localStorage.getItem(BASH_COLLAPSED_SUMMARY_MODE_KEY)).toBe(
       JSON.stringify("intent")
     );
+  });
+
+  test("loads and persists the full-width chat transcript toggle", async () => {
+    const { updateChatTranscriptFullWidthMock, view } = renderGeneralSection({
+      chatTranscriptFullWidth: true,
+    });
+
+    const toggle = view.getByRole("switch", { name: "Toggle full-width chat transcript" });
+    await waitFor(() => {
+      expect(toggle.getAttribute("aria-checked")).toBe("true");
+    });
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(toggle.getAttribute("aria-checked")).toBe("false");
+      expect(updateChatTranscriptFullWidthMock).toHaveBeenCalledWith({ enabled: false });
+    });
   });
 
   test("renders the worktree archive behavior copy and loads the saved value", async () => {

--- a/src/browser/features/Settings/Sections/GeneralSection.tsx
+++ b/src/browser/features/Settings/Sections/GeneralSection.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/browser/components/SelectPrimitive/SelectPrimitive";
 import { Input } from "@/browser/components/Input/Input";
 import { Switch } from "@/browser/components/Switch/Switch";
-import { usePersistedState } from "@/browser/hooks/usePersistedState";
+import { updatePersistedState, usePersistedState } from "@/browser/hooks/usePersistedState";
 import { useAPI } from "@/browser/contexts/API";
 import { CUSTOM_EVENTS, createCustomEvent } from "@/common/constants/events";
 import {
@@ -20,6 +20,7 @@ import {
   LAUNCH_BEHAVIOR_KEY,
   BASH_COLLAPSED_SUMMARY_MODE_KEY,
   BASH_COLLAPSED_SUMMARY_MODES,
+  CHAT_TRANSCRIPT_FULL_WIDTH_KEY,
   DEFAULT_BASH_COLLAPSED_SUMMARY_MODE,
   normalizeBashCollapsedSummaryMode,
   type BashCollapsedSummaryMode,
@@ -224,6 +225,7 @@ export function GeneralSection() {
     DEFAULT_WORKTREE_ARCHIVE_BEHAVIOR
   );
   const [archiveSettingsLoaded, setArchiveSettingsLoaded] = useState(false);
+  const [chatTranscriptFullWidth, setChatTranscriptFullWidth] = useState(false);
   const [llmDebugLogs, setLlmDebugLogs] = useState(false);
   const archiveBehaviorLoadNonceRef = useRef(0);
   const archiveBehaviorRef = useRef<CoderWorkspaceArchiveBehavior>(DEFAULT_CODER_ARCHIVE_BEHAVIOR);
@@ -231,11 +233,13 @@ export function GeneralSection() {
     DEFAULT_WORKTREE_ARCHIVE_BEHAVIOR
   );
 
+  const chatTranscriptFullWidthLoadNonceRef = useRef(0);
   const llmDebugLogsLoadNonceRef = useRef(0);
 
   // updateCoderPrefs writes config.json on the backend. Serialize (and coalesce) updates so rapid
   // selections can't race and persist a stale value via out-of-order writes.
   const archiveBehaviorUpdateChainRef = useRef<Promise<void>>(Promise.resolve());
+  const chatTranscriptFullWidthUpdateChainRef = useRef<Promise<void>>(Promise.resolve());
   const llmDebugLogsUpdateChainRef = useRef<Promise<void>>(Promise.resolve());
   const archiveBehaviorPendingUpdateRef = useRef<CoderWorkspaceArchiveBehavior | undefined>(
     undefined
@@ -251,6 +255,7 @@ export function GeneralSection() {
 
     setArchiveSettingsLoaded(false);
     const archiveBehaviorNonce = ++archiveBehaviorLoadNonceRef.current;
+    const chatTranscriptFullWidthNonce = ++chatTranscriptFullWidthLoadNonceRef.current;
     const llmDebugLogsNonce = ++llmDebugLogsLoadNonceRef.current;
 
     void api.config
@@ -274,7 +279,16 @@ export function GeneralSection() {
           setArchiveSettingsLoaded(true);
         }
 
-        // Use an independent nonce so debug-log toggles do not discard archive-setting updates.
+        // Use independent nonces so appearance/debug toggles do not discard archive updates.
+        if (chatTranscriptFullWidthNonce === chatTranscriptFullWidthLoadNonceRef.current) {
+          const enabled = cfg.chatTranscriptFullWidth === true;
+          setChatTranscriptFullWidth(enabled);
+          updatePersistedState<boolean | undefined>(
+            CHAT_TRANSCRIPT_FULL_WIDTH_KEY,
+            enabled ? true : undefined
+          );
+        }
+
         if (llmDebugLogsNonce === llmDebugLogsLoadNonceRef.current) {
           setLlmDebugLogs(cfg.llmDebugLogs === true);
         }
@@ -360,6 +374,29 @@ export function GeneralSection() {
     },
     [api, archiveSettingsLoaded, queueArchiveBehaviorUpdate]
   );
+
+  const handleChatTranscriptFullWidthChange = (checked: boolean) => {
+    // Invalidate any in-flight config load so it does not overwrite the user's selection.
+    chatTranscriptFullWidthLoadNonceRef.current++;
+    setChatTranscriptFullWidth(checked);
+    updatePersistedState<boolean | undefined>(
+      CHAT_TRANSCRIPT_FULL_WIDTH_KEY,
+      checked ? true : undefined
+    );
+
+    if (!api?.config?.updateChatTranscriptFullWidth) {
+      return;
+    }
+
+    chatTranscriptFullWidthUpdateChainRef.current = chatTranscriptFullWidthUpdateChainRef.current
+      .catch(() => {
+        // Best-effort only.
+      })
+      .then(() => api.config.updateChatTranscriptFullWidth({ enabled: checked }))
+      .catch(() => {
+        // Best-effort persistence.
+      });
+  };
 
   const handleLlmDebugLogsChange = (checked: boolean) => {
     // Invalidate any in-flight debug-log load so it doesn't overwrite the user's selection.
@@ -519,6 +556,20 @@ export function GeneralSection() {
                 ))}
               </SelectContent>
             </Select>
+          </div>
+
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex-1">
+              <div className="text-foreground text-sm">Full-width chat transcript</div>
+              <div className="text-muted text-xs">
+                Let messages use the full chat pane instead of the default readable column.
+              </div>
+            </div>
+            <Switch
+              checked={chatTranscriptFullWidth}
+              onCheckedChange={handleChatTranscriptFullWidthChange}
+              aria-label="Toggle full-width chat transcript"
+            />
           </div>
 
           <div className="flex items-center justify-between gap-4">

--- a/src/browser/features/Tools/BashToolCall.tsx
+++ b/src/browser/features/Tools/BashToolCall.tsx
@@ -161,14 +161,10 @@ export const BashToolCall: React.FC<BashToolCallProps> = ({
         <ExpandIcon expanded={expanded}>▶</ExpandIcon>
         <ToolIcon toolName="bash" />
         {bashCollapsedSummary.kind === "intent-command" ? (
-          // Two lines: intent (primary) on top, command (muted mono) below.
-          // The duration chip sits on the command row so it inherits the same
-          // line-height and stays vertically centered on the command, not
-          // floating between the two lines.
-          <span className="flex max-w-[28rem] min-w-0 flex-col leading-tight">
+          <span className="flex min-w-0 flex-1 flex-col leading-tight">
             <span className="text-text truncate">{bashCollapsedSummary.intent}</span>
             <span className="flex min-w-0 items-center gap-2">
-              <span className="text-muted font-monospace min-w-0 truncate text-[10px]">
+              <span className="text-muted font-monospace min-w-0 flex-1 truncate text-[10px]">
                 {bashCollapsedSummary.command}
               </span>
               {!isBackground && (

--- a/src/browser/hooks/useChatTranscriptFullWidth.test.tsx
+++ b/src/browser/hooks/useChatTranscriptFullWidth.test.tsx
@@ -128,6 +128,82 @@ describe("useChatTranscriptFullWidth", () => {
     expect(result.current).toBe(true);
   });
 
+  test("accepts a newer backend refresh after a backend-driven cache update", async () => {
+    const firstFetch = Promise.withResolvers<TranscriptWidthConfig>();
+    const secondFetch = Promise.withResolvers<TranscriptWidthConfig>();
+    const stream = createConfigEventStream();
+    const getConfigMock = mock(() => {
+      if (getConfigMock.mock.calls.length === 1) {
+        return firstFetch.promise;
+      }
+
+      return secondFetch.promise;
+    });
+    const client = {
+      config: {
+        getConfig: getConfigMock,
+        onConfigChanged: mock(() => Promise.resolve(stream.iterator)),
+      },
+    } as unknown as APIClient;
+
+    const { result } = renderHook(() => useChatTranscriptFullWidth(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => {
+      expect(getConfigMock).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      firstFetch.resolve({ chatTranscriptFullWidth: true });
+      await firstFetch.promise;
+      stream.emit();
+    });
+    await waitFor(() => {
+      expect(getConfigMock).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      secondFetch.resolve({ chatTranscriptFullWidth: false });
+      await secondFetch.promise;
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+  });
+
+  test("keeps a local persisted update when an older backend fetch resolves", async () => {
+    const fetch = Promise.withResolvers<TranscriptWidthConfig>();
+    const client = {
+      config: {
+        getConfig: mock(() => fetch.promise),
+        onConfigChanged: mock(() => Promise.resolve(createConfigEventStream().iterator)),
+      },
+    } as unknown as APIClient;
+
+    const { result } = renderHook(() => useChatTranscriptFullWidth(), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(result.current).toBe(false);
+
+    act(() => {
+      updatePersistedState<boolean>(CHAT_TRANSCRIPT_FULL_WIDTH_KEY, true);
+    });
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+
+    await act(async () => {
+      fetch.resolve({ chatTranscriptFullWidth: false });
+      await fetch.promise;
+    });
+
+    expect(result.current).toBe(true);
+    expect(window.localStorage.getItem(CHAT_TRANSCRIPT_FULL_WIDTH_KEY)).toBe(JSON.stringify(true));
+  });
+
   test("ignores invalid cached preference values", () => {
     updatePersistedState<string>(CHAT_TRANSCRIPT_FULL_WIDTH_KEY, "false");
     const getConfig = Promise.withResolvers<TranscriptWidthConfig>();

--- a/src/browser/hooks/useChatTranscriptFullWidth.test.tsx
+++ b/src/browser/hooks/useChatTranscriptFullWidth.test.tsx
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { GlobalWindow } from "happy-dom";
+import type React from "react";
+
+import { APIProvider, type APIClient } from "@/browser/contexts/API";
+import { createControllableAsyncIterable } from "@/browser/testUtils";
+import { updatePersistedState } from "@/browser/hooks/usePersistedState";
+import { CHAT_TRANSCRIPT_FULL_WIDTH_KEY } from "@/common/constants/storage";
+
+import { useChatTranscriptFullWidth } from "./useChatTranscriptFullWidth";
+
+interface TranscriptWidthConfig {
+  chatTranscriptFullWidth: boolean;
+}
+
+function createConfigEventStream() {
+  const returnMock = mock(() => undefined);
+  const stream = createControllableAsyncIterable<unknown>({ onReturn: returnMock });
+
+  return {
+    emit(value: unknown = Symbol("config-change")) {
+      stream.push(value);
+    },
+    iterator: stream.iterable,
+    returnMock,
+  };
+}
+
+function createWrapper(client: APIClient): React.FC<{ children: React.ReactNode }> {
+  return function Wrapper(props) {
+    return <APIProvider client={client}>{props.children}</APIProvider>;
+  };
+}
+
+describe("useChatTranscriptFullWidth", () => {
+  beforeEach(() => {
+    globalThis.window = new GlobalWindow({ url: "https://mux.example.com/" }) as unknown as Window &
+      typeof globalThis;
+    globalThis.document = globalThis.window.document;
+  });
+
+  afterEach(() => {
+    cleanup();
+    updatePersistedState<boolean | undefined>(CHAT_TRANSCRIPT_FULL_WIDTH_KEY, undefined);
+  });
+
+  test("uses the cached preference until backend config resolves", async () => {
+    updatePersistedState<boolean>(CHAT_TRANSCRIPT_FULL_WIDTH_KEY, true);
+    const stream = createConfigEventStream();
+    const getConfigMock = mock(() =>
+      Promise.resolve<TranscriptWidthConfig>({ chatTranscriptFullWidth: true })
+    );
+    const onConfigChangedMock = mock(() => Promise.resolve(stream.iterator));
+    const client = {
+      config: {
+        getConfig: getConfigMock,
+        onConfigChanged: onConfigChangedMock,
+      },
+    } as unknown as APIClient;
+
+    const { result, unmount } = renderHook(() => useChatTranscriptFullWidth(), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(result.current).toBe(true);
+    await waitFor(() => {
+      expect(getConfigMock).toHaveBeenCalledTimes(1);
+      expect(onConfigChangedMock).toHaveBeenCalledTimes(1);
+    });
+
+    unmount();
+
+    await waitFor(() => {
+      expect(stream.returnMock).toHaveBeenCalled();
+    });
+  });
+
+  test("ignores stale config fetches after a newer subscription refresh", async () => {
+    const firstFetch = Promise.withResolvers<TranscriptWidthConfig>();
+    const secondFetch = Promise.withResolvers<TranscriptWidthConfig>();
+    const stream = createConfigEventStream();
+    const getConfigMock = mock(() => {
+      if (getConfigMock.mock.calls.length === 1) {
+        return firstFetch.promise;
+      }
+
+      return secondFetch.promise;
+    });
+    const client = {
+      config: {
+        getConfig: getConfigMock,
+        onConfigChanged: mock(() => Promise.resolve(stream.iterator)),
+      },
+    } as unknown as APIClient;
+
+    const { result } = renderHook(() => useChatTranscriptFullWidth(), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(result.current).toBe(false);
+    await waitFor(() => {
+      expect(getConfigMock).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      stream.emit();
+    });
+    await waitFor(() => {
+      expect(getConfigMock).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      secondFetch.resolve({ chatTranscriptFullWidth: true });
+      await secondFetch.promise;
+    });
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+
+    await act(async () => {
+      firstFetch.resolve({ chatTranscriptFullWidth: false });
+      await firstFetch.promise;
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  test("ignores invalid cached preference values", () => {
+    updatePersistedState<string>(CHAT_TRANSCRIPT_FULL_WIDTH_KEY, "false");
+    const getConfig = Promise.withResolvers<TranscriptWidthConfig>();
+    const client = {
+      config: {
+        getConfig: mock(() => getConfig.promise),
+        onConfigChanged: mock(() => Promise.resolve(createConfigEventStream().iterator)),
+      },
+    } as unknown as APIClient;
+
+    const { result } = renderHook(() => useChatTranscriptFullWidth(), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  test("responds to persisted preference updates while mounted", async () => {
+    const getConfig = Promise.withResolvers<TranscriptWidthConfig>();
+    const client = {
+      config: {
+        getConfig: mock(() => getConfig.promise),
+        onConfigChanged: mock(() => Promise.resolve(createConfigEventStream().iterator)),
+      },
+    } as unknown as APIClient;
+
+    const { result } = renderHook(() => useChatTranscriptFullWidth(), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(result.current).toBe(false);
+
+    act(() => {
+      updatePersistedState<boolean>(CHAT_TRANSCRIPT_FULL_WIDTH_KEY, true);
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+  });
+
+  test("caches backend config for the next mount", async () => {
+    const firstFetch = Promise.withResolvers<TranscriptWidthConfig>();
+    const secondFetch = Promise.withResolvers<TranscriptWidthConfig>();
+    const getConfigMock = mock(() => {
+      if (getConfigMock.mock.calls.length === 1) {
+        return firstFetch.promise;
+      }
+
+      return secondFetch.promise;
+    });
+    const client = {
+      config: {
+        getConfig: getConfigMock,
+        onConfigChanged: mock(() => Promise.resolve(createConfigEventStream().iterator)),
+      },
+    } as unknown as APIClient;
+
+    const firstRender = renderHook(() => useChatTranscriptFullWidth(), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(firstRender.result.current).toBe(false);
+    await act(async () => {
+      firstFetch.resolve({ chatTranscriptFullWidth: true });
+      await firstFetch.promise;
+    });
+    await waitFor(() => {
+      expect(firstRender.result.current).toBe(true);
+    });
+
+    firstRender.unmount();
+
+    const secondRender = renderHook(() => useChatTranscriptFullWidth(), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(secondRender.result.current).toBe(true);
+  });
+
+  test("preserves the last known value while API config is unavailable", () => {
+    updatePersistedState<boolean>(CHAT_TRANSCRIPT_FULL_WIDTH_KEY, true);
+    const client = { config: {} } as unknown as APIClient;
+
+    const { result } = renderHook(() => useChatTranscriptFullWidth(), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/src/browser/hooks/useChatTranscriptFullWidth.test.tsx
+++ b/src/browser/hooks/useChatTranscriptFullWidth.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
-import { GlobalWindow } from "happy-dom";
 import type React from "react";
+import { installDom } from "../../../tests/ui/dom";
 
 import { APIProvider, type APIClient } from "@/browser/contexts/API";
 import { createControllableAsyncIterable } from "@/browser/testUtils";
@@ -34,15 +34,17 @@ function createWrapper(client: APIClient): React.FC<{ children: React.ReactNode 
 }
 
 describe("useChatTranscriptFullWidth", () => {
+  let cleanupDom: (() => void) | null = null;
+
   beforeEach(() => {
-    globalThis.window = new GlobalWindow({ url: "https://mux.example.com/" }) as unknown as Window &
-      typeof globalThis;
-    globalThis.document = globalThis.window.document;
+    cleanupDom = installDom();
   });
 
   afterEach(() => {
     cleanup();
     updatePersistedState<boolean | undefined>(CHAT_TRANSCRIPT_FULL_WIDTH_KEY, undefined);
+    cleanupDom?.();
+    cleanupDom = null;
   });
 
   test("uses the cached preference until backend config resolves", async () => {

--- a/src/browser/hooks/useChatTranscriptFullWidth.ts
+++ b/src/browser/hooks/useChatTranscriptFullWidth.ts
@@ -15,8 +15,20 @@ export function useChatTranscriptFullWidth(): boolean {
   );
   const chatTranscriptFullWidth = rawChatTranscriptFullWidth === true;
   const chatTranscriptFullWidthRef = useRef(chatTranscriptFullWidth);
+  const persistedValueRef = useRef(chatTranscriptFullWidth);
+  const backendPersistedValueRef = useRef<boolean | undefined>(undefined);
 
   useEffect(() => {
+    if (persistedValueRef.current !== chatTranscriptFullWidth) {
+      persistedValueRef.current = chatTranscriptFullWidth;
+      const backendPersistedValue = backendPersistedValueRef.current;
+      backendPersistedValueRef.current = undefined;
+      if (backendPersistedValue !== chatTranscriptFullWidth) {
+        // Settings writes update persisted state first, so old backend reads must not overwrite them.
+        fetchVersionRef.current++;
+      }
+    }
+
     chatTranscriptFullWidthRef.current = chatTranscriptFullWidth;
   }, [chatTranscriptFullWidth]);
 
@@ -36,6 +48,7 @@ export function useChatTranscriptFullWidth(): boolean {
       }
 
       chatTranscriptFullWidthRef.current = enabled;
+      backendPersistedValueRef.current = enabled;
       updatePersistedState<boolean | undefined>(
         CHAT_TRANSCRIPT_FULL_WIDTH_KEY,
         enabled ? true : undefined

--- a/src/browser/hooks/useChatTranscriptFullWidth.ts
+++ b/src/browser/hooks/useChatTranscriptFullWidth.ts
@@ -1,0 +1,92 @@
+import { useEffect, useRef } from "react";
+
+import { useAPI } from "@/browser/contexts/API";
+import { updatePersistedState, usePersistedState } from "@/browser/hooks/usePersistedState";
+import { CHAT_TRANSCRIPT_FULL_WIDTH_KEY } from "@/common/constants/storage";
+
+/** Seeded from local cache to avoid a layout flash before the backend responds. */
+export function useChatTranscriptFullWidth(): boolean {
+  const { api } = useAPI();
+  const fetchVersionRef = useRef(0);
+  const [rawChatTranscriptFullWidth] = usePersistedState<unknown>(
+    CHAT_TRANSCRIPT_FULL_WIDTH_KEY,
+    false,
+    { listener: true }
+  );
+  const chatTranscriptFullWidth = rawChatTranscriptFullWidth === true;
+  const chatTranscriptFullWidthRef = useRef(chatTranscriptFullWidth);
+
+  useEffect(() => {
+    chatTranscriptFullWidthRef.current = chatTranscriptFullWidth;
+  }, [chatTranscriptFullWidth]);
+
+  useEffect(() => {
+    const getConfig = api?.config?.getConfig;
+    if (!getConfig) {
+      return;
+    }
+
+    const abortController = new AbortController();
+    const { signal } = abortController;
+    let iterator: AsyncIterator<unknown> | null = null;
+
+    const setSyncedValue = (enabled: boolean) => {
+      if (chatTranscriptFullWidthRef.current === enabled) {
+        return;
+      }
+
+      chatTranscriptFullWidthRef.current = enabled;
+      updatePersistedState<boolean | undefined>(
+        CHAT_TRANSCRIPT_FULL_WIDTH_KEY,
+        enabled ? true : undefined
+      );
+    };
+
+    const refresh = () => {
+      const fetchVersion = ++fetchVersionRef.current;
+      getConfig()
+        .then((config) => {
+          if (!signal.aborted && fetchVersion === fetchVersionRef.current) {
+            setSyncedValue(config.chatTranscriptFullWidth === true);
+          }
+        })
+        .catch(() => {
+          // Keep the current preference on failure.
+        });
+    };
+
+    refresh();
+
+    const onConfigChanged = api?.config?.onConfigChanged;
+    if (onConfigChanged) {
+      const runSubscription = async () => {
+        try {
+          const subscribedIterator = await onConfigChanged(undefined, { signal });
+          if (signal.aborted) {
+            void subscribedIterator.return?.();
+            return;
+          }
+
+          iterator = subscribedIterator;
+          for await (const _ of subscribedIterator) {
+            if (signal.aborted) {
+              break;
+            }
+            refresh();
+          }
+        } catch {
+          // Subscription errors are non-fatal.
+        }
+      };
+
+      void runSubscription();
+    }
+
+    return () => {
+      abortController.abort();
+      void iterator?.return?.();
+    };
+  }, [api]);
+
+  return chatTranscriptFullWidth;
+}

--- a/src/browser/stories/mocks/orpc.ts
+++ b/src/browser/stories/mocks/orpc.ts
@@ -132,6 +132,8 @@ export interface MockORPCClientOptions {
   coderWorkspaceArchiveBehavior?: CoderWorkspaceArchiveBehavior;
   /** What to do with mux-managed worktrees when archiving a chat. */
   worktreeArchiveBehavior?: WorktreeArchiveBehavior;
+  /** Initial full-width transcript toggle for config.getConfig */
+  chatTranscriptFullWidth?: boolean;
   /** Initial runtime enablement for config.getConfig */
   runtimeEnablement?: Record<string, boolean>;
   /** Initial default runtime for config.getConfig (global) */
@@ -369,6 +371,7 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
     agentAiDefaults: initialAgentAiDefaults,
     coderWorkspaceArchiveBehavior: initialCoderWorkspaceArchiveBehavior = "stop",
     worktreeArchiveBehavior: initialWorktreeArchiveBehavior = "keep",
+    chatTranscriptFullWidth: initialChatTranscriptFullWidth = false,
     runtimeEnablement: initialRuntimeEnablement,
     defaultRuntime: initialDefaultRuntime,
     onePasswordAccountName: initialOnePasswordAccountName = null,
@@ -501,6 +504,7 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
   let muxGatewayModels: string[] | undefined = undefined;
   let coderWorkspaceArchiveBehavior = initialCoderWorkspaceArchiveBehavior;
   let worktreeArchiveBehavior = initialWorktreeArchiveBehavior;
+  let chatTranscriptFullWidth = initialChatTranscriptFullWidth;
   let runtimeEnablement: Record<string, boolean> = initialRuntimeEnablement ?? {
     local: true,
     worktree: true,
@@ -710,6 +714,7 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
           heartbeatDefaultIntervalMs,
           imageGeneration,
           goalDefaults,
+          chatTranscriptFullWidth,
           muxGovernorEnrolled,
           llmDebugLogs: false,
         }),
@@ -778,6 +783,11 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
       }) => {
         routePriority = [...input.routePriority];
         routeOverrides = { ...(input.routeOverrides ?? {}) };
+        notifyConfigChanged();
+        return Promise.resolve(undefined);
+      },
+      updateChatTranscriptFullWidth: (input: { enabled: boolean }) => {
+        chatTranscriptFullWidth = input.enabled;
         notifyConfigChanged();
         return Promise.resolve(undefined);
       },

--- a/src/browser/testUtils.ts
+++ b/src/browser/testUtils.ts
@@ -25,3 +25,81 @@ export type RecursivePartial<T> = {
       ? RecursivePartial<T[P]>
       : T[P];
 };
+
+export interface ControllableAsyncIterable<T> {
+  iterable: AsyncIterableIterator<T>;
+  push(value: T): void;
+  close(): void;
+}
+
+export function createControllableAsyncIterable<T>(
+  options: {
+    onReturn?: () => void;
+  } = {}
+): ControllableAsyncIterable<T> {
+  const buffered: T[] = [];
+  const pending: Array<(result: IteratorResult<T>) => void> = [];
+  let closed = false;
+
+  const doneResult = (): IteratorResult<T> => ({
+    value: undefined as T,
+    done: true,
+  });
+
+  const flushDone = () => {
+    while (pending.length > 0) {
+      pending.shift()?.(doneResult());
+    }
+  };
+
+  const close = () => {
+    if (closed) {
+      return;
+    }
+
+    closed = true;
+    flushDone();
+  };
+
+  const iterable: AsyncIterableIterator<T> = {
+    [Symbol.asyncIterator]() {
+      return iterable;
+    },
+    next() {
+      if (closed) {
+        return Promise.resolve(doneResult());
+      }
+
+      if (buffered.length > 0) {
+        return Promise.resolve({ value: buffered.shift() as T, done: false });
+      }
+
+      return new Promise((resolve) => {
+        pending.push(resolve);
+      });
+    },
+    return() {
+      options.onReturn?.();
+      close();
+      return Promise.resolve(doneResult());
+    },
+  };
+
+  return {
+    iterable,
+    push(value: T) {
+      if (closed) {
+        return;
+      }
+
+      const resolve = pending.shift();
+      if (resolve) {
+        resolve({ value, done: false });
+        return;
+      }
+
+      buffered.push(value);
+    },
+    close,
+  };
+}

--- a/src/common/config/schemas/appConfigOnDisk.test.ts
+++ b/src/common/config/schemas/appConfigOnDisk.test.ts
@@ -15,6 +15,13 @@ describe("AppConfigOnDiskSchema", () => {
     expect(AppConfigOnDiskSchema.safeParse(valid).success).toBe(true);
   });
 
+  it("validates the full-width chat transcript flag", () => {
+    expect(AppConfigOnDiskSchema.safeParse({ chatTranscriptFullWidth: true }).success).toBe(true);
+    expect(AppConfigOnDiskSchema.safeParse({ chatTranscriptFullWidth: "true" }).success).toBe(
+      false
+    );
+  });
+
   it("validates taskSettings with limits", () => {
     const valid = {
       taskSettings: {

--- a/src/common/config/schemas/appConfigOnDisk.ts
+++ b/src/common/config/schemas/appConfigOnDisk.ts
@@ -90,6 +90,7 @@ export const AppConfigOnDiskSchema = z
     featureFlagOverrides: z.record(z.string(), FeatureFlagOverrideSchema).optional(),
     layoutPresets: z.unknown().optional(),
     taskSettings: TaskSettingsSchema.optional(),
+    chatTranscriptFullWidth: z.boolean().optional(),
     muxGatewayEnabled: z.boolean().optional(),
     llmDebugLogs: z.boolean().optional(),
     heartbeatDefaultPrompt: z.string().optional(),

--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -83,6 +83,11 @@ export const LAUNCH_BEHAVIOR_KEY = "launchBehavior";
 export type LaunchBehavior = "dashboard" | "new-chat" | "last-workspace";
 
 /**
+ * Synchronous mirror for the backend full-width transcript preference.
+ */
+export const CHAT_TRANSCRIPT_FULL_WIDTH_KEY = "chatTranscriptFullWidth";
+
+/**
  * Get the localStorage key for expanded projects in sidebar (global)
  * Format: "expandedProjects"
  */

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -1961,6 +1961,15 @@ const GoalDefaultsConfigSchema = z.object({
     .default(DEFAULT_GOAL_DEFAULTS.alwaysRequireExplicitBudget),
 });
 
+const booleanToggleRoute = {
+  input: z
+    .object({
+      enabled: z.boolean(),
+    })
+    .strict(),
+  output: z.void(),
+};
+
 export const config = {
   getConfig: {
     input: z.void(),
@@ -1987,6 +1996,7 @@ export const config = {
       // Mux Governor enrollment status (safe fields only - token never exposed)
       muxGovernorUrl: z.string().nullable(),
       muxGovernorEnrolled: z.boolean(),
+      chatTranscriptFullWidth: z.boolean(),
       llmDebugLogs: z.boolean(),
       heartbeatDefaultPrompt: z.string().optional(),
       heartbeatDefaultIntervalMs: z.number().optional(),
@@ -2072,14 +2082,8 @@ export const config = {
       .strict(),
     output: z.void(),
   },
-  updateLlmDebugLogs: {
-    input: z
-      .object({
-        enabled: z.boolean(),
-      })
-      .strict(),
-    output: z.void(),
-  },
+  updateChatTranscriptFullWidth: booleanToggleRoute,
+  updateLlmDebugLogs: booleanToggleRoute,
   updateHeartbeatDefaultPrompt: {
     input: z
       .object({

--- a/src/common/types/project.ts
+++ b/src/common/types/project.ts
@@ -81,6 +81,8 @@ export interface ProjectsConfig {
   taskSettings?: TaskSettings;
   /** UI layout presets + hotkeys (shared via ~/.mux/config.json). */
   layoutPresets?: LayoutPresetsConfig;
+  /** Let chat transcripts use the full chat pane width instead of the default readable column. */
+  chatTranscriptFullWidth?: boolean;
   /**
    * Mux Gateway routing preferences (shared via ~/.mux/config.json).
    * Mirrors browser localStorage so switching server ports doesn't reset the UI.

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -54,6 +54,47 @@ describe("Config", () => {
     });
   });
 
+  describe("chat transcript settings", () => {
+    it("persists the full-width transcript flag", async () => {
+      await config.editConfig((cfg) => {
+        cfg.chatTranscriptFullWidth = true;
+        return cfg;
+      });
+
+      const restartedConfig = new Config(tempDir);
+      expect(restartedConfig.loadConfigOrDefault().chatTranscriptFullWidth).toBe(true);
+
+      const raw = JSON.parse(fs.readFileSync(path.join(tempDir, "config.json"), "utf-8")) as {
+        chatTranscriptFullWidth?: unknown;
+      };
+      expect(raw.chatTranscriptFullWidth).toBe(true);
+    });
+
+    it("omits the full-width transcript flag when disabled", async () => {
+      await config.editConfig((cfg) => {
+        cfg.chatTranscriptFullWidth = false;
+        return cfg;
+      });
+
+      const raw = JSON.parse(fs.readFileSync(path.join(tempDir, "config.json"), "utf-8")) as {
+        chatTranscriptFullWidth?: unknown;
+      };
+      expect(raw.chatTranscriptFullWidth).toBeUndefined();
+    });
+
+    it("ignores invalid full-width transcript values on load", () => {
+      fs.writeFileSync(
+        path.join(tempDir, "config.json"),
+        JSON.stringify({
+          projects: [],
+          chatTranscriptFullWidth: "yes",
+        })
+      );
+
+      expect(config.loadConfigOrDefault().chatTranscriptFullWidth).toBeUndefined();
+    });
+  });
+
   describe("api server settings", () => {
     it("should persist apiServerBindHost, apiServerPort, and apiServerServeWebUi", async () => {
       await config.editConfig((cfg) => {

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -878,6 +878,7 @@ export class Config {
           viewedSplashScreens: parsed.viewedSplashScreens,
           layoutPresets,
           taskSettings,
+          chatTranscriptFullWidth: parseOptionalBoolean(parsed.chatTranscriptFullWidth),
           muxGatewayEnabled,
           llmDebugLogs: parseOptionalBoolean(parsed.llmDebugLogs),
           heartbeatDefaultPrompt: parseOptionalNonEmptyString(parsed.heartbeatDefaultPrompt),
@@ -952,6 +953,11 @@ export class Config {
       const muxGatewayEnabled = parseOptionalBoolean(config.muxGatewayEnabled);
       if (muxGatewayEnabled !== undefined) {
         data.muxGatewayEnabled = muxGatewayEnabled;
+      }
+
+      const chatTranscriptFullWidth = parseOptionalBoolean(config.chatTranscriptFullWidth);
+      if (chatTranscriptFullWidth === true) {
+        data.chatTranscriptFullWidth = true;
       }
 
       const llmDebugLogs = parseOptionalBoolean(config.llmDebugLogs);

--- a/src/node/orpc/router.test.ts
+++ b/src/node/orpc/router.test.ts
@@ -112,6 +112,22 @@ describe("router config.saveConfig", () => {
     expect(saved.subagentAiDefaults?.foo).toBeUndefined();
   });
 
+  test("persists the full-width chat transcript config flag", async () => {
+    const client = createRouterClient(router(), { context: createContext() });
+
+    expect((await client.config.getConfig()).chatTranscriptFullWidth).toBe(false);
+
+    await client.config.updateChatTranscriptFullWidth({ enabled: true });
+
+    expect((await client.config.getConfig()).chatTranscriptFullWidth).toBe(true);
+    expect(config.loadConfigOrDefault().chatTranscriptFullWidth).toBe(true);
+
+    await client.config.updateChatTranscriptFullWidth({ enabled: false });
+
+    expect((await client.config.getConfig()).chatTranscriptFullWidth).toBe(false);
+    expect(config.loadConfigOrDefault().chatTranscriptFullWidth).toBeUndefined();
+  });
+
   test("preserves optional task settings when a save omits them", async () => {
     await config.editConfig((current) => ({
       ...current,

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -698,6 +698,7 @@ export const router = (authToken?: string) => {
             // Mux Governor enrollment status (safe fields only - token never exposed)
             muxGovernorUrl,
             muxGovernorEnrolled,
+            chatTranscriptFullWidth: config.chatTranscriptFullWidth === true,
             llmDebugLogs: config.llmDebugLogs === true,
             heartbeatDefaultPrompt: config.heartbeatDefaultPrompt ?? undefined,
             heartbeatDefaultIntervalMs: config.heartbeatDefaultIntervalMs ?? undefined,
@@ -1108,6 +1109,19 @@ export const router = (authToken?: string) => {
 
           // Re-evaluate task queue in case more slots opened up
           await context.taskService.maybeStartQueuedTasks();
+        }),
+      updateChatTranscriptFullWidth: t
+        .input(schemas.config.updateChatTranscriptFullWidth.input)
+        .output(schemas.config.updateChatTranscriptFullWidth.output)
+        .handler(async ({ context, input }) => {
+          await context.config.editConfig((config) => {
+            if (input.enabled) {
+              config.chatTranscriptFullWidth = true;
+            } else {
+              delete config.chatTranscriptFullWidth;
+            }
+            return config;
+          });
         }),
       updateLlmDebugLogs: t
         .input(schemas.config.updateLlmDebugLogs.input)


### PR DESCRIPTION
> Mux is acting on Mike's behalf.

## Summary
Adds an appearance setting that lets users expand chat transcripts to the full chat pane width instead of the default readable column.

## Implementation
- Persists `chatTranscriptFullWidth` in app config only when enabled.
- Mirrors the last known backend value in persisted UI state so ChatPane avoids a narrow-width flash on mount or API reconnect.
- Exposes `config.updateChatTranscriptFullWidth` and returns the effective boolean from `config.getConfig`.
- Adds a settings toggle and a ChatPane hook that follows config changes.
- Lets collapsed bash intent summaries use extra horizontal room in wide transcript layouts while preserving the current intent-only summary mode setting.
- Updates Storybook ORPC mocks and config, router, settings, hook, and tool summary tests.

## Validation
- `bun test src/browser/hooks/useChatTranscriptFullWidth.test.tsx src/browser/features/Settings/Sections/GeneralSection.test.tsx src/browser/features/Tools/bashCollapsedSummary.test.ts src/browser/stores/GitStatusStore.test.ts src/common/config/schemas/appConfigOnDisk.test.ts src/node/config.test.ts src/node/orpc/router.test.ts`
- `MUX_ESLINT_CONCURRENCY=2 make static-check`
- `make test`
- Browser sandbox smoke test with screenshots for default width, enabled setting, and full-width transcript layout.

## Review notes
- The input remains at the default readable width because the setting intentionally scopes to the transcript reading area.
- Chromatic has expected UI baseline changes for the wider transcript layout and collapsed bash summary row.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$9.01`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=9.01 -->
