### PR TITLE
🤖 fix: retry failed workflows from checkpoint

### DIFF
--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -1213,6 +1213,547 @@ describe("WorkflowRunToolCall", () => {
     expect(view.getByText("resumed")).toBeTruthy();
   });
 
+  test("shows retry from checkpoint for recoverable failed workflows", async () => {
+    let retried = false;
+    let getRunCalls = 0;
+    const failedRun = {
+      id: "wfr_retry",
+      workspaceId: "workspace-1",
+      definition: {
+        name: "deep-research",
+        description: "Deep research",
+        scope: "built-in" as const,
+        executable: true,
+      },
+      definitionSource: "export default function workflow() { return null; }",
+      definitionHash: "sha256:test",
+      args: { topic: "workflow cards" },
+      status: "failed" as const,
+      createdAt: "2026-05-29T00:00:00.000Z",
+      updatedAt: "2026-05-29T00:00:01.000Z",
+      events: [
+        {
+          sequence: 1,
+          type: "error" as const,
+          at: "2026-05-29T00:00:00.000Z",
+          message: "Execution interrupted",
+        },
+        {
+          sequence: 2,
+          type: "status" as const,
+          at: "2026-05-29T00:00:01.000Z",
+          status: "failed" as const,
+        },
+      ],
+      steps: [],
+    };
+    const completedRun = {
+      ...failedRun,
+      status: "completed" as const,
+      updatedAt: "2026-05-29T00:00:02.000Z",
+      events: [
+        ...failedRun.events,
+        {
+          sequence: 3,
+          type: "status" as const,
+          at: "2026-05-29T00:00:01.500Z",
+          status: "running" as const,
+        },
+        {
+          sequence: 4,
+          type: "result" as const,
+          at: "2026-05-29T00:00:02.000Z",
+          result: { reportMarkdown: "retried" },
+        },
+        {
+          sequence: 5,
+          type: "status" as const,
+          at: "2026-05-29T00:00:02.000Z",
+          status: "completed" as const,
+        },
+      ],
+    };
+    const api = {
+      workflows: {
+        retryFromCheckpoint: async () => {
+          retried = true;
+          return {
+            runId: "wfr_retry",
+            status: "running" as const,
+            result: null,
+          };
+        },
+        getRun: async () => {
+          getRunCalls += 1;
+          return getRunCalls === 1 ? failedRun : completedRun;
+        },
+      },
+    };
+
+    const view = render(
+      <APIHarness client={api}>
+        <ThemeProvider forcedTheme="dark">
+          <TooltipProvider>
+            <WorkflowRunToolCall
+              args={{
+                name: "deep-research",
+                args: { topic: "workflow cards" },
+                run_in_background: true,
+              }}
+              status="completed"
+              result={{ status: "failed", runId: "wfr_retry", result: null, run: failedRun }}
+            />
+          </TooltipProvider>
+        </ThemeProvider>
+      </APIHarness>
+    );
+
+    fireEvent.click(view.getByRole("button", { name: "Retry from checkpoint" }));
+
+    await waitFor(() => expect(retried).toBe(true));
+    await waitFor(() => expect(view.getAllByText("completed").length).toBeGreaterThan(0));
+    fireEvent.click(getWorkflowHeader(view));
+    expect(view.getByText("retried")).toBeTruthy();
+  });
+
+  test("stops retry polling after an accepted retry reaches terminal failure", async () => {
+    const originalSetInterval = globalThis.window.setInterval;
+    const originalClearInterval = globalThis.window.clearInterval;
+    let clearIntervalCalls = 0;
+    const intervalRef: { handler: (() => void) | null } = { handler: null };
+    const intervalId = 123;
+    globalThis.window.setInterval = ((handler: () => void) => {
+      intervalRef.handler = handler;
+      return intervalId;
+    }) as unknown as typeof window.setInterval;
+    globalThis.window.clearInterval = ((id?: number) => {
+      if (id === intervalId) {
+        clearIntervalCalls += 1;
+      }
+    }) as unknown as typeof window.clearInterval;
+    try {
+      let getRunCalls = 0;
+      const failedRun = {
+        id: "wfr_retry_terminal_failed",
+        workspaceId: "workspace-1",
+        definition: {
+          name: "deep-research",
+          description: "Deep research",
+          scope: "built-in" as const,
+          executable: true,
+        },
+        definitionSource: "export default function workflow() { return null; }",
+        definitionHash: "sha256:test",
+        args: {},
+        status: "failed" as const,
+        createdAt: "2026-05-29T00:00:00.000Z",
+        updatedAt: "2026-05-29T00:00:01.000Z",
+        events: [
+          {
+            sequence: 1,
+            type: "error" as const,
+            at: "2026-05-29T00:00:00.000Z",
+            message: "Execution interrupted",
+          },
+          {
+            sequence: 2,
+            type: "status" as const,
+            at: "2026-05-29T00:00:01.000Z",
+            status: "failed" as const,
+          },
+        ],
+        steps: [],
+      };
+      const terminalFailedRun = {
+        ...failedRun,
+        updatedAt: "2026-05-29T00:00:04.000Z",
+        events: [
+          ...failedRun.events,
+          {
+            sequence: 3,
+            type: "status" as const,
+            at: "2026-05-29T00:00:02.000Z",
+            status: "running" as const,
+          },
+          {
+            sequence: 4,
+            type: "error" as const,
+            at: "2026-05-29T00:00:03.000Z",
+            message: "retry failed",
+          },
+          {
+            sequence: 5,
+            type: "status" as const,
+            at: "2026-05-29T00:00:04.000Z",
+            status: "failed" as const,
+          },
+        ],
+      };
+      const api = {
+        workflows: {
+          retryFromCheckpoint: async () => ({
+            runId: failedRun.id,
+            status: "running" as const,
+            result: null,
+          }),
+          getRun: async () => {
+            getRunCalls += 1;
+            return terminalFailedRun;
+          },
+        },
+      };
+
+      const view = render(
+        <APIHarness client={api}>
+          <ThemeProvider forcedTheme="dark">
+            <TooltipProvider>
+              <WorkflowRunToolCall
+                args={{ name: "deep-research", args: {}, run_in_background: true }}
+                status="completed"
+                result={{ status: "failed", runId: failedRun.id, result: null, run: failedRun }}
+              />
+            </TooltipProvider>
+          </ThemeProvider>
+        </APIHarness>
+      );
+
+      fireEvent.click(view.getByRole("button", { name: "Retry from checkpoint" }));
+
+      await waitFor(() => expect(getRunCalls).toBe(1));
+      const pendingIntervalHandler = intervalRef.handler;
+      if (clearIntervalCalls === 0 && pendingIntervalHandler != null) {
+        pendingIntervalHandler();
+      }
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(getRunCalls).toBe(1);
+    } finally {
+      globalThis.window.setInterval = originalSetInterval;
+      globalThis.window.clearInterval = originalClearInterval;
+    }
+  });
+
+  test("stops resume polling after an accepted resume reaches terminal failure", async () => {
+    const originalSetInterval = globalThis.window.setInterval;
+    const originalClearInterval = globalThis.window.clearInterval;
+    let clearIntervalCalls = 0;
+    const intervalRef: { handler: (() => void) | null } = { handler: null };
+    const intervalId = 456;
+    globalThis.window.setInterval = ((handler: () => void) => {
+      intervalRef.handler = handler;
+      return intervalId;
+    }) as unknown as typeof window.setInterval;
+    globalThis.window.clearInterval = ((id?: number) => {
+      if (id === intervalId) {
+        clearIntervalCalls += 1;
+      }
+    }) as unknown as typeof window.clearInterval;
+    try {
+      let getRunCalls = 0;
+      const interruptedRun = {
+        id: "wfr_resume_terminal_failed",
+        workspaceId: "workspace-1",
+        definition: {
+          name: "deep-research",
+          description: "Deep research",
+          scope: "built-in" as const,
+          executable: true,
+        },
+        definitionSource: "export default function workflow() { return null; }",
+        definitionHash: "sha256:test",
+        args: {},
+        status: "interrupted" as const,
+        createdAt: "2026-05-29T00:00:00.000Z",
+        updatedAt: "2026-05-29T00:00:01.000Z",
+        events: [
+          {
+            sequence: 1,
+            type: "status" as const,
+            at: "2026-05-29T00:00:01.000Z",
+            status: "interrupted" as const,
+          },
+        ],
+        steps: [],
+      };
+      const terminalFailedRun = {
+        ...interruptedRun,
+        status: "failed" as const,
+        updatedAt: "2026-05-29T00:00:04.000Z",
+        events: [
+          ...interruptedRun.events,
+          {
+            sequence: 2,
+            type: "status" as const,
+            at: "2026-05-29T00:00:02.000Z",
+            status: "running" as const,
+          },
+          {
+            sequence: 3,
+            type: "error" as const,
+            at: "2026-05-29T00:00:03.000Z",
+            message: "resume failed",
+          },
+          {
+            sequence: 4,
+            type: "status" as const,
+            at: "2026-05-29T00:00:04.000Z",
+            status: "failed" as const,
+          },
+        ],
+      };
+      const api = {
+        workflows: {
+          resume: async () => ({
+            runId: interruptedRun.id,
+            status: "running" as const,
+            result: null,
+          }),
+          getRun: async () => {
+            getRunCalls += 1;
+            return terminalFailedRun;
+          },
+        },
+      };
+
+      const view = render(
+        <APIHarness client={api}>
+          <ThemeProvider forcedTheme="dark">
+            <TooltipProvider>
+              <WorkflowRunToolCall
+                args={{ name: "deep-research", args: {}, run_in_background: true }}
+                status="completed"
+                result={{
+                  status: "interrupted",
+                  runId: interruptedRun.id,
+                  result: null,
+                  run: interruptedRun,
+                }}
+              />
+            </TooltipProvider>
+          </ThemeProvider>
+        </APIHarness>
+      );
+
+      fireEvent.click(view.getByRole("button", { name: "Resume workflow" }));
+
+      await waitFor(() => expect(getRunCalls).toBe(1));
+      const pendingIntervalHandler = intervalRef.handler;
+      if (clearIntervalCalls === 0 && pendingIntervalHandler != null) {
+        pendingIntervalHandler();
+      }
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(getRunCalls).toBe(1);
+    } finally {
+      globalThis.window.setInterval = originalSetInterval;
+      globalThis.window.clearInterval = originalClearInterval;
+    }
+  });
+
+  test("ignores duplicate checkpoint retry clicks while a retry request is in flight", async () => {
+    let releaseRetry!: () => void;
+    const retryStarted = new Promise<void>((resolve) => {
+      releaseRetry = resolve;
+    });
+    let retryCalls = 0;
+    const failedRun = {
+      id: "wfr_retry_duplicate",
+      workspaceId: "workspace-1",
+      definition: {
+        name: "deep-research",
+        description: "Deep research",
+        scope: "built-in" as const,
+        executable: true,
+      },
+      definitionSource: "export default function workflow() { return null; }",
+      definitionHash: "sha256:test",
+      args: {},
+      status: "failed" as const,
+      createdAt: "2026-05-29T00:00:00.000Z",
+      updatedAt: "2026-05-29T00:00:01.000Z",
+      events: [
+        {
+          sequence: 1,
+          type: "error" as const,
+          at: "2026-05-29T00:00:00.000Z",
+          message: "Execution interrupted",
+        },
+        {
+          sequence: 2,
+          type: "status" as const,
+          at: "2026-05-29T00:00:01.000Z",
+          status: "failed" as const,
+        },
+      ],
+      steps: [],
+    };
+    const completedRun = {
+      ...failedRun,
+      status: "completed" as const,
+      updatedAt: "2026-05-29T00:00:02.000Z",
+      events: [
+        ...failedRun.events,
+        {
+          sequence: 3,
+          type: "result" as const,
+          at: "2026-05-29T00:00:02.000Z",
+          result: { reportMarkdown: "retried" },
+        },
+        {
+          sequence: 4,
+          type: "status" as const,
+          at: "2026-05-29T00:00:02.000Z",
+          status: "completed" as const,
+        },
+      ],
+    };
+    const api = {
+      workflows: {
+        retryFromCheckpoint: async () => {
+          retryCalls += 1;
+          await retryStarted;
+          return { runId: failedRun.id, status: "running" as const, result: null };
+        },
+        getRun: async () => completedRun,
+      },
+    };
+    const view = render(
+      <APIHarness client={api}>
+        <ThemeProvider forcedTheme="dark">
+          <TooltipProvider>
+            <WorkflowRunToolCall
+              args={{ name: "deep-research", args: {}, run_in_background: true }}
+              status="completed"
+              result={{ status: "failed", runId: failedRun.id, result: null, run: failedRun }}
+            />
+          </TooltipProvider>
+        </ThemeProvider>
+      </APIHarness>
+    );
+
+    const retryButton = view.getByRole("button", { name: "Retry from checkpoint" });
+    fireEvent.click(retryButton);
+    fireEvent.click(retryButton);
+
+    await waitFor(() => expect(retryCalls).toBe(1));
+    releaseRetry();
+    await waitFor(() => expect(view.getAllByText("completed").length).toBeGreaterThan(0));
+  });
+
+  test("does not show retry from checkpoint for non-recoverable failed workflows", () => {
+    const api = { workflows: { retryFromCheckpoint: async () => null } };
+    const view = render(
+      <APIHarness client={api}>
+        <ThemeProvider forcedTheme="dark">
+          <TooltipProvider>
+            <WorkflowRunToolCall
+              args={{ name: "deep-research", args: {}, run_in_background: true }}
+              status="completed"
+              result={{
+                status: "failed",
+                runId: "wfr_no_retry",
+                result: null,
+                run: {
+                  id: "wfr_no_retry",
+                  workspaceId: "workspace-1",
+                  definition: {
+                    name: "deep-research",
+                    description: "Deep research",
+                    scope: "built-in",
+                    executable: true,
+                  },
+                  definitionSource: "export default function workflow() { return null; }",
+                  definitionHash: "sha256:test",
+                  args: {},
+                  status: "failed",
+                  createdAt: "2026-05-29T00:00:00.000Z",
+                  updatedAt: "2026-05-29T00:00:01.000Z",
+                  events: [
+                    {
+                      sequence: 1,
+                      type: "error",
+                      at: "2026-05-29T00:00:00.000Z",
+                      message: "SyntaxError: Unexpected token",
+                    },
+                    {
+                      sequence: 2,
+                      type: "status",
+                      at: "2026-05-29T00:00:01.000Z",
+                      status: "failed",
+                    },
+                  ],
+                  steps: [],
+                },
+              }}
+            />
+          </TooltipProvider>
+        </ThemeProvider>
+      </APIHarness>
+    );
+
+    expect(view.queryByRole("button", { name: "Retry from checkpoint" })).toBeNull();
+  });
+
+  test("does not show retry from checkpoint for unfinished patch checkpoints", () => {
+    const api = { workflows: { retryFromCheckpoint: async () => null } };
+    const view = render(
+      <APIHarness client={api}>
+        <ThemeProvider forcedTheme="dark">
+          <TooltipProvider>
+            <WorkflowRunToolCall
+              args={{ name: "deep-research", args: {}, run_in_background: true }}
+              status="completed"
+              result={{
+                status: "failed",
+                runId: "wfr_patch_no_retry",
+                result: null,
+                run: {
+                  id: "wfr_patch_no_retry",
+                  workspaceId: "workspace-1",
+                  definition: {
+                    name: "deep-research",
+                    description: "Deep research",
+                    scope: "built-in",
+                    executable: true,
+                  },
+                  definitionSource: "export default function workflow() { return null; }",
+                  definitionHash: "sha256:test",
+                  args: {},
+                  status: "failed",
+                  createdAt: "2026-05-29T00:00:00.000Z",
+                  updatedAt: "2026-05-29T00:00:01.000Z",
+                  events: [
+                    {
+                      sequence: 1,
+                      type: "patch",
+                      at: "2026-05-29T00:00:00.000Z",
+                      stepId: "apply-implement",
+                      sourceTaskId: "task_impl",
+                      status: "started",
+                    },
+                    {
+                      sequence: 2,
+                      type: "error",
+                      at: "2026-05-29T00:00:00.500Z",
+                      message: "Execution interrupted",
+                    },
+                    {
+                      sequence: 3,
+                      type: "status",
+                      at: "2026-05-29T00:00:01.000Z",
+                      status: "failed",
+                    },
+                  ],
+                  steps: [],
+                },
+              }}
+            />
+          </TooltipProvider>
+        </ThemeProvider>
+      </APIHarness>
+    );
+
+    expect(view.queryByRole("button", { name: "Retry from checkpoint" })).toBeNull();
+  });
+
   test("clears resume polling when resume fails", async () => {
     let getRunCalls = 0;
     const api = {

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -19,6 +19,7 @@ import type {
   WorkflowRunToolSuccessResult,
 } from "@/common/types/tools";
 import assert from "@/common/utils/assert";
+import { canRetryWorkflowFromCheckpoint } from "@/common/utils/workflowRetryEligibility";
 
 import {
   ToolContainer,
@@ -57,7 +58,21 @@ interface WorkflowRunToolCallProps {
   startedAt?: number;
 }
 
-type WorkflowRunAction = "interrupt" | "resume";
+type WorkflowRunAction = "interrupt" | "resume" | "retryFromCheckpoint";
+
+function shouldKeepWorkflowActionPolling(input: {
+  action: WorkflowRunAction;
+  run: WorkflowRunRecord;
+  baselineSequence: number;
+}): boolean {
+  if (input.run.status === "interrupted") {
+    return true;
+  }
+  if (input.action !== "retryFromCheckpoint" || input.run.status !== "failed") {
+    return false;
+  }
+  return getLatestWorkflowEventSequence(input.run) <= input.baselineSequence;
+}
 
 async function updateWorkflowRunFromAction(input: {
   api: APIClient;
@@ -67,6 +82,7 @@ async function updateWorkflowRunFromAction(input: {
   setActionError: React.Dispatch<React.SetStateAction<string | null>>;
   setRefreshedRun: React.Dispatch<React.SetStateAction<WorkflowRunRecord | null>>;
   setResumingRunId: React.Dispatch<React.SetStateAction<string | null>>;
+  baselineSequence: number;
 }) {
   input.setActionError(null);
   let resumeRequestAccepted = false;
@@ -77,16 +93,30 @@ async function updateWorkflowRunFromAction(input: {
             workspaceId: input.workspaceId,
             runId: input.runId,
           })
-        : await input.api.workflows.resume({
-            workspaceId: input.workspaceId,
-            runId: input.runId,
-          });
-    if (input.action === "resume") {
+        : input.action === "resume"
+          ? await input.api.workflows.resume({
+              workspaceId: input.workspaceId,
+              runId: input.runId,
+            })
+          : await input.api.workflows.retryFromCheckpoint({
+              workspaceId: input.workspaceId,
+              runId: input.runId,
+            });
+    if (input.action === "resume" || input.action === "retryFromCheckpoint") {
       resumeRequestAccepted = true;
       input.setResumingRunId(input.runId);
     }
     if ("id" in nextRun) {
       input.setRefreshedRun((current) => getNewestWorkflowRunSnapshot(current, nextRun));
+      if (
+        !shouldKeepWorkflowActionPolling({
+          action: input.action,
+          run: nextRun,
+          baselineSequence: input.baselineSequence,
+        })
+      ) {
+        input.setResumingRunId(null);
+      }
       return;
     }
     const refreshed = await input.api.workflows.getRun({
@@ -95,9 +125,21 @@ async function updateWorkflowRunFromAction(input: {
     });
     if (refreshed != null) {
       input.setRefreshedRun((current) => getNewestWorkflowRunSnapshot(current, refreshed));
+      if (
+        !shouldKeepWorkflowActionPolling({
+          action: input.action,
+          run: refreshed,
+          baselineSequence: input.baselineSequence,
+        })
+      ) {
+        input.setResumingRunId(null);
+      }
     }
   } catch (error) {
-    if (input.action === "resume" && !resumeRequestAccepted) {
+    if (
+      (input.action === "resume" || input.action === "retryFromCheckpoint") &&
+      !resumeRequestAccepted
+    ) {
       input.setResumingRunId(null);
     }
     input.setActionError(
@@ -525,8 +567,8 @@ function isFreshEnoughForToolCall(run: WorkflowRunRecord, startedAt: number | un
   return createdAt >= startedAt - FOREGROUND_WORKFLOW_DISCOVERY_SKEW_MS;
 }
 
-function getLatestWorkflowEventSequence(run: WorkflowRunRecord): number {
-  return run.events.reduce((maxSequence, event) => Math.max(maxSequence, event.sequence), 0);
+function getLatestWorkflowEventSequence(run: WorkflowRunRecord | null | undefined): number {
+  return run?.events.reduce((maxSequence, event) => Math.max(maxSequence, event.sequence), 0) ?? 0;
 }
 
 function compareWorkflowRunSnapshots(left: WorkflowRunRecord, right: WorkflowRunRecord): number {
@@ -639,6 +681,14 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
   const successResult = isWorkflowRunSuccessResult(result) ? result : null;
   const [refreshedRun, setRefreshedRun] = useState<WorkflowRunRecord | null>(null);
   const [resumingRunId, setResumingRunId] = useState<string | null>(null);
+  const [workflowActionInFlightRunId, setWorkflowActionInFlightRunId] = useState<string | null>(
+    null
+  );
+  const workflowActionInFlightRunIdRef = useRef<string | null>(null);
+  const setWorkflowActionInFlight = (nextRunId: string | null) => {
+    workflowActionInFlightRunIdRef.current = nextRunId;
+    setWorkflowActionInFlightRunId(nextRunId);
+  };
   const baseRun = successResult?.run;
   const selectedRun = selectWorkflowRunSnapshot({
     runId: successResult?.runId,
@@ -648,6 +698,7 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
   const runId = selectedRun.runId;
   const run = selectedRun.run;
   const displayStatus = run?.status ?? successResult?.status ?? status;
+  const displayEventSequence = getLatestWorkflowEventSequence(run);
   const resultValue = successResult?.result ?? getLatestResultEvent(run);
   const reportMarkdown = getReportMarkdown(resultValue);
   const structuredOutput = getStructuredOutput(resultValue);
@@ -680,6 +731,8 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
   const [savingPromotionTarget, setSavingPromotionTarget] =
     useState<WorkflowPromotionTarget | null>(null);
   const savingPromotionTargetRef = useRef<WorkflowPromotionTarget | null>(null);
+  const resumeOrRetryPendingForRun =
+    runId != null && (resumingRunId === runId || workflowActionInFlightRunId === runId);
   const displayDefinition = promotedDefinition ?? run?.definition;
   // A uniquely discovered foreground run is actionable before the blocking tool call returns.
   const discoveredForegroundRunConfirmed =
@@ -700,7 +753,14 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
     runIdentityConfirmed &&
     apiState?.api != null &&
     run?.workspaceId != null &&
-    displayStatus === "interrupted";
+    displayStatus === "interrupted" &&
+    !resumeOrRetryPendingForRun;
+  const canRetryFromCheckpoint =
+    runIdentityConfirmed &&
+    apiState?.api != null &&
+    run?.workspaceId != null &&
+    canRetryWorkflowFromCheckpoint(run) &&
+    !resumeOrRetryPendingForRun;
   const canPromote =
     runIdentityConfirmed &&
     run?.workspaceId != null &&
@@ -717,16 +777,33 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
     if (apiState?.api == null || run?.workspaceId == null || runId == null) {
       return;
     }
-    await updateWorkflowRunFromAction({
-      api: apiState.api,
-      workspaceId: run.workspaceId,
-      runId,
-      action,
-      setActionError,
-      setRefreshedRun,
-      setResumingRunId,
-    });
+    const isResumeOrRetry = action === "resume" || action === "retryFromCheckpoint";
+    if (isResumeOrRetry) {
+      if (workflowActionInFlightRunIdRef.current === runId || resumingRunId === runId) {
+        return;
+      }
+      setWorkflowActionInFlight(runId);
+    }
+    try {
+      await updateWorkflowRunFromAction({
+        api: apiState.api,
+        workspaceId: run.workspaceId,
+        runId,
+        action,
+        setActionError,
+        setRefreshedRun,
+        setResumingRunId,
+        baselineSequence: getLatestWorkflowEventSequence(run),
+      });
+    } finally {
+      if (isResumeOrRetry) {
+        setWorkflowActionInFlight(null);
+      }
+    }
   };
+
+  const updateRunFromActionRef = useRef(updateRunFromAction);
+  updateRunFromActionRef.current = updateRunFromAction;
 
   const saveScratchWorkflow = (location: WorkflowPromotionTarget) => {
     const api = apiState?.api;
@@ -772,10 +849,16 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
   };
 
   useEffect(() => {
-    if (resumingRunId === runId && run?.status !== "interrupted") {
+    // Checkpoint retries briefly keep showing the old failed snapshot until polling observes a
+    // post-retry event sequence, so don't clear that pending marker just because status is failed.
+    if (
+      resumingRunId === runId &&
+      run?.status !== "interrupted" &&
+      !(run?.status === "failed" && canRetryWorkflowFromCheckpoint(run))
+    ) {
       setResumingRunId(null);
     }
-  }, [resumingRunId, run?.status, runId]);
+  }, [resumingRunId, run, runId]);
 
   const saveScratchWorkflowRef = useRef(saveScratchWorkflow);
   saveScratchWorkflowRef.current = saveScratchWorkflow;
@@ -784,23 +867,6 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
     if (registerCommandSource == null || runId == null || run?.workspaceId == null) {
       return;
     }
-
-    const workflowApi = apiState?.api;
-    const workspaceId = run.workspaceId;
-    const runWorkflowAction = async (action: WorkflowRunAction) => {
-      if (workflowApi == null) {
-        return;
-      }
-      await updateWorkflowRunFromAction({
-        api: workflowApi,
-        workspaceId,
-        runId,
-        action,
-        setActionError,
-        setRefreshedRun,
-        setResumingRunId,
-      });
-    };
 
     const unregister = registerCommandSource(() => {
       const subtitle = `${args.name} • ${runId}`;
@@ -812,7 +878,7 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
           subtitle,
           section: "Workflows",
           keywords: ["workflow", "interrupt", "stop", args.name, runId],
-          run: () => runWorkflowAction("interrupt"),
+          run: () => updateRunFromActionRef.current("interrupt"),
         });
       }
       if (canResume) {
@@ -822,7 +888,17 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
           subtitle,
           section: "Workflows",
           keywords: ["workflow", "resume", "continue", args.name, runId],
-          run: () => runWorkflowAction("resume"),
+          run: () => updateRunFromActionRef.current("resume"),
+        });
+      }
+      if (canRetryFromCheckpoint) {
+        actions.push({
+          id: `workflow:${runId}:retry-from-checkpoint`,
+          title: `Retry workflow from checkpoint: ${args.name}`,
+          subtitle,
+          section: "Workflows",
+          keywords: ["workflow", "retry", "resume", "checkpoint", args.name, runId],
+          run: () => updateRunFromActionRef.current("retryFromCheckpoint"),
         });
       }
       if (canPromote) {
@@ -861,8 +937,10 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
     apiState?.api,
     args.name,
     canInterrupt,
+    canRetryFromCheckpoint,
     canPromote,
     canResume,
+    resumeOrRetryPendingForRun,
     registerCommandSource,
     run?.workspaceId,
     runId,
@@ -922,7 +1000,13 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
         });
         if (!ignore && nextRun != null) {
           setRefreshedRun((current) => getNewestWorkflowRunSnapshot(current, nextRun));
-          if (nextRun.status !== "interrupted") {
+          if (
+            !shouldKeepWorkflowActionPolling({
+              action: "retryFromCheckpoint",
+              run: nextRun,
+              baselineSequence: displayEventSequence,
+            })
+          ) {
             setResumingRunId(null);
           }
         }
@@ -939,7 +1023,7 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
       ignore = true;
       window.clearInterval(interval);
     };
-  }, [apiState?.api, displayStatus, resumingRunId, run?.workspaceId, runId]);
+  }, [apiState?.api, displayEventSequence, displayStatus, resumingRunId, run?.workspaceId, runId]);
 
   return (
     <ToolContainer expanded={expanded}>
@@ -982,7 +1066,7 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
             </WorkflowDisclosureSection>
           )}
 
-          {(canInterrupt || canResume || canPromote) && (
+          {(canInterrupt || canResume || canRetryFromCheckpoint || canPromote) && (
             <div className="mb-2 flex flex-wrap gap-2 text-[10px]">
               {canInterrupt && (
                 <button
@@ -1006,6 +1090,18 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
                   }}
                 >
                   Resume workflow
+                </button>
+              )}
+              {canRetryFromCheckpoint && (
+                <button
+                  type="button"
+                  className={WORKFLOW_ACTION_BUTTON_CLASS}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    void updateRunFromAction("retryFromCheckpoint");
+                  }}
+                >
+                  Retry from checkpoint
                 </button>
               )}
               {canPromote && (

--- a/src/browser/utils/workflowRunMessages.test.ts
+++ b/src/browser/utils/workflowRunMessages.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { buildWorkflowResultContextMessage } from "@/common/utils/workflowRunMessages";
 import {
   buildWorkflowRunCardMessage,
   filterWorkflowDisplayOnlyMessages,
@@ -43,6 +44,71 @@ describe("buildWorkflowRunCardMessage", () => {
       input: { name: "deep-research", args: { topic: "reload" }, run_in_background: true },
       output: { status: "completed", runId: "wfr_reload", result: { reportMarkdown: "done" }, run },
     });
+  });
+
+  test("omits stale historical errors from completed retry result context", () => {
+    const run: WorkflowRunRecord = {
+      id: "wfr_retried",
+      workspaceId: "workspace-1",
+      definition: {
+        name: "deep-research",
+        description: "Deep research",
+        scope: "built-in",
+        executable: true,
+      },
+      definitionSource: "export default function workflow() { return null; }",
+      definitionHash: "sha256:test",
+      args: { topic: "retry" },
+      status: "completed",
+      createdAt: "2026-05-29T00:00:00.000Z",
+      updatedAt: "2026-05-29T00:00:04.000Z",
+      events: [
+        {
+          sequence: 1,
+          type: "error",
+          at: "2026-05-29T00:00:00.000Z",
+          message: "Execution interrupted",
+        },
+        {
+          sequence: 2,
+          type: "status",
+          at: "2026-05-29T00:00:01.000Z",
+          status: "failed",
+        },
+        {
+          sequence: 3,
+          type: "status",
+          at: "2026-05-29T00:00:02.000Z",
+          status: "running",
+        },
+        {
+          sequence: 4,
+          type: "result",
+          at: "2026-05-29T00:00:03.000Z",
+          result: { reportMarkdown: "retried successfully" },
+        },
+        {
+          sequence: 5,
+          type: "status",
+          at: "2026-05-29T00:00:04.000Z",
+          status: "completed",
+        },
+      ],
+      steps: [],
+    };
+
+    const message = buildWorkflowResultContextMessage({
+      rawCommand: "/deep-research retry",
+      name: "deep-research",
+      runId: run.id,
+      status: run.status,
+      result: null,
+      run,
+    });
+
+    expect(message).toContain("retried successfully");
+    expect(message).toContain('"status": "completed"');
+    expect(message).not.toContain("Execution interrupted");
   });
 
   test("filters durable workflow UI-only rows while preserving workflow results", () => {

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -1761,6 +1761,14 @@ export const workflows = {
       result: z.unknown(),
     }),
   },
+  retryFromCheckpoint: {
+    input: z.object({ workspaceId: z.string().min(1), runId: WorkflowRunIdSchema }).strict(),
+    output: z.object({
+      runId: WorkflowRunIdSchema,
+      status: WorkflowRunStatusSchema,
+      result: z.unknown(),
+    }),
+  },
   promoteScratchDefinition: {
     input: z
       .object({

--- a/src/common/utils/workflowRetryEligibility.ts
+++ b/src/common/utils/workflowRetryEligibility.ts
@@ -1,0 +1,67 @@
+import type { WorkflowRunEvent, WorkflowRunRecord } from "@/common/types/workflow";
+
+export const WORKFLOW_CHECKPOINT_RETRY_ERROR_MESSAGE = "Execution interrupted";
+
+export interface WorkflowCheckpointRetryEligibility {
+  canRetry: boolean;
+  reason: string | null;
+}
+
+type WorkflowPatchEvent = Extract<WorkflowRunEvent, { type: "patch" }>;
+
+export function getWorkflowCheckpointRetryEligibility(
+  run: WorkflowRunRecord | null | undefined
+): WorkflowCheckpointRetryEligibility {
+  if (run == null) {
+    return { canRetry: false, reason: "Workflow run is not available" };
+  }
+  if (run.status !== "failed") {
+    return { canRetry: false, reason: `Workflow run is not failed: ${run.id}` };
+  }
+  const latestError = run.events.findLast((event) => event.type === "error");
+  if (latestError?.message !== WORKFLOW_CHECKPOINT_RETRY_ERROR_MESSAGE) {
+    return { canRetry: false, reason: "Workflow run cannot be retried from checkpoint" };
+  }
+  const unsafePatchReason = getUnsafePatchRetryReason(run);
+  if (unsafePatchReason != null) {
+    return { canRetry: false, reason: unsafePatchReason };
+  }
+  return { canRetry: true, reason: null };
+}
+
+export function canRetryWorkflowFromCheckpoint(run: WorkflowRunRecord | null | undefined): boolean {
+  return getWorkflowCheckpointRetryEligibility(run).canRetry;
+}
+
+function getUnsafePatchRetryReason(run: WorkflowRunRecord): string | null {
+  const latestPatchEventsByStep = new Map<string, WorkflowPatchEvent>();
+  for (const event of run.events) {
+    if (event.type === "patch") {
+      latestPatchEventsByStep.set(getPatchEventKey(event), event);
+    }
+  }
+
+  for (const event of latestPatchEventsByStep.values()) {
+    if (event.status === "started" || event.status === "failed") {
+      return "Workflow run cannot be retried from checkpoint with unfinished patch steps";
+    }
+    if (!hasCompletedPatchStep(run, event)) {
+      return "Workflow run cannot be retried from checkpoint with incomplete patch step records";
+    }
+  }
+  return null;
+}
+
+function hasCompletedPatchStep(run: WorkflowRunRecord, event: WorkflowPatchEvent): boolean {
+  return run.steps.some(
+    (step) =>
+      step.stepId === event.stepId &&
+      step.taskId === event.sourceTaskId &&
+      step.status === "completed" &&
+      step.result?.structuredOutput != null
+  );
+}
+
+function getPatchEventKey(event: WorkflowPatchEvent): string {
+  return `${event.stepId}\0${event.sourceTaskId}`;
+}

--- a/src/common/utils/workflowRunMessages.ts
+++ b/src/common/utils/workflowRunMessages.ts
@@ -15,8 +15,15 @@ function getWorkflowResultValue(result: unknown, run: WorkflowRunRecord | null):
   return run?.events.findLast((event) => event.type === "result")?.result ?? result;
 }
 
-function getWorkflowError(run: WorkflowRunRecord | null): string | undefined {
-  return run?.events.findLast((event) => event.type === "error")?.message;
+function getWorkflowError(input: {
+  run: WorkflowRunRecord | null;
+  status: string;
+  resultValue: unknown;
+}): string | undefined {
+  if (input.status !== "failed" && input.resultValue != null) {
+    return undefined;
+  }
+  return input.run?.events.findLast((event) => event.type === "error")?.message;
 }
 
 function getWorkflowResultField(value: unknown, field: string): unknown {
@@ -52,6 +59,11 @@ export function buildWorkflowResultContextMessage(input: {
   const resultValue = getWorkflowResultValue(input.result, input.run);
   const reportMarkdown = getWorkflowResultField(resultValue, "reportMarkdown");
   const structuredOutput = getWorkflowResultField(resultValue, "structuredOutput");
+  const workflowError = getWorkflowError({
+    run: input.run,
+    status: input.status,
+    resultValue,
+  });
   const payload = {
     workflow: {
       name: input.name,
@@ -61,7 +73,7 @@ export function buildWorkflowResultContextMessage(input: {
     ...(typeof reportMarkdown === "string" ? { reportMarkdown } : {}),
     ...(structuredOutput !== undefined ? { structuredOutput } : {}),
     ...(resultValue != null ? { result: resultValue } : {}),
-    ...(getWorkflowError(input.run) ? { error: getWorkflowError(input.run) } : {}),
+    ...(workflowError ? { error: workflowError } : {}),
   };
 
   return [

--- a/src/node/orpc/router.test.ts
+++ b/src/node/orpc/router.test.ts
@@ -135,6 +135,9 @@ describe("router workflow routes", () => {
       },
       workspaceService: {
         appendWorkflowRunInvocation: mock(async () => true),
+        isWorkflowInvocationCurrent: mock(async () => false),
+        getWorkflowContinuationSendOptions: mock(() => null),
+        sendMessage: mock(async () => ({ success: true, data: undefined })),
       },
       taskService: {},
       experimentsService: {
@@ -251,6 +254,106 @@ describe("router workflow routes", () => {
       result: null,
     });
     await waitForRouterWorkflowStatus(client, "workspace-1", "wfr_api_resume", "completed");
+  });
+
+  test("retries a recoverable failed workflow through the API", async () => {
+    const runStore = new WorkflowRunStore({ sessionDir: config.getSessionDir("workspace-1") });
+    await runStore.createRun({
+      id: "wfr_api_retry",
+      workspaceId: "workspace-1",
+      definition: { name: "demo", description: "Demo", scope: "built-in", executable: true },
+      definitionSource:
+        "export default function workflow() { return { reportMarkdown: 'retried via api' }; }\n",
+      args: {},
+      now: "2026-05-29T00:00:00.000Z",
+    });
+    await runStore.appendEvent("wfr_api_retry", {
+      sequence: 1,
+      type: "error",
+      at: "2026-05-29T00:00:00.750Z",
+      message: "Execution interrupted",
+    });
+    await runStore.appendStatus("wfr_api_retry", "failed", "2026-05-29T00:00:00.751Z");
+    const client = createRouterClient(router(), { context: createContext({ enabled: true }) });
+
+    await expect(
+      client.workflows.retryFromCheckpoint({ workspaceId: "workspace-1", runId: "wfr_api_retry" })
+    ).resolves.toEqual({
+      runId: "wfr_api_retry",
+      status: "running",
+      result: null,
+    });
+    await waitForRouterWorkflowStatus(client, "workspace-1", "wfr_api_retry", "completed");
+  });
+
+  test("continues current workflow invocations after checkpoint retry completes", async () => {
+    const runStore = new WorkflowRunStore({ sessionDir: config.getSessionDir("workspace-1") });
+    await runStore.createRun({
+      id: "wfr_api_retry_continue",
+      workspaceId: "workspace-1",
+      definition: { name: "demo", description: "Demo", scope: "built-in", executable: true },
+      definitionSource:
+        "export default function workflow() { return { reportMarkdown: 'continued after retry' }; }\n",
+      args: {},
+      now: "2026-05-29T00:00:00.000Z",
+    });
+    await runStore.appendEvent("wfr_api_retry_continue", {
+      sequence: 1,
+      type: "error",
+      at: "2026-05-29T00:00:00.750Z",
+      message: "Execution interrupted",
+    });
+    await runStore.appendStatus("wfr_api_retry_continue", "failed", "2026-05-29T00:00:00.751Z");
+    const context = createContext({ enabled: true });
+    const workspaceService = context.workspaceService as unknown as {
+      isWorkflowInvocationCurrent: ReturnType<typeof mock>;
+      getWorkflowContinuationSendOptions: ReturnType<typeof mock>;
+      sendMessage: ReturnType<typeof mock>;
+    };
+    workspaceService.isWorkflowInvocationCurrent = mock(async () => true);
+    workspaceService.getWorkflowContinuationSendOptions = mock(() => ({
+      model: "test:model",
+      agentId: "exec",
+    }));
+    workspaceService.sendMessage = mock(async () => ({ success: true, data: undefined }));
+    const client = createRouterClient(router(), { context });
+
+    await expect(
+      client.workflows.retryFromCheckpoint({
+        workspaceId: "workspace-1",
+        runId: "wfr_api_retry_continue",
+      })
+    ).resolves.toEqual({
+      runId: "wfr_api_retry_continue",
+      status: "running",
+      result: null,
+    });
+    await waitForRouterCondition(
+      "checkpoint retry continuation",
+      () => workspaceService.sendMessage.mock.calls.length === 1
+    );
+
+    expect(workspaceService.sendMessage.mock.calls[0]?.[0]).toBe("workspace-1");
+    expect(workspaceService.sendMessage.mock.calls[0]?.[1]).toContain("<mux_workflow_result>");
+    expect(workspaceService.sendMessage.mock.calls[0]?.[2]).toMatchObject({
+      model: "test:model",
+      agentId: "exec",
+      skipAiSettingsPersistence: true,
+      muxMetadata: {
+        type: "workflow-result",
+        rawCommand: "workflow_run demo",
+        commandPrefix: "workflow_run",
+        runId: "wfr_api_retry_continue",
+        requestedModel: "test:model",
+      },
+    });
+    expect(workspaceService.sendMessage.mock.calls[0]?.[3]).toMatchObject({
+      skipAutoResumeReset: true,
+      synthetic: true,
+      agentInitiated: true,
+      requireIdle: true,
+      startStreamInBackground: true,
+    });
   });
 
   test("starts a trusted project-local workflow through the API", async () => {

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -24,6 +24,7 @@ import type {
   WorkspaceChatMessage,
   WorkspaceStatsSnapshot,
   FrontendWorkspaceMetadataSchemaType,
+  SendMessageOptions,
 } from "@/common/orpc/types";
 import type { WorkspaceMetadata } from "@/common/types/workspace";
 import type { SshPromptEvent, SshPromptRequest } from "@/common/orpc/schemas/ssh";
@@ -140,6 +141,81 @@ function isWorkspaceBusyIdleOnlySend(error: { type: string; raw?: string }): boo
   return (
     error.type === "unknown" && error.raw?.includes(WORKSPACE_BUSY_IDLE_ONLY_SEND_MESSAGE) === true
   );
+}
+
+async function sendWorkflowRunTerminalContinuation(input: {
+  context: ORPCContext;
+  workspaceId: string;
+  rawCommand: string;
+  name: string;
+  event: WorkflowBackgroundRunTerminalEvent;
+  continuationOptions?: SendMessageOptions;
+}): Promise<void> {
+  const { context, workspaceId, rawCommand, name, event } = input;
+  const { runId, status, result, run } = event;
+  const commandPrefix = rawCommand.split(/\s+/u)[0] ?? name;
+  const workflowResultMessage = buildWorkflowResultContextMessage({
+    rawCommand,
+    name,
+    runId,
+    status,
+    result,
+    run,
+  });
+  let continuationOptions = input.continuationOptions ?? null;
+
+  for (;;) {
+    const invocationCurrent = await context.workspaceService.isWorkflowInvocationCurrent(
+      workspaceId,
+      runId
+    );
+    if (!invocationCurrent) {
+      log.debug("Skipping superseded workflow continuation", { workspaceId, runId });
+      return;
+    }
+
+    continuationOptions ??=
+      context.workspaceService.getWorkflowContinuationSendOptions(workspaceId);
+    if (continuationOptions == null) {
+      log.warn("Skipping workflow continuation without send options", { workspaceId, runId });
+      return;
+    }
+
+    const sendResult = await context.workspaceService.sendMessage(
+      workspaceId,
+      workflowResultMessage,
+      {
+        ...continuationOptions,
+        skipAiSettingsPersistence: true,
+        muxMetadata: {
+          type: WORKFLOW_RESULT_METADATA_TYPE,
+          rawCommand,
+          commandPrefix,
+          runId,
+          requestedModel: continuationOptions.model,
+        },
+      },
+      {
+        skipAutoResumeReset: true,
+        synthetic: true,
+        agentInitiated: true,
+        requireIdle: true,
+        startStreamInBackground: true,
+      }
+    );
+    if (sendResult.success) {
+      return;
+    }
+    if (!isWorkspaceBusyIdleOnlySend(sendResult.error)) {
+      log.warn("Failed to continue workflow after completion", {
+        workspaceId,
+        runId,
+        error: sendResult.error,
+      });
+      return;
+    }
+    await waitForWorkflowContinuationRetry();
+  }
 }
 
 function waitForWorkflowContinuationRetry(): Promise<void> {
@@ -1776,6 +1852,32 @@ export const router = (authToken?: string) => {
             projectTrusted,
           });
         }),
+      // Retry actions arrive from a fresh oRPC request, so rebuild the terminal continuation
+      // callback here instead of relying on the original WorkflowService instance still existing.
+      retryFromCheckpoint: t
+        .input(schemas.workflows.retryFromCheckpoint.input)
+        .output(schemas.workflows.retryFromCheckpoint.output)
+        .handler(async ({ context, input }) => {
+          const { service, projectTrusted } = await resolveWorkflowContext(
+            context,
+            input.workspaceId,
+            {
+              onBackgroundRunTerminal: (event) =>
+                sendWorkflowRunTerminalContinuation({
+                  context,
+                  workspaceId: input.workspaceId,
+                  rawCommand: `workflow_run ${event.run.definition.name}`,
+                  name: event.run.definition.name,
+                  event,
+                }),
+            }
+          );
+          return service.retryRunFromCheckpointInBackground({
+            workspaceId: input.workspaceId,
+            runId: input.runId,
+            projectTrusted,
+          });
+        }),
       promoteScratchDefinition: t
         .input(schemas.workflows.promoteScratchDefinition.input)
         .output(schemas.workflows.promoteScratchDefinition.output)
@@ -1825,74 +1927,24 @@ export const router = (authToken?: string) => {
           const continuationOptions = input.continuationOptions;
           const onBackgroundRunTerminal =
             rawCommandForContinuation != null && continuationOptions != null
-              ? async ({ runId, status, result, run }: WorkflowBackgroundRunTerminalEvent) => {
+              ? async (event: WorkflowBackgroundRunTerminalEvent) => {
                   const persistedInvocation =
                     invocationMessagePersisted === true ? true : await invocationPersistence;
                   if (persistedInvocation !== true) {
                     log.warn("Skipping slash workflow continuation without persisted invocation", {
                       workspaceId: input.workspaceId,
-                      runId,
+                      runId: event.runId,
                     });
                     return;
                   }
-                  const commandPrefix = rawCommandForContinuation.split(/\s+/u)[0] ?? input.name;
-                  const workflowResultMessage = buildWorkflowResultContextMessage({
+                  await sendWorkflowRunTerminalContinuation({
+                    context,
+                    workspaceId: input.workspaceId,
                     rawCommand: rawCommandForContinuation,
                     name: input.name,
-                    runId,
-                    status,
-                    result,
-                    run,
+                    event,
+                    continuationOptions,
                   });
-                  for (;;) {
-                    const invocationCurrent =
-                      await context.workspaceService.isWorkflowInvocationCurrent(
-                        input.workspaceId,
-                        runId
-                      );
-                    if (!invocationCurrent) {
-                      log.debug("Skipping superseded slash workflow continuation", {
-                        workspaceId: input.workspaceId,
-                        runId,
-                      });
-                      return;
-                    }
-
-                    const sendResult = await context.workspaceService.sendMessage(
-                      input.workspaceId,
-                      workflowResultMessage,
-                      {
-                        ...continuationOptions,
-                        skipAiSettingsPersistence: true,
-                        muxMetadata: {
-                          type: WORKFLOW_RESULT_METADATA_TYPE,
-                          rawCommand: rawCommandForContinuation,
-                          commandPrefix,
-                          runId,
-                          requestedModel: continuationOptions.model,
-                        },
-                      },
-                      {
-                        skipAutoResumeReset: true,
-                        synthetic: true,
-                        agentInitiated: true,
-                        requireIdle: true,
-                        startStreamInBackground: true,
-                      }
-                    );
-                    if (sendResult.success) {
-                      return;
-                    }
-                    if (!isWorkspaceBusyIdleOnlySend(sendResult.error)) {
-                      log.warn("Failed to continue slash workflow after completion", {
-                        workspaceId: input.workspaceId,
-                        runId,
-                        error: sendResult.error,
-                      });
-                      return;
-                    }
-                    await waitForWorkflowContinuationRetry();
-                  }
                 }
               : undefined;
           const { service, projectTrusted } = await resolveWorkflowContext(

--- a/src/node/services/workflows/WorkflowRunStore.test.ts
+++ b/src/node/services/workflows/WorkflowRunStore.test.ts
@@ -226,6 +226,23 @@ describe("WorkflowRunStore", () => {
     await expect(store.getRun("wfr_123")).resolves.toMatchObject({ status: "completed" });
   });
 
+  test("requires explicit checkpoint retry permission to reopen failed runs", async () => {
+    using tmp = new DisposableTempDir("workflow-runs");
+    const store = await createStore(tmp.path);
+
+    await store.appendStatus("wfr_123", "running", "2026-05-29T00:00:01.000Z");
+    await store.appendStatus("wfr_123", "failed", "2026-05-29T00:00:02.000Z");
+
+    await expect(
+      store.appendStatus("wfr_123", "running", "2026-05-29T00:00:03.000Z")
+    ).rejects.toThrow(/Cannot transition/);
+    await expect(
+      store.appendStatus("wfr_123", "running", "2026-05-29T00:00:04.000Z", {
+        allowFailedCheckpointRetry: true,
+      })
+    ).resolves.toMatchObject({ status: "running" });
+  });
+
   test("reuses completed steps by stable step id and input hash", async () => {
     using tmp = new DisposableTempDir("workflow-runs");
     const store = await createStore(tmp.path);

--- a/src/node/services/workflows/WorkflowRunStore.ts
+++ b/src/node/services/workflows/WorkflowRunStore.ts
@@ -45,6 +45,8 @@ export interface AppendWorkflowRunEventOptions {
    * interrupt.
    */
   allowInterruptedResume?: boolean;
+  /** Only explicit failed-run checkpoint retry may reopen a failed run. */
+  allowFailedCheckpointRetry?: boolean;
   /** Fence a journal/step mutation so only the current lease owner can write it. */
   expectedLeaseOwnerId?: string;
 }
@@ -452,13 +454,18 @@ export class WorkflowRunStore {
       parsedEvent.type === "status" &&
       options.allowInterruptedResume === true &&
       parsedEvent.status === "running";
+    const isFailedCheckpointRetryEvent =
+      parsedEvent.type === "status" &&
+      options.allowFailedCheckpointRetry === true &&
+      run.status === "failed" &&
+      parsedEvent.status === "running";
     const isRepeatedInterruptedStatus =
       parsedEvent.type === "status" && parsedEvent.status === "interrupted";
     if (run.status === "interrupted" && !isInterruptedResumeEvent && !isRepeatedInterruptedStatus) {
       throw new Error(`Workflow run interrupted: ${runId}`);
     }
     if (parsedEvent.type === "status") {
-      if (isTerminalRunStatus(run.status)) {
+      if (isTerminalRunStatus(run.status) && !isFailedCheckpointRetryEvent) {
         throw new Error(
           `Cannot transition workflow run from ${run.status} to ${parsedEvent.status}`
         );

--- a/src/node/services/workflows/WorkflowRunner.test.ts
+++ b/src/node/services/workflows/WorkflowRunner.test.ts
@@ -433,6 +433,48 @@ describe("WorkflowRunner", () => {
     expect(taskCalls).toBe(1);
   });
 
+  test("requires explicit checkpoint retry permission to restart failed runs", async () => {
+    using tmp = new DisposableTempDir("workflow-runner");
+    const store = await createRunStore(tmp.path);
+    const spec = { id: "summarize-topic", prompt: "Summarize durable workflows" };
+    await store.recordStepStarted("wfr_123", {
+      stepId: spec.id,
+      inputHash: hashWorkflowStepInput(spec.id, spec),
+      taskId: "task_existing",
+      startedAt: "2026-05-29T00:00:00.500Z",
+    });
+    await store.appendEvent("wfr_123", {
+      sequence: 1,
+      type: "error",
+      at: "2026-05-29T00:00:00.750Z",
+      message: "Execution interrupted",
+    });
+    await store.appendStatus("wfr_123", "failed", "2026-05-29T00:00:00.751Z");
+
+    let runAgentCalls = 0;
+    const waitedFor: string[] = [];
+    const runner = createRunner(store, {
+      async runAgent() {
+        runAgentCalls += 1;
+        return { taskId: "task_duplicate", reportMarkdown: "duplicate" };
+      },
+      async waitForAgentTask(taskId) {
+        waitedFor.push(taskId);
+        return { taskId, reportMarkdown: "summary" };
+      },
+    });
+
+    await expect(runner.run("wfr_123")).rejects.toThrow(/failed/);
+    await expect(runner.run("wfr_123", { allowRetryFromFailedCheckpoint: true })).resolves.toEqual({
+      reportMarkdown: "Final: summary",
+    });
+    const run = await store.getRun("wfr_123");
+
+    expect(run.status).toBe("completed");
+    expect(waitedFor).toEqual(["task_existing"]);
+    expect(runAgentCalls).toBe(0);
+  });
+
   test("aborts without terminal writes after losing its lease", async () => {
     using tmp = new DisposableTempDir("workflow-runner");
     const store = await createRunStore(tmp.path);

--- a/src/node/services/workflows/WorkflowRunner.ts
+++ b/src/node/services/workflows/WorkflowRunner.ts
@@ -121,6 +121,7 @@ export interface WorkflowRunnerRunOptions {
   abortSignal?: AbortSignal;
   backgroundOnMessageQueued?: boolean;
   allowResumeFromInterrupted?: boolean;
+  allowRetryFromFailedCheckpoint?: boolean;
 }
 
 interface WorkflowRunnerLeaseGuard {
@@ -316,8 +317,12 @@ export class WorkflowRunner {
         }
       }
       const resumingInterruptedRun = run.status === "interrupted";
+      const retryingFailedRun = run.status === "failed";
       if (resumingInterruptedRun && options?.allowResumeFromInterrupted !== true) {
         throw new Error(`Workflow run interrupted: ${runId}`);
+      }
+      if (retryingFailedRun && options?.allowRetryFromFailedCheckpoint !== true) {
+        throw new Error(`Workflow run failed: ${runId}`);
       }
       const ignoreStartedTaskIds = resumingInterruptedRun;
       let backgrounded: Promise<void> | null = null;
@@ -341,7 +346,10 @@ export class WorkflowRunner {
           at: this.clock.nowIso(),
           status: "running",
         },
-        { allowInterruptedResume: resumingInterruptedRun }
+        {
+          allowInterruptedResume: resumingInterruptedRun,
+          allowFailedCheckpointRetry: retryingFailedRun,
+        }
       );
 
       let runtime: IJSRuntime | undefined;

--- a/src/node/services/workflows/WorkflowService.test.ts
+++ b/src/node/services/workflows/WorkflowService.test.ts
@@ -779,6 +779,239 @@ export default function workflow({ args, agent }) {
     expect(backgroundFlags).toEqual([true, false]);
   });
 
+  test("retries recoverable failed workflows from their checkpoint in the background", async () => {
+    using tmp = new DisposableTempDir("workflow-service");
+    const runStore = new WorkflowRunStore({ sessionDir: tmp.path });
+    await runStore.createRun({
+      id: "wfr_retry_checkpoint",
+      workspaceId: "workspace-1",
+      definition: {
+        name: "deep-research",
+        description: "Deep research",
+        scope: "built-in",
+        executable: true,
+      },
+      definitionSource:
+        "export default function workflow({ agent }) { const child = agent({ id: 'summarize-topic', prompt: 'Summarize durable workflows' }); return { reportMarkdown: 'Final: ' + child.reportMarkdown }; }\n",
+      args: {},
+      now: "2026-05-29T00:00:00.000Z",
+    });
+    const spec = { id: "summarize-topic", prompt: "Summarize durable workflows" };
+    await runStore.recordStepStarted("wfr_retry_checkpoint", {
+      stepId: spec.id,
+      inputHash: hashWorkflowStepInput(spec.id, spec),
+      taskId: "task_existing",
+      startedAt: "2026-05-29T00:00:00.500Z",
+    });
+    await runStore.appendEvent("wfr_retry_checkpoint", {
+      sequence: 1,
+      type: "error",
+      at: "2026-05-29T00:00:00.750Z",
+      message: "Execution interrupted",
+    });
+    await runStore.appendStatus("wfr_retry_checkpoint", "failed", "2026-05-29T00:00:00.751Z");
+
+    let releaseExistingTask!: () => void;
+    const existingTaskReleased = new Promise<void>((resolve) => {
+      releaseExistingTask = resolve;
+    });
+    const waitedFor: string[] = [];
+    const service = new WorkflowService({
+      definitionStore: new WorkflowDefinitionStore({
+        projectRoot: path.join(tmp.path, "project"),
+        globalRoot: path.join(tmp.path, "global"),
+        builtIns: [],
+      }),
+      runStore,
+      runtimeFactory: new QuickJSRuntimeFactory(),
+      taskAdapter: {
+        async runAgent() {
+          throw new Error("retry should harvest existing task before spawning replacement");
+        },
+        async waitForAgentTask(taskId) {
+          waitedFor.push(taskId);
+          await existingTaskReleased;
+          return { taskId, reportMarkdown: "summary" };
+        },
+      },
+      runnerId: "runner-a",
+      clock: {
+        nowIso: () => "2026-05-29T00:00:01.000Z",
+        nowMs: () => 1_000,
+      },
+    });
+
+    await expect(
+      service.retryRunFromCheckpointInBackground({
+        workspaceId: "workspace-1",
+        runId: "wfr_retry_checkpoint",
+        projectTrusted: true,
+      })
+    ).resolves.toEqual({ runId: "wfr_retry_checkpoint", status: "running", result: null });
+    await waitForWorkflowStatus(runStore, "wfr_retry_checkpoint", "running");
+
+    releaseExistingTask();
+    await waitForWorkflowStatus(runStore, "wfr_retry_checkpoint", "completed");
+    expect(waitedFor).toEqual(["task_existing"]);
+  });
+
+  test("retries failed workflows with completed patch checkpoints without reapplying", async () => {
+    using tmp = new DisposableTempDir("workflow-service");
+    const runStore = new WorkflowRunStore({ sessionDir: tmp.path });
+    await runStore.createRun({
+      id: "wfr_retry_completed_patch",
+      workspaceId: "workspace-1",
+      definition: {
+        name: "patch-demo",
+        description: "Patch demo",
+        scope: "built-in",
+        executable: true,
+      },
+      definitionSource:
+        "export default function workflow({ agent, applyPatch }) { const child = agent({ id: 'implement', prompt: 'Implement change' }); const patch = applyPatch({ id: 'apply-implement', source: child, target: 'parent' }); return { reportMarkdown: 'Patch ' + patch.status }; }\n",
+      args: {},
+      now: "2026-05-29T00:00:00.000Z",
+    });
+    const agentSpec = { id: "implement", prompt: "Implement change" };
+    await runStore.recordStepCompleted("wfr_retry_completed_patch", {
+      stepId: agentSpec.id,
+      inputHash: hashWorkflowStepInput(agentSpec.id, agentSpec),
+      taskId: "task_impl",
+      result: { taskId: "task_impl", reportMarkdown: "implemented" },
+      startedAt: "2026-05-29T00:00:00.100Z",
+      completedAt: "2026-05-29T00:00:00.200Z",
+    });
+    const patchSpec = {
+      id: "apply-implement",
+      sourceTaskId: "task_impl",
+      target: "parent" as const,
+      threeWay: true,
+      force: false,
+    };
+    const patchResult = { success: true, status: "applied" as const, taskId: "task_impl" };
+    await runStore.recordStepCompleted("wfr_retry_completed_patch", {
+      stepId: patchSpec.id,
+      inputHash: hashWorkflowStepInput(patchSpec.id, patchSpec),
+      taskId: "task_impl",
+      result: {
+        reportMarkdown: "Patch applied from task task_impl.",
+        structuredOutput: patchResult,
+      },
+      startedAt: "2026-05-29T00:00:00.300Z",
+      completedAt: "2026-05-29T00:00:00.400Z",
+    });
+    await runStore.appendEvent("wfr_retry_completed_patch", {
+      sequence: 1,
+      type: "patch",
+      at: "2026-05-29T00:00:00.300Z",
+      stepId: patchSpec.id,
+      sourceTaskId: "task_impl",
+      status: "started",
+    });
+    await runStore.appendEvent("wfr_retry_completed_patch", {
+      sequence: 2,
+      type: "patch",
+      at: "2026-05-29T00:00:00.400Z",
+      stepId: patchSpec.id,
+      sourceTaskId: "task_impl",
+      status: "applied",
+      details: patchResult,
+    });
+    await runStore.appendEvent("wfr_retry_completed_patch", {
+      sequence: 3,
+      type: "error",
+      at: "2026-05-29T00:00:00.750Z",
+      message: "Execution interrupted",
+    });
+    await runStore.appendStatus("wfr_retry_completed_patch", "failed", "2026-05-29T00:00:00.751Z");
+    let applyPatchCalls = 0;
+    let runAgentCalls = 0;
+    const service = new WorkflowService({
+      definitionStore: new WorkflowDefinitionStore({
+        projectRoot: path.join(tmp.path, "project"),
+        globalRoot: path.join(tmp.path, "global"),
+        builtIns: [],
+      }),
+      runStore,
+      runtimeFactory: new QuickJSRuntimeFactory(),
+      taskAdapter: {
+        async runAgent() {
+          runAgentCalls += 1;
+          throw new Error("completed agent checkpoint should replay");
+        },
+        async applyPatch() {
+          applyPatchCalls += 1;
+          throw new Error("completed patch checkpoint should replay");
+        },
+      },
+      runnerId: "runner-a",
+      clock: {
+        nowIso: () => "2026-05-29T00:00:01.000Z",
+        nowMs: () => 1_000,
+      },
+    });
+
+    await expect(
+      service.retryRunFromCheckpointInBackground({
+        workspaceId: "workspace-1",
+        runId: "wfr_retry_completed_patch",
+        projectTrusted: true,
+      })
+    ).resolves.toEqual({ runId: "wfr_retry_completed_patch", status: "running", result: null });
+    await waitForWorkflowStatus(runStore, "wfr_retry_completed_patch", "completed");
+    await expect(runStore.getRun("wfr_retry_completed_patch")).resolves.toMatchObject({
+      status: "completed",
+    });
+    expect(runAgentCalls).toBe(0);
+    expect(applyPatchCalls).toBe(0);
+  });
+
+  test("rejects checkpoint retry for non-recoverable failed workflows", async () => {
+    using tmp = new DisposableTempDir("workflow-service");
+    const runStore = new WorkflowRunStore({ sessionDir: tmp.path });
+    await runStore.createRun({
+      id: "wfr_retry_rejected",
+      workspaceId: "workspace-1",
+      definition: { name: "demo", description: "Demo", scope: "built-in", executable: true },
+      definitionSource: "export default function workflow() { return null; }\n",
+      args: {},
+      now: "2026-05-29T00:00:00.000Z",
+    });
+    await runStore.appendEvent("wfr_retry_rejected", {
+      sequence: 1,
+      type: "error",
+      at: "2026-05-29T00:00:00.750Z",
+      message: "SyntaxError: Unexpected token",
+    });
+    await runStore.appendStatus("wfr_retry_rejected", "failed", "2026-05-29T00:00:00.751Z");
+    const service = new WorkflowService({
+      definitionStore: new WorkflowDefinitionStore({
+        projectRoot: path.join(tmp.path, "project"),
+        globalRoot: path.join(tmp.path, "global"),
+        builtIns: [],
+      }),
+      runStore,
+      runtimeFactory: new QuickJSRuntimeFactory(),
+      taskAdapter: {
+        async runAgent() {
+          throw new Error("non-recoverable retry must not run");
+        },
+      },
+      runnerId: "runner-a",
+    });
+
+    await expect(
+      service.retryRunFromCheckpointInBackground({
+        workspaceId: "workspace-1",
+        runId: "wfr_retry_rejected",
+        projectTrusted: true,
+      })
+    ).rejects.toThrow(/cannot be retried from checkpoint/);
+    await expect(runStore.getRun("wfr_retry_rejected")).resolves.toMatchObject({
+      status: "failed",
+    });
+  });
+
   test("does not mark resume running before the runner acquires the lease", async () => {
     using tmp = new DisposableTempDir("workflow-service");
     const runStore = new WorkflowRunStore({ sessionDir: tmp.path });

--- a/src/node/services/workflows/WorkflowService.ts
+++ b/src/node/services/workflows/WorkflowService.ts
@@ -8,6 +8,7 @@ import type {
 } from "@/common/types/workflow";
 import assert from "@/common/utils/assert";
 import { getErrorMessage } from "@/common/utils/errors";
+import { getWorkflowCheckpointRetryEligibility } from "@/common/utils/workflowRetryEligibility";
 import type { IJSRuntimeFactory } from "@/node/services/ptc/runtime";
 import type { WorkflowActionRegistry } from "./WorkflowActionRegistry";
 import { WorkflowActionRunner } from "./WorkflowActionRunner";
@@ -246,6 +247,21 @@ export class WorkflowService {
     );
     await (this.taskAdapterFactory?.(input.runId) ?? this.requireTaskAdapter()).interruptRun?.();
     return interrupted;
+  }
+
+  async retryRunFromCheckpointInBackground(input: {
+    workspaceId: string;
+    runId: string;
+    projectTrusted: boolean;
+  }): Promise<StartNamedWorkflowResult> {
+    const run = await this.requireRunForWorkspace(input);
+    assertRunCanResumeWithCurrentTrust(run, input.projectTrusted);
+    assertWorkflowRunCanRetryFromCheckpoint(run);
+    await this.runInBackground(input.runId, "Background workflow checkpoint retry failed:", {
+      allowRetryFromFailedCheckpoint: true,
+      projectTrusted: input.projectTrusted,
+    });
+    return { runId: input.runId, status: "running", result: null };
   }
 
   async resumeRunInBackground(input: {
@@ -551,7 +567,10 @@ export class WorkflowService {
   private runInBackground(
     runId: string,
     failureMessage: string,
-    runnerOptions: Pick<WorkflowRunnerRunOptions, "allowResumeFromInterrupted"> & {
+    runnerOptions: Pick<
+      WorkflowRunnerRunOptions,
+      "allowResumeFromInterrupted" | "allowRetryFromFailedCheckpoint"
+    > & {
       projectTrusted: boolean;
     }
   ): Promise<void> {
@@ -694,6 +713,13 @@ function canResumeRunWithCurrentTrust(run: WorkflowRunRecord, projectTrusted: bo
 function assertRunCanResumeWithCurrentTrust(run: WorkflowRunRecord, projectTrusted: boolean): void {
   if (!canResumeRunWithCurrentTrust(run, projectTrusted)) {
     throw new Error("Project trust is required to resume project-local or scratch workflow runs");
+  }
+}
+
+function assertWorkflowRunCanRetryFromCheckpoint(run: WorkflowRunRecord): void {
+  const eligibility = getWorkflowCheckpointRetryEligibility(run);
+  if (!eligibility.canRetry) {
+    throw new Error(eligibility.reason ?? "Workflow run cannot be retried from checkpoint");
   }
 }
 

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -7801,6 +7801,10 @@ export class WorkspaceService extends EventEmitter {
     };
   }
 
+  getWorkflowContinuationSendOptions(workspaceId: string): SendMessageOptions | null {
+    return this.getGoalContinuationKickoffSendOptions(workspaceId);
+  }
+
   getGoalContinuationKickoffSendOptions(workspaceId: string): SendMessageOptions | null {
     assert(
       workspaceId.trim().length > 0,


### PR DESCRIPTION
## Summary

Adds an explicit **Retry from checkpoint** path for recoverable failed workflow runs. The backend reopens failed runs only through guarded checkpoint-retry options, reuses completed work, harvests already-started child tasks, and rejects non-recoverable or unsafe checkpoints. The UI exposes a conservative retry action and avoids stale polling/duplicate-action races.

## Background

This addresses failed workflow conductors that ended with recoverable infrastructure-style `Execution interrupted` errors even though child reports/checkpoints existed. Previously, humans had no safe UI action to continue those failed runs from checkpoint.

## Implementation

- Added `workflows.retryFromCheckpoint` oRPC schema/router wiring.
- Added shared checkpoint retry eligibility for backend and UI, including patch checkpoint safety.
- Added explicit failed-run reopening gates in `WorkflowRunStore` and `WorkflowRunner`.
- Preserved interrupted-run resume semantics while making failed checkpoint retry harvest started child tasks.
- Fixed successful retry continuation context so stale historical errors do not poison completed results.
- Hardened workflow-card retry/resume polling against terminal failures and duplicate clicks.

## Validation

- `bun test src/node/services/workflows/WorkflowRunStore.test.ts src/node/services/workflows/WorkflowRunner.test.ts src/node/services/workflows/WorkflowService.test.ts src/node/orpc/router.test.ts src/browser/features/Tools/WorkflowRunToolCall.test.tsx src/browser/utils/workflowRunMessages.test.ts`
- `make typecheck`
- `make static-check`
- Foreground `deep-review-workflow` run: `wfr_4bb931233187ed1b`; all five verified findings were addressed.
- Dogfood evidence captured earlier under `dogfood-output/workflow-retry/` with screenshots/video for recoverable retry success and non-recoverable no-retry state.

## Risks

Medium risk: this touches workflow run state transitions, retry/replay, and UI polling. Mitigations include explicit service/store/runner gates, shared eligibility checks, targeted regression tests for patch replay, stale result context, terminal-failure polling, and duplicate retry clicks.

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Recover workflow runs from resumable `Execution interrupted` failures

## Context and evidence

- User-visible incident: built-in `deep-research` run `wfr_0a0c158036910038` showed `failed` with final event `ERROR Execution interrupted`; the user had to visit child agents manually to trigger/resume report handling.
- Verified run journal under `~/.mux/sessions/27132cf9a3/workflows/wfr_0a0c158036910038`:
  - run started at `2026-06-04T15:15:53Z`, reached `adversarial-verification`, replayed early phases at `15:41:00Z`, then wrote `error: Execution interrupted` and `status: failed` at `15:46:05Z`.
  - verifier child reports later existed, but `verify-claim-*` workflow steps stayed `started`, so the conductor failed before harvesting/persisting those reports.
- Runtime facts from repo investigation:
  - `Execution interrupted` is formatted by `src/node/services/ptc/quickjsRuntime.ts` when QuickJS/host errors contain `interrupted` and the runtime was not explicitly aborted/timed out.
  - `WorkflowService.resumeCrashedRuns()` only recovers `running`/`backgrounded` runs; `failed`/`completed` are terminal.
  - Existing UI in `src/browser/features/Tools/WorkflowRunToolCall.tsx` already offers **Resume workflow** for `interrupted` only; failed runs have no recovery action.
  - `WorkflowRunner` already has checkpoint replay primitives: completed `(stepId,inputHash)` steps are reused; started child tasks may be waited/restarted depending on mode.

## Goal

Give humans a safe UI action to recover a workflow conductor from a resumable checkpoint when the run failed due to an infrastructure/interruption-style error, without making all failed workflows look resumable or rerunning completed work unnecessarily.

## Recommended approach A: explicit failed-run checkpoint retry (preferred, net product LoC ~220-330)

Add a new explicit backend/UI action, **Retry from checkpoint**, for failed runs that backend marks as recoverable.

### Phase 1 — Backend eligibility and API contract

1. Add a new workflow API route, tentatively `workflows.retryFromCheckpoint({ workspaceId, runId })`, in:
   - `src/common/orpc/schemas/api.ts`
   - `src/node/orpc/router.ts`
   - API client type surface as generated/consumed by existing oRPC setup.
2. Add a backend helper in `src/node/services/workflows/WorkflowService.ts`:
   - `retryRunFromCheckpointInBackground(input)` or similarly named.
   - Require workspace ownership and current project trust exactly like `resumeRunInBackground()`.
   - Allow only `run.status === "failed"` and an explicit recoverability predicate.
3. Add a narrow recoverability predicate near workflow service/store code:
   - Prefer a pure helper such as `getWorkflowRunRetryEligibility(run)` over adding derived fields to persisted `WorkflowRunRecord`.
   - Initial accepted latest-error messages: `Execution interrupted` and possibly exact/known child-wait interruptions such as `Task interrupted` if directly available before QuickJS normalization.
   - Do **not** allow compile errors, schema validation failures, workflow authoring errors, apply-patch failures, or arbitrary provider/model errors in the first pass.
   - Return clear user-facing rejection messages when a failed run is not recoverable.
4. Keep existing `workflows.resume` semantics unchanged for `interrupted` runs.
5. Reuse the same accepted-action return shape as `workflows.resume`: `{ runId, status, result }`, with `status` normally `"running"` when the background retry is accepted.

### Phase 2 — Store/runner transition support

1. Let a recoverable failed run append a `running` status under a deliberate option rather than broadly changing terminal semantics.
   - Prefer an explicit store option such as `allowFailedCheckpointRetry` on the one status append path over making `failed -> running` a general transition everywhere.
   - Keep the option narrow: only latest status `failed`, new status `running`, and only after service-level recoverability validation.
   - Add assertions so only the retry API path can reopen a failed run.
2. In `WorkflowRunner.run()`, make failed retry deliberate:
   - Add an option such as `allowRetryFromFailedCheckpoint`.
   - Reject `failed` unless this option is true and the run passes recoverability validation.
   - Reuse existing completed-step replay.
   - For failed checkpoint retry, **do not** set `ignoreStartedTaskIds`; started child tasks should first be waited/read so already-finished child reports can be harvested. If `Task not found`/`Task interrupted` occurs without a persisted report, fall back to existing restart behavior for that step.
   - Treat `applyPatch` conservatively: completed patch steps may replay, but started/failed patch steps can be side-effectful. In the first pass, either declare failed checkpoint retry eligible only for workflows/paths without pending patch steps (covers `deep-research`) or explicitly reject recoverability when a non-completed patch step exists.
3. Ensure stale terminal failure does not poison later successful run output:
   - Audit `src/common/utils/workflowRunMessages.ts` so old error events are only surfaced as terminal error details when the current run status remains `failed`, or so the latest terminal status/result wins clearly.

### Phase 3 — UI action and command palette

1. Extend `src/browser/features/Tools/WorkflowRunToolCall.tsx`:
   - Show **Retry from checkpoint** conservatively for failed runs whose latest error is `Execution interrupted`, with backend rejection as the source of truth. Avoid adding persisted eligibility fields to `WorkflowRunRecord` unless implementation evidence shows it is necessary.
   - Reuse `WORKFLOW_ACTION_BUTTON_CLASS` and existing action error handling.
   - Add a distinct action type, e.g. `"retryFromCheckpoint"`, rather than overloading `"resume"`.
   - Poll `getRun()` while retry is accepted, mirroring current `resumingRunId` behavior.
2. Register a command-palette action:
   - title: `Retry workflow from checkpoint: <name>`
   - keywords: `workflow`, `retry`, `resume`, `checkpoint`, run id, workflow name.
3. Keep **Resume workflow** label for `interrupted`; use **Retry from checkpoint** for `failed` to avoid suggesting arbitrary failures are safe to continue.

### Phase 4 — Tests

Backend tests:

- `src/node/services/workflows/WorkflowService.test.ts`
  - recoverable failed run is accepted and returns `{ status: "running" }` while background runner continues.
  - non-recoverable failed run is rejected with a clear message.
  - project/scratch workflows still require trust.
  - busy lease leaves failed run unchanged.
- `src/node/services/workflows/WorkflowRunner.test.ts`
  - failed checkpoint retry reuses completed steps.
  - started child task with persisted report is harvested and recorded completed, including the important case where child task status is `interrupted` but its report artifact exists.
  - started child task without usable report restarts only that step.
  - non-completed patch steps are rejected as non-recoverable or otherwise proven safe by an explicit test before support is widened.
  - old failure event does not prevent final `completed` status/result.
- `src/node/services/workflows/WorkflowRunStore.test.ts`
  - `failed -> running` is blocked by default but allowed only with explicit retry option.
- `src/node/orpc/router.test.ts`
  - route wiring calls the service and returns accepted retry result.
- `src/common/orpc/schemas/workflow.test.ts` only if shared transition schema changes; otherwise document why the production override remains narrower.

Frontend tests:

- `src/browser/features/Tools/WorkflowRunToolCall.test.tsx`
  - failed recoverable run shows **Retry from checkpoint** and calls the new API.
  - failed non-recoverable run does not show the button if backend eligibility is modeled in the run shape; otherwise backend rejection appears in `ErrorBox`.
  - interrupted run still shows **Resume workflow** and not **Retry from checkpoint**.
  - command palette includes retry action only when eligible.

## Alternative B: broaden existing `resume` to include selected failed runs (not preferred, net product LoC ~150-240)

- Reuse `workflows.resume` and show **Resume workflow** for failed `Execution interrupted` runs.
- Pros: fewer new API names and slightly less code.
- Cons: blurs user-interrupted resume with failed-run recovery, makes command/UI copy less honest, and increases risk of future callers assuming arbitrary failed runs are resumable.
- Use only if maintainers prefer a smaller API surface over semantic clarity.

## Alternative C: manual-only recovery command/tool, no inline button (not preferred, net product LoC ~120-200)

- Add a command-palette action or developer tool to retry recoverable failed workflows, but no inline failed-card button.
- Pros: lower UI risk.
- Cons: misses the user’s stated need for an obvious human UI recovery button.

## Acceptance criteria

- Failed workflow runs caused by recoverable interruption-style failures expose a human-visible **Retry from checkpoint** action.
- Clicking the action keeps the same `runId` and transitions the card to `running`/`backgrounded`/eventual terminal state.
- Completed workflow steps are not rerun.
- Already-reported child tasks from previously `started` steps are harvested before spawning replacements.
- Non-recoverable failed workflows do not silently retry and show clear feedback if a user attempts recovery.
- Existing `interrupted` workflow resume behavior remains unchanged.
- Crash recovery for `running`/`backgrounded` workflows remains unchanged.
- Old `error` events may remain visible as historical event-log entries, but they do not make a later completed retry look failed in model-visible summaries, card status, or final result payloads.

## Defensive programming notes

- Assert non-empty `workspaceId`, `runId`, and runner option combinations.
- Keep failed-run reopening behind explicit options on both service and store/runner layers.
- Prefer exact recoverability predicates over fuzzy substring matching, except where QuickJS currently only preserves `Execution interrupted`.
- Preserve lease-owner fencing when appending retry status/step mutations.
- Re-check recoverability as close as practical to the `failed -> running` append so a stale UI/action cannot reopen a now-ineligible run.
- Do not swallow backend rejection in the UI; show it in the existing `ErrorBox`.

## Dogfooding and quality gates

Skills read for this plan: `dogfood`, `agent-browser`, and `dev-server-sandbox`.

### Gate 1 — automated validation before dogfood

Run targeted checks after implementation:

```bash
bun test src/node/services/workflows/WorkflowService.test.ts
bun test src/node/services/workflows/WorkflowRunner.test.ts
bun test src/node/services/workflows/WorkflowRunStore.test.ts
bun test src/node/orpc/router.test.ts
bun test src/browser/features/Tools/WorkflowRunToolCall.test.tsx
make typecheck
```

If touched surfaces are wider, finish with `make static-check`.

### Gate 2 — sandboxed app setup

Use an isolated Mux root and free ports so dogfood cannot mutate the user’s real session data:

```bash
make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-projects"
```

Capture the printed app URL/ports. Before running browser commands, load installed browser instructions as required by the `agent-browser` skill:

```bash
agent-browser skills get core
```

### Gate 3 — deterministic dogfood scenario

Seed or create a recoverable failed workflow run in the sandbox. Preferred implementation-time method:

1. Add a test/dev-only fixture or temporary local script that creates a workflow run with:
   - status `failed`
   - latest error event `Execution interrupted`
   - at least one completed step
   - at least one started step whose child report artifact already exists
   - keep this fixture/script temporary unless reviewers intentionally accept it as a committed dev tool
2. Open the sandbox app to the workspace containing that run.
3. Use `agent-browser` to capture evidence:

```bash
mkdir -p dogfood-output/workflow-retry/screenshots dogfood-output/workflow-retry/videos
agent-browser --session workflow-retry open <SANDBOX_APP_URL>
agent-browser --session workflow-retry wait --load networkidle
agent-browser --session workflow-retry screenshot --annotate dogfood-output/workflow-retry/screenshots/01-failed-run.png
agent-browser --session workflow-retry snapshot -i
agent-browser --session workflow-retry record start dogfood-output/workflow-retry/videos/retry-from-checkpoint.webm
# click the Retry from checkpoint button by ref from snapshot
agent-browser --session workflow-retry click @eN
sleep 2
agent-browser --session workflow-retry screenshot --annotate dogfood-output/workflow-retry/screenshots/02-retry-running.png
# wait/poll until terminal state, then capture final card
agent-browser --session workflow-retry screenshot --annotate dogfood-output/workflow-retry/screenshots/03-retry-completed.png
agent-browser --session workflow-retry record stop
agent-browser --session workflow-retry console
agent-browser --session workflow-retry errors
```

Attach the screenshots/video in the final implementation report so reviewers can verify the UI path.

### Gate 4 — negative dogfood scenario

Repeat with a failed compile-error or schema-validation workflow:

- Verify no **Retry from checkpoint** button appears, or clicking an intentionally exposed disabled/attempt path yields a clear error.
- Capture at least one annotated screenshot.

## Open implementation decisions with recommended defaults

- Eligibility source: backend service predicate is the source of truth; frontend may use latest-error text only as conservative button visibility. Avoid derived eligibility on persisted `WorkflowRunRecord` unless implementation evidence justifies it.
- API naming: prefer `retryFromCheckpoint` to distinguish failed-run recovery from `resume`.
- Transition model: prefer explicit production override for recoverable failed retry rather than globally making `failed -> running` a normal transition.

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$135.28`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=135.28 -->
