### PR TITLE
🤖 ci: update Daytona pagination for Terminal-Bench

### DIFF
--- a/.github/workflows/terminal-bench.yml
+++ b/.github/workflows/terminal-bench.yml
@@ -176,7 +176,8 @@ jobs:
           if [ -z "$DAYTONA_API_KEY" ]; then
             exit 0
           fi
-          pip install --quiet daytona
+          pip install --quiet 'daytona>=0.180.0,<2'
+          python3 -c 'import importlib.metadata as m; print("daytona", m.version("daytona"))'
           python3 scripts/daytona_sandbox_cleanup.py snapshot > /tmp/daytona-pre-existing.txt
           echo "Snapshot $(wc -l < /tmp/daytona-pre-existing.txt) pre-existing sandbox(es)"
 
@@ -224,7 +225,8 @@ jobs:
             echo "No pre-run snapshot found, skipping cleanup to avoid deleting unrelated sandboxes"
             exit 0
           fi
-          pip install --quiet daytona
+          pip install --quiet 'daytona>=0.180.0,<2'
+          python3 -c 'import importlib.metadata as m; print("daytona", m.version("daytona"))'
           python3 scripts/daytona_sandbox_cleanup.py cleanup --pre-existing-file /tmp/daytona-pre-existing.txt
 
       - name: Print results summary

--- a/Makefile
+++ b/Makefile
@@ -576,26 +576,30 @@ chromatic: node_modules/.installed ## Run Chromatic for visual regression testin
 	@bun x chromatic --exit-zero-on-changes
 
 ## Benchmarks
-benchmark-terminal: ## Run Terminal-Bench 2.0 with Harbor (use TB_HARBOR_PACKAGE/TB_DATASET/TB_CONCURRENCY/TB_TIMEOUT/TB_ENV/TB_MODEL/TB_ARGS to customize)
+benchmark-terminal: ## Run Terminal-Bench 2.0 with Harbor (use TB_HARBOR_PACKAGE/TB_HARBOR_DAYTONA_PACKAGE/TB_DATASET/TB_CONCURRENCY/TB_TIMEOUT/TB_ENV/TB_MODEL/TB_ARGS to customize)
 	@# Pin Harbor with the Daytona extra so scheduled ingestion does not break on future CLI or adapter API drift.
+	@# Force the Daytona SDK to the cursor-pagination API while keeping Harbor stable.
 	@# Harbor removed --task-name, so keep smoke-test task filtering on the current dataset filter flag.
 	@HARBOR_PACKAGE=$${TB_HARBOR_PACKAGE:-harbor[daytona]==0.6.4}; \
+	HARBOR_DAYTONA_PACKAGE=$${TB_HARBOR_DAYTONA_PACKAGE:-daytona>=0.180.0,<2}; \
 	TB_DATASET=$${TB_DATASET:-terminal-bench@2.0}; \
 	TB_TIMEOUT=$${TB_TIMEOUT:-1800}; \
 	TB_CONCURRENCY=$${TB_CONCURRENCY:-4}; \
 	ENV_FLAG=$${TB_ENV:+--env $$TB_ENV}; \
 	MODEL_FLAG=$${TB_MODEL:+-m $$TB_MODEL}; \
 	TASK_NAME_FLAGS=""; \
-	if [ -n "$$TB_TASK_NAMES" ]; then \
+	if [ -n "$${TB_TASK_NAMES:-}" ]; then \
 		for task_name in $$TB_TASK_NAMES; do \
 			TASK_NAME_FLAGS="$$TASK_NAME_FLAGS --include-task-name $$task_name"; \
 		done; \
 	fi; \
 	echo "Using Harbor package: $$HARBOR_PACKAGE"; \
+	echo "Using Daytona package constraint: $$HARBOR_DAYTONA_PACKAGE"; \
 	echo "Using timeout: $$TB_TIMEOUT seconds"; \
 	echo "Running Terminal-Bench with dataset $$TB_DATASET (concurrency: $$TB_CONCURRENCY)"; \
 	export MUX_TIMEOUT_MS=$$((TB_TIMEOUT * 1000)); \
-	uvx --from "$$HARBOR_PACKAGE" harbor run \
+	uvx --from "$$HARBOR_PACKAGE" --with "$$HARBOR_DAYTONA_PACKAGE" python -c 'import importlib.metadata as m; print("Resolved Harbor package:", m.version("harbor")); print("Resolved Daytona package:", m.version("daytona"))'; \
+	uvx --from "$$HARBOR_PACKAGE" --with "$$HARBOR_DAYTONA_PACKAGE" harbor run \
 		--dataset "$$TB_DATASET" \
 		--agent-import-path benchmarks.terminal_bench.mux_agent:MuxAgent \
 		--agent-kwarg timeout=$$TB_TIMEOUT \
@@ -603,7 +607,7 @@ benchmark-terminal: ## Run Terminal-Bench 2.0 with Harbor (use TB_HARBOR_PACKAGE
 		$$ENV_FLAG \
 		$$MODEL_FLAG \
 		$$TASK_NAME_FLAGS \
-		$${TB_ARGS}
+		$${TB_ARGS:-}
 
 ## Clean
 clean: ## Clean build artifacts

--- a/scripts/daytona_sandbox_cleanup.py
+++ b/scripts/daytona_sandbox_cleanup.py
@@ -5,9 +5,9 @@ import argparse
 from pathlib import Path
 from typing import Any
 
-from daytona import Daytona
+from daytona import Daytona, ListSandboxesQuery
 
-ACTIVE_STATES = {"started", "creating", "starting"}
+DELETABLE_STATES = {"stopped", "error", "build_failed", "archived", "destroyed"}
 
 
 def sandbox_id(sandbox: Any) -> str:
@@ -17,19 +17,15 @@ def sandbox_id(sandbox: Any) -> str:
 
 
 def list_all_sandboxes(daytona: Daytona):
-    # Daytona SDK versions have returned either a generator/list or a paginated
-    # object. Handle both so workflow snapshot/cleanup stays best-effort.
-    page = 1
-    while True:
-        result = daytona.list(page=page)
-        if not hasattr(result, "items"):
-            yield from result
-            return
-        yield from result.items
-        total_pages = getattr(result, "total_pages", None) or 1
-        if page >= total_pages:
-            break
-        page += 1
+    # Daytona SDK 0.180.0 moved sandbox listing to cursor pagination.
+    # Iterate through the SDK so workflow snapshot/cleanup sees every sandbox.
+    yield from daytona.list(ListSandboxesQuery(limit=100))
+
+
+def normalized_state(sandbox: Any) -> str:
+    # Daytona returns SandboxState enums; use values so active sandboxes are never deleted.
+    state = getattr(sandbox, "state", "")
+    return str(getattr(state, "value", state)).lower()
 
 
 def snapshot(daytona: Daytona) -> None:
@@ -44,19 +40,15 @@ def cleanup(daytona: Daytona, pre_existing_file: Path) -> None:
         for sandbox in list_all_sandboxes(daytona)
         if sandbox_id(sandbox) not in pre_existing
     ]
-    to_delete = [
-        sandbox
-        for sandbox in candidates
-        if str(getattr(sandbox, "state", "")).lower() not in ACTIVE_STATES
-    ]
+    to_delete = [sandbox for sandbox in candidates if normalized_state(sandbox) in DELETABLE_STATES]
     skipped = len(candidates) - len(to_delete)
     if skipped:
-        print(f"Skipping {skipped} still-active sandbox(es)")
+        print(f"Skipping {skipped} active or transitional sandbox(es)")
     if not to_delete:
-        print("No stopped sandboxes to clean up")
+        print("No stopped or errored sandboxes to clean up")
         return
 
-    print(f"Cleaning up {len(to_delete)} stopped sandbox(es) from this run...")
+    print(f"Cleaning up {len(to_delete)} stopped or errored sandbox(es) from this run...")
     for sandbox in to_delete:
         sandbox_identifier = sandbox_id(sandbox)
         state = getattr(sandbox, "state", "unknown")


### PR DESCRIPTION
> Mux is opening this PR on behalf of Mike.

## Summary

Updates the Terminal-Bench Daytona cleanup path to require the cursor-pagination Daytona SDK and keeps Harbor pinned while forcing its Daytona dependency to a safe version.

## Background

Daytona removed offset pagination for sandbox listing. The nightly Terminal-Bench workflow must stop depending on `daytona.list(page=...)` before that API path disappears.

## Implementation

- Installs `daytona>=0.180.0,<2` in the snapshot and cleanup workflow steps and logs the resolved version.
- Updates `scripts/daytona_sandbox_cleanup.py` to call `daytona.list(ListSandboxesQuery(limit=100))`.
- Narrows cleanup deletion to explicit finished states so active or transitional sandboxes are skipped.
- Adds `TB_HARBOR_DAYTONA_PACKAGE`, defaulting to `daytona>=0.180.0,<2`, and passes it to Harbor via `uvx --with` while keeping `harbor[daytona]==0.6.4` as the default runner.

## Validation

- `make static-check`
- Targeted Daytona helper smoke test with `daytona==0.180.0`
- Harbor resolver check for `harbor[daytona]==0.6.4` with `daytona>=0.180.0,<2`, resolved Harbor `0.6.4` and Daytona `0.183.0`
- `rg 'daytona\.list\(page=|/api/sandbox/paginated|total_pages|pip install --quiet daytona' .github Makefile scripts`

## Risks

This is scoped to benchmark CI plumbing. I could not run a live Daytona list or cleanup call locally because `DAYTONA_API_KEY` is not available in the workspace.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$7.99`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=7.99 -->
