### PR TITLE
🤖 fix: disable native spellchecker in Electron windows

### DIFF
--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -883,6 +883,9 @@ function createWindow() {
       nodeIntegration: false,
       contextIsolation: true,
       preload: path.join(__dirname, "../preload.js"),
+      // Disable the native spellchecker: mux is a coding tool where inputs are
+      // full of code, paths, and identifiers that trigger noisy red squiggles.
+      spellcheck: false,
     },
     title: "mux - coder multiplexer",
     // Hide menu bar on Linux by default (like VS Code)

--- a/src/desktop/terminalWindowManager.ts
+++ b/src/desktop/terminalWindowManager.ts
@@ -55,6 +55,8 @@ export class TerminalWindowManager {
         contextIsolation: true,
         // __dirname is dist/services/ but preload.js is in dist/
         preload: path.join(__dirname, "../preload.js"),
+        // Disable spellcheck to match the main window; terminal content is code.
+        spellcheck: false,
       },
       backgroundColor: "#1e1e1e",
     });


### PR DESCRIPTION
## Summary

Disable Electron's native spellchecker across the renderer windows. mux is a coding tool whose text inputs are full of code, file paths, and identifiers, so the OS spellchecker just produces noisy red squiggles with no value.

## Implementation

Added `spellcheck: false` to `webPreferences` for:

- The main app window (`src/desktop/main.ts`) — where all chat/text input happens.
- The popped-out terminal window (`src/desktop/terminalWindowManager.ts`) — content is code.

The splash window has no text inputs, so it was left untouched. Per-element `spellCheck={false}` attributes that already existed on individual React inputs remain (now redundant but harmless).

## Validation

- `make static-check` passes (eslint, typecheck for both app + main tsconfig projects, formatting, docs links).

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-8` • Thinking: `xhigh` • Cost: `$0.43`_

<!-- mux-attribution: model=anthropic:claude-opus-4-8 thinking=xhigh costs=0.43 -->
