### PR TITLE
🤖 perf: skip composer height measurement for empty drafts

### DIFF
--- a/src/browser/components/VimTextArea/VimTextArea.tsx
+++ b/src/browser/components/VimTextArea/VimTextArea.tsx
@@ -278,6 +278,9 @@ export const VimTextArea = React.forwardRef<HTMLTextAreaElement, VimTextAreaProp
               onChange(e.target.value, e.target.selectionStart ?? e.target.value.length)
             }
             onKeyDown={handleKeyDownInternal}
+            // Keep the empty natural height at one line (textareas default to rows=2) so
+            // useAutoResizeTextarea can leave empty drafts to CSS sizing without measuring.
+            rows={1}
             spellCheck={false}
             autoCorrect="off"
             autoCapitalize="none"

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -1178,8 +1178,15 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       const cursor = element.value.length;
       element.selectionStart = cursor;
       element.selectionEnd = cursor;
-      element.style.height = "auto";
-      element.style.height = Math.min(element.scrollHeight, window.innerHeight * 0.5) + "px";
+      // Skip the resize dance when empty: reading scrollHeight after a height write
+      // forces a synchronous reflow, and this rAF fires right after a workspace
+      // switch while the freshly mounted transcript is still dirty — laying out the
+      // whole document before first paint. Empty composers are sized by CSS alone
+      // (rows=1 + min-height; see useAutoResizeTextarea).
+      if (element.value !== "") {
+        element.style.height = "auto";
+        element.style.height = Math.min(element.scrollHeight, window.innerHeight * 0.5) + "px";
+      }
     });
   }, []);
 

--- a/src/browser/features/Tools/AskUserQuestionToolCall.tsx
+++ b/src/browser/features/Tools/AskUserQuestionToolCall.tsx
@@ -192,6 +192,9 @@ function AutoResizeTextarea(props: {
   return (
     <textarea
       ref={textareaRef}
+      // Keep the empty natural height at one line (textareas default to rows=2) so
+      // useAutoResizeTextarea can leave empty drafts to CSS sizing without measuring.
+      rows={1}
       placeholder={props.placeholder}
       value={props.value}
       onChange={(e) => props.onChange(e.target.value)}

--- a/src/browser/hooks/useAutoResizeTextarea.test.tsx
+++ b/src/browser/hooks/useAutoResizeTextarea.test.tsx
@@ -9,9 +9,11 @@ function createFakeTextarea(initialScrollHeight: number): {
   assignments: string[];
   setScrollHeight: (value: number) => void;
   setInlineHeight: (value: string) => void;
+  scrollHeightReads: () => number;
 } {
   let height = "";
   let scrollHeight = initialScrollHeight;
+  let scrollHeightReads = 0;
   const assignments: string[] = [];
   const style = {
     get height() {
@@ -26,6 +28,7 @@ function createFakeTextarea(initialScrollHeight: number): {
   const textarea = {
     style,
     get scrollHeight() {
+      scrollHeightReads += 1;
       return scrollHeight;
     },
   } as unknown as HTMLTextAreaElement;
@@ -39,6 +42,7 @@ function createFakeTextarea(initialScrollHeight: number): {
     setInlineHeight: (value) => {
       height = value;
     },
+    scrollHeightReads: () => scrollHeightReads,
   };
 }
 
@@ -59,18 +63,48 @@ describe("useAutoResizeTextarea", () => {
     globalThis.document = undefined as unknown as Document;
   });
 
+  it("skips measurement entirely while the value is empty", () => {
+    const textarea = createFakeTextarea(40);
+    renderHook(({ value }) => useAutoResizeTextarea(textarea.ref, value, 50), {
+      initialProps: { value: "" },
+    });
+
+    // This is the hot path for switching to a workspace with an empty draft: reading
+    // scrollHeight inside the commit phase would force a synchronous reflow of the
+    // freshly mounted transcript, so the hook must not measure or write any height.
+    expect(textarea.assignments).toEqual([]);
+    expect(textarea.scrollHeightReads()).toBe(0);
+  });
+
+  it("clears the inline height when the draft becomes empty", () => {
+    const textarea = createFakeTextarea(800);
+    const { rerender } = renderHook(({ value }) => useAutoResizeTextarea(textarea.ref, value, 50), {
+      initialProps: { value: "line one\nline two" },
+    });
+    expect(textarea.assignments).toEqual(["auto", "500px"]);
+    textarea.assignments.length = 0;
+
+    rerender({ value: "" });
+
+    // Empty drafts (e.g. after send) fall back to CSS sizing without measuring.
+    expect(textarea.assignments).toEqual([""]);
+  });
+
   it("does not reset height to auto for pure typing that does not change composer height", () => {
     const textarea = createFakeTextarea(40);
     const { rerender } = renderHook(({ value }) => useAutoResizeTextarea(textarea.ref, value, 50), {
       initialProps: { value: "" },
     });
 
-    expect(textarea.assignments).toEqual(["auto", "40px"]);
+    // First keystroke after the unmeasured empty state grows from scrollHeight
+    // without the shrink-to-auto reset.
+    rerender({ value: "a" });
+    expect(textarea.assignments).toEqual(["40px"]);
     textarea.assignments.length = 0;
 
     // This is the hot path for typing in a large chat: keep the existing height when
     // scrollHeight is unchanged so the transcript flex sibling does not get re-laid out.
-    rerender({ value: "a" });
+    rerender({ value: "ab" });
 
     expect(textarea.assignments).toEqual([]);
   });

--- a/src/browser/hooks/useAutoResizeTextarea.ts
+++ b/src/browser/hooks/useAutoResizeTextarea.ts
@@ -53,6 +53,25 @@ export function useAutoResizeTextarea(
     if (!el) return;
 
     const max = window.innerHeight * (maxHeightVh / 100);
+
+    // Fast path: an empty textarea needs no inline height at all — consumers size the
+    // empty state via CSS (rows={1} + min-height). Measuring it through the
+    // `auto` + scrollHeight dance below forces a synchronous reflow of every dirty
+    // node, and this effect runs inside React's commit phase. On workspace switch the
+    // entire transcript has just mounted, so that reflow lays out the whole document
+    // (~50k nodes in large chats) before first paint — profiled as the single hottest
+    // frame during chat switching. Drafts are empty in the common case, so skip
+    // measurement entirely and clear any stale inline height (e.g. after send).
+    if (value === "") {
+      if (el.style.height !== "") {
+        el.style.height = "";
+      }
+      appliedHeightRef.current = null;
+      previousValueRef.current = value;
+      previousMaxRef.current = max;
+      return;
+    }
+
     const previousValue = previousValueRef.current;
     const previousMax = previousMaxRef.current;
     const canOnlyGrow =


### PR DESCRIPTION
## Summary

Eliminates the forced-reflow storm that made chat/workspace switching slow: when the composer draft is empty (the common case), `useAutoResizeTextarea` and `focusMessageInput` no longer measure `scrollHeight` inside the commit phase / pre-paint rAF, letting CSS size the empty textarea instead.

## Background

A CDP CPU profile of a live session (30s, repeated chat switches, ~49k-node transcript) showed switches blocking the renderer main thread for 0.6–3.4s each. The hottest application frame by far (2.18s self time, 14% of busy time; up to 991ms inside a single switch) was `useAutoResizeTextarea`'s layout effect, called from `commitLayoutEffects` during the sync render triggered by the switch click.

The cost is not JS: the effect writes `height = "auto"` then reads `scrollHeight`, which forces a synchronous layout of the entire freshly-mounted (fully dirty) document before first paint. `focusMessageInput` in `ChatInput` repeats the same dance in a pre-paint rAF on every switch.

## Implementation

- `useAutoResizeTextarea`: fast path for `value === ""` — clear any stale inline height (matching the existing send-path convention of `style.height = ""` + "let CSS min-height take over"), record state, and skip measurement entirely. No `scrollHeight` read, no reflow. The first keystroke afterwards takes the existing grow-only path (measures once on a clean tree, no `auto` reset).
- `focusMessageInput` (ChatInput): skip the `auto`/`scrollHeight` resize dance when the composer is empty; it fires right after a workspace switch while the new transcript is still dirty.
- `VimTextArea` / `AskUserQuestionToolCall` textareas: `rows={1}` so the natural (un-measured) empty height stays one line — textareas default to `rows=2`. With the consumers' existing `min-h-*` clamps, the rendered empty height is unchanged (verified live: empty composer renders at exactly its CSS `min-height`, same as before).

Non-empty drafts keep the existing measure-on-mount behavior.

## Validation

- Captured the profile against the running dev instance via CDP; per-switch blocking spans attributed 29–45% of their time to this exact reflow path.
- Verified via HMR on the same live instance: empty composer has no inline height, `rows=1`, and `offsetHeight` exactly equals its CSS `min-height` (pixel-identical to the previous measured state).
- Hook unit tests updated/extended: empty mount performs zero `scrollHeight` reads and zero style writes; clearing to empty resets the inline height; first keystroke after the unmeasured empty state grows without the `auto` reset.

## Risks

Low-moderate, scoped to composer sizing. The empty state is now CSS-governed; if a consumer styled the empty composer expecting an inline px height (none found — both consumers have `min-h` clamps that already dominated), its empty height could shift by a couple px. Typing, draft-restore, deletion/shrink, and max-height capping paths are unchanged and covered by existing tests.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `high` • Cost: `$2.11`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=high costs=2.11 -->
