### PR TITLE
🤖 feat: support {{time_filter}} placeholder in analytics SQL panels

### DIFF
--- a/src/browser/features/Analytics/AnalyticsDashboard.tsx
+++ b/src/browser/features/Analytics/AnalyticsDashboard.tsx
@@ -30,6 +30,7 @@ import { SummaryCards } from "./SummaryCards";
 import { TimingChart } from "./TimingChart";
 import { TokensByModelChart } from "./TokensByModelChart";
 import { formatProjectDisplayName } from "./analyticsUtils";
+import { buildTimeFilterPredicate } from "./sqlTimeFilter";
 
 interface AnalyticsDashboardProps {
   leftSidebarCollapsed: boolean;
@@ -105,6 +106,10 @@ export function AnalyticsDashboard(props: AnalyticsDashboardProps) {
   const timingMetric = normalizeTimingMetric(rawTimingMetric);
 
   const dateRange = computeDateRange(timeRange);
+  // SQL predicate substituted for the time-filter placeholder in saved panels
+  // and the SQL explorer, so user-authored queries can opt into the header's
+  // date-range selection.
+  const timeFilterSql = buildTimeFilterPredicate(dateRange.from, dateRange.to);
 
   const summary = useAnalyticsSummary(projectPath, {
     from: dateRange.from,
@@ -321,13 +326,14 @@ export function AnalyticsDashboard(props: AnalyticsDashboardProps) {
                 <SavedQueryPanel
                   key={query.id}
                   query={query}
+                  timeFilterSql={timeFilterSql}
                   onDelete={removeSavedQuery}
                   onUpdate={updateSavedQuery}
                 />
               ))}
             </div>
           )}
-          <SqlExplorer onSaveQuery={saveQuery} />
+          <SqlExplorer onSaveQuery={saveQuery} timeFilterSql={timeFilterSql} />
         </div>
       </div>
     </div>

--- a/src/browser/features/Analytics/SavedQueryPanel.test.tsx
+++ b/src/browser/features/Analytics/SavedQueryPanel.test.tsx
@@ -71,6 +71,7 @@ function createSavedQuery(overrides: Partial<SavedQuery> = {}): SavedQuery {
 function renderPanel(
   overrides: Partial<{
     query: SavedQuery;
+    timeFilterSql: string;
     onDelete: (id: string) => Promise<void> | void;
     onUpdate: (input: {
       id: string;
@@ -84,13 +85,27 @@ function renderPanel(
   const onDelete = overrides.onDelete ?? mock(() => Promise.resolve());
   const onUpdate = overrides.onUpdate ?? mock(() => Promise.resolve(null));
 
-  const view = render(
+  const buildElement = (timeFilterSql: string) => (
     <TooltipProvider>
-      <SavedQueryPanel query={query} onDelete={onDelete} onUpdate={onUpdate} />
+      <SavedQueryPanel
+        query={query}
+        timeFilterSql={timeFilterSql}
+        onDelete={onDelete}
+        onUpdate={onUpdate}
+      />
     </TooltipProvider>
   );
 
-  return { ...view, query, onDelete, onUpdate };
+  const view = render(buildElement(overrides.timeFilterSql ?? "TRUE"));
+
+  return {
+    ...view,
+    query,
+    onDelete,
+    onUpdate,
+    rerenderWithTimeFilter: (nextTimeFilterSql: string) =>
+      view.rerender(buildElement(nextTimeFilterSql)),
+  };
 }
 
 describe("SavedQueryPanel", () => {
@@ -113,6 +128,36 @@ describe("SavedQueryPanel", () => {
     mock.restore();
     globalThis.window = originalWindow;
     globalThis.document = originalDocument;
+  });
+
+  test("substitutes the dashboard time filter into the saved SQL and re-runs when it changes", async () => {
+    const query = createSavedQuery({
+      sql: "SELECT model FROM events WHERE {{time_filter}} GROUP BY model",
+    });
+    const view = renderPanel({ query, timeFilterSql: "(date >= DATE '2026-06-05')" });
+
+    await waitFor(() =>
+      expect(executeQueryMock).toHaveBeenCalledWith(
+        "SELECT model FROM events WHERE (date >= DATE '2026-06-05') GROUP BY model"
+      )
+    );
+
+    view.rerenderWithTimeFilter("TRUE");
+    await waitFor(() =>
+      expect(executeQueryMock).toHaveBeenCalledWith(
+        "SELECT model FROM events WHERE TRUE GROUP BY model"
+      )
+    );
+  });
+
+  test("does not re-run placeholder-free SQL when the time filter changes", async () => {
+    const view = renderPanel({ timeFilterSql: "TRUE" });
+
+    await waitFor(() => expect(executeQueryMock).toHaveBeenCalledTimes(1));
+    expect(executeQueryMock).toHaveBeenCalledWith(view.query.sql);
+
+    view.rerenderWithTimeFilter("(date >= DATE '2026-06-05')");
+    expect(executeQueryMock).toHaveBeenCalledTimes(1);
   });
 
   test("renders a panel-level SQL button and opens the dialog with the saved SQL", () => {

--- a/src/browser/features/Analytics/SavedQueryPanel.tsx
+++ b/src/browser/features/Analytics/SavedQueryPanel.tsx
@@ -13,9 +13,13 @@ import type { SavedQuery } from "@/common/types/savedQueries";
 import { getErrorMessage } from "@/common/utils/errors";
 import { ChartTypePicker } from "./ChartTypePicker";
 import { SavedQuerySqlDialog } from "./SavedQuerySqlDialog";
+import { substituteTimeFilter } from "./sqlTimeFilter";
 
 interface SavedQueryPanelProps {
   query: SavedQuery;
+  /** Predicate for the dashboard's date-range selection, substituted for the
+   *  time-filter placeholder before the saved SQL is executed. */
+  timeFilterSql: string;
   onDelete: (id: string) => Promise<void> | void;
   onUpdate: (input: {
     id: string;
@@ -158,18 +162,23 @@ export function SavedQueryPanel(props: SavedQueryPanelProps) {
   const saveSqlDisabled =
     savingSql || normalizedDraftSql.length === 0 || normalizedDraftSql === normalizedSavedSql;
 
+  // SQL actually executed for this panel: the saved SQL with the dashboard's
+  // active date-range predicate substituted in. Using the resolved string as
+  // the effect dependency means only panels that use the placeholder re-run
+  // when the header range changes.
+  const resolvedSql = substituteTimeFilter(props.query.sql, props.timeFilterSql).trim();
+
   useEffect(() => {
     executeQueryRef.current = executeQuery;
   }, [executeQuery]);
 
   useEffect(() => {
-    const normalizedSql = props.query.sql.trim();
-    if (!normalizedSql) {
+    if (!resolvedSql) {
       return;
     }
 
-    void executeQueryRef.current(normalizedSql);
-  }, [props.query.sql]);
+    void executeQueryRef.current(resolvedSql);
+  }, [resolvedSql]);
 
   const inferredChartType = data ? inferChartType(data.columns, data.rows) : "table";
   const explicitChartType = normalizeChartType(props.query.chartType);
@@ -197,12 +206,11 @@ export function SavedQueryPanel(props: SavedQueryPanelProps) {
       return;
     }
 
-    const normalizedSql = props.query.sql.trim();
-    if (!normalizedSql) {
+    if (!resolvedSql) {
       return;
     }
 
-    void executeQuery(normalizedSql);
+    void executeQuery(resolvedSql);
   };
 
   const handleDelete = async () => {

--- a/src/browser/features/Analytics/SavedQuerySqlDialog.tsx
+++ b/src/browser/features/Analytics/SavedQuerySqlDialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/browser/components/Dialog/Dialog";
+import { TIME_FILTER_PLACEHOLDER } from "./sqlTimeFilter";
 
 interface SavedQuerySqlDialogProps {
   open: boolean;
@@ -28,7 +29,9 @@ export function SavedQuerySqlDialog(props: SavedQuerySqlDialogProps) {
         <DialogHeader>
           <DialogTitle>{`Edit SQL — ${props.label}`}</DialogTitle>
           <DialogDescription>
-            Saving updates this panel and reruns it with the edited query.
+            Saving updates this panel and reruns it with the edited query. Use{" "}
+            <code className="text-foreground">{TIME_FILTER_PLACEHOLDER}</code> in a WHERE clause to
+            filter by the dashboard&apos;s selected date range.
           </DialogDescription>
         </DialogHeader>
 

--- a/src/browser/features/Analytics/SqlExplorer.tsx
+++ b/src/browser/features/Analytics/SqlExplorer.tsx
@@ -10,6 +10,7 @@ import { ResultTable } from "../Tools/analyticsQuery/ResultTable";
 import { inferAxes, inferChartType } from "../Tools/analyticsQuery/chartHeuristics";
 import type { ChartType } from "../Tools/analyticsQuery/types";
 import { ChartTypePicker } from "./ChartTypePicker";
+import { substituteTimeFilter, TIME_FILTER_PLACEHOLDER } from "./sqlTimeFilter";
 
 export const SAMPLE_QUERIES = [
   {
@@ -31,6 +32,9 @@ export const SAMPLE_QUERIES = [
 ];
 
 interface SqlExplorerProps {
+  /** Predicate for the dashboard's date-range selection, substituted for the
+   *  time-filter placeholder before the SQL is executed. */
+  timeFilterSql: string;
   onSaveQuery?: (input: {
     label: string;
     sql: string;
@@ -68,9 +72,11 @@ export function SqlExplorer(props: SqlExplorerProps) {
     }
 
     const thisExecutionId = ++executionIdRef.current;
-    await executeQuery(normalizedSql);
+    await executeQuery(substituteTimeFilter(normalizedSql, props.timeFilterSql));
 
     if (thisExecutionId === executionIdRef.current) {
+      // Keep the raw SQL (with placeholder) so "Save as Panel" stores a query
+      // that keeps tracking the dashboard's date-range selection.
       setLastExecutedSql(normalizedSql);
     }
   };
@@ -179,6 +185,11 @@ export function SqlExplorer(props: SqlExplorerProps) {
               Run Query
             </Button>
           </div>
+        </div>
+
+        <div className="text-muted text-[10px]">
+          Use <code className="text-foreground">{TIME_FILTER_PLACEHOLDER}</code> in a WHERE clause
+          to filter by the selected date range (7D/30D/90D/All).
         </div>
 
         {error && (

--- a/src/browser/features/Analytics/sqlTimeFilter.test.ts
+++ b/src/browser/features/Analytics/sqlTimeFilter.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildTimeFilterPredicate,
+  substituteTimeFilter,
+  TIME_FILTER_PLACEHOLDER,
+} from "./sqlTimeFilter";
+
+describe("buildTimeFilterPredicate", () => {
+  test("returns a tautology when no boundaries are set (All time)", () => {
+    expect(buildTimeFilterPredicate(null, null)).toBe("TRUE");
+  });
+
+  test("builds a from-only predicate", () => {
+    expect(buildTimeFilterPredicate(new Date(Date.UTC(2026, 5, 5)), null)).toBe(
+      "(date >= DATE '2026-06-05')"
+    );
+  });
+
+  test("builds a bounded predicate when both boundaries are set", () => {
+    expect(
+      buildTimeFilterPredicate(new Date(Date.UTC(2026, 5, 1)), new Date(Date.UTC(2026, 5, 11)))
+    ).toBe("(date >= DATE '2026-06-01' AND date <= DATE '2026-06-11')");
+  });
+
+  test("throws on invalid date boundaries", () => {
+    expect(() => buildTimeFilterPredicate(new Date(NaN), null)).toThrow();
+  });
+});
+
+describe("substituteTimeFilter", () => {
+  test("replaces every placeholder occurrence", () => {
+    const sql = `SELECT * FROM events WHERE ${TIME_FILTER_PLACEHOLDER} AND model IS NOT NULL AND ${TIME_FILTER_PLACEHOLDER}`;
+    expect(substituteTimeFilter(sql, "TRUE")).toBe(
+      "SELECT * FROM events WHERE TRUE AND model IS NOT NULL AND TRUE"
+    );
+  });
+
+  test("tolerates casing and inner whitespace", () => {
+    expect(substituteTimeFilter("WHERE {{ TIME_FILTER }}", "TRUE")).toBe("WHERE TRUE");
+  });
+
+  test("leaves SQL without a placeholder untouched", () => {
+    const sql = "SELECT model FROM events GROUP BY model";
+    expect(substituteTimeFilter(sql, "TRUE")).toBe(sql);
+  });
+
+  test("rejects a blank predicate", () => {
+    expect(() => substituteTimeFilter("SELECT 1", "   ")).toThrow();
+  });
+});

--- a/src/browser/features/Analytics/sqlTimeFilter.ts
+++ b/src/browser/features/Analytics/sqlTimeFilter.ts
@@ -1,0 +1,43 @@
+import assert from "@/common/utils/assert";
+
+/**
+ * Placeholder users can embed in saved-panel / SQL-explorer queries so the
+ * dashboard's date-range selection (7D/30D/90D/All) applies to their own SQL.
+ * Before execution it is substituted with a boolean predicate on the events
+ * `date` column (e.g. `(date >= DATE '2026-06-05')`), or `TRUE` when "All"
+ * is selected, so the query stays valid for every range selection.
+ */
+export const TIME_FILTER_PLACEHOLDER = "{{time_filter}}";
+
+// Tolerate whitespace inside the braces and any casing, e.g. `{{ TIME_FILTER }}`.
+const TIME_FILTER_PATTERN = /\{\{\s*time_filter\s*\}\}/gi;
+
+function toUtcDateLiteral(date: Date): string {
+  assert(Number.isFinite(date.getTime()), "Time filter boundary must be a valid date");
+  return `DATE '${date.toISOString().slice(0, 10)}'`;
+}
+
+/** Build the SQL predicate for the dashboard's active date range. */
+export function buildTimeFilterPredicate(from: Date | null, to: Date | null): string {
+  const conditions: string[] = [];
+  if (from) {
+    conditions.push(`date >= ${toUtcDateLiteral(from)}`);
+  }
+  if (to) {
+    conditions.push(`date <= ${toUtcDateLiteral(to)}`);
+  }
+
+  // "All" has no boundaries; substitute a tautology so a bare
+  // `WHERE <placeholder>` clause remains valid SQL.
+  if (conditions.length === 0) {
+    return "TRUE";
+  }
+
+  return `(${conditions.join(" AND ")})`;
+}
+
+/** Replace every time-filter placeholder in user SQL with the active predicate. */
+export function substituteTimeFilter(sql: string, timeFilterSql: string): string {
+  assert(timeFilterSql.trim().length > 0, "timeFilterSql must be a non-empty predicate");
+  return sql.replace(TIME_FILTER_PATTERN, timeFilterSql);
+}

--- a/src/browser/hooks/useAnalytics.test.tsx
+++ b/src/browser/hooks/useAnalytics.test.tsx
@@ -504,6 +504,68 @@ describe("useAnalytics hooks", () => {
     expect(result.current.data).toBeNull();
   });
 
+  test("executeRawQuery ignores stale completions when a newer query is issued", async () => {
+    // Regression: saved panels auto re-run on dashboard date-range changes.
+    // A slower superseded query must not overwrite the newer query's result.
+    const makeResult = (marker: string) => ({
+      columns: [{ name: "v", type: "VARCHAR" }],
+      rows: [{ v: marker }],
+      truncated: false,
+      rowCount: 1,
+      rowCountExact: true,
+      durationMs: 1,
+    });
+
+    const deferredBySql = new Map<string, (marker: string) => void>();
+    const analyticsStub = createAnalyticsServiceStub(summaryFixture);
+    analyticsStub.service.executeRawQuery = (sql: string) =>
+      new Promise((resolve) => {
+        deferredBySql.set(sql, (marker: string) => resolve(makeResult(marker)));
+      });
+
+    await server?.close();
+    const context: Partial<ORPCContext> = {
+      analyticsService: analyticsStub.service as unknown as ORPCContext["analyticsService"],
+    };
+
+    const createOrpcServer = importCreateOrpcServer();
+
+    server = await createOrpcServer({
+      host: "127.0.0.1",
+      port: 0,
+      context: context as ORPCContext,
+      onOrpcError: () => undefined,
+    });
+    currentApiClient = createHttpClient(server.baseUrl);
+
+    const { result } = renderAnalyticsHook(() => useAnalyticsRawQuery());
+
+    let stalePromise!: Promise<void>;
+    let freshPromise!: Promise<void>;
+    act(() => {
+      stalePromise = result.current.executeQuery("SELECT 'stale'");
+      freshPromise = result.current.executeQuery("SELECT 'fresh'");
+    });
+
+    await waitFor(() => expect(deferredBySql.size).toBe(2));
+
+    // Resolve the newer query first, then let the stale one complete late.
+    deferredBySql.get("SELECT 'fresh'")?.("fresh");
+    await act(async () => {
+      await freshPromise;
+    });
+    await waitFor(() => expect(result.current.data?.rows).toEqual([{ v: "fresh" }]));
+
+    deferredBySql.get("SELECT 'stale'")?.("stale");
+    await act(async () => {
+      await stalePromise;
+    });
+
+    expect(result.current.data?.rows).toEqual([{ v: "fresh" }]);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
   test("executeRawQuery keeps infrastructure failures as generic internal errors", async () => {
     const analyticsStub = createAnalyticsServiceStub(summaryFixture);
     analyticsStub.service.executeRawQuery = () =>

--- a/src/browser/hooks/useAnalytics.ts
+++ b/src/browser/hooks/useAnalytics.ts
@@ -1,6 +1,6 @@
 import assert from "@/common/utils/assert";
 import type React from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { z } from "zod";
 import type { APIClient } from "@/browser/contexts/API";
 import { useAPI } from "@/browser/contexts/API";
@@ -422,6 +422,11 @@ export function useAnalyticsRawQuery() {
     loading: false,
     error: null,
   });
+  // Saved panels auto re-run when the dashboard date range changes, so rapid
+  // toggles can leave multiple raw queries in flight. Track a monotonic
+  // execution id and drop completions of superseded requests so a slower
+  // older query cannot overwrite the newest result.
+  const executionIdRef = useRef(0);
 
   const executeQuery = async (sql: string) => {
     if (!api) {
@@ -435,16 +440,24 @@ export function useAnalyticsRawQuery() {
       return;
     }
 
+    const executionId = ++executionIdRef.current;
     setState((prev) => ({ ...prev, loading: true, error: null }));
     try {
       const result = await namespace.executeRawQuery({ sql });
-      setState({ data: result, loading: false, error: null });
+      if (executionId === executionIdRef.current) {
+        setState({ data: result, loading: false, error: null });
+      }
     } catch (err) {
-      setState({ data: null, loading: false, error: getErrorMessage(err) });
+      if (executionId === executionIdRef.current) {
+        setState({ data: null, loading: false, error: getErrorMessage(err) });
+      }
     }
   };
 
   const clearResults = () => {
+    // Invalidate in-flight executions so a late completion cannot resurrect
+    // results the caller explicitly cleared.
+    executionIdRef.current += 1;
     setState({ data: null, loading: false, error: null });
   };
 


### PR DESCRIPTION
## Summary

Saved analytics panels and the SQL Explorer now support a `{{time_filter}}` placeholder that is substituted with the dashboard's selected date range (7D/30D/90D/All) before execution, so user-authored SQL can follow the header's range selection instead of always querying all-time data.

## Background

The dashboard's date-range buttons only filtered the built-in named queries. Custom SQL panels (e.g. a TPS-quantiles-by-model query) always ran against the full `events` table with no way to scope them to the selected range, making "last 7 days" performance analysis impossible without hand-editing date literals into the SQL.

## Implementation

- New `sqlTimeFilter.ts` helper: `buildTimeFilterPredicate(from, to)` produces a `date` predicate (e.g. `(date >= DATE '2026-06-05')`, or `TRUE` for "All" so a bare `WHERE {{time_filter}}` stays valid), and `substituteTimeFilter(sql, predicate)` replaces every placeholder occurrence (case/whitespace tolerant).
- `AnalyticsDashboard` computes the predicate from the existing `computeDateRange` boundaries and passes it to `SavedQueryPanel` and `SqlExplorer`.
- `SavedQueryPanel` executes the resolved SQL and uses it as the run-effect dependency, so panels using the placeholder automatically re-run on range changes while placeholder-free panels are unaffected.
- `SqlExplorer` substitutes at run time but keeps the raw SQL (with placeholder) for "Save as Panel", so pinned panels keep tracking the range.
- The Edit SQL dialog and explorer surface a short hint documenting the placeholder.

Substitution happens client-side before the existing `executeRawQuery` IPC; the substituted predicate is a date literal that passes the existing raw-SQL validation unchanged.

## Validation

- Unit tests for predicate building and substitution; component tests assert a placeholder panel re-runs with the new predicate on range change and a placeholder-free panel does not re-run.
- Dogfooded in a sandboxed dev server seeded with ~250 real session histories: a `MIN(date)/MAX(date)/COUNT(*)` probe query clamped correctly per range (7D: 137 rows, 30D: 230, All: 943), and the motivating TPS-quantiles query saved as a panel re-ran automatically when toggling 7D ↔ All (model set narrowed to those meeting the `HAVING COUNT(*) >= 10` threshold within the window).

## Risks

Low. The feature is opt-in per query; SQL without the placeholder behaves exactly as before (verified by test). The only shared-path change is that saved panels now run substituted SQL through the same execution hook.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$1.31`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=1.31 -->
