### PR TITLE
🤖 fix: preserve browser file URL navigation

### DIFF
--- a/src/browser/features/RightSidebar/BrowserTab/BrowserToolbar.test.tsx
+++ b/src/browser/features/RightSidebar/BrowserTab/BrowserToolbar.test.tsx
@@ -135,6 +135,26 @@ describe("BrowserToolbar", () => {
     });
   });
 
+  test("preserves file URLs when submitting navigation", async () => {
+    const { onSetPendingUrl, getByLabelText } = renderToolbar({
+      pendingUrl: "file:///Users/me/report.html",
+    });
+    const input = getByLabelText("Browser URL") as HTMLInputElement;
+
+    input.focus();
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onSetPendingUrl).toHaveBeenCalledWith("file:///Users/me/report.html");
+    await waitFor(() => {
+      expect(controlMock).toHaveBeenCalledWith({
+        workspaceId: "workspace-1",
+        sessionName: "session-a",
+        action: "open",
+        url: "file:///Users/me/report.html",
+      });
+    });
+  });
+
   test("shows open command errors returned by the browser control API", async () => {
     controlMock.mockResolvedValueOnce({ success: false, error: "Navigation failed" });
     const { onSetPendingUrl, getByLabelText, getByText } = renderToolbar({

--- a/src/node/services/browser/AgentBrowserSessionDiscoveryService.ts
+++ b/src/node/services/browser/AgentBrowserSessionDiscoveryService.ts
@@ -1,12 +1,12 @@
 import assert from "node:assert/strict";
 import { spawn, type ChildProcess } from "node:child_process";
 import * as fsPromises from "node:fs/promises";
-import * as os from "node:os";
 import * as path from "node:path";
 import { getErrorMessage } from "@/common/utils/errors";
 import { log } from "@/node/services/log";
 import { DisposableProcess } from "@/node/utils/disposableExec";
 import { isPathInsideDir } from "@/node/utils/pathUtils";
+import { getAgentBrowserSocketDir } from "./agentBrowserSocketPaths";
 
 const CLI_TIMEOUT_MS = 30_000;
 const PROCESS_CWD_TIMEOUT_MS = 5_000;
@@ -229,26 +229,6 @@ interface AgentBrowserSessionDiscoveryServiceOptions {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
-}
-
-function getAgentBrowserSocketDir(env: NodeJS.ProcessEnv): string {
-  const override = env.AGENT_BROWSER_SOCKET_DIR?.trim();
-  if (override) {
-    return override;
-  }
-
-  const xdgRuntimeDir = env.XDG_RUNTIME_DIR?.trim();
-  if (xdgRuntimeDir) {
-    return path.join(xdgRuntimeDir, "agent-browser");
-  }
-
-  const homeDir = env.HOME?.trim();
-  if (homeDir) {
-    return path.join(homeDir, ".agent-browser");
-  }
-
-  const tmpDir = env.TMPDIR?.trim();
-  return path.join(tmpDir ?? os.tmpdir(), "agent-browser");
 }
 
 function extractSessionNames(payload: unknown): string[] {

--- a/src/node/services/browser/BrowserControlService.test.ts
+++ b/src/node/services/browser/BrowserControlService.test.ts
@@ -7,6 +7,7 @@ import {
   type BrowserControlAction,
   type BrowserControlParams,
 } from "./BrowserControlService";
+import type { SendAgentBrowserDaemonCommandFn } from "./agentBrowserCommandClient";
 
 const WORKSPACE_ID = "workspace-1";
 const SESSION_NAME = "session-a";
@@ -73,6 +74,7 @@ function createService(options?: {
   ) => Promise<ReturnType<typeof createAttachableSession> | null>;
   resolveSessionEnvFn?: (workspaceId: string) => Promise<NodeJS.ProcessEnv>;
   spawnFn?: SpawnFn;
+  sendDaemonCommandFn?: SendAgentBrowserDaemonCommandFn;
   timeoutMs?: number;
 }): BrowserControlService {
   return new BrowserControlService({
@@ -87,6 +89,7 @@ function createService(options?: {
       options?.resolveSessionEnvFn ??
       mock(() => Promise.resolve({ AGENT_BROWSER_SOCKET_DIR: "/tmp/socket" })),
     spawnFn: options?.spawnFn,
+    sendDaemonCommandFn: options?.sendDaemonCommandFn,
     timeoutMs: options?.timeoutMs,
   });
 }
@@ -184,6 +187,68 @@ describe("BrowserControlService", () => {
         windowsHide: true,
       });
     }
+  });
+
+  test("executeControl sends explicit file URLs directly to the daemon", async () => {
+    const spawnFn = mock(() => new MockChildProcess() as unknown as ChildProcess);
+    const resolveSessionEnvFn = mock(() => Promise.resolve({ TEST_ENV: "1" }));
+    const daemonCommandCalls: Array<Parameters<SendAgentBrowserDaemonCommandFn>[0]> = [];
+    const sendDaemonCommandFn = mock((options: Parameters<SendAgentBrowserDaemonCommandFn>[0]) => {
+      daemonCommandCalls.push(options);
+      return Promise.resolve({ success: true });
+    });
+    const service = createService({
+      spawnFn,
+      resolveSessionEnvFn,
+      sendDaemonCommandFn,
+    });
+
+    expect(
+      await service.executeControl({
+        workspaceId: WORKSPACE_ID,
+        sessionName: SESSION_NAME,
+        action: "open",
+        url: "file:///Users/me/report.html",
+      })
+    ).toEqual({ success: true });
+
+    expect(spawnFn).not.toHaveBeenCalled();
+    expect(resolveSessionEnvFn).toHaveBeenCalledWith(WORKSPACE_ID);
+    expect(sendDaemonCommandFn).toHaveBeenCalledTimes(1);
+    expect(daemonCommandCalls).toHaveLength(1);
+    expect(daemonCommandCalls[0]).toMatchObject({
+      env: { TEST_ENV: "1" },
+      sessionName: SESSION_NAME,
+      timeoutMs: 15_000,
+      command: {
+        action: "navigate",
+        url: "file:///Users/me/report.html",
+      },
+    });
+    expect(typeof daemonCommandCalls[0]?.command.id).toBe("string");
+  });
+
+  test("executeControl does not fall back to the CLI when file URL daemon navigation fails", async () => {
+    const spawnFn = mock(() => new MockChildProcess() as unknown as ChildProcess);
+    const sendDaemonCommandFn = mock(() =>
+      Promise.resolve({ success: false, error: "daemon rejected navigation" })
+    );
+    const service = createService({
+      spawnFn,
+      sendDaemonCommandFn,
+    });
+
+    expect(
+      await service.executeControl({
+        workspaceId: WORKSPACE_ID,
+        sessionName: SESSION_NAME,
+        action: "open",
+        url: "file:///Users/me/report.html",
+      })
+    ).toEqual({ success: false, error: "daemon rejected navigation" });
+
+    expect(sendDaemonCommandFn).toHaveBeenCalledTimes(1);
+    expect(spawnFn).not.toHaveBeenCalled();
   });
 
   test('executeControl requires a non-empty URL for "open"', async () => {

--- a/src/node/services/browser/BrowserControlService.ts
+++ b/src/node/services/browser/BrowserControlService.ts
@@ -1,11 +1,26 @@
 import assert from "node:assert/strict";
 import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
 import { getErrorMessage } from "@/common/utils/errors";
-import type { AgentBrowserSessionDiscoveryService } from "./AgentBrowserSessionDiscoveryService";
 import { DisposableProcess } from "@/node/utils/disposableExec";
+import type { AgentBrowserSessionDiscoveryService } from "./AgentBrowserSessionDiscoveryService";
+import {
+  sendAgentBrowserDaemonCommand,
+  type SendAgentBrowserDaemonCommandFn,
+} from "./agentBrowserCommandClient";
 
 const CONTROL_COMMAND_TIMEOUT_MS = 15_000;
 const BROWSER_CONTROL_ACTIONS = ["open", "back", "forward", "reload"] as const;
+
+let browserControlCommandCounter = 0;
+
+function createBrowserControlCommandId(): string {
+  browserControlCommandCounter += 1;
+  return `mux-browser-control-${Date.now()}-${browserControlCommandCounter}`;
+}
+
+function isExplicitFileUrl(url: string): boolean {
+  return url.toLowerCase().startsWith("file:");
+}
 
 type SpawnFn = (command: string, args: string[], options: SpawnOptions) => ChildProcess;
 
@@ -44,6 +59,7 @@ interface BrowserControlServiceOptions {
   browserSessionDiscoveryService: Pick<AgentBrowserSessionDiscoveryService, "getSessionConnection">;
   resolveSessionEnvFn?: (workspaceId: string) => Promise<NodeJS.ProcessEnv>;
   spawnFn?: SpawnFn;
+  sendDaemonCommandFn?: SendAgentBrowserDaemonCommandFn;
   timeoutMs?: number;
 }
 
@@ -51,6 +67,7 @@ export class BrowserControlService {
   private readonly browserSessionDiscoveryService: BrowserControlServiceOptions["browserSessionDiscoveryService"];
   private readonly resolveSessionEnvFn: (workspaceId: string) => Promise<NodeJS.ProcessEnv>;
   private readonly spawnFn: SpawnFn;
+  private readonly sendDaemonCommandFn: SendAgentBrowserDaemonCommandFn;
   private readonly timeoutMs: number;
 
   constructor(options: BrowserControlServiceOptions) {
@@ -62,6 +79,7 @@ export class BrowserControlService {
     this.browserSessionDiscoveryService = options.browserSessionDiscoveryService;
     this.resolveSessionEnvFn = options.resolveSessionEnvFn ?? (() => Promise.resolve(process.env));
     this.spawnFn = options.spawnFn ?? spawn;
+    this.sendDaemonCommandFn = options.sendDaemonCommandFn ?? sendAgentBrowserDaemonCommand;
     this.timeoutMs = options.timeoutMs ?? CONTROL_COMMAND_TIMEOUT_MS;
     assert(this.timeoutMs > 0, "BrowserControlService timeoutMs must be positive");
   }
@@ -86,6 +104,22 @@ export class BrowserControlService {
         connection.sessionName === params.sessionName,
         "BrowserControlService resolved session must match the requested session name"
       );
+
+      if (params.action === "open") {
+        const trimmedUrl = params.url!.trim();
+        if (isExplicitFileUrl(trimmedUrl)) {
+          const daemonResult = await this.navigateFileUrlViaDaemon(
+            params.workspaceId,
+            params.sessionName,
+            trimmedUrl
+          );
+          if (!daemonResult.success) {
+            return daemonResult;
+          }
+
+          return { success: true };
+        }
+      }
 
       const execution = await this.runAgentBrowserCommand(
         params.workspaceId,
@@ -198,6 +232,36 @@ export class BrowserControlService {
   private assertValidSessionIdentifiers(workspaceId: string, sessionName: string): void {
     assert(workspaceId.trim().length > 0, "BrowserControlService requires a non-empty workspaceId");
     assert(sessionName.trim().length > 0, "BrowserControlService requires a non-empty sessionName");
+  }
+
+  private async navigateFileUrlViaDaemon(
+    workspaceId: string,
+    sessionName: string,
+    url: string
+  ): Promise<BrowserControlResult> {
+    const env = await this.resolveSessionEnvFn(workspaceId);
+    const result = await this.sendDaemonCommandFn({
+      env,
+      sessionName,
+      timeoutMs: this.timeoutMs,
+      // Older agent-browser CLI parsers can normalize file:// into https:// before
+      // the daemon sees it. Send the navigation command directly for explicit file
+      // URLs so Mux preserves the exact local-file target the user requested.
+      command: {
+        id: createBrowserControlCommandId(),
+        action: "navigate",
+        url,
+      },
+    });
+
+    if (!result.success) {
+      return {
+        success: false,
+        error: result.error ?? `agent-browser navigate for session ${sessionName} failed`,
+      };
+    }
+
+    return { success: true };
   }
 
   private buildControlArgs(params: BrowserControlParams): string[] {

--- a/src/node/services/browser/agentBrowserCommandClient.test.ts
+++ b/src/node/services/browser/agentBrowserCommandClient.test.ts
@@ -1,0 +1,181 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import * as net from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  resolveAgentBrowserDaemonEndpoint,
+  sendAgentBrowserDaemonCommand,
+} from "./agentBrowserCommandClient";
+import {
+  getAgentBrowserPortForSession,
+  getAgentBrowserSocketDir,
+  getAgentBrowserSocketPath,
+} from "./agentBrowserSocketPaths";
+
+describe("agent-browser socket paths", () => {
+  test("resolves socket directory using the agent-browser priority order", () => {
+    expect(
+      getAgentBrowserSocketDir({
+        AGENT_BROWSER_SOCKET_DIR: "/custom/socket",
+        XDG_RUNTIME_DIR: "/run/user/1000",
+        HOME: "/home/alice",
+        TMPDIR: "/tmp/custom",
+      })
+    ).toBe("/custom/socket");
+    expect(
+      getAgentBrowserSocketDir({
+        AGENT_BROWSER_SOCKET_DIR: "",
+        XDG_RUNTIME_DIR: "/run/user/1000",
+        HOME: "/home/alice",
+        TMPDIR: "/tmp/custom",
+      })
+    ).toBe(path.join("/run/user/1000", "agent-browser"));
+    expect(
+      getAgentBrowserSocketDir({
+        AGENT_BROWSER_SOCKET_DIR: "",
+        XDG_RUNTIME_DIR: "",
+        HOME: "/home/alice",
+        TMPDIR: "/tmp/custom",
+      })
+    ).toBe(path.join("/home/alice", ".agent-browser"));
+    expect(
+      getAgentBrowserSocketDir({
+        AGENT_BROWSER_SOCKET_DIR: "",
+        XDG_RUNTIME_DIR: "",
+        HOME: "",
+        TMPDIR: "/tmp/custom",
+      })
+    ).toBe(path.join("/tmp/custom", "agent-browser"));
+  });
+
+  test("matches agent-browser's Windows fallback port hash", () => {
+    expect(getAgentBrowserPortForSession("default")).toBe(50838);
+    expect(getAgentBrowserPortForSession("my-session")).toBe(63105);
+    expect(getAgentBrowserPortForSession("work")).toBe(51184);
+    expect(getAgentBrowserPortForSession("")).toBe(49152);
+  });
+});
+
+async function closeServer(server: net.Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error != null) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+async function listenOnUnixSocket(server: net.Server, socketPath: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+describe("sendAgentBrowserDaemonCommand", () => {
+  test("retries transient daemon transport failures", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "mux-agent-browser-command-retry-"));
+    const socketPath = path.join(tempDir, "default.sock");
+    const receivedCommands: unknown[] = [];
+    let connectionCount = 0;
+    const server = net.createServer((socket) => {
+      connectionCount += 1;
+      if (connectionCount === 1) {
+        socket.end();
+        return;
+      }
+
+      let requestBuffer = "";
+      socket.on("data", (chunk: Buffer | string) => {
+        requestBuffer += chunk.toString();
+        const newlineIndex = requestBuffer.indexOf("\n");
+        if (newlineIndex === -1) {
+          return;
+        }
+
+        receivedCommands.push(JSON.parse(requestBuffer.slice(0, newlineIndex)));
+        socket.write(`${JSON.stringify({ success: true })}\n`);
+      });
+    });
+
+    try {
+      await listenOnUnixSocket(server, socketPath);
+
+      expect(
+        await sendAgentBrowserDaemonCommand({
+          env: { AGENT_BROWSER_SOCKET_DIR: tempDir },
+          sessionName: "default",
+          command: {
+            id: "cmd-1",
+            action: "navigate",
+            url: "file:///tmp/report.html",
+          },
+          timeoutMs: 1_000,
+          retryDelayMs: 1,
+        })
+      ).toEqual({ success: true });
+
+      expect(connectionCount).toBe(2);
+      expect(receivedCommands).toEqual([
+        { id: "cmd-1", action: "navigate", url: "file:///tmp/report.html" },
+      ]);
+    } finally {
+      await closeServer(server);
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("resolveAgentBrowserDaemonEndpoint", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "mux-agent-browser-command-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("uses Unix sockets outside Windows", async () => {
+    expect(
+      await resolveAgentBrowserDaemonEndpoint({
+        env: { AGENT_BROWSER_SOCKET_DIR: tempDir },
+        sessionName: "default",
+        platform: "linux",
+      })
+    ).toEqual({
+      kind: "unix",
+      socketPath: getAgentBrowserSocketPath({ AGENT_BROWSER_SOCKET_DIR: tempDir }, "default"),
+    });
+  });
+
+  test("uses the Windows port sidecar when present", async () => {
+    await writeFile(path.join(tempDir, "default.port"), "60000\n", "utf8");
+
+    expect(
+      await resolveAgentBrowserDaemonEndpoint({
+        env: { AGENT_BROWSER_SOCKET_DIR: tempDir },
+        sessionName: "default",
+        platform: "win32",
+      })
+    ).toEqual({ kind: "tcp", host: "127.0.0.1", port: 60000 });
+  });
+
+  test("falls back to the Windows hash-derived port when the sidecar is missing", async () => {
+    expect(
+      await resolveAgentBrowserDaemonEndpoint({
+        env: { AGENT_BROWSER_SOCKET_DIR: tempDir },
+        sessionName: "default",
+        platform: "win32",
+      })
+    ).toEqual({ kind: "tcp", host: "127.0.0.1", port: 50838 });
+  });
+});

--- a/src/node/services/browser/agentBrowserCommandClient.ts
+++ b/src/node/services/browser/agentBrowserCommandClient.ts
@@ -1,0 +1,288 @@
+import * as fsPromises from "node:fs/promises";
+import * as net from "node:net";
+import { setTimeout as delay } from "node:timers/promises";
+import assert from "node:assert/strict";
+import { getErrorMessage } from "@/common/utils/errors";
+import {
+  getAgentBrowserPortForSession,
+  getAgentBrowserPortPath,
+  getAgentBrowserSocketPath,
+} from "./agentBrowserSocketPaths";
+
+const MAX_DAEMON_COMMAND_ATTEMPTS = 5;
+const DAEMON_COMMAND_RETRY_DELAY_MS = 200;
+
+export interface AgentBrowserDaemonNavigateCommand {
+  id: string;
+  action: "navigate";
+  url: string;
+}
+
+export type AgentBrowserDaemonCommand = AgentBrowserDaemonNavigateCommand;
+
+export interface AgentBrowserDaemonCommandResponse {
+  success: boolean;
+  data?: unknown;
+  error?: string;
+}
+
+export interface SendAgentBrowserDaemonCommandOptions {
+  env: NodeJS.ProcessEnv;
+  sessionName: string;
+  command: AgentBrowserDaemonCommand;
+  timeoutMs: number;
+  retryDelayMs?: number;
+}
+
+export type SendAgentBrowserDaemonCommandFn = (
+  options: SendAgentBrowserDaemonCommandOptions
+) => Promise<AgentBrowserDaemonCommandResponse>;
+
+interface AgentBrowserUnixEndpoint {
+  kind: "unix";
+  socketPath: string;
+}
+
+interface AgentBrowserTcpEndpoint {
+  kind: "tcp";
+  host: string;
+  port: number;
+}
+
+export type AgentBrowserDaemonEndpoint = AgentBrowserUnixEndpoint | AgentBrowserTcpEndpoint;
+
+interface ResolveAgentBrowserDaemonEndpointOptions {
+  env: NodeJS.ProcessEnv;
+  sessionName: string;
+  platform?: NodeJS.Platform;
+  readFileFn?: typeof fsPromises.readFile;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseDaemonResponse(payload: string): AgentBrowserDaemonCommandResponse {
+  const parsed: unknown = JSON.parse(payload);
+  if (!isRecord(parsed) || typeof parsed.success !== "boolean") {
+    return { success: false, error: "agent-browser daemon returned an invalid response" };
+  }
+
+  const response: AgentBrowserDaemonCommandResponse = { success: parsed.success };
+  if ("data" in parsed) {
+    response.data = parsed.data;
+  }
+  if (typeof parsed.error === "string") {
+    response.error = parsed.error;
+  }
+  return response;
+}
+
+function parsePortFile(value: string): number | null {
+  const trimmedValue = value.trim();
+  if (!/^\d+$/.test(trimmedValue)) {
+    return null;
+  }
+
+  const port = Number.parseInt(trimmedValue, 10);
+  return Number.isInteger(port) && port > 0 && port <= 65535 ? port : null;
+}
+
+export async function resolveAgentBrowserDaemonEndpoint(
+  options: ResolveAgentBrowserDaemonEndpointOptions
+): Promise<AgentBrowserDaemonEndpoint> {
+  assert(options.sessionName.trim().length > 0, "agent-browser daemon requires a session name");
+  const platform = options.platform ?? process.platform;
+  if (platform !== "win32") {
+    return {
+      kind: "unix",
+      socketPath: getAgentBrowserSocketPath(options.env, options.sessionName),
+    };
+  }
+
+  let port = getAgentBrowserPortForSession(options.sessionName);
+  const readFileFn = options.readFileFn ?? fsPromises.readFile;
+  try {
+    const portFile = await readFileFn(
+      getAgentBrowserPortPath(options.env, options.sessionName),
+      "utf8"
+    );
+    port = parsePortFile(portFile) ?? port;
+  } catch {
+    // agent-browser falls back to a stable hash-derived TCP port when the sidecar
+    // file is missing or unreadable; do the same so file:// navigation still works
+    // while the daemon is starting on Windows.
+  }
+
+  return { kind: "tcp", host: "127.0.0.1", port };
+}
+
+function createSocket(endpoint: AgentBrowserDaemonEndpoint): net.Socket {
+  if (endpoint.kind === "unix") {
+    return net.createConnection(endpoint.socketPath);
+  }
+
+  return net.createConnection({ host: endpoint.host, port: endpoint.port });
+}
+
+export function isTransientAgentBrowserDaemonError(error: string): boolean {
+  return (
+    error.includes("EAGAIN") ||
+    error.includes("EWOULDBLOCK") ||
+    error.includes("WouldBlock") ||
+    error.includes("Resource temporarily unavailable") ||
+    error.includes("EOF") ||
+    error.includes("ENOENT") ||
+    error.includes("ECONNREFUSED") ||
+    error.includes("ECONNRESET") ||
+    error.includes("EPIPE") ||
+    error.includes("Connection reset") ||
+    error.includes("Broken pipe") ||
+    error.includes("agent-browser daemon closed before responding") ||
+    error.includes("os error 35") ||
+    error.includes("os error 11") ||
+    error.includes("os error 54") ||
+    error.includes("os error 104") ||
+    error.includes("os error 2") ||
+    error.includes("os error 61") ||
+    error.includes("os error 111") ||
+    error.includes("os error 10061") ||
+    error.includes("os error 10054")
+  );
+}
+
+export async function sendAgentBrowserDaemonCommand(
+  options: SendAgentBrowserDaemonCommandOptions
+): Promise<AgentBrowserDaemonCommandResponse> {
+  assert(options.sessionName.trim().length > 0, "agent-browser daemon requires a session name");
+  assert(options.timeoutMs > 0, "agent-browser daemon timeoutMs must be positive");
+
+  const startTimeMs = Date.now();
+  const retryDelayMs = options.retryDelayMs ?? DAEMON_COMMAND_RETRY_DELAY_MS;
+  let lastResult: AgentBrowserDaemonCommandResponse | null = null;
+
+  for (let attempt = 0; attempt < MAX_DAEMON_COMMAND_ATTEMPTS; attempt += 1) {
+    if (attempt > 0) {
+      const remainingBeforeDelayMs = options.timeoutMs - (Date.now() - startTimeMs);
+      if (remainingBeforeDelayMs <= 0) {
+        return createDaemonTimeoutResult(options);
+      }
+      await delay(Math.min(retryDelayMs * attempt, remainingBeforeDelayMs));
+    }
+
+    const remainingMs = options.timeoutMs - (Date.now() - startTimeMs);
+    if (remainingMs <= 0) {
+      return createDaemonTimeoutResult(options);
+    }
+
+    const endpoint = await resolveAgentBrowserDaemonEndpoint({
+      env: options.env,
+      sessionName: options.sessionName,
+    });
+    const result = await sendAgentBrowserDaemonCommandOnce(
+      { ...options, timeoutMs: remainingMs },
+      endpoint
+    );
+    if (
+      result.success ||
+      result.error == null ||
+      !isTransientAgentBrowserDaemonError(result.error)
+    ) {
+      return result;
+    }
+
+    lastResult = result;
+  }
+
+  return {
+    success: false,
+    error: `${lastResult?.error ?? "agent-browser daemon did not respond"} (after ${MAX_DAEMON_COMMAND_ATTEMPTS} attempts - daemon may be busy or unresponsive)`,
+  };
+}
+
+function createDaemonTimeoutResult(
+  options: SendAgentBrowserDaemonCommandOptions
+): AgentBrowserDaemonCommandResponse {
+  return {
+    success: false,
+    error: `agent-browser ${options.command.action} for session ${options.sessionName} timed out after ${options.timeoutMs}ms`,
+  };
+}
+
+async function sendAgentBrowserDaemonCommandOnce(
+  options: SendAgentBrowserDaemonCommandOptions,
+  endpoint: AgentBrowserDaemonEndpoint
+): Promise<AgentBrowserDaemonCommandResponse> {
+  return await new Promise<AgentBrowserDaemonCommandResponse>((resolve) => {
+    let socket: net.Socket;
+    try {
+      socket = createSocket(endpoint);
+    } catch (error) {
+      resolve({ success: false, error: getErrorMessage(error) });
+      return;
+    }
+
+    let settled = false;
+    let responseBuffer = "";
+
+    const finish = (result: AgentBrowserDaemonCommandResponse): void => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimeout(timeoutId);
+      socket.destroy();
+      resolve(result);
+    };
+
+    const timeoutId = setTimeout(() => {
+      finish(createDaemonTimeoutResult(options));
+    }, options.timeoutMs);
+    timeoutId.unref?.();
+
+    socket.setEncoding("utf8");
+    socket.once("connect", () => {
+      try {
+        socket.write(`${JSON.stringify(options.command)}\n`);
+      } catch (error) {
+        finish({ success: false, error: getErrorMessage(error) });
+      }
+    });
+
+    socket.on("data", (chunk: Buffer | string) => {
+      responseBuffer += chunk.toString();
+      const newlineIndex = responseBuffer.indexOf("\n");
+      if (newlineIndex === -1) {
+        return;
+      }
+
+      const responseLine = responseBuffer.slice(0, newlineIndex).trim();
+      if (responseLine.length === 0) {
+        finish({ success: false, error: "agent-browser daemon returned an empty response" });
+        return;
+      }
+
+      try {
+        finish(parseDaemonResponse(responseLine));
+      } catch (error) {
+        finish({
+          success: false,
+          error: `Invalid agent-browser daemon response: ${getErrorMessage(error)}`,
+        });
+      }
+    });
+
+    socket.once("end", () => {
+      finish({ success: false, error: "agent-browser daemon closed before responding" });
+    });
+
+    socket.once("error", (error) => {
+      finish({ success: false, error: getErrorMessage(error) });
+    });
+
+    socket.once("close", () => {
+      finish({ success: false, error: "agent-browser daemon closed before responding" });
+    });
+  });
+}

--- a/src/node/services/browser/agentBrowserSocketPaths.ts
+++ b/src/node/services/browser/agentBrowserSocketPaths.ts
@@ -1,0 +1,46 @@
+import * as os from "node:os";
+import * as path from "node:path";
+
+const WINDOWS_DYNAMIC_PORT_START = 49152;
+const WINDOWS_DYNAMIC_PORT_RANGE = 16383;
+
+export function getAgentBrowserSocketDir(env: NodeJS.ProcessEnv): string {
+  const override = env.AGENT_BROWSER_SOCKET_DIR?.trim();
+  if (override) {
+    return override;
+  }
+
+  const xdgRuntimeDir = env.XDG_RUNTIME_DIR?.trim();
+  if (xdgRuntimeDir) {
+    return path.join(xdgRuntimeDir, "agent-browser");
+  }
+
+  const homeDir = env.HOME?.trim();
+  if (homeDir) {
+    return path.join(homeDir, ".agent-browser");
+  }
+
+  const tmpDir = env.TMPDIR?.trim();
+  return path.join(tmpDir ?? os.tmpdir(), "agent-browser");
+}
+
+export function getAgentBrowserSocketPath(env: NodeJS.ProcessEnv, sessionName: string): string {
+  return path.join(getAgentBrowserSocketDir(env), `${sessionName}.sock`);
+}
+
+export function getAgentBrowserPortPath(env: NodeJS.ProcessEnv, sessionName: string): string {
+  return path.join(getAgentBrowserSocketDir(env), `${sessionName}.port`);
+}
+
+export function getAgentBrowserPortForSession(sessionName: string): number {
+  let hash = 0;
+  for (const char of sessionName) {
+    const charCode = char.codePointAt(0);
+    if (charCode == null) {
+      continue;
+    }
+    hash = (Math.imul(hash, 31) + charCode) | 0;
+  }
+
+  return WINDOWS_DYNAMIC_PORT_START + (Math.abs(hash) % WINDOWS_DYNAMIC_PORT_RANGE);
+}


### PR DESCRIPTION
Summary
- Fixes browser pane navigation for explicit `file://` URLs by preserving the local-file target end-to-end.

Background
- Closes #3382. The browser pane could route local file URLs through `agent-browser open`, where older CLI URL parsing normalized `file:///...` into an `https://...` URL before the daemon saw it.

Implementation
- Routes explicit `file:` opens directly to the selected agent-browser daemon with a `navigate` command, bypassing CLI URL normalization only for local-file URLs.
- Retries transient direct-daemon transport failures so file URL navigation keeps the same stale-socket/restarting-daemon resilience as the agent-browser CLI path.
- Shares agent-browser socket path resolution between session discovery and the new daemon command client.
- Keeps existing CLI behavior for non-file opens plus back/forward/reload/get-url commands.

Validation
- `bun test src/node/services/browser/BrowserControlService.test.ts`
- `bun test src/browser/features/RightSidebar/BrowserTab/BrowserToolbar.test.tsx`
- `bun test src/node/services/browser/agentBrowserCommandClient.test.ts`
- `bun test src/node/services/browser/AgentBrowserSessionDiscoveryService.test.ts`
- `make typecheck`
- `make lint`
- `make fmt-check`
- `make static-check`

Risks
- Low to moderate: the change adds a direct daemon protocol path, but scopes it to explicit `file:` opens and leaves existing browser control commands on their prior CLI path.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=0.00 -->
