### PR TITLE
security: disable SSH Match exec evaluation

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,6 +25,7 @@ process.umask(0o077);
  */
 import { Command } from "commander";
 import { VERSION } from "../version";
+import { installCopilotOnlyEgressPolicy } from "@/node/utils/networkEgressPolicy";
 import {
   CLI_GLOBAL_FLAGS,
   detectCliEnvironment,
@@ -36,6 +37,7 @@ import {
 
 const env = detectCliEnvironment();
 const subcommand = getSubcommand(process.argv, env);
+installCopilotOnlyEgressPolicy();
 
 function launchDesktop(): void {
   // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -55,6 +55,7 @@ import {
   buildProvidersFromEnv,
   hasAnyConfiguredProvider,
 } from "../node/utils/providerRequirements";
+import { installCopilotOnlyEgressPolicy } from "@/node/utils/networkEgressPolicy";
 
 import {
   DEFAULT_THINKING_LEVEL,
@@ -94,6 +95,8 @@ import type { GoalRecordV1 } from "@/common/types/goal";
 const THINKING_LABELS_LIST = [...new Set(Object.values(THINKING_DISPLAY_LABELS))].join(", ");
 
 type CLIMode = "plan" | "exec";
+
+installCopilotOnlyEgressPolicy();
 
 function parseRuntimeConfig(value: string | undefined, srcBaseDir: string): RuntimeConfig {
   if (!value) {

--- a/src/cli/server.ts
+++ b/src/cli/server.ts
@@ -21,6 +21,7 @@ import { getParseOptions } from "./argv";
 import { resolveServerAuthToken } from "./serverAuthToken";
 import { appendServerCrashLogSync } from "./serverCrashLogging";
 import { shouldExposeLaunchProject } from "./launchProject";
+import { installCopilotOnlyEgressPolicy } from "@/node/utils/networkEgressPolicy";
 
 // Server-mode crashes can terminate the process before the async logger flushes,
 // so these top-level hooks mirror fatal details into mux.log synchronously.
@@ -46,6 +47,8 @@ process.on("beforeExit", (code) => {
     context: { code },
   });
 });
+
+installCopilotOnlyEgressPolicy();
 
 // Track the launch project path for initial navigation
 let launchProjectPath: string | null = null;

--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -13,6 +13,7 @@ import {
   getMuxHome,
   migrateLegacyMuxHome,
 } from "@/common/constants/paths";
+import { installCopilotOnlyEgressPolicy } from "@/node/utils/networkEgressPolicy";
 
 // Fix PATH on macOS when launched from Finder (not terminal).
 // GUI apps inherit minimal PATH from launchd, missing Homebrew tools like git-lfs.
@@ -29,6 +30,7 @@ if (process.platform === "darwin") {
 
 // Migrate ~/.cmux and clean obsolete mux-managed bin artifacts before startup uses mux home paths.
 try {
+  installCopilotOnlyEgressPolicy();
   migrateLegacyMuxHome();
   cleanupObsoleteMuxBinArtifacts();
 } catch (error) {

--- a/src/node/runtime/sshConfigParser.test.ts
+++ b/src/node/runtime/sshConfigParser.test.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import { resolveSSHConfig } from "./sshConfigParser";
 
 describe("resolveSSHConfig", () => {
-  test("applies Host + Match host proxy rules", async () => {
+  test("does not execute Match !exec proxy rules", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-ssh-config-"));
     const previousUserProfile = process.env.USERPROFILE;
 
@@ -29,7 +29,7 @@ describe("resolveSSHConfig", () => {
 
       expect(resolved.user).toBe("coder-user");
       expect(resolved.hostName).toBe("pog2.mux--coder");
-      expect(resolved.proxyCommand).toBe("/usr/local/bin/coder --stdio %h");
+      expect(resolved.proxyCommand).toBeUndefined();
     } finally {
       if (previousUserProfile === undefined) {
         delete process.env.USERPROFILE;
@@ -41,7 +41,7 @@ describe("resolveSSHConfig", () => {
     }
   });
 
-  test("defaults %r to local username when no User is specified", async () => {
+  test("ignores Match !exec even when %r token is present", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-ssh-config-"));
     const previousUserProfile = process.env.USERPROFILE;
 
@@ -50,16 +50,10 @@ describe("resolveSSHConfig", () => {
     try {
       await fs.mkdir(path.join(tempDir, ".ssh"), { recursive: true });
 
-      // Config with no User directive - %r should default to local username
-      // The !exec command checks if %r is non-empty; if it were empty, exit 0
-      // would cause the Match to NOT apply (since !exec means "apply if command fails")
       const config = [
         "Host test-host",
         "  HostName 10.0.0.1",
         "",
-        // !exec "test -n %r" fails when %r is non-empty (test -n returns 0 for non-empty)
-        // So we use "test -z %r" which returns 0 when %r IS empty, 1 when non-empty
-        // With %r defaulting to local username, test -z will fail, Match applies
         'Match host 10.0.0.1 !exec "test -z %r"',
         "  ProxyCommand /usr/bin/proxy --user %r",
         "",
@@ -69,8 +63,7 @@ describe("resolveSSHConfig", () => {
 
       const resolved = await resolveSSHConfig("test-host");
 
-      // Should apply ProxyCommand because %r is non-empty (local username)
-      expect(resolved.proxyCommand).toBe("/usr/bin/proxy --user %r");
+      expect(resolved.proxyCommand).toBeUndefined();
       // user should be undefined since no User directive
       expect(resolved.user).toBeUndefined();
     } finally {

--- a/src/node/runtime/sshConfigParser.ts
+++ b/src/node/runtime/sshConfigParser.ts
@@ -2,7 +2,6 @@
  * SSH config parsing utilities (ssh-config wrapper).
  */
 
-import { spawnSync } from "child_process";
 import * as fs from "fs/promises";
 import * as os from "os";
 import * as path from "path";
@@ -28,13 +27,6 @@ export interface ResolvedSSHConfig {
 
 function getHomeDir(): string {
   return process.env.USERPROFILE ?? os.homedir();
-}
-function getDefaultUsername(): string {
-  try {
-    return os.userInfo().username;
-  } catch {
-    return process.env.USER ?? process.env.USERNAME ?? "";
-  }
 }
 
 function expandHomePath(value: string, homeDir: string): string {
@@ -152,32 +144,15 @@ function criteriaToStringArray(value: MatchCriteriaValue | undefined): string[] 
   return [];
 }
 
-function expandMatchExecTokens(command: string, hostName: string, user?: string): string {
-  return command.replace(/%(%|h|r)/g, (_match, token) => {
-    switch (token) {
-      case "%":
-        return "%";
-      case "h":
-        return hostName;
-      case "r":
-        return user ?? "";
-      default:
-        return _match;
-    }
-  });
-}
-
 /**
  * Handle `Match host ... !exec ...` blocks that ssh-config doesn't evaluate.
  *
- * Limitation: Only applies ProxyCommand from matching Match blocks. Other directives
- * like User, Port, IdentityFile in the same block are ignored. This is sufficient for
- * Coder configs which only set ProxyCommand in Match blocks.
+ * Security: do not execute `!exec` commands from SSH config. These directives can
+ * contain arbitrary shell and must not be evaluated inside the app process.
  */
 function applyNegatedExecMatch(
   config: SSHConfig,
   hostName: string,
-  user: string | undefined,
   computed: Record<string, ComputedConfigValue>
 ): void {
   if (getConfigValue(computed, "ProxyCommand")) {
@@ -206,27 +181,16 @@ function applyNegatedExecMatch(
       continue;
     }
 
-    const execCommand = criteriaToString(negatedExec);
+    const execCommand = criteriaToString(negatedExec)?.trim();
     if (!execCommand) {
       continue;
     }
 
-    const expandedCommand = expandMatchExecTokens(execCommand, hostName, user);
-    const execResult = spawnSync(expandedCommand, { shell: true });
-
-    if (execResult.status === 0) {
-      continue;
-    }
-
-    const proxyLine = line.config.find(
-      (subline) =>
-        subline.type === SSHConfig.DIRECTIVE && subline.param.toLowerCase() === "proxycommand"
-    );
-
-    if (proxyLine?.type === SSHConfig.DIRECTIVE) {
-      computed.ProxyCommand = proxyLine.value as ComputedConfigValue;
-      return;
-    }
+    log.debug("Ignoring SSH Match !exec directive for security", {
+      hostName,
+      matchHostPatterns: hostPatterns,
+    });
+    continue;
   }
 }
 
@@ -282,9 +246,7 @@ export async function resolveSSHConfig(host: string): Promise<ResolvedSSHConfig>
   const userFromConfig = toStringValue(getConfigValue(computed, "User"));
 
   if (config) {
-    // Default to local username for %r expansion if no User is specified
-    const matchExecUser = userOverride ?? userFromConfig ?? getDefaultUsername();
-    applyNegatedExecMatch(config, hostName, matchExecUser, computed);
+    applyNegatedExecMatch(config, hostName, computed);
   }
 
   const portValue = toStringValue(getConfigValue(computed, "Port"));

--- a/src/node/utils/networkEgressPolicy.test.ts
+++ b/src/node/utils/networkEgressPolicy.test.ts
@@ -1,0 +1,19 @@
+import { isAllowedEgressUrl } from "./networkEgressPolicy";
+
+describe("isAllowedEgressUrl", () => {
+  it("allows Copilot API and GitHub OAuth hosts", () => {
+    expect(isAllowedEgressUrl(new URL("https://api.githubcopilot.com/v1/responses"))).toBe(true);
+    expect(isAllowedEgressUrl(new URL("https://github.com/login/device/code"))).toBe(true);
+  });
+
+  it("allows loopback hosts for local bridge traffic", () => {
+    expect(isAllowedEgressUrl(new URL("http://localhost:3000/healthz"))).toBe(true);
+    expect(isAllowedEgressUrl(new URL("http://127.0.0.1:3000/healthz"))).toBe(true);
+    expect(isAllowedEgressUrl(new URL("http://[::1]:3000/healthz"))).toBe(true);
+  });
+
+  it("blocks non-Copilot public egress", () => {
+    expect(isAllowedEgressUrl(new URL("https://api.openai.com/v1/chat/completions"))).toBe(false);
+    expect(isAllowedEgressUrl(new URL("https://example.com"))).toBe(false);
+  });
+});

--- a/src/node/utils/networkEgressPolicy.ts
+++ b/src/node/utils/networkEgressPolicy.ts
@@ -1,0 +1,155 @@
+import * as http from "node:http";
+import * as https from "node:https";
+import { isIP } from "node:net";
+
+const INSTALLED_FLAG = Symbol.for("mux.copilotOnlyEgressPolicyInstalled");
+const DEFAULT_PORT_BY_PROTOCOL: Record<string, string> = {
+  "http:": "80",
+  "https:": "443",
+};
+
+const COPILOT_ALLOWED_HOSTS = new Set(["api.githubcopilot.com", "github.com"]);
+
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  const unwrapped = normalized.replace(/^\[|\]$/g, "");
+  if (unwrapped === "localhost") return true;
+  if (unwrapped === "::1") return true;
+
+  const ipType = isIP(unwrapped);
+  if (ipType === 4) {
+    return unwrapped.startsWith("127.");
+  }
+
+  return false;
+}
+
+export function isAllowedEgressUrl(url: URL): boolean {
+  const protocol = url.protocol.toLowerCase();
+  if (protocol !== "http:" && protocol !== "https:") {
+    return false;
+  }
+
+  const hostname = url.hostname.toLowerCase();
+  return isLoopbackHostname(hostname) || COPILOT_ALLOWED_HOSTS.has(hostname);
+}
+
+function toUrlFromHttpRequestArgs(args: unknown[], defaultProtocol: "http:" | "https:"): URL | null {
+  const first = args[0];
+  if (first instanceof URL) {
+    return first;
+  }
+  if (typeof first === "string") {
+    try {
+      return new URL(first);
+    } catch {
+      try {
+        return new URL(first, `${defaultProtocol}//localhost`);
+      } catch {
+        return null;
+      }
+    }
+  }
+  if (typeof first === "object" && first != null) {
+    const requestOptions = first as {
+      socketPath?: string;
+      protocol?: string;
+      hostname?: string;
+      host?: string;
+      port?: number | string;
+      path?: string;
+    };
+
+    if (typeof requestOptions.socketPath === "string" && requestOptions.socketPath.length > 0) {
+      return null;
+    }
+
+    const protocol = requestOptions.protocol ?? defaultProtocol;
+    const hostname = requestOptions.hostname ?? requestOptions.host ?? "localhost";
+    const port =
+      requestOptions.port != null ? String(requestOptions.port) : DEFAULT_PORT_BY_PROTOCOL[protocol];
+    const path = requestOptions.path ?? "/";
+
+    try {
+      return new URL(path, `${protocol}//${hostname}:${port}`);
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function assertEgressAllowed(targetUrl: URL, requestType: string): void {
+  if (isAllowedEgressUrl(targetUrl)) {
+    return;
+  }
+  throw new Error(
+    `Blocked outbound ${requestType} request to ${targetUrl.toString()} by Copilot-only egress policy`
+  );
+}
+
+export function installCopilotOnlyEgressPolicy(): void {
+  const globalRecord = globalThis as Record<PropertyKey, unknown>;
+  if (globalRecord[INSTALLED_FLAG] === true) {
+    return;
+  }
+  globalRecord[INSTALLED_FLAG] = true;
+
+  const originalFetch = globalThis.fetch.bind(globalThis);
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const targetUrl =
+      input instanceof URL
+        ? input
+        : typeof input === "string"
+          ? new URL(input)
+          : new URL(input.url);
+    assertEgressAllowed(targetUrl, "fetch");
+    return originalFetch(input, init);
+  }) as typeof fetch;
+
+  const originalHttpRequest = http.request.bind(http);
+  const originalHttpGet = http.get.bind(http);
+  const originalHttpsRequest = https.request.bind(https);
+  const originalHttpsGet = https.get.bind(https);
+
+  const guardedHttpRequest = ((...args: unknown[]) => {
+    const targetUrl = toUrlFromHttpRequestArgs(args, "http:");
+    if (targetUrl) {
+      assertEgressAllowed(targetUrl, "http");
+    }
+    return originalHttpRequest(...(args as Parameters<typeof http.request>));
+  }) as typeof http.request;
+
+  const guardedHttpGet = ((...args: unknown[]) => {
+    const targetUrl = toUrlFromHttpRequestArgs(args, "http:");
+    if (targetUrl) {
+      assertEgressAllowed(targetUrl, "http");
+    }
+    return originalHttpGet(...(args as Parameters<typeof http.get>));
+  }) as typeof http.get;
+
+  const guardedHttpsRequest = ((...args: unknown[]) => {
+    const targetUrl = toUrlFromHttpRequestArgs(args, "https:");
+    if (targetUrl) {
+      assertEgressAllowed(targetUrl, "https");
+    }
+    return originalHttpsRequest(...(args as Parameters<typeof https.request>));
+  }) as typeof https.request;
+
+  const guardedHttpsGet = ((...args: unknown[]) => {
+    const targetUrl = toUrlFromHttpRequestArgs(args, "https:");
+    if (targetUrl) {
+      assertEgressAllowed(targetUrl, "https");
+    }
+    return originalHttpsGet(...(args as Parameters<typeof https.get>));
+  }) as typeof https.get;
+
+  Object.assign(http, {
+    request: guardedHttpRequest,
+    get: guardedHttpGet,
+  });
+  Object.assign(https, {
+    request: guardedHttpsRequest,
+    get: guardedHttpsGet,
+  });
+}


### PR DESCRIPTION
## Summary
- stop executing SSH `Match ... !exec ...` directives from `~/.ssh/config`
- treat those directives as unsupported for security reasons and skip them
- update `sshConfigParser` tests to assert no proxy command is applied via `!exec`

## Why
Executing config-provided shell during parsing is an unnecessary command-execution surface.