### PR TITLE
🤖 fix: stop chat send & streaming-indicator layout flashes; add shimmer transcript loading

### DIFF
--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -177,7 +177,28 @@ type ChatPaneContentProps = Omit<
 
 type ReviewsState = ReturnType<typeof useReviews>;
 
-const AUTO_SCROLL_TRANSCRIPT_STYLE = { overflowAnchor: "none" } as const;
+// Bottom-stick is owned by native CSS scroll anchoring (see useAutoScroll). While
+// locked, the transcript content opts OUT of anchoring so the only eligible anchor
+// is the 0-height bottom sentinel; the browser then keeps that sentinel pinned as
+// rows/tokens/the streaming barrier append above it — no per-frame scrollTop chase.
+// When unlocked (manual reading) we drop this so the browser anchors to an onscreen
+// row and preserves the reading position while off-screen content above settles.
+const TRANSCRIPT_CONTENT_NO_ANCHOR_STYLE = { overflowAnchor: "none" } as const;
+// The sentinel is the sole anchor candidate while locked.
+const TRANSCRIPT_BOTTOM_SENTINEL_STYLE = { overflowAnchor: "auto" } as const;
+// The composer floats over the bottom of the transcript region so its height
+// changes never resize the scrollport's clientHeight (the root cause of the
+// send-time "viewport resize from below" flash). The scrollport instead reserves
+// clearance via bottom padding equal to the live composer height (--composer-h,
+// published by a ResizeObserver in ChatPaneContent); 15px matches the original
+// uniform p-[15px] inset.
+const TRANSCRIPT_SCROLLPORT_STYLE: React.CSSProperties = {
+  paddingBottom: "calc(15px + var(--composer-h, 0px))",
+};
+// Keep the jump-to-bottom chip just above the floating composer (8px gap).
+const JUMP_TO_BOTTOM_CHIP_STYLE: React.CSSProperties = {
+  bottom: "calc(var(--composer-h, 0px) + 8px)",
+};
 
 function findTranscriptMessageElement(
   scrollContainer: HTMLElement,
@@ -220,7 +241,11 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
         ref={chatAreaRef}
         aria-hidden={immersiveHidden || undefined}
         className={cn(
-          "bg-surface-primary flex min-w-96 flex-1 flex-col",
+          // `relative` is the positioning context for the floating composer dock
+          // (absolute bottom of this column); it overlays the bottom of the flex-1
+          // transcript region without taking flex space, so composer height changes
+          // never resize the transcript scrollport.
+          "bg-surface-primary relative flex min-w-96 flex-1 flex-col",
           // Immersive review overlays the entire workspace, so hiding the chat pane removes
           // its layout cost while preserving component state for the return transition.
           immersiveHidden && "hidden",
@@ -487,9 +512,11 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
   // Use auto-scroll hook for scroll management
   const {
     contentRef,
+    sentinelRef,
     autoScroll,
     disableAutoScroll,
     jumpToBottom,
+    reanchorBottom,
     handleScroll,
     markUserScrollIntent,
     handleScrollContainerWheel,
@@ -498,6 +525,31 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
     handleScrollContainerMouseUp,
     handleScrollContainerKeyDown,
   } = useAutoScroll();
+
+  // The composer floats over the transcript region (see TRANSCRIPT_SCROLLPORT_STYLE).
+  // Publish its measured height as `--composer-h` on the transcript region so the
+  // scrollport can reserve matching bottom clearance, and re-pin when it grows
+  // (composer growth only changes the scrollport's bottom padding, which neither
+  // native anchoring nor the content ResizeObserver can see — see reanchorBottom).
+  const transcriptRegionRef = useRef<HTMLDivElement>(null);
+  const composerRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    const region = transcriptRegionRef.current;
+    const composer = composerRef.current;
+    const ResizeObserverCtor = typeof window !== "undefined" ? window.ResizeObserver : undefined;
+    if (!region || !composer || !ResizeObserverCtor) return;
+
+    const applyComposerHeight = () => {
+      const heightPx = Math.ceil(composer.getBoundingClientRect().height);
+      region.style.setProperty("--composer-h", `${heightPx}px`);
+      reanchorBottom();
+    };
+
+    applyComposerHeight();
+    const observer = new ResizeObserverCtor(applyComposerHeight);
+    observer.observe(composer);
+    return () => observer.disconnect();
+  }, [reanchorBottom]);
 
   const sideQuestionScrollHoldRef = useRef<SideQuestionScrollHoldState>({
     initialized: false,
@@ -1146,8 +1198,14 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
   return (
     <>
       <PerfRenderMarker id="chat-pane.transcript">
-        {/* Spacer for fixed mobile header - mobile-header-spacer adds padding-top on touch devices */}
-        <div className="mobile-header-spacer relative flex-1 overflow-hidden">
+        {/* Spacer for fixed mobile header - mobile-header-spacer adds padding-top on touch devices.
+            `flex-1` keeps this region filling all space below the header regardless of the floating
+            composer (which is out of flow), so the scrollport's clientHeight never changes when the
+            composer resizes. `--composer-h` is published here for the scrollport clearance + jump chip. */}
+        <div
+          ref={transcriptRegionRef}
+          className="mobile-header-spacer relative flex-1 overflow-hidden"
+        >
           <div
             ref={contentRef}
             onWheel={handleTranscriptWheel}
@@ -1165,17 +1223,23 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
             tabIndex={0}
             data-testid="message-window"
             data-loaded={!loading && !isHydratingTranscript}
-            // Disable browser scroll anchoring only while bottom-lock owns the tail.
-            // In manual reading mode, anchoring should preserve the user's viewport
-            // when async highlights/diagrams above the fold settle.
-            style={autoScroll ? AUTO_SCROLL_TRANSCRIPT_STYLE : undefined}
+            // Browser scroll anchoring stays ENABLED on the scrollport; the
+            // overflow-anchor policy lives on the inner content (opt rows out while
+            // locked so the bottom sentinel is the sole anchor). `paddingBottom`
+            // reserves clearance for the floating composer (--composer-h) so the
+            // last message scrolls clear of it instead of resizing the viewport.
+            style={TRANSCRIPT_SCROLLPORT_STYLE}
             // The named `transcript` container is what the sticky plan TOC queries
             // for visibility — using a container query rather than a viewport media
             // query means sidebars opening/closing correctly hide the TOC even when
             // the viewport width is unchanged. See `.plan-toc-aside` in globals.css.
-            className="@container/transcript h-full overflow-x-hidden overflow-y-auto p-[15px] leading-[1.5] break-words whitespace-pre-wrap"
+            className="@container/transcript h-full overflow-x-hidden overflow-y-auto px-[15px] pt-[15px] leading-[1.5] break-words whitespace-pre-wrap"
           >
             <div
+              // While locked, opt the whole transcript subtree out of scroll
+              // anchoring so the only anchor candidate is the sibling bottom
+              // sentinel below — native anchoring then pins the bottom on append.
+              style={autoScroll ? TRANSCRIPT_CONTENT_NO_ANCHOR_STYLE : undefined}
               className={cn(
                 // `plan-toc-aware` opts only the centered max-w transcript into the
                 // sticky plan TOC layout. In `chatTranscriptFullWidth` mode the plan
@@ -1359,13 +1423,28 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
                 items={transcriptTailItems}
               />
             </div>
+            {/* Bottom anchor: a 0-height sibling of the transcript content. While
+                locked it is the sole `overflow-anchor: auto` element, so native CSS
+                scroll anchoring keeps it (and therefore the bottom) pinned as rows
+                append above it. It sits below the inner content but above the
+                scrollport's composer-clearance padding, so the last message clears
+                the floating composer. */}
+            <div
+              ref={sentinelRef}
+              data-testid="transcript-bottom-sentinel"
+              aria-hidden="true"
+              className="h-0 w-full"
+              style={TRANSCRIPT_BOTTOM_SENTINEL_STYLE}
+            />
           </div>
           {transcriptContextMenu.menu}
           {!autoScroll && (
             <button
               onClick={handleJumpToBottom}
               type="button"
-              className="assistant-chip font-primary text-foreground hover:assistant-chip-hover absolute bottom-2 left-1/2 z-20 -translate-x-1/2 cursor-pointer rounded-[20px] px-2 py-1 text-xs font-medium shadow-[0_4px_12px_rgba(0,0,0,0.3)] backdrop-blur-[1px] transition-all duration-200 hover:scale-105 active:scale-95"
+              // Sit just above the floating composer rather than the region bottom.
+              style={JUMP_TO_BOTTOM_CHIP_STYLE}
+              className="assistant-chip font-primary text-foreground hover:assistant-chip-hover absolute left-1/2 z-20 -translate-x-1/2 cursor-pointer rounded-[20px] px-2 py-1 text-xs font-medium shadow-[0_4px_12px_rgba(0,0,0,0.3)] backdrop-blur-[1px] transition-transform duration-200 hover:scale-105 active:scale-95"
             >
               Jump to bottom{" "}
               <span className="mobile-hide-shortcut-hints">
@@ -1376,47 +1455,58 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
         </div>
       </PerfRenderMarker>
       <PerfRenderMarker id="chat-pane.input">
-        {transcriptOnly ? (
-          // Transcript-only workspaces keep their historical transcript, but the whole
-          // composer surface is replaced with a single read-only notice.
-          <TranscriptOnlyNoticePane />
-        ) : (
-          <ChatInputPane
-            workspaceId={workspaceId}
-            projectName={projectName}
-            workspaceName={workspaceName}
-            isStreamStarting={isStreamStarting}
-            isHydratingTranscript={isHydratingTranscript}
-            runtimeConfig={runtimeConfig}
-            isQueuedAgentTask={isQueuedAgentTask}
-            isCompacting={isCompacting}
-            shouldShowPinnedTodoList={shouldShowPinnedTodoList}
-            shouldShowReviewsBanner={shouldShowReviewsBanner}
-            concurrentLocalStreamingWorkspaceName={concurrentLocalStreamingWorkspaceName}
-            canInterrupt={canInterrupt}
-            autoCompactionResult={autoCompactionResult}
-            shouldShowCompactionWarning={shouldShowCompactionWarning}
-            contextSwitchWarning={contextSwitchWarning}
-            onContextSwitchCompact={handleContextSwitchCompact}
-            onContextSwitchDismiss={handleContextSwitchDismiss}
-            onModelChange={handleModelChange}
-            onMessageSendStarted={handleMessageSendStarted}
-            onMessageSent={handleMessageSent}
-            onResetContext={handleResetContext}
-            onTruncateHistory={handleClearHistory}
-            editingMessage={editingMessage}
-            onCancelEdit={handleCancelEdit}
-            onEditLastUserMessage={handleEditLastUserMessageClick}
-            onChatInputReady={handleChatInputReady}
-            queuedMessage={workspaceState?.queuedMessage ?? null}
-            onEditQueuedMessage={() => void handleEditQueuedMessage()}
-            onSendQueuedImmediately={
-              workspaceState?.canInterrupt ? handleSendQueuedImmediately : undefined
-            }
-            reviews={reviews}
-            onCheckReviews={handleCheckReviews}
-          />
-        )}
+        {/* The composer floats over the bottom of the chat column instead of taking
+            flex space, so its height changes never resize the transcript scrollport
+            (the send-time "viewport resize from below" flash). `bg-surface-primary`
+            keeps transcript content from showing through gaps between decoration
+            banners. `composerRef` feeds the scrollport clearance (--composer-h). */}
+        <div
+          ref={composerRef}
+          data-testid="chat-composer-dock"
+          className="bg-surface-primary absolute right-0 bottom-0 left-0 z-10"
+        >
+          {transcriptOnly ? (
+            // Transcript-only workspaces keep their historical transcript, but the whole
+            // composer surface is replaced with a single read-only notice.
+            <TranscriptOnlyNoticePane />
+          ) : (
+            <ChatInputPane
+              workspaceId={workspaceId}
+              projectName={projectName}
+              workspaceName={workspaceName}
+              isStreamStarting={isStreamStarting}
+              isHydratingTranscript={isHydratingTranscript}
+              runtimeConfig={runtimeConfig}
+              isQueuedAgentTask={isQueuedAgentTask}
+              isCompacting={isCompacting}
+              shouldShowPinnedTodoList={shouldShowPinnedTodoList}
+              shouldShowReviewsBanner={shouldShowReviewsBanner}
+              concurrentLocalStreamingWorkspaceName={concurrentLocalStreamingWorkspaceName}
+              canInterrupt={canInterrupt}
+              autoCompactionResult={autoCompactionResult}
+              shouldShowCompactionWarning={shouldShowCompactionWarning}
+              contextSwitchWarning={contextSwitchWarning}
+              onContextSwitchCompact={handleContextSwitchCompact}
+              onContextSwitchDismiss={handleContextSwitchDismiss}
+              onModelChange={handleModelChange}
+              onMessageSendStarted={handleMessageSendStarted}
+              onMessageSent={handleMessageSent}
+              onResetContext={handleResetContext}
+              onTruncateHistory={handleClearHistory}
+              editingMessage={editingMessage}
+              onCancelEdit={handleCancelEdit}
+              onEditLastUserMessage={handleEditLastUserMessageClick}
+              onChatInputReady={handleChatInputReady}
+              queuedMessage={workspaceState?.queuedMessage ?? null}
+              onEditQueuedMessage={() => void handleEditQueuedMessage()}
+              onSendQueuedImmediately={
+                workspaceState?.canInterrupt ? handleSendQueuedImmediately : undefined
+              }
+              reviews={reviews}
+              onCheckReviews={handleCheckReviews}
+            />
+          )}
+        </div>
       </PerfRenderMarker>
     </>
   );
@@ -1563,8 +1653,9 @@ const ChatInputPane: React.FC<ChatInputPaneProps> = (props) => {
       ),
     });
   }
-  // The decoration lane changes the transcript viewport height from below; the
-  // scrollport ResizeObserver inside useAutoScroll owns any required bottom pin.
+  // The decoration lane lives inside the floating composer dock, so its height is
+  // captured by the composer ResizeObserver (--composer-h) and never resizes the
+  // transcript scrollport; the bottom stays pinned via native anchoring + reanchorBottom.
 
   return (
     <>

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -23,6 +23,7 @@ import { StreamingBarrier } from "@/browser/features/Messages/ChatBarrier/Stream
 import { RetryBarrier } from "@/browser/features/Messages/ChatBarrier/RetryBarrier";
 import { PinnedTodoList } from "../PinnedTodoList/PinnedTodoList";
 import { ChatInputDecorationStackLane, TranscriptTailStackLane } from "./LayoutStackLane";
+import { TranscriptHydrationSkeleton } from "./TranscriptHydrationSkeleton";
 import {
   createChatInputDecorationStackItem,
   createTranscriptTailStackItem,
@@ -1246,17 +1247,14 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
                 // already fills the available width, so the TOC would either
                 // overlap content or get clipped by `overflow-x-hidden`.
                 chatTranscriptFullWidth ? "w-full" : "plan-toc-aware max-w-4xl mx-auto",
-                (showTranscriptHydrationPlaceholder || showEmptyTranscriptPlaceholder) && "h-full"
+                // Only the empty/centered placeholder fills height. The hydration
+                // skeleton renders in normal top-aligned transcript flow so it sits
+                // where real messages will, avoiding a jump when hydration completes.
+                showEmptyTranscriptPlaceholder && "h-full"
               )}
             >
               {showTranscriptHydrationPlaceholder ? (
-                <div
-                  data-testid="transcript-hydration-placeholder"
-                  className="text-placeholder flex h-full flex-1 flex-col items-center justify-center text-center [&_h3]:m-0 [&_h3]:mb-2.5 [&_h3]:text-base [&_h3]:font-medium [&_p]:m-0 [&_p]:text-[13px]"
-                >
-                  <h3>Loading transcript...</h3>
-                  <p>Syncing recent messages for this workspace</p>
-                </div>
+                <TranscriptHydrationSkeleton />
               ) : showEmptyTranscriptPlaceholder ? (
                 <div className="text-placeholder flex h-full flex-1 flex-col items-center justify-center text-center [&_h3]:m-0 [&_h3]:mb-2.5 [&_h3]:text-base [&_h3]:font-medium [&_p]:m-0 [&_p]:text-[13px]">
                   <h3>No Messages Yet</h3>

--- a/src/browser/components/ChatPane/TranscriptHydrationSkeleton.stories.tsx
+++ b/src/browser/components/ChatPane/TranscriptHydrationSkeleton.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { lightweightMeta } from "@/browser/stories/meta.js";
+import { TranscriptHydrationSkeleton } from "./TranscriptHydrationSkeleton";
+
+// Typed as bare `Meta` (not `Meta<typeof TranscriptHydrationSkeleton>`): the
+// component takes no props, so the component-generic form conflicts with the
+// spread of `lightweightMeta` (whose decorators are typed for arbitrary args).
+const meta = {
+  ...lightweightMeta,
+  title: "App/Chat/TranscriptHydrationSkeleton",
+  component: TranscriptHydrationSkeleton,
+  render: () => (
+    // Mirror the transcript's centered max-width column so the skeleton's line
+    // widths read the same as real messages will.
+    <div className="bg-background min-h-screen overflow-y-auto p-6">
+      <div className="mx-auto max-w-4xl">
+        <TranscriptHydrationSkeleton />
+      </div>
+    </div>
+  ),
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Shimmer placeholder shown while a workspace's transcript hydrates. Mimics a few
+ * conversation turns (short user bubble + assistant prose lines) and fades toward
+ * the bottom, so the loading state reads as "messages are arriving" rather than a
+ * generic centered spinner.
+ */
+export const Default: Story = {};

--- a/src/browser/components/ChatPane/TranscriptHydrationSkeleton.tsx
+++ b/src/browser/components/ChatPane/TranscriptHydrationSkeleton.tsx
@@ -1,0 +1,51 @@
+/**
+ * Shimmer placeholder shown while the transcript hydrates.
+ *
+ * Mimics the shape of a few conversation turns (a short user bubble + assistant
+ * prose lines) using the shared shimmer `Skeleton`, so the loading state reads as
+ * "messages are arriving" rather than a generic centered spinner. Turns fade out
+ * toward the bottom to suggest more content below. It is top-aligned (not
+ * vertically centered) and uses normal transcript flow so it occupies the same
+ * place the real messages will, avoiding a jump when hydration completes.
+ */
+import { Skeleton } from "@/browser/components/Skeleton/Skeleton";
+
+// Decreasing opacity per turn produces the trailing fade characteristic of
+// skeleton loaders without an extra mask layer.
+const TURNS: ReadonlyArray<{ opacity: number; assistantLineWidths: readonly string[] }> = [
+  { opacity: 1, assistantLineWidths: ["w-[92%]", "w-[80%]", "w-[58%]"] },
+  { opacity: 0.65, assistantLineWidths: ["w-[85%]", "w-[64%]"] },
+  { opacity: 0.4, assistantLineWidths: ["w-[78%]", "w-[52%]"] },
+];
+
+export function TranscriptHydrationSkeleton() {
+  return (
+    <div
+      data-testid="transcript-hydration-placeholder"
+      role="status"
+      aria-busy="true"
+      aria-label="Loading transcript"
+      className="flex flex-col gap-8 py-6 select-none"
+    >
+      {TURNS.map((turn, turnIndex) => (
+        <div key={turnIndex} className="flex flex-col gap-4" style={{ opacity: turn.opacity }}>
+          {/* User message: a short, right-aligned bubble. */}
+          <Skeleton
+            variant="shimmer"
+            className="ml-auto block h-8 w-1/2 max-w-[16rem] rounded-lg"
+          />
+          {/* Assistant message: a left-aligned stack of prose lines of varied width. */}
+          <div className="flex flex-col gap-2.5">
+            {turn.assistantLineWidths.map((width, lineIndex) => (
+              <Skeleton
+                key={lineIndex}
+                variant="shimmer"
+                className={`block h-3.5 rounded ${width}`}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/browser/features/Messages/ChatBarrier/StreamingBarrierView.stories.tsx
+++ b/src/browser/features/Messages/ChatBarrier/StreamingBarrierView.stories.tsx
@@ -61,3 +61,20 @@ export const LoadingToolsDiagnostic: Story = {
     },
   },
 };
+
+/**
+ * Active streaming state with the token-stats slot revealed. The slot is reserved
+ * (rendered but hidden) during startup, so the row geometry is identical across the
+ * starting -> streaming transition — compare against the startup stories above to
+ * confirm the status text and stop control do not shift when stats appear.
+ */
+export const Streaming: Story = {
+  args: {
+    statusText: "claude-opus-4 streaming...",
+    cancelText: "hit Esc to cancel",
+    cancelShortcutText: "Esc",
+    onCancel: fn(),
+    tokenCount: 12_840,
+    tps: 73,
+  },
+};

--- a/src/browser/features/Messages/ChatBarrier/StreamingBarrierView.test.tsx
+++ b/src/browser/features/Messages/ChatBarrier/StreamingBarrierView.test.tsx
@@ -61,4 +61,35 @@ describe("StreamingBarrierView", () => {
     expect(view.getByText("hit Esc to cancel")).toBeTruthy();
     expect(view.queryByRole("button", { name: "Stop streaming" })).toBeNull();
   });
+
+  // The token-stats slot must stay mounted across the starting -> streaming
+  // transition (only its visibility toggles), otherwise mounting it on transition
+  // reflows the row -> a layout flash. These two cases assert the slot is present
+  // in both phases and is merely hidden when no stats are available yet.
+  test("reserves the stats slot but hides it when token count is unavailable (starting)", () => {
+    const view = render(
+      <StreamingBarrierView statusText="starting..." cancelText="hit Esc to cancel" />
+    );
+
+    const stats = view.getByTestId("streaming-barrier-stats");
+    expect(stats.className).toContain("invisible");
+    expect(stats.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  test("reveals the same stats slot with values once streaming", () => {
+    const view = render(
+      <StreamingBarrierView
+        statusText="streaming..."
+        cancelText="hit Esc to cancel"
+        tokenCount={1234}
+        tps={45}
+      />
+    );
+
+    const stats = view.getByTestId("streaming-barrier-stats");
+    expect(stats.className).not.toContain("invisible");
+    expect(stats.getAttribute("aria-hidden")).toBe("false");
+    expect(stats.textContent).toContain("1,234");
+    expect(stats.textContent).toContain("45");
+  });
 });

--- a/src/browser/features/Messages/ChatBarrier/StreamingBarrierView.tsx
+++ b/src/browser/features/Messages/ChatBarrier/StreamingBarrierView.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { CircleStopIcon } from "lucide-react";
 
+import { cn } from "@/common/lib/utils";
 import { TooltipIfPresent } from "@/browser/components/Tooltip/Tooltip";
 import { BaseBarrier } from "./BaseBarrier";
 
@@ -30,16 +31,25 @@ export const StreamingBarrierView: React.FC<StreamingBarrierViewProps> = (props)
       <div className="flex flex-1 items-center gap-2">
         <BaseBarrier text={props.statusText} color="var(--color-assistant-border)" animate />
         {props.hintElement}
-        {props.tokenCount !== undefined && (
-          <span className="text-assistant-border counter-nums-mono inline-flex min-w-[14ch] items-baseline justify-end text-[11px] whitespace-nowrap select-none">
-            <span>~{props.tokenCount.toLocaleString()} tokens</span>
-            <span className="text-dim ml-1 inline-flex min-w-[7ch] items-baseline justify-end gap-1">
-              <span>@</span>
-              <span>{props.tps !== undefined && props.tps > 0 ? props.tps : "--"}</span>
-              <span>t/s</span>
-            </span>
+        {/* Always render the stats slot so the row geometry is identical across the
+            starting -> streaming transition; only its visibility toggles. Previously
+            this slot mounted exactly when streaming began, reflowing the row (layout
+            flash). Reserving it (with placeholder values) keeps the layout stable. */}
+        <span
+          data-testid="streaming-barrier-stats"
+          aria-hidden={props.tokenCount === undefined}
+          className={cn(
+            "text-assistant-border counter-nums-mono inline-flex min-w-[14ch] items-baseline justify-end text-[11px] whitespace-nowrap select-none",
+            props.tokenCount === undefined && "invisible"
+          )}
+        >
+          <span>~{(props.tokenCount ?? 0).toLocaleString()} tokens</span>
+          <span className="text-dim ml-1 inline-flex min-w-[7ch] items-baseline justify-end gap-1">
+            <span>@</span>
+            <span>{props.tps !== undefined && props.tps > 0 ? props.tps : "--"}</span>
+            <span>t/s</span>
           </span>
-        )}
+        </span>
       </div>
       <div className="ml-auto">
         {props.onCancel && props.cancelText.length > 0 ? (

--- a/src/browser/hooks/useAutoScroll.test.tsx
+++ b/src/browser/hooks/useAutoScroll.test.tsx
@@ -34,10 +34,12 @@ function createWheelEvent(
   } as unknown as WheelEvent<HTMLDivElement>;
 }
 
-let scheduledFrames: Array<{ id: number; callback: FrameRequestCallback }> = [];
-let nextFrameId = 1;
 let resizeObserverCallback: ResizeObserverCallback | null = null;
 
+// Capture the hook's ResizeObserver so the safety-net pin can be driven directly.
+// Bottom-stick no longer uses a requestAnimationFrame settle loop: native CSS
+// scroll anchoring (not exercisable in happy-dom) holds the bottom, and this
+// observer + handleScroll re-establish it on discrete layout/scroll signals.
 class ResizeObserverMock {
   constructor(callback: ResizeObserverCallback) {
     resizeObserverCallback = callback;
@@ -51,16 +53,10 @@ class ResizeObserverMock {
   }
 }
 
-function flushOneFrame(): void {
-  const next = scheduledFrames.shift();
-  if (!next) return;
-  next.callback(performance.now());
-}
-
-function flushFrames(count: number): void {
-  for (let index = 0; index < count; index += 1) {
-    flushOneFrame();
-  }
+// Run the captured ResizeObserver callback (the layout-settled signal that
+// re-establishes the bottom while locked).
+function triggerResizeObserver(): void {
+  resizeObserverCallback?.([], {} as ResizeObserver);
 }
 
 describe("useAutoScroll", () => {
@@ -68,32 +64,17 @@ describe("useAutoScroll", () => {
 
   beforeEach(() => {
     cleanupDom = installDom();
-    scheduledFrames = [];
-    nextFrameId = 1;
     resizeObserverCallback = null;
     window.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
-
-    // Install the deterministic scheduler on the per-test `window` rather than
-    // `globalThis` so this mock never leaks into downstream test files. The
-    // hook resolves rAF/cAF from `window` for exactly this reason.
-    window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
-      const id = nextFrameId++;
-      scheduledFrames.push({ id, callback });
-      return id;
-    }) as typeof window.requestAnimationFrame;
-    window.cancelAnimationFrame = ((id: number) => {
-      scheduledFrames = scheduledFrames.filter((frame) => frame.id !== id);
-    }) as typeof window.cancelAnimationFrame;
   });
 
   afterEach(() => {
     cleanup();
-    scheduledFrames = [];
     cleanupDom?.();
     cleanupDom = null;
   });
 
-  test("rAF tick pins to bottom whenever layout grows under bottom lock", () => {
+  test("layout growth under the lock re-pins to the bottom", () => {
     const { result } = renderHook(() => useAutoScroll());
     const element = document.createElement("div");
     const metrics = attachScrollMetrics(element, {
@@ -108,16 +89,18 @@ describe("useAutoScroll", () => {
 
     expect(metrics.scrollTop).toBe(metrics.maxScrollTop);
 
+    // Content grows below the fold. Native anchoring holds the sentinel in a real
+    // browser; here we drive the synchronous safety-net pin via the scroll signal
+    // that growth produces.
     metrics.setScrollHeight(1500);
-    // Browser would normally emit a paint frame; the rAF tick pins before paint.
     act(() => {
-      flushOneFrame();
+      result.current.handleScroll(createScrollEvent(element));
     });
 
     expect(metrics.scrollTop).toBe(metrics.maxScrollTop);
   });
 
-  test("rAF tick is a no-op when auto-scroll is off", () => {
+  test("the safety-net pin is a no-op when auto-scroll is off", () => {
     const { result } = renderHook(() => useAutoScroll());
     const element = document.createElement("div");
     const metrics = attachScrollMetrics(element, {
@@ -133,14 +116,14 @@ describe("useAutoScroll", () => {
 
     metrics.setScrollHeight(1500);
     act(() => {
-      flushFrames(3);
+      result.current.reanchorBottom();
     });
 
     expect(metrics.scrollTop).toBe(200);
     expect(result.current.autoScroll).toBe(false);
   });
 
-  test("rAF tick continues pinning across multiple frames during a CSS transition", () => {
+  test("each layout growth re-pins to the bottom while locked", () => {
     const { result } = renderHook(() => useAutoScroll());
     const element = document.createElement("div");
     const metrics = attachScrollMetrics(element, {
@@ -155,13 +138,13 @@ describe("useAutoScroll", () => {
     for (const next of [1100, 1180, 1240, 1300]) {
       metrics.setScrollHeight(next);
       act(() => {
-        flushOneFrame();
+        result.current.handleScroll(createScrollEvent(element));
       });
       expect(metrics.scrollTop).toBe(metrics.maxScrollTop);
     }
   });
 
-  test("user-owned scroll up disables the lock and survives subsequent rAF ticks", () => {
+  test("user-owned scroll up disables the lock and survives later re-pins", () => {
     const { result } = renderHook(() => useAutoScroll());
     const element = document.createElement("div");
     const metrics = attachScrollMetrics(element, {
@@ -186,8 +169,10 @@ describe("useAutoScroll", () => {
       });
       expect(result.current.autoScroll).toBe(false);
 
+      // The layout-driven safety-net pin must stay released-aware: re-anchoring
+      // is a no-op while unlocked, so the user keeps their position.
       act(() => {
-        flushFrames(5);
+        result.current.reanchorBottom();
       });
       expect(metrics.scrollTop).toBe(600);
     } finally {
@@ -199,8 +184,8 @@ describe("useAutoScroll", () => {
     // Regression: a slow wheel-up gesture from the very bottom (~3-7 px per
     // notch) used to keep the lock engaged because the user-intent branch
     // treated "still ≤ USER_BOTTOM_RELOCK_THRESHOLD_PX from bottom" as
-    // "relock". The rAF settle tick then wrote scrollTop = max on the next
-    // frame, snapping the user back to the bottom mid-gesture.
+    // "relock". A re-pin would then write scrollTop = max, snapping the user
+    // back to the bottom mid-gesture.
     const { result } = renderHook(() => useAutoScroll());
     const element = document.createElement("div");
     const metrics = attachScrollMetrics(element, {
@@ -229,9 +214,9 @@ describe("useAutoScroll", () => {
       });
       expect(result.current.autoScroll).toBe(false);
 
-      // Subsequent rAF ticks must not snap the user back to the bottom.
+      // A subsequent layout re-pin must not snap the user back to the bottom.
       act(() => {
-        flushFrames(5);
+        result.current.reanchorBottom();
       });
       expect(metrics.scrollTop).toBe(595);
     } finally {
@@ -281,7 +266,7 @@ describe("useAutoScroll", () => {
       expect(result.current.autoScroll).toBe(false);
 
       act(() => {
-        flushFrames(5);
+        result.current.reanchorBottom();
       });
       expect(metrics.scrollTop).toBe(594);
     } finally {
@@ -453,7 +438,7 @@ describe("useAutoScroll", () => {
     }
   });
 
-  test("returning to bottom geometry re-acquires the lock and rAF resumes pinning", () => {
+  test("returning to bottom geometry re-acquires the lock and resumes pinning", () => {
     const { result } = renderHook(() => useAutoScroll());
     const element = document.createElement("div");
     const metrics = attachScrollMetrics(element, {
@@ -488,10 +473,10 @@ describe("useAutoScroll", () => {
       });
       expect(result.current.autoScroll).toBe(true);
 
-      // New layout growth lands; rAF tick pins it.
+      // New layout growth lands; the re-acquired lock pins it on the next signal.
       metrics.setScrollHeight(1500);
       act(() => {
-        flushOneFrame();
+        result.current.handleScroll(createScrollEvent(element));
       });
       expect(metrics.scrollTop).toBe(metrics.maxScrollTop);
     } finally {
@@ -517,7 +502,7 @@ describe("useAutoScroll", () => {
 
     metrics.setScrollHeight(1500);
     act(() => {
-      flushOneFrame();
+      result.current.handleScroll(createScrollEvent(element));
     });
 
     expect(metrics.scrollTop).toBe(metrics.maxScrollTop);
@@ -691,7 +676,7 @@ describe("useAutoScroll", () => {
 
     metrics.setScrollHeight(1600);
     act(() => {
-      flushOneFrame();
+      result.current.handleScroll(createScrollEvent(element));
     });
     expect(metrics.scrollTop).toBe(metrics.maxScrollTop);
     expect(result.current.autoScroll).toBe(true);
@@ -777,7 +762,7 @@ describe("useAutoScroll", () => {
     }
   });
 
-  test("disableAutoScroll keeps later layout user-owned across rAF ticks", () => {
+  test("disableAutoScroll keeps later layout user-owned across re-pins", () => {
     const { result } = renderHook(() => useAutoScroll());
     const element = document.createElement("div");
     const metrics = attachScrollMetrics(element, {
@@ -794,7 +779,7 @@ describe("useAutoScroll", () => {
 
     metrics.setScrollHeight(1500);
     act(() => {
-      flushFrames(4);
+      result.current.reanchorBottom();
     });
 
     expect(metrics.scrollTop).toBe(500);
@@ -823,68 +808,7 @@ describe("useAutoScroll", () => {
     expect(result.current.autoScroll).toBe(false);
   });
 
-  test("rAF loop only runs while bottom-lock is held", () => {
-    const { result } = renderHook(() => useAutoScroll());
-    const element = document.createElement("div");
-    const metrics = attachScrollMetrics(element, {
-      scrollHeight: 1000,
-      clientHeight: 400,
-    });
-
-    act(() => {
-      (result.current.contentRef as MutableRefObject<HTMLDivElement | null>).current = element;
-    });
-
-    // Initial render: autoScroll = true, the loop is scheduling.
-    expect(scheduledFrames.length).toBeGreaterThan(0);
-
-    // User scrolls up — disable lock. The loop must stop entirely so manual
-    // reading sessions don't pay a per-frame cost.
-    act(() => {
-      result.current.disableAutoScroll();
-    });
-    while (scheduledFrames.length > 0) {
-      flushOneFrame();
-    }
-    expect(scheduledFrames.length).toBe(0);
-
-    metrics.setScrollHeight(1500);
-    metrics.setScrollTop(0);
-    act(() => {
-      flushFrames(3);
-    });
-    expect(metrics.scrollTop).toBe(0);
-
-    // Reacquiring the lock (e.g., jumpToBottom) restarts the loop.
-    act(() => {
-      result.current.jumpToBottom();
-    });
-    expect(scheduledFrames.length).toBeGreaterThan(0);
-  });
-
-  test("rAF settle loop stops after the idle frame budget", () => {
-    const { result } = renderHook(() => useAutoScroll());
-    const element = document.createElement("div");
-    attachScrollMetrics(element, {
-      scrollHeight: 1000,
-      clientHeight: 400,
-    });
-
-    act(() => {
-      (result.current.contentRef as MutableRefObject<HTMLDivElement | null>).current = element;
-    });
-
-    expect(scheduledFrames.length).toBeGreaterThan(0);
-
-    act(() => {
-      flushFrames(100);
-    });
-
-    expect(result.current.autoScroll).toBe(true);
-    expect(scheduledFrames.length).toBe(0);
-  });
-
-  test("ResizeObserver pins to bottom before the next rAF", () => {
+  test("the ResizeObserver re-pins the bottom while locked and stays released-aware", () => {
     const { result } = renderHook(() => useAutoScroll());
     const element = document.createElement("div");
     const metrics = attachScrollMetrics(element, {
@@ -903,7 +827,7 @@ describe("useAutoScroll", () => {
 
     metrics.setScrollHeight(1500);
     act(() => {
-      resizeObserverCallback?.([], {} as ResizeObserver);
+      triggerResizeObserver();
     });
 
     expect(metrics.scrollTop).toBe(metrics.maxScrollTop);
@@ -921,33 +845,28 @@ describe("useAutoScroll", () => {
     expect(metrics.scrollTop).toBe(100);
   });
 
-  test("rAF loop is torn down on unmount and stops scheduling new frames", () => {
+  test("the safety-net observer disconnects on unmount", () => {
     const { result, unmount } = renderHook(() => useAutoScroll());
     const element = document.createElement("div");
-    const metrics = attachScrollMetrics(element, {
+    attachScrollMetrics(element, {
       scrollHeight: 1000,
       clientHeight: 400,
     });
 
+    // Toggle autoScroll after attaching the ref so the observer effect re-runs and
+    // captures the callback (the effect bails when contentRef is null on mount).
     act(() => {
       (result.current.contentRef as MutableRefObject<HTMLDivElement | null>).current = element;
+      result.current.disableAutoScroll();
     });
-
-    expect(scheduledFrames.length).toBeGreaterThan(0);
+    act(() => {
+      result.current.jumpToBottom();
+    });
+    expect(resizeObserverCallback).not.toBeNull();
 
     unmount();
 
-    // After unmount the loop should not schedule any further frames.
-    metrics.setScrollHeight(1500);
-    metrics.setScrollTop(0);
-
-    while (scheduledFrames.length > 0) {
-      flushOneFrame();
-    }
-
-    // No infinite re-scheduling happened.
-    expect(scheduledFrames.length).toBe(0);
-    // And the unmounted loop did not write to scrollTop after disposal.
-    expect(metrics.scrollTop).toBe(0);
+    // disconnect() nulls the captured callback, so no stray pin can fire after teardown.
+    expect(resizeObserverCallback).toBeNull();
   });
 });

--- a/src/browser/hooks/useAutoScroll.ts
+++ b/src/browser/hooks/useAutoScroll.ts
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 const BOTTOM_LOCK_EPSILON_PX = 1;
 const USER_BOTTOM_RELOCK_THRESHOLD_PX = 8;
 const USER_SCROLL_INTENT_WINDOW_MS = 750;
-const BOTTOM_LOCK_SETTLE_FRAME_LIMIT = 60;
 const TRANSCRIPT_SCROLL_KEYS = new Set([
   "ArrowDown",
   "ArrowUp",
@@ -56,18 +55,36 @@ function isMouseDownExemptFromScrollIntent(
 }
 
 /**
- * Bottom-lock invariant: while `autoScroll` is true the transcript `scrollTop`
- * equals `scrollHeight - clientHeight`. Layout signals such as ResizeObserver,
- * open-chat, send, and geometric relock arm a short requestAnimationFrame settle
- * window instead of polling forever. The rAF tick lands just before paint, so
- * sub-pixel CSS transitions, async font/image settling, and scroll-anchor races
- * inside expanding tool panes converge without adding continuous idle work.
- * User input releases the lock; an explicit action (open chat, send,
- * jump-to-bottom) or geometric return-to-bottom reacquires it.
+ * Bottom-stick architecture: the browser owns bottom anchoring; JS only sets the
+ * initial bottom on discrete events.
+ *
+ * The scroll content ends with a 0-height sentinel (`sentinelRef`). While
+ * `autoScroll` is true the consumer marks the sentinel as the *only* element with
+ * `overflow-anchor: auto` (every transcript row opts out via `overflow-anchor:
+ * none`). Native CSS scroll anchoring then keeps that sentinel pinned to the
+ * bottom as rows, tokens, and the streaming barrier append above it — no per-frame
+ * `scrollTop` chase. This replaced an earlier 60-frame requestAnimationFrame settle
+ * loop that re-pinned every frame and visibly fought sub-pixel transitions, font
+ * swaps, and composer-driven viewport resizes (the recurring "send flash").
+ *
+ * `stickToBottom` is therefore only invoked on discrete ownership transfers
+ * (open-chat, send, jump-to-bottom, geometric relock) and once per scrollport
+ * resize as a safety net; anchoring holds the bottom in between. User input
+ * releases the lock; an explicit action or a geometric return-to-bottom reacquires
+ * it, at which point the sentinel comes back onscreen and anchoring re-engages.
+ *
+ * NOTE: anchoring only sticks to the bottom while the sentinel is onscreen (i.e.
+ * we are at the bottom). Once the user scrolls up, `autoScroll` flips false, rows
+ * regain `overflow-anchor: auto`, and the browser preserves the user's reading
+ * position when off-screen content above the fold settles.
  */
 export function useAutoScroll() {
   const [autoScroll, setAutoScroll] = useState(true);
   const contentRef = useRef<HTMLDivElement>(null);
+  // 0-height marker rendered as the last child of the scroll content, below the
+  // composer-clearance padding. See the hook doc comment: while locked it is the
+  // sole `overflow-anchor: auto` element so native anchoring pins the bottom.
+  const sentinelRef = useRef<HTMLDivElement>(null);
   const autoScrollRef = useRef(true);
   const programmaticDisableRef = useRef(false);
   const userScrollIntentUntilRef = useRef(0);
@@ -106,47 +123,6 @@ export function useAutoScroll() {
     }
   }, []);
 
-  const frameLoopRef = useRef<{ id: number | null; framesRemaining: number }>({
-    id: null,
-    framesRemaining: 0,
-  });
-
-  const stopBottomLockFrameLoop = useCallback(() => {
-    const frameId = frameLoopRef.current.id;
-    if (frameId !== null && typeof window !== "undefined") {
-      const cancelFrame = window.cancelAnimationFrame?.bind(window);
-      cancelFrame?.(frameId);
-    }
-    frameLoopRef.current.id = null;
-    frameLoopRef.current.framesRemaining = 0;
-  }, []);
-
-  const startBottomLockFrameLoop = useCallback(() => {
-    if (!autoScrollRef.current) return;
-    const win = typeof window !== "undefined" ? window : undefined;
-    const raf = win?.requestAnimationFrame?.bind(win);
-    if (!raf) return;
-
-    frameLoopRef.current.framesRemaining = BOTTOM_LOCK_SETTLE_FRAME_LIMIT;
-    if (frameLoopRef.current.id !== null) return;
-
-    const tick = () => {
-      frameLoopRef.current.id = null;
-      if (!autoScrollRef.current || frameLoopRef.current.framesRemaining <= 0) {
-        frameLoopRef.current.framesRemaining = 0;
-        return;
-      }
-
-      stickToBottom();
-      frameLoopRef.current.framesRemaining -= 1;
-      if (frameLoopRef.current.framesRemaining > 0) {
-        frameLoopRef.current.id = raf(tick);
-      }
-    };
-
-    frameLoopRef.current.id = raf(tick);
-  }, [stickToBottom]);
-
   const jumpToBottom = useCallback(() => {
     // Opening/sending is an explicit transfer of scroll ownership back to the
     // transcript tail. Clear stale wheel/touch/key intent before the browser emits
@@ -154,12 +130,13 @@ export function useAutoScroll() {
     userScrollIntentUntilRef.current = 0;
     programmaticDisableRef.current = false;
     setAutoScrollEnabled(true);
+    // Establish the bottom once. The sentinel is now onscreen, so native scroll
+    // anchoring holds it as later rows/tokens append — no settle loop required.
     stickToBottom();
     // stickToBottom skips the write when scrollTop is already max, so we may
     // not get a follow-up scroll event to refresh lastScrollTopRef.
     seedScrollDirectionBaseline();
-    startBottomLockFrameLoop();
-  }, [seedScrollDirectionBaseline, setAutoScrollEnabled, startBottomLockFrameLoop, stickToBottom]);
+  }, [seedScrollDirectionBaseline, setAutoScrollEnabled, stickToBottom]);
 
   const disableAutoScroll = useCallback(() => {
     userScrollIntentUntilRef.current = 0;
@@ -169,8 +146,19 @@ export function useAutoScroll() {
     // baseline now to keep the next user-driven scroll event's direction
     // check honest.
     seedScrollDirectionBaseline();
-    stopBottomLockFrameLoop();
-  }, [seedScrollDirectionBaseline, setAutoScrollEnabled, stopBottomLockFrameLoop]);
+  }, [seedScrollDirectionBaseline, setAutoScrollEnabled]);
+
+  // Re-establish the bottom after an external layout change the content
+  // ResizeObserver cannot see. The floating composer grows the scrollport's
+  // bottom *padding* (the composer clearance), which changes scrollHeight without
+  // resizing the scrollport's content box or the message content — so neither the
+  // safety-net observer nor native anchoring (the change is below the sentinel)
+  // re-pins. No-op unless locked, so a scrolled-up reader is never yanked down by
+  // composer growth.
+  const reanchorBottom = useCallback(() => {
+    if (!autoScrollRef.current) return;
+    stickToBottom();
+  }, [stickToBottom]);
 
   const markUserScrollIntent = useCallback(() => {
     programmaticDisableRef.current = false;
@@ -264,7 +252,6 @@ export function useAutoScroll() {
           !isWithinBottomThreshold(scrollContainer, BOTTOM_LOCK_EPSILON_PX)
         ) {
           stickToBottom();
-          startBottomLockFrameLoop();
           return;
         }
 
@@ -274,7 +261,9 @@ export function useAutoScroll() {
           isWithinBottomThreshold(scrollContainer, USER_BOTTOM_RELOCK_THRESHOLD_PX)
         ) {
           setAutoScrollEnabled(true);
-          startBottomLockFrameLoop();
+          // Snap the sentinel fully onscreen so anchoring re-engages from the exact
+          // bottom (relock fires within USER_BOTTOM_RELOCK_THRESHOLD_PX of it).
+          stickToBottom();
         }
         return;
       }
@@ -310,28 +299,18 @@ export function useAutoScroll() {
         isWithinBottomThreshold(scrollContainer, USER_BOTTOM_RELOCK_THRESHOLD_PX)
       ) {
         setAutoScrollEnabled(true);
-        startBottomLockFrameLoop();
+        stickToBottom();
       }
     },
-    [setAutoScrollEnabled, startBottomLockFrameLoop, stickToBottom]
+    [setAutoScrollEnabled, stickToBottom]
   );
 
-  // Frame-aligned bottom-lock enforcer.
-  //
-  // The rAF work is bounded: open-chat/send/relock/resize signals arm a short
-  // settle window, and the loop stops once that budget is exhausted or the user
-  // releases the lock. That keeps the paint-aligned correction without continuous
-  // idle polling in long-lived chats.
-  useEffect(() => {
-    if (autoScroll) {
-      startBottomLockFrameLoop();
-      return stopBottomLockFrameLoop;
-    }
-
-    stopBottomLockFrameLoop();
-    return undefined;
-  }, [autoScroll, startBottomLockFrameLoop, stopBottomLockFrameLoop]);
-
+  // Safety net behind native scroll anchoring. Anchoring (the sentinel) keeps us
+  // pinned as content appends, but a resize of the scrollport itself (e.g. the
+  // window, sidebars, or the composer-clearance padding changing) is not an
+  // "append above the anchor", so re-establish the bottom once per resize while
+  // locked. This is a single synchronous write — NOT a per-frame loop — so it
+  // cannot fight CSS transitions or font swaps the way the old settle loop did.
   useEffect(() => {
     if (!autoScroll) return;
     const scrollContainer = contentRef.current;
@@ -341,7 +320,6 @@ export function useAutoScroll() {
     const observer = new ResizeObserverCtor(() => {
       if (!autoScrollRef.current) return;
       stickToBottom();
-      startBottomLockFrameLoop();
     });
     observer.observe(scrollContainer);
     const content = scrollContainer.firstElementChild;
@@ -350,13 +328,15 @@ export function useAutoScroll() {
     }
 
     return () => observer.disconnect();
-  }, [autoScroll, startBottomLockFrameLoop, stickToBottom]);
+  }, [autoScroll, stickToBottom]);
 
   return {
     contentRef,
+    sentinelRef,
     autoScroll,
     disableAutoScroll,
     jumpToBottom,
+    reanchorBottom,
     handleScroll,
     markUserScrollIntent,
     handleScrollContainerWheel,

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -1807,6 +1807,49 @@ describe("WorkspaceStore", () => {
       expect(store.getWorkspaceState(workspaceId).isStreamStarting).toBe(false);
     });
 
+    it("stays in starting state when a streaming lifecycle event lands before the stream is interruptible", async () => {
+      // Regression guard for the starting -> streaming flash: the backend can emit a
+      // "streaming" lifecycle event a frame before stream-start makes the stream
+      // interruptible. In that window canInterrupt is still false, so isStreamStarting
+      // must remain true (keyed off the pending start, not the lifecycle phase).
+      // Otherwise shouldShowStreamingBarrier (isStreamStarting || canInterrupt) drops
+      // to false for a frame and the streaming barrier unmounts then remounts.
+      const workspaceId = "stream-starting-lifecycle-gap";
+
+      mockChatStreamFor(workspaceId, async function* () {
+        yield { type: "caught-up" };
+        await Promise.resolve();
+        // Trailing user message with no assistant reply -> optimistic pending start.
+        yield createUserMessageEvent("lifecycle-gap-user", "hello", 1, 1_000);
+        await Promise.resolve();
+        // Stream reports "streaming" but stream-start (which populates the
+        // interruptible active stream) has not been applied yet.
+        yield {
+          type: "stream-lifecycle",
+          workspaceId,
+          phase: "streaming",
+          hadAnyOutput: false,
+        };
+      });
+
+      createAndAddWorkspace(store, workspaceId);
+
+      const reachedGap = await waitUntil(() => {
+        const state = store.getWorkspaceState(workspaceId);
+        return (
+          state.pendingStreamStartTime !== null &&
+          !state.canInterrupt &&
+          store.getAggregator(workspaceId)?.getStreamLifecycle()?.phase === "streaming"
+        );
+      });
+      expect(reachedGap).toBe(true);
+
+      const state = store.getWorkspaceState(workspaceId);
+      expect(state.canInterrupt).toBe(false);
+      // The key assertion: the barrier-visibility flag stays true across the gap.
+      expect(state.isStreamStarting).toBe(true);
+    });
+
     it("clears optimistic starting state on pre-stream abort", async () => {
       const workspaceId = "optimistic-pending-start-stream-abort";
       const requestedModel = "openai:gpt-4o-mini";

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -1798,8 +1798,6 @@ export class WorkspaceStore {
           activity?.lastThinkingLevel ??
           aggregator.getCurrentThinkingLevel() ??
           null);
-      const hasAuthoritativeStreamLifecycle =
-        streamLifecycle !== null && streamLifecycle.phase !== "idle";
       const activePendingStreamStartTime = isActiveWorkspace ? pendingStreamStartTime : null;
       const aggregatorRecency = aggregator.getRecencyTimestamp();
       const recencyTimestamp =
@@ -1810,11 +1808,18 @@ export class WorkspaceStore {
       // flashing "Catching up"/"No Messages Yet" while the very first send is still in flight.
       // The aggregator owns both normal user-message startup and the optimistic new-chat handoff,
       // so the workspace only needs to ask whether the active transcript still has a pending start.
+      // A turn is "starting" from the optimistic pending-start until the stream
+      // becomes interruptible. Keying off pendingStreamStartTime — which every
+      // terminal handler (end/abort/error) clears — keeps the streaming barrier
+      // continuously mounted across the starting -> streaming handoff with no gap.
+      // Keying off streamLifecycle.phase instead would risk both a flash (a
+      // "streaming" lifecycle event can land a frame before stream-start populates
+      // the active stream, leaving neither flag set) and a stuck barrier
+      // (handleStreamEnd leaves the lifecycle snapshot non-idle).
       const isStreamStarting =
         isActiveWorkspace &&
         !canInterrupt &&
-        (streamLifecycle?.phase === "preparing" ||
-          (!hasAuthoritativeStreamLifecycle && activePendingStreamStartTime !== null));
+        (streamLifecycle?.phase === "preparing" || activePendingStreamStartTime !== null);
       // Only actively running init output should bypass transcript hydration. Completed init
       // rows are still replayed, but they should not suppress the normal catch-up placeholder
       // for stale cached transcript content on reconnect.
@@ -1924,14 +1929,14 @@ export class WorkspaceStore {
       : bufferedActiveStreamStart !== null
         ? true
         : (activity?.streaming ?? hasInterruptibleActiveStream);
-    const hasAuthoritativeStreamLifecycle =
-      streamLifecycle !== null && streamLifecycle.phase !== "idle";
     const activePendingStreamStartTime = isActiveWorkspace ? pendingStreamStartTime : null;
+    // Mirror getWorkspaceState's starting derivation: pendingStreamStartTime is the
+    // gap-free, terminal-cleared signal that a turn is in flight but not yet
+    // interruptible. See the rationale in getWorkspaceState above.
     const isStreamStarting =
       isActiveWorkspace &&
       !canInterrupt &&
-      (streamLifecycle?.phase === "preparing" ||
-        (!hasAuthoritativeStreamLifecycle && activePendingStreamStartTime !== null));
+      (streamLifecycle?.phase === "preparing" || activePendingStreamStartTime !== null);
     const isHydratingTranscript =
       isActiveWorkspace &&
       transient.isHydratingTranscript &&

--- a/tests/e2e/scenarios/composerLayoutStability.spec.ts
+++ b/tests/e2e/scenarios/composerLayoutStability.spec.ts
@@ -1,0 +1,143 @@
+import { electronTest as test, electronExpect as expect } from "../electronTest";
+import { MOCK_LIST_PROGRAMMING_LANGUAGES } from "../mockAiPrompts";
+
+// Real-browser gate for the chat-send "layout flash" fix. happy-dom cannot evaluate
+// native CSS scroll anchoring, calc(var(--composer-h)) clearance, or per-frame
+// layout geometry, so the architecture's core invariants are proven here:
+//
+//   Pillar D — the composer floats out of flow, so growing/collapsing it (the
+//   send-time root cause) NEVER changes the transcript scrollport's clientHeight.
+//   Pillar A — the bottom sentinel + native anchoring keep the transcript pinned to
+//   the bottom with the last message clear of the floating composer.
+//
+// clientHeight is a stable per-frame layout property (not a transient paint), so
+// sampling it across the send is deterministic rather than flaky.
+test.skip(
+  ({ browserName }) => browserName !== "chromium",
+  "Electron scenario runs on chromium only"
+);
+
+const MESSAGE_WINDOW = '[data-testid="message-window"]';
+const COMPOSER_DOCK = '[data-testid="chat-composer-dock"]';
+const SENTINEL = '[data-testid="transcript-bottom-sentinel"]';
+
+const TALL_DRAFT = Array.from({ length: 8 }, (_, i) => `draft line ${i + 1}`).join("\n");
+
+test("composer height changes never resize the transcript viewport, and the bottom stays pinned", async ({
+  page,
+  ui,
+}) => {
+  await ui.projects.openFirstWorkspace();
+
+  // Seed a transcript so the scrollport is scrollable and a real "last message" exists.
+  await ui.chat.sendMessage(MOCK_LIST_PROGRAMMING_LANGUAGES);
+  await ui.chat.expectTranscriptContains("Python");
+
+  const input = page.getByRole("textbox", { name: /Message Claude|Edit your last message/ });
+  await expect(input).toBeVisible();
+
+  // Baseline: scrollport clientHeight with the composer at its minimum height.
+  const baseline = await page.evaluate(
+    (sel) => document.querySelector<HTMLElement>(sel)!.clientHeight,
+    MESSAGE_WINDOW
+  );
+  expect(baseline).toBeGreaterThan(0);
+
+  // Pillar D (grow): a tall multi-line draft must enlarge the composer WITHOUT
+  // shrinking the scrollport, and the scrollport must reserve matching clearance.
+  await input.fill(TALL_DRAFT);
+  const grown = await page.evaluate(
+    ({ win, dock }) => {
+      const sp = document.querySelector<HTMLElement>(win)!;
+      const composer = document.querySelector<HTMLElement>(dock)!;
+      return {
+        clientHeight: sp.clientHeight,
+        composerHeight: Math.round(composer.getBoundingClientRect().height),
+        paddingBottom: Number.parseFloat(getComputedStyle(sp).paddingBottom),
+      };
+    },
+    { win: MESSAGE_WINDOW, dock: COMPOSER_DOCK }
+  );
+  expect(grown.composerHeight).toBeGreaterThan(0);
+  // The headline invariant: a taller composer does not steal scrollport height.
+  expect(grown.clientHeight).toBe(baseline);
+  // The clearance padding tracks the live composer height (calc(var(--composer-h))).
+  expect(grown.paddingBottom).toBeGreaterThanOrEqual(grown.composerHeight);
+
+  // Pillar D (collapse): clearing the draft collapses the composer; still no resize.
+  await input.fill("");
+  await expect
+    .poll(() =>
+      page.evaluate(
+        (dock) =>
+          Math.round(document.querySelector<HTMLElement>(dock)!.getBoundingClientRect().height),
+        COMPOSER_DOCK
+      )
+    )
+    .toBeLessThan(grown.composerHeight);
+  const collapsed = await page.evaluate(
+    (sel) => document.querySelector<HTMLElement>(sel)!.clientHeight,
+    MESSAGE_WINDOW
+  );
+  expect(collapsed).toBe(baseline);
+
+  // Sample the scrollport clientHeight repeatedly across the next send. A flash from
+  // the composer resizing the viewport (the historical bug) would show up as any
+  // sample diverging from the baseline. Sampling is driven from Playwright (not an
+  // in-page rAF loop) because requestAnimationFrame is throttled under headless xvfb.
+  await input.fill(MOCK_LIST_PROGRAMMING_LANGUAGES);
+  const samplingDone = (async () => {
+    const samples: number[] = [];
+    for (let i = 0; i < 25; i += 1) {
+      samples.push(
+        await page.evaluate(
+          (sel) => document.querySelector<HTMLElement>(sel)!.clientHeight,
+          MESSAGE_WINDOW
+        )
+      );
+      await page.waitForTimeout(40);
+    }
+    return samples;
+  })();
+  await page.keyboard.press("Enter");
+  await ui.chat.expectTranscriptContains("JavaScript");
+  const samples = await samplingDone;
+
+  expect(samples.length).toBeGreaterThan(10);
+  // Every sample spanning send -> composer collapse -> barrier mount -> user echo ->
+  // stream kept the viewport height fixed.
+  for (const sample of samples) {
+    expect(sample).toBe(baseline);
+  }
+
+  // Pillar A: after settling, the transcript is pinned to the bottom, the sentinel is
+  // the last child, and the last message clears the floating composer — all while the
+  // viewport height is still the baseline.
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          ({ win, dock, sentinel, baselineHeight }) => {
+            const sp = document.querySelector<HTMLElement>(win)!;
+            const composer = document.querySelector<HTMLElement>(dock)!;
+            const sentinelEl = document.querySelector<HTMLElement>(sentinel)!;
+            const rows = sp.querySelectorAll<HTMLElement>("[data-message-id]");
+            const last = rows[rows.length - 1];
+            if (!last) return false;
+            const pinnedToBottom = sp.scrollHeight - sp.clientHeight - sp.scrollTop <= 4;
+            const sentinelIsLast = sp.lastElementChild === sentinelEl;
+            const lastClearsComposer =
+              last.getBoundingClientRect().bottom <= composer.getBoundingClientRect().top + 2;
+            return (
+              sp.clientHeight === baselineHeight &&
+              pinnedToBottom &&
+              sentinelIsLast &&
+              lastClearsComposer
+            );
+          },
+          { win: MESSAGE_WINDOW, dock: COMPOSER_DOCK, sentinel: SENTINEL, baselineHeight: baseline }
+        ),
+      { timeout: 10_000 }
+    )
+    .toBe(true);
+});

--- a/tests/ui/chat/floatingComposerAnchoring.test.ts
+++ b/tests/ui/chat/floatingComposerAnchoring.test.ts
@@ -1,0 +1,89 @@
+import "../dom";
+
+import { fireEvent, waitFor } from "@testing-library/react";
+
+// App-level UI tests render the loader shell first, so stub Lottie before importing the
+// harness to keep happy-dom from tripping over lottie-web's canvas bootstrap.
+jest.mock("lottie-react", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+import { preloadTestModules } from "../../ipc/setup";
+import { createAppHarness } from "../harness";
+import { mockScrollMetrics as mockScrollportMetrics } from "../scrollMetrics";
+
+function getMessageWindow(container: HTMLElement): HTMLDivElement {
+  const element = container.querySelector('[data-testid="message-window"]');
+  if (!element || element.tagName !== "DIV") {
+    throw new Error("Message window not found");
+  }
+  return element as HTMLDivElement;
+}
+
+// These tests encode the structural contract behind the "send flash" fix:
+//   1. The composer floats (absolute) in its own subtree, so its height changes never
+//      resize the transcript scrollport (the root cause of viewport-resize-from-below).
+//   2. A 0-height bottom sentinel is the LAST child of the scrollport and the sole
+//      `overflow-anchor: auto` element while locked, so native CSS scroll anchoring
+//      pins the bottom on append without a JS settle loop.
+//   3. Releasing the lock (scrolling up) restores row anchoring so the reading
+//      position is preserved.
+// happy-dom cannot exercise real native anchoring, so these assert the DOM/style
+// contract the browser relies on; the pixel behavior is covered by the e2e suite.
+describe("Floating composer + bottom anchoring", () => {
+  beforeAll(async () => {
+    await preloadTestModules();
+  });
+
+  test("floats the composer, reserves clearance, and keeps the sentinel as the sole bottom anchor", async () => {
+    const app = await createAppHarness({ branchPrefix: "floating-composer-anchor" });
+
+    try {
+      await app.chat.send("Seed transcript before asserting the anchoring contract");
+      await app.chat.expectStreamComplete();
+
+      const messageWindow = getMessageWindow(app.view.container);
+
+      // (1) The composer lives in a separate, floating subtree — not a flex sibling
+      // nested in (or wrapping) the scrollport. (The scrollport's clearance padding
+      // uses calc(var(--composer-h)), which happy-dom drops; the pixel clearance is
+      // asserted in the e2e suite where a real layout engine evaluates it.)
+      const dock = app.view.container.querySelector('[data-testid="chat-composer-dock"]');
+      if (!dock) throw new Error("Composer dock not found");
+      expect(messageWindow.contains(dock)).toBe(false);
+      expect(dock.contains(messageWindow)).toBe(false);
+      expect(dock.classList.contains("absolute")).toBe(true);
+
+      // (2) The sentinel is the last child of the scrollport and is the anchor.
+      const sentinel = messageWindow.querySelector('[data-testid="transcript-bottom-sentinel"]');
+      if (!sentinel) throw new Error("Bottom sentinel not found");
+      expect(messageWindow.lastElementChild).toBe(sentinel);
+      expect((sentinel as HTMLElement).style.overflowAnchor).toBe("auto");
+
+      // (2) While locked (at the bottom after a send) the transcript content opts OUT
+      // of anchoring so the sentinel is the only candidate the browser can pick.
+      const content = messageWindow.firstElementChild as HTMLElement;
+      expect(content.style.overflowAnchor).toBe("none");
+
+      // (3) Scrolling up releases the lock and restores default row anchoring so the
+      // browser preserves the reading position when content above the fold settles.
+      const port = mockScrollportMetrics(messageWindow, {
+        scrollHeight: 2000,
+        clientHeight: 500,
+        scrollTop: 1500,
+      });
+      // A real wheel delta opens the user-scroll-intent window (delta-0 events are
+      // filtered); the off-bottom scroll that follows then releases the lock.
+      fireEvent.wheel(messageWindow, { deltaY: -120 });
+      port.setScrollTop(200);
+      fireEvent.scroll(messageWindow);
+
+      await waitFor(() => {
+        expect((messageWindow.firstElementChild as HTMLElement).style.overflowAnchor).toBe("");
+      });
+    } finally {
+      await app.dispose();
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

Eliminates the recurring chat layout flashes and polishes the transcript loading state. Three related changes:

1. **Send-time flash** — the composer no longer resizes the transcript viewport, and bottom-stick is owned by the browser's native scroll anchoring instead of a per-frame `scrollTop` chase.
2. **Streaming-indicator flash** — the streaming barrier no longer reflows or unmounts when it transitions from `starting` → `streaming`.
3. **Transcript loading** — the centered "Loading transcript…" text is replaced with a vercel-style shimmer row skeleton.

## Background

The transcript is a flex column `[header / flex-1 scrollport / composer]`. The composer was an auto-height flex sibling, so every send (which collapses the textarea) resized the scrollport `clientHeight` from below. Bottom-stick had `overflow-anchor` disabled and was re-implemented as a bounded 60-frame `requestAnimationFrame` loop writing `scrollTop = scrollHeight - clientHeight`. On one send, the composer collapse, the optimistic streaming-barrier mount, the user-message echo, the first tokens, and `font-display: swap` all change geometry across adjacent frames, and the JS pin races those paints — the recurring "flash". ~19 fixes over ~60 days iterated on the rAF loop, debounce constants, and min-height lanes without converging because they corrected layout *after* it had already changed.

The **streaming indicator** flashed separately on `starting → streaming` for two reasons: (a) the token-stats element (`~N tokens @ … t/s`) mounted exactly at that transition, reflowing the barrier row; and (b) `shouldShowStreamingBarrier = isStreamStarting || canInterrupt` could be *false for a frame* — `isStreamStarting` was gated on `!hasAuthoritativeStreamLifecycle`, so when a `streaming` lifecycle event landed before `stream-start` populated the interruptible stream, neither flag was set and the whole barrier briefly unmounted.

## Implementation

**Send-time flash** — one invariant: the browser owns bottom anchoring, and the send path never resizes the scroll viewport from below.

- **Floating composer (Pillar D):** the composer renders in an absolute dock at the bottom of the (now `relative`) chat column, out of flex flow, so its height changes no longer alter the scrollport `clientHeight`. The scrollport reserves clearance with `padding-bottom: calc(15px + var(--composer-h))`, published by a `ResizeObserver` on the dock. The jump-to-bottom chip sits above the dock.
- **Native bottom anchoring (Pillar A):** a 0-height bottom sentinel is the last child of the scrollport. While locked, the transcript content opts out of anchoring (`overflow-anchor: none`) so the sentinel is the *sole* anchor candidate; the browser keeps it pinned as content appends above it. On scroll-up, row anchoring is restored.
- **`useAutoScroll`:** removed the 60-frame settle loop; `jumpToBottom`/relock establish the bottom once and anchoring holds it. A single non-looping `ResizeObserver` + `reanchorBottom` are the safety net. Intent/relock logic and `/btw` scroll-hold are unchanged.

**Streaming-indicator flash** — make the barrier geometry phase-invariant and keep it mounted across the whole turn.

- `StreamingBarrierView` always renders the token-stats slot (with placeholder values) and only toggles its `visibility`, so the row geometry is identical in `starting` and `streaming` — nothing mounts on transition.
- `WorkspaceStore` derives `isStreamStarting` from `pendingStreamStartTime` (set on send, cleared by **every** terminal handler — end/abort/error) rather than the lifecycle phase. This keeps `shouldShowStreamingBarrier` continuously true from send until the stream is interruptible, with no gap, and can't get stuck (a stale non-idle lifecycle after `stream-end` no longer matters). Mirrored in the lighter `getWorkspaceShellStatus` selector.

**Transcript loading** — `TranscriptHydrationSkeleton` renders a few conversation-shaped turns (short user bubble + assistant prose lines) with the shared shimmer `Skeleton`, fading toward the bottom. It is top-aligned in normal transcript flow (not vertically centered), so it sits where real messages will and doesn't jump when hydration completes. The empty-transcript placeholder is unchanged.

## Validation

- `useAutoScroll` unit tests reworked onto the discrete-pin + ResizeObserver paths (24/24).
- `floatingComposerAnchoring` happy-dom test: composer dock is a separate subtree, sentinel is last child + sole `overflow-anchor:auto`, anchor policy toggles back on scroll release.
- `composerLayoutStability` e2e (real Electron/Chromium): tall draft + collapse-on-send keep scrollport `clientHeight` fixed; `calc(var(--composer-h))` clearance ≥ composer height; after settle the transcript is pinned and the last message clears the composer.
- **New** `StreamingBarrierView` tests: the stats slot is reserved-but-hidden during `starting` and revealed (same element) once streaming.
- **New** `WorkspaceStore` regression guard: a `streaming` lifecycle event arriving before the stream is interruptible keeps `isStreamStarting` true (barrier never unmounts). Full `WorkspaceStore` suite green.
- New `Streaming` barrier story + `TranscriptHydrationSkeleton` story for Chromatic. `make static-check` clean.

## Risks

- Touches the hot transcript scroll path and the streaming-state derivation. Mitigations: native anchoring is primary with a single ResizeObserver safety net; the real-browser e2e gate runs in CI; the `isStreamStarting` change only *broadens* the existing pending-start window (and is keyed off a signal already cleared on all terminals), guarded by a new regression test and the full store suite.
- **Expected Chromatic visual diffs** — the composer now floats and the transcript carries bottom padding (send-flash work), plus two new stories. The streaming-stats and skeleton changes are otherwise structural / additive.
- Mobile (`max-width:768px`) keeps the dock at the column bottom with existing safe-area handling; worth a manual touch-viewport check.

## Pains

happy-dom cannot evaluate native scroll anchoring or `calc(var())`, and `requestAnimationFrame` is throttled under headless `xvfb` — so the composer-stability sampler became a Playwright-driven `clientHeight` loop, and real anchoring is covered only by the e2e gate.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-8` • Thinking: `max` • Cost: `$37.92`_

<!-- mux-attribution: model=anthropic:claude-opus-4-8 thinking=max costs=37.92 -->
