### PR TITLE
🤖 fix: mask regex literals in workflow action static export detection

### DIFF
--- a/src/node/services/workflows/WorkflowActionRunner.test.ts
+++ b/src/node/services/workflows/WorkflowActionRunner.test.ts
@@ -361,6 +361,55 @@ describe("WorkflowActionRunner", () => {
     expect(description.hasReconcile).toBe(false);
   });
 
+  test("detects exports in sources containing regex literals", async () => {
+    using tmp = new DisposableTempDir("workflow-action-regex-mask");
+    const sourcePath = path.join(tmp.path, "regex.js");
+    // Regression: "//" inside regex literals (URL matchers, comment strippers) was
+    // misread as a line comment, swallowing the rest of the line. That unbalanced the
+    // masked source and hid the execute export ("must export an execute function").
+    const source = `
+      module.exports.metadata = { version: 1, description: "Regex", effect: "read" };
+      function stripBlockComments(text) {
+        return String(text).replace(/\\/\\*[\\s\\S]*?\\*\\//g, "");
+      }
+      function isHttpUrl(text) {
+        return /^https?:\\/\\//.test(text);
+      }
+      const half = 10 / 2;
+      module.exports.execute = async function (input) {
+        return { url: isHttpUrl(String(input)), ratio: stripBlockComments(String(input)).length / half };
+      };
+    `;
+    await fs.writeFile(sourcePath, source, "utf-8");
+    const runner = new WorkflowActionRunner();
+
+    const description = await runner.describe(createAction(sourcePath, source));
+
+    expect(description.metadata.description).toBe("Regex");
+    expect(description.hasReconcile).toBe(false);
+  });
+
+  test("describes every built-in workflow action", async () => {
+    // Built-in sources must always pass static describe validation; a failure here
+    // surfaces in the UI as a "blocked" action (e.g. security.hashFiles, whose regex
+    // literals previously broke the static export detection).
+    using tmp = new DisposableTempDir("workflow-action-built-in-describe");
+    const registry = new WorkflowActionRegistry({
+      projectRoot: path.join(tmp.path, "project-actions"),
+      globalRoot: path.join(tmp.path, "global-actions"),
+    });
+    const runner = new WorkflowActionRunner();
+
+    const actions = await registry.listActions({ projectTrusted: false });
+
+    expect(actions.length).toBeGreaterThan(0);
+    for (const action of actions) {
+      const resolved = await registry.resolveAction(action.name, { projectTrusted: false });
+      const description = await runner.describe(resolved);
+      expect(description.metadata.description).toBeTruthy();
+    }
+  });
+
   test("does not rewrite export syntax inside action strings", async () => {
     using tmp = new DisposableTempDir("workflow-action-export-template");
     const sourcePath = path.join(tmp.path, "template.js");

--- a/src/node/services/workflows/WorkflowActionRunner.test.ts
+++ b/src/node/services/workflows/WorkflowActionRunner.test.ts
@@ -400,6 +400,13 @@ describe("WorkflowActionRunner", () => {
       `module.exports.metadata = { version: 1, description: "Division", effect: "read" }; const n = \`10\` / 2; module.exports.execute = async () => ({ n });`,
       `module.exports.metadata = { version: 1, description: "Division", effect: "read" }; let count = 4; const n = count++ / 2; module.exports.execute = async () => ({ n });`,
       `module.exports.metadata = { version: 1, description: "Division", effect: "read" }; const n = { valueOf() { return 10; } } / 2; module.exports.execute = async () => ({ n });`,
+      // Object-literal division followed by a real regex on the same line: the later
+      // "/" must not be mistaken for the closing delimiter of a regex starting at the
+      // division slash (which would mask the execute export between them).
+      `module.exports.metadata = { version: 1, description: "Division", effect: "read" }; const n = { valueOf() { return 10; } } / 2; module.exports.execute = async () => /x/.test("x");`,
+      // Counter-case: "}" closing a block (not an object literal) still starts a regex;
+      // the "(" inside the character class must stay masked or it corrupts paren depth.
+      `module.exports.metadata = { version: 1, description: "Division", effect: "read" }; if (globalThis.x) {} /^[(]/.test("a"); module.exports.execute = async () => ({ ok: true });`,
     ];
     const runner = new WorkflowActionRunner();
     for (const [index, source] of sources.entries()) {

--- a/src/node/services/workflows/WorkflowActionRunner.test.ts
+++ b/src/node/services/workflows/WorkflowActionRunner.test.ts
@@ -389,6 +389,27 @@ describe("WorkflowActionRunner", () => {
     expect(description.hasReconcile).toBe(false);
   });
 
+  test("treats division after masked literals as division, even on one line", async () => {
+    using tmp = new DisposableTempDir("workflow-action-division-mask");
+    // Regression (Codex review): masking strings to spaces erased the value token
+    // before "/", so division after a string/template literal was misread as a regex
+    // start. With a single "/" in a one-line (minified) source, everything after it —
+    // including the execute export — was masked away, blocking a valid action.
+    const sources = [
+      `module.exports.metadata = { version: 1, description: "Division", effect: "read" }; const n = "10" / 2; module.exports.execute = async () => ({ n });`,
+      `module.exports.metadata = { version: 1, description: "Division", effect: "read" }; const n = \`10\` / 2; module.exports.execute = async () => ({ n });`,
+    ];
+    const runner = new WorkflowActionRunner();
+    for (const [index, source] of sources.entries()) {
+      const sourcePath = path.join(tmp.path, `division-${index}.js`);
+      await fs.writeFile(sourcePath, source, "utf-8");
+
+      const description = await runner.describe(createAction(sourcePath, source));
+
+      expect(description.metadata.description).toBe("Division");
+    }
+  });
+
   test("describes every built-in workflow action", async () => {
     // Built-in sources must always pass static describe validation; a failure here
     // surfaces in the UI as a "blocked" action (e.g. security.hashFiles, whose regex

--- a/src/node/services/workflows/WorkflowActionRunner.test.ts
+++ b/src/node/services/workflows/WorkflowActionRunner.test.ts
@@ -398,6 +398,8 @@ describe("WorkflowActionRunner", () => {
     const sources = [
       `module.exports.metadata = { version: 1, description: "Division", effect: "read" }; const n = "10" / 2; module.exports.execute = async () => ({ n });`,
       `module.exports.metadata = { version: 1, description: "Division", effect: "read" }; const n = \`10\` / 2; module.exports.execute = async () => ({ n });`,
+      `module.exports.metadata = { version: 1, description: "Division", effect: "read" }; let count = 4; const n = count++ / 2; module.exports.execute = async () => ({ n });`,
+      `module.exports.metadata = { version: 1, description: "Division", effect: "read" }; const n = { valueOf() { return 10; } } / 2; module.exports.execute = async () => ({ n });`,
     ];
     const runner = new WorkflowActionRunner();
     for (const [index, source] of sources.entries()) {

--- a/src/node/services/workflows/WorkflowActionRunner.test.ts
+++ b/src/node/services/workflows/WorkflowActionRunner.test.ts
@@ -407,6 +407,12 @@ describe("WorkflowActionRunner", () => {
       // Counter-case: "}" closing a block (not an object literal) still starts a regex;
       // the "(" inside the character class must stay masked or it corrupts paren depth.
       `module.exports.metadata = { version: 1, description: "Division", effect: "read" }; if (globalThis.x) {} /^[(]/.test("a"); module.exports.execute = async () => ({ ok: true });`,
+      // Object literals introduced by ternary/logical operators are values too.
+      `module.exports.metadata = { version: 1, description: "Division", effect: "read" }; const n = globalThis.cond ? { valueOf() { return 10; } } / 2 : 0; module.exports.execute = async () => /x/.test("x");`,
+      `module.exports.metadata = { version: 1, description: "Division", effect: "read" }; const n = globalThis.flag || { valueOf() { return 10; } } / 2; module.exports.execute = async () => /x/.test("x");`,
+      // Counter-case: ")" closing a control-statement header is statement position, so
+      // a regex (not division) follows; its "(" must stay masked.
+      `module.exports.metadata = { version: 1, description: "Division", effect: "read" }; if (globalThis.x) /^[(]/.test("a"); module.exports.execute = async () => ({ ok: true });`,
     ];
     const runner = new WorkflowActionRunner();
     for (const [index, source] of sources.entries()) {

--- a/src/node/services/workflows/WorkflowActionRunner.test.ts
+++ b/src/node/services/workflows/WorkflowActionRunner.test.ts
@@ -413,6 +413,12 @@ describe("WorkflowActionRunner", () => {
       // Counter-case: ")" closing a control-statement header is statement position, so
       // a regex (not division) follows; its "(" must stay masked.
       `module.exports.metadata = { version: 1, description: "Division", effect: "read" }; if (globalThis.x) /^[(]/.test("a"); module.exports.execute = async () => ({ ok: true });`,
+      // A masked regex literal is itself a value: dividing it keeps the next "/" as
+      // division instead of pairing with a later regex and masking across.
+      `module.exports.metadata = { version: 1, description: "Division", effect: "read" }; const n = /x/ / 2; module.exports.execute = async () => /y/.test("y");`,
+      // Counter-case: a regex literal as the right operand of division still gets
+      // masked (its "(" and "[" must not corrupt depth counting).
+      `module.exports.metadata = { version: 1, description: "Division", effect: "read" }; const a = 4; const q = a / /([(])/.source.length; module.exports.execute = async () => ({ q });`,
     ];
     const runner = new WorkflowActionRunner();
     for (const [index, source] of sources.entries()) {

--- a/src/node/services/workflows/WorkflowActionRunner.ts
+++ b/src/node/services/workflows/WorkflowActionRunner.ts
@@ -573,10 +573,16 @@ function maskStaticJavaScriptSource(source: string): string {
       // instead of swallowing the rest of the line and hiding real exports.
       const closingIndex = findRegExpLiteralEnd(source, index);
       if (closingIndex !== -1) {
-        while (index <= closingIndex) {
+        // Keep the "/" delimiters (mask only the body) so isRegExpLiteralStart still
+        // sees the literal as a value and `/x/ / 2` stays division.
+        output += "/";
+        index += 1;
+        while (index < closingIndex) {
           output += " ";
           index += 1;
         }
+        output += "/";
+        index += 1;
         continue;
       }
     }
@@ -667,10 +673,11 @@ const REGEX_PRECEDING_KEYWORDS = new Set([
 const IDENTIFIER_CHARACTER = /[A-Za-z0-9_$]/;
 
 /**
- * Heuristic lexer rule for "/" disambiguation: division follows a value
- * (identifier, number, ")", or "]"); a regex literal follows an operator,
- * punctuation, start of file, or a keyword like `return`. Receives the already
- * masked prefix so comment/string contents never influence the decision.
+ * Heuristic lexer rule for "/" disambiguation: division follows a value (identifier,
+ * number, "]", a kept string/regex delimiter, postfix ++/--, an object-literal "}",
+ * or a call/grouping ")"); a regex literal follows an operator, punctuation, start of
+ * file, a keyword like `return`, a block "}", or a control-header ")". Receives the
+ * already masked prefix so comment/string/regex contents never influence the decision.
  */
 function isRegExpLiteralStart(maskedPrefix: string): boolean {
   let index = maskedPrefix.length - 1;
@@ -714,6 +721,18 @@ function isRegExpLiteralStart(maskedPrefix: string): boolean {
     // ")" is ambiguous too: a control-statement header (`if (x) /re/.test(s)`) is
     // followed by statement position, while a call/grouping result is a value.
     return isControlHeaderEnd(maskedPrefix, index);
+  }
+  if (character === "/") {
+    // A kept "/" is either the closing delimiter of a masked regex literal or a
+    // division operator. Skipping the space-masked body backwards lands on the
+    // opening "/" only in the regex case: the literal is a value, so division
+    // follows (`/x/ / 2`). A division operator is preceded by its value operand
+    // instead, so the current slash opens a regex (`a / /re/.source`).
+    let before = index - 1;
+    while (before >= 0 && (maskedPrefix[before] === " " || maskedPrefix[before] === "\n")) {
+      before -= 1;
+    }
+    return !(before >= 0 && maskedPrefix[before] === "/");
   }
   // Values end with "]" or a kept quote delimiter of a masked literal;
   // a "/" after any of these is division, not a regex literal.

--- a/src/node/services/workflows/WorkflowActionRunner.ts
+++ b/src/node/services/workflows/WorkflowActionRunner.ts
@@ -563,6 +563,40 @@ function maskStaticJavaScriptSource(source: string): string {
       }
       continue;
     }
+    if (current === "/" && isRegExpLiteralStart(output)) {
+      // Mask regex literal bodies: characters like "//", "(", or "[" inside a regex
+      // (e.g. /https:\/\// or /\/\*[\s\S]*?\*\//) must not be misread as comments or
+      // counted toward bracket depth, which would unbalance the masked source.
+      output += " ";
+      index += 1;
+      let inCharacterClass = false;
+      while (index < source.length) {
+        const regexCurrent = source[index];
+        assert(regexCurrent != null, "maskStaticJavaScriptSource: regex character is required");
+        if (regexCurrent === "\n") {
+          // Regex literals cannot span lines; bail so a misclassified division
+          // (e.g. after a masked string) damages at most one line.
+          break;
+        }
+        output += " ";
+        index += 1;
+        if (regexCurrent === "\\") {
+          if (index < source.length && source[index] !== "\n") {
+            output += " ";
+            index += 1;
+          }
+          continue;
+        }
+        if (regexCurrent === "[") {
+          inCharacterClass = true;
+        } else if (regexCurrent === "]") {
+          inCharacterClass = false;
+        } else if (regexCurrent === "/" && !inCharacterClass) {
+          break;
+        }
+      }
+      continue;
+    }
     if (current === '"' || current === "'" || current === "`") {
       const quote = current;
       output += " ";
@@ -592,6 +626,62 @@ function maskStaticJavaScriptSource(source: string): string {
   }
   assert(output.length === source.length, "maskStaticJavaScriptSource must preserve indexes");
   return output;
+}
+
+// Keywords after which "/" begins a regex literal rather than division (e.g. `return /x/`).
+const REGEX_PRECEDING_KEYWORDS = new Set([
+  "return",
+  "throw",
+  "typeof",
+  "instanceof",
+  "in",
+  "of",
+  "new",
+  "delete",
+  "void",
+  "case",
+  "do",
+  "else",
+  "yield",
+  "await",
+]);
+
+const IDENTIFIER_CHARACTER = /[A-Za-z0-9_$]/;
+
+/**
+ * Heuristic lexer rule for "/" disambiguation: division follows a value
+ * (identifier, number, ")", or "]"); a regex literal follows an operator,
+ * punctuation, start of file, or a keyword like `return`. Receives the already
+ * masked prefix so comment/string contents never influence the decision.
+ */
+function isRegExpLiteralStart(maskedPrefix: string): boolean {
+  let index = maskedPrefix.length - 1;
+  while (index >= 0) {
+    const character = maskedPrefix[index];
+    if (character === " " || character === "\n" || character === "\t" || character === "\r") {
+      index -= 1;
+      continue;
+    }
+    break;
+  }
+  if (index < 0) {
+    return true;
+  }
+  const character = maskedPrefix[index];
+  assert(character != null, "isRegExpLiteralStart: character is required");
+  if (IDENTIFIER_CHARACTER.test(character)) {
+    let start = index;
+    while (start >= 0) {
+      const wordCharacter = maskedPrefix[start];
+      assert(wordCharacter != null, "isRegExpLiteralStart: word character is required");
+      if (!IDENTIFIER_CHARACTER.test(wordCharacter)) {
+        break;
+      }
+      start -= 1;
+    }
+    return REGEX_PRECEDING_KEYWORDS.has(maskedPrefix.slice(start + 1, index + 1));
+  }
+  return character !== ")" && character !== "]";
 }
 
 function isTopLevelStaticMatch(maskedSource: string, matchIndex: number): boolean {

--- a/src/node/services/workflows/WorkflowActionRunner.ts
+++ b/src/node/services/workflows/WorkflowActionRunner.ts
@@ -567,35 +567,18 @@ function maskStaticJavaScriptSource(source: string): string {
       // Mask regex literal bodies: characters like "//", "(", or "[" inside a regex
       // (e.g. /https:\/\// or /\/\*[\s\S]*?\*\//) must not be misread as comments or
       // counted toward bracket depth, which would unbalance the masked source.
-      output += " ";
-      index += 1;
-      let inCharacterClass = false;
-      while (index < source.length) {
-        const regexCurrent = source[index];
-        assert(regexCurrent != null, "maskStaticJavaScriptSource: regex character is required");
-        if (regexCurrent === "\n") {
-          // Regex literals cannot span lines; bail so a misclassified division
-          // (e.g. after a masked string) damages at most one line.
-          break;
+      // Regex literals cannot span lines, so a candidate without a closing "/" on the
+      // same line must be division whose left operand the heuristic did not recognize
+      // (e.g. `count++ / total` or `{ valueOf() {...} } / 2`); leave it unmasked
+      // instead of swallowing the rest of the line and hiding real exports.
+      const closingIndex = findRegExpLiteralEnd(source, index);
+      if (closingIndex !== -1) {
+        while (index <= closingIndex) {
+          output += " ";
+          index += 1;
         }
-        output += " ";
-        index += 1;
-        if (regexCurrent === "\\") {
-          if (index < source.length && source[index] !== "\n") {
-            output += " ";
-            index += 1;
-          }
-          continue;
-        }
-        if (regexCurrent === "[") {
-          inCharacterClass = true;
-        } else if (regexCurrent === "]") {
-          inCharacterClass = false;
-        } else if (regexCurrent === "/" && !inCharacterClass) {
-          break;
-        }
+        continue;
       }
-      continue;
     }
     if (current === '"' || current === "'" || current === "`") {
       const quote = current;
@@ -628,6 +611,39 @@ function maskStaticJavaScriptSource(source: string): string {
   }
   assert(output.length === source.length, "maskStaticJavaScriptSource must preserve indexes");
   return output;
+}
+
+/**
+ * Returns the index of the "/" closing the regex literal opened at openIndex, or -1
+ * when the literal does not close before the end of the line/source (in which case
+ * the opening "/" cannot be a regex literal). Honors "\" escapes and [...] character
+ * classes, inside which "/" does not terminate the literal.
+ */
+function findRegExpLiteralEnd(source: string, openIndex: number): number {
+  assert(source[openIndex] === "/", "findRegExpLiteralEnd: openIndex must point at '/'");
+  let index = openIndex + 1;
+  let inCharacterClass = false;
+  while (index < source.length) {
+    const character = source[index];
+    assert(character != null, "findRegExpLiteralEnd: character is required");
+    if (character === "\n") {
+      return -1;
+    }
+    if (character === "\\") {
+      // Skip the escaped character unless it is a newline (which still ends the line).
+      index += source[index + 1] === "\n" ? 1 : 2;
+      continue;
+    }
+    if (character === "[") {
+      inCharacterClass = true;
+    } else if (character === "]") {
+      inCharacterClass = false;
+    } else if (character === "/" && !inCharacterClass) {
+      return index;
+    }
+    index += 1;
+  }
+  return -1;
 }
 
 // Keywords after which "/" begins a regex literal rather than division (e.g. `return /x/`).
@@ -682,6 +698,11 @@ function isRegExpLiteralStart(maskedPrefix: string): boolean {
       start -= 1;
     }
     return REGEX_PRECEDING_KEYWORDS.has(maskedPrefix.slice(start + 1, index + 1));
+  }
+  if (character === "+" || character === "-") {
+    // Postfix increment/decrement ends a value, so `count++ / total` is division.
+    // Require exactly two: `a+++/x/` lexes as `a++ + /x/`, a regex context.
+    return !(maskedPrefix[index - 1] === character && maskedPrefix[index - 2] !== character);
   }
   // Values end with ")", "]", or a kept quote delimiter of a masked literal;
   // a "/" after any of these is division, not a regex literal.

--- a/src/node/services/workflows/WorkflowActionRunner.ts
+++ b/src/node/services/workflows/WorkflowActionRunner.ts
@@ -599,13 +599,19 @@ function maskStaticJavaScriptSource(source: string): string {
     }
     if (current === '"' || current === "'" || current === "`") {
       const quote = current;
-      output += " ";
+      // Keep the quote delimiters (mask only the contents) so isRegExpLiteralStart
+      // still sees a value token after the literal and `"10" / 2` stays division.
+      output += quote;
       index += 1;
       while (index < source.length) {
         const stringCurrent = source[index];
         assert(stringCurrent != null, "maskStaticJavaScriptSource: string character is required");
-        output += stringCurrent === "\n" ? "\n" : " ";
         index += 1;
+        if (stringCurrent === quote) {
+          output += quote;
+          break;
+        }
+        output += stringCurrent === "\n" ? "\n" : " ";
         if (stringCurrent === "\\") {
           if (index < source.length) {
             const escaped = source[index];
@@ -613,10 +619,6 @@ function maskStaticJavaScriptSource(source: string): string {
             output += escaped === "\n" ? "\n" : " ";
             index += 1;
           }
-          continue;
-        }
-        if (stringCurrent === quote) {
-          break;
         }
       }
       continue;
@@ -681,7 +683,15 @@ function isRegExpLiteralStart(maskedPrefix: string): boolean {
     }
     return REGEX_PRECEDING_KEYWORDS.has(maskedPrefix.slice(start + 1, index + 1));
   }
-  return character !== ")" && character !== "]";
+  // Values end with ")", "]", or a kept quote delimiter of a masked literal;
+  // a "/" after any of these is division, not a regex literal.
+  return (
+    character !== ")" &&
+    character !== "]" &&
+    character !== '"' &&
+    character !== "'" &&
+    character !== "`"
+  );
 }
 
 function isTopLevelStaticMatch(maskedSource: string, matchIndex: number): boolean {

--- a/src/node/services/workflows/WorkflowActionRunner.ts
+++ b/src/node/services/workflows/WorkflowActionRunner.ts
@@ -710,15 +710,71 @@ function isRegExpLiteralStart(maskedPrefix: string): boolean {
     // the matching "{".
     return !isObjectLiteralEnd(maskedPrefix, index);
   }
-  // Values end with ")", "]", or a kept quote delimiter of a masked literal;
+  if (character === ")") {
+    // ")" is ambiguous too: a control-statement header (`if (x) /re/.test(s)`) is
+    // followed by statement position, while a call/grouping result is a value.
+    return isControlHeaderEnd(maskedPrefix, index);
+  }
+  // Values end with "]" or a kept quote delimiter of a masked literal;
   // a "/" after any of these is division, not a regex literal.
-  return (
-    character !== ")" &&
-    character !== "]" &&
-    character !== '"' &&
-    character !== "'" &&
-    character !== "`"
-  );
+  return character !== "]" && character !== '"' && character !== "'" && character !== "`";
+}
+
+// Keywords whose parenthesized header is followed by statement position, so a "/"
+// after the closing ")" starts a regex (e.g. `if (x) /re/.test(s)`).
+const PAREN_STATEMENT_KEYWORDS = new Set(["if", "while", "for", "switch", "with"]);
+
+/**
+ * Determines whether the ")" at closeParenIndex ends a control-statement header by
+ * finding the matching "(" in the masked prefix and checking whether a control
+ * keyword precedes it.
+ */
+function isControlHeaderEnd(maskedPrefix: string, closeParenIndex: number): boolean {
+  assert(maskedPrefix[closeParenIndex] === ")", "isControlHeaderEnd: index must point at ')'");
+  let depth = 0;
+  let openParenIndex = -1;
+  for (let index = closeParenIndex; index >= 0; index -= 1) {
+    const character = maskedPrefix[index];
+    if (character === ")") {
+      depth += 1;
+    } else if (character === "(") {
+      depth -= 1;
+      if (depth === 0) {
+        openParenIndex = index;
+        break;
+      }
+    }
+  }
+  if (openParenIndex <= 0) {
+    return false;
+  }
+  let index = openParenIndex - 1;
+  while (index >= 0) {
+    const character = maskedPrefix[index];
+    if (character === " " || character === "\n" || character === "\t" || character === "\r") {
+      index -= 1;
+      continue;
+    }
+    break;
+  }
+  if (index < 0) {
+    return false;
+  }
+  const character = maskedPrefix[index];
+  assert(character != null, "isControlHeaderEnd: character is required");
+  if (!IDENTIFIER_CHARACTER.test(character)) {
+    return false;
+  }
+  let start = index;
+  while (start >= 0) {
+    const wordCharacter = maskedPrefix[start];
+    assert(wordCharacter != null, "isControlHeaderEnd: word character is required");
+    if (!IDENTIFIER_CHARACTER.test(wordCharacter)) {
+      break;
+    }
+    start -= 1;
+  }
+  return PAREN_STATEMENT_KEYWORDS.has(maskedPrefix.slice(start + 1, index + 1));
 }
 
 // Keywords that expect an expression next, so a following "{" opens an object literal
@@ -742,9 +798,10 @@ const OBJECT_PRECEDING_KEYWORDS = new Set([
 /**
  * Determines whether the "}" at closeBraceIndex ends an object literal (a value) or a
  * block (statement position) by finding the matching "{" in the masked prefix and
- * inspecting the token before it: expression contexts ("=", "(", "[", ",", ":", or an
- * expression keyword like `return`) open object literals; anything else (statement
- * start, ")", "=>", ";") is treated as a block.
+ * inspecting the token before it. Block contexts are enumerated (")", ";", "{", "}",
+ * "=>", block keywords like `do`/`else`, file start); any other preceding operator or
+ * punctuation ("=", "(", "[", ",", ":", "?", "||", arithmetic, ...) leaves the "{" in
+ * expression position, so it opens an object literal.
  */
 function isObjectLiteralEnd(maskedPrefix: string, closeBraceIndex: number): boolean {
   assert(maskedPrefix[closeBraceIndex] === "}", "isObjectLiteralEnd: index must point at '}'");
@@ -780,12 +837,6 @@ function isObjectLiteralEnd(maskedPrefix: string, closeBraceIndex: number): bool
   }
   const character = maskedPrefix[index];
   assert(character != null, "isObjectLiteralEnd: character is required");
-  if (character === "=") {
-    return true;
-  }
-  if (character === "(" || character === "[" || character === "," || character === ":") {
-    return true;
-  }
   if (IDENTIFIER_CHARACTER.test(character)) {
     let start = index;
     while (start >= 0) {
@@ -796,9 +847,21 @@ function isObjectLiteralEnd(maskedPrefix: string, closeBraceIndex: number): bool
       }
       start -= 1;
     }
+    // Expression keywords (return, typeof, ...) take object literals; any other
+    // identifier (do/else/try/finally, class names, function headers) opens a block.
     return OBJECT_PRECEDING_KEYWORDS.has(maskedPrefix.slice(start + 1, index + 1));
   }
-  return false;
+  if (character === ")" || character === ";" || character === "{" || character === "}") {
+    // Control headers (`if (...) {`), statement boundaries, and adjacent blocks.
+    return false;
+  }
+  if (character === ">" && maskedPrefix[index - 1] === "=") {
+    // "=>" introduces an arrow function block body.
+    return false;
+  }
+  // Any other punctuation ("=", "(", "[", ",", ":", "?", "&", "|", arithmetic, ...)
+  // keeps the "{" in expression position: object literal.
+  return true;
 }
 
 function isTopLevelStaticMatch(maskedSource: string, matchIndex: number): boolean {

--- a/src/node/services/workflows/WorkflowActionRunner.ts
+++ b/src/node/services/workflows/WorkflowActionRunner.ts
@@ -704,6 +704,12 @@ function isRegExpLiteralStart(maskedPrefix: string): boolean {
     // Require exactly two: `a+++/x/` lexes as `a++ + /x/`, a regex context.
     return !(maskedPrefix[index - 1] === character && maskedPrefix[index - 2] !== character);
   }
+  if (character === "}") {
+    // "}" is ambiguous: an object literal end is a value (division follows), while a
+    // block end is statement position (regex follows). Classify by what introduced
+    // the matching "{".
+    return !isObjectLiteralEnd(maskedPrefix, index);
+  }
   // Values end with ")", "]", or a kept quote delimiter of a masked literal;
   // a "/" after any of these is division, not a regex literal.
   return (
@@ -713,6 +719,86 @@ function isRegExpLiteralStart(maskedPrefix: string): boolean {
     character !== "'" &&
     character !== "`"
   );
+}
+
+// Keywords that expect an expression next, so a following "{" opens an object literal
+// (e.g. `return {}`). Unlike REGEX_PRECEDING_KEYWORDS this excludes do/else, which
+// introduce blocks.
+const OBJECT_PRECEDING_KEYWORDS = new Set([
+  "return",
+  "throw",
+  "typeof",
+  "instanceof",
+  "in",
+  "of",
+  "new",
+  "delete",
+  "void",
+  "case",
+  "yield",
+  "await",
+]);
+
+/**
+ * Determines whether the "}" at closeBraceIndex ends an object literal (a value) or a
+ * block (statement position) by finding the matching "{" in the masked prefix and
+ * inspecting the token before it: expression contexts ("=", "(", "[", ",", ":", or an
+ * expression keyword like `return`) open object literals; anything else (statement
+ * start, ")", "=>", ";") is treated as a block.
+ */
+function isObjectLiteralEnd(maskedPrefix: string, closeBraceIndex: number): boolean {
+  assert(maskedPrefix[closeBraceIndex] === "}", "isObjectLiteralEnd: index must point at '}'");
+  let depth = 0;
+  let openBraceIndex = -1;
+  for (let index = closeBraceIndex; index >= 0; index -= 1) {
+    const character = maskedPrefix[index];
+    if (character === "}") {
+      depth += 1;
+    } else if (character === "{") {
+      depth -= 1;
+      if (depth === 0) {
+        openBraceIndex = index;
+        break;
+      }
+    }
+  }
+  if (openBraceIndex <= 0) {
+    // Unmatched or file-initial "{": statement-position block.
+    return false;
+  }
+  let index = openBraceIndex - 1;
+  while (index >= 0) {
+    const character = maskedPrefix[index];
+    if (character === " " || character === "\n" || character === "\t" || character === "\r") {
+      index -= 1;
+      continue;
+    }
+    break;
+  }
+  if (index < 0) {
+    return false;
+  }
+  const character = maskedPrefix[index];
+  assert(character != null, "isObjectLiteralEnd: character is required");
+  if (character === "=") {
+    return true;
+  }
+  if (character === "(" || character === "[" || character === "," || character === ":") {
+    return true;
+  }
+  if (IDENTIFIER_CHARACTER.test(character)) {
+    let start = index;
+    while (start >= 0) {
+      const wordCharacter = maskedPrefix[start];
+      assert(wordCharacter != null, "isObjectLiteralEnd: word character is required");
+      if (!IDENTIFIER_CHARACTER.test(wordCharacter)) {
+        break;
+      }
+      start -= 1;
+    }
+    return OBJECT_PRECEDING_KEYWORDS.has(maskedPrefix.slice(start + 1, index + 1));
+  }
+  return false;
 }
 
 function isTopLevelStaticMatch(maskedSource: string, matchIndex: number): boolean {


### PR DESCRIPTION
## Summary

Fixes the built-in `security.hashFiles` workflow action showing as **blocked** with *"Workflow action must export an execute function"*. The action source was fine — the static validator's source masker misparsed regex literals. The fix masks regex literal bodies and adds the standard tokenizer heuristic for `/` division-vs-regex disambiguation, hardened through five Codex review rounds into full token-class coverage.

## Background

`WorkflowActionRunner.describe()` validates actions without executing them by masking comments/strings (`maskStaticJavaScriptSource`) and then scanning the masked source for top-level `execute`/`reconcile` exports. The masker had no concept of regex literals: in `security.hashFiles`, the regex `/\/\*[\s\S]*?\*\//g` ends with `\*\//g`, whose two consecutive `/` characters were misread as a line-comment start. The rest of the line — including the closing `)` of the enclosing `.replace(` call — was masked away, permanently unbalancing the paren-depth counter used by `isTopLevelStaticMatch`. Every subsequent top-level match (including `module.exports.execute = ...`) was then rejected as "not top-level", surfacing in the UI as a blocked built-in action. User-authored actions with regexes like `/^https?:\/\//` hit the same bug.

## Implementation

`maskStaticJavaScriptSource` now masks regex literal bodies (keeping the `/` delimiters), driven by `isRegExpLiteralStart` — the standard lexer heuristic for `/` disambiguation, where division follows a value token and a regex literal follows operators/punctuation/keywords. Every token class to the left of a `/` is classified:

- **identifiers/numbers**: division, unless an expression keyword (`return`, `typeof`, ...);
- **string/template literals**: quote delimiters are kept in the masked output (contents still blanked) so `"10" / 2` stays division;
- **regex literals**: delimiters kept, so `/x/ / 2` stays division while `a / /re/.source` still masks the right-operand regex;
- **postfix `++`/`--`**: division (requiring exactly two — `a+++/x/` lexes as `a++ + /x/`);
- **`}`**: resolved via `isObjectLiteralEnd`, which walks back to the matching `{` (reliable in masked text) and classifies by the preceding token — block contexts (`)`, `;`, `{`, `}`, `=>`, `do`/`else`/class names, file start) keep regex position, any operator/expression context means object literal → division;
- **`)`**: resolved via `isControlHeaderEnd` — `if`/`while`/`for`/`switch`/`with` headers put the following `/` in regex position (`if (x) /re/.test(s)`), call/grouping parens mean division.

As a safety net, a `/` in regex-start position that never closes on its line (regex literals cannot span lines) is treated as division instead of masking the rest of the line — bounding the damage of any residual misclassification (e.g. label/`case`-block edges).

## Validation

- Every fix was verified red→green (failing test first, then the fix).
- New regression tests:
  - regex literals containing `//` mixed with real division;
  - one-line/minified division after string, template, postfix `++`, object literal (incl. ternary/`||`-introduced, and followed by later regexes on the same line), and regex-literal values;
  - block-`}` and control-header-`)` counter-cases where regexes with depth-corrupting `(`/`[` must stay masked;
  - **every built-in workflow action must pass `describe()`** through the real registry→runner path — the coverage gap that let the broken built-in ship (previously only listing was tested).
- Dogfooded the exact failing path from the bug report: resolving + describing `security.hashFiles` (`/__mux_builtin_workflow_actions__/security/hashFiles.js`) returns its metadata cleanly.
- Full workflow suite (225+ tests) and `make static-check` green on the rebased branch.

## Risks

Contained to static action validation (`describe`), not runtime execution. The heuristic now mirrors standard tokenizer disambiguation rules; remaining ambiguities (labels, `case`-block edges) are not reachable from valid code that previously described successfully, and the unclosed-candidate fallback bounds any misclassification to leaving a single `/` unmasked. All built-in actions are describe-tested, so a regression here fails CI rather than shipping a blocked action.

## Pains

The masker is a heuristic lexer, and Codex review correctly identified successive token classes whose value-ness was erased by masking (strings, postfix operators, object literals, ternary operators, regex literals). Each round was fixed red→green; the final design (keep literal delimiters + enumerate block contexts + same-line closing invariant) converges on the standard Esprima-style tokenizer heuristic rather than an enumeration of special cases.

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `anthropic:claude-fable-5` • Thinking: `max` • Cost: `$4.61`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=max costs=4.61 -->
