### PR TITLE
🤖 feat: allow collapsing attached reviews in the chat decoration

### DIFF
--- a/src/browser/features/ChatInput/AttachedReviewsPanel.tsx
+++ b/src/browser/features/ChatInput/AttachedReviewsPanel.tsx
@@ -1,10 +1,14 @@
 import React from "react";
-import { X } from "lucide-react";
+import { MessageSquare, X } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/browser/components/Tooltip/Tooltip";
+import { ChatInputDecoration } from "@/browser/components/ChatPane/ChatInputDecoration";
+import { usePersistedState } from "@/browser/hooks/usePersistedState";
+import { getAttachedReviewsExpandedKey } from "@/common/constants/storage";
 import { ReviewBlockFromData } from "../Shared/ReviewBlock";
 import type { Review } from "@/common/types/review";
 
 export interface AttachedReviewsPanelProps {
+  workspaceId: string;
   reviews: Review[];
   onDetachAll?: () => void;
   onDetach?: (reviewId: string) => void;
@@ -14,10 +18,17 @@ export interface AttachedReviewsPanelProps {
 }
 
 /**
- * Displays attached reviews in the chat input area.
- * Shows a header with count and "Clear all" button when multiple reviews attached.
+ * Displays reviews attached to the pending message as a collapsible chat-input
+ * decoration. Reuses the {@link ChatInputDecoration} primitive so the panel
+ * reads with the same collapsed chrome as the other composer decorations and so
+ * a long list of attachments can be tucked away without detaching them. The
+ * collapsed/expanded intent persists per-workspace; the panel defaults to
+ * expanded to preserve the prior always-visible behavior. The summary surfaces
+ * the count, and "Clear all" lives in the expanded body when multiple reviews
+ * are attached.
  */
 export const AttachedReviewsPanel: React.FC<AttachedReviewsPanelProps> = ({
+  workspaceId,
   reviews,
   onDetachAll,
   onDetach,
@@ -25,41 +36,66 @@ export const AttachedReviewsPanel: React.FC<AttachedReviewsPanelProps> = ({
   onDelete,
   onUpdateNote,
 }) => {
+  const [expanded, setExpanded] = usePersistedState(
+    getAttachedReviewsExpandedKey(workspaceId),
+    true
+  );
+
   if (reviews.length === 0) return null;
 
   return (
-    <div className="border-border max-h-[50vh] space-y-2 overflow-y-auto border-b px-1.5 py-1.5">
-      {/* Header with count and clear all button */}
-      <div className="flex items-center justify-between text-xs">
-        <span className="text-muted font-medium">
-          {reviews.length} review{reviews.length !== 1 && "s"} attached
-        </span>
-        {onDetachAll && reviews.length > 1 && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                onClick={onDetachAll}
-                className="text-muted hover:text-error flex items-center gap-1 text-xs transition-colors"
-              >
-                <X className="size-3" />
-                Clear all
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>Remove all reviews from message</TooltipContent>
-          </Tooltip>
-        )}
-      </div>
-      {reviews.map((review) => (
-        <ReviewBlockFromData
-          key={review.id}
-          data={review.data}
-          onComplete={onCheck ? () => onCheck(review.id) : undefined}
-          onDetach={onDetach ? () => onDetach(review.id) : undefined}
-          onDelete={onDelete ? () => onDelete(review.id) : undefined}
-          onEditComment={onUpdateNote ? (newNote) => onUpdateNote(review.id, newNote) : undefined}
-        />
-      ))}
-    </div>
+    <ChatInputDecoration
+      expanded={expanded}
+      onToggle={() => setExpanded(!expanded)}
+      dataComponent="AttachedReviewsPanel"
+      // Unlike the decorations stacked above the composer, this panel renders
+      // inside the chat-input card (which already supplies the gutter), so drop
+      // the primitive's top border + horizontal padding and keep a bottom
+      // divider above the textarea, matching the panel's prior placement.
+      className="border-t-0 border-b px-0"
+      contentClassName="max-h-[50vh] space-y-2 overflow-y-auto py-1.5"
+      summary={
+        <>
+          <MessageSquare className="size-3.5 text-[var(--color-review-accent)] transition-colors" />
+          <span className="text-muted group-hover:text-secondary transition-colors">
+            <span className="font-medium">{reviews.length}</span> review
+            {reviews.length !== 1 && "s"} attached
+          </span>
+        </>
+      }
+      renderExpanded={() => (
+        <>
+          {onDetachAll && reviews.length > 1 && (
+            <div className="flex items-center justify-end">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={onDetachAll}
+                    className="text-muted hover:text-error flex items-center gap-1 text-xs transition-colors"
+                  >
+                    <X className="size-3" />
+                    Clear all
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Remove all reviews from message</TooltipContent>
+              </Tooltip>
+            </div>
+          )}
+          {reviews.map((review) => (
+            <ReviewBlockFromData
+              key={review.id}
+              data={review.data}
+              onComplete={onCheck ? () => onCheck(review.id) : undefined}
+              onDetach={onDetach ? () => onDetach(review.id) : undefined}
+              onDelete={onDelete ? () => onDelete(review.id) : undefined}
+              onEditComment={
+                onUpdateNote ? (newNote) => onUpdateNote(review.id, newNote) : undefined
+              }
+            />
+          ))}
+        </>
+      )}
+    />
   );
 };

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -2992,6 +2992,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           {/* Hide during send to avoid duplicate display with the sent message */}
           {variant === "workspace" && !hideReviewsDuringSend && (
             <AttachedReviewsPanel
+              workspaceId={props.workspaceId}
               reviews={reviewPanelItems}
               onDetachAll={
                 reviewOverrideActive

--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -219,6 +219,15 @@ export function getPinnedTodoExpandedKey(workspaceId: string): string {
 }
 
 /**
+ * Get the localStorage key for the attached reviews panel expansion state.
+ * Lets a long list of reviews attached to the pending message be collapsed
+ * without detaching them. Format: "attachedReviewsExpanded:{workspaceId}"
+ */
+export function getAttachedReviewsExpandedKey(workspaceId: string): string {
+  return `attachedReviewsExpanded:${workspaceId}`;
+}
+
+/**
  * Get the localStorage key for per-workspace transcript auto-expand preferences.
  *
  * Stores the user's last expand/collapse intent, shaped like


### PR DESCRIPTION
## Summary

Make the "Attached Reviews" panel in the chat composer collapsible by rendering it through the shared `ChatInputDecoration` primitive, so a pending message with many attached reviews can be tucked away without detaching them.

## Background

Reviews attached to the pending message were always rendered fully expanded above the textarea. When several reviews are attached, the panel could consume a large portion of the composer area and push the input around. Every other composer-adjacent decoration (pending reviews banner, pinned TODO list, queued message, background processes) already uses the collapsible `ChatInputDecoration` chrome; the attached-reviews panel was the odd one out.

## Implementation

- `AttachedReviewsPanel` now wraps its contents in `ChatInputDecoration`:
  - Collapsed summary shows the review icon + attached count.
  - Expanded body keeps the existing review blocks and the "Clear all" action (shown when more than one review is attached).
- Expansion intent persists per-workspace via `usePersistedState` under a new `getAttachedReviewsExpandedKey(workspaceId)` storage key, defaulting to **expanded** to preserve the prior always-visible behavior.
- The panel renders inside the chat-input card (which already supplies the gutter), so the decoration's top border + horizontal padding are dropped and a bottom divider is kept above the textarea, matching the panel's prior placement.
- `ChatInput` passes `workspaceId` to the panel (only rendered in the `workspace` variant).

## Validation

- `make typecheck`, `make static-check`, and targeted `eslint` on the touched files all pass.

## Risks

Low. Scope is limited to the composer's attached-reviews preview; detach/clear/edit handlers are unchanged, and the default expanded state preserves existing behavior. Worst case is a per-workspace UI preference being mis-persisted, which self-heals on toggle.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-8` • Thinking: `xhigh` • Cost: `n/a`_

<!-- mux-attribution: model=anthropic:claude-opus-4-8 thinking=xhigh costs=n/a -->
