### PR TITLE
🤖 tests: disable tutorials in e2e harness

### DIFF
--- a/tests/e2e/electronTest.ts
+++ b/tests/e2e/electronTest.ts
@@ -373,12 +373,13 @@ export const electronTest = base.extend<ElectronFixtures>({
     await window.waitForLoadState("domcontentloaded");
     await window.setViewportSize({ width: 1600, height: 900 });
 
-    // Disable tutorials for e2e tests by marking them as completed
-    // Must set before React reads the state, so we set and reload
+    // Disable tutorials for e2e tests before React reads the state, then reload.
+    // Otherwise delayed tutorial backdrops can race with Playwright clicks and make
+    // unrelated UI scenarios flaky when a new tutorial sequence is added.
     await window.evaluate(() => {
       const tutorialState = {
-        disabled: false,
-        completed: { settings: true, creation: true, workspace: true },
+        disabled: true,
+        completed: { creation: true, workspace: true, review: true },
       };
       localStorage.setItem("tutorialState", JSON.stringify(tutorialState));
     });

--- a/tests/e2e/scenarios/reviewRefresh.spec.ts
+++ b/tests/e2e/scenarios/reviewRefresh.spec.ts
@@ -106,6 +106,11 @@ test.describe("review refresh", () => {
     const refreshButton = page.getByTestId("review-refresh");
     await expect(refreshButton).toBeVisible({ timeout: 10_000 });
 
+    // The review tutorial used to start 500ms after this panel mounted, leaving
+    // a backdrop over the tab strip and making the Stats tab click time out.
+    await page.waitForTimeout(600);
+    await expect(page.getByTestId("tutorial-backdrop")).toHaveCount(0);
+
     // Do a manual refresh
     await refreshButton.dispatchEvent("click");
 


### PR DESCRIPTION
## Summary

Fixes the `review refresh › refresh state persists after tab switch` Linux E2E flake by fully disabling tutorials in the Electron E2E harness before the renderer reloads.

## Background

I reviewed `/memories/project/known-flaky-tests.md` and surveyed PR workflow failures from the last 14 days. Among the named flaky tests in that file, `tests/e2e/scenarios/reviewRefresh.spec.ts:100` had the most exact failures (4), compared with `backgroundBashDirect.test.ts` (2). The failing logs show Playwright timing out on the Stats tab because `<div data-testid="tutorial-backdrop">` intercepted pointer events.

## Root Cause

The E2E fixture tried to disable tutorials by marking the then-known sequences completed, but it left the newer `review` tutorial sequence incomplete and kept `disabled: false`. `ReviewControls` starts the review tutorial 500ms after mount, so slower CI runs could reveal the backdrop just before the test clicked the Stats tab.

## Implementation

- Persist `disabled: true` in the E2E tutorial state and mark current tutorial sequences completed before React reads localStorage.
- Add a targeted regression assertion in the flaky review refresh test that waits past the review tutorial timer and verifies no tutorial backdrop exists before switching tabs.

## Validation

- `bun test src/browser/contexts/TutorialContext.test.tsx`
- `make typecheck`
- `make static-check`

Local targeted Electron E2E execution is blocked in this workspace by the missing X server / `xvfb` (`Missing X server or $DISPLAY`). The new regression assertion is intended to run in CI's Linux E2E environment.

## Risks

Low. The change is confined to the E2E harness and one E2E regression assertion; production tutorial behavior is unchanged.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$unknown`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=unknown -->
