### PR TITLE
🤖 tests: fix flaky workflow crash-recovery stale-lease test

### DIFF
--- a/src/node/services/workflows/WorkflowRunStore.ts
+++ b/src/node/services/workflows/WorkflowRunStore.ts
@@ -951,7 +951,10 @@ async function acquireWorkflowMutationLock(
     if (await acquireLeaseMutationLock(lockDir, Date.now(), staleLeaseMs)) {
       return;
     }
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    // Jittered backoff: a fixed sleep can phase-lock with the periodic lease renewal (whose
+    // interval is also a small constant when staleLeaseMs is short, e.g. in tests), so every
+    // retry lands while a renewal holds the lock and waiters starve for hundreds of ms.
+    await new Promise((resolve) => setTimeout(resolve, 2 + Math.random() * 6));
   }
   throw new Error(`Timed out acquiring workflow mutation lock: ${lockDir}`);
 }

--- a/src/node/services/workflows/WorkflowService.test.ts
+++ b/src/node/services/workflows/WorkflowService.test.ts
@@ -38,7 +38,9 @@ async function waitForWorkflowStatus(
   runId: string,
   status: string
 ): Promise<void> {
-  const deadline = Date.now() + 1_000;
+  // Match waitForCondition's 5s budget: loaded CI runners have hit >1s for the
+  // post-agent append/lease-renewal phase (see flaky "fresh persisted lease" failures).
+  const deadline = Date.now() + 5_000;
   while (Date.now() < deadline) {
     const run = await runStore.getRun(runId);
     if (run.status === status) {
@@ -55,7 +57,7 @@ async function waitForWorkflowRunFileStatus(
   status: string
 ): Promise<void> {
   const runFile = path.join(sessionDir, "workflows", runId, "run.json");
-  const deadline = Date.now() + 1_000;
+  const deadline = Date.now() + 5_000;
   while (Date.now() < deadline) {
     try {
       const run = JSON.parse(await fs.readFile(runFile, "utf-8")) as { status?: unknown };


### PR DESCRIPTION
## Summary

Fixes the flaky `WorkflowService > retries crash recovery after a fresh persisted lease becomes stale` unit test by eliminating lock starvation in `WorkflowRunStore` and aligning the test helper deadlines with the rest of the file.

## Background

CI failure (run 27342908020): `Timed out waiting for wfr_fresh_crash_lease to become completed; got running` after 1042ms. The workflow's agent step ran within ~40ms, but the run never reached `completed` within the helper's 1s deadline. A sibling green run completed the same test at 782ms — uncomfortably close to the ceiling.

**Root cause — phase-locked lock starvation.** The test configures `staleLeaseMs: 10`, so the runner renews its lease every `floor(10/2)` = 5ms, grabbing the lease lockdir each time. Every event append (`withExpectedLeaseOwner`) contends for the same lockdir, and `acquireWorkflowMutationLock` retried with a **fixed 5ms sleep**. Two identical 5ms periods phase-lock: the append's retry repeatedly wakes exactly while a renewal holds the lock. A probe against the real `WorkflowRunStore` showed a single append stalling **544ms on an idle machine**; on a loaded CI runner the post-agent appends (step record → result → completed) easily blow the 1s test budget.

## Implementation

- `WorkflowRunStore.acquireWorkflowMutationLock`: jittered retry backoff (`2 + Math.random() * 6` ms) breaks the harmonic with the renewal interval. This also protects `WorkflowRunner.test.ts` (100ms lease → 50ms renewals, same 5ms harmonic). Production (30s lease → 15s renewals) was never meaningfully exposed.
- `WorkflowService.test.ts`: `waitForWorkflowStatus` / `waitForWorkflowRunFileStatus` deadlines 1s → 5s, matching the file's existing `waitForCondition` budget.

## Validation

- Probe max single-append stall: **544ms → ~20ms** (3 runs)
- Formerly flaky test: **0/20 failures** pinned to one contended core (3 busy-loop competitors), plus 0/57 across plain/coverage/full-file loops
- Full workflow suite: 223/223 pass

## Risks

Low. The jitter only changes retry timing on an already-contended path; lock acquisition semantics, staleness handling, and timeout budgets are unchanged. Worst case is a marginally different retry cadence under contention.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `max` • Cost: `$12.15`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=max costs=12.15 -->
