### PR TITLE
🤖 ci: add agent-browser to nix dev shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -206,8 +206,11 @@
               # Documentation
               mdbook
               mdbook-mermaid
-              mdbook-linkcheck
+              mdbook-linkcheck2
               mdbook-pagetoc
+
+              # Browser automation
+              agent-browser
 
               # Terminal bench + browser recording
               uv

--- a/src/node/runtime/ptySpawn.ts
+++ b/src/node/runtime/ptySpawn.ts
@@ -1,4 +1,5 @@
-import type { IPty } from "node-pty";
+import type * as NodePty from "@lydell/node-pty";
+import type { IPty } from "@lydell/node-pty";
 import { log } from "@/node/services/log";
 import { getErrorMessage } from "@/common/utils/errors";
 import { sanitizeMuxChildEnv, sanitizeMuxChildPath } from "./childProcessEnv";
@@ -16,23 +17,20 @@ interface PtySpawnRequest {
   logLocalEnv?: boolean;
 }
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-function loadNodePty(runtimeType: string, preferElectronBuild: boolean): typeof import("node-pty") {
+function loadNodePty(runtimeType: string, preferElectronBuild: boolean): typeof NodePty {
   const first = preferElectronBuild ? "node-pty" : "@lydell/node-pty";
   const second = preferElectronBuild ? "@lydell/node-pty" : "node-pty";
 
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment
-    const pty = require(first);
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const pty = require(first) as typeof NodePty;
     log.debug(`Using ${first} for ${runtimeType}`);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return pty;
   } catch {
     try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment
-      const pty = require(second);
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const pty = require(second) as typeof NodePty;
       log.debug(`Using ${second} for ${runtimeType} (fallback)`);
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return pty;
     } catch (err) {
       log.error("Neither @lydell/node-pty nor node-pty available:", err);


### PR DESCRIPTION
Summary
- Adds `agent-browser` to the Nix develop shell for direct browser automation access.
- Updates the flake inputs to the latest nixpkgs revision.
- Switches the docs link-check package to `mdbook-linkcheck2`, which current nixpkgs requires, and keeps PTY type imports compatible when optional `node-pty` is absent.

Validation
- `nix fmt -- --check flake.nix`
- `nix develop --impure . --command sh -lc 'command -v agent-browser && agent-browser --help | head -20'`
- `nix develop --impure . --command make static-check`

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `medium` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=medium costs=0.00 -->
