### PR TITLE
🤖 feat: show workflow task open affordance

### DIFF
--- a/.mux/workflows/.scratch/.gitignore
+++ b/.mux/workflows/.scratch/.gitignore
@@ -1,4 +1,2 @@
 *
 !.gitignore
-# mux: hide scratch workflow drafts when repo rules unignore workflows
-*

--- a/.mux/workflows/.scratch/.gitignore
+++ b/.mux/workflows/.scratch/.gitignore
@@ -1,2 +1,4 @@
 *
 !.gitignore
+# mux: hide scratch workflow drafts when repo rules unignore workflows
+*

--- a/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
@@ -303,7 +303,7 @@ const taskActionsProps = {
 } satisfies Parameters<typeof WorkflowRunToolCall>[0];
 
 export const TaskActions: Story = {
-  render: () => <WorkflowTaskActionsStory {...taskActionsProps} />,
+  render: (args) => <WorkflowTaskActionsStory {...taskActionsProps} {...args} />,
   args: taskActionsProps,
 };
 

--- a/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
@@ -1,9 +1,10 @@
-import { useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import type { WorkflowRunRecord } from "@/common/types/workflow";
 import { APIContext } from "@/browser/contexts/API";
 import { WorkflowRunToolCall } from "@/browser/features/Tools/WorkflowRunToolCall";
+import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
 import { lightweightMeta } from "@/browser/stories/meta.js";
 
 const storyApi = {
@@ -164,6 +165,86 @@ const resumedForegroundDiscoveryRun: WorkflowRunRecord = {
   ],
 };
 
+const taskActionsRun: WorkflowRunRecord = {
+  id: "wfr_story_task_actions",
+  workspaceId: "workspace-1",
+  definition: {
+    name: "implementation",
+    description: "Implementation workflow",
+    scope: "built-in" as const,
+    executable: true,
+  },
+  definitionSource: "export default function workflow() { return null; }",
+  definitionHash: "sha256:story-task-actions",
+  args: { topic: "workflow task actions" },
+  status: "running" as const,
+  createdAt: "2026-05-29T00:00:00.000Z",
+  updatedAt: "2026-05-29T00:00:02.000Z",
+  events: [
+    {
+      sequence: 1,
+      type: "status" as const,
+      at: "2026-05-29T00:00:00.000Z",
+      status: "running" as const,
+    },
+    { sequence: 2, type: "phase" as const, at: "2026-05-29T00:00:00.000Z", name: "implementation" },
+    {
+      sequence: 3,
+      type: "task" as const,
+      at: "2026-05-29T00:00:01.000Z",
+      stepId: "summarize-source-15",
+      taskId: "7b1a07d84d",
+      status: "completed",
+    },
+    {
+      sequence: 4,
+      type: "task" as const,
+      at: "2026-05-29T00:00:02.000Z",
+      stepId: "extract-claims",
+      taskId: "a36921beca",
+      status: "started",
+    },
+  ],
+  steps: [
+    {
+      stepId: "summarize-source-15",
+      inputHash: "sha256:summarize",
+      status: "completed" as const,
+      taskId: "7b1a07d84d",
+      startedAt: "2026-05-29T00:00:01.000Z",
+      completedAt: "2026-05-29T00:00:02.000Z",
+      result: { reportMarkdown: "## Summary report\n\nCompleted task report body." },
+    },
+    {
+      stepId: "extract-claims",
+      inputHash: "sha256:extract",
+      status: "started" as const,
+      taskId: "a36921beca",
+      startedAt: "2026-05-29T00:00:02.000Z",
+    },
+  ],
+};
+
+function WorkflowTaskActionsStory(props: Parameters<typeof WorkflowRunToolCall>[0]) {
+  const [openedTaskId, setOpenedTaskId] = useState<string | null>(null);
+
+  useEffect(() => {
+    useWorkspaceStoreRaw().setNavigateToWorkspace((workspaceId) => {
+      setOpenedTaskId(workspaceId);
+    });
+    return () => useWorkspaceStoreRaw().setNavigateToWorkspace(() => undefined);
+  }, []);
+
+  return (
+    <div className="space-y-2">
+      <WorkflowRunToolCall {...props} />
+      <div className="text-muted text-xs" aria-live="polite">
+        Last opened task: {openedTaskId ?? "none"}
+      </div>
+    </div>
+  );
+}
+
 function ForegroundWorkflowAPIProvider(props: { children: ReactNode }) {
   const currentRunRef = useRef(foregroundDiscoveryRun);
   const [, setRenderVersion] = useState(0);
@@ -205,6 +286,26 @@ function ForegroundWorkflowAPIProvider(props: { children: ReactNode }) {
     </APIContext.Provider>
   );
 }
+
+const taskActionsProps = {
+  args: {
+    name: "implementation",
+    args: { topic: "workflow task actions" },
+    run_in_background: true,
+  },
+  status: "completed" as const,
+  result: {
+    status: "running" as const,
+    runId: "wfr_story_task_actions",
+    result: null,
+    run: taskActionsRun,
+  },
+} satisfies Parameters<typeof WorkflowRunToolCall>[0];
+
+export const TaskActions: Story = {
+  render: () => <WorkflowTaskActionsStory {...taskActionsProps} />,
+  args: taskActionsProps,
+};
 
 export const RunningForegroundDiscovered: Story = {
   render: (args) => (

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -391,8 +391,10 @@ describe("WorkflowRunToolCall", () => {
     expect(view.queryByText("implement / task_live / started")).toBeNull();
     expect(view.getByText("implement / task_retry / started")).toBeTruthy();
     expect(view.getByText("apply-implement / task_live / started")).toBeTruthy();
+    expect(view.getByText("Open")).toBeTruthy();
+    expect(view.queryByRole("button", { name: "Open" })).toBeNull();
 
-    fireEvent.click(view.getByText("implement / task_retry / started"));
+    fireEvent.click(view.getByText("Open"));
     expect(navigatedTo).toEqual(["task_retry"]);
 
     const completedTaskControl = view

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -391,11 +391,18 @@ describe("WorkflowRunToolCall", () => {
     expect(view.queryByText("implement / task_live / started")).toBeNull();
     expect(view.getByText("implement / task_retry / started")).toBeTruthy();
     expect(view.getByText("apply-implement / task_live / started")).toBeTruthy();
-    expect(view.getByText("Open")).toBeTruthy();
+    const openAffordance = view.getByText("Open");
+    expect(openAffordance.getAttribute("aria-hidden")).toBe("true");
+    const activeTaskControl = view.getByRole("button", {
+      name: "Open workflow task task_retry",
+    });
+    expect(activeTaskControl.contains(openAffordance)).toBe(true);
     expect(view.queryByRole("button", { name: "Open" })).toBeNull();
 
-    fireEvent.click(view.getByText("Open"));
+    fireEvent.click(activeTaskControl);
     expect(navigatedTo).toEqual(["task_retry"]);
+    fireEvent.keyDown(activeTaskControl, { key: "Enter" });
+    expect(navigatedTo).toEqual(["task_retry", "task_retry"]);
 
     const completedTaskControl = view
       .getByText("implement / task_live / completed")
@@ -405,14 +412,14 @@ describe("WorkflowRunToolCall", () => {
     }
 
     fireEvent.keyDown(completedTaskControl, { key: "Enter" });
-    expect(navigatedTo).toEqual(["task_retry", "task_live"]);
+    expect(navigatedTo).toEqual(["task_retry", "task_retry", "task_live"]);
     expect(view.container.textContent).not.toContain("Completed task body.");
 
     const reportToggle = view.getByLabelText("Open report for task_live");
     expect(reportToggle.closest('[role="button"]')).toBeNull();
     fireEvent.click(reportToggle);
 
-    expect(navigatedTo).toEqual(["task_retry", "task_live"]);
+    expect(navigatedTo).toEqual(["task_retry", "task_retry", "task_live"]);
     await waitFor(() => {
       const reportDialog = document.querySelector('[role="dialog"]');
       expect(reportDialog?.textContent).toContain("Completed task body.");

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -475,6 +475,12 @@ function WorkflowTaskReportDialogContent(props: {
   );
 }
 
+function shouldShowWorkflowTaskOpenAffordance(
+  event: WorkflowRunEvent
+): event is Extract<WorkflowRunEvent, { type: "task" }> {
+  return event.type === "task" && event.status === "started";
+}
+
 function WorkflowTaskRow(props: {
   row: Extract<WorkflowDisplayRow, { kind: "task" }>;
   displayIndex: number;
@@ -486,6 +492,8 @@ function WorkflowTaskRow(props: {
   const event = props.row.latestEvent;
   const label = getWorkflowEventLabel(event);
   const taskReportMarkdown = getTaskReportMarkdown(event, props.steps);
+  const showOpenAffordance =
+    taskReportMarkdown == null && shouldShowWorkflowTaskOpenAffordance(event);
   const activateTaskRow = () => props.onNavigate(event.taskId);
   const handleReportDialogOpenChange = (isOpen: boolean) => {
     if (isOpen) {
@@ -503,7 +511,11 @@ function WorkflowTaskRow(props: {
 
   const taskRow = (
     <div
-      className="grid cursor-pointer grid-cols-[3rem_4.75rem_minmax(0,1fr)] items-center gap-2 border-l-2 border-transparent px-2 py-1 text-[10px]"
+      className={`grid cursor-pointer items-center gap-2 border-l-2 border-transparent px-2 py-1 text-[10px] ${
+        showOpenAffordance
+          ? "grid-cols-[3rem_4.75rem_minmax(0,1fr)_auto]"
+          : "grid-cols-[3rem_4.75rem_minmax(0,1fr)]"
+      }`}
       role="button"
       tabIndex={0}
       aria-label={`Open workflow task ${event.taskId}`}
@@ -530,6 +542,15 @@ function WorkflowTaskRow(props: {
       </TooltipIfPresent>
       <span className={`w-fit font-mono uppercase ${getEventTypeClass(event)}`}>{event.type}</span>
       <span className="text-foreground truncate">{label}</span>
+      {/* Keep Open visual-only so the task row remains the single keyboard target. */}
+      {showOpenAffordance ? (
+        <span
+          className={`${WORKFLOW_ACTION_BUTTON_CLASS} pointer-events-none inline-flex items-center px-1.5 py-0.5 text-[10px] whitespace-nowrap`}
+          aria-hidden="true"
+        >
+          Open
+        </span>
+      ) : null}
     </div>
   );
 


### PR DESCRIPTION
## Summary

Adds an explicit visual **Open** affordance to active workflow task rows while preserving the row as the single accessible navigation target. Completed task rows with report markdown continue to show **Report** instead of **Open**.

## Background

Running workflow sub-agent rows were already clickable, but that navigation path was implicit compared with completed rows that visibly expose a **Report** action. This change makes the active-task inspection path obvious without adding a duplicate keyboard stop.

## Implementation

- Adds a started-task helper and renders a right-aligned visual-only **Open** span for active task rows without report markdown.
- Keeps the workflow task row as the only role/button navigation target, including keyboard activation.
- Extends tests to assert the visual affordance is aria-hidden, no standalone **Open** button exists, and the active task row remains role/query/keyboard accessible.
- Adds a Storybook `TaskActions` fixture for dogfooding active **Open** and completed **Report** behavior.

## Deep review

Ran `deep-review-workflow` against `origin/main...HEAD`. It identified three issues, all fixed before PR creation:

1. The test clicked the visual-only **Open** span instead of the accessible row.
2. The new Storybook story ignored Storybook-provided args.
3. An unrelated scratch workflow `.gitignore` hunk was present in the branch diff.

## Validation

- `bun test src/browser/features/Tools/WorkflowRunToolCall.test.tsx`
- `scratch-gitignore-precedence` local check
- `make static-check`
- Storybook dogfooding with `agent-browser` screenshots/video captured in the workspace run.

## Risks

Low. The visible affordance is gated to started task rows without reports, and the existing row navigation/report dialog paths are preserved.

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Add an explicit active-agent Open affordance to workflow task rows

## Recommendation

Ship a small, active-row-only **Open** affordance for workflow task rows.

- **Recommended approach — in-row visual CTA, single accessible target**: add a button-styled `Open` affordance inside active task rows as a non-interactive `span`, while keeping the existing row as the single semantic `role="button"` / keyboard target. This makes the call to action visible without introducing a duplicate tab stop for the same navigation action. **Estimated product LoC: +25 to +45.**
- **Fallback approach — literal sibling button**: add a right-aligned `<button>` sibling that calls the existing navigation handler for active rows. This is slightly smaller, but creates two adjacent keyboard targets with the same action unless extra focus management is added. I would not choose it unless implementation complexity unexpectedly rises. **Estimated product LoC: +10 to +25.**
- Do **not** add both `Open` and `Report` to completed rows with reports. For those rows, keep `Report` as the visible primary action and preserve row-click navigation.

## Verified context

- `src/browser/features/Tools/WorkflowRunToolCall.tsx` contains `WorkflowTaskRow`, which already makes workflow task rows clickable/focusable and navigates via `workspaceStore.navigateToWorkspace(taskId)`.
- Completed task rows with non-empty report markdown already render a right-aligned `Report` button that opens a report dialog.
- Active/started task rows are navigable today, but the affordance is implicit: the row cursor/role changes, yet there is no visible CTA comparable to `Report`.
- `src/browser/features/Tools/WorkflowRunToolCall.test.tsx` already covers coalesced task rows, row navigation, and report-dialog behavior.
- `src/browser/features/Tools/WorkflowRunToolCall.stories.tsx` has useful workflow states for visual validation, including running/discovered runs.
- Requested skills reviewed for validation planning: `dogfood`, `agent-browser`, and `dev-server-sandbox`.

## UX intent

Make the running sub-agent inspection path obvious while keeping the event list compact.

Expected visual model:

```text
#23  TASK   summarize-source-15 / 7b1a07d84d / completed     Report
#24  PHASE  claim-extraction
#25  TASK   extract-claims / a36921beca / started            Open
```

## Implementation steps

1. **Define active task status helper**
   - Add a local helper near the workflow row utilities in `WorkflowRunToolCall.tsx`, e.g. `shouldShowOpenAffordance(event)`.
   - Start narrowly with `event.type === "task" && event.status === "started"` unless the workflow event type already includes additional active states that should be represented.
   - Keep the helper local; no shared abstraction unless another caller exists.

2. **Render active-row Open affordance**
   - In `WorkflowTaskRow`, compute:
     - `taskReportMarkdown`
     - `hasReportAction = taskReportMarkdown != null`
     - `showOpenAffordance = !hasReportAction && shouldShowOpenAffordance(event)`
   - For `showOpenAffordance`, render an `Open` label styled with `WORKFLOW_ACTION_BUTTON_CLASS` inside the clickable task row as a non-focusable visual affordance, preferably a `span` with `aria-hidden` and `pointer-events-none` so the parent row remains the hit target.
   - Switch the row to a four-column layout only when the `Open` affordance is shown, so the task label truncates cleanly and `Open` stays right-aligned.
   - Keep the row itself as the semantic and keyboard-accessible control (`role="button"`, `tabIndex={0}`, Enter/Space behavior, existing `aria-label`). This avoids two tab stops for the same action.
   - Preserve the existing `Report` dialog button path for rows with report markdown.

3. **Preserve click behavior**
   - Clicking anywhere in the active task row, including the visible `Open` affordance, should call the existing `activateTaskRow()` path.
   - Clicking `Report` must continue opening the report dialog only and must not navigate.

4. **Update tests**
   - Extend the existing `coalesces task attempts, navigates rows, and opens completed reports separately` test in `WorkflowRunToolCall.test.tsx` or add a focused adjacent test.
   - Assert the active `task_retry` row visibly contains `Open`, but do not query it as a separate role button.
   - Click the active row / visual `Open` area and assert navigation receives `task_retry`.
   - Assert completed `task_live` still displays `Report`, opens the report dialog, and does not navigate when the report button is clicked.
   - Add a no-duplicate-accessibility check if practical: active rows should have one semantic row/button target for navigation, not row + separate focusable duplicate.

5. **Optional story polish only if needed**
   - If current Storybook stories do not make the visual before/after obvious enough, add or adjust a small story state in `WorkflowRunToolCall.stories.tsx` with one started task and one completed task with a report.
   - Avoid broad Storybook fixture churn.

## Acceptance criteria

- Active workflow task rows visibly show `Open`.
- Completed workflow task rows with reports still visibly show `Report` and do not also show `Open`.
- Row click and keyboard navigation still open the workflow task workspace.
- Clicking `Report` still opens the report dialog without navigating.
- The event list remains compact at narrow widths; the task label truncates before overlapping the action affordance.
- No new manual memoization, speculative abstractions, or unrelated styling changes.

## Validation plan

Run these after implementation:

```bash
bun test src/browser/features/Tools/WorkflowRunToolCall.test.tsx
make static-check
```

If Storybook fixtures are touched, also run the relevant Storybook validation available in the repo, or at minimum start Storybook and visually inspect the workflow run stories.

## Dogfooding plan

Use the requested skills as follows:

1. **Prepare the app/story environment**
   - Prefer Storybook for fast visual validation of this component state:
     ```bash
     make storybook
     # or, if needed:
     bun run storybook
     ```
   - For full app validation, use an isolated sandbox rather than the developer's normal profile:
     ```bash
     make dev-server-sandbox
     # or desktop E2E if implementation needs the Electron shell:
     make dev-desktop-sandbox
     ```
   - Before browser automation, load the installed agent-browser command guide:
     ```bash
     agent-browser skills get core
     ```

2. **Capture evidence with agent-browser**
   - Open the Storybook `App/Chat/Tools/WorkflowRun` story that contains an active task row.
   - Capture an annotated screenshot showing the active task row with `Open`.
   - Click the `Open` affordance / row and capture evidence that the navigation action is triggered or, in a full app sandbox, that the child workspace opens.
   - Open a completed-with-report state and capture an annotated screenshot showing `Report` without `Open`.
   - Click `Report`, capture a screenshot of the report dialog, and record a short video of the interaction so reviewers can verify the behavior.

3. **Quality gates between phases**
   - After unit tests pass, take the Storybook screenshot before running broader static checks.
   - After `make static-check` passes, dogfood in the sandbox and collect final screenshot/video evidence.

## Risks and mitigations

- **Duplicate accessibility targets**: avoid a second focusable `Open` button for the same action by making the row remain the semantic control and using the `Open` text as an in-row visual affordance.
- **Visual clutter**: only show `Open` for active task rows without reports; do not add it to every task row.
- **Action ambiguity**: keep `Report` and `Open` mutually exclusive in the visible action slot.
- **Narrow layout overflow**: keep the task label truncating and action affordance non-shrinking/right-aligned.

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `440972{MUX_COSTS_USD:-unknown}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=14.51 -->
