### PR TITLE
🤖 fix: stabilize hydration layout slots

### DIFF
--- a/src/browser/components/AgentsInitBanner/AgentsInitBanner.tsx
+++ b/src/browser/components/AgentsInitBanner/AgentsInitBanner.tsx
@@ -1,5 +1,8 @@
 import { Bot, X } from "lucide-react";
 
+const AGENTS_INIT_BANNER_FRAME_CLASS =
+  "bg-bg-dark border-border-medium flex min-h-[4.5rem] items-center gap-3 rounded-lg border px-4 py-3";
+
 interface AgentsInitBannerProps {
   onRunInit: () => void | Promise<void>;
   onDismiss: () => void;
@@ -11,10 +14,7 @@ interface AgentsInitBannerProps {
  */
 export function AgentsInitBanner(props: AgentsInitBannerProps) {
   return (
-    <div
-      className="bg-bg-dark border-border-medium flex items-center gap-3 rounded-lg border px-4 py-3"
-      data-testid="agents-init-banner"
-    >
+    <div className={AGENTS_INIT_BANNER_FRAME_CLASS} data-testid="agents-init-banner">
       <Bot className="text-muted-foreground h-5 w-5 shrink-0" />
       <div className="flex flex-1 flex-col gap-0.5">
         <span className="text-foreground text-sm font-medium">
@@ -46,6 +46,20 @@ export function AgentsInitBanner(props: AgentsInitBannerProps) {
           <X className="h-4 w-4" />
         </button>
       </div>
+    </div>
+  );
+}
+
+export function AgentsInitBannerPlaceholder() {
+  return (
+    <div
+      // Render the real banner invisibly so future copy or wrapping changes reserve
+      // the exact same responsive height while provider config hydrates.
+      aria-hidden="true"
+      className="invisible"
+      data-testid="agents-init-banner-placeholder"
+    >
+      <AgentsInitBanner onRunInit={() => undefined} onDismiss={() => undefined} />
     </div>
   );
 }

--- a/src/browser/components/AppLoader/AppLoader.auth.test.tsx
+++ b/src/browser/components/AppLoader/AppLoader.auth.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, render } from "@testing-library/react";
 import { useTheme } from "../../contexts/ThemeContext";
+import type { APIClient, UseAPIResult } from "../../contexts/API";
 import { installDom } from "../../../../tests/ui/dom";
 
 let cleanupDom: (() => void) | null = null;
@@ -27,37 +28,56 @@ void mock.module("lottie-react", () => ({
   default: () => <div data-testid="LottieMock" />,
 }));
 
-void mock.module("@/browser/contexts/API", () => ({
-  APIProvider: (props: { children: React.ReactNode }) => props.children,
-  useAPI: () => {
-    if (apiStatus === "auth_required") {
-      return {
-        api: null,
-        status: "auth_required" as const,
-        error: apiError,
-        authenticate: () => undefined,
-        retry: () => undefined,
-      };
-    }
-
-    if (apiStatus === "error") {
-      return {
-        api: null,
-        status: "error" as const,
-        error: apiError ?? "Connection error",
-        authenticate: () => undefined,
-        retry: () => undefined,
-      };
-    }
-
+function getMockAPIContextValue(): UseAPIResult {
+  if (apiStatus === "auth_required") {
     return {
       api: null,
-      status: "connecting" as const,
-      error: null,
+      status: "auth_required" as const,
+      error: apiError,
       authenticate: () => undefined,
       retry: () => undefined,
     };
+  }
+
+  if (apiStatus === "error") {
+    return {
+      api: null,
+      status: "error" as const,
+      error: apiError ?? "Connection error",
+      authenticate: () => undefined,
+      retry: () => undefined,
+    };
+  }
+
+  return {
+    api: null,
+    status: "connecting" as const,
+    error: null,
+    authenticate: () => undefined,
+    retry: () => undefined,
+  };
+}
+
+const MockAPIContext = React.createContext<UseAPIResult | null>(null);
+let injectedAPIValue: UseAPIResult | null = null;
+
+void mock.module("@/browser/contexts/API", () => ({
+  APIContext: MockAPIContext,
+  APIProvider: (props: { children: React.ReactNode; client?: APIClient }) => {
+    const value = props.client
+      ? {
+          api: props.client,
+          status: "connected" as const,
+          error: null,
+          authenticate: () => undefined,
+          retry: () => undefined,
+        }
+      : getMockAPIContextValue();
+    injectedAPIValue = value;
+    return <MockAPIContext.Provider value={value}>{props.children}</MockAPIContext.Provider>;
   },
+  useAPI: () => injectedAPIValue ?? getMockAPIContextValue(),
+  useOptionalAPI: () => injectedAPIValue ?? getMockAPIContextValue(),
 }));
 
 void mock.module("@/browser/components/LoadingScreen/LoadingScreen", () => ({

--- a/src/browser/components/ConfiguredProvidersBar/ConfiguredProvidersBar.tsx
+++ b/src/browser/components/ConfiguredProvidersBar/ConfiguredProvidersBar.tsx
@@ -1,11 +1,27 @@
 import { Check, Settings } from "lucide-react";
 import type { ProvidersConfigMap } from "@/common/orpc/types";
+import { Skeleton } from "../Skeleton/Skeleton";
 import { formatProviderDisplayName } from "@/common/utils/providers/customProviders";
 import { usePolicy } from "@/browser/contexts/PolicyContext";
 import { getAllowedProvidersForUi } from "@/browser/utils/policyUi";
 import { hasProviderIcon, ProviderIcon } from "../ProviderIcon/ProviderIcon";
 import { useSettings } from "@/browser/contexts/SettingsContext";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../Tooltip/Tooltip";
+
+const CONFIGURED_PROVIDERS_BAR_FRAME_CLASS = "flex h-9 items-center justify-center gap-2 text-sm";
+
+export function ConfiguredProvidersBarSkeleton() {
+  return (
+    <div
+      // User-reported hydration flash: keep this loading slot height tied to
+      // ConfiguredProvidersBar so ProjectPage cannot jump when provider config resolves.
+      className={CONFIGURED_PROVIDERS_BAR_FRAME_CLASS}
+      data-component="ConfiguredProvidersBarSkeleton"
+    >
+      <Skeleton className="h-6 w-32" />
+    </div>
+  );
+}
 
 interface ConfiguredProvidersBarProps {
   providersConfig: ProvidersConfigMap;
@@ -35,7 +51,10 @@ export function ConfiguredProvidersBar(props: ConfiguredProvidersBarProps) {
     .join(", ");
 
   return (
-    <div className="text-muted-foreground flex items-center justify-center gap-2 py-1.5 text-sm">
+    <div
+      className={`text-muted-foreground ${CONFIGURED_PROVIDERS_BAR_FRAME_CLASS}`}
+      data-component="ConfiguredProvidersBar"
+    >
       <Tooltip>
         <TooltipTrigger asChild>
           <span className="border-border/50 hover:border-border inline-flex items-center gap-1.5 rounded border px-2 py-1 text-sm transition-colors">

--- a/src/browser/components/ProjectPage/ProjectPage.autofocus.test.tsx
+++ b/src/browser/components/ProjectPage/ProjectPage.autofocus.test.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { createContext, useEffect, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { requireTestModule } from "@/browser/testUtils";
 import { RouterProvider } from "@/browser/contexts/RouterContext";
@@ -23,14 +23,18 @@ function registerProjectPageMocks() {
     default: () => <div data-testid="LottieMock" />,
   }));
 
+  const apiContextValue = {
+    api: null,
+    status: "connecting" as const,
+    error: null,
+    authenticate: () => undefined,
+    retry: () => undefined,
+  };
   void mock.module("@/browser/contexts/API", () => ({
-    useAPI: () => ({
-      api: null,
-      status: "connecting" as const,
-      error: null,
-      authenticate: () => undefined,
-      retry: () => undefined,
-    }),
+    APIContext: createContext(apiContextValue),
+    APIProvider: (props: { children: ReactNode }) => props.children,
+    useAPI: () => apiContextValue,
+    useOptionalAPI: () => apiContextValue,
   }));
 
   // Mock useProvidersConfig to return a configured provider so ChatInput renders
@@ -43,13 +47,21 @@ function registerProjectPageMocks() {
   }));
 
   // Mock ConfiguredProvidersBar to avoid tooltip/context dependencies
+  const providerBarFrameClass = "flex h-9 items-center justify-center gap-2 text-sm";
   void mock.module("@/browser/components/ConfiguredProvidersBar/ConfiguredProvidersBar", () => ({
-    ConfiguredProvidersBar: () => <div data-testid="ConfiguredProvidersBarMock" />,
+    CONFIGURED_PROVIDERS_BAR_FRAME_CLASS: providerBarFrameClass,
+    ConfiguredProvidersBar: () => (
+      <div className={providerBarFrameClass} data-component="ConfiguredProvidersBar" />
+    ),
+    ConfiguredProvidersBarSkeleton: () => (
+      <div className={providerBarFrameClass} data-component="ConfiguredProvidersBarSkeleton" />
+    ),
   }));
 
   // Mock ProjectContext to provide the minimal routing/project surface used by the
   // real WorkspaceProvider/AgentProvider stack without wiring the full app shell.
   void mock.module("@/browser/contexts/ProjectContext", () => ({
+    ProjectProvider: (props: { children: ReactNode }) => props.children,
     useProjectContext: () => ({
       userProjects: new Map(),
       systemProjectPath: null,
@@ -91,6 +103,8 @@ function registerProjectPageMocks() {
   // Mock ChatInput to simulate the old (buggy) behavior where onReady can fire again
   // on unrelated re-renders (e.g. workspace list updates).
   void mock.module("@/browser/features/ChatInput/index", () => ({
+    CREATION_CHAT_INPUT_SECTION_FRAME_CLASS:
+      "bg-surface-primary border-border-light min-h-56 w-full max-w-3xl rounded-lg border px-6 py-5 shadow-lg",
     ChatInput: (props: {
       onReady?: (api: {
         focus: () => void;
@@ -165,8 +179,8 @@ describe("ProjectPage", () => {
       </RouterProvider>
     );
 
-    await waitFor(() => expect(readyCalls).toBe(1));
     await waitFor(() => expect(focusMock).toHaveBeenCalledTimes(1));
+    const readyCallsAfterInitialHydration = readyCalls;
 
     // Simulate an unrelated App re-render that changes an inline callback identity.
     rerender(
@@ -179,7 +193,7 @@ describe("ProjectPage", () => {
       </RouterProvider>
     );
 
-    await waitFor(() => expect(readyCalls).toBe(2));
+    await waitFor(() => expect(readyCalls).toBeGreaterThan(readyCallsAfterInitialHydration));
 
     // Focus should not be re-triggered (would move caret to end).
     expect(focusMock).toHaveBeenCalledTimes(1);

--- a/src/browser/components/ProjectPage/ProjectPage.tsx
+++ b/src/browser/components/ProjectPage/ProjectPage.tsx
@@ -4,18 +4,28 @@ import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import { cn } from "@/common/lib/utils";
 import { AgentProvider } from "@/browser/contexts/AgentContext";
 import { ThinkingProvider } from "@/browser/contexts/ThinkingContext";
-import { ChatInput } from "@/browser/features/ChatInput/index";
+import {
+  ChatInput,
+  CREATION_CHAT_INPUT_SECTION_FRAME_CLASS,
+} from "@/browser/features/ChatInput/index";
 import type { ChatInputAPI, WorkspaceCreatedOptions } from "@/browser/features/ChatInput/types";
 import { ProjectMCPOverview } from "../ProjectMCPOverview/ProjectMCPOverview";
 import { ArchivedWorkspaces } from "../ArchivedWorkspaces/ArchivedWorkspaces";
 import { useAPI } from "@/browser/contexts/API";
 import { isWorkspaceArchived } from "@/common/utils/archive";
 import { GitInitBanner } from "../GitInitBanner/GitInitBanner";
-import { ConfiguredProvidersBar } from "../ConfiguredProvidersBar/ConfiguredProvidersBar";
+import {
+  ConfiguredProvidersBar,
+  ConfiguredProvidersBarSkeleton,
+} from "../ConfiguredProvidersBar/ConfiguredProvidersBar";
 import { ConfigureProvidersPrompt } from "../ConfigureProvidersPrompt/ConfigureProvidersPrompt";
+import { Skeleton } from "../Skeleton/Skeleton";
 import { useProvidersConfig } from "@/browser/hooks/useProvidersConfig";
 import type { ProvidersConfigMap } from "@/common/orpc/types";
-import { AgentsInitBanner } from "../AgentsInitBanner/AgentsInitBanner";
+import {
+  AgentsInitBanner,
+  AgentsInitBannerPlaceholder,
+} from "../AgentsInitBanner/AgentsInitBanner";
 import {
   usePersistedState,
   updatePersistedState,
@@ -25,13 +35,13 @@ import {
   getAgentIdKey,
   getAgentsInitNudgeKey,
   getArchivedWorkspacesKey,
+  HAS_CONFIGURED_PROVIDER_CACHE_KEY,
   getDraftScopeId,
   getInputKey,
   getPendingScopeId,
   getProjectScopeId,
 } from "@/common/constants/storage";
 import { Button } from "@/browser/components/Button/Button";
-import { Skeleton } from "@/browser/components/Skeleton/Skeleton";
 import { isDesktopMode } from "@/browser/hooks/useDesktopTitlebar";
 
 interface ProjectPageProps {
@@ -65,6 +75,40 @@ function hasConfiguredProvider(config: ProvidersConfigMap | null): boolean {
   return Object.values(config).some((provider) => provider?.isConfigured);
 }
 
+const PROJECT_CREATION_PROVIDER_GATE_CLASS = "flex min-h-[30rem] flex-col justify-end gap-4";
+
+function CreationChatInputSkeleton() {
+  return (
+    <div
+      // Mirrors the creation ChatInput frame while provider availability is still unknown.
+      // Showing an actual composer before we know providers exist causes a no-provider
+      // hydration swap to look like a layout flash.
+      aria-hidden="true"
+      className={CREATION_CHAT_INPUT_SECTION_FRAME_CLASS}
+      data-component="ChatInputSectionSkeleton"
+    >
+      <div className="flex flex-col gap-4">
+        <Skeleton className="h-7 w-56" />
+        <div className="flex flex-wrap items-end gap-x-3 gap-y-2">
+          <div className="flex min-w-40 flex-1 flex-col gap-1.5">
+            <Skeleton className="h-3.5 w-28" />
+            <Skeleton className="h-7 w-full" />
+          </div>
+          <div className="flex min-w-40 flex-1 flex-col gap-1.5">
+            <Skeleton className="h-3.5 w-24" />
+            <Skeleton className="h-7 w-full" />
+          </div>
+        </div>
+        <Skeleton className="h-28 w-full" />
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-7 w-40" />
+          <Skeleton className="h-8 w-8 rounded-full" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 /**
  * Project page shown when a project is selected but no workspace is active.
  * Combines workspace creation with archived workspaces view.
@@ -90,9 +134,19 @@ export const ProjectPage: React.FC<ProjectPageProps> = ({
     false,
     { listener: true }
   );
+  const [cachedHasProviders] = useState<boolean | null>(() =>
+    readPersistedState<boolean | null>(HAS_CONFIGURED_PROVIDER_CACHE_KEY, null)
+  );
   const { config: providersConfig, loading: providersLoading } = useProvidersConfig();
   const hasProviders = hasConfiguredProvider(providersConfig);
-  const shouldShowAgentsInitBanner = !providersLoading && hasProviders && showAgentsInitNudge;
+  const effectiveHasProviders = providersLoading ? cachedHasProviders : hasProviders;
+  const isProviderAvailabilityUnknown = effectiveHasProviders === null;
+  const shouldShowProviderPrompt = effectiveHasProviders === false;
+  const shouldRenderCreationChat = effectiveHasProviders === true;
+  const shouldReserveAgentsInitBanner =
+    showAgentsInitNudge && (providersLoading || shouldRenderCreationChat);
+  const shouldShowAgentsInitBanner =
+    !providersLoading && shouldRenderCreationChat && showAgentsInitNudge;
 
   // Git repository state for the banner
   const [branchesLoaded, setBranchesLoaded] = useState(false);
@@ -296,44 +350,56 @@ export const ProjectPage: React.FC<ProjectPageProps> = ({
                 {isNonGitRepo && (
                   <GitInitBanner projectPath={projectPath} onSuccess={handleGitInitSuccess} />
                 )}
-                {/* Show configure prompt when no providers, otherwise show ChatInput */}
-                {!providersLoading && !hasProviders ? (
-                  <ConfigureProvidersPrompt />
-                ) : (
-                  <>
-                    {shouldShowAgentsInitBanner && (
-                      <AgentsInitBanner
-                        onRunInit={handleRunAgentsInit}
-                        onDismiss={handleDismissAgentsInit}
-                      />
-                    )}
-                    {/* Configured providers bar - compact icon carousel */}
-                    {providersLoading ? (
-                      // Skeleton placeholder matching ConfiguredProvidersBar height
-                      <div className="flex items-center justify-center gap-2 py-1.5">
-                        <Skeleton className="h-7 w-32" />
-                      </div>
-                    ) : (
-                      hasProviders &&
-                      providersConfig && (
-                        <ConfiguredProvidersBar providersConfig={providersConfig} />
-                      )
-                    )}
-                    {/* ChatInput for workspace creation. */}
-                    <ChatInput
-                      // Key by project + draft so project navigation and draft switches both remount
-                      // creation-local state (including any in-flight creation overlays).
-                      key={`${projectPath}:${pendingDraftId ?? "__pending__"}`}
-                      variant="creation"
-                      projectPath={projectPath}
-                      projectName={projectName}
-                      pendingSubProjectPath={pendingSubProjectPath}
-                      pendingDraftId={pendingDraftId}
-                      onReady={handleChatReady}
-                      onWorkspaceCreated={onWorkspaceCreated}
-                    />
-                  </>
-                )}
+                <div
+                  // Keep the provider-dependent creation branch in a stable frame. The
+                  // budget covers the agents nudge + provider bar + initial composer;
+                  // shorter states bottom-align inside it instead of recentering the page.
+                  className={PROJECT_CREATION_PROVIDER_GATE_CLASS}
+                  data-component="ProjectCreationProviderGate"
+                >
+                  {/* Show configure prompt when no providers, otherwise show ChatInput. */}
+                  {shouldShowProviderPrompt ? (
+                    <ConfigureProvidersPrompt />
+                  ) : (
+                    <>
+                      {shouldReserveAgentsInitBanner &&
+                        (shouldShowAgentsInitBanner ? (
+                          <AgentsInitBanner
+                            onRunInit={handleRunAgentsInit}
+                            onDismiss={handleDismissAgentsInit}
+                          />
+                        ) : (
+                          <AgentsInitBannerPlaceholder />
+                        ))}
+                      {/* Configured providers bar - compact icon carousel */}
+                      {providersLoading ? (
+                        <ConfiguredProvidersBarSkeleton />
+                      ) : (
+                        hasProviders &&
+                        providersConfig && (
+                          <ConfiguredProvidersBar providersConfig={providersConfig} />
+                        )
+                      )}
+                      {/* ChatInput for workspace creation. */}
+                      {isProviderAvailabilityUnknown ? (
+                        <CreationChatInputSkeleton />
+                      ) : shouldRenderCreationChat ? (
+                        <ChatInput
+                          // Key by project + draft so project navigation and draft switches both remount
+                          // creation-local state (including any in-flight creation overlays).
+                          key={`${projectPath}:${pendingDraftId ?? "__pending__"}`}
+                          variant="creation"
+                          projectPath={projectPath}
+                          projectName={projectName}
+                          pendingSubProjectPath={pendingSubProjectPath}
+                          pendingDraftId={pendingDraftId}
+                          onReady={handleChatReady}
+                          onWorkspaceCreated={onWorkspaceCreated}
+                        />
+                      ) : null}
+                    </>
+                  )}
+                </div>
               </div>
             </div>
 

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -211,6 +211,9 @@ function replaceSuggestions(prev: SlashSuggestion[], next: SlashSuggestion[]): S
   return prev.length === 0 && next.length === 0 ? prev : next;
 }
 
+export const CREATION_CHAT_INPUT_SECTION_FRAME_CLASS =
+  "bg-surface-primary border-border-light min-h-56 w-full max-w-3xl rounded-lg border px-6 py-5 shadow-lg";
+
 const PDF_MEDIA_TYPE = "application/pdf";
 
 function getBaseMediaType(mediaType: string): string {
@@ -2964,11 +2967,12 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         className={cn(
           "relative flex flex-col gap-1",
           variant === "creation"
-            ? "bg-surface-primary w-full max-w-3xl rounded-lg border border-border-light px-6 py-5 shadow-lg"
+            ? CREATION_CHAT_INPUT_SECTION_FRAME_CLASS
             : `bg-surface-primary border-border-light px-4 
               pb-[max(8px,min(env(safe-area-inset-bottom,0px),40px))] 
               mb-[calc(-1*min(env(safe-area-inset-bottom,0px),40px))]`
         )}
+        data-chat-input-variant={variant}
         data-component="ChatInputSection"
         data-autofocus-state="done"
       >

--- a/src/browser/hooks/useProvidersConfig.test.ts
+++ b/src/browser/hooks/useProvidersConfig.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ProviderConfigInfo } from "@/common/orpc/types";
+import { getOptimisticConfiguredProvider } from "./useProvidersConfig";
+
+function providerConfig(overrides: Partial<ProviderConfigInfo> = {}): ProviderConfigInfo {
+  return {
+    apiKeySet: false,
+    isEnabled: true,
+    isConfigured: false,
+    ...overrides,
+  };
+}
+
+describe("getOptimisticConfiguredProvider", () => {
+  test("requires custom provider base URL even when auth is present", () => {
+    const withAuthOnly = getOptimisticConfiguredProvider(
+      "custom-openai-compatible",
+      providerConfig({
+        apiKeySet: true,
+        apiKeySource: "config",
+        providerType: "openai-compatible",
+        isCustom: true,
+      })
+    );
+
+    expect(withAuthOnly.isConfigured).toBe(false);
+
+    const withBaseUrl = getOptimisticConfiguredProvider(
+      "custom-openai-compatible",
+      providerConfig({
+        apiKeySet: true,
+        apiKeySource: "config",
+        baseUrl: "https://models.example.test/v1",
+        providerType: "openai-compatible",
+        isCustom: true,
+      })
+    );
+
+    expect(withBaseUrl.isConfigured).toBe(true);
+  });
+
+  test("mirrors Bedrock region-based configuredness instead of credential flags", () => {
+    const credentialsWithoutRegion = getOptimisticConfiguredProvider(
+      "bedrock",
+      providerConfig({
+        aws: {
+          bearerTokenSet: true,
+          accessKeyIdSet: true,
+          secretAccessKeySet: true,
+        },
+      })
+    );
+
+    expect(credentialsWithoutRegion.isConfigured).toBe(false);
+
+    const regionOnly = getOptimisticConfiguredProvider(
+      "bedrock",
+      providerConfig({
+        aws: {
+          region: "us-east-1",
+          bearerTokenSet: false,
+          accessKeyIdSet: false,
+          secretAccessKeySet: false,
+        },
+      })
+    );
+
+    expect(regionOnly.isConfigured).toBe(true);
+  });
+
+  test("keeps keyless local providers tied to explicit base URL or model config", () => {
+    const emptyOllama = getOptimisticConfiguredProvider("ollama", providerConfig());
+    expect(emptyOllama.isConfigured).toBe(false);
+
+    const withModel = getOptimisticConfiguredProvider(
+      "ollama",
+      providerConfig({ models: [{ id: "llama3.2" }] })
+    );
+    expect(withModel.isConfigured).toBe(true);
+  });
+});

--- a/src/browser/hooks/useProvidersConfig.ts
+++ b/src/browser/hooks/useProvidersConfig.ts
@@ -1,10 +1,65 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useAPI } from "@/browser/contexts/API";
+import { updatePersistedState } from "@/browser/hooks/usePersistedState";
+import { HAS_CONFIGURED_PROVIDER_CACHE_KEY } from "@/common/constants/storage";
 import type {
   ProviderConfigInfo,
   ProviderModelEntry,
   ProvidersConfigMap,
 } from "@/common/orpc/types";
+
+function hasConfiguredProvider(config: ProvidersConfigMap): boolean {
+  return Object.values(config).some((provider) => provider?.isConfigured);
+}
+
+function hasText(value: string | null | undefined): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function getOptimisticConfiguredProvider(
+  provider: string,
+  info: ProviderConfigInfo
+): ProviderConfigInfo {
+  const hasBaseUrl = hasText(info.baseUrl) || hasText(info.baseUrlResolved);
+  const hasModels = (info.models?.length ?? 0) > 0;
+  const isEnabled = info.isEnabled !== false;
+
+  const isConfigured = (() => {
+    if (!isEnabled) return false;
+
+    if (provider === "bedrock") {
+      return hasText(info.aws?.region);
+    }
+
+    if (provider === "mux-gateway") {
+      return info.couponCodeSet === true;
+    }
+
+    if (info.isCustom === true || info.providerType === "openai-compatible") {
+      return hasBaseUrl;
+    }
+
+    if (provider === "ollama") {
+      return hasBaseUrl || hasModels;
+    }
+
+    // This is a deliberately conservative browser-side mirror of the backend's
+    // computed configuredness. The backend refresh remains authoritative, but the
+    // local mirror prevents ProjectPage from hydrating through a stale provider branch.
+    return (
+      info.apiKeySet === true ||
+      info.apiKeyFile != null ||
+      info.apiKeySource === "env" ||
+      info.codexOauthSet === true
+    );
+  })();
+
+  return { ...info, isConfigured };
+}
+
+function updateHasConfiguredProviderCache(config: ProvidersConfigMap): void {
+  updatePersistedState(HAS_CONFIGURED_PROVIDER_CACHE_KEY, hasConfiguredProvider(config));
+}
 
 /**
  * Hook to get provider config with automatic refresh on config changes.
@@ -33,6 +88,7 @@ export function useProvidersConfig() {
       // Only update if this is the latest fetch (ignore stale responses)
       if (myVersion === fetchVersionRef.current) {
         configRef.current = cfg;
+        updateHasConfiguredProviderCache(cfg);
         setConfig(cfg);
       }
     } catch {
@@ -58,12 +114,17 @@ export function useProvidersConfig() {
       const prev = configRef.current;
       if (!prev) return;
 
+      const nextProvider = getOptimisticConfiguredProvider(provider, {
+        ...prev[provider],
+        ...updates,
+      });
       const next: ProvidersConfigMap = {
         ...prev,
-        [provider]: { ...prev[provider], ...updates },
+        [provider]: nextProvider,
       };
 
       configRef.current = next;
+      updateHasConfiguredProviderCache(next);
       setConfig(next);
     },
     []
@@ -88,12 +149,17 @@ export function useProvidersConfig() {
       const currentModels = prev[provider]?.models ?? [];
       const newModels = updater(currentModels);
 
+      const nextProvider = getOptimisticConfiguredProvider(provider, {
+        ...prev[provider],
+        models: newModels,
+      });
       const next: ProvidersConfigMap = {
         ...prev,
-        [provider]: { ...prev[provider], models: newModels },
+        [provider]: nextProvider,
       };
 
       configRef.current = next;
+      updateHasConfiguredProviderCache(next);
       setConfig(next);
       return newModels;
     },

--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -316,6 +316,13 @@ export function getTrunkBranchKey(projectPath: string): string {
 }
 
 /**
+ * Synchronous mirror of whether any provider was configured on the last provider config load.
+ * ProjectPage uses this to choose the same creation shell during hydration instead of
+ * briefly showing the wrong no-provider/configured-provider layout while config loads.
+ */
+export const HAS_CONFIGURED_PROVIDER_CACHE_KEY = "hasConfiguredProviderCache";
+
+/**
  * Get the localStorage key for whether to show the "Initialize with AGENTS.md" nudge for a project.
  * Set to true when a project is first added; cleared when user dismisses or runs /init.
  * Format: "agentsInitNudge:{projectPath}"

--- a/tests/e2e/scenarios/hydrationLayoutStability.spec.ts
+++ b/tests/e2e/scenarios/hydrationLayoutStability.spec.ts
@@ -1,0 +1,225 @@
+import type { Page } from "@playwright/test";
+import { electronTest as test, electronExpect as expect } from "../electronTest";
+import {
+  LAST_VISITED_ROUTE_KEY,
+  SELECTED_WORKSPACE_KEY,
+} from "../../../src/common/constants/storage";
+
+// Real-browser hydration regression coverage. happy-dom cannot observe the small
+// first-paint geometry deltas users reported, so this samples consecutive Chromium
+// animation frames and treats sub-pixel noise as OK while catching visible pixel jumps.
+test.skip(
+  ({ browserName }) => browserName !== "chromium",
+  "Electron scenario runs on chromium only"
+);
+
+const CREATION_CHAT_INPUT_SECTION =
+  '[data-component="ChatInputSection"][data-chat-input-variant="creation"]';
+const MESSAGE_WINDOW = '[data-testid="message-window"]';
+const COMPOSER_DOCK = '[data-testid="chat-composer-dock"]';
+const FIRST_MESSAGE = "[data-message-id]";
+
+const MAX_VISIBLE_VERTICAL_SHIFT_PX = 0.75;
+const MAX_STARTUP_FRAMES = 600;
+const FRAMES_AFTER_TARGET_VISIBLE = 45;
+const SAMPLE_INTERVAL_MS = 25;
+
+interface RectSnapshot {
+  top: number;
+  bottom: number;
+  height: number;
+}
+
+interface HydrationFrame {
+  frame: number;
+  timestamp: number;
+  hasMarker: boolean;
+  chatInput: RectSnapshot | null;
+  messageWindow: RectSnapshot | null;
+  composer: RectSnapshot | null;
+  firstMessage: RectSnapshot | null;
+}
+
+type RectKey = "chatInput" | "messageWindow" | "composer" | "firstMessage";
+type RectProperty = keyof RectSnapshot;
+
+function workspaceRoute(workspaceId: string): string {
+  return `/workspace/${encodeURIComponent(workspaceId)}`;
+}
+
+async function restoreRouteOnReload(page: Page, route: string) {
+  await page.evaluate(
+    ({ routeKey, selectedWorkspaceKey, value }) => {
+      localStorage.setItem(routeKey, JSON.stringify(value));
+      if (value.startsWith("/project")) {
+        localStorage.removeItem(selectedWorkspaceKey);
+      }
+    },
+    { routeKey: LAST_VISITED_ROUTE_KEY, selectedWorkspaceKey: SELECTED_WORKSPACE_KEY, value: route }
+  );
+}
+
+async function sampleHydrationFrame(
+  page: Page,
+  options: { frame: number; marker?: string }
+): Promise<HydrationFrame> {
+  return await page.evaluate(
+    ({ frame, marker, selectors }) => {
+      const snapshotRect = (selector: string): RectSnapshot | null => {
+        const element = document.querySelector<HTMLElement>(selector);
+        if (!element) return null;
+        const rect = element.getBoundingClientRect();
+        return {
+          top: rect.top,
+          bottom: rect.bottom,
+          height: rect.height,
+        };
+      };
+
+      const bodyText = document.body.textContent ?? "";
+      return {
+        frame,
+        timestamp: performance.now(),
+        hasMarker: marker ? bodyText.includes(marker) : false,
+        chatInput: snapshotRect(selectors.chatInput),
+        messageWindow: snapshotRect(selectors.messageWindow),
+        composer: snapshotRect(selectors.composerDock),
+        firstMessage: snapshotRect(selectors.firstMessage),
+      };
+    },
+    {
+      frame: options.frame,
+      marker: options.marker ?? null,
+      selectors: {
+        chatInput: CREATION_CHAT_INPUT_SECTION,
+        messageWindow: MESSAGE_WINDOW,
+        composerDock: COMPOSER_DOCK,
+        firstMessage: FIRST_MESSAGE,
+      },
+    }
+  );
+}
+
+async function loadRouteForSampling(page: Page, route: string): Promise<void> {
+  await restoreRouteOnReload(page, route);
+
+  const currentUrl = new URL(page.url());
+  if (currentUrl.protocol === "http:" || currentUrl.protocol === "https:") {
+    await page.goto(new URL(route, currentUrl.origin).toString(), {
+      waitUntil: "domcontentloaded",
+    });
+    return;
+  }
+
+  await page.reload({ waitUntil: "domcontentloaded" });
+}
+
+async function reloadAndSampleHydrationFrames(
+  page: Page,
+  options: { route?: string; marker?: string; target: RectKey }
+): Promise<HydrationFrame[]> {
+  if (options.route) {
+    await loadRouteForSampling(page, options.route);
+  }
+
+  // Match the composer layout stability test: Playwright drives sampling because
+  // renderer requestAnimationFrame can be throttled under headless xvfb.
+  const frames: HydrationFrame[] = [];
+  let visibleTargetFrameCount = 0;
+  for (let frame = 0; frame < MAX_STARTUP_FRAMES; frame += 1) {
+    const sample = await sampleHydrationFrame(page, { frame, marker: options.marker });
+    frames.push(sample);
+
+    if (sample[options.target] !== null && (!options.marker || sample.hasMarker)) {
+      visibleTargetFrameCount += 1;
+      if (visibleTargetFrameCount >= FRAMES_AFTER_TARGET_VISIBLE) {
+        break;
+      }
+    }
+
+    await page.waitForTimeout(SAMPLE_INTERVAL_MS);
+  }
+
+  return frames;
+}
+
+function firstFrameIndex(
+  frames: readonly HydrationFrame[],
+  predicate: (frame: HydrationFrame) => boolean
+): number {
+  const index = frames.findIndex(predicate);
+  if (index === -1) {
+    throw new Error("Expected hydration frame was never observed");
+  }
+  return index;
+}
+
+function maxRectDelta(
+  frames: readonly HydrationFrame[],
+  key: RectKey,
+  property: RectProperty,
+  fromIndex: number
+): number {
+  const visible = frames
+    .slice(fromIndex)
+    .map((frame) => frame[key])
+    .filter(Boolean) as RectSnapshot[];
+  if (visible.length < 2) {
+    throw new Error(`Need at least two visible ${key} frames to measure layout stability`);
+  }
+
+  const values = visible.map((rect) => rect[property]);
+  return Math.max(...values) - Math.min(...values);
+}
+
+async function waitForCompletedMockResponse(page: Page, marker: string): Promise<void> {
+  await page.waitForFunction(
+    (expectedMarker: string) => {
+      const messages = document.querySelectorAll("[data-message-block]");
+      const lastMessage = messages.length > 0 ? messages[messages.length - 1] : null;
+      const lastMessageText = lastMessage?.textContent ?? "";
+      const actionButtonCount =
+        lastMessage?.querySelectorAll("[data-message-meta-actions] button").length ?? 0;
+      return lastMessageText.includes(`Mock response: ${expectedMarker}`) && actionButtonCount > 1;
+    },
+    marker,
+    { timeout: 60_000 }
+  );
+}
+
+test.describe("Hydration layout stability", () => {
+  test("keeps an existing chat shell vertically stable while a routed transcript opens", async ({
+    page,
+    ui,
+    workspace,
+  }) => {
+    await ui.projects.openFirstWorkspace();
+    const marker = "[[hydration-layout-stability-existing-chat]]";
+    await ui.chat.sendMessage(`${marker} seed a completed transcript before reload`);
+    await waitForCompletedMockResponse(page, marker);
+
+    const frames = await reloadAndSampleHydrationFrames(page, {
+      route: workspaceRoute(workspace.demoProject.workspaceId),
+      marker,
+      target: "messageWindow",
+    });
+    const firstWindowFrame = firstFrameIndex(frames, (frame) => frame.messageWindow !== null);
+    const firstTranscriptFrame = firstFrameIndex(
+      frames,
+      (frame) => frame.hasMarker && frame.firstMessage !== null
+    );
+
+    expect(maxRectDelta(frames, "messageWindow", "top", firstWindowFrame)).toBeLessThanOrEqual(
+      MAX_VISIBLE_VERTICAL_SHIFT_PX
+    );
+    expect(maxRectDelta(frames, "messageWindow", "height", firstWindowFrame)).toBeLessThanOrEqual(
+      MAX_VISIBLE_VERTICAL_SHIFT_PX
+    );
+    expect(maxRectDelta(frames, "composer", "top", firstWindowFrame)).toBeLessThanOrEqual(
+      MAX_VISIBLE_VERTICAL_SHIFT_PX
+    );
+    expect(maxRectDelta(frames, "firstMessage", "top", firstTranscriptFrame)).toBeLessThanOrEqual(
+      MAX_VISIBLE_VERTICAL_SHIFT_PX
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Stabilizes hydration-time layout slots for project creation and existing chats so provider config, provider bars, and onboarding nudges do not cause visible vertical jumps while the app is loading.

## Background

Existing coverage already handled streaming placeholders, bottom pinning, composer resizing, and workspace-switch tearing. A local geometry sampler reproduced the reported ProjectPage startup movement when provider configuration resolved, and follow-up audits found additional provider-branch and nudge-slot cases that could still recenter the creation stack.

## Implementation

- Co-located `ConfiguredProvidersBarSkeleton` with `ConfiguredProvidersBar` so the loading and resolved provider rows share one fixed frame.
- Added a stable `ProjectCreationProviderGate` around provider-dependent ProjectPage content, with an unknown-provider skeleton that mirrors the creation composer frame and reserves the initial composer controls/textarea/footer budget.
- Render the real `AgentsInitBanner` invisibly for its loading placeholder so responsive wrapping and copy changes reserve the exact final banner height.
- Cache provider availability through `useProvidersConfig`, updating the cache on authoritative refreshes plus optimistic provider/model updates using provider-specific configuredness rules for custom providers, Bedrock, Mux Gateway, Ollama, and standard API-key providers.
- Added provider-cache unit coverage and real-browser hydration geometry coverage for existing chat shell/transcript stability.

## Validation

- `bun test src/browser/hooks/useProvidersConfig.test.ts src/browser/components/ProjectPage/ProjectPage.autofocus.test.tsx src/browser/components/AppLoader/AppLoader.auth.test.tsx src/browser/features/Settings/Sections/ProvidersSection.test.tsx`
- `xvfb-run -a env MUX_E2E_LOAD_DIST=1 MUX_E2E_SKIP_BUILD=1 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 bun x playwright test --project=electron tests/e2e/scenarios/hydrationLayoutStability.spec.ts`
- `make static-check`
- 5 independent read-only audit sub-agents approved the final rebased diff as having no remaining layout-flash or maintainability blockers.

## Risks

Moderate-low. The production changes are scoped to ProjectPage hydration slots and provider-config cache freshness, but they affect the project creation screen before the first workspace is opened. The cache remains conservative and is corrected by authoritative provider refreshes.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `off` • Cost: `$295.00`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=off costs=295.00 -->
