### PR TITLE
🤖 fix: lazily create scratch workflow ignores

### DIFF
--- a/.mux/workflows/.scratch/.gitignore
+++ b/.mux/workflows/.scratch/.gitignore
@@ -1,3 +1,0 @@
-# mux: hide scratch workflow drafts when repo rules unignore workflows
-*
-!.gitignore

--- a/src/node/services/workflows/WorkflowDefinitionStore.test.ts
+++ b/src/node/services/workflows/WorkflowDefinitionStore.test.ts
@@ -155,7 +155,7 @@ describe("WorkflowDefinitionStore", () => {
     expect(discovered.every((candidate) => candidate.scope !== "scratch")).toBe(true);
   });
 
-  test("prepares local scratch excludes while listing without creating workspace scratch files", async () => {
+  test("keeps local scratch listing read-only until a scratch workflow exists", async () => {
     using tmp = new DisposableTempDir("workflow-definitions");
     const workspaceRoot = path.join(tmp.path, "project");
     const scratchRoot = path.join(workspaceRoot, ".mux", "workflows", ".scratch");
@@ -175,10 +175,105 @@ describe("WorkflowDefinitionStore", () => {
     const gitExclude = await readGitExclude(workspaceRoot);
     expect(definitions).toEqual([]);
     expect(await pathExists(path.join(workspaceRoot, ".mux"))).toBe(false);
-    expect(gitExclude).toContain("/.mux/workflows/.scratch/");
+    expect(gitExclude).not.toContain("/.mux/workflows/.scratch/");
     expect(await runGit(workspaceRoot, ["status", "--short"])).toBe("");
 
     await writeWorkflow(scratchRoot, "draft", "Scratch draft");
+    const scratchDefinitions = await store.listDefinitions({ projectTrusted: true });
+    expect(scratchDefinitions.map((definition) => definition.name)).toEqual(["draft"]);
+    expect(await readGitExclude(workspaceRoot)).toContain("/.mux/workflows/.scratch/");
+    expect(await pathExists(path.join(scratchRoot, ".gitignore"))).toBe(false);
+    expect(
+      await runGit(workspaceRoot, [
+        "status",
+        "--short",
+        "--untracked-files=all",
+        "--",
+        ".mux/workflows/.scratch",
+      ])
+    ).toBe("");
+  });
+
+  test("deletes stale generated scratch gitignore when no scratch workflow exists", async () => {
+    using tmp = new DisposableTempDir("workflow-definitions");
+    const workspaceRoot = path.join(tmp.path, "project");
+    const scratchRoot = path.join(workspaceRoot, ".mux", "workflows", ".scratch");
+    const projectRoot = path.join(workspaceRoot, ".mux", "workflows");
+    const globalRoot = path.join(tmp.path, "mux-home", "workflows");
+    const staleGitignorePath = path.join(scratchRoot, ".gitignore");
+    const generatedFallback =
+      "# mux: hide scratch workflow drafts when repo rules unignore workflows\n*\n!.gitignore\n";
+    await fs.mkdir(scratchRoot, { recursive: true });
+    await runGit(workspaceRoot, ["init"]);
+    await fs.writeFile(
+      path.join(workspaceRoot, ".gitignore"),
+      "/.mux/\n!/.mux/\n!/.mux/workflows/\n!/.mux/workflows/**\n",
+      "utf-8"
+    );
+    await fs.writeFile(staleGitignorePath, generatedFallback, "utf-8");
+    const store = new WorkflowDefinitionStore({
+      scratchRoot,
+      projectRoot,
+      globalRoot,
+      builtIns: [],
+    });
+
+    expect(
+      await runGit(workspaceRoot, [
+        "status",
+        "--short",
+        "--untracked-files=all",
+        "--",
+        ".mux/workflows/.scratch",
+      ])
+    ).toBe("?? .mux/workflows/.scratch/.gitignore");
+
+    const definitions = await store.listDefinitions({ projectTrusted: true });
+
+    expect(definitions).toEqual([]);
+    expect(await pathExists(staleGitignorePath)).toBe(false);
+    expect(await readGitExclude(workspaceRoot)).not.toContain("/.mux/workflows/.scratch/");
+    expect(
+      await runGit(workspaceRoot, [
+        "status",
+        "--short",
+        "--untracked-files=all",
+        "--",
+        ".mux/workflows/.scratch",
+      ])
+    ).toBe("");
+  });
+
+  test("preserves generated scratch gitignore when other scratch files rely on it", async () => {
+    using tmp = new DisposableTempDir("workflow-definitions");
+    const workspaceRoot = path.join(tmp.path, "project");
+    const scratchRoot = path.join(workspaceRoot, ".mux", "workflows", ".scratch");
+    const projectRoot = path.join(workspaceRoot, ".mux", "workflows");
+    const globalRoot = path.join(tmp.path, "mux-home", "workflows");
+    const staleGitignorePath = path.join(scratchRoot, ".gitignore");
+    await fs.mkdir(scratchRoot, { recursive: true });
+    await runGit(workspaceRoot, ["init"]);
+    await fs.writeFile(
+      path.join(workspaceRoot, ".gitignore"),
+      "/.mux/\n!/.mux/\n!/.mux/workflows/\n!/.mux/workflows/**\n",
+      "utf-8"
+    );
+    await fs.writeFile(staleGitignorePath, "*\n!.gitignore\n", "utf-8");
+    await fs.writeFile(path.join(scratchRoot, "notes.txt"), "scratch note\n", "utf-8");
+    const store = new WorkflowDefinitionStore({
+      scratchRoot,
+      projectRoot,
+      globalRoot,
+      builtIns: [],
+    });
+
+    const definitions = await store.listDefinitions({ projectTrusted: true });
+
+    expect(definitions).toEqual([]);
+    expect(await readGitExclude(workspaceRoot)).toContain("/.mux/workflows/.scratch/");
+    expect(await fs.readFile(staleGitignorePath, "utf-8")).toContain(
+      "# mux: hide scratch workflow drafts when repo rules unignore workflows\n*\n"
+    );
     expect(
       await runGit(workspaceRoot, [
         "status",
@@ -304,7 +399,7 @@ describe("WorkflowDefinitionStore", () => {
     ).toContain("packages/app0/.mux/workflows/.scratch/sibling.js");
   });
 
-  test("adds a self-ignored fallback before repo rules can unignore the first draft", async () => {
+  test("adds a self-ignored fallback only after repo rules expose a scratch workflow", async () => {
     using tmp = new DisposableTempDir("workflow-definitions");
     const workspaceRoot = path.join(tmp.path, "project");
     const scratchRoot = path.join(workspaceRoot, ".mux", "workflows", ".scratch");
@@ -327,21 +422,17 @@ describe("WorkflowDefinitionStore", () => {
     const definitions = await store.listDefinitions({ projectTrusted: true });
 
     expect(definitions).toEqual([]);
+    expect(await readGitExclude(workspaceRoot)).not.toContain("/.mux/workflows/.scratch/");
+    expect(await pathExists(path.join(scratchRoot, ".gitignore"))).toBe(false);
+
+    await writeWorkflow(scratchRoot, "scratch-demo", "Workspace scratch demo");
+    const scratchDefinitions = await store.listDefinitions({ projectTrusted: true });
+
+    expect(scratchDefinitions.map((definition) => definition.name)).toEqual(["scratch-demo"]);
     expect(await readGitExclude(workspaceRoot)).toContain("/.mux/workflows/.scratch/");
     expect(await fs.readFile(path.join(scratchRoot, ".gitignore"), "utf-8")).toContain(
       "# mux: hide scratch workflow drafts when repo rules unignore workflows\n*\n"
     );
-    expect(
-      await runGit(workspaceRoot, [
-        "status",
-        "--short",
-        "--untracked-files=all",
-        "--",
-        ".mux/workflows/.scratch",
-      ])
-    ).toBe("");
-
-    await writeWorkflow(scratchRoot, "scratch-demo", "Workspace scratch demo");
     expect(
       await runGit(workspaceRoot, [
         "status",
@@ -371,6 +462,7 @@ describe("WorkflowDefinitionStore", () => {
       "# existing comment *\n!keep-*\n",
       "utf-8"
     );
+    await writeWorkflow(scratchRoot, "scratch-demo", "Workspace scratch demo");
     const store = new WorkflowDefinitionStore({
       scratchRoot,
       projectRoot,
@@ -385,7 +477,6 @@ describe("WorkflowDefinitionStore", () => {
     expect(fallback).toContain(
       "# mux: hide scratch workflow drafts when repo rules unignore workflows\n*\n"
     );
-    await writeWorkflow(scratchRoot, "scratch-demo", "Workspace scratch demo");
     expect(
       await runGit(workspaceRoot, [
         "status",
@@ -397,7 +488,7 @@ describe("WorkflowDefinitionStore", () => {
     ).toBe("");
   });
 
-  test("locally excludes an existing generated scratch gitignore", async () => {
+  test("does not duplicate fallback for an existing generated scratch gitignore", async () => {
     using tmp = new DisposableTempDir("workflow-definitions");
     const workspaceRoot = path.join(tmp.path, "project");
     const scratchRoot = path.join(workspaceRoot, ".mux", "workflows", ".scratch");
@@ -405,7 +496,15 @@ describe("WorkflowDefinitionStore", () => {
     const globalRoot = path.join(tmp.path, "mux-home", "workflows");
     await fs.mkdir(scratchRoot, { recursive: true });
     await runGit(workspaceRoot, ["init"]);
-    await fs.writeFile(path.join(scratchRoot, ".gitignore"), "*\n!.gitignore\n", "utf-8");
+    await fs.writeFile(
+      path.join(workspaceRoot, ".gitignore"),
+      "/.mux/\n!/.mux/\n!/.mux/workflows/\n!/.mux/workflows/**\n",
+      "utf-8"
+    );
+    const existingFallback =
+      "*\n!.gitignore\n# mux: hide scratch workflow drafts when repo rules unignore workflows\n*\n";
+    await fs.writeFile(path.join(scratchRoot, ".gitignore"), existingFallback, "utf-8");
+    await writeWorkflow(scratchRoot, "scratch-demo", "Workspace scratch demo");
     const store = new WorkflowDefinitionStore({
       scratchRoot,
       projectRoot,
@@ -415,10 +514,9 @@ describe("WorkflowDefinitionStore", () => {
 
     const definitions = await store.listDefinitions({ projectTrusted: true });
 
-    const gitExclude = await readGitExclude(workspaceRoot);
-    expect(definitions).toEqual([]);
-    expect(gitExclude).toContain("/.mux/workflows/.scratch/");
-    expect(await runGit(workspaceRoot, ["status", "--short"])).toBe("");
+    expect(definitions.map((definition) => definition.name)).toEqual(["scratch-demo"]);
+    expect(await readGitExclude(workspaceRoot)).toContain("/.mux/workflows/.scratch/");
+    expect(await fs.readFile(path.join(scratchRoot, ".gitignore"), "utf-8")).toBe(existingFallback);
   });
 
   test("serializes local exclude updates for multiple scratch roots in one repo", async () => {

--- a/src/node/services/workflows/WorkflowDefinitionStore.ts
+++ b/src/node/services/workflows/WorkflowDefinitionStore.ts
@@ -185,6 +185,49 @@ done`,
     .filter((entry) => entry.length > 0);
 }
 
+async function runtimeScratchContentExists(
+  runtime: Runtime,
+  root: string,
+  cwd: string
+): Promise<boolean> {
+  assert(root.length > 0, "Workflow runtime scratch root is required");
+  const quotedRoot = quoteRuntimeProbePath(root);
+  const result = await execBuffered(
+    runtime,
+    `if [ ! -d ${quotedRoot} ]; then exit 0; fi
+find ${quotedRoot} -mindepth 1 -maxdepth 1 ! -name .gitignore -print -quit`,
+    { cwd, timeout: 5 }
+  );
+  return result.exitCode === 0 && result.stdout.trim().length > 0;
+}
+
+async function deleteRuntimeGeneratedScratchGitignore(
+  runtime: Runtime,
+  root: string,
+  cwd: string
+): Promise<boolean> {
+  assert(root.length > 0, "Workflow runtime scratch root is required");
+  const gitignorePath = runtime.normalizePath(".gitignore", root);
+  try {
+    if (!(await runtimePathExists(runtime, gitignorePath, cwd))) {
+      return false;
+    }
+    if (await runtimeScratchContentExists(runtime, root, cwd)) {
+      return false;
+    }
+    if (!isGeneratedScratchGitignoreContent(await readFileString(runtime, gitignorePath))) {
+      return false;
+    }
+    const result = await execBuffered(runtime, `rm -f -- ${quoteRuntimeProbePath(gitignorePath)}`, {
+      cwd,
+      timeout: 5,
+    });
+    return result.exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
 async function scanRuntimeDirectory(
   runtime: Runtime,
   root: string,
@@ -346,12 +389,29 @@ function gitExcludeContentWithPattern(content: string, pattern: string): string 
   return `${content}${separator}${WORKFLOW_SCRATCH_GIT_EXCLUDE_COMMENT}\n${pattern}\n`;
 }
 
-function scratchGitignoreFallbackContent(content: string): string | null {
-  const lastPattern = content
+function isScratchGitignoreSelfException(pattern: string): boolean {
+  return pattern === "!.gitignore" || pattern === "!/.gitignore";
+}
+
+function scratchGitignorePatterns(content: string): string[] {
+  return content
     .split(/\r?\n/u)
     .map((line) => line.trim())
-    .filter((line) => line.length > 0 && !line.startsWith("#"))
-    .at(-1);
+    .filter((line) => line.length > 0 && !line.startsWith("#"));
+}
+
+function isGeneratedScratchGitignoreContent(content: string): boolean {
+  const patterns = scratchGitignorePatterns(content);
+  const draftPatterns = patterns.filter((pattern) => !isScratchGitignoreSelfException(pattern));
+  return (
+    draftPatterns.length > 0 &&
+    draftPatterns.every((pattern) => pattern === "*") &&
+    patterns.every((pattern) => pattern === "*" || isScratchGitignoreSelfException(pattern))
+  );
+}
+
+function scratchGitignoreFallbackContent(content: string): string | null {
+  const lastPattern = scratchGitignorePatterns(content).at(-1);
   if (lastPattern === "*") {
     return null;
   }
@@ -408,6 +468,24 @@ async function writeLocalScratchGitignoreFallback(scratchRoot: string): Promise<
   }
 }
 
+async function deleteLocalGeneratedScratchGitignore(scratchRoot: string): Promise<boolean> {
+  assert(scratchRoot.length > 0, "Workflow scratch root is required");
+  const gitignorePath = path.join(scratchRoot, ".gitignore");
+  try {
+    if (await localScratchContentExists(scratchRoot)) {
+      return false;
+    }
+    const content = await fs.readFile(gitignorePath, "utf-8");
+    if (!isGeneratedScratchGitignoreContent(content)) {
+      return false;
+    }
+    await fs.unlink(gitignorePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function tryLocalGitStdout(cwd: string, args: readonly string[]): Promise<string | null> {
   try {
     using proc = execFileAsync("git", ["-C", cwd, ...args], {
@@ -444,6 +522,16 @@ async function localDirectoryExists(targetPath: string): Promise<boolean> {
   try {
     const stat = await fs.stat(targetPath);
     return stat.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function localScratchContentExists(scratchRoot: string): Promise<boolean> {
+  assert(scratchRoot.length > 0, "Workflow scratch root is required");
+  try {
+    const entries = await fs.readdir(scratchRoot);
+    return entries.some((entry) => entry !== ".gitignore");
   } catch {
     return false;
   }
@@ -823,27 +911,54 @@ export class WorkflowDefinitionStore {
     if (this.scratchRoot != null && options.projectTrusted) {
       // Scratch workflows live under the workspace checkout, so treat them like project-local
       // code for trust gating rather than exposing repo-controlled files from untrusted projects.
+      // Keep plain workflow discovery read-only: only create/touch scratch ignore files once
+      // there is an actual scratch workflow candidate for Git to hide.
       if (this.projectRuntime != null) {
         assert(
           this.projectCwd != null,
           "WorkflowDefinitionStore.collectDefinitions: projectCwd missing"
         );
-        await ensureRuntimeScratchGitExclude(
+        const scratchDefinitions = await scanRuntimeDirectory(
           this.projectRuntime,
           this.scratchRoot,
-          this.projectCwd
+          this.projectCwd,
+          "scratch"
         );
-        sources.push(
-          await scanRuntimeDirectory(
+        const hasScratchContent =
+          scratchDefinitions.length > 0 ||
+          (await runtimeScratchContentExists(
             this.projectRuntime,
             this.scratchRoot,
-            this.projectCwd,
-            "scratch"
-          )
-        );
+            this.projectCwd
+          ));
+        if (hasScratchContent) {
+          await ensureRuntimeScratchGitExclude(
+            this.projectRuntime,
+            this.scratchRoot,
+            this.projectCwd
+          );
+        } else {
+          // Older eager versions may have left only the generated fallback behind;
+          // delete that stale file so upgrade returns the checkout to clean.
+          await deleteRuntimeGeneratedScratchGitignore(
+            this.projectRuntime,
+            this.scratchRoot,
+            this.projectCwd
+          );
+        }
+        sources.push(scratchDefinitions);
       } else {
-        await ensureLocalScratchGitExclude(this.scratchRoot);
-        sources.push(await scanDirectory(this.scratchRoot, "scratch"));
+        const scratchDefinitions = await scanDirectory(this.scratchRoot, "scratch");
+        const hasScratchContent =
+          scratchDefinitions.length > 0 || (await localScratchContentExists(this.scratchRoot));
+        if (hasScratchContent) {
+          await ensureLocalScratchGitExclude(this.scratchRoot);
+        } else {
+          // Older eager versions may have left only the generated fallback behind;
+          // delete that stale file so upgrade returns the checkout to clean.
+          await deleteLocalGeneratedScratchGitignore(this.scratchRoot);
+        }
+        sources.push(scratchDefinitions);
       }
     }
     if (options.projectTrusted) {


### PR DESCRIPTION
## Summary

Make scratch workflow ignore setup lazy so regular workflow discovery no longer creates or touches `.mux/workflows/.scratch/.gitignore` in clean worktrees.

## Background

Mux previously prepared scratch workflow ignore files even when no scratch workflow existed, which could leave an annoying modified `.mux/workflows/.scratch/.gitignore` in the user's working tree. The UX should stay read-only until actual scratch content is present, and stale generated scratch ignore files from older eager behavior should not keep dirtying upgraded workspaces.

## Implementation

- Removed the tracked scratch fallback `.gitignore` from the repo.
- Changed `WorkflowDefinitionStore` to scan scratch definitions first and only install local Git excludes or fallback `.gitignore` content when scratch content exists.
- Deletes stale generated scratch `.gitignore` files only when the scratch directory contains no other entries that rely on them.
- Preserves and repairs generated fallback ignores when non-workflow scratch files are present so those files stay hidden.
- Updated regression coverage for read-only empty scratch discovery, stale generated fallback cleanup, preservation for other scratch files, lazy fallback creation, and duplicate fallback avoidance.

## Validation

- `bun test src/node/services/workflows/WorkflowDefinitionStore.test.ts`
- `make typecheck`
- `make lint`
- `git diff --check`
- `make static-check`

## Risks

Low. The change is scoped to workflow definition discovery and scratch ignore setup. Existing scratch content still triggers local ignore installation before Git status assertions, while empty scratch directories avoid file-system side effects and clean up only generated stale fallback files.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$4.16`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=4.16 -->
