### PR TITLE
🤖 feat: enable native Google tools for Gemini 3

### DIFF
--- a/src/common/utils/tools/toolDefinitions.test.ts
+++ b/src/common/utils/tools/toolDefinitions.test.ts
@@ -425,14 +425,16 @@ describe("TOOL_DEFINITIONS", () => {
     expect(enabledTools).toContain("workflow_run");
   });
 
-  it("gates native Google tools to Gemini 3+ models", () => {
+  it("gates native Google tools to Gemini 3 models", () => {
     expect(getAvailableTools("google:gemini-2.5-pro")).not.toContain("google_search");
     expect(getAvailableTools("google:gemini-2.5-pro")).not.toContain("url_context");
+    expect(getAvailableTools("google:gemini-4-pro")).not.toContain("google_search");
+    expect(getAvailableTools("google:gemini-4-pro")).not.toContain("url_context");
 
     for (const modelString of [
       "google:gemini-3.1-pro-preview",
       "google:gemini-3.5-flash",
-      "google:gemini-4-pro",
+      "google:models/gemini-3.5-flash",
     ]) {
       const tools = getAvailableTools(modelString);
       expect(tools).toContain("google_search");
@@ -440,11 +442,12 @@ describe("TOOL_DEFINITIONS", () => {
     }
   });
 
-  it("classifies Gemini 3+ as supporting mixed native Google and function tools", () => {
+  it("classifies Gemini 3 as supporting mixed native Google and function tools", () => {
     expect(supportsGoogleNativeToolsWithFunctionTools("gemini-2.5-pro")).toBe(false);
     expect(supportsGoogleNativeToolsWithFunctionTools("gemini-3.1-pro-preview")).toBe(true);
     expect(supportsGoogleNativeToolsWithFunctionTools("gemini-3.5-flash")).toBe(true);
-    expect(supportsGoogleNativeToolsWithFunctionTools("gemini-4-pro")).toBe(true);
+    expect(supportsGoogleNativeToolsWithFunctionTools("models/gemini-3.5-flash")).toBe(true);
+    expect(supportsGoogleNativeToolsWithFunctionTools("gemini-4-pro")).toBe(false);
   });
 
   it("agent_skill_write schema rejects an advertise tool argument (advertise is authored in content)", () => {

--- a/src/common/utils/tools/toolDefinitions.test.ts
+++ b/src/common/utils/tools/toolDefinitions.test.ts
@@ -2,6 +2,7 @@ import { RUNTIME_MODE } from "@/common/types/runtime";
 import {
   buildTaskToolDescription,
   getAvailableTools,
+  supportsGoogleNativeToolsWithFunctionTools,
   TaskToolArgsSchema,
   TOOL_DEFINITIONS,
 } from "./toolDefinitions";
@@ -422,6 +423,28 @@ describe("TOOL_DEFINITIONS", () => {
     expect(enabledTools).toContain("workflow_read");
     expect(enabledTools).toContain("workflow_action_list");
     expect(enabledTools).toContain("workflow_run");
+  });
+
+  it("gates native Google tools to Gemini 3+ models", () => {
+    expect(getAvailableTools("google:gemini-2.5-pro")).not.toContain("google_search");
+    expect(getAvailableTools("google:gemini-2.5-pro")).not.toContain("url_context");
+
+    for (const modelString of [
+      "google:gemini-3.1-pro-preview",
+      "google:gemini-3.5-flash",
+      "google:gemini-4-pro",
+    ]) {
+      const tools = getAvailableTools(modelString);
+      expect(tools).toContain("google_search");
+      expect(tools).toContain("url_context");
+    }
+  });
+
+  it("classifies Gemini 3+ as supporting mixed native Google and function tools", () => {
+    expect(supportsGoogleNativeToolsWithFunctionTools("gemini-2.5-pro")).toBe(false);
+    expect(supportsGoogleNativeToolsWithFunctionTools("gemini-3.1-pro-preview")).toBe(true);
+    expect(supportsGoogleNativeToolsWithFunctionTools("gemini-3.5-flash")).toBe(true);
+    expect(supportsGoogleNativeToolsWithFunctionTools("gemini-4-pro")).toBe(true);
   });
 
   it("agent_skill_write schema rejects an advertise tool argument (advertise is authored in content)", () => {

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -2333,6 +2333,17 @@ export function getToolSchemas(): Record<string, ToolSchema> {
 }
 
 /**
+ * Google's mixed built-in + function tool path is supported for Gemini 3+.
+ * Keep native Google tools gated here so the prompt allowlist matches the actual toolset.
+ */
+export function supportsGoogleNativeToolsWithFunctionTools(modelId: string): boolean {
+  const match = /^gemini-(\d+)(?:[.-]|$)/.exec(modelId);
+  if (!match) return false;
+  const major = Number.parseInt(match[1], 10);
+  return major >= 3;
+}
+
+/**
  * Get which tools are available for a given model
  * @param modelString The model string (e.g., "anthropic:claude-opus-4-1")
  * @returns Array of tool names available for the model
@@ -2348,7 +2359,7 @@ export function getAvailableTools(
     enableMuxGlobalAgentsTools?: boolean;
   }
 ): string[] {
-  const [provider] = modelString.split(":");
+  const [provider, modelId = ""] = modelString.split(":");
   const enableAgentReport = options?.enableAgentReport ?? true;
   const enableAnalyticsQuery = options?.enableAnalyticsQuery ?? true;
   const enableAdvisor = options?.enableAdvisor ?? false;
@@ -2416,7 +2427,10 @@ export function getAvailableTools(
       }
       return baseTools;
     case "google":
-      return [...baseTools, "google_search"];
+      if (supportsGoogleNativeToolsWithFunctionTools(modelId)) {
+        return [...baseTools, "google_search", "url_context"];
+      }
+      return baseTools;
     default:
       return baseTools;
   }

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -2333,14 +2333,16 @@ export function getToolSchemas(): Record<string, ToolSchema> {
 }
 
 /**
- * Google's mixed built-in + function tool path is supported for Gemini 3+.
+ * Google's mixed built-in + function tool path is currently supported for Gemini 3.
  * Keep native Google tools gated here so the prompt allowlist matches the actual toolset.
  */
 export function supportsGoogleNativeToolsWithFunctionTools(modelId: string): boolean {
-  const match = /^gemini-(\d+)(?:[.-]|$)/.exec(modelId);
+  const bareModelId = modelId.split("/").pop() ?? modelId;
+  const match = /^gemini-(\d+)(?:[.-]|$)/.exec(bareModelId);
   if (!match) return false;
   const major = Number.parseInt(match[1], 10);
-  return major >= 3;
+  // The installed @ai-sdk/google mixed native/function serialization path is Gemini 3-only.
+  return major === 3;
 }
 
 /**

--- a/src/common/utils/tools/tools.test.ts
+++ b/src/common/utils/tools/tools.test.ts
@@ -223,6 +223,39 @@ describe("getToolsForModel", () => {
     expect(Object.keys(tools).filter((toolName) => toolName.startsWith("desktop_"))).toEqual([]);
   });
 
+  test("adds native Google Search and URL Context only for Gemini 3+ models", async () => {
+    const runtime = new LocalRuntime(process.cwd());
+    const initStateManager = createInitStateManager();
+
+    const gemini25Tools = await getToolsForModel(
+      "google:gemini-2.5-pro",
+      {
+        cwd: process.cwd(),
+        runtime,
+        runtimeTempDir: "/tmp",
+        workspaceId: "ws-1",
+      },
+      "ws-1",
+      initStateManager
+    );
+    expect(gemini25Tools.google_search).toBeUndefined();
+    expect(gemini25Tools.url_context).toBeUndefined();
+
+    const gemini35Tools = await getToolsForModel(
+      "google:gemini-3.5-flash",
+      {
+        cwd: process.cwd(),
+        runtime,
+        runtimeTempDir: "/tmp",
+        workspaceId: "ws-1",
+      },
+      "ws-1",
+      initStateManager
+    );
+    expect(gemini35Tools.google_search).toBeDefined();
+    expect(gemini35Tools.url_context).toBeDefined();
+  });
+
   test("returns tool keys in sorted order", async () => {
     const runtime = new LocalRuntime(process.cwd());
     const initStateManager = createInitStateManager();

--- a/src/common/utils/tools/tools.test.ts
+++ b/src/common/utils/tools/tools.test.ts
@@ -223,7 +223,7 @@ describe("getToolsForModel", () => {
     expect(Object.keys(tools).filter((toolName) => toolName.startsWith("desktop_"))).toEqual([]);
   });
 
-  test("adds native Google Search and URL Context only for Gemini 3+ models", async () => {
+  test("adds native Google Search and URL Context only for Gemini 3 models", async () => {
     const runtime = new LocalRuntime(process.cwd());
     const initStateManager = createInitStateManager();
 
@@ -241,6 +241,20 @@ describe("getToolsForModel", () => {
     expect(gemini25Tools.google_search).toBeUndefined();
     expect(gemini25Tools.url_context).toBeUndefined();
 
+    const gemini4Tools = await getToolsForModel(
+      "google:gemini-4-pro",
+      {
+        cwd: process.cwd(),
+        runtime,
+        runtimeTempDir: "/tmp",
+        workspaceId: "ws-1",
+      },
+      "ws-1",
+      initStateManager
+    );
+    expect(gemini4Tools.google_search).toBeUndefined();
+    expect(gemini4Tools.url_context).toBeUndefined();
+
     const gemini35Tools = await getToolsForModel(
       "google:gemini-3.5-flash",
       {
@@ -252,6 +266,20 @@ describe("getToolsForModel", () => {
       "ws-1",
       initStateManager
     );
+    const namespacedGemini35Tools = await getToolsForModel(
+      "google:models/gemini-3.5-flash",
+      {
+        cwd: process.cwd(),
+        runtime,
+        runtimeTempDir: "/tmp",
+        workspaceId: "ws-1",
+      },
+      "ws-1",
+      initStateManager
+    );
+    expect(namespacedGemini35Tools.google_search).toBeDefined();
+    expect(namespacedGemini35Tools.url_context).toBeDefined();
+
     expect(gemini35Tools.google_search).toBeDefined();
     expect(gemini35Tools.url_context).toBeDefined();
   });

--- a/src/common/utils/tools/tools.ts
+++ b/src/common/utils/tools/tools.ts
@@ -53,7 +53,10 @@ import { log } from "@/node/services/log";
 import { attachModelOnlyToolNotifications } from "@/common/utils/tools/internalToolResultFields";
 import { NotificationEngine } from "@/node/services/agentNotifications/NotificationEngine";
 import { TodoListReminderSource } from "@/node/services/agentNotifications/sources/TodoListReminderSource";
-import { getAvailableTools } from "@/common/utils/tools/toolDefinitions";
+import {
+  getAvailableTools,
+  supportsGoogleNativeToolsWithFunctionTools,
+} from "@/common/utils/tools/toolDefinitions";
 import { sanitizeMCPToolsForOpenAI } from "@/common/utils/tools/schemaSanitizer";
 
 import type { Runtime } from "@/node/runtime/Runtime";
@@ -594,10 +597,20 @@ export async function getToolsForModel(
         break;
       }
 
-      // Note: Gemini 3 tool support:
-      // Combining native tools with function calling is currently only
-      // supported in the Live API. Thus no `google_search` or `url_context` added here.
-      // - https://ai.google.dev/gemini-api/docs/function-calling?example=meeting#native-tools
+      case "google": {
+        if (supportsGoogleNativeToolsWithFunctionTools(modelId)) {
+          const { google } = await import("@ai-sdk/google");
+          allTools = {
+            ...baseTools,
+            ...(mcpTools ?? {}),
+            // Google exposes native Search and URL Context as provider-executed tools for
+            // Gemini 3+. These coexist with Mux function tools in the standard streaming API.
+            google_search: google.tools.googleSearch({}) as Tool,
+            url_context: google.tools.urlContext({}) as Tool,
+          };
+        }
+        break;
+      }
     }
   } catch (error) {
     // If tools aren't available, just use base tools

--- a/src/node/utils/main/tokenizer.test.ts
+++ b/src/node/utils/main/tokenizer.test.ts
@@ -74,4 +74,16 @@ describe("tokenizer", () => {
     );
     expect(tokens).toBeGreaterThan(0);
   });
+
+  test("uses native Google tool token fallbacks for Gemini 3", async () => {
+    await expect(
+      getToolDefinitionTokens("url_context", "google:gemini-2.5-pro", undefined, undefined)
+    ).resolves.toBe(0);
+    await expect(
+      getToolDefinitionTokens("url_context", "google:gemini-3.5-flash", undefined, undefined)
+    ).resolves.toBe(50);
+    await expect(
+      getToolDefinitionTokens("google_search", "google:gemini-3.5-flash", undefined, undefined)
+    ).resolves.toBe(50);
+  });
 });

--- a/src/node/utils/main/tokenizer.ts
+++ b/src/node/utils/main/tokenizer.ts
@@ -243,6 +243,17 @@ export function countTokensForData(data: unknown, tokenizer: Tokenizer): Promise
   return tokenizer.countTokens(serialized);
 }
 
+const TOOL_DEFINITION_FALLBACK_TOKENS: Record<string, number> = {
+  bash: 65,
+  file_read: 45,
+  file_edit_replace_string: 70,
+  file_edit_replace_lines: 80,
+  file_edit_insert: 50,
+  web_search: 50,
+  google_search: 50,
+  url_context: 50,
+};
+
 export async function getToolDefinitionTokens(
   toolName: string,
   modelString: string,
@@ -260,23 +271,13 @@ export async function getToolDefinitionTokens(
     const toolSchemas = getToolSchemas();
     const toolSchema = toolSchemas[toolName];
     if (!toolSchema) {
-      return 40;
+      return TOOL_DEFINITION_FALLBACK_TOKENS[toolName] ?? 40;
     }
 
     const tokenizerModel = metadataModelOverride ?? modelString;
     return countTokens(tokenizerModel, JSON.stringify(toolSchema));
   } catch {
-    const fallbackSizes: Record<string, number> = {
-      bash: 65,
-      file_read: 45,
-      file_edit_replace_string: 70,
-      file_edit_replace_lines: 80,
-      file_edit_insert: 50,
-      web_search: 50,
-      google_search: 50,
-      url_context: 50,
-    };
-    return fallbackSizes[toolName] ?? 40;
+    return TOOL_DEFINITION_FALLBACK_TOKENS[toolName] ?? 40;
   }
 }
 

--- a/src/node/utils/main/tokenizer.ts
+++ b/src/node/utils/main/tokenizer.ts
@@ -274,6 +274,7 @@ export async function getToolDefinitionTokens(
       file_edit_insert: 50,
       web_search: 50,
       google_search: 50,
+      url_context: 50,
     };
     return fallbackSizes[toolName] ?? 40;
   }


### PR DESCRIPTION
Summary

Enable provider-native Google Search and URL Context for direct Google Gemini 3 models, so Gemini 3 agents can use Google's built-in web/context tools alongside Mux function tools.

Background

Google's current Gemini 3 tooling supports combining provider-native tools with function calling. The previous Mux implementation had a stale comment that prevented Google native tools from being instantiated, so Gemini models only received Mux's runtime `web_fetch` and no native Google Search.

Implementation

- Add a shared `supportsGoogleNativeToolsWithFunctionTools()` gate for Google native tools.
- Gate native Google tools to Gemini 3 model IDs, including the valid `models/gemini-3.5-flash` spelling.
- Instantiate `google.tools.googleSearch({})` and `google.tools.urlContext({})` for supported direct Google models.
- Keep Gemini 2.5 and future Gemini 4 IDs off the native-tool path until the installed Google SDK serializes mixed native/function tools for them.
- Add tokenizer fallback handling/tests for schema-less provider-native tools.

Validation

- `bun test src/common/utils/tools/toolDefinitions.test.ts src/common/utils/tools/tools.test.ts`
- `bun x jest src/node/utils/main/tokenizer.test.ts --runInBand`
- `make typecheck`
- `make static-check`
- Ran `deep-review-workflow` and fixed the three verified findings: Gemini 4 over-gating, `models/...` Gemini 3 IDs, and unreachable `url_context` token fallback.

Risks

Medium-low. This changes tool availability for Google Gemini 3 direct-provider sessions only. The main risk is provider SDK compatibility, so the gate intentionally tracks the currently verified Gemini 3 mixed native/function path rather than pre-enabling future major versions.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$20.40`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=20.40 -->
