### PR TITLE
🤖 fix: show sub-agent titles in workflow task event rows

### DIFF
--- a/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
@@ -233,6 +233,8 @@ const taskActionsRun: WorkflowRunRecord = {
       stepId: "summarize-source-15",
       taskId: "7b1a07d84d",
       status: "completed",
+      // Human title is 1-based while the step id is 0-based; rows show the title.
+      title: "Summarize source 16",
     },
     {
       sequence: 4,

--- a/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
@@ -256,7 +256,7 @@ const taskActionsRun: WorkflowRunRecord = {
       result: {
         reportMarkdown: "## Summary report\n\nCompleted task report body.",
         structuredOutput: {
-          summary: "Source 15 is ready for downstream extraction.",
+          summary: "Source 16 is ready for downstream extraction.",
           confidence: "high",
           citations: 3,
         },

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -475,6 +475,71 @@ describe("WorkflowRunToolCall", () => {
     });
   });
 
+  test("labels task rows with the sub-agent title and falls back to stepId without one", () => {
+    const view = render(
+      <ThemeProvider forcedTheme="dark">
+        <TooltipProvider>
+          <WorkflowRunToolCall
+            args={{ name: "deep-research", args: {}, run_in_background: true }}
+            status="executing"
+            result={{
+              status: "running",
+              runId: "wfr_task_titles",
+              result: null,
+              run: {
+                id: "wfr_task_titles",
+                workspaceId: "workspace-1",
+                definition: {
+                  name: "deep-research",
+                  description: "Deep research",
+                  scope: "built-in",
+                  executable: true,
+                },
+                definitionSource: "export default function workflow() { return null; }",
+                definitionHash: "sha256:test",
+                args: {},
+                status: "running",
+                createdAt: "2026-05-29T00:00:00.000Z",
+                updatedAt: "2026-05-29T00:00:01.000Z",
+                events: [
+                  {
+                    sequence: 1,
+                    type: "status",
+                    at: "2026-05-29T00:00:00.000Z",
+                    status: "running",
+                  },
+                  {
+                    sequence: 2,
+                    type: "task",
+                    at: "2026-05-29T00:00:00.000Z",
+                    stepId: "verify-claim-0-vote-2",
+                    taskId: "task_verify",
+                    status: "started",
+                    title: "Verify claim 1 vote 3",
+                  },
+                  // Legacy persisted event without a title keeps the stepId label.
+                  {
+                    sequence: 3,
+                    type: "task",
+                    at: "2026-05-29T00:00:01.000Z",
+                    stepId: "extract-source-0",
+                    taskId: "task_extract",
+                    status: "started",
+                  },
+                ],
+                steps: [],
+              },
+            }}
+          />
+        </TooltipProvider>
+      </ThemeProvider>
+    );
+
+    expect(view.getByText("Verify claim 1 vote 3 / task_verify / started")).toBeTruthy();
+    expect(view.container.textContent).not.toContain("verify-claim-0-vote-2");
+    expect(view.getByText("extract-source-0 / task_extract / started")).toBeTruthy();
+  });
+
   test("coalesces action start and completion events into one row with combined details", () => {
     const view = render(
       <ThemeProvider forcedTheme="dark">

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -338,7 +338,9 @@ function getWorkflowEventLabel(event: WorkflowRunEvent): string {
     case "log":
       return event.message;
     case "task":
-      return `${event.stepId} / ${event.taskId} / ${event.status}`;
+      // Prefer the human-readable sub-agent title (matches the spawned
+      // workspace title); fall back to stepId for legacy events without one.
+      return `${event.title ?? event.stepId} / ${event.taskId} / ${event.status}`;
     case "patch":
       return `${event.stepId} / ${event.sourceTaskId} / ${event.status}`;
     case "action":

--- a/src/common/orpc/schemas/workflow.ts
+++ b/src/common/orpc/schemas/workflow.ts
@@ -126,6 +126,9 @@ export const WorkflowRunEventSchema = z.discriminatedUnion("type", [
     stepId: z.string().min(1),
     taskId: z.string().min(1),
     status: z.string().min(1),
+    // Human-readable sub-agent title (matches the spawned workspace title).
+    // Optional so legacy persisted events without it still parse.
+    title: z.string().min(1).optional(),
   }),
   z.object({
     sequence: z.number().int().positive(),

--- a/src/node/builtinSkills/workflow-authoring.md
+++ b/src/node/builtinSkills/workflow-authoring.md
@@ -99,7 +99,7 @@ Required fields:
 
 Optional fields:
 
-- `title`: UI title.
+- `title`: UI title; used as the spawned child workspace title and the run-card task row label, falling back to `id` when omitted. Prefer human numbering (e.g. 1-based "Verify claim 1") over raw 0-based step ids.
 - `agentId`: sub-agent type/id; defaults to the workflow adapter default (usually `explore`).
 - `outputSchema`: JSON Schema subset used to validate `structuredOutput`.
 

--- a/src/node/services/agentSkills/builtInSkillContent.generated.ts
+++ b/src/node/services/agentSkills/builtInSkillContent.generated.ts
@@ -6838,7 +6838,7 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
       "",
       "Optional fields:",
       "",
-      "- `title`: UI title.",
+      '- `title`: UI title; used as the spawned child workspace title and the run-card task row label, falling back to `id` when omitted. Prefer human numbering (e.g. 1-based "Verify claim 1") over raw 0-based step ids.',
       "- `agentId`: sub-agent type/id; defaults to the workflow adapter default (usually `explore`).",
       "- `outputSchema`: JSON Schema subset used to validate `structuredOutput`.",
       "",

--- a/src/node/services/workflows/WorkflowRunStore.test.ts
+++ b/src/node/services/workflows/WorkflowRunStore.test.ts
@@ -157,6 +157,7 @@ describe("WorkflowRunStore", () => {
       stepId: "source-a",
       inputHash: "hash:source-a",
       taskId: "task_source-a",
+      title: "Extract claims from source 1",
       result: { reportMarkdown: "source-a" },
       startedAt: "2026-05-29T00:00:01.000Z",
       completedAt: "2026-05-29T00:00:02.000Z",
@@ -175,6 +176,7 @@ describe("WorkflowRunStore", () => {
       stepId: "source-a",
       taskId: "task_source-a",
       status: "completed",
+      title: "Extract claims from source 1",
     });
   });
 

--- a/src/node/services/workflows/WorkflowRunStore.test.ts
+++ b/src/node/services/workflows/WorkflowRunStore.test.ts
@@ -188,6 +188,7 @@ describe("WorkflowRunStore", () => {
       stepId: "source-b",
       inputHash: "hash:source-b",
       taskId: "task_source-b_bad",
+      title: "Extract claims from source 2",
       error: "structured output failed schema validation",
       startedAt: "2026-05-29T00:00:01.000Z",
       completedAt: "2026-05-29T00:00:02.000Z",
@@ -214,6 +215,7 @@ describe("WorkflowRunStore", () => {
       stepId: "source-b",
       taskId: "task_source-b_bad",
       status: "failed",
+      title: "Extract claims from source 2",
     });
   });
 

--- a/src/node/services/workflows/WorkflowRunStore.ts
+++ b/src/node/services/workflows/WorkflowRunStore.ts
@@ -248,6 +248,8 @@ export class WorkflowRunStore {
       stepId: string;
       inputHash: string;
       taskId?: string;
+      // Agent-spec title for the task event row; distinct from result.title,
+      // which is the sub-agent's self-reported report title.
       title?: string;
       result: StructuredTaskOutput;
       startedAt: string;
@@ -255,6 +257,13 @@ export class WorkflowRunStore {
     },
     options: AppendWorkflowRunEventOptions = {}
   ): Promise<void> {
+    // Fail fast on empty titles: the event schema enforces min(1), and letting it
+    // surface as a ZodError mid-write would abort step persistence with a less
+    // actionable error.
+    assert(
+      input.title == null || input.title.length > 0,
+      "WorkflowRunStore.recordStepCompletedAndAppendTaskEvent: title must be non-empty when provided"
+    );
     await this.withWorkflowMutationLock(runId, async () => {
       await this.withExpectedLeaseOwner(runId, options.expectedLeaseOwnerId, async () => {
         const record = WorkflowStepRecordSchema.parse({
@@ -311,6 +320,7 @@ export class WorkflowRunStore {
       stepId: string;
       inputHash: string;
       taskId?: string;
+      // Agent-spec title for the task event row (see recordStepCompletedAndAppendTaskEvent).
       title?: string;
       error: string;
       startedAt: string;
@@ -320,6 +330,10 @@ export class WorkflowRunStore {
     },
     options: AppendWorkflowRunEventOptions = {}
   ): Promise<void> {
+    assert(
+      input.title == null || input.title.length > 0,
+      "WorkflowRunStore.recordStepFailedAndAppendTaskEvent: title must be non-empty when provided"
+    );
     await this.withWorkflowMutationLock(runId, async () => {
       await this.withExpectedLeaseOwner(runId, options.expectedLeaseOwnerId, async () => {
         const record = WorkflowStepRecordSchema.parse({
@@ -385,12 +399,17 @@ export class WorkflowRunStore {
 
   async appendTaskEventIfMissing(
     runId: string,
+    // title is the agent-spec title for the task event row (see recordStepCompletedAndAppendTaskEvent).
     task: { stepId: string; taskId: string; status: string; at: string; title?: string },
     options: AppendWorkflowRunEventOptions = {}
   ): Promise<void> {
     assert(task.stepId.length > 0, "WorkflowRunStore.appendTaskEventIfMissing: stepId is required");
     assert(task.taskId.length > 0, "WorkflowRunStore.appendTaskEventIfMissing: taskId is required");
     assert(task.status.length > 0, "WorkflowRunStore.appendTaskEventIfMissing: status is required");
+    assert(
+      task.title == null || task.title.length > 0,
+      "WorkflowRunStore.appendTaskEventIfMissing: title must be non-empty when provided"
+    );
     await this.withWorkflowMutationLock(runId, async () => {
       await this.withExpectedLeaseOwner(runId, options.expectedLeaseOwnerId, async () => {
         const run = await this.getRunUnlocked(runId);

--- a/src/node/services/workflows/WorkflowRunStore.ts
+++ b/src/node/services/workflows/WorkflowRunStore.ts
@@ -248,6 +248,7 @@ export class WorkflowRunStore {
       stepId: string;
       inputHash: string;
       taskId?: string;
+      title?: string;
       result: StructuredTaskOutput;
       startedAt: string;
       completedAt: string;
@@ -289,6 +290,7 @@ export class WorkflowRunStore {
               stepId: input.stepId,
               taskId: input.taskId,
               status: "completed",
+              title: input.title,
             },
             options
           );
@@ -309,6 +311,7 @@ export class WorkflowRunStore {
       stepId: string;
       inputHash: string;
       taskId?: string;
+      title?: string;
       error: string;
       startedAt: string;
       completedAt: string;
@@ -365,6 +368,7 @@ export class WorkflowRunStore {
               stepId: input.stepId,
               taskId: input.taskId,
               status: "failed",
+              title: input.title,
             },
             options
           );
@@ -381,7 +385,7 @@ export class WorkflowRunStore {
 
   async appendTaskEventIfMissing(
     runId: string,
-    task: { stepId: string; taskId: string; status: string; at: string },
+    task: { stepId: string; taskId: string; status: string; at: string; title?: string },
     options: AppendWorkflowRunEventOptions = {}
   ): Promise<void> {
     assert(task.stepId.length > 0, "WorkflowRunStore.appendTaskEventIfMissing: stepId is required");
@@ -409,6 +413,7 @@ export class WorkflowRunStore {
             stepId: task.stepId,
             taskId: task.taskId,
             status: task.status,
+            title: task.title,
           },
           options
         );

--- a/src/node/services/workflows/WorkflowRunner.test.ts
+++ b/src/node/services/workflows/WorkflowRunner.test.ts
@@ -192,9 +192,13 @@ describe("WorkflowRunner", () => {
     });
     let nextTaskNumber = 1;
     const runner = createRunner(store, {
-      async runAgent() {
+      async runAgent(_spec, lifecycle) {
         const taskId = `task_${nextTaskNumber}`;
         nextTaskNumber += 1;
+        // Report the taskId via the lifecycle callback like the production adapter
+        // does, so the started-event title is pinned on the lifecycle path rather
+        // than the post-hoc fallback.
+        await lifecycle?.onTaskCreated?.(taskId);
         return { taskId, reportMarkdown: "ok" };
       },
     });
@@ -1065,8 +1069,8 @@ describe("WorkflowRunner", () => {
       definition,
       definitionSource: `export default function workflow({ parallelAgents }) {
         const results = parallelAgents([
-          { id: "source-a", prompt: "Read source A" },
-          { id: "source-b", prompt: "Read source B" },
+          { id: "source-a", title: "Read source 1", prompt: "Read source A" },
+          { id: "source-b", title: "Read source 2", prompt: "Read source B" },
         ]);
         return { reportMarkdown: results.map((result) => result.reportMarkdown).join(" + ") };
       }`,
@@ -1102,6 +1106,25 @@ describe("WorkflowRunner", () => {
     expect(waitForAgentTask).toHaveBeenCalledTimes(2);
     const run = await store.getRun("wfr_parallel_bulk");
     expect(run.steps.map((step) => step.taskId).sort()).toEqual(["task_source-a", "task_source-b"]);
+    // The bulk onTaskCreated path is how production parallel fan-outs record started
+    // events; pin that it forwards spec titles (started events are recorded there).
+    const taskEvents = run.events.filter((event) => event.type === "task");
+    expect(taskEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ stepId: "source-a", title: "Read source 1", status: "started" }),
+        expect.objectContaining({ stepId: "source-b", title: "Read source 2", status: "started" }),
+        expect.objectContaining({
+          stepId: "source-a",
+          title: "Read source 1",
+          status: "completed",
+        }),
+        expect.objectContaining({
+          stepId: "source-b",
+          title: "Read source 2",
+          status: "completed",
+        }),
+      ])
+    );
   });
 
   test("records completed parallelAgents results before slower siblings finish", async () => {

--- a/src/node/services/workflows/WorkflowRunner.test.ts
+++ b/src/node/services/workflows/WorkflowRunner.test.ts
@@ -172,6 +172,60 @@ describe("WorkflowRunner", () => {
     ]);
   });
 
+  test("task events carry the agent spec title and omit it when the spec has none", async () => {
+    using tmp = new DisposableTempDir("workflow-runner-task-event-title");
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
+    await store.createRun({
+      id: "wfr_titled",
+      workspaceId: "workspace-1",
+      definition,
+      definitionSource: `export default function workflow({ agent }) {
+        agent({ id: "verify-claim-0-vote-2", title: "Verify claim 1 vote 3", prompt: "Verify" });
+        agent({ id: "untitled-step", prompt: "No title" });
+        return { reportMarkdown: "done" };
+      }`,
+      args: {},
+      now: "2026-05-29T00:00:00.000Z",
+    });
+    let nextTaskNumber = 1;
+    const runner = createRunner(store, {
+      async runAgent() {
+        const taskId = `task_${nextTaskNumber}`;
+        nextTaskNumber += 1;
+        return { taskId, reportMarkdown: "ok" };
+      },
+    });
+
+    await runner.run("wfr_titled");
+    const taskEvents = (await store.getRun("wfr_titled")).events.filter(
+      (event) => event.type === "task"
+    );
+
+    expect(taskEvents).toEqual([
+      expect.objectContaining({
+        stepId: "verify-claim-0-vote-2",
+        title: "Verify claim 1 vote 3",
+        status: "started",
+      }),
+      expect.objectContaining({
+        stepId: "verify-claim-0-vote-2",
+        title: "Verify claim 1 vote 3",
+        status: "completed",
+      }),
+      expect.objectContaining({ stepId: "untitled-step", status: "started" }),
+      expect.objectContaining({ stepId: "untitled-step", status: "completed" }),
+    ]);
+    // Untitled specs must omit the field rather than defaulting it to something else.
+    const untitledEvents = taskEvents.filter((event) => event.stepId === "untitled-step");
+    expect(untitledEvents).toHaveLength(2);
+    for (const event of untitledEvents) {
+      expect(event.title).toBeUndefined();
+    }
+  });
+
   test("returns child task IDs to workflow code", async () => {
     using tmp = new DisposableTempDir("workflow-runner-task-id");
     const store = new WorkflowRunStore({

--- a/src/node/services/workflows/WorkflowRunner.ts
+++ b/src/node/services/workflows/WorkflowRunner.ts
@@ -1190,6 +1190,7 @@ export class WorkflowRunner {
         await this.recordTaskCompletedEventIfMissing(runId, sequence, {
           stepId: spec.id,
           taskId: existingStep.taskId,
+          title: spec.title,
         });
       }
       return existingStep.result;
@@ -1250,6 +1251,7 @@ export class WorkflowRunner {
           await this.recordTaskCompletedEventIfMissing(runId, sequence, {
             stepId: step.spec.id,
             taskId: existingStep.taskId,
+            title: step.spec.title,
           });
         }
         results[index] = existingStep.result;
@@ -1328,6 +1330,7 @@ export class WorkflowRunner {
                 await this.recordTaskStartedEventIfMissing(runId, sequence, {
                   stepId: step.spec.id,
                   taskId,
+                  title: step.spec.title,
                 });
               },
             }
@@ -1509,6 +1512,7 @@ export class WorkflowRunner {
       await this.recordTaskStartedEventIfMissing(runId, sequence, {
         stepId: step.spec.id,
         taskId: step.taskId,
+        title: step.spec.title,
       });
       try {
         return await this.taskAdapter.waitForAgentTask(step.taskId, step.spec, step.waitOptions);
@@ -1518,6 +1522,7 @@ export class WorkflowRunner {
           await this.recordTaskTerminalEventIfMissing(runId, sequence, {
             stepId: step.spec.id,
             taskId: step.taskId,
+            title: step.spec.title,
             status: getTaskTerminalStatusForError(error, step.waitOptions?.abortSignal),
           });
         }
@@ -1546,6 +1551,7 @@ export class WorkflowRunner {
             await this.recordTaskStartedEventIfMissing(runId, sequence, {
               stepId: step.spec.id,
               taskId,
+              title: step.spec.title,
             });
           },
         },
@@ -1557,6 +1563,7 @@ export class WorkflowRunner {
         await this.recordTaskTerminalEventIfMissing(runId, sequence, {
           stepId: step.spec.id,
           taskId: recordedTaskId,
+          title: step.spec.title,
           status: getTaskTerminalStatusForError(error, step.waitOptions?.abortSignal),
         });
       }
@@ -1573,6 +1580,7 @@ export class WorkflowRunner {
       await this.recordTaskStartedEventIfMissing(runId, sequence, {
         stepId: step.spec.id,
         taskId: rawResult.taskId,
+        title: step.spec.title,
       });
     }
     return rawResult;
@@ -1581,7 +1589,7 @@ export class WorkflowRunner {
   private async recordTaskStartedEventIfMissing(
     runId: string,
     sequence: WorkflowEventSequence,
-    task: { stepId: string; taskId: string }
+    task: { stepId: string; taskId: string; title?: string }
   ): Promise<void> {
     await this.recordTaskEventIfMissing(runId, sequence, { ...task, status: "started" });
   }
@@ -1589,7 +1597,7 @@ export class WorkflowRunner {
   private async recordTaskCompletedEventIfMissing(
     runId: string,
     sequence: WorkflowEventSequence,
-    task: { stepId: string; taskId: string }
+    task: { stepId: string; taskId: string; title?: string }
   ): Promise<void> {
     await this.recordTaskEventIfMissing(runId, sequence, { ...task, status: "completed" });
   }
@@ -1597,7 +1605,7 @@ export class WorkflowRunner {
   private async recordTaskTerminalEventIfMissing(
     runId: string,
     sequence: WorkflowEventSequence,
-    task: { stepId: string; taskId: string; status: "failed" | "interrupted" }
+    task: { stepId: string; taskId: string; title?: string; status: "failed" | "interrupted" }
   ): Promise<void> {
     await this.recordTaskEventIfMissing(runId, sequence, task);
   }
@@ -1605,7 +1613,7 @@ export class WorkflowRunner {
   private async recordTaskEventIfMissing(
     runId: string,
     sequence: WorkflowEventSequence,
-    task: { stepId: string; taskId: string; status: string }
+    task: { stepId: string; taskId: string; title?: string; status: string }
   ): Promise<void> {
     assert(runId.length > 0, "WorkflowRunner.recordTaskEventIfMissing: runId is required");
     assert(task.stepId.length > 0, "WorkflowRunner: task event stepId is required");
@@ -1621,6 +1629,7 @@ export class WorkflowRunner {
         taskId: task.taskId,
         status: task.status,
         at: this.clock.nowIso(),
+        title: task.title,
       },
       { expectedLeaseOwnerId: this.runnerId }
     );
@@ -1698,6 +1707,7 @@ export class WorkflowRunner {
         stepId: step.spec.id,
         inputHash: step.inputHash,
         taskId,
+        title: step.spec.title,
         result,
         startedAt: step.startedAt,
         completedAt,
@@ -1732,6 +1742,7 @@ export class WorkflowRunner {
         stepId: step.spec.id,
         inputHash: step.inputHash,
         taskId,
+        title: step.spec.title,
         error: message,
         startedAt: step.startedAt,
         completedAt: failedAt,


### PR DESCRIPTION
## Summary

Workflow task rows in the run-card events pane printed the raw 0-based step id (`verify-claim-0-vote-2`) while the spawned sub-agent workspace title is 1-based ("Verify claim 1 vote 3"), so the two visible surfaces disagreed about the same task. This PR threads the agent-spec `title` through task events end to end and renders it in the events pane with a `stepId` fallback.

## Background

Both `deep-research` and `deep-review` spawn sub-agents with 1-based human titles over 0-based replay step ids. The events pane rendered the machine id verbatim (`getWorkflowEventLabel`), so the sidebar said "Verify claim 1 vote 3" while the events row said `verify-claim-0-vote-2 / … / started`.

Renumbering either side was rejected: ids are durable replay keys (persisted in journals, parsed by tests), and 0-based sidebar titles would be worse UX. Changing workflow specs would also invalidate replay `inputHash`es for in-flight runs. Rendering the existing title in the events pane is the only zero-replay-churn fix, because task events are journal output, not replay input.

## Implementation

- **Schema** (`src/common/orpc/schemas/workflow.ts`): optional `title` on the `task` member of `WorkflowRunEventSchema`. Legacy persisted `events.jsonl` lines without it still parse — no migration.
- **Store** (`WorkflowRunStore.ts`): `recordStepCompletedAndAppendTaskEvent`, `recordStepFailedAndAppendTaskEvent`, and `appendTaskEventIfMissing` accept and persist the title, with fail-fast asserts rejecting empty strings (the schema's `min(1)` would otherwise surface as a ZodError mid-write and abort step persistence).
- **Runner** (`WorkflowRunner.ts`): all task-event helpers carry `title?`; every call site passes `step.spec.title`. `parseWorkflowAgentSpec` only sets non-empty titles, so untitled specs omit the field; `buildRetryAgentSpec` spreads the spec, so retries keep it.
- **UI** (`WorkflowRunToolCall.tsx`): task rows render `title ?? stepId`. Patch/action/validation rows keep step ids (machine steps); raw `stepId` stays inspectable in `events.jsonl` / `run.json`.
- **Docs**: workflow-authoring skill now documents both `title` surfaces (child workspace title + run-card row label) and the `id` fallback; built-in skill content regenerated.

A `/deep-review-workflow` run on the change verified it ship-ready (no correctness/security/reliability defects; risk low). Its P3 finding (test coverage of production-primary title paths) and four unambiguous P4s (store asserts, dual-title comments, skill doc, story fixture numbering) are addressed in the second commit. Three P4s were intentionally deferred as design questions: aria-labels/tooltips still use taskId hashes (possibly intentional as stable E2E identifiers), and patch-row title borrowing.

## Validation

- Title pass-through is pinned on the production-primary paths: lifecycle `onTaskCreated` (single agents), bulk `createAgentTasks` (parallel fan-outs), failed-path store writes, and untitled specs omitting the field — dropping `title` at any call site now fails a test.
- Storybook + a live dev-server-sandbox run (persisted run with one titled + one legacy title-less event, served through the real oRPC backend) confirmed the events pane renders "Verify claim 1 vote 1 / task_demo_1 / completed" beside the legacy stepId fallback row.

## Risks

Low. Additive optional field with `stepId` fallback on both read (schema) and render (UI); no migration; in-flight runs unaffected because task events are journal output, not replay input. Worst case for a malformed legacy event is the pre-existing behavior (stepId label).

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix the title ↔ step-id off-by-one in workflow task rows

## Problem

In `deep-research` (and `deep-review`), spawned sub-agent **titles are 1-based** while **step ids are 0-based**, and the Workflow Events pane prints the raw step id, so the two visible surfaces disagree:

- Sidebar workspace title: `Verify claim 1 vote 3` ← `title: \`Verify claim ${claimIndex + 1} vote ${vote + 1}\``
- Events pane row: `verify-claim-0-vote-2 / … / started` ← `id: \`verify-claim-${claimIndex}-vote-${vote}\``

Both come from `src/node/builtinWorkflows/deep-research.js:612-631` (`buildVerificationSpecs`). The events pane renders the id verbatim in `getWorkflowEventLabel` (`src/browser/features/Tools/WorkflowRunToolCall.tsx:334-359`):

```ts
case "task":
  return `${event.stepId} / ${event.taskId} / ${event.status}`;
```

Same pattern exists for `extract-source-${i}` / "Extract claims from source ${i+1}", `discover-sources-${i}`, and three task families in `deep-review-workflow.js` (`verify-issue-`, `fix-issue-`, `resolve-fix-`).

## Which one to keep? → Keep **both**, they serve different purposes — fix the display

- The **0-based id** is the durable replay key. It matches array indices in code/artifacts, is persisted in the run journal, and tests *parse indices out of it* (`builtInWorkflowDefinitions.test.ts:965,1082`: `/verify-claim-(\d+)-vote-/` → array index). Renumbering ids is churn + breakage risk.
- The **1-based title** is the human label (sidebar, and LLM-written reports also number findings 1-based). "Verify claim 0 vote 0" in the sidebar would be worse UX.
- The actual bug is the events pane using the **machine id as the human label**. Render the spec `title` there instead (fallback to `stepId`).

Bonus: this is the only option with **zero replay churn** — task *events* are journal output, not replay input. Renumbering either ids or titles in the workflow specs would change the replay `inputHash` (title is hashed too, per `workflowReplayKey.ts`) and force in-flight runs to re-spawn tasks.

## Changes (≈ +20 net product LoC)

1. **Schema** — `src/common/orpc/schemas/workflow.ts:122-129`: add `title: z.string().min(1).optional()` to the `task` event member of `WorkflowRunEventSchema`. (Internal oRPC schema, not an AI tool input schema, so `.optional()` is correct; legacy `events.jsonl` lines without `title` still `safeParse` fine — no migration.)
2. **Store** — `src/node/services/workflows/WorkflowRunStore.ts`: accept optional `title` in the task-event payloads of `recordStepCompletedAndAppendTaskEvent` / `recordStepFailedAndAppendTaskEvent` and include it in the appended event.
3. **Runner** — `src/node/services/workflows/WorkflowRunner.ts`: thread `title: step.spec.title` (or `spec.title`) through the task-event helpers and their ~10 call sites, all of which already have the parsed spec in scope:
   - `recordTaskStartedEventIfMissing` (lines ~1328, 1509, 1546, 1573)
   - `recordTaskTerminalEventIfMissing` (~1518, 1557)
   - `recordTaskCompletedEventIfMissing` backfills (~1190, 1250)
   - store calls in `recordAgentResult` (~1695) and `recordFailedAgentAttempt` (~1729)
   `parseWorkflowAgentSpec` only sets `title` when non-empty, so untitled specs naturally omit the field.
4. **UI** — `WorkflowRunToolCall.tsx` `getWorkflowEventLabel`, task case only:
   ```ts
   return `${event.title ?? event.stepId} / ${event.taskId} / ${event.status}`;
   ```
   Row truncation, coalescing (keyed by stepId), Report/Open buttons, and the report dialog (which reuses the label) need no changes. Raw `stepId` stays inspectable in `events.jsonl` / `run.json` steps.

**Non-goals:** no changes to `deep-research.js` / `deep-review-workflow.js` numbering; `patch`/`action`/`validation` rows keep showing step ids (machine steps); no new tooltips/debug UI.

## Tests (behavioral, not tautological)

- `WorkflowRunner.test.ts` ("appends started and completed task events"): assert emitted task events carry the spec title, and omit it when the spec has none.
- `WorkflowRunToolCall.test.tsx`: title-bearing event renders the title as the row label; legacy event without `title` falls back to `stepId` (existing `scope-topic / task_scope / completed` assertion covers this path).
- Extend one `WorkflowRunStore.test.ts` round-trip with `title` if cheap; `builtInWorkflowDefinitions.test.ts` stays untouched and green.
- Update `WorkflowRunToolCall.stories.tsx` so one task event carries a title (visual coverage).

## Validation

`make typecheck && make lint`, then targeted: `bun test src/node/services/workflows/WorkflowRunner.test.ts src/node/services/workflows/WorkflowRunStore.test.ts src/browser/features/Tools/WorkflowRunToolCall.test.tsx`.

## Dogfooding (quality gate before claiming done)

1. **Deterministic UI check:** run Storybook, open the updated `WorkflowRunToolCall` story; `agent-browser` screenshot of the events list showing `Verify claim 1 vote 3 / … / started` next to a legacy (stepId-fallback) row; `attach_file` the screenshot.
2. **Live end-to-end:** per the `dev-server-sandbox` skill, launch an isolated dev server (temp `MUX_ROOT`, free ports). Create a workspace, add a scratch workflow `.mux/workflows/.scratch/title-demo.js` that `parallelAgents`-spawns 2–3 trivial tasks (`id: verify-claim-0-vote-0`, `title: "Verify claim 1 vote 1"`, prompt "Reply done."). With `agent-browser`, capture sidebar title and events pane side by side — labels must match — plus a short screencast/screenshot sequence of the flow; attach all artifacts. If no provider key is available in the sandbox, document that and rely on gate 1 + tests.
3. Verify a pre-change run's persisted events (no `title`) still render with stepId labels (load an old run or hand-write a legacy `events.jsonl` line in the sandbox).

## Acceptance criteria

- Task rows in the events pane show the sub-agent title (matching the sidebar workspace title) when the spec has one; `stepId` otherwise.
- Legacy persisted events (no `title`) parse and render exactly as today.
- No workflow-definition, step-id, or replay-key changes; in-flight runs are unaffected.
- Typecheck, lint, and the targeted tests above pass.

## Alternatives considered

- **A. Drop the `+ 1` → 0-based everywhere** (~10 modified lines, net 0 LoC): smallest diff, but sidebar reads "Verify claim 0 vote 0", clashes with 1-based prose in prompts/reports ("Vote 1 of 3"), and changing spec titles invalidates replay hashes for in-flight runs anyway.
- **B. Make ids 1-based to match titles** (~10–25 LoC + audit): durable-id churn in journals/history, and `builtInWorkflowDefinitions.test.ts` parses array indices straight out of id strings — easy to break, no engine benefit. Rejected.

</details>

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `max` • Cost: `$83.75`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=max costs=83.75 -->
