### PR TITLE
🤖 feat: stack bash intent + command in collapsed header

### DIFF
--- a/src/browser/features/Settings/Sections/GeneralSection.test.tsx
+++ b/src/browser/features/Settings/Sections/GeneralSection.test.tsx
@@ -12,7 +12,6 @@ import {
   DEFAULT_WORKTREE_ARCHIVE_BEHAVIOR,
   type WorktreeArchiveBehavior,
 } from "@/common/config/worktreeArchiveBehavior";
-import { TOOL_COLLAPSED_DISPLAY_MODE_KEY } from "@/common/constants/storage";
 
 interface MockConfig {
   coderWorkspaceArchiveBehavior: CoderWorkspaceArchiveBehavior;
@@ -302,37 +301,6 @@ describe("GeneralSection", () => {
       expect(trigger.textContent).toContain(optionText);
     });
   }
-
-  async function waitForArchiveSettingsLoad(view: ReturnType<typeof render>): Promise<void> {
-    // Storage-only tests still need the async backend config load to settle before cleanup.
-    await waitFor(() => {
-      expect(getSelectTrigger(view, "Worktree archive behavior").textContent).toContain(
-        "Keep checkout"
-      );
-    });
-  }
-
-  test("updates the collapsed tool summary mode selection", async () => {
-    const { view } = renderGeneralSection();
-
-    expect(getSelectTrigger(view, "Collapsed bash summaries").textContent).toContain(
-      "Intent and command"
-    );
-
-    await chooseSelectOption(view, "Collapsed bash summaries", "Command");
-    await waitForArchiveSettingsLoad(view);
-  });
-
-  test("falls back to the default collapsed tool summary mode for invalid storage", async () => {
-    window.localStorage.setItem(TOOL_COLLAPSED_DISPLAY_MODE_KEY, JSON.stringify("invalid"));
-
-    const { view } = renderGeneralSection();
-
-    expect(getSelectTrigger(view, "Collapsed bash summaries").textContent).toContain(
-      "Intent and command"
-    );
-    await waitForArchiveSettingsLoad(view);
-  });
 
   test("renders the worktree archive behavior copy and loads the saved value", async () => {
     const { view } = renderGeneralSection({

--- a/src/browser/features/Settings/Sections/GeneralSection.tsx
+++ b/src/browser/features/Settings/Sections/GeneralSection.tsx
@@ -18,14 +18,10 @@ import {
   TERMINAL_FONT_CONFIG_KEY,
   DEFAULT_TERMINAL_FONT_CONFIG,
   LAUNCH_BEHAVIOR_KEY,
-  DEFAULT_TOOL_COLLAPSED_DISPLAY_MODE,
-  TOOL_COLLAPSED_DISPLAY_MODE_KEY,
-  isToolCollapsedDisplayMode,
   type EditorConfig,
   type EditorType,
   type LaunchBehavior,
   type TerminalFontConfig,
-  type ToolCollapsedDisplayMode,
 } from "@/common/constants/storage";
 import {
   appendTerminalIconFallback,
@@ -147,13 +143,6 @@ const LAUNCH_BEHAVIOR_OPTIONS = [
   { value: "new-chat", label: "New chat on recent project" },
   { value: "last-workspace", label: "Last visited workspace" },
 ] as const;
-const TOOL_COLLAPSED_DISPLAY_MODE_OPTIONS: Array<{
-  value: ToolCollapsedDisplayMode;
-  label: string;
-}> = [
-  { value: "command", label: "Command" },
-  { value: "intent-command", label: "Intent and command" },
-];
 const ARCHIVE_BEHAVIOR_OPTIONS = [
   { value: "keep", label: "Keep running" },
   { value: "stop", label: "Stop workspace" },
@@ -178,13 +167,6 @@ export function GeneralSection() {
     LAUNCH_BEHAVIOR_KEY,
     "dashboard"
   );
-  const [rawToolCollapsedDisplayMode, setToolCollapsedDisplayMode] = usePersistedState<unknown>(
-    TOOL_COLLAPSED_DISPLAY_MODE_KEY,
-    DEFAULT_TOOL_COLLAPSED_DISPLAY_MODE
-  );
-  const toolCollapsedDisplayMode = isToolCollapsedDisplayMode(rawToolCollapsedDisplayMode)
-    ? rawToolCollapsedDisplayMode
-    : DEFAULT_TOOL_COLLAPSED_DISPLAY_MODE;
   const [rawTerminalFontConfig, setTerminalFontConfig] = usePersistedState<TerminalFontConfig>(
     TERMINAL_FONT_CONFIG_KEY,
     DEFAULT_TERMINAL_FONT_CONFIG
@@ -421,12 +403,6 @@ export function GeneralSection() {
     setEditorConfig((prev) => ({ ...normalizeEditorConfig(prev), editor }));
   };
 
-  const handleToolCollapsedDisplayModeChange = (value: string) => {
-    if (isToolCollapsedDisplayMode(value)) {
-      setToolCollapsedDisplayMode(value);
-    }
-  };
-
   const handleTerminalFontFamilyChange = (fontFamily: string) => {
     setTerminalFontConfig((prev) => ({ ...normalizeTerminalFontConfig(prev), fontFamily }));
   };
@@ -518,31 +494,6 @@ export function GeneralSection() {
               </SelectTrigger>
               <SelectContent>
                 {LAUNCH_BEHAVIOR_OPTIONS.map((option) => (
-                  <SelectItem key={option.value} value={option.value}>
-                    {option.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="flex items-center justify-between gap-4">
-            <div className="flex-1">
-              <div className="text-foreground text-sm">Collapsed bash summaries</div>
-              <div className="text-muted text-xs">
-                Choose whether collapsed bash tools show the raw command or the model&apos;s intent
-                plus the command.
-              </div>
-            </div>
-            <Select
-              value={toolCollapsedDisplayMode}
-              onValueChange={handleToolCollapsedDisplayModeChange}
-            >
-              <SelectTrigger className="border-border-medium bg-background-secondary hover:bg-hover h-9 w-auto cursor-pointer rounded-md border px-3 text-sm transition-colors">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {TOOL_COLLAPSED_DISPLAY_MODE_OPTIONS.map((option) => (
                   <SelectItem key={option.value} value={option.value}>
                     {option.label}
                   </SelectItem>

--- a/src/browser/features/Tools/Bash/BashToolCall.stories.tsx
+++ b/src/browser/features/Tools/Bash/BashToolCall.stories.tsx
@@ -7,8 +7,6 @@ import { BashBackgroundTerminateToolCall } from "@/browser/features/Tools/BashBa
 import { BashOutputToolCall } from "@/browser/features/Tools/BashOutputToolCall";
 import { BashToolCall } from "@/browser/features/Tools/BashToolCall";
 import { lightweightMeta } from "@/browser/stories/meta.js";
-import { updatePersistedState } from "@/browser/hooks/usePersistedState";
-import { TOOL_COLLAPSED_DISPLAY_MODE_KEY } from "@/common/constants/storage";
 
 const meta = {
   ...lightweightMeta,
@@ -21,10 +19,6 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const STORYBOOK_WORKSPACE_ID = "storybook-bash";
-
-function setCollapsedDisplayMode(mode: "command" | "intent-command") {
-  updatePersistedState(TOOL_COLLAPSED_DISPLAY_MODE_KEY, mode);
-}
 
 function ToolStoryShell(props: { children: ReactNode }) {
   return (
@@ -92,34 +86,31 @@ export const WithTerminal: Story = {
   ),
 };
 
-/** collapsed bash header variants for command-only and intent-aware display modes */
+/** collapsed bash header showing intent on top and command on the second line */
 export const IntentCollapsedSummary: Story = {
-  render: () => {
-    setCollapsedDisplayMode("intent-command");
-    return (
-      <ToolStoryShell>
-        <BashToolCall
-          workspaceId={STORYBOOK_WORKSPACE_ID}
-          toolCallId="intent-summary"
-          args={{
-            script: "sleep 30 && tail -30 /tmp/develop.log",
-            model_intent:
-              "Waiting for the dev instance to start using sleep 30 && tail -30 /tmp/develop.log for 30.1s",
-            run_in_background: false,
-            timeout_secs: 120,
-            display_name: "Dev server readiness",
-          }}
-          result={{
-            success: true,
-            output: "VITE ready on the sandbox frontend. Backend health check passed.",
-            exitCode: 0,
-            wall_duration_ms: 30_100,
-          }}
-          status="completed"
-        />
-      </ToolStoryShell>
-    );
-  },
+  render: () => (
+    <ToolStoryShell>
+      <BashToolCall
+        workspaceId={STORYBOOK_WORKSPACE_ID}
+        toolCallId="intent-summary"
+        args={{
+          script: "sleep 30 && tail -30 /tmp/develop.log",
+          model_intent:
+            "Waiting for the dev instance to start using sleep 30 && tail -30 /tmp/develop.log for 30.1s",
+          run_in_background: false,
+          timeout_secs: 120,
+          display_name: "Dev server readiness",
+        }}
+        result={{
+          success: true,
+          output: "VITE ready on the sandbox frontend. Backend health check passed.",
+          exitCode: 0,
+          wall_duration_ms: 30_100,
+        }}
+        status="completed"
+      />
+    </ToolStoryShell>
+  ),
   play: async ({ canvasElement }) => {
     await waitFor(() => {
       const textContent = canvasElement.textContent ?? "";
@@ -127,10 +118,10 @@ export const IntentCollapsedSummary: Story = {
         throw new Error("Intent summary text should be visible");
       }
       if (!textContent.includes("sleep 30 && tail -30 /tmp/develop.log")) {
-        throw new Error("Raw command should stay visible in intent mode");
+        throw new Error("Raw command should stay visible alongside intent");
       }
       if (!textContent.includes("for 30.1s")) {
-        throw new Error("Completed duration should be visible outside the truncated intent");
+        throw new Error("Completed duration should be visible outside the intent text");
       }
       if (textContent.includes("timeout: 120s")) {
         throw new Error("Completed intent summaries should not repeat the timeout chip");
@@ -140,26 +131,23 @@ export const IntentCollapsedSummary: Story = {
 };
 
 export const IntentExecutingSummary: Story = {
-  render: () => {
-    setCollapsedDisplayMode("intent-command");
-    return (
-      <ToolStoryShell>
-        <BashToolCall
-          workspaceId={STORYBOOK_WORKSPACE_ID}
-          toolCallId="intent-executing-summary"
-          args={{
-            script: "sleep 30 && tail -30 /tmp/develop.log",
-            model_intent: "Waiting for the dev instance to start",
-            run_in_background: false,
-            timeout_secs: 120,
-            display_name: "Dev server readiness",
-          }}
-          status="executing"
-          startedAt={Date.now() - 1_000}
-        />
-      </ToolStoryShell>
-    );
-  },
+  render: () => (
+    <ToolStoryShell>
+      <BashToolCall
+        workspaceId={STORYBOOK_WORKSPACE_ID}
+        toolCallId="intent-executing-summary"
+        args={{
+          script: "sleep 30 && tail -30 /tmp/develop.log",
+          model_intent: "Waiting for the dev instance to start",
+          run_in_background: false,
+          timeout_secs: 120,
+          display_name: "Dev server readiness",
+        }}
+        status="executing"
+        startedAt={Date.now() - 1_000}
+      />
+    </ToolStoryShell>
+  ),
   play: async ({ canvasElement }) => {
     await waitFor(() => {
       const textContent = canvasElement.textContent ?? "";
@@ -176,46 +164,40 @@ export const IntentExecutingSummary: Story = {
   },
 };
 
-export const CommandCollapsedSummary: Story = {
-  render: () => {
-    setCollapsedDisplayMode("command");
-    return (
-      <ToolStoryShell>
-        <BashToolCall
-          workspaceId={STORYBOOK_WORKSPACE_ID}
-          toolCallId="command-summary"
-          args={{
-            script: "sleep 30 && tail -30 /tmp/develop.log",
-            model_intent: "Waiting for the dev instance to start",
-            run_in_background: false,
-            timeout_secs: 120,
-            display_name: "Dev server readiness",
-          }}
-          result={{
-            success: true,
-            output: "VITE ready on the sandbox frontend. Backend health check passed.",
-            exitCode: 0,
-            wall_duration_ms: 30_100,
-          }}
-          status="completed"
-        />
-      </ToolStoryShell>
-    );
-  },
+/** when the model omits `model_intent`, the collapsed row falls back to the bare command */
+export const NoIntentSummary: Story = {
+  render: () => (
+    <ToolStoryShell>
+      <BashToolCall
+        workspaceId={STORYBOOK_WORKSPACE_ID}
+        toolCallId="command-summary"
+        args={{
+          script: "sleep 30 && tail -30 /tmp/develop.log",
+          run_in_background: false,
+          timeout_secs: 120,
+          display_name: "Dev server readiness",
+        }}
+        result={{
+          success: true,
+          output: "VITE ready on the sandbox frontend. Backend health check passed.",
+          exitCode: 0,
+          wall_duration_ms: 30_100,
+        }}
+        status="completed"
+      />
+    </ToolStoryShell>
+  ),
   play: async ({ canvasElement }) => {
     await waitFor(() => {
       const textContent = canvasElement.textContent ?? "";
       if (!textContent.includes("sleep 30 && tail -30 /tmp/develop.log")) {
-        throw new Error("Raw command should be visible in command mode");
+        throw new Error("Raw command should be visible when intent is absent");
       }
       if (!textContent.includes("timeout: 120s")) {
-        throw new Error("Command mode should keep timeout metadata visible");
+        throw new Error("Command-only mode should keep timeout metadata visible");
       }
       if (!textContent.includes("took 30s")) {
-        throw new Error("Command mode should keep duration metadata visible");
-      }
-      if (textContent.includes("Waiting for the dev instance to start")) {
-        throw new Error("Command mode should not show model intent text");
+        throw new Error("Command-only mode should keep duration metadata visible");
       }
     });
   },

--- a/src/browser/features/Tools/BashToolCall.tsx
+++ b/src/browser/features/Tools/BashToolCall.tsx
@@ -24,11 +24,6 @@ import { useBashToolLiveOutput, useLatestStreamingBashId } from "@/browser/store
 import { useForegroundBashToolCallIds } from "@/browser/stores/BackgroundBashStore";
 import { useBackgroundBashActions } from "@/browser/contexts/BackgroundBashContext";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/browser/components/Tooltip/Tooltip";
-import { usePersistedState } from "@/browser/hooks/usePersistedState";
-import {
-  DEFAULT_TOOL_COLLAPSED_DISPLAY_MODE,
-  TOOL_COLLAPSED_DISPLAY_MODE_KEY,
-} from "@/common/constants/storage";
 import { buildBashCollapsedSummary } from "./bashCollapsedSummary";
 import { BackgroundBashOutputDialog } from "@/browser/components/BackgroundBashOutputDialog/BackgroundBashOutputDialog";
 
@@ -113,16 +108,10 @@ export const BashToolCall: React.FC<BashToolCallProps> = ({
     result && "backgroundProcessId" in result ? result.backgroundProcessId : null;
   const isBackground = args.run_in_background ?? Boolean(backgroundProcessId);
 
-  const [rawToolCollapsedDisplayMode] = usePersistedState<unknown>(
-    TOOL_COLLAPSED_DISPLAY_MODE_KEY,
-    DEFAULT_TOOL_COLLAPSED_DISPLAY_MODE,
-    { listener: true }
-  );
   const bashCollapsedSummary = buildBashCollapsedSummary({
     args,
     result,
     isBackground,
-    displayMode: rawToolCollapsedDisplayMode,
   });
   const isIntentCommandSummary = bashCollapsedSummary.kind === "intent-command";
 
@@ -169,10 +158,11 @@ export const BashToolCall: React.FC<BashToolCallProps> = ({
         <ExpandIcon expanded={expanded}>▶</ExpandIcon>
         <ToolIcon toolName="bash" />
         {bashCollapsedSummary.kind === "intent-command" ? (
-          <span className="text-text flex max-w-96 min-w-0 items-baseline gap-1">
-            <span className="max-w-48 min-w-0 truncate">{bashCollapsedSummary.intent}</span>
-            <span className="text-muted shrink-0">using</span>
-            <span className="font-monospace max-w-48 min-w-0 truncate">
+          // Two lines: intent (primary) on top, command (muted mono) below. Stacking
+          // lets users read both without truncating either down to ~48ch.
+          <span className="flex max-w-[28rem] min-w-0 flex-col leading-tight">
+            <span className="text-text truncate">{bashCollapsedSummary.intent}</span>
+            <span className="text-muted font-monospace truncate text-[10px]">
               {bashCollapsedSummary.command}
             </span>
           </span>
@@ -279,6 +269,14 @@ export const BashToolCall: React.FC<BashToolCallProps> = ({
 
       {expanded && (
         <ToolDetails>
+          {typeof args.model_intent === "string" && args.model_intent.trim().length > 0 && (
+            <DetailSection>
+              <DetailLabel>Intent</DetailLabel>
+              <DetailContent className="px-2 py-1.5 whitespace-pre-wrap">
+                {args.model_intent}
+              </DetailContent>
+            </DetailSection>
+          )}
           <DetailSection>
             <DetailLabel>Script</DetailLabel>
             <DetailContent className="px-2 py-1.5">{args.script}</DetailContent>

--- a/src/browser/features/Tools/BashToolCall.tsx
+++ b/src/browser/features/Tools/BashToolCall.tsx
@@ -158,38 +158,42 @@ export const BashToolCall: React.FC<BashToolCallProps> = ({
         <ExpandIcon expanded={expanded}>▶</ExpandIcon>
         <ToolIcon toolName="bash" />
         {bashCollapsedSummary.kind === "intent-command" ? (
-          // Two lines: intent (primary) on top, command (muted mono) below. Stacking
-          // lets users read both without truncating either down to ~48ch.
+          // Two lines: intent (primary) on top, command (muted mono) below.
+          // The duration chip sits on the command row so it inherits the same
+          // line-height and stays vertically centered on the command, not
+          // floating between the two lines.
           <span className="flex max-w-[28rem] min-w-0 flex-col leading-tight">
             <span className="text-text truncate">{bashCollapsedSummary.intent}</span>
-            <span className="text-muted font-monospace truncate text-[10px]">
-              {bashCollapsedSummary.command}
+            <span className="flex min-w-0 items-center gap-2">
+              <span className="text-muted font-monospace min-w-0 truncate text-[10px]">
+                {bashCollapsedSummary.command}
+              </span>
+              {!isBackground && (
+                <span
+                  className={cn(
+                    "shrink-0 text-[10px] tabular-nums whitespace-nowrap [@container(max-width:500px)]:hidden",
+                    isPending ? "text-pending" : "text-text-secondary"
+                  )}
+                >
+                  {bashCollapsedSummary.durationLabel ? (
+                    <>for {bashCollapsedSummary.durationLabel}</>
+                  ) : (
+                    <>
+                      timeout: {args.timeout_secs ?? BASH_DEFAULT_TIMEOUT_SECS}s
+                      <ElapsedTimeDisplay
+                        startedAt={startedAt}
+                        isActive={isPending}
+                        prefix="for "
+                      />
+                    </>
+                  )}
+                </span>
+              )}
             </span>
           </span>
         ) : (
           <span className="text-text font-monospace max-w-96 truncate">
             {bashCollapsedSummary.command}
-          </span>
-        )}
-        {!isBackground && isIntentCommandSummary && (
-          // align-self: last baseline matches this chip's baseline against the
-          // *last* baseline in the flex row — i.e. the command line of the
-          // stacked block — so "for 30.1s" sits visually next to the bash
-          // command (which it describes), not floating between the two lines.
-          <span
-            className={cn(
-              "ml-2 text-[10px] tabular-nums whitespace-nowrap [align-self:last_baseline] [@container(max-width:500px)]:hidden",
-              isPending ? "text-pending" : "text-text-secondary"
-            )}
-          >
-            {bashCollapsedSummary.durationLabel ? (
-              <>for {bashCollapsedSummary.durationLabel}</>
-            ) : (
-              <>
-                timeout: {args.timeout_secs ?? BASH_DEFAULT_TIMEOUT_SECS}s
-                <ElapsedTimeDisplay startedAt={startedAt} isActive={isPending} prefix="for " />
-              </>
-            )}
           </span>
         )}
         {isBackground && backgroundProcessId && workspaceId && (

--- a/src/browser/features/Tools/BashToolCall.tsx
+++ b/src/browser/features/Tools/BashToolCall.tsx
@@ -172,9 +172,11 @@ export const BashToolCall: React.FC<BashToolCallProps> = ({
           </span>
         )}
         {!isBackground && isIntentCommandSummary && (
+          // Anchor the duration/timeout chip to the bottom of the flex row so it
+          // sits next to the command line (which it describes), not floating mid-block.
           <span
             className={cn(
-              "ml-2 text-[10px] tabular-nums whitespace-nowrap [@container(max-width:500px)]:hidden",
+              "ml-2 self-end pb-px text-[10px] tabular-nums whitespace-nowrap [@container(max-width:500px)]:hidden",
               isPending ? "text-pending" : "text-text-secondary"
             )}
           >

--- a/src/browser/features/Tools/BashToolCall.tsx
+++ b/src/browser/features/Tools/BashToolCall.tsx
@@ -172,11 +172,13 @@ export const BashToolCall: React.FC<BashToolCallProps> = ({
           </span>
         )}
         {!isBackground && isIntentCommandSummary && (
-          // Anchor the duration/timeout chip to the bottom of the flex row so it
-          // sits next to the command line (which it describes), not floating mid-block.
+          // align-self: last baseline matches this chip's baseline against the
+          // *last* baseline in the flex row — i.e. the command line of the
+          // stacked block — so "for 30.1s" sits visually next to the bash
+          // command (which it describes), not floating between the two lines.
           <span
             className={cn(
-              "ml-2 self-end pb-px text-[10px] tabular-nums whitespace-nowrap [@container(max-width:500px)]:hidden",
+              "ml-2 text-[10px] tabular-nums whitespace-nowrap [align-self:last_baseline] [@container(max-width:500px)]:hidden",
               isPending ? "text-pending" : "text-text-secondary"
             )}
           >

--- a/src/browser/features/Tools/bashCollapsedSummary.test.ts
+++ b/src/browser/features/Tools/bashCollapsedSummary.test.ts
@@ -23,40 +23,12 @@ const completedResult: BashToolResult = {
 };
 
 describe("buildBashCollapsedSummary", () => {
-  test("returns the legacy command summary in command mode", () => {
-    expect(
-      buildBashCollapsedSummary({
-        args: createArgs({ model_intent: "Waiting for the dev instance to start" }),
-        result: completedResult,
-        isBackground: false,
-        displayMode: "command",
-      })
-    ).toEqual({ kind: "command", command });
-  });
-
-  test("falls back to the default summary mode for invalid display mode values", () => {
-    expect(
-      buildBashCollapsedSummary({
-        args: createArgs({ model_intent: "Waiting for the dev instance to start" }),
-        result: completedResult,
-        isBackground: false,
-        displayMode: "invalid",
-      })
-    ).toEqual({
-      kind: "intent-command",
-      intent: "Waiting for the dev instance to start",
-      command,
-      durationLabel: "30.1s",
-    });
-  });
-
-  test("returns intent, command, and completed duration in intent-command mode", () => {
+  test("returns intent, command, and completed duration when intent is present", () => {
     expect(
       buildBashCollapsedSummary({
         args: createArgs({ model_intent: "waiting for the dev instance to start" }),
         result: completedResult,
         isBackground: false,
-        displayMode: "intent-command",
       })
     ).toEqual({
       kind: "intent-command",
@@ -71,7 +43,6 @@ describe("buildBashCollapsedSummary", () => {
       buildBashCollapsedSummary({
         args: createArgs(),
         isBackground: false,
-        displayMode: "intent-command",
       })
     ).toEqual({ kind: "command", command });
 
@@ -79,7 +50,6 @@ describe("buildBashCollapsedSummary", () => {
       buildBashCollapsedSummary({
         args: createArgs({ model_intent: "   " }),
         isBackground: false,
-        displayMode: "intent-command",
       })
     ).toEqual({ kind: "command", command });
 
@@ -87,7 +57,6 @@ describe("buildBashCollapsedSummary", () => {
       buildBashCollapsedSummary({
         args: createArgs({ model_intent: null }),
         isBackground: false,
-        displayMode: "intent-command",
       })
     ).toEqual({ kind: "command", command });
 
@@ -95,7 +64,6 @@ describe("buildBashCollapsedSummary", () => {
       buildBashCollapsedSummary({
         args: createArgs({ model_intent: command.toUpperCase() }),
         isBackground: false,
-        displayMode: "intent-command",
       })
     ).toEqual({ kind: "command", command });
   });
@@ -113,7 +81,6 @@ describe("buildBashCollapsedSummary", () => {
           backgroundProcessId: "proc-1",
         },
         isBackground: true,
-        displayMode: "intent-command",
       })
     ).toEqual({
       kind: "intent-command",

--- a/src/browser/features/Tools/bashCollapsedSummary.ts
+++ b/src/browser/features/Tools/bashCollapsedSummary.ts
@@ -1,8 +1,4 @@
 import type { BashToolArgs, BashToolResult } from "@/common/types/tools";
-import {
-  DEFAULT_TOOL_COLLAPSED_DISPLAY_MODE,
-  isToolCollapsedDisplayMode,
-} from "@/common/constants/storage";
 import { capitalize } from "@/common/utils/capitalize";
 import { formatDuration } from "@/common/utils/formatDuration";
 
@@ -14,7 +10,6 @@ interface BuildBashCollapsedSummaryOptions {
   args: BashToolArgs;
   result?: BashToolResult;
   isBackground: boolean;
-  displayMode: unknown;
 }
 
 const DURATION_TOKEN_PATTERN = String.raw`\d+(?:\.\d+)?\s*(?:ms|milliseconds?|s|secs?|seconds?|m|mins?|minutes?|h|hrs?|hours?)`;
@@ -31,13 +26,6 @@ export function buildBashCollapsedSummary(
   options: BuildBashCollapsedSummaryOptions
 ): BashCollapsedSummary {
   const command = typeof options.args.script === "string" ? options.args.script : "";
-  const displayMode = isToolCollapsedDisplayMode(options.displayMode)
-    ? options.displayMode
-    : DEFAULT_TOOL_COLLAPSED_DISPLAY_MODE;
-
-  if (displayMode === "command") {
-    return { kind: "command", command };
-  }
 
   const intent = sanitizeModelIntent(options.args.model_intent, command);
   if (!intent || normalizeForComparison(intent) === normalizeForComparison(command)) {

--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -83,19 +83,6 @@ export const LAUNCH_BEHAVIOR_KEY = "launchBehavior";
 export type LaunchBehavior = "dashboard" | "new-chat" | "last-workspace";
 
 /**
- * User preference for collapsed bash tool summaries (global).
- */
-export const TOOL_COLLAPSED_DISPLAY_MODE_KEY = "toolCollapsedDisplayMode";
-
-export type ToolCollapsedDisplayMode = "command" | "intent-command";
-
-export const DEFAULT_TOOL_COLLAPSED_DISPLAY_MODE: ToolCollapsedDisplayMode = "intent-command";
-
-export function isToolCollapsedDisplayMode(value: unknown): value is ToolCollapsedDisplayMode {
-  return value === "command" || value === "intent-command";
-}
-
-/**
  * Get the localStorage key for expanded projects in sidebar (global)
  * Format: "expandedProjects"
  */


### PR DESCRIPTION
## Summary

Replaces the inline "intent **using** command" header that #3337 introduced with a stacked two-line collapsed bash summary (intent on top, command below), surfaces the intent in the expanded details, and removes the **Collapsed bash summaries** General setting so the experience is consistent for everyone.

## Background

`model_intent` was added in #3337 to give scannable context for long-running bash calls, but the collapsed header rendered intent + command as a single inline row joined by the word "using". Both halves were truncated to ~48ch and the connector pushed real content off-screen. The behavior was also gated behind a General-section toggle, which added configuration surface without a strong reason to keep both modes around.

This PR keeps the underlying `model_intent` tool field and the sanitizer intact — it only changes how the value is presented and removes the toggle.

## Implementation

- `BashToolCall.tsx`: collapsed intent-command rows now render a stacked block — primary intent on top, muted mono `command` (10px) beneath — inside a `max-w-[28rem]` container, so both lines truncate independently. Right-side duration/status chips stay vertically centered next to the block. When `model_intent` is absent or equals the command, the single-line mono command renders as before.
- `BashToolCall.tsx` expanded view: when `model_intent` is a non-blank string, a new `Intent` `DetailSection` renders above `Script` using `whitespace-pre-wrap` so longer intents wrap cleanly.
- `bashCollapsedSummary.ts`: dropped the `displayMode` parameter; the helper now always attempts the intent-command summary and falls back to the command kind when intent is missing/blank/equal-to-command. Sanitization logic is unchanged.
- `common/constants/storage.ts`: removed `TOOL_COLLAPSED_DISPLAY_MODE_KEY`, `ToolCollapsedDisplayMode`, `DEFAULT_TOOL_COLLAPSED_DISPLAY_MODE`, and `isToolCollapsedDisplayMode`.
- `GeneralSection.tsx`: removed the Collapsed bash summaries select, its options table, change handler, persisted-state hook, and corresponding imports.
- Tests: dropped the two display-mode tests and the orphan `waitForArchiveSettingsLoad` helper from `GeneralSection.test.tsx`; refreshed `bashCollapsedSummary.test.ts` to the new signature. `BashToolCall.stories.tsx`: removed the `setCollapsedDisplayMode` helper and renamed `CommandCollapsedSummary` → `NoIntentSummary` (model omits `model_intent`) to still exercise the command-only fallback.

## Validation

- `bun test src/browser/features/Tools/bashCollapsedSummary.test.ts` ✅
- `bun test src/browser/features/Settings/Sections/GeneralSection.test.tsx` ✅
- `bun test src/browser/features/Tools/ src/browser/features/Settings/ src/common/constants/` ✅
- `make typecheck` ✅
- `make lint` ✅
- `make static-check` ✅

## Risks

Low. Surface area is limited to bash tool call rendering, one removed General setting, and a few storage exports nothing else consumes (verified via repo-wide grep). Stale `toolCollapsedDisplayMode` localStorage values are simply ignored on the next load. No backend or IPC changes.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `xhigh` • Cost: `$6.53`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=xhigh costs=6.53 -->
