### PR TITLE
🤖 fix: archive selects same-project chat above instead of jumping projects

### DIFF
--- a/src/browser/contexts/WorkspaceContext.tsx
+++ b/src/browser/contexts/WorkspaceContext.tsx
@@ -1191,12 +1191,16 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
           // removing it from the active metadata map. Otherwise we can briefly render the
           // root-route empty shell while still on `/workspace/:id`.
           //
-          // Prefer the next workspace in sidebar DOM order (like Ctrl+J) so the user
-          // stays in flow; fall back to the project page when no siblings remain.
+          // Prefer nearby chats in the same project first so archive does not jump the
+          // user into another project; fall back to the project page when none remain.
           if (meta !== null && isNowArchived) {
             const currentSelection = selectedWorkspaceRef.current;
             if (currentSelection?.workspaceId === event.workspaceId) {
-              const nextId = findAdjacentWorkspaceId(event.workspaceId);
+              const nextId = findAdjacentWorkspaceId(event.workspaceId, {
+                preferredProjectPath: meta.projectPath,
+                getProjectPath: (workspaceId) =>
+                  workspaceMetadataRef.current.get(workspaceId)?.projectPath,
+              });
               const nextMeta = nextId ? workspaceMetadataRef.current.get(nextId) : null;
 
               if (nextMeta) {

--- a/src/browser/utils/ui/workspaceDomNav.test.ts
+++ b/src/browser/utils/ui/workspaceDomNav.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { GlobalWindow } from "happy-dom";
+
+import { findAdjacentWorkspaceId, getVisibleWorkspaceIds } from "./workspaceDomNav";
+
+function appendWorkspaceRow(workspaceId: string): void {
+  const row = document.createElement("div");
+  row.setAttribute("data-workspace-id", workspaceId);
+  row.setAttribute("data-workspace-path", `/tmp/${workspaceId}`);
+  document.body.appendChild(row);
+}
+
+function renderWorkspaceRows(workspaceIds: string[]): void {
+  document.body.innerHTML = "";
+  workspaceIds.forEach(appendWorkspaceRow);
+}
+
+describe("workspaceDomNav", () => {
+  beforeEach(() => {
+    const happyWindow = new GlobalWindow();
+    globalThis.window = happyWindow as unknown as Window & typeof globalThis;
+    globalThis.document = happyWindow.document as unknown as Document;
+    (globalThis as unknown as { HTMLElement: unknown }).HTMLElement = happyWindow.HTMLElement;
+  });
+
+  afterEach(() => {
+    globalThis.window = undefined as unknown as Window & typeof globalThis;
+    globalThis.document = undefined as unknown as Document;
+    (globalThis as unknown as { HTMLElement?: unknown }).HTMLElement = undefined;
+  });
+
+  test("returns visible workspace IDs in DOM order", () => {
+    renderWorkspaceRows(["alpha", "beta", "gamma"]);
+
+    expect(getVisibleWorkspaceIds()).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  test("prefers the workspace above in the same project when archiving", () => {
+    renderWorkspaceRows(["same-above", "same-current", "other-below"]);
+
+    const projectByWorkspaceId: Record<string, string> = {
+      "same-above": "/projects/same",
+      "same-current": "/projects/same",
+      "other-below": "/projects/other",
+    };
+
+    expect(
+      findAdjacentWorkspaceId("same-current", {
+        preferredProjectPath: "/projects/same",
+        getProjectPath: (workspaceId) => projectByWorkspaceId[workspaceId],
+      })
+    ).toBe("same-above");
+  });
+
+  test("prefers the workspace below in the same project before leaving the project", () => {
+    renderWorkspaceRows(["other-above", "same-current", "same-below"]);
+
+    const projectByWorkspaceId: Record<string, string> = {
+      "other-above": "/projects/other",
+      "same-current": "/projects/same",
+      "same-below": "/projects/same",
+    };
+
+    expect(
+      findAdjacentWorkspaceId("same-current", {
+        preferredProjectPath: "/projects/same",
+        getProjectPath: (workspaceId) => projectByWorkspaceId[workspaceId],
+      })
+    ).toBe("same-below");
+  });
+
+  test("falls back to the workspace above when no same-project chat remains", () => {
+    renderWorkspaceRows(["other-above", "same-current", "other-below"]);
+
+    const projectByWorkspaceId: Record<string, string> = {
+      "other-above": "/projects/other",
+      "same-current": "/projects/same",
+      "other-below": "/projects/other-2",
+    };
+
+    expect(
+      findAdjacentWorkspaceId("same-current", {
+        preferredProjectPath: "/projects/same",
+        getProjectPath: (workspaceId) => projectByWorkspaceId[workspaceId],
+      })
+    ).toBe("other-above");
+  });
+
+  test("prefers a visible same-project chat when the current row is not rendered", () => {
+    renderWorkspaceRows(["other-above", "same-below"]);
+
+    const projectByWorkspaceId: Record<string, string> = {
+      "same-current": "/projects/same",
+      "other-above": "/projects/other",
+      "same-below": "/projects/same",
+    };
+
+    expect(
+      findAdjacentWorkspaceId("same-current", {
+        preferredProjectPath: "/projects/same",
+        getProjectPath: (workspaceId) => projectByWorkspaceId[workspaceId],
+      })
+    ).toBe("same-below");
+  });
+});

--- a/src/browser/utils/ui/workspaceDomNav.ts
+++ b/src/browser/utils/ui/workspaceDomNav.ts
@@ -2,15 +2,22 @@
  * DOM-based workspace navigation utilities.
  *
  * Reads the rendered sidebar to determine workspace ordering. This is the
- * canonical source of truth for "next/previous workspace" because it reflects
- * the exact visual order the user sees (respecting sort, sections, collapsed
+ * canonical source of truth for visual workspace navigation because it reflects
+ * the exact order the user sees (respecting sort, sections, collapsed
  * projects, etc.).
  *
- * Shared by Ctrl+J/K navigation and the archive-then-navigate behaviour.
+ * Shared by Ctrl+J/K navigation and archive-then-navigate behaviour.
  */
 
 /** Compound selector that targets only workspace *row* elements. */
 const WORKSPACE_ROW_SELECTOR = "[data-workspace-id][data-workspace-path]";
+
+export interface FindAdjacentWorkspaceIdOptions {
+  /** Project to keep the selection in when a sibling chat exists there. */
+  preferredProjectPath: string;
+  /** Resolve a visible workspace row to its project path. */
+  getProjectPath: (workspaceId: string) => string | undefined;
+}
 
 /** Return all visible workspace IDs in DOM (sidebar) order. */
 export function getVisibleWorkspaceIds(): string[] {
@@ -22,26 +29,30 @@ export function getVisibleWorkspaceIds(): string[] {
  * Given a workspace that is about to be removed (archived / deleted), return
  * the ID of the workspace the user should land on next.
  *
- * Prefers the item immediately *after* {@link currentWorkspaceId} (so the list
- * feels like it scrolled up to fill the gap), falling back to the item before
- * it.  When the current workspace isn't rendered at all (e.g. its project or
- * section is collapsed), returns the first visible workspace — matching how
- * Ctrl+J picks a target when the selection is off-screen.
+ * User rationale: archiving a chat should stay in the same project when
+ * possible so removing one row does not unexpectedly jump to another project.
+ * Selection priority: same-project row above, same-project row below, any row
+ * above, any row below, otherwise null.
  *
- * Returns `null` only when no other workspaces are visible in the sidebar.
+ * When the current workspace is not rendered at all (e.g. its project or
+ * section is collapsed), every other visible row counts as "below" so the same
+ * preference chain applies.
  */
-export function findAdjacentWorkspaceId(currentWorkspaceId: string): string | null {
+export function findAdjacentWorkspaceId(
+  currentWorkspaceId: string,
+  options: FindAdjacentWorkspaceIdOptions
+): string | null {
   const ids = getVisibleWorkspaceIds();
   const idx = ids.indexOf(currentWorkspaceId);
 
-  if (idx === -1) {
-    // Current workspace not rendered (collapsed project/section) — pick the
-    // first visible workspace that isn't the one being removed.
-    return ids.find((id) => id !== currentWorkspaceId) ?? null;
-  }
+  // Nearest-first on both sides: walk upward from the removed row, then downward.
+  const above = idx === -1 ? [] : ids.slice(0, idx).reverse();
+  const below = idx === -1 ? ids.filter((id) => id !== currentWorkspaceId) : ids.slice(idx + 1);
 
-  // Prefer next (below), then previous (above).
-  if (idx + 1 < ids.length) return ids[idx + 1];
-  if (idx - 1 >= 0) return ids[idx - 1];
-  return null;
+  const inPreferredProject = (id: string) =>
+    options.getProjectPath(id) === options.preferredProjectPath;
+
+  return (
+    above.find(inPreferredProject) ?? below.find(inPreferredProject) ?? above[0] ?? below[0] ?? null
+  );
 }


### PR DESCRIPTION
## Summary

Archiving the currently-selected chat now lands on the chat **above** it in the sidebar (instead of below), and prioritises chats in the **same project** before falling back to other projects.

## Background

Archiving a chat picked the next selection via a pure DOM-order walk (`findAdjacentWorkspaceId`), preferring the row below with no awareness of project boundaries. Archiving the last chat in a project would jump the user into a different project's chat, which is disorienting. The delete path already preferred same-project siblings, so archive was the odd one out.

## Implementation

`findAdjacentWorkspaceId` still reads the rendered sidebar DOM (the canonical visual order shared with Ctrl+J/K), but now takes required project context and applies a single preference chain: same-project row above → same-project row below → any row above → any row below → `null`. When the archived row isn't rendered (collapsed project/section), all other visible rows are treated as "below" so the same chain applies. The archive handler in `WorkspaceContext` passes the archived workspace's `projectPath` and resolves rows to projects via the in-memory metadata map; when nothing is selectable it falls back to the project page as before. Ctrl+J/K navigation uses `getVisibleWorkspaceIds` directly and is unaffected.

## Risks

Low. The change is scoped to the post-archive selection path; covered by new happy-dom unit tests for same-project priority, above/below ordering, and the collapsed-row fallback.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$4.60`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=4.60 -->
