### PR TITLE
🤖 fix: repair corrupt SSH worktree base repos

### DIFF
--- a/src/node/runtime/SSHRuntime.syncContract.test.ts
+++ b/src/node/runtime/SSHRuntime.syncContract.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
-import { execSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 import { mkdtemp, rm } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -100,6 +100,69 @@ class CommandCaptureSSHRuntime extends SSHRuntime {
   }
 }
 
+class LocalUnpackSSHRuntime extends SSHRuntime {
+  readonly commands: string[] = [];
+
+  constructor(private readonly baseRepoPath: string) {
+    const config: SSHRuntimeConfig = {
+      host: "example.test",
+      srcBaseDir: "/remote/src",
+    };
+    super(config, createMockTransport(config));
+  }
+
+  override exec(command: string, options: ExecOptions): Promise<ExecStream> {
+    this.commands.push(command);
+    if (!command.includes("unpack-objects -r")) {
+      const result = spawnSync("sh", ["-c", command], {
+        cwd: options.cwd,
+        encoding: "utf8",
+      });
+      return Promise.resolve(
+        createExecStream(result.stdout || "", result.stderr || "", result.status ?? 1)
+      );
+    }
+
+    const chunks: Buffer[] = [];
+    let resolveExitCode: (exitCode: number) => void = noop;
+    const exitCode = new Promise<number>((resolve) => {
+      resolveExitCode = resolve;
+    });
+    let unpackRan = false;
+    const runUnpack = () => {
+      if (unpackRan) {
+        return;
+      }
+      unpackRan = true;
+      const result = spawnSync("git", ["-C", this.baseRepoPath, "unpack-objects", "-r"], {
+        input: Buffer.concat(chunks),
+      });
+      resolveExitCode(result.status ?? 1);
+    };
+
+    return Promise.resolve({
+      stdout: createTextStream(""),
+      stderr: createTextStream(""),
+      stdin: new WritableStream<Uint8Array>({
+        write(chunk) {
+          chunks.push(Buffer.from(chunk));
+          return Promise.resolve();
+        },
+        close() {
+          runUnpack();
+          return Promise.resolve();
+        },
+        abort() {
+          resolveExitCode(1);
+          return Promise.resolve();
+        },
+      }),
+      exitCode,
+      duration: exitCode.then(() => 0),
+    });
+  }
+}
+
 interface GitPushPrivateApi {
   syncProjectSnapshotViaGitPush(
     projectPath: string,
@@ -150,6 +213,19 @@ interface FreshWorkspaceSourcePrivateApi {
     abortSignal?: AbortSignal,
     nhp?: string
   ): Promise<boolean>;
+}
+
+interface MissingObjectRepairPrivateApi {
+  checkBaseRepoBundleConnectivity(
+    baseRepoPathArg: string,
+    abortSignal?: AbortSignal
+  ): Promise<{ healthy: true } | { healthy: false; detail: string }>;
+  repairBaseRepoMissingObjectsFromLocal(
+    projectPath: string,
+    baseRepoPathArg: string,
+    initLogger: InitLogger,
+    abortSignal?: AbortSignal
+  ): Promise<void>;
 }
 
 function createLayout(): RemoteProjectLayout {
@@ -386,6 +462,42 @@ describe("SSHRuntime authoritative sync contract", () => {
     expect(runtime.commands).toContain(
       "git fetch origin '+refs/heads/main:refs/remotes/origin/main'"
     );
+  });
+
+  it("repairs missing objects in reusable base repos with a full local pack", async () => {
+    const repoPath = await createTempGitRepo();
+    const baseParent = await mkdtemp(path.join(os.tmpdir(), "mux-ssh-missing-objects-base-"));
+    tempDirs.push(baseParent);
+    const baseRepoPath = path.join(baseParent, "base.git");
+    const worktreePath = path.join(baseParent, "repaired-worktree");
+
+    execSync(`git clone --bare "${repoPath}" "${baseRepoPath}"`, { stdio: "pipe" });
+    execSync(`git -C "${baseRepoPath}" update-ref refs/mux-bundle/main refs/heads/main`, {
+      stdio: "pipe",
+    });
+
+    execSync(`find "${path.join(baseRepoPath, "objects")}" -type f -delete`, { stdio: "pipe" });
+
+    const runtime = new LocalUnpackSSHRuntime(baseRepoPath);
+    const privateApi = runtime as unknown as MissingObjectRepairPrivateApi;
+
+    const beforeRepair = await privateApi.checkBaseRepoBundleConnectivity(baseRepoPath);
+    expect(beforeRepair.healthy).toBe(false);
+
+    await privateApi.repairBaseRepoMissingObjectsFromLocal(repoPath, baseRepoPath, noopInitLogger);
+
+    const afterRepair = await privateApi.checkBaseRepoBundleConnectivity(baseRepoPath);
+    expect(afterRepair.healthy).toBe(true);
+    expect(runtime.commands).toContain(`git -C ${baseRepoPath} unpack-objects -r`);
+
+    execSync(
+      `git -C "${baseRepoPath}" worktree add "${worktreePath}" -B repaired refs/mux-bundle/main`,
+      { stdio: "pipe" }
+    );
+    const repairedContent = execSync(`cat "${path.join(worktreePath, "file.txt")}"`, {
+      encoding: "utf8",
+    });
+    expect(repairedContent).toBe("initial");
   });
 
   it("fetches pruneable bundle branches separately from shared tags", async () => {

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -69,6 +69,8 @@ const BUNDLE_REF_PREFIX = "refs/mux-bundle/";
 /** Small backoff for concurrent writers healing the same shared base repo config. */
 const BASE_REPO_CONFIG_LOCK_RETRY_DELAYS_MS = [50, 100, 200];
 const BASE_REPO_HEALTH_PROBE_TIMEOUT_SECONDS = 10;
+const BASE_REPO_CONNECTIVITY_CHECK_TIMEOUT_SECONDS = 120;
+const BASE_REPO_MISSING_OBJECT_REPAIR_TIMEOUT_MS = 300_000;
 const BASE_REPO_PROMISOR_CLEANUP_TIMEOUT_SECONDS = 10;
 /**
  * Timeout for *spawning* remote detached gc, not for gc itself. The remote
@@ -129,6 +131,12 @@ const UNRESOLVED_DELTA_PUSH_PATTERNS = [
 
 function isUnresolvedDeltaPushFailure(errorMsg: string): boolean {
   return UNRESOLVED_DELTA_PUSH_PATTERNS.some((pattern) => errorMsg.includes(pattern));
+}
+
+function isMissingObjectCheckoutFailure(message: string): boolean {
+  return /unable to read sha1 file|Could not reset index file|missing (blob|tree|commit)|bad object|unable to read tree|object file .* is empty|loose object .* is corrupt/i.test(
+    message
+  );
 }
 
 const sharedProjectSyncTails = new Map<string, Promise<void>>();
@@ -263,8 +271,17 @@ function createAbortController(
   };
 }
 async function waitForProcessExit(proc: ChildProcess): Promise<number> {
+  // Callers often consume stdout before awaiting the process. Tiny git helpers
+  // can close in that window, so make the helper safe even when subscribed late.
+  if (proc.exitCode !== null) {
+    return proc.exitCode;
+  }
+  if (proc.signalCode !== null) {
+    return 1;
+  }
+
   return new Promise((resolve, reject) => {
-    proc.on("close", (code) => resolve(code ?? 0));
+    proc.on("close", (code) => resolve(code ?? 1));
     proc.on("error", (err) => reject(err));
   });
 }
@@ -804,6 +821,203 @@ export class SSHRuntime extends RemoteRuntime {
         throw healthError instanceof Error ? healthError : new Error(healthErrorMsg);
       }
       log.warn(`Shared base repository maintenance preflight failed: ${healthErrorMsg}`);
+    }
+  }
+
+  private async checkBaseRepoBundleConnectivity(
+    baseRepoPathArg: string,
+    abortSignal?: AbortSignal
+  ): Promise<{ healthy: true } | { healthy: false; detail: string }> {
+    const result = await execBuffered(
+      this,
+      [
+        `set -- $(git -C ${baseRepoPathArg} for-each-ref --format='%(refname)' ${shescape.quote(BUNDLE_REF_PREFIX)})`,
+        'if [ "$#" -eq 0 ]; then echo "no synced bundle refs found" >&2; exit 1; fi',
+        `git -C ${baseRepoPathArg} fsck --connectivity-only --no-dangling "$@"`,
+      ].join("\n"),
+      {
+        cwd: "/tmp",
+        timeout: BASE_REPO_CONNECTIVITY_CHECK_TIMEOUT_SECONDS,
+        abortSignal,
+      }
+    );
+
+    if (result.exitCode === 0) {
+      return { healthy: true };
+    }
+
+    return {
+      healthy: false,
+      detail: (result.stderr || result.stdout).trim() || `exit ${result.exitCode}`,
+    };
+  }
+
+  private async checkBaseRepoRevisionConnectivity(
+    baseRepoPathArg: string,
+    revision: string,
+    abortSignal?: AbortSignal
+  ): Promise<{ healthy: true } | { healthy: false; detail: string }> {
+    const result = await execBuffered(
+      this,
+      `git -C ${baseRepoPathArg} fsck --connectivity-only --no-dangling ${shescape.quote(revision)}`,
+      {
+        cwd: "/tmp",
+        timeout: BASE_REPO_CONNECTIVITY_CHECK_TIMEOUT_SECONDS,
+        abortSignal,
+      }
+    );
+
+    if (result.exitCode === 0) {
+      return { healthy: true };
+    }
+
+    return {
+      healthy: false,
+      detail: (result.stderr || result.stdout).trim() || `exit ${result.exitCode}`,
+    };
+  }
+
+  private async repairBaseRepoMissingObjectsFromLocal(
+    projectPath: string,
+    baseRepoPathArg: string,
+    initLogger: InitLogger,
+    abortSignal?: AbortSignal
+  ): Promise<void> {
+    if (abortSignal?.aborted) {
+      throw new Error("Operation aborted");
+    }
+
+    await this.transport.acquireConnection({
+      abortSignal,
+      onWait: (waitMs) => logSSHBackoffWait(initLogger, waitMs),
+    });
+
+    if (abortSignal?.aborted) {
+      throw new Error("Operation aborted");
+    }
+
+    initLogger.logStep("Repairing shared base repository object cache...");
+    const remoteAbortController = createAbortController(
+      BASE_REPO_MISSING_OBJECT_REPAIR_TIMEOUT_MS,
+      abortSignal
+    );
+
+    try {
+      const remoteStream = await this.exec(`git -C ${baseRepoPathArg} unpack-objects -r`, {
+        cwd: "/tmp",
+        abortSignal: remoteAbortController.signal,
+      });
+      const remoteStdoutPromise = streamToString(remoteStream.stdout);
+      const remoteStderrPromise = streamToString(remoteStream.stderr);
+
+      // A normal fetch/push can be a no-op when the remote already has the
+      // commit object but is missing blobs from the same tree. Stream a complete
+      // non-thin local pack and let `unpack-objects -r` add only the missing
+      // objects without deleting or recreating the shared gitdir used by siblings.
+      const gitProc = spawn("git", ["-C", projectPath, "pack-objects", "--all", "--stdout"], {
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      });
+
+      let packStderr = "";
+      gitProc.stderr?.on("data", (data: Buffer) => {
+        const chunk = data.toString();
+        packStderr += chunk;
+        for (const line of chunk.split("\n").filter(Boolean)) {
+          initLogger.logStderr(line);
+        }
+      });
+      const gitExitCodePromise = waitForProcessExit(gitProc);
+
+      try {
+        await pipeReadableToWebWritable(gitProc.stdout, remoteStream.stdin, abortSignal);
+      } catch (error) {
+        gitProc.kill();
+        throw error;
+      }
+
+      const [gitExitCode, remoteExitCode, remoteStdout, remoteStderr] = await Promise.all([
+        gitExitCodePromise,
+        remoteStream.exitCode,
+        remoteStdoutPromise,
+        remoteStderrPromise,
+      ]);
+
+      if (remoteAbortController.didTimeout()) {
+        throw new Error(
+          `SSH command timed out after ${BASE_REPO_MISSING_OBJECT_REPAIR_TIMEOUT_MS}ms: git -C ${baseRepoPathArg} unpack-objects -r`
+        );
+      }
+
+      if (abortSignal?.aborted) {
+        throw new Error("Operation aborted");
+      }
+
+      if (gitExitCode !== 0) {
+        throw new Error(
+          `Failed to create repair pack: ${packStderr.trim() || `exit ${gitExitCode}`}`
+        );
+      }
+
+      if (remoteExitCode !== 0) {
+        const detail = (remoteStderr || remoteStdout).trim() || `exit ${remoteExitCode}`;
+        throw new Error(`Failed to unpack repair pack into shared base repository: ${detail}`);
+      }
+    } finally {
+      remoteAbortController.dispose();
+    }
+
+    initLogger.logStep("Shared base repository object cache repaired");
+  }
+
+  private async ensureBaseRepoSnapshotConnectivity(
+    projectPath: string,
+    baseRepoPathArg: string,
+    initLogger: InitLogger,
+    abortSignal?: AbortSignal
+  ): Promise<void> {
+    const initialCheck = await this.checkBaseRepoBundleConnectivity(baseRepoPathArg, abortSignal);
+    if (initialCheck.healthy) {
+      return;
+    }
+
+    initLogger.logStep("Remote snapshot is missing objects; repairing shared base repository...");
+    log.warn("Remote snapshot failed connectivity check before reuse", {
+      detail: initialCheck.detail,
+    });
+
+    await this.repairBaseRepoMissingObjectsFromLocal(
+      projectPath,
+      baseRepoPathArg,
+      initLogger,
+      abortSignal
+    );
+
+    const repairedCheck = await this.checkBaseRepoBundleConnectivity(baseRepoPathArg, abortSignal);
+    if (!repairedCheck.healthy) {
+      throw new Error(
+        `Shared base repository is still missing objects after repair: ${repairedCheck.detail}`
+      );
+    }
+  }
+
+  private async cleanupFailedNewWorktreeCheckout(
+    baseRepoPathArg: string,
+    workspacePathArg: string,
+    abortSignal?: AbortSignal
+  ): Promise<void> {
+    const result = await execBuffered(
+      this,
+      `git -C ${baseRepoPathArg} worktree remove --force ${workspacePathArg} >/dev/null 2>&1 || rm -rf ${workspacePathArg}`,
+      {
+        cwd: "/tmp",
+        timeout: 30,
+        abortSignal,
+      }
+    );
+    if (result.exitCode !== 0) {
+      const detail = (result.stderr || result.stdout).trim() || `exit ${result.exitCode}`;
+      log.warn(`Failed to clean up partial SSH worktree checkout: ${detail}`);
     }
   }
 
@@ -2067,6 +2281,12 @@ export class SSHRuntime extends RemoteRuntime {
           : await this.resolveRemoteSyncRefManifest(baseRepoPathArg, abortSignal);
       if (localRefManifest != null && remoteRefManifest === localRefManifest) {
         await this.refreshBaseRepoOrigin(projectPath, baseRepoPathArg, initLogger, abortSignal);
+        await this.ensureBaseRepoSnapshotConnectivity(
+          projectPath,
+          baseRepoPathArg,
+          initLogger,
+          abortSignal
+        );
         initLogger.logStep("Reusing existing remote project snapshot");
         return;
       }
@@ -2360,9 +2580,23 @@ export class SSHRuntime extends RemoteRuntime {
       `  git -C ${baseRepoPathArg} rev-parse --verify "$r" >/dev/null 2>&1 || r=$(git -C ${baseRepoPathArg} for-each-ref --count=1 --format='%(refname)' ${bundleRefFallbackPrefix})`,
       `  [ -n "$r" ] || { echo WARM_MISS:no-bundle-ref; exit 0; }`,
       "fi",
-      // Materialize.
+      // Materialize. Capture checkout failures so a missing-object cache can
+      // fall through to the repairing slow path instead of becoming an opaque
+      // `worktree-add-failed` miss. The path was proven absent above, so removing
+      // a partial checkout here cannot wipe a pre-existing workspace.
       `mkdir -p ${workspaceParentArg}`,
-      `${nhp}git -C ${baseRepoPathArg} worktree add ${workspacePathArg} -B ${branchArg} "$r" >/dev/null 2>&1 || { echo WARM_MISS:worktree-add-failed; exit 0; }`,
+      `wt_output=$(${nhp}git -C ${baseRepoPathArg} worktree add ${workspacePathArg} -B ${branchArg} "$r" 2>&1 >/dev/null)`,
+      "wt_status=$?",
+      'if [ "$wt_status" -ne 0 ]; then',
+      '  case "$wt_output" in',
+      '    *"unable to read sha1 file"*|*"Could not reset index file"*|*"missing blob"*|*"missing tree"*|*"missing commit"*|*"bad object"*|*"unable to read tree"*) wt_reason=missing-objects ;;',
+      "    *) wt_reason=worktree-add-failed ;;",
+      "  esac",
+      `  git -C ${baseRepoPathArg} worktree remove --force ${workspacePathArg} >/dev/null 2>&1 || rm -rf ${workspacePathArg}`,
+      '  [ -z "$wt_output" ] || printf "%s\\n" "$wt_output" >&2',
+      '  echo "WARM_MISS:$wt_reason"',
+      "  exit 0",
+      "fi",
       // .gitmodules probe folded inline to skip a post-warm SSH RTT.
       `test -f ${workspacePathArg}/.gitmodules && echo GITMODULES=present || echo GITMODULES=missing`,
       "echo WARM_OK",
@@ -2437,6 +2671,7 @@ export class SSHRuntime extends RemoteRuntime {
     // another SSH workspace via worktree add or legacy cp), skip the expensive sync step.
     const workspacePathArg = expandTildeForSSH(workspacePath);
     let needsWorktreeCheckout = true;
+    let workspacePathExistedBeforeCheckout = false;
 
     try {
       const dirCheck = await execBuffered(this, `test -d ${workspacePathArg}`, {
@@ -2445,6 +2680,7 @@ export class SSHRuntime extends RemoteRuntime {
         abortSignal,
       });
       if (dirCheck.exitCode === 0) {
+        workspacePathExistedBeforeCheckout = true;
         const gitCheck = await execBuffered(
           this,
           `git -C ${workspacePathArg} rev-parse --is-inside-work-tree`,
@@ -2457,8 +2693,10 @@ export class SSHRuntime extends RemoteRuntime {
         needsWorktreeCheckout = gitCheck.exitCode !== 0;
       }
     } catch {
-      // Default to materializing the workspace on unexpected errors.
+      // Default to materializing the workspace on unexpected errors, but do not
+      // later delete the path because we failed to prove it was absent first.
       needsWorktreeCheckout = true;
+      workspacePathExistedBeforeCheckout = true;
     }
 
     if (needsWorktreeCheckout) {
@@ -2507,13 +2745,70 @@ export class SSHRuntime extends RemoteRuntime {
       // (e.g. orphaned from a previously deleted workspace). Git still prevents
       // checking out a branch that's active in another worktree.
       initLogger.logStep(`Creating worktree for branch: ${branchName}`);
-      const worktreeCmd = `${nhp}git -C ${baseRepoPathArg} worktree add ${workspacePathArg} -B ${shescape.quote(branchName)} ${shescape.quote(newBranchBase)}`;
+      const runWorktreeAdd = (baseRef: string) =>
+        execBuffered(
+          this,
+          `${nhp}git -C ${baseRepoPathArg} worktree add ${workspacePathArg} -B ${shescape.quote(branchName)} ${shescape.quote(baseRef)}`,
+          {
+            cwd: "/tmp",
+            timeout: 300,
+            abortSignal,
+          }
+        );
 
-      const worktreeResult = await execBuffered(this, worktreeCmd, {
-        cwd: "/tmp",
-        timeout: 300,
-        abortSignal,
-      });
+      let worktreeBase = newBranchBase;
+      let worktreeResult = await runWorktreeAdd(worktreeBase);
+
+      if (
+        worktreeResult.exitCode !== 0 &&
+        isMissingObjectCheckoutFailure(worktreeResult.stderr || worktreeResult.stdout)
+      ) {
+        initLogger.logStep("Shared base repository is missing checkout objects; repairing...");
+        if (!workspacePathExistedBeforeCheckout) {
+          await this.cleanupFailedNewWorktreeCheckout(
+            baseRepoPathArg,
+            workspacePathArg,
+            abortSignal
+          );
+        }
+
+        await this.repairBaseRepoMissingObjectsFromLocal(
+          projectPath,
+          baseRepoPathArg,
+          initLogger,
+          abortSignal
+        );
+
+        const repairedBaseCheck = await this.checkBaseRepoRevisionConnectivity(
+          baseRepoPathArg,
+          worktreeBase,
+          abortSignal
+        );
+        if (!repairedBaseCheck.healthy) {
+          if (worktreeBase === `origin/${trunkBranch}` && bundleTrunkRef != null) {
+            initLogger.logStderr(
+              `Note: origin/${trunkBranch} is still missing objects after repair; using local snapshot ${bundleTrunkRef}`
+            );
+            worktreeBase = bundleTrunkRef;
+            const fallbackCheck = await this.checkBaseRepoRevisionConnectivity(
+              baseRepoPathArg,
+              worktreeBase,
+              abortSignal
+            );
+            if (!fallbackCheck.healthy) {
+              throw new Error(
+                `Shared base repository is still missing objects after repair: ${fallbackCheck.detail}`
+              );
+            }
+          } else {
+            throw new Error(
+              `Shared base repository is still missing objects after repair: ${repairedBaseCheck.detail}`
+            );
+          }
+        }
+
+        worktreeResult = await runWorktreeAdd(worktreeBase);
+      }
 
       if (worktreeResult.exitCode !== 0) {
         throw new Error(

--- a/tests/runtime/runtime.test.ts
+++ b/tests/runtime/runtime.test.ts
@@ -1946,6 +1946,80 @@ describeIntegration("Runtime integration tests", () => {
       }
     }, 120000);
 
+    test("initWorkspace repairs a reusable snapshot whose base repo is missing objects", async () => {
+      const runtime = createSSHRuntime();
+
+      const projectName = `sync-heal-missing-objects-${Date.now()}-${Math.random().toString(36).substring(7)}`;
+      const tmpDir = await import("os").then((os) => os.tmpdir());
+      const localProjectPath = `${tmpDir}/${projectName}`;
+      const layout = buildRemoteProjectLayout(srcBaseDir, localProjectPath);
+      const firstWorkspacePath = getRemoteWorkspacePath(layout, "missing-objects-a");
+      const secondWorkspacePath = getRemoteWorkspacePath(layout, "missing-objects-b");
+      const baseRepoPath = layout.baseRepoPath;
+      const repairSteps: string[] = [];
+      const repairLogger = {
+        ...noopInitLogger,
+        logStep(step: string) {
+          repairSteps.push(step);
+        },
+      };
+
+      const { execSync } = await import("child_process");
+      try {
+        execSync(
+          [
+            `mkdir -p "${localProjectPath}"`,
+            `cd "${localProjectPath}"`,
+            `git init -b main`,
+            `git config user.email "test@test.com"`,
+            `git config user.name "Test"`,
+            `echo "content" > file.txt`,
+            `git add file.txt`,
+            `git commit -m "initial"`,
+          ].join(" && "),
+          { stdio: "pipe" }
+        );
+
+        const firstInit = await runtime.initWorkspace({
+          projectPath: localProjectPath,
+          branchName: "missing-objects-a",
+          trunkBranch: "main",
+          workspacePath: firstWorkspacePath,
+          initLogger: noopInitLogger,
+        });
+        if (!firstInit.success) {
+          throw new Error(`first initWorkspace failed: ${firstInit.error}`);
+        }
+
+        // Simulate a stale/corrupt managed cache left behind by older SSH path
+        // layouts or partial-clone state: refs and the snapshot marker still say
+        // the remote snapshot is reusable, but the object database cannot
+        // materialize a worktree. Init must repair additively rather than
+        // deleting the base repo, because sibling worktrees share this gitdir.
+        await execSSH(runtime, `find "${baseRepoPath}/objects" -type f -delete`);
+
+        const secondInit = await runtime.initWorkspace({
+          projectPath: localProjectPath,
+          branchName: "missing-objects-b",
+          trunkBranch: "main",
+          workspacePath: secondWorkspacePath,
+          initLogger: repairLogger,
+        });
+        if (!secondInit.success) {
+          throw new Error(`second initWorkspace failed: ${secondInit.error}`);
+        }
+
+        expect(repairSteps).toContain(
+          "Remote snapshot is missing objects; repairing shared base repository..."
+        );
+        const fileCheck = await execSSH(runtime, `cat "${secondWorkspacePath}/file.txt"`);
+        expect(fileCheck.stdout.trim()).toBe("content");
+      } finally {
+        execSync(`rm -rf "${localProjectPath}"`);
+        await execSSH(runtime, `rm -rf "${layout.projectRoot}"`);
+      }
+    }, 120000);
+
     test("initWorkspace reimports when the snapshot marker outlives the base repo", async () => {
       const runtime = createSSHRuntime();
 


### PR DESCRIPTION
Summary
- Repair corrupt SSH shared base repos when snapshot refs are reusable but the object database is missing blobs/trees.
- Harden warm and slow worktree creation so missing-object checkout failures self-heal instead of failing workspace initialization.

Background
A recent SSH workspace path/layout change can leave a reusable remote project snapshot pointing at a shared bare repo whose refs and snapshot marker look valid, but whose object store is incomplete. Git then fails `worktree add` with errors such as `unable to read sha1 file ...` and `Could not reset index file to revision 'HEAD'`.

Implementation
- Validate `refs/mux-bundle/*` connectivity before reusing a remote snapshot.
- Repair missing objects additively by streaming a complete local pack into the remote base repo via `git unpack-objects -r`, avoiding deletion/recreation of `.mux-base.git` because existing worktrees share that gitdir.
- Classify warm-path missing-object failures and fall through to the repairing slow path.
- Retry slow-path `git worktree add` once after repair, with a fallback from corrupt `origin/<trunk>` to the local snapshot ref when available.

Validation
- `bun test src/node/runtime/SSHRuntime.retry.test.ts src/node/runtime/SSHRuntime.syncContract.test.ts`
- `TEST_INTEGRATION=1 bun x jest tests/runtime/runtime.test.ts -t "missing objects" --runInBand`
- `make typecheck`
- `make lint`
- `make fmt-check`
- `make static-check`

Risks
- Touches SSH workspace initialization, especially the warm fast path and slow worktree materialization path. The common healthy snapshot path pays one scoped connectivity check only when the slow path is already considering snapshot reuse; the warm fast path remains a single probe and only falls back on worktree-add failure.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$16.67`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=16.67 -->
