### PR TITLE
🤖 feat: show fallback badge in transcript when a model refused

### DIFF
--- a/src/browser/components/ModelSelector/ModelSelector.tsx
+++ b/src/browser/components/ModelSelector/ModelSelector.tsx
@@ -26,6 +26,7 @@ import { stopKeyboardPropagation } from "@/browser/utils/events";
 import { formatModelDisplayName } from "@/common/utils/ai/modelDisplay";
 import { formatProviderDisplayName } from "@/common/utils/providers/customProviders";
 import {
+  formatModelStringForDisplay,
   getExplicitGatewayPrefix,
   getModelName,
   getModelProvider,
@@ -277,7 +278,7 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
     const canonicalValue = hasValue ? normalizeToCanonical(value) : "";
     const selectedProvider = hasValue ? getModelProvider(canonicalValue) : "";
     const displayValue = hasValue
-      ? formatModelDisplayName(getModelName(canonicalValue))
+      ? formatModelStringForDisplay(canonicalValue)
       : (emptyLabel ?? "");
 
     // Explicit gateway selections short-circuit route resolution: the user

--- a/src/browser/features/Messages/AssistantMessage.tsx
+++ b/src/browser/features/Messages/AssistantMessage.tsx
@@ -29,6 +29,7 @@ import { CompactionBackground } from "./CompactionBackground";
 import type { ButtonConfig } from "./MessageWindow";
 import { MessageWindow } from "./MessageWindow";
 import { ModelDisplay } from "./ModelDisplay";
+import { ModelFallbackBadge } from "./ModelFallbackBadge";
 import { TypewriterMarkdown } from "./TypewriterMarkdown";
 
 interface AssistantMessageProps {
@@ -226,6 +227,9 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
             routedThroughGateway={message.routedThroughGateway}
             routeProvider={message.routeProvider}
           />
+        )}
+        {message.modelFallback && (
+          <ModelFallbackBadge modelFallback={message.modelFallback} effectiveModel={modelName} />
         )}
         {isCompacted && (
           <span className="text-plan-mode bg-plan-mode/10 inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[10px] font-medium uppercase">

--- a/src/browser/features/Messages/ModelDisplay.tsx
+++ b/src/browser/features/Messages/ModelDisplay.tsx
@@ -2,8 +2,11 @@ import React from "react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/browser/components/Tooltip/Tooltip";
 import { ProviderIcon } from "@/browser/components/ProviderIcon/ProviderIcon";
 import { PROVIDER_DEFINITIONS, type ProviderName } from "@/common/constants/providers";
-import { formatModelDisplayName } from "@/common/utils/ai/modelDisplay";
-import { getModelName, getModelProvider, normalizeToCanonical } from "@/common/utils/ai/models";
+import {
+  formatModelStringForDisplay,
+  getModelProvider,
+  normalizeToCanonical,
+} from "@/common/utils/ai/models";
 
 interface ModelDisplayProps {
   modelString: string;
@@ -44,7 +47,7 @@ function getRouteDisplayName(
 export const ModelDisplay: React.FC<ModelDisplayProps> = (props) => {
   const canonicalModel = normalizeToCanonical(props.modelString);
   const originProvider = getModelProvider(canonicalModel);
-  const displayName = formatModelDisplayName(getModelName(canonicalModel));
+  const displayName = formatModelStringForDisplay(canonicalModel);
   const resolvedRouteProvider = resolveRouteProvider(
     props.routeProvider,
     props.routedThroughGateway

--- a/src/browser/features/Messages/ModelFallbackBadge.test.ts
+++ b/src/browser/features/Messages/ModelFallbackBadge.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { buildModelFallbackTooltipLines } from "./ModelFallbackBadge";
+
+// Tooltip copy is rendered through a Radix portal that happy-dom can't observe,
+// so the line-building behavior (ordering, hop handling, defensive fallback) is
+// tested directly. Assertions use model display names, not full sentences, so
+// copy tweaks don't break them.
+describe("buildModelFallbackTooltipLines", () => {
+  test("multi-hop chain yields one line per refused model in chain order, then the answering model", () => {
+    const lines = buildModelFallbackTooltipLines(
+      {
+        requestedModel: "openai:gpt-5.5-pro",
+        refusedModels: ["openai:gpt-5.5-pro", "google:gemini-3.1-pro-preview"],
+      },
+      "anthropic:claude-opus-4-8"
+    );
+
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toContain("GPT-5.5 Pro");
+    expect(lines[1]).toContain("Gemini");
+    expect(lines[2]).toContain("Opus 4.8");
+  });
+
+  test("omits the answering line when the effective model is unknown", () => {
+    const lines = buildModelFallbackTooltipLines(
+      { requestedModel: "openai:gpt-5.5", refusedModels: ["openai:gpt-5.5"] },
+      undefined
+    );
+
+    expect(lines).toHaveLength(1);
+  });
+
+  test("falls back to the requested model when refusedModels is empty (malformed record)", () => {
+    const lines = buildModelFallbackTooltipLines(
+      { requestedModel: "openai:gpt-5.5", refusedModels: [] },
+      "anthropic:claude-sonnet-4-6"
+    );
+
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain("GPT-5.5");
+  });
+});

--- a/src/browser/features/Messages/ModelFallbackBadge.test.ts
+++ b/src/browser/features/Messages/ModelFallbackBadge.test.ts
@@ -21,13 +21,15 @@ describe("buildModelFallbackTooltipLines", () => {
     expect(lines[2]).toContain("Opus 4.8");
   });
 
-  test("omits the answering line when the effective model is unknown", () => {
-    const lines = buildModelFallbackTooltipLines(
-      { requestedModel: "openai:gpt-5.5", refusedModels: ["openai:gpt-5.5"] },
-      undefined
-    );
+  test("omits the answering line when the effective model is unknown or empty", () => {
+    for (const effectiveModel of [undefined, ""]) {
+      const lines = buildModelFallbackTooltipLines(
+        { requestedModel: "openai:gpt-5.5", refusedModels: ["openai:gpt-5.5"] },
+        effectiveModel
+      );
 
-    expect(lines).toHaveLength(1);
+      expect(lines).toHaveLength(1);
+    }
   });
 
   test("falls back to the requested model when refusedModels is empty (malformed record)", () => {

--- a/src/browser/features/Messages/ModelFallbackBadge.tsx
+++ b/src/browser/features/Messages/ModelFallbackBadge.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { ArrowRightLeft } from "lucide-react";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/browser/components/Tooltip/Tooltip";
+import type { ModelFallbackRecord } from "@/common/types/message";
+import { formatModelDisplayName } from "@/common/utils/ai/modelDisplay";
+import { getModelName, normalizeToCanonical } from "@/common/utils/ai/models";
+
+function formatModel(modelString: string): string {
+  return formatModelDisplayName(getModelName(normalizeToCanonical(modelString)));
+}
+
+/**
+ * Tooltip copy for a fallback badge, one line per entry.
+ *
+ * Exported for unit tests: Radix tooltip content renders through a portal that
+ * happy-dom can't observe, so the formatting branches are tested directly.
+ */
+export function buildModelFallbackTooltipLines(
+  record: ModelFallbackRecord,
+  effectiveModel: string | undefined
+): string[] {
+  // Defensive: refusedModels always starts with the requested model; tolerate
+  // malformed records by falling back to the requested model alone.
+  const refused = record.refusedModels.length > 0 ? record.refusedModels : [record.requestedModel];
+  const lines = refused.map((model, index) =>
+    index === 0
+      ? `Requested ${formatModel(model)} refused to respond.`
+      : `Fallback ${formatModel(model)} also refused.`
+  );
+  if (effectiveModel !== undefined) {
+    lines.push(`Answered by ${formatModel(effectiveModel)}.`);
+  }
+  return lines;
+}
+
+interface ModelFallbackBadgeProps {
+  modelFallback: ModelFallbackRecord;
+  /** The model that actually answered (the message's `model`). */
+  effectiveModel?: string;
+}
+
+/**
+ * Header badge shown when a configured model-fallback chain answered after the
+ * requested model refused. The header itself shows the effective model, so
+ * without this badge the swap would be invisible in the transcript.
+ */
+export const ModelFallbackBadge: React.FC<ModelFallbackBadgeProps> = (props) => {
+  const lines = buildModelFallbackTooltipLines(props.modelFallback, props.effectiveModel);
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="text-warning bg-warning/10 inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[10px] font-medium uppercase"
+          data-model-fallback-badge
+        >
+          <ArrowRightLeft aria-hidden="true" className="h-3 w-3" />
+          <span>fallback</span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent align="center">
+        {lines.map((line) => (
+          <div key={line}>{line}</div>
+        ))}
+      </TooltipContent>
+    </Tooltip>
+  );
+};

--- a/src/browser/features/Messages/ModelFallbackBadge.tsx
+++ b/src/browser/features/Messages/ModelFallbackBadge.tsx
@@ -2,12 +2,7 @@ import React from "react";
 import { ArrowRightLeft } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/browser/components/Tooltip/Tooltip";
 import type { ModelFallbackRecord } from "@/common/types/message";
-import { formatModelDisplayName } from "@/common/utils/ai/modelDisplay";
-import { getModelName, normalizeToCanonical } from "@/common/utils/ai/models";
-
-function formatModel(modelString: string): string {
-  return formatModelDisplayName(getModelName(normalizeToCanonical(modelString)));
-}
+import { formatModelStringForDisplay } from "@/common/utils/ai/models";
 
 /**
  * Tooltip copy for a fallback badge, one line per entry.
@@ -24,11 +19,13 @@ export function buildModelFallbackTooltipLines(
   const refused = record.refusedModels.length > 0 ? record.refusedModels : [record.requestedModel];
   const lines = refused.map((model, index) =>
     index === 0
-      ? `Requested ${formatModel(model)} refused to respond.`
-      : `Fallback ${formatModel(model)} also refused.`
+      ? `Requested ${formatModelStringForDisplay(model)} refused to respond.`
+      : `Fallback ${formatModelStringForDisplay(model)} also refused.`
   );
-  if (effectiveModel !== undefined) {
-    lines.push(`Answered by ${formatModel(effectiveModel)}.`);
+  // Truthy guard (not just !== undefined): an empty-string model must not
+  // render a dangling "Answered by ." line; matches ModelDisplay's gating.
+  if (effectiveModel) {
+    lines.push(`Answered by ${formatModelStringForDisplay(effectiveModel)}.`);
   }
   return lines;
 }
@@ -49,7 +46,10 @@ export const ModelFallbackBadge: React.FC<ModelFallbackBadgeProps> = (props) => 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
+        {/* tabIndex makes the explanation keyboard-reachable (Radix opens tooltips on focus).
+            data-model-fallback-badge is a stable selector for browser-automation checks. */}
         <span
+          tabIndex={0}
           className="text-warning bg-warning/10 inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[10px] font-medium uppercase"
           data-model-fallback-badge
         >
@@ -58,8 +58,11 @@ export const ModelFallbackBadge: React.FC<ModelFallbackBadgeProps> = (props) => 
         </span>
       </TooltipTrigger>
       <TooltipContent align="center">
-        {lines.map((line) => (
-          <div key={line}>{line}</div>
+        {/* Keyed by index: distinct refused models can share a display name
+            (e.g. the same model via two providers), so line text is not unique.
+            The list is static per render and never reorders. */}
+        {lines.map((line, index) => (
+          <div key={index}>{line}</div>
         ))}
       </TooltipContent>
     </Tooltip>

--- a/src/browser/utils/messages/StreamingMessageAggregator.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.test.ts
@@ -402,6 +402,36 @@ describe("StreamingMessageAggregator", () => {
   });
 
   describe("display flags", () => {
+    test("propagates modelFallback metadata to displayed assistant rows", () => {
+      const aggregator = new StreamingMessageAggregator(TEST_CREATED_AT);
+
+      const fallback = createMuxMessage("a1", "assistant", "answer", {
+        timestamp: 1,
+        historySequence: 1,
+        model: "anthropic:claude-opus-4-8",
+        modelFallback: {
+          requestedModel: "openai:gpt-5.5",
+          refusedModels: ["openai:gpt-5.5"],
+        },
+      });
+      const plain = createMuxMessage("a2", "assistant", "no fallback", {
+        timestamp: 2,
+        historySequence: 2,
+        model: "anthropic:claude-opus-4-8",
+      });
+
+      aggregator.loadHistoricalMessages([fallback, plain], false);
+
+      const assistantRows = aggregator.getDisplayedMessages().filter((m) => m.type === "assistant");
+
+      expect(assistantRows).toHaveLength(2);
+      expect(assistantRows[0]?.modelFallback).toEqual({
+        requestedModel: "openai:gpt-5.5",
+        refusedModels: ["openai:gpt-5.5"],
+      });
+      expect(assistantRows[1]?.modelFallback).toBeUndefined();
+    });
+
     test("should hide synthetic messages by default", () => {
       const aggregator = new StreamingMessageAggregator(TEST_CREATED_AT);
 

--- a/src/browser/utils/messages/displayedMessageBuilder.ts
+++ b/src/browser/utils/messages/displayedMessageBuilder.ts
@@ -403,6 +403,7 @@ function appendAssistantTextRow(
       message.metadata?.routeProvider,
       message.metadata?.routedThroughGateway
     ),
+    modelFallback: message.metadata?.modelFallback,
     mode: message.metadata?.mode,
     agentId: message.metadata?.agentId ?? message.metadata?.mode,
     timestamp: part.timestamp ?? options.baseTimestamp,

--- a/src/common/orpc/schemas/message.test.ts
+++ b/src/common/orpc/schemas/message.test.ts
@@ -43,6 +43,48 @@ describe("MuxMessageSchema compactionEpoch parsing", () => {
     expect(parsed.metadata?.routeProvider).toBe("openai");
   });
 
+  test("preserves modelFallback metadata", () => {
+    const parsed = MuxMessageSchema.parse({
+      ...createMessage(),
+      metadata: {
+        modelFallback: {
+          requestedModel: "openai:gpt-5.5",
+          refusedModels: ["openai:gpt-5.5", "google:gemini-3.1-pro-preview"],
+        },
+      },
+    });
+
+    expect(parsed.metadata?.modelFallback).toEqual({
+      requestedModel: "openai:gpt-5.5",
+      refusedModels: ["openai:gpt-5.5", "google:gemini-3.1-pro-preview"],
+    });
+  });
+
+  test("tolerates malformed modelFallback values by treating them as absent", () => {
+    const malformedModelFallbackValues: unknown[] = [
+      null,
+      "openai:gpt-5.5",
+      7,
+      [],
+      {},
+      { requestedModel: "openai:gpt-5.5" }, // missing refusedModels
+      { refusedModels: ["openai:gpt-5.5"] }, // missing requestedModel
+      { requestedModel: "openai:gpt-5.5", refusedModels: [7] }, // wrong element type
+      { requestedModel: 7, refusedModels: ["openai:gpt-5.5"] },
+    ];
+
+    for (const malformedModelFallback of malformedModelFallbackValues) {
+      const parsed = MuxMessageSchema.parse({
+        ...createMessage(),
+        metadata: {
+          modelFallback: malformedModelFallback,
+        },
+      });
+
+      expect(parsed.metadata?.modelFallback).toBeUndefined();
+    }
+  });
+
   test("tolerates malformed compactionEpoch values by treating them as absent", () => {
     const malformedCompactionEpochValues: unknown[] = [
       0,

--- a/src/common/orpc/schemas/message.ts
+++ b/src/common/orpc/schemas/message.ts
@@ -126,7 +126,10 @@ export const MuxMessageSchema = z.object({
       thinkingLevel: ThinkingLevelSchema.optional(),
       routedThroughGateway: z.boolean().optional(),
       routeProvider: z.string().optional(), // Preserve replayed/non-stream route attribution.
-      modelFallback: ModelFallbackRecordSchema.optional(),
+      // Self-healing read path (like agentId/compactionEpoch): the badge is purely
+      // decorative, so a shape-corrupt persisted record must degrade to "no badge"
+      // instead of failing whole-chat loading at the oRPC output boundary.
+      modelFallback: ModelFallbackRecordSchema.optional().catch(undefined),
       usage: z.any().optional(),
       contextUsage: z.any().optional(),
       providerMetadata: z.record(z.string(), z.unknown()).optional(),

--- a/src/common/orpc/schemas/message.ts
+++ b/src/common/orpc/schemas/message.ts
@@ -96,6 +96,14 @@ const CompactionEpochSchema = z.optional(
   )
 );
 
+// Fallback record persisted when a configured model-fallback chain answered
+// after refusal(s). Must survive the IPC boundary so the transcript can show
+// which model was originally requested.
+export const ModelFallbackRecordSchema = z.object({
+  requestedModel: z.string(),
+  refusedModels: z.array(z.string()),
+});
+
 // MuxMessage (simplified)
 export const MuxMessageSchema = z.object({
   id: z.string(),
@@ -118,6 +126,7 @@ export const MuxMessageSchema = z.object({
       thinkingLevel: ThinkingLevelSchema.optional(),
       routedThroughGateway: z.boolean().optional(),
       routeProvider: z.string().optional(), // Preserve replayed/non-stream route attribution.
+      modelFallback: ModelFallbackRecordSchema.optional(),
       usage: z.any().optional(),
       contextUsage: z.any().optional(),
       providerMetadata: z.record(z.string(), z.unknown()).optional(),

--- a/src/common/orpc/schemas/stream.ts
+++ b/src/common/orpc/schemas/stream.ts
@@ -6,6 +6,7 @@ import { ChatUsageDisplaySchema } from "./chatStats";
 import { StreamErrorTypeSchema } from "./errors";
 import {
   FilePartSchema,
+  ModelFallbackRecordSchema,
   MuxMessageSchema,
   MuxReasoningPartSchema,
   MuxTextPartSchema,
@@ -234,6 +235,8 @@ export const StreamEndEventSchema = z.object({
       thinkingLevel: ThinkingLevelSchema.optional(),
       routedThroughGateway: z.boolean().optional(),
       routeProvider: z.string().optional(),
+      // Present when a fallback model answered after the requested model refused.
+      modelFallback: ModelFallbackRecordSchema.optional(),
       // Total usage across all steps (for cost calculation)
       usage: LanguageModelV2UsageSchema.optional(),
       // Last step's usage only (for context window display - inputTokens = current context size)

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -500,6 +500,17 @@ export interface PersistedToolModelUsage {
   providerMetadata?: Record<string, unknown>;
 }
 
+/**
+ * Record of a model-fallback chain application. `requestedModel` is the model
+ * originally asked for; `refusedModels` lists every model that refused, in
+ * chain order (the requested model is always the first entry). The effective
+ * (answering) model is recorded separately as the message's `model`.
+ */
+export interface ModelFallbackRecord {
+  requestedModel: string;
+  refusedModels: string[];
+}
+
 // Our custom metadata type
 export interface MuxMetadata {
   historySequence?: number; // Assigned by backend for global message ordering (required when writing to history)
@@ -536,10 +547,7 @@ export interface MuxMetadata {
    * records the originally requested model and the models that refused, in
    * order. Refused-attempt token usage is attributed via toolModelUsages.
    */
-  modelFallback?: {
-    requestedModel: string;
-    refusedModels: string[];
-  };
+  modelFallback?: ModelFallbackRecord;
   // Last step's provider metadata (for context window cache display)
   contextProviderMetadata?: Record<string, unknown>;
   systemMessageTokens?: number; // Token count for system message sent with this request (calculated by AIService)
@@ -743,6 +751,8 @@ export type DisplayedMessage =
       model?: string;
       routedThroughGateway?: boolean;
       routeProvider?: string;
+      /** Present when a fallback model answered after the requested model refused. */
+      modelFallback?: ModelFallbackRecord;
       agentId?: string; // Agent id active when this message was sent (assistant messages only)
       /** @deprecated Legacy base mode derived from agent definition. */
       mode?: AgentMode;

--- a/src/common/utils/ai/models.ts
+++ b/src/common/utils/ai/models.ts
@@ -4,6 +4,7 @@
 
 import { DEFAULT_MODEL, MODEL_ABBREVIATIONS } from "@/common/constants/knownModels";
 import { PROVIDER_DEFINITIONS, type ProviderName } from "@/common/constants/providers";
+import { formatModelDisplayName } from "./modelDisplay";
 
 export const defaultModel = DEFAULT_MODEL;
 
@@ -100,6 +101,16 @@ export function getModelName(modelString: string): string {
     return normalized;
   }
   return normalized.substring(colonIndex + 1);
+}
+
+/**
+ * Format a full model string (e.g. "anthropic:claude-sonnet-4-5") into its
+ * human display name (e.g. "Sonnet 4.5"). Shared by ModelDisplay,
+ * ModelSelector, and ModelFallbackBadge. Lives here (not modelDisplay.ts) to
+ * avoid a modelDisplay -> knownModels -> modelDisplay import cycle.
+ */
+export function formatModelStringForDisplay(modelString: string): string {
+  return formatModelDisplayName(getModelName(modelString));
 }
 
 /**

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, afterEach, beforeEach, mock, spyOn } from "bun:
 import * as fs from "node:fs/promises";
 
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
+import { StreamEndEventSchema } from "@/common/orpc/schemas/stream";
 import { Ok, Err } from "@/common/types/result";
 import type { ToolPolicy } from "@/common/utils/tools/toolPolicy";
 import { StreamManager, stripEncryptedContent } from "./streamManager";
@@ -2026,6 +2027,14 @@ describe("StreamManager - empty stream completions", () => {
     const metadata = streamEndEvents[0]?.metadata;
     expect(metadata?.model).toBe(fallbackModel);
     expect(metadata?.modelFallback).toEqual({
+      requestedModel: KNOWN_MODELS.SONNET.id,
+      refusedModels: [KNOWN_MODELS.SONNET.id],
+    });
+    // Pin the IPC passthrough: the oRPC schema strips unknown metadata keys, so
+    // modelFallback must survive StreamEndEventSchema or the live transcript
+    // never learns about the swap.
+    const ipcEvent = StreamEndEventSchema.parse(streamEndEvents[0]);
+    expect(ipcEvent.metadata.modelFallback).toEqual({
       requestedModel: KNOWN_MODELS.SONNET.id,
       refusedModels: [KNOWN_MODELS.SONNET.id],
     });


### PR DESCRIPTION
## Summary

When a model refuses and the configured model-fallback chain (#3505) answers instead, the transcript header now shows an amber `⇄ FALLBACK` badge next to the answering model. Hovering (or keyboard-focusing) the badge explains the swap: which model was requested, which models refused, and which model answered.

## Background

Model fallback currently swaps silently: the message header shows only the _answering_ model, so there is no transcript-visible trace that your requested model refused. The metadata (`modelFallback: { requestedModel, refusedModels[] }`) was already persisted by the backend but never reached the frontend — the oRPC zod schemas strip unknown metadata keys at the IPC boundary.

## Implementation

- `MuxMessageSchema` / `StreamEndEventSchema` gain a `modelFallback` passthrough so the record survives the IPC boundary (history replay and live stream-end).
  - The history read path uses `.catch(undefined)` (like `agentId`/`compactionEpoch`): the badge is decorative, so a shape-corrupt persisted record degrades to "no badge" instead of failing whole-chat loading.
- `displayedMessageBuilder` maps the metadata onto displayed assistant rows; `AssistantMessage` renders the new `ModelFallbackBadge` between the model display and the compacted badge.
- Tooltip copy is built by an exported pure helper (`buildModelFallbackTooltipLines`) because Radix portals are unobservable under happy-dom; lines cover single-hop, multi-hop ("Fallback X also refused."), and the answering model.
- Extracted `formatModelStringForDisplay()` (models.ts) — the badge would have been the third copy of the `formatModelDisplayName(getModelName(normalizeToCanonical(...)))` chain; ModelDisplay and ModelSelector now share it.

A deep-review pass found no P0/P1; its P2 (self-healing schema), P3 (schema roundtrip tests), and P4 findings (duplicate React keys on colliding display names, empty-string effective model, keyboard-unreachable tooltip, DRY) are addressed in the second commit. One P4 is intentionally deferred as a follow-up: during a _live_ stream the header shows the refused model until stream-end delivers the corrected metadata (and an interrupt right after a swap only shows the badge after reload) — pre-existing behavior of abort/live metadata paths, not introduced here.

## Validation

- Dogfooded in a `dev-server-sandbox` with seeded `chat.jsonl` fixtures (single-hop, multi-hop, and control messages) via agent-browser: badge renders only on fallback messages, tooltip shows the full chain.
- New behavioral tests: tooltip line building (multi-hop order, missing/empty effective model, malformed empty `refusedModels`), aggregator propagation to displayed rows, schema roundtrip + malformed-record tolerance, and a `StreamEndEventSchema.parse` assertion inside the existing streamManager fallback test so reverting either schema line fails CI.

## Risks

Low. The badge renders only when `metadata.modelFallback` is present (fallback users only); schema additions are optional fields, and the only shared-code change is the display-name helper consolidation (`normalizeToCanonical` is idempotent, so ModelDisplay/ModelSelector behavior is unchanged).

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `max` • Cost: `$68.92`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=max costs=68.92 -->
