### PR TITLE
🤖 fix: keep terminal subscription stable

### DIFF
--- a/src/browser/components/TerminalView/TerminalView.test.tsx
+++ b/src/browser/components/TerminalView/TerminalView.test.tsx
@@ -1,0 +1,207 @@
+import "../../../../tests/ui/dom";
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { installDom } from "../../../../tests/ui/dom";
+
+interface TerminalSubscribeCallbacks {
+  onOutput: (data: string) => void;
+  onScreenState: (state: string) => void;
+  onExit: (code: number) => void;
+}
+
+interface MockTerminalOptions {
+  fontSize: number;
+  fontFamily: string;
+  cursorBlink: boolean;
+  theme: {
+    background: string;
+    foreground: string;
+  };
+}
+
+interface MockRouter {
+  subscribe: ReturnType<
+    typeof mock<(sessionId: string, callbacks: TerminalSubscribeCallbacks) => () => void>
+  >;
+  resize: ReturnType<typeof mock<(sessionId: string, cols: number, rows: number) => Promise<void>>>;
+  sendInput: ReturnType<typeof mock<(sessionId: string, data: string) => void>>;
+}
+
+let cleanupDom: (() => void) | null = null;
+let mockRouter: MockRouter;
+let subscribeCallbacks: TerminalSubscribeCallbacks[] = [];
+let terminalInstances: MockTerminal[] = [];
+let unsubscribeMock: ReturnType<typeof mock<() => void>>;
+
+const initMock = mock(() => Promise.resolve());
+const terminalOnExitMock = mock(
+  (_input: { sessionId: string }, _options?: { signal?: AbortSignal }) =>
+    Promise.resolve(
+      (async function* (): AsyncGenerator<number, void, unknown> {
+        await Promise.resolve();
+        yield* [];
+      })()
+    )
+);
+
+class MockTerminal {
+  cols = 80;
+  rows = 24;
+  options: MockTerminalOptions;
+  clear = mock(() => undefined);
+  write = mock((_data: string) => undefined);
+  resize = mock((cols: number, rows: number) => {
+    this.cols = cols;
+    this.rows = rows;
+  });
+  blur = mock(() => undefined);
+  focus = mock(() => undefined);
+  dispose = mock(() => undefined);
+
+  constructor(options: MockTerminalOptions) {
+    this.options = options;
+    terminalInstances.push(this);
+  }
+
+  loadAddon = mock((_addon: unknown) => undefined);
+
+  open(container: HTMLElement): void {
+    container.append(document.createElement("textarea"));
+  }
+
+  attachCustomKeyEventHandler = mock((_handler: (ev: KeyboardEvent) => boolean) => undefined);
+
+  paste = mock((_text: string) => undefined);
+
+  hasSelection(): boolean {
+    return false;
+  }
+
+  getSelection(): string {
+    return "";
+  }
+
+  onData(_callback: (data: string) => void): { dispose: () => void } {
+    return { dispose: mock(() => undefined) };
+  }
+
+  onTitleChange(_callback: (title: string) => void): { dispose: () => void } {
+    return { dispose: mock(() => undefined) };
+  }
+}
+
+class MockFitAddon {
+  fit = mock(() => undefined);
+  proposeDimensions = mock(() => ({ cols: 80, rows: 24 }));
+}
+
+void mock.module("ghostty-web", () => ({
+  init: initMock,
+  Terminal: MockTerminal,
+  FitAddon: MockFitAddon,
+}));
+
+void mock.module("@/browser/contexts/API", () => ({
+  useAPI: () => ({
+    api: {
+      terminal: {
+        onExit: terminalOnExitMock,
+      },
+    },
+    status: "connected" as const,
+    error: null,
+    authenticate: () => undefined,
+    retry: () => undefined,
+  }),
+}));
+
+void mock.module("@/browser/terminal/TerminalRouterContext", () => ({
+  useTerminalRouter: () => mockRouter,
+}));
+
+import { TerminalView } from "./TerminalView";
+
+function createRouter(): MockRouter {
+  unsubscribeMock = mock(() => undefined);
+  return {
+    subscribe: mock((sessionId: string, callbacks: TerminalSubscribeCallbacks) => {
+      expect(sessionId).toBe("terminal-1");
+      subscribeCallbacks.push(callbacks);
+      callbacks.onScreenState("initial screen");
+      return unsubscribeMock;
+    }),
+    resize: mock((_sessionId: string, _cols: number, _rows: number) => Promise.resolve()),
+    sendInput: mock((_sessionId: string, _data: string) => undefined),
+  };
+}
+
+function renderTerminal(onExit: (exitCode: number) => void) {
+  return render(
+    <TerminalView
+      workspaceId="workspace-1"
+      sessionId="terminal-1"
+      visible
+      setDocumentTitle={false}
+      autoFocus={false}
+      onExit={onExit}
+    />
+  );
+}
+
+describe("TerminalView", () => {
+  beforeEach(() => {
+    cleanupDom = installDom();
+    mockRouter = createRouter();
+    subscribeCallbacks = [];
+    terminalInstances = [];
+  });
+
+  afterEach(() => {
+    cleanup();
+    cleanupDom?.();
+    cleanupDom = null;
+    mock.restore();
+  });
+
+  test("keeps the router subscription stable when onExit changes", async () => {
+    const firstOnExit = mock((_exitCode: number) => undefined);
+    const secondOnExit = mock((_exitCode: number) => undefined);
+
+    const view = renderTerminal(firstOnExit);
+
+    await waitFor(() => {
+      expect(mockRouter.subscribe).toHaveBeenCalledTimes(1);
+    });
+
+    const firstSubscription = subscribeCallbacks[0];
+    const terminal = terminalInstances[0];
+    expect(firstSubscription).toBeDefined();
+    expect(terminal).toBeDefined();
+    expect(terminal.clear).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      view.rerender(
+        <TerminalView
+          workspaceId="workspace-1"
+          sessionId="terminal-1"
+          visible
+          setDocumentTitle={false}
+          autoFocus={false}
+          onExit={secondOnExit}
+        />
+      );
+      await Promise.resolve();
+    });
+
+    expect(mockRouter.subscribe).toHaveBeenCalledTimes(1);
+    expect(unsubscribeMock).toHaveBeenCalledTimes(0);
+    expect(terminal.clear).toHaveBeenCalledTimes(1);
+
+    firstSubscription.onExit(7);
+
+    expect(firstOnExit).toHaveBeenCalledTimes(0);
+    expect(secondOnExit).toHaveBeenCalledTimes(1);
+    expect(secondOnExit.mock.calls[0]?.[0]).toBe(7);
+  });
+});

--- a/src/browser/components/TerminalView/TerminalView.tsx
+++ b/src/browser/components/TerminalView/TerminalView.tsx
@@ -166,6 +166,10 @@ export function TerminalView({
   const autoFocusRef = useRef(autoFocus);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const exitHandledRef = useRef(false);
+  const onExitRef = useRef(onExit);
+  // The right sidebar can recreate onExit while chat streams; keep the latest callback in
+  // a ref so terminal subscriptions do not tear down and clear the screen for callback churn.
+  onExitRef.current = onExit;
   const [terminalError, setTerminalError] = useState<string | null>(null);
   const [terminalReady, setTerminalReady] = useState(false);
   // Track whether we've received the initial screen state from backend
@@ -214,26 +218,23 @@ export function TerminalView({
     onAutoFocusConsumed?.();
   }, [onAutoFocusConsumed]);
 
-  const handleExit = useCallback(
-    (code: number) => {
-      if (exitHandledRef.current) {
-        return;
-      }
-      exitHandledRef.current = true;
+  const handleExit = useCallback((code: number) => {
+    if (exitHandledRef.current) {
+      return;
+    }
+    exitHandledRef.current = true;
 
-      const term = termRef.current;
-      if (term) {
-        try {
-          term.write(`\r\n[Process exited with code ${code}]\r\n`);
-        } catch (err) {
-          console.warn("[TerminalView] Error writing exit message:", err);
-        }
+    const term = termRef.current;
+    if (term) {
+      try {
+        term.write(`\r\n[Process exited with code ${code}]\r\n`);
+      } catch (err) {
+        console.warn("[TerminalView] Error writing exit message:", err);
       }
+    }
 
-      onExit?.(code);
-    },
-    [onExit]
-  );
+    onExitRef.current?.(code);
+  }, []);
 
   useEffect(() => {
     autoFocusRef.current = autoFocus;

--- a/src/browser/components/TerminalView/TerminalView.tsx
+++ b/src/browser/components/TerminalView/TerminalView.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useState, useCallback } from "react";
+import { useRef, useEffect, useState, useCallback, useLayoutEffect } from "react";
 import { init, Terminal, FitAddon } from "ghostty-web";
 import { useAPI } from "@/browser/contexts/API";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
@@ -167,9 +167,11 @@ export function TerminalView({
   const fitAddonRef = useRef<FitAddon | null>(null);
   const exitHandledRef = useRef(false);
   const onExitRef = useRef(onExit);
-  // The right sidebar can recreate onExit while chat streams; keep the latest callback in
-  // a ref so terminal subscriptions do not tear down and clear the screen for callback churn.
-  onExitRef.current = onExit;
+  // The right sidebar can recreate onExit while chat streams. Sync the latest committed
+  // callback through a ref so subscriptions stay stable without exposing render-time props.
+  useLayoutEffect(() => {
+    onExitRef.current = onExit;
+  }, [onExit]);
   const [terminalError, setTerminalError] = useState<string | null>(null);
   const [terminalReady, setTerminalReady] = useState(false);
   // Track whether we've received the initial screen state from backend


### PR DESCRIPTION
## Summary

Keep the integrated terminal's router subscription stable when parent renders recreate the `onExit` callback, preventing chat streaming updates from causing a terminal unsubscribe/resubscribe cycle that clears the visible screen.

## Background

The web terminal flashed because `TerminalView` cleared the terminal every time its router subscription effect re-ran. Chat streaming can rerender the right sidebar and recreate inline terminal callbacks, which changed `handleExit`, retriggered the subscription effect, and briefly showed a blank terminal before cached screen state replayed.

## Implementation

`TerminalView` now stores the latest committed `onExit` callback in a ref synchronized from a layout effect, then keeps `handleExit` stable. That preserves current exit behavior while ensuring callback identity churn does not tear down the terminal router subscription, and it avoids making render-time callback props observable before React commits them. The new regression test renders `TerminalView`, rerenders it with a different `onExit`, and asserts the router subscription, unsubscribe, and terminal clear counts remain unchanged while exit still invokes the latest committed callback.

## Validation

Verified the regression test fails without the `TerminalView` fix by temporarily restoring that file from `origin/main`; it fails with `Expected number of calls: 1 / Received number of calls: 2` for `mockRouter.subscribe`. Reapplied the fix and ran the regression test successfully, then ran the regression test 10 times in a loop to check consistency and ran `make static-check` with local ESLint concurrency reduced to 2.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$17.02`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=17.02 -->
