### PR TITLE
🤖 fix: harden remote base repo normalization

### DIFF
--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -3371,9 +3371,16 @@ export class SSHRuntime extends RemoteRuntime {
         // Skip protected trunk branch names to avoid accidental deletion.
         const PROTECTED_BRANCHES = ["main", "master", "trunk", "develop", "default"];
         if (branchToDelete && !PROTECTED_BRANCHES.includes(branchToDelete)) {
+          const branchRefArg = shescape.quote(`refs/heads/${branchToDelete}`);
           await execBuffered(
             this,
-            `${nhp}git --git-dir=${baseRepoPathArg} update-ref -d ${shescape.quote(`refs/heads/${branchToDelete}`)} 2>/dev/null || true`,
+            [
+              `branch_ref=${branchRefArg}`,
+              `branch_oid=$(git --git-dir=${baseRepoPathArg} rev-parse --verify --quiet "$branch_ref" 2>/dev/null || true)`,
+              '[ -n "$branch_oid" ] || exit 0',
+              `if git -C ${baseRepoPathArg} worktree list --porcelain | grep -Fqx "branch $branch_ref"; then exit 0; fi`,
+              `${nhp}git --git-dir=${baseRepoPathArg} update-ref -d "$branch_ref" "$branch_oid" 2>/dev/null || true`,
+            ].join("\n"),
             { cwd: "/tmp", timeout: 10 }
           ).catch(() => undefined);
         }

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -3373,7 +3373,7 @@ export class SSHRuntime extends RemoteRuntime {
         if (branchToDelete && !PROTECTED_BRANCHES.includes(branchToDelete)) {
           await execBuffered(
             this,
-            `${nhp}git -C ${baseRepoPathArg} branch -D ${shescape.quote(branchToDelete)} 2>/dev/null || true`,
+            `${nhp}git --git-dir=${baseRepoPathArg} update-ref -d ${shescape.quote(`refs/heads/${branchToDelete}`)} 2>/dev/null || true`,
             { cwd: "/tmp", timeout: 10 }
           ).catch(() => undefined);
         }

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -58,6 +58,7 @@ import {
 import {
   buildRemoteProjectLayout,
   getRemoteWorkspacePath,
+  REMOTE_BASE_REPO_DIR,
   type RemoteProjectLayout,
 } from "./remoteProjectLayout";
 import { streamToString, shescape } from "./streamUtils";
@@ -3314,9 +3315,12 @@ export class SSHRuntime extends RemoteRuntime {
       if (isWorktree) {
         // Worktree: use `git worktree remove` against the actual common git dir for this
         // workspace so upgraded legacy SSH worktrees keep their original base repo metadata.
-        const baseRepoPathArg = expandTildeForSSH(
-          await this.resolveWorktreeBaseRepoPath(projectPath, deletedPath, abortSignal)
+        const baseRepoPath = await this.resolveWorktreeBaseRepoPath(
+          projectPath,
+          deletedPath,
+          abortSignal
         );
+        const baseRepoPathArg = expandTildeForSSH(baseRepoPath);
         const removeCmd = force
           ? `${nhp}git -C ${baseRepoPathArg} worktree remove --force ${this.quoteForRemote(deletedPath)}`
           : `${nhp}git -C ${baseRepoPathArg} worktree remove ${this.quoteForRemote(deletedPath)}`;
@@ -3356,10 +3360,25 @@ export class SSHRuntime extends RemoteRuntime {
         // Skip protected trunk branch names to avoid accidental deletion.
         const PROTECTED_BRANCHES = ["main", "master", "trunk", "develop", "default"];
         if (branchToDelete && !PROTECTED_BRANCHES.includes(branchToDelete)) {
+          // HEAD neutralization migrates legacy *Mux-owned* base repos whose
+          // HEAD still points at a user branch (the Graphite-poisoning state)
+          // so `branch -D` keeps Git's native checked-out-branch guard instead
+          // of refusing because the bare repo "has the branch checked out".
+          // The resolved common git dir is workspace-derived, though: a
+          // hand-crafted or legacy worktree can resolve to a real checkout's
+          // `.git`, and rewriting that repo's HEAD would strand the user's
+          // checkout on the unborn internal branch. Managed base repos
+          // (canonical and legacy hashed layouts alike) are always named
+          // `.mux-base.git`, so scope the HEAD rewrite to them.
+          const isManagedBaseRepo = path.posix.basename(baseRepoPath) === REMOTE_BASE_REPO_DIR;
           await execBuffered(
             this,
             [
-              `git --git-dir=${baseRepoPathArg} symbolic-ref HEAD ${shescape.quote(BASE_REPO_UNBORN_HEAD_REF)} 2>/dev/null || true`,
+              ...(isManagedBaseRepo
+                ? [
+                    `git --git-dir=${baseRepoPathArg} symbolic-ref HEAD ${shescape.quote(BASE_REPO_UNBORN_HEAD_REF)} 2>/dev/null || true`,
+                  ]
+                : []),
               `${nhp}git -C ${baseRepoPathArg} branch -D ${shescape.quote(branchToDelete)} 2>/dev/null || true`,
             ].join("\n"),
             { cwd: "/tmp", timeout: 10 }

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -2637,11 +2637,17 @@ export class SSHRuntime extends RemoteRuntime {
     //      its latency is upstream→datacenter (typically fast, and the same
     //      cost the slow path pays separately).
     const warmBaseRepoNormalizationPreamble = [
-      ...BASE_REPO_SHARED_CONFIG_KEYS_TO_UNSET.map(
-        (key) =>
-          `git --git-dir=${baseRepoPathArg} config --local --unset-all ${shescape.quote(key)} 2>/dev/null || true`
+      ...BASE_REPO_SHARED_CONFIG_KEYS_TO_UNSET.map((key) =>
+        [
+          `git --git-dir=${baseRepoPathArg} config --local --unset-all ${shescape.quote(key)} 2>/dev/null`,
+          "cleanup_status=$?",
+          'if [ "$cleanup_status" -ne 0 ] && [ "$cleanup_status" -ne 5 ]; then echo WARM_MISS:base-config-normalization-failed; exit 0; fi',
+        ].join("\n")
       ),
-      `git --git-dir=${baseRepoPathArg} symbolic-ref HEAD ${baseRepoUnbornHeadArg} 2>/dev/null || true`,
+      // If the lightweight warm-path hygiene cannot run, fall back to the slow
+      // path where ensureBaseRepo() has retry/error handling instead of risking
+      // materializing a worktree from still-poisoned shared config.
+      `git --git-dir=${baseRepoPathArg} symbolic-ref HEAD ${baseRepoUnbornHeadArg} 2>/dev/null || { echo WARM_MISS:base-head-normalization-failed; exit 0; }`,
     ];
 
     const originPreamble = originUrlArg

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -66,11 +66,12 @@ import { streamToString, shescape } from "./streamUtils";
  *  refs/heads/* so they don't collide with branches checked out in worktrees. */
 const BUNDLE_REF_PREFIX = "refs/mux-bundle/";
 /**
- * The shared SSH base repo is a bare common git dir, not a checkout. Keeping
- * HEAD on trunk makes checkout-aware tools like Graphite think trunk is checked
- * out at `.mux-base.git`, so point it at an internal unborn ref instead.
+ * The shared SSH base repo is a bare common git dir, not a checkout. Keep its
+ * HEAD branch-shaped but unborn until a real base commit is available, then
+ * detach HEAD at that commit. In both states, `git worktree list --porcelain`
+ * does not report a user branch checked out at `.mux-base.git`.
  */
-const BASE_REPO_SENTINEL_HEAD_REF = "refs/mux-internal/base-head";
+const BASE_REPO_UNBORN_HEAD_REF = "refs/heads/__mux_internal_base_head";
 const BASE_REPO_SHARED_CONFIG_KEYS_TO_UNSET = ["core.bare", "core.worktree"] as const;
 type BaseRepoSharedConfigKey = (typeof BASE_REPO_SHARED_CONFIG_KEYS_TO_UNSET)[number];
 
@@ -200,22 +201,21 @@ async function enqueueProjectSync(
   }
 }
 
-function isOnlyExpectedBaseRepoSentinelHeadFsckError(detail: string): boolean {
-  const lines = detail
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean);
-
-  return (
-    lines.length > 0 &&
-    lines.every(
-      (line) => line.includes("badHeadTarget") && line.includes(BASE_REPO_SENTINEL_HEAD_REF)
-    )
-  );
-}
-
 function isGitConfigLockConflict(message: string): boolean {
   return /could not lock config file/i.test(message);
+}
+
+function buildBestEffortDetachBaseRepoHeadCommand(
+  baseRepoPathArg: string,
+  revisionShell: string
+): string {
+  return [
+    // Resolve only the ref value here, not `<rev>^{commit}`: missing-object
+    // repair still belongs to the following worktree checkout, which produces
+    // richer errors and already has a retry path.
+    `head_oid=$(git -C ${baseRepoPathArg} rev-parse --verify ${revisionShell} 2>/dev/null || true)`,
+    `if [ -n "$head_oid" ]; then git --git-dir=${baseRepoPathArg} update-ref --no-deref HEAD "$head_oid" 2>/dev/null || true; fi`,
+  ].join("\n");
 }
 
 function logSSHBackoffWait(initLogger: InitLogger, waitMs: number): void {
@@ -869,14 +869,6 @@ export class SSHRuntime extends RemoteRuntime {
     }
 
     const detail = [result.stderr, result.stdout].join("\n").trim() || `exit ${result.exitCode}`;
-    // Git versions that validate HEAD as a branch can report our intentional
-    // internal sentinel as badHeadTarget. The object-connectivity question here
-    // is scoped to explicit bundle refs, so that expected HEAD-only complaint
-    // should not trigger missing-object repair failure.
-    if (isOnlyExpectedBaseRepoSentinelHeadFsckError(detail)) {
-      return { healthy: true };
-    }
-
     return {
       healthy: false,
       detail,
@@ -903,13 +895,6 @@ export class SSHRuntime extends RemoteRuntime {
     }
 
     const detail = [result.stderr, result.stdout].join("\n").trim() || `exit ${result.exitCode}`;
-    // Same sentinel-HEAD exception as bundle connectivity: callers pass an
-    // explicit revision, so a HEAD-only fsck complaint is not evidence that the
-    // requested revision is missing objects.
-    if (isOnlyExpectedBaseRepoSentinelHeadFsckError(detail)) {
-      return { healthy: true };
-    }
-
     return {
       healthy: false,
       detail,
@@ -1240,7 +1225,7 @@ export class SSHRuntime extends RemoteRuntime {
     // Promisor keys are idempotently neutered as a best-effort epilogue (no
     // sentinel needed; failures fall through harmlessly because subsequent
     // pushes can re-run the cleanup if a deadlock recurs).
-    const baseRepoSentinelHeadArg = shescape.quote(BASE_REPO_SENTINEL_HEAD_REF);
+    const baseRepoUnbornHeadArg = shescape.quote(BASE_REPO_UNBORN_HEAD_REF);
     const configUnsetCmds = BASE_REPO_SHARED_CONFIG_KEYS_TO_UNSET.map((key) => {
       const statusName = key.replace(".", "_").toUpperCase();
       const errorPath = `/tmp/.mux-${key.replace(".", "-")}-$$.err`;
@@ -1283,12 +1268,14 @@ export class SSHRuntime extends RemoteRuntime {
       //    0 = removed, 5 = key absent. Anything else needs the retry/inspect
       //    dance, which the caller handles by re-running the slow-path helper.
       configUnsetCmds,
-      // 3. Keep the base repo's own HEAD off trunk so checkout-aware tooling
-      //    doesn't mistake `.mux-base.git` for the user's trunk worktree.
+      // 3. Keep the base repo's own HEAD off user branches so checkout-aware
+      //    tooling doesn't mistake `.mux-base.git` for a real worktree. This
+      //    symbolic ref is intentionally unborn; materialization detaches HEAD
+      //    at the chosen base commit once one is known.
       `current_head=$(git --git-dir=${baseRepoPathArg} symbolic-ref HEAD 2>/dev/null || true)`,
-      `if [ "$current_head" = ${baseRepoSentinelHeadArg} ]; then`,
+      `if [ "$current_head" = ${baseRepoUnbornHeadArg} ]; then`,
       "  echo STATUS_BASE_HEAD=already",
-      `elif git --git-dir=${baseRepoPathArg} symbolic-ref HEAD ${baseRepoSentinelHeadArg} 2>/tmp/.mux-base-head-$$.err; then`,
+      `elif git --git-dir=${baseRepoPathArg} symbolic-ref HEAD ${baseRepoUnbornHeadArg} 2>/tmp/.mux-base-head-$$.err; then`,
       "  echo STATUS_BASE_HEAD=set",
       "else",
       "  echo STATUS_BASE_HEAD=error",
@@ -1360,7 +1347,7 @@ export class SSHRuntime extends RemoteRuntime {
     }
 
     if (baseHeadStatus === "set") {
-      initLogger.logStep("Pointed shared base repository HEAD at internal sentinel");
+      initLogger.logStep("Neutralized shared base repository HEAD for worktrees");
     } else if (baseHeadStatus === "error") {
       throw new Error(
         `Failed to normalize base repo HEAD: ${result.stderr.trim() || result.stdout.trim()}`
@@ -2604,7 +2591,7 @@ export class SSHRuntime extends RemoteRuntime {
     }
     const snapshotDigest = crypto.createHash("sha256").update(headsOutput).digest("hex");
     const baseRepoPathArg = expandTildeForSSH(layout.baseRepoPath);
-    const baseRepoSentinelHeadArg = shescape.quote(BASE_REPO_SENTINEL_HEAD_REF);
+    const baseRepoUnbornHeadArg = shescape.quote(BASE_REPO_UNBORN_HEAD_REF);
     const currentSnapshotPathArg = expandTildeForSSH(layout.currentSnapshotPath);
     const workspacePathArg = expandTildeForSSH(workspacePath);
     const workspaceParentArg = expandTildeForSSH(
@@ -2654,7 +2641,7 @@ export class SSHRuntime extends RemoteRuntime {
         (key) =>
           `git --git-dir=${baseRepoPathArg} config --local --unset-all ${shescape.quote(key)} 2>/dev/null || true`
       ),
-      `git --git-dir=${baseRepoPathArg} symbolic-ref HEAD ${baseRepoSentinelHeadArg} 2>/dev/null || true`,
+      `git --git-dir=${baseRepoPathArg} symbolic-ref HEAD ${baseRepoUnbornHeadArg} 2>/dev/null || true`,
     ];
 
     const originPreamble = originUrlArg
@@ -2695,10 +2682,12 @@ export class SSHRuntime extends RemoteRuntime {
       // fall through to the repairing slow path instead of becoming an opaque
       // `worktree-add-failed` miss. The path was proven absent above, so removing
       // a partial checkout here cannot wipe a pre-existing workspace.
-      // Detached add keeps `.mux-base.git/HEAD` on the internal sentinel; the
-      // branch is attached inside the new worktree immediately afterward.
+      // Detach the base repo's own HEAD from user branches when the chosen ref
+      // has an object; if the cache is missing that object, worktree add below
+      // surfaces the existing repairable checkout error.
+      buildBestEffortDetachBaseRepoHeadCommand(baseRepoPathArg, '"$r"'),
       `mkdir -p ${workspaceParentArg}`,
-      `wt_output=$(${nhp}git -C ${baseRepoPathArg} worktree add --detach ${workspacePathArg} "$r" 2>&1 >/dev/null && ${nhp}git -C ${workspacePathArg} checkout -B ${branchArg} 2>&1 >/dev/null)`,
+      `wt_output=$(${nhp}git -C ${baseRepoPathArg} worktree add ${workspacePathArg} -B ${branchArg} "$r" 2>&1 >/dev/null)`,
       "wt_status=$?",
       'if [ "$wt_status" -ne 0 ]; then',
       '  case "$wt_output" in',
@@ -2853,28 +2842,18 @@ export class SSHRuntime extends RemoteRuntime {
         abortSignal
       );
 
-      // Keep the base repo's HEAD on the internal sentinel: add a detached
-      // worktree from the chosen start point, then attach/reset the workspace
-      // branch inside the new worktree. `checkout -B` creates the branch or
-      // resets it to the start point if it already exists (e.g. orphaned from a
-      // previously deleted workspace). Git still prevents checking out a branch
-      // that's active in another worktree.
+      // `ensureBaseRepo()` keeps the bare repo HEAD on an unborn internal
+      // branch so Git porcelain stays happy even when there is no commit yet.
+      // Once we know the start point, detach HEAD at that commit when possible
+      // and let `worktree add -B` own branch creation/reset. Git still prevents
+      // resetting a branch that's active in another worktree.
       initLogger.logStep(`Creating worktree for branch: ${branchName}`);
       const runWorktreeAdd = (baseRef: string) =>
         execBuffered(
           this,
           [
-            `${nhp}git -C ${baseRepoPathArg} worktree add --detach ${workspacePathArg} ${shescape.quote(baseRef)}`,
-            "worktree_add_status=$?",
-            'if [ "$worktree_add_status" -ne 0 ]; then exit "$worktree_add_status"; fi',
-            `${nhp}git -C ${workspacePathArg} checkout -B ${shescape.quote(branchName)}`,
-            "checkout_status=$?",
-            'if [ "$checkout_status" -ne 0 ]; then',
-            !workspacePathExistedBeforeCheckout
-              ? `  git -C ${baseRepoPathArg} worktree remove --force ${workspacePathArg} >/dev/null 2>&1 || rm -rf ${workspacePathArg}`
-              : "  true",
-            '  exit "$checkout_status"',
-            "fi",
+            buildBestEffortDetachBaseRepoHeadCommand(baseRepoPathArg, shescape.quote(baseRef)),
+            `${nhp}git -C ${baseRepoPathArg} worktree add ${workspacePathArg} -B ${shescape.quote(branchName)} ${shescape.quote(baseRef)}`,
           ].join("\n"),
           {
             cwd: "/tmp",
@@ -3371,15 +3350,11 @@ export class SSHRuntime extends RemoteRuntime {
         // Skip protected trunk branch names to avoid accidental deletion.
         const PROTECTED_BRANCHES = ["main", "master", "trunk", "develop", "default"];
         if (branchToDelete && !PROTECTED_BRANCHES.includes(branchToDelete)) {
-          const branchRefArg = shescape.quote(`refs/heads/${branchToDelete}`);
           await execBuffered(
             this,
             [
-              `branch_ref=${branchRefArg}`,
-              `branch_oid=$(git --git-dir=${baseRepoPathArg} rev-parse --verify --quiet "$branch_ref" 2>/dev/null || true)`,
-              '[ -n "$branch_oid" ] || exit 0',
-              `if git -C ${baseRepoPathArg} worktree list --porcelain | grep -Fqx "branch $branch_ref"; then exit 0; fi`,
-              `${nhp}git --git-dir=${baseRepoPathArg} update-ref -d "$branch_ref" "$branch_oid" 2>/dev/null || true`,
+              `git --git-dir=${baseRepoPathArg} symbolic-ref HEAD ${shescape.quote(BASE_REPO_UNBORN_HEAD_REF)} 2>/dev/null || true`,
+              `${nhp}git -C ${baseRepoPathArg} branch -D ${shescape.quote(branchToDelete)} 2>/dev/null || true`,
             ].join("\n"),
             { cwd: "/tmp", timeout: 10 }
           ).catch(() => undefined);
@@ -3543,23 +3518,15 @@ export class SSHRuntime extends RemoteRuntime {
 
       if (hasBaseRepo.exitCode === 0) {
         initLogger.logStep("Creating worktree for forked workspace...");
-        // Use checkout -b (not -B) after the detached add so we fail instead
-        // of silently resetting an existing branch that another worktree might
-        // reference. initWorkspace uses -B because it owns the branch lifecycle;
-        // fork is creating a new name.
         // Stage the worktree under `stagingPath`; `git worktree move` will
         // rename it (and update the bare repo's gitdir back-reference) into
-        // `newWorkspacePath` once everything else has succeeded.
+        // `newWorkspacePath` once everything else has succeeded. The base repo
+        // HEAD is neutralized first so `worktree add -b` keeps Git's normal
+        // active-branch and existing-branch guards.
         const worktreeCmd = [
-          `${nhp}git -C ${baseRepoPathArg} worktree add --detach ${stagingPathArg} ${shescape.quote(sourceBranch)}`,
-          "worktree_add_status=$?",
-          'if [ "$worktree_add_status" -ne 0 ]; then exit "$worktree_add_status"; fi',
-          `${nhp}git -C ${stagingPathArg} checkout -b ${shescape.quote(newWorkspaceName)}`,
-          "checkout_status=$?",
-          'if [ "$checkout_status" -ne 0 ]; then',
-          `  git -C ${baseRepoPathArg} worktree remove --force ${stagingPathArg} >/dev/null 2>&1 || rm -rf ${stagingPathArg}`,
-          '  exit "$checkout_status"',
-          "fi",
+          `git --git-dir=${baseRepoPathArg} symbolic-ref HEAD ${shescape.quote(BASE_REPO_UNBORN_HEAD_REF)} 2>/dev/null || true`,
+          buildBestEffortDetachBaseRepoHeadCommand(baseRepoPathArg, shescape.quote(sourceBranch)),
+          `${nhp}git -C ${baseRepoPathArg} worktree add -b ${shescape.quote(newWorkspaceName)} ${stagingPathArg} ${shescape.quote(sourceBranch)}`,
         ].join("\n");
         const worktreeResult = await execBuffered(this, worktreeCmd, {
           cwd: "/tmp",

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -65,6 +65,14 @@ import { streamToString, shescape } from "./streamUtils";
 /** Staging namespace for synced branch refs. Branches land here instead of
  *  refs/heads/* so they don't collide with branches checked out in worktrees. */
 const BUNDLE_REF_PREFIX = "refs/mux-bundle/";
+/**
+ * The shared SSH base repo is a bare common git dir, not a checkout. Keeping
+ * HEAD on trunk makes checkout-aware tools like Graphite think trunk is checked
+ * out at `.mux-base.git`, so point it at an internal unborn ref instead.
+ */
+const BASE_REPO_SENTINEL_HEAD_REF = "refs/mux-internal/base-head";
+const BASE_REPO_SHARED_CONFIG_KEYS_TO_UNSET = ["core.bare", "core.worktree"] as const;
+type BaseRepoSharedConfigKey = (typeof BASE_REPO_SHARED_CONFIG_KEYS_TO_UNSET)[number];
 
 /** Small backoff for concurrent writers healing the same shared base repo config. */
 const BASE_REPO_CONFIG_LOCK_RETRY_DELAYS_MS = [50, 100, 200];
@@ -1190,20 +1198,35 @@ export class SSHRuntime extends RemoteRuntime {
     const parentDirArg = expandTildeForSSH(path.posix.dirname(baseRepoPath));
 
     // STARTUP-PERF: This used to be 3-5 sequential SSH round-trips
-    // (test -d, mkdir, git init, unset core.bare, unset 3× promisor keys).
+    // (test -d, mkdir, git init, normalize base config, unset 3× promisor keys).
     // Each round-trip costs ~80-100ms even over a multiplexed control channel,
     // so on a cold SSH workspace this single batched command shaves ~500ms off
     // the critical path of `mux run --runtime ssh <host>`.
     //
-    // The script is split into two well-defined sections, each producing a
-    // status sentinel that the caller parses:
-    //
-    //   STATUS_CREATED=<existed|created>   — repo presence/creation outcome
-    //   STATUS_CORE_BARE=<unset|absent|locked|error>  — normalization result
+    // The script emits status sentinels that the caller parses for repo
+    // creation, shared config-key normalization, and base HEAD normalization.
     //
     // Promisor keys are idempotently neutered as a best-effort epilogue (no
     // sentinel needed; failures fall through harmlessly because subsequent
     // pushes can re-run the cleanup if a deadlock recurs).
+    const baseRepoSentinelHeadArg = shescape.quote(BASE_REPO_SENTINEL_HEAD_REF);
+    const configUnsetCmds = BASE_REPO_SHARED_CONFIG_KEYS_TO_UNSET.map((key) => {
+      const statusName = key.replace(".", "_").toUpperCase();
+      const errorPath = `/tmp/.mux-${key.replace(".", "-")}-$$.err`;
+      return [
+        `git --git-dir=${baseRepoPathArg} config --local --unset-all ${shescape.quote(key)} 2>${errorPath}`,
+        "rc=$?",
+        'if [ "$rc" -eq 0 ]; then',
+        `  echo STATUS_${statusName}=unset`,
+        'elif [ "$rc" -eq 5 ]; then',
+        `  echo STATUS_${statusName}=absent`,
+        "else",
+        `  echo STATUS_${statusName}=error`,
+        `  cat ${errorPath} >&2 2>/dev/null || true`,
+        "fi",
+        `rm -f ${errorPath} 2>/dev/null || true`,
+      ].join("\n");
+    }).join("\n");
     const promisorUnsetCmds = BASE_REPO_PROMISOR_CONFIG_KEYS.map(
       (key) => `git -C ${baseRepoPathArg} config --unset-all ${key} 2>/dev/null || true`
     ).join("\n");
@@ -1224,29 +1247,28 @@ export class SSHRuntime extends RemoteRuntime {
       "  fi",
       "  echo STATUS_CREATED=created",
       "fi",
-      // 2. Normalize core.bare in the *local* config — see
-      //    normalizeBaseRepoSharedConfig() for full context.
-      //    Exit codes: 0 = removed, 5 = key absent.  Anything else needs the
-      //    retry/inspect dance, which the caller handles by re-running the
-      //    slow-path helper.
-      `git -C ${baseRepoPathArg} config --local --unset-all core.bare 2>/tmp/.mux-corebare.err`,
-      "rc=$?",
-      'if [ "$rc" -eq 0 ]; then',
-      "  echo STATUS_CORE_BARE=unset",
-      'elif [ "$rc" -eq 5 ]; then',
-      "  echo STATUS_CORE_BARE=absent",
+      // 2. Normalize shared config keys in the *local* config — see
+      //    normalizeBaseRepoSharedConfigKeys() for full context. Exit codes:
+      //    0 = removed, 5 = key absent. Anything else needs the retry/inspect
+      //    dance, which the caller handles by re-running the slow-path helper.
+      configUnsetCmds,
+      // 3. Keep the base repo's own HEAD off trunk so checkout-aware tooling
+      //    doesn't mistake `.mux-base.git` for the user's trunk worktree.
+      `current_head=$(git --git-dir=${baseRepoPathArg} symbolic-ref HEAD 2>/dev/null || true)`,
+      `if [ "$current_head" = ${baseRepoSentinelHeadArg} ]; then`,
+      "  echo STATUS_BASE_HEAD=already",
+      `elif git --git-dir=${baseRepoPathArg} symbolic-ref HEAD ${baseRepoSentinelHeadArg} 2>/tmp/.mux-base-head-$$.err; then`,
+      "  echo STATUS_BASE_HEAD=set",
       "else",
-      // Surface the stderr to the caller so the slow-path retry can decide
-      // whether this is a lock conflict (transient) or a real error.
-      "  echo STATUS_CORE_BARE=error",
-      "  cat /tmp/.mux-corebare.err >&2 2>/dev/null || true",
+      "  echo STATUS_BASE_HEAD=error",
+      "  cat /tmp/.mux-base-head-$$.err >&2 2>/dev/null || true",
       "fi",
-      "rm -f /tmp/.mux-corebare.err 2>/dev/null || true",
-      // 3. Idempotently strip partial-clone / promisor keys (always best-effort).
+      "rm -f /tmp/.mux-base-head-$$.err 2>/dev/null || true",
+      // 4. Idempotently strip partial-clone / promisor keys (always best-effort).
       //    See stripBaseRepoPromisorConfig() docstring for the upstream Git
       //    sideband-deadlock bug this guards against.
       promisorUnsetCmds,
-      // 4. Force receive-pack to use index-pack (with `--fix-thin`) instead of
+      // 5. Force receive-pack to use index-pack (with `--fix-thin`) instead of
       //    `unpack-objects` for incoming pushes, regardless of object count.
       //    This avoids the "unresolved deltas left after unpacking" /
       //    "unpacker error" failure mode where small thin pushes (below the
@@ -1272,42 +1294,82 @@ export class SSHRuntime extends RemoteRuntime {
     }
 
     const created = result.stdout.includes("STATUS_CREATED=created");
-    const coreBareStatus = /STATUS_CORE_BARE=(\w+)/.exec(result.stdout)?.[1];
+    const configStatuses = new Map(
+      BASE_REPO_SHARED_CONFIG_KEYS_TO_UNSET.map((key) => [
+        key,
+        new RegExp(`STATUS_${key.replace(".", "_").toUpperCase()}=(\\w+)`).exec(result.stdout)?.[1],
+      ])
+    );
+    const baseHeadStatus = /STATUS_BASE_HEAD=(\w+)/.exec(result.stdout)?.[1];
 
     if (created) {
       initLogger.logStep("Created shared base repository");
     }
 
-    if (coreBareStatus === "unset") {
+    let loggedConfigNormalization = false;
+    if ([...configStatuses.values()].some((status) => status === "unset")) {
       initLogger.logStep("Normalized shared base repository config for worktrees");
-    } else if (coreBareStatus === "error") {
+      loggedConfigNormalization = true;
+    }
+
+    const configErrorKeys = BASE_REPO_SHARED_CONFIG_KEYS_TO_UNSET.filter(
+      (key) => configStatuses.get(key) === "error"
+    );
+    if (configErrorKeys.length > 0) {
       // Fall back to the slow-path retry helper, which handles lock conflicts
-      // by re-trying with backoff and inspecting whether the key is still set.
-      const normalized = await this.normalizeBaseRepoSharedConfig(baseRepoPathArg, abortSignal);
-      if (normalized) {
+      // by re-trying with backoff and inspecting whether each key is still set.
+      const normalized = await this.normalizeBaseRepoSharedConfigKeys(
+        baseRepoPathArg,
+        configErrorKeys,
+        abortSignal
+      );
+      if (normalized && !loggedConfigNormalization) {
         initLogger.logStep("Normalized shared base repository config for worktrees");
       }
     }
-    // STATUS_CORE_BARE=absent: nothing to do.
+
+    if (baseHeadStatus === "set") {
+      initLogger.logStep("Pointed shared base repository HEAD at internal sentinel");
+    } else if (baseHeadStatus === "error") {
+      throw new Error(
+        `Failed to normalize base repo HEAD: ${result.stderr.trim() || result.stdout.trim()}`
+      );
+    }
 
     return { baseRepoPathArg, freshlyCreated: created };
   }
 
   /**
-   * Keep the shared SSH base repo bare by layout instead of by sharing `core.bare`
-   * through the repo's common config. Linked worktrees consult that local config too,
-   * so leaving `core.bare=true` there leaks bare-repo metadata into normal workspace
-   * checkouts even though Git can infer the host repo is bare from its directory
-   * layout alone.
+   * Keep the shared SSH base repo bare by layout instead of by sharing checkout
+   * config through the repo's common config. Linked worktrees consult that local
+   * config too, so leaving keys like `core.bare` or `core.worktree` there leaks
+   * base-repo metadata into normal workspace checkouts.
    */
-  private async normalizeBaseRepoSharedConfig(
+  private async normalizeBaseRepoSharedConfigKeys(
     baseRepoPathArg: string,
+    keys: readonly BaseRepoSharedConfigKey[],
     abortSignal?: AbortSignal
   ): Promise<boolean> {
+    let normalized = false;
+    for (const key of keys) {
+      normalized =
+        (await this.normalizeBaseRepoSharedConfigKey(baseRepoPathArg, key, abortSignal)) ||
+        normalized;
+    }
+    return normalized;
+  }
+
+  private async normalizeBaseRepoSharedConfigKey(
+    baseRepoPathArg: string,
+    key: BaseRepoSharedConfigKey,
+    abortSignal?: AbortSignal
+  ): Promise<boolean> {
+    const keyArg = shescape.quote(key);
+
     for (let attempt = 0; attempt <= BASE_REPO_CONFIG_LOCK_RETRY_DELAYS_MS.length; attempt++) {
       const unsetResult = await execBuffered(
         this,
-        `git -C ${baseRepoPathArg} config --local --unset-all core.bare`,
+        `git --git-dir=${baseRepoPathArg} config --local --unset-all ${keyArg}`,
         {
           cwd: "/tmp",
           timeout: 10,
@@ -1325,12 +1387,12 @@ export class SSHRuntime extends RemoteRuntime {
 
       const errorDetail = unsetResult.stderr || unsetResult.stdout;
       if (!isGitConfigLockConflict(errorDetail)) {
-        throw new Error(`Failed to normalize base repo config: ${errorDetail}`);
+        throw new Error(`Failed to normalize base repo config ${key}: ${errorDetail}`);
       }
 
       const inspectResult = await execBuffered(
         this,
-        `git -C ${baseRepoPathArg} config --local --get core.bare`,
+        `git --git-dir=${baseRepoPathArg} config --local --get ${keyArg}`,
         {
           cwd: "/tmp",
           timeout: 10,
@@ -1344,12 +1406,12 @@ export class SSHRuntime extends RemoteRuntime {
 
       if (inspectResult.exitCode !== 0) {
         throw new Error(
-          `Failed to inspect base repo config after lock conflict: ${inspectResult.stderr || inspectResult.stdout}`
+          `Failed to inspect base repo config ${key} after lock conflict: ${inspectResult.stderr || inspectResult.stdout}`
         );
       }
 
       if (attempt === BASE_REPO_CONFIG_LOCK_RETRY_DELAYS_MS.length) {
-        throw new Error(`Failed to normalize base repo config: ${errorDetail}`);
+        throw new Error(`Failed to normalize base repo config ${key}: ${errorDetail}`);
       }
 
       // Another initWorkspace may be healing the same shared base repo; if the
@@ -2511,6 +2573,7 @@ export class SSHRuntime extends RemoteRuntime {
     }
     const snapshotDigest = crypto.createHash("sha256").update(headsOutput).digest("hex");
     const baseRepoPathArg = expandTildeForSSH(layout.baseRepoPath);
+    const baseRepoSentinelHeadArg = shescape.quote(BASE_REPO_SENTINEL_HEAD_REF);
     const currentSnapshotPathArg = expandTildeForSSH(layout.currentSnapshotPath);
     const workspacePathArg = expandTildeForSSH(workspacePath);
     const workspaceParentArg = expandTildeForSSH(
@@ -2555,6 +2618,14 @@ export class SSHRuntime extends RemoteRuntime {
     //      when `fetchedOrigin` is false. The fetch runs on the SSH host, so
     //      its latency is upstream→datacenter (typically fast, and the same
     //      cost the slow path pays separately).
+    const warmBaseRepoNormalizationPreamble = [
+      ...BASE_REPO_SHARED_CONFIG_KEYS_TO_UNSET.map(
+        (key) =>
+          `git --git-dir=${baseRepoPathArg} config --local --unset-all ${shescape.quote(key)} 2>/dev/null || true`
+      ),
+      `git --git-dir=${baseRepoPathArg} symbolic-ref HEAD ${baseRepoSentinelHeadArg} 2>/dev/null || true`,
+    ];
+
     const originPreamble = originUrlArg
       ? [
           `git -C ${baseRepoPathArg} remote set-url origin ${originUrlArg} 2>/dev/null || git -C ${baseRepoPathArg} remote add origin ${originUrlArg} >/dev/null 2>&1 || true`,
@@ -2574,6 +2645,8 @@ export class SSHRuntime extends RemoteRuntime {
       `read -r s < ${currentSnapshotPathArg} || true`,
       `[ "$s" = ${digestArg} ] || { echo WARM_MISS:snapshot-digest-drift; exit 0; }`,
       `test -e ${workspacePathArg} && { echo WARM_MISS:workspace-exists; exit 0; }`,
+      // Best-effort base-repo hygiene before the warm path reuses the shared gitdir.
+      ...warmBaseRepoNormalizationPreamble,
       // Optional origin fetch (preserves slow-path origin-freshness).
       ...originPreamble,
       // Choose the worktree base ref. Prefer freshly-fetched
@@ -2591,8 +2664,10 @@ export class SSHRuntime extends RemoteRuntime {
       // fall through to the repairing slow path instead of becoming an opaque
       // `worktree-add-failed` miss. The path was proven absent above, so removing
       // a partial checkout here cannot wipe a pre-existing workspace.
+      // Detached add keeps `.mux-base.git/HEAD` on the internal sentinel; the
+      // branch is attached inside the new worktree immediately afterward.
       `mkdir -p ${workspaceParentArg}`,
-      `wt_output=$(${nhp}git -C ${baseRepoPathArg} worktree add ${workspacePathArg} -B ${branchArg} "$r" 2>&1 >/dev/null)`,
+      `wt_output=$(${nhp}git -C ${baseRepoPathArg} worktree add --detach ${workspacePathArg} "$r" 2>&1 >/dev/null && ${nhp}git -C ${workspacePathArg} checkout -B ${branchArg} 2>&1 >/dev/null)`,
       "wt_status=$?",
       'if [ "$wt_status" -ne 0 ]; then',
       '  case "$wt_output" in',
@@ -2747,15 +2822,29 @@ export class SSHRuntime extends RemoteRuntime {
         abortSignal
       );
 
-      // git worktree add creates the directory and checks out the branch in one step.
-      // -B creates the branch or resets it to the start point if it already exists
-      // (e.g. orphaned from a previously deleted workspace). Git still prevents
-      // checking out a branch that's active in another worktree.
+      // Keep the base repo's HEAD on the internal sentinel: add a detached
+      // worktree from the chosen start point, then attach/reset the workspace
+      // branch inside the new worktree. `checkout -B` creates the branch or
+      // resets it to the start point if it already exists (e.g. orphaned from a
+      // previously deleted workspace). Git still prevents checking out a branch
+      // that's active in another worktree.
       initLogger.logStep(`Creating worktree for branch: ${branchName}`);
       const runWorktreeAdd = (baseRef: string) =>
         execBuffered(
           this,
-          `${nhp}git -C ${baseRepoPathArg} worktree add ${workspacePathArg} -B ${shescape.quote(branchName)} ${shescape.quote(baseRef)}`,
+          [
+            `${nhp}git -C ${baseRepoPathArg} worktree add --detach ${workspacePathArg} ${shescape.quote(baseRef)}`,
+            "worktree_add_status=$?",
+            'if [ "$worktree_add_status" -ne 0 ]; then exit "$worktree_add_status"; fi',
+            `${nhp}git -C ${workspacePathArg} checkout -B ${shescape.quote(branchName)}`,
+            "checkout_status=$?",
+            'if [ "$checkout_status" -ne 0 ]; then',
+            !workspacePathExistedBeforeCheckout
+              ? `  git -C ${baseRepoPathArg} worktree remove --force ${workspacePathArg} >/dev/null 2>&1 || rm -rf ${workspacePathArg}`
+              : "  true",
+            '  exit "$checkout_status"',
+            "fi",
+          ].join("\n"),
           {
             cwd: "/tmp",
             timeout: 300,
@@ -3416,13 +3505,24 @@ export class SSHRuntime extends RemoteRuntime {
 
       if (hasBaseRepo.exitCode === 0) {
         initLogger.logStep("Creating worktree for forked workspace...");
-        // Use -b (not -B) so we fail instead of silently resetting an existing
-        // branch that another worktree might reference. initWorkspace uses -B
-        // because it owns the branch lifecycle; fork is creating a new name.
+        // Use checkout -b (not -B) after the detached add so we fail instead
+        // of silently resetting an existing branch that another worktree might
+        // reference. initWorkspace uses -B because it owns the branch lifecycle;
+        // fork is creating a new name.
         // Stage the worktree under `stagingPath`; `git worktree move` will
         // rename it (and update the bare repo's gitdir back-reference) into
         // `newWorkspacePath` once everything else has succeeded.
-        const worktreeCmd = `${nhp}git -C ${baseRepoPathArg} worktree add ${stagingPathArg} -b ${shescape.quote(newWorkspaceName)} ${shescape.quote(sourceBranch)}`;
+        const worktreeCmd = [
+          `${nhp}git -C ${baseRepoPathArg} worktree add --detach ${stagingPathArg} ${shescape.quote(sourceBranch)}`,
+          "worktree_add_status=$?",
+          'if [ "$worktree_add_status" -ne 0 ]; then exit "$worktree_add_status"; fi',
+          `${nhp}git -C ${stagingPathArg} checkout -b ${shescape.quote(newWorkspaceName)}`,
+          "checkout_status=$?",
+          'if [ "$checkout_status" -ne 0 ]; then',
+          `  git -C ${baseRepoPathArg} worktree remove --force ${stagingPathArg} >/dev/null 2>&1 || rm -rf ${stagingPathArg}`,
+          '  exit "$checkout_status"',
+          "fi",
+        ].join("\n");
         const worktreeResult = await execBuffered(this, worktreeCmd, {
           cwd: "/tmp",
           timeout: 60,

--- a/src/node/runtime/SSHRuntime.ts
+++ b/src/node/runtime/SSHRuntime.ts
@@ -200,6 +200,20 @@ async function enqueueProjectSync(
   }
 }
 
+function isOnlyExpectedBaseRepoSentinelHeadFsckError(detail: string): boolean {
+  const lines = detail
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  return (
+    lines.length > 0 &&
+    lines.every(
+      (line) => line.includes("badHeadTarget") && line.includes(BASE_REPO_SENTINEL_HEAD_REF)
+    )
+  );
+}
+
 function isGitConfigLockConflict(message: string): boolean {
   return /could not lock config file/i.test(message);
 }
@@ -854,9 +868,18 @@ export class SSHRuntime extends RemoteRuntime {
       return { healthy: true };
     }
 
+    const detail = [result.stderr, result.stdout].join("\n").trim() || `exit ${result.exitCode}`;
+    // Git versions that validate HEAD as a branch can report our intentional
+    // internal sentinel as badHeadTarget. The object-connectivity question here
+    // is scoped to explicit bundle refs, so that expected HEAD-only complaint
+    // should not trigger missing-object repair failure.
+    if (isOnlyExpectedBaseRepoSentinelHeadFsckError(detail)) {
+      return { healthy: true };
+    }
+
     return {
       healthy: false,
-      detail: (result.stderr || result.stdout).trim() || `exit ${result.exitCode}`,
+      detail,
     };
   }
 
@@ -879,9 +902,17 @@ export class SSHRuntime extends RemoteRuntime {
       return { healthy: true };
     }
 
+    const detail = [result.stderr, result.stdout].join("\n").trim() || `exit ${result.exitCode}`;
+    // Same sentinel-HEAD exception as bundle connectivity: callers pass an
+    // explicit revision, so a HEAD-only fsck complaint is not evidence that the
+    // requested revision is missing objects.
+    if (isOnlyExpectedBaseRepoSentinelHeadFsckError(detail)) {
+      return { healthy: true };
+    }
+
     return {
       healthy: false,
-      detail: (result.stderr || result.stdout).trim() || `exit ${result.exitCode}`,
+      detail,
     };
   }
 

--- a/tests/runtime/runtime.test.ts
+++ b/tests/runtime/runtime.test.ts
@@ -1674,6 +1674,13 @@ describeIntegration("Runtime integration tests", () => {
     const createSSHRuntime = (): SSHRuntime =>
       createTestRuntime("ssh", srcBaseDir, sshConfig) as SSHRuntime;
 
+    const createCapturingInitLogger = (steps: string[]) => ({
+      ...noopInitLogger,
+      logStep(step: string) {
+        steps.push(step);
+      },
+    });
+
     test("initWorkspace does not populate refs/remotes/origin in the base repo from the bundle", async () => {
       const runtime = createSSHRuntime();
 
@@ -1762,13 +1769,6 @@ describeIntegration("Runtime integration tests", () => {
       const secondWorkspacePath = getRemoteWorkspacePath(layout, "tags-b");
       const thirdWorkspacePath = getRemoteWorkspacePath(layout, "tags-c");
       const baseRepoPath = layout.baseRepoPath;
-
-      const createCapturingInitLogger = (steps: string[]) => ({
-        ...noopInitLogger,
-        logStep(step: string) {
-          steps.push(step);
-        },
-      });
 
       const { execSync } = await import("child_process");
       try {
@@ -1940,6 +1940,239 @@ describeIntegration("Runtime integration tests", () => {
           `git -C "${workspacePath}" config --get core.bare`
         );
         expect(workspaceCoreBareCheck.exitCode).toBe(1);
+      } finally {
+        execSync(`rm -rf "${localProjectPath}"`);
+        await execSSH(runtime, `rm -rf "${layout.projectRoot}"`);
+      }
+    }, 120000);
+
+    test("initWorkspace strips shared core.worktree from pre-existing base repos before checkout", async () => {
+      const runtime = createSSHRuntime();
+
+      const projectName = `sync-heal-worktree-${Date.now()}-${Math.random().toString(36).substring(7)}`;
+      const tmpDir = await import("os").then((os) => os.tmpdir());
+      const localProjectPath = `${tmpDir}/${projectName}`;
+      const layout = buildRemoteProjectLayout(srcBaseDir, localProjectPath);
+      const branchName = "worktree-heal";
+      const workspacePath = getRemoteWorkspacePath(layout, branchName);
+      const baseRepoPath = layout.baseRepoPath;
+      const bogusWorktreePath = `${layout.projectRoot}/.bogus-worktree`;
+
+      const { execSync } = await import("child_process");
+      try {
+        execSync(
+          [
+            `mkdir -p "${localProjectPath}"`,
+            `cd "${localProjectPath}"`,
+            `git init -b main`,
+            `git config user.email "test@test.com"`,
+            `git config user.name "Test"`,
+            `echo "content" > file.txt`,
+            `git add file.txt`,
+            `git commit -m "initial"`,
+          ].join(" && "),
+          { stdio: "pipe" }
+        );
+
+        await execSSH(
+          runtime,
+          [
+            `mkdir -p "${layout.projectRoot}"`,
+            `git init --bare "${baseRepoPath}"`,
+            `git --git-dir="${baseRepoPath}" config --local core.worktree "${bogusWorktreePath}"`,
+          ].join(" && ")
+        );
+
+        const beforeCheck = await execSSH(
+          runtime,
+          `git --git-dir="${baseRepoPath}" config --get core.worktree`
+        );
+        expect(beforeCheck.stdout.trim()).toBe(bogusWorktreePath);
+
+        const initResult = await runtime.initWorkspace({
+          projectPath: localProjectPath,
+          branchName,
+          trunkBranch: "main",
+          workspacePath,
+          initLogger: noopInitLogger,
+        });
+        if (!initResult.success) {
+          throw new Error(`initWorkspace failed: ${initResult.error}`);
+        }
+
+        const baseRepoCoreWorktreeCheck = await execSSH(
+          runtime,
+          `git --git-dir="${baseRepoPath}" config --get core.worktree`
+        );
+        expect(baseRepoCoreWorktreeCheck.exitCode).toBe(1);
+
+        const insideWorkTreeCheck = await execSSH(
+          runtime,
+          `git -C "${workspacePath}" rev-parse --is-inside-work-tree`
+        );
+        expect(insideWorkTreeCheck.stdout.trim()).toBe("true");
+
+        const workspaceTopLevelCheck = await execSSH(
+          runtime,
+          `git -C "${workspacePath}" rev-parse --show-toplevel`
+        );
+        expect(workspaceTopLevelCheck.stdout.trim()).toBe(workspacePath);
+      } finally {
+        execSync(`rm -rf "${localProjectPath}"`);
+        await execSSH(runtime, `rm -rf "${layout.projectRoot}"`);
+      }
+    }, 120000);
+
+    test("initWorkspace points base-repo HEAD at internal sentinel ref", async () => {
+      const runtime = createSSHRuntime();
+
+      const projectName = `sync-sentinel-head-${Date.now()}-${Math.random().toString(36).substring(7)}`;
+      const tmpDir = await import("os").then((os) => os.tmpdir());
+      const localProjectPath = `${tmpDir}/${projectName}`;
+      const layout = buildRemoteProjectLayout(srcBaseDir, localProjectPath);
+      const branchName = "sentinel-head";
+      const workspacePath = getRemoteWorkspacePath(layout, branchName);
+      const baseRepoPath = layout.baseRepoPath;
+
+      const { execSync } = await import("child_process");
+      try {
+        execSync(
+          [
+            `mkdir -p "${localProjectPath}"`,
+            `cd "${localProjectPath}"`,
+            `git init -b main`,
+            `git config user.email "test@test.com"`,
+            `git config user.name "Test"`,
+            `echo "content" > file.txt`,
+            `git add file.txt`,
+            `git commit -m "initial"`,
+          ].join(" && "),
+          { stdio: "pipe" }
+        );
+
+        const initResult = await runtime.initWorkspace({
+          projectPath: localProjectPath,
+          branchName,
+          trunkBranch: "main",
+          workspacePath,
+          initLogger: noopInitLogger,
+        });
+        if (!initResult.success) {
+          throw new Error(`initWorkspace failed: ${initResult.error}`);
+        }
+
+        const baseHeadCheck = await execSSH(
+          runtime,
+          `git --git-dir="${baseRepoPath}" symbolic-ref HEAD`
+        );
+        expect(baseHeadCheck.stdout.trim()).toBe("refs/mux-internal/base-head");
+
+        const baseRepoBareCheck = await execSSH(
+          runtime,
+          `git -C "${baseRepoPath}" rev-parse --is-bare-repository`
+        );
+        expect(baseRepoBareCheck.stdout.trim()).toBe("true");
+
+        const baseWorktreeEntry = await execSSH(
+          runtime,
+          `git -C "${baseRepoPath}" worktree list --porcelain | sed -n '1,/^$/p'`
+        );
+        expect(baseWorktreeEntry.stdout).toContain(`worktree ${baseRepoPath}`);
+        expect(baseWorktreeEntry.stdout).toContain("bare");
+        expect(baseWorktreeEntry.stdout).not.toContain("branch ");
+      } finally {
+        execSync(`rm -rf "${localProjectPath}"`);
+        await execSSH(runtime, `rm -rf "${layout.projectRoot}"`);
+      }
+    }, 120000);
+
+    test("warm fast-path heals poisoned base repo before materializing workspace", async () => {
+      const runtime = createSSHRuntime();
+
+      const projectName = `sync-warm-heal-${Date.now()}-${Math.random().toString(36).substring(7)}`;
+      const tmpDir = await import("os").then((os) => os.tmpdir());
+      const localProjectPath = `${tmpDir}/${projectName}`;
+      const layout = buildRemoteProjectLayout(srcBaseDir, localProjectPath);
+      const firstWorkspacePath = getRemoteWorkspacePath(layout, "warm-heal-a");
+      const secondWorkspacePath = getRemoteWorkspacePath(layout, "warm-heal-b");
+      const baseRepoPath = layout.baseRepoPath;
+      const bogusWorktreePath = `${layout.projectRoot}/.mux-base-worktree`;
+
+      const { execSync } = await import("child_process");
+      try {
+        execSync(
+          [
+            `mkdir -p "${localProjectPath}"`,
+            `cd "${localProjectPath}"`,
+            `git init -b main`,
+            `git config user.email "test@test.com"`,
+            `git config user.name "Test"`,
+            `echo "content" > file.txt`,
+            `git add file.txt`,
+            `git commit -m "initial"`,
+          ].join(" && "),
+          { stdio: "pipe" }
+        );
+
+        const firstInit = await runtime.initWorkspace({
+          projectPath: localProjectPath,
+          branchName: "warm-heal-a",
+          trunkBranch: "main",
+          workspacePath: firstWorkspacePath,
+          initLogger: noopInitLogger,
+        });
+        if (!firstInit.success) {
+          throw new Error(`first initWorkspace failed: ${firstInit.error}`);
+        }
+
+        const poisonResult = await execSSH(
+          runtime,
+          [
+            `git --git-dir="${baseRepoPath}" config --local core.bare true`,
+            `git --git-dir="${baseRepoPath}" config --local core.worktree "${bogusWorktreePath}"`,
+            `git --git-dir="${baseRepoPath}" symbolic-ref HEAD refs/heads/main`,
+          ].join(" && ")
+        );
+        expect(poisonResult.exitCode).toBe(0);
+
+        const reuseSteps: string[] = [];
+        const secondInit = await runtime.initWorkspace({
+          projectPath: localProjectPath,
+          branchName: "warm-heal-b",
+          trunkBranch: "main",
+          workspacePath: secondWorkspacePath,
+          initLogger: createCapturingInitLogger(reuseSteps),
+        });
+        if (!secondInit.success) {
+          throw new Error(`second initWorkspace failed: ${secondInit.error}`);
+        }
+        expect(
+          reuseSteps.some((step) => step.includes("Materialized workspace via warm fast-path"))
+        ).toBe(true);
+
+        const insideWorkTreeCheck = await execSSH(
+          runtime,
+          `git -C "${secondWorkspacePath}" rev-parse --is-inside-work-tree`
+        );
+        expect(insideWorkTreeCheck.stdout.trim()).toBe("true");
+
+        const baseRepoCoreBareCheck = await execSSH(
+          runtime,
+          `git --git-dir="${baseRepoPath}" config --get core.bare`
+        );
+        expect(baseRepoCoreBareCheck.exitCode).toBe(1);
+
+        const baseRepoCoreWorktreeCheck = await execSSH(
+          runtime,
+          `git --git-dir="${baseRepoPath}" config --get core.worktree`
+        );
+        expect(baseRepoCoreWorktreeCheck.exitCode).toBe(1);
+
+        const baseHeadCheck = await execSSH(
+          runtime,
+          `git --git-dir="${baseRepoPath}" symbolic-ref HEAD`
+        );
+        expect(baseHeadCheck.stdout.trim()).toBe("refs/mux-internal/base-head");
       } finally {
         execSync(`rm -rf "${localProjectPath}"`);
         await execSSH(runtime, `rm -rf "${layout.projectRoot}"`);

--- a/tests/runtime/runtime.test.ts
+++ b/tests/runtime/runtime.test.ts
@@ -1381,10 +1381,7 @@ describeIntegration("Runtime integration tests", () => {
         );
         expect(beforeCheck.stdout.trim()).toBe("worktree");
 
-        await execSSH(
-          runtime,
-          `git --git-dir="${baseRepoPath}" symbolic-ref HEAD refs/mux-internal/base-head`
-        );
+        await execSSH(runtime, `git --git-dir="${baseRepoPath}" symbolic-ref HEAD refs/heads/main`);
 
         // Delete the workspace.
         const deleteResult = await runtime.deleteWorkspace(
@@ -2034,14 +2031,14 @@ describeIntegration("Runtime integration tests", () => {
       }
     }, 120000);
 
-    test("initWorkspace points base-repo HEAD at internal sentinel ref", async () => {
+    test("initWorkspace keeps base-repo HEAD detached from user branches", async () => {
       const runtime = createSSHRuntime();
 
-      const projectName = `sync-sentinel-head-${Date.now()}-${Math.random().toString(36).substring(7)}`;
+      const projectName = `sync-neutral-head-${Date.now()}-${Math.random().toString(36).substring(7)}`;
       const tmpDir = await import("os").then((os) => os.tmpdir());
       const localProjectPath = `${tmpDir}/${projectName}`;
       const layout = buildRemoteProjectLayout(srcBaseDir, localProjectPath);
-      const branchName = "sentinel-head";
+      const branchName = "neutral-head";
       const workspacePath = getRemoteWorkspacePath(layout, branchName);
       const baseRepoPath = layout.baseRepoPath;
 
@@ -2072,11 +2069,18 @@ describeIntegration("Runtime integration tests", () => {
           throw new Error(`initWorkspace failed: ${initResult.error}`);
         }
 
-        const baseHeadCheck = await execSSH(
+        const baseHeadSymbolicCheck = await execSSH(
           runtime,
-          `git --git-dir="${baseRepoPath}" symbolic-ref HEAD`
+          `git --git-dir="${baseRepoPath}" symbolic-ref -q HEAD`
         );
-        expect(baseHeadCheck.stdout.trim()).toBe("refs/mux-internal/base-head");
+        expect(baseHeadSymbolicCheck.exitCode).toBe(1);
+
+        const baseHeadCommit = await execSSH(
+          runtime,
+          `git --git-dir="${baseRepoPath}" rev-parse --verify HEAD`
+        );
+        const workspaceCommit = await execSSH(runtime, `git -C "${workspacePath}" rev-parse HEAD`);
+        expect(baseHeadCommit.stdout.trim()).toBe(workspaceCommit.stdout.trim());
 
         const baseRepoBareCheck = await execSSH(
           runtime,
@@ -2179,11 +2183,21 @@ describeIntegration("Runtime integration tests", () => {
         );
         expect(baseRepoCoreWorktreeCheck.exitCode).toBe(1);
 
-        const baseHeadCheck = await execSSH(
+        const baseHeadSymbolicCheck = await execSSH(
           runtime,
-          `git --git-dir="${baseRepoPath}" symbolic-ref HEAD`
+          `git --git-dir="${baseRepoPath}" symbolic-ref -q HEAD`
         );
-        expect(baseHeadCheck.stdout.trim()).toBe("refs/mux-internal/base-head");
+        expect(baseHeadSymbolicCheck.exitCode).toBe(1);
+
+        const baseHeadCommit = await execSSH(
+          runtime,
+          `git --git-dir="${baseRepoPath}" rev-parse --verify HEAD`
+        );
+        const secondWorkspaceCommit = await execSSH(
+          runtime,
+          `git -C "${secondWorkspacePath}" rev-parse HEAD`
+        );
+        expect(baseHeadCommit.stdout.trim()).toBe(secondWorkspaceCommit.stdout.trim());
       } finally {
         execSync(`rm -rf "${localProjectPath}"`);
         await execSSH(runtime, `rm -rf "${layout.projectRoot}"`);

--- a/tests/runtime/runtime.test.ts
+++ b/tests/runtime/runtime.test.ts
@@ -1413,6 +1413,66 @@ describeIntegration("Runtime integration tests", () => {
       }
     }, 60000);
 
+    test("deleteWorkspace leaves an unmanaged source checkout's HEAD untouched", async () => {
+      const runtime = createSSHRuntime();
+      const projectName = `wt-del-unmanaged-${Date.now()}-${Math.random().toString(36).substring(7)}`;
+      const projectPath = `/some/path/${projectName}`;
+      const layout = getLayout(projectPath);
+      const sourceCheckoutPath = `${layout.projectRoot}/unmanaged-src`;
+      const workspaceName = "doomed-wt";
+      const workspacePath = getRemoteWorkspacePath(layout, workspaceName);
+
+      try {
+        // A real (non-Mux) checkout whose worktree happens to live at the
+        // canonical workspace path. resolveWorktreeBaseRepoPath() resolves the
+        // workspace's git-common-dir to this checkout's .git, so deletion
+        // cleanup must not rewrite the checkout's HEAD.
+        await execSSH(
+          runtime,
+          [
+            `mkdir -p "${sourceCheckoutPath}"`,
+            `cd "${sourceCheckoutPath}"`,
+            `git init -b main`,
+            `git config user.email "test@test.com"`,
+            `git config user.name "Test"`,
+            `echo "x" > x.txt && git add x.txt && git commit -m "init"`,
+            `git worktree add "${workspacePath}" -b ${workspaceName}`,
+          ].join(" && ")
+        );
+
+        const headCommitBefore = await execSSH(
+          runtime,
+          `git -C "${sourceCheckoutPath}" rev-parse HEAD`
+        );
+
+        const deleteResult = await runtime.deleteWorkspace(projectPath, workspaceName, true);
+        expect(deleteResult.success).toBe(true);
+
+        const afterCheck = await execSSH(
+          runtime,
+          `test -d "${workspacePath}" && echo "exists" || echo "missing"`
+        );
+        expect(afterCheck.stdout.trim()).toBe("missing");
+
+        // The source checkout must still be on its own branch with a
+        // resolvable HEAD — not stranded on Mux's unborn internal branch.
+        const headRefAfter = await execSSH(
+          runtime,
+          `git -C "${sourceCheckoutPath}" symbolic-ref HEAD`
+        );
+        expect(headRefAfter.stdout.trim()).toBe("refs/heads/main");
+
+        const headCommitAfter = await execSSH(
+          runtime,
+          `git -C "${sourceCheckoutPath}" rev-parse --verify HEAD`
+        );
+        expect(headCommitAfter.exitCode).toBe(0);
+        expect(headCommitAfter.stdout.trim()).toBe(headCommitBefore.stdout.trim());
+      } finally {
+        await execSSH(runtime, `rm -rf "${layout.projectRoot}"`);
+      }
+    }, 60000);
+
     test("deleteWorkspace still works for legacy full-clone workspaces", async () => {
       const runtime = createSSHRuntime();
       const projectName = `wt-del-legacy-${Date.now()}-${Math.random().toString(36).substring(7)}`;

--- a/tests/runtime/runtime.test.ts
+++ b/tests/runtime/runtime.test.ts
@@ -1381,6 +1381,11 @@ describeIntegration("Runtime integration tests", () => {
         );
         expect(beforeCheck.stdout.trim()).toBe("worktree");
 
+        await execSSH(
+          runtime,
+          `git --git-dir="${baseRepoPath}" symbolic-ref HEAD refs/mux-internal/base-head`
+        );
+
         // Delete the workspace.
         const deleteResult = await runtime.deleteWorkspace(
           projectPath,
@@ -1400,6 +1405,12 @@ describeIntegration("Runtime integration tests", () => {
         // Verify worktree metadata is cleaned up in the base repo.
         const worktreeList = await execSSH(runtime, `git -C "${baseRepoPath}" worktree list`);
         expect(worktreeList.stdout).not.toContain(workspaceName);
+
+        const deletedBranchRef = await execSSH(
+          runtime,
+          `git --git-dir="${baseRepoPath}" show-ref --verify --quiet refs/heads/${workspaceName}`
+        );
+        expect(deletedBranchRef.exitCode).toBe(1);
       } finally {
         await execSSH(runtime, `rm -rf "${layout.projectRoot}"`);
       }


### PR DESCRIPTION
## Summary

Hardens SSH/Coder remote workspace setup so Mux treats `.mux-base.git` as an internal bare common git directory rather than a checkout. Shared base repos are normalized by removing leaked `core.bare` / `core.worktree` config, keeping the base repo's own `HEAD` off user branches, and healing poisoned warm-path caches before materializing new workspaces.

## Background

A remote Coder host ended up with `.mux-base.git/config` containing shared checkout config (`core.bare=false` and `core.worktree=<synthetic path>`). Linked worktrees inherit that common config, so a repair that made one workspace look healthy poisoned future sibling workspaces. Separately, leaving the base repo `HEAD` on trunk makes checkout-aware tools such as Graphite interpret the bare cache as the real trunk checkout.

## Implementation

The base repo invariant is now explicit: `.mux-base.git` is bare by layout, has no shared checkout config, and does not advertise a user branch in `git worktree list --porcelain`. Empty base repos point `HEAD` at an unborn internal branch so Git porcelain stays branch-shaped; once Mux selects a real worktree base commit, it detaches the base repo `HEAD` at that commit. This keeps Graphite from seeing trunk checked out at the base repo while preserving normal Git behavior for `worktree add -B`, `worktree add -b`, `fsck`, and `branch -D`.

Both the slow sync path and the fused warm fast-path normalize poisoned base repos before checkout. The warm path treats cleanup failures as cache misses so the slow path can run its retry/error handling instead of materializing from still-poisoned shared config. Branch cleanup after workspace deletion keeps Git's own active-worktree guard by neutralizing base `HEAD` and using `git branch -D` instead of raw ref deletion; the `HEAD` rewrite is scoped to common git dirs named `.mux-base.git` so deleting a worktree of an unmanaged real checkout never strands that checkout on the internal branch. Regression coverage exercises pre-existing poisoned `core.bare` / `core.worktree`, neutral base `HEAD`, warm fast-path healing, missing-object repair, and deleted-worktree branch cleanup.

## Validation

Focused SSH integration coverage was run for the poisoned-config, neutral-HEAD, warm-path healing, missing-object repair, and worktree-delete cases. Local static validation also passed with `MUX_ESLINT_CONCURRENCY=1 make static-check`.

## Risks

This touches remote SSH workspace materialization and deletion. The riskiest area is old/corrupted shared base repos, but the change is intentionally defensive: normalization is idempotent, warm-path cleanup failures fall back to the slow path, missing-object repair remains in the checkout path, and branch cleanup is best-effort.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$47.88`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=47.88 -->
