### PR TITLE
🤖 fix: serialize Config.editConfig to prevent concurrent lost updates

### DIFF
--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -55,6 +55,41 @@ describe("Config", () => {
     });
   });
 
+  describe("editConfig", () => {
+    it("serializes concurrent edits so no update is lost", async () => {
+      // Regression: editConfig used to be a non-serialized read-modify-write
+      // (load → mutate → async save). Two concurrent edits could both load the
+      // same snapshot, and the later write clobbered the earlier one. TaskService
+      // launches tasks in parallel and flips each task's status via editConfig,
+      // so a lost update left tasks stuck in "starting" (flaky
+      // "resumes accepted queued starts instead of replaying prompts").
+      await config.editConfig((cfg) => {
+        cfg.projects.set("/repo", {
+          workspaces: [
+            { path: "/repo/a", id: "aaaaaaaaaa", name: "a", taskStatus: "starting" },
+            { path: "/repo/b", id: "bbbbbbbbbb", name: "b", taskStatus: "starting" },
+          ],
+        });
+        return cfg;
+      });
+
+      const setStatus = (id: string) =>
+        config.editConfig((cfg) => {
+          const ws = cfg.projects.get("/repo")?.workspaces.find((w) => w.id === id);
+          if (ws) ws.taskStatus = "running";
+          return cfg;
+        });
+
+      // Fire both edits without awaiting in between, mirroring parallel task launches.
+      await Promise.all([setStatus("aaaaaaaaaa"), setStatus("bbbbbbbbbb")]);
+
+      const workspaces = new Config(tempDir)
+        .loadConfigOrDefault()
+        .projects.get("/repo")?.workspaces;
+      expect(workspaces?.map((w) => w.taskStatus)).toEqual(["running", "running"]);
+    });
+  });
+
   describe("userPreferences", () => {
     it("loads and saves user preferences", async () => {
       await config.editConfig((cfg) => ({

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -585,6 +585,8 @@ export class Config {
   private readonly providersFile: string;
   private readonly secretsFile: string;
   private readonly emitter = new EventEmitter();
+  /** Serializes editConfig calls; see editConfig for why. */
+  private editConfigQueue: Promise<void> = Promise.resolve();
 
   constructor(rootDir?: string) {
     this.rootDir = rootDir ?? getMuxHome();
@@ -1314,14 +1316,27 @@ export class Config {
   /**
    * Edit config atomically using a transformation function
    * @param fn Function that takes current config and returns modified config
+   *
+   * Edits are serialized on an internal queue: each edit's read happens only
+   * after the previous edit's write has landed. Without this, concurrent edits
+   * (e.g. parallel task launches updating taskStatus) read the same snapshot
+   * and the later write silently clobbers the earlier one.
    */
   async editConfig(fn: (config: ProjectsConfig) => ProjectsConfig): Promise<void> {
-    const config = this.loadConfigOrDefault();
-    const newConfig = fn(config);
-    await this.saveConfig(newConfig);
-    // Backend-initiated config edits (for example gateway auth changes) use this signal
-    // so frontend subscribers can refresh derived state without polling.
-    this.notifyConfigChanged();
+    const run = this.editConfigQueue.then(async () => {
+      const config = this.loadConfigOrDefault();
+      const newConfig = fn(config);
+      await this.saveConfig(newConfig);
+      // Backend-initiated config edits (for example gateway auth changes) use this signal
+      // so frontend subscribers can refresh derived state without polling.
+      this.notifyConfigChanged();
+    });
+    // Keep the queue alive when an edit fails; the failure still propagates to this caller.
+    this.editConfigQueue = run.then(
+      () => undefined,
+      () => undefined
+    );
+    return run;
   }
 
   getUpdateChannel(): UpdateChannel {


### PR DESCRIPTION
## Summary

Serializes `Config.editConfig` on an internal promise queue so concurrent edits can no longer clobber each other's writes. This fixes the flaky `TaskService > resumes accepted queued starts instead of replaying prompts` test and a real lost-update race affecting parallel task launches.

## Background

CI failed with `Expected: "running", Received: "starting"` at `taskService.test.ts:897` even though `resumeStream` had been called for the queued task.

`Config.editConfig` was a non-serialized read-modify-write (`loadConfigOrDefault()` → mutate → `await saveConfig()`). Since bulk task launching (#3494), `TaskService` launches reserved tasks in parallel via `Promise.allSettled`, and each launch tail issues several `editConfig` calls (workspace path update, then `setTaskStatus("running")`). Under slow disk writes, launch B's edit can load a config snapshot taken *before* launch A's `"running"` status write lands; B's later write then silently reverts A's task to `"starting"`. Nothing requeues `"starting"` tasks, so the task is stuck — flaky in tests, and a real stuck-task bug in production whenever parallel launches race on slow disks.

## Implementation

`editConfig` now chains each call on a private `editConfigQueue` promise: an edit's read happens only after the previous edit's write has landed. The transform `fn` stays synchronous and each queued edit is self-contained, so the chain always drains (no deadlock risk). Failures still propagate to their own caller while keeping the queue alive for subsequent edits.

## Validation

Causality was proven deterministically by injecting 300 ms write latency into `saveConfig` (simulating CI fsync pressure):

| Configuration | Result |
|---|---|
| old `editConfig` + 300 ms latency | failed 3/3 with the exact CI error (`Expected "running", Received "starting"`) |
| serialized `editConfig` + 300 ms latency | passed 3/3 |

Added a regression test (`config.test.ts > editConfig > serializes concurrent edits so no update is lost`) that fires two concurrent status edits — it fails on the old implementation (one update lost) and passes now.

Also ran: the previously-flaky test 15× in a loop, `taskService.test.ts` (169 pass), full `bun test src/node` sweep (4463 pass / 0 fail), and `make static-check`.

## Risks

Low. `editConfig` previously interleaved at every await point with undefined ordering; strict FIFO serialization is a subset of previously possible schedules. Throughput of config writes is bounded by the queue, but edits are small, local JSON writes. Direct `saveConfig` callers (e.g. `projectService`, `workspaceService`) bypass the queue exactly as before — unchanged behavior, same pre-existing caveat.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `max` • Cost: `$15.07`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=max costs=15.07 -->
