### PR TITLE
🤖 fix: stabilize /btw transcript placement

### DIFF
--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -98,8 +98,6 @@ import {
 import {
   findActiveSideQuestionScrollHoldTarget,
   findSideQuestionScrollHoldTarget,
-  getSideQuestionScrollHoldScrollportStartTop,
-  isSideQuestionScrollHoldBottomClamped,
   type SideQuestionScrollHoldState,
 } from "./sideQuestionScrollHold";
 import { recordSyntheticReactRenderSample } from "@/browser/utils/perf/reactProfileCollector";
@@ -549,23 +547,10 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
     };
 
     const currentHold = findActiveSideQuestionScrollHoldTarget(deferredMessages, targetHistoryId);
-    const releaseSettledHoldIfAligned = (targetElement: HTMLElement | undefined): void => {
+    const releaseSettledHold = (): void => {
       if (
         currentHold.keepActive ||
         activeSideQuestionScrollHoldTargetRef.current !== targetHistoryId
-      ) {
-        return;
-      }
-
-      // If the first settled-render alignment is still clamped to the transcript
-      // bottom, keep the /btw hold alive for later main-stream growth. Otherwise
-      // the side branch can sit on the viewport bottom forever with newer main
-      // content accumulating below it off-screen.
-      if (
-        targetElement &&
-        isSideQuestionScrollHoldBottomClamped(scrollContainer, targetElement, {
-          scrollportStartTop: getSideQuestionScrollHoldScrollportStartTop(scrollContainer),
-        })
       ) {
         return;
       }
@@ -576,15 +561,14 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
     // The main stream can now keep rendering below an active /btw branch. Once
     // that happens, bottom-lock would otherwise follow the main tail and yank
     // the user away from the aside they just requested. Release bottom-lock once
-    // per side branch and keep the side-question row readable. Keep re-aligning
-    // while the side answer grows and, after it settles, only while the attempted
-    // start alignment is still bottom-clamped. That prevents the side Q/A from
-    // becoming permanent visual clutter at the transcript bottom.
+    // per interrupted side branch, then let the finite hold expire as soon as
+    // both the side answer and interrupted main stream are settled.
     if (shouldStartHold) {
       activeSideQuestionScrollHoldTargetRef.current = targetHistoryId;
       disableAutoScroll();
     }
-    releaseSettledHoldIfAligned(alignSideBranchStart());
+    alignSideBranchStart();
+    releaseSettledHold();
 
     const win = typeof window !== "undefined" ? window : undefined;
     const raf = win?.requestAnimationFrame?.bind(win);
@@ -593,7 +577,10 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
       return;
     }
 
-    const frameId = raf(() => releaseSettledHoldIfAligned(alignSideBranchStart()));
+    const frameId = raf(() => {
+      alignSideBranchStart();
+      releaseSettledHold();
+    });
     return () => cancelRaf(frameId);
   }, [autoScroll, contentRef, deferredMessages, disableAutoScroll, isHydratingTranscript, loading]);
 

--- a/src/browser/components/ChatPane/sideQuestionScrollHold.test.ts
+++ b/src/browser/components/ChatPane/sideQuestionScrollHold.test.ts
@@ -8,7 +8,12 @@ import {
 
 function userMessage(
   historyId: string,
-  opts: { isSideQuestion?: boolean } = {}
+  opts: {
+    isSideQuestion?: boolean;
+    placement?: "interrupted" | "standalone";
+    branchId?: string;
+    interruptedMessageId?: string;
+  } = {}
 ): Extract<DisplayedMessage, { type: "user" }> {
   return {
     type: "user",
@@ -17,12 +22,25 @@ function userMessage(
     content: historyId,
     historySequence: 1,
     isSideQuestion: opts.isSideQuestion,
+    sideQuestionBranch: opts.isSideQuestion
+      ? {
+          branchId: opts.branchId ?? historyId,
+          placement: opts.placement ?? "interrupted",
+          interruptedMessageId: opts.interruptedMessageId ?? "main-1",
+        }
+      : undefined,
   };
 }
 
 function assistantMessage(
   historyId: string,
-  opts: { isSideAnswer?: boolean; isStreaming?: boolean } = {}
+  opts: {
+    isSideAnswer?: boolean;
+    isStreaming?: boolean;
+    placement?: "interrupted" | "standalone";
+    branchId?: string;
+    interruptedMessageId?: string;
+  } = {}
 ): Extract<DisplayedMessage, { type: "assistant" }> {
   return {
     type: "assistant",
@@ -35,6 +53,13 @@ function assistantMessage(
     isCompacted: false,
     isIdleCompacted: false,
     isSideAnswer: opts.isSideAnswer,
+    sideQuestionBranch: opts.isSideAnswer
+      ? {
+          branchId: opts.branchId ?? "btw-q",
+          placement: opts.placement ?? "interrupted",
+          interruptedMessageId: opts.interruptedMessageId ?? "main-1",
+        }
+      : undefined,
   };
 }
 
@@ -86,14 +111,58 @@ describe("findSideQuestionScrollHoldTarget", () => {
   test("does not target a standalone side question when only its answer is below it", () => {
     const messages: DisplayedMessage[] = [
       assistantMessage("main-1"),
-      userMessage("btw-q", { isSideQuestion: true }),
-      assistantMessage("btw-a", { isSideAnswer: true, isStreaming: true }),
+      userMessage("btw-q", { isSideQuestion: true, placement: "standalone" }),
+      assistantMessage("btw-a", {
+        isSideAnswer: true,
+        isStreaming: true,
+        placement: "standalone",
+      }),
     ];
 
     const result = findSideQuestionScrollHoldTarget(messages, state());
 
     expect(result.targetHistoryId).toBeUndefined();
-    expect([...result.nextState.heldSideQuestionIds]).toEqual([]);
+    expect([...result.nextState.heldSideQuestionIds]).toEqual(["btw-q"]);
+  });
+
+  test("does not target a standalone side question when later transcript rows appear below it", () => {
+    const messages: DisplayedMessage[] = [
+      assistantMessage("main-1"),
+      userMessage("btw-q", { isSideQuestion: true, placement: "standalone" }),
+      assistantMessage("btw-a", { isSideAnswer: true, placement: "standalone" }),
+      assistantMessage("main-2"),
+    ];
+
+    const result = findSideQuestionScrollHoldTarget(messages, state());
+
+    expect(result.targetHistoryId).toBeUndefined();
+    expect([...result.nextState.heldSideQuestionIds]).toEqual(["btw-q"]);
+  });
+
+  test("does not target a side question that becomes interrupted after first rendering standalone", () => {
+    const first = findSideQuestionScrollHoldTarget(
+      [
+        assistantMessage("main-1"),
+        userMessage("btw-q", { isSideQuestion: true, placement: "standalone" }),
+        assistantMessage("btw-a", { isSideAnswer: true, placement: "standalone" }),
+      ],
+      state()
+    );
+    expect(first.targetHistoryId).toBeUndefined();
+    expect([...first.nextState.heldSideQuestionIds]).toEqual(["btw-q"]);
+
+    const second = findSideQuestionScrollHoldTarget(
+      [
+        assistantMessage("main-1"),
+        userMessage("btw-q", { isSideQuestion: true }),
+        assistantMessage("btw-a", { isSideAnswer: true }),
+        assistantMessage("main-1-post"),
+      ],
+      first.nextState
+    );
+
+    expect(second.targetHistoryId).toBeUndefined();
+    expect([...second.nextState.heldSideQuestionIds]).toEqual(["btw-q"]);
   });
 
   test("targets the side question when a streaming side answer has transcript rows below it", () => {
@@ -234,6 +303,20 @@ describe("findSideQuestionScrollHoldTarget", () => {
     expect(settledAnswer).toEqual({ targetHistoryId: "btw-q", keepActive: false });
   });
 
+  test("keeps an active side-question hold while the interrupted main message streams", () => {
+    const activeMain = findActiveSideQuestionScrollHoldTarget(
+      [
+        assistantMessage("main-1"),
+        userMessage("btw-q", { isSideQuestion: true }),
+        assistantMessage("btw-a", { isSideAnswer: true, isStreaming: false }),
+        assistantMessage("main-1", { isStreaming: true }),
+      ],
+      "btw-q"
+    );
+
+    expect(activeMain).toEqual({ targetHistoryId: "btw-q", keepActive: true });
+  });
+
   test("keeps an active fallback answer-row hold while the side answer streams", () => {
     const streamingAnswer = findActiveSideQuestionScrollHoldTarget(
       [
@@ -254,6 +337,23 @@ describe("findSideQuestionScrollHoldTarget", () => {
       "btw-a"
     );
     expect(settledAnswer).toEqual({ targetHistoryId: "btw-a", keepActive: false });
+  });
+
+  test("does not keep an active fallback answer-row hold for standalone answers", () => {
+    const result = findActiveSideQuestionScrollHoldTarget(
+      [
+        assistantMessage("main-1"),
+        assistantMessage("btw-a", {
+          isSideAnswer: true,
+          isStreaming: true,
+          placement: "standalone",
+        }),
+        assistantMessage("main-1-post"),
+      ],
+      "btw-a"
+    );
+
+    expect(result).toEqual({ keepActive: false });
   });
 
   test("detects a side-question alignment that is still clamped to transcript bottom", () => {

--- a/src/browser/components/ChatPane/sideQuestionScrollHold.ts
+++ b/src/browser/components/ChatPane/sideQuestionScrollHold.ts
@@ -1,4 +1,4 @@
-import type { DisplayedMessage } from "@/common/types/message";
+import type { DisplayedMessage, SideQuestionDisplayBranch } from "@/common/types/message";
 
 export interface SideQuestionScrollHoldState {
   initialized: boolean;
@@ -34,6 +34,59 @@ interface ScrollHoldBottomClampOptions {
 
 const BOTTOM_CLAMP_EPSILON_PX = 1;
 const TARGET_START_ALIGNMENT_EPSILON_PX = 2;
+
+function getInterruptedSideQuestionBranch(
+  message: DisplayedMessage
+): SideQuestionDisplayBranch | undefined {
+  if (message.type !== "user" && message.type !== "assistant") {
+    return undefined;
+  }
+
+  return message.sideQuestionBranch?.placement === "interrupted"
+    ? message.sideQuestionBranch
+    : undefined;
+}
+
+function isInterruptedSideQuestionUser(
+  message: DisplayedMessage
+): message is Extract<DisplayedMessage, { type: "user" }> {
+  return (
+    message.type === "user" &&
+    message.isSideQuestion === true &&
+    getInterruptedSideQuestionBranch(message) !== undefined
+  );
+}
+
+function isInterruptedSideQuestionAnswer(
+  message: DisplayedMessage
+): message is Extract<DisplayedMessage, { type: "assistant" }> {
+  return (
+    message.type === "assistant" &&
+    message.isSideAnswer === true &&
+    getInterruptedSideQuestionBranch(message) !== undefined
+  );
+}
+
+function isStreamingHistoryRow(message: DisplayedMessage, historyId: string): boolean {
+  return (
+    "historyId" in message &&
+    message.historyId === historyId &&
+    "isStreaming" in message &&
+    message.isStreaming === true
+  );
+}
+
+function isInterruptedBranchStreaming(
+  messages: readonly DisplayedMessage[],
+  branch: SideQuestionDisplayBranch | undefined
+): boolean {
+  const interruptedMessageId = branch?.interruptedMessageId;
+  if (branch?.placement !== "interrupted" || !interruptedMessageId) {
+    return false;
+  }
+
+  return messages.some((message) => isStreamingHistoryRow(message, interruptedMessageId));
+}
 
 function readCssPixelValue(value: string): number {
   const parsed = Number.parseFloat(value);
@@ -80,13 +133,10 @@ export function isSideQuestionScrollHoldBottomClamped(
 }
 
 /**
- * Continue aligning a side-question branch after the first hand-off from
- * bottom-lock. The first scroll can happen before there is enough content below
- * the branch for the browser to place it in a readable position, so active side
- * holds keep re-aligning on subsequent stream updates until the side answer has
- * produced one final settled render. If no answer row is currently rendered
- * (model setup lag, retry, or failure), the ChatPane keeps that target alive
- * only while DOM geometry says the attempted alignment is still bottom-clamped.
+ * Continue aligning an interrupted side-question branch after the first hand-off
+ * from bottom-lock. A /btw hold is a finite lease: it may stay active while the
+ * side answer or interrupted main message is still streaming, but settled
+ * branches must release even if browser start-alignment was bottom-clamped.
  */
 export function findActiveSideQuestionScrollHoldTarget(
   messages: readonly DisplayedMessage[],
@@ -98,16 +148,12 @@ export function findActiveSideQuestionScrollHoldTarget(
 
   const sideQuestionIndex = messages.findIndex(
     (message) =>
-      message.type === "user" &&
-      message.isSideQuestion === true &&
-      message.historyId === activeTargetHistoryId
+      isInterruptedSideQuestionUser(message) && message.historyId === activeTargetHistoryId
   );
   if (sideQuestionIndex === -1) {
     const sideAnswer = messages.find(
       (message): message is Extract<DisplayedMessage, { type: "assistant" }> =>
-        message.type === "assistant" &&
-        message.isSideAnswer === true &&
-        message.historyId === activeTargetHistoryId
+        isInterruptedSideQuestionAnswer(message) && message.historyId === activeTargetHistoryId
     );
     if (!sideAnswer) {
       return { keepActive: false };
@@ -115,19 +161,35 @@ export function findActiveSideQuestionScrollHoldTarget(
 
     return {
       targetHistoryId: activeTargetHistoryId,
-      keepActive: sideAnswer.isStreaming === true,
+      keepActive:
+        sideAnswer.isStreaming === true ||
+        isInterruptedBranchStreaming(messages, sideAnswer.sideQuestionBranch),
     };
   }
 
+  const sideQuestion = messages[sideQuestionIndex];
+  const sideQuestionBranch = getInterruptedSideQuestionBranch(sideQuestion);
+  if (!sideQuestionBranch) {
+    return { keepActive: false };
+  }
   const nextMessage = messages[sideQuestionIndex + 1];
-  if (nextMessage?.type === "assistant" && nextMessage.isSideAnswer === true) {
+  if (
+    nextMessage !== undefined &&
+    isInterruptedSideQuestionAnswer(nextMessage) &&
+    nextMessage.sideQuestionBranch?.branchId === sideQuestionBranch?.branchId
+  ) {
     return {
       targetHistoryId: activeTargetHistoryId,
-      keepActive: nextMessage.isStreaming === true,
+      keepActive:
+        nextMessage.isStreaming === true ||
+        isInterruptedBranchStreaming(messages, sideQuestionBranch),
     };
   }
 
-  return { targetHistoryId: activeTargetHistoryId, keepActive: false };
+  return {
+    targetHistoryId: activeTargetHistoryId,
+    keepActive: isInterruptedBranchStreaming(messages, sideQuestionBranch),
+  };
 }
 
 /**
@@ -149,23 +211,36 @@ export function findSideQuestionScrollHoldTarget(
     const message = messages[index];
 
     if (message.type === "user" && message.isSideQuestion === true) {
-      const wasHeld = state.heldSideQuestionIds.has(message.historyId);
+      const sideQuestionHistoryId = message.historyId;
+      if (!isInterruptedSideQuestionUser(message)) {
+        // Track standalone/stale side-question rows as already seen. If their
+        // anchor arrives later and the display projection flips them to
+        // interrupted, that historical row must not acquire a fresh scroll lease.
+        nextHeldSideQuestionIds.add(sideQuestionHistoryId);
+        continue;
+      }
+
+      const wasHeld = state.heldSideQuestionIds.has(sideQuestionHistoryId);
       const nextMessage = messages[index + 1];
       const branchEndIndex =
-        nextMessage?.type === "assistant" && nextMessage.isSideAnswer === true ? index + 1 : index;
+        nextMessage !== undefined &&
+        isInterruptedSideQuestionAnswer(nextMessage) &&
+        nextMessage.sideQuestionBranch?.branchId === message.sideQuestionBranch?.branchId
+          ? index + 1
+          : index;
       const hasTranscriptRowsBelow = branchEndIndex < messages.length - 1;
       if (!state.initialized || wasHeld) {
-        nextHeldSideQuestionIds.add(message.historyId);
+        nextHeldSideQuestionIds.add(sideQuestionHistoryId);
         continue;
       }
       if (hasTranscriptRowsBelow) {
-        nextHeldSideQuestionIds.add(message.historyId);
-        targetHistoryId = message.historyId;
+        nextHeldSideQuestionIds.add(sideQuestionHistoryId);
+        targetHistoryId = sideQuestionHistoryId;
       }
       continue;
     }
 
-    if (message.type !== "assistant" || message.isSideAnswer !== true) {
+    if (!isInterruptedSideQuestionAnswer(message)) {
       continue;
     }
 
@@ -194,7 +269,9 @@ export function findSideQuestionScrollHoldTarget(
 
     const sideQuestion = messages[index - 1];
     targetHistoryId =
-      sideQuestion?.type === "user" && sideQuestion.isSideQuestion === true
+      sideQuestion !== undefined &&
+      isInterruptedSideQuestionUser(sideQuestion) &&
+      sideQuestion.sideQuestionBranch?.branchId === message.sideQuestionBranch?.branchId
         ? sideQuestion.historyId
         : message.historyId;
   }

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -5215,7 +5215,7 @@ describe("WorkspaceStore", () => {
           historySequence: 3,
           timestamp: 1_300,
           model: "claude-haiku-3.5",
-          muxMetadata: { type: "side-question-answer" },
+          muxMetadata: { type: "side-question-answer", questionMessageId: "btw-user-1" },
         },
       });
       rawStore.handleChatMessage(workspaceId, {
@@ -5265,6 +5265,20 @@ describe("WorkspaceStore", () => {
           .filter((m) => m.type === "assistant" || m.type === "user")
           .map((m) => m.historyId);
       expect(readVisibleHistoryIds()).toEqual(["main-1", "btw-user-1", "btw-ans-1", "main-1"]);
+
+      const sideRows = aggregator
+        .getDisplayedMessages()
+        .filter(
+          (m) =>
+            (m.type === "assistant" || m.type === "user") &&
+            (m.historyId === "btw-user-1" || m.historyId === "btw-ans-1")
+        );
+      expect(sideRows).toHaveLength(2);
+      expect(
+        sideRows.map((m) =>
+          m.type === "assistant" || m.type === "user" ? m.sideQuestionBranch?.placement : undefined
+        )
+      ).toEqual(["interrupted", "interrupted"]);
 
       // After /btw settles, the underlying main message still has the full
       // text and the displayed rows keep the same split order.
@@ -5356,6 +5370,21 @@ describe("WorkspaceStore", () => {
           .find((message) => message.id === "btw-answer-standalone")
           ?.parts.some((part) => part.type === "text" && part.text === "side answer")
       ).toBe(true);
+      const displayedSideRows = aggregator
+        ?.getDisplayedMessages()
+        .filter(
+          (message) =>
+            (message.type === "assistant" || message.type === "user") &&
+            (message.historyId === "btw-user-standalone" ||
+              message.historyId === "btw-answer-standalone")
+        );
+      expect(
+        displayedSideRows?.map((message) =>
+          message.type === "assistant" || message.type === "user"
+            ? message.sideQuestionBranch?.placement
+            : undefined
+        )
+      ).toEqual(["standalone", "standalone"]);
     });
     it("keeps replayed /btw answer streams out of workspace interrupt state", async () => {
       const workspaceId = "btw-replay-side-only-not-busy";

--- a/src/browser/utils/messages/StreamingMessageAggregator.sideQuestion.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.sideQuestion.test.ts
@@ -92,6 +92,14 @@ function appendSideAnswer(
   aggregator.handleMessage(envelope);
 }
 
+function readSideQuestionPlacement(
+  row: ReturnType<StreamingMessageAggregator["getDisplayedMessages"]>[number]
+): "interrupted" | "standalone" | undefined {
+  return row.type === "user" || row.type === "assistant"
+    ? row.sideQuestionBranch?.placement
+    : undefined;
+}
+
 describe("StreamingMessageAggregator /btw rendering", () => {
   it("marks side-question-answer rows with isSideAnswer in displayed messages", () => {
     // Regression: the renderer derives `isSideAnswer` from the
@@ -476,7 +484,7 @@ describe("StreamingMessageAggregator /btw rendering", () => {
       interruptedTextLength: 5,
       interruptedHistorySequence: 1,
     });
-    appendSideAnswer(aggregator, "btw-a", 3, "four");
+    appendSideAnswer(aggregator, "btw-a", 3, "four", "btw-q");
 
     const rows = aggregator.getDisplayedMessages();
     const visibleHistoryIds = rows
@@ -485,6 +493,24 @@ describe("StreamingMessageAggregator /btw rendering", () => {
 
     // Pre-aside main row, side question, side answer, post-aside main row.
     expect(visibleHistoryIds).toEqual(["main-1", "btw-q", "btw-a", "main-1"]);
+
+    const sideRows = rows.filter(
+      (r) =>
+        (r.type === "user" || r.type === "assistant") &&
+        (r.historyId === "btw-q" || r.historyId === "btw-a")
+    );
+    expect(sideRows).toHaveLength(2);
+    for (const row of sideRows) {
+      if (row.type !== "user" && row.type !== "assistant") {
+        throw new Error("expected /btw display rows to be user or assistant rows");
+      }
+      expect(row.sideQuestionBranch).toEqual({
+        branchId: "btw-q",
+        placement: "interrupted",
+        interruptedMessageId: "main-1",
+        interruptedHistorySequence: 1,
+      });
+    }
 
     // The pre and post halves carry the split text content.
     const mainRows = rows.filter(
@@ -529,6 +555,84 @@ describe("StreamingMessageAggregator /btw rendering", () => {
       "btw-a2",
       "main-1",
     ]);
+  });
+
+  it("does not duplicate anchored /btw rows when side rows sort before the interrupted assistant", () => {
+    // The split owner must be decided before the display walk starts. Otherwise
+    // out-of-order replay can render the side rows chronologically and then
+    // render them again inside the interrupted assistant split.
+    const aggregator = new StreamingMessageAggregator(WORKSPACE_CREATED_AT);
+
+    appendSideUser(aggregator, "btw-q", 2, "what's 2+2", {
+      interruptedMessageId: "main-1",
+      interruptedTextLength: 5,
+      interruptedHistorySequence: 10,
+    });
+    appendSideAnswer(aggregator, "btw-a", 3, "four", "btw-q");
+    appendMainAssistant(aggregator, "main-1", 10, "hello world");
+
+    const visibleHistoryIds = aggregator
+      .getDisplayedMessages()
+      .filter((r) => r.type === "assistant" || r.type === "user")
+      .map((r) => r.historyId);
+
+    expect(visibleHistoryIds).toEqual(["main-1", "btw-q", "btw-a", "main-1"]);
+    expect(visibleHistoryIds.filter((id) => id === "btw-q")).toHaveLength(1);
+    expect(visibleHistoryIds.filter((id) => id === "btw-a")).toHaveLength(1);
+  });
+
+  it("treats interruptedHistorySequence mismatches as standalone /btw rows", () => {
+    const aggregator = new StreamingMessageAggregator(WORKSPACE_CREATED_AT);
+
+    appendMainAssistant(aggregator, "main-1", 1, "hello world");
+    appendSideUser(aggregator, "btw-q", 2, "stale anchor", {
+      interruptedMessageId: "main-1",
+      interruptedTextLength: 5,
+      interruptedHistorySequence: 999,
+    });
+    appendSideAnswer(aggregator, "btw-a", 3, "answer", "btw-q");
+
+    const rows = aggregator.getDisplayedMessages();
+    const visibleHistoryIds = rows
+      .filter((r) => r.type === "assistant" || r.type === "user")
+      .map((r) => r.historyId);
+
+    expect(visibleHistoryIds).toEqual(["main-1", "btw-q", "btw-a"]);
+    const sideRows = rows.filter(
+      (r) =>
+        (r.type === "user" || r.type === "assistant") &&
+        (r.historyId === "btw-q" || r.historyId === "btw-a")
+    );
+    expect(sideRows.map(readSideQuestionPlacement)).toEqual(["standalone", "standalone"]);
+  });
+
+  it("keeps /btw rows chronological when the interrupted assistant owner is hidden", () => {
+    // Synthetic assistant messages are hidden from the transcript. If a stale
+    // /btw anchor points at one, the side rows must remain visible instead of
+    // being reserved for a split owner that will never render.
+    const aggregator = new StreamingMessageAggregator(WORKSPACE_CREATED_AT);
+
+    aggregator.handleMessage({
+      type: "message",
+      id: "main-hidden",
+      role: "assistant",
+      parts: [{ type: "text", text: "hidden main output" }],
+      metadata: { historySequence: 1, timestamp: 1, synthetic: true },
+    });
+    appendSideUser(aggregator, "btw-q", 2, "why hidden?", {
+      interruptedMessageId: "main-hidden",
+      interruptedTextLength: 6,
+      interruptedHistorySequence: 1,
+    });
+    appendSideAnswer(aggregator, "btw-a", 3, "because synthetic", "btw-q");
+
+    const rows = aggregator.getDisplayedMessages();
+    const visibleHistoryIds = rows
+      .filter((r) => r.type === "assistant" || r.type === "user")
+      .map((r) => r.historyId);
+
+    expect(visibleHistoryIds).toEqual(["btw-q", "btw-a"]);
+    expect(rows.map(readSideQuestionPlacement)).toEqual(["standalone", "standalone"]);
   });
 
   it("keeps pre-existing non-text parts before the side branch at the same text offset", () => {
@@ -687,5 +791,12 @@ describe("StreamingMessageAggregator /btw rendering", () => {
       .map((r) => r.historyId);
 
     expect(visibleHistoryIds).toEqual(["main-1", "btw-q", "btw-a"]);
+
+    const sideRows = rows.filter(
+      (r) =>
+        (r.type === "user" || r.type === "assistant") &&
+        (r.historyId === "btw-q" || r.historyId === "btw-a")
+    );
+    expect(sideRows.map(readSideQuestionPlacement)).toEqual(["standalone", "standalone"]);
   });
 });

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -5,6 +5,7 @@ import type {
   CompactionRequestData,
   InlineSkillSnapshotMap,
   AgentSkillReference,
+  SideQuestionDisplayBranch,
 } from "@/common/types/message";
 import { createMuxMessage, isCompactionSummaryMetadata } from "@/common/types/message";
 
@@ -432,6 +433,11 @@ function deriveInlineSkillSnapshotDisplayState(
 interface MessagePartSplitCut {
   textLength: number;
   partIndex?: number;
+}
+
+interface SideQuestionDisplayPlan {
+  interruptionsByInterruptedId: Map<string, SideQuestionInterrupt[]>;
+  inlineSideQuestionMessageIds: Set<string>;
 }
 
 interface SideQuestionInterrupt {
@@ -3021,6 +3027,154 @@ export class StreamingMessageAggregator {
     });
   }
 
+  private isRenderableSideQuestionAnswer(answer: MuxMessage): boolean {
+    return this.activeStreams.has(answer.id) || answer.parts.length > 0;
+  }
+
+  private compareSideQuestionInterrupts(
+    left: SideQuestionInterrupt,
+    right: SideQuestionInterrupt
+  ): number {
+    const leftHistorySequence = left.sideQuestionUserMsg.metadata?.historySequence ?? Infinity;
+    const rightHistorySequence = right.sideQuestionUserMsg.metadata?.historySequence ?? Infinity;
+    return (
+      left.atTextLength - right.atTextLength ||
+      (left.atPartIndex ?? Infinity) - (right.atPartIndex ?? Infinity) ||
+      leftHistorySequence - rightHistorySequence ||
+      left.sideQuestionUserMsg.id.localeCompare(right.sideQuestionUserMsg.id)
+    );
+  }
+
+  private buildSideQuestionDisplayPlan(
+    allMessages: readonly MuxMessage[],
+    shouldHideMessageFromTranscript: (message: MuxMessage) => boolean
+  ): SideQuestionDisplayPlan {
+    const messagesById = new Map<string, MuxMessage>();
+    const linkedSideAnswerByQuestionId = new Map<string, MuxMessage>();
+    for (const message of allMessages) {
+      messagesById.set(message.id, message);
+      if (!isSideQuestionAnswerMuxMessage(message)) {
+        continue;
+      }
+
+      const questionMessageId = message.metadata.muxMetadata.questionMessageId;
+      if (typeof questionMessageId === "string") {
+        linkedSideAnswerByQuestionId.set(questionMessageId, message);
+      }
+    }
+
+    const interruptionsByInterruptedId = new Map<string, SideQuestionInterrupt[]>();
+    const inlineSideQuestionMessageIds = new Set<string>();
+
+    for (let i = 0; i < allMessages.length; i++) {
+      const msg = allMessages[i];
+      if (!isSideQuestionUserMuxMessage(msg)) {
+        continue;
+      }
+
+      const muxMeta = msg.metadata.muxMetadata;
+      if (
+        typeof muxMeta.interruptedMessageId !== "string" ||
+        typeof muxMeta.interruptedTextLength !== "number" ||
+        !Number.isFinite(muxMeta.interruptedTextLength)
+      ) {
+        continue;
+      }
+
+      const interruptedMessage = messagesById.get(muxMeta.interruptedMessageId);
+      if (
+        interruptedMessage?.role !== "assistant" ||
+        isSideQuestionAnswerMuxMessage(interruptedMessage) ||
+        shouldHideMessageFromTranscript(interruptedMessage)
+      ) {
+        continue;
+      }
+
+      // Use the persisted sequence as part of the anchor identity so a stale
+      // /btw snapshot cannot split an unrelated assistant message that happens
+      // to reuse the same id after history repair or compaction-edge replay.
+      if (
+        typeof muxMeta.interruptedHistorySequence === "number" &&
+        interruptedMessage.metadata?.historySequence !== muxMeta.interruptedHistorySequence
+      ) {
+        continue;
+      }
+
+      const linkedAnswer = linkedSideAnswerByQuestionId.get(msg.id);
+      const next = allMessages[i + 1];
+      const adjacentAnswer =
+        next !== undefined && isSideQuestionAnswerMuxMessage(next) ? next : undefined;
+      const adjacentAnswerQuestionId = adjacentAnswer?.metadata.muxMetadata.questionMessageId;
+      const legacyAdjacentAnswer =
+        adjacentAnswer !== undefined && adjacentAnswerQuestionId === undefined
+          ? adjacentAnswer
+          : undefined;
+      const answer = linkedAnswer ?? legacyAdjacentAnswer;
+      const answerIsRenderable =
+        answer !== undefined && this.isRenderableSideQuestionAnswer(answer);
+      const entry: SideQuestionInterrupt = {
+        atTextLength: Math.max(0, muxMeta.interruptedTextLength),
+        atPartIndex:
+          typeof muxMeta.interruptedPartIndex === "number"
+            ? muxMeta.interruptedPartIndex
+            : undefined,
+        sideQuestionUserMsg: msg,
+        sideQuestionAnswerMsg: answerIsRenderable ? answer : undefined,
+      };
+      const existing = interruptionsByInterruptedId.get(muxMeta.interruptedMessageId);
+      if (existing) {
+        existing.push(entry);
+      } else {
+        interruptionsByInterruptedId.set(muxMeta.interruptedMessageId, [entry]);
+      }
+
+      // Decide split ownership before the display walk starts. This keeps
+      // anchored /btw rows from ever rendering once at their chronological tail
+      // and again inside the interrupted assistant split.
+      inlineSideQuestionMessageIds.add(msg.id);
+      if (answerIsRenderable && answer) {
+        inlineSideQuestionMessageIds.add(answer.id);
+      }
+    }
+
+    for (const interruptions of interruptionsByInterruptedId.values()) {
+      interruptions.sort((left, right) => this.compareSideQuestionInterrupts(left, right));
+    }
+
+    return { interruptionsByInterruptedId, inlineSideQuestionMessageIds };
+  }
+
+  private getInterruptedSideQuestionBranch(
+    interruptedMessage: MuxMessage,
+    interrupt: SideQuestionInterrupt
+  ): SideQuestionDisplayBranch {
+    return {
+      branchId: interrupt.sideQuestionUserMsg.id,
+      placement: "interrupted",
+      interruptedMessageId: interruptedMessage.id,
+      interruptedHistorySequence: interruptedMessage.metadata?.historySequence,
+    };
+  }
+
+  private applySideQuestionBranch(
+    rows: DisplayedMessage[],
+    branch: SideQuestionDisplayBranch
+  ): DisplayedMessage[] {
+    let didChange = false;
+    const markedRows = rows.map((row) => {
+      if (row.type === "user" && row.isSideQuestion === true) {
+        didChange = true;
+        return { ...row, sideQuestionBranch: branch };
+      }
+      if (row.type === "assistant" && row.isSideAnswer === true) {
+        didChange = true;
+        return { ...row, sideQuestionBranch: branch };
+      }
+      return row;
+    });
+    return didChange ? markedRows : rows;
+  }
+
   /**
    * Split a list of message parts at one or more cumulative-text-length
    * boundaries.
@@ -3144,7 +3298,9 @@ export class StreamingMessageAggregator {
     agentSkillSnapshot?: { frontmatterYaml?: string; body?: string },
     inlineSkillSnapshots?: InlineSkillSnapshotMap
   ): DisplayedMessage[] {
-    const sorted = [...interrupts].sort((a, b) => a.atTextLength - b.atTextLength);
+    const sorted = [...interrupts].sort((left, right) =>
+      this.compareSideQuestionInterrupts(left, right)
+    );
     const segments = this.splitMessagePartsAtTextLengths(
       message.parts,
       sorted.map((interrupt) => ({
@@ -3196,9 +3352,20 @@ export class StreamingMessageAggregator {
 
       if (i < sorted.length) {
         const interrupt = sorted[i];
-        result.push(...this.buildDisplayedMessagesForMessage(interrupt.sideQuestionUserMsg));
+        const branch = this.getInterruptedSideQuestionBranch(message, interrupt);
+        result.push(
+          ...this.applySideQuestionBranch(
+            this.buildDisplayedMessagesForMessage(interrupt.sideQuestionUserMsg),
+            branch
+          )
+        );
         if (interrupt.sideQuestionAnswerMsg) {
-          result.push(...this.buildDisplayedMessagesForMessage(interrupt.sideQuestionAnswerMsg));
+          result.push(
+            ...this.applySideQuestionBranch(
+              this.buildDisplayedMessagesForMessage(interrupt.sideQuestionAnswerMsg),
+              branch
+            )
+          );
         }
       }
     }
@@ -3249,6 +3416,11 @@ export class StreamingMessageAggregator {
       const showSyntheticMessages =
         typeof window !== "undefined" && window.api?.debugLlmRequest === true;
 
+      const shouldHideMessageFromTranscript = (message: MuxMessage): boolean =>
+        message.metadata?.synthetic === true &&
+        !showSyntheticMessages &&
+        message.metadata?.uiVisible !== true;
+
       // Synthetic agent-skill snapshot messages are hidden from the transcript unless
       // debugLlmRequest is enabled. We still want to surface their content in the UI by
       // attaching the resolved snapshot (frontmatterYaml + body) to subsequent user
@@ -3268,82 +3440,21 @@ export class StreamingMessageAggregator {
       // (lower historySequence => higher in the transcript), defeating
       // the "main chat continues after the aside" UX.
       //
-      // We pre-walk allMessages to build:
-      //   - interruptionsByInterruptedId: which main-agent messages get
-      //     split, and at which text offsets.
-      //   - emittedAsSplitChildren: side-question user + answer rows
-      //     that the split path will emit inline. The main walk must
-      //     SKIP these to avoid double-rendering.
+      // Build a placement plan before rendering any rows. Anchored /btw rows
+      // are owned by the interrupted assistant's split output; stale or
+      // standalone /btw rows render chronologically and cannot become split
+      // children later in the same pass.
       // ---------------------------------------------------------------
-      const interruptionsByInterruptedId = new Map<string, SideQuestionInterrupt[]>();
-      const emittedAsSplitChildren = new Set<string>();
-
-      const isRenderableSideQuestionAnswer = (answer: MuxMessage): boolean =>
-        this.activeStreams.has(answer.id) || answer.parts.length > 0;
-      const linkedSideAnswerByQuestionId = new Map<string, MuxMessage>();
-      for (const message of allMessages) {
-        if (!isSideQuestionAnswerMuxMessage(message)) {
-          continue;
-        }
-        const questionMessageId = message.metadata.muxMetadata.questionMessageId;
-        if (typeof questionMessageId === "string") {
-          linkedSideAnswerByQuestionId.set(questionMessageId, message);
-        }
-      }
-
-      // A /btw answer (side-question-answer) normally follows its user
-      // /btw row in history, but model setup can lag behind the user row.
-      // Pair by the stable questionMessageId when present, falling back to
-      // adjacency only for legacy history rows that predate that link.
-      for (let i = 0; i < allMessages.length; i++) {
-        const msg = allMessages[i];
-        if (!isSideQuestionUserMuxMessage(msg)) {
-          continue;
-        }
-        const muxMeta = msg.metadata.muxMetadata;
-        if (
-          typeof muxMeta.interruptedMessageId !== "string" ||
-          typeof muxMeta.interruptedTextLength !== "number"
-        ) {
-          continue;
-        }
-
-        const linkedAnswer = linkedSideAnswerByQuestionId.get(msg.id);
-        const next = allMessages[i + 1];
-        const adjacentAnswer =
-          next !== undefined && isSideQuestionAnswerMuxMessage(next) ? next : undefined;
-        const adjacentAnswerQuestionId = adjacentAnswer?.metadata.muxMetadata.questionMessageId;
-        const legacyAdjacentAnswer =
-          adjacentAnswer !== undefined && adjacentAnswerQuestionId === undefined
-            ? adjacentAnswer
-            : undefined;
-        const answer = linkedAnswer ?? legacyAdjacentAnswer;
-        const answerIsRenderable = answer !== undefined && isRenderableSideQuestionAnswer(answer);
-        const existing = interruptionsByInterruptedId.get(muxMeta.interruptedMessageId);
-        const entry = {
-          atTextLength: muxMeta.interruptedTextLength,
-          atPartIndex:
-            typeof muxMeta.interruptedPartIndex === "number"
-              ? muxMeta.interruptedPartIndex
-              : undefined,
-          sideQuestionUserMsg: msg,
-          sideQuestionAnswerMsg: answerIsRenderable ? answer : undefined,
-        };
-        if (existing) {
-          existing.push(entry);
-        } else {
-          interruptionsByInterruptedId.set(muxMeta.interruptedMessageId, [entry]);
-        }
-      }
+      const sideQuestionDisplayPlan = this.buildSideQuestionDisplayPlan(
+        allMessages,
+        shouldHideMessageFromTranscript
+      );
 
       for (const message of allMessages) {
         maybeCollectAgentSkillSnapshot(message, latestAgentSkillSnapshotByKey);
-        const isSynthetic = message.metadata?.synthetic === true;
-        const isUiVisibleSynthetic = message.metadata?.uiVisible === true;
-
         // Synthetic messages are typically for model context only.
         // Show them only in debug mode, or when explicitly marked as UI-visible.
-        if (isSynthetic && !showSyntheticMessages && !isUiVisibleSynthetic) {
+        if (shouldHideMessageFromTranscript(message)) {
           continue;
         }
 
@@ -3379,11 +3490,11 @@ export class StreamingMessageAggregator {
         // guard the side-question pair would render twice — once between
         // the split halves and once at its natural sequence position
         // (below the interrupted message).
-        if (emittedAsSplitChildren.has(message.id)) {
+        if (sideQuestionDisplayPlan.inlineSideQuestionMessageIds.has(message.id)) {
           continue;
         }
 
-        const interrupts = interruptionsByInterruptedId.get(message.id);
+        const interrupts = sideQuestionDisplayPlan.interruptionsByInterruptedId.get(message.id);
         if (interrupts && message.role === "assistant") {
           // Interrupted main-agent message: build its display rows with
           // the /btw pair(s) interleaved in the middle. We bypass the
@@ -3396,12 +3507,6 @@ export class StreamingMessageAggregator {
             agentSkillSnapshotForDisplay,
             inlineSkillSnapshotState?.snapshots
           );
-          for (const interrupt of interrupts) {
-            emittedAsSplitChildren.add(interrupt.sideQuestionUserMsg.id);
-            if (interrupt.sideQuestionAnswerMsg) {
-              emittedAsSplitChildren.add(interrupt.sideQuestionAnswerMsg.id);
-            }
-          }
           if (splitRows.length > 0) {
             displayedMessages.push(...splitRows);
           }

--- a/src/browser/utils/messages/displayedMessageBuilder.ts
+++ b/src/browser/utils/messages/displayedMessageBuilder.ts
@@ -4,6 +4,7 @@ import type {
   InlineSkillSnapshotMap,
   MuxFilePart,
   MuxMessage,
+  SideQuestionDisplayBranch,
 } from "@/common/types/message";
 import { getCompactionFollowUpContent } from "@/common/types/message";
 import type { StreamErrorType } from "@/common/types/errors";
@@ -138,6 +139,27 @@ export function resolveRouteProvider(
   routedThroughGateway: boolean | undefined
 ): string | undefined {
   return routeProvider ?? (routedThroughGateway === true ? "mux-gateway" : undefined);
+}
+
+function getStandaloneSideQuestionBranch(
+  message: MuxMessage
+): SideQuestionDisplayBranch | undefined {
+  const muxMeta = message.metadata?.muxMetadata;
+  if (muxMeta?.type === "side-question") {
+    return {
+      branchId: message.id,
+      placement: "standalone",
+    };
+  }
+
+  if (muxMeta?.type === "side-question-answer") {
+    return {
+      branchId: muxMeta.questionMessageId ?? message.id,
+      placement: "standalone",
+    };
+  }
+
+  return undefined;
 }
 
 export function normalizeMessageRouteProvider(message: MuxMessage): MuxMessage {
@@ -354,6 +376,7 @@ function buildUserDisplayedMessages(options: {
       inlineSkillSnapshots,
       compactionRequest,
       reviews: muxMeta?.reviews,
+      sideQuestionBranch: getStandaloneSideQuestionBranch(message),
       isSideQuestion: isSideQuestionUserMessage(message) ? true : undefined,
     },
   ];
@@ -452,6 +475,7 @@ function appendAssistantTextRow(
     // Support both new enum ("user"|"idle") and legacy boolean (true).
     isCompacted: !!message.metadata?.compacted,
     isIdleCompacted: message.metadata?.compacted === "idle",
+    sideQuestionBranch: getStandaloneSideQuestionBranch(message),
     isSideAnswer: isSideQuestionAnswerMessage(message) ? true : undefined,
     model: message.metadata?.model,
     routedThroughGateway: message.metadata?.routedThroughGateway,

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -621,6 +621,13 @@ export type MuxMessage = Omit<UIMessage<MuxMetadata, never, never>, "parts"> & {
   parts: Array<MuxTextPart | MuxReasoningPart | MuxFilePart | MuxToolPart>;
 };
 
+export interface SideQuestionDisplayBranch {
+  branchId: string;
+  placement: "interrupted" | "standalone";
+  interruptedMessageId?: string;
+  interruptedHistorySequence?: number;
+}
+
 // DisplayedMessage represents a single UI message block
 // This is what the UI components consume, splitting complex messages into separate visual blocks
 export type DisplayedMessage =
@@ -668,6 +675,8 @@ export type DisplayedMessage =
       };
       /** Structured review data for rich UI display (from muxMetadata) */
       reviews?: ReviewNoteDataForDisplay[];
+      /** Display-only placement for /btw scroll/projection logic. */
+      sideQuestionBranch?: SideQuestionDisplayBranch;
       /** True when this user message is a /btw side question. */
       isSideQuestion?: boolean;
     }
@@ -685,6 +694,8 @@ export type DisplayedMessage =
       isIdleCompacted: boolean; // Whether this compaction was auto-triggered due to inactivity
       /** True when this assistant row predates the latest Context Boundary. */
       isBeforeLatestContextBoundary?: boolean;
+      /** Display-only placement for /btw scroll/projection logic. */
+      sideQuestionBranch?: SideQuestionDisplayBranch;
       /** True when this assistant row is the answer to a /btw side question. */
       isSideAnswer?: boolean;
       model?: string;


### PR DESCRIPTION
Summary
- Fixes recurring `/btw` transcript tail stickiness by making side-question display placement explicit and by limiting scroll ownership to valid interrupted branches.

Background
- `/btw` rows are durable history, but interrupted `/btw` branches are projected into the interrupted assistant message by the renderer. The previous display walk decided inline ownership during rendering, and scroll hold logic only looked at broad `isSideQuestion` / `isSideAnswer` flags. That made standalone or stale side-question rows eligible for sticky scroll behavior.

Implementation
- Adds display-only `sideQuestionBranch` placement metadata for `/btw` user and assistant rows.
- Precomputes a side-question display plan before rendering transcript rows so anchored `/btw` rows are emitted exactly once inside the interrupted assistant split.
- Validates `interruptedHistorySequence` when present to avoid splitting stale anchors.
- Makes side-question scroll hold require interrupted placement and expire once the side answer and interrupted main message have both settled.

Validation
- `bun test src/browser/utils/messages/StreamingMessageAggregator.sideQuestion.test.ts`
- `bun test src/browser/components/ChatPane/sideQuestionScrollHold.test.ts`
- `bun test src/browser/stores/WorkspaceStore.test.ts --test-name-pattern "/btw|side-question|side answer"`
- `bun run typecheck`
- `make static-check`

Risks
- Moderate localized risk around transcript projection and `/btw` scroll behavior. Legacy side-question answers without `questionMessageId` still use the existing adjacency fallback; stale or mismatched anchors now render chronologically instead of splitting an unrelated assistant row.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$31.98`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=31.98 -->
