### PR TITLE
🤖 feat: add /spawn built-in skill + tip carousel entry

### DIFF
--- a/src/browser/features/ChatInput/placeholderTips.ts
+++ b/src/browser/features/ChatInput/placeholderTips.ts
@@ -41,6 +41,7 @@ const STORYBOOK_PINNED_TIP_INDEX = 0;
 
 export const PLACEHOLDER_TIPS: readonly string[] = [
   "Try /orchestrate to coordinate sub-agents and integrate their patches",
+  "Try /spawn <task> to offload it to a single sub-agent and preserve context",
   "Try /btw <question> to ask a side question without nudging the agent",
   "Try /haiku <msg> to send just this message on a different model",
   "Try /+high <msg> to crank up reasoning for this message only",

--- a/src/node/builtinSkills/spawn.md
+++ b/src/node/builtinSkills/spawn.md
@@ -1,0 +1,9 @@
+---
+name: spawn
+description: Delegate the whole task to a single sub-agent to preserve the parent's context window
+advertise: false
+---
+
+# Spawn
+
+When the user invokes `/spawn`, complete the entire task by spawning one sub-agent with a self-contained brief instead of doing the work yourself. This keeps your context window spent on coordination rather than on the file reads, searches, and tool output the work would otherwise accumulate. Wait for the sub-agent, then integrate and report its result.

--- a/src/node/services/agentSkills/agentSkillsService.test.ts
+++ b/src/node/services/agentSkills/agentSkillsService.test.ts
@@ -256,6 +256,7 @@ describe("agentSkillsService", () => {
       "mux-diagram",
       "mux-docs",
       "orchestrate",
+      "spawn",
     ]);
 
     const foo = skills.find((s) => s.name === "foo");
@@ -662,6 +663,7 @@ describe("agentSkillsService", () => {
       "mux-diagram",
       "mux-docs",
       "orchestrate",
+      "spawn",
     ]);
 
     const invalidNames = diagnostics.invalidSkills.map((issue) => issue.directoryName).sort();

--- a/src/node/services/agentSkills/builtInSkillContent.generated.ts
+++ b/src/node/services/agentSkills/builtInSkillContent.generated.ts
@@ -6581,4 +6581,18 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
       "",
     ].join("\n"),
   },
+  spawn: {
+    "SKILL.md": [
+      "---",
+      "name: spawn",
+      "description: Delegate the whole task to a single sub-agent to preserve the parent's context window",
+      "advertise: false",
+      "---",
+      "",
+      "# Spawn",
+      "",
+      "When the user invokes `/spawn`, complete the entire task by spawning one sub-agent with a self-contained brief instead of doing the work yourself. This keeps your context window spent on coordination rather than on the file reads, searches, and tool output the work would otherwise accumulate. Wait for the sub-agent, then integrate and report its result.",
+      "",
+    ].join("\n"),
+  },
 };

--- a/src/node/services/agentSkills/builtInSpawnSkill.test.ts
+++ b/src/node/services/agentSkills/builtInSpawnSkill.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+
+import { SkillNameSchema } from "@/common/orpc/schemas";
+import { getBuiltInSkillDescriptors } from "./builtInSkillDefinitions";
+
+describe("built-in spawn skill", () => {
+  const name = SkillNameSchema.parse("spawn");
+
+  test("is registered as a built-in skill", () => {
+    const descriptor = getBuiltInSkillDescriptors().find((d) => d.name === name);
+    expect(descriptor).toBeDefined();
+    expect(descriptor!.scope).toBe("built-in");
+  });
+
+  test("is unadvertised so it stays out of the system-prompt skill index", () => {
+    // Reachable via `/spawn` or `agent_skill_read({ name: "spawn" })`, but not surfaced
+    // in the advertised skill list that primes the model.
+    const descriptor = getBuiltInSkillDescriptors().find((d) => d.name === name);
+    expect(descriptor?.advertise).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `/spawn` built-in skill that instructs the calling agent to complete the entire task by delegating to a single sub-agent, preserving the parent's context window. Also surfaces it in the ChatInput tip carousel so users discover it.

## Background

Long-running tasks accumulate file reads, searches, and tool output that eat the parent's context window. `/spawn` gives users a one-shot way to hand the whole task to one sub-agent — the simple "just delegate it" counterpart to the multi-agent `/orchestrate` workflow.

## Implementation

- New built-in skill `src/node/builtinSkills/spawn.md` (3-sentence body, `advertise: false` so it stays out of the system-prompt skill index but remains invocable via `/spawn`). No command wiring needed — unknown slash commands resolve against discovered skill descriptors.
- Regenerated `builtInSkillContent.generated.ts` via `bun scripts/gen_builtin_skills.ts`.
- Added the `/spawn` tip to `PLACEHOLDER_TIPS` (slot 1; the lead `/orchestrate` slot is locked by tests and the Storybook pin). `/spawn` is a real, ungated built-in command, so it satisfies the carousel's "must be a working slash command" invariant.
- Behavioral test `builtInSpawnSkill.test.ts` (registration + `advertise: false`) and updated the built-in name enumerations in `agentSkillsService.test.ts`.

## Validation

- `make static-check` passes locally.
- `bun test` for the new spawn skill, `agentSkillsService`, and `placeholderTips` suites all pass.

## Risks

Low. Additive: one new built-in skill file + one carousel string. No existing behavior changes; the skill is unadvertised and only acts when explicitly invoked.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-8` • Thinking: `xhigh` • Cost: `$3.16`_

<!-- mux-attribution: model=anthropic:claude-opus-4-8 thinking=xhigh costs=3.16 -->
