### PR TITLE
🤖 fix: show Dream agent in Settings only when Memory Consolidation is enabled

### DIFF
--- a/src/browser/features/Settings/Sections/TasksSection.agents.ts
+++ b/src/browser/features/Settings/Sections/TasksSection.agents.ts
@@ -102,17 +102,24 @@ function compareAgentsByName(a: AgentDefinitionDescriptor, b: AgentDefinitionDes
   return a.name.localeCompare(b.name);
 }
 
+// Experiment-gated agents are dead weight in Settings while their experiment
+// is off (they never run), so hide their cards; their overrides stay "known"
+// via knownAgentIds below.
 function shouldShowAgentInTasksSettings(
   agent: AgentDefinitionDescriptor,
-  portableDesktopEnabled: boolean
+  params: { portableDesktopEnabled: boolean; memoryConsolidationEnabled: boolean }
 ): boolean {
-  return portableDesktopEnabled || agent.id !== "desktop";
+  if (agent.id === "desktop") return params.portableDesktopEnabled;
+  if (agent.id === "dream") return params.memoryConsolidationEnabled;
+  return true;
 }
 
 export function deriveTasksSectionAgentGroups(params: {
   listedAgents: AgentDefinitionDescriptor[];
   agentAiDefaults: AgentAiDefaults;
   portableDesktopEnabled: boolean;
+  /** True only when both Agent Memory and Memory Consolidation experiments are on (mirrors the runtime gate in memoryConsolidationService). */
+  memoryConsolidationEnabled: boolean;
 }): {
   uiAgents: AgentDefinitionDescriptor[];
   subagents: AgentDefinitionDescriptor[];
@@ -120,7 +127,7 @@ export function deriveTasksSectionAgentGroups(params: {
   unknownAgentIds: string[];
 } {
   const visible = params.listedAgents.filter((agent) =>
-    shouldShowAgentInTasksSettings(agent, params.portableDesktopEnabled)
+    shouldShowAgentInTasksSettings(agent, params)
   );
   const knownAgentIds = new Set(params.listedAgents.map((agent) => agent.id));
 

--- a/src/browser/features/Settings/Sections/TasksSection.agents.ts
+++ b/src/browser/features/Settings/Sections/TasksSection.agents.ts
@@ -85,6 +85,17 @@ export const FALLBACK_AGENTS: AgentDefinitionDescriptor[] = [
       require: ["propose_name"],
     },
   },
+  {
+    id: "dream",
+    scope: "built-in",
+    name: "Dream",
+    description: "Background memory consolidation (internal)",
+    uiSelectable: false,
+    subagentRunnable: false,
+    tools: {
+      require: ["memory"],
+    },
+  },
 ];
 
 function compareAgentsByName(a: AgentDefinitionDescriptor, b: AgentDefinitionDescriptor): number {

--- a/src/browser/features/Settings/Sections/TasksSection.test.ts
+++ b/src/browser/features/Settings/Sections/TasksSection.test.ts
@@ -2,12 +2,17 @@ import { describe, expect, test } from "bun:test";
 import type { AgentAiDefaults } from "@/common/types/agentAiDefaults";
 import { FALLBACK_AGENTS, deriveTasksSectionAgentGroups } from "./TasksSection.agents";
 
+// NOTE: the invariant that FALLBACK_AGENTS mirrors the built-in agent inventory
+// lives in src/node/services/agentDefinitions/builtInAgentDefinitions.test.ts,
+// since browser/ cannot value-import from node/.
+
 describe("FALLBACK_AGENTS", () => {
   test("keeps hidden built-ins in the fallback inventory", () => {
     const fallbackAgentIds = FALLBACK_AGENTS.map((agent) => agent.id);
 
     expect(fallbackAgentIds).toContain("desktop");
     expect(fallbackAgentIds).toContain("name_workspace");
+    expect(fallbackAgentIds).toContain("dream");
   });
 });
 

--- a/src/browser/features/Settings/Sections/TasksSection.test.ts
+++ b/src/browser/features/Settings/Sections/TasksSection.test.ts
@@ -27,6 +27,7 @@ describe("deriveTasksSectionAgentGroups", () => {
       listedAgents: FALLBACK_AGENTS,
       agentAiDefaults,
       portableDesktopEnabled: false,
+      memoryConsolidationEnabled: false,
     });
 
     expect(groups.subagents.map((agent) => agent.id)).toEqual(["explore"]);
@@ -38,8 +39,37 @@ describe("deriveTasksSectionAgentGroups", () => {
       listedAgents: FALLBACK_AGENTS,
       agentAiDefaults: {},
       portableDesktopEnabled: true,
+      memoryConsolidationEnabled: false,
     });
 
     expect(groups.subagents.map((agent) => agent.id)).toEqual(["desktop", "explore"]);
+  });
+
+  test("hides Dream from Settings while keeping its overrides known when Memory Consolidation is off", () => {
+    const agentAiDefaults: AgentAiDefaults = {
+      dream: { modelString: "anthropic:claude-haiku-4-5" },
+    };
+
+    const groups = deriveTasksSectionAgentGroups({
+      listedAgents: FALLBACK_AGENTS,
+      agentAiDefaults,
+      portableDesktopEnabled: false,
+      memoryConsolidationEnabled: false,
+    });
+
+    expect(groups.internalAgents.map((agent) => agent.id)).not.toContain("dream");
+    // The saved override must stay "known", not surface under Unknown agents.
+    expect(groups.unknownAgentIds).toEqual([]);
+  });
+
+  test("shows Dream under Internal when Memory Consolidation is on", () => {
+    const groups = deriveTasksSectionAgentGroups({
+      listedAgents: FALLBACK_AGENTS,
+      agentAiDefaults: {},
+      portableDesktopEnabled: false,
+      memoryConsolidationEnabled: true,
+    });
+
+    expect(groups.internalAgents.map((agent) => agent.id)).toContain("dream");
   });
 });

--- a/src/browser/features/Settings/Sections/TasksSection.tsx
+++ b/src/browser/features/Settings/Sections/TasksSection.tsx
@@ -494,6 +494,11 @@ export function TasksSection() {
   const newWorkspaceDefaultAgentId = coerceAgentId(globalDefaultAgentIdRaw);
   const portableDesktopEnabled = useExperimentValue(EXPERIMENT_IDS.PORTABLE_DESKTOP);
   const advisorToolEnabled = useExperimentValue(EXPERIMENT_IDS.ADVISOR_TOOL);
+  // Dream only runs when both flags are on (see memoryConsolidationService);
+  // mirror that gate for its Settings card.
+  const memoryEnabled = useExperimentValue(EXPERIMENT_IDS.MEMORY);
+  const memoryConsolidationFlag = useExperimentValue(EXPERIMENT_IDS.MEMORY_CONSOLIDATION);
+  const memoryConsolidationEnabled = memoryEnabled && memoryConsolidationFlag;
 
   // Resolve the workspace's active model so that when a sub-agent's model is
   // "Inherit", we show thinking levels for the workspace model (falling back to
@@ -851,8 +856,9 @@ export function TasksSection() {
         listedAgents,
         agentAiDefaults,
         portableDesktopEnabled,
+        memoryConsolidationEnabled,
       }),
-    [agentAiDefaults, listedAgents, portableDesktopEnabled]
+    [agentAiDefaults, listedAgents, portableDesktopEnabled, memoryConsolidationEnabled]
   );
   const execSubagentAgent = listedAgents.find(
     (agent) => agent.id === "exec" && agent.subagentRunnable && agent.uiSelectable

--- a/src/node/services/agentDefinitions/builtInAgentDefinitions.test.ts
+++ b/src/node/services/agentDefinitions/builtInAgentDefinitions.test.ts
@@ -1,10 +1,24 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
+// Importing browser code from node tests is allowed (only browser->node value
+// imports are banned); TasksSection.agents is a pure data module.
+import { FALLBACK_AGENTS } from "@/browser/features/Settings/Sections/TasksSection.agents";
 import { clearBuiltInAgentCache, getBuiltInAgentDefinitions } from "./builtInAgentDefinitions";
 
 describe("built-in agent definitions", () => {
   beforeEach(() => {
     clearBuiltInAgentCache();
+  });
+
+  test("Settings fallback inventory mirrors built-ins, including hidden agents", () => {
+    // FALLBACK_AGENTS must cover every built-in (hidden ones too) so saved
+    // overrides are not mislabeled as unknown when discovery is unavailable.
+    const builtInIds = getBuiltInAgentDefinitions()
+      .map((pkg) => pkg.id)
+      .sort();
+    const fallbackIds = FALLBACK_AGENTS.map((agent) => agent.id).sort();
+
+    expect(fallbackIds).toEqual(builtInIds);
   });
 
   test("does not include a built-in auto agent", () => {


### PR DESCRIPTION
## Summary

The Dream (memory consolidation) agent was missing from the Settings → Agents page in fallback mode, and conversely showed up as dead weight when the Memory Consolidation experiment was off. This PR fixes the fallback inventory and gates the Dream card behind the experiment, following the existing Desktop/Portable Desktop precedent.

## Background

A user enabled the memory dreams experiment but could not find the Dream agent on Settings → Agents. Root cause: `FALLBACK_AGENTS` (used when agent discovery is unavailable, e.g. Settings opened without a workspace selected) was never updated when the dream agent shipped, so the card vanished and any saved override would be mislabeled under "Unknown agents".

While dogfooding the fix, a second UX issue surfaced: the Dream card rendered even with the experiments off — an internal agent the user cannot select or run, which never executes unless both Agent Memory and Memory Consolidation are enabled (see the runtime gate in `memoryConsolidationService`).

## Implementation

- **Commit 1** adds `dream` to `FALLBACK_AGENTS`, mirroring its frontmatter in `src/node/builtinAgents/dream.md`, and replaces the spot-check test with an invariant test pinning `FALLBACK_AGENTS` to `getBuiltInAgentDefinitions()` so future built-ins cannot regress this. (The invariant lives node-side because browser/ cannot value-import from node/.)
- **Commit 2** turns `shouldShowAgentInTasksSettings` into a per-agent rule table: `desktop` → Portable Desktop, `dream` → Memory Consolidation (ANDed with Agent Memory, mirroring the runtime gate). Hidden agents stay in `knownAgentIds`, so saved overrides are not relabeled as unknown when the experiment is toggled off.

## Validation

Dogfooded both states in isolated dev-server sandboxes via agent-browser:

- Experiments off: Internal group shows Compact → Name Workspace, no Dream card.
- Agent Memory + Memory Consolidation on: Dream card appears under Internal with Enabled toggle and Model/Reasoning overrides, live without reload.
- Fallback path (Settings opened from Home, no workspace): Dream listed correctly.

## Risks

Low. Pure Settings-page visibility logic; no change to when consolidation actually runs. Worst case is a Settings card showing/hiding incorrectly; override persistence is covered by tests.
---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$12.77`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=12.77 -->
