### PR TITLE
🤖 fix: correct browser preview click offset

### DIFF
--- a/src/browser/features/RightSidebar/BrowserTab/BrowserViewport.test.tsx
+++ b/src/browser/features/RightSidebar/BrowserTab/BrowserViewport.test.tsx
@@ -101,6 +101,72 @@ describe("BrowserViewport", () => {
     ).toBeNull();
   });
 
+  test("maps decoded frame height when Chrome outer height differs from the page viewport", () => {
+    expect(
+      mapDomPointToViewport(
+        640,
+        317,
+        { left: 0, top: 0, width: 1280, height: 633 },
+        { ...FRAME_METADATA, deviceWidth: 1280, deviceHeight: 720 },
+        { frameImageSize: { width: 1280, height: 633 } }
+      )
+    ).toEqual({ x: 640, y: 317 });
+  });
+
+  test("uses decoded frame dimensions for click input when outer height differs", () => {
+    const view = renderViewport(
+      createSession({
+        frameMetadata: { ...FRAME_METADATA, deviceWidth: 1280, deviceHeight: 720 },
+      })
+    );
+    const image = view.getByAltText("Browser session screenshot") as HTMLImageElement;
+    const viewport = view.getByRole("region", { name: "Browser viewport" });
+
+    Object.defineProperties(image, {
+      naturalWidth: { configurable: true, value: 1280 },
+      naturalHeight: { configurable: true, value: 633 },
+    });
+    fireEvent.load(image);
+    Object.assign(viewport, {
+      setPointerCapture: () => undefined,
+      releasePointerCapture: () => undefined,
+      hasPointerCapture: () => true,
+    });
+    Object.defineProperty(viewport, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({
+        left: 0,
+        top: 0,
+        width: 1280,
+        height: 633,
+        right: 1280,
+        bottom: 633,
+        x: 0,
+        y: 0,
+        toJSON: () => undefined,
+      }),
+    });
+
+    fireEvent.pointerDown(viewport, {
+      pointerId: 7,
+      button: 0,
+      buttons: 1,
+      clientX: 640,
+      clientY: 317,
+      detail: 1,
+    });
+
+    expect(sendInputMock).toHaveBeenCalledWith({
+      type: "input_mouse",
+      eventType: "mousePressed",
+      x: 640,
+      y: 317,
+      button: "left",
+      clickCount: 1,
+      modifiers: 0,
+    });
+  });
+
   test("forwards mapped click and wheel input for interactive sessions", () => {
     const view = renderViewport(createSession());
     const viewport = view.getByRole("region", { name: "Browser viewport" });

--- a/src/browser/features/RightSidebar/BrowserTab/BrowserViewport.tsx
+++ b/src/browser/features/RightSidebar/BrowserTab/BrowserViewport.tsx
@@ -719,9 +719,18 @@ export function mapDomPointToViewport(
 
   const normalizedX = clamp(relativeX, 0, renderedFrameRect.width) / renderedFrameRect.width;
   const normalizedY = clamp(relativeY, 0, renderedFrameRect.height) / renderedFrameRect.height;
+  const coordinateWidth = metadata.deviceWidth;
+  // agent-browser reports Chrome's outer viewport height in metadata, but the
+  // screencast JPEG can be the page viewport. Derive the Y coordinate space from
+  // the decoded frame aspect so clicks land under the visible cursor.
+  const coordinateHeight =
+    options?.frameImageSize == null
+      ? metadata.deviceHeight
+      : coordinateWidth * (options.frameImageSize.height / options.frameImageSize.width);
+
   return {
-    x: Math.round(clamp(normalizedX * metadata.deviceWidth, 0, metadata.deviceWidth)),
-    y: Math.round(clamp(normalizedY * metadata.deviceHeight, 0, metadata.deviceHeight)),
+    x: Math.round(clamp(normalizedX * coordinateWidth, 0, coordinateWidth)),
+    y: Math.round(clamp(normalizedY * coordinateHeight, 0, coordinateHeight)),
   };
 }
 


### PR DESCRIPTION
Summary
- Fix Browser tab pointer coordinate mapping when agent-browser frame images are shorter than Chrome's reported outer viewport.
- Add regression coverage for decoded frame dimensions driving click coordinates.

Background
- During live testing, clicks in the Browser preview landed below the cursor because stream metadata reported an outer height (for example 720px) while the displayed JPEG frame represented the page viewport (for example 633px).

Implementation
- Continue using decoded frame image dimensions for rendered hit testing, and derive the Y coordinate space from that frame aspect when a frame image size is available.
- Preserve existing capped-stream behavior while correcting the outer-height/page-frame mismatch.

Validation
- `bun test src/browser/features/RightSidebar/BrowserTab/BrowserTab.test.tsx src/browser/features/RightSidebar/BrowserTab/BrowserToolbar.test.tsx src/browser/features/RightSidebar/BrowserTab/BrowserViewport.test.tsx src/browser/features/RightSidebar/BrowserTab/useBrowserBridgeConnection.test.tsx`
- `nix develop --command make static-check`

Risks
- Low. The change is scoped to Browser preview pointer coordinate mapping and keeps the existing fallback for frames without decoded image dimensions.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `108995{MUX_COSTS_USD:-0.00}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=0.00 -->
