### PR TITLE
🤖 fix: memory editor fills the settings pane and gets a bordered panel

### DIFF
--- a/src/browser/features/Memory/MemoryBrowser.tsx
+++ b/src/browser/features/Memory/MemoryBrowser.tsx
@@ -183,7 +183,9 @@ export function MemoryBrowser(props: MemoryBrowserProps) {
   const visibleScopes = scopes.filter((scope) => files?.some((file) => file.scope === scope));
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    // h-full fills block parents (sidebar tabpanel); flex-1 fills flex parents
+    // (Settings → Memory). Each is inert in the other context.
+    <div className="flex h-full min-h-0 flex-1 flex-col">
       {error !== null && (
         <div className="text-error px-3 py-2 text-xs" role="alert">
           {error}
@@ -199,17 +201,33 @@ export function MemoryBrowser(props: MemoryBrowserProps) {
           </div>
         )}
         <div className="flex flex-col gap-3">
-          {visibleScopes.map((scope) => (
-            <ScopeSection
-              key={scope}
-              title={SCOPE_LABELS[scope]}
-              files={(files ?? []).filter((file) => file.scope === scope)}
-              agentEditedPaths={agentEditedPaths}
-              onOpen={openFile}
-              onTogglePin={(file) => void handleTogglePin(file)}
-              onRequestDelete={setDeleteTarget}
-            />
-          ))}
+          {visibleScopes.map((scope) => {
+            const scopeFiles = (files ?? []).filter((file) => file.scope === scope);
+            // With a single configured scope (Settings → Memory) the page
+            // heading already names it, so the collapsible scope card would
+            // just double the chrome — render the file tree directly.
+            return scopes.length === 1 ? (
+              <div key={scope} className="flex flex-col gap-px">
+                <TreeNodes
+                  dir={buildTree(scopeFiles)}
+                  agentEditedPaths={agentEditedPaths}
+                  onOpen={openFile}
+                  onTogglePin={(file) => void handleTogglePin(file)}
+                  onRequestDelete={setDeleteTarget}
+                />
+              </div>
+            ) : (
+              <ScopeSection
+                key={scope}
+                title={SCOPE_LABELS[scope]}
+                files={scopeFiles}
+                agentEditedPaths={agentEditedPaths}
+                onOpen={openFile}
+                onTogglePin={(file) => void handleTogglePin(file)}
+                onRequestDelete={setDeleteTarget}
+              />
+            );
+          })}
         </div>
       </div>
       {deleteTarget !== null && (

--- a/src/browser/features/Memory/MemoryFileEditor.tsx
+++ b/src/browser/features/Memory/MemoryFileEditor.tsx
@@ -89,7 +89,9 @@ export function MemoryFileEditor(props: MemoryFileEditorProps) {
   };
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    // h-full fills block parents (sidebar tabpanel); flex-1 fills flex parents
+    // (Settings → Memory). Each is inert in the other context.
+    <div className="flex h-full min-h-0 flex-1 flex-col">
       <div className="border-border-light flex items-center gap-2 border-b px-2 py-2">
         <RowActionButton aria-label="Back to memory list" onClick={props.onBack}>
           <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
@@ -131,8 +133,8 @@ export function MemoryFileEditor(props: MemoryFileEditorProps) {
       ) : (
         <textarea
           ref={textareaRef}
-          // min-h floor keeps the editor usable when the parent has no fixed
-          // height (Settings → Memory); flex-1 fills the sidebar tab.
+          // flex-1 fills the available height; the min-h floor keeps the
+          // editor usable on very short viewports.
           className="min-h-48 flex-1 resize-none bg-transparent p-3 font-mono text-xs outline-none"
           aria-label="Memory file content"
           value={draft}

--- a/src/browser/features/Settings/Sections/MemorySection.tsx
+++ b/src/browser/features/Settings/Sections/MemorySection.tsx
@@ -8,7 +8,9 @@ import { MemoryBrowser } from "@/browser/features/Memory/MemoryBrowser";
  */
 export function MemorySection() {
   return (
-    <div className="flex flex-col gap-4">
+    // flex-1/min-h-0 lets the file editor (and the browser list) fill the
+    // remaining settings-page height instead of collapsing to its min-height.
+    <div className="flex min-h-0 flex-1 flex-col gap-4">
       <div>
         <h3 className="text-foreground mb-1 text-sm font-medium">Global Memories</h3>
         <p className="text-muted text-xs">
@@ -16,7 +18,11 @@ export function MemorySection() {
           memories live in the Memory tab of each workspace.
         </p>
       </div>
-      <MemoryBrowser workspaceId={null} scopes={["global"]} />
+      {/* Bordered panel so the editable area is visually distinct from the
+          settings page background (the sidebar Memory tab has its own chrome). */}
+      <div className="border-border-light flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border">
+        <MemoryBrowser workspaceId={null} scopes={["global"]} />
+      </div>
     </div>
   );
 }

--- a/src/browser/features/Settings/SettingsPage.tsx
+++ b/src/browser/features/Settings/SettingsPage.tsx
@@ -311,8 +311,10 @@ export function SettingsPage(props: SettingsPageProps) {
             </Button>
           </div>
           <div className="flex-1 overflow-y-auto p-4 md:p-6">
-            {/* Keep settings content width bounded so long forms remain readable on wide screens. */}
-            <div className="w-full max-w-4xl">
+            {/* Keep settings content width bounded so long forms remain readable on wide screens.
+                min-h-full + flex-col lets full-height sections (Settings → Memory editor) grow to
+                the bottom via flex-1 while content-sized sections keep their natural height. */}
+            <div className="flex min-h-full w-full max-w-4xl flex-col">
               {onboardingPause.paused && (
                 <div className="bg-accent/10 border-accent/30 text-foreground mb-3 flex items-center justify-between rounded-md border px-3 py-2 text-sm">
                   <span>Setup is paused while you configure providers.</span>


### PR DESCRIPTION
## Summary

Settings → Memory previously rendered the memory file editor at a fixed `min-h-48` height floating on the page background, which looked odd on large screens and made the editable area hard to distinguish. The editor (and file list) now fill the available height down to the bottom of the settings pane, sit inside a bordered panel, and the redundant collapsible "GLOBAL" scope card is dropped on single-scope surfaces.

## Background

`MemoryFileEditor` already used `flex-1`/`h-full`, but in Settings nothing above it had a definite height (scroll container → auto-height width wrapper → auto-height section), so `h-full` resolved to nothing and the textarea collapsed to its min-height. The sidebar Memory tab was unaffected because its tabpanel gets an explicit `h-full`.

## Implementation

- `SettingsPage`: the bounded-width content wrapper becomes a `min-h-full` flex column, so sections can opt into filling the remaining height with `flex-1`. Content-sized sections (all use `space-y-*`/`gap-*` roots) keep their natural height and long forms still scroll.
- `MemorySection`: opts in via `min-h-0 flex-1`, and wraps `MemoryBrowser` in a bordered rounded panel so the editable area is visually distinct from the page background.
- `MemoryBrowser`: with a single configured scope (Settings → Memory), the file tree renders directly instead of inside the collapsible `ScopeSection` card — the page heading already names the scope, and the card doubled the chrome inside the new bordered panel. The multi-scope sidebar tab keeps scope cards.
- `MemoryBrowser`/`MemoryFileEditor` roots gain `flex-1` alongside the existing `h-full`; each is inert in the other consumer's context.

## Validation

Dogfooded in a dev-server sandbox with seeded global memory files:

- Settings @ 1900×900: textarea bottom = viewport − page padding (fills exactly); list view flat inside one bordered panel.
- Sidebar Memory tab: textarea bottom matches tabpanel bottom exactly (no regression); scope cards still render with usage stats.
- Mobile @ 375×812: fills to bottom, no horizontal overflow.

## Risks

Low. The only shared-surface change is the settings content wrapper becoming a flex column; verified every other settings section root uses content-sized layouts (`space-y-*`/`gap-*`), which are unaffected by the parent's flex direction.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$17.89`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=17.89 -->
