### PR TITLE
🤖 bench: fix Terminal-Bench log capture permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -177,7 +177,29 @@ jobs:
       - run: make build-main
       # workflow_dispatch inputs are only triggerable by repo members, so direct
       # interpolation is acceptable and preserves shell quoting in the filter.
-      - run: bun test --coverage --coverage-reporter=lcov ${{ github.event.inputs.test_filter || 'src' }} # zizmor: ignore[template-injection]
+      - run: | # zizmor: ignore[template-injection]
+          set -euo pipefail
+
+          if [[ -n "${{ github.event.inputs.test_filter }}" ]]; then
+            bun test --max-concurrency=1 --coverage --coverage-reporter=lcov ${{ github.event.inputs.test_filter }}
+            exit 0
+          fi
+
+          isolated_unit_tests=(
+            src/browser/components/WorkspaceHeartbeatModal/WorkspaceHeartbeatModal.test.tsx
+            src/browser/features/Messages/InlineSkillMarkdown.test.tsx
+            src/browser/utils/commands/sources.test.ts
+          )
+          bun test --max-concurrency=1 "${isolated_unit_tests[@]}"
+
+          mapfile -d '' unit_files < <(
+            find src -type f \( -name '*.test.ts' -o -name '*.test.tsx' \) \
+              ! -path 'src/browser/components/WorkspaceHeartbeatModal/WorkspaceHeartbeatModal.test.tsx' \
+              ! -path 'src/browser/features/Messages/InlineSkillMarkdown.test.tsx' \
+              ! -path 'src/browser/utils/commands/sources.test.ts' \
+              -print0
+          )
+          bun test --max-concurrency=1 --coverage --coverage-reporter=lcov "${unit_files[@]}"
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/terminal-bench.yml
+++ b/.github/workflows/terminal-bench.yml
@@ -298,9 +298,10 @@ jobs:
             echo "❌ No result.json found - benchmark failed to produce results"
             exit 1
           fi
-          # Harbor format: n_total_trials, stats.n_trials, stats.n_errors, stats.evals.<key>.metrics[0].mean
+          # Harbor has used both top-level stats.n_errors and stats.n_errored_trials;
+          # fall back to per-eval n_errors so schema drift cannot hide broken runs.
           N_TRIALS=$(jq -r '.n_total_trials // .stats.n_trials // 0' "$RESULTS_FILE")
-          N_ERRORS=$(jq -r '.stats.n_errors // 0' "$RESULTS_FILE")
+          N_ERRORS=$(jq -r '.stats.n_errors // .stats.n_errored_trials // (reduce ((.stats.evals // {}) | to_entries[]) as $eval (0; . + ($eval.value.n_errors // 0)))' "$RESULTS_FILE")
           # Get mean score from first eval entry (pass rate 0-1)
           MEAN_SCORE=$(jq -r '[.stats.evals | to_entries[].value.metrics[0].mean] | add // 0' "$RESULTS_FILE")
           echo "Trials: $N_TRIALS, Errors: $N_ERRORS, Mean score: $MEAN_SCORE"

--- a/benchmarks/terminal_bench/mux_agent.py
+++ b/benchmarks/terminal_bench/mux_agent.py
@@ -32,6 +32,8 @@ class MuxAgent(BaseInstalledAgent):
     _ARCHIVE_NAME = "mux-app.tar.gz"
     _RUNNER_NAME = "mux-run.sh"
     _SETUP_SCRIPT_NAME = "mux_setup.sh"
+    _COMMAND_STDOUT_NAME = "stdout.txt"
+    _COMMAND_STDERR_NAME = "stderr.txt"
     _DEFAULT_MODEL = "anthropic:claude-sonnet-4-5"
     _DEFAULT_PROJECT_CANDIDATES = "/workspace:/app:/workspaces:/root/project"
     _INCLUDE_PATHS: Sequence[str] = (
@@ -314,6 +316,13 @@ class MuxAgent(BaseInstalledAgent):
             command_dir.mkdir(parents=True, exist_ok=True)
             (command_dir / "command.txt").write_text(exec_input.command)
 
+            # /logs is bind-mounted; pre-create files so sandbox tee output
+            # does not leave root-owned files that host-side log writes cannot replace.
+            stdout_path = command_dir / self._COMMAND_STDOUT_NAME
+            stderr_path = command_dir / self._COMMAND_STDERR_NAME
+            for output_path in (stdout_path, stderr_path):
+                output_path.write_text("")
+
             result = await environment.exec(
                 command=exec_input.command,
                 cwd=exec_input.cwd,
@@ -323,9 +332,9 @@ class MuxAgent(BaseInstalledAgent):
 
             (command_dir / "return-code.txt").write_text(str(result.return_code))
             if result.stdout:
-                (command_dir / "stdout.txt").write_text(result.stdout)
+                stdout_path.write_text(result.stdout)
             if result.stderr:
-                (command_dir / "stderr.txt").write_text(result.stderr)
+                stderr_path.write_text(result.stderr)
             if result.return_code != 0:
                 failed_command = (i, result.return_code)
                 break

--- a/benchmarks/terminal_bench/mux_agent_test.py
+++ b/benchmarks/terminal_bench/mux_agent_test.py
@@ -87,11 +87,23 @@ class _ExecResult:
 
 
 class _FakeEnvironment:
-    def __init__(self, result: _ExecResult) -> None:
+    def __init__(
+        self,
+        result: _ExecResult,
+        command_dir: Path | None = None,
+    ) -> None:
         self.result = result
+        self.command_dir = command_dir
         self.download_attempts: list[tuple[str, Path]] = []
 
     async def exec(self, **_kwargs: object) -> _ExecResult:
+        if self.command_dir is not None:
+            stdout_path = self.command_dir / MuxAgent._COMMAND_STDOUT_NAME
+            stderr_path = self.command_dir / MuxAgent._COMMAND_STDERR_NAME
+            assert stdout_path.exists()
+            assert stderr_path.exists()
+            stdout_path.write_text("sandbox out")
+            stderr_path.write_text("sandbox err")
         return self.result
 
     async def download_file(self, source_path: str, target_path: Path) -> None:
@@ -114,14 +126,32 @@ def test_run_raises_after_preserving_logs_for_nonzero_exit(
 
     command_dir = tmp_path / "command-0"
     assert (command_dir / "return-code.txt").read_text() == "3"
-    assert (command_dir / "stdout.txt").read_text() == "out"
-    assert (command_dir / "stderr.txt").read_text() == "err"
+    assert (command_dir / MuxAgent._COMMAND_STDOUT_NAME).read_text() == "out"
+    assert (command_dir / MuxAgent._COMMAND_STDERR_NAME).read_text() == "err"
     assert environment.download_attempts == [
         (agent._TOKEN_FILE_PATH, tmp_path / "mux-tokens.json")
     ]
     assert getattr(context, "n_input_tokens") == 7
     assert getattr(context, "n_output_tokens") == 11
     assert getattr(context, "cost_usd") == 0.42
+
+
+def test_run_preseeds_command_logs_before_sandbox_exec(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("MUX_AGENT_REPO_ROOT", str(_repo_root()))
+    agent = MuxAgent(logs_dir=tmp_path)
+    command_dir = tmp_path / "command-0"
+    environment = _FakeEnvironment(
+        _ExecResult(return_code=0, stdout="out", stderr="err"),
+        command_dir=command_dir,
+    )
+    context = SimpleNamespace()
+
+    asyncio.run(agent.run("do the task", environment, context))
+
+    assert (command_dir / MuxAgent._COMMAND_STDOUT_NAME).read_text() == "out"
+    assert (command_dir / MuxAgent._COMMAND_STDERR_NAME).read_text() == "err"
 
 
 def test_run_populates_context_for_successful_exit(
@@ -138,8 +168,8 @@ def test_run_populates_context_for_successful_exit(
 
     command_dir = tmp_path / "command-0"
     assert (command_dir / "return-code.txt").read_text() == "0"
-    assert (command_dir / "stdout.txt").read_text() == "out"
-    assert (command_dir / "stderr.txt").read_text() == "err"
+    assert (command_dir / MuxAgent._COMMAND_STDOUT_NAME).read_text() == "out"
+    assert (command_dir / MuxAgent._COMMAND_STDERR_NAME).read_text() == "err"
     assert getattr(context, "n_input_tokens") == 7
     assert getattr(context, "n_output_tokens") == 11
     assert getattr(context, "cost_usd") == 0.42

--- a/src/browser/stores/GitStatusStore.test.ts
+++ b/src/browser/stores/GitStatusStore.test.ts
@@ -201,6 +201,8 @@ describe("GitStatusStore", () => {
     mockGetProjectGitStatuses.mockResolvedValue([]);
 
     (globalThis as unknown as { window: unknown }).window = {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
       api: {
         workspace: {
           executeBash: mockExecuteBash,

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -1,4 +1,15 @@
-import { describe, expect, it, beforeEach, afterEach, mock, spyOn, type Mock } from "bun:test";
+import { GlobalWindow } from "happy-dom";
+import {
+  describe,
+  expect,
+  it,
+  beforeEach,
+  afterEach,
+  afterAll,
+  mock,
+  spyOn,
+  type Mock,
+} from "bun:test";
 import type { CompactionFollowUpRequest, DisplayedMessage } from "@/common/types/message";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import type { StreamStartEvent, ToolCallStartEvent } from "@/common/types/stream";
@@ -132,21 +143,37 @@ const mockLocalStorage: Storage = {
   },
 };
 
-const mockWindow = {
-  localStorage: mockLocalStorage,
+type WorkspaceStoreTestWindow = Omit<Window & typeof globalThis, "api"> & {
   api: {
     workspace: {
-      onChat: mock((_workspaceId, _callback) => {
-        return () => {
-          // cleanup
-        };
-      }),
-    },
-  },
+      onChat: (_workspaceId: unknown, _callback: unknown) => () => void;
+    };
+  };
 };
 
-global.window = mockWindow as unknown as Window & typeof globalThis;
-global.window.dispatchEvent = mock();
+const originalWindow = global.window;
+
+const mockWindow = new GlobalWindow() as unknown as WorkspaceStoreTestWindow;
+Object.defineProperty(mockWindow, "localStorage", {
+  configurable: true,
+  value: mockLocalStorage,
+});
+mockWindow.api = {
+  workspace: {
+    onChat: mock((_workspaceId, _callback) => {
+      return () => {
+        // cleanup
+      };
+    }),
+  },
+};
+mockWindow.dispatchEvent = mock();
+
+global.window = mockWindow as Window & typeof globalThis;
+
+afterAll(() => {
+  global.window = originalWindow;
+});
 
 // Mock queueMicrotask
 global.queueMicrotask = (fn) => fn();

--- a/src/node/services/utils/forkOrchestrator.multiProject.test.ts
+++ b/src/node/services/utils/forkOrchestrator.multiProject.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, spyOn, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn, vi } from "bun:test";
 import type { RuntimeConfig } from "@/common/types/runtime";
 import type { WorkspaceMetadata } from "@/common/types/workspace";
 import type { Config } from "@/node/config";
@@ -188,6 +188,11 @@ describe("orchestrateFork (multi-project)", () => {
     detectDefaultTrunkBranchMock = spyOn(gitModule, "detectDefaultTrunkBranch").mockResolvedValue(
       "main"
     );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   it("fails closed before any project fork work when the multi-project experiment is disabled", async () => {


### PR DESCRIPTION
## Summary
Fixes Terminal-Bench strict goal-mode runs failing after successful agent execution because sandbox-created log files could be root-owned on the host bind mount. Also updates the workflow error gate to recognize Harbor's current errored-trial field, and makes CI unit execution deterministic around tests that mutate shared browser globals.

## Background
A manually dispatched Terminal-Bench run with `MUX_RUN_AS_GOAL=1` produced an artifact with 89 errored trials. Most runs had completed goals and return code 0, but Harbor recorded `PermissionError` while the adapter rewrote `agent/command-0/stdout.txt` after sandbox execution.

## Implementation
- Pre-create command stdout/stderr files from the host before running the sandbox command, so `/logs` tee output does not leave root-owned files behind.
- Reuse command log filename constants in the adapter tests.
- Count `.stats.n_errored_trials` and per-eval `n_errors` in the workflow guard in addition to the older `.stats.n_errors` field.
- Add focus listener methods to the GitStatusStore test window mock so RefreshController cleanup does not abort and leak a broken global window into later tests.
- Restore WorkspaceStore's top-level window mock after its test file and restore fork-orchestrator spies after each test so later unit tests are isolated.
- Run known shared-global-sensitive unit files in a clean Bun process before the rest of the unit suite, then run remaining unit files with `--max-concurrency=1`.

## Validation
- `make static-check`
- `PATH="$HOME/.local/share/mise/installs/bun/1.3.5/bin:$PATH" make static-check`
- `PATH="$HOME/.local/bin:$PATH" uvx ruff format benchmarks/terminal_bench/mux_agent.py benchmarks/terminal_bench/mux_agent_test.py`
- `PATH="$HOME/.local/bin:$PATH" uvx ruff check benchmarks/terminal_bench/mux_agent.py benchmarks/terminal_bench/mux_agent_test.py`
- `PATH="$HOME/.local/bin:$PATH" UV_PYTHON=3.12 uvx --from 'harbor[daytona]==0.6.4' --with pytest pytest benchmarks/terminal_bench/mux_agent_test.py -q`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/terminal-bench.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/pr.yml`
- `make check-bench-agent`
- `~/.local/share/mise/installs/bun/1.3.5/bin/bun test --max-concurrency=1 src/browser/components/WorkspaceHeartbeatModal/WorkspaceHeartbeatModal.test.tsx src/browser/features/Messages/InlineSkillMarkdown.test.tsx src/browser/utils/commands/sources.test.ts`
- `~/.local/share/mise/installs/bun/1.3.5/bin/bun test --coverage --coverage-reporter=lcov src/browser/stores/WorkspaceStore.test.ts src/browser/stores/GitStatusStore.test.ts src/browser/components/WorkspaceHeartbeatModal/WorkspaceHeartbeatModal.test.tsx src/browser/utils/commands/sources.test.ts src/browser/features/Messages/InlineSkillMarkdown.test.tsx src/node/services/utils/forkOrchestrator.multiProject.test.ts src/node/services/tools/task_apply_git_patch.test.ts`
- Replayed the workflow error-counting logic against `/tmp/terminal-bench-results-openai-gpt-5.5-terminal-bench-2.0-all-tasks-26233637001-a1.zip`; it now reports `Trials=89 Errors=89 Infra=2 Other=87`.

## Risks
Low product risk: the runtime change only affects benchmark adapter/log handling and the rest is workflow/test-only.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$10.67`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=10.67 -->
