### PR TITLE
🤖 fix: remove workflow sidebar progress fraction

### DIFF
--- a/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
@@ -942,6 +942,7 @@ describe("ProjectSidebar multi-project completed-subagent toggles", () => {
     expect(view.getByTestId(agentItemTestId("parent"))).toBeTruthy();
     const groupRow = view.getByTestId("task-group-best-of-demo");
     expect(groupRow.textContent).toContain("Best of 3");
+    expect(groupRow.textContent).toContain("0/3");
     expect(view.queryByTestId(agentItemTestId("child-1"))).toBeNull();
     expect(view.queryByTestId(agentItemTestId("child-2"))).toBeNull();
     expect(view.queryByTestId(agentItemTestId("child-3"))).toBeNull();
@@ -1287,9 +1288,13 @@ describe("ProjectSidebar multi-project completed-subagent toggles", () => {
 
     // One header per run, even though beta-1 interleaves between the alpha tasks.
     const alphaHeader = view.getByTestId("task-group-wfr_alpha");
-    expect(view.getByTestId("task-group-wfr_beta")).toBeTruthy();
+    const betaHeader = view.getByTestId("task-group-wfr_beta");
+    expect(betaHeader).toBeTruthy();
     // The stamped workflow name reaches the header label.
     expect(alphaHeader.textContent).toContain("review-pipeline");
+    // Workflow rows keep the live status text but omit the compact completed/total fraction.
+    expect(betaHeader.textContent).toContain("1 running");
+    expect(betaHeader.textContent).not.toContain("0/1");
 
     // Active workflow groups default to expanded (D6), so members render as
     // group members without an explicit toggle.

--- a/src/browser/components/ProjectSidebar/TaskGroupListItem.tsx
+++ b/src/browser/components/ProjectSidebar/TaskGroupListItem.tsx
@@ -48,6 +48,7 @@ export function TaskGroupListItem(props: TaskGroupListItemProps) {
   const statusDescriptionId = `task-group-status-${props.groupId}`;
   const paddingLeft = getSidebarItemPaddingLeft(props.depth);
   const KindGlyph = props.kind === "workflow" ? Workflow : Layers3;
+  const showProgressFraction = props.kind !== "workflow";
   const statusParts: string[] = [];
   if (props.runningCount > 0) {
     statusParts.push(`${props.runningCount} running`);
@@ -109,7 +110,12 @@ export function TaskGroupListItem(props: TaskGroupListItemProps) {
         />
       </span>
       <div className="ml-1.5 flex min-w-0 flex-1 flex-col gap-0.5">
-        <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1.5">
+        <div
+          className={cn(
+            "grid min-w-0 items-center gap-1.5",
+            showProgressFraction ? "grid-cols-[minmax(0,1fr)_auto]" : "grid-cols-1"
+          )}
+        >
           <span className="flex min-w-0 items-center gap-1.5">
             <KindGlyph
               aria-hidden="true"
@@ -128,9 +134,11 @@ export function TaskGroupListItem(props: TaskGroupListItemProps) {
               {formatSidebarTaskGroupHeader(props.kind, props.totalCount, props.title)}
             </span>
           </span>
-          <span className="text-muted text-[11px]">
-            {props.completedCount}/{props.totalCount}
-          </span>
+          {showProgressFraction && (
+            <span className="text-muted text-[11px]">
+              {props.completedCount}/{props.totalCount}
+            </span>
+          )}
         </div>
         <div
           id={statusDescriptionId}


### PR DESCRIPTION
## Summary

Remove the compact completed/total fraction from workflow task-group rows in the left sidebar while preserving that fraction for best-of and variants task groups.

## Background

Workflow rows already summarize progress in the secondary status line (for example, `1 running` or `1 completed`), so the extra right-aligned `0/1` indicator adds visual noise and truncates the workflow title sooner.

## Implementation

- Gate the compact completed/total fraction behind non-workflow task groups in `TaskGroupListItem`.
- Let workflow headers use a single title column so the workflow name gets the reclaimed space.
- Add regression coverage that workflow groups omit `0/1` while best-of groups still render their fraction.

## Validation

- `bun test src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx`
- `make static-check`
- Storybook dogfood of `Components/ProjectSidebar / Workflow Run Groups` at desktop and narrow/mobile widths; verified workflow row text no longer contains `0/1` while the variants row still shows `0/2`.

## Risks

Low. This is a sidebar presentation-only change scoped to task-group headers. Best-of and variants rows keep their existing progress fraction, and workflow status text remains visible below the header.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$5.75`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=5.75 -->
