### PR TITLE
🤖 fix: gate immersive review diff hydration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -49,7 +49,7 @@
         "@vercel/ai-sdk-openai-websocket-fetch": "^1.0.0",
         "@xterm/addon-serialize": "^0.14.0",
         "@xterm/headless": "^6.0.0",
-        "ai": "^6.0.175",
+        "ai": "6.0.175",
         "ai-tokenizer": "^1.0.6",
         "chalk": "^5.6.2",
         "comlink": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@vercel/ai-sdk-openai-websocket-fetch": "^1.0.0",
     "@xterm/addon-serialize": "^0.14.0",
     "@xterm/headless": "^6.0.0",
-    "ai": "^6.0.175",
+    "ai": "6.0.175",
     "ai-tokenizer": "^1.0.6",
     "chalk": "^5.6.2",
     "comlink": "^4.4.2",

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveMinimap.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveMinimap.test.tsx
@@ -97,6 +97,7 @@ describe("ImmersiveMinimap", () => {
       />
     );
 
+    expect(view.getByTestId("immersive-minimap").className).toContain("h-full");
     // Synchronous render — no waitFor needed since parseDiffLines runs during render
     expect(view.getByTestId("immersive-minimap-canvas")).toBeTruthy();
   });
@@ -131,6 +132,41 @@ describe("ImmersiveMinimap", () => {
     );
 
     expect(parseSpy).toHaveBeenCalledWith(updatedContent);
+  });
+
+  test("redraws from the latest scroll position when parent bumps redraw nonce", () => {
+    const stableLineCategories: immersiveMinimapMath.LineCategory[] = ["add", "remove", "context"];
+    spyOn(immersiveMinimapMath, "parseDiffLines").mockImplementation(() => stableLineCategories);
+    const getThumbMetricsSpy = spyOn(immersiveMinimapMath, "getThumbMetrics");
+    const scrollFixture = createScrollContainerFixture();
+    const scrollContainerRef = { current: scrollFixture.element };
+    const commentLineIndices = new Set<number>();
+    const onSelectLineIndex = mock(() => undefined);
+
+    const renderMinimap = (redrawNonce: number) => (
+      <ImmersiveMinimap
+        content="+line a\n-line b\n context"
+        scrollContainerRef={scrollContainerRef}
+        activeLineIndex={null}
+        redrawNonce={redrawNonce}
+        onSelectLineIndex={onSelectLineIndex}
+        commentLineIndices={commentLineIndices}
+      />
+    );
+
+    const view = render(renderMinimap(0));
+    const canvas = view.getByTestId("immersive-minimap-canvas") as HTMLCanvasElement;
+    Object.defineProperty(canvas, "clientWidth", { configurable: true, get: () => 48 });
+    Object.defineProperty(canvas, "clientHeight", { configurable: true, get: () => 120 });
+    getThumbMetricsSpy.mockClear();
+
+    scrollFixture.element.scrollTop = 375;
+    view.rerender(renderMinimap(1));
+
+    // Parent reveal scroll happens outside the minimap. The nonce is the contract
+    // that forces a hidden pre-reveal canvas redraw using the new scrollTop even
+    // when React Compiler keeps parsed line categories stable across renders.
+    expect(getThumbMetricsSpy).toHaveBeenCalledWith(375, 1000, 250, 120);
   });
 
   test("clicking minimap dispatches the mapped line index", () => {

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveMinimap.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveMinimap.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 
 import { clamp } from "@/common/utils/clamp";
 import {
@@ -15,6 +15,8 @@ interface ImmersiveMinimapProps {
   onSelectLineIndex: (lineIndex: number) => void;
   /** Diff line indices where review comments exist (drawn as yellow indicators) */
   commentLineIndices: ReadonlySet<number>;
+  /** Bump after parent-owned scroll positioning so the canvas reads fresh scrollTop before reveal. */
+  redrawNonce?: number;
 }
 
 const DEFAULT_ADD_COLOR = "rgba(34, 197, 94, 0.85)";
@@ -133,9 +135,11 @@ export const ImmersiveMinimap: React.FC<ImmersiveMinimapProps> = (props) => {
     }
   }, [lineCategories, props.activeLineIndex, props.commentLineIndices, props.scrollContainerRef]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    // Canvas pixels are visible layout state; redraw before paint so hydration
+    // swaps do not show one frame of the previous minimap/scroll thumb.
     redrawCanvas();
-  }, [redrawCanvas]);
+  }, [redrawCanvas, props.redrawNonce]);
 
   useEffect(() => {
     const scrollContainer = props.scrollContainerRef.current;
@@ -280,7 +284,7 @@ export const ImmersiveMinimap: React.FC<ImmersiveMinimapProps> = (props) => {
   }
 
   return (
-    <div className="w-6 shrink-0 bg-[var(--color-bg-dark)]" data-testid="immersive-minimap">
+    <div className="h-full w-6 shrink-0 bg-[var(--color-bg-dark)]" data-testid="immersive-minimap">
       <canvas
         ref={canvasRef}
         className="h-full w-full cursor-pointer"

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { GlobalWindow } from "happy-dom";
 import { useEffect, useState, type ComponentProps } from "react";
 
@@ -32,7 +32,7 @@ void mock.module("@/browser/contexts/API", () => ({
   }),
 }));
 
-import { ImmersiveReviewView } from "./ImmersiveReviewView";
+import { ImmersiveReviewView, shouldPreserveImmersiveContextCursor } from "./ImmersiveReviewView";
 
 function createHunk(overrides: Partial<DiffHunk> = {}): DiffHunk {
   return {
@@ -114,6 +114,36 @@ function renderImmersiveReview(
   );
 }
 
+function installManualAnimationFrame() {
+  let nextFrameId = 1;
+  const callbacks = new Map<number, FrameRequestCallback>();
+
+  const requestAnimationFrameMock = mock((callback: FrameRequestCallback) => {
+    const frameId = nextFrameId;
+    nextFrameId += 1;
+    callbacks.set(frameId, callback);
+    return frameId;
+  }) as unknown as typeof globalThis.requestAnimationFrame;
+  const cancelAnimationFrameMock = mock((frameId: number) => {
+    callbacks.delete(frameId);
+  }) as unknown as typeof globalThis.cancelAnimationFrame;
+
+  globalThis.requestAnimationFrame = requestAnimationFrameMock;
+  globalThis.cancelAnimationFrame = cancelAnimationFrameMock;
+  globalThis.window.requestAnimationFrame = requestAnimationFrameMock;
+  globalThis.window.cancelAnimationFrame = cancelAnimationFrameMock;
+
+  return {
+    flush() {
+      const pendingCallbacks = Array.from(callbacks.values());
+      callbacks.clear();
+      for (const callback of pendingCallbacks) {
+        callback(performance.now());
+      }
+    },
+  };
+}
+
 describe("ImmersiveReviewView", () => {
   let originalWindow: typeof globalThis.window;
   let originalDocument: typeof globalThis.document;
@@ -191,6 +221,116 @@ describe("ImmersiveReviewView", () => {
         exitCode: 0,
       },
     });
+  });
+
+  test("keeps hydrated full-file context behind the reveal gate until positioned", async () => {
+    type ExecuteBashValue = Awaited<ReturnType<MockApiClient["workspace"]["executeBash"]>>;
+    let resolveRead: ((value: ExecuteBashValue) => void) | undefined;
+    const pendingRead = new Promise<ExecuteBashValue>((resolve) => {
+      resolveRead = resolve;
+    });
+    mockApi.workspace.executeBash = mock(() => pendingRead);
+    const animationFrame = installManualAnimationFrame();
+
+    const hunk = createHunk({
+      newStart: 3,
+      oldStart: 3,
+      header: "@@ -3 +3 @@",
+      content: "-old selected line\n+new selected line",
+    });
+
+    const view = renderImmersiveReview({
+      fileTree: createFileTree(hunk.filePath),
+      hunks: [hunk],
+      allHunks: [hunk],
+      selectedHunkId: hunk.id,
+      isTouchImmersive: false,
+    });
+
+    await waitFor(() => expect(mockApi.workspace.executeBash).toHaveBeenCalledTimes(1));
+    expect(view.getByTestId("immersive-diff-reveal-overlay").textContent ?? "").toContain(
+      "Loading file"
+    );
+    expect(view.getByTestId("immersive-diff-reveal-stage").className).toContain("invisible");
+
+    act(() => animationFrame.flush());
+    await waitFor(() => expect(view.queryByTestId("immersive-diff-reveal-overlay")).toBeNull());
+    expect(view.getByTestId("immersive-diff-reveal-stage").className).not.toContain("invisible");
+
+    const resolveLoadedContent = resolveRead;
+    if (!resolveLoadedContent) {
+      throw new Error("Read promise resolver was not captured");
+    }
+
+    act(() => {
+      resolveLoadedContent({
+        success: true,
+        data: {
+          success: true,
+          output: encodeFileReadOutput(
+            ["context before selected 1", "context before selected 2", "new selected line"].join(
+              "\n"
+            )
+          ),
+          exitCode: 0,
+        },
+      });
+    });
+
+    await waitFor(() =>
+      expect(view.getByTestId("immersive-diff-reveal-overlay").textContent ?? "").toContain(
+        "Preparing diff"
+      )
+    );
+    expect(view.container.textContent ?? "").toContain("context before selected 1");
+    expect(view.getByTestId("immersive-diff-reveal-stage").className).toContain("invisible");
+    expect(view.getByTestId("immersive-minimap-reveal-stage").className).toContain("h-full");
+    expect(view.getByTestId("immersive-minimap-reveal-stage").className).toContain("invisible");
+
+    act(() => animationFrame.flush());
+    await waitFor(() => expect(view.queryByTestId("immersive-diff-reveal-overlay")).toBeNull());
+    expect(view.getByTestId("immersive-diff-reveal-stage").className).not.toContain("invisible");
+    expect(view.getByTestId("immersive-minimap-reveal-stage").className).not.toContain("invisible");
+  });
+
+  test("only preserves context cursors while overlay content is unchanged", () => {
+    const previousRange = { startIndex: 0, endIndex: 1 };
+
+    expect(
+      shouldPreserveImmersiveContextCursor({
+        cursorLineIndex: 2,
+        previousRange,
+        previousHunkId: "hunk-selected",
+        currentHunkId: "hunk-selected",
+        previousOverlayContent: "compact overlay",
+        currentOverlayContent: "compact overlay",
+      })
+    ).toBe(true);
+
+    // Compact hunk overlays and hydrated full-file overlays use different
+    // numeric row indices. Do not carry an out-of-hunk compact cursor across
+    // hydration, or the reveal can replay a stale context/separator row.
+    expect(
+      shouldPreserveImmersiveContextCursor({
+        cursorLineIndex: 2,
+        previousRange,
+        previousHunkId: "hunk-selected",
+        currentHunkId: "hunk-selected",
+        previousOverlayContent: "compact overlay",
+        currentOverlayContent: "hydrated full-file overlay",
+      })
+    ).toBe(false);
+
+    expect(
+      shouldPreserveImmersiveContextCursor({
+        cursorLineIndex: 1,
+        previousRange,
+        previousHunkId: "hunk-selected",
+        currentHunkId: "hunk-selected",
+        previousOverlayContent: "compact overlay",
+        currentOverlayContent: "compact overlay",
+      })
+    ).toBe(false);
   });
 
   test("skips full-file reads when the selected hunk starts beyond the render budget", () => {

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -146,6 +146,11 @@ interface ImmersiveOverlayData {
   hunkLineRanges: Map<string, HunkLineRange>;
 }
 
+interface OverlayRevealIdentity {
+  filePath: string;
+  content: string;
+}
+
 const MAX_FULL_FILE_CONTEXT_LINES = 1500;
 const MAX_FULL_FILE_CONTEXT_BYTES = 256 * 1024;
 
@@ -364,6 +369,13 @@ function buildOverlayFromHunks(sortedHunks: DiffHunk[]): ImmersiveOverlayData {
   };
 }
 
+function isSameOverlayRevealIdentity(
+  lhs: OverlayRevealIdentity | null,
+  rhs: OverlayRevealIdentity | null
+): boolean {
+  return lhs?.filePath === rhs?.filePath && lhs?.content === rhs?.content;
+}
+
 function isSelectionInsideRange(selection: SelectedLineRange, range: HunkLineRange): boolean {
   const start = Math.min(selection.startIndex, selection.endIndex);
   const end = Math.max(selection.startIndex, selection.endIndex);
@@ -374,6 +386,29 @@ function isLineInsideSelection(lineIndex: number, selection: SelectedLineRange):
   const start = Math.min(selection.startIndex, selection.endIndex);
   const end = Math.max(selection.startIndex, selection.endIndex);
   return lineIndex >= start && lineIndex <= end;
+}
+
+export function shouldPreserveImmersiveContextCursor(input: {
+  cursorLineIndex: number | null;
+  previousRange: { startIndex: number; endIndex: number } | null;
+  previousHunkId: string | null;
+  currentHunkId: string | null;
+  previousOverlayContent: string | null;
+  currentOverlayContent: string;
+}): boolean {
+  if (
+    input.cursorLineIndex === null ||
+    !input.previousRange ||
+    input.previousHunkId !== input.currentHunkId ||
+    input.previousOverlayContent !== input.currentOverlayContent
+  ) {
+    return false;
+  }
+
+  return (
+    input.cursorLineIndex < input.previousRange.startIndex ||
+    input.cursorLineIndex > input.previousRange.endIndex
+  );
 }
 
 /** Resolve the hunk that contains a given overlay line index using the lineHunkIds lookup. */
@@ -533,8 +568,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     return null;
   }, [selectedHunkId, hunks, allHunks, fileList, isReviewComplete]);
 
-  const activeFilePathRef = useRef<string | null>(null);
-  activeFilePathRef.current = activeFilePath;
+  const activeOverlayRevealIdentityRef = useRef<OverlayRevealIdentity | null>(null);
 
   const selectedHunkFromAll = useMemo(
     () => (selectedHunkId ? (allHunks.find((item) => item.id === selectedHunkId) ?? null) : null),
@@ -606,10 +640,11 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     [activeFilePath, currentFileHunks, props.workspaceId]
   );
 
-  // Hold diff reveal during file switches until the initial scroll is complete.
-  // Track the last revealed file instead of setting "pending" from an effect so
-  // a newly selected file is hidden on its first render rather than for one frame after paint.
-  const [revealedFilePath, setRevealedFilePath] = useState<string | null>(null);
+  // Hold diff reveal until geometry-changing overlay swaps have been positioned.
+  // This covers file switches and same-file hydration from compact hunk overlays
+  // into full-file context, so the browser never paints an unanchored diff tree.
+  const [revealedOverlayIdentity, setRevealedOverlayIdentity] =
+    useState<OverlayRevealIdentity | null>(null);
   const revealAnimationFrameRef = useRef<number | null>(null);
 
   // Load full file context only when it is cheap. The hunk overlay remains visible
@@ -737,6 +772,32 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     return buildOverlayFromHunks(currentFileHunks);
   }, [resolvedActiveFileContent, currentFileHunks]);
 
+  const activeOverlayRevealIdentity = useMemo<OverlayRevealIdentity | null>(
+    () => (activeFilePath ? { filePath: activeFilePath, content: overlayData.content } : null),
+    [activeFilePath, overlayData.content]
+  );
+  const isActiveOverlayRevealPending =
+    activeOverlayRevealIdentity !== null &&
+    !isSameOverlayRevealIdentity(revealedOverlayIdentity, activeOverlayRevealIdentity);
+  const isActiveFileRevealPending =
+    activeFilePath !== null && revealedOverlayIdentity?.filePath !== activeFilePath;
+  const revealLoadingLabel = isActiveFileRevealPending ? "Loading file..." : "Preparing diff...";
+
+  const scheduleOverlayReveal = useCallback((overlayIdentity: OverlayRevealIdentity) => {
+    if (revealAnimationFrameRef.current !== null) {
+      cancelAnimationFrame(revealAnimationFrameRef.current);
+    }
+
+    revealAnimationFrameRef.current = window.requestAnimationFrame(() => {
+      setRevealedOverlayIdentity((currentRevealedIdentity) =>
+        isSameOverlayRevealIdentity(activeOverlayRevealIdentityRef.current, overlayIdentity)
+          ? overlayIdentity
+          : currentRevealedIdentity
+      );
+      revealAnimationFrameRef.current = null;
+    });
+  }, []);
+
   const selectedHunkRange = useMemo(
     () => (selectedHunk ? (overlayData.hunkLineRanges.get(selectedHunk.id) ?? null) : null),
     [selectedHunk, overlayData]
@@ -818,6 +879,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
   const [activeLineIndex, setActiveLineIndex] = useState<number | null>(null);
   const [selectedLineRange, setSelectedLineRange] = useState<SelectedLineRange | null>(null);
   const [scrollNonce, setScrollNonce] = useState(0);
+  const [minimapRedrawNonce, setMinimapRedrawNonce] = useState(0);
   const [boundaryToast, setBoundaryToast] = useState<string | null>(null);
 
   // Which panel has keyboard focus while in immersive mode.
@@ -834,18 +896,20 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
       revealAnimationFrameRef.current = null;
     }
 
-    if (!activeFilePath) {
-      setRevealedFilePath(null);
+    activeOverlayRevealIdentityRef.current = activeOverlayRevealIdentity;
+
+    if (!activeOverlayRevealIdentity) {
+      setRevealedOverlayIdentity(null);
       return;
     }
 
-    if (revealedFilePath !== activeFilePath) {
-      // Keep the splash visible for each file switch until we have scrolled to the target hunk.
-      // The pending state is derived during render so cross-file hunk iteration never flashes
-      // the new file at the old scroll position before this effect runs.
+    if (isActiveOverlayRevealPending) {
+      // The pending state is derived during render, not set from an effect, so
+      // file switches and same-file hydration swaps are hidden on their first
+      // paint until the scroll effect reveals the positioned overlay.
       hunkJumpRef.current = true;
     }
-  }, [activeFilePath, revealedFilePath]);
+  }, [activeOverlayRevealIdentity, isActiveOverlayRevealPending]);
 
   useEffect(() => {
     return () => {
@@ -857,21 +921,20 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
 
   const selectedHunkRevealTargetLineIndex =
     selectedHunkRange?.firstModifiedIndex ?? selectedHunkRange?.startIndex ?? null;
-  const isActiveFileRevealPending = activeFilePath !== null && revealedFilePath !== activeFilePath;
-  const revealTargetLineIndex = isActiveFileRevealPending
+  const revealTargetLineIndex = isActiveOverlayRevealPending
     ? selectedHunkRevealTargetLineIndex
     : (activeLineIndex ?? selectedHunkRevealTargetLineIndex);
   const hasResolvedSelectedHunkForReveal =
     selectedHunkId !== null && currentFileHunks.some((hunk) => hunk.id === selectedHunkId);
 
   useLayoutEffect(() => {
-    if (!isActiveFileRevealPending) {
+    if (!isActiveOverlayRevealPending || !activeOverlayRevealIdentity) {
       return;
     }
 
     // Fail open so the UI cannot get stuck if a file has no hunks.
     if (currentFileHunks.length === 0) {
-      setRevealedFilePath(activeFilePath);
+      setRevealedOverlayIdentity(activeOverlayRevealIdentity);
       return;
     }
 
@@ -882,13 +945,13 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
 
     // Fail open once selection is stable if we still cannot resolve a reveal target.
     if (selectedHunkRevealTargetLineIndex === null) {
-      setRevealedFilePath(activeFilePath);
+      setRevealedOverlayIdentity(activeOverlayRevealIdentity);
     }
   }, [
-    activeFilePath,
+    activeOverlayRevealIdentity,
     currentFileHunks.length,
     hasResolvedSelectedHunkForReveal,
-    isActiveFileRevealPending,
+    isActiveOverlayRevealPending,
     selectedHunkRevealTargetLineIndex,
   ]);
 
@@ -955,6 +1018,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
   const onSelectHunkRef = useRef(onSelectHunk);
   const allHunksRef = useRef(allHunks);
   const hunkLineRangesRef = useRef(overlayData.hunkLineRanges);
+  const previousOverlayContentRef = useRef<string | null>(null);
   const previousSelectedHunkIdRef = useRef<string | null>(null);
   const previousSelectedHunkRangeRef = useRef<HunkLineRange | null>(null);
   const skipScrollUntilCursorSettlesRef = useRef(false);
@@ -996,9 +1060,11 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
   // iteration does not flash the previous cursor/selection for a frame.
   useLayoutEffect(() => {
     const resolvedSelectedHunkId = selectedHunk?.id ?? null;
+    const previousOverlayContent = previousOverlayContentRef.current;
     const previousSelectedHunkId = previousSelectedHunkIdRef.current;
     const previousSelectedHunkRange = previousSelectedHunkRangeRef.current;
 
+    previousOverlayContentRef.current = overlayData.content;
     previousSelectedHunkIdRef.current = resolvedSelectedHunkId;
     previousSelectedHunkRangeRef.current = selectedHunkRange;
 
@@ -1026,23 +1092,20 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     }
 
     const cursorLineIndex = activeLineIndexRef.current;
-    const cursorWasInPreviousSelectedHunk = Boolean(
-      cursorLineIndex !== null &&
-      previousSelectedHunkRange &&
-      cursorLineIndex >= previousSelectedHunkRange.startIndex &&
-      cursorLineIndex <= previousSelectedHunkRange.endIndex
-    );
-    const shouldPreserveContextCursor = Boolean(
-      cursorLineIndex !== null &&
-      previousSelectedHunkRange &&
-      previousSelectedHunkId === resolvedSelectedHunkId &&
-      !cursorWasInPreviousSelectedHunk
-    );
+    const shouldPreserveContextCursor = shouldPreserveImmersiveContextCursor({
+      cursorLineIndex,
+      previousRange: previousSelectedHunkRange,
+      previousHunkId: previousSelectedHunkId,
+      currentHunkId: resolvedSelectedHunkId,
+      previousOverlayContent,
+      currentOverlayContent: overlayData.content,
+    });
 
     if (shouldPreserveContextCursor) {
-      // Full-file context can arrive after the user has intentionally moved the
-      // cursor onto an unchanged/context row. Preserve that cursor instead of
-      // snapping back to the selected hunk just because overlay indices changed.
+      // Preserve intentional context-row cursor movement only while the rendered
+      // overlay is unchanged. Compact hunk overlays and hydrated full-file
+      // overlays use different numeric indices, so carrying a context-row index
+      // across that geometry swap would reveal at the wrong row.
       skipScrollUntilCursorSettlesRef.current = false;
       return;
     }
@@ -1083,6 +1146,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
       return null;
     });
   }, [
+    overlayData.content,
     selectedHunk?.id,
     selectedHunkRange?.startIndex,
     selectedHunkRange?.endIndex,
@@ -1724,25 +1788,27 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
         activeLineIndex <= selectedHunkRange.endIndex
       );
       hunkJumpRef.current = Boolean(
-        isActiveFileRevealPending ||
+        isActiveOverlayRevealPending ||
         skipScrollUntilCursorSettlesRef.current ||
         activeLineIndex === null ||
         !selectedHunkRange ||
         cursorIsInsideSelectedHunk
       );
-      if (!isActiveFileRevealPending) {
+      if (!isActiveOverlayRevealPending) {
         return;
       }
     }
 
-    const lineIndexForScroll = isActiveFileRevealPending ? revealTargetLineIndex : activeLineIndex;
+    const lineIndexForScroll = isActiveOverlayRevealPending
+      ? revealTargetLineIndex
+      : activeLineIndex;
     if (lineIndexForScroll === null) {
       return;
     }
 
     if (skipScrollUntilCursorSettlesRef.current) {
       const cursorHasSettled =
-        isActiveFileRevealPending ||
+        isActiveOverlayRevealPending ||
         activeLineIndex === null ||
         !selectedHunkRange ||
         (activeLineIndex >= selectedHunkRange.startIndex &&
@@ -1764,21 +1830,11 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
       `[data-line-index="${lineIndexForScroll}"]`
     );
     if (!lineElement) {
-      if (!isActiveFileRevealPending || !activeFilePath || contentChanged) {
+      if (!isActiveOverlayRevealPending || !activeOverlayRevealIdentity || contentChanged) {
         return;
       }
 
-      if (revealAnimationFrameRef.current !== null) {
-        cancelAnimationFrame(revealAnimationFrameRef.current);
-      }
-
-      const revealFilePath = activeFilePath;
-      revealAnimationFrameRef.current = window.requestAnimationFrame(() => {
-        setRevealedFilePath((currentRevealedFilePath) =>
-          activeFilePathRef.current === revealFilePath ? revealFilePath : currentRevealedFilePath
-        );
-        revealAnimationFrameRef.current = null;
-      });
+      scheduleOverlayReveal(activeOverlayRevealIdentity);
       return;
     }
 
@@ -1795,27 +1851,24 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     hunkJumpRef.current = false;
     lineElement.scrollIntoView({ behavior: "auto", block });
 
-    if (!isActiveFileRevealPending || !activeFilePath) {
+    if (!isActiveOverlayRevealPending || !activeOverlayRevealIdentity) {
       return;
     }
 
-    if (revealAnimationFrameRef.current !== null) {
-      cancelAnimationFrame(revealAnimationFrameRef.current);
+    if (!isTouchExperience) {
+      // The minimap redraws from scrollTop; after a hidden hydration/file-swap
+      // scroll, force one hidden redraw before the shared reveal gate opens.
+      setMinimapRedrawNonce((previousNonce) => previousNonce + 1);
     }
-
-    const revealFilePath = activeFilePath;
-    revealAnimationFrameRef.current = window.requestAnimationFrame(() => {
-      setRevealedFilePath((currentRevealedFilePath) =>
-        activeFilePathRef.current === revealFilePath ? revealFilePath : currentRevealedFilePath
-      );
-      revealAnimationFrameRef.current = null;
-    });
+    scheduleOverlayReveal(activeOverlayRevealIdentity);
   }, [
-    activeFilePath,
     activeLineIndex,
-    isActiveFileRevealPending,
+    activeOverlayRevealIdentity,
+    isActiveOverlayRevealPending,
+    isTouchExperience,
     overlayData.content,
     revealTargetLineIndex,
+    scheduleOverlayReveal,
     scrollNonce,
     selectedHunkRange,
   ]);
@@ -2155,12 +2208,18 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
               </div>
             ) : (
               <div className="bg-dark relative overflow-hidden">
-                {isActiveFileRevealPending && (
-                  <div className="bg-dark/95 text-muted absolute inset-0 z-10 flex items-center justify-center text-sm">
-                    <span className="animate-pulse">Loading file...</span>
+                {isActiveOverlayRevealPending && (
+                  <div
+                    className="bg-dark/95 text-muted absolute inset-0 z-10 flex items-center justify-center text-sm"
+                    data-testid="immersive-diff-reveal-overlay"
+                  >
+                    <span className="animate-pulse">{revealLoadingLabel}</span>
                   </div>
                 )}
-                <div className={cn(isActiveFileRevealPending && "invisible")}>
+                <div
+                  className={cn(isActiveOverlayRevealPending && "invisible")}
+                  data-testid="immersive-diff-reveal-stage"
+                >
                   <SelectableDiffRenderer
                     content={overlayData.content}
                     filePath={activeFilePath ?? currentFileHunks[0].filePath}
@@ -2186,13 +2245,19 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
         </div>
 
         {!isReviewComplete && !isTouchExperience && (
-          <ImmersiveMinimap
-            content={overlayData.content}
-            scrollContainerRef={scrollContainerRef}
-            activeLineIndex={activeLineIndex}
-            onSelectLineIndex={handleMinimapSelectLine}
-            commentLineIndices={commentLineIndices}
-          />
+          <div
+            className={cn("h-full self-stretch", isActiveOverlayRevealPending && "invisible")}
+            data-testid="immersive-minimap-reveal-stage"
+          >
+            <ImmersiveMinimap
+              content={overlayData.content}
+              scrollContainerRef={scrollContainerRef}
+              activeLineIndex={activeLineIndex}
+              redrawNonce={minimapRedrawNonce}
+              onSelectLineIndex={handleMinimapSelectLine}
+              commentLineIndices={commentLineIndices}
+            />
+          </div>
         )}
 
         {!isReviewComplete && !isTouchExperience && (


### PR DESCRIPTION
## Summary

Prevents Immersive Review from painting unpositioned diff geometry while compact hunk overlays hydrate into full-file context. The reveal gate now keys on the rendered overlay identity instead of file path alone, so file switches, hydration swaps, and filtered hunk-content swaps stay hidden until the selected hunk has been scrolled into place.

## Background

PR #3442 fixed hunk-to-hunk scroll thrash and assisted-banner reflow, but the remaining flash came from a different invariant: while full-file content loaded asynchronously, the visible diff could swap from a compact hunk-only overlay to a much taller full-file overlay. That changes row indices and minimap geometry even when the selected hunk is unchanged.

## Implementation

- Gate reveal by `{ filePath, overlayData.content }`, not just file path.
- Keep both the diff stage and minimap stage invisible while a geometry-changing overlay is pending.
- During pending reveal, scroll using the selected hunk's resolved line in the new overlay, ignoring stale compact-overlay cursor indices.
- Only preserve an out-of-hunk context cursor when the overlay content is unchanged; compact → full-file hydration remaps the cursor back into the selected hunk.
- Force a hidden minimap redraw after parent scroll positioning and before the reveal RAF opens the stage, so the thumb/active marker read the final scrollTop.
- Move minimap canvas redraw to a layout effect because canvas pixels are visible layout state.
- Pin the `ai` package to the already-locked 6.0.175 release so lockfile-free static checks avoid the currently broken 6.0.196 tarball.

## Validation

- `bun test src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx src/browser/features/RightSidebar/CodeReview/ImmersiveMinimap.test.tsx`
- `make typecheck`
- `make lint`
- `git diff --check`
- `make static-check`
- `make static-check-full`
- Re-ran targeted tests + `make static-check` after rebasing onto latest `origin/main`.
- Read-only review sub-agent audited the final design and found no remaining plausible hydration/minimap flash path.

## Risks

Moderate, localized to Immersive Review diff/minimap reveal behavior. The main user-visible tradeoff is that geometry swaps may briefly show the existing loading scrim instead of painting an unanchored diff. The code intentionally keeps normal same-file hunk navigation out of the reveal gate unless the overlay content changes.

The `ai` dependency pin narrows the package range to the version already resolved in `bun.lock`; this is intended to make lockfile-free package checks deterministic while npm metadata advertises a latest tarball that returns 404.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$71.64`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=71.64 -->
