### PR TITLE
🤖 fix: wait for chat idle before slash workflows

### DIFF
--- a/src/node/orpc/router.test.ts
+++ b/src/node/orpc/router.test.ts
@@ -135,6 +135,7 @@ describe("router workflow routes", () => {
       },
       workspaceService: {
         waitForWorkspaceIdle: mock(async () => undefined),
+        prepareManualWorkflowInvocation: mock(async () => undefined),
         appendWorkflowRunInvocation: mock(async () => true),
         isWorkflowInvocationCurrent: mock(async () => false),
         getWorkflowContinuationSendOptions: mock(() => null),
@@ -419,6 +420,7 @@ describe("router workflow routes", () => {
     const context = createContext({ enabled: true });
     const workspaceService = context.workspaceService as unknown as {
       waitForWorkspaceIdle: ReturnType<typeof mock>;
+      prepareManualWorkflowInvocation: ReturnType<typeof mock>;
       appendWorkflowRunInvocation: ReturnType<typeof mock>;
     };
     let releaseIdle: (() => void) | undefined;
@@ -443,12 +445,18 @@ describe("router workflow routes", () => {
       "slash workflow idle barrier",
       () => workspaceService.waitForWorkspaceIdle.mock.calls.length === 1
     );
+    expect(workspaceService.waitForWorkspaceIdle).toHaveBeenCalledWith(
+      "workspace-1",
+      expect.objectContaining({ manualFollowUp: true })
+    );
+    expect(workspaceService.prepareManualWorkflowInvocation).not.toHaveBeenCalled();
     expect(await runStore.listRuns()).toEqual([]);
     expect(workspaceService.appendWorkflowRunInvocation).not.toHaveBeenCalled();
 
     releaseIdle?.();
     const result = await startPromise;
 
+    expect(workspaceService.prepareManualWorkflowInvocation).toHaveBeenCalledWith("workspace-1");
     expect(result).toMatchObject({ status: "running", invocationMessagePersisted: true });
     expect(workspaceService.appendWorkflowRunInvocation).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -527,6 +535,7 @@ describe("router workflow routes", () => {
     const context = createContext({ enabled: true });
     const workspaceService = context.workspaceService as unknown as {
       waitForWorkspaceIdle: ReturnType<typeof mock>;
+      prepareManualWorkflowInvocation: ReturnType<typeof mock>;
     };
     const client = createRouterClient(router(), { context });
 
@@ -537,6 +546,7 @@ describe("router workflow routes", () => {
       args: { topic: "background workflow routes" },
     });
 
+    expect(workspaceService.prepareManualWorkflowInvocation).not.toHaveBeenCalled();
     expect(workspaceService.waitForWorkspaceIdle).not.toHaveBeenCalled();
     expect(result.status).toBe("running");
     expect(result.runId).toMatch(/^wfr_/);

--- a/src/node/orpc/router.test.ts
+++ b/src/node/orpc/router.test.ts
@@ -134,6 +134,7 @@ describe("router workflow routes", () => {
         })),
       },
       workspaceService: {
+        waitForWorkspaceIdle: mock(async () => undefined),
         appendWorkflowRunInvocation: mock(async () => true),
         isWorkflowInvocationCurrent: mock(async () => false),
         getWorkflowContinuationSendOptions: mock(() => null),
@@ -411,6 +412,52 @@ describe("router workflow routes", () => {
         status: "running",
       })
     );
+    await waitForRouterWorkflowStatus(client, "workspace-1", result.runId, "completed");
+  });
+
+  test("waits for chat idle before starting slash workflow invocations", async () => {
+    const context = createContext({ enabled: true });
+    const workspaceService = context.workspaceService as unknown as {
+      waitForWorkspaceIdle: ReturnType<typeof mock>;
+      appendWorkflowRunInvocation: ReturnType<typeof mock>;
+    };
+    let releaseIdle: (() => void) | undefined;
+    workspaceService.waitForWorkspaceIdle = mock(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseIdle = resolve;
+        })
+    );
+    const runStore = new WorkflowRunStore({ sessionDir: config.getSessionDir("workspace-1") });
+    const client = createRouterClient(router(), { context });
+
+    const startPromise = client.workflows.start({
+      workspaceId: "workspace-1",
+      name: "demo",
+      runInBackground: true,
+      args: { topic: "queued until idle" },
+      rawCommand: "/demo queued until idle",
+    });
+
+    await waitForRouterCondition(
+      "slash workflow idle barrier",
+      () => workspaceService.waitForWorkspaceIdle.mock.calls.length === 1
+    );
+    expect(await runStore.listRuns()).toEqual([]);
+    expect(workspaceService.appendWorkflowRunInvocation).not.toHaveBeenCalled();
+
+    releaseIdle?.();
+    const result = await startPromise;
+
+    expect(result).toMatchObject({ status: "running", invocationMessagePersisted: true });
+    expect(workspaceService.appendWorkflowRunInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "workspace-1",
+        rawCommand: "/demo queued until idle",
+        status: "running",
+      })
+    );
+    await waitForRouterWorkflowStatus(client, "workspace-1", result.runId, "completed");
   });
 
   test("waits for foreground slash invocation persistence before terminal continuation", async () => {
@@ -477,7 +524,11 @@ describe("router workflow routes", () => {
   });
 
   test("starts a workflow in the background when requested through the API", async () => {
-    const client = createRouterClient(router(), { context: createContext({ enabled: true }) });
+    const context = createContext({ enabled: true });
+    const workspaceService = context.workspaceService as unknown as {
+      waitForWorkspaceIdle: ReturnType<typeof mock>;
+    };
+    const client = createRouterClient(router(), { context });
 
     const result = await client.workflows.start({
       workspaceId: "workspace-1",
@@ -486,6 +537,7 @@ describe("router workflow routes", () => {
       args: { topic: "background workflow routes" },
     });
 
+    expect(workspaceService.waitForWorkspaceIdle).not.toHaveBeenCalled();
     expect(result.status).toBe("running");
     expect(result.runId).toMatch(/^wfr_/);
     expect(result.result).toBeNull();

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -1951,7 +1951,10 @@ export const router = (authToken?: string) => {
             // Slash workflow commands are user follow-ups, just like normal composer sends.
             // Wait for the active chat turn (including compaction follow-ups and queued messages)
             // to finish before starting the workflow or appending its invocation to history.
-            await context.workspaceService.waitForWorkspaceIdle(input.workspaceId, { signal });
+            await context.workspaceService.waitForWorkspaceIdle(input.workspaceId, {
+              signal,
+              manualFollowUp: true,
+            });
           }
           const { service, projectTrusted } = await resolveWorkflowContext(
             context,
@@ -1960,6 +1963,9 @@ export const router = (authToken?: string) => {
               ...(onBackgroundRunTerminal != null ? { onBackgroundRunTerminal } : {}),
             }
           );
+          if (input.rawCommand != null) {
+            await context.workspaceService.prepareManualWorkflowInvocation(input.workspaceId);
+          }
           const workflowStartArgs = {
             name: input.name,
             workspaceId: input.workspaceId,

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -1947,6 +1947,12 @@ export const router = (authToken?: string) => {
                   });
                 }
               : undefined;
+          if (input.rawCommand != null) {
+            // Slash workflow commands are user follow-ups, just like normal composer sends.
+            // Wait for the active chat turn (including compaction follow-ups and queued messages)
+            // to finish before starting the workflow or appending its invocation to history.
+            await context.workspaceService.waitForWorkspaceIdle(input.workspaceId, { signal });
+          }
           const { service, projectTrusted } = await resolveWorkflowContext(
             context,
             input.workspaceId,

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -351,6 +351,7 @@ export class AgentSession {
   private deferQueuedFlushUntilAfterEdit = false;
 
   private idleWaiters: Array<() => void> = [];
+  private pendingExternalManualFollowUps = 0;
   private readonly messageQueue = new MessageQueue();
   private readonly compactionHandler: CompactionHandler;
   private readonly compactionMonitor: CompactionMonitor;
@@ -4682,8 +4683,9 @@ export class AgentSession {
         }
 
         // Stream end: auto-send queued messages (for user messages typed during streaming)
+        // and suppress goal continuations for external slash workflow follow-ups waiting on idle.
         // P2: if an edit is waiting, skip the queue flush so the edit truncates first.
-        const hadQueuedMessages = this.hasQueuedMessages();
+        const hadQueuedMessages = this.hasPendingManualFollowUp();
         if (this.deferQueuedFlushUntilAfterEdit) {
           // Clear the queued message flag so the next turn's tools don't early-return.
           this.backgroundProcessManager.setMessageQueued(this.workspaceId, false);
@@ -4886,6 +4888,38 @@ export class AgentSession {
     });
   }
 
+  /**
+   * Slash workflow commands are user follow-ups even though they do not live in MessageQueue.
+   * Reserve a manual slot while they wait so goal continuations do not outrun them at stream end.
+   */
+  registerExternalManualFollowUp(signal?: AbortSignal): () => void {
+    assert(
+      signal == null || typeof signal.aborted === "boolean",
+      "registerExternalManualFollowUp signal must be an AbortSignal"
+    );
+    if (signal?.aborted === true) {
+      throw new Error("External manual follow-up canceled.");
+    }
+
+    let released = false;
+    const release = () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      signal?.removeEventListener("abort", release);
+      assert(
+        this.pendingExternalManualFollowUps > 0,
+        "pending external manual follow-up count underflowed"
+      );
+      this.pendingExternalManualFollowUps -= 1;
+    };
+
+    this.pendingExternalManualFollowUps += 1;
+    signal?.addEventListener("abort", release, { once: true });
+    return release;
+  }
+
   queueMessage(
     message: string,
     options?: SendMessageOptions & { fileParts?: FilePart[] },
@@ -4916,6 +4950,10 @@ export class AgentSession {
 
   hasQueuedMessages(): boolean {
     return !this.messageQueue.isEmpty();
+  }
+
+  hasPendingManualFollowUp(): boolean {
+    return !this.messageQueue.isEmpty() || this.pendingExternalManualFollowUps > 0;
   }
 
   /**
@@ -5116,7 +5154,7 @@ export class AgentSession {
       imageParts?: FilePart[];
     };
 
-    const hasQueuedMessages = this.hasQueuedMessages();
+    const hasQueuedMessages = this.hasPendingManualFollowUp();
     const hasActiveNonCompletingTurn = this.isBusy() && this.turnPhase !== TurnPhase.COMPLETING;
     if (
       followUp.dispatchOptions?.requireIdle === true &&

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -4850,12 +4850,40 @@ export class AgentSession {
     return this.isPreparingTurn();
   }
 
-  async waitForIdle(): Promise<void> {
+  async waitForIdle(signal?: AbortSignal): Promise<void> {
+    assert(
+      signal == null || typeof signal.aborted === "boolean",
+      "waitForIdle signal must be an AbortSignal"
+    );
+    if (signal?.aborted === true) {
+      throw new Error("Waiting for session idle canceled.");
+    }
     if (this.turnPhase === TurnPhase.IDLE) {
       return;
     }
 
-    await new Promise<void>((resolve) => this.idleWaiters.push(resolve));
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const settle = (callback: () => void) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        signal?.removeEventListener("abort", abort);
+        callback();
+      };
+      const waiter = () => settle(resolve);
+      const abort = () => {
+        const waiterIndex = this.idleWaiters.indexOf(waiter);
+        if (waiterIndex !== -1) {
+          this.idleWaiters.splice(waiterIndex, 1);
+        }
+        settle(() => reject(new Error("Waiting for session idle canceled.")));
+      };
+
+      this.idleWaiters.push(waiter);
+      signal?.addEventListener("abort", abort, { once: true });
+    });
   }
 
   queueMessage(

--- a/src/node/services/agentSession.waitForIdle.test.ts
+++ b/src/node/services/agentSession.waitForIdle.test.ts
@@ -45,6 +45,31 @@ describe("AgentSession.waitForIdle", () => {
     }
   });
 
+  test("counts external manual follow-ups separately from queued message text", async () => {
+    const { session, cleanup } = await createAgentSessionHarness({
+      workspaceId: "wait-for-idle-external-manual-follow-up",
+    });
+
+    try {
+      expect(session.hasQueuedMessages()).toBe(false);
+      expect(session.hasPendingManualFollowUp()).toBe(false);
+
+      const controller = new AbortController();
+      const release = session.registerExternalManualFollowUp(controller.signal);
+      expect(session.hasQueuedMessages()).toBe(false);
+      expect(session.hasPendingManualFollowUp()).toBe(true);
+
+      controller.abort();
+      expect(session.hasPendingManualFollowUp()).toBe(false);
+
+      release();
+      expect(session.hasPendingManualFollowUp()).toBe(false);
+    } finally {
+      session.dispose();
+      await cleanup();
+    }
+  });
+
   test("removes repeated aborted idle waiters during one busy turn", async () => {
     const { session, cleanup } = await createAgentSessionHarness({
       workspaceId: "wait-for-idle-repeated-aborts",

--- a/src/node/services/agentSession.waitForIdle.test.ts
+++ b/src/node/services/agentSession.waitForIdle.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+
+import { createAgentSessionHarness } from "./agentSession.testHarness";
+
+interface IdleWaiterTestSession {
+  setTurnPhase(next: "idle" | "preparing"): void;
+  idleWaiters: Array<() => void>;
+}
+
+const WAIT_FOR_IDLE_CANCELED_MESSAGE = "Waiting for session idle canceled.";
+
+function captureWaitForIdleResult(promise: Promise<void>): Promise<unknown> {
+  return promise.then(
+    () => undefined,
+    (error: unknown) => error
+  );
+}
+
+describe("AgentSession.waitForIdle", () => {
+  test("removes an aborted idle waiter while the session stays busy", async () => {
+    const { session, cleanup } = await createAgentSessionHarness({
+      workspaceId: "wait-for-idle-abort",
+    });
+    const internalSession = session as unknown as IdleWaiterTestSession;
+
+    try {
+      internalSession.setTurnPhase("preparing");
+      const controller = new AbortController();
+      const waitResult = captureWaitForIdleResult(session.waitForIdle(controller.signal));
+
+      expect(session.isBusy()).toBe(true);
+      expect(internalSession.idleWaiters).toHaveLength(1);
+
+      controller.abort();
+
+      const error = await waitResult;
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe(WAIT_FOR_IDLE_CANCELED_MESSAGE);
+      expect(session.isBusy()).toBe(true);
+      expect(internalSession.idleWaiters).toHaveLength(0);
+    } finally {
+      internalSession.setTurnPhase("idle");
+      session.dispose();
+      await cleanup();
+    }
+  });
+
+  test("removes repeated aborted idle waiters during one busy turn", async () => {
+    const { session, cleanup } = await createAgentSessionHarness({
+      workspaceId: "wait-for-idle-repeated-aborts",
+    });
+    const internalSession = session as unknown as IdleWaiterTestSession;
+
+    try {
+      internalSession.setTurnPhase("preparing");
+      const waits = Array.from({ length: 3 }, () => {
+        const controller = new AbortController();
+        return {
+          controller,
+          result: captureWaitForIdleResult(session.waitForIdle(controller.signal)),
+        };
+      });
+
+      expect(internalSession.idleWaiters).toHaveLength(waits.length);
+
+      for (const wait of waits) {
+        wait.controller.abort();
+      }
+
+      const errors = await Promise.all(waits.map((wait) => wait.result));
+      for (const error of errors) {
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toBe(WAIT_FOR_IDLE_CANCELED_MESSAGE);
+      }
+      expect(session.isBusy()).toBe(true);
+      expect(internalSession.idleWaiters).toHaveLength(0);
+    } finally {
+      internalSession.setTurnPhase("idle");
+      session.dispose();
+      await cleanup();
+    }
+  });
+});

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -473,6 +473,41 @@ function isArchiveLossyUntrackedFilesConfirmation(
   );
 }
 
+function waitForAgentSessionIdle(session: AgentSession, signal?: AbortSignal): Promise<void> {
+  assert(session instanceof AgentSession, "waitForAgentSessionIdle requires an AgentSession");
+  if (signal?.aborted === true) {
+    return Promise.reject(
+      new Error("Workflow start canceled while waiting for workspace to become idle.")
+    );
+  }
+  if (signal == null) {
+    return session.waitForIdle();
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const settle = (callback: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      signal.removeEventListener("abort", abort);
+      callback();
+    };
+    const abort = () => {
+      settle(() =>
+        reject(new Error("Workflow start canceled while waiting for workspace to become idle."))
+      );
+    };
+
+    signal.addEventListener("abort", abort, { once: true });
+    session.waitForIdle().then(
+      () => settle(resolve),
+      (error: unknown) => settle(() => reject(new Error(getErrorMessage(error))))
+    );
+  });
+}
+
 interface FileCompletionsCacheEntry {
   index: FileCompletionsIndex;
   fetchedAt: number;
@@ -2118,6 +2153,29 @@ export class WorkspaceService extends EventEmitter {
     this.attachSessionSubscriptions(trimmed, session);
 
     return session;
+  }
+
+  async waitForWorkspaceIdle(
+    workspaceId: string,
+    options?: { signal?: AbortSignal }
+  ): Promise<void> {
+    assert(typeof workspaceId === "string", "waitForWorkspaceIdle requires a workspaceId string");
+    const trimmed = workspaceId.trim();
+    assert(trimmed.length > 0, "waitForWorkspaceIdle requires a non-empty workspaceId");
+
+    for (;;) {
+      if (options?.signal?.aborted === true) {
+        throw new Error("Workflow start canceled while waiting for workspace to become idle.");
+      }
+
+      const session =
+        this.sessions.get(trimmed) ?? this.transientStartupRecoverySessions.get(trimmed);
+      if (session?.isBusy() !== true) {
+        return;
+      }
+
+      await waitForAgentSessionIdle(session, options?.signal);
+    }
   }
 
   /**

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -473,39 +473,19 @@ function isArchiveLossyUntrackedFilesConfirmation(
   );
 }
 
-function waitForAgentSessionIdle(session: AgentSession, signal?: AbortSignal): Promise<void> {
+const WORKSPACE_IDLE_WAIT_CANCELED_MESSAGE =
+  "Workflow start canceled while waiting for workspace to become idle.";
+
+async function waitForAgentSessionIdle(session: AgentSession, signal?: AbortSignal): Promise<void> {
   assert(session instanceof AgentSession, "waitForAgentSessionIdle requires an AgentSession");
-  if (signal?.aborted === true) {
-    return Promise.reject(
-      new Error("Workflow start canceled while waiting for workspace to become idle.")
-    );
+  try {
+    await session.waitForIdle(signal);
+  } catch (error) {
+    if (signal?.aborted === true) {
+      throw new Error(WORKSPACE_IDLE_WAIT_CANCELED_MESSAGE);
+    }
+    throw new Error(getErrorMessage(error));
   }
-  if (signal == null) {
-    return session.waitForIdle();
-  }
-
-  return new Promise<void>((resolve, reject) => {
-    let settled = false;
-    const settle = (callback: () => void) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      signal.removeEventListener("abort", abort);
-      callback();
-    };
-    const abort = () => {
-      settle(() =>
-        reject(new Error("Workflow start canceled while waiting for workspace to become idle."))
-      );
-    };
-
-    signal.addEventListener("abort", abort, { once: true });
-    session.waitForIdle().then(
-      () => settle(resolve),
-      (error: unknown) => settle(() => reject(new Error(getErrorMessage(error))))
-    );
-  });
 }
 
 interface FileCompletionsCacheEntry {
@@ -2165,7 +2145,7 @@ export class WorkspaceService extends EventEmitter {
 
     for (;;) {
       if (options?.signal?.aborted === true) {
-        throw new Error("Workflow start canceled while waiting for workspace to become idle.");
+        throw new Error(WORKSPACE_IDLE_WAIT_CANCELED_MESSAGE);
       }
 
       const session =

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2137,24 +2137,32 @@ export class WorkspaceService extends EventEmitter {
 
   async waitForWorkspaceIdle(
     workspaceId: string,
-    options?: { signal?: AbortSignal }
+    options?: { signal?: AbortSignal; manualFollowUp?: boolean }
   ): Promise<void> {
     assert(typeof workspaceId === "string", "waitForWorkspaceIdle requires a workspaceId string");
     const trimmed = workspaceId.trim();
     assert(trimmed.length > 0, "waitForWorkspaceIdle requires a non-empty workspaceId");
 
-    for (;;) {
-      if (options?.signal?.aborted === true) {
-        throw new Error(WORKSPACE_IDLE_WAIT_CANCELED_MESSAGE);
-      }
+    let releaseManualFollowUp: (() => void) | undefined;
+    try {
+      for (;;) {
+        if (options?.signal?.aborted === true) {
+          throw new Error(WORKSPACE_IDLE_WAIT_CANCELED_MESSAGE);
+        }
 
-      const session =
-        this.sessions.get(trimmed) ?? this.transientStartupRecoverySessions.get(trimmed);
-      if (session?.isBusy() !== true) {
-        return;
-      }
+        const session =
+          this.sessions.get(trimmed) ?? this.transientStartupRecoverySessions.get(trimmed);
+        if (session?.isBusy() !== true) {
+          return;
+        }
 
-      await waitForAgentSessionIdle(session, options?.signal);
+        if (options?.manualFollowUp === true && releaseManualFollowUp == null) {
+          releaseManualFollowUp = session.registerExternalManualFollowUp(options.signal);
+        }
+        await waitForAgentSessionIdle(session, options?.signal);
+      }
+    } finally {
+      releaseManualFollowUp?.();
     }
   }
 
@@ -5930,6 +5938,35 @@ export class WorkspaceService extends EventEmitter {
     }
   }
 
+  async prepareManualWorkflowInvocation(workspaceId: string): Promise<void> {
+    const trimmed = workspaceId.trim();
+    assert(trimmed.length > 0, "prepareManualWorkflowInvocation requires workspaceId");
+    const goalService = this.workspaceGoalService;
+    if (!goalService) {
+      return;
+    }
+
+    // Slash workflows are explicit user interventions, so they should preempt
+    // pending automatic goal continuations just like queued composer messages do.
+    goalService.clearPendingContinuationForManualUserMessage(trimmed);
+    const goal = await goalService.acknowledgeUser(trimmed);
+    if (goal?.status !== "active") {
+      return;
+    }
+
+    const result = await goalService.setGoal({
+      workspaceId: trimmed,
+      status: "paused",
+      initiator: "auto",
+    });
+    if (!result.success) {
+      log.warn("Failed to auto-pause goal for workflow slash invocation", {
+        workspaceId: trimmed,
+        error: result.error,
+      });
+    }
+  }
+
   async appendWorkflowRunInvocation(input: {
     workspaceId: string;
     rawCommand: string;
@@ -7834,7 +7871,7 @@ export class WorkspaceService extends EventEmitter {
       isInitializing: initState?.status === "running",
       isRuntimeCompatible: true,
       isBusy: session?.isBusy() === true,
-      hasQueuedMessages: session?.hasQueuedMessages() === true,
+      hasQueuedMessages: session?.hasPendingManualFollowUp() === true,
       hasPendingFollowUp: false,
     };
   }


### PR DESCRIPTION
## Summary

Blocks slash workflow invocations behind the active chat-session idle barrier so compaction or other busy chat turns finish before workflow runs start or append invocation history. Also makes slash workflows participate in manual follow-up ordering for goal continuations, and makes the underlying idle wait abort-aware so canceled workflow starts do not retain stale waiters.

## Background

Slash workflow commands called `workflows.start` directly and bypassed the normal message queue behavior used by composer sends. That allowed a workflow invocation to start while a workspace was compacting or otherwise busy, creating history mutation races. It also meant slash workflows were not visible as queued user follow-ups to goal continuation logic.

## Implementation

- Added `WorkspaceService.waitForWorkspaceIdle()` and invoked it for raw slash workflow commands before resolving workflow context or creating workflow run records.
- Left API-driven workflow starts unchanged when no `rawCommand` is present.
- Made `AgentSession.waitForIdle()` optionally abort-aware, removing its idle waiter on abort to avoid retained closures during long busy turns.
- Added an external manual follow-up reservation for slash workflows waiting on idle so automatic goal continuations cannot outrun them at stream end.
- Prepared valid slash workflow invocations as manual goal interventions before starting the workflow, clearing pending continuations and pausing active goals like manual composer input.
- Added router coverage for the idle barrier/manual workflow preparation and AgentSession coverage for single/repeated aborted idle waits plus external manual follow-up reservations.

## Validation

- `bun test src/node/services/agentSession.waitForIdle.test.ts src/node/orpc/router.test.ts`
- `make typecheck`
- `make lint`
- `make static-check`
- Ran `deep-review-workflow`; fixed verified issue `workflow-idle-abort-waiter-leak`.
- Addressed Codex thread `PRRT_kwDOPxxmWM6HzNQ9` locally and reran `make static-check` before pushing.

## Risks

Medium regression risk in chat/workflow/goal coordination: this touches session busy-state waiting, workflow start ordering, goal-continuation preemption, and abort handling. The change is scoped to raw slash workflow starts and preserves immediate API workflow execution.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$16.87`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=16.87 -->
