### PR TITLE
🤖 fix: keep workflow run records out of model context

### DIFF
--- a/src/browser/utils/messages/applyToolOutputRedaction.test.ts
+++ b/src/browser/utils/messages/applyToolOutputRedaction.test.ts
@@ -131,6 +131,75 @@ describe("applyToolOutputRedaction", () => {
     });
   });
 
+  it("strips the embedded workflow run record from workflow_run/workflow_resume outputs", () => {
+    const runRecord = {
+      id: "wfr_demo",
+      definitionSource: "export default function workflow() {}\n",
+      events: [{ sequence: 1, type: "log", at: "2026-01-01T00:00:00.000Z", message: "noisy" }],
+    };
+    const messages: MuxMessage[] = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolCallId: "tool-1",
+            toolName: "workflow_run",
+            input: { name: "demo" },
+            state: "output-available",
+            output: { status: "running", runId: "wfr_demo", result: null, run: runRecord },
+          },
+          {
+            type: "dynamic-tool",
+            toolCallId: "tool-2",
+            toolName: "workflow_resume",
+            input: { run_id: "wfr_demo" },
+            state: "output-available",
+            output: {
+              type: "json",
+              value: {
+                status: "completed",
+                runId: "wfr_demo",
+                result: { ok: true },
+                run: runRecord,
+              },
+            },
+          },
+          {
+            // Only workflow tools are affected: other tools may legitimately output a `run` key.
+            type: "dynamic-tool",
+            toolCallId: "tool-3",
+            toolName: "bash",
+            input: {},
+            state: "output-available",
+            output: { success: true, run: "value preserved" },
+          },
+        ],
+      },
+    ];
+
+    const result = applyToolOutputRedaction(messages);
+    const [runPart, resumePart, bashPart] = result[0]?.parts ?? [];
+    if (
+      runPart?.type !== "dynamic-tool" ||
+      resumePart?.type !== "dynamic-tool" ||
+      bashPart?.type !== "dynamic-tool" ||
+      runPart.state !== "output-available" ||
+      resumePart.state !== "output-available" ||
+      bashPart.state !== "output-available"
+    ) {
+      throw new Error("Expected dynamic tool outputs");
+    }
+
+    expect(runPart.output).toEqual({ status: "running", runId: "wfr_demo", result: null });
+    expect(resumePart.output).toEqual({
+      type: "json",
+      value: { status: "completed", runId: "wfr_demo", result: { ok: true } },
+    });
+    expect(bashPart.output).toEqual({ success: true, run: "value preserved" });
+  });
+
   it("sanitizes binary-like provider output strings for top-level and nested tools", () => {
     const messages: MuxMessage[] = [
       {

--- a/src/browser/utils/messages/applyToolOutputRedaction.ts
+++ b/src/browser/utils/messages/applyToolOutputRedaction.ts
@@ -5,6 +5,7 @@
 import type { MuxMessage } from "@/common/types/message";
 import { sanitizeUnknownForProviderOutput } from "@/common/utils/providerOutputSanitization";
 import { stripToolOutputUiOnly } from "@/common/utils/tools/toolOutputUiOnly";
+import { isWorkflowRunEmittingToolName } from "@/common/utils/workflowRunMessages";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -66,6 +67,27 @@ function stripLegacyImageToolOutputForModel(output: unknown): unknown {
   return stripped;
 }
 
+// workflow_run / workflow_resume outputs embed the full run record (definition source, event
+// log, step snapshots) solely for the UI run card. The model only needs status/runId/result —
+// in-progress events may never materialize in the final outcome — so drop the record from
+// provider-bound history while persisted history keeps rendering the card.
+function stripWorkflowRunRecordForModel(toolName: string, output: unknown): unknown {
+  if (!isWorkflowRunEmittingToolName(toolName) || !isRecord(output)) {
+    return output;
+  }
+  // Some persisted outputs are wrapped in a { type: "json", value } container.
+  if (output.type === "json" && "value" in output) {
+    return { ...output, value: stripWorkflowRunRecordForModel(toolName, output.value) };
+  }
+  const stripped: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(output)) {
+    if (key !== "run") {
+      stripped[key] = value;
+    }
+  }
+  return stripped;
+}
+
 export function applyToolOutputRedaction(messages: MuxMessage[]): MuxMessage[] {
   return messages.map((msg) => {
     if (msg.role !== "assistant") return msg;
@@ -74,7 +96,10 @@ export function applyToolOutputRedaction(messages: MuxMessage[]): MuxMessage[] {
       if (part.type !== "dynamic-tool") return part;
       if (part.state !== "output-available") return part;
 
-      const outputWithoutUiOnly = stripToolOutputUiOnly(part.output);
+      const outputWithoutUiOnly = stripWorkflowRunRecordForModel(
+        part.toolName,
+        stripToolOutputUiOnly(part.output)
+      );
       const sanitizedOutput = sanitizeUnknownForProviderOutput(
         stripLegacyImageToolOutputForModel(outputWithoutUiOnly)
       );
@@ -82,7 +107,10 @@ export function applyToolOutputRedaction(messages: MuxMessage[]): MuxMessage[] {
         if (nestedCall.state !== "output-available") {
           return nestedCall;
         }
-        const nestedOutputWithoutUiOnly = stripToolOutputUiOnly(nestedCall.output);
+        const nestedOutputWithoutUiOnly = stripWorkflowRunRecordForModel(
+          nestedCall.toolName,
+          stripToolOutputUiOnly(nestedCall.output)
+        );
         return {
           ...nestedCall,
           output: sanitizeUnknownForProviderOutput(

--- a/src/browser/utils/messages/applyToolOutputRedaction.ts
+++ b/src/browser/utils/messages/applyToolOutputRedaction.ts
@@ -5,7 +5,7 @@
 import type { MuxMessage } from "@/common/types/message";
 import { sanitizeUnknownForProviderOutput } from "@/common/utils/providerOutputSanitization";
 import { stripToolOutputUiOnly } from "@/common/utils/tools/toolOutputUiOnly";
-import { isWorkflowRunEmittingToolName } from "@/common/utils/workflowRunMessages";
+import { stripWorkflowRunRecordForModel } from "@/common/utils/workflowRunMessages";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -63,27 +63,6 @@ function stripLegacyImageToolOutputForModel(output: unknown): unknown {
       isLegacyImageToolSuccess && key === "images"
         ? value
         : stripLegacyImageToolOutputForModel(value);
-  }
-  return stripped;
-}
-
-// workflow_run / workflow_resume outputs embed the full run record (definition source, event
-// log, step snapshots) solely for the UI run card. The model only needs status/runId/result —
-// in-progress events may never materialize in the final outcome — so drop the record from
-// provider-bound history while persisted history keeps rendering the card.
-function stripWorkflowRunRecordForModel(toolName: string, output: unknown): unknown {
-  if (!isWorkflowRunEmittingToolName(toolName) || !isRecord(output)) {
-    return output;
-  }
-  // Some persisted outputs are wrapped in a { type: "json", value } container.
-  if (output.type === "json" && "value" in output) {
-    return { ...output, value: stripWorkflowRunRecordForModel(toolName, output.value) };
-  }
-  const stripped: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(output)) {
-    if (key !== "run") {
-      stripped[key] = value;
-    }
   }
   return stripped;
 }

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -36,6 +36,7 @@ import {
   WorkflowNameSchema,
   WorkflowRunRecordSchema,
   WorkflowRunStatusSchema,
+  WorkflowStepStatusSchema,
 } from "@/common/orpc/schemas";
 import { RUNTIME_MODE, type RuntimeMode } from "@/common/types/runtime";
 import {
@@ -607,12 +608,32 @@ export const TaskAwaitToolInvalidScopeResultSchema = z
   })
   .strict();
 
+// Failure is the one case where workflow state must reach the model: it has to decide between
+// workflow_resume (retry_from_checkpoint) and a fresh workflow_run. Surface per-step outcomes
+// compactly — never the full run record (definition source / event log).
+export const TaskAwaitWorkflowFailureStateSchema = z
+  .object({
+    name: z.string().min(1),
+    steps: z.array(
+      z
+        .object({
+          stepId: z.string().min(1),
+          status: WorkflowStepStatusSchema,
+          taskId: z.string().optional(),
+          error: z.string().optional(),
+        })
+        .strict()
+    ),
+  })
+  .strict();
+
 export const TaskAwaitToolErrorResultSchema = z
   .object({
     status: z.literal("error"),
     taskId: z.string(),
     error: z.string(),
     elapsed_ms: z.number().optional(),
+    workflow: TaskAwaitWorkflowFailureStateSchema.optional(),
   })
   .strict();
 

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -570,7 +570,6 @@ export const TaskAwaitToolCompletedResultSchema = z
     elapsed_ms: z.number().optional(),
     exitCode: z.number().optional(),
     note: z.string().optional(),
-    run: WorkflowRunRecordSchema.optional(),
     artifacts: TaskAwaitToolArtifactsSchema.optional(),
   })
   .strict();
@@ -589,7 +588,6 @@ export const TaskAwaitToolActiveResultSchema = z
     output: z.string().optional(),
     elapsed_ms: z.number().optional(),
     note: z.string().optional(),
-    run: WorkflowRunRecordSchema.optional(),
   })
   .strict();
 
@@ -615,7 +613,6 @@ export const TaskAwaitToolErrorResultSchema = z
     taskId: z.string(),
     error: z.string(),
     elapsed_ms: z.number().optional(),
-    run: WorkflowRunRecordSchema.optional(),
   })
   .strict();
 

--- a/src/common/utils/workflowRunMessages.ts
+++ b/src/common/utils/workflowRunMessages.ts
@@ -21,6 +21,39 @@ export function isWorkflowRunEmittingToolName(toolName: string): boolean {
   return WORKFLOW_RUN_EMITTING_TOOL_NAMES.has(toolName);
 }
 
+function isRecordValue(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * workflow_run / workflow_resume outputs embed the full run record (definition source, event
+ * log, step snapshots) solely for the UI run card. The model only needs status/runId/result —
+ * in-progress events may never materialize in the final outcome — so drop the record from
+ * model-bound copies (persisted-history requests and internal stream steps alike) while the
+ * persisted output keeps rendering the card.
+ */
+export function stripWorkflowRunRecordForModel(toolName: string, output: unknown): unknown {
+  if (!isWorkflowRunEmittingToolName(toolName) || !isRecordValue(output)) {
+    return output;
+  }
+  // Tool outputs may be wrapped in a { type: "json", value } container (UI parts and
+  // SDK ToolResultPart outputs share this shape).
+  if (output.type === "json" && "value" in output) {
+    const strippedValue = stripWorkflowRunRecordForModel(toolName, output.value);
+    return strippedValue === output.value ? output : { ...output, value: strippedValue };
+  }
+  if (!("run" in output)) {
+    return output;
+  }
+  const stripped: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(output)) {
+    if (key !== "run") {
+      stripped[key] = value;
+    }
+  }
+  return stripped;
+}
+
 export const WORKFLOW_RESULT_XML_TAG = "mux_workflow_result";
 
 function getWorkflowResultValue(result: unknown, run: WorkflowRunRecord | null): unknown {

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -53,6 +53,7 @@ import {
 import type { SessionUsageService } from "./sessionUsageService";
 import { createDisplayUsage } from "@/common/utils/tokens/displayUsage";
 import { extractToolMediaAsUserMessagesFromModelMessages } from "@/node/utils/messages/extractToolMediaAsUserMessagesFromModelMessages";
+import { stripWorkflowRunRecordsFromModelMessages } from "@/node/utils/messages/stripWorkflowRunRecordsFromModelMessages";
 import { normalizeToCanonical } from "@/common/utils/ai/models";
 import { MUX_GATEWAY_SESSION_EXPIRED_MESSAGE } from "@/common/constants/muxGatewayOAuth";
 import { getModelStats, getModelStatsResolved } from "@/common/utils/tokens/modelStats";
@@ -1415,8 +1416,12 @@ export class StreamManager extends EventEmitter {
       abortSignal: abortController.signal,
       prepareStep: async ({ messages: stepMessages }) => {
         // streamText runs multiple internal LLM calls (steps) when tools are enabled.
-        // Extract supported attachments out of tool-result JSON so providers don't treat them as text.
-        const rewritten = await extractToolMediaAsUserMessagesFromModelMessages(stepMessages);
+        // Strip workflow run records from same-turn tool results (history-level redaction in
+        // applyToolOutputRedaction can't see these), then extract supported attachments out of
+        // tool-result JSON so providers don't treat them as text.
+        const withoutWorkflowRunRecords = stripWorkflowRunRecordsFromModelMessages(stepMessages);
+        const rewritten =
+          await extractToolMediaAsUserMessagesFromModelMessages(withoutWorkflowRunRecords);
         const effectiveMessages = rewritten === stepMessages ? stepMessages : rewritten;
         if (stepTracker) {
           stepTracker.latestMessages = effectiveMessages;

--- a/src/node/services/tools/task_await.test.ts
+++ b/src/node/services/tools/task_await.test.ts
@@ -704,7 +704,6 @@ describe("task_await tool", () => {
           structuredOutput: { ok: true },
           title: "demo",
           elapsed_ms: 5000,
-          run: completedRun,
           note: COMPLETED_REPORT_REFETCH_NOTE,
         },
       ],
@@ -765,7 +764,6 @@ describe("task_await tool", () => {
       status: "error",
       taskId: "wfr_demo",
       elapsed_ms: 5000,
-      run: failedRun,
     });
     expect(workflowResult.results[0]?.error).toContain(WORKFLOW_CHECKPOINT_RETRY_ERROR_MESSAGE);
     expect(workflowResult.results[0]?.error).toContain("workflow_resume");
@@ -823,7 +821,6 @@ describe("task_await tool", () => {
           taskId: "wfr_demo",
           error: "boom",
           elapsed_ms: 5000,
-          run: failedRun,
         },
       ],
     });
@@ -882,8 +879,7 @@ describe("task_await tool", () => {
           status: "backgrounded",
           taskId: "wfr_backgrounded",
           elapsed_ms: workflowResult.results[0]?.elapsed_ms,
-          note: "Workflow run is backgrounded. Use task_await to monitor progress.",
-          run: backgroundedRun,
+          note: "Workflow demo is backgrounded. Use task_await to monitor progress.",
         },
       ],
     });
@@ -945,7 +941,6 @@ describe("task_await tool", () => {
           reportMarkdown: "poll complete",
           title: "demo",
           elapsed_ms: 5000,
-          run: completedRun,
           note: COMPLETED_REPORT_REFETCH_NOTE,
         },
       ],
@@ -998,7 +993,6 @@ describe("task_await tool", () => {
     expect(interruptedResult.results[0]).toMatchObject({
       status: "interrupted",
       taskId: "wfr_demo",
-      run: interruptedRun,
     });
     expect(interruptedResult.results[0]?.note).toContain("workflow_resume");
   });

--- a/src/node/services/tools/task_await.test.ts
+++ b/src/node/services/tools/task_await.test.ts
@@ -764,6 +764,7 @@ describe("task_await tool", () => {
       status: "error",
       taskId: "wfr_demo",
       elapsed_ms: 5000,
+      workflow: { name: "demo", steps: [] },
     });
     expect(workflowResult.results[0]?.error).toContain(WORKFLOW_CHECKPOINT_RETRY_ERROR_MESSAGE);
     expect(workflowResult.results[0]?.error).toContain("workflow_resume");
@@ -773,26 +774,45 @@ describe("task_await tool", () => {
   it("does not show checkpoint retry guidance for ordinary failed workflow runs", async () => {
     using tempDir = new TestTempDir("test-task-await-tool-workflow-ordinary-failed");
     const baseConfig = createTestToolConfig(tempDir.path, { workspaceId: "parent-workspace" });
-    const failedRun = createWorkflowRun("failed", [
-      {
-        sequence: 1,
-        type: "status",
-        at: "2026-01-01T00:00:01.000Z",
-        status: "running",
-      },
-      {
-        sequence: 2,
-        type: "error",
-        at: "2026-01-01T00:00:04.000Z",
-        message: "boom",
-      },
-      {
-        sequence: 3,
-        type: "status",
-        at: "2026-01-01T00:00:05.000Z",
-        status: "failed",
-      },
-    ]);
+    const failedRun = {
+      ...createWorkflowRun("failed", [
+        {
+          sequence: 1,
+          type: "status" as const,
+          at: "2026-01-01T00:00:01.000Z",
+          status: "running" as const,
+        },
+        {
+          sequence: 2,
+          type: "error" as const,
+          at: "2026-01-01T00:00:04.000Z",
+          message: "boom",
+        },
+        {
+          sequence: 3,
+          type: "status" as const,
+          at: "2026-01-01T00:00:05.000Z",
+          status: "failed" as const,
+        },
+      ]),
+      steps: [
+        {
+          stepId: "step-one",
+          inputHash: "sha256:one",
+          status: "completed" as const,
+          taskId: "child-task-1",
+          startedAt: "2026-01-01T00:00:01.000Z",
+          completedAt: "2026-01-01T00:00:02.000Z",
+        },
+        {
+          stepId: "step-two",
+          inputHash: "sha256:two",
+          status: "failed" as const,
+          startedAt: "2026-01-01T00:00:03.000Z",
+          error: "boom",
+        },
+      ],
+    };
 
     const taskService = {
       listActiveDescendantAgentTaskIds: mock(() => []),
@@ -814,6 +834,8 @@ describe("task_await tool", () => {
       tool.execute!({ task_ids: ["wfr_demo"] }, mockToolCallOptions)
     );
 
+    // The compact failure state replaces the full run record: per-step outcomes (with
+    // completed steps' taskIds for report re-fetching) instead of the event log/source.
     expect(result).toEqual({
       results: [
         {
@@ -821,6 +843,13 @@ describe("task_await tool", () => {
           taskId: "wfr_demo",
           error: "boom",
           elapsed_ms: 5000,
+          workflow: {
+            name: "demo",
+            steps: [
+              { stepId: "step-one", status: "completed", taskId: "child-task-1" },
+              { stepId: "step-two", status: "failed", error: "boom" },
+            ],
+          },
         },
       ],
     });

--- a/src/node/services/tools/task_await.ts
+++ b/src/node/services/tools/task_await.ts
@@ -133,6 +133,22 @@ function getWorkflowRunError(run: WorkflowRunRecord): string {
   return message;
 }
 
+// Failure is the one case where workflow state helps the model decide between
+// workflow_resume (retry_from_checkpoint) and a fresh workflow_run. Per-step outcomes are
+// enough: completed steps keep their taskId so their durable reports stay re-fetchable via
+// task_await without re-running anything.
+function buildWorkflowFailureState(run: WorkflowRunRecord) {
+  return {
+    name: run.definition.name,
+    steps: run.steps.map((step) => ({
+      stepId: step.stepId,
+      status: step.status,
+      ...(step.taskId != null ? { taskId: step.taskId } : {}),
+      ...(step.error != null ? { error: step.error } : {}),
+    })),
+  };
+}
+
 function buildWorkflowAwaitResult(run: WorkflowRunRecord) {
   // Deliberately omit the full run record (definition source, event log, step snapshots):
   // it is huge and model-facing only. In-progress events may never materialize in the final
@@ -161,6 +177,7 @@ function buildWorkflowAwaitResult(run: WorkflowRunRecord) {
         status: "error" as const,
         ...base,
         error: getWorkflowRunError(run),
+        workflow: buildWorkflowFailureState(run),
       };
     case "interrupted":
       return {

--- a/src/node/services/tools/task_await.ts
+++ b/src/node/services/tools/task_await.ts
@@ -134,9 +134,11 @@ function getWorkflowRunError(run: WorkflowRunRecord): string {
 }
 
 function buildWorkflowAwaitResult(run: WorkflowRunRecord) {
+  // Deliberately omit the full run record (definition source, event log, step snapshots):
+  // it is huge and model-facing only. In-progress events may never materialize in the final
+  // result, so the model only needs the status plus the final report/error.
   const base = {
     taskId: run.id,
-    run,
     ...withElapsedMs(getWorkflowRunElapsedMs(run)),
   };
 
@@ -170,17 +172,19 @@ function buildWorkflowAwaitResult(run: WorkflowRunRecord) {
       return {
         status: "queued" as const,
         ...base,
+        note: `Workflow ${run.definition.name} is queued.`,
       };
     case "backgrounded":
       return {
         status: "backgrounded" as const,
         ...base,
-        note: "Workflow run is backgrounded. Use task_await to monitor progress.",
+        note: `Workflow ${run.definition.name} is backgrounded. Use task_await to monitor progress.`,
       };
     case "running":
       return {
         status: "running" as const,
         ...base,
+        note: `Workflow ${run.definition.name} is still running.`,
       };
   }
 }
@@ -362,7 +366,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
         const deadline = Date.now() + (timeoutMs ?? DEFAULT_TASK_AWAIT_TIMEOUT_MS);
         while (!isWorkflowRunTerminalStatus(run.status)) {
           if (abortSignal?.aborted) {
-            return { status: "error" as const, taskId: runId, error: "Interrupted", run };
+            return { status: "error" as const, taskId: runId, error: "Interrupted" };
           }
           if (taskSignal.aborted || Date.now() >= deadline) {
             return buildWorkflowAwaitResult(run);

--- a/src/node/utils/messages/stripWorkflowRunRecordsFromModelMessages.test.ts
+++ b/src/node/utils/messages/stripWorkflowRunRecordsFromModelMessages.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+import type { ModelMessage } from "ai";
+import { stripWorkflowRunRecordsFromModelMessages } from "./stripWorkflowRunRecordsFromModelMessages";
+
+const runRecord = {
+  id: "wfr_demo",
+  definitionSource: "export default function workflow() {}\n",
+  events: [{ sequence: 1, type: "log", at: "2026-01-01T00:00:00.000Z", message: "noisy" }],
+};
+
+describe("stripWorkflowRunRecordsFromModelMessages", () => {
+  it("strips run records from same-turn workflow tool results", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "workflow_run",
+            output: {
+              type: "json",
+              value: { status: "running", runId: "wfr_demo", result: null, run: runRecord },
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = stripWorkflowRunRecordsFromModelMessages(messages);
+
+    expect(result).not.toBe(messages);
+    const part = result[0]?.role === "tool" ? result[0].content[0] : undefined;
+    expect(part?.type === "tool-result" ? part.output : undefined).toEqual({
+      type: "json",
+      value: { status: "running", runId: "wfr_demo", result: null },
+    });
+  });
+
+  it("returns the original array when no workflow tool results carry a run record", () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "hello" },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "bash",
+            // Non-workflow tools may legitimately output a `run` key; it must survive.
+            output: { type: "json", value: { success: true, run: "value preserved" } },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "call-2",
+            toolName: "workflow_run",
+            output: { type: "json", value: { status: "completed", runId: "wfr_demo" } },
+          },
+        ],
+      },
+    ];
+
+    expect(stripWorkflowRunRecordsFromModelMessages(messages)).toBe(messages);
+  });
+});

--- a/src/node/utils/messages/stripWorkflowRunRecordsFromModelMessages.ts
+++ b/src/node/utils/messages/stripWorkflowRunRecordsFromModelMessages.ts
@@ -1,0 +1,58 @@
+import type { AssistantModelMessage, ModelMessage, ToolModelMessage, ToolResultPart } from "ai";
+import { stripWorkflowRunRecordForModel } from "@/common/utils/workflowRunMessages";
+
+type ToolResultOutput = ToolResultPart["output"];
+
+function stripToolResultPart<P extends { type: string }>(part: P, onChange: () => void): P {
+  if (part.type !== "tool-result") {
+    return part;
+  }
+  const toolResult = part as P & ToolResultPart;
+  const strippedOutput = stripWorkflowRunRecordForModel(toolResult.toolName, toolResult.output);
+  if (strippedOutput === toolResult.output) {
+    return part;
+  }
+  onChange();
+  return { ...part, output: strippedOutput as ToolResultOutput };
+}
+
+/**
+ * Request-only rewrite for *internal* streamText steps.
+ *
+ * applyToolOutputRedaction strips workflow run records when building a request from persisted
+ * history, but within a single streamText turn the SDK feeds tool results straight back into
+ * the next step. Without this, the model step immediately after a workflow_run/workflow_resume
+ * call still sees the full run record (definition source + event log) this redaction exists to
+ * keep out of context.
+ *
+ * Returns the original array when nothing changed so prepareStep can skip the rewrite.
+ */
+export function stripWorkflowRunRecordsFromModelMessages(messages: ModelMessage[]): ModelMessage[] {
+  let didChange = false;
+
+  const result = messages.map((message): ModelMessage => {
+    let changedMessage = false;
+    const onChange = () => {
+      didChange = true;
+      changedMessage = true;
+    };
+
+    // Tool results normally arrive in `tool` messages; assistant content can also carry
+    // tool-result parts after some transforms, so handle both.
+    if (message.role === "tool") {
+      const newContent: ToolModelMessage["content"] = message.content.map((part) =>
+        stripToolResultPart(part, onChange)
+      );
+      return changedMessage ? { ...message, content: newContent } : message;
+    }
+    if (message.role === "assistant" && Array.isArray(message.content)) {
+      const newContent: Exclude<AssistantModelMessage["content"], string> = message.content.map(
+        (part) => stripToolResultPart(part, onChange)
+      );
+      return changedMessage ? { ...message, content: newContent } : message;
+    }
+    return message;
+  });
+
+  return didChange ? result : messages;
+}


### PR DESCRIPTION
## Summary

Stops `task_await` (and provider-bound history generally) from flooding model context with full workflow run records — definition source, the entire event log, and step snapshots — every time a running workflow is awaited. The model now only learns that a workflow is running; on failure it receives a compact, decision-relevant step summary instead of the raw dump.

## Background

Awaiting a running workflow via `task_await` embedded the complete `WorkflowRunRecord` in every result, and `workflow_run`/`workflow_resume` outputs replayed the same record from history on every subsequent request. That is pure token waste: in-progress events may never materialize in the final result, and the definition source is irrelevant to the model. The one legitimate need for workflow state is the failure case, where the model must decide between `workflow_resume (retry_from_checkpoint)` and a fresh `workflow_run`.

## Implementation

- **`task_await` results** no longer carry `run` (removed from the three result schemas; `.strict()` parsing prevents silent reintroduction). Non-terminal statuses return `status`/`taskId`/`elapsed_ms` plus a one-line note naming the workflow; completed results keep `reportMarkdown`/`structuredOutput` as before.
- **Failed workflow awaits** gain a compact `workflow: { name, steps: [{ stepId, status, taskId?, error? }] }` summary. Completed steps keep their `taskId` so durable reports stay re-fetchable without re-running anything.
- **`workflow_run`/`workflow_resume` outputs** still persist the run record — the UI run card and run-provenance scanners need it — but `applyToolOutputRedaction` (the existing request-only redaction layer for `ui_only` fields and image thumbnails) now strips the `run` key from provider-bound copies, keyed via the shared `isWorkflowRunEmittingToolName` predicate so other tools' `run` fields are untouched. Handles `{type:"json", value}` containers and nested calls.

## Validation

- New redaction test covers `workflow_run`, json-wrapped `workflow_resume`, and a non-workflow tool with a `run` key (preserved).
- Updated `task_await` tests pin the exact model-facing payloads via `toEqual`, including the new failure-state steps summary.
- Verified the UI never read `run` from `task_await` output (`TaskAwaitResult` in `TaskToolCall.tsx`), and provenance scanners key off `runId`, which is preserved.

## Risks

Low. Persisted history and UI are unchanged (request-only redaction). The behavioral surface is what the model sees: agents awaiting running workflows lose access to intermediate event logs — by design. If a future feature wants the model to inspect mid-run events, it should expose a targeted query rather than re-embedding the record.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$11.31`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=11.31 -->
