### PR TITLE
Prevent XSS via unsafe href protocols in WebFetchToolCall

### DIFF
--- a/src/browser/features/Tools/WebFetchToolCall.tsx
+++ b/src/browser/features/Tools/WebFetchToolCall.tsx
@@ -36,7 +36,7 @@ interface NormalizedResult {
 }
 
 /**
- * Only allow http/https URLs as clickable hrefs to prevent javascript: XSS.
+ * Allowlist http/https for clickable hrefs. Blocks javascript:, data:, vbscript:, etc.
  */
 function isSafeHref(url: string): boolean {
   try {

--- a/src/browser/features/Tools/WebFetchToolCall.tsx
+++ b/src/browser/features/Tools/WebFetchToolCall.tsx
@@ -36,6 +36,18 @@ interface NormalizedResult {
 }
 
 /**
+ * Only allow http/https URLs as clickable hrefs to prevent javascript: XSS.
+ */
+function isSafeHref(url: string): boolean {
+  try {
+    const protocol = new URL(url).protocol;
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Extract domain from URL for compact display
  */
 function getDomain(url: string): string {
@@ -144,14 +156,18 @@ export const WebFetchToolCall: React.FC<WebFetchToolCallProps> = ({
             <div className="bg-code-bg flex flex-wrap gap-4 rounded px-2 py-1.5 text-[11px] leading-[1.4]">
               <div className="flex min-w-0 gap-1.5">
                 <span className="text-secondary font-medium">URL:</span>
-                <a
-                  href={args.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-link font-monospace truncate hover:underline"
-                >
-                  {args.url}
-                </a>
+                {isSafeHref(args.url) ? (
+                  <a
+                    href={args.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-link font-monospace truncate hover:underline"
+                  >
+                    {args.url}
+                  </a>
+                ) : (
+                  <span className="font-monospace truncate">{args.url}</span>
+                )}
               </div>
               {normalized?.success && normalized.title && (
                 <div className="flex min-w-0 gap-1.5">


### PR DESCRIPTION
## Summary
Add URL validation to prevent javascript: and other unsafe protocol XSS attacks when rendering fetched URLs as clickable links in the WebFetchToolCall component.

## Changes
- **New `isSafeHref()` function**: Validates that URLs use only http: or https: protocols before rendering as clickable `<a>` tags. Uses `URL` constructor for robust parsing and safely catches malformed URLs.
- **Conditional link rendering**: URLs that fail the safety check are now rendered as plain `<span>` elements instead of clickable links, preventing potential XSS while still displaying the URL text.

## Implementation Details
The validation happens at render time in the URL display section. Safe URLs render as before with full link functionality; unsafe URLs (including malformed ones) degrade gracefully to plain text, maintaining readability without the security risk.

https://claude.ai/code/session_015vY8c55jcKPoPNKm2264uC