### PR TITLE
feat: add Files tab for inline project file browsing

### DIFF
--- a/src/browser/features/RightSidebar/FilesTab/FilesTab.tsx
+++ b/src/browser/features/RightSidebar/FilesTab/FilesTab.tsx
@@ -1,0 +1,400 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { ChevronRight, File, Folder, FolderOpen } from "lucide-react";
+import { useAPI } from "@/browser/contexts/API";
+import { MarkdownRenderer } from "@/browser/features/Messages/MarkdownRenderer";
+import { HighlightedCode } from "@/browser/features/Tools/Shared/HighlightedCode";
+import { cn } from "@/common/lib/utils";
+
+interface FilesTabProps {
+  projectPath: string;
+}
+
+interface FileEntry {
+  name: string;
+  path: string;
+  isDirectory: boolean;
+}
+
+// Maps common file extensions to Shiki language identifiers.
+const EXTENSION_TO_LANGUAGE: Record<string, string> = {
+  ts: "typescript",
+  tsx: "tsx",
+  js: "javascript",
+  jsx: "jsx",
+  mjs: "javascript",
+  cjs: "javascript",
+  py: "python",
+  rb: "ruby",
+  go: "go",
+  rs: "rust",
+  cpp: "cpp",
+  cc: "cpp",
+  cxx: "cpp",
+  c: "c",
+  h: "c",
+  hpp: "cpp",
+  java: "java",
+  cs: "csharp",
+  php: "php",
+  swift: "swift",
+  kt: "kotlin",
+  css: "css",
+  scss: "scss",
+  less: "less",
+  html: "html",
+  htm: "html",
+  xml: "xml",
+  svg: "xml",
+  json: "json",
+  jsonc: "jsonc",
+  yaml: "yaml",
+  yml: "yaml",
+  toml: "toml",
+  sh: "bash",
+  bash: "bash",
+  zsh: "bash",
+  sql: "sql",
+  graphql: "graphql",
+  gql: "graphql",
+  vue: "vue",
+  svelte: "svelte",
+  lua: "lua",
+  r: "r",
+  pl: "perl",
+  dockerfile: "dockerfile",
+  mk: "makefile",
+};
+
+function getExtension(filename: string): string {
+  const lower = filename.toLowerCase();
+  if (lower === "dockerfile" || lower === "makefile" || lower === "gemfile") return lower;
+  const dot = filename.lastIndexOf(".");
+  return dot >= 0 ? filename.slice(dot + 1).toLowerCase() : "";
+}
+
+function isMarkdownFile(filename: string): boolean {
+  const ext = getExtension(filename);
+  return ext === "md" || ext === "mdx";
+}
+
+function getLanguage(filename: string): string {
+  const ext = getExtension(filename);
+  return EXTENSION_TO_LANGUAGE[ext] ?? "text";
+}
+
+// Cross-platform path utilities — handle both `/` (POSIX) and `\` (Windows).
+function pathBasename(p: string): string {
+  const lastSlash = Math.max(p.lastIndexOf("/"), p.lastIndexOf("\\"));
+  return lastSlash >= 0 ? p.slice(lastSlash + 1) : p;
+}
+
+function pathDirname(p: string): string {
+  const lastSlash = Math.max(p.lastIndexOf("/"), p.lastIndexOf("\\"));
+  return lastSlash > 0 ? p.slice(0, lastSlash) : "";
+}
+
+interface BreadcrumbProps {
+  projectPath: string;
+  currentDir: string;
+  onNavigate: (dir: string) => void;
+}
+
+const Breadcrumb: React.FC<BreadcrumbProps> = ({ projectPath, currentDir, onNavigate }) => {
+  const rootName = pathBasename(projectPath) || projectPath;
+
+  if (currentDir === projectPath) {
+    return (
+      <div className="text-muted flex items-center gap-0.5 truncate text-[11px]">
+        <span className="text-foreground font-medium">{rootName}</span>
+      </div>
+    );
+  }
+
+  // Walk upward from currentDir to projectPath, collecting each ancestor.
+  // This avoids string-splitting on the separator (fragile cross-platform).
+  const ancestors: { name: string; path: string }[] = [];
+  let cursor = currentDir;
+  while (cursor !== projectPath) {
+    ancestors.unshift({ name: pathBasename(cursor), path: cursor });
+    const parent = pathDirname(cursor);
+    if (!parent || parent === cursor) break;
+    cursor = parent;
+  }
+
+  return (
+    <div className="text-muted flex items-center gap-0.5 overflow-hidden text-[11px]">
+      <button
+        type="button"
+        className="hover:text-foreground shrink-0 truncate transition-colors"
+        onClick={() => onNavigate(projectPath)}
+      >
+        {rootName}
+      </button>
+      {ancestors.map(({ name, path }, i) => {
+        const isLast = i === ancestors.length - 1;
+        return (
+          <React.Fragment key={path}>
+            <ChevronRight className="h-2.5 w-2.5 shrink-0 opacity-40" />
+            {isLast ? (
+              <span className="text-foreground truncate font-medium">{name}</span>
+            ) : (
+              <button
+                type="button"
+                className="hover:text-foreground shrink-0 truncate transition-colors"
+                onClick={() => onNavigate(path)}
+              >
+                {name}
+              </button>
+            )}
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+};
+
+interface FileTreeProps {
+  entries: FileEntry[];
+  selectedPath: string | null;
+  onSelectDir: (entry: FileEntry) => void;
+  onSelectFile: (entry: FileEntry) => void;
+}
+
+const FileTree: React.FC<FileTreeProps> = ({ entries, selectedPath, onSelectDir, onSelectFile }) => {
+  // Directories first, then files, both alphabetically.
+  const sorted = [...entries].sort((a, b) => {
+    if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  if (sorted.length === 0) {
+    return <p className="text-muted px-3 py-2 text-[11px]">Empty directory</p>;
+  }
+
+  return (
+    <ul className="m-0 list-none p-0">
+      {sorted.map((entry) => {
+        const isSelected = entry.path === selectedPath;
+        return (
+          <li key={entry.path}>
+            <button
+              type="button"
+              className={cn(
+                "flex w-full items-center gap-1.5 px-2 py-1 text-left text-[12px] transition-colors",
+                isSelected
+                  ? "bg-white/10 text-foreground"
+                  : "text-muted hover:bg-white/5 hover:text-foreground"
+              )}
+              onClick={() => (entry.isDirectory ? onSelectDir(entry) : onSelectFile(entry))}
+              title={entry.name}
+            >
+              {entry.isDirectory ? (
+                <Folder className="h-3.5 w-3.5 shrink-0 text-yellow-500/80" />
+              ) : (
+                <File className="h-3.5 w-3.5 shrink-0 opacity-60" />
+              )}
+              <span className="truncate">{entry.name}</span>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+interface FileViewerProps {
+  filename: string;
+  content: string;
+  truncated: boolean;
+}
+
+const FileViewer: React.FC<FileViewerProps> = ({ filename, content, truncated }) => {
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="text-muted border-border-medium flex shrink-0 items-center border-b px-3 py-1.5 text-[11px]">
+        <span className="truncate font-mono">{filename}</span>
+        {truncated && (
+          <span className="text-warning ml-auto shrink-0 pl-2">(truncated at 512 KB)</span>
+        )}
+      </div>
+      {isMarkdownFile(filename) ? (
+        <div className="flex-1 overflow-y-auto p-4">
+          <MarkdownRenderer content={content} />
+        </div>
+      ) : (
+        <div className="flex-1 overflow-auto p-2">
+          <HighlightedCode
+            code={content}
+            language={getLanguage(filename)}
+            showLineNumbers
+            className="text-[11px]"
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const FilesTab: React.FC<FilesTabProps> = ({ projectPath }) => {
+  const { api } = useAPI();
+  const [currentDir, setCurrentDir] = useState<string>(projectPath);
+  const [entries, setEntries] = useState<FileEntry[]>([]);
+  const [loadingDir, setLoadingDir] = useState(false);
+  const [dirError, setDirError] = useState<string | null>(null);
+  const [selectedFile, setSelectedFile] = useState<FileEntry | null>(null);
+  const [fileContent, setFileContent] = useState<string | null>(null);
+  const [fileTruncated, setFileTruncated] = useState(false);
+  const [loadingFile, setLoadingFile] = useState(false);
+  const [fileError, setFileError] = useState<string | null>(null);
+  // Incremented on every loadFile call; checked after await to discard stale results.
+  const fileLoadIdRef = useRef(0);
+
+  const loadDir = useCallback(
+    async (dirPath: string, signal: AbortSignal) => {
+      if (!api) return;
+      setLoadingDir(true);
+      setDirError(null);
+      try {
+        const result = await api.general.listProjectFiles(
+          { rootPath: projectPath, dirPath },
+          { signal }
+        );
+        if (signal.aborted) return;
+        if (result.success) {
+          setEntries(result.data);
+        } else {
+          setDirError(result.error);
+        }
+      } catch (err) {
+        if (signal.aborted) return;
+        setDirError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!signal.aborted) setLoadingDir(false);
+      }
+    },
+    [api, projectPath]
+  );
+
+  const loadFile = useCallback(
+    async (entry: FileEntry) => {
+      if (!api) return;
+      const loadId = ++fileLoadIdRef.current;
+      setSelectedFile(entry);
+      setFileContent(null);
+      setFileError(null);
+      setLoadingFile(true);
+      try {
+        const result = await api.general.readProjectFile({
+          rootPath: projectPath,
+          filePath: entry.path,
+        });
+        if (fileLoadIdRef.current !== loadId) return;
+        if (result.success) {
+          setFileContent(result.data.content);
+          setFileTruncated(result.data.truncated);
+        } else {
+          setFileError(result.error);
+        }
+      } catch (err) {
+        if (fileLoadIdRef.current !== loadId) return;
+        setFileError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (fileLoadIdRef.current === loadId) setLoadingFile(false);
+      }
+    },
+    [api, projectPath]
+  );
+
+  const navigateDir = useCallback((entry: FileEntry) => {
+    setSelectedFile(null);
+    setFileContent(null);
+    setFileError(null);
+    setCurrentDir(entry.path);
+  }, []);
+
+  const navigateTo = useCallback((dirPath: string) => {
+    setSelectedFile(null);
+    setFileContent(null);
+    setFileError(null);
+    setCurrentDir(dirPath);
+  }, []);
+
+  const navigateUp = useCallback(() => {
+    const parent = pathDirname(currentDir);
+    if (!parent || parent.length < projectPath.length) return;
+    navigateTo(parent);
+  }, [currentDir, projectPath, navigateTo]);
+
+  // Reload directory listing whenever currentDir changes; cancel stale requests.
+  useEffect(() => {
+    const controller = new AbortController();
+    void loadDir(currentDir, controller.signal);
+    return () => controller.abort();
+  }, [currentDir, loadDir]);
+
+  const atRoot = currentDir === projectPath;
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      {/* Top bar: breadcrumb + up button */}
+      <div className="border-border-medium flex shrink-0 items-center gap-1 border-b px-2 py-1.5">
+        {!atRoot && (
+          <button
+            type="button"
+            className="text-muted hover:text-foreground shrink-0 rounded p-0.5 transition-colors"
+            onClick={navigateUp}
+            title="Go up"
+            aria-label="Navigate to parent directory"
+          >
+            <FolderOpen className="h-3.5 w-3.5" />
+          </button>
+        )}
+        <Breadcrumb projectPath={projectPath} currentDir={currentDir} onNavigate={navigateTo} />
+      </div>
+
+      {/* Main area: file tree (left) + viewer (right) */}
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        {/* File tree */}
+        <div className="border-border-medium flex w-44 shrink-0 flex-col overflow-hidden border-r">
+          <div className="flex-1 overflow-y-auto">
+            {loadingDir ? (
+              <p className="text-muted px-3 py-2 text-[11px]">Loading…</p>
+            ) : dirError ? (
+              <p className="text-destructive px-3 py-2 text-[11px]">{dirError}</p>
+            ) : (
+              <FileTree
+                entries={entries}
+                selectedPath={selectedFile?.path ?? null}
+                onSelectDir={navigateDir}
+                onSelectFile={loadFile}
+              />
+            )}
+          </div>
+        </div>
+
+        {/* File viewer */}
+        <div className="min-w-0 flex-1 overflow-hidden">
+          {loadingFile ? (
+            <div className="text-muted flex h-full items-center justify-center text-[11px]">
+              Loading file…
+            </div>
+          ) : fileError ? (
+            <div className="text-destructive flex h-full items-center justify-center px-4 text-center text-[11px]">
+              {fileError}
+            </div>
+          ) : fileContent !== null && selectedFile !== null ? (
+            <FileViewer
+              filename={selectedFile.name}
+              content={fileContent}
+              truncated={fileTruncated}
+            />
+          ) : (
+            <div className="text-muted flex h-full items-center justify-center text-[11px]">
+              Select a file to view
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/browser/features/RightSidebar/RightSidebar.tsx
+++ b/src/browser/features/RightSidebar/RightSidebar.tsx
@@ -673,6 +673,7 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
   const api = apiState.api;
   const desktopExperimentEnabled = useExperimentValue(EXPERIMENT_IDS.PORTABLE_DESKTOP);
   const browserExperimentEnabled = useExperimentValue(EXPERIMENT_IDS.AGENT_BROWSER);
+  const fileBrowserExperimentEnabled = useExperimentValue(EXPERIMENT_IDS.FILE_BROWSER);
   // Child task workspaces can't run goal actions — backend rejects them
   // via `WorkspaceGoalService.assertParentWorkspace`. We use this flag
   // both to hide the Goal tab below and to gate any inline goal UX.
@@ -692,6 +693,7 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
   const [llmDebugLogsEnabled, setLlmDebugLogsEnabled] = React.useState<boolean | null>(null);
   const [desktopAvailable, setDesktopAvailable] = React.useState<boolean | null>(null);
   const [browserAvailable, setBrowserAvailable] = React.useState<boolean | null>(null);
+  const [fileBrowserAvailable, setFileBrowserAvailable] = React.useState<boolean | null>(null);
   const debugLogsLocalOverrideRef = React.useRef(false);
 
   const setGoalWithSingleConflictRetry = async (intent: {
@@ -960,6 +962,31 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
       return prev;
     });
   }, [browserAvailable, initialActiveTab, setLayoutRaw]);
+
+  React.useEffect(() => {
+    setFileBrowserAvailable(fileBrowserExperimentEnabled);
+  }, [fileBrowserExperimentEnabled]);
+
+  React.useEffect(() => {
+    if (fileBrowserAvailable == null) {
+      return;
+    }
+
+    setLayoutRaw((prevRaw) => {
+      const prev = parseRightSidebarLayoutState(prevRaw, initialActiveTab);
+      const hasFiles = collectAllTabs(prev.root).includes("files");
+
+      if (fileBrowserAvailable && !hasFiles) {
+        return addTabToFocusedTabset(prev, "files", false);
+      }
+
+      if (!fileBrowserAvailable && hasFiles) {
+        return removeTabEverywhere(prev, "files");
+      }
+
+      return prev;
+    });
+  }, [fileBrowserAvailable, initialActiveTab, setLayoutRaw]);
 
   React.useEffect(() => {
     setLayoutRaw((prevRaw) => {

--- a/src/browser/features/RightSidebar/Tabs/TabLabels.tsx
+++ b/src/browser/features/RightSidebar/Tabs/TabLabels.tsx
@@ -11,6 +11,7 @@ import React from "react";
 import {
   BugPlay,
   ExternalLink,
+  FolderOpen,
   Monitor,
   Globe,
   Sparkles,
@@ -155,6 +156,14 @@ export const BrowserTabLabel: React.FC = () => (
   <span className="inline-flex items-center gap-1">
     <Globe className="h-3 w-3 shrink-0" />
     Browser
+  </span>
+);
+
+/** Files tab label with folder icon */
+export const FilesTabLabel: React.FC = () => (
+  <span className="inline-flex items-center gap-1">
+    <FolderOpen className="h-3 w-3 shrink-0" />
+    Files
   </span>
 );
 

--- a/src/browser/features/RightSidebar/Tabs/tabConfig.ts
+++ b/src/browser/features/RightSidebar/Tabs/tabConfig.ts
@@ -53,6 +53,13 @@ const TAB_CONFIG_DEF = {
     defaultOrder: 35,
     paletteKeywords: ["goal", "target", "objective"],
   },
+  files: {
+    name: "Files",
+    contentClassName: "overflow-hidden p-0",
+    featureFlag: EXPERIMENT_IDS.FILE_BROWSER,
+    defaultOrder: 45,
+    paletteKeywords: ["files", "explorer", "file browser", "browse", "readme"],
+  },
   desktop: {
     name: "Desktop",
     contentClassName: "overflow-hidden p-0",

--- a/src/browser/features/RightSidebar/Tabs/tabRegistry.tsx
+++ b/src/browser/features/RightSidebar/Tabs/tabRegistry.tsx
@@ -20,6 +20,7 @@ import { StatsContainer } from "@/browser/features/RightSidebar/StatsContainer";
 import { ReviewPanel } from "@/browser/features/RightSidebar/CodeReview/ReviewPanel";
 import { DesktopPanel } from "@/browser/features/desktop/DesktopPanel";
 import { BrowserTab } from "@/browser/features/RightSidebar/BrowserTab";
+import { FilesTab } from "@/browser/features/RightSidebar/FilesTab/FilesTab";
 import { DevToolsTab } from "@/browser/features/RightSidebar/DevToolsTab";
 import { GoalTab, type GoalCreateIntent } from "@/browser/features/RightSidebar/GoalTab";
 import type { GoalSnapshot, GoalStatus } from "@/common/types/goal";
@@ -29,6 +30,7 @@ import {
   BrowserTabLabel,
   DebugTabLabel,
   DesktopTabLabel,
+  FilesTabLabel,
   GoalTabLabel,
   InstructionsTabLabel,
   OutputTabLabel,
@@ -162,6 +164,14 @@ const TAB_RENDERERS = {
     renderPanel: (ctx) => (
       <ErrorBoundary workspaceInfo="Desktop tab">
         <DesktopPanel workspaceId={ctx.workspaceId} />
+      </ErrorBoundary>
+    ),
+  },
+  files: {
+    Label: FilesTabLabel,
+    renderPanel: (ctx) => (
+      <ErrorBoundary workspaceInfo="Files tab">
+        <FilesTab projectPath={ctx.projectPath} />
       </ErrorBoundary>
     ),
   },

--- a/src/common/constants/experiments.ts
+++ b/src/common/constants/experiments.ts
@@ -18,6 +18,7 @@ export const EXPERIMENT_IDS = {
   PORTABLE_DESKTOP: "portable-desktop",
   DYNAMIC_WORKFLOWS: "dynamic-workflows",
   SUBAGENT_FILE_REPORTS: "subagent-file-reports",
+  FILE_BROWSER: "file-browser",
 } as const;
 
 export type ExperimentId = (typeof EXPERIMENT_IDS)[keyof typeof EXPERIMENT_IDS];
@@ -146,6 +147,15 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     name: "Subagent File Reports",
     description:
       "Submit subagent task reports through workspace files (`report.md` and `structured-output.json`)",
+    enabledByDefault: false,
+    userOverridable: true,
+    showInSettings: true,
+  },
+  [EXPERIMENT_IDS.FILE_BROWSER]: {
+    id: EXPERIMENT_IDS.FILE_BROWSER,
+    name: "File Browser",
+    description:
+      "Show a Files tab in the right sidebar to browse and read project files (markdown, code, etc.) inline",
     enabledByDefault: false,
     userOverridable: true,
     showInSettings: true,

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -2548,6 +2548,28 @@ export const general = {
     output: ResultSchema(FileTreeNodeSchema),
   },
   /**
+   * List files and directories immediately inside `dirPath`, which must be
+   * within (or equal to) `rootPath`. Used by the Files tab file browser.
+   */
+  listProjectFiles: {
+    input: z.object({ rootPath: z.string(), dirPath: z.string() }),
+    output: ResultSchema(
+      z.array(z.object({ name: z.string(), path: z.string(), isDirectory: z.boolean() })),
+      z.string()
+    ),
+  },
+  /**
+   * Read the text content of a file within a project root.
+   * Binary files are rejected; files over 512 KB are truncated.
+   */
+  readProjectFile: {
+    input: z.object({ rootPath: z.string(), filePath: z.string() }),
+    output: ResultSchema(
+      z.object({ content: z.string(), truncated: z.boolean() }),
+      z.string()
+    ),
+  },
+  /**
    * Create a directory at the specified path.
    * Creates parent directories recursively if they don't exist (like mkdir -p).
    */

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -2527,6 +2527,18 @@ export const router = (authToken?: string) => {
         .handler(({ context }) => {
           return context.windowService.restartApp();
         }),
+      listProjectFiles: t
+        .input(schemas.general.listProjectFiles.input)
+        .output(schemas.general.listProjectFiles.output)
+        .handler(async ({ context, input }) => {
+          return context.projectService.listProjectFiles(input.rootPath, input.dirPath);
+        }),
+      readProjectFile: t
+        .input(schemas.general.readProjectFile.input)
+        .output(schemas.general.readProjectFile.output)
+        .handler(async ({ context, input }) => {
+          return context.projectService.readProjectFile(input.rootPath, input.filePath);
+        }),
       openInEditor: t
         .input(schemas.general.openInEditor.input)
         .output(schemas.general.openInEditor.output)

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -75,6 +75,83 @@ async function listDirectory(requestedPath: string): Promise<FileTreeNode> {
   };
 }
 
+// Maximum bytes to read when serving a file to the frontend.
+// Guards against accidentally streaming huge files over IPC.
+const MAX_READ_BYTES = 512 * 1024;
+
+/**
+ * Verify `targetPath` is contained within `rootPath` (no directory traversal).
+ * Uses `path.relative` so it works correctly on both POSIX and Windows.
+ */
+function isWithinRoot(rootPath: string, targetPath: string): boolean {
+  const rel = path.relative(rootPath, targetPath);
+  return !rel.startsWith("..") && !path.isAbsolute(rel);
+}
+
+/**
+ * List immediate children (files and directories) of `dirPath` inside `rootPath`.
+ */
+async function listProjectFiles(
+  rootPath: string,
+  dirPath: string
+): Promise<Array<{ name: string; path: string; isDirectory: boolean }>> {
+  const normalizedRoot = path.resolve(rootPath);
+  const normalizedDir = path.resolve(dirPath);
+
+  if (normalizedDir !== normalizedRoot && !isWithinRoot(normalizedRoot, normalizedDir)) {
+    throw new Error("Access denied: path is outside the project root");
+  }
+
+  const entries = await fsPromises.readdir(normalizedDir, { withFileTypes: true });
+  return entries.map((entry) => ({
+    name: entry.name,
+    path: path.join(normalizedDir, entry.name),
+    isDirectory: entry.isDirectory(),
+  }));
+}
+
+/**
+ * Read a text file within `rootPath`. Rejects binary files and truncates files
+ * over MAX_READ_BYTES. Returns the content and whether it was truncated.
+ */
+async function readProjectFile(
+  rootPath: string,
+  filePath: string
+): Promise<{ content: string; truncated: boolean }> {
+  const normalizedRoot = path.resolve(rootPath);
+  const normalizedFile = path.resolve(filePath);
+
+  if (!isWithinRoot(normalizedRoot, normalizedFile)) {
+    throw new Error("Access denied: path is outside the project root");
+  }
+
+  const stat = await fsPromises.stat(normalizedFile);
+  if (stat.isDirectory()) {
+    throw new Error("Cannot read a directory as a file");
+  }
+
+  const bytesToRead = Math.min(stat.size, MAX_READ_BYTES);
+  const truncated = stat.size > MAX_READ_BYTES;
+
+  const handle = await fsPromises.open(normalizedFile, "r");
+  try {
+    const buffer = Buffer.alloc(bytesToRead);
+    await handle.read(buffer, 0, bytesToRead, 0);
+
+    // Detect binary by scanning the first 8 KB for null bytes.
+    const sampleSize = Math.min(bytesToRead, 8192);
+    for (let i = 0; i < sampleSize; i++) {
+      if (buffer[i] === 0) {
+        throw new Error("Binary files cannot be displayed as text");
+      }
+    }
+
+    return { content: buffer.toString("utf-8"), truncated };
+  } finally {
+    await handle.close();
+  }
+}
+
 interface CloneProjectParams {
   repoUrl: string;
   cloneParentDir?: string | null;
@@ -1312,6 +1389,24 @@ export class ProjectService {
         success: false as const,
         error: getErrorMessage(error),
       };
+    }
+  }
+
+  async listProjectFiles(rootPath: string, dirPath: string) {
+    try {
+      const entries = await listProjectFiles(rootPath, dirPath);
+      return { success: true as const, data: entries };
+    } catch (error) {
+      return { success: false as const, error: getErrorMessage(error) };
+    }
+  }
+
+  async readProjectFile(rootPath: string, filePath: string) {
+    try {
+      const result = await readProjectFile(rootPath, filePath);
+      return { success: true as const, data: result };
+    } catch (error) {
+      return { success: false as const, error: getErrorMessage(error) };
     }
   }
 


### PR DESCRIPTION
Closes #3443

## Summary

- Adds a **Files tab** to the right sidebar, feature-gated behind a new `FILE_BROWSER` experiment flag (disabled by default, user-toggleable in Settings → Experiments)
- New `listProjectFiles` and `readProjectFile` IPC endpoints on the backend with path-traversal protection and binary file detection
- File tree shows directories first, then files alphabetically; clicking a directory navigates into it with breadcrumb navigation
- Markdown files rendered via the existing `MarkdownRenderer`; all other files syntax-highlighted via `HighlightedCode` (Shiki) — HTML is shown as highlighted source, never live-rendered (XSS prevention)
- Breadcrumb uses `pathDirname` walk rather than string splitting — correct on both Windows (backslash) and POSIX paths
- Stale request cancellation: `AbortController` cleanup in `useEffect` for directory listing; load-ID counter for file reads

## Design decisions

- Follows the existing Agent Browser / Portable Desktop featureFlag gating pattern exactly
- Reuses `MarkdownRenderer` and `HighlightedCode` rather than adding new renderers
- Separate `listProjectFiles` endpoint (returns files + dirs) rather than reusing the existing `listDirectory` (dirs only) to avoid breaking `DirectoryPickerModal`
- 512 KB read cap with truncation warning; binary files (null-byte detection) rejected with a user-visible error

## Test plan

- [ ] Enable "File Browser" in Settings → Experiments
- [ ] Files tab appears in right sidebar
- [ ] Can browse directories and navigate with breadcrumbs
- [ ] Markdown files render formatted
- [ ] Code files render with syntax highlighting and line numbers
- [ ] HTML files show as highlighted source (not rendered)
- [ ] Binary files show an error message
- [ ] Disabling the experiment removes the tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)