### PR TITLE
🤖 feat: withhold review pane tools from sub-agents

### DIFF
--- a/src/common/utils/tools/toolAvailability.test.ts
+++ b/src/common/utils/tools/toolAvailability.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { getGoalToolAvailability } from "./toolAvailability";
+import { getGoalToolAvailability, getToolAvailabilityOptions } from "./toolAvailability";
 import type { GoalStatus } from "@/common/types/goal";
 
 const execAgent = {
@@ -75,5 +75,22 @@ describe("goal tool availability", () => {
         editingCapable: true,
       })
     ).toEqual(["get_goal", "complete_goal"]);
+  });
+});
+
+describe("getToolAvailabilityOptions", () => {
+  test("enables the Review pane for top-level workspaces", () => {
+    const options = getToolAvailabilityOptions({ workspaceId: "ws-1" });
+    expect(options.enableReviewPane).toBe(true);
+    expect(options.enableAgentReport).toBe(false);
+  });
+
+  test("withholds the Review pane (and enables agent_report) for sub-agents", () => {
+    const options = getToolAvailabilityOptions({
+      workspaceId: "ws-child",
+      parentWorkspaceId: "ws-parent",
+    });
+    expect(options.enableReviewPane).toBe(false);
+    expect(options.enableAgentReport).toBe(true);
   });
 });

--- a/src/common/utils/tools/toolAvailability.ts
+++ b/src/common/utils/tools/toolAvailability.ts
@@ -46,6 +46,10 @@ export function getGoalToolAvailability(
 export function getToolAvailabilityOptions(context: ToolAvailabilityContext) {
   return {
     enableAgentReport: Boolean(context.parentWorkspaceId),
+    // The Review pane is a user-facing parent-workspace concept. Sub-agents
+    // (child task workspaces, identified by a parentWorkspaceId) shouldn't pin
+    // code to it, so withhold the review_pane_* tools from them.
+    enableReviewPane: !context.parentWorkspaceId,
     // skills_catalog_* tools are always available; agent tool policy controls access.
   } as const;
 }

--- a/src/common/utils/tools/toolDefinitions.test.ts
+++ b/src/common/utils/tools/toolDefinitions.test.ts
@@ -411,6 +411,22 @@ describe("TOOL_DEFINITIONS", () => {
     expect(tools).toContain("skills_catalog_read");
   });
 
+  it("only includes Review pane tools when enableReviewPane is not disabled", () => {
+    const defaultTools = getAvailableTools("openai:gpt-4o");
+    expect(defaultTools).toContain("review_pane_update");
+    expect(defaultTools).toContain("review_pane_get");
+
+    const enabledTools = getAvailableTools("openai:gpt-4o", { enableReviewPane: true });
+    expect(enabledTools).toContain("review_pane_update");
+    expect(enabledTools).toContain("review_pane_get");
+
+    // Sub-agents pass enableReviewPane: false so they can't pin code to the
+    // user-facing parent Review pane.
+    const subAgentTools = getAvailableTools("openai:gpt-4o", { enableReviewPane: false });
+    expect(subAgentTools).not.toContain("review_pane_update");
+    expect(subAgentTools).not.toContain("review_pane_get");
+  });
+
   it("only includes workflow tools when dynamic workflows are enabled", () => {
     const disabledTools = getAvailableTools("openai:gpt-4o", { enableDynamicWorkflows: false });
     expect(disabledTools).not.toContain("workflow_list");

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -2365,6 +2365,13 @@ export function getAvailableTools(
     enableAnalyticsQuery?: boolean;
     enableAdvisor?: boolean;
     enableDynamicWorkflows?: boolean;
+    /**
+     * Whether the Review pane tools (review_pane_update/review_pane_get) are
+     * available. The Review pane belongs to the user-facing parent workspace,
+     * so sub-agents (child task workspaces) pass false to keep them from
+     * pinning code to a pane the user never sees. Defaults to true.
+     */
+    enableReviewPane?: boolean;
     /** @deprecated Mux global tools are always included. */
     enableMuxGlobalAgentsTools?: boolean;
   }
@@ -2374,6 +2381,7 @@ export function getAvailableTools(
   const enableAnalyticsQuery = options?.enableAnalyticsQuery ?? true;
   const enableAdvisor = options?.enableAdvisor ?? false;
   const enableDynamicWorkflows = options?.enableDynamicWorkflows ?? false;
+  const enableReviewPane = options?.enableReviewPane ?? true;
 
   // Base tools available for all models
   // Note: Tool availability is controlled by agent tool policy (allowlist), not mode checks here.
@@ -2419,8 +2427,7 @@ export function getAvailableTools(
     "complete_goal",
     "todo_write",
     "todo_read",
-    "review_pane_update",
-    "review_pane_get",
+    ...(enableReviewPane ? ["review_pane_update", "review_pane_get"] : []),
     "notify",
     ...(enableAnalyticsQuery ? ["analytics_query"] : []),
     "web_fetch",

--- a/src/common/utils/tools/tools.test.ts
+++ b/src/common/utils/tools/tools.test.ts
@@ -90,6 +90,41 @@ describe("getToolsForModel", () => {
     expect(toolsWithReport.agent_report).toBeDefined();
   });
 
+  test("withholds review_pane_* tools from sub-agents (enableAgentReport=true)", async () => {
+    const runtime = new LocalRuntime(process.cwd());
+    const initStateManager = createInitStateManager();
+
+    // Top-level workspace (not a sub-agent): Review pane tools available.
+    const topLevelTools = await getToolsForModel(
+      "noop:model",
+      {
+        cwd: process.cwd(),
+        runtime,
+        runtimeTempDir: "/tmp",
+        enableAgentReport: false,
+      },
+      "ws-1",
+      initStateManager
+    );
+    expect(topLevelTools.review_pane_update).toBeDefined();
+    expect(topLevelTools.review_pane_get).toBeDefined();
+
+    // Sub-agent (child task workspace): can't pin code to the parent Review pane.
+    const subAgentTools = await getToolsForModel(
+      "noop:model",
+      {
+        cwd: process.cwd(),
+        runtime,
+        runtimeTempDir: "/tmp",
+        enableAgentReport: true,
+      },
+      "ws-1",
+      initStateManager
+    );
+    expect(subAgentTools.review_pane_update).toBeUndefined();
+    expect(subAgentTools.review_pane_get).toBeUndefined();
+  });
+
   test("only includes workflow tools when dynamic workflows service and experiment are enabled", async () => {
     const runtime = new LocalRuntime(process.cwd());
     const initStateManager = createInitStateManager();

--- a/src/common/utils/tools/tools.ts
+++ b/src/common/utils/tools/tools.ts
@@ -627,6 +627,11 @@ export async function getToolsForModel(
         config.workflowService && config.experiments?.dynamicWorkflows
       ),
       enableAdvisor: Boolean(config.advisorRuntime),
+      // The Review pane belongs to the user-facing parent workspace. config
+      // .enableAgentReport is the canonical "is sub-agent" signal (set true iff
+      // the workspace has a parentWorkspaceId), so withhold the review_pane_*
+      // tools from sub-agents to keep the toolset in sync with the system prompt.
+      enableReviewPane: !config.enableAgentReport,
       // Mux global tools are always created; tool policy (agent frontmatter)
       // controls which agents can actually use them.
       enableMuxGlobalAgentsTools: true,

--- a/src/node/services/systemMessage.ts
+++ b/src/node/services/systemMessage.ts
@@ -246,6 +246,7 @@ export function extractToolInstructions(
   modelString: string,
   options?: {
     enableAgentReport?: boolean;
+    enableReviewPane?: boolean;
     enableMuxGlobalAgentsTools?: boolean;
     agentInstructions?: string;
   }

--- a/src/node/services/tokenizerService.test.ts
+++ b/src/node/services/tokenizerService.test.ts
@@ -78,6 +78,7 @@ describe("TokenizerService", () => {
       expect(result).toBe(mockResult);
       expect(statsSpy).toHaveBeenCalledWith(messages, "gpt-4", null, {
         enableAgentReport: false,
+        enableReviewPane: true,
       });
       expect(persistSpy).toHaveBeenCalledWith(
         "test-workspace",
@@ -122,6 +123,7 @@ describe("TokenizerService", () => {
 
       expect(statsSpy).toHaveBeenCalledWith([messages[1]], "gpt-4", null, {
         enableAgentReport: false,
+        enableReviewPane: true,
       });
       expect(persistSpy).toHaveBeenCalledWith(
         "test-workspace",
@@ -152,9 +154,11 @@ describe("TokenizerService", () => {
 
       expect(statsSpy).toHaveBeenNthCalledWith(1, messages, "gpt-4", null, {
         enableAgentReport: false,
+        enableReviewPane: true,
       });
       expect(statsSpy).toHaveBeenNthCalledWith(2, messages, "gpt-4", null, {
         enableAgentReport: false,
+        enableReviewPane: true,
       });
 
       statsSpy.mockRestore();
@@ -177,6 +181,7 @@ describe("TokenizerService", () => {
 
       expect(statsSpy).toHaveBeenCalledWith(messages, "gpt-4", null, {
         enableAgentReport: true,
+        enableReviewPane: false,
       });
 
       statsSpy.mockRestore();


### PR DESCRIPTION
## Summary

Withhold the Review pane tools (`review_pane_update` / `review_pane_get`) from sub-agents so child task workspaces can no longer pin code to the user-facing parent Review pane.

## Background

The Review pane is a parent-workspace, user-facing concept. Sub-agents run in isolated child task workspaces with their own session dir, so anything they "pin" lands in a pane the user never sees — pure noise and wasted effort. The pinning tool (`review_pane_update`) and its read counterpart (`review_pane_get`) should simply not be offered to sub-agents.

## Implementation

- `getAvailableTools()` gains an `enableReviewPane` option (defaults to `true`). When `false`, both `review_pane_update` and `review_pane_get` are dropped from the tool allowlist.
- `getToolAvailabilityOptions()` — the single source of truth for these capability flags — now returns `enableReviewPane: !parentWorkspaceId`, so every consumer (system prompt tool instructions, tokenizer estimates, cost debug) disables the pane for sub-agents automatically.
- `getToolsForModel()` mirrors the gate when filtering the concrete toolset to the canonical allowlist, using `config.enableAgentReport` (the existing canonical "is sub-agent" signal, set true iff `parentWorkspaceId` is present) so the toolset and system prompt stay in sync.

`review_pane_get` is gated alongside `review_pane_update` because it only ever reads a sub-agent's own (now always-empty) list, making it useless without the ability to pin.

## Validation

- New behavioral tests: `getToolAvailabilityOptions` flag derivation, `getAvailableTools` gating, and `getToolsForModel` excluding the pane tools for sub-agents (`enableAgentReport=true`).
- `make static-check` and the touched tool test suites pass.

## Risks

Low. Top-level workspaces are unaffected (flag defaults to enabled). The change only removes two tools from sub-agent toolsets; no persisted data or existing pins are touched.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-8` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-opus-4-8 thinking=xhigh -->
