### PR TITLE
🤖 feat: single-line immersive review TODO bar

### DIFF
--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
-import { act, cleanup, fireEvent, render, type RenderResult } from "@testing-library/react";
+import { act, cleanup, render, type RenderResult } from "@testing-library/react";
 import { Profiler } from "react";
 
 import { installDom } from "../../../../../tests/ui/dom";
@@ -145,14 +145,16 @@ describe("ImmersiveReviewAgentStatusBar", () => {
     { content: "Add tests", status: "pending" },
   ];
 
-  test("renders the TODO plan (expanded) when todos exist", () => {
+  test("renders the TODO plan inline on a single line when todos exist", () => {
     seed("ws-todos", { todos });
     const result = renderBar("ws-todos");
-    // The horizontal TodoList strip is visible by default.
+    // The bar always shows the full plan: a static "TODO" label plus the inline
+    // horizontal TodoList strip listing each todo (no collapse toggle).
+    expect(result.getByText("TODO")).toBeTruthy();
     expect(result.getByText("Wire up status bar")).toBeTruthy();
     expect(result.getByText("Add tests")).toBeTruthy();
-    // Summary reflects the counts.
-    expect(result.getByText(/1 in progress/)).toBeTruthy();
+    // The plan is never collapsible, so there's no expand/collapse button.
+    expect(result.queryByRole("button")).toBeNull();
   });
 
   test("renders nothing when there is no plan and no active stream", () => {
@@ -181,29 +183,6 @@ describe("ImmersiveReviewAgentStatusBar", () => {
     expect(result.getByText("Mux has a question")).toBeTruthy();
     // The question chip wins over the streaming label.
     expect(result.queryByText("Streaming…")).toBeNull();
-  });
-
-  test("collapsing hides the plan and the collapsed choice persists across remounts", () => {
-    const workspaceId = "ws-collapse";
-    seed(workspaceId, { todos });
-    const first = renderBar(workspaceId);
-
-    // Plan is expanded by default; collapsing hides the horizontal strip.
-    expect(first.getByText("Wire up status bar")).toBeTruthy();
-    fireEvent.click(first.getByRole("button", { name: /todo/i }));
-    expect(first.queryByText("Wire up status bar")).toBeNull();
-
-    // Remounting the bar for the same workspace must restore the collapsed
-    // choice (asserted via the user-visible re-render rather than reading the
-    // raw localStorage value, which keeps this resilient to the test-runner's
-    // shared-global quirks).
-    first.unmount();
-    const second = renderBar(workspaceId);
-    expect(second.queryByText("Wire up status bar")).toBeNull();
-
-    // Re-expanding brings the plan back, proving the toggle round-trips.
-    fireEvent.click(second.getByRole("button", { name: /todo/i }));
-    expect(second.getByText("Wire up status bar")).toBeTruthy();
   });
 
   test("does not re-render on unrelated workspace-state bumps, only on watched fields", () => {

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.tsx
@@ -6,8 +6,9 @@
  * loses all signal about what the agent is doing.
  *
  * This bar restores that signal without leaving immersive:
- *   - the agent's TODO plan as a single horizontal strip (collapsible,
- *     persisted) so it reserves minimal review height, and
+ *   - the agent's TODO plan on a single line — a "TODO" label and the plan as a
+ *     horizontally-scrolling strip share one row with the streaming chip, so it
+ *     reserves minimal review height, and
  *   - live streaming status (starting / streaming / awaiting a question).
  *
  * Design notes:
@@ -24,15 +25,13 @@
  */
 
 import React, { useSyncExternalStore } from "react";
-import { ChevronDown, ChevronRight, CircleHelp, List, Loader2 } from "lucide-react";
+import { CircleHelp, List, Loader2 } from "lucide-react";
 import { TodoList } from "@/browser/components/TodoList/TodoList";
 import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
 import {
   getWorkspaceStreamingStatusPhase,
   useWorkspaceStreamingStatusPhase,
 } from "@/browser/hooks/useWorkspaceStreamingStatusPhase";
-import { usePersistedState } from "@/browser/hooks/usePersistedState";
-import { getImmersiveReviewAgentBarExpandedKey } from "@/common/constants/storage";
 import { cn } from "@/common/lib/utils";
 import type { TodoItem } from "@/common/types/tools";
 
@@ -48,11 +47,6 @@ interface ImmersiveReviewAgentStatusBarProps {
 export const ImmersiveReviewAgentStatusBar: React.FC<ImmersiveReviewAgentStatusBarProps> = ({
   workspaceId,
 }) => {
-  const [expanded, setExpanded] = usePersistedState(
-    getImmersiveReviewAgentBarExpandedKey(workspaceId),
-    true
-  );
-
   // Subscribe to each field this bar uses as its OWN snapshot rather than
   // returning the whole WorkspaceState object. getWorkspaceState is version-
   // cached, so its reference changes on EVERY state bump (e.g. each streamed
@@ -99,20 +93,6 @@ export const ImmersiveReviewAgentStatusBar: React.FC<ImmersiveReviewAgentStatusB
   // Nothing to surface: don't reserve any vertical space in the review viewport.
   if (!hasTodos && !isStreamingStatusVisible) {
     return null;
-  }
-
-  const inProgressCount = todos.filter((todo) => todo.status === "in_progress").length;
-  const pendingCount = todos.filter((todo) => todo.status === "pending").length;
-  const completedCount = todos.length - inProgressCount - pendingCount;
-  const summaryParts: string[] = [];
-  if (inProgressCount > 0) {
-    summaryParts.push(`${inProgressCount} in progress`);
-  }
-  if (pendingCount > 0) {
-    summaryParts.push(`${pendingCount} pending`);
-  }
-  if (summaryParts.length === 0 && hasTodos) {
-    summaryParts.push(`${completedCount} completed`);
   }
 
   // role=status + aria-live so screen readers announce streaming/question
@@ -166,27 +146,24 @@ export const ImmersiveReviewAgentStatusBar: React.FC<ImmersiveReviewAgentStatusB
       data-component="ImmersiveReviewAgentStatusBar"
     >
       {hasTodos ? (
-        <button
-          type="button"
-          onClick={() => setExpanded(!expanded)}
-          className="group flex h-7 w-full items-center gap-2 px-3 text-left leading-none"
-          aria-expanded={expanded}
-        >
-          <List
-            aria-hidden="true"
-            className="text-muted group-hover:text-secondary size-3.5 shrink-0 transition-colors"
-          />
-          <span className="text-muted group-hover:text-secondary min-w-0 truncate transition-colors">
+        // Single-row layout: a static "TODO" label, the plan, and the streaming
+        // chip all share one line so the bar reserves a single row of review
+        // height. The plan renders as a horizontally-scrolling strip. min-h-7
+        // (not a fixed h-7) lets the row grow to the strip's natural height so
+        // the chips aren't vertically clipped.
+        <div className="flex min-h-7 w-full items-center gap-2 px-3 leading-none">
+          <div className="text-muted flex shrink-0 items-center gap-1.5">
+            <List aria-hidden="true" className="size-3.5 shrink-0" />
             <span className="font-medium">TODO</span>
-            {summaryParts.length > 0 && <> · {summaryParts.join(" · ")}</>}
-          </span>
+          </div>
+          {/* Horizontal strip fills the remaining width and scrolls sideways
+              when the plan is longer than the bar; min-w-0 lets it shrink so
+              the scroll container is bounded instead of pushing the chip off. */}
+          <div className="min-w-0 flex-1">
+            <TodoList todos={todos} layout="horizontal" />
+          </div>
           {renderStatusChip(true)}
-          {expanded ? (
-            <ChevronDown className="text-muted group-hover:text-secondary size-3.5 shrink-0 transition-colors" />
-          ) : (
-            <ChevronRight className="text-muted group-hover:text-secondary size-3.5 shrink-0 transition-colors" />
-          )}
-        </button>
+        </div>
       ) : (
         // Streaming/question only (no plan yet): static row, nothing to expand.
         // Chip is left-aligned here so it reads as a status label rather than
@@ -194,11 +171,6 @@ export const ImmersiveReviewAgentStatusBar: React.FC<ImmersiveReviewAgentStatusB
         <div className="flex h-7 w-full items-center gap-2 px-3 leading-none">
           {renderStatusChip(false)}
         </div>
-      )}
-      {hasTodos && expanded && (
-        // Horizontal strip: one row tall (the list scrolls sideways), so the
-        // plan costs minimal vertical space in the review viewport.
-        <TodoList todos={todos} layout="horizontal" />
       )}
     </div>
   );

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.stories.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.stories.tsx
@@ -716,7 +716,7 @@ export const ImmersiveWithAgentStatusBar: Story = {
     await waitFor(
       () => {
         canvas.getByTestId("immersive-review-view");
-        // The collapsible TODO bar + its horizontal plan strip render.
+        // The single-line TODO bar + its inline horizontal plan strip render.
         canvas.getByTestId("immersive-agent-status-bar");
         canvas.getByText("Add the top status bar (TODO + streaming)");
         // Live streaming chip is visible alongside the plan.
@@ -750,7 +750,7 @@ export const ImmersiveWithStreamingNoTodo: Story = {
     await waitFor(
       () => {
         canvas.getByTestId("immersive-review-view");
-        // The bar renders the streaming chip with no TODO toggle/summary.
+        // The bar renders the streaming chip with no TODO label/plan.
         canvas.getByTestId("immersive-agent-status-bar");
         canvas.getByText("Streaming…");
         if (canvas.queryByText("TODO")) {

--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -637,18 +637,6 @@ export function getReviewImmersiveKey(workspaceId: string): string {
 }
 
 /**
- * Get the localStorage key for the immersive-review agent status bar expansion
- * state (the TODO plan + streaming-status bar pinned to the top of immersive
- * review). Persisted per workspace so a user's collapse choice survives
- * navigation. Mirrors getPinnedTodoExpandedKey — a transient UI preference, so
- * intentionally NOT copied on fork.
- * Format: "review-immersive-agentbar-expanded:{workspaceId}"
- */
-export function getImmersiveReviewAgentBarExpandedKey(workspaceId: string): string {
-  return `review-immersive-agentbar-expanded:${workspaceId}`;
-}
-
-/**
  * Get the localStorage key for auto-compaction enabled preference per workspace
  * Format: "autoCompaction:enabled:{workspaceId}"
  */
@@ -716,7 +704,6 @@ const EPHEMERAL_WORKSPACE_KEY_FUNCTIONS: Array<(workspaceId: string) => string> 
   getPendingWorkspaceSendErrorKey,
   getPlanContentKey, // Cache only, no need to preserve on fork
   getPostCompactionStateKey, // Cache only, no need to preserve on fork
-  getImmersiveReviewAgentBarExpandedKey, // Transient UI pref; clean up on removal, don't carry on fork
 ];
 
 /**


### PR DESCRIPTION
## Summary

Collapse the immersive-review agent TODO bar from two stacked rows into a single line. The "TODO" label, the agent's plan (rendered as the existing horizontally-scrolling strip), and the live streaming/question chip now all share one row, and the bar is no longer collapsible.

## Background

The TODO bar at the top of immersive review previously rendered two rows: a header button (`TODO · summary` + expand chevron + streaming chip) above a separate full-width plan strip that appeared when expanded. That reserved more vertical space than necessary in the review viewport. The ask was to make it one line; per follow-up, the collapse affordance isn't needed either.

## Implementation

- `ImmersiveReviewAgentStatusBar.tsx`: replaced the toggle button + conditional strip with a single `min-h-7` flex row — a static `List` + "TODO" label, the `TodoList` (`layout="horizontal"`) strip in a `min-w-0 flex-1` container so it scrolls sideways and stays bounded, and the streaming chip pinned right via the existing `renderStatusChip`. Removed the persisted `expanded` state, the now-redundant count-summary computation, and the unused `ChevronDown`/`ChevronRight`/`usePersistedState` imports. Used `min-h-7` rather than a fixed `h-7` so the row grows to the strip's natural height instead of clipping the chips.
- `storage.ts`: removed `getImmersiveReviewAgentBarExpandedKey` (its only consumer) and its entry in the ephemeral-key cleanup list.
- Tests/stories: updated the unit test to assert the single-line plan renders with no collapse button, dropped the collapse/persistence test, and refreshed story comments. The streaming-only (no-plan) path is unchanged.

## Risks

Low. Scoped to the immersive-review status bar's presentation; no change to streaming/question state wiring or the leaf-subscription re-render isolation. Removing the persisted-expand key is safe — it was a transient, not-copied-on-fork UI preference, and stale localStorage entries are simply ignored.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-8` • Thinking: `xhigh` • Cost: `$1.92`_

<!-- mux-attribution: model=anthropic:claude-opus-4-8 thinking=xhigh costs=1.92 -->
