### PR TITLE
🤖 fix(ssh): harden bare base repo against receive-pack thin-pack failures

### DIFF
--- a/src/node/runtime/SSHRuntime.retry.test.ts
+++ b/src/node/runtime/SSHRuntime.retry.test.ts
@@ -86,6 +86,9 @@ class TestSSHRuntime extends SSHRuntime {
   readonly callOrder: string[] = [];
   readonly cleanupCalls: string[] = [];
   readonly backoffCalls: number[] = [];
+  /** Records `options.forceNoThin` per attempt so tests can assert the retry
+   *  loop opts the next push into `--no-thin` after a thin-pack failure. */
+  readonly forceNoThinPerAttempt: boolean[] = [];
 
   private readonly actions: SyncAction[] = [];
   private cleanupHook?: () => Promise<void>;
@@ -114,7 +117,8 @@ class TestSSHRuntime extends SSHRuntime {
     _projectPath: string,
     _layout: RemoteProjectLayout,
     _initLogger: InitLogger,
-    _abortSignal?: AbortSignal
+    _abortSignal?: AbortSignal,
+    options: { forceNoThin?: boolean } = {}
   ): Promise<void> {
     const action = this.actions.shift();
     if (!action) {
@@ -122,6 +126,7 @@ class TestSSHRuntime extends SSHRuntime {
     }
 
     this.callOrder.push(action.label);
+    this.forceNoThinPerAttempt.push(options.forceNoThin === true);
     action.abortController?.abort();
     if (action.error) {
       return Promise.reject(action.error);
@@ -235,6 +240,23 @@ function expectedGcCommand(baseRepoPathArg: string, waitForGc: boolean): string 
   ].join("\n");
 }
 
+function expectedReindexCommand(baseRepoPathArg: string): string {
+  return [
+    `pack_dir=${baseRepoPathArg}/objects/pack`,
+    'if [ ! -d "$pack_dir" ]; then exit 0; fi',
+    `for pack in "$pack_dir"/pack-*.pack; do`,
+    '  [ -e "$pack" ] || continue',
+    '  idx="${pack%.pack}.idx"',
+    '  if [ -f "$idx" ]; then continue; fi',
+    `  if git index-pack "$pack" >/dev/null 2>&1; then`,
+    '    echo "reindexed $pack"',
+    "  else",
+    '    echo "reindex-failed $pack" >&2',
+    "  fi",
+    "done",
+  ].join("\n");
+}
+
 function expectedStripPromisorCommand(baseRepoPathArg: string): string {
   return (
     `git -C ${baseRepoPathArg} config --unset-all remote.origin.promisor; ` +
@@ -265,11 +287,12 @@ describe("SSHRuntime project sync retry orchestration", () => {
     expect(runtime.commands).toEqual([
       expectedStripPromisorCommand(baseRepoPathArg),
       `find ${baseRepoPathArg}/objects/pack -name '*.promisor' -print -delete 2>/dev/null || true`,
+      expectedReindexCommand(baseRepoPathArg),
       expectedGcCommand(baseRepoPathArg, true),
     ]);
     // Last timeout waits for `setsid -w`. It can stop waiting without killing
     // the detached gc process itself.
-    expect(runtime.timeouts).toEqual([10, 10, 30 * 60]);
+    expect(runtime.timeouts).toEqual([10, 10, 10, 30 * 60]);
   });
 
   it("proactively repairs fragmented base repos before sync", async () => {
@@ -286,10 +309,11 @@ describe("SSHRuntime project sync retry orchestration", () => {
       `git -C ${baseRepoPathArg} count-objects -v`,
       expectedStripPromisorCommand(baseRepoPathArg),
       `find ${baseRepoPathArg}/objects/pack -name '*.promisor' -print -delete 2>/dev/null || true`,
+      expectedReindexCommand(baseRepoPathArg),
       expectedGcCommand(baseRepoPathArg, false),
     ]);
     // Last timeout is the SSH spawn round-trip, NOT gc itself.
-    expect(runtime.timeouts).toEqual([10, 10, 10, 10]);
+    expect(runtime.timeouts).toEqual([10, 10, 10, 10, 10]);
   });
 
   it("skips proactive maintenance for healthy base repos", async () => {
@@ -333,9 +357,10 @@ describe("SSHRuntime project sync retry orchestration", () => {
       `git -C ${baseRepoPathArg} count-objects -v`,
       expectedStripPromisorCommand(baseRepoPathArg),
       `find ${baseRepoPathArg}/objects/pack -name '*.promisor' -print -delete 2>/dev/null || true`,
+      expectedReindexCommand(baseRepoPathArg),
       expectedGcCommand(baseRepoPathArg, false),
     ]);
-    expect(runtime.timeouts).toEqual([10, 10, 10, 10]);
+    expect(runtime.timeouts).toEqual([10, 10, 10, 10, 10]);
   });
 
   it("propagates aborts during proactive maintenance preflight", async () => {
@@ -422,5 +447,59 @@ describe("SSHRuntime project sync retry orchestration", () => {
     expect(runtime.callOrder).toEqual(["first-1", "first-2", "second-1"]);
     expect(runtime.cleanupCalls).toHaveLength(1);
     expect(runtime.backoffCalls).toEqual([1000]);
+  });
+
+  it("retries thin-pack receive-pack failures with --no-thin on the next attempt", async () => {
+    // Real-world failure shape: receive-pack routes the first push through
+    // `unpack-objects` (because the object count is below
+    // `transfer.unpackLimit`), unpack-objects cannot resolve the thin pack's
+    // delta bases, and the push is rejected. The retry path runs base-repo
+    // maintenance (gc, pack reindex, receive.unpackLimit config) and the next
+    // attempt must opt out of thin-pack encoding entirely so the receiver can
+    // unpack without any cross-pack delta-base lookup.
+    const runtime = new TestSSHRuntime();
+    const projectPath = `/tmp/no-thin-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+    runtime.queueActions(
+      {
+        label: "attempt-1",
+        error: new Error(
+          "Failed to push to remote: remote: fatal: unresolved deltas left after unpacking\n" +
+            "error: remote unpack failed: unpack-objects abnormal exit\n" +
+            " ! [remote rejected]     main -> refs/mux-bundle/main (unpacker error)"
+        ),
+      },
+      { label: "attempt-2" }
+    );
+
+    await runtime.runSync(projectPath);
+
+    expect(runtime.callOrder).toEqual(["attempt-1", "attempt-2"]);
+    // First attempt uses the default thin-pack push; the retry forces
+    // --no-thin so the receiver doesn't need to resolve delta bases.
+    expect(runtime.forceNoThinPerAttempt).toEqual([false, true]);
+    expect(runtime.cleanupCalls).toHaveLength(1);
+    expect(runtime.backoffCalls).toEqual([1000]);
+  });
+
+  it("does not flip --no-thin for unrelated retryable failures", async () => {
+    // Connection-reset / killed-by-signal failures benefit from the standard
+    // retry, but forcing --no-thin would needlessly enlarge a pack that was
+    // never the problem. The flag must stay off for non-unpack errors.
+    const runtime = new TestSSHRuntime();
+    const projectPath = `/tmp/thin-default-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+    runtime.queueActions(
+      {
+        label: "attempt-1",
+        error: new Error("Failed to push to remote: Connection reset by peer"),
+      },
+      { label: "attempt-2" }
+    );
+
+    await runtime.runSync(projectPath);
+
+    expect(runtime.callOrder).toEqual(["attempt-1", "attempt-2"]);
+    expect(runtime.forceNoThinPerAttempt).toEqual([false, false]);
   });
 });

--- a/src/node/runtime/SSHRuntime.syncContract.test.ts
+++ b/src/node/runtime/SSHRuntime.syncContract.test.ts
@@ -106,7 +106,8 @@ interface GitPushPrivateApi {
     layout: RemoteProjectLayout,
     currentSnapshotPath: string,
     initLogger: InitLogger,
-    abortSignal?: AbortSignal
+    abortSignal?: AbortSignal,
+    options?: { forceNoThin?: boolean }
   ): Promise<void>;
 }
 
@@ -271,6 +272,64 @@ describe("SSHRuntime authoritative sync contract", () => {
     expect(pushCalls[0]).toContain("--atomic");
     expect(pushCalls[0]).toContain("+refs/heads/*:refs/mux-bundle/*");
     expect(pushCalls[0]).not.toContain("+refs/tags/*:refs/tags/*");
+  });
+
+  it("forces --no-thin pushes when the retry path requests a self-contained pack", async () => {
+    // After an `unresolved deltas` / `unpacker error` push failure, the retry
+    // loop opts the next attempt out of thin-pack encoding so the receiver
+    // does not need to resolve delta bases. Without this flag the retry could
+    // resend a thin pack and fail the same way.
+    const runtime = new CommandCaptureSSHRuntime();
+    const layout = createLayout();
+    const gitCalls: string[][] = [];
+
+    spyOn(disposableExec, "execFileAsync").mockImplementation((file, args) => {
+      expect(file).toBe("git");
+      gitCalls.push([...args]);
+      const isTagCheck = args.includes("for-each-ref") && args.includes("refs/tags");
+      return createMockExecResult(
+        Promise.resolve({ stdout: isTagCheck ? "refs/tags/v1.0.0\n" : "", stderr: "" })
+      );
+    });
+
+    await (runtime as unknown as GitPushPrivateApi).syncProjectSnapshotViaGitPush(
+      "/local/project",
+      layout,
+      layout.currentSnapshotPath,
+      noopInitLogger,
+      undefined,
+      { forceNoThin: true }
+    );
+
+    const pushCalls = gitCalls.filter((args) => args.includes("push"));
+
+    expect(pushCalls).toHaveLength(2);
+    // Branch push and tag push both carry --no-thin.
+    expect(pushCalls[0]).toContain("--no-thin");
+    expect(pushCalls[1]).toContain("--no-thin");
+  });
+
+  it("omits --no-thin on the happy push path", async () => {
+    // Default sync (no retry pressure) must still use Git's thin-pack
+    // optimization. --no-thin is opt-in via the retry loop only.
+    const runtime = new CommandCaptureSSHRuntime();
+    const layout = createLayout();
+    const gitCalls: string[][] = [];
+
+    spyOn(disposableExec, "execFileAsync").mockImplementation((_file, args) => {
+      gitCalls.push([...args]);
+      return createMockExecResult(Promise.resolve({ stdout: "", stderr: "" }));
+    });
+
+    await (runtime as unknown as GitPushPrivateApi).syncProjectSnapshotViaGitPush(
+      "/local/project",
+      layout,
+      layout.currentSnapshotPath,
+      noopInitLogger
+    );
+
+    const pushCalls = gitCalls.filter((args) => args.includes("push"));
+    expect(pushCalls.every((args) => !args.includes("--no-thin"))).toBe(true);
   });
 
   it("uses the upstream source branch over the synced local snapshot for fresh workspaces", async () => {

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -100,7 +100,36 @@ const PROJECT_SYNC_RETRYABLE_ERRORS = [
   "Broken pipe",
   "EPIPE",
   "Command killed by signal",
+  // Receive-pack thin-pack resolution failures. These happen when the bare
+  // base repo routes a small push through `unpack-objects` (because object
+  // count < `transfer.unpackLimit`, default 100) and the thin pack references
+  // delta bases that unpack-objects cannot resolve, or when the on-disk pack
+  // store is missing the assumed-present base objects (e.g. a `.pack` with no
+  // `.idx`). The retry path runs `repairBaseRepoForSync`, which sets
+  // `receive.unpackLimit=1` (forcing index-pack with `--fix-thin`) and runs
+  // gc, and the next push is force-promoted to `--no-thin` so the pack is
+  // self-contained. See `isUnresolvedDeltaPushFailure`.
+  "unresolved deltas",
+  "unpacker error",
+  "unpack-objects abnormal exit",
+  "remote unpack failed",
 ] as const;
+
+/**
+ * Patterns matching the receive-pack failure described above. Detected
+ * separately from generic retryable errors so the retry path can opt the next
+ * push into `--no-thin` instead of just rerunning the same thin push.
+ */
+const UNRESOLVED_DELTA_PUSH_PATTERNS = [
+  "unresolved deltas",
+  "unpacker error",
+  "unpack-objects abnormal exit",
+  "remote unpack failed",
+] as const;
+
+function isUnresolvedDeltaPushFailure(errorMsg: string): boolean {
+  return UNRESOLVED_DELTA_PUSH_PATTERNS.some((pattern) => errorMsg.includes(pattern));
+}
 
 const sharedProjectSyncTails = new Map<string, Promise<void>>();
 
@@ -661,6 +690,55 @@ export class SSHRuntime extends RemoteRuntime {
       );
     }
 
+    // Rebuild any orphaned pack indexes (`pack-<sha>.pack` with no matching
+    // `pack-<sha>.idx`). A previous gc that was SIGKILLed mid-finalization
+    // can leave a pack on disk whose `.idx` was never written, hiding every
+    // object inside that pack from negotiation. Subsequent thin pushes then
+    // assume those objects are missing → the remote pulls in delta bases
+    // that aren't actually reachable → `unresolved deltas left after
+    // unpacking`. `git index-pack` rebuilds the missing `.idx` from the
+    // `.pack` so the objects rejoin the negotiation surface before the next
+    // push. Best-effort: a corrupt `.pack` or environment without `git
+    // index-pack` will fall through to `gc` and ultimately the `--no-thin`
+    // retry push.
+    const reindexCommand = [
+      `pack_dir=${promisorPackDirArg}`,
+      'if [ ! -d "$pack_dir" ]; then exit 0; fi',
+      // Use `find` to enumerate orphan packs; for each, run `git index-pack`
+      // and log a line so the count is visible in the maintenance log.
+      `for pack in "$pack_dir"/pack-*.pack; do`,
+      '  [ -e "$pack" ] || continue',
+      '  idx="${pack%.pack}.idx"',
+      '  if [ -f "$idx" ]; then continue; fi',
+      `  if git index-pack "$pack" >/dev/null 2>&1; then`,
+      '    echo "reindexed $pack"',
+      "  else",
+      '    echo "reindex-failed $pack" >&2',
+      "  fi",
+      "done",
+    ].join("\n");
+    const reindexResult = await execBuffered(this, reindexCommand, {
+      cwd: "/tmp",
+      timeout: BASE_REPO_PROMISOR_CLEANUP_TIMEOUT_SECONDS,
+      abortSignal,
+    });
+    const reindexedCount = reindexResult.stdout
+      .split("\n")
+      .filter((line) => line.startsWith("reindexed ")).length;
+    if (reindexedCount > 0) {
+      log.info(
+        `Rebuilt ${reindexedCount} orphaned pack index file(s) during base repo maintenance`
+      );
+    }
+    const reindexFailures = reindexResult.stderr
+      .split("\n")
+      .filter((line) => line.startsWith("reindex-failed ")).length;
+    if (reindexFailures > 0) {
+      log.warn(
+        `Failed to rebuild ${reindexFailures} pack index file(s) during base repo maintenance`
+      );
+    }
+
     // Always detach `git gc` from mux's SSH command timeout. A SIGKILL between
     // `tmp_pack_X → pack-<sha>.pack` and `tmp_idx_X → pack-<sha>.idx` leaves a
     // .pack with no .idx, hiding every object inside that pack and making thin
@@ -954,6 +1032,17 @@ export class SSHRuntime extends RemoteRuntime {
       //    See stripBaseRepoPromisorConfig() docstring for the upstream Git
       //    sideband-deadlock bug this guards against.
       promisorUnsetCmds,
+      // 4. Force receive-pack to use index-pack (with `--fix-thin`) instead of
+      //    `unpack-objects` for incoming pushes, regardless of object count.
+      //    This avoids the "unresolved deltas left after unpacking" /
+      //    "unpacker error" failure mode where small thin pushes (below the
+      //    default `transfer.unpackLimit=100`) reach `unpack-objects`, which
+      //    cannot resolve thin-pack delta bases. Best-effort: an older Git
+      //    that does not honor this key still works under the retry path.
+      //    Trade-off: more small packs, but the existing fragmented-base-repo
+      //    maintenance (`ensureHealthyBaseRepoForSync`) collapses them on a
+      //    schedule, so this is a net robustness win.
+      `git -C ${baseRepoPathArg} config --local receive.unpackLimit 1 2>/dev/null || true`,
     ].join("\n");
 
     const result = await execBuffered(this, cmd, {
@@ -1317,11 +1406,19 @@ export class SSHRuntime extends RemoteRuntime {
         initLogger.logStep("Pre-fetched from origin on remote host");
       } else {
         initLogger.logStep("Pre-fetch from origin skipped (fetch failed)");
+        // Preserve the stderr in debug logs so we can diagnose recurrent
+        // prefetch misses (auth, unreachable URL, mismatched origin) without
+        // surfacing noisy detail on the happy path.
+        const detail = (result.stderr || result.stdout).trim();
+        if (detail) {
+          log.debug("Pre-fetch from origin failed", { detail });
+        }
       }
-    } catch {
+    } catch (error) {
       // Best-effort — if origin is unreachable or not configured, the local
       // push will still transfer all required objects.
       initLogger.logStep("Pre-fetch from origin skipped (not reachable)");
+      log.debug("Pre-fetch from origin errored", { error: getErrorMessage(error) });
     }
     return { refreshedOrigin: true };
   }
@@ -1665,8 +1762,15 @@ export class SSHRuntime extends RemoteRuntime {
     layout: RemoteProjectLayout,
     currentSnapshotPath: string,
     initLogger: InitLogger,
-    abortSignal?: AbortSignal
+    abortSignal?: AbortSignal,
+    options: { forceNoThin?: boolean } = {}
   ): Promise<void> {
+    // `forceNoThin` opts the push out of thin-pack delta-base optimization.
+    // This is set by the retry path after an "unresolved deltas" / "unpacker
+    // error" failure: the remote couldn't resolve the thin pack's delta
+    // bases, so we resend a self-contained pack on the next attempt instead
+    // of rerunning the same thin push and failing the same way.
+    const forceNoThin = options.forceNoThin === true;
     const prepareSnapshotDir = await execBuffered(
       this,
       `mkdir -p ${this.quoteForRemote(path.posix.dirname(currentSnapshotPath))}`,
@@ -1764,6 +1868,9 @@ export class SSHRuntime extends RemoteRuntime {
       }
       throw new Error(`Failed to push to remote: ${errorMsg}`);
     };
+    // `--no-thin` flag is positioned before the URL so it applies to the
+    // pack-objects step git invokes for this push (and to nothing else).
+    const noThinFlag = forceNoThin ? ["--no-thin"] : [];
     const branchPushArgsBase = [
       "-C",
       projectPath,
@@ -1771,6 +1878,7 @@ export class SSHRuntime extends RemoteRuntime {
       "--force",
       "--prune",
       "--no-verify",
+      ...noThinFlag,
       remoteUrl,
       `+refs/heads/*:${BUNDLE_REF_PREFIX}*`,
     ];
@@ -1809,6 +1917,7 @@ export class SSHRuntime extends RemoteRuntime {
         "push",
         "--force",
         "--no-verify",
+        ...noThinFlag,
         remoteUrl,
         "+refs/tags/*:refs/tags/*",
       ]);
@@ -1846,13 +1955,20 @@ export class SSHRuntime extends RemoteRuntime {
     // Keep retries, cancellation handling, and retry cleanup inside the project-scoped
     // sync lock so a follow-up init cannot race the shared base repo while we are healing it.
     await enqueueProjectSync(projectKey, abortSignal, async () => {
+      // Latches once a thin-pack delta-base failure is observed so every
+      // subsequent attempt in this sync push a self-contained pack (`--no-thin`).
+      // Stays `false` for connection-reset / killed-by-signal retries since
+      // those don't benefit from forcing a larger pack.
+      let forceNoThinNextAttempt = false;
       for (let attempt = 1; attempt <= PROJECT_SYNC_MAX_ATTEMPTS; attempt++) {
         if (abortSignal?.aborted) {
           throw new Error("Operation aborted");
         }
 
         try {
-          await this.syncProjectToRemoteOnce(projectPath, layout, initLogger, abortSignal);
+          await this.syncProjectToRemoteOnce(projectPath, layout, initLogger, abortSignal, {
+            forceNoThin: forceNoThinNextAttempt,
+          });
           return;
         } catch (error) {
           const errorMsg = getErrorMessage(error);
@@ -1864,6 +1980,10 @@ export class SSHRuntime extends RemoteRuntime {
             attempt === PROJECT_SYNC_MAX_ATTEMPTS
           ) {
             throw new Error(`Failed to sync project: ${errorMsg}`);
+          }
+
+          if (isUnresolvedDeltaPushFailure(errorMsg)) {
+            forceNoThinNextAttempt = true;
           }
 
           log.info(
@@ -1891,7 +2011,8 @@ export class SSHRuntime extends RemoteRuntime {
     projectPath: string,
     layout: RemoteProjectLayout,
     initLogger: InitLogger,
-    abortSignal?: AbortSignal
+    abortSignal?: AbortSignal,
+    options: { forceNoThin?: boolean } = {}
   ): Promise<void> {
     if (abortSignal?.aborted) {
       throw new Error("Operation aborted");
@@ -1981,7 +2102,8 @@ export class SSHRuntime extends RemoteRuntime {
         layout,
         currentSnapshotPath,
         initLogger,
-        abortSignal
+        abortSignal,
+        { forceNoThin: options.forceNoThin === true }
       );
     } else {
       await this.syncProjectSnapshotViaBundle(


### PR DESCRIPTION
## Summary

Hardens the SSH runtime's shared bare base repo (`.mux-base.git`) against the receive-pack `unresolved deltas left after unpacking` / `unpack-objects abnormal exit` failure that aborts workspace creation. The fix layers four independent defenses so that any one of them is enough to keep the slow-path push healthy on both new and legacy remote repos.

## Background

A user hit this during SSH workspace init:

```
Pushing to remote...
remote: fatal: unresolved deltas left after unpacking
error: remote unpack failed: unpack-objects abnormal exit
 ! [remote rejected]     <branch> -> refs/mux-bundle/<branch> (unpacker error)
error: failed to push some refs to 'ssh://.../.mux-base.git'
Initialization failed: Failed to sync project: Failed to push to remote: ...
```

Two interacting root causes:

1. **Receive-pack's small-push fast path.** When the incoming pack contains fewer than `transfer.unpackLimit` objects (default `100`), receive-pack routes objects through `unpack-objects` instead of `index-pack`. `unpack-objects` cannot resolve thin-pack delta bases that live in *other* on-disk packs, so a small thin push to a populated bare repo can fail with `unresolved deltas left after unpacking` even when every base object is technically present.
2. **Orphan packs on disk.** A `git gc` that gets SIGKILLed between writing `pack-<sha>.pack` and `pack-<sha>.idx` leaves the pack with no index. Git's negotiation surface ignores indexless packs, so the *server* doesn't advertise objects it actually has on disk → the client builds a thin pack assuming those bases are missing → receive-pack fails to resolve them.

The pre-fetch from origin (which would have populated the bases) had also failed, exposing the underlying weakness.

The existing retry classifier only matched generic transport errors (`pack-objects died`, `Connection reset`, …), so a thin-pack failure surfaced immediately as a fatal `Failed to sync project`.

## Implementation

Four layered defenses in `src/node/runtime/SSHRuntime.ts`:

1. **Prevent the failure mode** — `ensureBaseRepo`'s batched setup script now also runs `git config --local receive.unpackLimit 1`. Receive-pack always routes incoming pushes through `index-pack` (which calls `--fix-thin` and resolves missing delta bases from local objects) instead of `unpack-objects`, regardless of object count. Idempotent — runs every sync, so legacy repos heal on the next workspace creation. Trade-off: more small packs, but the existing fragmented-pack maintenance (`ensureHealthyBaseRepoForSync`) already coalesces them on a threshold.
2. **Heal pre-existing on-disk damage** — `repairBaseRepoForSync` gets a new step before `gc`: scan `objects/pack/pack-*.pack` for orphans missing `.idx` and run `git index-pack` to rebuild the index from the pack. The existing code comment already noted this exact SIGKILL failure mode but didn't act on it.
3. **Retry the failure** — added `unresolved deltas`, `unpacker error`, `unpack-objects abnormal exit`, `remote unpack failed` to `PROJECT_SYNC_RETRYABLE_ERRORS` so the existing retry loop kicks in (which runs the maintenance from #1 + #2 before re-attempting).
4. **Defang the retry push** — when a retryable failure matches the unresolved-deltas pattern, the retry loop latches a `forceNoThinNextAttempt` flag and threads it into `syncProjectSnapshotViaGitPush` as `{ forceNoThin: true }`. The next push then includes `--no-thin` on both the branch and tag pushes, sending a self-contained pack the receiver can unpack without any delta-base lookup. Unrelated retryable failures (connection reset, killed by signal, …) leave the flag off — no bandwidth penalty for problems `--no-thin` wouldn't fix.

Also surfaces `Pre-fetch from origin skipped (fetch failed)` cause via `log.debug` so we can diagnose recurrent prefetch misses without spamming the init logger on the happy path.

## Validation

- `make static-check` passes (typecheck + lint + format + docs links).
- `bun test src/node/runtime/` passes (all SSH runtime / sync contract / retry orchestration suites).
- New retry tests cover: thin-pack failure → next attempt flips `--no-thin`; connection-reset → flag stays off.
- New contract tests cover: `--no-thin` appears on both branch and tag pushes when `forceNoThin: true`; default sync path omits `--no-thin`.
- Updated existing maintenance-command expectation tests for the new orphan-pack reindex step.

## Risks

Touches the SSH workspace init slow path, which runs on every cold SSH workspace creation and every snapshot-drift sync.

- `receive.unpackLimit=1` is unconditionally applied to every shared bare repo via `ensureBaseRepo`. The trade-off is more small packs vs. fewer thin-pack-unpack failures; existing maintenance already collapses fragmented packs so the steady-state is unchanged.
- The orphan-pack reindex runs `git index-pack` against any `.pack` lacking an `.idx`. A corrupt `.pack` will fail `index-pack` (best-effort, logged), then fall through to `gc` and the `--no-thin` retry push.
- `--no-thin` is only applied on retry after a confirmed thin-pack failure, so the happy path is unchanged.
- Retry classification is purely additive — existing retryable patterns and orchestration are untouched.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `high` • Cost: `$6.77`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=high costs=6.77 -->
