### PR TITLE
🤖 feat: highlight active heading in plan table of contents

### DIFF
--- a/src/browser/features/Tools/ProposePlan/PlanTableOfContents.test.tsx
+++ b/src/browser/features/Tools/ProposePlan/PlanTableOfContents.test.tsx
@@ -1,10 +1,86 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { useRef } from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
 
 import { installDom } from "../../../../../tests/ui/dom";
 import { PlanTableOfContents } from "./PlanTableOfContents";
 import type { PlanHeading } from "./extractPlanHeadings";
+
+/**
+ * Captures the live IntersectionObserver instances created by the component
+ * under test so individual tests can drive observer callbacks deterministically.
+ * happy-dom ships a no-op IntersectionObserver stub; replacing it with this
+ * controllable harness is the only way to simulate scroll events synchronously.
+ */
+interface ObserverHandle {
+  callback: IntersectionObserverCallback;
+  observed: Element[];
+}
+
+function installControllableIntersectionObserver(): {
+  handles: ObserverHandle[];
+  restore: () => void;
+} {
+  const handles: ObserverHandle[] = [];
+  const previous = (globalThis as unknown as { IntersectionObserver?: unknown })
+    .IntersectionObserver;
+
+  class ControllableIntersectionObserver {
+    private readonly handle: ObserverHandle;
+    constructor(cb: IntersectionObserverCallback) {
+      this.handle = { callback: cb, observed: [] };
+      handles.push(this.handle);
+    }
+    observe(target: Element): void {
+      this.handle.observed.push(target);
+    }
+    unobserve(target: Element): void {
+      const idx = this.handle.observed.indexOf(target);
+      if (idx >= 0) this.handle.observed.splice(idx, 1);
+    }
+    disconnect(): void {
+      this.handle.observed.length = 0;
+    }
+    takeRecords(): IntersectionObserverEntry[] {
+      return [];
+    }
+  }
+
+  (globalThis as unknown as { IntersectionObserver: unknown }).IntersectionObserver =
+    ControllableIntersectionObserver;
+
+  return {
+    handles,
+    restore: () => {
+      (globalThis as unknown as { IntersectionObserver?: unknown }).IntersectionObserver = previous;
+    },
+  };
+}
+
+/** Build a minimal IntersectionObserverEntry-shaped object for tests. */
+function makeEntry(target: HTMLElement, top: number): Partial<IntersectionObserverEntry> {
+  const boundingClientRect: DOMRect = {
+    top,
+    bottom: top + 20,
+    left: 0,
+    right: 100,
+    width: 100,
+    height: 20,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  };
+  const intersectionRect: DOMRectReadOnly = boundingClientRect;
+  return {
+    target,
+    boundingClientRect,
+    intersectionRatio: top < 0 ? 0 : 1,
+    intersectionRect,
+    isIntersecting: top >= 0,
+    rootBounds: null,
+    time: 0,
+  };
+}
 
 /**
  * Renders the PlanTableOfContents against a hand-rolled DOM that contains real
@@ -140,6 +216,101 @@ describe("PlanTableOfContents", () => {
     expect(scrollCalls[0].target).toBe(headings[2]);
     // Top alignment ensures the heading lands just below the scrollport edge.
     expect(scrollCalls[0].options.block).toBe("start");
+  });
+
+  test("updates the active indicator when an IntersectionObserver tick reports a heading has scrolled past the trigger", () => {
+    const io = installControllableIntersectionObserver();
+    try {
+      const entries: PlanHeading[] = [
+        { renderIndex: 0, level: 1, text: "Intro" },
+        { renderIndex: 1, level: 2, text: "First section" },
+        { renderIndex: 2, level: 2, text: "Second section" },
+      ];
+
+      const view = render(<HarnessRenderer entries={entries} title="Intro" />);
+
+      // The component should have created exactly one observer with the
+      // tracked headings observed.
+      expect(io.handles).toHaveLength(1);
+      const handle = io.handles[0];
+      expect(handle.observed.length).toBeGreaterThan(0);
+
+      const headings = Array.from(
+        view.container.querySelectorAll<HTMLElement>("h1, h2, h3, h4, h5, h6")
+      );
+
+      // Simulate the user scrolling so the SECOND h2 ("Second section") has
+      // just crossed above the trigger. We report intersection entries for
+      // both h2s — first h2 at top=-100 (passed), second h2 at top=10
+      // (passed), third heading (the h3 outside the visible set isn't
+      // tracked).
+      const secondSection = headings[2];
+      const firstSection = headings[1];
+      const title = headings[0];
+
+      act(() => {
+        handle.callback(
+          [
+            makeEntry(title, -200),
+            makeEntry(firstSection, -100),
+            makeEntry(secondSection, 10),
+          ] as unknown as IntersectionObserverEntry[],
+          handle as unknown as IntersectionObserver
+        );
+      });
+
+      // Active entry should be the SECOND section (the last passed in document
+      // order). Its button is the one tagged aria-current="location".
+      const activeBtn = view.container.querySelector<HTMLElement>('[aria-current="location"]');
+      expect(activeBtn).not.toBeNull();
+      expect(activeBtn?.textContent).toBe("Second section");
+
+      // The active <li> also carries data-active="true" for CSS styling.
+      const activeItem = view.container.querySelector<HTMLElement>(
+        '.plan-toc-item[data-active="true"]'
+      );
+      expect(activeItem).not.toBeNull();
+      expect(activeItem?.textContent).toContain("Second section");
+
+      // Now simulate scrolling further so the second section moves above and
+      // there are no more headings ahead — last-passed is still the second
+      // section.
+      act(() => {
+        handle.callback(
+          [makeEntry(secondSection, -50)] as unknown as IntersectionObserverEntry[],
+          handle as unknown as IntersectionObserver
+        );
+      });
+
+      const stillActive = view.container.querySelector<HTMLElement>('[aria-current="location"]');
+      expect(stillActive?.textContent).toBe("Second section");
+    } finally {
+      io.restore();
+    }
+  });
+
+  test("clicking a TOC entry marks it active immediately so the indicator does not lag scroll", () => {
+    const io = installControllableIntersectionObserver();
+    try {
+      const entries: PlanHeading[] = [
+        { renderIndex: 0, level: 2, text: "Alpha" },
+        { renderIndex: 1, level: 2, text: "Beta" },
+        { renderIndex: 2, level: 2, text: "Gamma" },
+      ];
+
+      const view = render(<HarnessRenderer entries={entries} />);
+
+      // Click the LAST entry; its active state must immediately reflect the
+      // click rather than waiting for the observer to fire post-scroll.
+      fireEvent.click(view.getByRole("button", { name: "Gamma" }));
+
+      // Exactly one entry should be marked active, and it must be the clicked one.
+      const active = view.container.querySelectorAll<HTMLElement>('[aria-current="location"]');
+      expect(active).toHaveLength(1);
+      expect(active[0].textContent).toBe("Gamma");
+    } finally {
+      io.restore();
+    }
   });
 
   test("normalizes indentation so the shallowest visible level sits at column 0", () => {

--- a/src/browser/features/Tools/ProposePlan/PlanTableOfContents.test.tsx
+++ b/src/browser/features/Tools/ProposePlan/PlanTableOfContents.test.tsx
@@ -7,59 +7,14 @@ import { PlanTableOfContents } from "./PlanTableOfContents";
 import type { PlanHeading } from "./extractPlanHeadings";
 
 /**
- * Captures the live IntersectionObserver instances created by the component
- * under test so individual tests can drive observer callbacks deterministically.
- * happy-dom ships a no-op IntersectionObserver stub; replacing it with this
- * controllable harness is the only way to simulate scroll events synchronously.
+ * Stub a heading's `getBoundingClientRect` to simulate the user having
+ * scrolled to a particular position. The active-heading effect reads
+ * `boundingClientRect.top` on every recompute, so overriding this method per
+ * heading is enough to drive the trigger logic in tests without needing real
+ * layout from happy-dom.
  */
-interface ObserverHandle {
-  callback: IntersectionObserverCallback;
-  observed: Element[];
-}
-
-function installControllableIntersectionObserver(): {
-  handles: ObserverHandle[];
-  restore: () => void;
-} {
-  const handles: ObserverHandle[] = [];
-  const previous = (globalThis as unknown as { IntersectionObserver?: unknown })
-    .IntersectionObserver;
-
-  class ControllableIntersectionObserver {
-    private readonly handle: ObserverHandle;
-    constructor(cb: IntersectionObserverCallback) {
-      this.handle = { callback: cb, observed: [] };
-      handles.push(this.handle);
-    }
-    observe(target: Element): void {
-      this.handle.observed.push(target);
-    }
-    unobserve(target: Element): void {
-      const idx = this.handle.observed.indexOf(target);
-      if (idx >= 0) this.handle.observed.splice(idx, 1);
-    }
-    disconnect(): void {
-      this.handle.observed.length = 0;
-    }
-    takeRecords(): IntersectionObserverEntry[] {
-      return [];
-    }
-  }
-
-  (globalThis as unknown as { IntersectionObserver: unknown }).IntersectionObserver =
-    ControllableIntersectionObserver;
-
-  return {
-    handles,
-    restore: () => {
-      (globalThis as unknown as { IntersectionObserver?: unknown }).IntersectionObserver = previous;
-    },
-  };
-}
-
-/** Build a minimal IntersectionObserverEntry-shaped object for tests. */
-function makeEntry(target: HTMLElement, top: number): Partial<IntersectionObserverEntry> {
-  const boundingClientRect: DOMRect = {
+function stubHeadingTop(el: HTMLElement, top: number): void {
+  const rect: DOMRect = {
     top,
     bottom: top + 20,
     left: 0,
@@ -70,16 +25,24 @@ function makeEntry(target: HTMLElement, top: number): Partial<IntersectionObserv
     y: top,
     toJSON: () => ({}),
   };
-  const intersectionRect: DOMRectReadOnly = boundingClientRect;
-  return {
-    target,
-    boundingClientRect,
-    intersectionRatio: top < 0 ? 0 : 1,
-    intersectionRect,
-    isIntersecting: top >= 0,
-    rootBounds: null,
-    time: 0,
-  };
+  el.getBoundingClientRect = () => rect;
+}
+
+/**
+ * Disable the rAF coalescing in the active-heading effect so a synchronous
+ * scroll event triggers an immediate recompute. The effect feature-detects
+ * `requestAnimationFrame`; replacing the global with `undefined` exercises the
+ * sync fallback path.
+ */
+function withSyncAnimationFrame<T>(run: () => T): T {
+  const previous = (globalThis as unknown as { requestAnimationFrame?: unknown })
+    .requestAnimationFrame;
+  (globalThis as unknown as { requestAnimationFrame?: unknown }).requestAnimationFrame = undefined;
+  try {
+    return run();
+  } finally {
+    (globalThis as unknown as { requestAnimationFrame?: unknown }).requestAnimationFrame = previous;
+  }
 }
 
 /**
@@ -218,9 +181,8 @@ describe("PlanTableOfContents", () => {
     expect(scrollCalls[0].options.block).toBe("start");
   });
 
-  test("updates the active indicator when an IntersectionObserver tick reports a heading has scrolled past the trigger", () => {
-    const io = installControllableIntersectionObserver();
-    try {
+  test("active indicator follows the last heading that has crossed the trigger as the user scrolls", () => {
+    withSyncAnimationFrame(() => {
       const entries: PlanHeading[] = [
         { renderIndex: 0, level: 1, text: "Intro" },
         { renderIndex: 1, level: 2, text: "First section" },
@@ -228,89 +190,107 @@ describe("PlanTableOfContents", () => {
       ];
 
       const view = render(<HarnessRenderer entries={entries} title="Intro" />);
-
-      // The component should have created exactly one observer with the
-      // tracked headings observed.
-      expect(io.handles).toHaveLength(1);
-      const handle = io.handles[0];
-      expect(handle.observed.length).toBeGreaterThan(0);
-
       const headings = Array.from(
         view.container.querySelectorAll<HTMLElement>("h1, h2, h3, h4, h5, h6")
       );
 
-      // Simulate the user scrolling so the SECOND h2 ("Second section") has
-      // just crossed above the trigger. We report intersection entries for
-      // both h2s — first h2 at top=-100 (passed), second h2 at top=10
-      // (passed), third heading (the h3 outside the visible set isn't
-      // tracked).
-      const secondSection = headings[2];
-      const firstSection = headings[1];
-      const title = headings[0];
+      // Simulate the reader having scrolled so the first h2's top edge has
+      // crossed the 16px trigger (top=-100) but the second h2 is still below
+      // (top=400). The active entry must be "First section".
+      stubHeadingTop(headings[0], -200); // h1: well above trigger
+      stubHeadingTop(headings[1], -100); // first h2: above trigger
+      stubHeadingTop(headings[2], 400); // second h2: below trigger
 
       act(() => {
-        handle.callback(
-          [
-            makeEntry(title, -200),
-            makeEntry(firstSection, -100),
-            makeEntry(secondSection, 10),
-          ] as unknown as IntersectionObserverEntry[],
-          handle as unknown as IntersectionObserver
-        );
+        window.dispatchEvent(new Event("scroll"));
       });
 
-      // Active entry should be the SECOND section (the last passed in document
-      // order). Its button is the one tagged aria-current="location".
-      const activeBtn = view.container.querySelector<HTMLElement>('[aria-current="location"]');
-      expect(activeBtn).not.toBeNull();
+      let activeBtn = view.container.querySelector<HTMLElement>('[aria-current="location"]');
+      expect(activeBtn?.textContent).toBe("First section");
+
+      // Reader continues scrolling: second h2 also crosses above the trigger.
+      // Active must advance to "Second section" — this is the case Codex
+      // flagged where an IO-based implementation would miss the mid-scroll
+      // transition because both headings are still inside the root.
+      stubHeadingTop(headings[2], 10); // second h2: just above trigger now
+
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      activeBtn = view.container.querySelector<HTMLElement>('[aria-current="location"]');
       expect(activeBtn?.textContent).toBe("Second section");
 
       // The active <li> also carries data-active="true" for CSS styling.
       const activeItem = view.container.querySelector<HTMLElement>(
         '.plan-toc-item[data-active="true"]'
       );
-      expect(activeItem).not.toBeNull();
       expect(activeItem?.textContent).toContain("Second section");
+    });
+  });
 
-      // Now simulate scrolling further so the second section moves above and
-      // there are no more headings ahead — last-passed is still the second
-      // section.
+  test("active indicator clears when the reader scrolls back above all tracked headings", () => {
+    withSyncAnimationFrame(() => {
+      // Map entries to the harness DOM: renderIndex aligns with the document
+      // order of <h1>/<h2>/<h3> elements in HarnessRenderer.
+      const entries: PlanHeading[] = [
+        { renderIndex: 1, level: 2, text: "First section" },
+        { renderIndex: 2, level: 2, text: "Second section" },
+      ];
+
+      const view = render(<HarnessRenderer entries={entries} />);
+      const headings = Array.from(
+        view.container.querySelectorAll<HTMLElement>("h1, h2, h3, h4, h5, h6")
+      );
+
+      // Scroll so the first h2 is just above the trigger.
+      stubHeadingTop(headings[1], -10);
+      stubHeadingTop(headings[2], 500);
       act(() => {
-        handle.callback(
-          [makeEntry(secondSection, -50)] as unknown as IntersectionObserverEntry[],
-          handle as unknown as IntersectionObserver
-        );
+        window.dispatchEvent(new Event("scroll"));
       });
+      expect(view.container.querySelector('[aria-current="location"]')?.textContent).toBe(
+        "First section"
+      );
 
-      const stillActive = view.container.querySelector<HTMLElement>('[aria-current="location"]');
-      expect(stillActive?.textContent).toBe("Second section");
-    } finally {
-      io.restore();
-    }
+      // Scroll back so all headings are below the trigger: nothing active.
+      stubHeadingTop(headings[1], 200);
+      stubHeadingTop(headings[2], 700);
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+      expect(view.container.querySelector('[aria-current="location"]')).toBeNull();
+    });
   });
 
   test("clicking a TOC entry marks it active immediately so the indicator does not lag scroll", () => {
-    const io = installControllableIntersectionObserver();
-    try {
+    withSyncAnimationFrame(() => {
       const entries: PlanHeading[] = [
-        { renderIndex: 0, level: 2, text: "Alpha" },
-        { renderIndex: 1, level: 2, text: "Beta" },
-        { renderIndex: 2, level: 2, text: "Gamma" },
+        { renderIndex: 1, level: 2, text: "First section" },
+        { renderIndex: 2, level: 2, text: "Second section" },
+        { renderIndex: 3, level: 3, text: "Nested" },
       ];
 
       const view = render(<HarnessRenderer entries={entries} />);
 
-      // Click the LAST entry; its active state must immediately reflect the
-      // click rather than waiting for the observer to fire post-scroll.
-      fireEvent.click(view.getByRole("button", { name: "Gamma" }));
+      // Position all headings below the trigger so nothing is active on mount.
+      const headings = Array.from(
+        view.container.querySelectorAll<HTMLElement>("h1, h2, h3, h4, h5, h6")
+      );
+      headings.forEach((el) => stubHeadingTop(el, 500));
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+      expect(view.container.querySelector('[aria-current="location"]')).toBeNull();
 
-      // Exactly one entry should be marked active, and it must be the clicked one.
+      // Click the LAST entry; its active state must immediately reflect the
+      // click rather than waiting for the scroll handler to fire post-animation.
+      fireEvent.click(view.getByRole("button", { name: "Nested" }));
+
       const active = view.container.querySelectorAll<HTMLElement>('[aria-current="location"]');
       expect(active).toHaveLength(1);
-      expect(active[0].textContent).toBe("Gamma");
-    } finally {
-      io.restore();
-    }
+      expect(active[0].textContent).toBe("Nested");
+    });
   });
 
   test("normalizes indentation so the shallowest visible level sits at column 0", () => {

--- a/src/browser/features/Tools/ProposePlan/PlanTableOfContents.tsx
+++ b/src/browser/features/Tools/ProposePlan/PlanTableOfContents.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { cn } from "@/common/lib/utils";
 import { TooltipIfPresent } from "@/browser/components/Tooltip/Tooltip";
 import type { PlanHeading } from "./extractPlanHeadings";
@@ -44,12 +44,134 @@ export interface PlanTableOfContentsProps {
 const HEADING_SELECTOR = "h1, h2, h3, h4, h5, h6";
 const DEFAULT_HEADING = "Contents";
 
+/**
+ * Distance in pixels from the top of the scrollport (or viewport) at which a
+ * heading is considered "passed" by the reader. The active TOC entry is the
+ * last heading (in document order) whose top edge has crossed this line.
+ *
+ * Matches `scroll-margin-top: 1rem` on plan headings so the indicator updates
+ * exactly when scroll-into-view lands a heading at its resting position.
+ */
+const ACTIVE_TRIGGER_OFFSET_PX = 16;
+
+/**
+ * Walk up the DOM to find the nearest ancestor that establishes a scroll
+ * context. Using that ancestor as the IntersectionObserver root means our
+ * trigger line is anchored to the user's actual reading frame (the transcript
+ * scrollport) instead of the browser viewport. Falls back to the viewport
+ * (`null`) when no scrolling ancestor is found, which still yields correct
+ * relative-position events.
+ */
+function findScrollAncestor(start: HTMLElement | null): HTMLElement | null {
+  let current = start?.parentElement ?? null;
+  while (current) {
+    const style = window.getComputedStyle(current);
+    if (/(auto|scroll|overlay)/.test(style.overflowY)) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+
 export const PlanTableOfContents: React.FC<PlanTableOfContentsProps> = (props) => {
   // h1 is reserved for the TOC's heading (the plan title), so it never appears
   // as a list entry — but it still consumes a renderIndex because the rendered
   // DOM still contains an <h1>. h5/h6 are also hidden as visual noise.
   const visibleEntries = props.entries.filter((entry) => entry.level >= 2 && entry.level <= 4);
-  if (visibleEntries.length < 2) {
+  // If the plan's source markdown begins with an h1, clicking the TOC heading
+  // jumps to that h1 (the natural "top of plan" target). Otherwise the heading
+  // is a static label — there's nothing meaningful to scroll to.
+  const titleHeadingEntry = props.entries.find((entry) => entry.level === 1);
+
+  // Track which heading the reader has most recently scrolled past so the TOC
+  // can highlight it. `null` means we're still above the first tracked heading.
+  const [activeRenderIndex, setActiveRenderIndex] = useState<number | null>(null);
+
+  // Reset the active indicator whenever the set of tracked headings changes
+  // (e.g. during streaming or when the user reopens a different plan). The
+  // observer effect below will recompute the correct value on its next tick.
+  const titleTrackedKey = titleHeadingEntry?.renderIndex ?? -1;
+  const trackedKey = `${titleTrackedKey}|${visibleEntries.map((entry) => entry.renderIndex).join(",")}`;
+  const hasEnoughVisibleEntries = visibleEntries.length >= 2;
+
+  useEffect(() => {
+    // Mirror the visibility gate from render so we don't observe headings the
+    // user can't navigate to. The render path bails out early in that case.
+    if (!hasEnoughVisibleEntries) return;
+    const container = props.contentRef.current;
+    if (!container) return;
+    if (typeof IntersectionObserver === "undefined") return;
+
+    // Re-query headings from the live DOM so renderIndexes line up with the
+    // index-based `querySelectorAll` lookup used for click navigation.
+    const allHeadings = Array.from(container.querySelectorAll<HTMLElement>(HEADING_SELECTOR));
+    // Track both the title heading and the list entries so the title can
+    // also light up when the reader is in its lead-in section.
+    const trackedIndexes = new Set<number>();
+    for (const entry of props.entries) {
+      if (entry.level >= 2 && entry.level <= 4) trackedIndexes.add(entry.renderIndex);
+      if (entry.level === 1) trackedIndexes.add(entry.renderIndex);
+    }
+    const tracked = allHeadings.flatMap<{ el: HTMLElement; renderIndex: number }>((el, idx) =>
+      trackedIndexes.has(idx) ? [{ el, renderIndex: idx }] : []
+    );
+    if (tracked.length === 0) return;
+
+    const root = findScrollAncestor(container);
+    // Map each tracked heading to whether its top edge has crossed the trigger
+    // line. The active entry is the LAST one (in document order) that is true.
+    const passedTrigger = new WeakMap<HTMLElement, boolean>();
+
+    const triggerTop = (): number => {
+      // When `root` is null IO uses the viewport, so the trigger is measured
+      // from the viewport's top (effectively 0 + offset). Otherwise the
+      // trigger sits at the scrollport's top + offset, in viewport-coords.
+      const rootTop = root?.getBoundingClientRect().top ?? 0;
+      return rootTop + ACTIVE_TRIGGER_OFFSET_PX;
+    };
+
+    const recompute = () => {
+      let active: number | null = null;
+      for (const { el, renderIndex } of tracked) {
+        if (passedTrigger.get(el)) active = renderIndex;
+      }
+      setActiveRenderIndex(active);
+    };
+
+    // Seed each heading's passed-trigger state synchronously so the initial
+    // render shows the correct indicator without waiting for the first IO tick.
+    const initialTrigger = triggerTop();
+    for (const { el } of tracked) {
+      passedTrigger.set(el, el.getBoundingClientRect().top <= initialTrigger);
+    }
+    recompute();
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const limit = triggerTop();
+        for (const entry of entries) {
+          // `boundingClientRect.top` is the heading's top in viewport
+          // coordinates, which `limit` is also expressed in.
+          passedTrigger.set(entry.target as HTMLElement, entry.boundingClientRect.top <= limit);
+        }
+        recompute();
+      },
+      {
+        root,
+        // Threshold 0 fires whenever the heading enters or leaves the root, so
+        // we get an update at both ends of the visibility transition.
+        threshold: 0,
+      }
+    );
+    for (const { el } of tracked) observer.observe(el);
+    return () => observer.disconnect();
+    // `trackedKey` is the stable summary of which headings to observe;
+    // recreating the observer when it changes covers streaming plan growth.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [trackedKey, hasEnoughVisibleEntries, props.contentRef]);
+
+  if (!hasEnoughVisibleEntries) {
     // A TOC with 0 or 1 entries adds visual chrome without navigation value.
     // (Note: this check intentionally excludes the title, since the title is
     // a single label, not a navigable destination on its own.)
@@ -70,6 +192,10 @@ export const PlanTableOfContents: React.FC<PlanTableOfContentsProps> = (props) =
     if (target && typeof target.scrollIntoView === "function") {
       target.scrollIntoView({ block: "start" });
     }
+    // Optimistically reflect the destination as active so the indicator doesn't
+    // visibly lag behind smooth scroll animations. The observer will confirm
+    // (or correct) this once the heading settles at its resting position.
+    setActiveRenderIndex(renderIndex);
   };
 
   // Use the supplied title when non-blank; fall back to "Contents" otherwise.
@@ -77,10 +203,7 @@ export const PlanTableOfContents: React.FC<PlanTableOfContentsProps> = (props) =
   // heading line and look broken.
   const trimmedTitle = props.title?.trim();
   const headingText = trimmedTitle && trimmedTitle.length > 0 ? trimmedTitle : DEFAULT_HEADING;
-  // If the plan's source markdown begins with an h1, clicking the TOC heading
-  // jumps to that h1 (the natural "top of plan" target). Otherwise the heading
-  // is a static label — there's nothing meaningful to scroll to.
-  const titleHeadingEntry = props.entries.find((entry) => entry.level === 1);
+  const isTitleActive = activeRenderIndex === titleHeadingEntry?.renderIndex;
 
   return (
     <aside
@@ -100,7 +223,14 @@ export const PlanTableOfContents: React.FC<PlanTableOfContentsProps> = (props) =
           <TooltipIfPresent tooltip={headingText} side="right" align="start">
             <button
               type="button"
-              className="plan-toc-heading plan-toc-heading-link"
+              className={cn(
+                "plan-toc-heading plan-toc-heading-link",
+                isTitleActive && "plan-toc-heading-link-active"
+              )}
+              // `aria-current="location"` signals to assistive tech that this
+              // is the section currently in view, the standard ARIA pattern
+              // for an in-page TOC indicator.
+              aria-current={isTitleActive ? "location" : undefined}
               onClick={() => handleNavigate(titleHeadingEntry.renderIndex)}
             >
               {headingText}
@@ -110,31 +240,42 @@ export const PlanTableOfContents: React.FC<PlanTableOfContentsProps> = (props) =
           <div className="plan-toc-heading">{headingText}</div>
         )}
         <ul className="plan-toc-list">
-          {visibleEntries.map((entry) => (
-            <li
-              key={entry.renderIndex}
-              className="plan-toc-item"
-              data-level={entry.level - minLevel + 1}
-            >
-              {/*
-               * Wrap with TooltipIfPresent so users can see the full heading
-               * in one place even when the side TOC wraps long text across
-               * multiple lines in the gutter.
-               *
-               * `side="right"` keeps the tooltip from drifting off the left
-               * edge of the transcript — the toc lives in the left gutter.
-               */}
-              <TooltipIfPresent tooltip={entry.text} side="right" align="start">
-                <button
-                  type="button"
-                  className="plan-toc-link"
-                  onClick={() => handleNavigate(entry.renderIndex)}
-                >
-                  {entry.text}
-                </button>
-              </TooltipIfPresent>
-            </li>
-          ))}
+          {visibleEntries.map((entry) => {
+            const isActive = activeRenderIndex === entry.renderIndex;
+            return (
+              <li
+                key={entry.renderIndex}
+                className="plan-toc-item"
+                data-level={entry.level - minLevel + 1}
+                // `data-active` lets CSS style the whole row (e.g. a left
+                // accent rail) while `aria-current` on the button announces
+                // the active section to screen readers.
+                data-active={isActive ? "true" : undefined}
+              >
+                {/*
+                 * Wrap with TooltipIfPresent so users can see the full heading
+                 * in one place even when the side TOC wraps long text across
+                 * multiple lines in the gutter.
+                 *
+                 * `side="right"` keeps the tooltip from drifting off the left
+                 * edge of the transcript — the toc lives in the left gutter.
+                 */}
+                <TooltipIfPresent tooltip={entry.text} side="right" align="start">
+                  <button
+                    type="button"
+                    className="plan-toc-link"
+                    // `aria-current="location"` signals to assistive tech that
+                    // this section is currently in view; CSS styling keys off
+                    // the parent <li>'s `data-active` attribute.
+                    aria-current={isActive ? "location" : undefined}
+                    onClick={() => handleNavigate(entry.renderIndex)}
+                  >
+                    {entry.text}
+                  </button>
+                </TooltipIfPresent>
+              </li>
+            );
+          })}
         </ul>
       </nav>
     </aside>

--- a/src/browser/features/Tools/ProposePlan/PlanTableOfContents.tsx
+++ b/src/browser/features/Tools/ProposePlan/PlanTableOfContents.tsx
@@ -101,7 +101,6 @@ export const PlanTableOfContents: React.FC<PlanTableOfContentsProps> = (props) =
     if (!hasEnoughVisibleEntries) return;
     const container = props.contentRef.current;
     if (!container) return;
-    if (typeof IntersectionObserver === "undefined") return;
 
     // Re-query headings from the live DOM so renderIndexes line up with the
     // index-based `querySelectorAll` lookup used for click navigation.
@@ -110,8 +109,9 @@ export const PlanTableOfContents: React.FC<PlanTableOfContentsProps> = (props) =
     // also light up when the reader is in its lead-in section.
     const trackedIndexes = new Set<number>();
     for (const entry of props.entries) {
-      if (entry.level >= 2 && entry.level <= 4) trackedIndexes.add(entry.renderIndex);
-      if (entry.level === 1) trackedIndexes.add(entry.renderIndex);
+      if (entry.level === 1 || (entry.level >= 2 && entry.level <= 4)) {
+        trackedIndexes.add(entry.renderIndex);
+      }
     }
     const tracked = allHeadings.flatMap<{ el: HTMLElement; renderIndex: number }>((el, idx) =>
       trackedIndexes.has(idx) ? [{ el, renderIndex: idx }] : []
@@ -119,55 +119,59 @@ export const PlanTableOfContents: React.FC<PlanTableOfContentsProps> = (props) =
     if (tracked.length === 0) return;
 
     const root = findScrollAncestor(container);
-    // Map each tracked heading to whether its top edge has crossed the trigger
-    // line. The active entry is the LAST one (in document order) that is true.
-    const passedTrigger = new WeakMap<HTMLElement, boolean>();
-
-    const triggerTop = (): number => {
-      // When `root` is null IO uses the viewport, so the trigger is measured
-      // from the viewport's top (effectively 0 + offset). Otherwise the
-      // trigger sits at the scrollport's top + offset, in viewport-coords.
-      const rootTop = root?.getBoundingClientRect().top ?? 0;
-      return rootTop + ACTIVE_TRIGGER_OFFSET_PX;
-    };
+    // We use a scroll listener (rAF-throttled) rather than IntersectionObserver
+    // because the active heading needs to update continuously as the user
+    // scrolls THROUGH a section, not just at the section's entry/exit points.
+    // IO with `threshold: 0` only fires when a heading enters or leaves the
+    // root; while a heading is fully in view the IO is silent, so the active
+    // indicator would not advance when the heading's top crosses the trigger
+    // line mid-scroll. The per-frame rect read is O(N) over the tracked
+    // headings, which is cheap for typical plan sizes.
+    let rafId: number | null = null;
 
     const recompute = () => {
+      rafId = null;
+      // Compute the trigger line in viewport coordinates. `root` of `null`
+      // means the viewport itself is the scrolling frame.
+      const rootTop = root?.getBoundingClientRect().top ?? 0;
+      const trigger = rootTop + ACTIVE_TRIGGER_OFFSET_PX;
+
       let active: number | null = null;
       for (const { el, renderIndex } of tracked) {
-        if (passedTrigger.get(el)) active = renderIndex;
+        if (el.getBoundingClientRect().top <= trigger) active = renderIndex;
       }
       setActiveRenderIndex(active);
     };
 
-    // Seed each heading's passed-trigger state synchronously so the initial
-    // render shows the correct indicator without waiting for the first IO tick.
-    const initialTrigger = triggerTop();
-    for (const { el } of tracked) {
-      passedTrigger.set(el, el.getBoundingClientRect().top <= initialTrigger);
-    }
+    const schedule = () => {
+      if (rafId !== null) return;
+      // requestAnimationFrame coalesces bursts of scroll events into a single
+      // recompute per frame; tests that lack rAF fall back to a sync compute.
+      if (typeof requestAnimationFrame === "function") {
+        rafId = requestAnimationFrame(recompute);
+      } else {
+        recompute();
+      }
+    };
+
+    // Initial sync so the indicator reflects current scroll position on mount.
     recompute();
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const limit = triggerTop();
-        for (const entry of entries) {
-          // `boundingClientRect.top` is the heading's top in viewport
-          // coordinates, which `limit` is also expressed in.
-          passedTrigger.set(entry.target as HTMLElement, entry.boundingClientRect.top <= limit);
-        }
-        recompute();
-      },
-      {
-        root,
-        // Threshold 0 fires whenever the heading enters or leaves the root, so
-        // we get an update at both ends of the visibility transition.
-        threshold: 0,
+    const scrollTarget: EventTarget = root ?? window;
+    scrollTarget.addEventListener("scroll", schedule, { passive: true });
+    // Resizing the window can also change the trigger line's viewport y
+    // coordinate (when the root is offset from the viewport top), so refresh
+    // on resize too.
+    window.addEventListener("resize", schedule, { passive: true });
+    return () => {
+      if (rafId !== null && typeof cancelAnimationFrame === "function") {
+        cancelAnimationFrame(rafId);
       }
-    );
-    for (const { el } of tracked) observer.observe(el);
-    return () => observer.disconnect();
+      scrollTarget.removeEventListener("scroll", schedule);
+      window.removeEventListener("resize", schedule);
+    };
     // `trackedKey` is the stable summary of which headings to observe;
-    // recreating the observer when it changes covers streaming plan growth.
+    // recreating the listener when it changes covers streaming plan growth.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [trackedKey, hasEnoughVisibleEntries, props.contentRef]);
 

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -1607,35 +1607,22 @@ code {
   line-height: 1.4;
   color: color-mix(in srgb, var(--color-muted-foreground) 88%, var(--color-foreground) 12%);
   padding: 4px 0;
-  /*
-   * Geometry tokens used by both the heading and the list rows so they align
-   * by construction:
-   *   --plan-toc-rail-width  : width of the always-on guide rail (lives on
-   *                            the .plan-toc-list's border-left).
-   *   --plan-toc-rail-gap    : visual gap between that rail and the text.
-   * The heading reserves an equivalent (rail-width + rail-gap) left padding
-   * so its text starts in the same column as level-1 list rows below it,
-   * even though the heading itself sits outside the rail.
-   */
-  --plan-toc-rail-width: 2px;
-  --plan-toc-rail-gap: 8px;
 }
 
 .plan-toc-heading {
   /* The plan title sits at the top of the TOC, in place of a separate
      "CONTENTS" label. A light plan tint ties the side nav back to the plan
-     card without competing with the main content. */
+     card without competing with the main content. The title text sits flush
+     with the level-1 list rows below — no reserved gutter, no indent —
+     because the TOC carries no always-on chrome that would need to live
+     there. */
   font-size: 12px;
   font-weight: 600;
   color: color-mix(in srgb, var(--color-plan-mode) 58%, var(--color-foreground) 42%);
   margin: 0 0 6px 0;
-  /* Align the title text with the list rows below: reserve the same left
-     column the list's rail + rail-gap occupies. The title itself sits above
-     the rail (no rail glyph at this row), but its TEXT lines up with level-1
-     list rows so the TOC reads as a coherent column. */
-  padding: 2px 0 2px calc(var(--plan-toc-rail-width) + var(--plan-toc-rail-gap));
-  /* Let long plan titles wrap inside the gutter instead of wasting available
-     horizontal space and hiding useful context behind an ellipsis. */
+  padding: 2px 0;
+  /* Let long plan titles wrap instead of wasting available horizontal space
+     and hiding useful context behind an ellipsis. */
   white-space: normal;
   overflow-wrap: anywhere;
   /* Match the .plan-toc-link reset for the clickable variant. */
@@ -1672,23 +1659,20 @@ code {
   color: color-mix(in srgb, var(--color-plan-mode) 88%, var(--color-foreground) 12%);
 }
 
+/* Source order matters: declared AFTER `.plan-toc-heading-link:hover` so
+   hovering an active title brightens (rather than dropping back to the
+   weaker inactive hover tint). Both rules have identical specificity so
+   later source wins. */
+.plan-toc-heading-link-active:hover {
+  color: var(--color-plan-mode-hover);
+}
+
 .plan-toc-list {
   list-style: none;
   margin: 0;
   padding: 0;
   display: flex;
   flex-direction: column;
-  /*
-   * Always-on guide rail spanning the entire list of nav rows. The rail
-   * provides the structural anchor every row shares; the active row's
-   * segment just brightens to indicate position. Putting the rail on the
-   * ul (rather than each li's border-left) keeps it a continuous line even
-   * if siblings ever gain a `gap`.
-   *
-   * Using `--surface-plan-divider` ties the rail's neutral state back to the
-   * plan card's own dividers, so the TOC reads as part of the plan surface.
-   */
-  border-left: var(--plan-toc-rail-width) solid var(--surface-plan-divider);
 }
 
 .plan-toc-item {
@@ -1698,9 +1682,6 @@ code {
      with the title (data-level=1 → 0 indent) and deeper headings get a small
      step per level. */
   --plan-toc-indent: 0;
-  /* Needed so the active-state rail overlay can be absolutely positioned on
-     top of the ul's border-left. */
-  position: relative;
 }
 
 .plan-toc-item[data-level="1"] {
@@ -1717,9 +1698,10 @@ code {
 }
 
 .plan-toc-link {
-  /* Render as a flush text link rather than a chunky button. The rail's
-     width is absorbed by the ul's border-left, so the link only needs to
-     pad by the rail-text gap plus the per-level indent. */
+  /* Render as a flush text link rather than a chunky button. Level-1 rows
+     anchor at column 0; deeper levels indent by `--plan-toc-indent`. No
+     reserved rail gutter — the active state is signalled by COLOR only,
+     not by chrome that would need its own column. */
   appearance: none;
   background: transparent;
   border: 0;
@@ -1729,8 +1711,8 @@ code {
   cursor: pointer;
   display: block;
   width: 100%;
-  padding: 3px 0 3px calc(var(--plan-toc-rail-gap) + var(--plan-toc-indent));
-  border-radius: 0;
+  padding: 3px 0 3px var(--plan-toc-indent);
+  border-radius: 3px;
   white-space: normal;
   overflow-wrap: anywhere;
   transition: color 120ms ease;
@@ -1757,37 +1739,21 @@ code {
   outline-offset: 1px;
 }
 
-/* Active section indicator.
+/* Active section indicator: COLOR-ONLY.
  *
- * The active row brightens two things WITHOUT changing any layout-affecting
- * property:
- *   1) its segment of the shared left rail (via an absolutely-positioned
- *      overlay that sits flush on top of the ul's border-left), and
- *   2) its text color.
- *
- * Crucially we do NOT bump font-weight, add a background pill, or apply a
- * box-shadow to the link. The font-weight bump previously caused the text to
- * gain horizontal width and shift the column rightward — which read as a
- * misalignment between active and inactive rows. With this design every row
- * occupies the exact same horizontal extents in every state, and the visual
- * "you are here" cue comes purely from color brightening of structure that
- * already exists.
+ * The active row's text shifts to the plan tint so the TOC inherits the
+ * plan's identity for its "you are here" cue. Every row retains identical
+ * horizontal extents in every state — no rail, no background pill, no
+ * weight bump, no inset shadow — so the active row cannot read as shifted
+ * vs its inactive siblings. The data-attribute selector outranks the
+ * level-1 color rule above so this color wins on level-1 active rows too.
  */
-.plan-toc-item[data-active="true"]::before {
-  content: "";
-  position: absolute;
-  /* The li's content box starts AFTER the ul's border-left, so the li's
-     own left:0 sits one rail-width to the right of the rail. We offset
-     leftward by the rail's width to land the overlay flush on top of it. */
-  left: calc(var(--plan-toc-rail-width) * -1);
-  top: 0;
-  bottom: 0;
-  width: var(--plan-toc-rail-width);
-  background: var(--color-plan-mode);
+.plan-toc-item[data-active="true"] .plan-toc-link {
+  color: color-mix(in srgb, var(--color-plan-mode) 88%, var(--color-foreground) 12%);
 }
 
-.plan-toc-item[data-active="true"] .plan-toc-link {
-  color: var(--color-foreground);
+.plan-toc-item[data-active="true"] .plan-toc-link:hover {
+  color: var(--color-plan-mode-hover);
 }
 
 /* Give plan headings breathing room so scrollIntoView({block:"start"}) lands

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -1650,6 +1650,14 @@ code {
   outline-offset: 1px;
 }
 
+/* Active heading indicator. When the reader has scrolled into the plan's
+   title-level section (before any h2), highlight the title link so the TOC
+   gives a clear "you are here" cue to match the in-list item active state. */
+.plan-toc-heading-link-active {
+  color: color-mix(in srgb, var(--color-plan-mode) 78%, var(--color-foreground) 22%);
+  background: color-mix(in srgb, var(--color-plan-mode) 10%, transparent);
+}
+
 .plan-toc-list {
   list-style: none;
   margin: 0;
@@ -1715,6 +1723,35 @@ code {
 .plan-toc-link:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--color-accent) 60%, transparent);
   outline-offset: 1px;
+}
+
+/* Active section indicator.
+ *
+ * The TOC needs a "you are here" cue that survives the gutter's narrow column
+ * width and stays legible against the muted default link color. We combine
+ * three signals:
+ *   1) a plan-tinted left accent rail that visually rhymes with the plan
+ *      surface so the indicator reads as part of the same component,
+ *   2) a stronger foreground color and slight weight bump for the active
+ *      entry so it pops out of the muted list without relying on color alone,
+ *   3) a faint plan-tinted background wash to match the hover affordance
+ *      while still letting hover layer cleanly on top.
+ *
+ * The accent rail uses an inset box-shadow rather than `border-left` so the
+ * link's left padding and per-level indentation continue to line up exactly
+ * with the inactive rows above and below it.
+ */
+.plan-toc-item[data-active="true"] .plan-toc-link {
+  color: var(--color-foreground);
+  font-weight: 500;
+  background: color-mix(in srgb, var(--color-plan-mode) 8%, transparent);
+  box-shadow: inset 2px 0 0 0 color-mix(in srgb, var(--color-plan-mode) 70%, transparent);
+}
+
+.plan-toc-item[data-active="true"] .plan-toc-link:hover {
+  /* Hover should still nudge brighter so users get tactile feedback even on
+     the already-highlighted active row. */
+  background: color-mix(in srgb, var(--color-plan-mode) 14%, var(--color-hover));
 }
 
 /* Give plan headings breathing room so scrollIntoView({block:"start"}) lands

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -1607,11 +1607,18 @@ code {
   line-height: 1.4;
   color: color-mix(in srgb, var(--color-muted-foreground) 88%, var(--color-foreground) 12%);
   padding: 4px 0;
-  /* Reserved gutter on every row's left edge so the active-state accent rail
-     has somewhere to live without overlapping the link text. The 2px rail
-     plus a ~6px gap before the text lands all heading text at column 8 and
-     keeps the heading and level-1 items vertically aligned by construction. */
-  --plan-toc-rail-gutter: 8px;
+  /*
+   * Geometry tokens used by both the heading and the list rows so they align
+   * by construction:
+   *   --plan-toc-rail-width  : width of the always-on guide rail (lives on
+   *                            the .plan-toc-list's border-left).
+   *   --plan-toc-rail-gap    : visual gap between that rail and the text.
+   * The heading reserves an equivalent (rail-width + rail-gap) left padding
+   * so its text starts in the same column as level-1 list rows below it,
+   * even though the heading itself sits outside the rail.
+   */
+  --plan-toc-rail-width: 2px;
+  --plan-toc-rail-gap: 8px;
 }
 
 .plan-toc-heading {
@@ -1622,9 +1629,11 @@ code {
   font-weight: 600;
   color: color-mix(in srgb, var(--color-plan-mode) 58%, var(--color-foreground) 42%);
   margin: 0 0 6px 0;
-  /* Match the rail gutter so the heading text aligns with level-1 list items,
-     and so the active-state rail (if added) lives in the same column. */
-  padding: 2px 0 2px var(--plan-toc-rail-gutter);
+  /* Align the title text with the list rows below: reserve the same left
+     column the list's rail + rail-gap occupies. The title itself sits above
+     the rail (no rail glyph at this row), but its TEXT lines up with level-1
+     list rows so the TOC reads as a coherent column. */
+  padding: 2px 0 2px calc(var(--plan-toc-rail-width) + var(--plan-toc-rail-gap));
   /* Let long plan titles wrap inside the gutter instead of wasting available
      horizontal space and hiding useful context behind an ellipsis. */
   white-space: normal;
@@ -1642,14 +1651,11 @@ code {
   display: block;
   width: 100%;
   border-radius: 3px;
-  transition:
-    color 120ms ease,
-    background-color 120ms ease;
+  transition: color 120ms ease;
 }
 
 .plan-toc-heading-link:hover {
-  color: color-mix(in srgb, var(--color-plan-mode) 70%, var(--color-foreground) 30%);
-  background: var(--color-hover);
+  color: color-mix(in srgb, var(--color-plan-mode) 78%, var(--color-foreground) 22%);
 }
 
 .plan-toc-heading-link:focus-visible {
@@ -1658,11 +1664,12 @@ code {
 }
 
 /* Active heading indicator. When the reader has scrolled into the plan's
-   title-level section (before any h2), highlight the title link so the TOC
-   gives a clear "you are here" cue to match the in-list item active state. */
+   title-level section (before any h2), the title gets a stronger plan tint
+   to signal "you are here". Color-only — no background, no weight change —
+   so the title's text occupies the exact same horizontal extents in both
+   states and never shifts vs the list rows below. */
 .plan-toc-heading-link-active {
-  color: color-mix(in srgb, var(--color-plan-mode) 78%, var(--color-foreground) 22%);
-  background: color-mix(in srgb, var(--color-plan-mode) 10%, transparent);
+  color: color-mix(in srgb, var(--color-plan-mode) 88%, var(--color-foreground) 12%);
 }
 
 .plan-toc-list {
@@ -1671,7 +1678,17 @@ code {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  /*
+   * Always-on guide rail spanning the entire list of nav rows. The rail
+   * provides the structural anchor every row shares; the active row's
+   * segment just brightens to indicate position. Putting the rail on the
+   * ul (rather than each li's border-left) keeps it a continuous line even
+   * if siblings ever gain a `gap`.
+   *
+   * Using `--surface-plan-divider` ties the rail's neutral state back to the
+   * plan card's own dividers, so the TOC reads as part of the plan surface.
+   */
+  border-left: var(--plan-toc-rail-width) solid var(--surface-plan-divider);
 }
 
 .plan-toc-item {
@@ -1681,6 +1698,9 @@ code {
      with the title (data-level=1 → 0 indent) and deeper headings get a small
      step per level. */
   --plan-toc-indent: 0;
+  /* Needed so the active-state rail overlay can be absolutely positioned on
+     top of the ul's border-left. */
+  position: relative;
 }
 
 .plan-toc-item[data-level="1"] {
@@ -1697,10 +1717,9 @@ code {
 }
 
 .plan-toc-link {
-  /* Render as a flush text link rather than a chunky button. The link's left
-     padding is `rail-gutter + per-level-indent` so all rows reserve the same
-     gutter for the active-state accent rail while still stepping deeper
-     headings under their parent. */
+  /* Render as a flush text link rather than a chunky button. The rail's
+     width is absorbed by the ul's border-left, so the link only needs to
+     pad by the rail-text gap plus the per-level indent. */
   appearance: none;
   background: transparent;
   border: 0;
@@ -1710,23 +1729,27 @@ code {
   cursor: pointer;
   display: block;
   width: 100%;
-  padding: 2px 0 2px calc(var(--plan-toc-rail-gutter) + var(--plan-toc-indent));
-  border-radius: 3px;
+  padding: 3px 0 3px calc(var(--plan-toc-rail-gap) + var(--plan-toc-indent));
+  border-radius: 0;
   white-space: normal;
   overflow-wrap: anywhere;
-  transition:
-    color 120ms ease,
-    background-color 120ms ease;
+  transition: color 120ms ease;
 }
 
 .plan-toc-item[data-level="1"] .plan-toc-link {
-  font-weight: 500;
+  /* Top-level items are the structural anchors of the plan; render them at
+     the full foreground color with a slight weight bump even when inactive
+     so the outline is legible at a glance. Nested levels remain at the
+     muted list color until hover or active.
+     This weight bump is keyed off level — NOT off the active state — so it
+     does not change between a row's inactive and active renders and cannot
+     cause horizontal text shift the way an active-only weight bump would. */
   color: var(--color-foreground);
+  font-weight: 500;
 }
 
 .plan-toc-link:hover {
   color: var(--color-foreground);
-  background: var(--color-hover);
 }
 
 .plan-toc-link:focus-visible {
@@ -1736,34 +1759,35 @@ code {
 
 /* Active section indicator.
  *
- * The TOC needs a "you are here" cue that survives the gutter's narrow column
- * width and stays legible against the muted default link color. We combine
- * three signals:
- *   1) a plan-tinted left accent rail that visually rhymes with the plan
- *      surface so the indicator reads as part of the same component,
- *   2) a stronger foreground color and slight weight bump for the active
- *      entry so it pops out of the muted list without relying on color alone,
- *   3) a faint plan-tinted background wash to match the hover affordance
- *      while still letting hover layer cleanly on top.
+ * The active row brightens two things WITHOUT changing any layout-affecting
+ * property:
+ *   1) its segment of the shared left rail (via an absolutely-positioned
+ *      overlay that sits flush on top of the ul's border-left), and
+ *   2) its text color.
  *
- * The accent rail uses an inset box-shadow rather than `border-left` so the
- * link's left padding and per-level indentation continue to line up exactly
- * with the inactive rows above and below it. The 2px rail lives inside the
- * dedicated `--plan-toc-rail-gutter` on the link's left edge, so it never
- * overlaps the link text — even for level-1 items where the per-level indent
- * is 0.
+ * Crucially we do NOT bump font-weight, add a background pill, or apply a
+ * box-shadow to the link. The font-weight bump previously caused the text to
+ * gain horizontal width and shift the column rightward — which read as a
+ * misalignment between active and inactive rows. With this design every row
+ * occupies the exact same horizontal extents in every state, and the visual
+ * "you are here" cue comes purely from color brightening of structure that
+ * already exists.
  */
-.plan-toc-item[data-active="true"] .plan-toc-link {
-  color: var(--color-foreground);
-  font-weight: 500;
-  background: color-mix(in srgb, var(--color-plan-mode) 8%, transparent);
-  box-shadow: inset 2px 0 0 0 color-mix(in srgb, var(--color-plan-mode) 70%, transparent);
+.plan-toc-item[data-active="true"]::before {
+  content: "";
+  position: absolute;
+  /* The li's content box starts AFTER the ul's border-left, so the li's
+     own left:0 sits one rail-width to the right of the rail. We offset
+     leftward by the rail's width to land the overlay flush on top of it. */
+  left: calc(var(--plan-toc-rail-width) * -1);
+  top: 0;
+  bottom: 0;
+  width: var(--plan-toc-rail-width);
+  background: var(--color-plan-mode);
 }
 
-.plan-toc-item[data-active="true"] .plan-toc-link:hover {
-  /* Hover should still nudge brighter so users get tactile feedback even on
-     the already-highlighted active row. */
-  background: color-mix(in srgb, var(--color-plan-mode) 14%, var(--color-hover));
+.plan-toc-item[data-active="true"] .plan-toc-link {
+  color: var(--color-foreground);
 }
 
 /* Give plan headings breathing room so scrollIntoView({block:"start"}) lands

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -1607,6 +1607,11 @@ code {
   line-height: 1.4;
   color: color-mix(in srgb, var(--color-muted-foreground) 88%, var(--color-foreground) 12%);
   padding: 4px 0;
+  /* Reserved gutter on every row's left edge so the active-state accent rail
+     has somewhere to live without overlapping the link text. The 2px rail
+     plus a ~6px gap before the text lands all heading text at column 8 and
+     keeps the heading and level-1 items vertically aligned by construction. */
+  --plan-toc-rail-gutter: 8px;
 }
 
 .plan-toc-heading {
@@ -1617,7 +1622,9 @@ code {
   font-weight: 600;
   color: color-mix(in srgb, var(--color-plan-mode) 58%, var(--color-foreground) 42%);
   margin: 0 0 6px 0;
-  padding: 2px 0;
+  /* Match the rail gutter so the heading text aligns with level-1 list items,
+     and so the active-state rail (if added) lives in the same column. */
+  padding: 2px 0 2px var(--plan-toc-rail-gutter);
   /* Let long plan titles wrap inside the gutter instead of wasting available
      horizontal space and hiding useful context behind an ellipsis. */
   white-space: normal;
@@ -1690,8 +1697,10 @@ code {
 }
 
 .plan-toc-link {
-  /* Render as a flush text link rather than a chunky button. Using the same
-     zero left padding as the title is what keeps h1 and h2 visually aligned. */
+  /* Render as a flush text link rather than a chunky button. The link's left
+     padding is `rail-gutter + per-level-indent` so all rows reserve the same
+     gutter for the active-state accent rail while still stepping deeper
+     headings under their parent. */
   appearance: none;
   background: transparent;
   border: 0;
@@ -1701,7 +1710,7 @@ code {
   cursor: pointer;
   display: block;
   width: 100%;
-  padding: 2px 0 2px var(--plan-toc-indent);
+  padding: 2px 0 2px calc(var(--plan-toc-rail-gutter) + var(--plan-toc-indent));
   border-radius: 3px;
   white-space: normal;
   overflow-wrap: anywhere;
@@ -1739,7 +1748,10 @@ code {
  *
  * The accent rail uses an inset box-shadow rather than `border-left` so the
  * link's left padding and per-level indentation continue to line up exactly
- * with the inactive rows above and below it.
+ * with the inactive rows above and below it. The 2px rail lives inside the
+ * dedicated `--plan-toc-rail-gutter` on the link's left edge, so it never
+ * overlaps the link text — even for level-1 items where the per-level indent
+ * is 0.
  */
 .plan-toc-item[data-active="true"] .plan-toc-link {
   color: var(--color-foreground);


### PR DESCRIPTION
## Summary

The plan table of contents now tracks which heading the reader has most recently scrolled past and visually marks it as active, giving a clear "you are here" cue that makes long plans easier to navigate.

## Background

The sticky plan TOC already let users jump to any section, but there was no signal back from scroll position — readers could lose their place in a long plan because the TOC always looked the same regardless of how far down they had scrolled. This change closes that loop so the TOC always reflects the reader's current position.

## Implementation

- **Active detection.** A scroll listener (rAF-throttled) is attached to the nearest scrollable ancestor (the transcript scrollport) so the trigger line moves with the user's actual reading frame instead of the browser viewport. Each tracked heading's top edge is compared to a 16px trigger line (matching the existing `scroll-margin-top: 1rem` on plan headings) every frame; the active entry is the last heading in document order whose top has been passed. A scroll listener — rather than an `IntersectionObserver` — was necessary because IO with `threshold: 0` only fires at the section's entry/exit points, so the active indicator would not advance while the user scrolls THROUGH a long section.
- **Title can also light up.** The plan title (h1) is tracked too, so when the reader is in the lead-in section before any h2, the title button gets the active treatment.
- **Optimistic click.** Clicking a TOC entry immediately marks it active so the indicator doesn't visibly lag the smooth-scroll animation. The next scroll tick confirms or corrects once the heading settles.
- **Streaming-safe.** The effect is keyed on a stable string summary of the tracked heading set, so plans growing during streaming re-attach listeners cleanly.
- **Active-indicator aesthetic.** Color-only: the active row's text shifts to a stronger plan tint (`color-mix(plan-mode 88%, foreground 12%)`); hovering an active row bumps to `--color-plan-mode-hover` for tactile feedback. No rail, no background pill, no weight bump, no inset shadow — so every row occupies identical horizontal extents in every state and the column cannot visibly jitter. The title gets the same active color treatment so the indicator reads consistently between the title and the list. `aria-current="location"` is set on the active button so assistive tech announces the current section.
- **Flush layout.** Title and level-1 list rows both anchor at the TOC's content-box left edge (column 0). Deeper levels (h3, h4) step in by 8px and 16px so the outline remains scannable.

## Validation

- `make static-check` (lint, typecheck, fmt, docs) ✅
- `bun test src/browser/features/Tools/ProposePlan/PlanTableOfContents.test.tsx` — 10 pass, 0 fail.
- New `PlanTableOfContents` tests cover the scroll-driven active state transition (last-passed-heading wins), the clears-above-trigger case, and the optimistic-click path. Existing tests for filtering, indentation, click-to-scroll, and title behavior continue to pass.

## Risks

Low. The change is scoped to the plan TOC component and a small block of CSS. The optional-chain comparison `activeRenderIndex === titleHeadingEntry?.renderIndex` is intentional: when no title heading exists, the title-active state is always false because `activeRenderIndex` is `number | null`, never `undefined`. Visual regression coverage exists via the `ProposePlanWithTableOfContents` Storybook story, which Chromatic will re-snapshot.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `max` • Cost: `$12.60`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=max costs=12.60 -->
