### PR TITLE
🤖 bench: fix Terminal-Bench result classification

### DIFF
--- a/.github/workflows/nightly-terminal-bench.yml
+++ b/.github/workflows/nightly-terminal-bench.yml
@@ -154,6 +154,7 @@ jobs:
       env: "daytona"
       experiments: ${{ inputs.experiments }}
       mux_run_as_goal: ${{ github.event_name == 'workflow_dispatch' && inputs.mux_run_as_goal || false }}
+      allow_transient_agent_errors: true
     secrets:
       TERMINAL_BENCH_ANTHROPIC_API_KEY: ${{ secrets.TERMINAL_BENCH_ANTHROPIC_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/terminal-bench.yml
+++ b/.github/workflows/terminal-bench.yml
@@ -59,6 +59,11 @@ on:
         required: false
         type: boolean
         default: false
+      allow_transient_agent_errors:
+        description: "Allow explicitly classified transient agent failures (full nightly only)"
+        required: false
+        type: boolean
+        default: false
     secrets:
       # Keep the runtime env name stable while routing benchmark spend to its own key.
       TERMINAL_BENCH_ANTHROPIC_API_KEY:
@@ -172,25 +177,7 @@ jobs:
             exit 0
           fi
           pip install --quiet daytona
-          python3 <<'PY' > /tmp/daytona-pre-existing.txt
-          from daytona import Daytona
-
-          def list_all_sandboxes(daytona):
-              # Daytona returns paginated results. Snapshot every page so cleanup
-              # can distinguish old sandboxes from ones this run created.
-              page = 1
-              while True:
-                  result = daytona.list(page=page)
-                  yield from result.items
-                  total_pages = result.total_pages or 1
-                  if page >= total_pages:
-                      break
-                  page += 1
-
-          d = Daytona()
-          ids = [sb.id for sb in list_all_sandboxes(d)]
-          print('\n'.join(ids))
-          PY
+          python3 scripts/daytona_sandbox_cleanup.py snapshot > /tmp/daytona-pre-existing.txt
           echo "Snapshot $(wc -l < /tmp/daytona-pre-existing.txt) pre-existing sandbox(es)"
 
       - name: Run Terminal-Bench
@@ -238,44 +225,7 @@ jobs:
             exit 0
           fi
           pip install --quiet daytona
-          python3 <<'PY'
-          from daytona import Daytona
-
-          def list_all_sandboxes(daytona):
-              # Daytona returns paginated results. Cleanup must inspect every
-              # page so stopped sandboxes from high-concurrency runs do not leak.
-              page = 1
-              while True:
-                  result = daytona.list(page=page)
-                  yield from result.items
-                  total_pages = result.total_pages or 1
-                  if page >= total_pages:
-                      break
-                  page += 1
-
-          with open('/tmp/daytona-pre-existing.txt') as f:
-              pre_existing = {line.strip() for line in f if line.strip()}
-          d = Daytona()
-          # Only consider sandboxes created after our snapshot (not pre-existing)
-          # and only delete ones that are no longer running (safe for parallel jobs).
-          ACTIVE_STATES = {'started', 'creating', 'starting'}
-          candidates = [sb for sb in list_all_sandboxes(d) if sb.id not in pre_existing]
-          to_delete = [sb for sb in candidates if str(sb.state).lower() not in ACTIVE_STATES]
-          skipped = len(candidates) - len(to_delete)
-          if skipped:
-              print(f'Skipping {skipped} still-active sandbox(es)')
-          if not to_delete:
-              print('No stopped sandboxes to clean up')
-          else:
-              print(f'Cleaning up {len(to_delete)} stopped sandbox(es) from this run...')
-              for sb in to_delete:
-                  try:
-                      print(f'  Deleting {sb.id} (state={sb.state})...')
-                      d.delete(sb)
-                      print(f'  Deleted {sb.id}')
-                  except Exception as e:
-                      print(f'  Failed to delete {sb.id}: {e}')
-          PY
+          python3 scripts/daytona_sandbox_cleanup.py cleanup --pre-existing-file /tmp/daytona-pre-existing.txt
 
       - name: Print results summary
         if: always()
@@ -291,46 +241,14 @@ jobs:
           fi
 
       - name: Verify agent ran successfully
+        env:
+          ALLOW_TRANSIENT_AGENT_ERRORS: ${{ inputs.allow_transient_agent_errors && '1' || '' }}
         run: |
-          # Harbor writes to jobs/<timestamp>/result.json
-          RESULTS_FILE=$(find jobs -maxdepth 2 -name 'result.json' 2>/dev/null | head -1)
-          if [ -z "$RESULTS_FILE" ]; then
-            echo "❌ No result.json found - benchmark failed to produce results"
-            exit 1
+          args=(--jobs-dir jobs)
+          if [ "$ALLOW_TRANSIENT_AGENT_ERRORS" = "1" ]; then
+            args+=(--allow-transient-agent-errors)
           fi
-          # Harbor has used both top-level stats.n_errors and stats.n_errored_trials;
-          # fall back to per-eval n_errors so schema drift cannot hide broken runs.
-          N_TRIALS=$(jq -r '.n_total_trials // .stats.n_trials // 0' "$RESULTS_FILE")
-          N_ERRORS=$(jq -r '.stats.n_errors // .stats.n_errored_trials // (reduce ((.stats.evals // {}) | to_entries[]) as $eval (0; . + ($eval.value.n_errors // 0)))' "$RESULTS_FILE")
-          # Get mean score from first eval entry (pass rate 0-1)
-          MEAN_SCORE=$(jq -r '[.stats.evals | to_entries[].value.metrics[0].mean] | add // 0' "$RESULTS_FILE")
-          echo "Trials: $N_TRIALS, Errors: $N_ERRORS, Mean score: $MEAN_SCORE"
-          if [ "$N_TRIALS" -eq 0 ]; then
-            echo "❌ No trials ran - benchmark configuration may be wrong"
-            exit 1
-          fi
-          # Count infrastructure/timeout errors separately from other errors
-          # These error types are expected and should not fail the workflow:
-          # - AgentTimeoutError: Agent exceeded task time limit (hard tasks)
-          # - VerifierTimeoutError: Verification timed out
-          # - AgentSetupTimeoutError: Agent install.sh timed out (slow network/packages)
-          # - EnvironmentStartTimeoutError: Daytona environment slow to start
-          # - DaytonaError: Daytona infrastructure issues (sandbox not started, no IP, etc.)
-          INFRA_PATTERN="(AgentTimeoutError|VerifierTimeoutError|AgentSetupTimeoutError|EnvironmentStartTimeoutError|DaytonaError)"
-          INFRA_ERRORS=$(find jobs -name 'exception.txt' -exec grep -lE "$INFRA_PATTERN" {} \; 2>/dev/null | wc -l | tr -d ' ')
-          OTHER_ERRORS=$((N_ERRORS - INFRA_ERRORS))
-          # Clamp to 0 in case exception.txt files exceed n_errors (defensive)
-          if [ "$OTHER_ERRORS" -lt 0 ]; then OTHER_ERRORS=0; fi
-          if [ "$OTHER_ERRORS" -gt 0 ]; then
-            echo "❌ $OTHER_ERRORS task(s) had non-infrastructure errors - agent execution failed"
-            echo "--- Exception details (excluding infra errors) ---"
-            find jobs -name 'exception.txt' -exec sh -c 'grep -qE "'"$INFRA_PATTERN"'" "$1" || { echo "=== $1 ===" && cat "$1"; }' _ {} \; 2>/dev/null || true
-            exit 1
-          fi
-          if [ "$INFRA_ERRORS" -gt 0 ]; then
-            echo "⏱️ $INFRA_ERRORS task(s) had infrastructure/timeout errors (expected for hard tasks or transient infra issues)"
-          fi
-          echo "✅ Agent ran $N_TRIALS trial(s) successfully (mean score: $MEAN_SCORE)"
+          python3 scripts/check_tbench_results.py "${args[@]}"
 
       - name: Set artifact name
         if: always()

--- a/benchmarks/terminal_bench/__init__.py
+++ b/benchmarks/terminal_bench/__init__.py
@@ -1,3 +1,11 @@
-from .mux_agent import MuxAgent
+from __future__ import annotations
 
 __all__ = ["MuxAgent"]
+
+
+def __getattr__(name: str):
+    if name == "MuxAgent":
+        from .mux_agent import MuxAgent
+
+        return MuxAgent
+    raise AttributeError(name)

--- a/benchmarks/terminal_bench/mux_agent.py
+++ b/benchmarks/terminal_bench/mux_agent.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import shlex
+import time
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -14,6 +15,11 @@ from harbor.environments.base import BaseEnvironment, ExecResult
 from harbor.models.agent.context import AgentContext
 from harbor.trial.trial import AgentTimeoutError
 
+from .mux_run_contract import (
+    MUX_RUN_TIMEOUT_FAILURE_MARKER,
+    RUN_COMPLETE_MARKER,
+    TIMEOUT_RETURN_CODE,
+)
 from .mux_payload import build_app_archive
 
 
@@ -352,6 +358,29 @@ class MuxAgent(BaseInstalledAgent):
             f"Agent execution timed out after {timeout_sec:g} seconds"
         )
 
+    @staticmethod
+    def _is_exec_timeout_return(
+        result: ExecResult,
+        timeout_sec: float | None,
+        elapsed_sec: float,
+    ) -> bool:
+        if timeout_sec is None or result.return_code != TIMEOUT_RETURN_CODE:
+            return False
+
+        assert timeout_sec > 0, "timeout_sec is validated when MuxAgent is constructed"
+        timeout_threshold = max(timeout_sec * 0.95, timeout_sec - 10)
+        if elapsed_sec < timeout_threshold:
+            return False
+
+        stdout = result.stdout or ""
+        stderr = result.stderr or ""
+        if RUN_COMPLETE_MARKER in stdout:
+            return False
+        if MUX_RUN_TIMEOUT_FAILURE_MARKER in stderr:
+            return False
+
+        return True
+
     async def run(
         self,
         instruction: str,
@@ -374,17 +403,25 @@ class MuxAgent(BaseInstalledAgent):
             for output_path in (stdout_path, stderr_path):
                 output_path.write_text("")
 
+            started_at = time.monotonic()
             try:
                 result = await self._exec_agent_command(environment, exec_input)
             except AgentTimeoutError as exc:
                 timeout_error = exc
                 break
+            elapsed_sec = time.monotonic() - started_at
 
             (command_dir / "return-code.txt").write_text(str(result.return_code))
             if result.stdout:
                 stdout_path.write_text(result.stdout)
             if result.stderr:
                 stderr_path.write_text(result.stderr)
+            if self._is_exec_timeout_return(
+                result, exec_input.timeout_sec, elapsed_sec
+            ):
+                assert exec_input.timeout_sec is not None
+                timeout_error = self._agent_timeout_error(exec_input.timeout_sec)
+                break
             if result.return_code != 0:
                 failed_command = (i, result.return_code)
                 break

--- a/benchmarks/terminal_bench/mux_agent_test.py
+++ b/benchmarks/terminal_bench/mux_agent_test.py
@@ -320,6 +320,72 @@ def test_run_timeout_surfaces_agent_timeout_error(
     assert getattr(context, "cost_usd") == 0.42
 
 
+def test_run_maps_near_timeout_return_code_124_to_agent_timeout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("MUX_AGENT_REPO_ROOT", str(_repo_root()))
+    agent = MuxAgent(logs_dir=tmp_path, timeout=0.01)
+    environment = _FakeEnvironment(
+        _ExecResult(return_code=124, stdout="partial event", stderr=""),
+        delay_sec=0.01,
+    )
+    context = SimpleNamespace()
+
+    with pytest.raises(AgentTimeoutError, match="timed out after 0.01 seconds"):
+        asyncio.run(agent.run("do the task", environment, context))
+
+    command_dir = tmp_path / "command-0"
+    assert (command_dir / "return-code.txt").read_text() == "124"
+    assert (command_dir / MuxAgent._COMMAND_STDOUT_NAME).read_text() == "partial event"
+
+
+def test_run_keeps_fast_return_code_124_strict(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("MUX_AGENT_REPO_ROOT", str(_repo_root()))
+    agent = MuxAgent(logs_dir=tmp_path, timeout=10)
+    environment = _FakeEnvironment(_ExecResult(return_code=124))
+    context = SimpleNamespace()
+
+    with pytest.raises(RuntimeError, match="exit 124"):
+        asyncio.run(agent.run("do the task", environment, context))
+
+
+@pytest.mark.parametrize("return_code", [1, 137])
+def test_run_keeps_non_timeout_agent_exits_strict(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, return_code: int
+) -> None:
+    monkeypatch.setenv("MUX_AGENT_REPO_ROOT", str(_repo_root()))
+    agent = MuxAgent(logs_dir=tmp_path, timeout=0.01)
+    environment = _FakeEnvironment(
+        _ExecResult(return_code=return_code, stdout="partial event", stderr=""),
+        delay_sec=0.01,
+    )
+    context = SimpleNamespace()
+
+    with pytest.raises(RuntimeError, match=f"exit {return_code}"):
+        asyncio.run(agent.run("do the task", environment, context))
+
+
+def test_run_keeps_explicit_return_code_124_failure_strict(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("MUX_AGENT_REPO_ROOT", str(_repo_root()))
+    agent = MuxAgent(logs_dir=tmp_path, timeout=0.01)
+    environment = _FakeEnvironment(
+        _ExecResult(
+            return_code=124,
+            stdout="partial event",
+            stderr="[mux-run] ERROR: mux agent session failed (exit 124)",
+        ),
+        delay_sec=0.01,
+    )
+    context = SimpleNamespace()
+
+    with pytest.raises(RuntimeError, match="exit 124"):
+        asyncio.run(agent.run("do the task", environment, context))
+
+
 def test_run_preseeds_command_logs_before_sandbox_exec(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/benchmarks/terminal_bench/mux_run_contract.py
+++ b/benchmarks/terminal_bench/mux_run_contract.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+TIMEOUT_RETURN_CODE = 124
+OOM_LIKE_RETURN_CODE = 137
+RUN_COMPLETE_MARKER = "run-complete"
+MUX_RUN_FAILURE_MARKER = "[mux-run] ERROR: mux agent session failed"
+
+
+def mux_run_failure_marker(return_code: int) -> str:
+    return f"{MUX_RUN_FAILURE_MARKER} (exit {return_code})"
+
+
+MUX_RUN_TIMEOUT_FAILURE_MARKER = mux_run_failure_marker(TIMEOUT_RETURN_CODE)

--- a/scripts/check_tbench_results.py
+++ b/scripts/check_tbench_results.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from benchmarks.terminal_bench.mux_run_contract import (  # noqa: E402
+    MUX_RUN_FAILURE_MARKER,
+    OOM_LIKE_RETURN_CODE,
+    RUN_COMPLETE_MARKER,
+    TIMEOUT_RETURN_CODE,
+    mux_run_failure_marker,
+)
+
+Category = Literal["infra", "soft", "hard"]
+
+INFRA_ERROR_NAMES = (
+    "AgentTimeoutError",
+    "VerifierTimeoutError",
+    "AgentSetupTimeoutError",
+    "EnvironmentStartTimeoutError",
+    "DaytonaError",
+    "DaytonaTimeoutError",
+    "DaytonaConnectionError",
+    "DaytonaNetworkError",
+    "DaytonaServerError",
+    "DaytonaInternalServerError",
+    "DaytonaServiceUnavailableError",
+    "DaytonaRateLimitError",
+    "DaytonaTooManyRequestsError",
+    "DaytonaSandboxTimeoutError",
+    "DaytonaSandboxStartTimeoutError",
+    "DaytonaSandboxNotStartedError",
+    "DaytonaSandboxNoIpError",
+)
+INFRA_ERROR_PATTERN = re.compile(r"\b(" + "|".join(INFRA_ERROR_NAMES) + r")\b")
+EXIT_CODE_PATTERN = re.compile(r"\bexit\s+(-?\d+)\b")
+TRANSIENT_STREAM_MARKERS = (
+    "Stream aborted before completion",
+    "EmptyStreamOutputError",
+    "model ended the stream before producing any assistant-visible output",
+)
+
+
+@dataclass(frozen=True)
+class ResultStats:
+    n_trials: int = 0
+    n_errors: int = 0
+    mean_score: float = 0.0
+
+
+@dataclass(frozen=True)
+class ClassifiedException:
+    path: Path
+    category: Category
+    reason: str
+    return_code: int | None
+    summary: str
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    stats: ResultStats
+    exceptions: tuple[ClassifiedException, ...]
+    fatal_errors: tuple[str, ...] = ()
+    missing_exception_count: int = 0
+
+    @property
+    def infra_count(self) -> int:
+        return self._count_category("infra")
+
+    @property
+    def soft_count(self) -> int:
+        return self._count_category("soft")
+
+    @property
+    def hard_count(self) -> int:
+        return self._count_category("hard") + self.missing_exception_count
+
+    @property
+    def is_success(self) -> bool:
+        return not self.fatal_errors and self.hard_count == 0
+
+    def _count_category(self, category: Category) -> int:
+        return sum(1 for exception in self.exceptions if exception.category == category)
+
+
+def load_json(path: Path) -> dict | None:
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text()
+    except OSError:
+        return ""
+
+
+def parse_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, str) and value.strip().lstrip("-").isdigit():
+        return int(value.strip())
+    return None
+
+
+def extract_result_stats(result: dict) -> ResultStats:
+    stats = result.get("stats")
+    stats = stats if isinstance(stats, dict) else {}
+
+    n_trials = parse_int(result.get("n_total_trials"))
+    if n_trials is None:
+        n_trials = parse_int(stats.get("n_trials")) or 0
+
+    n_errors = parse_int(stats.get("n_errors"))
+    if n_errors is None:
+        n_errors = parse_int(stats.get("n_errored_trials"))
+    if n_errors is None:
+        n_errors = 0
+        evals = stats.get("evals")
+        if isinstance(evals, dict):
+            for eval_result in evals.values():
+                if isinstance(eval_result, dict):
+                    n_errors += parse_int(eval_result.get("n_errors")) or 0
+
+    mean_scores: list[float] = []
+    evals = stats.get("evals")
+    if isinstance(evals, dict):
+        for eval_result in evals.values():
+            if not isinstance(eval_result, dict):
+                continue
+            metrics = eval_result.get("metrics")
+            if not isinstance(metrics, list) or not metrics:
+                continue
+            first_metric = metrics[0]
+            if isinstance(first_metric, dict):
+                mean = first_metric.get("mean")
+                if isinstance(mean, (int, float)) and not isinstance(mean, bool):
+                    mean_scores.append(float(mean))
+
+    mean_score = sum(mean_scores) / len(mean_scores) if mean_scores else 0.0
+    return ResultStats(n_trials=n_trials, n_errors=n_errors, mean_score=mean_score)
+
+
+def combine_stats(results: list[dict]) -> ResultStats:
+    stats = [extract_result_stats(result) for result in results]
+    if not stats:
+        return ResultStats()
+    mean_scores = [item.mean_score for item in stats]
+    return ResultStats(
+        n_trials=sum(item.n_trials for item in stats),
+        n_errors=sum(item.n_errors for item in stats),
+        mean_score=sum(mean_scores) / len(mean_scores) if mean_scores else 0.0,
+    )
+
+
+def parse_return_code(exception_text: str, command_dir: Path) -> int | None:
+    return_code = parse_int(read_text(command_dir / "return-code.txt"))
+    if return_code is not None:
+        return return_code
+    match = EXIT_CODE_PATTERN.search(exception_text)
+    return int(match.group(1)) if match else None
+
+
+def exception_summary(text: str) -> str:
+    non_empty_lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return non_empty_lines[-1] if non_empty_lines else "<empty exception>"
+
+
+def has_transient_stream_marker(text: str) -> bool:
+    return any(marker in text for marker in TRANSIENT_STREAM_MARKERS)
+
+
+def classify_exception(
+    exception_path: Path,
+    *,
+    allow_transient_agent_errors: bool,
+) -> ClassifiedException:
+    exception_text = read_text(exception_path)
+    command_dir = exception_path.parent / "agent" / "command-0"
+    stderr = read_text(command_dir / "stderr.txt")
+    stdout = read_text(command_dir / "stdout.txt")
+    return_code = parse_return_code(exception_text, command_dir)
+    combined_diagnostic = "\n".join((exception_text, stderr))
+
+    if INFRA_ERROR_PATTERN.search(exception_text):
+        return ClassifiedException(
+            path=exception_path,
+            category="infra",
+            reason="infrastructure exception",
+            return_code=return_code,
+            summary=exception_summary(exception_text),
+        )
+
+    if allow_transient_agent_errors:
+        if return_code == 1 and has_transient_stream_marker(combined_diagnostic):
+            return ClassifiedException(
+                path=exception_path,
+                category="soft",
+                reason="provider stream transient",
+                return_code=return_code,
+                summary=exception_summary(exception_text),
+            )
+        if return_code == OOM_LIKE_RETURN_CODE:
+            return ClassifiedException(
+                path=exception_path,
+                category="soft",
+                reason="agent process killed",
+                return_code=return_code,
+                summary=exception_summary(exception_text),
+            )
+        if (
+            return_code == TIMEOUT_RETURN_CODE
+            and RUN_COMPLETE_MARKER not in stdout
+            and mux_run_failure_marker(TIMEOUT_RETURN_CODE) not in stderr
+        ):
+            return ClassifiedException(
+                path=exception_path,
+                category="soft",
+                reason="timeout-like exit 124",
+                return_code=return_code,
+                summary=exception_summary(exception_text),
+            )
+
+    reason = "non-infrastructure exception"
+    if return_code is not None:
+        reason = f"agent exit {return_code}"
+    if MUX_RUN_FAILURE_MARKER in stderr:
+        reason = f"mux-run failure ({reason})"
+
+    return ClassifiedException(
+        path=exception_path,
+        category="hard",
+        reason=reason,
+        return_code=return_code,
+        summary=exception_summary(exception_text),
+    )
+
+
+def find_result_files(jobs_dir: Path) -> list[Path]:
+    if not jobs_dir.is_dir():
+        return []
+    return sorted(jobs_dir.glob("*/result.json"))
+
+
+def find_exception_files(jobs_dir: Path) -> list[Path]:
+    if not jobs_dir.is_dir():
+        return []
+    return sorted(jobs_dir.glob("*/**/exception.txt"))
+
+
+def check_results(
+    jobs_dir: Path,
+    *,
+    allow_transient_agent_errors: bool = False,
+) -> CheckResult:
+    result_files = find_result_files(jobs_dir)
+    if not result_files:
+        return CheckResult(
+            stats=ResultStats(),
+            exceptions=(),
+            fatal_errors=("No result.json found under jobs directory",),
+        )
+
+    results = [loaded for path in result_files if (loaded := load_json(path)) is not None]
+    if len(results) != len(result_files):
+        return CheckResult(
+            stats=ResultStats(),
+            exceptions=(),
+            fatal_errors=("Unable to parse one or more result.json files",),
+        )
+
+    stats = combine_stats(results)
+    fatal_errors: list[str] = []
+    if stats.n_trials == 0:
+        fatal_errors.append("No trials ran")
+    if stats.n_errors == 0:
+        return CheckResult(stats=stats, exceptions=(), fatal_errors=tuple(fatal_errors))
+
+    exception_files = find_exception_files(jobs_dir)
+    exceptions = tuple(
+        classify_exception(
+            exception_file,
+            allow_transient_agent_errors=allow_transient_agent_errors,
+        )
+        for exception_file in exception_files
+    )
+    missing_exception_count = max(stats.n_errors - len(exception_files), 0)
+
+    return CheckResult(
+        stats=stats,
+        exceptions=exceptions,
+        fatal_errors=tuple(fatal_errors),
+        missing_exception_count=missing_exception_count,
+    )
+
+
+def format_summary(result: CheckResult) -> str:
+    lines = [
+        (
+            f"Trials: {result.stats.n_trials}, Errors: {result.stats.n_errors}, "
+            f"Mean score: {result.stats.mean_score:g}"
+        ),
+        "",
+        "Error classification:",
+        f"  {'category':<8} {'count':>5}",
+        f"  {'infra':<8} {result.infra_count:>5}",
+        f"  {'soft':<8} {result.soft_count:>5}",
+        f"  {'hard':<8} {result.hard_count:>5}",
+    ]
+
+    if result.exceptions:
+        reason_counts = Counter(
+            (exception.category, exception.reason) for exception in result.exceptions
+        )
+        lines.extend(["", "Reasons:"])
+        for (category, reason), count in sorted(reason_counts.items()):
+            lines.append(f"  {category:<8} {count:>5}  {reason}")
+
+    hard_exceptions = [
+        exception for exception in result.exceptions if exception.category == "hard"
+    ]
+    if hard_exceptions or result.missing_exception_count:
+        lines.extend(["", "Hard error details:"])
+        for exception in hard_exceptions:
+            lines.append(f"=== {exception.path} ===")
+            lines.append(exception.summary)
+        if result.missing_exception_count:
+            lines.append(
+                f"Missing exception.txt details for {result.missing_exception_count} error(s)"
+            )
+
+    if result.fatal_errors:
+        lines.extend(["", "Fatal validation errors:"])
+        lines.extend(f"  - {error}" for error in result.fatal_errors)
+
+    if result.is_success:
+        lines.append("")
+        lines.append(
+            f"Agent ran {result.stats.n_trials} trial(s) successfully "
+            f"(mean score: {result.stats.mean_score:g})"
+        )
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Classify Harbor Terminal-Bench result errors."
+    )
+    parser.add_argument(
+        "--jobs-dir",
+        type=Path,
+        default=Path("jobs"),
+        help="Path to Harbor jobs directory (default: jobs)",
+    )
+    parser.add_argument(
+        "--allow-transient-agent-errors",
+        action="store_true",
+        help="Allow explicitly classified full-nightly agent transients.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    result = check_results(
+        args.jobs_dir,
+        allow_transient_agent_errors=args.allow_transient_agent_errors,
+    )
+    print(format_summary(result))
+    return 0 if result.is_success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_tbench_results_test.py
+++ b/scripts/check_tbench_results_test.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import check_tbench_results as checker  # noqa: E402
+
+
+def _write_job(
+    tmp_path: Path,
+    *,
+    n_trials: int = 1,
+    n_errors: int = 1,
+) -> Path:
+    job_dir = tmp_path / "jobs" / "2026-05-26__00-00-00"
+    job_dir.mkdir(parents=True)
+    (job_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "n_total_trials": n_trials,
+                "stats": {
+                    "n_errors": n_errors,
+                    "evals": {"terminal-bench": {"metrics": [{"mean": 0.5}]}},
+                },
+            }
+        )
+    )
+    return job_dir
+
+
+def _write_exception(
+    job_dir: Path,
+    trial_name: str,
+    exception_text: str,
+    *,
+    return_code: int | None = None,
+    stderr: str = "",
+    stdout: str = "",
+) -> Path:
+    trial_dir = job_dir / trial_name
+    command_dir = trial_dir / "agent" / "command-0"
+    command_dir.mkdir(parents=True)
+    (trial_dir / "exception.txt").write_text(exception_text)
+    if return_code is not None:
+        (command_dir / "return-code.txt").write_text(str(return_code))
+    (command_dir / "stderr.txt").write_text(stderr)
+    (command_dir / "stdout.txt").write_text(stdout)
+    return trial_dir / "exception.txt"
+
+
+def _analyze(
+    tmp_path: Path,
+    *,
+    allow_transient_agent_errors: bool = False,
+) -> checker.CheckResult:
+    return checker.check_results(
+        tmp_path / "jobs",
+        allow_transient_agent_errors=allow_transient_agent_errors,
+    )
+
+
+@pytest.mark.parametrize(
+    "exception_name",
+    [
+        "AgentTimeoutError",
+        "VerifierTimeoutError",
+        "AgentSetupTimeoutError",
+        "EnvironmentStartTimeoutError",
+        "DaytonaTimeoutError",
+        "DaytonaConnectionError",
+    ],
+)
+def test_known_infrastructure_errors_are_allowed(
+    tmp_path: Path, exception_name: str
+) -> None:
+    job_dir = _write_job(tmp_path)
+    _write_exception(job_dir, "task__abc", f"harbor.error.{exception_name}: transient")
+
+    result = _analyze(tmp_path)
+
+    assert result.hard_count == 0
+    assert result.infra_count == 1
+    assert result.is_success
+
+
+@pytest.mark.parametrize("exception_name", ["DaytonaAuthenticationError", "DaytonaValidationError"])
+def test_daytona_configuration_errors_stay_hard(
+    tmp_path: Path, exception_name: str
+) -> None:
+    job_dir = _write_job(tmp_path)
+    _write_exception(job_dir, "task__abc", f"daytona.error.{exception_name}: bad config")
+
+    result = _analyze(tmp_path)
+
+    assert result.hard_count == 1
+    assert result.infra_count == 0
+    assert not result.is_success
+
+
+def test_zero_mean_scores_are_included_when_combining_stats() -> None:
+    result = checker.combine_stats(
+        [
+            {
+                "n_total_trials": 1,
+                "stats": {"n_errors": 0, "evals": {"a": {"metrics": [{"mean": 0.0}]}}},
+            },
+            {
+                "n_total_trials": 1,
+                "stats": {"n_errors": 0, "evals": {"b": {"metrics": [{"mean": 1.0}]}}},
+            },
+        ]
+    )
+
+    assert result.mean_score == 0.5
+
+@pytest.mark.parametrize(
+    "transient_message",
+    [
+        "Stream aborted before completion",
+        "EmptyStreamOutputError",
+        "model ended the stream before producing any assistant-visible output",
+    ],
+)
+def test_exit_1_stream_transients_require_nightly_flag(
+    tmp_path: Path, transient_message: str
+) -> None:
+    job_dir = _write_job(tmp_path)
+    _write_exception(
+        job_dir,
+        "task__abc",
+        "RuntimeError: mux agent command failed (command 0, exit 1)",
+        return_code=1,
+        stderr=(
+            f"Error: {transient_message}\n"
+            "[mux-run] ERROR: mux agent session failed (exit 1)"
+        ),
+    )
+
+    strict_result = _analyze(tmp_path)
+    allowed_result = _analyze(tmp_path, allow_transient_agent_errors=True)
+
+    assert strict_result.hard_count == 1
+    assert not strict_result.is_success
+    assert allowed_result.hard_count == 0
+    assert allowed_result.soft_count == 1
+    assert allowed_result.is_success
+
+
+def test_exit_137_requires_nightly_flag(tmp_path: Path) -> None:
+    job_dir = _write_job(tmp_path)
+    _write_exception(
+        job_dir,
+        "task__abc",
+        "RuntimeError: mux agent command failed (command 0, exit 137)",
+        return_code=137,
+    )
+
+    strict_result = _analyze(tmp_path)
+    allowed_result = _analyze(tmp_path, allow_transient_agent_errors=True)
+
+    assert strict_result.hard_count == 1
+    assert not strict_result.is_success
+    assert allowed_result.hard_count == 0
+    assert allowed_result.soft_count == 1
+    assert allowed_result.is_success
+
+
+def test_unknown_exit_1_stays_hard_with_nightly_flag(tmp_path: Path) -> None:
+    job_dir = _write_job(tmp_path)
+    _write_exception(
+        job_dir,
+        "task__abc",
+        "RuntimeError: mux agent command failed (command 0, exit 1)",
+        return_code=1,
+        stderr="[mux-run] ERROR: mux agent session failed (exit 1)",
+    )
+
+    result = _analyze(tmp_path, allow_transient_agent_errors=True)
+
+    assert result.hard_count == 1
+    assert not result.is_success
+
+
+
+def test_no_errors_skips_exception_scan(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write_job(tmp_path, n_errors=0)
+
+    def fail_scan(_jobs_dir: Path) -> list[Path]:
+        raise AssertionError("exception scan should be skipped when n_errors is zero")
+
+    monkeypatch.setattr(checker, "find_exception_files", fail_scan)
+
+    result = _analyze(tmp_path)
+
+    assert result.is_success
+    assert result.hard_count == 0
+
+def test_missing_result_json_fails(tmp_path: Path) -> None:
+    (tmp_path / "jobs" / "empty-job").mkdir(parents=True)
+
+    result = _analyze(tmp_path)
+
+    assert not result.is_success
+    assert result.fatal_errors == ("No result.json found under jobs directory",)
+
+
+def test_zero_trials_fails(tmp_path: Path) -> None:
+    _write_job(tmp_path, n_trials=0, n_errors=0)
+
+    result = _analyze(tmp_path)
+
+    assert not result.is_success
+    assert result.fatal_errors == ("No trials ran",)

--- a/scripts/daytona_sandbox_cleanup.py
+++ b/scripts/daytona_sandbox_cleanup.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+from daytona import Daytona
+
+ACTIVE_STATES = {"started", "creating", "starting"}
+
+
+def sandbox_id(sandbox: Any) -> str:
+    value = str(getattr(sandbox, "id", ""))
+    assert value, "Daytona sandbox objects must expose a non-empty id"
+    return value
+
+
+def list_all_sandboxes(daytona: Daytona):
+    # Daytona SDK versions have returned either a generator/list or a paginated
+    # object. Handle both so workflow snapshot/cleanup stays best-effort.
+    page = 1
+    while True:
+        result = daytona.list(page=page)
+        if not hasattr(result, "items"):
+            yield from result
+            return
+        yield from result.items
+        total_pages = getattr(result, "total_pages", None) or 1
+        if page >= total_pages:
+            break
+        page += 1
+
+
+def snapshot(daytona: Daytona) -> None:
+    ids = [sandbox_id(sandbox) for sandbox in list_all_sandboxes(daytona)]
+    print("\n".join(ids))
+
+
+def cleanup(daytona: Daytona, pre_existing_file: Path) -> None:
+    pre_existing = {line.strip() for line in pre_existing_file.read_text().splitlines() if line.strip()}
+    candidates = [
+        sandbox
+        for sandbox in list_all_sandboxes(daytona)
+        if sandbox_id(sandbox) not in pre_existing
+    ]
+    to_delete = [
+        sandbox
+        for sandbox in candidates
+        if str(getattr(sandbox, "state", "")).lower() not in ACTIVE_STATES
+    ]
+    skipped = len(candidates) - len(to_delete)
+    if skipped:
+        print(f"Skipping {skipped} still-active sandbox(es)")
+    if not to_delete:
+        print("No stopped sandboxes to clean up")
+        return
+
+    print(f"Cleaning up {len(to_delete)} stopped sandbox(es) from this run...")
+    for sandbox in to_delete:
+        sandbox_identifier = sandbox_id(sandbox)
+        state = getattr(sandbox, "state", "unknown")
+        try:
+            print(f"  Deleting {sandbox_identifier} (state={state})...")
+            daytona.delete(sandbox)
+            print(f"  Deleted {sandbox_identifier}")
+        except Exception as exc:
+            print(f"  Failed to delete {sandbox_identifier}: {exc}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Snapshot or cleanup Daytona sandboxes for tbench workflows.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("snapshot")
+    cleanup_parser = subparsers.add_parser("cleanup")
+    cleanup_parser.add_argument("--pre-existing-file", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    daytona = Daytona()
+    if args.command == "snapshot":
+        snapshot(daytona)
+        return 0
+    if args.command == "cleanup":
+        cleanup(daytona, args.pre_existing_file)
+        return 0
+    raise AssertionError(f"Unhandled command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Fix Terminal-Bench result verification so nightly runs distinguish hard mux failures from infrastructure/timeouts and explicitly allowed full-nightly transients. This also teaches the adapter to map near-timeout Harbor/Daytona `ExecResult.return_code == 124` responses to `AgentTimeoutError` after preserving command logs.

## Background

Nightly Terminal-Bench #183 failed after the benchmark itself completed because the reusable workflow verifier treated timeout-like Harbor returns and high-concurrency transient agent failures as hard mux regressions. A separate best-effort Daytona cleanup helper also drifted with SDK return shapes.

## Implementation

- Added a tested `scripts/check_tbench_results.py` verifier that classifies infra, soft nightly-only transients, and hard failures.
- Kept reusable/manual runs strict by default; only the full nightly matrix opts into transient allowances.
- Added adapter-side near-timeout `124` handling while preserving `return-code.txt`, stdout, and stderr artifacts.
- Centralized mux-run marker constants and Daytona sandbox snapshot/cleanup helper logic.

## Validation

- `make fmt`
- `~/.local/bin/uv run --python ~/.local/bin/python3.12 --with pytest --with 'harbor[daytona]==0.6.4' pytest benchmarks/terminal_bench/mux_agent_test.py scripts/check_tbench_results_test.py`
- `python3 -m py_compile scripts/check_tbench_results.py scripts/check_tbench_results_test.py scripts/daytona_sandbox_cleanup.py benchmarks/terminal_bench/__init__.py benchmarks/terminal_bench/mux_run_contract.py benchmarks/terminal_bench/mux_agent.py benchmarks/terminal_bench/mux_agent_test.py`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/terminal-bench.yml .github/workflows/nightly-terminal-bench.yml`
- `./scripts/check-bench-agent.sh`
- Replayed the verifier against the failed Opus artifact: transient mode passed with 6 infra / 9 soft / 0 hard; strict mode still failed with 9 hard.
- Replayed the verifier against the OpenAI quota-exhausted goal-mode artifact: both strict and transient modes correctly failed with 89 hard errors.
- `make static-check`

## Risks

Moderate CI-only risk. The reusable workflow remains strict by default, and the new allowances are gated to the full nightly matrix. Hard failures such as quota exhaustion and unknown agent exits remain hard.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$37.94`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=37.94 -->
