### PR TITLE
🤖 fix: collapse settled operation bundles in hyper density

### DIFF
--- a/src/browser/utils/messages/transcriptRenderProjection.test.ts
+++ b/src/browser/utils/messages/transcriptRenderProjection.test.ts
@@ -701,7 +701,7 @@ describe("operational bundle coalescing", () => {
     expect(infos[4]).toMatchObject({ key: "bundle:search-1", position: "member" });
   });
 
-  test("active and just-settled tail bundles stay expanded until a visible event or turn end", () => {
+  test("keeps active bundles expanded while completed bundles default collapsed", () => {
     const active = computeOperationalBundleInfos(
       [reasoning({ id: "think-1", isStreaming: true })],
       {
@@ -721,7 +721,7 @@ describe("operational bundle coalescing", () => {
     expect(justSettledTail[0]).toMatchObject({
       position: "head",
       state: "settled",
-      defaultExpanded: true,
+      defaultExpanded: false,
     });
 
     const afterVisibleEvent = computeOperationalBundleInfos(

--- a/src/browser/utils/messages/transcriptRenderProjection.ts
+++ b/src/browser/utils/messages/transcriptRenderProjection.ts
@@ -178,7 +178,7 @@ export function computeWorkBundleInfos(
 
 export function computeOperationalBundleInfos(
   messages: DisplayedMessage[],
-  options: ComputeBundleInfosOptions
+  _options: ComputeBundleInfosOptions
 ): Array<OperationalBundleInfo | undefined> {
   const infos = new Array<OperationalBundleInfo | undefined>(messages.length);
   let index = 0;
@@ -224,9 +224,7 @@ export function computeOperationalBundleInfos(
     const state = frozenEntries.some((entry) => isActiveOperationalMessage(entry.message))
       ? "active"
       : "settled";
-    const hasSubsequentVisibleEvent = hasVisibleEventAfter(messages, index);
-    const defaultExpanded =
-      state === "active" || (options.isTurnActive && !hasSubsequentVisibleEvent);
+    const defaultExpanded = state === "active";
     const key = `bundle:${first.id}`;
     const summary = summarizeOperationalBundle(frozenEntries.map((entry) => entry.message));
 
@@ -466,16 +464,6 @@ function computeWorkBundleDurationMs(
     return undefined;
   }
   return endTimestamp - startTimestamp;
-}
-
-function hasVisibleEventAfter(messages: DisplayedMessage[], startIndex: number): boolean {
-  for (let index = startIndex; index < messages.length; index++) {
-    if (!isOperationalBundleMemberMessage(messages[index])) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
 export function summarizeOperationalBundle(

--- a/tests/ui/chat/transcriptDensity.test.ts
+++ b/tests/ui/chat/transcriptDensity.test.ts
@@ -147,7 +147,9 @@ describe("Hyper transcript density", () => {
         return button;
       });
       expect(firstOperationalButton.textContent).toContain("Ran 5 operations");
+      expect(firstOperationalButton.getAttribute("aria-expanded")).toBe("false");
       expect(view.container.textContent).toContain("Please validate with typecheck too");
+      expect(view.container.textContent).not.toContain("src/auth.ts");
       expect(view.container.textContent).not.toContain("make typecheck");
       expectTextOrder(
         view.container,
@@ -170,6 +172,7 @@ describe("Hyper transcript density", () => {
         }
         return button;
       });
+      expect(failedOperationalButton.getAttribute("aria-expanded")).toBe("false");
       fireEvent.click(failedOperationalButton);
 
       await waitFor(() => {


### PR DESCRIPTION
## Summary

Collapse completed hyper-density operational bundles by default while keeping active/running operational bundles expanded for live progress visibility.

## Background

Hyper transcript density already groups low-signal reasoning/tool details behind operation summaries. Completed summaries could still start expanded at the active turn tail, which let settled details consume viewport space before the user chose to inspect them.

## Implementation

- Simplified operational bundle default expansion to `state === "active"`.
- Removed the settled-tail visible-event exception and its now-unused helper.
- Added projection and app-level UI regressions proving completed summaries start collapsed and hide details until clicked.

## Validation

- `bun test src/browser/utils/messages/transcriptRenderProjection.test.ts`
- `bun test src/browser/features/Messages/OperationalBundleMessage.test.tsx`
- `make version`
- `bun x jest tests/ui/chat/transcriptDensity.test.ts -t "expands work bundles and nested operational bundles through the app render path"`
- `make typecheck`
- `make static-check`
- Storybook dogfood of `App/Chat/Transcript Density / HyperCollapsedBundles` with screenshots and a WebM recording verifying collapsed, expanded, and re-collapsed states.

## Risks

Low. The change only affects the default expansion flag for operational bundle summaries; manual expand/collapse state and active/running visibility are preserved.

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: collapse hyper-density operation summaries by default

## Goal

When transcript density is `hyper`, grouped operation summaries like `Ran 59 operations · ...` should start collapsed so completed tool/reasoning details do not consume the viewport. Manual expand/collapse should continue to work.

## Evidence gathered

- `ChatPaneContent` in `src/browser/components/ChatPane/ChatPane.tsx` only computes/renders operational bundles when `transcriptDensity === "hyper"`.
- The summary copy and default expansion are produced by `computeOperationalBundleInfos()` in `src/browser/utils/messages/transcriptRenderProjection.ts`.
- Current settled-tail behavior expands operation bundles by default while the turn is active: `state === "active" || (options.isTurnActive && !hasSubsequentVisibleEvent)`.
- `OperationalBundleMessage` in `src/browser/features/Messages/OperationalBundleMessage.tsx` already supports collapsed rendering via `expanded` / `onToggle`.
- Existing validation targets:
  - `src/browser/utils/messages/transcriptRenderProjection.test.ts`
  - `src/browser/features/Messages/OperationalBundleMessage.test.tsx`
  - `tests/ui/chat/transcriptDensity.test.ts`
  - `src/browser/features/Messages/TranscriptDensity.stories.tsx`

## Recommended approach

**Approach A — simplify operational bundle default expansion**  
Product code net LoC estimate: **-8 to -12 LoC**

1. Update `src/browser/utils/messages/transcriptRenderProjection.ts` so completed operational bundles default collapsed:
   - keep active/running bundles expanded: `defaultExpanded: state === "active"`;
   - remove the settled-tail exception that expands when `isTurnActive && !hasSubsequentVisibleEvent`;
   - remove now-unused `hasVisibleEventAfter()` helper if no other local use remains.
2. Preserve `ChatPaneContent` manual override behavior:
   - `operationalBundleOverride ?? operationalBundle.defaultExpanded` remains the expansion source;
   - user clicks still override the default for the current component lifetime.
3. Update `src/browser/utils/messages/transcriptRenderProjection.test.ts`:
   - assert active bundles still default expanded;
   - assert just-settled tail bundles default collapsed even while the turn is active;
   - keep or simplify existing older-settled collapse assertions.
4. Add/adjust a regression assertion in `tests/ui/chat/transcriptDensity.test.ts` if needed so the full app hyper-density path proves the `operational-bundle` button starts with `aria-expanded="false"` and hides details until clicked.

Why this is preferred: the `Ran N operations` bundle only renders in hyper density today, so making settled operational bundles collapsed in the projection is the smallest change and avoids adding a new density option or duplicated expansion logic.

<details>
<summary>Alternative considered</summary>

**Approach B — density-aware override in `ChatPaneContent`**  
Product code net LoC estimate: **+3 to +12 LoC**

Add a hyper-density override near `isOperationalBundleExpanded`, leaving `computeOperationalBundleInfos()` unchanged. This is more explicit about density but adds a second policy layer and makes projection tests less representative of actual default behavior. I would only use this if another caller needs the old settled-tail expansion semantics.

</details>

## Acceptance criteria

- In hyper transcript density, any completed `Ran N operations` bundle starts collapsed by default.
- Operation details under that summary are not visible until the user expands the bundle.
- Clicking the summary toggles expanded/collapsed state exactly as before.
- Active/running operational bundles remain expanded by default unless explicitly requested otherwise, so live progress is not hidden.
- Normal transcript density behavior is unchanged.
- No persisted-state or migration changes are introduced.

## Quality gates and validation

1. Targeted unit tests:
   ```bash
   bun test src/browser/utils/messages/transcriptRenderProjection.test.ts
   bun test src/browser/features/Messages/OperationalBundleMessage.test.tsx
   ```
2. Targeted full-app UI test:
   ```bash
   bun x jest tests/ui/chat/transcriptDensity.test.ts -t "expands work bundles and nested operational bundles through the app render path"
   ```
3. Type/static validation:
   ```bash
   make typecheck
   make static-check
   ```
4. If test runtime or environment blocks a command, capture the exact failure and validate the closest targeted subset instead before reporting.

## Dogfooding plan

1. Start Storybook:
   ```bash
   make storybook
   ```
2. Use `agent-browser` to open the transcript density Storybook story that displays hyper-density operation bundles, preferably `TranscriptDensity.stories.tsx` / `HyperExpandedBundle`.
3. Record a short video and take screenshots showing:
   - hyper density enabled;
   - the `Ran N operations` row visible with `aria-expanded="false"` by default;
   - operation details hidden before interaction;
   - details visible after clicking the operation summary;
   - details hidden again after a second click.
4. Optionally repeat in the desktop sandbox for the real app shell:
   ```bash
   MUX_E2E=1 make dev-desktop-sandbox DEV_DESKTOP_SANDBOX_ARGS="--clean-projects"
   ```
   Then use Electron/agent-browser automation to capture screenshots/video of the same collapsed-by-default and expand/collapse flow.

## Implementation notes

- Keep the change surgical; do not introduce persistent expansion state.
- Do not alter summary text, counts, icons, or category copy.
- If active/running bundles are later requested to collapse too, treat that as a separate UX decision because it hides live progress.

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$10.61`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=10.61 -->
