### PR TITLE
🤖 tests: stabilize deep-research fanout test

### DIFF
--- a/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
+++ b/src/node/services/workflows/builtInWorkflowDefinitions.test.ts
@@ -11,8 +11,7 @@ import { WorkflowActionRegistry } from "./WorkflowActionRegistry";
 import { WorkflowRunStore } from "./WorkflowRunStore";
 import { WorkflowRunner, type WorkflowAgentResult, type WorkflowAgentSpec } from "./WorkflowRunner";
 
-// Keep this above tiny lock timeouts: these fixtures exercise parallel workflow callbacks
-// that legitimately contend for the run-store mutation lock under CI coverage load.
+// Most fixtures use short leases so stale-run retry behavior stays fast.
 const BUILT_IN_WORKFLOW_TEST_STALE_LEASE_MS = 100;
 
 const deepResearch = BUILT_IN_WORKFLOW_DEFINITIONS.find(
@@ -2101,10 +2100,9 @@ describe("built-in deep-research workflow", () => {
       throw new Error("Expected built-in deep-research workflow");
     }
     using tmp = new DisposableTempDir("deep-research-capped-workflow");
-    const runStore = new WorkflowRunStore({
-      sessionDir: tmp.path,
-      staleLeaseMs: BUILT_IN_WORKFLOW_TEST_STALE_LEASE_MS,
-    });
+    // This fixture intentionally creates heavy parallel step persistence; use production
+    // lease timing so the assertion covers fan-out caps, not 50ms renewal churn.
+    const runStore = new WorkflowRunStore({ sessionDir: tmp.path });
     await runStore.createRun({
       id: "wfr_deep_research_capped",
       workspaceId: "workspace-1",
@@ -2240,7 +2238,7 @@ describe("built-in deep-research workflow", () => {
     expect(structuredOutput.claims).toHaveLength(16);
     expect(structuredOutput.verification).toHaveLength(16);
     expect(structuredOutput.stats.claimsExtracted).toBe(75);
-  }, 10_000);
+  }, 30_000);
 });
 
 describe("built-in deep-review-workflow", () => {


### PR DESCRIPTION
## Summary

Stabilizes the deep-research capped fanout unit test by letting that heavy fanout fixture use the production WorkflowRunStore lease timing instead of the 100ms stale-lease setting used by retry-focused fixtures.

## Background

The known flaky test `built-in deep-research workflow › caps model-produced deep-research fan-out` failed in merge-queue Unit runs with `Timed out acquiring workflow mutation lock: .../events.jsonl.lock`. I reproduced the same failure locally by pinning the targeted test to one CPU while running a same-core CPU hog; the short 100ms fixture lease renews every 50ms, which adds lock churn while the test is intentionally persisting many parallel workflow steps.

## Implementation

The capped fanout test now constructs `WorkflowRunStore` with its default production lease settings, because the test is asserting source/claim fanout caps rather than stale-lease retry behavior. Its per-test timeout is raised to 30s to leave room for CPU-contention repro runs without changing normal runtime.

## Validation

- Reproduced the pre-fix failure with `taskset -c 0` plus one same-core CPU hog: `Timed out acquiring workflow mutation lock: .../events.jsonl.lock`.
- After the fix, the same targeted test passed under two same-core CPU hogs (~11.5s) and three same-core CPU hogs (~18.0s).
- `bun test src/node/services/workflows/builtInWorkflowDefinitions.test.ts -t "caps model-produced deep-research fan-out"`
- `bun test src/node/services/workflows/builtInWorkflowDefinitions.test.ts`
- `make static-check`

## Risks

Low product risk: this is test-only and avoids applying retry-fixture lease timing to a high-concurrency fanout assertion. The broader workflow runtime code is unchanged.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$11.63`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=11.63 -->
