### PR TITLE
🤖 fix: guard direnv allow in init hook

### DIFF
--- a/.mux/init
+++ b/.mux/init
@@ -2,7 +2,11 @@
 set -euo pipefail
 
 echo "Installing dependencies with bun..."
+# Some contributors use direnv-managed toolchains; only opt in when direnv exists.
+if command -v direnv >/dev/null 2>&1; then
+  direnv allow
+fi
+
 # Keep tool bootstrap read-only for lockfiles so opening a workspace never dirties bun.lock.
 bun install --frozen-lockfile
 echo "Dependencies installed successfully!"
-


### PR DESCRIPTION
## Summary

Guard the `.mux/init` `direnv allow` step so workspace bootstrap only runs it when `direnv` is installed.

## Background

The init hook should support contributors who use direnv-managed toolchains without breaking environments where `direnv` is not present.

## Validation

- `bash -n .mux/init`

---

_Generated with `mux` • Model: `unknown` • Thinking: `unknown` • Cost: `$0.00`_

<!-- mux-attribution: model=unknown thinking=unknown costs=0.00 -->