### PR TITLE
🤖 fix: make /btw side question stickiness dismissable

### DIFF
--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -494,7 +494,22 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
 
   const activeSideQuestionScrollHoldTargetRef = useRef<string | null>(null);
 
+  // User-dismissed side question stickiness: any historyId in this set is
+  // permanently exempt from the scroll-hold for the lifetime of the workspace
+  // session. This is the deterministic escape hatch from the various heuristic
+  // hold-release paths (wheel / mousedown / key / touch / jump-to-bottom), which
+  // have been the source of recurring bugs. The set is keyed by the side
+  // question user-message historyId, but is also consulted when the associated
+  // side-answer is the active target (the hold logic aligns to the question
+  // row in both cases).
+  const dismissedSideQuestionStickyIdsRef = useRef<Set<string>>(new Set());
+
   const clearActiveSideQuestionScrollHold = useCallback(() => {
+    activeSideQuestionScrollHoldTargetRef.current = null;
+  }, []);
+
+  const handleDismissSideQuestionSticky = useCallback((historyId: string) => {
+    dismissedSideQuestionStickyIdsRef.current.add(historyId);
     activeSideQuestionScrollHoldTargetRef.current = null;
   }, []);
 
@@ -506,6 +521,11 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
       heldSideAnswerIds: new Set<string>(),
     };
     activeSideQuestionScrollHoldTargetRef.current = null;
+    // A workspace switch unloads the side-question rows that were dismissed,
+    // so the dismissal set is no longer meaningful. Reset to avoid leaking
+    // historyIds across workspaces (and to allow a fresh first-time hold if
+    // the same workspace is later reopened with new branches).
+    dismissedSideQuestionStickyIdsRef.current = new Set();
   }, [workspaceId]);
 
   useLayoutEffect(() => {
@@ -517,6 +537,48 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
       findSideQuestionScrollHoldTarget(deferredMessages, sideQuestionScrollHoldRef.current);
     sideQuestionScrollHoldRef.current = nextState;
 
+    const dismissedIds = dismissedSideQuestionStickyIdsRef.current;
+    // The dismiss set tracks the side-question row's historyId. Some active
+    // holds use the side-answer's historyId as the target when the question
+    // row is not yet present in the displayed slice; resolve both directions
+    // by checking if the active target's neighbour pair has been dismissed.
+    const isTargetDismissed = (historyId: string | null | undefined): boolean => {
+      if (!historyId) return false;
+      if (dismissedIds.has(historyId)) return true;
+      const index = deferredMessages.findIndex(
+        (message) =>
+          (message.type === "user" || message.type === "assistant") &&
+          message.historyId === historyId
+      );
+      if (index === -1) return false;
+      const message = deferredMessages[index];
+      if (message.type === "assistant" && message.isSideAnswer === true) {
+        const previous = deferredMessages[index - 1];
+        if (
+          previous?.type === "user" &&
+          previous.isSideQuestion === true &&
+          dismissedIds.has(previous.historyId)
+        ) {
+          return true;
+        }
+      }
+      if (message.type === "user" && message.isSideQuestion === true) {
+        const next = deferredMessages[index + 1];
+        if (
+          next?.type === "assistant" &&
+          next.isSideAnswer === true &&
+          dismissedIds.has(next.historyId)
+        ) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    if (isTargetDismissed(activeSideQuestionScrollHoldTargetRef.current)) {
+      activeSideQuestionScrollHoldTargetRef.current = null;
+    }
+
     const activeTargetHistoryId = activeSideQuestionScrollHoldTargetRef.current;
     const activeHold = findActiveSideQuestionScrollHoldTarget(
       deferredMessages,
@@ -524,7 +586,10 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
     );
     const continuingTargetHistoryId =
       activeHold.targetHistoryId === activeTargetHistoryId ? activeHold.targetHistoryId : undefined;
-    const shouldStartHold = detectedTargetHistoryId !== undefined && autoScroll;
+    const shouldStartHold =
+      detectedTargetHistoryId !== undefined &&
+      autoScroll &&
+      !isTargetDismissed(detectedTargetHistoryId);
     const targetHistoryId = shouldStartHold ? detectedTargetHistoryId : continuingTargetHistoryId;
 
     if (!targetHistoryId) {
@@ -1235,6 +1300,11 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
                               userMessageNavigation={
                                 msg.type === "user"
                                   ? userMessageNavigationByHistoryId?.get(msg.historyId)
+                                  : undefined
+                              }
+                              onDismissSideQuestionSticky={
+                                msg.type === "user" && msg.isSideQuestion === true
+                                  ? handleDismissSideQuestionSticky
                                   : undefined
                               }
                             />

--- a/src/browser/features/Messages/MessageRenderer.stories.tsx
+++ b/src/browser/features/Messages/MessageRenderer.stories.tsx
@@ -218,6 +218,82 @@ export const SyntheticAutoResumeMessages: AppStory = {
   ),
 };
 
+/**
+ * /btw side-question Q/A pair with the dismiss-stickiness control visible.
+ *
+ * The dismiss control is rendered inline in the "Side question" header (top
+ * right of the user row's stripe) and is plumbed from `ChatPane` to clear the
+ * transcript scroll-hold for that side question for the rest of the session.
+ * The `play` test asserts the control is rendered and clicks it to exercise
+ * the wired-up dismissal callback.
+ */
+export const SideQuestionWithDismiss: AppStory = {
+  parameters: { chromatic: { modes: CHROMATIC_SMOKE_MODES } },
+  render: () => (
+    <AppWithMocks
+      setup={() => {
+        collapseLeftSidebar();
+        return setupSimpleChatStory({
+          workspaceId: "ws-side-question",
+          messages: [
+            createUserMessage("msg-1", "Refactor the request retry logic", {
+              historySequence: 1,
+              timestamp: STABLE_TIMESTAMP - 240000,
+            }),
+            createAssistantMessage(
+              "msg-2",
+              "I'll start by reading the current retry implementation and outlining the changes.",
+              {
+                historySequence: 2,
+                timestamp: STABLE_TIMESTAMP - 230000,
+              }
+            ),
+            createUserMessage("msg-3-btw", "/btw what does exponential backoff mean?", {
+              historySequence: 3,
+              timestamp: STABLE_TIMESTAMP - 200000,
+              muxMetadata: {
+                type: "side-question",
+                rawCommand: "/btw what does exponential backoff mean?",
+              },
+            }),
+            createAssistantMessage(
+              "msg-4-btw-answer",
+              "Exponential backoff doubles the wait between retries so a struggling service has time to recover instead of being hammered by a tight retry loop.",
+              {
+                historySequence: 4,
+                timestamp: STABLE_TIMESTAMP - 195000,
+                muxMetadata: {
+                  type: "side-question-answer",
+                  questionMessageId: "msg-3-btw",
+                },
+              }
+            ),
+            createAssistantMessage(
+              "msg-5",
+              "Back to the main task — I'll switch the retry helper to use exponential backoff with jitter.",
+              {
+                historySequence: 5,
+                timestamp: STABLE_TIMESTAMP - 180000,
+              }
+            ),
+          ],
+        });
+      }}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const dismissButton = await canvas.findByLabelText("Dismiss side question sticky position");
+    await expect(dismissButton).toBeInTheDocument();
+    // Click to exercise the dismissal pathway end-to-end (ChatPane handler
+    // clears the active scroll-hold ref and adds the row's historyId to the
+    // dismissed set). The button stays in the DOM after click — the visual
+    // change is the scroll behavior, which Chromatic captures via the static
+    // layout snapshot.
+    await userEvent.click(dismissButton);
+  },
+};
+
 export const GoalContinuationMessages: AppStory = {
   render: () => (
     <AppWithMocks

--- a/src/browser/features/Messages/MessageRenderer.test.tsx
+++ b/src/browser/features/Messages/MessageRenderer.test.tsx
@@ -222,6 +222,83 @@ Live goal accounting at limit:
   });
 });
 
+describe("MessageRenderer /btw side-question rows", () => {
+  beforeEach(() => {
+    globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
+    globalThis.document = globalThis.window.document;
+    globalThis.localStorage = globalThis.window.localStorage;
+  });
+
+  afterEach(() => {
+    cleanup();
+
+    globalThis.window = undefined as unknown as Window & typeof globalThis;
+    globalThis.document = undefined as unknown as Document;
+    globalThis.localStorage = undefined as unknown as Storage;
+  });
+
+  function makeSideQuestionMessage(historyId: string): DisplayedMessage {
+    return {
+      type: "user",
+      id: historyId,
+      historyId,
+      content: "Why is the sky blue?",
+      historySequence: 1,
+      isSideQuestion: true,
+    };
+  }
+
+  test("does not render a dismiss-sticky control when no handler is supplied", () => {
+    const message = makeSideQuestionMessage("btw-no-handler");
+
+    const { queryByLabelText } = render(
+      <TooltipProvider>
+        <MessageRenderer message={message} />
+      </TooltipProvider>
+    );
+
+    expect(queryByLabelText("Dismiss side question sticky position")).toBeNull();
+  });
+
+  test("renders a dismiss-sticky control on side-question rows and forwards the historyId", () => {
+    const message = makeSideQuestionMessage("btw-with-handler");
+    const dismissed: string[] = [];
+
+    const { getByLabelText } = render(
+      <TooltipProvider>
+        <MessageRenderer
+          message={message}
+          onDismissSideQuestionSticky={(historyId) => dismissed.push(historyId)}
+        />
+      </TooltipProvider>
+    );
+
+    const button = getByLabelText("Dismiss side question sticky position");
+    expect(button).toBeDefined();
+    (button as HTMLButtonElement).click();
+    expect(dismissed).toEqual(["btw-with-handler"]);
+  });
+
+  test("does not render the dismiss control on non-side-question user rows", () => {
+    const message: DisplayedMessage = {
+      type: "user",
+      id: "plain-user",
+      historyId: "plain-user",
+      content: "Hello",
+      historySequence: 1,
+    };
+
+    const { queryByLabelText } = render(
+      <TooltipProvider>
+        <MessageRenderer message={message} onDismissSideQuestionSticky={() => undefined} />
+      </TooltipProvider>
+    );
+
+    // The dismiss button only renders inside the side-question header chrome.
+    expect(queryByLabelText("Dismiss side question sticky position")).toBeNull();
+  });
+});
+
 describe("MessageRenderer generated image rows", () => {
   beforeEach(() => {
     globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;

--- a/src/browser/features/Messages/MessageRenderer.tsx
+++ b/src/browser/features/Messages/MessageRenderer.tsx
@@ -34,6 +34,12 @@ interface MessageRendererProps {
   taskReportLinking?: TaskReportLinking;
   /** Navigation info for user messages (backward/forward between user messages) */
   userMessageNavigation?: UserMessageNavigation;
+  /**
+   * For /btw side-question rows: opt-in dismissal of the transcript scroll-hold
+   * ("stickiness") for this side question. When provided, UserMessage renders a
+   * small dismiss control in the side-question header.
+   */
+  onDismissSideQuestionSticky?: (historyId: string) => void;
 }
 
 function getMessageHistoryId(message: DisplayedMessage): string | undefined {
@@ -82,6 +88,7 @@ export const MessageRenderer = React.memo<MessageRendererProps>(
     bashOutputGroup,
     taskReportLinking,
     userMessageNavigation,
+    onDismissSideQuestionSticky,
   }) => {
     let renderedMessage: React.ReactNode;
 
@@ -95,6 +102,7 @@ export const MessageRenderer = React.memo<MessageRendererProps>(
             onEdit={onEditUserMessage}
             isCompacting={isCompacting}
             navigation={userMessageNavigation}
+            onDismissSticky={onDismissSideQuestionSticky}
           />
         );
         break;

--- a/src/browser/features/Messages/UserMessage.tsx
+++ b/src/browser/features/Messages/UserMessage.tsx
@@ -7,6 +7,7 @@ import { UserMessageContent } from "./UserMessageContent";
 import { GoalSyntheticMessageContent } from "./GoalSyntheticMessageContent";
 import { TerminalOutput } from "./TerminalOutput";
 import { formatKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
+import { TooltipIfPresent } from "@/browser/components/Tooltip/Tooltip";
 import { useCopyToClipboard } from "@/browser/hooks/useCopyToClipboard";
 import { copyToClipboard } from "@/browser/utils/clipboard";
 import {
@@ -23,6 +24,7 @@ import {
   ClipboardCheck,
   MessageCircleQuestion,
   Pencil,
+  PinOff,
   Target,
 } from "lucide-react";
 import {
@@ -49,6 +51,14 @@ interface UserMessageProps {
   clipboardWriteText?: (data: string) => Promise<void>;
   /** Navigation info for backward/forward between user messages */
   navigation?: UserMessageNavigation;
+  /**
+   * For /btw side-question rows only: callback invoked when the user clicks the
+   * dismiss-stickiness control in the side-question header. The ChatPane uses
+   * this to permanently exempt this side question from the transcript
+   * scroll-hold for the rest of the workspace session. When omitted, no
+   * dismiss control is rendered.
+   */
+  onDismissSticky?: (historyId: string) => void;
 }
 
 export const UserMessage: React.FC<UserMessageProps> = ({
@@ -58,6 +68,7 @@ export const UserMessage: React.FC<UserMessageProps> = ({
   isCompacting,
   clipboardWriteText = copyToClipboard,
   navigation,
+  onDismissSticky,
 }) => {
   const isSynthetic = message.isSynthetic === true;
   const isGoalContinuation = message.isGoalContinuation === true;
@@ -236,7 +247,26 @@ export const UserMessage: React.FC<UserMessageProps> = ({
       >
         <div className={SIDE_QUESTION_HEADER_CLASS}>
           <MessageCircleQuestion aria-hidden="true" className="h-3 w-3" />
-          Side question
+          <span>Side question</span>
+          {onDismissSticky && (
+            // Explicit per-instance escape hatch from the transcript
+            // scroll-hold ("stickiness") this row triggers. The various
+            // heuristic release paths (wheel / mousedown / key / touch /
+            // jump-to-bottom) have been fragile, so give the user a
+            // deterministic dismiss that also prevents the hold from
+            // re-arming for this row on subsequent stream updates.
+            <TooltipIfPresent tooltip="Dismiss sticky position">
+              <button
+                type="button"
+                aria-label="Dismiss side question sticky position"
+                data-side-question-dismiss
+                onClick={() => onDismissSticky(message.historyId)}
+                className="text-muted hover:text-foreground ml-auto inline-flex h-4 w-4 items-center justify-center rounded-sm transition-colors"
+              >
+                <PinOff aria-hidden="true" className="h-3 w-3" />
+              </button>
+            </TooltipIfPresent>
+          )}
         </div>
         {messageWindow}
       </div>

--- a/src/browser/stories/mocks/messages.ts
+++ b/src/browser/stories/mocks/messages.ts
@@ -125,6 +125,11 @@ export function createAssistantMessage(
     partial?: boolean;
     /** Custom context usage for testing context meter display */
     contextUsage?: { inputTokens: number; outputTokens: number; totalTokens?: number };
+    /**
+     * Optional muxMetadata payload — used by stories that need to tag the
+     * assistant message as a side-question answer, a goal summary, etc.
+     */
+    muxMetadata?: MuxMessageMetadata;
   }
 ): ChatMuxMessage {
   const parts: MuxPart[] = [];
@@ -154,6 +159,7 @@ export function createAssistantMessage(
       contextUsage,
       duration: 1000,
       partial: opts.partial,
+      muxMetadata: opts.muxMetadata,
     },
   };
 }


### PR DESCRIPTION
## Summary

Add an explicit "Dismiss sticky position" control to the `/btw` side-question header so users have a deterministic escape hatch from the transcript scroll-hold ("stickiness") that pins a side question to the top of the viewport.

## Background

The side-question feature uses a complex `useLayoutEffect`-based scroll-hold (see `sideQuestionScrollHold.ts` and the layout effect in `ChatPane.tsx`) that hands ownership of `scrollTop` between bottom-lock and the side branch as the side answer streams and as new main-stream rows accumulate below the branch. Recovery from that hold relies on a handful of heuristic release paths — wheel, `mousedown`, key press, touch, jump-to-bottom — each of which has been the source of repeated bugs (the side Q/A sticking at the bottom edge of the viewport, the hold re-arming on subsequent stream updates, the alignment fighting browser scroll anchoring, etc.).

Rather than try to make those heuristics perfect, this PR ships a user-controlled override.

## Implementation

- `ChatPane` keeps a `dismissedSideQuestionStickyIdsRef = useRef<Set<string>>` keyed by the side-question user message's `historyId`. The set is reset on workspace switch alongside the existing scroll-hold ref reset.
- The scroll-hold `useLayoutEffect` now consults that set:
  - if the currently-active hold target has been dismissed, the active ref is cleared immediately,
  - `shouldStartHold` is gated on `!isTargetDismissed(detectedTargetHistoryId)`, so detection cannot re-arm the hold for a dismissed branch on subsequent stream updates,
  - dismissal of the question row also covers the paired side-answer row (the existing hold logic uses either historyId as the target depending on which row is visible).
- A small `PinOff` icon button is rendered in the existing side-question header next to the "Side question" label, wrapped in the shared `TooltipIfPresent` surface (per the repo's `no-native-interactive-tooltips` lint rule). The button is only rendered when an `onDismissSticky` handler is supplied — so non-`/btw` user rows are unaffected, and existing stories/tests that render `UserMessage` standalone don't grow chrome.
- The handler is plumbed `ChatPane → MessageRenderer → UserMessage` as an optional callback, conditional on `msg.isSideQuestion === true`, so the dismiss UI only appears on `/btw` user rows.

## Validation

- `bun test src/browser/features/Messages/MessageRenderer.test.tsx src/browser/components/ChatPane/sideQuestionScrollHold.test.ts` — 31 pass, including 3 new tests covering (a) no button without handler, (b) button click forwards the `historyId`, (c) button never appears on non-side-question user rows.
- `make static-check` — passes (caught and resolved one lint hit on a native `title` attribute by switching to `TooltipIfPresent`).

## Risks

Low. The added state lives in a `ref`, is reset on workspace switch, and only gates the existing scroll-hold paths (it cannot start a hold that wouldn't have started before). The new UI control renders only inside the `/btw` header for messages where `isSideQuestion === true` and an opt-in callback is provided, so other user-message rendering paths (regular chat, goal-continuation, budget-limit, synthetic-auto, edited messages, queued previews, stories) are untouched.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `high` • Cost: `$`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=high costs= -->
