### PR TITLE
🤖 refactor(review): drop dismiss + jump-to-source from Assisted pins

### DIFF
--- a/src/browser/features/RightSidebar/CodeReview/HunkViewer.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/HunkViewer.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useMemo } from "react";
-import { Check, Circle, MessageCircle, Sparkles, X } from "lucide-react";
+import { Check, Circle, Sparkles } from "lucide-react";
 import type { DiffHunk, Review, ReviewNoteData } from "@/common/types/review";
 import { SelectableDiffRenderer } from "../../Shared/DiffRenderer";
 import type { ReviewActionCallbacks } from "../../Shared/InlineReviewNote";
@@ -70,25 +70,6 @@ interface HunkViewerProps {
    * happened to be replayed from chat).
    */
   isAssistedNew?: boolean;
-  /**
-   * Stable formatted key for the matched assisted entry (path[:range]).
-   * Required when `onDismissAssisted` is provided so the parent can record
-   * a user-side dismissal without re-deriving the key from the hunk.
-   */
-  assistedKey?: string;
-  /**
-   * Optional source message id (assistant turn that flagged this hunk).
-   * When present together with `onJumpToAssistedSource`, the assisted strip
-   * renders a "↗ source" link that scrolls the transcript to that turn.
-   */
-  assistedSourceMessageId?: string;
-  /**
-   * Local-only "quiet" dismissal — drops the pin from the user's view
-   * without touching the agent's state. Called with `assistedKey`.
-   */
-  onDismissAssisted?: (assistedKey: string) => void;
-  /** Scroll the chat transcript to the assistant turn referenced by `assistedSourceMessageId`. */
-  onJumpToAssistedSource?: (messageId: string) => void;
   /**
    * When set, the hunk body is trimmed to just these new-side line numbers
    * (inclusive) by default. Lines before/after the range hide behind a
@@ -178,10 +159,6 @@ export const HunkViewer = React.memo<HunkViewerProps>(
     assistedComment,
     isAssisted = false,
     isAssistedNew = false,
-    assistedKey,
-    assistedSourceMessageId,
-    onDismissAssisted,
-    onJumpToAssistedSource,
     visibleNewLineRange,
   }) => {
     // Ref for the hunk container to track visibility
@@ -406,54 +383,6 @@ export const HunkViewer = React.memo<HunkViewerProps>(
                   </span>
                 )}
               </div>
-              {(assistedSourceMessageId !== undefined || onDismissAssisted) && (
-                <div className="flex items-center gap-3 text-[10px]">
-                  {assistedSourceMessageId !== undefined && onJumpToAssistedSource && (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onJumpToAssistedSource(assistedSourceMessageId);
-                          }}
-                          className="text-muted hover:text-foreground inline-flex cursor-pointer items-center gap-1 border-none bg-transparent p-0 transition-colors"
-                          aria-label="Jump to the agent turn that flagged this hunk"
-                          data-testid="hunk-assisted-jump-source"
-                        >
-                          <MessageCircle aria-hidden="true" className="h-3 w-3" />
-                          <span>jump to source</span>
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="top" align="start">
-                        Scroll to the agent turn that flagged this hunk.
-                      </TooltipContent>
-                    </Tooltip>
-                  )}
-                  {onDismissAssisted && assistedKey !== undefined && (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onDismissAssisted(assistedKey);
-                          }}
-                          className="text-muted hover:text-foreground inline-flex cursor-pointer items-center gap-1 border-none bg-transparent p-0 transition-colors"
-                          aria-label="Dismiss this agent pin (local-only)"
-                          data-testid="hunk-assisted-dismiss"
-                        >
-                          <X aria-hidden="true" className="h-3 w-3" />
-                          <span>dismiss</span>
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="top" align="start">
-                        Hide this pin from your view. The agent&apos;s state is not changed.
-                      </TooltipContent>
-                    </Tooltip>
-                  )}
-                </div>
-              )}
             </div>
           </div>
         )}

--- a/src/browser/features/RightSidebar/CodeReview/ReviewControls.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ReviewControls.tsx
@@ -56,15 +56,6 @@ interface ReviewControlsProps {
    * matching the Review tab badge.
    */
   assistedUnreadCount?: number;
-  /**
-   * When > 0, render a "show dismissed" hint that lets the user restore
-   * locally-dismissed pins. Distinct from `assistedCount` because dismissed
-   * pins are still part of the agent's set — they just don't appear in the
-   * panel until the user opts back in.
-   */
-  assistedDismissedCount?: number;
-  /** Restore all user-dismissed assisted pins for this workspace. */
-  onRestoreDismissedAssisted?: () => void;
 }
 
 export const ReviewControls: React.FC<ReviewControlsProps> = ({
@@ -82,8 +73,6 @@ export const ReviewControls: React.FC<ReviewControlsProps> = ({
   onToggleImmersive,
   assistedCount = 0,
   assistedUnreadCount = 0,
-  assistedDismissedCount = 0,
-  onRestoreDismissedAssisted,
 }) => {
   // Per-project default base (used for new workspaces in this project)
   const [defaultBase, setDefaultBase] = usePersistedState<string>(
@@ -287,36 +276,6 @@ export const ReviewControls: React.FC<ReviewControlsProps> = ({
                 ({assistedUnreadCount}/{assistedCount})
               </span>
             </label>
-          </TooltipIfPresent>
-        </>
-      )}
-
-      {/* Restore-dismissed control rendered OUTSIDE the Assisted group so the
-          user always has a path back to dismissed pins. Without this, a user
-          who dismisses every pin and exits Assisted gets stuck (the Assisted
-          toggle is hidden once `assistedCount === 0` and Assisted is off, and
-          the Shift+P keybind also no-ops in that state). */}
-      {assistedDismissedCount > 0 && onRestoreDismissedAssisted && (
-        <>
-          {/* Avoid a stranded divider when the Assisted group above already
-              rendered one. The cheap check is just whether that group was
-              also visible. */}
-          {assistedCount === 0 && !filters.assistedOnly && (
-            <div className="bg-border-light h-3 w-px" />
-          )}
-          <TooltipIfPresent
-            tooltip={`${assistedDismissedCount} agent pin${assistedDismissedCount === 1 ? "" : "s"} dismissed locally — click to restore`}
-            side="bottom"
-          >
-            <button
-              type="button"
-              onClick={onRestoreDismissedAssisted}
-              className="text-dim hover:text-foreground inline-flex cursor-pointer items-center gap-1 border-none bg-transparent p-0 text-[10px] whitespace-nowrap transition-colors"
-              data-testid="review-restore-dismissed"
-            >
-              <Sparkles aria-hidden="true" className="text-review-accent/60 h-3 w-3 shrink-0" />
-              <span>+{assistedDismissedCount} dismissed</span>
-            </button>
           </TooltipIfPresent>
         </>
       )}

--- a/src/browser/features/RightSidebar/CodeReview/ReviewPanel.assistedStats.test.ts
+++ b/src/browser/features/RightSidebar/CodeReview/ReviewPanel.assistedStats.test.ts
@@ -7,7 +7,6 @@ import {
   countUnreadAssistedHunks,
   getEffectiveReviewFrontendFilters,
   getEffectiveReviewIncludeUncommitted,
-  getNextDismissedAssistedKeys,
 } from "./ReviewPanel";
 
 function hunk(overrides: Partial<DiffHunk>): DiffHunk {
@@ -137,40 +136,6 @@ describe("buildReviewDiffPathFilterSpecs", () => {
         selectedFilePath: "project-b/src/user-selected.ts",
       },
     ]);
-  });
-});
-
-describe("getNextDismissedAssistedKeys", () => {
-  test("keeps dismissed keys while an empty assisted set may still be hydrating", () => {
-    const dismissedKeys = ["src/agent.ts:3-5"];
-
-    expect(
-      getNextDismissedAssistedKeys({
-        dismissedKeys,
-        rawAssistedHunks: [],
-        isTranscriptHydrated: false,
-      })
-    ).toBe(dismissedKeys);
-  });
-
-  test("clears dismissed keys once an empty assisted set is authoritative", () => {
-    expect(
-      getNextDismissedAssistedKeys({
-        dismissedKeys: ["src/agent.ts:3-5"],
-        rawAssistedHunks: [],
-        isTranscriptHydrated: true,
-      })
-    ).toEqual([]);
-  });
-
-  test("prunes dismissed keys that no longer exist in the live assisted set", () => {
-    expect(
-      getNextDismissedAssistedKeys({
-        dismissedKeys: ["src/agent.ts:3-5", "src/stale.ts"],
-        rawAssistedHunks: [{ path: "src/agent.ts", range: { start: 3, end: 5 } }],
-        isTranscriptHydrated: true,
-      })
-    ).toEqual(["src/agent.ts:3-5"]);
   });
 });
 

--- a/src/browser/features/RightSidebar/CodeReview/ReviewPanel.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ReviewPanel.tsx
@@ -32,7 +32,7 @@ import React, {
   useRef,
   useSyncExternalStore,
 } from "react";
-import { findAssistedMatch, formatAssistedFilter } from "@/common/utils/review/assistedReview";
+import { findAssistedMatch } from "@/common/utils/review/assistedReview";
 import { createPortal } from "react-dom";
 import { HunkViewer } from "./HunkViewer";
 import { InlineReviewNote, type ReviewActionCallbacks } from "../../Shared/InlineReviewNote";
@@ -580,24 +580,6 @@ export function getEffectiveReviewFrontendFilters(params: {
   return { showReadHunks: effectiveShowRead, searchTerm: params.searchTerm };
 }
 
-export function getNextDismissedAssistedKeys(params: {
-  dismissedKeys: string[];
-  rawAssistedHunks: readonly AssistedReviewHunk[];
-  isTranscriptHydrated: boolean;
-}): string[] {
-  if (params.dismissedKeys.length === 0) {
-    return params.dismissedKeys;
-  }
-
-  if (params.rawAssistedHunks.length === 0) {
-    return params.isTranscriptHydrated ? [] : params.dismissedKeys;
-  }
-
-  const liveKeys = new Set(params.rawAssistedHunks.map((hunk) => formatAssistedFilter(hunk)));
-  const pruned = params.dismissedKeys.filter((key) => liveKeys.has(key));
-  return pruned.length === params.dismissedKeys.length ? params.dismissedKeys : pruned;
-}
-
 interface ReviewAssistedStatsReporterProps {
   workspaceId: string;
   workspacePath: string;
@@ -623,54 +605,9 @@ export const ReviewAssistedStatsReporter: React.FC<ReviewAssistedStatsReporterPr
     (callback: () => void) => rawWorkspaceStore.subscribeKey(workspaceId, callback),
     [rawWorkspaceStore, workspaceId]
   );
-  const rawAssistedHunks = useSyncExternalStore(subscribeAssistedHunks, () =>
+  const assistedHunks = useSyncExternalStore(subscribeAssistedHunks, () =>
     rawWorkspaceStore.getAssistedReviewHunks(workspaceId)
   );
-  const isTranscriptHydrated = useSyncExternalStore(subscribeAssistedHunks, () =>
-    rawWorkspaceStore.isWorkspaceTranscriptCaughtUp(workspaceId)
-  );
-  // Subscribe to the user's per-workspace dismissed pin list (same key the
-  // panel writes via `usePersistedState`). Listening here keeps the Review
-  // tab badge in lock-step with dismissals so the user doesn't get attention
-  // cues for pins they explicitly silenced — even when the Review panel
-  // itself isn't mounted.
-  const [dismissedAssistedKeys, setDismissedAssistedKeys] = usePersistedState<string[]>(
-    STORAGE_KEYS.reviewAssistedDismissed(workspaceId),
-    [],
-    { listener: true }
-  );
-  const assistedHunks = useMemo(() => {
-    if (dismissedAssistedKeys.length === 0) return rawAssistedHunks;
-    const dismissed = new Set(dismissedAssistedKeys);
-    return rawAssistedHunks.filter((entry) => !dismissed.has(formatAssistedFilter(entry)));
-  }, [rawAssistedHunks, dismissedAssistedKeys]);
-
-  // Self-heal the dismissed-pin list whenever the agent's set changes:
-  // drop any dismissed key that is no longer present in the agent's pins
-  // so the localStorage entry stays bounded across long-lived workspaces.
-  //
-  // This effect lives in the always-mounted stats reporter (not the panel)
-  // because the user may dismiss pins, switch tabs, the agent then
-  // clears/replaces the set, and the panel never remounts — without this
-  // the dismissed entry would silently filter a future re-appearance of
-  // the same key until manual restore. The panel's `usePersistedState`
-  // listener picks up the pruned value automatically on next mount.
-  //
-  // Empty `rawAssistedHunks` is ambiguous on its own. Before transcript replay
-  // catches up, it can be only a cold-load or reconnect placeholder, so keep
-  // dismissals. Once replay is caught up, an empty set is authoritative: the
-  // agent either had no pins or cleared them while the app was closed, so clear
-  // local dismissals to avoid suppressing a future re-add of the same path:range.
-  useEffect(() => {
-    const nextDismissedAssistedKeys = getNextDismissedAssistedKeys({
-      dismissedKeys: dismissedAssistedKeys,
-      rawAssistedHunks,
-      isTranscriptHydrated,
-    });
-    if (nextDismissedAssistedKeys !== dismissedAssistedKeys) {
-      setDismissedAssistedKeys(nextDismissedAssistedKeys);
-    }
-  }, [rawAssistedHunks, dismissedAssistedKeys, isTranscriptHydrated, setDismissedAssistedKeys]);
 
   const projectDefaultBaseKey = STORAGE_KEYS.reviewDefaultBase(projectPath);
   const workspaceDiffBaseKey = STORAGE_KEYS.reviewDiffBase(workspaceId);
@@ -1076,52 +1013,11 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
     (callback: () => void) => rawWorkspaceStore.subscribeKey(workspaceId, callback),
     [rawWorkspaceStore, workspaceId]
   );
-  const rawAssistedHunks = useSyncExternalStore(subscribeAssistedHunks, () =>
+  const assistedHunks = useSyncExternalStore(subscribeAssistedHunks, () =>
     rawWorkspaceStore.getAssistedReviewHunks(workspaceId)
   );
 
-  // Per-workspace user-dismissed pin keys (formatted path[:range]). This is
-  // a purely user-side quiet list — we don't mutate the agent's view of the
-  // assisted set, we just filter dismissed entries out of the panel so users
-  // can quiet a noisy agent without waiting for the agent to clear/replace
-  // its pins. Cleared entries naturally fall off the list once the agent
-  // drops them.
-  const [dismissedAssistedKeys, setDismissedAssistedKeys] = usePersistedState<string[]>(
-    STORAGE_KEYS.reviewAssistedDismissed(workspaceId),
-    [],
-    { listener: true }
-  );
-  const dismissedAssistedKeySet = useMemo(
-    () => new Set(dismissedAssistedKeys),
-    [dismissedAssistedKeys]
-  );
-
-  // Effective assisted set after applying user dismissals. Memoized so all
-  // downstream maps depend on a stable reference when nothing changes.
-  const assistedHunks = useMemo(() => {
-    if (dismissedAssistedKeySet.size === 0) return rawAssistedHunks;
-    return rawAssistedHunks.filter(
-      (entry) => !dismissedAssistedKeySet.has(formatAssistedFilter(entry))
-    );
-  }, [rawAssistedHunks, dismissedAssistedKeySet]);
-
-  // The self-healing prune of stale dismissed keys lives in
-  // `ReviewAssistedStatsReporter` (always mounted) so it runs even when the
-  // user is on another tab — see the note next to its prune effect.
-
-  const handleDismissAssistedPin = useCallback(
-    (key: string) => {
-      setDismissedAssistedKeys((prev) => (prev.includes(key) ? prev : [...prev, key]));
-    },
-    [setDismissedAssistedKeys]
-  );
-
-  const handleRestoreDismissedAssisted = useCallback(() => {
-    setDismissedAssistedKeys([]);
-  }, [setDismissedAssistedKeys]);
-
   const hasAssistedHunks = assistedHunks.length > 0;
-  const hasDismissedAssistedHunks = dismissedAssistedKeys.length > 0;
 
   // Auto-focus the Review pane on the agent's flagged hunks the first time
   // they appear in a session: flip `assistedOnly` to true so the user lands
@@ -1777,31 +1673,6 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
     return result;
   }, [assistedMatchByHunkId]);
 
-  // Stable formatted key per matched hunk so HunkViewer can request a
-  // user-side dismissal without leaking the structured AssistedReviewHunk.
-  const assistedKeyByHunkId = useMemo(() => {
-    if (assistedMatchByHunkId.size === 0) return new Map<string, string>();
-    const result = new Map<string, string>();
-    for (const [hunkId, match] of assistedMatchByHunkId) {
-      result.set(hunkId, formatAssistedFilter(match.entry));
-    }
-    return result;
-  }, [assistedMatchByHunkId]);
-
-  // Source-message lookup so each hunk can render a "jump to source turn"
-  // affordance. Empty when no pins carry a sourceMessageId yet (replayed
-  // from history without context, etc.).
-  const assistedSourceMessageIdByHunkId = useMemo(() => {
-    if (assistedMatchByHunkId.size === 0) return new Map<string, string>();
-    const result = new Map<string, string>();
-    for (const [hunkId, match] of assistedMatchByHunkId) {
-      if (match.entry.sourceMessageId) {
-        result.set(hunkId, match.entry.sourceMessageId);
-      }
-    }
-    return result;
-  }, [assistedMatchByHunkId]);
-
   // Set of hunkIds whose pin was added recently enough to qualify for the
   // transient "new" badge.
   //
@@ -1874,17 +1745,6 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
     }
     return count;
   }, [assistedMatchByHunkId, isRead]);
-
-  // Jump-to-source: scrolls the chat transcript so the originating agent
-  // turn is in view. The transcript already tags each message boundary with
-  // `data-message-id` (see MessageRenderer); we use that as the lookup key
-  // rather than threading another callback through the workspace store.
-  const handleJumpToAssistedSource = useCallback((messageId: string) => {
-    if (!messageId || typeof document === "undefined") return;
-    const element = document.querySelector(`[data-message-id="${CSS.escape(messageId)}"]`);
-    if (!element) return;
-    element.scrollIntoView({ behavior: "smooth", block: "center" });
-  }, []);
 
   // Apply frontend filters (read state, search term) and sorting
   // Note: selectedFilePath is a git-level filter, applied when fetching hunks
@@ -2174,15 +2034,10 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
       // actually fires.
       if (matchesKeybind(e, KEYBINDS.TOGGLE_ASSISTED_REVIEW)) {
         // Skip the keystroke only when nothing assisted is reachable: no
-        // live pins, no currently-active worklist mode, AND no dismissed
-        // pins waiting to be restored. The last condition lets users
-        // re-enter Assisted via the keyboard to discover the restore
-        // button in the empty state, instead of getting stuck.
-        if (
-          assistedHunks.length === 0 &&
-          !filters.assistedOnly &&
-          dismissedAssistedKeys.length === 0
-        ) {
+        // live pins and no currently-active worklist mode. Otherwise we
+        // toggle so the user can leave Assisted even when its set just
+        // emptied.
+        if (assistedHunks.length === 0 && !filters.assistedOnly) {
           return;
         }
         e.preventDefault();
@@ -2246,7 +2101,6 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
     handleMarkAsUnread,
     assistedHunks.length,
     filters.assistedOnly,
-    dismissedAssistedKeys.length,
     setFilters,
     handleMarkFileAsRead,
     isImmersive,
@@ -2314,8 +2168,6 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
         lastRefreshFailure={lastRefreshFailure}
         assistedCount={assistedHunks.length}
         assistedUnreadCount={unreadAssistedInDiff}
-        assistedDismissedCount={dismissedAssistedKeys.length}
-        onRestoreDismissedAssisted={handleRestoreDismissedAssisted}
       />
 
       {diffState.status === "error" ? (
@@ -2509,15 +2361,6 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
                           Show read pins
                         </button>
                       )}
-                      {hasDismissedAssistedHunks && (
-                        <button
-                          type="button"
-                          onClick={handleRestoreDismissedAssisted}
-                          className="hover:text-foreground cursor-pointer border-none bg-transparent p-0 underline-offset-2 transition-colors hover:underline"
-                        >
-                          Restore {dismissedAssistedKeys.length} dismissed
-                        </button>
-                      )}
                     </div>
                   </div>
                 </div>
@@ -2613,16 +2456,6 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
                           Show read pins
                         </button>
                       )}
-                      {hasDismissedAssistedHunks && (
-                        <button
-                          type="button"
-                          onClick={handleRestoreDismissedAssisted}
-                          className="border-border-light hover:bg-hover hover:text-foreground rounded border bg-transparent px-2 py-0.5 transition-colors"
-                          data-testid="review-assisted-empty-restore-dismissed"
-                        >
-                          Restore {dismissedAssistedKeys.length} dismissed
-                        </button>
-                      )}
                     </div>
                   )}
                 </div>
@@ -2656,10 +2489,6 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
                       assistedComment={assistedCommentByHunkId.get(hunk.id)}
                       isAssisted={assistedMatchByHunkId.has(hunk.id)}
                       isAssistedNew={assistedNewByHunkId.has(hunk.id)}
-                      assistedKey={assistedKeyByHunkId.get(hunk.id)}
-                      assistedSourceMessageId={assistedSourceMessageIdByHunkId.get(hunk.id)}
-                      onDismissAssisted={handleDismissAssistedPin}
-                      onJumpToAssistedSource={handleJumpToAssistedSource}
                       visibleNewLineRange={assistedRangeByHunkId.get(hunk.id)}
                     />
                   );

--- a/src/browser/utils/messages/StreamingMessageAggregator.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.test.ts
@@ -3164,17 +3164,15 @@ describe("StreamingMessageAggregator", () => {
 /**
  * Tests for `review_pane_update` -> assistedReviewHunks bookkeeping.
  *
- * Cover the metadata bits added when implementing the assisted-review UX
- * fixes:
- *   - sourceMessageId: the assistant turn id is recorded with each pin so
- *     the UI can offer a "jump to source turn" affordance.
+ * Cover the metadata bits the aggregator tracks for the assisted-review UI:
  *   - addedAt: set on first sight of each pin's path[:range] key during a
  *     live update, used to drive the transient "new" badge. Replay
  *     intentionally skips this so historical pins don't flash as "new" on
  *     initial load.
- *   - Carryover: re-flagging an existing key (typical with `operation: "add"`
- *     when an agent refines a comment) preserves the original metadata so a
- *     refined comment does not make the pin look brand-new.
+ *   - Carryover: re-flagging an existing key with `operation: "add"`
+ *     preserves the original `addedAt` so a refined comment does not make
+ *     the pin look brand-new.
+ *   - Dedup: a fresh `replace` snapshot drops keys that aren't reincluded.
  *
  * Lives in this file (rather than its own test file) so test ordering stays
  * stable — adding a new `*.test.ts` shifts the alphabetical order across the
@@ -3203,11 +3201,10 @@ function historicalReviewPaneUpdateMessage(
 }
 
 describe("review_pane_update -> assistedReviewHunks", () => {
-  test("replay tags pins with sourceMessageId but skips addedAt", () => {
-    // Initial-load case: we never want replayed history to light up the
+  test("replay parses pins without lighting up the addedAt badge", () => {
+    // Initial-load case: we never want replayed history to flash the
     // transient "new" badge. The aggregator deliberately omits the
-    // timestamp on replay, so addedAt stays undefined while
-    // sourceMessageId is set.
+    // timestamp on replay, so addedAt stays undefined for every pin.
     const aggregator = new StreamingMessageAggregator(TEST_CREATED_AT);
     aggregator.loadHistoricalMessages([
       historicalReviewPaneUpdateMessage("assistant-1", [
@@ -3219,15 +3216,17 @@ describe("review_pane_update -> assistedReviewHunks", () => {
     const pins = aggregator.getAssistedReviewHunks();
     expect(pins).toHaveLength(2);
     expect(pins[0].path).toBe("src/foo.ts");
-    expect(pins[0].sourceMessageId).toBe("assistant-1");
+    expect(pins[0].range).toEqual({ start: 10, end: 12 });
     expect(pins[0].addedAt).toBeUndefined();
 
     expect(pins[1].path).toBe("src/bar.ts");
-    expect(pins[1].sourceMessageId).toBe("assistant-1");
     expect(pins[1].addedAt).toBeUndefined();
   });
 
-  test("carryover: re-flagging an existing path:range preserves sourceMessageId", () => {
+  test("`add` re-flagging an existing path:range refines the comment in place", () => {
+    // `add` semantics: dedup the existing key, but let the latest comment
+    // win so an agent can revise its rationale without producing a second
+    // pin for the same range.
     const aggregator = new StreamingMessageAggregator(TEST_CREATED_AT);
     aggregator.loadHistoricalMessages([
       historicalReviewPaneUpdateMessage(
@@ -3246,47 +3245,12 @@ describe("review_pane_update -> assistedReviewHunks", () => {
 
     const refreshed = aggregator.getAssistedReviewHunks();
     expect(refreshed).toHaveLength(1);
-    // Carry-over: sourceMessageId sticks to the first turn that introduced
-    // this path:range key so "jump to source" still points at the original
-    // rationale, even after an `add` refined the comment.
-    expect(refreshed[0].sourceMessageId).toBe("assistant-1");
-    // But the refined comment wins, mirroring the tool's last-writer-wins
-    // behavior on duplicate keys.
+    // Last-writer-wins on the comment for duplicate keys under `add`.
     expect(refreshed[0].comment).toBe("look at parser (revised)");
   });
 
-  test("brand-new pins during a later turn get that turn's sourceMessageId", () => {
-    const aggregator = new StreamingMessageAggregator(TEST_CREATED_AT);
-    aggregator.loadHistoricalMessages([
-      historicalReviewPaneUpdateMessage(
-        "assistant-1",
-        [{ path: "src/foo.ts", comment: null }],
-        "replace",
-        { historySequence: 1 }
-      ),
-      historicalReviewPaneUpdateMessage(
-        "assistant-2",
-        [
-          { path: "src/foo.ts", comment: null }, // existing — carryover
-          { path: "src/baz.ts:5", comment: "new turn introduced this" },
-        ],
-        "add",
-        { historySequence: 2, toolCallId: "tc-2" }
-      ),
-    ]);
-
-    const pins = aggregator.getAssistedReviewHunks();
-    expect(pins).toHaveLength(2);
-    const foo = pins.find((p) => p.path === "src/foo.ts");
-    const baz = pins.find((p) => p.path === "src/baz.ts");
-    expect(foo?.sourceMessageId).toBe("assistant-1");
-    expect(baz?.sourceMessageId).toBe("assistant-2");
-  });
-
-  test("a `replace` with a fresh key drops sourceMessageId of dropped entries", () => {
+  test("a `replace` drops keys that the new snapshot does not reinclude", () => {
     // Sanity check: when the agent replaces the set, dropped keys vanish.
-    // We don't carry forward sourceMessageId for entries that the replace
-    // didn't reinclude.
     const aggregator = new StreamingMessageAggregator(TEST_CREATED_AT);
     aggregator.loadHistoricalMessages([
       historicalReviewPaneUpdateMessage(
@@ -3306,34 +3270,5 @@ describe("review_pane_update -> assistedReviewHunks", () => {
     const pins = aggregator.getAssistedReviewHunks();
     expect(pins).toHaveLength(1);
     expect(pins[0].path).toBe("src/bar.ts");
-    expect(pins[0].sourceMessageId).toBe("assistant-2");
-  });
-
-  test("a `replace` republishing an existing key refreshes sourceMessageId", () => {
-    // `replace` is an explicit re-publish: even if the same path:range
-    // key reappears in the new snapshot, that's the agent intentionally
-    // re-flagging the region, not a refinement. Metadata should refresh
-    // so the UI's "jump to source turn" link points at the latest turn
-    // and the "new" badge can re-arm.
-    const aggregator = new StreamingMessageAggregator(TEST_CREATED_AT);
-    aggregator.loadHistoricalMessages([
-      historicalReviewPaneUpdateMessage(
-        "assistant-1",
-        [{ path: "src/foo.ts", comment: "original" }],
-        "replace",
-        { historySequence: 1 }
-      ),
-      historicalReviewPaneUpdateMessage(
-        "assistant-2",
-        [{ path: "src/foo.ts", comment: "republished" }],
-        "replace",
-        { historySequence: 2, toolCallId: "tc-2" }
-      ),
-    ]);
-
-    const pins = aggregator.getAssistedReviewHunks();
-    expect(pins).toHaveLength(1);
-    expect(pins[0].sourceMessageId).toBe("assistant-2");
-    expect(pins[0].comment).toBe("republished");
   });
 });

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -505,11 +505,10 @@ export class StreamingMessageAggregator {
   // Reconstructed from chat history on reload via processToolResult so the
   // pinned set survives restarts; not persisted to disk.
   //
-  // Each entry carries optional `sourceMessageId` + `addedAt` metadata so the
-  // UI can render "jump to source turn" and "new since last update" cues. These
-  // fields are populated when the surrounding message context is known (i.e.
-  // when processing tool results); they are intentionally optional so callers
-  // without message context (legacy paths, tests) don't have to fabricate them.
+  // Each entry carries optional `addedAt` metadata so the UI can render a
+  // "new since last update" badge. The timestamp is populated only during
+  // live tool-call processing (not history replay); legacy paths and tests
+  // can omit it.
   private assistedReviewHunks: AssistedReviewHunk[] = [];
 
   // Loaded skills (updated when agent_skill_read succeeds)
@@ -1166,13 +1165,10 @@ export class StreamingMessageAggregator {
           let assistantUpdatedTodos = false;
           for (const part of message.parts) {
             if (isDynamicToolPart(part) && part.state === "output-available") {
-              // Pass messageId so derived state like assisted-review pins can
-              // remember which turn introduced them. We intentionally skip the
-              // timestamp on replay so historical pins don't all light up as
-              // "new" on initial load; only live updates get a fresh addedAt.
-              this.processToolResult(part.toolName, part.input, part.output, {
-                messageId: message.id,
-              });
+              // Replay deliberately omits the timestamp so historical
+              // assisted-review pins don't all light up as "new" on initial
+              // load; only live updates get a fresh addedAt.
+              this.processToolResult(part.toolName, part.input, part.output);
               if (
                 part.toolName === "todo_write" &&
                 hasSuccessResult(part.output) &&
@@ -2493,15 +2489,15 @@ export class StreamingMessageAggregator {
    * @param input - Tool input arguments
    * @param output - Tool output result
    * @param messageContext - Optional metadata about the assistant message that
-   *   owns this tool call. Used by `review_pane_update` to remember which turn
-   *   introduced each agent-flagged hunk so the UI can offer a "jump to source
-   *   message" affordance and a "new since last update" badge.
+   *   owns this tool call. Used by `review_pane_update` to stamp each
+   *   agent-flagged hunk with the originating turn's timestamp so the UI
+   *   can render a "new since last update" badge for freshly-added pins.
    */
   private processToolResult(
     toolName: string,
     input: unknown,
     output: unknown,
-    messageContext?: { messageId?: string; timestamp?: number }
+    messageContext?: { timestamp?: number }
   ): void {
     // Update TODO state if this was a successful todo_write.
     // We still reconstruct from history so interrupted/incomplete plans survive reloads;
@@ -2521,19 +2517,18 @@ export class StreamingMessageAggregator {
     // structured AssistedReviewHunk form. Re-running this across the entire
     // history naturally reconstructs the final state on reload.
     //
-    // We additionally carry `sourceMessageId` + `addedAt` per pin so the UI
-    // can show a "jump to source turn" affordance and a transient "new" badge.
+    // We additionally carry `addedAt` per pin so the UI can render a
+    // transient "new" badge for freshly-added pins.
     //
     // Carryover semantics:
     //   - `operation: "add"` — the agent is appending to or refining the
     //     existing set, so a previously-seen key keeps its original
-    //     metadata. This prevents an `add` that just tweaks a comment
+    //     `addedAt`. This prevents an `add` that just tweaks a comment
     //     from re-arming the "new" badge.
     //   - `operation: "replace"` — the agent is republishing a fresh
     //     snapshot. Treat every entry as new for metadata purposes (the
     //     same key reappearing is an explicit re-flag, not a refinement),
-    //     so the UI can highlight the snapshot and link to the latest
-    //     source turn.
+    //     so the UI can re-highlight the snapshot.
     if (toolName === "review_pane_update") {
       const parsed = ReviewPaneUpdateSuccessResultSchema.safeParse(output);
       if (parsed.success) {
@@ -2556,21 +2551,17 @@ export class StreamingMessageAggregator {
           const key = formatAssistedFilter(candidate);
           const previous = previousByKey.get(key);
           if (isAdd && previous) {
-            // Carry forward sourceMessageId/addedAt for `add` ops only so
-            // a refined comment doesn't reset the "new" badge.
-            candidate.sourceMessageId = previous.sourceMessageId;
+            // Carry forward addedAt for `add` ops only so a refined
+            // comment doesn't reset the "new" badge.
             candidate.addedAt = previous.addedAt;
-          } else {
+          } else if (messageContext?.timestamp !== undefined) {
             // `replace` op (or first time we've seen this key under any op):
-            // stamp with the current message's metadata. `replace` is an
-            // explicit republish, so reuse of an old key should still be
-            // surfaced with fresh "source turn" + "new" cues. Replay
-            // deliberately omits the timestamp so historical pins don't
-            // all light up as "new" on initial load.
-            candidate.sourceMessageId = messageContext?.messageId;
-            if (messageContext?.timestamp !== undefined) {
-              candidate.addedAt = messageContext.timestamp;
-            }
+            // stamp with the current message's timestamp. `replace` is an
+            // explicit republish, so reuse of an old key should still
+            // re-arm the "new" badge. Replay deliberately omits the
+            // timestamp so historical pins don't all light up as "new"
+            // on initial load.
+            candidate.addedAt = messageContext.timestamp;
           }
           next.push(candidate);
         }
@@ -2708,7 +2699,6 @@ export class StreamingMessageAggregator {
         // badge can highlight just-introduced pins (the replay path
         // intentionally omits this so historical pins don't flash on load).
         this.processToolResult(data.toolName, toolPart.input, data.result, {
-          messageId: data.messageId,
           timestamp: Date.now(),
         });
 

--- a/src/common/types/review.ts
+++ b/src/common/types/review.ts
@@ -122,16 +122,6 @@ export interface AssistedReviewHunk {
   /** Optional agent comment explaining why this area needs review. */
   comment?: string;
   /**
-   * Frontend-only: id of the assistant message whose `review_pane_update`
-   * tool call produced this pin. Tracked during history replay so the UI
-   * can offer a "jump to source turn" affordance for each pin. Carried
-   * forward across subsequent `operation: "add"` calls so a refined comment
-   * doesn't make the pin look like it was just introduced.
-   *
-   * Not persisted to disk; recomputed from the transcript on every load.
-   */
-  sourceMessageId?: string;
-  /**
    * Frontend-only: timestamp (ms since epoch) when this pin was first
    * observed during this client's lifetime — i.e., when `review_pane_update`
    * introduced the path:range key. Used to render a transient "new" badge

--- a/src/constants/workspaceDefaults.ts
+++ b/src/constants/workspaceDefaults.ts
@@ -6,15 +6,6 @@ export const STORAGE_KEYS = {
   reviewDefaultBase: (projectPath: string) => `review-default-base:${projectPath}`,
   /** Per-workspace diff base override. Pass workspaceId. */
   reviewDiffBase: (workspaceId: string) => `review-diff-base:${workspaceId}`,
-  /**
-   * Per-workspace set of assisted-review pins the user has explicitly
-   * dismissed. Stored as a JSON array of formatted path[:range] keys
-   * (matching `formatAssistedFilter`). Dismissed pins are treated as
-   * non-assisted for filtering and pin-first sorting, letting users
-   * quiet a noisy agent without waiting for it to clear/replace the
-   * set. Pass workspaceId.
-   */
-  reviewAssistedDismissed: (workspaceId: string) => `review-assisted-dismissed:${workspaceId}`,
 } as const;
 
 Object.freeze(STORAGE_KEYS);


### PR DESCRIPTION
## Summary

Follow-up to the assisted-review UX pass (#3358). Removes the per-pin
"dismiss" and "jump to source" actions plus all of their supporting
state, since neither was carrying its weight: dismiss did not survive
user testing as useful, and jump-to-source only worked when the chat
transcript happened to be mounted with the matching `data-message-id`
in the DOM — it silently no-op'd in immersive review and in many
split-view layouts.

## Background

Direct feedback after the UX pass shipped:

> The dismiss action is not useful, and the jump to source doesn't
> even work so should be removed unless it can easily be made more
> reliable.

The jump-to-source mechanism relied on a global `document.querySelector`
hitting the transcript boundary. That assumption breaks any time the
right sidebar isn't on the Chat tab, the immersive review overlay is
covering the transcript, or virtualization clipping is in play. Making
it reliable in all those cases would require routing the jump through a
chat-pane scroll API and reasoning about which tab/route is currently
in front — well beyond a minor UX touch-up, especially given the action
wasn't earning attention in practice.

## Implementation

- `HunkViewer`: drops `assistedKey`, `assistedSourceMessageId`,
  `onDismissAssisted`, and `onJumpToAssistedSource` props plus the
  entire actions strip below the assisted comment.
- `ReviewPanel`: drops the dismissed-pin `usePersistedState` (in both
  the panel and the always-mounted stats reporter), the self-healing
  prune effect, the `handleDismissAssistedPin` /
  `handleRestoreDismissedAssisted` / `handleJumpToAssistedSource`
  callbacks, the `assistedKeyByHunkId` /
  `assistedSourceMessageIdByHunkId` maps, and the "Restore N dismissed"
  links in the banner / empty-state. The keybind effect no longer needs
  `dismissedAssistedKeys.length` to decide whether to no-op the toggle.
- `ReviewControls`: drops the `assistedDismissedCount` /
  `onRestoreDismissedAssisted` props and the "+N dismissed" tooltip
  entry in the control bar.
- `STORAGE_KEYS.reviewAssistedDismissed`: deleted (no other consumer).
- `AssistedReviewHunk.sourceMessageId`: deleted; it was only consumed
  by the removed jump button. `StreamingMessageAggregator` no longer
  threads `messageId` into `processToolResult`; the live-vs-replay
  distinction is now carried entirely by the existing `addedAt`
  timestamp, which still drives the transient "new" badge.

## Validation

- `make static-check`
- `bun test src/browser/utils/messages/StreamingMessageAggregator.test.ts src/browser/features/RightSidebar/CodeReview/ReviewPanel.assistedStats.test.ts`
- `make test` — same 5 pre-existing failures as on `origin/main`
  (`useChatTranscriptFullWidth`, `GeneralSection`); unrelated to this
  change.

## Risks

Low. The change is a pure removal of two surfaced affordances and their
supporting localStorage. Existing `review-assisted-dismissed:<workspaceId>`
entries become harmless orphans in localStorage — they're per-workspace
and small, and self-heal next time the user clears site data; no
migration is warranted given the feature shipped only days ago in
#3358. The remaining assisted-review behavior (matching, "new" badge,
worklist toggle, filter persistence) is unchanged.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `xhigh` • Cost: `$?`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=xhigh costs=? -->
