### PR TITLE
🤖 feat: add project-local memory scope

### DIFF
--- a/src/browser/features/Memory/MemoryBrowser.tsx
+++ b/src/browser/features/Memory/MemoryBrowser.tsx
@@ -22,6 +22,7 @@ import { getErrorMessage } from "@/common/utils/errors";
 import { MemoryFileEditor } from "./MemoryFileEditor";
 
 const SCOPE_LABELS: Record<MemoryScope, string> = {
+  "project-local": "Project (local)",
   global: "Global",
   project: "Project",
   workspace: "Workspace",

--- a/src/common/constants/memory.ts
+++ b/src/common/constants/memory.ts
@@ -4,15 +4,17 @@
  * Models only ever see virtual paths under the virtual root (e.g.
  * /memories/global/preferences.md). The MemoryService maps each scope to a
  * physical root:
- * - global    -> <muxHome>/memory/ (host-local, permanent, shared across projects)
- * - project   -> <workspace checkout>/.mux/memory/ (via Runtime, git-tracked)
- * - workspace -> <sessionDir>/memory/ (host-local, deleted with the workspace)
+ * - global        -> <muxHome>/memory/ (host-local, permanent, shared across projects)
+ * - project       -> <workspace checkout>/.mux/memory/ (via Runtime, git-tracked)
+ * - project-local -> <muxHome>/project-memory/<project dir>/ (host-local, private
+ *                    per-project notes; never committed, survives workspaces)
+ * - workspace     -> <sessionDir>/memory/ (host-local, deleted with the workspace)
  */
 
 /** Virtual root prefix all memory paths are expressed under. */
 export const MEMORY_VIRTUAL_ROOT = "/memories";
 
-export const MEMORY_SCOPES = ["global", "project", "workspace"] as const;
+export const MEMORY_SCOPES = ["global", "project", "project-local", "workspace"] as const;
 export type MemoryScope = (typeof MEMORY_SCOPES)[number];
 
 export type MemoryAccessLevel = "read" | "readwrite";
@@ -21,7 +23,8 @@ export type MemoryAccessLevel = "read" | "readwrite";
  * Per-scope write policy for the memory tool, derived from the agent class:
  * - Exec-like (editing-capable): all scopes read-write.
  * - Plan-like: project scope read-only (project memories are git-tracked files
- *   in the checkout; plan agents must not mutate the repo).
+ *   in the checkout; plan agents must not mutate the repo). project-local stays
+ *   read-write: it is host-local and never touches the checkout.
  * - Explore/read-only: all scopes read-only (view only).
  */
 export type MemoryScopeAccess = Record<MemoryScope, MemoryAccessLevel>;

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -1203,6 +1203,7 @@ export const TOOL_DEFINITIONS = {
       "Scopes (all paths are virtual):\n" +
       "- /memories/global/... — personal, permanent, shared across all projects\n" +
       "- /memories/project/... — committed with the repository (git-tracked, reviewable); never store secrets here\n" +
+      "- /memories/project-local/... — private notes about this project; host-local, never committed, survives workspaces\n" +
       "- /memories/workspace/... — scratch state for this workspace; deleted with the workspace\n" +
       "Commands:\n" +
       "- view: list a directory (up to 2 levels, dotfiles excluded) or show a file with line numbers (offset/limit supported)\n" +

--- a/src/node/orpc/router.memory.test.ts
+++ b/src/node/orpc/router.memory.test.ts
@@ -368,7 +368,7 @@ describe("router memory routes", () => {
     const consumer = (async () => {
       for await (const event of iterator) {
         received.push(event);
-        if (received.length >= 3) break;
+        if (received.length >= 4) break;
       }
     })();
     // The route attaches its service listener lazily (on first pull).
@@ -390,6 +390,15 @@ describe("router memory routes", () => {
     emit({
       scope: "project",
       path: "/memories/project/notes.md",
+      actor: "agent",
+      workspaceId: "ws-other",
+      projectPath: "/somewhere/else",
+    });
+    // Dropped: another project's project-local file (host-local stores are
+    // separate per project; same virtual path, different physical file).
+    emit({
+      scope: "project-local",
+      path: "/memories/project-local/notes.md",
       actor: "agent",
       workspaceId: "ws-other",
       projectPath: "/somewhere/else",
@@ -419,12 +428,22 @@ describe("router memory routes", () => {
       workspaceId: "ws-other",
       projectPath,
     });
+    // Delivered: same project's project-local file (shared across the
+    // project's workspaces, host-local).
+    emit({
+      scope: "project-local",
+      path: "/memories/project-local/notes.md",
+      actor: "agent",
+      workspaceId: "ws-other",
+      projectPath,
+    });
 
     await consumer;
     expect(received.map((e) => [e.scope, e.workspaceId])).toEqual([
       ["global", "ws-other"],
       ["workspace", "ws-mem"],
       ["project", "ws-other"],
+      ["project-local", "ws-other"],
     ]);
   });
 });

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -3808,7 +3808,14 @@ export const router = (authToken?: string) => {
           // Global events are always forwarded (shared across everything).
           const onChange = (event: MemoryChangeEvent) => {
             if (event.scope === "workspace" && event.workspaceId !== boundWorkspaceId) return;
-            if (event.scope === "project" && event.projectPath !== boundProjectPath) return;
+            // project AND project-local are both keyed by project identity:
+            // the same virtual path in another project is a different file.
+            if (
+              (event.scope === "project" || event.scope === "project-local") &&
+              event.projectPath !== boundProjectPath
+            ) {
+              return;
+            }
             queue.push(event);
           };
           context.memoryService.on("change", onChange);

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -47,6 +47,7 @@ import { readPlanFile } from "@/node/utils/runtime/helpers";
 import {
   parseMemoryPath,
   resolveMemoryProjectAnchor,
+  resolveMemoryProjectIdentity,
   type MemoryChangeEvent,
   type MemoryScopeContext,
 } from "@/node/services/memoryService";
@@ -316,9 +317,12 @@ async function resolveMemoryScopeContext(
   const runtime = createRuntimeForWorkspace(metadata);
   // "" disables the project scope (multi-project container / unresolvable root).
   const checkoutCwd = resolveMemoryProjectAnchor(metadata, runtime) ?? "";
+  // "" for multi-project workspaces: metadata.projectPath is the first
+  // project's path, not a single stable identity.
+  const projectPath = resolveMemoryProjectIdentity(metadata);
   return {
-    projectPath: metadata.projectPath,
-    scopeCtx: { runtime, checkoutCwd, workspaceId, projectPath: metadata.projectPath },
+    projectPath,
+    scopeCtx: { runtime, checkoutCwd, workspaceId, projectPath },
   };
 }
 
@@ -3800,8 +3804,13 @@ export const router = (authToken?: string) => {
           // scope) is a physically different file, so those events are
           // dropped here rather than badging unrelated files in the UI.
           const boundWorkspaceId = input.workspaceId ?? null;
-          const boundProjectPath = boundWorkspaceId
-            ? ((await context.workspaceService.getInfo(boundWorkspaceId))?.projectPath ?? null)
+          const boundMetadata = boundWorkspaceId
+            ? await context.workspaceService.getInfo(boundWorkspaceId)
+            : null;
+          // Same identity resolution as the scope context: multi-project
+          // subscribers bind "" so no project-keyed events match.
+          const boundProjectPath = boundMetadata
+            ? resolveMemoryProjectIdentity(boundMetadata)
             : null;
           const queue = createAsyncEventQueue<MemoryChangeEvent>();
 

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -87,7 +87,11 @@ import type { WorkspaceMCPOverrides } from "@/common/types/mcp";
 import type { MCPServerManager, MCPWorkspaceStats } from "@/node/services/mcpServerManager";
 import { WorkspaceMcpOverridesService } from "./workspaceMcpOverridesService";
 import type { TaskService } from "@/node/services/taskService";
-import { resolveMemoryProjectAnchor, type MemoryService } from "@/node/services/memoryService";
+import {
+  resolveMemoryProjectAnchor,
+  resolveMemoryProjectIdentity,
+  type MemoryService,
+} from "@/node/services/memoryService";
 import { formatHotMemoriesBlock } from "@/node/services/memoryHotSet";
 import { resolveMemoryAccessPolicy } from "@/node/services/tools/memory";
 import { isExecLikeEditingCapableInResolvedChain } from "@/common/utils/agentTools";
@@ -520,7 +524,7 @@ export class AIService extends EventEmitter {
         // "" disables the project scope (multi-project / unresolvable root).
         checkoutCwd: resolveMemoryProjectAnchor(metadata, runtime) ?? "",
         workspaceId,
-        projectPath: metadata.projectPath,
+        projectPath: resolveMemoryProjectIdentity(metadata),
       });
       return items.length === 0 ? null : formatHotMemoriesBlock(items);
     } catch (error) {

--- a/src/node/services/memoryMeta.ts
+++ b/src/node/services/memoryMeta.ts
@@ -33,6 +33,7 @@ function encodeKeyComponent(value: string): string {
  * Logical identity of a memory file, independent of physical location:
  * - global:<relPath>
  * - project:<projectId>:<relPath>
+ * - project-local:<projectId>:<relPath>
  * - workspace:<workspaceId>:<relPath>
  *
  * Components are escaped so embedded ':' cannot alias another memory's key
@@ -52,6 +53,8 @@ export function memoryLogicalKey(
       return `global:${encodeKeyComponent(relPath)}`;
     case "project":
       return `project:${encodeKeyComponent(ids.projectPath)}:${encodeKeyComponent(relPath)}`;
+    case "project-local":
+      return `project-local:${encodeKeyComponent(ids.projectPath)}:${encodeKeyComponent(relPath)}`;
     case "workspace":
       return `workspace:${encodeKeyComponent(ids.workspaceId)}:${encodeKeyComponent(relPath)}`;
   }

--- a/src/node/services/memoryService.test.ts
+++ b/src/node/services/memoryService.test.ts
@@ -13,6 +13,7 @@ import {
   MemoryService,
   projectMemoryDirName,
   resolveMemoryProjectAnchor,
+  resolveMemoryProjectIdentity,
   type MemoryScopeContext,
 } from "./memoryService";
 import { MemoryMetaService } from "./memoryMeta";
@@ -203,6 +204,32 @@ describe("MemoryService", () => {
       // Original content untouched.
       const physical = path.join(fixture.muxHome, "memory", "a.md");
       expect(await fsPromises.readFile(physical, "utf-8")).toBe("v1");
+    });
+  });
+
+  describe("resolveMemoryProjectIdentity", () => {
+    const baseMetadata = {
+      id: "ws-1",
+      name: "ws-1",
+      projectName: "alpha",
+      projectPath: "/projects/alpha",
+      createdAt: new Date().toISOString(),
+      runtimeConfig: { type: "local" as const, srcBaseDir: "/tmp" },
+    };
+
+    it("passes through the single-project identity", () => {
+      expect(resolveMemoryProjectIdentity(baseMetadata)).toBe("/projects/alpha");
+    });
+
+    it("returns '' for multi-project metadata (projectPath is just the first project)", () => {
+      const multi = {
+        ...baseMetadata,
+        projects: [
+          { projectPath: "/projects/alpha", projectName: "alpha" },
+          { projectPath: "/projects/beta", projectName: "beta" },
+        ],
+      };
+      expect(resolveMemoryProjectIdentity(multi)).toBe("");
     });
   });
 

--- a/src/node/services/memoryService.test.ts
+++ b/src/node/services/memoryService.test.ts
@@ -156,6 +156,24 @@ describe("MemoryService", () => {
       });
     });
 
+    it("disables project-local for multi-project workspaces (synthetic '_multi' identity)", async () => {
+      using fixture = await createFixture();
+      // All multi-project workspaces share the "_multi" config key; resolving
+      // a store from it would collide their private notes into one root.
+      const result = await fixture.service.create(
+        { ...fixture.ctx, projectPath: "_multi" },
+        "/memories/project-local/notes.md",
+        "leaked",
+        "agent"
+      );
+      expect(result).toEqual({
+        success: false,
+        error:
+          "Project-local memory is unavailable: multi-project workspaces have no single project identity",
+      });
+      expect(await pathExists(path.join(fixture.muxHome, "project-memory"))).toBe(false);
+    });
+
     it("supports nested paths, creating parent directories", async () => {
       using fixture = await createFixture();
       const created = await fixture.service.create(

--- a/src/node/services/memoryService.test.ts
+++ b/src/node/services/memoryService.test.ts
@@ -11,6 +11,7 @@ import {
   extractMemoryDescription,
   formatMemoryIndexBlock,
   MemoryService,
+  projectMemoryDirName,
   resolveMemoryProjectAnchor,
   type MemoryScopeContext,
 } from "./memoryService";
@@ -120,6 +121,41 @@ describe("MemoryService", () => {
       expect(await fsPromises.readFile(physical, "utf-8")).toBe("branch context");
     });
 
+    it("creates a project-local memory file under <muxHome>/project-memory, never the checkout", async () => {
+      using fixture = await createFixture();
+      const created = await fixture.service.create(
+        fixture.ctx,
+        "/memories/project-local/notes.md",
+        "private repo notes",
+        "agent"
+      );
+      expect(created.success).toBe(true);
+
+      const physical = path.join(
+        fixture.muxHome,
+        "project-memory",
+        projectMemoryDirName(FIXTURE_PROJECT_PATH),
+        "notes.md"
+      );
+      expect(await fsPromises.readFile(physical, "utf-8")).toBe("private repo notes");
+      // Private notes must never touch the repo checkout.
+      expect(await pathExists(path.join(fixture.checkout, ".mux"))).toBe(false);
+    });
+
+    it("fails project-local writes with a recoverable error when no project identity exists", async () => {
+      using fixture = await createFixture();
+      const result = await fixture.service.create(
+        { ...fixture.ctx, projectPath: "" },
+        "/memories/project-local/notes.md",
+        "orphan",
+        "agent"
+      );
+      expect(result).toEqual({
+        success: false,
+        error: "Project-local memory is unavailable: no project is associated with this session",
+      });
+    });
+
     it("supports nested paths, creating parent directories", async () => {
       using fixture = await createFixture();
       const created = await fixture.service.create(
@@ -149,6 +185,22 @@ describe("MemoryService", () => {
       // Original content untouched.
       const physical = path.join(fixture.muxHome, "memory", "a.md");
       expect(await fsPromises.readFile(physical, "utf-8")).toBe("v1");
+    });
+  });
+
+  describe("projectMemoryDirName", () => {
+    it("disambiguates same-named projects in different parent directories", () => {
+      const a = projectMemoryDirName("/home/alice/mux");
+      const b = projectMemoryDirName("/home/bob/mux");
+      expect(a).not.toBe(b);
+      // Both stay human-recognizable via the shared basename.
+      expect(a).toStartWith("mux-");
+      expect(b).toStartWith("mux-");
+    });
+
+    it("sanitizes path-hostile basenames into filesystem-safe names", () => {
+      const name = projectMemoryDirName("/tmp/we ird:proj");
+      expect(name).toMatch(/^[A-Za-z0-9._-]+$/);
     });
   });
 
@@ -205,13 +257,14 @@ describe("MemoryService", () => {
       }
     });
 
-    it("lists the three scopes when viewing the virtual root", async () => {
+    it("lists every scope when viewing the virtual root", async () => {
       using fixture = await createFixture();
       const viewed = await fixture.service.view(fixture.ctx, "/memories");
       expect(viewed.success).toBe(true);
       if (viewed.success) {
         expect(viewed.output).toContain("global/");
         expect(viewed.output).toContain("project/");
+        expect(viewed.output).toContain("project-local/");
         expect(viewed.output).toContain("workspace/");
       }
     });

--- a/src/node/services/memoryService.ts
+++ b/src/node/services/memoryService.ts
@@ -37,6 +37,7 @@ import {
   type MemoryScope,
 } from "@/common/constants/memory";
 import { shellQuote } from "@/common/utils/shell";
+import { PlatformPaths } from "@/common/utils/paths";
 import { getErrorMessage } from "@/common/utils/errors";
 import { isMultiProject } from "@/common/utils/multiProject";
 import type { WorkspaceMetadata } from "@/common/types/workspace";
@@ -212,6 +213,23 @@ export function parseMemoryPath(virtualPath: string): ParsedMemoryPath {
     `memory path validation must guarantee containment: '${virtualPath}'`
   );
   return { scope, relPath };
+}
+
+/**
+ * Filesystem-safe directory name for a project's host-local memory root
+ * (<muxHome>/project-memory/<dirName>). The sanitized basename keeps the dir
+ * human-recognizable; the path hash guarantees uniqueness across same-named
+ * projects in different parent directories.
+ */
+export function projectMemoryDirName(projectPath: string): string {
+  assert(projectPath !== "", "projectMemoryDirName requires a project identity");
+  const hash = createHash("sha256").update(projectPath).digest("hex").slice(0, 12);
+  // getProjectName falls back to "unknown" and sanitization maps (never
+  // drops) disallowed chars, so base is always non-empty.
+  const base = PlatformPaths.getProjectName(projectPath)
+    .replace(/[^A-Za-z0-9._-]/g, "_")
+    .slice(0, 40);
+  return `${base}-${hash}`;
 }
 
 function toVirtualPath(scope: MemoryScope, relPath: string): string {
@@ -671,7 +689,7 @@ export class MemoryService extends EventEmitter {
 
   /** Logical sidecar key, or null when the scope has no stable identity. */
   private logicalKeyFor(ctx: MemoryScopeContext, scope: MemoryScope, relPath: string) {
-    if (scope === "project" && ctx.projectPath === "") return null;
+    if ((scope === "project" || scope === "project-local") && ctx.projectPath === "") return null;
     return memoryLogicalKey(scope, relPath, {
       projectPath: ctx.projectPath,
       workspaceId: ctx.workspaceId,
@@ -740,6 +758,19 @@ export class MemoryService extends EventEmitter {
     switch (scope) {
       case "global":
         return new LocalMemoryStore(path.join(this.config.rootDir, "memory"));
+      case "project-local": {
+        if (ctx.projectPath === "") {
+          throw new MemoryCommandError(
+            "Project-local memory is unavailable: no project is associated with this session"
+          );
+        }
+        // Host-local private notes about the project: keyed by stable project
+        // identity (never the per-workspace checkout), so they survive
+        // re-checkouts and never appear in the repo.
+        return new LocalMemoryStore(
+          path.join(this.config.rootDir, "project-memory", projectMemoryDirName(ctx.projectPath))
+        );
+      }
       case "workspace": {
         if (!ctx.workspaceId) {
           throw new MemoryCommandError(

--- a/src/node/services/memoryService.ts
+++ b/src/node/services/memoryService.ts
@@ -40,6 +40,7 @@ import { shellQuote } from "@/common/utils/shell";
 import { PlatformPaths } from "@/common/utils/paths";
 import { getErrorMessage } from "@/common/utils/errors";
 import { isMultiProject } from "@/common/utils/multiProject";
+import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
 import type { WorkspaceMetadata } from "@/common/types/workspace";
 import type { Config } from "@/node/config";
 import type { Runtime } from "@/node/runtime/Runtime";
@@ -762,6 +763,15 @@ export class MemoryService extends EventEmitter {
         if (ctx.projectPath === "") {
           throw new MemoryCommandError(
             "Project-local memory is unavailable: no project is associated with this session"
+          );
+        }
+        // Multi-project workspaces share the synthetic "_multi" config key as
+        // their projectPath — not a real project identity. Resolving a store
+        // from it would make every multi-project workspace share (and be able
+        // to overwrite) one private-notes root, so the scope is disabled.
+        if (ctx.projectPath === MULTI_PROJECT_CONFIG_KEY) {
+          throw new MemoryCommandError(
+            "Project-local memory is unavailable: multi-project workspaces have no single project identity"
           );
         }
         // Host-local private notes about the project: keyed by stable project

--- a/src/node/services/memoryService.ts
+++ b/src/node/services/memoryService.ts
@@ -318,6 +318,18 @@ export function resolveMemoryProjectAnchor(
   }
 }
 
+/**
+ * Stable project identity for memory scope contexts ("" disables the
+ * project-keyed scopes and sidecar keys). Multi-project workspaces have no
+ * single project identity — metadata.projectPath resolves to the FIRST
+ * project's path (see Config.getAllWorkspaceMetadata), so passing it through
+ * would silently bind project-local memories (and sidecar stats) to whichever
+ * project happens to be listed first.
+ */
+export function resolveMemoryProjectIdentity(metadata: WorkspaceMetadata): string {
+  return isMultiProject(metadata) ? "" : metadata.projectPath;
+}
+
 const SYMLINKED_MEMORY_ROOT_ERROR =
   "Project memory is unavailable: .mux/memory (or a repo-controlled ancestor) is a symlink";
 

--- a/src/node/services/streamContextBuilder.ts
+++ b/src/node/services/streamContextBuilder.ts
@@ -51,6 +51,7 @@ import { getErrorMessage } from "@/common/utils/errors";
 import {
   formatMemoryIndexBlock,
   resolveMemoryProjectAnchor,
+  resolveMemoryProjectIdentity,
   type MemoryService,
 } from "@/node/services/memoryService";
 
@@ -620,7 +621,7 @@ export async function buildStreamSystemContext(
         // tool/UI/hot-set; "" disables the project scope.
         checkoutCwd: resolveMemoryProjectAnchor(metadata, runtime) ?? "",
         workspaceId,
-        projectPath: metadata.projectPath,
+        projectPath: resolveMemoryProjectIdentity(metadata),
       });
       systemMessage = `${systemMessage}\n\n${formatMemoryIndexBlock(entries)}`;
     } catch (error) {

--- a/src/node/services/tools/memory.test.ts
+++ b/src/node/services/tools/memory.test.ts
@@ -80,6 +80,32 @@ describe("memory tool sub-project workspaces", () => {
   });
 });
 
+describe("memory tool multi-project workspaces", () => {
+  it("disables project-local (no single project identity, even though workspaceProjectPath is set)", async () => {
+    using fixture = await createFixture();
+    // Multi-project tool configs carry the FIRST project's path in
+    // workspaceProjectPath; binding stores to it would expose one project's
+    // private notes to every multi-project session that lists it first.
+    fixture.config.workspaceProjectPath = "/projects/alpha";
+    fixture.config.projects = [
+      { projectPath: "/projects/alpha", projectName: "alpha" },
+      { projectPath: "/projects/beta", projectName: "beta" },
+    ];
+    const tool = createMemoryTool(fixture.config);
+
+    const result = await run(tool, {
+      command: "create",
+      path: "/memories/project-local/notes.md",
+      file_text: "leaked",
+    });
+    expect(result).toEqual({
+      success: false,
+      error: "Project-local memory is unavailable: no project is associated with this session",
+    });
+    expect(await pathExists(path.join(fixture.muxHome, "project-memory"))).toBe(false);
+  });
+});
+
 async function run(tool: Tool, input: Record<string, unknown>): Promise<MemoryToolResult> {
   const parsed = TOOL_DEFINITIONS.memory.schema.parse(input);
   return (await tool.execute!(parsed, mockToolCallOptions)) as MemoryToolResult;

--- a/src/node/services/tools/memory.test.ts
+++ b/src/node/services/tools/memory.test.ts
@@ -43,6 +43,7 @@ async function createFixture(options?: {
   config.memoryAccess = options?.memoryAccess ?? {
     global: "readwrite",
     project: "readwrite",
+    "project-local": "readwrite",
     workspace: "readwrite",
   };
   return {
@@ -270,16 +271,19 @@ describe("memory tool", () => {
       expect(resolveMemoryAccessPolicy({ planLike: false, editingCapable: true })).toEqual({
         global: "readwrite",
         project: "readwrite",
+        "project-local": "readwrite",
         workspace: "readwrite",
       });
       expect(resolveMemoryAccessPolicy({ planLike: true, editingCapable: true })).toEqual({
         global: "readwrite",
         project: "read",
+        "project-local": "readwrite",
         workspace: "readwrite",
       });
       expect(resolveMemoryAccessPolicy({ planLike: false, editingCapable: false })).toEqual({
         global: "read",
         project: "read",
+        "project-local": "read",
         workspace: "read",
       });
     });

--- a/src/node/services/tools/memory.ts
+++ b/src/node/services/tools/memory.ts
@@ -67,8 +67,13 @@ export const createMemoryTool: ToolFactory = (config: ToolConfiguration) => {
         ? ""
         : (config.workspaceCheckoutRootPath ?? config.cwd),
     workspaceId: config.workspaceId ?? "",
-    // Stable project identity for sidecar logical keys (never the checkout cwd).
-    projectPath: config.workspaceProjectPath ?? "",
+    // Stable project identity for sidecar logical keys (never the checkout
+    // cwd). Multi-project workspaces have no single identity — their
+    // workspaceProjectPath is the FIRST project's path, which must not become
+    // the project-local store key — so "" disables the project-keyed scopes
+    // (same resolution as resolveMemoryProjectIdentity; config.projects
+    // mirrors metadata.projects via getProjects).
+    projectPath: (config.projects?.length ?? 0) > 1 ? "" : (config.workspaceProjectPath ?? ""),
   };
 
   /**

--- a/src/node/services/tools/memory.ts
+++ b/src/node/services/tools/memory.ts
@@ -11,6 +11,7 @@ import { parseMemoryPath, type MemoryScopeContext } from "@/node/services/memory
 const READ_ONLY_ACCESS: MemoryScopeAccess = {
   global: "read",
   project: "read",
+  "project-local": "read",
   workspace: "read",
 };
 
@@ -18,6 +19,7 @@ const READ_ONLY_ACCESS: MemoryScopeAccess = {
  * Map an agent class onto the per-scope memory write matrix
  * (see MemoryScopeAccess in src/common/constants/memory.ts):
  * - Plan-like agents must not mutate the repo checkout, so project is read-only.
+ *   project-local stays writable: it lives under muxHome, not the checkout.
  * - Editing-capable (exec-like) agents get read-write everywhere.
  * - Everything else (explore/read-only agents) is view-only.
  */
@@ -26,10 +28,20 @@ export function resolveMemoryAccessPolicy(options: {
   editingCapable: boolean;
 }): MemoryScopeAccess {
   if (options.planLike) {
-    return { global: "readwrite", project: "read", workspace: "readwrite" };
+    return {
+      global: "readwrite",
+      project: "read",
+      "project-local": "readwrite",
+      workspace: "readwrite",
+    };
   }
   if (options.editingCapable) {
-    return { global: "readwrite", project: "readwrite", workspace: "readwrite" };
+    return {
+      global: "readwrite",
+      project: "readwrite",
+      "project-local": "readwrite",
+      workspace: "readwrite",
+    };
   }
   return READ_ONLY_ACCESS;
 }


### PR DESCRIPTION
## Summary

Adds a fourth memory scope, `project-local`: private, host-local, per-project agent memories stored under `<muxHome>/project-memory/<project>-<hash>/`, filling the gap between `global` (personal but cross-project) and `project` (per-project but git-tracked and shared).

## Background

The existing scopes leave one quadrant uncovered: notes that are **about a specific project** but **personal** (not meant to be committed and reviewed). Today agents emulate this with naming conventions in global scope (e.g. `mux-repo-workflow-tips.md`), which pollutes the global memory index in unrelated projects. `workspace` scope doesn't fit either — it dies with the workspace, while repo lessons should survive across worktrees.

| Scope | Visibility | Storage |
|---|---|---|
| `global` | personal, all projects | `<muxHome>/memory/` |
| `project` | shared via git | `<checkout>/.mux/memory/` |
| **`project-local`** (new) | **personal, this project** | **`<muxHome>/project-memory/<dir>/`** |
| `workspace` | this workspace | `<sessionDir>/memory/` |

## Implementation

- **Store resolution** (`memoryService.ts`): new `getStore()` case mapping the scope to a `LocalMemoryStore` keyed by the *stable project identity* (`ctx.projectPath` from Mux config, never the per-workspace checkout path), so memories survive re-checkouts. Directory name is `sanitizedBasename-sha256(projectPath)[:12]` to stay human-recognizable while disambiguating same-named projects.
- **Sidecar keys** (`memoryMeta.ts`): `project-local:<projectId>:<relPath>`, consistent with the existing project-scope key shape; pins/stats/hot-set work unchanged.
- **Access policy** (`tools/memory.ts`): exec-like read-write, explore read-only — and notably **plan-like agents get read-write** (project scope is read-only for them only because it mutates the checkout; project-local is host-local, so planning sessions can finally record repo lessons).
- **No new plumbing**: `projectPath` was already threaded through all four `MemoryScopeContext` construction sites; remote runtimes need nothing since the scope is host-local by design.
- Adding the scope to `MEMORY_SCOPES` propagated through `Record<MemoryScope, …>` exhaustiveness to every remaining site (UI labels, policy matrices) via typecheck.

## Validation

- End-to-end dogfood through a real `MemoryService` against a temp muxHome: created one memory per scope via the tool surface, verified the model-visible root listing and `<memory_index>` block include the new scope, and verified the physical layout — `project-local` lands under `mux-home/project-memory/mux-f8a163370ef2/` while the checkout contains only the git-tracked `project` file.
- New behavioral tests: physical root placement + checkout-stays-clean invariant, recoverable error when no project identity exists, dir-name uniqueness for same-named projects in different parents, sanitization of hostile basenames.

## Risks

Low. The new scope is additive; existing scope behavior is untouched (verified by the 152-test memory suite). The main semantic decision is plan-like write access to project-local — intentional and documented in the policy matrix comment.
---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$7.21`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=7.21 -->
