### PR TITLE
🤖 fix: avoid upscaling capped browser preview frames

### DIFF
--- a/src/browser/features/RightSidebar/BrowserTab/BrowserViewport.test.tsx
+++ b/src/browser/features/RightSidebar/BrowserTab/BrowserViewport.test.tsx
@@ -74,6 +74,33 @@ describe("BrowserViewport", () => {
     ).toBeNull();
   });
 
+  test("maps intrinsic frame size so capped streams are not stretched into gutters", () => {
+    const highResolutionMetadata = {
+      ...FRAME_METADATA,
+      deviceWidth: 2160,
+      deviceHeight: 2160,
+    };
+
+    expect(
+      mapDomPointToViewport(
+        500,
+        500,
+        { left: 0, top: 0, width: 1000, height: 1000 },
+        highResolutionMetadata,
+        { frameImageSize: { width: 720, height: 720 } }
+      )
+    ).toEqual({ x: 1080, y: 1080 });
+    expect(
+      mapDomPointToViewport(
+        100,
+        500,
+        { left: 0, top: 0, width: 1000, height: 1000 },
+        highResolutionMetadata,
+        { frameImageSize: { width: 720, height: 720 } }
+      )
+    ).toBeNull();
+  });
+
   test("forwards mapped click and wheel input for interactive sessions", () => {
     const view = renderViewport(createSession());
     const viewport = view.getByRole("region", { name: "Browser viewport" });
@@ -153,6 +180,73 @@ describe("BrowserViewport", () => {
       y: 50,
       deltaX: 4,
       deltaY: 12,
+      modifiers: 0,
+    });
+  });
+
+  test("uses loaded screenshot dimensions for pointer hit testing", () => {
+    const view = renderViewport(
+      createSession({
+        frameMetadata: {
+          ...FRAME_METADATA,
+          deviceWidth: 2160,
+          deviceHeight: 2160,
+        },
+      })
+    );
+    const image = view.getByAltText("Browser session screenshot");
+    Object.defineProperties(image, {
+      naturalWidth: { configurable: true, value: 720 },
+      naturalHeight: { configurable: true, value: 720 },
+    });
+    fireEvent.load(image);
+
+    const viewport = view.getByRole("region", { name: "Browser viewport" });
+    Object.assign(viewport, {
+      setPointerCapture: () => undefined,
+      releasePointerCapture: () => undefined,
+      hasPointerCapture: () => true,
+    });
+    Object.defineProperty(viewport, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({
+        left: 0,
+        top: 0,
+        width: 1000,
+        height: 1000,
+        right: 1000,
+        bottom: 1000,
+        x: 0,
+        y: 0,
+        toJSON: () => undefined,
+      }),
+    });
+
+    fireEvent.pointerDown(viewport, {
+      pointerId: 7,
+      button: 0,
+      buttons: 1,
+      clientX: 100,
+      clientY: 500,
+      detail: 1,
+    });
+    fireEvent.pointerDown(viewport, {
+      pointerId: 8,
+      button: 0,
+      buttons: 1,
+      clientX: 500,
+      clientY: 500,
+      detail: 1,
+    });
+
+    expect(sendInputMock).toHaveBeenCalledTimes(1);
+    expect(sendInputMock).toHaveBeenCalledWith({
+      type: "input_mouse",
+      eventType: "mousePressed",
+      x: 1080,
+      y: 1080,
+      button: "left",
+      clickCount: 1,
       modifiers: 0,
     });
   });

--- a/src/browser/features/RightSidebar/BrowserTab/BrowserViewport.tsx
+++ b/src/browser/features/RightSidebar/BrowserTab/BrowserViewport.tsx
@@ -14,6 +14,7 @@ import { cn } from "@/common/lib/utils";
 import { clamp } from "@/common/utils/clamp";
 import assert from "@/common/utils/assert";
 import type {
+  BrowserFrameImageSize,
   BrowserViewportMetadata,
   BrowserInputEvent,
   BrowserKeyboardInput,
@@ -48,6 +49,11 @@ interface ViewportPoint {
   y: number;
 }
 
+interface BrowserFrameImageSnapshot {
+  sessionId: string;
+  imageSize: BrowserFrameImageSize;
+}
+
 interface BrowserViewportSessionSnapshot {
   sessionId: string | null;
   canInteract: boolean;
@@ -65,6 +71,9 @@ export function BrowserViewport(props: BrowserViewportProps) {
   assert(props.workspaceId.trim().length > 0, "BrowserViewport requires a workspaceId");
 
   const [hasFocus, setHasFocus] = useState(false);
+  const [frameImageSnapshot, setFrameImageSnapshot] = useState<BrowserFrameImageSnapshot | null>(
+    null
+  );
   const surfaceRef = useRef<HTMLDivElement | null>(null);
   const mountedRef = useRef(true);
   const sessionSnapshotRef = useRef<BrowserViewportSessionSnapshot>({
@@ -79,6 +88,8 @@ export function BrowserViewport(props: BrowserViewportProps) {
   const moveAnimationFrameRef = useRef<number | null>(null);
   const interactionState = getViewportInteractionState(props.session);
   const currentSessionId = props.session?.id ?? null;
+  const frameImageSize =
+    frameImageSnapshot?.sessionId === currentSessionId ? frameImageSnapshot.imageSize : null;
 
   sessionSnapshotRef.current = {
     sessionId: currentSessionId,
@@ -161,7 +172,7 @@ export function BrowserViewport(props: BrowserViewportProps) {
       queuedMove.clientY,
       currentSurface.getBoundingClientRect(),
       session.frameMetadata,
-      { clampOutsideContent: true }
+      { clampOutsideContent: true, frameImageSize }
     );
     if (mappedPoint == null) {
       return;
@@ -244,6 +255,31 @@ export function BrowserViewport(props: BrowserViewportProps) {
   const focusSurface = () => {
     surfaceRef.current?.focus({ preventScroll: true });
   };
+  const handleScreenshotLoad = (event: { currentTarget: HTMLImageElement }) => {
+    if (currentSessionId == null) {
+      return;
+    }
+
+    const imageSize = {
+      width: event.currentTarget.naturalWidth,
+      height: event.currentTarget.naturalHeight,
+    } satisfies BrowserFrameImageSize;
+    if (!isValidFrameImageSize(imageSize)) {
+      return;
+    }
+
+    setFrameImageSnapshot((previousSnapshot) => {
+      if (
+        previousSnapshot?.sessionId === currentSessionId &&
+        previousSnapshot.imageSize.width === imageSize.width &&
+        previousSnapshot.imageSize.height === imageSize.height
+      ) {
+        return previousSnapshot;
+      }
+
+      return { sessionId: currentSessionId, imageSize };
+    });
+  };
 
   const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
     if (!interactionState.canInteract || props.session == null) {
@@ -254,7 +290,8 @@ export function BrowserViewport(props: BrowserViewportProps) {
       event.clientX,
       event.clientY,
       event.currentTarget.getBoundingClientRect(),
-      props.session.frameMetadata
+      props.session.frameMetadata,
+      { frameImageSize }
     );
     if (mappedPoint == null) {
       return;
@@ -331,7 +368,7 @@ export function BrowserViewport(props: BrowserViewportProps) {
       event.clientY,
       event.currentTarget.getBoundingClientRect(),
       props.session.frameMetadata,
-      { clampOutsideContent: true }
+      { clampOutsideContent: true, frameImageSize }
     );
     if (mappedPoint != null) {
       sendInput(
@@ -366,7 +403,8 @@ export function BrowserViewport(props: BrowserViewportProps) {
       event.clientX,
       event.clientY,
       event.currentTarget.getBoundingClientRect(),
-      props.session.frameMetadata
+      props.session.frameMetadata,
+      { frameImageSize }
     );
     if (mappedPoint == null) {
       return;
@@ -468,7 +506,10 @@ export function BrowserViewport(props: BrowserViewportProps) {
         <img
           src={props.screenshotSrc}
           alt="Browser session screenshot"
-          className="pointer-events-none h-full w-full object-contain select-none"
+          onLoad={handleScreenshotLoad}
+          // agent-browser may cap screencast frames below the viewport size; rendering the
+          // captured bitmap at intrinsic size avoids making that capped stream blurrier.
+          className="pointer-events-none absolute top-1/2 left-1/2 max-h-full max-w-full -translate-x-1/2 -translate-y-1/2 select-none"
           draggable={false}
         />
         <div
@@ -651,7 +692,7 @@ export function mapDomPointToViewport(
   clientY: number,
   surfaceRect: MeasuredViewportRect,
   metadata: BrowserViewportMetadata | null,
-  options?: { clampOutsideContent?: boolean }
+  options?: { clampOutsideContent?: boolean; frameImageSize?: BrowserFrameImageSize | null }
 ): ViewportPoint | null {
   assert(metadata != null, "BrowserViewport requires frame metadata to map viewport coordinates");
   assert(Number.isFinite(metadata.deviceWidth), "BrowserViewport deviceWidth must be finite");
@@ -660,6 +701,54 @@ export function mapDomPointToViewport(
   assert(metadata.deviceHeight > 0, "BrowserViewport deviceHeight must be positive");
   assert(surfaceRect.width > 0, "BrowserViewport surface width must be positive");
   assert(surfaceRect.height > 0, "BrowserViewport surface height must be positive");
+
+  const renderedFrameRect = getRenderedFrameRect(surfaceRect, metadata, options?.frameImageSize);
+  const relativeX = clientX - renderedFrameRect.left;
+  const relativeY = clientY - renderedFrameRect.top;
+  const clampOutsideContent = options?.clampOutsideContent ?? false;
+
+  if (
+    !clampOutsideContent &&
+    (relativeX < 0 ||
+      relativeX > renderedFrameRect.width ||
+      relativeY < 0 ||
+      relativeY > renderedFrameRect.height)
+  ) {
+    return null;
+  }
+
+  const normalizedX = clamp(relativeX, 0, renderedFrameRect.width) / renderedFrameRect.width;
+  const normalizedY = clamp(relativeY, 0, renderedFrameRect.height) / renderedFrameRect.height;
+  return {
+    x: Math.round(clamp(normalizedX * metadata.deviceWidth, 0, metadata.deviceWidth)),
+    y: Math.round(clamp(normalizedY * metadata.deviceHeight, 0, metadata.deviceHeight)),
+  };
+}
+
+function getRenderedFrameRect(
+  surfaceRect: MeasuredViewportRect,
+  metadata: BrowserViewportMetadata,
+  frameImageSize: BrowserFrameImageSize | null | undefined
+): MeasuredViewportRect {
+  if (frameImageSize != null) {
+    assert(
+      isValidFrameImageSize(frameImageSize),
+      "BrowserViewport frame image size must be positive"
+    );
+    const renderedScale = Math.min(
+      surfaceRect.width / frameImageSize.width,
+      surfaceRect.height / frameImageSize.height,
+      1
+    );
+    const renderedWidth = frameImageSize.width * renderedScale;
+    const renderedHeight = frameImageSize.height * renderedScale;
+    return {
+      left: surfaceRect.left + (surfaceRect.width - renderedWidth) / 2,
+      top: surfaceRect.top + (surfaceRect.height - renderedHeight) / 2,
+      width: renderedWidth,
+      height: renderedHeight,
+    };
+  }
 
   const viewportAspectRatio = metadata.deviceWidth / metadata.deviceHeight;
   const surfaceAspectRatio = surfaceRect.width / surfaceRect.height;
@@ -671,23 +760,22 @@ export function mapDomPointToViewport(
     surfaceAspectRatio > viewportAspectRatio
       ? surfaceRect.height
       : surfaceRect.width / viewportAspectRatio;
-  const renderedLeft = surfaceRect.left + (surfaceRect.width - renderedWidth) / 2;
-  const renderedTop = surfaceRect.top + (surfaceRect.height - renderedHeight) / 2;
-  const relativeX = clientX - renderedLeft;
-  const relativeY = clientY - renderedTop;
-  const clampOutsideContent = options?.clampOutsideContent ?? false;
-
-  if (
-    !clampOutsideContent &&
-    (relativeX < 0 || relativeX > renderedWidth || relativeY < 0 || relativeY > renderedHeight)
-  ) {
-    return null;
-  }
-
-  const normalizedX = clamp(relativeX, 0, renderedWidth) / renderedWidth;
-  const normalizedY = clamp(relativeY, 0, renderedHeight) / renderedHeight;
   return {
-    x: Math.round(clamp(normalizedX * metadata.deviceWidth, 0, metadata.deviceWidth)),
-    y: Math.round(clamp(normalizedY * metadata.deviceHeight, 0, metadata.deviceHeight)),
+    left: surfaceRect.left + (surfaceRect.width - renderedWidth) / 2,
+    top: surfaceRect.top + (surfaceRect.height - renderedHeight) / 2,
+    width: renderedWidth,
+    height: renderedHeight,
   };
+}
+
+function isValidFrameImageSize(
+  frameImageSize: BrowserFrameImageSize | null | undefined
+): frameImageSize is BrowserFrameImageSize {
+  return (
+    frameImageSize != null &&
+    Number.isFinite(frameImageSize.width) &&
+    Number.isFinite(frameImageSize.height) &&
+    frameImageSize.width > 0 &&
+    frameImageSize.height > 0
+  );
 }

--- a/src/browser/features/RightSidebar/BrowserTab/browserBridgeTypes.ts
+++ b/src/browser/features/RightSidebar/BrowserTab/browserBridgeTypes.ts
@@ -10,6 +10,11 @@ export interface BrowserViewportMetadata {
   scrollOffsetY: number;
 }
 
+export interface BrowserFrameImageSize {
+  width: number;
+  height: number;
+}
+
 export type BrowserDiscoveredSessionStatus = "attachable" | "missing_stream";
 
 export interface BrowserDiscoveredSession {


### PR DESCRIPTION
Summary

Avoid making capped agent-browser screencast frames blurrier by rendering Browser Preview screenshots at their intrinsic captured bitmap size instead of always stretching them to fill the preview pane.

Background

Issue #3115 reports that Browser Preview becomes blurry at high viewport resolutions. Mux receives already-encoded frames from agent-browser, so it cannot restore detail lost by upstream capture caps. This change keeps Mux from further degrading capped streams by upscaling the received bitmap.

Implementation

- Track the loaded screenshot's natural dimensions per browser session.
- Center the screenshot with max bounds rather than forcing full width/height object-contain scaling.
- Map pointer coordinates through the actual rendered frame rectangle so clicks, wheels, and drag moves still land correctly when the frame is letterboxed.

Validation

- `bun test src/browser/features/RightSidebar/BrowserTab/BrowserViewport.test.tsx`
- `nix shell --extra-experimental-features 'nix-command flakes' nixpkgs#shfmt nixpkgs#shellcheck nixpkgs#hadolint -c make static-check`

Risks

Low-to-moderate Browser Preview risk: rendering and input mapping changed for sessions where captured frame dimensions differ from the preview panel. Tests cover capped-frame gutters and existing object-contain coordinate behavior.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `88851{MUX_COSTS_USD:-0.00}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=0.00 -->
