### PR TITLE
🤖 feat: add deep-review auto-fix loop mode

### DIFF
--- a/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, type ReactNode } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import type { WorkflowRunRecord } from "@/common/types/workflow";
+import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import { APIContext } from "@/browser/contexts/API";
 import { WorkflowRunToolCall } from "@/browser/features/Tools/WorkflowRunToolCall";
 import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
@@ -165,6 +166,19 @@ const resumedForegroundDiscoveryRun: WorkflowRunRecord = {
   ],
 };
 
+function createTaskWorkspaceMetadata(workspaceId: string): FrontendWorkspaceMetadata {
+  return {
+    id: workspaceId,
+    name: workspaceId,
+    title: workspaceId,
+    projectPath: "/repo",
+    projectName: "repo",
+    namedWorkspacePath: `/repo/${workspaceId}`,
+    createdAt: "2026-05-29T00:00:00.000Z",
+    runtimeConfig: { type: "local", srcBaseDir: "/tmp/mux-src" },
+  };
+}
+
 const taskActionsRun: WorkflowRunRecord = {
   id: "wfr_story_task_actions",
   workspaceId: "workspace-1",
@@ -236,10 +250,20 @@ function WorkflowTaskActionsStory(props: Parameters<typeof WorkflowRunToolCall>[
   const [openedTaskId, setOpenedTaskId] = useState<string | null>(null);
 
   useEffect(() => {
-    useWorkspaceStoreRaw().setNavigateToWorkspace((workspaceId) => {
+    const workspaceStore = useWorkspaceStoreRaw();
+    workspaceStore.syncWorkspaces(
+      new Map([
+        ["7b1a07d84d", createTaskWorkspaceMetadata("7b1a07d84d")],
+        ["a36921beca", createTaskWorkspaceMetadata("a36921beca")],
+      ])
+    );
+    workspaceStore.setNavigateToWorkspace((workspaceId) => {
       setOpenedTaskId(workspaceId);
     });
-    return () => useWorkspaceStoreRaw().setNavigateToWorkspace(() => undefined);
+    return () => {
+      workspaceStore.setNavigateToWorkspace(() => undefined);
+      workspaceStore.syncWorkspaces(new Map());
+    };
   }, []);
 
   return (

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -15,6 +15,7 @@ import {
 } from "react";
 
 import { APIContext } from "@/browser/contexts/API";
+import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import {
   CommandRegistryProvider,
   useCommandRegistry,
@@ -23,6 +24,19 @@ import {
 import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
 import { ThemeProvider } from "@/browser/contexts/ThemeContext";
 import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
+function createWorkflowTaskWorkspaceMetadata(workspaceId: string): FrontendWorkspaceMetadata {
+  return {
+    id: workspaceId,
+    name: workspaceId,
+    title: workspaceId,
+    projectPath: "/repo",
+    projectName: "repo",
+    namedWorkspacePath: `/repo/${workspaceId}`,
+    createdAt: "2026-05-29T00:00:00.000Z",
+    runtimeConfig: { type: "local", srcBaseDir: "/tmp/mux-src" },
+  };
+}
+
 interface MockDialogContextValue {
   open: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -136,6 +150,7 @@ describe("WorkflowRunToolCall", () => {
 
   afterEach(() => {
     useWorkspaceStoreRaw().setNavigateToWorkspace(() => undefined);
+    useWorkspaceStoreRaw().syncWorkspaces(new Map());
     cleanup();
     globalThis.window = originalWindow;
     globalThis.document = originalDocument;
@@ -272,7 +287,7 @@ describe("WorkflowRunToolCall", () => {
     const taskEventRow = view.getByText("scope-topic / task_scope / completed");
     const taskEventIndex = view.getByText("#3");
     expect(taskEventIndex.className).toContain("cursor-help");
-    expect(taskEventRow.closest('[role="button"]')?.className).toContain("cursor-pointer");
+    expect(taskEventRow.closest('[role="button"]')).toBeNull();
     expect(taskEventRow.getAttribute("title")).toBeNull();
     expect(taskEventRow.closest("summary")).toBeNull();
     const taskReportToggle = view.getByLabelText("Open report for task_scope");
@@ -297,6 +312,12 @@ describe("WorkflowRunToolCall", () => {
     useWorkspaceStoreRaw().setNavigateToWorkspace((workspaceId) => {
       navigatedTo.push(workspaceId);
     });
+    useWorkspaceStoreRaw().syncWorkspaces(
+      new Map([
+        ["task_live", createWorkflowTaskWorkspaceMetadata("task_live")],
+        ["task_retry", createWorkflowTaskWorkspaceMetadata("task_retry")],
+      ])
+    );
     const view = render(
       <ThemeProvider forcedTheme="dark">
         <TooltipProvider>
@@ -451,6 +472,88 @@ describe("WorkflowRunToolCall", () => {
     fireEvent.click(view.getByLabelText("Close"));
     await waitFor(() => {
       expect(document.querySelector('[role="dialog"]')).toBeNull();
+    });
+  });
+
+  test("hides task workspace actions when the task workspace is unavailable", async () => {
+    const navigatedTo: string[] = [];
+    useWorkspaceStoreRaw().setNavigateToWorkspace((workspaceId) => {
+      navigatedTo.push(workspaceId);
+    });
+    const view = render(
+      <ThemeProvider forcedTheme="dark">
+        <TooltipProvider>
+          <WorkflowRunToolCall
+            args={{ name: "implementation", args: {}, run_in_background: true }}
+            status="executing"
+            result={{
+              status: "running",
+              runId: "wfr_missing_task_workspace",
+              result: null,
+              run: {
+                id: "wfr_missing_task_workspace",
+                workspaceId: "workspace-1",
+                definition: {
+                  name: "implementation",
+                  description: "Implementation",
+                  scope: "built-in",
+                  executable: true,
+                },
+                definitionSource: "export default function workflow() { return null; }",
+                definitionHash: "sha256:test",
+                args: {},
+                status: "running",
+                createdAt: "2026-05-29T00:00:00.000Z",
+                updatedAt: "2026-05-29T00:00:01.000Z",
+                events: [
+                  {
+                    sequence: 1,
+                    type: "task",
+                    at: "2026-05-29T00:00:00.000Z",
+                    stepId: "completed-task",
+                    taskId: "task_deleted_report",
+                    status: "completed",
+                  },
+                  {
+                    sequence: 2,
+                    type: "task",
+                    at: "2026-05-29T00:00:01.000Z",
+                    stepId: "running-task",
+                    taskId: "task_deleted_running",
+                    status: "started",
+                  },
+                ],
+                steps: [
+                  {
+                    stepId: "completed-task",
+                    inputHash: "sha256:completed",
+                    status: "completed",
+                    taskId: "task_deleted_report",
+                    startedAt: "2026-05-29T00:00:00.000Z",
+                    completedAt: "2026-05-29T00:00:01.000Z",
+                    result: {
+                      reportMarkdown: "## Deleted workspace report\n\nReport remains readable.",
+                    },
+                  },
+                ],
+              },
+            }}
+          />
+        </TooltipProvider>
+      </ThemeProvider>
+    );
+
+    expect(view.queryByLabelText("Open task workspace for task_deleted_report")).toBeNull();
+    expect(view.queryByText("Open")).toBeNull();
+    expect(
+      view.queryByRole("button", { name: "Open workflow task task_deleted_running" })
+    ).toBeNull();
+    expect(navigatedTo).toEqual([]);
+
+    fireEvent.click(view.getByLabelText("Open report for task_deleted_report"));
+    await waitFor(() => {
+      const reportDialog = document.querySelector('[role="dialog"]');
+      expect(reportDialog?.textContent).toContain("Report remains readable.");
     });
   });
 

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -1,4 +1,11 @@
-import React, { useContext, useEffect, useLayoutEffect, useRef, useState } from "react";
+import React, {
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
 import { APIContext, type APIClient } from "@/browser/contexts/API";
 import {
@@ -489,6 +496,17 @@ function shouldShowWorkflowTaskOpenAffordance(
   return event.type === "task" && event.status === "started";
 }
 
+// Workflow history can outlive child task workspaces, so only render navigation
+// affordances when the live workspace registry still contains the task id.
+function useWorkflowTaskWorkspaceAvailable(taskId: string): boolean {
+  const workspaceStore = useWorkspaceStoreRaw();
+  return useSyncExternalStore(
+    workspaceStore.subscribeDerived,
+    () => workspaceStore.getWorkspaceMetadata(taskId) != null,
+    () => false
+  );
+}
+
 function WorkflowTaskRow(props: {
   row: Extract<WorkflowDisplayRow, { kind: "task" }>;
   displayIndex: number;
@@ -503,14 +521,15 @@ function WorkflowTaskRow(props: {
   const label = getWorkflowEventLabel(event);
   const taskReportMarkdown = getTaskReportMarkdown(event, props.steps);
   const taskStructuredOutput = getTaskStructuredOutput(event, props.steps);
+  const taskWorkspaceAvailable = useWorkflowTaskWorkspaceAvailable(event.taskId);
   // Completed task rows inspect structured output inline; keep workspace navigation as a separate action.
   const canExpandStructuredOutput =
     event.status === "completed" && taskStructuredOutput !== undefined;
-  const showWorkspaceAction = canExpandStructuredOutput;
+  const canNavigateViaRow = !canExpandStructuredOutput && taskWorkspaceAvailable;
+  const taskRowInteractive = canExpandStructuredOutput || canNavigateViaRow;
+  const showWorkspaceAction = canExpandStructuredOutput && taskWorkspaceAvailable;
   const showOpenAffordance =
-    taskReportMarkdown == null &&
-    !canExpandStructuredOutput &&
-    shouldShowWorkflowTaskOpenAffordance(event);
+    taskReportMarkdown == null && canNavigateViaRow && shouldShowWorkflowTaskOpenAffordance(event);
   const toggleStructuredOutput = () => {
     props.onInspectStructuredOutput();
     setStructuredOutputExpanded((isExpanded) => !isExpanded);
@@ -520,7 +539,9 @@ function WorkflowTaskRow(props: {
       toggleStructuredOutput();
       return;
     }
-    props.onNavigate(event.taskId);
+    if (taskWorkspaceAvailable) {
+      props.onNavigate(event.taskId);
+    }
   };
   const handleReportDialogOpenChange = (isOpen: boolean) => {
     if (isOpen) {
@@ -537,21 +558,25 @@ function WorkflowTaskRow(props: {
   };
   const taskRowAriaLabel = canExpandStructuredOutput
     ? `${structuredOutputExpanded ? "Collapse" : "Expand"} structured output for workflow task ${event.taskId}`
-    : `Open workflow task ${event.taskId}`;
+    : canNavigateViaRow
+      ? `Open workflow task ${event.taskId}`
+      : undefined;
 
   const taskRow = (
     <div
-      className={`grid cursor-pointer items-center gap-2 border-l-2 border-transparent px-2 py-1 text-[10px] ${
+      className={`grid items-center gap-2 border-l-2 border-transparent px-2 py-1 text-[10px] ${
+        taskRowInteractive ? "cursor-pointer" : ""
+      } ${
         showOpenAffordance
           ? "grid-cols-[3rem_4.75rem_minmax(0,1fr)_auto]"
           : "grid-cols-[3rem_4.75rem_minmax(0,1fr)]"
       }`}
-      role="button"
-      tabIndex={0}
+      role={taskRowInteractive ? "button" : undefined}
+      tabIndex={taskRowInteractive ? 0 : undefined}
       aria-expanded={canExpandStructuredOutput ? structuredOutputExpanded : undefined}
       aria-label={taskRowAriaLabel}
-      onClick={activateTaskRow}
-      onKeyDown={onKeyDown}
+      onClick={taskRowInteractive ? activateTaskRow : undefined}
+      onKeyDown={taskRowInteractive ? onKeyDown : undefined}
     >
       <TooltipIfPresent
         tooltip={

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -3586,6 +3586,7 @@ export class WorkspaceStore {
 
     // Store metadata for name lookup
     this.workspaceMetadata.set(workspaceId, metadata);
+    this.derived.bump("workspaces");
 
     // Backend guarantees createdAt via config.ts - this should never be undefined
     assert(
@@ -3692,6 +3693,7 @@ export class WorkspaceStore {
     this.aggregators.delete(workspaceId);
     this.chatTransientState.delete(workspaceId);
     this.workspaceMetadata.delete(workspaceId);
+    this.derived.bump("workspaces");
     this.workspaceActivity.delete(workspaceId);
     this.refreshActiveGoalCount();
     this.workspaceTerminalActivity.delete(workspaceId);

--- a/src/node/services/workflows/WorkflowDefinitionStore.test.ts
+++ b/src/node/services/workflows/WorkflowDefinitionStore.test.ts
@@ -519,6 +519,47 @@ describe("WorkflowDefinitionStore", () => {
     expect(await fs.readFile(path.join(scratchRoot, ".gitignore"), "utf-8")).toBe(existingFallback);
   });
 
+  test("hides an untracked generated scratch gitignore when repo rules unignore workflows", async () => {
+    using tmp = new DisposableTempDir("workflow-definitions");
+    const workspaceRoot = path.join(tmp.path, "project");
+    const scratchRoot = path.join(workspaceRoot, ".mux", "workflows", ".scratch");
+    const projectRoot = path.join(workspaceRoot, ".mux", "workflows");
+    const globalRoot = path.join(tmp.path, "mux-home", "workflows");
+    await fs.mkdir(scratchRoot, { recursive: true });
+    await runGit(workspaceRoot, ["init"]);
+    await fs.writeFile(
+      path.join(workspaceRoot, ".gitignore"),
+      "/.mux/\n!/.mux/\n!/.mux/workflows/\n!/.mux/workflows/**\n",
+      "utf-8"
+    );
+    const existingGitignore = "*\n!.gitignore\n";
+    await fs.writeFile(path.join(scratchRoot, ".gitignore"), existingGitignore, "utf-8");
+    await writeWorkflow(scratchRoot, "scratch-demo", "Workspace scratch demo");
+    const store = new WorkflowDefinitionStore({
+      scratchRoot,
+      projectRoot,
+      globalRoot,
+      builtIns: [],
+    });
+
+    const definitions = await store.listDefinitions({ projectTrusted: true });
+
+    const fallback = await fs.readFile(path.join(scratchRoot, ".gitignore"), "utf-8");
+    expect(definitions.map((definition) => definition.name)).toEqual(["scratch-demo"]);
+    expect(fallback).toBe(
+      `${existingGitignore}# mux: hide scratch workflow drafts when repo rules unignore workflows\n*\n`
+    );
+    expect(
+      await runGit(workspaceRoot, [
+        "status",
+        "--short",
+        "--untracked-files=all",
+        "--",
+        ".mux/workflows/.scratch",
+      ])
+    ).toBe("");
+  });
+
   test("serializes local exclude updates for multiple scratch roots in one repo", async () => {
     using tmp = new DisposableTempDir("workflow-definitions");
     const repoRoot = path.join(tmp.path, "repo");

--- a/src/node/services/workflows/WorkflowDefinitionStore.ts
+++ b/src/node/services/workflows/WorkflowDefinitionStore.ts
@@ -395,8 +395,7 @@ function isScratchGitignoreSelfException(pattern: string): boolean {
 
 function scratchGitignorePatterns(content: string): string[] {
   return content
-    .split(/?
-/u)
+    .split(/\r?\n/u)
     .map((line) => line.trim())
     .filter((line) => line.length > 0 && !line.startsWith("#"));
 }
@@ -416,12 +415,8 @@ function scratchGitignoreFallbackContent(content: string): string | null {
   if (lastPattern === "*") {
     return null;
   }
-  const separator = content.length > 0 && !content.endsWith("
-") ? "
-" : "";
-  return `${content}${separator}${WORKFLOW_SCRATCH_GITIGNORE_FALLBACK_COMMENT}
-*
-`;
+  const separator = content.length > 0 && !content.endsWith("\n") ? "\n" : "";
+  return `${content}${separator}${WORKFLOW_SCRATCH_GITIGNORE_FALLBACK_COMMENT}\n*\n`;
 }
 
 async function writeLocalGitExcludePattern(excludePath: string, pattern: string): Promise<void> {

--- a/src/node/services/workflows/WorkflowDefinitionStore.ts
+++ b/src/node/services/workflows/WorkflowDefinitionStore.ts
@@ -395,7 +395,8 @@ function isScratchGitignoreSelfException(pattern: string): boolean {
 
 function scratchGitignorePatterns(content: string): string[] {
   return content
-    .split(/\r?\n/u)
+    .split(/?
+/u)
     .map((line) => line.trim())
     .filter((line) => line.length > 0 && !line.startsWith("#"));
 }
@@ -415,8 +416,12 @@ function scratchGitignoreFallbackContent(content: string): string | null {
   if (lastPattern === "*") {
     return null;
   }
-  const separator = content.length > 0 && !content.endsWith("\n") ? "\n" : "";
-  return `${content}${separator}${WORKFLOW_SCRATCH_GITIGNORE_FALLBACK_COMMENT}\n*\n`;
+  const separator = content.length > 0 && !content.endsWith("
+") ? "
+" : "";
+  return `${content}${separator}${WORKFLOW_SCRATCH_GITIGNORE_FALLBACK_COMMENT}
+*
+`;
 }
 
 async function writeLocalGitExcludePattern(excludePath: string, pattern: string): Promise<void> {

--- a/src/node/services/workflows/builtInWorkflowActions.ts
+++ b/src/node/services/workflows/builtInWorkflowActions.ts
@@ -129,6 +129,12 @@ module.exports.execute = async function (rawInput, ctx) {
   const requestedHead = optionalString(input.head) ?? "HEAD";
   const headSha = await tryGit(ctx, ["rev-parse", "--verify", "HEAD"]);
   const requestedHeadSha = await tryGit(ctx, ["rev-parse", "--verify", requestedHead]);
+  const requestedHeadRef = await tryGit(ctx, [
+    "rev-parse",
+    "--symbolic-full-name",
+    "--verify",
+    requestedHead,
+  ]);
   const stdout = await runGit(ctx, [
     "status",
     "--porcelain=v1",
@@ -161,6 +167,7 @@ module.exports.execute = async function (rawInput, ctx) {
     headSha,
     requestedHead,
     requestedHeadSha,
+    requestedHeadRef,
     clean: staged.length === 0 && unstaged.length === 0 && untracked.length === 0,
     staged,
     unstaged,

--- a/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
+++ b/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
@@ -1182,7 +1182,12 @@ describe("built-in deep-review-workflow", () => {
         executable: true,
       },
       definitionSource: deepReviewWorkflow.source,
-      args: { input: "current workspace changes --fix --loop", maxCandidates: 1, maxFixes: 2 },
+      args: {
+        input: "current workspace changes --fix --loop",
+        headRef: reviewedHeadSha,
+        maxCandidates: 1,
+        maxFixes: 2,
+      },
       defaultActionCwd: repoRoot,
       now: "2026-05-29T00:00:00.000Z",
     });
@@ -1466,8 +1471,9 @@ describe("built-in deep-review-workflow", () => {
           taskCalls.push(spec);
           switch (spec.id) {
             case "scope-review-surface-loop-1":
+            case "scope-review-surface-loop-2":
               return {
-                taskId: "task_scope_loop_1",
+                taskId: `task_${spec.id}`,
                 reportMarkdown: "Scoped.",
                 structuredOutput: {
                   summary: "Review service code.",
@@ -1484,6 +1490,9 @@ describe("built-in deep-review-workflow", () => {
               };
             case "review-tests-loop-1":
             case "review-architecture-loop-1":
+            case "review-correctness-loop-2":
+            case "review-tests-loop-2":
+            case "review-architecture-loop-2":
               return {
                 taskId: `task_${spec.id}`,
                 reportMarkdown: "No findings.",
@@ -1494,6 +1503,12 @@ describe("built-in deep-review-workflow", () => {
                 taskId: "task_triage_loop_1",
                 reportMarkdown: "One candidate.",
                 structuredOutput: { issues: [issue] },
+              };
+            case "triage-candidate-issues-loop-2":
+              return {
+                taskId: "task_triage_loop_2",
+                reportMarkdown: "No candidates.",
+                structuredOutput: { issues: [] },
               };
             case "verify-issue-0-loop-1":
               return {
@@ -1515,6 +1530,18 @@ describe("built-in deep-review-workflow", () => {
                   verifiedIssueIds: ["budgeted-fix"],
                   risk: "medium",
                   validationPlan: ["bun test src/service.test.ts"],
+                  discardedIssueCount: 0,
+                },
+              };
+            case "synthesize-review-loop-2":
+              return {
+                taskId: "task_final_loop_2",
+                reportMarkdown: "# Deep Review\n\nNo verified issues.",
+                structuredOutput: {
+                  verifiedIssueCount: 0,
+                  verifiedIssueIds: [],
+                  risk: "low",
+                  validationPlan: [],
                   discardedIssueCount: 0,
                 },
               };
@@ -1567,16 +1594,19 @@ describe("built-in deep-review-workflow", () => {
 
     const result = await runner.run("wfr_deep_review_fix_loop_budget");
 
-    expect(taskCalls.map((call) => call.id)).not.toContain("scope-review-surface-loop-2");
+    const callIds = taskCalls.map((call) => call.id);
+    expect(callIds).toContain("scope-review-surface-loop-2");
+    expect(callIds).not.toContain("fix-issue-0-loop-2");
     expect(applyCalls).toHaveLength(1);
     expect(result).toMatchObject({
       structuredOutput: {
         loop: {
-          completed: false,
-          iterations: 1,
+          completed: true,
+          iterations: 2,
           remainingFixBudget: 0,
-          stopReason: "fix-budget-exhausted",
+          stopReason: "no-verified-issues",
         },
+        final: { verifiedIssueCount: 0 },
       },
     });
   }, 10_000);
@@ -1732,6 +1762,176 @@ describe("built-in deep-review-workflow", () => {
           completed: false,
           iterations: 1,
           stopReason: "no-fix-progress",
+        },
+      },
+    });
+  }, 10_000);
+
+  test("auto-fix loop stops when validation fails", async () => {
+    if (!deepReviewWorkflow) {
+      throw new Error("Expected built-in deep-review-workflow workflow");
+    }
+    using tmp = new DisposableTempDir("deep-review-workflow-fix-loop-validation-failed");
+    const repoRoot = path.join(tmp.path, "repo");
+    const projectRoot = path.join(tmp.path, "project-actions");
+    const globalRoot = path.join(tmp.path, "global-actions");
+    await fs.mkdir(repoRoot, { recursive: true });
+    await runGit(repoRoot, ["init"]);
+    await runGit(repoRoot, ["config", "user.email", "mux@example.com"]);
+    await runGit(repoRoot, ["config", "user.name", "Mux"]);
+    await fs.writeFile(path.join(repoRoot, "service.ts"), "export const value = 1;\n", "utf-8");
+    await runGit(repoRoot, ["add", "service.ts"]);
+    await runGit(repoRoot, ["commit", "-m", "base commit"]);
+
+    const issue = {
+      id: "validation-fails",
+      severity: "P1",
+      category: "correctness",
+      title: "Validation fails after fix",
+      rationale: "The fix must stop when validation fails.",
+      evidence: "service.ts has a bug.",
+      filePaths: ["service.ts"],
+      suggestedFix: "Fix service.ts.",
+      validation: "Run targeted tests.",
+      confidence: "high",
+    };
+    const runStore = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    await runStore.createRun({
+      id: "wfr_deep_review_fix_loop_validation_failed",
+      workspaceId: "workspace-1",
+      definition: {
+        name: deepReviewWorkflow.name,
+        description: deepReviewWorkflow.description,
+        scope: "built-in",
+        executable: true,
+      },
+      definitionSource: deepReviewWorkflow.source,
+      args: {
+        input: "current workspace changes --fix --loop",
+        maxCandidates: 1,
+        maxLoopIterations: 3,
+      },
+      defaultActionCwd: repoRoot,
+      now: "2026-05-29T00:00:00.000Z",
+    });
+
+    const taskCalls: WorkflowAgentSpec[] = [];
+    const runner = new WorkflowRunner({
+      runStore,
+      runtimeFactory: new QuickJSRuntimeFactory(),
+      taskAdapter: {
+        async runAgent(spec) {
+          taskCalls.push(spec);
+          switch (spec.id) {
+            case "scope-review-surface-loop-1":
+              return {
+                taskId: "task_scope_loop_1",
+                reportMarkdown: "Scoped.",
+                structuredOutput: {
+                  summary: "Review service code.",
+                  files: ["service.ts"],
+                  riskAreas: ["correctness"],
+                  lanes: ["correctness"],
+                },
+              };
+            case "review-correctness-loop-1":
+              return {
+                taskId: "task_review_correctness_loop_1",
+                reportMarkdown: "Finding.",
+                structuredOutput: { issues: [issue] },
+              };
+            case "review-tests-loop-1":
+            case "review-architecture-loop-1":
+              return {
+                taskId: `task_${spec.id}`,
+                reportMarkdown: "No findings.",
+                structuredOutput: { issues: [] },
+              };
+            case "triage-candidate-issues-loop-1":
+              return {
+                taskId: "task_triage_loop_1",
+                reportMarkdown: "One candidate.",
+                structuredOutput: { issues: [issue] },
+              };
+            case "verify-issue-0-loop-1":
+              return {
+                taskId: "task_verify_loop_1",
+                reportMarkdown: "Issue is valid.",
+                structuredOutput: {
+                  issueId: "validation-fails",
+                  verdict: "valid",
+                  confidence: "high",
+                  rationale: "The issue is valid.",
+                },
+              };
+            case "synthesize-review-loop-1":
+              return {
+                taskId: "task_final_loop_1",
+                reportMarkdown: "# Deep Review\n\n- P1 Validation fails after fix.",
+                structuredOutput: {
+                  verifiedIssueCount: 1,
+                  verifiedIssueIds: ["validation-fails"],
+                  risk: "medium",
+                  validationPlan: ["bun test src/service.test.ts"],
+                  discardedIssueCount: 0,
+                },
+              };
+            case "fix-issue-0-loop-1":
+              return {
+                taskId: "task_fix_loop_1",
+                reportMarkdown: "Fixed issue.",
+                structuredOutput: {
+                  issueId: "validation-fails",
+                  status: "fixed",
+                  summary: "Fixed service.ts.",
+                  validation: ["bun test src/service.test.ts"],
+                  commitCreated: true,
+                },
+              };
+            case "validate-auto-fixes-loop-1":
+              return {
+                taskId: "task_validate_loop_1",
+                reportMarkdown: "Validation failed.",
+                structuredOutput: {
+                  status: "failed",
+                  commands: ["bun test src/service.test.ts"],
+                  summary: "Targeted tests failed.",
+                  failures: ["service test failed"],
+                },
+              };
+            default:
+              throw new Error(`Unexpected deep-review validation-failed step: ${spec.id}`);
+          }
+        },
+        async applyPatch(spec) {
+          return {
+            success: true,
+            status: "applied",
+            taskId: spec.sourceTaskId,
+            projectResults: [{ projectPath: repoRoot, projectName: "repo", status: "applied" }],
+          };
+        },
+      },
+      actionRegistry: new WorkflowActionRegistry({ projectRoot, globalRoot }),
+      projectTrusted: true,
+      defaultActionCwd: repoRoot,
+      runnerId: "runner-a",
+      clock: {
+        nowIso: () => "2026-05-29T00:00:01.000Z",
+        nowMs: () => 1_000,
+      },
+    });
+
+    const result = await runner.run("wfr_deep_review_fix_loop_validation_failed");
+
+    expect(taskCalls.map((call) => call.id)).not.toContain("scope-review-surface-loop-2");
+    expect(result).toMatchObject({
+      structuredOutput: {
+        loop: {
+          completed: false,
+          iterations: 1,
+          remainingFixBudget: 4,
+          stopReason: "validation-failed",
         },
       },
     });
@@ -2615,6 +2815,145 @@ describe("built-in deep-review-workflow", () => {
         fix: {
           requested: true,
           skippedReason: "auto-fix requires the current Git branch to match the reviewed snapshot",
+          selectedIssues: [],
+        },
+      },
+    });
+  }, 10_000);
+
+  test("auto-fix skips when same-branch HEAD changes after review context is captured", async () => {
+    if (!deepReviewWorkflow) {
+      throw new Error("Expected built-in deep-review-workflow workflow");
+    }
+    using tmp = new DisposableTempDir("deep-review-workflow-fix-head-drift");
+    const repoRoot = path.join(tmp.path, "repo");
+    const projectRoot = path.join(tmp.path, "project-actions");
+    const globalRoot = path.join(tmp.path, "global-actions");
+    await fs.mkdir(repoRoot, { recursive: true });
+    await runGit(repoRoot, ["init"]);
+    await runGit(repoRoot, ["config", "user.email", "mux@example.com"]);
+    await runGit(repoRoot, ["config", "user.name", "Mux"]);
+    await fs.writeFile(path.join(repoRoot, "service.ts"), "export const value = 1;\n", "utf-8");
+    await runGit(repoRoot, ["add", "service.ts"]);
+    await runGit(repoRoot, ["commit", "-m", "base commit"]);
+
+    const issue = {
+      id: "head-drift",
+      severity: "P2",
+      category: "correctness",
+      title: "Stale review finding",
+      rationale: "The finding was made against an older HEAD.",
+      evidence: "service.ts had the original value.",
+      filePaths: ["service.ts"],
+      suggestedFix: "Fix service.ts.",
+      validation: "Run targeted tests.",
+      confidence: "high",
+    };
+    const runStore = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    await runStore.createRun({
+      id: "wfr_deep_review_fix_head_drift",
+      workspaceId: "workspace-1",
+      definition: {
+        name: deepReviewWorkflow.name,
+        description: deepReviewWorkflow.description,
+        scope: "built-in",
+        executable: true,
+      },
+      definitionSource: deepReviewWorkflow.source,
+      args: { fix: true, input: "current workspace changes", maxCandidates: 1 },
+      defaultActionCwd: repoRoot,
+      now: "2026-05-29T00:00:00.000Z",
+    });
+
+    const taskCalls: WorkflowAgentSpec[] = [];
+    const runner = new WorkflowRunner({
+      runStore,
+      runtimeFactory: new QuickJSRuntimeFactory(),
+      taskAdapter: {
+        async runAgent(spec) {
+          taskCalls.push(spec);
+          switch (spec.id) {
+            case "scope-review-surface":
+              return {
+                taskId: "task_scope",
+                reportMarkdown: "Scoped.",
+                structuredOutput: {
+                  summary: "Review service code.",
+                  files: ["service.ts"],
+                  riskAreas: ["correctness"],
+                  lanes: ["correctness"],
+                },
+              };
+            case "review-correctness":
+            case "review-tests":
+            case "review-architecture":
+              return {
+                taskId: `task_${spec.id}`,
+                reportMarkdown: "Findings.",
+                structuredOutput: { issues: spec.id === "review-correctness" ? [issue] : [] },
+              };
+            case "triage-candidate-issues":
+              return {
+                taskId: "task_triage",
+                reportMarkdown: "One candidate.",
+                structuredOutput: { issues: [issue] },
+              };
+            case "verify-issue-0":
+              return {
+                taskId: "task_verify_0",
+                reportMarkdown: "Issue is valid.",
+                structuredOutput: {
+                  issueId: "head-drift",
+                  verdict: "valid",
+                  confidence: "high",
+                  rationale: "The issue is valid before the drift.",
+                },
+              };
+            case "synthesize-review":
+              await fs.writeFile(
+                path.join(repoRoot, "service.ts"),
+                "export const value = 2;\n",
+                "utf-8"
+              );
+              await runGit(repoRoot, ["add", "service.ts"]);
+              await runGit(repoRoot, ["commit", "-m", "external same-branch drift"]);
+              return {
+                taskId: "task_final",
+                reportMarkdown: "# Deep Review\n\n- P2 Stale review finding.",
+                structuredOutput: {
+                  verifiedIssueCount: 1,
+                  verifiedIssueIds: ["head-drift"],
+                  risk: "medium",
+                  validationPlan: ["bun test src/service.test.ts"],
+                  discardedIssueCount: 0,
+                },
+              };
+            default:
+              throw new Error(`Unexpected same-branch head drift step: ${spec.id}`);
+          }
+        },
+      },
+      actionRegistry: new WorkflowActionRegistry({ projectRoot, globalRoot }),
+      projectTrusted: true,
+      defaultActionCwd: repoRoot,
+      runnerId: "runner-a",
+      clock: {
+        nowIso: () => "2026-05-29T00:00:01.000Z",
+        nowMs: () => 1_000,
+      },
+    });
+
+    const result = await runner.run("wfr_deep_review_fix_head_drift");
+
+    expect(taskCalls.map((call) => call.id)).not.toContain("fix-issue-0");
+    expect(result.reportMarkdown).toContain(
+      "auto-fix requires the current Git HEAD to match the reviewed snapshot"
+    );
+    expect(result).toMatchObject({
+      structuredOutput: {
+        fix: {
+          requested: true,
+          skippedReason: "auto-fix requires the current Git HEAD to match the reviewed snapshot",
           selectedIssues: [],
         },
       },

--- a/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
+++ b/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
@@ -1137,6 +1137,783 @@ describe("built-in deep-review-workflow", () => {
     });
   }, 10_000);
 
+  test("auto-fix loop repeats review until a clean pass", async () => {
+    if (!deepReviewWorkflow) {
+      throw new Error("Expected built-in deep-review-workflow workflow");
+    }
+    using tmp = new DisposableTempDir("deep-review-workflow-fix-loop");
+    const repoRoot = path.join(tmp.path, "repo");
+    const projectRoot = path.join(tmp.path, "project-actions");
+    const globalRoot = path.join(tmp.path, "global-actions");
+    await fs.mkdir(repoRoot, { recursive: true });
+    await runGit(repoRoot, ["init"]);
+    await runGit(repoRoot, ["config", "user.email", "mux@example.com"]);
+    await runGit(repoRoot, ["config", "user.name", "Mux"]);
+    await fs.writeFile(path.join(repoRoot, "service.ts"), "export const value = 1;\n", "utf-8");
+    await runGit(repoRoot, ["add", "service.ts"]);
+    await runGit(repoRoot, ["commit", "-m", "base commit"]);
+    await runGit(repoRoot, ["branch", "-M", "main"]);
+    await runGit(repoRoot, ["checkout", "-b", "feature"]);
+    const { stdout: reviewedHeadStdout } = await execFileAsync("git", ["rev-parse", "HEAD"], {
+      cwd: repoRoot,
+    });
+    const reviewedHeadSha = reviewedHeadStdout.trim();
+
+    const issue = {
+      id: "await-write",
+      severity: "P1",
+      category: "correctness",
+      title: "Missing await drops write failures",
+      rationale: "The service reports success before persistence completes.",
+      evidence: "service.ts calls persist() without awaiting it.",
+      filePaths: ["service.ts"],
+      suggestedFix: "Await persist() before returning success.",
+      validation: "Run targeted tests.",
+      confidence: "high",
+    };
+    const runStore = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    await runStore.createRun({
+      id: "wfr_deep_review_fix_loop",
+      workspaceId: "workspace-1",
+      definition: {
+        name: deepReviewWorkflow.name,
+        description: deepReviewWorkflow.description,
+        scope: "built-in",
+        executable: true,
+      },
+      definitionSource: deepReviewWorkflow.source,
+      args: { input: "current workspace changes --fix --loop", maxCandidates: 1, maxFixes: 2 },
+      defaultActionCwd: repoRoot,
+      now: "2026-05-29T00:00:00.000Z",
+    });
+
+    const taskCalls: WorkflowAgentSpec[] = [];
+    const applyCalls: unknown[] = [];
+    const runner = new WorkflowRunner({
+      runStore,
+      runtimeFactory: new QuickJSRuntimeFactory(),
+      taskAdapter: {
+        async runAgent(spec) {
+          taskCalls.push(spec);
+          switch (spec.id) {
+            case "scope-review-surface-loop-1":
+            case "scope-review-surface-loop-2":
+              return {
+                taskId: `task_${spec.id}`,
+                reportMarkdown: "Review service changes.",
+                structuredOutput: {
+                  summary: "PR touches persistence service code.",
+                  files: ["service.ts"],
+                  riskAreas: ["async persistence"],
+                  lanes: ["correctness"],
+                },
+              };
+            case "review-correctness-loop-1":
+              return {
+                taskId: "task_review_correctness_loop_1",
+                reportMarkdown: "One finding.",
+                structuredOutput: { issues: [issue] },
+              };
+            case "review-tests-loop-1":
+            case "review-architecture-loop-1":
+            case "review-correctness-loop-2":
+            case "review-tests-loop-2":
+            case "review-architecture-loop-2":
+              return {
+                taskId: `task_${spec.id}`,
+                reportMarkdown: "No findings.",
+                structuredOutput: { issues: [] },
+              };
+            case "triage-candidate-issues-loop-1":
+              return {
+                taskId: "task_triage_loop_1",
+                reportMarkdown: "One candidate.",
+                structuredOutput: { issues: [issue] },
+              };
+            case "triage-candidate-issues-loop-2":
+              return {
+                taskId: "task_triage_loop_2",
+                reportMarkdown: "No candidates.",
+                structuredOutput: { issues: [] },
+              };
+            case "verify-issue-0-loop-1":
+              return {
+                taskId: "task_verify_loop_1",
+                reportMarkdown: "Issue is valid.",
+                structuredOutput: {
+                  issueId: "await-write",
+                  verdict: "valid",
+                  confidence: "high",
+                  rationale: "The code path can return early.",
+                },
+              };
+            case "synthesize-review-loop-1":
+              return {
+                taskId: "task_final_loop_1",
+                reportMarkdown: "# Deep Review\n\n- P1 Missing await drops write failures.",
+                structuredOutput: {
+                  verifiedIssueCount: 1,
+                  verifiedIssueIds: ["await-write"],
+                  risk: "medium",
+                  validationPlan: ["bun test src/service.test.ts"],
+                  discardedIssueCount: 0,
+                },
+              };
+            case "fix-issue-0-loop-1":
+              return {
+                taskId: "task_fix_loop_1",
+                reportMarkdown: "Fixed missing await.",
+                structuredOutput: {
+                  issueId: "await-write",
+                  status: "fixed",
+                  summary: "Awaited the write and added a regression test.",
+                  validation: ["bun test src/service.test.ts"],
+                  commitCreated: true,
+                },
+              };
+            case "validate-auto-fixes-loop-1":
+              return {
+                taskId: "task_validate_loop_1",
+                reportMarkdown: "Validation passed.",
+                structuredOutput: {
+                  status: "passed",
+                  commands: ["bun test src/service.test.ts"],
+                  summary: "Targeted tests passed.",
+                  failures: [],
+                },
+              };
+            case "synthesize-review-loop-2":
+              return {
+                taskId: "task_final_loop_2",
+                reportMarkdown: "# Deep Review\n\nNo verified issues.",
+                structuredOutput: {
+                  verifiedIssueCount: 0,
+                  verifiedIssueIds: [],
+                  risk: "low",
+                  validationPlan: [],
+                  discardedIssueCount: 0,
+                },
+              };
+            default:
+              throw new Error(`Unexpected deep-review loop step: ${spec.id}`);
+          }
+        },
+        async applyPatch(spec) {
+          applyCalls.push(spec);
+          await fs.writeFile(
+            path.join(repoRoot, "service.ts"),
+            "export const value = 2;\n",
+            "utf-8"
+          );
+          await runGit(repoRoot, ["add", "service.ts"]);
+          await runGit(repoRoot, ["commit", "-m", "fix service value"]);
+          const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], { cwd: repoRoot });
+          const headCommitSha = stdout.trim();
+          return {
+            success: true,
+            status: "applied",
+            taskId: spec.sourceTaskId,
+            headCommitSha: headCommitSha,
+            projectResults: [
+              {
+                projectPath: repoRoot,
+                projectName: "repo",
+                status: "applied",
+                headCommitSha: headCommitSha,
+              },
+            ],
+          };
+        },
+      },
+      actionRegistry: new WorkflowActionRegistry({ projectRoot, globalRoot }),
+      projectTrusted: true,
+      defaultActionCwd: repoRoot,
+      runnerId: "runner-a",
+      clock: {
+        nowIso: () => "2026-05-29T00:00:01.000Z",
+        nowMs: () => 1_000,
+      },
+    });
+
+    const result = await runner.run("wfr_deep_review_fix_loop");
+    const run = await runStore.getRun("wfr_deep_review_fix_loop");
+
+    expect(taskCalls.map((call) => call.id)).toEqual([
+      "scope-review-surface-loop-1",
+      "review-correctness-loop-1",
+      "review-tests-loop-1",
+      "review-architecture-loop-1",
+      "triage-candidate-issues-loop-1",
+      "verify-issue-0-loop-1",
+      "synthesize-review-loop-1",
+      "fix-issue-0-loop-1",
+      "validate-auto-fixes-loop-1",
+      "scope-review-surface-loop-2",
+      "review-correctness-loop-2",
+      "review-tests-loop-2",
+      "review-architecture-loop-2",
+      "triage-candidate-issues-loop-2",
+      "synthesize-review-loop-2",
+    ]);
+    expect(applyCalls).toEqual([
+      expect.objectContaining({
+        id: "apply-fix-0-loop-1",
+        sourceTaskId: "task_fix_loop_1",
+        target: "parent",
+        expectedHeadSha: reviewedHeadSha,
+      }),
+    ]);
+    expect(run.events.filter((event) => event.type === "phase").map((event) => event.name)).toEqual(
+      [
+        "loop-iteration",
+        "scope",
+        "lane-review",
+        "triage-dedupe",
+        "adversarial-verification",
+        "final-synthesis",
+        "fix-preflight",
+        "loop-iteration",
+        "scope",
+        "lane-review",
+        "triage-dedupe",
+        "adversarial-verification",
+        "final-synthesis",
+      ]
+    );
+    const completedActionStepIds = run.events.flatMap((event) =>
+      event.type === "action" && event.status === "completed" ? [event.stepId] : []
+    );
+    expect(completedActionStepIds).toContain("git-status-loop-1");
+    expect(completedActionStepIds).toContain("fix-git-status-loop-1");
+    expect(completedActionStepIds).toContain("git-status-loop-2");
+    const loopTwoScopePrompt = taskCalls.find(
+      (call) => call.id === "scope-review-surface-loop-2"
+    )?.prompt;
+    expect(loopTwoScopePrompt).toContain("+export const value = 2;");
+    expect(result.reportMarkdown).toContain("# Deep Review Loop");
+    expect(result.reportMarkdown).toContain("## Loop iteration 2");
+    expect(result).toMatchObject({
+      structuredOutput: {
+        loop: {
+          requested: true,
+          completed: true,
+          iterations: 2,
+          maxIterations: 5,
+          stopReason: "no-verified-issues",
+        },
+        passes: [{ iteration: 1 }, { iteration: 2 }],
+        final: { verifiedIssueCount: 0 },
+      },
+    });
+  }, 10_000);
+
+  test("auto-fix loop treats maxFixes as a run-wide budget", async () => {
+    if (!deepReviewWorkflow) {
+      throw new Error("Expected built-in deep-review-workflow workflow");
+    }
+    using tmp = new DisposableTempDir("deep-review-workflow-fix-loop-budget");
+    const repoRoot = path.join(tmp.path, "repo");
+    const projectRoot = path.join(tmp.path, "project-actions");
+    const globalRoot = path.join(tmp.path, "global-actions");
+    await fs.mkdir(repoRoot, { recursive: true });
+    await runGit(repoRoot, ["init"]);
+    await runGit(repoRoot, ["config", "user.email", "mux@example.com"]);
+    await runGit(repoRoot, ["config", "user.name", "Mux"]);
+    await fs.writeFile(path.join(repoRoot, "service.ts"), "export const value = 1;\n", "utf-8");
+    await runGit(repoRoot, ["add", "service.ts"]);
+    await runGit(repoRoot, ["commit", "-m", "base commit"]);
+
+    const issue = {
+      id: "budgeted-fix",
+      severity: "P1",
+      category: "correctness",
+      title: "Budgeted fix",
+      rationale: "The issue requires one fixer.",
+      evidence: "service.ts has a bug.",
+      filePaths: ["service.ts"],
+      suggestedFix: "Fix service.ts.",
+      validation: "Run targeted tests.",
+      confidence: "high",
+    };
+    const runStore = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    await runStore.createRun({
+      id: "wfr_deep_review_fix_loop_budget",
+      workspaceId: "workspace-1",
+      definition: {
+        name: deepReviewWorkflow.name,
+        description: deepReviewWorkflow.description,
+        scope: "built-in",
+        executable: true,
+      },
+      definitionSource: deepReviewWorkflow.source,
+      args: {
+        input: "current workspace changes --fix --loop",
+        maxCandidates: 1,
+        maxFixes: 1,
+        maxLoopIterations: 3,
+      },
+      defaultActionCwd: repoRoot,
+      now: "2026-05-29T00:00:00.000Z",
+    });
+
+    const taskCalls: WorkflowAgentSpec[] = [];
+    const applyCalls: unknown[] = [];
+    const runner = new WorkflowRunner({
+      runStore,
+      runtimeFactory: new QuickJSRuntimeFactory(),
+      taskAdapter: {
+        async runAgent(spec) {
+          taskCalls.push(spec);
+          switch (spec.id) {
+            case "scope-review-surface-loop-1":
+              return {
+                taskId: "task_scope_loop_1",
+                reportMarkdown: "Scoped.",
+                structuredOutput: {
+                  summary: "Review service code.",
+                  files: ["service.ts"],
+                  riskAreas: ["correctness"],
+                  lanes: ["correctness"],
+                },
+              };
+            case "review-correctness-loop-1":
+              return {
+                taskId: "task_review_correctness_loop_1",
+                reportMarkdown: "Finding.",
+                structuredOutput: { issues: [issue] },
+              };
+            case "review-tests-loop-1":
+            case "review-architecture-loop-1":
+              return {
+                taskId: `task_${spec.id}`,
+                reportMarkdown: "No findings.",
+                structuredOutput: { issues: [] },
+              };
+            case "triage-candidate-issues-loop-1":
+              return {
+                taskId: "task_triage_loop_1",
+                reportMarkdown: "One candidate.",
+                structuredOutput: { issues: [issue] },
+              };
+            case "verify-issue-0-loop-1":
+              return {
+                taskId: "task_verify_loop_1",
+                reportMarkdown: "Issue is valid.",
+                structuredOutput: {
+                  issueId: "budgeted-fix",
+                  verdict: "valid",
+                  confidence: "high",
+                  rationale: "The issue is valid.",
+                },
+              };
+            case "synthesize-review-loop-1":
+              return {
+                taskId: "task_final_loop_1",
+                reportMarkdown: "# Deep Review\n\n- P1 Budgeted fix.",
+                structuredOutput: {
+                  verifiedIssueCount: 1,
+                  verifiedIssueIds: ["budgeted-fix"],
+                  risk: "medium",
+                  validationPlan: ["bun test src/service.test.ts"],
+                  discardedIssueCount: 0,
+                },
+              };
+            case "fix-issue-0-loop-1":
+              return {
+                taskId: "task_fix_loop_1",
+                reportMarkdown: "Fixed budgeted issue.",
+                structuredOutput: {
+                  issueId: "budgeted-fix",
+                  status: "fixed",
+                  summary: "Fixed service.ts.",
+                  validation: ["bun test src/service.test.ts"],
+                  commitCreated: true,
+                },
+              };
+            case "validate-auto-fixes-loop-1":
+              return {
+                taskId: "task_validate_loop_1",
+                reportMarkdown: "Validation passed.",
+                structuredOutput: {
+                  status: "passed",
+                  commands: ["bun test src/service.test.ts"],
+                  summary: "Targeted tests passed.",
+                  failures: [],
+                },
+              };
+            default:
+              throw new Error(`Unexpected deep-review budget step: ${spec.id}`);
+          }
+        },
+        async applyPatch(spec) {
+          applyCalls.push(spec);
+          return {
+            success: true,
+            status: "applied",
+            taskId: spec.sourceTaskId,
+            projectResults: [{ projectPath: repoRoot, projectName: "repo", status: "applied" }],
+          };
+        },
+      },
+      actionRegistry: new WorkflowActionRegistry({ projectRoot, globalRoot }),
+      projectTrusted: true,
+      defaultActionCwd: repoRoot,
+      runnerId: "runner-a",
+      clock: {
+        nowIso: () => "2026-05-29T00:00:01.000Z",
+        nowMs: () => 1_000,
+      },
+    });
+
+    const result = await runner.run("wfr_deep_review_fix_loop_budget");
+
+    expect(taskCalls.map((call) => call.id)).not.toContain("scope-review-surface-loop-2");
+    expect(applyCalls).toHaveLength(1);
+    expect(result).toMatchObject({
+      structuredOutput: {
+        loop: {
+          completed: false,
+          iterations: 1,
+          remainingFixBudget: 0,
+          stopReason: "fix-budget-exhausted",
+        },
+      },
+    });
+  }, 10_000);
+
+  test("auto-fix loop stops when a fixer reports already-fixed without changing state", async () => {
+    if (!deepReviewWorkflow) {
+      throw new Error("Expected built-in deep-review-workflow workflow");
+    }
+    using tmp = new DisposableTempDir("deep-review-workflow-fix-loop-no-progress");
+    const repoRoot = path.join(tmp.path, "repo");
+    const projectRoot = path.join(tmp.path, "project-actions");
+    const globalRoot = path.join(tmp.path, "global-actions");
+    await fs.mkdir(repoRoot, { recursive: true });
+    await runGit(repoRoot, ["init"]);
+    await runGit(repoRoot, ["config", "user.email", "mux@example.com"]);
+    await runGit(repoRoot, ["config", "user.name", "Mux"]);
+    await fs.writeFile(path.join(repoRoot, "service.ts"), "export const value = 1;\n", "utf-8");
+    await runGit(repoRoot, ["add", "service.ts"]);
+    await runGit(repoRoot, ["commit", "-m", "base commit"]);
+
+    const issue = {
+      id: "already-fixed-noop",
+      severity: "P2",
+      category: "correctness",
+      title: "Already fixed no-op",
+      rationale: "The reviewer still reports this issue.",
+      evidence: "service.ts has a suspected issue.",
+      filePaths: ["service.ts"],
+      suggestedFix: "Confirm whether this is fixed.",
+      validation: "Run targeted tests.",
+      confidence: "high",
+    };
+    const runStore = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    await runStore.createRun({
+      id: "wfr_deep_review_fix_loop_no_progress",
+      workspaceId: "workspace-1",
+      definition: {
+        name: deepReviewWorkflow.name,
+        description: deepReviewWorkflow.description,
+        scope: "built-in",
+        executable: true,
+      },
+      definitionSource: deepReviewWorkflow.source,
+      args: {
+        input: "current workspace changes --fix --loop",
+        maxCandidates: 1,
+        maxLoopIterations: 3,
+      },
+      defaultActionCwd: repoRoot,
+      now: "2026-05-29T00:00:00.000Z",
+    });
+
+    const taskCalls: WorkflowAgentSpec[] = [];
+    const applyCalls: unknown[] = [];
+    const runner = new WorkflowRunner({
+      runStore,
+      runtimeFactory: new QuickJSRuntimeFactory(),
+      taskAdapter: {
+        async runAgent(spec) {
+          taskCalls.push(spec);
+          switch (spec.id) {
+            case "scope-review-surface-loop-1":
+              return {
+                taskId: "task_scope_loop_1",
+                reportMarkdown: "Scoped.",
+                structuredOutput: {
+                  summary: "Review service code.",
+                  files: ["service.ts"],
+                  riskAreas: ["correctness"],
+                  lanes: ["correctness"],
+                },
+              };
+            case "review-correctness-loop-1":
+              return {
+                taskId: "task_review_correctness_loop_1",
+                reportMarkdown: "Finding.",
+                structuredOutput: { issues: [issue] },
+              };
+            case "review-tests-loop-1":
+            case "review-architecture-loop-1":
+              return {
+                taskId: `task_${spec.id}`,
+                reportMarkdown: "No findings.",
+                structuredOutput: { issues: [] },
+              };
+            case "triage-candidate-issues-loop-1":
+              return {
+                taskId: "task_triage_loop_1",
+                reportMarkdown: "One candidate.",
+                structuredOutput: { issues: [issue] },
+              };
+            case "verify-issue-0-loop-1":
+              return {
+                taskId: "task_verify_loop_1",
+                reportMarkdown: "Issue is valid.",
+                structuredOutput: {
+                  issueId: "already-fixed-noop",
+                  verdict: "valid",
+                  confidence: "high",
+                  rationale: "The issue is valid.",
+                },
+              };
+            case "synthesize-review-loop-1":
+              return {
+                taskId: "task_final_loop_1",
+                reportMarkdown: "# Deep Review\n\n- P2 Already fixed no-op.",
+                structuredOutput: {
+                  verifiedIssueCount: 1,
+                  verifiedIssueIds: ["already-fixed-noop"],
+                  risk: "medium",
+                  validationPlan: ["bun test src/service.test.ts"],
+                  discardedIssueCount: 0,
+                },
+              };
+            case "fix-issue-0-loop-1":
+              return {
+                taskId: "task_fix_loop_1",
+                reportMarkdown: "Already fixed.",
+                structuredOutput: {
+                  issueId: "already-fixed-noop",
+                  status: "already-fixed",
+                  summary: "No parent workspace changes were needed.",
+                  validation: [],
+                  commitCreated: false,
+                },
+              };
+            default:
+              throw new Error(`Unexpected deep-review no-progress step: ${spec.id}`);
+          }
+        },
+        async applyPatch(spec) {
+          applyCalls.push(spec);
+          return { success: true, status: "applied", taskId: spec.sourceTaskId };
+        },
+      },
+      actionRegistry: new WorkflowActionRegistry({ projectRoot, globalRoot }),
+      projectTrusted: true,
+      defaultActionCwd: repoRoot,
+      runnerId: "runner-a",
+      clock: {
+        nowIso: () => "2026-05-29T00:00:01.000Z",
+        nowMs: () => 1_000,
+      },
+    });
+
+    const result = await runner.run("wfr_deep_review_fix_loop_no_progress");
+
+    expect(taskCalls.map((call) => call.id)).not.toContain("scope-review-surface-loop-2");
+    expect(applyCalls).toEqual([]);
+    expect(result).toMatchObject({
+      structuredOutput: {
+        loop: {
+          completed: false,
+          iterations: 1,
+          stopReason: "no-fix-progress",
+        },
+      },
+    });
+  }, 10_000);
+
+  test("auto-fix loop stops at maxLoopIterations", async () => {
+    if (!deepReviewWorkflow) {
+      throw new Error("Expected built-in deep-review-workflow workflow");
+    }
+    using tmp = new DisposableTempDir("deep-review-workflow-fix-loop-max-iterations");
+    const repoRoot = path.join(tmp.path, "repo");
+    const projectRoot = path.join(tmp.path, "project-actions");
+    const globalRoot = path.join(tmp.path, "global-actions");
+    await fs.mkdir(repoRoot, { recursive: true });
+    await runGit(repoRoot, ["init"]);
+    await runGit(repoRoot, ["config", "user.email", "mux@example.com"]);
+    await runGit(repoRoot, ["config", "user.name", "Mux"]);
+    await fs.writeFile(path.join(repoRoot, "service.ts"), "export const value = 1;\n", "utf-8");
+    await runGit(repoRoot, ["add", "service.ts"]);
+    await runGit(repoRoot, ["commit", "-m", "base commit"]);
+
+    const issue = {
+      id: "persistent-issue",
+      severity: "P1",
+      category: "correctness",
+      title: "Persistent issue",
+      rationale: "The issue remains verified through the loop cap.",
+      evidence: "service.ts has a persistent issue.",
+      filePaths: ["service.ts"],
+      suggestedFix: "Fix service.ts.",
+      validation: "Run targeted tests.",
+      confidence: "high",
+    };
+    const runStore = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    await runStore.createRun({
+      id: "wfr_deep_review_fix_loop_max_iterations",
+      workspaceId: "workspace-1",
+      definition: {
+        name: deepReviewWorkflow.name,
+        description: deepReviewWorkflow.description,
+        scope: "built-in",
+        executable: true,
+      },
+      definitionSource: deepReviewWorkflow.source,
+      args: {
+        input: "current workspace changes --fix --loop",
+        maxCandidates: 1,
+        maxLoopIterations: 2,
+      },
+      defaultActionCwd: repoRoot,
+      now: "2026-05-29T00:00:00.000Z",
+    });
+
+    const taskCalls: WorkflowAgentSpec[] = [];
+    const applyCalls: unknown[] = [];
+    const runner = new WorkflowRunner({
+      runStore,
+      runtimeFactory: new QuickJSRuntimeFactory(),
+      taskAdapter: {
+        async runAgent(spec) {
+          taskCalls.push(spec);
+          const loopMatch = /-loop-(1|2)$/.exec(spec.id);
+          const iteration = loopMatch?.[1] ?? "";
+          switch (spec.id.replace(/-loop-(1|2)$/, "-loop-N")) {
+            case "scope-review-surface-loop-N":
+              return {
+                taskId: `task_scope_loop_${iteration}`,
+                reportMarkdown: "Scoped.",
+                structuredOutput: {
+                  summary: "Review service code.",
+                  files: ["service.ts"],
+                  riskAreas: ["correctness"],
+                  lanes: ["correctness"],
+                },
+              };
+            case "review-correctness-loop-N":
+              return {
+                taskId: `task_review_correctness_loop_${iteration}`,
+                reportMarkdown: "Finding.",
+                structuredOutput: { issues: [issue] },
+              };
+            case "review-tests-loop-N":
+            case "review-architecture-loop-N":
+              return {
+                taskId: `task_${spec.id}`,
+                reportMarkdown: "No findings.",
+                structuredOutput: { issues: [] },
+              };
+            case "triage-candidate-issues-loop-N":
+              return {
+                taskId: `task_triage_loop_${iteration}`,
+                reportMarkdown: "One candidate.",
+                structuredOutput: { issues: [issue] },
+              };
+            case "verify-issue-0-loop-N":
+              return {
+                taskId: `task_verify_loop_${iteration}`,
+                reportMarkdown: "Issue is valid.",
+                structuredOutput: {
+                  issueId: "persistent-issue",
+                  verdict: "valid",
+                  confidence: "high",
+                  rationale: "The issue remains valid.",
+                },
+              };
+            case "synthesize-review-loop-N":
+              return {
+                taskId: `task_final_loop_${iteration}`,
+                reportMarkdown: "# Deep Review\n\n- P1 Persistent issue.",
+                structuredOutput: {
+                  verifiedIssueCount: 1,
+                  verifiedIssueIds: ["persistent-issue"],
+                  risk: "medium",
+                  validationPlan: ["bun test src/service.test.ts"],
+                  discardedIssueCount: 0,
+                },
+              };
+            case "fix-issue-0-loop-N":
+              return {
+                taskId: `task_fix_loop_${iteration}`,
+                reportMarkdown: "Fixed persistent issue.",
+                structuredOutput: {
+                  issueId: "persistent-issue",
+                  status: "fixed",
+                  summary: "Fixed service.ts.",
+                  validation: ["bun test src/service.test.ts"],
+                  commitCreated: true,
+                },
+              };
+            case "validate-auto-fixes-loop-N":
+              return {
+                taskId: `task_validate_loop_${iteration}`,
+                reportMarkdown: "Validation passed.",
+                structuredOutput: {
+                  status: "passed",
+                  commands: ["bun test src/service.test.ts"],
+                  summary: "Targeted tests passed.",
+                  failures: [],
+                },
+              };
+            default:
+              throw new Error(`Unexpected deep-review max-iterations step: ${spec.id}`);
+          }
+        },
+        async applyPatch(spec) {
+          applyCalls.push(spec);
+          return {
+            success: true,
+            status: "applied",
+            taskId: spec.sourceTaskId,
+            projectResults: [{ projectPath: repoRoot, projectName: "repo", status: "applied" }],
+          };
+        },
+      },
+      actionRegistry: new WorkflowActionRegistry({ projectRoot, globalRoot }),
+      projectTrusted: true,
+      defaultActionCwd: repoRoot,
+      runnerId: "runner-a",
+      clock: {
+        nowIso: () => "2026-05-29T00:00:01.000Z",
+        nowMs: () => 1_000,
+      },
+    });
+
+    const result = await runner.run("wfr_deep_review_fix_loop_max_iterations");
+    const callIds = taskCalls.map((call) => call.id);
+
+    expect(callIds).toContain("scope-review-surface-loop-2");
+    expect(callIds).not.toContain("scope-review-surface-loop-3");
+    expect(applyCalls).toHaveLength(2);
+    expect(result).toMatchObject({
+      structuredOutput: {
+        loop: {
+          completed: false,
+          iterations: 2,
+          remainingFixBudget: 3,
+          stopReason: "max-iterations",
+        },
+      },
+    });
+  }, 10_000);
+
   test("auto-fix uses final synthesis issue IDs and rejects mismatched fixer output", async () => {
     if (!deepReviewWorkflow) {
       throw new Error("Expected built-in deep-review-workflow workflow");
@@ -2378,6 +3155,47 @@ describe("built-in deep-review-workflow", () => {
         },
       },
     });
+  }, 10_000);
+
+  test("--loop without --fix fails before spawning review agents", async () => {
+    if (!deepReviewWorkflow) {
+      throw new Error("Expected built-in deep-review-workflow workflow");
+    }
+    using tmp = new DisposableTempDir("deep-review-workflow-loop-without-fix");
+    const runStore = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    await runStore.createRun({
+      id: "wfr_deep_review_loop_without_fix",
+      workspaceId: "workspace-1",
+      definition: {
+        name: deepReviewWorkflow.name,
+        description: deepReviewWorkflow.description,
+        scope: "built-in",
+        executable: true,
+      },
+      definitionSource: deepReviewWorkflow.source,
+      args: { input: "current workspace changes --loop", maxCandidates: 1 },
+      now: "2026-05-29T00:00:00.000Z",
+    });
+    const taskCalls: WorkflowAgentSpec[] = [];
+    const runner = new WorkflowRunner({
+      runStore,
+      runtimeFactory: new QuickJSRuntimeFactory(),
+      taskAdapter: createNoIssueDeepReviewTaskAdapter(taskCalls),
+      runnerId: "runner-a",
+      clock: {
+        nowIso: () => "2026-05-29T00:00:01.000Z",
+        nowMs: () => 1_000,
+      },
+    });
+
+    let rejectionMessage = "";
+    try {
+      await runner.run("wfr_deep_review_loop_without_fix");
+    } catch (error) {
+      rejectionMessage = error instanceof Error ? error.message : String(error);
+    }
+    expect(rejectionMessage).toContain("--loop requires --fix for deep-review-workflow");
+    expect(taskCalls).toEqual([]);
   }, 10_000);
 
   test("auto-fix skips explicit diff targets and does not spawn fixers", async () => {

--- a/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
+++ b/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
@@ -27,6 +27,11 @@ async function runGit(cwd: string, args: string[]): Promise<void> {
   await execFileAsync("git", args, { cwd });
 }
 
+async function readGit(cwd: string, args: string[]): Promise<string> {
+  const result = await execFileAsync("git", args, { cwd });
+  return result.stdout.trimEnd();
+}
+
 function createNoIssueDeepReviewTaskAdapter(taskCalls: WorkflowAgentSpec[]) {
   return {
     async runAgent(spec: WorkflowAgentSpec) {
@@ -1794,7 +1799,7 @@ describe("built-in deep-review-workflow", () => {
         final: { verifiedIssueCount: 1 },
       },
     });
-  }, 10_000);
+  }, 20_000);
 
   test("auto-fix loop stops when a fixer reports already-fixed without changing state", async () => {
     if (!deepReviewWorkflow) {
@@ -2117,6 +2122,176 @@ describe("built-in deep-review-workflow", () => {
           iterations: 1,
           remainingFixBudget: 4,
           stopReason: "validation-failed",
+        },
+      },
+    });
+  }, 10_000);
+
+  test("auto-fix loop stops when validation is not run", async () => {
+    if (!deepReviewWorkflow) {
+      throw new Error("Expected built-in deep-review-workflow workflow");
+    }
+    using tmp = new DisposableTempDir("deep-review-workflow-fix-loop-validation-not-run");
+    const repoRoot = path.join(tmp.path, "repo");
+    const projectRoot = path.join(tmp.path, "project-actions");
+    const globalRoot = path.join(tmp.path, "global-actions");
+    await fs.mkdir(repoRoot, { recursive: true });
+    await runGit(repoRoot, ["init"]);
+    await runGit(repoRoot, ["config", "user.email", "mux@example.com"]);
+    await runGit(repoRoot, ["config", "user.name", "Mux"]);
+    await fs.writeFile(path.join(repoRoot, "service.ts"), "export const value = 1;\n", "utf-8");
+    await runGit(repoRoot, ["add", "service.ts"]);
+    await runGit(repoRoot, ["commit", "-m", "base commit"]);
+
+    const issue = {
+      id: "validation-not-run",
+      severity: "P1",
+      category: "correctness",
+      title: "Validation was not run after fix",
+      rationale: "The fix loop must stop unless validation passes.",
+      evidence: "service.ts has a bug.",
+      filePaths: ["service.ts"],
+      suggestedFix: "Fix service.ts.",
+      validation: "Run targeted tests.",
+      confidence: "high",
+    };
+    const runStore = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    await runStore.createRun({
+      id: "wfr_deep_review_fix_loop_validation_not_run",
+      workspaceId: "workspace-1",
+      definition: {
+        name: deepReviewWorkflow.name,
+        description: deepReviewWorkflow.description,
+        scope: "built-in",
+        executable: true,
+      },
+      definitionSource: deepReviewWorkflow.source,
+      args: {
+        input: "current workspace changes --fix --loop",
+        maxCandidates: 1,
+        maxLoopIterations: 3,
+      },
+      defaultActionCwd: repoRoot,
+      now: "2026-05-29T00:00:00.000Z",
+    });
+
+    const taskCalls: WorkflowAgentSpec[] = [];
+    const runner = new WorkflowRunner({
+      runStore,
+      runtimeFactory: new QuickJSRuntimeFactory(),
+      taskAdapter: {
+        async runAgent(spec) {
+          taskCalls.push(spec);
+          switch (spec.id) {
+            case "scope-review-surface-loop-1":
+              return {
+                taskId: "task_scope_loop_1",
+                reportMarkdown: "Scoped.",
+                structuredOutput: {
+                  summary: "Review service code.",
+                  files: ["service.ts"],
+                  riskAreas: ["correctness"],
+                  lanes: ["correctness"],
+                },
+              };
+            case "review-correctness-loop-1":
+              return {
+                taskId: "task_review_correctness_loop_1",
+                reportMarkdown: "Finding.",
+                structuredOutput: { issues: [issue] },
+              };
+            case "review-tests-loop-1":
+            case "review-architecture-loop-1":
+              return {
+                taskId: `task_${spec.id}`,
+                reportMarkdown: "No findings.",
+                structuredOutput: { issues: [] },
+              };
+            case "triage-candidate-issues-loop-1":
+              return {
+                taskId: "task_triage_loop_1",
+                reportMarkdown: "One candidate.",
+                structuredOutput: { issues: [issue] },
+              };
+            case "verify-issue-0-loop-1":
+              return {
+                taskId: "task_verify_loop_1",
+                reportMarkdown: "Issue is valid.",
+                structuredOutput: {
+                  issueId: "validation-not-run",
+                  verdict: "valid",
+                  confidence: "high",
+                  rationale: "The issue is valid.",
+                },
+              };
+            case "synthesize-review-loop-1":
+              return {
+                taskId: "task_final_loop_1",
+                reportMarkdown: "# Deep Review\n\n- P1 Validation was not run after fix.",
+                structuredOutput: {
+                  verifiedIssueCount: 1,
+                  verifiedIssueIds: ["validation-not-run"],
+                  risk: "medium",
+                  validationPlan: ["bun test src/service.test.ts"],
+                  discardedIssueCount: 0,
+                },
+              };
+            case "fix-issue-0-loop-1":
+              return {
+                taskId: "task_fix_loop_1",
+                reportMarkdown: "Fixed issue.",
+                structuredOutput: {
+                  issueId: "validation-not-run",
+                  status: "fixed",
+                  summary: "Fixed service.ts.",
+                  validation: [],
+                  commitCreated: true,
+                },
+              };
+            case "validate-auto-fixes-loop-1":
+              return {
+                taskId: "task_validate_loop_1",
+                reportMarkdown: "Validation was not run.",
+                structuredOutput: {
+                  status: "not-run",
+                  commands: [],
+                  summary: "No validation commands were run.",
+                  failures: [],
+                },
+              };
+            default:
+              throw new Error(`Unexpected deep-review validation-not-run step: ${spec.id}`);
+          }
+        },
+        async applyPatch(spec) {
+          return {
+            success: true,
+            status: "applied",
+            taskId: spec.sourceTaskId,
+            projectResults: [{ projectPath: repoRoot, projectName: "repo", status: "applied" }],
+          };
+        },
+      },
+      actionRegistry: new WorkflowActionRegistry({ projectRoot, globalRoot }),
+      projectTrusted: true,
+      defaultActionCwd: repoRoot,
+      runnerId: "runner-a",
+      clock: {
+        nowIso: () => "2026-05-29T00:00:01.000Z",
+        nowMs: () => 1_000,
+      },
+    });
+
+    const result = await runner.run("wfr_deep_review_fix_loop_validation_not_run");
+
+    expect(taskCalls.map((call) => call.id)).not.toContain("scope-review-surface-loop-2");
+    expect(result).toMatchObject({
+      structuredOutput: {
+        loop: {
+          completed: false,
+          iterations: 1,
+          remainingFixBudget: 4,
+          stopReason: "validation-not-run",
         },
       },
     });
@@ -3006,11 +3181,150 @@ describe("built-in deep-review-workflow", () => {
     });
   }, 10_000);
 
-  test("auto-fix skips non-current branch refs that resolve to current HEAD", async () => {
+  test("auto-fix skips detached HEAD checkouts", async () => {
     if (!deepReviewWorkflow) {
       throw new Error("Expected built-in deep-review-workflow workflow");
     }
-    using tmp = new DisposableTempDir("deep-review-workflow-fix-non-current-ref");
+    using tmp = new DisposableTempDir("deep-review-workflow-fix-detached-head");
+    const repoRoot = path.join(tmp.path, "repo");
+    const projectRoot = path.join(tmp.path, "project-actions");
+    const globalRoot = path.join(tmp.path, "global-actions");
+    await fs.mkdir(repoRoot, { recursive: true });
+    await runGit(repoRoot, ["init"]);
+    await runGit(repoRoot, ["config", "user.email", "mux@example.com"]);
+    await runGit(repoRoot, ["config", "user.name", "Mux"]);
+    await fs.writeFile(path.join(repoRoot, "service.ts"), "export const value = 1;\n", "utf-8");
+    await runGit(repoRoot, ["add", "service.ts"]);
+    await runGit(repoRoot, ["commit", "-m", "base commit"]);
+    await runGit(repoRoot, ["checkout", "--detach", "HEAD"]);
+
+    const issue = {
+      id: "detached-head",
+      severity: "P2",
+      category: "correctness",
+      title: "Detached HEAD should not auto-fix",
+      rationale: "Auto-fix commits need a real checked-out branch.",
+      evidence: "The repository is detached at HEAD.",
+      filePaths: ["service.ts"],
+      suggestedFix: "Skip auto-fix while detached.",
+      validation: "Run targeted workflow tests.",
+      confidence: "high",
+    };
+    const runStore = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    await runStore.createRun({
+      id: "wfr_deep_review_fix_detached_head",
+      workspaceId: "workspace-1",
+      definition: {
+        name: deepReviewWorkflow.name,
+        description: deepReviewWorkflow.description,
+        scope: "built-in",
+        executable: true,
+      },
+      definitionSource: deepReviewWorkflow.source,
+      args: { fix: true, input: "current workspace changes", maxCandidates: 1 },
+      defaultActionCwd: repoRoot,
+      now: "2026-05-29T00:00:00.000Z",
+    });
+
+    const taskCalls: WorkflowAgentSpec[] = [];
+    const applyCalls: unknown[] = [];
+    const runner = new WorkflowRunner({
+      runStore,
+      runtimeFactory: new QuickJSRuntimeFactory(),
+      taskAdapter: {
+        async runAgent(spec) {
+          taskCalls.push(spec);
+          switch (spec.id) {
+            case "scope-review-surface":
+              return {
+                taskId: "task_scope",
+                reportMarkdown: "Scoped.",
+                structuredOutput: {
+                  summary: "Review service code.",
+                  files: ["service.ts"],
+                  riskAreas: ["correctness"],
+                  lanes: ["correctness"],
+                },
+              };
+            case "review-correctness":
+            case "review-tests":
+            case "review-architecture":
+              return {
+                taskId: `task_${spec.id}`,
+                reportMarkdown: "Findings.",
+                structuredOutput: { issues: spec.id === "review-correctness" ? [issue] : [] },
+              };
+            case "triage-candidate-issues":
+              return {
+                taskId: "task_triage",
+                reportMarkdown: "One candidate.",
+                structuredOutput: { issues: [issue] },
+              };
+            case "verify-issue-0":
+              return {
+                taskId: "task_verify_0",
+                reportMarkdown: "Issue is valid.",
+                structuredOutput: {
+                  issueId: "detached-head",
+                  verdict: "valid",
+                  confidence: "high",
+                  rationale: "The issue is valid.",
+                },
+              };
+            case "synthesize-review":
+              return {
+                taskId: "task_final",
+                reportMarkdown: "# Deep Review\n\n- P2 Detached HEAD should not auto-fix.",
+                structuredOutput: {
+                  verifiedIssueCount: 1,
+                  verifiedIssueIds: ["detached-head"],
+                  risk: "medium",
+                  validationPlan: ["bun test src/service.test.ts"],
+                  discardedIssueCount: 0,
+                },
+              };
+            default:
+              throw new Error(`Unexpected detached HEAD step: ${spec.id}`);
+          }
+        },
+        async applyPatch(spec) {
+          applyCalls.push(spec);
+          return { success: true, status: "applied", taskId: spec.sourceTaskId };
+        },
+      },
+      actionRegistry: new WorkflowActionRegistry({ projectRoot, globalRoot }),
+      projectTrusted: true,
+      defaultActionCwd: repoRoot,
+      runnerId: "runner-a",
+      clock: {
+        nowIso: () => "2026-05-29T00:00:01.000Z",
+        nowMs: () => 1_000,
+      },
+    });
+
+    const result = await runner.run("wfr_deep_review_fix_detached_head");
+
+    expect(taskCalls.map((call) => call.id)).not.toContain("fix-issue-0");
+    expect(applyCalls).toEqual([]);
+    expect(result.reportMarkdown).toContain(
+      "auto-fix requires a reviewed Git branch and HEAD snapshot"
+    );
+    expect(result).toMatchObject({
+      structuredOutput: {
+        fix: {
+          requested: true,
+          skippedReason: "auto-fix requires a reviewed Git branch and HEAD snapshot",
+          selectedIssues: [],
+        },
+      },
+    });
+  }, 10_000);
+
+  test("auto-fix skips hex-like non-current branch refs that resolve to current HEAD", async () => {
+    if (!deepReviewWorkflow) {
+      throw new Error("Expected built-in deep-review-workflow workflow");
+    }
+    using tmp = new DisposableTempDir("deep-review-workflow-fix-hex-non-current-ref");
     const repoRoot = path.join(tmp.path, "repo");
     const projectRoot = path.join(tmp.path, "project-actions");
     const globalRoot = path.join(tmp.path, "global-actions");
@@ -3022,7 +3336,7 @@ describe("built-in deep-review-workflow", () => {
     await runGit(repoRoot, ["add", "service.ts"]);
     await runGit(repoRoot, ["commit", "-m", "base commit"]);
     await runGit(repoRoot, ["branch", "-M", "main"]);
-    await runGit(repoRoot, ["branch", "feature"]);
+    await runGit(repoRoot, ["branch", "deadbee"]);
 
     const issue = {
       id: "non-current-ref",
@@ -3030,7 +3344,7 @@ describe("built-in deep-review-workflow", () => {
       category: "correctness",
       title: "Non-current ref should not auto-fix",
       rationale: "The reviewed head names a different branch than the checkout.",
-      evidence: "feature points at the same commit as main.",
+      evidence: "deadbee points at the same commit as main.",
       filePaths: ["service.ts"],
       suggestedFix: "Skip auto-fix unless that branch is checked out.",
       validation: "Run targeted workflow tests.",
@@ -3047,7 +3361,7 @@ describe("built-in deep-review-workflow", () => {
         executable: true,
       },
       definitionSource: deepReviewWorkflow.source,
-      args: { fix: true, input: "current workspace changes", headRef: "feature", maxCandidates: 1 },
+      args: { fix: true, input: "current workspace changes", headRef: "deadbee", maxCandidates: 1 },
       defaultActionCwd: repoRoot,
       now: "2026-05-29T00:00:00.000Z",
     });
@@ -3281,6 +3595,196 @@ describe("built-in deep-review-workflow", () => {
           requested: true,
           skippedReason: "auto-fix requires the current Git HEAD to match the reviewed snapshot",
           selectedIssues: [],
+        },
+      },
+    });
+  }, 10_000);
+
+  test("auto-fix checkpoint retry preserves completed patch after HEAD advances", async () => {
+    if (!deepReviewWorkflow) {
+      throw new Error("Expected built-in deep-review-workflow workflow");
+    }
+    using tmp = new DisposableTempDir("deep-review-workflow-fix-replay-head-advance");
+    const repoRoot = path.join(tmp.path, "repo");
+    const projectRoot = path.join(tmp.path, "project-actions");
+    const globalRoot = path.join(tmp.path, "global-actions");
+    await fs.mkdir(repoRoot, { recursive: true });
+    await runGit(repoRoot, ["init"]);
+    await runGit(repoRoot, ["config", "user.email", "mux@example.com"]);
+    await runGit(repoRoot, ["config", "user.name", "Mux"]);
+    await fs.writeFile(path.join(repoRoot, "service.ts"), "export const value = 1;\n", "utf-8");
+    await runGit(repoRoot, ["add", "service.ts"]);
+    await runGit(repoRoot, ["commit", "-m", "base commit"]);
+    const baseHead = await readGit(repoRoot, ["rev-parse", "HEAD"]);
+
+    const issue = {
+      id: "replay-head-advance",
+      severity: "P1",
+      category: "correctness",
+      title: "Replay must preserve applied patch progress",
+      rationale: "A retry should not rerun preflight against the post-patch HEAD.",
+      evidence: "service.ts needs a fix.",
+      filePaths: ["service.ts"],
+      suggestedFix: "Fix service.ts.",
+      validation: "Run targeted tests.",
+      confidence: "high",
+    };
+    const runStore = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    await runStore.createRun({
+      id: "wfr_deep_review_fix_replay_head_advance",
+      workspaceId: "workspace-1",
+      definition: {
+        name: deepReviewWorkflow.name,
+        description: deepReviewWorkflow.description,
+        scope: "built-in",
+        executable: true,
+      },
+      definitionSource: deepReviewWorkflow.source,
+      args: { fix: true, input: "current workspace changes", maxCandidates: 1 },
+      defaultActionCwd: repoRoot,
+      now: "2026-05-29T00:00:00.000Z",
+    });
+
+    const taskCalls: WorkflowAgentSpec[] = [];
+    const applyCalls: unknown[] = [];
+    let validationCalls = 0;
+    const runner = new WorkflowRunner({
+      runStore,
+      runtimeFactory: new QuickJSRuntimeFactory(),
+      taskAdapter: {
+        async runAgent(spec) {
+          taskCalls.push(spec);
+          switch (spec.id) {
+            case "scope-review-surface":
+              return {
+                taskId: "task_scope",
+                reportMarkdown: "Scoped.",
+                structuredOutput: {
+                  summary: "Review service code.",
+                  files: ["service.ts"],
+                  riskAreas: ["correctness"],
+                  lanes: ["correctness"],
+                },
+              };
+            case "review-correctness":
+            case "review-tests":
+            case "review-architecture":
+              return {
+                taskId: `task_${spec.id}`,
+                reportMarkdown: "Findings.",
+                structuredOutput: { issues: spec.id === "review-correctness" ? [issue] : [] },
+              };
+            case "triage-candidate-issues":
+              return {
+                taskId: "task_triage",
+                reportMarkdown: "One candidate.",
+                structuredOutput: { issues: [issue] },
+              };
+            case "verify-issue-0":
+              return {
+                taskId: "task_verify_0",
+                reportMarkdown: "Issue is valid.",
+                structuredOutput: {
+                  issueId: "replay-head-advance",
+                  verdict: "valid",
+                  confidence: "high",
+                  rationale: "The issue is valid.",
+                },
+              };
+            case "synthesize-review":
+              return {
+                taskId: "task_final",
+                reportMarkdown:
+                  "# Deep Review\n\n- P1 Replay must preserve applied patch progress.",
+                structuredOutput: {
+                  verifiedIssueCount: 1,
+                  verifiedIssueIds: ["replay-head-advance"],
+                  risk: "medium",
+                  validationPlan: ["bun test src/service.test.ts"],
+                  discardedIssueCount: 0,
+                },
+              };
+            case "fix-issue-0":
+              return {
+                taskId: "task_fix_0",
+                reportMarkdown: "Fixed issue.",
+                structuredOutput: {
+                  issueId: "replay-head-advance",
+                  status: "fixed",
+                  summary: "Fixed service.ts.",
+                  validation: ["bun test src/service.test.ts"],
+                  commitCreated: true,
+                },
+              };
+            case "validate-auto-fixes":
+              validationCalls += 1;
+              if (validationCalls === 1) {
+                throw new Error("Execution interrupted");
+              }
+              return {
+                taskId: "task_validate_retry",
+                reportMarkdown: "Validation passed.",
+                structuredOutput: {
+                  status: "passed",
+                  commands: ["bun test src/service.test.ts"],
+                  summary: "Targeted tests passed.",
+                  failures: [],
+                },
+              };
+            default:
+              throw new Error(`Unexpected replay head advance step: ${spec.id}`);
+          }
+        },
+        async applyPatch(spec) {
+          applyCalls.push(spec);
+          await fs.writeFile(
+            path.join(repoRoot, "service.ts"),
+            "export const value = 2;\n",
+            "utf-8"
+          );
+          await runGit(repoRoot, ["add", "service.ts"]);
+          await runGit(repoRoot, ["commit", "-m", "apply auto-fix"]);
+          return {
+            success: true,
+            status: "applied",
+            taskId: spec.sourceTaskId,
+            headCommitSha: await readGit(repoRoot, ["rev-parse", "HEAD"]),
+            projectResults: [{ projectPath: repoRoot, projectName: "repo", status: "applied" }],
+          };
+        },
+      },
+      actionRegistry: new WorkflowActionRegistry({ projectRoot, globalRoot }),
+      projectTrusted: true,
+      defaultActionCwd: repoRoot,
+      runnerId: "runner-a",
+      clock: {
+        nowIso: () => "2026-05-29T00:00:01.000Z",
+        nowMs: () => 1_000,
+      },
+    });
+
+    let firstFailure = "";
+    try {
+      await runner.run("wfr_deep_review_fix_replay_head_advance");
+    } catch (error) {
+      firstFailure = error instanceof Error ? error.message : String(error);
+    }
+    expect(firstFailure).toContain("Execution interrupted");
+    expect(await readGit(repoRoot, ["rev-parse", "HEAD"])).not.toBe(baseHead);
+
+    const retryResult = await runner.run("wfr_deep_review_fix_replay_head_advance", {
+      allowRetryFromFailedCheckpoint: true,
+    });
+
+    expect(applyCalls).toHaveLength(1);
+    expect(validationCalls).toBe(2);
+    expect(taskCalls.map((call) => call.id)).toContain("validate-auto-fixes");
+    expect(retryResult).toMatchObject({
+      structuredOutput: {
+        fix: {
+          requested: true,
+          applications: [{ status: "applied" }],
+          validation: { status: "passed" },
         },
       },
     });

--- a/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
+++ b/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
@@ -2821,6 +2821,147 @@ describe("built-in deep-review-workflow", () => {
     });
   }, 10_000);
 
+  test("auto-fix skips non-current branch refs that resolve to current HEAD", async () => {
+    if (!deepReviewWorkflow) {
+      throw new Error("Expected built-in deep-review-workflow workflow");
+    }
+    using tmp = new DisposableTempDir("deep-review-workflow-fix-non-current-ref");
+    const repoRoot = path.join(tmp.path, "repo");
+    const projectRoot = path.join(tmp.path, "project-actions");
+    const globalRoot = path.join(tmp.path, "global-actions");
+    await fs.mkdir(repoRoot, { recursive: true });
+    await runGit(repoRoot, ["init"]);
+    await runGit(repoRoot, ["config", "user.email", "mux@example.com"]);
+    await runGit(repoRoot, ["config", "user.name", "Mux"]);
+    await fs.writeFile(path.join(repoRoot, "service.ts"), "export const value = 1;\n", "utf-8");
+    await runGit(repoRoot, ["add", "service.ts"]);
+    await runGit(repoRoot, ["commit", "-m", "base commit"]);
+    await runGit(repoRoot, ["branch", "-M", "main"]);
+    await runGit(repoRoot, ["branch", "feature"]);
+
+    const issue = {
+      id: "non-current-ref",
+      severity: "P2",
+      category: "correctness",
+      title: "Non-current ref should not auto-fix",
+      rationale: "The reviewed head names a different branch than the checkout.",
+      evidence: "feature points at the same commit as main.",
+      filePaths: ["service.ts"],
+      suggestedFix: "Skip auto-fix unless that branch is checked out.",
+      validation: "Run targeted workflow tests.",
+      confidence: "high",
+    };
+    const runStore = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    await runStore.createRun({
+      id: "wfr_deep_review_fix_non_current_ref",
+      workspaceId: "workspace-1",
+      definition: {
+        name: deepReviewWorkflow.name,
+        description: deepReviewWorkflow.description,
+        scope: "built-in",
+        executable: true,
+      },
+      definitionSource: deepReviewWorkflow.source,
+      args: { fix: true, input: "current workspace changes", headRef: "feature", maxCandidates: 1 },
+      defaultActionCwd: repoRoot,
+      now: "2026-05-29T00:00:00.000Z",
+    });
+
+    const taskCalls: WorkflowAgentSpec[] = [];
+    const applyCalls: unknown[] = [];
+    const runner = new WorkflowRunner({
+      runStore,
+      runtimeFactory: new QuickJSRuntimeFactory(),
+      taskAdapter: {
+        async runAgent(spec) {
+          taskCalls.push(spec);
+          switch (spec.id) {
+            case "scope-review-surface":
+              return {
+                taskId: "task_scope",
+                reportMarkdown: "Scoped.",
+                structuredOutput: {
+                  summary: "Review service code.",
+                  files: ["service.ts"],
+                  riskAreas: ["correctness"],
+                  lanes: ["correctness"],
+                },
+              };
+            case "review-correctness":
+            case "review-tests":
+            case "review-architecture":
+              return {
+                taskId: `task_${spec.id}`,
+                reportMarkdown: "Findings.",
+                structuredOutput: { issues: spec.id === "review-correctness" ? [issue] : [] },
+              };
+            case "triage-candidate-issues":
+              return {
+                taskId: "task_triage",
+                reportMarkdown: "One candidate.",
+                structuredOutput: { issues: [issue] },
+              };
+            case "verify-issue-0":
+              return {
+                taskId: "task_verify_0",
+                reportMarkdown: "Issue is valid.",
+                structuredOutput: {
+                  issueId: "non-current-ref",
+                  verdict: "valid",
+                  confidence: "high",
+                  rationale: "The issue is valid.",
+                },
+              };
+            case "synthesize-review":
+              return {
+                taskId: "task_final",
+                reportMarkdown: "# Deep Review\n\n- P2 Non-current ref should not auto-fix.",
+                structuredOutput: {
+                  verifiedIssueCount: 1,
+                  verifiedIssueIds: ["non-current-ref"],
+                  risk: "medium",
+                  validationPlan: ["bun test src/service.test.ts"],
+                  discardedIssueCount: 0,
+                },
+              };
+            default:
+              throw new Error(`Unexpected non-current ref step: ${spec.id}`);
+          }
+        },
+        async applyPatch(spec) {
+          applyCalls.push(spec);
+          return { success: true, status: "applied", taskId: spec.sourceTaskId };
+        },
+      },
+      actionRegistry: new WorkflowActionRegistry({ projectRoot, globalRoot }),
+      projectTrusted: true,
+      defaultActionCwd: repoRoot,
+      runnerId: "runner-a",
+      clock: {
+        nowIso: () => "2026-05-29T00:00:01.000Z",
+        nowMs: () => 1_000,
+      },
+    });
+
+    const result = await runner.run("wfr_deep_review_fix_non_current_ref");
+
+    expect(taskCalls.map((call) => call.id)).not.toContain("fix-issue-0");
+    expect(applyCalls).toEqual([]);
+    expect(result.reportMarkdown).toContain(
+      "auto-fix requires the reviewed head ref to be the current checked-out branch"
+    );
+    expect(result).toMatchObject({
+      structuredOutput: {
+        fix: {
+          requested: true,
+          skippedReason:
+            "auto-fix requires the reviewed head ref to be the current checked-out branch",
+          selectedIssues: [],
+        },
+      },
+    });
+  }, 10_000);
+
   test("auto-fix skips when same-branch HEAD changes after review context is captured", async () => {
     if (!deepReviewWorkflow) {
       throw new Error("Expected built-in deep-review-workflow workflow");

--- a/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
+++ b/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
@@ -1611,6 +1611,191 @@ describe("built-in deep-review-workflow", () => {
     });
   }, 10_000);
 
+  test("auto-fix loop reports exhausted fix budget when verified issues remain", async () => {
+    if (!deepReviewWorkflow) {
+      throw new Error("Expected built-in deep-review-workflow workflow");
+    }
+    using tmp = new DisposableTempDir("deep-review-workflow-fix-loop-budget-exhausted");
+    const repoRoot = path.join(tmp.path, "repo");
+    const projectRoot = path.join(tmp.path, "project-actions");
+    const globalRoot = path.join(tmp.path, "global-actions");
+    await fs.mkdir(repoRoot, { recursive: true });
+    await runGit(repoRoot, ["init"]);
+    await runGit(repoRoot, ["config", "user.email", "mux@example.com"]);
+    await runGit(repoRoot, ["config", "user.name", "Mux"]);
+    await fs.writeFile(path.join(repoRoot, "service.ts"), "export const value = 1;\n", "utf-8");
+    await runGit(repoRoot, ["add", "service.ts"]);
+    await runGit(repoRoot, ["commit", "-m", "base commit"]);
+
+    const issue = {
+      id: "persistent-budgeted-fix",
+      severity: "P1",
+      category: "correctness",
+      title: "Persistent budgeted fix",
+      rationale: "The issue remains after the one allowed fixer.",
+      evidence: "service.ts still has a bug.",
+      filePaths: ["service.ts"],
+      suggestedFix: "Fix service.ts.",
+      validation: "Run targeted tests.",
+      confidence: "high",
+    };
+    const runStore = new WorkflowRunStore({ sessionDir: tmp.path, staleLeaseMs: 10 });
+    await runStore.createRun({
+      id: "wfr_deep_review_fix_loop_budget_exhausted",
+      workspaceId: "workspace-1",
+      definition: {
+        name: deepReviewWorkflow.name,
+        description: deepReviewWorkflow.description,
+        scope: "built-in",
+        executable: true,
+      },
+      definitionSource: deepReviewWorkflow.source,
+      args: {
+        input: "current workspace changes --fix --loop",
+        maxCandidates: 1,
+        maxFixes: 1,
+        maxLoopIterations: 3,
+      },
+      defaultActionCwd: repoRoot,
+      now: "2026-05-29T00:00:00.000Z",
+    });
+
+    const taskCalls: WorkflowAgentSpec[] = [];
+    const applyCalls: unknown[] = [];
+    const runner = new WorkflowRunner({
+      runStore,
+      runtimeFactory: new QuickJSRuntimeFactory(),
+      taskAdapter: {
+        async runAgent(spec) {
+          taskCalls.push(spec);
+          switch (spec.id) {
+            case "scope-review-surface-loop-1":
+            case "scope-review-surface-loop-2":
+              return {
+                taskId: `task_${spec.id}`,
+                reportMarkdown: "Scoped.",
+                structuredOutput: {
+                  summary: "Review service code.",
+                  files: ["service.ts"],
+                  riskAreas: ["correctness"],
+                  lanes: ["correctness"],
+                },
+              };
+            case "review-correctness-loop-1":
+            case "review-correctness-loop-2":
+              return {
+                taskId: `task_${spec.id}`,
+                reportMarkdown: "Finding.",
+                structuredOutput: { issues: [issue] },
+              };
+            case "review-tests-loop-1":
+            case "review-architecture-loop-1":
+            case "review-tests-loop-2":
+            case "review-architecture-loop-2":
+              return {
+                taskId: `task_${spec.id}`,
+                reportMarkdown: "No findings.",
+                structuredOutput: { issues: [] },
+              };
+            case "triage-candidate-issues-loop-1":
+            case "triage-candidate-issues-loop-2":
+              return {
+                taskId: `task_${spec.id}`,
+                reportMarkdown: "One candidate.",
+                structuredOutput: { issues: [issue] },
+              };
+            case "verify-issue-0-loop-1":
+            case "verify-issue-0-loop-2":
+              return {
+                taskId: `task_${spec.id}`,
+                reportMarkdown: "Issue is valid.",
+                structuredOutput: {
+                  issueId: "persistent-budgeted-fix",
+                  verdict: "valid",
+                  confidence: "high",
+                  rationale: "The issue remains valid.",
+                },
+              };
+            case "synthesize-review-loop-1":
+            case "synthesize-review-loop-2":
+              return {
+                taskId: `task_${spec.id}`,
+                reportMarkdown: "# Deep Review\n\n- P1 Persistent budgeted fix.",
+                structuredOutput: {
+                  verifiedIssueCount: 1,
+                  verifiedIssueIds: ["persistent-budgeted-fix"],
+                  risk: "medium",
+                  validationPlan: ["bun test src/service.test.ts"],
+                  discardedIssueCount: 0,
+                },
+              };
+            case "fix-issue-0-loop-1":
+              return {
+                taskId: "task_fix_loop_1",
+                reportMarkdown: "Fixed budgeted issue.",
+                structuredOutput: {
+                  issueId: "persistent-budgeted-fix",
+                  status: "fixed",
+                  summary: "Fixed service.ts.",
+                  validation: ["bun test src/service.test.ts"],
+                  commitCreated: true,
+                },
+              };
+            case "validate-auto-fixes-loop-1":
+              return {
+                taskId: "task_validate_loop_1",
+                reportMarkdown: "Validation passed.",
+                structuredOutput: {
+                  status: "passed",
+                  commands: ["bun test src/service.test.ts"],
+                  summary: "Targeted tests passed.",
+                  failures: [],
+                },
+              };
+            default:
+              throw new Error(`Unexpected deep-review budget-exhausted step: ${spec.id}`);
+          }
+        },
+        async applyPatch(spec) {
+          applyCalls.push(spec);
+          return {
+            success: true,
+            status: "applied",
+            taskId: spec.sourceTaskId,
+            projectResults: [{ projectPath: repoRoot, projectName: "repo", status: "applied" }],
+          };
+        },
+      },
+      actionRegistry: new WorkflowActionRegistry({ projectRoot, globalRoot }),
+      projectTrusted: true,
+      defaultActionCwd: repoRoot,
+      runnerId: "runner-a",
+      clock: {
+        nowIso: () => "2026-05-29T00:00:01.000Z",
+        nowMs: () => 1_000,
+      },
+    });
+
+    const result = await runner.run("wfr_deep_review_fix_loop_budget_exhausted");
+
+    const callIds = taskCalls.map((call) => call.id);
+    expect(callIds).toContain("scope-review-surface-loop-2");
+    expect(callIds).not.toContain("fix-issue-0-loop-2");
+    expect(callIds).not.toContain("scope-review-surface-loop-3");
+    expect(applyCalls).toHaveLength(1);
+    expect(result).toMatchObject({
+      structuredOutput: {
+        loop: {
+          completed: false,
+          iterations: 2,
+          remainingFixBudget: 0,
+          stopReason: "fix-budget-exhausted",
+        },
+        final: { verifiedIssueCount: 1 },
+      },
+    });
+  }, 10_000);
+
   test("auto-fix loop stops when a fixer reports already-fixed without changing state", async () => {
     if (!deepReviewWorkflow) {
       throw new Error("Expected built-in deep-review-workflow workflow");

--- a/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
+++ b/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
@@ -3461,7 +3461,7 @@ describe("built-in deep-review-workflow", () => {
     });
   }, 10_000);
 
-  test("auto-fix skips when same-branch HEAD changes after review context is captured", async () => {
+  test("auto-fix lets applyPatch reject same-branch HEAD drift", async () => {
     if (!deepReviewWorkflow) {
       throw new Error("Expected built-in deep-review-workflow workflow");
     }
@@ -3476,6 +3476,8 @@ describe("built-in deep-review-workflow", () => {
     await fs.writeFile(path.join(repoRoot, "service.ts"), "export const value = 1;\n", "utf-8");
     await runGit(repoRoot, ["add", "service.ts"]);
     await runGit(repoRoot, ["commit", "-m", "base commit"]);
+
+    const reviewedHead = await readGit(repoRoot, ["rev-parse", "HEAD"]);
 
     const issue = {
       id: "head-drift",
@@ -3506,6 +3508,7 @@ describe("built-in deep-review-workflow", () => {
     });
 
     const taskCalls: WorkflowAgentSpec[] = [];
+    const applyCalls: Array<{ expectedHeadSha?: string }> = [];
     const runner = new WorkflowRunner({
       runStore,
       runtimeFactory: new QuickJSRuntimeFactory(),
@@ -3568,9 +3571,30 @@ describe("built-in deep-review-workflow", () => {
                   discardedIssueCount: 0,
                 },
               };
+            case "fix-issue-0":
+              return {
+                taskId: "task_fix_0",
+                reportMarkdown: "Fixed issue.",
+                structuredOutput: {
+                  issueId: "head-drift",
+                  status: "fixed",
+                  summary: "Fixed service.ts.",
+                  validation: ["bun test src/service.test.ts"],
+                  commitCreated: true,
+                },
+              };
             default:
               throw new Error(`Unexpected same-branch head drift step: ${spec.id}`);
           }
+        },
+        async applyPatch(spec) {
+          applyCalls.push({ expectedHeadSha: spec.expectedHeadSha });
+          return {
+            success: false,
+            status: "failed",
+            taskId: spec.sourceTaskId,
+            error: "Current HEAD does not match expected HEAD",
+          };
         },
       },
       actionRegistry: new WorkflowActionRegistry({ projectRoot, globalRoot }),
@@ -3585,16 +3609,16 @@ describe("built-in deep-review-workflow", () => {
 
     const result = await runner.run("wfr_deep_review_fix_head_drift");
 
-    expect(taskCalls.map((call) => call.id)).not.toContain("fix-issue-0");
-    expect(result.reportMarkdown).toContain(
-      "auto-fix requires the current Git HEAD to match the reviewed snapshot"
-    );
+    expect(taskCalls.map((call) => call.id)).toContain("fix-issue-0");
+    expect(applyCalls).toEqual([{ expectedHeadSha: reviewedHead }]);
     expect(result).toMatchObject({
       structuredOutput: {
         fix: {
           requested: true,
-          skippedReason: "auto-fix requires the current Git HEAD to match the reviewed snapshot",
-          selectedIssues: [],
+          applications: [{ status: "failed" }],
+          unresolved: [
+            { issueId: "head-drift", reason: "Current HEAD does not match expected HEAD" },
+          ],
         },
       },
     });

--- a/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
+++ b/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
@@ -2472,7 +2472,7 @@ describe("built-in deep-review-workflow", () => {
         },
       },
     });
-  }, 10_000);
+  }, 20_000);
 
   test("auto-fix uses final synthesis issue IDs and rejects mismatched fixer output", async () => {
     if (!deepReviewWorkflow) {

--- a/src/node/services/workflows/builtInWorkflowDefinitions.ts
+++ b/src/node/services/workflows/builtInWorkflowDefinitions.ts
@@ -230,20 +230,93 @@ function normalizeDeepResearchTopic(args) {
   const readOnlyReviewPrompt =
     "This is a read-only deep code review task. Do not edit files, create commits, apply patches, push branches, or open PRs. Inspect repository evidence only as needed and report findings.\\n\\n";
   const input = normalizeDeepReviewArgs(args);
-  const gitContext = shouldCollectGitReviewContext(input) ? collectGitReviewContext(action, input, log) : null;
+  if (input.loop && !input.fix) {
+    throw new Error("--loop requires --fix for deep-review-workflow");
+  }
+  if (input.loop) {
+    return runDeepReviewLoop({
+      input: input,
+      phase: phase,
+      log: log,
+      agent: agent,
+      action: action,
+      parallelAgents: parallelAgents,
+      applyPatch: applyPatch,
+      exploreAgentId: exploreAgentId,
+      reasoningAgentId: reasoningAgentId,
+      readOnlyReviewPrompt: readOnlyReviewPrompt,
+    });
+  }
+  return runDeepReviewPass({
+    input: input,
+    phase: phase,
+    log: log,
+    agent: agent,
+    action: action,
+    parallelAgents: parallelAgents,
+    applyPatch: applyPatch,
+    exploreAgentId: exploreAgentId,
+    reasoningAgentId: reasoningAgentId,
+    readOnlyReviewPrompt: readOnlyReviewPrompt,
+    stepSuffix: "",
+    iteration: 0,
+    skipFixWhenNoVerifiedIssues: false,
+  }).reviewResult;
+}
+
+function runDeepReviewLoop(context) {
+  const passes = [];
+  let stopReason = "";
+  let remainingFixBudget = context.input.maxFixes;
+  for (let iteration = 1; iteration <= context.input.maxLoopIterations; iteration += 1) {
+    context.phase("loop-iteration", {
+      iteration: iteration,
+      maxIterations: context.input.maxLoopIterations,
+      remainingFixBudget: remainingFixBudget,
+    });
+    const iterationInput = cloneDeepReviewInput(context.input);
+    iterationInput.maxFixes = remainingFixBudget;
+    const pass = runDeepReviewPass({
+      input: iterationInput,
+      phase: context.phase,
+      log: context.log,
+      agent: context.agent,
+      action: context.action,
+      parallelAgents: context.parallelAgents,
+      applyPatch: context.applyPatch,
+      exploreAgentId: context.exploreAgentId,
+      reasoningAgentId: context.reasoningAgentId,
+      readOnlyReviewPrompt: context.readOnlyReviewPrompt,
+      stepSuffix: "loop-" + iteration,
+      iteration: iteration,
+      skipFixWhenNoVerifiedIssues: true,
+    });
+    passes.push(pass.reviewResult);
+    remainingFixBudget = Math.max(0, remainingFixBudget - countSelectedFixes(pass.reviewResult));
+    stopReason = getLoopStopReason(pass.reviewResult, remainingFixBudget);
+    if (stopReason) {
+      return buildLoopResult(context.input, passes, stopReason, remainingFixBudget);
+    }
+  }
+  return buildLoopResult(context.input, passes, "max-iterations", remainingFixBudget);
+}
+
+function runDeepReviewPass(context) {
+  const input = cloneDeepReviewInput(context.input);
+  const gitContext = shouldCollectGitReviewContext(input) ? collectGitReviewContext(context.action, input, context.log, context.stepSuffix) : null;
   applyGitContextToReviewInput(input, gitContext);
   const maxCandidates = input.maxCandidates;
 
-  phase("scope", {
+  context.phase("scope", withLoopIteration({
     target: input.target,
     fileCount: input.files.length,
     hasDiffSnapshot: input.diff.length > 0,
     hasGitSnapshot: input.gitSnapshot.length > 0,
-  });
-  const scope = agent({
-    id: "scope-review-surface",
+  }, context.iteration));
+  const scope = context.agent({
+    id: workflowStepId("scope-review-surface", context.stepSuffix),
     title: "Scope review surface",
-    agentId: exploreAgentId,
+    agentId: context.exploreAgentId,
     prompt:
       "Scope this code review. Identify changed files, likely intent, touched layers, highest-risk areas, and which review lanes should run. Use repository evidence; do not assume the diff is complete if refs are provided.\\n\\n" +
       renderReviewInput(input),
@@ -251,17 +324,17 @@ function normalizeDeepResearchTopic(args) {
   });
 
   const lanes = selectReviewLanes(scope.structuredOutput.lanes);
-  log("Selected deep review lanes", { lanes: lanes });
+  context.log("Selected deep review lanes", withLoopIteration({ lanes: lanes }, context.iteration));
 
-  phase("lane-review", { lanes: lanes });
-  const laneReviews = parallelAgents(
+  context.phase("lane-review", withLoopIteration({ lanes: lanes }, context.iteration));
+  const laneReviews = context.parallelAgents(
     lanes.map(function (lane) {
       return {
-        id: "review-" + lane,
+        id: workflowStepId("review-" + lane, context.stepSuffix),
         title: "Review lane: " + lane,
-        agentId: reasoningAgentId,
+        agentId: context.reasoningAgentId,
         prompt:
-          readOnlyReviewPrompt +
+          context.readOnlyReviewPrompt +
           lanePrompt(lane) +
           "\\n\\nReview target:\\n" +
           renderReviewInput(input) +
@@ -277,15 +350,15 @@ function normalizeDeepResearchTopic(args) {
       return review.structuredOutput.issues || [];
     })
   );
-  log("Lane review produced candidate issues", { count: laneIssues.length });
+  context.log("Lane review produced candidate issues", withLoopIteration({ count: laneIssues.length }, context.iteration));
 
-  phase("triage-dedupe", { candidateCount: laneIssues.length });
-  const triage = agent({
-    id: "triage-candidate-issues",
+  context.phase("triage-dedupe", withLoopIteration({ candidateCount: laneIssues.length }, context.iteration));
+  const triage = context.agent({
+    id: workflowStepId("triage-candidate-issues", context.stepSuffix),
     title: "Triage and dedupe review findings",
-    agentId: reasoningAgentId,
+    agentId: context.reasoningAgentId,
     prompt:
-      readOnlyReviewPrompt +
+      context.readOnlyReviewPrompt +
       "Deduplicate and triage these candidate code review findings. Merge duplicates, drop vague or non-actionable items, normalize severity, and preserve concrete evidence.\\n\\n" +
       "Review target:\\n" +
       renderReviewInput(input) +
@@ -294,21 +367,21 @@ function normalizeDeepResearchTopic(args) {
     outputSchema: issueListSchema(),
   });
   const candidates = (triage.structuredOutput.issues || []).slice(0, maxCandidates);
-  log("Triaged candidate issues", {
+  context.log("Triaged candidate issues", withLoopIteration({
     candidateCount: triage.structuredOutput.issues.length,
     selectedCount: candidates.length,
-  });
+  }, context.iteration));
 
-  phase("adversarial-verification", { candidateCount: candidates.length });
+  context.phase("adversarial-verification", withLoopIteration({ candidateCount: candidates.length }, context.iteration));
   const verificationResults = candidates.length > 0
-    ? parallelAgents(
+    ? context.parallelAgents(
         candidates.map(function (issue, index) {
           return {
-            id: "verify-issue-" + index,
+            id: workflowStepId("verify-issue-" + index, context.stepSuffix),
             title: "Verify review finding " + (index + 1),
-            agentId: reasoningAgentId,
+            agentId: context.reasoningAgentId,
             prompt:
-              readOnlyReviewPrompt +
+              context.readOnlyReviewPrompt +
               "Adversarially verify this code review finding. Try to disprove it. Inspect relevant code paths and tests. Decide whether it is valid, duplicate, overstated, not reproducible, or needs more information.\\n\\n" +
               "Review target:\\n" +
               renderReviewInput(input) +
@@ -322,18 +395,18 @@ function normalizeDeepResearchTopic(args) {
   const verifications = verificationResults.map(function (verification) {
     return verification.structuredOutput;
   });
-  log("Verified candidate issues", { count: verifications.length });
+  context.log("Verified candidate issues", withLoopIteration({ count: verifications.length }, context.iteration));
 
-  phase("final-synthesis", {
+  context.phase("final-synthesis", withLoopIteration({
     candidateCount: candidates.length,
     verificationCount: verifications.length,
-  });
-  const final = agent({
-    id: "synthesize-review",
+  }, context.iteration));
+  const final = context.agent({
+    id: workflowStepId("synthesize-review", context.stepSuffix),
     title: "Synthesize final deep review",
-    agentId: reasoningAgentId,
+    agentId: context.reasoningAgentId,
     prompt:
-      readOnlyReviewPrompt +
+      context.readOnlyReviewPrompt +
       "Write the final code review. Include only findings that remain actionable after adversarial verification. Use severity P0-P4, file paths, issue IDs, and concrete evidence. If there are no verified issues, say so clearly. Include questions and a validation plan. Set verifiedIssueIds to the issue IDs included in the final review when any are verified.\\n\\n" +
       "Scoped review surface:\\n" +
       JSON.stringify(scope.structuredOutput, null, 2) +
@@ -355,26 +428,132 @@ function normalizeDeepResearchTopic(args) {
       final: final.structuredOutput,
     },
   };
-  if (!input.fix) return reviewResult;
+  if (!input.fix) return { reviewResult: reviewResult, gitContext: gitContext };
+  if (context.skipFixWhenNoVerifiedIssues && !hasVerifiedIssues(final.structuredOutput)) {
+    return { reviewResult: reviewResult, gitContext: gitContext };
+  }
 
-  phase("fix-preflight", { requested: true });
+  context.phase("fix-preflight", withLoopIteration({ requested: true }, context.iteration));
   const fixResult = runDeepReviewFix({
     input: input,
-    action: action,
-    log: log,
-    agent: agent,
-    parallelAgents: parallelAgents,
-    applyPatch: applyPatch,
+    action: context.action,
+    log: context.log,
+    agent: context.agent,
+    parallelAgents: context.parallelAgents,
+    applyPatch: context.applyPatch,
     candidates: candidates,
     verifications: verifications,
     final: final.structuredOutput,
     gitContext: gitContext,
-    exploreAgentId: exploreAgentId,
-    reasoningAgentId: reasoningAgentId,
+    exploreAgentId: context.exploreAgentId,
+    reasoningAgentId: context.reasoningAgentId,
+    stepSuffix: context.stepSuffix,
   });
   reviewResult.structuredOutput.fix = fixResult;
   reviewResult.reportMarkdown = final.reportMarkdown + renderFixMarkdown(fixResult);
-  return reviewResult;
+  return { reviewResult: reviewResult, gitContext: gitContext };
+}
+
+function cloneDeepReviewInput(input) {
+  return {
+    target: input.target,
+    baseRef: input.baseRef,
+    headRef: input.headRef,
+    diff: input.diff,
+    files: input.files.slice(),
+    instructions: input.instructions,
+    gitSnapshot: input.gitSnapshot,
+    explicitDiff: input.explicitDiff,
+    explicitFiles: input.explicitFiles,
+    includeGitContext: input.includeGitContext,
+    maxCandidates: input.maxCandidates,
+    fix: input.fix,
+    loop: input.loop,
+    maxFixes: input.maxFixes,
+    maxLoopIterations: input.maxLoopIterations,
+    fixIssueIds: input.fixIssueIds.slice(),
+  };
+}
+
+function workflowStepId(baseId, suffix) {
+  return suffix ? baseId + "-" + suffix : baseId;
+}
+
+function withLoopIteration(details, iteration) {
+  if (iteration) details.iteration = iteration;
+  return details;
+}
+
+function hasVerifiedIssues(final) {
+  if (!final) return false;
+  if (typeof final.verifiedIssueCount === "number") return final.verifiedIssueCount > 0;
+  return Array.isArray(final.verifiedIssueIds) && final.verifiedIssueIds.length > 0;
+}
+
+function countSelectedFixes(reviewResult) {
+  const output = reviewResult && reviewResult.structuredOutput ? reviewResult.structuredOutput : {};
+  const fix = output.fix;
+  return fix && Array.isArray(fix.selectedIssues) ? fix.selectedIssues.length : 0;
+}
+
+function getLoopStopReason(reviewResult, remainingFixBudget) {
+  const output = reviewResult && reviewResult.structuredOutput ? reviewResult.structuredOutput : {};
+  if (!hasVerifiedIssues(output.final)) return "no-verified-issues";
+  const fix = output.fix;
+  if (!fix) return "no-fix-attempted";
+  if (fix.skippedReason) return "fix-skipped";
+  if (fix.validation && fix.validation.status === "failed") return "validation-failed";
+  if (!fix.selectedIssues || fix.selectedIssues.length === 0) return "no-fixable-issues";
+  if (!fixHasProgress(fix)) return "no-fix-progress";
+  if (remainingFixBudget <= 0) return "fix-budget-exhausted";
+  return "";
+}
+
+function fixHasProgress(fix) {
+  return countStatus(fix.applications, "applied") > 0;
+}
+
+function buildLoopResult(input, passes, stopReason, remainingFixBudget) {
+  const loop = {
+    requested: true,
+    completed: stopReason === "no-verified-issues",
+    iterations: passes.length,
+    maxIterations: input.maxLoopIterations,
+    remainingFixBudget: remainingFixBudget,
+    stopReason: stopReason,
+  };
+  const structuredOutput = {
+    target: input.target,
+    loop: loop,
+    passes: passes.map(function (pass, index) {
+      return {
+        iteration: index + 1,
+        result: pass.structuredOutput,
+      };
+    }),
+  };
+  if (passes.length > 0) {
+    const latest = passes[passes.length - 1].structuredOutput;
+    structuredOutput.latest = latest;
+    structuredOutput.final = latest.final || null;
+    if (latest.fix) structuredOutput.fix = latest.fix;
+  }
+  return {
+    reportMarkdown: renderLoopMarkdown(passes, loop),
+    structuredOutput: structuredOutput,
+  };
+}
+
+function renderLoopMarkdown(passes, loop) {
+  let markdown = "# Deep Review Loop\\n\\n";
+  markdown += "- Iterations: " + loop.iterations + " / " + loop.maxIterations + "\\n";
+  markdown += "- Stop reason: " + loop.stopReason + "\\n";
+  markdown += "- Completed: " + (loop.completed ? "yes" : "no") + "\\n";
+  for (let index = 0; index < passes.length; index += 1) {
+    markdown += "\\n\\n---\\n\\n## Loop iteration " + (index + 1) + "\\n\\n";
+    markdown += passes[index].reportMarkdown || "";
+  }
+  return markdown;
 }
 
 function runDeepReviewFix(context) {
@@ -387,7 +566,7 @@ function runDeepReviewFix(context) {
     resolutions: [],
     unresolved: [],
   };
-  const preflight = collectFixPreflight(context.action, context.log, input, context.gitContext);
+  const preflight = collectFixPreflight(context.action, context.log, input, context.gitContext, context.stepSuffix);
   if (preflight.skippedReason) {
     baseFix.skippedReason = preflight.skippedReason;
     return baseFix;
@@ -407,7 +586,7 @@ function runDeepReviewFix(context) {
   const fixerResults = context.parallelAgents(
     selected.map(function (item, index) {
       return {
-        id: "fix-issue-" + index,
+        id: workflowStepId("fix-issue-" + index, context.stepSuffix),
         title: "Fix verified review finding " + (index + 1),
         agentId: context.reasoningAgentId,
         prompt: buildFixPrompt(input, item),
@@ -434,7 +613,7 @@ function runDeepReviewFix(context) {
       continue;
     }
 
-    const application = safeApplyPatch(context.applyPatch, "apply-fix-" + index, fixerResult, expectedHeadSha);
+    const application = safeApplyPatch(context.applyPatch, workflowStepId("apply-fix-" + index, context.stepSuffix), fixerResult, expectedHeadSha);
     application.issueId = item.issueId;
     baseFix.applications.push(application);
     if (application.status === "applied") {
@@ -448,7 +627,7 @@ function runDeepReviewFix(context) {
     }
 
     const resolver = context.agent({
-      id: "resolve-fix-" + index + "-conflict",
+      id: workflowStepId("resolve-fix-" + index + "-conflict", context.stepSuffix),
       title: "Resolve auto-fix conflict " + (index + 1),
       agentId: context.reasoningAgentId,
       prompt: buildResolverPrompt(input, item, fixerResult, application, integratedIssues),
@@ -466,7 +645,7 @@ function runDeepReviewFix(context) {
       continue;
     }
     if (resolutionOutput.status === "resolved" && resolutionOutput.commitCreated === true) {
-      const resolvedApplication = safeApplyPatch(context.applyPatch, "apply-resolved-fix-" + index, resolver, expectedHeadSha);
+      const resolvedApplication = safeApplyPatch(context.applyPatch, workflowStepId("apply-resolved-fix-" + index, context.stepSuffix), resolver, expectedHeadSha);
       resolvedApplication.issueId = item.issueId;
       resolution.applyStatus = resolvedApplication.status;
       baseFix.applications.push(resolvedApplication);
@@ -483,7 +662,7 @@ function runDeepReviewFix(context) {
 
   if (integratedIssues.length > 0) {
     const validation = context.agent({
-      id: "validate-auto-fixes",
+      id: workflowStepId("validate-auto-fixes", context.stepSuffix),
       title: "Validate applied auto-fixes",
       agentId: context.exploreAgentId,
       prompt: buildValidationPrompt(input, context.final, baseFix),
@@ -494,13 +673,13 @@ function runDeepReviewFix(context) {
   return baseFix;
 }
 
-function collectFixPreflight(action, log, input, gitContext) {
+function collectFixPreflight(action, log, input, gitContext, stepSuffix) {
   if (input.explicitDiff) return { skippedReason: "auto-fix requires a local current workspace target, not an explicit diff" };
   if (looksNonLocalTarget(input.target)) return { skippedReason: "auto-fix requires a local current workspace target" };
   let status = null;
   try {
     status = action.git.status({
-      id: "fix-git-status",
+      id: workflowStepId("fix-git-status", stepSuffix),
       input: { includeIgnored: false, head: input.headRef || "HEAD" },
       builtInOnly: true,
       cache: false,
@@ -848,7 +1027,9 @@ function normalizeDeepReviewArgs(args) {
     includeGitContext: false,
     maxCandidates: 12,
     fix: false,
+    loop: false,
     maxFixes: 5,
+    maxLoopIterations: 5,
     fixIssueIds: [],
   };
 
@@ -901,11 +1082,17 @@ function normalizeDeepReviewArgs(args) {
   if (typeof args.maxFixes === "number" && args.maxFixes > 0) {
     normalized.maxFixes = Math.min(20, Math.max(1, Math.floor(args.maxFixes)));
   }
+  if (typeof args.maxLoopIterations === "number" && args.maxLoopIterations > 0) {
+    normalized.maxLoopIterations = Math.min(10, Math.max(1, Math.floor(args.maxLoopIterations)));
+  }
   if (Array.isArray(args.fixIssueIds)) {
     normalized.fixIssueIds = sanitizeStringArray(args.fixIssueIds);
   }
   if (typeof args.fix === "boolean") {
     normalized.fix = args.fix;
+  }
+  if (typeof args.loop === "boolean") {
+    normalized.loop = args.loop;
   }
 
   return normalized;
@@ -916,6 +1103,8 @@ function applyFixFlags(normalized, text) {
   for (const flag of parsed.flags) {
     if (flag === "--fix") normalized.fix = true;
     else if (flag === "--no-fix") normalized.fix = false;
+    else if (flag === "--loop") normalized.loop = true;
+    else if (flag === "--no-loop") normalized.loop = false;
   }
   const target = parsed.target.trim().split(/ +/).join(" ");
   if (target) normalized.target = target;
@@ -926,7 +1115,7 @@ function parseTrailingFixFlags(text) {
   const flags = [];
   while (parts.length > 0) {
     const last = parts[parts.length - 1];
-    if (last !== "--fix" && last !== "--no-fix") break;
+    if (last !== "--fix" && last !== "--no-fix" && last !== "--loop" && last !== "--no-loop") break;
     flags.unshift(last);
     parts.pop();
   }
@@ -947,34 +1136,34 @@ function shouldCollectGitReviewContext(input) {
   return input.includeGitContext || (!input.explicitFiles && !input.explicitDiff);
 }
 
-function collectGitReviewContext(action, input, log) {
+function collectGitReviewContext(action, input, log, stepSuffix) {
   const gitInput = buildGitActionInput(input);
   const failures = [];
   const builtInOnly = true;
   const status = tryGitAction(log, failures, "git.status", function () {
     return action.git.status({
-      id: "git-status",
+      id: workflowStepId("git-status", stepSuffix),
       input: { includeIgnored: false },
       builtInOnly,
     }).output;
   });
   const changedFiles = tryGitAction(log, failures, "git.changedFiles", function () {
     return action.git.changedFiles({
-      id: "git-changed-files",
+      id: workflowStepId("git-changed-files", stepSuffix),
       input: gitInput,
       builtInOnly,
     }).output;
   });
   const diffStat = tryGitAction(log, failures, "git.diffStat", function () {
     return action.git.diffStat({
-      id: "git-diff-stat",
+      id: workflowStepId("git-diff-stat", stepSuffix),
       input: gitInput,
       builtInOnly,
     }).output;
   });
   const diff = tryGitAction(log, failures, "git.diff", function () {
     return action.git.diff({
-      id: "git-diff",
+      id: workflowStepId("git-diff", stepSuffix),
       input: gitInput,
       builtInOnly,
     }).output;
@@ -983,7 +1172,7 @@ function collectGitReviewContext(action, input, log) {
     const commitsInput = copyGitActionInput(gitInput);
     commitsInput.limit = 20;
     return action.git.commitsBetween({
-      id: "git-commits-between",
+      id: workflowStepId("git-commits-between", stepSuffix),
       input: commitsInput,
       builtInOnly,
     }).output;

--- a/src/node/services/workflows/builtInWorkflowDefinitions.ts
+++ b/src/node/services/workflows/builtInWorkflowDefinitions.ts
@@ -268,14 +268,18 @@ function runDeepReviewLoop(context) {
   const passes = [];
   let stopReason = "";
   let remainingFixBudget = context.input.maxFixes;
+  let loopHeadRef = context.input.headRef;
   for (let iteration = 1; iteration <= context.input.maxLoopIterations; iteration += 1) {
     context.phase("loop-iteration", {
       iteration: iteration,
       maxIterations: context.input.maxLoopIterations,
       remainingFixBudget: remainingFixBudget,
     });
+    const budgetExhaustedReadOnlyCheck = remainingFixBudget <= 0;
     const iterationInput = cloneDeepReviewInput(context.input);
+    iterationInput.headRef = loopHeadRef;
     iterationInput.maxFixes = remainingFixBudget;
+    if (budgetExhaustedReadOnlyCheck) iterationInput.fix = false;
     const pass = runDeepReviewPass({
       input: iterationInput,
       phase: context.phase,
@@ -292,8 +296,15 @@ function runDeepReviewLoop(context) {
       skipFixWhenNoVerifiedIssues: true,
     });
     passes.push(pass.reviewResult);
+    if (budgetExhaustedReadOnlyCheck) {
+      stopReason = hasVerifiedIssues(pass.reviewResult.structuredOutput.final) ? "fix-budget-exhausted" : "no-verified-issues";
+      return buildLoopResult(context.input, passes, stopReason, remainingFixBudget);
+    }
+    const fixProgress = reviewResultHasFixProgress(pass.reviewResult);
     remainingFixBudget = Math.max(0, remainingFixBudget - countSelectedFixes(pass.reviewResult));
+    if (fixProgress) loopHeadRef = "";
     stopReason = getLoopStopReason(pass.reviewResult, remainingFixBudget);
+    if (stopReason === "fix-budget-exhausted" && iteration < context.input.maxLoopIterations) continue;
     if (stopReason) {
       return buildLoopResult(context.input, passes, stopReason, remainingFixBudget);
     }
@@ -488,6 +499,12 @@ function hasVerifiedIssues(final) {
   if (!final) return false;
   if (typeof final.verifiedIssueCount === "number") return final.verifiedIssueCount > 0;
   return Array.isArray(final.verifiedIssueIds) && final.verifiedIssueIds.length > 0;
+}
+
+function reviewResultHasFixProgress(reviewResult) {
+  const output = reviewResult && reviewResult.structuredOutput ? reviewResult.structuredOutput : {};
+  const fix = output.fix;
+  return Boolean(fix && fixHasProgress(fix));
 }
 
 function countSelectedFixes(reviewResult) {
@@ -700,6 +717,9 @@ function collectFixPreflight(action, log, input, gitContext, stepSuffix) {
   if (!matchesReviewedGitBranch(reviewedSnapshot, status)) {
     return { skippedReason: "auto-fix requires the current Git branch to match the reviewed snapshot" };
   }
+  if (!matchesReviewedGitHead(reviewedSnapshot, status)) {
+    return { skippedReason: "auto-fix requires the current Git HEAD to match the reviewed snapshot" };
+  }
   if (arrayLength(status.staged) > 0 || arrayLength(status.unstaged) > 0 || arrayLength(status.untracked) > 0) {
     return { skippedReason: "auto-fix requires a clean committed local worktree" };
   }
@@ -729,6 +749,11 @@ function getReviewedGitSnapshot(gitContext) {
 function matchesReviewedGitBranch(reviewedSnapshot, status) {
   const currentBranch = typeof status.branch === "string" ? status.branch : "";
   return currentBranch.length > 0 && currentBranch === reviewedSnapshot.branch;
+}
+
+function matchesReviewedGitHead(reviewedSnapshot, status) {
+  const currentHeadSha = typeof status.headSha === "string" ? status.headSha : "";
+  return currentHeadSha.length > 0 && currentHeadSha === reviewedSnapshot.headSha;
 }
 
 function looksNonLocalTarget(target) {

--- a/src/node/services/workflows/builtInWorkflowDefinitions.ts
+++ b/src/node/services/workflows/builtInWorkflowDefinitions.ts
@@ -701,6 +701,7 @@ function collectFixPreflight(action, log, input, gitContext, stepSuffix) {
       id: workflowStepId("fix-git-status", stepSuffix),
       input: { includeIgnored: false, head: input.headRef || "HEAD" },
       builtInOnly: true,
+      cache: false,
     }).output;
   } catch (error) {
     const message = formatError(error);
@@ -717,9 +718,6 @@ function collectFixPreflight(action, log, input, gitContext, stepSuffix) {
   }
   if (!matchesReviewedGitBranch(reviewedSnapshot, status)) {
     return { skippedReason: "auto-fix requires the current Git branch to match the reviewed snapshot" };
-  }
-  if (!matchesReviewedGitHead(reviewedSnapshot, status)) {
-    return { skippedReason: "auto-fix requires the current Git HEAD to match the reviewed snapshot" };
   }
   if (arrayLength(status.staged) > 0 || arrayLength(status.unstaged) > 0 || arrayLength(status.untracked) > 0) {
     return { skippedReason: "auto-fix requires a clean committed local worktree" };
@@ -765,11 +763,6 @@ function normalizedGitBranch(branch) {
   const trimmed = branch.trim();
   if (!trimmed || trimmed === "HEAD (no branch)") return "";
   return trimmed;
-}
-
-function matchesReviewedGitHead(reviewedSnapshot, status) {
-  const currentHeadSha = typeof status.headSha === "string" ? status.headSha : "";
-  return currentHeadSha.length > 0 && currentHeadSha === reviewedSnapshot.headSha;
 }
 
 function looksNonLocalTarget(target) {

--- a/src/node/services/workflows/builtInWorkflowDefinitions.ts
+++ b/src/node/services/workflows/builtInWorkflowDefinitions.ts
@@ -519,9 +519,11 @@ function getLoopStopReason(reviewResult, remainingFixBudget) {
   const fix = output.fix;
   if (!fix) return "no-fix-attempted";
   if (fix.skippedReason) return "fix-skipped";
-  if (fix.validation && fix.validation.status === "failed") return "validation-failed";
   if (!fix.selectedIssues || fix.selectedIssues.length === 0) return "no-fixable-issues";
   if (!fixHasProgress(fix)) return "no-fix-progress";
+  const validationStatus = fix.validation ? fix.validation.status : "not-run";
+  if (validationStatus === "failed") return "validation-failed";
+  if (validationStatus !== "passed") return "validation-not-run";
   if (remainingFixBudget <= 0) return "fix-budget-exhausted";
   return "";
 }
@@ -699,7 +701,6 @@ function collectFixPreflight(action, log, input, gitContext, stepSuffix) {
       id: workflowStepId("fix-git-status", stepSuffix),
       input: { includeIgnored: false, head: input.headRef || "HEAD" },
       builtInOnly: true,
-      cache: false,
     }).output;
   } catch (error) {
     const message = formatError(error);
@@ -730,8 +731,11 @@ function isCurrentReviewHead(input, status) {
   if (!input.headRef) return true;
   const headRef = String(input.headRef).trim();
   if (!headRef || headRef === "HEAD") return true;
-  const branch = typeof status.branch === "string" ? status.branch : "";
-  if (branch.length > 0 && (headRef === branch || headRef === "refs/heads/" + branch)) return true;
+  const branch = normalizedGitBranch(status.branch);
+  const currentBranchRef = branch ? "refs/heads/" + branch : "";
+  if (branch && (headRef === branch || headRef === currentBranchRef)) return true;
+  const requestedHeadRef = typeof status.requestedHeadRef === "string" ? status.requestedHeadRef : "";
+  if (requestedHeadRef.length > 0) return false;
   if (!isExplicitCommitShaRef(headRef)) return false;
   const headSha = typeof status.headSha === "string" ? status.headSha : "";
   const requestedHeadSha = typeof status.requestedHeadSha === "string" ? status.requestedHeadSha : "";
@@ -745,15 +749,22 @@ function isExplicitCommitShaRef(headRef) {
 function getReviewedGitSnapshot(gitContext) {
   const reviewedStatus = gitContext && isObject(gitContext.status) ? gitContext.status : null;
   if (!reviewedStatus) return null;
-  const branch = typeof reviewedStatus.branch === "string" ? reviewedStatus.branch : "";
+  const branch = normalizedGitBranch(reviewedStatus.branch);
   const headSha = typeof reviewedStatus.headSha === "string" ? reviewedStatus.headSha : "";
   if (!branch || !headSha) return null;
   return { branch: branch, headSha: headSha };
 }
 
 function matchesReviewedGitBranch(reviewedSnapshot, status) {
-  const currentBranch = typeof status.branch === "string" ? status.branch : "";
+  const currentBranch = normalizedGitBranch(status.branch);
   return currentBranch.length > 0 && currentBranch === reviewedSnapshot.branch;
+}
+
+function normalizedGitBranch(branch) {
+  if (typeof branch !== "string") return "";
+  const trimmed = branch.trim();
+  if (!trimmed || trimmed === "HEAD (no branch)") return "";
+  return trimmed;
 }
 
 function matchesReviewedGitHead(reviewedSnapshot, status) {

--- a/src/node/services/workflows/builtInWorkflowDefinitions.ts
+++ b/src/node/services/workflows/builtInWorkflowDefinitions.ts
@@ -730,11 +730,16 @@ function isCurrentReviewHead(input, status) {
   if (!input.headRef) return true;
   const headRef = String(input.headRef).trim();
   if (!headRef || headRef === "HEAD") return true;
+  const branch = typeof status.branch === "string" ? status.branch : "";
+  if (branch.length > 0 && (headRef === branch || headRef === "refs/heads/" + branch)) return true;
+  if (!isExplicitCommitShaRef(headRef)) return false;
   const headSha = typeof status.headSha === "string" ? status.headSha : "";
   const requestedHeadSha = typeof status.requestedHeadSha === "string" ? status.requestedHeadSha : "";
-  if (headSha && requestedHeadSha) return headSha === requestedHeadSha;
-  const branch = typeof status.branch === "string" ? status.branch : "";
-  return branch.length > 0 && (headRef === branch || headRef === "refs/heads/" + branch);
+  return Boolean(headSha && requestedHeadSha && headSha === requestedHeadSha);
+}
+
+function isExplicitCommitShaRef(headRef) {
+  return /^[0-9a-fA-F]{7,64}$/.test(headRef);
 }
 
 function getReviewedGitSnapshot(gitContext) {


### PR DESCRIPTION
## Summary

Adds looped auto-fix support to `deep-review-workflow`, including iteration budgeting, replay-safe workflow step IDs, validation gating, branch/HEAD drift safety, and clearer workflow task actions that only offer task-workspace navigation when the child workspace still exists.

## Background

`deep-review-workflow --fix` previously performed a single review/fix pass. This change adds a `--loop` mode so the workflow can re-review after applied fixes and stop when the code is clean, the fix budget is exhausted, validation fails or is not run, no fix progress is made, or the loop safety cap is reached. It also fixes a workflow-events UX issue where stale task-workspace navigation could be shown after a child task workspace had been deleted.

## Implementation

- Adds `--loop` / `--no-loop` parsing and `maxLoopIterations` handling.
- Splits the workflow into reusable single-pass and loop orchestration paths with per-iteration step suffixes to avoid stale durable replay results.
- Tracks `maxFixes` as a run-wide budget and performs a read-only confirmation pass after budget exhaustion.
- Hardens auto-fix preflight for local clean worktrees, reviewed branch/HEAD drift, detached HEAD, ambiguous hex-like refs, and durable checkpoint retries after a patch advances `HEAD`.
- Requires post-fix validation to pass before continuing loop iterations; `not-run` now stops with an incomplete loop result.
- Adapts scratch workflow ignore handling to the latest lazy scratch-ignore behavior on `main`.
- Makes workflow task workspace/open affordances depend on live workspace metadata, while keeping completed task reports accessible after child workspaces are deleted.

## Validation

- `bun test src/node/services/workflows/builtInWorkflowDefinitions.test.ts --timeout 20000`
- `bun test src/node/services/workflows/WorkflowDefinitionStore.test.ts --timeout 20000`
- `bun test src/node/services/workflows/builtInWorkflowDefinitions.test.ts`
- `bun test src/node/services/workflows/WorkflowDefinitionStore.test.ts`
- `bun test src/browser/features/Tools/WorkflowRunToolCall.test.tsx`
- `make typecheck`
- `make static-check`

## Risks

This touches durable workflow orchestration, parent-workspace patch application safety, scratch workflow ignore behavior, and workflow-run task actions. Regression coverage was added for loop exits, run-wide budgets, replay after applied patches, detached/ambiguous refs, validation not-run handling, scratch gitignore edge cases, and stale/deleted task-workspace actions.

## Pains

The branch was rebased after `main` landed lazy scratch workflow ignore handling and inline workflow task structured output, so the final branch explicitly resolves those overlaps and was revalidated after the rebase.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$193.56`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=193.56 -->
