### PR TITLE
🤖 fix: show live workflow task rows

### DIFF
--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/browser/contexts/CommandRegistryContext";
 import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
 import { ThemeProvider } from "@/browser/contexts/ThemeContext";
+import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
 import { WorkflowRunToolCall } from "./WorkflowRunToolCall";
 
 function APIHarness(props: { client: unknown; children: ReactNode }) {
@@ -62,6 +63,7 @@ describe("WorkflowRunToolCall", () => {
   });
 
   afterEach(() => {
+    useWorkspaceStoreRaw().setNavigateToWorkspace(() => undefined);
     cleanup();
     globalThis.window = originalWindow;
     globalThis.document = originalDocument;
@@ -198,30 +200,142 @@ describe("WorkflowRunToolCall", () => {
     const taskEventRow = view.getByText("scope-topic / task_scope / completed");
     const taskEventIndex = view.getByText("#3");
     expect(taskEventIndex.className).toContain("cursor-help");
-    expect(taskEventRow.className).toContain("cursor-pointer");
+    expect(taskEventRow.closest('[role="button"]')?.className).toContain("cursor-pointer");
     expect(taskEventRow.getAttribute("title")).toBeNull();
-    const taskEventSummary = taskEventRow.closest("summary");
-    const taskEventDetails = taskEventRow.closest("details");
-    if (taskEventSummary == null) {
-      throw new Error("Expected task event summary");
-    }
-    expect(taskEventDetails?.hasAttribute("open")).toBe(false);
+    expect(taskEventRow.closest("summary")).toBeNull();
+    expect(view.queryByText("Show report")).toBeNull();
 
-    fireEvent.click(taskEventSummary);
+    fireEvent.click(taskEventRow);
 
-    expect(taskEventDetails?.hasAttribute("open")).toBe(true);
-    await waitFor(
-      () => expect(taskEventDetails?.textContent).toContain("Child task report body."),
-      {
-        timeout: 5_000,
-      }
-    );
+    await waitFor(() => expect(view.container.textContent).toContain("Child task report body."), {
+      timeout: 5_000,
+    });
     await waitFor(() => expect(view.container.textContent).toContain("Workflow result body"));
     const renderedText = view.container.textContent ?? "";
     expect(renderedText.indexOf("confidence")).toBeLessThan(
       renderedText.indexOf("Workflow result body")
     );
     expect(renderedText).toContain("confidence");
+  });
+
+  test("coalesces task attempts, navigates running rows, and expands completed reports inline", async () => {
+    const navigatedTo: string[] = [];
+    useWorkspaceStoreRaw().setNavigateToWorkspace((workspaceId) => {
+      navigatedTo.push(workspaceId);
+    });
+    const view = render(
+      <ThemeProvider forcedTheme="dark">
+        <TooltipProvider>
+          <WorkflowRunToolCall
+            args={{ name: "implementation", args: {}, run_in_background: true }}
+            status="executing"
+            result={{
+              status: "running",
+              runId: "wfr_task_rows",
+              result: null,
+              run: {
+                id: "wfr_task_rows",
+                workspaceId: "workspace-1",
+                definition: {
+                  name: "implementation",
+                  description: "Implementation",
+                  scope: "built-in",
+                  executable: true,
+                },
+                definitionSource: "export default function workflow() { return null; }",
+                definitionHash: "sha256:test",
+                args: {},
+                status: "running",
+                createdAt: "2026-05-29T00:00:00.000Z",
+                updatedAt: "2026-05-29T00:00:01.000Z",
+                events: [
+                  {
+                    sequence: 1,
+                    type: "status",
+                    at: "2026-05-29T00:00:00.000Z",
+                    status: "running",
+                  },
+                  {
+                    sequence: 2,
+                    type: "task",
+                    at: "2026-05-29T00:00:00.000Z",
+                    stepId: "implement",
+                    taskId: "task_live",
+                    status: "started",
+                  },
+                  {
+                    sequence: 3,
+                    type: "task",
+                    at: "2026-05-29T00:00:01.000Z",
+                    stepId: "implement",
+                    taskId: "task_live",
+                    status: "completed",
+                  },
+                  {
+                    sequence: 4,
+                    type: "task",
+                    at: "2026-05-29T00:00:01.000Z",
+                    stepId: "implement",
+                    taskId: "task_retry",
+                    status: "started",
+                  },
+                  {
+                    sequence: 5,
+                    type: "patch",
+                    at: "2026-05-29T00:00:01.000Z",
+                    stepId: "apply-implement",
+                    sourceTaskId: "task_live",
+                    status: "started",
+                  },
+                ],
+                steps: [
+                  {
+                    stepId: "implement",
+                    inputHash: "sha256:implement-live",
+                    status: "completed",
+                    taskId: "task_live",
+                    startedAt: "2026-05-29T00:00:00.000Z",
+                    completedAt: "2026-05-29T00:00:01.000Z",
+                    result: { reportMarkdown: "## Implement report\n\nCompleted task body." },
+                  },
+                  {
+                    stepId: "apply-implement",
+                    inputHash: "sha256:patch",
+                    status: "started",
+                    taskId: "task_live",
+                    startedAt: "2026-05-29T00:00:01.000Z",
+                  },
+                ],
+              },
+            }}
+          />
+        </TooltipProvider>
+      </ThemeProvider>
+    );
+
+    expect(view.getAllByText("implement / task_live / completed")).toHaveLength(1);
+    expect(view.queryByText("implement / task_live / started")).toBeNull();
+    expect(view.getByText("implement / task_retry / started")).toBeTruthy();
+    expect(view.getByText("apply-implement / task_live / started")).toBeTruthy();
+
+    fireEvent.click(view.getByText("implement / task_retry / started"));
+    expect(navigatedTo).toEqual(["task_retry"]);
+
+    expect(view.queryByText("Show report")).toBeNull();
+    const completedTaskControl = view
+      .getByText("implement / task_live / completed")
+      .closest('[role="button"]');
+    if (completedTaskControl == null) {
+      throw new Error("Expected completed task row to be keyboard focusable");
+    }
+
+    fireEvent.keyDown(completedTaskControl, { key: "Enter" });
+
+    expect(navigatedTo).toEqual(["task_retry"]);
+    await waitFor(() => expect(view.container.textContent).toContain("Completed task body."));
+
+    fireEvent.click(view.getByText("implement / task_live / completed"));
+    expect(view.container.textContent).not.toContain("Completed task body.");
   });
 
   test("refreshes a running workflow from the API and shows the completed result", async () => {

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -203,9 +203,10 @@ describe("WorkflowRunToolCall", () => {
     expect(taskEventRow.closest('[role="button"]')?.className).toContain("cursor-pointer");
     expect(taskEventRow.getAttribute("title")).toBeNull();
     expect(taskEventRow.closest("summary")).toBeNull();
-    expect(view.queryByText("Show report")).toBeNull();
+    const taskReportToggle = view.getByLabelText("Show report for task_scope");
+    expect(taskReportToggle.closest('[role="button"]')).toBeNull();
 
-    fireEvent.click(taskEventRow);
+    fireEvent.click(taskReportToggle);
 
     await waitFor(() => expect(view.container.textContent).toContain("Child task report body."), {
       timeout: 5_000,
@@ -218,7 +219,7 @@ describe("WorkflowRunToolCall", () => {
     expect(renderedText).toContain("confidence");
   });
 
-  test("coalesces task attempts, navigates running rows, and expands completed reports inline", async () => {
+  test("coalesces task attempts, navigates rows, and toggles completed reports separately", async () => {
     const navigatedTo: string[] = [];
     useWorkspaceStoreRaw().setNavigateToWorkspace((workspaceId) => {
       navigatedTo.push(workspaceId);
@@ -321,7 +322,6 @@ describe("WorkflowRunToolCall", () => {
     fireEvent.click(view.getByText("implement / task_retry / started"));
     expect(navigatedTo).toEqual(["task_retry"]);
 
-    expect(view.queryByText("Show report")).toBeNull();
     const completedTaskControl = view
       .getByText("implement / task_live / completed")
       .closest('[role="button"]');
@@ -330,11 +330,17 @@ describe("WorkflowRunToolCall", () => {
     }
 
     fireEvent.keyDown(completedTaskControl, { key: "Enter" });
+    expect(navigatedTo).toEqual(["task_retry", "task_live"]);
+    expect(view.container.textContent).not.toContain("Completed task body.");
 
-    expect(navigatedTo).toEqual(["task_retry"]);
+    const reportToggle = view.getByLabelText("Show report for task_live");
+    expect(reportToggle.closest('[role="button"]')).toBeNull();
+    fireEvent.click(reportToggle);
+
+    expect(navigatedTo).toEqual(["task_retry", "task_live"]);
     await waitFor(() => expect(view.container.textContent).toContain("Completed task body."));
 
-    fireEvent.click(view.getByText("implement / task_live / completed"));
+    fireEvent.click(view.getByLabelText("Hide report for task_live"));
     expect(view.container.textContent).not.toContain("Completed task body.");
   });
 

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -45,6 +45,7 @@ import {
   formatWorkflowSavedMessage,
   type WorkflowPromotionTarget,
 } from "./WorkflowDefinitionToolCall";
+import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
 import { MarkdownRenderer } from "../Messages/MarkdownRenderer";
 
 interface WorkflowRunToolCallProps {
@@ -131,6 +132,53 @@ function getStructuredOutput(value: unknown): unknown {
   return undefined;
 }
 
+type WorkflowTaskEvent = Extract<WorkflowRunEvent, { type: "task" }>;
+
+type WorkflowDisplayRow =
+  | { kind: "event"; event: WorkflowRunEvent }
+  | { kind: "task"; firstEvent: WorkflowTaskEvent; latestEvent: WorkflowTaskEvent };
+
+function getTaskEventKey(event: WorkflowTaskEvent): string {
+  return `task:${event.stepId}:${event.taskId}`;
+}
+
+function getWorkflowDisplayRows(events: readonly WorkflowRunEvent[]): WorkflowDisplayRow[] {
+  const rows: WorkflowDisplayRow[] = [];
+  const taskRows = new Map<string, Extract<WorkflowDisplayRow, { kind: "task" }>>();
+
+  for (const event of events) {
+    if (event.type === "status" || event.type === "result") {
+      continue;
+    }
+    if (event.type !== "task") {
+      rows.push({ kind: "event", event });
+      continue;
+    }
+
+    const key = getTaskEventKey(event);
+    const existingRow = taskRows.get(key);
+    if (existingRow != null) {
+      existingRow.latestEvent = event;
+      continue;
+    }
+
+    const row: Extract<WorkflowDisplayRow, { kind: "task" }> = {
+      kind: "task",
+      firstEvent: event,
+      latestEvent: event,
+    };
+    taskRows.set(key, row);
+    rows.push(row);
+  }
+  return rows;
+}
+
+function getDisplayRowKey(row: WorkflowDisplayRow): string {
+  if (row.kind === "task") {
+    return getTaskEventKey(row.firstEvent);
+  }
+  return getEventKey(row.event);
+}
 function getEventKey(event: WorkflowRunEvent): string {
   return `${event.sequence}:${event.type}`;
 }
@@ -247,11 +295,7 @@ function findTaskStepForEvent(
     return null;
   }
 
-  const byTaskId = steps.find((step) => step.taskId === event.taskId);
-  if (byTaskId != null) {
-    return byTaskId;
-  }
-  return steps.find((step) => step.stepId === event.stepId) ?? null;
+  return steps.find((step) => step.taskId === event.taskId && step.stepId === event.stepId) ?? null;
 }
 
 function getTaskReportMarkdown(
@@ -341,6 +385,74 @@ function WorkflowEventRow(props: {
   );
 }
 
+function WorkflowTaskRow(props: {
+  row: Extract<WorkflowDisplayRow, { kind: "task" }>;
+  displayIndex: number;
+  steps: readonly WorkflowStepRecord[];
+  onNavigate: (taskId: string) => void;
+}) {
+  const [reportExpanded, setReportExpanded] = useState(false);
+  const event = props.row.latestEvent;
+  const label = getWorkflowEventLabel(event);
+  const taskReportMarkdown = getTaskReportMarkdown(event, props.steps);
+  const canShowReport = taskReportMarkdown != null;
+  const activateTaskRow = () => {
+    if (canShowReport) {
+      setReportExpanded((isExpanded) => !isExpanded);
+      return;
+    }
+    props.onNavigate(event.taskId);
+  };
+  const onKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (keyboardEvent) => {
+    if (keyboardEvent.key !== "Enter" && keyboardEvent.key !== " ") {
+      return;
+    }
+    keyboardEvent.preventDefault();
+    activateTaskRow();
+  };
+
+  return (
+    <li className="hover:bg-background/50">
+      <div
+        className={`grid cursor-pointer grid-cols-[3rem_4.75rem_minmax(0,1fr)] items-center gap-2 border-l-2 border-transparent px-2 py-1 text-[10px]`}
+        role="button"
+        tabIndex={0}
+        aria-expanded={canShowReport ? reportExpanded : undefined}
+        onClick={activateTaskRow}
+        onKeyDown={onKeyDown}
+      >
+        <TooltipIfPresent
+          tooltip={
+            <WorkflowEventTooltip
+              event={props.row.firstEvent}
+              displayIndex={props.displayIndex}
+              label={label}
+            />
+          }
+          side="top"
+          align="start"
+        >
+          <span
+            className="text-muted counter-nums-mono w-fit cursor-help"
+            aria-label={`Raw event #${props.row.firstEvent.sequence}`}
+          >
+            #{props.displayIndex}
+          </span>
+        </TooltipIfPresent>
+        <span className={`w-fit font-mono uppercase ${getEventTypeClass(event)}`}>
+          {event.type}
+        </span>
+        <span className="text-foreground truncate">{label}</span>
+      </div>
+      {reportExpanded && taskReportMarkdown != null && (
+        <div className="border-border bg-background/40 mx-2 mb-2 rounded border p-2 text-[11px]">
+          <MarkdownRenderer content={taskReportMarkdown} />
+        </div>
+      )}
+    </li>
+  );
+}
+
 const AUTO_COLLAPSE_WORKFLOW_STATUSES = new Set(["completed"]);
 
 const REFRESHING_WORKFLOW_STATUSES = new Set(["pending", "running", "backgrounded"]);
@@ -393,10 +505,9 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
   const structuredOutput = getStructuredOutput(resultValue);
   const invocationArgs = run?.args ?? args.args ?? {};
   const events = run?.events ?? [];
-  const interestingEvents = events.filter(
-    (event) => event.type !== "status" && event.type !== "result"
-  );
+  const displayRows = getWorkflowDisplayRows(events);
   const headerStatus = toToolStatus(displayStatus);
+  const workspaceStore = useWorkspaceStoreRaw();
 
   const toggleWorkflowExpanded = () => {
     userToggledExpansionRef.current = true;
@@ -733,18 +844,28 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
 
           {actionError && <ErrorBox className="mb-2">{actionError}</ErrorBox>}
 
-          {interestingEvents.length > 0 && (
-            <WorkflowSection title={`Workflow events (${interestingEvents.length})`}>
+          {displayRows.length > 0 && (
+            <WorkflowSection title={`Workflow events (${displayRows.length})`}>
               <div className="border-border bg-background/20 max-h-[220px] overflow-y-auto rounded border">
                 <ol className="divide-border/60 divide-y">
-                  {interestingEvents.map((event, index) => (
-                    <WorkflowEventRow
-                      key={getEventKey(event)}
-                      event={event}
-                      displayIndex={index + 1}
-                      steps={run?.steps ?? []}
-                    />
-                  ))}
+                  {displayRows.map((row, index) =>
+                    row.kind === "task" ? (
+                      <WorkflowTaskRow
+                        key={getDisplayRowKey(row)}
+                        row={row}
+                        displayIndex={index + 1}
+                        steps={run?.steps ?? []}
+                        onNavigate={(taskId) => workspaceStore.navigateToWorkspace(taskId)}
+                      />
+                    ) : (
+                      <WorkflowEventRow
+                        key={getDisplayRowKey(row)}
+                        event={row.event}
+                        displayIndex={index + 1}
+                        steps={run?.steps ?? []}
+                      />
+                    )
+                  )}
                 </ol>
               </div>
             </WorkflowSection>

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 
 import { APIContext, type APIClient } from "@/browser/contexts/API";
 import { TooltipIfPresent } from "@/browser/components/Tooltip/Tooltip";
@@ -396,13 +397,8 @@ function WorkflowTaskRow(props: {
   const label = getWorkflowEventLabel(event);
   const taskReportMarkdown = getTaskReportMarkdown(event, props.steps);
   const canShowReport = taskReportMarkdown != null;
-  const activateTaskRow = () => {
-    if (canShowReport) {
-      setReportExpanded((isExpanded) => !isExpanded);
-      return;
-    }
-    props.onNavigate(event.taskId);
-  };
+  const reportId = `workflow-task-report-${props.row.firstEvent.sequence}-${event.taskId}`;
+  const activateTaskRow = () => props.onNavigate(event.taskId);
   const onKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (keyboardEvent) => {
     if (keyboardEvent.key !== "Enter" && keyboardEvent.key !== " ") {
       return;
@@ -411,41 +407,67 @@ function WorkflowTaskRow(props: {
     activateTaskRow();
   };
 
+  const taskRow = (
+    <div
+      className="grid cursor-pointer grid-cols-[3rem_4.75rem_minmax(0,1fr)] items-center gap-2 border-l-2 border-transparent px-2 py-1 text-[10px]"
+      role="button"
+      tabIndex={0}
+      aria-label={`Open workflow task ${event.taskId}`}
+      onClick={activateTaskRow}
+      onKeyDown={onKeyDown}
+    >
+      <TooltipIfPresent
+        tooltip={
+          <WorkflowEventTooltip
+            event={props.row.firstEvent}
+            displayIndex={props.displayIndex}
+            label={label}
+          />
+        }
+        side="top"
+        align="start"
+      >
+        <span
+          className="text-muted counter-nums-mono w-fit cursor-help"
+          aria-label={`Raw event #${props.row.firstEvent.sequence}`}
+        >
+          #{props.displayIndex}
+        </span>
+      </TooltipIfPresent>
+      <span className={`w-fit font-mono uppercase ${getEventTypeClass(event)}`}>{event.type}</span>
+      <span className="text-foreground truncate">{label}</span>
+    </div>
+  );
+
   return (
     <li className="hover:bg-background/50">
-      <div
-        className={`grid cursor-pointer grid-cols-[3rem_4.75rem_minmax(0,1fr)] items-center gap-2 border-l-2 border-transparent px-2 py-1 text-[10px]`}
-        role="button"
-        tabIndex={0}
-        aria-expanded={canShowReport ? reportExpanded : undefined}
-        onClick={activateTaskRow}
-        onKeyDown={onKeyDown}
-      >
-        <TooltipIfPresent
-          tooltip={
-            <WorkflowEventTooltip
-              event={props.row.firstEvent}
-              displayIndex={props.displayIndex}
-              label={label}
-            />
-          }
-          side="top"
-          align="start"
-        >
-          <span
-            className="text-muted counter-nums-mono w-fit cursor-help"
-            aria-label={`Raw event #${props.row.firstEvent.sequence}`}
+      {canShowReport ? (
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center">
+          {taskRow}
+          <button
+            type="button"
+            className={`${WORKFLOW_ACTION_BUTTON_CLASS} mr-2 gap-1 px-1.5 py-0.5 text-[10px]`}
+            aria-controls={reportId}
+            aria-expanded={reportExpanded}
+            aria-label={`${reportExpanded ? "Hide" : "Show"} report for ${event.taskId}`}
+            onClick={() => setReportExpanded((isExpanded) => !isExpanded)}
           >
-            #{props.displayIndex}
-          </span>
-        </TooltipIfPresent>
-        <span className={`w-fit font-mono uppercase ${getEventTypeClass(event)}`}>
-          {event.type}
-        </span>
-        <span className="text-foreground truncate">{label}</span>
-      </div>
+            {reportExpanded ? (
+              <ChevronDown className="h-3 w-3" aria-hidden="true" />
+            ) : (
+              <ChevronRight className="h-3 w-3" aria-hidden="true" />
+            )}
+            Report
+          </button>
+        </div>
+      ) : (
+        taskRow
+      )}
       {reportExpanded && taskReportMarkdown != null && (
-        <div className="border-border bg-background/40 mx-2 mb-2 rounded border p-2 text-[11px]">
+        <div
+          id={reportId}
+          className="border-border bg-background/40 mx-2 mb-2 rounded border p-2 text-[11px]"
+        >
           <MarkdownRenderer content={taskReportMarkdown} />
         </div>
       )}

--- a/src/node/services/workflows/WorkflowRunner.test.ts
+++ b/src/node/services/workflows/WorkflowRunner.test.ts
@@ -443,6 +443,46 @@ describe("WorkflowRunner", () => {
     expect(taskCalls).toBe(1);
   });
 
+  test("backfills completed task events when replaying completed agent steps", async () => {
+    using tmp = new DisposableTempDir("workflow-runner-completed-task-event-backfill");
+    const store = await createRunStore(tmp.path);
+    const spec = { id: "summarize-topic", prompt: "Summarize durable workflows" };
+    await store.recordStepCompleted("wfr_123", {
+      stepId: spec.id,
+      inputHash: hashWorkflowStepInput(spec.id, spec),
+      taskId: "task_completed_missing_event",
+      result: { taskId: "task_completed_missing_event", reportMarkdown: "summary" },
+      startedAt: "2026-05-29T00:00:00.500Z",
+      completedAt: "2026-05-29T00:00:00.750Z",
+    });
+    await store.appendEvent("wfr_123", {
+      sequence: 1,
+      type: "task",
+      at: "2026-05-29T00:00:00.500Z",
+      stepId: spec.id,
+      taskId: "task_completed_missing_event",
+      status: "started",
+    });
+    let taskCalls = 0;
+    const runner = createRunner(store, {
+      async runAgent() {
+        taskCalls += 1;
+        throw new Error("agent should replay");
+      },
+    });
+
+    await expect(runner.run("wfr_123")).resolves.toEqual({ reportMarkdown: "Final: summary" });
+    const taskEvents = (await store.getRun("wfr_123")).events.filter(
+      (event) => event.type === "task" && event.taskId === "task_completed_missing_event"
+    );
+
+    expect(taskCalls).toBe(0);
+    expect(taskEvents).toEqual([
+      expect.objectContaining({ status: "started" }),
+      expect.objectContaining({ status: "completed" }),
+    ]);
+  });
+
   test("reuses a recorded started task id instead of respawning on resume", async () => {
     using tmp = new DisposableTempDir("workflow-runner");
     const store = await createRunStore(tmp.path);
@@ -552,6 +592,43 @@ describe("WorkflowRunner", () => {
       status: "completed",
       taskId: "task_recovered",
     });
+    expect(run.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "task",
+          stepId: "summarize-topic",
+          taskId: "task_missing",
+          status: "failed",
+        }),
+        expect.objectContaining({
+          type: "task",
+          stepId: "summarize-topic",
+          taskId: "task_recovered",
+          status: "completed",
+        }),
+      ])
+    );
+  });
+
+  test("records failed task events when an agent task fails after creation", async () => {
+    using tmp = new DisposableTempDir("workflow-runner-child-failure");
+    const store = await createRunStore(tmp.path);
+    const runner = createRunner(store, {
+      async runAgent(_spec, lifecycle) {
+        await lifecycle?.onTaskCreated?.("task_failed_after_create");
+        throw new Error("child execution failed");
+      },
+    });
+
+    await expect(runner.run("wfr_123")).rejects.toThrow("child execution failed");
+    const taskEvents = (await store.getRun("wfr_123")).events.filter(
+      (event) => event.type === "task" && event.taskId === "task_failed_after_create"
+    );
+
+    expect(taskEvents).toEqual([
+      expect.objectContaining({ status: "started" }),
+      expect.objectContaining({ status: "failed" }),
+    ]);
   });
 
   test("restarts started task records when resuming a user-interrupted run", async () => {

--- a/src/node/services/workflows/WorkflowRunner.test.ts
+++ b/src/node/services/workflows/WorkflowRunner.test.ts
@@ -85,8 +85,13 @@ describe("WorkflowRunner", () => {
       "phase",
       "log",
       "task",
+      "task",
       "result",
       "status",
+    ]);
+    expect(run.events.filter((event) => event.type === "task")).toEqual([
+      expect.objectContaining({ stepId: "summarize-topic", taskId: "task_1", status: "started" }),
+      expect.objectContaining({ stepId: "summarize-topic", taskId: "task_1", status: "completed" }),
     ]);
     expect(run.steps).toHaveLength(1);
     expect(run.steps[0]).toMatchObject({
@@ -95,6 +100,50 @@ describe("WorkflowRunner", () => {
       taskId: "task_1",
       result: { reportMarkdown: "summary", structuredOutput: { sources: 3 } },
     });
+  });
+
+  test("records a started task event as soon as an agent task is created", async () => {
+    using tmp = new DisposableTempDir("workflow-runner-started-task-event");
+    const store = await createRunStore(tmp.path);
+    const runner = createRunner(store, {
+      async runAgent(_spec, lifecycle) {
+        await lifecycle?.onTaskCreated?.("task_live");
+        const runDuringTask = await store.getRun("wfr_123");
+        expect(runDuringTask.events).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              type: "task",
+              stepId: "summarize-topic",
+              taskId: "task_live",
+              status: "started",
+            }),
+          ])
+        );
+        return {
+          taskId: "task_live",
+          reportMarkdown: "summary",
+          structuredOutput: { sources: 3 },
+        };
+      },
+    });
+
+    await runner.run("wfr_123");
+    const taskEvents = (await store.getRun("wfr_123")).events.filter(
+      (event) => event.type === "task"
+    );
+
+    expect(taskEvents).toEqual([
+      expect.objectContaining({
+        stepId: "summarize-topic",
+        taskId: "task_live",
+        status: "started",
+      }),
+      expect.objectContaining({
+        stepId: "summarize-topic",
+        taskId: "task_live",
+        status: "completed",
+      }),
+    ]);
   });
 
   test("returns child task IDs to workflow code", async () => {
@@ -404,6 +453,14 @@ describe("WorkflowRunner", () => {
       taskId: "task_existing",
       startedAt: "2026-05-29T00:00:00.500Z",
     });
+    await store.appendEvent("wfr_123", {
+      sequence: 1,
+      type: "task",
+      at: "2026-05-29T00:00:00.500Z",
+      stepId: spec.id,
+      taskId: "task_existing",
+      status: "started",
+    });
     let runAgentCalls = 0;
     const waitedFor: string[] = [];
     let waitTimeoutMs: number | undefined;
@@ -425,8 +482,41 @@ describe("WorkflowRunner", () => {
 
     expect(runAgentCalls).toBe(0);
     expect(waitedFor).toEqual(["task_existing"]);
+    const startedEvents = (await store.getRun("wfr_123")).events.filter(
+      (event) =>
+        event.type === "task" && event.status === "started" && event.taskId === "task_existing"
+    );
+    expect(startedEvents).toHaveLength(1);
     expect(waitTimeoutMs).toBeGreaterThan(5 * 60 * 1000);
     expect(waitAbortSignal?.aborted).toBe(false);
+  });
+
+  test("adds one started task event when resuming legacy started steps", async () => {
+    using tmp = new DisposableTempDir("workflow-runner-legacy-started-event");
+    const store = await createRunStore(tmp.path);
+    const spec = { id: "summarize-topic", prompt: "Summarize durable workflows" };
+    await store.recordStepStarted("wfr_123", {
+      stepId: spec.id,
+      inputHash: hashWorkflowStepInput(spec.id, spec),
+      taskId: "task_legacy",
+      startedAt: "2026-05-29T00:00:00.500Z",
+    });
+    const runner = createRunner(store, {
+      async runAgent() {
+        throw new Error("agent should not respawn");
+      },
+      async waitForAgentTask(taskId) {
+        return { taskId, reportMarkdown: "summary" };
+      },
+    });
+
+    await expect(runner.run("wfr_123")).resolves.toEqual({ reportMarkdown: "Final: summary" });
+    const startedEvents = (await store.getRun("wfr_123")).events.filter(
+      (event) =>
+        event.type === "task" && event.status === "started" && event.taskId === "task_legacy"
+    );
+
+    expect(startedEvents).toHaveLength(1);
   });
 
   test("reruns stale started task ids that no longer have recoverable reports", async () => {
@@ -517,10 +607,11 @@ describe("WorkflowRunner", () => {
     let active = 0;
     let maxActive = 0;
     const runner = createRunner(store, {
-      async runAgent(spec) {
+      async runAgent(spec, lifecycle) {
         calls.push(spec.id);
         active += 1;
         maxActive = Math.max(maxActive, active);
+        await lifecycle?.onTaskCreated?.(`task_${spec.id}`);
         await new Promise((resolve) => setTimeout(resolve, 10));
         active -= 1;
         return { taskId: `task_${spec.id}`, reportMarkdown: spec.id };
@@ -534,6 +625,25 @@ describe("WorkflowRunner", () => {
     expect(calls).toEqual(["source-a", "source-b"]);
     expect(maxActive).toBe(2);
     const run = await store.getRun("wfr_parallel");
+    const eventSequences = run.events.map((event) => event.sequence);
+    expect(eventSequences).toEqual([...eventSequences].sort((a, b) => a - b));
+    expect(new Set(eventSequences).size).toBe(eventSequences.length);
+    expect(run.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "task",
+          stepId: "source-a",
+          taskId: "task_source-a",
+          status: "started",
+        }),
+        expect.objectContaining({
+          type: "task",
+          stepId: "source-b",
+          taskId: "task_source-b",
+          status: "started",
+        }),
+      ])
+    );
     expect(run.steps.map((step) => step.stepId).sort()).toEqual(["source-a", "source-b"]);
   });
 

--- a/src/node/services/workflows/WorkflowRunner.ts
+++ b/src/node/services/workflows/WorkflowRunner.ts
@@ -9,6 +9,7 @@ import assert from "@/common/utils/assert";
 import { getErrorMessage } from "@/common/utils/errors";
 import { validateJsonSchemaSubset } from "@/common/utils/jsonSchemaSubset";
 import type { IJSRuntime, IJSRuntimeFactory } from "@/node/services/ptc/runtime";
+import { AsyncMutex } from "@/node/utils/concurrency/asyncMutex";
 import type { AppendWorkflowRunEventOptions, WorkflowRunStore } from "./WorkflowRunStore";
 import { assertWorkflowStepId, hashWorkflowStepInput } from "./workflowReplayKey";
 
@@ -128,6 +129,16 @@ function shouldRestartUnrecoverableStartedTask(error: unknown): boolean {
   return message === "Task not found" || message === "Task interrupted";
 }
 
+function getTaskTerminalStatusForError(
+  error: unknown,
+  abortSignal?: AbortSignal
+): "failed" | "interrupted" {
+  if (abortSignal?.aborted === true || getErrorMessage(error) === "Task interrupted") {
+    return "interrupted";
+  }
+  return "failed";
+}
+
 function isRetryableAgentOutputError(error: unknown): boolean {
   return error instanceof WorkflowAgentOutputValidationError;
 }
@@ -192,7 +203,7 @@ export class WorkflowRunner {
   private readonly taskAdapter: WorkflowTaskAdapter;
   private readonly runnerId: string;
   private readonly clock: WorkflowRunnerClock;
-  private readonly taskStartedEventMutex = new AsyncMutex();
+  private readonly taskEventMutex = new AsyncMutex();
 
   constructor(options: WorkflowRunnerOptions) {
     assert(options.runnerId.length > 0, "WorkflowRunner: runnerId is required");
@@ -658,6 +669,13 @@ export class WorkflowRunner {
     options.leaseGuard.throwIfLost();
     const existingStep = await this.runStore.getStep(runId, spec.id, inputHash);
     if (existingStep?.status === "completed" && existingStep.result != null) {
+      if (existingStep.taskId != null) {
+        options.leaseGuard.throwIfLost();
+        await this.recordTaskCompletedEventIfMissing(runId, sequence, {
+          stepId: spec.id,
+          taskId: existingStep.taskId,
+        });
+      }
       return existingStep.result;
     }
 
@@ -711,6 +729,13 @@ export class WorkflowRunner {
     for (const [index, step] of parsedSteps.entries()) {
       const existingStep = existingSteps[index];
       if (existingStep?.status === "completed" && existingStep.result != null) {
+        if (existingStep.taskId != null) {
+          options.leaseGuard.throwIfLost();
+          await this.recordTaskCompletedEventIfMissing(runId, sequence, {
+            stepId: step.spec.id,
+            taskId: existingStep.taskId,
+          });
+        }
         results[index] = existingStep.result;
         continue;
       }
@@ -911,6 +936,14 @@ export class WorkflowRunner {
       try {
         return await this.taskAdapter.waitForAgentTask(step.taskId, step.spec, step.waitOptions);
       } catch (error) {
+        if (!isForegroundWaitBackgroundedError(error)) {
+          step.leaseGuard.throwIfLost();
+          await this.recordTaskTerminalEventIfMissing(runId, sequence, {
+            stepId: step.spec.id,
+            taskId: step.taskId,
+            status: getTaskTerminalStatusForError(error, step.waitOptions?.abortSignal),
+          });
+        }
         if (!shouldRestartUnrecoverableStartedTask(error)) {
           throw error;
         }
@@ -919,26 +952,39 @@ export class WorkflowRunner {
 
     step.leaseGuard.throwIfLost();
     let recordedTaskId: string | undefined;
-    const rawResult = await this.taskAdapter.runAgent(
-      step.spec,
-      {
-        onTaskCreated: async (taskId) => {
-          step.leaseGuard.throwIfLost();
-          recordedTaskId = taskId;
-          await this.recordStepStarted(runId, {
-            stepId: step.spec.id,
-            inputHash: step.inputHash,
-            taskId,
-            startedAt: step.startedAt,
-          });
-          await this.recordTaskStartedEventIfMissing(runId, sequence, {
-            stepId: step.spec.id,
-            taskId,
-          });
+    let rawResult: WorkflowAgentResult;
+    try {
+      rawResult = await this.taskAdapter.runAgent(
+        step.spec,
+        {
+          onTaskCreated: async (taskId) => {
+            step.leaseGuard.throwIfLost();
+            recordedTaskId = taskId;
+            await this.recordStepStarted(runId, {
+              stepId: step.spec.id,
+              inputHash: step.inputHash,
+              taskId,
+              startedAt: step.startedAt,
+            });
+            await this.recordTaskStartedEventIfMissing(runId, sequence, {
+              stepId: step.spec.id,
+              taskId,
+            });
+          },
         },
-      },
-      step.waitOptions
-    );
+        step.waitOptions
+      );
+    } catch (error) {
+      if (recordedTaskId != null && !isForegroundWaitBackgroundedError(error)) {
+        step.leaseGuard.throwIfLost();
+        await this.recordTaskTerminalEventIfMissing(runId, sequence, {
+          stepId: step.spec.id,
+          taskId: recordedTaskId,
+          status: getTaskTerminalStatusForError(error, step.waitOptions?.abortSignal),
+        });
+      }
+      throw error;
+    }
     step.leaseGuard.throwIfLost();
     if (recordedTaskId == null) {
       await this.recordStepStarted(runId, {
@@ -960,30 +1006,54 @@ export class WorkflowRunner {
     sequence: WorkflowEventSequence,
     task: { stepId: string; taskId: string }
   ): Promise<void> {
-    assert(runId.length > 0, "WorkflowRunner.recordTaskStartedEventIfMissing: runId is required");
-    assert(task.stepId.length > 0, "WorkflowRunner: started task stepId is required");
-    assert(task.taskId.length > 0, "WorkflowRunner: started task taskId is required");
+    await this.recordTaskEventIfMissing(runId, sequence, { ...task, status: "started" });
+  }
 
-    await this.taskStartedEventMutex.runExclusive(async () => {
-      const run = await this.runStore.getRun(runId);
-      const alreadyRecorded = run.events.some(
-        (event) =>
-          event.type === "task" &&
-          event.status === "started" &&
-          event.stepId === task.stepId &&
-          event.taskId === task.taskId
-      );
-      if (alreadyRecorded) {
-        return;
-      }
-      await this.appendEvent(runId, {
-        sequence: sequence.next(),
-        type: "task",
-        at: this.clock.nowIso(),
-        stepId: task.stepId,
-        taskId: task.taskId,
-        status: "started",
-      });
+  private async recordTaskCompletedEventIfMissing(
+    runId: string,
+    sequence: WorkflowEventSequence,
+    task: { stepId: string; taskId: string }
+  ): Promise<void> {
+    await this.recordTaskEventIfMissing(runId, sequence, { ...task, status: "completed" });
+  }
+
+  private async recordTaskTerminalEventIfMissing(
+    runId: string,
+    sequence: WorkflowEventSequence,
+    task: { stepId: string; taskId: string; status: "failed" | "interrupted" }
+  ): Promise<void> {
+    await this.recordTaskEventIfMissing(runId, sequence, task);
+  }
+
+  private async recordTaskEventIfMissing(
+    runId: string,
+    sequence: WorkflowEventSequence,
+    task: { stepId: string; taskId: string; status: string }
+  ): Promise<void> {
+    assert(runId.length > 0, "WorkflowRunner.recordTaskEventIfMissing: runId is required");
+    assert(task.stepId.length > 0, "WorkflowRunner: task event stepId is required");
+    assert(task.taskId.length > 0, "WorkflowRunner: task event taskId is required");
+    assert(task.status.length > 0, "WorkflowRunner: task event status is required");
+
+    await using _lock = await this.taskEventMutex.acquire();
+    const run = await this.runStore.getRun(runId);
+    const alreadyRecorded = run.events.some(
+      (event) =>
+        event.type === "task" &&
+        event.status === task.status &&
+        event.stepId === task.stepId &&
+        event.taskId === task.taskId
+    );
+    if (alreadyRecorded) {
+      return;
+    }
+    await this.appendEvent(runId, {
+      sequence: sequence.next(),
+      type: "task",
+      at: this.clock.nowIso(),
+      stepId: task.stepId,
+      taskId: task.taskId,
+      status: task.status,
     });
   }
 
@@ -1090,24 +1160,6 @@ export class WorkflowRunner {
       `agent ${stepId} returned no taskId`
     );
     return maybeTaskId;
-  }
-}
-
-class AsyncMutex {
-  private tail: Promise<void> = Promise.resolve();
-
-  async runExclusive<T>(callback: () => Promise<T>): Promise<T> {
-    const previous = this.tail;
-    let release!: () => void;
-    this.tail = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    await previous;
-    try {
-      return await callback();
-    } finally {
-      release();
-    }
   }
 }
 

--- a/src/node/services/workflows/WorkflowRunner.ts
+++ b/src/node/services/workflows/WorkflowRunner.ts
@@ -192,6 +192,7 @@ export class WorkflowRunner {
   private readonly taskAdapter: WorkflowTaskAdapter;
   private readonly runnerId: string;
   private readonly clock: WorkflowRunnerClock;
+  private readonly taskStartedEventMutex = new AsyncMutex();
 
   constructor(options: WorkflowRunnerOptions) {
     assert(options.runnerId.length > 0, "WorkflowRunner: runnerId is required");
@@ -752,7 +753,7 @@ export class WorkflowRunner {
         abortSignal: batchAbortController.signal,
       };
       const pendingRuns = currentPending.map(async (step) => {
-        return await this.runOrResumeAgentStep(runId, {
+        return await this.runOrResumeAgentStep(runId, sequence, {
           spec:
             step.attempt === 1
               ? step.spec
@@ -838,7 +839,7 @@ export class WorkflowRunner {
     let taskId = step.taskId;
     let spec = step.spec;
     while (attempt <= WORKFLOW_AGENT_MAX_ATTEMPTS) {
-      const rawResult = await this.runOrResumeAgentStep(runId, {
+      const rawResult = await this.runOrResumeAgentStep(runId, sequence, {
         spec,
         inputHash: step.inputHash,
         startedAt,
@@ -891,6 +892,7 @@ export class WorkflowRunner {
 
   private async runOrResumeAgentStep(
     runId: string,
+    sequence: WorkflowEventSequence,
     step: {
       spec: WorkflowAgentSpec;
       inputHash: string;
@@ -902,6 +904,10 @@ export class WorkflowRunner {
   ): Promise<WorkflowAgentResult> {
     step.leaseGuard.throwIfLost();
     if (step.taskId != null && this.taskAdapter.waitForAgentTask != null) {
+      await this.recordTaskStartedEventIfMissing(runId, sequence, {
+        stepId: step.spec.id,
+        taskId: step.taskId,
+      });
       try {
         return await this.taskAdapter.waitForAgentTask(step.taskId, step.spec, step.waitOptions);
       } catch (error) {
@@ -925,6 +931,10 @@ export class WorkflowRunner {
             taskId,
             startedAt: step.startedAt,
           });
+          await this.recordTaskStartedEventIfMissing(runId, sequence, {
+            stepId: step.spec.id,
+            taskId,
+          });
         },
       },
       step.waitOptions
@@ -937,8 +947,44 @@ export class WorkflowRunner {
         taskId: rawResult.taskId,
         startedAt: step.startedAt,
       });
+      await this.recordTaskStartedEventIfMissing(runId, sequence, {
+        stepId: step.spec.id,
+        taskId: rawResult.taskId,
+      });
     }
     return rawResult;
+  }
+
+  private async recordTaskStartedEventIfMissing(
+    runId: string,
+    sequence: WorkflowEventSequence,
+    task: { stepId: string; taskId: string }
+  ): Promise<void> {
+    assert(runId.length > 0, "WorkflowRunner.recordTaskStartedEventIfMissing: runId is required");
+    assert(task.stepId.length > 0, "WorkflowRunner: started task stepId is required");
+    assert(task.taskId.length > 0, "WorkflowRunner: started task taskId is required");
+
+    await this.taskStartedEventMutex.runExclusive(async () => {
+      const run = await this.runStore.getRun(runId);
+      const alreadyRecorded = run.events.some(
+        (event) =>
+          event.type === "task" &&
+          event.status === "started" &&
+          event.stepId === task.stepId &&
+          event.taskId === task.taskId
+      );
+      if (alreadyRecorded) {
+        return;
+      }
+      await this.appendEvent(runId, {
+        sequence: sequence.next(),
+        type: "task",
+        at: this.clock.nowIso(),
+        stepId: task.stepId,
+        taskId: task.taskId,
+        status: "started",
+      });
+    });
   }
 
   private async recordAgentResult(
@@ -1044,6 +1090,24 @@ export class WorkflowRunner {
       `agent ${stepId} returned no taskId`
     );
     return maybeTaskId;
+  }
+}
+
+class AsyncMutex {
+  private tail: Promise<void> = Promise.resolve();
+
+  async runExclusive<T>(callback: () => Promise<T>): Promise<T> {
+    const previous = this.tail;
+    let release!: () => void;
+    this.tail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await callback();
+    } finally {
+      release();
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Shows workflow-spawned child tasks in the workflow run card as soon as they are created, keeps task attempts coalesced by exact step/task identity, and preserves direct child-workspace navigation even after a task has an inline report.

## Background

Workflow runs previously surfaced sub-agent tasks only after their final report, leaving active parallel workflow work invisible. The first implementation added live rows; this follow-up also addresses review findings around completed-row navigation, stale resumed attempts, child failures after creation, replay backfills, and the duplicated mutex helper.

## Implementation

- Emits idempotent workflow `task / started` events when child tasks are created or resumed.
- Coalesces workflow task rows by exact `stepId + taskId`, with reports matched by the same identity so retries stay distinct.
- Splits task-row navigation from report expansion: row activation opens the child workspace; a sibling Report toggle expands markdown inline.
- Backfills missing completed task events during replay and terminalizes stale/failed child task attempts.
- Reuses the shared `AsyncMutex` implementation for serialized workflow task event writes.

## Validation

- `bun test src/browser/features/Tools/WorkflowRunToolCall.test.tsx src/node/services/workflows/WorkflowRunner.test.ts` — 43 passed.
- `make typecheck` — passed.
- `make static-check` — passed.
- Dogfooded with a seeded `dev-server-sandbox` workflow card using `agent-browser`; captured screenshots for live task rows, report toggle expansion, child workspace navigation, plus a WebM recording.

## Risks

Moderate workflow-card risk because this changes how workflow task lifecycle state is projected into the UI. Mitigations include exact task-attempt keys, backend idempotency checks, targeted UI/backend tests for retries and stale attempts, and sandbox dogfooding of the navigation/report paths.

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Show workflow-spawned sub-agents while running and navigate to them

> Advisor review: approved after revisions. Key advisor-requested fixes incorporated: task events are authoritative, start events are serialized, report enrichment exact-matches task attempts, retries stay distinct, and patch steps are not misclassified as sub-agent rows.

## Context and evidence

- The user-observed gap is in the workflow run card's task/event list: workflow-spawned agents are only shown after completion, even though the workflow has already launched them.
- Current backend lifecycle already persists launched workflow child tasks before completion:
  - `src/node/services/workflows/WorkflowRunner.ts` calls `taskAdapter.runAgent(...)` from `runOrResumeAgentStep(...)`.
  - The `onTaskCreated` lifecycle callback records a started step with `recordStepStarted(...)` as soon as `TaskService.create(...)` returns a child `taskId`.
  - `recordAgentResult(...)` appends the visible workflow `task` event only after the agent reports, which explains why the UI only shows task rows at completion time.
- Current persistence already exposes both data streams needed by the UI:
  - `src/node/services/workflows/WorkflowRunStore.ts#getRun(...)` returns `events` and `steps`.
  - `WorkflowRunStore.readSteps(...)` returns the latest step record per `(stepId, inputHash)`, which is useful for current report/details enrichment. Workflow `task` events should be treated as the authoritative per-task-attempt timeline.
- Current UI already refreshes active workflow runs:
  - `src/browser/features/Tools/WorkflowRunToolCall.tsx` polls `api.workflows.getRun(...)` every 2s while the run status is `pending`, `running`, or `backgrounded`.
  - The same component currently renders `interestingEvents = run.events.filter(...)`, so `run.steps` are available but not used as first-class live rows.
- `TaskService.create(...)` already emits workspace metadata for queued/running child tasks, so child workspaces can be navigated to by `taskId` as workspace id.
- Advisor review identified one important correction: `run.steps` alone is not a safe source for live sub-agent rows because `applyPatch` steps also record `taskId`. The recommended plan therefore uses explicit `task / started` workflow events for agent launches, and uses `steps` only for report/details enrichment.

## Goal

When a workflow launches sub-agent tasks, the workflow run card should immediately show those child tasks in the list, allow the user to navigate into a child task while it is running, and update the same row when the child finishes.

## Recommended approach — backend `task: started` events plus UI task-row coalescing

**Net product LoC estimate:** +130 to +220 LoC.

This is the recommended implementation because it uses the workflow event stream as the authoritative source of user-visible task rows, avoids misclassifying patch steps as sub-agents, and still keeps the change scoped.

### Backend implementation steps

1. **Serialize task-start workflow event writes in `WorkflowRunner.ts`.**
   - Add a runner-local `AsyncMutex` or small helper that protects the pair `sequence.next()` + `appendEvent(...)` for start events.
   - This is required because `parallelAgents(...)` can invoke multiple `onTaskCreated` callbacks concurrently.
   - Assert defensively that `runId`, `stepId`, and `taskId` are non-empty before appending.

2. **Append `task` events with `status: "started"` when agent tasks are created.**
   - In `runOrResumeAgentStep(...)`, extend the existing `onTaskCreated` lifecycle callback:
     1. keep recording `recordStepStarted(...)` as today,
     2. then append a workflow event `{ type: "task", stepId, taskId, status: "started" }` using the serialized event helper.
   - `WorkflowRunEventSchema` already permits string task statuses, so this should not require a schema migration.
   - Do not append task-start events from `runApplyPatchStep(...)`; patch progress continues to use `type: "patch"` events.

3. **Handle resume/crash-recovery without duplicate start events.**
   - When `runOrResumeAgentStep(...)` resumes an existing started step via `waitForAgentTask(...)`, ensure there is at most one `task / started` event for the exact `(stepId, taskId)` pair.
   - For legacy started steps that predate this change and have no task event yet, append one defensively so crash-resumed/backgrounded runs can still show the live child row.
   - Use exact `(stepId, taskId)` identity, not `(stepId, inputHash)`, because validation retries can reuse the logical step/input while launching a new child task id.

### UI implementation steps

4. **Introduce a workflow display-row model in `WorkflowRunToolCall.tsx`.**
   - Add a small discriminated union such as:
     - `event` rows for phase/log/validation/patch/error events.
     - `task` rows coalesced from workflow `task` events.
   - Task rows are keyed by exact `task:${stepId}:${taskId}`.
   - `run.steps` may be consulted only to enrich a task row with report markdown/details after completion; it must not independently create sub-agent rows.
   - Report enrichment must match the task row by exact `taskId` and preferably `stepId`; do not fall back to step-id-only matching. If no exact step/result exists for that task attempt, show no report for that row.

5. **Coalesce started/completed/failed task events without hiding retries.**
   - For each exact `(stepId, taskId)` pair, render one task row.
   - Keep the earliest task event position for row ordering and the latest task event status for row text.
   - A retry with the same `stepId` but a new `taskId` should render as a distinct row/attempt, preserving any previous failed event.
   - Existing completed-only workflow runs still render because a lone completed task event forms the row.

6. **Make task rows navigable while preserving report access.**
   - Use `useWorkspaceStoreRaw().navigateToWorkspace(taskId)` or an equivalent existing workspace-navigation path so the child task id routes to the child workspace.
   - Make the main task-row content clickable and keyboard accessible to satisfy the user expectation that clicking the row navigates to the sub-agent.
   - Avoid invalid nested interactive controls: split the row into sibling clickable regions, or use a `role="button"` row with no nested native button.
   - If a completed row has report markdown, provide a separate sibling report toggle/control that stops propagation and does not trigger navigation.

7. **Preserve existing behavior for non-task events.**
   - Phase highlighting, log JSON expansion, validation/error tones, patch details, and final report rendering should continue to behave as they do today.
   - Patch rows remain patch rows and are not navigable sub-agent rows unless a separate patch-specific UX is added later.

### Rejected alternative — UI-only rows from `run.steps`

**Net product LoC estimate if chosen:** +90 to +150 LoC.

This was the initial low-LoC idea, but it is not recommended because `WorkflowStepRecord` lacks a step kind and `applyPatch` steps also record `taskId`. A steps-only renderer would either risk briefly showing patch steps as sub-agents or require brittle inference from patch events/results.

## Testing plan

### Unit/UI tests

Update `src/browser/features/Tools/WorkflowRunToolCall.test.tsx`:

1. **Live started event row appears before completion.**
   - Render a running workflow run with a `task` event `{ stepId: "step-id", taskId: "task_live", status: "started" }` and no completed result.
   - Assert the task row text is visible, e.g. `step-id / task_live / started`.

2. **Started row updates instead of duplicating.**
   - Mock `api.workflows.getRun(...)` to return the same `(stepId, taskId)` first as `started`, then as `completed` with a matching step report.
   - Assert there is exactly one visible row for `task_live` and its status changes to `completed`.

3. **Retries with new task ids remain distinct.**
   - Render task events for the same `stepId` with `task_old / failed` and `task_new / started`.
   - Assert both attempts are visible so the new task does not overwrite the failed attempt.

4. **Patch steps/events are not navigable sub-agent rows.**
   - Render a workflow run containing a `patch` event and a patch step with `taskId`.
   - Assert the patch row remains a patch row and no sub-agent navigation affordance is created from that step alone.

5. **Report enrichment does not cross retry attempts.**
   - Render `task_old / failed` and `task_new / completed` with the same `stepId`, where only `task_new` has a matching step report.
   - Assert `task_old` does not show `task_new`'s report, while `task_new` can show it.

6. **Clicking task row navigates to child workspace.**
   - Install a test navigation callback through the raw `WorkspaceStore` in a test wrapper.
   - Restore/reset the singleton callback in `afterEach` so navigation state does not leak across tests.
   - Click the started task row and assert the callback receives `task_live`.
   - Also cover Enter/Space activation for the chosen accessible row control.

7. **Completed report affordance does not navigate.**
   - For a completed task with `reportMarkdown`, click the report toggle/control and assert the report opens while navigation callback is not called.
   - Include a DOM-shape assertion or interaction test that catches invalid nested button behavior if native buttons are used.

8. **Regression coverage for existing events.**
   - Keep/adjust existing assertions for phase/log/validation/patch/final report rendering.
   - Avoid tautological tests that only assert static copy; focus on status precedence, deduplication, event-kind separation, and navigation behavior.

### Backend tests

Update `src/node/services/workflows/WorkflowRunner.test.ts`:

1. **Emits a started task event when an agent task is created.**
   - Use a fake task adapter that calls `lifecycle.onTaskCreated("task_live")` before resolving.
   - Assert the stored run includes `task / started` before the later terminal task event.

2. **Serializes parallel started events.**
   - Use `parallelAgents(...)` with two child specs and a fake adapter that calls both `onTaskCreated` callbacks concurrently.
   - Assert workflow event sequences remain strictly increasing and both started rows are present.

3. **Resume path does not duplicate started events.**
   - Pre-seed a started step/task and matching started event, resume via `waitForAgentTask(...)`, and assert no duplicate started event is appended.
   - Optional legacy case: pre-seed a started step/task with no event, resume, and assert one started event is added.

4. **Validation retry keeps attempts separate.**
   - Force one invalid structured output attempt and one retry with a new task id.
   - Assert the run preserves distinct task events for the failed and retried task ids.

### Validation commands

Run after implementation:

```bash
bun test src/browser/features/Tools/WorkflowRunToolCall.test.tsx
bun test src/node/services/workflows/WorkflowRunner.test.ts
make typecheck
```

Before final handoff/PR readiness:

```bash
make static-check
```

## Dogfooding plan

This follows the requested dogfood, `agent-browser`, and `dev-server-sandbox` workflows. Use direct `agent-browser` commands, never `npx agent-browser`.

### Setup

1. Start an isolated app instance:

   ```bash
   make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-projects"
   ```

   Capture the emitted frontend URL and sandbox `MUX_ROOT` from the command output.

2. Before browser automation, load the installed CLI's current browser guide:

   ```bash
   agent-browser skills get core
   ```

3. Prepare evidence directories:

   ```bash
   mkdir -p dogfood-output/workflow-live-tasks/screenshots dogfood-output/workflow-live-tasks/videos
   ```

4. Open the sandboxed frontend:

   ```bash
   agent-browser --session workflow-live-tasks open "$FRONTEND_URL"
   agent-browser --session workflow-live-tasks wait --load networkidle
   agent-browser --session workflow-live-tasks screenshot --annotate dogfood-output/workflow-live-tasks/screenshots/initial.png
   agent-browser --session workflow-live-tasks snapshot -i
   ```

### Scenario

1. In the sandbox app, create or use a test workspace for this repo.
2. Add a scratch workflow that launches at least two sub-agents with `parallelAgents(...)`; use prompts that require enough investigation to observe the in-progress state.
3. Run the workflow in background.
4. Start a recording before interacting with the workflow card:

   ```bash
   agent-browser --session workflow-live-tasks record start dogfood-output/workflow-live-tasks/videos/live-task-navigation.webm
   ```

5. Expand the workflow run card and capture the live state:

   ```bash
   agent-browser --session workflow-live-tasks screenshot --annotate dogfood-output/workflow-live-tasks/screenshots/started-task-rows.png
   agent-browser --session workflow-live-tasks snapshot -i
   ```

6. Click a started task row and verify navigation into the child workspace:

   ```bash
   # Use the element ref from snapshot output.
   agent-browser --session workflow-live-tasks click @eN
   agent-browser --session workflow-live-tasks wait --load networkidle
   agent-browser --session workflow-live-tasks screenshot --annotate dogfood-output/workflow-live-tasks/screenshots/navigated-to-child-task.png
   ```

7. Navigate back to the workflow parent, wait for child completion, and capture the updated row:

   ```bash
   agent-browser --session workflow-live-tasks screenshot --annotate dogfood-output/workflow-live-tasks/screenshots/completed-task-rows.png
   ```

8. Stop recording and capture diagnostics:

   ```bash
   agent-browser --session workflow-live-tasks record stop
   agent-browser --session workflow-live-tasks errors
   agent-browser --session workflow-live-tasks console
   ```

### Dogfood acceptance gate

The reviewer evidence should include:

- `started-task-rows.png`: workflow task rows visible while child agents are still running.
- `navigated-to-child-task.png`: clicking a task row navigates into that sub-agent workspace.
- `completed-task-rows.png`: the same tasks show completed/failed state after finishing.
- `live-task-navigation.webm`: video of the live row appearing, click navigation, and row update.
- Console/errors output with no new relevant browser errors.

## Acceptance criteria

- A workflow-spawned child task produces a `task / started` workflow event as soon as the child task id is created.
- `parallelAgents(...)` can launch multiple children concurrently without duplicate or out-of-order workflow event sequence numbers.
- The workflow card shows the child task row before the child reports.
- The row includes step id, child task id, and current status (`started`, `completed`, `failed`, or any future task status string persisted by the backend).
- Clicking the task row navigates to the child workspace while it is still running.
- Completed task rows still provide access to the child report without hijacking row navigation.
- A single task attempt appears once: started/completed/failed statuses for the same `(stepId, taskId)` update one logical row.
- Retries with a new `taskId` appear as distinct attempts, even when they share the same workflow step id.
- Patch events/steps are not rendered as navigable sub-agent rows.
- Existing workflow phase/log/validation/patch/error/result display remains unchanged.

## Risks and mitigations

- **Concurrent started-event writes:** `parallelAgents(...)` can call `onTaskCreated` concurrently. Mitigate by serializing `sequence.next()` + `appendEvent(...)` with `AsyncMutex`, and test strict sequence ordering.
- **Duplicate started events on resume:** Crash recovery can encounter already-started steps. Mitigate with exact `(stepId, taskId)` event existence checks before appending a defensive started event.
- **Retry row collapse:** Retries can reuse the same step id/input hash. Mitigate by keying task rows by `(stepId, taskId)`, not `(stepId, inputHash)`.
- **Patch misclassification:** Patch steps also carry task ids. Mitigate by creating visible live sub-agent rows only from `task` events emitted by agent launch paths; never create task rows directly from `run.steps`.
- **Navigation vs report expansion conflict:** Make navigation and report expansion separate sibling controls or otherwise avoid nested interactive elements; add interaction tests for both paths.
- **Stale child task ids after cleanup:** Active/running workflow children should still be present. For old completed rows whose child workspace was cleaned up, navigation may no-op; the report remains visible from persisted step result.

## Quality gates

1. **Backend gate:** Add started-event emission and WorkflowRunner tests for serial ordering, resume de-dupe, and retry identity before changing UI navigation.
2. **UI gate:** Add display-row coalescing and workflow-card tests for started rows, no duplicates, retries, patch separation, navigation, and report toggling.
3. **Targeted validation gate:** Run the workflow runner and workflow tool-call test files after backend/UI changes.
4. **Type gate:** Run `make typecheck` before dogfooding.
5. **Dogfood gate:** Capture screenshots and video through `agent-browser` against a `dev-server-sandbox` instance.
6. **Final gate:** Run `make static-check` and fix failures before claiming completion.

</details>

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$248.13`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=248.13 -->
