### PR TITLE
🤖 fix: reveal tail plans in hyper density

### DIFF
--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -113,6 +113,18 @@ import { recordSyntheticReactRenderSample } from "@/browser/utils/perf/reactProf
 const TRANSCRIPT_ONLY_NOTICE =
   "This workspace's worktree is no longer available. This is a read-only chat transcript kept for historical and usage-tracking reasons.";
 
+function findTailProposePlanToolId(messages: readonly DisplayedMessage[]): string | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message.type !== "tool") {
+      continue;
+    }
+    return message.toolName === "propose_plan" ? message.id : null;
+  }
+
+  return null;
+}
+
 function PerfRenderMarker(props: { id: string; children: React.ReactNode }): React.ReactElement {
   const renderStartTimeRef = useRef(performance.now());
   renderStartTimeRef.current = performance.now();
@@ -462,6 +474,21 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
         : undefined,
     [canInterrupt, deferredMessages, isStreamStarting, transcriptDensity]
   );
+
+  // A tail propose_plan usually means the agent paused for user review; reveal only the
+  // containing hyper-density bundles by default so historical plans stay collapsed.
+  const tailProposePlanToolId =
+    transcriptDensity === "hyper" ? findTailProposePlanToolId(deferredMessages) : null;
+  const tailProposePlanIndex =
+    tailProposePlanToolId === null
+      ? -1
+      : deferredMessages.findIndex((message) => message.id === tailProposePlanToolId);
+  const tailProposePlanWorkBundleKey =
+    tailProposePlanIndex === -1 ? null : (workBundleInfos?.[tailProposePlanIndex]?.key ?? null);
+  const tailProposePlanOperationalBundleKey =
+    tailProposePlanIndex === -1
+      ? null
+      : (operationalBundleInfos?.[tailProposePlanIndex]?.key ?? null);
 
   const autoCompactionResult = useMemo(
     () =>
@@ -1235,8 +1262,12 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
                       const workBundleOverride = workBundle
                         ? workBundleExpansionOverrides.get(workBundle.key)
                         : undefined;
+                      const defaultRevealTailPlanWorkBundle =
+                        tailProposePlanWorkBundleKey !== null &&
+                        workBundle?.key === tailProposePlanWorkBundleKey;
                       const isWorkBundleExpanded = workBundle
-                        ? (workBundleOverride ?? workBundle.defaultExpanded)
+                        ? (workBundleOverride ??
+                          (defaultRevealTailPlanWorkBundle || workBundle.defaultExpanded))
                         : false;
 
                       const keepCollapsedWorkBundleMemberVisible =
@@ -1259,8 +1290,13 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
                       const operationalBundleOverride = operationalBundle
                         ? operationalBundleExpansionOverrides.get(operationalBundle.key)
                         : undefined;
+                      const defaultRevealTailPlanOperationalBundle =
+                        tailProposePlanOperationalBundleKey !== null &&
+                        operationalBundle?.key === tailProposePlanOperationalBundleKey;
                       const isOperationalBundleExpanded = operationalBundle
-                        ? (operationalBundleOverride ?? operationalBundle.defaultExpanded)
+                        ? (operationalBundleOverride ??
+                          (defaultRevealTailPlanOperationalBundle ||
+                            operationalBundle.defaultExpanded))
                         : false;
 
                       if (
@@ -1301,8 +1337,14 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
                                     nestedOperationalBundle.key
                                   )
                                 : undefined;
+                              const defaultRevealTailPlanNestedBundle =
+                                tailProposePlanOperationalBundleKey !== null &&
+                                nestedOperationalBundle?.key ===
+                                  tailProposePlanOperationalBundleKey;
                               const isNestedExpanded = nestedOperationalBundle
-                                ? (nestedOverride ?? nestedOperationalBundle.defaultExpanded)
+                                ? (nestedOverride ??
+                                  (defaultRevealTailPlanNestedBundle ||
+                                    nestedOperationalBundle.defaultExpanded))
                                 : false;
 
                               if (

--- a/src/browser/features/Messages/TranscriptDensity.stories.tsx
+++ b/src/browser/features/Messages/TranscriptDensity.stories.tsx
@@ -12,6 +12,7 @@ import {
   createFileReadTool,
   createGenericTool,
   createPendingTool,
+  createProposePlanTool,
   createWebSearchTool,
 } from "@/browser/stories/mocks/tools";
 import { STABLE_TIMESTAMP } from "@/browser/stories/mocks/workspaces";
@@ -119,6 +120,47 @@ export const NormalNoisyTranscript: AppStory = {
 export const HyperCollapsedBundles: AppStory = {
   parameters: { chromatic: { modes: CHROMATIC_SMOKE_MODES } },
   render: () => <AppWithMocks setup={() => setupTranscriptDensityStory("hyper")} />,
+};
+
+export const HyperTailProposePlanExpanded: AppStory = {
+  parameters: { chromatic: { modes: CHROMATIC_SMOKE_MODES } },
+  render: () => (
+    <AppWithMocks
+      setup={() => {
+        collapseLeftSidebar();
+        setDensity("hyper");
+        return setupSimpleChatStory({
+          messages: [
+            createUserMessage("tail-plan-user-1", "Plan the transcript density fix", {
+              historySequence: 1,
+              timestamp: STABLE_TIMESTAMP - 20_000,
+            }),
+            createAssistantMessage("tail-plan-assistant-1", "I'll draft the implementation plan.", {
+              historySequence: 2,
+              timestamp: STABLE_TIMESTAMP - 15_000,
+              toolCalls: [
+                createProposePlanTool(
+                  "tail-plan-tool-1",
+                  [
+                    "# Tail Plan",
+                    "",
+                    "## Acceptance",
+                    "",
+                    "- The tail propose_plan is visible in hyper density without expanding bundles.",
+                  ].join("\n")
+                ),
+                {
+                  type: "text",
+                  text: "Plan ready for review.",
+                  timestamp: STABLE_TIMESTAMP - 5_000,
+                },
+              ],
+            }),
+          ],
+        });
+      }}
+    />
+  ),
 };
 
 export const HyperExpandedBundle: AppStory = {

--- a/tests/ui/chat/transcriptDensity.test.ts
+++ b/tests/ui/chat/transcriptDensity.test.ts
@@ -10,6 +10,7 @@ import {
   createBashTool,
   createFileReadTool,
   createGenericTool,
+  createProposePlanTool,
   createWebSearchTool,
 } from "@/browser/stories/mocks/tools";
 import { installDom } from "../dom";
@@ -177,6 +178,159 @@ describe("Hyper transcript density", () => {
 
       await waitFor(() => {
         expect(view.container.textContent).toContain("make typecheck");
+      });
+    } finally {
+      await cleanupView(view, cleanupDom);
+    }
+  }, 30_000);
+
+  test("reveals a tail propose_plan through collapsed hyper-density bundles", async () => {
+    const cleanupDom = installDom();
+    updatePersistedState<TranscriptDensity>(TRANSCRIPT_DENSITY_KEY, "hyper");
+
+    const metadata = createWorkspace({
+      id: "ws-tail-plan",
+      name: "tail-plan",
+      projectName: "my-app",
+      projectPath: "/home/user/projects/my-app",
+    });
+    const client = setupSimpleChatStory({
+      workspaceId: metadata.id,
+      workspaceName: metadata.name,
+      projectName: metadata.projectName,
+      projectPath: metadata.projectPath,
+      messages: [
+        createUserMessage("tail-plan-user-1", "Plan the transcript density fix", {
+          historySequence: 1,
+          timestamp: 0,
+        }),
+        createAssistantMessage("tail-plan-assistant-1", "I'll draft the implementation plan.", {
+          historySequence: 2,
+          timestamp: 1_000,
+          toolCalls: [
+            createProposePlanTool(
+              "tail-plan-tool-1",
+              "# Tail Plan\n\n- Reveal the tail propose_plan without a click."
+            ),
+            { type: "text", text: "Plan ready for review." },
+          ],
+        }),
+      ],
+    });
+    const view = renderApp({ apiClient: client, metadata });
+
+    try {
+      await setupWorkspaceView(view, metadata, metadata.id);
+
+      const workButton = await waitFor(() => {
+        const button = queryButton(view.container, "work-bundle");
+        if (!button) {
+          throw new Error("Tail plan work bundle button not found");
+        }
+        return button;
+      });
+      expect(workButton.getAttribute("aria-expanded")).toBe("true");
+
+      const operationalButton = await waitFor(() => {
+        const button = queryButton(view.container, "operational-bundle");
+        if (!button) {
+          throw new Error("Tail plan operational bundle button not found");
+        }
+        return button;
+      });
+      expect(operationalButton.getAttribute("aria-expanded")).toBe("true");
+      expect(view.container.textContent).toContain("Tail Plan");
+      expect(view.container.textContent).toContain("Reveal the tail propose_plan without a click.");
+
+      fireEvent.click(workButton);
+      await waitFor(() => {
+        expect(workButton.getAttribute("aria-expanded")).toBe("false");
+      });
+      expect(view.container.textContent).not.toContain("Tail Plan");
+    } finally {
+      await cleanupView(view, cleanupDom);
+    }
+  }, 30_000);
+
+  test("keeps historical propose_plan collapsed when a later image tool call exists", async () => {
+    const cleanupDom = installDom();
+    updatePersistedState<TranscriptDensity>(TRANSCRIPT_DENSITY_KEY, "hyper");
+
+    const metadata = createWorkspace({
+      id: "ws-historical-plan",
+      name: "historical-plan",
+      projectName: "my-app",
+      projectPath: "/home/user/projects/my-app",
+    });
+    const client = setupSimpleChatStory({
+      workspaceId: metadata.id,
+      workspaceName: metadata.name,
+      projectName: metadata.projectName,
+      projectPath: metadata.projectPath,
+      messages: [
+        createUserMessage("historical-plan-user-1", "Plan then validate", {
+          historySequence: 1,
+          timestamp: 0,
+        }),
+        createAssistantMessage("historical-plan-assistant-1", "I'll plan and then validate.", {
+          historySequence: 2,
+          timestamp: 1_000,
+          toolCalls: [
+            createProposePlanTool(
+              "historical-plan-tool-1",
+              "# Historical Plan\n\n- This older plan should stay hidden."
+            ),
+            createGenericTool(
+              "historical-plan-image-1",
+              "image_generate",
+              { prompt: "Create a validation image" },
+              {
+                success: true,
+                model: "gpt-image-1",
+                prompt: "Create a validation image",
+                requestedCount: 1,
+                images: [
+                  {
+                    path: "/tmp/generated.png",
+                    filename: "generated.png",
+                    mediaType: "image/png",
+                  },
+                ],
+              }
+            ),
+            { type: "text", text: "Validation finished." },
+          ],
+        }),
+      ],
+    });
+    const view = renderApp({ apiClient: client, metadata });
+
+    try {
+      await setupWorkspaceView(view, metadata, metadata.id);
+      await waitFor(() => {
+        expect(view.container.textContent).toContain("Validation finished.");
+      });
+      expect(view.container.textContent).not.toContain("Historical Plan");
+
+      const workButton = queryButton(view.container, "work-bundle");
+      if (workButton) {
+        expect(workButton.getAttribute("aria-expanded")).toBe("false");
+        fireEvent.click(workButton);
+      }
+
+      const operationalButton = await waitFor(() => {
+        const button = queryButton(view.container, "operational-bundle");
+        if (!button) {
+          throw new Error("Historical plan operational bundle button not found");
+        }
+        return button;
+      });
+      expect(operationalButton.getAttribute("aria-expanded")).toBe("false");
+      expect(view.container.textContent).not.toContain("Historical Plan");
+
+      fireEvent.click(operationalButton);
+      await waitFor(() => {
+        expect(view.container.textContent).toContain("Historical Plan");
       });
     } finally {
       await cleanupView(view, cleanupDom);


### PR DESCRIPTION
## Summary

Reveal the final `propose_plan` tool call in hyper transcript density by default-expanding only the work and operational bundles that contain the tail plan.

## Background

In hyper density, settled work and operational bundles can hide tool rows before `ProposePlanToolCall` renders. That made an agent pause after `propose_plan` look like no actionable plan was visible. The requested behavior is scoped to the last displayed tool call, not the latest plan anywhere in history.

## Implementation

- Detect when the last displayed tool call is `propose_plan`.
- Resolve the containing work/operational bundle keys for the tail plan.
- Default-expand only those matching bundles without mutating expansion override state.
- Let explicit user collapse overrides win after the auto-reveal has made the tail plan visible.
- Keep historical plans collapsed when any later tool call exists, including `image_generate`/`image_edit` tool rows.

## Validation

- `bun test ./tests/ui/chat/transcriptDensity.test.ts`
- `TEST_INTEGRATION=1 bun x jest tests/ui/chat/transcriptDensity.test.ts --runInBand`
- `make static-check`
- `make storybook-build`
- Dogfood via `agent-browser` against `HyperTailProposePlanExpanded`; captured screenshot/video artifacts under `dogfood-output/ui-density-tail-plan/` and verified no browser errors.

## Risks

Low-to-medium: the change touches transcript render projection consumption in `ChatPane`, but the default expansion is keyed to the exact tail plan's containing bundles and does not persist state changes.

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: reveal tail `propose_plan` in hyper transcript density

## Goal

When transcript density is `hyper`, a `propose_plan` tool call should be immediately visible when it is the **last tool call in the displayed transcript**, so the user can see why the agent paused. This must not globally expand old/historical `propose_plan` calls; if any later tool call exists, the older plan should stay collapsed under the normal hyper-density rules.

## Evidence gathered

- `ChatPane.tsx` owns transcript density, hyper bundle projection, expansion overrides, and per-row hide/show decisions.
- Hyper density uses two collapse layers:
  - work bundles from `computeWorkBundleInfos(deferredMessages)`;
  - operational bundles from `computeOperationalBundleInfos(deferredMessages, ...)`.
- Settled bundles default collapsed, which hides tool rows before `MessageRenderer` can render the tool component.
- `ProposePlanToolCall` already uses `useToolExpansion(true)`, so the missing UI is caused by parent bundle hiding, not by the plan component itself being collapsed.
- `ChatPane.tsx` already computes a latest `propose_plan` id for `isLatestProposePlan`, but that means “latest plan anywhere”; the requested behavior is based on the **last tool call**, so this should remain separate.
- Existing coverage exists in `tests/ui/chat/transcriptDensity.test.ts` and `src/browser/features/Messages/TranscriptDensity.stories.tsx`; plan mocks are available via `createProposePlanTool` in `src/browser/stories/mocks/tools.ts`.

## Recommended approach

**Approach A — ChatPane-owned tail-plan forced expansion**

- Product-code net LoC estimate: **+20 to +35 LoC**.
- Keep the change local to `ChatPane.tsx` unless implementation needs a tiny pure helper for readability.
- Use `deferredMessages` for tail-tool detection because it is the same message snapshot used by hyper bundle projections and rendering.
- Do not mutate user expansion override maps; compute a render-time forced-expanded state while the condition holds.

<details>
<summary>Alternative considered</summary>

Extracting a reusable helper into `transcriptRenderProjection.ts` would make the tail-tool detection easier to unit test in isolation, but it likely raises product-code LoC to **+35 to +60 LoC** without much benefit because the actual bug is in `ChatPane`'s render-time interaction between work and operational bundles. Use this only if the local helper becomes awkward.

</details>

## Implementation steps

1. **Compute the last displayed tool call**
   - In `ChatPane.tsx`, scan `deferredMessages` from the end for `message.type === "tool"`.
   - Derive `tailProposePlanToolId` only when `transcriptDensity === "hyper"` and that last tool has `toolName === "propose_plan"`.
   - Keep the existing `latestProposePlanId` logic unchanged for `ProposePlanToolCall` freshness/actions.

2. **Force-expand only bundles containing the tail plan**
   - Add a small local predicate such as `bundleContainsMessageId(bundle, tailProposePlanToolId)`.
   - For the work bundle containing `tailProposePlanToolId`, compute:
     - `isWorkBundleExpanded = forceRevealTailPlan || (override ?? workBundle.defaultExpanded)`.
   - For the operational bundle containing `tailProposePlanToolId`, compute:
     - `isOperationalBundleExpanded = forceRevealTailPlan || (override ?? operationalBundle.defaultExpanded)`.
   - Apply this at both operational-bundle sites if there is a top-level and nested path inside expanded work bundles.
   - Do not force-expand unrelated bundles.

3. **Preserve expected non-plan behavior**
   - Normal density remains unchanged.
   - Hyper density remains collapsed for historical plan calls when a later tool call exists.
   - Later assistant text should not disqualify the plan if no later tool call exists; this follows the user’s “last tool call in the transcript” wording.
   - If a user manually collapses the tail-plan bundle while it is still the last tool call, the render-time forced reveal will reopen it. This is intentional for the pause state; once a later tool appears, normal user/default state applies again.

## Tests

1. **Update `tests/ui/chat/transcriptDensity.test.ts`**
   - Import `createProposePlanTool`.
   - Add a positive hyper-density case where a settled transcript has `propose_plan` as the last tool call.
     - Assert the relevant work bundle is expanded without a click.
     - Assert the relevant operational bundle is expanded without a click, or assert the plan tool UI/body is visible without a click.
   - Add a negative case where an earlier `propose_plan` is followed by another tool call.
     - Assert the older plan remains hidden under collapsed hyper-density defaults.
     - Optionally click the bundle afterward to prove the plan exists but was not auto-revealed.

2. **Add Storybook visual coverage in `src/browser/features/Messages/TranscriptDensity.stories.tsx`**
   - Add a `HyperTailProposePlanExpanded` story that sets density to `hyper` and ends with `createProposePlanTool(...)`.
   - Keep it deterministic using existing story helpers and `STABLE_TIMESTAMP`.
   - If the story depends on a viewport, pin Chromatic mode/globals consistently with existing story conventions.

3. **Optional pure-helper tests**
   - Only if helper logic moves to `transcriptRenderProjection.ts`, add focused tests in `src/browser/utils/messages/transcriptRenderProjection.test.ts` for “last tool is plan” vs “later non-plan tool exists”.

## Acceptance criteria

- In hyper density, when the last displayed tool call is `propose_plan`, the plan tool UI is visible without manually expanding any transcript bundle.
- Historical `propose_plan` calls do not auto-expand when a later tool call exists.
- Both work-bundle and operational-bundle collapse layers are handled, so the plan is not hidden behind either summary row.
- Existing latest-plan semantics used by `ProposePlanToolCall` remain unchanged.
- Normal transcript density behavior is unchanged.
- Tests cover the positive tail-plan case and the negative historical-plan case.

## Validation and quality gates

Run after implementation:

1. Targeted UI test:
   - `bun test tests/ui/chat/transcriptDensity.test.ts`
2. If `transcriptRenderProjection.ts` is touched:
   - `bun test src/browser/utils/messages/transcriptRenderProjection.test.ts`
3. Static checks:
   - `make static-check`
4. Storybook build or targeted story validation as time allows:
   - `make storybook-build`

Proceed to the next phase only after the relevant gate passes; fix failures before moving on.

## Dogfooding plan

Skill guidance applied: read `dogfood`, `agent-browser`, `dev-server-sandbox`, `dogfood/references/issue-taxonomy.md`, and current `agent-browser skills get core` guidance. Use direct `agent-browser` commands, not `npx`; use snapshots for refs; re-snapshot after page changes; collect screenshots/videos as evidence; check console/errors; and run isolated app instances with a temporary `MUX_ROOT` via `make dev-server-sandbox`.

1. **Start an isolated Mux dev surface**
   - Run `make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-projects"` so dogfooding uses a fresh temporary `MUX_ROOT`, free backend/Vite ports, copied provider config if present, no copied projects, and no collision with the user’s real app state.
   - Use the Vite URL printed by the sandbox command as the target URL. Keep the sandbox running until evidence collection is complete.
   - Before browser automation, refresh the installed CLI guidance with `agent-browser skills get core`.

2. **Initialize browser evidence capture**
   - Create a dogfood output directory such as `./dogfood-output/ui-density-tail-plan/` with `screenshots/` and `videos/` subdirectories.
   - Open the app with a named session, e.g. `agent-browser --session ui-density-tail-plan open <VITE_URL>` followed by `agent-browser --session ui-density-tail-plan wait --load networkidle`.
   - Capture an initial annotated screenshot and interactive snapshot:
     - `agent-browser --session ui-density-tail-plan screenshot --annotate ./dogfood-output/ui-density-tail-plan/screenshots/initial.png`
     - `agent-browser --session ui-density-tail-plan snapshot -i`
   - Use only browser-observed behavior for dogfood findings; do not inspect source while documenting UI issues.

3. **Positive behavior check: tail `propose_plan` is visible**
   - Navigate to the deterministic `HyperTailProposePlanExpanded` Storybook story if the fixture is implemented there, or load the equivalent seeded app state in the sandbox.
   - Record video before reproducing: `agent-browser --session ui-density-tail-plan record start ./dogfood-output/ui-density-tail-plan/videos/tail-plan-visible.webm`.
   - Reload/open the scenario, wait for the transcript to settle, and take step screenshots.
   - Assert visually that hyper density shows the `propose_plan` tool UI without manually clicking work/operational bundle rows.
   - Capture the final annotated screenshot and stop recording.
   - Check `agent-browser --session ui-density-tail-plan errors` and `agent-browser --session ui-density-tail-plan console`.

4. **Negative behavior check: historical plan stays collapsed**
   - Open a scenario where a `propose_plan` is followed by a later non-plan tool call.
   - Capture an annotated screenshot showing the older plan remains hidden/collapsed under hyper-density defaults.
   - If interaction is needed to prove the plan exists, record a short video: start recording, click the relevant bundle, show the historical plan, then stop recording.
   - Re-check console/errors.

5. **Focused exploratory pass around the changed surface**
   - Apply the dogfood issue taxonomy to this feature only: visual layout, functional controls, UX clarity, performance/jank, console errors, accessibility/focus, and responsive clipping around expanded/collapsed transcript rows.
   - Use screenshots for static findings and video plus step screenshots for interactive findings.
   - Record any issues immediately with severity and reproduction steps; target evidence quality over issue count.

6. **Wrap up dogfood artifacts**
   - Close the browser session with `agent-browser --session ui-density-tail-plan close`.
   - Keep screenshots/videos available for review and attach the key positive/negative screenshots if the execution environment supports attachments.
   - If `KEEP_SANDBOX=1` was used for debugging, note the sandbox root; otherwise let the temporary `MUX_ROOT` clean up on exit.

## Review focus

- The last-tool predicate should be based on ordered displayed messages, not “latest plan”.
- Forced expansion should be scoped to the containing work/operational bundles only.
- The change should not persist or overwrite user expansion overrides.
- Tests should assert behavior/visibility rather than tautological copy.

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$39.77`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=39.77 -->
