### PR TITLE
🤖 fix: wait for pending patch generation in task_apply_git_patch

### DIFF
--- a/src/node/services/tools/task_apply_git_patch.test.ts
+++ b/src/node/services/tools/task_apply_git_patch.test.ts
@@ -987,28 +987,20 @@ describe("task_apply_git_patch tool", () => {
       ],
     });
 
-    // Flip the artifact to ready while the apply call is polling.
-    const markReady = (async () => {
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      await writePatchArtifact({
-        sessionDir,
-        workspaceId,
-        childTaskId,
-        projectArtifacts: [
-          await buildReadyProjectArtifact({
-            sessionDir,
-            childTaskId,
-            storageKey: "target",
-            projectPath: targetRepo,
-            projectName: "target",
-            childRepo,
-            baseSha,
-            headSha,
-          }),
-        ],
-      });
-    })();
+    const readyProjectArtifact = await buildReadyProjectArtifact({
+      sessionDir,
+      childTaskId,
+      storageKey: "target",
+      projectPath: targetRepo,
+      projectName: "target",
+      childRepo,
+      baseSha,
+      headSha,
+    });
 
+    // Flip the artifact to ready only once the wait loop is observably polling,
+    // so the test deterministically exercises the wait path (never vacuous).
+    const markReadyCalls: Array<Promise<void>> = [];
     const result = await applyTaskGitPatchArtifact(
       {
         ...getTestDeps(),
@@ -1018,10 +1010,244 @@ describe("task_apply_git_patch tool", () => {
         workspaceSessionDir: sessionDir,
       },
       { task_id: childTaskId, three_way: true },
-      { pendingGenerationWaitMs: 10_000, pendingGenerationPollIntervalMs: 25 }
+      {
+        pendingGenerationWaitMs: 10_000,
+        pendingGenerationPollIntervalMs: 25,
+        pendingGenerationOnPoll: () => {
+          if (markReadyCalls.length === 0) {
+            markReadyCalls.push(
+              writePatchArtifact({
+                sessionDir,
+                workspaceId,
+                childTaskId,
+                projectArtifacts: [readyProjectArtifact],
+              })
+            );
+          }
+        },
+      }
     );
-    await markReady;
+    expect(markReadyCalls.length).toBeGreaterThan(0);
+    await Promise.all(markReadyCalls);
 
+    expect(result.success).toBe(true);
+    expect(result.projectResults?.map((projectResult) => projectResult.status)).toEqual([
+      "applied",
+    ]);
+  }, 20_000);
+
+  it("aborts the pending-generation wait promptly without applying", async () => {
+    const targetRepo = path.join(rootDir, "target");
+    const sessionDir = path.join(rootDir, "session");
+    for (const repo of [targetRepo, sessionDir]) {
+      await fsPromises.mkdir(repo, { recursive: true });
+    }
+    initGitRepo(targetRepo);
+    await commitFile(targetRepo, "README.md", "hello", "base");
+    const headBefore = execSync("git rev-parse HEAD", {
+      cwd: targetRepo,
+      encoding: "utf-8",
+    }).trim();
+
+    const childTaskId = "child-task-1";
+    await writePatchArtifact({
+      sessionDir,
+      workspaceId: getTestDeps().workspaceId,
+      childTaskId,
+      projectArtifacts: [
+        {
+          projectPath: targetRepo,
+          projectName: "target",
+          storageKey: "target",
+          status: "pending",
+        },
+      ],
+    });
+
+    const controller = new AbortController();
+    const startedAtMs = Date.now();
+    const result = await applyTaskGitPatchArtifact(
+      {
+        ...getTestDeps(),
+        cwd: targetRepo,
+        runtime: createRuntime({ type: "local", srcBaseDir: "/tmp" }),
+        runtimeTempDir: "/tmp",
+        workspaceSessionDir: sessionDir,
+      },
+      { task_id: childTaskId, three_way: true },
+      {
+        abortSignal: controller.signal,
+        pendingGenerationWaitMs: 10_000,
+        pendingGenerationPollIntervalMs: 25,
+        pendingGenerationOnPoll: () => controller.abort(),
+      }
+    );
+
+    // The wait must exit on abort instead of sleeping out the 10s budget.
+    expect(Date.now() - startedAtMs).toBeLessThan(5_000);
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected failure result");
+    }
+    expect(result.error).toContain("Aborted");
+    expect(result.conflictPaths).toBeUndefined();
+    // No apply may run after cancellation.
+    const headAfter = execSync("git rev-parse HEAD", { cwd: targetRepo, encoding: "utf-8" }).trim();
+    expect(headAfter).toBe(headBefore);
+  }, 20_000);
+
+  it("fails atomically when a sibling project is still pending after the wait times out", async () => {
+    const childRepo = path.join(rootDir, "child");
+    const targetRepoA = path.join(rootDir, "target-a");
+    const targetRepoB = path.join(rootDir, "target-b");
+    const sessionDir = path.join(rootDir, "session");
+    for (const repo of [childRepo, targetRepoA, targetRepoB, sessionDir]) {
+      await fsPromises.mkdir(repo, { recursive: true });
+    }
+    initGitRepo(childRepo);
+    initGitRepo(targetRepoA);
+    initGitRepo(targetRepoB);
+
+    await commitFile(childRepo, "README.md", "hello", "base");
+    await commitFile(targetRepoA, "README.md", "hello", "base");
+    await commitFile(targetRepoB, "README.md", "hello", "base");
+    const baseSha = execSync("git rev-parse HEAD", { cwd: childRepo, encoding: "utf-8" }).trim();
+    await commitFile(childRepo, "README.md", "hello\nworld", "child change");
+    const headSha = execSync("git rev-parse HEAD", { cwd: childRepo, encoding: "utf-8" }).trim();
+    const headBeforeA = execSync("git rev-parse HEAD", {
+      cwd: targetRepoA,
+      encoding: "utf-8",
+    }).trim();
+
+    const childTaskId = "child-task-1";
+    await writePatchArtifact({
+      sessionDir,
+      workspaceId: getTestDeps().workspaceId,
+      childTaskId,
+      projectArtifacts: [
+        await buildReadyProjectArtifact({
+          sessionDir,
+          childTaskId,
+          storageKey: "target-a",
+          projectPath: targetRepoA,
+          projectName: "target-a",
+          childRepo,
+          baseSha,
+          headSha,
+        }),
+        {
+          projectPath: targetRepoB,
+          projectName: "target-b",
+          storageKey: "target-b",
+          status: "pending",
+        },
+      ],
+    });
+
+    const result = await applyTaskGitPatchArtifact(
+      {
+        ...getTestDeps(),
+        cwd: targetRepoA,
+        runtime: createRuntime({ type: "local", srcBaseDir: "/tmp" }),
+        runtimeTempDir: "/tmp",
+        workspaceSessionDir: sessionDir,
+      },
+      { task_id: childTaskId, three_way: true },
+      { pendingGenerationWaitMs: 50, pendingGenerationPollIntervalMs: 10 }
+    );
+
+    // The ready sibling must not be partially applied while the pending
+    // project's commits would silently drop (and workflows would checkpoint
+    // the step as applied).
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected failure result");
+    }
+    expect(result.error).toContain("not an apply conflict");
+    expect(result.conflictPaths).toBeUndefined();
+    expect(result.projectResults?.map((projectResult) => projectResult.status)).toEqual([
+      "skipped",
+      "skipped",
+    ]);
+    const headAfterA = execSync("git rev-parse HEAD", {
+      cwd: targetRepoA,
+      encoding: "utf-8",
+    }).trim();
+    expect(headAfterA).toBe(headBeforeA);
+  }, 20_000);
+
+  it("does not wait on a pending sibling project when project_path targets a ready project", async () => {
+    const childRepo = path.join(rootDir, "child");
+    const targetRepoA = path.join(rootDir, "target-a");
+    const targetRepoB = path.join(rootDir, "target-b");
+    for (const repo of [childRepo, targetRepoA, targetRepoB]) {
+      await fsPromises.mkdir(repo, { recursive: true });
+      initGitRepo(repo);
+    }
+
+    await commitFile(childRepo, "README.md", "hello", "base");
+    await commitFile(targetRepoA, "README.md", "hello", "base");
+    await commitFile(targetRepoB, "README.md", "hello", "base");
+    const baseSha = execSync("git rev-parse HEAD", { cwd: childRepo, encoding: "utf-8" }).trim();
+    await commitFile(childRepo, "README.md", "hello\nworld", "child change");
+    const headSha = execSync("git rev-parse HEAD", { cwd: childRepo, encoding: "utf-8" }).trim();
+
+    const muxRoot = path.join(rootDir, "mux");
+    const currentWorkspaceId = "current-workspace";
+    const sessionDir = path.join(muxRoot, "sessions", currentWorkspaceId);
+    await fsPromises.mkdir(sessionDir, { recursive: true });
+    await writeWorkspaceConfig({
+      muxRoot,
+      workspaceId: currentWorkspaceId,
+      workspaceName: "current",
+      primaryProjectPath: targetRepoA,
+      projects: [
+        { projectPath: targetRepoA, projectName: "target-a" },
+        { projectPath: targetRepoB, projectName: "target-b" },
+      ],
+    });
+
+    const childTaskId = "child-task-1";
+    await writePatchArtifact({
+      sessionDir,
+      workspaceId: currentWorkspaceId,
+      childTaskId,
+      projectArtifacts: [
+        await buildReadyProjectArtifact({
+          sessionDir,
+          childTaskId,
+          storageKey: "target-a",
+          projectPath: targetRepoA,
+          projectName: "target-a",
+          childRepo,
+          baseSha,
+          headSha,
+        }),
+        {
+          projectPath: targetRepoB,
+          projectName: "target-b",
+          storageKey: "target-b",
+          status: "pending",
+        },
+      ],
+    });
+
+    const startedAtMs = Date.now();
+    const result = await applyTaskGitPatchArtifact(
+      {
+        ...getTestDeps(),
+        workspaceId: currentWorkspaceId,
+        cwd: targetRepoA,
+        runtime: createRuntime({ type: "local", srcBaseDir: "/tmp" }),
+        runtimeTempDir: "/tmp",
+        workspaceSessionDir: sessionDir,
+      },
+      { task_id: childTaskId, project_path: targetRepoA, three_way: true },
+      { pendingGenerationWaitMs: 30_000, pendingGenerationPollIntervalMs: 25 }
+    );
+
+    // The scoped apply must not consume the wait budget on the pending sibling.
+    expect(Date.now() - startedAtMs).toBeLessThan(10_000);
     expect(result.success).toBe(true);
     expect(result.projectResults?.map((projectResult) => projectResult.status)).toEqual([
       "applied",

--- a/src/node/services/tools/task_apply_git_patch.test.ts
+++ b/src/node/services/tools/task_apply_git_patch.test.ts
@@ -6,7 +6,10 @@ import { execSync } from "node:child_process";
 
 import type { ToolExecutionOptions } from "ai";
 
-import { createTaskApplyGitPatchTool } from "@/node/services/tools/task_apply_git_patch";
+import {
+  applyTaskGitPatchArtifact,
+  createTaskApplyGitPatchTool,
+} from "@/node/services/tools/task_apply_git_patch";
 import {
   getSubagentGitPatchArtifactsFilePath,
   getSubagentGitPatchMboxPath,
@@ -87,7 +90,7 @@ async function writePatchArtifact(params: {
         projectPath: string;
         projectName: string;
         storageKey: string;
-        status: "skipped" | "failed";
+        status: "pending" | "skipped" | "failed";
         error?: string;
         commitCount?: number;
       }
@@ -949,6 +952,129 @@ describe("task_apply_git_patch tool", () => {
     expect(result.projectResults).toHaveLength(1);
     expect(result.appliedCommits?.map((commit) => commit.subject)).toEqual(["child change"]);
     expect(typeof result.headCommitSha).toBe("string");
+  }, 20_000);
+
+  it("waits for pending patch generation to become ready before applying", async () => {
+    const childRepo = path.join(rootDir, "child");
+    const targetRepo = path.join(rootDir, "target");
+    const sessionDir = path.join(rootDir, "session");
+    for (const repo of [childRepo, targetRepo, sessionDir]) {
+      await fsPromises.mkdir(repo, { recursive: true });
+    }
+    initGitRepo(childRepo);
+    initGitRepo(targetRepo);
+
+    await commitFile(childRepo, "README.md", "hello", "base");
+    await commitFile(targetRepo, "README.md", "hello", "base");
+    const baseSha = execSync("git rev-parse HEAD", { cwd: childRepo, encoding: "utf-8" }).trim();
+    await commitFile(childRepo, "README.md", "hello\nworld", "child change");
+    const headSha = execSync("git rev-parse HEAD", { cwd: childRepo, encoding: "utf-8" }).trim();
+
+    const childTaskId = "child-task-1";
+    const workspaceId = getTestDeps().workspaceId;
+    // The task has reported but background `git format-patch` has not finished.
+    await writePatchArtifact({
+      sessionDir,
+      workspaceId,
+      childTaskId,
+      projectArtifacts: [
+        {
+          projectPath: targetRepo,
+          projectName: "target",
+          storageKey: "target",
+          status: "pending",
+        },
+      ],
+    });
+
+    // Flip the artifact to ready while the apply call is polling.
+    const markReady = (async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await writePatchArtifact({
+        sessionDir,
+        workspaceId,
+        childTaskId,
+        projectArtifacts: [
+          await buildReadyProjectArtifact({
+            sessionDir,
+            childTaskId,
+            storageKey: "target",
+            projectPath: targetRepo,
+            projectName: "target",
+            childRepo,
+            baseSha,
+            headSha,
+          }),
+        ],
+      });
+    })();
+
+    const result = await applyTaskGitPatchArtifact(
+      {
+        ...getTestDeps(),
+        cwd: targetRepo,
+        runtime: createRuntime({ type: "local", srcBaseDir: "/tmp" }),
+        runtimeTempDir: "/tmp",
+        workspaceSessionDir: sessionDir,
+      },
+      { task_id: childTaskId, three_way: true },
+      { pendingGenerationWaitMs: 10_000, pendingGenerationPollIntervalMs: 25 }
+    );
+    await markReady;
+
+    expect(result.success).toBe(true);
+    expect(result.projectResults?.map((projectResult) => projectResult.status)).toEqual([
+      "applied",
+    ]);
+  }, 20_000);
+
+  it("reports still-pending generation as a retryable non-conflict failure after the wait times out", async () => {
+    const targetRepo = path.join(rootDir, "target");
+    const sessionDir = path.join(rootDir, "session");
+    for (const repo of [targetRepo, sessionDir]) {
+      await fsPromises.mkdir(repo, { recursive: true });
+    }
+    initGitRepo(targetRepo);
+    await commitFile(targetRepo, "README.md", "hello", "base");
+
+    const childTaskId = "child-task-1";
+    await writePatchArtifact({
+      sessionDir,
+      workspaceId: getTestDeps().workspaceId,
+      childTaskId,
+      projectArtifacts: [
+        {
+          projectPath: targetRepo,
+          projectName: "target",
+          storageKey: "target",
+          status: "pending",
+        },
+      ],
+    });
+
+    const result = await applyTaskGitPatchArtifact(
+      {
+        ...getTestDeps(),
+        cwd: targetRepo,
+        runtime: createRuntime({ type: "local", srcBaseDir: "/tmp" }),
+        runtimeTempDir: "/tmp",
+        workspaceSessionDir: sessionDir,
+      },
+      { task_id: childTaskId, dry_run: true, three_way: true },
+      { pendingGenerationWaitMs: 50, pendingGenerationPollIntervalMs: 10 }
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected failure result");
+    }
+    // The timing gap must not be reported as an apply conflict (workflows
+    // would otherwise spawn conflict-resolution agents for it).
+    expect(result.error).toContain("not an apply conflict");
+    expect(result.conflictPaths).toBeUndefined();
+    expect(result.projectResults?.map((projectResult) => projectResult.status)).toEqual([
+      "skipped",
+    ]);
   }, 20_000);
 
   it("replays patch artifacts from an ancestor session dir without mutating metadata", async () => {

--- a/src/node/services/tools/task_apply_git_patch.ts
+++ b/src/node/services/tools/task_apply_git_patch.ts
@@ -411,8 +411,11 @@ function listRelevantProjectArtifacts(
     : artifact.projectArtifacts;
 }
 
-async function sleepWithAbort(delayMs: number, abortSignal?: AbortSignal): Promise<void> {
-  assert(delayMs > 0, "sleepWithAbort: delayMs must be positive");
+// Unlike the shared sleepWithAbort in @/node/utils/abort (which REJECTS on
+// abort), this helper RESOLVES on abort so the wait loop can fall through to a
+// structured tool result instead of throwing out of applyTaskGitPatchArtifact.
+async function sleepResolvingOnAbort(delayMs: number, abortSignal?: AbortSignal): Promise<void> {
+  assert(delayMs > 0, "sleepResolvingOnAbort: delayMs must be positive");
   if (abortSignal?.aborted === true) {
     return;
   }
@@ -442,6 +445,7 @@ async function waitForPendingPatchGeneration(params: {
   waitMs: number;
   pollIntervalMs: number;
   abortSignal?: AbortSignal;
+  onPoll?: () => void;
 }): Promise<NonNullable<Awaited<ReturnType<typeof readSubagentGitPatchArtifact>>>> {
   assert(params.waitMs >= 0, "waitForPendingPatchGeneration: waitMs must be non-negative");
   assert(
@@ -462,7 +466,8 @@ async function waitForPendingPatchGeneration(params: {
     params.abortSignal?.aborted !== true
   ) {
     waited = true;
-    await sleepWithAbort(params.pollIntervalMs, params.abortSignal);
+    params.onPoll?.();
+    await sleepResolvingOnAbort(params.pollIntervalMs, params.abortSignal);
     const refreshed = await readSubagentGitPatchArtifact(
       params.artifactSessionDir,
       params.childTaskId
@@ -476,7 +481,12 @@ async function waitForPendingPatchGeneration(params: {
     log.debug("task_apply_git_patch: waited for pending patch generation", {
       childTaskId: params.childTaskId,
       waitedMs: Date.now() - startedAtMs,
-      settledStatus: artifact.status,
+      // Log the statuses the loop actually waited on; the artifact-level
+      // summary stays "pending" while filtered-out sibling projects generate.
+      settledStatuses: listRelevantProjectArtifacts(artifact, params.requestedProjectPath).map(
+        (projectArtifact) => projectArtifact.status
+      ),
+      requestedProjectPath: params.requestedProjectPath ?? null,
     });
   }
 
@@ -1167,9 +1177,10 @@ export async function applyTaskGitPatchArtifact(
   options: {
     abortSignal?: AbortSignal;
     allowAlreadyApplied?: boolean;
-    // Test seam for the pending-generation wait; production callers use defaults.
+    // Test seams for the pending-generation wait; production callers use defaults.
     pendingGenerationWaitMs?: number;
     pendingGenerationPollIntervalMs?: number;
+    pendingGenerationOnPoll?: () => void;
   } = {}
 ): Promise<TaskApplyGitPatchResult> {
   const workspaceId = requireWorkspaceId(config, "task_apply_git_patch");
@@ -1257,7 +1268,25 @@ export async function applyTaskGitPatchArtifact(
     pollIntervalMs:
       options.pendingGenerationPollIntervalMs ?? PENDING_PATCH_GENERATION_POLL_INTERVAL_MS,
     abortSignal: options.abortSignal,
+    onPoll: options.pendingGenerationOnPoll,
   });
+
+  // The wait exits when aborted, but the artifact may have settled to "ready"
+  // on its final re-read. Never start a (destructive) apply for a cancelled
+  // call — bail before any repo mutation.
+  if (options.abortSignal?.aborted === true) {
+    return parseToolResult(
+      TaskApplyGitPatchToolResultSchema,
+      {
+        success: false as const,
+        taskId,
+        dryRun,
+        error: "Aborted while waiting for patch generation; the patch was not applied.",
+        note: artifactLookupNote,
+      },
+      "task_apply_git_patch"
+    );
+  }
 
   const projectArtifacts = listRelevantProjectArtifacts(artifact, requestedProjectPath);
 
@@ -1287,6 +1316,38 @@ export async function applyTaskGitPatchArtifact(
     );
   }
 
+  // Still-pending here means generation outlived the wait above. Do not
+  // partially apply (ready siblings would land while the pending project's
+  // commits silently drop, and workflows would checkpoint the step as
+  // applied); fail atomically with a retryable, non-conflict error instead.
+  if (projectArtifacts.some((projectArtifact) => projectArtifact.status === "pending")) {
+    const pendingProjectResults = projectArtifacts.map((projectArtifact) =>
+      projectArtifact.status === "ready"
+        ? {
+            projectPath: projectArtifact.projectPath,
+            projectName: projectArtifact.projectName,
+            status: "skipped" as const,
+            error:
+              "Not attempted because patch generation has not finished for another project in this task.",
+          }
+        : summarizeNonReadyProjectArtifact({ projectArtifact })
+    );
+    return parseToolResult(
+      TaskApplyGitPatchToolResultSchema,
+      {
+        success: false as const,
+        taskId,
+        dryRun,
+        projectResults: pendingProjectResults,
+        error:
+          "Patch generation has not finished for this task yet. This is not an apply conflict; retry task_apply_git_patch shortly.",
+        note: artifactLookupNote,
+        ...toLegacyFields(pendingProjectResults),
+      },
+      "task_apply_git_patch"
+    );
+  }
+
   const repoTargetsByProjectPath = resolveCurrentWorkspaceRepoTargets({
     workspaceId,
     workspaceSessionDir,
@@ -1301,11 +1362,6 @@ export async function applyTaskGitPatchArtifact(
       projectResults.push(summarizeNonReadyProjectArtifact({ projectArtifact }));
     }
 
-    // Still-pending here means generation outlived the wait above; make clear
-    // this is a timing issue (retry), not an apply conflict to resolve.
-    const hasPendingProjectArtifact = projectArtifacts.some(
-      (projectArtifact) => projectArtifact.status === "pending"
-    );
     const legacyFields = toLegacyFields(projectResults);
     return parseToolResult(
       TaskApplyGitPatchToolResultSchema,
@@ -1314,9 +1370,7 @@ export async function applyTaskGitPatchArtifact(
         taskId,
         dryRun,
         projectResults,
-        error: hasPendingProjectArtifact
-          ? "Patch generation has not finished for this task yet. This is not an apply conflict; retry task_apply_git_patch shortly."
-          : "This task has no ready project patch artifacts.",
+        error: "This task has no ready project patch artifacts.",
         note: artifactLookupNote,
         ...legacyFields,
       },

--- a/src/node/services/tools/task_apply_git_patch.ts
+++ b/src/node/services/tools/task_apply_git_patch.ts
@@ -392,6 +392,97 @@ async function findGitPatchArtifactInWorkspaceOrAncestors(params: {
   return null;
 }
 
+// A child task's report is delivered before its background `git format-patch`
+// generation finishes, so a freshly completed task can briefly expose a
+// "pending" patch artifact. Failing immediately misleads callers (e.g. workflow
+// applyPatch steps treat the failure as an apply problem and may spawn
+// conflict-resolution agents), so we wait for generation to settle instead.
+const PENDING_PATCH_GENERATION_WAIT_MS = 120_000;
+const PENDING_PATCH_GENERATION_POLL_INTERVAL_MS = 500;
+
+function listRelevantProjectArtifacts(
+  artifact: NonNullable<Awaited<ReturnType<typeof readSubagentGitPatchArtifact>>>,
+  requestedProjectPath: string | null | undefined
+): NonNullable<Awaited<ReturnType<typeof readSubagentGitPatchArtifact>>>["projectArtifacts"] {
+  return requestedProjectPath != null
+    ? artifact.projectArtifacts.filter((projectArtifact) =>
+        matchesProjectArtifactProjectPath(projectArtifact, requestedProjectPath)
+      )
+    : artifact.projectArtifacts;
+}
+
+async function sleepWithAbort(delayMs: number, abortSignal?: AbortSignal): Promise<void> {
+  assert(delayMs > 0, "sleepWithAbort: delayMs must be positive");
+  if (abortSignal?.aborted === true) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      abortSignal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, delayMs);
+    abortSignal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Re-read the artifact until no relevant project artifact is still "pending"
+ * (generation finished as ready/failed/skipped), the deadline passes, or the
+ * caller aborts. Returns the freshest artifact observed.
+ */
+async function waitForPendingPatchGeneration(params: {
+  artifact: NonNullable<Awaited<ReturnType<typeof readSubagentGitPatchArtifact>>>;
+  artifactSessionDir: string;
+  childTaskId: string;
+  requestedProjectPath: string | null | undefined;
+  waitMs: number;
+  pollIntervalMs: number;
+  abortSignal?: AbortSignal;
+}): Promise<NonNullable<Awaited<ReturnType<typeof readSubagentGitPatchArtifact>>>> {
+  assert(params.waitMs >= 0, "waitForPendingPatchGeneration: waitMs must be non-negative");
+  assert(
+    params.pollIntervalMs > 0,
+    "waitForPendingPatchGeneration: pollIntervalMs must be positive"
+  );
+
+  let artifact = params.artifact;
+  const deadlineMs = Date.now() + params.waitMs;
+  const startedAtMs = Date.now();
+  let waited = false;
+
+  while (
+    listRelevantProjectArtifacts(artifact, params.requestedProjectPath).some(
+      (projectArtifact) => projectArtifact.status === "pending"
+    ) &&
+    Date.now() < deadlineMs &&
+    params.abortSignal?.aborted !== true
+  ) {
+    waited = true;
+    await sleepWithAbort(params.pollIntervalMs, params.abortSignal);
+    const refreshed = await readSubagentGitPatchArtifact(
+      params.artifactSessionDir,
+      params.childTaskId
+    );
+    if (refreshed != null) {
+      artifact = refreshed;
+    }
+  }
+
+  if (waited) {
+    log.debug("task_apply_git_patch: waited for pending patch generation", {
+      childTaskId: params.childTaskId,
+      waitedMs: Date.now() - startedAtMs,
+      settledStatus: artifact.status,
+    });
+  }
+
+  return artifact;
+}
+
 function toLegacyFields(projectResults: TaskApplyGitPatchProjectResult[]): {
   appliedCommits?: AppliedCommit[];
   headCommitSha?: string;
@@ -1073,7 +1164,13 @@ async function cleanupRuntimePatchFile(params: {
 export async function applyTaskGitPatchArtifact(
   config: TaskApplyGitPatchConfiguration,
   args: TaskApplyGitPatchArgs,
-  options: { abortSignal?: AbortSignal; allowAlreadyApplied?: boolean } = {}
+  options: {
+    abortSignal?: AbortSignal;
+    allowAlreadyApplied?: boolean;
+    // Test seam for the pending-generation wait; production callers use defaults.
+    pendingGenerationWaitMs?: number;
+    pendingGenerationPollIntervalMs?: number;
+  } = {}
 ): Promise<TaskApplyGitPatchResult> {
   const workspaceId = requireWorkspaceId(config, "task_apply_git_patch");
   assert(config.cwd, "task_apply_git_patch requires cwd");
@@ -1123,7 +1220,7 @@ export async function applyTaskGitPatchArtifact(
     );
   }
 
-  const artifact = artifactLookup.artifact;
+  let artifact = artifactLookup.artifact;
   const artifactWorkspaceId = artifactLookup.artifactWorkspaceId;
   const artifactSessionDir = artifactLookup.artifactSessionDir;
   const isReplay = artifactWorkspaceId !== workspaceId;
@@ -1147,12 +1244,22 @@ export async function applyTaskGitPatchArtifact(
   }
 
   const requestedProjectPath = parsedArgs.project_path;
-  const projectArtifacts =
-    requestedProjectPath != null
-      ? artifact.projectArtifacts.filter((projectArtifact) =>
-          matchesProjectArtifactProjectPath(projectArtifact, requestedProjectPath)
-        )
-      : artifact.projectArtifacts;
+
+  // Patch generation runs in the background after the child task reports, so
+  // the artifact may still be "pending" when apply is requested right after
+  // task completion. Wait for it to settle before deciding success/failure.
+  artifact = await waitForPendingPatchGeneration({
+    artifact,
+    artifactSessionDir,
+    childTaskId: taskId,
+    requestedProjectPath,
+    waitMs: options.pendingGenerationWaitMs ?? PENDING_PATCH_GENERATION_WAIT_MS,
+    pollIntervalMs:
+      options.pendingGenerationPollIntervalMs ?? PENDING_PATCH_GENERATION_POLL_INTERVAL_MS,
+    abortSignal: options.abortSignal,
+  });
+
+  const projectArtifacts = listRelevantProjectArtifacts(artifact, requestedProjectPath);
 
   if (parsedArgs.project_path != null && projectArtifacts.length === 0) {
     return parseToolResult(
@@ -1194,6 +1301,11 @@ export async function applyTaskGitPatchArtifact(
       projectResults.push(summarizeNonReadyProjectArtifact({ projectArtifact }));
     }
 
+    // Still-pending here means generation outlived the wait above; make clear
+    // this is a timing issue (retry), not an apply conflict to resolve.
+    const hasPendingProjectArtifact = projectArtifacts.some(
+      (projectArtifact) => projectArtifact.status === "pending"
+    );
     const legacyFields = toLegacyFields(projectResults);
     return parseToolResult(
       TaskApplyGitPatchToolResultSchema,
@@ -1202,7 +1314,9 @@ export async function applyTaskGitPatchArtifact(
         taskId,
         dryRun,
         projectResults,
-        error: "This task has no ready project patch artifacts.",
+        error: hasPendingProjectArtifact
+          ? "Patch generation has not finished for this task yet. This is not an apply conflict; retry task_apply_git_patch shortly."
+          : "This task has no ready project patch artifacts.",
         note: artifactLookupNote,
         ...legacyFields,
       },


### PR DESCRIPTION
## Summary

`task_apply_git_patch` raced background patch generation: a child task's report is delivered before its `git format-patch` artifact finishes generating, so applying right after task completion failed with "Patch generation is still in progress" — and workflow `applyPatch` steps treated that timing gap as an apply failure needing conflict resolution. The tool now waits for pending artifacts to settle before deciding success/failure.

## Background

Observed in workflow run `wfr_3df02c0fe3d4542c`: a dry-run apply for a freshly completed task returned

```json
{ "success": false, "error": "This task has no ready project patch artifacts.",
  "projectResults": [{ "status": "skipped", "error": "Patch generation is still in progress for this project." }] }
```

`TaskService` kicks off `GitPatchArtifactService.maybeStartGeneration` (writes a `pending` marker, generates in the background) *before* delivering the report to the parent, so the artifact always exists but may still be `pending` when the parent applies. `task_await` already documented this race ("the artifact may still be pending at read time — task_apply_git_patch does a fresh read"), but the fresh read didn't tolerate pending.

## Implementation

- `applyTaskGitPatchArtifact` polls the artifact (500 ms interval, 120 s cap, abort-aware) while any **relevant** (project_path-filtered) project artifact is `pending`, then proceeds with the settled state. Covers both the agent-facing tool and workflow `applyPatch` steps (both route through this function).
- If generation outlives the wait, the failure is explicit and atomic: *"Patch generation has not finished for this task yet. This is not an apply conflict; retry task_apply_git_patch shortly."* No partial apply of ready siblings (which would make workflows checkpoint the step as `applied` while silently dropping the pending project's commits), and no `conflictPaths`/`failedPatchSubject`, so workflow normalization classifies it `failed`, never `conflict`.
- A cancelled call never falls through into a destructive `git am`: the abort signal is re-checked after the wait before any repo mutation.
- Local sleep helper named `sleepResolvingOnAbort` (the shared `sleepWithAbort` in `@/node/utils/abort` rejects on abort; this one must resolve so the tool returns a structured result).
- Test seams: `pendingGenerationWaitMs` / `pendingGenerationPollIntervalMs` / `pendingGenerationOnPoll`.

## Validation

- Ran the `deep-review-workflow` (adversarial multi-agent review) on the initial fix; it verified 8 findings (3×P3, 5×P4). All are addressed in the second commit except WAIT-CHECKPOINT (P4 follow-up: workflow steps durably checkpoint retryable failures — requires replay-semantics design changes out of scope for this surgical fix).
- 6 behavioral tests in `task_apply_git_patch.test.ts` (16 total pass): pending→ready wait (deterministically exercised via the poll seam), still-pending timeout (non-conflict), abort during wait (prompt return, no repo mutation), mixed ready+pending atomic failure, project_path-scoped apply not blocked by a pending sibling, plus existing suite.
- `make static-check` green; `WorkflowRunner`/`WorkflowTaskServiceAdapter`/`gitPatchArtifactService`/`subagentGitPatchArtifacts`/`task_await` suites pass.

## Risks

Medium-low. The wait adds up to 120 s latency per apply when generation genuinely hangs (normal generation settles in <5 s; startup recovery re-kicks orphaned pending artifacts). The mixed ready+pending case changes behavior from partial-apply-success to atomic retryable failure — intentional, since retry converges and the workflow path self-heals via `allowAlreadyApplied`.

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$8.23`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=8.23 -->
