### PR TITLE
🤖 fix: stop forwarding OpenRouter model catalog

### DIFF
--- a/src/node/services/providerModelFactory.test.ts
+++ b/src/node/services/providerModelFactory.test.ts
@@ -1225,6 +1225,45 @@ describe("ProviderModelFactory routing", () => {
     });
   });
 
+  it("omits configured model catalog from OpenRouter request body", async () => {
+    await withTempConfig(async (config, factory) => {
+      const originalOpenRouterRegistry = PROVIDER_REGISTRY.openrouter;
+      let capturedExtraBody: unknown;
+
+      config.saveProvidersConfig({
+        openrouter: {
+          apiKey: "or-test",
+          models: [
+            "openai/gpt-5",
+            "anthropic/claude-sonnet-4.6",
+            "google/gemini-3-pro",
+            "x-ai/grok-4",
+          ],
+          allow_fallbacks: false,
+        },
+      });
+
+      PROVIDER_REGISTRY.openrouter = async () => {
+        const module = await originalOpenRouterRegistry();
+        return {
+          ...module,
+          createOpenRouter: (options) => {
+            capturedExtraBody = options?.extraBody;
+            return module.createOpenRouter(options);
+          },
+        };
+      };
+
+      try {
+        const result = await factory.createModel("openrouter:openai/gpt-5");
+        expect(result.success).toBe(true);
+        expect(capturedExtraBody).toEqual({ provider: { allow_fallbacks: false } });
+      } finally {
+        PROVIDER_REGISTRY.openrouter = originalOpenRouterRegistry;
+      }
+    });
+  });
+
   it("routes Anthropic models through Bedrock when Bedrock is configured and prioritized", async () => {
     await withTempConfig(async (config, factory) => {
       config.saveProvidersConfig({

--- a/src/node/services/providerModelFactory.ts
+++ b/src/node/services/providerModelFactory.ts
@@ -1819,12 +1819,15 @@ export class ProviderModelFactory {
         }
         const baseFetch = getProviderFetch(providerConfig);
 
-        // Extract standard provider settings (apiKey, baseUrl, headers, fetch)
+        // Extract standard provider settings and Mux-local metadata before building extraBody.
+        // OpenRouter also has a request-level `models` fallback field capped at 3 entries; our
+        // configured `models` catalog can be longer and must not be forwarded as request input.
         const {
           apiKey: _apiKey,
           baseUrl,
           headers,
           fetch: _fetch,
+          models: _models,
           ...extraOptions
         } = providerConfig;
 


### PR DESCRIPTION
Summary
- Fixes #3119 by keeping Mux's configured OpenRouter model catalog out of request-level `extraBody`.

Background
- OpenRouter caps request-level model fallback arrays at three entries, while Mux provider config can store longer model catalogs for routing/UI metadata.

Implementation
- Destructure `models` out of the OpenRouter provider config before converting passthrough options into `extraBody`.
- Preserve supported OpenRouter routing options under `extraBody.provider`.
- Add regression coverage for a four-model OpenRouter config.

Validation
- `bun test src/node/services/providerModelFactory.test.ts`
- `nix develop --command make static-check`

Risks
- Low: scoped to OpenRouter provider option assembly. Existing OpenRouter routing options remain covered by the regression assertion.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=0.00 -->
