### PR TITLE
🤖 fix(review): use blue for Assisted Review highlight

### DIFF
--- a/src/browser/features/RightSidebar/CodeReview/HunkViewer.stories.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/HunkViewer.stories.tsx
@@ -5,6 +5,10 @@ import { useRef, useState, type ComponentType, type FC, type ReactNode } from "r
 import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
 import { APIProvider, type APIClient } from "@/browser/contexts/API";
 import { ThemeProvider } from "@/browser/contexts/ThemeContext";
+import {
+  WorkspaceContext,
+  type WorkspaceContext as WorkspaceContextValue,
+} from "@/browser/contexts/WorkspaceContext";
 import { createMockORPCClient } from "@/browser/stories/mocks/orpc";
 import { CHROMATIC_SMOKE_MODES } from "@/browser/stories/meta";
 import type { DiffHunk } from "@/common/types/review";
@@ -62,11 +66,54 @@ function createHunkViewerStoryClient(): APIClient {
   });
 }
 
+// HunkViewer → useReadMore → useWorkspaceMetadata. The hook only needs the
+// metadata map to resolve a repo-root project path (gracefully returns undefined
+// for missing entries), so the empty map + no-op actions stub is enough to let
+// HunkViewer mount without spinning up the full WorkspaceProvider stack.
+function createStubWorkspaceContextValue(): WorkspaceContextValue {
+  return {
+    workspaceMetadata: new Map(),
+    loading: false,
+    workspaceDraftPromotionsByProject: {},
+    promoteWorkspaceDraft: () => undefined,
+    createWorkspace: () =>
+      Promise.resolve({
+        projectPath: "/tmp/project",
+        projectName: "project",
+        namedWorkspacePath: "/tmp/project/main",
+        workspaceId: "created-workspace",
+      }),
+    removeWorkspace: () => Promise.resolve({ success: true }),
+    updateWorkspaceTitle: () => Promise.resolve({ success: true }),
+    preflightArchiveWorkspace: () => Promise.resolve({ success: true }),
+    archiveWorkspace: () => Promise.resolve({ success: true }),
+    unarchiveWorkspace: () => Promise.resolve({ success: true }),
+    refreshWorkspaceMetadata: () => Promise.resolve(),
+    setWorkspaceMetadata: () => undefined,
+    selectedWorkspace: null,
+    setSelectedWorkspace: () => undefined,
+    pendingNewWorkspaceProject: null,
+    pendingNewWorkspaceSubProjectPath: null,
+    pendingNewWorkspaceDraftId: null,
+    beginWorkspaceCreation: () => undefined,
+    workspaceDraftsByProject: {},
+    createWorkspaceDraft: () => undefined,
+    updateWorkspaceDraftSubProject: () => undefined,
+    openWorkspaceDraft: () => undefined,
+    deleteWorkspaceDraft: () => undefined,
+    getWorkspaceInfo: () => Promise.resolve(null),
+  };
+}
+
 const HunkViewerStoryShell: FC<{ client: APIClient; children: ReactNode }> = (props) => {
   return (
     <ThemeProvider>
       <TooltipProvider>
-        <APIProvider client={props.client}>{props.children}</APIProvider>
+        <APIProvider client={props.client}>
+          <WorkspaceContext.Provider value={createStubWorkspaceContextValue()}>
+            {props.children}
+          </WorkspaceContext.Provider>
+        </APIProvider>
       </TooltipProvider>
     </ThemeProvider>
   );

--- a/src/browser/features/RightSidebar/CodeReview/HunkViewer.stories.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/HunkViewer.stories.tsx
@@ -1,0 +1,197 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { within, waitFor } from "@storybook/test";
+import { useRef, useState, type ComponentType, type FC, type ReactNode } from "react";
+
+import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
+import { APIProvider, type APIClient } from "@/browser/contexts/API";
+import { ThemeProvider } from "@/browser/contexts/ThemeContext";
+import { createMockORPCClient } from "@/browser/stories/mocks/orpc";
+import { CHROMATIC_SMOKE_MODES } from "@/browser/stories/meta";
+import type { DiffHunk } from "@/common/types/review";
+import { extractAllHunks, parseDiff } from "@/common/utils/git/diffParser";
+
+import { HunkViewer } from "./HunkViewer";
+
+// Small TypeScript diff so the Sparkles + assisted comment row sits next to a
+// realistic block of highlighted code in Chromatic snapshots. Reuses the same
+// parsing pipeline as production so the story renders the exact hunk shape the
+// app uses, including `id` / `header` / new-line ranges.
+const ASSISTED_DIFF = `diff --git a/src/utils/formatPrice.ts b/src/utils/formatPrice.ts
+index 1111111..2222222 100644
+--- a/src/utils/formatPrice.ts
++++ b/src/utils/formatPrice.ts
+@@ -1,6 +1,8 @@
+ export function formatPrice(amount: number, currency = "USD"): string {
++  const formatter = new Intl.NumberFormat("en-US", { style: "currency", currency });
++
+   if (!Number.isFinite(amount)) {
+-    return "$0.00";
++    return formatter.format(0);
+   }
+-  return amount.toFixed(2);
++  return formatter.format(amount);
+ }
+`;
+
+const STORY_WORKSPACE_ID = "ws-hunk-viewer-assisted";
+const STORY_FIRST_SEEN_AT = 1_700_000_000_000;
+
+function parseStoryHunk(): DiffHunk {
+  const hunks = extractAllHunks(parseDiff(ASSISTED_DIFF));
+  const firstHunk = hunks[0];
+  if (!firstHunk) {
+    throw new Error("ASSISTED_DIFF fixture must produce at least one hunk.");
+  }
+  return firstHunk;
+}
+
+const STORY_HUNK = parseStoryHunk();
+
+function createHunkViewerStoryClient(): APIClient {
+  // HunkViewer's useReadMore hook calls into the API client, but only when the
+  // user expands additional context. We mock executeBash with an empty success
+  // so the lazy expansion path stays inert during snapshot capture.
+  return createMockORPCClient({
+    executeBash: () =>
+      Promise.resolve({
+        success: true,
+        output: "",
+        exitCode: 0,
+        wall_duration_ms: 0,
+      }),
+  });
+}
+
+const HunkViewerStoryShell: FC<{ client: APIClient; children: ReactNode }> = (props) => {
+  return (
+    <ThemeProvider>
+      <TooltipProvider>
+        <APIProvider client={props.client}>{props.children}</APIProvider>
+      </TooltipProvider>
+    </ThemeProvider>
+  );
+};
+
+interface HunkViewerStoryProps {
+  assistedComment?: string;
+  isAssisted?: boolean;
+  isAssistedNew?: boolean;
+}
+
+function HunkViewerStory(props: HunkViewerStoryProps) {
+  const client = useRef(createHunkViewerStoryClient()).current;
+  const [isRead, setIsRead] = useState(false);
+
+  return (
+    <HunkViewerStoryShell client={client}>
+      <div className="bg-background p-4">
+        <HunkViewer
+          hunk={STORY_HUNK}
+          hunkId={STORY_HUNK.id}
+          workspaceId={STORY_WORKSPACE_ID}
+          isSelected={false}
+          isRead={isRead}
+          firstSeenAt={STORY_FIRST_SEEN_AT}
+          onToggleRead={() => setIsRead((prev) => !prev)}
+          diffBase="main"
+          includeUncommitted={false}
+          assistedComment={props.assistedComment}
+          isAssisted={props.isAssisted}
+          isAssistedNew={props.isAssistedNew}
+        />
+      </div>
+    </HunkViewerStoryShell>
+  );
+}
+
+const meta: Meta<typeof HunkViewer> = {
+  title: "Features/RightSidebar/CodeReview/HunkViewer",
+  component: HunkViewer,
+  decorators: [
+    (Story: ComponentType) => (
+      <div style={{ width: 880 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: "padded",
+    // Dual light/dark coverage so the assisted accent (blue) is verified in both
+    // themes — the whole point of these stories is to lock in the accent color
+    // across themes so it cannot drift back toward the warning/amber family.
+    chromatic: { delay: 300, modes: CHROMATIC_SMOKE_MODES },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Baseline (non-assisted) hunk so reviewers can compare against the assisted variants. */
+export const Default: Story = {
+  render: () => <HunkViewerStory />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => {
+      // Should NOT have any assisted UI — confirms the comparison baseline.
+      if (canvas.queryByTestId("hunk-assisted-comment")) {
+        throw new Error("Baseline hunk should not render the assisted-comment banner.");
+      }
+    });
+  },
+};
+
+/**
+ * Assisted hunk with an agent-provided comment. Exercises the primary
+ * `--color-review-accent` surfaces: Sparkles icon, banner border/background,
+ * and the foreground text color used inside the strip.
+ */
+export const WithAssistedComment: Story = {
+  render: () => (
+    <HunkViewerStory assistedComment="The formatter is recreated on every call — hoist it outside the function so currency changes still share the cached Intl.NumberFormat." />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => {
+      canvas.getByTestId("hunk-assisted-comment");
+    });
+  },
+};
+
+/**
+ * Assisted hunk with the transient "NEW" pill. Locks in the additional
+ * `--color-review-accent` surface used by the `isAssistedNew` badge so a
+ * regression in either the banner or the pill is caught by Chromatic.
+ */
+export const WithAssistedCommentNewBadge: Story = {
+  render: () => (
+    <HunkViewerStory
+      assistedComment="Just pinned by the agent — surfaces the NEW pill alongside the comment."
+      isAssistedNew
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => {
+      canvas.getByTestId("hunk-assisted-comment");
+      canvas.getByTestId("hunk-assisted-new-badge");
+    });
+  },
+};
+
+/**
+ * Assisted hunk *without* a comment. Exercises the italic "Flagged by agent for
+ * review" placeholder plus the header's left-edge accent stripe
+ * (`border-l-review-accent`), which is the only assisted surface that doesn't
+ * also appear in the with-comment story.
+ */
+export const AssistedWithoutComment: Story = {
+  render: () => <HunkViewerStory isAssisted />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => {
+      canvas.getByTestId("hunk-assisted-comment");
+      canvas.getByText(/Flagged by agent for review/i);
+    });
+  },
+};

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.stories.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.stories.tsx
@@ -285,6 +285,10 @@ interface ImmersiveReviewStoryProps {
   fixture: ImmersiveStoryFixture;
   reviewActions?: ComponentProps<typeof ImmersiveReviewView>["reviewActions"];
   initialReadHunkIds?: string[];
+  /** Hunk IDs flagged by the agent (via `review_pane_update`). */
+  assistedHunkIds?: ReadonlySet<string>;
+  /** Per-hunk agent comments — drives the immersive assisted-review banner. */
+  assistedCommentByHunkId?: Map<string, string>;
 }
 
 function ImmersiveReviewStory(props: ImmersiveReviewStoryProps) {
@@ -334,6 +338,8 @@ function ImmersiveReviewStory(props: ImmersiveReviewStoryProps) {
         reviewActions={props.reviewActions}
         reviewsByFilePath={props.fixture.reviewsByFilePath}
         firstSeenMap={props.fixture.firstSeenMap}
+        assistedHunkIds={props.assistedHunkIds}
+        assistedCommentByHunkId={props.assistedCommentByHunkId}
       />
     </ImmersiveStoryShell>
   );
@@ -492,6 +498,48 @@ export const ImmersiveWithMinimap: Story = {
       () => {
         canvas.getByTestId("immersive-review-view");
         canvas.getByRole("button", { name: /exit immersive review/i });
+      },
+      { timeout: 10_000 }
+    );
+  },
+};
+
+const IMMERSIVE_ASSISTED_WORKSPACE_ID = "ws-review-immersive-assisted";
+const IMMERSIVE_ASSISTED_FIXTURE = LINE_HEIGHT_FIXTURE;
+const IMMERSIVE_ASSISTED_FIRST_HUNK_ID = IMMERSIVE_ASSISTED_FIXTURE.hunks[0]?.id ?? "";
+const IMMERSIVE_ASSISTED_HUNK_IDS: ReadonlySet<string> = new Set([
+  IMMERSIVE_ASSISTED_FIRST_HUNK_ID,
+]);
+// Map literal lookup matches production — ImmersiveReviewView reads the comment
+// for the *selected* hunk and renders the assisted banner above the diff.
+const IMMERSIVE_ASSISTED_COMMENT_BY_HUNK_ID = new Map<string, string>([
+  [
+    IMMERSIVE_ASSISTED_FIRST_HUNK_ID,
+    "Hoist the formatter out of formatPrice — recreating it on every call defeats the Intl.NumberFormat cache.",
+  ],
+]);
+
+/**
+ * Immersive review with an active assisted-review pin. Locks in the
+ * `--color-review-accent` blue accent for the immersive banner (Sparkles +
+ * border + background tint) in both light + dark themes.
+ */
+export const ImmersiveWithAssistedBanner: Story = {
+  render: () => (
+    <ImmersiveReviewStory
+      workspaceId={IMMERSIVE_ASSISTED_WORKSPACE_ID}
+      fixture={IMMERSIVE_ASSISTED_FIXTURE}
+      assistedHunkIds={IMMERSIVE_ASSISTED_HUNK_IDS}
+      assistedCommentByHunkId={IMMERSIVE_ASSISTED_COMMENT_BY_HUNK_ID}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(
+      () => {
+        canvas.getByTestId("immersive-review-view");
+        canvas.getByTestId("immersive-assisted-banner");
       },
       { timeout: 10_000 }
     );

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -217,7 +217,7 @@
     /* Status */
     --color-interrupted: hsl(0 0% 53%);
     --color-backgrounded: hsl(200 70% 55%); /* cyan-ish blue for backgrounded processes */
-    --color-review-accent: hsl(48 70% 50%);
+    --color-review-accent: hsl(210 100% 65%); /* sky blue — distinct from amber/yellow warning states */
     --color-git-dirty: hsl(38 92% 50%);
     --color-error: hsl(0 70% 50%);
     --color-error-bg: hsl(0 32% 18%);
@@ -489,7 +489,7 @@
 
   --color-interrupted: hsl(0 0% 50%);
   --color-backgrounded: hsl(200 70% 50%);
-  --color-review-accent: hsl(48 70% 52%);
+  --color-review-accent: hsl(212 85% 48%); /* saturated blue — distinct from amber/yellow warning states */
   --color-git-dirty: hsl(38 92% 50%);
   --color-error: hsl(0 68% 46%);
   --color-error-bg: hsl(0 82% 94%);
@@ -728,7 +728,7 @@
 
   --color-interrupted: #6f6e69;
   --color-backgrounded: #24837b; /* Flexoki cyan-600 */
-  --color-review-accent: #ad8301;
+  --color-review-accent: #4385be; /* Flexoki blue-400 — distinct from amber/yellow warning states */
   --color-git-dirty: #bc5215;
   --color-error: #af3029; /* Flexoki red-600 */
   --color-error-bg: hsl(from var(--color-error) h s l / 0.12);
@@ -954,7 +954,7 @@
 
   --color-interrupted: #878580;
   --color-backgrounded: #3aa99f; /* Flexoki cyan-400 */
-  --color-review-accent: #d0a215;
+  --color-review-accent: #92bfdb; /* Flexoki blue-300 — distinct from amber/yellow warning states */
   --color-git-dirty: #da702c;
   --color-error: #d14d41; /* Flexoki red-400 */
   --color-error-bg: hsl(from var(--color-error) h s l / 0.15);


### PR DESCRIPTION
## Summary

The Assisted Review highlight (`--color-review-accent`) was a yellow/gold that lived in the same hue family as `--color-warning`, `--color-edit-mode`, and `--color-info-yellow`. That overlap made agent-pinned hunks read as "warning" rather than "agent flagged this for review." This switches the accent to blue in every theme so the assisted highlight is visually distinct from warning states while remaining off the primary `--color-accent` so it doesn't read as a generic UI accent either.

## Implementation

Single variable, four theme blocks — every consumer of `--color-review-accent` inherits the new color (HunkViewer assisted border + Sparkles, ReviewControls toggle, ReviewPanel header banner, ImmersiveReviewView banner + minimap active line, InlineReviewNote, ReviewBlock, ReviewsBanner, DiffRenderer review-range tint, ReviewPaneUpdateToolCall icon, Tab labels).

| Theme | Before | After |
|---|---|---|
| Default (dark) | `hsl(48 70% 50%)` yellow | `hsl(210 100% 65%)` sky blue |
| Light | `hsl(48 70% 52%)` yellow | `hsl(212 85% 48%)` saturated blue |
| Flexoki-light | `#ad8301` (yellow-600) | `#4385be` (blue-400) |
| Flexoki-dark | `#d0a215` (yellow-400) | `#92bfdb` (blue-300) |

The Flexoki tones are shifted one step off `--color-accent` in each direction (light theme uses the standard blue-400; dark theme uses a lighter blue-300) so the assisted highlight remains separable from generic accent blues. Inline comments document the rationale at each definition site so future theme work doesn't silently re-yellow it.

### Storybook coverage

The assisted-review surfaces previously had no Storybook stories, so the existing tonal regression wouldn't have been caught by Chromatic. This PR adds coverage so the new blue (and any future drift back toward warning amber) is locked in across both themes:

- **`HunkViewer.stories.tsx`** (new) — 4 stories covering every unique assisted accent surface:
  - `Default` — non-assisted baseline for visual diff
  - `WithAssistedComment` — Sparkles + banner border/background + foreground text
  - `WithAssistedCommentNewBadge` — adds the transient `NEW` pill (`border-review-accent/40 text-review-accent bg-review-accent/10`)
  - `AssistedWithoutComment` — italic "Flagged by agent for review" placeholder + the header's left-edge `border-l-review-accent` stripe (the only surface that doesn't appear in the with-comment variants)
- **`ImmersiveReviewView.stories.tsx`** — augmented with `assistedHunkIds` + `assistedCommentByHunkId` plumbing and a new `ImmersiveWithAssistedBanner` story exercising the immersive assisted-review banner (`data-testid="immersive-assisted-banner"`).

All new stories ship with light + dark Chromatic modes.

## Risks

Low — pure CSS variable swap, no logic touched. The variable is already consumed via `var(--color-review-accent)`, `border-review-accent`, and `text-review-accent` Tailwind aliases, so all surfaces pick up the new color automatically. The `ImmersiveMinimap` review-comment indicators (which intentionally use `--color-warning`, not the review accent) are unchanged.

## Validation

- `make static-check` passes locally (typecheck, fmt-check, lint, docs link check).
- New story `play` functions assert the assisted UI is mounted (e.g., `hunk-assisted-comment`, `hunk-assisted-new-badge`, `immersive-assisted-banner` testids).

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `high` • Cost: `$1.20`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=high costs=1.20 -->
