### PR TITLE
🤖 fix: clean up completed workflow task workspaces

### DIFF
--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -11160,6 +11160,7 @@ describe("TaskService", () => {
       agentType: string;
       taskStatus?: "reported" | "interrupted";
       reportedAt?: string;
+      workflowTask?: WorkspaceConfigEntry["workflowTask"];
     }
 
     type TaskCleanupEligibility =
@@ -11232,6 +11233,7 @@ describe("TaskService", () => {
           agentType: task.agentType,
           taskStatus: task.taskStatus ?? "reported",
           reportedAt: task.reportedAt,
+          ...(task.workflowTask !== undefined ? { workflowTask: task.workflowTask } : {}),
         });
         parentWorkspaceId = task.id;
       }
@@ -11278,6 +11280,46 @@ describe("TaskService", () => {
 
       expect(remove).not.toHaveBeenCalled();
       expect(findWorkspaceInConfig(config, childTaskId)).toBeTruthy();
+    });
+
+    test("workflow-owned completed descendants bypass preserve-until-archive cleanup", async () => {
+      const workflowTaskId = "workflow-222";
+      const childTaskId = "child-333";
+      const { config, taskService, remove, rootWorkspaceId, internal } =
+        await setupReportedTaskChain({
+          taskChain: [
+            {
+              id: workflowTaskId,
+              directoryName: "workflow-task",
+              name: "agent_explore_workflow",
+              agentType: "explore",
+              taskStatus: "reported",
+              workflowTask: { runId: "wfr_cleanup", stepId: "review" },
+            },
+            {
+              id: childTaskId,
+              directoryName: "child-task",
+              name: "agent_exec_child",
+              agentType: "exec",
+              taskStatus: "reported",
+            },
+          ],
+        });
+
+      expect(await internal.canCleanupReportedTask(childTaskId)).toEqual({
+        ok: true,
+        parentWorkspaceId: workflowTaskId,
+      });
+      expect(taskService.hasPreservedCompletedDescendants(rootWorkspaceId)).toBe(false);
+
+      await internal.cleanupReportedLeafTask(childTaskId);
+
+      expect(remove.mock.calls).toEqual([
+        [childTaskId, true],
+        [workflowTaskId, true],
+      ]);
+      expect(findWorkspaceInConfig(config, childTaskId)).toBeUndefined();
+      expect(findWorkspaceInConfig(config, workflowTaskId)).toBeUndefined();
     });
 
     test("startup recovery leaves preserved descendants alone before archive", async () => {

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -816,10 +816,6 @@ export class TaskService {
   // Serialize stream-end processing per workspace to avoid races when
   // finalizing reported tasks and cleanup state transitions.
   private readonly workspaceEventLocks = new MutexMap<string>();
-  // Workflow runs whose completed child workspaces must not be auto-deleted yet
-  // (see markWorkflowRunActive). In-memory by design: lost holds self-heal via
-  // the startup completed-report recheck.
-  private readonly activeWorkflowRunIds = new Set<string>();
   // Separate parent-scoped lock for deferred best-of fallback/finalization. This path can run
   // concurrently from multiple child stream-end handlers for the same parent, and it must remain
   // safe even when the parent stream-end already holds workspaceEventLocks for the parent itself.
@@ -2785,25 +2781,12 @@ export class TaskService {
     return Ok({ terminatedTaskIds });
   }
 
-  /**
-   * Defer auto-cleanup of a workflow run's completed child workspaces while
-   * the run is active. Without the hold, sequential steps flash in the sidebar:
-   * step N's workspace is deleted the moment its report is consumed, leaving
-   * the run with zero workspaces until step N+1 spawns. The hold is in-memory
-   * only - after a crash/restart the regular startup recheck sweeps leftovers.
-   */
-  markWorkflowRunActive(workflowRunId: string): void {
-    assert(workflowRunId.length > 0, "markWorkflowRunActive: workflowRunId must be non-empty");
-    this.activeWorkflowRunIds.add(workflowRunId);
-  }
-
-  /** Release the cleanup hold for a terminal run and sweep its deferred children. */
+  /** Best-effort final recheck for any completed workflow children still deferred by cleanup gates. */
   async markWorkflowRunEnded(workflowRunId: string): Promise<void> {
     assert(workflowRunId.length > 0, "markWorkflowRunEnded: workflowRunId must be non-empty");
-    this.activeWorkflowRunIds.delete(workflowRunId);
 
     const cfg = this.config.loadConfigOrDefault();
-    const heldTaskIds: string[] = [];
+    const completedTaskIds: string[] = [];
     for (const project of cfg.projects.values()) {
       for (const workspace of project.workspaces) {
         if (
@@ -2811,11 +2794,11 @@ export class TaskService {
           workspace.workflowTask?.runId === workflowRunId &&
           hasCompletedAgentReport(workspace)
         ) {
-          heldTaskIds.push(workspace.id);
+          completedTaskIds.push(workspace.id);
         }
       }
     }
-    for (const taskId of heldTaskIds) {
+    for (const taskId of completedTaskIds) {
       await this.cleanupReportedLeafTask(taskId);
     }
   }
@@ -3516,7 +3499,9 @@ export class TaskService {
     const index = this.buildAgentTaskIndex(cfg);
     const completedDescendants = this.listCompletedDescendantAgentTaskIds(index, workspaceId);
     return completedDescendants.some(
-      (descendantId) => !this.hasArchivedAncestor(index, cfg, descendantId)
+      (descendantId) =>
+        !this.isWorkflowOwnedTaskUsingIndex(index, descendantId) &&
+        !this.hasArchivedAncestor(index, cfg, descendantId)
     );
   }
 
@@ -3939,6 +3924,26 @@ export class TaskService {
         isWorkspaceArchived(entry.workspace.archivedAt, entry.workspace.unarchivedAt)
       );
     });
+  }
+
+  private isWorkflowOwnedTaskUsingIndex(index: AgentTaskIndex, taskId: string): boolean {
+    assert(taskId.length > 0, "isWorkflowOwnedTaskUsingIndex: taskId must be non-empty");
+
+    let current: string | undefined = taskId;
+    for (let depth = 0; current != null && depth < 32; depth++) {
+      const entry = index.byId.get(current);
+      if (entry?.workflowTask != null) {
+        return true;
+      }
+      current = index.parentById.get(current);
+    }
+
+    if (current != null) {
+      throw new Error(
+        `isWorkflowOwnedTaskUsingIndex: possible parentWorkspaceId cycle starting at ${taskId}`
+      );
+    }
+    return false;
   }
 
   private countActiveAgentTasks(config: ReturnType<Config["loadConfigOrDefault"]>): number {
@@ -6563,13 +6568,6 @@ export class TaskService {
       return { ok: false, reason: "task_not_reported" };
     }
 
-    // Workflow-owned children stay visible in the sidebar for the run's whole
-    // duration; markWorkflowRunEnded sweeps them once the run is terminal.
-    const workflowRunId = entry.workspace.workflowTask?.runId;
-    if (workflowRunId != null && this.activeWorkflowRunIds.has(workflowRunId)) {
-      return { ok: false, reason: "workflow_run_active" };
-    }
-
     if (entry.workspace.bestOf?.total != null && entry.workspace.bestOf.total > 1) {
       if (
         await this.shouldDeferBestOfFallback({
@@ -6594,6 +6592,7 @@ export class TaskService {
     // (has no child agent tasks in config). This stays status-agnostic so ancestor deletion
     // never orphans descendants that have not been pruned yet.
     const index = this.buildAgentTaskIndex(config);
+    const isWorkflowOwnedTask = this.isWorkflowOwnedTaskUsingIndex(index, workspaceId);
     if (this.hasChildAgentTasks(index, workspaceId)) {
       return { ok: false, reason: "has_child_tasks" };
     }
@@ -6608,8 +6607,12 @@ export class TaskService {
       return { ok: false, reason: "patch_pending" };
     }
 
+    // Workflow task results are persisted in the workflow run/report artifacts before cleanup,
+    // so the user-level "preserve subagents until archive" setting should not keep those
+    // transient worktrees around indefinitely.
     const taskSettings = normalizeTaskSettings(config.taskSettings);
     if (
+      !isWorkflowOwnedTask &&
       taskSettings.preserveSubagentsUntilArchive &&
       !this.hasArchivedAncestor(index, config, workspaceId)
     ) {

--- a/src/node/services/workflows/WorkflowRunner.test.ts
+++ b/src/node/services/workflows/WorkflowRunner.test.ts
@@ -79,7 +79,7 @@ function createDeferred() {
 }
 
 describe("WorkflowRunner", () => {
-  test("brackets runs with onRunStarted/onRunEnded so child-workspace cleanup holds match run lifetime", async () => {
+  test("runs onRunEnded after a successful workflow", async () => {
     using tmp = new DisposableTempDir("workflow-runner");
     const store = await createRunStore(tmp.path);
     const lifecycle: string[] = [];
@@ -88,9 +88,6 @@ describe("WorkflowRunner", () => {
         lifecycle.push("agent");
         return { taskId: "task_1", reportMarkdown: "summary" };
       },
-      onRunStarted() {
-        lifecycle.push("started");
-      },
       onRunEnded() {
         lifecycle.push("ended");
       },
@@ -98,19 +95,16 @@ describe("WorkflowRunner", () => {
 
     await runner.run("wfr_123");
 
-    expect(lifecycle).toEqual(["started", "agent", "ended"]);
+    expect(lifecycle).toEqual(["agent", "ended"]);
   });
 
-  test("releases the run hold when the workflow fails", async () => {
+  test("runs the terminal lifecycle callback when the workflow fails", async () => {
     using tmp = new DisposableTempDir("workflow-runner");
     const store = await createRunStore(tmp.path);
     const lifecycle: string[] = [];
     const runner = createRunner(store, {
       async runAgent() {
         throw new Error("agent exploded");
-      },
-      onRunStarted() {
-        lifecycle.push("started");
       },
       onRunEnded() {
         lifecycle.push("ended");
@@ -119,10 +113,10 @@ describe("WorkflowRunner", () => {
 
     await expect(runner.run("wfr_123")).rejects.toThrow("agent exploded");
 
-    expect(lifecycle).toEqual(["started", "ended"]);
+    expect(lifecycle).toEqual(["ended"]);
   });
 
-  test("keeps the run hold when the lease belongs to another runner", async () => {
+  test("does not run the terminal lifecycle callback when the lease belongs to another runner", async () => {
     using tmp = new DisposableTempDir("workflow-runner");
     const store = await createRunStore(tmp.path);
     // Simulate a concurrent runner owning a fresh (non-stale) lease at the
@@ -134,9 +128,6 @@ describe("WorkflowRunner", () => {
       async runAgent() {
         return { taskId: "task_1", reportMarkdown: "summary" };
       },
-      onRunStarted() {
-        lifecycle.push("started");
-      },
       onRunEnded() {
         lifecycle.push("ended");
       },
@@ -144,8 +135,8 @@ describe("WorkflowRunner", () => {
 
     await expect(runner.run("wfr_123")).rejects.toThrow("Workflow run is already active");
 
-    // The lease owner is responsible for releasing the hold; this runner must not.
-    expect(lifecycle).toEqual(["started"]);
+    // The lease owner is responsible for the terminal lifecycle callback; this runner must not.
+    expect(lifecycle).toEqual([]);
   });
 
   test("executes conductor primitives and persists run events/results", async () => {

--- a/src/node/services/workflows/WorkflowRunner.ts
+++ b/src/node/services/workflows/WorkflowRunner.ts
@@ -130,13 +130,6 @@ export interface WorkflowTaskAdapter {
   ): Promise<unknown>;
   interruptRun?(): Promise<void>;
   /**
-   * Called when the runner begins executing the run (including resumes and
-   * background continuations). Adapters use this to hold completed child-task
-   * workspaces alive so the sidebar shows the run's tasks for its whole
-   * duration instead of flashing between sequential steps.
-   */
-  onRunStarted?(): Promise<void> | void;
-  /**
    * Called when the run reaches a terminal state. Not called when the run is
    * backgrounded (the background continuation re-enters run()) or when the
    * lease was held by another runner.
@@ -310,9 +303,6 @@ export class WorkflowRunner {
 
   async run(runId: string, options?: WorkflowRunnerRunOptions): Promise<WorkflowResult> {
     assert(runId.length > 0, "WorkflowRunner.run: runId is required");
-    // Hold workflow-owned child workspaces for the run's whole duration so the
-    // sidebar keeps showing the run's tasks between sequential steps.
-    await this.taskAdapter.onRunStarted?.();
     try {
       const result = await this.runWithLease(runId, options);
       await this.taskAdapter.onRunEnded?.();

--- a/src/node/services/workflows/WorkflowTaskServiceAdapter.test.ts
+++ b/src/node/services/workflows/WorkflowTaskServiceAdapter.test.ts
@@ -295,8 +295,7 @@ describe("WorkflowTaskServiceAdapter", () => {
     ]);
   });
 
-  test("forwards run lifecycle hooks to the task service cleanup hold", async () => {
-    const markWorkflowRunActive = mock((_runId: string) => undefined);
+  test("forwards run-end lifecycle hooks to the task service", async () => {
     const markWorkflowRunEnded = mock(async (_runId: string) => undefined);
     const adapter = new WorkflowTaskServiceAdapter({
       taskService: {
@@ -304,7 +303,6 @@ describe("WorkflowTaskServiceAdapter", () => {
           Ok({ taskId: "task_1", kind: "agent" as const, status: "running" as const })
         ),
         waitForAgentReport: mock(async () => ({ reportMarkdown: "unused" })),
-        markWorkflowRunActive,
         markWorkflowRunEnded,
       },
       parentWorkspaceId: "parent_1",
@@ -312,10 +310,8 @@ describe("WorkflowTaskServiceAdapter", () => {
       defaultAgentId: "explore",
     });
 
-    adapter.onRunStarted();
     await adapter.onRunEnded();
 
-    expect(markWorkflowRunActive).toHaveBeenCalledWith("wfr_123");
     expect(markWorkflowRunEnded).toHaveBeenCalledWith("wfr_123");
   });
 

--- a/src/node/services/workflows/WorkflowTaskServiceAdapter.ts
+++ b/src/node/services/workflows/WorkflowTaskServiceAdapter.ts
@@ -74,7 +74,6 @@ interface WorkflowTaskServiceLike {
     workspaceId: string,
     options?: { workflowRunId?: string }
   ): Promise<string[]>;
-  markWorkflowRunActive?(workflowRunId: string): void;
   markWorkflowRunEnded?(workflowRunId: string): Promise<void>;
 }
 
@@ -210,12 +209,6 @@ export class WorkflowTaskServiceAdapter implements WorkflowTaskAdapter {
     await this.taskService.terminateAllDescendantAgentTasks?.(this.parentWorkspaceId, {
       workflowRunId: this.workflowRunId,
     });
-  }
-
-  // Completed child workspaces are held (not auto-deleted) while the run is
-  // active so the sidebar shows the run's tasks for its entire duration.
-  onRunStarted(): void {
-    this.taskService.markWorkflowRunActive?.(this.workflowRunId);
   }
 
   async onRunEnded(): Promise<void> {


### PR DESCRIPTION
Summary

Allow completed workflow-owned task workspaces to be pruned after their reports/structured outputs have been persisted, instead of retaining those transient worktrees for the full workflow run or behind the user-level preserve-subagents-until-archive setting.

Background

Workflow tasks already persist their report payloads into ancestor report artifacts and the workflow run journal. Keeping the backing task workspaces indefinitely after completion leaves completed workflow lanes in the sidebar even when their structured output is already available from the workflow card.

Implementation

- Removed the in-memory active workflow-run cleanup hold and the corresponding run-start lifecycle callback.
- Kept the run-end lifecycle callback as a best-effort cleanup recheck for workflow children that may have been deferred by other gates.
- Added workflow-owned lineage detection so completed workflow task trees bypass preserve-subagents-until-archive while normal subagents keep the existing behavior.
- Updated workflow lifecycle tests and added regression coverage for workflow-owned cleanup with preserve-subagents-until-archive enabled.

Validation

- `bun test src/node/services/taskService.test.ts -t "preserve subagents until archive"`
- `bun test src/node/services/workflows/WorkflowRunner.test.ts src/node/services/workflows/WorkflowTaskServiceAdapter.test.ts`
- `bun test src/node/services/taskService.test.ts`
- `make typecheck`
- `make lint`
- `make fmt-check`
- `git diff --check`
- `make static-check`

Risks

Medium-low. This touches task cleanup behavior, but the change is scoped to completed workflow-owned task trees and preserves existing cleanup gates for active descendants, pending patch artifacts, and non-workflow subagent preservation.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$16.15`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=16.15 -->
