### PR TITLE
🤖 fix: repair Nix native rebuild tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,8 +131,22 @@ ensure-deps: node_modules/.installed
 # Rebuild native modules for Electron
 rebuild-native: node_modules/.installed ## Rebuild native modules (node-pty, DuckDB) for Electron
 	@echo "Rebuilding native modules for Electron..."
-	@npx @electron/rebuild -f -m node_modules/node-pty
-	@npx @electron/rebuild -f -m node_modules/@duckdb/node-bindings
+	@# Failed optional native installs can leave node_modules/.installed newer than package.json
+	@# while node-pty itself is missing; refresh once so this target can self-heal.
+	@if [ ! -f node_modules/node-pty/package.json ]; then \
+		echo "node-pty package missing; refreshing optional dependencies..."; \
+		bun install --frozen-lockfile; \
+	fi
+	@if [ -f node_modules/node-pty/package.json ]; then \
+		npx @electron/rebuild -f -m node_modules/node-pty; \
+	else \
+		echo "node-pty package missing; skipping node-pty rebuild"; \
+	fi
+	@if [ -f node_modules/@duckdb/node-bindings/package.json ]; then \
+		npx @electron/rebuild -f -m node_modules/@duckdb/node-bindings; \
+	else \
+		echo "DuckDB node bindings package missing; skipping DuckDB rebuild"; \
+	fi
 	@echo "Native modules rebuilt successfully"
 
 # Run compiled CLI with trailing arguments (builds only if missing)

--- a/flake.nix
+++ b/flake.nix
@@ -185,6 +185,8 @@
               # Node + build tooling
               nodejs
               gnumake
+              # node-gyp requires Python when rebuilding Electron native modules.
+              python3
               stdenv.cc.cc.lib # Provides libstdc++.so.6 for DuckDB native bindings under Bun
 
               # Common CLIs

--- a/fmt.mk
+++ b/fmt.mk
@@ -82,10 +82,11 @@ else ifeq ($(wildcard flake.nix),)
 	@echo "flake.nix not found; skipping Nix format check"
 else
 	@echo "Checking flake.nix formatting..."
+	@# Nix flakes in temp dirs still need a Git root so copied files are visible.
 	@tmp_dir=$$(mktemp -d "$${TMPDIR:-/tmp}/fmt-nix-check.XXXXXX"); \
 	trap "rm -rf $$tmp_dir" EXIT; \
 	cp flake.nix flake.lock package.json bun.lock "$$tmp_dir/"; \
-	(cd "$$tmp_dir" && nix fmt -- flake.nix >/dev/null 2>&1); \
+	(cd "$$tmp_dir" && git init -q && git add flake.nix flake.lock package.json bun.lock && nix fmt -- flake.nix >/dev/null 2>&1); \
 	if ! cmp -s flake.nix "$$tmp_dir/flake.nix"; then \
 		echo "flake.nix is not formatted correctly. Run 'make fmt-nix' to fix."; \
 		diff -u flake.nix "$$tmp_dir/flake.nix" || true; \

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -35,12 +35,12 @@ if [ ! -d "$ELECTRON_PATH" ]; then
 fi
 
 HAS_NODE_PTY=0
-if [ -d "$NODE_PTY_PATH" ]; then
+if [ -f "$NODE_PTY_PATH/package.json" ]; then
   HAS_NODE_PTY=1
 fi
 
 HAS_DUCKDB=0
-if [ -d "$DUCKDB_NODE_API_PATH" ] && [ -d "$DUCKDB_NODE_BINDINGS_PATH" ]; then
+if [ -f "$DUCKDB_NODE_API_PATH/package.json" ] && [ -f "$DUCKDB_NODE_BINDINGS_PATH/package.json" ]; then
   HAS_DUCKDB=1
 fi
 


### PR DESCRIPTION
Summary
- Add Python to the Nix dev shell so node-gyp can rebuild Electron native modules.
- Make `make rebuild-native` recover when a previous failed optional install left `node-pty` missing from `node_modules`.
- Harden native-module presence checks and Nix format checking in temporary directories.

Background
This fixes the NixOS native rebuild path where `node-gyp` first failed without Python and then `@electron/rebuild` failed with ENOENT for `node_modules/node-pty/package.json` after the optional dependency was left missing.

Validation
- `make fmt-nix-check`
- `nix develop --command make rebuild-native`
- `make static-check`

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=0.00 -->
