### PR TITLE
🤖 fix: render foreground workflows like backgrounded runs

### DIFF
--- a/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
@@ -1,6 +1,7 @@
-import type { ReactNode } from "react";
+import { useRef, useState, type ReactNode } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
+import type { WorkflowRunRecord } from "@/common/types/workflow";
 import { APIContext } from "@/browser/contexts/API";
 import { WorkflowRunToolCall } from "@/browser/features/Tools/WorkflowRunToolCall";
 import { lightweightMeta } from "@/browser/stories/meta.js";
@@ -103,6 +104,146 @@ export const CompletedDeepResearch: Story = {
         ],
         steps: [],
       },
+    },
+  },
+};
+
+const foregroundDiscoveryRun: WorkflowRunRecord = {
+  id: "wfr_story_foreground",
+  workspaceId: "workspace-1",
+  definition: {
+    name: "deep-research",
+    description: "Deep research",
+    scope: "built-in" as const,
+    executable: true,
+  },
+  definitionSource: "export default function workflow() { return null; }",
+  definitionHash: "sha256:story-foreground",
+  args: { topic: "workflow run cards" },
+  status: "running" as const,
+  createdAt: "2026-05-29T00:00:01.000Z",
+  updatedAt: "2026-05-29T00:00:02.000Z",
+  events: [
+    {
+      sequence: 1,
+      type: "status" as const,
+      at: "2026-05-29T00:00:01.000Z",
+      status: "running" as const,
+    },
+    { sequence: 2, type: "phase" as const, at: "2026-05-29T00:00:02.000Z", name: "scope" },
+  ],
+  steps: [],
+};
+
+const interruptedForegroundDiscoveryRun: WorkflowRunRecord = {
+  ...foregroundDiscoveryRun,
+  status: "interrupted" as const,
+  updatedAt: "2026-05-29T00:00:03.000Z",
+  events: [
+    ...foregroundDiscoveryRun.events,
+    {
+      sequence: 3,
+      type: "status" as const,
+      at: "2026-05-29T00:00:03.000Z",
+      status: "interrupted" as const,
+    },
+  ],
+};
+
+const resumedForegroundDiscoveryRun: WorkflowRunRecord = {
+  ...foregroundDiscoveryRun,
+  updatedAt: "2026-05-29T00:00:04.000Z",
+  events: [
+    ...interruptedForegroundDiscoveryRun.events,
+    {
+      sequence: 4,
+      type: "status" as const,
+      at: "2026-05-29T00:00:04.000Z",
+      status: "running" as const,
+    },
+  ],
+};
+
+function ForegroundWorkflowAPIProvider(props: { children: ReactNode }) {
+  const currentRunRef = useRef(foregroundDiscoveryRun);
+  const [, setRenderVersion] = useState(0);
+  const setCurrentRun = (run: WorkflowRunRecord) => {
+    currentRunRef.current = run;
+    setRenderVersion((version) => version + 1);
+  };
+
+  const foregroundWorkflowApi = {
+    workflows: {
+      listRuns: () => Promise.resolve([currentRunRef.current]),
+      getRun: () => Promise.resolve(currentRunRef.current),
+      interrupt: () => {
+        setCurrentRun(interruptedForegroundDiscoveryRun);
+        return Promise.resolve(interruptedForegroundDiscoveryRun);
+      },
+      resume: () => {
+        setCurrentRun(resumedForegroundDiscoveryRun);
+        return Promise.resolve({
+          runId: foregroundDiscoveryRun.id,
+          status: "running",
+          result: null,
+        });
+      },
+    },
+  };
+
+  return (
+    <APIContext.Provider
+      value={{
+        status: "connected",
+        api: foregroundWorkflowApi as never,
+        error: null,
+        authenticate: () => undefined,
+        retry: () => undefined,
+      }}
+    >
+      {props.children}
+    </APIContext.Provider>
+  );
+}
+
+export const RunningForegroundDiscovered: Story = {
+  render: (args) => (
+    <ForegroundWorkflowAPIProvider>
+      <WorkflowRunToolCall
+        {...args}
+        workspaceId="workspace-1"
+        startedAt={Date.parse("2026-05-29T00:00:00.500Z")}
+      />
+    </ForegroundWorkflowAPIProvider>
+  ),
+  args: {
+    args: {
+      name: "deep-research",
+      args: { topic: "workflow run cards" },
+      run_in_background: false,
+    },
+    status: "executing",
+  },
+};
+
+export const RunningBackgroundWithRun: Story = {
+  render: (args) => (
+    <ForegroundWorkflowAPIProvider>
+      <WorkflowRunToolCall {...args} />
+    </ForegroundWorkflowAPIProvider>
+  ),
+  args: {
+    args: {
+      name: "deep-research",
+      args: { topic: "workflow run cards" },
+      run_in_background: true,
+    },
+    status: "completed",
+    result: {
+      status: "running",
+      runId: "wfr_story_foreground",
+      result: null,
+      run: foregroundDiscoveryRun,
     },
   },
 };

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/require-await */
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalWindow } from "happy-dom";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { useEffect, type ReactNode } from "react";
@@ -342,6 +342,382 @@ describe("WorkflowRunToolCall", () => {
 
     fireEvent.click(view.getByLabelText("Hide report for task_live"));
     expect(view.container.textContent).not.toContain("Completed task body.");
+  });
+
+  test("renders executing foreground workflow status before the durable run is discovered", () => {
+    const view = render(
+      <ThemeProvider forcedTheme="dark">
+        <TooltipProvider>
+          <WorkflowRunToolCall
+            args={{
+              name: "deep-research",
+              args: { topic: "workflow cards" },
+              run_in_background: false,
+            }}
+            status="executing"
+          />
+        </TooltipProvider>
+      </ThemeProvider>
+    );
+
+    const workflowHeader = getWorkflowHeader(view);
+    expect(workflowHeader.textContent).toContain("executing");
+    expect(workflowHeader.textContent).not.toContain("pending");
+  });
+
+  test("discovers foreground workflow runs and renders live run details", async () => {
+    const staleRun = {
+      id: "wfr_stale",
+      workspaceId: "workspace-1",
+      definition: {
+        name: "deep-research",
+        description: "Deep research",
+        scope: "built-in" as const,
+        executable: true,
+      },
+      definitionSource: "export default function workflow() { return null; }",
+      definitionHash: "sha256:stale",
+      args: { topic: "workflow cards" },
+      status: "running" as const,
+      createdAt: "2026-05-28T00:00:00.000Z",
+      updatedAt: "2026-05-28T00:00:01.000Z",
+      events: [
+        { sequence: 1, type: "phase" as const, at: "2026-05-28T00:00:01.000Z", name: "stale" },
+      ],
+      steps: [],
+    };
+    const foregroundRun = {
+      ...staleRun,
+      id: "wfr_foreground",
+      definitionHash: "sha256:foreground",
+      createdAt: "2026-05-29T00:00:00.490Z",
+      updatedAt: "2026-05-29T00:00:02.000Z",
+      events: [
+        {
+          sequence: 1,
+          type: "status" as const,
+          at: "2026-05-29T00:00:01.000Z",
+          status: "running" as const,
+        },
+        { sequence: 2, type: "phase" as const, at: "2026-05-29T00:00:02.000Z", name: "scope" },
+      ],
+    };
+    const interruptedForegroundRun = {
+      ...foregroundRun,
+      status: "interrupted" as const,
+      updatedAt: "2026-05-29T00:00:03.000Z",
+      events: [
+        ...foregroundRun.events,
+        {
+          sequence: 3,
+          type: "status" as const,
+          at: "2026-05-29T00:00:03.000Z",
+          status: "interrupted" as const,
+        },
+      ],
+    };
+    const listRuns = mock(async () => [staleRun, foregroundRun]);
+    const getRun = mock(async () => foregroundRun);
+    const interrupt = mock(async (input: { workspaceId: string; runId: string }) => {
+      expect(input).toEqual({ workspaceId: "workspace-1", runId: "wfr_foreground" });
+      return interruptedForegroundRun;
+    });
+    const api = {
+      workflows: {
+        listRuns,
+        getRun,
+        interrupt,
+      },
+    };
+
+    const view = render(
+      <APIHarness client={api}>
+        <ThemeProvider forcedTheme="dark">
+          <TooltipProvider>
+            <WorkflowRunToolCall
+              args={{
+                name: "deep-research",
+                args: { topic: "workflow cards" },
+                run_in_background: false,
+              }}
+              status="executing"
+              workspaceId="workspace-1"
+              startedAt={Date.parse("2026-05-29T00:00:00.500Z")}
+            />
+          </TooltipProvider>
+        </ThemeProvider>
+      </APIHarness>
+    );
+
+    await waitFor(() => expect(view.getByText("wfr_foreground")).toBeTruthy());
+    expect(getWorkflowHeader(view).textContent).toContain("executing");
+    expect(view.queryByText("wfr_stale")).toBeNull();
+    expect(view.queryByText("stale")).toBeNull();
+    expect(view.getAllByText("built-in").length).toBeGreaterThan(0);
+    expect(view.getByText("Workflow events (1)")).toBeTruthy();
+    expect(view.getByText("scope")).toBeTruthy();
+    expect(listRuns).toHaveBeenCalledWith({ workspaceId: "workspace-1" });
+
+    fireEvent.click(view.getByRole("button", { name: "Interrupt workflow" }));
+
+    await waitFor(() => expect(interrupt).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(getWorkflowHeader(view).textContent).toContain("interrupted"));
+  });
+
+  test("does not attach ambiguous foreground workflow run matches", async () => {
+    const firstRun = {
+      id: "wfr_first",
+      workspaceId: "workspace-1",
+      definition: {
+        name: "deep-research",
+        description: "Deep research",
+        scope: "built-in" as const,
+        executable: true,
+      },
+      definitionSource: "export default function workflow() { return null; }",
+      definitionHash: "sha256:first",
+      args: { topic: "workflow cards" },
+      status: "running" as const,
+      createdAt: "2026-05-29T00:00:01.000Z",
+      updatedAt: "2026-05-29T00:00:02.000Z",
+      events: [
+        { sequence: 1, type: "phase" as const, at: "2026-05-29T00:00:02.000Z", name: "first" },
+      ],
+      steps: [],
+    };
+    const secondRun = {
+      ...firstRun,
+      id: "wfr_second",
+      definitionHash: "sha256:second",
+      updatedAt: "2026-05-29T00:00:03.000Z",
+      events: [
+        { sequence: 1, type: "phase" as const, at: "2026-05-29T00:00:03.000Z", name: "second" },
+      ],
+    };
+    const listRuns = mock(async () => [firstRun, secondRun]);
+    const getRun = mock(async () => secondRun);
+    const api = {
+      workflows: {
+        listRuns,
+        getRun,
+      },
+    };
+
+    const view = render(
+      <APIHarness client={api}>
+        <ThemeProvider forcedTheme="dark">
+          <TooltipProvider>
+            <WorkflowRunToolCall
+              args={{
+                name: "deep-research",
+                args: { topic: "workflow cards" },
+                run_in_background: false,
+              }}
+              status="executing"
+              workspaceId="workspace-1"
+              startedAt={Date.parse("2026-05-29T00:00:00.500Z")}
+            />
+          </TooltipProvider>
+        </ThemeProvider>
+      </APIHarness>
+    );
+
+    await waitFor(() => expect(listRuns).toHaveBeenCalledWith({ workspaceId: "workspace-1" }));
+    expect(getWorkflowHeader(view).textContent).toContain("executing");
+    expect(view.queryByText("wfr_first")).toBeNull();
+    expect(view.queryByText("wfr_second")).toBeNull();
+    expect(view.queryByText("first")).toBeNull();
+    expect(view.queryByText("second")).toBeNull();
+    expect(view.queryByRole("button", { name: "Interrupt workflow" })).toBeNull();
+    expect(getRun).not.toHaveBeenCalled();
+  });
+
+  test("keeps the newest workflow refresh snapshot when polls resolve out of order", async () => {
+    const originalSetInterval = globalThis.window.setInterval;
+    const originalClearInterval = globalThis.window.clearInterval;
+    globalThis.window.setInterval = ((handler: TimerHandler) => {
+      if (typeof handler === "function") {
+        const callback = handler as () => void;
+        queueMicrotask(callback);
+      }
+      return 1;
+    }) as typeof globalThis.window.setInterval;
+    globalThis.window.clearInterval = (() => undefined) as typeof globalThis.window.clearInterval;
+
+    try {
+      const runningRun = {
+        id: "wfr_ordered",
+        workspaceId: "workspace-1",
+        definition: {
+          name: "deep-research",
+          description: "Deep research",
+          scope: "built-in" as const,
+          executable: true,
+        },
+        definitionSource: "export default function workflow() { return null; }",
+        definitionHash: "sha256:ordered",
+        args: { topic: "workflow cards" },
+        status: "running" as const,
+        createdAt: "2026-05-29T00:00:00.000Z",
+        updatedAt: "2026-05-29T00:00:01.000Z",
+        events: [
+          { sequence: 1, type: "phase" as const, at: "2026-05-29T00:00:01.000Z", name: "initial" },
+        ],
+        steps: [],
+      };
+      const olderRun = {
+        ...runningRun,
+        updatedAt: "2026-05-29T00:00:03.000Z",
+        events: [
+          { sequence: 2, type: "phase" as const, at: "2026-05-29T00:00:03.000Z", name: "older" },
+        ],
+      };
+      const newerRun = {
+        ...runningRun,
+        updatedAt: "2026-05-29T00:00:03.000Z",
+        events: [
+          { sequence: 3, type: "phase" as const, at: "2026-05-29T00:00:03.000Z", name: "newer" },
+        ],
+      };
+      const refreshes: Array<(run: typeof runningRun) => void> = [];
+      const api = {
+        workflows: {
+          getRun: mock(
+            async () =>
+              await new Promise<typeof runningRun>((resolve) => {
+                refreshes.push(resolve);
+              })
+          ),
+        },
+      };
+
+      const view = render(
+        <APIHarness client={api}>
+          <ThemeProvider forcedTheme="dark">
+            <TooltipProvider>
+              <WorkflowRunToolCall
+                args={{
+                  name: "deep-research",
+                  args: { topic: "workflow cards" },
+                  run_in_background: true,
+                }}
+                status="completed"
+                result={{ status: "running", runId: "wfr_ordered", result: null, run: runningRun }}
+              />
+            </TooltipProvider>
+          </ThemeProvider>
+        </APIHarness>
+      );
+
+      await waitFor(() => expect(refreshes.length).toBeGreaterThanOrEqual(2));
+      refreshes[1]?.(newerRun);
+      await waitFor(() => expect(view.getByText("newer")).toBeTruthy());
+
+      refreshes[0]?.(olderRun);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(view.getByText("newer")).toBeTruthy();
+      expect(view.queryByText("older")).toBeNull();
+    } finally {
+      globalThis.window.setInterval = originalSetInterval;
+      globalThis.window.clearInterval = originalClearInterval;
+    }
+  });
+
+  test("keeps newer poll snapshots when an older action response resolves later", async () => {
+    const runningRun = {
+      id: "wfr_action_ordered",
+      workspaceId: "workspace-1",
+      definition: {
+        name: "deep-research",
+        description: "Deep research",
+        scope: "built-in" as const,
+        executable: true,
+      },
+      definitionSource: "export default function workflow() { return null; }",
+      definitionHash: "sha256:action-ordered",
+      args: { topic: "workflow cards" },
+      status: "running" as const,
+      createdAt: "2026-05-29T00:00:00.000Z",
+      updatedAt: "2026-05-29T00:00:01.000Z",
+      events: [
+        { sequence: 1, type: "phase" as const, at: "2026-05-29T00:00:01.000Z", name: "initial" },
+      ],
+      steps: [],
+    };
+    const olderRun = {
+      ...runningRun,
+      status: "interrupted" as const,
+      updatedAt: "2026-05-29T00:00:02.000Z",
+      events: [
+        { sequence: 2, type: "phase" as const, at: "2026-05-29T00:00:02.000Z", name: "older" },
+      ],
+    };
+    const newerRun = {
+      ...runningRun,
+      updatedAt: "2026-05-29T00:00:03.000Z",
+      events: [
+        { sequence: 3, type: "phase" as const, at: "2026-05-29T00:00:03.000Z", name: "newer" },
+      ],
+    };
+    const refreshes: Array<(run: typeof runningRun) => void> = [];
+    const pendingInterrupt: { resolve?: (run: typeof olderRun) => void } = {};
+    const api = {
+      workflows: {
+        getRun: mock(
+          async () =>
+            await new Promise<typeof runningRun>((resolve) => {
+              refreshes.push(resolve);
+            })
+        ),
+        interrupt: mock(
+          async () =>
+            await new Promise<typeof olderRun>((resolve) => {
+              pendingInterrupt.resolve = resolve;
+            })
+        ),
+      },
+    };
+
+    const view = render(
+      <APIHarness client={api}>
+        <ThemeProvider forcedTheme="dark">
+          <TooltipProvider>
+            <WorkflowRunToolCall
+              args={{
+                name: "deep-research",
+                args: { topic: "workflow cards" },
+                run_in_background: true,
+              }}
+              status="completed"
+              result={{
+                status: "running",
+                runId: "wfr_action_ordered",
+                result: null,
+                run: runningRun,
+              }}
+            />
+          </TooltipProvider>
+        </ThemeProvider>
+      </APIHarness>
+    );
+
+    await waitFor(() => expect(refreshes.length).toBe(1));
+    fireEvent.click(view.getByText("Interrupt workflow"));
+    await waitFor(() => expect(pendingInterrupt.resolve).toBeDefined());
+
+    refreshes[0]?.(newerRun);
+    await waitFor(() => expect(view.getByText("newer")).toBeTruthy());
+
+    const completeInterrupt = pendingInterrupt.resolve;
+    if (completeInterrupt == null) {
+      throw new Error("Expected interrupt to be pending");
+    }
+    completeInterrupt(olderRun);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(view.getByText("newer")).toBeTruthy();
+    expect(view.queryByText("older")).toBeNull();
   });
 
   test("refreshes a running workflow from the API and shows the completed result", async () => {

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -53,6 +53,8 @@ interface WorkflowRunToolCallProps {
   args: WorkflowRunToolArgs;
   result?: WorkflowRunToolResult;
   status?: ToolStatus;
+  workspaceId?: string;
+  startedAt?: number;
 }
 
 type WorkflowRunAction = "interrupt" | "resume";
@@ -84,10 +86,7 @@ async function updateWorkflowRunFromAction(input: {
       input.setResumingRunId(input.runId);
     }
     if ("id" in nextRun) {
-      input.setRefreshedRun(nextRun);
-      if (nextRun.status !== "interrupted") {
-        input.setResumingRunId(null);
-      }
+      input.setRefreshedRun((current) => getNewestWorkflowRunSnapshot(current, nextRun));
       return;
     }
     const refreshed = await input.api.workflows.getRun({
@@ -95,10 +94,7 @@ async function updateWorkflowRunFromAction(input: {
       runId: input.runId,
     });
     if (refreshed != null) {
-      input.setRefreshedRun(refreshed);
-      if (refreshed.status !== "interrupted") {
-        input.setResumingRunId(null);
-      }
+      input.setRefreshedRun((current) => getNewestWorkflowRunSnapshot(current, refreshed));
     }
   } catch (error) {
     if (input.action === "resume" && !resumeRequestAccepted) {
@@ -479,6 +475,115 @@ const AUTO_COLLAPSE_WORKFLOW_STATUSES = new Set(["completed"]);
 
 const REFRESHING_WORKFLOW_STATUSES = new Set(["pending", "running", "backgrounded"]);
 
+const FOREGROUND_WORKFLOW_DISCOVERY_SKEW_MS = 1_000;
+
+const DISCOVERABLE_FOREGROUND_WORKFLOW_STATUSES = new Set(["pending", "running", "backgrounded"]);
+
+function getWorkflowRunTimestamp(value: string): number | null {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function stringifyWorkflowArgs(value: unknown): string | null {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return null;
+  }
+}
+
+function workflowArgsEqual(left: unknown, right: unknown): boolean {
+  const leftJson = stringifyWorkflowArgs(left);
+  const rightJson = stringifyWorkflowArgs(right);
+  return leftJson != null && rightJson != null && leftJson === rightJson;
+}
+
+function isFreshEnoughForToolCall(run: WorkflowRunRecord, startedAt: number | undefined): boolean {
+  if (startedAt == null) {
+    return true;
+  }
+  const createdAt = getWorkflowRunTimestamp(run.createdAt);
+  if (createdAt == null) {
+    return true;
+  }
+  // Tool-call timestamps are monotonic stream timestamps; run.createdAt is workflow-service wall
+  // time. Allow a small skew for same-tick creation without accepting clearly stale runs.
+  return createdAt >= startedAt - FOREGROUND_WORKFLOW_DISCOVERY_SKEW_MS;
+}
+
+function getLatestWorkflowEventSequence(run: WorkflowRunRecord): number {
+  return run.events.reduce((maxSequence, event) => Math.max(maxSequence, event.sequence), 0);
+}
+
+function compareWorkflowRunSnapshots(left: WorkflowRunRecord, right: WorkflowRunRecord): number {
+  const leftUpdatedAt = getWorkflowRunTimestamp(left.updatedAt);
+  const rightUpdatedAt = getWorkflowRunTimestamp(right.updatedAt);
+  if (leftUpdatedAt != null && rightUpdatedAt != null && leftUpdatedAt !== rightUpdatedAt) {
+    return leftUpdatedAt - rightUpdatedAt;
+  }
+  if (leftUpdatedAt != null && rightUpdatedAt == null) {
+    return 1;
+  }
+  if (leftUpdatedAt == null && rightUpdatedAt != null) {
+    return -1;
+  }
+  return getLatestWorkflowEventSequence(left) - getLatestWorkflowEventSequence(right);
+}
+
+function getNewestWorkflowRunSnapshot(
+  current: WorkflowRunRecord | null,
+  next: WorkflowRunRecord
+): WorkflowRunRecord {
+  if (current == null || current.id !== next.id) {
+    return next;
+  }
+  return compareWorkflowRunSnapshots(current, next) > 0 ? current : next;
+}
+
+function findForegroundWorkflowRun(input: {
+  runs: readonly WorkflowRunRecord[];
+  args: WorkflowRunToolArgs;
+  startedAt?: number;
+}): WorkflowRunRecord | null {
+  assert(input.args.name.length > 0, "findForegroundWorkflowRun requires a workflow name");
+  const invocationArgs = input.args.args ?? {};
+  const candidates = input.runs.filter(
+    (run) =>
+      run.definition.name === input.args.name &&
+      DISCOVERABLE_FOREGROUND_WORKFLOW_STATUSES.has(run.status) &&
+      workflowArgsEqual(run.args ?? {}, invocationArgs) &&
+      isFreshEnoughForToolCall(run, input.startedAt)
+  );
+  if (candidates.length !== 1) {
+    return null;
+  }
+  return candidates[0] ?? null;
+}
+
+function selectWorkflowRunSnapshot(input: {
+  runId?: string;
+  baseRun?: WorkflowRunRecord;
+  refreshedRun: WorkflowRunRecord | null;
+}): { runId?: string; run?: WorkflowRunRecord } {
+  const runId = input.runId ?? input.baseRun?.id ?? input.refreshedRun?.id;
+  if (runId == null) {
+    return {};
+  }
+  if (input.refreshedRun?.id !== runId) {
+    return input.baseRun == null ? { runId } : { runId, run: input.baseRun };
+  }
+  if (input.baseRun?.id !== runId) {
+    return { runId, run: input.refreshedRun };
+  }
+  return {
+    runId,
+    run:
+      compareWorkflowRunSnapshots(input.refreshedRun, input.baseRun) >= 0
+        ? input.refreshedRun
+        : input.baseRun,
+  };
+}
+
 function getLatestResultEvent(run: WorkflowRunRecord | null | undefined): unknown {
   return run?.events.findLast((event) => event.type === "result")?.result;
 }
@@ -488,7 +593,7 @@ function shouldRefreshWorkflow(status: string): boolean {
 }
 
 function toToolStatus(status: string): ToolStatus {
-  if (status === "running") {
+  if (status === "running" || status === "executing") {
     return "executing";
   }
   if (
@@ -507,6 +612,8 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
   args,
   result,
   status = "pending",
+  workspaceId,
+  startedAt,
 }) => {
   const apiState = useContext(APIContext);
   const commandRegistry = useOptionalCommandRegistry();
@@ -519,8 +626,13 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
   const [refreshedRun, setRefreshedRun] = useState<WorkflowRunRecord | null>(null);
   const [resumingRunId, setResumingRunId] = useState<string | null>(null);
   const baseRun = successResult?.run;
-  const runId = successResult?.runId ?? baseRun?.id;
-  const run = refreshedRun?.id === runId ? refreshedRun : baseRun;
+  const selectedRun = selectWorkflowRunSnapshot({
+    runId: successResult?.runId,
+    baseRun,
+    refreshedRun,
+  });
+  const runId = selectedRun.runId;
+  const run = selectedRun.run;
   const displayStatus = run?.status ?? successResult?.status ?? status;
   const resultValue = successResult?.result ?? getLatestResultEvent(run);
   const reportMarkdown = getReportMarkdown(resultValue);
@@ -555,14 +667,31 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
     useState<WorkflowPromotionTarget | null>(null);
   const savingPromotionTargetRef = useRef<WorkflowPromotionTarget | null>(null);
   const displayDefinition = promotedDefinition ?? run?.definition;
+  // A uniquely discovered foreground run is actionable before the blocking tool call returns.
+  const discoveredForegroundRunConfirmed =
+    status === "executing" &&
+    args.run_in_background !== true &&
+    workspaceId != null &&
+    refreshedRun != null &&
+    runId === refreshedRun.id &&
+    refreshedRun.workspaceId === workspaceId;
+  const runIdentityConfirmed =
+    successResult?.runId != null || baseRun?.id != null || discoveredForegroundRunConfirmed;
   const canInterrupt =
+    runIdentityConfirmed &&
     apiState?.api != null &&
     run?.workspaceId != null &&
     (displayStatus === "running" || displayStatus === "backgrounded");
   const canResume =
-    apiState?.api != null && run?.workspaceId != null && displayStatus === "interrupted";
+    runIdentityConfirmed &&
+    apiState?.api != null &&
+    run?.workspaceId != null &&
+    displayStatus === "interrupted";
   const canPromote =
-    run?.workspaceId != null && run.definition.scope === "scratch" && promotedDefinition == null;
+    runIdentityConfirmed &&
+    run?.workspaceId != null &&
+    run.definition.scope === "scratch" &&
+    promotedDefinition == null;
   const canSavePromotedWorkflow =
     apiState?.api != null &&
     runId != null &&
@@ -627,6 +756,12 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
         setSavingPromotionTarget(null);
       });
   };
+
+  useEffect(() => {
+    if (resumingRunId === runId && run?.status !== "interrupted") {
+      setResumingRunId(null);
+    }
+  }, [resumingRunId, run?.status, runId]);
 
   const saveScratchWorkflowRef = useRef(saveScratchWorkflow);
   saveScratchWorkflowRef.current = saveScratchWorkflow;
@@ -723,6 +858,40 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
   useEffect(() => {
     if (
       apiState?.api == null ||
+      workspaceId == null ||
+      runId != null ||
+      status !== "executing" ||
+      args.run_in_background === true
+    ) {
+      return;
+    }
+
+    let ignore = false;
+    const discover = async () => {
+      try {
+        const runs = await apiState.api.workflows.listRuns({ workspaceId });
+        const foregroundRun = findForegroundWorkflowRun({ runs, args, startedAt });
+        if (!ignore && foregroundRun != null) {
+          setRefreshedRun((current) => getNewestWorkflowRunSnapshot(current, foregroundRun));
+        }
+      } catch (error) {
+        console.error("Failed to discover foreground workflow run:", error);
+      }
+    };
+
+    void discover();
+    const interval = window.setInterval(() => {
+      void discover();
+    }, 2_000);
+    return () => {
+      ignore = true;
+      window.clearInterval(interval);
+    };
+  }, [apiState?.api, args, runId, startedAt, status, workspaceId]);
+
+  useEffect(() => {
+    if (
+      apiState?.api == null ||
       runId == null ||
       run?.workspaceId == null ||
       (!shouldRefreshWorkflow(displayStatus) && resumingRunId !== runId)
@@ -738,7 +907,7 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
           runId,
         });
         if (!ignore && nextRun != null) {
-          setRefreshedRun(nextRun);
+          setRefreshedRun((current) => getNewestWorkflowRunSnapshot(current, nextRun));
           if (nextRun.status !== "interrupted") {
             setResumingRunId(null);
           }


### PR DESCRIPTION
## Summary

Render foreground workflow runs with the same live workflow details as backgrounded runs while they are still executing.

## Background

Foreground workflow tool calls block until completion, so the initial tool message does not include a durable `runId`. That left the UI showing only the raw arguments panel during execution. This change lets the card safely discover the matching active workflow run and render definition/details/events while the foreground tool is still running.

## Implementation

- Discover executing foreground workflow runs by matching workspace, workflow name, arguments, active status, and a freshness window.
- Refuse ambiguous same-name/same-args matches so mutating actions do not bind to the wrong run.
- Merge refreshed workflow snapshots monotonically by `updatedAt`, with event sequence as the same-millisecond tie-breaker.
- Gate mutating actions until run identity is confirmed, and keep resume state aligned with the displayed run status.
- Make the Storybook workflow API mock stateful so interrupt/resume can be dogfooded locally.

## Validation

- `make static-check`
- `bun test src/browser/features/Tools/WorkflowRunToolCall.test.tsx`
- `bun run prettier --check src/browser/features/Tools/WorkflowRunToolCall.tsx src/browser/features/Tools/WorkflowRunToolCall.test.tsx src/browser/features/Tools/WorkflowRunToolCall.stories.tsx`
- `bun x eslint src/browser/features/Tools/WorkflowRunToolCall.tsx src/browser/features/Tools/WorkflowRunToolCall.test.tsx src/browser/features/Tools/WorkflowRunToolCall.stories.tsx`
- `make typecheck`
- Dogfooded in Storybook with `agent-browser`: discovered foreground run rendering, interrupt transition, and resume transition. Screenshots/video were captured locally for review evidence.

## Risks

Moderate UI-state risk around workflow cards only. The discovery path is intentionally conservative: it declines ambiguous matches, filters stale runs, and only enables mutations for confirmed run IDs.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$109.15`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=109.15 -->
