### PR TITLE
🤖 feat: coalesce workflow patch events into a single row

### DIFF
--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -626,6 +626,83 @@ describe("WorkflowRunToolCall", () => {
     expect(view.container.textContent).toContain("durationMs");
   });
 
+  test("coalesces patch start and applied events into one row with combined details", () => {
+    const view = render(
+      <ThemeProvider forcedTheme="dark">
+        <TooltipProvider>
+          <WorkflowRunToolCall
+            args={{ name: "implementation", args: {}, run_in_background: true }}
+            status="completed"
+            result={{
+              status: "completed",
+              runId: "wfr_patch_rows",
+              result: null,
+              run: {
+                id: "wfr_patch_rows",
+                workspaceId: "workspace-1",
+                definition: {
+                  name: "implementation",
+                  description: "Implementation",
+                  scope: "built-in",
+                  executable: true,
+                },
+                definitionSource: "export default function workflow() { return null; }",
+                definitionHash: "sha256:patches",
+                args: {},
+                status: "completed",
+                createdAt: "2026-05-29T00:00:00.000Z",
+                updatedAt: "2026-05-29T00:00:02.000Z",
+                events: [
+                  {
+                    sequence: 1,
+                    type: "patch",
+                    at: "2026-05-29T00:00:00.000Z",
+                    stepId: "apply-p0-p1",
+                    sourceTaskId: "task_p0",
+                    status: "started",
+                    details: { target: "workspace" },
+                  },
+                  {
+                    sequence: 2,
+                    type: "patch",
+                    at: "2026-05-29T00:00:01.000Z",
+                    stepId: "apply-p0-p1",
+                    sourceTaskId: "task_p0",
+                    status: "applied",
+                    details: { commitCount: 3 },
+                  },
+                  {
+                    sequence: 3,
+                    type: "patch",
+                    at: "2026-05-29T00:00:02.000Z",
+                    stepId: "apply-p1-p2",
+                    sourceTaskId: "task_p1",
+                    status: "started",
+                    details: { target: "workspace" },
+                  },
+                ],
+                steps: [],
+              },
+            }}
+          />
+        </TooltipProvider>
+      </ThemeProvider>
+    );
+
+    fireEvent.click(getWorkflowHeader(view));
+
+    expect(view.getByText("Workflow events (2)")).toBeTruthy();
+    expect(view.getAllByText("apply-p0-p1 / task_p0 / applied")).toHaveLength(1);
+    expect(view.queryByText("apply-p0-p1 / task_p0 / started")).toBeNull();
+    expect(view.getByText("apply-p1-p2 / task_p1 / started")).toBeTruthy();
+    expect(view.getByText("#1").getAttribute("aria-label")).toBe("Raw event #1");
+
+    fireEvent.click(view.getByText("apply-p0-p1 / task_p0 / applied"));
+
+    expect(view.container.textContent).toContain("target");
+    expect(view.container.textContent).toContain("commitCount");
+  });
+
   test("leaves cached action events separate from pending started rows", () => {
     const view = render(
       <ThemeProvider forcedTheme="dark">

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -209,14 +209,17 @@ function getStructuredOutput(value: unknown): unknown {
 
 type WorkflowTaskEvent = Extract<WorkflowRunEvent, { type: "task" }>;
 type WorkflowActionEvent = Extract<WorkflowRunEvent, { type: "action" }>;
+type WorkflowPatchEvent = Extract<WorkflowRunEvent, { type: "patch" }>;
 
 type WorkflowDisplayRow =
   | { kind: "event"; event: WorkflowRunEvent }
   | { kind: "task"; firstEvent: WorkflowTaskEvent; latestEvent: WorkflowTaskEvent }
-  | { kind: "action"; firstEvent: WorkflowActionEvent; latestEvent: WorkflowActionEvent };
+  | { kind: "action"; firstEvent: WorkflowActionEvent; latestEvent: WorkflowActionEvent }
+  | { kind: "patch"; firstEvent: WorkflowPatchEvent; latestEvent: WorkflowPatchEvent };
 
 type WorkflowTaskRow = Extract<WorkflowDisplayRow, { kind: "task" }>;
 type WorkflowActionRow = Extract<WorkflowDisplayRow, { kind: "action" }>;
+type WorkflowPatchRow = Extract<WorkflowDisplayRow, { kind: "patch" }>;
 interface PendingWorkflowActionRows {
   rows: WorkflowActionRow[];
   ambiguous: boolean;
@@ -224,6 +227,10 @@ interface PendingWorkflowActionRows {
 
 function getTaskEventKey(event: WorkflowTaskEvent): string {
   return `task:${event.stepId}:${event.taskId}`;
+}
+
+function getPatchEventKey(event: WorkflowPatchEvent): string {
+  return `patch:${event.stepId}:${event.sourceTaskId}`;
 }
 
 function getActionEventKey(event: WorkflowActionEvent): string {
@@ -266,6 +273,7 @@ function getWorkflowDisplayRows(events: readonly WorkflowRunEvent[]): WorkflowDi
   const rows: WorkflowDisplayRow[] = [];
   const taskRows = new Map<string, WorkflowTaskRow>();
   const actionRows = new Map<string, PendingWorkflowActionRows>();
+  const patchRows = new Map<string, WorkflowPatchRow>();
 
   for (const event of events) {
     if (event.type === "status" || event.type === "result") {
@@ -285,6 +293,27 @@ function getWorkflowDisplayRows(events: readonly WorkflowRunEvent[]): WorkflowDi
         latestEvent: event,
       };
       taskRows.set(key, row);
+      rows.push(row);
+      continue;
+    }
+
+    if (event.type === "patch") {
+      // A patch step emits started → applied/conflict/failed for the same
+      // stepId+sourceTaskId; collapse them into one row (latest status wins),
+      // mirroring task-row coalescing.
+      const key = getPatchEventKey(event);
+      const existingRow = patchRows.get(key);
+      if (existingRow != null) {
+        existingRow.latestEvent = event;
+        continue;
+      }
+
+      const row: WorkflowPatchRow = {
+        kind: "patch",
+        firstEvent: event,
+        latestEvent: event,
+      };
+      patchRows.set(key, row);
       rows.push(row);
       continue;
     }
@@ -347,6 +376,9 @@ function getDisplayRowKey(row: WorkflowDisplayRow): string {
   }
   if (row.kind === "action") {
     return `${getActionEventKey(row.firstEvent)}:${row.firstEvent.sequence}`;
+  }
+  if (row.kind === "patch") {
+    return getPatchEventKey(row.firstEvent);
   }
   return getEventKey(row.event);
 }
@@ -519,7 +551,7 @@ function WorkflowEventTooltip(props: {
   );
 }
 
-function getWorkflowActionRowDetail(row: WorkflowActionRow): unknown {
+function getWorkflowMergedRowDetail(row: WorkflowActionRow | WorkflowPatchRow): unknown {
   const firstDetail = getWorkflowEventDetail(row.firstEvent);
   const latestDetail = getWorkflowEventDetail(row.latestEvent);
   if (row.firstEvent === row.latestEvent || row.latestEvent.status === "started") {
@@ -1512,13 +1544,13 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
                         />
                       );
                     }
-                    if (row.kind === "action") {
+                    if (row.kind === "action" || row.kind === "patch") {
                       return (
                         <WorkflowEventRow
                           key={getDisplayRowKey(row)}
                           event={row.latestEvent}
                           tooltipEvent={row.firstEvent}
-                          detailOverride={getWorkflowActionRowDetail(row)}
+                          detailOverride={getWorkflowMergedRowDetail(row)}
                           displayIndex={index + 1}
                           steps={run?.steps ?? []}
                         />


### PR DESCRIPTION
## Summary

The workflow event list rendered two rows per patch step (`started`, then `applied`/`conflict`/`failed`). Patch events with the same `stepId + sourceTaskId` now coalesce into a single row whose latest status wins, mirroring existing task/action row coalescing.

## Background

A patch step emits a `started` event and later a terminal event for the same step, producing redundant adjacent rows like `apply-p0-p1 / 2a7c53e7f7 / started` followed by `apply-p0-p1 / 2a7c53e7f7 / applied`. Task and action events already collapse into one row each; patch events were the remaining exception.

## Implementation

- `getWorkflowDisplayRows` gains a `patch` branch keyed by `stepId:sourceTaskId` (same pattern as task rows; retries merge into the same row, latest status wins).
- Coalesced patch rows render through the same merged-detail path as action rows (`getWorkflowActionRowDetail` renamed to `getWorkflowMergedRowDetail` and widened), so expanding a row shows `{ started: {...}, applied: {...} }` with no detail loss. Tooltip still references the first raw event sequence.
- An in-flight patch (only `started` seen) renders unchanged.

## Validation

- New UI test: started+applied coalesce into one row with combined expandable details, while a lone `started` patch stays a separate row.
- All 33 `WorkflowRunToolCall` tests pass; `make static-check` green.

## Risks

Low; display-only change in the workflow event list. Worst case is a mis-coalesced row in workflow run history rendering.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$3.83`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=3.83 -->
