### PR TITLE
🤖 fix(goals): keep live goal costs in sync with Stats

### DIFF
--- a/src/node/services/agentSession.goalAutoPause.test.ts
+++ b/src/node/services/agentSession.goalAutoPause.test.ts
@@ -268,16 +268,40 @@ describe("AgentSession goal safety hooks", () => {
       objective: "Restore preview on error",
       budgetCents: 1_000,
     });
+    // Capture goal-related activity snapshots. `previewStreamAccounting`
+    // is transient and intentionally does NOT touch
+    // extensionMetadata.json or goal.json — the UI receives the preview
+    // through the activity stream instead, which we observe here.
+    const activitySnapshots: Array<{
+      goal?: { costCents?: number } | null;
+      transientGoalOnly?: boolean;
+    }> = [];
+    goalService.setOnActivityChange((_workspaceId, snapshot) => {
+      activitySnapshots.push(snapshot);
+    });
+    const failedStreamStartedAtMs = created.createdAtMs + 1;
     await goalService.previewStreamAccounting({
       workspaceId,
       costUsd: 1.25,
-      streamStartedAtMs: created.createdAtMs + 1,
+      streamStartedAtMs: failedStreamStartedAtMs,
     });
-    expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({
+    expect(activitySnapshots.at(-1)).toMatchObject({
+      transientGoalOnly: true,
       goal: { costCents: 125 },
+    });
+    // The durable record stays untouched by the preview.
+    expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({
+      goal: { costCents: 0, budgetCents: 1_000 },
     });
 
     aiService.streamMessage = mock(() => {
+      aiService.emit("stream-start", {
+        type: "stream-start",
+        workspaceId,
+        messageId: "assistant-stream-error",
+        model: SEND_OPTIONS.model,
+        startTime: failedStreamStartedAtMs,
+      });
       aiService.emit("error", {
         workspaceId,
         messageId: "assistant-stream-error",
@@ -297,9 +321,32 @@ describe("AgentSession goal safety hooks", () => {
     });
     await waitForCondition(() => eventTypes.includes("stream-error"), { timeoutMs: 1_000 });
 
+    // After the error, restoreGoalAccountingSnapshot re-emits the durable
+    // goal so any UI that displayed the preview reverts to canonical
+    // costs. We assert via both the persisted snapshot and the activity
+    // stream because the preview never persisted in the first place.
     expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({
       goal: { costCents: 0, budgetCents: 1_000 },
     });
+    expect(activitySnapshots.at(-1)?.goal).toMatchObject({ costCents: 0 });
+
+    expect(
+      await goalService.previewStreamAccounting({
+        workspaceId,
+        costUsd: 1.25,
+        streamStartedAtMs: failedStreamStartedAtMs,
+      })
+    ).toBeNull();
+
+    const budgetEditAfterFailure = await setGoalOk(goalService, {
+      workspaceId,
+      budgetCents: 2_000,
+    });
+    expect(budgetEditAfterFailure).toMatchObject({ costCents: 0, budgetCents: 2_000 });
+    expect(activitySnapshots.at(-1)).toMatchObject({
+      goal: { costCents: 0, budgetCents: 2_000 },
+    });
+    expect(activitySnapshots.at(-1)?.transientGoalOnly).toBeUndefined();
     session.dispose();
   });
 

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -4171,7 +4171,16 @@ export class AgentSession {
     }
 
     try {
-      await this.workspaceGoalService.getGoal(this.workspaceId);
+      // Terminal stream errors do not run final goal accounting, so any
+      // live cost preview from the failed stream must be discarded before
+      // re-emitting the durable goal snapshot. Pass the stream start time so
+      // any queued usage-delta preview from the same failed stream is ignored
+      // under the goal service's workspace lock instead of repopulating stale
+      // "budget used" after this restore.
+      await this.workspaceGoalService.restoreGoalAccountingSnapshot(
+        this.workspaceId,
+        this.activeStreamStartedAtMs ?? null
+      );
     } catch (error) {
       log.warn("Failed to restore goal accounting snapshot", {
         workspaceId: this.workspaceId,

--- a/src/node/services/workspaceGoalService.test.ts
+++ b/src/node/services/workspaceGoalService.test.ts
@@ -2146,6 +2146,13 @@ describe("WorkspaceGoalService", () => {
       objective: "Preview live cost",
       budgetCents: 1_000,
     });
+    // Capture activity events so we can assert that previews reach
+    // subscribers (the renderer's WorkspaceStore) via the transient
+    // activity emit. When a baseline activity snapshot exists,
+    // `previewStreamAccounting` does NOT write to extensionMetadata.json
+    // or goal.json. The durable record is updated only by
+    // `recordStreamAccounting` at stream end.
+    const activityUpdates = captureGoalActivity(service);
 
     const firstPreview = await service.previewStreamAccounting({
       workspaceId,
@@ -2160,8 +2167,16 @@ describe("WorkspaceGoalService", () => {
 
     expect(firstPreview).toMatchObject({ costCents: 50, budgetCents: 1_000 });
     expect(secondPreview).toMatchObject({ costCents: 125, budgetCents: 1_000 });
-    expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({
+    // Transient activity snapshots reflect the latest preview so the UI
+    // updates without waiting on a disk write round-trip.
+    expect(activityUpdates.at(-1)).toMatchObject({
+      transientGoalOnly: true,
       goal: { costCents: 125, budgetCents: 1_000 },
+    });
+    // Neither extensionMetadata.json nor goal.json should carry the
+    // preview cost — both stay at the durable pre-stream value.
+    expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({
+      goal: { costCents: 0, budgetCents: 1_000 },
     });
     expect(await service.getGoal(workspaceId)).toMatchObject({ costCents: 0, budgetCents: 1_000 });
 
@@ -2189,9 +2204,72 @@ describe("WorkspaceGoalService", () => {
       streamStartedAtMs: created.createdAtMs + 1,
     });
     expect(previewAfterFinal).toBeNull();
+    // Final accounting persists to both goal.json and extensionMetadata.
     expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({
       goal: { costCents: 125, budgetCents: 2_000 },
     });
+  });
+
+  test("previewStreamAccounting falls back when no activity snapshot exists", async () => {
+    const created = await setGoalOk(service, {
+      workspaceId,
+      objective: "Preview without metadata",
+      budgetCents: 1_000,
+    });
+    await extensionMetadata.deleteWorkspace(workspaceId);
+    const activityUpdates = captureGoalActivity(service);
+
+    const preview = await service.previewStreamAccounting({
+      workspaceId,
+      costUsd: 1.25,
+      streamStartedAtMs: created.createdAtMs + 1,
+    });
+
+    expect(preview).toMatchObject({ costCents: 125, budgetCents: 1_000 });
+    expect(activityUpdates.at(-1)).toMatchObject({
+      goal: { costCents: 125, budgetCents: 1_000 },
+    });
+    expect(activityUpdates.at(-1)?.transientGoalOnly).toBeUndefined();
+    expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({
+      goal: { costCents: 125, budgetCents: 1_000 },
+    });
+    expect(await service.getGoal(workspaceId)).toMatchObject({ costCents: 0, budgetCents: 1_000 });
+  });
+
+  test("budget edits preserve live preview activity while durable accounting stays pre-stream", async () => {
+    const created = await setGoalOk(service, {
+      workspaceId,
+      objective: "Budget edit keeps live used amount",
+      budgetCents: 1_000,
+    });
+    const activityUpdates = captureGoalActivity(service);
+
+    await service.previewStreamAccounting({
+      workspaceId,
+      costUsd: 1.25,
+      streamStartedAtMs: created.createdAtMs + 1,
+    });
+    const updated = await setGoalOk(service, { workspaceId, budgetCents: 2_000 });
+
+    expect(updated).toMatchObject({ costCents: 0, budgetCents: 2_000 });
+    // Updating only the limit writes the durable pre-stream accounting to
+    // goal.json, then emits a transient overlay so the Goals UI does not
+    // reset "used" from the live Stats cost back to $0.00 mid-stream.
+    expect(activityUpdates.at(-1)).toMatchObject({
+      transientGoalOnly: true,
+      goal: { costCents: 125, budgetCents: 2_000 },
+    });
+    expect(await extensionMetadata.getSnapshot(workspaceId)).toMatchObject({
+      goal: { costCents: 0, budgetCents: 2_000 },
+    });
+
+    const final = await service.recordStreamAccounting({
+      workspaceId,
+      costUsd: 1.25,
+      streamStartedAtMs: created.createdAtMs + 1,
+      streamOriginKind: "goal_continuation",
+    });
+    expect(final).toMatchObject({ costCents: 125, budgetCents: 2_000 });
   });
 
   test("previewStreamAccounting preserves queued replacement snapshots", async () => {

--- a/src/node/services/workspaceGoalService.ts
+++ b/src/node/services/workspaceGoalService.ts
@@ -345,6 +345,7 @@ export class WorkspaceGoalService {
   private readonly suppressKickoffContinuation: boolean;
   private readonly pendingGoalMutations = new Map<string, PendingGoalMutation>();
   private readonly pendingGoalSnapshots = new Map<string, GoalSnapshot>();
+  private readonly liveGoalPreviewSnapshots = new Map<string, GoalSnapshot>();
 
   private pendingContinuationCandidates = new Map<string, PendingGoalContinuationCandidate>();
   private continuationReRequestTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -382,6 +383,14 @@ export class WorkspaceGoalService {
       Number.isFinite(this.continuationCooldownMs) && this.continuationCooldownMs >= 0,
       "WorkspaceGoalService requires a non-negative continuation cooldown"
     );
+  }
+
+  async restoreGoalAccountingSnapshot(
+    workspaceId: string,
+    streamStartedAtMs: number | null = null
+  ): Promise<void> {
+    assert(workspaceId.trim().length > 0, "restoreGoalAccountingSnapshot requires workspaceId");
+    await this.restorePersistedGoalSnapshot(workspaceId, { streamStartedAtMs });
   }
 
   setOnActivityChange(
@@ -523,17 +532,49 @@ export class WorkspaceGoalService {
   private async pushTransientGoalSnapshot(
     workspaceId: string,
     snapshot: GoalSnapshot
-  ): Promise<void> {
+  ): Promise<boolean> {
     const activity = await this.extensionMetadata.getSnapshot(workspaceId);
-    if (activity) {
-      this.onActivityChange?.(workspaceId, {
-        ...activity,
-        goal: snapshot,
-        transientGoalOnly: true,
-      });
+    if (!activity) {
+      // No baseline activity snapshot to overlay the transient goal on
+      // (extensionMetadata has no entry for this workspace yet). Callers
+      // that must guarantee delivery — e.g. live cost previews — should
+      // observe this `false` return and fall back to `pushSnapshot`, which
+      // creates the entry and emits via the durable path. Pending-goal
+      // publication does not retry here because it only fires after a
+      // `setGoal` that already created the entry.
+      return false;
     }
+    this.onActivityChange?.(workspaceId, {
+      ...activity,
+      goal: snapshot,
+      transientGoalOnly: true,
+    });
+    return true;
   }
 
+  private async pushLiveGoalPreviewOverlay(
+    workspaceId: string,
+    durableGoal: GoalRecordV1
+  ): Promise<void> {
+    const livePreview = this.liveGoalPreviewSnapshots.get(workspaceId);
+    if (!livePreview || livePreview.goalId !== durableGoal.goalId) {
+      return;
+    }
+
+    const durableSnapshot = toGoalSnapshot(durableGoal);
+    if (livePreview.costCents <= durableSnapshot.costCents) {
+      return;
+    }
+
+    // Preserve live "budget used" while a user edits budget/turn limits mid-stream.
+    // The mutable edit must persist the durable pre-stream accounting to goal.json so
+    // final `recordStreamAccounting` can add the cumulative stream cost exactly once,
+    // but the Goals UI should keep showing the same live usage Stats already reports.
+    await this.pushTransientGoalSnapshot(workspaceId, {
+      ...durableSnapshot,
+      costCents: livePreview.costCents,
+    });
+  }
   private async publishPendingGoalSnapshot(workspaceId: string, goal: GoalRecordV1): Promise<void> {
     const snapshot = toPendingGoalSnapshot(goal);
     this.pendingGoalSnapshots.set(workspaceId, snapshot);
@@ -561,9 +602,16 @@ export class WorkspaceGoalService {
     return this.pushSnapshot(workspaceId, goal);
   }
 
-  private async restorePersistedGoalSnapshot(workspaceId: string): Promise<void> {
+  private async restorePersistedGoalSnapshot(
+    workspaceId: string,
+    options: { streamStartedAtMs?: number | null } = {}
+  ): Promise<void> {
     try {
       await this.fileLocks.withLock(workspaceId, async () => {
+        this.liveGoalPreviewSnapshots.delete(workspaceId);
+        if (options.streamStartedAtMs != null) {
+          this.recordedStreamStartedAtMsByWorkspace.set(workspaceId, options.streamStartedAtMs);
+        }
         const current = await this.readGoalFile(workspaceId);
         await this.pushSnapshot(workspaceId, current);
       });
@@ -789,6 +837,7 @@ export class WorkspaceGoalService {
     this.lastUserStopAtMsByWorkspace.set(workspaceId, stoppedAtMs);
     this.pendingContinuationCandidates.delete(workspaceId);
     this.pendingGoalSnapshots.delete(workspaceId);
+    this.liveGoalPreviewSnapshots.delete(workspaceId);
     // Drop queued goal mutations too. If a
     // user sets a goal mid-stream then stops the stream, the mutation would
     // otherwise stay queued and apply on the NEXT stream's stream-end via
@@ -1736,6 +1785,7 @@ export class WorkspaceGoalService {
         }
         await this.writeGoal(input.workspaceId, withEdits);
         await this.pushSnapshot(input.workspaceId, withEdits);
+        await this.pushLiveGoalPreviewOverlay(input.workspaceId, withEdits);
         this.emitBudgetChanged(current, withEdits, input);
         this.emitBudgetLimited(withEdits, previousStatus);
         this.emitStatusLifecycle(withEdits, previousStatus, input.initiator ?? "user");
@@ -1791,6 +1841,7 @@ export class WorkspaceGoalService {
           }
           await this.writeGoal(input.workspaceId, updated);
           await this.pushSnapshot(input.workspaceId, updated);
+          await this.pushLiveGoalPreviewOverlay(input.workspaceId, updated);
           this.emitBudgetChanged(current, updated, input);
           this.emitBudgetLimited(updated, previousStatus);
           this.emitStatusLifecycle(updated, previousStatus, input.initiator ?? "user");
@@ -1823,6 +1874,7 @@ export class WorkspaceGoalService {
           message: UNPRICED_TARGET_MODEL_GOAL_MESSAGE,
         });
       }
+      this.liveGoalPreviewSnapshots.delete(input.workspaceId);
       // Archive the outgoing goal to history before we overwrite goal.json.
       // The new goal gets a fresh `goalId` so the right-sidebar GoalTab needs
       // a record of the prior one in its completed-goals list (cleared/
@@ -2078,9 +2130,25 @@ export class WorkspaceGoalService {
   }
 
   /**
-   * Push a live cost preview to the activity snapshot without persisting to
-   * goal.json. The cost is the cumulative current-stream cost on top of the
-   * durable base; `recordStreamAccounting` performs final accounting at stream end.
+   * Push a live cost preview to the activity snapshot. The cost is the
+   * cumulative current-stream cost on top of the durable base;
+   * `recordStreamAccounting` performs final accounting at stream end.
+   *
+   * Previously this path always called `pushSnapshot` which rewrote the
+   * shared `extensionMetadata.json` (writeFileAtomic, serialized through a
+   * global mutation lock) on every `usage-delta` event. That made the Goals
+   * UI cost lag behind the Stats/Costs tabs mid-stream: Stats reads the
+   * frontend aggregator in-memory, while Goal cost waited on a per-delta
+   * disk write + activity round-trip. Restart recovery overwrites
+   * extensionMetadata from goal.json anyway (`restorePersistedGoalSnapshot`
+   * and `restoreGoalAccountingSnapshot`), so preview writes were redundant
+   * once a baseline activity snapshot exists.
+   *
+   * Prefer `pushTransientGoalSnapshot` so subscribers (the renderer's
+   * WorkspaceStore, the Goal tab) receive the preview without the global
+   * write lock. If no baseline activity exists yet, fall back to
+   * `pushSnapshot` so the first preview still creates and emits the
+   * workspace activity entry instead of being dropped.
    */
   async previewStreamAccounting(input: StreamAccountingInput): Promise<GoalSnapshot | null> {
     assert(input.workspaceId.trim().length > 0, "previewStreamAccounting requires workspaceId");
@@ -2119,7 +2187,18 @@ export class WorkspaceGoalService {
         ...this.applyCostAccounting(current, costMicroCentsThisStream),
         updatedAtMs: Date.now(),
       });
-      return this.pushSnapshot(input.workspaceId, preview);
+      const snapshot = toGoalSnapshot(preview);
+      this.liveGoalPreviewSnapshots.set(input.workspaceId, snapshot);
+      const didEmitTransient = await this.pushTransientGoalSnapshot(input.workspaceId, snapshot);
+      if (!didEmitTransient) {
+        // If the baseline activity snapshot does not exist yet (for
+        // example, extensionMetadata was reset or stream-start's
+        // fire-and-forget metadata write has not finished), fall back to
+        // the durable path so this preview is still delivered to Goals UI
+        // subscribers instead of being dropped.
+        return this.pushSnapshot(input.workspaceId, preview);
+      }
+      return snapshot;
     });
   }
 
@@ -2133,6 +2212,7 @@ export class WorkspaceGoalService {
     }
 
     const costMicroCentsThisStream = costUsdToMicroCents(input.costUsd);
+    this.liveGoalPreviewSnapshots.delete(input.workspaceId);
     return this.fileLocks.withLock(input.workspaceId, async () => {
       const current = await this.readGoalFile(input.workspaceId);
       if (!current) {
@@ -2250,6 +2330,7 @@ export class WorkspaceGoalService {
       const current = await this.readGoalFile(workspaceId);
       this.pendingGoalMutations.delete(workspaceId);
       this.pendingGoalSnapshots.delete(workspaceId);
+      this.liveGoalPreviewSnapshots.delete(workspaceId);
       this.pendingContinuationCandidates.delete(workspaceId);
       this.recordedStreamStartedAtMsByWorkspace.delete(workspaceId);
       this.lastGoalStreamStamps.delete(workspaceId);
@@ -2327,6 +2408,7 @@ export class WorkspaceGoalService {
   }
 
   async applyPendingAfterStreamEnd(workspaceId: string): Promise<GoalRecordV1 | null> {
+    this.liveGoalPreviewSnapshots.delete(workspaceId);
     const pending = this.pendingGoalMutations.get(workspaceId);
     let drained: GoalRecordV1 | null = null;
 


### PR DESCRIPTION
## Summary

Goal-tab cost (and other surfaces reading `goal.costCents`) now tracks the Stats/Costs tabs mid-stream. The fix removes the normal per-`usage-delta` disk write from the live cost preview path, adds a safe fallback for missing activity baselines, preserves the live "budget used" overlay when the user edits only the budget/turn limit mid-stream, and serializes failed-stream preview cleanup before restoring durable state.

## Background

Stats/Costs and Goal cost both ultimately derive from the same `usage-delta` events, but their delivery paths diverged:

- **Stats / Costs tab (instant):** `usage-delta` → frontend `StreamingMessageAggregator.handleUsageDelta` → bumps `usageStore` → `CostsTab` reads `liveCostUsage` straight from the aggregator.
- **Goal cost (slow round-trip):** `usage-delta` → backend `previewGoalAccountingFromUsage` → `workspaceGoalService.previewStreamAccounting` → `pushSnapshot` → `extensionMetadata.setGoal` → `writeFileAtomic` on the shared `extensionMetadata.json` (serialized through `withSerializedMutation`) → ORPC `workspace.activity` event → renderer `WorkspaceStore.applyWorkspaceActivitySnapshot` updates `goal.costCents`.

Mid-stream the Goal tile lagged Stats by the round-trip cost. Every workspace's preview also contended on the same global mutation lock on `extensionMetadata.json`.

Separately, editing only the budget limit during a live stream could make "budget used" appear to reset to the pre-stream durable value. That happened because the budget edit correctly wrote the durable `goal.json` value (before the in-flight stream is finally accounted), but the UI activity snapshot lost the live preview overlay until the next preview/final accounting event.

## Implementation

- `previewStreamAccounting` now prefers `pushTransientGoalSnapshot`. The renderer already handles `transientGoalOnly: true` snapshots via `WorkspaceStore.applyWorkspaceActivitySnapshot`, merging the preview `goal` into the cached activity without persisting it.
- If there is no baseline activity snapshot (metadata reset/corruption or stream-start metadata write race), preview delivery falls back to `pushSnapshot` so the first preview still creates and emits a workspace activity entry rather than being dropped.
- `WorkspaceGoalService` tracks the latest live preview snapshot in memory and re-emits it as a transient overlay after in-place mutable edits (budget / turn cap / inline rename). This keeps the UI's "used" amount aligned with Stats while leaving `goal.json` at the pre-stream durable base so stream-end accounting cannot double-count.
- Terminal stream errors call `restoreGoalAccountingSnapshot` with the active stream start time. That method runs under the same workspace lock as preview accounting, clears the cached preview, marks that failed stream as recorded, and re-emits the durable goal snapshot. Late queued usage deltas from the failed stream are ignored instead of repopulating stale preview state.
- No change to `recordStreamAccounting`: stream-end still writes both `goal.json` and `extensionMetadata.json` and emits the durable activity event.

Tests updated to observe normal previews through the activity listener queue (`captureGoalActivity` / `setOnActivityChange`) instead of inspecting `extensionMetadata.getSnapshot`. The normal contract is: **preview is transient; durable record stays at `goal.json`**. The fallback test explicitly covers the no-baseline case where a one-time activity write is still needed for delivery.

## Validation

- `bun test src/node/services/workspaceGoalService.test.ts src/node/services/agentSession.goalAutoPause.test.ts src/browser/features/RightSidebar/GoalTab.test.tsx src/common/utils/goals/budgetPricing.test.ts src/browser/utils/goals/resolveGoalSetIntent.test.ts` — 189 pass / 0 fail.
- `bun test src/node/services/agentSession` (15 files) — 158 pass / 0 fail.
- `make typecheck` — green.
- `make lint` — green.
- `make fmt-check` — green.
- `make static-check` — green.

## Risks

Low-to-medium. The change is scoped to the preview/activity emit path:

- Final accounting (`recordStreamAccounting`) is unchanged, so durable budget enforcement, budget-limited gating, and restart recovery remain anchored on `goal.json`.
- The transient-activity-emit pattern is the same one already used by `publishPendingGoalSnapshot` for queued goal replacements, so the renderer's `applyWorkspaceActivitySnapshot` path is already well-exercised.
- A fallback still uses the durable activity path when no baseline activity snapshot exists, addressing the race where stream-start metadata has not populated `extensionMetadata` yet.
- In-memory preview overlays are cleared on stream accounting, stop/abort cleanup, terminal stream-error restore, replacement, clear, and persisted-snapshot restore to avoid stale overlays after the stream has settled.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=xhigh -->
