### PR TITLE
🤖 feat: immersive review assisted-mode badge + agent status bar

### DIFF
--- a/src/browser/components/TodoList/TodoList.tsx
+++ b/src/browser/components/TodoList/TodoList.tsx
@@ -68,6 +68,13 @@ function calculateTextOpacity(
 
 interface TodoListProps {
   todos: TodoItem[];
+  /**
+   * Orientation of the list:
+   *  - "vertical" (default): stacked rows — used by the pinned list and tool history.
+   *  - "horizontal": a single horizontally-scrolling row of compact chips, used by the
+   *    immersive review status bar to keep the plan to one row of vertical space.
+   */
+  layout?: "vertical" | "horizontal";
 }
 
 function getStatusIcon(status: TodoItem["status"]): React.ReactNode {
@@ -87,7 +94,8 @@ function getStatusIcon(status: TodoItem["status"]): React.ReactNode {
  * - TodoToolCall (in expanded tool history)
  * - PinnedTodoList (pinned at bottom of chat)
  */
-export const TodoList: React.FC<TodoListProps> = ({ todos }) => {
+export const TodoList: React.FC<TodoListProps> = ({ todos, layout = "vertical" }) => {
+  const isHorizontal = layout === "horizontal";
   // Count completed and pending items for fade effects
   const completedCount = todos.filter((t) => t.status === "completed").length;
   const pendingCount = todos.filter((t) => t.status === "pending").length;
@@ -95,7 +103,16 @@ export const TodoList: React.FC<TodoListProps> = ({ todos }) => {
   let pendingIndex = 0;
 
   return (
-    <div className="flex flex-col gap-[3px] px-2 py-1.5">
+    <div
+      className={cn(
+        "px-2 py-1.5",
+        isHorizontal
+          ? // Single row, horizontal scroll: stays one row tall no matter how many
+            // todos so the immersive bar reserves minimal review height.
+            "flex flex-row gap-1.5 overflow-x-auto"
+          : "flex flex-col gap-[3px]"
+      )}
+    >
       {todos.map((todo, index) => {
         const currentCompletedIndex = todo.status === "completed" ? completedIndex++ : undefined;
         const currentPendingIndex = todo.status === "pending" ? pendingIndex++ : undefined;
@@ -111,14 +128,19 @@ export const TodoList: React.FC<TodoListProps> = ({ todos }) => {
         return (
           <div
             key={index}
-            className="font-monospace flex items-start gap-1.5 rounded border-l-2 px-2 py-1 text-[11px] leading-[1.35]"
+            className={cn(
+              "font-monospace flex gap-1.5 rounded border-l-2 px-2 py-1 text-[11px] leading-[1.35]",
+              isHorizontal ? "max-w-[220px] shrink-0 items-center" : "items-start"
+            )}
             style={{
               background: statusBgColors[todo.status],
               borderLeftColor: statusBorderColors[todo.status],
               color: "var(--color-text)",
             }}
           >
-            <div className="mt-px shrink-0 text-xs opacity-80">{getStatusIcon(todo.status)}</div>
+            <div className={cn("shrink-0 text-xs opacity-80", !isHorizontal && "mt-px")}>
+              {getStatusIcon(todo.status)}
+            </div>
             <div className="min-w-0 flex-1">
               <div
                 title={todo.content}

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.test.tsx
@@ -122,7 +122,7 @@ describe("ImmersiveReviewAgentStatusBar", () => {
   test("renders the TODO plan (expanded) when todos exist", () => {
     seed("ws-todos", { todos });
     const result = renderBar("ws-todos");
-    // Vertical TodoList content is visible by default.
+    // The horizontal TodoList strip is visible by default.
     expect(result.getByText("Wire up status bar")).toBeTruthy();
     expect(result.getByText("Add tests")).toBeTruthy();
     // Summary reflects the counts.
@@ -162,7 +162,7 @@ describe("ImmersiveReviewAgentStatusBar", () => {
     seed(workspaceId, { todos });
     const first = renderBar(workspaceId);
 
-    // Plan is expanded by default; collapsing hides the vertical list.
+    // Plan is expanded by default; collapsing hides the horizontal strip.
     expect(first.getByText("Wire up status bar")).toBeTruthy();
     fireEvent.click(first.getByRole("button", { name: /todo/i }));
     expect(first.queryByText("Wire up status bar")).toBeNull();

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
-import { cleanup, fireEvent, render, type RenderResult } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, type RenderResult } from "@testing-library/react";
+import { Profiler } from "react";
 
 import { installDom } from "../../../../../tests/ui/dom";
 // Import the module namespace (not the hook directly) so we can spyOn the hook
@@ -66,6 +67,31 @@ function buildState(workspaceId: string, input: SeedInput): WorkspaceState {
 
 function seed(workspaceId: string, input: SeedInput): void {
   seeds.set(workspaceId, buildState(workspaceId, input));
+}
+
+function notify(workspaceId: string): void {
+  getSubscribers(workspaceId).forEach((cb) => cb());
+}
+
+/**
+ * Replace the cached state with a NEW object reference whose watched fields
+ * (todos/canInterrupt/isStreamStarting/awaitingUserQuestion) are byte-identical
+ * (todos keeps the same array ref), then notify subscribers — models an
+ * unrelated WorkspaceState bump such as a streamed message arriving.
+ */
+function bumpUnrelated(workspaceId: string): void {
+  const prev = seeds.get(workspaceId);
+  if (!prev) throw new Error(`Missing seed for ${workspaceId}`);
+  seeds.set(workspaceId, { ...prev, name: `${prev.name}-bump`, messages: [...prev.messages] });
+  notify(workspaceId);
+}
+
+/** Patch a watched field on the cached state and notify subscribers. */
+function patchState(workspaceId: string, patch: Partial<WorkspaceState>): void {
+  const prev = seeds.get(workspaceId);
+  if (!prev) throw new Error(`Missing seed for ${workspaceId}`);
+  seeds.set(workspaceId, { ...prev, ...patch });
+  notify(workspaceId);
 }
 
 // Minimal fake exposing only the store methods the bar calls. Cast through
@@ -178,5 +204,40 @@ describe("ImmersiveReviewAgentStatusBar", () => {
     // Re-expanding brings the plan back, proving the toggle round-trips.
     fireEvent.click(second.getByRole("button", { name: /todo/i }));
     expect(second.getByText("Wire up status bar")).toBeTruthy();
+  });
+
+  test("does not re-render on unrelated workspace-state bumps, only on watched fields", () => {
+    const workspaceId = "ws-stable";
+    seed(workspaceId, { todos, canInterrupt: true });
+
+    let commits = 0;
+    const result = render(
+      <Profiler
+        id="bar"
+        onRender={() => {
+          commits += 1;
+        }}
+      >
+        <ImmersiveReviewAgentStatusBar workspaceId={workspaceId} />
+      </Profiler>
+    );
+    expect(result.getByText("Streaming…")).toBeTruthy();
+
+    // An unrelated state bump (new WorkspaceState ref, same watched fields)
+    // must NOT re-render the bar — this is the leaf-subscription guarantee that
+    // keeps streamed-message churn off the immersive diff's sibling bar.
+    const committedAfterMount = commits;
+    act(() => {
+      bumpUnrelated(workspaceId);
+      bumpUnrelated(workspaceId);
+    });
+    expect(commits).toBe(committedAfterMount);
+
+    // Changing a field the bar actually reads DOES re-render it.
+    act(() => {
+      patchState(workspaceId, { awaitingUserQuestion: true });
+    });
+    expect(commits).toBeGreaterThan(committedAfterMount);
+    expect(result.getByText("Mux has a question")).toBeTruthy();
   });
 });

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.test.tsx
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render, type RenderResult } from "@testing-library/react";
+import { GlobalWindow } from "happy-dom";
+
+import { readPersistedState } from "@/browser/hooks/usePersistedState";
+import {
+  useWorkspaceStoreRaw as getWorkspaceStoreRaw,
+  type WorkspaceSidebarState,
+  type WorkspaceState,
+} from "@/browser/stores/WorkspaceStore";
+import { getImmersiveReviewAgentBarExpandedKey } from "@/common/constants/storage";
+import type { TodoItem } from "@/common/types/tools";
+import { ImmersiveReviewAgentStatusBar } from "./ImmersiveReviewAgentStatusBar";
+
+interface SeedInput {
+  todos: TodoItem[];
+  canInterrupt?: boolean;
+  isStarting?: boolean;
+  awaitingUserQuestion?: boolean;
+}
+
+interface SeedCache {
+  state: WorkspaceState;
+  sidebar: WorkspaceSidebarState;
+}
+
+// Cache the built snapshots per workspace so getWorkspaceState/getWorkspaceSidebarState
+// return referentially-stable objects (useSyncExternalStore would otherwise loop).
+const seeds = new Map<string, SeedCache>();
+const subscribers = new Map<string, Set<() => void>>();
+
+function getSubscribers(workspaceId: string): Set<() => void> {
+  let set = subscribers.get(workspaceId);
+  if (!set) {
+    set = new Set();
+    subscribers.set(workspaceId, set);
+  }
+  return set;
+}
+
+function buildState(workspaceId: string, input: SeedInput): WorkspaceState {
+  return {
+    name: workspaceId,
+    messages: [],
+    queuedMessage: null,
+    canInterrupt: input.canInterrupt ?? false,
+    isCompacting: false,
+    isStreamStarting: input.isStarting ?? false,
+    awaitingUserQuestion: input.awaitingUserQuestion ?? false,
+    loading: false,
+    isHydratingTranscript: false,
+    hasOlderHistory: false,
+    loadingOlderHistory: false,
+    muxMessages: [],
+    currentModel: null,
+    currentThinkingLevel: null,
+    recencyTimestamp: null,
+    todos: input.todos,
+    loadedSkills: [],
+    skillLoadErrors: [],
+    agentStatus: undefined,
+    lastAbortReason: null,
+    pendingStreamStartTime: null,
+    pendingStreamModel: null,
+    runtimeStatus: null,
+    autoRetryStatus: null,
+  };
+}
+
+function buildSidebar(input: SeedInput): WorkspaceSidebarState {
+  return {
+    canInterrupt: input.canInterrupt ?? false,
+    isStarting: input.isStarting ?? false,
+    awaitingUserQuestion: input.awaitingUserQuestion ?? false,
+    lastAbortReason: null,
+    currentModel: null,
+    pendingStreamModel: null,
+    recencyTimestamp: null,
+    loadedSkills: [],
+    skillLoadErrors: [],
+    agentStatus: undefined,
+    terminalActiveCount: 0,
+    terminalSessionCount: 0,
+    goal: null,
+  };
+}
+
+function seed(workspaceId: string, input: SeedInput): void {
+  seeds.set(workspaceId, {
+    state: buildState(workspaceId, input),
+    sidebar: buildSidebar(input),
+  });
+}
+
+const store = getWorkspaceStoreRaw();
+const original = {
+  hasRegisteredWorkspace: store.hasRegisteredWorkspace.bind(store),
+  subscribeKey: store.subscribeKey.bind(store),
+  getWorkspaceState: store.getWorkspaceState.bind(store),
+  getWorkspaceSidebarState: store.getWorkspaceSidebarState.bind(store),
+};
+
+function renderBar(workspaceId: string): RenderResult {
+  return render(<ImmersiveReviewAgentStatusBar workspaceId={workspaceId} />);
+}
+
+describe("ImmersiveReviewAgentStatusBar", () => {
+  let originalWindow: typeof globalThis.window;
+  let originalDocument: typeof globalThis.document;
+  let originalLocalStorage: typeof globalThis.localStorage;
+
+  beforeEach(() => {
+    originalWindow = globalThis.window;
+    originalDocument = globalThis.document;
+    originalLocalStorage = globalThis.localStorage;
+
+    globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
+    globalThis.document = globalThis.window.document;
+    globalThis.localStorage = globalThis.window.localStorage;
+    globalThis.localStorage.clear();
+    seeds.clear();
+    subscribers.clear();
+
+    store.hasRegisteredWorkspace = (id: string) => seeds.has(id);
+    store.subscribeKey = (id: string, cb: () => void) => {
+      const set = getSubscribers(id);
+      set.add(cb);
+      return () => {
+        set.delete(cb);
+      };
+    };
+    store.getWorkspaceState = (id: string) => {
+      const cache = seeds.get(id);
+      if (!cache) throw new Error(`Missing seed for ${id}`);
+      return cache.state;
+    };
+    store.getWorkspaceSidebarState = (id: string) => {
+      const cache = seeds.get(id);
+      if (!cache) throw new Error(`Missing seed for ${id}`);
+      return cache.sidebar;
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+    store.hasRegisteredWorkspace = original.hasRegisteredWorkspace;
+    store.subscribeKey = original.subscribeKey;
+    store.getWorkspaceState = original.getWorkspaceState;
+    store.getWorkspaceSidebarState = original.getWorkspaceSidebarState;
+    globalThis.window = originalWindow;
+    globalThis.document = originalDocument;
+    globalThis.localStorage = originalLocalStorage;
+    seeds.clear();
+    subscribers.clear();
+  });
+
+  const todos: TodoItem[] = [
+    { content: "Wire up status bar", status: "in_progress" },
+    { content: "Add tests", status: "pending" },
+  ];
+
+  test("renders the TODO plan (expanded) when todos exist", () => {
+    seed("ws-todos", { todos });
+    const result = renderBar("ws-todos");
+    // Vertical TodoList content is visible by default.
+    expect(result.getByText("Wire up status bar")).toBeTruthy();
+    expect(result.getByText("Add tests")).toBeTruthy();
+    // Summary reflects the counts.
+    expect(result.getByText(/1 in progress/)).toBeTruthy();
+  });
+
+  test("renders nothing when there is no plan and no active stream", () => {
+    seed("ws-idle", { todos: [] });
+    const result = renderBar("ws-idle");
+    expect(result.container.firstChild).toBeNull();
+  });
+
+  test("shows a streaming chip even when there is no plan yet", () => {
+    seed("ws-streaming", { todos: [], canInterrupt: true });
+    const result = renderBar("ws-streaming");
+    expect(result.getByText("Streaming…")).toBeTruthy();
+    // No plan means no TODO summary / expand toggle.
+    expect(result.queryByText("TODO")).toBeNull();
+  });
+
+  test("shows a starting chip during pre-stream startup", () => {
+    seed("ws-starting", { todos: [], isStarting: true });
+    const result = renderBar("ws-starting");
+    expect(result.getByText("Starting…")).toBeTruthy();
+  });
+
+  test("surfaces a prominent prompt when the agent awaits a question", () => {
+    seed("ws-question", { todos, awaitingUserQuestion: true });
+    const result = renderBar("ws-question");
+    expect(result.getByText("Mux has a question")).toBeTruthy();
+    // The question chip wins over the streaming label.
+    expect(result.queryByText("Streaming…")).toBeNull();
+  });
+
+  test("collapsing hides the plan and persists the choice", () => {
+    const workspaceId = "ws-collapse";
+    seed(workspaceId, { todos });
+    const result = renderBar(workspaceId);
+
+    fireEvent.click(result.getByRole("button", { name: /todo/i }));
+    expect(result.queryByText("Wire up status bar")).toBeNull();
+    expect(readPersistedState(getImmersiveReviewAgentBarExpandedKey(workspaceId), true)).toBe(
+      false
+    );
+  });
+});

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.test.tsx
@@ -1,14 +1,14 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { cleanup, fireEvent, render, type RenderResult } from "@testing-library/react";
-import { GlobalWindow } from "happy-dom";
 
-import { readPersistedState } from "@/browser/hooks/usePersistedState";
-import {
-  useWorkspaceStoreRaw as getWorkspaceStoreRaw,
-  type WorkspaceSidebarState,
-  type WorkspaceState,
-} from "@/browser/stores/WorkspaceStore";
-import { getImmersiveReviewAgentBarExpandedKey } from "@/common/constants/storage";
+import { installDom } from "../../../../../tests/ui/dom";
+// Import the module namespace (not the hook directly) so we can spyOn the hook
+// per-test. The bar resolves the store via useWorkspaceStoreRaw(), and several
+// OTHER test files globally mock.module this store; spying here keeps this file
+// hermetic regardless of cross-file load order (grabbing the real singleton at
+// module top-level would crash if another file's stub were active first).
+import * as WorkspaceStoreModule from "@/browser/stores/WorkspaceStore";
+import type { WorkspaceState, WorkspaceStore } from "@/browser/stores/WorkspaceStore";
 import type { TodoItem } from "@/common/types/tools";
 import { ImmersiveReviewAgentStatusBar } from "./ImmersiveReviewAgentStatusBar";
 
@@ -19,14 +19,11 @@ interface SeedInput {
   awaitingUserQuestion?: boolean;
 }
 
-interface SeedCache {
-  state: WorkspaceState;
-  sidebar: WorkspaceSidebarState;
-}
-
-// Cache the built snapshots per workspace so getWorkspaceState/getWorkspaceSidebarState
-// return referentially-stable objects (useSyncExternalStore would otherwise loop).
-const seeds = new Map<string, SeedCache>();
+// Cache the built state per workspace so getWorkspaceState returns a
+// referentially-stable object (useSyncExternalStore would otherwise loop).
+// The bar reads todos + streaming flags off a single getWorkspaceState read
+// (matching PinnedTodoList), so there's no separate sidebar-state mock.
+const seeds = new Map<string, WorkspaceState>();
 const subscribers = new Map<string, Set<() => void>>();
 
 function getSubscribers(workspaceId: string): Set<() => void> {
@@ -67,89 +64,52 @@ function buildState(workspaceId: string, input: SeedInput): WorkspaceState {
   };
 }
 
-function buildSidebar(input: SeedInput): WorkspaceSidebarState {
-  return {
-    canInterrupt: input.canInterrupt ?? false,
-    isStarting: input.isStarting ?? false,
-    awaitingUserQuestion: input.awaitingUserQuestion ?? false,
-    lastAbortReason: null,
-    currentModel: null,
-    pendingStreamModel: null,
-    recencyTimestamp: null,
-    loadedSkills: [],
-    skillLoadErrors: [],
-    agentStatus: undefined,
-    terminalActiveCount: 0,
-    terminalSessionCount: 0,
-    goal: null,
-  };
-}
-
 function seed(workspaceId: string, input: SeedInput): void {
-  seeds.set(workspaceId, {
-    state: buildState(workspaceId, input),
-    sidebar: buildSidebar(input),
-  });
+  seeds.set(workspaceId, buildState(workspaceId, input));
 }
 
-const store = getWorkspaceStoreRaw();
-const original = {
-  hasRegisteredWorkspace: store.hasRegisteredWorkspace.bind(store),
-  subscribeKey: store.subscribeKey.bind(store),
-  getWorkspaceState: store.getWorkspaceState.bind(store),
-  getWorkspaceSidebarState: store.getWorkspaceSidebarState.bind(store),
-};
+// Minimal fake exposing only the store methods the bar calls. Cast through
+// unknown because the bar uses just this slice of the WorkspaceStore surface.
+const fakeStore = {
+  hasRegisteredWorkspace: (id: string) => seeds.has(id),
+  subscribeKey: (id: string, cb: () => void) => {
+    const set = getSubscribers(id);
+    set.add(cb);
+    return () => {
+      set.delete(cb);
+    };
+  },
+  getWorkspaceState: (id: string) => {
+    const state = seeds.get(id);
+    if (!state) throw new Error(`Missing seed for ${id}`);
+    return state;
+  },
+} as unknown as WorkspaceStore;
 
 function renderBar(workspaceId: string): RenderResult {
   return render(<ImmersiveReviewAgentStatusBar workspaceId={workspaceId} />);
 }
 
 describe("ImmersiveReviewAgentStatusBar", () => {
-  let originalWindow: typeof globalThis.window;
-  let originalDocument: typeof globalThis.document;
-  let originalLocalStorage: typeof globalThis.localStorage;
+  // installDom snapshots + fully restores all DOM globals (window, document,
+  // localStorage, CustomEvent, …), so this file stays hermetic even when other
+  // test files in the same process leave the globals in a partial state.
+  let cleanupDom: (() => void) | null = null;
 
   beforeEach(() => {
-    originalWindow = globalThis.window;
-    originalDocument = globalThis.document;
-    originalLocalStorage = globalThis.localStorage;
-
-    globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
-    globalThis.document = globalThis.window.document;
-    globalThis.localStorage = globalThis.window.localStorage;
+    cleanupDom = installDom();
     globalThis.localStorage.clear();
     seeds.clear();
     subscribers.clear();
 
-    store.hasRegisteredWorkspace = (id: string) => seeds.has(id);
-    store.subscribeKey = (id: string, cb: () => void) => {
-      const set = getSubscribers(id);
-      set.add(cb);
-      return () => {
-        set.delete(cb);
-      };
-    };
-    store.getWorkspaceState = (id: string) => {
-      const cache = seeds.get(id);
-      if (!cache) throw new Error(`Missing seed for ${id}`);
-      return cache.state;
-    };
-    store.getWorkspaceSidebarState = (id: string) => {
-      const cache = seeds.get(id);
-      if (!cache) throw new Error(`Missing seed for ${id}`);
-      return cache.sidebar;
-    };
+    spyOn(WorkspaceStoreModule, "useWorkspaceStoreRaw").mockReturnValue(fakeStore);
   });
 
   afterEach(() => {
     cleanup();
-    store.hasRegisteredWorkspace = original.hasRegisteredWorkspace;
-    store.subscribeKey = original.subscribeKey;
-    store.getWorkspaceState = original.getWorkspaceState;
-    store.getWorkspaceSidebarState = original.getWorkspaceSidebarState;
-    globalThis.window = originalWindow;
-    globalThis.document = originalDocument;
-    globalThis.localStorage = originalLocalStorage;
+    mock.restore();
+    cleanupDom?.();
+    cleanupDom = null;
     seeds.clear();
     subscribers.clear();
   });
@@ -197,15 +157,26 @@ describe("ImmersiveReviewAgentStatusBar", () => {
     expect(result.queryByText("Streaming…")).toBeNull();
   });
 
-  test("collapsing hides the plan and persists the choice", () => {
+  test("collapsing hides the plan and the collapsed choice persists across remounts", () => {
     const workspaceId = "ws-collapse";
     seed(workspaceId, { todos });
-    const result = renderBar(workspaceId);
+    const first = renderBar(workspaceId);
 
-    fireEvent.click(result.getByRole("button", { name: /todo/i }));
-    expect(result.queryByText("Wire up status bar")).toBeNull();
-    expect(readPersistedState(getImmersiveReviewAgentBarExpandedKey(workspaceId), true)).toBe(
-      false
-    );
+    // Plan is expanded by default; collapsing hides the vertical list.
+    expect(first.getByText("Wire up status bar")).toBeTruthy();
+    fireEvent.click(first.getByRole("button", { name: /todo/i }));
+    expect(first.queryByText("Wire up status bar")).toBeNull();
+
+    // Remounting the bar for the same workspace must restore the collapsed
+    // choice (asserted via the user-visible re-render rather than reading the
+    // raw localStorage value, which keeps this resilient to the test-runner's
+    // shared-global quirks).
+    first.unmount();
+    const second = renderBar(workspaceId);
+    expect(second.queryByText("Wire up status bar")).toBeNull();
+
+    // Re-expanding brings the plan back, proving the toggle round-trips.
+    fireEvent.click(second.getByRole("button", { name: /todo/i }));
+    expect(second.getByText("Wire up status bar")).toBeTruthy();
   });
 });

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.tsx
@@ -1,0 +1,182 @@
+/**
+ * ImmersiveReviewAgentStatusBar — pinned to the top of full-screen immersive
+ * review. While the user reviews code in immersive mode the chat transcript and
+ * composer-adjacent status (TODO plan, streaming barrier) are hidden behind the
+ * opaque overlay, so a common workflow — reviewing while waiting on the agent —
+ * loses all signal about what the agent is doing.
+ *
+ * This bar restores that signal without leaving immersive:
+ *   - the agent's TODO plan in a vertical layout (collapsible, persisted), and
+ *   - live streaming status (starting / streaming / awaiting a question).
+ *
+ * Design notes:
+ *   - Subscriptions live in this leaf component (not in ImmersiveReviewView) so
+ *     per-token streaming/todo churn doesn't re-render the large diff tree.
+ *   - Flash-free: the streaming chip is gated on the *held* phase from
+ *     useWorkspaceStreamingStatusPhase (150ms), so brief starting<->streaming
+ *     handoffs don't blink. Because TODO plans persist across streams, the bar
+ *     stays mounted between turns and only unmounts once both the held phase
+ *     clears AND there are no todos left to show — no mid-review flicker.
+ *   - Crash-safe: when the workspace isn't registered in the store yet (tests,
+ *     storybook, teardown) the subscriptions fall back to empty/idle instead of
+ *     throwing, so the bar simply renders nothing.
+ */
+
+import React, { useSyncExternalStore } from "react";
+import { ChevronDown, ChevronRight, CircleHelp, List, Loader2 } from "lucide-react";
+import { TodoList } from "@/browser/components/TodoList/TodoList";
+import {
+  useOptionalWorkspaceSidebarState,
+  useWorkspaceStoreRaw,
+} from "@/browser/stores/WorkspaceStore";
+import {
+  getWorkspaceStreamingStatusPhase,
+  useWorkspaceStreamingStatusPhase,
+} from "@/browser/hooks/useWorkspaceStreamingStatusPhase";
+import { usePersistedState } from "@/browser/hooks/usePersistedState";
+import { getImmersiveReviewAgentBarExpandedKey } from "@/common/constants/storage";
+import type { TodoItem } from "@/common/types/tools";
+
+// Stable empty reference so useSyncExternalStore's snapshot stays referentially
+// stable when the workspace isn't registered — returning a fresh [] each call
+// would trip the store's "getSnapshot should be cached" infinite-loop guard.
+const EMPTY_TODOS: TodoItem[] = [];
+
+interface ImmersiveReviewAgentStatusBarProps {
+  workspaceId: string;
+}
+
+export const ImmersiveReviewAgentStatusBar: React.FC<ImmersiveReviewAgentStatusBarProps> = ({
+  workspaceId,
+}) => {
+  const [expanded, setExpanded] = usePersistedState(
+    getImmersiveReviewAgentBarExpandedKey(workspaceId),
+    true
+  );
+
+  const workspaceStore = useWorkspaceStoreRaw();
+  const todos = useSyncExternalStore(
+    (callback) =>
+      workspaceStore.hasRegisteredWorkspace(workspaceId)
+        ? workspaceStore.subscribeKey(workspaceId, callback)
+        : () => undefined,
+    () =>
+      workspaceStore.hasRegisteredWorkspace(workspaceId)
+        ? workspaceStore.getWorkspaceState(workspaceId).todos
+        : EMPTY_TODOS
+  );
+
+  const sidebarState = useOptionalWorkspaceSidebarState(workspaceId);
+  const canInterrupt = sidebarState?.canInterrupt ?? false;
+  const isStarting = sidebarState?.isStarting ?? false;
+  const awaitingUserQuestion = sidebarState?.awaitingUserQuestion ?? false;
+
+  // Held phase keeps the streaming chip steady across the starting->streaming
+  // handoff so it doesn't blink out for a frame between adjacent state settles.
+  const phase = getWorkspaceStreamingStatusPhase({ canInterrupt, isStarting });
+  const phaseSource = canInterrupt ? "streaming" : isStarting ? "pre-stream" : null;
+  const { displayPhase } = useWorkspaceStreamingStatusPhase(phase, phaseSource);
+
+  const hasTodos = todos.length > 0;
+  const isStreamingStatusVisible = displayPhase !== null || awaitingUserQuestion;
+
+  // Nothing to surface: don't reserve any vertical space in the review viewport.
+  if (!hasTodos && !isStreamingStatusVisible) {
+    return null;
+  }
+
+  const inProgressCount = todos.filter((todo) => todo.status === "in_progress").length;
+  const pendingCount = todos.filter((todo) => todo.status === "pending").length;
+  const completedCount = todos.length - inProgressCount - pendingCount;
+  const summaryParts: string[] = [];
+  if (inProgressCount > 0) {
+    summaryParts.push(`${inProgressCount} in progress`);
+  }
+  if (pendingCount > 0) {
+    summaryParts.push(`${pendingCount} pending`);
+  }
+  if (summaryParts.length === 0 && hasTodos) {
+    summaryParts.push(`${completedCount} completed`);
+  }
+
+  // role=status + aria-live so screen readers announce streaming/question
+  // transitions while the user is focused on the diff.
+  const statusChip = (() => {
+    if (awaitingUserQuestion) {
+      return (
+        <span className="bg-plan-mode-alpha text-plan-mode-light flex items-center gap-1 rounded px-1.5 py-0.5 font-medium">
+          <CircleHelp aria-hidden="true" className="h-3 w-3 shrink-0" />
+          <span>Mux has a question</span>
+        </span>
+      );
+    }
+    if (displayPhase === "starting") {
+      return (
+        <span className="text-muted flex items-center gap-1">
+          <Loader2 aria-hidden="true" className="h-3 w-3 shrink-0 animate-spin opacity-70" />
+          <span>Starting…</span>
+        </span>
+      );
+    }
+    if (displayPhase === "streaming") {
+      return (
+        <span className="text-muted flex items-center gap-1">
+          <Loader2 aria-hidden="true" className="h-3 w-3 shrink-0 animate-spin opacity-70" />
+          <span>Streaming…</span>
+        </span>
+      );
+    }
+    return null;
+  })();
+
+  const trailingStatus = (
+    <div
+      className="ml-auto flex shrink-0 items-center gap-2"
+      role="status"
+      aria-live="polite"
+      data-testid="immersive-agent-status-chip"
+    >
+      {statusChip}
+    </div>
+  );
+
+  return (
+    <div
+      className="border-border-light bg-dark border-b text-[11px]"
+      data-testid="immersive-agent-status-bar"
+      data-component="ImmersiveReviewAgentStatusBar"
+    >
+      {hasTodos ? (
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          className="group flex h-7 w-full items-center gap-2 px-3 text-left leading-none"
+          aria-expanded={expanded}
+        >
+          <List
+            aria-hidden="true"
+            className="text-muted group-hover:text-secondary size-3.5 shrink-0 transition-colors"
+          />
+          <span className="text-muted group-hover:text-secondary min-w-0 truncate transition-colors">
+            <span className="font-medium">TODO</span>
+            {summaryParts.length > 0 && <> · {summaryParts.join(" · ")}</>}
+          </span>
+          {trailingStatus}
+          {expanded ? (
+            <ChevronDown className="text-muted group-hover:text-secondary size-3.5 shrink-0 transition-colors" />
+          ) : (
+            <ChevronRight className="text-muted group-hover:text-secondary size-3.5 shrink-0 transition-colors" />
+          )}
+        </button>
+      ) : (
+        // Streaming/question only (no plan yet): static row, nothing to expand.
+        <div className="flex h-7 w-full items-center gap-2 px-3 leading-none">{trailingStatus}</div>
+      )}
+      {hasTodos && expanded && (
+        <div className="max-h-[240px] overflow-y-auto">
+          <TodoList todos={todos} />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.tsx
@@ -36,24 +36,10 @@ import { getImmersiveReviewAgentBarExpandedKey } from "@/common/constants/storag
 import { cn } from "@/common/lib/utils";
 import type { TodoItem } from "@/common/types/tools";
 
-/** The slice of WorkspaceState this bar reads. */
-interface AgentStatusSnapshot {
-  todos: TodoItem[];
-  canInterrupt: boolean;
-  isStreamStarting: boolean;
-  awaitingUserQuestion: boolean;
-}
-
-// Stable idle snapshot returned when the workspace isn't registered yet (tests,
-// storybook, teardown). A module-level constant keeps the useSyncExternalStore
-// snapshot referentially stable so the store's "getSnapshot should be cached"
-// guard doesn't loop, and the bar simply renders nothing.
-const IDLE_SNAPSHOT: AgentStatusSnapshot = {
-  todos: [],
-  canInterrupt: false,
-  isStreamStarting: false,
-  awaitingUserQuestion: false,
-};
+// Stable empty-plan reference for the unregistered case (tests, storybook,
+// teardown). Module-level so the `todos` snapshot stays referentially stable
+// and useSyncExternalStore's "getSnapshot should be cached" guard doesn't loop.
+const EMPTY_TODOS: TodoItem[] = [];
 
 interface ImmersiveReviewAgentStatusBarProps {
   workspaceId: string;
@@ -67,27 +53,39 @@ export const ImmersiveReviewAgentStatusBar: React.FC<ImmersiveReviewAgentStatusB
     true
   );
 
-  // Single subscription to the cached WorkspaceState (same pattern as
-  // PinnedTodoList) — it already carries todos AND the streaming flags, so we
-  // avoid a second sidebar-state hook. getWorkspaceState returns a stable,
-  // version-cached reference, so reading several fields off it is cheap and
-  // referentially safe for useSyncExternalStore.
+  // Subscribe to each field this bar uses as its OWN snapshot rather than
+  // returning the whole WorkspaceState object. getWorkspaceState is version-
+  // cached, so its reference changes on EVERY state bump (e.g. each streamed
+  // message) — returning it wholesale would re-render the bar on every token.
+  // Per-field selectors keep the bar stable: primitives compare by value, and
+  // `todos` keeps a stable reference from the aggregator (same basis as
+  // PinnedTodoList reading only `.todos`).
   const workspaceStore = useWorkspaceStoreRaw();
-  const snapshot = useSyncExternalStore<AgentStatusSnapshot>(
-    (callback) =>
-      workspaceStore.hasRegisteredWorkspace(workspaceId)
-        ? workspaceStore.subscribeKey(workspaceId, callback)
-        : () => undefined,
-    () =>
-      workspaceStore.hasRegisteredWorkspace(workspaceId)
-        ? workspaceStore.getWorkspaceState(workspaceId)
-        : IDLE_SNAPSHOT
+  const subscribe = (callback: () => void) =>
+    workspaceStore.hasRegisteredWorkspace(workspaceId)
+      ? workspaceStore.subscribeKey(workspaceId, callback)
+      : () => undefined;
+  const todos = useSyncExternalStore(subscribe, () =>
+    workspaceStore.hasRegisteredWorkspace(workspaceId)
+      ? workspaceStore.getWorkspaceState(workspaceId).todos
+      : EMPTY_TODOS
   );
-  const todos = snapshot.todos;
-  const canInterrupt = snapshot.canInterrupt;
+  const canInterrupt = useSyncExternalStore(subscribe, () =>
+    workspaceStore.hasRegisteredWorkspace(workspaceId)
+      ? workspaceStore.getWorkspaceState(workspaceId).canInterrupt
+      : false
+  );
   // Sidebar derives `isStarting` directly from `isStreamStarting`.
-  const isStarting = snapshot.isStreamStarting;
-  const awaitingUserQuestion = snapshot.awaitingUserQuestion;
+  const isStarting = useSyncExternalStore(subscribe, () =>
+    workspaceStore.hasRegisteredWorkspace(workspaceId)
+      ? workspaceStore.getWorkspaceState(workspaceId).isStreamStarting
+      : false
+  );
+  const awaitingUserQuestion = useSyncExternalStore(subscribe, () =>
+    workspaceStore.hasRegisteredWorkspace(workspaceId)
+      ? workspaceStore.getWorkspaceState(workspaceId).awaitingUserQuestion
+      : false
+  );
 
   // Held phase keeps the streaming chip steady across the starting->streaming
   // handoff so it doesn't blink out for a frame between adjacent state settles.

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.tsx
@@ -6,7 +6,8 @@
  * loses all signal about what the agent is doing.
  *
  * This bar restores that signal without leaving immersive:
- *   - the agent's TODO plan in a vertical layout (collapsible, persisted), and
+ *   - the agent's TODO plan as a single horizontal strip (collapsible,
+ *     persisted) so it reserves minimal review height, and
  *   - live streaming status (starting / streaming / awaiting a question).
  *
  * Design notes:
@@ -189,9 +190,9 @@ export const ImmersiveReviewAgentStatusBar: React.FC<ImmersiveReviewAgentStatusB
         <div className="flex h-7 w-full items-center gap-2 px-3 leading-none">{trailingStatus}</div>
       )}
       {hasTodos && expanded && (
-        <div className="max-h-[240px] overflow-y-auto">
-          <TodoList todos={todos} />
-        </div>
+        // Horizontal strip: one row tall (the list scrolls sideways), so the
+        // plan costs minimal vertical space in the review viewport.
+        <TodoList todos={todos} layout="horizontal" />
       )}
     </div>
   );

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/browser/hooks/useWorkspaceStreamingStatusPhase";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
 import { getImmersiveReviewAgentBarExpandedKey } from "@/common/constants/storage";
+import { cn } from "@/common/lib/utils";
 import type { TodoItem } from "@/common/types/tools";
 
 /** The slice of WorkspaceState this bar reads. */
@@ -146,9 +147,12 @@ export const ImmersiveReviewAgentStatusBar: React.FC<ImmersiveReviewAgentStatusB
     return null;
   })();
 
-  const trailingStatus = (
+  // `alignEnd` pushes the chip to the right with the TODO summary on its left;
+  // without a plan there's nothing on the left, so the chip is left-aligned
+  // instead of floating alone on the far right of an otherwise-empty bar.
+  const renderStatusChip = (alignEnd: boolean) => (
     <div
-      className="ml-auto flex shrink-0 items-center gap-2"
+      className={cn("flex shrink-0 items-center gap-2", alignEnd && "ml-auto")}
       role="status"
       aria-live="polite"
       data-testid="immersive-agent-status-chip"
@@ -178,7 +182,7 @@ export const ImmersiveReviewAgentStatusBar: React.FC<ImmersiveReviewAgentStatusB
             <span className="font-medium">TODO</span>
             {summaryParts.length > 0 && <> · {summaryParts.join(" · ")}</>}
           </span>
-          {trailingStatus}
+          {renderStatusChip(true)}
           {expanded ? (
             <ChevronDown className="text-muted group-hover:text-secondary size-3.5 shrink-0 transition-colors" />
           ) : (
@@ -187,7 +191,11 @@ export const ImmersiveReviewAgentStatusBar: React.FC<ImmersiveReviewAgentStatusB
         </button>
       ) : (
         // Streaming/question only (no plan yet): static row, nothing to expand.
-        <div className="flex h-7 w-full items-center gap-2 px-3 leading-none">{trailingStatus}</div>
+        // Chip is left-aligned here so it reads as a status label rather than
+        // hugging the far right of an otherwise-empty bar.
+        <div className="flex h-7 w-full items-center gap-2 px-3 leading-none">
+          {renderStatusChip(false)}
+        </div>
       )}
       {hasTodos && expanded && (
         // Horizontal strip: one row tall (the list scrolls sideways), so the

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.tsx
@@ -25,10 +25,7 @@
 import React, { useSyncExternalStore } from "react";
 import { ChevronDown, ChevronRight, CircleHelp, List, Loader2 } from "lucide-react";
 import { TodoList } from "@/browser/components/TodoList/TodoList";
-import {
-  useOptionalWorkspaceSidebarState,
-  useWorkspaceStoreRaw,
-} from "@/browser/stores/WorkspaceStore";
+import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
 import {
   getWorkspaceStreamingStatusPhase,
   useWorkspaceStreamingStatusPhase,
@@ -37,10 +34,24 @@ import { usePersistedState } from "@/browser/hooks/usePersistedState";
 import { getImmersiveReviewAgentBarExpandedKey } from "@/common/constants/storage";
 import type { TodoItem } from "@/common/types/tools";
 
-// Stable empty reference so useSyncExternalStore's snapshot stays referentially
-// stable when the workspace isn't registered — returning a fresh [] each call
-// would trip the store's "getSnapshot should be cached" infinite-loop guard.
-const EMPTY_TODOS: TodoItem[] = [];
+/** The slice of WorkspaceState this bar reads. */
+interface AgentStatusSnapshot {
+  todos: TodoItem[];
+  canInterrupt: boolean;
+  isStreamStarting: boolean;
+  awaitingUserQuestion: boolean;
+}
+
+// Stable idle snapshot returned when the workspace isn't registered yet (tests,
+// storybook, teardown). A module-level constant keeps the useSyncExternalStore
+// snapshot referentially stable so the store's "getSnapshot should be cached"
+// guard doesn't loop, and the bar simply renders nothing.
+const IDLE_SNAPSHOT: AgentStatusSnapshot = {
+  todos: [],
+  canInterrupt: false,
+  isStreamStarting: false,
+  awaitingUserQuestion: false,
+};
 
 interface ImmersiveReviewAgentStatusBarProps {
   workspaceId: string;
@@ -54,22 +65,27 @@ export const ImmersiveReviewAgentStatusBar: React.FC<ImmersiveReviewAgentStatusB
     true
   );
 
+  // Single subscription to the cached WorkspaceState (same pattern as
+  // PinnedTodoList) — it already carries todos AND the streaming flags, so we
+  // avoid a second sidebar-state hook. getWorkspaceState returns a stable,
+  // version-cached reference, so reading several fields off it is cheap and
+  // referentially safe for useSyncExternalStore.
   const workspaceStore = useWorkspaceStoreRaw();
-  const todos = useSyncExternalStore(
+  const snapshot = useSyncExternalStore<AgentStatusSnapshot>(
     (callback) =>
       workspaceStore.hasRegisteredWorkspace(workspaceId)
         ? workspaceStore.subscribeKey(workspaceId, callback)
         : () => undefined,
     () =>
       workspaceStore.hasRegisteredWorkspace(workspaceId)
-        ? workspaceStore.getWorkspaceState(workspaceId).todos
-        : EMPTY_TODOS
+        ? workspaceStore.getWorkspaceState(workspaceId)
+        : IDLE_SNAPSHOT
   );
-
-  const sidebarState = useOptionalWorkspaceSidebarState(workspaceId);
-  const canInterrupt = sidebarState?.canInterrupt ?? false;
-  const isStarting = sidebarState?.isStarting ?? false;
-  const awaitingUserQuestion = sidebarState?.awaitingUserQuestion ?? false;
+  const todos = snapshot.todos;
+  const canInterrupt = snapshot.canInterrupt;
+  // Sidebar derives `isStarting` directly from `isStreamStarting`.
+  const isStarting = snapshot.isStreamStarting;
+  const awaitingUserQuestion = snapshot.awaitingUserQuestion;
 
   // Held phase keeps the streaming chip steady across the starting->streaming
   // handoff so it doesn't blink out for a frame between adjacent state settles.

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.stories.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.stories.tsx
@@ -9,6 +9,9 @@ import { ExperimentsProvider } from "@/browser/contexts/ExperimentsContext";
 import { ThemeProvider } from "@/browser/contexts/ThemeContext";
 import { createMockORPCClient } from "@/browser/stories/mocks/orpc";
 import { createReview } from "@/browser/stories/helpers/reviews";
+import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
+import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
+import type { TodoItem } from "@/common/types/tools";
 import type { DiffHunk, Review } from "@/common/types/review";
 import { extractAllHunks, parseDiff } from "@/common/utils/git/diffParser";
 import {
@@ -265,6 +268,84 @@ function createImmersiveStoryClient(): APIClient {
   });
 }
 
+interface AgentStatusSeed {
+  /** TODO plan the agent has written (drives the vertical TODO list + summary). */
+  todos: TodoItem[];
+  /**
+   * When true, leaves the seeded stream open so the bar shows the live
+   * "Streaming…" chip alongside the plan. When false the stream is left
+   * un-started, so only the persisted (incomplete) plan shows.
+   */
+  streaming?: boolean;
+}
+
+/**
+ * Register a workspace in the singleton WorkspaceStore and push a `todo_write`
+ * tool call through its aggregator so the immersive view's
+ * ImmersiveReviewAgentStatusBar has real plan + streaming state to render.
+ * Seeds exactly once per workspace (addWorkspace is idempotent and the stream
+ * events are replayed only when the aggregator is freshly created), and runs
+ * during render before the child subscribes so the bar paints populated on the
+ * first frame (flash-free for Chromatic).
+ */
+function seedAgentStatus(
+  workspaceStore: ReturnType<typeof useWorkspaceStoreRaw>,
+  workspaceId: string,
+  seed: AgentStatusSeed
+): void {
+  const alreadyRegistered = workspaceStore.hasRegisteredWorkspace(workspaceId);
+  workspaceStore.addWorkspace({
+    id: workspaceId,
+    name: workspaceId,
+    projectName: "story-project",
+    projectPath: "/story/project",
+    namedWorkspacePath: "/story/workspace",
+    createdAt: new Date(0).toISOString(),
+    runtimeConfig: DEFAULT_RUNTIME_CONFIG,
+  });
+  if (alreadyRegistered) {
+    return;
+  }
+
+  const aggregator = workspaceStore.getAggregator(workspaceId);
+  if (!aggregator) {
+    return;
+  }
+
+  const messageId = `${workspaceId}-stream`;
+  aggregator.handleStreamStart({
+    type: "stream-start",
+    workspaceId,
+    messageId,
+    historySequence: 1,
+    model: "anthropic:claude-sonnet-4",
+    startTime: 0,
+  });
+  aggregator.handleToolCallStart({
+    type: "tool-call-start",
+    workspaceId,
+    messageId,
+    toolCallId: `${workspaceId}-todo`,
+    toolName: "todo_write",
+    args: { todos: seed.todos },
+    tokens: 10,
+    timestamp: 1,
+  });
+  aggregator.handleToolCallEnd({
+    type: "tool-call-end",
+    workspaceId,
+    messageId,
+    toolCallId: `${workspaceId}-todo`,
+    toolName: "todo_write",
+    result: { success: true },
+    timestamp: 2,
+  });
+  if (seed.streaming !== true) {
+    // Collapse the active stream so the chip clears; incomplete todos persist.
+    aggregator.clearActiveStreams();
+  }
+}
+
 const ImmersiveStoryShell: FC<{ client: APIClient; children: ReactNode }> = ({
   client,
   children,
@@ -293,6 +374,11 @@ interface ImmersiveReviewStoryProps {
   assistedOnly?: boolean;
   assistedCount?: number;
   assistedUnreadCount?: number;
+  /**
+   * Seeds the singleton WorkspaceStore so the immersive view's top status bar
+   * (ImmersiveReviewAgentStatusBar) renders a real TODO plan + streaming chip.
+   */
+  agentStatusSeed?: AgentStatusSeed;
 }
 
 function ImmersiveReviewStory(props: ImmersiveReviewStoryProps) {
@@ -303,6 +389,13 @@ function ImmersiveReviewStory(props: ImmersiveReviewStoryProps) {
   const [readHunkIds, setReadHunkIds] = useState<Set<string>>(
     () => new Set(props.initialReadHunkIds ?? [])
   );
+
+  // Seed agent status synchronously during render (before the child subscribes)
+  // so the top status bar paints with its plan/stream on the first frame.
+  const workspaceStore = useWorkspaceStoreRaw();
+  if (props.agentStatusSeed) {
+    seedAgentStatus(workspaceStore, props.workspaceId, props.agentStatusSeed);
+  }
 
   return (
     <ImmersiveStoryShell client={client}>
@@ -580,6 +673,46 @@ export const ImmersiveWithAssistedMode: Story = {
       () => {
         canvas.getByTestId("immersive-review-view");
         canvas.getByTestId("immersive-assisted-mode-badge");
+      },
+      { timeout: 10_000 }
+    );
+  },
+};
+
+const IMMERSIVE_AGENT_STATUS_WORKSPACE_ID = "ws-review-immersive-agent-status";
+const IMMERSIVE_AGENT_STATUS_TODOS: TodoItem[] = [
+  { content: "Audit immersive review layout", status: "completed" },
+  { content: "Scope assisted comment to the diff column", status: "completed" },
+  { content: "Add the top status bar (TODO + streaming)", status: "in_progress" },
+  { content: "Wire up flash-free loading states", status: "pending" },
+  { content: "Add Storybook + tests", status: "pending" },
+];
+
+/**
+ * Immersive review with the top agent status bar populated: the agent's TODO
+ * plan in a vertical layout plus the live "Streaming…" chip. This is the piece
+ * that keeps chat status visible while the user reviews code behind the
+ * full-screen overlay. Seeds the WorkspaceStore so the bar has real state.
+ */
+export const ImmersiveWithAgentStatusBar: Story = {
+  render: () => (
+    <ImmersiveReviewStory
+      workspaceId={IMMERSIVE_AGENT_STATUS_WORKSPACE_ID}
+      fixture={LINE_HEIGHT_FIXTURE}
+      agentStatusSeed={{ todos: IMMERSIVE_AGENT_STATUS_TODOS, streaming: true }}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(
+      () => {
+        canvas.getByTestId("immersive-review-view");
+        // The collapsible TODO bar + its vertical plan content render.
+        canvas.getByTestId("immersive-agent-status-bar");
+        canvas.getByText("Add the top status bar (TODO + streaming)");
+        // Live streaming chip is visible alongside the plan.
+        canvas.getByText("Streaming…");
       },
       { timeout: 10_000 }
     );

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.stories.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.stories.tsx
@@ -269,12 +269,16 @@ function createImmersiveStoryClient(): APIClient {
 }
 
 interface AgentStatusSeed {
-  /** TODO plan the agent has written (drives the vertical TODO list + summary). */
-  todos: TodoItem[];
+  /**
+   * TODO plan the agent has written (drives the horizontal TODO strip +
+   * summary). Omit (or pass an empty array) to model "streaming before any plan
+   * is written", where the bar shows only the streaming chip.
+   */
+  todos?: TodoItem[];
   /**
    * When true, leaves the seeded stream open so the bar shows the live
-   * "Streaming…" chip alongside the plan. When false the stream is left
-   * un-started, so only the persisted (incomplete) plan shows.
+   * "Streaming…" chip. When false the stream is left un-started, so only the
+   * persisted (incomplete) plan shows.
    */
   streaming?: boolean;
 }
@@ -321,25 +325,29 @@ function seedAgentStatus(
     model: "anthropic:claude-sonnet-4",
     startTime: 0,
   });
-  aggregator.handleToolCallStart({
-    type: "tool-call-start",
-    workspaceId,
-    messageId,
-    toolCallId: `${workspaceId}-todo`,
-    toolName: "todo_write",
-    args: { todos: seed.todos },
-    tokens: 10,
-    timestamp: 1,
-  });
-  aggregator.handleToolCallEnd({
-    type: "tool-call-end",
-    workspaceId,
-    messageId,
-    toolCallId: `${workspaceId}-todo`,
-    toolName: "todo_write",
-    result: { success: true },
-    timestamp: 2,
-  });
+  // Only push a plan when the seed has one; omitting it models "streaming
+  // before any TODO is written" so the bar renders the chip-only state.
+  if (seed.todos && seed.todos.length > 0) {
+    aggregator.handleToolCallStart({
+      type: "tool-call-start",
+      workspaceId,
+      messageId,
+      toolCallId: `${workspaceId}-todo`,
+      toolName: "todo_write",
+      args: { todos: seed.todos },
+      tokens: 10,
+      timestamp: 1,
+    });
+    aggregator.handleToolCallEnd({
+      type: "tool-call-end",
+      workspaceId,
+      messageId,
+      toolCallId: `${workspaceId}-todo`,
+      toolName: "todo_write",
+      result: { success: true },
+      timestamp: 2,
+    });
+  }
   if (seed.streaming !== true) {
     // Collapse the active stream so the chip clears; incomplete todos persist.
     aggregator.clearActiveStreams();
@@ -690,7 +698,7 @@ const IMMERSIVE_AGENT_STATUS_TODOS: TodoItem[] = [
 
 /**
  * Immersive review with the top agent status bar populated: the agent's TODO
- * plan in a vertical layout plus the live "Streaming…" chip. This is the piece
+ * plan as a horizontal strip plus the live "Streaming…" chip. This is the piece
  * that keeps chat status visible while the user reviews code behind the
  * full-screen overlay. Seeds the WorkspaceStore so the bar has real state.
  */
@@ -708,11 +716,46 @@ export const ImmersiveWithAgentStatusBar: Story = {
     await waitFor(
       () => {
         canvas.getByTestId("immersive-review-view");
-        // The collapsible TODO bar + its vertical plan content render.
+        // The collapsible TODO bar + its horizontal plan strip render.
         canvas.getByTestId("immersive-agent-status-bar");
         canvas.getByText("Add the top status bar (TODO + streaming)");
         // Live streaming chip is visible alongside the plan.
         canvas.getByText("Streaming…");
+      },
+      { timeout: 10_000 }
+    );
+  },
+};
+
+const IMMERSIVE_STREAMING_NO_TODO_WORKSPACE_ID = "ws-review-immersive-streaming-no-todo";
+
+/**
+ * Immersive review while the agent is streaming but has not written a TODO plan
+ * yet. Locks in the chip-only state of the status bar: with no plan on the left
+ * the "Streaming…" chip is left-aligned (reads as a status label) instead of
+ * floating alone on the far right of an otherwise-empty bar, and the bar stays
+ * a single row tall. Seeds an open stream with no `todo_write` call.
+ */
+export const ImmersiveWithStreamingNoTodo: Story = {
+  render: () => (
+    <ImmersiveReviewStory
+      workspaceId={IMMERSIVE_STREAMING_NO_TODO_WORKSPACE_ID}
+      fixture={LINE_HEIGHT_FIXTURE}
+      agentStatusSeed={{ streaming: true }}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(
+      () => {
+        canvas.getByTestId("immersive-review-view");
+        // The bar renders the streaming chip with no TODO toggle/summary.
+        canvas.getByTestId("immersive-agent-status-bar");
+        canvas.getByText("Streaming…");
+        if (canvas.queryByText("TODO")) {
+          throw new Error("Expected the chip-only status bar with no TODO plan.");
+        }
       },
       { timeout: 10_000 }
     );

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.stories.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.stories.tsx
@@ -289,6 +289,10 @@ interface ImmersiveReviewStoryProps {
   assistedHunkIds?: ReadonlySet<string>;
   /** Per-hunk agent comments — drives the immersive assisted-review banner. */
   assistedCommentByHunkId?: Map<string, string>;
+  /** Whether the Assisted worklist filter is active — drives the header badge. */
+  assistedOnly?: boolean;
+  assistedCount?: number;
+  assistedUnreadCount?: number;
 }
 
 function ImmersiveReviewStory(props: ImmersiveReviewStoryProps) {
@@ -340,6 +344,9 @@ function ImmersiveReviewStory(props: ImmersiveReviewStoryProps) {
         firstSeenMap={props.fixture.firstSeenMap}
         assistedHunkIds={props.assistedHunkIds}
         assistedCommentByHunkId={props.assistedCommentByHunkId}
+        assistedOnly={props.assistedOnly}
+        assistedCount={props.assistedCount}
+        assistedUnreadCount={props.assistedUnreadCount}
       />
     </ImmersiveStoryShell>
   );
@@ -542,6 +549,37 @@ export const ImmersiveWithAssistedBanner: Story = {
       () => {
         canvas.getByTestId("immersive-review-view");
         canvas.getByTestId("immersive-assisted-banner");
+      },
+      { timeout: 10_000 }
+    );
+  },
+};
+
+/**
+ * Immersive review with the Assisted worklist filter active. Locks in the
+ * header "Assisted unread/total" badge (Sparkles + review-accent) that tells
+ * the user the diff is filtered to agent-flagged hunks — the control bar that
+ * normally hosts this toggle is hidden behind the immersive overlay.
+ */
+export const ImmersiveWithAssistedMode: Story = {
+  render: () => (
+    <ImmersiveReviewStory
+      workspaceId={IMMERSIVE_ASSISTED_WORKSPACE_ID}
+      fixture={IMMERSIVE_ASSISTED_FIXTURE}
+      assistedHunkIds={IMMERSIVE_ASSISTED_HUNK_IDS}
+      assistedCommentByHunkId={IMMERSIVE_ASSISTED_COMMENT_BY_HUNK_ID}
+      assistedOnly
+      assistedCount={3}
+      assistedUnreadCount={2}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(
+      () => {
+        canvas.getByTestId("immersive-review-view");
+        canvas.getByTestId("immersive-assisted-mode-badge");
       },
       { timeout: 10_000 }
     );

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
@@ -213,6 +213,25 @@ describe("ImmersiveReviewView", () => {
     expect(mockApi.workspace.executeBash).not.toHaveBeenCalled();
   });
 
+  test("shows the assisted-mode badge only while the Assisted filter is active", () => {
+    // Off by default: the badge must not appear when not filtering.
+    const off = renderImmersiveReview();
+    expect(off.queryByTestId("immersive-assisted-mode-badge")).toBeNull();
+    cleanup();
+
+    // On: the header surfaces the badge with the unread/total counts so the
+    // active filter mode is visible even though the control bar is hidden
+    // behind the immersive overlay.
+    const on = renderImmersiveReview({
+      assistedOnly: true,
+      assistedCount: 3,
+      assistedUnreadCount: 2,
+    });
+    const badge = on.getByTestId("immersive-assisted-mode-badge");
+    expect(badge.textContent ?? "").toContain("Assisted");
+    expect(badge.textContent ?? "").toContain("2/3");
+  });
+
   test("loads full-file context for an in-budget selected hunk even when another hunk is far away", async () => {
     const nearHunk = createHunk({
       id: "hunk-near",

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -1963,99 +1963,107 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
           the diff tree; renders nothing when there's no plan and no stream. */}
       <ImmersiveReviewAgentStatusBar workspaceId={props.workspaceId} />
 
-      {/* Assisted-review banner — surfaces the agent's flag + comment when
-          the selected hunk is one the agent pinned for review. We render it
-          between the header and the diff so the focus signal is impossible
-          to miss after entering immersive mode, where the side-panel cues
-          aren't visible. */}
-      {isSelectedAssisted && (
-        <div
-          className="border-review-accent/40 bg-review-accent/5 text-foreground flex items-start gap-2 border-b px-3 py-1.5 text-[11px] leading-[1.4]"
-          data-testid="immersive-assisted-banner"
-          role="status"
-          aria-live="polite"
-        >
-          <Sparkles aria-hidden="true" className="text-review-accent mt-[2px] h-3 w-3 shrink-0" />
-          {selectedAssistedComment ? (
-            <span className="min-w-0 break-words whitespace-pre-wrap">
-              {selectedAssistedComment}
-            </span>
-          ) : (
-            <span className="text-muted italic">Flagged by agent for review</span>
-          )}
-        </div>
-      )}
-
       {/* Unified whole-file diff with hunk overlays + notes sidebar */}
       <div className="flex min-h-0 flex-1">
-        {/* Avoid top padding here; it reads as a blank block between the controls and diff. */}
-        <div
-          ref={scrollContainerRef}
-          className="scrollbar-none min-h-0 min-w-0 flex-1 overflow-y-auto pb-3"
-        >
-          {props.isLoading && currentFileHunks.length === 0 ? (
-            <div className="text-muted flex items-center justify-center py-12 text-sm">
-              <span className="animate-pulse">Loading diff...</span>
-            </div>
-          ) : isReviewComplete ? (
-            <div className="flex min-h-full items-center justify-center px-6 py-12">
-              <div
-                data-testid="immersive-review-complete"
-                className="flex max-w-md flex-col items-center gap-4 text-center"
-              >
-                <div className="bg-accent/10 text-accent rounded-full p-3">
-                  <CheckCircle2 aria-hidden="true" className="h-8 w-8" />
-                </div>
-                <div className="space-y-2">
-                  <h2 className="text-foreground text-base font-medium">Review complete</h2>
-                  <p className="text-muted text-sm leading-relaxed">
-                    You have already reviewed all {reviewedHunkLabel} in this diff. Return to chat
-                    to keep going, or reopen reviewed hunks from the review panel if you want
-                    another pass.
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  onClick={onExit}
-                  className="bg-accent hover:bg-accent/80 text-accent-foreground inline-flex items-center rounded-md px-3 py-1.5 text-xs font-medium transition-colors"
-                >
-                  Return to chat
-                </button>
-              </div>
-            </div>
-          ) : currentFileHunks.length === 0 ? (
-            <div className="text-muted flex items-center justify-center py-12 text-sm">
-              {activeFilePath ? "No hunks for this file" : "No files to review"}
-            </div>
-          ) : (
-            <div className="bg-dark relative overflow-hidden">
-              {isActiveFileRevealPending && (
-                <div className="bg-dark/95 text-muted absolute inset-0 z-10 flex items-center justify-center text-sm">
-                  <span className="animate-pulse">Loading file...</span>
-                </div>
+        {/* Diff column. The assisted-review banner lives INSIDE this column (not
+            above the whole body) so the agent's per-hunk comment spans only the
+            diff width and lines up with the code it refers to — rather than
+            stretching across the minimap and notes sidebar. */}
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+          {/* Assisted-review banner — surfaces the agent's flag + comment when
+              the selected hunk is one the agent pinned for review. Pinned to the
+              top of the diff column so the focus signal is impossible to miss
+              after entering immersive mode, where the side-panel cues aren't
+              visible. */}
+          {isSelectedAssisted && (
+            <div
+              className="border-review-accent/40 bg-review-accent/5 text-foreground flex shrink-0 items-start gap-2 border-b px-3 py-1.5 text-[11px] leading-[1.4]"
+              data-testid="immersive-assisted-banner"
+              role="status"
+              aria-live="polite"
+            >
+              <Sparkles
+                aria-hidden="true"
+                className="text-review-accent mt-[2px] h-3 w-3 shrink-0"
+              />
+              {selectedAssistedComment ? (
+                <span className="min-w-0 break-words whitespace-pre-wrap">
+                  {selectedAssistedComment}
+                </span>
+              ) : (
+                <span className="text-muted italic">Flagged by agent for review</span>
               )}
-              <div className={cn(isActiveFileRevealPending && "invisible")}>
-                <SelectableDiffRenderer
-                  content={overlayData.content}
-                  filePath={activeFilePath ?? currentFileHunks[0].filePath}
-                  inlineReviews={activeFileReviews}
-                  oldStart={1}
-                  newStart={1}
-                  fontSize="11px"
-                  maxHeight="none"
-                  className="rounded-none border-0 [&>div]:overflow-x-visible"
-                  onReviewNote={handleReviewNoteSubmit}
-                  onComposerCancel={handleInlineComposerCancel}
-                  reviewActions={diffReviewActions}
-                  enableHighlighting={shouldEnableHighlighting}
-                  selectedLineRange={selectedLineRange}
-                  onLineIndexSelect={handleLineIndexSelect}
-                  externalSelectionRequest={externalComposerSelectionRequest}
-                  externalEditRequest={inlineReviewEditRequest}
-                />
-              </div>
             </div>
           )}
+          {/* Avoid top padding here; it reads as a blank block between the controls and diff. */}
+          <div
+            ref={scrollContainerRef}
+            className="scrollbar-none min-h-0 min-w-0 flex-1 overflow-y-auto pb-3"
+          >
+            {props.isLoading && currentFileHunks.length === 0 ? (
+              <div className="text-muted flex items-center justify-center py-12 text-sm">
+                <span className="animate-pulse">Loading diff...</span>
+              </div>
+            ) : isReviewComplete ? (
+              <div className="flex min-h-full items-center justify-center px-6 py-12">
+                <div
+                  data-testid="immersive-review-complete"
+                  className="flex max-w-md flex-col items-center gap-4 text-center"
+                >
+                  <div className="bg-accent/10 text-accent rounded-full p-3">
+                    <CheckCircle2 aria-hidden="true" className="h-8 w-8" />
+                  </div>
+                  <div className="space-y-2">
+                    <h2 className="text-foreground text-base font-medium">Review complete</h2>
+                    <p className="text-muted text-sm leading-relaxed">
+                      You have already reviewed all {reviewedHunkLabel} in this diff. Return to chat
+                      to keep going, or reopen reviewed hunks from the review panel if you want
+                      another pass.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={onExit}
+                    className="bg-accent hover:bg-accent/80 text-accent-foreground inline-flex items-center rounded-md px-3 py-1.5 text-xs font-medium transition-colors"
+                  >
+                    Return to chat
+                  </button>
+                </div>
+              </div>
+            ) : currentFileHunks.length === 0 ? (
+              <div className="text-muted flex items-center justify-center py-12 text-sm">
+                {activeFilePath ? "No hunks for this file" : "No files to review"}
+              </div>
+            ) : (
+              <div className="bg-dark relative overflow-hidden">
+                {isActiveFileRevealPending && (
+                  <div className="bg-dark/95 text-muted absolute inset-0 z-10 flex items-center justify-center text-sm">
+                    <span className="animate-pulse">Loading file...</span>
+                  </div>
+                )}
+                <div className={cn(isActiveFileRevealPending && "invisible")}>
+                  <SelectableDiffRenderer
+                    content={overlayData.content}
+                    filePath={activeFilePath ?? currentFileHunks[0].filePath}
+                    inlineReviews={activeFileReviews}
+                    oldStart={1}
+                    newStart={1}
+                    fontSize="11px"
+                    maxHeight="none"
+                    className="rounded-none border-0 [&>div]:overflow-x-visible"
+                    onReviewNote={handleReviewNoteSubmit}
+                    onComposerCancel={handleInlineComposerCancel}
+                    reviewActions={diffReviewActions}
+                    enableHighlighting={shouldEnableHighlighting}
+                    selectedLineRange={selectedLineRange}
+                    onLineIndexSelect={handleLineIndexSelect}
+                    externalSelectionRequest={externalComposerSelectionRequest}
+                    externalEditRequest={inlineReviewEditRequest}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
         </div>
 
         {!isReviewComplete && !isTouchExperience && (

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -21,6 +21,7 @@ import {
 import { cn } from "@/common/lib/utils";
 import { SelectableDiffRenderer } from "../../Shared/DiffRenderer";
 import { ImmersiveMinimap } from "./ImmersiveMinimap";
+import { ImmersiveReviewAgentStatusBar } from "./ImmersiveReviewAgentStatusBar";
 import {
   buildNewLineNumberToIndexMap,
   buildOldLineNumberToIndexMap,
@@ -92,6 +93,18 @@ interface ImmersiveReviewViewProps {
    * see in the side panel.
    */
   assistedCommentByHunkId?: Map<string, string>;
+  /**
+   * Whether the "Assisted" filter (show only agent-flagged hunks) is active.
+   * The control bar that hosts this toggle is hidden behind the immersive
+   * overlay, so we surface a header badge to keep the active filter mode
+   * visible. Distinct from the per-hunk assisted banner: this means "the
+   * worklist filter is on", not "this hunk was flagged".
+   */
+  assistedOnly?: boolean;
+  /** Total agent-flagged hunks (mirrors the control bar's Assisted count). */
+  assistedCount?: number;
+  /** Agent-flagged hunks still unread (mirrors the control bar's count). */
+  assistedUnreadCount?: number;
 }
 
 interface InlineComposerRequest {
@@ -1885,6 +1898,25 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
             )}
           </div>
         )}
+        {/* Assisted-mode indicator — the control bar that hosts the Assisted
+            toggle is hidden behind the immersive overlay, so without this the
+            user has no way to tell the diff is filtered to agent-flagged hunks.
+            ml-auto anchors it to the row's trailing edge as a mode indicator. */}
+        {props.assistedOnly === true && (
+          <div
+            className="border-review-accent/40 bg-review-accent/10 text-review-accent ml-auto flex shrink-0 items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] font-medium"
+            data-testid="immersive-assisted-mode-badge"
+            role="status"
+          >
+            <Sparkles aria-hidden="true" className="h-3 w-3 shrink-0" />
+            <span>Assisted</span>
+            {(props.assistedCount ?? 0) > 0 && (
+              <span className="text-review-accent/70 counter-nums">
+                {props.assistedUnreadCount ?? 0}/{props.assistedCount ?? 0}
+              </span>
+            )}
+          </div>
+        )}
         {allHunks.length > 0 && (
           <div className="w-full pt-0.5">
             <TooltipIfPresent
@@ -1924,6 +1956,12 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
           </div>
         )}
       </div>
+
+      {/* Agent status bar — keeps the TODO plan + live streaming status visible
+          while reviewing, since the chat transcript/composer are hidden behind
+          the immersive overlay. Self-subscribes so its updates don't re-render
+          the diff tree; renders nothing when there's no plan and no stream. */}
+      <ImmersiveReviewAgentStatusBar workspaceId={props.workspaceId} />
 
       {/* Assisted-review banner — surfaces the agent's flag + comment when
           the selected hunk is one the agent pinned for review. We render it

--- a/src/browser/features/RightSidebar/CodeReview/ReviewPanel.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ReviewPanel.tsx
@@ -2595,6 +2595,9 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
               firstSeenMap={firstSeenMap}
               assistedHunkIds={assistedHunkIdSet}
               assistedCommentByHunkId={assistedCommentByHunkId}
+              assistedOnly={filters.assistedOnly}
+              assistedCount={assistedHunks.length}
+              assistedUnreadCount={unreadAssistedInDiff}
             />,
             root
           );

--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -716,6 +716,7 @@ const EPHEMERAL_WORKSPACE_KEY_FUNCTIONS: Array<(workspaceId: string) => string> 
   getPendingWorkspaceSendErrorKey,
   getPlanContentKey, // Cache only, no need to preserve on fork
   getPostCompactionStateKey, // Cache only, no need to preserve on fork
+  getImmersiveReviewAgentBarExpandedKey, // Transient UI pref; clean up on removal, don't carry on fork
 ];
 
 /**

--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -637,6 +637,18 @@ export function getReviewImmersiveKey(workspaceId: string): string {
 }
 
 /**
+ * Get the localStorage key for the immersive-review agent status bar expansion
+ * state (the TODO plan + streaming-status bar pinned to the top of immersive
+ * review). Persisted per workspace so a user's collapse choice survives
+ * navigation. Mirrors getPinnedTodoExpandedKey — a transient UI preference, so
+ * intentionally NOT copied on fork.
+ * Format: "review-immersive-agentbar-expanded:{workspaceId}"
+ */
+export function getImmersiveReviewAgentBarExpandedKey(workspaceId: string): string {
+  return `review-immersive-agentbar-expanded:${workspaceId}`;
+}
+
+/**
  * Get the localStorage key for auto-compaction enabled preference per workspace
  * Format: "autoCompaction:enabled:{workspaceId}"
  */


### PR DESCRIPTION
## Summary

Two gaps in full-screen **Immersive Review** are fixed: there's now a clear indicator when the **Assisted** filter is active, and a top status bar that surfaces the agent's **TODO plan** (a compact horizontal strip) alongside **live chat/streaming status** so reviewers waiting on the agent keep their signal without leaving review.

## Background

Immersive review renders into an opaque overlay (`#review-immersive-root`, `absolute inset-0 z-50`) that covers the normal review panel.

1. **No Assisted-mode indication.** The Assisted toggle/badge lives in `ReviewControls`, which is hidden behind that overlay. Once immersive, the diff could be filtered to agent-flagged hunks with zero on-screen indication. (The existing per-hunk assisted *banner* only means "this hunk was flagged" — not "the worklist filter is on".)
2. **No chat status.** A common workflow is reviewing code while waiting for the agent to respond. In immersive mode the transcript, composer streaming barrier, and pinned TODO list are all hidden, so the user had no view of plan progress or streaming state.

## Implementation

**Issue 1 — Assisted-mode badge**
- `ReviewPanel` now threads `assistedOnly` + `assistedCount` + `assistedUnreadCount` into the immersive portal (previously only the per-hunk `assistedHunkIds`/comments were passed).
- `ImmersiveReviewView` renders a header badge (`Sparkles` + `--color-review-accent` + `unread/total` via `counter-nums`) only while `assistedOnly` is on. Kept visually/semantically distinct from the per-hunk assisted banner.

**Issue 2 — Agent status bar** (`ImmersiveReviewAgentStatusBar.tsx`, mounted between header and the per-hunk banner)
- TODO plan rendered as a single **horizontal** strip via the shared `<TodoList layout="horizontal">` (one row tall, scrolls sideways — minimal review height), collapsible with per-workspace persisted expand state (new `getImmersiveReviewAgentBarExpandedKey`), plus a summary line ("TODO · 2 in progress · 3 pending").
- Compact streaming chip: `Starting…` / `Streaming…` / a prominent "Mux has a question".
- **Flash-free & graceful:**
  - Chip is gated on the *held* phase from `useWorkspaceStreamingStatusPhase` (150ms), so starting↔streaming handoffs don't blink.
  - Because plans persist across turns, the bar stays mounted between streams and only unmounts once the held phase clears **and** there are no todos — no mid-review flicker.
  - Data is synchronous from `WorkspaceStore` (no skeleton needed); subscriptions live in this leaf so todo/stream churn doesn't re-render the large diff tree.
  - Crash-safe: falls back to empty/idle when the workspace isn't registered (renders `null` in tests/stories rather than throwing).

**Banner scoping** — the per-hunk assisted comment banner now lives inside the diff column wrapper (not above the whole body), so it spans only the diff width and lines up with the code it refers to instead of stretching across the minimap + notes sidebar.

## Validation

- New behavioral tests: `ImmersiveReviewAgentStatusBar.test.tsx` (plan render, idle→null, streaming/starting chips, awaiting-question precedence, collapse persistence) and an assisted-badge gating test in `ImmersiveReviewView.test.tsx`.
- New Storybook stories for Chromatic coverage: `ImmersiveWithAssistedMode` (header badge), `ImmersiveWithAgentStatusBar` (horizontal TODO strip + live streaming chip), and `ImmersiveWithStreamingNoTodo` (chip-only state when streaming before any plan is written). The status-bar stories seed the `WorkspaceStore` so the bar has real state. Snapshot budget stays within limit (250/250, no bump).
- Snapshot budget: rebased on `main` (current limit 250); the two new immersive stories fit within budget (249/250), so no budget change or story compression was needed.

## Risks

Low. The status bar is an additive, self-subscribed leaf that returns `null` when there's nothing to show, so it can't reserve review height or cascade re-renders into the diff. The only change to existing render paths is the new header badge (gated on `assistedOnly`), three new optional props threaded from `ReviewPanel`, and moving the assisted banner inside the diff column.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-8` • Thinking: `xhigh` • Cost: `$47.63`_

<!-- mux-attribution: model=anthropic:claude-opus-4-8 thinking=xhigh costs=47.63 -->