### PR TITLE
🤖 fix: prevent compaction handoff notification pings

### DIFF
--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -3144,6 +3144,39 @@ describe("WorkspaceStore", () => {
       });
     });
 
+    it("marks background compaction stops from activity snapshots as non-notifying completions", async () => {
+      const activeWorkspaceId = "active-workspace-compaction-snapshot";
+      const backgroundWorkspaceId = "background-workspace-compaction-snapshot";
+      const initialRecency = new Date("2024-01-05T12:00:00.000Z").getTime();
+      const initialSnapshot = createActivitySnapshot(initialRecency);
+      const releaseBackgroundCompletion = mockBackgroundActivityTransition(
+        backgroundWorkspaceId,
+        initialSnapshot,
+        [
+          {
+            ...initialSnapshot,
+            recency: initialRecency + 1,
+            streaming: false,
+            isCompaction: true,
+          },
+        ]
+      );
+      const onResponseComplete = createResponseCompleteSpy();
+
+      recreateStore(onResponseComplete);
+      createAndAddWorkspace(store, activeWorkspaceId);
+      createAndAddWorkspace(store, backgroundWorkspaceId, {}, false);
+      releaseBackgroundCompletion();
+      await tick(0);
+
+      expectResponseComplete(onResponseComplete, {
+        workspaceId: backgroundWorkspaceId,
+        isFinal: true,
+        completion: { kind: "compaction" },
+        completedAt: initialRecency + 1,
+      });
+    });
+
     it("preserves internal resume metadata across background handoffs", async () => {
       const activeWorkspaceId = "active-workspace-internal-resume-background";
       const backgroundWorkspaceId = "background-workspace-internal-resume-background";
@@ -3187,7 +3220,7 @@ describe("WorkspaceStore", () => {
       expectResponseComplete(onResponseComplete, {
         workspaceId: backgroundWorkspaceId,
         isFinal: true,
-        completion: { kind: "compaction", hasAutoFollowUp: true, suppressNotification: true },
+        completion: { kind: "compaction", suppressNotification: true },
         completedAt: initialRecency + 1,
       });
     });
@@ -3307,7 +3340,7 @@ describe("WorkspaceStore", () => {
       expectResponseComplete(onResponseComplete, {
         workspaceId: backgroundWorkspaceId,
         isFinal: true,
-        completion: { kind: "compaction", hasAutoFollowUp: true },
+        completion: { kind: "compaction" },
         completedAt: initialRecency + 1,
       });
     });
@@ -3374,7 +3407,7 @@ describe("WorkspaceStore", () => {
         messageId: "compaction-stream",
         isFinal: true,
         finalText: "",
-        completion: { kind: "compaction", hasAutoFollowUp: true },
+        completion: { kind: "compaction" },
         completedAt: expect.any(Number),
       });
     });
@@ -3418,7 +3451,7 @@ describe("WorkspaceStore", () => {
       expectResponseComplete(onResponseComplete, {
         workspaceId: backgroundWorkspaceId,
         isFinal: true,
-        completion: { kind: "compaction", hasAutoFollowUp: true },
+        completion: { kind: "compaction" },
         completedAt: initialRecency + 1,
       });
     });

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -23,7 +23,7 @@ import {
   type SkillLoadError,
 } from "@/browser/utils/messages/StreamingMessageAggregator";
 import {
-  createIdleCompactionCompletion,
+  createCompactionCompletion,
   type ResponseCompleteEvent,
   type ResponseCompleteHandler,
 } from "@/browser/utils/messages/responseCompletionMetadata";
@@ -2729,12 +2729,16 @@ export class WorkspaceStore {
     const backgroundCompletion = isBackgroundStreamingStop
       ? this.aggregators.get(workspaceId)?.getActiveResponseCompleteMetadata()
       : undefined;
-    // The backend tags the streaming=false (stop) snapshot with isIdleCompaction.
-    // The idle marker is added after sendMessage returns (to avoid races with
-    // concurrent user streams), so only the stop snapshot carries the flag.
-    // Check both previous and current as defense-in-depth.
-    const wasIdleCompaction =
-      previous?.isIdleCompaction === true || snapshot?.isIdleCompaction === true;
+    // The backend tags compaction stop snapshots with an authoritative stream
+    // classification. Compaction is context-management rather than a response,
+    // so background notification policy must not fall back to "normal" if the
+    // frontend missed live compaction/follow-up events while unsubscribed.
+    // Check both previous and current as defense-in-depth against update ordering.
+    const wasCompaction =
+      previous?.isCompaction === true ||
+      snapshot?.isCompaction === true ||
+      previous?.isIdleCompaction === true ||
+      snapshot?.isIdleCompaction === true;
 
     // Trigger response completion notifications for background workspaces only when
     // activity indicates a true completion (streaming true -> false WITH recency advance).
@@ -2744,9 +2748,7 @@ export class WorkspaceStore {
       // Activity snapshots don't include message/content metadata. Reuse any
       // still-active stream context captured before this workspace was backgrounded
       // so queued follow-up handoffs remain suppressible in App notifications.
-      const completion = wasIdleCompaction
-        ? createIdleCompactionCompletion(backgroundCompletion?.hasAutoFollowUp ?? false)
-        : backgroundCompletion;
+      const completion = wasCompaction ? createCompactionCompletion() : backgroundCompletion;
       this.emitResponseComplete({
         workspaceId,
         isFinal: true,

--- a/src/browser/utils/messages/StreamingMessageAggregator.sideQuestion.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.sideQuestion.test.ts
@@ -265,7 +265,10 @@ describe("StreamingMessageAggregator /btw rendering", () => {
     const aggregator = new StreamingMessageAggregator(WORKSPACE_CREATED_AT, "ws");
     const completions: Array<{ hasAutoFollowUp: boolean | undefined }> = [];
     aggregator.onResponseComplete = (event) => {
-      completions.push({ hasAutoFollowUp: event.completion?.hasAutoFollowUp });
+      completions.push({
+        hasAutoFollowUp:
+          event.completion?.kind === "response" ? event.completion.hasAutoFollowUp : undefined,
+      });
     };
 
     appendMainAssistant(aggregator, "main-1", 1);

--- a/src/browser/utils/messages/StreamingMessageAggregator.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.test.ts
@@ -1644,7 +1644,7 @@ describe("StreamingMessageAggregator", () => {
       expect(callbackCompletedAt).toBeGreaterThanOrEqual(beforeEnd);
     });
 
-    test("marks idle compaction completions as non-notifying", () => {
+    test("marks compaction completions as non-notifying", () => {
       const workspaceId = "test-workspace-recency-idle-compaction";
       const aggregator = new StreamingMessageAggregator(TEST_CREATED_AT, workspaceId);
       let completion: Parameters<typeof shouldNotifyOnResponseComplete>[0];
@@ -1688,11 +1688,7 @@ describe("StreamingMessageAggregator", () => {
         parts: [],
       });
 
-      expect(completion).toEqual({
-        kind: "compaction",
-        hasAutoFollowUp: false,
-        isIdle: true,
-      });
+      expect(completion).toEqual({ kind: "compaction" });
       expect(shouldNotifyOnResponseComplete(completion)).toBe(false);
     });
 

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -216,10 +216,6 @@ interface StreamingContext {
 
   isComplete: boolean;
   isCompacting: boolean;
-  // Idle compaction is background maintenance, not a user-visible completion, so
-  // completion notifications must stay suppressed even for the currently selected workspace.
-  isIdleCompaction: boolean;
-  hasCompactionContinue: boolean;
   // Track the last known queued-follow-up state on the active stream itself so
   // background activity completion can still suppress intermediate notifications
   // after the workspace loses its live queued-message subscription.
@@ -1453,24 +1449,15 @@ export class StreamingMessageAggregator {
     return this.pendingCompactionRequest ?? this.getLatestHistoricalCompactionRequest();
   }
 
-  private resolveStreamStartCompaction(data: StreamStartEvent): {
-    isCompacting: boolean;
-    isIdleCompaction: boolean;
-    hasCompactionContinue: boolean;
-  } {
+  private resolveStreamStartCompaction(data: StreamStartEvent): boolean {
     // Keep stream classification separate from stream context construction so
     // continue turns after /compact do not inherit stale UI state from history.
     const streamSignalsCompaction = data.agentId === "compact" || data.mode === "compact";
     if (!streamSignalsCompaction && data.agentId != null) {
-      return { isCompacting: false, isIdleCompaction: false, hasCompactionContinue: false };
+      return false;
     }
 
-    const compactionRequest = this.getLatestUnresolvedCompactionRequest();
-    return {
-      isCompacting: streamSignalsCompaction || compactionRequest !== null,
-      isIdleCompaction: compactionRequest?.source === "idle-compaction",
-      hasCompactionContinue: Boolean(compactionRequest?.parsed.followUpContent),
-    };
+    return streamSignalsCompaction || this.getLatestUnresolvedCompactionRequest() !== null;
   }
 
   private isDefaultPostCompactionContinueTurn(): boolean {
@@ -1949,8 +1936,7 @@ export class StreamingMessageAggregator {
 
   // Unified event handlers that encapsulate all complex logic
   handleStreamStart(data: StreamStartEvent): void {
-    const { isCompacting, isIdleCompaction, hasCompactionContinue } =
-      this.resolveStreamStartCompaction(data);
+    const isCompacting = this.resolveStreamStartCompaction(data);
     const isSideQuestionAnswerStream = this.isSideQuestionAnswerStreamEvent(data);
 
     // Clear pending "starting..." UI once a main-agent turn is live. /btw
@@ -1987,8 +1973,6 @@ export class StreamingMessageAggregator {
       lastServerTimestamp: data.startTime,
       isComplete: false,
       isCompacting,
-      isIdleCompaction,
-      hasCompactionContinue,
       hasQueuedFollowUp: false,
       suppressNotification,
       isReplay: data.replay === true,

--- a/src/browser/utils/messages/responseCompletionMetadata.ts
+++ b/src/browser/utils/messages/responseCompletionMetadata.ts
@@ -13,8 +13,8 @@ export type ResponseCompleteMetadata =
     } & ResponseNotificationPolicy)
   | ({
       kind: "compaction";
-      hasAutoFollowUp: boolean;
-      isIdle?: boolean;
+      // Only used to carry synthetic follow-up suppression across background
+      // generation handoffs; compaction itself is never notify-eligible.
     } & ResponseNotificationPolicy);
 
 export interface ResponseCompleteEvent {
@@ -30,31 +30,28 @@ export type ResponseCompleteHandler = (event: ResponseCompleteEvent) => void;
 
 export interface ResponseCompletionState {
   isCompacting: boolean;
-  hasCompactionContinue: boolean;
   hasQueuedFollowUp: boolean;
   /** This stream is a synthetic implementation-detail turn and should not alert. */
   suppressNotification?: boolean;
-  // Idle compaction is maintenance work, so downstream notification policy must
-  // be able to suppress the final completion even when the workspace is selected.
-  isIdleCompaction?: boolean;
 }
 
 export function buildResponseCompleteMetadata(
   state: ResponseCompletionState
 ): ResponseCompleteMetadata | undefined {
-  const hasAutoFollowUp = state.hasCompactionContinue || state.hasQueuedFollowUp;
   const suppressNotification = state.suppressNotification === true;
-  if (!state.isCompacting && !hasAutoFollowUp && !suppressNotification) {
-    return undefined;
-  }
-
   if (state.isCompacting) {
+    // Compaction is context-management, not an assistant response. Treat every
+    // compaction boundary as non-notifiable so notification correctness never
+    // depends on racing follow-up/queue metadata.
     return {
       kind: "compaction",
-      hasAutoFollowUp,
-      ...(state.isIdleCompaction ? { isIdle: true } : {}),
       ...(suppressNotification ? { suppressNotification: true } : {}),
     };
+  }
+
+  const hasAutoFollowUp = state.hasQueuedFollowUp;
+  if (!hasAutoFollowUp && !suppressNotification) {
+    return undefined;
   }
 
   return {
@@ -68,48 +65,42 @@ export function buildAggregateResponseCompleteMetadata(
   states: Iterable<ResponseCompletionState>
 ): ResponseCompleteMetadata | undefined {
   let isCompacting = false;
-  let hasCompactionContinue = false;
   let hasQueuedFollowUp = false;
   let suppressNotification = false;
-  let isIdleCompaction = false;
 
   for (const state of states) {
     isCompacting ||= state.isCompacting;
-    hasCompactionContinue ||= state.hasCompactionContinue;
     hasQueuedFollowUp ||= state.hasQueuedFollowUp;
     suppressNotification ||= state.suppressNotification === true;
-    isIdleCompaction ||= state.isIdleCompaction === true;
   }
 
   return buildResponseCompleteMetadata({
     isCompacting,
-    hasCompactionContinue,
     hasQueuedFollowUp,
     suppressNotification,
-    isIdleCompaction,
   });
 }
 
-export function createIdleCompactionCompletion(hasAutoFollowUp: boolean): ResponseCompleteMetadata {
-  return {
-    kind: "compaction",
-    hasAutoFollowUp,
-    isIdle: true,
-  };
+export function createCompactionCompletion(): ResponseCompleteMetadata {
+  return { kind: "compaction" };
 }
 
 export function shouldNotifyOnResponseComplete(
   completion: ResponseCompleteMetadata | undefined
 ): boolean {
-  if (completion?.suppressNotification === true) {
+  if (completion === undefined) {
+    return true;
+  }
+
+  if (completion.kind === "compaction") {
     return false;
   }
 
-  if (completion?.kind === "compaction" && completion.isIdle) {
+  if (completion.suppressNotification === true) {
     return false;
   }
 
-  return completion?.hasAutoFollowUp !== true;
+  return !completion.hasAutoFollowUp;
 }
 
 export function getResponseCompleteNotificationBody(

--- a/src/common/orpc/schemas/workspace.ts
+++ b/src/common/orpc/schemas/workspace.ts
@@ -249,6 +249,10 @@ export const WorkspaceActivitySnapshotSchema = z.object({
   hasTodos: z.boolean().optional().meta({
     description: "Whether the workspace still had todos when streaming last stopped",
   }),
+  isCompaction: z.boolean().optional().meta({
+    description:
+      "Whether the current streaming activity is a compaction turn (transient UI classification)",
+  }),
   isIdleCompaction: z.boolean().optional().meta({
     description: "Whether the current streaming activity is an idle (background) compaction",
   }),

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -2610,6 +2610,56 @@ describe("WorkspaceService streaming generation guard", () => {
     expect(setStreaming).toHaveBeenCalledTimes(1);
     expect(setStreaming).toHaveBeenCalledWith(workspaceId, true, { model: "openai:gpt-4o-mini" });
   });
+  test("tags matching compaction stop snapshots and clears the generation marker", async () => {
+    const workspaceId = "ws-compaction-stream-stop";
+    const setStreaming = mock(
+      (_workspaceId: string, streaming: boolean, update: ExtensionMetadataStreamingUpdate = {}) =>
+        Promise.resolve({
+          recency: Date.now(),
+          streaming,
+          lastModel: update.model ?? null,
+          lastThinkingLevel: update.thinkingLevel ?? null,
+          hasTodos: update.hasTodos,
+          agentStatus: null,
+        })
+    );
+    const emitWorkspaceActivity = mock(
+      (_workspaceId: string, _snapshot: WorkspaceActivitySnapshot | null) => undefined
+    );
+
+    readTodosSpy = spyOn(todoStorageModule, "readTodosForSessionDir").mockResolvedValue([]);
+
+    const internals = workspaceService as unknown as {
+      extensionMetadata: ExtensionMetadataService;
+      streamingGenerations: Map<string, number>;
+      compactionStreamGenerations: Map<string, number>;
+      emitWorkspaceActivity: (
+        workspaceId: string,
+        snapshot: WorkspaceActivitySnapshot | null
+      ) => void;
+      updateStreamingStatus: (
+        workspaceId: string,
+        streaming: boolean,
+        options?: ExtensionMetadataStreamingUpdate
+      ) => Promise<void>;
+    };
+
+    internals.extensionMetadata = {
+      setStreaming,
+    } as unknown as ExtensionMetadataService;
+    internals.emitWorkspaceActivity = emitWorkspaceActivity;
+    internals.streamingGenerations.set(workspaceId, 3);
+    internals.compactionStreamGenerations.set(workspaceId, 3);
+
+    await internals.updateStreamingStatus(workspaceId, false, { generation: 3 });
+
+    expect(emitWorkspaceActivity).toHaveBeenCalledWith(
+      workspaceId,
+      expect.objectContaining({ streaming: false, isCompaction: true })
+    );
+    expect(internals.compactionStreamGenerations.has(workspaceId)).toBe(false);
+  });
+
   test("handleStreamCompletion skips recency updates for idle compaction", async () => {
     const workspaceId = "ws-idle-stream-completion";
     const setStreaming = mock(

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -1258,6 +1258,11 @@ export class WorkspaceService extends EventEmitter {
   // from waking a dedicated workspace during archive().
   private readonly archivingWorkspaces = new Set<string>();
 
+  // Tracks stream generations that are compaction turns so background stop snapshots
+  // can carry authoritative notification policy instead of forcing the frontend to
+  // infer compaction from best-effort chat replay state.
+  private readonly compactionStreamGenerations = new Map<string, number>();
+
   // Tracks workspaces undergoing idle (background) compaction so the activity snapshot
   // can tag the stream, letting the frontend suppress notifications for maintenance work.
   private readonly idleCompactingWorkspaces = new Set<string>();
@@ -1551,6 +1556,11 @@ export class WorkspaceService extends EventEmitter {
       if (isStreamStartEvent(data)) {
         const generation = (this.streamingGenerations.get(data.workspaceId) ?? 0) + 1;
         this.streamingGenerations.set(data.workspaceId, generation);
+        if (data.agentId === "compact" || data.mode === "compact") {
+          this.compactionStreamGenerations.set(data.workspaceId, generation);
+        } else {
+          this.compactionStreamGenerations.delete(data.workspaceId);
+        }
         void this.updateStreamingStatus(data.workspaceId, true, {
           model: data.model,
           thinkingLevel: data.thinkingLevel,
@@ -1690,6 +1700,7 @@ export class WorkspaceService extends EventEmitter {
     streaming: boolean,
     update: ExtensionMetadataStreamingUpdate = {}
   ): Promise<void> {
+    const streamGeneration = update.generation ?? this.streamingGenerations.get(workspaceId) ?? 0;
     try {
       let { hasTodos, todoStatus } = update;
       if (!streaming && (hasTodos === undefined || todoStatus === undefined)) {
@@ -1721,19 +1732,27 @@ export class WorkspaceService extends EventEmitter {
         ...(todoStatus !== undefined ? { todoStatus } : {}),
         ...(hasTodos !== undefined ? { hasTodos } : {}),
       });
-      // Idle compaction tagging is stop-snapshot only. Never tag streaming=true updates,
-      // otherwise fast follow-up turns can inherit stale idle metadata before cleanup runs.
+      // Compaction tagging is stop-snapshot only. Never tag streaming=true updates,
+      // otherwise fast follow-up turns can inherit stale compaction metadata before cleanup runs.
+      const shouldTagCompaction =
+        !streaming && this.compactionStreamGenerations.get(workspaceId) === streamGeneration;
       const shouldTagIdleCompaction = !streaming && this.idleCompactingWorkspaces.has(workspaceId);
-      this.emitWorkspaceActivity(
-        workspaceId,
-        shouldTagIdleCompaction ? { ...snapshot, isIdleCompaction: true } : snapshot
-      );
+      this.emitWorkspaceActivity(workspaceId, {
+        ...snapshot,
+        ...(shouldTagCompaction ? { isCompaction: true } : {}),
+        ...(shouldTagIdleCompaction ? { isIdleCompaction: true } : {}),
+      });
     } catch (error) {
       log.error("Failed to update workspace streaming status", { workspaceId, error });
     } finally {
-      // Idle compaction marker is turn-scoped. Always clear on streaming=false transitions,
-      // even when metadata writes fail, so stale state cannot leak into future user streams.
+      // Compaction markers are turn-scoped. Always clear matching streaming=false
+      // transitions, even when metadata writes fail, so stale state cannot leak into
+      // future user streams. Match by generation so an old stop cannot clear a newer
+      // compaction that started while the stop snapshot was doing async work.
       if (!streaming) {
+        if (this.compactionStreamGenerations.get(workspaceId) === streamGeneration) {
+          this.compactionStreamGenerations.delete(workspaceId);
+        }
         this.idleCompactingWorkspaces.delete(workspaceId);
       }
     }

--- a/tests/ui/compaction/compaction.test.ts
+++ b/tests/ui/compaction/compaction.test.ts
@@ -493,7 +493,7 @@ describe("Auto-follow-up and compaction notification behavior (mock AI router)",
     }
   }, 60_000);
 
-  test("compaction without continue message should fire notification with 'Compaction complete'", async () => {
+  test("compaction without continue message should not fire a notification", async () => {
     const { app, countAfterSeed, cleanup } = await setupNotificationTest(
       "Seed for standalone compaction"
     );
@@ -501,10 +501,9 @@ describe("Auto-follow-up and compaction notification behavior (mock AI router)",
     try {
       await app.chat.send("/compact -t 500");
       await app.chat.expectTranscriptContains("Mock compaction summary:");
+      await app.chat.expectStreamComplete();
 
-      const { newCount, last } = await waitForNewNotifications(countAfterSeed);
-      expect(newCount).toBe(1);
-      expect(last.body).toBe("Compaction complete");
+      expect(notifications.length).toBe(countAfterSeed);
     } finally {
       await cleanup();
     }


### PR DESCRIPTION
## Summary

Simplifies notify-on-response policy so compaction completions are treated as context-management handoffs instead of user-visible assistant responses. This prevents notification pings when compaction is followed by an auto-continue message, including background/unsubscribed workspace paths.

## Background

The prior policy split notification suppression across renderer stream state, compaction/follow-up message metadata, and workspace activity snapshots. When a compaction completed in the background, the renderer could receive only a generic `streaming: false` activity update and fall back to `completion: undefined`, which is notify-eligible.

## Implementation

- Makes `kind: "compaction"` completions never notify-eligible.
- Adds transient `isCompaction` activity snapshot classification from backend stream generations.
- Uses that backend classification for background completion metadata instead of relying on replayed chat state.
- Removes fragile compaction follow-up fields from the renderer notification metadata path while preserving synthetic internal-resume suppression for follow-up handoffs.
- Updates UI integration coverage to assert standalone compaction does not produce a notification.

## Validation

- `bun test src/browser/utils/messages/StreamingMessageAggregator.test.ts src/browser/utils/messages/StreamingMessageAggregator.sideQuestion.test.ts src/browser/stores/WorkspaceStore.test.ts src/node/services/workspaceService.test.ts`
- `TEST_INTEGRATION=1 bun x jest tests/ui/compaction/compaction.test.ts -t "compaction without continue message" --runInBand`
- `make typecheck`
- `make fmt-check`
- `make lint`
- `make static-check`

## Risks

Compaction completion notifications are now suppressed universally, including manual `/compact` without a follow-up. This is intentional to keep notification semantics simple and durable: only assistant response completions should ping.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$40.83`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=40.83 -->
