### PR TITLE
🤖 fix: prevent sandbox provider env fallback from pairing keys with AI-bridge base URLs

### DIFF
--- a/.mux/skills/dev-desktop-sandbox/SKILL.md
+++ b/.mux/skills/dev-desktop-sandbox/SKILL.md
@@ -24,10 +24,12 @@ make dev-desktop-sandbox
   - Each file is seeded independently from the first root that has it
     (`$MUX_ROOT`, then `~/.mux-dev`, then `~/.mux`), so a root with only
     `config.json` doesn't drop provider config
-- With `--clean-providers`, provider credential env vars (API keys, `*_BASE_URL`,
-  etc.) are stripped from the child processes' env so the app can't silently
-  fall back to env credentials (which may pair a real key with a proxy/AI-bridge
-  base URL)
+- Provider credential env vars (API keys, `*_BASE_URL`, etc.) are stripped from
+  the child processes' env when they could silently override or mismatch the
+  intended setup: all of them with `--clean-providers`, and those belonging to
+  providers configured in the seeded `providers.jsonc` otherwise (so the seeded
+  config is the single source of truth; env vars for unconfigured providers are
+  kept)
 - Picks free ports:
   - Vite devserver port (used by the renderer)
   - Electron remote debugging port (optional)

--- a/.mux/skills/dev-desktop-sandbox/SKILL.md
+++ b/.mux/skills/dev-desktop-sandbox/SKILL.md
@@ -21,6 +21,13 @@ make dev-desktop-sandbox
 - Copies these files into the sandbox if present (unless disabled by flags):
   - `providers.jsonc` (provider config)
   - `config.json` (project list)
+  - Each file is seeded independently from the first root that has it
+    (`$MUX_ROOT`, then `~/.mux-dev`, then `~/.mux`), so a root with only
+    `config.json` doesn't drop provider config
+- With `--clean-providers`, provider credential env vars (API keys, `*_BASE_URL`,
+  etc.) are stripped from the child processes' env so the app can't silently
+  fall back to env credentials (which may pair a real key with a proxy/AI-bridge
+  base URL)
 - Picks free ports:
   - Vite devserver port (used by the renderer)
   - Electron remote debugging port (optional)
@@ -48,7 +55,7 @@ make dev-desktop-sandbox DEV_DESKTOP_SANDBOX_ARGS="--clean-providers"
 # Clear projects from config.json (preserves other config)
 make dev-desktop-sandbox DEV_DESKTOP_SANDBOX_ARGS="--clean-projects"
 
-# Use a specific root to seed from (defaults to $MUX_ROOT then ~/.mux-dev then ~/.mux)
+# Use a specific root to seed from (default: per-file from $MUX_ROOT, ~/.mux-dev, ~/.mux)
 SEED_MUX_ROOT=~/.mux-dev make dev-desktop-sandbox
 
 # Keep the sandbox root directory after exit (useful for debugging)

--- a/.mux/skills/dev-desktop-sandbox/SKILL.md
+++ b/.mux/skills/dev-desktop-sandbox/SKILL.md
@@ -24,13 +24,13 @@ make dev-desktop-sandbox
   - Each file is seeded independently from the first root that has it
     (`$MUX_ROOT`, then `~/.mux-dev`, then `~/.mux`), so a root with only
     `config.json` doesn't drop provider config
-- Provider credential env vars (API keys, `*_BASE_URL`, etc.) are stripped from
-  the child processes' env when they could silently override or mismatch the
-  intended setup: all of them with `--clean-providers` (including Bedrock's
-  `AWS_REGION` and `AWS_BEARER_TOKEN_BEDROCK`; shared AWS credentials like
-  `AWS_PROFILE` are kept), and those belonging to providers configured in the
-  seeded `providers.jsonc` otherwise (so the seeded config is the single source
-  of truth; env vars for unconfigured providers are kept)
+- Provider credential env vars are stripped from the child processes' env when
+  they could silently override or mismatch the intended setup: all of them with
+  `--clean-providers` (including Bedrock's `AWS_REGION` and
+  `AWS_BEARER_TOKEN_BEDROCK`; shared AWS credentials like `AWS_PROFILE` are
+  kept); otherwise only `*_BASE_URL` env vars that would shadow a seeded
+  `providers.jsonc` entry that has an `apiKey` but no explicit `baseUrl`
+  (API key env vars are always kept so env-key fallback still works)
 - Picks free ports:
   - Vite devserver port (used by the renderer)
   - Electron remote debugging port (optional)

--- a/.mux/skills/dev-desktop-sandbox/SKILL.md
+++ b/.mux/skills/dev-desktop-sandbox/SKILL.md
@@ -26,10 +26,11 @@ make dev-desktop-sandbox
     `config.json` doesn't drop provider config
 - Provider credential env vars (API keys, `*_BASE_URL`, etc.) are stripped from
   the child processes' env when they could silently override or mismatch the
-  intended setup: all of them with `--clean-providers`, and those belonging to
-  providers configured in the seeded `providers.jsonc` otherwise (so the seeded
-  config is the single source of truth; env vars for unconfigured providers are
-  kept)
+  intended setup: all of them with `--clean-providers` (including Bedrock's
+  `AWS_REGION` and `AWS_BEARER_TOKEN_BEDROCK`; shared AWS credentials like
+  `AWS_PROFILE` are kept), and those belonging to providers configured in the
+  seeded `providers.jsonc` otherwise (so the seeded config is the single source
+  of truth; env vars for unconfigured providers are kept)
 - Picks free ports:
   - Vite devserver port (used by the renderer)
   - Electron remote debugging port (optional)

--- a/.mux/skills/dev-server-sandbox/SKILL.md
+++ b/.mux/skills/dev-server-sandbox/SKILL.md
@@ -25,6 +25,12 @@ make dev-server-sandbox
 - Copies these files into the sandbox if present (unless disabled by flags):
   - `providers.jsonc` (provider config)
   - `config.json` (project list)
+  - Each file is seeded independently from the first root that has it
+    (`$MUX_ROOT`, then `~/.mux-dev`, then `~/.mux`), so a root with only
+    `config.json` doesn't drop provider config
+- With `--clean-providers`, provider credential env vars (API keys, `*_BASE_URL`,
+  etc.) are stripped from the server's env so it can't silently fall back to
+  env credentials (which may pair a real key with a proxy/AI-bridge base URL)
 - Picks free ports (`BACKEND_PORT`, `VITE_PORT`)
 - Disables tutorials by default inside the sandbox (`MUX_ENABLE_TUTORIALS_IN_SANDBOX=1` opts back in)
 - Allows all hosts (`VITE_ALLOWED_HOSTS=all`) so it works behind port-forwarding domains
@@ -42,7 +48,7 @@ make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-providers"
 # Clear projects from config.json (preserves other config)
 make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-projects"
 
-# Use a specific root to seed from (defaults to ~/.mux-dev then ~/.mux)
+# Use a specific root to seed from (default: per-file from $MUX_ROOT, ~/.mux-dev, ~/.mux)
 SEED_MUX_ROOT=~/.mux-dev make dev-server-sandbox
 
 # Keep the sandbox root directory after exit (useful for debugging)

--- a/.mux/skills/dev-server-sandbox/SKILL.md
+++ b/.mux/skills/dev-server-sandbox/SKILL.md
@@ -28,9 +28,11 @@ make dev-server-sandbox
   - Each file is seeded independently from the first root that has it
     (`$MUX_ROOT`, then `~/.mux-dev`, then `~/.mux`), so a root with only
     `config.json` doesn't drop provider config
-- With `--clean-providers`, provider credential env vars (API keys, `*_BASE_URL`,
-  etc.) are stripped from the server's env so it can't silently fall back to
-  env credentials (which may pair a real key with a proxy/AI-bridge base URL)
+- Provider credential env vars (API keys, `*_BASE_URL`, etc.) are stripped from
+  the server's env when they could silently override or mismatch the intended
+  setup: all of them with `--clean-providers`, and those belonging to providers
+  configured in the seeded `providers.jsonc` otherwise (so the seeded config is
+  the single source of truth; env vars for unconfigured providers are kept)
 - Picks free ports (`BACKEND_PORT`, `VITE_PORT`)
 - Disables tutorials by default inside the sandbox (`MUX_ENABLE_TUTORIALS_IN_SANDBOX=1` opts back in)
 - Allows all hosts (`VITE_ALLOWED_HOSTS=all`) so it works behind port-forwarding domains

--- a/.mux/skills/dev-server-sandbox/SKILL.md
+++ b/.mux/skills/dev-server-sandbox/SKILL.md
@@ -30,9 +30,11 @@ make dev-server-sandbox
     `config.json` doesn't drop provider config
 - Provider credential env vars (API keys, `*_BASE_URL`, etc.) are stripped from
   the server's env when they could silently override or mismatch the intended
-  setup: all of them with `--clean-providers`, and those belonging to providers
-  configured in the seeded `providers.jsonc` otherwise (so the seeded config is
-  the single source of truth; env vars for unconfigured providers are kept)
+  setup: all of them with `--clean-providers` (including Bedrock's `AWS_REGION`
+  and `AWS_BEARER_TOKEN_BEDROCK`; shared AWS credentials like `AWS_PROFILE` are
+  kept), and those belonging to providers configured in the seeded
+  `providers.jsonc` otherwise (so the seeded config is the single source of
+  truth; env vars for unconfigured providers are kept)
 - Picks free ports (`BACKEND_PORT`, `VITE_PORT`)
 - Disables tutorials by default inside the sandbox (`MUX_ENABLE_TUTORIALS_IN_SANDBOX=1` opts back in)
 - Allows all hosts (`VITE_ALLOWED_HOSTS=all`) so it works behind port-forwarding domains

--- a/.mux/skills/dev-server-sandbox/SKILL.md
+++ b/.mux/skills/dev-server-sandbox/SKILL.md
@@ -28,13 +28,13 @@ make dev-server-sandbox
   - Each file is seeded independently from the first root that has it
     (`$MUX_ROOT`, then `~/.mux-dev`, then `~/.mux`), so a root with only
     `config.json` doesn't drop provider config
-- Provider credential env vars (API keys, `*_BASE_URL`, etc.) are stripped from
-  the server's env when they could silently override or mismatch the intended
-  setup: all of them with `--clean-providers` (including Bedrock's `AWS_REGION`
-  and `AWS_BEARER_TOKEN_BEDROCK`; shared AWS credentials like `AWS_PROFILE` are
-  kept), and those belonging to providers configured in the seeded
-  `providers.jsonc` otherwise (so the seeded config is the single source of
-  truth; env vars for unconfigured providers are kept)
+- Provider credential env vars are stripped from the server's env when they
+  could silently override or mismatch the intended setup: all of them with
+  `--clean-providers` (including Bedrock's `AWS_REGION` and
+  `AWS_BEARER_TOKEN_BEDROCK`; shared AWS credentials like `AWS_PROFILE` are
+  kept); otherwise only `*_BASE_URL` env vars that would shadow a seeded
+  `providers.jsonc` entry that has an `apiKey` but no explicit `baseUrl`
+  (API key env vars are always kept so env-key fallback still works)
 - Picks free ports (`BACKEND_PORT`, `VITE_PORT`)
 - Disables tutorials by default inside the sandbox (`MUX_ENABLE_TUTORIALS_IN_SANDBOX=1` opts back in)
 - Allows all hosts (`VITE_ALLOWED_HOSTS=all`) so it works behind port-forwarding domains

--- a/scripts/dev-desktop-sandbox.ts
+++ b/scripts/dev-desktop-sandbox.ts
@@ -38,12 +38,13 @@ import * as os from "os";
 import * as path from "path";
 
 import {
-  chooseSeedMuxRoot,
+  chooseSeedSources,
   copyConfigClearingProjectsIfExists,
   copyFileIfExists,
   forwardSignalsToChildProcesses,
   getFreePort,
   parseOptionalPort,
+  sanitizeSandboxProviderEnv,
   waitForHttpReady,
 } from "./sandboxUtils";
 
@@ -158,7 +159,7 @@ async function main(): Promise<number> {
   // Do any validation that might throw *before* creating the temp root so we
   // don't leave behind stale `mux-desktop-*` directories for simple mistakes.
   const shouldSeed = !(cleanProviders && cleanProjects);
-  const seedMuxRoot = shouldSeed ? chooseSeedMuxRoot() : null;
+  const seedSources = shouldSeed ? chooseSeedSources() : { providersPath: null, configPath: null };
 
   const vitePortOverride = parseOptionalPort(process.env.VITE_PORT);
   const debugPortConfig = parseElectronDebugPort(process.env.ELECTRON_DEBUG_PORT);
@@ -191,9 +192,8 @@ async function main(): Promise<number> {
   let electronProc: ReturnType<typeof spawn> | null = null;
 
   try {
-    const seedProvidersPath =
-      seedMuxRoot && !cleanProviders ? path.join(seedMuxRoot, "providers.jsonc") : null;
-    const seedConfigPath = seedMuxRoot ? path.join(seedMuxRoot, "config.json") : null;
+    const seedProvidersPath = !cleanProviders ? seedSources.providersPath : null;
+    const seedConfigPath = seedSources.configPath;
 
     const sandboxProvidersPath = path.join(muxRoot, "providers.jsonc");
     const sandboxConfigPath = path.join(muxRoot, "config.json");
@@ -209,13 +209,10 @@ async function main(): Promise<number> {
 
     console.log("\nStarting mux desktop sandbox...");
     console.log(`  MUX_ROOT:        ${muxRoot}`);
-    if (seedMuxRoot) {
-      console.log(`  Seeded from:     ${seedMuxRoot}`);
-      console.log(`  Copied config:   ${copiedConfig ? "yes" : "no"}`);
-      console.log(`  Copied providers: ${copiedProviders ? "yes" : "no"}`);
-    } else {
-      console.log("  Seeded from:     (none)");
-    }
+    console.log(`  Seed config:     ${copiedConfig && seedConfigPath ? seedConfigPath : "(none)"}`);
+    console.log(
+      `  Seed providers:  ${copiedProviders && seedProvidersPath ? seedProvidersPath : "(none)"}`
+    );
     if (cleanProviders || cleanProjects) {
       console.log(`  Clean providers: ${cleanProviders ? "yes" : "no"}`);
       console.log(`  Clean projects:  ${cleanProjects ? "yes" : "no"}`);
@@ -230,10 +227,14 @@ async function main(): Promise<number> {
       console.log("  KEEP_SANDBOX=1 (temp root will not be deleted)");
     }
 
+    // Strip provider env vars when --clean-providers, warn when the sandbox
+    // has no providers.jsonc and would silently fall back to env credentials.
+    const childEnv = sanitizeSandboxProviderEnv({ cleanProviders, copiedProviders });
+
     devProc = spawn(makeCmd, ["dev"], {
       stdio: "inherit",
       env: {
-        ...process.env,
+        ...childEnv,
         NODE_ENV: "development",
         MUX_ROOT: muxRoot,
         MUX_VITE_PORT: String(vitePort),
@@ -294,7 +295,7 @@ async function main(): Promise<number> {
     electronProc = spawn("bunx", electronArgs, {
       stdio: "inherit",
       env: {
-        ...process.env,
+        ...childEnv,
         NODE_ENV: "development",
         // Keep sandboxed desktop dev launches profile-ready too; callers can set
         // MUX_PROFILE_REACT=0 to compare against an uninstrumented renderer.

--- a/scripts/dev-desktop-sandbox.ts
+++ b/scripts/dev-desktop-sandbox.ts
@@ -227,9 +227,13 @@ async function main(): Promise<number> {
       console.log("  KEEP_SANDBOX=1 (temp root will not be deleted)");
     }
 
-    // Strip provider env vars when --clean-providers, warn when the sandbox
-    // has no providers.jsonc and would silently fall back to env credentials.
-    const childEnv = sanitizeSandboxProviderEnv({ cleanProviders, copiedProviders });
+    // Guard against provider env-var fallback: strip all provider env vars on
+    // --clean-providers, strip the seeded providers' env vars when a
+    // providers.jsonc was copied, and warn when env fallback would apply.
+    const childEnv = sanitizeSandboxProviderEnv({
+      cleanProviders,
+      seededProvidersPath: copiedProviders ? sandboxProvidersPath : null,
+    });
 
     devProc = spawn(makeCmd, ["dev"], {
       stdio: "inherit",

--- a/scripts/dev-server-sandbox.ts
+++ b/scripts/dev-server-sandbox.ts
@@ -34,12 +34,13 @@ import * as os from "os";
 import * as path from "path";
 
 import {
-  chooseSeedMuxRoot,
+  chooseSeedSources,
   copyConfigClearingProjectsIfExists,
   copyFileIfExists,
   forwardSignalsToChildProcesses,
   getFreePort,
   parseOptionalPort,
+  sanitizeSandboxProviderEnv,
 } from "./sandboxUtils";
 
 type SandboxCliFlags = {
@@ -97,7 +98,7 @@ async function main(): Promise<number> {
   // Do any validation that might throw *before* creating the temp root so we
   // don't leave behind stale `mux-dev-server-*` directories for simple mistakes.
   const shouldSeed = !(cleanProviders && cleanProjects);
-  const seedMuxRoot = shouldSeed ? chooseSeedMuxRoot() : null;
+  const seedSources = shouldSeed ? chooseSeedSources() : { providersPath: null, configPath: null };
 
   const backendPortOverride = parseOptionalPort(process.env.BACKEND_PORT);
   const vitePortOverride = parseOptionalPort(process.env.VITE_PORT);
@@ -136,9 +137,8 @@ async function main(): Promise<number> {
   const muxRoot = fs.mkdtempSync(path.join(os.tmpdir(), "mux-dev-server-"));
 
   try {
-    const seedProvidersPath =
-      seedMuxRoot && !cleanProviders ? path.join(seedMuxRoot, "providers.jsonc") : null;
-    const seedConfigPath = seedMuxRoot ? path.join(seedMuxRoot, "config.json") : null;
+    const seedProvidersPath = !cleanProviders ? seedSources.providersPath : null;
+    const seedConfigPath = seedSources.configPath;
 
     const sandboxProvidersPath = path.join(muxRoot, "providers.jsonc");
     const sandboxConfigPath = path.join(muxRoot, "config.json");
@@ -154,13 +154,10 @@ async function main(): Promise<number> {
 
     console.log("\nStarting mux dev-server sandbox...");
     console.log(`  MUX_ROOT:        ${muxRoot}`);
-    if (seedMuxRoot) {
-      console.log(`  Seeded from:     ${seedMuxRoot}`);
-      console.log(`  Copied config:   ${copiedConfig ? "yes" : "no"}`);
-      console.log(`  Copied providers: ${copiedProviders ? "yes" : "no"}`);
-    } else {
-      console.log("  Seeded from:     (none)");
-    }
+    console.log(`  Seed config:     ${copiedConfig && seedConfigPath ? seedConfigPath : "(none)"}`);
+    console.log(
+      `  Seed providers:  ${copiedProviders && seedProvidersPath ? seedProvidersPath : "(none)"}`
+    );
     if (cleanProviders || cleanProjects) {
       console.log(`  Clean providers: ${cleanProviders ? "yes" : "no"}`);
       console.log(`  Clean projects:  ${cleanProjects ? "yes" : "no"}`);
@@ -171,12 +168,16 @@ async function main(): Promise<number> {
       console.log("  KEEP_SANDBOX=1 (temp root will not be deleted)");
     }
 
+    // Strip provider env vars when --clean-providers, warn when the sandbox
+    // has no providers.jsonc and would silently fall back to env credentials.
+    const childEnv = sanitizeSandboxProviderEnv({ cleanProviders, copiedProviders });
+
     let child: ReturnType<typeof spawn>;
     try {
       child = spawn(makeCmd, ["dev-server"], {
         stdio: "inherit",
         env: {
-          ...process.env,
+          ...childEnv,
 
           // Allow access via reverse proxies / port-forwarding domains.
           // This sets the Makefile's `VITE_ALLOWED_HOSTS`, which is forwarded to

--- a/scripts/dev-server-sandbox.ts
+++ b/scripts/dev-server-sandbox.ts
@@ -168,9 +168,13 @@ async function main(): Promise<number> {
       console.log("  KEEP_SANDBOX=1 (temp root will not be deleted)");
     }
 
-    // Strip provider env vars when --clean-providers, warn when the sandbox
-    // has no providers.jsonc and would silently fall back to env credentials.
-    const childEnv = sanitizeSandboxProviderEnv({ cleanProviders, copiedProviders });
+    // Guard against provider env-var fallback: strip all provider env vars on
+    // --clean-providers, strip the seeded providers' env vars when a
+    // providers.jsonc was copied, and warn when env fallback would apply.
+    const childEnv = sanitizeSandboxProviderEnv({
+      cleanProviders,
+      seededProvidersPath: copiedProviders ? sandboxProvidersPath : null,
+    });
 
     let child: ReturnType<typeof spawn>;
     try {

--- a/scripts/sandboxUtils.ts
+++ b/scripts/sandboxUtils.ts
@@ -4,6 +4,8 @@ import * as net from "net";
 import * as os from "os";
 import * as path from "path";
 
+import * as jsonc from "jsonc-parser";
+
 import { AZURE_OPENAI_ENV_VARS, PROVIDER_ENV_VARS } from "../src/node/utils/providerRequirements";
 
 function dirExists(dirPath: string): boolean {
@@ -85,10 +87,14 @@ export function chooseSeedSources(): SeedSources {
  * Intentionally excludes shared AWS env vars (AWS_REGION etc.): stripping
  * those would break unrelated AWS tooling spawned inside the sandbox, and
  * Bedrock auth goes through the AWS SDK chain rather than key+baseUrl pairing.
+ *
+ * @param providers - when given, only env vars belonging to these providers
+ *   (Azure vars count as "openai"); when omitted, all known provider vars.
  */
-function providerCredentialEnvVarNames(): string[] {
+function providerCredentialEnvVarNames(providers?: ReadonlySet<string>): string[] {
   const names = new Set<string>();
-  for (const mapping of Object.values(PROVIDER_ENV_VARS)) {
+  for (const [provider, mapping] of Object.entries(PROVIDER_ENV_VARS)) {
+    if (providers && !providers.has(provider)) continue;
     for (const key of [
       ...(mapping.apiKey ?? []),
       ...(mapping.baseUrl ?? []),
@@ -97,32 +103,57 @@ function providerCredentialEnvVarNames(): string[] {
       names.add(key);
     }
   }
-  for (const key of Object.values(AZURE_OPENAI_ENV_VARS)) {
-    names.add(key);
+  if (!providers || providers.has("openai")) {
+    for (const key of Object.values(AZURE_OPENAI_ENV_VARS)) {
+      names.add(key);
+    }
   }
   return [...names];
 }
 
+/** Provider names configured in a providers.jsonc file (empty set on parse failure). */
+function readConfiguredProviderNames(providersJsoncPath: string): Set<string> {
+  try {
+    const raw = fs.readFileSync(providersJsoncPath, "utf-8");
+    const parsed: unknown = jsonc.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return new Set();
+    }
+    return new Set(Object.keys(parsed));
+  } catch (err) {
+    console.warn(`Failed to read providers.jsonc at ${providersJsoncPath}:`, err);
+    return new Set();
+  }
+}
+
 /**
  * Build the child env for a sandboxed mux instance, guarding against provider
- * env-var fallback surprises:
+ * env-var fallback surprises. mux resolves apiKey and baseUrl *independently*
+ * (config -> file -> env each), so a *_BASE_URL env var pointing at a proxy
+ * (e.g. Coder AI bridge) can get paired with an unrelated API key and fail
+ * auth. Guards:
  *
  * - `--clean-providers`: strip all provider credential env vars so the sandbox
- *   is actually clean (otherwise the server silently falls back to env keys,
- *   and a *_BASE_URL pointing at a proxy/AI-bridge can mismatch the env key).
+ *   is actually clean (no silent env fallback).
+ * - providers.jsonc seeded: strip env vars for the providers it configures,
+ *   making the seeded config the single source of truth for them (otherwise a
+ *   config entry with an apiKey but no baseUrl still inherits *_BASE_URL from
+ *   env). Env vars for providers *not* in the file are kept so env-only
+ *   provider setups keep working.
  * - providers.jsonc not seeded (none found): keep env vars (env-only setups
  *   are legitimate) but warn loudly about the fallback + base-URL pairing risk.
  */
 export function sanitizeSandboxProviderEnv(options: {
   cleanProviders: boolean;
-  copiedProviders: boolean;
+  /** Path of the seeded sandbox providers.jsonc, or null when not seeded. */
+  seededProvidersPath: string | null;
 }): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...process.env };
-  const present = providerCredentialEnvVarNames()
-    .filter((name) => (env[name] ?? "").trim() !== "")
-    .sort();
+  const presentVars = (names: string[]): string[] =>
+    names.filter((name) => (env[name] ?? "").trim() !== "").sort();
 
   if (options.cleanProviders) {
+    const present = presentVars(providerCredentialEnvVarNames());
     for (const name of present) {
       delete env[name];
     }
@@ -132,7 +163,20 @@ export function sanitizeSandboxProviderEnv(options: {
     return env;
   }
 
-  if (!options.copiedProviders && present.length > 0) {
+  if (options.seededProvidersPath !== null) {
+    const configuredProviders = readConfiguredProviderNames(options.seededProvidersPath);
+    const present = presentVars(providerCredentialEnvVarNames(configuredProviders));
+    for (const name of present) {
+      delete env[name];
+    }
+    if (present.length > 0) {
+      console.log(`  Stripped env vars shadowed by seeded providers.jsonc: ${present.join(", ")}`);
+    }
+    return env;
+  }
+
+  const present = presentVars(providerCredentialEnvVarNames());
+  if (present.length > 0) {
     console.warn(
       `\nWARNING: no providers.jsonc was seeded into the sandbox; the server will fall back to provider env vars: ${present.join(", ")}.\n` +
         "If a *_BASE_URL env var points at a proxy (e.g. Coder AI bridge), the env API key may not match it and provider auth will fail.\n"

--- a/scripts/sandboxUtils.ts
+++ b/scripts/sandboxUtils.ts
@@ -92,14 +92,10 @@ export function chooseSeedSources(): SeedSources {
  * shared with unrelated AWS tooling, and Bedrock has no key+baseUrl pairing
  * mismatch risk. They are stripped only in --clean-providers mode (see
  * BEDROCK_CLEAN_ENV_VARS).
- *
- * @param providers - when given, only env vars belonging to these providers
- *   (Azure vars count as "openai"); when omitted, all known provider vars.
  */
-function providerCredentialEnvVarNames(providers?: ReadonlySet<string>): string[] {
+function providerCredentialEnvVarNames(): string[] {
   const names = new Set<string>();
-  for (const [provider, mapping] of Object.entries(PROVIDER_ENV_VARS)) {
-    if (providers && !providers.has(provider)) continue;
+  for (const mapping of Object.values(PROVIDER_ENV_VARS)) {
     for (const key of [
       ...(mapping.apiKey ?? []),
       ...(mapping.baseUrl ?? []),
@@ -108,10 +104,8 @@ function providerCredentialEnvVarNames(providers?: ReadonlySet<string>): string[
       names.add(key);
     }
   }
-  if (!providers || providers.has("openai")) {
-    for (const key of Object.values(AZURE_OPENAI_ENV_VARS)) {
-      names.add(key);
-    }
+  for (const key of Object.values(AZURE_OPENAI_ENV_VARS)) {
+    names.add(key);
   }
   return [...names];
 }
@@ -129,19 +123,51 @@ const BEDROCK_CLEAN_ENV_VARS: string[] = [
   BEDROCK_AUTH_ENV_VARS.bearerToken,
 ];
 
-/** Provider names configured in a providers.jsonc file (empty set on parse failure). */
-function readConfiguredProviderNames(providersJsoncPath: string): Set<string> {
+/**
+ * Base-URL env vars shadowed by a seeded providers.jsonc.
+ *
+ * mux resolves apiKey and baseUrl independently (config -> file -> env each),
+ * so the dangerous combination is: the seeded config supplies the key while a
+ * *_BASE_URL env var supplies the URL (e.g. a Coder AI-bridge proxy that the
+ * config key cannot authenticate against). Only that combination is stripped:
+ * - entry has apiKey/apiKeyFile but no baseUrl -> strip that provider's
+ *   base-URL env vars so the key pairs with the provider default.
+ * - entry without a key keeps all env vars (env-key fallback for option-only
+ *   stubs like `{ "openai": { "models": [...] } }` is a supported pattern).
+ * - entry with an explicit baseUrl needs nothing (config wins both axes).
+ */
+function shadowedBaseUrlEnvVarNames(providersJsoncPath: string): string[] {
+  let parsed: unknown;
   try {
-    const raw = fs.readFileSync(providersJsoncPath, "utf-8");
-    const parsed: unknown = jsonc.parse(raw);
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      return new Set();
-    }
-    return new Set(Object.keys(parsed));
+    parsed = jsonc.parse(fs.readFileSync(providersJsoncPath, "utf-8"));
   } catch (err) {
     console.warn(`Failed to read providers.jsonc at ${providersJsoncPath}:`, err);
-    return new Set();
+    return [];
   }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return [];
+  }
+
+  const hasString = (entry: Record<string, unknown>, key: string): boolean => {
+    const value = entry[key];
+    return typeof value === "string" && value.trim() !== "";
+  };
+
+  const names = new Set<string>();
+  for (const [provider, mapping] of Object.entries(PROVIDER_ENV_VARS)) {
+    if (!mapping.baseUrl) continue;
+    const entry = (parsed as Record<string, unknown>)[provider];
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) continue;
+    const record = entry as Record<string, unknown>;
+    const hasKey = hasString(record, "apiKey") || hasString(record, "apiKeyFile");
+    const hasBaseUrl = hasString(record, "baseUrl") || hasString(record, "baseURL");
+    if (hasKey && !hasBaseUrl) {
+      for (const name of mapping.baseUrl) {
+        names.add(name);
+      }
+    }
+  }
+  return [...names];
 }
 
 /**
@@ -153,11 +179,9 @@ function readConfiguredProviderNames(providersJsoncPath: string): Set<string> {
  *
  * - `--clean-providers`: strip all provider credential env vars so the sandbox
  *   is actually clean (no silent env fallback).
- * - providers.jsonc seeded: strip env vars for the providers it configures,
- *   making the seeded config the single source of truth for them (otherwise a
- *   config entry with an apiKey but no baseUrl still inherits *_BASE_URL from
- *   env). Env vars for providers *not* in the file are kept so env-only
- *   provider setups keep working.
+ * - providers.jsonc seeded: strip only the base-URL env vars that would shadow
+ *   a config-supplied key (see shadowedBaseUrlEnvVarNames). API key env vars
+ *   are always kept so option-only config stubs still resolve env keys.
  * - providers.jsonc not seeded (none found): keep env vars (env-only setups
  *   are legitimate) but warn loudly about the fallback + base-URL pairing risk.
  */
@@ -182,13 +206,14 @@ export function sanitizeSandboxProviderEnv(options: {
   }
 
   if (options.seededProvidersPath !== null) {
-    const configuredProviders = readConfiguredProviderNames(options.seededProvidersPath);
-    const present = presentVars(providerCredentialEnvVarNames(configuredProviders));
+    const present = presentVars(shadowedBaseUrlEnvVarNames(options.seededProvidersPath));
     for (const name of present) {
       delete env[name];
     }
     if (present.length > 0) {
-      console.log(`  Stripped env vars shadowed by seeded providers.jsonc: ${present.join(", ")}`);
+      console.log(
+        `  Stripped base-URL env vars shadowing seeded providers.jsonc keys: ${present.join(", ")}`
+      );
     }
     return env;
   }

--- a/scripts/sandboxUtils.ts
+++ b/scripts/sandboxUtils.ts
@@ -6,7 +6,11 @@ import * as path from "path";
 
 import * as jsonc from "jsonc-parser";
 
-import { AZURE_OPENAI_ENV_VARS, PROVIDER_ENV_VARS } from "../src/node/utils/providerRequirements";
+import {
+  AZURE_OPENAI_ENV_VARS,
+  BEDROCK_AUTH_ENV_VARS,
+  PROVIDER_ENV_VARS,
+} from "../src/node/utils/providerRequirements";
 
 function dirExists(dirPath: string): boolean {
   try {
@@ -84,9 +88,10 @@ export function chooseSeedSources(): SeedSources {
  * Env vars that mux's provider-credential resolution reads as fallback
  * (API keys / auth tokens, base URLs, org IDs, Azure OpenAI vars).
  *
- * Intentionally excludes shared AWS env vars (AWS_REGION etc.): stripping
- * those would break unrelated AWS tooling spawned inside the sandbox, and
- * Bedrock auth goes through the AWS SDK chain rather than key+baseUrl pairing.
+ * Intentionally excludes Bedrock's region vars (AWS_REGION etc.): those are
+ * shared with unrelated AWS tooling, and Bedrock has no key+baseUrl pairing
+ * mismatch risk. They are stripped only in --clean-providers mode (see
+ * BEDROCK_CLEAN_ENV_VARS).
  *
  * @param providers - when given, only env vars belonging to these providers
  *   (Azure vars count as "openai"); when omitted, all known provider vars.
@@ -110,6 +115,19 @@ function providerCredentialEnvVarNames(providers?: ReadonlySet<string>): string[
   }
   return [...names];
 }
+
+/**
+ * Extra env vars stripped only with --clean-providers: Bedrock counts as
+ * "configured" from a region env var alone (credentials flow via the AWS SDK
+ * chain), so a truly clean sandbox must drop the region + bedrock bearer
+ * token too. Shared AWS credentials (AWS_PROFILE, AWS_ACCESS_KEY_ID, ...)
+ * are kept so unrelated AWS tooling inside the sandbox keeps working —
+ * without a region, mux reports Bedrock unconfigured regardless.
+ */
+const BEDROCK_CLEAN_ENV_VARS: string[] = [
+  ...(PROVIDER_ENV_VARS.bedrock?.region ?? []),
+  BEDROCK_AUTH_ENV_VARS.bearerToken,
+];
 
 /** Provider names configured in a providers.jsonc file (empty set on parse failure). */
 function readConfiguredProviderNames(providersJsoncPath: string): Set<string> {
@@ -153,7 +171,7 @@ export function sanitizeSandboxProviderEnv(options: {
     names.filter((name) => (env[name] ?? "").trim() !== "").sort();
 
   if (options.cleanProviders) {
-    const present = presentVars(providerCredentialEnvVarNames());
+    const present = presentVars([...providerCredentialEnvVarNames(), ...BEDROCK_CLEAN_ENV_VARS]);
     for (const name of present) {
       delete env[name];
     }

--- a/scripts/sandboxUtils.ts
+++ b/scripts/sandboxUtils.ts
@@ -4,6 +4,8 @@ import * as net from "net";
 import * as os from "os";
 import * as path from "path";
 
+import { AZURE_OPENAI_ENV_VARS, PROVIDER_ENV_VARS } from "../src/node/utils/providerRequirements";
+
 function dirExists(dirPath: string): boolean {
   try {
     return fs.statSync(dirPath).isDirectory();
@@ -27,35 +29,117 @@ export function expandTilde(input: string): string {
   return input;
 }
 
-export function chooseSeedMuxRoot(): string | null {
+export type SeedSources = {
+  providersPath: string | null;
+  configPath: string | null;
+};
+
+/**
+ * Pick seed files for a sandbox MUX_ROOT.
+ *
+ * providers.jsonc and config.json are chosen *independently* from the first
+ * candidate root that has each file. A root like ~/.mux-dev often has only
+ * config.json while provider credentials live in ~/.mux/providers.jsonc;
+ * picking a single root would silently drop provider config and push the
+ * sandboxed server onto env-var credential fallback, which can pair a real
+ * API key with an unrelated *_BASE_URL proxy (e.g. Coder AI bridge) and fail
+ * auth. See sanitizeSandboxProviderEnv for the env-side guard.
+ */
+export function chooseSeedSources(): SeedSources {
+  const findFirstFile = (roots: string[], fileName: string): string | null => {
+    for (const root of roots) {
+      const candidate = path.join(root, fileName);
+      if (fileExists(candidate)) return candidate;
+    }
+    return null;
+  };
+
   if (process.env.SEED_MUX_ROOT) {
     const explicit = expandTilde(process.env.SEED_MUX_ROOT);
     if (!dirExists(explicit)) {
       throw new Error(`SEED_MUX_ROOT does not exist or is not a directory: ${explicit}`);
     }
-    return explicit;
+    // Explicit seed root: only look there.
+    return {
+      providersPath: findFirstFile([explicit], "providers.jsonc"),
+      configPath: findFirstFile([explicit], "config.json"),
+    };
   }
 
   const candidates = [
     process.env.MUX_ROOT ? expandTilde(process.env.MUX_ROOT) : null,
     path.join(os.homedir(), ".mux-dev"),
     path.join(os.homedir(), ".mux"),
-  ].filter(Boolean) as string[];
+  ].filter((value): value is string => Boolean(value));
 
-  for (const candidate of candidates) {
-    if (!dirExists(candidate)) continue;
+  return {
+    providersPath: findFirstFile(candidates, "providers.jsonc"),
+    configPath: findFirstFile(candidates, "config.json"),
+  };
+}
 
-    const hasProviders = fileExists(path.join(candidate, "providers.jsonc"));
-    const hasConfig = fileExists(path.join(candidate, "config.json"));
+/**
+ * Env vars that mux's provider-credential resolution reads as fallback
+ * (API keys / auth tokens, base URLs, org IDs, Azure OpenAI vars).
+ *
+ * Intentionally excludes shared AWS env vars (AWS_REGION etc.): stripping
+ * those would break unrelated AWS tooling spawned inside the sandbox, and
+ * Bedrock auth goes through the AWS SDK chain rather than key+baseUrl pairing.
+ */
+function providerCredentialEnvVarNames(): string[] {
+  const names = new Set<string>();
+  for (const mapping of Object.values(PROVIDER_ENV_VARS)) {
+    for (const key of [
+      ...(mapping.apiKey ?? []),
+      ...(mapping.baseUrl ?? []),
+      ...(mapping.organization ?? []),
+    ]) {
+      names.add(key);
+    }
+  }
+  for (const key of Object.values(AZURE_OPENAI_ENV_VARS)) {
+    names.add(key);
+  }
+  return [...names];
+}
 
-    if (hasProviders || hasConfig) return candidate;
+/**
+ * Build the child env for a sandboxed mux instance, guarding against provider
+ * env-var fallback surprises:
+ *
+ * - `--clean-providers`: strip all provider credential env vars so the sandbox
+ *   is actually clean (otherwise the server silently falls back to env keys,
+ *   and a *_BASE_URL pointing at a proxy/AI-bridge can mismatch the env key).
+ * - providers.jsonc not seeded (none found): keep env vars (env-only setups
+ *   are legitimate) but warn loudly about the fallback + base-URL pairing risk.
+ */
+export function sanitizeSandboxProviderEnv(options: {
+  cleanProviders: boolean;
+  copiedProviders: boolean;
+}): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  const present = providerCredentialEnvVarNames()
+    .filter((name) => (env[name] ?? "").trim() !== "")
+    .sort();
+
+  if (options.cleanProviders) {
+    for (const name of present) {
+      delete env[name];
+    }
+    if (present.length > 0) {
+      console.log(`  Stripped provider env vars (--clean-providers): ${present.join(", ")}`);
+    }
+    return env;
   }
 
-  for (const candidate of candidates) {
-    if (dirExists(candidate)) return candidate;
+  if (!options.copiedProviders && present.length > 0) {
+    console.warn(
+      `\nWARNING: no providers.jsonc was seeded into the sandbox; the server will fall back to provider env vars: ${present.join(", ")}.\n` +
+        "If a *_BASE_URL env var points at a proxy (e.g. Coder AI bridge), the env API key may not match it and provider auth will fail.\n"
+    );
   }
 
-  return null;
+  return env;
 }
 
 export function copyConfigClearingProjectsIfExists(sourcePath: string, destPath: string): boolean {

--- a/src/node/utils/providerRequirements.ts
+++ b/src/node/utils/providerRequirements.ts
@@ -81,7 +81,9 @@ export const AZURE_OPENAI_ENV_VARS = {
   apiVersion: "AZURE_OPENAI_API_VERSION",
 };
 
-const BEDROCK_AUTH_ENV_VARS = {
+// Exported for sandbox env sanitization (scripts/sandboxUtils.ts), which needs
+// the bedrock-specific bearer token name without duplicating it.
+export const BEDROCK_AUTH_ENV_VARS = {
   accessKeyId: "AWS_ACCESS_KEY_ID",
   secretAccessKey: "AWS_SECRET_ACCESS_KEY",
   bearerToken: "AWS_BEARER_TOKEN_BEDROCK",


### PR DESCRIPTION
## Summary

Fixes dev/desktop sandbox launches that could silently route real provider API keys through an unrelated `*_BASE_URL` proxy (e.g. Coder AI bridge), causing token-mismatch auth failures.

## Background

In Coder workspaces the environment carries both real upstream keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) **and** AI-bridge base URLs (`ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL` → `https://<deployment>/api/v2/aibridge/...`). mux resolves API key and base URL independently (config → file → env each), so when a sandbox starts without a seeded `providers.jsonc`, env fallback pairs the real key with the bridge URL — the bridge expects a Coder session token and rejects the request.

Two sandbox paths triggered this:

1. `chooseSeedMuxRoot()` picked a single seed root accepting `config.json` alone. A `~/.mux-dev` containing only `config.json` shadowed `~/.mux/providers.jsonc`, silently dropping provider config even without flags.
2. `--clean-providers` left provider env vars intact, so the "clean" sandbox still resolved env credentials.

## Implementation

- `chooseSeedSources()` (replacing `chooseSeedMuxRoot()`): seeds `providers.jsonc` and `config.json` independently from the first candidate root (`$MUX_ROOT` → `~/.mux-dev` → `~/.mux`) that has each file. Explicit `SEED_MUX_ROOT` still scopes to that root only.
- `sanitizeSandboxProviderEnv()`: builds the child env for sandbox spawns. With `--clean-providers` it strips all provider credential env vars (keys, auth tokens, base URLs, org IDs, Azure vars — sourced from `PROVIDER_ENV_VARS`/`AZURE_OPENAI_ENV_VARS` so the list can't drift). When no `providers.jsonc` was seeded it keeps env vars (env-only setups are legitimate) but warns loudly about the key↔base-URL pairing risk. Shared AWS env vars are deliberately not stripped.
- Both sandbox scripts now log the actual seed file paths (`Seed providers: /home/user/.mux/providers.jsonc` / `(none)`).
- Skill docs updated accordingly.

## Validation

On a machine reproducing the original conditions (`~/.mux-dev` with only `config.json`, bridge env vars present):

- Default run: `providers.jsonc` now seeded byte-identical from `~/.mux` (previously silently dropped), no warning.
- `--clean-providers`: strip log printed; verified via `/proc/<pid>/environ` that all sandbox child processes (make, bun, node, esbuild) carry zero provider env vars.
- `SEED_MUX_ROOT=~/.mux-dev` (no providers.jsonc anywhere): loud fallback warning printed.
- Desktop sandbox `--clean-providers`: same strip behavior confirmed.

## Risks

Low; changes are confined to dev-only sandbox tooling. Behavior change: users who relied on env-var credentials *inside* a `--clean-providers` sandbox will now get a truly clean instance (that is the flag's documented intent).

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `high` • Cost: `$7.52`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=high costs=7.52 -->
