### PR TITLE
🤖 feat: surface completed task/workflow reports across compaction

### DIFF
--- a/src/browser/utils/messages/attachmentRenderer.test.ts
+++ b/src/browser/utils/messages/attachmentRenderer.test.ts
@@ -8,6 +8,7 @@ import type {
   PlanFileReferenceAttachment,
   LoadedSkillsSnapshotAttachment,
   EditedFilesReferenceAttachment,
+  CompletedReportsIndexAttachment,
 } from "@/common/types/attachment";
 
 describe("attachmentRenderer", () => {
@@ -125,6 +126,54 @@ describe("attachmentRenderer", () => {
     expect(content).toContain('<agent-skill name="react-effects" scope="project">');
     expect(content).not.toContain("File: src/a.ts");
     expect(content).toContain("omitted 1 file diff");
+  });
+
+  it("renders completed report handles with task_await re-fetch IDs but no report content", () => {
+    const attachment: CompletedReportsIndexAttachment = {
+      type: "completed_reports_index",
+      reports: [
+        {
+          id: "wfr_research",
+          kind: "workflow",
+          title: "deep-research",
+          completedAtMs: Date.parse("2026-06-01T12:00:00.000Z"),
+          reportTokenEstimate: 1200,
+        },
+        { id: "task-explore", kind: "task", completedAtMs: Date.parse("2026-06-01T13:00:00.000Z") },
+      ],
+    };
+
+    const content = renderAttachmentToContent(attachment);
+
+    expect(content).toContain("wfr_research");
+    expect(content).toContain("task-explore");
+    expect(content).toContain("task_await");
+  });
+
+  it("prioritizes completed report handles ahead of bulky file diffs under budget pressure", () => {
+    const editedFilesAttachment: EditedFilesReferenceAttachment = {
+      type: "edited_files_reference",
+      files: [{ path: "src/a.ts", diff: "a".repeat(2_000), truncated: false }],
+    };
+    const reportsAttachment: CompletedReportsIndexAttachment = {
+      type: "completed_reports_index",
+      reports: [
+        {
+          id: "wfr_research",
+          kind: "workflow",
+          completedAtMs: Date.parse("2026-06-01T12:00:00.000Z"),
+        },
+      ],
+    };
+
+    const content = renderAttachmentsToContentWithBudget(
+      [editedFilesAttachment, reportsAttachment],
+      { maxChars: 500 }
+    );
+
+    expect(content.length).toBeLessThanOrEqual(500);
+    expect(content).toContain("wfr_research");
+    expect(content).not.toContain("File: src/a.ts");
   });
 
   it("emits an omitted-file-diffs note when edited file diffs do not fit", () => {

--- a/src/browser/utils/messages/attachmentRenderer.test.ts
+++ b/src/browser/utils/messages/attachmentRenderer.test.ts
@@ -150,6 +150,60 @@ describe("attachmentRenderer", () => {
     expect(content).toContain("task_await");
   });
 
+  it("caps oversized report titles so they cannot crowd out the re-fetch handle", () => {
+    const longTitle = "T".repeat(500);
+    const attachment: CompletedReportsIndexAttachment = {
+      type: "completed_reports_index",
+      reports: [
+        {
+          id: "wfr_research",
+          kind: "workflow",
+          title: longTitle,
+          completedAtMs: Date.parse("2026-06-01T12:00:00.000Z"),
+        },
+      ],
+    };
+
+    const content = renderAttachmentToContent(attachment);
+
+    expect(content).toContain("wfr_research");
+    expect(content).not.toContain(longTitle);
+    expect(content).toContain("…");
+  });
+
+  it("packs as many report handles as fit and notes omitted ones instead of dropping all", () => {
+    const reportsAttachment: CompletedReportsIndexAttachment = {
+      type: "completed_reports_index",
+      reports: [
+        {
+          id: "wfr_newest",
+          kind: "workflow",
+          completedAtMs: Date.parse("2026-06-01T13:00:00.000Z"),
+        },
+        {
+          // Long IDs make the dropped entries far larger than the truncation note,
+          // so the budget outcome is stable regardless of exact header/footer sizes.
+          id: `task-middle-${"m".repeat(300)}`,
+          kind: "task",
+          completedAtMs: Date.parse("2026-06-01T12:00:00.000Z"),
+        },
+        {
+          id: `task-oldest-${"o".repeat(300)}`,
+          kind: "task",
+          completedAtMs: Date.parse("2026-06-01T11:00:00.000Z"),
+        },
+      ],
+    };
+
+    // Budget fits the header/footer plus the first (newest) entry line only.
+    const content = renderAttachmentsToContentWithBudget([reportsAttachment], { maxChars: 600 });
+
+    expect(content.length).toBeLessThanOrEqual(600);
+    expect(content).toContain("wfr_newest");
+    expect(content).not.toContain("task-oldest");
+    expect(content).toMatch(/omitted 2 completed report handles/);
+  });
+
   it("prioritizes completed report handles ahead of bulky file diffs under budget pressure", () => {
     const editedFilesAttachment: EditedFilesReferenceAttachment = {
       type: "edited_files_reference",

--- a/src/browser/utils/messages/attachmentRenderer.ts
+++ b/src/browser/utils/messages/attachmentRenderer.ts
@@ -4,6 +4,7 @@ import type {
   TodoListAttachment,
   LoadedSkillsSnapshotAttachment,
   EditedFilesReferenceAttachment,
+  CompletedReportsIndexAttachment,
 } from "@/common/types/attachment";
 import {
   AGENT_SKILL_BODY_TRUNCATION_NOTE,
@@ -48,6 +49,25 @@ function renderLoadedSkillsSnapshot(attachment: LoadedSkillsSnapshotAttachment):
 }
 
 /**
+ * Render the completed-reports index. Lists re-fetchable handles only (no report
+ * content): the full reports persist on disk and survive compaction, so the model
+ * can recover them via task_await instead of re-running expensive work.
+ */
+function renderCompletedReportsIndex(attachment: CompletedReportsIndexAttachment): string {
+  const lines = attachment.reports.map((report) => {
+    const title = report.title ? ` "${report.title}"` : "";
+    const tokens =
+      report.reportTokenEstimate != null ? `, ~${report.reportTokenEstimate} tokens` : "";
+    return `- ${report.id} [${report.kind}]${title} — completed ${new Date(report.completedAtMs).toISOString()}${tokens}`;
+  });
+
+  return `Completed sub-agent/workflow reports from before the last compaction (full content is no longer in context but persists on disk):
+${lines.join("\n")}
+
+Re-fetch any full report (reportMarkdown + structuredOutput) with task_await(task_ids: ["<id>"], timeout_secs: 0) instead of re-running the work.`;
+}
+
+/**
  * Render an edited files reference attachment to content string.
  */
 function renderEditedFilesReference(attachment: EditedFilesReferenceAttachment): string {
@@ -79,6 +99,8 @@ export function renderAttachmentToContent(attachment: PostCompactionAttachment):
       return renderLoadedSkillsSnapshot(attachment);
     case "edited_files_reference":
       return renderEditedFilesReference(attachment);
+    case "completed_reports_index":
+      return renderCompletedReportsIndex(attachment);
   }
 }
 
@@ -239,8 +261,11 @@ function sortAttachmentsForInjection(
   const priority: Record<PostCompactionAttachment["type"], number> = {
     plan_file_reference: 0,
     todo_list: 1,
-    loaded_skills_snapshot: 2,
-    edited_files_reference: 3,
+    // Small, high-value handles go before the bulky skill/diff blocks so budget
+    // truncation cannot drop them.
+    completed_reports_index: 2,
+    loaded_skills_snapshot: 3,
+    edited_files_reference: 4,
   };
 
   return attachments
@@ -300,6 +325,15 @@ export function renderAttachmentsToContentWithBudget(
 
     if (attachment.type === "todo_list") {
       const content = renderTodoListAttachment(attachment);
+      if (content.length <= remainingForContent) {
+        addBlock(wrapSystemUpdate(content));
+      }
+      continue;
+    }
+
+    if (attachment.type === "completed_reports_index") {
+      // Entries are capped one-liners, so all-or-nothing fits the budget in practice.
+      const content = renderCompletedReportsIndex(attachment);
       if (content.length <= remainingForContent) {
         addBlock(wrapSystemUpdate(content));
       }

--- a/src/browser/utils/messages/attachmentRenderer.ts
+++ b/src/browser/utils/messages/attachmentRenderer.ts
@@ -49,22 +49,78 @@ function renderLoadedSkillsSnapshot(attachment: LoadedSkillsSnapshotAttachment):
 }
 
 /**
+ * Titles are model-provided and unbounded; cap them per entry so an oversized title
+ * can never crowd the re-fetch handles (the IDs are the valuable part) out of budget.
+ */
+const MAX_REPORT_INDEX_TITLE_CHARS = 80;
+
+const COMPLETED_REPORTS_HEADER =
+  "Completed sub-agent/workflow reports from before the last compaction (full content is no longer in context but persists on disk):\n";
+const COMPLETED_REPORTS_FOOTER =
+  '\n\nRe-fetch any full report (reportMarkdown + structuredOutput) with task_await(task_ids: ["<id>"], timeout_secs: 0) instead of re-running the work.';
+
+function formatCompletedReportEntryLine(
+  report: CompletedReportsIndexAttachment["reports"][number]
+): string {
+  let title = "";
+  if (report.title) {
+    const capped =
+      report.title.length > MAX_REPORT_INDEX_TITLE_CHARS
+        ? `${report.title.slice(0, MAX_REPORT_INDEX_TITLE_CHARS - 1)}…`
+        : report.title;
+    title = ` "${capped}"`;
+  }
+  const tokens =
+    report.reportTokenEstimate != null ? `, ~${report.reportTokenEstimate} tokens` : "";
+  return `- ${report.id} [${report.kind}]${title} — completed ${new Date(report.completedAtMs).toISOString()}${tokens}`;
+}
+
+/**
  * Render the completed-reports index. Lists re-fetchable handles only (no report
  * content): the full reports persist on disk and survive compaction, so the model
  * can recover them via task_await instead of re-running expensive work.
  */
 function renderCompletedReportsIndex(attachment: CompletedReportsIndexAttachment): string {
-  const lines = attachment.reports.map((report) => {
-    const title = report.title ? ` "${report.title}"` : "";
-    const tokens =
-      report.reportTokenEstimate != null ? `, ~${report.reportTokenEstimate} tokens` : "";
-    return `- ${report.id} [${report.kind}]${title} — completed ${new Date(report.completedAtMs).toISOString()}${tokens}`;
-  });
+  const lines = attachment.reports.map(formatCompletedReportEntryLine);
+  return `${COMPLETED_REPORTS_HEADER}${lines.join("\n")}${COMPLETED_REPORTS_FOOTER}`;
+}
 
-  return `Completed sub-agent/workflow reports from before the last compaction (full content is no longer in context but persists on disk):
-${lines.join("\n")}
+/**
+ * Budget-aware variant: packs as many handles as fit (entries are newest-first, so
+ * the oldest drop first) instead of omitting the whole block — losing every re-fetch
+ * handle would defeat the recovery path this attachment exists for.
+ */
+function renderCompletedReportsIndexWithBudget(
+  attachment: CompletedReportsIndexAttachment,
+  maxChars: number
+): { content: string | null; omittedReports: number } {
+  const fixedLength = COMPLETED_REPORTS_HEADER.length + COMPLETED_REPORTS_FOOTER.length;
+  if (maxChars <= fixedLength) {
+    return { content: null, omittedReports: attachment.reports.length };
+  }
 
-Re-fetch any full report (reportMarkdown + structuredOutput) with task_await(task_ids: ["<id>"], timeout_secs: 0) instead of re-running the work.`;
+  const lines: string[] = [];
+  let used = fixedLength;
+
+  for (const report of attachment.reports) {
+    const line = formatCompletedReportEntryLine(report);
+    const separator = lines.length > 0 ? "\n" : "";
+    const nextLen = used + separator.length + line.length;
+    if (nextLen > maxChars) {
+      break;
+    }
+    lines.push(line);
+    used = nextLen;
+  }
+
+  if (lines.length === 0) {
+    return { content: null, omittedReports: attachment.reports.length };
+  }
+
+  return {
+    content: `${COMPLETED_REPORTS_HEADER}${lines.join("\n")}${COMPLETED_REPORTS_FOOTER}`,
+    omittedReports: attachment.reports.length - lines.length,
+  };
 }
 
 /**
@@ -292,6 +348,7 @@ export function renderAttachmentsToContentWithBudget(
   let currentLength = 0;
   let omittedLoadedSkills = 0;
   let omittedFileDiffs = 0;
+  let omittedReportHandles = 0;
 
   const addBlock = (block: string): boolean => {
     const separatorLen = blocks.length > 0 ? "\n".length : 0;
@@ -332,9 +389,13 @@ export function renderAttachmentsToContentWithBudget(
     }
 
     if (attachment.type === "completed_reports_index") {
-      // Entries are capped one-liners, so all-or-nothing fits the budget in practice.
-      const content = renderCompletedReportsIndex(attachment);
-      if (content.length <= remainingForContent) {
+      const { content, omittedReports } = renderCompletedReportsIndexWithBudget(
+        attachment,
+        remainingForContent
+      );
+      omittedReportHandles += omittedReports;
+
+      if (content) {
         addBlock(wrapSystemUpdate(content));
       }
       continue;
@@ -376,6 +437,12 @@ export function renderAttachmentsToContentWithBudget(
   if (omittedFileDiffs > 0) {
     const plural = omittedFileDiffs === 1 ? "" : "s";
     const note = `(post-compaction context truncated; omitted ${omittedFileDiffs} file diff${plural})`;
+    addBlock(wrapSystemUpdate(note));
+  }
+
+  if (omittedReportHandles > 0) {
+    const plural = omittedReportHandles === 1 ? "" : "s";
+    const note = `(post-compaction context truncated; omitted ${omittedReportHandles} completed report handle${plural})`;
     addBlock(wrapSystemUpdate(note));
   }
 

--- a/src/common/constants/attachments.ts
+++ b/src/common/constants/attachments.ts
@@ -27,3 +27,10 @@ export const MAX_POST_COMPACTION_INJECTION_CHARS = 80_000;
 
 /** Maximum size of plan content included in post-compaction attachments */
 export const MAX_POST_COMPACTION_PLAN_CHARS = 30_000;
+
+/**
+ * Maximum number of completed sub-agent/workflow report index entries to surface
+ * after compaction (newest first). Entries are one-liners (ID + title + size), so
+ * the cap bounds noise rather than context size.
+ */
+export const MAX_POST_COMPACTION_REPORT_INDEX_ENTRIES = 20;

--- a/src/common/types/attachment.ts
+++ b/src/common/types/attachment.ts
@@ -44,11 +44,33 @@ export interface LoadedSkillsSnapshotAttachment {
   skills: LoadedSkillSnapshot[];
 }
 
+export interface CompletedReportEntry {
+  /** task_await-compatible ID: sub-agent taskId or workflow runId (wfr_...). */
+  id: string;
+  kind: "task" | "workflow";
+  /** Sub-agent task title or workflow definition name. */
+  title?: string;
+  completedAtMs: number;
+  /** Estimated token count of the persisted report markdown (~4 chars/token). */
+  reportTokenEstimate?: number;
+}
+
+/**
+ * Index of completed sub-agent/workflow reports whose full content was summarized
+ * away by compaction. Reports persist on disk and can be re-fetched by ID via
+ * task_await, so the index only carries handles — never report content.
+ */
+export interface CompletedReportsIndexAttachment {
+  type: "completed_reports_index";
+  reports: CompletedReportEntry[];
+}
+
 export type PostCompactionAttachment =
   | PlanFileReferenceAttachment
   | TodoListAttachment
   | LoadedSkillsSnapshotAttachment
-  | EditedFilesReferenceAttachment;
+  | EditedFilesReferenceAttachment
+  | CompletedReportsIndexAttachment;
 
 /**
  * Exclusion state for post-compaction context items.

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -552,6 +552,13 @@ const TaskAwaitToolArtifactsSchema = z
   })
   .strict();
 
+/**
+ * Appended to completed task/workflow results so the model knows the report is durable
+ * and can be re-fetched by ID after context compaction instead of re-running the work.
+ */
+export const COMPLETED_REPORT_REFETCH_NOTE =
+  'Report persisted on disk; re-fetch anytime (even after context compaction) with task_await(task_ids: ["<id>"], timeout_secs: 0).';
+
 export const TaskAwaitToolCompletedResultSchema = z
   .object({
     status: z.literal("completed"),
@@ -873,6 +880,7 @@ export const WorkflowRunToolResultSchema = z
     runId: z.string().min(1),
     result: z.unknown(),
     run: WorkflowRunRecordSchema.optional(),
+    note: z.string().optional(),
   })
   .strict();
 
@@ -1569,6 +1577,7 @@ export const TOOL_DEFINITIONS = {
       "Always wait for the task/bash/workflow_run tool result first, then call task_await in a subsequent step. " +
       "When omitting task_ids to await active tasks/workflows, ensure at least one background task or workflow was already spawned in a prior step. Omitted task_ids exclude workflow-owned sub-agents and their background bash tasks because those results are consumed through workflow runs. " +
       "\n\nAgent tasks and workflow runs return reports when completed. " +
+      "Completed reports are persisted on disk and survive context compaction: calling task_await on an already-completed task/workflow run ID (timeout_secs: 0 for non-blocking) re-fetches the full report instead of re-running the work. " +
       "Bash tasks return incremental output while running and a final reportMarkdown when they exit. " +
       "For bash tasks, you may optionally pass filter/filter_exclude to include/exclude output lines by regex. " +
       "WARNING: when using filter, non-matching lines are permanently discarded. " +

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -5336,6 +5336,8 @@ export class AgentSession {
       return this.buildAttachmentsFromContext({
         diffs: pendingState.diffs,
         loadedSkills: pendingState.loadedSkills,
+        // Compaction just completed, so every already-completed report predates the boundary.
+        reportsCompletedBeforeMs: Date.now(),
       });
     }
 
@@ -5368,7 +5370,17 @@ export class AgentSession {
       ...extractLoadedSkillSnapshotsFromMessages(historyResult.data),
     ]);
 
-    return this.buildAttachmentsFromContext({ diffs: fileDiffs, loadedSkills });
+    // Reports completed before the latest boundary had their tool results summarized away;
+    // anything newer is still visible in the active epoch and would be redundant.
+    const boundaryTimestampMs = historyResult.data.find(
+      (message) => message.metadata?.compactionBoundary === true
+    )?.metadata?.timestamp;
+
+    return this.buildAttachmentsFromContext({
+      diffs: fileDiffs,
+      loadedSkills,
+      reportsCompletedBeforeMs: boundaryTimestampMs ?? Date.now(),
+    });
   }
 
   /**
@@ -5379,9 +5391,18 @@ export class AgentSession {
   private async buildAttachmentsFromContext(context: {
     diffs: FileEditDiff[];
     loadedSkills: LoadedSkillSnapshot[];
+    /** Cutoff for the completed-reports index: reports completed before this were summarized away. */
+    reportsCompletedBeforeMs: number;
   }): Promise<PostCompactionAttachment[]> {
     const excludedItems = await this.loadExcludedItems();
     const todoAttachment = await this.loadTodoListAttachment(excludedItems);
+
+    // Host-side disk read (session dir), independent of workspace metadata/runtime.
+    const completedReportsAttachment = await AttachmentService.generateCompletedReportsAttachment({
+      workspaceId: this.workspaceId,
+      sessionDir: this.config.getSessionDir(this.workspaceId),
+      completedBeforeMs: context.reportsCompletedBeforeMs,
+    });
 
     const metadataResult = await this.aiService.getWorkspaceMetadata(this.workspaceId);
     if (!metadataResult.success) {
@@ -5390,6 +5411,10 @@ export class AgentSession {
 
       if (todoAttachment) {
         attachments.push(todoAttachment);
+      }
+
+      if (completedReportsAttachment) {
+        attachments.push(completedReportsAttachment);
       }
 
       const loadedSkillsAttachment = AttachmentService.generateLoadedSkillsAttachment(
@@ -5424,6 +5449,11 @@ export class AgentSession {
       const planIndex = attachments.findIndex((att) => att.type === "plan_file_reference");
       const insertIndex = planIndex === -1 ? 0 : planIndex + 1;
       attachments.splice(insertIndex, 0, todoAttachment);
+    }
+
+    if (completedReportsAttachment) {
+      // Final injection order is decided by the renderer's priority sort.
+      attachments.push(completedReportsAttachment);
     }
 
     return attachments;

--- a/src/node/services/attachmentService.completedReports.test.ts
+++ b/src/node/services/attachmentService.completedReports.test.ts
@@ -1,3 +1,6 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
 import { describe, expect, test } from "bun:test";
 
 import { MAX_POST_COMPACTION_REPORT_INDEX_ENTRIES } from "@/common/constants/attachments";
@@ -175,6 +178,40 @@ describe("AttachmentService.generateCompletedReportsAttachment", () => {
     });
 
     expect(attachment).toBeNull();
+  });
+
+  test("skips persisted index entries with malformed ids or timestamps", async () => {
+    using tmp = new DisposableTempDir("completed-reports");
+    const cutoffMs = Date.parse("2026-06-02T00:00:00.000Z");
+
+    await writeTaskReport(tmp.path, { childTaskId: "task-valid", updatedAtMs: cutoffMs - 60_000 });
+    // Corrupt the persisted index the way a partial/legacy write could: entries whose
+    // updatedAtMs is missing or non-numeric, or whose id is missing.
+    const indexPath = path.join(tmp.path, "subagent-reports.json");
+    const file = JSON.parse(await fs.readFile(indexPath, "utf-8")) as {
+      artifactsByChildTaskId: Record<string, unknown>;
+    };
+    const valid = file.artifactsByChildTaskId["task-valid"] as Record<string, unknown>;
+    file.artifactsByChildTaskId["task-no-timestamp"] = {
+      ...valid,
+      childTaskId: "task-no-timestamp",
+      updatedAtMs: undefined,
+    };
+    file.artifactsByChildTaskId["task-nan-timestamp"] = {
+      ...valid,
+      childTaskId: "task-nan-timestamp",
+      updatedAtMs: "not-a-number",
+    };
+    file.artifactsByChildTaskId["task-no-id"] = { ...valid, childTaskId: undefined };
+    await fs.writeFile(indexPath, JSON.stringify(file, null, 2));
+
+    const attachment = await AttachmentService.generateCompletedReportsAttachment({
+      workspaceId: WORKSPACE_ID,
+      sessionDir: tmp.path,
+      completedBeforeMs: cutoffMs,
+    });
+
+    expect(attachment?.reports.map((report) => report.id)).toEqual(["task-valid"]);
   });
 
   test("caps entries at the configured maximum, keeping the newest", async () => {

--- a/src/node/services/attachmentService.completedReports.test.ts
+++ b/src/node/services/attachmentService.completedReports.test.ts
@@ -203,6 +203,15 @@ describe("AttachmentService.generateCompletedReportsAttachment", () => {
       updatedAtMs: "not-a-number",
     };
     file.artifactsByChildTaskId["task-no-id"] = { ...valid, childTaskId: undefined };
+    file.artifactsByChildTaskId["task-null-row"] = null;
+    file.artifactsByChildTaskId["task-string-row"] = "corrupt";
+    // Corrupt ownership marker must degrade to "not workflow-owned", not throw.
+    file.artifactsByChildTaskId["task-corrupt-owned"] = {
+      ...valid,
+      childTaskId: "task-corrupt-owned",
+      updatedAtMs: cutoffMs - 30_000,
+      workflowOwnedAncestorWorkspaceIds: "not-an-array",
+    };
     await fs.writeFile(indexPath, JSON.stringify(file, null, 2));
 
     const attachment = await AttachmentService.generateCompletedReportsAttachment({
@@ -211,7 +220,10 @@ describe("AttachmentService.generateCompletedReportsAttachment", () => {
       completedBeforeMs: cutoffMs,
     });
 
-    expect(attachment?.reports.map((report) => report.id)).toEqual(["task-valid"]);
+    expect(attachment?.reports.map((report) => report.id)).toEqual([
+      "task-corrupt-owned",
+      "task-valid",
+    ]);
   });
 
   test("caps entries at the configured maximum, keeping the newest", async () => {

--- a/src/node/services/attachmentService.completedReports.test.ts
+++ b/src/node/services/attachmentService.completedReports.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, test } from "bun:test";
+
+import { MAX_POST_COMPACTION_REPORT_INDEX_ENTRIES } from "@/common/constants/attachments";
+
+import { AttachmentService } from "./attachmentService";
+import { upsertSubagentReportArtifact } from "./subagentReportArtifacts";
+import { DisposableTempDir } from "./tempDir";
+import { WorkflowRunStore } from "./workflows/WorkflowRunStore";
+
+const WORKSPACE_ID = "workspace-reports-test";
+
+async function writeTaskReport(
+  sessionDir: string,
+  params: {
+    childTaskId: string;
+    updatedAtMs: number;
+    parentWorkspaceId?: string;
+    workflowOwnedAncestorWorkspaceIds?: string[];
+    title?: string;
+  }
+): Promise<void> {
+  await upsertSubagentReportArtifact({
+    workspaceId: WORKSPACE_ID,
+    workspaceSessionDir: sessionDir,
+    childTaskId: params.childTaskId,
+    parentWorkspaceId: params.parentWorkspaceId ?? WORKSPACE_ID,
+    ancestorWorkspaceIds: [params.parentWorkspaceId ?? WORKSPACE_ID],
+    reportMarkdown: "# Report\n\nSome findings.",
+    ...(params.workflowOwnedAncestorWorkspaceIds
+      ? { workflowOwnedAncestorWorkspaceIds: params.workflowOwnedAncestorWorkspaceIds }
+      : {}),
+    ...(params.title !== undefined ? { title: params.title } : {}),
+    nowMs: params.updatedAtMs,
+  });
+}
+
+async function writeWorkflowRun(
+  sessionDir: string,
+  params: {
+    runId: string;
+    workspaceId?: string;
+    completedAt?: string;
+    failed?: boolean;
+    reportMarkdown?: string;
+  }
+): Promise<void> {
+  const store = new WorkflowRunStore({ sessionDir });
+  await store.createRun({
+    id: params.runId,
+    workspaceId: params.workspaceId ?? WORKSPACE_ID,
+    definition: {
+      name: "deep-research",
+      description: "Research a topic",
+      scope: "built-in" as const,
+      executable: true,
+    },
+    definitionSource: "export default async function workflow() { return 'ok'; }\n",
+    args: {},
+    now: "2026-06-01T00:00:00.000Z",
+  });
+  await store.appendNextEvent(params.runId, {
+    type: "status",
+    at: "2026-06-01T00:00:01.000Z",
+    status: "running",
+  });
+  if (params.completedAt === undefined) {
+    return; // leave the run active
+  }
+  if (params.failed) {
+    await store.appendNextEvent(params.runId, {
+      type: "error",
+      at: params.completedAt,
+      message: "boom",
+    });
+    await store.appendNextEvent(params.runId, {
+      type: "status",
+      at: params.completedAt,
+      status: "failed",
+    });
+    return;
+  }
+  await store.appendNextEvent(params.runId, {
+    type: "result",
+    at: params.completedAt,
+    result: { reportMarkdown: params.reportMarkdown ?? "# Workflow report" },
+  });
+  await store.appendNextEvent(params.runId, {
+    type: "status",
+    at: params.completedAt,
+    status: "completed",
+  });
+}
+
+describe("AttachmentService.generateCompletedReportsAttachment", () => {
+  test("returns null when no completed reports exist", async () => {
+    using tmp = new DisposableTempDir("completed-reports");
+
+    const attachment = await AttachmentService.generateCompletedReportsAttachment({
+      workspaceId: WORKSPACE_ID,
+      sessionDir: tmp.path,
+      completedBeforeMs: Date.now(),
+    });
+
+    expect(attachment).toBeNull();
+  });
+
+  test("includes only reports completed before the cutoff, newest first", async () => {
+    using tmp = new DisposableTempDir("completed-reports");
+    const cutoffMs = Date.parse("2026-06-02T00:00:00.000Z");
+
+    await writeTaskReport(tmp.path, {
+      childTaskId: "task-old",
+      updatedAtMs: cutoffMs - 60_000,
+      title: "Old exploration",
+    });
+    await writeTaskReport(tmp.path, {
+      childTaskId: "task-new",
+      updatedAtMs: cutoffMs + 60_000,
+      title: "Still in context",
+    });
+    await writeWorkflowRun(tmp.path, {
+      runId: "wfr_done",
+      completedAt: "2026-06-01T12:00:00.000Z",
+    });
+
+    const attachment = await AttachmentService.generateCompletedReportsAttachment({
+      workspaceId: WORKSPACE_ID,
+      sessionDir: tmp.path,
+      completedBeforeMs: cutoffMs,
+    });
+
+    expect(attachment).not.toBeNull();
+    // Newest first: the task completed at cutoff-60s, the workflow 12h before that.
+    expect(attachment?.reports.map((report) => report.id)).toEqual(["task-old", "wfr_done"]);
+    const workflowEntry = attachment?.reports.find((report) => report.id === "wfr_done");
+    expect(workflowEntry?.kind).toBe("workflow");
+    expect(workflowEntry?.title).toBe("deep-research");
+    expect(workflowEntry?.reportTokenEstimate).toBeGreaterThan(0);
+    const taskEntry = attachment?.reports.find((report) => report.id === "task-old");
+    expect(taskEntry?.kind).toBe("task");
+    expect(taskEntry?.title).toBe("Old exploration");
+    expect(taskEntry?.reportTokenEstimate).toBeGreaterThan(0);
+  });
+
+  test("excludes non-direct-children, workflow-owned reports, and non-completed runs", async () => {
+    using tmp = new DisposableTempDir("completed-reports");
+    const cutoffMs = Date.parse("2026-06-02T00:00:00.000Z");
+
+    await writeTaskReport(tmp.path, {
+      childTaskId: "task-grandchild",
+      updatedAtMs: cutoffMs - 60_000,
+      parentWorkspaceId: "some-child-workspace",
+    });
+    await writeTaskReport(tmp.path, {
+      childTaskId: "task-workflow-owned",
+      updatedAtMs: cutoffMs - 60_000,
+      workflowOwnedAncestorWorkspaceIds: [WORKSPACE_ID],
+    });
+    await writeWorkflowRun(tmp.path, { runId: "wfr_active" });
+    await writeWorkflowRun(tmp.path, {
+      runId: "wfr_failed",
+      completedAt: "2026-06-01T12:00:00.000Z",
+      failed: true,
+    });
+    await writeWorkflowRun(tmp.path, {
+      runId: "wfr_other_ws",
+      workspaceId: "other-workspace",
+      completedAt: "2026-06-01T12:00:00.000Z",
+    });
+
+    const attachment = await AttachmentService.generateCompletedReportsAttachment({
+      workspaceId: WORKSPACE_ID,
+      sessionDir: tmp.path,
+      completedBeforeMs: cutoffMs,
+    });
+
+    expect(attachment).toBeNull();
+  });
+
+  test("caps entries at the configured maximum, keeping the newest", async () => {
+    using tmp = new DisposableTempDir("completed-reports");
+    const cutoffMs = Date.parse("2026-06-02T00:00:00.000Z");
+    const total = MAX_POST_COMPACTION_REPORT_INDEX_ENTRIES + 3;
+
+    for (let i = 0; i < total; i++) {
+      await writeTaskReport(tmp.path, {
+        childTaskId: `task-${i}`,
+        // Later index = newer completion.
+        updatedAtMs: cutoffMs - 60_000 + i * 1_000,
+      });
+    }
+
+    const attachment = await AttachmentService.generateCompletedReportsAttachment({
+      workspaceId: WORKSPACE_ID,
+      sessionDir: tmp.path,
+      completedBeforeMs: cutoffMs,
+    });
+
+    expect(attachment?.reports).toHaveLength(MAX_POST_COMPACTION_REPORT_INDEX_ENTRIES);
+    expect(attachment?.reports[0]?.id).toBe(`task-${total - 1}`);
+    // Oldest entries beyond the cap are dropped.
+    expect(attachment?.reports.map((report) => report.id)).not.toContain("task-0");
+  });
+});

--- a/src/node/services/attachmentService.ts
+++ b/src/node/services/attachmentService.ts
@@ -144,10 +144,13 @@ export class AttachmentService {
 
     const reportsFile = await readSubagentReportArtifactsFile(params.sessionDir);
     for (const entry of Object.values(reportsFile.artifactsByChildTaskId)) {
-      // Self-healing: the persisted index is cast without per-entry validation, and a
-      // malformed timestamp would slip past the cutoff comparison (NaN/undefined compare
-      // false) only to throw later in the renderer (`new Date(...).toISOString()`),
-      // blocking post-compaction injection. Skip corrupt rows instead.
+      // Self-healing: the persisted index is cast without per-entry validation, so rows
+      // may be null/non-objects or carry wrong-typed fields. A throw here (or a NaN
+      // timestamp surviving into the renderer's `toISOString()`) would drop ALL
+      // post-compaction attachments, so validate every field we read and skip bad rows.
+      if (entry == null || typeof entry !== "object") {
+        continue;
+      }
       if (
         typeof entry.childTaskId !== "string" ||
         entry.childTaskId.length === 0 ||
@@ -160,7 +163,11 @@ export class AttachmentService {
         continue;
       }
       // Workflow-owned sub-agent reports are consumed through their workflow run's report.
-      if (entry.workflowOwnedAncestorWorkspaceIds?.includes(params.workspaceId)) {
+      // Non-array (corrupt) values degrade to "not workflow-owned" rather than throwing.
+      if (
+        Array.isArray(entry.workflowOwnedAncestorWorkspaceIds) &&
+        entry.workflowOwnedAncestorWorkspaceIds.includes(params.workspaceId)
+      ) {
         continue;
       }
       // Reports completed after the cutoff still have their tool results in visible context.
@@ -170,9 +177,9 @@ export class AttachmentService {
       entries.push({
         id: entry.childTaskId,
         kind: "task",
-        ...(entry.title !== undefined ? { title: entry.title } : {}),
+        ...(typeof entry.title === "string" ? { title: entry.title } : {}),
         completedAtMs: entry.updatedAtMs,
-        ...(entry.reportTokenEstimate !== undefined
+        ...(Number.isFinite(entry.reportTokenEstimate)
           ? { reportTokenEstimate: entry.reportTokenEstimate }
           : {}),
       });

--- a/src/node/services/attachmentService.ts
+++ b/src/node/services/attachmentService.ts
@@ -4,13 +4,25 @@ import type {
   LoadedSkillsSnapshotAttachment,
   LoadedSkillSnapshot,
   EditedFilesReferenceAttachment,
+  CompletedReportEntry,
+  CompletedReportsIndexAttachment,
 } from "@/common/types/attachment";
+import type { WorkflowRunEvent } from "@/common/types/workflow";
 import { getPlanFilePath, getLegacyPlanFilePath } from "@/common/utils/planStorage";
 import type { FileEditDiff } from "@/common/utils/messages/extractEditedFiles";
+import assert from "@/common/utils/assert";
 import type { Runtime } from "@/node/runtime/Runtime";
 import { readFileString } from "@/node/utils/runtime/helpers";
 import { expandTilde } from "@/node/runtime/tildeExpansion";
-import { MAX_POST_COMPACTION_PLAN_CHARS } from "@/common/constants/attachments";
+import {
+  MAX_POST_COMPACTION_PLAN_CHARS,
+  MAX_POST_COMPACTION_REPORT_INDEX_ENTRIES,
+} from "@/common/constants/attachments";
+import {
+  CHARS_PER_TOKEN_ESTIMATE,
+  readSubagentReportArtifactsFile,
+} from "@/node/services/subagentReportArtifacts";
+import { WorkflowRunStore } from "@/node/services/workflows/WorkflowRunStore";
 
 const TRUNCATED_PLAN_NOTE = "\n\n...(truncated)\n";
 
@@ -106,6 +118,93 @@ export class AttachmentService {
     return {
       type: "edited_files_reference",
       files,
+    };
+  }
+
+  /**
+   * Generate an index of completed sub-agent/workflow reports whose tool results were
+   * summarized away by compaction (completed before `completedBeforeMs`). Reports are
+   * already durably persisted in the session dir; this surfaces only re-fetchable
+   * handles (IDs), never report content, so the model can recover lost results via
+   * task_await instead of re-running expensive work.
+   */
+  static async generateCompletedReportsAttachment(params: {
+    workspaceId: string;
+    sessionDir: string;
+    completedBeforeMs: number;
+  }): Promise<CompletedReportsIndexAttachment | null> {
+    assert(params.workspaceId.length > 0, "generateCompletedReportsAttachment: workspaceId");
+    assert(params.sessionDir.length > 0, "generateCompletedReportsAttachment: sessionDir");
+    assert(
+      Number.isFinite(params.completedBeforeMs) && params.completedBeforeMs > 0,
+      "generateCompletedReportsAttachment: completedBeforeMs must be a positive timestamp"
+    );
+
+    const entries: CompletedReportEntry[] = [];
+
+    const reportsFile = await readSubagentReportArtifactsFile(params.sessionDir);
+    for (const entry of Object.values(reportsFile.artifactsByChildTaskId)) {
+      // Direct children only: grandchild reports are synthesized into the child's report.
+      if (entry.parentWorkspaceId !== params.workspaceId) {
+        continue;
+      }
+      // Workflow-owned sub-agent reports are consumed through their workflow run's report.
+      if (entry.workflowOwnedAncestorWorkspaceIds?.includes(params.workspaceId)) {
+        continue;
+      }
+      // Reports completed after the cutoff still have their tool results in visible context.
+      if (entry.updatedAtMs > params.completedBeforeMs) {
+        continue;
+      }
+      entries.push({
+        id: entry.childTaskId,
+        kind: "task",
+        ...(entry.title !== undefined ? { title: entry.title } : {}),
+        completedAtMs: entry.updatedAtMs,
+        ...(entry.reportTokenEstimate !== undefined
+          ? { reportTokenEstimate: entry.reportTokenEstimate }
+          : {}),
+      });
+    }
+
+    // listRuns is defensive (skips unreadable runs) and reads atomic snapshots, so a
+    // second read-only store instance against the same session dir is safe.
+    const runStore = new WorkflowRunStore({ sessionDir: params.sessionDir });
+    const runs = await runStore.listRuns();
+    for (const run of runs) {
+      if (run.workspaceId !== params.workspaceId || run.status !== "completed") {
+        continue;
+      }
+      const resultEvent = run.events.findLast(
+        (event): event is Extract<WorkflowRunEvent, { type: "result" }> => event.type === "result"
+      );
+      const completedAtMs = Date.parse(resultEvent?.at ?? run.updatedAt);
+      if (Number.isNaN(completedAtMs) || completedAtMs > params.completedBeforeMs) {
+        continue;
+      }
+      entries.push({
+        id: run.id,
+        kind: "workflow",
+        title: run.definition.name,
+        completedAtMs,
+        ...(resultEvent !== undefined
+          ? {
+              reportTokenEstimate: Math.ceil(
+                resultEvent.result.reportMarkdown.length / CHARS_PER_TOKEN_ESTIMATE
+              ),
+            }
+          : {}),
+      });
+    }
+
+    if (entries.length === 0) {
+      return null;
+    }
+
+    entries.sort((a, b) => b.completedAtMs - a.completedAtMs);
+    return {
+      type: "completed_reports_index",
+      reports: entries.slice(0, MAX_POST_COMPACTION_REPORT_INDEX_ENTRIES),
     };
   }
 

--- a/src/node/services/attachmentService.ts
+++ b/src/node/services/attachmentService.ts
@@ -144,6 +144,17 @@ export class AttachmentService {
 
     const reportsFile = await readSubagentReportArtifactsFile(params.sessionDir);
     for (const entry of Object.values(reportsFile.artifactsByChildTaskId)) {
+      // Self-healing: the persisted index is cast without per-entry validation, and a
+      // malformed timestamp would slip past the cutoff comparison (NaN/undefined compare
+      // false) only to throw later in the renderer (`new Date(...).toISOString()`),
+      // blocking post-compaction injection. Skip corrupt rows instead.
+      if (
+        typeof entry.childTaskId !== "string" ||
+        entry.childTaskId.length === 0 ||
+        !Number.isFinite(entry.updatedAtMs)
+      ) {
+        continue;
+      }
       // Direct children only: grandchild reports are synthesized into the child's report.
       if (entry.parentWorkspaceId !== params.workspaceId) {
         continue;

--- a/src/node/services/tools/task_await.test.ts
+++ b/src/node/services/tools/task_await.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, mock, spyOn } from "bun:test";
 import type { ToolExecutionOptions } from "ai";
 
 import type { ToolConfiguration } from "@/common/utils/tools/tools";
+import { COMPLETED_REPORT_REFETCH_NOTE } from "@/common/utils/tools/toolDefinitions";
 import type { WorkflowRunRecord, WorkflowRunStatus } from "@/common/types/workflow";
 import { createTaskAwaitTool } from "./task_await";
 import { TestTempDir, createTestToolConfig } from "./testHelpers";
@@ -104,6 +105,7 @@ describe("task_await tool", () => {
           reportMarkdown: "ok",
           title: undefined,
           artifacts: { gitFormatPatch },
+          note: COMPLETED_REPORT_REFETCH_NOTE,
         },
       ],
     });
@@ -191,8 +193,20 @@ describe("task_await tool", () => {
 
     expect(result).toEqual({
       results: [
-        { status: "completed", taskId: "t1", reportMarkdown: "report:t1", title: "title:t1" },
-        { status: "completed", taskId: "t2", reportMarkdown: "report:t2", title: "title:t2" },
+        {
+          status: "completed",
+          taskId: "t1",
+          reportMarkdown: "report:t1",
+          title: "title:t1",
+          note: COMPLETED_REPORT_REFETCH_NOTE,
+        },
+        {
+          status: "completed",
+          taskId: "t2",
+          reportMarkdown: "report:t2",
+          title: "title:t2",
+          note: COMPLETED_REPORT_REFETCH_NOTE,
+        },
       ],
     });
     expect(waitForAgentReport).toHaveBeenCalledWith(
@@ -237,6 +251,7 @@ describe("task_await tool", () => {
           reportMarkdown: "ok",
           title: undefined,
           elapsed_ms: 2500,
+          note: COMPLETED_REPORT_REFETCH_NOTE,
         },
       ],
     });
@@ -307,7 +322,15 @@ describe("task_await tool", () => {
     );
 
     expect(result).toEqual({
-      results: [{ status: "completed", taskId: "t1", reportMarkdown: "ok", title: undefined }],
+      results: [
+        {
+          status: "completed",
+          taskId: "t1",
+          reportMarkdown: "ok",
+          title: undefined,
+          note: COMPLETED_REPORT_REFETCH_NOTE,
+        },
+      ],
     });
     expect(waitForAgentReport).toHaveBeenCalledTimes(1);
     expect(listBackgroundProcesses).toHaveBeenCalledTimes(0);
@@ -421,7 +444,15 @@ describe("task_await tool", () => {
     );
 
     expect(result).toEqual({
-      results: [{ status: "completed", taskId: "t1", reportMarkdown: "ok", title: undefined }],
+      results: [
+        {
+          status: "completed",
+          taskId: "t1",
+          reportMarkdown: "ok",
+          title: undefined,
+          note: COMPLETED_REPORT_REFETCH_NOTE,
+        },
+      ],
     });
     expect(isDescendantAgentTask).toHaveBeenCalledTimes(0);
     expect(waitForAgentReport).toHaveBeenCalledTimes(1);
@@ -555,6 +586,7 @@ describe("task_await tool", () => {
         error?: string;
         reportMarkdown?: string;
         title?: string;
+        note?: string;
       }>;
     };
 
@@ -564,6 +596,7 @@ describe("task_await tool", () => {
       taskId: "real-child",
       reportMarkdown: "ok",
       title: undefined,
+      note: COMPLETED_REPORT_REFETCH_NOTE,
     });
     expect(result.results[1]).toMatchObject({
       status: "error",
@@ -671,6 +704,7 @@ describe("task_await tool", () => {
           title: "demo",
           elapsed_ms: 5000,
           run: completedRun,
+          note: COMPLETED_REPORT_REFETCH_NOTE,
         },
       ],
     });
@@ -797,6 +831,7 @@ describe("task_await tool", () => {
           title: "demo",
           elapsed_ms: 5000,
           run: completedRun,
+          note: COMPLETED_REPORT_REFETCH_NOTE,
         },
       ],
     });
@@ -825,7 +860,15 @@ describe("task_await tool", () => {
       excludeWorkflowTasks: true,
     });
     expect(result).toEqual({
-      results: [{ status: "completed", taskId: "t1", reportMarkdown: "ok", title: undefined }],
+      results: [
+        {
+          status: "completed",
+          taskId: "t1",
+          reportMarkdown: "ok",
+          title: undefined,
+          note: COMPLETED_REPORT_REFETCH_NOTE,
+        },
+      ],
     });
   });
 
@@ -952,6 +995,7 @@ describe("task_await tool", () => {
           taskId: "t1",
           reportMarkdown: "ok",
           title: "cached-title",
+          note: COMPLETED_REPORT_REFETCH_NOTE,
         },
       ],
     });
@@ -1001,7 +1045,13 @@ describe("task_await tool", () => {
 
     expect(result).toEqual({
       results: [
-        { status: "completed", taskId: "t1", reportMarkdown: "report:t1", title: "title:t1" },
+        {
+          status: "completed",
+          taskId: "t1",
+          reportMarkdown: "report:t1",
+          title: "title:t1",
+          note: COMPLETED_REPORT_REFETCH_NOTE,
+        },
         { status: "running", taskId: "t2" },
       ],
     });
@@ -1040,8 +1090,20 @@ describe("task_await tool", () => {
 
     expect(result).toEqual({
       results: [
-        { status: "completed", taskId: "t1", reportMarkdown: "report:t1", title: "title:t1" },
-        { status: "completed", taskId: "t2", reportMarkdown: "report:t2", title: "title:t2" },
+        {
+          status: "completed",
+          taskId: "t1",
+          reportMarkdown: "report:t1",
+          title: "title:t1",
+          note: COMPLETED_REPORT_REFETCH_NOTE,
+        },
+        {
+          status: "completed",
+          taskId: "t2",
+          reportMarkdown: "report:t2",
+          title: "title:t2",
+          note: COMPLETED_REPORT_REFETCH_NOTE,
+        },
       ],
     });
   });
@@ -1076,8 +1138,20 @@ describe("task_await tool", () => {
 
     expect(result).toEqual({
       results: [
-        { status: "completed", taskId: "t1", reportMarkdown: "report:t1", title: "title:t1" },
-        { status: "completed", taskId: "t2", reportMarkdown: "report:t2", title: "title:t2" },
+        {
+          status: "completed",
+          taskId: "t1",
+          reportMarkdown: "report:t1",
+          title: "title:t1",
+          note: COMPLETED_REPORT_REFETCH_NOTE,
+        },
+        {
+          status: "completed",
+          taskId: "t2",
+          reportMarkdown: "report:t2",
+          title: "title:t2",
+          note: COMPLETED_REPORT_REFETCH_NOTE,
+        },
         { status: "running", taskId: "t3" },
       ],
     });
@@ -1105,8 +1179,20 @@ describe("task_await tool", () => {
 
     expect(result).toEqual({
       results: [
-        { status: "completed", taskId: "t1", reportMarkdown: "report:t1", title: "title:t1" },
-        { status: "completed", taskId: "t2", reportMarkdown: "report:t2", title: "title:t2" },
+        {
+          status: "completed",
+          taskId: "t1",
+          reportMarkdown: "report:t1",
+          title: "title:t1",
+          note: COMPLETED_REPORT_REFETCH_NOTE,
+        },
+        {
+          status: "completed",
+          taskId: "t2",
+          reportMarkdown: "report:t2",
+          title: "title:t2",
+          note: COMPLETED_REPORT_REFETCH_NOTE,
+        },
       ],
     });
   });
@@ -1139,7 +1225,13 @@ describe("task_await tool", () => {
 
     expect(result).toEqual({
       results: [
-        { status: "completed", taskId: "t1", reportMarkdown: "report:t1", title: "title:t1" },
+        {
+          status: "completed",
+          taskId: "t1",
+          reportMarkdown: "report:t1",
+          title: "title:t1",
+          note: COMPLETED_REPORT_REFETCH_NOTE,
+        },
         { status: "error", taskId: "t2", error: "Boom" },
       ],
     });
@@ -1179,7 +1271,13 @@ describe("task_await tool", () => {
     );
     expect(firstResult).toEqual({
       results: [
-        { status: "completed", taskId: "t1", reportMarkdown: "report:t1", title: "title:t1" },
+        {
+          status: "completed",
+          taskId: "t1",
+          reportMarkdown: "report:t1",
+          title: "title:t1",
+          note: COMPLETED_REPORT_REFETCH_NOTE,
+        },
         { status: "running", taskId: "t2" },
       ],
     });
@@ -1190,7 +1288,13 @@ describe("task_await tool", () => {
     );
     expect(secondResult).toEqual({
       results: [
-        { status: "completed", taskId: "t2", reportMarkdown: "report:t2", title: "title:t2" },
+        {
+          status: "completed",
+          taskId: "t2",
+          reportMarkdown: "report:t2",
+          title: "title:t2",
+          note: COMPLETED_REPORT_REFETCH_NOTE,
+        },
       ],
     });
   });
@@ -1257,7 +1361,13 @@ describe("task_await tool", () => {
 
     expect(result).toEqual({
       results: [
-        { status: "completed", taskId: "t1", reportMarkdown: "report:t1", title: "title:t1" },
+        {
+          status: "completed",
+          taskId: "t1",
+          reportMarkdown: "report:t1",
+          title: "title:t1",
+          note: COMPLETED_REPORT_REFETCH_NOTE,
+        },
         { status: "error", taskId: "bash:p1", error: "proc boom" },
       ],
     });

--- a/src/node/services/tools/task_await.ts
+++ b/src/node/services/tools/task_await.ts
@@ -3,7 +3,11 @@ import { tool } from "ai";
 import type { ToolConfiguration, ToolFactory } from "@/common/utils/tools/tools";
 import { readSubagentGitPatchArtifact } from "@/node/services/subagentGitPatchArtifacts";
 import { WorkflowRunRecordSchema } from "@/common/orpc/schemas";
-import { TaskAwaitToolResultSchema, TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
+import {
+  COMPLETED_REPORT_REFETCH_NOTE,
+  TaskAwaitToolResultSchema,
+  TOOL_DEFINITIONS,
+} from "@/common/utils/tools/toolDefinitions";
 import type { WorkflowRunRecord, WorkflowRunStatus } from "@/common/types/workflow";
 
 import { fromBashTaskId, toBashTaskId } from "./taskId";
@@ -146,6 +150,7 @@ function buildWorkflowAwaitResult(run: WorkflowRunRecord) {
           ? { structuredOutput: result.structuredOutput }
           : {}),
         title: run.definition.name,
+        note: COMPLETED_REPORT_REFETCH_NOTE,
       };
     }
     case "failed":
@@ -512,6 +517,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
               title: report.title,
               ...getAgentTaskElapsedField(taskId),
               ...(gitFormatPatch ? { artifacts: { gitFormatPatch } } : {}),
+              note: COMPLETED_REPORT_REFETCH_NOTE,
             };
           } catch (error: unknown) {
             const message = getErrorMessage(error);
@@ -539,6 +545,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
             title: report.title,
             ...getAgentTaskElapsedField(taskId),
             ...(gitFormatPatch ? { artifacts: { gitFormatPatch } } : {}),
+            note: COMPLETED_REPORT_REFETCH_NOTE,
           };
         } catch (error: unknown) {
           if (error instanceof ForegroundWaitBackgroundedError) {

--- a/src/node/services/tools/workflow_run.test.ts
+++ b/src/node/services/tools/workflow_run.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/await-thenable, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/require-await */
 import { describe, expect, mock, test } from "bun:test";
 import type { ToolExecutionOptions } from "ai";
+import { COMPLETED_REPORT_REFETCH_NOTE } from "@/common/utils/tools/toolDefinitions";
 import { createWorkflowRunTool } from "./workflow_run";
 import { TestTempDir, createTestToolConfig } from "./testHelpers";
 import { readAgentWorkflowRunReferences } from "@/node/services/agentWorkflowRunReferences";
@@ -98,6 +99,7 @@ describe("workflow_run tool", () => {
         status: "completed",
         events: expect.arrayContaining([expect.objectContaining({ type: "phase", name: "scope" })]),
       }),
+      note: COMPLETED_REPORT_REFETCH_NOTE,
     });
   });
 

--- a/src/node/services/tools/workflow_run.ts
+++ b/src/node/services/tools/workflow_run.ts
@@ -5,6 +5,7 @@ import type { ToolConfiguration, ToolFactory } from "@/common/utils/tools/tools"
 import { log } from "@/node/services/log";
 import { recordAgentWorkflowRunReference } from "@/node/services/agentWorkflowRunReferences";
 import {
+  COMPLETED_REPORT_REFETCH_NOTE,
   WorkflowRunToolResultSchema,
   TOOL_DEFINITIONS,
 } from "@/common/utils/tools/toolDefinitions";
@@ -92,6 +93,7 @@ export const createWorkflowRunTool: ToolFactory = (config: ToolConfiguration) =>
           runId: result.runId,
           result: result.result,
           ...(run != null ? { run } : {}),
+          ...(result.status === "completed" ? { note: COMPLETED_REPORT_REFETCH_NOTE } : {}),
         },
         "workflow_run"
       );


### PR DESCRIPTION
## Summary

Makes completed sub-agent/workflow reports recoverable after context compaction: a capped index of re-fetchable report handles is injected via the post-compaction attachment machinery, and completed `task_await`/`workflow_run` results now carry a note that the report is durable and re-fetchable by ID.

## Background

Workflow results and sub-agent reports are already durably persisted (session-dir `workflows/<runId>/run.json` and `subagent-reports/<taskId>/report.json`) and `task_await` can already re-fetch them by ID. But after compaction the model loses the runId/taskId **handles**, so expensive, long-running results become effectively unreachable and the work gets re-run. This change surfaces the existing durable results instead of duplicating them into new files.

## Implementation

1. **New `completed_reports_index` post-compaction attachment** — built in `AttachmentService.generateCompletedReportsAttachment()` from the two existing durable stores (`subagent-reports.json` index + `WorkflowRunStore.listRuns()`). Entries are handles only (ID, kind, title, completed-at, ~token estimate) — never report content. Filters:
   - direct children only (grandchild reports are synthesized into the child's report)
   - workflow-owned sub-agent reports excluded (consumed through the workflow run's report)
   - completed **before** the compaction cutoff (immediate injection: now; periodic re-injection: latest boundary timestamp) so reports still visible in the active epoch aren't duplicated
   - completed workflow runs only; capped at 20, newest first
   - **self-healing**: persisted index rows are validated per-field (null/non-object rows, malformed ids/timestamps, non-array ownership markers are skipped/degraded) so one corrupt row can never break post-compaction injection
2. **Budget-aware rendering** — the renderer emits one line per report plus a `task_await(task_ids: ["<id>"], timeout_secs: 0)` re-fetch instruction, prioritized ahead of bulky skills/diff blocks. Titles (model-provided, unbounded) are capped at 80 chars, and entries pack greedily under the 80k injection budget with an "omitted N handles" note — so a single oversized title can never drop every handle.
3. **`COMPLETED_REPORT_REFETCH_NOTE`** appended to completed `task_await` results (agent tasks + workflow runs) and foreground-completed `workflow_run` results (schema gained an optional `note`), and the `task_await` tool description now documents re-fetch-by-ID across compaction.

## Validation

- New tests: index generation against real artifact writers + a real `WorkflowRunStore` (cutoff/scope filtering, cap+ordering, malformed-row skipping, empty→null) and renderer tests (handle rendering, title capping, partial packing + truncation note, budget priority over file diffs).
- `bun test src/node/services/tools/ src/browser/utils/messages/` — 1,070 tests green; compaction handler/monitor and agentSession post-compaction suites green.

## Risks

Low. The attachment only adds a small injected block post-compaction (existing 80k-char budget applies); generation is read-only over session-dir artifacts, validates each persisted row defensively, and returns null when nothing qualifies. The `note` field is additive on tool results — existing exact-shape test expectations were updated accordingly. Worst-case regression is a missing or slightly stale index entry, which degrades to today's behavior.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `max` • Cost: `$23.53`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=max costs=23.53 -->
