### PR TITLE
🤖 fix: keep workflow scratch drafts out of git status

### DIFF
--- a/src/node/services/workflows/WorkflowDefinitionStore.test.ts
+++ b/src/node/services/workflows/WorkflowDefinitionStore.test.ts
@@ -304,7 +304,7 @@ describe("WorkflowDefinitionStore", () => {
     ).toContain("packages/app0/.mux/workflows/.scratch/sibling.js");
   });
 
-  test("adds a self-ignored fallback when repo rules unignore workflow files", async () => {
+  test("adds a self-ignored fallback before repo rules can unignore the first draft", async () => {
     using tmp = new DisposableTempDir("workflow-definitions");
     const workspaceRoot = path.join(tmp.path, "project");
     const scratchRoot = path.join(workspaceRoot, ".mux", "workflows", ".scratch");
@@ -317,7 +317,6 @@ describe("WorkflowDefinitionStore", () => {
       "/.mux/\n!/.mux/\n!/.mux/workflows/\n!/.mux/workflows/**\n",
       "utf-8"
     );
-    await writeWorkflow(scratchRoot, "scratch-demo", "Workspace scratch demo");
     const store = new WorkflowDefinitionStore({
       scratchRoot,
       projectRoot,
@@ -325,12 +324,24 @@ describe("WorkflowDefinitionStore", () => {
       builtIns: [],
     });
 
-    await store.listDefinitions({ projectTrusted: true });
+    const definitions = await store.listDefinitions({ projectTrusted: true });
 
+    expect(definitions).toEqual([]);
     expect(await readGitExclude(workspaceRoot)).toContain("/.mux/workflows/.scratch/");
     expect(await fs.readFile(path.join(scratchRoot, ".gitignore"), "utf-8")).toContain(
       "# mux: hide scratch workflow drafts when repo rules unignore workflows\n*\n"
     );
+    expect(
+      await runGit(workspaceRoot, [
+        "status",
+        "--short",
+        "--untracked-files=all",
+        "--",
+        ".mux/workflows/.scratch",
+      ])
+    ).toBe("");
+
+    await writeWorkflow(scratchRoot, "scratch-demo", "Workspace scratch demo");
     expect(
       await runGit(workspaceRoot, [
         "status",

--- a/src/node/services/workflows/WorkflowDefinitionStore.test.ts
+++ b/src/node/services/workflows/WorkflowDefinitionStore.test.ts
@@ -353,6 +353,50 @@ describe("WorkflowDefinitionStore", () => {
     ).toBe("");
   });
 
+  test("appends fallback when an existing scratch gitignore lacks a terminal catch-all", async () => {
+    using tmp = new DisposableTempDir("workflow-definitions");
+    const workspaceRoot = path.join(tmp.path, "project");
+    const scratchRoot = path.join(workspaceRoot, ".mux", "workflows", ".scratch");
+    const projectRoot = path.join(workspaceRoot, ".mux", "workflows");
+    const globalRoot = path.join(tmp.path, "mux-home", "workflows");
+    await fs.mkdir(scratchRoot, { recursive: true });
+    await runGit(workspaceRoot, ["init"]);
+    await fs.writeFile(
+      path.join(workspaceRoot, ".gitignore"),
+      "/.mux/\n!/.mux/\n!/.mux/workflows/\n!/.mux/workflows/**\n",
+      "utf-8"
+    );
+    await fs.writeFile(
+      path.join(scratchRoot, ".gitignore"),
+      "# existing comment *\n!keep-*\n",
+      "utf-8"
+    );
+    const store = new WorkflowDefinitionStore({
+      scratchRoot,
+      projectRoot,
+      globalRoot,
+      builtIns: [],
+    });
+
+    await store.listDefinitions({ projectTrusted: true });
+
+    const fallback = await fs.readFile(path.join(scratchRoot, ".gitignore"), "utf-8");
+    expect(fallback).toContain("# existing comment *\n!keep-*\n");
+    expect(fallback).toContain(
+      "# mux: hide scratch workflow drafts when repo rules unignore workflows\n*\n"
+    );
+    await writeWorkflow(scratchRoot, "scratch-demo", "Workspace scratch demo");
+    expect(
+      await runGit(workspaceRoot, [
+        "status",
+        "--short",
+        "--untracked-files=all",
+        "--",
+        ".mux/workflows/.scratch",
+      ])
+    ).toBe("");
+  });
+
   test("locally excludes an existing generated scratch gitignore", async () => {
     using tmp = new DisposableTempDir("workflow-definitions");
     const workspaceRoot = path.join(tmp.path, "project");

--- a/src/node/services/workflows/WorkflowDefinitionStore.test.ts
+++ b/src/node/services/workflows/WorkflowDefinitionStore.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from "bun:test";
 import { RUNTIME_MODE } from "@/common/types/runtime";
 import { DisposableTempDir } from "@/node/services/tempDir";
 import { TrueRemotePathMappedRuntime } from "@/node/services/tools/testHelpers";
+import { execFileAsync } from "@/node/utils/disposableExec";
 import {
   shouldDisableHostWorkflowActions,
   shouldUseRuntimeWorkflowProjectIO,
@@ -23,6 +24,35 @@ async function writeWorkflow(
     `// description: ${description}\nexport default async function workflow({ args }) { ${body} }\n`,
     "utf-8"
   );
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.stat(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function runGit(cwd: string, args: readonly string[]): Promise<string> {
+  using proc = execFileAsync("git", ["-C", cwd, ...args], { timeoutMs: 5_000 });
+  const result = await proc.result;
+  return result.stdout.replace(/\r?\n$/u, "");
+}
+
+async function readGitExclude(repoPath: string): Promise<string> {
+  const excludePath = await runGit(repoPath, [
+    "rev-parse",
+    "--path-format=absolute",
+    "--git-path",
+    "info/exclude",
+  ]);
+  try {
+    return await fs.readFile(excludePath, "utf-8");
+  } catch {
+    return "";
+  }
 }
 
 describe("WorkflowDefinitionStore", () => {
@@ -123,12 +153,45 @@ describe("WorkflowDefinitionStore", () => {
     expect(discovered.every((candidate) => candidate.scope !== "scratch")).toBe(true);
   });
 
-  test("discovers trusted workspace scratch workflows before reusable definitions and writes .gitignore", async () => {
+  test("does not create workspace scratch files while listing without scratch drafts", async () => {
     using tmp = new DisposableTempDir("workflow-definitions");
     const workspaceRoot = path.join(tmp.path, "project");
     const scratchRoot = path.join(workspaceRoot, ".mux", "workflows", ".scratch");
     const projectRoot = path.join(workspaceRoot, ".mux", "workflows");
     const globalRoot = path.join(tmp.path, "mux-home", "workflows");
+    await fs.mkdir(workspaceRoot, { recursive: true });
+    await runGit(workspaceRoot, ["init"]);
+    const store = new WorkflowDefinitionStore({
+      scratchRoot,
+      projectRoot,
+      globalRoot,
+      builtIns: [],
+    });
+
+    const definitions = await store.listDefinitions({ projectTrusted: true });
+
+    let muxDirExists = true;
+    try {
+      await fs.stat(path.join(workspaceRoot, ".mux"));
+    } catch {
+      muxDirExists = false;
+    }
+    const gitExclude = await readGitExclude(workspaceRoot);
+    expect(definitions).toEqual([]);
+    expect(muxDirExists).toBe(false);
+    expect(gitExclude).not.toContain(".mux/workflows/.scratch");
+    expect(await runGit(workspaceRoot, ["status", "--short"])).toBe("");
+  });
+
+  test("discovers trusted workspace scratch workflows before reusable definitions and excludes scratch locally", async () => {
+    using tmp = new DisposableTempDir("workflow-definitions");
+    const repoRoot = path.join(tmp.path, "repo");
+    const workspaceRoot = path.join(repoRoot, "packages", "app");
+    const scratchRoot = path.join(workspaceRoot, ".mux", "workflows", ".scratch");
+    const projectRoot = path.join(workspaceRoot, ".mux", "workflows");
+    const globalRoot = path.join(tmp.path, "mux-home", "workflows");
+    await fs.mkdir(workspaceRoot, { recursive: true });
+    await runGit(repoRoot, ["init"]);
     await writeWorkflow(globalRoot, "scratch-demo", "Global fallback");
     await writeWorkflow(
       scratchRoot,
@@ -151,7 +214,7 @@ describe("WorkflowDefinitionStore", () => {
 
     const definitions = await store.listDefinitions({ projectTrusted: true });
     const definition = await store.readDefinition("scratch-demo", { projectTrusted: true });
-    const gitignore = await fs.readFile(path.join(scratchRoot, ".gitignore"), "utf-8");
+    const gitExclude = await readGitExclude(workspaceRoot);
 
     expect(definitions).toEqual([
       {
@@ -165,7 +228,46 @@ describe("WorkflowDefinitionStore", () => {
     expect(definition.descriptor.scope).toBe("scratch");
     expect(definition.source).toContain("// description: Workspace scratch demo");
     expect(definition.source).toContain("reportMarkdown: 'scratch'");
-    expect(gitignore).toBe("*\n!.gitignore\n");
+    expect(await pathExists(path.join(scratchRoot, ".gitignore"))).toBe(false);
+    expect(gitExclude).toContain("# mux: local scratch workflow drafts");
+    expect(gitExclude).toContain("/packages/app/.mux/workflows/.scratch/");
+    expect(
+      await runGit(repoRoot, ["status", "--short", "--", "packages/app/.mux/workflows/.scratch"])
+    ).toBe("");
+
+    await writeWorkflow(projectRoot, "project-demo", "Project demo");
+    expect(
+      await runGit(repoRoot, [
+        "status",
+        "--short",
+        "--",
+        "packages/app/.mux/workflows/project-demo.js",
+      ])
+    ).toBe("?? packages/app/.mux/workflows/project-demo.js");
+  });
+
+  test("locally excludes an existing generated scratch gitignore", async () => {
+    using tmp = new DisposableTempDir("workflow-definitions");
+    const workspaceRoot = path.join(tmp.path, "project");
+    const scratchRoot = path.join(workspaceRoot, ".mux", "workflows", ".scratch");
+    const projectRoot = path.join(workspaceRoot, ".mux", "workflows");
+    const globalRoot = path.join(tmp.path, "mux-home", "workflows");
+    await fs.mkdir(scratchRoot, { recursive: true });
+    await runGit(workspaceRoot, ["init"]);
+    await fs.writeFile(path.join(scratchRoot, ".gitignore"), "*\n!.gitignore\n", "utf-8");
+    const store = new WorkflowDefinitionStore({
+      scratchRoot,
+      projectRoot,
+      globalRoot,
+      builtIns: [],
+    });
+
+    const definitions = await store.listDefinitions({ projectTrusted: true });
+
+    const gitExclude = await readGitExclude(workspaceRoot);
+    expect(definitions).toEqual([]);
+    expect(gitExclude).toContain("/.mux/workflows/.scratch/");
+    expect(await runGit(workspaceRoot, ["status", "--short"])).toBe("");
   });
 
   test("omits workspace scratch workflows when the project is not trusted", async () => {
@@ -205,9 +307,12 @@ describe("WorkflowDefinitionStore", () => {
     const runtime = new TrueRemotePathMappedRuntime(tmp.path, remoteBase);
     const projectRoot = runtime.normalizePath(".mux/workflows", workspacePath);
     const scratchRoot = runtime.normalizePath(".mux/workflows/.scratch", workspacePath);
-    const localWorkflowRoot = path.join(tmp.path, "project", "feature", ".mux", "workflows");
+    const localWorkspaceRoot = path.join(tmp.path, "project", "feature");
+    const localWorkflowRoot = path.join(localWorkspaceRoot, ".mux", "workflows");
     const localScratchRoot = path.join(localWorkflowRoot, ".scratch");
     const globalRoot = path.join(tmp.path, "mux-home", "workflows");
+    await fs.mkdir(localWorkspaceRoot, { recursive: true });
+    await runGit(localWorkspaceRoot, ["init"]);
     await writeWorkflow(
       localWorkflowRoot,
       "remote-demo",
@@ -247,8 +352,8 @@ describe("WorkflowDefinitionStore", () => {
     expect(definition.source).toContain("remote: true");
     expect(scratchDefinition.descriptor.sourcePath).toBe(`${scratchRoot}/scratch-remote.js`);
     expect(scratchDefinition.source).toContain("scratch: true");
-    const scratchGitignore = await fs.readFile(path.join(localScratchRoot, ".gitignore"), "utf-8");
-    expect(scratchGitignore).toBe("*\n!.gitignore\n");
+    expect(await pathExists(path.join(localScratchRoot, ".gitignore"))).toBe(false);
+    expect(await readGitExclude(localWorkspaceRoot)).toContain("/.mux/workflows/.scratch/");
     expect(promoted.sourcePath).toBe(`${projectRoot}/promoted-demo.js`);
     const promotedSource = await fs.readFile(
       path.join(localWorkflowRoot, "promoted-demo.js"),

--- a/src/node/services/workflows/WorkflowDefinitionStore.test.ts
+++ b/src/node/services/workflows/WorkflowDefinitionStore.test.ts
@@ -55,6 +55,8 @@ async function readGitExclude(repoPath: string): Promise<string> {
   }
 }
 
+const testPosixPermissions = process.platform === "win32" ? test.skip : test;
+
 describe("WorkflowDefinitionStore", () => {
   test("uses runtime project I/O only when workspace paths are runtime-owned", () => {
     expect(shouldUseRuntimeWorkflowProjectIO(RUNTIME_MODE.LOCAL)).toBe(false);
@@ -153,7 +155,7 @@ describe("WorkflowDefinitionStore", () => {
     expect(discovered.every((candidate) => candidate.scope !== "scratch")).toBe(true);
   });
 
-  test("does not create workspace scratch files while listing without scratch drafts", async () => {
+  test("prepares local scratch excludes while listing without creating workspace scratch files", async () => {
     using tmp = new DisposableTempDir("workflow-definitions");
     const workspaceRoot = path.join(tmp.path, "project");
     const scratchRoot = path.join(workspaceRoot, ".mux", "workflows", ".scratch");
@@ -170,17 +172,22 @@ describe("WorkflowDefinitionStore", () => {
 
     const definitions = await store.listDefinitions({ projectTrusted: true });
 
-    let muxDirExists = true;
-    try {
-      await fs.stat(path.join(workspaceRoot, ".mux"));
-    } catch {
-      muxDirExists = false;
-    }
     const gitExclude = await readGitExclude(workspaceRoot);
     expect(definitions).toEqual([]);
-    expect(muxDirExists).toBe(false);
-    expect(gitExclude).not.toContain(".mux/workflows/.scratch");
+    expect(await pathExists(path.join(workspaceRoot, ".mux"))).toBe(false);
+    expect(gitExclude).toContain("/.mux/workflows/.scratch/");
     expect(await runGit(workspaceRoot, ["status", "--short"])).toBe("");
+
+    await writeWorkflow(scratchRoot, "draft", "Scratch draft");
+    expect(
+      await runGit(workspaceRoot, [
+        "status",
+        "--short",
+        "--untracked-files=all",
+        "--",
+        ".mux/workflows/.scratch",
+      ])
+    ).toBe("");
   });
 
   test("discovers trusted workspace scratch workflows before reusable definitions and excludes scratch locally", async () => {
@@ -246,6 +253,95 @@ describe("WorkflowDefinitionStore", () => {
     ).toBe("?? packages/app/.mux/workflows/project-demo.js");
   });
 
+  test("escapes scratch exclude patterns for Git ignore metacharacters", async () => {
+    using tmp = new DisposableTempDir("workflow-definitions");
+    const repoRoot = path.join(tmp.path, "repo");
+    const workspaceRoot = path.join(repoRoot, "packages", "app[0]");
+    const scratchRoot = path.join(workspaceRoot, ".mux", "workflows", ".scratch");
+    const siblingScratchRoot = path.join(
+      repoRoot,
+      "packages",
+      "app0",
+      ".mux",
+      "workflows",
+      ".scratch"
+    );
+    const projectRoot = path.join(workspaceRoot, ".mux", "workflows");
+    const globalRoot = path.join(tmp.path, "mux-home", "workflows");
+    await fs.mkdir(workspaceRoot, { recursive: true });
+    await runGit(repoRoot, ["init"]);
+    await writeWorkflow(scratchRoot, "scratch-demo", "Workspace scratch demo");
+    const store = new WorkflowDefinitionStore({
+      scratchRoot,
+      projectRoot,
+      globalRoot,
+      builtIns: [],
+    });
+
+    await store.listDefinitions({ projectTrusted: true });
+
+    const gitExclude = await readGitExclude(repoRoot);
+    expect(gitExclude).toContain("/packages/app\\[0\\]/.mux/workflows/.scratch/");
+    expect(
+      await runGit(repoRoot, [
+        "status",
+        "--short",
+        "--untracked-files=all",
+        "--",
+        "packages/app[0]/.mux/workflows/.scratch",
+      ])
+    ).toBe("");
+
+    await writeWorkflow(siblingScratchRoot, "sibling", "Sibling scratch demo");
+    expect(
+      await runGit(repoRoot, [
+        "status",
+        "--short",
+        "--untracked-files=all",
+        "--",
+        "packages/app0/.mux/workflows/.scratch",
+      ])
+    ).toContain("packages/app0/.mux/workflows/.scratch/sibling.js");
+  });
+
+  test("adds a self-ignored fallback when repo rules unignore workflow files", async () => {
+    using tmp = new DisposableTempDir("workflow-definitions");
+    const workspaceRoot = path.join(tmp.path, "project");
+    const scratchRoot = path.join(workspaceRoot, ".mux", "workflows", ".scratch");
+    const projectRoot = path.join(workspaceRoot, ".mux", "workflows");
+    const globalRoot = path.join(tmp.path, "mux-home", "workflows");
+    await fs.mkdir(workspaceRoot, { recursive: true });
+    await runGit(workspaceRoot, ["init"]);
+    await fs.writeFile(
+      path.join(workspaceRoot, ".gitignore"),
+      "/.mux/\n!/.mux/\n!/.mux/workflows/\n!/.mux/workflows/**\n",
+      "utf-8"
+    );
+    await writeWorkflow(scratchRoot, "scratch-demo", "Workspace scratch demo");
+    const store = new WorkflowDefinitionStore({
+      scratchRoot,
+      projectRoot,
+      globalRoot,
+      builtIns: [],
+    });
+
+    await store.listDefinitions({ projectTrusted: true });
+
+    expect(await readGitExclude(workspaceRoot)).toContain("/.mux/workflows/.scratch/");
+    expect(await fs.readFile(path.join(scratchRoot, ".gitignore"), "utf-8")).toContain(
+      "# mux: hide scratch workflow drafts when repo rules unignore workflows\n*\n"
+    );
+    expect(
+      await runGit(workspaceRoot, [
+        "status",
+        "--short",
+        "--untracked-files=all",
+        "--",
+        ".mux/workflows/.scratch",
+      ])
+    ).toBe("");
+  });
+
   test("locally excludes an existing generated scratch gitignore", async () => {
     using tmp = new DisposableTempDir("workflow-definitions");
     const workspaceRoot = path.join(tmp.path, "project");
@@ -269,6 +365,90 @@ describe("WorkflowDefinitionStore", () => {
     expect(gitExclude).toContain("/.mux/workflows/.scratch/");
     expect(await runGit(workspaceRoot, ["status", "--short"])).toBe("");
   });
+
+  test("serializes local exclude updates for multiple scratch roots in one repo", async () => {
+    using tmp = new DisposableTempDir("workflow-definitions");
+    const repoRoot = path.join(tmp.path, "repo");
+    const appRoot = path.join(repoRoot, "packages", "app-a");
+    const otherRoot = path.join(repoRoot, "packages", "app-b");
+    const appScratchRoot = path.join(appRoot, ".mux", "workflows", ".scratch");
+    const otherScratchRoot = path.join(otherRoot, ".mux", "workflows", ".scratch");
+    const globalRoot = path.join(tmp.path, "mux-home", "workflows");
+    await fs.mkdir(appRoot, { recursive: true });
+    await fs.mkdir(otherRoot, { recursive: true });
+    await runGit(repoRoot, ["init"]);
+    await writeWorkflow(appScratchRoot, "app-draft", "App draft");
+    await writeWorkflow(otherScratchRoot, "other-draft", "Other draft");
+    const appStore = new WorkflowDefinitionStore({
+      scratchRoot: appScratchRoot,
+      projectRoot: path.join(appRoot, ".mux", "workflows"),
+      globalRoot,
+      builtIns: [],
+    });
+    const otherStore = new WorkflowDefinitionStore({
+      scratchRoot: otherScratchRoot,
+      projectRoot: path.join(otherRoot, ".mux", "workflows"),
+      globalRoot,
+      builtIns: [],
+    });
+
+    await Promise.all([
+      appStore.listDefinitions({ projectTrusted: true }),
+      otherStore.listDefinitions({ projectTrusted: true }),
+    ]);
+
+    const gitExclude = await readGitExclude(repoRoot);
+    expect(gitExclude).toContain("/packages/app-a/.mux/workflows/.scratch/");
+    expect(gitExclude).toContain("/packages/app-b/.mux/workflows/.scratch/");
+  });
+
+  testPosixPermissions(
+    "preserves existing local Git excludes when the exclude file cannot be read",
+    async () => {
+      using tmp = new DisposableTempDir("workflow-definitions");
+      const workspaceRoot = path.join(tmp.path, "project");
+      const scratchRoot = path.join(workspaceRoot, ".mux", "workflows", ".scratch");
+      const projectRoot = path.join(workspaceRoot, ".mux", "workflows");
+      const globalRoot = path.join(tmp.path, "mux-home", "workflows");
+      await fs.mkdir(workspaceRoot, { recursive: true });
+      await runGit(workspaceRoot, ["init"]);
+      const excludePath = await runGit(workspaceRoot, [
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-path",
+        "info/exclude",
+      ]);
+      const existingExclude = "# existing user exclude\nsecrets.txt\n";
+      await fs.mkdir(path.dirname(excludePath), { recursive: true });
+      await fs.writeFile(excludePath, existingExclude, "utf-8");
+      await fs.chmod(excludePath, 0o200);
+      let readBlocked = false;
+      try {
+        await fs.readFile(excludePath, "utf-8");
+      } catch {
+        readBlocked = true;
+      }
+      if (!readBlocked) {
+        await fs.chmod(excludePath, 0o600);
+        return;
+      }
+      await writeWorkflow(scratchRoot, "scratch-demo", "Workspace scratch demo");
+      const store = new WorkflowDefinitionStore({
+        scratchRoot,
+        projectRoot,
+        globalRoot,
+        builtIns: [],
+      });
+
+      try {
+        await store.listDefinitions({ projectTrusted: true });
+      } finally {
+        await fs.chmod(excludePath, 0o600);
+      }
+
+      expect(await fs.readFile(excludePath, "utf-8")).toBe(existingExclude);
+    }
+  );
 
   test("omits workspace scratch workflows when the project is not trusted", async () => {
     using tmp = new DisposableTempDir("workflow-definitions");

--- a/src/node/services/workflows/WorkflowDefinitionStore.ts
+++ b/src/node/services/workflows/WorkflowDefinitionStore.ts
@@ -347,8 +347,12 @@ function gitExcludeContentWithPattern(content: string, pattern: string): string 
 }
 
 function scratchGitignoreFallbackContent(content: string): string | null {
-  const trimmedContent = content.trimEnd();
-  if (trimmedContent.endsWith("*")) {
+  const lastPattern = content
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"))
+    .at(-1);
+  if (lastPattern === "*") {
     return null;
   }
   const separator = content.length > 0 && !content.endsWith("\n") ? "\n" : "";

--- a/src/node/services/workflows/WorkflowDefinitionStore.ts
+++ b/src/node/services/workflows/WorkflowDefinitionStore.ts
@@ -6,9 +6,11 @@ import { RUNTIME_MODE, type RuntimeMode } from "@/common/types/runtime";
 import type { WorkflowDefinitionDescriptor, WorkflowName } from "@/common/types/workflow";
 import assert from "@/common/utils/assert";
 import { getErrorMessage } from "@/common/utils/errors";
+import { shellQuote } from "@/common/utils/shell";
 import type { Runtime } from "@/node/runtime/Runtime";
 import { log } from "@/node/services/log";
 import { quoteRuntimeProbePath } from "@/node/services/tools/runtimePathShellQuote";
+import { execFileAsync } from "@/node/utils/disposableExec";
 import { execBuffered, readFileString, writeFileString } from "@/node/utils/runtime/helpers";
 import {
   BUILT_IN_WORKFLOW_DEFINITIONS,
@@ -56,9 +58,9 @@ interface ScannedWorkflowDefinition {
 }
 
 const DESCRIPTION_PREFIX = "// description:";
-// Workspace scratch workflows are edited through normal file tools, so keep generated drafts out
-// of the user's git status while leaving the ignore rule itself visible and reviewable.
-export const WORKFLOW_SCRATCH_GITIGNORE_CONTENT = "*\n!.gitignore\n";
+const WORKFLOW_SCRATCH_GIT_EXCLUDE_COMMENT = "# mux: local scratch workflow drafts";
+const LOCAL_GIT_COMMAND_TIMEOUT_MS = 5_000;
+const RUNTIME_GIT_COMMAND_TIMEOUT_SECONDS = 5;
 
 function parseWorkflowDescription(source: string): string | null {
   const firstMeaningfulLine = source
@@ -258,19 +260,190 @@ async function runtimePathExists(
   throw new Error(`Runtime workflow path probe failed: ${details}`);
 }
 
-async function ensureLocalScratchGitignore(scratchRoot: string): Promise<void> {
-  await fs.mkdir(scratchRoot, { recursive: true });
-  const gitignorePath = path.join(scratchRoot, ".gitignore");
-  await fs.writeFile(gitignorePath, WORKFLOW_SCRATCH_GITIGNORE_CONTENT, "utf-8");
+function stripTrailingLineEnding(value: string): string {
+  return value.replace(/\r?\n$/u, "");
 }
 
-async function ensureRuntimeScratchGitignore(runtime: Runtime, scratchRoot: string): Promise<void> {
-  await runtime.ensureDir(scratchRoot);
-  await writeFileString(
-    runtime,
-    runtime.normalizePath(".gitignore", scratchRoot),
-    WORKFLOW_SCRATCH_GITIGNORE_CONTENT
-  );
+function scratchGitExcludePatternFromPrefix(prefixOutput: string): string | null {
+  const prefix = stripTrailingLineEnding(prefixOutput).replace(/\/+$/u, "");
+  if (prefix.length === 0) {
+    return null;
+  }
+  assert(!prefix.startsWith("/"), "Workflow scratch Git prefix must be repo-relative");
+  assert(!prefix.includes("\0"), "Workflow scratch Git prefix must not contain NUL");
+  return `/${prefix}/`;
+}
+
+function gitExcludeContentWithPattern(content: string, pattern: string): string | null {
+  assert(pattern.startsWith("/"), "Workflow scratch Git exclude pattern must be root-relative");
+  if (content.split(/\r?\n/u).some((line) => line.trim() === pattern)) {
+    return null;
+  }
+
+  const separator = content.length > 0 && !content.endsWith("\n") ? "\n" : "";
+  return `${content}${separator}${WORKFLOW_SCRATCH_GIT_EXCLUDE_COMMENT}\n${pattern}\n`;
+}
+
+async function writeLocalGitExcludePattern(excludePath: string, pattern: string): Promise<void> {
+  assert(excludePath.length > 0, "Workflow scratch Git exclude path is required");
+  await fs.mkdir(path.dirname(excludePath), { recursive: true });
+
+  let content = "";
+  try {
+    content = await fs.readFile(excludePath, "utf-8");
+  } catch {
+    content = "";
+  }
+
+  const nextContent = gitExcludeContentWithPattern(content, pattern);
+  if (nextContent != null) {
+    await fs.writeFile(excludePath, nextContent, "utf-8");
+  }
+}
+
+async function tryLocalGitStdout(cwd: string, args: readonly string[]): Promise<string | null> {
+  try {
+    using proc = execFileAsync("git", ["-C", cwd, ...args], {
+      timeoutMs: LOCAL_GIT_COMMAND_TIMEOUT_MS,
+    });
+    const result = await proc.result;
+    return stripTrailingLineEnding(result.stdout);
+  } catch {
+    return null;
+  }
+}
+
+async function localDirectoryExists(targetPath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(targetPath);
+    return stat.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+// Scratch drafts are workspace-local, but writing .scratch/.gitignore dirties clean repos.
+// Use repo-local Git excludes only once a scratch directory actually exists.
+async function ensureLocalScratchGitExclude(scratchRoot: string): Promise<void> {
+  if (!(await localDirectoryExists(scratchRoot))) {
+    return;
+  }
+
+  try {
+    const prefix = await tryLocalGitStdout(scratchRoot, ["rev-parse", "--show-prefix"]);
+    if (prefix == null) {
+      return;
+    }
+    const pattern = scratchGitExcludePatternFromPrefix(prefix);
+    if (pattern == null) {
+      return;
+    }
+
+    const excludePath = await tryLocalGitStdout(scratchRoot, [
+      "rev-parse",
+      "--path-format=absolute",
+      "--git-path",
+      "info/exclude",
+    ]);
+    if (excludePath == null || excludePath.length === 0) {
+      return;
+    }
+
+    await writeLocalGitExcludePattern(excludePath, pattern);
+  } catch (error) {
+    log.debug("Failed to install local scratch workflow Git exclude", {
+      scratchRoot,
+      error: getErrorMessage(error),
+    });
+  }
+}
+
+async function runtimeDirectoryExists(runtime: Runtime, targetPath: string): Promise<boolean> {
+  try {
+    const stat = await runtime.stat(targetPath);
+    return stat.isDirectory;
+  } catch {
+    return false;
+  }
+}
+
+async function tryRuntimeGitStdout(
+  runtime: Runtime,
+  commandCwd: string,
+  gitCwd: string,
+  args: readonly string[]
+): Promise<string | null> {
+  const command = `git -C ${quoteRuntimeProbePath(gitCwd)} ${args.map(shellQuote).join(" ")}`;
+  const result = await execBuffered(runtime, command, {
+    cwd: commandCwd,
+    timeout: RUNTIME_GIT_COMMAND_TIMEOUT_SECONDS,
+  });
+  if (result.exitCode !== 0) {
+    return null;
+  }
+  return stripTrailingLineEnding(result.stdout);
+}
+
+async function writeRuntimeGitExcludePattern(
+  runtime: Runtime,
+  excludePath: string,
+  pattern: string
+): Promise<void> {
+  assert(excludePath.length > 0, "Workflow scratch runtime Git exclude path is required");
+  await runtime.ensureDir(path.posix.dirname(excludePath));
+
+  let content = "";
+  try {
+    content = await readFileString(runtime, excludePath);
+  } catch {
+    content = "";
+  }
+
+  const nextContent = gitExcludeContentWithPattern(content, pattern);
+  if (nextContent != null) {
+    await writeFileString(runtime, excludePath, nextContent);
+  }
+}
+
+async function ensureRuntimeScratchGitExclude(
+  runtime: Runtime,
+  scratchRoot: string,
+  commandCwd: string
+): Promise<void> {
+  if (!(await runtimeDirectoryExists(runtime, scratchRoot))) {
+    return;
+  }
+
+  try {
+    const prefix = await tryRuntimeGitStdout(runtime, commandCwd, scratchRoot, [
+      "rev-parse",
+      "--show-prefix",
+    ]);
+    if (prefix == null) {
+      return;
+    }
+    const pattern = scratchGitExcludePatternFromPrefix(prefix);
+    if (pattern == null) {
+      return;
+    }
+
+    const excludePath = await tryRuntimeGitStdout(runtime, commandCwd, scratchRoot, [
+      "rev-parse",
+      "--path-format=absolute",
+      "--git-path",
+      "info/exclude",
+    ]);
+    if (excludePath == null || excludePath.length === 0) {
+      return;
+    }
+
+    await writeRuntimeGitExcludePattern(runtime, excludePath, pattern);
+  } catch (error) {
+    log.debug("Failed to install runtime scratch workflow Git exclude", {
+      scratchRoot,
+      error: getErrorMessage(error),
+    });
+  }
 }
 
 function readBuiltInDefinitions(
@@ -423,7 +596,11 @@ export class WorkflowDefinitionStore {
           this.projectCwd != null,
           "WorkflowDefinitionStore.collectDefinitions: projectCwd missing"
         );
-        await ensureRuntimeScratchGitignore(this.projectRuntime, this.scratchRoot);
+        await ensureRuntimeScratchGitExclude(
+          this.projectRuntime,
+          this.scratchRoot,
+          this.projectCwd
+        );
         sources.push(
           await scanRuntimeDirectory(
             this.projectRuntime,
@@ -433,7 +610,7 @@ export class WorkflowDefinitionStore {
           )
         );
       } else {
-        await ensureLocalScratchGitignore(this.scratchRoot);
+        await ensureLocalScratchGitExclude(this.scratchRoot);
         sources.push(await scanDirectory(this.scratchRoot, "scratch"));
       }
     }

--- a/src/node/services/workflows/WorkflowDefinitionStore.ts
+++ b/src/node/services/workflows/WorkflowDefinitionStore.ts
@@ -59,6 +59,8 @@ interface ScannedWorkflowDefinition {
 
 const DESCRIPTION_PREFIX = "// description:";
 const WORKFLOW_SCRATCH_GIT_EXCLUDE_COMMENT = "# mux: local scratch workflow drafts";
+const WORKFLOW_SCRATCH_GITIGNORE_FALLBACK_COMMENT =
+  "# mux: hide scratch workflow drafts when repo rules unignore workflows";
 const LOCAL_GIT_COMMAND_TIMEOUT_MS = 5_000;
 const RUNTIME_GIT_COMMAND_TIMEOUT_SECONDS = 5;
 
@@ -260,8 +262,47 @@ async function runtimePathExists(
   throw new Error(`Runtime workflow path probe failed: ${details}`);
 }
 
+const gitExcludeUpdateLocks = new Map<string, Promise<void>>();
+
 function stripTrailingLineEnding(value: string): string {
   return value.replace(/\r?\n$/u, "");
+}
+
+function getErrorCode(error: unknown): string | null {
+  if (typeof error !== "object" || error == null || !("code" in error)) {
+    return null;
+  }
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" ? code : null;
+}
+
+async function withSerializedGitExcludeUpdate(
+  excludePath: string,
+  update: () => Promise<void>
+): Promise<void> {
+  const previous = gitExcludeUpdateLocks.get(excludePath) ?? Promise.resolve();
+  let releaseCurrent: (value?: void | PromiseLike<void>) => void = () => undefined;
+  const current = new Promise<void>((resolve) => {
+    releaseCurrent = resolve;
+  });
+  const queued = previous.catch(() => undefined).then(() => current);
+  gitExcludeUpdateLocks.set(excludePath, queued);
+
+  await previous.catch(() => undefined);
+  try {
+    await update();
+  } finally {
+    releaseCurrent();
+    if (gitExcludeUpdateLocks.get(excludePath) === queued) {
+      gitExcludeUpdateLocks.delete(excludePath);
+    }
+  }
+}
+
+function escapeGitIgnorePatternSegment(segment: string): string {
+  assert(!segment.includes("\0"), "Workflow scratch Git prefix must not contain NUL");
+  assert(!/[\r\n]/u.test(segment), "Workflow scratch Git prefix must not contain line separators");
+  return segment.replace(/[\\*?[\]]/gu, "\\$&");
 }
 
 function scratchGitExcludePatternFromPrefix(prefixOutput: string): string | null {
@@ -269,9 +310,30 @@ function scratchGitExcludePatternFromPrefix(prefixOutput: string): string | null
   if (prefix.length === 0) {
     return null;
   }
+  if (/[\r\n]/u.test(prefix)) {
+    return null;
+  }
   assert(!prefix.startsWith("/"), "Workflow scratch Git prefix must be repo-relative");
-  assert(!prefix.includes("\0"), "Workflow scratch Git prefix must not contain NUL");
-  return `/${prefix}/`;
+
+  const segments = prefix.split("/").filter((segment) => segment.length > 0);
+  assert(segments.length > 0, "Workflow scratch Git prefix must have path segments");
+  return `/${segments.map(escapeGitIgnorePatternSegment).join("/")}/`;
+}
+
+function scratchGitPrefixForWorkspace(
+  workspacePrefixOutput: string,
+  scratchRelativePath: string
+): string | null {
+  const workspacePrefix = stripTrailingLineEnding(workspacePrefixOutput).replace(/\/+$/u, "");
+  const scratchRelativePrefix = scratchRelativePath
+    .replaceAll("\\", "/")
+    .replace(/^\/+|\/+$/gu, "");
+  if (scratchRelativePrefix.length === 0) {
+    return null;
+  }
+  return workspacePrefix.length > 0
+    ? `${workspacePrefix}/${scratchRelativePrefix}/`
+    : `${scratchRelativePrefix}/`;
 }
 
 function gitExcludeContentWithPattern(content: string, pattern: string): string | null {
@@ -284,20 +346,61 @@ function gitExcludeContentWithPattern(content: string, pattern: string): string 
   return `${content}${separator}${WORKFLOW_SCRATCH_GIT_EXCLUDE_COMMENT}\n${pattern}\n`;
 }
 
+function scratchGitignoreFallbackContent(content: string): string | null {
+  const trimmedContent = content.trimEnd();
+  if (trimmedContent.endsWith("*")) {
+    return null;
+  }
+  const separator = content.length > 0 && !content.endsWith("\n") ? "\n" : "";
+  return `${content}${separator}${WORKFLOW_SCRATCH_GITIGNORE_FALLBACK_COMMENT}\n*\n`;
+}
+
 async function writeLocalGitExcludePattern(excludePath: string, pattern: string): Promise<void> {
   assert(excludePath.length > 0, "Workflow scratch Git exclude path is required");
-  await fs.mkdir(path.dirname(excludePath), { recursive: true });
+  await withSerializedGitExcludeUpdate(excludePath, async () => {
+    await fs.mkdir(path.dirname(excludePath), { recursive: true });
 
+    let content = "";
+    try {
+      await fs.stat(excludePath);
+      content = await fs.readFile(excludePath, "utf-8");
+    } catch (error) {
+      if (getErrorCode(error) !== "ENOENT") {
+        log.debug("Skipping scratch workflow Git exclude update after read failure", {
+          excludePath,
+          error: getErrorMessage(error),
+        });
+        return;
+      }
+    }
+
+    const nextContent = gitExcludeContentWithPattern(content, pattern);
+    if (nextContent != null) {
+      await fs.writeFile(excludePath, nextContent, "utf-8");
+    }
+  });
+}
+
+async function writeLocalScratchGitignoreFallback(scratchRoot: string): Promise<void> {
+  await fs.mkdir(scratchRoot, { recursive: true });
+  const gitignorePath = path.join(scratchRoot, ".gitignore");
   let content = "";
   try {
-    content = await fs.readFile(excludePath, "utf-8");
-  } catch {
-    content = "";
+    await fs.stat(gitignorePath);
+    content = await fs.readFile(gitignorePath, "utf-8");
+  } catch (error) {
+    if (getErrorCode(error) !== "ENOENT") {
+      log.debug("Skipping scratch workflow fallback .gitignore update after read failure", {
+        gitignorePath,
+        error: getErrorMessage(error),
+      });
+      return;
+    }
   }
 
-  const nextContent = gitExcludeContentWithPattern(content, pattern);
+  const nextContent = scratchGitignoreFallbackContent(content);
   if (nextContent != null) {
-    await fs.writeFile(excludePath, nextContent, "utf-8");
+    await fs.writeFile(gitignorePath, nextContent, "utf-8");
   }
 }
 
@@ -313,6 +416,26 @@ async function tryLocalGitStdout(cwd: string, args: readonly string[]): Promise<
   }
 }
 
+function getProcessExitCode(error: unknown): number | null {
+  if (typeof error !== "object" || error == null || !("code" in error)) {
+    return null;
+  }
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "number" ? code : null;
+}
+
+async function tryLocalGitExitCode(cwd: string, args: readonly string[]): Promise<number | null> {
+  try {
+    using proc = execFileAsync("git", ["-C", cwd, ...args], {
+      timeoutMs: LOCAL_GIT_COMMAND_TIMEOUT_MS,
+    });
+    await proc.result;
+    return 0;
+  } catch (error) {
+    return getProcessExitCode(error);
+  }
+}
+
 async function localDirectoryExists(targetPath: string): Promise<boolean> {
   try {
     const stat = await fs.stat(targetPath);
@@ -322,24 +445,54 @@ async function localDirectoryExists(targetPath: string): Promise<boolean> {
   }
 }
 
+function localScratchWorkspaceRoot(scratchRoot: string): string {
+  return path.dirname(path.dirname(path.dirname(scratchRoot)));
+}
+
+function localScratchRelativePath(workspaceRoot: string, scratchRoot: string): string {
+  const relativePath = path.relative(workspaceRoot, scratchRoot);
+  assert(
+    relativePath.length > 0 && !relativePath.startsWith("..") && !path.isAbsolute(relativePath),
+    "Workflow scratch root must be under the workspace root"
+  );
+  return relativePath.split(path.sep).join("/");
+}
+
+async function isLocalGitIgnored(cwd: string, targetPath: string): Promise<boolean | null> {
+  const exitCode = await tryLocalGitExitCode(cwd, ["check-ignore", "-q", "--", targetPath]);
+  if (exitCode === 0) {
+    return true;
+  }
+  if (exitCode === 1) {
+    return false;
+  }
+  return null;
+}
+
 // Scratch drafts are workspace-local, but writing .scratch/.gitignore dirties clean repos.
-// Use repo-local Git excludes only once a scratch directory actually exists.
+// Prefer repo-local Git excludes; write a self-ignored fallback only when repo rules override them.
 async function ensureLocalScratchGitExclude(scratchRoot: string): Promise<void> {
-  if (!(await localDirectoryExists(scratchRoot))) {
+  const workspaceRoot = localScratchWorkspaceRoot(scratchRoot);
+  if (!(await localDirectoryExists(workspaceRoot))) {
     return;
   }
 
   try {
-    const prefix = await tryLocalGitStdout(scratchRoot, ["rev-parse", "--show-prefix"]);
-    if (prefix == null) {
+    const workspacePrefix = await tryLocalGitStdout(workspaceRoot, ["rev-parse", "--show-prefix"]);
+    if (workspacePrefix == null) {
       return;
     }
-    const pattern = scratchGitExcludePatternFromPrefix(prefix);
+    const scratchPrefix = scratchGitPrefixForWorkspace(
+      workspacePrefix,
+      localScratchRelativePath(workspaceRoot, scratchRoot)
+    );
+    const pattern =
+      scratchPrefix == null ? null : scratchGitExcludePatternFromPrefix(scratchPrefix);
     if (pattern == null) {
       return;
     }
 
-    const excludePath = await tryLocalGitStdout(scratchRoot, [
+    const excludePath = await tryLocalGitStdout(workspaceRoot, [
       "rev-parse",
       "--path-format=absolute",
       "--git-path",
@@ -350,6 +503,14 @@ async function ensureLocalScratchGitExclude(scratchRoot: string): Promise<void> 
     }
 
     await writeLocalGitExcludePattern(excludePath, pattern);
+
+    if (await localDirectoryExists(scratchRoot)) {
+      const fallbackProbePath = path.join(scratchRoot, ".gitignore");
+      const ignored = await isLocalGitIgnored(workspaceRoot, fallbackProbePath);
+      if (ignored === false) {
+        await writeLocalScratchGitignoreFallback(scratchRoot);
+      }
+    }
   } catch (error) {
     log.debug("Failed to install local scratch workflow Git exclude", {
       scratchRoot,
@@ -365,6 +526,21 @@ async function runtimeDirectoryExists(runtime: Runtime, targetPath: string): Pro
   } catch {
     return false;
   }
+}
+
+function runtimeRelativePathUnder(basePath: string, targetPath: string): string | null {
+  const normalizedBase = basePath.replace(/\/+$/u, "");
+  const normalizedTarget = targetPath.replace(/\/+$/u, "");
+  if (normalizedBase === "/") {
+    return normalizedTarget.startsWith("/") ? normalizedTarget.slice(1) : null;
+  }
+  if (normalizedTarget === normalizedBase) {
+    return "";
+  }
+  if (!normalizedTarget.startsWith(`${normalizedBase}/`)) {
+    return null;
+  }
+  return normalizedTarget.slice(normalizedBase.length + 1);
 }
 
 async function tryRuntimeGitStdout(
@@ -386,23 +562,78 @@ async function tryRuntimeGitStdout(
 
 async function writeRuntimeGitExcludePattern(
   runtime: Runtime,
+  commandCwd: string,
   excludePath: string,
   pattern: string
 ): Promise<void> {
   assert(excludePath.length > 0, "Workflow scratch runtime Git exclude path is required");
-  await runtime.ensureDir(path.posix.dirname(excludePath));
+  await withSerializedGitExcludeUpdate(excludePath, async () => {
+    await runtime.ensureDir(path.posix.dirname(excludePath));
 
+    let content = "";
+    if (await runtimePathExists(runtime, excludePath, commandCwd)) {
+      try {
+        content = await readFileString(runtime, excludePath);
+      } catch (error) {
+        log.debug("Skipping runtime scratch workflow Git exclude update after read failure", {
+          excludePath,
+          error: getErrorMessage(error),
+        });
+        return;
+      }
+    }
+
+    const nextContent = gitExcludeContentWithPattern(content, pattern);
+    if (nextContent != null) {
+      await writeFileString(runtime, excludePath, nextContent);
+    }
+  });
+}
+
+async function writeRuntimeScratchGitignoreFallback(
+  runtime: Runtime,
+  commandCwd: string,
+  scratchRoot: string
+): Promise<void> {
+  await runtime.ensureDir(scratchRoot);
+  const gitignorePath = runtime.normalizePath(".gitignore", scratchRoot);
   let content = "";
-  try {
-    content = await readFileString(runtime, excludePath);
-  } catch {
-    content = "";
+  if (await runtimePathExists(runtime, gitignorePath, commandCwd)) {
+    try {
+      content = await readFileString(runtime, gitignorePath);
+    } catch (error) {
+      log.debug("Skipping runtime scratch workflow fallback .gitignore update after read failure", {
+        gitignorePath,
+        error: getErrorMessage(error),
+      });
+      return;
+    }
   }
 
-  const nextContent = gitExcludeContentWithPattern(content, pattern);
+  const nextContent = scratchGitignoreFallbackContent(content);
   if (nextContent != null) {
-    await writeFileString(runtime, excludePath, nextContent);
+    await writeFileString(runtime, gitignorePath, nextContent);
   }
+}
+
+async function isRuntimeGitIgnored(
+  runtime: Runtime,
+  commandCwd: string,
+  gitCwd: string,
+  targetPath: string
+): Promise<boolean | null> {
+  const command = `git -C ${quoteRuntimeProbePath(gitCwd)} check-ignore -q -- ${quoteRuntimeProbePath(targetPath)}`;
+  const result = await execBuffered(runtime, command, {
+    cwd: commandCwd,
+    timeout: RUNTIME_GIT_COMMAND_TIMEOUT_SECONDS,
+  });
+  if (result.exitCode === 0) {
+    return true;
+  }
+  if (result.exitCode === 1) {
+    return false;
+  }
+  return null;
 }
 
 async function ensureRuntimeScratchGitExclude(
@@ -410,24 +641,26 @@ async function ensureRuntimeScratchGitExclude(
   scratchRoot: string,
   commandCwd: string
 ): Promise<void> {
-  if (!(await runtimeDirectoryExists(runtime, scratchRoot))) {
-    return;
-  }
-
   try {
-    const prefix = await tryRuntimeGitStdout(runtime, commandCwd, scratchRoot, [
+    const workspacePrefix = await tryRuntimeGitStdout(runtime, commandCwd, commandCwd, [
       "rev-parse",
       "--show-prefix",
     ]);
-    if (prefix == null) {
+    if (workspacePrefix == null) {
       return;
     }
-    const pattern = scratchGitExcludePatternFromPrefix(prefix);
+    const scratchRelativePath = runtimeRelativePathUnder(commandCwd, scratchRoot);
+    if (scratchRelativePath == null) {
+      return;
+    }
+    const scratchPrefix = scratchGitPrefixForWorkspace(workspacePrefix, scratchRelativePath);
+    const pattern =
+      scratchPrefix == null ? null : scratchGitExcludePatternFromPrefix(scratchPrefix);
     if (pattern == null) {
       return;
     }
 
-    const excludePath = await tryRuntimeGitStdout(runtime, commandCwd, scratchRoot, [
+    const excludePath = await tryRuntimeGitStdout(runtime, commandCwd, commandCwd, [
       "rev-parse",
       "--path-format=absolute",
       "--git-path",
@@ -437,7 +670,15 @@ async function ensureRuntimeScratchGitExclude(
       return;
     }
 
-    await writeRuntimeGitExcludePattern(runtime, excludePath, pattern);
+    await writeRuntimeGitExcludePattern(runtime, commandCwd, excludePath, pattern);
+
+    if (await runtimeDirectoryExists(runtime, scratchRoot)) {
+      const fallbackProbePath = runtime.normalizePath(".gitignore", scratchRoot);
+      const ignored = await isRuntimeGitIgnored(runtime, commandCwd, commandCwd, fallbackProbePath);
+      if (ignored === false) {
+        await writeRuntimeScratchGitignoreFallback(runtime, commandCwd, scratchRoot);
+      }
+    }
   } catch (error) {
     log.debug("Failed to install runtime scratch workflow Git exclude", {
       scratchRoot,

--- a/src/node/services/workflows/WorkflowDefinitionStore.ts
+++ b/src/node/services/workflows/WorkflowDefinitionStore.ts
@@ -504,27 +504,16 @@ async function ensureLocalScratchGitExclude(scratchRoot: string): Promise<void> 
 
     await writeLocalGitExcludePattern(excludePath, pattern);
 
-    if (await localDirectoryExists(scratchRoot)) {
-      const fallbackProbePath = path.join(scratchRoot, ".gitignore");
-      const ignored = await isLocalGitIgnored(workspaceRoot, fallbackProbePath);
-      if (ignored === false) {
-        await writeLocalScratchGitignoreFallback(scratchRoot);
-      }
+    const fallbackProbePath = path.join(scratchRoot, ".gitignore");
+    const ignored = await isLocalGitIgnored(workspaceRoot, fallbackProbePath);
+    if (ignored === false) {
+      await writeLocalScratchGitignoreFallback(scratchRoot);
     }
   } catch (error) {
     log.debug("Failed to install local scratch workflow Git exclude", {
       scratchRoot,
       error: getErrorMessage(error),
     });
-  }
-}
-
-async function runtimeDirectoryExists(runtime: Runtime, targetPath: string): Promise<boolean> {
-  try {
-    const stat = await runtime.stat(targetPath);
-    return stat.isDirectory;
-  } catch {
-    return false;
   }
 }
 
@@ -672,12 +661,10 @@ async function ensureRuntimeScratchGitExclude(
 
     await writeRuntimeGitExcludePattern(runtime, commandCwd, excludePath, pattern);
 
-    if (await runtimeDirectoryExists(runtime, scratchRoot)) {
-      const fallbackProbePath = runtime.normalizePath(".gitignore", scratchRoot);
-      const ignored = await isRuntimeGitIgnored(runtime, commandCwd, commandCwd, fallbackProbePath);
-      if (ignored === false) {
-        await writeRuntimeScratchGitignoreFallback(runtime, commandCwd, scratchRoot);
-      }
+    const fallbackProbePath = runtime.normalizePath(".gitignore", scratchRoot);
+    const ignored = await isRuntimeGitIgnored(runtime, commandCwd, commandCwd, fallbackProbePath);
+    if (ignored === false) {
+      await writeRuntimeScratchGitignoreFallback(runtime, commandCwd, scratchRoot);
     }
   } catch (error) {
     log.debug("Failed to install runtime scratch workflow Git exclude", {

--- a/src/node/services/workflows/WorkflowRunner.test.ts
+++ b/src/node/services/workflows/WorkflowRunner.test.ts
@@ -18,6 +18,8 @@ import { hashWorkflowStepInput } from "./workflowReplayKey";
 
 const execFileAsync = promisify(execFile);
 
+const WORKFLOW_RUNNER_TEST_STALE_LEASE_MS = 100;
+
 async function runGit(cwd: string, args: string[]): Promise<void> {
   await execFileAsync("git", args, { cwd });
 }
@@ -38,7 +40,10 @@ const source = `export default function workflow({ args, phase, log, agent }) {
 `;
 
 async function createRunStore(sessionDir: string) {
-  const store = new WorkflowRunStore({ sessionDir, staleLeaseMs: 10 });
+  const store = new WorkflowRunStore({
+    sessionDir,
+    staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+  });
   await store.createRun({
     id: "wfr_123",
     workspaceId: "workspace-1",
@@ -159,7 +164,10 @@ describe("WorkflowRunner", () => {
 
   test("returns child task IDs to workflow code", async () => {
     using tmp = new DisposableTempDir("workflow-runner-task-id");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_task_id",
       workspaceId: "workspace-1",
@@ -185,7 +193,10 @@ describe("WorkflowRunner", () => {
 
   test("applies workflow-owned child patches through a durable applyPatch step", async () => {
     using tmp = new DisposableTempDir("workflow-runner-apply-patch");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_apply_patch",
       workspaceId: "workspace-1",
@@ -242,7 +253,10 @@ describe("WorkflowRunner", () => {
 
   test("classifies nested failedPatchSubject applyPatch results as conflicts", async () => {
     using tmp = new DisposableTempDir("workflow-runner-apply-patch-nested-subject");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_apply_patch_nested_subject",
       workspaceId: "workspace-1",
@@ -295,7 +309,10 @@ describe("WorkflowRunner", () => {
 
   test("replays completed applyPatch steps without reapplying", async () => {
     using tmp = new DisposableTempDir("workflow-runner-apply-patch-replay");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     const agentSpec = { id: "implement", prompt: "Implement" };
     const applySpec = {
       id: "apply-implement",
@@ -351,7 +368,10 @@ describe("WorkflowRunner", () => {
 
   test("rejects applyPatch sources that are not workflow-owned child tasks", async () => {
     using tmp = new DisposableTempDir("workflow-runner-apply-patch-unowned");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_apply_patch_unowned",
       workspaceId: "workspace-1",
@@ -771,7 +791,10 @@ describe("WorkflowRunner", () => {
 
   test("runs parallelAgents specs concurrently and returns ordered results", async () => {
     using tmp = new DisposableTempDir("workflow-runner");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_parallel",
       workspaceId: "workspace-1",
@@ -832,7 +855,10 @@ describe("WorkflowRunner", () => {
 
   test("interrupts sibling parallelAgents when one child task fails", async () => {
     using tmp = new DisposableTempDir("workflow-runner");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_parallel_failure",
       workspaceId: "workspace-1",
@@ -876,7 +902,10 @@ describe("WorkflowRunner", () => {
 
   test("does not interrupt sibling parallelAgents when foreground wait backgrounds", async () => {
     using tmp = new DisposableTempDir("workflow-runner");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_parallel_backgrounded",
       workspaceId: "workspace-1",
@@ -927,7 +956,10 @@ describe("WorkflowRunner", () => {
 
   test("retries only failed parallelAgents steps after structured output validation errors", async () => {
     using tmp = new DisposableTempDir("workflow-runner");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_parallel_retry_validation",
       workspaceId: "workspace-1",
@@ -989,7 +1021,10 @@ describe("WorkflowRunner", () => {
 
   test("retries workflow agent steps that fail structured output validation", async () => {
     using tmp = new DisposableTempDir("workflow-runner");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_retry_validation",
       workspaceId: "workspace-1",
@@ -1061,7 +1096,10 @@ describe("WorkflowRunner", () => {
 
   test("stops retrying workflow agent validation after the maximum attempts", async () => {
     using tmp = new DisposableTempDir("workflow-runner");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_retry_exhausted",
       workspaceId: "workspace-1",
@@ -1101,7 +1139,10 @@ describe("WorkflowRunner", () => {
 
   test("validates workflow agent structured output against requested schema", async () => {
     using tmp = new DisposableTempDir("workflow-runner");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_schema",
       workspaceId: "workspace-1",
@@ -1151,7 +1192,10 @@ describe("WorkflowRunner", () => {
 
   test("applies sandbox limits before evaluating workflow source", async () => {
     using tmp = new DisposableTempDir("workflow-runner");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_limits",
       workspaceId: "workspace-1",
@@ -1214,7 +1258,10 @@ describe("WorkflowRunner", () => {
 
   test("supports async workflow function exports", async () => {
     using tmp = new DisposableTempDir("workflow-runner");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_async",
       workspaceId: "workspace-1",
@@ -1234,7 +1281,10 @@ describe("WorkflowRunner", () => {
 
   test("returns the normalized workflow result for JSON-serializable values", async () => {
     using tmp = new DisposableTempDir("workflow-runner");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_normalized_return",
       workspaceId: "workspace-1",
@@ -1256,7 +1306,10 @@ describe("WorkflowRunner", () => {
 
   test("marks empty workflow returns as failed runs", async () => {
     using tmp = new DisposableTempDir("workflow-runner");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_empty_return",
       workspaceId: "workspace-1",
@@ -1307,7 +1360,10 @@ describe("WorkflowRunner", () => {
 
   test("marks compile failures as failed runs", async () => {
     using tmp = new DisposableTempDir("workflow-runner");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_compile_error",
       workspaceId: "workspace-1",
@@ -1330,7 +1386,10 @@ describe("WorkflowRunner", () => {
 
   test("fails fast when a replay-boundary primitive omits a stable id", async () => {
     using tmp = new DisposableTempDir("workflow-runner");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_missing_id",
       workspaceId: "workspace-1",
@@ -1370,7 +1429,10 @@ describe("WorkflowRunner", () => {
       }`,
       "utf-8"
     );
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_action",
       workspaceId: "workspace-1",
@@ -1463,7 +1525,10 @@ describe("WorkflowRunner", () => {
     await runGit(repoRoot, ["commit", "-m", "ignore file"]);
     await fs.writeFile(path.join(repoRoot, "ignored.txt"), "ignored\n", "utf-8");
     await fs.writeFile(path.join(repoRoot, "new.txt"), "new\n", "utf-8");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_built_in_git_actions",
       workspaceId: "workspace-1",
@@ -1553,7 +1618,10 @@ describe("WorkflowRunner", () => {
       export async function execute() { throw new Error("action should replay"); }`,
       "utf-8"
     );
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     const actionSource = await fs.readFile(actionPath, "utf-8");
     const actionRegistry = new WorkflowActionRegistry({ projectRoot, globalRoot });
     const action = await actionRegistry.resolveAction("counter", { projectTrusted: true });
@@ -1636,7 +1704,10 @@ describe("WorkflowRunner", () => {
       export async function execute() { throw new Error("action should replay"); }`,
       "utf-8"
     );
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     const actionRegistry = new WorkflowActionRegistry({ projectRoot, globalRoot });
     const action = await actionRegistry.resolveAction("counter", { projectTrusted: true });
     await store.createRun({
@@ -1713,7 +1784,10 @@ describe("WorkflowRunner", () => {
     );
     const actionRegistry = new WorkflowActionRegistry({ projectRoot, globalRoot });
     const action = await actionRegistry.resolveAction("submit", { projectTrusted: true });
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_action_incomplete",
       workspaceId: "workspace-1",
@@ -1788,7 +1862,10 @@ describe("WorkflowRunner", () => {
       }`,
       "utf-8"
     );
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_action_source_drift",
       workspaceId: "workspace-1",
@@ -1849,7 +1926,10 @@ describe("WorkflowRunner", () => {
     );
     const actionRegistry = new WorkflowActionRegistry({ projectRoot, globalRoot });
     const oldAction = await actionRegistry.resolveAction("submit", { projectTrusted: true });
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_action_completed_drift",
       workspaceId: "workspace-1",
@@ -1946,7 +2026,10 @@ describe("WorkflowRunner", () => {
     );
     const actionRegistry = new WorkflowActionRegistry({ projectRoot, globalRoot });
     const oldAction = await actionRegistry.resolveAction("submit", { projectTrusted: true });
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_action_completed_missing_event",
       workspaceId: "workspace-1",
@@ -2047,7 +2130,10 @@ describe("WorkflowRunner", () => {
     );
     const actionRegistry = new WorkflowActionRegistry({ projectRoot, globalRoot });
     const action = await actionRegistry.resolveAction("submit", { projectTrusted: true });
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_action_failed_mutating",
       workspaceId: "workspace-1",
@@ -2107,7 +2193,10 @@ describe("WorkflowRunner", () => {
       export async function execute() { throw new Error("action should replay"); }`,
       "utf-8"
     );
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     const actionRegistry = new WorkflowActionRegistry({ projectRoot, globalRoot });
     const action = await actionRegistry.resolveAction("counter", { projectTrusted: true });
     await store.createRun({
@@ -2185,7 +2274,10 @@ describe("WorkflowRunner", () => {
     await fs.writeFile(actionPath, sourceB, "utf-8");
     const actionB = await actionRegistry.resolveAction("submit", { projectTrusted: true });
     await fs.writeFile(actionPath, sourceA, "utf-8");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_action_cache_unsafe_later",
       workspaceId: "workspace-1",
@@ -2310,7 +2402,10 @@ describe("WorkflowRunner", () => {
       }`,
       "utf-8"
     );
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_action_relative_cwd",
       workspaceId: "workspace-1",
@@ -2361,7 +2456,10 @@ describe("WorkflowRunner", () => {
       export async function execute() { throw new Error("action should replay"); }`,
       "utf-8"
     );
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     const actionRegistry = new WorkflowActionRegistry({ projectRoot, globalRoot });
     const action = await actionRegistry.resolveAction("cwd", { projectTrusted: true });
     await store.createRun({
@@ -2437,7 +2535,10 @@ describe("WorkflowRunner", () => {
       export async function execute() { return { value: helper.value }; }`;
     await fs.writeFile(actionPath, actionSource, "utf-8");
     await fs.writeFile(helperPath, "module.exports = { value: 1 };", "utf-8");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     const actionRegistry = new WorkflowActionRegistry({ projectRoot, globalRoot });
     const oldAction = await actionRegistry.resolveAction("counter", { projectTrusted: true });
     await store.createRun({
@@ -2515,7 +2616,10 @@ describe("WorkflowRunner", () => {
     );
     const actionRegistry = new WorkflowActionRegistry({ projectRoot, globalRoot });
     const oldAction = await actionRegistry.resolveAction("submit", { projectTrusted: true });
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_action_effect_drift",
       workspaceId: "workspace-1",
@@ -2599,7 +2703,10 @@ describe("WorkflowRunner", () => {
     );
     const actionRegistry = new WorkflowActionRegistry({ projectRoot, globalRoot });
     const oldAction = await actionRegistry.resolveAction("submit", { projectTrusted: true });
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_action_reconcile_drift",
       workspaceId: "workspace-1",
@@ -2671,7 +2778,10 @@ describe("WorkflowRunner", () => {
 
   test("does not expose mux tools, filesystem imports, or timers to workflow code", async () => {
     using tmp = new DisposableTempDir("workflow-runner");
-    const store = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
     await store.createRun({
       id: "wfr_forbidden",
       workspaceId: "workspace-1",

--- a/src/node/services/workflows/WorkflowService.test.ts
+++ b/src/node/services/workflows/WorkflowService.test.ts
@@ -315,9 +315,7 @@ export default function workflow({ args, agent }) {
     await expect(
       fs.readFile(path.join(scratchRoot, "scratch-research.js"), "utf-8")
     ).resolves.toContain("// description: Scratch research");
-    await expect(fs.readFile(path.join(scratchRoot, ".gitignore"), "utf-8")).resolves.toBe(
-      "*\n!.gitignore\n"
-    );
+    await expect(fs.readFile(path.join(scratchRoot, ".gitignore"), "utf-8")).rejects.toThrow();
   });
 
   test("lists definitions through the definition store trust gate", async () => {

--- a/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
+++ b/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
@@ -6,6 +6,8 @@ import { BUILT_IN_WORKFLOW_DEFINITIONS } from "./builtInWorkflowDefinitions";
 import { WorkflowRunStore } from "./WorkflowRunStore";
 import { WorkflowRunner, type WorkflowAgentSpec } from "./WorkflowRunner";
 
+const BUILT_IN_WORKFLOW_TEST_STALE_LEASE_MS = 100;
+
 const deepResearch = BUILT_IN_WORKFLOW_DEFINITIONS.find(
   (definition) => definition.name === "deep-research"
 );
@@ -20,7 +22,10 @@ describe("built-in deep-research workflow", () => {
       throw new Error("Expected built-in deep-research workflow");
     }
     using tmp = new DisposableTempDir("deep-research-workflow");
-    const runStore = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const runStore = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: BUILT_IN_WORKFLOW_TEST_STALE_LEASE_MS,
+    });
     await runStore.createRun({
       id: "wfr_deep_research",
       workspaceId: "workspace-1",
@@ -210,7 +215,10 @@ describe("built-in deep-research workflow", () => {
       throw new Error("Expected built-in deep-research workflow");
     }
     using tmp = new DisposableTempDir("deep-research-empty-workflow");
-    const runStore = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const runStore = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: BUILT_IN_WORKFLOW_TEST_STALE_LEASE_MS,
+    });
     await runStore.createRun({
       id: "wfr_deep_research_empty",
       workspaceId: "workspace-1",
@@ -294,7 +302,10 @@ describe("built-in deep-research workflow", () => {
       throw new Error("Expected built-in deep-research workflow");
     }
     using tmp = new DisposableTempDir("deep-research-capped-workflow");
-    const runStore = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const runStore = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: BUILT_IN_WORKFLOW_TEST_STALE_LEASE_MS,
+    });
     await runStore.createRun({
       id: "wfr_deep_research_capped",
       workspaceId: "workspace-1",
@@ -403,7 +414,10 @@ describe("built-in deep-review-workflow", () => {
       throw new Error("Expected built-in deep-review-workflow workflow");
     }
     using tmp = new DisposableTempDir("deep-review-workflow");
-    const runStore = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    const runStore = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: BUILT_IN_WORKFLOW_TEST_STALE_LEASE_MS,
+    });
     await runStore.createRun({
       id: "wfr_deep_review_workflow",
       workspaceId: "workspace-1",


### PR DESCRIPTION
## Summary

Stops workflow discovery from dirtying clean repositories with generated scratch `.gitignore` files, while keeping scratch workflow drafts hidden from Git status by default.

## Background

Workflow scratch drafts live under `.mux/workflows/.scratch/`, but the previous implementation eagerly generated `.mux/workflows/.scratch/.gitignore` during discovery. That made repos show `?? .mux/workflows/` even when users had no scratch scripts.

## Implementation

- Replaces generated scratch `.gitignore` files with repo-local `.git/info/exclude` entries.
- Prepares the local exclude during workflow discovery without creating `.mux/`, so first-time scratch authoring after workflow listing remains clean.
- Escapes Git ignore metacharacters in repo-relative scratch paths.
- Preserves existing unreadable Git excludes instead of treating every read failure as empty.
- Serializes in-process exclude updates per exclude path to avoid lost updates across multiple workspaces in the same repo.
- Adds a self-ignored `.scratch/.gitignore` fallback only when repo `.gitignore` rules re-include scratch workflow files and override `.git/info/exclude`.

## Validation

- `bun test src/node/services/workflows/WorkflowDefinitionStore.test.ts`
- `bun test src/node/services/workflows/WorkflowService.test.ts`
- `make typecheck`
- `make fmt-check`
- `bun x eslint src/node/services/workflows/WorkflowDefinitionStore.ts src/node/services/workflows/WorkflowDefinitionStore.test.ts src/node/services/workflows/WorkflowService.test.ts`
- `env MUX_ESLINT_CONCURRENCY=1 make lint`
- `env MUX_ESLINT_CONCURRENCY=1 make static-check`

## Risks

Medium. This touches workflow definition discovery and local Git metadata updates. The change is intentionally fail-soft for non-Git projects and Git errors, and regression coverage now includes nested workspace paths, `.gitignore` unignore precedence, old generated scratch `.gitignore` files, concurrent exclude updates, and runtime-backed discovery.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$3.24`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=3.24 -->
