### PR TITLE
🤖 feat: group workflow sub-agents per run in sidebar + integrate task-group UI

### DIFF
--- a/src/browser/components/AgentListItem/AgentListItem.test.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.test.tsx
@@ -244,6 +244,7 @@ function renderWorkspaceItem(
     depth?: number;
     rowRenderMeta?: AgentRowRenderMeta;
     subAgentConnectorLayout?: "default" | "task-group-member";
+    taskGroupHeaderTitle?: string;
     delegatedActivity?: WorkspaceDelegatedActivity;
     completedChildrenExpanded?: boolean;
     onToggleCompletedChildren?: (workspaceId: string) => void;
@@ -261,6 +262,7 @@ function renderWorkspaceItem(
       depth={options.depth ?? options.rowRenderMeta?.depth}
       rowRenderMeta={options.rowRenderMeta}
       subAgentConnectorLayout={options.subAgentConnectorLayout}
+      taskGroupHeaderTitle={options.taskGroupHeaderTitle}
       delegatedActivity={options.delegatedActivity}
       completedChildrenExpanded={options.completedChildrenExpanded}
       onToggleCompletedChildren={options.onToggleCompletedChildren}
@@ -274,9 +276,13 @@ function renderWorkspaceItem(
   return {
     metadata,
     view,
-    row: view.getByRole("button", {
-      name: `${options.isArchiving ? "Archiving" : "Select"} workspace ${metadata.title ?? metadata.name}`,
-    }),
+    // Lazy: D8 title suppression changes the accessible name for group-member
+    // rows, so only resolve the default lookup when a test actually uses it.
+    get row() {
+      return view.getByRole("button", {
+        name: `${options.isArchiving ? "Archiving" : "Select"} workspace ${metadata.title ?? metadata.name}`,
+      });
+    },
   };
 }
 
@@ -301,6 +307,52 @@ describe("AgentListItem", () => {
     cleanupDom?.();
     cleanupDom = null;
     mock.restore();
+  });
+
+  test("suppresses group-member titles that repeat the group header (D8)", () => {
+    // Variant member: label-only row keeps the variant label as the title text.
+    const variant = renderWorkspaceItem({
+      metadata: createMetadata({
+        title: "Split review",
+        parentWorkspaceId: "parent",
+        bestOf: { groupId: "g1", index: 0, total: 2, kind: "variants", label: "frontend" },
+      }),
+      subAgentConnectorLayout: "task-group-member",
+      taskGroupHeaderTitle: "Split review",
+    });
+    expect(variant.view.getByRole("button", { name: "Select workspace frontend" })).toBeTruthy();
+    expect(variant.view.queryByText("Split review")).toBeNull();
+    cleanup();
+
+    // Best-of member: bare letters become "Candidate A" so the row stays readable.
+    const candidate = renderWorkspaceItem({
+      metadata: createMetadata({
+        title: "Split review",
+        parentWorkspaceId: "parent",
+        bestOf: { groupId: "g1", index: 0, total: 2 },
+      }),
+      subAgentConnectorLayout: "task-group-member",
+      taskGroupHeaderTitle: "Split review",
+    });
+    expect(
+      candidate.view.getByRole("button", { name: "Select workspace Candidate A" })
+    ).toBeTruthy();
+    cleanup();
+
+    // A custom (differing) title still renders alongside the label.
+    const customTitle = renderWorkspaceItem({
+      metadata: createMetadata({
+        title: "My renamed run",
+        parentWorkspaceId: "parent",
+        bestOf: { groupId: "g1", index: 1, total: 2, kind: "variants", label: "backend" },
+      }),
+      subAgentConnectorLayout: "task-group-member",
+      taskGroupHeaderTitle: "Split review",
+    });
+    expect(
+      customTitle.view.getByRole("button", { name: "Select workspace backend · My renamed run" })
+    ).toBeTruthy();
+    expect(customTitle.view.getByText("My renamed run")).toBeTruthy();
   });
 
   test("shows active delegated workflow work on idle workspace rows", () => {

--- a/src/browser/components/AgentListItem/AgentListItem.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.tsx
@@ -30,6 +30,14 @@ import React, { useState, useEffect, useRef, useCallback } from "react";
 import { useDrag } from "react-dnd";
 import { getEmptyImage } from "react-dnd-html5-backend";
 import { SubAgentListItem } from "./SubAgentListItem";
+import {
+  LEADING_SLOT_CONTAINER_CLASSES,
+  LEADING_SLOT_CONTAINER_STYLE,
+  STATUS_DOT_SLOT_CONTAINER_CLASSES,
+  StatusDot,
+  isStatusDotVisible,
+  type VisualState,
+} from "./StatusDot";
 
 import { Tooltip, TooltipTrigger, TooltipContent } from "../Tooltip/Tooltip";
 import { Popover, PopoverContent, PopoverTrigger, PopoverAnchor } from "../Popover/Popover";
@@ -39,7 +47,6 @@ import {
   getSidebarItemPaddingLeft,
   getSubAgentChildStatusCenterX,
   getSubAgentParentRailX,
-  SIDEBAR_LEADING_SLOT_SIZE_PX,
   type SubAgentConnectorLayout,
 } from "../sidebarItemLayout";
 import {
@@ -102,6 +109,11 @@ export interface AgentListItemProps extends AgentListItemBaseProps {
   metadata: FrontendWorkspaceMetadata;
   projectName: string;
   subAgentConnectorLayout?: SubAgentConnectorLayout;
+  /**
+   * Title of the enclosing task-group header when rendered as an expanded
+   * group member. Used to suppress titles that just repeat the header (D8).
+   */
+  taskGroupHeaderTitle?: string;
   isArchiving?: boolean;
   /** True when deletion is in-flight (optimistic UI while backend removes). */
   isRemoving?: boolean;
@@ -141,13 +153,6 @@ const HIDE_INLINE_ACTIONS_ON_MOBILE_TOUCH =
 const SHOW_INLINE_ACTIONS_ON_WIDE_TOUCH =
   "[@media(min-width:769px)_and_(hover:none)_and_(pointer:coarse)]:opacity-100";
 
-const LEADING_SLOT_CONTAINER_STYLE = {
-  width: SIDEBAR_LEADING_SLOT_SIZE_PX,
-  height: SIDEBAR_LEADING_SLOT_SIZE_PX,
-} as const;
-
-type VisualState = "active" | "idle" | "seen" | "hidden" | "error" | "question";
-
 function getVisualState(opts: {
   awaitingUserQuestion: boolean;
   isInitializing: boolean;
@@ -181,76 +186,9 @@ function getVisualState(opts: {
   return opts.isUnread ? "idle" : "seen";
 }
 
-function isStatusDotVisible(state: VisualState, isDraft?: boolean, isSubAgent?: boolean): boolean {
-  if (isDraft) {
-    return true;
-  }
-  if (state === "hidden") {
-    return false;
-  }
-  if (state === "seen") {
-    return isSubAgent === true;
-  }
-  return true;
-}
-
-const LEADING_SLOT_CONTAINER_CLASSES =
-  "relative z-1 flex shrink-0 items-center justify-center self-center";
-const STATUS_DOT_SLOT_CONTAINER_CLASSES =
-  "relative z-20 flex shrink-0 items-center justify-center self-center";
-
 function HeartbeatFallbackIcon() {
   return (
     <HeartPulse aria-hidden="true" className="text-muted h-4 w-4" data-testid="heartbeat-icon" />
-  );
-}
-
-function StatusDot(props: {
-  state: VisualState;
-  isDraft?: boolean;
-  isSubAgent?: boolean;
-  overlay?: React.ReactNode;
-}) {
-  const hasVisibleDot = isStatusDotVisible(props.state, props.isDraft, props.isSubAgent);
-  const usesSubAgentConnectorDot =
-    props.isSubAgent === true && (props.state === "idle" || props.state === "seen");
-  const dot = props.isDraft ? (
-    <span className="border-border-subtle block h-3 w-3 rounded-full border border-dashed" />
-  ) : !hasVisibleDot ? (
-    <span className="block h-3 w-3 opacity-0" />
-  ) : (
-    <span
-      className={cn(
-        "block h-3 w-3",
-        props.state === "active" &&
-          "bg-content-success border-surface-green workspace-status-dot-active",
-        usesSubAgentConnectorDot && "bg-border-light border-border-light h-2 w-2",
-        props.state === "idle" &&
-          props.isSubAgent !== true &&
-          "bg-surface-invert-secondary border-surface-tertiary",
-        props.state === "error" && "bg-content-destructive border-surface-destructive",
-        props.state === "question" && "bg-border-pending border-surface-sky",
-        "rounded-full border-[3.5px]"
-      )}
-    />
-  );
-
-  return (
-    // Keep the dot centered relative to the full row height so multi-line rows
-    // (for example while streaming) do not pin the icon to the title line.
-    <div
-      // Keep the status dot above sub-agent connector overlays so branch lines do
-      // not draw across the dot when rows are nested.
-      className={STATUS_DOT_SLOT_CONTAINER_CLASSES}
-      style={LEADING_SLOT_CONTAINER_STYLE}
-    >
-      {dot}
-      {props.overlay && (
-        <span className="pointer-events-none absolute inset-0 flex items-center justify-center">
-          {props.overlay}
-        </span>
-      )}
-    </div>
   );
 }
 
@@ -523,13 +461,29 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
   const workspaceTitle = metadata.title ?? metadata.name;
   // Derive a short group label for grouped task children: explicit label for variants,
   // alphabetical letter (A, B, C…) for best-of-n candidates.
+  const isBestOfCandidate =
+    metadata.bestOf != null &&
+    getTaskGroupKindFromMetadata(metadata.bestOf) !== TASK_GROUP_KIND.VARIANTS;
   const groupLabel =
     metadata.bestOf != null
-      ? getTaskGroupKindFromMetadata(metadata.bestOf) === TASK_GROUP_KIND.VARIANTS
-        ? normalizeTaskGroupLabel(metadata.bestOf.label)
-        : String.fromCharCode(65 + (metadata.bestOf.index ?? 0))
+      ? isBestOfCandidate
+        ? String.fromCharCode(65 + (metadata.bestOf.index ?? 0))
+        : normalizeTaskGroupLabel(metadata.bestOf.label)
       : undefined;
-  const displayTitle = groupLabel ? `${groupLabel} · ${workspaceTitle}` : workspaceTitle;
+  // D8: expanded group members drop a title that merely repeats the group
+  // header; the remaining label must stay readable on its own, so bare best-of
+  // letters render as "Candidate A". Custom titles still show (self-healing).
+  const suppressGroupMemberTitle =
+    props.taskGroupHeaderTitle !== undefined &&
+    props.taskGroupHeaderTitle === workspaceTitle &&
+    groupLabel !== undefined;
+  const memberOnlyLabel =
+    isBestOfCandidate && groupLabel !== undefined ? `Candidate ${groupLabel}` : groupLabel;
+  const displayTitle = suppressGroupMemberTitle
+    ? (memberOnlyLabel ?? workspaceTitle)
+    : groupLabel
+      ? `${groupLabel} · ${workspaceTitle}`
+      : workspaceTitle;
   const isEditing = editingWorkspaceId === workspaceId;
 
   const linkSharingEnabled = useLinkSharingEnabled();
@@ -1092,7 +1046,7 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
                     badge so it stays visible even when the sidebar is narrow.
                     items-baseline keeps the 12px label on the same text baseline as the
                     14px title so they look naturally aligned despite the size difference. */}
-                {groupLabel && (
+                {groupLabel && !suppressGroupMemberTitle && (
                   <span className="text-muted shrink-0 text-[12px] leading-6">{groupLabel}</span>
                 )}
                 <span
@@ -1103,7 +1057,7 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
                     titleColorClass
                   )}
                 >
-                  {workspaceTitle}
+                  {suppressGroupMemberTitle ? memberOnlyLabel : workspaceTitle}
                 </span>
               </div>
             )}

--- a/src/browser/components/AgentListItem/StatusDot.tsx
+++ b/src/browser/components/AgentListItem/StatusDot.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+
+import { SIDEBAR_LEADING_SLOT_SIZE_PX } from "@/browser/components/sidebarItemLayout";
+import { cn } from "@/common/lib/utils";
+
+// Shared sidebar status language: agent rows and task-group headers render the
+// same dot states so grouped rows read as native parts of the agent tree.
+export type VisualState = "active" | "idle" | "seen" | "hidden" | "error" | "question";
+
+export const LEADING_SLOT_CONTAINER_STYLE = {
+  width: SIDEBAR_LEADING_SLOT_SIZE_PX,
+  height: SIDEBAR_LEADING_SLOT_SIZE_PX,
+} as const;
+
+export const LEADING_SLOT_CONTAINER_CLASSES =
+  "relative z-1 flex shrink-0 items-center justify-center self-center";
+export const STATUS_DOT_SLOT_CONTAINER_CLASSES =
+  "relative z-20 flex shrink-0 items-center justify-center self-center";
+
+export function isStatusDotVisible(
+  state: VisualState,
+  isDraft?: boolean,
+  isSubAgent?: boolean
+): boolean {
+  if (isDraft) {
+    return true;
+  }
+  if (state === "hidden") {
+    return false;
+  }
+  if (state === "seen") {
+    return isSubAgent === true;
+  }
+  return true;
+}
+
+export function StatusDot(props: {
+  state: VisualState;
+  isDraft?: boolean;
+  isSubAgent?: boolean;
+  overlay?: React.ReactNode;
+}) {
+  const hasVisibleDot = isStatusDotVisible(props.state, props.isDraft, props.isSubAgent);
+  const usesSubAgentConnectorDot =
+    props.isSubAgent === true && (props.state === "idle" || props.state === "seen");
+  const dot = props.isDraft ? (
+    <span className="border-border-subtle block h-3 w-3 rounded-full border border-dashed" />
+  ) : !hasVisibleDot ? (
+    <span className="block h-3 w-3 opacity-0" />
+  ) : (
+    <span
+      className={cn(
+        "block h-3 w-3",
+        props.state === "active" &&
+          "bg-content-success border-surface-green workspace-status-dot-active",
+        usesSubAgentConnectorDot && "bg-border-light border-border-light h-2 w-2",
+        props.state === "idle" &&
+          props.isSubAgent !== true &&
+          "bg-surface-invert-secondary border-surface-tertiary",
+        props.state === "error" && "bg-content-destructive border-surface-destructive",
+        props.state === "question" && "bg-border-pending border-surface-sky",
+        "rounded-full border-[3.5px]"
+      )}
+    />
+  );
+
+  return (
+    // Keep the dot centered relative to the full row height so multi-line rows
+    // (for example while streaming) do not pin the icon to the title line.
+    <div
+      // Keep the status dot above sub-agent connector overlays so branch lines do
+      // not draw across the dot when rows are nested.
+      className={STATUS_DOT_SLOT_CONTAINER_CLASSES}
+      style={LEADING_SLOT_CONTAINER_STYLE}
+    >
+      {dot}
+      {props.overlay && (
+        <span className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          {props.overlay}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.stories.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.stories.tsx
@@ -5,6 +5,8 @@ import { expandProjects } from "@/browser/stories/helpers/uiState";
 import { createMockORPCClient } from "@/browser/stories/mocks/orpc";
 import { createWorkspace, groupWorkspacesByProject } from "@/browser/stories/mocks/workspaces";
 
+const PROJECT_PATH = "/home/user/projects/my-app";
+
 const meta = {
   ...appMeta,
   title: "Components/ProjectSidebar",
@@ -73,5 +75,173 @@ export const ProjectRemovalDisabled: AppStory = {
       },
       { timeout: 2000 }
     );
+  },
+};
+
+// Phase 1 visual contract: a variant group nested inside a sub-agent tree must
+// keep continuous connector rails through the group header (no gap above/below),
+// and expanded members render label-only rows ("frontend", "backend").
+export const NestedTaskGroupConnectors: AppStory = {
+  parameters: {
+    chromatic: { modes: CHROMATIC_SMOKE_MODES },
+  },
+  render: () => (
+    <AppWithMocks
+      setup={() => {
+        const projectName = "my-app";
+        const workspaces = [
+          createWorkspace({
+            id: "ws-parent",
+            name: "feature/orchestrator",
+            projectName,
+            title: "Orchestrate feature work",
+          }),
+          createWorkspace({
+            id: "sub-backend",
+            name: "task/backend",
+            projectName,
+            title: "Implement backend",
+            parentWorkspaceId: "ws-parent",
+            taskStatus: "running",
+          }),
+          createWorkspace({
+            id: "variant-frontend",
+            name: "task/variant-frontend",
+            projectName,
+            title: "Compare designs",
+            parentWorkspaceId: "sub-backend",
+            taskStatus: "running",
+            bestOf: { groupId: "vg-1", index: 0, total: 2, kind: "variants", label: "frontend" },
+          }),
+          createWorkspace({
+            id: "variant-backend",
+            name: "task/variant-backend",
+            projectName,
+            title: "Compare designs",
+            parentWorkspaceId: "sub-backend",
+            taskStatus: "queued",
+            bestOf: { groupId: "vg-1", index: 1, total: 2, kind: "variants", label: "backend" },
+          }),
+          // Lower sibling: the parent trunk must continue through the group header.
+          createWorkspace({
+            id: "sub-docs",
+            name: "task/docs",
+            projectName,
+            title: "Write docs",
+            parentWorkspaceId: "ws-parent",
+            taskStatus: "running",
+          }),
+        ];
+        expandProjects([PROJECT_PATH]);
+        localStorage.setItem(
+          "expandedTaskGroups",
+          JSON.stringify({ "task:sub-backend:vg-1": true })
+        );
+        return createMockORPCClient({
+          projects: groupWorkspacesByProject(workspaces),
+          workspaces,
+        });
+      }}
+    />
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    await waitFor(() => {
+      if (!canvasElement.querySelector('[data-testid="task-group-vg-1"]')) {
+        throw new Error("Variant group header not found");
+      }
+    });
+  },
+};
+
+// Phase 2 visual contract: two concurrent workflow runs form separate collapsible
+// groups (one with a stamped name, one falling back to the run id), active runs
+// default to expanded, and a variants group coexists under the same workspace.
+export const WorkflowRunGroups: AppStory = {
+  parameters: {
+    chromatic: { modes: CHROMATIC_SMOKE_MODES },
+  },
+  render: () => (
+    <AppWithMocks
+      setup={() => {
+        const projectName = "my-app";
+        const reviewRun = (
+          id: string,
+          stepId: string,
+          opts: Partial<Parameters<typeof createWorkspace>[0]>
+        ) =>
+          createWorkspace({
+            id,
+            name: `task/${id}`,
+            projectName,
+            parentWorkspaceId: "ws-main",
+            workflowTask: { runId: "wfr_review1234", stepId, workflowName: "review-pipeline" },
+            ...opts,
+          } as Parameters<typeof createWorkspace>[0]);
+        const workspaces = [
+          createWorkspace({
+            id: "ws-main",
+            name: "feature/payments",
+            projectName,
+            title: "Payments integration",
+          }),
+          reviewRun("wf-claims", "claims", {
+            title: "Extract claims",
+            taskStatus: "reported",
+            createdAt: new Date(Date.now() - 8 * 60_000).toISOString(),
+          }),
+          createWorkspace({
+            id: "wf-tests",
+            name: "task/wf-tests",
+            projectName,
+            title: "Run test matrix",
+            parentWorkspaceId: "ws-main",
+            taskStatus: "running",
+            createdAt: new Date(Date.now() - 6 * 60_000).toISOString(),
+            workflowTask: { runId: "wfr_legacy567890", stepId: "tests" },
+          }),
+          reviewRun("wf-verify", "verify", {
+            title: "Verify claims",
+            taskStatus: "running",
+            createdAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+          }),
+          createWorkspace({
+            id: "var-a",
+            name: "task/var-a",
+            projectName,
+            title: "Split review",
+            parentWorkspaceId: "ws-main",
+            taskStatus: "queued",
+            bestOf: { groupId: "vg-2", index: 0, total: 2, kind: "variants", label: "frontend" },
+          }),
+          createWorkspace({
+            id: "var-b",
+            name: "task/var-b",
+            projectName,
+            title: "Split review",
+            parentWorkspaceId: "ws-main",
+            taskStatus: "queued",
+            bestOf: { groupId: "vg-2", index: 1, total: 2, kind: "variants", label: "backend" },
+          }),
+        ];
+        expandProjects([PROJECT_PATH]);
+        return createMockORPCClient({
+          projects: groupWorkspacesByProject(workspaces),
+          workspaces,
+        });
+      }}
+    />
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    await waitFor(() => {
+      const named = canvasElement.querySelector('[data-testid="task-group-wfr_review1234"]');
+      const fallback = canvasElement.querySelector('[data-testid="task-group-wfr_legacy567890"]');
+      if (!named || !fallback) {
+        throw new Error("Expected two workflow run group headers");
+      }
+      // Active runs default to expanded: the completed claims task stays visible.
+      if (!canvasElement.querySelector('[aria-label="Select workspace Extract claims"]')) {
+        throw new Error("Expected expanded workflow run to show its completed member");
+      }
+    });
   },
 };

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.stories.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.stories.tsx
@@ -153,6 +153,58 @@ export const NestedTaskGroupConnectors: AppStory = {
   },
 };
 
+// Best-of group rendering contract: collapsed header reads "Best of 3 · <title>";
+// expanded members drop the repeated title and render as "Candidate A/B/C".
+export const BestOfGroup: AppStory = {
+  parameters: {
+    chromatic: { modes: CHROMATIC_SMOKE_MODES },
+  },
+  render: () => (
+    <AppWithMocks
+      setup={() => {
+        const projectName = "my-app";
+        const candidate = (index: number, taskStatus: "running" | "queued") =>
+          createWorkspace({
+            id: `cand-${index}`,
+            name: `task/cand-${index}`,
+            projectName,
+            title: "Compare implementation options",
+            parentWorkspaceId: "ws-parent",
+            taskStatus,
+            bestOf: { groupId: "bo-1", index, total: 3 },
+          });
+        const workspaces = [
+          createWorkspace({
+            id: "ws-parent",
+            name: "feature/compare",
+            projectName,
+            title: "Pick the best approach",
+          }),
+          candidate(0, "running"),
+          candidate(1, "running"),
+          candidate(2, "queued"),
+        ];
+        expandProjects([PROJECT_PATH]);
+        localStorage.setItem("expandedTaskGroups", JSON.stringify({ "task:ws-parent:bo-1": true }));
+        return createMockORPCClient({
+          projects: groupWorkspacesByProject(workspaces),
+          workspaces,
+        });
+      }}
+    />
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    await waitFor(() => {
+      if (!canvasElement.querySelector('[data-testid="task-group-bo-1"]')) {
+        throw new Error("Best-of group header not found");
+      }
+      if (!canvasElement.querySelector('[aria-label="Select workspace Candidate A"]')) {
+        throw new Error("Expected label-only candidate rows");
+      }
+    });
+  },
+};
+
 // Phase 2 visual contract: two concurrent workflow runs form separate collapsible
 // groups (one with a stamped name, one falling back to the run id), active runs
 // default to expanded, and a variants group coexists under the same workspace.

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
@@ -1226,6 +1226,273 @@ describe("ProjectSidebar multi-project completed-subagent toggles", () => {
     expect(childTwoRow.dataset.connectorLayout).toBe("task-group-member");
   });
 
+  test("groups workflow sub-agents per run, gathering non-contiguous members of concurrent runs", () => {
+    window.localStorage.setItem(EXPANDED_PROJECTS_KEY, JSON.stringify(["/projects/demo-project"]));
+    projectContextValue = createProjectContextValue({
+      userProjects: new Map([["/projects/demo-project", { workspaces: [] }]]),
+      hasAnyProject: true,
+      resolveNewChatProjectPath: () => "/projects/demo-project",
+    });
+
+    const singleProjectRefs = [
+      { projectPath: "/projects/demo-project", projectName: "demo-project" },
+    ];
+    const parentWorkspace = {
+      ...createWorkspace("parent", { title: "Parent workspace" }),
+      projects: singleProjectRefs,
+    };
+    const alphaOne = {
+      ...createWorkspace("alpha-1", {
+        parentWorkspaceId: "parent",
+        taskStatus: "running",
+        title: "Extract claims",
+        workflowTask: { runId: "wfr_alpha", stepId: "claims", workflowName: "review-pipeline" },
+      }),
+      projects: singleProjectRefs,
+    };
+    const betaOne = {
+      ...createWorkspace("beta-1", {
+        parentWorkspaceId: "parent",
+        taskStatus: "running",
+        title: "Run tests",
+        workflowTask: { runId: "wfr_beta", stepId: "tests" },
+      }),
+      projects: singleProjectRefs,
+    };
+    const alphaTwo = {
+      ...createWorkspace("alpha-2", {
+        parentWorkspaceId: "parent",
+        taskStatus: "queued",
+        title: "Verify claims",
+        workflowTask: { runId: "wfr_alpha", stepId: "verify", workflowName: "review-pipeline" },
+      }),
+      projects: singleProjectRefs,
+    };
+
+    const view = render(
+      <ProjectSidebar
+        collapsed={false}
+        onToggleCollapsed={() => undefined}
+        sortedWorkspacesByProject={
+          new Map([["/projects/demo-project", [parentWorkspace, alphaOne, betaOne, alphaTwo]]])
+        }
+        workspaceRecency={{
+          parent: Date.now(),
+          "alpha-1": Date.now(),
+          "beta-1": Date.now(),
+          "alpha-2": Date.now(),
+        }}
+      />
+    );
+
+    // One header per run, even though beta-1 interleaves between the alpha tasks.
+    const alphaHeader = view.getByTestId("task-group-wfr_alpha");
+    expect(view.getByTestId("task-group-wfr_beta")).toBeTruthy();
+    // The stamped workflow name reaches the header label.
+    expect(alphaHeader.textContent).toContain("review-pipeline");
+
+    // Active workflow groups default to expanded (D6), so members render as
+    // group members without an explicit toggle.
+    const alphaOneRow = view.getByTestId(agentItemTestId("alpha-1"));
+    const alphaTwoRow = view.getByTestId(agentItemTestId("alpha-2"));
+    expect(alphaOneRow.dataset.connectorLayout).toBe("task-group-member");
+    expect(alphaTwoRow.dataset.connectorLayout).toBe("task-group-member");
+    expect(view.getByTestId(agentItemTestId("beta-1")).dataset.connectorLayout).toBe(
+      "task-group-member"
+    );
+  });
+
+  test("persisted collapse beats the active-run default and toggles persist", async () => {
+    window.localStorage.setItem(EXPANDED_PROJECTS_KEY, JSON.stringify(["/projects/demo-project"]));
+    window.localStorage.setItem(
+      "expandedTaskGroups",
+      JSON.stringify({ "workflow:parent:wfr_alpha": false })
+    );
+    projectContextValue = createProjectContextValue({
+      userProjects: new Map([["/projects/demo-project", { workspaces: [] }]]),
+      hasAnyProject: true,
+      resolveNewChatProjectPath: () => "/projects/demo-project",
+    });
+
+    const singleProjectRefs = [
+      { projectPath: "/projects/demo-project", projectName: "demo-project" },
+    ];
+    const parentWorkspace = {
+      ...createWorkspace("parent", { title: "Parent workspace" }),
+      projects: singleProjectRefs,
+    };
+    const task = {
+      ...createWorkspace("alpha-1", {
+        parentWorkspaceId: "parent",
+        taskStatus: "running",
+        title: "Extract claims",
+        workflowTask: { runId: "wfr_alpha", stepId: "claims", workflowName: "review-pipeline" },
+      }),
+      projects: singleProjectRefs,
+    };
+
+    const view = render(
+      <ProjectSidebar
+        collapsed={false}
+        onToggleCollapsed={() => undefined}
+        sortedWorkspacesByProject={new Map([["/projects/demo-project", [parentWorkspace, task]]])}
+        workspaceRecency={{ parent: Date.now(), "alpha-1": Date.now() }}
+      />
+    );
+
+    // The persisted user toggle wins over the active-run default expansion.
+    expect(view.queryByTestId(agentItemTestId("alpha-1"))).toBeNull();
+
+    fireEvent.click(view.getByTestId("task-group-wfr_alpha"));
+
+    await waitFor(() => {
+      expect(view.getByTestId(agentItemTestId("alpha-1"))).toBeTruthy();
+    });
+    const persisted = JSON.parse(
+      window.localStorage.getItem("expandedTaskGroups") ?? "{}"
+    ) as Record<string, boolean>;
+    expect(persisted["workflow:parent:wfr_alpha"]).toBe(true);
+  });
+
+  test("active workflow groups reveal completed siblings hidden by completed-sub-agent filtering", () => {
+    window.localStorage.setItem(EXPANDED_PROJECTS_KEY, JSON.stringify(["/projects/demo-project"]));
+    projectContextValue = createProjectContextValue({
+      userProjects: new Map([["/projects/demo-project", { workspaces: [] }]]),
+      hasAnyProject: true,
+      resolveNewChatProjectPath: () => "/projects/demo-project",
+    });
+
+    const singleProjectRefs = [
+      { projectPath: "/projects/demo-project", projectName: "demo-project" },
+    ];
+    const parentWorkspace = {
+      ...createWorkspace("parent", { title: "Parent workspace" }),
+      projects: singleProjectRefs,
+    };
+    const completed = {
+      ...createWorkspace("done-1", {
+        parentWorkspaceId: "parent",
+        taskStatus: "reported",
+        title: "Extract claims",
+        workflowTask: { runId: "wfr_alpha", stepId: "claims" },
+      }),
+      projects: singleProjectRefs,
+    };
+    const running = {
+      ...createWorkspace("run-1", {
+        parentWorkspaceId: "parent",
+        taskStatus: "running",
+        title: "Verify claims",
+        workflowTask: { runId: "wfr_alpha", stepId: "verify" },
+      }),
+      projects: singleProjectRefs,
+    };
+
+    const view = render(
+      <ProjectSidebar
+        collapsed={false}
+        onToggleCollapsed={() => undefined}
+        sortedWorkspacesByProject={
+          new Map([["/projects/demo-project", [parentWorkspace, completed, running]]])
+        }
+        workspaceRecency={{ parent: Date.now(), "done-1": Date.now(), "run-1": Date.now() }}
+      />
+    );
+
+    // done-1 would normally be hidden (completed child, parent not expanded),
+    // but the active run keeps its full task list visible (D9).
+    expect(view.getByTestId(agentItemTestId("done-1")).dataset.connectorLayout).toBe(
+      "task-group-member"
+    );
+    expect(view.getByTestId(agentItemTestId("run-1"))).toBeTruthy();
+  });
+
+  test("renders a completed-only workflow group when a hidden member is selected and reveals it on expand", async () => {
+    window.localStorage.setItem(EXPANDED_PROJECTS_KEY, JSON.stringify(["/projects/demo-project"]));
+    projectContextValue = createProjectContextValue({
+      userProjects: new Map([["/projects/demo-project", { workspaces: [] }]]),
+      hasAnyProject: true,
+      resolveNewChatProjectPath: () => "/projects/demo-project",
+    });
+    spyOn(WorkspaceContextModule, "useWorkspaceActions").mockImplementation(
+      () =>
+        ({
+          selectedWorkspace: {
+            workspaceId: "done-1",
+            projectPath: "/projects/demo-project",
+            projectName: "demo-project",
+            namedWorkspacePath: "/projects/demo-project/done-1",
+          },
+          setSelectedWorkspace: () => undefined,
+          preflightArchiveWorkspace: preflightArchiveWorkspaceMock,
+          archiveWorkspace: archiveWorkspaceActionMock,
+          removeWorkspace: () => Promise.resolve({ success: true }),
+          updateWorkspaceTitle: () => Promise.resolve({ success: true }),
+          refreshWorkspaceMetadata: () => Promise.resolve(),
+          pendingNewWorkspaceProject: null,
+          pendingNewWorkspaceDraftId: null,
+          workspaceDraftsByProject: {},
+          workspaceDraftPromotionsByProject: {},
+          createWorkspaceDraft: () => undefined,
+          openWorkspaceDraft: () => undefined,
+          deleteWorkspaceDraft: () => undefined,
+        }) as unknown as ReturnType<typeof WorkspaceContextModule.useWorkspaceActions>
+    );
+
+    const singleProjectRefs = [
+      { projectPath: "/projects/demo-project", projectName: "demo-project" },
+    ];
+    const parentWorkspace = {
+      ...createWorkspace("parent", { title: "Parent workspace" }),
+      projects: singleProjectRefs,
+    };
+    // Two members so the run stays in the sidebar via its visible sibling; the
+    // selected one is hidden by completed-sub-agent filtering.
+    const hiddenSelected = {
+      ...createWorkspace("done-1", {
+        parentWorkspaceId: "parent",
+        taskStatus: "reported",
+        title: "Extract claims",
+        workflowTask: { runId: "wfr_alpha", stepId: "claims" },
+      }),
+      projects: singleProjectRefs,
+    };
+    const interrupted = {
+      ...createWorkspace("int-1", {
+        parentWorkspaceId: "parent",
+        taskStatus: "interrupted",
+        title: "Verify claims",
+        workflowTask: { runId: "wfr_alpha", stepId: "verify" },
+      }),
+      projects: singleProjectRefs,
+    };
+
+    const view = render(
+      <ProjectSidebar
+        collapsed={false}
+        onToggleCollapsed={() => undefined}
+        sortedWorkspacesByProject={
+          new Map([["/projects/demo-project", [parentWorkspace, hiddenSelected, interrupted]]])
+        }
+        workspaceRecency={{ parent: Date.now(), "done-1": Date.now(), "int-1": Date.now() }}
+      />
+    );
+
+    // Inactive group: default collapsed, but the header is marked selected for
+    // the hidden member.
+    const header = view.getByTestId("task-group-wfr_alpha");
+    expect(view.queryByTestId(agentItemTestId("done-1"))).toBeNull();
+
+    fireEvent.click(header);
+
+    await waitFor(() => {
+      // Expanding reveals the selected member even though completed-sub-agent
+      // filtering would normally hide it.
+      expect(view.getByTestId(agentItemTestId("done-1"))).toBeTruthy();
+      expect(view.getByTestId(agentItemTestId("int-1"))).toBeTruthy();
+    });
+  });
+
   test("does not coalesce a best-of group when one candidate still has hidden child tasks", () => {
     window.localStorage.setItem(EXPANDED_PROJECTS_KEY, JSON.stringify(["/projects/demo-project"]));
 

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
@@ -1407,6 +1407,49 @@ describe("ProjectSidebar multi-project completed-subagent toggles", () => {
     expect(view.getByTestId(agentItemTestId("run-1"))).toBeTruthy();
   });
 
+  test("keeps the workflow group mounted across step gaps where all members are terminal", () => {
+    window.localStorage.setItem(EXPANDED_PROJECTS_KEY, JSON.stringify(["/projects/demo-project"]));
+    projectContextValue = createProjectContextValue({
+      userProjects: new Map([["/projects/demo-project", { workspaces: [] }]]),
+      hasAnyProject: true,
+      resolveNewChatProjectPath: () => "/projects/demo-project",
+    });
+
+    const singleProjectRefs = [
+      { projectPath: "/projects/demo-project", projectName: "demo-project" },
+    ];
+    const parentWorkspace = {
+      ...createWorkspace("parent", { title: "Parent workspace" }),
+      projects: singleProjectRefs,
+    };
+    const step = (taskStatus: FrontendWorkspaceMetadata["taskStatus"]) => ({
+      ...createWorkspace("step-1", {
+        parentWorkspaceId: "parent",
+        taskStatus,
+        title: "Extract claims",
+        workflowTask: { runId: "wfr_alpha", stepId: "claims", workflowName: "review-pipeline" },
+      }),
+      projects: singleProjectRefs,
+    });
+
+    const renderProps = (child: FrontendWorkspaceMetadata) =>
+      ({
+        collapsed: false,
+        onToggleCollapsed: () => undefined,
+        sortedWorkspacesByProject: new Map([["/projects/demo-project", [parentWorkspace, child]]]),
+        workspaceRecency: { parent: Date.now(), "step-1": Date.now() },
+      }) as const;
+
+    const view = render(<ProjectSidebar {...renderProps(step("running"))} />);
+    expect(view.getByTestId("task-group-wfr_alpha")).toBeTruthy();
+
+    // Step gap: the only member finished, the next step hasn't spawned yet.
+    // The group must stay mounted (no flash-out) with its member visible.
+    view.rerender(<ProjectSidebar {...renderProps(step("reported"))} />);
+    expect(view.getByTestId("task-group-wfr_alpha")).toBeTruthy();
+    expect(view.getByTestId(agentItemTestId("step-1"))).toBeTruthy();
+  });
+
   test("renders a completed-only workflow group when a hidden member is selected and reveals it on expand", async () => {
     window.localStorage.setItem(EXPANDED_PROJECTS_KEY, JSON.stringify(["/projects/demo-project"]));
     projectContextValue = createProjectContextValue({

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
@@ -85,8 +85,10 @@ import {
 } from "../sidebarItemLayout";
 import { TaskGroupListItem } from "./TaskGroupListItem";
 import {
+  collectActiveWorkflowGroupKeys,
   computeSidebarTaskGroups,
   computeTaskGroupMemberRowMeta,
+  ensureWorkflowGroupMembersVisible,
   type SidebarTaskGroupsResult,
 } from "./sidebarTaskGroups";
 import { TitleEditProvider, useTitleEdit } from "@/browser/contexts/WorkspaceTitleEditContext";
@@ -2117,10 +2119,24 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                               }));
                               const depthByWorkspaceId =
                                 computeWorkspaceDepthMap(projectWorkspaces);
-                              const visibleWorkspacesForNormalRendering = filterVisibleAgentRows(
+                              // Track runs that are (or were, this session) active so their
+                              // groups stay mounted across step gaps where every member is
+                              // momentarily terminal (no flash-out between sequential steps).
+                              for (const key of collectActiveWorkflowGroupKeys(
                                 workspacesForNormalRendering,
-                                expandedCompletedParentIds
-                              );
+                                { isWorkspaceLiveActive }
+                              )) {
+                                sessionActiveTaskGroupKeysRef.current.add(key);
+                              }
+                              const visibleWorkspacesForNormalRendering =
+                                ensureWorkflowGroupMembersVisible({
+                                  allRows: workspacesForNormalRendering,
+                                  visibleRows: filterVisibleAgentRows(
+                                    workspacesForNormalRendering,
+                                    expandedCompletedParentIds
+                                  ),
+                                  sessionActiveGroupKeys: sessionActiveTaskGroupKeysRef.current,
+                                });
                               const baseRowMetaByWorkspaceId = computeAgentRowRenderMeta(
                                 workspacesForNormalRendering,
                                 depthByWorkspaceId,

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
@@ -52,7 +52,6 @@ import {
   AGE_THRESHOLDS_DAYS,
   computeWorkspaceDepthMap,
   computeDelegatedActivityByWorkspaceId,
-  isWorkspaceDelegatedActivityActive,
   filterVisibleAgentRows,
   computeAgentRowRenderMeta,
   findNextNonEmptyTier,
@@ -61,7 +60,9 @@ import {
   getSectionTierKey,
   resolveEffectiveSectionId,
   isRunningOrStartingTaskStatus,
+  computeRowMetaForVisibleNodes,
   type AgentRowRenderMeta,
+  type SidebarVisibleRowNode,
 } from "@/browser/utils/ui/workspaceFiltering";
 import { Tooltip, TooltipTrigger, TooltipContent } from "../Tooltip/Tooltip";
 import { SidebarCollapseButton } from "../SidebarCollapseButton/SidebarCollapseButton";
@@ -75,8 +76,19 @@ import { useSettings } from "@/browser/contexts/SettingsContext";
 import { normalizeTaskSettings } from "@/common/types/tasks";
 
 import { AgentListItem, type WorkspaceSelection } from "../AgentListItem/AgentListItem";
-import { getTaskGroupMemberDepth } from "../sidebarItemLayout";
+import { SubAgentListItem } from "../AgentListItem/SubAgentListItem";
+import {
+  getAncestorRailX,
+  getSubAgentChildStatusCenterX,
+  getSubAgentParentRailX,
+  getTaskGroupMemberDepth,
+} from "../sidebarItemLayout";
 import { TaskGroupListItem } from "./TaskGroupListItem";
+import {
+  computeSidebarTaskGroups,
+  computeTaskGroupMemberRowMeta,
+  type SidebarTaskGroupsResult,
+} from "./sidebarTaskGroups";
 import { TitleEditProvider, useTitleEdit } from "@/browser/contexts/WorkspaceTitleEditContext";
 import { useConfirmDialog } from "@/browser/contexts/ConfirmDialogContext";
 import { useProjectContext } from "@/browser/contexts/ProjectContext";
@@ -112,8 +124,6 @@ import { getErrorMessage } from "@/common/utils/errors";
 import { isMultiProject } from "@/common/utils/multiProject";
 import { MULTI_PROJECT_SIDEBAR_SECTION_ID } from "@/common/constants/multiProject";
 import { getProjectWorkspaceCounts } from "@/common/utils/projectRemoval";
-import { getTaskGroupKindFromMetadata } from "@/common/utils/tools/taskGroups";
-import { hasCompletedAgentReport } from "@/common/utils/agentTaskCompletion";
 import { useExperimentValue } from "@/browser/hooks/useExperiments";
 import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { HexColorPicker } from "react-colorful";
@@ -880,11 +890,20 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
     }
   }
 
-  const [expandedTaskGroups, setExpandedTaskGroups] = useState<Record<string, boolean>>({});
-  const toggleTaskGroupExpansion = (groupId: string) => {
+  // Task-group expansion survives reloads (D7). Keys are namespaced per group
+  // kind: task:<parentWorkspaceId>:<groupId> / workflow:<parentWorkspaceId>:<runId>.
+  const [expandedTaskGroups, setExpandedTaskGroups] = usePersistedState<Record<string, boolean>>(
+    "expandedTaskGroups",
+    {}
+  );
+  // D6: a workflow group that is (or was, this session) active defaults to
+  // expanded and must not auto-collapse when its members finish mid-session.
+  // The render-time ref keeps that default sticky; an explicit toggle wins.
+  const sessionActiveTaskGroupKeysRef = useRef<Set<string>>(new Set());
+  const toggleTaskGroupExpansion = (storageKey: string, isCurrentlyExpanded: boolean) => {
     setExpandedTaskGroups((prev) => ({
       ...prev,
-      [groupId]: !prev[groupId],
+      [storageKey]: !isCurrentlyExpanded,
     }));
   };
 
@@ -2159,7 +2178,8 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                                 rowRenderMetaOverride?: AgentRowRenderMeta | null,
                                 depthOverride?: number,
                                 keyOverride?: string,
-                                subAgentConnectorLayout?: "default" | "task-group-member"
+                                subAgentConnectorLayout?: "default" | "task-group-member",
+                                taskGroupHeaderTitle?: string
                               ) => {
                                 const rowRenderMeta =
                                   rowRenderMetaOverride === undefined
@@ -2192,6 +2212,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                                     sectionId={sectionId}
                                     rowRenderMeta={rowRenderMeta}
                                     subAgentConnectorLayout={subAgentConnectorLayout}
+                                    taskGroupHeaderTitle={taskGroupHeaderTitle}
                                     delegatedActivity={delegatedActivityByWorkspaceId.get(
                                       metadata.id
                                     )}
@@ -2205,108 +2226,27 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
 
                               const renderWorkspaceRowsWithTaskGroupCoalescing = ({
                                 rows,
-                                allRows,
                                 sectionId,
                                 rowMetaByWorkspaceId,
+                                taskGroups,
+                                memberMetaByWorkspaceId,
                               }: {
                                 rows: FrontendWorkspaceMetadata[];
-                                allRows: FrontendWorkspaceMetadata[];
                                 sectionId?: string;
                                 rowMetaByWorkspaceId: ReadonlyMap<string, AgentRowRenderMeta>;
+                                taskGroups: SidebarTaskGroupsResult;
+                                memberMetaByWorkspaceId: ReadonlyMap<string, AgentRowRenderMeta>;
                               }): React.ReactNode[] => {
-                                if (rows.length === 0) {
-                                  return [];
-                                }
-
-                                const childrenByParentId = new Map<
-                                  string,
-                                  FrontendWorkspaceMetadata[]
-                                >();
-                                for (const workspace of allRows) {
-                                  const parentId = workspace.parentWorkspaceId;
-                                  if (!parentId) {
-                                    continue;
-                                  }
-                                  const children = childrenByParentId.get(parentId) ?? [];
-                                  children.push(workspace);
-                                  childrenByParentId.set(parentId, children);
-                                }
-
-                                const getTaskGroupId = (
-                                  workspace: FrontendWorkspaceMetadata
-                                ): string | null => {
-                                  const groupId = workspace.bestOf?.groupId;
-                                  if (!groupId || !workspace.parentWorkspaceId) {
-                                    return null;
-                                  }
-                                  if ((workspace.bestOf?.total ?? 1) < 2) {
-                                    return null;
-                                  }
-                                  const hasChildren = childrenByParentId.has(workspace.id);
-                                  return hasChildren ? null : groupId;
-                                };
-
-                                const allMembersByGroupId = new Map<
-                                  string,
-                                  FrontendWorkspaceMetadata[]
-                                >();
-                                for (const workspace of allRows) {
-                                  const groupId = getTaskGroupId(workspace);
-                                  if (!groupId) {
-                                    continue;
-                                  }
-                                  const group = allMembersByGroupId.get(groupId) ?? [];
-                                  group.push(workspace);
-                                  allMembersByGroupId.set(groupId, group);
-                                }
-
-                                const visibleMembersByGroupId = new Map<
-                                  string,
-                                  FrontendWorkspaceMetadata[]
-                                >();
-                                for (const workspace of rows) {
-                                  const groupId = getTaskGroupId(workspace);
-                                  if (!groupId) {
-                                    continue;
-                                  }
-                                  const group = visibleMembersByGroupId.get(groupId) ?? [];
-                                  group.push(workspace);
-                                  visibleMembersByGroupId.set(groupId, group);
-                                }
-
-                                const indexByWorkspaceId = new Map(
-                                  rows.map((workspace, index) => [workspace.id, index] as const)
-                                );
-                                const validGroupIds = new Set<string>();
-                                for (const [groupId, visibleMembers] of visibleMembersByGroupId) {
-                                  const allMembers = allMembersByGroupId.get(groupId) ?? [];
-                                  if (visibleMembers.length < 2 || allMembers.length < 2) {
-                                    continue;
-                                  }
-                                  const indices = visibleMembers
-                                    .map((workspace) => indexByWorkspaceId.get(workspace.id))
-                                    .filter((index): index is number => index != null);
-                                  if (indices.length !== visibleMembers.length) {
-                                    continue;
-                                  }
-                                  const firstIndex = Math.min(...indices);
-                                  const lastIndex = Math.max(...indices);
-                                  if (lastIndex - firstIndex + 1 !== visibleMembers.length) {
-                                    continue;
-                                  }
-                                  validGroupIds.add(groupId);
-                                }
-
-                                const skippedWorkspaceIds = new Set<string>();
                                 const renderedRows: React.ReactNode[] = [];
 
                                 for (const workspace of rows) {
-                                  if (skippedWorkspaceIds.has(workspace.id)) {
-                                    continue;
-                                  }
-
-                                  const taskGroupId = getTaskGroupId(workspace);
-                                  if (!taskGroupId || !validGroupIds.has(taskGroupId)) {
+                                  const groupKey =
+                                    taskGroups.memberGroupStorageKeyByWorkspaceId.get(workspace.id);
+                                  const group =
+                                    groupKey != null
+                                      ? taskGroups.groupsByStorageKey.get(groupKey)
+                                      : undefined;
+                                  if (group == null) {
                                     renderedRows.push(
                                       renderWorkspace(
                                         workspace,
@@ -2317,105 +2257,101 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                                     continue;
                                   }
 
-                                  const visibleMembers =
-                                    visibleMembersByGroupId.get(taskGroupId) ?? [];
-                                  if (visibleMembers[0]?.id !== workspace.id) {
+                                  if (group.anchorId !== workspace.id) {
+                                    // Non-anchor members render under the group header at the
+                                    // anchor's position (D5), so suppress them here.
                                     continue;
                                   }
 
-                                  for (const member of visibleMembers) {
-                                    skippedWorkspaceIds.add(member.id);
-                                  }
+                                  const headerMeta = rowMetaByWorkspaceId.get(group.storageKey);
+                                  const headerDepth =
+                                    headerMeta?.depth ?? depthByWorkspaceId[workspace.id] ?? 0;
 
-                                  const sortTaskGroupMembers = (
-                                    members: FrontendWorkspaceMetadata[]
-                                  ): FrontendWorkspaceMetadata[] => {
-                                    return [...members].sort(
-                                      (left, right) =>
-                                        (left.bestOf?.index ?? Number.MAX_SAFE_INTEGER) -
-                                          (right.bestOf?.index ?? Number.MAX_SAFE_INTEGER) ||
-                                        left.id.localeCompare(right.id)
-                                    );
-                                  };
-                                  const allMembers = sortTaskGroupMembers(
-                                    allMembersByGroupId.get(taskGroupId) ?? visibleMembers
-                                  );
-                                  const sortedVisibleMembers = sortTaskGroupMembers(visibleMembers);
-                                  const depth =
-                                    rowMetaByWorkspaceId.get(workspace.id)?.depth ??
-                                    depthByWorkspaceId[workspace.id] ??
-                                    0;
-                                  const totalCount = Math.max(
-                                    allMembers[0]?.bestOf?.total ?? allMembers.length,
-                                    allMembers.length
-                                  );
-                                  const groupKind = getTaskGroupKindFromMetadata(
-                                    allMembers[0]?.bestOf
-                                  );
-                                  let completedCount = 0;
-                                  let runningCount = 0;
-                                  let queuedCount = 0;
-                                  let interruptedCount = 0;
-                                  for (const member of allMembers) {
-                                    const hasCompletedReport = hasCompletedAgentReport(member);
-                                    if (hasCompletedReport) {
-                                      completedCount += 1;
-                                      continue;
-                                    }
-                                    if (
-                                      isWorkspaceDelegatedActivityActive(member, {
-                                        isWorkspaceLiveActive,
-                                      })
-                                    ) {
-                                      runningCount += 1;
-                                      continue;
-                                    }
-                                    if (member.taskStatus === "queued") {
-                                      queuedCount += 1;
-                                      continue;
-                                    }
-                                    if (member.taskStatus === "interrupted") {
-                                      interruptedCount += 1;
-                                    }
+                                  // D6: groups seen active this session keep defaulting to
+                                  // expanded - no live auto-collapse on completion. An explicit
+                                  // (persisted) user toggle always wins.
+                                  if (group.kind === "workflow" && group.hasActiveMember) {
+                                    sessionActiveTaskGroupKeysRef.current.add(group.storageKey);
                                   }
-                                  const groupTitle =
-                                    allMembers[0]?.title ?? allMembers[0]?.name ?? "Task group";
-                                  const isExpanded = expandedTaskGroups[taskGroupId] ?? false;
+                                  const defaultExpanded =
+                                    group.kind === "workflow" &&
+                                    (group.hasActiveMember ||
+                                      sessionActiveTaskGroupKeysRef.current.has(group.storageKey));
+                                  const isExpanded =
+                                    expandedTaskGroups[group.storageKey] ?? defaultExpanded;
+                                  const isGroupSelected = group.allMembers.some(
+                                    (member) => member.id === selectedWorkspace?.workspaceId
+                                  );
 
-                                  renderedRows.push(
+                                  const headerRow = (
                                     <TaskGroupListItem
-                                      key={`task-group:${taskGroupId}`}
-                                      groupId={taskGroupId}
-                                      title={groupTitle}
-                                      kind={groupKind}
+                                      groupId={group.id}
+                                      title={group.title}
+                                      kind={group.kind}
                                       sectionId={sectionId}
-                                      depth={depth}
-                                      totalCount={totalCount}
-                                      visibleCount={sortedVisibleMembers.length}
-                                      completedCount={completedCount}
-                                      runningCount={runningCount}
-                                      queuedCount={queuedCount}
-                                      interruptedCount={interruptedCount}
+                                      depth={headerDepth}
+                                      totalCount={group.totalCount}
+                                      visibleCount={group.displayMembers.length}
+                                      completedCount={group.completedCount}
+                                      runningCount={group.runningCount}
+                                      queuedCount={group.queuedCount}
+                                      interruptedCount={group.interruptedCount}
                                       isExpanded={isExpanded}
-                                      isSelected={allMembers.some(
-                                        (member) => member.id === selectedWorkspace?.workspaceId
-                                      )}
+                                      isSelected={isGroupSelected}
                                       onToggle={() => {
-                                        toggleTaskGroupExpansion(taskGroupId);
+                                        toggleTaskGroupExpansion(group.storageKey, isExpanded);
                                       }}
                                     />
                                   );
 
+                                  // Wrap the header in the same connector rail used by agent
+                                  // rows so trunks continue through the group header.
+                                  renderedRows.push(
+                                    headerMeta != null ? (
+                                      <SubAgentListItem
+                                        key={`task-group:${group.storageKey}`}
+                                        connectorPosition={headerMeta.connectorPosition}
+                                        connectorStartsAtParent={headerMeta.connectorStartsAtParent}
+                                        sharedTrunkActiveThroughRow={
+                                          headerMeta.sharedTrunkActiveThroughRow
+                                        }
+                                        sharedTrunkActiveBelowRow={
+                                          headerMeta.sharedTrunkActiveBelowRow
+                                        }
+                                        ancestorTrunks={headerMeta.ancestorTrunks.map((trunk) => ({
+                                          left: getAncestorRailX(trunk.depth, "default"),
+                                          active: trunk.active,
+                                        }))}
+                                        connectorRailX={getSubAgentParentRailX(
+                                          headerDepth,
+                                          "default"
+                                        )}
+                                        childStatusCenterX={getSubAgentChildStatusCenterX(
+                                          headerDepth
+                                        )}
+                                        isSelected={isGroupSelected}
+                                        isElbowActive={group.runningCount > 0}
+                                      >
+                                        {headerRow}
+                                      </SubAgentListItem>
+                                    ) : (
+                                      <React.Fragment key={`task-group:${group.storageKey}`}>
+                                        {headerRow}
+                                      </React.Fragment>
+                                    )
+                                  );
+
                                   if (isExpanded) {
-                                    for (const member of sortedVisibleMembers) {
+                                    for (const member of group.displayMembers) {
                                       renderedRows.push(
                                         renderWorkspace(
                                           member,
                                           sectionId,
-                                          rowMetaByWorkspaceId.get(member.id) ?? null,
-                                          getTaskGroupMemberDepth(depth),
-                                          `task-group-member:${taskGroupId}:${member.id}`,
-                                          "task-group-member"
+                                          memberMetaByWorkspaceId.get(member.id) ?? null,
+                                          getTaskGroupMemberDepth(headerDepth),
+                                          `task-group-member:${group.storageKey}:${member.id}`,
+                                          "task-group-member",
+                                          group.title
                                         )
                                       );
                                     }
@@ -2536,116 +2472,92 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                                 const visibleRows = workspaces.filter((workspace) =>
                                   visibleRowIds.has(workspace.id)
                                 );
-                                const visibleRowsById = new Map(
-                                  visibleRows.map((workspace) => [workspace.id, workspace])
-                                );
-                                const visibleChildrenByParent = new Map<
-                                  string,
-                                  FrontendWorkspaceMetadata[]
-                                >();
+                                // Coalesce grouped task rows (variants/best-of + workflow runs)
+                                // before deriving connector geometry: headers join the row model
+                                // as synthetic nodes so trunks/elbows stay continuous (D5).
+                                const taskGroups = computeSidebarTaskGroups({
+                                  rows: visibleRows,
+                                  allRows: allRowsForTaskGroupCoalescing,
+                                  selectedWorkspaceId: selectedWorkspace?.workspaceId,
+                                  isWorkspaceLiveActive,
+                                });
+
+                                const rowNodes: SidebarVisibleRowNode[] = [];
+                                const seenGroupKeys = new Set<string>();
                                 for (const workspace of visibleRows) {
-                                  const parentId = workspace.parentWorkspaceId;
-                                  if (!parentId) {
-                                    continue;
-                                  }
-
-                                  const siblings = visibleChildrenByParent.get(parentId) ?? [];
-                                  siblings.push(workspace);
-                                  visibleChildrenByParent.set(parentId, siblings);
-                                }
-
-                                const rowMetaByVisibleWorkspaceId = new Map<
-                                  string,
-                                  AgentRowRenderMeta
-                                >();
-                                for (const workspace of visibleRows) {
-                                  const baseRowMeta = baseRowMetaByWorkspaceId.get(workspace.id);
-                                  if (!baseRowMeta) {
-                                    continue;
-                                  }
-
-                                  const parentId = workspace.parentWorkspaceId;
-                                  if (!parentId) {
-                                    rowMetaByVisibleWorkspaceId.set(workspace.id, {
-                                      ...baseRowMeta,
-                                      ancestorTrunks: [],
+                                  const groupKey =
+                                    taskGroups.memberGroupStorageKeyByWorkspaceId.get(workspace.id);
+                                  const group =
+                                    groupKey != null
+                                      ? taskGroups.groupsByStorageKey.get(groupKey)
+                                      : undefined;
+                                  if (group != null) {
+                                    if (seenGroupKeys.has(group.storageKey)) {
+                                      continue;
+                                    }
+                                    seenGroupKeys.add(group.storageKey);
+                                    const headerDepth =
+                                      baseRowMetaByWorkspaceId.get(workspace.id)?.depth ??
+                                      depthByWorkspaceId[workspace.id] ??
+                                      0;
+                                    rowNodes.push({
+                                      id: group.storageKey,
+                                      parentId: group.parentWorkspaceId,
+                                      depth: headerDepth,
+                                      isRunning: group.runningCount > 0,
+                                      baseMeta: {
+                                        depth: headerDepth,
+                                        rowKind: "subagent",
+                                        connectorPosition: "single",
+                                        connectorStartsAtParent: false,
+                                        sharedTrunkActiveThroughRow: false,
+                                        sharedTrunkActiveBelowRow: false,
+                                        ancestorTrunks: [],
+                                        hasHiddenCompletedChildren: false,
+                                        visibleCompletedChildrenCount: 0,
+                                      },
                                     });
                                     continue;
                                   }
 
-                                  const siblings = visibleChildrenByParent.get(parentId) ?? [];
-                                  const siblingIndex = siblings.findIndex(
-                                    (sibling) => sibling.id === workspace.id
-                                  );
-                                  let connectorPosition: AgentRowRenderMeta["connectorPosition"] =
-                                    "single";
-                                  if (siblings.length > 1) {
-                                    connectorPosition =
-                                      siblings[siblings.length - 1]?.id === workspace.id
-                                        ? "last"
-                                        : "middle";
+                                  const baseRowMeta = baseRowMetaByWorkspaceId.get(workspace.id);
+                                  if (!baseRowMeta) {
+                                    continue;
                                   }
-
-                                  let lastRunningSiblingIndex = -1;
-                                  for (let index = siblings.length - 1; index >= 0; index -= 1) {
-                                    if (
-                                      isRunningOrStartingTaskStatus(siblings[index]?.taskStatus)
-                                    ) {
-                                      lastRunningSiblingIndex = index;
-                                      break;
-                                    }
-                                  }
-
-                                  const connectorStartsAtParent = siblingIndex === 0;
-                                  const sharedTrunkActiveThroughRow =
-                                    siblingIndex >= 0 &&
-                                    lastRunningSiblingIndex >= 0 &&
-                                    siblingIndex <= lastRunningSiblingIndex;
-                                  const sharedTrunkActiveBelowRow =
-                                    siblingIndex >= 0 &&
-                                    lastRunningSiblingIndex >= 0 &&
-                                    siblingIndex < lastRunningSiblingIndex;
-
-                                  const ancestorTrunks: Array<{
-                                    depth: number;
-                                    active: boolean;
-                                  }> = [];
-                                  const visitedAncestorIds = new Set<string>();
-                                  let ancestorId: string | undefined = parentId;
-                                  while (ancestorId && !visitedAncestorIds.has(ancestorId)) {
-                                    visitedAncestorIds.add(ancestorId);
-
-                                    const ancestorWorkspace = visibleRowsById.get(ancestorId);
-                                    if (!ancestorWorkspace) {
-                                      break;
-                                    }
-
-                                    const ancestorMeta =
-                                      rowMetaByVisibleWorkspaceId.get(ancestorId) ??
-                                      baseRowMetaByWorkspaceId.get(ancestorId);
-                                    const ancestorDepth = depthByWorkspaceId[ancestorId] ?? 0;
-                                    if (
-                                      ancestorDepth > 0 &&
-                                      ancestorMeta?.connectorPosition === "middle"
-                                    ) {
-                                      ancestorTrunks.push({
-                                        depth: ancestorDepth,
-                                        active: ancestorMeta.sharedTrunkActiveBelowRow,
-                                      });
-                                    }
-
-                                    ancestorId = ancestorWorkspace.parentWorkspaceId;
-                                  }
-                                  ancestorTrunks.sort((left, right) => left.depth - right.depth);
-
-                                  rowMetaByVisibleWorkspaceId.set(workspace.id, {
-                                    ...baseRowMeta,
-                                    connectorPosition,
-                                    connectorStartsAtParent,
-                                    sharedTrunkActiveThroughRow,
-                                    sharedTrunkActiveBelowRow,
-                                    ancestorTrunks,
+                                  rowNodes.push({
+                                    id: workspace.id,
+                                    parentId: workspace.parentWorkspaceId,
+                                    depth: baseRowMeta.depth,
+                                    isRunning: isRunningOrStartingTaskStatus(workspace.taskStatus),
+                                    baseMeta: baseRowMeta,
                                   });
+                                }
+                                const rowMetaByVisibleWorkspaceId =
+                                  computeRowMetaForVisibleNodes(rowNodes);
+
+                                // Expanded members hang off their header row, so their connector
+                                // meta derives from the header's computed geometry.
+                                const memberMetaByWorkspaceId = new Map<
+                                  string,
+                                  AgentRowRenderMeta
+                                >();
+                                for (const group of taskGroups.groupsByStorageKey.values()) {
+                                  const headerMeta = rowMetaByVisibleWorkspaceId.get(
+                                    group.storageKey
+                                  );
+                                  if (headerMeta == null) {
+                                    continue;
+                                  }
+                                  for (const [
+                                    memberId,
+                                    memberMeta,
+                                  ] of computeTaskGroupMemberRowMeta({
+                                    group,
+                                    headerMeta,
+                                    headerDepth: headerMeta.depth,
+                                  })) {
+                                    memberMetaByWorkspaceId.set(memberId, memberMeta);
+                                  }
                                 }
 
                                 const renderTier = (tierIndex: number): React.ReactNode => {
@@ -2702,9 +2614,10 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                                         <>
                                           {renderWorkspaceRowsWithTaskGroupCoalescing({
                                             rows: bucket,
-                                            allRows: allRowsForTaskGroupCoalescing,
                                             sectionId,
                                             rowMetaByWorkspaceId: rowMetaByVisibleWorkspaceId,
+                                            taskGroups,
+                                            memberMetaByWorkspaceId,
                                           })}
                                           {(() => {
                                             const nextTier = findNextNonEmptyTier(
@@ -2723,9 +2636,10 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                                   <>
                                     {renderWorkspaceRowsWithTaskGroupCoalescing({
                                       rows: topVisibleRows,
-                                      allRows: allRowsForTaskGroupCoalescing,
                                       sectionId,
                                       rowMetaByWorkspaceId: rowMetaByVisibleWorkspaceId,
+                                      taskGroups,
+                                      memberMetaByWorkspaceId,
                                     })}
                                     {firstTier !== -1 && renderTier(firstTier)}
                                   </>

--- a/src/browser/components/ProjectSidebar/TaskGroupListItem.test.tsx
+++ b/src/browser/components/ProjectSidebar/TaskGroupListItem.test.tsx
@@ -63,4 +63,18 @@ describe("TaskGroupListItem", () => {
     );
     expect(groupRow.textContent).toContain("1 queued");
   });
+
+  test("aggregates member state into the shared status-dot language", () => {
+    // Running wins over interrupted: the group is still making progress.
+    const running = renderTaskGroup({ runningCount: 1, interruptedCount: 1 });
+    expect(running.getByTestId("task-group-best-of-demo").dataset.aggregateState).toBe("active");
+    cleanup();
+
+    const interrupted = renderTaskGroup({ interruptedCount: 1, completedCount: 2 });
+    expect(interrupted.getByTestId("task-group-best-of-demo").dataset.aggregateState).toBe("error");
+    cleanup();
+
+    const completed = renderTaskGroup({ completedCount: 3 });
+    expect(completed.getByTestId("task-group-best-of-demo").dataset.aggregateState).toBe("idle");
+  });
 });

--- a/src/browser/components/ProjectSidebar/TaskGroupListItem.tsx
+++ b/src/browser/components/ProjectSidebar/TaskGroupListItem.tsx
@@ -1,17 +1,18 @@
-import { ChevronRight, Layers3 } from "lucide-react";
+import { ChevronRight, Layers3, Workflow } from "lucide-react";
 
+import { StatusDot, type VisualState } from "@/browser/components/AgentListItem/StatusDot";
 import { getSidebarItemPaddingLeft } from "@/browser/components/sidebarItemLayout";
 import { cn } from "@/common/lib/utils";
 import {
-  formatTaskGroupHeader,
-  formatTaskGroupItemsLabel,
-  type TaskGroupKind,
-} from "@/common/utils/tools/taskGroups";
+  formatSidebarTaskGroupHeader,
+  formatSidebarTaskGroupItemsLabel,
+  type SidebarGroupKind,
+} from "./sidebarTaskGroups";
 
 interface TaskGroupListItemProps {
   groupId: string;
   title: string;
-  kind: TaskGroupKind;
+  kind: SidebarGroupKind;
   sectionId?: string;
   depth: number;
   totalCount: number;
@@ -25,10 +26,28 @@ interface TaskGroupListItemProps {
   onToggle: () => void;
 }
 
+/**
+ * Aggregate member state in the same visual language as agent rows. Running
+ * wins over interrupted: while any member still works the group is making
+ * progress, so the error-ish interrupted state only surfaces once nothing is
+ * running anymore.
+ */
+function getAggregateVisualState(props: TaskGroupListItemProps): VisualState {
+  if (props.runningCount > 0) {
+    return "active";
+  }
+  if (props.interruptedCount > 0) {
+    return "error";
+  }
+  return "idle";
+}
+
 export function TaskGroupListItem(props: TaskGroupListItemProps) {
   const hasRunningWork = props.runningCount > 0;
+  const aggregateState = getAggregateVisualState(props);
   const statusDescriptionId = `task-group-status-${props.groupId}`;
   const paddingLeft = getSidebarItemPaddingLeft(props.depth);
+  const KindGlyph = props.kind === "workflow" ? Workflow : Layers3;
   const statusParts: string[] = [];
   if (props.runningCount > 0) {
     statusParts.push(`${props.runningCount} running`);
@@ -55,8 +74,9 @@ export function TaskGroupListItem(props: TaskGroupListItemProps) {
       aria-describedby={statusDescriptionId}
       data-testid={`task-group-${props.groupId}`}
       data-running={hasRunningWork}
+      data-aggregate-state={aggregateState}
       className={cn(
-        "bg-surface-primary relative flex items-start gap-1.5 rounded-l-sm py-2 pr-2 pl-1 select-none transition-all duration-150 hover:bg-surface-secondary",
+        "bg-surface-primary relative flex items-start rounded-l-sm py-2 pr-2 select-none transition-all duration-150 hover:bg-surface-secondary",
         props.sectionId != null ? "ml-2" : "ml-0",
         hasRunningWork && "bg-surface-secondary",
         props.isSelected && "bg-surface-secondary"
@@ -72,33 +92,41 @@ export function TaskGroupListItem(props: TaskGroupListItemProps) {
         }
       }}
     >
+      {/* Leading slot mirrors agent rows: the sub-agent connector elbow lands on
+          the status dot center, so the header reads as part of the tree. */}
+      <StatusDot state={aggregateState} isSubAgent />
+      {/* Expanded member rows keep their shared rail one-and-a-half indent steps
+          in (getTaskGroupMemberDepth), which is exactly this chevron's center -
+          the disclosure control visually anchors the member trunk. */}
       <span
         aria-hidden="true"
-        className="text-muted mt-0.5 -ml-2.5 inline-flex h-4 w-4 shrink-0 items-center justify-center"
+        className="text-muted -ml-0.5 inline-flex w-3 shrink-0 items-center justify-center self-center"
+        data-testid="task-group-chevron"
       >
         <ChevronRight
           className="h-3 w-3 transition-transform duration-150"
           style={{ transform: props.isExpanded ? "rotate(90deg)" : "rotate(0deg)" }}
         />
       </span>
-      <div
-        className={cn(
-          "text-muted mt-[3px] flex h-4 w-4 shrink-0 items-center justify-center",
-          hasRunningWork && "text-content-success"
-        )}
-        data-testid="task-group-status-icon"
-      >
-        <Layers3 className="h-3 w-3" />
-      </div>
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+      <div className="ml-1.5 flex min-w-0 flex-1 flex-col gap-0.5">
         <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1.5">
-          <span
-            className={cn(
-              "min-w-0 truncate text-left text-[14px] leading-6",
-              hasRunningWork ? "text-content-primary" : "text-foreground"
-            )}
-          >
-            {formatTaskGroupHeader(props.kind, props.totalCount, props.title)}
+          <span className="flex min-w-0 items-center gap-1.5">
+            <KindGlyph
+              aria-hidden="true"
+              className={cn(
+                "h-3 w-3 shrink-0",
+                hasRunningWork ? "text-content-success" : "text-muted"
+              )}
+              data-testid="task-group-status-icon"
+            />
+            <span
+              className={cn(
+                "min-w-0 truncate text-left text-[14px] leading-6",
+                hasRunningWork ? "text-content-primary" : "text-foreground"
+              )}
+            >
+              {formatSidebarTaskGroupHeader(props.kind, props.totalCount, props.title)}
+            </span>
           </span>
           <span className="text-muted text-[11px]">
             {props.completedCount}/{props.totalCount}
@@ -112,7 +140,7 @@ export function TaskGroupListItem(props: TaskGroupListItemProps) {
             statusParts.map((part) => <span key={part}>{part}</span>)
           ) : (
             <span>
-              {props.totalCount} {formatTaskGroupItemsLabel(props.kind).toLowerCase()}
+              {props.totalCount} {formatSidebarTaskGroupItemsLabel(props.kind).toLowerCase()}
             </span>
           )}
         </div>

--- a/src/browser/components/ProjectSidebar/sidebarTaskGroups.test.ts
+++ b/src/browser/components/ProjectSidebar/sidebarTaskGroups.test.ts
@@ -4,8 +4,10 @@ import type { AgentRowRenderMeta } from "@/browser/utils/ui/workspaceFiltering";
 import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import {
+  collectActiveWorkflowGroupKeys,
   computeSidebarTaskGroups,
   computeTaskGroupMemberRowMeta,
+  ensureWorkflowGroupMembersVisible,
   shortenWorkflowRunId,
 } from "./sidebarTaskGroups";
 
@@ -173,6 +175,68 @@ describe("computeSidebarTaskGroups", () => {
 
     expect(group?.queuedCount).toBe(1);
     expect(group?.hasActiveMember).toBe(true);
+  });
+});
+
+describe("workflow group session stickiness", () => {
+  test("collectActiveWorkflowGroupKeys reports runs with non-terminal members only", () => {
+    const running = workflowChild("running", "wfr_alpha", { taskStatus: "running" });
+    const done = workflowChild("done", "wfr_beta", { taskStatus: "reported" });
+    const queued = workflowChild("queued", "wfr_gamma", { taskStatus: "queued" });
+
+    const keys = collectActiveWorkflowGroupKeys([parent, running, done, queued]);
+
+    expect(keys.has("workflow:parent:wfr_alpha")).toBe(true);
+    expect(keys.has("workflow:parent:wfr_beta")).toBe(false);
+    expect(keys.has("workflow:parent:wfr_gamma")).toBe(true);
+  });
+
+  test("re-includes hidden members of session-active runs so the group never unmounts", () => {
+    // Step gap: the only member is terminal and hidden by completed-sub-agent
+    // filtering, but the run was active earlier this session.
+    const done = workflowChild("done", "wfr_alpha", { taskStatus: "reported" });
+    const other = createWorkspace("other", { parentWorkspaceId: "parent" });
+    const allRows = [parent, done, other];
+    const visibleRows = [parent, other];
+
+    const result = ensureWorkflowGroupMembersVisible({
+      allRows,
+      visibleRows,
+      sessionActiveGroupKeys: new Set(["workflow:parent:wfr_alpha"]),
+    });
+
+    // Original order preserved.
+    expect(result.map((w) => w.id)).toEqual(["parent", "done", "other"]);
+
+    // Non-sticky runs stay hidden.
+    const untouched = ensureWorkflowGroupMembersVisible({
+      allRows,
+      visibleRows,
+      sessionActiveGroupKeys: new Set(["workflow:parent:wfr_other"]),
+    });
+    expect(untouched.map((w) => w.id)).toEqual(["parent", "other"]);
+  });
+
+  test("never resurrects members whose parent is hidden or that have their own subtree", () => {
+    const done = workflowChild("done", "wfr_alpha", { taskStatus: "reported" });
+    const grandchild = createWorkspace("grandchild", { parentWorkspaceId: "done" });
+    const sticky = new Set(["workflow:parent:wfr_alpha"]);
+
+    // Member has children (leaf-only rule) => not re-included.
+    const withSubtree = ensureWorkflowGroupMembersVisible({
+      allRows: [parent, done, grandchild],
+      visibleRows: [parent],
+      sessionActiveGroupKeys: sticky,
+    });
+    expect(withSubtree.map((w) => w.id)).toEqual(["parent"]);
+
+    // Parent itself hidden => member stays hidden.
+    const parentHidden = ensureWorkflowGroupMembersVisible({
+      allRows: [parent, done],
+      visibleRows: [],
+      sessionActiveGroupKeys: sticky,
+    });
+    expect(parentHidden).toEqual([]);
   });
 });
 

--- a/src/browser/components/ProjectSidebar/sidebarTaskGroups.test.ts
+++ b/src/browser/components/ProjectSidebar/sidebarTaskGroups.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from "bun:test";
+
+import type { AgentRowRenderMeta } from "@/browser/utils/ui/workspaceFiltering";
+import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
+import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
+import {
+  computeSidebarTaskGroups,
+  computeTaskGroupMemberRowMeta,
+  shortenWorkflowRunId,
+} from "./sidebarTaskGroups";
+
+function createWorkspace(
+  id: string,
+  opts?: {
+    parentWorkspaceId?: string;
+    taskStatus?: FrontendWorkspaceMetadata["taskStatus"];
+    title?: string;
+    createdAt?: string;
+    bestOf?: FrontendWorkspaceMetadata["bestOf"];
+    workflowTask?: FrontendWorkspaceMetadata["workflowTask"];
+  }
+): FrontendWorkspaceMetadata {
+  return {
+    id,
+    name: `${id}-name`,
+    title: opts?.title ?? id,
+    projectName: "demo",
+    projectPath: "/projects/demo",
+    namedWorkspacePath: `/projects/demo/${id}`,
+    runtimeConfig: DEFAULT_RUNTIME_CONFIG,
+    createdAt: opts?.createdAt,
+    parentWorkspaceId: opts?.parentWorkspaceId,
+    taskStatus: opts?.taskStatus,
+    bestOf: opts?.bestOf,
+    workflowTask: opts?.workflowTask,
+  };
+}
+
+const parent = createWorkspace("parent");
+
+function workflowChild(
+  id: string,
+  runId: string,
+  opts?: {
+    taskStatus?: FrontendWorkspaceMetadata["taskStatus"];
+    createdAt?: string;
+    workflowName?: string;
+    title?: string;
+  }
+): FrontendWorkspaceMetadata {
+  return createWorkspace(id, {
+    parentWorkspaceId: "parent",
+    taskStatus: opts?.taskStatus ?? "running",
+    createdAt: opts?.createdAt,
+    title: opts?.title,
+    workflowTask: {
+      runId,
+      stepId: `${id}-step`,
+      workflowName: opts?.workflowName,
+    },
+  });
+}
+
+describe("computeSidebarTaskGroups", () => {
+  test("groups workflow tasks per runId from the first member, separating concurrent runs", () => {
+    const a1 = workflowChild("a1", "wfr_alpha", { workflowName: "review-pipeline" });
+    const b1 = workflowChild("b1", "wfr_beta");
+    const a2 = workflowChild("a2", "wfr_alpha");
+    const single = workflowChild("solo", "wfr_solo");
+    const rows = [parent, a1, b1, a2, single];
+
+    const result = computeSidebarTaskGroups({ rows, allRows: rows });
+
+    const alpha = result.groupsByStorageKey.get("workflow:parent:wfr_alpha");
+    const beta = result.groupsByStorageKey.get("workflow:parent:wfr_beta");
+    const solo = result.groupsByStorageKey.get("workflow:parent:wfr_solo");
+    expect(alpha).toBeDefined();
+    expect(beta).toBeDefined();
+    // Single-member workflow groups form immediately (no min-2 rule).
+    expect(solo).toBeDefined();
+    // Non-contiguous members (b1 interleaves) still gather under one header.
+    expect(alpha?.displayMembers.map((m) => m.id)).toEqual(["a1", "a2"]);
+    expect(alpha?.anchorId).toBe("a1");
+    expect(alpha?.title).toBe("review-pipeline");
+    // Run without a stamped name falls back to the shortened run id.
+    expect(beta?.title).toBe(shortenWorkflowRunId("wfr_beta"));
+    expect(result.memberGroupStorageKeyByWorkspaceId.get("a2")).toBe("workflow:parent:wfr_alpha");
+    expect(result.memberGroupStorageKeyByWorkspaceId.get("b1")).toBe("workflow:parent:wfr_beta");
+  });
+
+  test("bestOf grouping wins over workflow metadata and keeps the contiguity rule", () => {
+    const both = createWorkspace("both", {
+      parentWorkspaceId: "parent",
+      taskStatus: "running",
+      bestOf: { groupId: "bg", index: 0, total: 2 },
+      workflowTask: { runId: "wfr_alpha", stepId: "s" },
+    });
+    const sibling = createWorkspace("sibling", {
+      parentWorkspaceId: "parent",
+      taskStatus: "running",
+      bestOf: { groupId: "bg", index: 1, total: 2 },
+    });
+    // A non-member row between the two best-of members breaks contiguity.
+    const interloper = createWorkspace("interloper", { parentWorkspaceId: "parent" });
+    const contiguous = [parent, both, sibling, interloper];
+    const interleaved = [parent, both, interloper, sibling];
+
+    const grouped = computeSidebarTaskGroups({ rows: contiguous, allRows: contiguous });
+    expect(grouped.memberGroupStorageKeyByWorkspaceId.get("both")).toBe("task:parent:bg");
+    expect(grouped.groupsByStorageKey.get("workflow:parent:wfr_alpha")).toBeUndefined();
+
+    const broken = computeSidebarTaskGroups({ rows: interleaved, allRows: interleaved });
+    expect(broken.groupsByStorageKey.size).toBe(0);
+  });
+
+  test("excludes members that spawned their own sub-agents (leaf-only rule)", () => {
+    const member = workflowChild("member", "wfr_alpha");
+    const grandchild = createWorkspace("grandchild", { parentWorkspaceId: "member" });
+    const rows = [parent, member, grandchild];
+
+    const result = computeSidebarTaskGroups({ rows, allRows: rows });
+
+    expect(result.groupsByStorageKey.size).toBe(0);
+  });
+
+  test("active workflow groups display hidden completed siblings; inactive ones do not", () => {
+    const done = workflowChild("done", "wfr_alpha", {
+      taskStatus: "reported",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    const running = workflowChild("running", "wfr_alpha", {
+      taskStatus: "running",
+      createdAt: "2026-01-01T00:01:00.000Z",
+    });
+    const allRows = [parent, done, running];
+    // Completed-sub-agent filtering hid "done" from the visible rows.
+    const visibleRows = [parent, running];
+
+    const active = computeSidebarTaskGroups({ rows: visibleRows, allRows });
+    const activeGroup = active.groupsByStorageKey.get("workflow:parent:wfr_alpha");
+    expect(activeGroup?.hasActiveMember).toBe(true);
+    expect(activeGroup?.displayMembers.map((m) => m.id)).toEqual(["done", "running"]);
+
+    // Same run, fully terminal: hidden completed members stay hidden...
+    const doneToo = { ...running, taskStatus: "reported" as const };
+    const inactive = computeSidebarTaskGroups({
+      rows: [parent, doneToo],
+      allRows: [parent, done, doneToo],
+    });
+    const inactiveGroup = inactive.groupsByStorageKey.get("workflow:parent:wfr_alpha");
+    expect(inactiveGroup?.hasActiveMember).toBe(false);
+    expect(inactiveGroup?.displayMembers.map((m) => m.id)).toEqual(["running"]);
+
+    // ...unless one of them is selected, which must stay reachable on expand.
+    const withSelection = computeSidebarTaskGroups({
+      rows: [parent, doneToo],
+      allRows: [parent, done, doneToo],
+      selectedWorkspaceId: "done",
+    });
+    expect(
+      withSelection.groupsByStorageKey
+        .get("workflow:parent:wfr_alpha")
+        ?.displayMembers.map((m) => m.id)
+    ).toEqual(["done", "running"]);
+  });
+
+  test("counts queued members as active so new runs default to expanded", () => {
+    const queued = workflowChild("queued", "wfr_alpha", { taskStatus: "queued" });
+    const rows = [parent, queued];
+
+    const result = computeSidebarTaskGroups({ rows, allRows: rows });
+    const group = result.groupsByStorageKey.get("workflow:parent:wfr_alpha");
+
+    expect(group?.queuedCount).toBe(1);
+    expect(group?.hasActiveMember).toBe(true);
+  });
+});
+
+describe("computeTaskGroupMemberRowMeta", () => {
+  const headerMetaBase: AgentRowRenderMeta = {
+    depth: 1,
+    rowKind: "subagent",
+    connectorPosition: "middle",
+    connectorStartsAtParent: true,
+    sharedTrunkActiveThroughRow: true,
+    sharedTrunkActiveBelowRow: true,
+    ancestorTrunks: [{ depth: 1, active: false }],
+    hasHiddenCompletedChildren: false,
+    visibleCompletedChildrenCount: 0,
+  };
+
+  test("members form a sibling run under the header and inherit its trunks", () => {
+    const first = workflowChild("first", "wfr_alpha", { taskStatus: "reported" });
+    const second = workflowChild("second", "wfr_alpha", { taskStatus: "running" });
+    const rows = [parent, first, second];
+    const group = computeSidebarTaskGroups({ rows, allRows: rows }).groupsByStorageKey.get(
+      "workflow:parent:wfr_alpha"
+    );
+    expect(group).toBeDefined();
+
+    const meta = computeTaskGroupMemberRowMeta({
+      group: group!,
+      headerMeta: headerMetaBase,
+      headerDepth: 1,
+    });
+
+    const firstMeta = meta.get("first");
+    const secondMeta = meta.get("second");
+    expect(firstMeta?.connectorPosition).toBe("middle");
+    expect(firstMeta?.connectorStartsAtParent).toBe(true);
+    // Trunk animates down to the lowest running member.
+    expect(firstMeta?.sharedTrunkActiveThroughRow).toBe(true);
+    expect(firstMeta?.sharedTrunkActiveBelowRow).toBe(true);
+    expect(secondMeta?.connectorPosition).toBe("last");
+    expect(secondMeta?.sharedTrunkActiveBelowRow).toBe(false);
+    // Header is a middle sibling, so its trunk continues through member rows.
+    expect(firstMeta?.ancestorTrunks).toEqual([
+      { depth: 1, active: false },
+      { depth: 1, active: true },
+    ]);
+  });
+
+  test("does not add a pass-through trunk when the header is the last sibling", () => {
+    const only = workflowChild("only", "wfr_alpha");
+    const rows = [parent, only];
+    const group = computeSidebarTaskGroups({ rows, allRows: rows }).groupsByStorageKey.get(
+      "workflow:parent:wfr_alpha"
+    );
+
+    const meta = computeTaskGroupMemberRowMeta({
+      group: group!,
+      headerMeta: { ...headerMetaBase, connectorPosition: "last", ancestorTrunks: [] },
+      headerDepth: 1,
+    });
+
+    expect(meta.get("only")?.connectorPosition).toBe("single");
+    expect(meta.get("only")?.ancestorTrunks).toEqual([]);
+  });
+});

--- a/src/browser/components/ProjectSidebar/sidebarTaskGroups.ts
+++ b/src/browser/components/ProjectSidebar/sidebarTaskGroups.ts
@@ -1,0 +1,378 @@
+import { getTaskGroupMemberDepth } from "@/browser/components/sidebarItemLayout";
+import {
+  isRunningOrStartingTaskStatus,
+  isWorkspaceDelegatedActivityActive,
+  type AgentRowRenderMeta,
+} from "@/browser/utils/ui/workspaceFiltering";
+import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
+import { hasCompletedAgentReport } from "@/common/utils/agentTaskCompletion";
+import {
+  formatTaskGroupHeader,
+  formatTaskGroupItemsLabel,
+  getTaskGroupKindFromMetadata,
+  type TaskGroupKind,
+} from "@/common/utils/tools/taskGroups";
+
+/**
+ * Sidebar-local group kind: task-tool groups (bestOf/variants) plus workflow
+ * runs. Workflow semantics intentionally stay out of the tool-level
+ * TaskGroupKind in src/common/utils/tools/taskGroups.ts - that utility
+ * describes task-tool metadata, while workflow grouping is UI-only.
+ */
+export type SidebarGroupKind = TaskGroupKind | "workflow";
+
+export function formatSidebarTaskGroupHeader(
+  kind: SidebarGroupKind,
+  totalCount: number,
+  title: string
+): string {
+  if (kind === "workflow") {
+    return `Workflow · ${title}`;
+  }
+  return formatTaskGroupHeader(kind, totalCount, title);
+}
+
+export function formatSidebarTaskGroupItemsLabel(kind: SidebarGroupKind): string {
+  if (kind === "workflow") {
+    return "Tasks";
+  }
+  return formatTaskGroupItemsLabel(kind);
+}
+
+/** Compact fallback header label for workflow runs spawned before workflowName existed. */
+export function shortenWorkflowRunId(runId: string): string {
+  return runId.length > 12 ? `${runId.slice(0, 12)}…` : runId;
+}
+
+export interface SidebarTaskGroupModel {
+  /**
+   * Persisted-expansion key, namespaced per D7: task:<parent>:<groupId> or
+   * workflow:<parent>:<runId>. Also used as the synthetic row-node id, so it
+   * must never collide with workspace ids.
+   */
+  storageKey: string;
+  /** Raw group identity (bestOf groupId or workflow runId), used in testids. */
+  id: string;
+  kind: SidebarGroupKind;
+  parentWorkspaceId: string;
+  /** Workspace id of the first visible member; the header renders at that row's position. */
+  anchorId: string;
+  /**
+   * Members rendered under the header when expanded, in display order. For
+   * active workflow groups this includes completed siblings that completed-
+   * sub-agent filtering would otherwise hide (D9).
+   */
+  displayMembers: FrontendWorkspaceMetadata[];
+  /** All known members (visible or not) for aggregate counts. */
+  allMembers: FrontendWorkspaceMetadata[];
+  title: string;
+  totalCount: number;
+  completedCount: number;
+  runningCount: number;
+  queuedCount: number;
+  interruptedCount: number;
+  /** True while any member is queued or actively working: drives default expansion (D6). */
+  hasActiveMember: boolean;
+}
+
+export interface SidebarTaskGroupsResult {
+  groupsByStorageKey: Map<string, SidebarTaskGroupModel>;
+  /** Maps every member workspace id to its group key so non-anchor rows are suppressed. */
+  memberGroupStorageKeyByWorkspaceId: Map<string, string>;
+}
+
+interface GroupDescriptor {
+  id: string;
+  kind: SidebarGroupKind;
+  parentWorkspaceId: string;
+  storageKey: string;
+}
+
+function getGroupDescriptor(
+  workspace: FrontendWorkspaceMetadata,
+  hasChildren: (workspaceId: string) => boolean
+): GroupDescriptor | null {
+  const parentWorkspaceId = workspace.parentWorkspaceId;
+  if (!parentWorkspaceId) {
+    return null;
+  }
+  // Leaf-only rule (D4): a member that spawned its own sub-agents falls out of
+  // the group and renders as a normal subtree.
+  if (hasChildren(workspace.id)) {
+    return null;
+  }
+
+  const bestOfGroupId = workspace.bestOf?.groupId;
+  if (bestOfGroupId) {
+    if ((workspace.bestOf?.total ?? 1) < 2) {
+      return null;
+    }
+    return {
+      id: bestOfGroupId,
+      kind: getTaskGroupKindFromMetadata(workspace.bestOf),
+      parentWorkspaceId,
+      storageKey: `task:${parentWorkspaceId}:${bestOfGroupId}`,
+    };
+  }
+
+  // bestOf grouping wins when both are present (D3).
+  const workflowRunId = workspace.workflowTask?.runId;
+  if (workflowRunId) {
+    return {
+      id: workflowRunId,
+      kind: "workflow",
+      parentWorkspaceId,
+      storageKey: `workflow:${parentWorkspaceId}:${workflowRunId}`,
+    };
+  }
+
+  return null;
+}
+
+function sortBestOfMembers(members: FrontendWorkspaceMetadata[]): FrontendWorkspaceMetadata[] {
+  return [...members].sort(
+    (left, right) =>
+      (left.bestOf?.index ?? Number.MAX_SAFE_INTEGER) -
+        (right.bestOf?.index ?? Number.MAX_SAFE_INTEGER) || left.id.localeCompare(right.id)
+  );
+}
+
+function sortWorkflowMembers(members: FrontendWorkspaceMetadata[]): FrontendWorkspaceMetadata[] {
+  // Spawn order: workflow steps run over time, so creation time is the
+  // natural reading order for a run's tasks.
+  return [...members].sort(
+    (left, right) =>
+      (left.createdAt ?? "").localeCompare(right.createdAt ?? "") || left.id.localeCompare(right.id)
+  );
+}
+
+/**
+ * Compute coalesced sidebar task groups for one ordered list of visible rows.
+ *
+ * Variant/best-of groups keep the legacy constraints (min 2 members, visible
+ * members contiguous). Workflow run groups form from the first member and
+ * gather non-contiguous members because steps spawn over time and interleave
+ * with other rows (D5/D6).
+ */
+export function computeSidebarTaskGroups(params: {
+  /** Ordered rows the sidebar would render (visibility rules already applied). */
+  rows: FrontendWorkspaceMetadata[];
+  /** Unfiltered section rows used for totals and the leaf-only rule. */
+  allRows: FrontendWorkspaceMetadata[];
+  selectedWorkspaceId?: string;
+  isWorkspaceLiveActive?: (workspaceId: string) => boolean;
+}): SidebarTaskGroupsResult {
+  const childrenByParentId = new Map<string, FrontendWorkspaceMetadata[]>();
+  for (const workspace of params.allRows) {
+    const parentId = workspace.parentWorkspaceId;
+    if (!parentId) {
+      continue;
+    }
+    const children = childrenByParentId.get(parentId) ?? [];
+    children.push(workspace);
+    childrenByParentId.set(parentId, children);
+  }
+  const hasChildren = (workspaceId: string) => childrenByParentId.has(workspaceId);
+
+  const descriptorsByStorageKey = new Map<string, GroupDescriptor>();
+  const allMembersByStorageKey = new Map<string, FrontendWorkspaceMetadata[]>();
+  for (const workspace of params.allRows) {
+    const descriptor = getGroupDescriptor(workspace, hasChildren);
+    if (!descriptor) {
+      continue;
+    }
+    descriptorsByStorageKey.set(descriptor.storageKey, descriptor);
+    const members = allMembersByStorageKey.get(descriptor.storageKey) ?? [];
+    members.push(workspace);
+    allMembersByStorageKey.set(descriptor.storageKey, members);
+  }
+
+  const visibleMembersByStorageKey = new Map<string, FrontendWorkspaceMetadata[]>();
+  const indexByRowId = new Map(
+    params.rows.map((workspace, index) => [workspace.id, index] as const)
+  );
+  for (const workspace of params.rows) {
+    const descriptor = getGroupDescriptor(workspace, hasChildren);
+    if (!descriptor) {
+      continue;
+    }
+    const members = visibleMembersByStorageKey.get(descriptor.storageKey) ?? [];
+    members.push(workspace);
+    visibleMembersByStorageKey.set(descriptor.storageKey, members);
+  }
+
+  const groupsByStorageKey = new Map<string, SidebarTaskGroupModel>();
+  const memberGroupStorageKeyByWorkspaceId = new Map<string, string>();
+
+  for (const [storageKey, visibleMembers] of visibleMembersByStorageKey) {
+    const descriptor = descriptorsByStorageKey.get(storageKey);
+    if (!descriptor || visibleMembers.length === 0) {
+      continue;
+    }
+    const allMembers = allMembersByStorageKey.get(storageKey) ?? visibleMembers;
+
+    if (descriptor.kind !== "workflow") {
+      if (visibleMembers.length < 2 || allMembers.length < 2) {
+        continue;
+      }
+      // Visible variant/best-of members must stay contiguous (spawned
+      // atomically and sorted adjacent); bail out when other rows interleave.
+      const indices = visibleMembers
+        .map((workspace) => indexByRowId.get(workspace.id))
+        .filter((index): index is number => index != null);
+      if (indices.length !== visibleMembers.length) {
+        continue;
+      }
+      const firstIndex = Math.min(...indices);
+      const lastIndex = Math.max(...indices);
+      if (lastIndex - firstIndex + 1 !== visibleMembers.length) {
+        continue;
+      }
+    }
+
+    let completedCount = 0;
+    let runningCount = 0;
+    let queuedCount = 0;
+    let interruptedCount = 0;
+    for (const member of allMembers) {
+      if (hasCompletedAgentReport(member)) {
+        completedCount += 1;
+        continue;
+      }
+      if (
+        isWorkspaceDelegatedActivityActive(member, {
+          isWorkspaceLiveActive: params.isWorkspaceLiveActive,
+        })
+      ) {
+        runningCount += 1;
+        continue;
+      }
+      if (member.taskStatus === "queued") {
+        queuedCount += 1;
+        continue;
+      }
+      if (member.taskStatus === "interrupted") {
+        interruptedCount += 1;
+      }
+    }
+    const hasActiveMember = runningCount > 0 || queuedCount > 0;
+
+    let displayMembers: FrontendWorkspaceMetadata[];
+    let title: string;
+    let totalCount: number;
+    if (descriptor.kind === "workflow") {
+      if (hasActiveMember) {
+        // D9: active runs show their full task list, including completed
+        // siblings that completed-sub-agent filtering would otherwise hide.
+        displayMembers = sortWorkflowMembers(allMembers);
+      } else {
+        const selected =
+          params.selectedWorkspaceId != null
+            ? allMembers.find((member) => member.id === params.selectedWorkspaceId)
+            : undefined;
+        const visibleIds = new Set(visibleMembers.map((member) => member.id));
+        displayMembers = sortWorkflowMembers(
+          selected != null && !visibleIds.has(selected.id)
+            ? [...visibleMembers, selected]
+            : visibleMembers
+        );
+      }
+      const workflowName = allMembers.find((member) => member.workflowTask?.workflowName != null)
+        ?.workflowTask?.workflowName;
+      title = workflowName ?? shortenWorkflowRunId(descriptor.id);
+      // No up-front total for workflow runs; count live members only.
+      totalCount = allMembers.length;
+    } else {
+      displayMembers = sortBestOfMembers(visibleMembers);
+      const sortedAllMembers = sortBestOfMembers(allMembers);
+      title = sortedAllMembers[0]?.title ?? sortedAllMembers[0]?.name ?? "Task group";
+      totalCount = Math.max(
+        sortedAllMembers[0]?.bestOf?.total ?? allMembers.length,
+        allMembers.length
+      );
+    }
+
+    const anchorId = visibleMembers[0]?.id;
+    if (anchorId == null) {
+      continue;
+    }
+
+    groupsByStorageKey.set(storageKey, {
+      storageKey,
+      id: descriptor.id,
+      kind: descriptor.kind,
+      parentWorkspaceId: descriptor.parentWorkspaceId,
+      anchorId,
+      displayMembers,
+      allMembers,
+      title,
+      totalCount,
+      completedCount,
+      runningCount,
+      queuedCount,
+      interruptedCount,
+      hasActiveMember,
+    });
+    for (const member of allMembers) {
+      memberGroupStorageKeyByWorkspaceId.set(member.id, storageKey);
+    }
+  }
+
+  return { groupsByStorageKey, memberGroupStorageKeyByWorkspaceId };
+}
+
+/**
+ * Connector metadata for the member rows rendered under an expanded group
+ * header. Members form their own sibling run hanging off the header row, and
+ * inherit the header's continuing ancestor trunks so rails stay unbroken.
+ */
+export function computeTaskGroupMemberRowMeta(params: {
+  group: SidebarTaskGroupModel;
+  headerMeta: AgentRowRenderMeta;
+  headerDepth: number;
+}): Map<string, AgentRowRenderMeta> {
+  const members = params.group.displayMembers;
+  const memberDepth = getTaskGroupMemberDepth(params.headerDepth);
+
+  let lastRunningMemberIndex = -1;
+  for (let index = members.length - 1; index >= 0; index -= 1) {
+    if (isRunningOrStartingTaskStatus(members[index]?.taskStatus)) {
+      lastRunningMemberIndex = index;
+      break;
+    }
+  }
+
+  const ancestorTrunks: Array<{ depth: number; active: boolean }> = [
+    ...params.headerMeta.ancestorTrunks,
+  ];
+  if (params.headerMeta.connectorPosition === "middle") {
+    // The header has visible lower siblings, so its shared trunk must pass
+    // through the member rows to reach them.
+    ancestorTrunks.push({
+      depth: params.headerDepth,
+      active: params.headerMeta.sharedTrunkActiveBelowRow,
+    });
+  }
+  ancestorTrunks.sort((left, right) => left.depth - right.depth);
+
+  const metaByWorkspaceId = new Map<string, AgentRowRenderMeta>();
+  for (const [index, member] of members.entries()) {
+    let connectorPosition: AgentRowRenderMeta["connectorPosition"] = "single";
+    if (members.length > 1) {
+      connectorPosition = index === members.length - 1 ? "last" : "middle";
+    }
+    metaByWorkspaceId.set(member.id, {
+      depth: memberDepth,
+      rowKind: "subagent",
+      connectorPosition,
+      connectorStartsAtParent: index === 0,
+      sharedTrunkActiveThroughRow: lastRunningMemberIndex >= 0 && index <= lastRunningMemberIndex,
+      sharedTrunkActiveBelowRow: lastRunningMemberIndex >= 0 && index < lastRunningMemberIndex,
+      ancestorTrunks,
+      // Leaf-only rule: grouped members never have visible children.
+      hasHiddenCompletedChildren: false,
+      visibleCompletedChildrenCount: 0,
+    });
+  }
+  return metaByWorkspaceId;
+}

--- a/src/browser/components/ProjectSidebar/sidebarTaskGroups.ts
+++ b/src/browser/components/ProjectSidebar/sidebarTaskGroups.ts
@@ -129,6 +129,97 @@ function getGroupDescriptor(
   return null;
 }
 
+/**
+ * Storage key of the workflow group a workspace would belong to, ignoring the
+ * leaf-only rule (used for liveness tracking and force-visibility, where the
+ * cheap metadata-only check is sufficient).
+ */
+export function getWorkflowGroupStorageKey(workspace: FrontendWorkspaceMetadata): string | null {
+  const parentWorkspaceId = workspace.parentWorkspaceId;
+  const runId = workspace.workflowTask?.runId;
+  // bestOf grouping wins when both are present (D3).
+  if (!parentWorkspaceId || !runId || workspace.bestOf?.groupId) {
+    return null;
+  }
+  return `workflow:${parentWorkspaceId}:${runId}`;
+}
+
+/**
+ * Collect workflow groups that currently have a non-terminal member. The
+ * sidebar accumulates these per session so a run's group stays mounted across
+ * step gaps (see ensureWorkflowGroupMembersVisible).
+ */
+export function collectActiveWorkflowGroupKeys(
+  workspaces: FrontendWorkspaceMetadata[],
+  options: { isWorkspaceLiveActive?: (workspaceId: string) => boolean } = {}
+): Set<string> {
+  const keys = new Set<string>();
+  for (const workspace of workspaces) {
+    const key = getWorkflowGroupStorageKey(workspace);
+    if (key == null || keys.has(key) || hasCompletedAgentReport(workspace)) {
+      continue;
+    }
+    if (
+      workspace.taskStatus === "queued" ||
+      isWorkspaceDelegatedActivityActive(workspace, options)
+    ) {
+      keys.add(key);
+    }
+  }
+  return keys;
+}
+
+/**
+ * Keep workflow-run groups mounted for the entire run. Between sequential
+ * steps every member of a run can be terminal, and completed-sub-agent
+ * filtering would hide them all - flashing the group out of the sidebar and
+ * back when the next step's task spawns. Re-include hidden leaf members of
+ * session-active runs (in their original order) so the group header keeps a
+ * stable anchor row.
+ */
+export function ensureWorkflowGroupMembersVisible(params: {
+  /** Unfiltered rows in render order. */
+  allRows: FrontendWorkspaceMetadata[];
+  /** Rows that survived completed-sub-agent filtering, in the same order. */
+  visibleRows: FrontendWorkspaceMetadata[];
+  sessionActiveGroupKeys: ReadonlySet<string>;
+}): FrontendWorkspaceMetadata[] {
+  if (params.sessionActiveGroupKeys.size === 0) {
+    return params.visibleRows;
+  }
+
+  const visibleIds = new Set(params.visibleRows.map((workspace) => workspace.id));
+  const parentIdsWithChildren = new Set<string>();
+  for (const workspace of params.allRows) {
+    if (workspace.parentWorkspaceId) {
+      parentIdsWithChildren.add(workspace.parentWorkspaceId);
+    }
+  }
+
+  let changed = false;
+  const result: FrontendWorkspaceMetadata[] = [];
+  for (const workspace of params.allRows) {
+    if (visibleIds.has(workspace.id)) {
+      result.push(workspace);
+      continue;
+    }
+    const key = getWorkflowGroupStorageKey(workspace);
+    if (
+      key != null &&
+      params.sessionActiveGroupKeys.has(key) &&
+      // Leaf-only rule (D4): members with their own subtree are not grouped.
+      !parentIdsWithChildren.has(workspace.id) &&
+      workspace.parentWorkspaceId != null &&
+      // Never resurrect rows whose parent chain is itself hidden.
+      visibleIds.has(workspace.parentWorkspaceId)
+    ) {
+      result.push(workspace);
+      changed = true;
+    }
+  }
+  return changed ? result : params.visibleRows;
+}
+
 function sortBestOfMembers(members: FrontendWorkspaceMetadata[]): FrontendWorkspaceMetadata[] {
   return [...members].sort(
     (left, right) =>

--- a/src/browser/stories/mocks/workspaces.ts
+++ b/src/browser/stories/mocks/workspaces.ts
@@ -20,7 +20,10 @@ export interface WorkspaceFixture {
   projectName: string;
   runtimeConfig?: RuntimeConfig;
   createdAt?: string;
+  parentWorkspaceId?: string;
+  taskStatus?: FrontendWorkspaceMetadata["taskStatus"];
   bestOf?: FrontendWorkspaceMetadata["bestOf"];
+  workflowTask?: FrontendWorkspaceMetadata["workflowTask"];
   title?: string;
   transcriptOnly?: boolean;
 }
@@ -41,7 +44,10 @@ export function createWorkspace(
     // Default to current time so workspaces aren't filtered as "old" by age-based UI
     createdAt: opts.createdAt ?? new Date().toISOString(),
     title: opts.title,
+    parentWorkspaceId: opts.parentWorkspaceId,
+    taskStatus: opts.taskStatus,
     bestOf: opts.bestOf,
+    workflowTask: opts.workflowTask,
     transcriptOnly: opts.transcriptOnly,
   };
 }

--- a/src/browser/utils/ui/workspaceFiltering.test.ts
+++ b/src/browser/utils/ui/workspaceFiltering.test.ts
@@ -7,7 +7,10 @@ import {
   computeWorkspaceDepthMap,
   computeAgentRowRenderMeta,
   computeDelegatedActivityByWorkspaceId,
+  computeRowMetaForVisibleNodes,
   filterVisibleAgentRows,
+  type AgentRowRenderMeta,
+  type SidebarVisibleRowNode,
 } from "./workspaceFiltering";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import type { ProjectConfig } from "@/common/types/project";
@@ -1083,5 +1086,63 @@ describe("sub-agent row render metadata", () => {
     expect(expandedMeta.get("reported-1")?.connectorPosition).toBe("middle");
     expect(expandedMeta.get("active-2")?.connectorPosition).toBe("middle");
     expect(expandedMeta.get("reported-2")?.connectorPosition).toBe("last");
+  });
+});
+
+describe("computeRowMetaForVisibleNodes", () => {
+  const baseMeta = (depth: number): AgentRowRenderMeta => ({
+    depth,
+    rowKind: "subagent",
+    connectorPosition: "single",
+    connectorStartsAtParent: false,
+    sharedTrunkActiveThroughRow: false,
+    sharedTrunkActiveBelowRow: false,
+    ancestorTrunks: [],
+    hasHiddenCompletedChildren: false,
+    visibleCompletedChildrenCount: 0,
+  });
+
+  const node = (
+    id: string,
+    parentId: string | undefined,
+    depth: number,
+    isRunning = false
+  ): SidebarVisibleRowNode => ({ id, parentId, depth, isRunning, baseMeta: baseMeta(depth) });
+
+  it("treats synthetic group-header nodes as ordinary siblings for connector geometry", () => {
+    const meta = computeRowMetaForVisibleNodes([
+      node("root", undefined, 0),
+      node("child-a", "root", 1, true),
+      // Synthetic header node sits between two workspace siblings.
+      node("workflow:root:wfr_x", "root", 1, true),
+      node("child-b", "root", 1),
+      node("grandchild", "child-b", 2),
+    ]);
+
+    const header = meta.get("workflow:root:wfr_x");
+    expect(header?.connectorPosition).toBe("middle");
+    expect(header?.connectorStartsAtParent).toBe(false);
+    // The shared trunk animates down to the lowest running sibling (the header).
+    expect(header?.sharedTrunkActiveThroughRow).toBe(true);
+    expect(header?.sharedTrunkActiveBelowRow).toBe(false);
+    expect(meta.get("child-a")?.sharedTrunkActiveBelowRow).toBe(true);
+    expect(meta.get("child-b")?.connectorPosition).toBe("last");
+
+    // Descendants of a middle sibling receive its continuing trunk.
+    const grandchild = meta.get("grandchild");
+    expect(grandchild?.connectorPosition).toBe("single");
+    expect(grandchild?.ancestorTrunks).toEqual([]);
+  });
+
+  it("gives descendants of middle siblings an ancestor trunk at the sibling depth", () => {
+    const meta = computeRowMetaForVisibleNodes([
+      node("root", undefined, 0),
+      node("child-a", "root", 1),
+      node("nested", "child-a", 2),
+      node("child-b", "root", 1, true),
+    ]);
+
+    expect(meta.get("child-a")?.connectorPosition).toBe("middle");
+    expect(meta.get("nested")?.ancestorTrunks).toEqual([{ depth: 1, active: true }]);
   });
 });

--- a/src/browser/utils/ui/workspaceFiltering.ts
+++ b/src/browser/utils/ui/workspaceFiltering.ts
@@ -489,6 +489,107 @@ export function computeAgentRowRenderMeta(
 }
 
 /**
+ * One renderable sidebar row in final visual order: either a workspace row or
+ * a synthetic task-group header. Connector geometry must be derived from this
+ * final order (after group coalescing pulled member rows together), otherwise
+ * trunks/elbows go stale around group headers.
+ */
+export interface SidebarVisibleRowNode {
+  id: string;
+  parentId: string | undefined;
+  depth: number;
+  /** Drives the shared-trunk animation through this row's sibling run. */
+  isRunning: boolean;
+  /** Base meta whose non-connector fields (rowKind, completed-children info) are preserved. */
+  baseMeta: AgentRowRenderMeta;
+}
+
+/**
+ * Recompute connector geometry for the final, visible row order. Mirrors the
+ * sibling/trunk rules of computeAgentRowRenderMeta but works on generic nodes
+ * so synthetic group-header rows participate in the same geometry as
+ * workspace rows.
+ */
+export function computeRowMetaForVisibleNodes(
+  nodes: readonly SidebarVisibleRowNode[]
+): Map<string, AgentRowRenderMeta> {
+  const nodesById = new Map(nodes.map((node) => [node.id, node] as const));
+  const childrenByParentId = new Map<string, SidebarVisibleRowNode[]>();
+  for (const node of nodes) {
+    if (node.parentId == null) {
+      continue;
+    }
+    const siblings = childrenByParentId.get(node.parentId) ?? [];
+    siblings.push(node);
+    childrenByParentId.set(node.parentId, siblings);
+  }
+
+  const metaById = new Map<string, AgentRowRenderMeta>();
+  for (const node of nodes) {
+    if (node.parentId == null) {
+      metaById.set(node.id, { ...node.baseMeta, ancestorTrunks: [] });
+      continue;
+    }
+
+    const siblings = childrenByParentId.get(node.parentId) ?? [];
+    const siblingIndex = siblings.findIndex((sibling) => sibling.id === node.id);
+    let connectorPosition: AgentRowRenderMeta["connectorPosition"] = "single";
+    if (siblings.length > 1) {
+      connectorPosition = siblings[siblings.length - 1]?.id === node.id ? "last" : "middle";
+    }
+
+    let lastRunningSiblingIndex = -1;
+    for (let index = siblings.length - 1; index >= 0; index -= 1) {
+      if (siblings[index]?.isRunning) {
+        lastRunningSiblingIndex = index;
+        break;
+      }
+    }
+
+    const connectorStartsAtParent = siblingIndex === 0;
+    const sharedTrunkActiveThroughRow =
+      siblingIndex >= 0 && lastRunningSiblingIndex >= 0 && siblingIndex <= lastRunningSiblingIndex;
+    const sharedTrunkActiveBelowRow =
+      siblingIndex >= 0 && lastRunningSiblingIndex >= 0 && siblingIndex < lastRunningSiblingIndex;
+
+    const ancestorTrunks: Array<{ depth: number; active: boolean }> = [];
+    const visitedAncestorIds = new Set<string>();
+    let ancestorId: string | undefined = node.parentId;
+    while (ancestorId && !visitedAncestorIds.has(ancestorId)) {
+      visitedAncestorIds.add(ancestorId);
+
+      const ancestorNode = nodesById.get(ancestorId);
+      if (!ancestorNode) {
+        break;
+      }
+
+      const ancestorMeta = metaById.get(ancestorId);
+      if (ancestorNode.depth > 0 && ancestorMeta?.connectorPosition === "middle") {
+        ancestorTrunks.push({
+          depth: ancestorNode.depth,
+          active: ancestorMeta.sharedTrunkActiveBelowRow,
+        });
+      }
+
+      ancestorId = ancestorNode.parentId;
+    }
+    ancestorTrunks.sort((left, right) => left.depth - right.depth);
+
+    metaById.set(node.id, {
+      ...node.baseMeta,
+      depth: node.depth,
+      connectorPosition,
+      connectorStartsAtParent,
+      sharedTrunkActiveThroughRow,
+      sharedTrunkActiveBelowRow,
+      ancestorTrunks,
+    });
+  }
+
+  return metaById;
+}
+
+/**
  * Age thresholds for workspace filtering, in ascending order.
  * Each tier hides workspaces older than the specified duration.
  */

--- a/src/browser/utils/workspace.ts
+++ b/src/browser/utils/workspace.ts
@@ -23,5 +23,8 @@ export function getWorkspaceSidebarKey(meta: FrontendWorkspaceMetadata): string 
     meta.taskStatus ?? "", // Task lifecycle label/state for sub-agent rows
     meta.agentType ?? "", // Agent preset badge/label (future)
     meta.subProjectPath ?? "", // Sub-project grouping and cwd context for sidebar organization
+    meta.workflowTask?.runId ?? "", // Workflow run grouping in the sidebar
+    meta.workflowTask?.stepId ?? "", // Workflow step identity for grouped rows
+    meta.workflowTask?.workflowName ?? "", // Workflow group header label
   ].join("|");
 }

--- a/src/common/orpc/schemas/workspace.ts
+++ b/src/common/orpc/schemas/workspace.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { ThinkingLevelSchema } from "../../types/thinking";
 import { RuntimeConfigSchema } from "./runtime";
-import { WorkflowRunIdSchema } from "./workflow";
 import { WorkspaceAISettingsByAgentSchema, WorkspaceAISettingsSchema } from "./workspaceAiSettings";
 import { TASK_GROUP_KIND_VALUES } from "@/common/utils/tools/taskGroups";
 import { GoalSnapshotSchema } from "./goal";
@@ -87,9 +86,17 @@ export const WorkspaceHeartbeatSettingsSchema = z.object({
   }),
 });
 
+// Single source of truth for workflow task metadata on both persisted config
+// entries (src/common/schemas/project.ts) and workspace metadata IPC. The runId
+// stays a loose non-empty string (not WorkflowRunIdSchema) so a malformed
+// persisted entry can never brick config/metadata parsing (self-healing rule).
 export const WorkflowTaskMetadataSchema = z.object({
-  runId: WorkflowRunIdSchema.meta({ description: "Workflow run that spawned this task." }),
+  runId: z.string().min(1).meta({ description: "Workflow run that spawned this task." }),
   stepId: z.string().min(1).meta({ description: "Workflow step that spawned this task." }),
+  workflowName: z.string().min(1).optional().meta({
+    description:
+      "Human-readable workflow definition name stamped at spawn time for sidebar grouping. Optional: absent on tasks created before this field existed.",
+  }),
   outputSchema: z.unknown().optional().meta({
     description: "Optional JSON Schema subset required for this task's structured output.",
   }),

--- a/src/common/schemas/project.ts
+++ b/src/common/schemas/project.ts
@@ -3,6 +3,7 @@ import { WorkspaceMCPOverridesSchema } from "@/common/orpc/schemas/mcp";
 import {
   BestOfGroupSchema,
   ProjectRefSchema,
+  WorkflowTaskMetadataSchema,
   WorkspaceGoalDefaultsOverrideSchema,
   WorkspaceHeartbeatSettingsSchema,
 } from "@/common/orpc/schemas/workspace";
@@ -54,13 +55,8 @@ export const WorktreeArchiveSnapshotSchema = z.object({
   }),
 });
 
-export const WorkflowTaskMetadataSchema = z.object({
-  runId: z.string().min(1).meta({ description: "Workflow run that spawned this task." }),
-  stepId: z.string().min(1).meta({ description: "Workflow step that spawned this task." }),
-  outputSchema: z.unknown().optional().meta({
-    description: "Optional JSON Schema subset required for this task's structured output.",
-  }),
-});
+// Shared with workspace metadata IPC; see src/common/orpc/schemas/workspace.ts.
+export { WorkflowTaskMetadataSchema };
 
 export const WorkspaceConfigSchema = z.object({
   path: z.string().meta({

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -376,11 +376,12 @@ async function resolveWorkflowContext(
       defaultActionCwd: workspacePath,
       runStore: new WorkflowRunStore({ sessionDir: context.config.getSessionDir(workspaceId) }),
       runtimeFactory: context.workflowRuntimeFactory,
-      taskAdapterFactory: (runId) =>
+      taskAdapterFactory: (runId, workflowName) =>
         new WorkflowTaskServiceAdapter({
           taskService: context.taskService,
           parentWorkspaceId: workspaceId,
           workflowRunId: runId,
+          workflowName,
           defaultAgentId: "explore",
           patchToolConfig: {
             workspaceId,

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1674,11 +1674,12 @@ export class AIService extends EventEmitter {
                 sessionDir: this.config.getSessionDir(workspaceId),
               }),
               runtimeFactory: new QuickJSRuntimeFactory(),
-              taskAdapterFactory: (runId) =>
+              taskAdapterFactory: (runId, workflowName) =>
                 new WorkflowTaskServiceAdapter({
                   taskService: this.taskService!,
                   parentWorkspaceId: workspaceId,
                   workflowRunId: runId,
+                  workflowName,
                   defaultAgentId: "explore",
                   patchToolConfig: {
                     workspaceId,

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -816,6 +816,10 @@ export class TaskService {
   // Serialize stream-end processing per workspace to avoid races when
   // finalizing reported tasks and cleanup state transitions.
   private readonly workspaceEventLocks = new MutexMap<string>();
+  // Workflow runs whose completed child workspaces must not be auto-deleted yet
+  // (see markWorkflowRunActive). In-memory by design: lost holds self-heal via
+  // the startup completed-report recheck.
+  private readonly activeWorkflowRunIds = new Set<string>();
   // Separate parent-scoped lock for deferred best-of fallback/finalization. This path can run
   // concurrently from multiple child stream-end handlers for the same parent, and it must remain
   // safe even when the parent stream-end already holds workspaceEventLocks for the parent itself.
@@ -2779,6 +2783,41 @@ export class TaskService {
     await this.maybeStartQueuedTasks();
 
     return Ok({ terminatedTaskIds });
+  }
+
+  /**
+   * Defer auto-cleanup of a workflow run's completed child workspaces while
+   * the run is active. Without the hold, sequential steps flash in the sidebar:
+   * step N's workspace is deleted the moment its report is consumed, leaving
+   * the run with zero workspaces until step N+1 spawns. The hold is in-memory
+   * only - after a crash/restart the regular startup recheck sweeps leftovers.
+   */
+  markWorkflowRunActive(workflowRunId: string): void {
+    assert(workflowRunId.length > 0, "markWorkflowRunActive: workflowRunId must be non-empty");
+    this.activeWorkflowRunIds.add(workflowRunId);
+  }
+
+  /** Release the cleanup hold for a terminal run and sweep its deferred children. */
+  async markWorkflowRunEnded(workflowRunId: string): Promise<void> {
+    assert(workflowRunId.length > 0, "markWorkflowRunEnded: workflowRunId must be non-empty");
+    this.activeWorkflowRunIds.delete(workflowRunId);
+
+    const cfg = this.config.loadConfigOrDefault();
+    const heldTaskIds: string[] = [];
+    for (const project of cfg.projects.values()) {
+      for (const workspace of project.workspaces) {
+        if (
+          workspace.id &&
+          workspace.workflowTask?.runId === workflowRunId &&
+          hasCompletedAgentReport(workspace)
+        ) {
+          heldTaskIds.push(workspace.id);
+        }
+      }
+    }
+    for (const taskId of heldTaskIds) {
+      await this.cleanupReportedLeafTask(taskId);
+    }
   }
 
   /**
@@ -6522,6 +6561,13 @@ export class TaskService {
 
     if (!hasCompletedAgentReport(entry.workspace)) {
       return { ok: false, reason: "task_not_reported" };
+    }
+
+    // Workflow-owned children stay visible in the sidebar for the run's whole
+    // duration; markWorkflowRunEnded sweeps them once the run is terminal.
+    const workflowRunId = entry.workspace.workflowTask?.runId;
+    if (workflowRunId != null && this.activeWorkflowRunIds.has(workflowRunId)) {
+      return { ok: false, reason: "workflow_run_active" };
     }
 
     if (entry.workspace.bestOf?.total != null && entry.workspace.bestOf.total > 1) {

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -171,6 +171,7 @@ export interface TaskCreateArgs {
   workflowTask?: {
     runId: string;
     stepId: string;
+    workflowName?: string;
     outputSchema?: unknown;
   };
   /** Experiments to inherit to subagent */

--- a/src/node/services/workflows/WorkflowRunner.test.ts
+++ b/src/node/services/workflows/WorkflowRunner.test.ts
@@ -79,6 +79,75 @@ function createDeferred() {
 }
 
 describe("WorkflowRunner", () => {
+  test("brackets runs with onRunStarted/onRunEnded so child-workspace cleanup holds match run lifetime", async () => {
+    using tmp = new DisposableTempDir("workflow-runner");
+    const store = await createRunStore(tmp.path);
+    const lifecycle: string[] = [];
+    const runner = createRunner(store, {
+      async runAgent() {
+        lifecycle.push("agent");
+        return { taskId: "task_1", reportMarkdown: "summary" };
+      },
+      onRunStarted() {
+        lifecycle.push("started");
+      },
+      onRunEnded() {
+        lifecycle.push("ended");
+      },
+    });
+
+    await runner.run("wfr_123");
+
+    expect(lifecycle).toEqual(["started", "agent", "ended"]);
+  });
+
+  test("releases the run hold when the workflow fails", async () => {
+    using tmp = new DisposableTempDir("workflow-runner");
+    const store = await createRunStore(tmp.path);
+    const lifecycle: string[] = [];
+    const runner = createRunner(store, {
+      async runAgent() {
+        throw new Error("agent exploded");
+      },
+      onRunStarted() {
+        lifecycle.push("started");
+      },
+      onRunEnded() {
+        lifecycle.push("ended");
+      },
+    });
+
+    await expect(runner.run("wfr_123")).rejects.toThrow("agent exploded");
+
+    expect(lifecycle).toEqual(["started", "ended"]);
+  });
+
+  test("keeps the run hold when the lease belongs to another runner", async () => {
+    using tmp = new DisposableTempDir("workflow-runner");
+    const store = await createRunStore(tmp.path);
+    // Simulate a concurrent runner owning a fresh (non-stale) lease at the
+    // same clock instant the runner under test will see (nowMs = 1000).
+    expect(await store.acquireLease("wfr_123", "runner-other", 1_000)).toBe(true);
+
+    const lifecycle: string[] = [];
+    const runner = createRunner(store, {
+      async runAgent() {
+        return { taskId: "task_1", reportMarkdown: "summary" };
+      },
+      onRunStarted() {
+        lifecycle.push("started");
+      },
+      onRunEnded() {
+        lifecycle.push("ended");
+      },
+    });
+
+    await expect(runner.run("wfr_123")).rejects.toThrow("Workflow run is already active");
+
+    // The lease owner is responsible for releasing the hold; this runner must not.
+    expect(lifecycle).toEqual(["started"]);
+  });
+
   test("executes conductor primitives and persists run events/results", async () => {
     using tmp = new DisposableTempDir("workflow-runner");
     const store = await createRunStore(tmp.path);

--- a/src/node/services/workflows/WorkflowRunner.ts
+++ b/src/node/services/workflows/WorkflowRunner.ts
@@ -129,6 +129,19 @@ export interface WorkflowTaskAdapter {
     options?: { abortSignal?: AbortSignal }
   ): Promise<unknown>;
   interruptRun?(): Promise<void>;
+  /**
+   * Called when the runner begins executing the run (including resumes and
+   * background continuations). Adapters use this to hold completed child-task
+   * workspaces alive so the sidebar shows the run's tasks for its whole
+   * duration instead of flashing between sequential steps.
+   */
+  onRunStarted?(): Promise<void> | void;
+  /**
+   * Called when the run reaches a terminal state. Not called when the run is
+   * backgrounded (the background continuation re-enters run()) or when the
+   * lease was held by another runner.
+   */
+  onRunEnded?(): Promise<void> | void;
 }
 
 export interface WorkflowRunnerRunOptions {
@@ -297,6 +310,31 @@ export class WorkflowRunner {
 
   async run(runId: string, options?: WorkflowRunnerRunOptions): Promise<WorkflowResult> {
     assert(runId.length > 0, "WorkflowRunner.run: runId is required");
+    // Hold workflow-owned child workspaces for the run's whole duration so the
+    // sidebar keeps showing the run's tasks between sequential steps.
+    await this.taskAdapter.onRunStarted?.();
+    try {
+      const result = await this.runWithLease(runId, options);
+      await this.taskAdapter.onRunEnded?.();
+      return result;
+    } catch (error) {
+      // Backgrounding is not terminal (the background continuation re-enters
+      // run()), and a lease-acquisition loss means another runner owns the run
+      // and will release the hold itself when it finishes.
+      const keepsHold =
+        error instanceof WorkflowRunBackgroundedError ||
+        (error instanceof Error && error.message === `Workflow run is already active: ${runId}`);
+      if (!keepsHold) {
+        await this.taskAdapter.onRunEnded?.();
+      }
+      throw error;
+    }
+  }
+
+  private async runWithLease(
+    runId: string,
+    options?: WorkflowRunnerRunOptions
+  ): Promise<WorkflowResult> {
     const leaseAcquired = await this.runStore.acquireLease(
       runId,
       this.runnerId,

--- a/src/node/services/workflows/WorkflowService.ts
+++ b/src/node/services/workflows/WorkflowService.ts
@@ -42,7 +42,8 @@ export interface WorkflowServiceOptions {
   defaultActionCwd?: string;
   runtimeFactory: IJSRuntimeFactory;
   taskAdapter?: WorkflowTaskAdapter;
-  taskAdapterFactory?: (runId: string) => WorkflowTaskAdapter;
+  /** workflowName is the human-readable definition name, used to label spawned tasks. */
+  taskAdapterFactory?: (runId: string, workflowName?: string) => WorkflowTaskAdapter;
   onBackgroundRunTerminal?: (event: WorkflowBackgroundRunTerminalEvent) => Promise<void> | void;
   generateRunId?: () => string;
   // Delayed crash-recovery retries must use current trust, not the value captured when scheduled.
@@ -112,7 +113,10 @@ export class WorkflowService {
   private readonly defaultActionCwd?: string;
   private readonly runtimeFactory: IJSRuntimeFactory;
   private readonly taskAdapter?: WorkflowTaskAdapter;
-  private readonly taskAdapterFactory?: (runId: string) => WorkflowTaskAdapter;
+  private readonly taskAdapterFactory?: (
+    runId: string,
+    workflowName?: string
+  ) => WorkflowTaskAdapter;
   private readonly onBackgroundRunTerminal?: (
     event: WorkflowBackgroundRunTerminalEvent
   ) => Promise<void> | void;
@@ -349,7 +353,7 @@ export class WorkflowService {
       runnerAbortController
     );
     try {
-      const runner = this.createRunner(input.runId, input.projectTrusted);
+      const runner = await this.createRunner(input.runId, input.projectTrusted);
       const result = await runner.run(input.runId, {
         abortSignal: runnerAbortController.signal,
         onLeaseAcquired: () => {
@@ -468,7 +472,7 @@ export class WorkflowService {
       runnerAbortController
     );
     try {
-      const runner = this.createRunner(runId, input.projectTrusted);
+      const runner = await this.createRunner(runId, input.projectTrusted);
       const result = await runner.run(runId, {
         abortSignal: runnerAbortController.signal,
         ...(input.backgroundOnMessageQueued !== undefined
@@ -666,7 +670,7 @@ export class WorkflowService {
     return runId;
   }
 
-  private runInBackground(
+  private async runInBackground(
     runId: string,
     failureMessage: string,
     runnerOptions: Pick<
@@ -676,7 +680,7 @@ export class WorkflowService {
       projectTrusted: boolean;
     }
   ): Promise<void> {
-    const runner = this.createRunner(runId, runnerOptions.projectTrusted);
+    const runner = await this.createRunner(runId, runnerOptions.projectTrusted);
     const runnerAbortController = new AbortController();
     let unregisterRunnerAbort: () => void = () => undefined;
     let startedSettled = false;
@@ -759,11 +763,17 @@ export class WorkflowService {
     }
   }
 
-  private createRunner(runId: string, projectTrusted: boolean): WorkflowRunner {
+  private async createRunner(runId: string, projectTrusted: boolean): Promise<WorkflowRunner> {
+    // The run record always exists by the time a runner is created (create/resume/retry
+    // paths persist it first), so resolve the definition name for task labeling here.
+    const workflowName =
+      this.taskAdapterFactory != null
+        ? (await this.runStore.getRun(runId)).definition.name
+        : undefined;
     return new WorkflowRunner({
       runStore: this.runStore,
       runtimeFactory: this.runtimeFactory,
-      taskAdapter: this.taskAdapterFactory?.(runId) ?? this.requireTaskAdapter(),
+      taskAdapter: this.taskAdapterFactory?.(runId, workflowName) ?? this.requireTaskAdapter(),
       actionRegistry: this.actionRegistry,
       actionRunner: this.actionRunner,
       getProjectTrusted: () => this.resolveCurrentProjectTrust(projectTrusted),

--- a/src/node/services/workflows/WorkflowTaskServiceAdapter.test.ts
+++ b/src/node/services/workflows/WorkflowTaskServiceAdapter.test.ts
@@ -295,6 +295,30 @@ describe("WorkflowTaskServiceAdapter", () => {
     ]);
   });
 
+  test("forwards run lifecycle hooks to the task service cleanup hold", async () => {
+    const markWorkflowRunActive = mock((_runId: string) => undefined);
+    const markWorkflowRunEnded = mock(async (_runId: string) => undefined);
+    const adapter = new WorkflowTaskServiceAdapter({
+      taskService: {
+        create: mock(async () =>
+          Ok({ taskId: "task_1", kind: "agent" as const, status: "running" as const })
+        ),
+        waitForAgentReport: mock(async () => ({ reportMarkdown: "unused" })),
+        markWorkflowRunActive,
+        markWorkflowRunEnded,
+      },
+      parentWorkspaceId: "parent_1",
+      workflowRunId: "wfr_123",
+      defaultAgentId: "explore",
+    });
+
+    adapter.onRunStarted();
+    await adapter.onRunEnded();
+
+    expect(markWorkflowRunActive).toHaveBeenCalledWith("wfr_123");
+    expect(markWorkflowRunEnded).toHaveBeenCalledWith("wfr_123");
+  });
+
   test("passes workflow wait options into report waits", async () => {
     const abortController = new AbortController();
     const create = mock(async () =>

--- a/src/node/services/workflows/WorkflowTaskServiceAdapter.test.ts
+++ b/src/node/services/workflows/WorkflowTaskServiceAdapter.test.ts
@@ -262,6 +262,39 @@ describe("WorkflowTaskServiceAdapter", () => {
     );
   });
 
+  test("stamps the workflow name onto spawned tasks when known", async () => {
+    const create = mock(async (_args: unknown) =>
+      Ok({ taskId: "task_1", kind: "agent" as const, status: "running" as const })
+    );
+    const createMany = mock(async (args: unknown[]) =>
+      Ok(
+        args.map((_, index) => ({
+          taskId: `task_${index}`,
+          kind: "agent" as const,
+          status: "queued" as const,
+        }))
+      )
+    );
+    const waitForAgentReport = mock(async () => ({ reportMarkdown: "child report" }));
+    const adapter = new WorkflowTaskServiceAdapter({
+      taskService: { create, createMany, waitForAgentReport },
+      parentWorkspaceId: "parent_1",
+      workflowRunId: "wfr_123",
+      workflowName: "sidebar-demo",
+      defaultAgentId: "explore",
+    });
+
+    await adapter.runAgent({ id: "claims", prompt: "Extract claims", title: "Claim extractor" });
+    await adapter.createAgentTasks([{ id: "first", prompt: "Do first", title: "First" }]);
+
+    expect(create.mock.calls[0]?.[0]).toMatchObject({
+      workflowTask: { runId: "wfr_123", stepId: "claims", workflowName: "sidebar-demo" },
+    });
+    expect(createMany.mock.calls[0]?.[0]).toMatchObject([
+      { workflowTask: { runId: "wfr_123", stepId: "first", workflowName: "sidebar-demo" } },
+    ]);
+  });
+
   test("passes workflow wait options into report waits", async () => {
     const abortController = new AbortController();
     const create = mock(async () =>

--- a/src/node/services/workflows/WorkflowTaskServiceAdapter.ts
+++ b/src/node/services/workflows/WorkflowTaskServiceAdapter.ts
@@ -74,6 +74,8 @@ interface WorkflowTaskServiceLike {
     workspaceId: string,
     options?: { workflowRunId?: string }
   ): Promise<string[]>;
+  markWorkflowRunActive?(workflowRunId: string): void;
+  markWorkflowRunEnded?(workflowRunId: string): Promise<void>;
 }
 
 type WorkflowPatchArtifactApplier = (
@@ -208,6 +210,16 @@ export class WorkflowTaskServiceAdapter implements WorkflowTaskAdapter {
     await this.taskService.terminateAllDescendantAgentTasks?.(this.parentWorkspaceId, {
       workflowRunId: this.workflowRunId,
     });
+  }
+
+  // Completed child workspaces are held (not auto-deleted) while the run is
+  // active so the sidebar shows the run's tasks for its entire duration.
+  onRunStarted(): void {
+    this.taskService.markWorkflowRunActive?.(this.workflowRunId);
+  }
+
+  async onRunEnded(): Promise<void> {
+    await this.taskService.markWorkflowRunEnded?.(this.workflowRunId);
   }
 
   async createAgentTasks(

--- a/src/node/services/workflows/WorkflowTaskServiceAdapter.ts
+++ b/src/node/services/workflows/WorkflowTaskServiceAdapter.ts
@@ -35,6 +35,7 @@ interface WorkflowTaskServiceLike {
     workflowTask: {
       runId: string;
       stepId: string;
+      workflowName?: string;
       outputSchema?: unknown;
     };
     experiments?: WorkflowTaskExperiments;
@@ -51,6 +52,7 @@ interface WorkflowTaskServiceLike {
       workflowTask: {
         runId: string;
         stepId: string;
+        workflowName?: string;
         outputSchema?: unknown;
       };
       experiments?: WorkflowTaskExperiments;
@@ -83,6 +85,12 @@ export interface WorkflowTaskServiceAdapterOptions {
   taskService: WorkflowTaskServiceLike;
   parentWorkspaceId: string;
   workflowRunId: string;
+  /**
+   * Human-readable workflow definition name, stamped onto spawned tasks so the
+   * sidebar can label workflow run groups. Optional: interrupt-only adapters
+   * and legacy call sites may not know the name.
+   */
+  workflowName?: string;
   defaultAgentId: string;
   experiments?: WorkflowTaskExperiments;
   modelString?: string;
@@ -96,6 +104,7 @@ export class WorkflowTaskServiceAdapter implements WorkflowTaskAdapter {
   private readonly taskService: WorkflowTaskServiceLike;
   private readonly parentWorkspaceId: string;
   private readonly workflowRunId: string;
+  private readonly workflowName?: string;
   private readonly defaultAgentId: string;
   private readonly patchToolConfig?: TaskApplyGitPatchConfiguration;
   private readonly applyPatchArtifact?: WorkflowPatchArtifactApplier;
@@ -121,6 +130,7 @@ export class WorkflowTaskServiceAdapter implements WorkflowTaskAdapter {
     this.taskService = options.taskService;
     this.parentWorkspaceId = options.parentWorkspaceId;
     this.workflowRunId = options.workflowRunId;
+    this.workflowName = options.workflowName;
     this.defaultAgentId = options.defaultAgentId;
     this.patchToolConfig = options.patchToolConfig;
     this.applyPatchArtifact = options.applyPatchArtifact;
@@ -249,10 +259,18 @@ export class WorkflowTaskServiceAdapter implements WorkflowTaskAdapter {
     assert(spec.id.length > 0, "WorkflowTaskServiceAdapter: spec.id is required");
     assert(spec.prompt.length > 0, "WorkflowTaskServiceAdapter: spec.prompt is required");
 
-    const workflowTask: { runId: string; stepId: string; outputSchema?: unknown } = {
+    const workflowTask: {
+      runId: string;
+      stepId: string;
+      workflowName?: string;
+      outputSchema?: unknown;
+    } = {
       runId: this.workflowRunId,
       stepId: spec.id,
     };
+    if (this.workflowName !== undefined) {
+      workflowTask.workflowName = this.workflowName;
+    }
     if (spec.outputSchema !== undefined) {
       workflowTask.outputSchema = spec.outputSchema;
     }


### PR DESCRIPTION
### Summary

Groups workflow-spawned agent sub-tasks under a collapsible `Workflow · <name>` heading per run (`wfr_…`) in the left sidebar, and integrates all task-group headers (variants, best-of, workflow runs) with the native sub-agent tree: continuous connector rails, the shared `StatusDot` status language, deduped member titles, and persisted expansion state.

### Background

Workflow runs spawn agent sub-tasks that previously rendered as ordinary nested rows under the host workspace — tasks from concurrent runs interleaved with no visual division, no way to tell which task belonged to which run, and no way to collapse a run's tasks. The existing variant/best-of group UI (`TaskGroupListItem`) also looked bolted-on: it broke tree connectors, used a different status language than agent rows, repeated titles in member rows, and lost expansion state on reload.

### Implementation

**Phase 1 — task-group UI integration**

- **Row-model refactor**: the sidebar now builds the final renderable row list (workspace rows + synthetic group-header rows, post-coalescing) first, then derives connector geometry from that final order via `computeRowMetaForVisibleNodes`. This keeps trunks/elbows continuous through group headers and enables non-contiguous member gathering.
- **Visual integration**: extracted `StatusDot` from `AgentListItem` into a shared component; group headers show an aggregate dot (error → active → idle) and render inside the same connector rails as sub-agent rows.
- **Member dedup**: expanded members suppress titles that repeat the group header; best-of candidates render as `Candidate A/B/C`, variants render their label.
- **Persistence**: expansion state moves to `usePersistedState("expandedTaskGroups", …)` with namespaced keys (`task:<parent>:<groupId>` / `workflow:<parent>:<runId>`).

**Phase 2 — workflow run grouping**

- **Name plumbing**: `WorkflowTaskMetadataSchema` gains an optional `workflowName`, stamped at spawn time by `WorkflowTaskServiceAdapter` (threaded from the runner via `WorkflowService.createRunner`). Optional ⇒ upgrade/downgrade-safe, no migration; old entries fall back to a shortened run id in the header.
- **Grouping rules**: workspaces with `workflowTask.runId` (and no `bestOf` — best-of precedence preserved) coalesce into one group per run, scoped `section + parent + runId`, gathering non-contiguous members, forming from the first spawned task. Leaf-only rule kept: members with their own children fall out as normal subtrees.
- **Liveness / anti-flash**: active runs default to expanded and stay session-sticky; all same-run leaf members — including completed siblings normally hidden by completed-sub-agent filtering — remain visible while the run is active, so step transitions don't flash the group out. The backend `TaskService` additionally holds completed child workspaces (`markWorkflowRunActive`/`markWorkflowRunEnded`, bracketed by `WorkflowRunner`) so cleanup can't delete them mid-run.

### Validation

- Unit + component coverage: `sidebarTaskGroups.test.ts`, `workspaceFiltering.test.ts`, `ProjectSidebar.test.tsx` (concurrent runs, non-contiguous gathering, best-of precedence, persisted toggles, hidden-selected-member reveal, step-gap stability), `AgentListItem.test.tsx`, `WorkflowTaskServiceAdapter.test.ts`, `WorkflowRunner.test.ts` (lifecycle bracket incl. failure + lease-loss paths).
- Storybook/Chromatic: `NestedTaskGroupConnectors`, `WorkflowRunGroups`, `BestOfGroup` stories with play assertions.
- End-to-end sandbox dogfood: isolated dev-server (`make dev-server-sandbox`), two concurrent scratch workflow runs + a variants batch in one workspace; verified grouping, expansion persistence across reload, and no sidebar flashing between sequential steps (screenshots + recording captured during development).

### Risks

Moderate, contained to the sidebar render pipeline: the connector-geometry refactor touches how all nested rows compute rails, so a regression would surface as cosmetic tree-line glitches across the sidebar (covered by geometry tests + Chromatic stories). The backend cleanup-hold is additive and fails open — if a hold is leaked, workspaces persist until the next sweep rather than being deleted prematurely.

---

<details>
<summary>📋 Implementation Plan</summary>

# Sidebar: group workflow sub-agents per run + integrate variant/task-group UI

## Context

Workflow runs (`wfr_…`) spawn agent sub-tasks that currently render as ordinary nested rows under the host workspace — when multiple workflows run concurrently their tasks interleave and there is no way to tell which task belongs to which run, nor to collapse a run's tasks. Meanwhile the existing variant/best-of group UI (`TaskGroupListItem`) looks bolted-on: it breaks the sub-agent tree connectors, uses a different status language than agent rows, repeats titles in member rows, and loses expansion state on reload.

Two phases: **(1)** integrate the existing task-group UI with agent-row rendering, **(2)** reuse that machinery to group workflow-owned sub-agents per `workflowTask.runId`.

## Goals

- Workflow-spawned sub-agents stay grouped + collapsible per workflow run in the left sidebar; concurrent runs form separate groups.
- Task-group headers (variants/best-of **and** workflow runs) look and behave like native parts of the agent tree.

## Non-goals (follow-ups, not in this change)

- Group-level actions (terminate-all, archive-all, context menu on header).
- Sidebar rows for workflow runs that spawned no agent tasks (chat's `WorkflowRunToolCall` already covers run lifecycle).
- Grouping members that have their own children (leaf-only rule kept, see D4).
- New IPC endpoints or run-event subscriptions.

## Current state (verified)

- **Grouping pass**: `renderWorkspaceRowsWithTaskGroupCoalescing` + `getTaskGroupId` in `src/browser/components/ProjectSidebar/ProjectSidebar.tsx`. Groups require `bestOf.groupId`, a `parentWorkspaceId`, `total >= 2`, leaf members, and **contiguous visible rows**. Header = `TaskGroupListItem`; expanded members render via `renderWorkspace(…, "task-group-member")` at `getTaskGroupMemberDepth(depth)` (= depth + 1.5, `src/browser/components/sidebarItemLayout.ts`).
- **Expansion**: `const [expandedTaskGroups] = useState<Record<string, boolean>>({})` — in-memory only, default collapsed (`?? false`). Completed sub-agents by contrast persist under `usePersistedState("expandedCompletedSubAgents", …)`.
- **Header row**: `TaskGroupListItem.tsx` is a plain `div`: no ancestor-trunk/elbow connectors (those live in `SubAgentListItem.tsx`), a static `Layers3` icon tinted green when running (vs the `StatusDot` visual language `active|idle|seen|hidden|error|question` defined inline in `AgentListItem.tsx`), title `formatTaskGroupHeader(kind, total, title)` from `src/common/utils/tools/taskGroups.ts`.
- **Member rows**: `AgentListItem.tsx` composes `groupLabel · workspaceTitle` where `groupLabel` = variant label or letter `A/B/C…`; the title duplicates the group header title verbatim.
- **Workflow metadata already flows to the frontend**: `WorkflowTaskMetadataSchema { runId, stepId, outputSchema? }` is stamped by `WorkflowTaskServiceAdapter.buildCreateArgs` (`src/node/services/workflows/WorkflowTaskServiceAdapter.ts`) → `TaskService.create/createMany` (`src/node/services/taskService.ts`) → persisted on the workspace entry in `~/.mux/config.json` (`src/common/schemas/project.ts`) → passes untouched through `src/node/config.ts` / `workspaceService.ts` into `FrontendWorkspaceMetadata` (`workflowTask` field on `WorkspaceMetadataSchema`, `src/common/orpc/schemas/workspace.ts`).
- **Missing for a nice header title**: the human-readable workflow name. The adapter only knows `workflowRunId`; the name lives in `WorkflowRunRecordSchema.definition.name` (`src/common/orpc/schemas/workflow.ts`, persisted by `WorkflowRunStore`). The `taskAdapterFactory` closure in `src/node/orpc/router.ts` constructs the adapter per run. There are **no push events** for runs (chat UI polls every 2s), so a frontend `runId → name` join would add polling; stamping the name at spawn time is cleaner.

## Design decisions

| # | Decision | Choice + rationale |
|---|---|---|
| D1 | Workflow group header component | **Reuse `TaskGroupListItem`** with a **sidebar-local** `SidebarGroupKind = "bestOf" \| "variants" \| "workflow"` (defined in the sidebar layer, e.g. next to `TaskGroupListItem`). Do **not** extend tool-level `TaskGroupKind` in `src/common/utils/tools/taskGroups.ts` — that utility describes task-tool metadata; workflow semantics stay UI-only. Workflow header copy is formatted in the sidebar layer. Avoids a parallel `WorkflowRunListItem`; run controls already exist in chat. |
| D2 | Workflow name plumbing | **Stamp `workflowName` into `workflowTask` at spawn time** (optional schema field). Reject frontend join via `workflows.listRuns` (would need polling; no push events). Fallback when absent (old runs / resumed pre-upgrade runs): header shows shortened `runId`. |
| D3 | Grouping key precedence | A workspace with `bestOf` groups by `bestOf.groupId` (existing behavior wins); `workflowTask.runId` grouping applies only when `bestOf` is absent. Both require `parentWorkspaceId`. |
| D4 | Leaf-only rule | Keep for workflow members in v1 (member that spawns its own sub-agents falls out of the group and renders as a normal subtree). Avoids nested-subtree-inside-group connector math; noted as follow-up. |
| D5 | Contiguity + render model | Variants keep the existing contiguous-rows requirement (spawned atomically, sorted adjacent). **Workflow groups must not require contiguity** — steps spawn over time and interleave with other rows, especially with concurrent runs (the motivating scenario). All visible members of a run render under the group header at the first member's position; later positions are suppressed. **Prerequisite**: today `rowMetaByWorkspaceId` (connector geometry) is computed *before* coalescing, so pulling rows up would leave stale connectors ⇒ Phase 1 first builds a final renderable row model (workspace rows + synthetic group-header rows, post-coalescing) and derives connector metadata from that final order. Group identity is scoped **`section + parentWorkspaceId + groupId/runId`** so active/archived sections never merge. |
| D6 | Min group size / default expansion | Workflow groups form **from the first member** (`total` is unknown up-front; avoids layout flip when the 2nd task appears). Default expansion is **initial-default only, never a live flip**: a group whose members are (or become, this session) queued/running defaults expanded and *stays* expanded — no auto-collapse on completion mid-session. After reload, a completed-only group defaults collapsed. An explicit user toggle (persisted) always wins. Variants keep min-2 and default-collapsed. |
| D7 | Expansion persistence | Switch `expandedTaskGroups` to `usePersistedState("expandedTaskGroups", {})`, shared by variant and workflow groups, with **namespaced keys** — `task:${parentWorkspaceId}:${groupId}` / `workflow:${parentWorkspaceId}:${runId}` — rather than assuming raw ids are globally unique. Matches the `expandedCompletedSubAgents` pattern. Persisted keys intentionally omit the section so a user's toggle survives a group moving between sections (rendering identity still uses section scoping per D5). |
| D8 | Member label dedup | In `task-group-member` layout, suppress the member's `workspaceTitle` when it equals the group title; show the title when it differs (self-healing for custom titles). Label-only rows stay readable: variant label as-is, best-of letters render as `Candidate A` (never a bare `A`). Workflow members keep their own task titles (usually distinct per step) — same rule applies naturally. |
| D9 | Completed-member visibility | If any workflow group member is queued/running/active, the group is eligible and renders **all same-run leaf members — including completed siblings that would otherwise be hidden** by completed-sub-agent filtering — so active workflow context stays complete. If **all** members are terminal, apply the existing completed-sub-agent visibility rules (hidden unless the parent's completed children are expanded or a member is selected); when visible after reload, default collapsed (D6). |

## Phase 1 — Integrate task-group UI with agent rows

Files: `TaskGroupListItem.tsx`, `ProjectSidebar.tsx`, `AgentListItem.tsx`, `SubAgentListItem.tsx`, `sidebarItemLayout.ts`, `src/browser/utils/ui/workspaceFiltering.ts`.

1. **Row-model refactor (prerequisite for D5 and connector continuity)**: restructure the sidebar render pipeline to first build the final renderable row list (workspace rows + synthetic group-header rows, after coalescing/suppression), then derive `AgentRowRenderMeta`/connector geometry from that final order — today meta is computed pre-coalescing in `workspaceFiltering.ts`, which breaks once rows can be pulled together non-contiguously (Phase 2) and leaves group headers without connector meta.
2. **Connector continuity**: render the group header with the same ancestor-trunk + elbow connectors as sub-agent rows. Extract the connector-rail rendering from `SubAgentListItem` (or wrap `TaskGroupListItem` in it) and feed it the header's own `AgentRowRenderMeta` from the row model, so trunks no longer cut off at the header.
3. **Status language**: extract the inline `StatusDot` from `AgentListItem.tsx` into a shared component; group header's leading slot shows an aggregate `StatusDot` (any error → `error`, else any running → `active`, else `idle`), replacing the green-tinted static icon. The kind glyph (`Layers3`) may stay as a small inline element before the title; exact micro-layout settled in Storybook.
4. **Member label dedup** per D8 in `AgentListItem.tsx`.
5. **Persist expansion** per D7 in `ProjectSidebar.tsx`.

*Optional delivery split if smaller PRs are preferred: **1A** = row model + persisted expansion + label dedup; **1B** = connector + StatusDot visual integration.*

**Acceptance criteria**

- A variant group nested inside a sub-agent tree shows continuous vertical rails through the header (no visual gap above/below).
- Header reflects member aggregate state with the same `StatusDot` states/animation as agent rows (incl. error state).
- Expanded members don't repeat the header title; labels (`frontend`, `Candidate A`) remain.
- Expand/collapse survives app reload.
- No behavior change for ungrouped rows; existing coalescing tests still pass.

**Tests**: update/extend `TaskGroupListItem.test.tsx` (aggregate dot states, a11y), `ProjectSidebar.test.tsx` (persisted expansion, dedup), `sidebarItemLayout.test.ts` (header connector geometry), `AgentListItem.test.tsx` (label-only member rows). Stories: extend `ProjectSidebar.stories.tsx` with a variant group nested under a sub-agent (the connector-break case) and `AgentListItem.stories.tsx` for member rows; verify at mobile width (~375px) per repo rule.

**Gate 1 (dogfood before Phase 2)**: Storybook screenshots of the nested-group story (before/after), real-app variant spawn — see Dogfooding section.

*Net LoC estimate (product code): **+150–230*** (row model ~50–80, connector reuse ~60–90, StatusDot extraction ~0 net, dedup ~10, persistence ~10, geometry helpers ~20).

## Phase 2 — Group workflow sub-agents per run

Files: `src/common/schemas/project.ts` (+ orpc schema if `WorkflowTaskMetadataSchema` is duplicated there — consolidate to one source if so), `WorkflowTaskServiceAdapter.ts`, `src/node/orpc/router.ts` (+ the factory's call site in `WorkflowService`/`WorkflowRunner`), `ProjectSidebar.tsx`, `TaskGroupListItem.tsx` (sidebar-local kind), `src/browser/utils/workspace.ts`, `src/browser/stories/mocks/workspaces.ts`.

1. **Schema**: add `workflowName: z.string().min(1).optional()` to `WorkflowTaskMetadataSchema`. Optional ⇒ upgrade/downgrade-safe, no migration (old entries parse; old app versions ignore the field).
2. **Stamping**: add `workflowName` to `WorkflowTaskServiceAdapterOptions`; include it in `buildCreateArgs`'s `workflowTask`. Thread the name into the factory: extend the `taskAdapterFactory` signature (`(runId) ⇒ adapter` → `(runId, workflowName) ⇒ adapter`) — the caller (workflow runner/service) has `definition.name` when executing. (Fallback option if threading is awkward: pass `WorkflowRunStore` and resolve lazily; avoid if the sync path works.)
3. **Kind**: add sidebar-local `SidebarGroupKind` incl. `"workflow"` per D1 (tool-level `TaskGroupKind` untouched); header copy `Workflow · <name>` (fallback `Workflow · wfr_…` short id); items label "tasks". Counts show live members only (no up-front total — `totalCount` = members spawned so far).
4. **Sidebar grouping**: in `ProjectSidebar.tsx`, add a `getWorkflowGroupId` (`workflowTask.runId` when `bestOf` absent + `parentWorkspaceId` set + leaf), keyed per D5 (`section + parentWorkspaceId + runId`), and extend the row-model grouping per D5 (non-contiguous gathering, min size 1), D6 (initial-default expansion), and D9 (completed-member visibility). Sort members by spawn order (config order / `createdAt`), label rows with their task titles.
5. **Sidebar re-render key**: add `workflowTask?.runId`, `stepId`, `workflowName` to `getWorkspaceSidebarKey` (documented convention in that file).
6. **Mocks/stories**: add `workflowTask` to `WorkspaceFixture` in `src/browser/stories/mocks/workspaces.ts`; story with two concurrent workflow runs + a variant group under one workspace.

**Acceptance criteria**

- Tasks of one workflow run render under one collapsible `Workflow · <name>` header; two concurrent runs ⇒ two separate groups, even when their tasks interleave by recency.
- Group appears from the first spawned task; new tasks join the group without layout flip.
- Header shows aggregate status + live counts; default expansion per D6 (expanded while active, no live auto-collapse, collapsed-after-reload when done); manual toggle persists.
- `bestOf` workspaces are untouched by workflow grouping (D3); workspaces without `workflowTask` unaffected.
- Active groups render all same-run leaf members incl. otherwise-hidden completed siblings; completed-only groups follow existing completed-sub-agent visibility (D9).
- **Selection**: a selected member inside a collapsed group marks the header selected; expanding reveals the selected row — including when the member is completed/normally hidden.
- Old persisted workspaces (no `workflowName`) fall back to short `runId` header — no crash, no migration.

**Tests**: `WorkflowTaskServiceAdapter.test.ts` (workflowName passed to `taskService.create/createMany`), `ProjectSidebar.test.tsx` (grouping by runId, non-contiguous members pulled together, single-member group, two concurrent runs, bestOf precedence, fallback title, completed-siblings-visible-while-active per D9, selection of a hidden/completed member in a collapsed group marks header + expand reveals it), behavioral only — no prompt-text/copy assertions.

**Gate 2**: real-app dogfood with two concurrent scratch workflows — see below.

*Net LoC estimate (product code): **+120–180*** (schema +3, adapter/factory +15–25, sidebar kind/copy +15, sidebar grouping incl. D6/D9 rules +80–130, key +3, mocks excluded).

## Dogfooding & verification (both gates)

**Storybook (Phase 1 + 2 visual checks)**

1. `bun install && make storybook` (or `bun run storybook`) in the worktree.
2. Use `agent-browser` to open the relevant stories (`ProjectSidebar` task-group / workflow-group stories), `snapshot -i`, take screenshots at desktop and `mobile1` (~375px) widths.
3. `attach_file` before/after screenshots of: nested variant group (connector continuity), header StatusDot states (running/error/idle), workflow group with two runs.

**Real app (Gate 2, end-to-end)**

1. Read the `dev-server-sandbox` skill; start an isolated mux dev-server (temp `MUX_ROOT`, free ports).
2. Create a test project + workspace via the UI (agent-browser).
3. Drop a scratch workflow at `.mux/workflows/.scratch/sidebar-demo.js` (per `workflow-authoring` skill) that spawns 2–3 cheap agent tasks across two steps (e.g. `explore` agents with trivial prompts).
4. Start the workflow twice concurrently (two runs); also spawn a `variants` task batch in the same workspace.
5. Screenshot the sidebar: two collapsed/expanded workflow groups + one variant group; collapse one run, reload the app, verify persistence; screenshot again.
6. **Record a video of the interaction (required)** — agent-browser recording of the sandboxed app session — plus the step-by-step screenshot sequence; `attach_file` everything for review. If recording tooling is unavailable in the environment, report that as a validation blocker rather than silently skipping.

**Validation commands**

- `make static-check` (typecheck + lint + fmt + docs links) — must pass before each gate.
- Targeted: `bun test src/browser/components/ProjectSidebar src/browser/components/AgentListItem src/node/services/workflows/WorkflowTaskServiceAdapter.test.ts src/browser/components/sidebarItemLayout.test.ts`.
- Full `make test` before final handoff.

## Risks & notes

- **Row-model refactor + connector geometry** is the riskiest part (Phase 1.1–1.2); mitigated by `workspaceFiltering.test.ts`/`sidebarItemLayout.test.ts` coverage + Storybook/Chromatic stories pinned at the breakpoints that matter.
- **D6 expansion defaults** are initial-default-only (no live flips), so mid-session surprise is eliminated; if reload-collapse feels off during dogfood, fall back to default-expanded-always (one-line change).
- **`WorkflowTaskMetadataSchema` duplication**: defined in `src/common/schemas/project.ts` and referenced from `src/common/orpc/schemas/workspace.ts` — implementer must confirm single source and add the field once (repo rule: no duplicate types around IPC).
- **Total LoC**: ~+270–410 net product code across both phases.

</details>

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `high` • Cost: `$71.24`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=high costs=71.24 -->
