### PR TITLE
🤖 feat: complete Claude Opus 4.8 metadata coverage

### DIFF
--- a/benchmarks/terminal_bench/prepare_leaderboard_submission.py
+++ b/benchmarks/terminal_bench/prepare_leaderboard_submission.py
@@ -109,6 +109,13 @@ MODEL_METADATA = {
         "model_org_display_name": "Anthropic",
         "folder_name": "Claude-Opus-4.7",
     },
+    "anthropic/claude-opus-4-8": {
+        "model_name": "claude-opus-4-8",
+        "model_provider": "anthropic",
+        "model_display_name": "Claude Opus 4.8",
+        "model_org_display_name": "Anthropic",
+        "folder_name": "Claude-Opus-4.8",
+    },
     # Keep historical GPT metadata alongside the current GPT-5.5 bench target
     # so mixed or older artifact sets still map to the canonical leaderboard names.
     "openai/gpt-5.2": {
@@ -442,7 +449,7 @@ def main():
     parser.add_argument(
         "--models",
         nargs="+",
-        help="Only process specific models (e.g., anthropic/claude-opus-4-7, openai/gpt-5.5)",
+        help="Only process specific models (e.g., anthropic/claude-opus-4-8, openai/gpt-5.5)",
     )
     args = parser.parse_args()
 

--- a/src/browser/features/Settings/Sections/ModelsSection.stories.tsx
+++ b/src/browser/features/Settings/Sections/ModelsSection.stories.tsx
@@ -76,7 +76,7 @@ export const ModelsConfigured: Story = {
               isEnabled: true,
               isConfigured: true,
               baseUrl: "",
-              models: ["claude-sonnet-4-20250514", "claude-opus-4-7"],
+              models: ["claude-sonnet-4-20250514", "claude-opus-4-8"],
             },
             openai: {
               apiKeySet: true,

--- a/src/common/routing/types.ts
+++ b/src/common/routing/types.ts
@@ -1,7 +1,7 @@
 import type { ProviderName } from "@/common/constants/providers";
 
 export interface RouteContext {
-  /** Canonical model string (e.g., "anthropic:claude-opus-4-7") */
+  /** Canonical model string (e.g., "anthropic:claude-opus-4-8") */
   canonical: string;
   /** Origin provider — who made the model. Determines capabilities. */
   origin: ProviderName;

--- a/src/common/types/thinking.ts
+++ b/src/common/types/thinking.ts
@@ -167,7 +167,7 @@ export const ANTHROPIC_THINKING_BUDGETS: Record<ThinkingLevel, number> = {
  * Note: Opus 4.7 introduced a native "xhigh" effort level in the API, but the
  * SDK's Zod validator still rejects "xhigh". Mux handles this by sending "max"
  * through the SDK and rewriting `output_config.effort` to "xhigh" in a fetch
- * wrapper for Opus 4.7 when the user selected the xhigh ThinkingLevel.
+ * wrapper for Opus 4.7+ when the user selected the xhigh ThinkingLevel.
  * See `wrapFetchWithAnthropicCacheControl` and `buildRequestHeaders`.
  */
 export type AnthropicEffortLevel = "low" | "medium" | "high" | "max";
@@ -189,7 +189,7 @@ const ANTHROPIC_EFFORT: Record<ThinkingLevel, AnthropicEffortLevel> = {
   low: "low",
   medium: "medium",
   high: "high",
-  xhigh: "max", // SDK placeholder; fetch wrapper rewrites to "xhigh" on Opus 4.7
+  xhigh: "max", // SDK placeholder; fetch wrapper rewrites to "xhigh" on Opus 4.7+
   max: "max",
 };
 

--- a/src/common/utils/ai/models.test.ts
+++ b/src/common/utils/ai/models.test.ts
@@ -122,7 +122,9 @@ describe("Anthropic 1M context classification", () => {
     expect(hasNative1MContext("anthropic:claude-sonnet-4-5")).toBe(false);
   });
 
-  it("treats Opus 4.6 and Sonnet 4.6 as native 1M models", () => {
+  it("treats Opus 4.6 through 4.8 and Sonnet 4.6 as native 1M models", () => {
+    expect(getAnthropic1MContextMode("anthropic:claude-opus-4-8")).toBe("native");
+    expect(getAnthropic1MContextMode("anthropic:claude-opus-4-8-20260528")).toBe("native");
     expect(getAnthropic1MContextMode("anthropic:claude-opus-4-6")).toBe("native");
     expect(getAnthropic1MContextMode("anthropic:claude-opus-4-6-20260201")).toBe("native");
     expect(getAnthropic1MContextMode("anthropic:claude-sonnet-4-6")).toBe("native");

--- a/src/common/utils/ai/providerOptions.test.ts
+++ b/src/common/utils/ai/providerOptions.test.ts
@@ -962,7 +962,7 @@ describe("buildRequestHeaders", () => {
     });
   }
 
-  describe("Opus 4.7 xhigh effort override", () => {
+  describe("Opus 4.7+ xhigh effort override", () => {
     for (const { name, model, routeProvider, thinkingLevel, expected } of [
       {
         name: "emits override header when thinkingLevel=xhigh for Opus 4.7",
@@ -979,8 +979,7 @@ describe("buildRequestHeaders", () => {
         expected: { [MUX_ANTHROPIC_EFFORT_OVERRIDE_HEADER]: "xhigh" },
       },
       {
-        name: "emits override header for hypothetical Opus 4.8",
-        // Detection should match future versions so xhigh doesn't silently collapse to max.
+        name: "emits override header for Opus 4.8",
         model: "anthropic:claude-opus-4-8",
         routeProvider: undefined,
         thinkingLevel: "xhigh",

--- a/src/common/utils/ai/providerOptions.ts
+++ b/src/common/utils/ai/providerOptions.ts
@@ -32,7 +32,7 @@ import { normalizeToCanonical, supports1MContext } from "./models";
 /**
  * Request header used to override Anthropic's `output_config.effort` at the
  * wire level. The @ai-sdk/anthropic Zod schema rejects "xhigh", so for
- * Opus 4.7 + xhigh ThinkingLevel we send "max" through the SDK and ask the
+ * Opus 4.7+ with xhigh ThinkingLevel we send "max" through the SDK and ask the
  * fetch wrapper to rewrite it to "xhigh" via this header (which is then stripped
  * before the request reaches Anthropic).
  */
@@ -283,7 +283,7 @@ export function buildProviderOptions(
     const usesAdaptiveThinking = isOpus46 || isOpus47Plus || isSonnet46;
 
     if (isOpus45 || usesAdaptiveThinking) {
-      // Map to SDK-accepted effort. For Opus 4.7 + xhigh ThinkingLevel, the SDK
+      // Map to SDK-accepted effort. For Opus 4.7+ with xhigh ThinkingLevel, the SDK
       // gets "max" as a placeholder and the Anthropic fetch wrapper rewrites
       // `output_config.effort` to "xhigh" via the X-Mux-Anthropic-Effort header
       // (added in buildRequestHeaders).
@@ -305,10 +305,10 @@ export function buildProviderOptions(
         thinkingLevel: effectiveThinking,
       });
 
-      // Note: Opus 4.7 requires `thinking.display: "summarized"` to receive
+      // Note: Opus 4.7+ requires `thinking.display: "summarized"` to receive
       // thinking content, but the SDK's Zod schema strips unknown keys so we
       // can't add it here. The Anthropic fetch wrapper injects `display` on the
-      // wire for Opus 4.7 + adaptive thinking requests.
+      // wire for Opus 4.7+ adaptive thinking requests.
       const anthropicOptions: AnthropicProviderOptions = {
         disableParallelToolUse: false,
         sendReasoning: true,

--- a/src/common/utils/thinking/policy.test.ts
+++ b/src/common/utils/thinking/policy.test.ts
@@ -342,8 +342,8 @@ describe("getThinkingPolicyForModel", () => {
     ]);
   });
 
-  test("returns all 6 levels for future Opus versions (4.8+, 5+)", () => {
-    // Detection should extend forward so future models don't regress to the default policy.
+  test("returns all 6 levels for Opus 4.8 and future Opus versions", () => {
+    // Detection should extend forward so new Opus models don't regress to the default policy.
     expect(getThinkingPolicyForModel("anthropic:claude-opus-4-8")).toEqual([
       "off",
       "low",

--- a/src/node/services/providerModelFactory.test.ts
+++ b/src/node/services/providerModelFactory.test.ts
@@ -1746,20 +1746,22 @@ function parseSentBody(call: CapturedFetchCall): Record<string, unknown> {
   return JSON.parse(call.init.body as string) as Record<string, unknown>;
 }
 
-describe("wrapFetchWithAnthropicCacheControl — Opus 4.7 wire transforms", () => {
-  it("injects thinking.display=summarized for Opus 4.7 adaptive thinking", async () => {
-    const { calls, fakeFetch } = createCapturingFetch();
-    const wrapped = wrapFetchWithAnthropicCacheControl(fakeFetch);
-    const body = JSON.stringify({
-      model: "claude-opus-4-7",
-      thinking: { type: "adaptive" },
-      output_config: { effort: "medium" },
+describe("wrapFetchWithAnthropicCacheControl — Opus 4.7+ wire transforms", () => {
+  for (const model of ["claude-opus-4-7", "claude-opus-4-8"] as const) {
+    it(`injects thinking.display=summarized for ${model} adaptive thinking`, async () => {
+      const { calls, fakeFetch } = createCapturingFetch();
+      const wrapped = wrapFetchWithAnthropicCacheControl(fakeFetch);
+      const body = JSON.stringify({
+        model,
+        thinking: { type: "adaptive" },
+        output_config: { effort: "medium" },
+      });
+      await wrapped("https://api.anthropic.com/v1/messages", { method: "POST", body });
+      expect(calls.length).toBe(1);
+      const sent = parseSentBody(calls[0]);
+      expect(sent.thinking).toEqual({ type: "adaptive", display: "summarized" });
     });
-    await wrapped("https://api.anthropic.com/v1/messages", { method: "POST", body });
-    expect(calls.length).toBe(1);
-    const sent = parseSentBody(calls[0]);
-    expect(sent.thinking).toEqual({ type: "adaptive", display: "summarized" });
-  });
+  }
 
   it("preserves a user-supplied display value on Opus 4.7", async () => {
     const { calls, fakeFetch } = createCapturingFetch();

--- a/src/node/services/providerModelFactory.ts
+++ b/src/node/services/providerModelFactory.ts
@@ -1453,7 +1453,7 @@ export class ProviderModelFactory {
         // Use getProviderFetch to preserve any user-configured custom fetch (e.g., proxies)
         const baseFetch = getProviderFetch(providerConfig);
         const disableBeta = muxProviderOptions?.anthropic?.disableBetaFeatures === true;
-        // Always wrap to apply Opus 4.7 wire-level transforms (display + effort
+        // Always wrap to apply Opus 4.7+ wire-level transforms (display + effort
         // override); skip cache_control injection when beta features are off.
         const fetchWithCacheControl = wrapFetchWithAnthropicCacheControl(
           baseFetch,
@@ -1965,7 +1965,7 @@ export class ProviderModelFactory {
         const baseFetch = getProviderFetch(providerConfig);
         const isAnthropicModel = modelId.startsWith("anthropic/");
         const disableBeta = muxProviderOptions?.anthropic?.disableBetaFeatures === true;
-        // For Anthropic models via gateway, always wrap to apply Opus 4.7 wire
+        // For Anthropic models via gateway, always wrap to apply Opus 4.7+ wire
         // transforms; skip cache_control injection when beta features are off.
         const fetchWithCacheControl = isAnthropicModel
           ? wrapFetchWithAnthropicCacheControl(baseFetch, effectiveAnthropicCacheTtl, {


### PR DESCRIPTION
## Summary

Completes the Claude Opus 4.8 rollout on top of the upstream default-model bump by adding the remaining metadata, examples, and regression coverage that mirror the previous Opus upgrade pattern.

## Background

`main` now includes the core Claude Opus 4.8 default-model update from #3409. After rebasing this branch onto `main`, this PR is the follow-up diff: Terminal-Bench leaderboard metadata, story/test fixtures, model-routing examples, and explicit Opus 4.8 coverage around native 1M/xhigh behavior.

## Implementation

- Adds `anthropic/claude-opus-4-8` to Terminal-Bench leaderboard submission metadata and examples.
- Updates the Models settings story fixture to use Opus 4.8.
- Updates routing/example comments and Opus 4.7+ thinking/provider comments to describe the forward-compatible behavior accurately.
- Adds explicit Opus 4.8 assertions for native 1M context, xhigh effort override, and Anthropic wire transforms.
- Table-drives duplicated Opus 4.7/4.8 wire-transform test setup from the simplify/deslop pass.

## Validation

- `bun test src/common/constants/knownModels.test.ts src/common/utils/ai/models.test.ts src/common/utils/ai/providerOptions.test.ts src/node/services/providerModelFactory.test.ts src/browser/hooks/useModelsFromSettings.test.ts`
- `make static-check`
- `git diff --check`

## Risks

Low risk: the default model bump itself is already on `main`; this PR only fills in surrounding metadata, examples, and tests. Runtime changes are limited to comments and test coverage, with no behavior change beyond leaderboard metadata availability.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$13.05`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=13.05 -->
