### PR TITLE
🤖 feat: add workflow visibility surfaces

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -190,6 +190,7 @@ function AppInner() {
   );
 
   const [isMultiProjectWorkspaceModalOpen, setMultiProjectWorkspaceModalOpen] = useState(false);
+  const dynamicWorkflowsEnabled = useExperimentValue(EXPERIMENT_IDS.DYNAMIC_WORKFLOWS);
   const multiProjectWorkspacesEnabled = useExperimentValue(EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES);
 
   // Left sidebar is drag-resizable (mirrors RightSidebar). Width is persisted globally;
@@ -717,6 +718,9 @@ function AppInner() {
     onSetThinkingLevel: setThinkingLevelFromPalette,
     getMinThinkingOverride,
     onStartWorkspaceCreation: openNewWorkspaceFromPalette,
+    enabledRightSidebarFeatureFlags: dynamicWorkflowsEnabled
+      ? new Set([EXPERIMENT_IDS.DYNAMIC_WORKFLOWS])
+      : undefined,
     onStartMultiProjectWorkspaceCreation: openNewMultiProjectWorkspaceFromPalette,
     multiProjectWorkspacesEnabled,
     onArchiveMergedWorkspacesInProject: archiveMergedWorkspacesInProjectFromPalette,

--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -190,7 +190,9 @@ function AppInner() {
   );
 
   const [isMultiProjectWorkspaceModalOpen, setMultiProjectWorkspaceModalOpen] = useState(false);
+  const agentBrowserEnabled = useExperimentValue(EXPERIMENT_IDS.AGENT_BROWSER);
   const dynamicWorkflowsEnabled = useExperimentValue(EXPERIMENT_IDS.DYNAMIC_WORKFLOWS);
+  const portableDesktopEnabled = useExperimentValue(EXPERIMENT_IDS.PORTABLE_DESKTOP);
   const multiProjectWorkspacesEnabled = useExperimentValue(EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES);
 
   // Left sidebar is drag-resizable (mirrors RightSidebar). Width is persisted globally;
@@ -709,6 +711,12 @@ function AppInner() {
     [handleNavigateWorkspace]
   );
 
+  const enabledRightSidebarFeatureFlags = new Set<string>();
+  if (agentBrowserEnabled) enabledRightSidebarFeatureFlags.add(EXPERIMENT_IDS.AGENT_BROWSER);
+  if (dynamicWorkflowsEnabled)
+    enabledRightSidebarFeatureFlags.add(EXPERIMENT_IDS.DYNAMIC_WORKFLOWS);
+  if (portableDesktopEnabled) enabledRightSidebarFeatureFlags.add(EXPERIMENT_IDS.PORTABLE_DESKTOP);
+
   registerParamsRef.current = {
     userProjects,
     workspaceMetadata,
@@ -718,9 +726,7 @@ function AppInner() {
     onSetThinkingLevel: setThinkingLevelFromPalette,
     getMinThinkingOverride,
     onStartWorkspaceCreation: openNewWorkspaceFromPalette,
-    enabledRightSidebarFeatureFlags: dynamicWorkflowsEnabled
-      ? new Set([EXPERIMENT_IDS.DYNAMIC_WORKFLOWS])
-      : undefined,
+    enabledRightSidebarFeatureFlags,
     onStartMultiProjectWorkspaceCreation: openNewMultiProjectWorkspaceFromPalette,
     multiProjectWorkspacesEnabled,
     onArchiveMergedWorkspacesInProject: archiveMergedWorkspacesInProjectFromPalette,

--- a/src/browser/components/WorkflowIndicator/WorkflowIndicator.test.tsx
+++ b/src/browser/components/WorkflowIndicator/WorkflowIndicator.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
 import { installDom } from "../../../../tests/ui/dom";
 
 import type { WorkflowDefinitionDescriptor, WorkflowRunRecord } from "@/common/types/workflow";
@@ -100,7 +100,7 @@ describe("WorkflowIndicatorView", () => {
     expect(view.getByLabelText("2 workflows need attention")).toBeTruthy();
   });
 
-  test("opens the workflows tab from the popover action", () => {
+  test("opens the workflows tab from the popover action", async () => {
     let opened = false;
     const view = render(
       <TooltipProvider>
@@ -124,7 +124,9 @@ describe("WorkflowIndicatorView", () => {
     );
 
     fireEvent.click(view.getByLabelText("Workflows"));
-    fireEvent.click(view.getByText("Open tab"));
+    const body = within(view.container.ownerDocument.body);
+    const openTabButton = await waitFor(() => body.getByText("Open tab"));
+    fireEvent.click(openTabButton);
 
     expect(opened).toBe(true);
   });

--- a/src/browser/components/WorkflowIndicator/WorkflowIndicator.test.tsx
+++ b/src/browser/components/WorkflowIndicator/WorkflowIndicator.test.tsx
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { installDom } from "../../../../tests/ui/dom";
 
 import type { WorkflowDefinitionDescriptor, WorkflowRunRecord } from "@/common/types/workflow";
 import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
-import { WorkflowIndicatorView } from "./WorkflowIndicator";
+import { WorkflowIndicatorPopoverContent, WorkflowIndicatorView } from "./WorkflowIndicator";
 import {
   groupWorkflowDefinitionsByScope,
   summarizeWorkflowRuns,
@@ -100,33 +100,27 @@ describe("WorkflowIndicatorView", () => {
     expect(view.getByLabelText("2 workflows need attention")).toBeTruthy();
   });
 
-  test("opens the workflows tab from the popover action", async () => {
+  test("opens the workflows tab from the popover action", () => {
     let opened = false;
     const view = render(
-      <TooltipProvider>
-        <WorkflowIndicatorView
-          workspaceId="workspace-1"
-          onOpenWorkflowsTab={() => {
-            opened = true;
-          }}
-          snapshot={{
-            definitions: [],
-            definitionGroups: groupWorkflowDefinitionsByScope([]),
-            runs: [],
-            currentRuns: [],
-            historyRuns: [],
-            summary: summarizeWorkflowRuns([]),
-            isLoading: false,
-            error: null,
-          }}
-        />
-      </TooltipProvider>
+      <WorkflowIndicatorPopoverContent
+        onOpenWorkflowsTab={() => {
+          opened = true;
+        }}
+        snapshot={{
+          definitions: [],
+          definitionGroups: groupWorkflowDefinitionsByScope([]),
+          runs: [],
+          currentRuns: [],
+          historyRuns: [],
+          summary: summarizeWorkflowRuns([]),
+          isLoading: false,
+          error: null,
+        }}
+      />
     );
 
-    fireEvent.click(view.getByLabelText("Workflows"));
-    const body = within(view.container.ownerDocument.body);
-    const openTabButton = await waitFor(() => body.getByText("Open tab"));
-    fireEvent.click(openTabButton);
+    fireEvent.click(view.getByText("Open tab"));
 
     expect(opened).toBe(true);
   });

--- a/src/browser/components/WorkflowIndicator/WorkflowIndicator.test.tsx
+++ b/src/browser/components/WorkflowIndicator/WorkflowIndicator.test.tsx
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { installDom } from "../../../../tests/ui/dom";
+
+import type { WorkflowDefinitionDescriptor, WorkflowRunRecord } from "@/common/types/workflow";
+import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
+import { WorkflowIndicatorView } from "./WorkflowIndicator";
+import {
+  groupWorkflowDefinitionsByScope,
+  summarizeWorkflowRuns,
+} from "@/browser/features/Workflows/workflowStatusPresentation";
+
+function definition(
+  name: string,
+  scope: WorkflowDefinitionDescriptor["scope"]
+): WorkflowDefinitionDescriptor {
+  return { name, scope, description: `${name} workflow`, executable: true };
+}
+
+function run(overrides: Partial<WorkflowRunRecord>): WorkflowRunRecord {
+  return {
+    id: "wfr_test",
+    workspaceId: "workspace-1",
+    definition: definition("demo", "project"),
+    definitionSource: "/repo/.mux/workflows/demo.js",
+    definitionHash: "hash",
+    args: {},
+    status: "running",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    events: [],
+    steps: [],
+    ...overrides,
+  };
+}
+
+describe("WorkflowIndicatorView", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installDom();
+  });
+
+  afterEach(() => {
+    cleanup();
+    cleanupDom?.();
+    cleanupDom = null;
+  });
+
+  test("prioritizes problem runs over active counts", () => {
+    const definitions = [definition("project-flow", "project")];
+    const runs = [
+      run({ id: "wfr_failed", status: "failed", definition: definitions[0] }),
+      run({ id: "wfr_running", status: "running" }),
+    ];
+    const view = render(
+      <TooltipProvider>
+        <WorkflowIndicatorView
+          workspaceId="workspace-1"
+          snapshot={{
+            definitions,
+            definitionGroups: groupWorkflowDefinitionsByScope(definitions),
+            runs,
+            currentRuns: runs,
+            historyRuns: [],
+            summary: summarizeWorkflowRuns(runs),
+            isLoading: false,
+            error: null,
+          }}
+        />
+      </TooltipProvider>
+    );
+
+    const button = view.getByLabelText("1 workflow needs attention");
+    expect(button.textContent).toContain("1");
+  });
+
+  test("uses plural grammar for multiple problem runs", () => {
+    const failed = run({ id: "wfr_failed", status: "failed" });
+    const interrupted = run({ id: "wfr_interrupted", status: "interrupted" });
+    const runs = [failed, interrupted];
+    const view = render(
+      <TooltipProvider>
+        <WorkflowIndicatorView
+          workspaceId="workspace-1"
+          snapshot={{
+            definitions: [],
+            definitionGroups: groupWorkflowDefinitionsByScope([]),
+            runs,
+            currentRuns: runs,
+            historyRuns: [],
+            summary: summarizeWorkflowRuns(runs),
+            isLoading: false,
+            error: null,
+          }}
+        />
+      </TooltipProvider>
+    );
+
+    expect(view.getByLabelText("2 workflows need attention")).toBeTruthy();
+  });
+
+  test("opens the workflows tab from the popover action", () => {
+    let opened = false;
+    const view = render(
+      <TooltipProvider>
+        <WorkflowIndicatorView
+          workspaceId="workspace-1"
+          onOpenWorkflowsTab={() => {
+            opened = true;
+          }}
+          snapshot={{
+            definitions: [],
+            definitionGroups: groupWorkflowDefinitionsByScope([]),
+            runs: [],
+            currentRuns: [],
+            historyRuns: [],
+            summary: summarizeWorkflowRuns([]),
+            isLoading: false,
+            error: null,
+          }}
+        />
+      </TooltipProvider>
+    );
+
+    fireEvent.click(view.getByLabelText("Workflows"));
+    fireEvent.click(view.getByText("Open tab"));
+
+    expect(opened).toBe(true);
+  });
+});

--- a/src/browser/components/WorkflowIndicator/WorkflowIndicator.tsx
+++ b/src/browser/components/WorkflowIndicator/WorkflowIndicator.tsx
@@ -83,47 +83,59 @@ export function WorkflowIndicatorView(props: WorkflowIndicatorViewProps) {
         align="end"
         className="bg-modal-bg border-separator-light w-72 overflow-visible rounded px-3 py-2 text-xs font-normal shadow-[0_2px_8px_rgba(0,0,0,0.4)]"
       >
-        <div className="flex flex-col gap-3">
-          <div className="flex items-center justify-between gap-2">
-            <div className="text-foreground font-medium">Workflows</div>
-            <button
-              type="button"
-              className="text-accent hover:underline"
-              onClick={openWorkflowsTab}
-            >
-              Open tab
-            </button>
-          </div>
-          <IndicatorSection title="Active and attention">
-            {props.snapshot.currentRuns.length === 0 ? (
-              <p className="text-muted">No active workflows</p>
-            ) : (
-              props.snapshot.currentRuns.slice(0, 5).map((run) => {
-                const presentation = getWorkflowStatusPresentation(run.status);
-                return (
-                  <div key={run.id} className="flex items-center justify-between gap-2">
-                    <span className="truncate">{run.definition.name}</span>
-                    <span className="text-muted shrink-0">{presentation.label}</span>
-                  </div>
-                );
-              })
-            )}
-          </IndicatorSection>
-          <IndicatorSection title="Available definitions">
-            {props.snapshot.definitions.length === 0 ? (
-              <p className="text-muted">No definitions found</p>
-            ) : (
-              <p className="text-muted">
-                {props.snapshot.definitionGroups.project.length} project ·{" "}
-                {props.snapshot.definitionGroups.global.length} global ·{" "}
-                {props.snapshot.definitionGroups["built-in"].length} built-in ·{" "}
-                {props.snapshot.definitionGroups.scratch.length} scratch
-              </p>
-            )}
-          </IndicatorSection>
-        </div>
+        <WorkflowIndicatorPopoverContent
+          snapshot={props.snapshot}
+          onOpenWorkflowsTab={openWorkflowsTab}
+        />
       </PopoverContent>
     </Popover>
+  );
+}
+
+export function WorkflowIndicatorPopoverContent(props: {
+  snapshot: WorkflowWorkspaceSnapshot;
+  onOpenWorkflowsTab: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-foreground font-medium">Workflows</div>
+        <button
+          type="button"
+          className="text-accent hover:underline"
+          onClick={props.onOpenWorkflowsTab}
+        >
+          Open tab
+        </button>
+      </div>
+      <IndicatorSection title="Active and attention">
+        {props.snapshot.currentRuns.length === 0 ? (
+          <p className="text-muted">No active workflows</p>
+        ) : (
+          props.snapshot.currentRuns.slice(0, 5).map((run) => {
+            const presentation = getWorkflowStatusPresentation(run.status);
+            return (
+              <div key={run.id} className="flex items-center justify-between gap-2">
+                <span className="truncate">{run.definition.name}</span>
+                <span className="text-muted shrink-0">{presentation.label}</span>
+              </div>
+            );
+          })
+        )}
+      </IndicatorSection>
+      <IndicatorSection title="Available definitions">
+        {props.snapshot.definitions.length === 0 ? (
+          <p className="text-muted">No definitions found</p>
+        ) : (
+          <p className="text-muted">
+            {props.snapshot.definitionGroups.project.length} project ·{" "}
+            {props.snapshot.definitionGroups.global.length} global ·{" "}
+            {props.snapshot.definitionGroups["built-in"].length} built-in ·{" "}
+            {props.snapshot.definitionGroups.scratch.length} scratch
+          </p>
+        )}
+      </IndicatorSection>
+    </div>
   );
 }
 

--- a/src/browser/components/WorkflowIndicator/WorkflowIndicator.tsx
+++ b/src/browser/components/WorkflowIndicator/WorkflowIndicator.tsx
@@ -1,0 +1,139 @@
+import React from "react";
+import { Workflow } from "lucide-react";
+
+import { Popover, PopoverContent, PopoverTrigger } from "@/browser/components/Popover/Popover";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/browser/components/Tooltip/Tooltip";
+import { CUSTOM_EVENTS, createCustomEvent } from "@/common/constants/events";
+import { cn } from "@/common/lib/utils";
+
+import {
+  useWorkflowWorkspaceSnapshot,
+  type WorkflowWorkspaceSnapshot,
+} from "@/browser/features/Workflows/WorkflowStore";
+import { getWorkflowStatusPresentation } from "@/browser/features/Workflows/workflowStatusPresentation";
+
+interface WorkflowIndicatorProps {
+  workspaceId: string;
+}
+
+interface WorkflowIndicatorViewProps {
+  workspaceId: string;
+  snapshot: WorkflowWorkspaceSnapshot;
+  onOpenWorkflowsTab?: () => void;
+}
+
+export function WorkflowIndicator(props: WorkflowIndicatorProps) {
+  const snapshot = useWorkflowWorkspaceSnapshot(props.workspaceId);
+  return <WorkflowIndicatorView workspaceId={props.workspaceId} snapshot={snapshot} />;
+}
+
+export function WorkflowIndicatorView(props: WorkflowIndicatorViewProps) {
+  const [open, setOpen] = React.useState(false);
+  const problemCount = props.snapshot.summary.problemCount;
+  const activeCount = props.snapshot.summary.activeCount;
+  const hasProblems = problemCount > 0;
+  const hasActive = activeCount > 0;
+  const badgeCount = hasProblems ? problemCount : activeCount;
+  const label = hasProblems
+    ? `${problemCount} workflow${problemCount === 1 ? "" : "s"} ${problemCount === 1 ? "needs" : "need"} attention`
+    : hasActive
+      ? `${activeCount} active workflow${activeCount === 1 ? "" : "s"}`
+      : "Workflows";
+
+  const openWorkflowsTab = () => {
+    setOpen(false);
+    if (props.onOpenWorkflowsTab) {
+      props.onOpenWorkflowsTab();
+      return;
+    }
+    window.dispatchEvent(
+      createCustomEvent(CUSTOM_EVENTS.OPEN_WORKFLOWS_TAB, { workspaceId: props.workspaceId })
+    );
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className={cn(
+                "relative flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted hover:bg-sidebar-hover hover:text-foreground max-[520px]:hidden",
+                hasProblems && "text-error",
+                !hasProblems && hasActive && "text-success"
+              )}
+              aria-label={label}
+            >
+              <Workflow className="h-3.5 w-3.5" />
+              {(hasProblems || hasActive) && (
+                <span className="bg-background counter-nums absolute -top-1 -right-1 min-w-3 rounded-full px-0.5 text-[9px] leading-3">
+                  {badgeCount}
+                </span>
+              )}
+            </button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" align="end">
+          {label}
+        </TooltipContent>
+      </Tooltip>
+      <PopoverContent
+        side="bottom"
+        align="end"
+        className="bg-modal-bg border-separator-light w-72 overflow-visible rounded px-3 py-2 text-xs font-normal shadow-[0_2px_8px_rgba(0,0,0,0.4)]"
+      >
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center justify-between gap-2">
+            <div className="text-foreground font-medium">Workflows</div>
+            <button
+              type="button"
+              className="text-accent hover:underline"
+              onClick={openWorkflowsTab}
+            >
+              Open tab
+            </button>
+          </div>
+          <IndicatorSection title="Active and attention">
+            {props.snapshot.currentRuns.length === 0 ? (
+              <p className="text-muted">No active workflows</p>
+            ) : (
+              props.snapshot.currentRuns.slice(0, 5).map((run) => {
+                const presentation = getWorkflowStatusPresentation(run.status);
+                return (
+                  <div key={run.id} className="flex items-center justify-between gap-2">
+                    <span className="truncate">{run.definition.name}</span>
+                    <span className="text-muted shrink-0">{presentation.label}</span>
+                  </div>
+                );
+              })
+            )}
+          </IndicatorSection>
+          <IndicatorSection title="Available definitions">
+            {props.snapshot.definitions.length === 0 ? (
+              <p className="text-muted">No definitions found</p>
+            ) : (
+              <p className="text-muted">
+                {props.snapshot.definitionGroups.project.length} project ·{" "}
+                {props.snapshot.definitionGroups.global.length} global ·{" "}
+                {props.snapshot.definitionGroups["built-in"].length} built-in ·{" "}
+                {props.snapshot.definitionGroups.scratch.length} scratch
+              </p>
+            )}
+          </IndicatorSection>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function IndicatorSection(props: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="flex flex-col gap-1">
+      <h3 className="text-muted text-[11px] font-semibold tracking-wide uppercase">
+        {props.title}
+      </h3>
+      {props.children}
+    </section>
+  );
+}

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
@@ -44,6 +44,7 @@ import { PopoverError } from "../PopoverError/PopoverError";
 import { WorkspaceActionsMenuContent } from "../WorkspaceActionsMenuContent/WorkspaceActionsMenuContent";
 import { WorkspaceTerminalIcon } from "../icons/WorkspaceTerminalIcon/WorkspaceTerminalIcon";
 
+import { WorkflowIndicator } from "../WorkflowIndicator/WorkflowIndicator";
 import { SkillIndicator } from "../SkillIndicator/SkillIndicator";
 import { useAPI } from "@/browser/contexts/API";
 import { useAgent } from "@/browser/contexts/AgentContext";
@@ -683,6 +684,7 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
             </div>
           </PopoverContent>
         </Popover>
+        <WorkflowIndicator workspaceId={workspaceId} />
         <SkillIndicator
           loadedSkills={loadedSkills}
           availableSkills={availableSkills}

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
@@ -96,6 +96,7 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
   const { disableWorkspaceAgents } = useAgent();
   const { preflightArchiveWorkspace, archiveWorkspace } = useWorkspaceActions();
   const { workspaceMetadata } = useWorkspaceContext();
+  const dynamicWorkflowsEnabled = useExperimentValue(EXPERIMENT_IDS.DYNAMIC_WORKFLOWS);
   const workspaceHeartbeatsEnabled = useExperimentValue(EXPERIMENT_IDS.WORKSPACE_HEARTBEATS);
   const linkSharingEnabled = useLinkSharingEnabled();
   const openTerminalPopout = useOpenTerminal();
@@ -684,7 +685,7 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
             </div>
           </PopoverContent>
         </Popover>
-        <WorkflowIndicator workspaceId={workspaceId} />
+        {dynamicWorkflowsEnabled && <WorkflowIndicator workspaceId={workspaceId} />}
         <SkillIndicator
           loadedSkills={loadedSkills}
           availableSkills={availableSkills}

--- a/src/browser/features/RightSidebar/RightSidebar.tsx
+++ b/src/browser/features/RightSidebar/RightSidebar.tsx
@@ -1110,6 +1110,21 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
   }, [setCollapsed, setLayout, workspaceId]);
 
   React.useEffect(() => {
+    const handleOpenWorkflowsTab = (event: Event) => {
+      const detail = (event as CustomEvent<{ workspaceId: string }>).detail;
+      if (detail?.workspaceId !== workspaceId) {
+        return;
+      }
+      setCollapsed(false);
+      setLayout((prev) => selectOrAddTab(prev, "workflows"));
+    };
+
+    window.addEventListener(CUSTOM_EVENTS.OPEN_WORKFLOWS_TAB, handleOpenWorkflowsTab);
+    return () =>
+      window.removeEventListener(CUSTOM_EVENTS.OPEN_WORKFLOWS_TAB, handleOpenWorkflowsTab);
+  }, [setCollapsed, setLayout, workspaceId]);
+
+  React.useEffect(() => {
     const handleOpenTouchReviewImmersive = (event: Event) => {
       const detail = (event as CustomEvent<{ workspaceId: string }>).detail;
       if (detail?.workspaceId !== workspaceId) {

--- a/src/browser/features/RightSidebar/RightSidebar.tsx
+++ b/src/browser/features/RightSidebar/RightSidebar.tsx
@@ -671,6 +671,7 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
   // API for reading config and managing terminal sessions.
   const apiState = useAPI();
   const api = apiState.api;
+  const workflowsExperimentEnabled = useExperimentValue(EXPERIMENT_IDS.DYNAMIC_WORKFLOWS);
   const desktopExperimentEnabled = useExperimentValue(EXPERIMENT_IDS.PORTABLE_DESKTOP);
   const browserExperimentEnabled = useExperimentValue(EXPERIMENT_IDS.AGENT_BROWSER);
   // Child task workspaces can't run goal actions — backend rejects them
@@ -984,6 +985,19 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
   }, [initialActiveTab, setLayoutRaw, isChildWorkspaceForGoal]);
 
   React.useEffect(() => {
+    if (workflowsExperimentEnabled) {
+      return;
+    }
+
+    setLayoutRaw((prevRaw) => {
+      const prev = parseRightSidebarLayoutState(prevRaw, initialActiveTab);
+      return collectAllTabs(prev.root).includes("workflows")
+        ? removeTabEverywhere(prev, "workflows")
+        : prev;
+    });
+  }, [initialActiveTab, setLayoutRaw, workflowsExperimentEnabled]);
+
+  React.useEffect(() => {
     if (!desktopExperimentEnabled) {
       setDesktopAvailable(false);
       return;
@@ -1112,7 +1126,7 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
   React.useEffect(() => {
     const handleOpenWorkflowsTab = (event: Event) => {
       const detail = (event as CustomEvent<{ workspaceId: string }>).detail;
-      if (detail?.workspaceId !== workspaceId) {
+      if (detail?.workspaceId !== workspaceId || !workflowsExperimentEnabled) {
         return;
       }
       setCollapsed(false);
@@ -1122,7 +1136,7 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
     window.addEventListener(CUSTOM_EVENTS.OPEN_WORKFLOWS_TAB, handleOpenWorkflowsTab);
     return () =>
       window.removeEventListener(CUSTOM_EVENTS.OPEN_WORKFLOWS_TAB, handleOpenWorkflowsTab);
-  }, [setCollapsed, setLayout, workspaceId]);
+  }, [setCollapsed, setLayout, workflowsExperimentEnabled, workspaceId]);
 
   React.useEffect(() => {
     const handleOpenTouchReviewImmersive = (event: Event) => {

--- a/src/browser/features/RightSidebar/Tabs/TabLabels.tsx
+++ b/src/browser/features/RightSidebar/Tabs/TabLabels.tsx
@@ -15,6 +15,7 @@ import {
   Globe,
   Sparkles,
   Target,
+  Workflow,
   Terminal as TerminalIcon,
   X,
 } from "lucide-react";
@@ -32,6 +33,7 @@ import {
   useOptionalWorkspaceSidebarState,
   useWorkspaceUsage,
 } from "@/browser/stores/WorkspaceStore";
+import { useWorkflowWorkspaceSummary } from "@/browser/features/Workflows/WorkflowStore";
 import { goalActiveMode, isGoalPendingPersistence } from "@/common/types/goal";
 import { sumUsageHistory, type ChatUsageDisplay } from "@/common/utils/tokens/usageAggregator";
 
@@ -217,6 +219,41 @@ export const GoalTabLabel: React.FC<GoalTabLabelProps> = ({ workspaceId }) => {
     >
       <Target className="h-3 w-3 shrink-0" />
       Goal
+    </span>
+  );
+};
+
+interface WorkflowsTabLabelProps {
+  workspaceId: string;
+}
+
+export const WorkflowsTabLabel: React.FC<WorkflowsTabLabelProps> = ({ workspaceId }) => {
+  const summary = useWorkflowWorkspaceSummary(workspaceId);
+  const hasProblems = summary.problemCount > 0;
+  const hasActive = summary.activeCount > 0;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1",
+        hasProblems && "text-error",
+        !hasProblems && hasActive && "text-success"
+      )}
+      aria-label={
+        hasProblems
+          ? `Workflows (${summary.problemCount} needing attention)`
+          : hasActive
+            ? `Workflows (${summary.activeCount} active)`
+            : "Workflows"
+      }
+    >
+      <Workflow className="h-3 w-3 shrink-0" />
+      Workflows
+      {(hasProblems || hasActive) && (
+        <span className="counter-nums text-[10px]">
+          {hasProblems ? summary.problemCount : summary.activeCount}
+        </span>
+      )}
     </span>
   );
 };

--- a/src/browser/features/RightSidebar/Tabs/tabConfig.ts
+++ b/src/browser/features/RightSidebar/Tabs/tabConfig.ts
@@ -53,6 +53,12 @@ const TAB_CONFIG_DEF = {
     defaultOrder: 35,
     paletteKeywords: ["goal", "target", "objective"],
   },
+  workflows: {
+    name: "Workflows",
+    contentClassName: "overflow-hidden p-0",
+    defaultOrder: 37,
+    paletteKeywords: ["workflow", "workflows", "automation", "run"],
+  },
   desktop: {
     name: "Desktop",
     contentClassName: "overflow-hidden p-0",

--- a/src/browser/features/RightSidebar/Tabs/tabConfig.ts
+++ b/src/browser/features/RightSidebar/Tabs/tabConfig.ts
@@ -56,6 +56,7 @@ const TAB_CONFIG_DEF = {
   workflows: {
     name: "Workflows",
     contentClassName: "overflow-hidden p-0",
+    featureFlag: EXPERIMENT_IDS.DYNAMIC_WORKFLOWS,
     defaultOrder: 37,
     paletteKeywords: ["workflow", "workflows", "automation", "run"],
   },

--- a/src/browser/features/RightSidebar/Tabs/tabRegistry.tsx
+++ b/src/browser/features/RightSidebar/Tabs/tabRegistry.tsx
@@ -22,6 +22,7 @@ import { DesktopPanel } from "@/browser/features/desktop/DesktopPanel";
 import { BrowserTab } from "@/browser/features/RightSidebar/BrowserTab";
 import { DevToolsTab } from "@/browser/features/RightSidebar/DevToolsTab";
 import { GoalTab, type GoalCreateIntent } from "@/browser/features/RightSidebar/GoalTab";
+import { WorkflowsTab } from "@/browser/features/Workflows/WorkflowsTab";
 import type { GoalSnapshot, GoalStatus } from "@/common/types/goal";
 import type { ReviewNoteData } from "@/common/types/review";
 import { BASE_TAB_IDS, TAB_CONFIG, type BaseTabType, type TabConfig } from "./tabConfig";
@@ -31,6 +32,7 @@ import {
   DesktopTabLabel,
   GoalTabLabel,
   InstructionsTabLabel,
+  WorkflowsTabLabel,
   OutputTabLabel,
   ReviewTabLabel,
   StatsTabLabel,
@@ -154,6 +156,14 @@ const TAB_RENDERERS = {
           onClear={ctx.goal.onClear}
           onCreate={ctx.goal.onCreate}
         />
+      </ErrorBoundary>
+    ),
+  },
+  workflows: {
+    Label: ({ workspaceId }) => <WorkflowsTabLabel workspaceId={workspaceId} />,
+    renderPanel: (ctx) => (
+      <ErrorBoundary workspaceInfo="Workflows tab">
+        <WorkflowsTab workspaceId={ctx.workspaceId} />
       </ErrorBoundary>
     ),
   },

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -60,7 +60,10 @@ import {
   formatWorkflowSavedMessage,
   type WorkflowPromotionTarget,
 } from "./WorkflowDefinitionToolCall";
-import { useWorkflowWorkspaceSnapshot } from "@/browser/features/Workflows/WorkflowStore";
+import {
+  getWorkflowStoreInstance,
+  useWorkflowWorkspaceSnapshot,
+} from "@/browser/features/Workflows/WorkflowStore";
 import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
 import { MarkdownRenderer } from "../Messages/MarkdownRenderer";
 
@@ -116,6 +119,7 @@ async function updateWorkflowRunFromAction(input: {
               workspaceId: input.workspaceId,
               runId: input.runId,
             });
+    getWorkflowStoreInstance().invalidateWorkspace(input.workspaceId);
     if (input.action === "resume" || input.action === "retryFromCheckpoint") {
       resumeRequestAccepted = true;
       input.setResumingRunId(input.runId);
@@ -1088,12 +1092,13 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
     }
 
     assert(sourceDefinition.scope === "scratch", "Only scratch workflow runs can be saved");
+    const sourceWorkspaceId = run.workspaceId;
     setActionError(null);
     setSavingPromotionTarget(location);
     savingPromotionTargetRef.current = location;
     api.workflows
       .promoteScratch({
-        workspaceId: run.workspaceId,
+        workspaceId: sourceWorkspaceId,
         runId,
         name: sourceDefinition.name,
         description: sourceDefinition.description,
@@ -1105,6 +1110,7 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
           descriptor.scope === location,
           "promoteScratch returned a descriptor for a different location"
         );
+        getWorkflowStoreInstance().invalidateWorkspace(sourceWorkspaceId);
         setPromotedDefinition(descriptor);
       })
       .catch((error: unknown) => {

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -60,6 +60,7 @@ import {
   formatWorkflowSavedMessage,
   type WorkflowPromotionTarget,
 } from "./WorkflowDefinitionToolCall";
+import { useWorkflowWorkspaceSnapshot } from "@/browser/features/Workflows/WorkflowStore";
 import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
 import { MarkdownRenderer } from "../Messages/MarkdownRenderer";
 
@@ -885,24 +886,22 @@ function selectWorkflowRunSnapshot(input: {
   runId?: string;
   baseRun?: WorkflowRunRecord;
   refreshedRun: WorkflowRunRecord | null;
+  storeRun?: WorkflowRunRecord;
 }): { runId?: string; run?: WorkflowRunRecord } {
-  const runId = input.runId ?? input.baseRun?.id ?? input.refreshedRun?.id;
+  const runId = input.runId ?? input.baseRun?.id ?? input.refreshedRun?.id ?? input.storeRun?.id;
   if (runId == null) {
     return {};
   }
-  if (input.refreshedRun?.id !== runId) {
-    return input.baseRun == null ? { runId } : { runId, run: input.baseRun };
+  const candidates = [input.baseRun, input.refreshedRun, input.storeRun].filter(
+    (candidate): candidate is WorkflowRunRecord => candidate?.id === runId
+  );
+  if (candidates.length === 0) {
+    return { runId };
   }
-  if (input.baseRun?.id !== runId) {
-    return { runId, run: input.refreshedRun };
-  }
-  return {
-    runId,
-    run:
-      compareWorkflowRunSnapshots(input.refreshedRun, input.baseRun) >= 0
-        ? input.refreshedRun
-        : input.baseRun,
-  };
+  const run = candidates.reduce((newest, candidate) =>
+    compareWorkflowRunSnapshots(newest, candidate) >= 0 ? newest : candidate
+  );
+  return { runId, run };
 }
 
 function getLatestResultEvent(run: WorkflowRunRecord | null | undefined): unknown {
@@ -955,10 +954,14 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
     setWorkflowActionInFlightRunId(nextRunId);
   };
   const baseRun = successResult?.run;
+  const workflowSnapshot = useWorkflowWorkspaceSnapshot(workspaceId);
+  const snapshotRunId = successResult?.runId ?? baseRun?.id ?? refreshedRun?.id;
+  const storeRun = workflowSnapshot.runs.find((candidate) => candidate.id === snapshotRunId);
   const selectedRun = selectWorkflowRunSnapshot({
     runId: successResult?.runId,
     baseRun,
     refreshedRun,
+    storeRun,
   });
   const runId = selectedRun.runId;
   const run = selectedRun.run;
@@ -1251,7 +1254,7 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
       apiState?.api == null ||
       runId == null ||
       run?.workspaceId == null ||
-      (!shouldRefreshWorkflow(displayStatus) && resumingRunId !== runId)
+      (resumingRunId !== runId && (storeRun != null || !shouldRefreshWorkflow(displayStatus)))
     ) {
       return;
     }
@@ -1288,7 +1291,15 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
       ignore = true;
       window.clearInterval(interval);
     };
-  }, [apiState?.api, displayEventSequence, displayStatus, resumingRunId, run?.workspaceId, runId]);
+  }, [
+    apiState?.api,
+    displayEventSequence,
+    displayStatus,
+    resumingRunId,
+    run?.workspaceId,
+    runId,
+    storeRun,
+  ]);
 
   return (
     <ToolContainer expanded={expanded}>

--- a/src/browser/features/Workflows/WorkflowStore.test.ts
+++ b/src/browser/features/Workflows/WorkflowStore.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { APIClient } from "@/browser/contexts/API";
+import type { WorkflowDefinitionDescriptor, WorkflowRunRecord } from "@/common/types/workflow";
+
+import { WORKFLOW_RUN_POLL_INTERVAL_MS, WorkflowStore } from "./WorkflowStore";
+
+function definition(
+  name: string,
+  scope: WorkflowDefinitionDescriptor["scope"]
+): WorkflowDefinitionDescriptor {
+  return { name, scope, description: `${name} workflow`, executable: true };
+}
+
+function run(overrides: Partial<WorkflowRunRecord>): WorkflowRunRecord {
+  return {
+    id: "wfr_test",
+    workspaceId: "workspace-1",
+    definition: definition("demo", "project"),
+    definitionSource: "/repo/.mux/workflows/demo.js",
+    definitionHash: "hash",
+    args: {},
+    status: "running",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    events: [],
+    steps: [],
+    ...overrides,
+  };
+}
+
+function createClient(input: {
+  definitions?: WorkflowDefinitionDescriptor[];
+  runs?: WorkflowRunRecord[];
+  runDetails?: WorkflowRunRecord[];
+}) {
+  const calls = {
+    listDefinitions: mock(() => Promise.resolve(input.definitions ?? [])),
+    listRuns: mock(() => Promise.resolve(input.runs ?? [])),
+    getRun: mock(() => Promise.resolve(input.runDetails?.shift() ?? input.runs?.[0] ?? null)),
+  };
+  const client = {
+    workflows: {
+      listDefinitions: calls.listDefinitions,
+      listRuns: calls.listRuns,
+      getRun: calls.getRun,
+    },
+  } as unknown as APIClient;
+  return { client, calls };
+}
+
+async function waitForStoreSnapshot(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    if (predicate()) return;
+    await Bun.sleep(1);
+  }
+  throw new Error("Timed out waiting for workflow store snapshot");
+}
+
+describe("WorkflowStore", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("deduplicates workspace snapshot loading for duplicate subscribers", async () => {
+    const { client, calls } = createClient({
+      definitions: [definition("project-flow", "project"), definition("scratch-flow", "scratch")],
+      runs: [run({ id: "wfr_running", status: "running" })],
+    });
+    const store = new WorkflowStore();
+    store.setClient(client);
+
+    const unsubscribeA = store.subscribeWorkspace("workspace-1", () => undefined);
+    const unsubscribeB = store.subscribeWorkspace("workspace-1", () => undefined);
+    await waitForStoreSnapshot(
+      () => store.getWorkspaceSnapshot("workspace-1").definitionGroups.scratch.length === 1
+    );
+
+    expect(calls.listDefinitions).toHaveBeenCalledTimes(1);
+    expect(calls.listRuns).toHaveBeenCalledTimes(1);
+    expect(store.getWorkspaceSnapshot("workspace-1").definitionGroups.scratch).toHaveLength(1);
+
+    unsubscribeA();
+    unsubscribeB();
+    store.dispose();
+  });
+
+  test("polls active run details while subscribed and stops after the last subscriber leaves", async () => {
+    const { client, calls } = createClient({
+      definitions: [],
+      runs: [run({ id: "wfr_running", status: "running" })],
+      runDetails: [run({ id: "wfr_running", status: "completed" })],
+    });
+    const store = new WorkflowStore();
+    store.setClient(client);
+
+    const unsubscribe = store.subscribeWorkspace("workspace-1", () => undefined);
+    await waitForStoreSnapshot(() => store.getWorkspaceSnapshot("workspace-1").runs.length === 1);
+    await Bun.sleep(WORKFLOW_RUN_POLL_INTERVAL_MS + 20);
+    await waitForStoreSnapshot(
+      () => store.getWorkspaceSnapshot("workspace-1").runs[0]?.status === "completed"
+    );
+
+    expect(calls.getRun).toHaveBeenCalledTimes(1);
+    expect(store.getWorkspaceSnapshot("workspace-1").runs[0]?.status).toBe("completed");
+
+    unsubscribe();
+    await Bun.sleep(WORKFLOW_RUN_POLL_INTERVAL_MS + 20);
+
+    expect(calls.getRun).toHaveBeenCalledTimes(1);
+    store.dispose();
+  });
+
+  test("keeps summary snapshots stable for event-only active run updates", async () => {
+    const running = run({ id: "wfr_running", status: "running" });
+    const { client } = createClient({
+      definitions: [],
+      runs: [running],
+      runDetails: [
+        run({
+          id: "wfr_running",
+          status: "running",
+          events: [{ type: "log", at: "2026-01-01T00:00:01.000Z", sequence: 1, message: "tick" }],
+          updatedAt: "2026-01-01T00:00:01.000Z",
+        }),
+      ],
+    });
+    const store = new WorkflowStore();
+    store.setClient(client);
+
+    const unsubscribe = store.subscribeWorkspace("workspace-1", () => undefined);
+    await waitForStoreSnapshot(() => store.getWorkspaceSnapshot("workspace-1").runs.length === 1);
+    const initialSummary = store.getWorkspaceSummary("workspace-1");
+
+    await Bun.sleep(WORKFLOW_RUN_POLL_INTERVAL_MS + 20);
+    await waitForStoreSnapshot(
+      () => store.getWorkspaceSnapshot("workspace-1").runs[0]?.events.length === 1
+    );
+
+    expect(store.getWorkspaceSummary("workspace-1")).toBe(initialSummary);
+
+    unsubscribe();
+    store.dispose();
+  });
+});

--- a/src/browser/features/Workflows/WorkflowStore.test.ts
+++ b/src/browser/features/Workflows/WorkflowStore.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import type { APIClient } from "@/browser/contexts/API";
 import type { WorkflowDefinitionDescriptor, WorkflowRunRecord } from "@/common/types/workflow";
 
-import { WORKFLOW_RUN_POLL_INTERVAL_MS, WorkflowStore } from "./WorkflowStore";
+import { WorkflowStore } from "./WorkflowStore";
 
 function definition(
   name: string,
@@ -29,15 +29,33 @@ function run(overrides: Partial<WorkflowRunRecord>): WorkflowRunRecord {
   };
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
 function createClient(input: {
   definitions?: WorkflowDefinitionDescriptor[];
   runs?: WorkflowRunRecord[];
-  runDetails?: WorkflowRunRecord[];
+  runDetails?: Array<WorkflowRunRecord | null | Error>;
+  listDefinitions?: () => Promise<WorkflowDefinitionDescriptor[]>;
+  listRuns?: () => Promise<WorkflowRunRecord[]>;
 }) {
   const calls = {
-    listDefinitions: mock(() => Promise.resolve(input.definitions ?? [])),
-    listRuns: mock(() => Promise.resolve(input.runs ?? [])),
-    getRun: mock(() => Promise.resolve(input.runDetails?.shift() ?? input.runs?.[0] ?? null)),
+    listDefinitions: mock(
+      input.listDefinitions ?? (() => Promise.resolve(input.definitions ?? []))
+    ),
+    listRuns: mock(input.listRuns ?? (() => Promise.resolve(input.runs ?? []))),
+    getRun: mock(() => {
+      const next = input.runDetails?.shift();
+      if (next instanceof Error) return Promise.reject(next);
+      return Promise.resolve(next ?? input.runs?.[0] ?? null);
+    }),
   };
   const client = {
     workflows: {
@@ -49,10 +67,17 @@ function createClient(input: {
   return { client, calls };
 }
 
+function createFastStore(options: { workspaceRefreshIntervalMs?: number } = {}) {
+  return new WorkflowStore({
+    runPollIntervalMs: 1,
+    workspaceRefreshIntervalMs: options.workspaceRefreshIntervalMs ?? 1_000,
+  });
+}
+
 async function waitForStoreSnapshot(predicate: () => boolean): Promise<void> {
-  for (let attempt = 0; attempt < 20; attempt++) {
+  for (let attempt = 0; attempt < 80; attempt++) {
     if (predicate()) return;
-    await Bun.sleep(1);
+    await Bun.sleep(2);
   }
   throw new Error("Timed out waiting for workflow store snapshot");
 }
@@ -67,7 +92,7 @@ describe("WorkflowStore", () => {
       definitions: [definition("project-flow", "project"), definition("scratch-flow", "scratch")],
       runs: [run({ id: "wfr_running", status: "running" })],
     });
-    const store = new WorkflowStore();
+    const store = createFastStore();
     store.setClient(client);
 
     const unsubscribeA = store.subscribeWorkspace("workspace-1", () => undefined);
@@ -91,12 +116,10 @@ describe("WorkflowStore", () => {
       runs: [run({ id: "wfr_running", status: "running" })],
       runDetails: [run({ id: "wfr_running", status: "completed" })],
     });
-    const store = new WorkflowStore();
+    const store = createFastStore();
     store.setClient(client);
 
     const unsubscribe = store.subscribeWorkspace("workspace-1", () => undefined);
-    await waitForStoreSnapshot(() => store.getWorkspaceSnapshot("workspace-1").runs.length === 1);
-    await Bun.sleep(WORKFLOW_RUN_POLL_INTERVAL_MS + 20);
     await waitForStoreSnapshot(
       () => store.getWorkspaceSnapshot("workspace-1").runs[0]?.status === "completed"
     );
@@ -105,9 +128,34 @@ describe("WorkflowStore", () => {
     expect(store.getWorkspaceSnapshot("workspace-1").runs[0]?.status).toBe("completed");
 
     unsubscribe();
-    await Bun.sleep(WORKFLOW_RUN_POLL_INTERVAL_MS + 20);
+    await Bun.sleep(5);
 
     expect(calls.getRun).toHaveBeenCalledTimes(1);
+    store.dispose();
+  });
+
+  test("restarts active-run polling when a cached workspace is resubscribed", async () => {
+    const { client, calls } = createClient({
+      definitions: [],
+      runs: [run({ id: "wfr_running", status: "running" })],
+      runDetails: [run({ id: "wfr_running", status: "completed" })],
+    });
+    const store = new WorkflowStore({ runPollIntervalMs: 20, workspaceRefreshIntervalMs: 1_000 });
+    store.setClient(client);
+
+    const unsubscribeFirst = store.subscribeWorkspace("workspace-1", () => undefined);
+    await waitForStoreSnapshot(() => store.getWorkspaceSnapshot("workspace-1").runs.length === 1);
+    unsubscribeFirst();
+    await Bun.sleep(5);
+    expect(calls.getRun).toHaveBeenCalledTimes(0);
+
+    const unsubscribeSecond = store.subscribeWorkspace("workspace-1", () => undefined);
+    await waitForStoreSnapshot(
+      () => store.getWorkspaceSnapshot("workspace-1").runs[0]?.status === "completed"
+    );
+
+    expect(calls.getRun).toHaveBeenCalledTimes(1);
+    unsubscribeSecond();
     store.dispose();
   });
 
@@ -125,19 +173,129 @@ describe("WorkflowStore", () => {
         }),
       ],
     });
-    const store = new WorkflowStore();
+    const store = createFastStore();
     store.setClient(client);
 
     const unsubscribe = store.subscribeWorkspace("workspace-1", () => undefined);
     await waitForStoreSnapshot(() => store.getWorkspaceSnapshot("workspace-1").runs.length === 1);
     const initialSummary = store.getWorkspaceSummary("workspace-1");
 
-    await Bun.sleep(WORKFLOW_RUN_POLL_INTERVAL_MS + 20);
     await waitForStoreSnapshot(
       () => store.getWorkspaceSnapshot("workspace-1").runs[0]?.events.length === 1
     );
 
     expect(store.getWorkspaceSummary("workspace-1")).toBe(initialSummary);
+
+    unsubscribe();
+    store.dispose();
+  });
+
+  test("discovers externally-created runs from periodic workspace refreshes", async () => {
+    let listRunsCallCount = 0;
+    const externalRun = run({ id: "wfr_external", status: "running" });
+    const { client, calls } = createClient({
+      definitions: [],
+      listRuns: () => Promise.resolve(listRunsCallCount++ === 0 ? [] : [externalRun]),
+    });
+    const store = createFastStore({ workspaceRefreshIntervalMs: 1 });
+    store.setClient(client);
+
+    const unsubscribe = store.subscribeWorkspace("workspace-1", () => undefined);
+    await waitForStoreSnapshot(() => store.getWorkspaceSnapshot("workspace-1").runs.length === 1);
+
+    expect(calls.listRuns.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(store.getWorkspaceSnapshot("workspace-1").runs[0]?.id).toBe("wfr_external");
+
+    unsubscribe();
+    store.dispose();
+  });
+
+  test("queues invalidation requests that arrive during an in-flight snapshot load", async () => {
+    const firstRuns = createDeferred<WorkflowRunRecord[]>();
+    let listRunsCallCount = 0;
+    const afterActionRun = run({ id: "wfr_after_action", status: "running" });
+    const { client, calls } = createClient({
+      definitions: [],
+      listRuns: () => {
+        listRunsCallCount++;
+        return listRunsCallCount === 1 ? firstRuns.promise : Promise.resolve([afterActionRun]);
+      },
+    });
+    const store = createFastStore();
+    store.setClient(client);
+
+    const unsubscribe = store.subscribeWorkspace("workspace-1", () => undefined);
+    await waitForStoreSnapshot(() => calls.listRuns.mock.calls.length === 1);
+    store.invalidateWorkspace("workspace-1");
+    firstRuns.resolve([]);
+
+    await waitForStoreSnapshot(() => store.getWorkspaceSnapshot("workspace-1").runs.length === 1);
+
+    expect(calls.listRuns).toHaveBeenCalledTimes(2);
+    expect(store.getWorkspaceSnapshot("workspace-1").runs[0]?.id).toBe("wfr_after_action");
+
+    unsubscribe();
+    store.dispose();
+  });
+
+  test("preserves cached data and surfaces an error when list refreshes fail", async () => {
+    let listDefinitionsCallCount = 0;
+    let listRunsCallCount = 0;
+    const cachedDefinition = definition("project-flow", "project");
+    const cachedRun = run({ id: "wfr_cached", status: "running" });
+    const { client } = createClient({
+      listDefinitions: () => {
+        listDefinitionsCallCount++;
+        return listDefinitionsCallCount === 1
+          ? Promise.resolve([cachedDefinition])
+          : Promise.reject(new Error("definitions unavailable"));
+      },
+      listRuns: () => {
+        listRunsCallCount++;
+        return listRunsCallCount === 1
+          ? Promise.resolve([cachedRun])
+          : Promise.reject(new Error("runs unavailable"));
+      },
+    });
+    const store = createFastStore();
+    store.setClient(client);
+
+    const unsubscribe = store.subscribeWorkspace("workspace-1", () => undefined);
+    await waitForStoreSnapshot(() => store.getWorkspaceSnapshot("workspace-1").runs.length === 1);
+    store.invalidateWorkspace("workspace-1");
+
+    await waitForStoreSnapshot(() => store.getWorkspaceSnapshot("workspace-1").error != null);
+    const failedRefreshSnapshot = store.getWorkspaceSnapshot("workspace-1");
+
+    expect(failedRefreshSnapshot.definitions).toEqual([cachedDefinition]);
+    expect(failedRefreshSnapshot.runs.map((candidate) => candidate.id)).toContain("wfr_cached");
+    expect(failedRefreshSnapshot.error).toContain("definitions unavailable");
+    expect(failedRefreshSnapshot.error).toContain("runs unavailable");
+
+    unsubscribe();
+    store.dispose();
+  });
+
+  test("keeps polling active runs after null or rejected getRun responses", async () => {
+    const { client, calls } = createClient({
+      definitions: [],
+      runs: [run({ id: "wfr_running", status: "running" })],
+      runDetails: [
+        null,
+        new Error("transient transport failure"),
+        run({ id: "wfr_running", status: "completed" }),
+      ],
+    });
+    const store = createFastStore();
+    store.setClient(client);
+
+    const unsubscribe = store.subscribeWorkspace("workspace-1", () => undefined);
+    await waitForStoreSnapshot(
+      () => store.getWorkspaceSnapshot("workspace-1").runs[0]?.status === "completed"
+    );
+
+    expect(calls.getRun).toHaveBeenCalledTimes(3);
+    expect(store.getWorkspaceSnapshot("workspace-1").error).toBeNull();
 
     unsubscribe();
     store.dispose();

--- a/src/browser/features/Workflows/WorkflowStore.ts
+++ b/src/browser/features/Workflows/WorkflowStore.ts
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useSyncExternalStore } from "react";
+import { useCallback, useContext, useEffect, useSyncExternalStore } from "react";
 
 import { APIContext, type APIClient } from "@/browser/contexts/API";
 import assert from "@/common/utils/assert";
@@ -12,6 +12,12 @@ import {
 } from "./workflowStatusPresentation";
 
 export const WORKFLOW_RUN_POLL_INTERVAL_MS = 2000;
+export const WORKFLOW_WORKSPACE_REFRESH_INTERVAL_MS = 10_000;
+
+export interface WorkflowStoreOptions {
+  runPollIntervalMs?: number;
+  workspaceRefreshIntervalMs?: number;
+}
 
 export interface WorkflowWorkspaceSnapshot {
   definitions: WorkflowDefinitionDescriptor[];
@@ -52,8 +58,23 @@ export class WorkflowStore {
   private readonly listenersByWorkspace = new Map<string, Set<Listener>>();
   private readonly states = new Map<string, WorkspaceState>();
   private readonly inFlightSnapshots = new Set<string>();
+  private readonly pendingSnapshotRefreshes = new Set<string>();
   private readonly runTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly workspaceRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly runPollIntervalMs: number;
+  private readonly workspaceRefreshIntervalMs: number;
   private disposed = false;
+
+  constructor(options: WorkflowStoreOptions = {}) {
+    this.runPollIntervalMs = options.runPollIntervalMs ?? WORKFLOW_RUN_POLL_INTERVAL_MS;
+    this.workspaceRefreshIntervalMs =
+      options.workspaceRefreshIntervalMs ?? WORKFLOW_WORKSPACE_REFRESH_INTERVAL_MS;
+    assert(this.runPollIntervalMs > 0, "Workflow run poll interval must be positive");
+    assert(
+      this.workspaceRefreshIntervalMs > 0,
+      "Workflow workspace refresh interval must be positive"
+    );
+  }
 
   setClient(client: APIClient | null): void {
     this.client = client;
@@ -73,8 +94,14 @@ export class WorkflowStore {
     }
     listeners.add(listener);
 
-    if (!this.states.has(workspaceId) && !this.inFlightSnapshots.has(workspaceId)) {
+    const state = this.states.get(workspaceId);
+    if (state == null && !this.inFlightSnapshots.has(workspaceId)) {
       queueMicrotask(() => this.refreshWorkspace(workspaceId));
+    } else if (state != null) {
+      // React may unsubscribe/resubscribe external stores during ordinary commits. Keep the
+      // cached snapshot for layout stability, but restart polling for active cached runs.
+      this.syncRunPolling(workspaceId, state.runs);
+      this.scheduleWorkspaceRefresh(workspaceId);
     }
 
     return () => {
@@ -82,7 +109,9 @@ export class WorkflowStore {
       currentListeners?.delete(listener);
       if (currentListeners?.size === 0) {
         this.listenersByWorkspace.delete(workspaceId);
+        this.pendingSnapshotRefreshes.delete(workspaceId);
         this.stopWorkspaceRunPolling(workspaceId);
+        this.clearWorkspaceRefreshTimer(workspaceId);
       }
     };
   };
@@ -97,22 +126,31 @@ export class WorkflowStore {
   }
 
   invalidateWorkspace(workspaceId: string): void {
-    this.refreshWorkspace(workspaceId);
+    this.refreshWorkspace(workspaceId, { queueIfInFlight: true });
   }
 
   dispose(): void {
     this.disposed = true;
     for (const timer of this.runTimers.values()) clearTimeout(timer);
+    for (const timer of this.workspaceRefreshTimers.values()) clearTimeout(timer);
     this.runTimers.clear();
+    this.workspaceRefreshTimers.clear();
     this.listenersByWorkspace.clear();
     this.states.clear();
     this.inFlightSnapshots.clear();
+    this.pendingSnapshotRefreshes.clear();
   }
 
-  private refreshWorkspace(workspaceId: string): void {
+  private refreshWorkspace(workspaceId: string, options: { queueIfInFlight?: boolean } = {}): void {
     if (this.client == null || this.disposed || !this.listenersByWorkspace.has(workspaceId)) return;
-    if (this.inFlightSnapshots.has(workspaceId)) return;
+    if (this.inFlightSnapshots.has(workspaceId)) {
+      if (options.queueIfInFlight === true) {
+        this.pendingSnapshotRefreshes.add(workspaceId);
+      }
+      return;
+    }
 
+    this.clearWorkspaceRefreshTimer(workspaceId);
     this.inFlightSnapshots.add(workspaceId);
     this.updateWorkspaceLoading(workspaceId, true, null);
     void this.loadWorkspaceSnapshot(workspaceId);
@@ -122,25 +160,38 @@ export class WorkflowStore {
     assert(this.client != null, "WorkflowStore cannot load workflows without an API client");
     const client = this.client;
     try {
-      const [definitions, runs] = await Promise.all([
-        Promise.resolve()
-          .then(() => client.workflows.listDefinitions({ workspaceId }))
-          .catch(() => []),
-        Promise.resolve()
-          .then(() => client.workflows.listRuns({ workspaceId }))
-          .catch(() => []),
+      const [definitionsResult, runsResult] = await Promise.allSettled([
+        client.workflows.listDefinitions({ workspaceId }),
+        client.workflows.listRuns({ workspaceId }),
       ]);
       if (this.disposed) return;
-      this.setWorkspaceData(workspaceId, definitions, runs, false, null);
+
+      const current = this.states.get(workspaceId);
+      const errors: string[] = [];
+      const definitions = readSettledWorkflowValue(
+        definitionsResult,
+        current?.definitions ?? [],
+        "definitions",
+        errors
+      );
+      const runs = readSettledWorkflowValue(runsResult, current?.runs ?? [], "runs", errors);
+      this.setWorkspaceData(
+        workspaceId,
+        definitions,
+        runs,
+        false,
+        errors.length > 0 ? `Failed to load workflows: ${errors.join("; ")}` : null
+      );
     } catch (error) {
       if (this.disposed) return;
-      this.updateWorkspaceLoading(
-        workspaceId,
-        false,
-        error instanceof Error ? error.message : "Failed to load workflows"
-      );
+      this.updateWorkspaceLoading(workspaceId, false, getWorkflowErrorMessage(error));
     } finally {
       this.inFlightSnapshots.delete(workspaceId);
+      if (this.pendingSnapshotRefreshes.delete(workspaceId)) {
+        queueMicrotask(() => this.refreshWorkspace(workspaceId));
+      } else {
+        this.scheduleWorkspaceRefresh(workspaceId);
+      }
     }
   }
 
@@ -189,6 +240,7 @@ export class WorkflowStore {
     };
     this.states.set(workspaceId, { definitions, runs: orderedRuns, snapshot, isLoading, error });
     this.syncRunPolling(workspaceId, orderedRuns);
+    this.scheduleWorkspaceRefresh(workspaceId);
     this.emit(workspaceId);
   }
 
@@ -219,7 +271,7 @@ export class WorkflowStore {
     const timer = setTimeout(() => {
       this.runTimers.delete(key);
       void this.pollRun(workspaceId, runId);
-    }, WORKFLOW_RUN_POLL_INTERVAL_MS);
+    }, this.runPollIntervalMs);
     if (typeof timer === "object" && "unref" in timer && typeof timer.unref === "function") {
       timer.unref();
     }
@@ -228,21 +280,62 @@ export class WorkflowStore {
 
   private async pollRun(workspaceId: string, runId: string): Promise<void> {
     if (this.client == null || this.disposed || !this.listenersByWorkspace.has(workspaceId)) return;
-    const run = await this.client.workflows.getRun({ workspaceId, runId });
-    if (this.disposed || !this.listenersByWorkspace.has(workspaceId) || run == null) return;
+    try {
+      const run = await this.client.workflows.getRun({ workspaceId, runId });
+      if (this.disposed || !this.listenersByWorkspace.has(workspaceId)) return;
+      if (run == null) {
+        this.scheduleRunPollIfStillActive(workspaceId, runId);
+        return;
+      }
 
-    const state = this.states.get(workspaceId);
-    const currentRuns = state?.runs ?? [];
-    const nextRuns = currentRuns.some((candidate) => candidate.id === run.id)
-      ? currentRuns.map((candidate) => (candidate.id === run.id ? run : candidate))
-      : [run, ...currentRuns];
-    this.setWorkspaceData(
-      workspaceId,
-      state?.definitions ?? [],
-      nextRuns,
-      state?.isLoading ?? false,
-      null
-    );
+      const state = this.states.get(workspaceId);
+      const currentRuns = state?.runs ?? [];
+      const nextRuns = currentRuns.some((candidate) => candidate.id === run.id)
+        ? currentRuns.map((candidate) => (candidate.id === run.id ? run : candidate))
+        : [run, ...currentRuns];
+      this.setWorkspaceData(
+        workspaceId,
+        state?.definitions ?? [],
+        nextRuns,
+        state?.isLoading ?? false,
+        null
+      );
+    } catch (error) {
+      if (this.disposed || !this.listenersByWorkspace.has(workspaceId)) return;
+      this.updateWorkspaceLoading(
+        workspaceId,
+        this.states.get(workspaceId)?.isLoading ?? false,
+        `Failed to refresh workflow run: ${getWorkflowErrorMessage(error)}`
+      );
+      this.scheduleRunPollIfStillActive(workspaceId, runId);
+    }
+  }
+
+  private scheduleRunPollIfStillActive(workspaceId: string, runId: string): void {
+    if (!this.listenersByWorkspace.has(workspaceId)) return;
+    const run = this.states.get(workspaceId)?.runs.find((candidate) => candidate.id === runId);
+    if (run == null || summarizeWorkflowRuns([run]).activeCount === 0) return;
+    this.scheduleRunPoll(workspaceId, runId);
+  }
+
+  private scheduleWorkspaceRefresh(workspaceId: string): void {
+    if (
+      this.disposed ||
+      !this.listenersByWorkspace.has(workspaceId) ||
+      this.inFlightSnapshots.has(workspaceId) ||
+      this.workspaceRefreshTimers.has(workspaceId)
+    ) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      this.workspaceRefreshTimers.delete(workspaceId);
+      this.refreshWorkspace(workspaceId);
+    }, this.workspaceRefreshIntervalMs);
+    if (typeof timer === "object" && "unref" in timer && typeof timer.unref === "function") {
+      timer.unref();
+    }
+    this.workspaceRefreshTimers.set(workspaceId, timer);
   }
 
   private stopWorkspaceRunPolling(workspaceId: string): void {
@@ -259,11 +352,32 @@ export class WorkflowStore {
     this.runTimers.delete(key);
   }
 
+  private clearWorkspaceRefreshTimer(workspaceId: string): void {
+    const timer = this.workspaceRefreshTimers.get(workspaceId);
+    if (timer != null) clearTimeout(timer);
+    this.workspaceRefreshTimers.delete(workspaceId);
+  }
+
   private emit(workspaceId: string): void {
     const listeners = this.listenersByWorkspace.get(workspaceId);
     if (listeners == null) return;
     for (const listener of listeners) listener();
   }
+}
+
+function readSettledWorkflowValue<T>(
+  result: PromiseSettledResult<T>,
+  fallback: T,
+  label: string,
+  errors: string[]
+): T {
+  if (result.status === "fulfilled") return result.value;
+  errors.push(`${label}: ${getWorkflowErrorMessage(result.reason)}`);
+  return fallback;
+}
+
+function getWorkflowErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Unknown workflow error";
 }
 
 function areWorkflowSummariesEqual(
@@ -307,8 +421,14 @@ export function useWorkflowWorkspaceSummary(workspaceId: string | undefined): Wo
     store.setClient(api);
   }, [api, store]);
 
+  const subscribe = useCallback(
+    (listener: Listener) =>
+      workspaceId ? store.subscribeWorkspace(workspaceId, listener) : () => undefined,
+    [store, workspaceId]
+  );
+
   return useSyncExternalStore(
-    (listener) => (workspaceId ? store.subscribeWorkspace(workspaceId, listener) : () => undefined),
+    subscribe,
     () => store.getWorkspaceSummary(workspaceId),
     () => EMPTY_SUMMARY
   );
@@ -325,8 +445,14 @@ export function useWorkflowWorkspaceSnapshot(
     store.setClient(api);
   }, [api, store]);
 
+  const subscribe = useCallback(
+    (listener: Listener) =>
+      workspaceId ? store.subscribeWorkspace(workspaceId, listener) : () => undefined,
+    [store, workspaceId]
+  );
+
   return useSyncExternalStore(
-    (listener) => (workspaceId ? store.subscribeWorkspace(workspaceId, listener) : () => undefined),
+    subscribe,
     () => store.getWorkspaceSnapshot(workspaceId),
     () => EMPTY_SNAPSHOT
   );

--- a/src/browser/features/Workflows/WorkflowStore.ts
+++ b/src/browser/features/Workflows/WorkflowStore.ts
@@ -1,0 +1,333 @@
+import { useContext, useEffect, useSyncExternalStore } from "react";
+
+import { APIContext, type APIClient } from "@/browser/contexts/API";
+import assert from "@/common/utils/assert";
+import type { WorkflowDefinitionDescriptor, WorkflowRunRecord } from "@/common/types/workflow";
+
+import {
+  compareWorkflowRunsForAttention,
+  groupWorkflowDefinitionsByScope,
+  summarizeWorkflowRuns,
+  type WorkflowRunsSummary,
+} from "./workflowStatusPresentation";
+
+export const WORKFLOW_RUN_POLL_INTERVAL_MS = 2000;
+
+export interface WorkflowWorkspaceSnapshot {
+  definitions: WorkflowDefinitionDescriptor[];
+  definitionGroups: ReturnType<typeof groupWorkflowDefinitionsByScope>;
+  runs: WorkflowRunRecord[];
+  currentRuns: WorkflowRunRecord[];
+  historyRuns: WorkflowRunRecord[];
+  summary: WorkflowRunsSummary;
+  isLoading: boolean;
+  error: string | null;
+}
+
+const EMPTY_DEFINITION_GROUPS = groupWorkflowDefinitionsByScope([]);
+const EMPTY_SUMMARY = summarizeWorkflowRuns([]);
+const EMPTY_SNAPSHOT: WorkflowWorkspaceSnapshot = {
+  definitions: [],
+  definitionGroups: EMPTY_DEFINITION_GROUPS,
+  runs: [],
+  currentRuns: [],
+  historyRuns: [],
+  summary: EMPTY_SUMMARY,
+  isLoading: false,
+  error: null,
+};
+
+type Listener = () => void;
+
+interface WorkspaceState {
+  definitions: WorkflowDefinitionDescriptor[];
+  runs: WorkflowRunRecord[];
+  snapshot: WorkflowWorkspaceSnapshot;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export class WorkflowStore {
+  private client: APIClient | null = null;
+  private readonly listenersByWorkspace = new Map<string, Set<Listener>>();
+  private readonly states = new Map<string, WorkspaceState>();
+  private readonly inFlightSnapshots = new Set<string>();
+  private readonly runTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private disposed = false;
+
+  setClient(client: APIClient | null): void {
+    this.client = client;
+    if (client == null || this.disposed) return;
+
+    for (const workspaceId of this.listenersByWorkspace.keys()) {
+      this.refreshWorkspace(workspaceId);
+    }
+  }
+
+  subscribeWorkspace = (workspaceId: string, listener: Listener): (() => void) => {
+    assert(workspaceId.length > 0, "WorkflowStore subscriptions require a workspace id");
+    let listeners = this.listenersByWorkspace.get(workspaceId);
+    if (listeners == null) {
+      listeners = new Set<Listener>();
+      this.listenersByWorkspace.set(workspaceId, listeners);
+    }
+    listeners.add(listener);
+
+    if (!this.states.has(workspaceId) && !this.inFlightSnapshots.has(workspaceId)) {
+      queueMicrotask(() => this.refreshWorkspace(workspaceId));
+    }
+
+    return () => {
+      const currentListeners = this.listenersByWorkspace.get(workspaceId);
+      currentListeners?.delete(listener);
+      if (currentListeners?.size === 0) {
+        this.listenersByWorkspace.delete(workspaceId);
+        this.stopWorkspaceRunPolling(workspaceId);
+      }
+    };
+  };
+
+  getWorkspaceSnapshot(workspaceId: string | undefined): WorkflowWorkspaceSnapshot {
+    if (!workspaceId) return EMPTY_SNAPSHOT;
+    return this.states.get(workspaceId)?.snapshot ?? EMPTY_SNAPSHOT;
+  }
+
+  getWorkspaceSummary(workspaceId: string | undefined): WorkflowRunsSummary {
+    return this.getWorkspaceSnapshot(workspaceId).summary;
+  }
+
+  invalidateWorkspace(workspaceId: string): void {
+    this.refreshWorkspace(workspaceId);
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    for (const timer of this.runTimers.values()) clearTimeout(timer);
+    this.runTimers.clear();
+    this.listenersByWorkspace.clear();
+    this.states.clear();
+    this.inFlightSnapshots.clear();
+  }
+
+  private refreshWorkspace(workspaceId: string): void {
+    if (this.client == null || this.disposed || !this.listenersByWorkspace.has(workspaceId)) return;
+    if (this.inFlightSnapshots.has(workspaceId)) return;
+
+    this.inFlightSnapshots.add(workspaceId);
+    this.updateWorkspaceLoading(workspaceId, true, null);
+    void this.loadWorkspaceSnapshot(workspaceId);
+  }
+
+  private async loadWorkspaceSnapshot(workspaceId: string): Promise<void> {
+    assert(this.client != null, "WorkflowStore cannot load workflows without an API client");
+    const client = this.client;
+    try {
+      const [definitions, runs] = await Promise.all([
+        Promise.resolve()
+          .then(() => client.workflows.listDefinitions({ workspaceId }))
+          .catch(() => []),
+        Promise.resolve()
+          .then(() => client.workflows.listRuns({ workspaceId }))
+          .catch(() => []),
+      ]);
+      if (this.disposed) return;
+      this.setWorkspaceData(workspaceId, definitions, runs, false, null);
+    } catch (error) {
+      if (this.disposed) return;
+      this.updateWorkspaceLoading(
+        workspaceId,
+        false,
+        error instanceof Error ? error.message : "Failed to load workflows"
+      );
+    } finally {
+      this.inFlightSnapshots.delete(workspaceId);
+    }
+  }
+
+  private updateWorkspaceLoading(
+    workspaceId: string,
+    isLoading: boolean,
+    error: string | null
+  ): void {
+    const current = this.states.get(workspaceId);
+    this.setWorkspaceData(
+      workspaceId,
+      current?.definitions ?? [],
+      current?.runs ?? [],
+      isLoading,
+      error
+    );
+  }
+
+  private setWorkspaceData(
+    workspaceId: string,
+    definitions: WorkflowDefinitionDescriptor[],
+    runs: WorkflowRunRecord[],
+    isLoading: boolean,
+    error: string | null
+  ): void {
+    const previousSummary = this.states.get(workspaceId)?.snapshot.summary;
+    const orderedRuns = [...runs].sort(compareWorkflowRunsForAttention);
+    const activeOrProblemRuns = orderedRuns.filter((run) => {
+      const singleSummary = summarizeWorkflowRuns([run]);
+      return singleSummary.activeCount > 0 || singleSummary.problemCount > 0;
+    });
+    const historyRuns = orderedRuns.filter((run) => !activeOrProblemRuns.includes(run));
+    const nextSummary = summarizeWorkflowRuns(orderedRuns);
+    const summary = areWorkflowSummariesEqual(previousSummary, nextSummary)
+      ? previousSummary
+      : nextSummary;
+    const snapshot: WorkflowWorkspaceSnapshot = {
+      definitions,
+      definitionGroups: groupWorkflowDefinitionsByScope(definitions),
+      runs: orderedRuns,
+      currentRuns: activeOrProblemRuns,
+      historyRuns,
+      summary,
+      isLoading,
+      error,
+    };
+    this.states.set(workspaceId, { definitions, runs: orderedRuns, snapshot, isLoading, error });
+    this.syncRunPolling(workspaceId, orderedRuns);
+    this.emit(workspaceId);
+  }
+
+  private syncRunPolling(workspaceId: string, runs: readonly WorkflowRunRecord[]): void {
+    if (!this.listenersByWorkspace.has(workspaceId)) return;
+
+    const activeRunIds = new Set(
+      runs.filter((run) => summarizeWorkflowRuns([run]).activeCount > 0).map((run) => run.id)
+    );
+    for (const runId of activeRunIds) {
+      const key = getRunKey(workspaceId, runId);
+      if (!this.runTimers.has(key)) {
+        this.scheduleRunPoll(workspaceId, runId);
+      }
+    }
+    for (const key of Array.from(this.runTimers.keys())) {
+      const { workspaceId: keyWorkspaceId, runId } = parseRunKey(key);
+      if (keyWorkspaceId === workspaceId && !activeRunIds.has(runId)) {
+        this.clearRunTimer(key);
+      }
+    }
+  }
+
+  private scheduleRunPoll(workspaceId: string, runId: string): void {
+    assert(workspaceId.length > 0 && runId.length > 0, "Workflow run polling requires ids");
+    const key = getRunKey(workspaceId, runId);
+    if (this.runTimers.has(key)) return;
+    const timer = setTimeout(() => {
+      this.runTimers.delete(key);
+      void this.pollRun(workspaceId, runId);
+    }, WORKFLOW_RUN_POLL_INTERVAL_MS);
+    if (typeof timer === "object" && "unref" in timer && typeof timer.unref === "function") {
+      timer.unref();
+    }
+    this.runTimers.set(key, timer);
+  }
+
+  private async pollRun(workspaceId: string, runId: string): Promise<void> {
+    if (this.client == null || this.disposed || !this.listenersByWorkspace.has(workspaceId)) return;
+    const run = await this.client.workflows.getRun({ workspaceId, runId });
+    if (this.disposed || !this.listenersByWorkspace.has(workspaceId) || run == null) return;
+
+    const state = this.states.get(workspaceId);
+    const currentRuns = state?.runs ?? [];
+    const nextRuns = currentRuns.some((candidate) => candidate.id === run.id)
+      ? currentRuns.map((candidate) => (candidate.id === run.id ? run : candidate))
+      : [run, ...currentRuns];
+    this.setWorkspaceData(
+      workspaceId,
+      state?.definitions ?? [],
+      nextRuns,
+      state?.isLoading ?? false,
+      null
+    );
+  }
+
+  private stopWorkspaceRunPolling(workspaceId: string): void {
+    for (const key of Array.from(this.runTimers.keys())) {
+      if (parseRunKey(key).workspaceId === workspaceId) {
+        this.clearRunTimer(key);
+      }
+    }
+  }
+
+  private clearRunTimer(key: string): void {
+    const timer = this.runTimers.get(key);
+    if (timer != null) clearTimeout(timer);
+    this.runTimers.delete(key);
+  }
+
+  private emit(workspaceId: string): void {
+    const listeners = this.listenersByWorkspace.get(workspaceId);
+    if (listeners == null) return;
+    for (const listener of listeners) listener();
+  }
+}
+
+function areWorkflowSummariesEqual(
+  left: WorkflowRunsSummary | undefined,
+  right: WorkflowRunsSummary
+): left is WorkflowRunsSummary {
+  return (
+    left != null &&
+    left.activeCount === right.activeCount &&
+    left.problemCount === right.problemCount &&
+    left.highestSeverity === right.highestSeverity
+  );
+}
+
+function getRunKey(workspaceId: string, runId: string): string {
+  return JSON.stringify([workspaceId, runId]);
+}
+
+function parseRunKey(key: string): { workspaceId: string; runId: string } {
+  const value: unknown = JSON.parse(key);
+  assert(Array.isArray(value) && value.length === 2, "Invalid workflow run polling key");
+  const workspaceId: unknown = value[0];
+  const runId: unknown = value[1];
+  assert(typeof workspaceId === "string" && typeof runId === "string", "Invalid workflow run ids");
+  return { workspaceId, runId };
+}
+
+let workflowStoreInstance: WorkflowStore | null = null;
+
+export function getWorkflowStoreInstance(): WorkflowStore {
+  workflowStoreInstance ??= new WorkflowStore();
+  return workflowStoreInstance;
+}
+
+export function useWorkflowWorkspaceSummary(workspaceId: string | undefined): WorkflowRunsSummary {
+  const apiState = useContext(APIContext);
+  const api = apiState?.api ?? null;
+  const store = getWorkflowStoreInstance();
+
+  useEffect(() => {
+    store.setClient(api);
+  }, [api, store]);
+
+  return useSyncExternalStore(
+    (listener) => (workspaceId ? store.subscribeWorkspace(workspaceId, listener) : () => undefined),
+    () => store.getWorkspaceSummary(workspaceId),
+    () => EMPTY_SUMMARY
+  );
+}
+
+export function useWorkflowWorkspaceSnapshot(
+  workspaceId: string | undefined
+): WorkflowWorkspaceSnapshot {
+  const apiState = useContext(APIContext);
+  const api = apiState?.api ?? null;
+  const store = getWorkflowStoreInstance();
+
+  useEffect(() => {
+    store.setClient(api);
+  }, [api, store]);
+
+  return useSyncExternalStore(
+    (listener) => (workspaceId ? store.subscribeWorkspace(workspaceId, listener) : () => undefined),
+    () => store.getWorkspaceSnapshot(workspaceId),
+    () => EMPTY_SNAPSHOT
+  );
+}

--- a/src/browser/features/Workflows/WorkflowsTab.test.tsx
+++ b/src/browser/features/Workflows/WorkflowsTab.test.tsx
@@ -4,6 +4,8 @@ import { installDom } from "../../../../tests/ui/dom";
 
 import type { WorkflowDefinitionDescriptor, WorkflowRunRecord } from "@/common/types/workflow";
 
+import { WORKFLOW_CHECKPOINT_RETRY_ERROR_MESSAGE } from "@/common/utils/workflowRetryEligibility";
+
 import { WorkflowsTabView } from "./WorkflowsTab";
 import {
   groupWorkflowDefinitionsByScope,
@@ -113,7 +115,7 @@ describe("WorkflowsTabView", () => {
     expect(view.getByText("Recent history")).toBeTruthy();
   });
 
-  test("offers foreground and background run actions", () => {
+  test("starts workflow definitions in the background from the sidebar", () => {
     const started: Array<{ name: string; runInBackground: boolean }> = [];
     const project = definition("project-flow", "project");
     const view = render(
@@ -129,12 +131,9 @@ describe("WorkflowsTabView", () => {
     );
 
     fireEvent.click(view.getByRole("button", { name: "Run project-flow" }));
-    fireEvent.click(view.getByRole("button", { name: "Run project-flow in background" }));
 
-    expect(started).toEqual([
-      { name: "project-flow", runInBackground: false },
-      { name: "project-flow", runInBackground: true },
-    ]);
+    expect(view.queryByRole("button", { name: "Run project-flow in background" })).toBeNull();
+    expect(started).toEqual([{ name: "project-flow", runInBackground: true }]);
   });
 
   test("offers supported current-run actions", () => {
@@ -158,6 +157,14 @@ describe("WorkflowsTabView", () => {
       id: "wfr_failed",
       status: "failed",
       definition: definition("failed-flow", "project"),
+      events: [
+        {
+          type: "error",
+          at: "2026-01-01T00:00:01.000Z",
+          sequence: 1,
+          message: WORKFLOW_CHECKPOINT_RETRY_ERROR_MESSAGE,
+        },
+      ],
     });
     const completed = run({
       id: "wfr_completed",
@@ -187,6 +194,30 @@ describe("WorkflowsTabView", () => {
       { id: "wfr_interrupted", action: "resume" },
       { id: "wfr_failed", action: "retryFromCheckpoint" },
     ]);
+  });
+
+  test("does not offer checkpoint retry for ordinary failed runs", () => {
+    const failed = run({
+      id: "wfr_failed",
+      status: "failed",
+      definition: definition("failed-flow", "project"),
+      events: [
+        {
+          type: "error",
+          at: "2026-01-01T00:00:01.000Z",
+          sequence: 1,
+          message: "Compilation failed",
+        },
+      ],
+    });
+    const view = render(
+      <WorkflowsTabView
+        snapshot={snapshot({ currentRuns: [failed] })}
+        onRunAction={() => undefined}
+      />
+    );
+
+    expect(view.queryByRole("button", { name: "Retry failed-flow" })).toBeNull();
   });
 
   test("offers promotion actions for scratch definitions", () => {

--- a/src/browser/features/Workflows/WorkflowsTab.test.tsx
+++ b/src/browser/features/Workflows/WorkflowsTab.test.tsx
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { installDom } from "../../../../tests/ui/dom";
+
+import type { WorkflowDefinitionDescriptor, WorkflowRunRecord } from "@/common/types/workflow";
+
+import { WorkflowsTabView } from "./WorkflowsTab";
+import {
+  groupWorkflowDefinitionsByScope,
+  summarizeWorkflowRuns,
+} from "./workflowStatusPresentation";
+
+function definition(
+  name: string,
+  scope: WorkflowDefinitionDescriptor["scope"]
+): WorkflowDefinitionDescriptor {
+  return { name, scope, description: `${name} workflow`, executable: true };
+}
+
+function run(overrides: Partial<WorkflowRunRecord>): WorkflowRunRecord {
+  return {
+    id: "wfr_test",
+    workspaceId: "workspace-1",
+    definition: definition("demo", "project"),
+    definitionSource: "/repo/.mux/workflows/demo.js",
+    definitionHash: "hash",
+    args: {},
+    status: "running",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    events: [],
+    steps: [],
+    ...overrides,
+  };
+}
+
+function snapshot(input: {
+  definitions?: WorkflowDefinitionDescriptor[];
+  currentRuns?: WorkflowRunRecord[];
+  historyRuns?: WorkflowRunRecord[];
+}) {
+  const definitions = input.definitions ?? [];
+  const runs = [...(input.currentRuns ?? []), ...(input.historyRuns ?? [])];
+  return {
+    definitions,
+    definitionGroups: groupWorkflowDefinitionsByScope(definitions),
+    runs,
+    currentRuns: input.currentRuns ?? [],
+    historyRuns: input.historyRuns ?? [],
+    summary: summarizeWorkflowRuns(runs),
+    isLoading: false,
+    error: null,
+  };
+}
+
+describe("WorkflowsTabView", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installDom();
+  });
+
+  afterEach(() => {
+    cleanup();
+    cleanupDom?.();
+    cleanupDom = null;
+  });
+
+  test("renders empty states without an API-backed snapshot", () => {
+    const view = render(<WorkflowsTabView snapshot={snapshot({})} />);
+
+    expect(view.getByText("No active workflows")).toBeTruthy();
+    expect(view.getByText("No workflow definitions found")).toBeTruthy();
+    expect(view.getByText("No workflow history yet")).toBeTruthy();
+  });
+
+  test("groups definitions by source scope and highlights runs needing attention first", () => {
+    const view = render(
+      <WorkflowsTabView
+        snapshot={snapshot({
+          definitions: [
+            definition("project-flow", "project"),
+            definition("global-flow", "global"),
+            definition("built-in-flow", "built-in"),
+            definition("scratch-flow", "scratch"),
+          ],
+          currentRuns: [
+            run({
+              id: "wfr_failed",
+              status: "failed",
+              definition: definition("project-flow", "project"),
+            }),
+            run({
+              id: "wfr_running",
+              status: "running",
+              definition: definition("global-flow", "global"),
+            }),
+          ],
+          historyRuns: [run({ id: "wfr_done", status: "completed" })],
+        })}
+      />
+    );
+
+    expect(view.getByText(/2 current/)).toBeTruthy();
+    expect(view.getByText(/1 needs attention/)).toBeTruthy();
+    for (const heading of ["Project", "Global", "Built-in", "Scratch"]) {
+      expect(view.getByText(heading)).toBeTruthy();
+    }
+    expect(view.getAllByText("project-flow").length).toBeGreaterThan(0);
+    expect(view.getAllByText("global-flow").length).toBeGreaterThan(0);
+    expect(view.getAllByText("built-in-flow").length).toBeGreaterThan(0);
+    expect(view.getAllByText("scratch-flow").length).toBeGreaterThan(0);
+    expect(view.getByText("Recent history")).toBeTruthy();
+  });
+
+  test("offers foreground and background run actions", () => {
+    const started: Array<{ name: string; runInBackground: boolean }> = [];
+    const project = definition("project-flow", "project");
+    const view = render(
+      <WorkflowsTabView
+        snapshot={snapshot({ definitions: [project] })}
+        onRunDefinition={(definition, options) => {
+          started.push({
+            name: definition.name,
+            runInBackground: options?.runInBackground === true,
+          });
+        }}
+      />
+    );
+
+    fireEvent.click(view.getByRole("button", { name: "Run project-flow" }));
+    fireEvent.click(view.getByRole("button", { name: "Run project-flow in background" }));
+
+    expect(started).toEqual([
+      { name: "project-flow", runInBackground: false },
+      { name: "project-flow", runInBackground: true },
+    ]);
+  });
+
+  test("offers supported current-run actions", () => {
+    const actions: Array<{ id: string; action: string }> = [];
+    const running = run({
+      id: "wfr_running",
+      status: "running",
+      definition: definition("running-flow", "project"),
+    });
+    const backgrounded = run({
+      id: "wfr_backgrounded",
+      status: "backgrounded",
+      definition: definition("backgrounded-flow", "project"),
+    });
+    const interrupted = run({
+      id: "wfr_interrupted",
+      status: "interrupted",
+      definition: definition("interrupted-flow", "project"),
+    });
+    const failed = run({
+      id: "wfr_failed",
+      status: "failed",
+      definition: definition("failed-flow", "project"),
+    });
+    const completed = run({
+      id: "wfr_completed",
+      status: "completed",
+      definition: definition("completed-flow", "project"),
+    });
+    const view = render(
+      <WorkflowsTabView
+        snapshot={snapshot({
+          currentRuns: [running, backgrounded, interrupted, failed, completed],
+        })}
+        onRunAction={(run, action) => {
+          actions.push({ id: run.id, action });
+        }}
+      />
+    );
+
+    fireEvent.click(view.getByRole("button", { name: "Interrupt running-flow" }));
+    fireEvent.click(view.getByRole("button", { name: "Interrupt backgrounded-flow" }));
+    fireEvent.click(view.getByRole("button", { name: "Resume interrupted-flow" }));
+    fireEvent.click(view.getByRole("button", { name: "Retry failed-flow" }));
+
+    expect(view.queryByRole("button", { name: "Retry completed-flow" })).toBeNull();
+    expect(actions).toEqual([
+      { id: "wfr_running", action: "interrupt" },
+      { id: "wfr_backgrounded", action: "interrupt" },
+      { id: "wfr_interrupted", action: "resume" },
+      { id: "wfr_failed", action: "retryFromCheckpoint" },
+    ]);
+  });
+
+  test("offers promotion actions for scratch definitions", () => {
+    const promoted: Array<{ name: string; location: "project" | "global" }> = [];
+    const scratch = definition("scratch-flow", "scratch");
+    const view = render(
+      <WorkflowsTabView
+        snapshot={snapshot({ definitions: [scratch] })}
+        onPromoteScratchDefinition={(definition, location) => {
+          promoted.push({ name: definition.name, location });
+        }}
+      />
+    );
+
+    fireEvent.click(view.getByRole("button", { name: "Save scratch-flow to project workflows" }));
+    fireEvent.click(view.getByRole("button", { name: "Save scratch-flow to global workflows" }));
+
+    expect(promoted).toEqual([
+      { name: "scratch-flow", location: "project" },
+      { name: "scratch-flow", location: "global" },
+    ]);
+  });
+});

--- a/src/browser/features/Workflows/WorkflowsTab.tsx
+++ b/src/browser/features/Workflows/WorkflowsTab.tsx
@@ -1,0 +1,411 @@
+import React, { useContext, useState } from "react";
+import { Play, RefreshCw } from "lucide-react";
+
+import { APIContext } from "@/browser/contexts/API";
+import { Button } from "@/browser/components/Button/Button";
+import { cn } from "@/common/lib/utils";
+import type {
+  WorkflowDefinitionDescriptor,
+  WorkflowDefinitionScope,
+  WorkflowRunRecord,
+} from "@/common/types/workflow";
+
+import {
+  getWorkflowStoreInstance,
+  type WorkflowWorkspaceSnapshot,
+  useWorkflowWorkspaceSnapshot,
+} from "./WorkflowStore";
+import {
+  getLatestWorkflowRunSummary,
+  getWorkflowStatusPresentation,
+  type WorkflowStatusSeverity,
+} from "./workflowStatusPresentation";
+
+interface WorkflowsTabProps {
+  workspaceId: string;
+}
+
+interface RunWorkflowOptions {
+  runInBackground: boolean;
+}
+
+type WorkflowRunAction = "interrupt" | "resume" | "retryFromCheckpoint";
+
+interface WorkflowsTabViewProps {
+  snapshot: WorkflowWorkspaceSnapshot;
+  onRunDefinition?: (
+    definition: WorkflowDefinitionDescriptor,
+    options?: RunWorkflowOptions
+  ) => Promise<void> | void;
+  onRunAction?: (run: WorkflowRunRecord, action: WorkflowRunAction) => Promise<void> | void;
+  onPromoteScratchDefinition?: (
+    definition: WorkflowDefinitionDescriptor,
+    location: "project" | "global"
+  ) => Promise<void> | void;
+  onRefresh?: () => void;
+}
+
+const SCOPE_LABELS: Record<WorkflowDefinitionScope, string> = {
+  project: "Project",
+  global: "Global",
+  "built-in": "Built-in",
+  scratch: "Scratch",
+};
+
+const SCOPE_ORDER: WorkflowDefinitionScope[] = ["project", "global", "built-in", "scratch"];
+
+const SEVERITY_CLASS: Record<WorkflowStatusSeverity, string> = {
+  error: "text-error border-error/40 bg-error/10",
+  warning: "text-warning border-warning/40 bg-warning/10",
+  active: "text-success border-success/40 bg-success/10",
+  "active-background": "text-muted border-border bg-secondary",
+  pending: "text-muted border-border bg-secondary",
+  terminal: "text-muted border-border bg-secondary",
+  unknown: "text-muted border-border bg-secondary",
+};
+
+export function WorkflowsTab(props: WorkflowsTabProps) {
+  const apiState = useContext(APIContext);
+  const snapshot = useWorkflowWorkspaceSnapshot(props.workspaceId);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const handleRunDefinition = async (
+    definition: WorkflowDefinitionDescriptor,
+    options?: RunWorkflowOptions
+  ) => {
+    if (!apiState?.api) return;
+    setActionError(null);
+    try {
+      await apiState.api.workflows.start({
+        workspaceId: props.workspaceId,
+        name: definition.name,
+        runInBackground: options?.runInBackground === true,
+      });
+      getWorkflowStoreInstance().invalidateWorkspace(props.workspaceId);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Failed to start workflow");
+    }
+  };
+
+  const handleRunAction = async (run: WorkflowRunRecord, action: WorkflowRunAction) => {
+    if (!apiState?.api) return;
+    setActionError(null);
+    try {
+      if (action === "interrupt") {
+        await apiState.api.workflows.interrupt({ workspaceId: props.workspaceId, runId: run.id });
+      } else if (action === "resume") {
+        await apiState.api.workflows.resume({ workspaceId: props.workspaceId, runId: run.id });
+      } else {
+        await apiState.api.workflows.retryFromCheckpoint({
+          workspaceId: props.workspaceId,
+          runId: run.id,
+        });
+      }
+      getWorkflowStoreInstance().invalidateWorkspace(props.workspaceId);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Failed to update workflow");
+    }
+  };
+
+  const handlePromoteScratchDefinition = async (
+    definition: WorkflowDefinitionDescriptor,
+    location: "project" | "global"
+  ) => {
+    if (!apiState?.api) return;
+    setActionError(null);
+    try {
+      await apiState.api.workflows.promoteScratchDefinition({
+        workspaceId: props.workspaceId,
+        name: definition.name,
+        description: definition.description,
+        location,
+        overwrite: false,
+      });
+      getWorkflowStoreInstance().invalidateWorkspace(props.workspaceId);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Failed to save workflow");
+    }
+  };
+
+  return (
+    <div className="h-full overflow-y-auto p-3">
+      <WorkflowsTabView
+        snapshot={actionError == null ? snapshot : { ...snapshot, error: actionError }}
+        onRunDefinition={apiState?.api ? handleRunDefinition : undefined}
+        onRunAction={apiState?.api ? handleRunAction : undefined}
+        onPromoteScratchDefinition={apiState?.api ? handlePromoteScratchDefinition : undefined}
+      />
+    </div>
+  );
+}
+
+export function WorkflowsTabView(props: WorkflowsTabViewProps) {
+  const { snapshot } = props;
+  return (
+    <div className="flex flex-col gap-3 text-sm">
+      <section className="border-border bg-background rounded-lg border p-3">
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <h2 className="text-sm font-semibold">Workflows</h2>
+            <p className="text-muted text-xs">
+              {snapshot.summary.activeCount} active · {snapshot.summary.problemCount} needing
+              attention
+            </p>
+          </div>
+          {props.onRefresh && (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={props.onRefresh}
+              aria-label="Refresh workflows"
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+            </Button>
+          )}
+        </div>
+        {snapshot.error && <p className="text-error mt-2 text-xs">{snapshot.error}</p>}
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <h3 className="text-muted text-xs font-semibold tracking-wide uppercase">Current runs</h3>
+          {snapshot.currentRuns.length > 0 && (
+            <span className="text-muted text-xs">
+              {snapshot.currentRuns.length} current
+              {snapshot.summary.problemCount > 0
+                ? ` · ${snapshot.summary.problemCount} needs attention`
+                : ""}
+            </span>
+          )}
+        </div>
+        {snapshot.currentRuns.length === 0 ? (
+          <EmptyState>No active workflows</EmptyState>
+        ) : (
+          snapshot.currentRuns.map((run) => (
+            <WorkflowRunCard key={run.id} run={run} onAction={props.onRunAction} />
+          ))
+        )}
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h3 className="text-muted text-xs font-semibold tracking-wide uppercase">
+          Available definitions
+        </h3>
+        {snapshot.definitions.length === 0 ? (
+          <EmptyState>No workflow definitions found</EmptyState>
+        ) : (
+          SCOPE_ORDER.map((scope) => {
+            const definitions = snapshot.definitionGroups[scope];
+            if (definitions.length === 0) return null;
+            return (
+              <details
+                key={scope}
+                open
+                className="border-border bg-background rounded-lg border p-2"
+              >
+                <summary className="text-muted cursor-pointer text-xs font-semibold">
+                  {SCOPE_LABELS[scope]}
+                </summary>
+                <div className="mt-2 flex flex-col gap-2">
+                  {definitions.map((definition) => (
+                    <WorkflowDefinitionRow
+                      key={`${definition.scope}:${definition.name}`}
+                      definition={definition}
+                      onRun={props.onRunDefinition}
+                      onPromoteScratchDefinition={props.onPromoteScratchDefinition}
+                    />
+                  ))}
+                </div>
+              </details>
+            );
+          })
+        )}
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h3 className="text-muted text-xs font-semibold tracking-wide uppercase">Recent history</h3>
+        {snapshot.historyRuns.length === 0 ? (
+          <EmptyState>No workflow history yet</EmptyState>
+        ) : (
+          <details className="border-border bg-background rounded-lg border p-2">
+            <summary className="text-muted cursor-pointer text-xs">
+              {snapshot.historyRuns.length} completed or inactive run
+              {snapshot.historyRuns.length === 1 ? "" : "s"}
+            </summary>
+            <div className="mt-2 flex flex-col gap-2">
+              {snapshot.historyRuns.slice(0, 10).map((run) => (
+                <WorkflowRunCard key={run.id} run={run} compact />
+              ))}
+            </div>
+          </details>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function WorkflowRunCard(props: {
+  run: WorkflowRunRecord;
+  compact?: boolean;
+  onAction?: (run: WorkflowRunRecord, action: WorkflowRunAction) => Promise<void> | void;
+}) {
+  const presentation = getWorkflowStatusPresentation(props.run.status);
+  const action = getWorkflowRunAction(props.run.status);
+  return (
+    <article
+      className="border-border bg-background rounded-lg border p-2"
+      aria-label={props.run.id}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="truncate text-sm font-medium">{props.run.definition.name}</div>
+          {!props.compact && (
+            <div className="text-muted truncate text-xs">
+              {getLatestWorkflowRunSummary(props.run)}
+            </div>
+          )}
+        </div>
+        <div className="flex shrink-0 flex-col items-end gap-1">
+          <StatusBadge label={presentation.label} severity={presentation.severity} />
+          {!props.compact && props.onAction && action && (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              aria-label={`${action.label} ${props.run.definition.name}`}
+              onClick={() => {
+                void props.onAction?.(props.run, action.action);
+              }}
+            >
+              {action.label}
+            </Button>
+          )}
+        </div>
+      </div>
+      <div className="text-muted counter-nums-mono mt-1 text-[11px]">{props.run.id}</div>
+    </article>
+  );
+}
+
+function WorkflowDefinitionRow(props: {
+  definition: WorkflowDefinitionDescriptor;
+  onRun?: (
+    definition: WorkflowDefinitionDescriptor,
+    options?: RunWorkflowOptions
+  ) => Promise<void> | void;
+  onPromoteScratchDefinition?: (
+    definition: WorkflowDefinitionDescriptor,
+    location: "project" | "global"
+  ) => Promise<void> | void;
+}) {
+  return (
+    <article className="border-border bg-secondary/40 rounded-md border p-2">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="truncate text-sm font-medium">{props.definition.name}</div>
+          <p className="text-muted line-clamp-2 text-xs">{props.definition.description}</p>
+          {props.definition.sourcePath && (
+            <p className="text-muted mt-1 truncate text-[11px]">{props.definition.sourcePath}</p>
+          )}
+          {!props.definition.executable && props.definition.blockedReason && (
+            <p className="text-warning mt-1 text-xs">{props.definition.blockedReason}</p>
+          )}
+        </div>
+        {props.definition.executable && (
+          <div className="flex shrink-0 flex-col gap-1">
+            {props.onRun && (
+              <>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  aria-label={`Run ${props.definition.name}`}
+                  onClick={() => {
+                    void props.onRun?.(props.definition, { runInBackground: false });
+                  }}
+                >
+                  <Play className="h-3 w-3" />
+                  Run
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  aria-label={`Run ${props.definition.name} in background`}
+                  onClick={() => {
+                    void props.onRun?.(props.definition, { runInBackground: true });
+                  }}
+                >
+                  Run background
+                </Button>
+              </>
+            )}
+            {props.definition.scope === "scratch" && props.onPromoteScratchDefinition && (
+              <>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  aria-label={`Save ${props.definition.name} to project workflows`}
+                  onClick={() => {
+                    void props.onPromoteScratchDefinition?.(props.definition, "project");
+                  }}
+                >
+                  Save project
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  aria-label={`Save ${props.definition.name} to global workflows`}
+                  onClick={() => {
+                    void props.onPromoteScratchDefinition?.(props.definition, "global");
+                  }}
+                >
+                  Save global
+                </Button>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}
+
+function getWorkflowRunAction(
+  status: WorkflowRunRecord["status"]
+): { action: WorkflowRunAction; label: string } | null {
+  if (status === "pending" || status === "running" || status === "backgrounded") {
+    return { action: "interrupt", label: "Interrupt" };
+  }
+  if (status === "interrupted") {
+    return { action: "resume", label: "Resume" };
+  }
+  if (status === "failed") {
+    return { action: "retryFromCheckpoint", label: "Retry" };
+  }
+  return null;
+}
+
+function StatusBadge(props: { label: string; severity: WorkflowStatusSeverity }) {
+  return (
+    <span
+      className={cn(
+        "shrink-0 rounded-full border px-2 py-0.5 text-[11px] font-medium",
+        SEVERITY_CLASS[props.severity]
+      )}
+    >
+      {props.label}
+    </span>
+  );
+}
+
+function EmptyState(props: { children: React.ReactNode }) {
+  return (
+    <div className="border-border text-muted rounded-lg border border-dashed p-3 text-xs">
+      {props.children}
+    </div>
+  );
+}

--- a/src/browser/features/Workflows/WorkflowsTab.tsx
+++ b/src/browser/features/Workflows/WorkflowsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useRef, useState } from "react";
 import { Play, RefreshCw } from "lucide-react";
 
 import { APIContext } from "@/browser/contexts/API";
@@ -9,6 +9,8 @@ import type {
   WorkflowDefinitionScope,
   WorkflowRunRecord,
 } from "@/common/types/workflow";
+
+import { canRetryWorkflowFromCheckpoint } from "@/common/utils/workflowRetryEligibility";
 
 import {
   getWorkflowStoreInstance,
@@ -42,6 +44,7 @@ interface WorkflowsTabViewProps {
     definition: WorkflowDefinitionDescriptor,
     location: "project" | "global"
   ) => Promise<void> | void;
+  pendingDefinitionNames?: ReadonlySet<string>;
   onRefresh?: () => void;
 }
 
@@ -67,23 +70,33 @@ const SEVERITY_CLASS: Record<WorkflowStatusSeverity, string> = {
 export function WorkflowsTab(props: WorkflowsTabProps) {
   const apiState = useContext(APIContext);
   const snapshot = useWorkflowWorkspaceSnapshot(props.workspaceId);
+  const pendingDefinitionNamesRef = useRef(new Set<string>());
+  const [pendingDefinitionNames, setPendingDefinitionNames] = useState<ReadonlySet<string>>(
+    () => new Set()
+  );
   const [actionError, setActionError] = useState<string | null>(null);
 
   const handleRunDefinition = async (
     definition: WorkflowDefinitionDescriptor,
     options?: RunWorkflowOptions
   ) => {
-    if (!apiState?.api) return;
+    if (!apiState?.api || pendingDefinitionNamesRef.current.has(definition.name)) return;
+    pendingDefinitionNamesRef.current.add(definition.name);
+    setPendingDefinitionNames(new Set(pendingDefinitionNamesRef.current));
     setActionError(null);
     try {
       await apiState.api.workflows.start({
         workspaceId: props.workspaceId,
         name: definition.name,
-        runInBackground: options?.runInBackground === true,
+        // Sidebar launches should return immediately so progress appears in Current runs.
+        runInBackground: options?.runInBackground ?? true,
       });
       getWorkflowStoreInstance().invalidateWorkspace(props.workspaceId);
     } catch (error) {
       setActionError(error instanceof Error ? error.message : "Failed to start workflow");
+    } finally {
+      pendingDefinitionNamesRef.current.delete(definition.name);
+      setPendingDefinitionNames(new Set(pendingDefinitionNamesRef.current));
     }
   };
 
@@ -134,6 +147,7 @@ export function WorkflowsTab(props: WorkflowsTabProps) {
         onRunDefinition={apiState?.api ? handleRunDefinition : undefined}
         onRunAction={apiState?.api ? handleRunAction : undefined}
         onPromoteScratchDefinition={apiState?.api ? handlePromoteScratchDefinition : undefined}
+        pendingDefinitionNames={pendingDefinitionNames}
       />
     </div>
   );
@@ -212,6 +226,7 @@ export function WorkflowsTabView(props: WorkflowsTabViewProps) {
                     <WorkflowDefinitionRow
                       key={`${definition.scope}:${definition.name}`}
                       definition={definition}
+                      isStarting={props.pendingDefinitionNames?.has(definition.name) === true}
                       onRun={props.onRunDefinition}
                       onPromoteScratchDefinition={props.onPromoteScratchDefinition}
                     />
@@ -251,7 +266,7 @@ function WorkflowRunCard(props: {
   onAction?: (run: WorkflowRunRecord, action: WorkflowRunAction) => Promise<void> | void;
 }) {
   const presentation = getWorkflowStatusPresentation(props.run.status);
-  const action = getWorkflowRunAction(props.run.status);
+  const action = getWorkflowRunAction(props.run);
   return (
     <article
       className="border-border bg-background rounded-lg border p-2"
@@ -290,6 +305,7 @@ function WorkflowRunCard(props: {
 
 function WorkflowDefinitionRow(props: {
   definition: WorkflowDefinitionDescriptor;
+  isStarting?: boolean;
   onRun?: (
     definition: WorkflowDefinitionDescriptor,
     options?: RunWorkflowOptions
@@ -315,31 +331,19 @@ function WorkflowDefinitionRow(props: {
         {props.definition.executable && (
           <div className="flex shrink-0 flex-col gap-1">
             {props.onRun && (
-              <>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="secondary"
-                  aria-label={`Run ${props.definition.name}`}
-                  onClick={() => {
-                    void props.onRun?.(props.definition, { runInBackground: false });
-                  }}
-                >
-                  <Play className="h-3 w-3" />
-                  Run
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="ghost"
-                  aria-label={`Run ${props.definition.name} in background`}
-                  onClick={() => {
-                    void props.onRun?.(props.definition, { runInBackground: true });
-                  }}
-                >
-                  Run background
-                </Button>
-              </>
+              <Button
+                type="button"
+                size="sm"
+                variant="secondary"
+                aria-label={`Run ${props.definition.name}`}
+                disabled={props.isStarting === true}
+                onClick={() => {
+                  void props.onRun?.(props.definition, { runInBackground: true });
+                }}
+              >
+                <Play className="h-3 w-3" />
+                {props.isStarting === true ? "Starting..." : "Run"}
+              </Button>
             )}
             {props.definition.scope === "scratch" && props.onPromoteScratchDefinition && (
               <>
@@ -375,15 +379,15 @@ function WorkflowDefinitionRow(props: {
 }
 
 function getWorkflowRunAction(
-  status: WorkflowRunRecord["status"]
+  run: WorkflowRunRecord
 ): { action: WorkflowRunAction; label: string } | null {
-  if (status === "pending" || status === "running" || status === "backgrounded") {
+  if (run.status === "pending" || run.status === "running" || run.status === "backgrounded") {
     return { action: "interrupt", label: "Interrupt" };
   }
-  if (status === "interrupted") {
+  if (run.status === "interrupted") {
     return { action: "resume", label: "Resume" };
   }
-  if (status === "failed") {
+  if (canRetryWorkflowFromCheckpoint(run)) {
     return { action: "retryFromCheckpoint", label: "Retry" };
   }
   return null;

--- a/src/browser/features/Workflows/workflowStatusPresentation.test.ts
+++ b/src/browser/features/Workflows/workflowStatusPresentation.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+
+import type { WorkflowRunRecord } from "@/common/types/workflow";
+import {
+  compareWorkflowRunsForAttention,
+  getLatestWorkflowRunSummary,
+  getWorkflowStatusPresentation,
+  summarizeWorkflowRuns,
+} from "./workflowStatusPresentation";
+
+function run(overrides: Partial<WorkflowRunRecord>): WorkflowRunRecord {
+  return {
+    id: "wfr_test",
+    workspaceId: "workspace-1",
+    definition: {
+      name: "demo",
+      description: "Demo workflow",
+      scope: "project",
+      executable: true,
+      sourcePath: "/repo/.mux/workflows/demo.js",
+    },
+    definitionSource: "/repo/.mux/workflows/demo.js",
+    definitionHash: "hash",
+    args: {},
+    status: "pending",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    events: [],
+    steps: [],
+    ...overrides,
+  };
+}
+
+describe("workflow status presentation", () => {
+  test("aggregates active and problem runs with problem severity winning over activity", () => {
+    const summary = summarizeWorkflowRuns([
+      run({ id: "wfr_running", status: "running" }),
+      run({ id: "wfr_failed", status: "failed" }),
+      run({ id: "wfr_completed", status: "completed" }),
+    ]);
+
+    expect(summary.activeCount).toBe(1);
+    expect(summary.problemCount).toBe(1);
+    expect(summary.highestSeverity).toBe("error");
+  });
+
+  test("sorts failed and interrupted runs before live runs, then by most recent update", () => {
+    const sorted = [
+      run({ id: "wfr_old_running", status: "running", updatedAt: "2026-01-01T00:00:00.000Z" }),
+      run({ id: "wfr_new_running", status: "running", updatedAt: "2026-01-03T00:00:00.000Z" }),
+      run({ id: "wfr_interrupted", status: "interrupted", updatedAt: "2026-01-02T00:00:00.000Z" }),
+      run({ id: "wfr_failed", status: "failed", updatedAt: "2026-01-01T00:00:00.000Z" }),
+    ].sort(compareWorkflowRunsForAttention);
+
+    expect(sorted.map((item) => item.id)).toEqual([
+      "wfr_failed",
+      "wfr_interrupted",
+      "wfr_new_running",
+      "wfr_old_running",
+    ]);
+  });
+
+  test("summarizes the latest meaningful event instead of status churn", () => {
+    const summary = getLatestWorkflowRunSummary(
+      run({
+        events: [
+          { sequence: 1, type: "status", at: "2026-01-01T00:00:00.000Z", status: "running" },
+          { sequence: 2, type: "phase", at: "2026-01-01T00:00:01.000Z", name: "Collect inputs" },
+          { sequence: 3, type: "log", at: "2026-01-01T00:00:02.000Z", message: "Fetched 3 items" },
+        ],
+      })
+    );
+
+    expect(summary).toBe("Fetched 3 items");
+  });
+
+  test("falls back safely for unrecognized persisted statuses", () => {
+    const presentation = getWorkflowStatusPresentation("paused-by-old-build");
+
+    expect(presentation.severity).toBe("unknown");
+    expect(presentation.isActive).toBe(false);
+    expect(presentation.needsAttention).toBe(false);
+  });
+});

--- a/src/browser/features/Workflows/workflowStatusPresentation.ts
+++ b/src/browser/features/Workflows/workflowStatusPresentation.ts
@@ -1,0 +1,155 @@
+import type {
+  WorkflowDefinitionDescriptor,
+  WorkflowDefinitionScope,
+  WorkflowRunEvent,
+  WorkflowRunRecord,
+  WorkflowRunStatus,
+} from "@/common/types/workflow";
+import assert from "@/common/utils/assert";
+
+export type WorkflowStatusSeverity =
+  | "error"
+  | "warning"
+  | "active"
+  | "active-background"
+  | "pending"
+  | "terminal"
+  | "unknown";
+
+export interface WorkflowStatusPresentation {
+  label: string;
+  severity: WorkflowStatusSeverity;
+  isActive: boolean;
+  needsAttention: boolean;
+}
+
+export interface WorkflowRunsSummary {
+  activeCount: number;
+  problemCount: number;
+  highestSeverity: WorkflowStatusSeverity | null;
+}
+
+const WORKFLOW_STATUS_PRESENTATION: Record<WorkflowRunStatus, WorkflowStatusPresentation> = {
+  failed: { label: "Failed", severity: "error", isActive: false, needsAttention: true },
+  interrupted: {
+    label: "Interrupted",
+    severity: "warning",
+    isActive: false,
+    needsAttention: true,
+  },
+  running: { label: "Running", severity: "active", isActive: true, needsAttention: false },
+  backgrounded: {
+    label: "Backgrounded",
+    severity: "active-background",
+    isActive: true,
+    needsAttention: false,
+  },
+  pending: { label: "Pending", severity: "pending", isActive: true, needsAttention: false },
+  completed: { label: "Completed", severity: "terminal", isActive: false, needsAttention: false },
+};
+
+const KNOWN_WORKFLOW_STATUSES = new Set<WorkflowRunStatus>(
+  Object.keys(WORKFLOW_STATUS_PRESENTATION) as WorkflowRunStatus[]
+);
+
+const SEVERITY_RANK: Record<WorkflowStatusSeverity, number> = {
+  error: 6,
+  warning: 5,
+  active: 4,
+  "active-background": 3,
+  pending: 2,
+  terminal: 1,
+  unknown: 0,
+};
+
+export function getWorkflowStatusPresentation(status: string): WorkflowStatusPresentation {
+  if (KNOWN_WORKFLOW_STATUSES.has(status as WorkflowRunStatus)) {
+    return WORKFLOW_STATUS_PRESENTATION[status as WorkflowRunStatus];
+  }
+
+  // Persisted runs may have been written by a newer or older build. Keep the UI usable,
+  // while assertions/tests make newly-added statuses impossible to forget during development.
+  return {
+    label: status || "Unknown",
+    severity: "unknown",
+    isActive: false,
+    needsAttention: false,
+  };
+}
+
+export function summarizeWorkflowRuns(runs: readonly WorkflowRunRecord[]): WorkflowRunsSummary {
+  let activeCount = 0;
+  let problemCount = 0;
+  let highestSeverity: WorkflowStatusSeverity | null = null;
+
+  for (const run of runs) {
+    assert(run.id.length > 0, "Workflow run summaries require persisted run ids");
+    const presentation = getWorkflowStatusPresentation(run.status);
+    if (presentation.isActive) activeCount++;
+    if (presentation.needsAttention) problemCount++;
+    if (
+      highestSeverity == null ||
+      SEVERITY_RANK[presentation.severity] > SEVERITY_RANK[highestSeverity]
+    ) {
+      highestSeverity = presentation.severity;
+    }
+  }
+
+  return { activeCount, problemCount, highestSeverity };
+}
+
+export function compareWorkflowRunsForAttention(
+  a: WorkflowRunRecord,
+  b: WorkflowRunRecord
+): number {
+  const aSeverity = getWorkflowStatusPresentation(a.status).severity;
+  const bSeverity = getWorkflowStatusPresentation(b.status).severity;
+  const severityDelta = SEVERITY_RANK[bSeverity] - SEVERITY_RANK[aSeverity];
+  if (severityDelta !== 0) return severityDelta;
+  return Date.parse(b.updatedAt) - Date.parse(a.updatedAt);
+}
+
+export function getLatestWorkflowRunSummary(run: WorkflowRunRecord): string {
+  for (let index = run.events.length - 1; index >= 0; index--) {
+    const event = run.events[index];
+    const summary = summarizeEvent(event);
+    if (summary != null) return summary;
+  }
+  return getWorkflowStatusPresentation(run.status).label;
+}
+
+function summarizeEvent(event: WorkflowRunEvent): string | null {
+  switch (event.type) {
+    case "status":
+    case "result":
+      return null;
+    case "phase":
+      return event.name;
+    case "log":
+    case "error":
+      return event.message;
+    case "task":
+      return `Task ${event.status}`;
+    case "patch":
+      return `Patch ${event.status}`;
+    case "action":
+      return `${event.name} ${event.status}`;
+    case "validation":
+      return event.message ?? (event.success ? "Validation passed" : "Validation failed");
+    default: {
+      const exhaustive: never = event;
+      return exhaustive;
+    }
+  }
+}
+
+export function groupWorkflowDefinitionsByScope(
+  definitions: readonly WorkflowDefinitionDescriptor[]
+): Record<WorkflowDefinitionScope, WorkflowDefinitionDescriptor[]> {
+  return {
+    project: definitions.filter((definition) => definition.scope === "project"),
+    global: definitions.filter((definition) => definition.scope === "global"),
+    "built-in": definitions.filter((definition) => definition.scope === "built-in"),
+    scratch: definitions.filter((definition) => definition.scope === "scratch"),
+  };
+}

--- a/src/browser/utils/chatCommands.ts
+++ b/src/browser/utils/chatCommands.ts
@@ -64,6 +64,7 @@ import { getProviderModelEntryId } from "@/common/utils/providers/modelEntries";
 import { isCustomOpenAICompatibleProviderConfig } from "@/common/utils/providers/customProviders";
 import { isValidProvider } from "@/common/constants/providers";
 import { openInEditor } from "@/browser/utils/openInEditor";
+import { getWorkflowStoreInstance } from "@/browser/features/Workflows/WorkflowStore";
 import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 
 // ============================================================================
@@ -453,6 +454,7 @@ export async function processSlashCommand(
         continuationOptions: context.sendMessageOptions,
         rawCommand,
       });
+      getWorkflowStoreInstance().invalidateWorkspace(workspaceId);
       // The workflow is durable and backgrounded; do not pin the composer while polling for
       // completion, otherwise the user cannot supersede a long-running slash workflow.
       setWorkflowSendingState(false);

--- a/src/browser/utils/commands/sources.test.ts
+++ b/src/browser/utils/commands/sources.test.ts
@@ -259,9 +259,16 @@ test("buildCoreSources includes create/switch workspace actions", () => {
 });
 
 test("right sidebar add-tool options respect enabled feature flags", async () => {
-  const withoutWorkflows = getActions();
-  const withWorkflows = getActions({
+  const withoutEnabledFlags = getActions();
+  const withWorkflowFlag = getActions({
     enabledRightSidebarFeatureFlags: new Set([EXPERIMENT_IDS.DYNAMIC_WORKFLOWS]),
+  });
+  const withAllFlaggedSidebarTabs = getActions({
+    enabledRightSidebarFeatureFlags: new Set([
+      EXPERIMENT_IDS.AGENT_BROWSER,
+      EXPERIMENT_IDS.DYNAMIC_WORKFLOWS,
+      EXPERIMENT_IDS.PORTABLE_DESKTOP,
+    ]),
   });
 
   const getToolOptionLabels = async (actions: ReturnType<typeof getActions>) => {
@@ -274,8 +281,12 @@ test("right sidebar add-tool options respect enabled feature flags", async () =>
     return options.map((option) => option.label);
   };
 
-  expect(await getToolOptionLabels(withoutWorkflows)).not.toContain("Workflows");
-  expect(await getToolOptionLabels(withWorkflows)).toContain("Workflows");
+  expect(await getToolOptionLabels(withoutEnabledFlags)).not.toContain("Workflows");
+  expect(await getToolOptionLabels(withWorkflowFlag)).toContain("Workflows");
+  const allFlaggedSidebarLabels = await getToolOptionLabels(withAllFlaggedSidebarTabs);
+  expect(allFlaggedSidebarLabels).toContain("Browser");
+  expect(allFlaggedSidebarLabels).toContain("Desktop");
+  expect(allFlaggedSidebarLabels).toContain("Workflows");
 });
 
 test("appearance commands offer auto when a manual theme is selected", () => {

--- a/src/browser/utils/commands/sources.test.ts
+++ b/src/browser/utils/commands/sources.test.ts
@@ -5,6 +5,7 @@ import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
 import { GlobalWindow } from "happy-dom";
 import { getModelKey } from "@/common/constants/storage";
+import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { CUSTOM_EVENTS } from "@/common/constants/events";
 import type { WorkspaceState } from "@/browser/stores/WorkspaceStore";
 import type { APIClient } from "@/browser/contexts/API";
@@ -255,6 +256,26 @@ test("buildCoreSources includes create/switch workspace actions", () => {
   expect(titles.includes("Right Sidebar: Focus Terminal")).toBe(true);
   expect(titles.includes("New Terminal Window")).toBe(true);
   expect(titles.includes("Open Terminal Window for Workspace…")).toBe(true);
+});
+
+test("right sidebar add-tool options respect enabled feature flags", async () => {
+  const withoutWorkflows = getActions();
+  const withWorkflows = getActions({
+    enabledRightSidebarFeatureFlags: new Set([EXPERIMENT_IDS.DYNAMIC_WORKFLOWS]),
+  });
+
+  const getToolOptionLabels = async (actions: ReturnType<typeof getActions>) => {
+    const addToolAction = actions.find((action) => action.title === "Right Sidebar: Add Tool…");
+    const toolField = addToolAction?.prompt?.fields.find((field) => field.name === "tool");
+    if (toolField?.type !== "select") {
+      throw new Error("Expected add-tool select field");
+    }
+    const options = await toolField.getOptions({});
+    return options.map((option) => option.label);
+  };
+
+  expect(await getToolOptionLabels(withoutWorkflows)).not.toContain("Workflows");
+  expect(await getToolOptionLabels(withWorkflows)).toContain("Workflows");
 });
 
 test("appearance commands offer auto when a manual theme is selected", () => {

--- a/src/browser/utils/commands/sources.ts
+++ b/src/browser/utils/commands/sources.ts
@@ -86,6 +86,7 @@ export interface BuildSourcesParams {
   getMinThinkingOverride?: (modelString: string) => ThinkingLevel | null | undefined;
 
   onStartWorkspaceCreation: (projectPath: string) => void;
+  enabledRightSidebarFeatureFlags?: ReadonlySet<string>;
   onStartMultiProjectWorkspaceCreation: () => void;
   multiProjectWorkspacesEnabled: boolean;
   onArchiveMergedWorkspacesInProject: (projectPath: string) => Promise<void>;
@@ -323,6 +324,11 @@ function openGoalPanel(workspaceId: string, openCompleteInput = false): void {
 }
 export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandAction[]> {
   const actions: Array<() => CommandAction[]> = [];
+
+  const isRightSidebarBaseTabEnabled = (tabId: BaseTabType): boolean => {
+    const featureFlag = getTabConfig(tabId).featureFlag;
+    return featureFlag == null || p.enabledRightSidebarFeatureFlags?.has(featureFlag) === true;
+  };
 
   // NOTE: We intentionally route to the chat-based creation flow instead of
   // building a separate prompt. This keeps `/new`, keybinds, and the command
@@ -637,7 +643,7 @@ export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandActi
         ...getOrderedBaseTabIds()
           .filter((tabId) => {
             const config = getTabConfig(tabId);
-            return config.inDefaultLayout !== true && config.featureFlag == null;
+            return config.inDefaultLayout !== true && isRightSidebarBaseTabEnabled(tabId);
           })
           .map((tabId) => buildToggleTabCommand(wsId, tabId, section.navigation)),
         {
@@ -697,7 +703,7 @@ export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandActi
                 // Terminal is appended manually because it lives outside the static registry.
                 getOptions: () => [
                   ...getOrderedBaseTabIds()
-                    .filter((tabId) => getTabConfig(tabId).featureFlag == null)
+                    .filter((tabId) => isRightSidebarBaseTabEnabled(tabId))
                     .map((tabId) => {
                       const config = getTabConfig(tabId);
                       return {

--- a/src/common/constants/events.ts
+++ b/src/common/constants/events.ts
@@ -124,6 +124,12 @@ export const CUSTOM_EVENTS = {
   OPEN_GOAL_TAB: "mux:openGoalTab",
 
   /**
+   * Event to open the right-sidebar Workflows tab.
+   * Detail: { workspaceId: string }
+   */
+  OPEN_WORKFLOWS_TAB: "mux:openWorkflowsTab",
+
+  /**
    * Event to show a toast when a child task pushes the parent's goal over budget.
    * Detail: { workspaceId: string, message: string }
    */
@@ -196,6 +202,9 @@ export interface CustomEventPayloads {
   [CUSTOM_EVENTS.OPEN_GOAL_TAB]: {
     workspaceId: string;
     openCompleteInput?: boolean;
+  };
+  [CUSTOM_EVENTS.OPEN_WORKFLOWS_TAB]: {
+    workspaceId: string;
   };
   [CUSTOM_EVENTS.GOAL_CHILD_BUDGET_TOAST]: {
     workspaceId: string;

--- a/src/node/services/workflows/WorkflowDefinitionStore.test.ts
+++ b/src/node/services/workflows/WorkflowDefinitionStore.test.ts
@@ -107,6 +107,31 @@ describe("WorkflowDefinitionStore", () => {
     );
   });
 
+  test("project definitions win over scratch drafts with the same name", async () => {
+    using tmp = new DisposableTempDir("workflow-definitions-project-over-scratch");
+    const projectRoot = path.join(tmp.path, "project", ".mux", "workflows");
+    const scratchRoot = path.join(projectRoot, ".scratch");
+    const globalRoot = path.join(tmp.path, "mux-home", "workflows");
+    await writeWorkflow(projectRoot, "demo", "Project demo");
+    await writeWorkflow(scratchRoot, "demo", "Scratch demo");
+
+    const store = new WorkflowDefinitionStore({
+      projectRoot,
+      scratchRoot,
+      globalRoot,
+      builtIns: [],
+    });
+
+    const definitions = await store.listDefinitions({ projectTrusted: true });
+    const definition = await store.readDefinition("demo", { projectTrusted: true });
+
+    expect(definitions.map((candidate) => [candidate.name, candidate.scope])).toEqual([
+      ["demo", "project"],
+    ]);
+    expect(definition.descriptor.scope).toBe("project");
+    expect(definition.source).toContain("Project demo");
+  });
+
   test("omits project-local workflows when the project is not trusted", async () => {
     using tmp = new DisposableTempDir("workflow-definitions");
     const projectRoot = path.join(tmp.path, "project", ".mux", "workflows");

--- a/src/node/services/workflows/WorkflowDefinitionStore.ts
+++ b/src/node/services/workflows/WorkflowDefinitionStore.ts
@@ -908,11 +908,30 @@ export class WorkflowDefinitionStore {
     const byName = new Map<WorkflowName, ScannedWorkflowDefinition>();
     const sources: ScannedWorkflowDefinition[][] = [];
 
+    if (options.projectTrusted) {
+      if (this.projectRuntime != null) {
+        assert(
+          this.projectCwd != null,
+          "WorkflowDefinitionStore.collectDefinitions: projectCwd missing"
+        );
+        sources.push(
+          await scanRuntimeDirectory(
+            this.projectRuntime,
+            this.projectRoot,
+            this.projectCwd,
+            "project"
+          )
+        );
+      } else {
+        sources.push(await scanDirectory(this.projectRoot, "project"));
+      }
+    }
     if (this.scratchRoot != null && options.projectTrusted) {
       // Scratch workflows live under the workspace checkout, so treat them like project-local
       // code for trust gating rather than exposing repo-controlled files from untrusted projects.
       // Keep plain workflow discovery read-only: only create/touch scratch ignore files once
-      // there is an actual scratch workflow candidate for Git to hide.
+      // there is an actual scratch workflow candidate for Git to hide. Project definitions still
+      // take precedence so promoting a scratch draft to a reusable workflow is visible immediately.
       if (this.projectRuntime != null) {
         assert(
           this.projectCwd != null,
@@ -959,24 +978,6 @@ export class WorkflowDefinitionStore {
           await deleteLocalGeneratedScratchGitignore(this.scratchRoot);
         }
         sources.push(scratchDefinitions);
-      }
-    }
-    if (options.projectTrusted) {
-      if (this.projectRuntime != null) {
-        assert(
-          this.projectCwd != null,
-          "WorkflowDefinitionStore.collectDefinitions: projectCwd missing"
-        );
-        sources.push(
-          await scanRuntimeDirectory(
-            this.projectRuntime,
-            this.projectRoot,
-            this.projectCwd,
-            "project"
-          )
-        );
-      } else {
-        sources.push(await scanDirectory(this.projectRoot, "project"));
       }
     }
     sources.push(await scanDirectory(this.globalRoot, "global"));

--- a/src/node/services/workflows/WorkflowRunStore.test.ts
+++ b/src/node/services/workflows/WorkflowRunStore.test.ts
@@ -387,6 +387,16 @@ describe("WorkflowRunStore", () => {
     });
   });
 
+  test("creates the run directory before acquiring a lease lock", async () => {
+    using tmp = new DisposableTempDir("workflow-runs");
+    const store = new WorkflowRunStore({ sessionDir: tmp.path });
+
+    await expect(store.acquireLease("wfr_missing", "runner-a", 1000)).resolves.toBe(true);
+    await expect(
+      fs.readFile(path.join(tmp.path, "workflows", "wfr_missing", "lease.json"), "utf-8")
+    ).resolves.toContain("runner-a");
+  });
+
   test("renews active leases so they are not reclaimed as stale", async () => {
     using tmp = new DisposableTempDir("workflow-runs");
     const store = await createStore(tmp.path);

--- a/src/node/services/workflows/WorkflowRunStore.ts
+++ b/src/node/services/workflows/WorkflowRunStore.ts
@@ -485,6 +485,9 @@ export class WorkflowRunStore {
     assert(ownerId.length > 0, "WorkflowRunStore.acquireLease: ownerId is required");
     const leaseFile = this.leaseFile(runId);
     const lockDir = `${leaseFile}.lock`;
+    // The lock itself must remain a non-recursive mkdir for atomicity, but its parent can be
+    // absent during resume/crash-recovery races in tests or after partial run directory repair.
+    await fs.mkdir(path.dirname(lockDir), { recursive: true });
     if (!(await acquireLeaseMutationLock(lockDir, Date.now(), this.leaseMutationLockStaleMs()))) {
       return false;
     }


### PR DESCRIPTION
## Summary

Adds workflow visibility surfaces for Dynamic Workflows: a shared browser workflow store, a right-sidebar Workflows tab, top-bar workflow indicator, and chat-card store integration. Also hardens the implementation against the deep-review findings by gating the UI behind the Dynamic Workflows experiment, preserving state on transient API failures, restarting polling after resubscribe, discovering externally-created runs, and limiting retry/run actions to supported flows.

## Implementation

- Added a shared workflow store with active-run polling, low-frequency workspace refresh polling, queued invalidations, error-preserving snapshot refreshes, and stable external-store subscriptions.
- Added/registered Workflows sidebar and top-bar indicator surfaces behind the Dynamic Workflows feature flag.
- Defaulted sidebar starts to background runs so Current runs can show progress immediately, with duplicate-start protection while requests are pending.
- Reused checkpoint retry eligibility in the sidebar and invalidated the shared store from slash commands and workflow card actions.
- Fixed scratch/project definition precedence in the workflow definition scanner.

## Validation

- `bun test src/browser/utils/commands/sources.test.ts src/browser/features/Workflows/WorkflowStore.test.ts src/browser/features/Workflows/WorkflowsTab.test.tsx src/browser/features/Workflows/workflowStatusPresentation.test.ts src/browser/components/WorkflowIndicator/WorkflowIndicator.test.tsx`
- `make typecheck`
- `make static-check`
- Dogfooding artifacts from the feature implementation are in `dogfood-output/workflows-ui/` with screenshots/videos for empty state, definition discovery, live foreground/background runs, failure surfacing, scratch promotion, and narrow layout checks.

## Risks

Workflow visibility is experiment-gated and uses polling rather than a backend subscription. The main regression risk is extra local API traffic while the Workflows tab/indicator/card is mounted; the shared store deduplicates run polling and tears down timers when subscribers leave.

---

<details>
<summary>📋 Implementation Plan</summary>

# Workflow Visibility UX Plan

## Goal

Improve workflow visibility in Mux so users can discover available workflows, understand where they come from, and monitor live workflow execution outside the chat transcript. The design should preserve chat as the canonical chronological record while adding a dashboard-style right-sidebar tab and a glanceable top-bar indicator.

## Evidence and constraints

- Right-sidebar tabs use a two-layer architecture: static metadata in `src/browser/features/RightSidebar/Tabs/tabConfig.ts`, React labels/panels in `src/browser/features/RightSidebar/Tabs/tabRegistry.tsx`. Keep React imports out of `tabConfig.ts`.
- GoalTab is the closest UX precedent: current/active content appears first, with secondary items organized into collapsible board sections below. Workflows need a multi-active variant because multiple runs can be pending/running/backgrounded at once.
- Workflow definitions have four scopes: `project`, `global`, `built-in`, and `scratch`.
- Workflow run statuses are `pending`, `running`, `backgrounded`, `interrupted`, `completed`, and `failed`.
- Current workflow cards refresh live state with local polling in `WorkflowRunToolCall.tsx`; there is no verified workflow-specific browser store or oRPC subscription today.
- `featureFlag` and `keepAlive` in tab config are metadata only for this task unless explicit runtime behavior is added and verified.
- Existing scratch promotion support is limited to APIs already present (`promoteScratch`, `promoteScratchDefinition`); do not imply broader definition management like rename/delete/edit unless separately verified.

## Recommendation

Build the feature as a three-surface system:

1. **Chat workflow cards** remain the canonical execution transcript and detailed event/log surface.
2. **New Workflows right-sidebar tab** becomes the discovery, summary, and control surface.
3. **New top-bar Workflows indicator** becomes the glanceable status entry point near the existing Skills indicator.

Recommended implementation approach: **Full phased system with shared store, sidebar tab, then top-bar indicator**.

- Net product LoC estimate: **1,200–1,800** lines.
- Test/story LoC estimate, not counted as product code: **500–900** lines.
- Why this approach: it directly solves workflow invisibility, avoids duplicated polling across chat/sidebar/top-bar, and preserves chat context.

Alternative implementation approaches:

| Approach | Product LoC estimate | Pros | Cons | Recommendation |
|---|---:|---|---|---|
| Sidebar-only MVP | 650–1,000 | Fastest user-visible improvement; definitions/runs become discoverable. | Top-bar still lacks glanceable workflow status; likely repeats polling unless store still built. | Acceptable first slice only if timeboxed. |
| Full phased system with shared store | 1,200–1,800 | Best UX and performance path; supports chat/sidebar/top-bar consistently. | More moving parts; requires careful store tests. | **Recommended.** |
| Backend subscription-first system | 1,600–2,400 | Best long-term live-state model; avoids polling. | Larger backend/API scope; unnecessary to prove the UX. | Defer until polling store reveals real pain. |

## Information architecture

### Workflows sidebar tab

```text
Workflows
├─ Header summary
│  ├─ active run count
│  ├─ highest-severity badge
│  └─ Run workflow action
├─ Current runs
│  ├─ pending / running / backgrounded
│  └─ interrupted / failed needing attention
├─ Available definitions
│  ├─ Project
│  ├─ Global
│  ├─ Built-in
│  └─ Scratch
└─ History
   ├─ Failed / interrupted recent runs
   └─ Completed recent runs
```

Sidebar cards should show name, scope/source, status, elapsed time, latest meaningful event/phase, and the next supported action. Keep detailed logs behind an explicit disclosure, dialog, or “View in chat” jump.

### Top-bar Workflows indicator

Add a sibling indicator near `SkillIndicator`, not inside it. Skills are capabilities; workflows are capabilities plus live processes, so urgent workflow state should not be hidden in the skills popover.

Indicator behavior:

- No active/problem runs: quiet icon or hidden-at-narrow-width state.
- Active runs: badge with count.
- Failed/interrupted runs: warning/error badge takes precedence.
- Popover sections: Active runs, recent failures/interrupted runs, available definitions by scope, and “Open Workflows tab”.

### Shared status severity

| Status | Severity | UI treatment |
|---|---|---|
| `failed` | error | Highest priority; red/error badge. |
| `interrupted` | warning | Needs attention; amber/warning badge. |
| `running` | active | Success/active cue. |
| `backgrounded` | active-background | Active-neutral or amber with background badge. |
| `pending` | pending | Neutral/subtle active cue. |
| `completed` | terminal | Muted in history; do not dominate active indicator. |

Use a shared workflow-specific helper rather than exporting `WorkflowRunToolCall.tsx`’s local `toToolStatus()` directly.

## Phased implementation plan

### Phase 0 — Verify event shape and define shared presentation

Files/subsystems to inspect or update:

- `src/common/orpc/schemas/workflow.ts`
- `src/browser/features/Tools/WorkflowRunToolCall.tsx`
- new shared helper near workflow UI code, e.g. `src/browser/features/Workflows/workflowStatusPresentation.ts`

Tasks:

1. Confirm exact event fields needed for “latest meaningful event” summaries.
2. Add workflow status/severity presentation helpers.
3. Add debug assertions for impossible/unknown statuses in helper tests while keeping runtime fallback safe for persisted older data.

Acceptance criteria:

- All six known workflow statuses map exhaustively to severity and display labels.
- Unknown persisted status values do not crash the UI, but tests/assertions catch missing known statuses during development.
- Existing workflow chat cards keep their current behavior.

Quality gate:

- Run targeted unit tests for the presentation helper.
- Run `make typecheck` or a narrower typecheck target if available.

### Phase 1 — Add a shared browser workflow store

Likely files/subsystems:

- new `src/browser/stores/WorkflowStore.ts` or equivalent colocated workflow store
- hooks such as `useWorkflowSummary(workspaceId)`, `useWorkflowRuns(workspaceId)`, `useWorkflowRun(workspaceId, runId)`
- existing oRPC calls: `workflows.listRuns`, `workflows.getRun`, `workflows.listDefinitions`

Tasks:

1. Implement workspace-level run/definition snapshot loading.
2. Implement run-detail polling for active statuses using existing 2s cadence.
3. Deduplicate polling by `workspaceId` and `runId`.
4. Poll only while subscribers exist.
5. Expose narrow selectors for tab label/top-bar usage: active count, problem count, highest severity, grouped definitions.
6. Add defensive assertions around required IDs and store key construction.

Acceptance criteria:

- New sidebar/top-bar consumers share one store-backed polling loop per active run; full chat/sidebar/top-bar dedupe is not claimed until Phase 4 integrates chat cards with the store.
- Store subscriptions are scoped: summary consumers do not receive every event-log detail update unless the summary changes.
- Definitions are grouped by all four scopes.
- Store teardown clears timers/subscriptions when no consumers remain.

Quality gate:

- Unit tests for deduped polling, teardown, severity aggregation, and scope grouping.
- Instrument or test a fake client to ensure duplicate subscribers do not duplicate `getRun` polling.

### Phase 2 — Build Workflows sidebar tab MVP

Likely files/subsystems:

- `src/browser/features/RightSidebar/Tabs/tabConfig.ts`
- `src/browser/features/RightSidebar/Tabs/tabRegistry.tsx`
- new `src/browser/features/RightSidebar/WorkflowsTab.tsx` or `src/browser/features/Workflows/WorkflowsTab.tsx`
- optional `WorkflowsTabLabel` in `TabLabels.tsx` or a colocated label imported by the registry

Tasks:

1. Add a `workflows` static tab metadata entry without React imports in `tabConfig.ts`.
2. Register label and panel renderers in `tabRegistry.tsx`.
3. Render header summary, current runs, definitions grouped by scope, and recent history.
4. Keep completed history collapsed/truncated by default.
5. Provide supported actions only: run/start where existing UI/API supports it, interrupt/resume/retry where supported by run state, scratch promotion where existing APIs apply, and “View in chat” where a chat anchor can be resolved.
6. Add empty states for no definitions, no active runs, and no history.

Acceptance criteria:

- User can see available workflows and their sources/scopes in the right sidebar.
- Active/backgrounded/interrupted/failed runs are visible above definitions/history.
- Sidebar never becomes a full log dump by default.
- The tab works when API context is unavailable in isolated stories/tests by rendering a non-crashing empty or unavailable state.
- Keyboard access exists for open tab, run workflow, and primary run actions; shortcuts should not be shown on mobile views.

Quality gate:

- Component tests for grouping, empty states, severity ordering, and current-run sorting.
- Storybook stories or UI fixtures for empty, many definitions, active run, failed run, backgrounded run, and narrow width.

### Phase 3 — Add top-bar Workflows indicator

Likely files/subsystems:

- `src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx`
- new `src/browser/components/WorkflowIndicator/WorkflowIndicator.tsx` or colocated component
- shared workflow store hooks from Phase 1

Tasks:

1. Add a compact indicator near `SkillIndicator`, respecting menu-bar density and platform window-control spacing.
2. Use summary selector only; do not pass full workflow arrays through `WorkspaceMenuBar`.
3. Popover includes active runs, recent failures/interrupted runs, grouped definitions, and “Open Workflows tab”.
4. Add responsive behavior for narrow widths.

Acceptance criteria:

- User can tell from the top bar when workflows are active or need attention.
- Popover exposes workflow definitions and sources without crowding the main bar.
- Indicator does not overlap or make existing controls unclickable on narrow layouts or Windows/Linux titlebar-control layouts.
- Clicking “Open Workflows tab” focuses the sidebar tab.

Quality gate:

- Component tests for badge priority, active counts, quiet state, and popover grouping.
- Visual stories/Chromatic snapshots for normal and narrow menu bars.

### Phase 4 — Integrate chat cards with the shared store where safe

Likely files/subsystems:

- `src/browser/features/Tools/WorkflowRunToolCall.tsx`
- workflow store from Phase 1

Tasks:

1. Replace or wrap component-local polling with store-backed run detail subscriptions.
2. Preserve existing chat-card behavior: auto-collapse completed runs, promotion controls, task/event expansion, and dialogs.
3. Keep chat cards as the canonical detailed execution surface.

Acceptance criteria:

- No user-visible regression in workflow chat cards.
- Existing workflow card tests still pass.
- When chat integration is complete, one run visible in chat, sidebar, and top bar shares the store-backed polling path instead of each surface owning independent polling.

Quality gate:

- Existing `WorkflowRunToolCall` tests pass.
- Targeted regression test proves one shared polling path when chat and sidebar both observe the same run.

## Dogfooding and self-verification plan

Use the project `dev-server-sandbox` flow so dogfooding does not interfere with the user’s normal Mux data.

Setup:

```bash
make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-projects"
```

Then use the assigned Vite URL from the sandbox output, normally `http://localhost:<VITE_PORT>`, and drive the UI with the direct `agent-browser` binary, not `npx`.

Before running browser automation, load the installed `agent-browser` command guidance and the dogfood workflow guidance so commands match the local version:

```bash
agent-browser skills get core
agent-browser skills get dogfood
```

Prepare a dogfood report from the dogfood template and read the issue taxonomy/checklist before exploring. If using the Mux skill files, copy `templates/dogfood-report-template.md` into the output directory and read `references/issue-taxonomy.md`.

Dogfood artifacts directory:

```bash
mkdir -p dogfood-output/workflows-ui/screenshots dogfood-output/workflows-ui/videos
```

Required dogfood scenarios:

1. **Empty state**
   - Open Mux in the sandbox.
   - Open the Workflows tab.
   - Capture annotated screenshot of no active workflows / available definitions state.
2. **Definition discovery**
   - Seed or open a workspace with project/global/built-in/scratch workflow definitions.
   - Capture screenshot showing grouped definitions and source/scope labels.
3. **Foreground active run**
   - Start a workflow.
   - Record video showing the workflow appearing in chat, the sidebar Current Runs section, and the top-bar indicator.
   - Capture screenshots at start, mid-run, and completion.
4. **Backgrounded run**
   - Start or background a workflow if supported by the existing workflow UX.
   - Capture top-bar/sidebar state and verify severity/count presentation.
5. **Interrupted/failed run**
   - Reproduce an interrupted or failed workflow using a safe test workflow.
   - Record video showing warning/error surfacing in the indicator and sidebar.
6. **Scratch promotion**
   - Run or create a scratch workflow.
   - Capture the promotion affordance and result after promoting to project/global.
7. **Narrow layout**
   - Resize to a narrow width and capture screenshot/video that menu-bar controls remain clickable and the indicator degrades gracefully.
8. **Dogfood report package**
   - Update the report summary counts.
   - Attach screenshots/videos for each verified dogfood claim.
   - Close the browser session after the report is complete.

For interactive issues discovered during dogfooding, follow the dogfood skill evidence standard: reproduce once, then record a watchable repro video with step-by-step screenshots before filing the issue. Static visual issues need at least one annotated screenshot. Final implementation handoff should attach the screenshots and videos so reviewers can validate the claims.

## Validation plan

Run validation in this order while implementing:

1. Targeted unit/component tests for new helpers/store/components.
2. Store polling instrumentation or fake-client tests proving duplicate subscribers do not duplicate `listRuns`/`getRun` polling for the same key.
3. `make typecheck`.
4. `make lint` or `make static-check` if the touched area warrants full validation.
5. Storybook/visual validation for sidebar/menu-bar states if stories are added.
6. Black-box dogfood scenarios above with screenshots and videos.

## Risks and mitigations

| Risk | Mitigation |
|---|---|
| Sidebar becomes too dense and duplicates chat logs. | Summary-first cards; detailed logs behind disclosure/dialog/chat jump. |
| Multiple surfaces duplicate polling. | Build shared store before top-bar/sidebar live rendering; test dedupe. |
| Tab config runtime assumptions are wrong. | Only add static metadata there; wire actual React UI in registry; do not rely on existing `keepAlive`/`featureFlag` behavior. |
| Top-bar gets crowded. | Quiet default state, compact badge, responsive hiding/overflow behavior, narrow-layout dogfood. |
| Unsupported workflow management slips in. | Limit actions to verified APIs; follow-up issue for rename/delete/edit if desired. |
| Unknown persisted workflow data crashes UI. | Exhaustive known-status tests plus safe runtime fallback for unrecognized persisted values. |

## Advisor review status

Advisor review fully approved the final plan. Required clarifications from the first review were applied and re-reviewed: Phase 1/Phase 4 dedupe scope, dogfood setup, black-box dogfood separation from implementation validation, and approval status. The second advisor review reported no remaining blockers or required changes.

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `1223199{MUX_COSTS_USD:-0}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=272.92 -->
