### PR TITLE
🤖 fix: stabilize coalesced transcript tool rows

### DIFF
--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -1213,6 +1213,8 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
                           {renderCoalesceSummary && toolCoalesceGroup && toggleCoalesceGroup && (
                             <CoalescedToolCall
                               kind={toolCoalesceGroup.kind}
+                              reserveActionSlot={toolCoalesceGroup.reserveActionSlot}
+                              status={toolCoalesceGroup.status}
                               filePaths={toolCoalesceGroup.filePaths}
                               expanded={isToolCoalesceExpanded}
                               onToggle={toggleCoalesceGroup}

--- a/src/browser/features/Tools/CoalescedToolCall.layout.stories.tsx
+++ b/src/browser/features/Tools/CoalescedToolCall.layout.stories.tsx
@@ -1,0 +1,164 @@
+import type { ReactElement, ReactNode } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { waitFor } from "@storybook/test";
+
+import { CoalescedToolCall } from "@/browser/features/Tools/CoalescedToolCall";
+import { FileEditToolCall } from "@/browser/features/Tools/FileEditToolCall";
+import { FileReadToolCall } from "@/browser/features/Tools/FileReadToolCall";
+import { CHROMATIC_DISABLED, lightweightMeta } from "@/browser/stories/meta.js";
+
+const NOOP = () => undefined;
+
+function ToolProbe(props: { id: string; children: ReactNode }): ReactElement {
+  return <div data-testid={props.id}>{props.children}</div>;
+}
+
+function getToolSurface(root: HTMLElement, id: string): HTMLElement {
+  const probe = root.querySelector(`[data-testid="${id}"]`);
+  const surface = probe?.querySelector<HTMLElement>('[data-transcript-row-surface="tool"]');
+  if (!surface) {
+    throw new Error(`Missing tool surface for ${id}`);
+  }
+  return surface;
+}
+
+function assertHeightParity(a: HTMLElement, b: HTMLElement, label: string): void {
+  const delta = Math.abs(a.getBoundingClientRect().height - b.getBoundingClientRect().height);
+  if (delta > 1) {
+    throw new Error(`${label} changed by ${delta.toFixed(2)}px`);
+  }
+}
+
+function assertNoLayoutTransition(surface: HTMLElement, label: string): void {
+  const transitionProperty = getComputedStyle(surface).transitionProperty;
+  const forbiddenProperties = ["all", "height", "max-height", "padding", "margin"];
+
+  for (const property of forbiddenProperties) {
+    if (transitionProperty.includes(property)) {
+      throw new Error(`${label} must not transition ${property}; got ${transitionProperty}`);
+    }
+  }
+}
+
+function LayoutContractFixture(): ReactElement {
+  return (
+    <div className="bg-background p-6">
+      <div className="w-[640px] leading-[1.5] break-words whitespace-pre-wrap">
+        <ToolProbe id="single-read">
+          <FileReadToolCall
+            args={{ path: "src/App.tsx" }}
+            result={{
+              success: true,
+              content: "1\tconsole.log('hello');",
+              file_size: 21,
+              modifiedTime: "2026-05-26T00:00:00.000Z",
+              lines_read: 1,
+            }}
+            status="completed"
+          />
+        </ToolProbe>
+
+        <ToolProbe id="coalesced-read">
+          <CoalescedToolCall
+            kind="file_read"
+            filePaths={["src/App.tsx", "src/main.ts"]}
+            status="completed"
+            expanded={false}
+            onToggle={NOOP}
+          />
+        </ToolProbe>
+
+        <ToolProbe id="single-edit">
+          <FileEditToolCall
+            toolName="file_edit_replace_string"
+            args={{ path: "src/App.tsx", old_string: "hello", new_string: "hi" }}
+            result={{
+              success: true,
+              diff: "--- src/App.tsx\n+++ src/App.tsx\n@@ -1 +1 @@\n-hello\n+hi",
+              edits_applied: 1,
+            }}
+            status="completed"
+          />
+        </ToolProbe>
+
+        <ToolProbe id="coalesced-edit">
+          <CoalescedToolCall
+            reserveActionSlot={true}
+            kind="file_edit"
+            filePaths={["src/App.tsx", "src/main.ts"]}
+            status="completed"
+            expanded={false}
+            onToggle={NOOP}
+          />
+        </ToolProbe>
+
+        <div className="w-[280px]">
+          <ToolProbe id="narrow-coalesced-read">
+            <CoalescedToolCall
+              kind="file_read"
+              filePaths={[
+                "src/browser/features/Tools/CoalescedToolCall.layout.stories.tsx",
+                "src/browser/components/ChatPane/ChatPane.tsx",
+              ]}
+              status="executing"
+              expanded={false}
+              onToggle={NOOP}
+            />
+          </ToolProbe>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const meta: Meta = {
+  ...lightweightMeta,
+  title: "App/Chat/Tools/CoalescedToolCall Layout Contract",
+  component: LayoutContractFixture,
+  parameters: {
+    ...lightweightMeta.parameters,
+    chromatic: CHROMATIC_DISABLED,
+  },
+  render: () => <LayoutContractFixture />,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Real-browser layout guardrail for transcript row swaps. Coalesced summaries
+ * replace the head tool row in-place, so their collapsed height and transition
+ * contract must stay aligned with the single-row tool baseline.
+ */
+export const StableRowSwapContract: Story = {
+  play: async ({ canvasElement }) => {
+    const root = canvasElement.ownerDocument.body;
+
+    await waitFor(() => {
+      if (!root.querySelector('[data-testid="coalesced-read"]')) {
+        throw new Error("Coalesced read probe has not rendered yet");
+      }
+    });
+
+    const singleRead = getToolSurface(root, "single-read");
+    const coalescedRead = getToolSurface(root, "coalesced-read");
+    const singleEdit = getToolSurface(root, "single-edit");
+    const coalescedEdit = getToolSurface(root, "coalesced-edit");
+    const narrowCoalescedRead = getToolSurface(root, "narrow-coalesced-read");
+
+    assertHeightParity(singleRead, coalescedRead, "file_read coalesce summary row height");
+    assertHeightParity(singleEdit, coalescedEdit, "file_edit coalesce summary row height");
+    assertHeightParity(singleRead, narrowCoalescedRead, "narrow coalesce summary stays one row");
+
+    for (const [label, surface] of [
+      ["single read", singleRead],
+      ["coalesced read", coalescedRead],
+      ["single edit", singleEdit],
+      ["coalesced edit", coalescedEdit],
+      ["narrow coalesced read", narrowCoalescedRead],
+    ] as const) {
+      assertNoLayoutTransition(surface, label);
+    }
+  },
+};

--- a/src/browser/features/Tools/CoalescedToolCall.test.tsx
+++ b/src/browser/features/Tools/CoalescedToolCall.test.tsx
@@ -56,6 +56,22 @@ describe("CoalescedToolCall", () => {
     expect(view.getByText(/Wrote files/)).toBeTruthy();
   });
 
+  test("surfaces aggregate live status while individual members are hidden", () => {
+    const view = render(
+      <TooltipProvider>
+        <CoalescedToolCall
+          kind="file_read"
+          filePaths={["a.ts", "b.ts"]}
+          status="executing"
+          expanded={false}
+          onToggle={noop}
+        />
+      </TooltipProvider>
+    );
+
+    expect(view.getByText("executing")).toBeTruthy();
+  });
+
   test("clicking the header fires onToggle and reflects aria-expanded state", () => {
     const onToggle = mock(noop);
     const view = render(

--- a/src/browser/features/Tools/CoalescedToolCall.tsx
+++ b/src/browser/features/Tools/CoalescedToolCall.tsx
@@ -1,7 +1,14 @@
 import React from "react";
 import { FileIcon } from "@/browser/components/FileIcon/FileIcon";
-import { ToolContainer, ToolHeader, ExpandIcon, ToolIcon } from "./Shared/ToolPrimitives";
-import type { ToolCoalesceKind } from "@/browser/utils/messages/toolCoalescing";
+import {
+  ToolContainer,
+  ToolHeader,
+  ExpandIcon,
+  ToolIcon,
+  StatusIndicator,
+} from "./Shared/ToolPrimitives";
+import { getStatusDisplay } from "./Shared/toolUtils";
+import type { ToolCoalesceKind, ToolCoalesceStatus } from "@/browser/utils/messages/toolCoalescing";
 
 /**
  * Summary row that takes the place of the head call in a coalesced tool group.
@@ -44,6 +51,10 @@ interface CoalescedToolCallProps {
    * that the user can see by expanding.
    */
   filePaths: string[];
+  /** Reserve the trailing action slot from the replaced head row for height parity. */
+  reserveActionSlot?: boolean;
+  /** Aggregate status for the hidden members, surfaced while collapsed. */
+  status?: ToolCoalesceStatus;
   /** Whether the group is currently expanded. */
   expanded: boolean;
   /** Toggle the group's expansion state. */
@@ -53,6 +64,8 @@ interface CoalescedToolCallProps {
 export const CoalescedToolCall: React.FC<CoalescedToolCallProps> = ({
   kind,
   filePaths,
+  reserveActionSlot = false,
+  status = "completed",
   expanded,
   onToggle,
 }) => {
@@ -80,13 +93,14 @@ export const CoalescedToolCall: React.FC<CoalescedToolCallProps> = ({
   // visual anchor that matches the single-call layout.
   const leadingPath = uniquePaths[0] ?? "";
   const joinedPaths = uniquePaths.join(", ");
+  const showStatus = kind !== "file_edit" || status !== "completed";
 
   return (
     <ToolContainer expanded={false} className="@container">
       <ToolHeader onClick={onToggle} aria-expanded={expanded}>
         <ExpandIcon expanded={expanded}>▶</ExpandIcon>
         <ToolIcon toolName={iconToolName} />
-        <div className="text-text flex min-w-0 flex-1 items-center gap-1.5">
+        <div className="text-text flex max-w-96 min-w-0 items-center gap-1.5">
           <span className="shrink-0">
             {verb} {noun}
           </span>
@@ -100,6 +114,16 @@ export const CoalescedToolCall: React.FC<CoalescedToolCallProps> = ({
         <span className="text-secondary ml-2 shrink-0 text-[10px] whitespace-nowrap">
           {fileCount}
         </span>
+        {showStatus && (
+          <StatusIndicator status={status}>{getStatusDisplay(status)}</StatusIndicator>
+        )}
+        {reserveActionSlot && (
+          <div className="mr-2" aria-hidden="true">
+            <span className="font-primary text-foreground invisible flex items-center justify-center rounded-[3px] border border-white/20 px-2 py-0.5 text-[10px] whitespace-nowrap">
+              ⋮
+            </span>
+          </div>
+        )}
       </ToolHeader>
     </ToolContainer>
   );

--- a/src/browser/features/Tools/FileEdit/FileEditToolCall.stories.tsx
+++ b/src/browser/features/Tools/FileEdit/FileEditToolCall.stories.tsx
@@ -84,6 +84,7 @@ function FileEditCard(props: { path: string; diff: string }) {
       toolName="file_edit_replace_string"
       args={{ path: props.path, old_string: "...", new_string: "..." }}
       result={{ success: true, diff: props.diff, edits_applied: 1 }}
+      initialExpanded={true}
       status="completed"
     />
   );

--- a/src/browser/features/Tools/FileEditToolCall.tsx
+++ b/src/browser/features/Tools/FileEditToolCall.tsx
@@ -90,6 +90,8 @@ interface FileEditToolCallProps {
   args: FileEditOperationArgs;
   result?: FileEditToolResult;
   status?: ToolStatus;
+  /** Story/test escape hatch for cases that intentionally inspect the rendered diff. */
+  initialExpanded?: boolean;
   onReviewNote?: (data: ReviewNoteData) => void;
 }
 
@@ -153,12 +155,12 @@ export const FileEditToolCall: React.FC<FileEditToolCallProps> = ({
   args,
   result,
   status = "pending",
+  initialExpanded = false,
   onReviewNote,
 }) => {
-  // Collapse failed edits by default since they're common and expected
-  const isFailed = result && !result.success;
-  const initialExpanded = !isFailed;
-
+  // File edits share the collapsed one-line baseline used by coalesced file-tool summaries.
+  // If the first edit in a burst expanded by default, the second edit would shrink it into
+  // a summary row and cause a visible transcript layout flash.
   const { expanded, toggleExpanded } = useToolExpansion(initialExpanded);
   const [showRaw, setShowRaw] = React.useState(false);
   const [showInvocation, setShowInvocation] = React.useState(false);

--- a/src/browser/features/Tools/Shared/ToolPrimitives.tsx
+++ b/src/browser/features/Tools/Shared/ToolPrimitives.tsx
@@ -48,8 +48,11 @@ interface ToolContainerProps extends React.HTMLAttributes<HTMLDivElement> {
 
 export const ToolContainer: React.FC<ToolContainerProps> = ({ expanded, className, ...props }) => (
   <div
+    data-transcript-row-surface="tool"
     className={cn(
-      "my-2 rounded font-mono text-[11px] transition-all duration-200",
+      // Transcript scroll pinning depends on row size settling before paint. Never animate
+      // layout-affecting properties here; coalescing swaps one tool row for another in-place.
+      "my-2 rounded font-mono text-[11px] transition-colors duration-200",
       "[container-type:inline-size]",
       expanded ? "py-2 px-3" : "py-1 px-3",
       className

--- a/src/browser/utils/messages/toolCoalescing.test.ts
+++ b/src/browser/utils/messages/toolCoalescing.test.ts
@@ -3,11 +3,14 @@ import { describe, it, expect } from "@jest/globals";
 import { computeToolCoalesceInfos, type ToolCoalesceInfo } from "./toolCoalescing";
 import type { DisplayedMessage } from "@/common/types/message";
 
+type ToolMessage = Extract<DisplayedMessage, { type: "tool" }>;
+
 function fileReadMessage(
   id: string,
   path: string,
-  historySequence: number
-): Extract<DisplayedMessage, { type: "tool" }> {
+  historySequence: number,
+  status: ToolMessage["status"] = "completed"
+): ToolMessage {
   return {
     type: "tool",
     id,
@@ -15,8 +18,11 @@ function fileReadMessage(
     toolCallId: `tc-${id}`,
     toolName: "file_read",
     args: { path },
-    result: { success: true, content: "", file_size: 0, modifiedTime: "", lines_read: 0 },
-    status: "completed",
+    result:
+      status === "completed"
+        ? { success: true, content: "", file_size: 0, modifiedTime: "", lines_read: 0 }
+        : undefined,
+    status,
     isPartial: false,
     historySequence,
   };
@@ -76,6 +82,7 @@ describe("computeToolCoalesceInfos", () => {
     expect(head).toMatchObject({
       kind: "file_read",
       position: "head",
+      status: "completed",
       totalCount: 2,
       headIndex: 0,
       filePaths: ["/a.ts", "/b.ts"],
@@ -113,6 +120,7 @@ describe("computeToolCoalesceInfos", () => {
     expect(infoAt(messages, 0)).toMatchObject({
       kind: "file_edit",
       position: "head",
+      reserveActionSlot: true,
       totalCount: 3,
       filePaths: ["/a.ts", "/b.ts", "/c.ts"],
     });
@@ -228,15 +236,48 @@ describe("computeToolCoalesceInfos", () => {
     expect(infoAt(messages, 2)).toBeUndefined();
   });
 
-  it("does not coalesce a group with a still-running member", () => {
-    // Mid-stream a fresh tool call is `executing`; the summary row hides
-    // that status until the user expands, so refuse to coalesce.
-    const running = fileReadMessage("2", "/b.ts", 2);
-    running.status = "executing";
-    const messages: DisplayedMessage[] = [fileReadMessage("1", "/a.ts", 1), running];
+  it("does not coalesce interrupted or redacted members", () => {
+    for (const status of ["interrupted", "redacted"] as const) {
+      const messages: DisplayedMessage[] = [
+        fileReadMessage("1", "/a.ts", 1),
+        fileReadMessage("2", "/b.ts", 2, status),
+      ];
 
-    expect(infoAt(messages, 0)).toBeUndefined();
-    expect(infoAt(messages, 1)).toBeUndefined();
+      expect(infoAt(messages, 0)).toBeUndefined();
+      expect(infoAt(messages, 1)).toBeUndefined();
+    }
+  });
+
+  it("coalesces a group with a still-running member and surfaces executing status", () => {
+    // Coalesce live file bursts as soon as the next call appears so the second
+    // row does not briefly insert and then disappear on completion.
+    const messages: DisplayedMessage[] = [
+      fileReadMessage("1", "/a.ts", 1),
+      fileReadMessage("2", "/b.ts", 2, "executing"),
+    ];
+
+    expect(infoAt(messages, 0)).toMatchObject({ position: "head", status: "executing" });
+    expect(infoAt(messages, 1)).toMatchObject({ position: "member", status: "executing" });
+  });
+
+  it("prioritizes executing over pending in the aggregate status", () => {
+    const messages: DisplayedMessage[] = [
+      fileReadMessage("1", "/a.ts", 1, "pending"),
+      fileReadMessage("2", "/b.ts", 2, "executing"),
+      fileReadMessage("3", "/c.ts", 3),
+    ];
+
+    expect(infoAt(messages, 0)?.status).toBe("executing");
+  });
+
+  it("coalesces a group with a pending member and surfaces pending status", () => {
+    const messages: DisplayedMessage[] = [
+      fileReadMessage("1", "/a.ts", 1),
+      fileReadMessage("2", "/b.ts", 2, "pending"),
+    ];
+
+    expect(infoAt(messages, 0)).toMatchObject({ position: "head", status: "pending" });
+    expect(infoAt(messages, 1)).toMatchObject({ position: "member", status: "pending" });
   });
 
   it("still coalesces a group when every member is completed", () => {

--- a/src/browser/utils/messages/toolCoalescing.ts
+++ b/src/browser/utils/messages/toolCoalescing.ts
@@ -41,6 +41,9 @@ const FILE_EDIT_TOOL_NAMES = new Set<string>([
 /** Minimum group size before we coalesce. Below this we just render normally. */
 const MIN_COALESCE_GROUP_SIZE = 2;
 
+/** Statuses whose tool row can be summarized without hiding errors/interruption UI. */
+export type ToolCoalesceStatus = "pending" | "executing" | "completed";
+
 /**
  * Information about a tool message's position within a coalesced group.
  * Aligned with the messages array passed to {@link computeToolCoalesceInfos}.
@@ -57,6 +60,10 @@ export interface ToolCoalesceInfo {
    * normally when expanded.
    */
   position: "head" | "member";
+  /** Aggregate status surfaced by the summary while live members are hidden. */
+  status: ToolCoalesceStatus;
+  /** Reserve the head row's trailing action area so summary swaps keep the same height. */
+  reserveActionSlot: boolean;
   /** Total number of tool calls coalesced into this group (>= 2). */
   totalCount: number;
   /** Index of the head message; used as the expansion-state key. */
@@ -77,17 +84,46 @@ function getCoalesceKind(msg: DisplayedMessage | undefined): ToolCoalesceKind | 
 }
 
 /**
- * A coalesceable member is a tool call whose row carries no actionable
- * signal the user would lose if hidden. Individual tool rows surface
- * status (pending/executing/failed/interrupted/redacted) and inline
- * errors, and partial rows render an InterruptedBarrier. The summary
- * row deliberately renders none of those, so any non-completed or
- * partial member forces the whole group back to normal rendering.
+ * A coalesceable member is a tool call whose status can be faithfully surfaced
+ * by the summary row. Live pending/executing calls should coalesce immediately
+ * so a fresh file_read does not briefly insert its own row and then disappear
+ * on completion. Errors, interruptions, redaction, and partial rows still force
+ * normal rendering because they carry row-local UI (error details/barriers) that
+ * must stay visible without requiring the user to expand the group first.
  */
-function isCoalesceableToolMember(msg: DisplayedMessage | undefined): boolean {
-  if (msg?.type !== "tool") return false;
-  if (msg.isPartial) return false;
-  return msg.status === "completed";
+function getCoalesceableStatus(msg: DisplayedMessage | undefined): ToolCoalesceStatus | undefined {
+  if (msg?.type !== "tool") return undefined;
+  if (msg.isPartial) return undefined;
+  if (msg.status === "pending" || msg.status === "executing" || msg.status === "completed") {
+    return msg.status;
+  }
+  return undefined;
+}
+
+function shouldReserveActionSlot(
+  messages: DisplayedMessage[],
+  headIndex: number,
+  kind: ToolCoalesceKind
+): boolean {
+  const head = messages[headIndex];
+  // Completed file edits expose a kebab menu in their normal collapsed row. The
+  // summary row has no equivalent actions, but reserving the same trailing slot
+  // prevents the head row from shrinking when it is replaced by the summary.
+  return kind === "file_edit" && head?.type === "tool" && head.result != null;
+}
+
+function getGroupStatus(
+  messages: DisplayedMessage[],
+  start: number,
+  end: number
+): ToolCoalesceStatus {
+  let sawPending = false;
+  for (let j = start; j <= end; j++) {
+    const status = getCoalesceableStatus(messages[j]);
+    if (status === "executing") return "executing";
+    if (status === "pending") sawPending = true;
+  }
+  return sawPending ? "pending" : "completed";
 }
 
 /**
@@ -121,20 +157,21 @@ export function computeToolCoalesceInfos(
 
     const groupSize = groupEnd - index + 1;
 
-    // Skip coalescing if any member is not safely coalesceable (still
-    // running, failed, interrupted, redacted, or partial). Those rows
-    // carry status/error UI or an InterruptedBarrier that the summary
-    // row deliberately does not render, so hiding them would eat the
-    // signal until the user manually expands the group.
+    // Skip coalescing if any member is not safely coalesceable. Live
+    // pending/executing statuses are represented on the summary row; failures,
+    // interruptions, redactions, and partial rows remain normal rows so their
+    // actionable UI is never hidden behind expansion.
     let allMembersCoalesceable = true;
     for (let j = index; j <= groupEnd; j++) {
-      if (!isCoalesceableToolMember(messages[j])) {
+      if (!getCoalesceableStatus(messages[j])) {
         allMembersCoalesceable = false;
         break;
       }
     }
 
     if (groupSize >= MIN_COALESCE_GROUP_SIZE && allMembersCoalesceable) {
+      const reserveActionSlot = shouldReserveActionSlot(messages, index, kind);
+      const status = getGroupStatus(messages, index, groupEnd);
       const filePaths: string[] = [];
       for (let j = index; j <= groupEnd; j++) {
         const candidate = messages[j];
@@ -147,6 +184,8 @@ export function computeToolCoalesceInfos(
         infos[j] = {
           kind,
           position: j === index ? "head" : "member",
+          reserveActionSlot,
+          status,
           totalCount: groupSize,
           headIndex: index,
           filePaths,


### PR DESCRIPTION
## Summary

Stabilizes the coalesced file-tool transcript rows introduced in #3379 so file-read/file-edit bursts keep a one-row baseline while streaming, and adds a real-browser Storybook layout contract to catch future row-height regressions.

## Background

The original coalescing path waited until every member was completed before hiding follow-up rows. That preserved non-completed status UI, but it meant a second `file_read` could briefly render as its own row and then disappear into the summary when it completed, causing exactly the layout flash the coalesce row was meant to avoid.

## Implementation

- Coalescing now includes `pending`, `executing`, and `completed` file-tool rows, with an aggregate status rendered on the summary row.
- Failed, interrupted, redacted, and partial rows still break coalescing so error details and interruption barriers remain visible without expansion.
- Tool containers no longer use `transition-all`; they only transition colors so transcript row size changes settle immediately for scroll pinning.
- Successful file-edit rows now default to the same collapsed one-line baseline as the coalesced edit summary, with stories that inspect diffs opting into `initialExpanded` explicitly.
- Coalesced edit summaries reserve the head row's trailing action slot when replacing a completed edit row, preventing the summary from shrinking relative to the row it replaced.
- Added a Chromatic-disabled Storybook layout-contract story that checks coalesced rows match single tool-row heights and reject layout-affecting transitions.

## Validation

- `bun test ./src/browser/utils/messages/toolCoalescing.test.ts ./src/browser/features/Tools/CoalescedToolCall.test.tsx ./src/browser/features/Tools/FileEditToolCall.test.ts`
- `bun test ./tests/ui/storybook/`
- `make storybook-build`
- `make test-storybook`
- `make static-check`

## Risks

Low-to-medium UX risk in the transcript tool rows: single successful file edits now start collapsed by default to maintain the same stable baseline used for coalescing. The diff remains one click away, and existing diff-focused Storybook coverage opts back into expanded rendering.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$33.38`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=33.38 -->
