### PR TITLE
🤖 refactor: clean up runtime maintainability

### DIFF
--- a/src/node/runtime/CoderSSHRuntime.test.ts
+++ b/src/node/runtime/CoderSSHRuntime.test.ts
@@ -457,6 +457,23 @@ describe("CoderSSHRuntime.deleteWorkspace", () => {
     expect(deleteWorkspaceEventually).not.toHaveBeenCalled();
   });
 
+  it("passes abort signal to the Coder status check during delete", async () => {
+    const getWorkspaceStatus = mock(() => Promise.resolve({ kind: "not_found" as const }));
+    const coderService = createMockCoderService({ getWorkspaceStatus });
+    const runtime = createRuntime(
+      { existingWorkspace: false, workspaceName: "my-ws" },
+      coderService
+    );
+    const abortController = new AbortController();
+
+    await runtime.deleteWorkspace("/project", "ws", false, abortController.signal);
+
+    expect(getWorkspaceStatus).toHaveBeenCalledWith(
+      "my-ws",
+      expect.objectContaining({ signal: abortController.signal })
+    );
+  });
+
   it("proceeds with SSH cleanup when status check fails with API error", async () => {
     // API error (auth, network) - should NOT treat as "already deleted"
     const getWorkspaceStatus = mock(() =>

--- a/src/node/runtime/CoderSSHRuntime.ts
+++ b/src/node/runtime/CoderSSHRuntime.ts
@@ -25,7 +25,7 @@ import type { SSHTransport } from "./transports";
 import type { CoderWorkspaceConfig, RuntimeConfig } from "@/common/types/runtime";
 import { isSSHRuntime } from "@/common/types/runtime";
 import { resolveCoderSSHHost } from "@/constants/coder";
-import type { CoderService } from "@/node/services/coderService";
+import type { CoderService, WorkspaceStatusResult } from "@/node/services/coderService";
 import type { Result } from "@/common/types/result";
 import { Ok, Err } from "@/common/types/result";
 import { log } from "@/node/services/log";
@@ -141,6 +141,67 @@ export class CoderSSHRuntime extends SSHRuntime {
     activityByWorkspace.set(workspaceName, now);
   }
 
+  private coderWorkspaceNotFound(workspaceName: string): EnsureReadyResult {
+    return {
+      ready: false,
+      error: `Coder workspace "${workspaceName}" not found`,
+      errorType: "runtime_not_ready",
+    };
+  }
+
+  private async markReadyIfRepoPresent(
+    workspaceName: string,
+    options: EnsureReadyOptions | undefined,
+    emitStatus: (phase: RuntimeStatusEvent["phase"], detail?: string) => void
+  ): Promise<EnsureReadyResult> {
+    const repoCheck = await this.checkWorkspaceRepo(options);
+    if (repoCheck && !repoCheck.ready) {
+      emitStatus("error", repoCheck.error);
+      return repoCheck;
+    }
+
+    this.markActivity(workspaceName);
+    emitStatus("ready");
+    return { ready: true };
+  }
+
+  private isStoppingOrCanceling(status: WorkspaceStatusResult): boolean {
+    return status.kind === "ok" && (status.status === "stopping" || status.status === "canceling");
+  }
+
+  private async waitForStoppingOrCancelingToClear(
+    workspaceName: string,
+    status: WorkspaceStatusResult,
+    options: {
+      abortSignal?: AbortSignal;
+      timeoutMs?: () => number;
+      isTimedOut?: () => boolean;
+      onWait?: () => void;
+    } = {}
+  ): Promise<WorkspaceStatusResult> {
+    if (!this.isStoppingOrCanceling(status)) {
+      return status;
+    }
+
+    options.onWait?.();
+    while (this.isStoppingOrCanceling(status)) {
+      if (options.abortSignal?.aborted) {
+        throw new Error("Aborted while waiting for Coder workspace to stop");
+      }
+      if (options.isTimedOut?.()) {
+        return status;
+      }
+
+      await this.sleep(CODER_STATUS_POLL_INTERVAL_MS, options.abortSignal);
+      status = await this.coderService.getWorkspaceStatus(workspaceName, {
+        timeoutMs: options.timeoutMs?.(),
+        signal: options.abortSignal,
+      });
+    }
+
+    return status;
+  }
+
   /** In-flight ensureReady promise to avoid duplicate start/wait sequences */
   private ensureReadyPromise: Promise<EnsureReadyResult> | null = null;
 
@@ -178,7 +239,12 @@ export class CoderSSHRuntime extends SSHRuntime {
       return { ready: true };
     }
 
-    // Avoid duplicate concurrent start/wait sequences
+    // Avoid duplicate start/wait sequences only for calls without request-local observers.
+    // Abort signals and status sinks are per caller; sharing those would make cancellation/status
+    // delivery depend on whichever caller happened to start the singleflight.
+    if (options?.signal || options?.statusSink) {
+      return this.doEnsureReady(workspaceName, options);
+    }
     if (this.ensureReadyPromise) {
       return this.ensureReadyPromise;
     }
@@ -232,25 +298,13 @@ export class CoderSSHRuntime extends SSHRuntime {
 
     // Short-circuit: already running
     if (statusResult.kind === "ok" && statusResult.status === "running") {
-      const repoCheck = await this.checkWorkspaceRepo(options);
-      if (repoCheck && !repoCheck.ready) {
-        emitStatus("error", repoCheck.error);
-        return repoCheck;
-      }
-
-      this.markActivity(workspaceName);
-      emitStatus("ready");
-      return { ready: true };
+      return this.markReadyIfRepoPresent(workspaceName, options, emitStatus);
     }
 
     // Short-circuit: workspace doesn't exist
     if (statusResult.kind === "not_found") {
       emitStatus("error");
-      return {
-        ready: false,
-        error: `Coder workspace "${workspaceName}" not found`,
-        errorType: "runtime_not_ready",
-      };
+      return this.coderWorkspaceNotFound(workspaceName);
     }
 
     // For status check errors (timeout, auth issues), proceed optimistically
@@ -267,59 +321,37 @@ export class CoderSSHRuntime extends SSHRuntime {
     }
 
     // Step 2: Wait for "stopping"/"canceling" to clear (coder ssh can't autostart during these)
-    if (
-      statusResult.kind === "ok" &&
-      (statusResult.status === "stopping" || statusResult.status === "canceling")
-    ) {
-      emitStatus("waiting", "Waiting for Coder workspace to stop...");
-
-      while (
-        statusResult.kind === "ok" &&
-        (statusResult.status === "stopping" || statusResult.status === "canceling") &&
-        !isTimedOut()
-      ) {
-        if (signal?.aborted) {
-          emitStatus("error");
-          return { ready: false, error: "Aborted", errorType: "runtime_start_failed" };
-        }
-
-        await this.sleep(CODER_STATUS_POLL_INTERVAL_MS, signal);
-        statusResult = await this.coderService.getWorkspaceStatus(workspaceName, {
-          timeoutMs: Math.min(remainingMs(), 10_000),
-          signal,
-        });
-
-        // Check for state changes during polling
-        if (statusResult.kind === "ok" && statusResult.status === "running") {
-          // Ensure setup failures (missing repo) surface before marking ready.
-          const repoCheck = await this.checkWorkspaceRepo(options);
-          if (repoCheck && !repoCheck.ready) {
-            emitStatus("error", repoCheck.error);
-            return repoCheck;
-          }
-
-          this.markActivity(workspaceName);
-          emitStatus("ready");
-          return { ready: true };
-        }
-        if (statusResult.kind === "not_found") {
-          emitStatus("error");
-          return {
-            ready: false,
-            error: `Coder workspace "${workspaceName}" not found`,
-            errorType: "runtime_not_ready",
-          };
-        }
-      }
-
-      if (isTimedOut()) {
+    try {
+      statusResult = await this.waitForStoppingOrCancelingToClear(workspaceName, statusResult, {
+        abortSignal: signal,
+        timeoutMs: () => Math.min(remainingMs(), 10_000),
+        isTimedOut,
+        onWait: () => emitStatus("waiting", "Waiting for Coder workspace to stop..."),
+      });
+    } catch (error) {
+      if (signal?.aborted) {
         emitStatus("error");
-        return {
-          ready: false,
-          error: "Coder workspace is still stopping... Please retry shortly.",
-          errorType: "runtime_start_failed",
-        };
+        return { ready: false, error: "Aborted", errorType: "runtime_start_failed" };
       }
+      throw error;
+    }
+
+    // Check for state changes during polling
+    if (statusResult.kind === "ok" && statusResult.status === "running") {
+      // Ensure setup failures (missing repo) surface before marking ready.
+      return this.markReadyIfRepoPresent(workspaceName, options, emitStatus);
+    }
+    if (statusResult.kind === "not_found") {
+      emitStatus("error");
+      return this.coderWorkspaceNotFound(workspaceName);
+    }
+    if (isTimedOut() && this.isStoppingOrCanceling(statusResult)) {
+      emitStatus("error");
+      return {
+        ready: false,
+        error: "Coder workspace is still stopping... Please retry shortly.",
+        errorType: "runtime_start_failed",
+      };
     }
 
     // Step 3: Use coder ssh --wait=yes to handle all other states
@@ -349,15 +381,7 @@ export class CoderSSHRuntime extends SSHRuntime {
         // Consume output for timeout/abort handling
       }
 
-      const repoCheck = await this.checkWorkspaceRepo(options);
-      if (repoCheck && !repoCheck.ready) {
-        emitStatus("error", repoCheck.error);
-        return repoCheck;
-      }
-
-      this.markActivity(workspaceName);
-      emitStatus("ready");
-      return { ready: true };
+      return this.markReadyIfRepoPresent(workspaceName, options, emitStatus);
     } catch (error) {
       const errorMsg = getErrorMessage(error);
 
@@ -377,11 +401,7 @@ export class CoderSSHRuntime extends SSHRuntime {
 
       // Map "not found" errors to runtime_not_ready
       if (/not found|no access/i.test(errorMsg)) {
-        return {
-          ready: false,
-          error: `Coder workspace "${workspaceName}" not found`,
-          errorType: "runtime_not_ready",
-        };
+        return this.coderWorkspaceNotFound(workspaceName);
       }
 
       return {
@@ -413,6 +433,9 @@ export class CoderSSHRuntime extends SSHRuntime {
       };
 
       abortSignal?.addEventListener("abort", onAbort, { once: true });
+      if (abortSignal?.aborted) {
+        onAbort();
+      }
     });
   }
 
@@ -597,7 +620,9 @@ export class CoderSSHRuntime extends SSHRuntime {
 
     // Check if Coder workspace still exists before attempting SSH operations.
     // If it's already gone, skip SSH cleanup (would hang trying to connect to non-existent host).
-    const statusResult = await this.coderService.getWorkspaceStatus(coderWorkspaceName);
+    const statusResult = await this.coderService.getWorkspaceStatus(coderWorkspaceName, {
+      signal: abortSignal,
+    });
     if (statusResult.kind === "not_found") {
       log.debug("Coder workspace already deleted, skipping SSH cleanup", { coderWorkspaceName });
       return { success: true, deletedPath: this.getWorkspacePath(projectPath, workspaceName) };
@@ -801,25 +826,14 @@ export class CoderSSHRuntime extends SSHRuntime {
       // For existing workspaces, wait for "stopping"/"canceling" to clear before SSH
       // (coder ssh --wait=yes can't autostart while a stop/cancel build is in progress)
       const workspaceName = this.coderConfig.workspaceName;
-      let status = await this.coderService.getWorkspaceStatus(workspaceName, {
+      const status = await this.coderService.getWorkspaceStatus(workspaceName, {
         signal: abortSignal,
       });
-
-      if (status.kind === "ok" && (status.status === "stopping" || status.status === "canceling")) {
-        initLogger.logStep(`Waiting for Coder workspace "${workspaceName}" to stop...`);
-        while (
-          status.kind === "ok" &&
-          (status.status === "stopping" || status.status === "canceling")
-        ) {
-          if (abortSignal?.aborted) {
-            throw new Error("Aborted while waiting for Coder workspace to stop");
-          }
-          await this.sleep(CODER_STATUS_POLL_INTERVAL_MS, abortSignal);
-          status = await this.coderService.getWorkspaceStatus(workspaceName, {
-            signal: abortSignal,
-          });
-        }
-      }
+      await this.waitForStoppingOrCancelingToClear(workspaceName, status, {
+        abortSignal,
+        onWait: () =>
+          initLogger.logStep(`Waiting for Coder workspace "${workspaceName}" to stop...`),
+      });
 
       // waitForStartupScripts (coder ssh --wait=yes) handles all other states:
       // - stopped: auto-starts, streams build logs, waits for scripts

--- a/src/node/runtime/DevcontainerRuntime.test.ts
+++ b/src/node/runtime/DevcontainerRuntime.test.ts
@@ -3,6 +3,7 @@ import * as fs from "fs/promises";
 import * as os from "os";
 import * as path from "path";
 import { DevcontainerRuntime } from "./DevcontainerRuntime";
+import type { ExecOptions, ExecStream } from "./Runtime";
 
 interface RuntimeState {
   remoteHomeDir?: string;
@@ -23,6 +24,48 @@ function createRuntime(state: RuntimeState): DevcontainerRuntime {
   internal.currentWorkspacePath = state.currentWorkspacePath;
   return runtime;
 }
+
+function createTextStream(value: string): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(value));
+      controller.close();
+    },
+  });
+}
+
+function createSinkStream(): WritableStream<Uint8Array> {
+  return new WritableStream<Uint8Array>();
+}
+
+class RecordingDevcontainerRuntime extends DevcontainerRuntime {
+  execOptions: ExecOptions | undefined;
+
+  override exec(_command: string, options: ExecOptions): Promise<ExecStream> {
+    this.execOptions = options;
+    return Promise.resolve({
+      stdout: createTextStream("123 456 regular file\n"),
+      stderr: createTextStream(""),
+      stdin: createSinkStream(),
+      exitCode: Promise.resolve(0),
+      duration: Promise.resolve(0),
+    });
+  }
+}
+
+describe("DevcontainerRuntime.stat", () => {
+  it("forwards abort signals to exec-backed container stats", async () => {
+    const runtime = new RecordingDevcontainerRuntime({
+      srcBaseDir: "/tmp/mux",
+      configPath: ".devcontainer/devcontainer.json",
+    });
+    const abortController = new AbortController();
+
+    await runtime.stat("/container-only/file.txt", abortController.signal);
+
+    expect(runtime.execOptions?.abortSignal).toBe(abortController.signal);
+  });
+});
 
 describe("DevcontainerRuntime.resolvePath", () => {
   it("resolves ~ to cached remoteHomeDir", async () => {

--- a/src/node/runtime/DevcontainerRuntime.ts
+++ b/src/node/runtime/DevcontainerRuntime.ts
@@ -223,14 +223,22 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
     return filePath === "~" || filePath.startsWith("~/");
   }
 
-  private async setupCredentials(env?: Record<string, string>): Promise<void> {
+  private async setupCredentials(
+    env?: Record<string, string>,
+    abortSignal?: AbortSignal
+  ): Promise<void> {
     if (!this.shareCredentials) return;
+
+    if (abortSignal?.aborted) {
+      throw new RuntimeError("Operation aborted before credential setup", "exec");
+    }
 
     const gitconfigContents = await readHostGitconfig();
     if (gitconfigContents) {
       const stream = await this.exec('cat > "$HOME/.gitconfig"', {
         cwd: this.getContainerBasePath(),
         timeout: 30,
+        abortSignal,
       });
       const writer = stream.stdin.getWriter();
       try {
@@ -252,18 +260,21 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
         cwd: this.getContainerBasePath(),
         timeout: 30,
         env: { GH_TOKEN: ghToken },
+        abortSignal,
       });
       await stream.stdin.close();
       await stream.exitCode;
     }
   }
 
-  private async fetchRemoteHome(): Promise<void> {
+  private async fetchRemoteHome(abortSignal?: AbortSignal): Promise<void> {
     if (!this.currentWorkspacePath) return;
+    if (abortSignal?.aborted) return;
     try {
       const stream = await this.exec('printf "%s" "$HOME"', {
         cwd: this.remoteWorkspaceFolder ?? "/",
         timeout: 10,
+        abortSignal,
       });
       await stream.stdin.close();
       const stdout = await streamToString(stream.stdout);
@@ -329,12 +340,22 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
     const writeCommand = `mkdir -p $(dirname ${quotedPath}) && cat > ${quotedTempPath} && mv ${quotedTempPath} ${quotedPath}`;
 
     let execPromise: Promise<ExecStream> | null = null;
+    const writeAbortController = new AbortController();
+    const abortWrite = () => writeAbortController.abort();
+    if (abortSignal?.aborted) {
+      writeAbortController.abort();
+    } else {
+      abortSignal?.addEventListener("abort", abortWrite, { once: true });
+    }
+    const cleanupAbortForwarder = () => {
+      abortSignal?.removeEventListener("abort", abortWrite);
+    };
 
     const getExecStream = () => {
       execPromise ??= this.exec(writeCommand, {
         cwd: this.getContainerBasePath(),
         timeout: 300,
-        abortSignal,
+        abortSignal: writeAbortController.signal,
       });
       return execPromise;
     };
@@ -350,27 +371,42 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
         }
       },
       close: async () => {
-        const stream = await getExecStream();
-        await stream.stdin.close();
-        const exitCode = await stream.exitCode;
+        try {
+          const stream = await getExecStream();
+          await stream.stdin.close();
+          const exitCode = await stream.exitCode;
 
-        if (exitCode !== 0) {
-          const stderr = await streamToString(stream.stderr);
-          throw new RuntimeError(`Failed to write file ${filePath}: ${stderr}`, "file_io");
+          if (exitCode !== 0) {
+            const stderr = await streamToString(stream.stderr);
+            throw new RuntimeError(`Failed to write file ${filePath}: ${stderr}`, "file_io");
+          }
+        } finally {
+          cleanupAbortForwarder();
         }
       },
       abort: async (reason?: unknown) => {
-        const stream = await getExecStream();
-        await stream.stdin.abort();
+        writeAbortController.abort();
+        if (execPromise) {
+          try {
+            const stream = await execPromise;
+            await stream.stdin.abort(reason).catch(() => undefined);
+            await stream.exitCode.catch(() => undefined);
+          } finally {
+            cleanupAbortForwarder();
+          }
+        } else {
+          cleanupAbortForwarder();
+        }
         throw new RuntimeError(`Failed to write file ${filePath}: ${String(reason)}`, "file_io");
       },
     });
   }
 
-  private async ensureDirViaExec(dirPath: string): Promise<void> {
+  private async ensureDirViaExec(dirPath: string, abortSignal?: AbortSignal): Promise<void> {
     const stream = await this.exec(`mkdir -p ${this.quoteForContainer(dirPath)}`, {
       cwd: "/",
       timeout: 10,
+      abortSignal,
     });
 
     await stream.stdin.close();
@@ -512,9 +548,9 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
       this.remoteWorkspaceFolder = result.remoteWorkspaceFolder;
       this.remoteUser = result.remoteUser;
       this.currentWorkspacePath = workspacePath;
-      await this.fetchRemoteHome();
+      await this.fetchRemoteHome(abortSignal);
 
-      await this.setupCredentials(env);
+      await this.setupCredentials(env, abortSignal);
 
       initLogger.logStep("Devcontainer ready");
     } catch (error) {
@@ -580,7 +616,7 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
     // Map host workspace path to container path; fall back to container workspace if unmappable
     const mappedCwd = options.cwd ? this.mapHostPathToContainer(options.cwd) : null;
     const cwd = mappedCwd ?? this.resolveContainerCwd(options.cwd, workspaceFolder);
-    const fullCommand = `cd ${JSON.stringify(cwd)} && ${command}`;
+    const fullCommand = `cd ${shescape.quote(cwd)} && ${command}`;
     args.push("--", "bash", "-c", fullCommand);
 
     const childProcess = spawn("devcontainer", args, {
@@ -645,9 +681,11 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
         disposable[Symbol.dispose]();
       }, options.timeout * 1000);
 
-      void exitCode.finally(() => {
-        if (timeoutId) clearTimeout(timeoutId);
-      });
+      void exitCode
+        .catch(() => undefined)
+        .finally(() => {
+          if (timeoutId) clearTimeout(timeoutId);
+        });
     }
 
     // Handle abort signal
@@ -655,10 +693,15 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
       aborted = true;
       disposable[Symbol.dispose]();
     };
-    options.abortSignal?.addEventListener("abort", abortHandler);
-    void exitCode.finally(() => {
-      options.abortSignal?.removeEventListener("abort", abortHandler);
-    });
+    options.abortSignal?.addEventListener("abort", abortHandler, { once: true });
+    if (options.abortSignal?.aborted) {
+      abortHandler();
+    }
+    void exitCode
+      .catch(() => undefined)
+      .finally(() => {
+        options.abortSignal?.removeEventListener("abort", abortHandler);
+      });
 
     return Promise.resolve({
       stdout,
@@ -685,20 +728,20 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
     return this.writeFileViaExec(filePath, abortSignal);
   }
 
-  override async stat(filePath: string): Promise<FileStat> {
+  override async stat(filePath: string, abortSignal?: AbortSignal): Promise<FileStat> {
     const hostPath = this.resolveHostPathForMounted(filePath);
     if (hostPath) {
-      return super.stat(hostPath);
+      return super.stat(hostPath, abortSignal);
     }
-    return this.statViaExec(filePath);
+    return this.statViaExec(filePath, abortSignal);
   }
 
-  override async ensureDir(dirPath: string): Promise<void> {
+  override async ensureDir(dirPath: string, abortSignal?: AbortSignal): Promise<void> {
     const hostPath = this.resolveHostPathForMounted(dirPath);
     if (hostPath) {
-      return super.ensureDir(hostPath);
+      return super.ensureDir(hostPath, abortSignal);
     }
-    return this.ensureDirViaExec(dirPath);
+    return this.ensureDirViaExec(dirPath, abortSignal);
   }
 
   override async resolvePath(filePath: string): Promise<string> {
@@ -807,9 +850,9 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
       // Update cached info (container may have been rebuilt)
       this.remoteWorkspaceFolder = result.remoteWorkspaceFolder;
       this.remoteUser = result.remoteUser;
-      await this.fetchRemoteHome();
+      await this.fetchRemoteHome(options?.signal);
 
-      await this.setupCredentials(this.lastCredentialEnv);
+      await this.setupCredentials(this.lastCredentialEnv, options?.signal);
 
       statusSink?.({ phase: "ready", runtimeType: "devcontainer" });
       return { ready: true };

--- a/src/node/runtime/DockerRuntime.test.ts
+++ b/src/node/runtime/DockerRuntime.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it } from "bun:test";
 import { DockerRuntime, getContainerName } from "./DockerRuntime";
+import type { InitLogger } from "./Runtime";
+
+const noopInitLogger: InitLogger = {
+  logStep: () => {
+    // no-op
+  },
+  logStdout: () => {
+    // no-op
+  },
+  logStderr: () => {
+    // no-op
+  },
+  logComplete: () => {
+    // no-op
+  },
+};
 
 /**
  * DockerRuntime constructor tests (run with bun test)
@@ -38,6 +54,25 @@ describe("DockerRuntime constructor", () => {
     });
     expect(runtime.getImage()).toBe("ubuntu:22.04");
     // Runtime should be ready for exec operations without calling createWorkspace
+  });
+});
+
+describe("DockerRuntime.forkWorkspace", () => {
+  it("stops before Docker commands when the fork is already aborted", async () => {
+    const runtime = new DockerRuntime({ image: "ubuntu:22.04" });
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const result = await runtime.forkWorkspace({
+      projectPath: "/tmp/project",
+      sourceWorkspaceName: "main",
+      newWorkspaceName: "feature",
+      initLogger: noopInitLogger,
+      abortSignal: abortController.signal,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("aborted");
   });
 });
 

--- a/src/node/runtime/DockerRuntime.ts
+++ b/src/node/runtime/DockerRuntime.ts
@@ -11,7 +11,7 @@
  * Extends RemoteRuntime for shared exec/file operations.
  */
 
-import { spawn, exec } from "child_process";
+import { spawn } from "child_process";
 import { createHash } from "crypto";
 import * as path from "path";
 import * as fs from "fs/promises";
@@ -64,29 +64,53 @@ function sanitizeContainerUserId(rawValue: string): string {
   return /^\d+$/.test(trimmedValue) ? trimmedValue : "0";
 }
 
+interface ContainerUserInfo {
+  uid: string;
+  gid: string;
+  home: string;
+}
+
 /** Result of checking if a container already exists and is valid for reuse */
 type ContainerCheckResult =
   | { action: "skip" } // Valid forked container, skip setup
   | { action: "cleanup"; reason: string } // Exists but invalid, needs removal
   | { action: "create" }; // Doesn't exist, proceed to create
 
-/**
- * Run a Docker CLI command and return result.
- * Unlike execAsync, this always resolves (never rejects) and returns exit code.
- */
-function runDockerCommand(command: string, timeoutMs = 30000): Promise<DockerCommandResult> {
+function runCommand(
+  command: string,
+  args: string[],
+  options: { timeoutMs?: number; shell?: boolean; abortSignal?: AbortSignal } = {}
+): Promise<DockerCommandResult> {
   return new Promise((resolve) => {
     let stdout = "";
     let stderr = "";
-    let timedOut = false;
+    let settled = false;
 
-    const child = exec(command);
+    if (options.abortSignal?.aborted) {
+      resolve({ exitCode: -1, stdout, stderr: "Command aborted" });
+      return;
+    }
+
+    const child = spawn(command, args, { shell: options.shell === true });
+
+    const finish = (result: DockerCommandResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      options.abortSignal?.removeEventListener("abort", onAbort);
+      resolve(result);
+    };
 
     const timer = setTimeout(() => {
-      timedOut = true;
       child.kill();
-      resolve({ exitCode: -1, stdout, stderr: "Command timed out" });
-    }, timeoutMs);
+      finish({ exitCode: -1, stdout, stderr: "Command timed out" });
+    }, options.timeoutMs ?? 30000);
+
+    const onAbort = () => {
+      child.kill();
+      finish({ exitCode: -1, stdout, stderr: "Command aborted" });
+    };
+    options.abortSignal?.addEventListener("abort", onAbort, { once: true });
 
     child.stdout?.on("data", (data: Buffer) => {
       stdout += data.toString();
@@ -97,61 +121,35 @@ function runDockerCommand(command: string, timeoutMs = 30000): Promise<DockerCom
     });
 
     child.on("close", (code) => {
-      clearTimeout(timer);
-      if (timedOut) return;
-      resolve({ exitCode: code ?? -1, stdout, stderr });
+      finish({ exitCode: code ?? -1, stdout, stderr });
     });
 
     child.on("error", (err) => {
-      clearTimeout(timer);
-      if (timedOut) return;
-      resolve({ exitCode: -1, stdout, stderr: err.message });
+      finish({ exitCode: -1, stdout, stderr: err.message });
     });
   });
 }
 
 /**
- * Run a command with array args (no shell interpolation).
- * Similar to runDockerCommand but safer for paths with special characters.
+ * Run a Docker CLI command and return result.
+ * Unlike execAsync, this always resolves (never rejects) and returns exit code.
  */
+function runDockerCommand(
+  command: string,
+  timeoutMs = 30000,
+  abortSignal?: AbortSignal
+): Promise<DockerCommandResult> {
+  return runCommand(command, [], { timeoutMs, shell: true, abortSignal });
+}
+
+/** Run a command with array args to avoid shell interpolation for host/container paths. */
 function runSpawnCommand(
   command: string,
   args: string[],
-  timeoutMs = 30000
+  timeoutMs = 30000,
+  abortSignal?: AbortSignal
 ): Promise<DockerCommandResult> {
-  return new Promise((resolve) => {
-    let stdout = "";
-    let stderr = "";
-    let timedOut = false;
-
-    const child = spawn(command, args);
-
-    const timer = setTimeout(() => {
-      timedOut = true;
-      child.kill();
-      resolve({ exitCode: -1, stdout, stderr: "Command timed out" });
-    }, timeoutMs);
-
-    child.stdout?.on("data", (data: Buffer) => {
-      stdout += data.toString();
-    });
-
-    child.stderr?.on("data", (data: Buffer) => {
-      stderr += data.toString();
-    });
-
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      if (timedOut) return;
-      resolve({ exitCode: code ?? -1, stdout, stderr });
-    });
-
-    child.on("error", (err) => {
-      clearTimeout(timer);
-      if (timedOut) return;
-      resolve({ exitCode: -1, stdout, stderr: err.message });
-    });
-  });
+  return runCommand(command, args, { timeoutMs, abortSignal });
 }
 
 /**
@@ -302,9 +300,7 @@ export class DockerRuntime extends RemoteRuntime {
   private readonly config: DockerRuntimeConfig;
   /** Container name - set during construction (for existing) or createWorkspace (for new) */
   private containerName?: string;
-  /** Container user info - detected after container creation/start */
-  private containerUid?: string;
-  private containerGid?: string;
+  /** Container home - detected after container creation/start */
   private containerHome?: string;
 
   constructor(config: DockerRuntimeConfig) {
@@ -598,6 +594,39 @@ export class DockerRuntime extends RemoteRuntime {
     return { action: "skip" };
   }
 
+  private async detectContainerUser(
+    containerName: string,
+    abortSignal?: AbortSignal
+  ): Promise<ContainerUserInfo> {
+    const [uidResult, gidResult, homeResult] = await Promise.all([
+      runDockerCommand(`docker exec ${containerName} id -u`, 5000, abortSignal),
+      runDockerCommand(`docker exec ${containerName} id -g`, 5000, abortSignal),
+      runDockerCommand(`docker exec ${containerName} sh -c 'echo $HOME'`, 5000, abortSignal),
+    ]);
+
+    return {
+      uid: sanitizeContainerUserId(uidResult.stdout),
+      gid: sanitizeContainerUserId(gidResult.stdout),
+      home: homeResult.stdout.trim() || "/root",
+    };
+  }
+
+  private storeContainerUserInfo(userInfo: ContainerUserInfo): void {
+    this.containerHome = userInfo.home;
+  }
+
+  private prepareWorkspaceDirectories(
+    containerName: string,
+    userInfo: ContainerUserInfo,
+    abortSignal?: AbortSignal
+  ): Promise<DockerCommandResult> {
+    return runDockerCommand(
+      `docker exec --user root ${containerName} sh -c 'mkdir -p ${CONTAINER_SRC_DIR} /var/mux/plans && chown ${userInfo.uid}:${userInfo.gid} ${CONTAINER_SRC_DIR} /var/mux /var/mux/plans'`,
+      10000,
+      abortSignal
+    );
+  }
+
   /**
    * Copy gitconfig and configure gh CLI credential helper in container.
    * Called for both new containers and reused forked containers.
@@ -608,10 +637,12 @@ export class DockerRuntime extends RemoteRuntime {
   ): Promise<void> {
     if (!this.config.shareCredentials) return;
 
-    // Copy host gitconfig into container (not mounted, so gh can modify it)
+    // Copy host gitconfig into container (not mounted, so gh can modify it).
+    // Use argv-based Docker calls so credential paths/tokens never go through a host shell.
     if (hasHostGitconfig()) {
-      await runDockerCommand(
-        `docker cp ${getHostGitconfigPath()} ${containerName}:/root/.gitconfig`,
+      await runSpawnCommand(
+        "docker",
+        ["cp", getHostGitconfigPath(), `${containerName}:/root/.gitconfig`],
         10000
       );
     }
@@ -620,8 +651,17 @@ export class DockerRuntime extends RemoteRuntime {
     // GH_TOKEN can come from project secrets (env) or host environment (buildCredentialArgs)
     const ghToken = resolveGhToken(env);
     if (ghToken) {
-      await runDockerCommand(
-        `docker exec -e GH_TOKEN=${shescape.quote(ghToken)} ${containerName} sh -c 'command -v gh >/dev/null && gh auth setup-git || true'`,
+      await runSpawnCommand(
+        "docker",
+        [
+          "exec",
+          "-e",
+          `GH_TOKEN=${ghToken}`,
+          containerName,
+          "sh",
+          "-c",
+          "command -v gh >/dev/null && gh auth setup-git || true",
+        ],
         10000
       );
     }
@@ -672,23 +712,17 @@ export class DockerRuntime extends RemoteRuntime {
     }
 
     // Detect container's default user (may be non-root, e.g., codercom/enterprise-base runs as "coder")
-    const [uidResult, gidResult, homeResult] = await Promise.all([
-      runDockerCommand(`docker exec ${containerName} id -u`, 5000),
-      runDockerCommand(`docker exec ${containerName} id -g`, 5000),
-      runDockerCommand(`docker exec ${containerName} sh -c 'echo $HOME'`, 5000),
-    ]);
-    this.containerUid = sanitizeContainerUserId(uidResult.stdout);
-    this.containerGid = sanitizeContainerUserId(gidResult.stdout);
-    this.containerHome = homeResult.stdout.trim() || "/root";
+    const containerUser = await this.detectContainerUser(containerName, abortSignal);
+    this.storeContainerUserInfo(containerUser);
 
-    // Create /src directory and /var/mux/plans in container
-    // Use --user root to create directories, then chown to container's default user
+    // Create /src directory and /var/mux/plans in container.
     // /var/mux is used instead of ~/.mux because /root has 700 permissions,
-    // which makes it inaccessible to VS Code Dev Containers (non-root user)
+    // which makes it inaccessible to VS Code Dev Containers (non-root user).
     initLogger.logStep("Preparing workspace directory...");
-    const mkdirResult = await runDockerCommand(
-      `docker exec --user root ${containerName} sh -c 'mkdir -p ${CONTAINER_SRC_DIR} /var/mux/plans && chown ${this.containerUid}:${this.containerGid} ${CONTAINER_SRC_DIR} /var/mux /var/mux/plans'`,
-      10000
+    const mkdirResult = await this.prepareWorkspaceDirectories(
+      containerName,
+      containerUser,
+      abortSignal
     );
     if (mkdirResult.exitCode !== 0) {
       await runDockerCommand(`docker rm -f ${containerName}`, 10000);
@@ -976,7 +1010,12 @@ export class DockerRuntime extends RemoteRuntime {
   }
 
   async forkWorkspace(params: WorkspaceForkParams): Promise<WorkspaceForkResult> {
-    const { projectPath, sourceWorkspaceName, newWorkspaceName, initLogger } = params;
+    const { projectPath, sourceWorkspaceName, newWorkspaceName, initLogger, abortSignal } = params;
+    const throwIfAborted = () => {
+      if (abortSignal?.aborted) {
+        throw new Error("Docker workspace fork aborted");
+      }
+    };
 
     const srcContainerName = getContainerName(projectPath, sourceWorkspaceName);
     const destContainerName = getContainerName(projectPath, newWorkspaceName);
@@ -986,8 +1025,14 @@ export class DockerRuntime extends RemoteRuntime {
     let forkSucceeded = false;
 
     try {
+      throwIfAborted();
+
       // 1. Verify source container exists
-      const srcCheck = await runDockerCommand(`docker inspect ${srcContainerName}`, 10000);
+      const srcCheck = await runDockerCommand(
+        `docker inspect ${srcContainerName}`,
+        10000,
+        abortSignal
+      );
       if (srcCheck.exitCode !== 0) {
         return {
           success: false,
@@ -997,9 +1042,11 @@ export class DockerRuntime extends RemoteRuntime {
 
       // 2. Get current branch from source
       initLogger.logStep("Detecting source workspace branch...");
+      throwIfAborted();
       const branchResult = await runDockerCommand(
         `docker exec ${srcContainerName} git -C ${CONTAINER_SRC_DIR} branch --show-current`,
-        30000
+        30000,
+        abortSignal
       );
       const sourceBranch = branchResult.stdout.trim();
       if (branchResult.exitCode !== 0 || sourceBranch.length === 0) {
@@ -1011,9 +1058,11 @@ export class DockerRuntime extends RemoteRuntime {
 
       // 3. Create git bundle inside source container
       initLogger.logStep("Creating git bundle from source...");
+      throwIfAborted();
       const bundleResult = await runDockerCommand(
         `docker exec ${srcContainerName} git -C ${CONTAINER_SRC_DIR} bundle create ${containerBundlePath} --all`,
-        300000
+        300000,
+        abortSignal
       );
       if (bundleResult.exitCode !== 0) {
         return { success: false, error: `Failed to create git bundle: ${bundleResult.stderr}` };
@@ -1021,9 +1070,12 @@ export class DockerRuntime extends RemoteRuntime {
 
       // 4. Transfer bundle to host
       initLogger.logStep("Copying bundle from source container...");
-      const cpOutResult = await runDockerCommand(
-        `docker cp ${srcContainerName}:${containerBundlePath} ${shescape.quote(hostTempPath)}`,
-        300000
+      throwIfAborted();
+      const cpOutResult = await runSpawnCommand(
+        "docker",
+        ["cp", `${srcContainerName}:${containerBundlePath}`, hostTempPath],
+        300000,
+        abortSignal
       );
       if (cpOutResult.exitCode !== 0) {
         return {
@@ -1039,7 +1091,8 @@ export class DockerRuntime extends RemoteRuntime {
         dockerArgs.push(...buildCredentialArgs());
       }
       dockerArgs.push(this.config.image, "sleep", "infinity");
-      const runResult = await runSpawnCommand("docker", dockerArgs, 60000);
+      throwIfAborted();
+      const runResult = await runSpawnCommand("docker", dockerArgs, 60000, abortSignal);
       if (runResult.exitCode !== 0) {
         // Handle TOCTOU race - container may have been created between check and run
         if (runResult.stderr.includes("already in use")) {
@@ -1053,19 +1106,12 @@ export class DockerRuntime extends RemoteRuntime {
       destContainerCreated = true;
 
       // 5b. Detect container user and prepare directories (may be non-root)
-      const [uidResult, gidResult, homeResult] = await Promise.all([
-        runDockerCommand(`docker exec ${destContainerName} id -u`, 5000),
-        runDockerCommand(`docker exec ${destContainerName} id -g`, 5000),
-        runDockerCommand(`docker exec ${destContainerName} sh -c 'echo $HOME'`, 5000),
-      ]);
-      const destUid = sanitizeContainerUserId(uidResult.stdout);
-      const destGid = sanitizeContainerUserId(gidResult.stdout);
-      const destHome = homeResult.stdout.trim() || "/root";
-
-      // Create /src and /var/mux/plans as root, then chown to container user
-      const mkdirResult = await runDockerCommand(
-        `docker exec --user root ${destContainerName} sh -c 'mkdir -p ${CONTAINER_SRC_DIR} /var/mux/plans && chown ${destUid}:${destGid} ${CONTAINER_SRC_DIR} /var/mux /var/mux/plans'`,
-        10000
+      throwIfAborted();
+      const destUser = await this.detectContainerUser(destContainerName, abortSignal);
+      const mkdirResult = await this.prepareWorkspaceDirectories(
+        destContainerName,
+        destUser,
+        abortSignal
       );
       if (mkdirResult.exitCode !== 0) {
         return {
@@ -1076,9 +1122,12 @@ export class DockerRuntime extends RemoteRuntime {
 
       // 6. Copy bundle into destination and clone
       initLogger.logStep("Copying bundle to destination container...");
-      const cpInResult = await runDockerCommand(
-        `docker cp ${shescape.quote(hostTempPath)} ${destContainerName}:${containerBundlePath}`,
-        300000
+      throwIfAborted();
+      const cpInResult = await runSpawnCommand(
+        "docker",
+        ["cp", hostTempPath, `${destContainerName}:${containerBundlePath}`],
+        300000,
+        abortSignal
       );
       if (cpInResult.exitCode !== 0) {
         return {
@@ -1096,24 +1145,31 @@ export class DockerRuntime extends RemoteRuntime {
             .map(([k, v]) => `${k}=${v}`)
             .join(" ") +
           " ";
+      throwIfAborted();
       const cloneResult = await runDockerCommand(
         `docker exec ${destContainerName} ${noHooksEnvCmd}git clone ${containerBundlePath} ${CONTAINER_SRC_DIR}`,
-        300000
+        300000,
+        abortSignal
       );
       if (cloneResult.exitCode !== 0) {
         return { success: false, error: `Failed to clone from bundle: ${cloneResult.stderr}` };
       }
 
       // Ensure /src is owned by the container user (git clone may create as current user)
-      await runDockerCommand(
-        `docker exec --user root ${destContainerName} chown -R ${destUid}:${destGid} ${CONTAINER_SRC_DIR}`,
-        30000
+      const chownResult = await runDockerCommand(
+        `docker exec --user root ${destContainerName} chown -R ${destUser.uid}:${destUser.gid} ${CONTAINER_SRC_DIR}`,
+        30000,
+        abortSignal
       );
+      if (chownResult.exitCode !== 0) {
+        return {
+          success: false,
+          error: `Failed to fix workspace ownership: ${chownResult.stderr}`,
+        };
+      }
 
       // Store user info for this runtime instance
-      this.containerUid = destUid;
-      this.containerGid = destGid;
-      this.containerHome = destHome;
+      this.storeContainerUserInfo(destUser);
 
       // 7. Create local tracking branches (best-effort)
       initLogger.logStep("Creating local tracking branches...");
@@ -1169,9 +1225,11 @@ export class DockerRuntime extends RemoteRuntime {
       const checkoutCmd =
         `${forkNhp}git checkout ${shescape.quote(newWorkspaceName)} 2>/dev/null || ` +
         `${forkNhp}git checkout -b ${shescape.quote(newWorkspaceName)} ${shescape.quote(sourceBranch)}`;
+      throwIfAborted();
       const checkoutResult = await runDockerCommand(
         `docker exec ${destContainerName} bash -c ${shescape.quote(`cd ${CONTAINER_SRC_DIR} && ${checkoutCmd}`)}`,
-        120000
+        120000,
+        abortSignal
       );
       if (checkoutResult.exitCode !== 0) {
         return {
@@ -1247,14 +1305,7 @@ export class DockerRuntime extends RemoteRuntime {
 
     // Detect container user info if not already set (e.g., runtime recreated for existing workspace)
     if (!this.containerHome) {
-      const [uidResult, gidResult, homeResult] = await Promise.all([
-        runDockerCommand(`docker exec ${this.containerName} id -u`, 5000),
-        runDockerCommand(`docker exec ${this.containerName} id -g`, 5000),
-        runDockerCommand(`docker exec ${this.containerName} sh -c 'echo $HOME'`, 5000),
-      ]);
-      this.containerUid = sanitizeContainerUserId(uidResult.stdout);
-      this.containerGid = sanitizeContainerUserId(gidResult.stdout);
-      this.containerHome = homeResult.stdout.trim() || "/root";
+      this.storeContainerUserInfo(await this.detectContainerUser(this.containerName));
     }
 
     return { ready: true };

--- a/src/node/runtime/LocalBaseRuntime.ts
+++ b/src/node/runtime/LocalBaseRuntime.ts
@@ -28,6 +28,7 @@ import { expandTilde } from "./tildeExpansion";
 import { getInitHookPath, createLineBufferedLoggers } from "./initHook";
 import { getErrorMessage } from "@/common/utils/errors";
 import { getAtomicWriteTempPath } from "./atomicWriteTempPath";
+import { buildShellExport } from "./shellEnv";
 import { sanitizeMuxChildEnv } from "./childProcessEnv";
 
 /**
@@ -53,6 +54,10 @@ export abstract class LocalBaseRuntime implements Runtime {
   async exec(command: string, options: ExecOptions): Promise<ExecStream> {
     const startTime = performance.now();
 
+    if (options.abortSignal?.aborted) {
+      throw new RuntimeErrorClass("Operation aborted before execution", "exec");
+    }
+
     // Use the specified working directory (must be a specific workspace path)
     const cwd = options.cwd;
 
@@ -77,7 +82,7 @@ export abstract class LocalBaseRuntime implements Runtime {
     // - On Windows, env var casing and shell startup state can be surprising.
     // - These are non-sensitive vars that we want to guarantee for git/editor safety.
     const nonInteractivePrelude = Object.entries(NON_INTERACTIVE_ENV_VARS)
-      .map(([key, value]) => `export ${key}=${shellQuote(value)}`)
+      .map(([key, value]) => buildShellExport(key, value))
       .join("\n");
 
     const spawnArgs = ["-c", `${nonInteractivePrelude}\n${command}`];
@@ -179,12 +184,16 @@ export abstract class LocalBaseRuntime implements Runtime {
     });
 
     // Handle abort signal
-    if (options.abortSignal) {
-      options.abortSignal.addEventListener("abort", () => {
-        aborted = true;
-        disposable[Symbol.dispose](); // Kill process and run cleanup
+    const onAbort = () => {
+      aborted = true;
+      disposable[Symbol.dispose](); // Kill process and run cleanup
+    };
+    options.abortSignal?.addEventListener("abort", onAbort, { once: true });
+    void exitCode
+      .catch(() => undefined)
+      .finally(() => {
+        options.abortSignal?.removeEventListener("abort", onAbort);
       });
-    }
 
     // Handle timeout
     if (options.timeout !== undefined) {
@@ -322,7 +331,10 @@ export abstract class LocalBaseRuntime implements Runtime {
     }
   }
 
-  async ensureDir(dirPath: string): Promise<void> {
+  async ensureDir(dirPath: string, abortSignal?: AbortSignal): Promise<void> {
+    if (abortSignal?.aborted) {
+      throw new RuntimeErrorClass("Operation aborted before directory creation", "file_io");
+    }
     const expandedPath = expandTilde(dirPath);
     try {
       await fsPromises.mkdir(expandedPath, { recursive: true });
@@ -430,7 +442,7 @@ export abstract class LocalBaseRuntime implements Runtime {
 
     return new Promise<void>((resolve) => {
       const bashPath = getBashPath();
-      const proc = spawn(bashPath, ["-c", `"${hookPath}"`], {
+      const proc = spawn(bashPath, ["-c", shellQuote(hookPath)], {
         cwd: workspacePath,
         stdio: ["ignore", "pipe", "pipe"],
         env: {

--- a/src/node/runtime/LocalRuntime.test.ts
+++ b/src/node/runtime/LocalRuntime.test.ts
@@ -66,6 +66,25 @@ describe("LocalRuntime", () => {
     });
   });
 
+  describe("exec", () => {
+    it("rejects before command execution when abort signal is already aborted", async () => {
+      const runtime = new LocalRuntime(testDir);
+      const abortController = new AbortController();
+      abortController.abort();
+
+      try {
+        await runtime.exec("echo should-not-run", {
+          cwd: path.join(testDir, "does-not-exist"),
+          abortSignal: abortController.signal,
+        });
+        throw new Error("Expected exec to reject");
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toContain("Operation aborted before execution");
+      }
+    });
+  });
+
   describe("createWorkspace", () => {
     it("succeeds when directory exists", async () => {
       const runtime = new LocalRuntime(testDir);
@@ -159,6 +178,29 @@ describe("LocalRuntime", () => {
         () => false
       );
       expect(skippedMarkerExists).toBe(false);
+    });
+
+    it("runs init hooks from project paths containing shell metacharacters", async () => {
+      const projectDir = path.join(testDir, "project-$quoted");
+      await fs.rm(projectDir, { recursive: true, force: true });
+      await fs.mkdir(path.join(projectDir, ".mux"), { recursive: true });
+
+      const hookPath = path.join(projectDir, ".mux", "init");
+      await fs.writeFile(hookPath, "#!/usr/bin/env bash\n\necho ran > .init-marker\n");
+      await fs.chmod(hookPath, 0o755);
+
+      const runtime = new LocalRuntime(projectDir);
+      const result = await runtime.initWorkspace({
+        projectPath: projectDir,
+        branchName: "main",
+        trunkBranch: "main",
+        workspacePath: projectDir,
+        initLogger: createMockLogger(),
+        trusted: true,
+      });
+
+      expect(result.success).toBe(true);
+      await fs.access(path.join(projectDir, ".init-marker"));
     });
 
     it("skips init hook when project is untrusted", async () => {

--- a/src/node/runtime/RemoteRuntime.test.ts
+++ b/src/node/runtime/RemoteRuntime.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import { RemoteRuntime, type SpawnResult } from "./RemoteRuntime";
+
+class RecordingRemoteRuntime extends RemoteRuntime {
+  spawnCount = 0;
+
+  protected readonly commandPrefix = "Recording";
+
+  protected getBasePath(): string {
+    return "/workspace";
+  }
+
+  protected quoteForRemote(filePath: string): string {
+    return `'${filePath}'`;
+  }
+
+  protected cdCommand(cwd: string): string {
+    return `cd '${cwd}'`;
+  }
+
+  protected spawnRemoteProcess(): Promise<SpawnResult> {
+    this.spawnCount += 1;
+    throw new Error("spawn should not be called");
+  }
+
+  resolvePath(filePath: string): Promise<string> {
+    return Promise.resolve(filePath);
+  }
+
+  getWorkspacePath(): string {
+    return "/workspace";
+  }
+
+  createWorkspace() {
+    return Promise.resolve({ success: false as const, error: "not implemented" });
+  }
+
+  initWorkspace() {
+    return Promise.resolve({ success: true });
+  }
+
+  deleteWorkspace() {
+    return Promise.resolve({ success: true as const, deletedPath: "/workspace" });
+  }
+
+  renameWorkspace() {
+    return Promise.resolve({
+      success: true as const,
+      oldPath: "/workspace",
+      newPath: "/workspace",
+    });
+  }
+
+  forkWorkspace() {
+    return Promise.resolve({ success: false as const, error: "not implemented" });
+  }
+
+  ensureReady() {
+    return Promise.resolve({ ready: true as const });
+  }
+}
+
+describe("RemoteRuntime.writeFile", () => {
+  it("does not start a remote write command when aborted before the first write", async () => {
+    const runtime = new RecordingRemoteRuntime();
+    const writer = runtime.writeFile("/workspace/file.txt").getWriter();
+
+    try {
+      await writer.abort("cancelled");
+      throw new Error("Expected writer abort to reject");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain("cancelled");
+    }
+
+    expect(runtime.spawnCount).toBe(0);
+  });
+});

--- a/src/node/runtime/RemoteRuntime.ts
+++ b/src/node/runtime/RemoteRuntime.ts
@@ -37,6 +37,7 @@ import { DisposableProcess } from "@/node/utils/disposableExec";
 import { streamToString, shescape } from "./streamUtils";
 import { getErrorMessage } from "@/common/utils/errors";
 import { getAtomicWriteTempPath } from "./atomicWriteTempPath";
+import { buildShellExport } from "./shellEnv";
 
 /**
  * Result from spawning a remote process.
@@ -113,7 +114,7 @@ export abstract class RemoteRuntime implements Runtime {
     // Add environment variable exports (user env first, then non-interactive overrides)
     const envVars = { ...options.env, ...NON_INTERACTIVE_ENV_VARS };
     for (const [key, value] of Object.entries(envVars)) {
-      parts.push(`export ${key}=${shescape.quote(value)}`);
+      parts.push(buildShellExport(key, value, (envValue) => shescape.quote(envValue)));
     }
 
     // Add the actual command
@@ -220,9 +221,14 @@ export abstract class RemoteRuntime implements Runtime {
       };
 
       abortSignal.addEventListener("abort", onAbort, { once: true });
+      if (abortSignal.aborted) {
+        onAbort();
+      }
 
       // Avoid retaining closures on long-lived abort signals once the process exits.
-      void exitCode.finally(() => abortSignal.removeEventListener("abort", onAbort));
+      void exitCode
+        .catch(() => undefined)
+        .finally(() => abortSignal.removeEventListener("abort", onAbort));
     }
 
     // Handle timeout. Include connection acquisition time in the local deadline so
@@ -248,7 +254,7 @@ export abstract class RemoteRuntime implements Runtime {
         hardKillHandle.unref();
       }, remainingTimeoutMs);
 
-      void exitCode.finally(() => clearTimeout(timeoutHandle));
+      void exitCode.catch(() => undefined).finally(() => clearTimeout(timeoutHandle));
     }
 
     // Convert Node.js streams to Web Streams
@@ -391,12 +397,22 @@ export abstract class RemoteRuntime implements Runtime {
     const writeCommand = this.buildWriteCommand(quotedPath, quotedTempPath);
 
     let execPromise: Promise<ExecStream> | null = null;
+    const writeAbortController = new AbortController();
+    const abortWrite = () => writeAbortController.abort();
+    if (abortSignal?.aborted) {
+      writeAbortController.abort();
+    } else {
+      abortSignal?.addEventListener("abort", abortWrite, { once: true });
+    }
+    const cleanupAbortForwarder = () => {
+      abortSignal?.removeEventListener("abort", abortWrite);
+    };
 
     const getExecStream = () => {
       execPromise ??= this.exec(writeCommand, {
         cwd: this.getBasePath(),
         timeout: 300,
-        abortSignal,
+        abortSignal: writeAbortController.signal,
       });
       return execPromise;
     };
@@ -412,18 +428,32 @@ export abstract class RemoteRuntime implements Runtime {
         }
       },
       close: async () => {
-        const stream = await getExecStream();
-        await stream.stdin.close();
-        const exitCode = await stream.exitCode;
+        try {
+          const stream = await getExecStream();
+          await stream.stdin.close();
+          const exitCode = await stream.exitCode;
 
-        if (exitCode !== 0) {
-          const stderr = await streamToString(stream.stderr);
-          throw new RuntimeError(`Failed to write file ${filePath}: ${stderr}`, "file_io");
+          if (exitCode !== 0) {
+            const stderr = await streamToString(stream.stderr);
+            throw new RuntimeError(`Failed to write file ${filePath}: ${stderr}`, "file_io");
+          }
+        } finally {
+          cleanupAbortForwarder();
         }
       },
       abort: async (reason?: unknown) => {
-        const stream = await getExecStream();
-        await stream.stdin.abort();
+        writeAbortController.abort();
+        if (execPromise) {
+          try {
+            const stream = await execPromise;
+            await stream.stdin.abort(reason).catch(() => undefined);
+            await stream.exitCode.catch(() => undefined);
+          } finally {
+            cleanupAbortForwarder();
+          }
+        } else {
+          cleanupAbortForwarder();
+        }
         throw new RuntimeError(`Failed to write file ${filePath}: ${String(reason)}`, "file_io");
       },
     });
@@ -440,10 +470,11 @@ export abstract class RemoteRuntime implements Runtime {
   /**
    * Ensure a directory exists (mkdir -p semantics).
    */
-  async ensureDir(dirPath: string): Promise<void> {
+  async ensureDir(dirPath: string, abortSignal?: AbortSignal): Promise<void> {
     const stream = await this.exec(`mkdir -p ${this.quoteForRemote(dirPath)}`, {
       cwd: "/",
       timeout: 10,
+      abortSignal,
     });
 
     await stream.stdin.close();

--- a/src/node/runtime/Runtime.ts
+++ b/src/node/runtime/Runtime.ts
@@ -240,12 +240,6 @@ export interface WorkspaceInitResult {
 }
 
 /**
- * Runtime interface - minimal, low-level abstraction for tool execution environments.
- *
- * All methods return streaming primitives for memory efficiency.
- * Use helpers in utils/runtime/ for convenience wrappers (e.g., readFileString, execBuffered).
-
-/**
  * Parameters for forking an existing workspace
  */
 export interface WorkspaceForkParams {
@@ -408,7 +402,7 @@ export interface Runtime {
    * This intentionally lives on the Runtime abstraction so local runtimes can use
    * Node fs APIs (Windows-safe) while remote runtimes can use shell commands.
    */
-  ensureDir(path: string): Promise<void>;
+  ensureDir(path: string, abortSignal?: AbortSignal): Promise<void>;
 
   /**
    * Resolve a path to its absolute, canonical form (expanding tildes, resolving symlinks, etc.).

--- a/src/node/runtime/SSH2ConnectionPool.ts
+++ b/src/node/runtime/SSH2ConnectionPool.ts
@@ -20,6 +20,12 @@ import { attachStreamErrorHandler } from "@/node/utils/streamErrors";
 import type { SSHConnectionConfig, ConnectionHealth } from "./sshConnectionPool";
 import { resolveSSHConfig, type ResolvedSSHConfig } from "./sshConfigParser";
 import type { SshPromptService } from "@/node/services/sshPromptService";
+import {
+  DEFAULT_SSH_MAX_WAIT_MS,
+  SSH_BACKOFF_SCHEDULE_SECONDS,
+  type BaseSshAcquireConnectionOptions,
+  withSshBackoffJitter,
+} from "./sshBackoff";
 
 let sshPromptService: SshPromptService | undefined;
 
@@ -30,13 +36,8 @@ export function setSshPromptService(svc: SshPromptService): void {
 // ConnectionStatus and ConnectionHealth are shared with the OpenSSH pool —
 // imported from sshConnectionPool.ts to avoid duplication.
 
-/**
- * Backoff schedule in seconds: 1s → 2s → 4s → 7s → 10s (cap)
- */
-const BACKOFF_SCHEDULE = [1, 2, 4, 7, 10];
-
+const SSH2_OPERATION_ABORTED_ERROR = "Operation aborted";
 const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
-const DEFAULT_MAX_WAIT_MS = 2 * 60 * 1000;
 
 /**
  * Close idle connections after 60 seconds (matches ControlPersist=60).
@@ -44,26 +45,7 @@ const DEFAULT_MAX_WAIT_MS = 2 * 60 * 1000;
  */
 const IDLE_TIMEOUT_MS = 60 * 1000;
 
-export interface AcquireConnectionOptions {
-  /** Timeout for the connection attempt. */
-  timeoutMs?: number;
-
-  /**
-   * Max time to wait (ms) for a host to become healthy (waits + retries).
-   *
-   * - Omit to use the default (waits through backoff).
-   * - Set to 0 to fail fast.
-   */
-  maxWaitMs?: number;
-
-  /** Optional abort signal to cancel any waiting. */
-  abortSignal?: AbortSignal;
-
-  /**
-   * Called when acquireConnection is waiting due to backoff.
-   */
-  onWait?: (waitMs: number) => void;
-
+export interface AcquireConnectionOptions extends BaseSshAcquireConnectionOptions {
   /**
    * Test seam.
    *
@@ -80,9 +62,27 @@ interface SSH2ConnectionEntry {
   idleTimer?: ReturnType<typeof setTimeout>;
 }
 
-function withJitter(seconds: number): number {
-  const jitterFactor = 0.8 + Math.random() * 0.4;
-  return seconds * jitterFactor;
+function waitForAbortable<T>(promise: Promise<T>, abortSignal?: AbortSignal): Promise<T> {
+  if (!abortSignal) return promise;
+  if (abortSignal.aborted) return Promise.reject(new Error(SSH2_OPERATION_ABORTED_ERROR));
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      abortSignal.removeEventListener("abort", onAbort);
+      reject(new Error(SSH2_OPERATION_ABORTED_ERROR));
+    };
+    abortSignal.addEventListener("abort", onAbort, { once: true });
+    void promise.then(
+      (value) => {
+        abortSignal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        abortSignal.removeEventListener("abort", onAbort);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    );
+  });
 }
 
 function getAgentConfig(): string | undefined {
@@ -275,13 +275,13 @@ export class SSH2ConnectionPool {
     const key = makeConnectionKey(config);
     const timeoutMs = options.timeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
     const sleep = options.sleep ?? sleepWithAbort;
-    const maxWaitMs = options.maxWaitMs ?? DEFAULT_MAX_WAIT_MS;
+    const maxWaitMs = options.maxWaitMs ?? DEFAULT_SSH_MAX_WAIT_MS;
     const shouldWait = maxWaitMs > 0;
     const startTime = Date.now();
 
     while (true) {
       if (options.abortSignal?.aborted) {
-        throw new Error("Operation aborted");
+        throw new Error(SSH2_OPERATION_ABORTED_ERROR);
       }
 
       const existing = this.connections.get(key);
@@ -330,7 +330,7 @@ export class SSH2ConnectionPool {
       }
 
       try {
-        const entry = await inflight;
+        const entry = await waitForAbortable(inflight, options.abortSignal);
         return entry;
       } catch (error) {
         if (!shouldWait) {
@@ -362,8 +362,8 @@ export class SSH2ConnectionPool {
     const now = new Date();
     const current = this.health.get(key);
     const failures = (current?.consecutiveFailures ?? 0) + 1;
-    const backoffIndex = Math.min(failures - 1, BACKOFF_SCHEDULE.length - 1);
-    const backoffSeconds = withJitter(BACKOFF_SCHEDULE[backoffIndex]);
+    const backoffIndex = Math.min(failures - 1, SSH_BACKOFF_SCHEDULE_SECONDS.length - 1);
+    const backoffSeconds = withSshBackoffJitter(SSH_BACKOFF_SCHEDULE_SECONDS[backoffIndex]);
 
     this.health.set(key, {
       status: "unhealthy",
@@ -467,6 +467,9 @@ export class SSH2ConnectionPool {
         };
 
         const readableKeys = await resolvePrivateKeys(resolvedConfigWithIdentities.identityFiles);
+        if (abortSignal?.aborted) {
+          throw new Error(SSH2_OPERATION_ABORTED_ERROR);
+        }
         const keysToTry: Array<Buffer | undefined> =
           readableKeys.length > 0 ? readableKeys : [undefined];
         // Keep the sshPromptService wiring in place so known_hosts-backed
@@ -530,6 +533,8 @@ export class SSH2ConnectionPool {
             }
           }
 
+          let aborted = false;
+
           const onClose = () => {
             if (entry.idleTimer) {
               clearTimeout(entry.idleTimer);
@@ -544,7 +549,7 @@ export class SSH2ConnectionPool {
             if (entry.idleTimer) {
               clearTimeout(entry.idleTimer);
             }
-            if (!isAuthFailure(err) || reportAuthFailure) {
+            if (!aborted && (!isAuthFailure(err) || reportAuthFailure)) {
               this.reportFailure(config, getErrorMessage(err));
             }
             this.connections.delete(key);
@@ -563,10 +568,11 @@ export class SSH2ConnectionPool {
             };
 
             const onAbort = () => {
+              aborted = true;
               cleanup();
               client.end();
               cleanupProxy();
-              reject(new Error("Operation aborted"));
+              reject(new Error(SSH2_OPERATION_ABORTED_ERROR));
             };
 
             const cleanup = () => {
@@ -578,6 +584,11 @@ export class SSH2ConnectionPool {
             client.on("ready", onReady);
             client.on("error", onError);
             abortSignal?.addEventListener("abort", onAbort, { once: true });
+
+            if (abortSignal?.aborted) {
+              onAbort();
+              return;
+            }
 
             const connectOptions = {
               host: resolvedConfig.hostName,
@@ -599,8 +610,9 @@ export class SSH2ConnectionPool {
           });
 
           if (abortSignal?.aborted) {
+            aborted = true;
             client.end();
-            throw new Error("Operation aborted");
+            throw new Error(SSH2_OPERATION_ABORTED_ERROR);
           }
 
           this.markHealthy(config);
@@ -640,7 +652,12 @@ export class SSH2ConnectionPool {
       const agentForFallback = shouldTryAgentOnly ? undefined : agent;
       return await attemptConnection(fallbackIdentityFiles, agentForFallback);
     } catch (error) {
-      this.reportFailure(config, getErrorMessage(error));
+      const errorMessage = getErrorMessage(error);
+      const wasAborted =
+        (abortSignal?.aborted ?? false) || errorMessage === SSH2_OPERATION_ABORTED_ERROR;
+      if (!wasAborted) {
+        this.reportFailure(config, errorMessage);
+      }
       throw error;
     }
   }

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -2050,6 +2050,10 @@ export class SSHRuntime extends RemoteRuntime {
     // so it depends on the local `ssh` CLI being available. On OpenSSH runtimes,
     // the transport already depends on that binary and shares the same ControlPath.
     const runPush = async (pushArgs: string[]): Promise<void> => {
+      if (abortSignal?.aborted) {
+        throw new Error("Git push aborted");
+      }
+
       using pushProc = execFileAsync("git", pushArgs, {
         env: { GIT_SSH_COMMAND: gitSshCommand },
         onStderrData: (chunk) => {
@@ -2064,6 +2068,9 @@ export class SSHRuntime extends RemoteRuntime {
       const pushTimeout = setTimeout(() => pushProc[Symbol.dispose](), 300_000);
       const onAbort = () => pushProc[Symbol.dispose]();
       abortSignal?.addEventListener("abort", onAbort, { once: true });
+      if (abortSignal?.aborted) {
+        onAbort();
+      }
       try {
         await pushProc.result;
       } finally {

--- a/src/node/runtime/backgroundCommands.ts
+++ b/src/node/runtime/backgroundCommands.ts
@@ -1,4 +1,5 @@
 import { shellQuote } from "@/common/utils/shell";
+import { buildShellExport } from "./shellEnv";
 export { shellQuote };
 
 /** Exit code for process killed by SIGKILL (128 + 9) */
@@ -67,7 +68,7 @@ export function buildWrapperScript(options: WrapperScriptOptions): string {
   // Add environment variable exports
   if (options.env) {
     for (const [key, value] of Object.entries(options.env)) {
-      parts.push(`export ${key}=${shellQuote(value)}`);
+      parts.push(buildShellExport(key, value));
     }
   }
 

--- a/src/node/runtime/devcontainerCli.test.ts
+++ b/src/node/runtime/devcontainerCli.test.ts
@@ -1,9 +1,45 @@
 import { describe, expect, it } from "bun:test";
 import {
+  devcontainerUp,
   formatDevcontainerUpError,
   parseDevcontainerStdoutLine,
   shouldCleanupDevcontainer,
 } from "./devcontainerCli";
+import type { InitLogger } from "./Runtime";
+
+const noopInitLogger: InitLogger = {
+  logStep: () => {
+    // no-op
+  },
+  logStdout: () => {
+    // no-op
+  },
+  logStderr: () => {
+    // no-op
+  },
+  logComplete: () => {
+    // no-op
+  },
+};
+
+describe("devcontainerUp", () => {
+  it("rejects before spawning when already aborted", async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+
+    try {
+      await devcontainerUp({
+        workspaceFolder: "/tmp/does-not-need-to-exist",
+        initLogger: noopInitLogger,
+        abortSignal: abortController.signal,
+      });
+      throw new Error("Expected devcontainerUp to reject");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain("devcontainer up aborted");
+    }
+  });
+});
 
 describe("parseDevcontainerStdoutLine", () => {
   it("parses JSON log lines with text", () => {

--- a/src/node/runtime/devcontainerCli.ts
+++ b/src/node/runtime/devcontainerCli.ts
@@ -245,6 +245,11 @@ export async function devcontainerUp(
     initLogger.logStep(`Running: devcontainer ${logArgs.join(" ")}`);
 
     return new Promise((resolve, reject) => {
+      if (abortSignal?.aborted) {
+        reject(new Error("devcontainer up aborted"));
+        return;
+      }
+
       const proc = spawn("devcontainer", args, {
         stdio: ["ignore", "pipe", "pipe"],
         timeout: timeoutMs,
@@ -320,7 +325,10 @@ export async function devcontainerUp(
           settleError(new Error(`devcontainer up timed out after ${timeoutMs}ms`));
         }, timeoutMs);
       }
-      abortSignal?.addEventListener("abort", abortHandler);
+      abortSignal?.addEventListener("abort", abortHandler, { once: true });
+      if (abortSignal?.aborted) {
+        abortHandler();
+      }
 
       const finalizeError = async (message: string, result?: DevcontainerUpResultLine | null) => {
         if (result && shouldCleanupDevcontainer(result)) {
@@ -410,16 +418,31 @@ export type DevcontainerStopResult =
   | { kind: "absent" }
   | { kind: "error"; message: string };
 
-export async function probeDevcontainerStatus(
-  workspacePath: string,
+export async function probeDevcontainerStatuses(
+  workspacePaths: string[],
   timeoutMs = 10_000
-): Promise<DevcontainerProbeResult> {
-  const labelValue = workspacePath;
+): Promise<Record<string, DevcontainerProbeResult>> {
+  const results: Record<string, DevcontainerProbeResult> = {};
+  for (const workspacePath of workspacePaths) {
+    results[workspacePath] = { kind: "absent" };
+  }
 
-  return new Promise((resolve) => {
+  if (workspacePaths.length === 0) {
+    return results;
+  }
+
+  const requestedPaths = new Set(workspacePaths);
+
+  return await new Promise((resolve) => {
     const proc = spawn(
       "docker",
-      ["ps", "-q", "--filter", `label=devcontainer.local_folder=${labelValue}`],
+      [
+        "ps",
+        "--filter",
+        "label=devcontainer.local_folder",
+        "--format",
+        '{{.ID}}\t{{.Label "devcontainer.local_folder"}}',
+      ],
       {
         stdio: ["ignore", "pipe", "pipe"],
         timeout: timeoutMs,
@@ -435,31 +458,46 @@ export async function probeDevcontainerStatus(
       stderr += data.toString();
     });
 
+    const resolveAllError = (message: string) => {
+      for (const workspacePath of workspacePaths) {
+        results[workspacePath] = { kind: "error", message };
+      }
+      resolve(results);
+    };
+
     proc.on("error", (error) => {
-      resolve({ kind: "error", message: getErrorMessage(error) });
+      resolveAllError(getErrorMessage(error));
     });
 
     proc.on("close", (code, signal) => {
-      const containerId = stdout.trim().split("\n")[0];
-      if (code === 0 && containerId) {
-        resolve({ kind: "found", containerId });
-        return;
-      }
-      if (code === 0) {
-        resolve({ kind: "absent" });
+      if (code !== 0) {
+        const stderrMessage = stderr.trim();
+        const exitMessage = signal
+          ? `docker ps exited with signal ${signal}`
+          : `docker ps exited with code ${code ?? "null"}`;
+        resolveAllError(stderrMessage ? `${exitMessage}: ${stderrMessage}` : exitMessage);
         return;
       }
 
-      const stderrMessage = stderr.trim();
-      const exitMessage = signal
-        ? `docker ps exited with signal ${signal}`
-        : `docker ps exited with code ${code ?? "null"}`;
-      resolve({
-        kind: "error",
-        message: stderrMessage ? `${exitMessage}: ${stderrMessage}` : exitMessage,
-      });
+      for (const line of stdout.split("\n")) {
+        const [containerId, workspacePath] = line.split("\t");
+        if (!containerId || !workspacePath || !requestedPaths.has(workspacePath)) {
+          continue;
+        }
+        results[workspacePath] = { kind: "found", containerId };
+      }
+
+      resolve(results);
     });
   });
+}
+
+export async function probeDevcontainerStatus(
+  workspacePath: string,
+  timeoutMs = 10_000
+): Promise<DevcontainerProbeResult> {
+  const results = await probeDevcontainerStatuses([workspacePath], timeoutMs);
+  return results[workspacePath] ?? { kind: "absent" };
 }
 /**
  * Get the container name for a devcontainer workspace.

--- a/src/node/runtime/multiProjectRuntime.ts
+++ b/src/node/runtime/multiProjectRuntime.ts
@@ -419,8 +419,8 @@ export class MultiProjectRuntime implements Runtime {
     return this.primaryRuntime.stat(filePath, abortSignal);
   }
 
-  ensureDir(dirPath: string): Promise<void> {
-    return this.primaryRuntime.ensureDir(dirPath);
+  ensureDir(dirPath: string, abortSignal?: AbortSignal): Promise<void> {
+    return this.primaryRuntime.ensureDir(dirPath, abortSignal);
   }
 
   tempDir(): Promise<string> {

--- a/src/node/runtime/shellEnv.test.ts
+++ b/src/node/runtime/shellEnv.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test";
+import { buildShellExport } from "./shellEnv";
+
+describe("buildShellExport", () => {
+  it("quotes values for valid environment variable names", () => {
+    expect(buildShellExport("MUX_VALUE", "hello world")).toBe("export MUX_VALUE='hello world'");
+  });
+
+  it("rejects invalid environment variable names before building shell", () => {
+    expect(() => buildShellExport("BAD;echo pwn", "value")).toThrow(
+      "Invalid shell environment variable name"
+    );
+  });
+});

--- a/src/node/runtime/shellEnv.ts
+++ b/src/node/runtime/shellEnv.ts
@@ -1,0 +1,18 @@
+import { shellQuote } from "@/common/utils/shell";
+
+const SHELL_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export function assertShellEnvName(key: string): void {
+  if (!SHELL_ENV_NAME_PATTERN.test(key)) {
+    throw new Error(`Invalid shell environment variable name: ${key}`);
+  }
+}
+
+export function buildShellExport(
+  key: string,
+  value: string,
+  quoteValue: (value: string) => string = shellQuote
+): string {
+  assertShellEnvName(key);
+  return `export ${key}=${quoteValue(value)}`;
+}

--- a/src/node/runtime/sshBackoff.ts
+++ b/src/node/runtime/sshBackoff.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared SSH retry policy for transports that maintain their own connection pools.
+ * Keeping the constants in one place prevents OpenSSH and ssh2 reliability from drifting.
+ */
+export const SSH_BACKOFF_SCHEDULE_SECONDS = [1, 2, 4, 7, 10] as const;
+
+export const DEFAULT_SSH_MAX_WAIT_MS = 2 * 60 * 1000;
+
+export interface BaseSshAcquireConnectionOptions {
+  /** Timeout for the connection health check or connect attempt. */
+  timeoutMs?: number;
+
+  /**
+   * Max time to wait (ms) for a host to become healthy.
+   *
+   * - Omit to use the default (waits through backoff).
+   * - Set to 0 to fail fast.
+   */
+  maxWaitMs?: number;
+
+  /** Optional abort signal to cancel any waiting. */
+  abortSignal?: AbortSignal;
+
+  /** Called when acquireConnection is waiting due to backoff. */
+  onWait?: (waitMs: number) => void;
+}
+
+/** Add ±20% jitter to prevent thundering herd when multiple clients recover simultaneously. */
+export function withSshBackoffJitter(seconds: number): number {
+  const jitterFactor = 0.8 + Math.random() * 0.4; // 0.8 to 1.2
+  return seconds * jitterFactor;
+}

--- a/src/node/runtime/sshConnectionPool.test.ts
+++ b/src/node/runtime/sshConnectionPool.test.ts
@@ -372,6 +372,35 @@ describe("SSHConnectionPool", () => {
       expect(path1).toBe(getControlPath(config));
     });
 
+    test("does not record backoff when a probe is aborted", async () => {
+      const pool = new SSHConnectionPool();
+      const config: SSHRuntimeConfig = {
+        host: "abort.example.com",
+        srcBaseDir: "/work",
+      };
+      const abortController = new AbortController();
+
+      const spy = spyOn(
+        pool as unknown as { probeConnection: () => Promise<void> },
+        "probeConnection"
+      ).mockImplementationOnce(() => {
+        abortController.abort();
+        return Promise.reject(new Error("Operation aborted"));
+      });
+
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(
+        pool.acquireConnection(config, {
+          timeoutMs: 1000,
+          maxWaitMs: 0,
+          abortSignal: abortController.signal,
+        })
+      ).rejects.toThrow("Operation aborted");
+
+      expect(pool.getConnectionHealth(config)).toBeUndefined();
+      spy.mockRestore();
+    });
+
     test("records backoff when probe rejects without recording it (safety net)", async () => {
       const pool = new SSHConnectionPool();
       const config: SSHRuntimeConfig = {

--- a/src/node/runtime/sshConnectionPool.ts
+++ b/src/node/runtime/sshConnectionPool.ts
@@ -24,6 +24,12 @@ import { formatSshEndpoint } from "@/common/utils/ssh/formatSshEndpoint";
 import { log } from "@/node/services/log";
 import type { SshPromptService } from "@/node/services/sshPromptService";
 import { createMediatedAskpassSession } from "./openSshPromptMediation";
+import {
+  DEFAULT_SSH_MAX_WAIT_MS,
+  SSH_BACKOFF_SCHEDULE_SECONDS,
+  type BaseSshAcquireConnectionOptions,
+  withSshBackoffJitter,
+} from "./sshBackoff";
 
 export type OpenSSHHostKeyPolicyMode = "strict" | "headless-fallback";
 
@@ -91,50 +97,14 @@ export interface ConnectionHealth {
 }
 
 /**
- * Backoff schedule in seconds: 1s → 2s → 4s → 7s → 10s (cap)
- * Kept short to avoid blocking user actions; thundering herd is mitigated by jitter.
- */
-const BACKOFF_SCHEDULE = [1, 2, 4, 7, 10];
-
-/**
- * Add ±20% jitter to prevent thundering herd when multiple clients recover simultaneously.
- */
-function withJitter(seconds: number): number {
-  const jitterFactor = 0.8 + Math.random() * 0.4; // 0.8 to 1.2
-  return seconds * jitterFactor;
-}
-
-/**
  * Time after which a "healthy" connection should be re-probed.
  * Prevents stale health state when network silently degrades.
  */
 const HEALTHY_TTL_MS = 15 * 1000; // 15 seconds
 
+const SSH_OPERATION_ABORTED_ERROR = "Operation aborted";
 const DEFAULT_PROBE_TIMEOUT_MS = 10_000;
-const DEFAULT_MAX_WAIT_MS = 2 * 60 * 1000; // 2 minutes
-
-export interface AcquireConnectionOptions {
-  /** Timeout for the health check probe. */
-  timeoutMs?: number;
-
-  /**
-   * Max time to wait (ms) for a host to become healthy (waits + probes).
-   *
-   * - Omit to use the default (waits through backoff).
-   * - Set to 0 to fail fast.
-   */
-  maxWaitMs?: number;
-
-  /** Optional abort signal to cancel any waiting. */
-  abortSignal?: AbortSignal;
-
-  /**
-   * Called when acquireConnection is waiting due to backoff.
-   *
-   * Useful for user-facing progress logs (e.g. workspace init).
-   */
-  onWait?: (waitMs: number) => void;
-
+export interface AcquireConnectionOptions extends BaseSshAcquireConnectionOptions {
   /**
    * Optional explicit ControlPath to probe/bootstrap before returning. When omitted,
    * the default host-scoped ControlPath is used.
@@ -235,7 +205,7 @@ export class SSHConnectionPool {
     const timeoutMs = options.timeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
     const sleep = options.sleep ?? sleepWithAbort;
 
-    const maxWaitMs = options.maxWaitMs ?? DEFAULT_MAX_WAIT_MS;
+    const maxWaitMs = options.maxWaitMs ?? DEFAULT_SSH_MAX_WAIT_MS;
     const shouldWait = maxWaitMs > 0;
 
     const key = makeConnectionKey(config);
@@ -251,7 +221,7 @@ export class SSHConnectionPool {
 
     while (true) {
       if (options.abortSignal?.aborted) {
-        throw new Error("Operation aborted");
+        throw new Error(SSH_OPERATION_ABORTED_ERROR);
       }
 
       const health = this.health.get(key);
@@ -340,21 +310,32 @@ export class SSHConnectionPool {
         throw createWaitBudgetExceededError(health?.lastError);
       }
       log.debug(`SSH connection to ${config.host} needs probe, starting health check`);
-      const probe = this.probeConnection(config, probeTimeoutMs, key, requestedControlPath);
+      const probe = this.probeConnection(
+        config,
+        probeTimeoutMs,
+        key,
+        requestedControlPath,
+        options.abortSignal
+      );
       this.inflight.set(key, probe);
 
       try {
         await probe;
         return;
       } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        const wasAborted =
+          (options.abortSignal?.aborted ?? false) || errorMessage === SSH_OPERATION_ABORTED_ERROR;
+
         // Ensure backoff is recorded even if probeConnection rejected before
         // reaching markFailedByKey (e.g., askpass setup failure). Without this,
         // the while-loop retries immediately with no backoff — a hot loop.
+        // Explicit user cancellation is not host failure and must not poison health/backoff.
         const h = this.health.get(key);
-        if (!h?.backoffUntil || h.backoffUntil <= new Date()) {
-          this.markFailedByKey(key, error instanceof Error ? error.message : String(error));
+        if (!wasAborted && (!h?.backoffUntil || h.backoffUntil <= new Date())) {
+          this.markFailedByKey(key, errorMessage);
         }
-        if (!shouldWait) {
+        if (!shouldWait || wasAborted) {
           throw error;
         }
         continue;
@@ -444,8 +425,8 @@ export class SSHConnectionPool {
   private markFailedByKey(key: string, error: string): void {
     const current = this.health.get(key);
     const failures = (current?.consecutiveFailures ?? 0) + 1;
-    const backoffIndex = Math.min(failures - 1, BACKOFF_SCHEDULE.length - 1);
-    const backoffSecs = withJitter(BACKOFF_SCHEDULE[backoffIndex]);
+    const backoffIndex = Math.min(failures - 1, SSH_BACKOFF_SCHEDULE_SECONDS.length - 1);
+    const backoffSecs = withSshBackoffJitter(SSH_BACKOFF_SCHEDULE_SECONDS[backoffIndex]);
 
     this.clearReadyControlPaths(key);
     this.health.set(key, {
@@ -478,8 +459,13 @@ export class SSHConnectionPool {
     config: SSHConnectionConfig,
     timeoutMs: number,
     key: string,
-    controlPath = getControlPath(config)
+    controlPath = getControlPath(config),
+    abortSignal?: AbortSignal
   ): Promise<void> {
+    if (abortSignal?.aborted) {
+      throw new Error(SSH_OPERATION_ABORTED_ERROR);
+    }
+
     const promptService = sshPromptService;
     const canPromptInteractively = isInteractiveHostKeyApprovalAvailable();
 
@@ -546,6 +532,12 @@ export class SSHConnectionPool {
         : undefined;
 
     return new Promise((resolve, reject) => {
+      if (abortSignal?.aborted) {
+        askpass?.cleanup();
+        reject(new Error(SSH_OPERATION_ABORTED_ERROR));
+        return;
+      }
+
       const proc = spawn("ssh", args, {
         stdio: ["ignore", "pipe", "pipe"],
         ...(askpass ? { env: { ...process.env, ...askpass.env } } : {}),
@@ -554,6 +546,25 @@ export class SSHConnectionPool {
       let timedOut = false;
       let timer: ReturnType<typeof setTimeout> | undefined;
 
+      const cleanup = () => {
+        if (timer) clearTimeout(timer);
+        abortSignal?.removeEventListener("abort", onAbort);
+        askpass?.cleanup();
+      };
+
+      let aborted = false;
+
+      const onAbort = () => {
+        aborted = true;
+        proc.kill("SIGKILL");
+        cleanup();
+        reject(new Error(SSH_OPERATION_ABORTED_ERROR));
+      };
+      abortSignal?.addEventListener("abort", onAbort, { once: true });
+      if (abortSignal?.aborted) {
+        onAbort();
+      }
+
       const scheduleKill = (ms: number) => {
         if (timer) {
           clearTimeout(timer);
@@ -561,7 +572,7 @@ export class SSHConnectionPool {
         timer = setTimeout(() => {
           timedOut = true;
           proc.kill("SIGKILL");
-          askpass?.cleanup();
+          cleanup();
           const error = "SSH probe timed out";
           this.markFailedByKey(key, error);
           reject(new Error(error));
@@ -577,11 +588,8 @@ export class SSHConnectionPool {
       });
 
       proc.on("close", (code) => {
-        if (timer) {
-          clearTimeout(timer);
-        }
-        askpass?.cleanup();
-        if (timedOut) return; // Already handled by timeout
+        cleanup();
+        if (timedOut || aborted) return; // Already handled by timeout/abort
 
         if (code === 0) {
           this.markHealthyByKey(key);
@@ -596,10 +604,7 @@ export class SSHConnectionPool {
       });
 
       proc.on("error", (err) => {
-        if (timer) {
-          clearTimeout(timer);
-        }
-        askpass?.cleanup();
+        cleanup();
         const error = `SSH probe spawn error: ${err.message}`;
         this.markFailedByKey(key, error);
         reject(new Error(error));

--- a/src/node/runtime/transports/OpenSSHTransport.ts
+++ b/src/node/runtime/transports/OpenSSHTransport.ts
@@ -10,6 +10,7 @@ import {
 import type { SpawnResult } from "../RemoteRuntime";
 import type {
   SSHTransport,
+  SSHTransportAcquireOptions,
   SSHTransportConfig,
   SpawnOptions,
   PtyHandle,
@@ -49,12 +50,7 @@ export class OpenSSHTransport implements SSHTransport {
     return this.config;
   }
 
-  async acquireConnection(options?: {
-    abortSignal?: AbortSignal;
-    timeoutMs?: number;
-    maxWaitMs?: number;
-    onWait?: (waitMs: number) => void;
-  }): Promise<void> {
+  async acquireConnection(options?: SSHTransportAcquireOptions): Promise<void> {
     await sshConnectionPool.acquireConnection(this.config, {
       abortSignal: options?.abortSignal,
       timeoutMs: options?.timeoutMs,

--- a/src/node/runtime/transports/SSH2Transport.test.ts
+++ b/src/node/runtime/transports/SSH2Transport.test.ts
@@ -110,6 +110,35 @@ describe("SSH2Transport.spawnRemoteProcess", () => {
     acquireConnectionSpy.mockRestore();
   });
 
+  test("aborts while waiting for ssh2 exec channel", async () => {
+    acquireConnectionSpy.mockResolvedValue({
+      client: {
+        exec() {
+          // Simulate ssh2 never invoking the exec callback.
+        },
+      },
+    } as never);
+
+    const reportFailureSpy = spyOn(ssh2ConnectionPool, "reportFailure");
+    const transport = new SSH2Transport({ host: "remote.example.com" });
+    const abortController = new AbortController();
+    const spawnPromise = transport.spawnRemoteProcess("echo ok", {
+      abortSignal: abortController.signal,
+    });
+
+    abortController.abort();
+
+    try {
+      await spawnPromise;
+      throw new Error("Expected spawnRemoteProcess to reject");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain("Operation aborted");
+    }
+    expect(reportFailureSpy).not.toHaveBeenCalled();
+    reportFailureSpy.mockRestore();
+  });
+
   test("forcePTY closes the synthetic stderr stream when ssh2 omits channel.stderr", async () => {
     const channel = new FakeClientChannel();
     acquireConnectionSpy.mockResolvedValue({

--- a/src/node/runtime/transports/SSH2Transport.ts
+++ b/src/node/runtime/transports/SSH2Transport.ts
@@ -11,6 +11,7 @@ import { ssh2ConnectionPool } from "../SSH2ConnectionPool";
 import type { SpawnResult } from "../RemoteRuntime";
 import type {
   SSHTransport,
+  SSHTransportAcquireOptions,
   SSHTransportConfig,
   SpawnOptions,
   PtyHandle,
@@ -235,12 +236,7 @@ export class SSH2Transport implements SSHTransport {
     return this.config;
   }
 
-  async acquireConnection(options?: {
-    abortSignal?: AbortSignal;
-    timeoutMs?: number;
-    maxWaitMs?: number;
-    onWait?: (waitMs: number) => void;
-  }): Promise<void> {
+  async acquireConnection(options?: SSHTransportAcquireOptions): Promise<void> {
     await ssh2ConnectionPool.acquireConnection(this.config, {
       abortSignal: options?.abortSignal,
       timeoutMs: options?.timeoutMs,
@@ -269,16 +265,61 @@ export class SSH2Transport implements SSHTransport {
 
     try {
       const channel = await new Promise<ClientChannel>((resolve, reject) => {
+        let settled = false;
+        let streamFromLateCallback: ClientChannel | undefined;
+
+        const remainingDeadlineMs =
+          options.deadlineMs != null ? Math.max(0, options.deadlineMs - Date.now()) : undefined;
+        const timeoutMs =
+          remainingDeadlineMs ??
+          (options.timeout != null ? Math.max(0, options.timeout * 1000) : undefined);
+        const timeoutHandle =
+          timeoutMs != null
+            ? setTimeout(() => {
+                streamFromLateCallback?.close();
+                finish(() => reject(new Error("SSH2 exec channel timed out")));
+              }, timeoutMs)
+            : undefined;
+        timeoutHandle?.unref?.();
+
+        const cleanup = () => {
+          options.abortSignal?.removeEventListener("abort", onAbort);
+          if (timeoutHandle) clearTimeout(timeoutHandle);
+        };
+
+        const finish = (handler: () => void) => {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          handler();
+        };
+
+        const onAbort = () => {
+          streamFromLateCallback?.close();
+          finish(() => reject(new Error("Operation aborted")));
+        };
+
+        options.abortSignal?.addEventListener("abort", onAbort, { once: true });
+        if (options.abortSignal?.aborted) {
+          onAbort();
+          return;
+        }
+
         const onExec = (err?: Error, stream?: ClientChannel) => {
+          if (settled) {
+            stream?.close();
+            return;
+          }
+          streamFromLateCallback = stream;
           if (err) {
-            reject(err);
+            finish(() => reject(err));
             return;
           }
           if (!stream) {
-            reject(new Error("SSH2 exec did not return a stream"));
+            finish(() => reject(new Error("SSH2 exec did not return a stream")));
             return;
           }
-          resolve(stream);
+          finish(() => resolve(stream));
         };
 
         if (options.forcePTY) {
@@ -299,9 +340,14 @@ export class SSH2Transport implements SSHTransport {
         },
       };
     } catch (error) {
-      ssh2ConnectionPool.reportFailure(this.config, getErrorMessage(error));
+      const errorMessage = getErrorMessage(error);
+      const wasAborted =
+        (options.abortSignal?.aborted ?? false) || errorMessage === "Operation aborted";
+      if (!wasAborted) {
+        ssh2ConnectionPool.reportFailure(this.config, errorMessage);
+      }
       throw new RuntimeErrorClass(
-        `SSH2 command failed: ${getErrorMessage(error)}`,
+        `SSH2 command failed: ${errorMessage}`,
         "network",
         error instanceof Error ? error : undefined
       );

--- a/src/node/runtime/transports/SSHTransport.ts
+++ b/src/node/runtime/transports/SSHTransport.ts
@@ -25,6 +25,13 @@ export interface PtySessionParams {
   rows: number;
 }
 
+export interface SSHTransportAcquireOptions {
+  abortSignal?: AbortSignal;
+  timeoutMs?: number;
+  maxWaitMs?: number;
+  onWait?: (waitMs: number) => void;
+}
+
 export interface SSHTransport {
   /** Spawn a command on the remote host, returning a ChildProcess-compatible object. */
   spawnRemoteProcess(command: string, options: SpawnOptions): Promise<SpawnResult>;
@@ -33,12 +40,7 @@ export interface SSHTransport {
   isConnectionFailure(exitCode: number, stderr: string): boolean;
 
   /** Pre-flight connection check with backoff enforcement. */
-  acquireConnection(options?: {
-    abortSignal?: AbortSignal;
-    timeoutMs?: number;
-    maxWaitMs?: number;
-    onWait?: (waitMs: number) => void;
-  }): Promise<void>;
+  acquireConnection(options?: SSHTransportAcquireOptions): Promise<void>;
 
   /** Get underlying config (for PTY terminal spawning). */
   getConfig(): SSHTransportConfig;

--- a/src/node/services/coderService.ts
+++ b/src/node/services/coderService.ts
@@ -155,12 +155,20 @@ async function* streamCoderCommand(
     stdio: ["ignore", "pipe", "pipe"],
   });
 
+  const exitPromise = new Promise<number | null>((resolve) => {
+    child.on("close", resolve);
+    child.on("error", () => resolve(null));
+  });
+
   const terminator = createGracefulTerminator(child);
 
   const abortHandler = () => {
     terminator.terminate();
   };
-  abortSignal?.addEventListener("abort", abortHandler);
+  abortSignal?.addEventListener("abort", abortHandler, { once: true });
+  if (abortSignal?.aborted) {
+    abortHandler();
+  }
 
   try {
     // Use an async queue to stream lines as they arrive
@@ -231,11 +239,8 @@ async function* streamCoderCommand(
       }
     }
 
-    // Wait for process to exit
-    const exitCode = await new Promise<number | null>((resolve) => {
-      child.on("close", resolve);
-      child.on("error", () => resolve(null));
-    });
+    // Wait for process to exit; listener is attached before stream draining to avoid missing close.
+    const exitCode = await exitPromise;
 
     if (abortSignal?.aborted) {
       throw new Error(abortMessage);
@@ -313,6 +318,7 @@ function sanitizeCoderCliErrorForUi(error: unknown): string {
 export class CoderService {
   // Ephemeral API sessions scoped to workspace provisioning.
   // This keeps token reuse explicit without persisting anything to disk.
+  private provisioningSessionPromises = new Map<string, Promise<CoderApiSession>>();
   private provisioningSessions = new Map<string, CoderApiSession>();
   private cachedInfo: CoderInfo | null = null;
   // Cache whoami results so later URL lookups can reuse the last CLI response.
@@ -374,8 +380,9 @@ export class CoderService {
     const binaryPath = await this.resolveCoderBinaryPath();
 
     try {
-      using proc = execFileAsync("coder", ["version", "--output=json"]);
-      const { stdout } = await proc.result;
+      const stdout = await this.runCoderJsonCommand(["version", "--output=json"], {
+        timeoutMs: 10_000,
+      });
 
       // Parse JSON output
       const data = JSON.parse(stdout) as { version?: string };
@@ -490,14 +497,11 @@ export class CoderService {
    * Create a short-lived Coder API token for deployment endpoints.
    */
   private async createApiSession(tokenName: string): Promise<CoderApiSession> {
-    using tokenProc = execFileAsync("coder", [
-      "tokens",
-      "create",
-      "--lifetime",
-      "5m",
-      "--name",
-      tokenName,
-    ]);
+    using tokenProc = execFileAsync(
+      "coder",
+      ["tokens", "create", "--lifetime", "5m", "--name", tokenName],
+      { timeoutMs: 30_000 }
+    );
     const { stdout: token } = await tokenProc.result;
     const trimmed = token.trim();
 
@@ -505,7 +509,9 @@ export class CoderService {
       token: trimmed,
       dispose: async () => {
         try {
-          using deleteProc = execFileAsync("coder", ["tokens", "delete", tokenName]);
+          using deleteProc = execFileAsync("coder", ["tokens", "delete", tokenName], {
+            timeoutMs: 30_000,
+          });
           await deleteProc.result;
         } catch {
           // Best-effort cleanup; token will expire in 5 minutes anyway.
@@ -533,10 +539,24 @@ export class CoderService {
       return existing;
     }
 
+    const pending = this.provisioningSessionPromises.get(workspaceName);
+    if (pending) {
+      return pending;
+    }
+
     const tokenName = `mux-${workspaceName}-${Date.now().toString(36)}`;
-    const session = await this.createApiSession(tokenName);
-    this.provisioningSessions.set(workspaceName, session);
-    return session;
+    const sessionPromise = this.createApiSession(tokenName)
+      .then((session) => {
+        this.provisioningSessions.set(workspaceName, session);
+        this.provisioningSessionPromises.delete(workspaceName);
+        return session;
+      })
+      .catch((error: unknown) => {
+        this.provisioningSessionPromises.delete(workspaceName);
+        throw error;
+      });
+    this.provisioningSessionPromises.set(workspaceName, sessionPromise);
+    return sessionPromise;
   }
 
   takeProvisioningSession(workspaceName: string): CoderApiSession | undefined {
@@ -574,13 +594,18 @@ export class CoderService {
 
   // Preserve the old behavior: explicit whoami checks should hit the CLI even if cached.
   // The cache only exists so later URL lookups can reuse the last whoami response.
-  private async getWhoamiData(options?: { useCache?: boolean }): Promise<CoderWhoamiData> {
+  private async getWhoamiData(options?: {
+    useCache?: boolean;
+    signal?: AbortSignal;
+  }): Promise<CoderWhoamiData> {
     if (options?.useCache && this.cachedWhoami) {
       return this.cachedWhoami;
     }
 
-    using proc = execFileAsync("coder", ["whoami", "--output=json"]);
-    const { stdout } = await proc.result;
+    const stdout = await this.runCoderJsonCommand(["whoami", "--output=json"], {
+      timeoutMs: 10_000,
+      signal: options?.signal,
+    });
 
     const data = JSON.parse(stdout) as Array<Partial<CoderWhoamiData>>;
     if (!data[0]?.url) {
@@ -600,8 +625,8 @@ export class CoderService {
    * Get the Coder deployment URL via `coder whoami`.
    * Throws if Coder CLI is not configured/logged in.
    */
-  private async getDeploymentUrl(): Promise<string> {
-    const { url } = await this.getWhoamiData({ useCache: true });
+  private async getDeploymentUrl(signal?: AbortSignal): Promise<string> {
+    const { url } = await this.getWhoamiData({ useCache: true, signal });
     return url;
   }
 
@@ -609,10 +634,15 @@ export class CoderService {
    * Get the active template version ID for a template.
    * Throws if template not found.
    */
-  private async getActiveTemplateVersionId(templateName: string, org?: string): Promise<string> {
+  private async getActiveTemplateVersionId(
+    templateName: string,
+    org?: string,
+    signal?: AbortSignal
+  ): Promise<string> {
     // Note: `coder templates list` doesn't support --org flag, so we filter client-side
-    using proc = execFileAsync("coder", ["templates", "list", "--output=json"]);
-    const { stdout } = await proc.result;
+    const stdout = await this.runCoderJsonCommand(["templates", "list", "--output=json"], {
+      signal,
+    });
 
     if (!stdout.trim()) {
       throw new Error(`Template "${templateName}" not found (no templates exist)`);
@@ -645,13 +675,13 @@ export class CoderService {
   private async getPresetParamNames(
     templateName: string,
     presetName: string,
-    org?: string
+    org?: string,
+    signal?: AbortSignal
   ): Promise<Set<string>> {
     try {
       const args = ["templates", "presets", "list", templateName, "--output=json"];
       if (org) args.push("--org", org);
-      using proc = execFileAsync("coder", args);
-      const { stdout } = await proc.result;
+      const stdout = await this.runCoderJsonCommand(args, { signal });
 
       // Same non-JSON guard as listPresets (CLI prints info message for no presets)
       if (!stdout.trim() || !stdout.trimStart().startsWith("[")) {
@@ -672,6 +702,9 @@ export class CoderService {
 
       return new Set(preset.TemplatePreset.Parameters.map((p) => p.Name));
     } catch (error) {
+      if (signal?.aborted) {
+        throw error;
+      }
       log.debug("Failed to get preset param names", { templateName, presetName, error });
       return new Set();
     }
@@ -714,7 +747,8 @@ export class CoderService {
     deploymentUrl: string,
     versionId: string,
     workspaceName: string,
-    session?: CoderApiSession
+    session?: CoderApiSession,
+    signal?: AbortSignal
   ): Promise<
     Array<{
       name: string;
@@ -730,10 +764,22 @@ export class CoderService {
         deploymentUrl
       ).toString();
 
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 30_000);
+      const onAbort = () => controller.abort();
+      signal?.addEventListener("abort", onAbort, { once: true });
+      if (signal?.aborted) {
+        controller.abort();
+      }
+
       const response = await fetch(url, {
         headers: {
           "Coder-Session-Token": api.token,
         },
+        signal: controller.signal,
+      }).finally(() => {
+        clearTimeout(timeout);
+        signal?.removeEventListener("abort", onAbort);
       });
 
       if (!response.ok) {
@@ -831,8 +877,7 @@ export class CoderService {
    */
   async listTemplates(): Promise<CoderListTemplatesResult> {
     try {
-      using proc = execFileAsync("coder", ["templates", "list", "--output=json"]);
-      const { stdout } = await proc.result;
+      const stdout = await this.runCoderJsonCommand(["templates", "list", "--output=json"]);
 
       // Handle empty output (no templates)
       if (!stdout.trim()) {
@@ -873,8 +918,7 @@ export class CoderService {
     try {
       const args = ["templates", "presets", "list", templateName, "--output=json"];
       if (org) args.push("--org", org);
-      using proc = execFileAsync("coder", args);
-      const { stdout } = await proc.result;
+      const stdout = await this.runCoderJsonCommand(args);
 
       // Handle empty output or non-JSON info messages (no presets).
       // CLI prints "No presets found for template ..." to stdout even with --output=json
@@ -918,13 +962,12 @@ export class CoderService {
    */
   async workspaceExists(workspaceName: string): Promise<boolean> {
     try {
-      using proc = execFileAsync("coder", [
+      const stdout = await this.runCoderJsonCommand([
         "list",
         "--search",
         `name:${workspaceName}`,
         "--output=json",
       ]);
-      const { stdout } = await proc.result;
 
       if (!stdout.trim()) {
         return false;
@@ -948,8 +991,7 @@ export class CoderService {
     const KNOWN_STATUSES = new Set<string>(CoderWorkspaceStatusSchema.options);
 
     try {
-      using proc = execFileAsync("coder", ["list", "--output=json"]);
-      const { stdout } = await proc.result;
+      const stdout = await this.runCoderJsonCommand(["list", "--output=json"]);
 
       // Handle empty output (no workspaces)
       if (!stdout.trim()) {
@@ -1078,6 +1120,18 @@ export class CoderService {
 
       options.signal?.addEventListener("abort", onAbort);
     });
+  }
+
+  private async runCoderJsonCommand(
+    args: string[],
+    options: { timeoutMs?: number; signal?: AbortSignal } = {}
+  ): Promise<string> {
+    using proc = execFileAsync("coder", args, {
+      timeoutMs: options.timeoutMs ?? 30_000,
+      signal: options.signal,
+    });
+    const { stdout } = await proc.result;
+    return stdout;
   }
 
   /**
@@ -1237,18 +1291,36 @@ export class CoderService {
     }
 
     // 1. Get deployment URL
-    const deploymentUrl = await this.getDeploymentUrl();
+    const deploymentUrl = await this.getDeploymentUrl(abortSignal);
+
+    if (abortSignal?.aborted) {
+      throw new Error("Coder workspace creation aborted");
+    }
 
     // 2. Get active template version ID
-    const versionId = await this.getActiveTemplateVersionId(template, org);
+    const versionId = await this.getActiveTemplateVersionId(template, org, abortSignal);
+
+    if (abortSignal?.aborted) {
+      throw new Error("Coder workspace creation aborted");
+    }
 
     // 3. Get parameter names covered by preset (if any)
     const coveredByPreset = preset
-      ? await this.getPresetParamNames(template, preset, org)
+      ? await this.getPresetParamNames(template, preset, org, abortSignal)
       : new Set<string>();
 
+    if (abortSignal?.aborted) {
+      throw new Error("Coder workspace creation aborted");
+    }
+
     // 4. Fetch all template parameters from API
-    const allParams = await this.getTemplateRichParameters(deploymentUrl, versionId, name, session);
+    const allParams = await this.getTemplateRichParameters(
+      deploymentUrl,
+      versionId,
+      name,
+      session,
+      abortSignal
+    );
 
     // 5. Validate required params have values
     this.validateRequiredParams(allParams, coveredByPreset);

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -80,7 +80,7 @@ import type { DevcontainerRuntime } from "@/node/runtime/DevcontainerRuntime";
 import { WorktreeRuntime } from "@/node/runtime/WorktreeRuntime";
 import {
   getDevcontainerContainerName,
-  probeDevcontainerStatus,
+  probeDevcontainerStatuses,
   stopDevcontainer,
 } from "@/node/runtime/devcontainerCli";
 import { isWorktreeRuntime } from "@/node/runtime/worktreeLifecycleHooks";
@@ -4831,47 +4831,45 @@ export class WorkspaceService extends EventEmitter {
     }
 
     const metadataById = new Map(allMetadata.map((metadata) => [metadata.id, metadata]));
-    const probes = workspaceIds.map(async (workspaceId) => {
+    const devcontainerWorkspaces: Array<{ workspaceId: string; hostWorkspacePath: string }> = [];
+
+    for (const workspaceId of workspaceIds) {
       const metadata = metadataById.get(workspaceId);
       if (!metadata) {
-        return { workspaceId, status: "unknown" as const };
-      }
-
-      if (metadata.runtimeConfig.type !== "devcontainer") {
-        return { workspaceId, status: "unsupported" as const };
-      }
-
-      // Passive status probes must not call ensureReady(); Docker labels are enough to tell
-      // whether the devcontainer is already running.
-      const probeResult = await probeDevcontainerStatus(
-        await this.getDevcontainerHostWorkspacePath(workspaceId)
-      );
-      // A clean miss means the container is stopped; probe failures should surface as unknown.
-      const status =
-        probeResult.kind === "found"
-          ? ("running" as const)
-          : probeResult.kind === "absent"
-            ? ("stopped" as const)
-            : ("unknown" as const);
-      return {
-        workspaceId,
-        status,
-      };
-    });
-
-    const probeResults = await Promise.allSettled(probes);
-    for (let i = 0; i < probeResults.length; i++) {
-      const probeResult = probeResults[i];
-      const workspaceId = workspaceIds[i];
-      if (probeResult.status === "fulfilled") {
-        statuses[probeResult.value.workspaceId] = probeResult.value.status;
         continue;
       }
 
-      log.debug("Failed to determine workspace runtime status", {
-        workspaceId,
-        error: getErrorMessage(probeResult.reason),
-      });
+      if (metadata.runtimeConfig.type !== "devcontainer") {
+        statuses[workspaceId] = "unsupported";
+        continue;
+      }
+
+      try {
+        devcontainerWorkspaces.push({
+          workspaceId,
+          hostWorkspacePath: await this.getDevcontainerHostWorkspacePath(workspaceId),
+        });
+      } catch (error) {
+        log.debug("Failed to resolve devcontainer workspace path for runtime status", {
+          workspaceId,
+          error: getErrorMessage(error),
+        });
+      }
+    }
+
+    // Passive status probes must not call ensureReady(); Docker labels are enough to tell
+    // whether devcontainers are already running. Probe all requested paths with one docker ps.
+    const probeResults = await probeDevcontainerStatuses(
+      devcontainerWorkspaces.map((workspace) => workspace.hostWorkspacePath)
+    );
+    for (const workspace of devcontainerWorkspaces) {
+      const probeResult = probeResults[workspace.hostWorkspacePath] ?? { kind: "absent" as const };
+      statuses[workspace.workspaceId] =
+        probeResult.kind === "found"
+          ? "running"
+          : probeResult.kind === "absent"
+            ? "stopped"
+            : "unknown";
     }
 
     return statuses;

--- a/src/node/utils/disposableExec.test.ts
+++ b/src/node/utils/disposableExec.test.ts
@@ -5,8 +5,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 
 import type { ChildProcess } from "child_process";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
 import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
-import { execAsync } from "./disposableExec";
+import { execAsync, execFileAsync } from "./disposableExec";
 
 /**
  * Tests for DisposableExec - verifies no process leaks under any scenario
@@ -32,6 +35,19 @@ describe("disposableExec", () => {
       }
     }
     activeProcesses.clear();
+  });
+
+  test("pre-aborted execFileAsync rejects without starting the command", async () => {
+    const markerPath = path.join(os.tmpdir(), `mux-execfile-abort-${Date.now()}`);
+    const abortController = new AbortController();
+    abortController.abort();
+
+    using proc = execFileAsync("bash", ["-c", `touch ${JSON.stringify(markerPath)}`], {
+      signal: abortController.signal,
+    });
+
+    await expect(proc.result).rejects.toThrow("Command aborted before execution");
+    await expect(fs.access(markerPath)).rejects.toThrow();
   });
 
   test("successful command completes and cleans up automatically", async () => {

--- a/src/node/utils/disposableExec.ts
+++ b/src/node/utils/disposableExec.ts
@@ -162,10 +162,14 @@ export class DisposableProcess implements Disposable {
 class DisposableExec implements Disposable {
   constructor(
     private readonly promise: Promise<{ stdout: string; stderr: string }>,
-    private readonly child: ChildProcess
+    private readonly child?: ChildProcess
   ) {}
 
   [Symbol.dispose](): void {
+    if (!this.child) {
+      return;
+    }
+
     // Only kill if process hasn't exited naturally
     // Check the child's actual exit state, not promise state (avoids async timing issues)
     const hasExited = this.child.exitCode !== null || this.child.signalCode !== null;
@@ -261,6 +265,10 @@ export interface ExecFileAsyncOptions {
   env?: Record<string, string | undefined>;
   /** Optional callback for each stderr data chunk from the process. */
   onStderrData?: (chunk: string) => void;
+  /** Optional timeout in milliseconds before the process is killed. */
+  timeoutMs?: number;
+  /** Optional signal used to cancel the process. */
+  signal?: AbortSignal;
 }
 
 /**
@@ -279,10 +287,45 @@ export function execFileAsync(
   args: string[],
   options?: ExecFileAsyncOptions
 ): DisposableExec {
+  if (options?.signal?.aborted) {
+    const error = new Error("Command aborted before execution") as Error & {
+      code: number | null;
+      signal: string | null;
+      stdout: string;
+      stderr: string;
+    };
+    error.code = null;
+    error.signal = null;
+    error.stdout = "";
+    error.stderr = "";
+    const result = Promise.reject(error);
+    void result.catch(() => undefined);
+    return new DisposableExec(result);
+  }
+
   const child = spawn(file, args, {
     stdio: ["ignore", "pipe", "pipe"],
     env: options?.env ? { ...process.env, ...options.env } : undefined,
   });
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const cleanup = () => {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+    options?.signal?.removeEventListener("abort", onAbort);
+  };
+  const killChild = () => {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill();
+    }
+  };
+  const onAbort = () => killChild();
+  if (options?.timeoutMs != null && options.timeoutMs > 0) {
+    timeoutHandle = setTimeout(killChild, options.timeoutMs);
+    timeoutHandle.unref?.();
+  }
+  options?.signal?.addEventListener("abort", onAbort, { once: true });
+  if (options?.signal?.aborted) {
+    onAbort();
+  }
   const promise = new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
     let stdout = "";
     let stderr = "";
@@ -304,6 +347,7 @@ export function execFileAsync(
     });
 
     child.on("close", () => {
+      cleanup();
       if (exitCode === 0 && exitSignal === null) {
         resolve({ stdout, stderr });
       } else {
@@ -326,7 +370,10 @@ export function execFileAsync(
       }
     });
 
-    child.on("error", reject);
+    child.on("error", (error) => {
+      cleanup();
+      reject(error);
+    });
   });
 
   return new DisposableExec(promise, child);

--- a/src/node/worktree/WorktreeManager.ts
+++ b/src/node/worktree/WorktreeManager.ts
@@ -19,7 +19,11 @@ import { GIT_NO_HOOKS_ENV } from "@/node/utils/gitNoHooksEnv";
 import { syncLocalGitSubmodules } from "@/node/runtime/submoduleSync";
 import { syncMuxignoreFiles } from "./muxignore";
 
-type GitExecOptions = { env: Record<string, string> } | undefined;
+type GitExecOptions = { env?: Record<string, string>; signal?: AbortSignal } | undefined;
+
+function isAbortError(_error: unknown, signal?: AbortSignal): boolean {
+  return signal?.aborted ?? false;
+}
 
 const PROTECTED_BRANCH_NAMES = ["main", "master", "trunk", "develop", "default"];
 const MISSING_WORKTREE_ERROR_PATTERNS = ["not a working tree", "does not exist", "no such file"];
@@ -37,8 +41,9 @@ export class WorktreeManager {
     return path.join(this.srcBaseDir, projectName, workspaceName);
   }
 
-  private getGitExecOptions(trusted?: boolean): GitExecOptions {
-    return trusted ? undefined : { env: GIT_NO_HOOKS_ENV };
+  private getGitExecOptions(trusted?: boolean, signal?: AbortSignal): GitExecOptions {
+    const env = trusted ? undefined : GIT_NO_HOOKS_ENV;
+    return env || signal ? { ...(env ? { env } : {}), ...(signal ? { signal } : {}) } : undefined;
   }
 
   private async pruneWorktreesBestEffort(
@@ -76,7 +81,7 @@ export class WorktreeManager {
   }): Promise<WorkspaceCreationResult> {
     const { projectPath, branchName, trunkBranch, initLogger } = params;
     // Disable git hooks for untrusted projects (prevents post-checkout execution)
-    const noHooksEnv = this.getGitExecOptions(params.trusted);
+    const noHooksEnv = this.getGitExecOptions(params.trusted, params.abortSignal);
     const workspaceName = params.directoryName ?? branchName;
     const workspacePath =
       params.workspacePathOverride ?? this.getWorkspacePath(projectPath, workspaceName);
@@ -127,7 +132,12 @@ export class WorktreeManager {
       const shouldUseOrigin =
         !skipRemoteSync &&
         fetchedOrigin &&
-        (await this.canFastForwardToOrigin(projectPath, trunkBranch, initLogger));
+        (await this.canFastForwardToOrigin(
+          projectPath,
+          trunkBranch,
+          initLogger,
+          params.abortSignal
+        ));
 
       // Create worktree (git worktree is typically fast)
       if (branchExists) {
@@ -257,7 +267,7 @@ export class WorktreeManager {
     projectPath: string,
     trunkBranch: string,
     initLogger: InitLogger,
-    noHooksEnv?: { env: Record<string, string> }
+    noHooksEnv: GitExecOptions
   ): Promise<boolean> {
     try {
       initLogger.logStep(`Fetching latest from origin/${trunkBranch}...`);
@@ -272,6 +282,9 @@ export class WorktreeManager {
       initLogger.logStep("Fetched latest from origin");
       return true;
     } catch (error) {
+      if (isAbortError(error, noHooksEnv?.signal)) {
+        throw error;
+      }
       const errorMsg = getErrorMessage(error);
       // Branch doesn't exist on origin (common for subagent local-only branches)
       if (errorMsg.includes("couldn't find remote ref")) {
@@ -293,22 +306,23 @@ export class WorktreeManager {
   private async canFastForwardToOrigin(
     projectPath: string,
     trunkBranch: string,
-    initLogger: InitLogger
+    initLogger: InitLogger,
+    abortSignal?: AbortSignal
   ): Promise<boolean> {
     try {
       // Check if local trunk is an ancestor of origin/trunk
       // Exit code 0 = local is ancestor (can fast-forward), non-zero = cannot
-      using proc = execFileAsync("git", [
-        "-C",
-        projectPath,
-        "merge-base",
-        "--is-ancestor",
-        trunkBranch,
-        `origin/${trunkBranch}`,
-      ]);
+      using proc = execFileAsync(
+        "git",
+        ["-C", projectPath, "merge-base", "--is-ancestor", trunkBranch, `origin/${trunkBranch}`],
+        abortSignal ? { signal: abortSignal } : undefined
+      );
       await proc.result;
       return true; // Local is behind or equal to origin
-    } catch {
+    } catch (error) {
+      if (isAbortError(error, abortSignal)) {
+        throw error;
+      }
       // Local is ahead or diverged - preserve local state
       initLogger.logStderr(
         `Note: Local ${trunkBranch} is ahead of or diverged from origin, using local state`
@@ -325,7 +339,7 @@ export class WorktreeManager {
     workspacePath: string,
     trunkBranch: string,
     initLogger: InitLogger,
-    noHooksEnv?: { env: Record<string, string> }
+    noHooksEnv: GitExecOptions
   ): Promise<void> {
     try {
       initLogger.logStep("Fast-forward merging...");
@@ -338,6 +352,9 @@ export class WorktreeManager {
       await mergeProc.result;
       initLogger.logStep("Fast-forwarded to latest origin successfully");
     } catch (mergeError) {
+      if (isAbortError(mergeError, noHooksEnv?.signal)) {
+        throw mergeError;
+      }
       // Fast-forward not possible (diverged branches) - just warn
       const errorMsg = getErrorMessage(mergeError);
       initLogger.logStderr(`Note: Fast-forward failed (${errorMsg}), using local branch state`);
@@ -876,7 +893,11 @@ export class WorktreeManager {
 
     // Get current branch from source workspace
     try {
-      using proc = execFileAsync("git", ["-C", sourceWorkspacePath, "branch", "--show-current"]);
+      using proc = execFileAsync(
+        "git",
+        ["-C", sourceWorkspacePath, "branch", "--show-current"],
+        params.abortSignal ? { signal: params.abortSignal } : undefined
+      );
       const { stdout } = await proc.result;
       const sourceBranch = stdout.trim();
 


### PR DESCRIPTION
Summary

Refactors the runtime layer to reduce duplicated policy, tighten cancellation behavior, and make shell/process boundaries easier to maintain across local, SSH, Docker, devcontainer, Coder, and worktree flows.

Background

This cleanup was driven by repeated read-only runtime audits that identified practical maintainability issues: duplicated SSH backoff/options, inconsistent abort propagation, unsafe or duplicated shell/process helpers, O(n) devcontainer status probes, and lifecycle/session edge cases in Coder and Docker paths.

Implementation

- Centralized shared SSH backoff/acquire option policy and transport acquire option types.
- Threaded abort signals through runtime stat/ensureDir/write/exec paths, SSH pools/transports, devcontainer setup, Docker fork, Coder lifecycle, CoderService preflight/fetch, WorktreeManager git calls, and execFileAsync.
- Added shell env validation and safer shell quoting for runtime command construction and init hooks.
- Consolidated Docker command execution helpers and container user/directory setup logic.
- Added a bulk devcontainer status probe to avoid one Docker subprocess per workspace status check.
- Singleflighted Coder provisioning sessions and hardened Coder command streaming against close-event races.

Validation

- `bun test src/node/services/coderService.test.ts src/node/runtime/devcontainerCli.test.ts src/node/runtime/RemoteRuntime.test.ts src/node/runtime/LocalRuntime.test.ts src/node/runtime/shellEnv.test.ts src/node/runtime/DevcontainerRuntime.test.ts src/node/runtime/transports/SSH2Transport.test.ts src/node/runtime/DockerRuntime.test.ts src/node/runtime/CoderSSHRuntime.test.ts src/node/runtime/sshConnectionPool.test.ts`
- `make typecheck`
- `make static-check`
- Final sub-agent audit found no clear remaining practical runtime maintainability issues in scope.

Risks

Medium regression risk because this touches runtime process lifecycle and cancellation across several providers. The implementation is intentionally incremental and covered by targeted tests for the newly tightened behavior.

Pains

The cleanup required multiple audit/fix/validation rounds because cancellation and process ownership semantics are spread across runtime implementations, shared services, and test helpers.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$129.00`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=129.00 -->
