### PR TITLE
🤖 fix: open workflow task reports in modal

### DIFF
--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -2,7 +2,17 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalWindow } from "happy-dom";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
-import { useEffect, type ReactNode } from "react";
+import {
+  cloneElement,
+  createContext,
+  isValidElement,
+  useContext,
+  useEffect,
+  type MouseEvent,
+  type MouseEventHandler,
+  type ReactElement,
+  type ReactNode,
+} from "react";
 
 import { APIContext } from "@/browser/contexts/API";
 import {
@@ -13,6 +23,68 @@ import {
 import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
 import { ThemeProvider } from "@/browser/contexts/ThemeContext";
 import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
+interface MockDialogContextValue {
+  open: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+const MockDialogContext = createContext<MockDialogContextValue | null>(null);
+
+interface MockDialogTriggerChildProps {
+  onClick?: MouseEventHandler<HTMLElement>;
+  "aria-expanded"?: boolean;
+  "aria-haspopup"?: "dialog";
+}
+
+void mock.module("@/browser/components/Dialog/Dialog", () => ({
+  Dialog: (props: {
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+    children: ReactNode;
+  }) => (
+    <MockDialogContext.Provider value={{ open: props.open, onOpenChange: props.onOpenChange }}>
+      {props.children}
+    </MockDialogContext.Provider>
+  ),
+  DialogTrigger: (props: {
+    asChild?: boolean;
+    children: ReactElement<MockDialogTriggerChildProps>;
+  }) => {
+    const dialog = useContext(MockDialogContext);
+    if (!props.asChild || !isValidElement<MockDialogTriggerChildProps>(props.children)) {
+      throw new Error("Mock DialogTrigger expects asChild with a valid element");
+    }
+
+    return cloneElement(props.children, {
+      "aria-expanded": dialog?.open ?? false,
+      "aria-haspopup": "dialog",
+      onClick: (event: MouseEvent<HTMLElement>) => {
+        props.children.props.onClick?.(event);
+        dialog?.onOpenChange?.(true);
+      },
+    });
+  },
+  DialogContent: (props: { children: ReactNode; className?: string }) => {
+    const dialog = useContext(MockDialogContext);
+    if (dialog?.open !== true) {
+      return null;
+    }
+
+    return (
+      <div role="dialog" className={props.className}>
+        {props.children}
+        <button type="button" aria-label="Close" onClick={() => dialog.onOpenChange?.(false)}>
+          Close
+        </button>
+      </div>
+    );
+  },
+  DialogHeader: (props: { children: ReactNode }) => <div>{props.children}</div>,
+  DialogTitle: (props: { children: ReactNode; className?: string }) => (
+    <h2 className={props.className}>{props.children}</h2>
+  ),
+}));
+
 import { WorkflowRunToolCall } from "./WorkflowRunToolCall";
 
 function APIHarness(props: { client: unknown; children: ReactNode }) {
@@ -203,23 +275,24 @@ describe("WorkflowRunToolCall", () => {
     expect(taskEventRow.closest('[role="button"]')?.className).toContain("cursor-pointer");
     expect(taskEventRow.getAttribute("title")).toBeNull();
     expect(taskEventRow.closest("summary")).toBeNull();
-    const taskReportToggle = view.getByLabelText("Show report for task_scope");
+    const taskReportToggle = view.getByLabelText("Open report for task_scope");
     expect(taskReportToggle.closest('[role="button"]')).toBeNull();
 
     fireEvent.click(taskReportToggle);
 
-    await waitFor(() => expect(view.container.textContent).toContain("Child task report body."), {
-      timeout: 5_000,
+    await waitFor(() => {
+      const reportDialog = document.querySelector('[role="dialog"]');
+      expect(reportDialog?.textContent).toContain("Child task report body.");
     });
     await waitFor(() => expect(view.container.textContent).toContain("Workflow result body"));
-    const renderedText = view.container.textContent ?? "";
+    const renderedText = document.body.textContent ?? "";
     expect(renderedText.indexOf("confidence")).toBeLessThan(
       renderedText.indexOf("Workflow result body")
     );
     expect(renderedText).toContain("confidence");
   });
 
-  test("coalesces task attempts, navigates rows, and toggles completed reports separately", async () => {
+  test("coalesces task attempts, navigates rows, and opens completed reports separately", async () => {
     const navigatedTo: string[] = [];
     useWorkspaceStoreRaw().setNavigateToWorkspace((workspaceId) => {
       navigatedTo.push(workspaceId);
@@ -333,15 +406,20 @@ describe("WorkflowRunToolCall", () => {
     expect(navigatedTo).toEqual(["task_retry", "task_live"]);
     expect(view.container.textContent).not.toContain("Completed task body.");
 
-    const reportToggle = view.getByLabelText("Show report for task_live");
+    const reportToggle = view.getByLabelText("Open report for task_live");
     expect(reportToggle.closest('[role="button"]')).toBeNull();
     fireEvent.click(reportToggle);
 
     expect(navigatedTo).toEqual(["task_retry", "task_live"]);
-    await waitFor(() => expect(view.container.textContent).toContain("Completed task body."));
+    await waitFor(() => {
+      const reportDialog = document.querySelector('[role="dialog"]');
+      expect(reportDialog?.textContent).toContain("Completed task body.");
+    });
 
-    fireEvent.click(view.getByLabelText("Hide report for task_live"));
-    expect(view.container.textContent).not.toContain("Completed task body.");
+    fireEvent.click(view.getByLabelText("Close"));
+    await waitFor(() => {
+      expect(document.querySelector('[role="dialog"]')).toBeNull();
+    });
   });
 
   test("renders executing foreground workflow status before the durable run is discovered", () => {
@@ -898,6 +976,121 @@ describe("WorkflowRunToolCall", () => {
 
     await waitFor(() => expect(view.getByText("manual result")).toBeTruthy());
     expect(view.getAllByText("completed").length).toBeGreaterThan(0);
+  });
+
+  test("keeps open task report dialog mounted after workflow auto-completes", async () => {
+    const runningRun = {
+      id: "wfr_report_auto",
+      workspaceId: "workspace-1",
+      definition: {
+        name: "deep-research",
+        description: "Deep research",
+        scope: "built-in" as const,
+        executable: true,
+      },
+      definitionSource: "export default function workflow() { return null; }",
+      definitionHash: "sha256:test",
+      args: { topic: "workflow cards" },
+      status: "running" as const,
+      createdAt: "2026-05-29T00:00:00.000Z",
+      updatedAt: "2026-05-29T00:00:01.000Z",
+      events: [
+        {
+          sequence: 1,
+          type: "status" as const,
+          at: "2026-05-29T00:00:00.000Z",
+          status: "running" as const,
+        },
+        {
+          sequence: 2,
+          type: "task" as const,
+          at: "2026-05-29T00:00:01.000Z",
+          stepId: "report-step",
+          taskId: "task_report",
+          status: "completed" as const,
+        },
+      ],
+      steps: [
+        {
+          stepId: "report-step",
+          inputHash: "sha256:report",
+          status: "completed" as const,
+          taskId: "task_report",
+          startedAt: "2026-05-29T00:00:00.000Z",
+          completedAt: "2026-05-29T00:00:01.000Z",
+          result: { reportMarkdown: "## Running task report\n\nReport stays open." },
+        },
+      ],
+    };
+    const completedRun = {
+      ...runningRun,
+      status: "completed" as const,
+      updatedAt: "2026-05-29T00:00:02.000Z",
+      events: [
+        ...runningRun.events,
+        {
+          sequence: 3,
+          type: "result" as const,
+          at: "2026-05-29T00:00:02.000Z",
+          result: { reportMarkdown: "completed workflow result" },
+        },
+        {
+          sequence: 4,
+          type: "status" as const,
+          at: "2026-05-29T00:00:02.000Z",
+          status: "completed" as const,
+        },
+      ],
+    };
+    const pendingRefresh: { resolve?: (run: typeof completedRun) => void } = {};
+    const api = {
+      workflows: {
+        getRun: async () =>
+          await new Promise<typeof completedRun>((resolve) => {
+            pendingRefresh.resolve = resolve;
+          }),
+      },
+    };
+
+    const view = render(
+      <APIHarness client={api}>
+        <ThemeProvider forcedTheme="dark">
+          <TooltipProvider>
+            <WorkflowRunToolCall
+              args={{
+                name: "deep-research",
+                args: { topic: "workflow cards" },
+                run_in_background: true,
+              }}
+              status="completed"
+              result={{
+                status: "running",
+                runId: "wfr_report_auto",
+                result: null,
+                run: runningRun,
+              }}
+            />
+          </TooltipProvider>
+        </ThemeProvider>
+      </APIHarness>
+    );
+
+    await waitFor(() => expect(pendingRefresh.resolve).toBeDefined());
+    fireEvent.click(view.getByLabelText("Open report for task_report"));
+    await waitFor(() => {
+      expect(document.querySelector('[role="dialog"]')?.textContent).toContain(
+        "Report stays open."
+      );
+    });
+
+    const completeRefresh = pendingRefresh.resolve;
+    if (completeRefresh == null) {
+      throw new Error("Expected workflow refresh to be pending");
+    }
+    completeRefresh(completedRun);
+
+    await waitFor(() => expect(view.getByText("completed workflow result")).toBeTruthy());
+    expect(document.querySelector('[role="dialog"]')?.textContent).toContain("Report stays open.");
   });
 
   test("shows interrupt action for running workflows and updates with the returned run", async () => {

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -1,7 +1,13 @@
 import React, { useContext, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
 
 import { APIContext, type APIClient } from "@/browser/contexts/API";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/browser/components/Dialog/Dialog";
 import { TooltipIfPresent } from "@/browser/components/Tooltip/Tooltip";
 import {
   useOptionalCommandRegistry,
@@ -438,19 +444,55 @@ function WorkflowEventRow(props: {
   );
 }
 
+function WorkflowTaskReportDialogContent(props: {
+  taskId: string;
+  title: string;
+  reportMarkdown: string;
+}) {
+  assert(
+    props.reportMarkdown.trim().length > 0,
+    "WorkflowTaskReportDialogContent requires non-empty report markdown"
+  );
+
+  return (
+    <DialogContent className="flex max-h-[80vh] min-h-0 max-w-5xl flex-col overflow-hidden">
+      <DialogHeader>
+        <DialogTitle className="flex flex-col gap-1">
+          <span>Task report</span>
+          <span className="text-muted flex flex-wrap items-baseline gap-2 text-[11px] font-normal">
+            <span>{props.title}</span>
+            <code className="rounded bg-[var(--color-bg-tertiary)] px-1.5 py-0.5 font-mono text-[10px] leading-none">
+              {props.taskId}
+            </code>
+          </span>
+        </DialogTitle>
+      </DialogHeader>
+
+      <div className="min-h-0 flex-1 overflow-y-auto rounded bg-[var(--color-bg-secondary)] p-3">
+        <MarkdownRenderer content={props.reportMarkdown} />
+      </div>
+    </DialogContent>
+  );
+}
+
 function WorkflowTaskRow(props: {
   row: Extract<WorkflowDisplayRow, { kind: "task" }>;
   displayIndex: number;
   steps: readonly WorkflowStepRecord[];
   onNavigate: (taskId: string) => void;
+  onOpenReport: () => void;
 }) {
-  const [reportExpanded, setReportExpanded] = useState(false);
+  const [reportDialogOpen, setReportDialogOpen] = useState(false);
   const event = props.row.latestEvent;
   const label = getWorkflowEventLabel(event);
   const taskReportMarkdown = getTaskReportMarkdown(event, props.steps);
-  const canShowReport = taskReportMarkdown != null;
-  const reportId = `workflow-task-report-${props.row.firstEvent.sequence}-${event.taskId}`;
   const activateTaskRow = () => props.onNavigate(event.taskId);
+  const handleReportDialogOpenChange = (isOpen: boolean) => {
+    if (isOpen) {
+      props.onOpenReport();
+    }
+    setReportDialogOpen(isOpen);
+  };
   const onKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (keyboardEvent) => {
     if (keyboardEvent.key !== "Enter" && keyboardEvent.key !== " ") {
       return;
@@ -493,35 +535,28 @@ function WorkflowTaskRow(props: {
 
   return (
     <li className="hover:bg-background/50">
-      {canShowReport ? (
-        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center">
-          {taskRow}
-          <button
-            type="button"
-            className={`${WORKFLOW_ACTION_BUTTON_CLASS} mr-2 gap-1 px-1.5 py-0.5 text-[10px]`}
-            aria-controls={reportId}
-            aria-expanded={reportExpanded}
-            aria-label={`${reportExpanded ? "Hide" : "Show"} report for ${event.taskId}`}
-            onClick={() => setReportExpanded((isExpanded) => !isExpanded)}
-          >
-            {reportExpanded ? (
-              <ChevronDown className="h-3 w-3" aria-hidden="true" />
-            ) : (
-              <ChevronRight className="h-3 w-3" aria-hidden="true" />
-            )}
-            Report
-          </button>
-        </div>
+      {taskReportMarkdown != null ? (
+        <Dialog open={reportDialogOpen} onOpenChange={handleReportDialogOpenChange}>
+          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center">
+            {taskRow}
+            <DialogTrigger asChild>
+              <button
+                type="button"
+                className={`${WORKFLOW_ACTION_BUTTON_CLASS} mr-2 inline-flex items-center px-1.5 py-0.5 text-[10px] whitespace-nowrap`}
+                aria-label={`Open report for ${event.taskId}`}
+              >
+                Report
+              </button>
+            </DialogTrigger>
+          </div>
+          <WorkflowTaskReportDialogContent
+            taskId={event.taskId}
+            title={label}
+            reportMarkdown={taskReportMarkdown}
+          />
+        </Dialog>
       ) : (
         taskRow
-      )}
-      {reportExpanded && taskReportMarkdown != null && (
-        <div
-          id={reportId}
-          className="border-border bg-background/40 mx-2 mb-2 rounded border p-2 text-[11px]"
-        >
-          <MarkdownRenderer content={taskReportMarkdown} />
-        </div>
       )}
     </li>
   );
@@ -1157,6 +1192,9 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
                         displayIndex={index + 1}
                         steps={run?.steps ?? []}
                         onNavigate={(taskId) => workspaceStore.navigateToWorkspace(taskId)}
+                        onOpenReport={() => {
+                          userToggledExpansionRef.current = true;
+                        }}
                       />
                     ) : (
                       <WorkflowEventRow


### PR DESCRIPTION
## Summary

Moves workflow task report viewing out of the workflow event list and into a dedicated modal, matching the plan-preview style used in the right sidebar artifacts area.

## Background

Inline task reports made the workflow event list feel cramped, especially for markdown reports. Opening the report as a modal keeps the event list compact while still making the report easy to read.

## Implementation

- Added a task report dialog for workflow task rows with report markdown.
- Uses `DialogTrigger` so Radix retains trigger focus/ARIA behavior when the modal closes.
- Treats opening a task report as an explicit user interaction so a polling workflow completion does not auto-collapse the details and unmount an open report.
- Keeps the dialog title markup phrasing-only, matching the `PlanFileDialog` pattern.

## Validation

- `bun test src/browser/features/Tools/WorkflowRunToolCall.test.tsx`
- `bun test src/browser/features/RightSidebar/PlanFileDialog.test.tsx`
- `make typecheck`
- `make lint`
- `make static-check`
- Ran `deep-review-workflow` on the committed diff and fixed the verified findings.
- Dogfooded in Storybook with before/after screenshots and a WebM recording.

## Risks

Low-to-medium UI risk. This changes workflow task report presentation and dialog behavior only; backend workflow execution and report data are unchanged. Main regression areas are keyboard/focus behavior and workflow polling interactions, covered by targeted tests.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$18.77`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=18.77 -->
