### PR TITLE
🤖 fix: refine hyper density work bundling

### DIFF
--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -1243,13 +1243,14 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
                         msg.type === "user" ||
                         (msg.type === "assistant" && msg.isSideAnswer === true);
                       if (
-                        workBundle?.position === "member" &&
+                        (workBundle?.position === "member" || workBundle?.position === "final") &&
                         (isWorkBundleExpanded || !keepCollapsedWorkBundleMemberVisible)
                       ) {
                         return null;
                       }
 
                       const renderWorkBundle = workBundle?.position === "head";
+                      const renderMessageBeforeWorkBundle = renderWorkBundle && msg.type === "user";
                       const renderMessageAfterWorkBundle = !renderWorkBundle;
                       const operationalBundle = workBundle
                         ? undefined
@@ -1275,6 +1276,10 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
 
                       return (
                         <React.Fragment key={`${workspaceId}:${msg.id}`}>
+                          {renderMessageBeforeWorkBundle &&
+                            renderMessageAtIndex(msg, index, {
+                              key: `${workspaceId}:${msg.id}:message`,
+                            })}
                           {renderWorkBundle && workBundle && (
                             <WorkBundleMessage
                               item={workBundle}

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -1241,7 +1241,8 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
 
                       const keepCollapsedWorkBundleMemberVisible =
                         msg.type === "user" ||
-                        (msg.type === "assistant" && msg.isSideAnswer === true);
+                        (msg.type === "assistant" &&
+                          (msg.isSideAnswer === true || workBundle?.position === "final"));
                       if (
                         (workBundle?.position === "member" || workBundle?.position === "final") &&
                         (isWorkBundleExpanded || !keepCollapsedWorkBundleMemberVisible)

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -1239,7 +1239,13 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
                         ? (workBundleOverride ?? workBundle.defaultExpanded)
                         : false;
 
-                      if (workBundle?.position === "member") {
+                      const keepCollapsedWorkBundleMemberVisible =
+                        msg.type === "user" ||
+                        (msg.type === "assistant" && msg.isSideAnswer === true);
+                      if (
+                        workBundle?.position === "member" &&
+                        (isWorkBundleExpanded || !keepCollapsedWorkBundleMemberVisible)
+                      ) {
                         return null;
                       }
 

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -1321,23 +1321,20 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
                                   key={`${workspaceId}:${workBundle.key}:${entry.message.id}`}
                                 >
                                   {renderNestedBundle && nestedOperationalBundle && (
-                                    <div className="ml-4">
-                                      <OperationalBundleMessage
-                                        item={nestedOperationalBundle}
-                                        expanded={isNestedExpanded}
-                                        onToggle={() =>
-                                          setOperationalBundleExpanded(
-                                            nestedOperationalBundle.key,
-                                            !isNestedExpanded
-                                          )
-                                        }
-                                      />
-                                    </div>
+                                    <OperationalBundleMessage
+                                      item={nestedOperationalBundle}
+                                      expanded={isNestedExpanded}
+                                      onToggle={() =>
+                                        setOperationalBundleExpanded(
+                                          nestedOperationalBundle.key,
+                                          !isNestedExpanded
+                                        )
+                                      }
+                                    />
                                   )}
                                   {renderNestedMessage &&
                                     renderMessageAtIndex(entry.message, entry.originalIndex, {
                                       key: `${workspaceId}:${workBundle.key}:${entry.message.id}:message`,
-                                      className: nestedOperationalBundle ? "ml-8" : "ml-4",
                                     })}
                                 </React.Fragment>
                               );

--- a/src/browser/features/Messages/TranscriptDensity.stories.tsx
+++ b/src/browser/features/Messages/TranscriptDensity.stories.tsx
@@ -148,15 +148,16 @@ export const HyperActiveExpandedBundle: AppStory = {
       setup={() => {
         collapseLeftSidebar();
         setDensity("hyper");
+        const activeStartedAt = Date.now() - 40_000;
         return setupSimpleChatStory({
           messages: [
             createUserMessage("active-user-1", "Inspect the repository", {
               historySequence: 1,
-              timestamp: STABLE_TIMESTAMP - 40_000,
+              timestamp: activeStartedAt - 5_000,
             }),
             createAssistantMessage("active-assistant-1", "I'll read the key files now.", {
               historySequence: 2,
-              timestamp: STABLE_TIMESTAMP - 35_000,
+              timestamp: activeStartedAt,
               toolCalls: [
                 createPendingTool("active-read-1", "file_read", { path: "src/App.tsx" }),
                 createPendingTool("active-search-1", "web_search", {

--- a/src/browser/features/Messages/TranscriptDensity.stories.tsx
+++ b/src/browser/features/Messages/TranscriptDensity.stories.tsx
@@ -36,6 +36,7 @@ function setupTranscriptDensityStory(density: TranscriptDensity) {
       createAssistantMessage("density-assistant-1", "I'll gather context first.", {
         historySequence: 2,
         timestamp: STABLE_TIMESTAMP - 55_000,
+        partial: true,
         reasoning:
           "Need to inspect auth code, search related validation guidance, and then make a minimal patch.",
         toolCalls: [
@@ -43,38 +44,56 @@ function setupTranscriptDensityStory(density: TranscriptDensity) {
           createWebSearchTool("density-search-1", "JWT validation best practices", 3),
           createAgentSkillReadTool("density-skill-1", "react-effects", { scope: "global" }),
           createBashTool("density-rg-1", 'rg "verify" src', "src/auth.ts:1:verify"),
-          {
-            type: "text",
-            text: "I found the relevant code and will patch it.",
-            timestamp: STABLE_TIMESTAMP - 35_000,
-          },
-          createFileEditTool(
-            "density-edit-1",
-            "src/auth.ts",
-            [
-              "--- src/auth.ts",
-              "+++ src/auth.ts",
-              "@@ -1,3 +1,4 @@",
-              "+import { timingSafeEqual } from 'crypto';",
-              " export function verify() {}",
-            ].join("\n")
-          ),
-          createBashTool(
-            "density-test-1",
-            "make test",
-            "42 tests passed",
-            0,
-            30,
-            500,
-            "Running tests"
-          ),
-          {
-            type: "text",
-            text: "Implemented the auth audit fix and validated it.",
-            timestamp: STABLE_TIMESTAMP - 15_000,
-          },
         ],
       }),
+      createUserMessage("density-user-2", "Please validate with typecheck too", {
+        historySequence: 3,
+        timestamp: STABLE_TIMESTAMP - 40_000,
+      }),
+      createAssistantMessage(
+        "density-assistant-2",
+        "I found the relevant code and will patch it.",
+        {
+          historySequence: 4,
+          timestamp: STABLE_TIMESTAMP - 35_000,
+          toolCalls: [
+            createFileEditTool(
+              "density-edit-1",
+              "src/auth.ts",
+              [
+                "--- src/auth.ts",
+                "+++ src/auth.ts",
+                "@@ -1,3 +1,4 @@",
+                "+import { timingSafeEqual } from 'crypto';",
+                " export function verify() {}",
+              ].join("\n")
+            ),
+            createBashTool(
+              "density-test-1",
+              "make test",
+              "42 tests passed",
+              0,
+              30,
+              500,
+              "Running tests"
+            ),
+            createBashTool(
+              "density-fail-1",
+              "make typecheck",
+              "Type error in src/auth.ts",
+              1,
+              30,
+              500,
+              "Failing validation"
+            ),
+            {
+              type: "text",
+              text: "Implemented the auth audit fix and validated it.",
+              timestamp: STABLE_TIMESTAMP - 15_000,
+            },
+          ],
+        }
+      ),
     ],
   });
 }

--- a/src/browser/features/Messages/TranscriptDensity.stories.tsx
+++ b/src/browser/features/Messages/TranscriptDensity.stories.tsx
@@ -43,7 +43,12 @@ function setupTranscriptDensityStory(density: TranscriptDensity) {
           createFileReadTool("density-read-1", "src/auth.ts", "export function verify() {}"),
           createWebSearchTool("density-search-1", "JWT validation best practices", 3),
           createAgentSkillReadTool("density-skill-1", "react-effects", { scope: "global" }),
-          createBashTool("density-rg-1", 'rg "verify" src', "src/auth.ts:1:verify"),
+          createGenericTool(
+            "density-question-1",
+            "ask_user_question",
+            { question: "Any additional validation needed?" },
+            { answer: "Please validate with typecheck too" }
+          ),
         ],
       }),
       createUserMessage("density-user-2", "Please validate with typecheck too", {
@@ -148,7 +153,7 @@ export const HyperActiveExpandedBundle: AppStory = {
       setup={() => {
         collapseLeftSidebar();
         setDensity("hyper");
-        const activeStartedAt = Date.now() - 40_000;
+        const activeStartedAt = Date.now() - 39_000;
         return setupSimpleChatStory({
           messages: [
             createUserMessage("active-user-1", "Inspect the repository", {

--- a/src/browser/features/Messages/WorkBundleMessage.test.tsx
+++ b/src/browser/features/Messages/WorkBundleMessage.test.tsx
@@ -14,6 +14,7 @@ const item: WorkBundleInfo = {
   position: "head",
   headIndex: 1,
   entries: [],
+  startedAtMs: 0,
   durationMs: 180_000,
   state: "settled",
   defaultExpanded: false,
@@ -47,16 +48,22 @@ describe("WorkBundleMessage", () => {
     expect(view.getByRole("button", { expanded: true })).toBeDefined();
   });
 
-  test("renders active working label", () => {
+  test("renders active working label with elapsed duration", () => {
     const view = render(
       <WorkBundleMessage
-        item={{ ...item, state: "active", durationMs: undefined, defaultExpanded: true }}
+        item={{
+          ...item,
+          state: "active",
+          startedAtMs: Date.now() - 35_000,
+          durationMs: undefined,
+          defaultExpanded: true,
+        }}
         expanded
         onToggle={() => undefined}
       />
     );
 
-    expect(view.getByText("Working...")).toBeDefined();
+    expect(view.getByText(/Working for \d+s\.\.\./)).toBeDefined();
   });
 
   test("renders fallback label without duration", () => {

--- a/src/browser/features/Messages/WorkBundleMessage.test.tsx
+++ b/src/browser/features/Messages/WorkBundleMessage.test.tsx
@@ -15,6 +15,7 @@ const item: WorkBundleInfo = {
   headIndex: 1,
   entries: [],
   durationMs: 180_000,
+  state: "settled",
   defaultExpanded: false,
 };
 
@@ -44,6 +45,18 @@ describe("WorkBundleMessage", () => {
     view.rerender(<WorkBundleMessage item={item} expanded={expanded} onToggle={onToggle} />);
 
     expect(view.getByRole("button", { expanded: true })).toBeDefined();
+  });
+
+  test("renders active working label", () => {
+    const view = render(
+      <WorkBundleMessage
+        item={{ ...item, state: "active", durationMs: undefined, defaultExpanded: true }}
+        expanded
+        onToggle={() => undefined}
+      />
+    );
+
+    expect(view.getByText("Working...")).toBeDefined();
   });
 
   test("renders fallback label without duration", () => {

--- a/src/browser/features/Messages/WorkBundleMessage.tsx
+++ b/src/browser/features/Messages/WorkBundleMessage.tsx
@@ -13,7 +13,11 @@ interface WorkBundleMessageProps {
 export function WorkBundleMessage(props: WorkBundleMessageProps): React.ReactElement {
   const duration = props.item.durationMs;
   const label =
-    duration === undefined ? "Worked" : `Worked for ${formatDuration(duration, "precise")}`;
+    props.item.state === "active"
+      ? "Working..."
+      : duration === undefined
+        ? "Worked"
+        : `Worked for ${formatDuration(duration, "precise")}`;
 
   return (
     <button

--- a/src/browser/features/Messages/WorkBundleMessage.tsx
+++ b/src/browser/features/Messages/WorkBundleMessage.tsx
@@ -4,6 +4,22 @@ import { cn } from "@/common/lib/utils";
 import { ExpandIcon } from "@/browser/features/Tools/Shared/ToolPrimitives";
 import type { WorkBundleInfo } from "@/browser/utils/messages/transcriptRenderProjection";
 
+function useActiveNowMs(isActive: boolean): number {
+  const [nowMs, setNowMs] = React.useState(() => Date.now());
+
+  React.useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+
+    setNowMs(Date.now());
+    const intervalId = window.setInterval(() => setNowMs(Date.now()), 1_000);
+    return () => window.clearInterval(intervalId);
+  }, [isActive]);
+
+  return nowMs;
+}
+
 interface WorkBundleMessageProps {
   item: WorkBundleInfo;
   expanded: boolean;
@@ -11,13 +27,20 @@ interface WorkBundleMessageProps {
 }
 
 export function WorkBundleMessage(props: WorkBundleMessageProps): React.ReactElement {
-  const duration = props.item.durationMs;
-  const label =
-    props.item.state === "active"
+  const isActive = props.item.state === "active";
+  const nowMs = useActiveNowMs(isActive && props.item.startedAtMs !== undefined);
+  const duration = isActive
+    ? props.item.startedAtMs === undefined
+      ? undefined
+      : Math.max(0, nowMs - props.item.startedAtMs)
+    : props.item.durationMs;
+  const label = isActive
+    ? duration === undefined
       ? "Working..."
-      : duration === undefined
-        ? "Worked"
-        : `Worked for ${formatDuration(duration, "precise")}`;
+      : `Working for ${formatDuration(duration, "precise")}...`
+    : duration === undefined
+      ? "Worked"
+      : `Worked for ${formatDuration(duration, "precise")}`;
 
   return (
     <button
@@ -30,7 +53,7 @@ export function WorkBundleMessage(props: WorkBundleMessageProps): React.ReactEle
       aria-expanded={props.expanded}
       onClick={props.onToggle}
     >
-      <span className="min-w-0 truncate">{label}</span>
+      <span className="counter-nums min-w-0 truncate">{label}</span>
       <ExpandIcon expanded={props.expanded} className="text-muted shrink-0">
         ▶
       </ExpandIcon>

--- a/src/browser/utils/messages/transcriptRenderProjection.test.ts
+++ b/src/browser/utils/messages/transcriptRenderProjection.test.ts
@@ -75,6 +75,7 @@ function assistant(
     isLastPartOfMessage: overrides.isLastPartOfMessage,
     isCompacted: overrides.isCompacted ?? false,
     isIdleCompacted: overrides.isIdleCompacted ?? false,
+    isSideAnswer: overrides.isSideAnswer,
     timestamp: overrides.timestamp,
   };
 }
@@ -217,6 +218,122 @@ describe("work bundle coalescing", () => {
     });
   });
 
+  test("spans steering user messages until the turn final assistant row", () => {
+    const messages = [
+      user("u1"),
+      tool({ id: "read-1", historyId: "history-a1", timestamp: 1_000 }),
+      user("steer-1"),
+      tool({ id: "bash-1", historyId: "history-a1", toolName: "bash", timestamp: 31_000 }),
+      assistant("final-1", { historyId: "history-a1", timestamp: 61_000 }),
+    ];
+
+    const infos = computeWorkBundleInfos(messages);
+
+    expect(infos[1]).toMatchObject({
+      key: "work:read-1",
+      position: "head",
+      durationMs: 60_000,
+      entries: [
+        { message: messages[1], originalIndex: 1 },
+        { message: messages[2], originalIndex: 2 },
+        { message: messages[3], originalIndex: 3 },
+      ],
+    });
+    expect(infos[2]).toMatchObject({ key: "work:read-1", position: "member" });
+    expect(infos[3]).toMatchObject({ key: "work:read-1", position: "member" });
+    expect(infos[4]).toMatchObject({ key: "work:read-1", position: "final" });
+  });
+
+  test("keeps side-question answers visible while bundling surrounding agent work", () => {
+    const messages = [
+      user("u1"),
+      tool({ id: "read-1", historyId: "history-a1" }),
+      user("side-question-1"),
+      assistant("side-answer-1", { isSideAnswer: true }),
+      tool({ id: "bash-1", historyId: "history-a1", toolName: "bash" }),
+      assistant("final-1", { historyId: "history-a1" }),
+    ];
+
+    const infos = computeWorkBundleInfos(messages);
+
+    expect(infos[1]).toMatchObject({
+      key: "work:read-1",
+      entries: [
+        { message: messages[1], originalIndex: 1 },
+        { message: messages[2], originalIndex: 2 },
+        { message: messages[3], originalIndex: 3 },
+        { message: messages[4], originalIndex: 4 },
+      ],
+    });
+    expect(infos[2]).toMatchObject({ key: "work:read-1", position: "member" });
+    expect(infos[3]).toMatchObject({ key: "work:read-1", position: "member" });
+    expect(infos[4]).toMatchObject({ key: "work:read-1", position: "member" });
+    expect(infos[5]).toMatchObject({ key: "work:read-1", position: "final" });
+  });
+
+  test("does not start a work bundle at a side-question answer", () => {
+    const messages = [
+      user("u1"),
+      assistant("side-answer-1", { isSideAnswer: true }),
+      tool({ id: "bash-1", historyId: "history-a1", toolName: "bash" }),
+      assistant("final-1", { historyId: "history-a1" }),
+    ];
+
+    const infos = computeWorkBundleInfos(messages);
+
+    expect(infos[1]).toBeUndefined();
+    expect(infos[2]).toMatchObject({
+      key: "work:bash-1",
+      entries: [{ message: messages[2], originalIndex: 2 }],
+    });
+    expect(infos[3]).toMatchObject({ key: "work:bash-1", position: "final" });
+  });
+
+  test("does not merge interrupted work across the next user prompt", () => {
+    const messages = [
+      user("u1"),
+      tool({ id: "interrupted-1", historyId: "history-a1", status: "interrupted" }),
+      user("u2"),
+      tool({ id: "bash-1", historyId: "history-a2", toolName: "bash" }),
+      assistant("final-2", { historyId: "history-a2" }),
+    ];
+
+    const infos = computeWorkBundleInfos(messages);
+
+    expect(infos[1]).toBeUndefined();
+    expect(infos[2]).toBeUndefined();
+    expect(infos[3]).toMatchObject({
+      key: "work:bash-1",
+      entries: [{ message: messages[3], originalIndex: 3 }],
+    });
+    expect(infos[4]).toMatchObject({ key: "work:bash-1", position: "final" });
+  });
+
+  test("does not merge completed turns across the next user message", () => {
+    const messages = [
+      user("u1"),
+      tool({ id: "read-1", historyId: "history-a1" }),
+      assistant("final-1", { historyId: "history-a1" }),
+      user("u2"),
+      tool({ id: "bash-1", historyId: "history-a2", toolName: "bash" }),
+      assistant("final-2", { historyId: "history-a2" }),
+    ];
+
+    const infos = computeWorkBundleInfos(messages);
+
+    expect(infos[1]).toMatchObject({
+      key: "work:read-1",
+      entries: [{ message: messages[1], originalIndex: 1 }],
+    });
+    expect(infos[2]).toMatchObject({ key: "work:read-1", position: "final" });
+    expect(infos[3]).toBeUndefined();
+    expect(infos[4]).toMatchObject({
+      key: "work:bash-1",
+      entries: [{ message: messages[4], originalIndex: 4 }],
+    });
+    expect(infos[5]).toMatchObject({ key: "work:bash-1", position: "final" });
+  });
+
   test("leaves active work visible", () => {
     const messages = [
       reasoning({ id: "think-1", historyId: "history-a1" }),
@@ -229,7 +346,7 @@ describe("work bundle coalescing", () => {
     expect(infos.every((info) => info === undefined)).toBe(true);
   });
 
-  test("keeps non-success tools visible before a final assistant row", () => {
+  test("collapses non-success tools before a final assistant row", () => {
     const historyId = "history-a1";
     const failedSearch = tool({
       id: "search-1",
@@ -274,7 +391,22 @@ describe("work bundle coalescing", () => {
 
     const infos = computeWorkBundleInfos(messages);
 
-    expect(infos.every((info) => info === undefined)).toBe(true);
+    expect(infos[0]).toMatchObject({
+      key: "work:search-1",
+      position: "head",
+      entries: [
+        { message: failedSearch, originalIndex: 0 },
+        { message: failedBash, originalIndex: 1 },
+        { message: interruptedRead, originalIndex: 2 },
+        { message: redactedRead, originalIndex: 3 },
+        { message: partialRead, originalIndex: 4 },
+      ],
+    });
+    expect(infos[1]).toMatchObject({ key: "work:search-1", position: "member" });
+    expect(infos[2]).toMatchObject({ key: "work:search-1", position: "member" });
+    expect(infos[3]).toMatchObject({ key: "work:search-1", position: "member" });
+    expect(infos[4]).toMatchObject({ key: "work:search-1", position: "member" });
+    expect(infos[5]).toMatchObject({ key: "work:search-1", position: "final" });
   });
 
   test("keeps visible artifacts and stream errors out of work bundles", () => {
@@ -342,6 +474,28 @@ describe("operational bundle coalescing", () => {
     expect(infos[4]).toMatchObject({ position: "head" });
   });
 
+  test("assistant rows split non-success operational bundles", () => {
+    const first = tool({ id: "bash-1", toolName: "bash", status: "failed" });
+    const middle = assistant("a1");
+    const second = tool({ id: "bash-2", toolName: "bash", status: "failed" });
+
+    const infos = computeOperationalBundleInfos([first, middle, second], {
+      isTurnActive: false,
+    });
+
+    expect(infos[0]).toMatchObject({
+      key: "bundle:bash-1",
+      position: "head",
+      entries: [{ message: first, originalIndex: 0 }],
+    });
+    expect(infos[1]).toBeUndefined();
+    expect(infos[2]).toMatchObject({
+      key: "bundle:bash-2",
+      position: "head",
+      entries: [{ message: second, originalIndex: 2 }],
+    });
+  });
+
   test("leaves reasoning-only turns visible", () => {
     const message = reasoning({ id: "think-only", isOnlyMessageContent: true });
 
@@ -368,7 +522,7 @@ describe("operational bundle coalescing", () => {
     expect(reasoningThenTool[0]?.summary.title).toBe("Ran 2 operations");
   });
 
-  test("leaves non-success tools visible", () => {
+  test("groups non-success tools into operational bundles", () => {
     const failedSearch = tool({
       id: "search-1",
       toolName: "web_search",
@@ -402,7 +556,27 @@ describe("operational bundle coalescing", () => {
       { isTurnActive: false }
     );
 
-    expect(infos.every((info) => info === undefined)).toBe(true);
+    expect(infos[0]).toMatchObject({
+      key: "bundle:search-1",
+      position: "head",
+      state: "settled",
+      defaultExpanded: false,
+      entries: [
+        { message: failedSearch, originalIndex: 0 },
+        { message: failedBash, originalIndex: 1 },
+        { message: interruptedRead, originalIndex: 2 },
+        { message: redactedRead, originalIndex: 3 },
+        { message: partialRead, originalIndex: 4 },
+      ],
+      summary: {
+        title: "Ran 5 operations",
+        details: "1 search · 1 shell command · 3 reads",
+      },
+    });
+    expect(infos[1]).toMatchObject({ key: "bundle:search-1", position: "member" });
+    expect(infos[2]).toMatchObject({ key: "bundle:search-1", position: "member" });
+    expect(infos[3]).toMatchObject({ key: "bundle:search-1", position: "member" });
+    expect(infos[4]).toMatchObject({ key: "bundle:search-1", position: "member" });
   });
 
   test("active and just-settled tail bundles stay expanded until a visible event or turn end", () => {

--- a/src/browser/utils/messages/transcriptRenderProjection.test.ts
+++ b/src/browser/utils/messages/transcriptRenderProjection.test.ts
@@ -312,6 +312,19 @@ describe("work bundle coalescing", () => {
     expect(infos.every((info) => info === undefined)).toBe(true);
   });
 
+  test("does not merge interrupted partial tools into a text-only next prompt", () => {
+    const messages = [
+      user("u1"),
+      tool({ id: "read-1", historyId: "history-a1", isPartial: true }),
+      user("u2"),
+      assistant("answer-2", { historyId: "history-a2" }),
+    ];
+
+    const infos = computeWorkBundleInfos(messages);
+
+    expect(infos.every((info) => info === undefined)).toBe(true);
+  });
+
   test("does not merge mixed partial tool and text interruptions across the next user prompt", () => {
     const messages = [
       user("u1"),

--- a/src/browser/utils/messages/transcriptRenderProjection.test.ts
+++ b/src/browser/utils/messages/transcriptRenderProjection.test.ts
@@ -300,6 +300,26 @@ describe("work bundle coalescing", () => {
     expect(infos[3]).toMatchObject({ key: "work:bash-1", position: "final" });
   });
 
+  test("does not merge partial text-only interruptions across the next user prompt", () => {
+    const messages = [
+      user("u1"),
+      reasoning({ id: "think-1", historyId: "history-a1", isPartial: true }),
+      assistant("draft-1", { historyId: "history-a1", isPartial: true }),
+      user("u2"),
+      tool({ id: "bash-1", historyId: "history-a2", toolName: "bash" }),
+      assistant("final-2", { historyId: "history-a2" }),
+    ];
+
+    const infos = computeWorkBundleInfos(messages);
+
+    expect(infos[0]).toBeUndefined();
+    expect(infos[1]).toBeUndefined();
+    expect(infos[2]).toBeUndefined();
+    expect(infos[3]).toMatchObject({ key: "work:bash-1", position: "head", headIndex: 3 });
+    expect(infos[4]).toMatchObject({ key: "work:bash-1", position: "member" });
+    expect(infos[5]).toMatchObject({ key: "work:bash-1", position: "final" });
+  });
+
   test("does not merge interrupted work across the next user prompt", () => {
     const messages = [
       user("u1"),

--- a/src/browser/utils/messages/transcriptRenderProjection.test.ts
+++ b/src/browser/utils/messages/transcriptRenderProjection.test.ts
@@ -300,6 +300,18 @@ describe("work bundle coalescing", () => {
     expect(infos[3]).toMatchObject({ key: "work:bash-1", position: "final" });
   });
 
+  test("does not finalize work bundles before the first operation", () => {
+    const messages = [
+      user("u1"),
+      assistant("draft-1", { historyId: "history-a1", content: "I'll inspect first." }),
+      tool({ id: "read-1", historyId: "history-a1" }),
+    ];
+
+    const infos = computeWorkBundleInfos(messages);
+
+    expect(infos.every((info) => info === undefined)).toBe(true);
+  });
+
   test("does not merge mixed partial tool and text interruptions across the next user prompt", () => {
     const messages = [
       user("u1"),

--- a/src/browser/utils/messages/transcriptRenderProjection.test.ts
+++ b/src/browser/utils/messages/transcriptRenderProjection.test.ts
@@ -407,16 +407,27 @@ describe("work bundle coalescing", () => {
     expect(infos[5]).toMatchObject({ key: "work:bash-1", position: "final" });
   });
 
-  test("leaves active work visible", () => {
+  test("wraps active work in an expanded working bundle", () => {
     const messages = [
-      reasoning({ id: "think-1", historyId: "history-a1" }),
+      user("u1"),
+      assistant("draft-1", { historyId: "history-a1" }),
       tool({ id: "read-1", historyId: "history-a1", status: "executing" }),
-      assistant("final-1", { historyId: "history-a1" }),
     ];
 
     const infos = computeWorkBundleInfos(messages);
 
-    expect(infos.every((info) => info === undefined)).toBe(true);
+    expect(infos[0]).toMatchObject({
+      key: "work:draft-1",
+      position: "head",
+      state: "active",
+      defaultExpanded: true,
+      entries: [
+        { message: messages[1], originalIndex: 1 },
+        { message: messages[2], originalIndex: 2 },
+      ],
+    });
+    expect(infos[1]).toMatchObject({ key: "work:draft-1", position: "member" });
+    expect(infos[2]).toMatchObject({ key: "work:draft-1", position: "member" });
   });
 
   test("collapses non-success tools before a final assistant row", () => {

--- a/src/browser/utils/messages/transcriptRenderProjection.test.ts
+++ b/src/browser/utils/messages/transcriptRenderProjection.test.ts
@@ -222,7 +222,13 @@ describe("work bundle coalescing", () => {
   test("spans steering user messages until the turn final assistant row", () => {
     const messages = [
       user("u1"),
-      tool({ id: "read-1", historyId: "history-a1", isPartial: true, timestamp: 1_000 }),
+      tool({
+        id: "read-1",
+        historyId: "history-a1",
+        isPartial: true,
+        status: "executing",
+        timestamp: 1_000,
+      }),
       user("steer-1"),
       tool({ id: "bash-1", historyId: "history-a1", toolName: "bash", timestamp: 31_000 }),
       assistant("final-1", { historyId: "history-a1", timestamp: 61_000 }),
@@ -310,6 +316,24 @@ describe("work bundle coalescing", () => {
     const infos = computeWorkBundleInfos(messages);
 
     expect(infos.every((info) => info === undefined)).toBe(true);
+  });
+
+  test("does not merge completed partial tools into a tool-using next prompt", () => {
+    const messages = [
+      user("u1"),
+      tool({ id: "read-1", historyId: "history-a1", isPartial: true, status: "completed" }),
+      user("u2"),
+      tool({ id: "bash-1", historyId: "history-a2", toolName: "bash" }),
+      assistant("final-2", { historyId: "history-a2" }),
+    ];
+
+    const infos = computeWorkBundleInfos(messages);
+
+    expect(infos[0]).toBeUndefined();
+    expect(infos[1]).toBeUndefined();
+    expect(infos[2]).toMatchObject({ key: "work:bash-1", position: "head", headIndex: 2 });
+    expect(infos[3]).toMatchObject({ key: "work:bash-1", position: "member" });
+    expect(infos[4]).toMatchObject({ key: "work:bash-1", position: "final" });
   });
 
   test("does not merge interrupted partial tools into a text-only next prompt", () => {

--- a/src/browser/utils/messages/transcriptRenderProjection.test.ts
+++ b/src/browser/utils/messages/transcriptRenderProjection.test.ts
@@ -300,6 +300,26 @@ describe("work bundle coalescing", () => {
     expect(infos[3]).toMatchObject({ key: "work:bash-1", position: "final" });
   });
 
+  test("does not merge mixed partial tool and text interruptions across the next user prompt", () => {
+    const messages = [
+      user("u1"),
+      tool({ id: "read-1", historyId: "history-a1", isPartial: true }),
+      assistant("draft-1", { historyId: "history-a1", isPartial: true }),
+      user("u2"),
+      tool({ id: "bash-1", historyId: "history-a2", toolName: "bash" }),
+      assistant("final-2", { historyId: "history-a2" }),
+    ];
+
+    const infos = computeWorkBundleInfos(messages);
+
+    expect(infos[0]).toBeUndefined();
+    expect(infos[1]).toBeUndefined();
+    expect(infos[2]).toBeUndefined();
+    expect(infos[3]).toMatchObject({ key: "work:bash-1", position: "head", headIndex: 3 });
+    expect(infos[4]).toMatchObject({ key: "work:bash-1", position: "member" });
+    expect(infos[5]).toMatchObject({ key: "work:bash-1", position: "final" });
+  });
+
   test("does not merge partial text-only interruptions across the next user prompt", () => {
     const messages = [
       user("u1"),

--- a/src/browser/utils/messages/transcriptRenderProjection.test.ts
+++ b/src/browser/utils/messages/transcriptRenderProjection.test.ts
@@ -166,19 +166,20 @@ describe("work bundle coalescing", () => {
 
     const infos = computeWorkBundleInfos(messages);
 
-    expect(infos[0]).toBeUndefined();
-    expect(infos[1]).toMatchObject({
+    expect(infos[0]).toMatchObject({
       key: "work:think-1",
       position: "head",
-      headIndex: 1,
+      headIndex: 0,
       durationMs: 180_000,
       defaultExpanded: false,
       entries: [
         { message: messages[1], originalIndex: 1 },
         { message: messages[2], originalIndex: 2 },
         { message: messages[3], originalIndex: 3 },
+        { message: messages[4], originalIndex: 4 },
       ],
     });
+    expect(infos[1]).toMatchObject({ key: "work:think-1", position: "member" });
     expect(infos[2]).toMatchObject({ key: "work:think-1", position: "member" });
     expect(infos[3]).toMatchObject({ key: "work:think-1", position: "member" });
     expect(infos[4]).toMatchObject({ key: "work:think-1", position: "final" });
@@ -206,7 +207,7 @@ describe("work bundle coalescing", () => {
     const workInfos = computeWorkBundleInfos(messages);
     const operationalInfos = computeOperationalBundleInfos(messages, { isTurnActive: false });
 
-    expect(workInfos[0]?.entries.map((entry) => entry.originalIndex)).toEqual([0, 1, 2, 3]);
+    expect(workInfos[0]?.entries.map((entry) => entry.originalIndex)).toEqual([0, 1, 2, 3, 4]);
     expect(operationalInfos[2]).toMatchObject({
       position: "head",
       headIndex: 2,
@@ -221,7 +222,7 @@ describe("work bundle coalescing", () => {
   test("spans steering user messages until the turn final assistant row", () => {
     const messages = [
       user("u1"),
-      tool({ id: "read-1", historyId: "history-a1", timestamp: 1_000 }),
+      tool({ id: "read-1", historyId: "history-a1", isPartial: true, timestamp: 1_000 }),
       user("steer-1"),
       tool({ id: "bash-1", historyId: "history-a1", toolName: "bash", timestamp: 31_000 }),
       assistant("final-1", { historyId: "history-a1", timestamp: 61_000 }),
@@ -229,16 +230,19 @@ describe("work bundle coalescing", () => {
 
     const infos = computeWorkBundleInfos(messages);
 
-    expect(infos[1]).toMatchObject({
+    expect(infos[0]).toMatchObject({
       key: "work:read-1",
       position: "head",
+      headIndex: 0,
       durationMs: 60_000,
       entries: [
         { message: messages[1], originalIndex: 1 },
         { message: messages[2], originalIndex: 2 },
         { message: messages[3], originalIndex: 3 },
+        { message: messages[4], originalIndex: 4 },
       ],
     });
+    expect(infos[1]).toMatchObject({ key: "work:read-1", position: "member" });
     expect(infos[2]).toMatchObject({ key: "work:read-1", position: "member" });
     expect(infos[3]).toMatchObject({ key: "work:read-1", position: "member" });
     expect(infos[4]).toMatchObject({ key: "work:read-1", position: "final" });
@@ -256,15 +260,18 @@ describe("work bundle coalescing", () => {
 
     const infos = computeWorkBundleInfos(messages);
 
-    expect(infos[1]).toMatchObject({
+    expect(infos[0]).toMatchObject({
       key: "work:read-1",
+      headIndex: 0,
       entries: [
         { message: messages[1], originalIndex: 1 },
         { message: messages[2], originalIndex: 2 },
         { message: messages[3], originalIndex: 3 },
         { message: messages[4], originalIndex: 4 },
+        { message: messages[5], originalIndex: 5 },
       ],
     });
+    expect(infos[1]).toMatchObject({ key: "work:read-1", position: "member" });
     expect(infos[2]).toMatchObject({ key: "work:read-1", position: "member" });
     expect(infos[3]).toMatchObject({ key: "work:read-1", position: "member" });
     expect(infos[4]).toMatchObject({ key: "work:read-1", position: "member" });
@@ -281,10 +288,14 @@ describe("work bundle coalescing", () => {
 
     const infos = computeWorkBundleInfos(messages);
 
+    expect(infos[0]).toBeUndefined();
     expect(infos[1]).toBeUndefined();
     expect(infos[2]).toMatchObject({
       key: "work:bash-1",
-      entries: [{ message: messages[2], originalIndex: 2 }],
+      entries: [
+        { message: messages[2], originalIndex: 2 },
+        { message: messages[3], originalIndex: 3 },
+      ],
     });
     expect(infos[3]).toMatchObject({ key: "work:bash-1", position: "final" });
   });
@@ -301,10 +312,13 @@ describe("work bundle coalescing", () => {
     const infos = computeWorkBundleInfos(messages);
 
     expect(infos[1]).toBeUndefined();
-    expect(infos[2]).toBeUndefined();
+    expect(infos[2]).toMatchObject({ key: "work:bash-1", position: "head", headIndex: 2 });
     expect(infos[3]).toMatchObject({
       key: "work:bash-1",
-      entries: [{ message: messages[3], originalIndex: 3 }],
+      entries: [
+        { message: messages[3], originalIndex: 3 },
+        { message: messages[4], originalIndex: 4 },
+      ],
     });
     expect(infos[4]).toMatchObject({ key: "work:bash-1", position: "final" });
   });
@@ -321,15 +335,22 @@ describe("work bundle coalescing", () => {
 
     const infos = computeWorkBundleInfos(messages);
 
-    expect(infos[1]).toMatchObject({
+    expect(infos[0]).toMatchObject({
       key: "work:read-1",
-      entries: [{ message: messages[1], originalIndex: 1 }],
+      position: "head",
+      entries: [
+        { message: messages[1], originalIndex: 1 },
+        { message: messages[2], originalIndex: 2 },
+      ],
     });
     expect(infos[2]).toMatchObject({ key: "work:read-1", position: "final" });
-    expect(infos[3]).toBeUndefined();
+    expect(infos[3]).toMatchObject({ key: "work:bash-1", position: "head" });
     expect(infos[4]).toMatchObject({
       key: "work:bash-1",
-      entries: [{ message: messages[4], originalIndex: 4 }],
+      entries: [
+        { message: messages[4], originalIndex: 4 },
+        { message: messages[5], originalIndex: 5 },
+      ],
     });
     expect(infos[5]).toMatchObject({ key: "work:bash-1", position: "final" });
   });
@@ -400,6 +421,7 @@ describe("work bundle coalescing", () => {
         { message: interruptedRead, originalIndex: 2 },
         { message: redactedRead, originalIndex: 3 },
         { message: partialRead, originalIndex: 4 },
+        { message: messages[5], originalIndex: 5 },
       ],
     });
     expect(infos[1]).toMatchObject({ key: "work:search-1", position: "member" });

--- a/src/browser/utils/messages/transcriptRenderProjection.ts
+++ b/src/browser/utils/messages/transcriptRenderProjection.ts
@@ -36,6 +36,7 @@ export interface WorkBundleInfo {
   headIndex: number;
   entries: readonly WorkBundleEntry[];
   durationMs?: number;
+  state: "active" | "settled";
   defaultExpanded: boolean;
 }
 
@@ -128,12 +129,15 @@ export function computeWorkBundleInfos(
     }
 
     const finalMessage = messages[span.finalIndex];
-    if (finalMessage?.type !== "assistant") {
+    if (span.state === "settled" && finalMessage?.type !== "assistant") {
       index = span.finalIndex + 1;
       continue;
     }
 
-    if (entries.some((entry) => isActiveWorkBundleMessage(entry.message))) {
+    if (
+      span.state === "settled" &&
+      entries.some((entry) => isActiveWorkBundleMessage(entry.message))
+    ) {
       index = span.finalIndex + 1;
       continue;
     }
@@ -153,7 +157,8 @@ export function computeWorkBundleInfos(
       headIndex: span.headIndex,
       entries: frozenEntries,
       durationMs: computeWorkBundleDurationMs(frozenEntries, finalMessage),
-      defaultExpanded: false,
+      state: span.state,
+      defaultExpanded: span.state === "active",
     };
 
     infos[span.headIndex] = info;
@@ -163,7 +168,7 @@ export function computeWorkBundleInfos(
         position:
           entry.originalIndex === span.headIndex
             ? "head"
-            : entry.originalIndex === span.finalIndex
+            : span.state === "settled" && entry.originalIndex === span.finalIndex
               ? "final"
               : "member",
       };
@@ -248,6 +253,7 @@ interface WorkBundleSpan {
   headIndex: number;
   firstEntryIndex: number;
   finalIndex: number;
+  state: "active" | "settled";
 }
 
 function findWorkBundleSpan(
@@ -269,14 +275,14 @@ function findWorkBundleSpan(
   return {
     headIndex: message?.type === "user" ? index : firstEntryIndex,
     firstEntryIndex,
-    finalIndex,
+    ...finalIndex,
   };
 }
 
 function findWorkBundleFinalIndex(
   messages: DisplayedMessage[],
   startIndex: number
-): number | undefined {
+): Pick<WorkBundleSpan, "finalIndex" | "state"> | undefined {
   const firstHistoryId = getWorkBundleAgentHistoryId(messages[startIndex]);
   if (firstHistoryId === undefined) {
     return undefined;
@@ -286,6 +292,8 @@ function findWorkBundleFinalIndex(
   let canCrossVisibleConversation = false;
   let sawVisibleConversationSinceLastAgent = false;
   let sawOperationalMessage = false;
+  let sawActiveMessage = false;
+  let lastAgentIndex = startIndex;
   let finalIndex: number | undefined;
 
   for (let index = startIndex; index < messages.length; index++) {
@@ -323,6 +331,10 @@ function findWorkBundleFinalIndex(
       historyIds.add(messageHistoryId);
     }
     sawVisibleConversationSinceLastAgent = false;
+    lastAgentIndex = index;
+    if (isActiveWorkBundleMessage(message)) {
+      sawActiveMessage = true;
+    }
 
     if (isWorkBundleOperationalMessage(message)) {
       sawOperationalMessage = true;
@@ -337,11 +349,17 @@ function findWorkBundleFinalIndex(
     canCrossVisibleConversation = false;
   }
 
-  if (!sawOperationalMessage || finalIndex === undefined || finalIndex < startIndex) {
+  if (!sawOperationalMessage) {
     return undefined;
   }
+  if (finalIndex !== undefined && finalIndex >= startIndex) {
+    return { finalIndex, state: "settled" };
+  }
+  if (sawActiveMessage && lastAgentIndex >= startIndex) {
+    return { finalIndex: lastAgentIndex, state: "active" };
+  }
 
-  return finalIndex;
+  return undefined;
 }
 
 function isSideQuestionStart(messages: DisplayedMessage[], index: number): boolean {

--- a/src/browser/utils/messages/transcriptRenderProjection.ts
+++ b/src/browser/utils/messages/transcriptRenderProjection.ts
@@ -135,14 +135,6 @@ export function computeWorkBundleInfos(
       continue;
     }
 
-    if (
-      span.state === "settled" &&
-      entries.some((entry) => isActiveWorkBundleMessage(entry.message))
-    ) {
-      index = span.finalIndex + 1;
-      continue;
-    }
-
     const frozenEntries = Object.freeze(entries);
     const firstAgentMessage = frozenEntries.find((entry) =>
       isWorkBundleAgentMessage(entry.message)
@@ -401,7 +393,13 @@ function canContinueWorkBundleAcrossConversation(message: DisplayedMessage): boo
   // Only partial tool rows prove the agent was still doing operational work when
   // the user spoke. Partial reasoning/text alone can also be an interrupted turn;
   // do not anchor the next prompt under that old turn's work bundle.
-  return message.type === "tool" && message.isPartial === true && message.status !== "interrupted";
+  return (
+    message.type === "tool" &&
+    message.isPartial === true &&
+    (message.status === "pending" ||
+      message.status === "executing" ||
+      message.toolName === "ask_user_question")
+  );
 }
 
 function getWorkBundleAgentHistoryId(message: DisplayedMessage | undefined): string | undefined {

--- a/src/browser/utils/messages/transcriptRenderProjection.ts
+++ b/src/browser/utils/messages/transcriptRenderProjection.ts
@@ -329,7 +329,7 @@ function findWorkBundleFinalIndex(
     }
     canCrossVisibleConversation = canContinueWorkBundleAcrossConversation(message);
 
-    if (message.type !== "assistant" || message.isPartial) {
+    if (message.type !== "assistant" || message.isPartial || !sawOperationalMessage) {
       continue;
     }
 

--- a/src/browser/utils/messages/transcriptRenderProjection.ts
+++ b/src/browser/utils/messages/transcriptRenderProjection.ts
@@ -116,54 +116,59 @@ export function computeWorkBundleInfos(
   let index = 0;
 
   while (index < messages.length) {
-    if (!isWorkBundleStart(messages, index)) {
-      index += 1;
-      continue;
-    }
-
-    const startIndex = index;
-    const finalIndex = findWorkBundleFinalIndex(messages, startIndex);
-    if (finalIndex === undefined) {
+    const span = findWorkBundleSpan(messages, index);
+    if (span === undefined) {
       index += 1;
       continue;
     }
 
     const entries: WorkBundleEntry[] = [];
-    for (let entryIndex = startIndex; entryIndex < finalIndex; entryIndex++) {
+    for (let entryIndex = span.firstEntryIndex; entryIndex <= span.finalIndex; entryIndex++) {
       entries.push({ message: messages[entryIndex], originalIndex: entryIndex });
     }
 
-    const finalMessage = messages[finalIndex];
+    const finalMessage = messages[span.finalIndex];
     if (finalMessage?.type !== "assistant") {
-      index = finalIndex + 1;
+      index = span.finalIndex + 1;
       continue;
     }
 
-    const groupMessages = [...entries.map((entry) => entry.message), finalMessage];
-    if (groupMessages.some(isActiveWorkBundleMessage)) {
-      index = finalIndex + 1;
+    if (entries.some((entry) => isActiveWorkBundleMessage(entry.message))) {
+      index = span.finalIndex + 1;
       continue;
     }
 
     const frozenEntries = Object.freeze(entries);
-    const first = entries[0].message;
+    const firstAgentMessage = frozenEntries.find((entry) =>
+      isWorkBundleAgentMessage(entry.message)
+    );
+    if (firstAgentMessage === undefined) {
+      index = span.finalIndex + 1;
+      continue;
+    }
+
     const info: WorkBundleInfo = {
-      key: `work:${first.id}`,
+      key: `work:${firstAgentMessage.message.id}`,
       position: "head",
-      headIndex: startIndex,
+      headIndex: span.headIndex,
       entries: frozenEntries,
       durationMs: computeWorkBundleDurationMs(frozenEntries, finalMessage),
       defaultExpanded: false,
     };
 
+    infos[span.headIndex] = info;
     for (const entry of entries) {
       infos[entry.originalIndex] = {
         ...info,
-        position: entry.originalIndex === startIndex ? "head" : "member",
+        position:
+          entry.originalIndex === span.headIndex
+            ? "head"
+            : entry.originalIndex === span.finalIndex
+              ? "final"
+              : "member",
       };
     }
-    infos[finalIndex] = { ...info, position: "final" };
-    index = finalIndex + 1;
+    index = span.finalIndex + 1;
   }
 
   return infos;
@@ -239,78 +244,91 @@ export function computeOperationalBundleInfos(
   return infos;
 }
 
-function isWorkBundleStart(messages: DisplayedMessage[], index: number): boolean {
+interface WorkBundleSpan {
+  headIndex: number;
+  firstEntryIndex: number;
+  finalIndex: number;
+}
+
+function findWorkBundleSpan(
+  messages: DisplayedMessage[],
+  index: number
+): WorkBundleSpan | undefined {
   const message = messages[index];
-  const historyId = getWorkBundleAgentHistoryId(message);
-  if (historyId === undefined) {
-    return false;
-  }
-  if (message.type !== "assistant") {
-    return true;
-  }
-  if (message.isPartial) {
-    return true;
+  const firstEntryIndex = message?.type === "user" ? index + 1 : index;
+  const firstEntry = messages[firstEntryIndex];
+  if (getWorkBundleAgentHistoryId(firstEntry) === undefined) {
+    return undefined;
   }
 
-  for (let nextIndex = index + 1; nextIndex < messages.length; nextIndex++) {
-    const next = messages[nextIndex];
-    if (!isWorkBundleTimelineMessage(next)) {
-      return false;
-    }
-    if (isWorkBundleVisibleConversationMessage(next)) {
-      if (!hasFutureAgentMessageWithHistoryId(messages, nextIndex + 1, historyId)) {
-        return false;
-      }
-      continue;
-    }
-
-    const nextHistoryId = getWorkBundleAgentHistoryId(next);
-    if (nextHistoryId !== historyId) {
-      return false;
-    }
-    if (isWorkBundleOperationalMessage(next)) {
-      return true;
-    }
-    if (next.type === "assistant" && !next.isPartial) {
-      return false;
-    }
+  const finalIndex = findWorkBundleFinalIndex(messages, firstEntryIndex);
+  if (finalIndex === undefined) {
+    return undefined;
   }
 
-  return false;
+  return {
+    headIndex: message?.type === "user" ? index : firstEntryIndex,
+    firstEntryIndex,
+    finalIndex,
+  };
 }
 
 function findWorkBundleFinalIndex(
   messages: DisplayedMessage[],
   startIndex: number
 ): number | undefined {
-  const historyId = getWorkBundleAgentHistoryId(messages[startIndex]);
-  if (historyId === undefined) {
+  const firstHistoryId = getWorkBundleAgentHistoryId(messages[startIndex]);
+  if (firstHistoryId === undefined) {
     return undefined;
   }
 
-  let sawOperationalMessage = isWorkBundleOperationalMessage(messages[startIndex]);
+  const historyIds = new Set<string>([firstHistoryId]);
+  let canCrossVisibleConversation = false;
+  let sawVisibleConversationSinceLastAgent = false;
+  let sawOperationalMessage = false;
   let finalIndex: number | undefined;
 
-  for (let index = startIndex + 1; index < messages.length; index++) {
+  for (let index = startIndex; index < messages.length; index++) {
     const message = messages[index];
     if (!isWorkBundleTimelineMessage(message)) {
       break;
     }
 
     if (isWorkBundleVisibleConversationMessage(message)) {
-      if (!hasFutureAgentMessageWithHistoryId(messages, index + 1, historyId)) {
+      if (finalIndex !== undefined) {
         break;
       }
+      if (message.type === "assistant" || isSideQuestionStart(messages, index)) {
+        continue;
+      }
+      if (!canCrossVisibleConversation) {
+        break;
+      }
+      if (!hasFutureWorkBundleAgentMessage(messages, index + 1)) {
+        break;
+      }
+      sawVisibleConversationSinceLastAgent = true;
+      canCrossVisibleConversation = false;
       continue;
     }
 
     const messageHistoryId = getWorkBundleAgentHistoryId(message);
-    if (messageHistoryId !== historyId) {
+    if (messageHistoryId === undefined) {
       break;
     }
+    if (!historyIds.has(messageHistoryId)) {
+      if (!sawVisibleConversationSinceLastAgent) {
+        break;
+      }
+      historyIds.add(messageHistoryId);
+    }
+    sawVisibleConversationSinceLastAgent = false;
 
     if (isWorkBundleOperationalMessage(message)) {
       sawOperationalMessage = true;
+    }
+    if (canContinueWorkBundleAcrossConversation(message)) {
+      canCrossVisibleConversation = true;
     }
 
     if (message.type !== "assistant" || message.isPartial) {
@@ -318,29 +336,26 @@ function findWorkBundleFinalIndex(
     }
 
     finalIndex = index;
-    const next = messages[index + 1];
-    if (next === undefined || !isWorkBundleTimelineMessage(next)) {
-      break;
-    }
-    if (!isWorkBundleVisibleConversationMessage(next)) {
-      const nextHistoryId = getWorkBundleAgentHistoryId(next);
-      if (nextHistoryId !== historyId) {
-        break;
-      }
-    }
+    canCrossVisibleConversation = false;
   }
 
-  if (!sawOperationalMessage || finalIndex === undefined || finalIndex <= startIndex) {
+  if (!sawOperationalMessage || finalIndex === undefined || finalIndex < startIndex) {
     return undefined;
   }
 
   return finalIndex;
 }
 
-function hasFutureAgentMessageWithHistoryId(
+function isSideQuestionStart(messages: DisplayedMessage[], index: number): boolean {
+  const next = messages[index + 1];
+  return (
+    messages[index]?.type === "user" && next?.type === "assistant" && next.isSideAnswer === true
+  );
+}
+
+function hasFutureWorkBundleAgentMessage(
   messages: DisplayedMessage[],
-  startIndex: number,
-  historyId: string
+  startIndex: number
 ): boolean {
   for (let index = startIndex; index < messages.length; index++) {
     const message = messages[index];
@@ -351,10 +366,20 @@ function hasFutureAgentMessageWithHistoryId(
       continue;
     }
 
-    return getWorkBundleAgentHistoryId(message) === historyId;
+    return getWorkBundleAgentHistoryId(message) !== undefined;
   }
 
   return false;
+}
+
+function canContinueWorkBundleAcrossConversation(message: DisplayedMessage): boolean {
+  if (!isWorkBundleAgentMessage(message)) {
+    return false;
+  }
+  if (message.type === "tool" && message.status === "interrupted") {
+    return false;
+  }
+  return message.isPartial === true;
 }
 
 function getWorkBundleAgentHistoryId(message: DisplayedMessage | undefined): string | undefined {

--- a/src/browser/utils/messages/transcriptRenderProjection.ts
+++ b/src/browser/utils/messages/transcriptRenderProjection.ts
@@ -373,13 +373,10 @@ function hasFutureWorkBundleAgentMessage(
 }
 
 function canContinueWorkBundleAcrossConversation(message: DisplayedMessage): boolean {
-  if (!isWorkBundleAgentMessage(message)) {
-    return false;
-  }
-  if (message.type === "tool" && message.status === "interrupted") {
-    return false;
-  }
-  return message.isPartial === true;
+  // Only partial tool rows prove the agent was still doing operational work when
+  // the user spoke. Partial reasoning/text alone can also be an interrupted turn;
+  // do not anchor the next prompt under that old turn's work bundle.
+  return message.type === "tool" && message.isPartial === true && message.status !== "interrupted";
 }
 
 function getWorkBundleAgentHistoryId(message: DisplayedMessage | undefined): string | undefined {

--- a/src/browser/utils/messages/transcriptRenderProjection.ts
+++ b/src/browser/utils/messages/transcriptRenderProjection.ts
@@ -35,6 +35,7 @@ export interface WorkBundleInfo {
   /** Render slot where the work-bundle header is placed. */
   headIndex: number;
   entries: readonly WorkBundleEntry[];
+  startedAtMs?: number;
   durationMs?: number;
   state: "active" | "settled";
   defaultExpanded: boolean;
@@ -156,7 +157,11 @@ export function computeWorkBundleInfos(
       position: "head",
       headIndex: span.headIndex,
       entries: frozenEntries,
-      durationMs: computeWorkBundleDurationMs(frozenEntries, finalMessage),
+      startedAtMs: getMessageTimestamp(frozenEntries[0].message),
+      durationMs:
+        span.state === "active"
+          ? undefined
+          : computeWorkBundleDurationMs(frozenEntries, finalMessage),
       state: span.state,
       defaultExpanded: span.state === "active",
     };
@@ -291,6 +296,7 @@ function findWorkBundleFinalIndex(
   const historyIds = new Set<string>([firstHistoryId]);
   let canCrossVisibleConversation = false;
   let sawVisibleConversationSinceLastAgent = false;
+  let sawAnyOperationalMessage = false;
   let sawOperationalMessage = false;
   let sawActiveMessage = false;
   let lastAgentIndex = startIndex;
@@ -316,6 +322,8 @@ function findWorkBundleFinalIndex(
         break;
       }
       sawVisibleConversationSinceLastAgent = true;
+      sawOperationalMessage = false;
+      sawActiveMessage = false;
       canCrossVisibleConversation = false;
       continue;
     }
@@ -337,6 +345,7 @@ function findWorkBundleFinalIndex(
     }
 
     if (isWorkBundleOperationalMessage(message)) {
+      sawAnyOperationalMessage = true;
       sawOperationalMessage = true;
     }
     canCrossVisibleConversation = canContinueWorkBundleAcrossConversation(message);
@@ -349,7 +358,7 @@ function findWorkBundleFinalIndex(
     canCrossVisibleConversation = false;
   }
 
-  if (!sawOperationalMessage) {
+  if (!sawAnyOperationalMessage) {
     return undefined;
   }
   if (finalIndex !== undefined && finalIndex >= startIndex) {

--- a/src/browser/utils/messages/transcriptRenderProjection.ts
+++ b/src/browser/utils/messages/transcriptRenderProjection.ts
@@ -116,25 +116,15 @@ export function computeWorkBundleInfos(
   let index = 0;
 
   while (index < messages.length) {
-    const historyId = getWorkBundleHistoryId(messages[index]);
-    if (historyId === undefined) {
+    if (!isWorkBundleStart(messages, index)) {
       index += 1;
       continue;
     }
 
     const startIndex = index;
-    while (getWorkBundleHistoryId(messages[index + 1]) === historyId) {
+    const finalIndex = findWorkBundleFinalIndex(messages, startIndex);
+    if (finalIndex === undefined) {
       index += 1;
-    }
-
-    const finalIndex = index;
-    index += 1;
-
-    if (finalIndex <= startIndex) {
-      continue;
-    }
-
-    if (messages[finalIndex]?.type !== "assistant") {
       continue;
     }
 
@@ -143,8 +133,15 @@ export function computeWorkBundleInfos(
       entries.push({ message: messages[entryIndex], originalIndex: entryIndex });
     }
 
-    const groupMessages = [...entries.map((entry) => entry.message), messages[finalIndex]];
+    const finalMessage = messages[finalIndex];
+    if (finalMessage?.type !== "assistant") {
+      index = finalIndex + 1;
+      continue;
+    }
+
+    const groupMessages = [...entries.map((entry) => entry.message), finalMessage];
     if (groupMessages.some(isActiveWorkBundleMessage)) {
+      index = finalIndex + 1;
       continue;
     }
 
@@ -155,7 +152,7 @@ export function computeWorkBundleInfos(
       position: "head",
       headIndex: startIndex,
       entries: frozenEntries,
-      durationMs: computeWorkBundleDurationMs(frozenEntries, messages[finalIndex]),
+      durationMs: computeWorkBundleDurationMs(frozenEntries, finalMessage),
       defaultExpanded: false,
     };
 
@@ -166,6 +163,7 @@ export function computeWorkBundleInfos(
       };
     }
     infos[finalIndex] = { ...info, position: "final" };
+    index = finalIndex + 1;
   }
 
   return infos;
@@ -241,16 +239,156 @@ export function computeOperationalBundleInfos(
   return infos;
 }
 
-function getWorkBundleHistoryId(message: DisplayedMessage | undefined): string | undefined {
-  switch (message?.type) {
-    case "assistant":
-    case "reasoning":
-      return message.historyId;
-    case "tool":
-      return isBundleableToolMessage(message) ? message.historyId : undefined;
-    default:
-      return undefined;
+function isWorkBundleStart(messages: DisplayedMessage[], index: number): boolean {
+  const message = messages[index];
+  const historyId = getWorkBundleAgentHistoryId(message);
+  if (historyId === undefined) {
+    return false;
   }
+  if (message.type !== "assistant") {
+    return true;
+  }
+  if (message.isPartial) {
+    return true;
+  }
+
+  for (let nextIndex = index + 1; nextIndex < messages.length; nextIndex++) {
+    const next = messages[nextIndex];
+    if (!isWorkBundleTimelineMessage(next)) {
+      return false;
+    }
+    if (isWorkBundleVisibleConversationMessage(next)) {
+      if (!hasFutureAgentMessageWithHistoryId(messages, nextIndex + 1, historyId)) {
+        return false;
+      }
+      continue;
+    }
+
+    const nextHistoryId = getWorkBundleAgentHistoryId(next);
+    if (nextHistoryId !== historyId) {
+      return false;
+    }
+    if (isWorkBundleOperationalMessage(next)) {
+      return true;
+    }
+    if (next.type === "assistant" && !next.isPartial) {
+      return false;
+    }
+  }
+
+  return false;
+}
+
+function findWorkBundleFinalIndex(
+  messages: DisplayedMessage[],
+  startIndex: number
+): number | undefined {
+  const historyId = getWorkBundleAgentHistoryId(messages[startIndex]);
+  if (historyId === undefined) {
+    return undefined;
+  }
+
+  let sawOperationalMessage = isWorkBundleOperationalMessage(messages[startIndex]);
+  let finalIndex: number | undefined;
+
+  for (let index = startIndex + 1; index < messages.length; index++) {
+    const message = messages[index];
+    if (!isWorkBundleTimelineMessage(message)) {
+      break;
+    }
+
+    if (isWorkBundleVisibleConversationMessage(message)) {
+      if (!hasFutureAgentMessageWithHistoryId(messages, index + 1, historyId)) {
+        break;
+      }
+      continue;
+    }
+
+    const messageHistoryId = getWorkBundleAgentHistoryId(message);
+    if (messageHistoryId !== historyId) {
+      break;
+    }
+
+    if (isWorkBundleOperationalMessage(message)) {
+      sawOperationalMessage = true;
+    }
+
+    if (message.type !== "assistant" || message.isPartial) {
+      continue;
+    }
+
+    finalIndex = index;
+    const next = messages[index + 1];
+    if (next === undefined || !isWorkBundleTimelineMessage(next)) {
+      break;
+    }
+    if (!isWorkBundleVisibleConversationMessage(next)) {
+      const nextHistoryId = getWorkBundleAgentHistoryId(next);
+      if (nextHistoryId !== historyId) {
+        break;
+      }
+    }
+  }
+
+  if (!sawOperationalMessage || finalIndex === undefined || finalIndex <= startIndex) {
+    return undefined;
+  }
+
+  return finalIndex;
+}
+
+function hasFutureAgentMessageWithHistoryId(
+  messages: DisplayedMessage[],
+  startIndex: number,
+  historyId: string
+): boolean {
+  for (let index = startIndex; index < messages.length; index++) {
+    const message = messages[index];
+    if (!isWorkBundleTimelineMessage(message)) {
+      return false;
+    }
+    if (isWorkBundleVisibleConversationMessage(message)) {
+      continue;
+    }
+
+    return getWorkBundleAgentHistoryId(message) === historyId;
+  }
+
+  return false;
+}
+
+function getWorkBundleAgentHistoryId(message: DisplayedMessage | undefined): string | undefined {
+  if (!isWorkBundleAgentMessage(message) || isWorkBundleVisibleConversationMessage(message)) {
+    return undefined;
+  }
+  return message.historyId;
+}
+
+function isWorkBundleTimelineMessage(
+  message: DisplayedMessage | undefined
+): message is DisplayedMessage & { type: "assistant" | "reasoning" | "tool" | "user" } {
+  return (
+    message?.type === "assistant" ||
+    message?.type === "reasoning" ||
+    message?.type === "tool" ||
+    message?.type === "user"
+  );
+}
+
+function isWorkBundleAgentMessage(
+  message: DisplayedMessage | undefined
+): message is DisplayedMessage & { type: "assistant" | "reasoning" | "tool" } {
+  return message?.type === "assistant" || message?.type === "reasoning" || message?.type === "tool";
+}
+
+function isWorkBundleVisibleConversationMessage(message: DisplayedMessage | undefined): boolean {
+  return (
+    message?.type === "user" || (message?.type === "assistant" && message.isSideAnswer === true)
+  );
+}
+
+function isWorkBundleOperationalMessage(message: DisplayedMessage | undefined): boolean {
+  return message?.type === "reasoning" || message?.type === "tool";
 }
 
 function isActiveWorkBundleMessage(message: DisplayedMessage): boolean {
@@ -323,15 +461,6 @@ export function summarizeOperationalBundle(
   };
 }
 
-function isBundleableToolMessage(message: DisplayedMessage & { type: "tool" }): boolean {
-  if (message.isPartial) {
-    return false;
-  }
-  return (
-    message.status === "completed" || message.status === "pending" || message.status === "executing"
-  );
-}
-
 function isEmptyCompletedWebSearch(message: OperationalBundleMemberMessage): boolean {
   return (
     message.type === "tool" &&
@@ -366,7 +495,7 @@ function isOperationalBundleMemberMessage(
     return message.isOnlyMessageContent !== true;
   }
   if (message?.type === "tool") {
-    return isBundleableToolMessage(message);
+    return true;
   }
   return false;
 }

--- a/src/browser/utils/messages/transcriptRenderProjection.ts
+++ b/src/browser/utils/messages/transcriptRenderProjection.ts
@@ -327,9 +327,7 @@ function findWorkBundleFinalIndex(
     if (isWorkBundleOperationalMessage(message)) {
       sawOperationalMessage = true;
     }
-    if (canContinueWorkBundleAcrossConversation(message)) {
-      canCrossVisibleConversation = true;
-    }
+    canCrossVisibleConversation = canContinueWorkBundleAcrossConversation(message);
 
     if (message.type !== "assistant" || message.isPartial) {
       continue;

--- a/tests/ui/chat/transcriptDensity.test.ts
+++ b/tests/ui/chat/transcriptDensity.test.ts
@@ -38,6 +38,19 @@ function queryButton(container: HTMLElement, testId: string): HTMLButtonElement 
   return element instanceof HTMLButton ? element : (element?.querySelector("button") ?? null);
 }
 
+function expectTextOrder(container: HTMLElement, ...orderedText: string[]): void {
+  const text = container.textContent ?? "";
+  let previousIndex = -1;
+  for (const expected of orderedText) {
+    const index = text.indexOf(expected);
+    if (index === -1) {
+      throw new Error(`Expected transcript text to contain "${expected}"`);
+    }
+    expect(index).toBeGreaterThan(previousIndex);
+    previousIndex = index;
+  }
+}
+
 describe("Hyper transcript density", () => {
   test("expands work bundles and nested operational bundles through the app render path", async () => {
     const cleanupDom = installDom();
@@ -55,9 +68,13 @@ describe("Hyper transcript density", () => {
       projectName: metadata.projectName,
       projectPath: metadata.projectPath,
       messages: [
-        createUserMessage("density-user-1", "Audit the auth module", { historySequence: 1 }),
+        createUserMessage("density-user-1", "Audit the auth module", {
+          historySequence: 1,
+          timestamp: 0,
+        }),
         createAssistantMessage("density-assistant-1", "I'll gather context first.", {
           historySequence: 2,
+          timestamp: 1_000,
           partial: true,
           reasoning: "Need to inspect auth code before changing it.",
           toolCalls: [
@@ -69,9 +86,11 @@ describe("Hyper transcript density", () => {
         }),
         createUserMessage("density-user-2", "Please validate with typecheck too", {
           historySequence: 3,
+          timestamp: 11_000,
         }),
         createAssistantMessage("density-assistant-2", "I'll patch and validate now.", {
           historySequence: 4,
+          timestamp: 21_000,
           toolCalls: [
             createBashTool(
               "density-fail-1",
@@ -102,6 +121,13 @@ describe("Hyper transcript density", () => {
       expect(workButton.getAttribute("aria-expanded")).toBe("false");
       expect(view.container.textContent).toContain("Please validate with typecheck too");
       expect(view.container.textContent).not.toContain("make typecheck");
+      expect(view.container.textContent).not.toContain("I'll gather context first.");
+      expectTextOrder(
+        view.container,
+        "Audit the auth module",
+        "Worked for",
+        "Please validate with typecheck too"
+      );
       fireEvent.click(workButton);
 
       const firstOperationalButton = await waitFor(() => {
@@ -114,6 +140,12 @@ describe("Hyper transcript density", () => {
       expect(firstOperationalButton.textContent).toContain("Ran 5 operations");
       expect(view.container.textContent).toContain("Please validate with typecheck too");
       expect(view.container.textContent).not.toContain("make typecheck");
+      expectTextOrder(
+        view.container,
+        "I'll gather context first.",
+        "Please validate with typecheck too",
+        "I'll patch and validate now."
+      );
       fireEvent.click(firstOperationalButton);
 
       await waitFor(() => {

--- a/tests/ui/chat/transcriptDensity.test.ts
+++ b/tests/ui/chat/transcriptDensity.test.ts
@@ -121,12 +121,15 @@ describe("Hyper transcript density", () => {
       expect(workButton.getAttribute("aria-expanded")).toBe("false");
       expect(view.container.textContent).toContain("Please validate with typecheck too");
       expect(view.container.textContent).not.toContain("make typecheck");
+      expect(view.container.textContent).toContain("Implemented the auth audit fix.");
+      expect(view.container.textContent).not.toContain("I'll patch and validate now.");
       expect(view.container.textContent).not.toContain("I'll gather context first.");
       expectTextOrder(
         view.container,
         "Audit the auth module",
         "Worked for",
-        "Please validate with typecheck too"
+        "Please validate with typecheck too",
+        "Implemented the auth audit fix."
       );
       fireEvent.click(workButton);
 

--- a/tests/ui/chat/transcriptDensity.test.ts
+++ b/tests/ui/chat/transcriptDensity.test.ts
@@ -9,6 +9,7 @@ import {
   createAgentSkillReadTool,
   createBashTool,
   createFileReadTool,
+  createGenericTool,
   createWebSearchTool,
 } from "@/browser/stories/mocks/tools";
 import { installDom } from "../dom";
@@ -81,7 +82,12 @@ describe("Hyper transcript density", () => {
             createFileReadTool("density-read-1", "src/auth.ts", "export function verify() {}"),
             createWebSearchTool("density-search-1", "JWT validation best practices", 1),
             createAgentSkillReadTool("density-skill-1", "react-effects", { scope: "global" }),
-            createBashTool("density-rg-1", 'rg "verify" src', "src/auth.ts:1:verify"),
+            createGenericTool(
+              "density-question-1",
+              "ask_user_question",
+              { question: "Any additional validation needed?" },
+              { answer: "Please validate with typecheck too" }
+            ),
           ],
         }),
         createUserMessage("density-user-2", "Please validate with typecheck too", {

--- a/tests/ui/chat/transcriptDensity.test.tsx
+++ b/tests/ui/chat/transcriptDensity.test.tsx
@@ -15,11 +15,27 @@ import { installDom } from "../dom";
 import { cleanupView, setupWorkspaceView } from "../helpers";
 import { renderApp } from "../renderReviewPanel";
 
+function queryButtons(container: HTMLElement, testId: string): HTMLButtonElement[] {
+  const HTMLButton = container.ownerDocument.defaultView?.HTMLButtonElement;
+  if (!HTMLButton) {
+    throw new Error("Expected test DOM to provide HTMLButtonElement");
+  }
+  return Array.from(container.querySelectorAll(`[data-testid="${testId}"]`)).flatMap((element) => {
+    if (element instanceof HTMLButton) {
+      return [element];
+    }
+    const button = element.querySelector("button");
+    return button ? [button] : [];
+  });
+}
+
 function queryButton(container: HTMLElement, testId: string): HTMLButtonElement | null {
   const element = container.querySelector(`[data-testid="${testId}"]`);
-  return element instanceof HTMLButtonElement
-    ? element
-    : (element?.querySelector("button") ?? null);
+  const HTMLButton = container.ownerDocument.defaultView?.HTMLButtonElement;
+  if (!HTMLButton) {
+    throw new Error("Expected test DOM to provide HTMLButtonElement");
+  }
+  return element instanceof HTMLButton ? element : (element?.querySelector("button") ?? null);
 }
 
 describe("Hyper transcript density", () => {
@@ -42,12 +58,30 @@ describe("Hyper transcript density", () => {
         createUserMessage("density-user-1", "Audit the auth module", { historySequence: 1 }),
         createAssistantMessage("density-assistant-1", "I'll gather context first.", {
           historySequence: 2,
+          partial: true,
           reasoning: "Need to inspect auth code before changing it.",
           toolCalls: [
             createFileReadTool("density-read-1", "src/auth.ts", "export function verify() {}"),
             createWebSearchTool("density-search-1", "JWT validation best practices", 1),
             createAgentSkillReadTool("density-skill-1", "react-effects", { scope: "global" }),
             createBashTool("density-rg-1", 'rg "verify" src', "src/auth.ts:1:verify"),
+          ],
+        }),
+        createUserMessage("density-user-2", "Please validate with typecheck too", {
+          historySequence: 3,
+        }),
+        createAssistantMessage("density-assistant-2", "I'll patch and validate now.", {
+          historySequence: 4,
+          toolCalls: [
+            createBashTool(
+              "density-fail-1",
+              "make typecheck",
+              "Type error in src/auth.ts",
+              1,
+              30,
+              500,
+              "Failing validation"
+            ),
             { type: "text", text: "Implemented the auth audit fix." },
           ],
         }),
@@ -66,19 +100,39 @@ describe("Hyper transcript density", () => {
         return button;
       });
       expect(workButton.getAttribute("aria-expanded")).toBe("false");
+      expect(view.container.textContent).toContain("Please validate with typecheck too");
+      expect(view.container.textContent).not.toContain("make typecheck");
       fireEvent.click(workButton);
 
-      const operationalButton = await waitFor(() => {
+      const firstOperationalButton = await waitFor(() => {
         const button = queryButton(view.container, "operational-bundle");
         if (!button) {
           throw new Error("Operational bundle button not found");
         }
         return button;
       });
-      fireEvent.click(operationalButton);
+      expect(firstOperationalButton.textContent).toContain("Ran 5 operations");
+      expect(view.container.textContent).toContain("Please validate with typecheck too");
+      expect(view.container.textContent).not.toContain("make typecheck");
+      fireEvent.click(firstOperationalButton);
 
       await waitFor(() => {
         expect(view.container.textContent).toContain("src/auth.ts");
+      });
+
+      const failedOperationalButton = await waitFor(() => {
+        const button = queryButtons(view.container, "operational-bundle").find((candidate) =>
+          candidate.textContent?.includes("Ran 1 shell command")
+        );
+        if (!button) {
+          throw new Error("Failed operational bundle button not found");
+        }
+        return button;
+      });
+      fireEvent.click(failedOperationalButton);
+
+      await waitFor(() => {
+        expect(view.container.textContent).toContain("make typecheck");
       });
     } finally {
       await cleanupView(view, cleanupDom);


### PR DESCRIPTION
## Summary
Hyper transcript density now collapses failed, interrupted, redacted, and partial tool rows into operational bundles, anchors the outer `Worked for ...` bundle directly below the user message that triggered the turn, and consistently shows a work header/divider for both active and settled work. Active work now shows elapsed duration as `Working for Ns...`. Collapsed mode hides detailed agent-emitted work, keeps in-turn steering user messages visible below the collapsed bundle, and keeps the final assistant summary visible below the fold; expanded mode preserves chronological order without extra right indentation inside the work bundle.

## Background
The previous hyper-density behavior hid successful tool noise but left failed shell commands and other non-success tool rows visible. The first revision also placed the `Worked for ...` fold too low in steering-message scenarios, which made the collapsed hierarchy feel disconnected from the user prompt that started the turn. Follow-up Chromatic review showed the final assistant summary should remain visible below collapsed work, and the work header should act as a consistent divider in both active and settled states.

## Implementation
- Treat all displayed tool statuses as bundleable for hyper-density projections.
- Project work bundles from the triggering user row through the final assistant row for that turn.
- Allow steering messages and the final assistant summary to remain visible below collapsed work bundles, while rendering the whole bundle chronologically when expanded.
- Keep active work in an expanded `Working for Ns...` work bundle so the header/divider is always present while the agent is working.
- Remove nested work-bundle indentation so assistant text, operation summaries, and final summaries align under the divider.
- Tighten cross-user bundling so only active in-turn checkpoints can span a steering message; completed partial tools do not merge into the next prompt.
- Keep side-question answers visible and avoid merging interrupted work into the next user turn.
- Extend projection, component, and app-render tests for failed tools, steering messages, active work bundles, anchored work bundles, and collapsed/expanded ordering.

## Validation
- `bun test src/browser/utils/messages/transcriptRenderProjection.test.ts src/browser/features/Messages/WorkBundleMessage.test.tsx`
- `TEST_INTEGRATION=1 bun x jest tests/ui/chat/transcriptDensity.test.ts --runInBand --silent`
- `make typecheck`
- `make static-check`
- Dogfooded the Storybook hyper-density stories with screenshots/video:
  - collapsed state places `Worked for ...` after the triggering user message
  - collapsed state keeps the steering message and final assistant summary visible below the fold
  - expanded state renders the steering message chronologically between the two assistant work phases without extra inner indentation
  - active state shows elapsed `Working for Ns...` with the same divider and flat inner layout

## Risks
Moderate UI regression risk, limited to hyper transcript density rendering. The main behavior change is intentional: detailed agent-emitted rows are hidden until the containing work/operation bundle is expanded, while user-authored steering messages and the final assistant summary stay visible.

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$81.55`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=81.55 -->
