### PR TITLE
🤖 feat: stream advisor reasoning in tool UI

### DIFF
--- a/src/browser/features/Tools/AdvisorToolCall.test.tsx
+++ b/src/browser/features/Tools/AdvisorToolCall.test.tsx
@@ -20,6 +20,13 @@ const useAdvisorToolLivePhaseMock = mock(
   ): WorkspaceStoreModule.AdvisorLivePhaseState | undefined => undefined
 );
 
+const useAdvisorToolLiveReasoningMock = mock(
+  (
+    _workspaceId: string | undefined,
+    _toolCallId: string | undefined
+  ): WorkspaceStoreModule.AdvisorLiveReasoningState | null => null
+);
+
 /* eslint-disable @typescript-eslint/no-require-imports */
 const actualWorkspaceStore =
   require("@/browser/stores/WorkspaceStore?real=1") as typeof WorkspaceStoreModule;
@@ -29,6 +36,7 @@ void mock.module("@/browser/stores/WorkspaceStore", () => ({
   ...actualWorkspaceStore,
   useAdvisorToolLiveOutput: useAdvisorToolLiveOutputMock,
   useAdvisorToolLivePhase: useAdvisorToolLivePhaseMock,
+  useAdvisorToolLiveReasoning: useAdvisorToolLiveReasoningMock,
 }));
 
 void mock.module("./Shared/ElapsedTimeDisplay", () => ({
@@ -77,6 +85,7 @@ describe("AdvisorToolCall", () => {
 
     useAdvisorToolLiveOutputMock.mockReset();
     useAdvisorToolLivePhaseMock.mockReset();
+    useAdvisorToolLiveReasoningMock.mockReset();
   });
 
   afterEach(() => {
@@ -163,6 +172,29 @@ describe("AdvisorToolCall", () => {
     expect(useAdvisorToolLiveOutputMock).toHaveBeenCalledWith("workspace-1", "advisor-call-1");
     expect(view.getByText("Advice")).toBeTruthy();
     expect(view.getByText("Streamed partial advice")).toBeTruthy();
+  });
+
+  test("renders live advisor reasoning separately from live advice", () => {
+    useAdvisorToolLivePhaseMock.mockReturnValue({
+      phase: "waiting_for_response",
+      timestamp: 1,
+    });
+    useAdvisorToolLiveReasoningMock.mockReturnValue({
+      text: "Considering the risky edge case",
+      timestamp: 2,
+    });
+    useAdvisorToolLiveOutputMock.mockReturnValue({
+      text: "Prefer the safer path",
+      timestamp: 3,
+    });
+
+    const view = renderAdvisorToolCall({ status: "executing" });
+
+    expect(useAdvisorToolLiveReasoningMock).toHaveBeenCalledWith("workspace-1", "advisor-call-1");
+    expect(view.getByText("Thinking")).toBeTruthy();
+    expect(view.getByText("Considering the risky edge case")).toBeTruthy();
+    expect(view.getByText("Advice")).toBeTruthy();
+    expect(view.getByText("Prefer the safer path")).toBeTruthy();
   });
 
   test("collapses back to the settled default when execution completes", () => {

--- a/src/browser/features/Tools/AdvisorToolCall.tsx
+++ b/src/browser/features/Tools/AdvisorToolCall.tsx
@@ -7,6 +7,7 @@ import {
   type AdvisorLivePhaseState,
   useAdvisorToolLiveOutput,
   useAdvisorToolLivePhase,
+  useAdvisorToolLiveReasoning,
 } from "@/browser/stores/WorkspaceStore";
 import { formatModelDisplayName } from "@/common/utils/ai/modelDisplay";
 import { getModelName } from "@/common/utils/ai/models";
@@ -258,9 +259,14 @@ const AdvisorToolCallContent: React.FC<AdvisorToolCallContentProps> = ({
   // Streamed chunks need expansion to be visible.
   // Remount on settle so completed rows keep their collapsed default.
   const { expanded, toggleExpanded } = useToolExpansion(isExecutingWithoutResult);
-  const livePhase = useAdvisorToolLivePhase(workspaceId, toolCallId);
-  const liveOutput = useAdvisorToolLiveOutput(workspaceId, toolCallId);
+  const liveWorkspaceId = isExecutingWithoutResult ? workspaceId : undefined;
+  const liveToolCallId = isExecutingWithoutResult ? toolCallId : undefined;
+  const livePhase = useAdvisorToolLivePhase(liveWorkspaceId, liveToolCallId);
+  const liveOutput = useAdvisorToolLiveOutput(liveWorkspaceId, liveToolCallId);
+  const liveReasoning = useAdvisorToolLiveReasoning(liveWorkspaceId, liveToolCallId);
   const liveAdviceText = isExecutingWithoutResult && liveOutput?.text ? liveOutput.text : undefined;
+  const liveReasoningText =
+    isExecutingWithoutResult && liveReasoning?.text ? liveReasoning.text : undefined;
   const detailsText =
     advisorResult?.type === "advice"
       ? advisorResult.advice
@@ -329,6 +335,15 @@ const AdvisorToolCallContent: React.FC<AdvisorToolCallContentProps> = ({
                 </DetailSection>
               )}
             </>
+          )}
+
+          {advisorResult === null && liveReasoningText && (
+            <DetailSection>
+              <DetailLabel>Thinking</DetailLabel>
+              <div className="bg-code-bg text-secondary rounded px-3 py-2 text-[12px] leading-relaxed">
+                <MarkdownRenderer content={liveReasoningText} preserveLineBreaks />
+              </div>
+            </DetailSection>
           )}
 
           {advisorResult === null && liveAdviceText && (

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -532,6 +532,19 @@ const advisorOutputEvent = (
   timestamp: number
 ): WorkspaceChatMessage => ({ type: "advisor-output", workspaceId, toolCallId, text, timestamp });
 
+const advisorReasoningOutputEvent = (
+  workspaceId: string,
+  toolCallId: string,
+  text: string,
+  timestamp: number
+): WorkspaceChatMessage => ({
+  type: "advisor-reasoning-output",
+  workspaceId,
+  toolCallId,
+  text,
+  timestamp,
+});
+
 const taskCreatedEvent = (
   workspaceId: string,
   toolCallId: string,
@@ -1808,22 +1821,13 @@ describe("WorkspaceStore", () => {
     });
 
     it("stays in starting state when a streaming lifecycle event lands before the stream is interruptible", async () => {
-      // Regression guard for the starting -> streaming flash: the backend can emit a
-      // "streaming" lifecycle event a frame before stream-start makes the stream
-      // interruptible. In that window canInterrupt is still false, so isStreamStarting
-      // must remain true (keyed off the pending start, not the lifecycle phase).
-      // Otherwise shouldShowStreamingBarrier (isStreamStarting || canInterrupt) drops
-      // to false for a frame and the streaming barrier unmounts then remounts.
       const workspaceId = "stream-starting-lifecycle-gap";
 
       mockChatStreamFor(workspaceId, async function* () {
         yield { type: "caught-up" };
         await Promise.resolve();
-        // Trailing user message with no assistant reply -> optimistic pending start.
         yield createUserMessageEvent("lifecycle-gap-user", "hello", 1, 1_000);
         await Promise.resolve();
-        // Stream reports "streaming" but stream-start (which populates the
-        // interruptible active stream) has not been applied yet.
         yield {
           type: "stream-lifecycle",
           workspaceId,
@@ -1846,7 +1850,6 @@ describe("WorkspaceStore", () => {
 
       const state = store.getWorkspaceState(workspaceId);
       expect(state.canInterrupt).toBe(false);
-      // The key assertion: the barrier-visibility flag stays true across the gap.
       expect(state.isStreamStarting).toBe(true);
     });
 
@@ -4648,6 +4651,70 @@ describe("WorkspaceStore", () => {
           "buffered advice"
       );
       expect(hasLiveOutput).toBe(true);
+    });
+  });
+
+  describe("advisor-reasoning-output events", () => {
+    it("accumulates live advisor reasoning while the advisor tool is running", async () => {
+      const workspaceId = "advisor-reasoning-workspace-1";
+
+      mockChatScript([
+        caughtUpEvent(),
+        Promise.resolve(),
+        advisorReasoningOutputEvent(workspaceId, "call-advisor-reasoning-1", "thinking ", 1),
+        advisorReasoningOutputEvent(workspaceId, "call-advisor-reasoning-1", "through risk", 2),
+      ]);
+
+      createAndAddWorkspace(store, workspaceId);
+
+      const hasLiveReasoning = await waitUntil(
+        () =>
+          store.getAdvisorToolLiveReasoning(workspaceId, "call-advisor-reasoning-1")?.text ===
+          "thinking through risk"
+      );
+      expect(hasLiveReasoning).toBe(true);
+
+      const live = store.getAdvisorToolLiveReasoning(workspaceId, "call-advisor-reasoning-1");
+      expect(live).toEqual({ text: "thinking through risk", timestamp: 2 });
+      expect(store.getAdvisorToolLiveReasoning(workspaceId, "call-advisor-reasoning-1")).toBe(live);
+    });
+
+    it("clears live advisor reasoning on advisor tool-call-end", async () => {
+      const workspaceId = "advisor-reasoning-workspace-2";
+      let releaseToolEnd: (() => void) | undefined;
+      const waitForToolEnd = new Promise<void>((resolve) => {
+        releaseToolEnd = resolve;
+      });
+
+      mockChatScript([
+        caughtUpEvent(),
+        Promise.resolve(),
+        advisorReasoningOutputEvent(workspaceId, "call-advisor-reasoning-2", "partial thought", 1),
+        waitForToolEnd,
+        toolCallEndEvent(
+          workspaceId,
+          "call-advisor-reasoning-2",
+          "advisor",
+          { type: "advice", advice: "final advice" },
+          { messageId: "m-advisor-reasoning-2", timestamp: 2 }
+        ),
+      ]);
+
+      createAndAddWorkspace(store, workspaceId);
+
+      const hasLiveReasoning = await waitUntil(
+        () =>
+          store.getAdvisorToolLiveReasoning(workspaceId, "call-advisor-reasoning-2")?.text ===
+          "partial thought"
+      );
+      expect(hasLiveReasoning).toBe(true);
+
+      releaseToolEnd?.();
+
+      const clearedLiveReasoning = await waitUntil(
+        () => store.getAdvisorToolLiveReasoning(workspaceId, "call-advisor-reasoning-2") === null
+      );
+      expect(clearedLiveReasoning).toBe(true);
     });
   });
 

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -44,6 +44,7 @@ import {
   isInitOutput,
   isInitStart,
   isAdvisorOutputEvent,
+  isAdvisorReasoningOutputEvent,
   isAdvisorPhaseEvent,
   isBashOutputEvent,
   isTaskCreatedEvent,
@@ -231,10 +232,13 @@ export interface AdvisorLivePhaseState {
   timestamp: number;
 }
 
-export interface AdvisorLiveOutputState {
+export interface AdvisorLiveTextState {
   text: string;
   timestamp: number;
 }
+
+export type AdvisorLiveOutputState = AdvisorLiveTextState;
+export type AdvisorLiveReasoningState = AdvisorLiveTextState;
 
 interface WorkspaceChatTransientState {
   caughtUp: boolean;
@@ -245,6 +249,7 @@ interface WorkspaceChatTransientState {
   queuedMessage: QueuedMessage | null;
   liveBashOutput: Map<string, LiveBashOutputInternal>;
   liveAdvisorOutput: Map<string, AdvisorLiveOutputState>;
+  liveAdvisorReasoning: Map<string, AdvisorLiveReasoningState>;
   liveAdvisorPhase: Map<string, AdvisorLivePhaseState>;
   liveTaskIds: Map<string, string[]>;
   autoRetryStatus: AutoRetryStatus | null;
@@ -342,6 +347,27 @@ function getBufferedActiveStreamStart(
   };
 }
 
+function appendAdvisorLiveText(
+  liveTextByToolCallId: Map<string, AdvisorLiveTextState>,
+  toolCallId: string,
+  chunk: string,
+  timestamp: number
+): boolean {
+  const prev = liveTextByToolCallId.get(toolCallId);
+  const appendedText = `${prev?.text ?? ""}${chunk}`;
+  const text =
+    appendedText.length > ADVISOR_LIVE_OUTPUT_MAX_CHARS
+      ? appendedText.slice(-ADVISOR_LIVE_OUTPUT_MAX_CHARS)
+      : appendedText;
+
+  if (prev?.text === text && prev.timestamp === timestamp) {
+    return false;
+  }
+
+  liveTextByToolCallId.set(toolCallId, { text, timestamp });
+  return true;
+}
+
 function createInitialChatTransientState(): WorkspaceChatTransientState {
   return {
     caughtUp: false,
@@ -352,6 +378,7 @@ function createInitialChatTransientState(): WorkspaceChatTransientState {
     queuedMessage: null,
     liveBashOutput: new Map(),
     liveAdvisorOutput: new Map(),
+    liveAdvisorReasoning: new Map(),
     liveAdvisorPhase: new Map(),
     liveTaskIds: new Map(),
     autoRetryStatus: null,
@@ -854,6 +881,7 @@ export class WorkspaceStore {
       // Cleanup ephemeral advisor/task state once the actual tool result is available.
       if (toolCallEnd.toolName === "advisor") {
         transient?.liveAdvisorOutput.delete(toolCallEnd.toolCallId);
+        transient?.liveAdvisorReasoning.delete(toolCallEnd.toolCallId);
         transient?.liveAdvisorPhase.delete(toolCallEnd.toolCallId);
       }
       if (toolCallEnd.toolName === "task") {
@@ -1600,7 +1628,13 @@ export class WorkspaceStore {
   ): void {
     const transient = this.chatTransientState.get(workspaceId);
     if (!transient) return;
-    if (transient.liveBashOutput.size === 0 && transient.liveAdvisorOutput.size === 0) return;
+    if (
+      transient.liveBashOutput.size === 0 &&
+      transient.liveAdvisorOutput.size === 0 &&
+      transient.liveAdvisorReasoning.size === 0
+    ) {
+      return;
+    }
 
     const activeBashToolCallIds = new Set<string>();
     const activeAdvisorToolCallIds = new Set<string>();
@@ -1618,6 +1652,12 @@ export class WorkspaceStore {
     for (const toolCallId of Array.from(transient.liveBashOutput.keys())) {
       if (!activeBashToolCallIds.has(toolCallId)) {
         transient.liveBashOutput.delete(toolCallId);
+      }
+    }
+
+    for (const toolCallId of Array.from(transient.liveAdvisorReasoning.keys())) {
+      if (!activeAdvisorToolCallIds.has(toolCallId)) {
+        transient.liveAdvisorReasoning.delete(toolCallId);
       }
     }
 
@@ -1658,6 +1698,15 @@ export class WorkspaceStore {
 
   getAdvisorToolLiveOutput(workspaceId: string, toolCallId: string): AdvisorLiveOutputState | null {
     const state = this.chatTransientState.get(workspaceId)?.liveAdvisorOutput.get(toolCallId);
+
+    return state ?? null;
+  }
+
+  getAdvisorToolLiveReasoning(
+    workspaceId: string,
+    toolCallId: string
+  ): AdvisorLiveReasoningState | null {
+    const state = this.chatTransientState.get(workspaceId)?.liveAdvisorReasoning.get(toolCallId);
 
     return state ?? null;
   }
@@ -1804,18 +1853,8 @@ export class WorkspaceStore {
         aggregatorRecency === null
           ? (activity?.recency ?? null)
           : Math.max(aggregatorRecency, activity?.recency ?? aggregatorRecency);
-      // User rationale: a brand-new chat should show its startup barrier immediately instead of
-      // flashing "Catching up"/"No Messages Yet" while the very first send is still in flight.
-      // The aggregator owns both normal user-message startup and the optimistic new-chat handoff,
-      // so the workspace only needs to ask whether the active transcript still has a pending start.
-      // A turn is "starting" from the optimistic pending-start until the stream
-      // becomes interruptible. Keying off pendingStreamStartTime — which every
-      // terminal handler (end/abort/error) clears — keeps the streaming barrier
-      // continuously mounted across the starting -> streaming handoff with no gap.
-      // Keying off streamLifecycle.phase instead would risk both a flash (a
-      // "streaming" lifecycle event can land a frame before stream-start populates
-      // the active stream, leaving neither flag set) and a stuck barrier
-      // (handleStreamEnd leaves the lifecycle snapshot non-idle).
+      // Keep the startup barrier mounted until stream-start makes the turn interruptible;
+      // stream-lifecycle can report "streaming" slightly earlier.
       const isStreamStarting =
         isActiveWorkspace &&
         !canInterrupt &&
@@ -1930,9 +1969,7 @@ export class WorkspaceStore {
         ? true
         : (activity?.streaming ?? hasInterruptibleActiveStream);
     const activePendingStreamStartTime = isActiveWorkspace ? pendingStreamStartTime : null;
-    // Mirror getWorkspaceState's starting derivation: pendingStreamStartTime is the
-    // gap-free, terminal-cleared signal that a turn is in flight but not yet
-    // interruptible. See the rationale in getWorkspaceState above.
+    // Match getWorkspaceState so the shell does not flash between lifecycle and stream-start.
     const isStreamStarting =
       isActiveWorkspace &&
       !canInterrupt &&
@@ -3869,6 +3906,7 @@ export class WorkspaceStore {
       data.type in this.bufferedEventHandlers ||
       data.type === "bash-output" ||
       data.type === "advisor-output" ||
+      data.type === "advisor-reasoning-output" ||
       data.type === "advisor-phase" ||
       data.type === "task-created"
     );
@@ -3949,6 +3987,7 @@ export class WorkspaceStore {
         // replaces history, reports no active stream, or reports a different stream ID.
         transient.liveBashOutput.clear();
         transient.liveAdvisorOutput.clear();
+        transient.liveAdvisorReasoning.clear();
         transient.liveAdvisorPhase.clear();
         transient.liveTaskIds.clear();
       }
@@ -4140,19 +4179,35 @@ export class WorkspaceStore {
       if (data.text.length === 0) return;
 
       const transient = this.assertChatTransientState(workspaceId);
-      const prev = transient.liveAdvisorOutput.get(data.toolCallId);
-      const appendedText = `${prev?.text ?? ""}${data.text}`;
-      const text =
-        appendedText.length > ADVISOR_LIVE_OUTPUT_MAX_CHARS
-          ? appendedText.slice(-ADVISOR_LIVE_OUTPUT_MAX_CHARS)
-          : appendedText;
+      if (
+        !appendAdvisorLiveText(
+          transient.liveAdvisorOutput,
+          data.toolCallId,
+          data.text,
+          data.timestamp
+        )
+      ) {
+        return;
+      }
 
-      if (prev?.text === text && prev.timestamp === data.timestamp) return;
+      this.scheduleStreamingStateBump(workspaceId);
+      return;
+    }
 
-      transient.liveAdvisorOutput.set(data.toolCallId, {
-        text,
-        timestamp: data.timestamp,
-      });
+    if (isAdvisorReasoningOutputEvent(data)) {
+      if (data.text.length === 0) return;
+
+      const transient = this.assertChatTransientState(workspaceId);
+      if (
+        !appendAdvisorLiveText(
+          transient.liveAdvisorReasoning,
+          data.toolCallId,
+          data.text,
+          data.timestamp
+        )
+      ) {
+        return;
+      }
 
       this.scheduleStreamingStateBump(workspaceId);
       return;
@@ -4432,6 +4487,27 @@ export function useAdvisorToolLiveOutput(
     () => {
       if (!workspaceId || !toolCallId) return null;
       return store.getAdvisorToolLiveOutput(workspaceId, toolCallId);
+    }
+  );
+}
+
+/**
+ * Hook to get UI-only live reasoning for a running advisor tool call.
+ */
+export function useAdvisorToolLiveReasoning(
+  workspaceId: string | undefined,
+  toolCallId: string | undefined
+): AdvisorLiveReasoningState | null {
+  const store = getStoreInstance();
+
+  return useSyncExternalStore(
+    (listener) => {
+      if (!workspaceId) return () => undefined;
+      return store.subscribeKey(workspaceId, listener);
+    },
+    () => {
+      if (!workspaceId || !toolCallId) return null;
+      return store.getAdvisorToolLiveReasoning(workspaceId, toolCallId);
     }
   );
 }

--- a/src/common/orpc/schemas.ts
+++ b/src/common/orpc/schemas.ts
@@ -230,6 +230,7 @@ export {
   BashOutputEventSchema,
   TaskCreatedEventSchema,
   AdvisorOutputEventSchema,
+  AdvisorReasoningOutputEventSchema,
   AdvisorPhaseEventSchema,
   UpdateStatusSchema,
   UsageDeltaEventSchema,

--- a/src/common/orpc/schemas/stream.ts
+++ b/src/common/orpc/schemas/stream.ts
@@ -392,6 +392,20 @@ export const AdvisorOutputEventSchema = z.object({
 });
 
 /**
+ * UI-only incremental reasoning from the advisor tool.
+ *
+ * This is intentionally NOT part of the tool result returned to the model.
+ * It is streamed over workspace.onChat so users can see advisor thinking while it is generated.
+ */
+export const AdvisorReasoningOutputEventSchema = z.object({
+  type: z.literal("advisor-reasoning-output"),
+  workspaceId: z.string(),
+  toolCallId: z.string(),
+  text: z.string(),
+  timestamp: z.number().meta({ description: "When reasoning output was received (Date.now())" }),
+});
+
+/**
  * UI-only notification that a task tool call has created a child workspace.
  *
  * This is intentionally NOT part of the tool result returned to the model.
@@ -603,6 +617,7 @@ export const WorkspaceChatMessageSchema = z.discriminatedUnion("type", [
   ToolCallEndEventSchema,
   BashOutputEventSchema,
   AdvisorOutputEventSchema,
+  AdvisorReasoningOutputEventSchema,
   TaskCreatedEventSchema,
   AdvisorPhaseEventSchema,
   // Reasoning events

--- a/src/common/orpc/types.ts
+++ b/src/common/orpc/types.ts
@@ -11,6 +11,7 @@ import type {
   ToolCallDeltaEvent,
   ToolCallEndEvent,
   AdvisorOutputEvent,
+  AdvisorReasoningOutputEvent,
   AdvisorPhaseEvent,
   BashOutputEvent,
   TaskCreatedEvent,
@@ -107,6 +108,12 @@ export function isBashOutputEvent(msg: WorkspaceChatMessage): msg is BashOutputE
 
 export function isAdvisorOutputEvent(msg: WorkspaceChatMessage): msg is AdvisorOutputEvent {
   return (msg as { type?: string }).type === "advisor-output";
+}
+
+export function isAdvisorReasoningOutputEvent(
+  msg: WorkspaceChatMessage
+): msg is AdvisorReasoningOutputEvent {
+  return (msg as { type?: string }).type === "advisor-reasoning-output";
 }
 
 export function isTaskCreatedEvent(msg: WorkspaceChatMessage): msg is TaskCreatedEvent {

--- a/src/common/types/stream.ts
+++ b/src/common/types/stream.ts
@@ -26,6 +26,7 @@ import type {
   ToolCallStartEventSchema,
   BashOutputEventSchema,
   AdvisorOutputEventSchema,
+  AdvisorReasoningOutputEventSchema,
   TaskCreatedEventSchema,
   AdvisorPhaseEventSchema,
   UsageDeltaEventSchema,
@@ -66,6 +67,7 @@ export type ErrorEvent = z.infer<typeof ErrorEventSchema>;
 
 export type BashOutputEvent = z.infer<typeof BashOutputEventSchema>;
 export type AdvisorOutputEvent = z.infer<typeof AdvisorOutputEventSchema>;
+export type AdvisorReasoningOutputEvent = z.infer<typeof AdvisorReasoningOutputEventSchema>;
 export type TaskCreatedEvent = z.infer<typeof TaskCreatedEventSchema>;
 export type AdvisorPhaseEvent = z.infer<typeof AdvisorPhaseEventSchema>;
 export type ToolCallStartEvent = z.infer<typeof ToolCallStartEventSchema>;

--- a/src/node/acp/agent.ts
+++ b/src/node/acp/agent.ts
@@ -1518,6 +1518,7 @@ export class MuxAgent implements Agent {
         event.type === "usage-delta" ||
         event.type === "session-usage-delta" ||
         event.type === "advisor-output" ||
+        event.type === "advisor-reasoning-output" ||
         event.type === "bash-output" ||
         event.type === "init-output" ||
         // Drop replay history messages under saturation, but keep live message

--- a/src/node/acp/streamTranslator.ts
+++ b/src/node/acp/streamTranslator.ts
@@ -181,19 +181,9 @@ export class StreamTranslator {
         ];
       }
 
-      case "advisor-output": {
-        return [
-          {
-            sessionUpdate: "tool_call_update",
-            toolCallId: event.toolCallId,
-            status: "in_progress",
-            content: [textToolContent(event.text)],
-            _meta: {
-              source: "advisor-output",
-              timestamp: event.timestamp,
-            },
-          },
-        ];
+      case "advisor-output":
+      case "advisor-reasoning-output": {
+        return this.translateAdvisorTextToolCallUpdate(event);
       }
 
       case "error":
@@ -443,6 +433,23 @@ export class StreamTranslator {
       return undefined;
     }
     return [textToolContent(text)];
+  }
+
+  private translateAdvisorTextToolCallUpdate(
+    event: Extract<WorkspaceChatMessage, { type: "advisor-output" | "advisor-reasoning-output" }>
+  ): SessionUpdate[] {
+    return [
+      {
+        sessionUpdate: "tool_call_update",
+        toolCallId: event.toolCallId,
+        status: "in_progress",
+        content: [textToolContent(event.text)],
+        _meta: {
+          source: event.type,
+          timestamp: event.timestamp,
+        },
+      },
+    ];
   }
 
   private translatePlanUpdate(

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -3474,11 +3474,8 @@ export class AgentSession {
     this.activeStreamHadPostCompactionInjection =
       postCompactionAttachments !== null && postCompactionAttachments.length > 0;
 
-    // Enforce thinking policy for the specified model (single source of truth)
-    // This ensures model-specific requirements are met regardless of where the request originates.
-    // Apply the per-model minimum thinking floor here so every client (desktop, mobile, ACP)
-    // honors it: a stored/below-floor "off" is clamped up to the model's minimum (default medium).
-    // config may be a partial mock in tests, so read loadConfigOrDefault defensively.
+    // Apply per-model thinking floors once so desktop, mobile, and ACP requests match.
+    // Tests may provide partial config mocks, so read overrides only when available.
     const maybeConfig = this.config as Config & {
       loadConfigOrDefault?: () => {
         minThinkingLevelByModel?: Record<string, ThinkingLevel>;
@@ -4360,6 +4357,10 @@ export class AgentSession {
       this.emitChatEvent(payload);
     });
     forward("advisor-output", (payload) => {
+      this.markActiveStreamHadAnyOutput();
+      this.emitChatEvent(payload);
+    });
+    forward("advisor-reasoning-output", (payload) => {
       this.markActiveStreamHadAnyOutput();
       this.emitChatEvent(payload);
     });

--- a/src/node/services/tools/advisor.test.ts
+++ b/src/node/services/tools/advisor.test.ts
@@ -232,7 +232,8 @@ describe("advisor tool", () => {
         { type: "text-delta", delta: "with " },
         { type: "text-delta", textDelta: "the risky edge first." },
         { type: "text-delta", text: "" },
-        { type: "reasoning-delta", delta: "hidden reasoning" },
+        { type: "reasoning", text: "hidden reasoning" },
+        { type: "reasoning-delta", delta: " plus delta" },
       ],
       usage: {
         inputTokens: 40,
@@ -270,6 +271,22 @@ describe("advisor tool", () => {
         .filter((call) => call[0].type === "advisor-output")
         .map((call) => call[0])
     ).toHaveLength(3);
+    expect(emitChatEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "advisor-reasoning-output",
+        workspaceId: "workspace-1",
+        toolCallId: "test-call-id",
+        text: "hidden reasoning",
+      })
+    );
+    expect(emitChatEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "advisor-reasoning-output",
+        workspaceId: "workspace-1",
+        toolCallId: "test-call-id",
+        text: " plus delta",
+      })
+    );
   });
 
   it("falls back to the raw transcript when there is no question or same-step snapshot", async () => {

--- a/src/node/services/tools/advisor.ts
+++ b/src/node/services/tools/advisor.ts
@@ -13,7 +13,11 @@ import { buildProviderOptions } from "@/common/utils/ai/providerOptions";
 import { extractChunkDeltaText } from "@/common/utils/ai/streamChunks";
 import { getErrorMessage } from "@/common/utils/errors";
 import { sanitizeErrorMessageForDisplay } from "@/common/utils/providerOutputSanitization";
-import type { AdvisorOutputEvent, AdvisorPhaseEvent } from "@/common/types/stream";
+import type {
+  AdvisorOutputEvent,
+  AdvisorPhaseEvent,
+  AdvisorReasoningOutputEvent,
+} from "@/common/types/stream";
 import { AdvisorToolInputSchema, TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
 import type { AdvisorToolCallSnapshot, ToolConfiguration } from "@/common/utils/tools/tools";
 import { log } from "@/node/services/log";
@@ -78,18 +82,33 @@ function buildAdvisorHandoffMessage(
   };
 }
 
-function getAdvisorTextDelta(chunk: unknown): string | undefined {
+const ADVISOR_DELTA_TEXT_FIELDS = ["text", "delta", "textDelta"] as const;
+const ADVISOR_TEXT_DELTA_TYPES = ["text-delta", "text"] as const;
+const ADVISOR_REASONING_DELTA_TYPES = ["reasoning-delta", "reasoning"] as const;
+
+function getAdvisorChunkDelta(
+  chunk: unknown,
+  acceptedTypes: readonly string[]
+): string | undefined {
   if (typeof chunk !== "object" || chunk === null) {
     return undefined;
   }
 
   const record = chunk as Record<string, unknown>;
-  if (record.type !== "text-delta" && record.type !== "text") {
+  if (typeof record.type !== "string" || !acceptedTypes.includes(record.type)) {
     return undefined;
   }
 
-  const text = extractChunkDeltaText(record, ["text", "delta", "textDelta"]);
+  const text = extractChunkDeltaText(record, ADVISOR_DELTA_TEXT_FIELDS);
   return text.length > 0 ? text : undefined;
+}
+
+function getAdvisorTextDelta(chunk: unknown): string | undefined {
+  return getAdvisorChunkDelta(chunk, ADVISOR_TEXT_DELTA_TYPES);
+}
+
+function getAdvisorReasoningDelta(chunk: unknown): string | undefined {
+  return getAdvisorChunkDelta(chunk, ADVISOR_REASONING_DELTA_TYPES);
 }
 
 export function createAdvisorTool(config: ToolConfiguration): Tool {
@@ -171,6 +190,21 @@ export function createAdvisorTool(config: ToolConfiguration): Tool {
         } satisfies AdvisorOutputEvent);
       };
 
+      const emitAdvisorReasoningOutput = (text: string): void => {
+        assert(text.length > 0, "advisor reasoning output chunks must be non-empty");
+        if (!config.emitChatEvent || !config.workspaceId || !toolCallId) {
+          return;
+        }
+
+        config.emitChatEvent({
+          type: "advisor-reasoning-output",
+          workspaceId: config.workspaceId,
+          toolCallId,
+          text,
+          timestamp: Date.now(),
+        } satisfies AdvisorReasoningOutputEvent);
+      };
+
       emitAdvisorPhase("preparing_context");
 
       if (runtime.maxUsesPerTurn !== null && usesThisTurn >= runtime.maxUsesPerTurn) {
@@ -216,6 +250,12 @@ export function createAdvisorTool(config: ToolConfiguration): Tool {
             advisorStreamError = error;
           },
           onChunk: ({ chunk }) => {
+            const reasoningText = getAdvisorReasoningDelta(chunk);
+            if (reasoningText != null) {
+              emitAdvisorReasoningOutput(reasoningText);
+              return;
+            }
+
             const text = getAdvisorTextDelta(chunk);
             if (text == null) {
               return;


### PR DESCRIPTION
## Summary

Surface nested advisor model reasoning deltas in the advisor tool UI as transient, tool-scoped **Thinking** output while keeping advisor **Advice** separate and final tool results clean.

## Background

GPT-5 Pro advisor calls can emit reasoning chunks before final advice, but the previous advisor streaming path only forwarded text/advice chunks. This made Debug Logs show advisor activity while the main advisor tool card appeared idle during long advisor runs.

## Implementation

- Added a UI-only `advisor-reasoning-output` stream event and shared schema/type plumbing.
- Forward nested advisor `reasoning-delta` chunks from the backend advisor tool without appending them to final advice.
- Store live advisor reasoning transiently by `toolCallId`, clear it on advisor tool completion, and render it under a separate **Thinking** section.
- Forward advisor reasoning progress through ACP as in-progress tool updates.
- Added backend, store, and UI coverage for the new event path.

## Validation

- `bun test src/node/services/tools/advisor.test.ts`
- `bun test src/browser/features/Tools/AdvisorToolCall.test.tsx`
- `bun test src/browser/stores/WorkspaceStore.test.ts`
- `make static-check`
- Dogfooded in an isolated dev-server sandbox with a local OpenAI-compatible mock provider emitting `reasoning_content` through the real backend advisor stream path.
  - Key evidence captured under `dogfood-output/screenshots/` and `dogfood-output/videos/` in the implementation workspace.

## Risks

Low-to-medium risk, scoped to live advisor tool progress rendering and stream-event plumbing. The final advisor tool result remains unchanged, and reasoning is transient UI state rather than persisted tool output.

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: surface advisor GPT-5 Pro thinking chunks in the Mux UI

## Investigation summary

### Verified root cause

The advisor live-streaming path exists, but it only forwards advisor **answer text** chunks. It drops nested advisor `reasoning-delta` / thinking chunks before they ever reach the main UI.

Evidence from read-only exploration:

- `src/node/services/tools/advisor.ts`
  - `createAdvisorTool()` runs a nested `streamText()` call for the advisor model.
  - `getAdvisorTextDelta()` only accepts chunk types `"text-delta"` and `"text"`.
  - The advisor `onChunk` callback emits `advisor-output` only when `getAdvisorTextDelta()` returns text.
  - Result: GPT-5 Pro `reasoning-delta` chunks are ignored for UI purposes.
- `src/common/orpc/schemas/stream.ts`
  - `AdvisorOutputEventSchema` contains only `{ text }`; it has no reasoning/thinking channel.
  - Normal assistant `reasoning-delta` events are message-scoped, not advisor tool-call-scoped.
- `src/browser/stores/WorkspaceStore.ts`
  - The browser tracks only transient `liveAdvisorOutput: { text, timestamp }` and `liveAdvisorPhase` keyed by `toolCallId`.
  - It appends only `advisor-output.text`, then clears that transient advisor state on `tool-call-end`.
- `src/browser/features/Tools/AdvisorToolCall.tsx`
  - The running advisor UI subscribes to `useAdvisorToolLiveOutput()` and renders live content only as an `Advice` section when text exists.
  - There is no place to render advisor-scoped reasoning/thinking chunks.
- `src/node/services/devToolsMiddleware.ts`
  - Debug/devtools capture records provider chunks including `reasoning-start`, `reasoning-delta`, and `reasoning-end`, which explains why debug logs show activity while the main advisor UI remains visually idle.

So the inconsistency is not that the frontend misses already-emitted advisor chunks. The backend advisor tool never emits reasoning chunks into the chat UI event stream, and the frontend schema/state cannot represent them anyway.

## Recommended approach

Implement a separate **tool-scoped advisor reasoning live stream** and render it separately from final/live advice.

**Net product LoC estimate:** ~140-230 LoC.

Why this is the best default:

- Preserves the meaning of existing `advisor-output` as final-answer/advice text.
- Avoids misleadingly mixing thinking text into the `Advice` markdown block.
- Mirrors the existing main-assistant `reasoning-delta` support while respecting that advisor streams are nested tool-call streams keyed by `toolCallId`, not assistant `messageId`.
- Keeps reasoning transient by default, matching existing advisor live output behavior.

## Implementation plan

### Phase 1: Add advisor reasoning event plumbing

1. Add a new UI-only stream event schema in `src/common/orpc/schemas/stream.ts`, for example:
   - `type: "advisor-reasoning-output"`
   - `workspaceId`
   - `toolCallId`
   - `text` or `delta`
   - `timestamp`
2. Include the new event in the stream event union and any event helper/type guard lists.
3. Add backend forwarding for the event wherever `advisor-output` / `advisor-phase` are currently forwarded, including `src/node/services/agentSession.ts`.
4. If ACP clients should receive this progress too, add a droppable in-progress translation in `src/node/acp/streamTranslator.ts`; otherwise explicitly leave ACP unchanged and document it in the code review notes.

**Quality gate:** typecheck should catch every union exhaustiveness miss before moving on.

### Phase 2: Emit advisor reasoning chunks from the nested advisor stream

1. In `src/node/services/tools/advisor.ts`, add a companion extractor for reasoning chunks, analogous to the main stream handling in `src/node/services/streamManager.ts`:
   - accept `chunk.type === "reasoning-delta"`
   - extract `text ?? delta ?? textDelta ?? ""`
   - assert/guard that extracted data is a string before emitting
2. Add `emitAdvisorReasoningOutput()` next to `emitAdvisorOutput()`.
3. In the advisor `onChunk`, emit:
   - existing `advisor-output` for `text` / `text-delta`
   - new `advisor-reasoning-output` for `reasoning-delta`
4. Do **not** append reasoning deltas to `streamedAdviceChunks`; final tool results should remain final advice only.

**Quality gate:** update/add `src/node/services/tools/advisor.test.ts` so a simulated `reasoning-delta` chunk produces an advisor reasoning event and does not pollute the final `advice` result.

### Phase 3: Store advisor reasoning as transient UI state

1. In `src/browser/stores/WorkspaceStore.ts`, add transient advisor reasoning state keyed by `toolCallId`, parallel to `liveAdvisorOutput`.
2. Process `advisor-reasoning-output` by appending text to that transient buffer and bumping streaming state.
3. Clear advisor reasoning state on advisor `tool-call-end` alongside `liveAdvisorOutput` and `liveAdvisorPhase`.
4. Add a selector/hook such as `getAdvisorToolLiveReasoning()` / `useAdvisorToolLiveReasoning()`.

**Quality gate:** add store coverage showing reasoning chunks accumulate while running and are cleared after the advisor tool call completes.

### Phase 4: Render live advisor thinking in the tool UI

1. In `src/browser/features/Tools/AdvisorToolCall.tsx`, subscribe to the new live advisor reasoning hook.
2. While the advisor is executing and no final result exists, render accumulated reasoning in a distinct section such as `Thinking` or `Reasoning`.
3. Keep existing live/final `Advice` rendering unchanged for advisor text chunks and final result text.
4. Prefer the simplest UI:
   - show phase/elapsed status in the header as today
   - show `Thinking` above `Advice` when reasoning exists
   - do not persist completed reasoning after the final result unless explicitly requested later

**Quality gate:** update `src/browser/features/Tools/AdvisorToolCall.test.tsx` to verify live reasoning renders under a separate label and live advice still renders as advice.

### Phase 5: Validate with targeted and broad checks

Run, at minimum:

1. Targeted backend tests for advisor stream event emission.
2. Targeted frontend/store/tool-call tests for advisor reasoning rendering.
3. `make typecheck`.
4. `make lint` or `make static-check` if time permits / before PR submission.

Do not claim success until these pass, or report exact blockers.

## Dogfooding plan

Skill guidance applied:

- Use `make dev-server-sandbox` so the dogfood run has an isolated temporary `MUX_ROOT`, free `BACKEND_PORT` / `VITE_PORT`, and no conflict with the user's live Mux instance.
- Use the direct `agent-browser` binary, never `npx agent-browser`.
- Before browser automation, load the installed CLI's current workflow with `agent-browser skills get core`.
- Use `agent-browser snapshot -i` before interacting, re-snapshot after page changes because refs become stale, and prefer semantic waits (`wait --load networkidle`, `wait --text`, `wait --url`) over fixed sleeps except for human-paced video evidence.
- Capture reproducible evidence as the dogfood skill requires: annotated screenshots plus a short video for the interactive advisor-streaming behavior.

Recommended dogfood flow:

1. Start an isolated dev-server sandbox from the implementation worktree:
   - Prefer `make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-projects"` so provider config is available for GPT-5 Pro but test projects do not leak from the seed config.
   - Use `SEED_MUX_ROOT=~/.mux-dev` if the implementer needs to seed from a known dev config.
   - Use `KEEP_SANDBOX=1` only when preserving the sandbox for debugging is useful.
2. Note the sandbox's printed app URL / Vite URL and open it with a named agent-browser session:
   - `agent-browser --session advisor-streaming open <sandbox-url>`
   - `agent-browser --session advisor-streaming wait --load networkidle`
3. Orient and record baseline state:
   - `agent-browser --session advisor-streaming snapshot -i`
   - `agent-browser --session advisor-streaming screenshot --annotate dogfood-output/screenshots/initial.png`
   - `agent-browser --session advisor-streaming console`
   - `agent-browser --session advisor-streaming errors`
4. Configure/select an advisor model that emits reasoning chunks, e.g. GPT-5 Pro with high reasoning, in a disposable test workspace.
5. Start video before reproducing the issue/fix:
   - `agent-browser --session advisor-streaming record start dogfood-output/videos/advisor-reasoning-live.webm`
6. Trigger an advisor call from Plan Mode with a prompt likely to produce sustained reasoning.
7. While the advisor call is still in flight, open Debug Logs side-by-side with the advisor tool call and verify:
   - Debug Logs show provider `Thinking` / `reasoning-delta` chunks.
   - The main advisor tool call simultaneously shows live `Thinking` / `Reasoning`, not only a blank pending card.
   - Live advice text, if/when emitted, appears separately from reasoning.
8. Capture evidence at human-reviewable pacing:
   - screenshot while the advisor is still running and reasoning is visible in the main UI
   - screenshot with Debug Logs and advisor tool UI visible together
   - screenshot after final advice arrives showing final advice remains clean
   - stop the video with `agent-browser --session advisor-streaming record stop`
9. Re-check `agent-browser --session advisor-streaming console` and `agent-browser --session advisor-streaming errors`; fix any new console/runtime errors before claiming success.
10. Close the session with `agent-browser --session advisor-streaming close` after evidence is captured.

Dogfood acceptance evidence:

- `dogfood-output/screenshots/initial.png`
- annotated in-flight screenshot showing live advisor reasoning in the main tool UI
- screenshot showing Debug Logs reasoning chunks and main UI reasoning visible at the same time
- post-completion screenshot showing final advice is not polluted by reasoning text
- `dogfood-output/videos/advisor-reasoning-live.webm`

## Acceptance criteria

- During an advisor GPT-5 Pro run that emits `reasoning-delta` chunks, the main Mux advisor tool UI shows live thinking/reasoning activity before final advice arrives.
- Debug Logs and the main UI no longer disagree about whether advisor streaming activity is happening.
- Advisor reasoning is visually separated from advisor advice.
- Final advisor tool result remains the final advice text only; transient reasoning does not pollute persisted tool results.
- Existing advisor live `advisor-output` behavior continues to work for text chunks.
- Targeted backend and frontend tests cover the new reasoning event path.
- Typecheck and relevant tests pass.

## Alternatives considered

### Alternative A: Reuse `advisor-output` for reasoning deltas

**Net product LoC estimate:** ~25-60 LoC.

Pros:

- Smallest code change.
- Would make something visible quickly.

Cons:

- Mixes reasoning into an `Advice` section.
- Risks final/live advice confusion.
- Changes the semantic meaning of `advisor-output` and may surprise ACP/UI consumers.

Recommendation: avoid unless the goal is a temporary local debugging patch only.

### Alternative B: Emit only reasoning heartbeat/progress, not text

**Net product LoC estimate:** ~60-110 LoC.

Pros:

- Safer if raw provider reasoning text should not be exposed.
- Fixes the “black box for 10-15 minutes” perception with lower privacy risk.

Cons:

- Does not satisfy the expectation that visible thinking chunks should appear in the UI.
- Debug logs would still contain richer content than the main UI.

Recommendation: use this only if product/privacy review decides advisor reasoning text must not be shown.

### Alternative C: Persist advisor reasoning in final tool results

**Net product LoC estimate:** ~180-300 LoC.

Pros:

- Completed advisor calls would retain the reasoning transcript.

Cons:

- Larger history/schema change.
- Potential privacy and storage concerns.
- Not necessary to solve the in-flight black-box problem.

Recommendation: defer unless explicitly requested.

## Risks and mitigations

- **Provider reasoning policy / chain-of-thought risk:** only forward textual reasoning chunks that the provider API exposes through the same public stream shape already visible in debug logs; label them clearly and keep them transient. If this is not acceptable, choose Alternative B.
- **High-frequency UI updates:** use the same buffering/batched update pattern as `advisor-output`; if ACP forwarding is added, make the event droppable under backpressure like other live progress events.
- **Ordering between reasoning and advice:** separate buffers are simpler but do not preserve exact interleaving. That is acceptable for the minimal fix because the UI sections are semantically distinct.
- **Regression risk in existing advisor output:** add tests ensuring current live advice text still appears and final advice is unchanged.

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$71.20`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=71.20 -->
