### PR TITLE
🤖 fix: stop counting UI memory reads as memory usage

### DIFF
--- a/src/node/orpc/router.memory.test.ts
+++ b/src/node/orpc/router.memory.test.ts
@@ -180,7 +180,7 @@ describe("router memory routes", () => {
     expect(await memoryMetaService.getPinnedKeys()).toEqual(new Set(["global:prefs.md"]));
   });
 
-  test("list exposes usage stats accumulated through reads and writes", async () => {
+  test("list exposes usage stats; UI reads do not count as uses", async () => {
     const client = createClient({ enabled: true });
     await client.memory.save({
       workspaceId: "ws-mem",
@@ -188,6 +188,7 @@ describe("router memory routes", () => {
       content: "tea",
       expectedSha256: null,
     });
+    // Opening a file in the Memory tab is human browsing, not agent usage.
     await client.memory.read({ workspaceId: "ws-mem", path: "/memories/global/prefs.md" });
 
     const list = await client.memory.list({ workspaceId: "ws-mem" });
@@ -196,7 +197,7 @@ describe("router memory routes", () => {
     expect(list.data.files).toEqual([
       expect.objectContaining({
         path: "/memories/global/prefs.md",
-        accessCount: 2,
+        accessCount: 1,
         lastAccessedAt: expect.any(Number),
       }),
     ]);

--- a/src/node/services/memoryService.test.ts
+++ b/src/node/services/memoryService.test.ts
@@ -1262,12 +1262,13 @@ describe("MemoryService", () => {
       expect((await fixture.metaService.getEntries()).get("global:a.md")?.accessCount).toBe(3);
     });
 
-    it("records UI reads and saves", async () => {
+    it("records UI saves but not UI reads (stats track agent usage, not human browsing)", async () => {
       using fixture = await createFixture();
       await fixture.service.saveFile(fixture.ctx, "/memories/global/ui.md", "draft", null, "user");
       await fixture.service.readFileWithSha(fixture.ctx, "/memories/global/ui.md");
       const entry = (await fixture.metaService.getEntries()).get("global:ui.md");
-      expect(entry?.accessCount).toBe(2);
+      // Only the save counted; opening the file in the Memory tab did not.
+      expect(entry?.accessCount).toBe(1);
       expect(entry?.lastWriteAt).not.toBeNull();
     });
 

--- a/src/node/services/memoryService.ts
+++ b/src/node/services/memoryService.ts
@@ -697,8 +697,9 @@ export class MemoryService extends EventEmitter {
 
   // -------------------------------------------------------------------------
   // Usage stats (sidecar): recorded here — the single chokepoint every agent
-  // command and UI read/write funnels through. Best-effort: stats failures
-  // must never break a memory command.
+  // command and UI write funnels through. UI reads (readFileWithSha) are
+  // intentionally not counted: stats track agent usage, not human browsing.
+  // Best-effort: stats failures must never break a memory command.
   // -------------------------------------------------------------------------
 
   /** Logical sidecar key, or null when the scope has no stable identity. */
@@ -1175,7 +1176,10 @@ export class MemoryService extends EventEmitter {
       const scope = this.requireFilePath(parsed, virtualPath);
       const store = await this.resolveStore(ctx, scope, parsed.relPath);
       const content = await this.readTextFileForEdit(store, parsed.relPath, virtualPath);
-      await this.recordUsage(ctx, scope, parsed.relPath, { write: false });
+      // Deliberately NOT recorded as a use: this is a human browsing the
+      // Memory tab/settings, and usage stats must reflect agent reads only so
+      // UI browsing never inflates hot-set ranking. (UI saves still count —
+      // an edit is an explicit signal the file matters, like pinning.)
       return { success: true, data: { content, sha256: sha256Hex(content) } };
     } catch (error) {
       if (error instanceof MemoryCommandError) {


### PR DESCRIPTION
## Summary

Opening a memory file from the Memory tab or Settings no longer counts as a "use" in the memory usage stats. Usage stats now reflect agent reads only, so human browsing can't inflate hot-set ranking.

## Background

The Memory sidecar (`memory-meta.json`) tracks `accessCount`/`lastAccessedAt` per memory file, and that signal drives hot-set preloading (which memories get injected into agent context). The UI read path (`memory.read` → `readFileWithSha`, used by the Memory tab and Settings → Memory) recorded a use on every open — so a human simply browsing their memories made those files look "hot" to the ranking, displacing genuinely agent-used memories.

## Implementation

- `MemoryService.readFileWithSha` no longer calls `recordUsage`; a comment documents the boundary (agent reads via the `view` memory command still count).
- UI **saves** still count as uses: an explicit edit is a deliberate "this file matters" signal, consistent with pinning counting as a use.
- Updated the two tests asserting the old behavior into behavioral assertions of the new rule (save + UI read ⇒ `accessCount === 1`), and fixed the stale "chokepoint" comment.

## Risks

Low. The only behavior change is that UI reads stop bumping usage stats; agent command paths, rename/delete metadata handling, and pinning are untouched. Worst case is slightly different hot-set ranking for users who relied on UI browsing to keep files hot — which is exactly the bias being removed.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$2.95`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=2.95 -->
