### PR TITLE
🤖 feat: seed default Fable 5 → Opus 4.8 refusal fallback (one-time, user-respecting)

### DIFF
--- a/src/common/config/schemas/appConfigOnDisk.ts
+++ b/src/common/config/schemas/appConfigOnDisk.ts
@@ -73,6 +73,8 @@ export const ModelFallbacksSchema = z.record(z.string(), ModelFallbackEntrySchem
 export const AppConfigMigrationsSchema = z.object({
   execSubagentDefaultsSplit: z.boolean().optional(),
   userPreferencesInitialized: z.boolean().optional(),
+  /** One-time seed of DEFAULT_MODEL_FALLBACKS; never re-applied once true. */
+  defaultModelFallbacksSeeded: z.boolean().optional(),
 });
 
 export const FeatureFlagOverrideSchema = z.enum(["default", "on", "off"]);

--- a/src/common/config/schemas/appConfigOnDisk.ts
+++ b/src/common/config/schemas/appConfigOnDisk.ts
@@ -70,12 +70,17 @@ export const ModelFallbackEntrySchema = z.object({
 /** Per-model fallback chains, keyed by canonical source model. */
 export const ModelFallbacksSchema = z.record(z.string(), ModelFallbackEntrySchema);
 
-export const AppConfigMigrationsSchema = z.object({
-  execSubagentDefaultsSplit: z.boolean().optional(),
-  userPreferencesInitialized: z.boolean().optional(),
-  /** One-time seed of DEFAULT_MODEL_FALLBACKS; never re-applied once true. */
-  defaultModelFallbacksSeeded: z.boolean().optional(),
-});
+export const AppConfigMigrationsSchema = z
+  .object({
+    execSubagentDefaultsSplit: z.boolean().optional(),
+    userPreferencesInitialized: z.boolean().optional(),
+    /** One-time seed of DEFAULT_MODEL_FALLBACKS; not re-applied while true. */
+    defaultModelFallbacksSeeded: z.boolean().optional(),
+  })
+  // Preserve flags introduced by newer app versions: without the catchall a
+  // downgrade to this version would strip unknown flags on save, re-running
+  // their one-time migrations after re-upgrade (see normalizeConfigMigrations).
+  .catchall(z.boolean());
 
 export const FeatureFlagOverrideSchema = z.enum(["default", "on", "off"]);
 

--- a/src/common/utils/ai/modelFallbacks.test.ts
+++ b/src/common/utils/ai/modelFallbacks.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import {
+  DEFAULT_MODEL_FALLBACKS,
   MODEL_FALLBACK_CHAIN_LIMIT,
   resolveModelFallbackChain,
   sanitizeModelFallbackChain,
@@ -102,5 +103,24 @@ describe("sanitizeModelFallbacks", () => {
     ).toEqual({
       [SOURCE]: { enabled: true, triggers: ["model_refusal"], models: [FALLBACK_A] },
     });
+  });
+});
+
+describe("DEFAULT_MODEL_FALLBACKS", () => {
+  it("survives sanitization unchanged", () => {
+    // The config seed writes the constant verbatim while every read path
+    // sanitizes; a default that violates chain invariants (self-fallback,
+    // non-canonical key, over-limit chain) would be silently dropped on read,
+    // turning the shipped default into a no-op.
+    expect(sanitizeModelFallbacks(DEFAULT_MODEL_FALLBACKS)).toEqual(DEFAULT_MODEL_FALLBACKS);
+  });
+
+  it("is deeply frozen so shared references cannot be mutated in place", () => {
+    for (const [sourceModel, entry] of Object.entries(DEFAULT_MODEL_FALLBACKS)) {
+      expect(() => entry.models.push(sourceModel)).toThrow();
+      expect(() => {
+        entry.enabled = false;
+      }).toThrow();
+    }
   });
 });

--- a/src/common/utils/ai/modelFallbacks.ts
+++ b/src/common/utils/ai/modelFallbacks.ts
@@ -1,3 +1,4 @@
+import { KNOWN_MODELS } from "@/common/constants/knownModels";
 import { normalizeToCanonical } from "@/common/utils/ai/models";
 import type { ModelFallbacks } from "@/common/config/schemas/appConfigOnDisk";
 
@@ -6,6 +7,20 @@ import type { ModelFallbacks } from "@/common/config/schemas/appConfigOnDisk";
  * per turn, so this bounds the worst case to 1 + 3 provider calls per refusal.
  */
 export const MODEL_FALLBACK_CHAIN_LIMIT = 3;
+
+/**
+ * Default refusal-fallback chains shipped with the app. Fable 5 runs with
+ * safeguards that refuse some requests Opus happily serves (Anthropic itself
+ * falls back to Opus 4.8 server-side for flagged requests), so retrying on
+ * Opus 4.8 is the sensible out-of-the-box behavior.
+ *
+ * Seeded into the config exactly once, guarded by
+ * migrations.defaultModelFallbacksSeeded — user edits or deletions of these
+ * chains are never overridden by later app updates.
+ */
+export const DEFAULT_MODEL_FALLBACKS: ModelFallbacks = {
+  [KNOWN_MODELS.FABLE.id]: { models: [KNOWN_MODELS.OPUS.id] },
+};
 
 /**
  * Sanitize one fallback chain relative to its source model: canonicalize every

--- a/src/common/utils/ai/modelFallbacks.ts
+++ b/src/common/utils/ai/modelFallbacks.ts
@@ -15,12 +15,22 @@ export const MODEL_FALLBACK_CHAIN_LIMIT = 3;
  * Opus 4.8 is the sensible out-of-the-box behavior.
  *
  * Seeded into the config exactly once, guarded by
- * migrations.defaultModelFallbacksSeeded — user edits or deletions of these
- * chains are never overridden by later app updates.
+ * migrations.defaultModelFallbacksSeeded — on versions that know the flag,
+ * user edits or deletions of these chains are never overridden by updates.
+ * (Versions predating the flag strip it on save, so a downgrade→save→
+ * re-upgrade round-trip re-seeds a deleted chain; bounded to re-adding this
+ * benign, re-deletable default.)
  */
 export const DEFAULT_MODEL_FALLBACKS: ModelFallbacks = {
   [KNOWN_MODELS.FABLE.id]: { models: [KNOWN_MODELS.OPUS.id] },
 };
+// Deep-freeze: entries are spread by reference into live configs (fresh-install
+// defaults, seed merge). Accidental in-place mutation must crash fast instead
+// of silently corrupting the process-wide default.
+for (const entry of Object.values(Object.freeze(DEFAULT_MODEL_FALLBACKS))) {
+  Object.freeze(entry);
+  Object.freeze(entry.models);
+}
 
 /**
  * Sanitize one fallback chain relative to its source model: canonicalize every

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -307,6 +307,97 @@ describe("Config", () => {
       expect(config.loadConfigOrDefault().modelFallbacks).toBeUndefined();
     });
 
+    it("merges the seeded default with pre-existing chains for other source models", () => {
+      fs.writeFileSync(
+        configFilePath(),
+        JSON.stringify({
+          projects: [],
+          modelFallbacks: {
+            "anthropic:claude-opus-4-6": { models: ["openai:gpt-5.5"] },
+          },
+        })
+      );
+
+      const loaded = config.loadConfigOrDefault();
+      expect(loaded.modelFallbacks).toEqual({
+        "anthropic:claude-opus-4-6": { models: ["openai:gpt-5.5"] },
+        [FABLE]: { models: [OPUS] },
+      });
+
+      // The user's chain must survive the seed write-back on disk unchanged.
+      const raw = JSON.parse(fs.readFileSync(configFilePath(), "utf-8")) as {
+        modelFallbacks?: unknown;
+        migrations?: { defaultModelFallbacksSeeded?: unknown };
+      };
+      expect(raw.modelFallbacks).toEqual({
+        "anthropic:claude-opus-4-6": { models: ["openai:gpt-5.5"] },
+        [FABLE]: { models: [OPUS] },
+      });
+      expect(raw.migrations?.defaultModelFallbacksSeeded).toBe(true);
+    });
+
+    it("does not double-seed when the user chain uses a gateway-prefixed Fable key", () => {
+      fs.writeFileSync(
+        configFilePath(),
+        JSON.stringify({
+          projects: [],
+          modelFallbacks: {
+            "openrouter:anthropic/claude-fable-5": { models: ["openai:gpt-5.5"] },
+          },
+        })
+      );
+
+      // The gateway-prefixed key canonicalizes to the same source model, so
+      // the seed must treat it as configured and leave the user's chain alone.
+      expect(config.loadConfigOrDefault().modelFallbacks).toEqual({
+        [FABLE]: { models: ["openai:gpt-5.5"] },
+      });
+    });
+
+    it("respects a hand-edited tombstone whose chain sanitizes away", () => {
+      fs.writeFileSync(
+        configFilePath(),
+        JSON.stringify({
+          projects: [],
+          modelFallbacks: {
+            [FABLE]: { enabled: false, models: [] },
+          },
+        })
+      );
+
+      const loaded = config.loadConfigOrDefault();
+      // The entry sanitizes to nothing at runtime (no fallback fires), but it
+      // is still user intent: the seed must not replace it with an enabled
+      // default chain, and the raw on-disk form must survive.
+      expect(loaded.modelFallbacks).toBeUndefined();
+      expect(loaded.migrations?.defaultModelFallbacksSeeded).toBe(true);
+
+      const raw = JSON.parse(fs.readFileSync(configFilePath(), "utf-8")) as {
+        modelFallbacks?: unknown;
+      };
+      expect(raw.modelFallbacks).toEqual({ [FABLE]: { enabled: false, models: [] } });
+    });
+
+    it("preserves unknown migration flags from newer app versions across saves", async () => {
+      fs.writeFileSync(
+        configFilePath(),
+        JSON.stringify({
+          projects: [],
+          migrations: { defaultModelFallbacksSeeded: true, futureFlag: true },
+        })
+      );
+
+      await config.editConfig((cfg) => cfg);
+
+      // A downgrade to this version + save must not strip flags it does not
+      // know, or the corresponding one-time migrations re-run on re-upgrade.
+      const raw = JSON.parse(fs.readFileSync(configFilePath(), "utf-8")) as {
+        migrations?: Record<string, unknown>;
+      };
+      expect(raw.migrations?.futureFlag).toBe(true);
+      expect(raw.migrations?.defaultModelFallbacksSeeded).toBe(true);
+    });
+
     it("preserves a pre-existing user chain for the seeded source model", () => {
       fs.writeFileSync(
         configFilePath(),

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_WORKTREE_ARCHIVE_BEHAVIOR,
   WORKTREE_ARCHIVE_BEHAVIORS,
 } from "@/common/config/worktreeArchiveBehavior";
+import { KNOWN_MODELS } from "@/common/constants/knownModels";
 import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
 import { type ExternalSecretResolver, secretsToRecord } from "@/common/types/secrets";
 
@@ -244,6 +245,8 @@ describe("Config", () => {
         configFile,
         JSON.stringify({
           projects: [],
+          // Keep this test focused on normalization, not default seeding.
+          migrations: { defaultModelFallbacksSeeded: true },
           modelFallbacks: {
             // Gateway-prefixed key + non-string chain entries + unknown trigger.
             "openrouter:anthropic/claude-opus-4-6": {
@@ -268,6 +271,73 @@ describe("Config", () => {
           triggers: [],
         },
       });
+    });
+  });
+
+  describe("default model fallbacks seeding", () => {
+    const FABLE = KNOWN_MODELS.FABLE.id;
+    const OPUS = KNOWN_MODELS.OPUS.id;
+    const configFilePath = () => path.join(tempDir, "config.json");
+
+    it("seeds the default chain once on first load and persists the migration flag", () => {
+      fs.writeFileSync(configFilePath(), JSON.stringify({ projects: [] }));
+
+      const loaded = config.loadConfigOrDefault();
+      expect(loaded.modelFallbacks).toEqual({ [FABLE]: { models: [OPUS] } });
+      expect(loaded.migrations?.defaultModelFallbacksSeeded).toBe(true);
+
+      // Seed is written back so the flag survives restarts even without saves.
+      const raw = JSON.parse(fs.readFileSync(configFilePath(), "utf-8")) as {
+        modelFallbacks?: unknown;
+        migrations?: { defaultModelFallbacksSeeded?: unknown };
+      };
+      expect(raw.modelFallbacks).toEqual({ [FABLE]: { models: [OPUS] } });
+      expect(raw.migrations?.defaultModelFallbacksSeeded).toBe(true);
+    });
+
+    it("does not re-seed after the user deletes the default chain", () => {
+      fs.writeFileSync(
+        configFilePath(),
+        JSON.stringify({
+          projects: [],
+          migrations: { defaultModelFallbacksSeeded: true },
+        })
+      );
+
+      expect(config.loadConfigOrDefault().modelFallbacks).toBeUndefined();
+    });
+
+    it("preserves a pre-existing user chain for the seeded source model", () => {
+      fs.writeFileSync(
+        configFilePath(),
+        JSON.stringify({
+          projects: [],
+          modelFallbacks: {
+            [FABLE]: { enabled: false, models: ["openai:gpt-5.5"] },
+          },
+        })
+      );
+
+      const loaded = config.loadConfigOrDefault();
+      expect(loaded.modelFallbacks).toEqual({
+        [FABLE]: { enabled: false, models: ["openai:gpt-5.5"] },
+      });
+      expect(loaded.migrations?.defaultModelFallbacksSeeded).toBe(true);
+    });
+
+    it("applies the defaults to fresh installs and locks the flag on first save", async () => {
+      expect(config.loadConfigOrDefault().modelFallbacks).toEqual({
+        [FABLE]: { models: [OPUS] },
+      });
+
+      await config.editConfig((cfg) => cfg);
+
+      const raw = JSON.parse(fs.readFileSync(configFilePath(), "utf-8")) as {
+        modelFallbacks?: unknown;
+        migrations?: { defaultModelFallbacksSeeded?: unknown };
+      };
+      expect(raw.modelFallbacks).toEqual({ [FABLE]: { models: [OPUS] } });
+      expect(raw.migrations?.defaultModelFallbacksSeeded).toBe(true);
     });
   });
 
@@ -1124,6 +1194,9 @@ describe("Config", () => {
           routeOverrides: {
             "openai:gpt-4o": "direct",
           },
+          // Without this flag the one-time default-fallbacks seed would write
+          // the file, which is not the rewrite this test guards against.
+          migrations: { defaultModelFallbacksSeeded: true },
         })
       );
 

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -26,7 +26,7 @@ import type {
   ModelFallbacks,
   ProvidersConfig as CanonicalProvidersConfig,
 } from "@/common/config/schemas";
-import { sanitizeModelFallbacks } from "@/common/utils/ai/modelFallbacks";
+import { DEFAULT_MODEL_FALLBACKS, sanitizeModelFallbacks } from "@/common/utils/ai/modelFallbacks";
 import {
   DEFAULT_TASK_SETTINGS,
   deriveLegacySubagentAiDefaultsFromAgentDefaults,
@@ -374,6 +374,7 @@ function normalizeConfigMigrations(value: unknown): AppConfigMigrations {
   return {
     ...(record.execSubagentDefaultsSplit === true ? { execSubagentDefaultsSplit: true } : {}),
     ...(record.userPreferencesInitialized === true ? { userPreferencesInitialized: true } : {}),
+    ...(record.defaultModelFallbacksSeeded === true ? { defaultModelFallbacksSeeded: true } : {}),
   };
 }
 
@@ -819,6 +820,30 @@ export class Config {
         const minThinkingLevelByModel = normalizeMinThinkingLevelByModel(
           parsed.minThinkingLevelByModel
         );
+        // One-time seed of the default refusal-fallback chains (e.g. Fable 5 →
+        // Opus 4.8). Guarded by migrations.defaultModelFallbacksSeeded so the
+        // seed is applied exactly once: users who later edit or delete the
+        // default chains are not overridden on subsequent loads/updates.
+        const migrationsBeforeSeed = normalizeConfigMigrations(parsed.migrations);
+        if (migrationsBeforeSeed.defaultModelFallbacksSeeded !== true) {
+          const existingFallbacks = normalizeModelFallbacks(parsed.modelFallbacks);
+          // Respect chains the user already configured for a default's source
+          // model (including explicitly disabled ones); only fill in the gaps.
+          const missingDefaults = Object.fromEntries(
+            Object.entries(DEFAULT_MODEL_FALLBACKS).filter(
+              ([sourceModel]) => existingFallbacks?.[sourceModel] === undefined
+            )
+          );
+          if (Object.keys(missingDefaults).length > 0) {
+            parsed.modelFallbacks = { ...existingFallbacks, ...missingDefaults };
+          }
+          parsed.migrations = {
+            ...migrationsBeforeSeed,
+            defaultModelFallbacksSeeded: true,
+          };
+          configModified = true;
+        }
+
         const modelFallbacks = normalizeModelFallbacks(parsed.modelFallbacks);
 
         const defaultModel = normalizeOptionalModelString(parsed.defaultModel);
@@ -999,6 +1024,11 @@ export class Config {
       coderWorkspaceArchiveBehavior: DEFAULT_CODER_ARCHIVE_BEHAVIOR,
       worktreeArchiveBehavior: DEFAULT_WORKTREE_ARCHIVE_BEHAVIOR,
       deleteWorktreeOnArchive: false,
+      // Fresh installs get the default refusal-fallback chains immediately; the
+      // migration flag rides along so the first save locks in seed-once
+      // semantics (later loads never re-apply the defaults).
+      modelFallbacks: { ...DEFAULT_MODEL_FALLBACKS },
+      migrations: { defaultModelFallbacksSeeded: true },
     };
   }
 
@@ -1191,6 +1221,7 @@ export class Config {
       if (
         migrations.execSubagentDefaultsSplit === true ||
         migrations.userPreferencesInitialized === true ||
+        migrations.defaultModelFallbacksSeeded === true ||
         config.userPreferences !== undefined ||
         config.agentAiDefaults?.exec != null ||
         config.subagentAiDefaults?.exec != null

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -371,11 +371,17 @@ function normalizeConfigMigrations(value: unknown): AppConfigMigrations {
   }
 
   const record = value as Record<string, unknown>;
-  return {
-    ...(record.execSubagentDefaultsSplit === true ? { execSubagentDefaultsSplit: true } : {}),
-    ...(record.userPreferencesInitialized === true ? { userPreferencesInitialized: true } : {}),
-    ...(record.defaultModelFallbacksSeeded === true ? { defaultModelFallbacksSeeded: true } : {}),
-  };
+  // Pass through every true-valued flag, including ones this version does not
+  // know about. Migration flags from newer app versions must survive a
+  // downgrade-to-here + save, otherwise their one-time migrations re-run after
+  // re-upgrade (e.g. re-seeding defaults a user deleted).
+  const migrations: AppConfigMigrations = {};
+  for (const [flag, flagValue] of Object.entries(record)) {
+    if (flagValue === true) {
+      migrations[flag] = true;
+    }
+  }
+  return migrations;
 }
 
 function extractAgentDefaultsFromLegacySubagents(
@@ -826,16 +832,31 @@ export class Config {
         // default chains are not overridden on subsequent loads/updates.
         const migrationsBeforeSeed = normalizeConfigMigrations(parsed.migrations);
         if (migrationsBeforeSeed.defaultModelFallbacksSeeded !== true) {
-          const existingFallbacks = normalizeModelFallbacks(parsed.modelFallbacks);
-          // Respect chains the user already configured for a default's source
-          // model (including explicitly disabled ones); only fill in the gaps.
+          // Gap-check against the RAW on-disk map with canonicalized keys, not
+          // the sanitized map: a hand-edited entry whose chain sanitizes away
+          // (e.g. {enabled:false, models:[]}) is still user intent and must not
+          // be overwritten. Merging into the raw map also keeps unrelated
+          // chains byte-identical on disk (lenient-on-read preserved).
+          const rawFallbacks =
+            typeof parsed.modelFallbacks === "object" &&
+            parsed.modelFallbacks !== null &&
+            !Array.isArray(parsed.modelFallbacks)
+              ? (parsed.modelFallbacks as Record<string, unknown>)
+              : {};
+          const existingCanonicalKeys = new Set(
+            Object.keys(rawFallbacks).map((key) => normalizeToCanonical(key).trim())
+          );
           const missingDefaults = Object.fromEntries(
             Object.entries(DEFAULT_MODEL_FALLBACKS).filter(
-              ([sourceModel]) => existingFallbacks?.[sourceModel] === undefined
+              ([sourceModel]) => !existingCanonicalKeys.has(sourceModel)
             )
           );
           if (Object.keys(missingDefaults).length > 0) {
-            parsed.modelFallbacks = { ...existingFallbacks, ...missingDefaults };
+            // Write through the raw-record view: user entries are deliberately
+            // kept unvalidated on disk (normalizeModelFallbacks sanitizes on
+            // every read), so the merged map is not a ModelFallbacks yet.
+            const rawParsed: Record<string, unknown> = parsed;
+            rawParsed.modelFallbacks = { ...rawFallbacks, ...missingDefaults };
           }
           parsed.migrations = {
             ...migrationsBeforeSeed,
@@ -1218,10 +1239,10 @@ export class Config {
       }
 
       const migrations = normalizeConfigMigrations(config.migrations);
+      // Any true flag (known or from a newer version) must persist; the spread
+      // below writes them all, so gate only on presence.
       if (
-        migrations.execSubagentDefaultsSplit === true ||
-        migrations.userPreferencesInitialized === true ||
-        migrations.defaultModelFallbacksSeeded === true ||
+        Object.keys(migrations).length > 0 ||
         config.userPreferences !== undefined ||
         config.agentAiDefaults?.exec != null ||
         config.subagentAiDefaults?.exec != null


### PR DESCRIPTION
## Summary

Ships a sensible out-of-the-box refusal fallback: when **Claude Fable 5** refuses with zero output, the turn retries on **Opus 4.8**. The default is seeded into `~/.mux/config.json` exactly once (guarded by `migrations.defaultModelFallbacksSeeded`), so users who edit or delete the chain are never overridden by later app updates.

## Background

#3505 added opt-in per-model refusal fallback chains but shipped no defaults. Fable 5 runs with safeguards that refuse some requests Opus happily serves (Anthropic itself falls back to Opus 4.8 server-side for flagged requests), so Fable → Opus 4.8 is the natural default. The requirement: a one-time seed that respects user intent on every subsequent load/update.

## Implementation

- `DEFAULT_MODEL_FALLBACKS` (`src/common/utils/ai/modelFallbacks.ts`): `anthropic:claude-fable-5 → anthropic:claude-opus-4-8`, built from `KNOWN_MODELS` so IDs cannot drift. Deep-frozen — entries are spread by reference into live configs, so accidental in-place mutation crashes fast.
- **Seed-once on load** (`src/node/config.ts`): if `migrations.defaultModelFallbacksSeeded` is unset, missing defaults are merged into the **raw** on-disk map (gap-checked by canonicalized key) and the flag is persisted via the existing atomic, crash-safe write-back. Existing user entries — including gateway-prefixed keys and hand-edited disabled tombstones whose chains sanitize away — block the seed and survive byte-identical on disk.
- **Fresh installs**: the default config includes the chain and the flag; the first save locks seed-once semantics.
- **Downgrade hardening** (from deep-review finding FB-1): `normalizeConfigMigrations` now passes through *unknown* true-valued migration flags and `AppConfigMigrationsSchema` gained a boolean catchall, so flags introduced by newer versions survive a downgrade-to-this-version + save instead of being stripped (which would re-run their one-time migrations after re-upgrade). Downgrades to versions predating this change remain unfixable retroactively; the constant's doc comment scopes the guarantee accordingly.
- The `saveConfig` migrations gate now keys on presence of any flag instead of a hand-enumerated OR-list.

## Validation

- A deep-review workflow pass (4 lanes + adversarial verification) found 6 issues (2×P3, 4×P4); all are fixed in the second commit, including new regression tests for the merge path, gateway-prefixed keys, tombstones, unknown-flag durability, the `sanitizeModelFallbacks(DEFAULT_MODEL_FALLBACKS)` round-trip invariant, and the frozen constant.
- Dogfooded the full lifecycle against the real `Config` class: pre-update config → chain active + flag persisted; delete chain → restart → stays deleted; fresh install → chain active immediately; newer-version unknown flag survives an unrelated save on this version; hand-edited tombstone survives the seed.
- `make static-check`, `make typecheck`, full `src/node` + config/fallback/schema suites green (10 pre-existing flaky UI failures reproduced identically on `origin/main`).

## Risks

Low. The seed runs inside the existing parse-success branch of `loadConfigOrDefault` with try/catch-wrapped persistence, so startup cannot crash on write failure (idempotent re-seed next launch). Worst verified outcome is the known, documented limitation: a downgrade to a pre-flag version + save + re-upgrade re-seeds the (benign, re-deletable) default chain.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `max` • Cost: `$3.16`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=max costs=3.16 -->
