### PR TITLE
🤖 fix: harden deep research workflow

### DIFF
--- a/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
+++ b/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
@@ -9,7 +9,7 @@ import { DisposableTempDir } from "@/node/services/tempDir";
 import { BUILT_IN_WORKFLOW_DEFINITIONS } from "./builtInWorkflowDefinitions";
 import { WorkflowActionRegistry } from "./WorkflowActionRegistry";
 import { WorkflowRunStore } from "./WorkflowRunStore";
-import { WorkflowRunner, type WorkflowAgentSpec } from "./WorkflowRunner";
+import { WorkflowRunner, type WorkflowAgentResult, type WorkflowAgentSpec } from "./WorkflowRunner";
 
 const BUILT_IN_WORKFLOW_TEST_STALE_LEASE_MS = 100;
 
@@ -30,6 +30,71 @@ async function runGit(cwd: string, args: string[]): Promise<void> {
 async function readGit(cwd: string, args: string[]): Promise<string> {
   const result = await execFileAsync("git", args, { cwd });
   return result.stdout.trimEnd();
+}
+
+async function runDeepResearchFixture(
+  runId: string,
+  args: unknown,
+  taskCalls: WorkflowAgentSpec[],
+  runAgent: (spec: WorkflowAgentSpec) => Promise<WorkflowAgentResult> | WorkflowAgentResult
+) {
+  if (!deepResearch) {
+    throw new Error("Expected built-in deep-research workflow");
+  }
+  using tmp = new DisposableTempDir(runId);
+  const runStore = new WorkflowRunStore({
+    sessionDir: tmp.path,
+    staleLeaseMs: BUILT_IN_WORKFLOW_TEST_STALE_LEASE_MS,
+  });
+  await runStore.createRun({
+    id: runId,
+    workspaceId: "workspace-1",
+    definition: {
+      name: deepResearch.name,
+      description: deepResearch.description,
+      scope: "built-in",
+      executable: true,
+    },
+    definitionSource: deepResearch.source,
+    args,
+    now: "2026-05-29T00:00:00.000Z",
+  });
+  const runner = new WorkflowRunner({
+    runStore,
+    runtimeFactory: new QuickJSRuntimeFactory(),
+    taskAdapter: {
+      async runAgent(spec) {
+        taskCalls.push(spec);
+        return runAgent(spec);
+      },
+    },
+    runnerId: "runner-a",
+    clock: {
+      nowIso: () => "2026-05-29T00:00:01.000Z",
+      nowMs: () => 1_000,
+    },
+  });
+
+  const result = await runner.run(runId);
+  const run = await runStore.getRun(runId);
+  return { result, run };
+}
+
+function expectSchemaHasNoOptionalObjectProperties(schema: unknown): void {
+  if (!isRecord(schema)) return;
+  const properties = schema.properties;
+  if (isRecord(properties)) {
+    const required = Array.isArray(schema.required) ? schema.required : [];
+    expect(Object.keys(properties).filter((key) => !required.includes(key))).toEqual([]);
+    Object.values(properties).forEach(expectSchemaHasNoOptionalObjectProperties);
+  }
+  if (schema.items !== undefined) {
+    expectSchemaHasNoOptionalObjectProperties(schema.items);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
 function createNoIssueDeepReviewTaskAdapter(taskCalls: WorkflowAgentSpec[]) {
@@ -112,6 +177,37 @@ describe("built-in deep-research workflow", () => {
       taskAdapter: {
         async runAgent(spec) {
           taskCalls.push(spec);
+          if (spec.id.startsWith("verify-claim-0-vote-")) {
+            return {
+              taskId: `task_${spec.id}`,
+              reportMarkdown: "Completed-step replay is supported.",
+              structuredOutput: {
+                claim: "Completed steps are reused on resume.",
+                refuted: false,
+                confidence: "high",
+                evidence: "The runner reuses completed step results on resume.",
+                counterSource: "",
+              },
+            };
+          }
+          if (spec.id.startsWith("verify-claim-1-vote-")) {
+            const refuted = !spec.id.endsWith("-vote-0");
+            return {
+              taskId: `task_${spec.id}`,
+              reportMarkdown: refuted
+                ? "Structured output validation claim is overstated."
+                : "Structured output validation is partly supported.",
+              structuredOutput: {
+                claim: "Structured outputs are validated at report time.",
+                refuted,
+                confidence: "medium",
+                evidence: refuted
+                  ? "The evidence does not show every structured output is validated at report time."
+                  : "The workflow runner validates structured outputs for agent steps.",
+                counterSource: "",
+              },
+            };
+          }
           switch (spec.id) {
             case "scope-topic":
               return {
@@ -119,84 +215,103 @@ describe("built-in deep-research workflow", () => {
                 reportMarkdown: "Research durable orchestration semantics.",
                 structuredOutput: {
                   refinedTopic: "durable workflow orchestration",
+                  strategy: "Compare implementation and tests for replay and validation semantics.",
                   questions: ["How are runs resumed?", "How are tasks verified?"],
+                  angles: [
+                    {
+                      label: "implementation",
+                      query: "durable workflow orchestration implementation",
+                      rationale: "Read the runner implementation.",
+                    },
+                    {
+                      label: "validation",
+                      query: "durable workflow structured output validation tests",
+                      rationale: "Check how tests cover validation behavior.",
+                    },
+                  ],
                 },
               };
-            case "discover-sources":
+            case "discover-sources-0":
               return {
-                taskId: "task_sources",
-                reportMarkdown: "Found implementation, RFC, and tests.",
+                taskId: "task_sources_0",
+                reportMarkdown: "Found implementation and RFC.",
                 structuredOutput: {
                   sources: [
-                    { title: "RFC", url: "rfc/20260529_dynamic-workflows.md", relevance: "design" },
+                    {
+                      title: "RFC",
+                      url: "rfc/20260529_dynamic-workflows.md",
+                      relevance: "high",
+                      sourceType: "primary",
+                    },
+                  ],
+                },
+              };
+            case "discover-sources-1":
+              return {
+                taskId: "task_sources_1",
+                reportMarkdown: "Found runner source.",
+                structuredOutput: {
+                  sources: [
+                    {
+                      title: "RFC duplicate",
+                      url: "rfc/20260529_dynamic-workflows.md?utm_source=duplicate",
+                      relevance: "high",
+                      sourceType: "primary",
+                    },
                     {
                       title: "Runner",
                       url: "src/node/services/workflows/WorkflowRunner.ts",
-                      relevance: "implementation",
+                      relevance: "high",
+                      sourceType: "primary",
                     },
                   ],
                 },
               };
-            case "summarize-source-0":
+            case "extract-source-0":
               return {
-                taskId: "task_summary_0",
+                taskId: "task_extract_0",
                 reportMarkdown: "RFC describes journal replay and validation.",
                 structuredOutput: {
                   source: "RFC",
+                  sourceQuality: "primary",
+                  publishDate: "2026-05-29",
                   summary: "Defines durable runs and replay.",
-                },
-              };
-            case "summarize-source-1":
-              return {
-                taskId: "task_summary_1",
-                reportMarkdown: "Runner describes replay lookup.",
-                structuredOutput: {
-                  source: "Runner",
-                  summary: "Replays completed steps by hash.",
-                },
-              };
-            case "extract-claims":
-              return {
-                taskId: "task_claims",
-                reportMarkdown: "Extracted two claims.",
-                structuredOutput: {
                   claims: [
                     {
                       claim: "Completed steps are reused on resume.",
-                      support: "Runner step lookup",
-                    },
-                    {
-                      claim: "Structured outputs are validated at report time.",
-                      support: "outputSchema",
+                      quote: "Defines durable runs and replay.",
+                      importance: "central",
                     },
                   ],
                 },
               };
-            case "verify-claim-0":
+            case "extract-source-1":
               return {
-                taskId: "task_verify_0",
-                reportMarkdown: "Completed-step replay is supported.",
+                taskId: "task_extract_1",
+                reportMarkdown: "Runner describes replay lookup.",
                 structuredOutput: {
-                  claim: "Completed steps are reused on resume.",
-                  verdict: "supported",
-                  risk: "low",
-                },
-              };
-            case "verify-claim-1":
-              return {
-                taskId: "task_verify_1",
-                reportMarkdown: "Structured output validation is supported.",
-                structuredOutput: {
-                  claim: "Structured outputs are validated at report time.",
-                  verdict: "supported",
-                  risk: "low",
+                  source: "Runner",
+                  sourceQuality: "primary",
+                  publishDate: "",
+                  summary: "Replays completed steps by hash.",
+                  claims: [
+                    {
+                      claim: "Structured outputs are validated at report time.",
+                      quote: "outputSchema validation runs for completed steps.",
+                      importance: "supporting",
+                    },
+                  ],
                 },
               };
             case "synthesize-report":
               return {
                 taskId: "task_final",
                 reportMarkdown: "# Deep Research\nDurable workflows replay completed steps.",
-                structuredOutput: { confidence: "medium", gaps: ["Needs UI dogfood"] },
+                structuredOutput: {
+                  confidence: "medium",
+                  gaps: ["Needs UI dogfood"],
+                  findings: ["Replay"],
+                },
               };
             default:
               throw new Error(`Unexpected deep-research step: ${spec.id}`);
@@ -215,12 +330,16 @@ describe("built-in deep-research workflow", () => {
 
     expect(taskCalls.map((call) => call.id)).toEqual([
       "scope-topic",
-      "discover-sources",
-      "summarize-source-0",
-      "summarize-source-1",
-      "extract-claims",
-      "verify-claim-0",
-      "verify-claim-1",
+      "discover-sources-0",
+      "discover-sources-1",
+      "extract-source-0",
+      "extract-source-1",
+      "verify-claim-0-vote-0",
+      "verify-claim-0-vote-1",
+      "verify-claim-0-vote-2",
+      "verify-claim-1-vote-0",
+      "verify-claim-1-vote-1",
+      "verify-claim-1-vote-2",
       "synthesize-report",
     ]);
     expect(taskCalls.map((call) => call.agentId)).toEqual([
@@ -228,50 +347,91 @@ describe("built-in deep-research workflow", () => {
       "explore",
       "explore",
       "explore",
+      "explore",
+      "exec",
+      "exec",
+      "exec",
       "exec",
       "exec",
       "exec",
       "exec",
     ]);
     expect(taskCalls.every((call) => call.outputSchema != null)).toBe(true);
+    taskCalls.forEach((call) => expectSchemaHasNoOptionalObjectProperties(call.outputSchema));
     expect(run.events.filter((event) => event.type === "phase").map((event) => event.name)).toEqual(
       [
         "scope",
         "source-discovery",
-        "source-synthesis",
-        "claim-extraction",
+        "source-extraction",
+        "claim-ranking",
         "adversarial-verification",
         "final-synthesis",
       ]
     );
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       reportMarkdown: "# Deep Research\nDurable workflows replay completed steps.",
       structuredOutput: {
         topic: "durable workflow orchestration",
         refinedTopic: "durable workflow orchestration",
-        sources: [
-          { title: "RFC", url: "rfc/20260529_dynamic-workflows.md", relevance: "design" },
-          {
-            title: "Runner",
-            url: "src/node/services/workflows/WorkflowRunner.ts",
-            relevance: "implementation",
-          },
-        ],
-        claims: [
-          { claim: "Completed steps are reused on resume.", support: "Runner step lookup" },
-          { claim: "Structured outputs are validated at report time.", support: "outputSchema" },
-        ],
-        verification: [
-          { claim: "Completed steps are reused on resume.", verdict: "supported", risk: "low" },
-          {
-            claim: "Structured outputs are validated at report time.",
-            verdict: "supported",
-            risk: "low",
-          },
-        ],
+        mode: "smart",
         confidence: "medium",
         gaps: ["Needs UI dogfood"],
+        findings: ["Replay"],
       },
+    });
+    const structuredOutput = (
+      result as {
+        structuredOutput: {
+          claims: Array<{ claim: string }>;
+          verification: Array<{
+            claim: string;
+            source: string;
+            vote: string;
+            refutedVotes: number;
+            survives: boolean;
+          }>;
+          confirmedClaims: unknown[];
+          refutedClaims: unknown[];
+          stats: {
+            claimsVerified: number;
+            confirmed: number;
+            killed: number;
+            votesPerClaim: number;
+            agentCalls: number;
+          };
+        };
+      }
+    ).structuredOutput;
+    expect(structuredOutput.claims.map((claim) => claim.claim)).toEqual([
+      "Completed steps are reused on resume.",
+      "Structured outputs are validated at report time.",
+    ]);
+    expect(structuredOutput.verification).toEqual([
+      {
+        claim: "Completed steps are reused on resume.",
+        source: "rfc/20260529_dynamic-workflows.md",
+        vote: "3-0",
+        refutedVotes: 0,
+        survives: true,
+      },
+      {
+        claim: "Structured outputs are validated at report time.",
+        source: "src/node/services/workflows/WorkflowRunner.ts",
+        vote: "1-2",
+        refutedVotes: 2,
+        survives: false,
+      },
+    ]);
+    expect(structuredOutput.confirmedClaims).toHaveLength(1);
+    expect(structuredOutput.refutedClaims).toHaveLength(1);
+    expect(structuredOutput.stats).toMatchObject({
+      claimsVerified: 2,
+      confirmed: 1,
+      killed: 1,
+      sourceCandidates: 3,
+      urlDupes: 1,
+      votesPerClaim: 3,
+      agentCalls: 12,
     });
   });
 
@@ -310,25 +470,24 @@ describe("built-in deep-research workflow", () => {
               return {
                 taskId: "task_scope",
                 reportMarkdown: "Scoped obscure topic.",
-                structuredOutput: { refinedTopic: "obscure empty topic", questions: [] },
+                structuredOutput: {
+                  refinedTopic: "obscure empty topic",
+                  strategy: "Try one broad source-discovery angle.",
+                  questions: [],
+                  angles: [
+                    {
+                      label: "general",
+                      query: "obscure empty topic",
+                      rationale: "Fallback search for any relevant source.",
+                    },
+                  ],
+                },
               };
-            case "discover-sources":
+            case "discover-sources-0":
               return {
                 taskId: "task_sources",
                 reportMarkdown: "No high-signal sources found.",
                 structuredOutput: { sources: [] },
-              };
-            case "extract-claims":
-              return {
-                taskId: "task_claims",
-                reportMarkdown: "No claims extracted.",
-                structuredOutput: { claims: [] },
-              };
-            case "synthesize-report":
-              return {
-                taskId: "task_final",
-                reportMarkdown: "# Deep Research\nNo sources were found.",
-                structuredOutput: { confidence: "low", gaps: ["No sources found"] },
               };
             default:
               throw new Error(`Unexpected deep-research step: ${spec.id}`);
@@ -346,20 +505,463 @@ describe("built-in deep-research workflow", () => {
     const run = await runStore.getRun("wfr_deep_research_empty");
 
     expect(run.status).toBe("completed");
-    expect(taskCalls.map((call) => call.id)).toEqual([
-      "scope-topic",
-      "discover-sources",
-      "extract-claims",
-      "synthesize-report",
-    ]);
-    expect(taskCalls.map((call) => call.agentId)).toEqual(["explore", "explore", "exec", "exec"]);
+    expect(taskCalls.map((call) => call.id)).toEqual(["scope-topic", "discover-sources-0"]);
+    expect(taskCalls.map((call) => call.agentId)).toEqual(["explore", "explore"]);
+    expect(run.events.filter((event) => event.type === "phase").map((event) => event.name)).toEqual(
+      ["scope", "source-discovery", "source-extraction", "claim-ranking"]
+    );
     expect(result).toMatchObject({
+      reportMarkdown:
+        "# Deep Research\n\nNo verifiable claims were extracted from 0 selected sources. The research run stopped before adversarial verification.",
       structuredOutput: {
         sources: [],
         claims: [],
         verification: [],
+        confidence: "low",
+        gaps: ["No verifiable claims were extracted."],
       },
     });
+  });
+
+  test("returns no-topic result without launching agents for missing or blank topics", async () => {
+    const cases: Array<{ id: string; args: unknown }> = [
+      { id: "empty_object", args: {} },
+      { id: "mode_only", args: { mode: "quick" } },
+      { id: "blank_topic", args: { topic: "   " } },
+      { id: "blank_string", args: "" },
+      { id: "null_args", args: null },
+    ];
+
+    for (const testCase of cases) {
+      const taskCalls: WorkflowAgentSpec[] = [];
+      const { result, run } = await runDeepResearchFixture(
+        `wfr_deep_research_no_topic_${testCase.id}`,
+        testCase.args,
+        taskCalls,
+        async (spec) => {
+          throw new Error(`No agent should launch for missing topic; got ${spec.id}`);
+        }
+      );
+
+      expect(run.status).toBe("completed");
+      expect(taskCalls).toEqual([]);
+      expect(result).toMatchObject({
+        reportMarkdown: "# Deep Research\n\nNo research topic was provided.",
+        structuredOutput: {
+          topic: "",
+          refinedTopic: "",
+          sources: [],
+          claims: [],
+          verification: [],
+          confidence: "low",
+          gaps: ["No research topic was provided."],
+        },
+      });
+    }
+  });
+
+  test("filters extracted claims that have no supporting quote", async () => {
+    const taskCalls: WorkflowAgentSpec[] = [];
+    const { result } = await runDeepResearchFixture(
+      "wfr_deep_research_empty_quote_filter",
+      { topic: "evidence filtering" },
+      taskCalls,
+      async (spec) => {
+        if (spec.id.startsWith("verify-claim-")) {
+          return {
+            taskId: `task_${spec.id}`,
+            reportMarkdown: "Verified supported claim.",
+            structuredOutput: {
+              claim: "Supported claim",
+              refuted: false,
+              confidence: "high",
+              evidence: "The claim has a quote.",
+              counterSource: "",
+            },
+          };
+        }
+        switch (spec.id) {
+          case "scope-topic":
+            return {
+              taskId: "task_scope",
+              reportMarkdown: "Scoped.",
+              structuredOutput: {
+                refinedTopic: "evidence filtering",
+                strategy: "Read one source.",
+                questions: ["Which claims have evidence?"],
+                angles: [
+                  { label: "primary", query: "evidence filtering", rationale: "Use one source." },
+                ],
+              },
+            };
+          case "discover-sources-0":
+            return {
+              taskId: "task_sources",
+              reportMarkdown: "Found source.",
+              structuredOutput: {
+                sources: [
+                  { title: "Source", url: "source.md", relevance: "high", sourceType: "primary" },
+                ],
+              },
+            };
+          case "extract-source-0":
+            return {
+              taskId: "task_extract",
+              reportMarkdown: "Extracted claims.",
+              structuredOutput: {
+                source: "Source",
+                sourceQuality: "primary",
+                publishDate: "",
+                summary: "One supported and one unsupported claim.",
+                claims: [
+                  { claim: "Unsupported claim", quote: "   ", importance: "central" },
+                  { claim: "Supported claim", quote: "Direct evidence", importance: "supporting" },
+                ],
+              },
+            };
+          case "synthesize-report":
+            return {
+              taskId: "task_final",
+              reportMarkdown: "# Evidence filtering",
+              structuredOutput: { confidence: "high", gaps: [], findings: ["Supported claim"] },
+            };
+          default:
+            throw new Error(`Unexpected deep-research step: ${spec.id}`);
+        }
+      }
+    );
+
+    const structuredOutput = (
+      result as { structuredOutput: { claims: Array<{ claim: string }>; verification: unknown[] } }
+    ).structuredOutput;
+    expect(structuredOutput.claims.map((claim) => claim.claim)).toEqual(["Supported claim"]);
+    expect(
+      taskCalls.filter((call) => call.id.startsWith("verify-claim-")).map((call) => call.id)
+    ).toEqual(["verify-claim-0-vote-0", "verify-claim-0-vote-1", "verify-claim-0-vote-2"]);
+    expect(structuredOutput.verification).toHaveLength(1);
+  });
+
+  test("treats verifier claim identity mismatches as refutations", async () => {
+    const taskCalls: WorkflowAgentSpec[] = [];
+    const { result } = await runDeepResearchFixture(
+      "wfr_deep_research_vote_identity",
+      { topic: "claim identity" },
+      taskCalls,
+      async (spec) => {
+        if (spec.id.startsWith("verify-claim-")) {
+          const mismatched = !spec.id.endsWith("-vote-2");
+          return {
+            taskId: `task_${spec.id}`,
+            reportMarkdown: mismatched ? "Wrong claim." : "Right claim.",
+            structuredOutput: {
+              claim: mismatched ? "Different claim" : "Identity-sensitive claim",
+              refuted: false,
+              confidence: "high",
+              evidence: mismatched
+                ? "This response evaluated a different claim."
+                : "The expected claim is supported.",
+              counterSource: "",
+            },
+          };
+        }
+        switch (spec.id) {
+          case "scope-topic":
+            return {
+              taskId: "task_scope",
+              reportMarkdown: "Scoped.",
+              structuredOutput: {
+                refinedTopic: "claim identity",
+                strategy: "Use one claim.",
+                questions: ["Can verifier identity drift?"],
+                angles: [
+                  { label: "primary", query: "claim identity", rationale: "Use one source." },
+                ],
+              },
+            };
+          case "discover-sources-0":
+            return {
+              taskId: "task_sources",
+              reportMarkdown: "Found source.",
+              structuredOutput: {
+                sources: [
+                  { title: "Source", url: "identity.md", relevance: "high", sourceType: "primary" },
+                ],
+              },
+            };
+          case "extract-source-0":
+            return {
+              taskId: "task_extract",
+              reportMarkdown: "Extracted claim.",
+              structuredOutput: {
+                source: "Source",
+                sourceQuality: "primary",
+                publishDate: "",
+                summary: "One claim.",
+                claims: [
+                  {
+                    claim: "Identity-sensitive claim",
+                    quote: "Direct evidence",
+                    importance: "central",
+                  },
+                ],
+              },
+            };
+          case "synthesize-report":
+            return {
+              taskId: "task_final",
+              reportMarkdown: "# Claim identity",
+              structuredOutput: { confidence: "low", gaps: ["Verifier mismatches"], findings: [] },
+            };
+          default:
+            throw new Error(`Unexpected deep-research step: ${spec.id}`);
+        }
+      }
+    );
+
+    const structuredOutput = (
+      result as {
+        structuredOutput: {
+          verification: Array<{
+            claim: string;
+            source: string;
+            vote: string;
+            refutedVotes: number;
+            survives: boolean;
+          }>;
+          confirmedClaims: unknown[];
+          refutedClaims: unknown[];
+        };
+      }
+    ).structuredOutput;
+    expect(structuredOutput.verification).toEqual([
+      {
+        claim: "Identity-sensitive claim",
+        source: "identity.md",
+        vote: "1-2",
+        refutedVotes: 2,
+        survives: false,
+      },
+    ]);
+    expect(structuredOutput.confirmedClaims).toHaveLength(0);
+    expect(structuredOutput.refutedClaims).toHaveLength(1);
+  });
+
+  test("dedupes tracking-only source variants without dropping meaningful query or path-case variants", async () => {
+    const taskCalls: WorkflowAgentSpec[] = [];
+    const { result } = await runDeepResearchFixture(
+      "wfr_deep_research_source_dedupe",
+      { topic: "source dedupe" },
+      taskCalls,
+      async (spec) => {
+        switch (spec.id) {
+          case "scope-topic":
+            return {
+              taskId: "task_scope",
+              reportMarkdown: "Scoped.",
+              structuredOutput: {
+                refinedTopic: "source dedupe",
+                strategy: "Return similar-looking sources.",
+                questions: ["Which URLs are distinct?"],
+                angles: [
+                  {
+                    label: "sources",
+                    query: "source dedupe",
+                    rationale: "Check canonicalization.",
+                  },
+                ],
+              },
+            };
+          case "discover-sources-0":
+            return {
+              taskId: "task_sources",
+              reportMarkdown: "Found sources.",
+              structuredOutput: {
+                sources: [
+                  {
+                    title: "Doc 1",
+                    url: "https://example.com/view?id=1",
+                    relevance: "high",
+                    sourceType: "primary",
+                  },
+                  {
+                    title: "Doc 2",
+                    url: "https://example.com/view?id=2",
+                    relevance: "high",
+                    sourceType: "primary",
+                  },
+                  {
+                    title: "Upper path",
+                    url: "src/Foo.ts",
+                    relevance: "high",
+                    sourceType: "primary",
+                  },
+                  {
+                    title: "Lower path",
+                    url: "src/foo.ts",
+                    relevance: "high",
+                    sourceType: "primary",
+                  },
+                  {
+                    title: "Doc 1 tracking duplicate",
+                    url: "https://www.example.com/view?utm_source=newsletter&id=1#section",
+                    relevance: "high",
+                    sourceType: "primary",
+                  },
+                ],
+              },
+            };
+          default:
+            if (spec.id.startsWith("extract-source-")) {
+              return {
+                taskId: `task_${spec.id}`,
+                reportMarkdown: spec.id,
+                structuredOutput: {
+                  source: spec.id,
+                  sourceQuality: "primary",
+                  publishDate: "",
+                  summary: "No claims needed for dedupe coverage.",
+                  claims: [],
+                },
+              };
+            }
+            throw new Error(`Unexpected deep-research step: ${spec.id}`);
+        }
+      }
+    );
+
+    const structuredOutput = (
+      result as {
+        structuredOutput: { sources: Array<{ url: string }>; stats: { urlDupes: number } };
+      }
+    ).structuredOutput;
+    expect(structuredOutput.sources.map((source) => source.url)).toEqual([
+      "https://example.com/view?id=1",
+      "https://example.com/view?id=2",
+      "src/Foo.ts",
+      "src/foo.ts",
+    ]);
+    expect(structuredOutput.stats.urlDupes).toBe(1);
+    expect(
+      taskCalls.filter((call) => call.id.startsWith("extract-source-")).map((call) => call.id)
+    ).toEqual(["extract-source-0", "extract-source-1", "extract-source-2", "extract-source-3"]);
+  });
+
+  test("quick mode applies smaller caps, one-vote verification, and bounded verifier batches", async () => {
+    const taskCalls: WorkflowAgentSpec[] = [];
+    let activeVerifyTasks = 0;
+    let maxActiveVerifyTasks = 0;
+    const { result } = await runDeepResearchFixture(
+      "wfr_deep_research_quick_mode",
+      { topic: "quick caps", mode: "quick" },
+      taskCalls,
+      async (spec) => {
+        if (spec.id.startsWith("verify-claim-")) {
+          const claimIndex = Number(/verify-claim-(\d+)-vote-/.exec(spec.id)?.[1] ?? "0");
+          activeVerifyTasks += 1;
+          maxActiveVerifyTasks = Math.max(maxActiveVerifyTasks, activeVerifyTasks);
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          activeVerifyTasks -= 1;
+          return {
+            taskId: `task_${spec.id}`,
+            reportMarkdown: spec.id,
+            structuredOutput: {
+              claim: `Quick claim ${claimIndex}`,
+              refuted: claimIndex === 0,
+              confidence: "high",
+              evidence:
+                claimIndex === 0 ? "Single quick-mode vote refutes this claim." : "Supported.",
+              counterSource: claimIndex === 0 ? "counter.example" : "",
+            },
+          };
+        }
+        if (spec.id === "scope-topic") {
+          return {
+            taskId: "task_scope",
+            reportMarkdown: "Scoped.",
+            structuredOutput: {
+              refinedTopic: "quick caps",
+              strategy: "Return more angles and sources than quick mode should use.",
+              questions: ["How quick?"],
+              angles: [0, 1, 2, 3].map((index) => ({
+                label: `angle-${index}`,
+                query: `quick caps ${index}`,
+                rationale: "Stress quick-mode caps.",
+              })),
+            },
+          };
+        }
+        if (spec.id.startsWith("discover-sources-")) {
+          const angleIndex = Number(spec.id.replace("discover-sources-", ""));
+          return {
+            taskId: `task_${spec.id}`,
+            reportMarkdown: spec.id,
+            structuredOutput: {
+              sources: Array.from({ length: 4 }, (_value, sourceIndex) => ({
+                title: `Quick source ${angleIndex}-${sourceIndex}`,
+                url: `quick-${angleIndex}-${sourceIndex}.md`,
+                relevance: "high",
+                sourceType: "primary",
+              })),
+            },
+          };
+        }
+        if (spec.id.startsWith("extract-source-")) {
+          const sourceIndex = Number(spec.id.replace("extract-source-", ""));
+          return {
+            taskId: `task_${spec.id}`,
+            reportMarkdown: spec.id,
+            structuredOutput: {
+              source: spec.id,
+              sourceQuality: "primary",
+              publishDate: "",
+              summary: "summary",
+              claims: [
+                { claim: `Quick claim ${sourceIndex}`, quote: "fixture", importance: "central" },
+              ],
+            },
+          };
+        }
+        if (spec.id === "synthesize-report") {
+          return {
+            taskId: "task_final",
+            reportMarkdown: "# Quick capped",
+            structuredOutput: { confidence: "medium", gaps: [], findings: [] },
+          };
+        }
+        throw new Error(`Unexpected deep-research step: ${spec.id}`);
+      }
+    );
+
+    const callIds = taskCalls.map((call) => call.id);
+    const structuredOutput = (
+      result as {
+        structuredOutput: {
+          mode: string;
+          sources: unknown[];
+          claims: unknown[];
+          verification: Array<{ vote: string; refutedVotes: number; survives: boolean }>;
+          confirmedClaims: unknown[];
+          refutedClaims: unknown[];
+          stats: { votesPerClaim: number };
+        };
+      }
+    ).structuredOutput;
+    expect(callIds.filter((id) => id.startsWith("discover-sources-")).length).toBe(3);
+    expect(callIds).not.toContain("discover-sources-3");
+    expect(callIds.filter((id) => id.startsWith("extract-source-")).length).toBe(8);
+    expect(callIds.filter((id) => id.startsWith("verify-claim-")).length).toBe(8);
+    expect(maxActiveVerifyTasks).toBeLessThanOrEqual(4);
+    expect(structuredOutput.mode).toBe("quick");
+    expect(structuredOutput.sources).toHaveLength(8);
+    expect(structuredOutput.claims).toHaveLength(8);
+    expect(structuredOutput.stats.votesPerClaim).toBe(1);
+    expect(structuredOutput.verification[0]).toMatchObject({
+      vote: "0-1",
+      refutedVotes: 1,
+      survives: false,
+    });
+    expect(structuredOutput.confirmedClaims).toHaveLength(7);
+    expect(structuredOutput.refutedClaims).toHaveLength(1);
   });
 
   test("caps model-produced deep-research fan-out", async () => {
@@ -386,6 +988,8 @@ describe("built-in deep-research workflow", () => {
     });
 
     const taskCalls: WorkflowAgentSpec[] = [];
+    let activeVerifyTasks = 0;
+    let maxActiveVerifyTasks = 0;
     const runner = new WorkflowRunner({
       runStore,
       runtimeFactory: new QuickJSRuntimeFactory(),
@@ -396,10 +1000,21 @@ describe("built-in deep-research workflow", () => {
             return {
               taskId: "task_scope",
               reportMarkdown: "Scoped.",
-              structuredOutput: { refinedTopic: "fanout cap", questions: ["How much fanout?"] },
+              structuredOutput: {
+                refinedTopic: "fanout cap",
+                strategy: "Return more sources and claims than the workflow should fan out to.",
+                questions: ["How much fanout?"],
+                angles: [
+                  {
+                    label: "fanout",
+                    query: "fanout cap",
+                    rationale: "Stress source and claim caps.",
+                  },
+                ],
+              },
             };
           }
-          if (spec.id === "discover-sources") {
+          if (spec.id === "discover-sources-0") {
             return {
               taskId: "task_sources",
               reportMarkdown: "Many sources.",
@@ -407,42 +1022,53 @@ describe("built-in deep-research workflow", () => {
                 sources: Array.from({ length: 20 }, (_value, index) => ({
                   title: `Source ${index}`,
                   url: `source-${index}.md`,
-                  relevance: "fixture",
+                  relevance: "high",
+                  sourceType: "primary",
                 })),
               },
             };
           }
-          if (spec.id.startsWith("summarize-source-")) {
+          if (spec.id.startsWith("extract-source-")) {
+            const sourceIndex = Number(spec.id.replace("extract-source-", ""));
             return {
               taskId: `task_${spec.id}`,
               reportMarkdown: spec.id,
-              structuredOutput: { source: spec.id, summary: "summary" },
-            };
-          }
-          if (spec.id === "extract-claims") {
-            return {
-              taskId: "task_claims",
-              reportMarkdown: "Many claims.",
               structuredOutput: {
-                claims: Array.from({ length: 20 }, (_value, index) => ({
-                  claim: `Claim ${index}`,
-                  support: "fixture",
+                source: spec.id,
+                sourceQuality: "primary",
+                publishDate: "",
+                summary: "summary",
+                claims: [0, 1].map((claimIndex) => ({
+                  claim: `Claim ${sourceIndex}-${claimIndex}`,
+                  quote: "fixture",
+                  importance: "central",
                 })),
               },
             };
           }
           if (spec.id.startsWith("verify-claim-")) {
+            const claimIndex = Number(/verify-claim-(\d+)-vote-/.exec(spec.id)?.[1] ?? "0");
+            activeVerifyTasks += 1;
+            maxActiveVerifyTasks = Math.max(maxActiveVerifyTasks, activeVerifyTasks);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            activeVerifyTasks -= 1;
             return {
               taskId: `task_${spec.id}`,
               reportMarkdown: spec.id,
-              structuredOutput: { claim: spec.id, verdict: "supported", risk: "low" },
+              structuredOutput: {
+                claim: `Claim ${Math.floor(claimIndex / 2)}-${claimIndex % 2}`,
+                refuted: false,
+                confidence: "high",
+                evidence: "fixture support",
+                counterSource: "",
+              },
             };
           }
           if (spec.id === "synthesize-report") {
             return {
               taskId: "task_final",
               reportMarkdown: "# Capped",
-              structuredOutput: { confidence: "medium", gaps: [] },
+              structuredOutput: { confidence: "medium", gaps: [], findings: [] },
             };
           }
           throw new Error(`Unexpected deep-research step: ${spec.id}`);
@@ -458,16 +1084,17 @@ describe("built-in deep-research workflow", () => {
     const result = await runner.run("wfr_deep_research_capped");
     const callIds = taskCalls.map((call) => call.id);
 
-    expect(callIds.filter((id) => id.startsWith("summarize-source-")).length).toBe(16);
-    expect(callIds.filter((id) => id.startsWith("verify-claim-")).length).toBe(16);
-    expect(callIds).not.toContain("summarize-source-16");
-    expect(callIds).not.toContain("verify-claim-16");
+    expect(callIds.filter((id) => id.startsWith("extract-source-")).length).toBe(15);
+    expect(callIds.filter((id) => id.startsWith("verify-claim-")).length).toBe(48);
+    expect(maxActiveVerifyTasks).toBeLessThanOrEqual(6);
+    expect(callIds).not.toContain("extract-source-15");
+    expect(callIds).not.toContain("verify-claim-16-vote-0");
     const structuredOutput = (
       result as {
         structuredOutput: { sources: unknown[]; claims: unknown[]; verification: unknown[] };
       }
     ).structuredOutput;
-    expect(structuredOutput.sources).toHaveLength(16);
+    expect(structuredOutput.sources).toHaveLength(15);
     expect(structuredOutput.claims).toHaveLength(16);
     expect(structuredOutput.verification).toHaveLength(16);
   }, 10_000);

--- a/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
+++ b/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
@@ -519,6 +519,7 @@ describe("built-in deep-research workflow", () => {
         verification: [],
         confidence: "low",
         gaps: ["No verifiable claims were extracted."],
+        findings: [],
       },
     });
   });
@@ -846,6 +847,109 @@ describe("built-in deep-research workflow", () => {
     ).toEqual(["extract-source-0", "extract-source-1", "extract-source-2", "extract-source-3"]);
   });
 
+  test("keeps prototype-key source identifiers during dedupe", async () => {
+    const taskCalls: WorkflowAgentSpec[] = [];
+    const { result } = await runDeepResearchFixture(
+      "wfr_deep_research_source_dedupe_prototype_keys",
+      { topic: "prototype key source dedupe" },
+      taskCalls,
+      async (spec) => {
+        switch (spec.id) {
+          case "scope-topic":
+            return {
+              taskId: "task_scope",
+              reportMarkdown: "Scoped.",
+              structuredOutput: {
+                refinedTopic: "prototype key source dedupe",
+                strategy: "Return prototype-like source identifiers.",
+                questions: ["Which source keys collide with object prototypes?"],
+                angles: [
+                  {
+                    label: "sources",
+                    query: "prototype key source dedupe",
+                    rationale: "Check source key trust boundaries.",
+                  },
+                ],
+              },
+            };
+          case "discover-sources-0":
+            return {
+              taskId: "task_sources",
+              reportMarkdown: "Found prototype-key sources.",
+              structuredOutput: {
+                sources: [
+                  {
+                    title: "Constructor",
+                    url: "constructor",
+                    relevance: "high",
+                    sourceType: "primary",
+                  },
+                  {
+                    title: "To string",
+                    url: "toString",
+                    relevance: "high",
+                    sourceType: "primary",
+                  },
+                  {
+                    title: "Has own property",
+                    url: "hasOwnProperty",
+                    relevance: "high",
+                    sourceType: "primary",
+                  },
+                  {
+                    title: "Proto",
+                    url: "__proto__",
+                    relevance: "high",
+                    sourceType: "primary",
+                  },
+                  {
+                    title: "Constructor tracking duplicate",
+                    url: "constructor?utm_source=duplicate#section",
+                    relevance: "high",
+                    sourceType: "primary",
+                  },
+                ],
+              },
+            };
+          default:
+            if (spec.id.startsWith("extract-source-")) {
+              return {
+                taskId: `task_${spec.id}`,
+                reportMarkdown: spec.id,
+                structuredOutput: {
+                  source: spec.id,
+                  sourceQuality: "primary",
+                  publishDate: "",
+                  summary: "No claims needed for prototype-key dedupe coverage.",
+                  claims: [],
+                },
+              };
+            }
+            throw new Error(`Unexpected deep-research step: ${spec.id}`);
+        }
+      }
+    );
+
+    const structuredOutput = (
+      result as {
+        structuredOutput: {
+          sources: Array<{ url: string }>;
+          stats: { sourcesFetched: number; urlDupes: number };
+        };
+      }
+    ).structuredOutput;
+    expect(structuredOutput.sources.map((source) => source.url)).toEqual([
+      "constructor",
+      "toString",
+      "hasOwnProperty",
+      "__proto__",
+    ]);
+    expect(structuredOutput.stats).toMatchObject({ sourcesFetched: 4, urlDupes: 1 });
+    expect(
+      taskCalls.filter((call) => call.id.startsWith("extract-source-")).map((call) => call.id)
+    ).toEqual(["extract-source-0", "extract-source-1", "extract-source-2", "extract-source-3"]);
+  });
+
   test("quick mode applies smaller caps, one-vote verification, and bounded verifier batches", async () => {
     const taskCalls: WorkflowAgentSpec[] = [];
     let activeVerifyTasks = 0;
@@ -964,6 +1068,129 @@ describe("built-in deep-research workflow", () => {
     expect(structuredOutput.refutedClaims).toHaveLength(1);
   });
 
+  test("dedupes exact claim text before spending verification budget", async () => {
+    const taskCalls: WorkflowAgentSpec[] = [];
+    const claimByIndex = ["Repeated central claim", "Unique central claim"];
+    const { result } = await runDeepResearchFixture(
+      "wfr_deep_research_duplicate_claim_budget",
+      { topic: "duplicate claim budget", mode: "quick" },
+      taskCalls,
+      async (spec) => {
+        if (spec.id.startsWith("verify-claim-")) {
+          const claimIndex = Number(/verify-claim-(\d+)-vote-/.exec(spec.id)?.[1] ?? "0");
+          const claim = claimByIndex[claimIndex];
+          if (claim == null) {
+            throw new Error(`Unexpected duplicate-claim verification index: ${claimIndex}`);
+          }
+          return {
+            taskId: `task_${spec.id}`,
+            reportMarkdown: spec.id,
+            structuredOutput: {
+              claim,
+              refuted: false,
+              confidence: "high",
+              evidence: "The grouped claim is supported.",
+              counterSource: "",
+            },
+          };
+        }
+        if (spec.id === "scope-topic") {
+          return {
+            taskId: "task_scope",
+            reportMarkdown: "Scoped.",
+            structuredOutput: {
+              refinedTopic: "duplicate claim budget",
+              strategy:
+                "Return duplicate claims that would otherwise fill quick-mode verification.",
+              questions: ["Do duplicate claims crowd out unique claims?"],
+              angles: [
+                {
+                  label: "duplicates",
+                  query: "duplicate claim budget",
+                  rationale: "Stress exact claim grouping.",
+                },
+              ],
+            },
+          };
+        }
+        if (spec.id === "discover-sources-0") {
+          return {
+            taskId: "task_sources",
+            reportMarkdown: "Found sources.",
+            structuredOutput: {
+              sources: Array.from({ length: 8 }, (_value, index) => ({
+                title: `Duplicate source ${index}`,
+                url: `duplicate-${index}.md`,
+                relevance: "high",
+                sourceType: "primary",
+              })),
+            },
+          };
+        }
+        if (spec.id.startsWith("extract-source-")) {
+          const sourceIndex = Number(spec.id.replace("extract-source-", ""));
+          const claims = [
+            {
+              claim: "Repeated central claim",
+              quote: `Repeated evidence ${sourceIndex}`,
+              importance: "central",
+            },
+          ];
+          if (sourceIndex === 7) {
+            claims.push({
+              claim: "Unique central claim",
+              quote: "Unique evidence",
+              importance: "central",
+            });
+          }
+          return {
+            taskId: `task_${spec.id}`,
+            reportMarkdown: spec.id,
+            structuredOutput: {
+              source: spec.id,
+              sourceQuality: "primary",
+              publishDate: "",
+              summary: "summary",
+              claims,
+            },
+          };
+        }
+        if (spec.id === "synthesize-report") {
+          return {
+            taskId: "task_final",
+            reportMarkdown: "# Duplicate claims grouped",
+            structuredOutput: { confidence: "high", gaps: [], findings: ["Grouped claims"] },
+          };
+        }
+        throw new Error(`Unexpected deep-research step: ${spec.id}`);
+      }
+    );
+
+    const structuredOutput = (
+      result as {
+        structuredOutput: {
+          claims: Array<{ claim: string; duplicateCount: number; evidence: unknown[] }>;
+          verification: unknown[];
+          stats: { claimsExtracted: number; claimsVerified: number };
+        };
+      }
+    ).structuredOutput;
+    expect(structuredOutput.claims.map((claim) => claim.claim)).toEqual([
+      "Repeated central claim",
+      "Unique central claim",
+    ]);
+    expect(structuredOutput.claims[0]).toMatchObject({
+      claim: "Repeated central claim",
+      duplicateCount: 8,
+    });
+    expect(structuredOutput.claims[0].evidence).toHaveLength(8);
+    expect(
+      taskCalls.filter((call) => call.id.startsWith("verify-claim-")).map((call) => call.id)
+    ).toEqual(["verify-claim-0-vote-0", "verify-claim-1-vote-0"]);
+    expect(structuredOutput.verification).toHaveLength(2);
+    expect(structuredOutput.stats).toMatchObject({ claimsExtracted: 2, claimsVerified: 2 });
+  });
+
   test("caps model-produced deep-research fan-out", async () => {
     if (!deepResearch) {
       throw new Error("Expected built-in deep-research workflow");
@@ -1038,7 +1265,7 @@ describe("built-in deep-research workflow", () => {
                 sourceQuality: "primary",
                 publishDate: "",
                 summary: "summary",
-                claims: [0, 1].map((claimIndex) => ({
+                claims: Array.from({ length: 8 }, (_value, claimIndex) => ({
                   claim: `Claim ${sourceIndex}-${claimIndex}`,
                   quote: "fixture",
                   importance: "central",
@@ -1056,7 +1283,7 @@ describe("built-in deep-research workflow", () => {
               taskId: `task_${spec.id}`,
               reportMarkdown: spec.id,
               structuredOutput: {
-                claim: `Claim ${Math.floor(claimIndex / 2)}-${claimIndex % 2}`,
+                claim: `Claim ${Math.floor(claimIndex / 5)}-${claimIndex % 5}`,
                 refuted: false,
                 confidence: "high",
                 evidence: "fixture support",
@@ -1091,12 +1318,23 @@ describe("built-in deep-research workflow", () => {
     expect(callIds).not.toContain("verify-claim-16-vote-0");
     const structuredOutput = (
       result as {
-        structuredOutput: { sources: unknown[]; claims: unknown[]; verification: unknown[] };
+        structuredOutput: {
+          sources: unknown[];
+          sourceExtracts: Array<{ claims: unknown[] }>;
+          claims: unknown[];
+          verification: unknown[];
+          stats: { claimsExtracted: number };
+        };
       }
     ).structuredOutput;
     expect(structuredOutput.sources).toHaveLength(15);
+    expect(structuredOutput.sourceExtracts).toHaveLength(15);
+    expect(structuredOutput.sourceExtracts.every((source) => source.claims.length === 5)).toBe(
+      true
+    );
     expect(structuredOutput.claims).toHaveLength(16);
     expect(structuredOutput.verification).toHaveLength(16);
+    expect(structuredOutput.stats.claimsExtracted).toBe(75);
   }, 10_000);
 });
 

--- a/src/node/services/workflows/builtInWorkflowDefinitions.ts
+++ b/src/node/services/workflows/builtInWorkflowDefinitions.ts
@@ -10,212 +10,629 @@ export const BUILT_IN_WORKFLOW_DEFINITIONS: readonly BuiltInWorkflowDefinition[]
   {
     name: "deep-research",
     description: "Coordinate delegated agents to research, verify, and synthesize a topic.",
-    source: `export default function deepResearch({ args, phase, log, agent, parallelAgents }) {
-  const maxFanOut = 16;
-  const exploreAgentId = "explore";
-  const reasoningAgentId = "exec";
-  // Some users configure Explore with fast/cheap models; reserve Exec for reasoning-heavy synthesis.
+    source: String.raw`export default function deepResearch({ args, phase, log, agent, parallelAgents }) {
+  const input = normalizeDeepResearchInput(args);
+  const config = researchConfigForMode(input.mode);
+  const fastAgentId = "explore";
+  const smartAgentId = "exec";
   const readOnlyReasoningPrompt =
-    "This is a read-only deep-research reasoning task. Do not edit files, create commits, apply patches, push branches, or open PRs. Inspect evidence only as needed and report findings.\\n\\n";
-  const topic = normalizeDeepResearchTopic(args);
+    "This is a read-only deep-research reasoning task. Do not edit files, create commits, apply patches, push branches, or open PRs. Inspect evidence only as needed and report findings.\n\n";
 
-  phase("scope", { topic });
+  if (!input.topic) {
+    return {
+      reportMarkdown: "# Deep Research\n\nNo research topic was provided.",
+      structuredOutput: emptyResearchOutput("", config.mode, "No research topic was provided."),
+    };
+  }
+
+  phase("scope", { topic: input.topic, mode: config.mode });
   const scope = agent({
     id: "scope-topic",
     title: "Scope research topic",
-    agentId: exploreAgentId,
+    agentId: fastAgentId,
     prompt:
-      "Refine this deep research topic into a focused investigation. Return concise research questions and the refined topic.\\n\\nTopic: " +
-      topic,
-    outputSchema: {
-      type: "object",
-      required: ["refinedTopic", "questions"],
-      additionalProperties: false,
-      properties: {
-        refinedTopic: { type: "string" },
-        questions: { type: "array", items: { type: "string" } },
-      },
-    },
+      "Refine this deep research topic into a focused investigation. Return the refined topic, 3-5 complementary research questions, and 3-5 source-discovery angles.\n\n" +
+      "Topic: " +
+      input.topic +
+      "\n\nAngles should be specific and non-overlapping. Favor a mix of primary/official sources, implementation or practitioner evidence, tests/data/benchmarks, recent context, and skeptical or contradictory evidence when relevant.\n\nStructured output only.",
+    outputSchema: scopeSchema(),
   });
-  const refinedTopic = scope.structuredOutput.refinedTopic || topic;
-  log("Scoped deep research topic", { refinedTopic });
+  const refinedTopic = nonEmptyString(scope.structuredOutput.refinedTopic) || input.topic;
+  const questions = asArray(scope.structuredOutput.questions).slice(0, config.maxAngles);
+  const scopedAngles = asArray(scope.structuredOutput.angles).slice(0, config.maxAngles);
+  const angles = scopedAngles.length > 0 ? scopedAngles : fallbackAngles(refinedTopic, questions);
+  log("Scoped deep research topic", { refinedTopic, mode: config.mode, angleCount: angles.length });
 
-  phase("source-discovery", { refinedTopic });
-  const sources = agent({
-    id: "discover-sources",
-    title: "Discover high-signal sources",
-    agentId: exploreAgentId,
-    prompt:
-      "Find high-signal primary or directly relevant sources for this research topic. Prefer repo files, specs, primary docs, and concrete evidence over summaries. Return sources with title, url/path, and relevance.\\n\\nTopic: " +
-      refinedTopic +
-      "\\nQuestions: " +
-      scope.structuredOutput.questions.join("; "),
-    outputSchema: {
-      type: "object",
-      required: ["sources"],
-      additionalProperties: false,
-      properties: {
-        sources: {
-          type: "array",
-          items: {
-            type: "object",
-            required: ["title", "url", "relevance"],
-            additionalProperties: false,
-            properties: {
-              title: { type: "string" },
-              url: { type: "string" },
-              relevance: { type: "string" },
-            },
-          },
-        },
-      },
-    },
+  phase("source-discovery", { angleCount: angles.length });
+  const discoveryResults = parallelAgents(
+    angles.map(function (angle, index) {
+      return {
+        id: "discover-sources-" + index,
+        title: "Discover sources for " + angle.label,
+        agentId: fastAgentId,
+        prompt:
+          "Find high-signal sources for this deep research angle. Use repo inspection and web/docs lookup as appropriate for the topic.\n\n" +
+          "Topic: " +
+          refinedTopic +
+          "\nResearch questions: " +
+          questions.join("; ") +
+          "\nAngle: " +
+          JSON.stringify(angle) +
+          "\n\nReturn 4-6 ranked sources. Prefer primary docs/specs/papers/source files/test evidence and concrete data over summaries. Include a URL or repository path in url. Skip SEO spam and unsupported commentary.\n\nStructured output only.",
+        outputSchema: sourceDiscoverySchema(),
+      };
+    })
+  );
+  const sourceCandidates = discoveryResultsToSources(discoveryResults, angles);
+  const sourceSelection = selectNovelSources(sourceCandidates, angles.length, config.maxSources);
+  const discoveredSources = sourceSelection.sources;
+  log("Discovered sources", {
+    candidates: sourceCandidates.length,
+    selectedCount: discoveredSources.length,
+    urlDupes: sourceSelection.duplicates.length,
+    budgetDropped: sourceSelection.budgetDropped.length,
   });
-  const discoveredSources = sources.structuredOutput.sources.slice(0, maxFanOut);
-  log("Discovered sources", { count: sources.structuredOutput.sources.length, selectedCount: discoveredSources.length });
 
-  phase("source-synthesis", { sourceCount: discoveredSources.length });
-  const sourceSummaries = discoveredSources.length > 0
+  phase("source-extraction", { sourceCount: discoveredSources.length });
+  const sourceExtractionResults = discoveredSources.length > 0
     ? parallelAgents(
         discoveredSources.map(function (source, index) {
           return {
-            id: "summarize-source-" + index,
-            title: "Read and summarize source " + (index + 1),
-            agentId: exploreAgentId,
+            id: "extract-source-" + index,
+            title: "Extract claims from source " + (index + 1),
+            agentId: fastAgentId,
             prompt:
-              "Read or inspect this discovered source and summarize the evidence relevant to the research questions.\\n\\nTopic: " +
+              "Inspect this source and extract falsifiable evidence for the research topic.\n\n" +
+              "Topic: " +
               refinedTopic +
-              "\\nSource: " +
-              JSON.stringify(source),
-            outputSchema: {
-              type: "object",
-              required: ["source", "summary"],
-              additionalProperties: false,
-              properties: {
-                source: { type: "string" },
-                summary: { type: "string" },
-              },
-            },
+              "\nResearch questions: " +
+              questions.join("; ") +
+              "\nSource: " +
+              JSON.stringify(source) +
+              "\n\nReturn a concise source summary, source quality, publish date if available, and 0-5 concrete claims. Each claim must be checkable, relevant to the topic, and backed by a direct quote or exact repository evidence. If the source is unavailable, paywalled, or irrelevant, return claims: [] and sourceQuality: \"unreliable\".\n\nStructured output only.",
+            outputSchema: sourceExtractionSchema(),
           };
         })
       )
     : [];
-  const summaries = { structuredOutput: { summaries: sourceSummaries.map(function (summary) { return summary.structuredOutput; }) } };
+  const sourceExtracts = sourceExtractionResultsToExtracts(sourceExtractionResults, discoveredSources);
+  const allClaims = extractsToClaims(sourceExtracts);
+  const rankedClaims = rankClaims(allClaims).slice(0, config.maxVerifyClaims);
 
-  phase("claim-extraction", { summaryCount: summaries.structuredOutput.summaries.length });
-  const claims = agent({
-    id: "extract-claims",
-    title: "Extract claims and support",
-    agentId: reasoningAgentId,
-    prompt:
-      readOnlyReasoningPrompt +
-      "Extract the most important factual claims and supporting evidence from these source summaries. Return claims with support notes.\\n\\nTopic: " +
-      refinedTopic +
-      "\\nSummaries: " +
-      JSON.stringify(summaries.structuredOutput.summaries),
-    outputSchema: {
-      type: "object",
-      required: ["claims"],
-      additionalProperties: false,
-      properties: {
-        claims: {
-          type: "array",
-          items: {
-            type: "object",
-            required: ["claim", "support"],
-            additionalProperties: false,
-            properties: {
-              claim: { type: "string" },
-              support: { type: "string" },
-            },
-          },
-        },
-      },
-    },
+  phase("claim-ranking", { claimCount: allClaims.length, selectedCount: rankedClaims.length });
+  log("Extracted claims", {
+    sources: sourceExtracts.length,
+    claims: allClaims.length,
+    selectedForVerification: rankedClaims.length,
   });
 
-  const extractedClaims = claims.structuredOutput.claims.slice(0, maxFanOut);
-  phase("adversarial-verification", { claimCount: extractedClaims.length });
-  const verificationFindings = extractedClaims.length > 0
-    ? parallelAgents(
-        extractedClaims.map(function (claim, index) {
-          return {
-            id: "verify-claim-" + index,
-            title: "Adversarially verify claim " + (index + 1),
-            agentId: reasoningAgentId,
-            prompt:
-              readOnlyReasoningPrompt +
-              "Challenge this claim. Look for contradictions, missing evidence, overreach, and lower-confidence areas. Return verdict and risk.\\n\\nTopic: " +
-              refinedTopic +
-              "\\nClaim: " +
-              JSON.stringify(claim),
-            outputSchema: {
-              type: "object",
-              required: ["claim", "verdict", "risk"],
-              additionalProperties: false,
-              properties: {
-                claim: { type: "string" },
-                verdict: { type: "string", enum: ["supported", "mixed", "refuted", "unclear"] },
-                risk: { type: "string", enum: ["low", "medium", "high"] },
-              },
-            },
-          };
-        })
-      )
-    : [];
-  const verification = { structuredOutput: { findings: verificationFindings.map(function (finding) { return finding.structuredOutput; }) } };
-  log("Verified claims", { count: verification.structuredOutput.findings.length });
+  if (rankedClaims.length === 0) {
+    return {
+      reportMarkdown:
+        "# Deep Research\n\nNo verifiable claims were extracted from " +
+        sourceExtracts.length +
+        " selected sources. The research run stopped before adversarial verification.",
+      structuredOutput: {
+        topic: input.topic,
+        refinedTopic: refinedTopic,
+        mode: config.mode,
+        questions: questions,
+        angles: angles,
+        sources: discoveredSources,
+        sourceExtracts: sourceExtracts,
+        claims: [],
+        verification: [],
+        confirmedClaims: [],
+        refutedClaims: [],
+        confidence: "low",
+        gaps: ["No verifiable claims were extracted."],
+        stats: researchStats(config, angles, sourceCandidates, sourceSelection, sourceExtracts, allClaims, [], []),
+      },
+    };
+  }
 
-  phase("final-synthesis", { topic: refinedTopic });
+  phase("adversarial-verification", { claimCount: rankedClaims.length, votesPerClaim: config.votesPerClaim });
+  const voteSpecs = verificationSpecs(rankedClaims, config, smartAgentId, readOnlyReasoningPrompt, refinedTopic);
+  const voteResults = runParallelAgentBatches(voteSpecs, config.verificationBatchSize, parallelAgents);
+  const votedClaims = aggregateVotes(rankedClaims, voteResults, config);
+  const confirmedClaims = votedClaims.filter(function (claim) { return claim.survives; });
+  const refutedClaims = votedClaims.filter(function (claim) { return !claim.survives; });
+  log("Verified claims", {
+    verified: votedClaims.length,
+    confirmed: confirmedClaims.length,
+    refuted: refutedClaims.length,
+  });
+
+  phase("final-synthesis", { confirmed: confirmedClaims.length, refuted: refutedClaims.length });
   const final = agent({
     id: "synthesize-report",
     title: "Synthesize final deep research report",
-    agentId: reasoningAgentId,
+    agentId: smartAgentId,
     prompt:
       readOnlyReasoningPrompt +
-      "Write the final deep research report. Include key findings, citations/source references by title or path, uncertainty, and recommendations for follow-up. Return confidence and remaining gaps as structured output.\\n\\nTopic: " +
+      "Write the final deep research report. Merge semantically duplicate surviving claims, cite source titles/paths/URLs, disclose refuted or uncertain claims, and call out caveats and follow-up work.\n\n" +
+      "Topic: " +
       refinedTopic +
-      "\\nSources: " +
+      "\nMode: " +
+      config.mode +
+      "\nQuestions: " +
+      JSON.stringify(questions) +
+      "\nSources: " +
       JSON.stringify(discoveredSources) +
-      "\\nClaims: " +
-      JSON.stringify(extractedClaims) +
-      "\\nVerification: " +
-      JSON.stringify(verification.structuredOutput.findings),
-    outputSchema: {
-      type: "object",
-      required: ["confidence", "gaps"],
-      additionalProperties: false,
-      properties: {
-        confidence: { type: "string", enum: ["low", "medium", "high"] },
-        gaps: { type: "array", items: { type: "string" } },
-      },
-    },
+      "\nSource extracts: " +
+      JSON.stringify(sourceExtracts.map(function (source) {
+        return {
+          title: source.title,
+          url: source.url,
+          quality: source.sourceQuality,
+          summary: source.summary,
+          claimCount: source.claims.length,
+        };
+      })) +
+      "\nConfirmed claims: " +
+      JSON.stringify(confirmedClaims) +
+      "\nRefuted or unverified claims: " +
+      JSON.stringify(refutedClaims) +
+      "\n\nReturn confidence, remaining gaps, and finding labels as structured output. Put the human-readable report in your final markdown.",
+    outputSchema: finalSynthesisSchema(),
   });
 
   return {
     reportMarkdown: final.reportMarkdown,
     structuredOutput: {
-      topic,
-      refinedTopic,
+      topic: input.topic,
+      refinedTopic: refinedTopic,
+      mode: config.mode,
+      questions: questions,
+      angles: angles,
       sources: discoveredSources,
-      claims: extractedClaims,
-      verification: verification.structuredOutput.findings,
+      sourceExtracts: sourceExtracts,
+      claims: rankedClaims,
+      verification: votedClaims.map(function (claim) {
+        return {
+          claim: claim.claim,
+          source: claim.sourceUrl,
+          vote: claim.vote,
+          refutedVotes: claim.refutedVotes,
+          survives: claim.survives,
+        };
+      }),
+      confirmedClaims: confirmedClaims,
+      refutedClaims: refutedClaims,
       confidence: final.structuredOutput.confidence,
       gaps: final.structuredOutput.gaps,
+      findings: asArray(final.structuredOutput.findings),
+      stats: researchStats(config, angles, sourceCandidates, sourceSelection, sourceExtracts, allClaims, votedClaims, confirmedClaims),
     },
   };
 }
 
+function normalizeDeepResearchInput(args) {
+  const topic = normalizeDeepResearchTopic(args);
+  let mode = "smart";
+  if (args && typeof args === "object") {
+    if (args.quick === true) mode = "quick";
+    if (typeof args.mode === "string") mode = normalizeResearchMode(args.mode);
+  }
+  return { topic: topic, mode: mode };
+}
+
 function normalizeDeepResearchTopic(args) {
-  if (typeof args === "string" && args.trim()) return args.trim();
+  if (typeof args === "string") return nonEmptyString(args);
   if (args && typeof args === "object") {
     if (typeof args.topic === "string" && args.topic.trim()) return args.topic.trim();
     if (typeof args.input === "string" && args.input.trim()) return args.input.trim();
     if (typeof args.query === "string" && args.query.trim()) return args.query.trim();
   }
-  return JSON.stringify(args);
+  return "";
 }
-`,
+
+function normalizeResearchMode(mode) {
+  const normalized = mode.trim().toLowerCase();
+  return normalized === "quick" || normalized === "fast" ? "quick" : "smart";
+}
+
+function researchConfigForMode(mode) {
+  if (mode === "quick") {
+    return { mode: "quick", maxAngles: 3, maxSources: 8, maxVerifyClaims: 8, votesPerClaim: 1, refutationsRequired: 1, verificationBatchSize: 4 };
+  }
+  return { mode: "smart", maxAngles: 5, maxSources: 15, maxVerifyClaims: 16, votesPerClaim: 3, refutationsRequired: 2, verificationBatchSize: 6 };
+}
+
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function fallbackAngles(refinedTopic, questions) {
+  if (questions.length > 0) {
+    return questions.map(function (question, index) {
+      return { label: "question-" + (index + 1), query: question, rationale: "Fallback angle from scoped research question." };
+    });
+  }
+  return [{ label: "general", query: refinedTopic, rationale: "Fallback angle because scoping returned no angles." }];
+}
+
+function discoveryResultsToSources(discoveryResults, angles) {
+  const sources = [];
+  discoveryResults.forEach(function (result, angleIndex) {
+    const angle = angles[angleIndex] || { label: "angle-" + angleIndex };
+    asArray(result.structuredOutput.sources).forEach(function (source, sourceIndex) {
+      sources.push({
+        title: nonEmptyString(source.title) || "Untitled source",
+        url: nonEmptyString(source.url) || nonEmptyString(source.title) || "source-" + angleIndex + "-" + sourceIndex,
+        relevance: normalizeEnum(source.relevance, ["high", "medium", "low"], "medium"),
+        sourceType: normalizeEnum(source.sourceType, ["primary", "secondary", "blog", "forum", "unreliable"], "secondary"),
+        angle: angle.label,
+        angleIndex: angleIndex,
+      });
+    });
+  });
+  return sources;
+}
+
+function selectNovelSources(sources, angleCount, maxSources) {
+  const ordered = interleaveSourcesByAngle(sources, angleCount);
+  const seen = {};
+  const selected = [];
+  const duplicates = [];
+  const budgetDropped = [];
+  ordered.forEach(function (source) {
+    const key = normalizeSourceKey(source.url || source.title);
+    if (!key) {
+      budgetDropped.push(source);
+      return;
+    }
+    if (seen[key]) {
+      duplicates.push(source);
+      return;
+    }
+    if (selected.length >= maxSources) {
+      budgetDropped.push(source);
+      return;
+    }
+    seen[key] = true;
+    selected.push(source);
+  });
+  return { sources: selected, duplicates: duplicates, budgetDropped: budgetDropped };
+}
+
+function interleaveSourcesByAngle(sources, angleCount) {
+  const bucketCount = Math.max(angleCount, 1);
+  const buckets = Array.from({ length: bucketCount }, function () { return []; });
+  sources.forEach(function (source) {
+    const index = typeof source.angleIndex === "number" && source.angleIndex >= 0 && source.angleIndex < bucketCount ? source.angleIndex : 0;
+    buckets[index].push(source);
+  });
+  const maxBucketLength = buckets.reduce(function (max, bucket) { return Math.max(max, bucket.length); }, 0);
+  const ordered = [];
+  for (let offset = 0; offset < maxBucketLength; offset++) {
+    for (let index = 0; index < buckets.length; index++) {
+      if (buckets[index][offset]) ordered.push(buckets[index][offset]);
+    }
+  }
+  return ordered;
+}
+
+function normalizeSourceKey(value) {
+  const raw = stripFragment(String(value || "").trim());
+  if (!raw) return "";
+  const split = splitQuery(raw);
+  const query = normalizeQueryString(split.query);
+  const urlParts = split.path.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\/([^/]*)(.*)$/);
+  if (urlParts) {
+    const scheme = urlParts[1].toLowerCase();
+    const host = urlParts[2].replace(/^www\./i, "").toLowerCase();
+    const path = trimTrailingSlashes(urlParts[3] || "");
+    return scheme + "://" + host + path + (query ? "?" + query : "");
+  }
+  return trimTrailingSlashes(split.path) + (query ? "?" + query : "");
+}
+
+function stripFragment(value) {
+  const hashIndex = value.indexOf("#");
+  return hashIndex >= 0 ? value.slice(0, hashIndex) : value;
+}
+
+function splitQuery(value) {
+  const queryIndex = value.indexOf("?");
+  if (queryIndex < 0) return { path: value, query: "" };
+  return { path: value.slice(0, queryIndex), query: value.slice(queryIndex + 1) };
+}
+
+function normalizeQueryString(query) {
+  if (!query) return "";
+  return query.split("&")
+    .filter(function (part) { return part; })
+    .filter(function (part) { return !isTrackingQueryParam(part); })
+    .sort()
+    .join("&");
+}
+
+function isTrackingQueryParam(part) {
+  const eqIndex = part.indexOf("=");
+  const name = (eqIndex >= 0 ? part.slice(0, eqIndex) : part).toLowerCase();
+  return name.indexOf("utm_") === 0 || name === "fbclid" || name === "gclid" || name === "dclid" || name === "mc_cid" || name === "mc_eid" || name === "igshid";
+}
+
+function trimTrailingSlashes(value) {
+  return value.replace(/\/+$/, "");
+}
+
+function sourceExtractionResultsToExtracts(results, selectedSources) {
+  return results.map(function (result, index) {
+    const source = selectedSources[index] || {};
+    const output = result.structuredOutput;
+    return {
+      title: source.title || nonEmptyString(output.source) || "Untitled source",
+      url: source.url || nonEmptyString(output.source),
+      angle: source.angle || "unknown",
+      relevance: source.relevance || "medium",
+      sourceType: source.sourceType || "secondary",
+      sourceQuality: normalizeEnum(output.sourceQuality, ["primary", "secondary", "blog", "forum", "unreliable"], "unreliable"),
+      publishDate: nonEmptyString(output.publishDate),
+      summary: nonEmptyString(output.summary),
+      claims: asArray(output.claims).map(function (claim) {
+        return {
+          claim: nonEmptyString(claim.claim),
+          quote: nonEmptyString(claim.quote),
+          importance: normalizeEnum(claim.importance, ["central", "supporting", "tangential"], "supporting"),
+        };
+      }).filter(function (claim) { return claim.claim && claim.quote; }),
+    };
+  });
+}
+
+function extractsToClaims(sourceExtracts) {
+  const claims = [];
+  sourceExtracts.forEach(function (source) {
+    source.claims.forEach(function (claim) {
+      claims.push({
+        claim: claim.claim,
+        quote: claim.quote,
+        importance: claim.importance,
+        sourceUrl: source.url,
+        sourceTitle: source.title,
+        sourceQuality: source.sourceQuality,
+        publishDate: source.publishDate,
+      });
+    });
+  });
+  return claims;
+}
+
+function rankClaims(claims) {
+  const importanceRank = { central: 0, supporting: 1, tangential: 2 };
+  const qualityRank = { primary: 0, secondary: 1, blog: 2, forum: 3, unreliable: 4 };
+  return claims.slice().sort(function (left, right) {
+    return (importanceRank[left.importance] - importanceRank[right.importance]) ||
+      (qualityRank[left.sourceQuality] - qualityRank[right.sourceQuality]);
+  });
+}
+
+function verificationSpecs(claims, config, agentId, readOnlyReasoningPrompt, refinedTopic) {
+  const specs = [];
+  claims.forEach(function (claim, claimIndex) {
+    for (let vote = 0; vote < config.votesPerClaim; vote++) {
+      specs.push({
+        id: "verify-claim-" + claimIndex + "-vote-" + vote,
+        title: "Verify claim " + (claimIndex + 1) + " vote " + (vote + 1),
+        agentId: agentId,
+        prompt:
+          readOnlyReasoningPrompt +
+          "Be skeptical and try to refute this claim. Default to refuted=true if the quote does not support the claim, if credible evidence contradicts it, if the source quality is too weak for the claim, or if the claim is stale/marketing/cherry-picked.\n\n" +
+          "Topic: " +
+          refinedTopic +
+          "\nClaim: " +
+          JSON.stringify(claim) +
+          "\nVote: " +
+          (vote + 1) +
+          " of " +
+          config.votesPerClaim +
+          "\n\nReturn a specific verdict. Evidence must explain why the claim is supported or refuted. Structured output only.",
+        outputSchema: verificationSchema(),
+      });
+    }
+  });
+  return specs;
+}
+
+function runParallelAgentBatches(specs, batchSize, parallelAgents) {
+  const results = [];
+  for (let index = 0; index < specs.length; index += batchSize) {
+    const batch = specs.slice(index, index + batchSize);
+    parallelAgents(batch).forEach(function (result) { results.push(result); });
+  }
+  return results;
+}
+
+function aggregateVotes(claims, voteResults, config) {
+  return claims.map(function (claim, claimIndex) {
+    const start = claimIndex * config.votesPerClaim;
+    const votes = voteResults.slice(start, start + config.votesPerClaim).map(function (result) {
+      const output = result.structuredOutput;
+      const returnedClaim = nonEmptyString(output.claim);
+      const claimMismatch = returnedClaim !== claim.claim;
+      return {
+        refuted: claimMismatch || output.refuted === true,
+        confidence: normalizeEnum(output.confidence, ["high", "medium", "low"], "low"),
+        evidence: claimMismatch ? "Verifier returned a mismatched claim identity: " + returnedClaim : nonEmptyString(output.evidence),
+        counterSource: nonEmptyString(output.counterSource),
+      };
+    });
+    const refutedVotes = votes.filter(function (vote) { return vote.refuted; }).length;
+    const supportingVotes = votes.length - refutedVotes;
+    const survives = votes.length >= config.refutationsRequired && refutedVotes < config.refutationsRequired;
+    return Object.assign({}, claim, {
+      votes: votes,
+      vote: supportingVotes + "-" + refutedVotes,
+      refutedVotes: refutedVotes,
+      survives: survives,
+    });
+  });
+}
+
+function researchStats(config, angles, sourceCandidates, sourceSelection, sourceExtracts, allClaims, votedClaims, confirmedClaims) {
+  return {
+    mode: config.mode,
+    angles: angles.length,
+    sourceCandidates: sourceCandidates.length,
+    sourcesFetched: sourceExtracts.length,
+    claimsExtracted: allClaims.length,
+    claimsVerified: votedClaims.length,
+    confirmed: confirmedClaims.length,
+    killed: votedClaims.length - confirmedClaims.length,
+    urlDupes: sourceSelection.duplicates.length,
+    budgetDropped: sourceSelection.budgetDropped.length,
+    votesPerClaim: config.votesPerClaim,
+    agentCalls: 1 + angles.length + sourceExtracts.length + (votedClaims.length * config.votesPerClaim) + (votedClaims.length > 0 ? 1 : 0),
+  };
+}
+
+function emptyResearchOutput(topic, mode, gap) {
+  return {
+    topic: topic,
+    refinedTopic: topic,
+    mode: mode,
+    questions: [],
+    angles: [],
+    sources: [],
+    sourceExtracts: [],
+    claims: [],
+    verification: [],
+    confirmedClaims: [],
+    refutedClaims: [],
+    confidence: "low",
+    gaps: [gap],
+    findings: [],
+    stats: {
+      mode: mode,
+      angles: 0,
+      sourceCandidates: 0,
+      sourcesFetched: 0,
+      claimsExtracted: 0,
+      claimsVerified: 0,
+      confirmed: 0,
+      killed: 0,
+      urlDupes: 0,
+      budgetDropped: 0,
+      votesPerClaim: mode === "quick" ? 1 : 3,
+      agentCalls: 0,
+    },
+  };
+}
+
+function normalizeEnum(value, allowed, fallback) {
+  return allowed.indexOf(value) >= 0 ? value : fallback;
+}
+
+function scopeSchema() {
+  return {
+    type: "object",
+    required: ["refinedTopic", "strategy", "questions", "angles"],
+    additionalProperties: false,
+    properties: {
+      refinedTopic: { type: "string" },
+      strategy: { type: "string" },
+      questions: { type: "array", items: { type: "string" } },
+      angles: {
+        type: "array",
+        items: {
+          type: "object",
+          required: ["label", "query", "rationale"],
+          additionalProperties: false,
+          properties: {
+            label: { type: "string" },
+            query: { type: "string" },
+            rationale: { type: "string" },
+          },
+        },
+      },
+    },
+  };
+}
+
+function sourceDiscoverySchema() {
+  return {
+    type: "object",
+    required: ["sources"],
+    additionalProperties: false,
+    properties: {
+      sources: {
+        type: "array",
+        items: {
+          type: "object",
+          required: ["title", "url", "relevance", "sourceType"],
+          additionalProperties: false,
+          properties: {
+            title: { type: "string" },
+            url: { type: "string" },
+            relevance: { type: "string", enum: ["high", "medium", "low"] },
+            sourceType: { type: "string", enum: ["primary", "secondary", "blog", "forum", "unreliable"] },
+          },
+        },
+      },
+    },
+  };
+}
+
+function sourceExtractionSchema() {
+  return {
+    type: "object",
+    required: ["source", "sourceQuality", "publishDate", "summary", "claims"],
+    additionalProperties: false,
+    properties: {
+      source: { type: "string" },
+      sourceQuality: { type: "string", enum: ["primary", "secondary", "blog", "forum", "unreliable"] },
+      publishDate: { type: "string" },
+      summary: { type: "string" },
+      claims: {
+        type: "array",
+        items: {
+          type: "object",
+          required: ["claim", "quote", "importance"],
+          additionalProperties: false,
+          properties: {
+            claim: { type: "string" },
+            quote: { type: "string" },
+            importance: { type: "string", enum: ["central", "supporting", "tangential"] },
+          },
+        },
+      },
+    },
+  };
+}
+
+function verificationSchema() {
+  return {
+    type: "object",
+    required: ["claim", "refuted", "confidence", "evidence", "counterSource"],
+    additionalProperties: false,
+    properties: {
+      claim: { type: "string" },
+      refuted: { type: "boolean" },
+      confidence: { type: "string", enum: ["high", "medium", "low"] },
+      evidence: { type: "string" },
+      counterSource: { type: "string" },
+    },
+  };
+}
+
+function finalSynthesisSchema() {
+  return {
+    type: "object",
+    required: ["confidence", "gaps", "findings"],
+    additionalProperties: false,
+    properties: {
+      confidence: { type: "string", enum: ["low", "medium", "high"] },
+      gaps: { type: "array", items: { type: "string" } },
+      findings: { type: "array", items: { type: "string" } },
+    },
+  };
+}`,
   },
   // Keep the lightweight /deep-review skill; this workflow is the heavier structured path with
   // adversarial verification for review findings.

--- a/src/node/services/workflows/builtInWorkflowDefinitions.ts
+++ b/src/node/services/workflows/builtInWorkflowDefinitions.ts
@@ -95,7 +95,7 @@ export const BUILT_IN_WORKFLOW_DEFINITIONS: readonly BuiltInWorkflowDefinition[]
         })
       )
     : [];
-  const sourceExtracts = sourceExtractionResultsToExtracts(sourceExtractionResults, discoveredSources);
+  const sourceExtracts = sourceExtractionResultsToExtracts(sourceExtractionResults, discoveredSources, config);
   const allClaims = extractsToClaims(sourceExtracts);
   const rankedClaims = rankClaims(allClaims).slice(0, config.maxVerifyClaims);
 
@@ -126,6 +126,7 @@ export const BUILT_IN_WORKFLOW_DEFINITIONS: readonly BuiltInWorkflowDefinition[]
         refutedClaims: [],
         confidence: "low",
         gaps: ["No verifiable claims were extracted."],
+        findings: [],
         stats: researchStats(config, angles, sourceCandidates, sourceSelection, sourceExtracts, allClaims, [], []),
       },
     };
@@ -234,9 +235,9 @@ function normalizeResearchMode(mode) {
 
 function researchConfigForMode(mode) {
   if (mode === "quick") {
-    return { mode: "quick", maxAngles: 3, maxSources: 8, maxVerifyClaims: 8, votesPerClaim: 1, refutationsRequired: 1, verificationBatchSize: 4 };
+    return { mode: "quick", maxAngles: 3, maxSources: 8, maxClaimsPerSource: 5, maxVerifyClaims: 8, votesPerClaim: 1, refutationsRequired: 1, verificationBatchSize: 4 };
   }
-  return { mode: "smart", maxAngles: 5, maxSources: 15, maxVerifyClaims: 16, votesPerClaim: 3, refutationsRequired: 2, verificationBatchSize: 6 };
+  return { mode: "smart", maxAngles: 5, maxSources: 15, maxClaimsPerSource: 5, maxVerifyClaims: 16, votesPerClaim: 3, refutationsRequired: 2, verificationBatchSize: 6 };
 }
 
 function nonEmptyString(value) {
@@ -276,7 +277,7 @@ function discoveryResultsToSources(discoveryResults, angles) {
 
 function selectNovelSources(sources, angleCount, maxSources) {
   const ordered = interleaveSourcesByAngle(sources, angleCount);
-  const seen = {};
+  const seen = new Set();
   const selected = [];
   const duplicates = [];
   const budgetDropped = [];
@@ -286,7 +287,7 @@ function selectNovelSources(sources, angleCount, maxSources) {
       budgetDropped.push(source);
       return;
     }
-    if (seen[key]) {
+    if (seen.has(key)) {
       duplicates.push(source);
       return;
     }
@@ -294,7 +295,7 @@ function selectNovelSources(sources, angleCount, maxSources) {
       budgetDropped.push(source);
       return;
     }
-    seen[key] = true;
+    seen.add(key);
     selected.push(source);
   });
   return { sources: selected, duplicates: duplicates, budgetDropped: budgetDropped };
@@ -362,10 +363,17 @@ function trimTrailingSlashes(value) {
   return value.replace(/\/+$/, "");
 }
 
-function sourceExtractionResultsToExtracts(results, selectedSources) {
+function sourceExtractionResultsToExtracts(results, selectedSources, config) {
   return results.map(function (result, index) {
     const source = selectedSources[index] || {};
     const output = result.structuredOutput;
+    const claims = asArray(output.claims).map(function (claim) {
+      return {
+        claim: nonEmptyString(claim.claim),
+        quote: nonEmptyString(claim.quote),
+        importance: normalizeEnum(claim.importance, ["central", "supporting", "tangential"], "supporting"),
+      };
+    }).filter(function (claim) { return claim.claim && claim.quote; }).slice(0, config.maxClaimsPerSource);
     return {
       title: source.title || nonEmptyString(output.source) || "Untitled source",
       url: source.url || nonEmptyString(output.source),
@@ -375,22 +383,26 @@ function sourceExtractionResultsToExtracts(results, selectedSources) {
       sourceQuality: normalizeEnum(output.sourceQuality, ["primary", "secondary", "blog", "forum", "unreliable"], "unreliable"),
       publishDate: nonEmptyString(output.publishDate),
       summary: nonEmptyString(output.summary),
-      claims: asArray(output.claims).map(function (claim) {
-        return {
-          claim: nonEmptyString(claim.claim),
-          quote: nonEmptyString(claim.quote),
-          importance: normalizeEnum(claim.importance, ["central", "supporting", "tangential"], "supporting"),
-        };
-      }).filter(function (claim) { return claim.claim && claim.quote; }),
+      claims: claims,
     };
   });
 }
 
 function extractsToClaims(sourceExtracts) {
+  const claimsByKey = new Map();
   const claims = [];
   sourceExtracts.forEach(function (source) {
     source.claims.forEach(function (claim) {
-      claims.push({
+      const key = normalizeClaimKey(claim.claim);
+      if (!key) return;
+      const evidence = {
+        quote: claim.quote,
+        sourceUrl: source.url,
+        sourceTitle: source.title,
+        sourceQuality: source.sourceQuality,
+        publishDate: source.publishDate,
+      };
+      const candidate = {
         claim: claim.claim,
         quote: claim.quote,
         importance: claim.importance,
@@ -398,19 +410,43 @@ function extractsToClaims(sourceExtracts) {
         sourceTitle: source.title,
         sourceQuality: source.sourceQuality,
         publishDate: source.publishDate,
-      });
+        evidence: [evidence],
+        duplicateCount: 1,
+      };
+      const existing = claimsByKey.get(key);
+      if (!existing) {
+        claimsByKey.set(key, candidate);
+        claims.push(candidate);
+        return;
+      }
+      existing.evidence.push(evidence);
+      existing.duplicateCount += 1;
+      if (compareClaimsForRanking(candidate, existing) < 0) {
+        existing.quote = candidate.quote;
+        existing.importance = candidate.importance;
+        existing.sourceUrl = candidate.sourceUrl;
+        existing.sourceTitle = candidate.sourceTitle;
+        existing.sourceQuality = candidate.sourceQuality;
+        existing.publishDate = candidate.publishDate;
+      }
     });
   });
   return claims;
 }
 
+function normalizeClaimKey(value) {
+  return nonEmptyString(value).toLowerCase().split(/\s+/).join(" ");
+}
+
 function rankClaims(claims) {
+  return claims.slice().sort(compareClaimsForRanking);
+}
+
+function compareClaimsForRanking(left, right) {
   const importanceRank = { central: 0, supporting: 1, tangential: 2 };
   const qualityRank = { primary: 0, secondary: 1, blog: 2, forum: 3, unreliable: 4 };
-  return claims.slice().sort(function (left, right) {
-    return (importanceRank[left.importance] - importanceRank[right.importance]) ||
-      (qualityRank[left.sourceQuality] - qualityRank[right.sourceQuality]);
-  });
+  return (importanceRank[left.importance] - importanceRank[right.importance]) ||
+    (qualityRank[left.sourceQuality] - qualityRank[right.sourceQuality]);
 }
 
 function verificationSpecs(claims, config, agentId, readOnlyReasoningPrompt, refinedTopic) {


### PR DESCRIPTION
## Summary

Hardens the built-in `deep-research` workflow by turning the prior linear pass into a staged, bounded, adversarial research pipeline with strict structured-output schemas and targeted regression coverage.

## Background

The workflow now decomposes research topics into source-discovery angles, extracts quote-backed claims from selected sources, ranks claims, runs adversarial verification votes, and synthesizes a final report. A follow-up `deep-review-workflow` pass found four additional correctness/reliability issues, which are fixed in this PR.

## Implementation

- Adds smart/quick research configs with bounded angle/source/claim/verification fan-out.
- Uses source-key `Set` dedupe to avoid `Object.prototype` collisions while preserving meaningful URL query/path variants.
- Caps extracted claims per source before ranking/serialization and filters quote-less claims.
- Groups exact normalized duplicate claim text before applying the verification budget while retaining evidence/source references.
- Treats verifier claim-identity drift as a refutation and batches verifier agents.
- Keeps terminal structured outputs consistent, including `findings: []` on no-topic/no-claim exits.

## Validation

- Ran `deep-review-workflow` against the branch and fixed all four verified findings.
- `bun test src/node/services/workflows/builtInWorkflowDefinitions.test.ts -t "built-in deep-research workflow"`
- `bun test src/node/services/workflows/builtInWorkflowDefinitions.test.ts`
- `make static-check`
- Re-ran workflow tests and `make static-check` after rebasing onto latest `origin/main`.

## Risks

Medium: this changes a built-in workflow conductor string executed inside QuickJS. The changes are bounded to `deep-research` and covered by regression tests for no-topic/no-claim paths, strict schema shape, source dedupe, quote filtering, claim identity validation, quick-mode caps, verifier batching, per-source claim caps, and duplicate-claim grouping.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$49.29`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=49.29 -->
