### PR TITLE
🤖 feat: structured UI for workflow_action_list tool calls

### DIFF
--- a/src/browser/features/Tools/Shared/ToolPrimitives.tsx
+++ b/src/browser/features/Tools/Shared/ToolPrimitives.tsx
@@ -31,6 +31,7 @@ import {
   Square,
   Target,
   Wrench,
+  Zap,
 } from "lucide-react";
 import { EmojiIcon } from "@/browser/components/icons/EmojiIcon/EmojiIcon";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/browser/components/Tooltip/Tooltip";
@@ -239,6 +240,7 @@ export const TOOL_NAME_TO_ICON: Partial<Record<string, LucideIcon>> = {
   workflow_list: List,
   workflow_read: BookOpen,
   workflow_run: Sparkles,
+  workflow_action_list: Zap,
   agent_report: FileText,
   agent_skill_read: GraduationCap,
   agent_skill_read_file: GraduationCap,

--- a/src/browser/features/Tools/Shared/getToolComponent.ts
+++ b/src/browser/features/Tools/Shared/getToolComponent.ts
@@ -43,6 +43,7 @@ import { TaskApplyGitPatchToolCall } from "../TaskApplyGitPatchToolCall";
 import { GetGoalToolCall } from "../GetGoalToolCall";
 import { WorkflowRunToolCall } from "../WorkflowRunToolCall";
 import { WorkflowListToolCall, WorkflowReadToolCall } from "../WorkflowDefinitionToolCall";
+import { WorkflowActionListToolCall } from "../WorkflowActionListToolCall";
 import { CompleteGoalToolCall } from "../CompleteGoalToolCall";
 
 /**
@@ -177,6 +178,10 @@ const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
   workflow_run: {
     component: WorkflowRunToolCall,
     schema: TOOL_DEFINITIONS.workflow_run.schema,
+  },
+  workflow_action_list: {
+    component: WorkflowActionListToolCall,
+    schema: TOOL_DEFINITIONS.workflow_action_list.schema,
   },
   agent_report: {
     component: AgentReportToolCall,

--- a/src/browser/features/Tools/WorkflowActionListToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowActionListToolCall.test.tsx
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { GlobalWindow } from "happy-dom";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import type React from "react";
+
+import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
+import { ThemeProvider } from "@/browser/contexts/ThemeContext";
+import { WorkflowActionListToolCall } from "./WorkflowActionListToolCall";
+
+function renderWithTooltip(ui: React.ReactElement) {
+  return render(
+    <ThemeProvider forcedTheme="dark">
+      <TooltipProvider>{ui}</TooltipProvider>
+    </ThemeProvider>
+  );
+}
+
+describe("WorkflowActionListToolCall", () => {
+  let originalWindow: typeof globalThis.window;
+  let originalDocument: typeof globalThis.document;
+  let originalLocalStorage: typeof globalThis.localStorage;
+
+  beforeEach(() => {
+    originalWindow = globalThis.window;
+    originalDocument = globalThis.document;
+    originalLocalStorage = globalThis.localStorage;
+    globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
+    globalThis.document = globalThis.window.document;
+    globalThis.localStorage = globalThis.window.localStorage;
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.window = originalWindow;
+    globalThis.document = originalDocument;
+    globalThis.localStorage = originalLocalStorage;
+  });
+
+  test("renders action rows with effect and blocked badges", () => {
+    const view = renderWithTooltip(
+      <WorkflowActionListToolCall
+        args={{}}
+        status="completed"
+        result={{
+          actions: [
+            {
+              name: "git.changedFiles",
+              scope: "built-in",
+              sourcePath: "/__mux_builtin_workflow_actions__/git/changedFiles.js",
+              executable: true,
+              hasReconcile: false,
+              metadata: {
+                version: 1,
+                description: "Return changed file lists.",
+                effect: "read",
+              },
+            },
+            {
+              name: "audit.scan",
+              scope: "project",
+              sourcePath: "/repo/.mux/workflows/actions/audit/scan.js",
+              executable: false,
+              blockedReason: "Project is not trusted",
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(view.getByText("2 actions")).toBeTruthy();
+    expect(view.getByText("git.changedFiles")).toBeTruthy();
+    expect(view.getByText("read")).toBeTruthy();
+    expect(view.getByText("blocked")).toBeTruthy();
+    // Blocked actions surface their reason in the row description slot.
+    expect(view.getByText("Project is not trusted")).toBeTruthy();
+  });
+
+  test("expanding a row reveals source path and schemas", () => {
+    const view = renderWithTooltip(
+      <WorkflowActionListToolCall
+        args={{}}
+        status="completed"
+        result={{
+          actions: [
+            {
+              name: "git.changedFiles",
+              scope: "built-in",
+              sourcePath: "/__mux_builtin_workflow_actions__/git/changedFiles.js",
+              executable: true,
+              hasReconcile: true,
+              metadata: {
+                version: 1,
+                description: "Return changed file lists.",
+                effect: "read",
+                inputSchema: { type: "object" },
+                timeoutMs: 60_000,
+              },
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(view.queryByText("Input schema")).toBeNull();
+
+    fireEvent.click(view.getByRole("button", { expanded: false }));
+
+    expect(view.getByText("/__mux_builtin_workflow_actions__/git/changedFiles.js")).toBeTruthy();
+    expect(view.getByText("Input schema")).toBeTruthy();
+    expect(view.queryByText("Output schema")).toBeNull();
+    expect(view.getByText("reconcile")).toBeTruthy();
+    expect(view.getByText("timeout 1m")).toBeTruthy();
+  });
+});

--- a/src/browser/features/Tools/WorkflowActionListToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowActionListToolCall.tsx
@@ -1,0 +1,194 @@
+import React, { useState } from "react";
+
+import type { WorkflowActionDescriptor, WorkflowActionEffect } from "@/common/types/workflow";
+import type {
+  WorkflowActionListToolArgs,
+  WorkflowActionListToolResult,
+  WorkflowActionListToolSuccessResult,
+} from "@/common/types/tools";
+import { formatDuration } from "@/common/utils/formatDuration";
+
+import {
+  ErrorBox,
+  ExpandIcon,
+  StatusIndicator,
+  ToolContainer,
+  ToolDetails,
+  ToolHeader,
+  ToolIcon,
+  ToolName,
+} from "./Shared/ToolPrimitives";
+import {
+  getStatusDisplay,
+  isToolErrorResult,
+  type ToolStatus,
+  useToolExpansion,
+} from "./Shared/toolUtils";
+import {
+  WorkflowBadge,
+  WorkflowJsonBlock,
+  WorkflowKindBadge,
+  WorkflowLoadingState,
+  WorkflowSection,
+} from "./WorkflowDefinitionToolCall";
+
+interface WorkflowActionListToolCallProps {
+  args: WorkflowActionListToolArgs;
+  result?: WorkflowActionListToolResult;
+  status?: ToolStatus;
+}
+
+/** Risk-ordered tones: reads are safe, workspace mutates local state, external leaves the machine. */
+const EFFECT_TONE: Record<WorkflowActionEffect, "success" | "normal" | "warning"> = {
+  read: "success",
+  workspace: "normal",
+  external: "warning",
+};
+
+function formatWorkflowActionCount(count: number): string {
+  return count === 1 ? "1 action" : `${count} actions`;
+}
+
+function WorkflowActionDetails(props: { descriptor: WorkflowActionDescriptor }) {
+  const action = props.descriptor;
+  return (
+    <div className="px-2 pb-2 pl-7">
+      <div className="text-muted truncate font-mono text-[10px]" title={action.sourcePath}>
+        {action.sourcePath}
+      </div>
+      {action.executable ? (
+        <>
+          <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+            <WorkflowBadge>v{action.metadata.version}</WorkflowBadge>
+            {action.metadata.timeoutMs != null && (
+              <WorkflowBadge>timeout {formatDuration(action.metadata.timeoutMs)}</WorkflowBadge>
+            )}
+            {action.hasReconcile && <WorkflowBadge tone="success">reconcile</WorkflowBadge>}
+          </div>
+          {action.metadata.inputSchema != null && (
+            <WorkflowSection title="Input schema">
+              <WorkflowJsonBlock
+                value={action.metadata.inputSchema}
+                className="max-h-[160px]"
+                ariaLabel={`${action.name} input schema`}
+              />
+            </WorkflowSection>
+          )}
+          {action.metadata.outputSchema != null && (
+            <WorkflowSection title="Output schema">
+              <WorkflowJsonBlock
+                value={action.metadata.outputSchema}
+                className="max-h-[160px]"
+                ariaLabel={`${action.name} output schema`}
+              />
+            </WorkflowSection>
+          )}
+          {action.metadata.permissions != null && (
+            <WorkflowSection title="Permissions">
+              <WorkflowJsonBlock
+                value={action.metadata.permissions}
+                className="max-h-[160px]"
+                ariaLabel={`${action.name} permissions`}
+              />
+            </WorkflowSection>
+          )}
+        </>
+      ) : (
+        <div className="text-warning mt-1.5 text-[10px]">{action.blockedReason}</div>
+      )}
+    </div>
+  );
+}
+
+function WorkflowActionListRow(props: { descriptor: WorkflowActionDescriptor }) {
+  const action = props.descriptor;
+  // Self-contained per-row expansion: schemas are the bulk of the payload, so they
+  // stay hidden until the user drills into a specific action.
+  const [expanded, setExpanded] = useState(false);
+  const description = action.executable ? action.metadata.description : action.blockedReason;
+  return (
+    <div>
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((value) => !value)}
+        className="grid w-full cursor-pointer grid-cols-[auto_minmax(8rem,16rem)_auto_auto_minmax(0,1fr)] items-center gap-2 px-2 py-1.5 text-left hover:bg-white/5 [@container(max-width:640px)]:grid-cols-[auto_minmax(0,1fr)] [@container(max-width:640px)]:items-start"
+      >
+        <ExpandIcon expanded={expanded}>▶</ExpandIcon>
+        <span className="text-foreground truncate font-mono text-[12px] font-medium">
+          {action.name}
+        </span>
+        <WorkflowBadge>{action.scope}</WorkflowBadge>
+        {action.executable ? (
+          <WorkflowBadge tone={EFFECT_TONE[action.metadata.effect]}>
+            {action.metadata.effect}
+          </WorkflowBadge>
+        ) : (
+          <WorkflowBadge tone="warning">blocked</WorkflowBadge>
+        )}
+        <span className="text-muted truncate text-[11px]" title={description}>
+          {description}
+        </span>
+      </button>
+      {expanded && <WorkflowActionDetails descriptor={action} />}
+    </div>
+  );
+}
+
+function WorkflowActionList(props: { actions: WorkflowActionDescriptor[] }) {
+  return (
+    <div className="border-border bg-background/20 rounded border">
+      <div className="divide-border/60 divide-y">
+        {props.actions.map((action) => (
+          <WorkflowActionListRow key={`${action.scope}:${action.name}`} descriptor={action} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function isWorkflowActionListSuccessResult(
+  value: WorkflowActionListToolResult | undefined
+): value is WorkflowActionListToolSuccessResult {
+  return value != null && !isToolErrorResult(value);
+}
+
+export const WorkflowActionListToolCall: React.FC<WorkflowActionListToolCallProps> = ({
+  result,
+  status = "pending",
+}) => {
+  const { expanded, toggleExpanded } = useToolExpansion(true);
+  const errorResult = isToolErrorResult(result) ? result : null;
+  const successResult = isWorkflowActionListSuccessResult(result) ? result : null;
+  const actions = successResult?.actions ?? [];
+
+  return (
+    <ToolContainer expanded={expanded}>
+      <ToolHeader onClick={toggleExpanded}>
+        <ExpandIcon expanded={expanded}>▶</ExpandIcon>
+        <ToolIcon toolName="workflow_action_list" />
+        <WorkflowKindBadge />
+        <ToolName>actions</ToolName>
+        {actions.length > 0 && (
+          <span className="text-muted text-[10px]">
+            {formatWorkflowActionCount(actions.length)}
+          </span>
+        )}
+        <StatusIndicator status={status}>{getStatusDisplay(status)}</StatusIndicator>
+      </ToolHeader>
+
+      {expanded && (
+        <ToolDetails>
+          {actions.length > 0 ? (
+            <WorkflowActionList actions={actions} />
+          ) : status === "executing" ? (
+            <WorkflowLoadingState />
+          ) : (
+            <div className="text-muted text-[11px] italic">No workflow actions returned.</div>
+          )}
+          {errorResult && <ErrorBox className="mt-2">{errorResult.error}</ErrorBox>}
+        </ToolDetails>
+      )}
+    </ToolContainer>
+  );
+};

--- a/src/browser/features/Tools/WorkflowDefinitionToolCall.stories.tsx
+++ b/src/browser/features/Tools/WorkflowDefinitionToolCall.stories.tsx
@@ -4,6 +4,7 @@ import {
   WorkflowListToolCall,
   WorkflowReadToolCall,
 } from "@/browser/features/Tools/WorkflowDefinitionToolCall";
+import { WorkflowActionListToolCall } from "@/browser/features/Tools/WorkflowActionListToolCall";
 import { lightweightMeta } from "@/browser/stories/meta.js";
 
 const source = `export default function workflow({ args, agent, phase, log }) {
@@ -47,6 +48,70 @@ export const WorkflowRead: Story = {
           executable: true,
         },
         source,
+      }}
+    />
+  ),
+};
+
+export const WorkflowActionList: Story = {
+  render: () => (
+    <WorkflowActionListToolCall
+      args={{}}
+      status="completed"
+      result={{
+        actions: [
+          {
+            name: "git.changedFiles",
+            scope: "built-in",
+            sourcePath: "/__mux_builtin_workflow_actions__/git/changedFiles.js",
+            executable: true,
+            hasReconcile: false,
+            metadata: {
+              version: 1,
+              description:
+                "Return changed file lists for branch, staged, unstaged, and untracked files.",
+              effect: "read",
+              inputSchema: { type: "object", properties: { base: { type: "string" } } },
+              outputSchema: {
+                type: "object",
+                properties: { files: { type: "array", items: { type: "string" } } },
+              },
+              timeoutMs: 60_000,
+            },
+          },
+          {
+            name: "git.commit",
+            scope: "built-in",
+            sourcePath: "/__mux_builtin_workflow_actions__/git/commit.js",
+            executable: true,
+            hasReconcile: true,
+            metadata: {
+              version: 2,
+              description: "Create a git commit from staged changes.",
+              effect: "workspace",
+            },
+          },
+          {
+            name: "slack.notify",
+            scope: "global",
+            sourcePath: "~/.mux/workflows/actions/slack/notify.js",
+            executable: true,
+            hasReconcile: false,
+            metadata: {
+              version: "2026-01-01",
+              description: "Post a message to a Slack channel via webhook.",
+              effect: "external",
+              permissions: { network: ["hooks.slack.com"] },
+            },
+          },
+          {
+            name: "audit.scan",
+            scope: "project",
+            sourcePath: "/repo/.mux/workflows/actions/audit/scan.js",
+            executable: false,
+            blockedReason: "Trust this project before running project-local actions.",
+          },
+        ],
       }}
     />
   ),

--- a/src/browser/features/Tools/WorkflowDefinitionToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowDefinitionToolCall.tsx
@@ -217,7 +217,7 @@ function isWorkflowReadSuccessResult(
   return value != null && !isToolErrorResult(value);
 }
 
-function WorkflowLoadingState() {
+export function WorkflowLoadingState() {
   return (
     <div className="text-muted text-[11px] italic">
       Waiting for workflow result


### PR DESCRIPTION
## Summary

Adds a structured renderer for `workflow_action_list` tool calls, replacing the generic raw-JSON args/result dump with a scannable, expandable action list.

## Background

`workflow_action_list` was the only workflow tool still rendered by `GenericToolCall`: two syntax-highlighted JSON blobs where schemas dominate the payload and the interesting bits (name, scope, effect, blocked state) are buried. `workflow_list`, `workflow_read`, and `workflow_run` already have purpose-built UIs.

## Implementation

- New `WorkflowActionListToolCall`, reusing the existing workflow primitives (`WorkflowBadge`, `WorkflowSection`, `WorkflowJsonBlock`, `WorkflowKindBadge`, and `WorkflowLoadingState` — now exported).
- Collapsed view: one row per action with mono name, scope badge, and an effect badge using risk-ordered tones (`read` = success, `workspace` = neutral, `external` = warning). Blocked actions show a warning `blocked` badge and surface `blockedReason` in the description slot.
- Rows expand (button with `aria-expanded`) to reveal the source path, `v{version}` / `timeout` / `reconcile` badges, and highlighted Input schema / Output schema / Permissions JSON blocks — each rendered only when present, since schemas are the bulk of the payload.
- Registered in `TOOL_REGISTRY` with the tool's Zod schema, so malformed args still fall back to the generic renderer; added a `Zap` icon mapping in `TOOL_NAME_TO_ICON`.

## Validation

- New unit tests cover badge/blocked-reason rendering and the per-row expand interaction (schemas hidden until expanded, conditional sections absent when not provided).
- New `WorkflowActionList` story exercising all badge tones, number and string versions, schemas/permissions, and a blocked action.
- Dogfooded the story in Storybook via agent-browser: verified collapsed list, expanded executable action (schemas + timeout/reconcile badges), external action (permissions), and blocked action (reason).

## Risks

Low — additive UI change scoped to one tool's transcript rendering. Schema-validated registry entry means unexpected payloads degrade to the previous generic renderer.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `max` • Cost: `$6.62`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=max costs=6.62 -->
