### PR TITLE
🤖 feat: show file edit LoC delta preview

### DIFF
--- a/src/browser/features/Tools/FileEditToolCall.tsx
+++ b/src/browser/features/Tools/FileEditToolCall.tsx
@@ -86,6 +86,56 @@ export function buildLargeDiffPreview(diff: string): LargeDiffPreview | null {
   };
 }
 
+interface DiffLineDeltaPreview {
+  additions: number;
+  deletions: number;
+  additionsLabel: string;
+  deletionsLabel: string;
+  title: string;
+}
+
+function formatLineDeltaTitle(count: number, noun: "added" | "removed"): string {
+  return `${count.toLocaleString()} ${count === 1 ? "line" : "lines"} ${noun}`;
+}
+
+export function buildDiffLineDeltaPreview(diff: string): DiffLineDeltaPreview | null {
+  let additions = 0;
+  let deletions = 0;
+
+  try {
+    // Count parsed hunk payload lines instead of filtering raw +/- prefixes: real edited
+    // content can itself begin with +++ or ---, which looks like a file header in raw text.
+    for (const patch of parsePatch(diff)) {
+      for (const hunk of patch.hunks) {
+        for (const line of hunk.lines) {
+          if (line.startsWith("+")) {
+            additions += 1;
+          } else if (line.startsWith("-")) {
+            deletions += 1;
+          }
+        }
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  if (additions === 0 && deletions === 0) {
+    return null;
+  }
+
+  return {
+    additions,
+    deletions,
+    additionsLabel: `+${additions.toLocaleString()}`,
+    deletionsLabel: `-${deletions.toLocaleString()}`,
+    title: `${formatLineDeltaTitle(additions, "added")}, ${formatLineDeltaTitle(
+      deletions,
+      "removed"
+    )}`,
+  };
+}
+
 interface FileEditToolCallProps {
   toolName: "file_edit_replace_string" | "file_edit_replace_lines" | "file_edit_insert";
   args: FileEditOperationArgs;
@@ -169,6 +219,7 @@ export const FileEditToolCall: React.FC<FileEditToolCallProps> = ({
   const uiOnlyDiff = getToolOutputUiOnly(result)?.file_edit?.diff;
   const diff = result && result.success ? (uiOnlyDiff ?? result.diff) : undefined;
   const filePath = extractToolFilePath(args);
+  const diffLineDelta = diff ? buildDiffLineDeltaPreview(diff) : null;
   const largeDiffPreview = diff ? buildLargeDiffPreview(diff) : null;
   // Single nullable handle for the active preview so JSX truthiness checks narrow the type
   // directly (no separate boolean + repeated `&& largeDiffPreview` guards).
@@ -215,6 +266,17 @@ export const FileEditToolCall: React.FC<FileEditToolCallProps> = ({
             <FileIcon filePath={filePath} className="text-[15px] leading-none" />
             <span className="font-monospace truncate">{filePath}</span>
           </div>
+          {diffLineDelta && (
+            <span
+              className="counter-nums-mono shrink-0 text-[10px] whitespace-nowrap [@container(max-width:420px)]:hidden"
+              title={diffLineDelta.title}
+              aria-label={diffLineDelta.title}
+            >
+              <span className="text-success">{diffLineDelta.additionsLabel}</span>
+              <span className="text-muted">, </span>
+              <span className="text-danger">{diffLineDelta.deletionsLabel}</span>
+            </span>
+          )}
         </div>
         {!(result && result.success && diff) && (
           <StatusIndicator status={status}>{getStatusDisplay(status)}</StatusIndicator>

--- a/src/browser/features/Tools/FileEditToolCall.ui.test.tsx
+++ b/src/browser/features/Tools/FileEditToolCall.ui.test.tsx
@@ -4,11 +4,73 @@ import { GlobalWindow } from "happy-dom";
 import type { ReactElement } from "react";
 
 import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
-import { FileEditToolCall } from "./FileEditToolCall";
+import { ThemeProvider } from "@/browser/contexts/ThemeContext";
+import { MessageListProvider } from "@/browser/features/Messages/MessageListContext";
+import { getAutoExpandPrefsKey } from "@/common/constants/storage";
+import { buildDiffLineDeltaPreview, FileEditToolCall } from "./FileEditToolCall";
+
+const TEST_WORKSPACE_ID = "file-edit-tool-test";
 
 function renderWithProviders(ui: ReactElement) {
-  return render(<TooltipProvider>{ui}</TooltipProvider>);
+  return render(
+    <ThemeProvider forcedTheme="dark">
+      <MessageListProvider value={{ workspaceId: TEST_WORKSPACE_ID, latestMessageId: null }}>
+        <TooltipProvider>{ui}</TooltipProvider>
+      </MessageListProvider>
+    </ThemeProvider>
+  );
 }
+
+describe("buildDiffLineDeltaPreview", () => {
+  test("counts unified diff payload additions and deletions without file headers", () => {
+    const diff = [
+      "--- src/example.ts",
+      "+++ src/example.ts",
+      "@@ -1,3 +1,4 @@",
+      " import { keep } from './keep';",
+      "+import { added } from './added';",
+      "-const oldValue = 1;",
+      "+const newValue = 2;",
+      " const unchanged = true;",
+    ].join("\n");
+
+    expect(buildDiffLineDeltaPreview(diff)).toEqual({
+      additions: 2,
+      deletions: 1,
+      additionsLabel: "+2",
+      deletionsLabel: "-1",
+      title: "2 lines added, 1 line removed",
+    });
+  });
+
+  test("counts payload changes whose content looks like file headers", () => {
+    const diff = [
+      "--- README.md",
+      "+++ README.md",
+      "@@ -1,1 +1,1 @@",
+      "---- old horizontal rule",
+      "++++ new heading",
+    ].join("\n");
+
+    expect(buildDiffLineDeltaPreview(diff)).toMatchObject({
+      additions: 1,
+      deletions: 1,
+      additionsLabel: "+1",
+      deletionsLabel: "-1",
+    });
+  });
+
+  test("returns null when a diff has no changed payload lines", () => {
+    const diff = [
+      "--- src/example.ts",
+      "+++ src/example.ts",
+      "@@ -1,1 +1,1 @@",
+      " const unchanged = true;",
+    ].join("\n");
+
+    expect(buildDiffLineDeltaPreview(diff)).toBeNull();
+  });
+});
 
 describe("FileEditToolCall expansion", () => {
   beforeEach(() => {
@@ -20,6 +82,34 @@ describe("FileEditToolCall expansion", () => {
     cleanup();
     globalThis.window = undefined as unknown as Window & typeof globalThis;
     globalThis.document = undefined as unknown as Document;
+  });
+
+  test("keeps the line delta visible in a collapsed successful edit", () => {
+    globalThis.window.localStorage.setItem(
+      getAutoExpandPrefsKey(TEST_WORKSPACE_ID),
+      JSON.stringify({ tools: false })
+    );
+    const diff = [
+      "--- src/example.ts",
+      "+++ src/example.ts",
+      "@@ -1,2 +1,3 @@",
+      "+const first = true;",
+      "+const second = true;",
+      "-const old = true;",
+      " const unchanged = true;",
+    ].join("\n");
+
+    const view = renderWithProviders(
+      <FileEditToolCall
+        toolName="file_edit_replace_string"
+        args={{ path: "src/example.ts", old_string: "old", new_string: "new" }}
+        result={{ success: true, diff, edits_applied: 1 }}
+        status="completed"
+      />
+    );
+
+    expect(view.queryByText("const unchanged = true;")).toBeNull();
+    expect(view.getByTitle("2 lines added, 1 line removed").textContent).toBe("+2, -1");
   });
 
   test("does not mutate a present edit's expand state when the result arrives later", () => {
@@ -39,14 +129,18 @@ describe("FileEditToolCall expansion", () => {
     expect(view.queryByText("Waiting for result")).not.toBeNull();
 
     view.rerender(
-      <TooltipProvider>
-        <FileEditToolCall
-          toolName="file_edit_replace_string"
-          args={{ path: "src/example.ts", old_string: "old", new_string: "new" }}
-          result={{ success: false, error: "edit failed" }}
-          status="failed"
-        />
-      </TooltipProvider>
+      <ThemeProvider forcedTheme="dark">
+        <MessageListProvider value={{ workspaceId: TEST_WORKSPACE_ID, latestMessageId: null }}>
+          <TooltipProvider>
+            <FileEditToolCall
+              toolName="file_edit_replace_string"
+              args={{ path: "src/example.ts", old_string: "old", new_string: "new" }}
+              result={{ success: false, error: "edit failed" }}
+              status="failed"
+            />
+          </TooltipProvider>
+        </MessageListProvider>
+      </ThemeProvider>
     );
 
     // Still expanded — the failure is visible without re-expanding.


### PR DESCRIPTION
Summary
- Shows a compact line delta preview (for example `+433, -23`) in successful file edit tool headers so it remains visible when the tool call is collapsed.
- Counts unified diff payload additions/deletions while ignoring `---`/`+++` file headers.
- Adds UI coverage for the collapsed header behavior and delta-count helper coverage.

Background
- Collapsed file edit tool calls previously showed the target path but not the size of the applied change, making it harder to scan completed write/edit operations.

Validation
- `bun test src/browser/features/Tools/FileEditToolCall.ui.test.tsx`
- `make typecheck`
- `make static-check`

Risks
- Low; the change only derives a display-only summary from the existing diff already rendered by the tool call UI.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `high` • Cost: `n/a`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=high costs=n/a -->
