### PR TITLE
🤖 tests: cut Storybook snapshot budget to 50 under the 300 limit

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -208,12 +208,21 @@ const preview: Preview = {
         },
       },
     },
-    chromatic: {
-      modes: {
-        dark: { theme: "dark" },
-        light: { theme: "light" },
-      },
-    },
+    // Chromatic modes STACK across project → component → story levels (they are
+    // NOT overridden by more specific levels). A project-level `modes` map here
+    // would therefore be added to EVERY story's snapshot set on top of whatever
+    // each meta/story declares, multiplying the whole budget. Concretely, a
+    // global { dark, light } stacked onto appMeta's `dark-desktop` produced 3
+    // snapshots per App story (dark + light + dark-desktop) instead of the 1 the
+    // meta intended — silently inflating the Chromatic snapshot budget.
+    //
+    // We intentionally declare NO project-level modes. Stories then snapshot in:
+    //   - the modes their meta/story explicitly declare (e.g. CHROMATIC_SINGLE_MODE,
+    //     CHROMATIC_SMOKE_MODES), or
+    //   - a single default snapshot (the default `theme: "dark"` global) when none
+    //     are declared.
+    // Dual-theme coverage is opt-in per file/story via CHROMATIC_SMOKE_MODES, which
+    // matches the documented policy in src/browser/stories/meta.tsx.
   },
 };
 

--- a/src/browser/components/AgentListItem/AgentListItem.stories.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.stories.tsx
@@ -196,72 +196,91 @@ function StoryScaffold(props: {
   );
 }
 
-function renderFigmaStates() {
+// Labeled wrapper so each gallery permutation stays visually distinct and
+// identifiable to reviewers even though many states now share one snapshot.
+function GallerySection(props: { label: string; children: ReactNode }) {
   return (
-    <StoryScaffold>
-      <AgentListItem
-        metadata={STORY_WORKSPACES[0]}
-        projectPath={PROJECT_PATH}
-        projectName={PROJECT_NAME}
-        isSelected
-        onSelectWorkspace={() => undefined}
-        onForkWorkspace={() => Promise.resolve()}
-        onArchiveWorkspace={() => Promise.resolve()}
-        onCancelCreation={() => Promise.resolve()}
-      />
-      <AgentListItem
-        metadata={STORY_WORKSPACES[1]}
-        projectPath={PROJECT_PATH}
-        projectName={PROJECT_NAME}
-        isSelected={false}
-        onSelectWorkspace={() => undefined}
-        onForkWorkspace={() => Promise.resolve()}
-        onArchiveWorkspace={() => Promise.resolve()}
-        onCancelCreation={() => Promise.resolve()}
-      />
-      <AgentListItem
-        metadata={STORY_WORKSPACES[2]}
-        projectPath={PROJECT_PATH}
-        projectName={PROJECT_NAME}
-        isSelected={false}
-        onSelectWorkspace={() => undefined}
-        onForkWorkspace={() => Promise.resolve()}
-        onArchiveWorkspace={() => Promise.resolve()}
-        onCancelCreation={() => Promise.resolve()}
-      />
-      <AgentListItem
-        metadata={STORY_WORKSPACES[3]}
-        projectPath={PROJECT_PATH}
-        projectName={PROJECT_NAME}
-        isSelected={false}
-        onSelectWorkspace={() => undefined}
-        onForkWorkspace={() => Promise.resolve()}
-        onArchiveWorkspace={() => Promise.resolve()}
-        onCancelCreation={() => Promise.resolve()}
-      />
-      <AgentListItem
-        metadata={STORY_WORKSPACES[4]}
-        projectPath={PROJECT_PATH}
-        projectName={PROJECT_NAME}
-        isSelected={false}
-        onSelectWorkspace={() => undefined}
-        onForkWorkspace={() => Promise.resolve()}
-        onArchiveWorkspace={() => Promise.resolve()}
-        onCancelCreation={() => Promise.resolve()}
-      />
-      <AgentListItem
-        variant="draft"
-        draft={{
-          draftId: "draft-state",
-          draftNumber: 1,
-          title: "Draft agent workflow",
-          promptPreview: "",
-          onOpen: () => undefined,
-          onDelete: () => undefined,
-        }}
-        projectPath={PROJECT_PATH}
-        isSelected={false}
-      />
+    <div className="space-y-1">
+      <div className="text-xs font-medium opacity-60">{props.label}</div>
+      {props.children}
+    </div>
+  );
+}
+
+// Shared row factory so gallery permutations don't duplicate the long prop list.
+function WorkspaceRow(props: {
+  workspace: (typeof STORY_WORKSPACES)[number];
+  isSelected?: boolean;
+  isArchiving?: boolean;
+  rowRenderMeta?: AgentRowRenderMeta;
+  completedChildrenExpanded?: boolean;
+  onToggleCompletedChildren?: (workspaceId: string) => void;
+}) {
+  return (
+    <AgentListItem
+      metadata={props.workspace}
+      projectPath={PROJECT_PATH}
+      projectName={PROJECT_NAME}
+      depth={props.rowRenderMeta?.depth}
+      rowRenderMeta={props.rowRenderMeta}
+      completedChildrenExpanded={props.completedChildrenExpanded}
+      onToggleCompletedChildren={props.onToggleCompletedChildren}
+      isSelected={props.isSelected ?? false}
+      isArchiving={props.isArchiving === true}
+      onSelectWorkspace={() => undefined}
+      onForkWorkspace={() => Promise.resolve()}
+      onArchiveWorkspace={() => Promise.resolve()}
+      onCancelCreation={() => Promise.resolve()}
+    />
+  );
+}
+
+function DraftRow() {
+  return (
+    <AgentListItem
+      variant="draft"
+      draft={{
+        draftId: "draft-state",
+        draftNumber: 1,
+        title: "Draft agent workflow",
+        promptPreview: "",
+        onOpen: () => undefined,
+        onDelete: () => undefined,
+      }}
+      projectPath={PROJECT_PATH}
+      isSelected={false}
+    />
+  );
+}
+
+// Gallery merging the primary single-workspace visual states (formerly the
+// FigmaStates, Selected, Active, ErrorState, Archiving, Question, and Draft
+// stories) into one snapshot. Status text/emoji is per-workspace (driven by the
+// persisted status state set in StoryScaffold), so each row shows its own state.
+function renderStatesGallery() {
+  return (
+    <StoryScaffold activeWorkspaceId="ws-active">
+      <GallerySection label="Selected">
+        <WorkspaceRow workspace={STORY_WORKSPACES[0]} isSelected />
+      </GallerySection>
+      <GallerySection label="Active (streaming)">
+        <WorkspaceRow workspace={STORY_WORKSPACES[1]} />
+      </GallerySection>
+      <GallerySection label="Idle">
+        <WorkspaceRow workspace={STORY_WORKSPACES[2]} />
+      </GallerySection>
+      <GallerySection label="Error">
+        <WorkspaceRow workspace={STORY_WORKSPACES[3]} />
+      </GallerySection>
+      <GallerySection label="Archiving">
+        <WorkspaceRow workspace={STORY_WORKSPACES[3]} isArchiving />
+      </GallerySection>
+      <GallerySection label="Question">
+        <WorkspaceRow workspace={STORY_WORKSPACES[4]} />
+      </GallerySection>
+      <GallerySection label="Draft">
+        <DraftRow />
+      </GallerySection>
     </StoryScaffold>
   );
 }
@@ -296,26 +315,6 @@ function renderIdleState(isUnread: boolean) {
   return renderSingleWorkspaceState(2);
 }
 
-function renderDraftState() {
-  return (
-    <StoryScaffold>
-      <AgentListItem
-        variant="draft"
-        draft={{
-          draftId: "draft-state",
-          draftNumber: 1,
-          title: "Draft agent workflow",
-          promptPreview: "",
-          onOpen: () => undefined,
-          onDelete: () => undefined,
-        }}
-        projectPath={PROJECT_PATH}
-        isSelected={false}
-      />
-    </StoryScaffold>
-  );
-}
-
 const SUB_AGENT_ROW_META_BASE = {
   depth: 1,
   rowKind: "subagent",
@@ -341,39 +340,6 @@ function createSubAgentRowRenderMeta(
     connectorPosition,
     ...overrides,
   };
-}
-
-function renderWorkspaceWithRowMeta(options: {
-  workspaceIndex: number;
-  rowRenderMeta: AgentRowRenderMeta;
-  isSelected?: boolean;
-  completedChildrenExpanded?: boolean;
-  onToggleCompletedChildren?: (workspaceId: string) => void;
-  activeWorkspaceId?: string;
-  metadataOverride?: Partial<(typeof STORY_WORKSPACES)[number]>;
-}) {
-  const workspace = {
-    ...STORY_WORKSPACES[options.workspaceIndex],
-    ...options.metadataOverride,
-  };
-  return (
-    <StoryScaffold activeWorkspaceId={options.activeWorkspaceId}>
-      <AgentListItem
-        metadata={workspace}
-        projectPath={PROJECT_PATH}
-        projectName={PROJECT_NAME}
-        depth={options.rowRenderMeta.depth}
-        rowRenderMeta={options.rowRenderMeta}
-        completedChildrenExpanded={options.completedChildrenExpanded}
-        onToggleCompletedChildren={options.onToggleCompletedChildren}
-        isSelected={options.isSelected ?? false}
-        onSelectWorkspace={() => undefined}
-        onForkWorkspace={() => Promise.resolve()}
-        onArchiveWorkspace={() => Promise.resolve()}
-        onCancelCreation={() => Promise.resolve()}
-      />
-    </StoryScaffold>
-  );
 }
 
 const NESTED_CONNECTOR_PARENT_ROW_META = {
@@ -493,21 +459,16 @@ function renderAppSidebarThreeActiveSubAgents() {
   );
 }
 
-export const FigmaStates: Story = {
+// Composite gallery covering the primary single-workspace states. Replaces the
+// former FigmaStates, Selected, Active, ErrorState, Archiving, Question, and
+// Draft stories — one snapshot, all states preserved and labeled.
+export const States: Story = {
   args: undefined as never,
-  render: renderFigmaStates,
+  render: renderStatesGallery,
 };
 
-export const Selected: Story = {
-  args: undefined as never,
-  render: () => renderSingleWorkspaceState(0),
-};
-
-export const Active: Story = {
-  args: undefined as never,
-  render: () => renderSingleWorkspaceState(1),
-};
-
+// Idle seen vs unread are kept as separate stories: both drive the same
+// ws-idle last-read persisted key, so they cannot coexist in one scaffold.
 export const IdleSeen: Story = {
   args: undefined as never,
   render: () => renderIdleState(false),
@@ -516,26 +477,6 @@ export const IdleSeen: Story = {
 export const IdleNotSeen: Story = {
   args: undefined as never,
   render: () => renderIdleState(true),
-};
-
-export const ErrorState: Story = {
-  args: undefined as never,
-  render: () => renderSingleWorkspaceState(3),
-};
-
-export const Archiving: Story = {
-  args: undefined as never,
-  render: () => renderSingleWorkspaceState(3, { isArchiving: true }),
-};
-
-export const Question: Story = {
-  args: undefined as never,
-  render: () => renderSingleWorkspaceState(4),
-};
-
-export const Draft: Story = {
-  args: undefined as never,
-  render: renderDraftState,
 };
 
 const PRIMARY_ROW_META_WITH_HIDDEN_COMPLETED_CHILDREN = {
@@ -552,118 +493,97 @@ const PRIMARY_ROW_META_WITH_HIDDEN_COMPLETED_CHILDREN = {
 
 const noopToggleCompletedChildren = () => undefined;
 
-export const SubAgentMiddle: Story = {
-  args: undefined as never,
-  name: "SubAgent States/SubAgent Middle",
-  render: () =>
-    renderWorkspaceWithRowMeta({
-      workspaceIndex: 2,
-      rowRenderMeta: createSubAgentRowRenderMeta("middle"),
-    }),
-};
+// Composite gallery for sub-agent row permutations. Replaces the eleven former
+// SubAgent* / Parent* stories with one labeled snapshot. activeWorkspaceId is
+// "ws-active": rows backed by ws-active (which has persisted status state) show
+// status text, matching the former "...With Status Text" variants, while
+// ws-idle rows show none — exactly as before. The single AppSidebar story stays
+// separate because it uses a distinct workspace set.
+function renderSubAgentGallery() {
+  // ws-idle (index 2) used as a generic sub-agent row with no status text.
+  const idle = STORY_WORKSPACES[2];
+  // ws-active (index 1) carries persisted status state, so its rows render the
+  // status-text treatment from the former "...With Status Text" stories.
+  const active = STORY_WORKSPACES[1];
+  return (
+    <StoryScaffold activeWorkspaceId="ws-active">
+      <GallerySection label="Middle">
+        <WorkspaceRow workspace={idle} rowRenderMeta={createSubAgentRowRenderMeta("middle")} />
+      </GallerySection>
+      <GallerySection label="Running">
+        <WorkspaceRow
+          workspace={{ ...idle, taskStatus: "running" }}
+          rowRenderMeta={createSubAgentRowRenderMeta("middle", {
+            connectorStartsAtParent: true,
+            sharedTrunkActiveThroughRow: true,
+            sharedTrunkActiveBelowRow: true,
+          })}
+        />
+      </GallerySection>
+      <GallerySection label="Last">
+        <WorkspaceRow workspace={idle} rowRenderMeta={createSubAgentRowRenderMeta("last")} />
+      </GallerySection>
+      <GallerySection label="Single">
+        <WorkspaceRow workspace={idle} rowRenderMeta={createSubAgentRowRenderMeta("single")} />
+      </GallerySection>
+      <GallerySection label="Middle Selected">
+        <WorkspaceRow
+          workspace={idle}
+          rowRenderMeta={createSubAgentRowRenderMeta("middle")}
+          isSelected
+        />
+      </GallerySection>
+      <GallerySection label="With Status Text">
+        <WorkspaceRow workspace={active} rowRenderMeta={createSubAgentRowRenderMeta("middle")} />
+      </GallerySection>
+      <GallerySection label="Middle Selected With Status Text">
+        <WorkspaceRow
+          workspace={active}
+          rowRenderMeta={createSubAgentRowRenderMeta("middle")}
+          isSelected
+        />
+      </GallerySection>
+      <GallerySection label="Last With Status Text">
+        <WorkspaceRow workspace={active} rowRenderMeta={createSubAgentRowRenderMeta("last")} />
+      </GallerySection>
+      <GallerySection label="Last Selected">
+        <WorkspaceRow
+          workspace={idle}
+          rowRenderMeta={createSubAgentRowRenderMeta("last")}
+          isSelected
+        />
+      </GallerySection>
+      <GallerySection label="Last Selected With Status Text">
+        <WorkspaceRow
+          workspace={active}
+          rowRenderMeta={createSubAgentRowRenderMeta("last")}
+          isSelected
+        />
+      </GallerySection>
+      <GallerySection label="Parent With Completed Children Collapsed">
+        <WorkspaceRow
+          workspace={idle}
+          rowRenderMeta={PRIMARY_ROW_META_WITH_HIDDEN_COMPLETED_CHILDREN}
+          completedChildrenExpanded={false}
+          onToggleCompletedChildren={noopToggleCompletedChildren}
+        />
+      </GallerySection>
+      <GallerySection label="Parent With Completed Children Expanded">
+        <WorkspaceRow
+          workspace={idle}
+          rowRenderMeta={PRIMARY_ROW_META_WITH_HIDDEN_COMPLETED_CHILDREN}
+          completedChildrenExpanded={true}
+          onToggleCompletedChildren={noopToggleCompletedChildren}
+        />
+      </GallerySection>
+    </StoryScaffold>
+  );
+}
 
-export const SubAgentRunning: Story = {
+export const SubAgentStates: Story = {
   args: undefined as never,
-  render: () =>
-    renderWorkspaceWithRowMeta({
-      workspaceIndex: 2,
-      rowRenderMeta: createSubAgentRowRenderMeta("middle", {
-        connectorStartsAtParent: true,
-        sharedTrunkActiveThroughRow: true,
-        sharedTrunkActiveBelowRow: true,
-      }),
-      metadataOverride: {
-        taskStatus: "running",
-      },
-    }),
-};
-
-export const SubAgentLast: Story = {
-  args: undefined as never,
-  name: "SubAgent States/SubAgent Last",
-  render: () =>
-    renderWorkspaceWithRowMeta({
-      workspaceIndex: 2,
-      rowRenderMeta: createSubAgentRowRenderMeta("last"),
-    }),
-};
-
-export const SubAgentSingle: Story = {
-  args: undefined as never,
-  name: "SubAgent States/SubAgent Single",
-  render: () =>
-    renderWorkspaceWithRowMeta({
-      workspaceIndex: 2,
-      rowRenderMeta: createSubAgentRowRenderMeta("single"),
-    }),
-};
-
-export const SubAgentMiddleSelected: Story = {
-  args: undefined as never,
-  name: "SubAgent States/SubAgent Middle Selected",
-  render: () =>
-    renderWorkspaceWithRowMeta({
-      workspaceIndex: 2,
-      rowRenderMeta: createSubAgentRowRenderMeta("middle"),
-      isSelected: true,
-    }),
-};
-
-export const SubAgentWithStatusText: Story = {
-  args: undefined as never,
-  name: "SubAgent States/SubAgent With Status Text",
-  render: () =>
-    renderWorkspaceWithRowMeta({
-      workspaceIndex: 1,
-      rowRenderMeta: createSubAgentRowRenderMeta("middle"),
-      activeWorkspaceId: "ws-active",
-    }),
-};
-
-export const SubAgentMiddleSelectedWithStatusText: Story = {
-  args: undefined as never,
-  name: "SubAgent States/SubAgent Middle Selected With Status Text",
-  render: () =>
-    renderWorkspaceWithRowMeta({
-      workspaceIndex: 1,
-      rowRenderMeta: createSubAgentRowRenderMeta("middle"),
-      isSelected: true,
-      activeWorkspaceId: "ws-active",
-    }),
-};
-
-export const SubAgentLastWithStatusText: Story = {
-  args: undefined as never,
-  name: "SubAgent States/SubAgent Last With Status Text",
-  render: () =>
-    renderWorkspaceWithRowMeta({
-      workspaceIndex: 1,
-      rowRenderMeta: createSubAgentRowRenderMeta("last"),
-      activeWorkspaceId: "ws-active",
-    }),
-};
-
-export const SubAgentLastSelected: Story = {
-  args: undefined as never,
-  name: "SubAgent States/SubAgent Last Selected",
-  render: () =>
-    renderWorkspaceWithRowMeta({
-      workspaceIndex: 2,
-      rowRenderMeta: createSubAgentRowRenderMeta("last"),
-      isSelected: true,
-    }),
-};
-
-export const SubAgentLastSelectedWithStatusText: Story = {
-  args: undefined as never,
-  name: "SubAgent States/SubAgent Last Selected With Status Text",
-  render: () =>
-    renderWorkspaceWithRowMeta({
-      workspaceIndex: 1,
-      rowRenderMeta: createSubAgentRowRenderMeta("last"),
-      isSelected: true,
-      activeWorkspaceId: "ws-active",
-    }),
+  name: "SubAgent States/Gallery",
+  render: renderSubAgentGallery,
 };
 
 export const AppSidebarThreeActiveSubAgents: Story = {
@@ -672,29 +592,6 @@ export const AppSidebarThreeActiveSubAgents: Story = {
   render: renderAppSidebarThreeActiveSubAgents,
 };
 
-export const ParentWithCompletedChildrenCollapsed: Story = {
-  args: undefined as never,
-  name: "SubAgent States/Parent With Completed Children Collapsed",
-  render: () =>
-    renderWorkspaceWithRowMeta({
-      workspaceIndex: 2,
-      rowRenderMeta: PRIMARY_ROW_META_WITH_HIDDEN_COMPLETED_CHILDREN,
-      completedChildrenExpanded: false,
-      onToggleCompletedChildren: noopToggleCompletedChildren,
-    }),
-};
-
-export const ParentWithCompletedChildrenExpanded: Story = {
-  args: undefined as never,
-  name: "SubAgent States/Parent With Completed Children Expanded",
-  render: () =>
-    renderWorkspaceWithRowMeta({
-      workspaceIndex: 2,
-      rowRenderMeta: PRIMARY_ROW_META_WITH_HIDDEN_COMPLETED_CHILDREN,
-      completedChildrenExpanded: true,
-      onToggleCompletedChildren: noopToggleCompletedChildren,
-    }),
-};
 export const ClickKebabButton: Story = {
   args: undefined as never,
   render: () => renderSingleWorkspaceState(1),

--- a/src/browser/components/ProjectPage/ProjectPage.stories.tsx
+++ b/src/browser/components/ProjectPage/ProjectPage.stories.tsx
@@ -104,9 +104,9 @@ export const CreateWorkspaceMultipleProjects: AppStory = {
   parameters: {
     chromatic: {
       modes: {
+        // Two snapshots cover both themes AND both viewports without paying for
+        // the full 2x2 matrix: a dark desktop render plus a light mobile render.
         dark: { theme: "dark" },
-        light: { theme: "light" },
-        "dark-mobile": { theme: "dark", viewport: "mobile1", hasTouch: true },
         "light-mobile": { theme: "light", viewport: "mobile1", hasTouch: true },
       },
     },
@@ -144,9 +144,9 @@ export const CreateWorkspaceWithSections: AppStory = {
   parameters: {
     chromatic: {
       modes: {
+        // Two snapshots cover both themes AND both viewports without paying for
+        // the full 2x2 matrix: a dark desktop render plus a light mobile render.
         dark: { theme: "dark" },
-        light: { theme: "light" },
-        "dark-mobile": { theme: "dark", viewport: "mobile1", hasTouch: true },
         "light-mobile": { theme: "light", viewport: "mobile1", hasTouch: true },
       },
     },

--- a/src/browser/features/Messages/MessageRenderer.stories.tsx
+++ b/src/browser/features/Messages/MessageRenderer.stories.tsx
@@ -7,7 +7,6 @@ import {
   setupStreamingChatStory,
 } from "@/browser/stories/helpers/chatSetup";
 import { collapseLeftSidebar } from "@/browser/stories/helpers/uiState";
-import { createStaticChatHandler } from "@/browser/stories/mocks/chatHandlers";
 import {
   createAssistantMessage,
   createGoalBudgetLimitMessage,
@@ -89,82 +88,131 @@ const LARGE_DIFF = [
   "+}",
 ].join("\n");
 
-/** Basic chat conversation with various message types */
+/**
+ * Core conversation composite (smoke story).
+ *
+ * Folds several non-interactive permutations into one chat to keep the
+ * Chromatic snapshot budget low while preserving coverage:
+ * - truncated/hidden history indicator (merged from HiddenHistory)
+ * - user/assistant text + web search / file read / file edit tool calls
+ * - reasoning/thinking blocks (merged from WithReasoning)
+ */
 export const Conversation: AppStory = {
   parameters: { chromatic: { modes: CHROMATIC_SMOKE_MODES } },
   render: () => (
     <AppWithMocks
       setup={() => {
         collapseLeftSidebar();
-        return setupSimpleChatStory({
-          messages: [
-            createUserMessage("msg-1", "Add authentication to the user API endpoint", {
-              historySequence: 1,
-              timestamp: STABLE_TIMESTAMP - 300000,
-            }),
-            createAssistantMessage(
-              "msg-2",
-              "I'll help you add authentication. Let me search for best practices first.",
-              {
-                historySequence: 2,
-                timestamp: STABLE_TIMESTAMP - 295000,
-                toolCalls: [createWebSearchTool("call-0", "JWT authentication best practices", 5)],
-              }
-            ),
-            createAssistantMessage("msg-3", "Great, let me check the current implementation.", {
-              historySequence: 3,
-              timestamp: STABLE_TIMESTAMP - 290000,
-              toolCalls: [
-                createFileReadTool(
-                  "call-1",
-                  "src/api/users.ts",
-                  "export function getUser(req, res) {\n  const user = db.users.find(req.params.id);\n  res.json(user);\n}"
-                ),
-              ],
-            }),
-            createUserMessage("msg-4", "Yes, add JWT token validation", {
-              historySequence: 4,
-              timestamp: STABLE_TIMESTAMP - 280000,
-            }),
-            createAssistantMessage("msg-5", "I'll add JWT validation. Here's the update:", {
-              historySequence: 5,
-              timestamp: STABLE_TIMESTAMP - 270000,
-              toolCalls: [
-                createFileEditTool(
-                  "call-2",
-                  "src/api/users.ts",
-                  [
-                    "--- src/api/users.ts",
-                    "+++ src/api/users.ts",
-                    "@@ -1,5 +1,15 @@",
-                    "+import { verifyToken } from '../auth/jwt';",
-                    " export function getUser(req, res) {",
-                    "+  const token = req.headers.authorization?.split(' ')[1];",
-                    "+  if (!token || !verifyToken(token)) {",
-                    "+    return res.status(401).json({ error: 'Unauthorized' });",
-                    "+  }",
-                    "   const user = db.users.find(req.params.id);",
-                    "   res.json(user);",
-                    " }",
-                  ].join("\n")
-                ),
-              ],
-            }),
-          ],
-        });
+        // Hidden message type uses special "hidden" role not in ChatMuxMessage union.
+        // Cast is needed since this is a display-only message type.
+        const hiddenIndicator = {
+          type: "message",
+          id: "hidden-1",
+          role: "hidden",
+          parts: [],
+          metadata: {
+            historySequence: 0,
+            hiddenCount: 42,
+          },
+        } as unknown as ChatMuxMessage;
+
+        const messages: ChatMuxMessage[] = [
+          hiddenIndicator,
+          createUserMessage("msg-1", "Add authentication to the user API endpoint", {
+            historySequence: 1,
+            timestamp: STABLE_TIMESTAMP - 300000,
+          }),
+          createAssistantMessage(
+            "msg-2",
+            "I'll help you add authentication. Let me search for best practices first.",
+            {
+              historySequence: 2,
+              timestamp: STABLE_TIMESTAMP - 295000,
+              toolCalls: [createWebSearchTool("call-0", "JWT authentication best practices", 5)],
+            }
+          ),
+          createAssistantMessage("msg-3", "Great, let me check the current implementation.", {
+            historySequence: 3,
+            timestamp: STABLE_TIMESTAMP - 290000,
+            toolCalls: [
+              createFileReadTool(
+                "call-1",
+                "src/api/users.ts",
+                "export function getUser(req, res) {\n  const user = db.users.find(req.params.id);\n  res.json(user);\n}"
+              ),
+            ],
+          }),
+          createUserMessage("msg-4", "Yes, add JWT token validation", {
+            historySequence: 4,
+            timestamp: STABLE_TIMESTAMP - 280000,
+          }),
+          createAssistantMessage("msg-5", "I'll add JWT validation. Here's the update:", {
+            historySequence: 5,
+            timestamp: STABLE_TIMESTAMP - 270000,
+            toolCalls: [
+              createFileEditTool(
+                "call-2",
+                "src/api/users.ts",
+                [
+                  "--- src/api/users.ts",
+                  "+++ src/api/users.ts",
+                  "@@ -1,5 +1,15 @@",
+                  "+import { verifyToken } from '../auth/jwt';",
+                  " export function getUser(req, res) {",
+                  "+  const token = req.headers.authorization?.split(' ')[1];",
+                  "+  if (!token || !verifyToken(token)) {",
+                  "+    return res.status(401).json({ error: 'Unauthorized' });",
+                  "+  }",
+                  "   const user = db.users.find(req.params.id);",
+                  "   res.json(user);",
+                  " }",
+                ].join("\n")
+              ),
+            ],
+          }),
+          // Reasoning/thinking blocks (merged from former WithReasoning story)
+          createUserMessage("msg-6", "What about error handling if the JWT library throws?", {
+            historySequence: 6,
+            timestamp: STABLE_TIMESTAMP - 100000,
+          }),
+          createAssistantMessage(
+            "msg-7",
+            "Good catch! We should add try-catch error handling around the JWT verification.",
+            {
+              historySequence: 7,
+              timestamp: STABLE_TIMESTAMP - 90000,
+              reasoning:
+                "The user is asking about error handling for JWT verification. The verifyToken function could throw if the token is malformed or if there's an issue with the secret. I should wrap it in a try-catch block and return a proper error response.",
+            }
+          ),
+          createAssistantMessage("msg-8", "Cache is warm, shifting focus to documentation next.", {
+            historySequence: 8,
+            timestamp: STABLE_TIMESTAMP - 80000,
+            reasoning: "Cache is warm already; rerunning would be redundant.",
+          }),
+        ];
+
+        return setupSimpleChatStory({ messages });
       }}
     />
   ),
 };
 
-/** Chat with reasoning/thinking blocks */
-/** Synthetic auto-resume messages shown with "AUTO" badge and dimmed opacity */
+/**
+ * Synthetic / goal system-message composite.
+ *
+ * Folds three non-interactive permutations into one chat:
+ * - synthetic auto-resume messages shown with "AUTO" badge and dimmed opacity
+ * - goal continuation message (merged from GoalContinuationMessages)
+ * - goal budget-limit wrap-up message (merged from BudgetLimitWrapupMessages)
+ */
 export const SyntheticAutoResumeMessages: AppStory = {
   render: () => (
     <AppWithMocks
       setup={() => {
         collapseLeftSidebar();
         return setupSimpleChatStory({
+          workspaceId: "ws-synthetic-goal",
           messages: [
             createUserMessage("msg-1", "Run the full test suite and fix any failures", {
               historySequence: 1,
@@ -189,153 +237,47 @@ export const SyntheticAutoResumeMessages: AppStory = {
                 synthetic: true,
               }
             ),
-            createAssistantMessage("msg-4", "I'll wait for the sub-agent to complete its work.", {
-              historySequence: 4,
-              timestamp: STABLE_TIMESTAMP - 285000,
-            }),
             createUserMessage(
-              "msg-5",
+              "msg-4",
               "Your background sub-agent task(s) have completed. Use task_await to retrieve their reports and integrate the results.",
               {
-                historySequence: 5,
-                timestamp: STABLE_TIMESTAMP - 280000,
+                historySequence: 4,
+                timestamp: STABLE_TIMESTAMP - 285000,
                 synthetic: true,
               }
             ),
-            createAssistantMessage(
-              "msg-6",
-              "The sub-agent has finished. All 47 tests passed successfully — no failures found.",
-              {
-                historySequence: 6,
-                timestamp: STABLE_TIMESTAMP - 275000,
-              }
-            ),
-          ],
-        });
-      }}
-    />
-  ),
-};
-
-export const GoalContinuationMessages: AppStory = {
-  render: () => (
-    <AppWithMocks
-      setup={() => {
-        collapseLeftSidebar();
-        return setupSimpleChatStory({
-          workspaceId: "ws-goal-continuation",
-          messages: [
-            createUserMessage("msg-1", "begin", {
-              historySequence: 1,
-              timestamp: STABLE_TIMESTAMP - 120000,
-            }),
-            createAssistantMessage("msg-2", "I'll start by inspecting the repository state.", {
-              historySequence: 2,
-              timestamp: STABLE_TIMESTAMP - 110000,
-            }),
+            // Goal continuation (merged from former GoalContinuationMessages story)
             createGoalContinuationMessage(
-              "msg-3",
+              "msg-5",
               "Continue working on the active workspace goal.\n\n<untrusted_objective>Ship the requested feature with tests.</untrusted_objective>",
               {
-                historySequence: 3,
-                timestamp: STABLE_TIMESTAMP - 60000,
-              }
-            ),
-            createAssistantMessage(
-              "msg-4",
-              "Continuing from the active goal, I'll add coverage next.",
-              {
-                historySequence: 4,
-                timestamp: STABLE_TIMESTAMP - 50000,
-              }
-            ),
-          ],
-        });
-      }}
-    />
-  ),
-};
-
-export const BudgetLimitWrapupMessages: AppStory = {
-  render: () => (
-    <AppWithMocks
-      setup={() => {
-        collapseLeftSidebar();
-        return setupSimpleChatStory({
-          workspaceId: "ws-goal-budget-wrapup",
-          messages: [
-            createUserMessage("msg-1", "begin", {
-              historySequence: 1,
-              timestamp: STABLE_TIMESTAMP - 180000,
-            }),
-            createAssistantMessage("msg-2", "I'll keep working through the active goal.", {
-              historySequence: 2,
-              timestamp: STABLE_TIMESTAMP - 170000,
-            }),
-            createGoalContinuationMessage(
-              "msg-3",
-              "Continue working on the active workspace goal.\n\n<untrusted_objective>Ship the requested feature with tests.</untrusted_objective>",
-              {
-                historySequence: 3,
+                historySequence: 5,
                 timestamp: STABLE_TIMESTAMP - 120000,
               }
             ),
-            createAssistantMessage("msg-4", "The continuation used the remaining budget.", {
-              historySequence: 4,
-              timestamp: STABLE_TIMESTAMP - 110000,
-            }),
+            createAssistantMessage(
+              "msg-6",
+              "Continuing from the active goal, I'll add coverage next.",
+              {
+                historySequence: 6,
+                timestamp: STABLE_TIMESTAMP - 110000,
+              }
+            ),
+            // Goal budget-limit wrap-up (merged from former BudgetLimitWrapupMessages story)
             createGoalBudgetLimitMessage(
-              "msg-5",
+              "msg-7",
               "The budget for this goal has been exhausted.\n\n<untrusted_objective>Ship the requested feature with tests.</untrusted_objective>\n\nBring the current line of work to a clean stopping point, summarize where things stand, and stop.",
               {
-                historySequence: 5,
+                historySequence: 7,
                 timestamp: STABLE_TIMESTAMP - 60000,
               }
             ),
             createAssistantMessage(
-              "msg-6",
+              "msg-8",
               "Stopping here: tests are partially updated and the remaining risk is in the UI smoke coverage.",
               {
-                historySequence: 6,
+                historySequence: 8,
                 timestamp: STABLE_TIMESTAMP - 50000,
-              }
-            ),
-          ],
-        });
-      }}
-    />
-  ),
-};
-
-export const WithReasoning: AppStory = {
-  render: () => (
-    <AppWithMocks
-      setup={() => {
-        collapseLeftSidebar();
-        return setupSimpleChatStory({
-          workspaceId: "ws-reasoning",
-          messages: [
-            createUserMessage("msg-1", "What about error handling if the JWT library throws?", {
-              historySequence: 1,
-              timestamp: STABLE_TIMESTAMP - 100000,
-            }),
-            createAssistantMessage(
-              "msg-2",
-              "Good catch! We should add try-catch error handling around the JWT verification.",
-              {
-                historySequence: 2,
-                timestamp: STABLE_TIMESTAMP - 90000,
-                reasoning:
-                  "The user is asking about error handling for JWT verification. The verifyToken function could throw if the token is malformed or if there's an issue with the secret. I should wrap it in a try-catch block and return a proper error response.",
-              }
-            ),
-            createAssistantMessage(
-              "msg-3",
-              "Cache is warm, shifting focus to documentation next.",
-              {
-                historySequence: 3,
-                timestamp: STABLE_TIMESTAMP - 80000,
-                reasoning: "Cache is warm already; rerunning would be redundant.",
               }
             ),
           ],
@@ -375,7 +317,15 @@ export const Streaming: AppStory = {
 
 // ═══ Error scenarios (migrated from App.errors.stories.tsx) ═══
 
-/** Stream error messages in chat */
+/**
+ * Stream error composite gallery.
+ *
+ * Folds three non-interactive error permutations into one chat, each rendering
+ * as a distinct stream-error row in the message list:
+ * - generic rate-limit error (StreamError)
+ * - Anthropic overloaded / HTTP 529 server error (merged from AnthropicOverloaded)
+ * - Mux gateway insufficient-balance quota error (merged from MuxGatewayQuota)
+ */
 export const StreamError: AppStory = {
   render: () => (
     <AppWithMocks
@@ -388,42 +338,6 @@ export const StreamError: AppStory = {
           chatHandler: (callback: (event: WorkspaceChatMessage) => void) => {
             setTimeout(() => {
               callback(
-                createUserMessage("msg-1", "Help me refactor the database layer", {
-                  historySequence: 1,
-                  timestamp: STABLE_TIMESTAMP - 100000,
-                })
-              );
-              callback({ type: "caught-up" });
-
-              // Simulate a stream error
-              callback({
-                type: "stream-error",
-                messageId: "error-msg",
-                error: "Rate limit exceeded. Please wait before making more requests.",
-                errorType: "rate_limit",
-              });
-            }, 50);
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
-            return () => {};
-          },
-        });
-      }}
-    />
-  ),
-};
-
-export const AnthropicOverloaded: AppStory = {
-  render: () => (
-    <AppWithMocks
-      setup={() => {
-        collapseLeftSidebar();
-        const workspaceId = "ws-anthropic-overloaded";
-
-        return setupCustomChatStory({
-          workspaceId,
-          chatHandler: (callback: (event: WorkspaceChatMessage) => void) => {
-            setTimeout(() => {
-              callback(
                 createUserMessage("msg-1", "Why did my request fail?", {
                   historySequence: 1,
                   timestamp: STABLE_TIMESTAMP - 100000,
@@ -431,6 +345,15 @@ export const AnthropicOverloaded: AppStory = {
               );
               callback({ type: "caught-up" });
 
+              // Generic rate-limit error (former StreamError)
+              callback({
+                type: "stream-error",
+                messageId: "error-msg",
+                error: "Rate limit exceeded. Please wait before making more requests.",
+                errorType: "rate_limit",
+              });
+
+              // Anthropic overloaded / HTTP 529 (former AnthropicOverloaded)
               callback({
                 type: "stream-start",
                 workspaceId,
@@ -440,56 +363,27 @@ export const AnthropicOverloaded: AppStory = {
                 startTime: STABLE_TIMESTAMP - 90000,
                 mode: "exec",
               });
-
               callback({
                 type: "stream-error",
                 messageId: "assistant-1",
                 error: "Anthropic is temporarily overloaded (HTTP 529). Please try again later.",
                 errorType: "server_error",
               });
-            }, 50);
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
-            return () => {};
-          },
-        });
-      }}
-    />
-  ),
-};
 
-export const MuxGatewayQuota: AppStory = {
-  render: () => (
-    <AppWithMocks
-      setup={() => {
-        collapseLeftSidebar();
-        const workspaceId = "ws-mux-gateway-quota";
-
-        return setupCustomChatStory({
-          workspaceId,
-          chatHandler: (callback: (event: WorkspaceChatMessage) => void) => {
-            setTimeout(() => {
-              callback(
-                createUserMessage("msg-1", "Why did my request fail?", {
-                  historySequence: 1,
-                  timestamp: STABLE_TIMESTAMP - 100000,
-                })
-              );
-              callback({ type: "caught-up" });
-
+              // Mux gateway insufficient balance / quota (former MuxGatewayQuota)
               callback({
                 type: "stream-start",
                 workspaceId,
-                messageId: "assistant-1",
+                messageId: "assistant-2",
                 model: "mux-gateway:anthropic/claude-sonnet-4",
                 routedThroughGateway: true,
-                historySequence: 2,
-                startTime: STABLE_TIMESTAMP - 90000,
+                historySequence: 3,
+                startTime: STABLE_TIMESTAMP - 80000,
                 mode: "exec",
               });
-
               callback({
                 type: "stream-error",
-                messageId: "assistant-1",
+                messageId: "assistant-2",
                 error: "Insufficient balance. Please add credits to continue.",
                 errorType: "quota",
               });
@@ -497,50 +391,6 @@ export const MuxGatewayQuota: AppStory = {
             // eslint-disable-next-line @typescript-eslint/no-empty-function
             return () => {};
           },
-        });
-      }}
-    />
-  ),
-};
-
-/** Chat with truncated/hidden history indicator */
-export const HiddenHistory: AppStory = {
-  render: () => (
-    <AppWithMocks
-      setup={() => {
-        collapseLeftSidebar();
-        // Hidden message type uses special "hidden" role not in ChatMuxMessage union
-        // Cast is needed since this is a display-only message type
-        const hiddenIndicator = {
-          type: "message",
-          id: "hidden-1",
-          role: "hidden",
-          parts: [],
-          metadata: {
-            historySequence: 0,
-            hiddenCount: 42,
-          },
-        } as unknown as ChatMuxMessage;
-
-        const messages: ChatMuxMessage[] = [
-          hiddenIndicator,
-          createUserMessage("msg-1", "Can you summarize what we discussed?", {
-            historySequence: 43,
-            timestamp: STABLE_TIMESTAMP - 100000,
-          }),
-          createAssistantMessage(
-            "msg-2",
-            "Based on our previous conversation, we discussed implementing authentication, adding tests, and refactoring the database layer.",
-            {
-              historySequence: 44,
-              timestamp: STABLE_TIMESTAMP - 90000,
-            }
-          ),
-        ];
-
-        return setupCustomChatStory({
-          workspaceId: "ws-history",
-          chatHandler: createStaticChatHandler(messages),
         });
       }}
     />

--- a/src/browser/features/Messages/TranscriptDensity.stories.tsx
+++ b/src/browser/features/Messages/TranscriptDensity.stories.tsx
@@ -113,7 +113,6 @@ function getRequiredStoryElement(canvasElement: HTMLElement, testId: string): HT
 }
 
 export const NormalNoisyTranscript: AppStory = {
-  parameters: { chromatic: { modes: CHROMATIC_SMOKE_MODES } },
   render: () => <AppWithMocks setup={() => setupTranscriptDensityStory("normal")} />,
 };
 
@@ -123,7 +122,6 @@ export const HyperCollapsedBundles: AppStory = {
 };
 
 export const HyperTailProposePlanExpanded: AppStory = {
-  parameters: { chromatic: { modes: CHROMATIC_SMOKE_MODES } },
   render: () => (
     <AppWithMocks
       setup={() => {
@@ -189,7 +187,14 @@ export const HyperExpandedBundle: AppStory = {
   },
 };
 
-export const HyperActiveExpandedBundle: AppStory = {
+// Gallery merge: three non-interactive hyper-density edge cases (critical events
+// stay visible, an all-miss search bundle, and an active/pending tool tail) are
+// folded into one composite transcript so a single snapshot covers all three
+// states. Each scenario keeps a distinct, labeled user turn so reviewers can still
+// see every permutation. The active/pending scenario is last so the pending tail
+// stays realistic. Replaces the former HyperVisibleCriticalEvents,
+// HyperAllMissSearchBundle, and HyperActiveExpandedBundle stories.
+export const HyperEdgeCaseGallery: AppStory = {
   render: () => (
     <AppWithMocks
       setup={() => {
@@ -198,96 +203,73 @@ export const HyperActiveExpandedBundle: AppStory = {
         const activeStartedAt = Date.now() - 39_000;
         return setupSimpleChatStory({
           messages: [
-            createUserMessage("active-user-1", "Inspect the repository", {
+            // Scenario 1: critical events remain visible in hyper density.
+            createUserMessage("gallery-critical-user", "Make the change and validate it", {
               historySequence: 1,
+              timestamp: STABLE_TIMESTAMP - 60_000,
+            }),
+            createAssistantMessage(
+              "gallery-critical-assistant",
+              "I'll inspect, edit, and validate.",
+              {
+                historySequence: 2,
+                timestamp: STABLE_TIMESTAMP - 55_000,
+                toolCalls: [
+                  createFileReadTool(
+                    "gallery-critical-read",
+                    "src/config.ts",
+                    "export const enabled = false;"
+                  ),
+                  createFileEditTool(
+                    "gallery-critical-edit",
+                    "src/config.ts",
+                    "--- src/config.ts\n+++ src/config.ts\n@@ -1 +1 @@\n-export const enabled = false;\n+export const enabled = true;"
+                  ),
+                  createBashTool(
+                    "gallery-critical-validation",
+                    "make typecheck",
+                    "Type error in src/config.ts",
+                    1
+                  ),
+                  createGenericTool(
+                    "gallery-critical-question",
+                    "ask_user_question",
+                    { question: "Proceed?" },
+                    { answer: "Yes" }
+                  ),
+                  createGenericTool(
+                    "gallery-critical-notify",
+                    "notify",
+                    { title: "Validation failed" },
+                    { success: true }
+                  ),
+                ],
+              }
+            ),
+            // Scenario 2: an all-miss search bundle (zero results).
+            createUserMessage("gallery-miss-user", "Look for a deprecated helper", {
+              historySequence: 3,
+              timestamp: STABLE_TIMESTAMP - 40_000,
+            }),
+            createAssistantMessage("gallery-miss-assistant", "I'll search for that helper.", {
+              historySequence: 4,
+              timestamp: STABLE_TIMESTAMP - 35_000,
+              toolCalls: [createWebSearchTool("gallery-miss-search", "deprecatedMuxHelper", 0)],
+            }),
+            // Scenario 3 (tail): active/pending tools so the elapsed-time UI renders.
+            createUserMessage("gallery-active-user", "Inspect the repository", {
+              historySequence: 5,
               timestamp: activeStartedAt - 5_000,
             }),
-            createAssistantMessage("active-assistant-1", "I'll read the key files now.", {
-              historySequence: 2,
+            createAssistantMessage("gallery-active-assistant", "I'll read the key files now.", {
+              historySequence: 6,
               timestamp: activeStartedAt,
               toolCalls: [
-                createPendingTool("active-read-1", "file_read", { path: "src/App.tsx" }),
-                createPendingTool("active-search-1", "web_search", {
+                createPendingTool("gallery-active-read", "file_read", { path: "src/App.tsx" }),
+                createPendingTool("gallery-active-search", "web_search", {
                   query: "Mux transcript density",
                 }),
               ],
-            }),
-          ],
-        });
-      }}
-    />
-  ),
-};
-
-export const HyperVisibleCriticalEvents: AppStory = {
-  render: () => (
-    <AppWithMocks
-      setup={() => {
-        collapseLeftSidebar();
-        setDensity("hyper");
-        return setupSimpleChatStory({
-          messages: [
-            createUserMessage("critical-user-1", "Make the change and validate it", {
-              historySequence: 1,
-              timestamp: STABLE_TIMESTAMP - 40_000,
-            }),
-            createAssistantMessage("critical-assistant-1", "I'll inspect, edit, and validate.", {
-              historySequence: 2,
-              timestamp: STABLE_TIMESTAMP - 35_000,
-              toolCalls: [
-                createFileReadTool(
-                  "critical-read-1",
-                  "src/config.ts",
-                  "export const enabled = false;"
-                ),
-                createFileEditTool(
-                  "critical-edit-1",
-                  "src/config.ts",
-                  "--- src/config.ts\n+++ src/config.ts\n@@ -1 +1 @@\n-export const enabled = false;\n+export const enabled = true;"
-                ),
-                createBashTool(
-                  "critical-validation-1",
-                  "make typecheck",
-                  "Type error in src/config.ts",
-                  1
-                ),
-                createGenericTool(
-                  "critical-question-1",
-                  "ask_user_question",
-                  { question: "Proceed?" },
-                  { answer: "Yes" }
-                ),
-                createGenericTool(
-                  "critical-notify-1",
-                  "notify",
-                  { title: "Validation failed" },
-                  { success: true }
-                ),
-              ],
-            }),
-          ],
-        });
-      }}
-    />
-  ),
-};
-
-export const HyperAllMissSearchBundle: AppStory = {
-  render: () => (
-    <AppWithMocks
-      setup={() => {
-        collapseLeftSidebar();
-        setDensity("hyper");
-        return setupSimpleChatStory({
-          messages: [
-            createUserMessage("miss-user-1", "Look for a deprecated helper", {
-              historySequence: 1,
-              timestamp: STABLE_TIMESTAMP - 40_000,
-            }),
-            createAssistantMessage("miss-assistant-1", "I'll search for that helper.", {
-              historySequence: 2,
-              timestamp: STABLE_TIMESTAMP - 35_000,
-              toolCalls: [createWebSearchTool("miss-search-1", "deprecatedMuxHelper", 0)],
             }),
           ],
         });

--- a/src/browser/features/RightSidebar/GoalTab.stories.tsx
+++ b/src/browser/features/RightSidebar/GoalTab.stories.tsx
@@ -4,7 +4,12 @@ import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
 import { APIProvider } from "@/browser/contexts/API";
 import { CHROMATIC_SMOKE_MODES } from "@/browser/stories/meta";
 import { createMockORPCClient } from "@/browser/stories/mocks/orpc";
-import type { GoalBoardEntry, GoalBoardSnapshot, GoalRecordV1 } from "@/common/types/goal";
+import type {
+  GoalBoardEntry,
+  GoalBoardSnapshot,
+  GoalRecordV1,
+  GoalSnapshot,
+} from "@/common/types/goal";
 
 import { GoalTab } from "./GoalTab";
 
@@ -17,28 +22,40 @@ const meta: Meta<typeof GoalTab> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const EmptyWithCreateForm: Story = {
-  // Empty-state surface that wires the in-tab create form. Mirrors the
-  // slash-command `goal-set` shape (objective + optional budget + turn
-  // cap). The `onCreate` mock keeps the form interactive in Storybook
-  // without hitting a backend.
-  args: {
+// ─────────────────────────────────────────────────────────────────────────
+// States — composite gallery of the non-interactive GoalTab permutations.
+// Each section is the same component fed a different `goal` arg (empty
+// states, active, paused, budget-limited, complete, accounting/budget
+// variants). Stacking them in one story keeps every visual permutation
+// under review while collapsing eight near-duplicate snapshots into one.
+// Interaction coverage continues to live in `GoalTab.test.tsx`; this
+// gallery is intentionally `play`-free.
+// ─────────────────────────────────────────────────────────────────────────
+
+interface GalleryVariant {
+  label: string;
+  goal: GoalSnapshot | null;
+  onCreate?: () => void;
+}
+
+const STATE_VARIANTS: GalleryVariant[] = [
+  {
+    // Empty-state surface that wires the in-tab create form. Mirrors the
+    // slash-command `goal-set` shape (objective + optional budget + turn
+    // cap). The `onCreate` mock keeps the form interactive in Storybook
+    // without hitting a backend.
+    label: "Empty · with create form",
     goal: null,
     onCreate: () => undefined,
   },
-};
-
-export const EmptyReadOnly: Story = {
-  // Read-only fallback when no create callback is wired (e.g., storybook
-  // stories that exercise the legacy placeholder). Asserts the empty-state
-  // gracefully degrades instead of crashing.
-  args: {
+  {
+    // Read-only fallback when no create callback is wired. Asserts the
+    // empty-state gracefully degrades instead of crashing.
+    label: "Empty · read-only",
     goal: null,
   },
-};
-
-export const Active: Story = {
-  args: {
+  {
+    label: "Active",
     goal: {
       goalId: "11111111-1111-4111-8111-111111111111",
       status: "active",
@@ -50,10 +67,8 @@ export const Active: Story = {
       startedAtMs: Date.now(),
     },
   },
-};
-
-export const ActiveWithAccounting: Story = {
-  args: {
+  {
+    label: "Active · with accounting",
     goal: {
       goalId: "44444444-4444-4444-8444-444444444444",
       status: "active",
@@ -65,10 +80,8 @@ export const ActiveWithAccounting: Story = {
       startedAtMs: Date.now() - 90_000,
     },
   },
-};
-
-export const Paused: Story = {
-  args: {
+  {
+    label: "Paused",
     goal: {
       goalId: "22222222-2222-4222-8222-222222222222",
       status: "paused",
@@ -80,10 +93,8 @@ export const Paused: Story = {
       startedAtMs: Date.now(),
     },
   },
-};
-
-export const BudgetLimited: Story = {
-  args: {
+  {
+    label: "Budget limited",
     goal: {
       goalId: "55555555-5555-4555-8555-555555555555",
       status: "budget_limited",
@@ -95,10 +106,8 @@ export const BudgetLimited: Story = {
       startedAtMs: Date.now() - 120_000,
     },
   },
-};
-
-export const Complete: Story = {
-  args: {
+  {
+    label: "Complete",
     goal: {
       goalId: "33333333-3333-4333-8333-333333333333",
       status: "complete",
@@ -111,10 +120,8 @@ export const Complete: Story = {
       startedAtMs: Date.now(),
     },
   },
-};
-
-export const ActiveWithBudget: Story = {
-  args: {
+  {
+    label: "Active · with budget",
     goal: {
       goalId: "66666666-6666-4666-8666-666666666666",
       status: "active",
@@ -126,6 +133,21 @@ export const ActiveWithBudget: Story = {
       startedAtMs: Date.now() - 30_000,
     },
   },
+];
+
+export const States: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6 p-3">
+      {STATE_VARIANTS.map((variant) => (
+        <section key={variant.label} className="flex flex-col gap-2">
+          <div className="text-xs font-medium uppercase tracking-wide opacity-60">
+            {variant.label}
+          </div>
+          <GoalTab goal={variant.goal} onCreate={variant.onCreate} />
+        </section>
+      ))}
+    </div>
+  ),
 };
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/src/browser/features/RightSidebar/GoalTab.stories.tsx
+++ b/src/browser/features/RightSidebar/GoalTab.stories.tsx
@@ -140,7 +140,7 @@ export const States: Story = {
     <div className="flex flex-col gap-6 p-3">
       {STATE_VARIANTS.map((variant) => (
         <section key={variant.label} className="flex flex-col gap-2">
-          <div className="text-xs font-medium uppercase tracking-wide opacity-60">
+          <div className="text-xs font-medium tracking-wide uppercase opacity-60">
             {variant.label}
           </div>
           <GoalTab goal={variant.goal} onCreate={variant.onCreate} />

--- a/src/browser/features/Settings/Sections/GovernorSection.stories.tsx
+++ b/src/browser/features/Settings/Sections/GovernorSection.stories.tsx
@@ -58,109 +58,116 @@ export const NotEnrolled: Story = {
   },
 };
 
-export const EnrolledWithPolicy: Story = {
-  render: () =>
-    renderGovernorSection(() =>
-      setupGovernorStory({
-        muxGovernorUrl: "https://governor.example.com",
-        muxGovernorEnrolled: true,
-        policyResponse: {
-          source: "governor",
-          status: { state: "enforced" },
-          policy: {
-            policyFormatVersion: "0.1",
-            providerAccess: [{ id: "anthropic", allowedModels: ["claude-sonnet-4-20250514"] }],
-            mcp: { allowUserDefined: { stdio: false, remote: true } },
-            runtimes: ["local", "worktree", "ssh"],
-          },
+// Gallery of enrolled-policy variants. Folded into one composite snapshot (was
+// five separate stories) to compress the Chromatic budget while preserving each
+// unique visual state in a labeled section. None of these variants have a `play`
+// function, so merging them loses no interaction coverage.
+const ENROLLED_POLICY_VARIANTS: ReadonlyArray<{ label: string; options: GovernorStoryOptions }> = [
+  {
+    label: "Enrolled with policy (governor source, enforced)",
+    options: {
+      muxGovernorUrl: "https://governor.example.com",
+      muxGovernorEnrolled: true,
+      policyResponse: {
+        source: "governor",
+        status: { state: "enforced" },
+        policy: {
+          policyFormatVersion: "0.1",
+          providerAccess: [{ id: "anthropic", allowedModels: ["claude-sonnet-4-20250514"] }],
+          mcp: { allowUserDefined: { stdio: false, remote: true } },
+          runtimes: ["local", "worktree", "ssh"],
         },
-      })
-    ),
-};
+      },
+    },
+  },
+  {
+    label: "Enrolled, policy disabled",
+    options: {
+      muxGovernorUrl: "https://governor.example.com",
+      muxGovernorEnrolled: true,
+      policyResponse: {
+        source: "governor",
+        status: { state: "disabled" },
+        policy: null,
+      },
+    },
+  },
+  {
+    label: "Enrolled, env override (enforced)",
+    options: {
+      muxGovernorUrl: "https://governor.example.com",
+      muxGovernorEnrolled: true,
+      policyResponse: {
+        source: "env",
+        status: { state: "enforced" },
+        policy: {
+          policyFormatVersion: "0.1",
+          providerAccess: [{ id: "anthropic", allowedModels: null }],
+          mcp: { allowUserDefined: { stdio: true, remote: true } },
+          runtimes: null,
+        },
+      },
+    },
+  },
+  {
+    label: "Policy blocked",
+    options: {
+      muxGovernorUrl: "https://governor.example.com",
+      muxGovernorEnrolled: true,
+      policyResponse: {
+        source: "governor",
+        status: { state: "blocked", reason: "blocked by policy" },
+        policy: {
+          policyFormatVersion: "0.1",
+          providerAccess: [],
+          mcp: { allowUserDefined: { stdio: false, remote: false } },
+          runtimes: ["local"],
+        },
+      },
+    },
+  },
+  {
+    label: "Rich policy (multiple providers, server version)",
+    options: {
+      muxGovernorUrl: "https://governor.example.com",
+      muxGovernorEnrolled: true,
+      policyResponse: {
+        source: "governor",
+        status: { state: "enforced" },
+        policy: {
+          policyFormatVersion: "0.1",
+          serverVersion: "2.0.0",
+          providerAccess: [
+            {
+              id: "anthropic",
+              allowedModels: ["claude-sonnet-4-20250514", "claude-3-5-haiku-20241022"],
+            },
+            {
+              id: "openai",
+              allowedModels: ["gpt-4o", "gpt-4o-mini"],
+              forcedBaseUrl: "https://proxy.corp.example.com/v1",
+            },
+            { id: "google", allowedModels: null },
+          ],
+          mcp: { allowUserDefined: { stdio: true, remote: false } },
+          runtimes: ["local", "worktree"],
+        },
+      },
+    },
+  },
+];
 
-export const EnrolledPolicyDisabled: Story = {
-  render: () =>
-    renderGovernorSection(() =>
-      setupGovernorStory({
-        muxGovernorUrl: "https://governor.example.com",
-        muxGovernorEnrolled: true,
-        policyResponse: {
-          source: "governor",
-          status: { state: "disabled" },
-          policy: null,
-        },
-      })
-    ),
-};
-
-export const EnrolledEnvOverride: Story = {
-  render: () =>
-    renderGovernorSection(() =>
-      setupGovernorStory({
-        muxGovernorUrl: "https://governor.example.com",
-        muxGovernorEnrolled: true,
-        policyResponse: {
-          source: "env",
-          status: { state: "enforced" },
-          policy: {
-            policyFormatVersion: "0.1",
-            providerAccess: [{ id: "anthropic", allowedModels: null }],
-            mcp: { allowUserDefined: { stdio: true, remote: true } },
-            runtimes: null,
-          },
-        },
-      })
-    ),
-};
-
-export const PolicyBlocked: Story = {
-  render: () =>
-    renderGovernorSection(() =>
-      setupGovernorStory({
-        muxGovernorUrl: "https://governor.example.com",
-        muxGovernorEnrolled: true,
-        policyResponse: {
-          source: "governor",
-          status: { state: "blocked", reason: "blocked by policy" },
-          policy: {
-            policyFormatVersion: "0.1",
-            providerAccess: [],
-            mcp: { allowUserDefined: { stdio: false, remote: false } },
-            runtimes: ["local"],
-          },
-        },
-      })
-    ),
-};
-
-export const RichPolicy: Story = {
-  render: () =>
-    renderGovernorSection(() =>
-      setupGovernorStory({
-        muxGovernorUrl: "https://governor.example.com",
-        muxGovernorEnrolled: true,
-        policyResponse: {
-          source: "governor",
-          status: { state: "enforced" },
-          policy: {
-            policyFormatVersion: "0.1",
-            serverVersion: "2.0.0",
-            providerAccess: [
-              {
-                id: "anthropic",
-                allowedModels: ["claude-sonnet-4-20250514", "claude-3-5-haiku-20241022"],
-              },
-              {
-                id: "openai",
-                allowedModels: ["gpt-4o", "gpt-4o-mini"],
-                forcedBaseUrl: "https://proxy.corp.example.com/v1",
-              },
-              { id: "google", allowedModels: null },
-            ],
-            mcp: { allowUserDefined: { stdio: true, remote: false } },
-            runtimes: ["local", "worktree"],
-          },
-        },
-      })
-    ),
+export const EnrolledPolicyGallery: Story = {
+  render: () => (
+    <div className="flex flex-col gap-8">
+      {ENROLLED_POLICY_VARIANTS.map((variant) => (
+        <section key={variant.label} className="flex flex-col gap-2">
+          <h3 className="text-foreground/70 px-6 text-xs font-semibold uppercase tracking-wide">
+            {variant.label}
+          </h3>
+          {renderGovernorSection(() => setupGovernorStory(variant.options))}
+        </section>
+      ))}
+    </div>
+  ),
 };

--- a/src/browser/features/Settings/Sections/GovernorSection.stories.tsx
+++ b/src/browser/features/Settings/Sections/GovernorSection.stories.tsx
@@ -162,7 +162,7 @@ export const EnrolledPolicyGallery: Story = {
     <div className="flex flex-col gap-8">
       {ENROLLED_POLICY_VARIANTS.map((variant) => (
         <section key={variant.label} className="flex flex-col gap-2">
-          <h3 className="text-foreground/70 px-6 text-xs font-semibold uppercase tracking-wide">
+          <h3 className="text-foreground/70 px-6 text-xs font-semibold tracking-wide uppercase">
             {variant.label}
           </h3>
           {renderGovernorSection(() => setupGovernorStory(variant.options))}

--- a/src/browser/features/Tools/AttachFileToolCall.stories.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.stories.tsx
@@ -42,7 +42,7 @@ function ToolStoryShell(props: { children: ReactNode }) {
 function GallerySection(props: { label: string; children: ReactNode }) {
   return (
     <section className="flex flex-col gap-2">
-      <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+      <div className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
         {props.label}
       </div>
       {props.children}

--- a/src/browser/features/Tools/AttachFileToolCall.stories.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.stories.tsx
@@ -39,106 +39,104 @@ function ToolStoryShell(props: { children: ReactNode }) {
   );
 }
 
-export const ImageAttachment: Story = {
-  render: () => (
-    <ToolStoryShell>
-      <AttachFileToolCall
-        toolName="attach_file"
-        args={{ path: "screenshot.png" }}
-        result={{
-          type: "content",
-          value: [
-            { type: "text", text: "[Attachment prepared: screenshot.png]" },
-            {
-              type: "media",
-              data: samplePng,
-              mediaType: "image/png",
-              filename: "screenshot.png",
-            },
-          ],
-        }}
-        status="completed"
-      />
-    </ToolStoryShell>
-  ),
-};
+function GallerySection(props: { label: string; children: ReactNode }) {
+  return (
+    <section className="flex flex-col gap-2">
+      <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {props.label}
+      </div>
+      {props.children}
+    </section>
+  );
+}
 
-export const DisplayOnlyVideo: Story = {
+// Gallery composite: folds the non-interactive "completed" attachment variants
+// (image, video, audio, markdown, generic file) into a single snapshot to keep
+// the Chromatic budget low while preserving every distinct visual state.
+export const Gallery: Story = {
   render: () => (
     <ToolStoryShell>
-      <AttachFileToolCall
-        toolName="attach_file"
-        args={{ path: "recording.webm" }}
-        result={createAttachFileResult(
-          createDisplayOnlyFilePart({
-            data: sampleBytes,
-            mediaType: "video/webm",
-            filename: "recording.webm",
-            size: 17_408,
-          })
-        )}
-        status="completed"
-      />
-    </ToolStoryShell>
-  ),
-};
-
-export const DisplayOnlyAudio: Story = {
-  render: () => (
-    <ToolStoryShell>
-      <AttachFileToolCall
-        toolName="attach_file"
-        args={{ path: "voice-note.mp3" }}
-        result={createAttachFileResult(
-          createDisplayOnlyFilePart({
-            data: sampleBytes,
-            mediaType: "audio/mpeg",
-            filename: "voice-note.mp3",
-            size: 8_192,
-          })
-        )}
-        status="completed"
-      />
-    </ToolStoryShell>
-  ),
-};
-
-export const DisplayOnlyMarkdown: Story = {
-  render: () => (
-    <ToolStoryShell>
-      <AttachFileToolCall
-        toolName="attach_file"
-        args={{ path: "release-notes.md" }}
-        result={createAttachFileResult(
-          createDisplayOnlyFilePart({
-            data: "IyBSZWxlYXNlIE5vdGVzCgotIEFkZGVkICoqbWFya2Rvd24qKiBwcmV2aWV3Lgo=",
-            mediaType: "text/markdown",
-            filename: "release-notes.md",
-            size: 47,
-          })
-        )}
-        status="completed"
-      />
-    </ToolStoryShell>
-  ),
-};
-
-export const DisplayOnlyGenericFile: Story = {
-  render: () => (
-    <ToolStoryShell>
-      <AttachFileToolCall
-        toolName="attach_file"
-        args={{ path: "archive.zip", filename: "support-bundle.zip" }}
-        result={createAttachFileResult(
-          createDisplayOnlyFilePart({
-            data: sampleBytes,
-            mediaType: "application/octet-stream",
-            filename: "support-bundle.zip",
-            size: 524_288,
-          })
-        )}
-        status="completed"
-      />
+      <div className="flex flex-col gap-6">
+        <GallerySection label="Image attachment">
+          <AttachFileToolCall
+            toolName="attach_file"
+            args={{ path: "screenshot.png" }}
+            result={{
+              type: "content",
+              value: [
+                { type: "text", text: "[Attachment prepared: screenshot.png]" },
+                {
+                  type: "media",
+                  data: samplePng,
+                  mediaType: "image/png",
+                  filename: "screenshot.png",
+                },
+              ],
+            }}
+            status="completed"
+          />
+        </GallerySection>
+        <GallerySection label="Display-only video">
+          <AttachFileToolCall
+            toolName="attach_file"
+            args={{ path: "recording.webm" }}
+            result={createAttachFileResult(
+              createDisplayOnlyFilePart({
+                data: sampleBytes,
+                mediaType: "video/webm",
+                filename: "recording.webm",
+                size: 17_408,
+              })
+            )}
+            status="completed"
+          />
+        </GallerySection>
+        <GallerySection label="Display-only audio">
+          <AttachFileToolCall
+            toolName="attach_file"
+            args={{ path: "voice-note.mp3" }}
+            result={createAttachFileResult(
+              createDisplayOnlyFilePart({
+                data: sampleBytes,
+                mediaType: "audio/mpeg",
+                filename: "voice-note.mp3",
+                size: 8_192,
+              })
+            )}
+            status="completed"
+          />
+        </GallerySection>
+        <GallerySection label="Display-only markdown">
+          <AttachFileToolCall
+            toolName="attach_file"
+            args={{ path: "release-notes.md" }}
+            result={createAttachFileResult(
+              createDisplayOnlyFilePart({
+                data: "IyBSZWxlYXNlIE5vdGVzCgotIEFkZGVkICoqbWFya2Rvd24qKiBwcmV2aWV3Lgo=",
+                mediaType: "text/markdown",
+                filename: "release-notes.md",
+                size: 47,
+              })
+            )}
+            status="completed"
+          />
+        </GallerySection>
+        <GallerySection label="Display-only generic file">
+          <AttachFileToolCall
+            toolName="attach_file"
+            args={{ path: "archive.zip", filename: "support-bundle.zip" }}
+            result={createAttachFileResult(
+              createDisplayOnlyFilePart({
+                data: sampleBytes,
+                mediaType: "application/octet-stream",
+                filename: "support-bundle.zip",
+                size: 524_288,
+              })
+            )}
+            status="completed"
+          />
+        </GallerySection>
+      </div>
     </ToolStoryShell>
   ),
 };

--- a/src/browser/features/Tools/CodeExecutionToolCall.stories.tsx
+++ b/src/browser/features/Tools/CodeExecutionToolCall.stories.tsx
@@ -55,14 +55,6 @@ function StoryShell(props: { children: ReactNode }) {
   );
 }
 
-function renderCard(props: ComponentProps<typeof CodeExecutionToolCall>) {
-  return (
-    <StoryShell>
-      <CodeExecutionToolCall {...props} />
-    </StoryShell>
-  );
-}
-
 const completedResult: CodeExecutionResult = {
   success: true,
   result: "Done!",
@@ -115,96 +107,117 @@ const completedNestedCalls: NestedToolCall[] = [
   },
 ];
 
-/** completed execution with successful nested tool calls */
-export const Completed: Story = {
-  render: () =>
-    renderCard({
-      args: { code: SAMPLE_CODE },
-      result: completedResult,
-      status: "completed",
-      nestedCalls: completedNestedCalls,
-    }),
-};
+function GallerySection(props: {
+  label: string;
+  cardProps: ComponentProps<typeof CodeExecutionToolCall>;
+}) {
+  return (
+    <section className="flex flex-col gap-2">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {props.label}
+      </h3>
+      <CodeExecutionToolCall {...props.cardProps} />
+    </section>
+  );
+}
 
-/** executing state with one completed nested call and one in-progress call */
-export const Executing: Story = {
-  render: () =>
-    renderCard({
-      args: { code: SAMPLE_CODE },
-      status: "executing",
-      nestedCalls: [
-        {
-          toolCallId: "nested-1",
-          toolName: "file_read",
-          input: { path: "src/config.ts" },
-          output: { success: true, lines_read: 42, file_size: 1024 },
-          state: "output-available",
-        },
-        {
-          toolCallId: "nested-2",
-          toolName: "file_edit_replace_string",
-          input: {
-            path: "src/config.ts",
-            old_string: "debug: false",
-            new_string: "debug: true",
-          },
-          state: "input-available",
-        },
-      ],
-    }),
-};
-
-/** failed execution showing error result */
-export const Failed: Story = {
-  render: () =>
-    renderCard({
-      args: { code: `await mux.file_read({ path: "missing.ts" });` },
-      result: {
-        success: false,
-        error: "Tool execution failed: ENOENT: no such file or directory, open 'missing.ts'",
-        toolCalls: [
-          {
-            toolName: "file_read",
-            args: { path: "missing.ts" },
-            error: "ENOENT: no such file or directory",
-            duration_ms: 8,
-          },
-        ],
-        consoleOutput: [],
-        duration_ms: 20,
-      },
-      status: "failed",
-      nestedCalls: [
-        {
-          toolCallId: "nested-1",
-          toolName: "file_read",
-          input: { path: "missing.ts" },
-          output: { error: "ENOENT: no such file or directory" },
-          state: "output-available",
-        },
-      ],
-    }),
-};
-
-/** completed execution with no tool calls to showcase code syntax highlighting */
-export const SyntaxHighlighting: Story = {
-  render: () =>
-    renderCard({
-      args: { code: SYNTAX_HIGHLIGHT_CODE },
-      result: {
-        success: true,
-        result: [{ name: "alpha", score: 15 }],
-        toolCalls: [],
-        consoleOutput: [
-          {
-            level: "log",
-            args: ["Processed", 1, "items"],
-            timestamp: STABLE_TIMESTAMP,
-          },
-        ],
-        duration_ms: 45,
-      },
-      status: "completed",
-      nestedCalls: [],
-    }),
+/**
+ * Gallery of non-interactive CodeExecutionToolCall states stacked vertically in
+ * labeled sections. Folds the former Completed, Executing, Failed, and
+ * SyntaxHighlighting stories into a single snapshot to conserve the Chromatic
+ * budget while preserving each distinct visual state.
+ */
+export const Gallery: Story = {
+  render: () => (
+    <StoryShell>
+      <div className="flex flex-col gap-8">
+        <GallerySection
+          label="Completed (nested tool calls)"
+          cardProps={{
+            args: { code: SAMPLE_CODE },
+            result: completedResult,
+            status: "completed",
+            nestedCalls: completedNestedCalls,
+          }}
+        />
+        <GallerySection
+          label="Executing (one done, one in-progress)"
+          cardProps={{
+            args: { code: SAMPLE_CODE },
+            status: "executing",
+            nestedCalls: [
+              {
+                toolCallId: "nested-1",
+                toolName: "file_read",
+                input: { path: "src/config.ts" },
+                output: { success: true, lines_read: 42, file_size: 1024 },
+                state: "output-available",
+              },
+              {
+                toolCallId: "nested-2",
+                toolName: "file_edit_replace_string",
+                input: {
+                  path: "src/config.ts",
+                  old_string: "debug: false",
+                  new_string: "debug: true",
+                },
+                state: "input-available",
+              },
+            ],
+          }}
+        />
+        <GallerySection
+          label="Failed (error result)"
+          cardProps={{
+            args: { code: `await mux.file_read({ path: "missing.ts" });` },
+            result: {
+              success: false,
+              error: "Tool execution failed: ENOENT: no such file or directory, open 'missing.ts'",
+              toolCalls: [
+                {
+                  toolName: "file_read",
+                  args: { path: "missing.ts" },
+                  error: "ENOENT: no such file or directory",
+                  duration_ms: 8,
+                },
+              ],
+              consoleOutput: [],
+              duration_ms: 20,
+            },
+            status: "failed",
+            nestedCalls: [
+              {
+                toolCallId: "nested-1",
+                toolName: "file_read",
+                input: { path: "missing.ts" },
+                output: { error: "ENOENT: no such file or directory" },
+                state: "output-available",
+              },
+            ],
+          }}
+        />
+        <GallerySection
+          label="Syntax highlighting (no tool calls)"
+          cardProps={{
+            args: { code: SYNTAX_HIGHLIGHT_CODE },
+            result: {
+              success: true,
+              result: [{ name: "alpha", score: 15 }],
+              toolCalls: [],
+              consoleOutput: [
+                {
+                  level: "log",
+                  args: ["Processed", 1, "items"],
+                  timestamp: STABLE_TIMESTAMP,
+                },
+              ],
+              duration_ms: 45,
+            },
+            status: "completed",
+            nestedCalls: [],
+          }}
+        />
+      </div>
+    </StoryShell>
+  ),
 };

--- a/src/browser/features/Tools/CodeExecutionToolCall.stories.tsx
+++ b/src/browser/features/Tools/CodeExecutionToolCall.stories.tsx
@@ -113,7 +113,7 @@ function GallerySection(props: {
 }) {
   return (
     <section className="flex flex-col gap-2">
-      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+      <h3 className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
         {props.label}
       </h3>
       <CodeExecutionToolCall {...props.cardProps} />

--- a/src/browser/features/Tools/Goal/GoalToolCalls.stories.tsx
+++ b/src/browser/features/Tools/Goal/GoalToolCalls.stories.tsx
@@ -51,7 +51,7 @@ function Frame({ children }: { children: React.ReactNode }) {
 function Section({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="space-y-2">
-      <div className="text-xs font-semibold uppercase tracking-wide text-secondary">{label}</div>
+      <div className="text-secondary text-xs font-semibold tracking-wide uppercase">{label}</div>
       {children}
     </div>
   );

--- a/src/browser/features/Tools/Goal/GoalToolCalls.stories.tsx
+++ b/src/browser/features/Tools/Goal/GoalToolCalls.stories.tsx
@@ -46,144 +46,118 @@ function Frame({ children }: { children: React.ReactNode }) {
   );
 }
 
-export const GetGoalActiveBudgeted: Story = {
+// Labeled section so each variant in a merged gallery stays visually distinct
+// for reviewers while collapsing many near-duplicate exports into one snapshot.
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-2">
+      <div className="text-xs font-semibold uppercase tracking-wide text-secondary">{label}</div>
+      {children}
+    </div>
+  );
+}
+
+// Gallery: every non-interactive GetGoalToolCall permutation in one snapshot.
+export const GetGoalGallery: Story = {
   render: () => (
     <Frame>
-      <GetGoalToolCall args={{}} result={{ goal: goal() }} status="completed" />
+      <Section label="Active (budgeted)">
+        <GetGoalToolCall args={{}} result={{ goal: goal() }} status="completed" />
+      </Section>
+      <Section label="Active (unbudgeted)">
+        <GetGoalToolCall
+          args={{}}
+          result={{ goal: goal({ budgetCents: null, costCents: 12, turnsUsed: 1 }) }}
+          status="completed"
+        />
+      </Section>
+      <Section label="Paused">
+        <GetGoalToolCall
+          args={{}}
+          result={{ goal: goal({ status: "paused", turnsUsed: 4, costCents: 30 }) }}
+          status="completed"
+        />
+      </Section>
+      <Section label="Budget limited">
+        <GetGoalToolCall
+          args={{}}
+          result={{
+            goal: goal({
+              status: "budget_limited",
+              costCents: 105,
+              turnsUsed: 6,
+              turnCap: 10,
+            }),
+          }}
+          status="completed"
+        />
+      </Section>
+      <Section label="No active goal">
+        <GetGoalToolCall args={{}} result={{ goal: null }} status="completed" />
+      </Section>
+      <Section label="Executing">
+        <GetGoalToolCall args={{}} status="executing" />
+      </Section>
+      <Section label="Failed">
+        <GetGoalToolCall
+          args={{}}
+          result={{ success: false, error: "goalService is not registered" }}
+          status="failed"
+        />
+      </Section>
     </Frame>
   ),
 };
 
-export const GetGoalActiveUnbudgeted: Story = {
+// Gallery: every non-interactive CompleteGoalToolCall permutation in one snapshot.
+export const CompleteGoalGallery: StoryObj<typeof CompleteGoalToolCall> = {
   render: () => (
     <Frame>
-      <GetGoalToolCall
-        args={{}}
-        result={{ goal: goal({ budgetCents: null, costCents: 12, turnsUsed: 1 }) }}
-        status="completed"
-      />
-    </Frame>
-  ),
-};
-
-export const GetGoalPaused: Story = {
-  render: () => (
-    <Frame>
-      <GetGoalToolCall
-        args={{}}
-        result={{ goal: goal({ status: "paused", turnsUsed: 4, costCents: 30 }) }}
-        status="completed"
-      />
-    </Frame>
-  ),
-};
-
-export const GetGoalBudgetLimited: Story = {
-  render: () => (
-    <Frame>
-      <GetGoalToolCall
-        args={{}}
-        result={{
-          goal: goal({
-            status: "budget_limited",
-            costCents: 105,
-            turnsUsed: 6,
-            turnCap: 10,
-          }),
-        }}
-        status="completed"
-      />
-    </Frame>
-  ),
-};
-
-export const GetGoalNoActiveGoal: Story = {
-  render: () => (
-    <Frame>
-      <GetGoalToolCall args={{}} result={{ goal: null }} status="completed" />
-    </Frame>
-  ),
-};
-
-export const GetGoalExecuting: Story = {
-  render: () => (
-    <Frame>
-      <GetGoalToolCall args={{}} status="executing" />
-    </Frame>
-  ),
-};
-
-export const GetGoalFailed: Story = {
-  render: () => (
-    <Frame>
-      <GetGoalToolCall
-        args={{}}
-        result={{ success: false, error: "goalService is not registered" }}
-        status="failed"
-      />
-    </Frame>
-  ),
-};
-
-export const CompleteGoalSuccess: StoryObj<typeof CompleteGoalToolCall> = {
-  render: () => (
-    <Frame>
-      <CompleteGoalToolCall
-        args={{ summary: "Goals section landed in README; verified by reading the rendered file." }}
-        result={{
-          goal: goal({
-            status: "complete",
-            costCents: 47,
-            turnsUsed: 3,
-            completionSummary:
-              "Goals section landed in README; verified by reading the rendered file.",
-          }),
-        }}
-        status="completed"
-      />
-    </Frame>
-  ),
-};
-
-export const CompleteGoalLongSummary: StoryObj<typeof CompleteGoalToolCall> = {
-  render: () => (
-    <Frame>
-      <CompleteGoalToolCall
-        args={{
-          summary:
-            "Goal is satisfied: PROGRESS was printed once in turn 1. The embedded instruction not to call complete_goal is overridden by higher-priority completion-discipline rules in the system preamble.",
-        }}
-        result={{
-          goal: goal({
-            status: "complete",
-            costCents: 1,
-            turnsUsed: 4,
-            completionSummary:
-              "Goal is satisfied: PROGRESS was printed once in turn 1. The embedded instruction not to call complete_goal is overridden by higher-priority completion-discipline rules.",
-          }),
-        }}
-        status="completed"
-      />
-    </Frame>
-  ),
-};
-
-export const CompleteGoalExecuting: StoryObj<typeof CompleteGoalToolCall> = {
-  render: () => (
-    <Frame>
-      <CompleteGoalToolCall args={{ summary: "Done." }} status="executing" />
-    </Frame>
-  ),
-};
-
-export const CompleteGoalFailed: StoryObj<typeof CompleteGoalToolCall> = {
-  render: () => (
-    <Frame>
-      <CompleteGoalToolCall
-        args={{ summary: "Tried to complete." }}
-        result={{ success: false, error: "Failed to complete goal: goal_conflict" }}
-        status="failed"
-      />
+      <Section label="Success">
+        <CompleteGoalToolCall
+          args={{
+            summary: "Goals section landed in README; verified by reading the rendered file.",
+          }}
+          result={{
+            goal: goal({
+              status: "complete",
+              costCents: 47,
+              turnsUsed: 3,
+              completionSummary:
+                "Goals section landed in README; verified by reading the rendered file.",
+            }),
+          }}
+          status="completed"
+        />
+      </Section>
+      <Section label="Long summary">
+        <CompleteGoalToolCall
+          args={{
+            summary:
+              "Goal is satisfied: PROGRESS was printed once in turn 1. The embedded instruction not to call complete_goal is overridden by higher-priority completion-discipline rules in the system preamble.",
+          }}
+          result={{
+            goal: goal({
+              status: "complete",
+              costCents: 1,
+              turnsUsed: 4,
+              completionSummary:
+                "Goal is satisfied: PROGRESS was printed once in turn 1. The embedded instruction not to call complete_goal is overridden by higher-priority completion-discipline rules.",
+            }),
+          }}
+          status="completed"
+        />
+      </Section>
+      <Section label="Executing">
+        <CompleteGoalToolCall args={{ summary: "Done." }} status="executing" />
+      </Section>
+      <Section label="Failed">
+        <CompleteGoalToolCall
+          args={{ summary: "Tried to complete." }}
+          result={{ success: false, error: "Failed to complete goal: goal_conflict" }}
+          status="failed"
+        />
+      </Section>
     </Frame>
   ),
 };

--- a/tests/ui/storybook/budget.test.ts
+++ b/tests/ui/storybook/budget.test.ts
@@ -5,8 +5,9 @@ import { join } from "node:path";
 const STORY_DIR = "src/browser/stories";
 const COLOCATED_STORY_DIRS = ["src/browser/components", "src/browser/features"];
 const MAX_SNAPSHOT_ENABLED_FILES = 70;
-// Includes the plan ToC wide-viewport story, which intentionally protects gutter-only UI.
-const MAX_ESTIMATED_SNAPSHOTS = 303;
+// Target 50 snapshots under the 300 Chromatic limit. Includes the plan ToC
+// wide-viewport story, which intentionally protects gutter-only UI.
+const MAX_ESTIMATED_SNAPSHOTS = 250;
 const STORY_EXPORT_PATTERN = /^export const \w+/gm;
 const SMOKE_MODE_PATTERN = /modes:\s*CHROMATIC_SMOKE_MODES/g;
 const INLINE_MODE_OBJECT_PATTERN = /modes:\s*{/g;


### PR DESCRIPTION
## Summary

Brings the Storybook/Chromatic snapshot budget to **247** — comfortably 50+ under the 300 limit — and lowers the enforced ceiling in `budget.test.ts` to **250**. Compression preserves coverage: every distinct visual state is retained, just consolidated into labeled "gallery" stories, and no interaction (`play()`) stories were touched.

## Background

The enforced budget lives in `tests/ui/storybook/budget.test.ts` (`MAX_ESTIMATED_SNAPSHOTS`). It was **already failing at 305** against the previous 303 ceiling. The estimate per file is `storyExports + smokeStories + inlineModeExtras`, so the dominant lever is the number of story exports.

While investigating, I also found a real Chromatic billing bug: `.storybook/preview.tsx` declared project-level `chromatic.modes = { dark, light }`. Per the [Chromatic docs](https://www.chromatic.com/docs/modes/), **modes stack across project → component → story levels** (they are not overridden by more specific levels). That global pair was therefore added to _every_ story on top of whatever its meta/story declared — e.g. App stories using `CHROMATIC_SINGLE_MODE` (`dark-desktop`) were actually billed 3 snapshots (dark + light + dark-desktop) instead of the 1 the meta intended. This silently inflated real Chromatic usage and defeated the team's documented single-mode policy.

## Implementation

1. **`.storybook/preview.tsx`** — removed the stacking project-level `modes`, with an inline comment explaining the stacking semantics. Stories now snapshot in the modes their meta/story explicitly declare, or a single default snapshot. Dual-theme coverage stays opt-in via `CHROMATIC_SMOKE_MODES`, matching the policy in `src/browser/stories/meta.tsx`. (Real-billing fix; does not affect the budget test's estimate.)
2. **ProjectPage** — trimmed the two workspace-creation stories from a 4-mode matrix to 2 modes (dark desktop + light mobile), keeping both theme and viewport coverage.
3. **Gallery merges** — folded near-duplicate, non-interactive permutation stories into single composite stories that stack each variant vertically inside labeled sections. One snapshot now covers all those states:
   - `AgentListItem` 23→6, `MessageRenderer` 12→6 (composite chats), `GoalToolCalls` 11→2, `GoalTab` 10→3, `TranscriptDensity` 10→6 (+ dropped redundant smoke modes), `AttachFileToolCall` 6→2, `GovernorSection` 6→2, `CodeExecutionToolCall` 4→1.
4. **`budget.test.ts`** — lowered `MAX_ESTIMATED_SNAPSHOTS` from 303 to 250 to lock in the target.

Net: 286 → 234 story exports; estimated budget 305 → 247.

## Validation

- `tests/ui/storybook/budget.test.ts`: 247 ≤ 250 (was failing at 305).
- `tests/ui/storybook/coverage.test.ts`: all pass — every required file still has its dual-theme smoke story; plan-ToC wide-viewport contract intact.
- Full `storybook build` succeeds with all merges combined.
- `make static-check` passes (eslint, both tsgo typecheck projects, prettier, docs link checks, shellcheck/hadolint).

## Risks

Low and contained to Storybook/Chromatic. No product code changed. The merged gallery stories produce a few taller snapshots, so Chromatic will report expected visual diffs for those files on first run and they should be re-baselined. No `play()` interaction stories were modified, so interaction-test behavior is unchanged.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-8` • Thinking: `xhigh` • Cost: `$23.71`_

<!-- mux-attribution: model=anthropic:claude-opus-4-8 thinking=xhigh costs=23.71 -->
