### PR TITLE
🤖 fix: isolate fork partial snapshots

### DIFF
--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -7411,6 +7411,124 @@ describe("WorkspaceService fork", () => {
       generateStableIdSpy.mockRestore();
     }
   });
+  test("fork snapshots persisted partials without mutating the source workspace", async () => {
+    const sourceWorkspaceId = "source-workspace";
+    const newWorkspaceId = "forked-workspace";
+    const sourceProjectPath = path.join(tempDir, "project");
+    const forkedWorkspacePath = path.join(sourceProjectPath, "fork-child");
+    const sourceMetadata: FrontendWorkspaceMetadata = {
+      id: sourceWorkspaceId,
+      name: "source-branch",
+      projectPath: sourceProjectPath,
+      projectName: "project",
+      runtimeConfig: { type: "local" },
+      namedWorkspacePath: path.join(sourceProjectPath, "source-branch"),
+    };
+
+    await fsPromises.mkdir(sourceProjectPath, { recursive: true });
+    await config.addWorkspace(sourceProjectPath, sourceMetadata);
+    await config.editConfig((current) => {
+      const project = current.projects.get(sourceProjectPath);
+      if (!project) {
+        throw new Error("Expected test project config to exist");
+      }
+      project.trusted = true;
+      return current;
+    });
+
+    const sourcePartial = createMuxMessage(
+      "assistant-partial",
+      "assistant",
+      "Waiting on task_await",
+      { historySequence: 1 }
+    );
+    const writePartialResult = await historyService.writePartial(sourceWorkspaceId, sourcePartial);
+    expect(writePartialResult.success).toBe(true);
+
+    const mockAIService = {
+      isStreaming: mock(() => false),
+      getWorkspaceMetadata: mock(() => Promise.resolve(Ok(sourceMetadata))),
+      on: mock(() => undefined),
+      off: mock(() => undefined),
+    } as unknown as AIService;
+
+    const mockInitStateManager: Partial<InitStateManager> = {
+      on: mock(() => undefined as unknown as InitStateManager),
+      getInitState: mock(() => ({ status: "running" }) as unknown as InitStatus),
+      startInit: mock(() => undefined),
+      endInit: mock(() => Promise.resolve()),
+      appendOutput: mock(() => undefined),
+      enterHookPhase: mock(() => undefined),
+    };
+
+    const workspaceService = new WorkspaceService(
+      config,
+      historyService,
+      mockAIService,
+      mockInitStateManager as InitStateManager,
+      mockExtensionMetadataService as ExtensionMetadataService,
+      mockBackgroundProcessManager as BackgroundProcessManager
+    );
+
+    const targetRuntime = {
+      getWorkspacePath: mock(() => forkedWorkspacePath),
+    } as unknown as ReturnType<typeof runtimeFactory.createRuntime>;
+
+    const generateStableIdSpy = spyOn(config, "generateStableId").mockReturnValue(newWorkspaceId);
+    const getOrCreateSessionSpy = spyOn(workspaceService, "getOrCreateSession").mockReturnValue({
+      emitMetadata: mock(() => undefined),
+    } as unknown as AgentSession);
+    const createRuntimeSpy = spyOn(runtimeFactory, "createRuntime").mockReturnValue(
+      {} as ReturnType<typeof runtimeFactory.createRuntime>
+    );
+    const runBackgroundInitSpy = spyOn(runtimeFactory, "runBackgroundInit").mockImplementation(
+      () => undefined
+    );
+    const copyPlanSpy = spyOn(runtimeExecHelpers, "copyPlanFileAcrossRuntimes").mockResolvedValue(
+      undefined
+    );
+    const orchestrateForkSpy = spyOn(forkOrchestratorModule, "orchestrateFork").mockResolvedValue(
+      Ok({
+        workspacePath: forkedWorkspacePath,
+        trunkBranch: "main",
+        forkedRuntimeConfig: { type: "local" },
+        targetRuntime,
+        forkedFromSource: true,
+        sourceRuntimeConfigUpdated: false,
+      })
+    );
+
+    try {
+      const result = await workspaceService.fork(sourceWorkspaceId, "fork-child");
+      expect(result.success).toBe(true);
+      if (!result.success) {
+        throw new Error(`Expected success result, got error: ${result.error}`);
+      }
+
+      const sourcePartialAfterFork = await historyService.readPartial(sourceWorkspaceId);
+      expect(sourcePartialAfterFork?.id).toBe(sourcePartial.id);
+      expect(await historyService.readPartial(newWorkspaceId)).toBeNull();
+
+      const forkedMessageIds: string[] = [];
+      const historyResult = await historyService.iterateFullHistory(
+        newWorkspaceId,
+        "forward",
+        (chunk) => {
+          forkedMessageIds.push(...chunk.map((message) => message.id));
+        }
+      );
+      expect(historyResult.success).toBe(true);
+      expect(forkedMessageIds).toContain(sourcePartial.id);
+    } finally {
+      orchestrateForkSpy.mockRestore();
+      copyPlanSpy.mockRestore();
+      runBackgroundInitSpy.mockRestore();
+      createRuntimeSpy.mockRestore();
+      getOrCreateSessionSpy.mockRestore();
+      generateStableIdSpy.mockRestore();
+    }
+  });
+
   test("auto-generated fork names normalize legacy fork families before the validation fallback", async () => {
     const sourceWorkspaceId = "source-workspace";
     const newWorkspaceId = "forked-workspace";

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -583,6 +583,46 @@ async function resetForkedSessionUsage(
   );
 }
 
+async function materializeForkedPartialSnapshot(params: {
+  historyService: HistoryService;
+  partialSnapshot: MuxMessage | null;
+  sourceWorkspaceId: string;
+  targetWorkspaceId: string;
+}): Promise<void> {
+  if (!params.partialSnapshot) {
+    return;
+  }
+
+  // Forking must be read-only with respect to the source workspace. During tool calls
+  // such as task_await, deleting or committing the source partial can make the live
+  // parent turn look interrupted. Instead, copy the partial into the fork and finalize
+  // only that snapshot so the child has no inherited live-stream state. The snapshot
+  // is captured before fork checkout/copy I/O so a parent stream that finishes mid-fork
+  // cannot make the child miss the latest visible assistant state.
+  const writeResult = await params.historyService.writePartial(
+    params.targetWorkspaceId,
+    params.partialSnapshot
+  );
+  if (!writeResult.success) {
+    log.warn("Failed to snapshot source partial into fork", {
+      sourceWorkspaceId: params.sourceWorkspaceId,
+      targetWorkspaceId: params.targetWorkspaceId,
+      error: writeResult.error,
+    });
+    return;
+  }
+
+  const commitResult = await params.historyService.commitPartial(params.targetWorkspaceId);
+  if (!commitResult.success) {
+    log.warn("Failed to finalize forked partial snapshot", {
+      sourceWorkspaceId: params.sourceWorkspaceId,
+      targetWorkspaceId: params.targetWorkspaceId,
+      error: commitResult.error,
+    });
+    await params.historyService.deletePartial(params.targetWorkspaceId);
+  }
+}
+
 function getOldestSequencedMessage(
   messages: readonly MuxMessage[]
 ): { message: MuxMessage; historySequence: number } | null {
@@ -5366,15 +5406,13 @@ export class WorkspaceService extends EventEmitter {
     pendingAutoTitle?: boolean
   ): Promise<Result<{ metadata: FrontendWorkspaceMetadata; projectPath: string }>> {
     try {
-      if (this.aiService.isStreaming(sourceWorkspaceId)) {
-        await this.historyService.commitPartial(sourceWorkspaceId);
-      }
-
       const sourceMetadataResult = await this.aiService.getWorkspaceMetadata(sourceWorkspaceId);
       if (!sourceMetadataResult.success) {
         return Err(`Failed to get source workspace metadata: ${sourceMetadataResult.error}`);
       }
       const sourceMetadata = sourceMetadataResult.data;
+      const partialSnapshot =
+        sourceMessageId == null ? await this.historyService.readPartial(sourceWorkspaceId) : null;
       const foundProjectPath = sourceMetadata.projectPath;
       const projectName = sourceMetadata.projectName;
       const sourceRuntimeConfig = sourceMetadata.runtimeConfig;
@@ -5567,7 +5605,6 @@ export class WorkspaceService extends EventEmitter {
 
         const sessionFiles = [
           "chat.jsonl",
-          "partial.json",
           "session-timing.json",
           ADDITIONAL_SYSTEM_CONTEXT_FILENAME,
           // Preserve the enabled/disabled toggle when forking so the fork
@@ -5602,6 +5639,13 @@ export class WorkspaceService extends EventEmitter {
             await fsPromises.rm(path.join(newSessionDir, "session-timing.json"), { force: true });
           }
         }
+
+        await materializeForkedPartialSnapshot({
+          historyService: this.historyService,
+          partialSnapshot,
+          sourceWorkspaceId,
+          targetWorkspaceId: newWorkspaceId,
+        });
 
         // Forks inherit chat history, but their cost ledger must start fresh.
         // Persist an explicit empty usage file so later reads do not rebuild


### PR DESCRIPTION
## Summary

Fixes `/fork` while the parent is mid-stream (including `task_await`) so forking is read-only with respect to the source workspace. Live partial assistant state is now materialized only into the forked workspace snapshot, and live `partial.json` state is no longer copied as active child state.

## Background

`WorkspaceService.fork()` previously called `historyService.commitPartial(sourceWorkspaceId)` when the source was streaming. During a long-running tool call like `task_await`, that could delete or rewrite the parent workspace's live `partial.json`, making the parent turn appear interrupted.

## Implementation

- Removed source partial commits from the fork path.
- Stopped copying `partial.json` as a raw session file into forks.
- Added a fork-only partial snapshot helper that reads the source partial, writes it to the new workspace, commits it there, and cleans up only the fork's partial file on failure.
- Added a regression test proving the source partial remains intact while the fork receives a finalized snapshot.

## Validation

- `bun test src/node/services/workspaceService.test.ts --test-name-pattern "WorkspaceService fork"`
- `make typecheck`
- `make static-check`

## Risks

Low-to-medium. This changes fork snapshot semantics for in-flight streams: forks no longer inherit a live `partial.json`; they inherit a finalized snapshot when a live partial exists. That is intentional to prevent child or parent disruption from shared live-stream state.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `high` • Cost: `unknown`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=high costs=unknown -->
