### PR TITLE
🤖 feat: expand workflow task structured output inline

### DIFF
--- a/.mux/workflows/.scratch/.gitignore
+++ b/.mux/workflows/.scratch/.gitignore
@@ -1,3 +1,5 @@
 # mux: hide scratch workflow drafts when repo rules unignore workflows
 *
 !.gitignore
+# mux: hide scratch workflow drafts when repo rules unignore workflows
+*

--- a/.mux/workflows/.scratch/.gitignore
+++ b/.mux/workflows/.scratch/.gitignore
@@ -1,5 +1,3 @@
 # mux: hide scratch workflow drafts when repo rules unignore workflows
 *
 !.gitignore
-# mux: hide scratch workflow drafts when repo rules unignore workflows
-*

--- a/src/browser/features/Tools/WorkflowDefinitionToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowDefinitionToolCall.tsx
@@ -87,13 +87,21 @@ export function WorkflowSection(props: {
   );
 }
 
-export function WorkflowJsonBlock(props: { value: unknown; className?: string }) {
+export function WorkflowJsonBlock(props: {
+  value: unknown;
+  className?: string;
+  ariaLabel?: string;
+}) {
+  const isNamedScrollRegion = props.ariaLabel != null;
   return (
     <div
       className={cn(
         "border-border bg-code-bg max-h-[240px] overflow-auto rounded border p-2",
         props.className
       )}
+      role={isNamedScrollRegion ? "region" : undefined}
+      tabIndex={isNamedScrollRegion ? 0 : undefined}
+      aria-label={props.ariaLabel}
     >
       <JsonHighlight value={props.value} />
     </div>

--- a/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
@@ -213,7 +213,14 @@ const taskActionsRun: WorkflowRunRecord = {
       taskId: "7b1a07d84d",
       startedAt: "2026-05-29T00:00:01.000Z",
       completedAt: "2026-05-29T00:00:02.000Z",
-      result: { reportMarkdown: "## Summary report\n\nCompleted task report body." },
+      result: {
+        reportMarkdown: "## Summary report\n\nCompleted task report body.",
+        structuredOutput: {
+          summary: "Source 15 is ready for downstream extraction.",
+          confidence: "high",
+          citations: 3,
+        },
+      },
     },
     {
       stepId: "extract-claims",

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalWindow } from "happy-dom";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import {
   cloneElement,
   createContext,
@@ -292,7 +293,7 @@ describe("WorkflowRunToolCall", () => {
     expect(renderedText).toContain("confidence");
   });
 
-  test("coalesces task attempts, navigates active rows, expands completed outputs, and opens reports", async () => {
+  test("coalesces task attempts, navigates active rows, expands completed outputs, opens workspaces, and opens reports", async () => {
     const navigatedTo: string[] = [];
     useWorkspaceStoreRaw().setNavigateToWorkspace((workspaceId) => {
       navigatedTo.push(workspaceId);
@@ -393,6 +394,8 @@ describe("WorkflowRunToolCall", () => {
       </ThemeProvider>
     );
 
+    const user = userEvent.setup({ document: view.container.ownerDocument });
+
     expect(view.getAllByText("implement / task_live / completed")).toHaveLength(1);
     expect(view.queryByText("implement / task_live / started")).toBeNull();
     expect(view.getByText("implement / task_retry / started")).toBeTruthy();
@@ -426,14 +429,32 @@ describe("WorkflowRunToolCall", () => {
     expect(view.container.textContent).toContain("testsPassed");
     expect(view.container.textContent).not.toContain("Completed task body.");
 
-    expect(view.queryByRole("button", { name: "Open task workspace for task_live" })).toBeNull();
+    fireEvent.click(completedTaskControl);
+    expect(completedTaskControl.getAttribute("aria-expanded")).toBe("false");
+    expect(view.container.textContent).not.toContain("filesChanged");
+
+    fireEvent.click(completedTaskControl);
+    expect(completedTaskControl.getAttribute("aria-expanded")).toBe("true");
+    expect(view.container.textContent).toContain("filesChanged");
+
+    const workspaceButton = view.getByRole("button", {
+      name: "Open task workspace for task_live",
+    });
+    expect(workspaceButton.textContent).toBe("Workspace");
+    fireEvent.click(workspaceButton);
+    expect(navigatedTo).toEqual(["task_retry", "task_retry", "task_live"]);
+
+    workspaceButton.focus();
+    expect(view.container.ownerDocument.activeElement).toBe(workspaceButton);
+    await user.keyboard("{Enter}");
+    expect(navigatedTo).toEqual(["task_retry", "task_retry", "task_live", "task_live"]);
 
     const reportToggle = view.getByLabelText("Open report for task_live");
-    expect(reportToggle.textContent).toBe("Open");
+    expect(reportToggle.textContent).toBe("Report");
     expect(reportToggle.closest('[role="button"]')).toBeNull();
     fireEvent.click(reportToggle);
 
-    expect(navigatedTo).toEqual(["task_retry", "task_retry"]);
+    expect(navigatedTo).toEqual(["task_retry", "task_retry", "task_live", "task_live"]);
     await waitFor(() => {
       const reportDialog = document.querySelector('[role="dialog"]');
       expect(reportDialog?.textContent).toContain("Completed task body.");

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -438,7 +438,7 @@ describe("WorkflowRunToolCall", () => {
     expect(navigatedTo).toEqual(["task_retry", "task_retry", "task_live"]);
 
     const reportToggle = view.getByLabelText("Open report for task_live");
-    expect(reportToggle.textContent).toBe("Open");
+    expect(reportToggle.textContent).toBe("Report");
     expect(reportToggle.closest('[role="button"]')).toBeNull();
     fireEvent.click(reportToggle);
 

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -292,7 +292,7 @@ describe("WorkflowRunToolCall", () => {
     expect(renderedText).toContain("confidence");
   });
 
-  test("coalesces task attempts, navigates active rows, expands completed outputs, and opens reports", async () => {
+  test("coalesces task attempts, navigates active rows, expands completed outputs, opens workspaces, and opens reports", async () => {
     const navigatedTo: string[] = [];
     useWorkspaceStoreRaw().setNavigateToWorkspace((workspaceId) => {
       navigatedTo.push(workspaceId);
@@ -426,14 +426,17 @@ describe("WorkflowRunToolCall", () => {
     expect(view.container.textContent).toContain("testsPassed");
     expect(view.container.textContent).not.toContain("Completed task body.");
 
-    expect(view.queryByRole("button", { name: "Open task workspace for task_live" })).toBeNull();
+    const workspaceToggle = view.getByRole("button", { name: "Open task workspace for task_live" });
+    expect(workspaceToggle.textContent).toBe("Workspace");
+    fireEvent.click(workspaceToggle);
+    expect(navigatedTo).toEqual(["task_retry", "task_retry", "task_live"]);
 
     const reportToggle = view.getByLabelText("Open report for task_live");
     expect(reportToggle.textContent).toBe("Open");
     expect(reportToggle.closest('[role="button"]')).toBeNull();
     fireEvent.click(reportToggle);
 
-    expect(navigatedTo).toEqual(["task_retry", "task_retry"]);
+    expect(navigatedTo).toEqual(["task_retry", "task_retry", "task_live"]);
     await waitFor(() => {
       const reportDialog = document.querySelector('[role="dialog"]');
       expect(reportDialog?.textContent).toContain("Completed task body.");

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -2,7 +2,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalWindow } from "happy-dom";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import {
   cloneElement,
   createContext,
@@ -293,7 +292,7 @@ describe("WorkflowRunToolCall", () => {
     expect(renderedText).toContain("confidence");
   });
 
-  test("coalesces task attempts, navigates active rows, expands completed outputs, opens workspaces, and opens reports", async () => {
+  test("coalesces task attempts, navigates active rows, expands completed outputs, and opens reports", async () => {
     const navigatedTo: string[] = [];
     useWorkspaceStoreRaw().setNavigateToWorkspace((workspaceId) => {
       navigatedTo.push(workspaceId);
@@ -394,8 +393,6 @@ describe("WorkflowRunToolCall", () => {
       </ThemeProvider>
     );
 
-    const user = userEvent.setup({ document: view.container.ownerDocument });
-
     expect(view.getAllByText("implement / task_live / completed")).toHaveLength(1);
     expect(view.queryByText("implement / task_live / started")).toBeNull();
     expect(view.getByText("implement / task_retry / started")).toBeTruthy();
@@ -429,32 +426,14 @@ describe("WorkflowRunToolCall", () => {
     expect(view.container.textContent).toContain("testsPassed");
     expect(view.container.textContent).not.toContain("Completed task body.");
 
-    fireEvent.click(completedTaskControl);
-    expect(completedTaskControl.getAttribute("aria-expanded")).toBe("false");
-    expect(view.container.textContent).not.toContain("filesChanged");
-
-    fireEvent.click(completedTaskControl);
-    expect(completedTaskControl.getAttribute("aria-expanded")).toBe("true");
-    expect(view.container.textContent).toContain("filesChanged");
-
-    const workspaceButton = view.getByRole("button", {
-      name: "Open task workspace for task_live",
-    });
-    expect(workspaceButton.textContent).toBe("Workspace");
-    fireEvent.click(workspaceButton);
-    expect(navigatedTo).toEqual(["task_retry", "task_retry", "task_live"]);
-
-    workspaceButton.focus();
-    expect(view.container.ownerDocument.activeElement).toBe(workspaceButton);
-    await user.keyboard("{Enter}");
-    expect(navigatedTo).toEqual(["task_retry", "task_retry", "task_live", "task_live"]);
+    expect(view.queryByRole("button", { name: "Open task workspace for task_live" })).toBeNull();
 
     const reportToggle = view.getByLabelText("Open report for task_live");
-    expect(reportToggle.textContent).toBe("Report");
+    expect(reportToggle.textContent).toBe("Open");
     expect(reportToggle.closest('[role="button"]')).toBeNull();
     fireEvent.click(reportToggle);
 
-    expect(navigatedTo).toEqual(["task_retry", "task_retry", "task_live", "task_live"]);
+    expect(navigatedTo).toEqual(["task_retry", "task_retry"]);
     await waitFor(() => {
       const reportDialog = document.querySelector('[role="dialog"]');
       expect(reportDialog?.textContent).toContain("Completed task body.");

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -424,6 +424,12 @@ describe("WorkflowRunToolCall", () => {
     expect(view.container.textContent).toContain("filesChanged");
     expect(view.container.textContent).toContain("src/feature.ts");
     expect(view.container.textContent).toContain("testsPassed");
+    const structuredOutputRegion = view.getByRole("region", {
+      name: "Structured output for workflow task task_live",
+    });
+    expect(structuredOutputRegion.getAttribute("tabindex")).toBe("0");
+    structuredOutputRegion.focus();
+    expect(document.activeElement).toBe(structuredOutputRegion);
     expect(view.container.textContent).not.toContain("Completed task body.");
 
     const workspaceToggle = view.getByRole("button", { name: "Open task workspace for task_live" });

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -292,7 +292,7 @@ describe("WorkflowRunToolCall", () => {
     expect(renderedText).toContain("confidence");
   });
 
-  test("coalesces task attempts, navigates rows, and opens completed reports separately", async () => {
+  test("coalesces task attempts, navigates active rows, expands completed outputs, and opens reports", async () => {
     const navigatedTo: string[] = [];
     useWorkspaceStoreRaw().setNavigateToWorkspace((workspaceId) => {
       navigatedTo.push(workspaceId);
@@ -370,7 +370,13 @@ describe("WorkflowRunToolCall", () => {
                     taskId: "task_live",
                     startedAt: "2026-05-29T00:00:00.000Z",
                     completedAt: "2026-05-29T00:00:01.000Z",
-                    result: { reportMarkdown: "## Implement report\n\nCompleted task body." },
+                    result: {
+                      reportMarkdown: "## Implement report\n\nCompleted task body.",
+                      structuredOutput: {
+                        filesChanged: ["src/feature.ts"],
+                        testsPassed: true,
+                      },
+                    },
                   },
                   {
                     stepId: "apply-implement",
@@ -391,12 +397,11 @@ describe("WorkflowRunToolCall", () => {
     expect(view.queryByText("implement / task_live / started")).toBeNull();
     expect(view.getByText("implement / task_retry / started")).toBeTruthy();
     expect(view.getByText("apply-implement / task_live / started")).toBeTruthy();
-    const openAffordance = view.getByText("Open");
-    expect(openAffordance.getAttribute("aria-hidden")).toBe("true");
     const activeTaskControl = view.getByRole("button", {
       name: "Open workflow task task_retry",
     });
-    expect(activeTaskControl.contains(openAffordance)).toBe(true);
+    const openAffordance = activeTaskControl.querySelector('[aria-hidden="true"]');
+    expect(openAffordance?.textContent).toBe("Open");
     expect(view.queryByRole("button", { name: "Open" })).toBeNull();
 
     fireEvent.click(activeTaskControl);
@@ -404,22 +409,31 @@ describe("WorkflowRunToolCall", () => {
     fireEvent.keyDown(activeTaskControl, { key: "Enter" });
     expect(navigatedTo).toEqual(["task_retry", "task_retry"]);
 
-    const completedTaskControl = view
-      .getByText("implement / task_live / completed")
-      .closest('[role="button"]');
-    if (completedTaskControl == null) {
-      throw new Error("Expected completed task row to be keyboard focusable");
-    }
-
-    fireEvent.keyDown(completedTaskControl, { key: "Enter" });
-    expect(navigatedTo).toEqual(["task_retry", "task_retry", "task_live"]);
+    const completedTaskControl = view.getByRole("button", {
+      name: "Expand structured output for workflow task task_live",
+    });
+    expect(completedTaskControl.textContent).toContain("implement / task_live / completed");
+    expect(completedTaskControl.getAttribute("aria-expanded")).toBe("false");
+    expect(view.container.textContent).not.toContain("filesChanged");
     expect(view.container.textContent).not.toContain("Completed task body.");
 
+    fireEvent.keyDown(completedTaskControl, { key: "Enter" });
+
+    expect(navigatedTo).toEqual(["task_retry", "task_retry"]);
+    expect(completedTaskControl.getAttribute("aria-expanded")).toBe("true");
+    expect(view.container.textContent).toContain("filesChanged");
+    expect(view.container.textContent).toContain("src/feature.ts");
+    expect(view.container.textContent).toContain("testsPassed");
+    expect(view.container.textContent).not.toContain("Completed task body.");
+
+    expect(view.queryByRole("button", { name: "Open task workspace for task_live" })).toBeNull();
+
     const reportToggle = view.getByLabelText("Open report for task_live");
+    expect(reportToggle.textContent).toBe("Open");
     expect(reportToggle.closest('[role="button"]')).toBeNull();
     fireEvent.click(reportToggle);
 
-    expect(navigatedTo).toEqual(["task_retry", "task_retry", "task_live"]);
+    expect(navigatedTo).toEqual(["task_retry", "task_retry"]);
     await waitFor(() => {
       const reportDialog = document.querySelector('[role="dialog"]');
       expect(reportDialog?.textContent).toContain("Completed task body.");
@@ -1100,6 +1114,127 @@ describe("WorkflowRunToolCall", () => {
 
     await waitFor(() => expect(view.getByText("completed workflow result")).toBeTruthy());
     expect(document.querySelector('[role="dialog"]')?.textContent).toContain("Report stays open.");
+  });
+
+  test("keeps expanded task structured output visible after workflow auto-completes", async () => {
+    const runningRun = {
+      id: "wfr_structured_auto",
+      workspaceId: "workspace-1",
+      definition: {
+        name: "deep-research",
+        description: "Deep research",
+        scope: "built-in" as const,
+        executable: true,
+      },
+      definitionSource: "export default function workflow() { return null; }",
+      definitionHash: "sha256:test",
+      args: { topic: "workflow cards" },
+      status: "running" as const,
+      createdAt: "2026-05-29T00:00:00.000Z",
+      updatedAt: "2026-05-29T00:00:01.000Z",
+      events: [
+        {
+          sequence: 1,
+          type: "status" as const,
+          at: "2026-05-29T00:00:00.000Z",
+          status: "running" as const,
+        },
+        {
+          sequence: 2,
+          type: "task" as const,
+          at: "2026-05-29T00:00:01.000Z",
+          stepId: "structured-step",
+          taskId: "task_structured",
+          status: "completed" as const,
+        },
+      ],
+      steps: [
+        {
+          stepId: "structured-step",
+          inputHash: "sha256:structured",
+          status: "completed" as const,
+          taskId: "task_structured",
+          startedAt: "2026-05-29T00:00:00.000Z",
+          completedAt: "2026-05-29T00:00:01.000Z",
+          result: {
+            reportMarkdown: "## Structured task report\n\nReport remains available.",
+            structuredOutput: {
+              reviewSummary: "Keep this visible after completion.",
+            },
+          },
+        },
+      ],
+    };
+    const completedRun = {
+      ...runningRun,
+      status: "completed" as const,
+      updatedAt: "2026-05-29T00:00:02.000Z",
+      events: [
+        ...runningRun.events,
+        {
+          sequence: 3,
+          type: "result" as const,
+          at: "2026-05-29T00:00:02.000Z",
+          result: { reportMarkdown: "completed workflow result" },
+        },
+        {
+          sequence: 4,
+          type: "status" as const,
+          at: "2026-05-29T00:00:02.000Z",
+          status: "completed" as const,
+        },
+      ],
+    };
+    const pendingRefresh: { resolve?: (run: typeof completedRun) => void } = {};
+    const api = {
+      workflows: {
+        getRun: async () =>
+          await new Promise<typeof completedRun>((resolve) => {
+            pendingRefresh.resolve = resolve;
+          }),
+      },
+    };
+
+    const view = render(
+      <APIHarness client={api}>
+        <ThemeProvider forcedTheme="dark">
+          <TooltipProvider>
+            <WorkflowRunToolCall
+              args={{
+                name: "deep-research",
+                args: { topic: "workflow cards" },
+                run_in_background: true,
+              }}
+              status="completed"
+              result={{
+                status: "running",
+                runId: "wfr_structured_auto",
+                result: null,
+                run: runningRun,
+              }}
+            />
+          </TooltipProvider>
+        </ThemeProvider>
+      </APIHarness>
+    );
+
+    await waitFor(() => expect(pendingRefresh.resolve).toBeDefined());
+    fireEvent.click(
+      view.getByRole("button", {
+        name: "Expand structured output for workflow task task_structured",
+      })
+    );
+    expect(view.container.textContent).toContain("reviewSummary");
+
+    const completeRefresh = pendingRefresh.resolve;
+    if (completeRefresh == null) {
+      throw new Error("Expected workflow refresh to be pending");
+    }
+    completeRefresh(completedRun);
+
+    await waitFor(() => expect(view.getByText("completed workflow result")).toBeTruthy());
+    expect(view.container.textContent).toContain("reviewSummary");
+    expect(view.container.textContent).toContain("Keep this visible after completion.");
   });
 
   test("shows interrupt action for running workflows and updates with the returned run", async () => {

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -368,6 +368,14 @@ function getTaskReportMarkdown(
     : null;
 }
 
+function getTaskStructuredOutput(
+  event: WorkflowRunEvent,
+  steps: readonly WorkflowStepRecord[]
+): unknown {
+  const step = findTaskStepForEvent(event, steps);
+  return step?.result?.structuredOutput;
+}
+
 function WorkflowEventTooltip(props: {
   event: WorkflowRunEvent;
   displayIndex: number;
@@ -487,14 +495,32 @@ function WorkflowTaskRow(props: {
   steps: readonly WorkflowStepRecord[];
   onNavigate: (taskId: string) => void;
   onOpenReport: () => void;
+  onInspectStructuredOutput: () => void;
 }) {
   const [reportDialogOpen, setReportDialogOpen] = useState(false);
+  const [structuredOutputExpanded, setStructuredOutputExpanded] = useState(false);
   const event = props.row.latestEvent;
   const label = getWorkflowEventLabel(event);
   const taskReportMarkdown = getTaskReportMarkdown(event, props.steps);
+  const taskStructuredOutput = getTaskStructuredOutput(event, props.steps);
+  // Completed task rows inspect structured output inline; the dedicated Open button remains report-only.
+  const canExpandStructuredOutput =
+    event.status === "completed" && taskStructuredOutput !== undefined;
   const showOpenAffordance =
-    taskReportMarkdown == null && shouldShowWorkflowTaskOpenAffordance(event);
-  const activateTaskRow = () => props.onNavigate(event.taskId);
+    taskReportMarkdown == null &&
+    !canExpandStructuredOutput &&
+    shouldShowWorkflowTaskOpenAffordance(event);
+  const toggleStructuredOutput = () => {
+    props.onInspectStructuredOutput();
+    setStructuredOutputExpanded((isExpanded) => !isExpanded);
+  };
+  const activateTaskRow = () => {
+    if (canExpandStructuredOutput) {
+      toggleStructuredOutput();
+      return;
+    }
+    props.onNavigate(event.taskId);
+  };
   const handleReportDialogOpenChange = (isOpen: boolean) => {
     if (isOpen) {
       props.onOpenReport();
@@ -508,6 +534,9 @@ function WorkflowTaskRow(props: {
     keyboardEvent.preventDefault();
     activateTaskRow();
   };
+  const taskRowAriaLabel = canExpandStructuredOutput
+    ? `${structuredOutputExpanded ? "Collapse" : "Expand"} structured output for workflow task ${event.taskId}`
+    : `Open workflow task ${event.taskId}`;
 
   const taskRow = (
     <div
@@ -518,7 +547,8 @@ function WorkflowTaskRow(props: {
       }`}
       role="button"
       tabIndex={0}
-      aria-label={`Open workflow task ${event.taskId}`}
+      aria-expanded={canExpandStructuredOutput ? structuredOutputExpanded : undefined}
+      aria-label={taskRowAriaLabel}
       onClick={activateTaskRow}
       onKeyDown={onKeyDown}
     >
@@ -558,15 +588,15 @@ function WorkflowTaskRow(props: {
     <li className="hover:bg-background/50">
       {taskReportMarkdown != null ? (
         <Dialog open={reportDialogOpen} onOpenChange={handleReportDialogOpenChange}>
-          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center">
+          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1 pr-2">
             {taskRow}
             <DialogTrigger asChild>
               <button
                 type="button"
-                className={`${WORKFLOW_ACTION_BUTTON_CLASS} mr-2 inline-flex items-center px-1.5 py-0.5 text-[10px] whitespace-nowrap`}
+                className={`${WORKFLOW_ACTION_BUTTON_CLASS} inline-flex items-center px-1.5 py-0.5 text-[10px] whitespace-nowrap`}
                 aria-label={`Open report for ${event.taskId}`}
               >
-                Report
+                Open
               </button>
             </DialogTrigger>
           </div>
@@ -579,6 +609,12 @@ function WorkflowTaskRow(props: {
       ) : (
         taskRow
       )}
+      {canExpandStructuredOutput && structuredOutputExpanded ? (
+        <div className="mx-2 mb-2 space-y-1">
+          <div className="text-muted text-[10px] tracking-wide uppercase">Structured output</div>
+          <WorkflowJsonBlock value={taskStructuredOutput} className="max-h-[180px]" />
+        </div>
+      ) : null}
     </li>
   );
 }
@@ -1214,6 +1250,9 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
                         steps={run?.steps ?? []}
                         onNavigate={(taskId) => workspaceStore.navigateToWorkspace(taskId)}
                         onOpenReport={() => {
+                          userToggledExpansionRef.current = true;
+                        }}
+                        onInspectStructuredOutput={() => {
                           userToggledExpansionRef.current = true;
                         }}
                       />

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -615,7 +615,7 @@ function WorkflowTaskRow(props: {
                 className={`${WORKFLOW_ACTION_BUTTON_CLASS} inline-flex items-center px-1.5 py-0.5 text-[10px] whitespace-nowrap`}
                 aria-label={`Open report for ${event.taskId}`}
               >
-                Open
+                Report
               </button>
             </DialogTrigger>
           </div>

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -503,10 +503,9 @@ function WorkflowTaskRow(props: {
   const label = getWorkflowEventLabel(event);
   const taskReportMarkdown = getTaskReportMarkdown(event, props.steps);
   const taskStructuredOutput = getTaskStructuredOutput(event, props.steps);
-  // Completed task rows inspect structured output inline; keep workspace navigation as a separate action.
+  // Completed task rows inspect structured output inline; the dedicated Open button remains report-only.
   const canExpandStructuredOutput =
     event.status === "completed" && taskStructuredOutput !== undefined;
-  const showWorkspaceAction = canExpandStructuredOutput;
   const showOpenAffordance =
     taskReportMarkdown == null &&
     !canExpandStructuredOutput &&
@@ -585,37 +584,19 @@ function WorkflowTaskRow(props: {
     </div>
   );
 
-  const workspaceAction = showWorkspaceAction ? (
-    <button
-      type="button"
-      className={`${WORKFLOW_ACTION_BUTTON_CLASS} inline-flex items-center px-1.5 py-0.5 text-[10px] whitespace-nowrap`}
-      aria-label={`Open task workspace for ${event.taskId}`}
-      onClick={() => props.onNavigate(event.taskId)}
-    >
-      Workspace
-    </button>
-  ) : null;
-
   return (
     <li className="hover:bg-background/50">
       {taskReportMarkdown != null ? (
         <Dialog open={reportDialogOpen} onOpenChange={handleReportDialogOpenChange}>
-          <div
-            className={`grid ${
-              showWorkspaceAction
-                ? "grid-cols-[minmax(0,1fr)_auto_auto]"
-                : "grid-cols-[minmax(0,1fr)_auto]"
-            } items-center gap-1 pr-2`}
-          >
+          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1 pr-2">
             {taskRow}
-            {workspaceAction}
             <DialogTrigger asChild>
               <button
                 type="button"
                 className={`${WORKFLOW_ACTION_BUTTON_CLASS} inline-flex items-center px-1.5 py-0.5 text-[10px] whitespace-nowrap`}
                 aria-label={`Open report for ${event.taskId}`}
               >
-                Report
+                Open
               </button>
             </DialogTrigger>
           </div>
@@ -625,11 +606,6 @@ function WorkflowTaskRow(props: {
             reportMarkdown={taskReportMarkdown}
           />
         </Dialog>
-      ) : showWorkspaceAction ? (
-        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1 pr-2">
-          {taskRow}
-          {workspaceAction}
-        </div>
       ) : (
         taskRow
       )}

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -503,9 +503,10 @@ function WorkflowTaskRow(props: {
   const label = getWorkflowEventLabel(event);
   const taskReportMarkdown = getTaskReportMarkdown(event, props.steps);
   const taskStructuredOutput = getTaskStructuredOutput(event, props.steps);
-  // Completed task rows inspect structured output inline; the dedicated Open button remains report-only.
+  // Completed task rows inspect structured output inline; keep workspace navigation as a separate action.
   const canExpandStructuredOutput =
     event.status === "completed" && taskStructuredOutput !== undefined;
+  const showWorkspaceAction = canExpandStructuredOutput;
   const showOpenAffordance =
     taskReportMarkdown == null &&
     !canExpandStructuredOutput &&
@@ -584,19 +585,37 @@ function WorkflowTaskRow(props: {
     </div>
   );
 
+  const workspaceAction = showWorkspaceAction ? (
+    <button
+      type="button"
+      className={`${WORKFLOW_ACTION_BUTTON_CLASS} inline-flex items-center px-1.5 py-0.5 text-[10px] whitespace-nowrap`}
+      aria-label={`Open task workspace for ${event.taskId}`}
+      onClick={() => props.onNavigate(event.taskId)}
+    >
+      Workspace
+    </button>
+  ) : null;
+
   return (
     <li className="hover:bg-background/50">
       {taskReportMarkdown != null ? (
         <Dialog open={reportDialogOpen} onOpenChange={handleReportDialogOpenChange}>
-          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1 pr-2">
+          <div
+            className={`grid ${
+              showWorkspaceAction
+                ? "grid-cols-[minmax(0,1fr)_auto_auto]"
+                : "grid-cols-[minmax(0,1fr)_auto]"
+            } items-center gap-1 pr-2`}
+          >
             {taskRow}
+            {workspaceAction}
             <DialogTrigger asChild>
               <button
                 type="button"
                 className={`${WORKFLOW_ACTION_BUTTON_CLASS} inline-flex items-center px-1.5 py-0.5 text-[10px] whitespace-nowrap`}
                 aria-label={`Open report for ${event.taskId}`}
               >
-                Open
+                Report
               </button>
             </DialogTrigger>
           </div>
@@ -606,6 +625,11 @@ function WorkflowTaskRow(props: {
             reportMarkdown={taskReportMarkdown}
           />
         </Dialog>
+      ) : showWorkspaceAction ? (
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1 pr-2">
+          {taskRow}
+          {workspaceAction}
+        </div>
       ) : (
         taskRow
       )}

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -503,9 +503,10 @@ function WorkflowTaskRow(props: {
   const label = getWorkflowEventLabel(event);
   const taskReportMarkdown = getTaskReportMarkdown(event, props.steps);
   const taskStructuredOutput = getTaskStructuredOutput(event, props.steps);
-  // Completed task rows inspect structured output inline; the dedicated Open button remains report-only.
+  // Completed task rows inspect structured output inline; keep workspace navigation as a separate action.
   const canExpandStructuredOutput =
     event.status === "completed" && taskStructuredOutput !== undefined;
+  const showWorkspaceAction = canExpandStructuredOutput;
   const showOpenAffordance =
     taskReportMarkdown == null &&
     !canExpandStructuredOutput &&
@@ -584,12 +585,30 @@ function WorkflowTaskRow(props: {
     </div>
   );
 
+  const workspaceAction = showWorkspaceAction ? (
+    <button
+      type="button"
+      className={`${WORKFLOW_ACTION_BUTTON_CLASS} inline-flex items-center px-1.5 py-0.5 text-[10px] whitespace-nowrap`}
+      aria-label={`Open task workspace for ${event.taskId}`}
+      onClick={() => props.onNavigate(event.taskId)}
+    >
+      Workspace
+    </button>
+  ) : null;
+
   return (
     <li className="hover:bg-background/50">
       {taskReportMarkdown != null ? (
         <Dialog open={reportDialogOpen} onOpenChange={handleReportDialogOpenChange}>
-          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1 pr-2">
+          <div
+            className={`grid ${
+              showWorkspaceAction
+                ? "grid-cols-[minmax(0,1fr)_auto_auto]"
+                : "grid-cols-[minmax(0,1fr)_auto]"
+            } items-center gap-1 pr-2`}
+          >
             {taskRow}
+            {workspaceAction}
             <DialogTrigger asChild>
               <button
                 type="button"
@@ -606,6 +625,11 @@ function WorkflowTaskRow(props: {
             reportMarkdown={taskReportMarkdown}
           />
         </Dialog>
+      ) : showWorkspaceAction ? (
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1 pr-2">
+          {taskRow}
+          {workspaceAction}
+        </div>
       ) : (
         taskRow
       )}

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -636,7 +636,12 @@ function WorkflowTaskRow(props: {
       {canExpandStructuredOutput && structuredOutputExpanded ? (
         <div className="mx-2 mb-2 space-y-1">
           <div className="text-muted text-[10px] tracking-wide uppercase">Structured output</div>
-          <WorkflowJsonBlock value={taskStructuredOutput} className="max-h-[180px]" />
+          {/* The inline JSON is height-capped, so name/focus its own scroll region for keyboard users. */}
+          <WorkflowJsonBlock
+            value={taskStructuredOutput}
+            className="max-h-[180px]"
+            ariaLabel={`Structured output for workflow task ${event.taskId}`}
+          />
         </div>
       ) : null}
     </li>


### PR DESCRIPTION
## Summary

Adds inline structured-output inspection for completed workflow task rows while preserving separate task workspace navigation and report viewing affordances.

## Background

Completed workflow tasks can now return structured output that is useful to inspect without opening the full task report. This change lets users expand that JSON inline from the task row while keeping the existing workflow card auto-collapse behavior from interrupting active inspection.

## Implementation

- Completed task rows with `structuredOutput` can expand/collapse a pretty JSON block inline.
- The inline structured-output panel is keyboard focusable and named for accessibility.
- Completed structured-output task rows retain a separate keyboard-accessible workspace action.
- Report dialogs use a distinct visible `Report` action to avoid overloading the `Open` label.
- Storybook task-action fixture includes structured output so the interactive layout is covered.

## Validation

- `make static-check`
- `bun test src/browser/features/Tools/WorkflowRunToolCall.test.tsx`
- `make typecheck`
- `make lint`
- `make test-unit`
- Deep review workflow with auto-fixes: `wfr_c4c448b5fe8ed29c`
- Isolated scratch `.gitignore` semantics check verified the sentinel remains unignored while draft workflow files remain ignored.

## Risks

The main regression risk is workflow task-row interaction complexity: row expansion, workspace navigation, and report opening now coexist in one compact event-list row. Tests cover all three actions plus the workflow auto-complete preservation case.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$97.02`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=97.02 -->
