### PR TITLE
🤖 fix: cap immersive review file context

### DIFF
--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.stories.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.stories.tsx
@@ -436,17 +436,18 @@ export const ImmersiveNotesSidebarActionFooter: Story = {
     await waitFor(
       () => {
         canvas.getByTestId("immersive-review-view");
-        canvas.getByText(/Keep the formatter instance shared/i);
       },
       { timeout: 10_000 }
     );
 
-    const noteCard = canvasElement.querySelector<HTMLElement>('[data-note-index="0"]');
+    const noteCard = Array.from(
+      canvasElement.querySelectorAll<HTMLElement>("[data-note-index]")
+    ).find((card) => card.textContent?.includes("Keep the formatter instance shared"));
     if (!noteCard) {
-      throw new Error("Expected the first immersive review note card to render.");
+      throw new Error("Expected an immersive review note card with the formatter note to render.");
     }
 
-    // Focus the first card so Storybook captures the reserved footer state that prevents
+    // Focus the matching card so Storybook captures the reserved footer state that prevents
     // the note preview layout from shifting when review actions appear. Focus is more
     // deterministic than hover in the CI interaction runner while exercising the same UI.
     noteCard.focus();

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.stories.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.stories.tsx
@@ -436,18 +436,19 @@ export const ImmersiveNotesSidebarActionFooter: Story = {
     await waitFor(
       () => {
         canvas.getByTestId("immersive-review-view");
+        if (canvas.queryAllByText(/Keep the formatter instance shared/i).length === 0) {
+          throw new Error("Expected the immersive review formatter note to render.");
+        }
       },
       { timeout: 10_000 }
     );
 
-    const noteCard = Array.from(
-      canvasElement.querySelectorAll<HTMLElement>("[data-note-index]")
-    ).find((card) => card.textContent?.includes("Keep the formatter instance shared"));
+    const noteCard = canvasElement.querySelector<HTMLElement>('[data-note-index="0"]');
     if (!noteCard) {
-      throw new Error("Expected an immersive review note card with the formatter note to render.");
+      throw new Error("Expected the first immersive review note card to render.");
     }
 
-    // Focus the matching card so Storybook captures the reserved footer state that prevents
+    // Focus the first card so Storybook captures the reserved footer state that prevents
     // the note preview layout from shifting when review actions appear. Focus is more
     // deterministic than hover in the CI interaction runner while exercising the same UI.
     noteCard.focus();

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { GlobalWindow } from "happy-dom";
 import { useEffect, useState, type ComponentProps } from "react";
 
@@ -161,6 +161,52 @@ describe("ImmersiveReviewView", () => {
     globalThis.navigator = originalNavigator;
     globalThis.requestAnimationFrame = originalRequestAnimationFrame;
     globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+  });
+
+  test("renders the hunk overlay while full-file context is still pending", async () => {
+    type ExecuteBashValue = Awaited<ReturnType<MockApiClient["workspace"]["executeBash"]>>;
+    let resolveRead: ((value: ExecuteBashValue) => void) | undefined;
+    const pendingRead = new Promise<ExecuteBashValue>((resolve) => {
+      resolveRead = resolve;
+    });
+    mockApi.workspace.executeBash = mock(() => pendingRead);
+
+    const view = renderImmersiveReview();
+
+    expect(view.container.textContent ?? "").toContain("new line");
+    await waitFor(() => expect(mockApi.workspace.executeBash).toHaveBeenCalledTimes(1));
+
+    if (!resolveRead) {
+      throw new Error("Read promise resolver was not captured");
+    }
+    resolveRead({
+      success: true,
+      data: {
+        success: true,
+        output: "0",
+        exitCode: 0,
+      },
+    });
+  });
+
+  test("skips full-file reads when the selected hunk starts beyond the render budget", () => {
+    const farHunk = createHunk({
+      id: "hunk-far",
+      oldStart: 5000,
+      newStart: 5000,
+      header: "@@ -5000 +5000 @@",
+      content: "-old far line\n+new far line",
+    });
+
+    const view = renderImmersiveReview({
+      fileTree: createFileTree(farHunk.filePath),
+      hunks: [farHunk],
+      allHunks: [farHunk],
+      selectedHunkId: farHunk.id,
+    });
+
+    expect(view.container.textContent ?? "").toContain("new far line");
+    expect(mockApi.workspace.executeBash).not.toHaveBeenCalled();
   });
 
   test("weights completion by changed lines instead of hunk count", () => {

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
@@ -264,6 +264,53 @@ describe("ImmersiveReviewView", () => {
     );
   });
 
+  test("retries full-file context after a transient read failure", async () => {
+    const firstHunk = createHunk({ id: "hunk-first", filePath: "src/first.ts" });
+    const secondHunk = createHunk({ id: "hunk-second", filePath: "src/second.ts" });
+    const allHunks = [firstHunk, secondHunk];
+    const fileTree = createFileTreeForPaths(allHunks.map((hunk) => hunk.filePath));
+    const onSelectHunk = mock((_hunkId: string | null) => undefined);
+    mockApi.workspace.executeBash = mock(() =>
+      Promise.resolve({
+        success: true as const,
+        data: {
+          success: false,
+          output: "",
+          exitCode: 1,
+        },
+      })
+    );
+
+    const renderView = (selectedHunkId: string) => (
+      <ThemeProvider forcedTheme="dark">
+        <ImmersiveReviewView
+          workspaceId="workspace-1"
+          fileTree={fileTree}
+          hunks={allHunks}
+          allHunks={allHunks}
+          isRead={() => false}
+          onToggleRead={mock(() => undefined)}
+          onMarkFileAsRead={mock(() => undefined)}
+          selectedHunkId={selectedHunkId}
+          onSelectHunk={onSelectHunk}
+          onExit={mock(() => undefined)}
+          isTouchImmersive={true}
+          reviewsByFilePath={new Map()}
+          firstSeenMap={{}}
+        />
+      </ThemeProvider>
+    );
+
+    const view = render(renderView(firstHunk.id));
+    await waitFor(() => expect(mockApi.workspace.executeBash).toHaveBeenCalledTimes(1));
+
+    view.rerender(renderView(secondHunk.id));
+    await waitFor(() => expect(mockApi.workspace.executeBash).toHaveBeenCalledTimes(2));
+
+    view.rerender(renderView(firstHunk.id));
+    await waitFor(() => expect(mockApi.workspace.executeBash).toHaveBeenCalledTimes(3));
+  });
+
   test("weights completion by changed lines instead of hunk count", () => {
     const smallHunk = createHunk({
       id: "hunk-small",

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
@@ -83,6 +83,10 @@ function createFileTreeForPaths(filePaths: string[]): FileTreeNode {
   return root;
 }
 
+function encodeFileReadOutput(content: string): string {
+  return `${Buffer.byteLength(content, "utf8")}\n${Buffer.from(content, "utf8").toString("base64")}`;
+}
+
 function renderImmersiveReview(
   overrides: Partial<ComponentProps<typeof ImmersiveReviewView>> = {}
 ) {
@@ -207,6 +211,57 @@ describe("ImmersiveReviewView", () => {
 
     expect(view.container.textContent ?? "").toContain("new far line");
     expect(mockApi.workspace.executeBash).not.toHaveBeenCalled();
+  });
+
+  test("loads full-file context for an in-budget selected hunk even when another hunk is far away", async () => {
+    const nearHunk = createHunk({
+      id: "hunk-near",
+      newStart: 40,
+      newLines: 1,
+      header: "@@ -40 +40 @@",
+      content: "-old near line\n+new near line",
+    });
+    const farHunk = createHunk({
+      id: "hunk-far",
+      newStart: 5000,
+      newLines: 1,
+      header: "@@ -5000 +5000 @@",
+      content: "-old far line\n+new far line",
+    });
+
+    renderImmersiveReview({
+      fileTree: createFileTree(nearHunk.filePath),
+      hunks: [nearHunk, farHunk],
+      allHunks: [nearHunk, farHunk],
+      selectedHunkId: nearHunk.id,
+    });
+
+    await waitFor(() => expect(mockApi.workspace.executeBash).toHaveBeenCalledTimes(1));
+  });
+
+  test("accepts full-file context at the line budget when the file ends with a newline", async () => {
+    const lineBudget = 1500;
+    const fileContent = `${[
+      "new line",
+      "context after selected hunk",
+      ...Array.from({ length: lineBudget - 2 }, (_, index) => `filler ${index}`),
+    ].join("\n")}\n`;
+    mockApi.workspace.executeBash = mock(() =>
+      Promise.resolve({
+        success: true as const,
+        data: {
+          success: true,
+          output: encodeFileReadOutput(fileContent),
+          exitCode: 0,
+        },
+      })
+    );
+
+    const view = renderImmersiveReview();
+
+    await waitFor(() =>
+      expect(view.container.textContent ?? "").toContain("context after selected hunk")
+    );
   });
 
   test("weights completion by changed lines instead of hunk count", () => {

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -42,7 +42,12 @@ import {
   matchesKeybind,
 } from "@/browser/utils/ui/keybinds";
 import { stopKeyboardPropagation } from "@/browser/utils/events";
-import { buildReadFileScript, processFileContents } from "@/browser/utils/fileRead";
+import {
+  buildReadFileScript,
+  EXIT_CODE_TOO_LARGE,
+  EXIT_CODE_TOO_MANY_LINES,
+  processFileContents,
+} from "@/browser/utils/fileRead";
 import { TooltipIfPresent } from "@/browser/components/Tooltip/Tooltip";
 import {
   parseReviewLineRange,
@@ -618,8 +623,10 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
       isSettled: false,
     });
 
-    const settleLoadedContent = (content: string | null) => {
-      fileContentCacheRef.current.set(cacheKey, content);
+    const settleLoadedContent = (content: string | null, shouldCache: boolean) => {
+      if (shouldCache) {
+        fileContentCacheRef.current.set(cacheKey, content);
+      }
       if (!cancelled) {
         setActiveFileContentState({
           filePath: resolvedFilePath,
@@ -645,14 +652,17 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
       }
 
       if (!fileResult.success) {
-        settleLoadedContent(null);
+        settleLoadedContent(null, false);
         return;
       }
 
       const bashResult = fileResult.data;
+      const isDeterministicBudgetMiss =
+        bashResult.exitCode === EXIT_CODE_TOO_LARGE ||
+        bashResult.exitCode === EXIT_CODE_TOO_MANY_LINES;
 
       if (!bashResult.success && !bashResult.output) {
-        settleLoadedContent(null);
+        settleLoadedContent(null, isDeterministicBudgetMiss);
         return;
       }
 
@@ -661,11 +671,11 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
         data.type === "text" && isWithinFullFileContextLineBudget(data.content)
           ? data.content
           : null;
-      settleLoadedContent(content);
+      settleLoadedContent(content, content != null || isDeterministicBudgetMiss);
     }
 
     loadActiveFileContent().catch(() => {
-      settleLoadedContent(null);
+      settleLoadedContent(null, false);
     });
 
     return () => {

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -200,31 +200,16 @@ function normalizeFileLines(content: string): string[] {
 }
 
 function isWithinFullFileContextLineBudget(content: string): boolean {
-  let lineCount = content.length > 0 ? 1 : 0;
-  for (let index = 0; index < content.length; index += 1) {
-    if (content.charCodeAt(index) === 10) {
-      lineCount += 1;
-      if (lineCount > MAX_FULL_FILE_CONTEXT_LINES) {
-        return false;
-      }
-    }
-  }
-  return true;
+  return normalizeFileLines(content).length <= MAX_FULL_FILE_CONTEXT_LINES;
 }
 
-function shouldAttemptFullFileContext(sortedHunks: readonly DiffHunk[]): boolean {
-  if (sortedHunks.length === 0) {
+function shouldAttemptFullFileContext(selectedHunk: DiffHunk | null): boolean {
+  if (!selectedHunk) {
     return false;
   }
 
-  for (const hunk of sortedHunks) {
-    const lastDisplayLine = hunk.newStart + Math.max(hunk.newLines, 1) - 1;
-    if (lastDisplayLine > MAX_FULL_FILE_CONTEXT_LINES) {
-      return false;
-    }
-  }
-
-  return true;
+  const lastDisplayLine = selectedHunk.newStart + Math.max(selectedHunk.newLines, 1) - 1;
+  return lastDisplayLine <= MAX_FULL_FILE_CONTEXT_LINES;
 }
 
 function buildFileContentCacheKey(
@@ -583,8 +568,8 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
   });
   const fileContentCacheRef = useRef<Map<string, string | null>>(new Map());
   const shouldLoadFullFileContext = useMemo(
-    () => shouldAttemptFullFileContext(currentFileHunks),
-    [currentFileHunks]
+    () => shouldAttemptFullFileContext(selectedHunk),
+    [selectedHunk]
   );
   const activeFileContentCacheKey = useMemo(
     () =>

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -128,6 +128,9 @@ interface ImmersiveOverlayData {
   hunkLineRanges: Map<string, HunkLineRange>;
 }
 
+const MAX_FULL_FILE_CONTEXT_LINES = 1500;
+const MAX_FULL_FILE_CONTEXT_BYTES = 256 * 1024;
+
 const LINE_JUMP_SIZE = 10;
 // Keep syntax highlighting on for larger review files now that per-line tooltip overhead is gone,
 // but still cap it to avoid pathological DOM costs on extremely large diffs.
@@ -194,6 +197,43 @@ function normalizeFileLines(content: string): string[] {
     .split(/\r?\n/)
     .map((line) => (line.endsWith("\r") ? line.slice(0, Math.max(0, line.length - 1)) : line));
   return lines.filter((line, idx) => idx < lines.length - 1 || line !== "");
+}
+
+function isWithinFullFileContextLineBudget(content: string): boolean {
+  let lineCount = content.length > 0 ? 1 : 0;
+  for (let index = 0; index < content.length; index += 1) {
+    if (content.charCodeAt(index) === 10) {
+      lineCount += 1;
+      if (lineCount > MAX_FULL_FILE_CONTEXT_LINES) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+function shouldAttemptFullFileContext(sortedHunks: readonly DiffHunk[]): boolean {
+  if (sortedHunks.length === 0) {
+    return false;
+  }
+
+  for (const hunk of sortedHunks) {
+    const lastDisplayLine = hunk.newStart + Math.max(hunk.newLines, 1) - 1;
+    if (lastDisplayLine > MAX_FULL_FILE_CONTEXT_LINES) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function buildFileContentCacheKey(
+  workspaceId: string,
+  filePath: string,
+  sortedHunks: readonly DiffHunk[]
+): string {
+  const hunkSignature = sortedHunks.map((hunk) => hunk.id).join("|");
+  return [workspaceId, filePath, hunkSignature].join("\u0000");
 }
 
 function buildOverlayFromFileContent(
@@ -541,93 +581,118 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     content: null,
     isSettled: true,
   });
+  const fileContentCacheRef = useRef<Map<string, string | null>>(new Map());
+  const shouldLoadFullFileContext = useMemo(
+    () => shouldAttemptFullFileContext(currentFileHunks),
+    [currentFileHunks]
+  );
+  const activeFileContentCacheKey = useMemo(
+    () =>
+      activeFilePath
+        ? buildFileContentCacheKey(props.workspaceId, activeFilePath, currentFileHunks)
+        : null,
+    [activeFilePath, currentFileHunks, props.workspaceId]
+  );
 
-  // Hold diff reveal during file switches until loading + initial scroll are complete.
+  // Hold diff reveal during file switches until the initial scroll is complete.
   const [pendingRevealFilePath, setPendingRevealFilePath] = useState<string | null>(null);
   const revealAnimationFrameRef = useRef<number | null>(null);
 
-  // Load full file content so immersive mode can render one coherent file with hunk overlays.
-  // Keep a per-file loading state so switches can show a splash until loading settles,
-  // which avoids a visible fallback-overlay -> full-content jump.
+  // Load full file context only when it is cheap. The hunk overlay remains visible
+  // while this request is pending so file switches do not block on bash/base64 I/O.
   useEffect(() => {
     const apiClient = api;
     const filePath = activeFilePath;
+    const cacheKey = activeFileContentCacheKey;
 
-    if (!filePath || !apiClient) {
+    const settleContent = (content: string | null) => {
       setActiveFileContentState({
         filePath: filePath ?? null,
-        content: null,
+        content,
         isSettled: true,
       });
+    };
+
+    if (!filePath || !apiClient || !shouldLoadFullFileContext || !cacheKey) {
+      settleContent(null);
+      return;
+    }
+
+    if (fileContentCacheRef.current.has(cacheKey)) {
+      settleContent(fileContentCacheRef.current.get(cacheKey) ?? null);
       return;
     }
 
     const resolvedApi: NonNullable<typeof api> = apiClient;
     const resolvedFilePath: string = filePath;
-
     let cancelled = false;
+
     setActiveFileContentState({
       filePath: resolvedFilePath,
       content: null,
       isSettled: false,
     });
 
-    async function loadActiveFileContent() {
-      try {
-        // Keep plain file reads on the shared container root so immersive review can open
-        // sibling-project files without forcing the primary repo checkout.
-        const fileResult = await resolvedApi.workspace.executeBash({
-          workspaceId: props.workspaceId,
-          script: buildReadFileScript(resolvedFilePath),
-        });
-
-        if (cancelled) {
-          return;
-        }
-
-        if (!fileResult.success) {
-          setActiveFileContentState({
-            filePath: resolvedFilePath,
-            content: null,
-            isSettled: true,
-          });
-          return;
-        }
-
-        const bashResult = fileResult.data;
-
-        if (!bashResult.success && !bashResult.output) {
-          setActiveFileContentState({
-            filePath: resolvedFilePath,
-            content: null,
-            isSettled: true,
-          });
-          return;
-        }
-
-        const data = processFileContents(bashResult.output ?? "", bashResult.exitCode);
+    const settleLoadedContent = (content: string | null) => {
+      fileContentCacheRef.current.set(cacheKey, content);
+      if (!cancelled) {
         setActiveFileContentState({
           filePath: resolvedFilePath,
-          content: data.type === "text" ? data.content : null,
+          content,
           isSettled: true,
         });
-      } catch {
-        if (!cancelled) {
-          setActiveFileContentState({
-            filePath: resolvedFilePath,
-            content: null,
-            isSettled: true,
-          });
-        }
       }
+    };
+
+    async function loadActiveFileContent() {
+      // Keep plain file reads on the shared container root so immersive review can open
+      // sibling-project files without forcing the primary repo checkout.
+      const fileResult = await resolvedApi.workspace.executeBash({
+        workspaceId: props.workspaceId,
+        script: buildReadFileScript(resolvedFilePath, {
+          maxSizeBytes: MAX_FULL_FILE_CONTEXT_BYTES,
+          maxLineCount: MAX_FULL_FILE_CONTEXT_LINES,
+        }),
+      });
+
+      if (cancelled) {
+        return;
+      }
+
+      if (!fileResult.success) {
+        settleLoadedContent(null);
+        return;
+      }
+
+      const bashResult = fileResult.data;
+
+      if (!bashResult.success && !bashResult.output) {
+        settleLoadedContent(null);
+        return;
+      }
+
+      const data = processFileContents(bashResult.output ?? "", bashResult.exitCode);
+      const content =
+        data.type === "text" && isWithinFullFileContextLineBudget(data.content)
+          ? data.content
+          : null;
+      settleLoadedContent(content);
     }
 
-    void loadActiveFileContent();
+    loadActiveFileContent().catch(() => {
+      settleLoadedContent(null);
+    });
 
     return () => {
       cancelled = true;
     };
-  }, [api, props.workspaceId, activeFilePath]);
+  }, [
+    activeFileContentCacheKey,
+    activeFilePath,
+    api,
+    props.workspaceId,
+    shouldLoadFullFileContext,
+  ]);
 
   const isActiveFileContentSettled =
     !activeFilePath ||
@@ -636,10 +701,6 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
   const resolvedActiveFileContent = isActiveFileContentSettled
     ? activeFileContentState.content
     : null;
-
-  const isActiveFileContentLoading = Boolean(
-    activeFilePath && currentFileHunks.length > 0 && !isActiveFileContentSettled
-  );
 
   const overlayData = useMemo<ImmersiveOverlayData>(() => {
     if (currentFileHunks.length === 0) {
@@ -782,7 +843,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     selectedHunkId !== null && currentFileHunks.some((hunk) => hunk.id === selectedHunkId);
 
   useEffect(() => {
-    if (!isActiveFileRevealPending || !isActiveFileContentSettled) {
+    if (!isActiveFileRevealPending) {
       return;
     }
 
@@ -805,7 +866,6 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     currentFileHunks.length,
     hasResolvedSelectedHunkForReveal,
     isActiveFileRevealPending,
-    isActiveFileContentSettled,
     selectedHunkRevealTargetLineIndex,
   ]);
 
@@ -1579,10 +1639,6 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
       }
     }
 
-    if (isActiveFileRevealPending && !isActiveFileContentSettled) {
-      return;
-    }
-
     const lineIndexForScroll = isActiveFileRevealPending ? revealTargetLineIndex : activeLineIndex;
     if (lineIndexForScroll === null) {
       return;
@@ -1641,7 +1697,6 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
   }, [
     activeFilePath,
     activeLineIndex,
-    isActiveFileContentSettled,
     isActiveFileRevealPending,
     overlayData.content,
     revealTargetLineIndex,
@@ -1941,44 +1996,36 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
             </div>
           ) : (
             <div className="bg-dark relative overflow-hidden">
-              {isActiveFileContentLoading ? (
-                <div className="text-muted flex items-center justify-center py-12 text-sm">
+              {isActiveFileRevealPending && (
+                <div className="bg-dark/95 text-muted absolute inset-0 z-10 flex items-center justify-center text-sm">
                   <span className="animate-pulse">Loading file...</span>
                 </div>
-              ) : (
-                <>
-                  {isActiveFileRevealPending && (
-                    <div className="bg-dark/95 text-muted absolute inset-0 z-10 flex items-center justify-center text-sm">
-                      <span className="animate-pulse">Loading file...</span>
-                    </div>
-                  )}
-                  <div className={cn(isActiveFileRevealPending && "invisible")}>
-                    <SelectableDiffRenderer
-                      content={overlayData.content}
-                      filePath={activeFilePath ?? currentFileHunks[0].filePath}
-                      inlineReviews={activeFileReviews}
-                      oldStart={1}
-                      newStart={1}
-                      fontSize="11px"
-                      maxHeight="none"
-                      className="rounded-none border-0 [&>div]:overflow-x-visible"
-                      onReviewNote={handleReviewNoteSubmit}
-                      onComposerCancel={handleInlineComposerCancel}
-                      reviewActions={diffReviewActions}
-                      enableHighlighting={shouldEnableHighlighting}
-                      selectedLineRange={selectedLineRange}
-                      onLineIndexSelect={handleLineIndexSelect}
-                      externalSelectionRequest={externalComposerSelectionRequest}
-                      externalEditRequest={inlineReviewEditRequest}
-                    />
-                  </div>
-                </>
               )}
+              <div className={cn(isActiveFileRevealPending && "invisible")}>
+                <SelectableDiffRenderer
+                  content={overlayData.content}
+                  filePath={activeFilePath ?? currentFileHunks[0].filePath}
+                  inlineReviews={activeFileReviews}
+                  oldStart={1}
+                  newStart={1}
+                  fontSize="11px"
+                  maxHeight="none"
+                  className="rounded-none border-0 [&>div]:overflow-x-visible"
+                  onReviewNote={handleReviewNoteSubmit}
+                  onComposerCancel={handleInlineComposerCancel}
+                  reviewActions={diffReviewActions}
+                  enableHighlighting={shouldEnableHighlighting}
+                  selectedLineRange={selectedLineRange}
+                  onLineIndexSelect={handleLineIndexSelect}
+                  externalSelectionRequest={externalComposerSelectionRequest}
+                  externalEditRequest={inlineReviewEditRequest}
+                />
+              </div>
             </div>
           )}
         </div>
 
-        {!isReviewComplete && overlayData && !isTouchExperience && !isActiveFileContentLoading && (
+        {!isReviewComplete && !isTouchExperience && (
           <ImmersiveMinimap
             content={overlayData.content}
             scrollContainerRef={scrollContainerRef}

--- a/src/browser/features/Shared/DiffRenderer.tsx
+++ b/src/browser/features/Shared/DiffRenderer.tsx
@@ -717,28 +717,6 @@ const ReviewNoteInput: React.FC<ReviewNoteInputProps> = React.memo(
   }) => {
     const { showOld, showNew } = getLineNumberModeFlags(lineNumberMode);
     const textareaRef = React.useRef<HTMLTextAreaElement>(null);
-    const resizeFrameRef = React.useRef<number | null>(null);
-
-    const resizeTextarea = React.useCallback(() => {
-      const textarea = textareaRef.current;
-      if (!textarea) {
-        return;
-      }
-
-      textarea.style.height = "auto";
-      textarea.style.height = `${textarea.scrollHeight}px`;
-    }, []);
-
-    const scheduleTextareaResize = React.useCallback(() => {
-      if (resizeFrameRef.current !== null) {
-        cancelAnimationFrame(resizeFrameRef.current);
-      }
-
-      resizeFrameRef.current = window.requestAnimationFrame(() => {
-        resizeFrameRef.current = null;
-        resizeTextarea();
-      });
-    }, [resizeTextarea]);
 
     // Keep the composer uncontrolled so typing does not trigger per-key React re-renders
     // through immersive diff overlays. Parent-initiated prefill changes are synced here.
@@ -749,21 +727,11 @@ const ReviewNoteInput: React.FC<ReviewNoteInputProps> = React.memo(
       }
 
       textarea.value = initialNoteText ?? "";
-      scheduleTextareaResize();
-    }, [initialNoteText, scheduleTextareaResize]);
+    }, [initialNoteText]);
 
     // Auto-focus on mount.
     React.useEffect(() => {
       textareaRef.current?.focus();
-      scheduleTextareaResize();
-    }, [scheduleTextareaResize]);
-
-    React.useEffect(() => {
-      return () => {
-        if (resizeFrameRef.current !== null) {
-          cancelAnimationFrame(resizeFrameRef.current);
-        }
-      };
     }, []);
 
     const handleSubmit = () => {
@@ -881,15 +849,18 @@ const ReviewNoteInput: React.FC<ReviewNoteInputProps> = React.memo(
               className="w-[3px] shrink-0"
               style={{ background: "var(--color-review-accent)" }}
             />
+            {/* Avoid JS autosize here. Reading scrollHeight on every input forces layout across
+                large immersive diffs, which can make each typed character feel delayed. */}
             <textarea
               ref={textareaRef}
-              className="text-primary placeholder:text-muted/70 min-w-0 flex-1 resize-none overflow-y-hidden bg-transparent px-2 py-1.5 text-[12px] leading-[1.5] transition-colors focus:outline-none"
+              className="text-primary placeholder:text-muted/70 min-w-0 flex-1 resize-none overflow-y-auto bg-transparent px-2 py-1.5 text-[12px] leading-[1.5] transition-colors focus:outline-none"
               style={{
-                minHeight: "calc(12px * 1.5 * 2 + 12px)",
+                minHeight: "calc(12px * 1.5 * 3 + 12px)",
+                maxHeight: "12rem",
               }}
               placeholder="Add a review note… (Enter to submit, Shift+Enter for newline, Esc to cancel)"
               defaultValue={initialNoteText ?? ""}
-              onInput={scheduleTextareaResize}
+              rows={3}
               onClick={(e) => e.stopPropagation()}
               onKeyDown={(e) => {
                 stopKeyboardPropagation(e);

--- a/src/browser/features/Shared/SelectableDiffRenderer.dragSelect.test.tsx
+++ b/src/browser/features/Shared/SelectableDiffRenderer.dragSelect.test.tsx
@@ -135,6 +135,40 @@ describe("SelectableDiffRenderer drag selection", () => {
     });
   });
 
+  test("typing in the review composer does not schedule textarea layout work per key", async () => {
+    const content = Array.from({ length: 200 }, (_, index) => ` line ${index + 1}`).join("\n");
+
+    const { container, getByPlaceholderText } = render(
+      <ThemeProvider forcedTheme="dark">
+        <TooltipProvider>
+          <SelectableDiffRenderer
+            content={content}
+            filePath="src/test.ts"
+            onReviewNote={onReviewNote}
+            maxHeight="none"
+            enableHighlighting={false}
+          />
+        </TooltipProvider>
+      </ThemeProvider>
+    );
+
+    const commentButton = await waitFor(() =>
+      container.querySelector<HTMLButtonElement>('button[aria-label="Add review comment"]')
+    );
+    expect(commentButton).toBeTruthy();
+
+    fireEvent.click(commentButton!);
+    const textarea = (await waitFor(() =>
+      getByPlaceholderText(/Add a review note/i)
+    )) as HTMLTextAreaElement;
+
+    const animationFramesBeforeTyping = rafHandleCounter;
+    fireEvent.input(textarea, { target: { value: "a" } });
+    fireEvent.input(textarea, { target: { value: "ab" } });
+
+    expect(rafHandleCounter).toBe(animationFramesBeforeTyping);
+  });
+
   test("dragging on the indicator column selects a line range", async () => {
     const content = "+const a = 1;\n+const b = 2;\n+const c = 3;";
 

--- a/src/browser/utils/fileRead.test.ts
+++ b/src/browser/utils/fileRead.test.ts
@@ -1,3 +1,7 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import {
   buildReadFileScript,
@@ -27,7 +31,31 @@ describe("buildReadFileScript", () => {
     const script = buildReadFileScript("test.txt", { maxSizeBytes: 1234, maxLineCount: 99 });
 
     expect(script).toContain('[ "$size" -gt 1234 ] && exit 42');
-    expect(script).toContain("awk 'NR > 99 { exit 43 }' 'test.txt' || exit 43");
+    expect(script).toContain("awk 'NR > 99 { exit 43 }' 'test.txt'");
+    expect(script).toContain('exit "$awk_status"');
+  });
+
+  test("preserves non-budget awk failures while keeping line-budget exits", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "mux-file-read-"));
+
+    try {
+      const missingFileResult = spawnSync(
+        "bash",
+        ["-lc", buildReadFileScript("missing.txt", { maxLineCount: 1 })],
+        { cwd: tempDir }
+      );
+      expect(missingFileResult.status).not.toBe(EXIT_CODE_TOO_MANY_LINES);
+
+      writeFileSync(join(tempDir, "two-lines.txt"), "first\nsecond\n");
+      const tooManyLinesResult = spawnSync(
+        "bash",
+        ["-lc", buildReadFileScript("two-lines.txt", { maxLineCount: 1 })],
+        { cwd: tempDir }
+      );
+      expect(tooManyLinesResult.status).toBe(EXIT_CODE_TOO_MANY_LINES);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/browser/utils/fileRead.test.ts
+++ b/src/browser/utils/fileRead.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { buildReadFileScript, EXIT_CODE_TOO_LARGE, processFileContents } from "./fileRead";
+import {
+  buildReadFileScript,
+  EXIT_CODE_TOO_LARGE,
+  EXIT_CODE_TOO_MANY_LINES,
+  processFileContents,
+} from "./fileRead";
 
 describe("buildReadFileScript", () => {
   test("generates script with size check", () => {
@@ -17,6 +22,13 @@ describe("buildReadFileScript", () => {
     const script = buildReadFileScript("file'with'quotes.txt");
     expect(script).toContain("'file'\"'\"'with'\"'\"'quotes.txt'");
   });
+
+  test("supports smaller caller-specific size and line budgets", () => {
+    const script = buildReadFileScript("test.txt", { maxSizeBytes: 1234, maxLineCount: 99 });
+
+    expect(script).toContain('[ "$size" -gt 1234 ] && exit 42');
+    expect(script).toContain("awk 'NR > 99 { exit 43 }' 'test.txt' || exit 43");
+  });
 });
 
 describe("processFileContents", () => {
@@ -25,6 +37,14 @@ describe("processFileContents", () => {
     expect(result).toEqual({
       type: "error",
       message: "File is too large to display. Maximum: 10 MB.",
+    });
+  });
+
+  test("returns error for too many lines", () => {
+    const result = processFileContents("", EXIT_CODE_TOO_MANY_LINES);
+    expect(result).toEqual({
+      type: "error",
+      message: "File has too many lines to display.",
     });
   });
 

--- a/src/browser/utils/fileRead.ts
+++ b/src/browser/utils/fileRead.ts
@@ -8,6 +8,14 @@ const MAX_FILE_SIZE = 10 * 1024 * 1024;
 /** Exit code for "file too large". */
 export const EXIT_CODE_TOO_LARGE = 42;
 
+/** Exit code for "file has too many lines for the current UI budget". */
+export const EXIT_CODE_TOO_MANY_LINES = 43;
+
+interface ReadFileScriptOptions {
+  maxSizeBytes?: number;
+  maxLineCount?: number;
+}
+
 /** Magic bytes for image type detection. */
 const IMAGE_MAGIC_BYTES: Array<{ bytes: number[]; mime: string }> = [
   { bytes: [0x89, 0x50, 0x4e, 0x47], mime: "image/png" },
@@ -94,13 +102,25 @@ function detectBinary(buffer: Uint8Array): boolean {
 }
 
 /**
- * Generate bash script to read file contents with size check.
+ * Generate bash script to read file contents with size and optional line-count checks.
  * Uses base64 encoding for all files to handle binary safely.
  */
-export function buildReadFileScript(relativePath: string): string {
+export function buildReadFileScript(
+  relativePath: string,
+  options: ReadFileScriptOptions = {}
+): string {
   const file = shellEscape(relativePath);
+  const maxSizeBytes = Math.max(0, Math.trunc(options.maxSizeBytes ?? MAX_FILE_SIZE));
+  const maxLineCount =
+    options.maxLineCount == null ? null : Math.max(0, Math.trunc(options.maxLineCount));
+  const lineLimitScript =
+    maxLineCount == null
+      ? ""
+      : `
+awk 'NR > ${maxLineCount} { exit ${EXIT_CODE_TOO_MANY_LINES} }' ${file} || exit ${EXIT_CODE_TOO_MANY_LINES}`;
+
   return `size=$(stat -c %s ${file} 2>/dev/null || stat -f %z ${file})
-[ "$size" -gt ${MAX_FILE_SIZE} ] && exit ${EXIT_CODE_TOO_LARGE}
+[ "$size" -gt ${maxSizeBytes} ] && exit ${EXIT_CODE_TOO_LARGE}${lineLimitScript}
 echo "$size"
 base64 < ${file}`;
 }
@@ -135,6 +155,10 @@ export type FileContentsResult =
 export function processFileContents(output: string, exitCode: number): FileContentsResult {
   if (exitCode === EXIT_CODE_TOO_LARGE) {
     return { type: "error", message: "File is too large to display. Maximum: 10 MB." };
+  }
+
+  if (exitCode === EXIT_CODE_TOO_MANY_LINES) {
+    return { type: "error", message: "File has too many lines to display." };
   }
 
   const { size, base64 } = parseReadFileOutput(output);

--- a/src/browser/utils/fileRead.ts
+++ b/src/browser/utils/fileRead.ts
@@ -117,7 +117,9 @@ export function buildReadFileScript(
     maxLineCount == null
       ? ""
       : `
-awk 'NR > ${maxLineCount} { exit ${EXIT_CODE_TOO_MANY_LINES} }' ${file} || exit ${EXIT_CODE_TOO_MANY_LINES}`;
+awk 'NR > ${maxLineCount} { exit ${EXIT_CODE_TOO_MANY_LINES} }' ${file}
+awk_status=$?
+[ "$awk_status" -ne 0 ] && exit "$awk_status"`;
 
   return `size=$(stat -c %s ${file} 2>/dev/null || stat -f %z ${file})
 [ "$size" -gt ${maxSizeBytes} ] && exit ${EXIT_CODE_TOO_LARGE}${lineLimitScript}


### PR DESCRIPTION
> Mux working on behalf of Mike.

## Summary
Caps immersive review full-file context, renders hunk overlays immediately, and removes per-key layout work from the inline review composer so large files do not block file switching, composer opening, or typing.

## Implementation
- Loads full-file context in the background while showing hunk-only rendering first.
- Caps immersive full-file context at 1,500 lines and 256KB.
- Gates full-file reads by the selected hunk, so nearby hunks still get context even if a later hunk is far away.
- Counts trailing-newline files consistently with the shell-side line guard.
- Preserves non-budget file-read failures so transient read errors are retried instead of cached as line-budget misses.
- Caches loaded full-file context per workspace, file path, and hunk signature, while retrying transient read failures on later visits.
- Adds byte and line limits to file read script generation.
- Makes the inline review composer fixed-height and scrollable instead of reading `scrollHeight` on every input.
- Makes the immersive notes Storybook assertion tolerant of the same note rendering inline and in the sidebar without changing the focused visual state.

## Validation
- `bun test src/browser/features/Shared/SelectableDiffRenderer.dragSelect.test.tsx -t 'typing in the review composer'`
- `bun test src/browser/features/Shared/SelectableDiffRenderer.dragSelect.test.tsx`
- `bun test src/browser/utils/fileRead.test.ts src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx src/browser/features/Shared/SelectableDiffRenderer.dragSelect.test.tsx`
- `make storybook-run CMD='bun x test-storybook src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.stories.tsx --testTimeout 30000'`
- `make static-check`

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `4062530{MUX_COSTS_USD:-unknown}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=36.81 -->
