### PR TITLE
🤖 fix: isolate workflow action exec diagnostics

### DIFF
--- a/.mux/workflows/.scratch/.gitignore
+++ b/.mux/workflows/.scratch/.gitignore
@@ -1,3 +1,5 @@
 # mux: hide scratch workflow drafts when repo rules unignore workflows
 *
 !.gitignore
+# mux: hide scratch workflow drafts when repo rules unignore workflows
+*

--- a/.mux/workflows/.scratch/.gitignore
+++ b/.mux/workflows/.scratch/.gitignore
@@ -1,5 +1,3 @@
 # mux: hide scratch workflow drafts when repo rules unignore workflows
 *
 !.gitignore
-# mux: hide scratch workflow drafts when repo rules unignore workflows
-*

--- a/src/node/services/workflows/WorkflowActionRunner.test.ts
+++ b/src/node/services/workflows/WorkflowActionRunner.test.ts
@@ -228,6 +228,41 @@ describe("WorkflowActionRunner", () => {
     expect(result.stderr).toBe("");
   });
 
+  test("keeps cleanup ps warnings out of action diagnostics", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    using tmp = new DisposableTempDir("workflow-action-ps-diagnostics");
+    const fakeBinDir = path.join(tmp.path, "bin");
+    const fakePsPath = path.join(fakeBinDir, "ps");
+    const sourcePath = path.join(tmp.path, "ps-diagnostics.js");
+    const sentinel = "fake ps warning should stay hidden";
+    await fs.mkdir(fakeBinDir, { recursive: true });
+    await fs.writeFile(fakePsPath, `#!/bin/sh\nprintf '${sentinel}\\n' >&2\n`, "utf-8");
+    await fs.chmod(fakePsPath, 0o755);
+    const source = `
+      module.exports.metadata = { version: 1, description: "Ps diagnostics", effect: "read" };
+      module.exports.execute = async (_input, ctx) => {
+        process.env.PATH = ${JSON.stringify(fakeBinDir + path.delimiter)} + (process.env.PATH || "");
+        const result = await ctx.exec(process.execPath, ["-e", ""]);
+        return { exitCode: result.exitCode };
+      };
+    `;
+    await fs.writeFile(sourcePath, source, "utf-8");
+    const runner = new WorkflowActionRunner();
+
+    const result = await runner.execute(createAction(sourcePath, source), {
+      input: null,
+      cwd: tmp.path,
+      timeoutMs: 10_000,
+      artifactDir: path.join(tmp.path, "artifacts"),
+    });
+
+    expect(result.output).toEqual({ exitCode: 0 });
+    expect(result.stderr).not.toContain(sentinel);
+    expect(result.stderr).toBe("");
+  });
+
   test("built-in git actions reject truncated command output", async () => {
     using tmp = new DisposableTempDir("workflow-action-git-truncated");
     const repoRoot = path.join(tmp.path, "repo");

--- a/src/node/services/workflows/WorkflowActionRunner.test.ts
+++ b/src/node/services/workflows/WorkflowActionRunner.test.ts
@@ -202,6 +202,32 @@ describe("WorkflowActionRunner", () => {
     });
   });
 
+  test("keeps ctx.exec output out of action diagnostics", async () => {
+    using tmp = new DisposableTempDir("workflow-action-exec-diagnostics");
+    const sourcePath = path.join(tmp.path, "exec-diagnostics.js");
+    const source = `
+      module.exports.metadata = { version: 1, description: "Exec diagnostics", effect: "read" };
+      module.exports.execute = async (_input, ctx) => {
+        console.log("action log");
+        const result = await ctx.exec(process.execPath, ["-e", "process.stdout.write('cmd stdout'); process.stderr.write('cmd stderr')"]);
+        return { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode };
+      };
+    `;
+    await fs.writeFile(sourcePath, source, "utf-8");
+    const runner = new WorkflowActionRunner();
+
+    const result = await runner.execute(createAction(sourcePath, source), {
+      input: null,
+      cwd: tmp.path,
+      timeoutMs: 10_000,
+      artifactDir: path.join(tmp.path, "artifacts"),
+    });
+
+    expect(result.output).toEqual({ stdout: "cmd stdout", stderr: "cmd stderr", exitCode: 0 });
+    expect(result.stdout).toBe("action log\n");
+    expect(result.stderr).toBe("");
+  });
+
   test("built-in git actions reject truncated command output", async () => {
     using tmp = new DisposableTempDir("workflow-action-git-truncated");
     const repoRoot = path.join(tmp.path, "repo");

--- a/src/node/services/workflows/WorkflowActionRunner.ts
+++ b/src/node/services/workflows/WorkflowActionRunner.ts
@@ -992,7 +992,10 @@ function captureResult(capture) {
 
 function listChildPids(pid) {
   try {
-    return execFileSync("ps", ["-axo", "pid=,ppid="], { encoding: "utf-8" })
+    return execFileSync("ps", ["-axo", "pid=,ppid="], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
       .trim()
       .split(/\n+/)
       .map((line) => line.trim().split(/\s+/).map((value) => Number(value)))
@@ -1328,11 +1331,9 @@ async function execCommand(command, args = [], options = {}) {
   timer?.unref?.();
   child.stdout?.on("data", (chunk) => {
     appendCapture(stdout, chunk);
-    process.stdout.write(chunk);
   });
   child.stderr?.on("data", (chunk) => {
     appendCapture(stderr, chunk);
-    process.stderr.write(chunk);
   });
   child.on("exit", (code, childSignal) => {
     exitCode = code;

--- a/src/node/services/workflows/WorkflowRunner.test.ts
+++ b/src/node/services/workflows/WorkflowRunner.test.ts
@@ -1806,6 +1806,9 @@ describe("WorkflowRunner", () => {
     expect(parsed.ignored).toContain("ignored.txt");
     expect(parsed.branchFiles).toContain("feature.txt");
     expect(parsed.branchDiff).toContain("feature.txt");
+    expect(parsed.branchDiff).toContain("diff --git");
+    expect(parsed.branchDiff).toContain("+feature");
+    expect(parsed.branchStat).not.toContain("diff --git");
     expect(parsed.unstagedDiff).toContain("+dirty");
     expect(parsed.diffTruncated).toEqual({ branch: false, staged: false, unstaged: false });
     expect(parsed.branchStat).toContain("feature.txt");


### PR DESCRIPTION
## Summary

Fix workflow action diagnostics so output produced by `ctx.exec` commands stays on the returned command result instead of being echoed into the action-level `stdout`/`stderr` fields. Also suppress stderr from the internal `ps` cleanup probe so host warnings do not pollute action diagnostics.

## Background

A workflow run showed built-in Git actions with confusing action diagnostics: `stdout` contained concatenated internal Git command output and `stderr` contained host `ps` warnings such as `bad data in /proc/uptime`. The structured `output` fields were usable, but the action-level diagnostics were misleading.

## Implementation

- Stop forwarding `ctx.exec` child stdout/stderr chunks to the action child process stdout/stderr while still draining and returning those streams from `ctx.exec`.
- Run the cleanup `ps` probe with stderr ignored.
- Add regression coverage for command-output isolation and deterministic fake-`ps` cleanup warning suppression.
- Keep the Git action workflow regression assertions that distinguish `git.diff` patch output from `git.diffStat` stat output.

## Deep Review

Ran `deep-review-workflow` after the initial commit. It identified two actionable findings, both addressed:

- Added deterministic coverage for noisy cleanup `ps` stderr.
- Removed the accidental duplicate scratch workflow `.gitignore` block.

Workflow run: `wfr_4254a7721b3f70f4`.

## Validation

- `bun test src/node/services/workflows/WorkflowActionRunner.test.ts --timeout 30000 --test-name-pattern "cleanup ps warnings|ctx.exec output"`
- `bun test src/node/services/workflows/WorkflowRunner.test.ts --timeout 30000 --test-name-pattern "runs built-in Git workflow actions"`
- Isolated `git check-ignore -v --no-index` check for `.mux/workflows/.scratch/.gitignore` vs a scratch draft file
- `git diff --check origin/main..HEAD && git diff --check`
- `make static-check`

## Risks

Low-to-medium. The production change affects workflow action diagnostics only: command streams are still drained to avoid backpressure and still returned through `ctx.exec`. Users who depended on implicit live echoing from `ctx.exec` into action stdout/stderr would no longer see those chunks there; actions can still log explicitly with `console.log` when desired.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `702472{MUX_COSTS_USD:-0}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=7.31 -->
