### PR TITLE
🤖 fix: prevent immersive review hunk layout flashes

### DIFF
--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
@@ -232,6 +232,75 @@ describe("ImmersiveReviewView", () => {
     expect(badge.textContent ?? "").toContain("2/3");
   });
 
+  test("reserves the assisted banner slot while iterating through hunks in one file", () => {
+    const assistedHunk = createHunk({
+      id: "hunk-assisted",
+      filePath: "src/example.ts",
+      oldStart: 1,
+      oldLines: 1,
+      newStart: 1,
+      newLines: 1,
+      header: "@@ -1 +1 @@",
+      content: "-old assisted\n+new assisted",
+    });
+    const regularHunk = createHunk({
+      id: "hunk-regular",
+      filePath: assistedHunk.filePath,
+      oldStart: 12,
+      oldLines: 1,
+      newStart: 12,
+      newLines: 1,
+      header: "@@ -12 +12 @@",
+      content: "-old regular\n+new regular",
+    });
+    const hunks = [assistedHunk, regularHunk];
+    const assistedComment = "Inspect this change\nThe full rationale should remain available.";
+    const assistedHunkIds = new Set([assistedHunk.id]);
+    const assistedCommentByHunkId = new Map([[assistedHunk.id, assistedComment]]);
+
+    const renderView = (selectedHunkId: string, visibleHunks: DiffHunk[] = hunks) => (
+      <ThemeProvider forcedTheme="dark">
+        <ImmersiveReviewView
+          workspaceId="workspace-1"
+          fileTree={createFileTree(assistedHunk.filePath)}
+          hunks={visibleHunks}
+          allHunks={hunks}
+          isRead={() => false}
+          onToggleRead={mock(() => undefined)}
+          onMarkFileAsRead={mock(() => undefined)}
+          selectedHunkId={selectedHunkId}
+          onSelectHunk={mock(() => undefined)}
+          onExit={mock(() => undefined)}
+          isTouchImmersive={true}
+          reviewsByFilePath={new Map()}
+          firstSeenMap={{}}
+          assistedHunkIds={assistedHunkIds}
+          assistedCommentByHunkId={assistedCommentByHunkId}
+        />
+      </ThemeProvider>
+    );
+
+    const view = render(renderView(assistedHunk.id));
+
+    expect(view.container.querySelector('[data-assisted-banner-slot="true"]')).toBeTruthy();
+    const banner = view.getByTestId("immersive-assisted-banner");
+    expect(banner.textContent ?? "").toContain("Inspect this change");
+    expect(banner.getAttribute("title")).toBe(assistedComment);
+
+    view.rerender(renderView(regularHunk.id));
+
+    // The fixed slot remains mounted for same-file hunk iteration, but the
+    // selected-hunk callout content disappears when the plain hunk is selected.
+    expect(view.getByTestId("immersive-assisted-banner-slot")).toBeTruthy();
+    expect(view.queryByTestId("immersive-assisted-banner")).toBeNull();
+
+    // Filters can hide the assisted hunk while the file remains active; reserve
+    // from allHunks so hide-read/search does not collapse the layout mid-file.
+    view.rerender(renderView(regularHunk.id, [regularHunk]));
+    expect(view.getByTestId("immersive-assisted-banner-slot")).toBeTruthy();
+    expect(view.queryByTestId("immersive-assisted-banner")).toBeNull();
+  });
+
   test("loads full-file context for an in-budget selected hunk even when another hunk is far away", async () => {
     const nearHunk = createHunk({
       id: "hunk-near",

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -459,6 +459,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     selectedHunkId !== null ? (assistedCommentByHunkId?.get(selectedHunkId) ?? null) : null;
   const isSelectedAssisted =
     selectedHunkId !== null && (assistedHunkIds?.has(selectedHunkId) ?? false);
+  const selectedAssistedLabel = selectedAssistedComment ?? "Flagged by agent for review";
   const isTouchExperience = isTouchImmersive === true;
 
   // Flatten file tree into ordered file list
@@ -532,6 +533,9 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     return null;
   }, [selectedHunkId, hunks, allHunks, fileList, isReviewComplete]);
 
+  const activeFilePathRef = useRef<string | null>(null);
+  activeFilePathRef.current = activeFilePath;
+
   const selectedHunkFromAll = useMemo(
     () => (selectedHunkId ? (allHunks.find((item) => item.id === selectedHunkId) ?? null) : null),
     [selectedHunkId, allHunks]
@@ -562,6 +566,11 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
 
     return currentFileHunks[0] ?? null;
   }, [selectedHunkId, currentFileHunks]);
+
+  const shouldReserveAssistedBannerSlot =
+    assistedHunkIds != null &&
+    activeFilePath != null &&
+    getFileHunks(allHunks, activeFilePath).some((hunk) => assistedHunkIds.has(hunk.id));
 
   // Ensure we always have a selected hunk when the active file has hunks.
   useEffect(() => {
@@ -598,7 +607,9 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
   );
 
   // Hold diff reveal during file switches until the initial scroll is complete.
-  const [pendingRevealFilePath, setPendingRevealFilePath] = useState<string | null>(null);
+  // Track the last revealed file instead of setting "pending" from an effect so
+  // a newly selected file is hidden on its first render rather than for one frame after paint.
+  const [revealedFilePath, setRevealedFilePath] = useState<string | null>(null);
   const revealAnimationFrameRef = useRef<number | null>(null);
 
   // Load full file context only when it is cheap. The hunk overlay remains visible
@@ -817,21 +828,24 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
   // hide-read auto-advance without changing the main review panel's unread shortcut semantics.
   const readUndoStackRef = useRef<string[]>([]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (revealAnimationFrameRef.current !== null) {
       cancelAnimationFrame(revealAnimationFrameRef.current);
       revealAnimationFrameRef.current = null;
     }
 
     if (!activeFilePath) {
-      setPendingRevealFilePath(null);
+      setRevealedFilePath(null);
       return;
     }
 
-    // Keep the splash visible for each file switch until we have scrolled to the target hunk.
-    setPendingRevealFilePath(activeFilePath);
-    hunkJumpRef.current = true;
-  }, [activeFilePath]);
+    if (revealedFilePath !== activeFilePath) {
+      // Keep the splash visible for each file switch until we have scrolled to the target hunk.
+      // The pending state is derived during render so cross-file hunk iteration never flashes
+      // the new file at the old scroll position before this effect runs.
+      hunkJumpRef.current = true;
+    }
+  }, [activeFilePath, revealedFilePath]);
 
   useEffect(() => {
     return () => {
@@ -843,21 +857,21 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
 
   const selectedHunkRevealTargetLineIndex =
     selectedHunkRange?.firstModifiedIndex ?? selectedHunkRange?.startIndex ?? null;
-  const isActiveFileRevealPending = pendingRevealFilePath === activeFilePath;
+  const isActiveFileRevealPending = activeFilePath !== null && revealedFilePath !== activeFilePath;
   const revealTargetLineIndex = isActiveFileRevealPending
     ? selectedHunkRevealTargetLineIndex
     : (activeLineIndex ?? selectedHunkRevealTargetLineIndex);
   const hasResolvedSelectedHunkForReveal =
     selectedHunkId !== null && currentFileHunks.some((hunk) => hunk.id === selectedHunkId);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!isActiveFileRevealPending) {
       return;
     }
 
     // Fail open so the UI cannot get stuck if a file has no hunks.
     if (currentFileHunks.length === 0) {
-      setPendingRevealFilePath(null);
+      setRevealedFilePath(activeFilePath);
       return;
     }
 
@@ -868,9 +882,10 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
 
     // Fail open once selection is stable if we still cannot resolve a reveal target.
     if (selectedHunkRevealTargetLineIndex === null) {
-      setPendingRevealFilePath(null);
+      setRevealedFilePath(activeFilePath);
     }
   }, [
+    activeFilePath,
     currentFileHunks.length,
     hasResolvedSelectedHunkForReveal,
     isActiveFileRevealPending,
@@ -940,6 +955,9 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
   const onSelectHunkRef = useRef(onSelectHunk);
   const allHunksRef = useRef(allHunks);
   const hunkLineRangesRef = useRef(overlayData.hunkLineRanges);
+  const previousSelectedHunkIdRef = useRef<string | null>(null);
+  const previousSelectedHunkRangeRef = useRef<HunkLineRange | null>(null);
+  const skipScrollUntilCursorSettlesRef = useRef(false);
   const highlightedLineElementRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
@@ -974,12 +992,19 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     hunkLineRangesRef.current = overlayData.hunkLineRanges;
   }, [overlayData.hunkLineRanges]);
 
-  // Keep cursor and selection aligned to the selected hunk when hunk navigation changes.
-  useEffect(() => {
+  // Keep cursor and selection aligned to the selected hunk before paint so J/K hunk
+  // iteration does not flash the previous cursor/selection for a frame.
+  useLayoutEffect(() => {
     const resolvedSelectedHunkId = selectedHunk?.id ?? null;
+    const previousSelectedHunkId = previousSelectedHunkIdRef.current;
+    const previousSelectedHunkRange = previousSelectedHunkRangeRef.current;
+
+    previousSelectedHunkIdRef.current = resolvedSelectedHunkId;
+    previousSelectedHunkRangeRef.current = selectedHunkRange;
 
     if (!selectedHunkRange || !resolvedSelectedHunkId) {
       pendingJumpSelectAllHunkIdRef.current = null;
+      skipScrollUntilCursorSettlesRef.current = false;
       setActiveLineIndex(null);
       setSelectedLineRange(null);
       return;
@@ -991,6 +1016,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
       // Use actual modified boundaries (without context padding) for the highlight
       const modifiedStart = selectedHunkRange.firstModifiedIndex ?? selectedHunkRange.startIndex;
       const modifiedEnd = selectedHunkRange.lastModifiedIndex ?? selectedHunkRange.endIndex;
+      skipScrollUntilCursorSettlesRef.current = activeLineIndexRef.current !== modifiedEnd;
       setActiveLineIndex(modifiedEnd);
       setSelectedLineRange({
         startIndex: modifiedStart,
@@ -998,6 +1024,34 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
       });
       return;
     }
+
+    const cursorLineIndex = activeLineIndexRef.current;
+    const cursorWasInPreviousSelectedHunk = Boolean(
+      cursorLineIndex !== null &&
+      previousSelectedHunkRange &&
+      cursorLineIndex >= previousSelectedHunkRange.startIndex &&
+      cursorLineIndex <= previousSelectedHunkRange.endIndex
+    );
+    const shouldPreserveContextCursor = Boolean(
+      cursorLineIndex !== null &&
+      previousSelectedHunkRange &&
+      previousSelectedHunkId === resolvedSelectedHunkId &&
+      !cursorWasInPreviousSelectedHunk
+    );
+
+    if (shouldPreserveContextCursor) {
+      // Full-file context can arrive after the user has intentionally moved the
+      // cursor onto an unchanged/context row. Preserve that cursor instead of
+      // snapping back to the selected hunk just because overlay indices changed.
+      skipScrollUntilCursorSettlesRef.current = false;
+      return;
+    }
+
+    skipScrollUntilCursorSettlesRef.current = Boolean(
+      cursorLineIndex !== null &&
+      (cursorLineIndex < selectedHunkRange.startIndex ||
+        cursorLineIndex > selectedHunkRange.endIndex)
+    );
 
     setActiveLineIndex((previousLineIndex) => {
       if (
@@ -1132,6 +1186,19 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
       const targetHunkId = findReviewHunkId(review, fileHunks) ?? fileHunks[0].id;
       pendingJumpSelectAllHunkIdRef.current = null;
       hunkJumpRef.current = true;
+      const targetRange =
+        activeFilePath === review.data.filePath
+          ? (overlayData.hunkLineRanges.get(targetHunkId) ?? null)
+          : null;
+      if (targetRange) {
+        // Note/sidebar jumps are explicit hunk navigation, even when the note maps
+        // to the already-selected hunk. Reset any context-row cursor first so the
+        // centered jump lands on the note's hunk instead of a stale context line.
+        skipScrollUntilCursorSettlesRef.current = false;
+        setSelectedLineRange(null);
+        setActiveLineIndex(targetRange.firstModifiedIndex ?? targetRange.startIndex);
+      }
+
       onSelectHunk(targetHunkId);
       // Force scroll effect to re-fire even when activeLineIndex is unchanged
       // (for example when the cursor is already inside the selected hunk).
@@ -1145,7 +1212,13 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
         });
       }
     },
-    [allHunks, onSelectHunk, props.reviewActions?.onEditComment]
+    [
+      activeFilePath,
+      allHunks,
+      onSelectHunk,
+      overlayData.hunkLineRanges,
+      props.reviewActions?.onEditComment,
+    ]
   );
 
   const diffReviewActions = useMemo<ReviewActionCallbacks | undefined>(() => {
@@ -1624,8 +1697,10 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
   const previousContentRef = useRef(overlayData.content);
 
   // Keep the active line visible while moving with keyboard shortcuts, without
-  // forcing the full diff tree to re-render on every cursor move.
-  useEffect(() => {
+  // forcing the full diff tree to re-render on every cursor move. This is a layout
+  // effect because scroll/outline writes must happen before paint to avoid hunk
+  // navigation flashing at the previous viewport position.
+  useLayoutEffect(() => {
     const contentChanged = previousContentRef.current !== overlayData.content;
     previousContentRef.current = overlayData.content;
 
@@ -1638,10 +1713,23 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
 
     // When overlay content structure changes (fallback hunks -> full-file view),
     // defer regular scrolling until the selected-hunk effect has recalculated
-    // activeLineIndex. During a file-switch reveal gate we still need one initial
-    // scroll so the diff appears already positioned at the selected hunk.
+    // activeLineIndex. Preserve ordinary context-row cursor movement: if the user
+    // is already outside the selected hunk and no hunk sync is pending, do not arm
+    // a center jump for the next scroll.
     if (contentChanged) {
-      hunkJumpRef.current = true;
+      const cursorIsInsideSelectedHunk = Boolean(
+        activeLineIndex !== null &&
+        selectedHunkRange &&
+        activeLineIndex >= selectedHunkRange.startIndex &&
+        activeLineIndex <= selectedHunkRange.endIndex
+      );
+      hunkJumpRef.current = Boolean(
+        isActiveFileRevealPending ||
+        skipScrollUntilCursorSettlesRef.current ||
+        activeLineIndex === null ||
+        !selectedHunkRange ||
+        cursorIsInsideSelectedHunk
+      );
       if (!isActiveFileRevealPending) {
         return;
       }
@@ -1650,6 +1738,26 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     const lineIndexForScroll = isActiveFileRevealPending ? revealTargetLineIndex : activeLineIndex;
     if (lineIndexForScroll === null) {
       return;
+    }
+
+    if (skipScrollUntilCursorSettlesRef.current) {
+      const cursorHasSettled =
+        isActiveFileRevealPending ||
+        activeLineIndex === null ||
+        !selectedHunkRange ||
+        (activeLineIndex >= selectedHunkRange.startIndex &&
+          activeLineIndex <= selectedHunkRange.endIndex);
+
+      if (!cursorHasSettled) {
+        // A hunk jump renders once with the previous hunk's activeLineIndex before
+        // the selected-hunk layout effect commits the new cursor. Do not issue a
+        // stale scrollIntoView in that intermediate commit; the next layout pass
+        // will scroll directly to the selected hunk. Plain line-cursor movement to
+        // full-file context lines never sets this ref, so it still scrolls normally.
+        return;
+      }
+
+      skipScrollUntilCursorSettlesRef.current = false;
     }
 
     const lineElement = containerRef.current?.querySelector<HTMLElement>(
@@ -1666,8 +1774,8 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
 
       const revealFilePath = activeFilePath;
       revealAnimationFrameRef.current = window.requestAnimationFrame(() => {
-        setPendingRevealFilePath((pendingFilePath) =>
-          pendingFilePath === revealFilePath ? null : pendingFilePath
+        setRevealedFilePath((currentRevealedFilePath) =>
+          activeFilePathRef.current === revealFilePath ? revealFilePath : currentRevealedFilePath
         );
         revealAnimationFrameRef.current = null;
       });
@@ -1697,8 +1805,8 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
 
     const revealFilePath = activeFilePath;
     revealAnimationFrameRef.current = window.requestAnimationFrame(() => {
-      setPendingRevealFilePath((pendingFilePath) =>
-        pendingFilePath === revealFilePath ? null : pendingFilePath
+      setRevealedFilePath((currentRevealedFilePath) =>
+        activeFilePathRef.current === revealFilePath ? revealFilePath : currentRevealedFilePath
       );
       revealAnimationFrameRef.current = null;
     });
@@ -1709,6 +1817,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     overlayData.content,
     revealTargetLineIndex,
     scrollNonce,
+    selectedHunkRange,
   ]);
 
   useEffect(() => {
@@ -1965,36 +2074,46 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
 
       {/* Unified whole-file diff with hunk overlays + notes sidebar */}
       <div className="flex min-h-0 flex-1">
-        {/* Diff column. The assisted-review banner lives INSIDE this column (not
+        {/* Diff column. The assisted-review callout lives INSIDE this column (not
             above the whole body) so the agent's per-hunk comment spans only the
             diff width and lines up with the code it refers to — rather than
             stretching across the minimap and notes sidebar. */}
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-          {/* Assisted-review banner — surfaces the agent's flag + comment when
-              the selected hunk is one the agent pinned for review. Pinned to the
-              top of the diff column so the focus signal is impossible to miss
-              after entering immersive mode, where the side-panel cues aren't
-              visible. */}
-          {isSelectedAssisted && (
-            <div
-              className="border-review-accent/40 bg-review-accent/5 text-foreground flex shrink-0 items-start gap-2 border-b px-3 py-1.5 text-[11px] leading-[1.4]"
-              data-testid="immersive-assisted-banner"
-              role="status"
-              aria-live="polite"
-            >
-              <Sparkles
-                aria-hidden="true"
-                className="text-review-accent mt-[2px] h-3 w-3 shrink-0"
+          {shouldReserveAssistedBannerSlot &&
+            (isSelectedAssisted ? (
+              <TooltipIfPresent
+                tooltip={<span className="whitespace-pre-wrap">{selectedAssistedLabel}</span>}
+                side="bottom"
+                align="start"
+              >
+                <div
+                  className="border-review-accent/40 bg-review-accent/5 text-foreground flex h-[calc(1lh+0.75rem+1px)] shrink-0 cursor-help items-start gap-2 overflow-hidden border-b px-3 py-1.5 text-[11px] leading-[1.4]"
+                  data-assisted-banner-slot="true"
+                  data-testid="immersive-assisted-banner"
+                  role="status"
+                  aria-live="polite"
+                  aria-label={selectedAssistedLabel}
+                  title={selectedAssistedLabel}
+                >
+                  {/* Reserve a stable row for files that contain assisted hunks so J/K
+                      iteration doesn't reflow the diff when the selected hunk enters
+                      or leaves the agent's focus. */}
+                  <Sparkles
+                    aria-hidden="true"
+                    className="text-review-accent mt-[2px] h-3 w-3 shrink-0"
+                  />
+                  <span className="min-w-0 break-words whitespace-pre-wrap">
+                    {selectedAssistedLabel}
+                  </span>
+                </div>
+              </TooltipIfPresent>
+            ) : (
+              <div
+                className="border-border-light bg-dark h-[calc(1lh+0.75rem+1px)] shrink-0 border-b text-[11px] leading-[1.4]"
+                data-assisted-banner-slot="true"
+                data-testid="immersive-assisted-banner-slot"
               />
-              {selectedAssistedComment ? (
-                <span className="min-w-0 break-words whitespace-pre-wrap">
-                  {selectedAssistedComment}
-                </span>
-              ) : (
-                <span className="text-muted italic">Flagged by agent for review</span>
-              )}
-            </div>
-          )}
+            ))}
           {/* Avoid top padding here; it reads as a blank block between the controls and diff. */}
           <div
             ref={scrollContainerRef}


### PR DESCRIPTION
## Summary

Fixes layout flashes while iterating through hunks in Immersive Review by synchronizing visual hunk state before paint and keeping the agent-assisted callout from changing the diff column height mid-file.

## Background

Immersive Review hunk navigation is keyboard-first, so J/K iteration should feel stable. The previous flow corrected scroll position, cursor selection, and reveal state after paint, and the per-hunk assisted banner could mount/unmount above the diff when moving between flagged and unflagged hunks in the same file.

## Implementation

- Moved file reveal gating, selected-hunk cursor/selection sync, and scroll/outline DOM writes to layout effects so they settle before the browser paints.
- Added a fixed assisted-banner slot for files containing assisted hunks, so entering or leaving an assisted hunk does not reflow the diff column.
- Kept the assisted callout inside the diff column and rendered it as a stable one-line row.

## Validation

- `make fmt`
- `bun test src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx`
- `make typecheck`
- `make lint`
- `make static-check`
- `git diff --check`

## Risks

Low-to-medium. The change is scoped to Immersive Review layout/navigation. The main risk is altered timing around scroll/cursor effects, covered by existing Immersive Review tests plus a new regression test for same-file assisted/non-assisted hunk iteration.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `3826192{MUX_COSTS_USD:-0}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=10.47 -->
