### PR TITLE
🤖 perf: enable React profiling for dev launches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,12 @@
 #   It is automatically disabled in CI, test environments, and automation contexts.
 #   To manually disable telemetry, set MUX_DISABLE_TELEMETRY=1.
 
+# React profiling in development:
+# Default desktop dev launches opt into Mux's lightweight component render sampler so
+# already-running dev instances can be inspected without a restart. Override with
+# `make start MUX_PROFILE_REACT=0` when measuring an uninstrumented baseline.
+MUX_PROFILE_REACT ?= 1
+
 # Use PATH-resolved bash for portability across different systems.
 # - Windows: /usr/bin/bash doesn't exist in Chocolatey's make environment or GitHub Actions
 # - NixOS: /bin/bash doesn't exist, bash is in /nix/store/...
@@ -203,7 +209,7 @@ dev-server-sandbox: ## Start an isolated dev-server instance (fresh MUX_ROOT + f
 	@bun scripts/dev-server-sandbox.ts $(DEV_SERVER_SANDBOX_ARGS)
 
 start: node_modules/.installed build-main build-preload build-static ## Build and start Electron app
-	@NODE_ENV=development bunx electron --remote-debugging-port=9222 .
+	@NODE_ENV=development MUX_PROFILE_REACT=$(MUX_PROFILE_REACT) bunx electron --remote-debugging-port=9222 .
 
 ## Build targets (can run in parallel)
 build: node_modules/.installed src/version.ts build-renderer build-main build-preload build-icons build-static ## Build all targets

--- a/scripts/dev-desktop-sandbox.ts
+++ b/scripts/dev-desktop-sandbox.ts
@@ -296,6 +296,9 @@ async function main(): Promise<number> {
       env: {
         ...process.env,
         NODE_ENV: "development",
+        // Keep sandboxed desktop dev launches profile-ready too; callers can set
+        // MUX_PROFILE_REACT=0 to compare against an uninstrumented renderer.
+        MUX_PROFILE_REACT: process.env.MUX_PROFILE_REACT ?? "1",
         MUX_ROOT: muxRoot,
         MUX_DEVSERVER_HOST: "127.0.0.1",
         MUX_DEVSERVER_PORT: String(vitePort),

--- a/src/common/types/global.d.ts
+++ b/src/common/types/global.d.ts
@@ -18,7 +18,7 @@ declare global {
     enableTelemetryInDev?: boolean;
     // E2E test mode flag - used to adjust UI behavior (e.g., longer toast durations)
     isE2E?: boolean;
-    // Enables in-app React.Profiler capture for automated perf tests.
+    // Enables in-app React render capture for dev profiling and automated perf tests.
     enableReactPerfProfile?: boolean;
     // Sandbox launchers default tutorials off unless explicitly re-enabled by env.
     enableTutorialsInSandbox?: boolean;


### PR DESCRIPTION
## Summary

Default desktop dev launches now enable Mux's lightweight React render sampler so already-running dev instances can be inspected with component-level profiling data. Developers can still opt out with `MUX_PROFILE_REACT=0` when they need an uninstrumented baseline.

## Background

The live profiling probe showed CDP CPU/trace capture was available, but Mux's component-level React samples were disabled because `MUX_PROFILE_REACT` is latched by preload startup. Enabling it by default for standard dev desktop launches makes the usual workflow profile-ready without a restart cycle after discovering a performance issue.

## Implementation

- Added a Makefile default of `MUX_PROFILE_REACT ?= 1` and passed it through `make start`.
- Defaulted `dev-desktop-sandbox` Electron launches to `MUX_PROFILE_REACT=1` while preserving explicit opt-out.
- Updated the global API comment to cover dev profiling as well as automated perf tests.

## Validation

- `make -n start MUX_PROFILE_REACT=0`
- `make -n dev-desktop-sandbox`
- `make typecheck`
- `make static-check`

## Risks

Low risk. The sampler is capped and limited to selected render markers, but it can slightly perturb micro-benchmarks; developers can set `MUX_PROFILE_REACT=0` to compare against an uninstrumented renderer.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `13655{MUX_COSTS_USD:-unknown}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=2.74 -->
