### PR TITLE
🤖 fix: bound Shiki worker highlighting

### DIFF
--- a/src/browser/utils/highlighting/highlightDiffChunk.test.ts
+++ b/src/browser/utils/highlighting/highlightDiffChunk.test.ts
@@ -1,4 +1,4 @@
-import { highlightDiffChunk } from "./highlightDiffChunk";
+import { highlightDiffChunk, isWithinDiffHighlightSyncBudget } from "./highlightDiffChunk";
 import type { DiffChunk } from "./diffChunking";
 
 /**
@@ -15,6 +15,33 @@ describe("highlightDiffChunk", () => {
     oldLineNumbers: [null, null],
     newLineNumbers: [1, 2],
   };
+
+  describe("sync pre-worker budget", () => {
+    it("allows human-scale 10k-line chunks to attempt worker highlighting", () => {
+      const humanScaleLines = Array.from(
+        { length: 10_000 },
+        (_, i) => `const value${i} = computeValue(${i});`
+      );
+
+      expect(isWithinDiffHighlightSyncBudget(humanScaleLines)).toBe(true);
+    });
+
+    it("falls back before joining generated single-line chunks", async () => {
+      const generatedChunk: DiffChunk = {
+        type: "add",
+        lines: [`const generated = "${"x".repeat(25_000)}";`],
+        startIndex: 0,
+        oldLineNumbers: [null],
+        newLineNumbers: [1],
+      };
+
+      const result = await highlightDiffChunk(generatedChunk, "typescript");
+
+      expect(result.usedFallback).toBe(true);
+      expect(result.lines).toHaveLength(1);
+      expect(result.lines[0].html).toContain("const generated");
+    });
+  });
 
   describe("plain text files", () => {
     it("should return plain text for text/plaintext language", async () => {

--- a/src/browser/utils/highlighting/highlightDiffChunk.ts
+++ b/src/browser/utils/highlighting/highlightDiffChunk.ts
@@ -16,13 +16,27 @@ import type { DiffChunk } from "./diffChunking";
  * .line spans instead of extracting per-line HTML. Would simplify parsing
  * and reduce dangerouslySetInnerHTML usage.
  *
- * Size policy: we deliberately do NOT impose a byte cap here. Real-world
- * human-authored files routinely exceed any value we'd pick (a 10k-LoC file at
- * typical line widths is ~500 KB), and the worker client enforces a per-call
- * time budget that terminates pathological inputs without blocking the UI. So
- * "render plain text on cost overrun" is a property of the worker boundary,
- * not of this layer.
+ * Size policy: allow human-scale files (including 10k-LoC chunks) to attempt
+ * highlighting, but skip payloads that are too large or too minified to hand to
+ * the worker without visible renderer-thread pre-processing cost. The worker
+ * client still owns the runtime budget once a payload is handed off.
  */
+
+// Synchronous safety budget before the worker boundary. These are intentionally
+// far above human-scale source files but catch generated/minified hunks where
+// joining and structured-cloning the payload would itself be the UI stall.
+const MAX_DIFF_HIGHLIGHT_SYNC_CHARS = 2_000_000;
+const MAX_DIFF_HIGHLIGHT_LINE_CHARS = 20_000;
+
+export function isWithinDiffHighlightSyncBudget(lines: string[]): boolean {
+  let totalChars = Math.max(0, lines.length - 1); // account for join("\n") separators
+  for (const line of lines) {
+    if (line.length > MAX_DIFF_HIGHLIGHT_LINE_CHARS) return false;
+    totalChars += line.length;
+    if (totalChars > MAX_DIFF_HIGHLIGHT_SYNC_CHARS) return false;
+  }
+  return true;
+}
 
 export interface HighlightedLine {
   html: string; // HTML content (already escaped and tokenized)
@@ -60,6 +74,10 @@ export async function highlightDiffChunk(
       })),
       usedFallback: false,
     };
+  }
+
+  if (!isWithinDiffHighlightSyncBudget(chunk.lines)) {
+    return createFallbackChunk(chunk);
   }
 
   const code = chunk.lines.join("\n");

--- a/src/browser/utils/highlighting/highlightDiffChunk.ts
+++ b/src/browser/utils/highlighting/highlightDiffChunk.ts
@@ -15,11 +15,14 @@ import type { DiffChunk } from "./diffChunking";
  * Future optimization: Could render entire <code> blocks and use CSS to style
  * .line spans instead of extracting per-line HTML. Would simplify parsing
  * and reduce dangerouslySetInnerHTML usage.
+ *
+ * Size policy: we deliberately do NOT impose a byte cap here. Real-world
+ * human-authored files routinely exceed any value we'd pick (a 10k-LoC file at
+ * typical line widths is ~500 KB), and the worker client enforces a per-call
+ * time budget that terminates pathological inputs without blocking the UI. So
+ * "render plain text on cost overrun" is a property of the worker boundary,
+ * not of this layer.
  */
-
-// Maximum diff size to highlight (in bytes)
-// Diffs larger than this fall back to plain text for performance
-const MAX_DIFF_SIZE_BYTES = 32768; // 32kb
 
 export interface HighlightedLine {
   html: string; // HTML content (already escaped and tokenized)
@@ -57,14 +60,6 @@ export async function highlightDiffChunk(
       })),
       usedFallback: false,
     };
-  }
-
-  // Enforce size limit for performance
-  // Calculate size by summing line lengths + newlines (more performant than TextEncoder)
-  const sizeBytes =
-    chunk.lines.reduce((total, line) => total + line.length, 0) + chunk.lines.length - 1;
-  if (sizeBytes > MAX_DIFF_SIZE_BYTES) {
-    return createFallbackChunk(chunk);
   }
 
   const code = chunk.lines.join("\n");

--- a/src/browser/utils/highlighting/highlightWorkerClient.test.ts
+++ b/src/browser/utils/highlighting/highlightWorkerClient.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Unit tests for the time-budget helper that protects highlightCode against
+ * catastrophic-backtracking inputs.
+ *
+ * We test `highlightWithBudget` directly with injected fakes — no real Worker
+ * required — because the production callers (`highlightCode`) just compose
+ * this helper with `Comlink`. The end-to-end worker path is exercised by the
+ * existing `highlightDiffChunk.test.ts` suite (which falls through to
+ * main-thread Shiki because JSDOM has no Worker).
+ */
+
+import {
+  highlightWithBudget,
+  enqueueHighlightWithBudget,
+  __resetForTests,
+} from "./highlightWorkerClient";
+
+function neverResolves<T = string>(): Promise<T> {
+  return new Promise<T>((resolve) => {
+    void resolve;
+  });
+}
+
+describe("highlightWithBudget", () => {
+  beforeEach(() => {
+    __resetForTests();
+  });
+
+  it("returns the call's resolved HTML when it finishes within the budget", async () => {
+    const onTimeout = jest.fn();
+    const result = await highlightWithBudget(
+      "const x = 1;",
+      "typescript",
+      "dark",
+      () => Promise.resolve("<pre>resolved</pre>"),
+      onTimeout,
+      1000
+    );
+
+    expect(result).toBe("<pre>resolved</pre>");
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("throws and invokes onTimeout when the call exceeds the budget", async () => {
+    const onTimeout = jest.fn();
+    const pendingHighlight = neverResolves();
+
+    await expect(
+      highlightWithBudget("hang me", "typescript", "dark", () => pendingHighlight, onTimeout, 20)
+    ).rejects.toThrow("HIGHLIGHT_TIMEOUT");
+
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts the time budget only when a queued call reaches the front", async () => {
+    const onTimeout = jest.fn();
+    let firstStarted = false;
+    let secondStarted = false;
+
+    const first = enqueueHighlightWithBudget(
+      "bad",
+      "typescript",
+      "dark",
+      () => {
+        firstStarted = true;
+        return neverResolves();
+      },
+      onTimeout,
+      20
+    );
+    const second = enqueueHighlightWithBudget(
+      "good",
+      "typescript",
+      "dark",
+      () => {
+        secondStarted = true;
+        return Promise.resolve("<pre>good</pre>");
+      },
+      onTimeout,
+      20
+    );
+
+    await Promise.resolve();
+    expect(firstStarted).toBe(true);
+    expect(secondStarted).toBe(false);
+
+    await expect(first).rejects.toThrow("HIGHLIGHT_TIMEOUT");
+    await expect(second).resolves.toBe("<pre>good</pre>");
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("remembers timed-out inputs and short-circuits subsequent calls", async () => {
+    const onTimeout = jest.fn();
+    const callFn = jest.fn(() => neverResolves());
+
+    // First call: hangs, times out, populates the cache.
+    await expect(
+      highlightWithBudget("pathological", "typescript", "dark", callFn, onTimeout, 20)
+    ).rejects.toThrow("HIGHLIGHT_TIMEOUT");
+    expect(callFn).toHaveBeenCalledTimes(1);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+
+    // Same input again — must NOT call the underlying worker or fire another
+    // terminate. This is the bug-prevention guarantee: replaying the same
+    // pathological payload on every re-render must not chew through workers.
+    await expect(
+      highlightWithBudget("pathological", "typescript", "dark", callFn, onTimeout, 20)
+    ).rejects.toThrow("HIGHLIGHT_TIMEOUT");
+    expect(callFn).toHaveBeenCalledTimes(1);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not treat different inputs as previously timed out", async () => {
+    const onTimeout = jest.fn();
+
+    // First input blows the budget…
+    await expect(
+      highlightWithBudget("input-A", "typescript", "dark", () => neverResolves(), onTimeout, 20)
+    ).rejects.toThrow("HIGHLIGHT_TIMEOUT");
+
+    // …but a different input is still attempted (and can succeed).
+    const result = await highlightWithBudget(
+      "input-B",
+      "typescript",
+      "dark",
+      () => Promise.resolve("<pre>B</pre>"),
+      onTimeout,
+      1000
+    );
+    expect(result).toBe("<pre>B</pre>");
+    expect(onTimeout).toHaveBeenCalledTimes(1); // still just the one from input-A
+  });
+
+  it("keys the timed-out cache by language and theme", async () => {
+    const onTimeout = jest.fn();
+    const hang = () => neverResolves();
+
+    await expect(
+      highlightWithBudget("same code", "typescript", "dark", hang, onTimeout, 20)
+    ).rejects.toThrow("HIGHLIGHT_TIMEOUT");
+
+    // Same code, different language: must NOT be considered previously bad.
+    // We expect the worker to be invoked again.
+    const callFn = jest.fn(() => Promise.resolve("<pre>ok</pre>"));
+    const result = await highlightWithBudget(
+      "same code",
+      "python",
+      "dark",
+      callFn,
+      onTimeout,
+      1000
+    );
+    expect(result).toBe("<pre>ok</pre>");
+    expect(callFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates non-timeout errors without poisoning the cache", async () => {
+    const onTimeout = jest.fn();
+
+    await expect(
+      highlightWithBudget(
+        "crashy",
+        "typescript",
+        "dark",
+        () => Promise.reject(new Error("boom")),
+        onTimeout,
+        100
+      )
+    ).rejects.toThrow("boom");
+
+    // Non-timeout errors must NOT count as exceeding the budget — the input
+    // itself might be fine and a fresh worker may succeed next time.
+    expect(onTimeout).not.toHaveBeenCalled();
+
+    const callFn = jest.fn(() => Promise.resolve("<pre>retry</pre>"));
+    const result = await highlightWithBudget(
+      "crashy",
+      "typescript",
+      "dark",
+      callFn,
+      onTimeout,
+      100
+    );
+    expect(result).toBe("<pre>retry</pre>");
+    expect(callFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("populates the cache before invoking onTimeout (so synchronous follow-ups bail fast)", async () => {
+    // The recycle callback in production tears down the worker. If a queued
+    // re-render fires the same input synchronously from inside that callback,
+    // it must see the cache hit immediately rather than triggering another
+    // terminate.
+    let cacheHitObservedInsideOnTimeout: boolean | null = null;
+
+    const cacheProbes: Array<Promise<void>> = [];
+    const onTimeout = jest.fn(() => {
+      const cachedCall = jest.fn(() => neverResolves());
+      cacheProbes.push(
+        highlightWithBudget(
+          "race",
+          "typescript",
+          "dark",
+          cachedCall,
+          () => {
+            throw new Error("cache probe should short-circuit before timing out");
+          },
+          50
+        ).then(
+          () => {
+            cacheHitObservedInsideOnTimeout = false;
+          },
+          () => {
+            // Should reject quickly via cache hit without calling cachedCall.
+            cacheHitObservedInsideOnTimeout = cachedCall.mock.calls.length === 0;
+          }
+        )
+      );
+    });
+
+    await expect(
+      highlightWithBudget("race", "typescript", "dark", () => neverResolves(), onTimeout, 20)
+    ).rejects.toThrow("HIGHLIGHT_TIMEOUT");
+
+    expect(cacheProbes).toHaveLength(1);
+    await Promise.all(cacheProbes);
+    expect(cacheHitObservedInsideOnTimeout).toBe(true);
+  });
+});

--- a/src/browser/utils/highlighting/highlightWorkerClient.ts
+++ b/src/browser/utils/highlighting/highlightWorkerClient.ts
@@ -110,7 +110,14 @@ let warnedVscodeWorkerDisabled = false;
  * inputs are tracked separately by fingerprint, and well-formed inputs deserve
  * a fresh attempt against a fresh worker.
  */
-function recycleWorker(): void {
+function recycleWorker(expectedWorker?: Worker): void {
+  if (expectedWorker !== undefined && worker !== expectedWorker) {
+    // A stale worker can still emit asynchronous errors after a replacement has
+    // been created. Do not let that stale event tear down the healthy current
+    // worker and cascade fallback through unrelated queued highlights.
+    return;
+  }
+
   if (worker !== null) {
     try {
       worker.terminate();
@@ -147,20 +154,23 @@ function getWorkerAPI(): Comlink.Remote<HighlightWorkerAPI> | null {
 
   try {
     // Use relative path - @/ alias doesn't work in worker context.
-    worker = new Worker(new URL("../../workers/highlightWorker.ts", import.meta.url), {
+    const createdWorker = new Worker(new URL("../../workers/highlightWorker.ts", import.meta.url), {
       type: "module",
       name: "shiki-highlighter", // Shows up in DevTools
     });
+    worker = createdWorker;
 
-    worker.onerror = (e) => {
+    createdWorker.onerror = (e) => {
       // A worker that errored out is not necessarily permanently broken — the
       // error may be confined to a single grammar/input. Clear state so the
-      // next highlight call builds a fresh worker.
+      // next highlight call builds a fresh worker, but only if this is still
+      // the active worker. Stale error events from already-replaced workers
+      // must not terminate a healthy replacement.
       console.error("[highlightWorkerClient] Worker errored; recycling:", e);
-      recycleWorker();
+      recycleWorker(createdWorker);
     };
 
-    workerAPI = Comlink.wrap<HighlightWorkerAPI>(worker);
+    workerAPI = Comlink.wrap<HighlightWorkerAPI>(createdWorker);
     return workerAPI;
   } catch (e) {
     // Workers not available (e.g., test environment). Construction failures

--- a/src/browser/utils/highlighting/highlightWorkerClient.ts
+++ b/src/browser/utils/highlighting/highlightWorkerClient.ts
@@ -304,21 +304,27 @@ export async function highlightCode(
   language: string,
   theme: "dark" | "light"
 ): Promise<string> {
-  const api = getWorkerAPI();
-  if (!api) {
-    // Worker is structurally unavailable (vscode webview / test env).
-    // Main-thread Shiki is the only option; the timeout protection does not
-    // apply here, but these environments are not the ones that hit the
-    // pathological-input bug in practice.
-    return highlightMainThread(code, language, theme);
-  }
-
   try {
     return await enqueueHighlightWithBudget(
       code,
       language,
       theme,
-      () => api.highlight(code, language, theme),
+      async () => {
+        // Resolve the worker when this queued job starts, not when it is
+        // enqueued. If an earlier job timed out and recycled the worker,
+        // later queued jobs must talk to the fresh worker rather than a dead
+        // Comlink proxy captured from the old worker.
+        const api = getWorkerAPI();
+        if (!api) {
+          // Worker is structurally unavailable (vscode webview / test env).
+          // Main-thread Shiki is the only option; timeout protection cannot
+          // preempt synchronous work here, but these environments are not the
+          // ones that hit the pathological-input bug in practice.
+          return highlightMainThread(code, language, theme);
+        }
+
+        return api.highlight(code, language, theme);
+      },
       recycleWorker
     );
   } catch (e) {

--- a/src/browser/utils/highlighting/highlightWorkerClient.ts
+++ b/src/browser/utils/highlighting/highlightWorkerClient.ts
@@ -5,6 +5,22 @@
  * Falls back to main-thread highlighting in test environments where
  * Web Workers aren't available.
  *
+ * Optimistic + bounded-cost contract:
+ *   - Worker calls are serialized in the client and each call has a hard
+ *     time budget (HIGHLIGHT_TIMEOUT_MS) that starts only once that payload
+ *     reaches the front of the queue. When it expires we assume the worker is
+ *     wedged in native code (e.g. Oniguruma catastrophic backtracking on a
+ *     TextMate grammar) and terminate the worker, freeing its CPU immediately.
+ *   - Inputs that exceeded the budget are remembered by fingerprint so
+ *     subsequent re-renders (theme changes, streaming, scroll) don't kill
+ *     a fresh worker for the same payload.
+ *   - We deliberately do NOT fall back to the main-thread highlighter on
+ *     worker runtime errors: it uses the same Oniguruma engine and would
+ *     freeze the UI instead of one core. Main-thread Shiki is only used
+ *     when the worker is structurally unavailable (vscode webview, tests).
+ *   - Callers already render plain text when this function throws, so
+ *     timeout = "render the diff/code block as plain text" — never a hang.
+ *
  * Note: Caching happens at the caller level (DiffRenderer's highlightedDiffCache)
  * to enable synchronous cache hits and avoid "Processing" flash.
  */
@@ -14,6 +30,40 @@ import type { Highlighter } from "shiki";
 import type { HighlightWorkerAPI } from "@/browser/workers/highlightWorker";
 import { mapToShikiLang, SHIKI_DARK_THEME, SHIKI_LIGHT_THEME } from "./shiki-shared";
 import { isVscodeWebview } from "@/browser/utils/env";
+
+// 5 s is generous for human-scale files (a 10k-LoC file at typical line lengths
+// highlights in well under 1 s on real hardware) but cuts off catastrophic
+// backtracking, which otherwise pegs a core indefinitely.
+const HIGHLIGHT_TIMEOUT_MS = 5000;
+
+// Sentinel thrown internally when the time budget is exceeded. Kept distinct
+// from generic Errors so the caller path can choose how loudly to log it.
+const TIMEOUT_MARKER = "HIGHLIGHT_TIMEOUT";
+
+// Inputs that previously exceeded the time budget. We don't ship them to a
+// new worker again — that would just terminate another worker for the same
+// pathological payload. Keyed by a cheap fingerprint that includes language
+// and theme since both can change the matcher's behavior. Safe because
+// `enqueueHighlightWithBudget` starts the timeout only after the payload reaches
+// the front of the client-side queue, so queued requests are not mislabeled as
+// pathological merely because an earlier request is stuck.
+const timedOutInputs = new Set<string>();
+
+let workerHighlightQueue: Promise<void> = Promise.resolve();
+
+/**
+ * Cheap fingerprint for memoizing "this input previously blew the budget".
+ *
+ * We deliberately avoid hashing the full string (it's the hot path on every
+ * render of a streaming code block). Length + endpoints + language + theme is
+ * enough: false collisions only cost an extra plain-text render, never
+ * correctness.
+ */
+function inputKey(code: string, language: string, theme: "dark" | "light"): string {
+  const head = code.length > 64 ? code.slice(0, 64) : code;
+  const tail = code.length > 128 ? code.slice(-64) : "";
+  return `${language}\u0000${theme}\u0000${code.length}\u0000${head}\u0000${tail}`;
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Main-thread Shiki (fallback only)
@@ -43,9 +93,35 @@ async function getShikiHighlighter(): Promise<Highlighter> {
 // Worker Management (via Comlink)
 // ─────────────────────────────────────────────────────────────────────────────
 
+let worker: Worker | null = null;
 let workerAPI: Comlink.Remote<HighlightWorkerAPI> | null = null;
-let workerFailed = false;
+// Set when the worker is structurally unavailable (vscode webview, construction
+// throws). NOT set on runtime errors — we want the next call to spin up a fresh
+// worker, since the previous one may have been wedged in native code.
+let workerStructurallyUnavailable = false;
 let warnedVscodeWorkerDisabled = false;
+
+/**
+ * Tear down the current worker so the next call to `getWorkerAPI` builds a
+ * fresh one. Used after a timeout (worker assumed wedged in native code) or
+ * after a runtime error (worker may be in an indeterminate state).
+ *
+ * We deliberately do NOT mark the worker as permanently failed — pathological
+ * inputs are tracked separately by fingerprint, and well-formed inputs deserve
+ * a fresh attempt against a fresh worker.
+ */
+function recycleWorker(): void {
+  if (worker !== null) {
+    try {
+      worker.terminate();
+    } catch {
+      // terminate() can't really fail, but be defensive — we just want the
+      // module state cleared either way.
+    }
+  }
+  worker = null;
+  workerAPI = null;
+}
 
 function getWorkerAPI(): Comlink.Remote<HighlightWorkerAPI> | null {
   // VS Code webviews load the chat UI from a bundled ESM file.
@@ -60,33 +136,39 @@ function getWorkerAPI(): Comlink.Remote<HighlightWorkerAPI> | null {
       console.warn("[highlightWorkerClient] Worker highlighting disabled in VS Code webview");
     }
 
-    workerFailed = true;
+    workerStructurallyUnavailable = true;
+    worker = null;
     workerAPI = null;
     return null;
   }
 
-  if (workerFailed) return null;
+  if (workerStructurallyUnavailable) return null;
   if (workerAPI) return workerAPI;
 
   try {
     // Use relative path - @/ alias doesn't work in worker context.
-    const worker = new Worker(new URL("../../workers/highlightWorker.ts", import.meta.url), {
+    worker = new Worker(new URL("../../workers/highlightWorker.ts", import.meta.url), {
       type: "module",
       name: "shiki-highlighter", // Shows up in DevTools
     });
 
     worker.onerror = (e) => {
-      console.error("[highlightWorkerClient] Worker failed to load:", e);
-      workerFailed = true;
-      workerAPI = null;
+      // A worker that errored out is not necessarily permanently broken — the
+      // error may be confined to a single grammar/input. Clear state so the
+      // next highlight call builds a fresh worker.
+      console.error("[highlightWorkerClient] Worker errored; recycling:", e);
+      recycleWorker();
     };
 
     workerAPI = Comlink.wrap<HighlightWorkerAPI>(worker);
     return workerAPI;
   } catch (e) {
-    // Workers not available (e.g., test environment)
+    // Workers not available (e.g., test environment). Construction failures
+    // ARE permanent: no point retrying every render.
     console.error("[highlightWorkerClient] Failed to create worker:", e);
-    workerFailed = true;
+    workerStructurallyUnavailable = true;
+    worker = null;
+    workerAPI = null;
     return null;
   }
 }
@@ -131,15 +213,91 @@ async function highlightMainThread(
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
+ * Race `call` against the time budget. On budget expiry:
+ *   - invoke `onTimeout` (production: terminate the wedged worker),
+ *   - remember the input fingerprint so we don't retry it,
+ *   - throw the timeout sentinel so the caller renders plain text.
+ *
+ * Exported for unit testing. Production callers should use `highlightCode`.
+ */
+export async function highlightWithBudget(
+  code: string,
+  language: string,
+  theme: "dark" | "light",
+  call: () => Promise<string>,
+  onTimeout: () => void,
+  timeoutMs: number = HIGHLIGHT_TIMEOUT_MS
+): Promise<string> {
+  const key = inputKey(code, language, theme);
+  if (timedOutInputs.has(key)) {
+    // Previously blew the budget. Bail fast without touching the worker so we
+    // don't keep terminating workers for the same input on every re-render.
+    throw new Error(TIMEOUT_MARKER);
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      call(),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(TIMEOUT_MARKER)), timeoutMs);
+      }),
+    ]);
+  } catch (e) {
+    if (e instanceof Error && e.message === TIMEOUT_MARKER) {
+      timedOutInputs.add(key);
+      // Side effect (terminate worker) happens AFTER the cache is populated
+      // so any synchronous follow-on call sees the fingerprint immediately.
+      onTimeout();
+    }
+    throw e;
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+/**
+ * Serialize highlight attempts before applying the budget. The worker itself is
+ * single-threaded, so concurrent Comlink calls would only queue on the worker;
+ * keeping the queue on the client lets the timeout clock measure actual work on
+ * the specific payload rather than time spent waiting behind an earlier wedged
+ * request.
+ *
+ * Exported for unit testing. Production callers should use `highlightCode`.
+ */
+export function enqueueHighlightWithBudget(
+  code: string,
+  language: string,
+  theme: "dark" | "light",
+  call: () => Promise<string>,
+  onTimeout: () => void,
+  timeoutMs: number = HIGHLIGHT_TIMEOUT_MS
+): Promise<string> {
+  const run = () => highlightWithBudget(code, language, theme, call, onTimeout, timeoutMs);
+  const result = workerHighlightQueue.then(run, run);
+  workerHighlightQueue = result.then(
+    () => undefined,
+    () => undefined
+  );
+  return result;
+}
+
+/**
  * Highlight code with syntax highlighting (off-main-thread)
  *
- * Highlighting runs in a Web Worker to avoid blocking the main thread.
+ * Highlighting runs in a Web Worker to avoid blocking the main thread, with
+ * a hard time budget per call. If the budget expires (catastrophic
+ * backtracking, etc.) the worker is terminated and this function throws — the
+ * caller is expected to render plain text. We deliberately do NOT fall back to
+ * a main-thread Shiki call on worker timeouts/errors: the same Oniguruma
+ * engine would then freeze the UI instead of one core.
  *
  * @param code - Source code to highlight
  * @param language - Language identifier (e.g., "typescript", "python")
  * @param theme - Theme variant ("dark" or "light")
  * @returns Promise resolving to HTML string with syntax highlighting
- * @throws Error if highlighting fails (caller should fallback to plain text)
+ * @throws Error if highlighting fails or exceeds the time budget. Caller
+ *   should fall back to plain text on any throw.
  */
 export async function highlightCode(
   code: string,
@@ -148,19 +306,49 @@ export async function highlightCode(
 ): Promise<string> {
   const api = getWorkerAPI();
   if (!api) {
+    // Worker is structurally unavailable (vscode webview / test env).
+    // Main-thread Shiki is the only option; the timeout protection does not
+    // apply here, but these environments are not the ones that hit the
+    // pathological-input bug in practice.
     return highlightMainThread(code, language, theme);
   }
 
   try {
-    return await api.highlight(code, language, theme);
-  } catch (e) {
-    // Defensive fallback: if the worker crashes or fails to respond, keep rendering.
-    console.error(
-      "[highlightWorkerClient] Worker highlight failed; falling back to main thread:",
-      e
+    return await enqueueHighlightWithBudget(
+      code,
+      language,
+      theme,
+      () => api.highlight(code, language, theme),
+      recycleWorker
     );
-    workerFailed = true;
-    workerAPI = null;
-    return highlightMainThread(code, language, theme);
+  } catch (e) {
+    if (e instanceof Error && e.message === TIMEOUT_MARKER) {
+      // Demote to a warn once per pathological input — `timedOutInputs` is the
+      // dedupe key. The terminate side effect already happened inside
+      // `highlightWithBudget`.
+      console.warn(
+        `[highlightWorkerClient] highlight exceeded ${HIGHLIGHT_TIMEOUT_MS}ms budget for ${language}; ` +
+          `rendering as plain text and skipping this input henceforth (${code.length} chars)`
+      );
+    } else {
+      // Non-timeout error — worker may be in an indeterminate state. Recycle
+      // so the next call gets a fresh one. Don't main-thread fallback (same
+      // engine, same risk).
+      console.warn("[highlightWorkerClient] worker highlight failed; recycling:", e);
+      recycleWorker();
+    }
+    throw e;
   }
+}
+
+/**
+ * Test-only: reset all module state (worker singleton, structural-unavailability
+ * flag, timed-out input cache). Lets unit tests start from a clean slate.
+ */
+export function __resetForTests(): void {
+  recycleWorker();
+  workerHighlightQueue = Promise.resolve();
+  workerStructurallyUnavailable = false;
+  warnedVscodeWorkerDisabled = false;
+  timedOutInputs.clear();
 }

--- a/src/browser/utils/highlighting/highlightWorkerClient.ts
+++ b/src/browser/utils/highlighting/highlightWorkerClient.ts
@@ -118,16 +118,31 @@ function recycleWorker(expectedWorker?: Worker): void {
     return;
   }
 
-  if (worker !== null) {
+  const currentWorker = worker;
+  const currentWorkerAPI = workerAPI;
+  worker = null;
+  workerAPI = null;
+
+  if (currentWorkerAPI !== null) {
     try {
-      worker.terminate();
+      // Tell Comlink this proxy is intentionally done before terminating the
+      // endpoint. Otherwise Comlink's finalizer can later try to post a release
+      // message to an already-terminated worker, which surfaces as an
+      // unhandled InvalidStateError in Bun's test runner.
+      currentWorkerAPI[Comlink.releaseProxy]();
+    } catch {
+      // If the worker is already gone, clearing our references is enough.
+    }
+  }
+
+  if (currentWorker !== null) {
+    try {
+      currentWorker.terminate();
     } catch {
       // terminate() can't really fail, but be defensive — we just want the
       // module state cleared either way.
     }
   }
-  worker = null;
-  workerAPI = null;
 }
 
 function getWorkerAPI(): Comlink.Remote<HighlightWorkerAPI> | null {


### PR DESCRIPTION
## Summary

Keep syntax highlighting optimistic while preventing pathological Shiki/TextMate inputs from wedging the renderer. Highlighting still attempts human-scale diffs/code blocks, but worker calls now have bounded runtime, oversized generated/minified hunks fall back before expensive renderer-thread preprocessing, and recovery no longer leaves stale or dead workers in the queue.

## Background

A live Mux instance had a `shiki-highlighter` worker pegging one renderer thread after it became unresponsive inside native Oniguruma matching. Because `highlightCode()` awaited the Comlink call without a timeout, the worker singleton stayed wedged forever and every later highlight request queued behind it.

## Implementation

- Add a 5s budget around worker `highlight()` calls.
- Serialize highlight calls on the client so a queued request's timeout starts only when that payload reaches the front of the queue.
- On timeout, terminate/recycle the worker and remember the input fingerprint so re-renders do not repeatedly kill fresh workers for the same payload.
- Resolve the worker proxy when each queued job starts, so jobs queued behind a recycled worker use the fresh worker instead of a terminated Comlink proxy.
- Guard `worker.onerror` recycling against stale workers and release the Comlink proxy before termination to avoid unhandled `InvalidStateError` in Bun.
- Avoid main-thread Shiki fallback for worker runtime failures, since it uses the same matcher and could freeze the UI.
- Replace the old 32KB diff cap with a pre-worker sync budget that allows 10k-line human-scale chunks while skipping generated/minified payloads before `join`/structured-clone work can stall the renderer.

## Validation

- `make static-check`
- `bun test src/browser/utils/highlighting/`
- `make typecheck`
- CI: Codex approved; GitHub CI checks pass. Chromatic's optional UI baseline checks are pending human acceptance for the intended visual update.

## Risks

Low-to-medium, limited to syntax highlighting. Pathological or generated/minified inputs now render as plain text after the sync/runtime budget is exceeded, and the fingerprint cache can conservatively skip highlighting for a rare collision, but the underlying code/diff text remains visible and copyable.

## Pains

`git push`/`git fetch` to GitHub hung repeatedly in this workspace, so branch updates after the initial push were applied through the GitHub Git Database API while keeping the local branch ref synchronized to the API-created commits.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$5.98`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=5.98 -->
