### PR TITLE
🤖 fix: require provider stream terminal events

### DIFF
--- a/src/common/orpc/schemas/errors.ts
+++ b/src/common/orpc/schemas/errors.ts
@@ -40,6 +40,7 @@ export const StreamErrorTypeSchema = z.enum([
   "runtime_not_ready", // Container/runtime doesn't exist or failed to start (permanent)
   "runtime_start_failed", // Runtime is starting or temporarily unavailable (retryable)
   "empty_output", // Provider ended the stream without any assistant-visible output
+  "stream_truncated", // Provider stream closed before its terminal finish event
   "max_output_tokens", // Provider truncated the response at max_tokens (finishReason: "length")
   "unknown", // Catch-all
 ]);

--- a/src/node/services/copilot/copilotResponsesLanguageModel.test.ts
+++ b/src/node/services/copilot/copilotResponsesLanguageModel.test.ts
@@ -378,6 +378,98 @@ describe("CopilotResponsesLanguageModel", () => {
     });
   });
 
+  it("emits an error when the SSE stream closes before a terminal event", async () => {
+    restoreFetchers.push(
+      mockFetch(() =>
+        Promise.resolve(
+          createSseResponse([
+            {
+              event: "response.output_item.added",
+              data: {
+                type: "response.output_item.added",
+                output_index: 0,
+                content_index: 0,
+                item: { type: "message", id: "msg_1" },
+              },
+            },
+            {
+              event: "response.output_text.delta",
+              data: {
+                type: "response.output_text.delta",
+                output_index: 0,
+                content_index: 0,
+                item_id: "msg_1",
+                delta: "partial",
+              },
+            },
+          ])
+        )
+      )
+    );
+
+    const model = createModel();
+    const result = await model.doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "Stream please" }] }],
+    });
+    const parts = await collectStreamParts(result.stream);
+
+    expect(parts.map((part) => part.type)).toEqual([
+      "stream-start",
+      "text-start",
+      "text-delta",
+      "error",
+    ]);
+    const errorPart = parts.find(
+      (part): part is Extract<LanguageModelV2StreamPart, { type: "error" }> => part.type === "error"
+    );
+    expect(errorPart?.error).toBeInstanceOf(Error);
+    expect(errorPart?.error instanceof Error ? errorPart.error.message : "").toContain(
+      "stream closed before terminal event"
+    );
+  });
+
+  it("treats response.incomplete as a terminal finish event", async () => {
+    restoreFetchers.push(
+      mockFetch(() =>
+        Promise.resolve(
+          createSseResponse([
+            {
+              event: "response.incomplete",
+              data: {
+                type: "response.incomplete",
+                response: {
+                  incomplete_details: { reason: "max_output_tokens" },
+                  usage: { input_tokens: 3, output_tokens: 2, total_tokens: 5 },
+                },
+              },
+            },
+          ])
+        )
+      )
+    );
+
+    const model = createModel();
+    const result = await model.doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "Stream please" }] }],
+    });
+    const parts = await collectStreamParts(result.stream);
+
+    expect(parts).toEqual([
+      { type: "stream-start", warnings: [] },
+      {
+        type: "finish",
+        finishReason: "length",
+        usage: {
+          inputTokens: 3,
+          outputTokens: 2,
+          totalTokens: 5,
+          reasoningTokens: undefined,
+          cachedInputTokens: undefined,
+        },
+      },
+    ]);
+  });
+
   it("uses a stable synthetic text id even when item_id rotates", async () => {
     restoreFetchers.push(
       mockFetch(() =>

--- a/src/node/services/copilot/copilotResponsesLanguageModel.ts
+++ b/src/node/services/copilot/copilotResponsesLanguageModel.ts
@@ -283,6 +283,7 @@ async function consumeSseStream(
   const reader = source.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
+  let sawTerminalEvent = false;
 
   try {
     for (;;) {
@@ -294,13 +295,18 @@ async function consumeSseStream(
       while (boundary >= 0) {
         const frame = buffer.slice(0, boundary);
         buffer = buffer.slice(boundary + 2);
-        processFrame(frame, aliasRegistry, includeRawChunks, controller);
+        sawTerminalEvent =
+          processFrame(frame, aliasRegistry, includeRawChunks, controller) || sawTerminalEvent;
         boundary = buffer.indexOf("\n\n");
       }
 
       if (done) {
         if (buffer.trim().length > 0) {
-          processFrame(buffer, aliasRegistry, includeRawChunks, controller);
+          sawTerminalEvent =
+            processFrame(buffer, aliasRegistry, includeRawChunks, controller) || sawTerminalEvent;
+        }
+        if (!sawTerminalEvent) {
+          controller.enqueue({ type: "error", error: createStreamTruncatedError() });
         }
         break;
       }
@@ -318,19 +324,23 @@ function processFrame(
   aliasRegistry: Map<string, string>,
   includeRawChunks: boolean,
   controller: ReadableStreamDefaultController<LanguageModelV2StreamPart>
-) {
+): boolean {
   const parsed = parseSseFrame(frame);
   if (parsed == null) {
-    return;
+    return false;
   }
 
   if (includeRawChunks) {
     controller.enqueue({ type: "raw", rawValue: parsed });
   }
 
+  let sawTerminalEvent = false;
   for (const part of mapStreamEvent(parsed.event, parsed.data, aliasRegistry)) {
+    sawTerminalEvent = part.type === "finish" || part.type === "error" || sawTerminalEvent;
     controller.enqueue(part);
   }
+
+  return sawTerminalEvent;
 }
 
 function parseSseFrame(frame: string) {
@@ -393,6 +403,7 @@ function mapStreamEvent(event: string, data: JsonRecord, aliasRegistry: Map<stri
       return id ? ([{ type: "text-end", id }] satisfies LanguageModelV2StreamPart[]) : [];
     }
     case "response.completed":
+    case "response.incomplete":
       return [
         {
           type: "finish",
@@ -400,11 +411,30 @@ function mapStreamEvent(event: string, data: JsonRecord, aliasRegistry: Map<stri
           finishReason: mapFinishReason(getRawFinishReason(data.response)),
         },
       ] satisfies LanguageModelV2StreamPart[];
+    case "response.failed":
+      return [
+        { type: "error", error: createResponseFailedError(data) },
+      ] satisfies LanguageModelV2StreamPart[];
     case "error":
       return [{ type: "error", error: data }] satisfies LanguageModelV2StreamPart[];
     default:
       return [];
   }
+}
+
+function createStreamTruncatedError() {
+  return new Error("Copilot Responses stream closed before terminal event");
+}
+
+function createResponseFailedError(data: JsonRecord) {
+  const response = data.response as JsonRecord | undefined;
+  const error = response?.error as JsonRecord | undefined;
+  const message = getString(error?.message) ?? "Response failed";
+  const code = getString(error?.code);
+
+  return new Error(
+    code ? `response failed: ${message} (code: ${code})` : `response failed: ${message}`
+  );
 }
 
 function resolveStableTextId(
@@ -479,6 +509,7 @@ function mapFinishReason(reason: unknown): LanguageModelV2FinishReason {
     case "stop":
       return "stop";
     case "max_tokens":
+    case "max_output_tokens":
       return "length";
     case "content_filter":
       return "content-filter";

--- a/src/node/services/streamManager.modelOnlyNotifications.test.ts
+++ b/src/node/services/streamManager.modelOnlyNotifications.test.ts
@@ -52,6 +52,8 @@ describe("StreamManager - model-only tool notifications", () => {
             __mux_notifications: ["<notification>hello</notification>"],
           },
         };
+
+        yield { type: "finish", finishReason: "stop" };
       })(),
       totalUsage: Promise.resolve({ inputTokens: 0, outputTokens: 0, totalTokens: 0 }),
       usage: Promise.resolve({ inputTokens: 0, outputTokens: 0, totalTokens: 0 }),
@@ -131,6 +133,8 @@ describe("StreamManager - model-only tool notifications", () => {
             ],
           },
         };
+
+        yield { type: "finish", finishReason: "stop" };
       })(),
       totalUsage: Promise.resolve({ inputTokens: 0, outputTokens: 0, totalTokens: 0 }),
       usage: Promise.resolve({ inputTokens: 0, outputTokens: 0, totalTokens: 0 }),

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -209,6 +209,7 @@ function createStreamInfoForTests(
     cumulativeUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
     cumulativeProviderMetadata: undefined,
     didRetryPreviousResponseIdAtStep: false,
+    receivedTerminalEvent: false,
     currentStepStartIndex: 0,
     stepTracker: {},
     ...overrides,
@@ -941,6 +942,12 @@ describe("StreamManager - language model cleanup", () => {
       workspaceId: "cleanup-workspace",
       messageId: "cleanup-message",
       streamInfoOverrides: () => ({
+        streamResult: createStreamResultForTests(
+          (async function* () {
+            await Promise.resolve();
+            yield { type: "finish", finishReason: "stop" };
+          })()
+        ),
         parts: [{ type: "text" as const, text: "done", timestamp: Date.now() }],
       }),
     },
@@ -1583,6 +1590,70 @@ describe("StreamManager - empty stream completions", () => {
     expect(partial?.metadata?.metadataModel).toBe(KNOWN_MODELS.SONNET.id);
     expect(partial?.parts).toEqual([]);
   });
+
+  test("persists retryable partial error when a non-empty stream closes before finish", async () => {
+    const streamManager = new StreamManager(historyService);
+    const errorEvents: Array<{ messageId: string; error: string; errorType?: string }> = [];
+    const streamEndEvents: unknown[] = [];
+
+    streamManager.on("error", (data) => {
+      errorEvents.push(data as { messageId: string; error: string; errorType?: string });
+    });
+    streamManager.on("stream-end", (data) => {
+      streamEndEvents.push(data);
+    });
+
+    const replaceTokenTrackerResult = Reflect.set(streamManager, "tokenTracker", {
+      setModel: () => Promise.resolve(undefined),
+      countTokens: () => Promise.resolve(0),
+    });
+    expect(replaceTokenTrackerResult).toBe(true);
+
+    const workspaceId = "truncated-stream-workspace";
+    const messageId = "truncated-stream-message";
+    const historySequence = 1;
+
+    await appendPartialAssistantForTests(workspaceId, messageId, historySequence);
+    const processStreamWithCleanup = getProcessStreamWithCleanupForTests(streamManager);
+    const startTime = Date.now() - 250;
+    const streamInfo = createStreamInfoForTests({
+      streamResult: createStreamResultForTests(
+        (async function* () {
+          await Promise.resolve();
+          yield { type: "text-delta", text: "partial answer" };
+        })(),
+        { inputTokens: 3, outputTokens: 2, totalTokens: 5 }
+      ),
+      messageId,
+      startTime,
+      lastPartTimestamp: startTime,
+      model: KNOWN_MODELS.SONNET.id,
+      metadataModel: KNOWN_MODELS.SONNET.id,
+      historySequence,
+      initialMetadata: { agentId: "plan" },
+      runtime,
+    });
+
+    await processStreamWithCleanup.call(streamManager, workspaceId, streamInfo, historySequence);
+
+    expect(streamEndEvents).toHaveLength(0);
+    expect(errorEvents).toHaveLength(1);
+    expect(errorEvents[0]).toMatchObject({
+      messageId,
+      errorType: "stream_truncated",
+    });
+    expect(errorEvents[0]?.error).toContain(
+      "Anthropic stream closed unexpectedly before the response completed"
+    );
+
+    const partial = await historyService.readPartial(workspaceId);
+    expect(partial?.metadata?.errorType).toBe("stream_truncated");
+    expect(partial?.metadata?.error).toContain(
+      "Anthropic stream closed unexpectedly before the response completed"
+    );
+    expect(partial?.metadata?.metadataModel).toBe(KNOWN_MODELS.SONNET.id);
+    expect(partial?.parts).toMatchObject([{ type: "text", text: "partial answer" }]);
+  });
 });
 
 describe("StreamManager - TTFT metadata persistence", () => {
@@ -1702,7 +1773,9 @@ describe("StreamManager - TTFT metadata persistence", () => {
     const streamInfo = createStreamInfoForTests({
       streamResult: createStreamResultForTests(
         (async function* () {
-          // No-op stream: tests verify stream-end finalization behavior from pre-populated parts.
+          // Tests pre-populate parts but still need the provider's terminal proof of completion.
+          await Promise.resolve();
+          yield { type: "finish", finishReason: "stop" };
         })(),
         usage
       ),
@@ -2606,6 +2679,16 @@ describe("StreamManager - categorizeError", () => {
   });
 
   const categorizeCases: Array<{ name: string; error: unknown; expected: string }> = [
+    {
+      name: "classifies Anthropic missing message_stop as stream_truncated",
+      error: new Error("anthropic stream closed before message_stop"),
+      expected: "stream_truncated",
+    },
+    {
+      name: "classifies OpenAI Responses missing terminal event as stream_truncated",
+      error: new Error("openai responses stream closed before terminal event"),
+      expected: "stream_truncated",
+    },
     {
       name: "classifies model_not_found via message fallback",
       error: new Error("The model `gpt-5.2-codex` does not exist or you do not have access to it."),

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -64,6 +64,7 @@ import { runLanguageModelCleanup } from "./languageModelCleanup";
 import { shellQuote } from "@/common/utils/shell";
 import { classify429Capacity } from "@/common/utils/errors/classify429Capacity";
 import { extractChunkDeltaText } from "@/common/utils/ai/streamChunks";
+import { PROVIDER_DEFINITIONS } from "@/common/constants/providers";
 
 // Disable noisy AI SDK warning logging.
 globalThis.AI_SDK_LOG_WARNINGS = false;
@@ -74,11 +75,23 @@ const EMPTY_STREAM_OUTPUT_ERROR_MESSAGE =
   "The model ended the stream before producing any assistant-visible output. This usually means the upstream stream was dropped rather than completed normally. Mux will retry automatically when possible, and if retries keep failing you should try again or switch models.";
 
 const MAX_EMPTY_STREAM_RECOVERY_ATTEMPTS = 1;
+const STREAM_TRUNCATED_MESSAGE_SUFFIX =
+  "stream closed unexpectedly before the response completed. Mux will retry automatically when possible, and if retries keep failing you should try again or switch models.";
 
 class EmptyStreamOutputError extends Error {
   constructor() {
     super(EMPTY_STREAM_OUTPUT_ERROR_MESSAGE);
     this.name = "EmptyStreamOutputError";
+  }
+}
+
+class StreamTruncatedError extends Error {
+  readonly providerDisplayName: string;
+
+  constructor(providerDisplayName: string) {
+    super(`${providerDisplayName} ${STREAM_TRUNCATED_MESSAGE_SUFFIX}`);
+    this.name = "StreamTruncatedError";
+    this.providerDisplayName = providerDisplayName;
   }
 }
 
@@ -129,6 +142,31 @@ interface StreamRequestConfig {
   /** Optional hook for callers that need the live prepared step transcript. */
   onStepMessages?: (messages: ModelMessage[]) => void;
   toolPolicy?: ToolPolicy;
+}
+
+function isKnownProviderName(provider: string): provider is keyof typeof PROVIDER_DEFINITIONS {
+  return Object.hasOwn(PROVIDER_DEFINITIONS, provider);
+}
+
+function getStreamProviderDisplayName(model: string): string {
+  const canonicalModel = normalizeToCanonical(model);
+  const providerSeparatorIndex = canonicalModel.indexOf(":");
+  const provider =
+    providerSeparatorIndex > 0 ? canonicalModel.slice(0, providerSeparatorIndex) : undefined;
+  if (provider && isKnownProviderName(provider)) {
+    return PROVIDER_DEFINITIONS[provider].displayName;
+  }
+
+  return "The model";
+}
+
+function isStreamTruncatedMessage(message: string): boolean {
+  const lowerMessage = message.toLowerCase();
+  return (
+    lowerMessage.includes("stream closed before message_stop") ||
+    lowerMessage.includes("stream closed before terminal event") ||
+    lowerMessage.includes("stream closed unexpectedly before the response completed")
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -370,6 +408,10 @@ interface WorkspaceStreamInfo {
   // stream-end prefers cumulative usage across attempts instead of the final
   // attempt's totalUsage only.
   didRetryAfterEmptyOutput?: boolean;
+  // Provider streams must prove semantic completion with a terminal SDK finish part.
+  // A clean EOF can be a proxy/provider drop and must not finalize partial assistant text.
+  receivedTerminalEvent: boolean;
+  terminalFinishReason?: string;
   // Index into parts where the current step started (used to ensure safe retries)
   currentStepStartIndex: number;
   historySequence: number;
@@ -1380,6 +1422,7 @@ export class StreamManager extends EventEmitter {
       didRetryPreviousResponseIdAtStep: false,
       didRetryAfterEmptyOutput: false,
       stepTracker,
+      receivedTerminalEvent: false,
       currentStepStartIndex: 0,
       request,
       historySequence,
@@ -1684,6 +1727,39 @@ export class StreamManager extends EventEmitter {
     });
 
     await this.handleStreamFailure(workspaceId, streamInfo, new EmptyStreamOutputError());
+  }
+
+  private async handleTruncatedStreamCompletion(
+    workspaceId: WorkspaceId,
+    streamInfo: WorkspaceStreamInfo
+  ): Promise<void> {
+    const workspaceLog = this.getWorkspaceLogger(workspaceId, streamInfo);
+    const streamMeta = await this.getStreamMetadata(streamInfo);
+    const totalUsage = this.resolveTotalUsageForStreamEnd(streamInfo, streamMeta.totalUsage);
+    const contextUsage = streamMeta.contextUsage ?? streamInfo.lastStepUsage;
+    const previousResponseId = this.getOpenAIPreviousResponseId(streamInfo.request.providerOptions);
+    const providerDisplayName = getStreamProviderDisplayName(streamInfo.model);
+
+    // Do not treat iterator EOF as success. Anthropic and OpenAI Responses both
+    // have semantic terminal events; without the SDK finish part, this may be a
+    // clean proxy/provider drop after partial text was already streamed.
+    workspaceLog.error("Stream ended without a terminal finish event", {
+      messageId: streamInfo.messageId,
+      model: streamInfo.model,
+      providerDisplayName,
+      durationMs: streamMeta.duration,
+      totalUsage,
+      contextUsage,
+      cumulativeUsage: streamInfo.cumulativeUsage,
+      previousResponseId,
+      partsCount: streamInfo.parts.length,
+    });
+
+    await this.handleStreamFailure(
+      workspaceId,
+      streamInfo,
+      new StreamTruncatedError(providerDisplayName)
+    );
   }
 
   private async retryEmptyStreamBeforeFailure(
@@ -2038,9 +2114,17 @@ export class StreamManager extends EventEmitter {
               // Handle other event types as needed
               case "start":
               case "text-start":
-              case "finish":
                 // These events can be logged or handled if needed
                 break;
+
+              case "finish": {
+                const finishPart = part as { finishReason?: unknown };
+                streamInfo.receivedTerminalEvent = true;
+                if (typeof finishPart.finishReason === "string") {
+                  streamInfo.terminalFinishReason = finishPart.finishReason;
+                }
+                break;
+              }
 
               case "finish-step": {
                 // Emit usage-delta event with usage from this step
@@ -2115,6 +2199,11 @@ export class StreamManager extends EventEmitter {
               break;
             }
 
+            if (!streamInfo.receivedTerminalEvent) {
+              await this.handleTruncatedStreamCompletion(workspaceId, streamInfo);
+              break;
+            }
+
             // Get all metadata from stream result in one call
             // - totalUsage: sum of all steps (for cost calculation)
             // - contextUsage: last step only (for context window display)
@@ -2130,7 +2219,7 @@ export class StreamManager extends EventEmitter {
             const contextUsage = streamMeta.contextUsage ?? streamInfo.lastStepUsage;
             const contextProviderMetadata =
               streamMeta.contextProviderMetadata ?? streamInfo.lastStepProviderMetadata;
-            const finishReason = streamMeta.finishReason;
+            const finishReason = streamInfo.terminalFinishReason ?? streamMeta.finishReason;
             const duration = streamMeta.duration;
             const ttftMs = this.resolveTtftMsForStreamEnd(streamInfo);
             // Aggregated provider metadata across all steps (for cost calculation with cache tokens)
@@ -2323,6 +2412,15 @@ export class StreamManager extends EventEmitter {
       };
     }
 
+    if (error instanceof StreamTruncatedError) {
+      return {
+        messageId: streamInfo.messageId,
+        error: error.message,
+        errorType: "stream_truncated",
+        acpPromptId: streamInfo.initialMetadata?.acpPromptId,
+      };
+    }
+
     // Extract error message (errors thrown from 'error' parts already have the correct message)
     // Apply prefix stripping to remove noisy "undefined: " prefixes from provider errors
     let errorMessage: string = stripNoisyErrorPrefix(getErrorMessage(error));
@@ -2508,6 +2606,8 @@ export class StreamManager extends EventEmitter {
     if (!preserveParts) {
       streamInfo.parts = [];
     }
+    streamInfo.receivedTerminalEvent = false;
+    streamInfo.terminalFinishReason = undefined;
     streamInfo.lastPartialWriteTime = 0;
 
     if (!preserveUsage) {
@@ -2651,6 +2751,10 @@ export class StreamManager extends EventEmitter {
    * Categorizes errors for better error handling (used for event emission)
    */
   private categorizeError(error: unknown): StreamErrorType {
+    if (error instanceof StreamTruncatedError) {
+      return "stream_truncated";
+    }
+
     // Use AI SDK error type guards first
     if (LoadAPIKeyError.isInstance(error)) {
       return "authentication";
@@ -2768,6 +2872,10 @@ export class StreamManager extends EventEmitter {
     // Fall back to string matching for other errors
     if (error instanceof Error) {
       const message = error.message.toLowerCase();
+
+      if (isStreamTruncatedMessage(message)) {
+        return "stream_truncated";
+      }
 
       if (error.name === "AbortError" || message.includes("abort")) {
         return "aborted";


### PR DESCRIPTION
Summary

Requires provider stream completion to be witnessed by the AI SDK `finish` part before Mux finalizes an assistant message. If a non-empty stream closes before that terminal event, Mux now persists a retryable `stream_truncated` partial instead of committing partial text to `chat.jsonl` as a successful response.

Background

This mirrors the stream-terminal invariant from coder/coder#25074 and coder/fantasy#33: Anthropic streams must reach `message_stop`, and OpenAI Responses streams must reach a terminal lifecycle event (`response.completed`, `response.incomplete`, or `response.failed`) before the response is considered complete. A clean network EOF can be a proxy or provider drop and is not enough to prove semantic completion.

Implementation

`StreamManager` now records the terminal `finish` part as the proof required for the success path and classifies non-empty missing-terminal completions as retryable `stream_truncated` errors. Empty completions keep the existing safe internal retry path. The Copilot Responses adapter now enforces the same Responses lifecycle locally, maps `response.incomplete` to a length finish, and surfaces `response.failed` as an error instead of falling through to EOF handling.

Already-streamed content is preserved, not discarded

If the stream produced output before closing without a terminal event, that output is **not** thrown away. The final `flushPartialWrite` runs before the truncation guard fires, and `persistStreamError` writes a `MuxMessage` to `partial.json` whose `parts` array contains every streamed part accumulated so far (`metadata.partial = true`, `metadata.errorType = "stream_truncated"`). The success-path call to `historyService.updateHistory` is unreachable in this branch, so nothing partial leaks into `chat.jsonl`. The frontend surfaces the partial turn with a retry barrier; the user sees the streamed text and can retry, and because `stream_truncated` is omitted from `NON_RETRYABLE_STREAM_ERRORS`, retry is enabled by default. The new `streamManager.test.ts` regression test pins this: after a truncated stream, `partial.parts` still contains the streamed text-delta and `partial.metadata.errorType === "stream_truncated"`.

Risks

This makes the success path stricter for every provider routed through `streamText`. If a provider adapter fails to emit a `finish` part for a genuinely complete response, Mux will now surface a retryable partial instead of committing it. That is intentional for Anthropic and OpenAI Responses and safer than silently finalizing truncated output.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$3.95`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=3.95 -->
