### PR TITLE
🤖 fix: update workflow rows as agents finish

### DIFF
--- a/.mux/workflows/.scratch/.gitignore
+++ b/.mux/workflows/.scratch/.gitignore
@@ -1,4 +1,3 @@
-*
-!.gitignore
 # mux: hide scratch workflow drafts when repo rules unignore workflows
 *
+!.gitignore

--- a/.mux/workflows/.scratch/.gitignore
+++ b/.mux/workflows/.scratch/.gitignore
@@ -1,2 +1,4 @@
 *
 !.gitignore
+# mux: hide scratch workflow drafts when repo rules unignore workflows
+*

--- a/src/node/services/workflows/WorkflowRunStore.test.ts
+++ b/src/node/services/workflows/WorkflowRunStore.test.ts
@@ -122,6 +122,62 @@ describe("WorkflowRunStore", () => {
     ).rejects.toThrow(/strictly ordered/);
   });
 
+  test("assigns unique event sequences when appending next events concurrently", async () => {
+    using tmp = new DisposableTempDir("workflow-runs-append-next");
+    const store = await createStore(tmp.path);
+
+    await Promise.all([
+      store.appendNextEvent("wfr_123", {
+        type: "log",
+        at: "2026-05-29T00:00:01.000Z",
+        message: "first",
+      }),
+      store.appendNextEvent("wfr_123", {
+        type: "log",
+        at: "2026-05-29T00:00:02.000Z",
+        message: "second",
+      }),
+      store.appendNextEvent("wfr_123", {
+        type: "log",
+        at: "2026-05-29T00:00:03.000Z",
+        message: "third",
+      }),
+    ]);
+
+    const sequences = (await store.getRun("wfr_123")).events.map((event) => event.sequence);
+
+    expect(sequences).toEqual([1, 2, 3]);
+  });
+
+  test("records completed steps and task events in the same run snapshot", async () => {
+    using tmp = new DisposableTempDir("workflow-runs-step-task-snapshot");
+    const store = await createStore(tmp.path);
+
+    await store.recordStepCompletedAndAppendTaskEvent("wfr_123", {
+      stepId: "source-a",
+      inputHash: "hash:source-a",
+      taskId: "task_source-a",
+      result: { reportMarkdown: "source-a" },
+      startedAt: "2026-05-29T00:00:01.000Z",
+      completedAt: "2026-05-29T00:00:02.000Z",
+    });
+    const run = await store.getRun("wfr_123");
+
+    expect(run.steps).toHaveLength(1);
+    expect(run.steps[0]).toMatchObject({
+      stepId: "source-a",
+      taskId: "task_source-a",
+      status: "completed",
+    });
+    expect(run.events).toHaveLength(1);
+    expect(run.events[0]).toMatchObject({
+      type: "task",
+      stepId: "source-a",
+      taskId: "task_source-a",
+      status: "completed",
+    });
+  });
+
   test("preserves interrupted runs unless explicit resume is allowed", async () => {
     using tmp = new DisposableTempDir("workflow-runs");
     const store = await createStore(tmp.path);

--- a/src/node/services/workflows/WorkflowRunStore.test.ts
+++ b/src/node/services/workflows/WorkflowRunStore.test.ts
@@ -178,6 +178,43 @@ describe("WorkflowRunStore", () => {
     });
   });
 
+  test("records failed steps and validation task events in the same run snapshot", async () => {
+    using tmp = new DisposableTempDir("workflow-runs-step-failed-task-snapshot");
+    const store = await createStore(tmp.path);
+
+    await store.recordStepFailedAndAppendTaskEvent("wfr_123", {
+      stepId: "source-b",
+      inputHash: "hash:source-b",
+      taskId: "task_source-b_bad",
+      error: "structured output failed schema validation",
+      startedAt: "2026-05-29T00:00:01.000Z",
+      completedAt: "2026-05-29T00:00:02.000Z",
+      validationAt: "2026-05-29T00:00:02.000Z",
+      taskFailedAt: "2026-05-29T00:00:02.000Z",
+    });
+    const run = await store.getRun("wfr_123");
+
+    expect(run.steps).toHaveLength(1);
+    expect(run.steps[0]).toMatchObject({
+      stepId: "source-b",
+      taskId: "task_source-b_bad",
+      status: "failed",
+      error: "structured output failed schema validation",
+    });
+    expect(run.events).toHaveLength(2);
+    expect(run.events[0]).toMatchObject({
+      type: "validation",
+      stepId: "source-b",
+      success: false,
+    });
+    expect(run.events[1]).toMatchObject({
+      type: "task",
+      stepId: "source-b",
+      taskId: "task_source-b_bad",
+      status: "failed",
+    });
+  });
+
   test("preserves interrupted runs unless explicit resume is allowed", async () => {
     using tmp = new DisposableTempDir("workflow-runs");
     const store = await createStore(tmp.path);
@@ -267,6 +304,29 @@ describe("WorkflowRunStore", () => {
     await expect(
       store.appendStatus("wfr_123", "interrupted", "2026-05-29T00:00:02.000Z")
     ).rejects.toThrow(/Cannot transition/);
+  });
+
+  test("uses the atomic run file snapshot while a writer lock is active", async () => {
+    using tmp = new DisposableTempDir("workflow-runs-active-writer-snapshot");
+    const store = await createStore(tmp.path);
+    await store.appendStatus("wfr_123", "running", "2026-05-29T00:00:01.000Z");
+    const lockDir = path.join(tmp.path, "workflows", "wfr_123", "events.jsonl.lock");
+    await fs.mkdir(lockDir);
+    await fs.appendFile(
+      path.join(tmp.path, "workflows", "wfr_123", "events.jsonl"),
+      `${JSON.stringify({
+        sequence: 2,
+        type: "status",
+        at: "2026-05-29T00:00:02.000Z",
+        status: "completed",
+      })}\n`,
+      "utf-8"
+    );
+
+    await expect(store.getRun("wfr_123")).resolves.toMatchObject({ status: "running" });
+
+    await fs.rm(lockDir, { recursive: true, force: true });
+    await expect(store.getRun("wfr_123")).resolves.toMatchObject({ status: "completed" });
   });
 
   test("does not overwrite terminal runs with later interrupt status", async () => {

--- a/src/node/services/workflows/WorkflowRunStore.ts
+++ b/src/node/services/workflows/WorkflowRunStore.ts
@@ -111,7 +111,12 @@ export class WorkflowRunStore {
   }
 
   async getRun(runId: string): Promise<WorkflowRunRecord> {
-    return await this.withWorkflowMutationLock(runId, async () => await this.getRunUnlocked(runId));
+    // UI polling must not wait behind the writer lock; while a mutation is in progress,
+    // fall back to the last atomic run.json snapshot instead of reading half-updated journals.
+    if (await this.hasActiveWorkflowMutationLock(runId)) {
+      return await this.getRunFileSnapshot(runId);
+    }
+    return await this.getRunUnlocked(runId);
   }
 
   async listRuns(): Promise<WorkflowRunRecord[]> {
@@ -261,34 +266,115 @@ export class WorkflowRunStore {
           status: "completed",
         });
         const run = await this.getRunUnlocked(runId);
-        if (run.status === "interrupted") {
-          throw new Error(`Workflow run interrupted: ${runId}`);
+        this.assertCanAppendStepRecord(runId, run);
+
+        let updatedRun = this.withStepRecord(run, record);
+        const eventsToAppend: WorkflowRunEvent[] = [];
+        if (
+          input.taskId != null &&
+          !updatedRun.events.some(
+            (event) =>
+              event.type === "task" &&
+              event.status === "completed" &&
+              event.stepId === input.stepId &&
+              event.taskId === input.taskId
+          )
+        ) {
+          const event = this.createNextEventForRun(
+            runId,
+            updatedRun,
+            {
+              type: "task",
+              at: input.completedAt,
+              stepId: input.stepId,
+              taskId: input.taskId,
+              status: "completed",
+            },
+            options
+          );
+          eventsToAppend.push(event);
+          updatedRun = this.withEvent(updatedRun, event);
         }
+
         await appendJsonLine(this.stepsFile(runId), record);
-        if (input.taskId == null) {
-          return;
-        }
-        const alreadyRecorded = run.events.some(
-          (event) =>
-            event.type === "task" &&
-            event.status === "completed" &&
-            event.stepId === input.stepId &&
-            event.taskId === input.taskId
-        );
-        if (alreadyRecorded) {
-          return;
-        }
-        await this.appendNextEventUnlocked(
+        await appendJsonLines(this.eventsFile(runId), eventsToAppend);
+        await this.writeRunFile(runId, updatedRun);
+      });
+    });
+  }
+
+  async recordStepFailedAndAppendTaskEvent(
+    runId: string,
+    input: {
+      stepId: string;
+      inputHash: string;
+      taskId?: string;
+      error: string;
+      startedAt: string;
+      completedAt: string;
+      validationAt: string;
+      taskFailedAt?: string;
+    },
+    options: AppendWorkflowRunEventOptions = {}
+  ): Promise<void> {
+    await this.withWorkflowMutationLock(runId, async () => {
+      await this.withExpectedLeaseOwner(runId, options.expectedLeaseOwnerId, async () => {
+        const record = WorkflowStepRecordSchema.parse({
+          stepId: input.stepId,
+          inputHash: input.inputHash,
+          taskId: input.taskId,
+          error: input.error,
+          startedAt: input.startedAt,
+          completedAt: input.completedAt,
+          status: "failed",
+        });
+        const run = await this.getRunUnlocked(runId);
+        this.assertCanAppendStepRecord(runId, run);
+
+        const validationEvent = this.createNextEventForRun(
           runId,
+          run,
           {
-            type: "task",
-            at: input.completedAt,
+            type: "validation",
+            at: input.validationAt,
             stepId: input.stepId,
-            taskId: input.taskId,
-            status: "completed",
+            success: false,
+            message: input.error,
           },
           options
         );
+        let updatedRun = this.withEvent(run, validationEvent);
+        updatedRun = this.withStepRecord(updatedRun, record);
+        const eventsToAppend: WorkflowRunEvent[] = [validationEvent];
+        if (
+          input.taskId != null &&
+          !updatedRun.events.some(
+            (event) =>
+              event.type === "task" &&
+              event.status === "failed" &&
+              event.stepId === input.stepId &&
+              event.taskId === input.taskId
+          )
+        ) {
+          const taskEvent = this.createNextEventForRun(
+            runId,
+            updatedRun,
+            {
+              type: "task",
+              at: input.taskFailedAt ?? input.completedAt,
+              stepId: input.stepId,
+              taskId: input.taskId,
+              status: "failed",
+            },
+            options
+          );
+          eventsToAppend.push(taskEvent);
+          updatedRun = this.withEvent(updatedRun, taskEvent);
+        }
+
+        await appendJsonLine(this.stepsFile(runId), record);
+        await appendJsonLines(this.eventsFile(runId), eventsToAppend);
+        await this.writeRunFile(runId, updatedRun);
       });
     });
   }
@@ -314,8 +400,9 @@ export class WorkflowRunStore {
         if (alreadyRecorded) {
           return;
         }
-        await this.appendNextEventUnlocked(
+        const event = this.createNextEventForRun(
           runId,
+          run,
           {
             type: "task",
             at: task.at,
@@ -325,6 +412,8 @@ export class WorkflowRunStore {
           },
           options
         );
+        await appendJsonLine(this.eventsFile(runId), event);
+        await this.writeRunFile(runId, this.withEvent(run, event));
       });
     });
   }
@@ -524,6 +613,29 @@ export class WorkflowRunStore {
     }
   }
 
+  private async hasActiveWorkflowMutationLock(runId: string): Promise<boolean> {
+    try {
+      const stat = await fs.stat(`${this.eventsFile(runId)}.lock`);
+      return Date.now() - stat.mtimeMs <= this.leaseMutationLockStaleMs();
+    } catch {
+      return false;
+    }
+  }
+
+  private async getRunFileSnapshot(runId: string): Promise<WorkflowRunRecord> {
+    const rawRun = JSON.parse(await fs.readFile(this.runFile(runId), "utf-8")) as unknown;
+    const run = WorkflowRunRecordSchema.parse(rawRun);
+    const definitionSource = await fs.readFile(
+      path.join(this.runDir(runId), "definition.js"),
+      "utf-8"
+    );
+    return WorkflowRunRecordSchema.parse({
+      ...run,
+      definitionSource,
+      definitionHash: hashSource(definitionSource),
+    });
+  }
+
   private async getRunUnlocked(runId: string): Promise<WorkflowRunRecord> {
     const rawRun = JSON.parse(await fs.readFile(this.runFile(runId), "utf-8")) as unknown;
     const partial = WorkflowRunRecordSchema.omit({ events: true, steps: true }).parse(rawRun);
@@ -552,12 +664,12 @@ export class WorkflowRunStore {
     event: WorkflowRunEventDraft,
     options: AppendWorkflowRunEventOptions = {}
   ): Promise<WorkflowRunRecord> {
-    const events = await this.readEvents(runId);
-    return await this.appendEventUnlocked(
-      runId,
-      { ...event, sequence: (events.at(-1)?.sequence ?? 0) + 1 } as WorkflowRunEvent,
-      options
-    );
+    const run = await this.getRunUnlocked(runId);
+    const parsedEvent = this.createNextEventForRun(runId, run, event, options);
+    await appendJsonLine(this.eventsFile(runId), parsedEvent);
+    const updatedRun = this.withEvent(run, parsedEvent);
+    await this.writeRunFile(runId, updatedRun);
+    return updatedRun;
   }
 
   private async appendEventUnlocked(
@@ -565,45 +677,82 @@ export class WorkflowRunStore {
     event: WorkflowRunEvent,
     options: AppendWorkflowRunEventOptions = {}
   ): Promise<WorkflowRunRecord> {
+    const run = await this.getRunUnlocked(runId);
     const parsedEvent = WorkflowRunEventSchema.parse(event);
-    const existingEvents = await this.readEvents(runId);
-    const ordered = WorkflowEventSequenceSchema.safeParse([...existingEvents, parsedEvent]);
+    this.assertCanAppendEvent(runId, run, parsedEvent, options);
+    await appendJsonLine(this.eventsFile(runId), parsedEvent);
+    const updatedRun = this.withEvent(run, parsedEvent);
+    await this.writeRunFile(runId, updatedRun);
+    return updatedRun;
+  }
+
+  private createNextEventForRun(
+    runId: string,
+    run: WorkflowRunRecord,
+    event: WorkflowRunEventDraft,
+    options: AppendWorkflowRunEventOptions = {}
+  ): WorkflowRunEvent {
+    const parsedEvent = WorkflowRunEventSchema.parse({
+      ...event,
+      sequence: (run.events.at(-1)?.sequence ?? 0) + 1,
+    });
+    this.assertCanAppendEvent(runId, run, parsedEvent, options);
+    return parsedEvent;
+  }
+
+  private assertCanAppendEvent(
+    runId: string,
+    run: WorkflowRunRecord,
+    event: WorkflowRunEvent,
+    options: AppendWorkflowRunEventOptions
+  ): void {
+    const ordered = WorkflowEventSequenceSchema.safeParse([...run.events, event]);
     if (!ordered.success) {
       throw new Error(`Workflow events must be strictly ordered: ${ordered.error.message}`);
     }
 
-    const run = await this.getRunUnlocked(runId);
     const isInterruptedResumeEvent =
-      parsedEvent.type === "status" &&
+      event.type === "status" &&
       options.allowInterruptedResume === true &&
-      parsedEvent.status === "running";
+      event.status === "running";
     const isFailedCheckpointRetryEvent =
-      parsedEvent.type === "status" &&
+      event.type === "status" &&
       options.allowFailedCheckpointRetry === true &&
       run.status === "failed" &&
-      parsedEvent.status === "running";
-    const isRepeatedInterruptedStatus =
-      parsedEvent.type === "status" && parsedEvent.status === "interrupted";
+      event.status === "running";
+    const isRepeatedInterruptedStatus = event.type === "status" && event.status === "interrupted";
     if (run.status === "interrupted" && !isInterruptedResumeEvent && !isRepeatedInterruptedStatus) {
       throw new Error(`Workflow run interrupted: ${runId}`);
     }
-    if (parsedEvent.type === "status") {
-      if (isTerminalRunStatus(run.status) && !isFailedCheckpointRetryEvent) {
-        throw new Error(
-          `Cannot transition workflow run from ${run.status} to ${parsedEvent.status}`
-        );
-      }
+    if (
+      event.type === "status" &&
+      isTerminalRunStatus(run.status) &&
+      !isFailedCheckpointRetryEvent
+    ) {
+      throw new Error(`Cannot transition workflow run from ${run.status} to ${event.status}`);
     }
+  }
 
-    await appendJsonLine(this.eventsFile(runId), parsedEvent);
-    const updatedRun = {
+  private assertCanAppendStepRecord(runId: string, run: WorkflowRunRecord): void {
+    if (run.status === "interrupted") {
+      throw new Error(`Workflow run interrupted: ${runId}`);
+    }
+  }
+
+  private withEvent(run: WorkflowRunRecord, event: WorkflowRunEvent): WorkflowRunRecord {
+    return WorkflowRunRecordSchema.parse({
       ...run,
-      events: [...run.events, parsedEvent],
-      status: parsedEvent.type === "status" ? parsedEvent.status : run.status,
-      updatedAt: parsedEvent.at,
-    } satisfies WorkflowRunRecord;
-    await this.writeRunFile(runId, updatedRun);
-    return updatedRun;
+      events: [...run.events, event],
+      status: event.type === "status" ? event.status : run.status,
+      updatedAt: event.at,
+    });
+  }
+
+  private withStepRecord(run: WorkflowRunRecord, record: WorkflowStepRecord): WorkflowRunRecord {
+    return WorkflowRunRecordSchema.parse({
+      ...run,
+      steps: mergeWorkflowStepRecords(run.steps, record),
+    });
   }
 
   private async readEvents(runId: string): Promise<WorkflowRunEvent[]> {
@@ -613,11 +762,7 @@ export class WorkflowRunStore {
 
   private async readSteps(runId: string): Promise<WorkflowStepRecord[]> {
     const records = await readJsonLines(this.stepsFile(runId), WorkflowStepRecordSchema);
-    const byKey = new Map<string, WorkflowStepRecord>();
-    for (const record of records) {
-      byKey.set(getWorkflowStepKey(record), record);
-    }
-    return Array.from(byKey.values());
+    return mergeWorkflowStepRecords(records);
   }
 
   private async appendStepRecord(
@@ -629,9 +774,7 @@ export class WorkflowRunStore {
       await this.withExpectedLeaseOwner(runId, options.expectedLeaseOwnerId, async () => {
         const parsedRecord = WorkflowStepRecordSchema.parse(record);
         const run = await this.getRunUnlocked(runId);
-        if (run.status === "interrupted") {
-          throw new Error(`Workflow run interrupted: ${runId}`);
-        }
+        this.assertCanAppendStepRecord(runId, run);
         await appendJsonLine(this.stepsFile(runId), parsedRecord);
       });
     });
@@ -689,6 +832,20 @@ function getWorkflowStepKey(step: WorkflowStepLookup): string {
   return `${step.stepId}\0${step.inputHash}`;
 }
 
+function mergeWorkflowStepRecords(
+  records: readonly WorkflowStepRecord[],
+  nextRecord?: WorkflowStepRecord
+): WorkflowStepRecord[] {
+  const byKey = new Map<string, WorkflowStepRecord>();
+  for (const record of records) {
+    byKey.set(getWorkflowStepKey(record), record);
+  }
+  if (nextRecord !== undefined) {
+    byKey.set(getWorkflowStepKey(nextRecord), nextRecord);
+  }
+  return Array.from(byKey.values());
+}
+
 function hashSource(source: string): string {
   return `sha256:${crypto.createHash("sha256").update(source).digest("hex")}`;
 }
@@ -696,6 +853,18 @@ function hashSource(source: string): string {
 async function appendJsonLine(filePath: string, value: unknown): Promise<void> {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.appendFile(filePath, `${JSON.stringify(value)}\n`, "utf-8");
+}
+
+async function appendJsonLines(filePath: string, values: readonly unknown[]): Promise<void> {
+  if (values.length === 0) {
+    return;
+  }
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.appendFile(
+    filePath,
+    values.map((value) => JSON.stringify(value)).join("\n") + "\n",
+    "utf-8"
+  );
 }
 
 async function writeJsonAtomic(filePath: string, value: unknown): Promise<void> {

--- a/src/node/services/workflows/WorkflowRunStore.ts
+++ b/src/node/services/workflows/WorkflowRunStore.ts
@@ -51,6 +51,12 @@ export interface AppendWorkflowRunEventOptions {
   expectedLeaseOwnerId?: string;
 }
 
+type WorkflowRunEventDraft = WorkflowRunEvent extends infer Event
+  ? Event extends WorkflowRunEvent
+    ? Omit<Event, "sequence">
+    : never
+  : never;
+
 interface LeaseRecord {
   ownerId: string;
   acquiredAtMs: number;
@@ -105,26 +111,7 @@ export class WorkflowRunStore {
   }
 
   async getRun(runId: string): Promise<WorkflowRunRecord> {
-    const rawRun = JSON.parse(await fs.readFile(this.runFile(runId), "utf-8")) as unknown;
-    const partial = WorkflowRunRecordSchema.omit({ events: true, steps: true }).parse(rawRun);
-    const definitionSource = await fs.readFile(
-      path.join(this.runDir(runId), "definition.js"),
-      "utf-8"
-    );
-    const events = await this.readEvents(runId);
-    const steps = await this.readSteps(runId);
-
-    const latestEvent = events.at(-1);
-    const status = getRunStatusFromEvents(events) ?? partial.status;
-    return WorkflowRunRecordSchema.parse({
-      ...partial,
-      definitionSource,
-      definitionHash: hashSource(definitionSource),
-      status,
-      updatedAt: latestEvent?.at ?? partial.updatedAt,
-      events,
-      steps,
-    });
+    return await this.withWorkflowMutationLock(runId, async () => await this.getRunUnlocked(runId));
   }
 
   async listRuns(): Promise<WorkflowRunRecord[]> {
@@ -153,26 +140,42 @@ export class WorkflowRunStore {
       .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
   }
 
+  async appendNextEvent(
+    runId: string,
+    event: WorkflowRunEventDraft,
+    options: AppendWorkflowRunEventOptions = {}
+  ): Promise<WorkflowRunRecord> {
+    assert(runId.length > 0, "WorkflowRunStore.appendNextEvent: runId is required");
+    const eventWithMaybeSequence = event as WorkflowRunEventDraft & { sequence?: unknown };
+    assert(
+      eventWithMaybeSequence.sequence == null,
+      "WorkflowRunStore.appendNextEvent: event sequence is assigned by the store"
+    );
+    return await this.withWorkflowMutationLock(
+      runId,
+      async () =>
+        await this.withExpectedLeaseOwner(
+          runId,
+          options.expectedLeaseOwnerId,
+          async () => await this.appendNextEventUnlocked(runId, event, options)
+        )
+    );
+  }
+
   async appendEvent(
     runId: string,
     event: WorkflowRunEvent,
     options: AppendWorkflowRunEventOptions = {}
   ): Promise<WorkflowRunRecord> {
-    const lockDir = `${this.eventsFile(runId)}.lock`;
-    await acquireWorkflowMutationLock(
-      lockDir,
-      this.leaseMutationLockStaleMs(),
-      this.leaseMutationWaitTimeoutMs()
+    return await this.withWorkflowMutationLock(
+      runId,
+      async () =>
+        await this.withExpectedLeaseOwner(
+          runId,
+          options.expectedLeaseOwnerId,
+          async () => await this.appendEventUnlocked(runId, event, options)
+        )
     );
-    try {
-      return await this.withExpectedLeaseOwner(
-        runId,
-        options.expectedLeaseOwnerId,
-        async () => await this.appendEventUnlocked(runId, event, options)
-      );
-    } finally {
-      await fs.rm(lockDir, { recursive: true, force: true });
-    }
   }
 
   async appendStatus(
@@ -181,29 +184,7 @@ export class WorkflowRunStore {
     at: string,
     options: AppendWorkflowRunEventOptions = {}
   ): Promise<WorkflowRunRecord> {
-    const lockDir = `${this.eventsFile(runId)}.lock`;
-    await acquireWorkflowMutationLock(
-      lockDir,
-      this.leaseMutationLockStaleMs(),
-      this.leaseMutationWaitTimeoutMs()
-    );
-    try {
-      return await this.withExpectedLeaseOwner(runId, options.expectedLeaseOwnerId, async () => {
-        const events = await this.readEvents(runId);
-        return await this.appendEventUnlocked(
-          runId,
-          {
-            sequence: (events.at(-1)?.sequence ?? 0) + 1,
-            type: "status",
-            at,
-            status,
-          },
-          options
-        );
-      });
-    } finally {
-      await fs.rm(lockDir, { recursive: true, force: true });
-    }
+    return await this.appendNextEvent(runId, { type: "status", at, status }, options);
   }
 
   async recordStepStarted(
@@ -254,6 +235,98 @@ export class WorkflowRunStore {
       },
       options
     );
+  }
+
+  async recordStepCompletedAndAppendTaskEvent(
+    runId: string,
+    input: {
+      stepId: string;
+      inputHash: string;
+      taskId?: string;
+      result: StructuredTaskOutput;
+      startedAt: string;
+      completedAt: string;
+    },
+    options: AppendWorkflowRunEventOptions = {}
+  ): Promise<void> {
+    await this.withWorkflowMutationLock(runId, async () => {
+      await this.withExpectedLeaseOwner(runId, options.expectedLeaseOwnerId, async () => {
+        const record = WorkflowStepRecordSchema.parse({
+          stepId: input.stepId,
+          inputHash: input.inputHash,
+          taskId: input.taskId,
+          result: input.result,
+          startedAt: input.startedAt,
+          completedAt: input.completedAt,
+          status: "completed",
+        });
+        const run = await this.getRunUnlocked(runId);
+        if (run.status === "interrupted") {
+          throw new Error(`Workflow run interrupted: ${runId}`);
+        }
+        await appendJsonLine(this.stepsFile(runId), record);
+        if (input.taskId == null) {
+          return;
+        }
+        const alreadyRecorded = run.events.some(
+          (event) =>
+            event.type === "task" &&
+            event.status === "completed" &&
+            event.stepId === input.stepId &&
+            event.taskId === input.taskId
+        );
+        if (alreadyRecorded) {
+          return;
+        }
+        await this.appendNextEventUnlocked(
+          runId,
+          {
+            type: "task",
+            at: input.completedAt,
+            stepId: input.stepId,
+            taskId: input.taskId,
+            status: "completed",
+          },
+          options
+        );
+      });
+    });
+  }
+
+  async appendTaskEventIfMissing(
+    runId: string,
+    task: { stepId: string; taskId: string; status: string; at: string },
+    options: AppendWorkflowRunEventOptions = {}
+  ): Promise<void> {
+    assert(task.stepId.length > 0, "WorkflowRunStore.appendTaskEventIfMissing: stepId is required");
+    assert(task.taskId.length > 0, "WorkflowRunStore.appendTaskEventIfMissing: taskId is required");
+    assert(task.status.length > 0, "WorkflowRunStore.appendTaskEventIfMissing: status is required");
+    await this.withWorkflowMutationLock(runId, async () => {
+      await this.withExpectedLeaseOwner(runId, options.expectedLeaseOwnerId, async () => {
+        const run = await this.getRunUnlocked(runId);
+        const alreadyRecorded = run.events.some(
+          (event) =>
+            event.type === "task" &&
+            event.status === task.status &&
+            event.stepId === task.stepId &&
+            event.taskId === task.taskId
+        );
+        if (alreadyRecorded) {
+          return;
+        }
+        await this.appendNextEventUnlocked(
+          runId,
+          {
+            type: "task",
+            at: task.at,
+            stepId: task.stepId,
+            taskId: task.taskId,
+            status: task.status,
+          },
+          options
+        );
+      });
+    });
   }
 
   async recordStepFailed(
@@ -407,6 +480,20 @@ export class WorkflowRunStore {
     }
   }
 
+  private async withWorkflowMutationLock<T>(runId: string, mutation: () => Promise<T>): Promise<T> {
+    const lockDir = `${this.eventsFile(runId)}.lock`;
+    await acquireWorkflowMutationLock(
+      lockDir,
+      this.leaseMutationLockStaleMs(),
+      this.leaseMutationWaitTimeoutMs()
+    );
+    try {
+      return await mutation();
+    } finally {
+      await fs.rm(lockDir, { recursive: true, force: true });
+    }
+  }
+
   private async withExpectedLeaseOwner<T>(
     runId: string,
     expectedLeaseOwnerId: string | undefined,
@@ -437,6 +524,42 @@ export class WorkflowRunStore {
     }
   }
 
+  private async getRunUnlocked(runId: string): Promise<WorkflowRunRecord> {
+    const rawRun = JSON.parse(await fs.readFile(this.runFile(runId), "utf-8")) as unknown;
+    const partial = WorkflowRunRecordSchema.omit({ events: true, steps: true }).parse(rawRun);
+    const definitionSource = await fs.readFile(
+      path.join(this.runDir(runId), "definition.js"),
+      "utf-8"
+    );
+    const events = await this.readEvents(runId);
+    const steps = await this.readSteps(runId);
+
+    const latestEvent = events.at(-1);
+    const status = getRunStatusFromEvents(events) ?? partial.status;
+    return WorkflowRunRecordSchema.parse({
+      ...partial,
+      definitionSource,
+      definitionHash: hashSource(definitionSource),
+      status,
+      updatedAt: latestEvent?.at ?? partial.updatedAt,
+      events,
+      steps,
+    });
+  }
+
+  private async appendNextEventUnlocked(
+    runId: string,
+    event: WorkflowRunEventDraft,
+    options: AppendWorkflowRunEventOptions = {}
+  ): Promise<WorkflowRunRecord> {
+    const events = await this.readEvents(runId);
+    return await this.appendEventUnlocked(
+      runId,
+      { ...event, sequence: (events.at(-1)?.sequence ?? 0) + 1 } as WorkflowRunEvent,
+      options
+    );
+  }
+
   private async appendEventUnlocked(
     runId: string,
     event: WorkflowRunEvent,
@@ -449,7 +572,7 @@ export class WorkflowRunStore {
       throw new Error(`Workflow events must be strictly ordered: ${ordered.error.message}`);
     }
 
-    const run = await this.getRun(runId);
+    const run = await this.getRunUnlocked(runId);
     const isInterruptedResumeEvent =
       parsedEvent.type === "status" &&
       options.allowInterruptedResume === true &&
@@ -502,24 +625,16 @@ export class WorkflowRunStore {
     record: unknown,
     options: AppendWorkflowRunEventOptions = {}
   ): Promise<void> {
-    const lockDir = `${this.eventsFile(runId)}.lock`;
-    await acquireWorkflowMutationLock(
-      lockDir,
-      this.leaseMutationLockStaleMs(),
-      this.leaseMutationWaitTimeoutMs()
-    );
-    try {
+    await this.withWorkflowMutationLock(runId, async () => {
       await this.withExpectedLeaseOwner(runId, options.expectedLeaseOwnerId, async () => {
         const parsedRecord = WorkflowStepRecordSchema.parse(record);
-        const run = await this.getRun(runId);
+        const run = await this.getRunUnlocked(runId);
         if (run.status === "interrupted") {
           throw new Error(`Workflow run interrupted: ${runId}`);
         }
         await appendJsonLine(this.stepsFile(runId), parsedRecord);
       });
-    } finally {
-      await fs.rm(lockDir, { recursive: true, force: true });
-    }
+    });
   }
 
   private async writeRunFile(runId: string, run: WorkflowRunRecord): Promise<void> {

--- a/src/node/services/workflows/WorkflowRunner.test.ts
+++ b/src/node/services/workflows/WorkflowRunner.test.ts
@@ -3,8 +3,7 @@ import { execFile } from "node:child_process";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { promisify } from "node:util";
-import { describe, expect, test } from "bun:test";
-import type { WorkflowRunRecord } from "@/common/types/workflow";
+import { describe, expect, spyOn, test } from "bun:test";
 import { QuickJSRuntimeFactory } from "@/node/services/ptc/quickjsRuntime";
 import { ForegroundWaitBackgroundedError } from "@/node/services/taskService";
 import { DisposableTempDir } from "@/node/services/tempDir";
@@ -69,19 +68,14 @@ function createRunner(store: WorkflowRunStore, taskAdapter: WorkflowTaskAdapter)
   });
 }
 
-async function waitForRunSnapshot(
-  store: WorkflowRunStore,
-  runId: string,
-  predicate: (run: WorkflowRunRecord) => boolean
-): Promise<WorkflowRunRecord> {
-  const deadline = Date.now() + 500;
-  let latest = await store.getRun(runId);
-  while (!predicate(latest) && Date.now() < deadline) {
-    await new Promise((resolve) => setTimeout(resolve, 5));
-    latest = await store.getRun(runId);
-  }
-  expect(predicate(latest)).toBe(true);
-  return latest;
+function createDeferred() {
+  let resolve!: () => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<void>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
 }
 
 describe("WorkflowRunner", () => {
@@ -897,6 +891,23 @@ describe("WorkflowRunner", () => {
     const sourceAReturnedPromise = new Promise<void>((resolve) => {
       sourceAReturned = resolve;
     });
+    const sourceARecorded = createDeferred();
+    const recordCompleted = store.recordStepCompletedAndAppendTaskEvent.bind(store);
+    spyOn(store, "recordStepCompletedAndAppendTaskEvent").mockImplementation(
+      async (runId, input, options) => {
+        try {
+          await recordCompleted(runId, input, options);
+        } catch (error) {
+          if (input.stepId === "source-a") {
+            sourceARecorded.reject(error);
+          }
+          throw error;
+        }
+        if (input.stepId === "source-a") {
+          sourceARecorded.resolve();
+        }
+      }
+    );
     const runner = createRunner(store, {
       async runAgent(spec, lifecycle) {
         await lifecycle?.onTaskCreated?.(`task_${spec.id}`);
@@ -911,11 +922,8 @@ describe("WorkflowRunner", () => {
 
     const runPromise = runner.run("wfr_parallel_incremental");
     await sourceAReturnedPromise;
-    const runDuringSlowSibling = await waitForRunSnapshot(
-      store,
-      "wfr_parallel_incremental",
-      (run) => run.steps.some((step) => step.stepId === "source-a" && step.status === "completed")
-    );
+    await sourceARecorded.promise;
+    const runDuringSlowSibling = await store.getRun("wfr_parallel_incremental");
 
     const sourceAStep = runDuringSlowSibling.steps.find((step) => step.stepId === "source-a");
     expect(sourceAStep).toMatchObject({
@@ -1079,6 +1087,23 @@ describe("WorkflowRunner", () => {
       releaseSourceA = resolve;
     });
     const calls: string[] = [];
+    const sourceBFailureRecorded = createDeferred();
+    const recordFailed = store.recordStepFailedAndAppendTaskEvent.bind(store);
+    spyOn(store, "recordStepFailedAndAppendTaskEvent").mockImplementation(
+      async (runId, input, options) => {
+        try {
+          await recordFailed(runId, input, options);
+        } catch (error) {
+          if (input.stepId === "source-b" && input.taskId === "task_source-b_bad") {
+            sourceBFailureRecorded.reject(error);
+          }
+          throw error;
+        }
+        if (input.stepId === "source-b" && input.taskId === "task_source-b_bad") {
+          sourceBFailureRecorded.resolve();
+        }
+      }
+    );
     const runner = createRunner(store, {
       async runAgent(spec) {
         calls.push(spec.id);
@@ -1102,12 +1127,8 @@ describe("WorkflowRunner", () => {
     });
 
     const runPromise = runner.run("wfr_parallel_validation_incremental");
-    const runDuringSlowSibling = await waitForRunSnapshot(
-      store,
-      "wfr_parallel_validation_incremental",
-      (run) =>
-        run.events.some((event) => event.type === "validation" && event.stepId === "source-b")
-    );
+    await sourceBFailureRecorded.promise;
+    const runDuringSlowSibling = await store.getRun("wfr_parallel_validation_incremental");
 
     const validationEvent = runDuringSlowSibling.events.find(
       (event) => event.type === "validation" && event.stepId === "source-b"

--- a/src/node/services/workflows/WorkflowRunner.test.ts
+++ b/src/node/services/workflows/WorkflowRunner.test.ts
@@ -4,9 +4,10 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, test } from "bun:test";
+import type { WorkflowRunRecord } from "@/common/types/workflow";
+import { QuickJSRuntimeFactory } from "@/node/services/ptc/quickjsRuntime";
 import { ForegroundWaitBackgroundedError } from "@/node/services/taskService";
 import { DisposableTempDir } from "@/node/services/tempDir";
-import { QuickJSRuntimeFactory } from "@/node/services/ptc/quickjsRuntime";
 import { WorkflowActionRegistry } from "./WorkflowActionRegistry";
 import { WorkflowRunStore } from "./WorkflowRunStore";
 import {
@@ -66,6 +67,21 @@ function createRunner(store: WorkflowRunStore, taskAdapter: WorkflowTaskAdapter)
       nowMs: () => 1_000,
     },
   });
+}
+
+async function waitForRunSnapshot(
+  store: WorkflowRunStore,
+  runId: string,
+  predicate: (run: WorkflowRunRecord) => boolean
+): Promise<WorkflowRunRecord> {
+  const deadline = Date.now() + 500;
+  let latest = await store.getRun(runId);
+  while (!predicate(latest) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    latest = await store.getRun(runId);
+  }
+  expect(predicate(latest)).toBe(true);
+  return latest;
 }
 
 describe("WorkflowRunner", () => {
@@ -853,6 +869,82 @@ describe("WorkflowRunner", () => {
     expect(run.steps.map((step) => step.stepId).sort()).toEqual(["source-a", "source-b"]);
   });
 
+  test("records completed parallelAgents results before slower siblings finish", async () => {
+    using tmp = new DisposableTempDir("workflow-runner-parallel-incremental");
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
+    await store.createRun({
+      id: "wfr_parallel_incremental",
+      workspaceId: "workspace-1",
+      definition,
+      definitionSource: `export default function workflow({ parallelAgents }) {
+        const results = parallelAgents([
+          { id: "source-a", prompt: "Read source A" },
+          { id: "source-b", prompt: "Read source B" },
+        ]);
+        return { reportMarkdown: results.map((result) => result.reportMarkdown).join(" + ") };
+      }`,
+      args: {},
+      now: "2026-05-29T00:00:00.000Z",
+    });
+    let releaseSourceB!: () => void;
+    const sourceBBlocked = new Promise<void>((resolve) => {
+      releaseSourceB = resolve;
+    });
+    let sourceAReturned!: () => void;
+    const sourceAReturnedPromise = new Promise<void>((resolve) => {
+      sourceAReturned = resolve;
+    });
+    const runner = createRunner(store, {
+      async runAgent(spec, lifecycle) {
+        await lifecycle?.onTaskCreated?.(`task_${spec.id}`);
+        if (spec.id === "source-a") {
+          sourceAReturned();
+          return { taskId: "task_source-a", reportMarkdown: "source-a" };
+        }
+        await sourceBBlocked;
+        return { taskId: "task_source-b", reportMarkdown: "source-b" };
+      },
+    });
+
+    const runPromise = runner.run("wfr_parallel_incremental");
+    await sourceAReturnedPromise;
+    const runDuringSlowSibling = await waitForRunSnapshot(
+      store,
+      "wfr_parallel_incremental",
+      (run) => run.steps.some((step) => step.stepId === "source-a" && step.status === "completed")
+    );
+
+    const sourceAStep = runDuringSlowSibling.steps.find((step) => step.stepId === "source-a");
+    expect(sourceAStep).toMatchObject({
+      stepId: "source-a",
+      status: "completed",
+      taskId: "task_source-a",
+    });
+    expect(sourceAStep?.result).toMatchObject({
+      reportMarkdown: "source-a",
+      taskId: "task_source-a",
+    });
+    expect(runDuringSlowSibling.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "task",
+          stepId: "source-a",
+          taskId: "task_source-a",
+          status: "completed",
+        }),
+      ])
+    );
+    expect(runDuringSlowSibling.steps).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ stepId: "source-b", status: "completed" })])
+    );
+
+    releaseSourceB();
+    await expect(runPromise).resolves.toEqual({ reportMarkdown: "source-a + source-b" });
+  });
+
   test("interrupts sibling parallelAgents when one child task fails", async () => {
     using tmp = new DisposableTempDir("workflow-runner");
     const store = new WorkflowRunStore({
@@ -952,6 +1044,101 @@ describe("WorkflowRunner", () => {
 
     expect(sourceBStarted).toBe(true);
     expect(interruptRunCalls).toBe(0);
+  });
+
+  test("records parallelAgents validation failures before slower siblings finish", async () => {
+    using tmp = new DisposableTempDir("workflow-runner-parallel-validation-incremental");
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
+    await store.createRun({
+      id: "wfr_parallel_validation_incremental",
+      workspaceId: "workspace-1",
+      definition,
+      definitionSource: `export default function workflow({ parallelAgents }) {
+        const results = parallelAgents([
+          {
+            id: "source-a",
+            prompt: "Summarize A",
+            outputSchema: { type: "object", required: ["summary"], properties: { summary: { type: "string" } } },
+          },
+          {
+            id: "source-b",
+            prompt: "Summarize B",
+            outputSchema: { type: "object", required: ["summary"], properties: { summary: { type: "string" } } },
+          },
+        ]);
+        return { reportMarkdown: results.map((result) => result.structuredOutput.summary).join(" + ") };
+      }`,
+      args: {},
+      now: "2026-05-29T00:00:00.000Z",
+    });
+    let releaseSourceA!: () => void;
+    const sourceABlocked = new Promise<void>((resolve) => {
+      releaseSourceA = resolve;
+    });
+    const calls: string[] = [];
+    const runner = createRunner(store, {
+      async runAgent(spec) {
+        calls.push(spec.id);
+        if (spec.id === "source-a") {
+          await sourceABlocked;
+          return {
+            taskId: `task_${spec.id}`,
+            reportMarkdown: spec.id,
+            structuredOutput: { summary: spec.id },
+          };
+        }
+        if (calls.filter((id) => id === "source-b").length === 1) {
+          return { taskId: "task_source-b_bad", reportMarkdown: "bad" };
+        }
+        return {
+          taskId: "task_source-b_retry",
+          reportMarkdown: "source-b",
+          structuredOutput: { summary: "source-b" },
+        };
+      },
+    });
+
+    const runPromise = runner.run("wfr_parallel_validation_incremental");
+    const runDuringSlowSibling = await waitForRunSnapshot(
+      store,
+      "wfr_parallel_validation_incremental",
+      (run) =>
+        run.events.some((event) => event.type === "validation" && event.stepId === "source-b")
+    );
+
+    const validationEvent = runDuringSlowSibling.events.find(
+      (event) => event.type === "validation" && event.stepId === "source-b"
+    );
+    expect(validationEvent).toMatchObject({
+      type: "validation",
+      stepId: "source-b",
+      success: false,
+    });
+    const failedTaskEvent = runDuringSlowSibling.events.find(
+      (event) =>
+        event.type === "task" &&
+        event.stepId === "source-b" &&
+        event.taskId === "task_source-b_bad" &&
+        event.status === "failed"
+    );
+    expect(failedTaskEvent).toMatchObject({
+      type: "task",
+      stepId: "source-b",
+      taskId: "task_source-b_bad",
+      status: "failed",
+    });
+    expect(
+      runDuringSlowSibling.steps.some(
+        (step) => step.stepId === "source-b" && step.status === "completed"
+      )
+    ).toBe(false);
+
+    releaseSourceA();
+    await expect(runPromise).resolves.toEqual({ reportMarkdown: "source-a + source-b" });
+    expect(calls).toEqual(["source-a", "source-b", "source-b"]);
   });
 
   test("retries only failed parallelAgents steps after structured output validation errors", async () => {

--- a/src/node/services/workflows/WorkflowRunner.ts
+++ b/src/node/services/workflows/WorkflowRunner.ts
@@ -1550,34 +1550,25 @@ export class WorkflowRunner {
   ): Promise<void> {
     step.leaseGuard.throwIfLost();
     const taskId = getTaskIdFromUnknownAgentResult(step.rawResult);
-    await this.appendEvent(runId, {
-      sequence: sequence.next(),
-      type: "validation",
-      at: this.clock.nowIso(),
-      stepId: step.spec.id,
-      success: false,
-      message,
-    });
-    step.leaseGuard.throwIfLost();
-    await this.recordStepFailed(runId, {
-      stepId: step.spec.id,
-      inputHash: step.inputHash,
-      taskId,
-      error: message,
-      startedAt: step.startedAt,
-      completedAt: this.clock.nowIso(),
-    });
+    const failedAt = this.clock.nowIso();
+    sequence.next();
     if (taskId != null) {
-      step.leaseGuard.throwIfLost();
-      await this.appendEvent(runId, {
-        sequence: sequence.next(),
-        type: "task",
-        at: this.clock.nowIso(),
-        stepId: step.spec.id,
-        taskId,
-        status: "failed",
-      });
+      sequence.next();
     }
+    await this.runStore.recordStepFailedAndAppendTaskEvent(
+      runId,
+      {
+        stepId: step.spec.id,
+        inputHash: step.inputHash,
+        taskId,
+        error: message,
+        startedAt: step.startedAt,
+        completedAt: failedAt,
+        validationAt: failedAt,
+        taskFailedAt: failedAt,
+      },
+      { expectedLeaseOwnerId: this.runnerId }
+    );
   }
 
   private getTaskIdFromAgentResult(result: WorkflowAgentResult, stepId: string): string {

--- a/src/node/services/workflows/WorkflowRunner.ts
+++ b/src/node/services/workflows/WorkflowRunner.ts
@@ -575,7 +575,8 @@ export class WorkflowRunner {
     event: WorkflowRunEvent,
     options: AppendWorkflowRunEventOptions = {}
   ) {
-    return await this.runStore.appendEvent(runId, event, {
+    const { sequence: _storeAssignedSequence, ...eventDraft } = event;
+    return await this.runStore.appendNextEvent(runId, eventDraft, {
       ...options,
       expectedLeaseOwnerId: this.runnerId,
     });
@@ -1205,26 +1206,24 @@ export class WorkflowRunner {
         ...options.waitOptions,
         abortSignal: batchAbortController.signal,
       };
-      const pendingRuns = currentPending.map(async (step) => {
-        return await this.runOrResumeAgentStep(runId, sequence, {
-          spec:
-            step.attempt === 1
-              ? step.spec
-              : buildRetryAgentSpec(
-                  step.spec,
-                  step.attempt - 1,
-                  step.retryMessage ?? "previous attempt failed"
-                ),
-          inputHash: step.inputHash,
-          startedAt: step.startedAt,
-          taskId: step.taskId,
-          leaseGuard: options.leaseGuard,
-          waitOptions: batchWaitOptions,
-        });
-      });
-      const guardedRuns = pendingRuns.map(async (pendingRun) => {
+      const guardedRuns = currentPending.map(async (step, pendingIndex) => {
         try {
-          return await pendingRun;
+          const rawResult = await this.runOrResumeAgentStep(runId, sequence, {
+            spec:
+              step.attempt === 1
+                ? step.spec
+                : buildRetryAgentSpec(
+                    step.spec,
+                    step.attempt - 1,
+                    step.retryMessage ?? "previous attempt failed"
+                  ),
+            inputHash: step.inputHash,
+            startedAt: step.startedAt,
+            taskId: step.taskId,
+            leaseGuard: options.leaseGuard,
+            waitOptions: batchWaitOptions,
+          });
+          return { pendingIndex, step, rawResult };
         } catch (error) {
           if (isForegroundWaitBackgroundedError(error)) {
             foregroundBackgrounded = true;
@@ -1232,44 +1231,55 @@ export class WorkflowRunner {
           } else if (!foregroundBackgrounded) {
             await interruptRemainingTasks();
           }
-          throw error;
+          return { pendingIndex, step, error };
         }
       });
-      let rawResults: WorkflowAgentResult[];
+      const unsettledRuns = new Map(guardedRuns.map((run, index) => [index, run]));
       try {
-        rawResults = await Promise.all(guardedRuns);
-      } catch (error) {
-        await Promise.allSettled(guardedRuns);
-        if (foregroundBackgrounded) {
-          throw createForegroundWaitBackgroundedError();
+        while (unsettledRuns.size > 0) {
+          const settled = await Promise.race(unsettledRuns.values());
+          unsettledRuns.delete(settled.pendingIndex);
+          if ("error" in settled) {
+            await Promise.allSettled(unsettledRuns.values());
+            if (foregroundBackgrounded) {
+              throw createForegroundWaitBackgroundedError();
+            }
+            throw settled.error;
+          }
+          try {
+            results[settled.step.index] = await this.recordAgentResult(runId, sequence, {
+              ...settled.step,
+              leaseGuard: options.leaseGuard,
+              rawResult: settled.rawResult,
+            });
+          } catch (error) {
+            if (
+              !isRetryableAgentOutputError(error) ||
+              settled.step.attempt >= WORKFLOW_AGENT_MAX_ATTEMPTS
+            ) {
+              await interruptRemainingTasks();
+              await Promise.allSettled(unsettledRuns.values());
+              throw error;
+            }
+            options.leaseGuard.throwIfLost();
+            await this.recordAgentRetry(
+              runId,
+              sequence,
+              settled.step.spec.id,
+              settled.step.attempt,
+              error
+            );
+            pending.push({
+              ...settled.step,
+              startedAt: this.clock.nowIso(),
+              taskId: undefined,
+              attempt: settled.step.attempt + 1,
+              retryMessage: getErrorMessage(error),
+            });
+          }
         }
-        throw error;
       } finally {
         upstreamAbortSignal?.removeEventListener("abort", abortBatch);
-      }
-      for (const [pendingIndex, rawResult] of rawResults.entries()) {
-        const step = currentPending[pendingIndex];
-        assert(step != null, "WorkflowRunner.runAgentStepsInParallel: missing pending step");
-        try {
-          results[step.index] = await this.recordAgentResult(runId, sequence, {
-            ...step,
-            leaseGuard: options.leaseGuard,
-            rawResult,
-          });
-        } catch (error) {
-          if (!isRetryableAgentOutputError(error) || step.attempt >= WORKFLOW_AGENT_MAX_ATTEMPTS) {
-            throw error;
-          }
-          options.leaseGuard.throwIfLost();
-          await this.recordAgentRetry(runId, sequence, step.spec.id, step.attempt, error);
-          pending.push({
-            ...step,
-            startedAt: this.clock.nowIso(),
-            taskId: undefined,
-            attempt: step.attempt + 1,
-            retryMessage: getErrorMessage(error),
-          });
-        }
       }
     }
     return results;
@@ -1464,25 +1474,17 @@ export class WorkflowRunner {
     assert(task.status.length > 0, "WorkflowRunner: task event status is required");
 
     await using _lock = await this.taskEventMutex.acquire();
-    const run = await this.runStore.getRun(runId);
-    const alreadyRecorded = run.events.some(
-      (event) =>
-        event.type === "task" &&
-        event.status === task.status &&
-        event.stepId === task.stepId &&
-        event.taskId === task.taskId
+    sequence.next();
+    await this.runStore.appendTaskEventIfMissing(
+      runId,
+      {
+        stepId: task.stepId,
+        taskId: task.taskId,
+        status: task.status,
+        at: this.clock.nowIso(),
+      },
+      { expectedLeaseOwnerId: this.runnerId }
     );
-    if (alreadyRecorded) {
-      return;
-    }
-    await this.appendEvent(runId, {
-      sequence: sequence.next(),
-      type: "task",
-      at: this.clock.nowIso(),
-      stepId: task.stepId,
-      taskId: task.taskId,
-      status: task.status,
-    });
   }
 
   private async recordAgentResult(
@@ -1517,23 +1519,20 @@ export class WorkflowRunner {
     }
     step.leaseGuard.throwIfLost();
     const taskId = this.getTaskIdFromAgentResult(step.rawResult, step.spec.id);
-    await this.recordStepCompleted(runId, {
-      stepId: step.spec.id,
-      inputHash: step.inputHash,
-      taskId,
-      result,
-      startedAt: step.startedAt,
-      completedAt: this.clock.nowIso(),
-    });
-    step.leaseGuard.throwIfLost();
-    await this.appendEvent(runId, {
-      sequence: sequence.next(),
-      type: "task",
-      at: this.clock.nowIso(),
-      stepId: step.spec.id,
-      taskId,
-      status: "completed",
-    });
+    const completedAt = this.clock.nowIso();
+    sequence.next();
+    await this.runStore.recordStepCompletedAndAppendTaskEvent(
+      runId,
+      {
+        stepId: step.spec.id,
+        inputHash: step.inputHash,
+        taskId,
+        result,
+        startedAt: step.startedAt,
+        completedAt,
+      },
+      { expectedLeaseOwnerId: this.runnerId }
+    );
     return result;
   }
 


### PR DESCRIPTION
## Summary

Fixes durable workflow state updates for `parallelAgents(...)` so completed child agents are recorded and exposed in the workflow run card as soon as each child reports and passes workflow validation, without waiting for the slowest sibling.

## Background

Parallel workflow child workspaces could show as reported in the sidebar while the workflow card still displayed their rows as `started`. The root cause was backend journal timing: parallel child results were previously persisted only after the full parallel batch settled.

## Implementation

- Moves runner-generated workflow events onto store-assigned sequence numbers under the workflow mutation lock.
- Records accepted child step results and their matching `task completed` events under one store mutation.
- Records validation failures, failed step records, and matching failed task events under one store mutation.
- Refactors `parallelAgents(...)` settlement handling to persist each accepted result as soon as it settles while preserving ordered return values and retry behavior.
- Keeps public workflow reads lockless for UI polling, falling back to the last atomic `run.json` snapshot if a writer lock is active.
- Removes the redundant scratch workflow ignore rule that overrode the `.gitignore` exception.

## Validation

- `bun test src/node/services/workflows/WorkflowRunStore.test.ts src/node/services/workflows/WorkflowRunner.test.ts`
- `bun test src/browser/features/Tools/WorkflowRunToolCall.test.tsx`
- `make typecheck`
- `make lint` (rerun with `MUX_ESLINT_CONCURRENCY=1` after an OOM kill at concurrency 8)
- `make fmt-check`
- `make static-check`

## Dogfooding

Validated in an isolated dev-server sandbox with `agent-browser` using a scratch workflow that launches fast, normal, and slow parallel child agents. Captured screenshots and video under `dogfood-output/workflow-live-ui/`, including the fast lane showing `completed` with an available report while sibling lanes were still running.

## Risks

This touches durable workflow journal sequencing and replay-adjacent code. Risk is mitigated with targeted store/runner coverage for concurrent sequence assignment, atomic accepted and failed snapshots, deterministic incremental parallel completion tests, retry behavior, foreground backgrounding, and full static validation.

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Make workflow UI update as sub-agents finish

## Problem statement

In workflow runs with parallel sub-agents, the sidebar can show individual child agents as finished while the workflow run card still shows their task rows as `started`. This makes successful work look stalled or broken. The UI should expose completed child reports as soon as each sub-agent reports, without waiting for the full parallel batch or final workflow result.

## Verified evidence from repo investigation

- `src/browser/features/Tools/WorkflowRunToolCall.tsx` already refreshes active workflow runs by polling `api.workflows.getRun()` every 2 seconds while the run status is `pending`, `running`, or `backgrounded`.
- The workflow event table is derived from `run.events`; task rows are coalesced by `stepId + taskId` and display the latest task event status.
- A task report button appears only when the matching `WorkflowStepRecord` in `run.steps` has `result.reportMarkdown`.
- `src/node/services/taskService.ts` marks the child workspace `taskStatus = "reported"` and emits workspace metadata immediately when `agent_report` is finalized. That explains why the sidebar can update before the workflow card.
- `src/node/services/workflows/WorkflowRunner.ts` records completed workflow task events and step reports in `recordAgentResult(...)`.
- For `parallelAgents(...)`, `runAgentStepsInParallel(...)` starts all children concurrently, waits for `Promise.all(...)`, and only then loops over all raw results to call `recordAgentResult(...)`. That means fast siblings do not write their workflow step result or `task completed` event until the slowest sibling finishes.
- Current workflow run event sequencing is coordinated by a runner-local `WorkflowEventSequence`. Parallel completion recording must not call `sequence.next()` concurrently without an atomic append strategy.

## Goals

1. Show a completed workflow-owned sub-agent as completed in the workflow card as soon as the child reports and passes workflow validation.
2. Make that child report visible from the workflow card immediately after validation, while slower sibling agents continue running.
3. Preserve durable workflow semantics: replay, resume, retry, output-schema validation, and ordered `parallelAgents(...)` return values.
4. Avoid misleading labels: a child workspace being `reported` is not the same as the workflow step being accepted, because output validation may still fail and trigger a retry.
5. Keep the implementation minimal and surgical, then layer richer live UX only if needed.

## Recommended approach

### Approach A — recommended baseline: record parallel agent results incrementally

**Net product LoC estimate:** ~180–300 LoC.

Fix the source of truth first: the durable workflow journal should reflect each child completion when it happens. Once the journal updates incrementally, the existing 2-second workflow card polling can render the completed status and report without a large frontend architecture change.

#### Implementation outline

1. **Unify runner event sequencing behind store-assigned append-next events.**
   - Add a store-level helper in `WorkflowRunStore`, e.g. `appendNextEvent(runId, eventDraftWithoutSequence, options)`.
   - Under the existing workflow event mutation lock, read current events, assign `sequence = lastSequence + 1`, validate, append, and update `run.json`.
   - Migrate `WorkflowRunner`’s private event append path to use store-assigned sequencing for runner-generated events.
   - Stop using runner-local `WorkflowEventSequence.next()` in active runner paths once the store helper exists. Do not mix runner-local and store-assigned sequencing for the same run.
   - Keep the old sequenced `appendEvent(...)` only for compatibility or targeted tests if needed, not as an active `WorkflowRunner` write path.
   - Add defensive assertions that event drafts have non-empty required identifiers and do not include a caller-provided sequence.

2. **Make accepted agent results snapshot-consistent.**
   - Add a store-level helper for accepted child results, e.g. `recordStepCompletedAndAppendTaskEvent(...)`.
   - Under one workflow mutation lock, append the completed `WorkflowStepRecord`, perform the idempotent duplicate check for the completed task event, append the `task completed` event with the next sequence if missing, and update `run.json`.
   - The combined write helper must call unlocked/internal append, read, and write primitives while holding that one lock; do not compose public methods that reacquire the same lock and deadlock.
   - Add read-side consistency: public `WorkflowRunStore.getRun()` and `listRuns()` must read `run.json`, `events.jsonl`, and `steps.jsonl` under the same workflow mutation lock at least for mutating/active workflow runs, so UI polls cannot observe the step append between the paired event append.
   - Implement public locked reads by delegating to unlocked/internal read helpers such as `getRunUnlocked()` / `listRunsUnlocked()` / `readRunSnapshotUnlocked()`.
   - Any code path already holding the workflow mutation lock, including `appendNextEvent`, combined step+event writes, legacy `appendEventUnlocked`, and step-record writes, must call only unlocked/internal read/write helpers and never re-enter public lock-acquiring methods.
   - Use this helper from `recordAgentResult(...)` so the first refreshed snapshot that shows a report also shows the completed task event, avoiding transient `steps has report but row still says started` or `row completed but report missing` states.
   - Apply the same locked check-then-append pattern to idempotent task event insertion (`recordTaskEventIfMissing`) so duplicate detection and append are atomic.

3. **Refactor `runAgentStepsInParallel(...)` to handle settlements in completion order.**
   - Launch all current pending child tasks concurrently, as today.
   - Wrap each child promise with its pending step metadata and settle into `{ step, rawResult }` or `{ step, error }`.
   - Use a `Promise.race` loop over unsettled wrapped promises to process each completion immediately.
   - On success:
     - call `recordAgentResult(...)` immediately through the snapshot-consistent store helper;
     - store the validated `StructuredTaskOutput` into `results[step.index]`;
     - continue waiting for remaining siblings.
   - On output-schema validation failure:
     - preserve today’s retry semantics;
     - record failed attempt/retry log immediately;
     - enqueue only that step for the next retry wave.
   - On the first hard child failure:
     - preserve the original hard error as the error ultimately thrown;
     - preserve today’s sibling interruption behavior;
     - abort the batch and call `interruptRun()` for siblings as today;
     - await all settled/settling children to avoid unhandled promise leaks;
     - do not record late sibling successes after the first hard failure unless a narrow test proves the existing behavior already does so and the change is intentional.
   - Preserve foreground-backgrounding behavior: when a foreground wait backgrounds, abort the wait path without marking sibling failures as user-visible hard failures.

4. **Update tests for backend behavior.**
   - Add a controlled `WorkflowRunner.test.ts` case where `parallelAgents` has a fast child and a slow child.
   - Hold the slow child with a manual promise.
   - Assert that the fast child’s completed `WorkflowStepRecord`, report markdown, and `task completed` event exist in the same observed run snapshot before releasing the slow child.
   - Add/adjust validation retry tests so failed structured output is recorded immediately and only the failed lane retries.
   - Add an overlapping starts/completions test and assert event sequence numbers remain strictly increasing and unique.
   - Add a snapshot consistency test that races a poll/read with a completed step+event write; assert the observed accepted completion includes both report and completed event and does not deadlock.
   - Add a foreground-backgrounding regression test: one child backgrounds the foreground wait; siblings are not marked failed/interrupted; the run transitions to `backgrounded`; resume still works.

5. **Update/extend workflow UI tests only where needed.**
   - `WorkflowRunToolCall.test.tsx` already covers completed task rows and report dialog behavior.
   - Add a focused test if needed for mixed `started` + `completed` task rows in the same active run snapshot.

#### Expected UX after Approach A

- The workflow card may update up to 2 seconds after a child reports because it still polls.
- Rows will stop being stuck at `started` while completed child reports are already available elsewhere.
- Report buttons become available incrementally.

### Approach B — follow-up for sub-second live UX: workflow run subscription

**Net product LoC estimate:** ~220–380 LoC.

After Approach A establishes correct durable state, add push updates so workflow cards update immediately rather than on the next poll.

#### Implementation outline

1. Add an oRPC subscription such as `workflows.onRun({ workspaceId, runId })`.
2. On connect, send the current full `WorkflowRunRecord` snapshot.
3. Emit new snapshots whenever workflow events or steps are written.
4. Because `WorkflowService` is request-scoped, put the notification source in a process-global workflow run event hub or inside the store module keyed by `{ workspaceSessionDir, runId }`.
5. In `WorkflowRunToolCall`, subscribe while the card has a confirmed `runId` and the run is active or expanded.
6. Keep polling as a fallback for missed events, subscription disconnects, or older records.

#### Why not do this first?

A live subscription would still have nothing correct to push for fast parallel children until the backend journal records those children incrementally. The durable-state bug should be fixed first.

### Approach C — not recommended as the primary fix: overlay sidebar task metadata into workflow rows

**Net product LoC estimate:** ~80–160 LoC.

The UI could notice that a child workspace has `taskStatus = "reported"` and render the workflow row as `reported` before the workflow journal has accepted it. This is tempting but risks a new inconsistency: a reported child may still fail workflow output validation and be retried. If used at all, label it as `reported · validating`, never `completed`.

Use this only as a minor polish after Approach A, not as the source-of-truth fix.

## UX polish after durable correctness

1. Replace raw `/ started` text emphasis with compact status chips:
   - `running`
   - `reported · validating`
   - `completed`
   - `retrying`
   - `failed`
   - `interrupted`
2. Add an active workflow summary near the event section, for example:
   - `9 tasks · 2 completed · 6 running · 1 queued`
3. Make report availability explicit:
   - show `Report` or `Report ready` when `run.steps[].result.reportMarkdown` exists.
4. Preserve separate actions:
   - row click opens/navigates to child workspace;
   - report button opens the workflow-captured report.
5. Avoid auto-scroll unless the user is already at the bottom of the event list.
6. Optional: briefly highlight rows that changed status during the current UI session, without adding decorative animation.

## Acceptance criteria

### Backend/source-of-truth acceptance

- In a `parallelAgents(...)` workflow, if child A reports before child B, child A’s workflow step is recorded as completed before child B finishes.
- Child A’s report markdown is visible in `run.steps` before child B finishes.
- The workflow event sequence remains strictly increasing and contains no duplicate sequence values.
- Active runner paths use one sequencing strategy for a run: store-assigned append-next events, not a mix of runner-local and store-assigned sequence allocation.
- The first observed snapshot for an accepted child completion contains both the completed step/report and the matching `task completed` event.
- Locked combined writes and locked public reads do not deadlock; lock-holding code paths use unlocked/internal read/write helpers only.
- `parallelAgents(...)` still returns results in input order.
- Output-schema failure still records failure/retry and does not show the failed attempt as completed.
- Hard child failures still interrupt/abort siblings as today and preserve the original thrown error.
- Foreground backgrounding behavior remains unchanged.
- Resume/replay still reuses completed steps and does not duplicate completed task events.

### UI acceptance

- The workflow card shows mixed active/completed task states correctly.
- Completed task rows expose a report affordance while sibling tasks continue running.
- Final workflow reports still render as before.
- No row claims `completed` based only on sidebar/task metadata unless the workflow step has been accepted by the workflow journal.

## Validation plan

Run targeted checks first:

```bash
bun test src/node/services/workflows/WorkflowRunner.test.ts
bun test src/browser/features/Tools/WorkflowRunToolCall.test.tsx
```

Then run broader static validation:

```bash
make typecheck
make lint
make static-check
```

If the implementation touches oRPC schemas or subscriptions for Approach B, also run relevant router/API tests:

```bash
bun test src/node/orpc/router.test.ts
bun test src/common/orpc/schemas/workflow.test.ts
```

## Dogfooding plan

Use the requested sandbox and browser automation flow so reviewers can verify the behavior with screenshots and video evidence.

### Sandbox setup

1. Start an isolated dev server:

```bash
make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-projects"
```

2. Note the emitted Vite URL and backend port.
3. Ensure the sandbox has provider configuration available (copied from the seed root unless `--clean-providers` is used); otherwise add a test provider before running agents.
4. Add/open a throwaway test project inside the sandbox before invoking the workflow. `--clean-projects` intentionally starts with no projects.
5. Use that throwaway project so workflow runs and child agents do not affect the user’s normal state.

### Browser automation setup

Use `agent-browser` directly, following the skill guidance:

```bash
agent-browser --session workflow-live-ui open <VITE_URL>
agent-browser --session workflow-live-ui wait --load networkidle
agent-browser --session workflow-live-ui snapshot -i
```

Create an evidence directory, for example:

```bash
mkdir -p dogfood-output/workflow-live-ui/screenshots dogfood-output/workflow-live-ui/videos
```

### Dogfood workflow scenario

Create or use a scratch workflow that calls `parallelAgents(...)` with at least three sub-agents:

- one fast child that reports quickly,
- one intentionally slower child,
- one normal child.

The scenario should demonstrate that the fast child’s workflow row and report become visible before all siblings finish.

### Evidence to capture

Capture screenshots and video in the dogfood output directory:

1. Initial workflow card showing all children started.
2. A video from before the fast child reports through the moment its row changes to completed/report-ready.
3. A screenshot of the workflow card while at least one sibling is still running and one child is completed.
4. A screenshot/video opening the completed child’s report from the workflow card.
5. A final screenshot after the entire workflow completes.
6. Console and network error checks:

```bash
agent-browser --session workflow-live-ui console
agent-browser --session workflow-live-ui errors
```

### Dogfood pass criteria

- The workflow card no longer shows already accepted child reports as only `started`.
- The report button/dialog works before the whole workflow completes.
- The sidebar and workflow card do not contradict each other in normal successful cases.
- If a child is only `reported` but not yet workflow-accepted, the UI does not falsely label it completed.
- The dogfood artifact set includes screenshots and a video recording suitable for reviewer verification.

## Rollout strategy

1. Ship Approach A first because it fixes durable correctness with the smallest surface area.
2. Keep existing polling fallback.
3. If users still perceive the 2-second delay as too slow, ship Approach B as a follow-up.
4. Add UX polish after correctness is proven by tests and dogfood evidence.

## Risks and mitigations

- **Risk:** concurrent event appends produce duplicate or out-of-order sequence numbers.  
  **Mitigation:** assign sequence numbers under the workflow event mutation lock.

- **Risk:** immediate recording changes retry timing.  
  **Mitigation:** preserve current retry limits and only enqueue failed validation lanes for retry after recording the failed attempt.

- **Risk:** a child report appears completed before workflow validation.  
  **Mitigation:** do not mark a workflow row completed until `recordAgentResult(...)` succeeds.

- **Risk:** larger live subscription work expands scope.  
  **Mitigation:** keep Approach B as follow-up unless sub-second updates are explicitly required for the first patch.

## Recommended implementation order

1. Add atomic append helper in `WorkflowRunStore` and targeted tests.
2. Refactor parallel child settlement recording in `WorkflowRunner` and targeted tests.
3. Update/verify workflow UI rendering tests.
4. Run validation commands.
5. Dogfood with sandbox + `agent-browser`, collecting screenshots/video.
6. Consider Approach B only after the durable-state fix is verified.

## Advisor review status

- Advisor review 1: not approved yet. Required amendments were applied: unify runner event sequencing behind store-assigned append-next events; make accepted task result + completed event snapshot-consistent; make idempotent task event insertion atomic; preserve hard-failure semantics; add foreground-backgrounding and sequencing regression coverage; clarify sandbox dogfood prerequisites.
- Advisor review 2: not approved yet. Required amendment applied: add read-side consistency for `getRun()` / `listRuns()` under the workflow mutation lock and require combined write helpers to use unlocked/internal primitives rather than nested public methods.
- Advisor review 3: not approved yet. Required amendment applied: public locked reads must delegate to unlocked/internal read helpers, and all lock-holding code paths must avoid re-entering public lock-acquiring methods; added deadlock/snapshot race regression coverage.
- Advisor review 4: approved. Implementation-ready.

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$123.04`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=123.04 -->
