### PR TITLE
🤖 tests: stabilize flaky SubAgent States/Gallery story

### DIFF
--- a/src/browser/components/AgentListItem/AgentListItem.stories.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.stories.tsx
@@ -505,8 +505,21 @@ function renderSubAgentGallery() {
   // ws-active (index 1) carries persisted status state, so its rows render the
   // status-text treatment from the former "...With Status Text" stories.
   const active = STORY_WORKSPACES[1];
+  // Own ws-idle's last-read state. IdleSeen/IdleNotSeen write the same persisted
+  // key, so without pinning it here the idle rows inherit whichever sibling story
+  // rendered last and flip between "idle" (primary title) and "seen" (tertiary
+  // title) — a non-deterministic Chromatic diff. Pin to unread (matching the
+  // workspace's "idle" semantics) so the gallery is stable regardless of order.
+  const idleCreatedAtMs = Date.parse(idle.createdAt ?? new Date(NOW).toISOString());
+  updatePersistedState(getWorkspaceLastReadKey(idle.id), idleCreatedAtMs - 60_000);
   return (
-    <StoryScaffold activeWorkspaceId="ws-active">
+    // storybook-static-subagent-connectors freezes the active sub-agent connector
+    // animation for this gallery (see globals.css) so snapshots don't race the
+    // infinite stroke-dashoffset/translate animation to a random frame.
+    <StoryScaffold
+      activeWorkspaceId="ws-active"
+      rowContainerClassName="storybook-static-subagent-connectors space-y-1"
+    >
       <GallerySection label="Middle">
         <WorkspaceRow workspace={idle} rowRenderMeta={createSubAgentRowRenderMeta("middle")} />
       </GallerySection>
@@ -584,6 +597,19 @@ export const SubAgentStates: Story = {
   args: undefined as never,
   name: "SubAgent States/Gallery",
   render: renderSubAgentGallery,
+  // ws-active streams asynchronously: the scaffold's onChat emits stream-start
+  // through a fire-and-forget store subscription (ensureActiveOnChatSubscription
+  // → void runOnChatSubscription), which flips its rows to the "active" visual
+  // state (success-colored status dot). With no play() Chromatic races that
+  // async transition and captures the dot as active-or-not at random. Wait for
+  // the settled signal so every snapshot captures the same frame.
+  play: async ({ canvasElement }) => {
+    await waitFor(() => {
+      if (!canvasElement.querySelector(".workspace-status-dot-active")) {
+        throw new Error("ws-active streaming status dot has not settled yet");
+      }
+    });
+  },
 };
 
 export const AppSidebarThreeActiveSubAgents: Story = {

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -2500,6 +2500,17 @@ input[type="checkbox"] {
   }
 }
 
+/* Storybook/Chromatic determinism: the active sub-agent connector animates an
+   infinite stroke-dashoffset (SVG elbow) and translateY (trunk dashes).
+   Chromatic cannot pin those to a stable frame, so "SubAgent States/Gallery"
+   otherwise snapshots the dashes at a random phase. The story tags its row
+   container with this class to freeze both animations; the class is never used
+   in the shipped app, so this rule is inert outside Storybook. */
+.storybook-static-subagent-connectors .subagent-connector-active::before,
+.storybook-static-subagent-connectors .subagent-connector-elbow-active {
+  animation: none !important;
+}
+
 /* Section color picker - react-colorful sizing */
 .section-color-picker .react-colorful {
   width: 150px;


### PR DESCRIPTION
## Summary

Fixes the flaky `Components/AgentListItem` → **SubAgent States/Gallery** Storybook story, whose Chromatic snapshot was non-deterministic across builds.

## Background

The story is a pure visual snapshot (no `play()`) and combined three independent non-determinism sources:

1. **Animated active connector** — the "Running" section renders a sub-agent row with `taskStatus: "running"`, drawing an SVG `<path class="subagent-connector-elbow-active">` that runs `connector-elbow-dash-scroll 0.4s linear infinite` (animating `stroke-dashoffset: 6 → 0`), plus the active trunk's infinite `translateY` dash animation. Chromatic does not reliably pin SVG `stroke-dashoffset` to a stable frame, so the dashes were captured at a random phase.
2. **Async streaming race** — `ws-active` is the active workspace, so the scaffold's `onChat` emits `stream-start` through a fire-and-forget store subscription (`ensureActiveOnChatSubscription` → `void runOnChatSubscription`). That flips its rows into the `"active"` visual state (success-colored, pulsing status dot). With no `play()`, Chromatic raced that async transition and captured the dot as active-or-not at random.
3. **Order-dependent unread leak** — the gallery reuses the `ws-idle` workspace but never owned its persisted last-read key, while sibling stories `IdleSeen`/`IdleNotSeen` write that same key. The idle rows inherited whichever sibling rendered last, flipping their title color between `idle` (primary) and `seen` (tertiary).

## Implementation

- **`AgentListItem.stories.tsx`**
  - `renderSubAgentGallery` now pins `getWorkspaceLastReadKey("ws-idle")` to unread (matching the workspace's "idle" semantics and the most common pre-fix baseline → least snapshot churn).
  - Tags the gallery's row container with `storybook-static-subagent-connectors`.
  - Adds a `play()` to `SubAgentStates` that `waitFor`s the settled `.workspace-status-dot-active` signal before Chromatic captures, so the async streaming state is deterministic.
- **`globals.css`** — a scoped rule freezing both connector animations under `.storybook-static-subagent-connectors`, co-located with the connector keyframes. The class never appears in the shipped app, so the rule is inert in production.

Deliberately avoided broader fixes: global `prefers-reduced-motion`/preview-level animation disabling (unnecessary baseline churn), `diffThreshold` (masks the bug), and `delay`/`pauseAnimationAtEnd` (don't reliably freeze an infinite SVG dash animation).

## Validation

- Targeted Storybook test-runner against the static build: all `AgentListItem` stories pass, including the new `SubAgentStates` play-test — confirming the `play()` settles deterministically rather than hard-failing.
- `make storybook-build`, Storybook coverage contract (`tests/ui/storybook`), `fmt`, `typecheck`, `lint` all green.

## Risks

Low. Story/test-only change; production CSS is untouched (the freeze rule is gated on a Storybook-only class). The connector + active-dot baselines for this story will legitimately change once and need to be accepted on the next Chromatic build.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-8` • Thinking: `xhigh` • Cost: `$8.90`_

<!-- mux-attribution: model=anthropic:claude-opus-4-8 thinking=xhigh costs=8.90 -->
