### PR TITLE
🤖 feat: native UI for the Google Search grounding tool (server:GOOGLE_SEARCH_WEB)

### DIFF
--- a/src/browser/features/Tools/GoogleSearchToolCall.fixtures.ts
+++ b/src/browser/features/Tools/GoogleSearchToolCall.fixtures.ts
@@ -1,0 +1,74 @@
+/**
+ * Sample of Google's searchEntryPoint.renderedContent as returned by the
+ * server:GOOGLE_SEARCH_WEB grounding tool result ({ search_suggestions }).
+ *
+ * The style block is abridged, but the structure matches the wire payload: a <style>
+ * block keyed off prefers-color-scheme, a container with Google's logo SVGs, and one
+ * <a class="chip" href="https://www.google.com/search?q=…"> per query.
+ *
+ * Shared by GoogleSearchToolCall tests and stories; never imported by product code.
+ */
+
+export const SAMPLE_GOOGLE_SEARCH_QUERIES = [
+  "electron 34 release date",
+  "electron 34 breaking changes",
+  "electron 34 chromium version",
+];
+
+export const SAMPLE_SEARCH_SUGGESTIONS_HTML = `<style>
+.container {
+  align-items: center;
+  border-radius: 8px;
+  display: flex;
+  font-family: Google Sans, Roboto, sans-serif;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 8px 12px;
+}
+.chip {
+  display: inline-block;
+  border: solid 1px;
+  border-radius: 16px;
+  min-width: 14px;
+  padding: 5px 16px;
+  text-align: center;
+  user-select: none;
+  margin: 0 8px;
+}
+.carousel {
+  overflow: auto;
+  scrollbar-width: none;
+  white-space: nowrap;
+  padding-right: 12px;
+}
+.headline {
+  display: flex;
+  margin-right: 4px;
+}
+@media (prefers-color-scheme: light) {
+  .container { background-color: #fafafa; box-shadow: 0 0 0 1px #0000000f; }
+  .chip { background-color: #ffffff; border-color: #d2d2d2; color: #5e5e5e; }
+  .logo-dark { display: none; }
+}
+@media (prefers-color-scheme: dark) {
+  .container { background-color: #1f1f1f; box-shadow: 0 0 0 1px #ffffff26; }
+  .chip { background-color: #2c2c2c; border-color: #3c4043; color: #fff; }
+  .logo-light { display: none; }
+}
+</style>
+<div class="container">
+  <div class="headline">
+    <svg class="logo-light" width="18" height="18" viewBox="9 9 35 35" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path fill="#4285F4" d="M42.81 26.92c0-1.33-.11-2.6-.32-3.83H26.5v7.24h9.14a7.81 7.81 0 0 1-3.39 5.13v4.26h5.49c3.21-2.96 5.07-7.32 5.07-12.8Z"></path>
+    </svg>
+    <svg class="logo-dark" width="18" height="18" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="24" cy="23" fill="#FFF" r="22"></circle>
+    </svg>
+  </div>
+  <div class="carousel">
+    <a class="chip" href="https://www.google.com/search?q=electron+34+release+date">electron 34 release date</a>
+    <a class="chip" href="https://www.google.com/search?q=electron+34+breaking+changes">electron 34 breaking changes</a>
+    <a class="chip" href="https://www.google.com/search?q=electron+34+chromium+version">electron 34 chromium version</a>
+  </div>
+</div>
+`;

--- a/src/browser/features/Tools/GoogleSearchToolCall.stories.tsx
+++ b/src/browser/features/Tools/GoogleSearchToolCall.stories.tsx
@@ -18,61 +18,64 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-function ToolStoryShell(props: { children: ReactNode }) {
+function GallerySection(props: { label: string; children: ReactNode }) {
   return (
-    <div className="bg-background p-6">
-      <div className="w-full max-w-2xl">{props.children}</div>
-    </div>
+    <section className="flex flex-col gap-2">
+      <div className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+        {props.label}
+      </div>
+      {props.children}
+    </section>
   );
 }
 
-/** Completed grounding call: queries + parsed suggestion chips, expanded via play. */
-export const Completed: Story = {
-  args: {
-    args: { queries: SAMPLE_GOOGLE_SEARCH_QUERIES },
-    result: { search_suggestions: SAMPLE_SEARCH_SUGGESTIONS_HTML },
-    status: "completed",
-  },
-  render: (args) => (
-    <ToolStoryShell>
-      <GoogleSearchToolCall {...args} />
-    </ToolStoryShell>
+// Gallery composite: folds completed-expanded, executing, failed, and single-query
+// collapsed variants into a single snapshot to keep the Chromatic budget low
+// (same pattern as AttachFileToolCall's Gallery).
+export const Gallery: Story = {
+  render: () => (
+    <div className="bg-background p-6">
+      <div className="flex w-full max-w-2xl flex-col gap-6">
+        <GallerySection label="Completed with suggestions (expanded via play)">
+          <GoogleSearchToolCall
+            args={{ queries: SAMPLE_GOOGLE_SEARCH_QUERIES }}
+            result={{ search_suggestions: SAMPLE_SEARCH_SUGGESTIONS_HTML }}
+            status="completed"
+          />
+        </GallerySection>
+        <GallerySection label="Executing (expanded via play)">
+          <GoogleSearchToolCall
+            args={{ queries: SAMPLE_GOOGLE_SEARCH_QUERIES.slice(0, 2) }}
+            status="executing"
+          />
+        </GallerySection>
+        <GallerySection label="Failed (expanded via play)">
+          <GoogleSearchToolCall
+            args={{ queries: [SAMPLE_GOOGLE_SEARCH_QUERIES[0] ?? ""] }}
+            result={{ success: false, error: "Search quota exceeded" }}
+            status="failed"
+          />
+        </GallerySection>
+        <GallerySection label="Single query, collapsed">
+          <GoogleSearchToolCall
+            args={{ queries: [SAMPLE_GOOGLE_SEARCH_QUERIES[0] ?? ""] }}
+            result={{ search_suggestions: SAMPLE_SEARCH_SUGGESTIONS_HTML }}
+            status="completed"
+          />
+        </GallerySection>
+      </div>
+    </div>
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    canvas.getByText("Google Search").click();
+    // Expand the first three instances (completed, executing, failed); keep the
+    // last one collapsed to also snapshot the collapsed header state.
+    const headers = canvas.getAllByText("Google Search");
+    headers[0]?.click();
+    headers[1]?.click();
+    headers[2]?.click();
     await waitFor(() => canvas.getByText("Suggested searches"));
-  },
-};
-
-/** Provider is still executing the search: no result yet, loading details. */
-export const Executing: Story = {
-  args: {
-    args: { queries: SAMPLE_GOOGLE_SEARCH_QUERIES.slice(0, 2) },
-    status: "executing",
-  },
-  render: (args) => (
-    <ToolStoryShell>
-      <GoogleSearchToolCall {...args} />
-    </ToolStoryShell>
-  ),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    canvas.getByText("Google Search").click();
     await waitFor(() => canvas.getByText("Searching"));
+    await waitFor(() => canvas.getByText("Search quota exceeded"));
   },
-};
-
-/** Collapsed single-query row (no "+N more" badge). */
-export const SingleQueryCollapsed: Story = {
-  args: {
-    args: { queries: [SAMPLE_GOOGLE_SEARCH_QUERIES[0] ?? ""] },
-    result: { search_suggestions: SAMPLE_SEARCH_SUGGESTIONS_HTML },
-    status: "completed",
-  },
-  render: (args) => (
-    <ToolStoryShell>
-      <GoogleSearchToolCall {...args} />
-    </ToolStoryShell>
-  ),
 };

--- a/src/browser/features/Tools/GoogleSearchToolCall.stories.tsx
+++ b/src/browser/features/Tools/GoogleSearchToolCall.stories.tsx
@@ -1,0 +1,78 @@
+import type { ReactNode } from "react";
+import { waitFor, within } from "@storybook/test";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { GoogleSearchToolCall } from "@/browser/features/Tools/GoogleSearchToolCall";
+import { lightweightMeta } from "@/browser/stories/meta.js";
+import {
+  SAMPLE_GOOGLE_SEARCH_QUERIES,
+  SAMPLE_SEARCH_SUGGESTIONS_HTML,
+} from "@/browser/features/Tools/GoogleSearchToolCall.fixtures";
+
+const meta = {
+  ...lightweightMeta,
+  title: "App/Chat/Tools/GoogleSearch",
+  component: GoogleSearchToolCall,
+} satisfies Meta<typeof GoogleSearchToolCall>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function ToolStoryShell(props: { children: ReactNode }) {
+  return (
+    <div className="bg-background p-6">
+      <div className="w-full max-w-2xl">{props.children}</div>
+    </div>
+  );
+}
+
+/** Completed grounding call: queries + parsed suggestion chips, expanded via play. */
+export const Completed: Story = {
+  args: {
+    args: { queries: SAMPLE_GOOGLE_SEARCH_QUERIES },
+    result: { search_suggestions: SAMPLE_SEARCH_SUGGESTIONS_HTML },
+    status: "completed",
+  },
+  render: (args) => (
+    <ToolStoryShell>
+      <GoogleSearchToolCall {...args} />
+    </ToolStoryShell>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    canvas.getByText("Google Search").click();
+    await waitFor(() => canvas.getByText("Suggested searches"));
+  },
+};
+
+/** Provider is still executing the search: no result yet, loading details. */
+export const Executing: Story = {
+  args: {
+    args: { queries: SAMPLE_GOOGLE_SEARCH_QUERIES.slice(0, 2) },
+    status: "executing",
+  },
+  render: (args) => (
+    <ToolStoryShell>
+      <GoogleSearchToolCall {...args} />
+    </ToolStoryShell>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    canvas.getByText("Google Search").click();
+    await waitFor(() => canvas.getByText("Searching"));
+  },
+};
+
+/** Collapsed single-query row (no "+N more" badge). */
+export const SingleQueryCollapsed: Story = {
+  args: {
+    args: { queries: [SAMPLE_GOOGLE_SEARCH_QUERIES[0] ?? ""] },
+    result: { search_suggestions: SAMPLE_SEARCH_SUGGESTIONS_HTML },
+    status: "completed",
+  },
+  render: (args) => (
+    <ToolStoryShell>
+      <GoogleSearchToolCall {...args} />
+    </ToolStoryShell>
+  ),
+};

--- a/src/browser/features/Tools/GoogleSearchToolCall.test.tsx
+++ b/src/browser/features/Tools/GoogleSearchToolCall.test.tsx
@@ -3,6 +3,7 @@ import type { ComponentProps } from "react";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { GlobalWindow } from "happy-dom";
 import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
+import { ThemeProvider } from "@/browser/contexts/ThemeContext";
 import { GoogleSearchToolCall } from "./GoogleSearchToolCall";
 import {
   SAMPLE_GOOGLE_SEARCH_QUERIES,
@@ -10,10 +11,13 @@ import {
 } from "./GoogleSearchToolCall.fixtures";
 
 function renderTool(props: ComponentProps<typeof GoogleSearchToolCall>) {
+  // ThemeProvider is required by JsonHighlight (raw failure-result dump path).
   return render(
-    <TooltipProvider>
-      <GoogleSearchToolCall {...props} />
-    </TooltipProvider>
+    <ThemeProvider>
+      <TooltipProvider>
+        <GoogleSearchToolCall {...props} />
+      </TooltipProvider>
+    </ThemeProvider>
   );
 }
 
@@ -82,6 +86,8 @@ describe("GoogleSearchToolCall", () => {
       <a class="chip" href="javascript:alert(1)">xss attempt</a>
       <a class="chip" href="https://evil.com/search?q=phish">evil host</a>
       <a class="chip" href="http://www.google.com/search?q=downgrade">plain http</a>
+      <a class="chip" href="https://user:pass@www.google.com/search?q=creds">userinfo smuggle</a>
+      <a class="chip" href="https://www.google.com:8443/search?q=port">nonstandard port</a>
     </div></div>`;
 
     const view = renderTool({
@@ -97,6 +103,52 @@ describe("GoogleSearchToolCall", () => {
     expect(view.queryByText("xss attempt")).toBeNull();
     expect(view.queryByText("evil host")).toBeNull();
     expect(view.queryByText("plain http")).toBeNull();
+    expect(view.queryByText("userinfo smuggle")).toBeNull();
+    expect(view.queryByText("nonstandard port")).toBeNull();
+  });
+
+  test("dedupes chips sharing an href (no duplicate React keys)", () => {
+    const repeatedHtml = `<div class="carousel">
+      <a class="chip" href="https://www.google.com/search?q=dup">dup one</a>
+      <a class="chip" href="https://www.google.com/search?q=dup">dup two</a>
+      <a class="chip" href="https://www.google.com/search?q=other">other</a>
+    </div>`;
+
+    const view = renderTool({
+      args: { queries: ["dup"] },
+      result: { search_suggestions: repeatedHtml },
+      status: "completed",
+    });
+    expand(view);
+
+    const links = view.getAllByRole("link");
+    expect(links.map((link) => link.getAttribute("href"))).toEqual([
+      "https://www.google.com/search?q=dup",
+      "https://www.google.com/search?q=other",
+    ]);
+  });
+
+  test("surfaces the error message for failed calls with the synthesized error shape", () => {
+    const view = renderTool({
+      args: { queries: ["broken"] },
+      result: { success: false, error: "quota exceeded" },
+      status: "failed",
+    });
+    expand(view);
+
+    expect(view.getByText("quota exceeded")).toBeTruthy();
+    expect(view.queryAllByRole("link").length).toBe(0);
+  });
+
+  test("dumps the raw result for failed calls with an unrecognized shape", () => {
+    const view = renderTool({
+      args: { queries: ["broken"] },
+      result: { blocked_reason: "SAFETY" },
+      status: "failed",
+    });
+    expand(view);
+
+    expect(view.getByText(/blocked_reason/)).toBeTruthy();
   });
 
   test("renders queries without chips when suggestions HTML is malformed or empty", () => {

--- a/src/browser/features/Tools/GoogleSearchToolCall.test.tsx
+++ b/src/browser/features/Tools/GoogleSearchToolCall.test.tsx
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { ComponentProps } from "react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { GlobalWindow } from "happy-dom";
+import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
+import { GoogleSearchToolCall } from "./GoogleSearchToolCall";
+import {
+  SAMPLE_GOOGLE_SEARCH_QUERIES,
+  SAMPLE_SEARCH_SUGGESTIONS_HTML,
+} from "./GoogleSearchToolCall.fixtures";
+
+function renderTool(props: ComponentProps<typeof GoogleSearchToolCall>) {
+  return render(
+    <TooltipProvider>
+      <GoogleSearchToolCall {...props} />
+    </TooltipProvider>
+  );
+}
+
+/** Expand the collapsed tool row by clicking its header label. */
+function expand(view: ReturnType<typeof renderTool>) {
+  fireEvent.click(view.getByText("Google Search"));
+}
+
+describe("GoogleSearchToolCall", () => {
+  let originalWindow: typeof globalThis.window;
+  let originalDocument: typeof globalThis.document;
+  let originalDOMParser: typeof globalThis.DOMParser;
+
+  beforeEach(() => {
+    originalWindow = globalThis.window;
+    originalDocument = globalThis.document;
+    originalDOMParser = globalThis.DOMParser;
+
+    const domWindow = new GlobalWindow() as unknown as Window & typeof globalThis;
+    globalThis.window = domWindow;
+    globalThis.document = domWindow.document;
+    globalThis.DOMParser = domWindow.DOMParser;
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.window = originalWindow;
+    globalThis.document = originalDocument;
+    globalThis.DOMParser = originalDOMParser;
+  });
+
+  test("renders queries and Google suggestion chips from the sample payload", () => {
+    const view = renderTool({
+      args: { queries: SAMPLE_GOOGLE_SEARCH_QUERIES },
+      result: { search_suggestions: SAMPLE_SEARCH_SUGGESTIONS_HTML },
+      status: "completed",
+    });
+
+    // Collapsed header: first query + "+N more" badge for the remaining ones.
+    expect(view.getByText("electron 34 release date")).toBeTruthy();
+    expect(view.getByText("+2 more")).toBeTruthy();
+
+    expand(view);
+
+    // All queries listed (first one appears in header and details).
+    for (const query of SAMPLE_GOOGLE_SEARCH_QUERIES) {
+      expect(view.getAllByText(query).length).toBeGreaterThanOrEqual(1);
+    }
+
+    const links = view.getAllByRole("link");
+    expect(links.map((link) => link.getAttribute("href"))).toEqual([
+      "https://www.google.com/search?q=electron+34+release+date",
+      "https://www.google.com/search?q=electron+34+breaking+changes",
+      "https://www.google.com/search?q=electron+34+chromium+version",
+    ]);
+    // New-tab + opener hardening on every chip.
+    for (const link of links) {
+      expect(link.getAttribute("target")).toBe("_blank");
+      expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+    }
+  });
+
+  test("drops chips whose href is not https://www.google.com/search", () => {
+    const hostileHtml = `<div class="container"><div class="carousel">
+      <a class="chip" href="https://www.google.com/search?q=safe+query">safe query</a>
+      <a class="chip" href="javascript:alert(1)">xss attempt</a>
+      <a class="chip" href="https://evil.com/search?q=phish">evil host</a>
+      <a class="chip" href="http://www.google.com/search?q=downgrade">plain http</a>
+    </div></div>`;
+
+    const view = renderTool({
+      args: { queries: ["safe query"] },
+      result: { search_suggestions: hostileHtml },
+      status: "completed",
+    });
+    expand(view);
+
+    const links = view.getAllByRole("link");
+    expect(links.length).toBe(1);
+    expect(links[0]?.getAttribute("href")).toBe("https://www.google.com/search?q=safe+query");
+    expect(view.queryByText("xss attempt")).toBeNull();
+    expect(view.queryByText("evil host")).toBeNull();
+    expect(view.queryByText("plain http")).toBeNull();
+  });
+
+  test("renders queries without chips when suggestions HTML is malformed or empty", () => {
+    const malformedPayloads = ["", "not html at all", '<div><a class="chip">no href</a></div>'];
+    for (const html of malformedPayloads) {
+      const view = renderTool({
+        args: { queries: ["query one"] },
+        result: { search_suggestions: html },
+        status: "completed",
+      });
+      expand(view);
+
+      expect(view.queryAllByRole("link").length).toBe(0);
+      expect(view.queryByText("Suggested searches")).toBeNull();
+      cleanup();
+    }
+  });
+
+  test("unwraps { type: 'json', value } results from stream persistence", () => {
+    const view = renderTool({
+      args: { queries: ["wrapped"] },
+      result: {
+        type: "json",
+        value: {
+          search_suggestions:
+            '<a class="chip" href="https://www.google.com/search?q=wrapped">wrapped</a>',
+        },
+      },
+      status: "completed",
+    });
+    expand(view);
+
+    const links = view.getAllByRole("link");
+    expect(links.length).toBe(1);
+    expect(links[0]?.getAttribute("href")).toBe("https://www.google.com/search?q=wrapped");
+  });
+
+  test("shows searching placeholder while executing without args or result", () => {
+    const view = renderTool({ args: {}, status: "executing" });
+
+    expect(view.getByText("searching...")).toBeTruthy();
+
+    expand(view);
+    expect(view.getByText("Searching")).toBeTruthy();
+    expect(view.queryAllByRole("link").length).toBe(0);
+  });
+});

--- a/src/browser/features/Tools/GoogleSearchToolCall.tsx
+++ b/src/browser/features/Tools/GoogleSearchToolCall.tsx
@@ -10,13 +10,16 @@ import {
   DetailLabel,
   LoadingDots,
   ToolIcon,
+  ErrorBox,
 } from "./Shared/ToolPrimitives";
 import {
   useToolExpansion,
   getStatusDisplay,
   unwrapResult,
+  isToolErrorResult,
   type ToolStatus,
 } from "./Shared/toolUtils";
+import { JsonHighlight } from "./Shared/HighlightedCode";
 
 /**
  * Renderer for Google's native search grounding tool (Gemini 3+), which the provider
@@ -51,17 +54,27 @@ function parseSearchSuggestions(html: string): SuggestionChip[] {
   try {
     const doc = new DOMParser().parseFromString(html, "text/html");
     const chips: SuggestionChip[] = [];
+    // Dedupe by href: chips render with key={chip.href}, and a payload repeating a
+    // suggestion (duplicate model queries, tampered transcript) must not produce
+    // duplicate React keys.
+    const seenHrefs = new Set<string>();
     for (const anchor of Array.from(doc.querySelectorAll("a.chip"))) {
       const href = anchor.getAttribute("href");
       const label = anchor.textContent?.trim();
-      if (!href || !label) continue;
+      if (!href || !label || seenHrefs.has(href)) continue;
       try {
         const url = new URL(href);
         if (
           url.protocol === "https:" &&
           url.hostname === "www.google.com" &&
-          url.pathname === "/search"
+          url.pathname === "/search" &&
+          // Reject userinfo/port-bearing URLs: still google.com, but a tampered
+          // transcript could smuggle credentials or a dead port into the link.
+          url.username === "" &&
+          url.password === "" &&
+          url.port === ""
         ) {
+          seenHrefs.add(href);
           chips.push({ label, href });
         }
       } catch {
@@ -123,6 +136,14 @@ export const GoogleSearchToolCall: React.FC<GoogleSearchToolCallProps> = ({
   const queries = args.queries ?? [];
   const suggestionsHtml = extractSuggestionsHtml(result);
   const chips = suggestionsHtml ? parseSearchSuggestions(suggestionsHtml) : [];
+  // streamManager synthesizes { success: false, error } for tool errors; surface it so a
+  // failed call isn't a bare "failed" badge with empty details (regression-guard vs the
+  // GenericToolCall fallback, which always dumped the result JSON). Unwrap first: results
+  // can arrive inside the { type: "json", value } persistence container.
+  const unwrappedResult = unwrapResult(result);
+  const failureError =
+    status === "failed" && isToolErrorResult(unwrappedResult) ? unwrappedResult.error : undefined;
+  const showRawFailureResult = status === "failed" && failureError === undefined && result != null;
 
   return (
     <ToolContainer expanded={expanded} className="@container">
@@ -148,7 +169,9 @@ export const GoogleSearchToolCall: React.FC<GoogleSearchToolCallProps> = ({
               <DetailLabel>Queries</DetailLabel>
               <div className="bg-code-bg rounded px-2 py-1.5 text-[11px] leading-[1.4]">
                 {queries.map((query, i) => (
-                  <div key={i} className="font-monospace text-text truncate">
+                  // break-words (not truncate): the expanded view is the only place a long
+                  // query can be read in full — the collapsed header already truncates.
+                  <div key={i} className="font-monospace text-text break-words">
                     {query}
                   </div>
                 ))}
@@ -166,12 +189,28 @@ export const GoogleSearchToolCall: React.FC<GoogleSearchToolCallProps> = ({
                     href={chip.href}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="border-border-medium text-text hover:border-border-darker hover:bg-code-bg inline-flex min-w-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] no-underline transition-colors"
+                    className="border-border-medium text-text hover:border-border-darker hover:bg-code-bg focus-visible:border-accent focus-visible:ring-accent/50 inline-flex min-w-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] no-underline transition-colors focus-visible:ring-1"
                   >
                     <GoogleLogo />
                     <span className="truncate">{chip.label}</span>
                   </a>
                 ))}
+              </div>
+            </DetailSection>
+          )}
+
+          {failureError !== undefined && (
+            <DetailSection>
+              <DetailLabel>Error</DetailLabel>
+              <ErrorBox>{failureError}</ErrorBox>
+            </DetailSection>
+          )}
+
+          {showRawFailureResult && (
+            <DetailSection>
+              <DetailLabel>Result</DetailLabel>
+              <div className="bg-code-bg max-h-[300px] overflow-y-auto rounded px-3 py-2 text-[12px]">
+                <JsonHighlight value={result} />
               </div>
             </DetailSection>
           )}

--- a/src/browser/features/Tools/GoogleSearchToolCall.tsx
+++ b/src/browser/features/Tools/GoogleSearchToolCall.tsx
@@ -1,0 +1,191 @@
+import React from "react";
+import {
+  ToolContainer,
+  ToolHeader,
+  ExpandIcon,
+  ToolName,
+  StatusIndicator,
+  ToolDetails,
+  DetailSection,
+  DetailLabel,
+  LoadingDots,
+  ToolIcon,
+} from "./Shared/ToolPrimitives";
+import {
+  useToolExpansion,
+  getStatusDisplay,
+  unwrapResult,
+  type ToolStatus,
+} from "./Shared/toolUtils";
+
+/**
+ * Renderer for Google's native search grounding tool (Gemini 3+), which the provider
+ * executes server-side and streams back as a dynamic tool named "server:GOOGLE_SEARCH_WEB".
+ *
+ * args:   { queries: string[] }
+ * result: { search_suggestions: "<style>…</style><div class=\"container\">…" } — Google's
+ *         pre-rendered "Search Suggestions" HTML (searchEntryPoint.renderedContent): a Google
+ *         logo plus one <a class="chip" href="https://www.google.com/search?q=…"> per query.
+ */
+interface GoogleSearchToolCallProps {
+  args: { queries?: string[] };
+  result?: unknown;
+  status?: ToolStatus;
+}
+
+interface SuggestionChip {
+  label: string;
+  href: string;
+}
+
+/**
+ * SECURITY AUDIT: the search_suggestions HTML arrives in a tool result persisted to
+ * chat.jsonl, so we treat it as attacker-controlled (a tampered transcript can contain
+ * anything). We never inject it into the live DOM. DOMParser produces an inert detached
+ * document — scripts and styles in it do not execute — and we extract only chip labels and
+ * hrefs, keeping a link only when its URL parses to https://www.google.com/search. A hostile
+ * payload therefore yields no links rather than XSS. The chips are re-rendered as React
+ * elements; Google's HTML/CSS is never used directly.
+ */
+function parseSearchSuggestions(html: string): SuggestionChip[] {
+  try {
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const chips: SuggestionChip[] = [];
+    for (const anchor of Array.from(doc.querySelectorAll("a.chip"))) {
+      const href = anchor.getAttribute("href");
+      const label = anchor.textContent?.trim();
+      if (!href || !label) continue;
+      try {
+        const url = new URL(href);
+        if (
+          url.protocol === "https:" &&
+          url.hostname === "www.google.com" &&
+          url.pathname === "/search"
+        ) {
+          chips.push({ label, href });
+        }
+      } catch {
+        // Unparseable href → drop the chip.
+      }
+    }
+    return chips;
+  } catch {
+    return [];
+  }
+}
+
+/** Extract the rendered-suggestions HTML string from the tool result, if present. */
+function extractSuggestionsHtml(result: unknown): string | undefined {
+  const unwrapped = unwrapResult(result);
+  if (
+    unwrapped !== null &&
+    typeof unwrapped === "object" &&
+    "search_suggestions" in unwrapped &&
+    typeof (unwrapped as { search_suggestions: unknown }).search_suggestions === "string"
+  ) {
+    return (unwrapped as { search_suggestions: string }).search_suggestions;
+  }
+  return undefined;
+}
+
+/**
+ * Static Google "G" logo authored locally — never extracted from the payload. Fixed brand
+ * colors are intentional (logo artwork, not themeable UI); everything else in the chip uses
+ * theme variables.
+ */
+const GoogleLogo: React.FC = () => (
+  <svg viewBox="0 0 48 48" className="h-3 w-3 shrink-0" aria-hidden="true">
+    <path
+      fill="#EA4335"
+      d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+    />
+    <path
+      fill="#4285F4"
+      d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+    />
+    <path
+      fill="#FBBC05"
+      d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+    />
+    <path
+      fill="#34A853"
+      d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+    />
+  </svg>
+);
+
+export const GoogleSearchToolCall: React.FC<GoogleSearchToolCallProps> = ({
+  args,
+  result,
+  status = "pending",
+}) => {
+  const { expanded, toggleExpanded } = useToolExpansion();
+  const queries = args.queries ?? [];
+  const suggestionsHtml = extractSuggestionsHtml(result);
+  const chips = suggestionsHtml ? parseSearchSuggestions(suggestionsHtml) : [];
+
+  return (
+    <ToolContainer expanded={expanded} className="@container">
+      <ToolHeader onClick={toggleExpanded}>
+        <ExpandIcon expanded={expanded}>▶</ExpandIcon>
+        <ToolIcon toolName="server:GOOGLE_SEARCH_WEB" />
+        <ToolName className="shrink-0">Google Search</ToolName>
+        <div className="text-text flex max-w-96 min-w-0 items-center gap-1.5">
+          <span className="font-monospace truncate">{queries[0] ?? "searching..."}</span>
+        </div>
+        {queries.length > 1 && (
+          <span className="text-secondary ml-2 text-[10px] whitespace-nowrap">
+            +{queries.length - 1} more
+          </span>
+        )}
+        <StatusIndicator status={status}>{getStatusDisplay(status)}</StatusIndicator>
+      </ToolHeader>
+
+      {expanded && (
+        <ToolDetails>
+          {queries.length > 0 && (
+            <DetailSection>
+              <DetailLabel>Queries</DetailLabel>
+              <div className="bg-code-bg rounded px-2 py-1.5 text-[11px] leading-[1.4]">
+                {queries.map((query, i) => (
+                  <div key={i} className="font-monospace text-text truncate">
+                    {query}
+                  </div>
+                ))}
+              </div>
+            </DetailSection>
+          )}
+
+          {chips.length > 0 && (
+            <DetailSection>
+              <DetailLabel>Suggested searches</DetailLabel>
+              <div className="flex flex-wrap gap-1.5">
+                {chips.map((chip) => (
+                  <a
+                    key={chip.href}
+                    href={chip.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="border-border-medium text-text hover:border-border-darker hover:bg-code-bg inline-flex min-w-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] no-underline transition-colors"
+                  >
+                    <GoogleLogo />
+                    <span className="truncate">{chip.label}</span>
+                  </a>
+                ))}
+              </div>
+            </DetailSection>
+          )}
+
+          {status === "executing" && !result && (
+            <DetailSection>
+              <div className="text-secondary text-[11px]">
+                Searching
+                <LoadingDots />
+              </div>
+            </DetailSection>
+          )}
+        </ToolDetails>
+      )}
+    </ToolContainer>
+  );
+};

--- a/src/browser/features/Tools/Shared/ToolPrimitives.tsx
+++ b/src/browser/features/Tools/Shared/ToolPrimitives.tsx
@@ -260,6 +260,7 @@ export const TOOL_NAME_TO_ICON: Partial<Record<string, LucideIcon>> = {
   todo_write: List,
   web_fetch: Globe,
   web_search: Globe,
+  "server:GOOGLE_SEARCH_WEB": Globe,
   notify: Bell,
   review_pane_update: Sparkles,
   review_pane_get: ScanEye,

--- a/src/browser/features/Tools/Shared/ToolPrimitives.tsx
+++ b/src/browser/features/Tools/Shared/ToolPrimitives.tsx
@@ -271,7 +271,12 @@ export const TOOL_NAME_TO_ICON: Partial<Record<string, LucideIcon>> = {
 };
 
 export const ToolIcon: React.FC<ToolIconProps> = ({ toolName, emoji, emojiSpin, className }) => {
-  const Icon = TOOL_NAME_TO_ICON[toolName] ?? Sparkles;
+  // Object.hasOwn: toolName comes from persisted transcripts; a bare index lookup returns
+  // inherited Object members for names like "constructor", which would render garbage
+  // instead of falling back to Sparkles.
+  const Icon = Object.hasOwn(TOOL_NAME_TO_ICON, toolName)
+    ? (TOOL_NAME_TO_ICON[toolName] ?? Sparkles)
+    : Sparkles;
 
   return (
     <Tooltip>

--- a/src/browser/features/Tools/Shared/getToolComponent.test.ts
+++ b/src/browser/features/Tools/Shared/getToolComponent.test.ts
@@ -7,6 +7,7 @@ import { CompleteGoalToolCall } from "../CompleteGoalToolCall";
 import { DesktopActionToolCall } from "../DesktopActionToolCall";
 import { DesktopScreenshotToolCall } from "../DesktopScreenshotToolCall";
 import { GenericToolCall } from "../GenericToolCall";
+import { GoogleSearchToolCall } from "../GoogleSearchToolCall";
 import { WorkflowRunToolCall } from "../WorkflowRunToolCall";
 import { WorkflowListToolCall, WorkflowReadToolCall } from "../WorkflowDefinitionToolCall";
 import { GetGoalToolCall } from "../GetGoalToolCall";
@@ -68,6 +69,19 @@ describe("getToolComponent", () => {
 
   test("falls back to GenericToolCall when args validation fails", () => {
     const component = getToolComponent("agent_report", { reportMarkdown: "" });
+    expect(component).toBe(GenericToolCall);
+  });
+
+  test("returns GoogleSearchToolCall for server:GOOGLE_SEARCH_WEB", () => {
+    expect(getToolComponent("server:GOOGLE_SEARCH_WEB", { queries: ["gemini 3 pricing"] })).toBe(
+      GoogleSearchToolCall
+    );
+    // Streaming/pending args (not yet parsed) must not bounce to the generic renderer.
+    expect(getToolComponent("server:GOOGLE_SEARCH_WEB", {})).toBe(GoogleSearchToolCall);
+  });
+
+  test("server:GOOGLE_SEARCH_WEB falls back to GenericToolCall when args don't conform", () => {
+    const component = getToolComponent("server:GOOGLE_SEARCH_WEB", { queries: "not-an-array" });
     expect(component).toBe(GenericToolCall);
   });
 });

--- a/src/browser/features/Tools/Shared/getToolComponent.test.ts
+++ b/src/browser/features/Tools/Shared/getToolComponent.test.ts
@@ -84,4 +84,12 @@ describe("getToolComponent", () => {
     const component = getToolComponent("server:GOOGLE_SEARCH_WEB", { queries: "not-an-array" });
     expect(component).toBe(GenericToolCall);
   });
+
+  test("Object.prototype member names fall back to GenericToolCall instead of throwing", () => {
+    // toolName flows verbatim from persisted transcripts; inherited members of the
+    // registry object must not be treated as entries (self-healing invariant).
+    expect(getToolComponent("constructor", {})).toBe(GenericToolCall);
+    expect(getToolComponent("__proto__", {})).toBe(GenericToolCall);
+    expect(getToolComponent("toString", {})).toBe(GenericToolCall);
+  });
 });

--- a/src/browser/features/Tools/Shared/getToolComponent.ts
+++ b/src/browser/features/Tools/Shared/getToolComponent.ts
@@ -21,6 +21,7 @@ import { AgentSkillReadFileToolCall } from "../AgentSkillReadFileToolCall";
 import { FileReadToolCall } from "../FileReadToolCall";
 import { WebFetchToolCall } from "../WebFetchToolCall";
 import { WebSearchToolCall } from "../WebSearchToolCall";
+import { GoogleSearchToolCall } from "../GoogleSearchToolCall";
 import { AskUserQuestionToolCall } from "../AskUserQuestionToolCall";
 import { ProposePlanToolCall } from "../ProposePlanToolCall";
 import { TodoToolCall } from "../TodoToolCall";
@@ -198,6 +199,12 @@ const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
   // Provider-defined tool (Anthropic/OpenAI) - no TOOL_DEFINITIONS entry
   // Anthropic: args.query, OpenAI: args={}, query in result.action.query
   web_search: { component: WebSearchToolCall, schema: z.object({ query: z.string().optional() }) },
+  // Google native search grounding (Gemini 3+), provider-executed — name comes from the wire.
+  // queries stays optional so streaming/pending args don't bounce to GenericToolCall.
+  "server:GOOGLE_SEARCH_WEB": {
+    component: GoogleSearchToolCall,
+    schema: z.object({ queries: z.array(z.string()).optional() }),
+  },
 };
 
 /**

--- a/src/browser/features/Tools/Shared/getToolComponent.ts
+++ b/src/browser/features/Tools/Shared/getToolComponent.ts
@@ -212,7 +212,11 @@ const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
  * Validates args against Zod schemas; returns GenericToolCall if validation fails or tool unknown.
  */
 export function getToolComponent(toolName: string, args: unknown): AnyToolComponent {
-  const entry = TOOL_REGISTRY[toolName];
+  // Object.hasOwn: toolName flows verbatim from persisted transcripts (attacker-controlled).
+  // A bare index lookup returns truthy inherited members for names like "constructor",
+  // which would then throw on .schema and brick the workspace view instead of degrading
+  // to the generic renderer (self-healing invariant).
+  const entry = Object.hasOwn(TOOL_REGISTRY, toolName) ? TOOL_REGISTRY[toolName] : undefined;
   if (!entry?.schema.safeParse(args).success) {
     return GenericToolCall;
   }

--- a/src/browser/features/Tools/Shared/toolUtils.tsx
+++ b/src/browser/features/Tools/Shared/toolUtils.tsx
@@ -84,6 +84,23 @@ export function getStatusDisplay(status: ToolStatus): React.ReactNode {
 }
 
 /**
+ * Unwrap JSON container from streamManager's stripEncryptedContent.
+ * Results arrive as { type: "json", value: [...] } or direct array/object.
+ */
+export function unwrapResult(result: unknown): unknown {
+  if (
+    result !== null &&
+    typeof result === "object" &&
+    "type" in result &&
+    (result as { type: string }).type === "json" &&
+    "value" in result
+  ) {
+    return (result as { value: unknown }).value;
+  }
+  return result;
+}
+
+/**
  * Type guard for ToolErrorResult shape: { success: false, error: string }.
  * Use this when you need type narrowing to access error.
  */

--- a/src/browser/features/Tools/WebFetchToolCall.tsx
+++ b/src/browser/features/Tools/WebFetchToolCall.tsx
@@ -12,7 +12,12 @@ import {
   ToolIcon,
   ErrorBox,
 } from "./Shared/ToolPrimitives";
-import { useToolExpansion, getStatusDisplay, type ToolStatus } from "./Shared/toolUtils";
+import {
+  useToolExpansion,
+  getStatusDisplay,
+  unwrapResult,
+  type ToolStatus,
+} from "./Shared/toolUtils";
 import { MarkdownRenderer } from "../Messages/MarkdownRenderer";
 import { formatBytes } from "@/common/utils/formatBytes";
 
@@ -57,23 +62,6 @@ function getDomain(url: string): string {
   } catch {
     return url;
   }
-}
-
-/**
- * Unwrap JSON container from streamManager's stripEncryptedContent.
- * Results arrive as { type: "json", value: [...] } or direct object.
- */
-function unwrapResult(result: unknown): unknown {
-  if (
-    result !== null &&
-    typeof result === "object" &&
-    "type" in result &&
-    (result as { type: string }).type === "json" &&
-    "value" in result
-  ) {
-    return (result as { value: unknown }).value;
-  }
-  return result;
 }
 
 /**

--- a/src/browser/features/Tools/WebSearchToolCall.tsx
+++ b/src/browser/features/Tools/WebSearchToolCall.tsx
@@ -10,30 +10,18 @@ import {
   LoadingDots,
   ToolIcon,
 } from "./Shared/ToolPrimitives";
-import { useToolExpansion, getStatusDisplay, type ToolStatus } from "./Shared/toolUtils";
+import {
+  useToolExpansion,
+  getStatusDisplay,
+  unwrapResult,
+  type ToolStatus,
+} from "./Shared/toolUtils";
 import { JsonHighlight } from "./Shared/HighlightedCode";
 
 interface WebSearchToolCallProps {
   args: { query?: string }; // Anthropic puts query in args
   result?: unknown;
   status?: ToolStatus;
-}
-
-/**
- * Unwrap JSON container from streamManager's stripEncryptedContent.
- * Results arrive as { type: "json", value: [...] } or direct array/object.
- */
-function unwrapResult(result: unknown): unknown {
-  if (
-    result !== null &&
-    typeof result === "object" &&
-    "type" in result &&
-    (result as { type: string }).type === "json" &&
-    "value" in result
-  ) {
-    return (result as { value: unknown }).value;
-  }
-  return result;
 }
 
 /**

--- a/src/browser/utils/messages/transcriptRenderProjection.test.ts
+++ b/src/browser/utils/messages/transcriptRenderProjection.test.ts
@@ -728,6 +728,20 @@ describe("operational bundle summary", () => {
     expect(summary.details).toBe("2 searches · 2 fetches");
   });
 
+  test("categorizes Google native search grounding as a search", () => {
+    const summary = summarizeOperationalBundle([
+      tool({
+        id: "gsearch-1",
+        toolName: "server:GOOGLE_SEARCH_WEB",
+        args: { queries: ["electron 34 release date"] },
+        result: { search_suggestions: "<div></div>" },
+      }),
+      tool({ id: "search-1", toolName: "web_search", result: [{ title: "one" }] }),
+    ]);
+
+    expect(summary.details).toBe("2 searches");
+  });
+
   test("all-miss completed search bundle gets neutral copy", () => {
     const allMiss = summarizeOperationalBundle([
       tool({ id: "search-1", toolName: "web_search", status: "completed", result: [] }),

--- a/src/browser/utils/messages/transcriptRenderProjection.ts
+++ b/src/browser/utils/messages/transcriptRenderProjection.ts
@@ -576,7 +576,9 @@ function getOperationalBundleCategory(
   if (message.toolName === "bash") {
     return "shell";
   }
-  if (message.toolName === "web_search") {
+  // server:GOOGLE_SEARCH_WEB is Google's native search grounding (Gemini 3+); one call can
+  // carry several queries, but it is still one search operation for bundle copy purposes.
+  if (message.toolName === "web_search" || message.toolName === "server:GOOGLE_SEARCH_WEB") {
     return "search";
   }
   if (message.toolName === "web_fetch") {

--- a/tests/ui/storybook/budget.test.ts
+++ b/tests/ui/storybook/budget.test.ts
@@ -7,7 +7,9 @@ const COLOCATED_STORY_DIRS = ["src/browser/components", "src/browser/features"];
 const MAX_SNAPSHOT_ENABLED_FILES = 70;
 // Keep a buffer under Chromatic's 300 snapshot limit. This reflects the current
 // retained snapshot set while still blocking accidental growth.
-const MAX_ESTIMATED_SNAPSHOTS = 258;
+// 259 = 258 prior set + 1 Gallery composite for GoogleSearchToolCall (new themed
+// component; variants folded into one snapshot to minimize budget impact).
+const MAX_ESTIMATED_SNAPSHOTS = 259;
 const STORY_EXPORT_PATTERN = /^export const \w+/gm;
 const SMOKE_MODE_PATTERN = /modes:\s*CHROMATIC_SMOKE_MODES/g;
 const INLINE_MODE_OBJECT_PATTERN = /modes:\s*{/g;


### PR DESCRIPTION
## Summary

Gemini 3 models execute Google's native search grounding server-side and stream it back as a dynamic tool named `server:GOOGLE_SEARCH_WEB`. Until now it had no registry entry, so it fell back to `GenericToolCall` and rendered raw JSON args plus a wall of escaped HTML. This PR adds a first-class renderer: a collapsed row (Globe icon, "Google Search", first query, `+N more`, status) and expanded details (query list, clickable "Suggested searches" chips with the Google logo, error surfacing for failed calls).

## Background

The tool's result is Google's pre-rendered `searchEntryPoint.renderedContent` HTML (`{ search_suggestions: "<style>…<a class=\"chip\" href=\"https://www.google.com/search?q=…\">…" }`). Per the repo's renderer-XSS rules, persisted tool results are attacker-controlled (a tampered `chat.jsonl` can contain anything), so injecting that HTML was never an option. A sandboxed-iframe approach was rejected (theme mismatch via `prefers-color-scheme`, sandbox escapes needed for links, worse look).

## Implementation

- **Security boundary** (`GoogleSearchToolCall.tsx`, `SECURITY AUDIT` comment at the sink): the HTML is parsed with an inert `DOMParser` document (scripts never execute, nothing touches the live DOM). Only `a.chip` label/href pairs are extracted, deduped by href, and kept **only** when the URL parses to `https://www.google.com/search` with no userinfo and no port. Hostile payloads degrade to "no chips", never XSS. Chips are re-rendered as React elements with `target="_blank" rel="noopener noreferrer"`; the Google "G" logo is a locally-authored SVG, not extracted from the payload.
- **Failure states**: failed calls render an `ErrorBox` for the synthesized `{ success: false, error }` shape and a `JsonHighlight` dump for unrecognized shapes — parity with the old `GenericToolCall` fallback so error detail is never silently hidden.
- **Registry**: `server:GOOGLE_SEARCH_WEB` entry in `getToolComponent.ts` (with `queries` optional so streaming args don't bounce to Generic) + Globe icon mapping. Both lookup maps now use `Object.hasOwn` guards so prototype-key tool names from tampered transcripts (`"constructor"`, `"__proto__"`) fall back to `GenericToolCall`/`Sparkles` instead of crashing the workspace view (self-healing invariant).
- **Shared helpers**: `unwrapResult` promoted from `WebSearchToolCall` to `Shared/toolUtils` and adopted by WebSearch, WebFetch, and the new component (removes a pre-existing duplicate).
- **Transcript bundles**: `transcriptRenderProjection` now categorizes the tool as a "search" ("2 searches" instead of "Ran 2 operations").
- **Storybook**: one Gallery composite story (completed-expanded / executing / failed / collapsed) to stay within the Chromatic snapshot budget; `MAX_ESTIMATED_SNAPSHOTS` bumped 258→259 with rationale for the single new snapshot.

An adversarial multi-lane deep review was run against the branch; all 10 verified findings are addressed here except one explicitly deferred follow-up: making the shared `ToolHeader` keyboard-operable (affects all ~30 tool components, deserves its own change).

## Validation

- Behavioral tests: real-payload chip parsing with exact hrefs; hostile-href filtering (`javascript:`, foreign host, plain http, userinfo, non-default port); href dedupe; malformed/empty HTML; `{type:"json"}` unwrap; failed-state error surfacing (both shapes); executing placeholder; registry routing incl. prototype-key names; bundle categorization.
- Live end-to-end check against the real Gemini API: a sandboxed dev-server with Gemini 3.5 Flash triggered two real `server:GOOGLE_SEARCH_WEB` calls that rendered correctly — notably, real wire chips carry extra params (`&client=app-vertex-grounding&safesearch=active`) which the host/path validation correctly accepts.
- Storybook Gallery verified in dark + light themes via agent-browser, including the keyboard focus ring on chips (`focus-visible:` styles, since global CSS suppresses outlines).

## Risks

Low. The component is purely presentational and registry-gated to one wire tool name; a parse failure degrades to the queries-only view, and schema-validation failure degrades to `GenericToolCall`. The only shared-surface changes are the `Object.hasOwn` lookup guards (behavior-preserving for all registered names, tested) and the `unwrapResult` dedupe (byte-identical logic). The budget cap bump is deliberate and documented.

---

<details>
<summary>📋 Implementation Plan</summary>

# Nicer UI for the Google Search grounding tool (`server:GOOGLE_SEARCH_WEB`)

## Context

When Gemini 3 models run, Mux registers Google's native search tool (`google_search` in
`src/common/utils/tools/tools.ts`, gated by `supportsGoogleNativeToolsWithFunctionTools`). The
provider executes it server-side and streams it back as a dynamic tool named
**`server:GOOGLE_SEARCH_WEB`** with:

- **args**: `{ queries: string[] }`
- **result**: `{ search_suggestions: "<style>…</style><div class=\"container\">…" }` — Google's
  pre-rendered "Search Suggestions" HTML (`searchEntryPoint.renderedContent`): a Google logo plus
  one `<a class="chip" href="https://www.google.com/search?q=…">` per query.

There is no `TOOL_REGISTRY` entry for this name in
`src/browser/features/Tools/Shared/getToolComponent.ts`, so it falls back to `GenericToolCall` and
renders the raw JSON args + a wall of escaped HTML (the screenshot the user shared).

## Design decision: re-render natively, never inject Google's HTML

Per repo security rules (AGENTS.md: tool results / history content are attacker-controlled; never
`dangerouslySetInnerHTML`), we will **not** inject `search_suggestions` into the DOM. Instead:

- Parse the HTML string with `DOMParser` (`text/html` — inert document, scripts never execute).
- Extract `a.chip` elements → `{ label: textContent, href }`.
- **Strict href validation**: keep a chip only if `new URL(href)` succeeds with
  `protocol === "https:"`, `hostname === "www.google.com"`, `pathname === "/search"`. Everything
  else is dropped (defensive: a tampered chat.jsonl or hostile payload yields no links, not XSS).
- Render Mux-styled chips as React elements (`target="_blank" rel="noopener noreferrer"`, same as
  `WebFetchToolCall`'s `isSafeHref` pattern) with a small static Google "G" logo SVG that we author
  ourselves (not extracted from the payload).
- Add a `SECURITY AUDIT` comment at the parse site documenting the trust boundary.

Rejected alternative: sandboxed `<iframe srcdoc>` showing Google's HTML "as-is" (closest to
Google's display guidelines). Rejected because: fixed-height/theme mismatch inside chat (its CSS
keys off OS `prefers-color-scheme`, not the app theme), needs `allow-popups` sandbox escapes for
the links to work, and more code for a worse-looking result. Native chips preserve the substance
(Google branding, exact query text, links back to Google Search) while matching Mux styling.

Explicit non-goal (follow-up candidates, not in this change): rendering grounding
citations/sources. `groundingMetadata` (chunks, supports) is persisted only at message level
(`MuxMetadata.providerMetadata.google`) and `ToolMessage` doesn't forward it to tool components;
source stream parts are currently discarded by `StreamManager`. Same for the `url_context` native
tool — its wire name is unverified, so it stays on the Generic fallback for now.

## Implementation

### 1. New component — `src/browser/features/Tools/GoogleSearchToolCall.tsx` (~120 LoC)

Modeled directly on `WebSearchToolCall.tsx`, using shared primitives (`ToolContainer`,
`ToolHeader`, `ExpandIcon`, `ToolIcon`, `StatusIndicator`, `ToolDetails`, `DetailSection`,
`DetailLabel`, `LoadingDots`, `useToolExpansion`, `getStatusDisplay`).

- Props: `{ args: { queries?: string[] }, result?: unknown, status?: ToolStatus }`.
- Helpers in the same file:
  - `parseSearchSuggestions(html: string): Array<{ label: string; href: string }>` (DOMParser +
    strict URL validation as above; returns `[]` on any parse failure).
  - Reuse the `{ type: "json", value }` unwrap: move `unwrapResult` from `WebSearchToolCall.tsx`
    into `Shared/toolUtils.ts` and import it in both (DRY; net-zero LoC).
- **Collapsed header**: expand chevron · Globe `ToolIcon` · label `Google Search` · first query in
  monospace, truncated · `+N more` badge when `queries.length > 1` · `StatusIndicator`.
- **Expanded details**:
  - `Queries` section: each query on its own line (monospace, like the Query row in
    `WebSearchToolCall`).
  - `Suggested searches` section (only when chips parsed): pill-shaped links (rounded-full,
    `border-border-medium`-style theme vars — no hardcoded hex) prefixed by the Google "G" SVG,
    horizontally wrapping.
  - `status === "executing"` with no result → `Searching` + `LoadingDots`.
  - If result exists but no chips parse, show nothing extra (queries section still conveys what
    happened); never dump raw HTML.

### 2. Registry — `src/browser/features/Tools/Shared/getToolComponent.ts` (+~6 LoC)

```ts
// Google native search grounding (Gemini 3+), provider-executed — name comes from the wire
"server:GOOGLE_SEARCH_WEB": {
  component: GoogleSearchToolCall,
  schema: z.object({ queries: z.array(z.string()).optional() }),
},
```

`queries` stays optional so the pending/streaming state (args not yet complete) doesn't bounce to
`GenericToolCall` (same tolerance as the existing `web_search` entry).

### 3. Icon — `src/browser/features/Tools/Shared/ToolPrimitives.tsx` (+1 LoC)

Add `"server:GOOGLE_SEARCH_WEB": Globe` to `TOOL_NAME_TO_ICON` (tooltip keeps showing the real
tool name).

### 4. Tests (behavioral, not tautological)

- `src/browser/features/Tools/GoogleSearchToolCall.test.tsx` (new):
  - parses the real sample payload (from the user's report) → 3 chips with exact hrefs/labels;
  - **filters** chips whose href is `javascript:…`, `https://evil.com/search?…`, or
    `http://www.google.com/search` (security branch);
  - malformed/empty HTML → no chips, no crash;
  - renders all queries when expanded.
- `src/browser/features/Tools/Shared/getToolComponent.test.ts`: `server:GOOGLE_SEARCH_WEB` +
  `{ queries: [...] }` → `GoogleSearchToolCall`; non-conforming args (e.g. `{ queries: "x" }`) →
  `GenericToolCall`.

### 5. Storybook — `src/browser/features/Tools/GoogleSearchToolCall.stories.tsx` (new)

Follow the flat-story pattern (`AttachFileToolCall.stories.tsx`): stories for **completed**
(3 queries + chips, using the real sample HTML), **executing** (no result), and **single query**.

## Dogfooding & quality gates

Gate A — after step 1–3 (before tests are finalized):

1. `make storybook` (port 6006), then with agent-browser:
   `agent-browser open http://localhost:6006/?path=/story/...googlesearchtoolcall--completed`,
   snapshot, click the header to expand, screenshot both collapsed and expanded states and
   `attach_file` them for review. Verify chips render with Google logo, hover/click affordance,
   and that clicking a chip targets `https://www.google.com/search?...`.
2. Repeat in dark + light theme (Storybook toolbar) — chips must use theme variables, no
   hardcoded Google grays.

Gate B — full validation before claiming done:

3. `bun test src/browser/features/Tools/` (new tests + existing registry tests green).
4. `make typecheck && make lint`.
5. Optional live check if a Gemini API key is available in the sandbox: launch via the
   `dev-desktop-sandbox` skill, pick a Gemini 3 model, ask something that triggers search, and
   screenshot the real tool call in chat. If no key, note it and rely on the Storybook evidence
   (the stories use a captured real payload, so fidelity is high).

## Acceptance criteria

- `server:GOOGLE_SEARCH_WEB` no longer renders as raw JSON: collapsed row shows Globe icon,
  "Google Search", first query, `+N more`, status; expanded shows query list + clickable
  suggestion chips.
- No `dangerouslySetInnerHTML`/`innerHTML` anywhere in the new code; hostile hrefs in the payload
  are provably dropped by tests.
- Pending/executing states render gracefully (no crash on missing args/result).
- All gates above pass; screenshots attached as review evidence.

**Net LoC estimate (product code): ~+130** (component ~120, registry ~6, icon 1, toolUtils move ±0).
Tests + stories add ~140 non-product LoC.

</details>

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `max` • Cost: `$90.98`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=max costs=90.98 -->
