### PR TITLE
🤖 fix: continue promoted upcoming goals

### DIFF
--- a/src/node/services/workspaceGoalService.test.ts
+++ b/src/node/services/workspaceGoalService.test.ts
@@ -2839,10 +2839,22 @@ describe("WorkspaceGoalService", () => {
     test("auto-promotes the next upcoming goal when the active goal completes", async () => {
       const active = await setGoalOk(service, { workspaceId, objective: "First" });
       const queued = await service.addUpcomingGoal({ workspaceId, objective: "Second" });
+      const dispatcher = new IdleDispatcher();
+      const executed: string[] = [];
+      service.registerGoalContinuationConsumer(dispatcher, {
+        hasActiveDescendantTasks: () => false,
+        getRuntimeState: () => ({ isRuntimeCompatible: true }),
+        executeGoalContinuation: (input) => {
+          executed.push(input.message);
+          return Promise.resolve(true);
+        },
+        getKickoffSendOptions: () => ({ model: "openai:gpt-4o", agentId: "exec" }),
+      });
 
       // Mark the active goal complete. The board's invariant is: the
       // completed goal moves to history + the next upcoming becomes
-      // active in the same write.
+      // active in the same write, then the promoted goal starts without a
+      // manual pause/unpause nudge.
       await setGoalOk(service, {
         workspaceId,
         status: "complete",
@@ -2853,6 +2865,9 @@ describe("WorkspaceGoalService", () => {
       const activeEntry = board.entries.find((e) => e.section === "active");
       expect(activeEntry?.goal.goalId).toBe(queued.goalId);
       expect(activeEntry?.goal.status).toBe("active");
+
+      await waitForCondition(() => executed.length > 0, { timeoutMs: 1_000 });
+      expect(executed[0]).toContain("Second");
 
       const completed = board.entries.find(
         (e) => e.section === "complete" && e.goal.goalId === active.goalId
@@ -2972,6 +2987,44 @@ describe("WorkspaceGoalService", () => {
         .filter((e) => e.section === "upcoming")
         .map((e) => e.goal.goalId);
       expect(upcomingIds[0]).toBe(active.goalId);
+    });
+
+    test("promoteUpcomingGoal starts the promoted goal and clears stale stop gates", async () => {
+      const active = await setGoalOk(service, { workspaceId, objective: "Stopped active" });
+      const queued = await service.addUpcomingGoal({
+        workspaceId,
+        objective: "Promote after stop",
+      });
+      // The user stopped the previous active turn, then explicitly promoted a
+      // queued goal. That old stop/ack gate must not suppress the promoted
+      // goal's kickoff and force a pause/unpause workaround.
+      await service.recordUserStoppedStream(workspaceId, Date.now());
+
+      const dispatcher = new IdleDispatcher();
+      const executed: string[] = [];
+      service.registerGoalContinuationConsumer(dispatcher, {
+        hasActiveDescendantTasks: () => false,
+        getRuntimeState: () => ({ isRuntimeCompatible: true }),
+        executeGoalContinuation: (input) => {
+          executed.push(input.message);
+          return Promise.resolve(true);
+        },
+        getKickoffSendOptions: () => ({ model: "openai:gpt-4o", agentId: "exec" }),
+      });
+
+      const promoted = await service.promoteUpcomingGoal(workspaceId, queued.goalId);
+      expect(promoted?.goalId).toBe(queued.goalId);
+      await waitForCondition(() => executed.length >= 1, { timeoutMs: 1_000 });
+      expect(executed[0]).toContain("Promote after stop");
+
+      const rePromoted = await service.promoteUpcomingGoal(workspaceId, active.goalId);
+      expect(rePromoted?.goalId).toBe(active.goalId);
+      await waitForCondition(() => executed.length >= 2, { timeoutMs: 1_000 });
+      expect(executed[1]).toContain("Stopped active");
+      expect(await service.getGoal(workspaceId)).toMatchObject({
+        goalId: active.goalId,
+        requireUserAcknowledgmentSinceMs: null,
+      });
     });
 
     test("promoteUpcomingGoal archives a completed active goal instead of demoting to upcoming", async () => {

--- a/src/node/services/workspaceGoalService.ts
+++ b/src/node/services/workspaceGoalService.ts
@@ -1903,6 +1903,18 @@ export class WorkspaceGoalService {
       });
   }
 
+  private armContinuationForPromotedGoal(workspaceId: string, goal: GoalRecordV1): void {
+    // Promotion is an explicit handoff to this queued goal. Any stop/ack gate
+    // was attached to an older active turn and would otherwise strand the
+    // promoted goal until the user pause/unpauses it.
+    this.lastUserStopAtMsByWorkspace.delete(workspaceId);
+    if (goal.status === "active") {
+      this.armKickoffContinuationIfIdle(workspaceId, goal);
+    } else if (goal.status === "budget_limited") {
+      this.armBudgetWrapupForBudgetLimitedGoal(workspaceId, goal);
+    }
+  }
+
   /**
    * Re-arm pending continuation / budget-wrap-up dispatches after a process
    * restart. `pendingContinuationCandidates` and `lastGoalStreamStamps` are
@@ -2831,9 +2843,8 @@ export class WorkspaceGoalService {
    * which `recordStreamAccounting` reads on every chunk to attribute
    * cost. If we promote while a stream is still running for the
    * current active goal, the freshly-promoted goal would absorb the
-   * previous goal's cost. Reject up front with a typed transition
-   * error; the caller surfaces a "wait for the stream to finish"
-   * message and the user retries.
+   * previous goal's cost. Interrupt/poll first so the promoted goal can
+   * safely receive its kickoff continuation once the workspace is idle.
    *
    * Returns the new active record (the promoted goal, with status
    * flipped to `active` via the normal createGoal-like path) or
@@ -2845,13 +2856,13 @@ export class WorkspaceGoalService {
     // Interrupt the active stream (if any) before promoting so the
     // in-flight turn's costs are attributed to the goal that ran them.
     // The promoted goal's view (via the agent's `get_goal` tool) then
-    // takes effect on the next user message; otherwise a mid-stream
+    // takes effect on the kickoff continuation; otherwise a mid-stream
     // promote could attribute the current stream tail to the new goal.
     //
     // Behavior intentionally fails open: if no interrupter is wired
     // (tests) or the interrupt errors, we still proceed to promote.
-    // The next turn picks up the new goal via `get_goal`; worst case
-    // is the small slice of stream tail that lands before the abort
+    // The promotion arm below picks up the new goal via `get_goal`; worst
+    // case is the small slice of stream tail that lands before the abort
     // settles. We log so production paths flag the rare error.
     if (await this.isWorkspaceStreaming(workspaceId)) {
       if (this.streamInterrupter) {
@@ -2871,7 +2882,7 @@ export class WorkspaceGoalService {
       }
     }
 
-    return this.fileLocks.withLock(workspaceId, async () => {
+    const promotedGoal = await this.fileLocks.withLock(workspaceId, async () => {
       const [currentActive, board] = await Promise.all([
         this.readGoalFile(workspaceId),
         this.readBoard(workspaceId),
@@ -2905,6 +2916,7 @@ export class WorkspaceGoalService {
         status: "active",
         updatedAtMs: now,
         completionSummary: undefined,
+        requireUserAcknowledgmentSinceMs: null,
       });
       const activated = this.applyBudgetDrivenStatus(baseActivated);
 
@@ -2947,6 +2959,10 @@ export class WorkspaceGoalService {
       this.emitLifecycle("goal_resumed", { initiator: "user" });
       return activated;
     });
+    if (promotedGoal) {
+      this.armContinuationForPromotedGoal(workspaceId, promotedGoal);
+    }
+    return promotedGoal;
   }
 
   /**
@@ -3017,10 +3033,10 @@ export class WorkspaceGoalService {
   /**
    * Called after a goal is marked complete (by agent or user) or
    * cleared. If `upcoming` has a head, promote it to active so the
-   * agent has a roadmap to pick up on the next user message. Does NOT
-   * auto-fire a continuation turn — the user controls when work
-   * resumes (consistent with the no-auto-message-on-promotion design
-   * decision).
+   * agent has a roadmap to pick up immediately. Promotion also arms the
+   * kickoff continuation when a runtime bridge can supply send options; this
+   * matches explicit resume and prevents queued goals from waiting on a
+   * pause/unpause nudge.
    *
    * Caller must hold the workspace file lock. Returns the new active
    * record if a promotion happened, null otherwise.
@@ -3059,6 +3075,7 @@ export class WorkspaceGoalService {
       status: "active",
       updatedAtMs: now,
       completionSummary: undefined,
+      requireUserAcknowledgmentSinceMs: null,
     });
     const activated = this.applyBudgetDrivenStatus(baseActivated);
     // same pricing gate as `promoteUpcomingGoal`. If the next
@@ -3086,6 +3103,7 @@ export class WorkspaceGoalService {
       hasBudget: activated.budgetCents != null,
       hasTurnCap: activated.turnCap != null,
     });
+    this.armContinuationForPromotedGoal(workspaceId, activated);
     return activated;
   }
 }


### PR DESCRIPTION
## Summary

Fixes promoted upcoming goals so they start automatically on idle workspaces instead of requiring a manual pause/unpause nudge.

## Background

New goals and explicit paused-goal resumes already arm a kickoff continuation. Upcoming-goal promotion bypassed that path, so manual promotion and auto-promotion could leave the workspace with an active goal but no queued synthetic send. If the prior active turn had been stopped, its stale stop/ack gates could also suppress a promoted goal's continuation.

## Implementation

- Arm kickoff continuations or budget-limit wrap-ups after upcoming goals are promoted into the active slot.
- Clear stale stop/ack gates during activation so older stopped turns cannot strand newly promoted goals.
- Added regression coverage for auto-promotion after completion and manual promotion after a stopped turn, including re-promoting a goal that carried an acknowledgment gate.

## Validation

- `bun test src/node/services/workspaceGoalService.test.ts`
- `make static-check`

## Risks

Low-to-moderate. The change is scoped to goal promotion paths and reuses the existing idle-dispatch eligibility checks, so busy/streaming/queued-message gates still prevent unsafe sends.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `unknown`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=unknown -->
