### PR TITLE
🤖 fix: auto-trust ACP project cwd

### DIFF
--- a/src/node/acp/agent.ts
+++ b/src/node/acp/agent.ts
@@ -2181,7 +2181,19 @@ export class MuxAgent implements Agent {
       parentProjectPath != null &&
       (await pathsShareGitTopLevel(parentProjectPath, normalizedProjectPath))
     ) {
-      return { projectPath: parentProjectPath };
+      const createProjectResult = await this.server.client.projects.create({
+        projectPath: normalizedProjectPath,
+      });
+      if (!createProjectResult.success) {
+        throw new Error(
+          `resolveAcpWorkspaceCreationScope: failed to register sub-project '${normalizedProjectPath}': ${createProjectResult.error}`
+        );
+      }
+
+      return {
+        projectPath: parentProjectPath,
+        subProjectPath: createProjectResult.data.normalizedPath,
+      };
     }
 
     return { projectPath: normalizedProjectPath };

--- a/src/node/acp/agent.ts
+++ b/src/node/acp/agent.ts
@@ -300,6 +300,11 @@ export class MuxAgent implements Agent {
       const projectPath = meta.projectPath ?? params.cwd.trim();
       assert(projectPath.length > 0, "newSession: projectPath/cwd must be non-empty");
 
+      // Launching mux as an ACP adapter from an editor for a concrete cwd is an
+      // explicit trust signal, matching other CLI-style ACP adapters that work in
+      // the selected directory without a separate desktop approval step.
+      await this.server.client.projects.setTrust({ projectPath, trusted: true });
+
       // When the ACP client doesn't supply a trunk branch (typical — editors only
       // send `cwd`, not mux-specific `_meta`), derive it from the project's git
       // repo.  Worktree/SSH runtimes require a trunk branch for workspace creation.

--- a/src/node/acp/agent.ts
+++ b/src/node/acp/agent.ts
@@ -453,8 +453,9 @@ export class MuxAgent implements Agent {
     return {
       sessions: page.map((workspace) => ({
         sessionId: workspace.id,
-        // Surface projectPath as cwd so session/list filtering matches editor cwd.
-        cwd: workspace.projectPath,
+        // Surface subProjectPath when present so ACP clients reconnecting from a
+        // package/sub-project cwd can list and resume the session they created.
+        cwd: workspace.subProjectPath ?? workspace.projectPath,
         title: workspace.title ?? workspace.name,
         updatedAt: toSessionUpdatedAt(workspace, workspaceActivity),
       })),
@@ -2295,11 +2296,19 @@ function dedupeWorkspacesById(workspaces: WorkspaceInfo[]): WorkspaceInfo[] {
 }
 
 function workspaceMatchesCwd(workspace: WorkspaceInfo, cwd: string): boolean {
-  // Match both projectPath and concrete workspace path so clients can filter by
-  // either the original project root or the runtime-specific working directory.
+  // Match project, sub-project, and concrete workspace paths so clients can
+  // filter by either their editor cwd or the runtime-specific working directory.
   const normalizedProjectPath = normalizePathForWorkspaceMatch(workspace.projectPath);
+  const normalizedSubProjectPath =
+    workspace.subProjectPath != null
+      ? normalizePathForWorkspaceMatch(workspace.subProjectPath)
+      : null;
   const normalizedWorkspacePath = normalizePathForWorkspaceMatch(workspace.namedWorkspacePath);
-  return normalizedProjectPath === cwd || normalizedWorkspacePath === cwd;
+  return (
+    normalizedProjectPath === cwd ||
+    normalizedSubProjectPath === cwd ||
+    normalizedWorkspacePath === cwd
+  );
 }
 
 function compareSessionRecency(

--- a/src/node/acp/agent.ts
+++ b/src/node/acp/agent.ts
@@ -31,6 +31,7 @@ import {
   WORDS_TO_TOKENS_RATIO,
   buildCompactionPrompt,
 } from "@/common/constants/ui";
+import { execFileAsync } from "@/node/utils/disposableExec";
 import { RuntimeConfigSchema } from "@/common/orpc/schemas";
 import type { OnChatMode, SendMessageOptions, WorkspaceChatMessage } from "@/common/orpc/types";
 import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
@@ -2176,11 +2177,38 @@ export class MuxAgent implements Agent {
     }
 
     const parentProjectPath = findContainingTopLevelProjectPath(normalizedProjectPath, projects);
-    return { projectPath: parentProjectPath ?? normalizedProjectPath };
+    if (
+      parentProjectPath != null &&
+      (await pathsShareGitTopLevel(parentProjectPath, normalizedProjectPath))
+    ) {
+      return { projectPath: parentProjectPath };
+    }
+
+    return { projectPath: normalizedProjectPath };
   }
 
   private assertInitialized(methodName: string): void {
     assert(this.initialized, `${methodName}: initialize must be called first`);
+  }
+}
+
+async function pathsShareGitTopLevel(leftPath: string, rightPath: string): Promise<boolean> {
+  const [leftGitRoot, rightGitRoot] = await Promise.all([
+    readGitTopLevelForAcpScope(leftPath),
+    readGitTopLevelForAcpScope(rightPath),
+  ]);
+
+  return leftGitRoot != null && leftGitRoot === rightGitRoot;
+}
+
+async function readGitTopLevelForAcpScope(projectPath: string): Promise<string | null> {
+  try {
+    using proc = execFileAsync("git", ["-C", projectPath, "rev-parse", "--show-toplevel"]);
+    const { stdout } = await proc.result;
+    const trimmed = stdout.trim();
+    return trimmed.length > 0 ? normalizePathForWorkspaceMatch(trimmed) : null;
+  } catch {
+    return null;
   }
 }
 

--- a/src/node/acp/agent.ts
+++ b/src/node/acp/agent.ts
@@ -2160,9 +2160,10 @@ export class MuxAgent implements Agent {
     const normalizedProjectPath = normalizePathForWorkspaceMatch(projectPath);
     const projectEntries = await this.server.client.projects.list();
     const projects = deriveProjectHierarchy(new Map<string, ProjectConfig>(projectEntries));
+    const existingProjectPath = findProjectPathByNormalizedPath(normalizedProjectPath, projects);
 
-    if (projects.has(normalizedProjectPath)) {
-      const scope = resolveWorkspaceCreationScope(normalizedProjectPath, projects);
+    if (existingProjectPath != null) {
+      const scope = resolveWorkspaceCreationScope(existingProjectPath, projects);
       assert(
         scope.projectPath.trim().length > 0,
         "resolveAcpWorkspaceCreationScope: owning project path must be non-empty"
@@ -2181,6 +2182,19 @@ export class MuxAgent implements Agent {
   private assertInitialized(methodName: string): void {
     assert(this.initialized, `${methodName}: initialize must be called first`);
   }
+}
+
+function findProjectPathByNormalizedPath(
+  normalizedProjectPath: string,
+  projects: ReadonlyMap<string, ProjectConfig>
+): string | undefined {
+  for (const projectPath of projects.keys()) {
+    if (normalizePathForWorkspaceMatch(projectPath) === normalizedProjectPath) {
+      return projectPath;
+    }
+  }
+
+  return undefined;
 }
 
 function findContainingTopLevelProjectPath(

--- a/src/node/acp/agent.ts
+++ b/src/node/acp/agent.ts
@@ -2181,22 +2181,48 @@ export class MuxAgent implements Agent {
       parentProjectPath != null &&
       (await pathsShareGitTopLevel(parentProjectPath, normalizedProjectPath))
     ) {
-      const createProjectResult = await this.server.client.projects.create({
-        projectPath: normalizedProjectPath,
-      });
-      if (!createProjectResult.success) {
-        throw new Error(
-          `resolveAcpWorkspaceCreationScope: failed to register sub-project '${normalizedProjectPath}': ${createProjectResult.error}`
-        );
-      }
+      return await this.registerAcpSubProject(parentProjectPath, normalizedProjectPath);
+    }
 
-      return {
-        projectPath: parentProjectPath,
-        subProjectPath: createProjectResult.data.normalizedPath,
-      };
+    const gitTopLevel = await readGitTopLevelForAcpScope(normalizedProjectPath);
+    if (gitTopLevel != null && gitTopLevel !== normalizedProjectPath) {
+      const existingGitRootProjectPath = findProjectPathByNormalizedPath(gitTopLevel, projects);
+      const owningProjectPath =
+        existingGitRootProjectPath ?? (await this.registerAcpTopLevelProject(gitTopLevel));
+      return await this.registerAcpSubProject(owningProjectPath, normalizedProjectPath);
     }
 
     return { projectPath: normalizedProjectPath };
+  }
+
+  private async registerAcpTopLevelProject(projectPath: string): Promise<string> {
+    const createProjectResult = await this.server.client.projects.create({ projectPath });
+    if (!createProjectResult.success) {
+      throw new Error(
+        `resolveAcpWorkspaceCreationScope: failed to register project '${projectPath}': ${createProjectResult.error}`
+      );
+    }
+
+    return createProjectResult.data.normalizedPath;
+  }
+
+  private async registerAcpSubProject(
+    parentProjectPath: string,
+    subProjectPath: string
+  ): Promise<AcpWorkspaceCreationScope> {
+    const createProjectResult = await this.server.client.projects.create({
+      projectPath: subProjectPath,
+    });
+    if (!createProjectResult.success) {
+      throw new Error(
+        `resolveAcpWorkspaceCreationScope: failed to register sub-project '${subProjectPath}': ${createProjectResult.error}`
+      );
+    }
+
+    return {
+      projectPath: parentProjectPath,
+      subProjectPath: createProjectResult.data.normalizedPath,
+    };
   }
 
   private assertInitialized(methodName: string): void {

--- a/src/node/acp/agent.ts
+++ b/src/node/acp/agent.ts
@@ -37,11 +37,16 @@ import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
 import type { CompactionRequestData } from "@/common/types/message";
 import { buildAgentSkillMetadata } from "@/common/types/message";
 import { isWorktreeRuntime, type RuntimeConfig, type RuntimeMode } from "@/common/types/runtime";
+import type { ProjectConfig } from "@/common/types/project";
+import { deriveProjectHierarchy, resolveWorkspaceCreationScope } from "@/common/utils/subProjects";
 import { createAsyncMessageQueue } from "@/common/utils/asyncMessageQueue";
 import { negotiateCapabilities, type NegotiatedCapabilities } from "./capabilities";
 import { AGENT_MODE_CONFIG_ID, buildConfigOptions, handleSetConfigOption } from "./configOptions";
 import { forkSessionFromWorkspace } from "./experimental/sessionFork";
-import { loadSessionFromWorkspace } from "./experimental/sessionResume";
+import {
+  canonicalizePathForWorkspaceMatch,
+  loadSessionFromWorkspace,
+} from "./experimental/sessionResume";
 import { convertToAcpUsage } from "./experimental/sessionUsage";
 import { resolveAgentAiSettings, type ResolvedAiSettings } from "./resolveAgentAiSettings";
 import type { ServerConnection } from "./serverConnection";
@@ -95,6 +100,11 @@ interface SessionState {
   runtimeMode: RuntimeMode;
   agentId: string;
   aiSettings: ResolvedAiSettings;
+}
+
+interface AcpWorkspaceCreationScope {
+  projectPath: string;
+  subProjectPath?: string;
 }
 
 interface NewSessionWorkspaceLifecycle {
@@ -297,29 +307,30 @@ export class MuxAgent implements Agent {
     this.inFlightNewSessionCount += 1;
     try {
       const meta = parseMuxMeta(params._meta);
-      const projectPath = meta.projectPath ?? params.cwd.trim();
-      assert(projectPath.length > 0, "newSession: projectPath/cwd must be non-empty");
-
-      // Launching mux as an ACP adapter from an editor for a concrete cwd is an
-      // explicit trust signal, matching other CLI-style ACP adapters that work in
-      // the selected directory without a separate desktop approval step.
-      await this.server.client.projects.setTrust({ projectPath, trusted: true });
+      const requestedProjectPath = await resolveAcpNewSessionProjectPath(
+        params.cwd,
+        meta.projectPath
+      );
+      const workspaceScope = await this.ensureAcpProjectTrusted(requestedProjectPath);
 
       // When the ACP client doesn't supply a trunk branch (typical — editors only
       // send `cwd`, not mux-specific `_meta`), derive it from the project's git
       // repo.  Worktree/SSH runtimes require a trunk branch for workspace creation.
       let trunkBranch = meta.trunkBranch;
       if (trunkBranch == null || trunkBranch.trim().length === 0) {
-        const branchInfo = await this.server.client.projects.listBranches({ projectPath });
+        const branchInfo = await this.server.client.projects.listBranches({
+          projectPath: workspaceScope.projectPath,
+        });
         trunkBranch = branchInfo.recommendedTrunk ?? DEFAULT_TRUNK_BRANCH;
       }
 
       const createResult = await this.server.client.workspace.create({
-        projectPath,
+        projectPath: workspaceScope.projectPath,
         branchName: meta.branchName ?? generateDefaultBranchName(),
         trunkBranch,
         title: meta.title,
         runtimeConfig: meta.runtimeConfig,
+        subProjectPath: workspaceScope.subProjectPath,
       });
 
       if (!createResult.success) {
@@ -497,6 +508,17 @@ export class MuxAgent implements Agent {
     this.assertInitialized("unstable_forkSession");
 
     const meta = parseMuxMeta(params._meta);
+    const sourceWorkspaceId = this.sessionManager.getWorkspaceId(params.sessionId);
+    const sourceWorkspace = await this.server.client.workspace.getInfo({
+      workspaceId: sourceWorkspaceId,
+    });
+    if (!sourceWorkspace) {
+      throw new Error(
+        `unstable_forkSession: source workspace '${sourceWorkspaceId}' was not found`
+      );
+    }
+    await this.ensureAcpProjectTrusted(sourceWorkspace.projectPath);
+
     // Pass the source session's active agent so forks inherit mode switches
     const sourceSessionState = this.sessionStateById.get(params.sessionId);
     const forked = await forkSessionFromWorkspace(
@@ -846,6 +868,15 @@ export class MuxAgent implements Agent {
       }
 
       case "fork": {
+        const workspaceInfo = await this.server.client.workspace.getInfo({ workspaceId });
+        if (workspaceInfo == null) {
+          return this.respondToCommand(
+            sessionId,
+            "Failed to fork workspace: current workspace metadata is unavailable."
+          );
+        }
+        await this.ensureAcpProjectTrusted(workspaceInfo.projectPath);
+
         const forkResult = await this.server.client.workspace.fork({
           sourceWorkspaceId: workspaceId,
           pendingAutoTitle:
@@ -889,10 +920,14 @@ export class MuxAgent implements Agent {
           );
         }
 
+        const workspaceScope = await this.ensureAcpProjectTrusted(
+          workspaceInfo.subProjectPath ?? workspaceInfo.projectPath
+        );
+
         // Resolve trunk from project defaults — /new no longer accepts overrides
         // (it now mirrors /fork's seamless flow).
         const branchInfo = await this.server.client.projects.listBranches({
-          projectPath: workspaceInfo.projectPath,
+          projectPath: workspaceScope.projectPath,
         });
         const trunkBranch = branchInfo.recommendedTrunk ?? DEFAULT_TRUNK_BRANCH;
 
@@ -900,12 +935,13 @@ export class MuxAgent implements Agent {
           parsedCommand.startMessage != null && parsedCommand.startMessage.trim().length > 0;
 
         const createResult = await this.server.client.workspace.create({
-          projectPath: workspaceInfo.projectPath,
+          projectPath: workspaceScope.projectPath,
           // branchName intentionally omitted — backend auto-generates (like /fork).
           trunkBranch,
           // Mirror /fork: when a start message accompanies /new, defer the title
           // selection until the first message can drive LLM-based generation.
           pendingAutoTitle: hasStartMessage,
+          subProjectPath: workspaceScope.subProjectPath,
         });
 
         if (!createResult.success) {
@@ -2091,9 +2127,79 @@ export class MuxAgent implements Agent {
     await this.disconnectCleanupPromise;
   }
 
+  private async ensureAcpProjectTrusted(projectPath: string): Promise<AcpWorkspaceCreationScope> {
+    const workspaceScope = await this.resolveAcpWorkspaceCreationScope(projectPath);
+    const trustPaths =
+      workspaceScope.subProjectPath != null
+        ? [workspaceScope.subProjectPath, workspaceScope.projectPath]
+        : [workspaceScope.projectPath];
+
+    // Launching mux as an ACP adapter from an editor for a concrete cwd is an
+    // explicit trust signal, matching other CLI-style ACP adapters that work in
+    // the selected directory without a separate desktop approval step.  For
+    // sub-projects, trust both the requested child entry (so it exists) and the
+    // owning parent entry that workspace creation/fork gates on.
+    for (const trustedProjectPath of trustPaths) {
+      await this.server.client.projects.setTrust({
+        projectPath: trustedProjectPath,
+        trusted: true,
+      });
+    }
+
+    return workspaceScope;
+  }
+
+  private async resolveAcpWorkspaceCreationScope(
+    projectPath: string
+  ): Promise<AcpWorkspaceCreationScope> {
+    const normalizedProjectPath = normalizePathForWorkspaceMatch(projectPath);
+    const projectEntries = await this.server.client.projects.list();
+    const projects = new Map<string, ProjectConfig>(projectEntries);
+    if (!projects.has(normalizedProjectPath)) {
+      projects.set(normalizedProjectPath, { workspaces: [] });
+    }
+
+    const scope = resolveWorkspaceCreationScope(
+      normalizedProjectPath,
+      deriveProjectHierarchy(projects)
+    );
+    assert(
+      scope.projectPath.trim().length > 0,
+      "resolveAcpWorkspaceCreationScope: owning project path must be non-empty"
+    );
+
+    return {
+      projectPath: scope.projectPath,
+      subProjectPath: scope.subProjectPath ?? undefined,
+    };
+  }
+
   private assertInitialized(methodName: string): void {
     assert(this.initialized, `${methodName}: initialize must be called first`);
   }
+}
+
+async function resolveAcpNewSessionProjectPath(
+  cwd: string,
+  metaProjectPath: string | undefined
+): Promise<string> {
+  const cwdProjectPath = cwd.trim();
+  assert(cwdProjectPath.length > 0, "newSession: cwd must be non-empty");
+
+  if (metaProjectPath == null) {
+    return cwdProjectPath;
+  }
+
+  const [canonicalCwd, canonicalMetaProjectPath] = await Promise.all([
+    canonicalizePathForWorkspaceMatch(cwdProjectPath),
+    canonicalizePathForWorkspaceMatch(metaProjectPath),
+  ]);
+  assert(
+    canonicalCwd === canonicalMetaProjectPath,
+    "newSession: _meta.projectPath must match cwd before ACP can auto-trust the project"
+  );
+
+  return metaProjectPath;
 }
 
 function normalizeOptionalPath(value: string | null | undefined): string | undefined {

--- a/src/node/acp/agent.ts
+++ b/src/node/acp/agent.ts
@@ -38,7 +38,11 @@ import type { CompactionRequestData } from "@/common/types/message";
 import { buildAgentSkillMetadata } from "@/common/types/message";
 import { isWorktreeRuntime, type RuntimeConfig, type RuntimeMode } from "@/common/types/runtime";
 import type { ProjectConfig } from "@/common/types/project";
-import { deriveProjectHierarchy, resolveWorkspaceCreationScope } from "@/common/utils/subProjects";
+import {
+  deriveProjectHierarchy,
+  isPathDescendant,
+  resolveWorkspaceCreationScope,
+} from "@/common/utils/subProjects";
 import { createAsyncMessageQueue } from "@/common/utils/asyncMessageQueue";
 import { negotiateCapabilities, type NegotiatedCapabilities } from "./capabilities";
 import { AGENT_MODE_CONFIG_ID, buildConfigOptions, handleSetConfigOption } from "./configOptions";
@@ -2154,29 +2158,51 @@ export class MuxAgent implements Agent {
   ): Promise<AcpWorkspaceCreationScope> {
     const normalizedProjectPath = normalizePathForWorkspaceMatch(projectPath);
     const projectEntries = await this.server.client.projects.list();
-    const projects = new Map<string, ProjectConfig>(projectEntries);
-    if (!projects.has(normalizedProjectPath)) {
-      projects.set(normalizedProjectPath, { workspaces: [] });
+    const projects = deriveProjectHierarchy(new Map<string, ProjectConfig>(projectEntries));
+
+    if (projects.has(normalizedProjectPath)) {
+      const scope = resolveWorkspaceCreationScope(normalizedProjectPath, projects);
+      assert(
+        scope.projectPath.trim().length > 0,
+        "resolveAcpWorkspaceCreationScope: owning project path must be non-empty"
+      );
+
+      return {
+        projectPath: scope.projectPath,
+        subProjectPath: scope.subProjectPath ?? undefined,
+      };
     }
 
-    const scope = resolveWorkspaceCreationScope(
-      normalizedProjectPath,
-      deriveProjectHierarchy(projects)
-    );
-    assert(
-      scope.projectPath.trim().length > 0,
-      "resolveAcpWorkspaceCreationScope: owning project path must be non-empty"
-    );
-
-    return {
-      projectPath: scope.projectPath,
-      subProjectPath: scope.subProjectPath ?? undefined,
-    };
+    const parentProjectPath = findContainingTopLevelProjectPath(normalizedProjectPath, projects);
+    return { projectPath: parentProjectPath ?? normalizedProjectPath };
   }
 
   private assertInitialized(methodName: string): void {
     assert(this.initialized, `${methodName}: initialize must be called first`);
   }
+}
+
+function findContainingTopLevelProjectPath(
+  projectPath: string,
+  projects: ReadonlyMap<string, ProjectConfig>
+): string | undefined {
+  let closestParentPath: string | undefined;
+
+  for (const [candidatePath, candidateConfig] of projects) {
+    if (candidateConfig.parentProjectPath != null) {
+      continue;
+    }
+
+    if (!isPathDescendant(candidatePath, projectPath)) {
+      continue;
+    }
+
+    if (closestParentPath == null || candidatePath.length > closestParentPath.length) {
+      closestParentPath = candidatePath;
+    }
+  }
+
+  return closestParentPath;
 }
 
 async function resolveAcpNewSessionProjectPath(

--- a/src/node/acp/experimental/sessionResume.ts
+++ b/src/node/acp/experimental/sessionResume.ts
@@ -94,15 +94,24 @@ export async function loadSessionFromWorkspace(
     throw new Error(`loadSessionFromWorkspace: workspace '${requestedSessionId}' was not found`);
   }
 
-  const [canonicalRequestedCwd, canonicalProjectPath, canonicalWorkspacePath] = await Promise.all([
+  const [
+    canonicalRequestedCwd,
+    canonicalProjectPath,
+    canonicalWorkspacePath,
+    canonicalSubProjectPath,
+  ] = await Promise.all([
     canonicalizePathForWorkspaceMatch(requestedCwd),
     canonicalizePathForWorkspaceMatch(workspace.projectPath),
     canonicalizePathForWorkspaceMatch(workspace.namedWorkspacePath),
+    workspace.subProjectPath != null
+      ? canonicalizePathForWorkspaceMatch(workspace.subProjectPath)
+      : Promise.resolve(null),
   ]);
 
   const cwdMatchesWorkspace =
     canonicalProjectPath === canonicalRequestedCwd ||
-    canonicalWorkspacePath === canonicalRequestedCwd;
+    canonicalWorkspacePath === canonicalRequestedCwd ||
+    canonicalSubProjectPath === canonicalRequestedCwd;
   assert(
     cwdMatchesWorkspace,
     `loadSessionFromWorkspace: workspace '${requestedSessionId}' is not in cwd '${requestedCwd}'`

--- a/src/node/acp/experimental/sessionResume.ts
+++ b/src/node/acp/experimental/sessionResume.ts
@@ -61,7 +61,7 @@ function normalizePathCasingForComparison(value: string): string {
   return process.platform === "win32" ? value.toLowerCase() : value;
 }
 
-async function canonicalizePathForWorkspaceMatch(value: string): Promise<string> {
+export async function canonicalizePathForWorkspaceMatch(value: string): Promise<string> {
   const trimmed = value.trim();
   assert(trimmed.length > 0, "canonicalizePathForWorkspaceMatch: value must be non-empty");
 

--- a/tests/ipc/acp.disconnectCleanup.test.ts
+++ b/tests/ipc/acp.disconnectCleanup.test.ts
@@ -340,6 +340,35 @@ describe("ACP disconnect cleanup for untouched session/new workspaces", () => {
     expect(harness.createCalls).toEqual([]);
   });
 
+  it("registers the git top-level and requested cwd for fresh subdirectory launches", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-acp-fresh-git-root-"));
+    try {
+      const parentPath = path.join(tempDir, "monorepo");
+      const packagePath = path.join(parentPath, "packages", "api");
+      await fs.mkdir(packagePath, { recursive: true });
+      await execFileAsyncForTest("git", ["init", "-q"], { cwd: parentPath });
+
+      const harness = createHarness({ requireTrustedProjectForCreate: true });
+      await harness.agent.initialize({ protocolVersion: PROTOCOL_VERSION });
+
+      const newSessionResponse = await harness.agent.newSession({
+        cwd: packagePath,
+        mcpServers: [],
+        _meta: { trunkBranch: "main" },
+      });
+
+      expect(newSessionResponse.sessionId).toBe("ws-1");
+      expect(harness.setTrustCalls).toEqual([
+        { projectPath: packagePath, trusted: true },
+        { projectPath: parentPath, trusted: true },
+      ]);
+      expect(harness.createCalls[0]?.projectPath).toBe(parentPath);
+      expect(harness.createCalls[0]?.subProjectPath).toBe(packagePath);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps an unregistered descendant as its own project when git root cannot be verified", async () => {
     const parentPath = "/repo/monorepo";
     const packagePath = "/repo/monorepo/packages/unregistered";

--- a/tests/ipc/acp.disconnectCleanup.test.ts
+++ b/tests/ipc/acp.disconnectCleanup.test.ts
@@ -1,20 +1,32 @@
 import { AgentSideConnection, PROTOCOL_VERSION, ndJsonStream } from "@agentclientprotocol/sdk";
+import type { ProjectConfig } from "../../src/common/types/project";
 import type { OnChatMode, WorkspaceChatMessage } from "../../src/common/orpc/types";
 import { MuxAgent } from "../../src/node/acp/agent";
 import type { ORPCClient, ServerConnection } from "../../src/node/acp/serverConnection";
 
 type WorkspaceInfo = NonNullable<Awaited<ReturnType<ORPCClient["workspace"]["getInfo"]>>>;
 
+interface WorkspaceCreateInput {
+  projectPath: string;
+  branchName: string;
+  trunkBranch?: string;
+  title?: string;
+  runtimeConfig?: WorkspaceInfo["runtimeConfig"];
+  subProjectPath?: string;
+}
+
 interface HarnessOptions {
   getReplayEvents?: (workspaceId: string) => WorkspaceChatMessage[];
   beforeCreateResolves?: Promise<void>;
   disconnectCleanupMaxWaitMs?: number;
   requireTrustedProjectForCreate?: boolean;
+  projectEntries?: Array<[string, ProjectConfig]>;
 }
 
 interface Harness {
   agent: MuxAgent;
   createdWorkspaceIds: string[];
+  createCalls: WorkspaceCreateInput[];
   removeCalls: string[];
   replayChecks: string[];
   setTrustCalls: Array<{ projectPath: string; trusted: boolean }>;
@@ -96,16 +108,18 @@ function createDeferred<T>(): {
 function createHarness(options?: HarnessOptions): Harness {
   const workspacesById = new Map<string, WorkspaceInfo>();
   const createdWorkspaceIds: string[] = [];
+  const createCalls: WorkspaceCreateInput[] = [];
   const removeCalls: string[] = [];
   const replayChecks: string[] = [];
   const setTrustCalls: Array<{ projectPath: string; trusted: boolean }> = [];
-  const trustedProjectPaths = new Set<string>();
+  const projectsByPath = new Map<string, ProjectConfig>(options?.projectEntries ?? []);
 
   const client = {
     config: {
       getConfig: async () => ({}),
     },
     projects: {
+      list: async () => Array.from(projectsByPath.entries()),
       listBranches: async () => ({
         branches: ["main"],
         currentBranch: "main",
@@ -113,11 +127,11 @@ function createHarness(options?: HarnessOptions): Harness {
       }),
       setTrust: async (input: { projectPath: string; trusted: boolean }) => {
         setTrustCalls.push(input);
-        if (input.trusted) {
-          trustedProjectPaths.add(input.projectPath);
-        } else {
-          trustedProjectPaths.delete(input.projectPath);
-        }
+        const currentProject = projectsByPath.get(input.projectPath) ?? { workspaces: [] };
+        projectsByPath.set(input.projectPath, {
+          ...currentProject,
+          trusted: input.trusted,
+        });
       },
     },
     agents: {
@@ -133,16 +147,11 @@ function createHarness(options?: HarnessOptions): Harness {
       },
     },
     workspace: {
-      create: async (input: {
-        projectPath: string;
-        branchName: string;
-        trunkBranch?: string;
-        title?: string;
-        runtimeConfig?: WorkspaceInfo["runtimeConfig"];
-      }) => {
+      create: async (input: WorkspaceCreateInput) => {
+        createCalls.push(input);
         if (
           options?.requireTrustedProjectForCreate === true &&
-          !trustedProjectPaths.has(input.projectPath)
+          projectsByPath.get(input.projectPath)?.trusted !== true
         ) {
           return {
             success: false as const,
@@ -160,6 +169,7 @@ function createHarness(options?: HarnessOptions): Harness {
           name: input.branchName,
           title: input.title ?? input.branchName,
           projectPath: input.projectPath,
+          subProjectPath: input.subProjectPath,
           namedWorkspacePath: `${input.projectPath}/.mux/${input.branchName}`,
           runtimeConfig: input.runtimeConfig ?? { type: "local" },
         });
@@ -214,6 +224,7 @@ function createHarness(options?: HarnessOptions): Harness {
   return {
     agent: agentInstance,
     createdWorkspaceIds,
+    createCalls,
     removeCalls,
     replayChecks,
     setTrustCalls,
@@ -246,6 +257,78 @@ describe("ACP disconnect cleanup for untouched session/new workspaces", () => {
     expect(newSessionResponse.sessionId).toBe("ws-1");
     expect(harness.setTrustCalls).toEqual([{ projectPath: "/repo/acp-go-sdk", trusted: true }]);
     expect(harness.createdWorkspaceIds).toEqual(["ws-1"]);
+  });
+
+  it("accepts normalized-equivalent _meta.projectPath values", async () => {
+    const harness = createHarness({ requireTrustedProjectForCreate: true });
+    await harness.agent.initialize({ protocolVersion: PROTOCOL_VERSION });
+
+    const newSessionResponse = await harness.agent.newSession({
+      cwd: "/repo/acp-go-sdk",
+      mcpServers: [],
+      _meta: {
+        projectPath: "/repo/acp-go-sdk/.",
+        trunkBranch: "main",
+      },
+    });
+
+    expect(newSessionResponse.sessionId).toBe("ws-1");
+    expect(harness.setTrustCalls).toEqual([{ projectPath: "/repo/acp-go-sdk", trusted: true }]);
+    expect(harness.createCalls[0]?.projectPath).toBe("/repo/acp-go-sdk");
+  });
+
+  it("rejects mismatched _meta.projectPath before trusting any project", async () => {
+    const harness = createHarness({ requireTrustedProjectForCreate: true });
+    await harness.agent.initialize({ protocolVersion: PROTOCOL_VERSION });
+
+    await expect(
+      harness.agent.newSession({
+        cwd: "/repo/acp-go-sdk",
+        mcpServers: [],
+        _meta: {
+          projectPath: "/repo/other",
+          trunkBranch: "main",
+        },
+      })
+    ).rejects.toThrow("_meta.projectPath must match cwd");
+
+    expect(harness.setTrustCalls).toEqual([]);
+    expect(harness.createCalls).toEqual([]);
+  });
+
+  it("trusts the owning parent when ACP starts from a registered sub-project", async () => {
+    const parentPath = "/repo/monorepo";
+    const childPath = "/repo/monorepo/packages/api";
+    const harness = createHarness({
+      requireTrustedProjectForCreate: true,
+      projectEntries: [
+        [parentPath, { workspaces: [], trusted: false }],
+        [childPath, { workspaces: [], parentProjectPath: parentPath, trusted: false }],
+      ],
+    });
+    await harness.agent.initialize({ protocolVersion: PROTOCOL_VERSION });
+
+    const newSessionResponse = await harness.agent.newSession({
+      cwd: childPath,
+      mcpServers: [],
+      _meta: { trunkBranch: "main" },
+    });
+
+    expect(newSessionResponse.sessionId).toBe("ws-1");
+    expect(harness.setTrustCalls).toEqual([
+      { projectPath: childPath, trusted: true },
+      { projectPath: parentPath, trusted: true },
+    ]);
+    expect(harness.createCalls).toEqual([
+      {
+        projectPath: parentPath,
+        branchName: harness.createCalls[0]?.branchName ?? "",
+        trunkBranch: "main",
+        runtimeConfig: undefined,
+        subProjectPath: childPath,
+        title: undefined,
+      },
+    ]);
   });
 
   it("removes empty session/new workspace when connection closes", async () => {

--- a/tests/ipc/acp.disconnectCleanup.test.ts
+++ b/tests/ipc/acp.disconnectCleanup.test.ts
@@ -41,6 +41,28 @@ interface Harness {
   connectionClosed: Promise<void>;
 }
 
+function findTestParentProjectPath(
+  projectPath: string,
+  projectsByPath: ReadonlyMap<string, ProjectConfig>
+): string | undefined {
+  let parentProjectPath: string | undefined;
+  for (const [candidatePath, candidateConfig] of projectsByPath) {
+    if (candidateConfig.parentProjectPath != null) {
+      continue;
+    }
+
+    const descendantPrefix = `${candidatePath}${path.sep}`;
+    if (!projectPath.startsWith(descendantPrefix)) {
+      continue;
+    }
+
+    if (parentProjectPath == null || candidatePath.length > parentProjectPath.length) {
+      parentProjectPath = candidatePath;
+    }
+  }
+  return parentProjectPath;
+}
+
 function createWorkspaceInfo(overrides?: Partial<WorkspaceInfo>): WorkspaceInfo {
   return {
     id: "ws-default",
@@ -126,6 +148,21 @@ function createHarness(options?: HarnessOptions): Harness {
       getConfig: async () => ({}),
     },
     projects: {
+      create: async (input: { projectPath: string }) => {
+        const parentProjectPath = findTestParentProjectPath(input.projectPath, projectsByPath);
+        const projectConfig: ProjectConfig = {
+          workspaces: [],
+          parentProjectPath,
+        };
+        projectsByPath.set(input.projectPath, projectConfig);
+        return {
+          success: true as const,
+          data: {
+            projectConfig,
+            normalizedPath: input.projectPath,
+          },
+        };
+      },
       list: async () => Array.from(projectsByPath.entries()),
       listBranches: async () => ({
         branches: ["main"],
@@ -345,9 +382,12 @@ describe("ACP disconnect cleanup for untouched session/new workspaces", () => {
       });
 
       expect(newSessionResponse.sessionId).toBe("ws-1");
-      expect(harness.setTrustCalls).toEqual([{ projectPath: parentPath, trusted: true }]);
+      expect(harness.setTrustCalls).toEqual([
+        { projectPath: packagePath, trusted: true },
+        { projectPath: parentPath, trusted: true },
+      ]);
       expect(harness.createCalls[0]?.projectPath).toBe(parentPath);
-      expect(harness.createCalls[0]?.subProjectPath).toBeUndefined();
+      expect(harness.createCalls[0]?.subProjectPath).toBe(packagePath);
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }

--- a/tests/ipc/acp.disconnectCleanup.test.ts
+++ b/tests/ipc/acp.disconnectCleanup.test.ts
@@ -296,6 +296,27 @@ describe("ACP disconnect cleanup for untouched session/new workspaces", () => {
     expect(harness.createCalls).toEqual([]);
   });
 
+  it("uses the containing parent when ACP starts from an unregistered descendant", async () => {
+    const parentPath = "/repo/monorepo";
+    const packagePath = "/repo/monorepo/packages/unregistered";
+    const harness = createHarness({
+      requireTrustedProjectForCreate: true,
+      projectEntries: [[parentPath, { workspaces: [], trusted: false }]],
+    });
+    await harness.agent.initialize({ protocolVersion: PROTOCOL_VERSION });
+
+    const newSessionResponse = await harness.agent.newSession({
+      cwd: packagePath,
+      mcpServers: [],
+      _meta: { trunkBranch: "main" },
+    });
+
+    expect(newSessionResponse.sessionId).toBe("ws-1");
+    expect(harness.setTrustCalls).toEqual([{ projectPath: parentPath, trusted: true }]);
+    expect(harness.createCalls[0]?.projectPath).toBe(parentPath);
+    expect(harness.createCalls[0]?.subProjectPath).toBeUndefined();
+  });
+
   it("trusts the owning parent when ACP starts from a registered sub-project", async () => {
     const parentPath = "/repo/monorepo";
     const childPath = "/repo/monorepo/packages/api";

--- a/tests/ipc/acp.disconnectCleanup.test.ts
+++ b/tests/ipc/acp.disconnectCleanup.test.ts
@@ -1,8 +1,15 @@
+import { execFile } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { promisify } from "node:util";
 import { AgentSideConnection, PROTOCOL_VERSION, ndJsonStream } from "@agentclientprotocol/sdk";
 import type { ProjectConfig } from "../../src/common/types/project";
 import type { OnChatMode, WorkspaceChatMessage } from "../../src/common/orpc/types";
 import { MuxAgent } from "../../src/node/acp/agent";
 import type { ORPCClient, ServerConnection } from "../../src/node/acp/serverConnection";
+
+const execFileAsyncForTest = promisify(execFile);
 
 type WorkspaceInfo = NonNullable<Awaited<ReturnType<ORPCClient["workspace"]["getInfo"]>>>;
 
@@ -296,7 +303,7 @@ describe("ACP disconnect cleanup for untouched session/new workspaces", () => {
     expect(harness.createCalls).toEqual([]);
   });
 
-  it("uses the containing parent when ACP starts from an unregistered descendant", async () => {
+  it("keeps an unregistered descendant as its own project when git root cannot be verified", async () => {
     const parentPath = "/repo/monorepo";
     const packagePath = "/repo/monorepo/packages/unregistered";
     const harness = createHarness({
@@ -312,9 +319,38 @@ describe("ACP disconnect cleanup for untouched session/new workspaces", () => {
     });
 
     expect(newSessionResponse.sessionId).toBe("ws-1");
-    expect(harness.setTrustCalls).toEqual([{ projectPath: parentPath, trusted: true }]);
-    expect(harness.createCalls[0]?.projectPath).toBe(parentPath);
+    expect(harness.setTrustCalls).toEqual([{ projectPath: packagePath, trusted: true }]);
+    expect(harness.createCalls[0]?.projectPath).toBe(packagePath);
     expect(harness.createCalls[0]?.subProjectPath).toBeUndefined();
+  });
+
+  it("uses the containing parent when an unregistered descendant shares the same git root", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-acp-git-root-"));
+    try {
+      const parentPath = path.join(tempDir, "monorepo");
+      const packagePath = path.join(parentPath, "packages", "api");
+      await fs.mkdir(packagePath, { recursive: true });
+      await execFileAsyncForTest("git", ["init", "-q"], { cwd: parentPath });
+
+      const harness = createHarness({
+        requireTrustedProjectForCreate: true,
+        projectEntries: [[parentPath, { workspaces: [], trusted: false }]],
+      });
+      await harness.agent.initialize({ protocolVersion: PROTOCOL_VERSION });
+
+      const newSessionResponse = await harness.agent.newSession({
+        cwd: packagePath,
+        mcpServers: [],
+        _meta: { trunkBranch: "main" },
+      });
+
+      expect(newSessionResponse.sessionId).toBe("ws-1");
+      expect(harness.setTrustCalls).toEqual([{ projectPath: parentPath, trusted: true }]);
+      expect(harness.createCalls[0]?.projectPath).toBe(parentPath);
+      expect(harness.createCalls[0]?.subProjectPath).toBeUndefined();
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("trusts the owning parent when ACP starts from a registered sub-project", async () => {

--- a/tests/ipc/acp.disconnectCleanup.test.ts
+++ b/tests/ipc/acp.disconnectCleanup.test.ts
@@ -9,6 +9,7 @@ interface HarnessOptions {
   getReplayEvents?: (workspaceId: string) => WorkspaceChatMessage[];
   beforeCreateResolves?: Promise<void>;
   disconnectCleanupMaxWaitMs?: number;
+  requireTrustedProjectForCreate?: boolean;
 }
 
 interface Harness {
@@ -16,6 +17,7 @@ interface Harness {
   createdWorkspaceIds: string[];
   removeCalls: string[];
   replayChecks: string[];
+  setTrustCalls: Array<{ projectPath: string; trusted: boolean }>;
   closeConnection: () => void;
   connectionClosed: Promise<void>;
 }
@@ -96,6 +98,8 @@ function createHarness(options?: HarnessOptions): Harness {
   const createdWorkspaceIds: string[] = [];
   const removeCalls: string[] = [];
   const replayChecks: string[] = [];
+  const setTrustCalls: Array<{ projectPath: string; trusted: boolean }> = [];
+  const trustedProjectPaths = new Set<string>();
 
   const client = {
     config: {
@@ -107,7 +111,14 @@ function createHarness(options?: HarnessOptions): Harness {
         currentBranch: "main",
         recommendedTrunk: "main",
       }),
-      setTrust: async () => {},
+      setTrust: async (input: { projectPath: string; trusted: boolean }) => {
+        setTrustCalls.push(input);
+        if (input.trusted) {
+          trustedProjectPaths.add(input.projectPath);
+        } else {
+          trustedProjectPaths.delete(input.projectPath);
+        }
+      },
     },
     agents: {
       list: async () => [],
@@ -129,6 +140,16 @@ function createHarness(options?: HarnessOptions): Harness {
         title?: string;
         runtimeConfig?: WorkspaceInfo["runtimeConfig"];
       }) => {
+        if (
+          options?.requireTrustedProjectForCreate === true &&
+          !trustedProjectPaths.has(input.projectPath)
+        ) {
+          return {
+            success: false as const,
+            error: "project not trusted",
+          };
+        }
+
         const workspaceId = `ws-${workspacesById.size + 1}`;
         if (options?.beforeCreateResolves != null) {
           await options.beforeCreateResolves;
@@ -195,6 +216,7 @@ function createHarness(options?: HarnessOptions): Harness {
     createdWorkspaceIds,
     removeCalls,
     replayChecks,
+    setTrustCalls,
     closeConnection: closeInput,
     connectionClosed: connection.closed,
   };
@@ -211,6 +233,21 @@ async function waitForCondition(condition: () => boolean, timeoutMs = 1_000): Pr
 }
 
 describe("ACP disconnect cleanup for untouched session/new workspaces", () => {
+  it("trusts the ACP cwd before creating a session workspace", async () => {
+    const harness = createHarness({ requireTrustedProjectForCreate: true });
+    await harness.agent.initialize({ protocolVersion: PROTOCOL_VERSION });
+
+    const newSessionResponse = await harness.agent.newSession({
+      cwd: "/repo/acp-go-sdk",
+      mcpServers: [],
+      _meta: { trunkBranch: "main" },
+    });
+
+    expect(newSessionResponse.sessionId).toBe("ws-1");
+    expect(harness.setTrustCalls).toEqual([{ projectPath: "/repo/acp-go-sdk", trusted: true }]);
+    expect(harness.createdWorkspaceIds).toEqual(["ws-1"]);
+  });
+
   it("removes empty session/new workspace when connection closes", async () => {
     const harness = createHarness();
     await harness.agent.initialize({ protocolVersion: PROTOCOL_VERSION });

--- a/tests/ipc/acp.integration.test.ts
+++ b/tests/ipc/acp.integration.test.ts
@@ -45,8 +45,6 @@ interface AcpTestClient {
 
 interface CreateAcpClientOptions {
   logFilePath?: string;
-  /** Project path to pre-trust in the ephemeral config. */
-  projectPath?: string;
 }
 
 let buildMainPromise: Promise<void> | null = null;
@@ -180,16 +178,6 @@ async function createAcpClient(options: CreateAcpClientOptions = {}): Promise<Ac
   );
 
   const muxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "mux-acp-test-root-"));
-
-  // Pre-trust the repo in this test's ephemeral MUX_ROOT so workspace creation
-  // succeeds when newSession runs against a fresh config directory.
-  if (options.projectPath != null) {
-    const configPath = path.join(muxRoot, "config.json");
-    const trustedProjectConfig = {
-      projects: [[options.projectPath, { workspaces: [], trusted: true }]],
-    };
-    await fs.writeFile(configPath, JSON.stringify(trustedProjectConfig, null, 2));
-  }
 
   const acpArgs = ["dist/cli/index.js", "acp"];
   if (options.logFilePath != null) {
@@ -373,7 +361,7 @@ describeIntegration("ACP built CLI integration", () => {
     async () => {
       assert(repoPath.length > 0, "Temporary git repo path must be set");
 
-      const acpClient = await createAcpClient({ projectPath: repoPath });
+      const acpClient = await createAcpClient();
       try {
         await acpClient.runRpc(
           "initialize",
@@ -412,7 +400,7 @@ describeIntegration("ACP built CLI integration", () => {
       try {
         let acpClient: AcpTestClient | undefined;
         try {
-          acpClient = await createAcpClient({ logFilePath, projectPath: repoPath });
+          acpClient = await createAcpClient({ logFilePath });
 
           await acpClient.runRpc(
             "initialize",
@@ -458,7 +446,7 @@ describeIntegration("ACP built CLI integration", () => {
     async () => {
       assert(repoPath.length > 0, "Temporary git repo path must be set");
 
-      const acpClient = await createAcpClient({ projectPath: repoPath });
+      const acpClient = await createAcpClient();
       try {
         await acpClient.runRpc(
           "initialize",

--- a/tests/ipc/acp.promptCorrelation.test.ts
+++ b/tests/ipc/acp.promptCorrelation.test.ts
@@ -312,6 +312,7 @@ function createHarness(options?: HarnessOptions): Harness {
       getConfig: async () => ({}),
     },
     projects: {
+      list: async () => [],
       listBranches: async () => ({
         branches: ["main"],
         currentBranch: "main",

--- a/tests/ipc/acp.sessionMethods.test.ts
+++ b/tests/ipc/acp.sessionMethods.test.ts
@@ -1,4 +1,5 @@
 import { AgentSideConnection, PROTOCOL_VERSION, ndJsonStream } from "@agentclientprotocol/sdk";
+import type { ProjectConfig } from "../../src/common/types/project";
 import type { OnChatMode, WorkspaceChatMessage } from "../../src/common/orpc/types";
 import { MuxAgent } from "../../src/node/acp/agent";
 import type { ORPCClient, ServerConnection } from "../../src/node/acp/serverConnection";
@@ -6,18 +7,39 @@ import type { ORPCClient, ServerConnection } from "../../src/node/acp/serverConn
 type WorkspaceInfo = NonNullable<Awaited<ReturnType<ORPCClient["workspace"]["getInfo"]>>>;
 type WorkspaceActivityById = Awaited<ReturnType<ORPCClient["workspace"]["activity"]["list"]>>;
 
+interface WorkspaceCreateInput {
+  projectPath: string;
+  branchName?: string;
+  trunkBranch?: string;
+  title?: string;
+  runtimeConfig?: WorkspaceInfo["runtimeConfig"];
+  subProjectPath?: string;
+  pendingAutoTitle?: boolean;
+}
+
+interface WorkspaceForkInput {
+  sourceWorkspaceId: string;
+  newName?: string;
+  pendingAutoTitle?: boolean;
+}
+
 interface HarnessOptions {
   activeWorkspaces?: WorkspaceInfo[];
   archivedWorkspaces?: WorkspaceInfo[];
   workspaceActivity?: WorkspaceActivityById;
   onChatEvents?: WorkspaceChatMessage[];
   onChatStream?: AsyncIterable<WorkspaceChatMessage>;
+  requireTrustedProjectForCreate?: boolean;
+  projectEntries?: Array<[string, ProjectConfig]>;
   agentOptions?: ConstructorParameters<typeof MuxAgent>[2];
 }
 
 interface Harness {
   agent: MuxAgent;
   onChatCalls: Array<{ workspaceId: string; mode?: OnChatMode }>;
+  setTrustCalls: Array<{ projectPath: string; trusted: boolean }>;
+  createCalls: WorkspaceCreateInput[];
+  forkCalls: WorkspaceForkInput[];
   listCalls: Array<{ archived?: boolean } | undefined>;
 }
 
@@ -61,10 +83,36 @@ function createHarness(options?: HarnessOptions): Harness {
     allWorkspacesById.set(workspace.id, workspace);
   }
 
+  const setTrustCalls: Array<{ projectPath: string; trusted: boolean }> = [];
+  const createCalls: WorkspaceCreateInput[] = [];
+  const forkCalls: WorkspaceForkInput[] = [];
+  const projectsByPath = new Map<string, ProjectConfig>(options?.projectEntries ?? []);
   const onChatCalls: Array<{ workspaceId: string; mode?: OnChatMode }> = [];
   const listCalls: Array<{ archived?: boolean } | undefined> = [];
 
-  const client: Partial<ORPCClient> = {
+  const client = {
+    config: {
+      getConfig: async () => ({ agentAiDefaults: {} }),
+    },
+    projects: {
+      list: async () => Array.from(projectsByPath.entries()),
+      listBranches: async () => ({
+        branches: ["main"],
+        currentBranch: "main",
+        recommendedTrunk: "main",
+      }),
+      setTrust: async (input: { projectPath: string; trusted: boolean }) => {
+        setTrustCalls.push(input);
+        const currentProject = projectsByPath.get(input.projectPath) ?? { workspaces: [] };
+        projectsByPath.set(input.projectPath, {
+          ...currentProject,
+          trusted: input.trusted,
+        });
+      },
+    },
+    agents: {
+      list: async () => [],
+    },
     workspace: {
       list: async (input?: { archived?: boolean }) => {
         listCalls.push(input);
@@ -79,7 +127,58 @@ function createHarness(options?: HarnessOptions): Harness {
         onChatCalls.push(input);
         return sharedOnChatStream ?? createChatStream(onChatEvents);
       },
-    } as ORPCClient["workspace"],
+      create: async (input: WorkspaceCreateInput) => {
+        createCalls.push(input);
+        if (
+          options?.requireTrustedProjectForCreate === true &&
+          projectsByPath.get(input.projectPath)?.trusted !== true
+        ) {
+          return { success: false as const, error: "project not trusted" };
+        }
+
+        const workspaceId = `ws-created-${createCalls.length}`;
+        const metadata = createWorkspaceInfo({
+          id: workspaceId,
+          name: input.branchName ?? workspaceId,
+          title: input.title ?? input.branchName ?? workspaceId,
+          projectPath: input.projectPath,
+          subProjectPath: input.subProjectPath,
+          namedWorkspacePath: `${input.projectPath}/.mux/${input.branchName ?? workspaceId}`,
+          runtimeConfig: input.runtimeConfig ?? { type: "local" },
+        });
+        allWorkspacesById.set(workspaceId, metadata);
+        activeWorkspaces.push(metadata);
+        return { success: true as const, metadata };
+      },
+      fork: async (input: WorkspaceForkInput) => {
+        forkCalls.push(input);
+        const sourceWorkspace = allWorkspacesById.get(input.sourceWorkspaceId);
+        if (sourceWorkspace == null) {
+          return { success: false as const, error: "source workspace not found" };
+        }
+        if (
+          options?.requireTrustedProjectForCreate === true &&
+          projectsByPath.get(sourceWorkspace.projectPath)?.trusted !== true
+        ) {
+          return { success: false as const, error: "project not trusted" };
+        }
+
+        const workspaceId = `ws-forked-${forkCalls.length}`;
+        const metadata = createWorkspaceInfo({
+          ...sourceWorkspace,
+          id: workspaceId,
+          name: input.newName ?? workspaceId,
+          title: input.newName ?? workspaceId,
+          namedWorkspacePath: `${sourceWorkspace.projectPath}/.mux/${input.newName ?? workspaceId}`,
+        });
+        allWorkspacesById.set(workspaceId, metadata);
+        activeWorkspaces.push(metadata);
+        return { success: true as const, metadata };
+      },
+      sendMessage: async () => ({ success: true as const, data: undefined }),
+      updateModeAISettings: async () => ({ success: true as const, data: undefined }),
+      updateAgentAISettings: async () => ({ success: true as const, data: undefined }),
+    },
     agentSkills: {
       list: async () => [],
       listDiagnostics: async () => {
@@ -88,11 +187,11 @@ function createHarness(options?: HarnessOptions): Harness {
       get: async () => {
         throw new Error("createHarness: get not implemented for this test");
       },
-    } as ORPCClient["agentSkills"],
+    },
   };
 
   const server: ServerConnection = {
-    client: client as ORPCClient,
+    client: client as unknown as ORPCClient,
     baseUrl: "ws://127.0.0.1:1234",
     close: async () => undefined,
   };
@@ -115,6 +214,9 @@ function createHarness(options?: HarnessOptions): Harness {
   return {
     agent: agentInstance,
     onChatCalls,
+    setTrustCalls,
+    createCalls,
+    forkCalls,
     listCalls,
   };
 }
@@ -346,6 +448,97 @@ describe("ACP unstable session support", () => {
       workspaceId: "ws-live-to-full",
       mode: { type: "full" },
     });
+  });
+
+  it("trusts a loaded workspace before ACP /new creates a follow-on workspace", async () => {
+    const workspace = createWorkspaceInfo({
+      id: "ws-new-source",
+      projectPath: "/repo/follow-on",
+      namedWorkspacePath: "/repo/follow-on/.mux/ws-new-source",
+    });
+    const harness = createHarness({
+      activeWorkspaces: [workspace],
+      requireTrustedProjectForCreate: true,
+      projectEntries: [["/repo/follow-on", { workspaces: [], trusted: false }]],
+    });
+
+    await harness.agent.initialize({ protocolVersion: PROTOCOL_VERSION });
+    await harness.agent.loadSession({
+      sessionId: "ws-new-source",
+      cwd: "/repo/follow-on",
+      mcpServers: [],
+    });
+
+    await harness.agent.prompt({
+      sessionId: "ws-new-source",
+      prompt: [{ type: "text", text: "/new" }],
+    });
+
+    expect(harness.setTrustCalls).toEqual([{ projectPath: "/repo/follow-on", trusted: true }]);
+    expect(harness.createCalls).toHaveLength(1);
+    expect(harness.createCalls[0]?.projectPath).toBe("/repo/follow-on");
+  });
+
+  it("trusts a loaded workspace before ACP /fork creates a follow-on workspace", async () => {
+    const workspace = createWorkspaceInfo({
+      id: "ws-fork-source",
+      projectPath: "/repo/fork-follow-on",
+      namedWorkspacePath: "/repo/fork-follow-on/.mux/ws-fork-source",
+    });
+    const harness = createHarness({
+      activeWorkspaces: [workspace],
+      requireTrustedProjectForCreate: true,
+      projectEntries: [["/repo/fork-follow-on", { workspaces: [], trusted: false }]],
+    });
+
+    await harness.agent.initialize({ protocolVersion: PROTOCOL_VERSION });
+    await harness.agent.loadSession({
+      sessionId: "ws-fork-source",
+      cwd: "/repo/fork-follow-on",
+      mcpServers: [],
+    });
+
+    await harness.agent.prompt({
+      sessionId: "ws-fork-source",
+      prompt: [{ type: "text", text: "/fork" }],
+    });
+
+    expect(harness.setTrustCalls).toEqual([{ projectPath: "/repo/fork-follow-on", trusted: true }]);
+    expect(harness.forkCalls).toEqual([
+      { sourceWorkspaceId: "ws-fork-source", pendingAutoTitle: false },
+    ]);
+  });
+
+  it("trusts a loaded workspace before unstable_forkSession creates a follow-on workspace", async () => {
+    const workspace = createWorkspaceInfo({
+      id: "ws-rpc-fork-source",
+      projectPath: "/repo/rpc-fork-follow-on",
+      namedWorkspacePath: "/repo/rpc-fork-follow-on/.mux/ws-rpc-fork-source",
+    });
+    const harness = createHarness({
+      activeWorkspaces: [workspace],
+      requireTrustedProjectForCreate: true,
+      projectEntries: [["/repo/rpc-fork-follow-on", { workspaces: [], trusted: false }]],
+    });
+
+    await harness.agent.initialize({ protocolVersion: PROTOCOL_VERSION });
+    await harness.agent.loadSession({
+      sessionId: "ws-rpc-fork-source",
+      cwd: "/repo/rpc-fork-follow-on",
+      mcpServers: [],
+    });
+
+    const response = await harness.agent.unstable_forkSession({
+      sessionId: "ws-rpc-fork-source",
+      cwd: "/repo/rpc-fork-follow-on",
+      mcpServers: [],
+    });
+
+    expect(response.sessionId).toBe("ws-forked-1");
+    expect(harness.setTrustCalls).toEqual([
+      { projectPath: "/repo/rpc-fork-follow-on", trusted: true },
+    ]);
+    expect(harness.forkCalls).toEqual([{ sourceWorkspaceId: "ws-rpc-fork-source" }]);
   });
 
   it("evicts least-recently-used idle sessions when tracked session cap is exceeded", async () => {

--- a/tests/ipc/acp.sessionMethods.test.ts
+++ b/tests/ipc/acp.sessionMethods.test.ts
@@ -337,6 +337,37 @@ describe("ACP unstable session support", () => {
     expect(harness.listCalls.slice(0, 2)).toEqual([{ archived: false }, { archived: true }]);
   });
 
+  it("lists and resumes sessions from a sub-project cwd", async () => {
+    const workspace = createWorkspaceInfo({
+      id: "ws-sub-project",
+      projectPath: "/repo/monorepo",
+      subProjectPath: "/repo/monorepo/packages/api",
+      namedWorkspacePath: "/repo/monorepo/.mux/ws-sub-project",
+    });
+    const harness = createHarness({
+      activeWorkspaces: [workspace],
+      onChatEvents: [{ type: "caught-up" } as WorkspaceChatMessage],
+    });
+
+    await harness.agent.initialize({ protocolVersion: PROTOCOL_VERSION });
+
+    const listResponse = await harness.agent.unstable_listSessions({
+      cwd: "/repo/monorepo/packages/api",
+    });
+    expect(listResponse.sessions.map((session) => session.sessionId)).toEqual(["ws-sub-project"]);
+    expect(listResponse.sessions.map((session) => session.cwd)).toEqual([
+      "/repo/monorepo/packages/api",
+    ]);
+
+    await expect(
+      harness.agent.loadSession({
+        sessionId: "ws-sub-project",
+        cwd: "/repo/monorepo/packages/api",
+        mcpServers: [],
+      })
+    ).resolves.toBeDefined();
+  });
+
   it("rejects invalid list cursor values", async () => {
     const harness = createHarness();
     await harness.agent.initialize({ protocolVersion: PROTOCOL_VERSION });


### PR DESCRIPTION
## Summary

Auto-trust ACP-launched projects before workspace creation so editor-driven mux ACP sessions work from a fresh config without a separate desktop trust step.

## Background

ACP adapters are launched by an editor for a concrete working directory. Mux previously hit the backend workspace trust gate before an ACP session could be created, which made fresh ACP usage fail compared with other CLI-style adapters.

## Implementation

- Auto-trusts the ACP cwd before `session/new` branch discovery and workspace creation.
- Requires client-provided `_meta.projectPath` to canonicalize to the ACP `cwd` before it can influence the trusted path.
- Resolves registered sub-projects to their owning parent project so the same trust scope used by `workspace.create` is trusted, while preserving the sub-project path for workspace context.
- Applies the same ACP trust preflight to follow-on creation paths from loaded/resumed sessions: slash `/new`, slash `/fork`, and `unstable_forkSession`.

## Validation

- `bun test ./tests/ipc/acp.disconnectCleanup.test.ts ./tests/ipc/acp.sessionMethods.test.ts ./tests/ipc/acp.promptCorrelation.test.ts ./tests/ipc/acp.configOptions.test.ts`
- `bun run typecheck`
- `make fmt-check`
- `make static-check`

## Risks

Low-to-medium. The change intentionally broadens ACP session creation to persist trust for the editor cwd, but constrains metadata redirection and keeps existing backend trust gates in place. Regression coverage now covers mismatched metadata, normalized-equivalent metadata, sub-project parent trust, and loaded-session follow-on creation paths.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$32.32`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=32.32 -->
