### PR TITLE
🤖 feat: add Claude Fable 5 / Mythos 5 support

### DIFF
--- a/docs/config/models.mdx
+++ b/docs/config/models.mdx
@@ -13,6 +13,7 @@ Mux ships with curated models kept up to date with the frontier. Use any custom 
 
 | Model                  | ID                            | Aliases                                                      | Default |
 | ---------------------- | ----------------------------- | ------------------------------------------------------------ | ------- |
+| Fable 5                | anthropic:claude-fable-5      | `fable`                                                      |         |
 | Opus 4.8               | anthropic:claude-opus-4-8     | `opus`                                                       | ✓       |
 | Sonnet 4.6             | anthropic:claude-sonnet-4-6   | `sonnet`                                                     |         |
 | Haiku 4.5              | anthropic:claude-haiku-4-5    | `haiku`                                                      |         |

--- a/src/common/constants/knownModels.ts
+++ b/src/common/constants/knownModels.ts
@@ -27,6 +27,19 @@ interface KnownModel extends KnownModelDefinition {
 // Model definitions. Note we avoid listing legacy models here. These represent the focal models
 // of the community.
 const MODEL_DEFINITIONS = {
+  // Claude Fable 5 - Mythos-class model (a tier above Opus) released June 9, 2026.
+  // It is the generally-available variant of the Mythos 5 model, shipped with safeguards
+  // enabled (a small fraction of flagged requests fall back to Opus 4.8 server-side, which
+  // is transparent to API clients). API id `claude-fable-5`; $10/M input, $50/M output.
+  FABLE: {
+    provider: "anthropic",
+    providerModelId: "claude-fable-5",
+    aliases: ["fable"],
+    warm: true,
+    // Fable tokenizer not published upstream; reuse Opus 4.5 (Claude tokenization is
+    // unchanged across the 4.x / Mythos line) for approximate counting.
+    tokenizerOverride: "anthropic/claude-opus-4.5",
+  },
   OPUS: {
     provider: "anthropic",
     providerModelId: "claude-opus-4-8",

--- a/src/common/types/thinking.ts
+++ b/src/common/types/thinking.ts
@@ -198,11 +198,13 @@ export function getAnthropicEffort(level: ThinkingLevel): AnthropicEffortLevel {
 }
 
 /**
- * Whether the given Anthropic model is Opus 4.7 or newer and supports the
- * native "xhigh" API effort level (distinct from "max").
+ * Whether the given Anthropic model supports the native "xhigh" API effort level
+ * (distinct from "max").
  *
- * Matches `claude-opus-4-7`, `claude-opus-4-8`, ... `claude-opus-4-99`, and
- * any future Opus 5+ (which we assume preserves or exceeds 4.7's capabilities).
+ * Matches:
+ * - `claude-opus-4-7`, `claude-opus-4-8`, ... `claude-opus-4-99`, and any future Opus 5+
+ *   (which we assume preserves or exceeds 4.7's capabilities).
+ * - Mythos-class models (`claude-fable-*`, `claude-mythos-*`), the tier above Opus.
  */
 export function anthropicSupportsNativeXhigh(modelString: string): boolean {
   const withoutPrefix = modelString
@@ -210,8 +212,12 @@ export function anthropicSupportsNativeXhigh(modelString: string): boolean {
     .toLowerCase()
     .replace(/^[a-z0-9_-]+:\s*/, "")
     .replace(/^[a-z0-9_-]+\//, "");
-  // Opus 4.7+ (4-7, 4-8, 4-9, 4-10, 4-11, ...) or any Opus 5+.
-  return /claude-opus-(?:4-(?:[7-9]|\d{2,})|[5-9]|\d{2,})/.test(withoutPrefix);
+  // Opus 4.7+ (4-7, 4-8, 4-9, 4-10, 4-11, ...) or any Opus 5+, plus the Mythos-class
+  // Fable / Mythos models that sit above Opus.
+  return (
+    /claude-opus-(?:4-(?:[7-9]|\d{2,})|[5-9]|\d{2,})/.test(withoutPrefix) ||
+    /claude-(?:fable|mythos)-/.test(withoutPrefix)
+  );
 }
 
 /**

--- a/src/common/utils/ai/modelDisplay.test.ts
+++ b/src/common/utils/ai/modelDisplay.test.ts
@@ -11,6 +11,11 @@ describe("formatModelDisplayName", () => {
     test("formats Opus models", () => {
       expect(formatModelDisplayName("claude-opus-4-1")).toBe("Opus 4.1");
     });
+
+    test("formats Mythos-class Fable / Mythos models", () => {
+      expect(formatModelDisplayName("claude-fable-5")).toBe("Fable 5");
+      expect(formatModelDisplayName("claude-mythos-5")).toBe("Mythos 5");
+    });
   });
 
   describe("GPT models", () => {

--- a/src/common/utils/ai/modelDisplay.ts
+++ b/src/common/utils/ai/modelDisplay.ts
@@ -36,8 +36,9 @@ export function formatModelDisplayName(modelName: string): string {
   if (lower.startsWith("claude-")) {
     const parts = lower.replace("claude-", "").split("-");
 
-    // Known tiers for Claude models
-    const tiers = ["sonnet", "opus", "haiku"];
+    // Known tiers for Claude models. Fable / Mythos are the Mythos-class tier that
+    // sits above Opus (e.g. "claude-fable-5" -> "Fable 5", "claude-mythos-5" -> "Mythos 5").
+    const tiers = ["sonnet", "opus", "haiku", "fable", "mythos"];
 
     // Format: claude-{tier}-{major}-{minor} (newer naming)
     // e.g., "claude-sonnet-4-5" -> "Sonnet 4.5"

--- a/src/common/utils/ai/models.test.ts
+++ b/src/common/utils/ai/models.test.ts
@@ -136,6 +136,14 @@ describe("Anthropic 1M context classification", () => {
     expect(hasNative1MContext("anthropic:claude-sonnet-4-6")).toBe(true);
   });
 
+  it("treats Mythos-class Fable 5 / Mythos 5 as native 1M models", () => {
+    expect(getAnthropic1MContextMode("anthropic:claude-fable-5")).toBe("native");
+    expect(getAnthropic1MContextMode("anthropic:claude-mythos-5")).toBe("native");
+    expect(getAnthropic1MContextMode("mux-gateway:anthropic/claude-fable-5")).toBe("native");
+    expect(hasNative1MContext("anthropic:claude-fable-5")).toBe(true);
+    expect(supports1MContext("anthropic:claude-fable-5")).toBe(false);
+  });
+
   it("returns none for models without Anthropic 1M support", () => {
     expect(getAnthropic1MContextMode("anthropic:claude-opus-4-5")).toBe("none");
     expect(getAnthropic1MContextMode("anthropic:claude-haiku-4-5")).toBe("none");

--- a/src/common/utils/ai/models.ts
+++ b/src/common/utils/ai/models.ts
@@ -120,6 +120,9 @@ export type Anthropic1MContextMode = "none" | "beta" | "native";
 
 const OPTIONAL_VERSION_SUFFIX = String.raw`(?:-(?:\d{8}|\d{4}-\d{2}-\d{2}))?`;
 const ANTHROPIC_NATIVE_1M_PATTERNS = [
+  // Mythos-class models (Fable 5 / Mythos 5) ship 1M context as standard metadata.
+  new RegExp(`^claude-fable-5${OPTIONAL_VERSION_SUFFIX}$`, "i"),
+  new RegExp(`^claude-mythos-5${OPTIONAL_VERSION_SUFFIX}$`, "i"),
   new RegExp(`^claude-opus-4-8${OPTIONAL_VERSION_SUFFIX}$`, "i"),
   new RegExp(`^claude-opus-4-7${OPTIONAL_VERSION_SUFFIX}$`, "i"),
   new RegExp(`^claude-opus-4-6${OPTIONAL_VERSION_SUFFIX}$`, "i"),

--- a/src/common/utils/thinking/policy.test.ts
+++ b/src/common/utils/thinking/policy.test.ts
@@ -365,6 +365,26 @@ describe("getThinkingPolicyForModel", () => {
     ]);
   });
 
+  test("returns all 6 levels for Mythos-class Fable 5 / Mythos 5", () => {
+    // Fable / Mythos sit above Opus and support the native xhigh effort level.
+    expect(getThinkingPolicyForModel("anthropic:claude-fable-5")).toEqual([
+      "off",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
+    expect(getThinkingPolicyForModel("anthropic:claude-mythos-5")).toEqual([
+      "off",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
+  });
+
   test("returns 5 levels including xhigh for Sonnet 4.6", () => {
     expect(getThinkingPolicyForModel("anthropic:claude-sonnet-4-6")).toEqual([
       "off",

--- a/src/common/utils/tokens/models-extra.ts
+++ b/src/common/utils/tokens/models-extra.ts
@@ -55,6 +55,46 @@ export const modelsExtra: Record<string, ModelData> = {
     supports_pdf_input: true,
   },
 
+  // Claude Fable 5 / Mythos 5 - Released June 9, 2026
+  // Mythos-class model (a tier above Opus). Fable 5 (`claude-fable-5`) is the
+  // generally-available variant with safeguards; Mythos 5 (`claude-mythos-5`) is the same
+  // underlying model with some safeguards lifted, restricted to trusted-access partners.
+  // Both are priced identically: $10/M input, $50/M output. Cache pricing is inferred from
+  // Anthropic's standard ratios (cache write 1.25× input, cache read 0.1× input), matching
+  // the Opus 4.x shape. Native 1M context, 128K max output, native xhigh effort level.
+  "claude-fable-5": {
+    max_input_tokens: 1000000,
+    max_output_tokens: 128000,
+    input_cost_per_token: 0.00001, // $10 per million input tokens
+    output_cost_per_token: 0.00005, // $50 per million output tokens
+    cache_creation_input_token_cost: 0.0000125, // $12.50 per million tokens (1.25× input)
+    cache_read_input_token_cost: 0.000001, // $1.00 per million tokens (0.1× input)
+    litellm_provider: "anthropic",
+    mode: "chat",
+    supports_function_calling: true,
+    supports_vision: true,
+    supports_pdf_input: true,
+    supports_reasoning: true,
+    supports_response_schema: true,
+  },
+
+  // Same underlying model as Fable 5 (identical pricing/shape); restricted access.
+  "claude-mythos-5": {
+    max_input_tokens: 1000000,
+    max_output_tokens: 128000,
+    input_cost_per_token: 0.00001, // $10 per million input tokens
+    output_cost_per_token: 0.00005, // $50 per million output tokens
+    cache_creation_input_token_cost: 0.0000125, // $12.50 per million tokens (1.25× input)
+    cache_read_input_token_cost: 0.000001, // $1.00 per million tokens (0.1× input)
+    litellm_provider: "anthropic",
+    mode: "chat",
+    supports_function_calling: true,
+    supports_vision: true,
+    supports_pdf_input: true,
+    supports_reasoning: true,
+    supports_response_schema: true,
+  },
+
   // Claude Opus 4.8 - Released May 28, 2026
   // Same pricing/shape as Opus 4.7: $5/M input, $25/M output, native 1M context,
   // 128K max output, native xhigh effort level. Defaults to high effort on all

--- a/src/node/services/agentSkills/builtInSkillContent.generated.ts
+++ b/src/node/services/agentSkills/builtInSkillContent.generated.ts
@@ -2158,6 +2158,7 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
       "",
       "| Model                  | ID                            | Aliases                                                      | Default |",
       "| ---------------------- | ----------------------------- | ------------------------------------------------------------ | ------- |",
+      "| Fable 5                | anthropic:claude-fable-5      | `fable`                                                      |         |",
       "| Opus 4.8               | anthropic:claude-opus-4-8     | `opus`                                                       | ✓       |",
       "| Sonnet 4.6             | anthropic:claude-sonnet-4-6   | `sonnet`                                                     |         |",
       "| Haiku 4.5              | anthropic:claude-haiku-4-5    | `haiku`                                                      |         |",


### PR DESCRIPTION
## Summary

Adds first-class support for **Claude Fable 5** (`anthropic:claude-fable-5`), Anthropic's new Mythos-class model launched June 9, 2026, plus token/pricing metadata for its restricted-access twin **Mythos 5** (`claude-mythos-5`). Fable 5 surfaces in the model picker via the `fable` alias and inherits the full 6-level thinking policy, native 1M context, and native `xhigh` effort handling.

## Background

[Anthropic's announcement](https://www.anthropic.com/news/claude-fable-5-mythos-5) introduces the Mythos-class tier, which sits a step above Opus. Fable 5 is the generally-available variant (with safeguards that transparently fall back to Opus 4.8 server-side on a small fraction of sessions); Mythos 5 is the same underlying model with some safeguards lifted, restricted to trusted-access partners. Both are priced at **$10/M input, $50/M output**.

## Implementation

- **`knownModels.ts`** — new curated `FABLE` entry (`fable` alias, warmed tokenizer, reuses Opus 4.5 tokenizer for approximate counting). This automatically propagates to the model picker, settings, docs (`config/models.mdx`), and the embedded built-in skill content (both regenerated via `make fmt`).
- **`models-extra.ts`** — pricing/capability metadata for both `claude-fable-5` and `claude-mythos-5` (1M input, 128K output, vision + PDF + reasoning). Cache pricing inferred from Anthropic's standard ratios (write 1.25× input, read 0.1× input).
- **`modelDisplay.ts`** — added `fable`/`mythos` to the recognized Claude tiers so ids render as `Fable 5` / `Mythos 5`.
- **`thinking.ts`** — `anthropicSupportsNativeXhigh` now matches the Mythos-class models, granting them the native `xhigh` effort level and the full 6-level thinking policy (`off…max`).
- **`models.ts`** — added Fable 5 / Mythos 5 to the native-1M-context patterns.

## Validation

- Added behavioral tests for native 1M classification, display formatting, and the 6-level thinking policy.
- `make static-check` green (incl. docs/skill generation sync); targeted suites (`models`, `modelDisplay`, `policy`, `knownModels`) pass — 126 tests.

## Risks

Low. Changes are additive model-registry/metadata entries plus regex extensions that already account for future Opus versions; no existing model behavior changes.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-8` • Thinking: `xhigh` • Cost: `$2.42`_

<!-- mux-attribution: model=anthropic:claude-opus-4-8 thinking=xhigh costs=2.42 -->
