### PR TITLE
🤖 refactor: upgrade @agentclientprotocol/sdk to 0.25.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "mux",
       "dependencies": {
         "@1password/sdk": "^0.4.0",
-        "@agentclientprotocol/sdk": "^0.14.1",
+        "@agentclientprotocol/sdk": "^0.25.0",
         "@ai-sdk/amazon-bedrock": "^4.0.101",
         "@ai-sdk/anthropic": "^3.0.75",
         "@ai-sdk/deepseek": "^2.0.33",
@@ -81,8 +81,8 @@
         "quickjs-emscripten-core": "^0.31.0",
         "react": "18.3.1",
         "react-colorful": "^5.6.1",
-        "react-resizable-panels": "^3.0.6",
         "react-dom": "18.3.1",
+        "react-resizable-panels": "^3.0.6",
         "react-router-dom": "^7.11.0",
         "recharts": "^2.15.3",
         "rehype-harden": "^1.1.5",
@@ -220,7 +220,7 @@
 
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
-    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.14.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-b6r3PS3Nly+Wyw9U+0nOr47bV8tfS476EgyEMhoKvJCZLbgqoDFN7DJwkxL88RR0aiOqOYV1ZnESHqb+RmdH8w=="],
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.25.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-wU1VgXNtMvdVotX49txc3WJUDV+/QbLpsgjMvFhlRmp37osdLbI7L7y+iwAlQATwfjLxcv1r1p3ZxZBcXlGhcQ=="],
 
     "@ai-sdk/amazon-bedrock": ["@ai-sdk/amazon-bedrock@4.0.101", "", { "dependencies": { "@ai-sdk/anthropic": "3.0.75", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "@smithy/eventstream-codec": "^4.0.1", "@smithy/util-utf8": "^4.0.0", "aws4fetch": "^1.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-+l+e0QzKFu/qyoXa/4GKe9jUjQIJyQuHgChXJlhw8CsF+Q/LO93x8e6nztegU5sjphf/MfkHr042QWJxGHk/aQ=="],
 

--- a/flake.nix
+++ b/flake.nix
@@ -83,7 +83,7 @@
 
             outputHashMode = "recursive";
             # Marker used by scripts/update_flake_hash.sh to update this hash in place.
-            outputHash = "sha256-7KIc24de24lD8yCrTzy9K5gqQLKFepHMaT0IDJQQQ8k="; # mux-offline-cache-hash
+            outputHash = "sha256-5raCJYsYFFigk1Cytu07I+ytyEPFVxR+eFlZWTKts3k="; # mux-offline-cache-hash
           };
 
           configurePhase = ''

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@1password/sdk": "^0.4.0",
-    "@agentclientprotocol/sdk": "^0.14.1",
+    "@agentclientprotocol/sdk": "^0.25.0",
     "@ai-sdk/amazon-bedrock": "^4.0.101",
     "@ai-sdk/anthropic": "^3.0.75",
     "@ai-sdk/deepseek": "^2.0.33",

--- a/src/node/acp/agent.ts
+++ b/src/node/acp/agent.ts
@@ -26,6 +26,7 @@ import type {
   SetSessionConfigOptionResponse,
   Usage,
 } from "@agentclientprotocol/sdk";
+import { RequestError } from "@agentclientprotocol/sdk";
 import {
   DEFAULT_COMPACTION_WORD_TARGET,
   WORDS_TO_TOKENS_RATIO,
@@ -630,11 +631,15 @@ export class MuxAgent implements Agent {
     assert(trimmedConfigId.length > 0, "setSessionConfigOption: configId must be non-empty");
 
     // ACP supports boolean config options since schema 0.13, but mux only
-    // exposes select options; reject boolean values until one exists.
-    assert(
-      typeof params.value === "string",
-      `setSessionConfigOption: config option '${trimmedConfigId}' expects a select value`
-    );
+    // exposes select options; reject boolean values until one exists. Surface
+    // a spec-correct InvalidParams (-32602) error — matching what pre-0.25 SDK
+    // schemas returned for boolean values — instead of a generic internal error.
+    if (typeof params.value !== "string") {
+      throw RequestError.invalidParams(
+        { configId: trimmedConfigId },
+        `config option '${trimmedConfigId}' expects a select value`
+      );
+    }
 
     const activeAgentId = this.sessionStateById.get(sessionId)?.agentId;
     const configOptions = await handleSetConfigOption(

--- a/src/node/acp/agent.ts
+++ b/src/node/acp/agent.ts
@@ -84,8 +84,8 @@ const ACP_DELEGATION_CANDIDATE_TOOLS = [
 ] as const;
 const DEFAULT_DISCONNECT_CLEANUP_MAX_WAIT_MS = 10_000;
 /**
- * ACP currently has no session/close RPC. Keep idle sessions bounded so long-lived
- * editor connections cannot leak subscriptions and per-session caches forever.
+ * Mux does not implement the session/close RPC yet. Keep idle sessions bounded so
+ * long-lived editor connections cannot leak subscriptions and per-session caches forever.
  */
 const DEFAULT_SESSION_IDLE_TTL_MS = 30 * 60 * 1000;
 const DEFAULT_MAX_TRACKED_SESSIONS = 24;
@@ -425,9 +425,9 @@ export class MuxAgent implements Agent {
     return resumed.response;
   }
 
-  async unstable_listSessions(params: ListSessionsRequest): Promise<ListSessionsResponse> {
-    this.assertInitialized("unstable_listSessions");
-    assert(params != null, "unstable_listSessions: params are required");
+  async listSessions(params: ListSessionsRequest): Promise<ListSessionsResponse> {
+    this.assertInitialized("listSessions");
+    assert(params != null, "listSessions: params are required");
 
     const normalizedCwd = normalizeOptionalPath(params.cwd);
     const offset = parseSessionListCursor(params.cursor);
@@ -464,14 +464,14 @@ export class MuxAgent implements Agent {
     };
   }
 
-  async unstable_resumeSession(params: ResumeSessionRequest): Promise<ResumeSessionResponse> {
-    this.assertInitialized("unstable_resumeSession");
+  async resumeSession(params: ResumeSessionRequest): Promise<ResumeSessionResponse> {
+    this.assertInitialized("resumeSession");
 
     const sessionId = params.sessionId.trim();
-    assert(sessionId.length > 0, "unstable_resumeSession: sessionId must be non-empty");
+    assert(sessionId.length > 0, "resumeSession: sessionId must be non-empty");
 
     const cwd = params.cwd.trim();
-    assert(cwd.length > 0, "unstable_resumeSession: cwd must be non-empty");
+    assert(cwd.length > 0, "resumeSession: cwd must be non-empty");
 
     const existingState = this.sessionStateById.get(sessionId);
     const resumed = await loadSessionFromWorkspace(
@@ -628,6 +628,13 @@ export class MuxAgent implements Agent {
     const workspaceId = this.sessionManager.getWorkspaceId(sessionId);
     const trimmedConfigId = params.configId.trim();
     assert(trimmedConfigId.length > 0, "setSessionConfigOption: configId must be non-empty");
+
+    // ACP supports boolean config options since schema 0.13, but mux only
+    // exposes select options; reject boolean values until one exists.
+    assert(
+      typeof params.value === "string",
+      `setSessionConfigOption: config option '${trimmedConfigId}' expects a select value`
+    );
 
     const activeAgentId = this.sessionStateById.get(sessionId)?.agentId;
     const configOptions = await handleSetConfigOption(
@@ -2352,10 +2359,10 @@ function parseSessionListCursor(cursor: string | null | undefined): number {
     return 0;
   }
 
-  assert(/^\d+$/.test(trimmed), `unstable_listSessions: invalid cursor '${cursor}'`);
+  assert(/^\d+$/.test(trimmed), `listSessions: invalid cursor '${cursor}'`);
 
   const parsed = Number(trimmed);
-  assert(Number.isSafeInteger(parsed), `unstable_listSessions: invalid cursor '${cursor}'`);
+  assert(Number.isSafeInteger(parsed), `listSessions: invalid cursor '${cursor}'`);
   return parsed;
 }
 

--- a/src/node/acp/capabilities.ts
+++ b/src/node/acp/capabilities.ts
@@ -12,7 +12,7 @@ export function negotiateCapabilities(
   return {
     editorSupportsFsRead: clientCaps?.fs?.readTextFile ?? false,
     editorSupportsFsWrite: clientCaps?.fs?.writeTextFile ?? false,
-    // ACP SDK v0.14.x models terminal support as an optional boolean capability.
+    // The ACP SDK models terminal support as an optional boolean capability.
     editorSupportsTerminal: clientCaps?.terminal === true,
   };
 }

--- a/tests/ipc/acp.sessionMethods.test.ts
+++ b/tests/ipc/acp.sessionMethods.test.ts
@@ -315,7 +315,7 @@ describe("ACP unstable session support", () => {
 
     await harness.agent.initialize({ protocolVersion: PROTOCOL_VERSION });
 
-    const firstPage = await harness.agent.unstable_listSessions({
+    const firstPage = await harness.agent.listSessions({
       cwd: "/repo/a/",
     });
 
@@ -327,7 +327,7 @@ describe("ACP unstable session support", () => {
       new Date(repoAArchivedRecency).toISOString(),
     ]);
 
-    const secondPage = await harness.agent.unstable_listSessions({
+    const secondPage = await harness.agent.listSessions({
       cwd: "/repo/a/",
       cursor: "1",
     });
@@ -351,7 +351,7 @@ describe("ACP unstable session support", () => {
 
     await harness.agent.initialize({ protocolVersion: PROTOCOL_VERSION });
 
-    const listResponse = await harness.agent.unstable_listSessions({
+    const listResponse = await harness.agent.listSessions({
       cwd: "/repo/monorepo/packages/api",
     });
     expect(listResponse.sessions.map((session) => session.sessionId)).toEqual(["ws-sub-project"]);
@@ -373,13 +373,13 @@ describe("ACP unstable session support", () => {
     await harness.agent.initialize({ protocolVersion: PROTOCOL_VERSION });
 
     await expect(
-      harness.agent.unstable_listSessions({
+      harness.agent.listSessions({
         cursor: "not-a-number",
       })
     ).rejects.toThrow("invalid cursor");
 
     await expect(
-      harness.agent.unstable_listSessions({
+      harness.agent.listSessions({
         cursor: "1abc",
       })
     ).rejects.toThrow("invalid cursor");
@@ -400,7 +400,7 @@ describe("ACP unstable session support", () => {
     await harness.agent.initialize({ protocolVersion: PROTOCOL_VERSION });
 
     await expect(
-      harness.agent.unstable_resumeSession({
+      harness.agent.resumeSession({
         sessionId: "ws-cwd-check",
         cwd: "/repo/wrong",
         mcpServers: [],
@@ -422,7 +422,7 @@ describe("ACP unstable session support", () => {
 
     await harness.agent.initialize({ protocolVersion: PROTOCOL_VERSION });
 
-    const response = await harness.agent.unstable_resumeSession({
+    const response = await harness.agent.resumeSession({
       sessionId: "ws-resume",
       cwd: "/repo/resume/",
       mcpServers: [],
@@ -449,7 +449,7 @@ describe("ACP unstable session support", () => {
 
     await harness.agent.initialize({ protocolVersion: PROTOCOL_VERSION });
 
-    await harness.agent.unstable_resumeSession({
+    await harness.agent.resumeSession({
       sessionId: "ws-live-to-full",
       cwd: "/repo/resume",
       mcpServers: [],
@@ -600,17 +600,17 @@ describe("ACP unstable session support", () => {
 
     await harness.agent.initialize({ protocolVersion: PROTOCOL_VERSION });
 
-    await harness.agent.unstable_resumeSession({
+    await harness.agent.resumeSession({
       sessionId: "ws-a",
       cwd: "/repo/lru",
       mcpServers: [],
     });
-    await harness.agent.unstable_resumeSession({
+    await harness.agent.resumeSession({
       sessionId: "ws-b",
       cwd: "/repo/lru",
       mcpServers: [],
     });
-    await harness.agent.unstable_resumeSession({
+    await harness.agent.resumeSession({
       sessionId: "ws-c",
       cwd: "/repo/lru",
       mcpServers: [],

--- a/tests/ipc/acp.sessionMethods.test.ts
+++ b/tests/ipc/acp.sessionMethods.test.ts
@@ -1,4 +1,9 @@
-import { AgentSideConnection, PROTOCOL_VERSION, ndJsonStream } from "@agentclientprotocol/sdk";
+import {
+  AgentSideConnection,
+  ClientSideConnection,
+  PROTOCOL_VERSION,
+  ndJsonStream,
+} from "@agentclientprotocol/sdk";
 import type { ProjectConfig } from "../../src/common/types/project";
 import type { OnChatMode, WorkspaceChatMessage } from "../../src/common/orpc/types";
 import { MuxAgent } from "../../src/node/acp/agent";
@@ -71,7 +76,16 @@ function createWorkspaceInfo(overrides?: Partial<WorkspaceInfo>): WorkspaceInfo 
   };
 }
 
-function createHarness(options?: HarnessOptions): Harness {
+interface MockServer {
+  server: ServerConnection;
+  onChatCalls: Array<{ workspaceId: string; mode?: OnChatMode }>;
+  setTrustCalls: Array<{ projectPath: string; trusted: boolean }>;
+  createCalls: WorkspaceCreateInput[];
+  forkCalls: WorkspaceForkInput[];
+  listCalls: Array<{ archived?: boolean } | undefined>;
+}
+
+function createMockServer(options?: HarnessOptions): MockServer {
   const activeWorkspaces = options?.activeWorkspaces ?? [createWorkspaceInfo()];
   const archivedWorkspaces = options?.archivedWorkspaces ?? [];
   const workspaceActivity = options?.workspaceActivity ?? {};
@@ -196,12 +210,18 @@ function createHarness(options?: HarnessOptions): Harness {
     close: async () => undefined,
   };
 
+  return { server, onChatCalls, setTrustCalls, createCalls, forkCalls, listCalls };
+}
+
+function createHarness(options?: HarnessOptions): Harness {
+  const mockServer = createMockServer(options);
+
   let agentInstance: MuxAgent | null = null;
   // Use a real ACP connection instead of casting a hand-rolled stub to
   // AgentSideConnection. This keeps the test harness type-safe and exercises
   // the same connection surface MuxAgent uses in production.
   const _connection = new AgentSideConnection((connectionToAgent) => {
-    const createdAgent = new MuxAgent(connectionToAgent, server, options?.agentOptions);
+    const createdAgent = new MuxAgent(connectionToAgent, mockServer.server, options?.agentOptions);
     agentInstance = createdAgent;
     return createdAgent;
   }, createInMemoryAcpStream());
@@ -213,12 +233,48 @@ function createHarness(options?: HarnessOptions): Harness {
 
   return {
     agent: agentInstance,
-    onChatCalls,
-    setTrustCalls,
-    createCalls,
-    forkCalls,
-    listCalls,
+    onChatCalls: mockServer.onChatCalls,
+    setTrustCalls: mockServer.setTrustCalls,
+    createCalls: mockServer.createCalls,
+    forkCalls: mockServer.forkCalls,
+    listCalls: mockServer.listCalls,
   };
+}
+
+// Cross-wired in-memory pipes so a real ClientSideConnection talks to the real
+// AgentSideConnection over JSON-RPC. Unlike createHarness (which invokes MuxAgent
+// methods directly and therefore renames in lockstep with the implementation),
+// this exercises the SDK's wire dispatch: a missed Agent-interface rename (the
+// SDK declares listSessions/resumeSession as optional, e.g. unstable_listSessions
+// -> listSessions in SDK 0.16/0.20) still typechecks but fails here with
+// METHOD_NOT_FOUND.
+function createWireHarness(options?: HarnessOptions): { client: ClientSideConnection } {
+  const mockServer = createMockServer(options);
+  const clientToAgent = new TransformStream<Uint8Array, Uint8Array>();
+  const agentToClient = new TransformStream<Uint8Array, Uint8Array>();
+
+  const _agentConnection = new AgentSideConnection(
+    (connectionToAgent) =>
+      new MuxAgent(connectionToAgent, mockServer.server, options?.agentOptions),
+    ndJsonStream(agentToClient.writable, clientToAgent.readable)
+  );
+  void _agentConnection;
+
+  const client = new ClientSideConnection(
+    () => ({
+      requestPermission: async (params) => {
+        const firstOption = params.options[0];
+        if (firstOption == null) {
+          throw new Error("createWireHarness: requestPermission expected at least one option");
+        }
+        return { outcome: { outcome: "selected" as const, optionId: firstOption.optionId } };
+      },
+      sessionUpdate: async () => undefined,
+    }),
+    ndJsonStream(clientToAgent.writable, agentToClient.readable)
+  );
+
+  return { client };
 }
 
 async function* createChatStream(
@@ -246,8 +302,8 @@ function createNeverEndingChatStream(
     },
   };
 }
-describe("ACP unstable session support", () => {
-  it("advertises unstable list/fork/resume session capabilities", async () => {
+describe("ACP session list/resume/fork support", () => {
+  it("advertises list/resume and unstable fork session capabilities", async () => {
     const harness = createHarness();
 
     const response = await harness.agent.initialize({
@@ -383,6 +439,37 @@ describe("ACP unstable session support", () => {
         cursor: "1abc",
       })
     ).rejects.toThrow("invalid cursor");
+  });
+
+  it("rejects boolean config option values with an invalid-params error", async () => {
+    const workspace = createWorkspaceInfo({
+      id: "ws-bool-config",
+      projectPath: "/repo/boolcfg",
+      namedWorkspacePath: "/repo/boolcfg/.mux/ws-bool-config",
+    });
+
+    const harness = createHarness({
+      activeWorkspaces: [workspace],
+      onChatEvents: [{ type: "caught-up" } as WorkspaceChatMessage],
+    });
+
+    await harness.agent.initialize({ protocolVersion: PROTOCOL_VERSION });
+    await harness.agent.resumeSession({
+      sessionId: "ws-bool-config",
+      cwd: "/repo/boolcfg",
+      mcpServers: [],
+    });
+
+    // SDK 0.25 schemas permit {type:"boolean"} config values, but mux only
+    // exposes select options; the agent must reject rather than forward them.
+    await expect(
+      harness.agent.setSessionConfigOption({
+        sessionId: "ws-bool-config",
+        configId: "model",
+        type: "boolean",
+        value: true,
+      })
+    ).rejects.toThrow("expects a select value");
   });
 
   it("rejects resume when session does not belong to requested cwd", async () => {
@@ -626,5 +713,54 @@ describe("ACP unstable session support", () => {
     expect(sessionStateMap.has("ws-b")).toBe(true);
     expect(sessionStateMap.has("ws-c")).toBe(true);
     expect(harness.onChatCalls).toHaveLength(3);
+  });
+});
+
+describe("ACP wire-level session dispatch", () => {
+  // Regression guard for SDK upgrades: Agent-interface methods are optional in
+  // the SDK, so a missed stabilization rename would typecheck and pass the
+  // direct-call tests above while the wire dispatch silently answers
+  // METHOD_NOT_FOUND. This round-trip pins the JSON-RPC routing itself.
+  it("routes session/list, session/resume, and session/set_config_option", async () => {
+    const workspace = createWorkspaceInfo({
+      id: "ws-wire",
+      projectPath: "/repo/wire",
+      namedWorkspacePath: "/repo/wire/.mux/ws-wire",
+    });
+
+    const wire = createWireHarness({
+      activeWorkspaces: [workspace],
+      onChatEvents: [{ type: "caught-up" } as WorkspaceChatMessage],
+    });
+
+    const initResponse = await wire.client.initialize({
+      protocolVersion: PROTOCOL_VERSION,
+    });
+    expect(initResponse.agentCapabilities?.sessionCapabilities?.list).toEqual({});
+
+    const listResponse = await wire.client.listSessions({ cwd: "/repo/wire" });
+    expect(listResponse.sessions.map((session) => session.sessionId)).toEqual(["ws-wire"]);
+
+    const resumeResponse = await wire.client.resumeSession({
+      sessionId: "ws-wire",
+      cwd: "/repo/wire",
+      mcpServers: [],
+    });
+    expect(resumeResponse?.configOptions?.length).toBeGreaterThan(0);
+
+    // Boolean config values pass SDK schema validation but must surface a
+    // JSON-RPC invalid-params error (not a crash or hang).
+    await expect(
+      wire.client.setSessionConfigOption({
+        sessionId: "ws-wire",
+        configId: "model",
+        type: "boolean",
+        value: true,
+      })
+    ).rejects.toThrow("expects a select value");
+
+    // The connection must survive the rejected request.
+    const listAfterError = await wire.client.listSessions({ cwd: "/repo/wire" });
+    expect(listAfterError.sessions).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

Upgrades `@agentclientprotocol/sdk` from `^0.14.1` to `^0.25.0`, adopting the stabilized `listSessions` / `resumeSession` agent method names (formerly `unstable_*`), guarding `session/set_config_option` against the newly-schema-legal boolean config values mux doesn't support, and adding a wire-level dispatch regression test.

## Background

The ACP TypeScript SDK moved from 0.14 to 0.25 with several protocol stabilizations:

- 0.16 stabilized `unstable_listSessions` → `listSessions`
- 0.20 stabilized `unstable_resumeSession` → `resumeSession`
- The schema widened `SetSessionConfigOptionRequest.value` to a discriminated union (`string | boolean` via `type: "select" | "boolean"`)

Wire compatibility is preserved: the JSON-RPC method names (`session/list`, `session/resume`, `session/fork`, `session/set_config_option`), `PROTOCOL_VERSION = 1`, capability shapes, and the `Usage`/`ndJsonStream` surfaces are identical between 0.14.1 and 0.25.0 (verified by diffing the installed package against a downloaded 0.14.1 tarball). `unstable_forkSession` remains experimental upstream and is unchanged.

## Implementation

- `src/node/acp/agent.ts`: renamed the two stabilized methods (and their assert-message prefixes). Added a guard in `setSessionConfigOption` rejecting non-string values with a spec-correct JSON-RPC `-32602 InvalidParams` error — pre-0.25 SDK zod schemas rejected boolean values at the schema layer with the same code, so this restores prior wire semantics. Mux only exposes select-type config options.
- `tests/ipc/acp.sessionMethods.test.ts`: renamed call sites; extracted `createMockServer` from the harness and added `createWireHarness` — two cross-wired `ndJsonStream` pipes connecting a real `ClientSideConnection` to the real `AgentSideConnection`/`MuxAgent`. A new wire-level test pins JSON-RPC routing for `session/list`, `session/resume`, and `session/set_config_option`, because Agent-interface methods are _optional_ in the SDK: a missed stabilization rename typechecks cleanly and passes direct-call tests while the wire silently answers `METHOD_NOT_FOUND`. This matters again when `unstable_forkSession` eventually stabilizes.
- New direct-call test covering the boolean config value rejection.

### Deep-review findings addressed

The built-in `deep-review-workflow` was run on the upgrade commit; verdict "sound and safe to land" with five low-severity findings, all fixed here:

| Finding                                                                                         | Severity | Fix                            |
| ----------------------------------------------------------------------------------------------- | -------- | ------------------------------ |
| Boolean-rejection branch (the upgrade's only behavioral change) had zero coverage               | P3       | New direct-call test           |
| Optional Agent-interface methods make missed renames invisible to typecheck + direct-call tests | P3       | New wire-level round-trip test |
| Assert-based rejection surfaced as `-32603 Internal error` instead of `-32602 Invalid params`   | P4       | `RequestError.invalidParams`   |
| Test labels still said "unstable" for stabilized methods                                        | P4       | Renamed describes/test names   |
| Stale `// ACP SDK v0.14.x ...` comment                                                          | P4       | Version pin dropped            |

## Validation

- `make static-check` green; frozen-lockfile install passes under the pinned Bun 1.3.5.
- All 8 ACP jest suites pass (`tests/ipc/acp.*.test.ts`), including the two new tests.
- Live end-to-end verification against the built CLI (`dist/cli/index.js acp`) in an isolated `MUX_ROOT` sandbox:
  - **acpx 0.10.0** (itself on SDK ^0.22.1): `sessions new`, `sessions list` (exercises renamed `listSessions`), `status`, `set agentMode plan`, and a full real prompt turn (initialize → session/new → `file_read` tool call → correct reply → `end_turn`).
  - Raw wire script using SDK 0.25's `ClientSideConnection` over stdio: initialize, session/list, session/resume, session/load, session/fork, set_config_option (string accepted, boolean rejected; connection survives the rejection).
- Known non-regression: `tests/ipc/acp.integration.test.ts` "prompt completes with usage" fails locally with `Forbidden` — reproduced identically on 0.14.1 before the upgrade (local proxy credential issue); expected to pass in CI with its own `ANTHROPIC_API_KEY`.

## Risks

Low. The renames are wire-transparent (same JSON-RPC method strings), and clients that don't send boolean config values see no behavioral change. The one behavioral delta — boolean config values now rejected by an explicit agent-side guard instead of the SDK's zod schema — returns the same `-32602` error code as before. Affected area is limited to the ACP server surface (`mux acp`), used by external editor integrations.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `max` • Cost: `$59.57`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=max costs=59.57 -->
