### PR TITLE
🤖 fix: keep concurrent warning out of transcript tail

### DIFF
--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -59,7 +59,7 @@ import { QueuedMessage } from "@/browser/features/Messages/QueuedMessage";
 import { CompactionWarning } from "../CompactionWarning/CompactionWarning";
 import { ContextSwitchWarning as ContextSwitchWarningBanner } from "../ContextSwitchWarning/ContextSwitchWarning";
 import {
-  ConcurrentLocalWarningView,
+  ConcurrentLocalWarningDecoration,
   useConcurrentLocalStreamingWorkspaceName,
 } from "../ConcurrentLocalWarning/ConcurrentLocalWarning";
 import { BackgroundProcessesBanner } from "../BackgroundProcessesBanner/BackgroundProcessesBanner";
@@ -949,17 +949,6 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
       ),
     });
   }
-  if (concurrentLocalStreamingWorkspaceName) {
-    transcriptTailItems.push({
-      key: "concurrent-local-warning",
-      node: (
-        <ConcurrentLocalWarningView
-          streamingWorkspaceName={concurrentLocalStreamingWorkspaceName}
-        />
-      ),
-    });
-  }
-
   const handleLoadOlderHistory = useCallback(() => {
     if (!shouldRenderLoadOlderMessagesButton || loadingOlderHistory) {
       return;
@@ -1243,6 +1232,7 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
             isCompacting={isCompacting}
             shouldShowPinnedTodoList={shouldShowPinnedTodoList}
             shouldShowReviewsBanner={shouldShowReviewsBanner}
+            concurrentLocalStreamingWorkspaceName={concurrentLocalStreamingWorkspaceName}
             canInterrupt={canInterrupt}
             autoCompactionResult={autoCompactionResult}
             shouldShowCompactionWarning={shouldShowCompactionWarning}
@@ -1295,6 +1285,7 @@ interface ChatInputPaneProps {
   isHydratingTranscript: boolean;
   shouldShowPinnedTodoList: boolean;
   shouldShowReviewsBanner: boolean;
+  concurrentLocalStreamingWorkspaceName: string | null;
   canInterrupt: boolean;
   autoCompactionResult: ReturnType<typeof checkAutoCompaction>;
   shouldShowCompactionWarning: boolean;
@@ -1348,6 +1339,21 @@ const ChatInputPane: React.FC<ChatInputPaneProps> = (props) => {
       ),
     });
   }
+  // User rationale: keeping this warning inside the transcript tail made every appended
+  // message insert above a live tail row, so bottom-lock had to correct after layout and
+  // visibly flashed while another local agent was active. Pin it with composer decorations
+  // instead; new transcript rows no longer move the warning.
+  if (props.concurrentLocalStreamingWorkspaceName) {
+    decorationEntries.push({
+      key: "concurrent-local-warning",
+      node: (
+        <ConcurrentLocalWarningDecoration
+          streamingWorkspaceName={props.concurrentLocalStreamingWorkspaceName}
+        />
+      ),
+    });
+  }
+
   if (props.shouldShowPinnedTodoList) {
     decorationEntries.push({
       key: "pinned-todo-list",

--- a/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.stories.tsx
+++ b/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { lightweightMeta } from "@/browser/stories/meta.js";
+import { ConcurrentLocalWarningDecoration } from "./ConcurrentLocalWarning.js";
+
+const meta = {
+  ...lightweightMeta,
+  title: "App/Chat/Components/ConcurrentLocalWarning",
+  component: ConcurrentLocalWarningDecoration,
+} satisfies Meta<typeof ConcurrentLocalWarningDecoration>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const ComposerDecoration: Story = {
+  args: {
+    streamingWorkspaceName: "refactor-db",
+  },
+  render: (args) => (
+    <div className="bg-surface-primary text-light flex h-[360px] flex-col">
+      <div className="min-h-0 flex-1 overflow-hidden p-4">
+        <div className="mx-auto max-w-4xl space-y-4 text-sm">
+          <div className="ml-auto max-w-[70%] rounded-lg border border-[var(--color-user-border)] bg-[var(--color-user-surface)] px-3 py-2">
+            Can you keep working while I ask another agent to inspect the same checkout?
+          </div>
+          <div className="border-border bg-background-secondary text-muted rounded-lg border px-3 py-2">
+            I&apos;ll continue here, but there is another local workspace actively running in this
+            project directory.
+          </div>
+        </div>
+      </div>
+      {/* Keep the warning in the composer decoration lane so appended transcript rows do not
+          insert above it and trigger bottom-lock correction flashes. */}
+      <ConcurrentLocalWarningDecoration {...args} />
+      <div className="border-border bg-surface-primary border-t px-4 py-3">
+        <div className="border-border bg-background-secondary text-muted mx-auto max-w-4xl rounded-lg border px-3 py-2 text-sm">
+          Ask Mux anything...
+        </div>
+      </div>
+    </div>
+  ),
+  tags: ["concurrent-local-warning"],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Shows the concurrent local-agent warning pinned in the composer decoration lane, above the input and outside the transcript scroll flow.",
+      },
+    },
+  },
+};

--- a/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.tsx
+++ b/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useSyncExternalStore } from "react";
 import { AlertTriangle } from "lucide-react";
 import { useWorkspaceContext } from "@/browser/contexts/WorkspaceContext";
 import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
+import { cn } from "@/common/lib/utils";
 import { isLocalProjectRuntime } from "@/common/types/runtime";
 import type { RuntimeConfig } from "@/common/types/runtime";
 
@@ -66,12 +67,30 @@ export function useConcurrentLocalStreamingWorkspaceName(
   );
 }
 
-export const ConcurrentLocalWarningView: React.FC<{ streamingWorkspaceName: string }> = (props) => {
+interface ConcurrentLocalWarningViewProps {
+  streamingWorkspaceName: string;
+  className?: string;
+}
+
+export const ConcurrentLocalWarningView: React.FC<ConcurrentLocalWarningViewProps> = (props) => {
   return (
-    <div className="text-center text-xs text-yellow-600/80">
+    <div className={cn("text-center text-xs text-yellow-600/80", props.className)}>
       <AlertTriangle aria-hidden="true" className="mr-1 inline-block h-3 w-3 align-[-2px]" />
       <span className="text-yellow-500">{props.streamingWorkspaceName}</span> is also running in
       this project directory — agents may interfere
+    </div>
+  );
+};
+
+export const ConcurrentLocalWarningDecoration: React.FC<ConcurrentLocalWarningViewProps> = (
+  props
+) => {
+  return (
+    <div className="border-border bg-surface-primary border-t px-4 py-1.5">
+      <ConcurrentLocalWarningView
+        streamingWorkspaceName={props.streamingWorkspaceName}
+        className={cn("mx-auto max-w-4xl", props.className)}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Moves the concurrent local-agent warning out of the transcript tail stack and into the composer decoration lane. This keeps the warning pinned above the input while new transcript messages append, preventing the bottom-lock correction flash that happened when the warning was a live tail row. Adds Storybook coverage for the new composer-lane placement.

## Background

These flashes keep happening because the chat view has two competing jobs: preserve the user-visible scroll position, and continuously insert/mutate layout-affecting UI during streaming. When non-message chrome lives inside the transcript scroll area—especially at the tail—new messages insert above it. That changes `scrollHeight`, lets browser scroll anchoring pick its own anchor, and then our ResizeObserver/rAF bottom-lock corrects the scroll position. If the browser paints between those steps, users see a one-frame jump/flash.

Categorically, we should prevent this by making transcript layout ownership explicit: message rows belong in the transcript; persistent warnings, queues, todos, background process banners, and other composer-adjacent state belong in stable decoration lanes outside the transcript; overlays should not affect scroll height; and transient tail barriers should reserve/measure height before they appear during hydration/stream-start. New layout-affecting chat chrome should pick one of those lanes up front instead of ad hoc mounting inside the scrollport.

## Implementation

- Added `ConcurrentLocalWarningDecoration`, which wraps the existing warning copy with the same composer-decoration gutter and border treatment used by the input-adjacent stack.
- Passed the detected concurrent local streaming workspace name into `ChatInputPane`.
- Removed the concurrent warning from `transcriptTailItems`, so appended messages no longer insert above it while streaming.
- Added a Storybook story showing the warning pinned above the composer and outside the transcript flow.
- Left an inline rationale comment near the decoration placement to document the flash mechanism.

## Validation

- `make fmt`
- `bun test src/browser/components/ChatPane/LayoutStackLane.test.tsx`
- `make typecheck`
- `git diff --check`
- `env STORYBOOK_PORT=6017 make storybook-run CMD='bun x test-storybook --url http://127.0.0.1:6017 --testTimeout 30000 --includeTags concurrent-local-warning --no-cache'`
- `make static-check`

## Risks

Low. This changes placement of one warning from the transcript tail to the composer decoration stack. The warning condition and copy are unchanged; the main user-visible difference is that it is pinned above the composer instead of scrolling with the transcript tail.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$9.46`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=9.46 -->
