### PR TITLE
🤖 feat: centralize workflow automations

### DIFF
--- a/src/browser/components/AgentListItem/AgentListItem.stories.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.stories.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { useEffect } from "react";
 import { AgentListItem } from "@/browser/components/AgentListItem/AgentListItem";
 import { APIProvider } from "@/browser/contexts/API";
+import { ProjectProvider } from "@/browser/contexts/ProjectContext";
 import { TelemetryEnabledProvider } from "@/browser/contexts/TelemetryEnabledContext";
 import { TitleEditProvider } from "@/browser/contexts/WorkspaceTitleEditContext";
 import { DndProvider } from "react-dnd";
@@ -181,17 +182,19 @@ function StoryScaffold(props: {
 
   return (
     <APIProvider client={api}>
-      <TelemetryEnabledProvider>
-        <TitleEditProvider onUpdateTitle={() => Promise.resolve({ success: true })}>
-          <TooltipProvider>
-            <DndProvider backend={HTML5Backend}>
-              <div className="border-border bg-surface-primary w-[360px] rounded-md border p-2">
-                <div className={props.rowContainerClassName ?? "space-y-1"}>{props.children}</div>
-              </div>
-            </DndProvider>
-          </TooltipProvider>
-        </TitleEditProvider>
-      </TelemetryEnabledProvider>
+      <ProjectProvider>
+        <TelemetryEnabledProvider>
+          <TitleEditProvider onUpdateTitle={() => Promise.resolve({ success: true })}>
+            <TooltipProvider>
+              <DndProvider backend={HTML5Backend}>
+                <div className="border-border bg-surface-primary w-[360px] rounded-md border p-2">
+                  <div className={props.rowContainerClassName ?? "space-y-1"}>{props.children}</div>
+                </div>
+              </DndProvider>
+            </TooltipProvider>
+          </TitleEditProvider>
+        </TelemetryEnabledProvider>
+      </ProjectProvider>
     </APIProvider>
   );
 }

--- a/src/browser/components/AgentListItem/AgentListItem.test.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.test.tsx
@@ -7,6 +7,7 @@ import { installDom } from "../../../../tests/ui/dom";
 import type * as ReactDndModuleType from "react-dnd";
 import type * as ReactDndHtml5BackendModuleType from "react-dnd-html5-backend";
 import type * as APIModuleType from "@/browser/contexts/API";
+import type * as ProjectContextModuleType from "@/browser/contexts/ProjectContext";
 import type * as TelemetryEnabledContextModuleType from "@/browser/contexts/TelemetryEnabledContext";
 import type * as WorkspaceTitleEditContextModuleType from "@/browser/contexts/WorkspaceTitleEditContext";
 import type * as ContextMenuPositionModuleType from "@/browser/hooks/useContextMenuPosition";
@@ -133,6 +134,8 @@ function installAgentListItemTestDoubles() {
   const actualReactDndHtml5Backend =
     require("react-dnd-html5-backend?real=1") as typeof ReactDndHtml5BackendModuleType;
   const actualApi = require("@/browser/contexts/API?real=1") as typeof APIModuleType;
+  const actualProjectContext =
+    require("@/browser/contexts/ProjectContext?real=1") as typeof ProjectContextModuleType;
   const actualTelemetryEnabledContext =
     require("@/browser/contexts/TelemetryEnabledContext?real=1") as typeof TelemetryEnabledContextModuleType;
   const actualWorkspaceTitleEditContext =
@@ -172,6 +175,14 @@ function installAgentListItemTestDoubles() {
     }),
   }));
 
+  void mock.module("@/browser/contexts/ProjectContext", () => ({
+    ...actualProjectContext,
+    useProjectContext: () => ({
+      getProjectConfig: () => undefined,
+      userProjects: new Map(),
+    }),
+  }));
+
   void mock.module("@/browser/contexts/TelemetryEnabledContext", () => ({
     ...actualTelemetryEnabledContext,
     useLinkSharingEnabled: () => false,
@@ -191,6 +202,10 @@ function installAgentListItemTestDoubles() {
 
   void mock.module("../WorkspaceHeartbeatModal", () => ({
     WorkspaceHeartbeatModal: () => null,
+  }));
+
+  void mock.module("../AutomationModal", () => ({
+    AutomationModal: () => null,
   }));
 
   void mock.module("@/browser/hooks/useContextMenuPosition", () => ({

--- a/src/browser/components/AgentListItem/AgentListItem.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.tsx
@@ -73,8 +73,11 @@ import { useLinkSharingEnabled } from "@/browser/contexts/TelemetryEnabledContex
 import { formatKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
 import { ShareTranscriptDialog } from "../ShareTranscriptDialog/ShareTranscriptDialog";
 import { WorkspaceHeartbeatModal } from "../WorkspaceHeartbeatModal";
+import { AutomationModal } from "../AutomationModal";
 import { WorkspaceActionsMenuContent } from "../WorkspaceActionsMenuContent/WorkspaceActionsMenuContent";
 import { useAPI } from "@/browser/contexts/API";
+import { useProjectContext } from "@/browser/contexts/ProjectContext";
+import { getExistingWorkspaceProjectWorkflowSchedule } from "@/browser/utils/projectWorkflowSchedules";
 
 export interface WorkspaceSelection {
   projectPath: string;
@@ -432,6 +435,7 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
 
   // Destructure metadata for convenience
   const { id: workspaceId, namedWorkspacePath } = metadata;
+  const dynamicWorkflowsEnabled = useExperimentValue(EXPERIMENT_IDS.DYNAMIC_WORKFLOWS);
   const workspaceHeartbeatsEnabled = useExperimentValue(EXPERIMENT_IDS.WORKSPACE_HEARTBEATS);
   const isInitializing = metadata.isInitializing === true;
   const isRemoving = isRemovingProp === true || metadata.isRemoving === true;
@@ -485,9 +489,15 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
       ? `${groupLabel} · ${workspaceTitle}`
       : workspaceTitle;
   const isEditing = editingWorkspaceId === workspaceId;
+  const { getProjectConfig } = useProjectContext();
+  const projectWorkflowSchedule = getExistingWorkspaceProjectWorkflowSchedule({
+    projectConfig: getProjectConfig(projectPath),
+    workspaceId,
+  });
 
   const linkSharingEnabled = useLinkSharingEnabled();
   const [shareTranscriptOpen, setShareTranscriptOpen] = useState(false);
+  const [automationModalOpen, setAutomationModalOpen] = useState(false);
   const [heartbeatModalOpen, setHeartbeatModalOpen] = useState(false);
   const overflowMenuButtonRef = useRef<HTMLButtonElement | null>(null);
   const overflowMenuFrameRef = useRef<number | null>(null);
@@ -931,6 +941,9 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
                     onConfigureHeartbeat={
                       workspaceHeartbeatsEnabled ? () => setHeartbeatModalOpen(true) : null
                     }
+                    onConfigureAutomation={
+                      dynamicWorkflowsEnabled ? () => setAutomationModalOpen(true) : null
+                    }
                     onStopRuntime={
                       isRuntimeRunning && onStopRuntime
                         ? () =>
@@ -996,6 +1009,16 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
                   />
                 </PopoverContent>
               </Popover>
+              {dynamicWorkflowsEnabled && automationModalOpen && (
+                <AutomationModal
+                  projectPath={projectPath}
+                  workspaceId={workspaceId}
+                  workspaceName={displayTitle}
+                  projectWorkflowSchedule={projectWorkflowSchedule}
+                  open={automationModalOpen}
+                  onOpenChange={setAutomationModalOpen}
+                />
+              )}
               {workspaceHeartbeatsEnabled && (
                 <WorkspaceHeartbeatModal
                   workspaceId={workspaceId}

--- a/src/browser/components/AgentListItem/AgentListItem.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.tsx
@@ -77,7 +77,7 @@ import { AutomationModal } from "../AutomationModal";
 import { WorkspaceActionsMenuContent } from "../WorkspaceActionsMenuContent/WorkspaceActionsMenuContent";
 import { useAPI } from "@/browser/contexts/API";
 import { useProjectContext } from "@/browser/contexts/ProjectContext";
-import { getExistingWorkspaceProjectWorkflowSchedule } from "@/browser/utils/projectWorkflowSchedules";
+import { getExistingWorkspaceProjectWorkflowScheduleMatch } from "@/browser/utils/projectWorkflowSchedules";
 
 export interface WorkspaceSelection {
   projectPath: string;
@@ -489,7 +489,7 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
       ? `${groupLabel} · ${workspaceTitle}`
       : workspaceTitle;
   const isEditing = editingWorkspaceId === workspaceId;
-  const { getProjectConfig } = useProjectContext();
+  const { getProjectConfig, userProjects } = useProjectContext();
   const metadataSubProjectConfig =
     metadata.subProjectPath != null ? getProjectConfig(metadata.subProjectPath) : undefined;
   const sectionProjectConfig = sectionId != null ? getProjectConfig(sectionId) : undefined;
@@ -499,10 +499,16 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
       : sectionId != null && sectionProjectConfig?.parentProjectPath != null
         ? sectionId
         : projectPath;
-  const projectWorkflowSchedule = getExistingWorkspaceProjectWorkflowSchedule({
-    projectConfig: getProjectConfig(automationProjectPath),
+  const projectConfig = getProjectConfig(automationProjectPath);
+  const projectWorkflowScheduleMatch = getExistingWorkspaceProjectWorkflowScheduleMatch({
+    projectPath: automationProjectPath,
+    projectConfig,
+    userProjects,
     workspaceId,
   });
+  const projectWorkflowSchedule = projectWorkflowScheduleMatch?.schedule;
+  const automationScheduleProjectPath =
+    projectWorkflowScheduleMatch?.projectPath ?? automationProjectPath;
 
   const linkSharingEnabled = useLinkSharingEnabled();
   const [shareTranscriptOpen, setShareTranscriptOpen] = useState(false);
@@ -1020,7 +1026,7 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
               </Popover>
               {dynamicWorkflowsEnabled && automationModalOpen && (
                 <AutomationModal
-                  projectPath={automationProjectPath}
+                  projectPath={automationScheduleProjectPath}
                   workspaceId={workspaceId}
                   workspaceName={displayTitle}
                   workspaceWorkflowSchedule={metadata.workflowSchedule}

--- a/src/browser/components/AgentListItem/AgentListItem.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.tsx
@@ -1023,6 +1023,7 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
                   projectPath={automationProjectPath}
                   workspaceId={workspaceId}
                   workspaceName={displayTitle}
+                  workspaceWorkflowSchedule={metadata.workflowSchedule}
                   projectWorkflowSchedule={projectWorkflowSchedule}
                   open={automationModalOpen}
                   onOpenChange={setAutomationModalOpen}

--- a/src/browser/components/AgentListItem/AgentListItem.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.tsx
@@ -490,8 +490,17 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
       : workspaceTitle;
   const isEditing = editingWorkspaceId === workspaceId;
   const { getProjectConfig } = useProjectContext();
+  const metadataSubProjectConfig =
+    metadata.subProjectPath != null ? getProjectConfig(metadata.subProjectPath) : undefined;
+  const sectionProjectConfig = sectionId != null ? getProjectConfig(sectionId) : undefined;
+  const automationProjectPath =
+    metadata.subProjectPath != null && metadataSubProjectConfig?.parentProjectPath != null
+      ? metadata.subProjectPath
+      : sectionId != null && sectionProjectConfig?.parentProjectPath != null
+        ? sectionId
+        : projectPath;
   const projectWorkflowSchedule = getExistingWorkspaceProjectWorkflowSchedule({
-    projectConfig: getProjectConfig(projectPath),
+    projectConfig: getProjectConfig(automationProjectPath),
     workspaceId,
   });
 
@@ -1011,7 +1020,7 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
               </Popover>
               {dynamicWorkflowsEnabled && automationModalOpen && (
                 <AutomationModal
-                  projectPath={projectPath}
+                  projectPath={automationProjectPath}
                   workspaceId={workspaceId}
                   workspaceName={displayTitle}
                   projectWorkflowSchedule={projectWorkflowSchedule}

--- a/src/browser/components/AutomationModal/AutomationModal.stories.tsx
+++ b/src/browser/components/AutomationModal/AutomationModal.stories.tsx
@@ -1,0 +1,143 @@
+import { useRef } from "react";
+import type { FC, ReactNode } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "@storybook/test";
+
+import { APIProvider, type APIClient } from "@/browser/contexts/API";
+import { ProjectProvider } from "@/browser/contexts/ProjectContext";
+import { StoryUiShell } from "@/browser/stories/meta";
+import type { ProjectWorkflowSchedule } from "@/common/types/project";
+import type { WorkflowDefinitionDescriptor } from "@/common/types/workflow";
+import { AutomationModal } from "./AutomationModal";
+
+const PROJECT_PATH = "/Users/test/mux";
+const WORKSPACE_ID = "triage-control";
+const WORKSPACE_NAME = "Triage control";
+
+const WORKFLOW_DEFINITIONS: WorkflowDefinitionDescriptor[] = [
+  {
+    name: "triage-github-issues",
+    description: "Scan untriaged GitHub issues and create triage workspaces.",
+    scope: "project",
+    sourcePath: `${PROJECT_PATH}/.mux/workflows/triage-github-issues.js`,
+    executable: true,
+  },
+  {
+    name: "daily-maintenance",
+    description: "Run daily repository maintenance checks.",
+    scope: "global",
+    sourcePath: "/Users/test/.mux/workflows/daily-maintenance.js",
+    executable: true,
+  },
+  {
+    name: "blocked-project-workflow",
+    description: "A trusted-project-only workflow that should not be selectable.",
+    scope: "project",
+    sourcePath: `${PROJECT_PATH}/.mux/workflows/blocked-project-workflow.js`,
+    executable: false,
+    blockedReason: "Trust this project before running project-local workflows.",
+  },
+];
+
+const WORKFLOW_SCHEDULE: ProjectWorkflowSchedule = {
+  id: "triage-control-schedule",
+  enabled: true,
+  workflowName: "triage-github-issues",
+  intervalMs: 30 * 60_000,
+  args: { label: "needs-triage" },
+  target: { type: "existing-workspace", workspaceId: WORKSPACE_ID },
+  lastRunStartedAt: "2026-06-13T08:00:00.000Z",
+};
+
+function createAutomationClient(): APIClient {
+  return {
+    workflows: {
+      listDefinitions: () => Promise.resolve(WORKFLOW_DEFINITIONS),
+    },
+    workspace: {
+      setWorkflowSchedule: () => Promise.resolve({ success: true as const, data: undefined }),
+    },
+    projects: {
+      list: () =>
+        Promise.resolve([
+          [
+            PROJECT_PATH,
+            {
+              workspaces: [{ id: WORKSPACE_ID, path: "/tmp/triage-control" }],
+              workflowSchedules: [WORKFLOW_SCHEDULE],
+            },
+          ],
+        ]),
+      workflowSchedules: {
+        set: () => Promise.resolve({ success: true as const, data: WORKFLOW_SCHEDULE }),
+        remove: () => Promise.resolve({ success: true as const, data: undefined }),
+      },
+    },
+  } as unknown as APIClient;
+}
+
+const AutomationStoryShell: FC<{ children: ReactNode }> = (props) => {
+  const clientRef = useRef<APIClient | null>(null);
+  clientRef.current ??= createAutomationClient();
+
+  return (
+    <StoryUiShell>
+      <APIProvider client={clientRef.current}>
+        <ProjectProvider>{props.children}</ProjectProvider>
+      </APIProvider>
+    </StoryUiShell>
+  );
+};
+
+function renderAutomationModal(): JSX.Element {
+  return (
+    <AutomationStoryShell>
+      <AutomationModal
+        open={true}
+        projectPath={PROJECT_PATH}
+        workspaceId={WORKSPACE_ID}
+        workspaceName={WORKSPACE_NAME}
+        projectWorkflowSchedule={WORKFLOW_SCHEDULE}
+        onOpenChange={() => {
+          // Keep the story stable while users interact with the form.
+        }}
+      />
+    </AutomationStoryShell>
+  );
+}
+
+const meta: Meta<typeof AutomationModal> = {
+  title: "Components/AutomationModal",
+  component: AutomationModal,
+  parameters: {
+    layout: "fullscreen",
+    chromatic: { delay: 500 },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: renderAutomationModal,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement.ownerDocument.body);
+    await expect(canvas.findByText("Automation for Triage control")).resolves.toBeInTheDocument();
+    await expect(canvas.findByLabelText("Automation workflow")).resolves.toBeInTheDocument();
+  },
+};
+
+export const Mobile: Story = {
+  render: renderAutomationModal,
+  globals: { viewport: { value: "mobile1", isRotated: false } },
+  parameters: {
+    // Pinned mobile mode so Chromatic snapshots the responsive modal controls at phone width.
+    chromatic: { modes: { "dark-mobile": { theme: "dark", viewport: "mobile1", hasTouch: true } } },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement.ownerDocument.body);
+    await expect(canvas.findByText("Automation for Triage control")).resolves.toBeInTheDocument();
+    await expect(canvas.findByLabelText("Automation args")).resolves.toBeInTheDocument();
+  },
+};

--- a/src/browser/components/AutomationModal/AutomationModal.test.tsx
+++ b/src/browser/components/AutomationModal/AutomationModal.test.tsx
@@ -1,0 +1,446 @@
+import "../../../../tests/ui/dom";
+
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { installDom } from "../../../../tests/ui/dom";
+import * as APIModule from "@/browser/contexts/API";
+import type { APIClient, UseAPIResult } from "@/browser/contexts/API";
+import * as ProjectContextModule from "@/browser/contexts/ProjectContext";
+import type { ProjectWorkflowSchedule } from "@/common/types/project";
+import type { WorkflowDefinitionDescriptor } from "@/common/types/workflow";
+
+void mock.module("@/browser/components/Dialog/Dialog", () => ({
+  Dialog: (props: { open: boolean; children: ReactNode }) =>
+    props.open ? <div>{props.children}</div> : null,
+  DialogContent: (props: { children: ReactNode; className?: string }) => (
+    <div className={props.className}>{props.children}</div>
+  ),
+  DialogHeader: (props: { children: ReactNode }) => <div>{props.children}</div>,
+  DialogTitle: (props: { children: ReactNode; className?: string }) => (
+    <h2 className={props.className}>{props.children}</h2>
+  ),
+}));
+
+import { AutomationModal } from "./AutomationModal";
+
+type ConnectedUseAPIResult = Extract<UseAPIResult, { status: "connected" }>;
+type ErrorUseAPIResult = Extract<UseAPIResult, { status: "error" }>;
+
+interface AutomationTestAPI {
+  workflows: {
+    listDefinitions: (input: {
+      workspaceId?: string;
+      projectPath?: string;
+    }) => Promise<WorkflowDefinitionDescriptor[]>;
+  };
+  projects: {
+    workflowSchedules: {
+      set: (input: {
+        projectPath: string;
+        schedule: Omit<ProjectWorkflowSchedule, "id" | "lastRunStartedAt"> & { id?: string };
+      }) => Promise<
+        { success: true; data: ProjectWorkflowSchedule } | { success: false; error: string }
+      >;
+      remove: (input: {
+        projectPath: string;
+        scheduleId: string;
+      }) => Promise<{ success: true; data: void } | { success: false; error: string }>;
+    };
+  };
+}
+
+let cleanupDom: (() => void) | null = null;
+let listDefinitionsMock: ReturnType<typeof mock>;
+let setProjectWorkflowScheduleMock: ReturnType<typeof mock>;
+let removeProjectWorkflowScheduleMock: ReturnType<typeof mock>;
+let refreshProjectsMock: ReturnType<typeof mock>;
+
+function createConnectedUseAPIResult(api: AutomationTestAPI): ConnectedUseAPIResult {
+  return {
+    api: api as unknown as APIClient,
+    status: "connected",
+    error: null,
+    authenticate: () => undefined,
+    retry: () => undefined,
+  };
+}
+
+function createErrorUseAPIResult(): ErrorUseAPIResult {
+  return {
+    api: null,
+    status: "error",
+    error: "API unavailable",
+    authenticate: () => undefined,
+    retry: () => undefined,
+  };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+function changeTextField(element: Element, value: string): void {
+  const formElement = element as HTMLInputElement | HTMLTextAreaElement;
+  const valueDescriptor = Object.getOwnPropertyDescriptor(
+    Object.getPrototypeOf(formElement),
+    "value"
+  );
+  act(() => {
+    if (valueDescriptor?.set != null) {
+      valueDescriptor.set.call(formElement, value);
+    }
+    const trackedElement = formElement as unknown as {
+      _valueTracker?: { setValue: (trackedValue: string) => void };
+    };
+    trackedElement._valueTracker?.setValue("");
+    fireEvent.input(formElement, { target: { value } });
+    fireEvent.change(formElement, { target: { value } });
+  });
+}
+
+function createWorkflowDefinition(
+  overrides: Partial<WorkflowDefinitionDescriptor> = {}
+): WorkflowDefinitionDescriptor {
+  return {
+    name: "triage-issues",
+    description: "Scan GitHub issues and create triage workspaces.",
+    scope: "project",
+    executable: true,
+    sourcePath: "/repo/.mux/workflows/triage-issues.js",
+    ...overrides,
+  };
+}
+
+function createProjectWorkflowSchedule(
+  overrides: Partial<ProjectWorkflowSchedule> = {}
+): ProjectWorkflowSchedule {
+  return {
+    id: "automation-1",
+    enabled: true,
+    workflowName: "triage-issues",
+    intervalMs: 15 * 60_000,
+    target: { type: "existing-workspace", workspaceId: "ws-1" },
+    ...overrides,
+  };
+}
+
+function renderAutomationModal(
+  overrides: Partial<React.ComponentProps<typeof AutomationModal>> = {}
+) {
+  return render(
+    <AutomationModal
+      open={true}
+      projectPath="/repo"
+      workspaceId="ws-1"
+      workspaceName="Triage control"
+      onOpenChange={() => undefined}
+      {...overrides}
+    />
+  );
+}
+
+describe("AutomationModal", () => {
+  beforeEach(() => {
+    cleanupDom = installDom();
+    listDefinitionsMock = mock(() => Promise.resolve([createWorkflowDefinition()]));
+    setProjectWorkflowScheduleMock = mock(() =>
+      Promise.resolve({ success: true as const, data: createProjectWorkflowSchedule() })
+    );
+    removeProjectWorkflowScheduleMock = mock(() =>
+      Promise.resolve({ success: true as const, data: undefined })
+    );
+    refreshProjectsMock = mock(() => Promise.resolve());
+    const api: AutomationTestAPI = {
+      workflows: {
+        listDefinitions: listDefinitionsMock as AutomationTestAPI["workflows"]["listDefinitions"],
+      },
+      projects: {
+        workflowSchedules: {
+          set: setProjectWorkflowScheduleMock as AutomationTestAPI["projects"]["workflowSchedules"]["set"],
+          remove:
+            removeProjectWorkflowScheduleMock as AutomationTestAPI["projects"]["workflowSchedules"]["remove"],
+        },
+      },
+    };
+    spyOn(APIModule, "useAPI").mockImplementation(() => createConnectedUseAPIResult(api));
+    spyOn(ProjectContextModule, "useProjectContext").mockImplementation(
+      () =>
+        ({
+          getProjectConfig: () => undefined,
+          refreshProjects: refreshProjectsMock,
+        }) as unknown as ReturnType<typeof ProjectContextModule.useProjectContext>
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    mock.restore();
+    cleanupDom?.();
+    cleanupDom = null;
+  });
+
+  test("preserves edits made before workflow definitions finish loading", async () => {
+    const definitions = createDeferred<WorkflowDefinitionDescriptor[]>();
+    listDefinitionsMock = mock(() => definitions.promise);
+    const view = renderAutomationModal();
+
+    fireEvent.click(view.getByRole("switch", { name: "Enable automation" }));
+    changeTextField(view.getByLabelText("Automation interval in minutes"), "45");
+    changeTextField(view.getByLabelText("Automation args"), '{"label":"triage"}');
+
+    await act(async () => {
+      definitions.resolve([createWorkflowDefinition()]);
+      await definitions.promise;
+    });
+
+    await waitFor(() => {
+      expect((view.getByLabelText("Automation workflow") as HTMLSelectElement).value).toBe(
+        "triage-issues"
+      );
+    });
+    expect((view.getByLabelText("Automation interval in minutes") as HTMLInputElement).value).toBe(
+      "45"
+    );
+    expect((view.getByLabelText("Automation args") as HTMLTextAreaElement).value).toBe(
+      '{"label":"triage"}'
+    );
+  });
+
+  test("shows a loading option while workflow definitions are pending", () => {
+    listDefinitionsMock = mock(() => new Promise<WorkflowDefinitionDescriptor[]>(() => undefined));
+    const view = renderAutomationModal();
+
+    expect(view.getByRole("option", { name: "Loading workflows…" })).toBeTruthy();
+    expect(view.queryByText("No executable workflows found")).toBeNull();
+  });
+
+  test("loads workflow definitions by project path for sub-project schedules", async () => {
+    spyOn(ProjectContextModule, "useProjectContext").mockImplementation(
+      () =>
+        ({
+          getProjectConfig: () => ({ parentProjectPath: "/repo", workspaces: [] }),
+          refreshProjects: refreshProjectsMock,
+        }) as unknown as ReturnType<typeof ProjectContextModule.useProjectContext>
+    );
+    renderAutomationModal({ projectPath: "/repo/packages/api" });
+
+    await waitFor(() => {
+      expect(listDefinitionsMock).toHaveBeenCalledWith({ projectPath: "/repo/packages/api" });
+    });
+  });
+
+  test("saves an enabled project workflow schedule for this workspace", async () => {
+    const onOpenChange = mock((_open: boolean) => undefined);
+    const view = renderAutomationModal({ onOpenChange });
+
+    await waitFor(() => {
+      expect((view.getByLabelText("Automation workflow") as HTMLSelectElement).value).toBe(
+        "triage-issues"
+      );
+    });
+
+    fireEvent.click(view.getByRole("switch", { name: "Enable automation" }));
+    changeTextField(view.getByLabelText("Automation interval in minutes"), "30");
+    changeTextField(view.getByLabelText("Automation args"), '{"label":"needs-triage"}');
+    fireEvent.click(view.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(setProjectWorkflowScheduleMock).toHaveBeenCalledWith({
+        projectPath: "/repo",
+        schedule: {
+          enabled: true,
+          workflowName: "triage-issues",
+          intervalMs: 30 * 60_000,
+          args: { label: "needs-triage" },
+          target: { type: "existing-workspace", workspaceId: "ws-1" },
+        },
+      });
+    });
+    expect(refreshProjectsMock).toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  test("saves context mode for the workspace target", async () => {
+    const view = renderAutomationModal();
+
+    await waitFor(() => {
+      expect((view.getByLabelText("Automation workflow") as HTMLSelectElement).value).toBe(
+        "triage-issues"
+      );
+    });
+
+    fireEvent.change(view.getByLabelText("Automation context mode"), {
+      target: { value: "compact" },
+    });
+    fireEvent.click(view.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(setProjectWorkflowScheduleMock).toHaveBeenCalledWith({
+        projectPath: "/repo",
+        schedule: {
+          enabled: false,
+          workflowName: "triage-issues",
+          intervalMs: 15 * 60_000,
+          contextMode: "compact",
+          target: { type: "existing-workspace", workspaceId: "ws-1" },
+        },
+      });
+    });
+    expect(view.queryByLabelText("Automation run target")).toBeNull();
+  });
+
+  test("loads and updates the project automation targeting this workspace", async () => {
+    listDefinitionsMock.mockImplementation(() =>
+      Promise.resolve([
+        createWorkflowDefinition(),
+        createWorkflowDefinition({
+          name: "daily-maintenance",
+          description: "Run maintenance checks.",
+        }),
+      ])
+    );
+    const view = renderAutomationModal({
+      projectWorkflowSchedule: createProjectWorkflowSchedule({
+        id: "workspace-schedule",
+        title: "Named automation",
+        enabled: true,
+        workflowName: "daily-maintenance",
+        intervalMs: 60 * 60_000,
+        args: { cadence: "hourly" },
+      }),
+    });
+
+    await waitFor(() => {
+      expect((view.getByLabelText("Automation workflow") as HTMLSelectElement).value).toBe(
+        "daily-maintenance"
+      );
+    });
+    expect((view.getByLabelText("Automation interval in minutes") as HTMLInputElement).value).toBe(
+      "60"
+    );
+    expect((view.getByLabelText("Automation args") as HTMLTextAreaElement).value).toBe(
+      JSON.stringify({ cadence: "hourly" }, null, 2)
+    );
+
+    fireEvent.click(view.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(setProjectWorkflowScheduleMock).toHaveBeenCalledWith({
+        projectPath: "/repo",
+        schedule: {
+          id: "workspace-schedule",
+          title: "Named automation",
+          enabled: true,
+          workflowName: "daily-maintenance",
+          intervalMs: 60 * 60_000,
+          args: { cadence: "hourly" },
+          target: { type: "existing-workspace", workspaceId: "ws-1" },
+        },
+      });
+    });
+  });
+
+  test("shows persisted non-executable workflow selections", async () => {
+    listDefinitionsMock.mockImplementation(() =>
+      Promise.resolve([
+        createWorkflowDefinition({
+          name: "blocked-workflow",
+          executable: false,
+          blockedReason: "project is untrusted",
+        }),
+        createWorkflowDefinition(),
+      ])
+    );
+    const view = renderAutomationModal({
+      projectWorkflowSchedule: createProjectWorkflowSchedule({
+        enabled: true,
+        workflowName: "blocked-workflow",
+        intervalMs: 15 * 60_000,
+      }),
+    });
+
+    await waitFor(() => {
+      expect(
+        view.getByRole("option", { name: "blocked-workflow (project is untrusted)" })
+      ).toBeTruthy();
+    });
+    expect((view.getByLabelText("Automation workflow") as HTMLSelectElement).value).toBe(
+      "blocked-workflow"
+    );
+    expect((view.getByRole("button", { name: "Save" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test("blocks saving when args are not a JSON object", async () => {
+    const view = renderAutomationModal();
+
+    await waitFor(() => {
+      expect((view.getByLabelText("Automation workflow") as HTMLSelectElement).value).toBe(
+        "triage-issues"
+      );
+    });
+
+    changeTextField(view.getByLabelText("Automation args"), "[]");
+
+    expect(view.getByText("Workflow args must be a JSON object.")).toBeTruthy();
+    expect((view.getByRole("button", { name: "Save" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test("removes the project automation targeting this workspace", async () => {
+    const view = renderAutomationModal({
+      projectWorkflowSchedule: createProjectWorkflowSchedule({ id: "workspace-schedule" }),
+    });
+
+    fireEvent.click(view.getByRole("button", { name: "Remove automation" }));
+
+    await waitFor(() => {
+      expect(removeProjectWorkflowScheduleMock).toHaveBeenCalledWith({
+        projectPath: "/repo",
+        scheduleId: "workspace-schedule",
+      });
+    });
+    expect(refreshProjectsMock).toHaveBeenCalled();
+  });
+
+  test("disables remove when the API client is unavailable", () => {
+    spyOn(APIModule, "useAPI").mockImplementation(() => createErrorUseAPIResult());
+    const view = renderAutomationModal({
+      projectWorkflowSchedule: createProjectWorkflowSchedule({
+        enabled: false,
+        workflowName: "triage-issues",
+        intervalMs: 15 * 60_000,
+      }),
+    });
+
+    expect(
+      (view.getByRole("button", { name: "Remove automation" }) as HTMLButtonElement).disabled
+    ).toBe(true);
+  });
+
+  test("announces and associates interval and args validation errors", async () => {
+    const view = renderAutomationModal();
+
+    await waitFor(() => {
+      expect((view.getByLabelText("Automation workflow") as HTMLSelectElement).value).toBe(
+        "triage-issues"
+      );
+    });
+
+    const intervalInput = view.getByLabelText("Automation interval in minutes") as HTMLInputElement;
+    const argsInput = view.getByLabelText("Automation args") as HTMLTextAreaElement;
+    changeTextField(intervalInput, "0");
+    changeTextField(argsInput, "[]");
+
+    const alert = view.getByRole("alert");
+    expect(alert.textContent).toContain("Schedule interval must be between 1 and 1440 minutes.");
+    expect(alert.textContent).toContain("Workflow args must be a JSON object.");
+    expect(intervalInput.getAttribute("aria-invalid")).toBe("true");
+    expect(intervalInput.getAttribute("aria-describedby")).toContain("automation-interval-error");
+    expect(argsInput.getAttribute("aria-invalid")).toBe("true");
+    expect(argsInput.getAttribute("aria-describedby")).toContain("automation-args-error");
+  });
+});

--- a/src/browser/components/AutomationModal/AutomationModal.test.tsx
+++ b/src/browser/components/AutomationModal/AutomationModal.test.tsx
@@ -230,7 +230,10 @@ describe("AutomationModal", () => {
     renderAutomationModal({ projectPath: "/repo/packages/api" });
 
     await waitFor(() => {
-      expect(listDefinitionsMock).toHaveBeenCalledWith({ projectPath: "/repo/packages/api" });
+      expect(listDefinitionsMock).toHaveBeenCalledWith({
+        workspaceId: "ws-1",
+        projectPath: "/repo/packages/api",
+      });
     });
   });
 

--- a/src/browser/components/AutomationModal/AutomationModal.test.tsx
+++ b/src/browser/components/AutomationModal/AutomationModal.test.tsx
@@ -8,6 +8,7 @@ import * as APIModule from "@/browser/contexts/API";
 import type { APIClient, UseAPIResult } from "@/browser/contexts/API";
 import * as ProjectContextModule from "@/browser/contexts/ProjectContext";
 import type { ProjectWorkflowSchedule } from "@/common/types/project";
+import type { WorkspaceWorkflowSchedule } from "@/common/types/workspace";
 import type { WorkflowDefinitionDescriptor } from "@/common/types/workflow";
 
 void mock.module("@/browser/components/Dialog/Dialog", () => ({
@@ -34,6 +35,12 @@ interface AutomationTestAPI {
       projectPath?: string;
     }) => Promise<WorkflowDefinitionDescriptor[]>;
   };
+  workspace: {
+    setWorkflowSchedule: (input: {
+      workspaceId: string;
+      schedule: Omit<WorkspaceWorkflowSchedule, "lastRunStartedAt"> | null;
+    }) => Promise<{ success: true; data: void } | { success: false; error: string }>;
+  };
   projects: {
     workflowSchedules: {
       set: (input: {
@@ -54,6 +61,7 @@ let cleanupDom: (() => void) | null = null;
 let listDefinitionsMock: ReturnType<typeof mock>;
 let setProjectWorkflowScheduleMock: ReturnType<typeof mock>;
 let removeProjectWorkflowScheduleMock: ReturnType<typeof mock>;
+let setWorkspaceWorkflowScheduleMock: ReturnType<typeof mock>;
 let refreshProjectsMock: ReturnType<typeof mock>;
 
 function createConnectedUseAPIResult(api: AutomationTestAPI): ConnectedUseAPIResult {
@@ -129,6 +137,17 @@ function createProjectWorkflowSchedule(
   };
 }
 
+function createWorkspaceWorkflowSchedule(
+  overrides: Partial<WorkspaceWorkflowSchedule> = {}
+): WorkspaceWorkflowSchedule {
+  return {
+    enabled: true,
+    workflowName: "triage-issues",
+    intervalMs: 15 * 60_000,
+    ...overrides,
+  };
+}
+
 function renderAutomationModal(
   overrides: Partial<React.ComponentProps<typeof AutomationModal>> = {}
 ) {
@@ -154,10 +173,17 @@ describe("AutomationModal", () => {
     removeProjectWorkflowScheduleMock = mock(() =>
       Promise.resolve({ success: true as const, data: undefined })
     );
+    setWorkspaceWorkflowScheduleMock = mock(() =>
+      Promise.resolve({ success: true as const, data: undefined })
+    );
     refreshProjectsMock = mock(() => Promise.resolve());
     const api: AutomationTestAPI = {
       workflows: {
         listDefinitions: listDefinitionsMock as AutomationTestAPI["workflows"]["listDefinitions"],
+      },
+      workspace: {
+        setWorkflowSchedule:
+          setWorkspaceWorkflowScheduleMock as AutomationTestAPI["workspace"]["setWorkflowSchedule"],
       },
       projects: {
         workflowSchedules: {
@@ -346,6 +372,63 @@ describe("AutomationModal", () => {
         },
       });
     });
+  });
+
+  test("loads and updates a legacy workspace automation", async () => {
+    const view = renderAutomationModal({
+      workspaceWorkflowSchedule: createWorkspaceWorkflowSchedule({
+        enabled: true,
+        intervalMs: 45 * 60_000,
+        args: { label: "legacy" },
+      }),
+    });
+
+    await waitFor(() => {
+      expect((view.getByLabelText("Automation workflow") as HTMLSelectElement).value).toBe(
+        "triage-issues"
+      );
+    });
+    expect((view.getByLabelText("Automation interval in minutes") as HTMLInputElement).value).toBe(
+      "45"
+    );
+    expect((view.getByLabelText("Automation args") as HTMLTextAreaElement).value).toBe(
+      JSON.stringify({ label: "legacy" }, null, 2)
+    );
+
+    fireEvent.change(view.getByLabelText("Automation context mode"), {
+      target: { value: "compact" },
+    });
+    fireEvent.click(view.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(setWorkspaceWorkflowScheduleMock).toHaveBeenCalledWith({
+        workspaceId: "ws-1",
+        schedule: {
+          enabled: true,
+          workflowName: "triage-issues",
+          args: { label: "legacy" },
+          intervalMs: 45 * 60_000,
+          contextMode: "compact",
+        },
+      });
+    });
+    expect(setProjectWorkflowScheduleMock).not.toHaveBeenCalled();
+  });
+
+  test("removes a legacy workspace automation", async () => {
+    const view = renderAutomationModal({
+      workspaceWorkflowSchedule: createWorkspaceWorkflowSchedule(),
+    });
+
+    fireEvent.click(view.getByRole("button", { name: "Remove automation" }));
+
+    await waitFor(() => {
+      expect(setWorkspaceWorkflowScheduleMock).toHaveBeenCalledWith({
+        workspaceId: "ws-1",
+        schedule: null,
+      });
+    });
+    expect(removeProjectWorkflowScheduleMock).not.toHaveBeenCalled();
   });
 
   test("shows persisted non-executable workflow selections", async () => {

--- a/src/browser/components/AutomationModal/AutomationModal.tsx
+++ b/src/browser/components/AutomationModal/AutomationModal.tsx
@@ -12,6 +12,7 @@ import { Switch } from "@/browser/components/Switch/Switch";
 import { useAPI } from "@/browser/contexts/API";
 import { useProjectContext } from "@/browser/contexts/ProjectContext";
 import type { ProjectWorkflowSchedule } from "@/common/types/project";
+import type { WorkspaceWorkflowSchedule } from "@/common/types/workspace";
 import type { WorkflowDefinitionDescriptor } from "@/common/types/workflow";
 import { getErrorMessage } from "@/common/utils/errors";
 import assert from "@/common/utils/assert";
@@ -39,6 +40,7 @@ interface AutomationModalProps {
   workspaceId: string;
   workspaceName: string;
   projectWorkflowSchedule?: ProjectWorkflowSchedule;
+  workspaceWorkflowSchedule?: WorkspaceWorkflowSchedule;
   onOpenChange: (open: boolean) => void;
 }
 
@@ -60,20 +62,28 @@ function formatLastRunStartedAt(value: string | undefined): string | null {
   return date.toLocaleString();
 }
 
-type AutomationDraft = Pick<
-  ProjectWorkflowSchedule,
-  "enabled" | "workflowName" | "intervalMs" | "args" | "contextMode" | "lastRunStartedAt"
->;
+interface AutomationDraft {
+  enabled: boolean;
+  workflowName: string;
+  intervalMs: number;
+  args?: ProjectWorkflowSchedule["args"];
+  contextMode?: WorkflowScheduleContextMode;
+  lastRunStartedAt?: string;
+}
 
 export function AutomationModal(props: AutomationModalProps) {
   const { api } = useAPI();
   const { getProjectConfig, refreshProjects } = useProjectContext();
-  const workflowSchedule: AutomationDraft | undefined = props.projectWorkflowSchedule;
+  const workflowSchedule: AutomationDraft | undefined =
+    props.projectWorkflowSchedule ?? props.workspaceWorkflowSchedule;
+  const isLegacyWorkspaceSchedule =
+    props.projectWorkflowSchedule == null && props.workspaceWorkflowSchedule != null;
   const projectConfig = getProjectConfig(props.projectPath);
   const shouldLoadDefinitionsByProject = projectConfig?.parentProjectPath != null;
   const initializationKey = JSON.stringify({
     projectPath: props.projectPath,
     workspaceId: props.workspaceId,
+    scheduleKind: isLegacyWorkspaceSchedule ? "workspace" : "project",
     projectScheduleId: props.projectWorkflowSchedule?.id ?? "",
     enabled: workflowSchedule?.enabled ?? false,
     workflowName: workflowSchedule?.workflowName ?? "",
@@ -285,23 +295,41 @@ export function AutomationModal(props: AutomationModalProps) {
     }
 
     try {
-      const result = await api.projects.workflowSchedules.set({
-        projectPath: props.projectPath,
-        schedule: {
-          ...(props.projectWorkflowSchedule != null
-            ? {
-                id: props.projectWorkflowSchedule.id,
-                ...(props.projectWorkflowSchedule.title != null
-                  ? { title: props.projectWorkflowSchedule.title }
-                  : {}),
-              }
-            : {}),
-          ...nextSchedule,
-        },
-      });
-      if (!result.success) {
-        setSaveError(result.error ?? "Failed to save automation.");
-        return false;
+      if (isLegacyWorkspaceSchedule) {
+        const workspaceSchedule: Omit<WorkspaceWorkflowSchedule, "lastRunStartedAt"> = {
+          enabled: nextSchedule.enabled,
+          workflowName: nextSchedule.workflowName,
+          ...(nextSchedule.args != null ? { args: nextSchedule.args } : {}),
+          intervalMs: nextSchedule.intervalMs,
+          ...(nextSchedule.contextMode != null ? { contextMode: nextSchedule.contextMode } : {}),
+        };
+        const result = await api.workspace.setWorkflowSchedule({
+          workspaceId: props.workspaceId,
+          schedule: workspaceSchedule,
+        });
+        if (!result.success) {
+          setSaveError(result.error ?? "Failed to save automation.");
+          return false;
+        }
+      } else {
+        const result = await api.projects.workflowSchedules.set({
+          projectPath: props.projectPath,
+          schedule: {
+            ...(props.projectWorkflowSchedule != null
+              ? {
+                  id: props.projectWorkflowSchedule.id,
+                  ...(props.projectWorkflowSchedule.title != null
+                    ? { title: props.projectWorkflowSchedule.title }
+                    : {}),
+                }
+              : {}),
+            ...nextSchedule,
+          },
+        });
+        if (!result.success) {
+          setSaveError(result.error ?? "Failed to save automation.");
+          return false;
+        }
       }
 
       await refreshProjects();
@@ -358,6 +386,14 @@ export function AutomationModal(props: AutomationModalProps) {
         const result = await api.projects.workflowSchedules.remove({
           projectPath: props.projectPath,
           scheduleId: props.projectWorkflowSchedule.id,
+        });
+        if (!result.success) {
+          throw new Error(result.error ?? "Failed to remove automation.");
+        }
+      } else if (isLegacyWorkspaceSchedule) {
+        const result = await api.workspace.setWorkflowSchedule({
+          workspaceId: props.workspaceId,
+          schedule: null,
         });
         if (!result.success) {
           throw new Error(result.error ?? "Failed to remove automation.");

--- a/src/browser/components/AutomationModal/AutomationModal.tsx
+++ b/src/browser/components/AutomationModal/AutomationModal.tsx
@@ -1,0 +1,595 @@
+import React, { useEffect, useRef, useState } from "react";
+import { CalendarClock, Loader2 } from "lucide-react";
+import { Button } from "@/browser/components/Button/Button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/browser/components/Dialog/Dialog";
+import { Input } from "@/browser/components/Input/Input";
+import { Switch } from "@/browser/components/Switch/Switch";
+import { useAPI } from "@/browser/contexts/API";
+import { useProjectContext } from "@/browser/contexts/ProjectContext";
+import type { ProjectWorkflowSchedule } from "@/common/types/project";
+import type { WorkflowDefinitionDescriptor } from "@/common/types/workflow";
+import { getErrorMessage } from "@/common/utils/errors";
+import assert from "@/common/utils/assert";
+import {
+  WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE,
+  WORKFLOW_SCHEDULE_DEFAULT_INTERVAL_MS,
+  type WorkflowScheduleContextMode,
+} from "@/constants/workflowSchedule";
+import {
+  clampWorkflowScheduleIntervalMinutes,
+  formatWorkflowArgs,
+  formatWorkflowScheduleIntervalMinutes,
+  getWorkflowScheduleIntervalValidationError,
+  parseWorkflowArgs,
+  parseWorkflowScheduleIntervalMinutes,
+  WORKFLOW_SCHEDULE_DEFAULT_INTERVAL_MINUTES,
+  WORKFLOW_SCHEDULE_MAX_INTERVAL_MINUTES,
+  WORKFLOW_SCHEDULE_MIN_INTERVAL_MINUTES,
+  workflowScheduleIntervalMinutesToMs,
+} from "@/browser/utils/workflowScheduleIntervalMinutes";
+
+interface AutomationModalProps {
+  open: boolean;
+  projectPath: string;
+  workspaceId: string;
+  workspaceName: string;
+  projectWorkflowSchedule?: ProjectWorkflowSchedule;
+  onOpenChange: (open: boolean) => void;
+}
+
+function getWorkspaceLabel(workspaceName: string): string {
+  const trimmedName = workspaceName.trim();
+  return trimmedName.length > 0 ? trimmedName : "this workspace";
+}
+
+function formatLastRunStartedAt(value: string | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date.toLocaleString();
+}
+
+type AutomationDraft = Pick<
+  ProjectWorkflowSchedule,
+  "enabled" | "workflowName" | "intervalMs" | "args" | "contextMode" | "lastRunStartedAt"
+>;
+
+export function AutomationModal(props: AutomationModalProps) {
+  const { api } = useAPI();
+  const { getProjectConfig, refreshProjects } = useProjectContext();
+  const workflowSchedule: AutomationDraft | undefined = props.projectWorkflowSchedule;
+  const projectConfig = getProjectConfig(props.projectPath);
+  const shouldLoadDefinitionsByProject = projectConfig?.parentProjectPath != null;
+  const initializationKey = JSON.stringify({
+    projectPath: props.projectPath,
+    workspaceId: props.workspaceId,
+    projectScheduleId: props.projectWorkflowSchedule?.id ?? "",
+    enabled: workflowSchedule?.enabled ?? false,
+    workflowName: workflowSchedule?.workflowName ?? "",
+    intervalMs: workflowSchedule?.intervalMs ?? WORKFLOW_SCHEDULE_DEFAULT_INTERVAL_MS,
+    args: workflowSchedule?.args ?? null,
+    contextMode: workflowSchedule?.contextMode ?? WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE,
+  });
+  const [workflowDefinitions, setWorkflowDefinitions] = useState<WorkflowDefinitionDescriptor[]>(
+    []
+  );
+  const [definitionsLoading, setDefinitionsLoading] = useState(false);
+  const [definitionsError, setDefinitionsError] = useState<string | null>(null);
+  const [draftEnabled, setDraftEnabled] = useState(() => workflowSchedule?.enabled ?? false);
+  const [draftWorkflowName, setDraftWorkflowName] = useState(
+    () => workflowSchedule?.workflowName ?? ""
+  );
+  const [draftIntervalMinutes, setDraftIntervalMinutes] = useState(() =>
+    formatWorkflowScheduleIntervalMinutes(
+      workflowSchedule?.intervalMs ?? WORKFLOW_SCHEDULE_DEFAULT_INTERVAL_MS
+    )
+  );
+  const [draftArgs, setDraftArgs] = useState(() => formatWorkflowArgs(workflowSchedule?.args));
+  const [draftContextMode, setDraftContextMode] = useState<WorkflowScheduleContextMode>(
+    () => workflowSchedule?.contextMode ?? WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE
+  );
+  const [workflowNameTouched, setWorkflowNameTouched] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [definitionsLoaded, setDefinitionsLoaded] = useState(false);
+  const lastInitializedKeyRef = useRef<string | null>(props.open ? initializationKey : null);
+
+  const executableWorkflowDefinitions = workflowDefinitions.filter(
+    (workflow) => workflow.executable
+  );
+  const firstExecutableWorkflowName = executableWorkflowDefinitions[0]?.name ?? "";
+  const selectedWorkflowDefinition = workflowDefinitions.find(
+    (workflow) => workflow.name === draftWorkflowName
+  );
+  const selectedWorkflowExecutable = selectedWorkflowDefinition?.executable === true;
+  const selectedWorkflowMissing =
+    draftWorkflowName.length > 0 && selectedWorkflowDefinition == null;
+  const selectedWorkflowNonExecutable =
+    draftWorkflowName.length > 0 &&
+    selectedWorkflowDefinition != null &&
+    !selectedWorkflowExecutable;
+  const definitionsPending =
+    definitionsLoading ||
+    (props.open && api != null && props.workspaceId.length > 0 && !definitionsLoaded);
+  const argsParseResult = parseWorkflowArgs(draftArgs);
+  const intervalValidationError = getWorkflowScheduleIntervalValidationError(draftIntervalMinutes);
+  const intervalHelpId = "automation-interval-help";
+  const intervalErrorId = "automation-interval-error";
+  const argsHelpId = "automation-args-help";
+  const argsErrorId = "automation-args-error";
+  const intervalDescriptionIds = [intervalHelpId, intervalValidationError ? intervalErrorId : null]
+    .filter((id): id is string => id != null)
+    .join(" ");
+  const argsDescriptionIds = [argsHelpId, argsParseResult.error ? argsErrorId : null]
+    .filter((id): id is string => id != null)
+    .join(" ");
+  const workflowValidationError = definitionsPending
+    ? null
+    : draftWorkflowName.length === 0
+      ? "Choose a workflow before saving."
+      : draftEnabled && !selectedWorkflowExecutable
+        ? "Choose an executable workflow before enabling the automation."
+        : null;
+  const errorMessages = [
+    definitionsError,
+    saveError,
+    intervalValidationError,
+    argsParseResult.error,
+    workflowValidationError,
+  ].filter((message): message is string => message != null);
+  const hasSchedule = workflowSchedule != null;
+  const workspaceLabel = getWorkspaceLabel(props.workspaceName);
+  const lastRunStartedAt = formatLastRunStartedAt(workflowSchedule?.lastRunStartedAt);
+  const hasBlockingError =
+    isSaving ||
+    api == null ||
+    definitionsPending ||
+    intervalValidationError != null ||
+    argsParseResult.error != null ||
+    workflowValidationError != null;
+
+  useEffect(() => {
+    if (!props.open) {
+      lastInitializedKeyRef.current = null;
+      return;
+    }
+
+    if (lastInitializedKeyRef.current === initializationKey) {
+      return;
+    }
+
+    lastInitializedKeyRef.current = initializationKey;
+    setDraftEnabled(workflowSchedule?.enabled ?? false);
+    setDraftWorkflowName(workflowSchedule?.workflowName ?? "");
+    setDraftIntervalMinutes(
+      formatWorkflowScheduleIntervalMinutes(
+        workflowSchedule?.intervalMs ?? WORKFLOW_SCHEDULE_DEFAULT_INTERVAL_MS
+      )
+    );
+    setDraftArgs(formatWorkflowArgs(workflowSchedule?.args));
+    setDraftContextMode(workflowSchedule?.contextMode ?? WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE);
+    setWorkflowNameTouched(false);
+    setSaveError(null);
+  }, [initializationKey, props.open, props.workspaceId, workflowSchedule]);
+
+  useEffect(() => {
+    if (
+      !props.open ||
+      workflowNameTouched ||
+      draftWorkflowName.length > 0 ||
+      workflowSchedule?.workflowName
+    ) {
+      return;
+    }
+
+    if (firstExecutableWorkflowName.length > 0) {
+      setDraftWorkflowName(firstExecutableWorkflowName);
+    }
+  }, [
+    draftWorkflowName,
+    firstExecutableWorkflowName,
+    props.open,
+    workflowSchedule?.workflowName,
+    workflowNameTouched,
+  ]);
+
+  useEffect(() => {
+    if (
+      !props.open ||
+      !api ||
+      (shouldLoadDefinitionsByProject
+        ? props.projectPath.length === 0
+        : props.workspaceId.length === 0)
+    ) {
+      setWorkflowDefinitions([]);
+      setDefinitionsLoading(false);
+      setDefinitionsLoaded(false);
+      setDefinitionsError(null);
+      return;
+    }
+
+    let ignore = false;
+    setDefinitionsLoading(true);
+    setDefinitionsLoaded(false);
+    setDefinitionsError(null);
+
+    void (async () => {
+      try {
+        const definitions = await api.workflows.listDefinitions(
+          shouldLoadDefinitionsByProject
+            ? { projectPath: props.projectPath }
+            : { workspaceId: props.workspaceId }
+        );
+        if (ignore) {
+          return;
+        }
+        setWorkflowDefinitions(Array.isArray(definitions) ? definitions : []);
+        setDefinitionsLoaded(true);
+      } catch (error) {
+        if (ignore) {
+          return;
+        }
+        setWorkflowDefinitions([]);
+        setDefinitionsLoaded(true);
+        setDefinitionsError(getErrorMessage(error) || "Failed to load workflow definitions.");
+      } finally {
+        if (!ignore) {
+          setDefinitionsLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      ignore = true;
+    };
+  }, [api, props.open, props.projectPath, props.workspaceId, shouldLoadDefinitionsByProject]);
+
+  const handleIntervalBlur = () => {
+    const parsedMinutes = parseWorkflowScheduleIntervalMinutes(draftIntervalMinutes);
+    if (parsedMinutes == null) {
+      return;
+    }
+
+    const clampedMinutes = clampWorkflowScheduleIntervalMinutes(parsedMinutes);
+    const clampedMinutesValue = String(clampedMinutes);
+    if (clampedMinutesValue !== draftIntervalMinutes) {
+      setDraftIntervalMinutes(clampedMinutesValue);
+    }
+  };
+
+  const saveSchedule = async (
+    nextSchedule: Omit<ProjectWorkflowSchedule, "id" | "lastRunStartedAt">
+  ): Promise<boolean> => {
+    setIsSaving(true);
+    setSaveError(null);
+    if (api == null) {
+      setSaveError("Automation settings are unavailable while disconnected.");
+      setIsSaving(false);
+      return false;
+    }
+    if (props.projectPath.trim().length === 0 || props.workspaceId.trim().length === 0) {
+      setSaveError("Automation settings require a project and workspace.");
+      setIsSaving(false);
+      return false;
+    }
+
+    try {
+      const result = await api.projects.workflowSchedules.set({
+        projectPath: props.projectPath,
+        schedule: {
+          ...(props.projectWorkflowSchedule != null
+            ? {
+                id: props.projectWorkflowSchedule.id,
+                ...(props.projectWorkflowSchedule.title != null
+                  ? { title: props.projectWorkflowSchedule.title }
+                  : {}),
+              }
+            : {}),
+          ...nextSchedule,
+        },
+      });
+      if (!result.success) {
+        setSaveError(result.error ?? "Failed to save automation.");
+        return false;
+      }
+
+      await refreshProjects();
+      return true;
+    } catch (error) {
+      setSaveError(getErrorMessage(error) || "Failed to save automation.");
+      return false;
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleSave = async () => {
+    const parsedMinutes = parseWorkflowScheduleIntervalMinutes(draftIntervalMinutes);
+    assert(parsedMinutes != null, "Save should only run with a valid workflow schedule interval");
+    assert(
+      parsedMinutes >= WORKFLOW_SCHEDULE_MIN_INTERVAL_MINUTES &&
+        parsedMinutes <= WORKFLOW_SCHEDULE_MAX_INTERVAL_MINUTES,
+      "Save should only run with a workflow schedule interval inside the supported range"
+    );
+    assert(argsParseResult.error == null, "Save should only run with valid workflow args JSON");
+    assert(draftWorkflowName.length > 0, "Save should only run with a selected workflow");
+    assert(
+      !draftEnabled || selectedWorkflowExecutable,
+      "Enabled schedules must reference an executable workflow"
+    );
+
+    const didSave = await saveSchedule({
+      enabled: draftEnabled,
+      workflowName: draftWorkflowName,
+      intervalMs: workflowScheduleIntervalMinutesToMs(parsedMinutes),
+      ...(argsParseResult.args ? { args: argsParseResult.args } : {}),
+      ...(draftContextMode !== WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE
+        ? { contextMode: draftContextMode }
+        : {}),
+      target: { type: "existing-workspace", workspaceId: props.workspaceId },
+    });
+    if (didSave) {
+      props.onOpenChange(false);
+    }
+  };
+
+  const handleRemove = async () => {
+    setIsSaving(true);
+    setSaveError(null);
+    if (api == null) {
+      setSaveError("Automation settings are unavailable while disconnected.");
+      setIsSaving(false);
+      return;
+    }
+
+    try {
+      if (props.projectWorkflowSchedule != null) {
+        const result = await api.projects.workflowSchedules.remove({
+          projectPath: props.projectPath,
+          scheduleId: props.projectWorkflowSchedule.id,
+        });
+        if (!result.success) {
+          throw new Error(result.error ?? "Failed to remove automation.");
+        }
+      }
+      await refreshProjects();
+      props.onOpenChange(false);
+    } catch (error) {
+      setSaveError(getErrorMessage(error) || "Failed to remove automation.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent className="max-w-2xl" maxHeight="calc(100dvh - 2rem)">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <CalendarClock className="h-5 w-5" />
+            Automation for {workspaceLabel}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <p className="text-muted text-sm">
+            Configure the project-level automation that runs in this workspace. Each workspace can
+            be targeted by only one automation.
+          </p>
+
+          <div className="border-border rounded-lg border p-4">
+            <div className="flex items-center justify-between gap-4">
+              <div className="min-w-0 flex-1">
+                <div className="text-foreground text-sm font-medium">Enable automation</div>
+                <div className="text-muted mt-1 text-xs">
+                  Keep this automation eligible for recurring background workflow runs.
+                </div>
+              </div>
+              <Switch
+                checked={draftEnabled}
+                onCheckedChange={(checked) => {
+                  setDraftEnabled(checked);
+                }}
+                disabled={isSaving}
+                aria-label="Enable automation"
+              />
+            </div>
+
+            <div className="mt-4 space-y-2">
+              <label htmlFor="automation-name" className="block">
+                <div className="text-foreground text-sm font-medium">Workflow</div>
+                <div className="text-muted mt-1 text-xs">
+                  Only executable workflows can be enabled for automations.
+                </div>
+              </label>
+              <div className="relative">
+                <select
+                  id="automation-name"
+                  value={draftWorkflowName}
+                  onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
+                    setDraftWorkflowName(event.target.value);
+                    setWorkflowNameTouched(true);
+                  }}
+                  disabled={isSaving || definitionsPending}
+                  className="border-border-medium bg-background-secondary text-foreground focus:border-accent focus:ring-accent h-9 w-full min-w-0 rounded-md border px-3 text-sm focus:ring-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                  aria-label="Automation workflow"
+                >
+                  {definitionsPending ? (
+                    <option value={draftWorkflowName}>
+                      {draftWorkflowName
+                        ? `${draftWorkflowName} (loading workflows…)`
+                        : "Loading workflows…"}
+                    </option>
+                  ) : null}
+                  {!definitionsPending && selectedWorkflowMissing && (
+                    <option value={draftWorkflowName}>{draftWorkflowName} (not found)</option>
+                  )}
+                  {!definitionsPending && selectedWorkflowNonExecutable && (
+                    <option value={draftWorkflowName} disabled>
+                      {draftWorkflowName} (
+                      {selectedWorkflowDefinition.blockedReason ?? "not executable"})
+                    </option>
+                  )}
+                  {!definitionsPending &&
+                  executableWorkflowDefinitions.length === 0 &&
+                  !selectedWorkflowMissing &&
+                  !selectedWorkflowNonExecutable ? (
+                    <option value="">No executable workflows found</option>
+                  ) : null}
+                  {executableWorkflowDefinitions.map((workflow) => (
+                    <option key={`${workflow.scope}:${workflow.name}`} value={workflow.name}>
+                      {workflow.name} — {workflow.description}
+                    </option>
+                  ))}
+                </select>
+                {definitionsPending && (
+                  <Loader2 className="text-muted pointer-events-none absolute top-2.5 right-3 h-4 w-4 animate-spin" />
+                )}
+              </div>
+            </div>
+
+            <div className="mt-4 space-y-2">
+              <label htmlFor="automation-context-mode" className="block">
+                <div className="text-foreground text-sm font-medium">Context before run</div>
+                <div className="text-muted mt-1 text-xs">
+                  Applied before the workflow runs in this workspace. Empty contexts are left
+                  unchanged.
+                </div>
+              </label>
+              <select
+                id="automation-context-mode"
+                value={draftContextMode}
+                onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
+                  setDraftContextMode(event.target.value as WorkflowScheduleContextMode);
+                }}
+                disabled={isSaving}
+                className="border-border-medium bg-background-secondary text-foreground focus:border-accent focus:ring-accent h-9 w-full min-w-0 rounded-md border px-3 text-sm focus:ring-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label="Automation context mode"
+              >
+                <option value="normal">Keep existing context</option>
+                <option value="reset">Soft reset context</option>
+                <option value="compact">Compact context first</option>
+              </select>
+            </div>
+
+            <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <label htmlFor="automation-interval" className="min-w-0 flex-1">
+                <div className="text-foreground text-sm font-medium">Interval</div>
+                <div id={intervalHelpId} className="text-muted mt-1 text-xs">
+                  Valid range: {WORKFLOW_SCHEDULE_MIN_INTERVAL_MINUTES}–
+                  {WORKFLOW_SCHEDULE_MAX_INTERVAL_MINUTES} minutes. New automations default to{" "}
+                  {WORKFLOW_SCHEDULE_DEFAULT_INTERVAL_MINUTES} minutes.
+                </div>
+              </label>
+              <div className="flex items-center gap-2 self-start sm:self-auto">
+                <Input
+                  id="automation-interval"
+                  type="number"
+                  inputMode="numeric"
+                  min={WORKFLOW_SCHEDULE_MIN_INTERVAL_MINUTES}
+                  max={WORKFLOW_SCHEDULE_MAX_INTERVAL_MINUTES}
+                  step={1}
+                  value={draftIntervalMinutes}
+                  onInput={(event: React.FormEvent<HTMLInputElement>) => {
+                    setDraftIntervalMinutes(event.currentTarget.value);
+                  }}
+                  onBlur={handleIntervalBlur}
+                  disabled={isSaving}
+                  className="border-border-medium bg-background-secondary h-9 w-24 text-right"
+                  aria-label="Automation interval in minutes"
+                  aria-invalid={intervalValidationError != null}
+                  aria-describedby={intervalDescriptionIds}
+                />
+                <span className="text-muted text-sm">min</span>
+              </div>
+            </div>
+
+            <div className="mt-4 space-y-2">
+              <label htmlFor="automation-args" className="block">
+                <div className="text-foreground text-sm font-medium">Args</div>
+                <div id={argsHelpId} className="text-muted mt-1 text-xs">
+                  Optional JSON object passed to the workflow run.
+                </div>
+              </label>
+              <textarea
+                id="automation-args"
+                rows={5}
+                value={draftArgs}
+                onInput={(event: React.FormEvent<HTMLTextAreaElement>) => {
+                  setDraftArgs(event.currentTarget.value);
+                }}
+                disabled={isSaving}
+                className="border-border-medium bg-background-secondary text-foreground focus:border-accent focus:ring-accent min-h-[120px] w-full resize-y rounded-md border p-3 text-sm leading-relaxed focus:ring-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                placeholder={'{\n  "label": "needs-triage"\n}'}
+                aria-label="Automation args"
+                aria-invalid={argsParseResult.error != null}
+                aria-describedby={argsDescriptionIds}
+              />
+            </div>
+
+            {lastRunStartedAt && (
+              <p className="text-muted mt-3 text-xs">Last started: {lastRunStartedAt}</p>
+            )}
+          </div>
+
+          {errorMessages.length > 0 && (
+            <div
+              className="bg-danger-soft/10 text-danger-soft space-y-1 rounded-md p-3 text-sm"
+              role="alert"
+              aria-live="assertive"
+            >
+              {errorMessages.map((message) => (
+                <p
+                  key={message}
+                  id={
+                    message === intervalValidationError
+                      ? intervalErrorId
+                      : message === argsParseResult.error
+                        ? argsErrorId
+                        : undefined
+                  }
+                >
+                  {message}
+                </p>
+              ))}
+            </div>
+          )}
+
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              {hasSchedule && (
+                <Button
+                  variant="ghost"
+                  onClick={() => void handleRemove()}
+                  disabled={isSaving || api == null}
+                >
+                  Remove automation
+                </Button>
+              )}
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button variant="ghost" onClick={() => props.onOpenChange(false)} disabled={isSaving}>
+                Cancel
+              </Button>
+              <Button onClick={() => void handleSave()} disabled={hasBlockingError}>
+                {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                Save
+              </Button>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/browser/components/AutomationModal/AutomationModal.tsx
+++ b/src/browser/components/AutomationModal/AutomationModal.tsx
@@ -228,7 +228,7 @@ export function AutomationModal(props: AutomationModalProps) {
       try {
         const definitions = await api.workflows.listDefinitions(
           shouldLoadDefinitionsByProject
-            ? { projectPath: props.projectPath }
+            ? { workspaceId: props.workspaceId, projectPath: props.projectPath }
             : { workspaceId: props.workspaceId }
         );
         if (ignore) {

--- a/src/browser/components/AutomationModal/index.ts
+++ b/src/browser/components/AutomationModal/index.ts
@@ -1,0 +1,1 @@
+export { AutomationModal } from "./AutomationModal";

--- a/src/browser/components/PositionedMenu/PositionedMenu.tsx
+++ b/src/browser/components/PositionedMenu/PositionedMenu.tsx
@@ -115,7 +115,9 @@ export function PositionedMenuItem(props: PositionedMenuItemProps) {
         <span className="h-3 w-3 shrink-0 [&_svg]:h-3 [&_svg]:w-3">{props.icon}</span>
         {props.label}
         {props.shortcut && (
-          <span className="text-muted ml-auto text-[10px]">({props.shortcut})</span>
+          <span className="text-muted ml-auto hidden text-[10px] sm:inline">
+            ({props.shortcut})
+          </span>
         )}
       </span>
     </button>

--- a/src/browser/components/ProjectAutomationsModal/ProjectAutomationsModal.test.tsx
+++ b/src/browser/components/ProjectAutomationsModal/ProjectAutomationsModal.test.tsx
@@ -28,7 +28,10 @@ type ConnectedUseAPIResult = Extract<UseAPIResult, { status: "connected" }>;
 
 interface ProjectAutomationsTestAPI {
   workflows: {
-    listDefinitions: (input: { projectPath: string }) => Promise<WorkflowDefinitionDescriptor[]>;
+    listDefinitions: (input: {
+      projectPath: string;
+      workspaceId?: string;
+    }) => Promise<WorkflowDefinitionDescriptor[]>;
   };
   projects: {
     listBranches: (input: {
@@ -298,6 +301,40 @@ describe("ProjectAutomationsModal", () => {
           contextMode: "reset",
           target: { type: "existing-workspace", workspaceId: "ws-1" },
         },
+      });
+    });
+  });
+
+  test("loads workflow definitions through an owner workspace for sub-project automations", async () => {
+    const subProjectPath = "/repo/packages/api";
+    const parentConfig = createProjectConfig();
+    const subProjectConfig = createProjectConfig({ parentProjectPath: "/repo", workspaces: [] });
+    spyOn(ProjectContextModule, "useProjectContext").mockImplementation(
+      () =>
+        ({
+          getProjectConfig: (path: string) => (path === "/repo" ? parentConfig : undefined),
+          refreshProjects: refreshProjectsMock,
+          userProjects: new Map([
+            ["/repo", parentConfig],
+            [subProjectPath, subProjectConfig],
+          ]),
+        }) as unknown as ReturnType<typeof ProjectContextModule.useProjectContext>
+    );
+
+    render(
+      <ProjectAutomationsModal
+        open={true}
+        projectPath={subProjectPath}
+        projectName="API"
+        projectConfig={subProjectConfig}
+        onOpenChange={() => undefined}
+      />
+    );
+
+    await waitFor(() => {
+      expect(listDefinitionsMock).toHaveBeenCalledWith({
+        projectPath: subProjectPath,
+        workspaceId: "ws-1",
       });
     });
   });

--- a/src/browser/components/ProjectAutomationsModal/ProjectAutomationsModal.test.tsx
+++ b/src/browser/components/ProjectAutomationsModal/ProjectAutomationsModal.test.tsx
@@ -191,6 +191,7 @@ describe("ProjectAutomationsModal", () => {
         ({
           getProjectConfig: () => undefined,
           refreshProjects: refreshProjectsMock,
+          userProjects: new Map(),
         }) as unknown as ReturnType<typeof ProjectContextModule.useProjectContext>
     );
   });
@@ -321,6 +322,7 @@ describe("ProjectAutomationsModal", () => {
                 })
               : undefined,
           refreshProjects: refreshProjectsMock,
+          userProjects: new Map(),
         }) as unknown as ReturnType<typeof ProjectContextModule.useProjectContext>
     );
     const view = render(
@@ -350,6 +352,54 @@ describe("ProjectAutomationsModal", () => {
     expect(view.getByRole("option", { name: "Control workspace" })).toBeTruthy();
   });
 
+  test("filters owner workspace targets claimed by parent automations", async () => {
+    const subProjectPath = "/repo/packages/api";
+    const parentConfig = createProjectConfig({
+      workflowSchedules: [
+        {
+          id: "parent-automation",
+          enabled: true,
+          workflowName: "triage-github-issues",
+          intervalMs: 15 * 60_000,
+          target: { type: "existing-workspace", workspaceId: "ws-1" },
+        },
+      ],
+    });
+    const subProjectConfig = createProjectConfig({ parentProjectPath: "/repo", workspaces: [] });
+    spyOn(ProjectContextModule, "useProjectContext").mockImplementation(
+      () =>
+        ({
+          getProjectConfig: (path: string) => (path === "/repo" ? parentConfig : undefined),
+          refreshProjects: refreshProjectsMock,
+          userProjects: new Map([
+            ["/repo", parentConfig],
+            [subProjectPath, subProjectConfig],
+          ]),
+        }) as unknown as ReturnType<typeof ProjectContextModule.useProjectContext>
+    );
+    const view = render(
+      <ProjectAutomationsModal
+        open={true}
+        projectPath={subProjectPath}
+        projectName="API"
+        projectConfig={subProjectConfig}
+        onOpenChange={() => undefined}
+      />
+    );
+
+    fireEvent.click(view.getByRole("button", { name: "New automation" }));
+    await waitFor(() => {
+      expect((view.getByLabelText("Project automation workflow") as HTMLSelectElement).value).toBe(
+        "triage-github-issues"
+      );
+    });
+    fireEvent.change(view.getByLabelText("Project automation run target"), {
+      target: { value: "existing-workspace" },
+    });
+
+    expect(view.queryByRole("option", { name: "Control workspace" })).toBeNull();
+  });
+
   test("does not offer an existing workspace that already has an automation", async () => {
     const view = renderProjectAutomationsModal(
       createProjectConfig({
@@ -365,6 +415,44 @@ describe("ProjectAutomationsModal", () => {
             intervalMs: 15 * 60_000,
             target: { type: "existing-workspace", workspaceId: "ws-1" },
           },
+        ],
+      })
+    );
+
+    fireEvent.click(view.getByRole("button", { name: "New automation" }));
+    await waitFor(() => {
+      expect((view.getByLabelText("Project automation workflow") as HTMLSelectElement).value).toBe(
+        "triage-github-issues"
+      );
+    });
+    fireEvent.change(view.getByLabelText("Project automation run target"), {
+      target: { value: "existing-workspace" },
+    });
+
+    const workspaceSelect = view.getByLabelText(
+      "Project automation existing workspace"
+    ) as HTMLSelectElement;
+    expect(workspaceSelect.value).toBe("ws-2");
+    expect(view.queryByRole("option", { name: "Control workspace" })).toBeNull();
+    expect(view.getByRole("option", { name: "Review workspace" })).toBeTruthy();
+  });
+
+  test("does not offer an existing workspace that already has a workspace schedule", async () => {
+    const view = renderProjectAutomationsModal(
+      createProjectConfig({
+        workspaces: [
+          {
+            path: "/repo/control",
+            id: "ws-1",
+            name: "control",
+            title: "Control workspace",
+            workflowSchedule: {
+              enabled: true,
+              workflowName: "triage-github-issues",
+              intervalMs: 15 * 60_000,
+            },
+          },
+          { path: "/repo/review", id: "ws-2", name: "review", title: "Review workspace" },
         ],
       })
     );

--- a/src/browser/components/ProjectAutomationsModal/ProjectAutomationsModal.test.tsx
+++ b/src/browser/components/ProjectAutomationsModal/ProjectAutomationsModal.test.tsx
@@ -1,0 +1,476 @@
+import "../../../../tests/ui/dom";
+
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { installDom } from "../../../../tests/ui/dom";
+import * as APIModule from "@/browser/contexts/API";
+import type { APIClient, UseAPIResult } from "@/browser/contexts/API";
+import * as ProjectContextModule from "@/browser/contexts/ProjectContext";
+import type { ProjectConfig, ProjectWorkflowSchedule } from "@/common/types/project";
+import type { WorkflowDefinitionDescriptor } from "@/common/types/workflow";
+
+void mock.module("@/browser/components/Dialog/Dialog", () => ({
+  Dialog: (props: { open: boolean; children: ReactNode }) =>
+    props.open ? <div>{props.children}</div> : null,
+  DialogContent: (props: { children: ReactNode; className?: string }) => (
+    <div className={props.className}>{props.children}</div>
+  ),
+  DialogHeader: (props: { children: ReactNode }) => <div>{props.children}</div>,
+  DialogTitle: (props: { children: ReactNode; className?: string }) => (
+    <h2 className={props.className}>{props.children}</h2>
+  ),
+}));
+
+import { ProjectAutomationsModal } from "./ProjectAutomationsModal";
+
+type ConnectedUseAPIResult = Extract<UseAPIResult, { status: "connected" }>;
+
+interface ProjectAutomationsTestAPI {
+  workflows: {
+    listDefinitions: (input: { projectPath: string }) => Promise<WorkflowDefinitionDescriptor[]>;
+  };
+  projects: {
+    listBranches: (input: {
+      projectPath: string;
+    }) => Promise<{ branches: string[]; recommendedTrunk: string | null }>;
+    workflowSchedules: {
+      set: (input: {
+        projectPath: string;
+        schedule: Omit<ProjectWorkflowSchedule, "lastRunStartedAt"> & { id?: string };
+      }) => Promise<
+        { success: true; data: ProjectWorkflowSchedule } | { success: false; error: string }
+      >;
+      run: (input: { projectPath: string; scheduleId: string }) => Promise<
+        | {
+            success: true;
+            data: { runId: string; status: "backgrounded" | "completed" | "failed" };
+          }
+        | { success: false; error: string }
+      >;
+      remove: (input: {
+        projectPath: string;
+        scheduleId: string;
+      }) => Promise<{ success: true; data: void } | { success: false; error: string }>;
+    };
+  };
+}
+
+let cleanupDom: (() => void) | null = null;
+let listDefinitionsMock: ReturnType<typeof mock>;
+let listBranchesMock: ReturnType<typeof mock>;
+let setProjectScheduleMock: ReturnType<typeof mock>;
+let runProjectScheduleMock: ReturnType<typeof mock>;
+let removeProjectScheduleMock: ReturnType<typeof mock>;
+let refreshProjectsMock: ReturnType<typeof mock>;
+
+function createConnectedUseAPIResult(api: ProjectAutomationsTestAPI): ConnectedUseAPIResult {
+  return {
+    api: api as unknown as APIClient,
+    status: "connected",
+    error: null,
+    authenticate: () => undefined,
+    retry: () => undefined,
+  };
+}
+
+function createWorkflowDefinition(): WorkflowDefinitionDescriptor {
+  return {
+    name: "triage-github-issues",
+    description: "Scan untriaged GitHub issues.",
+    scope: "project",
+    executable: true,
+    sourcePath: "/repo/.mux/workflows/triage-github-issues.js",
+  };
+}
+
+function createProjectConfig(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
+  return {
+    workspaces: [
+      {
+        path: "/repo/control",
+        id: "ws-1",
+        name: "control",
+        title: "Control workspace",
+        runtimeConfig: { type: "local", srcBaseDir: "/tmp/mux-src" },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function changeTextField(element: Element, value: string): void {
+  const formElement = element as HTMLInputElement | HTMLTextAreaElement;
+  const valueDescriptor = Object.getOwnPropertyDescriptor(
+    Object.getPrototypeOf(formElement),
+    "value"
+  );
+  act(() => {
+    if (valueDescriptor?.set != null) {
+      valueDescriptor.set.call(formElement, value);
+    }
+    const trackedElement = formElement as unknown as {
+      _valueTracker?: { setValue: (trackedValue: string) => void };
+    };
+    trackedElement._valueTracker?.setValue("");
+    fireEvent.input(formElement, { target: { value } });
+    fireEvent.change(formElement, { target: { value } });
+  });
+}
+
+function renderProjectAutomationsModal(projectConfig: ProjectConfig = createProjectConfig()) {
+  return render(
+    <ProjectAutomationsModal
+      open={true}
+      projectPath="/repo"
+      projectName="Repo"
+      projectConfig={projectConfig}
+      onOpenChange={() => undefined}
+    />
+  );
+}
+
+describe("ProjectAutomationsModal", () => {
+  beforeEach(() => {
+    cleanupDom = installDom();
+    listDefinitionsMock = mock(() => Promise.resolve([createWorkflowDefinition()]));
+    listBranchesMock = mock(() =>
+      Promise.resolve({ branches: ["main"], recommendedTrunk: "main" })
+    );
+    setProjectScheduleMock = mock(
+      (input: Parameters<ProjectAutomationsTestAPI["projects"]["workflowSchedules"]["set"]>[0]) => {
+        const data: ProjectWorkflowSchedule = {
+          ...input.schedule,
+          id: input.schedule.id ?? "generated-schedule-id",
+        };
+        return Promise.resolve({ success: true as const, data });
+      }
+    );
+    runProjectScheduleMock = mock(() =>
+      Promise.resolve({
+        success: true as const,
+        data: { runId: "wfr_manual_project_schedule", status: "backgrounded" as const },
+      })
+    );
+    removeProjectScheduleMock = mock(() =>
+      Promise.resolve({ success: true as const, data: undefined })
+    );
+    refreshProjectsMock = mock(() => Promise.resolve());
+
+    const api: ProjectAutomationsTestAPI = {
+      workflows: {
+        listDefinitions: (input) =>
+          listDefinitionsMock(input) as Promise<WorkflowDefinitionDescriptor[]>,
+      },
+      projects: {
+        listBranches: (input) =>
+          listBranchesMock(input) as Promise<{
+            branches: string[];
+            recommendedTrunk: string | null;
+          }>,
+        workflowSchedules: {
+          set: setProjectScheduleMock,
+          run: runProjectScheduleMock,
+          remove: removeProjectScheduleMock,
+        },
+      },
+    };
+    spyOn(APIModule, "useAPI").mockImplementation(() => createConnectedUseAPIResult(api));
+    spyOn(ProjectContextModule, "useProjectContext").mockImplementation(
+      () =>
+        ({
+          getProjectConfig: () => undefined,
+          refreshProjects: refreshProjectsMock,
+        }) as unknown as ReturnType<typeof ProjectContextModule.useProjectContext>
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    mock.restore();
+    cleanupDom?.();
+    cleanupDom = null;
+  });
+
+  test("creates a fresh-workspace project automation", async () => {
+    const view = renderProjectAutomationsModal();
+
+    fireEvent.click(view.getByRole("button", { name: "New automation" }));
+
+    await waitFor(() => {
+      expect((view.getByLabelText("Project automation workflow") as HTMLSelectElement).value).toBe(
+        "triage-github-issues"
+      );
+    });
+    changeTextField(view.getByLabelText("Project automation name"), "GitHub triage");
+    changeTextField(view.getByLabelText("Project automation interval in minutes"), "360");
+    changeTextField(view.getByLabelText("Project automation args"), '{"label":"needs-triage"}');
+
+    fireEvent.click(view.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(setProjectScheduleMock).toHaveBeenCalledWith({
+        projectPath: "/repo",
+        schedule: {
+          title: "GitHub triage",
+          enabled: true,
+          workflowName: "triage-github-issues",
+          intervalMs: 360 * 60_000,
+          args: { label: "needs-triage" },
+          target: { type: "new-workspace", trunkBranch: "main" },
+        },
+      });
+    });
+    expect(refreshProjectsMock).toHaveBeenCalled();
+  });
+
+  test("runs a project automation from the list", async () => {
+    const view = renderProjectAutomationsModal(
+      createProjectConfig({
+        workflowSchedules: [
+          {
+            id: "automation-1",
+            title: "Security Scan",
+            enabled: true,
+            workflowName: "triage-github-issues",
+            intervalMs: 15 * 60_000,
+            target: { type: "new-workspace", trunkBranch: "main" },
+          },
+        ],
+      })
+    );
+
+    const runButton = view.getByRole("button", { name: "Run Security Scan now" });
+    await waitFor(() => {
+      expect((runButton as HTMLButtonElement).disabled).toBe(false);
+    });
+    fireEvent.click(runButton);
+
+    await waitFor(() => {
+      expect(runProjectScheduleMock).toHaveBeenCalledWith({
+        projectPath: "/repo",
+        scheduleId: "automation-1",
+      });
+    });
+    expect(refreshProjectsMock).toHaveBeenCalled();
+  });
+
+  test("only shows context mode for existing-workspace project automations", async () => {
+    const view = renderProjectAutomationsModal();
+
+    fireEvent.click(view.getByRole("button", { name: "New automation" }));
+
+    await waitFor(() => {
+      expect((view.getByLabelText("Project automation workflow") as HTMLSelectElement).value).toBe(
+        "triage-github-issues"
+      );
+    });
+    expect(view.queryByLabelText("Project automation context mode")).toBeNull();
+
+    fireEvent.change(view.getByLabelText("Project automation run target"), {
+      target: { value: "existing-workspace" },
+    });
+
+    const contextModeSelect = view.getByLabelText(
+      "Project automation context mode"
+    ) as HTMLSelectElement;
+    fireEvent.change(contextModeSelect, { target: { value: "reset" } });
+    fireEvent.click(view.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(setProjectScheduleMock).toHaveBeenCalledWith({
+        projectPath: "/repo",
+        schedule: {
+          enabled: true,
+          workflowName: "triage-github-issues",
+          intervalMs: 15 * 60_000,
+          contextMode: "reset",
+          target: { type: "existing-workspace", workspaceId: "ws-1" },
+        },
+      });
+    });
+  });
+
+  test("offers owner workspaces for sub-project automations", async () => {
+    const subProjectPath = "/repo/packages/api";
+    spyOn(ProjectContextModule, "useProjectContext").mockImplementation(
+      () =>
+        ({
+          getProjectConfig: (path: string) =>
+            path === "/repo"
+              ? createProjectConfig({
+                  workspaces: [
+                    {
+                      path: "/repo/control",
+                      id: "ws-1",
+                      name: "control",
+                      title: "Control workspace",
+                      subProjectPath,
+                    },
+                  ],
+                })
+              : undefined,
+          refreshProjects: refreshProjectsMock,
+        }) as unknown as ReturnType<typeof ProjectContextModule.useProjectContext>
+    );
+    const view = render(
+      <ProjectAutomationsModal
+        open={true}
+        projectPath={subProjectPath}
+        projectName="API"
+        projectConfig={createProjectConfig({ parentProjectPath: "/repo", workspaces: [] })}
+        onOpenChange={() => undefined}
+      />
+    );
+
+    fireEvent.click(view.getByRole("button", { name: "New automation" }));
+    await waitFor(() => {
+      expect((view.getByLabelText("Project automation workflow") as HTMLSelectElement).value).toBe(
+        "triage-github-issues"
+      );
+    });
+    fireEvent.change(view.getByLabelText("Project automation run target"), {
+      target: { value: "existing-workspace" },
+    });
+
+    const workspaceSelect = view.getByLabelText(
+      "Project automation existing workspace"
+    ) as HTMLSelectElement;
+    expect(workspaceSelect.value).toBe("ws-1");
+    expect(view.getByRole("option", { name: "Control workspace" })).toBeTruthy();
+  });
+
+  test("does not offer an existing workspace that already has an automation", async () => {
+    const view = renderProjectAutomationsModal(
+      createProjectConfig({
+        workspaces: [
+          { path: "/repo/control", id: "ws-1", name: "control", title: "Control workspace" },
+          { path: "/repo/review", id: "ws-2", name: "review", title: "Review workspace" },
+        ],
+        workflowSchedules: [
+          {
+            id: "automation-1",
+            enabled: true,
+            workflowName: "triage-github-issues",
+            intervalMs: 15 * 60_000,
+            target: { type: "existing-workspace", workspaceId: "ws-1" },
+          },
+        ],
+      })
+    );
+
+    fireEvent.click(view.getByRole("button", { name: "New automation" }));
+    await waitFor(() => {
+      expect((view.getByLabelText("Project automation workflow") as HTMLSelectElement).value).toBe(
+        "triage-github-issues"
+      );
+    });
+    fireEvent.change(view.getByLabelText("Project automation run target"), {
+      target: { value: "existing-workspace" },
+    });
+
+    const workspaceSelect = view.getByLabelText(
+      "Project automation existing workspace"
+    ) as HTMLSelectElement;
+    expect(workspaceSelect.value).toBe("ws-2");
+    expect(view.queryByRole("option", { name: "Control workspace" })).toBeNull();
+    expect(view.getByRole("option", { name: "Review workspace" })).toBeTruthy();
+  });
+
+  test("preserves new automation edits when branch discovery finishes", async () => {
+    const branches = createDeferred<{ branches: string[]; recommendedTrunk: string | null }>();
+    listBranchesMock = mock(() => branches.promise);
+    const view = renderProjectAutomationsModal();
+
+    fireEvent.click(view.getByRole("button", { name: "New automation" }));
+    await waitFor(() => {
+      expect((view.getByLabelText("Project automation workflow") as HTMLSelectElement).value).toBe(
+        "triage-github-issues"
+      );
+    });
+
+    changeTextField(view.getByLabelText("Project automation name"), "Typed title");
+    changeTextField(view.getByLabelText("Project automation args"), '{"label":"typed"}');
+
+    await act(async () => {
+      branches.resolve({ branches: ["develop"], recommendedTrunk: "develop" });
+      await branches.promise;
+    });
+
+    expect((view.getByLabelText("Project automation name") as HTMLInputElement).value).toBe(
+      "Typed title"
+    );
+    expect((view.getByLabelText("Project automation args") as HTMLTextAreaElement).value).toBe(
+      '{"label":"typed"}'
+    );
+    await waitFor(() => {
+      expect(
+        (view.getByLabelText("Project automation base branch") as HTMLInputElement).value
+      ).toBe("develop");
+    });
+  });
+
+  test("disables list controls for missing workflows", async () => {
+    const view = renderProjectAutomationsModal(
+      createProjectConfig({
+        workflowSchedules: [
+          {
+            id: "automation-1",
+            enabled: false,
+            workflowName: "missing-workflow",
+            intervalMs: 15 * 60_000,
+            target: { type: "new-workspace", trunkBranch: "main" },
+          },
+        ],
+      })
+    );
+
+    await waitFor(() => {
+      expect(view.getByText("Workflow not found.")).toBeTruthy();
+    });
+    expect(
+      (view.getByRole("button", { name: "Run missing-workflow now" }) as HTMLButtonElement).disabled
+    ).toBe(true);
+    expect(
+      (view.getByRole("switch", { name: "Enable missing-workflow" }) as HTMLInputElement).disabled
+    ).toBe(true);
+  });
+
+  test("associates project automation validation errors with fields", async () => {
+    const view = renderProjectAutomationsModal();
+
+    fireEvent.click(view.getByRole("button", { name: "New automation" }));
+    await waitFor(() => {
+      expect((view.getByLabelText("Project automation workflow") as HTMLSelectElement).value).toBe(
+        "triage-github-issues"
+      );
+    });
+
+    const intervalInput = view.getByLabelText(
+      "Project automation interval in minutes"
+    ) as HTMLInputElement;
+    const argsInput = view.getByLabelText("Project automation args") as HTMLTextAreaElement;
+    changeTextField(intervalInput, "0");
+    changeTextField(argsInput, "[]");
+
+    expect(view.getByRole("alert").textContent).toContain(
+      "Schedule interval must be between 1 and 1440 minutes."
+    );
+    expect(intervalInput.getAttribute("aria-invalid")).toBe("true");
+    expect(intervalInput.getAttribute("aria-describedby")).toContain(
+      "project-automation-interval-error"
+    );
+    expect(argsInput.getAttribute("aria-invalid")).toBe("true");
+    expect(argsInput.getAttribute("aria-describedby")).toContain("project-automation-args-error");
+  });
+});

--- a/src/browser/components/ProjectAutomationsModal/ProjectAutomationsModal.tsx
+++ b/src/browser/components/ProjectAutomationsModal/ProjectAutomationsModal.tsx
@@ -1,0 +1,1100 @@
+import React, { useEffect, useRef, useState } from "react";
+import { CalendarClock, Loader2, Play, Plus, Trash } from "lucide-react";
+import { Button } from "@/browser/components/Button/Button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/browser/components/Dialog/Dialog";
+import { Input } from "@/browser/components/Input/Input";
+import { Switch } from "@/browser/components/Switch/Switch";
+import { useAPI } from "@/browser/contexts/API";
+import { useProjectContext } from "@/browser/contexts/ProjectContext";
+import type { ProjectConfig, ProjectWorkflowSchedule, Workspace } from "@/common/types/project";
+import type { WorkflowDefinitionDescriptor } from "@/common/types/workflow";
+import assert from "@/common/utils/assert";
+import { getErrorMessage } from "@/common/utils/errors";
+import { isWorkspaceArchived } from "@/common/utils/archive";
+import { validateWorkspaceName } from "@/common/utils/validation/workspaceValidation";
+import { getSupportedWorkflowScheduleNewWorkspaceTemplate } from "@/common/utils/workflowScheduleTarget";
+import {
+  WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE,
+  WORKFLOW_SCHEDULE_DEFAULT_INTERVAL_MS,
+  type WorkflowScheduleContextMode,
+} from "@/constants/workflowSchedule";
+import {
+  formatWorkflowArgs,
+  formatWorkflowScheduleIntervalMinutes,
+  getWorkflowScheduleIntervalValidationError,
+  parseWorkflowArgs,
+  parseWorkflowScheduleIntervalMinutes,
+  WORKFLOW_SCHEDULE_DEFAULT_INTERVAL_MINUTES,
+  WORKFLOW_SCHEDULE_MAX_INTERVAL_MINUTES,
+  WORKFLOW_SCHEDULE_MIN_INTERVAL_MINUTES,
+  workflowScheduleIntervalMinutesToMs,
+} from "@/browser/utils/workflowScheduleIntervalMinutes";
+
+interface ProjectAutomationsModalProps {
+  open: boolean;
+  projectPath: string;
+  projectName: string;
+  projectConfig: ProjectConfig;
+  onOpenChange: (open: boolean) => void;
+}
+
+type ProjectAutomationTargetType = "new-workspace" | "existing-workspace";
+
+function getTargetBranchValidationError(value: string): string | null {
+  const trimmedValue = value.trim();
+  if (trimmedValue.length === 0) {
+    return null;
+  }
+
+  const validation = validateWorkspaceName(trimmedValue);
+  return validation.valid ? null : (validation.error ?? "Invalid workspace name");
+}
+
+function formatLastRunStartedAt(value: string | undefined): string {
+  if (!value) {
+    return "Never";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "Unknown";
+  }
+
+  return date.toLocaleString();
+}
+
+function getWorkspaceLabel(workspace: Workspace | undefined): string {
+  const title = workspace?.title?.trim();
+  if (title) return title;
+  const name = workspace?.name?.trim();
+  if (name) return name;
+  return workspace?.id ?? "Unknown workspace";
+}
+
+function getScheduleLabel(schedule: ProjectWorkflowSchedule): string {
+  const title = schedule.title?.trim();
+  if (title) return title;
+  return schedule.workflowName;
+}
+
+function getProjectAutomationRowKey(schedule: ProjectWorkflowSchedule): string {
+  return `project:${schedule.id}`;
+}
+
+function getProjectScheduleId(schedule: ProjectWorkflowSchedule | null): string | null {
+  const scheduleId = schedule?.id?.trim();
+  return scheduleId != null && scheduleId.length > 0 ? scheduleId : null;
+}
+
+function getExistingWorkspaceAutomationConflict(input: {
+  projectConfig: ProjectConfig;
+  workspaceId: string;
+  editingScheduleId: string | null;
+}): ProjectWorkflowSchedule | undefined {
+  const workspaceId = input.workspaceId.trim();
+  if (workspaceId.length === 0) {
+    return undefined;
+  }
+
+  return (input.projectConfig.workflowSchedules ?? []).find(
+    (schedule) =>
+      schedule.id !== input.editingScheduleId &&
+      schedule.target.type === "existing-workspace" &&
+      schedule.target.workspaceId === workspaceId
+  );
+}
+
+function getTargetLabel(
+  schedule: ProjectWorkflowSchedule,
+  workspacesById: Map<string, Workspace>
+): string {
+  const target = schedule.target;
+  if (target.type === "new-workspace") {
+    return "Fresh workspace each run";
+  }
+
+  return `Existing workspace: ${getWorkspaceLabel(workspacesById.get(target.workspaceId))}`;
+}
+
+function getNewWorkspaceAutomationUnavailableReason(input: {
+  projectPath: string;
+  workspaces: Workspace[];
+}): string | null {
+  return getSupportedWorkflowScheduleNewWorkspaceTemplate({
+    sourceProjectPath: input.projectPath,
+    workspaces: input.workspaces,
+  }).unavailableReason;
+}
+
+function getWorkflowUnavailableReason(input: {
+  workflowName: string;
+  workflowDefinitions: WorkflowDefinitionDescriptor[];
+  definitionsPending: boolean;
+}): string | null {
+  if (input.definitionsPending) {
+    return "Workflow definitions are still loading.";
+  }
+  const workflowName = input.workflowName.trim();
+  if (workflowName.length === 0) {
+    return "Choose a workflow before running this automation.";
+  }
+  const definition = input.workflowDefinitions.find((workflow) => workflow.name === workflowName);
+  if (definition == null) {
+    return "Workflow not found.";
+  }
+  if (!definition.executable) {
+    return definition.blockedReason ?? "Workflow is not executable.";
+  }
+  return null;
+}
+
+function getEnabledScheduleInput(
+  schedule: ProjectWorkflowSchedule,
+  enabled: boolean
+): Omit<ProjectWorkflowSchedule, "lastRunStartedAt"> {
+  return {
+    id: schedule.id,
+    ...(schedule.title != null ? { title: schedule.title } : {}),
+    enabled,
+    workflowName: schedule.workflowName,
+    ...(schedule.args != null ? { args: schedule.args } : {}),
+    ...(schedule.target.type === "existing-workspace" && schedule.contextMode != null
+      ? { contextMode: schedule.contextMode }
+      : {}),
+    intervalMs: schedule.intervalMs,
+    target: schedule.target,
+  };
+}
+
+export function ProjectAutomationsModal(props: ProjectAutomationsModalProps) {
+  const { api } = useAPI();
+  const { getProjectConfig, refreshProjects } = useProjectContext();
+  const rows = props.projectConfig.workflowSchedules ?? [];
+  const ownerProjectPath = props.projectConfig.parentProjectPath ?? props.projectPath;
+  const ownerProjectConfig =
+    ownerProjectPath === props.projectPath
+      ? props.projectConfig
+      : getProjectConfig(ownerProjectPath);
+  const ownerWorkspaces = ownerProjectConfig?.workspaces ?? props.projectConfig.workspaces;
+  const activeWorkspaces = ownerWorkspaces.filter(
+    (workspace) =>
+      workspace.id != null && !isWorkspaceArchived(workspace.archivedAt, workspace.unarchivedAt)
+  );
+  const workspacesById = new Map(
+    ownerWorkspaces
+      .filter((workspace) => workspace.id != null)
+      .map((workspace) => [workspace.id!, workspace])
+  );
+  const [mode, setMode] = useState<"list" | "edit">("list");
+  const [editingSchedule, setEditingSchedule] = useState<ProjectWorkflowSchedule | null>(null);
+  const [workflowDefinitions, setWorkflowDefinitions] = useState<WorkflowDefinitionDescriptor[]>(
+    []
+  );
+  const [definitionsLoading, setDefinitionsLoading] = useState(false);
+  const [definitionsLoaded, setDefinitionsLoaded] = useState(false);
+  const [definitionsError, setDefinitionsError] = useState<string | null>(null);
+  const [recommendedTrunk, setRecommendedTrunk] = useState("main");
+  const [isSaving, setIsSaving] = useState(false);
+  const [runningScheduleKey, setRunningScheduleKey] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const [draftTitle, setDraftTitle] = useState("");
+  const [draftEnabled, setDraftEnabled] = useState(true);
+  const [draftWorkflowName, setDraftWorkflowName] = useState("");
+  const [draftIntervalMinutes, setDraftIntervalMinutes] = useState(
+    String(WORKFLOW_SCHEDULE_DEFAULT_INTERVAL_MINUTES)
+  );
+  const [draftArgs, setDraftArgs] = useState("");
+  const [draftContextMode, setDraftContextMode] = useState<WorkflowScheduleContextMode>(
+    WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE
+  );
+  const [draftTargetType, setDraftTargetType] =
+    useState<ProjectAutomationTargetType>("new-workspace");
+  const [draftExistingWorkspaceId, setDraftExistingWorkspaceId] = useState("");
+  const [draftTargetBranchName, setDraftTargetBranchName] = useState("");
+  const [draftTargetTrunkBranch, setDraftTargetTrunkBranch] = useState("main");
+  const [targetTrunkTouched, setTargetTrunkTouched] = useState(false);
+  const [draftTargetTitle, setDraftTargetTitle] = useState("");
+  const lastInitializedEditKeyRef = useRef<string | null>(null);
+
+  const executableWorkflowDefinitions = workflowDefinitions.filter(
+    (workflow) => workflow.executable
+  );
+  const firstExecutableWorkflowName = executableWorkflowDefinitions[0]?.name ?? "";
+  const selectedWorkflowDefinition = workflowDefinitions.find(
+    (workflow) => workflow.name === draftWorkflowName
+  );
+  const selectedWorkflowMissing =
+    draftWorkflowName.length > 0 && selectedWorkflowDefinition == null;
+  const selectedWorkflowNonExecutable =
+    draftWorkflowName.length > 0 &&
+    selectedWorkflowDefinition != null &&
+    !selectedWorkflowDefinition.executable;
+  const selectedWorkflowExecutable = selectedWorkflowDefinition?.executable === true;
+  const definitionsPending =
+    definitionsLoading || (props.open && api != null && !definitionsLoaded);
+  const argsParseResult = parseWorkflowArgs(draftArgs);
+  const intervalValidationError = getWorkflowScheduleIntervalValidationError(draftIntervalMinutes);
+  const editingScheduleId = getProjectScheduleId(editingSchedule);
+  const newWorkspaceUnavailableReason = getNewWorkspaceAutomationUnavailableReason({
+    projectPath: props.projectPath,
+    workspaces: ownerWorkspaces,
+  });
+  const existingWorkspaceConflict =
+    draftTargetType === "existing-workspace"
+      ? getExistingWorkspaceAutomationConflict({
+          projectConfig: props.projectConfig,
+          workspaceId: draftExistingWorkspaceId,
+          editingScheduleId,
+        })
+      : undefined;
+  const existingWorkspaceOptions = activeWorkspaces.filter((workspace) => {
+    if (workspace.id == null) return false;
+    if (workspace.id === draftExistingWorkspaceId) return true;
+    return (
+      getExistingWorkspaceAutomationConflict({
+        projectConfig: props.projectConfig,
+        workspaceId: workspace.id,
+        editingScheduleId,
+      }) == null
+    );
+  });
+  const workflowValidationError = definitionsPending
+    ? null
+    : draftWorkflowName.length === 0
+      ? "Choose a workflow before saving."
+      : draftEnabled && !selectedWorkflowExecutable
+        ? "Choose an executable workflow before enabling the automation."
+        : null;
+  const targetTypeValidationError =
+    draftTargetType === "new-workspace" ? newWorkspaceUnavailableReason : null;
+  const targetValidationError =
+    draftTargetType !== "existing-workspace"
+      ? null
+      : draftExistingWorkspaceId.trim().length === 0
+        ? "Choose an existing workspace or use a fresh workspace target."
+        : existingWorkspaceConflict != null
+          ? `${getWorkspaceLabel(workspacesById.get(draftExistingWorkspaceId))} already has an automation.`
+          : null;
+  const targetTrunkValidationError =
+    draftTargetType === "new-workspace" && draftTargetTrunkBranch.trim().length === 0
+      ? "Base branch is required when creating a new workspace for each run."
+      : null;
+  const targetBranchValidationError =
+    draftTargetType === "new-workspace"
+      ? getTargetBranchValidationError(draftTargetBranchName)
+      : null;
+  const workflowHelpId = "project-automation-workflow-help";
+  const workflowErrorId = "project-automation-workflow-error";
+  const targetTypeHelpId = "project-automation-target-help";
+  const targetTypeErrorId = "project-automation-target-error";
+  const existingWorkspaceHelpId = "project-automation-existing-workspace-help";
+  const existingWorkspaceErrorId = "project-automation-existing-workspace-error";
+  const targetTrunkHelpId = "project-automation-target-trunk-help";
+  const targetTrunkErrorId = "project-automation-target-trunk-error";
+  const targetBranchHelpId = "project-automation-target-branch-help";
+  const targetBranchErrorId = "project-automation-target-branch-error";
+  const intervalHelpId = "project-automation-interval-help";
+  const intervalErrorId = "project-automation-interval-error";
+  const argsHelpId = "project-automation-args-help";
+  const argsErrorId = "project-automation-args-error";
+  const getDescriptionIds = (...ids: Array<string | null>): string | undefined => {
+    const descriptionIds = ids.filter((id): id is string => id != null).join(" ");
+    return descriptionIds.length > 0 ? descriptionIds : undefined;
+  };
+  const getErrorMessageId = (message: string): string | undefined => {
+    if (message === workflowValidationError) return workflowErrorId;
+    if (message === targetTypeValidationError) return targetTypeErrorId;
+    if (message === targetValidationError) return existingWorkspaceErrorId;
+    if (message === targetTrunkValidationError) return targetTrunkErrorId;
+    if (message === targetBranchValidationError) return targetBranchErrorId;
+    if (message === intervalValidationError) return intervalErrorId;
+    if (message === argsParseResult.error) return argsErrorId;
+    return undefined;
+  };
+  const errorMessages = [
+    definitionsError,
+    saveError,
+    intervalValidationError,
+    workflowValidationError,
+    targetTypeValidationError,
+    targetValidationError,
+    targetTrunkValidationError,
+    targetBranchValidationError,
+    argsParseResult.error,
+  ].filter((message): message is string => message != null);
+  const hasBlockingError =
+    isSaving ||
+    api == null ||
+    definitionsPending ||
+    intervalValidationError != null ||
+    workflowValidationError != null ||
+    targetTypeValidationError != null ||
+    targetValidationError != null ||
+    targetTrunkValidationError != null ||
+    targetBranchValidationError != null ||
+    argsParseResult.error != null;
+
+  useEffect(() => {
+    if (!props.open) {
+      setMode("list");
+      setEditingSchedule(null);
+      return;
+    }
+
+    let ignore = false;
+    setDefinitionsLoading(true);
+    setDefinitionsLoaded(false);
+    setDefinitionsError(null);
+
+    void (async () => {
+      try {
+        const definitions = await api?.workflows.listDefinitions({
+          projectPath: props.projectPath,
+        });
+        if (ignore) return;
+        setWorkflowDefinitions(Array.isArray(definitions) ? definitions : []);
+        setDefinitionsLoaded(true);
+      } catch (error) {
+        if (ignore) return;
+        setWorkflowDefinitions([]);
+        setDefinitionsLoaded(true);
+        setDefinitionsError(getErrorMessage(error) || "Failed to load workflow definitions.");
+      } finally {
+        if (!ignore) {
+          setDefinitionsLoading(false);
+        }
+      }
+    })();
+
+    void (async () => {
+      try {
+        const result = await api?.projects.listBranches({ projectPath: props.projectPath });
+        if (ignore) return;
+        const recommended = result?.recommendedTrunk ?? result?.branches[0] ?? "main";
+        setRecommendedTrunk(recommended || "main");
+      } catch {
+        if (!ignore) {
+          setRecommendedTrunk("main");
+        }
+      }
+    })();
+
+    return () => {
+      ignore = true;
+    };
+  }, [api, props.open, props.projectPath]);
+
+  const editInitializationKey =
+    mode === "edit"
+      ? `${props.projectPath}:${editingSchedule != null ? getProjectAutomationRowKey(editingSchedule) : "new"}`
+      : null;
+
+  useEffect(() => {
+    if (mode !== "edit" || editInitializationKey == null) {
+      lastInitializedEditKeyRef.current = null;
+      return;
+    }
+    if (lastInitializedEditKeyRef.current === editInitializationKey) {
+      return;
+    }
+    lastInitializedEditKeyRef.current = editInitializationKey;
+
+    const schedule = editingSchedule ?? undefined;
+    const editingScheduleId = getProjectScheduleId(editingSchedule);
+    const firstAvailableWorkspaceId =
+      ownerWorkspaces.find(
+        (workspace) =>
+          workspace.id != null &&
+          !isWorkspaceArchived(workspace.archivedAt, workspace.unarchivedAt) &&
+          getExistingWorkspaceAutomationConflict({
+            projectConfig: props.projectConfig,
+            workspaceId: workspace.id,
+            editingScheduleId,
+          }) == null
+      )?.id ?? "";
+    setSaveError(null);
+    setDraftTitle(schedule?.title ?? "");
+    setDraftEnabled(schedule?.enabled ?? true);
+    setDraftWorkflowName(schedule?.workflowName ?? "");
+    setDraftIntervalMinutes(
+      formatWorkflowScheduleIntervalMinutes(
+        schedule?.intervalMs ?? WORKFLOW_SCHEDULE_DEFAULT_INTERVAL_MS
+      )
+    );
+    setDraftArgs(formatWorkflowArgs(schedule?.args));
+    setDraftContextMode(schedule?.contextMode ?? WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE);
+    setTargetTrunkTouched(false);
+    if (schedule?.target.type === "existing-workspace") {
+      setDraftTargetType("existing-workspace");
+      setDraftExistingWorkspaceId(schedule.target.workspaceId);
+      setDraftTargetBranchName("");
+      setDraftTargetTrunkBranch(recommendedTrunk);
+      setDraftTargetTitle("");
+    } else if (schedule?.target.type === "new-workspace" || newWorkspaceUnavailableReason == null) {
+      setDraftTargetType("new-workspace");
+      setDraftExistingWorkspaceId(firstAvailableWorkspaceId);
+      setDraftTargetBranchName(
+        schedule?.target.type === "new-workspace" ? (schedule.target.branchName ?? "") : ""
+      );
+      setDraftTargetTrunkBranch(
+        schedule?.target.type === "new-workspace" ? schedule.target.trunkBranch : recommendedTrunk
+      );
+      setDraftTargetTitle(
+        schedule?.target.type === "new-workspace" ? (schedule.target.title ?? "") : ""
+      );
+    } else {
+      setDraftTargetType("existing-workspace");
+      setDraftExistingWorkspaceId(firstAvailableWorkspaceId);
+      setDraftTargetBranchName("");
+      setDraftTargetTrunkBranch(recommendedTrunk);
+      setDraftTargetTitle("");
+    }
+  }, [
+    editInitializationKey,
+    editingSchedule,
+    mode,
+    newWorkspaceUnavailableReason,
+    ownerWorkspaces,
+    props.projectConfig,
+    recommendedTrunk,
+  ]);
+
+  useEffect(() => {
+    if (mode !== "edit" || editingSchedule != null || draftWorkflowName.length > 0) {
+      return;
+    }
+    if (firstExecutableWorkflowName.length > 0) {
+      setDraftWorkflowName(firstExecutableWorkflowName);
+    }
+  }, [draftWorkflowName, editingSchedule, firstExecutableWorkflowName, mode]);
+
+  useEffect(() => {
+    if (
+      mode !== "edit" ||
+      editingSchedule != null ||
+      draftTargetType !== "new-workspace" ||
+      targetTrunkTouched
+    ) {
+      return;
+    }
+    setDraftTargetTrunkBranch(recommendedTrunk);
+  }, [draftTargetType, editingSchedule, mode, recommendedTrunk, targetTrunkTouched]);
+
+  const handleEdit = (row: ProjectWorkflowSchedule) => {
+    setEditingSchedule(row);
+    setMode("edit");
+  };
+
+  const handleNew = () => {
+    setEditingSchedule(null);
+    setMode("edit");
+  };
+
+  const handleBackToList = () => {
+    setMode("list");
+    setEditingSchedule(null);
+    setSaveError(null);
+  };
+
+  const handleSave = async () => {
+    const parsedMinutes = parseWorkflowScheduleIntervalMinutes(draftIntervalMinutes);
+    assert(parsedMinutes != null, "Save should only run with a valid workflow schedule interval");
+    assert(argsParseResult.error == null, "Save should only run with valid workflow args JSON");
+    assert(draftWorkflowName.length > 0, "Save should only run with a selected workflow");
+    assert(
+      !draftEnabled || selectedWorkflowExecutable,
+      "Enabled automations require executable workflows"
+    );
+
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      if (api == null) {
+        throw new Error("Project automation settings are unavailable while disconnected.");
+      }
+
+      const projectSchedule = editingSchedule ?? undefined;
+      const shouldPersistContextMode =
+        draftTargetType === "existing-workspace" &&
+        draftContextMode !== WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE;
+      const schedule = {
+        ...(projectSchedule?.id ? { id: projectSchedule.id } : {}),
+        ...(draftTitle.trim().length > 0 ? { title: draftTitle.trim() } : {}),
+        enabled: draftEnabled,
+        workflowName: draftWorkflowName,
+        intervalMs: workflowScheduleIntervalMinutesToMs(parsedMinutes),
+        ...(argsParseResult.args ? { args: argsParseResult.args } : {}),
+        ...(shouldPersistContextMode ? { contextMode: draftContextMode } : {}),
+        target:
+          draftTargetType === "existing-workspace"
+            ? {
+                type: "existing-workspace" as const,
+                workspaceId: draftExistingWorkspaceId.trim(),
+              }
+            : {
+                type: "new-workspace" as const,
+                trunkBranch: draftTargetTrunkBranch.trim(),
+                ...(draftTargetBranchName.trim().length > 0
+                  ? { branchName: draftTargetBranchName.trim() }
+                  : {}),
+                ...(draftTargetTitle.trim().length > 0 ? { title: draftTargetTitle.trim() } : {}),
+              },
+      };
+
+      const result = await api.projects.workflowSchedules.set({
+        projectPath: props.projectPath,
+        schedule,
+      });
+      if (!result.success) {
+        throw new Error(result.error);
+      }
+      await refreshProjects();
+      handleBackToList();
+    } catch (error) {
+      setSaveError(getErrorMessage(error) || "Failed to save project automation.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleRunNow = async (row: ProjectWorkflowSchedule) => {
+    const unavailableReason = getWorkflowUnavailableReason({
+      workflowName: row.workflowName,
+      workflowDefinitions,
+      definitionsPending,
+    });
+    if (unavailableReason != null) {
+      setSaveError(`Cannot run automation: ${unavailableReason}`);
+      return;
+    }
+
+    const rowKey = getProjectAutomationRowKey(row);
+    setRunningScheduleKey(rowKey);
+    setSaveError(null);
+    try {
+      if (api == null) throw new Error("Project automation runner is unavailable.");
+      const result = await api.projects.workflowSchedules.run({
+        projectPath: props.projectPath,
+        scheduleId: row.id,
+      });
+      if (!result.success) throw new Error(result.error);
+      await refreshProjects();
+    } catch (error) {
+      setSaveError(getErrorMessage(error) || "Failed to run project automation.");
+    } finally {
+      setRunningScheduleKey((current) => (current === rowKey ? null : current));
+    }
+  };
+
+  const handleToggle = async (row: ProjectWorkflowSchedule, enabled: boolean) => {
+    if (enabled) {
+      const unavailableReason = getWorkflowUnavailableReason({
+        workflowName: row.workflowName,
+        workflowDefinitions,
+        definitionsPending,
+      });
+      if (unavailableReason != null) {
+        setSaveError(`Cannot enable automation: ${unavailableReason}`);
+        return;
+      }
+    }
+
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      if (api == null) throw new Error("Project automation settings are unavailable.");
+      const result = await api.projects.workflowSchedules.set({
+        projectPath: props.projectPath,
+        schedule: getEnabledScheduleInput(row, enabled),
+      });
+      if (!result.success) throw new Error(result.error);
+      await refreshProjects();
+    } catch (error) {
+      setSaveError(getErrorMessage(error) || "Failed to update project automation.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleRemove = async (row: ProjectWorkflowSchedule) => {
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      if (api == null) throw new Error("Project automation settings are unavailable.");
+      const result = await api.projects.workflowSchedules.remove({
+        projectPath: props.projectPath,
+        scheduleId: row.id,
+      });
+      if (!result.success) throw new Error(result.error);
+      await refreshProjects();
+    } catch (error) {
+      setSaveError(getErrorMessage(error) || "Failed to remove project automation.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent className="max-w-3xl" maxHeight="calc(100dvh - 2rem)">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <CalendarClock className="h-5 w-5" />
+            Automations for {props.projectName}
+          </DialogTitle>
+        </DialogHeader>
+
+        {mode === "list" ? (
+          <div className="space-y-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <p className="text-muted text-sm">
+                Configure project-level automations. Workspaces are resolved or created when each
+                automation runs.
+              </p>
+              <Button onClick={handleNew} disabled={isSaving || api == null}>
+                <Plus className="h-4 w-4" />
+                New automation
+              </Button>
+            </div>
+
+            {saveError && (
+              <div
+                className="bg-danger-soft/10 text-danger-soft rounded-md p-3 text-sm"
+                role="alert"
+              >
+                {saveError}
+              </div>
+            )}
+
+            {rows.length === 0 ? (
+              <div className="border-border text-muted rounded-lg border p-6 text-sm">
+                No automations configured for this project yet.
+              </div>
+            ) : (
+              <div className="border-border divide-border divide-y overflow-hidden rounded-lg border">
+                {rows.map((row) => {
+                  const rowKey = getProjectAutomationRowKey(row);
+                  const isRunningNow = runningScheduleKey === rowKey;
+                  const rowWorkflowUnavailableReason = getWorkflowUnavailableReason({
+                    workflowName: row.workflowName,
+                    workflowDefinitions,
+                    definitionsPending,
+                  });
+                  const canEnableRow = row.enabled || rowWorkflowUnavailableReason == null;
+                  return (
+                    <div key={rowKey} className="space-y-3 p-4">
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                        <div className="min-w-0 flex-1">
+                          <div className="text-foreground truncate text-sm font-medium">
+                            {getScheduleLabel(row)}
+                          </div>
+                          <div className="text-muted mt-1 text-xs">
+                            {row.workflowName} • every{" "}
+                            {formatWorkflowScheduleIntervalMinutes(row.intervalMs)} min •{" "}
+                            {getTargetLabel(row, workspacesById)}
+                          </div>
+                          {rowWorkflowUnavailableReason != null && (
+                            <div className="text-danger-soft mt-1 text-xs">
+                              {rowWorkflowUnavailableReason}
+                            </div>
+                          )}
+                          <div className="text-muted mt-1 text-xs">
+                            Last run: {formatLastRunStartedAt(row.lastRunStartedAt)}
+                          </div>
+                        </div>
+                        <div className="flex shrink-0 items-center gap-2">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => void handleRunNow(row)}
+                            disabled={
+                              isSaving ||
+                              isRunningNow ||
+                              api == null ||
+                              !row.enabled ||
+                              rowWorkflowUnavailableReason != null
+                            }
+                            aria-label={`Run ${getScheduleLabel(row)} now`}
+                          >
+                            {isRunningNow ? (
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : (
+                              <Play className="h-4 w-4" />
+                            )}
+                          </Button>
+                          <Switch
+                            checked={row.enabled}
+                            onCheckedChange={(checked) => void handleToggle(row, checked)}
+                            disabled={isSaving || api == null || !canEnableRow}
+                            aria-label={`Enable ${getScheduleLabel(row)}`}
+                          />
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handleEdit(row)}
+                            disabled={isSaving}
+                          >
+                            Edit
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => void handleRemove(row)}
+                            disabled={isSaving || api == null}
+                            aria-label={`Remove ${getScheduleLabel(row)}`}
+                          >
+                            <Trash className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <p className="text-muted text-sm">
+              The project owns this automation; the workspace target is resolved at run time.
+            </p>
+
+            <div className="border-border rounded-lg border p-4">
+              <div className="flex items-center justify-between gap-4">
+                <div className="min-w-0 flex-1">
+                  <div className="text-foreground text-sm font-medium">Enable automation</div>
+                  <div className="text-muted mt-1 text-xs">
+                    Keep this project automation eligible for recurring background workflow runs.
+                  </div>
+                </div>
+                <Switch
+                  checked={draftEnabled}
+                  onCheckedChange={setDraftEnabled}
+                  disabled={isSaving}
+                  aria-label="Enable project automation"
+                />
+              </div>
+
+              <div className="mt-4 space-y-2">
+                <label htmlFor="project-automation-title" className="block">
+                  <div className="text-foreground text-sm font-medium">Name</div>
+                  <div className="text-muted mt-1 text-xs">
+                    Optional display name for this automation.
+                  </div>
+                </label>
+                <Input
+                  id="project-automation-title"
+                  value={draftTitle}
+                  onInput={(event: React.FormEvent<HTMLInputElement>) => {
+                    setDraftTitle(event.currentTarget.value);
+                  }}
+                  disabled={isSaving}
+                  className="border-border-medium bg-background-secondary h-9 w-full"
+                  placeholder="GitHub issue triage"
+                  aria-label="Project automation name"
+                />
+              </div>
+
+              <div className="mt-4 space-y-2">
+                <label htmlFor="project-automation-workflow" className="block">
+                  <div className="text-foreground text-sm font-medium">Workflow</div>
+                  <div id={workflowHelpId} className="text-muted mt-1 text-xs">
+                    Only executable workflows can be enabled for automations.
+                  </div>
+                </label>
+                <div className="relative">
+                  <select
+                    id="project-automation-workflow"
+                    value={draftWorkflowName}
+                    onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
+                      setDraftWorkflowName(event.target.value);
+                    }}
+                    disabled={isSaving || definitionsPending}
+                    className="border-border-medium bg-background-secondary text-foreground focus:border-accent focus:ring-accent h-9 w-full min-w-0 rounded-md border px-3 text-sm focus:ring-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                    aria-label="Project automation workflow"
+                    aria-invalid={workflowValidationError != null}
+                    aria-describedby={getDescriptionIds(
+                      workflowHelpId,
+                      workflowValidationError ? workflowErrorId : null
+                    )}
+                  >
+                    {definitionsPending ? <option value="">Loading workflows…</option> : null}
+                    {!definitionsPending && selectedWorkflowMissing ? (
+                      <option value={draftWorkflowName}>{draftWorkflowName} (not found)</option>
+                    ) : null}
+                    {!definitionsPending && selectedWorkflowNonExecutable ? (
+                      <option value={draftWorkflowName} disabled>
+                        {draftWorkflowName} (
+                        {selectedWorkflowDefinition.blockedReason ?? "not executable"})
+                      </option>
+                    ) : null}
+                    {!definitionsPending &&
+                    executableWorkflowDefinitions.length === 0 &&
+                    !selectedWorkflowMissing &&
+                    !selectedWorkflowNonExecutable ? (
+                      <option value="">No executable workflows found</option>
+                    ) : null}
+                    {executableWorkflowDefinitions.map((workflow) => (
+                      <option key={`${workflow.scope}:${workflow.name}`} value={workflow.name}>
+                        {workflow.name} — {workflow.description}
+                      </option>
+                    ))}
+                  </select>
+                  {definitionsPending && (
+                    <Loader2 className="text-muted pointer-events-none absolute top-2.5 right-3 h-4 w-4 animate-spin" />
+                  )}
+                </div>
+              </div>
+
+              <div className="mt-4 space-y-2">
+                <label htmlFor="project-automation-target" className="block">
+                  <div className="text-foreground text-sm font-medium">Run target</div>
+                  <div id={targetTypeHelpId} className="text-muted mt-1 text-xs">
+                    Fresh-workspace automations create a new workspace for every due run.
+                  </div>
+                </label>
+                <select
+                  id="project-automation-target"
+                  value={draftTargetType}
+                  onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
+                    setDraftTargetType(event.target.value as ProjectAutomationTargetType);
+                  }}
+                  disabled={isSaving}
+                  className="border-border-medium bg-background-secondary text-foreground focus:border-accent focus:ring-accent h-9 w-full min-w-0 rounded-md border px-3 text-sm focus:ring-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                  aria-label="Project automation run target"
+                  aria-invalid={targetTypeValidationError != null}
+                  aria-describedby={getDescriptionIds(
+                    targetTypeHelpId,
+                    targetTypeValidationError ? targetTypeErrorId : null
+                  )}
+                >
+                  <option value="new-workspace" disabled={newWorkspaceUnavailableReason != null}>
+                    New workspace each run
+                  </option>
+                  <option value="existing-workspace">Existing workspace</option>
+                </select>
+              </div>
+
+              {draftTargetType === "existing-workspace" ? (
+                <div className="mt-3 space-y-2">
+                  <label htmlFor="project-automation-existing-workspace" className="block">
+                    <div className="text-foreground text-sm font-medium">Workspace</div>
+                    <div id={existingWorkspaceHelpId} className="text-muted mt-1 text-xs">
+                      Workspace used whenever this automation runs.
+                    </div>
+                  </label>
+                  <select
+                    id="project-automation-existing-workspace"
+                    value={draftExistingWorkspaceId}
+                    onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
+                      setDraftExistingWorkspaceId(event.target.value);
+                    }}
+                    disabled={isSaving}
+                    className="border-border-medium bg-background-secondary text-foreground focus:border-accent focus:ring-accent h-9 w-full min-w-0 rounded-md border px-3 text-sm focus:ring-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                    aria-label="Project automation existing workspace"
+                    aria-invalid={targetValidationError != null}
+                    aria-describedby={getDescriptionIds(
+                      existingWorkspaceHelpId,
+                      targetValidationError ? existingWorkspaceErrorId : null
+                    )}
+                  >
+                    {existingWorkspaceOptions.length === 0 ? (
+                      <option value="">No active workspaces without an automation</option>
+                    ) : null}
+                    {existingWorkspaceOptions.map((workspace) => (
+                      <option key={workspace.id} value={workspace.id}>
+                        {getWorkspaceLabel(workspace)}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              ) : (
+                <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                  <label htmlFor="project-automation-target-trunk" className="block min-w-0">
+                    <div className="text-foreground text-sm font-medium">Base branch</div>
+                    <div id={targetTrunkHelpId} className="text-muted mt-1 text-xs">
+                      Branch checked out before the automation starts.
+                    </div>
+                    <Input
+                      id="project-automation-target-trunk"
+                      value={draftTargetTrunkBranch}
+                      onInput={(event: React.FormEvent<HTMLInputElement>) => {
+                        setTargetTrunkTouched(true);
+                        setDraftTargetTrunkBranch(event.currentTarget.value);
+                      }}
+                      disabled={isSaving}
+                      className="border-border-medium bg-background-secondary mt-2 h-9 w-full"
+                      placeholder="main"
+                      aria-label="Project automation base branch"
+                      aria-invalid={targetTrunkValidationError != null}
+                      aria-describedby={getDescriptionIds(
+                        targetTrunkHelpId,
+                        targetTrunkValidationError ? targetTrunkErrorId : null
+                      )}
+                    />
+                  </label>
+                  <label htmlFor="project-automation-target-branch" className="block min-w-0">
+                    <div className="text-foreground text-sm font-medium">New branch name</div>
+                    <div id={targetBranchHelpId} className="text-muted mt-1 text-xs">
+                      Optional base name; collisions may receive a suffix.
+                    </div>
+                    <Input
+                      id="project-automation-target-branch"
+                      value={draftTargetBranchName}
+                      onInput={(event: React.FormEvent<HTMLInputElement>) => {
+                        setDraftTargetBranchName(event.currentTarget.value);
+                      }}
+                      disabled={isSaving}
+                      className="border-border-medium bg-background-secondary mt-2 h-9 w-full"
+                      placeholder="scheduled-run"
+                      aria-label="Project automation new branch name"
+                      aria-invalid={targetBranchValidationError != null}
+                      aria-describedby={getDescriptionIds(
+                        targetBranchHelpId,
+                        targetBranchValidationError ? targetBranchErrorId : null
+                      )}
+                    />
+                  </label>
+                  <label
+                    htmlFor="project-automation-target-title"
+                    className="block min-w-0 sm:col-span-2"
+                  >
+                    <div className="text-foreground text-sm font-medium">New workspace title</div>
+                    <div className="text-muted mt-1 text-xs">
+                      Optional title applied to each created run workspace.
+                    </div>
+                    <Input
+                      id="project-automation-target-title"
+                      value={draftTargetTitle}
+                      onInput={(event: React.FormEvent<HTMLInputElement>) => {
+                        setDraftTargetTitle(event.currentTarget.value);
+                      }}
+                      disabled={isSaving}
+                      className="border-border-medium bg-background-secondary mt-2 h-9 w-full"
+                      placeholder="Automation run"
+                      aria-label="Project automation new workspace title"
+                    />
+                  </label>
+                </div>
+              )}
+
+              {draftTargetType === "existing-workspace" && (
+                <div className="mt-4 space-y-2">
+                  <label htmlFor="project-automation-context-mode" className="block">
+                    <div className="text-foreground text-sm font-medium">Context before run</div>
+                    <div className="text-muted mt-1 text-xs">
+                      Applied before running in the selected workspace.
+                    </div>
+                  </label>
+                  <select
+                    id="project-automation-context-mode"
+                    value={draftContextMode}
+                    onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
+                      setDraftContextMode(event.target.value as WorkflowScheduleContextMode);
+                    }}
+                    disabled={isSaving}
+                    className="border-border-medium bg-background-secondary text-foreground focus:border-accent focus:ring-accent h-9 w-full min-w-0 rounded-md border px-3 text-sm focus:ring-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                    aria-label="Project automation context mode"
+                  >
+                    <option value="normal">Keep existing context</option>
+                    <option value="reset">Soft reset context</option>
+                    <option value="compact">Compact context first</option>
+                  </select>
+                </div>
+              )}
+
+              <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <label htmlFor="project-automation-interval" className="min-w-0 flex-1">
+                  <div className="text-foreground text-sm font-medium">Interval</div>
+                  <div id={intervalHelpId} className="text-muted mt-1 text-xs">
+                    Valid range: {WORKFLOW_SCHEDULE_MIN_INTERVAL_MINUTES}–
+                    {WORKFLOW_SCHEDULE_MAX_INTERVAL_MINUTES} minutes. New automations default to{" "}
+                    {WORKFLOW_SCHEDULE_DEFAULT_INTERVAL_MINUTES} minutes.
+                  </div>
+                </label>
+                <div className="flex items-center gap-2 self-start sm:self-auto">
+                  <Input
+                    id="project-automation-interval"
+                    type="number"
+                    inputMode="numeric"
+                    min={WORKFLOW_SCHEDULE_MIN_INTERVAL_MINUTES}
+                    max={WORKFLOW_SCHEDULE_MAX_INTERVAL_MINUTES}
+                    step={1}
+                    value={draftIntervalMinutes}
+                    onInput={(event: React.FormEvent<HTMLInputElement>) => {
+                      setDraftIntervalMinutes(event.currentTarget.value);
+                    }}
+                    disabled={isSaving}
+                    className="border-border-medium bg-background-secondary h-9 w-24 text-right"
+                    aria-label="Project automation interval in minutes"
+                    aria-invalid={intervalValidationError != null}
+                    aria-describedby={getDescriptionIds(
+                      intervalHelpId,
+                      intervalValidationError ? intervalErrorId : null
+                    )}
+                  />
+                  <span className="text-muted text-sm">min</span>
+                </div>
+              </div>
+
+              <div className="mt-4 space-y-2">
+                <label htmlFor="project-automation-args" className="block">
+                  <div className="text-foreground text-sm font-medium">Args</div>
+                  <div id={argsHelpId} className="text-muted mt-1 text-xs">
+                    Optional JSON object passed to the workflow run.
+                  </div>
+                </label>
+                <textarea
+                  id="project-automation-args"
+                  rows={5}
+                  value={draftArgs}
+                  onInput={(event: React.FormEvent<HTMLTextAreaElement>) => {
+                    setDraftArgs(event.currentTarget.value);
+                  }}
+                  disabled={isSaving}
+                  className="border-border-medium bg-background-secondary text-foreground focus:border-accent focus:ring-accent min-h-[120px] w-full resize-y rounded-md border p-3 text-sm leading-relaxed focus:ring-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                  placeholder={'{\n  "label": "needs-triage"\n}'}
+                  aria-label="Project automation args"
+                  aria-invalid={argsParseResult.error != null}
+                  aria-describedby={getDescriptionIds(
+                    argsHelpId,
+                    argsParseResult.error ? argsErrorId : null
+                  )}
+                />
+              </div>
+            </div>
+
+            {errorMessages.length > 0 && (
+              <div
+                className="bg-danger-soft/10 text-danger-soft space-y-1 rounded-md p-3 text-sm"
+                role="alert"
+              >
+                {errorMessages.map((message) => (
+                  <p key={message} id={getErrorMessageId(message)}>
+                    {message}
+                  </p>
+                ))}
+              </div>
+            )}
+
+            <div className="flex justify-end gap-2">
+              <Button variant="ghost" onClick={handleBackToList} disabled={isSaving}>
+                Back
+              </Button>
+              <Button onClick={() => void handleSave()} disabled={hasBlockingError}>
+                {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                Save
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/browser/components/ProjectAutomationsModal/ProjectAutomationsModal.tsx
+++ b/src/browser/components/ProjectAutomationsModal/ProjectAutomationsModal.tsx
@@ -129,16 +129,6 @@ function getTargetLabel(
   return `Existing workspace: ${getWorkspaceLabel(workspacesById.get(target.workspaceId))}`;
 }
 
-function getNewWorkspaceAutomationUnavailableReason(input: {
-  projectPath: string;
-  workspaces: Workspace[];
-}): string | null {
-  return getSupportedWorkflowScheduleNewWorkspaceTemplate({
-    sourceProjectPath: input.projectPath,
-    workspaces: input.workspaces,
-  }).unavailableReason;
-}
-
 function getWorkflowUnavailableReason(input: {
   workflowName: string;
   workflowDefinitions: WorkflowDefinitionDescriptor[];
@@ -257,10 +247,15 @@ export function ProjectAutomationsModal(props: ProjectAutomationsModalProps) {
   const argsParseResult = parseWorkflowArgs(draftArgs);
   const intervalValidationError = getWorkflowScheduleIntervalValidationError(draftIntervalMinutes);
   const editingScheduleId = getProjectScheduleId(editingSchedule);
-  const newWorkspaceUnavailableReason = getNewWorkspaceAutomationUnavailableReason({
-    projectPath: props.projectPath,
+  const newWorkspaceSupport = getSupportedWorkflowScheduleNewWorkspaceTemplate({
+    sourceProjectPath: props.projectPath,
     workspaces: ownerWorkspaces,
   });
+  const newWorkspaceUnavailableReason = newWorkspaceSupport.unavailableReason;
+  const definitionDiscoveryWorkspaceId =
+    draftTargetType === "existing-workspace" && draftExistingWorkspaceId.trim().length > 0
+      ? draftExistingWorkspaceId.trim()
+      : (newWorkspaceSupport.workspace?.id ?? activeWorkspaces[0]?.id);
   const existingWorkspaceConflict =
     draftTargetType === "existing-workspace" &&
     hasExistingWorkspaceAutomationConflict({
@@ -380,9 +375,11 @@ export function ProjectAutomationsModal(props: ProjectAutomationsModalProps) {
 
     void (async () => {
       try {
-        const definitions = await api?.workflows.listDefinitions({
-          projectPath: props.projectPath,
-        });
+        const definitions = await api?.workflows.listDefinitions(
+          definitionDiscoveryWorkspaceId != null
+            ? { workspaceId: definitionDiscoveryWorkspaceId, projectPath: props.projectPath }
+            : { projectPath: props.projectPath }
+        );
         if (ignore) return;
         setWorkflowDefinitions(Array.isArray(definitions) ? definitions : []);
         setDefinitionsLoaded(true);
@@ -414,7 +411,7 @@ export function ProjectAutomationsModal(props: ProjectAutomationsModalProps) {
     return () => {
       ignore = true;
     };
-  }, [api, props.open, props.projectPath]);
+  }, [api, definitionDiscoveryWorkspaceId, props.open, props.projectPath]);
 
   const editInitializationKey =
     mode === "edit"

--- a/src/browser/components/ProjectAutomationsModal/ProjectAutomationsModal.tsx
+++ b/src/browser/components/ProjectAutomationsModal/ProjectAutomationsModal.tsx
@@ -91,21 +91,29 @@ function getProjectScheduleId(schedule: ProjectWorkflowSchedule | null): string 
   return scheduleId != null && scheduleId.length > 0 ? scheduleId : null;
 }
 
-function getExistingWorkspaceAutomationConflict(input: {
-  projectConfig: ProjectConfig;
+function hasExistingWorkspaceAutomationConflict(input: {
+  workflowSchedules: readonly ProjectWorkflowSchedule[];
+  workspaces: readonly Workspace[];
   workspaceId: string;
   editingScheduleId: string | null;
-}): ProjectWorkflowSchedule | undefined {
+}): boolean {
   const workspaceId = input.workspaceId.trim();
   if (workspaceId.length === 0) {
-    return undefined;
+    return false;
   }
 
-  return (input.projectConfig.workflowSchedules ?? []).find(
+  const conflictingProjectSchedule = input.workflowSchedules.some(
     (schedule) =>
       schedule.id !== input.editingScheduleId &&
       schedule.target.type === "existing-workspace" &&
       schedule.target.workspaceId === workspaceId
+  );
+  if (conflictingProjectSchedule) {
+    return true;
+  }
+
+  return input.workspaces.some(
+    (workspace) => workspace.id === workspaceId && workspace.workflowSchedule != null
   );
 }
 
@@ -173,7 +181,7 @@ function getEnabledScheduleInput(
 
 export function ProjectAutomationsModal(props: ProjectAutomationsModalProps) {
   const { api } = useAPI();
-  const { getProjectConfig, refreshProjects } = useProjectContext();
+  const { getProjectConfig, refreshProjects, userProjects } = useProjectContext();
   const rows = props.projectConfig.workflowSchedules ?? [];
   const ownerProjectPath = props.projectConfig.parentProjectPath ?? props.projectPath;
   const ownerProjectConfig =
@@ -189,6 +197,14 @@ export function ProjectAutomationsModal(props: ProjectAutomationsModalProps) {
     ownerWorkspaces
       .filter((workspace) => workspace.id != null)
       .map((workspace) => [workspace.id!, workspace])
+  );
+  const projectScheduleSources =
+    userProjects.size > 0 ? userProjects : new Map([[props.projectPath, props.projectConfig]]);
+  const ownerProjectWorkflowSchedules = Array.from(projectScheduleSources.entries()).flatMap(
+    ([projectPath, projectConfig]) => {
+      const projectOwnerPath = projectConfig.parentProjectPath ?? projectPath;
+      return projectOwnerPath === ownerProjectPath ? (projectConfig.workflowSchedules ?? []) : [];
+    }
   );
   const [mode, setMode] = useState<"list" | "edit">("list");
   const [editingSchedule, setEditingSchedule] = useState<ProjectWorkflowSchedule | null>(null);
@@ -246,24 +262,34 @@ export function ProjectAutomationsModal(props: ProjectAutomationsModalProps) {
     workspaces: ownerWorkspaces,
   });
   const existingWorkspaceConflict =
-    draftTargetType === "existing-workspace"
-      ? getExistingWorkspaceAutomationConflict({
-          projectConfig: props.projectConfig,
-          workspaceId: draftExistingWorkspaceId,
-          editingScheduleId,
-        })
-      : undefined;
+    draftTargetType === "existing-workspace" &&
+    hasExistingWorkspaceAutomationConflict({
+      workflowSchedules: ownerProjectWorkflowSchedules,
+      workspaces: ownerWorkspaces,
+      workspaceId: draftExistingWorkspaceId,
+      editingScheduleId,
+    });
   const existingWorkspaceOptions = activeWorkspaces.filter((workspace) => {
     if (workspace.id == null) return false;
     if (workspace.id === draftExistingWorkspaceId) return true;
-    return (
-      getExistingWorkspaceAutomationConflict({
-        projectConfig: props.projectConfig,
-        workspaceId: workspace.id,
-        editingScheduleId,
-      }) == null
-    );
+    return !hasExistingWorkspaceAutomationConflict({
+      workflowSchedules: ownerProjectWorkflowSchedules,
+      workspaces: ownerWorkspaces,
+      workspaceId: workspace.id,
+      editingScheduleId,
+    });
   });
+  const firstAvailableWorkspaceId =
+    activeWorkspaces.find(
+      (workspace) =>
+        workspace.id != null &&
+        !hasExistingWorkspaceAutomationConflict({
+          workflowSchedules: ownerProjectWorkflowSchedules,
+          workspaces: ownerWorkspaces,
+          workspaceId: workspace.id,
+          editingScheduleId,
+        })
+    )?.id ?? "";
   const workflowValidationError = definitionsPending
     ? null
     : draftWorkflowName.length === 0
@@ -278,7 +304,7 @@ export function ProjectAutomationsModal(props: ProjectAutomationsModalProps) {
       ? null
       : draftExistingWorkspaceId.trim().length === 0
         ? "Choose an existing workspace or use a fresh workspace target."
-        : existingWorkspaceConflict != null
+        : existingWorkspaceConflict
           ? `${getWorkspaceLabel(workspacesById.get(draftExistingWorkspaceId))} already has an automation.`
           : null;
   const targetTrunkValidationError =
@@ -406,18 +432,6 @@ export function ProjectAutomationsModal(props: ProjectAutomationsModalProps) {
     lastInitializedEditKeyRef.current = editInitializationKey;
 
     const schedule = editingSchedule ?? undefined;
-    const editingScheduleId = getProjectScheduleId(editingSchedule);
-    const firstAvailableWorkspaceId =
-      ownerWorkspaces.find(
-        (workspace) =>
-          workspace.id != null &&
-          !isWorkspaceArchived(workspace.archivedAt, workspace.unarchivedAt) &&
-          getExistingWorkspaceAutomationConflict({
-            projectConfig: props.projectConfig,
-            workspaceId: workspace.id,
-            editingScheduleId,
-          }) == null
-      )?.id ?? "";
     setSaveError(null);
     setDraftTitle(schedule?.title ?? "");
     setDraftEnabled(schedule?.enabled ?? true);
@@ -458,10 +472,9 @@ export function ProjectAutomationsModal(props: ProjectAutomationsModalProps) {
   }, [
     editInitializationKey,
     editingSchedule,
+    firstAvailableWorkspaceId,
     mode,
     newWorkspaceUnavailableReason,
-    ownerWorkspaces,
-    props.projectConfig,
     recommendedTrunk,
   ]);
 

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.stories.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.stories.tsx
@@ -78,6 +78,87 @@ export const ProjectRemovalDisabled: AppStory = {
   },
 };
 
+export const ProjectAutomations: AppStory = {
+  parameters: {
+    chromatic: { modes: CHROMATIC_SMOKE_MODES },
+  },
+  render: () => (
+    <AppWithMocks
+      setup={() => {
+        localStorage.setItem("experiment:dynamic-workflows", "true");
+        const workspaces = [
+          createWorkspace({ id: "ws-1", name: "main", projectName: "my-app", title: "Main" }),
+          createWorkspace({
+            id: "ws-2",
+            name: "feature/auth",
+            projectName: "my-app",
+            title: "Auth feature",
+          }),
+        ];
+        expandProjects([PROJECT_PATH]);
+        const projects = groupWorkspacesByProject(workspaces);
+        const project = projects.get(PROJECT_PATH);
+        if (project == null) throw new Error("ProjectAutomations story requires a project");
+        project.workflowSchedules = [
+          {
+            id: "security-scan",
+            title: "Security Scan",
+            enabled: true,
+            workflowName: "triage-github-issues",
+            intervalMs: 15 * 60_000,
+            target: { type: "new-workspace", trunkBranch: "main" },
+          },
+        ];
+        return createMockORPCClient({
+          projects,
+          workspaces,
+          workflowDefinitions: [
+            {
+              name: "triage-github-issues",
+              description: "Scan untriaged GitHub issues.",
+              scope: "project",
+              sourcePath: `${PROJECT_PATH}/.mux/workflows/triage-github-issues.js`,
+              executable: true,
+            },
+          ],
+        });
+      }}
+    />
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const projectOptionsButton = await waitFor(() => {
+      const button = canvasElement.querySelector<HTMLButtonElement>(
+        'button[aria-label="Project options for my-app"]'
+      );
+      if (!button) throw new Error("Project options button not found");
+      return button;
+    });
+
+    await fireEvent.click(projectOptionsButton);
+
+    const automationsMenuItem = await waitFor(() => {
+      const button = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find(
+        (candidate) => candidate.textContent?.trim().startsWith("Automations...") === true
+      );
+      if (!button) throw new Error("Automations menu item not found");
+      return button;
+    });
+
+    await userEvent.click(automationsMenuItem);
+
+    await waitFor(() => {
+      const runNowButton = document.querySelector<HTMLButtonElement>(
+        'button[aria-label="Run Security Scan now"]'
+      );
+      if (!runNowButton) throw new Error("Run-now button not found");
+      const newAutomationButton = Array.from(
+        document.querySelectorAll<HTMLButtonElement>("button")
+      ).find((candidate) => candidate.textContent?.trim() === "New automation");
+      if (!newAutomationButton) throw new Error("New automation button not found");
+    });
+  },
+};
+
 // Phase 1 visual contract: a variant group nested inside a sub-agent tree must
 // keep continuous connector rails through the group header (no gap above/below),
 // and expanded members render label-only rows ("frontend", "backend").

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
@@ -36,6 +36,7 @@ import * as PopoverErrorModule from "../PopoverError/PopoverError";
 import * as SectionHeaderModule from "../SectionHeader/SectionHeader";
 import * as WorkspaceSectionDropZoneModule from "../WorkspaceSectionDropZone/WorkspaceSectionDropZone";
 import * as WorkspaceDragLayerModule from "../WorkspaceDragLayer/WorkspaceDragLayer";
+import { KEYBINDS, formatKeybind } from "@/browser/utils/ui/keybinds";
 import { updatePersistedState } from "@/browser/hooks/usePersistedState";
 import type ProjectSidebarComponent from "./ProjectSidebar";
 import type * as WorkspaceStatusIndicatorModuleExports from "../WorkspaceStatusIndicator/WorkspaceStatusIndicator";
@@ -142,6 +143,11 @@ let latestArchiveConfirmationModalProps: {
   confirmLabel?: string;
   onConfirm: () => void | Promise<void>;
   onCancel: () => void;
+} | null = null;
+let latestProjectAutomationsModalProps: {
+  open: boolean;
+  projectPath: string;
+  projectName: string;
 } | null = null;
 let preflightArchiveWorkspaceMock = mock(
   (_workspaceId: string): Promise<ArchivePreflightActionResult> => resolveArchivePreflight()
@@ -281,6 +287,7 @@ function installProjectSidebarTestDoubles() {
   confirmDialogMock = mock(() => Promise.resolve(true));
   latestArchiveWorkspaceHandler = null;
   latestArchiveConfirmationModalProps = null;
+  latestProjectAutomationsModalProps = null;
   void mock.module("@/browser/assets/logos/mux-logo-dark.svg?react", () => ({
     __esModule: true,
     default: () => <svg data-testid="mux-logo-dark" />,
@@ -623,11 +630,25 @@ function installProjectSidebarTestDoubles() {
   spyOn(WorkspaceDragLayerModule, "WorkspaceDragLayer").mockImplementation(
     (() => null) as unknown as typeof WorkspaceDragLayerModule.WorkspaceDragLayer
   );
+  void mock.module("@/browser/components/ProjectAutomationsModal/ProjectAutomationsModal", () => ({
+    ProjectAutomationsModal: (props: {
+      open: boolean;
+      projectPath: string;
+      projectName: string;
+      onOpenChange: (open: boolean) => void;
+    }) => {
+      latestProjectAutomationsModalProps = props;
+      return props.open ? (
+        <div data-testid="project-automations-modal">{props.projectName}</div>
+      ) : null;
+    },
+  }));
   void mock.module("../PositionedMenu/PositionedMenu", () => ({
     PositionedMenu: (props: { open: boolean; children: React.ReactNode }) =>
       props.open ? <div data-testid="project-actions-menu">{props.children}</div> : null,
     PositionedMenuItem: (props: {
       label: string;
+      shortcut?: string;
       disabled?: boolean;
       onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
     }) => (
@@ -639,6 +660,7 @@ function installProjectSidebarTestDoubles() {
         }}
       >
         {props.label}
+        {props.shortcut ? `(${props.shortcut})` : null}
       </button>
     ),
   }));
@@ -657,6 +679,7 @@ function createWorkspace(
     title?: string;
     bestOf?: FrontendWorkspaceMetadata["bestOf"];
     workflowTask?: FrontendWorkspaceMetadata["workflowTask"];
+    subProjectPath?: string;
   }
 ): FrontendWorkspaceMetadata {
   return {
@@ -670,6 +693,7 @@ function createWorkspace(
       { projectPath: "/projects/other-project", projectName: "other-project" },
     ],
     namedWorkspacePath: `/projects/demo-project/${id}`,
+    subProjectPath: opts?.subProjectPath,
     runtimeConfig: DEFAULT_RUNTIME_CONFIG,
     parentWorkspaceId: opts?.parentWorkspaceId,
     taskStatus: opts?.taskStatus,
@@ -1991,10 +2015,71 @@ describe("ProjectSidebar project actions menu", () => {
     expect(menuButtons.map((button) => button.textContent)).toEqual([
       "Edit name",
       "Add sub-project",
+      `Automations...(${formatKeybind(KEYBINDS.CONFIGURE_PROJECT_AUTOMATIONS)})`,
       "Manage secrets",
       "Change color",
       "Delete...",
     ]);
+  });
+
+  test("opens project automations from the keyboard shortcut", () => {
+    const view = renderSidebar();
+
+    fireEvent.keyDown(window, {
+      key: KEYBINDS.CONFIGURE_PROJECT_AUTOMATIONS.key,
+      ctrlKey: true,
+      altKey: true,
+    });
+
+    expect(view.getByTestId("project-automations-modal").textContent).toBe("demo-project");
+    expect(latestProjectAutomationsModalProps?.projectPath).toBe(demoProjectPath);
+  });
+
+  test("opens sub-project automations from the keyboard shortcut when the selected workspace is scoped", () => {
+    const subProjectPath = `${demoProjectPath}/packages/api`;
+    const workspace = createWorkspace("ws-sub", { subProjectPath });
+    projectContextValue = createProjectContextValue({
+      userProjects: new Map([
+        [demoProjectPath, { workspaces: [{ path: workspace.namedWorkspacePath, subProjectPath }] }],
+        [subProjectPath, { parentProjectPath: demoProjectPath, workspaces: [] }],
+      ]),
+    });
+    spyOn(WorkspaceContextModule, "useWorkspaceActions").mockImplementation(
+      () =>
+        ({
+          selectedWorkspace: { workspaceId: workspace.id, projectPath: demoProjectPath },
+          setSelectedWorkspace: () => undefined,
+          preflightArchiveWorkspace: preflightArchiveWorkspaceMock,
+          archiveWorkspace: archiveWorkspaceActionMock,
+          removeWorkspace: () => Promise.resolve({ success: true }),
+          updateWorkspaceTitle: () => Promise.resolve({ success: true }),
+          refreshWorkspaceMetadata: () => Promise.resolve(),
+          pendingNewWorkspaceProject: null,
+          pendingNewWorkspaceDraftId: null,
+          workspaceDraftsByProject: {},
+          workspaceDraftPromotionsByProject: {},
+          createWorkspaceDraft: () => undefined,
+          openWorkspaceDraft: () => undefined,
+          deleteWorkspaceDraft: () => undefined,
+        }) as unknown as ReturnType<typeof WorkspaceContextModule.useWorkspaceActions>
+    );
+    const view = render(
+      <ProjectSidebar
+        collapsed={false}
+        onToggleCollapsed={() => undefined}
+        sortedWorkspacesByProject={new Map([[demoProjectPath, [workspace]]])}
+        workspaceRecency={{}}
+      />
+    );
+
+    fireEvent.keyDown(window, {
+      key: KEYBINDS.CONFIGURE_PROJECT_AUTOMATIONS.key,
+      ctrlKey: true,
+      altKey: true,
+    });
+
+    expect(view.getByTestId("project-automations-modal").textContent).toBe("api");
+    expect(latestProjectAutomationsModalProps?.projectPath).toBe(subProjectPath);
   });
 
   test("opens the same project actions menu on right-click", () => {

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
@@ -35,6 +35,7 @@ import { PROJECT_ORDER_KEY } from "@/common/constants/storage";
 import {
   matchesKeybind,
   formatKeybind,
+  isDialogOpen,
   isEditableElement,
   KEYBINDS,
 } from "@/browser/utils/ui/keybinds";
@@ -101,6 +102,7 @@ import {
   PositionedMenuItem,
 } from "@/browser/components/PositionedMenu/PositionedMenu";
 import {
+  CalendarClock,
   ChevronRight,
   EllipsisVertical,
   Folder,
@@ -128,6 +130,7 @@ import { MULTI_PROJECT_SIDEBAR_SECTION_ID } from "@/common/constants/multiProjec
 import { getProjectWorkspaceCounts } from "@/common/utils/projectRemoval";
 import { useExperimentValue } from "@/browser/hooks/useExperiments";
 import { EXPERIMENT_IDS } from "@/common/constants/experiments";
+import { ProjectAutomationsModal } from "@/browser/components/ProjectAutomationsModal/ProjectAutomationsModal";
 import { HexColorPicker } from "react-colorful";
 import { resolveSectionColor, SECTION_COLOR_PALETTE } from "@/common/constants/ui";
 
@@ -735,6 +738,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
   // Theme for logo variant
   const { theme } = useTheme();
   const MuxLogo = theme === "dark" || theme.endsWith("-dark") ? MuxLogoDark : MuxLogoLight;
+  const dynamicWorkflowsEnabled = useExperimentValue(EXPERIMENT_IDS.DYNAMIC_WORKFLOWS);
   const multiProjectWorkspacesEnabled = useExperimentValue(EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES);
 
   // Mobile breakpoint for auto-closing sidebar
@@ -958,6 +962,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
 
   const projectContextMenu = useContextMenuPosition({ longPress: true });
   const [projectMenuTargetPath, setProjectMenuTargetPath] = useState<string | null>(null);
+  const [automationsProjectPath, setAutomationsProjectPath] = useState<string | null>(null);
   const [editingProjectPath, setEditingProjectPath] = useState<string | null>(null);
   const [editingProjectDisplayName, setEditingProjectDisplayName] = useState("");
   const [autoEditingSection, setAutoEditingSection] = useState<{
@@ -1520,6 +1525,15 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
     closeProjectContextMenu();
   }, [closeProjectContextMenu, projectMenuTargetPath, userProjects]);
 
+  const handleProjectMenuAutomations = useCallback(() => {
+    if (!projectMenuTargetPath) {
+      return;
+    }
+
+    setAutomationsProjectPath(projectMenuTargetPath);
+    closeProjectContextMenu();
+  }, [closeProjectContextMenu, projectMenuTargetPath]);
+
   const handleProjectMenuManageSecrets = useCallback(() => {
     if (!projectMenuTargetPath) {
       return;
@@ -1704,9 +1718,47 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
 
   const hasProjectMenuTarget = projectMenuTargetPath !== null;
 
+  const automationsProjectConfig = automationsProjectPath
+    ? (userProjects.get(automationsProjectPath) ?? null)
+    : null;
+
   // Handle keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (dynamicWorkflowsEnabled && matchesKeybind(e, KEYBINDS.CONFIGURE_PROJECT_AUTOMATIONS)) {
+        if (e.defaultPrevented || isDialogOpen() || isEditableElement(e.target)) {
+          return;
+        }
+
+        let selectedProjectPath: string | undefined;
+        if (selectedWorkspace != null) {
+          const parentProjectPath = selectedWorkspace.projectPath;
+          const projectWorkspaces = sortedWorkspacesByProject.get(parentProjectPath) ?? [];
+          const byId = new Map(projectWorkspaces.map((m) => [m.id, m]));
+          const meta = byId.get(selectedWorkspace.workspaceId);
+          const validSectionIds = new Set(
+            getSubProjectsForParent(parentProjectPath, userProjects).map(([subPath]) => subPath)
+          );
+          selectedProjectPath = meta
+            ? (resolveEffectiveSectionId(meta, byId, validSectionIds) ?? parentProjectPath)
+            : parentProjectPath;
+        }
+        const targetProjectPath =
+          selectedProjectPath != null && userProjects.has(selectedProjectPath)
+            ? selectedProjectPath
+            : userProjects.size === 1
+              ? Array.from(userProjects.keys())[0]
+              : undefined;
+        if (targetProjectPath == null) {
+          return;
+        }
+
+        e.preventDefault();
+        closeProjectContextMenu();
+        setAutomationsProjectPath(targetProjectPath);
+        return;
+      }
+
       // Sub-project workspaces share the parent worktree, so recover the child
       // target from the live sidebar metadata before opening a sibling draft.
       if (matchesKeybind(e, KEYBINDS.NEW_WORKSPACE) && selectedWorkspace) {
@@ -1738,6 +1790,8 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [
+    closeProjectContextMenu,
+    dynamicWorkflowsEnabled,
     selectedWorkspace,
     handleAddWorkspace,
     handleArchiveWorkspace,
@@ -2879,6 +2933,17 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                 handleProjectMenuAddSubFolder();
               }}
             />
+            {dynamicWorkflowsEnabled && (
+              <PositionedMenuItem
+                icon={<CalendarClock className="h-4 w-4 shrink-0" strokeWidth={1.8} />}
+                label="Automations..."
+                shortcut={formatKeybind(KEYBINDS.CONFIGURE_PROJECT_AUTOMATIONS)}
+                disabled={!hasProjectMenuTarget}
+                onClick={() => {
+                  handleProjectMenuAutomations();
+                }}
+              />
+            )}
             <PositionedMenuItem
               icon={<KeyRound className="h-4 w-4 shrink-0" strokeWidth={1.8} />}
               label="Manage secrets"
@@ -2956,6 +3021,20 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
               }}
             />
           </PositionedMenu>
+
+          {dynamicWorkflowsEnabled && automationsProjectPath && automationsProjectConfig && (
+            <ProjectAutomationsModal
+              open={true}
+              projectPath={automationsProjectPath}
+              projectName={getProjectDisplayName(automationsProjectPath, automationsProjectConfig)}
+              projectConfig={automationsProjectConfig}
+              onOpenChange={(open) => {
+                if (!open) {
+                  setAutomationsProjectPath(null);
+                }
+              }}
+            />
+          )}
 
           <ConfirmationModal
             isOpen={archiveConfirmation !== null}

--- a/src/browser/components/WorkspaceActionsMenuContent/WorkspaceActionsMenuContent.test.tsx
+++ b/src/browser/components/WorkspaceActionsMenuContent/WorkspaceActionsMenuContent.test.tsx
@@ -1,0 +1,43 @@
+import "../../../../tests/ui/dom";
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { installDom } from "../../../../tests/ui/dom";
+
+import { formatKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
+import { WorkspaceActionsMenuContent } from "./WorkspaceActionsMenuContent";
+
+let cleanupDom: (() => void) | null = null;
+
+describe("WorkspaceActionsMenuContent", () => {
+  beforeEach(() => {
+    cleanupDom = installDom();
+  });
+
+  afterEach(() => {
+    cleanup();
+    cleanupDom?.();
+    cleanupDom = null;
+  });
+
+  test("opens automation settings as a workspace action", () => {
+    const onConfigureAutomation = mock(() => undefined);
+    const onCloseMenu = mock(() => undefined);
+    const view = render(
+      <WorkspaceActionsMenuContent
+        onConfigureAutomation={onConfigureAutomation}
+        onCloseMenu={onCloseMenu}
+        linkSharingEnabled={false}
+      />
+    );
+
+    expect(view.getByRole("button", { name: /Automations/ }).textContent).toContain(
+      formatKeybind(KEYBINDS.CONFIGURE_SCHEDULED_WORKFLOW)
+    );
+
+    fireEvent.click(view.getByRole("button", { name: /Automations/ }));
+
+    expect(onCloseMenu).toHaveBeenCalledTimes(1);
+    expect(onConfigureAutomation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/browser/components/WorkspaceActionsMenuContent/WorkspaceActionsMenuContent.tsx
+++ b/src/browser/components/WorkspaceActionsMenuContent/WorkspaceActionsMenuContent.tsx
@@ -1,6 +1,15 @@
 import { formatKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
 import { ArchiveIcon } from "../icons/ArchiveIcon/ArchiveIcon";
-import { GitBranch, HeartPulse, Link2, Maximize2, Pencil, Server, Square } from "lucide-react";
+import {
+  CalendarClock,
+  GitBranch,
+  HeartPulse,
+  Link2,
+  Maximize2,
+  Pencil,
+  Server,
+  Square,
+} from "lucide-react";
 import React from "react";
 
 interface WorkspaceActionButtonProps {
@@ -40,6 +49,8 @@ interface WorkspaceActionsMenuContentProps {
   onConfigureMcp?: (() => void) | null;
   /** Experiment-gated workspace heartbeat settings action. */
   onConfigureHeartbeat?: (() => void) | null;
+  /** Experiment-gated workspace automation settings action. */
+  onConfigureAutomation?: (() => void) | null;
   /** Mobile workspace-header action: open immersive review in full-screen touch mode. */
   onOpenTouchFullscreenReview?: (() => void) | null;
   onEnterImmersiveReview?: (() => void) | null;
@@ -97,6 +108,19 @@ export const WorkspaceActionsMenuContent: React.FC<WorkspaceActionsMenuContentPr
             e.stopPropagation();
             props.onCloseMenu();
             props.onConfigureHeartbeat?.();
+          }}
+        />
+      )}
+      {props.onConfigureAutomation && (
+        <WorkspaceActionButton
+          label="Automations..."
+          shortcut={formatKeybind(KEYBINDS.CONFIGURE_SCHEDULED_WORKFLOW)}
+          shortcutClassName={props.shortcutClassName}
+          icon={<CalendarClock className="h-3 w-3 shrink-0" />}
+          onClick={(e) => {
+            e.stopPropagation();
+            props.onCloseMenu();
+            props.onConfigureAutomation?.();
           }}
         />
       )}

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.test.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.test.tsx
@@ -443,6 +443,49 @@ describe("WorkspaceMenuBar archive confirmations", () => {
     });
   });
 
+  it("passes sibling sub-project automation targeting this workspace into automation settings", async () => {
+    spyOn(ExperimentsModule, "useExperimentValue").mockImplementation(
+      (experimentId) => experimentId === EXPERIMENT_IDS.DYNAMIC_WORKFLOWS
+    );
+    const subProjectPath = "/projects/demo/packages/api";
+    const projectWorkflowSchedule = {
+      id: "sub-project-automation",
+      enabled: true,
+      workflowName: "triage-api",
+      intervalMs: 15 * 60_000,
+      target: { type: "existing-workspace" as const, workspaceId },
+    };
+    const parentConfig = { workspaces: [{ id: workspaceId, path: "/tmp/workspace" }] };
+    const subProjectConfig = {
+      parentProjectPath: defaultProps.projectPath,
+      workspaces: [],
+      workflowSchedules: [projectWorkflowSchedule],
+    };
+    spyOn(ProjectContextModule, "useProjectContext").mockImplementation(
+      () =>
+        ({
+          getProjectConfig: (path: string) =>
+            path === subProjectPath ? subProjectConfig : parentConfig,
+          userProjects: new Map([
+            [defaultProps.projectPath, parentConfig],
+            [subProjectPath, subProjectConfig],
+          ]),
+        }) as unknown as ReturnType<typeof ProjectContextModule.useProjectContext>
+    );
+    render(<WorkspaceMenuBar {...defaultProps} />);
+
+    fireEvent.keyDown(window, {
+      key: KEYBINDS.CONFIGURE_SCHEDULED_WORKFLOW.key,
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    await waitFor(() => {
+      expect(latestAutomationModalProps?.projectPath).toBe(subProjectPath);
+      expect(latestAutomationModalProps?.projectWorkflowSchedule).toEqual(projectWorkflowSchedule);
+    });
+  });
+
   it("passes a legacy workspace automation into automation settings", async () => {
     spyOn(ExperimentsModule, "useExperimentValue").mockImplementation(
       (experimentId) => experimentId === EXPERIMENT_IDS.DYNAMIC_WORKFLOWS

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.test.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.test.tsx
@@ -443,6 +443,49 @@ describe("WorkspaceMenuBar archive confirmations", () => {
     });
   });
 
+  it("passes a legacy workspace automation into automation settings", async () => {
+    spyOn(ExperimentsModule, "useExperimentValue").mockImplementation(
+      (experimentId) => experimentId === EXPERIMENT_IDS.DYNAMIC_WORKFLOWS
+    );
+    const workspaceWorkflowSchedule = {
+      enabled: true,
+      workflowName: "legacy-triage",
+      intervalMs: 15 * 60_000,
+    };
+    spyOn(WorkspaceContextModule, "useWorkspaceContext").mockImplementation(
+      () =>
+        ({
+          workspaceMetadata: new Map([
+            [
+              workspaceId,
+              {
+                id: workspaceId,
+                name: "feature-branch",
+                projectName: "demo",
+                projectPath: defaultProps.projectPath,
+                namedWorkspacePath: defaultProps.namedWorkspacePath,
+                runtimeConfig: defaultProps.runtimeConfig,
+                workflowSchedule: workspaceWorkflowSchedule,
+              },
+            ],
+          ]),
+        }) as unknown as ReturnType<typeof WorkspaceContextModule.useWorkspaceContext>
+    );
+    render(<WorkspaceMenuBar {...defaultProps} />);
+
+    fireEvent.keyDown(window, {
+      key: KEYBINDS.CONFIGURE_SCHEDULED_WORKFLOW.key,
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    await waitFor(() => {
+      expect(latestAutomationModalProps?.workspaceWorkflowSchedule).toEqual(
+        workspaceWorkflowSchedule
+      );
+    });
+  });
+
   it("does not open automation settings while a modal dialog is open", () => {
     spyOn(ExperimentsModule, "useExperimentValue").mockImplementation(
       (experimentId) => experimentId === EXPERIMENT_IDS.DYNAMIC_WORKFLOWS

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.test.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.test.tsx
@@ -1,6 +1,6 @@
 import "../../../../tests/ui/dom";
 
-import type { PropsWithChildren } from "react";
+import type { ComponentProps, PropsWithChildren } from "react";
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { installDom } from "../../../../tests/ui/dom";
@@ -11,6 +11,7 @@ import * as ProjectContextModule from "@/browser/contexts/ProjectContext";
 import * as WorkspaceStoreModule from "@/browser/stores/WorkspaceStore";
 import * as GitStatusStoreModule from "@/browser/stores/GitStatusStore";
 import * as RuntimeStatusStoreModule from "@/browser/stores/RuntimeStatusStore";
+import * as ExperimentsModule from "@/browser/hooks/useExperiments";
 import * as OpenTerminalModule from "@/browser/hooks/useOpenTerminal";
 import * as OpenInEditorModule from "@/browser/hooks/useOpenInEditor";
 import * as PersistedStateModule from "@/browser/hooks/usePersistedState";
@@ -23,6 +24,8 @@ import * as GitStatusIndicatorModule from "../GitStatusIndicator/GitStatusIndica
 import * as MultiProjectGitStatusIndicatorModule from "../GitStatusIndicator/MultiProjectGitStatusIndicator";
 import * as RuntimeBadgeModule from "../RuntimeBadge/RuntimeBadge";
 import * as BranchSelectorModule from "../BranchSelector/BranchSelector";
+import type { AutomationModal } from "../AutomationModal";
+import type { WorkspaceMenuBar as WorkspaceMenuBarComponent } from "./WorkspaceMenuBar";
 import * as WorkspaceMCPModalModule from "../WorkspaceMCPModal/WorkspaceMCPModal";
 import * as TooltipModule from "../Tooltip/Tooltip";
 import * as PopoverModule from "../Popover/Popover";
@@ -36,8 +39,19 @@ import * as WorkspaceActionsMenuContentModule from "../WorkspaceActionsMenuConte
 import * as WorkspaceTerminalIconModule from "../icons/WorkspaceTerminalIcon/WorkspaceTerminalIcon";
 import * as SkillIndicatorModule from "../SkillIndicator/SkillIndicator";
 
+import { EXPERIMENT_IDS } from "@/common/constants/experiments";
+import { KEYBINDS } from "@/browser/utils/ui/keybinds";
 import { WORKSPACE_MENU_BAR_LEFT_SIDEBAR_COLLAPSED_PADDING_PX } from "@/constants/layout";
-import { WorkspaceMenuBar } from "./WorkspaceMenuBar";
+
+let latestAutomationModalProps: ComponentProps<typeof AutomationModal> | null = null;
+
+void mock.module("../AutomationModal", () => ({
+  AutomationModal: (props: ComponentProps<typeof AutomationModal>) => {
+    latestAutomationModalProps = props;
+    return props.open ? <div data-testid="automation-modal" /> : null;
+  },
+}));
+let WorkspaceMenuBar!: typeof WorkspaceMenuBarComponent;
 
 let cleanupDom: (() => void) | null = null;
 const workspaceId = "workspace-1";
@@ -126,9 +140,10 @@ function installWorkspaceMenuBarTestDoubles() {
   );
   spyOn(ProjectContextModule, "useProjectContext").mockImplementation(
     () =>
-      ({ userProjects: new Map() }) as unknown as ReturnType<
-        typeof ProjectContextModule.useProjectContext
-      >
+      ({
+        getProjectConfig: () => undefined,
+        userProjects: new Map(),
+      }) as unknown as ReturnType<typeof ProjectContextModule.useProjectContext>
   );
   spyOn(WorkspaceStoreModule, "useWorkspaceSidebarState").mockImplementation(
     () =>
@@ -190,6 +205,7 @@ function installWorkspaceMenuBarTestDoubles() {
   spyOn(BranchSelectorModule, "BranchSelector").mockImplementation(
     (() => null) as unknown as typeof BranchSelectorModule.BranchSelector
   );
+  latestAutomationModalProps = null;
   spyOn(WorkspaceMCPModalModule, "WorkspaceMCPModal").mockImplementation(
     (() => null) as unknown as typeof WorkspaceMCPModalModule.WorkspaceMCPModal
   );
@@ -264,7 +280,7 @@ function installWorkspaceMenuBarTestDoubles() {
   );
 }
 
-const defaultProps: React.ComponentProps<typeof WorkspaceMenuBar> = {
+const defaultProps: ComponentProps<typeof WorkspaceMenuBarComponent> = {
   workspaceId,
   projectName: "demo",
   projectPath: "/projects/demo",
@@ -280,6 +296,11 @@ describe("WorkspaceMenuBar archive confirmations", () => {
   beforeEach(() => {
     cleanupDom = installDom();
     installWorkspaceMenuBarTestDoubles();
+    /* eslint-disable @typescript-eslint/no-require-imports */
+    ({ WorkspaceMenuBar } = require("./WorkspaceMenuBar?workspace-menu-bar-test=1") as {
+      WorkspaceMenuBar: typeof WorkspaceMenuBarComponent;
+    });
+    /* eslint-enable @typescript-eslint/no-require-imports */
     if (!window.matchMedia) {
       window.matchMedia = (query: string): MediaQueryList => ({
         matches: false,
@@ -315,6 +336,153 @@ describe("WorkspaceMenuBar archive confirmations", () => {
     expect(view.getByTestId("workspace-menu-bar").style.paddingLeft).toBe(
       `${WORKSPACE_MENU_BAR_LEFT_SIDEBAR_COLLAPSED_PADDING_PX}px`
     );
+  });
+
+  it("opens automation settings with the keybind when dynamic workflows are enabled", async () => {
+    spyOn(ExperimentsModule, "useExperimentValue").mockImplementation(
+      (experimentId) => experimentId === EXPERIMENT_IDS.DYNAMIC_WORKFLOWS
+    );
+    render(<WorkspaceMenuBar {...defaultProps} />);
+
+    fireEvent.keyDown(window, {
+      key: KEYBINDS.CONFIGURE_SCHEDULED_WORKFLOW.key,
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    await waitFor(() => {
+      expect(latestAutomationModalProps?.open).toBe(true);
+    });
+  });
+
+  it("opens automation settings under the workspace sub-project when scoped", async () => {
+    spyOn(ExperimentsModule, "useExperimentValue").mockImplementation(
+      (experimentId) => experimentId === EXPERIMENT_IDS.DYNAMIC_WORKFLOWS
+    );
+    const subProjectPath = "/projects/demo/packages/api";
+    spyOn(WorkspaceContextModule, "useWorkspaceContext").mockImplementation(
+      () =>
+        ({
+          workspaceMetadata: new Map([
+            [
+              workspaceId,
+              {
+                id: workspaceId,
+                name: "feature-branch",
+                projectName: "demo",
+                projectPath: defaultProps.projectPath,
+                namedWorkspacePath: defaultProps.namedWorkspacePath,
+                runtimeConfig: defaultProps.runtimeConfig,
+                subProjectPath,
+              },
+            ],
+          ]),
+        }) as unknown as ReturnType<typeof WorkspaceContextModule.useWorkspaceContext>
+    );
+    spyOn(ProjectContextModule, "useProjectContext").mockImplementation(
+      () =>
+        ({
+          getProjectConfig: (path: string) =>
+            path === subProjectPath
+              ? {
+                  parentProjectPath: defaultProps.projectPath,
+                  workspaces: [],
+                  workflowSchedules: [],
+                }
+              : { workspaces: [{ id: workspaceId, path: "/tmp/workspace", subProjectPath }] },
+          userProjects: new Map([
+            [defaultProps.projectPath, { workspaces: [] }],
+            [subProjectPath, { parentProjectPath: defaultProps.projectPath, workspaces: [] }],
+          ]),
+        }) as unknown as ReturnType<typeof ProjectContextModule.useProjectContext>
+    );
+    render(<WorkspaceMenuBar {...defaultProps} />);
+
+    fireEvent.keyDown(window, {
+      key: KEYBINDS.CONFIGURE_SCHEDULED_WORKFLOW.key,
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    await waitFor(() => {
+      expect(latestAutomationModalProps?.projectPath).toBe(subProjectPath);
+    });
+  });
+
+  it("passes the project automation targeting this workspace into automation settings", async () => {
+    spyOn(ExperimentsModule, "useExperimentValue").mockImplementation(
+      (experimentId) => experimentId === EXPERIMENT_IDS.DYNAMIC_WORKFLOWS
+    );
+    const projectWorkflowSchedule = {
+      id: "workspace-automation",
+      enabled: true,
+      workflowName: "triage-issues",
+      intervalMs: 15 * 60_000,
+      target: { type: "existing-workspace" as const, workspaceId },
+    };
+    spyOn(ProjectContextModule, "useProjectContext").mockImplementation(
+      () =>
+        ({
+          getProjectConfig: () => ({
+            workspaces: [{ id: workspaceId, path: "/tmp/workspace" }],
+            workflowSchedules: [projectWorkflowSchedule],
+          }),
+          userProjects: new Map(),
+        }) as unknown as ReturnType<typeof ProjectContextModule.useProjectContext>
+    );
+    render(<WorkspaceMenuBar {...defaultProps} />);
+
+    fireEvent.keyDown(window, {
+      key: KEYBINDS.CONFIGURE_SCHEDULED_WORKFLOW.key,
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    await waitFor(() => {
+      expect(latestAutomationModalProps?.projectWorkflowSchedule).toEqual(projectWorkflowSchedule);
+    });
+  });
+
+  it("does not open automation settings while a modal dialog is open", () => {
+    spyOn(ExperimentsModule, "useExperimentValue").mockImplementation(
+      (experimentId) => experimentId === EXPERIMENT_IDS.DYNAMIC_WORKFLOWS
+    );
+    render(
+      <>
+        <WorkspaceMenuBar {...defaultProps} />
+        <div role="dialog" aria-modal="true">
+          Existing dialog
+        </div>
+      </>
+    );
+
+    fireEvent.keyDown(window, {
+      key: KEYBINDS.CONFIGURE_SCHEDULED_WORKFLOW.key,
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(latestAutomationModalProps?.open ?? false).toBe(false);
+  });
+
+  it("does not open automation settings from editable fields", () => {
+    spyOn(ExperimentsModule, "useExperimentValue").mockImplementation(
+      (experimentId) => experimentId === EXPERIMENT_IDS.DYNAMIC_WORKFLOWS
+    );
+    const view = render(
+      <>
+        <WorkspaceMenuBar {...defaultProps} />
+        <input aria-label="Editable target" />
+      </>
+    );
+
+    fireEvent.keyDown(view.getByLabelText("Editable target"), {
+      key: KEYBINDS.CONFIGURE_SCHEDULED_WORKFLOW.key,
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(latestAutomationModalProps?.open ?? false).toBe(false);
   });
 
   it("opens the archive confirmation modal when preflight finds untracked files", async () => {

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
@@ -827,6 +827,7 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
           projectPath={automationProjectPath}
           workspaceId={workspaceId}
           workspaceName={workspaceTitle ?? workspaceName}
+          workspaceWorkflowSchedule={workspaceEntry?.workflowSchedule}
           projectWorkflowSchedule={projectWorkflowSchedule}
           open={automationModalOpen}
           onOpenChange={setAutomationModalOpen}

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
@@ -60,7 +60,7 @@ import { useProjectContext } from "@/browser/contexts/ProjectContext";
 import { formatProjectHierarchyLabel } from "@/common/utils/subProjects";
 import { isMultiProject } from "@/common/utils/multiProject";
 import { forkWorkspace } from "@/browser/utils/chatCommands";
-import { getExistingWorkspaceProjectWorkflowSchedule } from "@/browser/utils/projectWorkflowSchedules";
+import { getExistingWorkspaceProjectWorkflowScheduleMatch } from "@/browser/utils/projectWorkflowSchedules";
 import { WORKSPACE_MENU_BAR_LEFT_SIDEBAR_COLLAPSED_PADDING_PX } from "@/constants/layout";
 import type { AgentSkillDescriptor, AgentSkillIssue } from "@/common/types/agentSkill";
 
@@ -121,10 +121,15 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
   const automationProjectPath =
     subProjectPath && userProjects.has(subProjectPath) ? subProjectPath : projectPath;
   const projectConfig = getProjectConfig(automationProjectPath);
-  const projectWorkflowSchedule = getExistingWorkspaceProjectWorkflowSchedule({
+  const projectWorkflowScheduleMatch = getExistingWorkspaceProjectWorkflowScheduleMatch({
+    projectPath: automationProjectPath,
     projectConfig,
+    userProjects,
     workspaceId,
   });
+  const projectWorkflowSchedule = projectWorkflowScheduleMatch?.schedule;
+  const automationScheduleProjectPath =
+    projectWorkflowScheduleMatch?.projectPath ?? automationProjectPath;
   const projectLabel =
     subProjectPath && userProjects.has(subProjectPath)
       ? formatProjectHierarchyLabel(subProjectPath, userProjects)
@@ -824,7 +829,7 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
       </div>
       {dynamicWorkflowsEnabled && automationModalOpen && (
         <AutomationModal
-          projectPath={automationProjectPath}
+          projectPath={automationScheduleProjectPath}
           workspaceId={workspaceId}
           workspaceName={workspaceTitle ?? workspaceName}
           workspaceWorkflowSchedule={workspaceEntry?.workflowSchedule}

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
@@ -15,11 +15,18 @@ import { MultiProjectGitStatusIndicator } from "../GitStatusIndicator/MultiProje
 import { RuntimeBadge } from "../RuntimeBadge/RuntimeBadge";
 import { BranchSelector } from "../BranchSelector/BranchSelector";
 import { WorkspaceHeartbeatModal } from "../WorkspaceHeartbeatModal";
+import { AutomationModal } from "../AutomationModal";
 import { WorkspaceMCPModal } from "../WorkspaceMCPModal/WorkspaceMCPModal";
 import { Tooltip, TooltipTrigger, TooltipContent } from "../Tooltip/Tooltip";
 import { Popover, PopoverTrigger, PopoverContent } from "../Popover/Popover";
 import { Checkbox } from "../Checkbox/Checkbox";
-import { formatKeybind, KEYBINDS, matchesKeybind } from "@/browser/utils/ui/keybinds";
+import {
+  formatKeybind,
+  isDialogOpen,
+  isEditableElement,
+  KEYBINDS,
+  matchesKeybind,
+} from "@/browser/utils/ui/keybinds";
 import { getDevcontainerStatusChip } from "@/browser/utils/runtimeUi";
 import { useGitStatus } from "@/browser/stores/GitStatusStore";
 import { useRuntimeStatus, useRuntimeStatusStoreRaw } from "@/browser/stores/RuntimeStatusStore";
@@ -53,6 +60,7 @@ import { useProjectContext } from "@/browser/contexts/ProjectContext";
 import { formatProjectHierarchyLabel } from "@/common/utils/subProjects";
 import { isMultiProject } from "@/common/utils/multiProject";
 import { forkWorkspace } from "@/browser/utils/chatCommands";
+import { getExistingWorkspaceProjectWorkflowSchedule } from "@/browser/utils/projectWorkflowSchedules";
 import { WORKSPACE_MENU_BAR_LEFT_SIDEBAR_COLLAPSED_PADDING_PX } from "@/constants/layout";
 import type { AgentSkillDescriptor, AgentSkillIssue } from "@/common/types/agentSkill";
 
@@ -95,6 +103,7 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
   const { disableWorkspaceAgents } = useAgent();
   const { preflightArchiveWorkspace, archiveWorkspace } = useWorkspaceActions();
   const { workspaceMetadata } = useWorkspaceContext();
+  const dynamicWorkflowsEnabled = useExperimentValue(EXPERIMENT_IDS.DYNAMIC_WORKFLOWS);
   const workspaceHeartbeatsEnabled = useExperimentValue(EXPERIMENT_IDS.WORKSPACE_HEARTBEATS);
   const linkSharingEnabled = useLinkSharingEnabled();
   const openTerminalPopout = useOpenTerminal();
@@ -107,8 +116,15 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
   // are owned by the top-most parent). When the workspace is scoped to a
   // sub-project we surface the hierarchy as "parent / child" so the menu bar
   // alone reveals the sub-project context.
-  const { userProjects } = useProjectContext();
+  const { getProjectConfig, userProjects } = useProjectContext();
   const subProjectPath = workspaceEntry?.subProjectPath;
+  const automationProjectPath =
+    subProjectPath && userProjects.has(subProjectPath) ? subProjectPath : projectPath;
+  const projectConfig = getProjectConfig(automationProjectPath);
+  const projectWorkflowSchedule = getExistingWorkspaceProjectWorkflowSchedule({
+    projectConfig,
+    workspaceId,
+  });
   const projectLabel =
     subProjectPath && userProjects.has(subProjectPath)
       ? formatProjectHierarchyLabel(subProjectPath, userProjects)
@@ -120,6 +136,7 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
   const { startSequence: startTutorial } = useTutorial();
   const [editorError, setEditorError] = useState<string | null>(null);
   const [debugLlmRequestOpen, setDebugLlmRequestOpen] = useState(false);
+  const [automationModalOpen, setAutomationModalOpen] = useState(false);
   const [mcpModalOpen, setMcpModalOpen] = useState(false);
   const [heartbeatModalOpen, setHeartbeatModalOpen] = useState(false);
   const [availableSkills, setAvailableSkills] = useState<AgentSkillDescriptor[]>([]);
@@ -439,6 +456,26 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
   }, [workspaceHeartbeatsEnabled]);
+
+  // Keybind for opening workspace automation configuration
+  useEffect(() => {
+    if (!dynamicWorkflowsEnabled) return;
+
+    const handler = (e: KeyboardEvent) => {
+      if (
+        e.defaultPrevented ||
+        isDialogOpen() ||
+        isEditableElement(e.target) ||
+        !matchesKeybind(e, KEYBINDS.CONFIGURE_SCHEDULED_WORKFLOW)
+      ) {
+        return;
+      }
+      e.preventDefault();
+      setAutomationModalOpen(true);
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [dynamicWorkflowsEnabled]);
 
   // Keybind for sharing transcript — lives here (not AgentListItem) so it
   // works even when the left sidebar is collapsed and list items are unmounted.
@@ -760,6 +797,9 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
               onConfigureHeartbeat={
                 workspaceHeartbeatsEnabled ? () => setHeartbeatModalOpen(true) : null
               }
+              onConfigureAutomation={
+                dynamicWorkflowsEnabled ? () => setAutomationModalOpen(true) : null
+              }
               onOpenTouchFullscreenReview={
                 isTouchMobileScreen ? handleOpenTouchFullscreenReview : null
               }
@@ -782,6 +822,16 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
           </PopoverContent>
         </Popover>
       </div>
+      {dynamicWorkflowsEnabled && automationModalOpen && (
+        <AutomationModal
+          projectPath={automationProjectPath}
+          workspaceId={workspaceId}
+          workspaceName={workspaceTitle ?? workspaceName}
+          projectWorkflowSchedule={projectWorkflowSchedule}
+          open={automationModalOpen}
+          onOpenChange={setAutomationModalOpen}
+        />
+      )}
       {workspaceHeartbeatsEnabled && (
         <WorkspaceHeartbeatModal
           workspaceId={workspaceId}

--- a/src/browser/contexts/ProjectContext.test.tsx
+++ b/src/browser/contexts/ProjectContext.test.tsx
@@ -124,6 +124,46 @@ describe("ProjectContext", () => {
     expect(ctx().userProjects.has("/alpha")).toBe(false);
   });
 
+  test("refreshes projects when config changes", async () => {
+    let projects: Array<[string, ProjectConfig]> = [["/alpha", { workspaces: [] }]];
+    const projectsApi = createMockAPI({
+      list: () => Promise.resolve(projects),
+    });
+    let triggerConfigChange: (() => void) | null = null;
+    const onConfigChanged = mock(() =>
+      Promise.resolve(
+        (async function* () {
+          await new Promise<void>((resolve) => {
+            triggerConfigChange = resolve;
+          });
+          yield undefined;
+        })()
+      )
+    );
+    currentClientMock = {
+      ...currentClientMock,
+      config: {
+        onConfigChanged: onConfigChanged as unknown as APIClient["config"]["onConfigChanged"],
+      },
+    };
+
+    const ctx = await setup();
+
+    await waitFor(() => expect(ctx().userProjects.size).toBe(1));
+    await waitFor(() => expect(triggerConfigChange).not.toBeNull());
+    projects = [
+      ["/alpha", { workspaces: [] }],
+      ["/beta", { workspaces: [] }],
+    ];
+
+    act(() => {
+      triggerConfigChange?.();
+    });
+
+    await waitFor(() => expect(ctx().userProjects.size).toBe(2));
+    expect(projectsApi.list.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
   test("exposes project list load failures without marking projects as loaded", async () => {
     createMockAPI({
       list: () => Promise.reject(new Error("projects unavailable")),

--- a/src/browser/contexts/ProjectContext.tsx
+++ b/src/browser/contexts/ProjectContext.tsx
@@ -222,6 +222,42 @@ export function ProjectProvider(props: { children: ReactNode }) {
     };
   }, [refreshProjects]);
 
+  useEffect(() => {
+    const onConfigChanged = api?.config?.onConfigChanged;
+    if (onConfigChanged == null) {
+      return;
+    }
+
+    const abortController = new AbortController();
+    const signal = abortController.signal;
+    let iterator: AsyncIterator<unknown> | null = null;
+
+    void (async () => {
+      try {
+        const subscribedIterator = await onConfigChanged(undefined, { signal });
+        if (signal.aborted) {
+          void subscribedIterator.return?.();
+          return;
+        }
+
+        iterator = subscribedIterator;
+        for await (const _ of subscribedIterator) {
+          if (signal.aborted) {
+            break;
+          }
+          void refreshProjects();
+        }
+      } catch {
+        // Subscription cancellation is expected during unmount/API reconnects.
+      }
+    })();
+
+    return () => {
+      abortController.abort();
+      void iterator?.return?.();
+    };
+  }, [api, refreshProjects]);
+
   const addProject = useCallback((normalizedPath: string, projectConfig: ProjectConfig) => {
     setAllProjectsInternal((prev) => {
       const next = new Map(prev);

--- a/src/browser/features/Settings/Sections/KeybindsSection.tsx
+++ b/src/browser/features/Settings/Sections/KeybindsSection.tsx
@@ -34,6 +34,8 @@ const KEYBIND_LABELS: Record<keyof typeof KEYBINDS, string> = {
   SHARE_TRANSCRIPT: "Share transcript",
   CONFIGURE_MCP: "Configure MCP servers",
   CONFIGURE_HEARTBEAT: "Configure heartbeat",
+  CONFIGURE_SCHEDULED_WORKFLOW: "Configure workspace automations",
+  CONFIGURE_PROJECT_AUTOMATIONS: "Configure project automations",
   OPEN_COMMAND_PALETTE: "Command palette",
   OPEN_COMMAND_PALETTE_ACTIONS: "Command palette (alternate)",
   TOGGLE_THINKING: "Toggle thinking",
@@ -103,6 +105,8 @@ const KEYBIND_GROUPS: Array<{ label: string; keys: Array<keyof typeof KEYBINDS> 
       "TOGGLE_NOTIFICATIONS",
       "SHARE_TRANSCRIPT",
       "CONFIGURE_MCP",
+      "CONFIGURE_SCHEDULED_WORKFLOW",
+      "CONFIGURE_PROJECT_AUTOMATIONS",
       "CONFIGURE_HEARTBEAT",
     ],
   },
@@ -198,6 +202,7 @@ const KEYBIND_DISPLAY_ALTERNATES: Partial<
 };
 
 export function KeybindsSection() {
+  const dynamicWorkflowsEnabled = useExperimentValue(EXPERIMENT_IDS.DYNAMIC_WORKFLOWS);
   const workspaceHeartbeatsEnabled = useExperimentValue(EXPERIMENT_IDS.WORKSPACE_HEARTBEATS);
   const visibleKeybindGroups = KEYBIND_GROUPS.map((group) => ({
     ...group,
@@ -205,7 +210,9 @@ export function KeybindsSection() {
     keys: group.keys.filter(
       (key) =>
         !isKeybindDeprecated(KEYBINDS[key]) &&
-        (key !== "CONFIGURE_HEARTBEAT" || workspaceHeartbeatsEnabled)
+        (key !== "CONFIGURE_HEARTBEAT" || workspaceHeartbeatsEnabled) &&
+        (key !== "CONFIGURE_SCHEDULED_WORKFLOW" || dynamicWorkflowsEnabled) &&
+        (key !== "CONFIGURE_PROJECT_AUTOMATIONS" || dynamicWorkflowsEnabled)
     ),
   })).filter((group) => group.keys.length > 0);
 

--- a/src/browser/stories/mocks/orpc.ts
+++ b/src/browser/stories/mocks/orpc.ts
@@ -20,6 +20,8 @@ import type {
   FrontendWorkspaceMetadata,
   WorkspaceActivitySnapshot,
 } from "@/common/types/workspace";
+import type { ProjectWorkflowSchedule } from "@/common/types/project";
+import type { WorkflowDefinitionDescriptor } from "@/common/types/workflow";
 import type { ProjectConfig } from "@/node/config";
 import {
   DEFAULT_LAYOUT_PRESETS_CONFIG,
@@ -131,6 +133,8 @@ export interface MockORPCClientOptions {
   taskSettings?: Partial<TaskSettings>;
   /** Initial unified AI defaults for agents (plan/exec/compact + subagents) */
   agentAiDefaults?: AgentAiDefaults;
+  /** Workflow definitions to expose via workflows.listDefinitions */
+  workflowDefinitions?: WorkflowDefinitionDescriptor[];
   /** Agent definitions to expose via agents.list */
   agentDefinitions?: AgentDefinitionDescriptor[];
   /** Initial per-subagent AI defaults for config.getConfig (e.g., Settings → Tasks section) */
@@ -383,6 +387,7 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
     userPreferences: initialUserPreferences,
     taskSettings: initialTaskSettings,
     subagentAiDefaults: initialSubagentAiDefaults,
+    workflowDefinitions = [],
     agentAiDefaults: initialAgentAiDefaults,
     coderWorkspaceArchiveBehavior: initialCoderWorkspaceArchiveBehavior = "stop",
     worktreeArchiveBehavior: initialWorktreeArchiveBehavior = "keep",
@@ -463,6 +468,8 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
     } while (terminalSessionsById.has(nextSessionId));
     return nextSessionId;
   };
+
+  let projectWorkflowScheduleCounter = 0;
 
   let createdWorkspaceCounter = 0;
 
@@ -1296,6 +1303,9 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
         return Promise.resolve({ success: true as const, data: undefined });
       },
     },
+    workflows: {
+      listDefinitions: () => Promise.resolve(workflowDefinitions),
+    },
     projects: {
       list: () => Promise.resolve(Array.from(projects.entries())),
       create: () =>
@@ -1364,6 +1374,56 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
           project.displayName = input.displayName ?? undefined;
         }
         return Promise.resolve();
+      },
+      workflowSchedules: {
+        set: (input: {
+          projectPath: string;
+          schedule: Omit<ProjectWorkflowSchedule, "lastRunStartedAt"> & { id?: string };
+        }) => {
+          const project = projects.get(input.projectPath);
+          if (!project) {
+            return Promise.resolve({ success: false as const, error: "Project not found" });
+          }
+          projectWorkflowScheduleCounter += 1;
+          const schedule: ProjectWorkflowSchedule = {
+            ...input.schedule,
+            id: input.schedule.id ?? `mock-project-schedule-${projectWorkflowScheduleCounter}`,
+          };
+          const existingSchedules = project.workflowSchedules ?? [];
+          project.workflowSchedules = [
+            ...existingSchedules.filter((existing) => existing.id !== schedule.id),
+            schedule,
+          ];
+          return Promise.resolve({ success: true as const, data: schedule });
+        },
+        run: (input: { projectPath: string; scheduleId: string }) => {
+          const project = projects.get(input.projectPath);
+          const schedule = project?.workflowSchedules?.find(
+            (entry) => entry.id === input.scheduleId
+          );
+          if (project == null || schedule == null) {
+            return Promise.resolve({
+              success: false as const,
+              error: "Project schedule not found",
+            });
+          }
+          schedule.lastRunStartedAt = new Date().toISOString();
+          return Promise.resolve({
+            success: true as const,
+            data: { runId: "wfr_mock_project_schedule_run", status: "backgrounded" as const },
+          });
+        },
+        remove: (input: { projectPath: string; scheduleId: string }) => {
+          const project = projects.get(input.projectPath);
+          if (!project) {
+            return Promise.resolve({ success: false as const, error: "Project not found" });
+          }
+          const existingSchedules = project.workflowSchedules ?? [];
+          project.workflowSchedules = existingSchedules.filter(
+            (schedule) => schedule.id !== input.scheduleId
+          );
+          return Promise.resolve({ success: true as const, data: undefined });
+        },
       },
       secrets: {
         get: (input: { projectPath: string }) =>
@@ -1472,6 +1532,7 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
       preflightArchive: () => Promise.resolve({ success: true, data: { kind: "ready" as const } }),
       archive: () => Promise.resolve({ success: true }),
       unarchive: () => Promise.resolve({ success: true }),
+      setWorkflowSchedule: () => Promise.resolve({ success: true as const, data: undefined }),
       // Goal mocks: storybook stories don't drive lifecycle, but mounted
       // settings/right-sidebar goal surfaces read current goal state.
       getGoal: () => Promise.resolve({ goal: null }),

--- a/src/browser/utils/projectWorkflowSchedules.ts
+++ b/src/browser/utils/projectWorkflowSchedules.ts
@@ -1,0 +1,16 @@
+import type { ProjectConfig, ProjectWorkflowSchedule } from "@/common/types/project";
+
+export function getExistingWorkspaceProjectWorkflowSchedule(input: {
+  projectConfig: ProjectConfig | undefined;
+  workspaceId: string;
+}): ProjectWorkflowSchedule | undefined {
+  const workspaceId = input.workspaceId.trim();
+  if (workspaceId.length === 0) {
+    return undefined;
+  }
+
+  return (input.projectConfig?.workflowSchedules ?? []).find(
+    (schedule) =>
+      schedule.target.type === "existing-workspace" && schedule.target.workspaceId === workspaceId
+  );
+}

--- a/src/browser/utils/projectWorkflowSchedules.ts
+++ b/src/browser/utils/projectWorkflowSchedules.ts
@@ -1,5 +1,10 @@
 import type { ProjectConfig, ProjectWorkflowSchedule } from "@/common/types/project";
 
+export interface ExistingWorkspaceProjectWorkflowScheduleMatch {
+  projectPath: string;
+  schedule: ProjectWorkflowSchedule;
+}
+
 export function getExistingWorkspaceProjectWorkflowSchedule(input: {
   projectConfig: ProjectConfig | undefined;
   workspaceId: string;
@@ -13,4 +18,35 @@ export function getExistingWorkspaceProjectWorkflowSchedule(input: {
     (schedule) =>
       schedule.target.type === "existing-workspace" && schedule.target.workspaceId === workspaceId
   );
+}
+
+export function getExistingWorkspaceProjectWorkflowScheduleMatch(input: {
+  projectPath: string;
+  projectConfig: ProjectConfig | undefined;
+  userProjects: ReadonlyMap<string, ProjectConfig>;
+  workspaceId: string;
+}): ExistingWorkspaceProjectWorkflowScheduleMatch | undefined {
+  const ownerProjectPath = input.projectConfig?.parentProjectPath ?? input.projectPath;
+  const projectEntries =
+    input.userProjects.size > 0
+      ? input.userProjects.entries()
+      : input.projectConfig != null
+        ? new Map([[input.projectPath, input.projectConfig]]).entries()
+        : new Map<string, ProjectConfig>().entries();
+
+  for (const [projectPath, projectConfig] of projectEntries) {
+    const projectOwnerPath = projectConfig.parentProjectPath ?? projectPath;
+    if (projectOwnerPath !== ownerProjectPath) {
+      continue;
+    }
+    const schedule = getExistingWorkspaceProjectWorkflowSchedule({
+      projectConfig,
+      workspaceId: input.workspaceId,
+    });
+    if (schedule != null) {
+      return { projectPath, schedule };
+    }
+  }
+
+  return undefined;
 }

--- a/src/browser/utils/ui/keybinds.ts
+++ b/src/browser/utils/ui/keybinds.ts
@@ -383,6 +383,14 @@ export const KEYBINDS = {
   // macOS: Cmd+Shift+H, Win/Linux: Ctrl+Shift+H
   CONFIGURE_HEARTBEAT: { key: "H", ctrl: true, shift: true },
 
+  /** Configure automations for current workspace */
+  // macOS: Cmd+Shift+K, Win/Linux: Ctrl+Shift+K
+  CONFIGURE_SCHEDULED_WORKFLOW: { key: "K", ctrl: true, shift: true },
+
+  /** Configure automations for current project */
+  // macOS: Cmd+Option+K, Win/Linux: Ctrl+Alt+K
+  CONFIGURE_PROJECT_AUTOMATIONS: { key: "K", ctrl: true, alt: true },
+
   /** Open Command Palette */
   // VS Code-style palette
   // macOS: Cmd+Shift+P, Win/Linux: Ctrl+Shift+P

--- a/src/browser/utils/workflowScheduleIntervalMinutes.ts
+++ b/src/browser/utils/workflowScheduleIntervalMinutes.ts
@@ -1,0 +1,109 @@
+import assert from "@/common/utils/assert";
+import {
+  WORKFLOW_SCHEDULE_DEFAULT_INTERVAL_MS,
+  WORKFLOW_SCHEDULE_MAX_INTERVAL_MS,
+  WORKFLOW_SCHEDULE_MIN_INTERVAL_MS,
+} from "@/constants/workflowSchedule";
+
+const MS_PER_MINUTE = 60_000;
+
+export const WORKFLOW_SCHEDULE_MIN_INTERVAL_MINUTES =
+  WORKFLOW_SCHEDULE_MIN_INTERVAL_MS / MS_PER_MINUTE;
+export const WORKFLOW_SCHEDULE_MAX_INTERVAL_MINUTES =
+  WORKFLOW_SCHEDULE_MAX_INTERVAL_MS / MS_PER_MINUTE;
+export const WORKFLOW_SCHEDULE_DEFAULT_INTERVAL_MINUTES =
+  WORKFLOW_SCHEDULE_DEFAULT_INTERVAL_MS / MS_PER_MINUTE;
+
+assert(
+  Number.isInteger(WORKFLOW_SCHEDULE_MIN_INTERVAL_MINUTES),
+  "Workflow schedule minimum interval must be a whole number of minutes"
+);
+assert(
+  Number.isInteger(WORKFLOW_SCHEDULE_MAX_INTERVAL_MINUTES),
+  "Workflow schedule maximum interval must be a whole number of minutes"
+);
+assert(
+  Number.isInteger(WORKFLOW_SCHEDULE_DEFAULT_INTERVAL_MINUTES),
+  "Workflow schedule default interval must be a whole number of minutes"
+);
+
+export function formatWorkflowScheduleIntervalMinutes(intervalMs: number | undefined): string {
+  if (intervalMs == null || !Number.isFinite(intervalMs)) {
+    return String(WORKFLOW_SCHEDULE_DEFAULT_INTERVAL_MINUTES);
+  }
+
+  const roundedMinutes = Math.round(intervalMs / MS_PER_MINUTE);
+  return String(clampWorkflowScheduleIntervalMinutes(roundedMinutes));
+}
+
+export function parseWorkflowScheduleIntervalMinutes(value: string): number | null {
+  const trimmedValue = value.trim();
+  if (trimmedValue.length === 0 || !/^\d+$/.test(trimmedValue)) {
+    return null;
+  }
+
+  const minutes = Number.parseInt(trimmedValue, 10);
+  return Number.isInteger(minutes) ? minutes : null;
+}
+
+export function clampWorkflowScheduleIntervalMinutes(minutes: number): number {
+  assert(Number.isInteger(minutes), "Workflow schedule minutes must be a whole number");
+  return Math.min(
+    WORKFLOW_SCHEDULE_MAX_INTERVAL_MINUTES,
+    Math.max(WORKFLOW_SCHEDULE_MIN_INTERVAL_MINUTES, minutes)
+  );
+}
+
+export interface ParsedWorkflowArgsResult {
+  args?: Record<string, unknown>;
+  error: string | null;
+}
+
+export function parseWorkflowArgs(value: string): ParsedWorkflowArgsResult {
+  const trimmedValue = value.trim();
+  if (trimmedValue.length === 0) {
+    return { error: null };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmedValue);
+  } catch {
+    return { error: "Workflow args must be valid JSON." };
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return { error: "Workflow args must be a JSON object." };
+  }
+
+  return { args: parsed as Record<string, unknown>, error: null };
+}
+
+export function formatWorkflowArgs(args: Record<string, unknown> | null | undefined): string {
+  if (args == null || Object.keys(args).length === 0) {
+    return "";
+  }
+
+  return JSON.stringify(args, null, 2);
+}
+
+export function getWorkflowScheduleIntervalValidationError(value: string): string | null {
+  const minutes = parseWorkflowScheduleIntervalMinutes(value);
+  if (minutes == null) {
+    return "Schedule interval must be a whole number of minutes.";
+  }
+
+  if (
+    minutes < WORKFLOW_SCHEDULE_MIN_INTERVAL_MINUTES ||
+    minutes > WORKFLOW_SCHEDULE_MAX_INTERVAL_MINUTES
+  ) {
+    return `Schedule interval must be between ${WORKFLOW_SCHEDULE_MIN_INTERVAL_MINUTES} and ${WORKFLOW_SCHEDULE_MAX_INTERVAL_MINUTES} minutes.`;
+  }
+
+  return null;
+}
+
+export function workflowScheduleIntervalMinutesToMs(minutes: number): number {
+  assert(Number.isInteger(minutes), "Workflow schedule minutes must be a whole number");
+  return minutes * MS_PER_MINUTE;
+}

--- a/src/common/orpc/schemas.ts
+++ b/src/common/orpc/schemas.ts
@@ -51,6 +51,8 @@ export {
   WorkspaceHeartbeatSettingsSchema,
   WorkspaceMetadataSchema,
   WorkspaceWorkflowScheduleSchema,
+  WorkspaceWorkflowScheduleTargetSchema,
+  WorkflowScheduleContextModeSchema,
 } from "./schemas/workspace";
 
 // Workspace stats schemas

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -29,7 +29,7 @@ import {
   GoalSetErrorSchema,
   GoalSetInputSchema,
 } from "./goal";
-import { ProjectConfigSchema } from "./project";
+import { ProjectConfigSchema, ProjectWorkflowScheduleSchema } from "./project";
 import {
   MemoryChangeEventSchema,
   MemoryConsolidationRecordSchema,
@@ -614,6 +614,13 @@ export const mcpOauth = {
   },
 };
 
+const ProjectWorkflowScheduleInputSchema = ProjectWorkflowScheduleSchema.omit({
+  id: true,
+  lastRunStartedAt: true,
+}).extend({
+  id: z.string().min(1).optional(),
+});
+
 // Projects
 export const projects = {
   create: {
@@ -719,6 +726,28 @@ export const projects = {
       })
       .passthrough(),
     output: z.void(),
+  },
+  workflowSchedules: {
+    set: {
+      input: z
+        .object({
+          projectPath: z.string().min(1),
+          schedule: ProjectWorkflowScheduleInputSchema,
+        })
+        .strict(),
+      output: ResultSchema(ProjectWorkflowScheduleSchema, z.string()),
+    },
+    run: {
+      input: z.object({ projectPath: z.string().min(1), scheduleId: z.string().min(1) }).strict(),
+      output: ResultSchema(
+        z.object({ runId: WorkflowRunIdSchema, status: WorkflowRunStatusSchema }),
+        z.string()
+      ),
+    },
+    remove: {
+      input: z.object({ projectPath: z.string().min(1), scheduleId: z.string().min(1) }).strict(),
+      output: ResultSchema(z.void(), z.string()),
+    },
   },
   mcp: {
     list: {
@@ -1820,15 +1849,20 @@ export const agentSkills = {
   },
 };
 
-const WorkflowDefinitionDiscoveryInputSchema = z
-  .object({
-    projectPath: z.string().min(1).optional(),
-    workspaceId: z.string().min(1).optional(),
-  })
-  .strict()
-  .refine((data) => Boolean(data.projectPath ?? data.workspaceId), {
-    message: "Either projectPath or workspaceId must be provided",
-  });
+const WorkflowDefinitionDiscoveryInputSchema = z.union([
+  z
+    .object({
+      projectPath: z.string().min(1),
+      workspaceId: z.never().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      workspaceId: z.string().min(1),
+      projectPath: z.never().optional(),
+    })
+    .strict(),
+]);
 
 // Workflows
 export const workflows = {

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -1859,7 +1859,7 @@ const WorkflowDefinitionDiscoveryInputSchema = z.union([
   z
     .object({
       workspaceId: z.string().min(1),
-      projectPath: z.never().optional(),
+      projectPath: z.string().min(1).optional(),
     })
     .strict(),
 ]);

--- a/src/common/orpc/schemas/project.ts
+++ b/src/common/orpc/schemas/project.ts
@@ -1,1 +1,5 @@
-export { ProjectConfigSchema, WorkspaceConfigSchema } from "@/common/schemas/project";
+export {
+  ProjectConfigSchema,
+  ProjectWorkflowScheduleSchema,
+  WorkspaceConfigSchema,
+} from "@/common/schemas/project";

--- a/src/common/orpc/schemas/workspace.ts
+++ b/src/common/orpc/schemas/workspace.ts
@@ -10,9 +10,11 @@ import {
   HEARTBEAT_MIN_INTERVAL_MS,
 } from "@/constants/heartbeat";
 import {
+  WORKFLOW_SCHEDULE_CONTEXT_MODE_VALUES,
   WORKFLOW_SCHEDULE_MAX_INTERVAL_MS,
   WORKFLOW_SCHEDULE_MIN_INTERVAL_MS,
 } from "@/constants/workflowSchedule";
+import { validateWorkspaceName } from "@/common/utils/validation/workspaceValidation";
 
 export const ProjectRefSchema = z.object({
   projectPath: z.string().meta({ description: "Absolute path to the project's main git repo" }),
@@ -90,6 +92,44 @@ export const WorkspaceHeartbeatSettingsSchema = z.object({
   }),
 });
 
+export const WorkflowScheduleTargetBranchNameSchema = z
+  .string()
+  .min(1)
+  .superRefine((value, ctx) => {
+    const validation = validateWorkspaceName(value.trim());
+    if (!validation.valid) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: validation.error ?? "Invalid workspace name",
+      });
+    }
+  });
+
+export const WorkflowScheduleContextModeSchema = z.enum(WORKFLOW_SCHEDULE_CONTEXT_MODE_VALUES);
+
+export const WorkspaceWorkflowScheduleTargetSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("current-workspace").meta({
+      description: "Run the workflow in the workspace that owns the schedule.",
+    }),
+  }),
+  z.object({
+    type: z.literal("new-workspace").meta({
+      description: "Create a fresh workspace for each due scheduled run.",
+    }),
+    branchName: WorkflowScheduleTargetBranchNameSchema.optional().meta({
+      description:
+        "Optional branch/workspace-name base for the fresh workspace. Runtime collision handling may suffix it.",
+    }),
+    trunkBranch: z.string().min(1).meta({
+      description: "Base branch checked out when creating the fresh workspace.",
+    }),
+    title: z.string().min(1).optional().meta({
+      description: "Optional human-readable title for each fresh scheduled-run workspace.",
+    }),
+  }),
+]);
+
 /**
  * Per-workspace scheduled workflow run (single source of truth for persisted
  * config entries and workspace metadata IPC). Wall-clock semantics: the
@@ -108,6 +148,14 @@ export const WorkspaceWorkflowScheduleSchema = z.object({
     .record(z.string(), z.unknown())
     .optional()
     .meta({ description: "JSON args passed to the workflow run." }),
+  contextMode: WorkflowScheduleContextModeSchema.optional().meta({
+    description:
+      'Context preparation before each scheduled run. Missing values default to "normal" at read time for backward compatibility.',
+  }),
+  target: WorkspaceWorkflowScheduleTargetSchema.optional().meta({
+    description:
+      'Workspace target for each run. Missing values default to "current-workspace" for backward compatibility.',
+  }),
   intervalMs: z
     .number()
     .int()

--- a/src/common/schemas/project.ts
+++ b/src/common/schemas/project.ts
@@ -7,12 +7,18 @@ import {
   WorkspaceGoalDefaultsOverrideSchema,
   WorkspaceHeartbeatSettingsSchema,
   WorkspaceWorkflowScheduleSchema,
+  WorkflowScheduleContextModeSchema,
+  WorkflowScheduleTargetBranchNameSchema,
 } from "@/common/orpc/schemas/workspace";
 import {
   WorkspaceAISettingsByAgentSchema,
   WorkspaceAISettingsSchema,
 } from "@/common/orpc/schemas/workspaceAiSettings";
 import { ThinkingLevelSchema } from "@/common/types/thinking";
+import {
+  WORKFLOW_SCHEDULE_MAX_INTERVAL_MS,
+  WORKFLOW_SCHEDULE_MIN_INTERVAL_MS,
+} from "@/constants/workflowSchedule";
 import { z } from "zod";
 
 import { RuntimeEnablementIdSchema } from "./ids";
@@ -217,6 +223,71 @@ export const WorkspaceConfigSchema = z.object({
   }),
 });
 
+export const ProjectWorkflowScheduleTargetSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("existing-workspace").meta({
+      description: "Run the project automation in a specific existing workspace.",
+    }),
+    workspaceId: z.string().min(1).meta({
+      description: "Workspace used as the execution target for this automation.",
+    }),
+  }),
+  z.object({
+    type: z.literal("new-workspace").meta({
+      description: "Create a fresh workspace for each due project automation run.",
+    }),
+    branchName: WorkflowScheduleTargetBranchNameSchema.optional().meta({
+      description:
+        "Optional branch/workspace-name base for the fresh workspace. Runtime collision handling may suffix it.",
+    }),
+    trunkBranch: z.string().min(1).meta({
+      description: "Base branch checked out when creating the fresh automation workspace.",
+    }),
+    title: z.string().min(1).optional().meta({
+      description: "Optional human-readable title for each fresh automation workspace.",
+    }),
+  }),
+]);
+
+/**
+ * Project-level scheduled workflow automation. The project owns the automation;
+ * workspaces are only runtime targets resolved at dispatch time.
+ */
+export const ProjectWorkflowScheduleSchema = z.object({
+  id: z.string().min(1).meta({
+    description: "Stable project-local automation identifier.",
+  }),
+  title: z.string().min(1).optional().meta({
+    description: "Optional user-facing automation title.",
+  }),
+  enabled: z.boolean().meta({
+    description: "Whether this project automation is active.",
+  }),
+  workflowName: z.string().min(1).meta({
+    description: "Named workflow definition to run (resolved like workflows.start).",
+  }),
+  args: z.record(z.string(), z.unknown()).optional().meta({
+    description: "JSON args passed to the workflow run.",
+  }),
+  contextMode: WorkflowScheduleContextModeSchema.optional().meta({
+    description:
+      'Context preparation before existing-workspace scheduled runs. Missing values default to "normal" at read time for backward compatibility.',
+  }),
+  target: ProjectWorkflowScheduleTargetSchema.meta({
+    description: "Workspace target policy for this project automation.",
+  }),
+  intervalMs: z
+    .number()
+    .int()
+    .min(WORKFLOW_SCHEDULE_MIN_INTERVAL_MS)
+    .max(WORKFLOW_SCHEDULE_MAX_INTERVAL_MS)
+    .meta({ description: "Wall-clock interval between dispatched runs." }),
+  lastRunStartedAt: z.string().optional().meta({
+    description:
+      "ISO timestamp of the last dispatched run (persisted before dispatch so restarts retry at most once per interval).",
+  }),
+});
+
 export const ProjectConfigSchema = z.object({
   displayName: z.string().nullish().meta({
     description: "Custom display name for the project",
@@ -233,6 +304,9 @@ export const ProjectConfigSchema = z.object({
     description: "Absolute path to the top-level parent project for one-level sub-projects",
   }),
   workspaces: z.array(WorkspaceConfigSchema),
+  workflowSchedules: z.array(ProjectWorkflowScheduleSchema).optional().meta({
+    description: "Project-level scheduled workflow automations.",
+  }),
   idleCompactionHours: z.number().min(1).nullable().optional().meta({
     description:
       "Hours of inactivity before auto-compacting workspaces. null/undefined = disabled.",

--- a/src/common/types/project.ts
+++ b/src/common/types/project.ts
@@ -24,6 +24,8 @@ export type Workspace = z.infer<typeof WorkspaceConfigSchema>;
 
 export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;
 
+export type ProjectWorkflowSchedule = NonNullable<ProjectConfig["workflowSchedules"]>[number];
+
 export type { UpdateChannel };
 
 export interface ProjectsConfig {

--- a/src/common/utils/workflowSchedule.ts
+++ b/src/common/utils/workflowSchedule.ts
@@ -1,0 +1,30 @@
+import { ProjectWorkflowScheduleSchema } from "@/common/schemas/project";
+import { WorkspaceWorkflowScheduleSchema } from "@/common/orpc/schemas/workspace";
+import type { ProjectWorkflowSchedule } from "@/common/types/project";
+import type { WorkspaceWorkflowSchedule } from "@/common/types/workspace";
+
+export function parsePersistedWorkflowSchedule(
+  value: unknown
+): WorkspaceWorkflowSchedule | undefined {
+  const parsed = WorkspaceWorkflowScheduleSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
+}
+
+export function parsePersistedProjectWorkflowSchedule(
+  value: unknown
+): ProjectWorkflowSchedule | undefined {
+  const parsed = ProjectWorkflowScheduleSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
+}
+
+export function isWorkflowScheduleDue(
+  schedule: { lastRunStartedAt?: string | null; intervalMs: number },
+  now: number
+): boolean {
+  if (schedule.lastRunStartedAt == null) {
+    return true;
+  }
+
+  const lastStarted = Date.parse(schedule.lastRunStartedAt);
+  return !Number.isFinite(lastStarted) || now - lastStarted >= schedule.intervalMs;
+}

--- a/src/common/utils/workflowScheduleTarget.test.ts
+++ b/src/common/utils/workflowScheduleTarget.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getRuntimeConfigForScheduledNewWorkspaceTarget,
+  getWorkflowScheduleNewWorkspaceTargetUnavailableReason,
+} from "./workflowScheduleTarget";
+
+describe("workflow schedule target helpers", () => {
+  test("rejects unsupported fresh target source shapes", () => {
+    expect(
+      getWorkflowScheduleNewWorkspaceTargetUnavailableReason({
+        projects: [
+          { projectPath: "/repo/a", projectName: "a" },
+          { projectPath: "/repo/b", projectName: "b" },
+        ],
+      })
+    ).toContain("multi-project workspaces");
+
+    expect(
+      getWorkflowScheduleNewWorkspaceTargetUnavailableReason({ runtimeConfig: { type: "local" } })
+    ).toContain("project-dir local workspaces");
+
+    expect(
+      getWorkflowScheduleNewWorkspaceTargetUnavailableReason({
+        runtimeConfig: {
+          type: "ssh",
+          host: "coder://",
+          srcBaseDir: "/home/coder/.mux/src",
+          coder: { workspaceName: "existing-vm", existingWorkspace: true },
+        },
+      })
+    ).toContain("existing Coder workspaces");
+  });
+
+  test("sanitizes template-backed Coder runtime identity for fresh scheduled targets", () => {
+    const runtimeConfig = {
+      type: "ssh" as const,
+      host: "coder://",
+      srcBaseDir: "/home/coder/.mux/src",
+      coder: {
+        workspaceName: "source-vm",
+        template: "node",
+        templateOrg: "coder",
+        preset: "default",
+      },
+    };
+
+    expect(getRuntimeConfigForScheduledNewWorkspaceTarget(runtimeConfig)).toEqual({
+      type: "ssh",
+      host: "coder://",
+      srcBaseDir: "/home/coder/.mux/src",
+      coder: {
+        template: "node",
+        templateOrg: "coder",
+        preset: "default",
+      },
+    });
+    expect(runtimeConfig.coder.workspaceName).toBe("source-vm");
+  });
+});

--- a/src/common/utils/workflowScheduleTarget.ts
+++ b/src/common/utils/workflowScheduleTarget.ts
@@ -1,0 +1,86 @@
+import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
+import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
+import type { ProjectRef } from "@/common/types/workspace";
+import type { RuntimeConfig } from "@/common/types/runtime";
+import { isWorkspaceArchived } from "@/common/utils/archive";
+
+interface WorkflowScheduleTargetSource {
+  sourceProjectPath?: string;
+  projects?: readonly ProjectRef[];
+  runtimeConfig?: RuntimeConfig;
+}
+
+export function getRuntimeConfigForScheduledNewWorkspaceTarget(
+  sourceRuntimeConfig: RuntimeConfig | undefined
+): RuntimeConfig | undefined {
+  if (sourceRuntimeConfig?.type !== "ssh" || sourceRuntimeConfig.coder == null) {
+    return sourceRuntimeConfig;
+  }
+
+  const {
+    workspaceName: _workspaceName,
+    existingWorkspace: _existingWorkspace,
+    ...coder
+  } = sourceRuntimeConfig.coder;
+  return { ...sourceRuntimeConfig, coder };
+}
+
+export function getWorkflowScheduleNewWorkspaceTargetUnavailableReason(
+  source: WorkflowScheduleTargetSource
+): string | null {
+  const runtimeConfig = source.runtimeConfig ?? DEFAULT_RUNTIME_CONFIG;
+
+  if (source.sourceProjectPath === MULTI_PROJECT_CONFIG_KEY || (source.projects?.length ?? 0) > 1) {
+    return "New-workspace scheduled runs are not supported for multi-project workspaces yet.";
+  }
+
+  if (runtimeConfig.type === "local" && !("srcBaseDir" in runtimeConfig)) {
+    return "New-workspace scheduled runs are not supported for project-dir local workspaces yet.";
+  }
+
+  if (runtimeConfig.type === "ssh" && runtimeConfig.coder?.existingWorkspace === true) {
+    return "New-workspace scheduled runs are not supported for existing Coder workspaces yet.";
+  }
+
+  return null;
+}
+
+export interface WorkflowScheduleNewWorkspaceTemplateCandidate {
+  archivedAt?: string;
+  unarchivedAt?: string;
+  projects?: readonly ProjectRef[];
+  runtimeConfig?: RuntimeConfig;
+}
+
+export function getSupportedWorkflowScheduleNewWorkspaceTemplate<
+  T extends WorkflowScheduleNewWorkspaceTemplateCandidate,
+>(input: {
+  sourceProjectPath: string;
+  workspaces: readonly T[];
+}): { workspace: T | undefined; unavailableReason: string | null } {
+  const activeWorkspaces = input.workspaces.filter(
+    (workspace) => !isWorkspaceArchived(workspace.archivedAt, workspace.unarchivedAt)
+  );
+  const supportedWorkspace = activeWorkspaces.find(
+    (workspace) =>
+      getWorkflowScheduleNewWorkspaceTargetUnavailableReason({
+        sourceProjectPath: input.sourceProjectPath,
+        projects: workspace.projects,
+        runtimeConfig: workspace.runtimeConfig,
+      }) == null
+  );
+  if (supportedWorkspace != null || activeWorkspaces.length === 0) {
+    return { workspace: supportedWorkspace, unavailableReason: null };
+  }
+
+  const unavailableReason = getWorkflowScheduleNewWorkspaceTargetUnavailableReason({
+    sourceProjectPath: input.sourceProjectPath,
+    projects: activeWorkspaces[0]?.projects,
+    runtimeConfig: activeWorkspaces[0]?.runtimeConfig,
+  });
+  return {
+    workspace: undefined,
+    unavailableReason:
+      unavailableReason ?? "New-workspace automations are unavailable for this project.",
+  };
+}

--- a/src/constants/workflowSchedule.ts
+++ b/src/constants/workflowSchedule.ts
@@ -7,5 +7,16 @@
  */
 export const WORKFLOW_SCHEDULE_MIN_INTERVAL_MS = 60 * 1000;
 export const WORKFLOW_SCHEDULE_MAX_INTERVAL_MS = 24 * 60 * 60 * 1000;
+/** Default cadence offered by the configuration UI for new schedules. */
+export const WORKFLOW_SCHEDULE_DEFAULT_INTERVAL_MS = 15 * 60 * 1000;
 /** How often the scheduler scans config for due schedules. */
 export const WORKFLOW_SCHEDULE_CHECK_INTERVAL_MS = 30 * 1000;
+/** Maximum time a scheduled compact context preparation may occupy before the run is skipped. */
+export const WORKFLOW_SCHEDULE_CONTEXT_PREPARATION_TIMEOUT_MS = 30 * 60 * 1000;
+
+export const WORKFLOW_SCHEDULE_CONTEXT_MODE_VALUES = ["normal", "compact", "reset"] as const;
+export type WorkflowScheduleContextMode = (typeof WORKFLOW_SCHEDULE_CONTEXT_MODE_VALUES)[number];
+export const WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE: WorkflowScheduleContextMode = "normal";
+
+export const WORKFLOW_SCHEDULE_TARGET_TYPES = ["current-workspace", "new-workspace"] as const;
+export type WorkflowScheduleTargetType = (typeof WORKFLOW_SCHEDULE_TARGET_TYPES)[number];

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -69,6 +69,10 @@ import { isProviderAutoRouteEligible } from "@/node/utils/providerRequirements";
 import { getContainerName as getDockerContainerName } from "@/node/runtime/DockerRuntime";
 import { deriveProjectHierarchy } from "@/common/utils/subProjects";
 import { coerceThinkingLevel, type ThinkingLevel } from "@/common/types/thinking";
+import {
+  parsePersistedProjectWorkflowSchedule,
+  parsePersistedWorkflowSchedule,
+} from "@/common/utils/workflowSchedule";
 
 // Re-export project/provider types from dedicated schema/types files (for preload usage)
 export type { Workspace, ProjectConfig, ProjectsConfig, ProviderConfig, CanonicalProvidersConfig };
@@ -537,10 +541,20 @@ function normalizeProjectRuntimeSettings(projectConfig: ProjectConfig): ProjectC
     defaultRuntime?: unknown;
     runtimeOverridesEnabled?: unknown;
     projectKind?: unknown;
+    workflowSchedules?: unknown;
   };
   const runtimeEnablement = normalizeRuntimeEnablementOverrides(record.runtimeEnablement);
   const defaultRuntime = normalizeRuntimeEnablementId(record.defaultRuntime);
   const runtimeOverridesEnabled = record.runtimeOverridesEnabled === true ? true : undefined;
+
+  const workflowSchedules = Array.isArray(record.workflowSchedules)
+    ? record.workflowSchedules
+        .map((schedule) => parsePersistedProjectWorkflowSchedule(schedule))
+        .filter(
+          (schedule): schedule is NonNullable<ProjectConfig["workflowSchedules"]>[number] =>
+            schedule != null
+        )
+    : [];
 
   const next = { ...record };
   delete (next as ProjectConfig & { sections?: unknown }).sections;
@@ -567,6 +581,12 @@ function normalizeProjectRuntimeSettings(projectConfig: ProjectConfig): ProjectC
     next.projectKind = projectKind;
   } else {
     delete next.projectKind;
+  }
+
+  if (workflowSchedules.length > 0) {
+    next.workflowSchedules = workflowSchedules;
+  } else {
+    delete next.workflowSchedules;
   }
 
   return next;
@@ -1644,7 +1664,7 @@ export class Config {
               runtimeConfig: workspace.runtimeConfig ?? DEFAULT_RUNTIME_CONFIG,
               aiSettings: workspace.aiSettings,
               heartbeat: workspace.heartbeat,
-              workflowSchedule: workspace.workflowSchedule,
+              workflowSchedule: parsePersistedWorkflowSchedule(workspace.workflowSchedule),
               goalDefaults: workspace.goalDefaults,
               aiSettingsByAgent:
                 workspace.aiSettingsByAgent ??
@@ -1818,7 +1838,7 @@ export class Config {
               runtimeConfig: DEFAULT_RUNTIME_CONFIG,
               aiSettings: workspace.aiSettings,
               heartbeat: workspace.heartbeat,
-              workflowSchedule: workspace.workflowSchedule,
+              workflowSchedule: parsePersistedWorkflowSchedule(workspace.workflowSchedule),
               goalDefaults: workspace.goalDefaults,
               aiSettingsByAgent:
                 workspace.aiSettingsByAgent ??

--- a/src/node/orpc/context.ts
+++ b/src/node/orpc/context.ts
@@ -1,3 +1,4 @@
+import type { WorkflowSchedulerService } from "@/node/services/workflows/WorkflowSchedulerService";
 import type { IJSRuntimeFactory } from "@/node/services/ptc/runtime";
 import type { IncomingHttpHeaders } from "http";
 import type { Config } from "@/node/config";
@@ -96,6 +97,7 @@ export interface ORPCContext {
   desktopSessionManager: DesktopSessionManager;
   desktopTokenManager: DesktopTokenManager;
   desktopBridgeServer: DesktopBridgeServer;
+  workflowSchedulerService: WorkflowSchedulerService;
   workflowRuntimeFactory: IJSRuntimeFactory;
   headers?: IncomingHttpHeaders;
 }

--- a/src/node/orpc/router.test.ts
+++ b/src/node/orpc/router.test.ts
@@ -10,7 +10,7 @@ import { QuickJSRuntimeFactory } from "@/node/services/ptc/quickjsRuntime";
 import { ForegroundWaitBackgroundedError } from "@/node/services/taskService";
 import { WorkflowRunStore } from "@/node/services/workflows/WorkflowRunStore";
 import type { ORPCContext } from "./context";
-import { router } from "./router";
+import { resolveWorkflowContext, router } from "./router";
 
 describe("router workspace goal validation", () => {
   test("goal routes do not touch goal files for unknown workspaces", async () => {
@@ -116,8 +116,15 @@ describe("router workflow routes", () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  function createContext(options: { enabled: boolean }): ORPCContext {
+  function createContext(options: { enabled: boolean; workspacePath?: string }): ORPCContext {
+    const workspacePath = options.workspacePath ?? projectPath;
     return {
+      workflowSchedulerService: {
+        runProjectScheduleNow: mock(async () => ({
+          runId: "wfr_manual_project_schedule",
+          status: "backgrounded",
+        })),
+      },
       workflowRuntimeFactory: new QuickJSRuntimeFactory(),
       config,
       aiService: {
@@ -131,7 +138,7 @@ describe("router workflow routes", () => {
             id: "workspace-1",
             name: "workspace-1",
             projectPath,
-            namedWorkspacePath: projectPath,
+            namedWorkspacePath: workspacePath,
             runtimeConfig: { type: "local", srcBaseDir: tempDir },
           },
         })),
@@ -180,6 +187,302 @@ describe("router workflow routes", () => {
         expect.objectContaining({ name: "demo", scope: "project", executable: true }),
       ])
     );
+  });
+
+  test("resolves scheduled sub-project workflow definitions inside the target workspace", async () => {
+    const workspacePath = path.join(tempDir, "workspace-checkout");
+    const subProjectPath = path.join(projectPath, "packages", "api");
+    const workspaceSubProjectPath = path.join(workspacePath, "packages", "api");
+    fs.mkdirSync(path.join(workspaceSubProjectPath, ".mux", "workflows"), { recursive: true });
+    fs.writeFileSync(
+      path.join(workspaceSubProjectPath, ".mux", "workflows", "sub-scan.js"),
+      `// description: Sub-project scan\nexport default function workflow() { return {}; }\n`
+    );
+    await config.editConfig((current) => {
+      current.projects.set(subProjectPath, {
+        parentProjectPath: projectPath,
+        workspaces: [],
+      });
+      return current;
+    });
+    const context = createContext({ enabled: true, workspacePath });
+
+    const { service, projectTrusted } = await resolveWorkflowContext(context, "workspace-1", {
+      projectPath: subProjectPath,
+    });
+    const definitions = await service.listDefinitions({ projectTrusted });
+
+    expect(definitions).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "sub-scan", scope: "project" })])
+    );
+    expect(definitions).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "demo" })])
+    );
+  });
+
+  test("project workflow discovery scans the requested project, not an active workspace checkout", async () => {
+    const workspacePath = path.join(tempDir, "workspace-checkout");
+    fs.mkdirSync(path.join(workspacePath, ".mux", "workflows"), { recursive: true });
+    fs.writeFileSync(
+      path.join(workspacePath, ".mux", "workflows", "workspace-only.js"),
+      `// description: Workspace-only workflow\nexport default function workflow() { return {}; }\n`
+    );
+    await config.editConfig((current) => {
+      current.projects.set(projectPath, {
+        ...(current.projects.get(projectPath) ?? { workspaces: [] }),
+        workspaces: [{ id: "workspace-1", path: workspacePath }],
+      });
+      return current;
+    });
+    const client = createRouterClient(router(), {
+      context: createContext({ enabled: true, workspacePath }),
+    });
+
+    const definitions = await client.workflows.listDefinitions({ projectPath });
+
+    expect(definitions).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "demo", scope: "project" })])
+    );
+    expect(definitions).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "workspace-only" })])
+    );
+  });
+
+  test("rejects ambiguous workflow definition discovery inputs", async () => {
+    const client = createRouterClient(router(), {
+      context: createContext({ enabled: true }),
+    });
+
+    await expect(
+      client.workflows.listDefinitions({ projectPath, workspaceId: "workspace-1" } as never)
+    ).rejects.toThrow();
+  });
+
+  test("validates sub-project new-workspace schedules against owner workspace templates", async () => {
+    const subProjectPath = path.join(projectPath, "packages", "api");
+    await config.editConfig((current) => {
+      current.projects.set(projectPath, {
+        trusted: true,
+        workspaces: [
+          {
+            id: "project-dir-template",
+            path: projectPath,
+            name: "project-dir-template",
+            runtimeConfig: { type: "local" },
+          },
+        ],
+      });
+      current.projects.set(subProjectPath, {
+        parentProjectPath: projectPath,
+        workspaces: [],
+      });
+      return current;
+    });
+    const client = createRouterClient(router(), { context: createContext({ enabled: true }) });
+
+    const result = await client.projects.workflowSchedules.set({
+      projectPath: subProjectPath,
+      schedule: {
+        enabled: true,
+        workflowName: "demo",
+        intervalMs: 60_000,
+        target: { type: "new-workspace", trunkBranch: "main" },
+      },
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("project-dir local workspaces"),
+    });
+  });
+
+  test("rejects existing-workspace conflicts across owner project schedules", async () => {
+    const subProjectPath = path.join(projectPath, "packages", "api");
+    await config.editConfig((current) => {
+      current.projects.set(projectPath, {
+        trusted: true,
+        workspaces: [{ id: "workspace-1", path: path.join(tempDir, "workspace-1") }],
+        workflowSchedules: [
+          {
+            id: "parent-schedule",
+            enabled: true,
+            workflowName: "demo",
+            intervalMs: 60_000,
+            target: { type: "existing-workspace", workspaceId: "workspace-1" },
+          },
+        ],
+      });
+      current.projects.set(subProjectPath, {
+        parentProjectPath: projectPath,
+        workspaces: [],
+      });
+      return current;
+    });
+    const client = createRouterClient(router(), { context: createContext({ enabled: true }) });
+
+    const result = await client.projects.workflowSchedules.set({
+      projectPath: subProjectPath,
+      schedule: {
+        enabled: true,
+        workflowName: "demo",
+        intervalMs: 60_000,
+        target: { type: "existing-workspace", workspaceId: "workspace-1" },
+      },
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("already has an automation"),
+    });
+  });
+
+  test("saves project workflow schedules through the API", async () => {
+    const client = createRouterClient(router(), { context: createContext({ enabled: true }) });
+
+    const result = await client.projects.workflowSchedules.set({
+      projectPath,
+      schedule: {
+        title: "GitHub triage",
+        enabled: true,
+        workflowName: "demo",
+        intervalMs: 6 * 60 * 60_000,
+        args: { label: "needs-triage" },
+        contextMode: "reset",
+        target: { type: "new-workspace", trunkBranch: "main", branchName: "scheduled-triage" },
+      },
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        title: "GitHub triage",
+        enabled: true,
+        workflowName: "demo",
+        intervalMs: 6 * 60 * 60_000,
+        args: { label: "needs-triage" },
+        target: { type: "new-workspace", trunkBranch: "main", branchName: "scheduled-triage" },
+      },
+    });
+    const storedSchedule = config.loadConfigOrDefault().projects.get(projectPath)
+      ?.workflowSchedules?.[0];
+    expect(storedSchedule?.contextMode).toBeUndefined();
+    expect(storedSchedule).toMatchObject({
+      id: expect.any(String),
+      title: "GitHub triage",
+      workflowName: "demo",
+    });
+  });
+
+  test("rejects multiple project schedules targeting the same existing workspace", async () => {
+    await config.editConfig((current) => {
+      current.projects.set(projectPath, {
+        ...(current.projects.get(projectPath) ?? { workspaces: [] }),
+        workspaces: [{ id: "workspace-1", path: path.join(projectPath, "workspace-1") }],
+      });
+      return current;
+    });
+    const client = createRouterClient(router(), { context: createContext({ enabled: true }) });
+
+    const first = await client.projects.workflowSchedules.set({
+      projectPath,
+      schedule: {
+        enabled: true,
+        workflowName: "demo",
+        intervalMs: 15 * 60_000,
+        target: { type: "existing-workspace", workspaceId: "workspace-1" },
+      },
+    });
+    expect(first.success).toBe(true);
+
+    if (!first.success) throw new Error("Expected first project schedule save to succeed");
+    const update = await client.projects.workflowSchedules.set({
+      projectPath,
+      schedule: {
+        id: first.data.id,
+        enabled: false,
+        workflowName: "demo",
+        intervalMs: 30 * 60_000,
+        target: { type: "existing-workspace", workspaceId: "workspace-1" },
+      },
+    });
+    expect(update.success).toBe(true);
+
+    const duplicate = await client.projects.workflowSchedules.set({
+      projectPath,
+      schedule: {
+        enabled: true,
+        workflowName: "demo",
+        intervalMs: 30 * 60_000,
+        target: { type: "existing-workspace", workspaceId: "workspace-1" },
+      },
+    });
+
+    expect(duplicate).toEqual({
+      success: false,
+      error:
+        "Failed to save project workflow schedule: Existing-workspace project automation target already has an automation",
+    });
+  });
+
+  test("rejects unsupported fresh-workspace project automations on save", async () => {
+    await config.editConfig((current) => {
+      current.projects.set(projectPath, {
+        ...(current.projects.get(projectPath) ?? { workspaces: [] }),
+        workspaces: [
+          {
+            id: "workspace-1",
+            path: projectPath,
+            runtimeConfig: { type: "local" },
+          },
+        ],
+      });
+      return current;
+    });
+    const client = createRouterClient(router(), { context: createContext({ enabled: true }) });
+
+    const result = await client.projects.workflowSchedules.set({
+      projectPath,
+      schedule: {
+        enabled: true,
+        workflowName: "demo",
+        intervalMs: 15 * 60_000,
+        target: { type: "new-workspace", trunkBranch: "main" },
+      },
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        "Failed to save project workflow schedule: New-workspace scheduled runs are not supported for project-dir local workspaces yet.",
+    });
+  });
+
+  test("runs project workflow schedules through the API", async () => {
+    const context = createContext({ enabled: true });
+    const runProjectScheduleNow = mock(
+      async (_input: { projectPath: string; scheduleId: string }) => ({
+        runId: "wfr_manual_project_schedule",
+        status: "backgrounded",
+      })
+    );
+    context.workflowSchedulerService = {
+      runProjectScheduleNow,
+    } as unknown as ORPCContext["workflowSchedulerService"];
+    const client = createRouterClient(router(), { context });
+
+    const result = await client.projects.workflowSchedules.run({
+      projectPath: `${projectPath}/`,
+      scheduleId: "automation-1",
+    });
+
+    expect(result).toEqual({
+      success: true,
+      data: { runId: "wfr_manual_project_schedule", status: "backgrounded" },
+    });
+    expect(runProjectScheduleNow).toHaveBeenCalledWith({
+      projectPath,
+      scheduleId: "automation-1",
+    });
   });
 
   test("promotes a scratch workflow run through the API", async () => {

--- a/src/node/orpc/router.test.ts
+++ b/src/node/orpc/router.test.ts
@@ -10,7 +10,7 @@ import { QuickJSRuntimeFactory } from "@/node/services/ptc/quickjsRuntime";
 import { ForegroundWaitBackgroundedError } from "@/node/services/taskService";
 import { WorkflowRunStore } from "@/node/services/workflows/WorkflowRunStore";
 import type { ORPCContext } from "./context";
-import { resolveWorkflowContext, router } from "./router";
+import { router } from "./router";
 
 describe("router workspace goal validation", () => {
   test("goal routes do not touch goal files for unknown workspaces", async () => {
@@ -205,12 +205,14 @@ describe("router workflow routes", () => {
       });
       return current;
     });
-    const context = createContext({ enabled: true, workspacePath });
+    const client = createRouterClient(router(), {
+      context: createContext({ enabled: true, workspacePath }),
+    });
 
-    const { service, projectTrusted } = await resolveWorkflowContext(context, "workspace-1", {
+    const definitions = await client.workflows.listDefinitions({
+      workspaceId: "workspace-1",
       projectPath: subProjectPath,
     });
-    const definitions = await service.listDefinitions({ projectTrusted });
 
     expect(definitions).toEqual(
       expect.arrayContaining([expect.objectContaining({ name: "sub-scan", scope: "project" })])
@@ -248,14 +250,12 @@ describe("router workflow routes", () => {
     );
   });
 
-  test("rejects ambiguous workflow definition discovery inputs", async () => {
+  test("rejects missing workflow definition discovery inputs", async () => {
     const client = createRouterClient(router(), {
       context: createContext({ enabled: true }),
     });
 
-    await expect(
-      client.workflows.listDefinitions({ projectPath, workspaceId: "workspace-1" } as never)
-    ).rejects.toThrow();
+    await expect(client.workflows.listDefinitions({} as never)).rejects.toThrow();
   });
 
   test("validates sub-project new-workspace schedules against owner workspace templates", async () => {

--- a/src/node/orpc/router.test.ts
+++ b/src/node/orpc/router.test.ts
@@ -296,6 +296,42 @@ describe("router workflow routes", () => {
     });
   });
 
+  test("rejects existing-workspace conflicts with workspace schedules", async () => {
+    await config.editConfig((current) => {
+      current.projects.set(projectPath, {
+        trusted: true,
+        workspaces: [
+          {
+            id: "workspace-1",
+            path: path.join(tempDir, "workspace-1"),
+            workflowSchedule: {
+              enabled: true,
+              workflowName: "demo",
+              intervalMs: 60_000,
+            },
+          },
+        ],
+      });
+      return current;
+    });
+    const client = createRouterClient(router(), { context: createContext({ enabled: true }) });
+
+    const result = await client.projects.workflowSchedules.set({
+      projectPath,
+      schedule: {
+        enabled: true,
+        workflowName: "demo",
+        intervalMs: 60_000,
+        target: { type: "existing-workspace", workspaceId: "workspace-1" },
+      },
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("already has an automation"),
+    });
+  });
+
   test("rejects existing-workspace conflicts across owner project schedules", async () => {
     const subProjectPath = path.join(projectPath, "packages", "api");
     await config.editConfig((current) => {

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -1964,7 +1964,8 @@ export const router = (authToken?: string) => {
           if (input.workspaceId != null) {
             const { service, projectTrusted } = await resolveWorkflowContext(
               context,
-              input.workspaceId
+              input.workspaceId,
+              input.projectPath != null ? { projectPath: input.projectPath } : {}
             );
             return service.listDefinitions({ projectTrusted });
           }

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -26,6 +26,7 @@ import type {
   FrontendWorkspaceMetadataSchemaType,
   SendMessageOptions,
 } from "@/common/orpc/types";
+import type { ProjectWorkflowSchedule } from "@/common/types/project";
 import type { WorkspaceMetadata } from "@/common/types/workspace";
 import type { SshPromptEvent, SshPromptRequest } from "@/common/orpc/schemas/ssh";
 import {
@@ -42,7 +43,11 @@ import { createReplayBufferedStreamMessageRelay } from "./replayBufferedStreamMe
 
 import { getRuntimeType } from "@/node/runtime/initHook";
 import { createRuntime, checkRuntimeAvailability } from "@/node/runtime/runtimeFactory";
-import { createRuntimeForWorkspace, resolveWorkspaceRootPath } from "@/node/runtime/runtimeHelpers";
+import {
+  appendSubProjectRelativePath,
+  createRuntimeForWorkspace,
+  resolveWorkspaceRootPath,
+} from "@/node/runtime/runtimeHelpers";
 import { readPlanFile } from "@/node/utils/runtime/helpers";
 import {
   parseMemoryPath,
@@ -93,6 +98,7 @@ import {
 import { isAgentEffectivelyDisabled } from "@/node/services/agentDefinitions/agentEnablement";
 import { resolveAgentVisibility } from "@/node/services/agentDefinitions/agentVisibility";
 import { isWorkspaceArchived } from "@/common/utils/archive";
+import { getSupportedWorkflowScheduleNewWorkspaceTemplate } from "@/common/utils/workflowScheduleTarget";
 import assert from "node:assert/strict";
 import * as fsPromises from "fs/promises";
 import * as path from "node:path";
@@ -124,6 +130,8 @@ import {
 } from "@/node/services/workflows/WorkflowService";
 import { WorkflowTaskServiceAdapter } from "@/node/services/workflows/WorkflowTaskServiceAdapter";
 import { resolveWorkflowScratchRoots } from "@/node/services/workflows/workflowScratchRoots";
+import { WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE } from "@/constants/workflowSchedule";
+import { validateWorkspaceName } from "@/common/utils/validation/workspaceValidation";
 import { isProjectTrusted } from "@/node/utils/projectTrust";
 
 import {
@@ -157,7 +165,7 @@ function isWorkspaceBusyIdleOnlySend(error: { type: string; raw?: string }): boo
   );
 }
 
-async function sendWorkflowRunTerminalContinuation(input: {
+export async function sendWorkflowRunTerminalContinuation(input: {
   context: ORPCContext;
   workspaceId: string;
   rawCommand: string;
@@ -339,6 +347,8 @@ export async function resolveWorkflowContext(
   workspaceId: string,
   options: {
     onBackgroundRunTerminal?: (event: WorkflowBackgroundRunTerminalEvent) => Promise<void> | void;
+    notifyInterruptedBackgroundRunTerminal?: boolean;
+    projectPath?: string;
   } = {}
 ): Promise<{ service: WorkflowService; projectTrusted: boolean }> {
   assert(workspaceId.length > 0, "resolveWorkflowContext: workspaceId is required");
@@ -349,9 +359,22 @@ export async function resolveWorkflowContext(
     throw new Error(metadataResult.error);
   }
   const metadata = metadataResult.data;
-  const projectTrusted = isTrustedProjectPath(context, metadata.projectPath);
+  const requestedWorkflowProjectPath = options.projectPath?.trim();
+  const workflowProjectPath =
+    requestedWorkflowProjectPath != null && requestedWorkflowProjectPath.length > 0
+      ? requestedWorkflowProjectPath
+      : metadata.projectPath;
+  const projectTrusted = isTrustedProjectPath(context, workflowProjectPath);
   const runtime = createRuntimeForWorkspace(metadata);
-  const workspacePath = resolveWorkspaceRootPath(metadata, runtime);
+  const workspaceRootPath = resolveWorkspaceRootPath(metadata, runtime);
+  const workspacePath =
+    options.projectPath != null
+      ? appendSubProjectRelativePath(
+          { ...metadata, subProjectPath: workflowProjectPath },
+          runtime,
+          workspaceRootPath
+        )
+      : workspaceRootPath;
   const runtimeType = getRuntimeType(metadata.runtimeConfig);
   const useRuntimeProjectIO = shouldUseRuntimeWorkflowProjectIO(runtimeType);
   const disableHostWorkflowActions = shouldDisableHostWorkflowActions(runtimeType);
@@ -376,6 +399,8 @@ export async function resolveWorkflowContext(
         projectRuntime: useRuntimeProjectIO ? runtime : undefined,
         projectCwd: useRuntimeProjectIO ? workspacePath : undefined,
       }),
+      notifyInterruptedBackgroundRunTerminal:
+        options.notifyInterruptedBackgroundRunTerminal === true,
       actionRegistry: new WorkflowActionRegistry({
         projectRoot: runtime.normalizePath(".mux/actions", workspacePath),
         globalRoot: path.join(context.config.rootDir, "actions"),
@@ -409,7 +434,7 @@ export async function resolveWorkflowContext(
             workspaceSessionDir: context.config.getSessionDir(workspaceId),
             trusted: projectTrusted,
           },
-          getProjectTrusted: () => isTrustedProjectPath(context, metadata.projectPath),
+          getProjectTrusted: () => isTrustedProjectPath(context, workflowProjectPath),
           experiments: {
             dynamicWorkflows: true,
             subagentFileReports: subagentFileReportsExperimentEnabled,
@@ -418,7 +443,7 @@ export async function resolveWorkflowContext(
       ...(options.onBackgroundRunTerminal != null
         ? { onBackgroundRunTerminal: options.onBackgroundRunTerminal }
         : {}),
-      getCurrentProjectTrusted: () => isTrustedProjectPath(context, metadata.projectPath),
+      getCurrentProjectTrusted: () => isTrustedProjectPath(context, workflowProjectPath),
       runnerId: `workflow-runner:${workspaceId}`,
     }),
   };
@@ -738,6 +763,80 @@ async function runBrowserCommandWithLoadingState<T extends { success: boolean }>
     await markBrowserCommandLoadedFromCurrentUrl({ ...params, commandToken });
     throw error;
   }
+}
+
+type ProjectWorkflowScheduleInput = Omit<ProjectWorkflowSchedule, "id" | "lastRunStartedAt"> & {
+  id?: string;
+};
+
+function normalizeProjectWorkflowScheduleForPersist(
+  schedule: ProjectWorkflowScheduleInput,
+  id: string
+): ProjectWorkflowSchedule {
+  const scheduleId = id.trim();
+  assert(scheduleId.length > 0, "Project workflow schedule requires a non-empty id");
+
+  const workflowName = schedule.workflowName.trim();
+  assert(workflowName.length > 0, "Project workflow schedule requires a non-empty workflowName");
+
+  const contextMode = schedule.contextMode ?? WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE;
+  assert(
+    contextMode === "normal" || contextMode === "compact" || contextMode === "reset",
+    `Unsupported project workflow schedule context mode: ${String(contextMode)}`
+  );
+
+  const title = schedule.title?.trim();
+  const target = schedule.target;
+  const normalizedTarget: ProjectWorkflowSchedule["target"] =
+    target.type === "existing-workspace"
+      ? {
+          type: "existing-workspace",
+          workspaceId: target.workspaceId.trim(),
+        }
+      : (() => {
+          const trunkBranch = target.trunkBranch.trim();
+          assert(
+            trunkBranch.length > 0,
+            "New-workspace project workflow schedules require a non-empty trunkBranch"
+          );
+          const branchName = target.branchName?.trim();
+          if (branchName) {
+            const branchNameValidation = validateWorkspaceName(branchName);
+            assert(
+              branchNameValidation.valid,
+              branchNameValidation.error ?? "Invalid project workflow target branch name"
+            );
+          }
+          const targetTitle = target.title?.trim();
+          return {
+            type: "new-workspace",
+            trunkBranch,
+            ...(branchName ? { branchName } : {}),
+            ...(targetTitle ? { title: targetTitle } : {}),
+          };
+        })();
+
+  if (normalizedTarget.type === "existing-workspace") {
+    assert(
+      normalizedTarget.workspaceId.length > 0,
+      "Existing-workspace project workflow schedules require a workspaceId"
+    );
+  }
+
+  const shouldPersistContextMode =
+    normalizedTarget.type === "existing-workspace" &&
+    contextMode !== WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE;
+
+  return {
+    id: scheduleId,
+    ...(title ? { title } : {}),
+    enabled: schedule.enabled,
+    workflowName,
+    ...(schedule.args != null ? { args: schedule.args } : {}),
+    intervalMs: schedule.intervalMs,
+    ...(shouldPersistContextMode ? { contextMode } : {}),
+    target: normalizedTarget,
+  };
 }
 
 export const router = (authToken?: string) => {
@@ -1875,13 +1974,13 @@ export const router = (authToken?: string) => {
             input.projectPath != null,
             "Workflow definition discovery requires a project path"
           );
+          const projectPath = stripTrailingSlashes(input.projectPath);
+          const projectTrusted = isTrustedProjectPath(context, projectPath);
           const definitionStore = new WorkflowDefinitionStore({
-            projectRoot: path.join(input.projectPath, ".mux", "workflows"),
+            projectRoot: path.join(projectPath, ".mux", "workflows"),
             globalRoot: path.join(context.config.rootDir, "workflows"),
           });
-          return definitionStore.listDefinitions({
-            projectTrusted: isTrustedProjectPath(context, input.projectPath),
-          });
+          return definitionStore.listDefinitions({ projectTrusted });
         }),
       readDefinition: t
         .input(schemas.workflows.readDefinition.input)
@@ -3186,6 +3285,152 @@ export const router = (authToken?: string) => {
             return config;
           });
         }),
+      workflowSchedules: {
+        set: t
+          .input(schemas.projects.workflowSchedules.set.input)
+          .output(schemas.projects.workflowSchedules.set.output)
+          .handler(async ({ context, input }) => {
+            if (input.schedule.enabled) {
+              assertDynamicWorkflowsEnabled(context);
+            }
+            try {
+              const normalizedPath = stripTrailingSlashes(input.projectPath);
+              const inputScheduleId = input.schedule.id?.trim();
+              const scheduleId =
+                inputScheduleId != null && inputScheduleId.length > 0
+                  ? inputScheduleId
+                  : context.config.generateStableId();
+              let savedSchedule: ProjectWorkflowSchedule | null = null;
+              await context.config.editConfig((config) => {
+                const project = config.projects.get(normalizedPath);
+                if (!project) {
+                  throw new Error(`Project not found: ${normalizedPath}`);
+                }
+                const normalizedSchedule = normalizeProjectWorkflowScheduleForPersist(
+                  input.schedule,
+                  scheduleId
+                );
+                const normalizedTarget = normalizedSchedule.target;
+                const ownerProjectPath = project.parentProjectPath ?? normalizedPath;
+                const ownerProject =
+                  ownerProjectPath === normalizedPath
+                    ? project
+                    : config.projects.get(ownerProjectPath);
+                assert(ownerProject != null, "Project automation owner project must exist");
+                if (normalizedTarget.type === "existing-workspace") {
+                  const targetWorkspace = ownerProject.workspaces.find(
+                    (workspace) => workspace.id === normalizedTarget.workspaceId
+                  );
+                  assert(
+                    targetWorkspace != null,
+                    "Existing-workspace project automation target must belong to the project"
+                  );
+                } else {
+                  const support = getSupportedWorkflowScheduleNewWorkspaceTemplate({
+                    sourceProjectPath: normalizedPath,
+                    workspaces: ownerProject.workspaces,
+                  });
+                  assert(
+                    support.unavailableReason == null,
+                    support.unavailableReason ??
+                      "New-workspace automations are unavailable for this project"
+                  );
+                }
+                const existingSchedules = project.workflowSchedules ?? [];
+                if (normalizedTarget.type === "existing-workspace") {
+                  const conflictingSchedule = Array.from(config.projects.entries())
+                    .flatMap(([candidateProjectPath, candidateProject]) => {
+                      const candidateOwnerPath =
+                        candidateProject.parentProjectPath ?? candidateProjectPath;
+                      if (candidateOwnerPath !== ownerProjectPath) {
+                        return [];
+                      }
+                      return (candidateProject.workflowSchedules ?? []).map((schedule) => ({
+                        projectPath: candidateProjectPath,
+                        schedule,
+                      }));
+                    })
+                    .find(
+                      (candidate) =>
+                        !(
+                          candidate.projectPath === normalizedPath &&
+                          candidate.schedule.id === normalizedSchedule.id
+                        ) &&
+                        candidate.schedule.target.type === "existing-workspace" &&
+                        candidate.schedule.target.workspaceId === normalizedTarget.workspaceId
+                    );
+                  assert(
+                    conflictingSchedule == null,
+                    "Existing-workspace project automation target already has an automation"
+                  );
+                }
+                project.workflowSchedules = [
+                  ...existingSchedules.filter((schedule) => schedule.id !== normalizedSchedule.id),
+                  normalizedSchedule,
+                ];
+                savedSchedule = normalizedSchedule;
+                return config;
+              });
+              assert(
+                savedSchedule != null,
+                "Project workflow schedule save must produce a schedule"
+              );
+              return Ok(savedSchedule);
+            } catch (error) {
+              return Err(`Failed to save project workflow schedule: ${getErrorMessage(error)}`);
+            }
+          }),
+        run: t
+          .input(schemas.projects.workflowSchedules.run.input)
+          .output(schemas.projects.workflowSchedules.run.output)
+          .handler(async ({ context, input }) => {
+            assertDynamicWorkflowsEnabled(context);
+            try {
+              const result = await context.workflowSchedulerService.runProjectScheduleNow({
+                projectPath: stripTrailingSlashes(input.projectPath),
+                scheduleId: input.scheduleId,
+              });
+              return Ok({
+                runId: result.runId,
+                status: schemas.WorkflowRunStatusSchema.parse(result.status),
+              });
+            } catch (error) {
+              return Err(`Failed to run project workflow schedule: ${getErrorMessage(error)}`);
+            }
+          }),
+        remove: t
+          .input(schemas.projects.workflowSchedules.remove.input)
+          .output(schemas.projects.workflowSchedules.remove.output)
+          .handler(async ({ context, input }) => {
+            try {
+              const normalizedPath = stripTrailingSlashes(input.projectPath);
+              let removed = false;
+              await context.config.editConfig((config) => {
+                const project = config.projects.get(normalizedPath);
+                if (!project) {
+                  throw new Error(`Project not found: ${normalizedPath}`);
+                }
+                const existingSchedules = project.workflowSchedules ?? [];
+                const nextSchedules = existingSchedules.filter(
+                  (schedule) => schedule.id !== input.scheduleId
+                );
+                removed = nextSchedules.length !== existingSchedules.length;
+                if (nextSchedules.length > 0) {
+                  project.workflowSchedules = nextSchedules;
+                } else {
+                  delete project.workflowSchedules;
+                }
+                return config;
+              });
+              if (!removed) {
+                return Err("Project workflow schedule not found");
+              }
+              return Ok(undefined);
+            } catch (error) {
+              return Err(`Failed to remove project workflow schedule: ${getErrorMessage(error)}`);
+            }
+          }),
+      },
       remove: t
         .input(schemas.projects.remove.input)
         .output(schemas.projects.remove.output)
@@ -4052,8 +4297,11 @@ export const router = (authToken?: string) => {
         .output(schemas.workspace.setWorkflowSchedule.output)
         .handler(async ({ context, input }) => {
           // Scheduled runs only dispatch under the dynamic-workflows experiment;
-          // reject configuration up-front instead of persisting a dormant schedule.
-          assertDynamicWorkflowsEnabled(context);
+          // reject non-null configuration up-front instead of persisting a dormant schedule.
+          // Clearing is always allowed so stale schedules can be removed after disabling the experiment.
+          if (input.schedule != null) {
+            assertDynamicWorkflowsEnabled(context);
+          }
           return context.workspaceService.setWorkflowSchedule(input.workspaceId, input.schedule);
         }),
       regenerateTitle: t

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -3359,8 +3359,13 @@ export const router = (authToken?: string) => {
                         candidate.schedule.target.type === "existing-workspace" &&
                         candidate.schedule.target.workspaceId === normalizedTarget.workspaceId
                     );
+                  const conflictingWorkspaceSchedule = ownerProject.workspaces.find(
+                    (workspace) =>
+                      workspace.id === normalizedTarget.workspaceId &&
+                      workspace.workflowSchedule != null
+                  );
                   assert(
-                    conflictingSchedule == null,
+                    conflictingSchedule == null && conflictingWorkspaceSchedule == null,
                     "Existing-workspace project automation target already has an automation"
                   );
                 }

--- a/src/node/services/serviceContainer.test.ts
+++ b/src/node/services/serviceContainer.test.ts
@@ -1,10 +1,37 @@
 import * as fs from "fs";
+import * as fsPromises from "fs/promises";
 import * as os from "os";
 import * as path from "path";
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
+import {
+  WORKFLOW_RESULT_METADATA_TYPE,
+  WORKFLOW_RUN_CARD_DISPLAY_METADATA_TYPE,
+  WORKFLOW_TRIGGER_DISPLAY_METADATA_TYPE,
+} from "@/common/utils/workflowRunMessages";
 import { Config } from "@/node/config";
 import { ServiceContainer } from "./serviceContainer";
+
+function parseJsonObjectLine(line: string): Record<string, unknown> {
+  const parsed: unknown = JSON.parse(line);
+  if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Expected chat.jsonl line to contain an object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function getMuxMetadata(message: Record<string, unknown>): Record<string, unknown> | null {
+  const metadata = message.metadata;
+  if (metadata == null || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return null;
+  }
+  const muxMetadata = (metadata as Record<string, unknown>).muxMetadata;
+  if (muxMetadata == null || typeof muxMetadata !== "object" || Array.isArray(muxMetadata)) {
+    return null;
+  }
+  return muxMetadata as Record<string, unknown>;
+}
 
 describe("ServiceContainer", () => {
   let tempDir: string;
@@ -75,6 +102,306 @@ describe("ServiceContainer", () => {
         parentWorkspaceId: "parent-workspace",
       }
     );
+  });
+
+  it("continues the target workspace after an automation workflow finishes", async () => {
+    const projectPath = path.join(tempDir, "project");
+    const workspaceId = "workspace-1";
+    await fsPromises.mkdir(path.join(projectPath, ".mux", "workflows"), { recursive: true });
+    await fsPromises.writeFile(
+      path.join(projectPath, ".mux", "workflows", "security-scan.js"),
+      "// description: Security scan\nexport default function workflow() { return { reportMarkdown: 'scan done' }; }\n",
+      "utf-8"
+    );
+    await config.editConfig((current) => {
+      current.projects.set(projectPath, {
+        trusted: true,
+        workspaces: [
+          {
+            path: projectPath,
+            id: workspaceId,
+            name: "main",
+            runtimeConfig: { type: "local" },
+          },
+        ],
+        workflowSchedules: [
+          {
+            id: "schedule-1",
+            enabled: true,
+            workflowName: "security-scan",
+            args: { severity: "high" },
+            intervalMs: 60_000,
+            target: { type: "existing-workspace", workspaceId },
+          },
+        ],
+      });
+      return current;
+    });
+    services = new ServiceContainer(config);
+    spyOn(services.experimentsService, "isExperimentEnabled").mockImplementation(
+      (experimentId) => experimentId === EXPERIMENT_IDS.DYNAMIC_WORKFLOWS
+    );
+    const continuationSpy = spyOn(services.workspaceService, "sendMessage").mockImplementation(() =>
+      Promise.resolve({ success: true as const, data: undefined })
+    );
+
+    services.workflowSchedulerService.tick();
+    await services.workflowSchedulerService.awaitActiveDispatches();
+
+    const chatPath = path.join(config.getSessionDir(workspaceId), "chat.jsonl");
+    const messages = (await fsPromises.readFile(chatPath, "utf-8"))
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map(parseJsonObjectLine);
+    const triggerMessage = messages.find(
+      (message) => getMuxMetadata(message)?.type === WORKFLOW_TRIGGER_DISPLAY_METADATA_TYPE
+    );
+    const cardMessage = messages.find(
+      (message) => getMuxMetadata(message)?.type === WORKFLOW_RUN_CARD_DISPLAY_METADATA_TYPE
+    );
+    if (triggerMessage == null || cardMessage == null) {
+      throw new Error("Expected automation trigger and card messages");
+    }
+    const triggerMetadata = triggerMessage.metadata as Record<string, unknown>;
+    const triggerMuxMetadata = getMuxMetadata(triggerMessage);
+    const cardMetadata = cardMessage.metadata as Record<string, unknown>;
+    const cardMuxMetadata = getMuxMetadata(cardMessage);
+    const triggerRunId = triggerMuxMetadata?.runId;
+    const cardRunId = cardMuxMetadata?.runId;
+
+    expect(typeof triggerRunId).toBe("string");
+    expect(cardRunId).toBe(triggerRunId);
+    expect(triggerMessage.role).toBe("user");
+    expect(triggerMetadata.synthetic).toBe(true);
+    expect(triggerMetadata.uiVisible).toBe(true);
+    expect(triggerMuxMetadata).toMatchObject({
+      type: WORKFLOW_TRIGGER_DISPLAY_METADATA_TYPE,
+      rawCommand: "Automation: security-scan",
+    });
+    expect(cardMessage.role).toBe("assistant");
+    expect(cardMetadata.synthetic).toBe(true);
+    expect(cardMetadata.uiVisible).toBe(true);
+    expect(cardMuxMetadata).toMatchObject({ type: WORKFLOW_RUN_CARD_DISPLAY_METADATA_TYPE });
+    if (!Array.isArray(cardMessage.parts) || cardMessage.parts.length !== 1) {
+      throw new Error("Expected automation card to contain one tool part");
+    }
+    const cardPart = cardMessage.parts[0] as Record<string, unknown>;
+    const cardInput = cardPart.input as Record<string, unknown>;
+    const cardOutput = cardPart.output as Record<string, unknown>;
+    expect(cardPart.type).toBe("dynamic-tool");
+    expect(cardPart.toolName).toBe("workflow_run");
+    expect(cardInput).toEqual({
+      name: "security-scan",
+      args: { severity: "high" },
+      run_in_background: true,
+    });
+    const continuationCall = continuationSpy.mock.calls[0];
+    if (continuationCall == null) {
+      throw new Error("Expected automation completion to trigger a continuation turn");
+    }
+    expect(continuationCall[0]).toBe(workspaceId);
+    expect(continuationCall[1]).toContain("<mux_workflow_result>");
+    expect(continuationCall[1]).toContain("scan done");
+    expect(continuationCall[2]?.muxMetadata).toMatchObject({
+      type: WORKFLOW_RESULT_METADATA_TYPE,
+      rawCommand: "Automation: security-scan",
+      runId: triggerRunId,
+    });
+    expect(continuationCall[3]).toMatchObject({
+      synthetic: true,
+      agentInitiated: true,
+      requireIdle: true,
+      startStreamInBackground: true,
+    });
+    expect(cardOutput.status).toBe("pending");
+    expect(cardOutput.runId).toBe(triggerRunId);
+  });
+
+  it("continues the target workspace after an automation workflow fails", async () => {
+    const projectPath = path.join(tempDir, "failing-project");
+    const workspaceId = "workspace-fail";
+    await fsPromises.mkdir(path.join(projectPath, ".mux", "workflows"), { recursive: true });
+    await fsPromises.writeFile(
+      path.join(projectPath, ".mux", "workflows", "failing-scan.js"),
+      "// description: Failing scan\nexport default function workflow() { throw new Error('scan failed'); }\n",
+      "utf-8"
+    );
+    await config.editConfig((current) => {
+      current.projects.set(projectPath, {
+        trusted: true,
+        workspaces: [
+          {
+            path: projectPath,
+            id: workspaceId,
+            name: "main",
+            runtimeConfig: { type: "local" },
+          },
+        ],
+        workflowSchedules: [
+          {
+            id: "schedule-fail",
+            enabled: true,
+            workflowName: "failing-scan",
+            intervalMs: 60_000,
+            target: { type: "existing-workspace", workspaceId },
+          },
+        ],
+      });
+      return current;
+    });
+    services = new ServiceContainer(config);
+    spyOn(services.experimentsService, "isExperimentEnabled").mockImplementation(
+      (experimentId) => experimentId === EXPERIMENT_IDS.DYNAMIC_WORKFLOWS
+    );
+    const continuationSpy = spyOn(services.workspaceService, "sendMessage").mockImplementation(() =>
+      Promise.resolve({ success: true as const, data: undefined })
+    );
+
+    services.workflowSchedulerService.tick();
+    await services.workflowSchedulerService.awaitActiveDispatches();
+
+    const continuationCall = continuationSpy.mock.calls[0];
+    if (continuationCall == null) {
+      throw new Error("Expected failing automation to trigger a continuation turn");
+    }
+    expect(continuationCall[0]).toBe(workspaceId);
+    expect(continuationCall[1]).toContain("<mux_workflow_result>");
+    expect(continuationCall[2]?.muxMetadata).toMatchObject({
+      type: WORKFLOW_RESULT_METADATA_TYPE,
+      rawCommand: "Automation: failing-scan",
+    });
+    expect(continuationCall[3]).toMatchObject({
+      synthetic: true,
+      agentInitiated: true,
+      requireIdle: true,
+      startStreamInBackground: true,
+    });
+  });
+
+  it("does not inherit sub-project scope when creating project automation workspaces", async () => {
+    const projectPath = path.join(tempDir, "project-with-subscope-template");
+    const subProjectPath = path.join(projectPath, "packages", "api");
+    const templateWorkspaceId = "template-workspace";
+    await config.editConfig((current) => {
+      current.projects.set(projectPath, {
+        trusted: true,
+        workspaces: [
+          {
+            path: projectPath,
+            id: templateWorkspaceId,
+            name: "api-workspace",
+            subProjectPath,
+            runtimeConfig: { type: "local", srcBaseDir: tempDir },
+          },
+        ],
+        workflowSchedules: [
+          {
+            id: "schedule-new-workspace",
+            enabled: true,
+            workflowName: "missing-workflow",
+            intervalMs: 60_000,
+            target: { type: "new-workspace", trunkBranch: "main" },
+          },
+        ],
+      });
+      current.projects.set(subProjectPath, {
+        parentProjectPath: projectPath,
+        workspaces: [],
+      });
+      return current;
+    });
+    services = new ServiceContainer(config);
+    spyOn(services.experimentsService, "isExperimentEnabled").mockImplementation(
+      (experimentId) => experimentId === EXPERIMENT_IDS.DYNAMIC_WORKFLOWS
+    );
+    const createSpy = spyOn(services.workspaceService, "create").mockImplementation(() =>
+      Promise.resolve({
+        success: true as const,
+        data: {
+          metadata: {
+            id: "created-workspace",
+            name: "created-workspace",
+            projectName: path.basename(projectPath),
+            projectPath,
+            namedWorkspacePath: path.join(tempDir, "created-workspace"),
+            runtimeConfig: { type: "local" as const, srcBaseDir: tempDir },
+          },
+        },
+      })
+    );
+    spyOn(services.workspaceService, "archive").mockImplementation(() =>
+      Promise.resolve({ success: true as const, data: { kind: "archived" as const } })
+    );
+
+    services.workflowSchedulerService.tick();
+    await services.workflowSchedulerService.awaitActiveDispatches();
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(createSpy.mock.calls[0]?.[5]).toBeUndefined();
+  });
+
+  it("uses parent workspace templates when creating sub-project automation workspaces", async () => {
+    const projectPath = path.join(tempDir, "project-with-subproject-schedule");
+    const subProjectPath = path.join(projectPath, "packages", "api");
+    await config.editConfig((current) => {
+      current.projects.set(projectPath, {
+        trusted: true,
+        workspaces: [
+          {
+            path: projectPath,
+            id: "parent-template",
+            name: "parent-template",
+            runtimeConfig: { type: "local", srcBaseDir: tempDir },
+          },
+        ],
+      });
+      current.projects.set(subProjectPath, {
+        parentProjectPath: projectPath,
+        workspaces: [],
+        workflowSchedules: [
+          {
+            id: "subproject-schedule",
+            enabled: true,
+            workflowName: "missing-workflow",
+            intervalMs: 60_000,
+            target: { type: "new-workspace", trunkBranch: "main" },
+          },
+        ],
+      });
+      return current;
+    });
+    services = new ServiceContainer(config);
+    spyOn(services.experimentsService, "isExperimentEnabled").mockImplementation(
+      (experimentId) => experimentId === EXPERIMENT_IDS.DYNAMIC_WORKFLOWS
+    );
+    const createSpy = spyOn(services.workspaceService, "create").mockImplementation(() =>
+      Promise.resolve({
+        success: true as const,
+        data: {
+          metadata: {
+            id: "created-subproject-workspace",
+            name: "created-subproject-workspace",
+            projectName: path.basename(projectPath),
+            projectPath,
+            namedWorkspacePath: path.join(tempDir, "created-subproject-workspace"),
+            subProjectPath,
+            runtimeConfig: { type: "local" as const, srcBaseDir: tempDir },
+          },
+        },
+      })
+    );
+    spyOn(services.workspaceService, "archive").mockImplementation(() =>
+      Promise.resolve({ success: true as const, data: { kind: "archived" as const } })
+    );
+
+    services.workflowSchedulerService.tick();
+    await services.workflowSchedulerService.awaitActiveDispatches();
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(createSpy.mock.calls[0]?.[0]).toBe(subProjectPath);
+    expect(createSpy.mock.calls[0]?.[4]).toEqual({ type: "local", srcBaseDir: tempDir });
+    expect(createSpy.mock.calls[0]?.[5]).toBeUndefined();
   });
 
   it("exposes desktopSessionManager in the ORPC context", () => {

--- a/src/node/services/serviceContainer.ts
+++ b/src/node/services/serviceContainer.ts
@@ -45,7 +45,7 @@ import { WorkspaceMcpOverridesService } from "@/node/services/workspaceMcpOverri
 import { McpOauthService } from "@/node/services/mcpOauthService";
 import { HeartbeatService } from "@/node/services/heartbeatService";
 import { WorkflowSchedulerService } from "@/node/services/workflows/WorkflowSchedulerService";
-import { resolveWorkflowContext } from "@/node/orpc/router";
+import { resolveWorkflowContext, sendWorkflowRunTerminalContinuation } from "@/node/orpc/router";
 import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { AgentStatusService } from "@/node/services/agentStatusService";
 import { IdleCompactionService } from "@/node/services/idleCompactionService";
@@ -75,6 +75,16 @@ import { DesktopSessionManager } from "@/node/services/desktop/DesktopSessionMan
 import { DesktopTokenManager } from "@/node/services/desktop/DesktopTokenManager";
 import type { ORPCContext } from "@/node/orpc/context";
 import type { ExternalSecretResolver } from "@/common/types/secrets";
+import {
+  getRuntimeConfigForScheduledNewWorkspaceTarget,
+  getSupportedWorkflowScheduleNewWorkspaceTemplate,
+  getWorkflowScheduleNewWorkspaceTargetUnavailableReason,
+} from "@/common/utils/workflowScheduleTarget";
+
+function trimToUndefined(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed != null && trimmed.length > 0 ? trimmed : undefined;
+}
 
 /**
  * ServiceContainer - Central dependency container for all backend services.
@@ -273,25 +283,213 @@ export class ServiceContainer {
       config,
       isEnabled: () =>
         this.experimentsService.isExperimentEnabled(EXPERIMENT_IDS.DYNAMIC_WORKFLOWS),
+      createWorkspaceForSchedule: async (input) => {
+        const unsupportedReason = getWorkflowScheduleNewWorkspaceTargetUnavailableReason({
+          sourceProjectPath: input.sourceProjectPath,
+          projects: input.sourceWorkspace.projects,
+          runtimeConfig: input.sourceWorkspace.runtimeConfig,
+        });
+        if (unsupportedReason != null) {
+          throw new Error(unsupportedReason);
+        }
+        const trunkBranch = input.target.trunkBranch.trim();
+        if (trunkBranch.length === 0) {
+          throw new Error("Automation new-workspace target requires a base branch");
+        }
+        const branchName = trimToUndefined(input.target.branchName);
+        const title = trimToUndefined(input.target.title);
+        const result = await this.workspaceService.create(
+          input.sourceProjectPath,
+          branchName,
+          trunkBranch,
+          title,
+          getRuntimeConfigForScheduledNewWorkspaceTarget(input.sourceWorkspace.runtimeConfig),
+          input.sourceWorkspace.subProjectPath,
+          false,
+          {
+            scheduledWorkflowSourceWorkspaceId: input.sourceWorkspaceId,
+            scheduledWorkflowName: input.workflowName,
+            scheduledWorkflowStartedAt: input.startedAt,
+          }
+        );
+        if (!result.success) {
+          throw new Error(result.error);
+        }
+        return { workspaceId: result.data.metadata.id };
+      },
+      createWorkspaceForProjectSchedule: async (input) => {
+        const ownerProjectPath = input.sourceProject.parentProjectPath ?? input.sourceProjectPath;
+        const ownerProject =
+          ownerProjectPath === input.sourceProjectPath
+            ? input.sourceProject
+            : this.config.loadConfigOrDefault().projects.get(ownerProjectPath);
+        if (ownerProject == null) {
+          throw new Error("Project automation owner project was not found");
+        }
+        const template = getSupportedWorkflowScheduleNewWorkspaceTemplate({
+          sourceProjectPath: input.sourceProjectPath,
+          workspaces: ownerProject.workspaces,
+        });
+        if (template.unavailableReason != null) {
+          throw new Error(template.unavailableReason);
+        }
+        const templateWorkspace = template.workspace;
+        const trunkBranch = input.target.trunkBranch.trim();
+        if (trunkBranch.length === 0) {
+          throw new Error("Project automation new-workspace target requires a base branch");
+        }
+        const branchName = trimToUndefined(input.target.branchName);
+        const title = trimToUndefined(input.target.title);
+        const result = await this.workspaceService.create(
+          input.sourceProjectPath,
+          branchName,
+          trunkBranch,
+          title,
+          getRuntimeConfigForScheduledNewWorkspaceTarget(templateWorkspace?.runtimeConfig),
+          // Project automations are scoped to the configured project; the template only donates runtime settings.
+          undefined,
+          false,
+          {
+            scheduledWorkflowProjectPath: input.sourceProjectPath,
+            scheduledWorkflowScheduleId: input.scheduleId,
+            scheduledWorkflowName: input.workflowName,
+            scheduledWorkflowStartedAt: input.startedAt,
+          }
+        );
+        if (!result.success) {
+          throw new Error(result.error);
+        }
+        return { workspaceId: result.data.metadata.id };
+      },
+      prepareContext: async (input) => {
+        const result = await this.workspaceService.prepareScheduledWorkflowContext(
+          input.workspaceId,
+          input.contextMode
+        );
+        if (!result.success) {
+          throw new Error(result.error);
+        }
+      },
+      cleanupWorkspaceForSchedule: async (input) => {
+        const result = await this.workspaceService.archive(input.workspaceId);
+        if (!result.success) {
+          throw new Error(result.error);
+        }
+        if (result.data.kind !== "archived") {
+          throw new Error("Automation target archive requires untracked-file confirmation");
+        }
+      },
+      onScheduleStamped: async (input) => {
+        if (input.type === "workspace") {
+          await this.workspaceService.emitCurrentWorkflowScheduleMetadata(input.workspaceId);
+        }
+      },
       startWorkflow: async (input) => {
         // Same construction as the workflows.* ORPC routes so scheduled runs
         // behave identically to manual ones (run store, trust, host actions).
+        const context = this.toORPCContext();
+        const rawCommand = `Automation: ${input.name}`;
+        let createdRunId: string | null = null;
+        const sendTerminalContinuation = async (
+          event: Parameters<typeof sendWorkflowRunTerminalContinuation>[0]["event"]
+        ) => {
+          try {
+            if (event.status !== "interrupted") {
+              await sendWorkflowRunTerminalContinuation({
+                context,
+                workspaceId: input.workspaceId,
+                rawCommand,
+                name: input.name,
+                event,
+              });
+            }
+          } finally {
+            await input.onTerminal?.(event);
+          }
+        };
         const { service, projectTrusted } = await resolveWorkflowContext(
-          this.toORPCContext(),
-          input.workspaceId
+          context,
+          input.workspaceId,
+          {
+            onBackgroundRunTerminal: sendTerminalContinuation,
+            notifyInterruptedBackgroundRunTerminal: input.onTerminal != null,
+            ...(input.projectScheduleId != null && input.sourceProjectPath != null
+              ? { projectPath: input.sourceProjectPath }
+              : {}),
+          }
         );
-        return service.startNamedWorkflow({
-          name: input.name,
-          workspaceId: input.workspaceId,
-          projectTrusted,
-          args: input.args,
-          // The scheduler's startWorkflow contract requires resolving only on
-          // a TERMINAL status: the runner's default (background on queued
-          // agent message, returning status "backgrounded" mid-run) would free
-          // the activeDispatches slot early and let the next tick double-
-          // dispatch, breaking skip-if-running.
-          backgroundOnMessageQueued: false,
+        let result: Awaited<ReturnType<typeof service.startNamedWorkflow>>;
+        try {
+          result = await service.startNamedWorkflow({
+            name: input.name,
+            workspaceId: input.workspaceId,
+            projectTrusted,
+            args: input.args,
+            onRunCreated: async (event) => {
+              createdRunId = event.runId;
+              try {
+                const persisted = await this.workspaceService.appendWorkflowRunInvocation({
+                  workspaceId: input.workspaceId,
+                  rawCommand,
+                  name: input.name,
+                  args: input.args,
+                  runId: event.runId,
+                  status: event.status,
+                  result: event.result,
+                  run: event.run,
+                  synthetic: true,
+                });
+                if (!persisted) {
+                  throw new Error("appendWorkflowRunInvocation returned false");
+                }
+              } catch (error) {
+                log.warn("Failed to persist automation invocation", {
+                  workspaceId: input.workspaceId,
+                  workflowName: input.name,
+                  runId: event.runId,
+                  error,
+                });
+              }
+            },
+            // Scheduled ticks require terminal waits for skip-if-running; manual
+            // runs opt into the runner's background-on-queued behavior so the UI
+            // play button returns after the workflow card is created.
+            backgroundOnMessageQueued: input.backgroundOnMessageQueued ?? false,
+          });
+        } catch (error) {
+          if (createdRunId == null) {
+            throw error;
+          }
+          const failedRun = await service.getRun({
+            workspaceId: input.workspaceId,
+            runId: createdRunId,
+          });
+          if (failedRun?.status !== "failed") {
+            throw error;
+          }
+          await sendTerminalContinuation({
+            runId: createdRunId,
+            status: failedRun.status,
+            result: null,
+            run: failedRun,
+          });
+          return { runId: createdRunId, status: failedRun.status, result: null };
+        }
+        if (result.status === "backgrounded") {
+          return result;
+        }
+
+        const run = await service.getRun({ workspaceId: input.workspaceId, runId: result.runId });
+        if (run == null) {
+          throw new Error("Automation terminal continuation requires a persisted run");
+        }
+        await sendTerminalContinuation({
+          runId: result.runId,
+          status: result.status,
+          result: result.result,
+          run,
         });
+        return result;
       },
     });
     this.windowService = new WindowService();
@@ -544,6 +742,7 @@ export class ServiceContainer {
     const resolveOnePasswordService = () => this.onePasswordService;
 
     return {
+      workflowSchedulerService: this.workflowSchedulerService,
       workflowRuntimeFactory: this.workflowRuntimeFactory,
       config: this.config,
       aiService: this.aiService,

--- a/src/node/services/workflows/WorkflowSchedulerService.test.ts
+++ b/src/node/services/workflows/WorkflowSchedulerService.test.ts
@@ -3,11 +3,14 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { Config } from "@/node/config";
-import type { ProjectsConfig, Workspace } from "@/common/types/project";
+import type { ProjectWorkflowSchedule, ProjectsConfig, Workspace } from "@/common/types/project";
 import type { WorkspaceWorkflowSchedule } from "@/common/types/workspace";
 import {
   WorkflowSchedulerService,
+  type WorkflowProjectScheduleCreateWorkspaceInput,
   type WorkflowSchedulerOptions,
+  type WorkflowScheduleCreateWorkspaceInput,
+  type WorkflowSchedulePrepareContextInput,
   type WorkflowScheduleStartInput,
 } from "./WorkflowSchedulerService";
 
@@ -67,8 +70,44 @@ describe("WorkflowSchedulerService", () => {
     return config.loadConfigOrDefault().projects.get("/repo")?.workspaces.at(0)?.workflowSchedule;
   }
 
+  async function seedProjectSchedule(
+    schedule: Partial<ProjectWorkflowSchedule> = {}
+  ): Promise<void> {
+    await config.editConfig((cfg) => {
+      cfg.projects.set("/repo", {
+        workspaces: [
+          {
+            path: "/repo/control",
+            id: WORKSPACE_ID,
+            name: "control",
+          },
+        ],
+        workflowSchedules: [
+          {
+            id: "automation-1",
+            enabled: true,
+            workflowName: "reconcile",
+            intervalMs: 60_000,
+            target: { type: "new-workspace", branchName: "scheduled-triage", trunkBranch: "main" },
+            ...schedule,
+          },
+        ],
+      });
+      return cfg;
+    });
+  }
+
+  function storedProjectSchedule(): ProjectWorkflowSchedule | undefined {
+    return config.loadConfigOrDefault().projects.get("/repo")?.workflowSchedules?.at(0);
+  }
+
   interface SchedulerSetup {
     enabled?: boolean;
+    createWorkspaceForSchedule?: WorkflowSchedulerOptions["createWorkspaceForSchedule"];
+    createWorkspaceForProjectSchedule?: WorkflowSchedulerOptions["createWorkspaceForProjectSchedule"];
+    prepareContext?: WorkflowSchedulerOptions["prepareContext"];
+    cleanupWorkspaceForSchedule?: WorkflowSchedulerOptions["cleanupWorkspaceForSchedule"];
+    onScheduleStamped?: WorkflowSchedulerOptions["onScheduleStamped"];
     startWorkflow?: (
       input: WorkflowScheduleStartInput
     ) => Promise<{ runId: string; status: string }>;
@@ -81,6 +120,19 @@ describe("WorkflowSchedulerService", () => {
     const scheduler = new WorkflowSchedulerService({
       config,
       isEnabled: () => options.enabled ?? true,
+      ...(options.createWorkspaceForSchedule != null
+        ? { createWorkspaceForSchedule: options.createWorkspaceForSchedule }
+        : {}),
+      ...(options.createWorkspaceForProjectSchedule != null
+        ? { createWorkspaceForProjectSchedule: options.createWorkspaceForProjectSchedule }
+        : {}),
+      ...(options.prepareContext != null ? { prepareContext: options.prepareContext } : {}),
+      ...(options.cleanupWorkspaceForSchedule != null
+        ? { cleanupWorkspaceForSchedule: options.cleanupWorkspaceForSchedule }
+        : {}),
+      ...(options.onScheduleStamped != null
+        ? { onScheduleStamped: options.onScheduleStamped }
+        : {}),
       startWorkflow,
       checkIntervalMs: 50,
     });
@@ -97,9 +149,480 @@ describe("WorkflowSchedulerService", () => {
     expect(startWorkflow).toHaveBeenCalledTimes(1);
     expect(startWorkflow.mock.calls[0]?.[0]).toEqual({
       workspaceId: WORKSPACE_ID,
+      sourceWorkspaceId: WORKSPACE_ID,
       name: "reconcile",
       args: { dryRun: true },
     });
+    expect(storedSchedule()?.lastRunStartedAt).toBeDefined();
+  });
+
+  test("creates a fresh target workspace before running new-workspace schedules", async () => {
+    await seedWorkspace({
+      schedule: {
+        target: {
+          type: "new-workspace",
+          branchName: "scheduled-triage",
+          trunkBranch: "main",
+          title: "Scheduled triage",
+        },
+      },
+    });
+    const createWorkspaceForSchedule = mock((_input: WorkflowScheduleCreateWorkspaceInput) =>
+      Promise.resolve({ workspaceId: "target-ws-1" })
+    );
+    const { scheduler, startWorkflow } = makeScheduler({ createWorkspaceForSchedule });
+
+    scheduler.tick();
+    await scheduler.awaitActiveDispatches();
+
+    expect(createWorkspaceForSchedule).toHaveBeenCalledTimes(1);
+    expect(createWorkspaceForSchedule.mock.calls[0]?.[0]).toMatchObject({
+      sourceWorkspaceId: WORKSPACE_ID,
+      sourceProjectPath: "/repo",
+      workflowName: "reconcile",
+      target: {
+        type: "new-workspace",
+        branchName: "scheduled-triage",
+        trunkBranch: "main",
+        title: "Scheduled triage",
+      },
+    });
+    expect(startWorkflow).toHaveBeenCalledWith({
+      workspaceId: "target-ws-1",
+      sourceWorkspaceId: WORKSPACE_ID,
+      name: "reconcile",
+      args: {},
+    });
+  });
+
+  test("creates a fresh workspace for due project automation schedules", async () => {
+    await seedProjectSchedule({ args: { label: "needs-triage" } });
+    const createWorkspaceForProjectSchedule = mock(
+      (_input: WorkflowProjectScheduleCreateWorkspaceInput) =>
+        Promise.resolve({ workspaceId: "project-target-ws-1" })
+    );
+    const { scheduler, startWorkflow } = makeScheduler({ createWorkspaceForProjectSchedule });
+
+    scheduler.tick();
+    await scheduler.awaitActiveDispatches();
+
+    expect(createWorkspaceForProjectSchedule).toHaveBeenCalledTimes(1);
+    expect(createWorkspaceForProjectSchedule.mock.calls[0]?.[0]).toMatchObject({
+      sourceProjectPath: "/repo",
+      workflowName: "reconcile",
+      scheduleId: "automation-1",
+      target: {
+        type: "new-workspace",
+        branchName: "scheduled-triage",
+        trunkBranch: "main",
+      },
+    });
+    expect(startWorkflow).toHaveBeenCalledWith({
+      workspaceId: "project-target-ws-1",
+      sourceWorkspaceId: "project-target-ws-1",
+      sourceProjectPath: "/repo",
+      projectScheduleId: "automation-1",
+      name: "reconcile",
+      args: { label: "needs-triage" },
+    });
+    expect(storedProjectSchedule()?.lastRunStartedAt).toBeDefined();
+  });
+
+  test("runs project automation on demand without waiting for the interval", async () => {
+    await seedProjectSchedule({
+      lastRunStartedAt: "2026-01-01T00:00:00.000Z",
+      target: { type: "existing-workspace", workspaceId: WORKSPACE_ID },
+    });
+    let releaseRun!: () => void;
+    const running = new Promise<{ runId: string; status: string }>((resolve) => {
+      releaseRun = () => resolve({ runId: "run-now-1", status: "backgrounded" });
+    });
+    const { scheduler, startWorkflow } = makeScheduler({ startWorkflow: () => running });
+
+    const resultPromise = scheduler.runProjectScheduleNow({
+      projectPath: "/repo",
+      scheduleId: "automation-1",
+    });
+    await waitFor(() => startWorkflow.mock.calls.length === 1);
+
+    const startInput = startWorkflow.mock.calls[0]?.[0];
+    expect(startInput).toMatchObject({
+      workspaceId: WORKSPACE_ID,
+      sourceWorkspaceId: WORKSPACE_ID,
+      sourceProjectPath: "/repo",
+      projectScheduleId: "automation-1",
+      name: "reconcile",
+      args: {},
+      backgroundOnMessageQueued: true,
+    });
+    expect(typeof startInput?.onTerminal).toBe("function");
+    let duplicateError: unknown;
+    try {
+      await scheduler.runProjectScheduleNow({ projectPath: "/repo", scheduleId: "automation-1" });
+    } catch (error) {
+      duplicateError = error;
+    }
+    expect(duplicateError).toBeInstanceOf(Error);
+    expect((duplicateError as Error).message).toMatch(/already starting or running/);
+
+    releaseRun();
+    const result = await resultPromise;
+    expect(result).toEqual({ runId: "run-now-1", status: "backgrounded" });
+
+    duplicateError = undefined;
+    try {
+      await scheduler.runProjectScheduleNow({ projectPath: "/repo", scheduleId: "automation-1" });
+    } catch (error) {
+      duplicateError = error;
+    }
+    expect(duplicateError).toBeInstanceOf(Error);
+    expect((duplicateError as Error).message).toMatch(/already starting or running/);
+
+    const terminalRun: Parameters<NonNullable<WorkflowScheduleStartInput["onTerminal"]>>[0]["run"] =
+      {
+        id: "run-now-1",
+        workspaceId: WORKSPACE_ID,
+        definition: {
+          name: "reconcile",
+          description: "Reconcile",
+          scope: "project",
+          sourcePath: "/repo/.mux/workflows/reconcile.js",
+          executable: true,
+        },
+        definitionSource: "export default function workflow() {}",
+        definitionHash: "hash",
+        args: {},
+        status: "completed",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        events: [],
+        steps: [],
+      };
+    const terminalEvent: Parameters<NonNullable<WorkflowScheduleStartInput["onTerminal"]>>[0] = {
+      runId: "run-now-1",
+      status: "completed",
+      result: null,
+      run: terminalRun,
+    };
+    await startInput?.onTerminal?.(terminalEvent);
+    await scheduler.awaitActiveDispatches();
+    expect(storedProjectSchedule()?.lastRunStartedAt).not.toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  test("releases manual project automation lock on interrupted background runs", async () => {
+    await seedProjectSchedule({
+      target: { type: "existing-workspace", workspaceId: WORKSPACE_ID },
+    });
+    let terminalCallback: WorkflowScheduleStartInput["onTerminal"] | undefined;
+    const { scheduler, startWorkflow } = makeScheduler({
+      startWorkflow: (input) => {
+        terminalCallback = input.onTerminal;
+        return Promise.resolve({ runId: "run-now-interrupted", status: "backgrounded" });
+      },
+    });
+
+    const result = await scheduler.runProjectScheduleNow({
+      projectPath: "/repo",
+      scheduleId: "automation-1",
+    });
+    expect(result).toEqual({ runId: "run-now-interrupted", status: "backgrounded" });
+    let duplicateError: unknown;
+    try {
+      await scheduler.runProjectScheduleNow({ projectPath: "/repo", scheduleId: "automation-1" });
+    } catch (error) {
+      duplicateError = error;
+    }
+    expect(duplicateError).toBeInstanceOf(Error);
+    expect((duplicateError as Error).message).toMatch(/already starting or running/);
+
+    const interruptedRun: Parameters<
+      NonNullable<WorkflowScheduleStartInput["onTerminal"]>
+    >[0]["run"] = {
+      id: "run-now-interrupted",
+      workspaceId: WORKSPACE_ID,
+      definition: {
+        name: "reconcile",
+        description: "Reconcile",
+        scope: "project",
+        sourcePath: "/repo/.mux/workflows/reconcile.js",
+        executable: true,
+      },
+      definitionSource: "export default function workflow() {}",
+      definitionHash: "hash",
+      args: {},
+      status: "interrupted",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      events: [],
+      steps: [],
+    };
+    await Promise.resolve(
+      terminalCallback?.({
+        runId: "run-now-interrupted",
+        status: "interrupted",
+        result: null,
+        run: interruptedRun,
+      })
+    );
+    await scheduler.awaitActiveDispatches();
+
+    const secondResult = await scheduler.runProjectScheduleNow({
+      projectPath: "/repo",
+      scheduleId: "automation-1",
+    });
+    expect(secondResult).toEqual({ runId: "run-now-interrupted", status: "backgrounded" });
+    expect(startWorkflow).toHaveBeenCalledTimes(2);
+  });
+
+  test("runs project automation schedules in an existing workspace target", async () => {
+    await seedProjectSchedule({
+      target: { type: "existing-workspace", workspaceId: WORKSPACE_ID },
+    });
+    const { scheduler, startWorkflow } = makeScheduler();
+
+    scheduler.tick();
+    await scheduler.awaitActiveDispatches();
+
+    expect(startWorkflow).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      sourceWorkspaceId: WORKSPACE_ID,
+      sourceProjectPath: "/repo",
+      projectScheduleId: "automation-1",
+      name: "reconcile",
+      args: {},
+    });
+  });
+
+  test("runs sub-project automation schedules in an owner workspace target", async () => {
+    const subProjectPath = "/repo/packages/api";
+    await config.editConfig((cfg) => {
+      cfg.projects.set("/repo", {
+        workspaces: [
+          {
+            path: "/repo/control",
+            id: WORKSPACE_ID,
+            name: "control",
+            subProjectPath,
+          },
+        ],
+      });
+      cfg.projects.set(subProjectPath, {
+        parentProjectPath: "/repo",
+        workspaces: [],
+        workflowSchedules: [
+          {
+            id: "subproject-automation",
+            enabled: true,
+            workflowName: "reconcile-api",
+            intervalMs: 60_000,
+            target: { type: "existing-workspace", workspaceId: WORKSPACE_ID },
+          },
+        ],
+      });
+      return cfg;
+    });
+    const { scheduler, startWorkflow } = makeScheduler();
+
+    scheduler.tick();
+    await scheduler.awaitActiveDispatches();
+
+    expect(startWorkflow).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      sourceWorkspaceId: WORKSPACE_ID,
+      sourceProjectPath: subProjectPath,
+      projectScheduleId: "subproject-automation",
+      name: "reconcile-api",
+      args: {},
+    });
+  });
+
+  test("skips archived existing-workspace project targets without stamping", async () => {
+    const previousLastRun = "2026-01-01T00:00:00.000Z";
+    await seedProjectSchedule({
+      lastRunStartedAt: previousLastRun,
+      target: { type: "existing-workspace", workspaceId: WORKSPACE_ID },
+    });
+    await config.editConfig((cfg) => {
+      const workspace = cfg.projects.get("/repo")?.workspaces.at(0);
+      if (workspace == null) throw new Error("Expected seeded workspace");
+      workspace.archivedAt = "2026-01-02T00:00:00.000Z";
+      return cfg;
+    });
+    const { scheduler, startWorkflow } = makeScheduler();
+
+    scheduler.tick();
+    await scheduler.awaitActiveDispatches();
+
+    expect(startWorkflow).not.toHaveBeenCalled();
+    expect(storedProjectSchedule()?.lastRunStartedAt).toBe(previousLastRun);
+  });
+
+  test("skips missing existing-workspace project targets without stamping", async () => {
+    const previousLastRun = "2026-01-01T00:00:00.000Z";
+    await seedProjectSchedule({
+      lastRunStartedAt: previousLastRun,
+      target: { type: "existing-workspace", workspaceId: "deleted-workspace" },
+    });
+    const { scheduler, startWorkflow } = makeScheduler();
+
+    scheduler.tick();
+    await scheduler.awaitActiveDispatches();
+
+    expect(startWorkflow).not.toHaveBeenCalled();
+    expect(storedProjectSchedule()?.lastRunStartedAt).toBe(previousLastRun);
+  });
+
+  test("prepares context only for existing-workspace project automation targets", async () => {
+    await seedProjectSchedule({
+      contextMode: "reset",
+      target: { type: "existing-workspace", workspaceId: WORKSPACE_ID },
+    });
+    const prepareContext = mock((_input: WorkflowSchedulePrepareContextInput) => Promise.resolve());
+    const { scheduler } = makeScheduler({ prepareContext });
+
+    scheduler.tick();
+    await scheduler.awaitActiveDispatches();
+
+    expect(prepareContext).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      sourceWorkspaceId: WORKSPACE_ID,
+      contextMode: "reset",
+    });
+
+    await seedProjectSchedule({ contextMode: "compact" });
+    const createWorkspaceForProjectSchedule = mock(
+      (_input: WorkflowProjectScheduleCreateWorkspaceInput) =>
+        Promise.resolve({ workspaceId: "project-target-ws-1" })
+    );
+    const freshPrepareContext = mock((_input: WorkflowSchedulePrepareContextInput) =>
+      Promise.resolve()
+    );
+    const fresh = makeScheduler({
+      createWorkspaceForProjectSchedule,
+      prepareContext: freshPrepareContext,
+    });
+
+    fresh.scheduler.tick();
+    await fresh.scheduler.awaitActiveDispatches();
+
+    expect(freshPrepareContext).not.toHaveBeenCalled();
+    expect(fresh.startWorkflow).toHaveBeenCalledTimes(1);
+  });
+
+  test("cleans up a fresh target workspace when pre-start work fails", async () => {
+    await seedWorkspace({
+      schedule: {
+        target: { type: "new-workspace", branchName: "scheduled-triage", trunkBranch: "main" },
+      },
+    });
+    const cleanupWorkspaceForSchedule = mock(
+      (
+        _input: Parameters<NonNullable<WorkflowSchedulerOptions["cleanupWorkspaceForSchedule"]>>[0]
+      ) => Promise.resolve()
+    );
+    const { scheduler, startWorkflow } = makeScheduler({
+      createWorkspaceForSchedule: () => Promise.resolve({ workspaceId: "target-ws-1" }),
+      cleanupWorkspaceForSchedule,
+      startWorkflow: () => Promise.reject(new Error("workflow missing")),
+    });
+
+    scheduler.tick();
+    await scheduler.awaitActiveDispatches();
+
+    expect(startWorkflow).toHaveBeenCalledTimes(1);
+    expect(cleanupWorkspaceForSchedule).toHaveBeenCalledTimes(1);
+    expect(cleanupWorkspaceForSchedule.mock.calls[0]?.[0]).toMatchObject({
+      workspaceId: "target-ws-1",
+      sourceWorkspaceId: WORKSPACE_ID,
+      workflowName: "reconcile",
+      error: "workflow missing",
+    });
+    expect(typeof cleanupWorkspaceForSchedule.mock.calls[0]?.[0]?.startedAt).toBe("string");
+  });
+
+  test("emits metadata after stamping lastRunStartedAt", async () => {
+    await seedWorkspace({ schedule: {} });
+    const onScheduleStamped = mock(
+      (_input: Parameters<NonNullable<WorkflowSchedulerOptions["onScheduleStamped"]>>[0]) =>
+        Promise.resolve()
+    );
+    const { scheduler } = makeScheduler({ onScheduleStamped });
+
+    scheduler.tick();
+    await scheduler.awaitActiveDispatches();
+
+    expect(onScheduleStamped).toHaveBeenCalledTimes(1);
+    expect(onScheduleStamped.mock.calls[0]?.[0]).toMatchObject({
+      workspaceId: WORKSPACE_ID,
+      workflowName: "reconcile",
+    });
+    expect(typeof onScheduleStamped.mock.calls[0]?.[0]?.startedAt).toBe("string");
+  });
+
+  test("skips malformed persisted schedules", async () => {
+    const malformedSchedule: WorkspaceWorkflowSchedule = {
+      enabled: true,
+      workflowName: "reconcile",
+      intervalMs: 0,
+    };
+    await config.editConfig((cfg) => {
+      cfg.projects.set("/repo", {
+        workspaces: [
+          {
+            path: "/repo/sched",
+            id: WORKSPACE_ID,
+            name: "sched",
+            workflowSchedule: malformedSchedule,
+          },
+        ],
+      });
+      return cfg;
+    });
+    const { scheduler, startWorkflow } = makeScheduler();
+
+    scheduler.tick();
+    await scheduler.awaitActiveDispatches();
+
+    expect(startWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("prepares scheduled workflow context before starting", async () => {
+    await seedWorkspace({ schedule: { contextMode: "reset" } });
+    const events: string[] = [];
+    const prepareContext = mock((input: WorkflowSchedulePrepareContextInput) => {
+      events.push(`prepare:${input.workspaceId}:${input.contextMode}`);
+      return Promise.resolve();
+    });
+    const { scheduler, startWorkflow } = makeScheduler({
+      prepareContext,
+      startWorkflow: (input) => {
+        events.push(`start:${input.workspaceId}`);
+        return Promise.resolve({ runId: "run-1", status: "completed" });
+      },
+    });
+
+    scheduler.tick();
+    await scheduler.awaitActiveDispatches();
+
+    expect(prepareContext).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      sourceWorkspaceId: WORKSPACE_ID,
+      contextMode: "reset",
+    });
+    expect(startWorkflow).toHaveBeenCalledTimes(1);
+    expect(events).toEqual(["prepare:sched-ws-1:reset", "start:sched-ws-1"]);
+  });
+
+  test("does not start the workflow when context preparation fails", async () => {
+    await seedWorkspace({ schedule: { contextMode: "compact" } });
+    const prepareContext = mock(() => Promise.reject(new Error("compaction failed")));
+    const { scheduler, startWorkflow } = makeScheduler({ prepareContext });
+
+    scheduler.tick();
+    await scheduler.awaitActiveDispatches();
+
+    expect(prepareContext).toHaveBeenCalledTimes(1);
+    expect(startWorkflow).not.toHaveBeenCalled();
     expect(storedSchedule()?.lastRunStartedAt).toBeDefined();
   });
 
@@ -209,8 +732,8 @@ describe("WorkflowSchedulerService", () => {
     releaseEdit();
     await scheduler.awaitActiveDispatches();
 
-    // Stale run still proceeded, but the reset schedule kept its due-now state.
-    expect(startWorkflow).toHaveBeenCalledTimes(1);
+    // The stale run is canceled, and the reset schedule keeps its due-now state.
+    expect(startWorkflow).not.toHaveBeenCalled();
     const persisted = projects.projects.get("/repo")?.workspaces.at(0)?.workflowSchedule;
     expect(persisted?.workflowName).toBe("reconcile-v2");
     expect(persisted?.lastRunStartedAt).toBeUndefined();

--- a/src/node/services/workflows/WorkflowSchedulerService.ts
+++ b/src/node/services/workflows/WorkflowSchedulerService.ts
@@ -26,21 +26,117 @@
 import assert from "@/common/utils/assert";
 import { getErrorMessage } from "@/common/utils/errors";
 import { isWorkspaceArchived } from "@/common/utils/archive";
+import {
+  isWorkflowScheduleDue,
+  parsePersistedProjectWorkflowSchedule,
+  parsePersistedWorkflowSchedule,
+} from "@/common/utils/workflowSchedule";
+import type { ProjectConfig, ProjectWorkflowSchedule, Workspace } from "@/common/types/project";
 import type { WorkspaceWorkflowSchedule } from "@/common/types/workspace";
+import type { WorkflowBackgroundRunTerminalEvent } from "@/node/services/workflows/WorkflowService";
 import type { Config } from "@/node/config";
 import { log } from "@/node/services/log";
-import { WORKFLOW_SCHEDULE_CHECK_INTERVAL_MS } from "@/constants/workflowSchedule";
+import {
+  WORKFLOW_SCHEDULE_CHECK_INTERVAL_MS,
+  WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE,
+  type WorkflowScheduleContextMode,
+} from "@/constants/workflowSchedule";
+
+type WorkflowScheduleTarget = NonNullable<WorkspaceWorkflowSchedule["target"]>;
+type WorkflowScheduleNewWorkspaceTarget = Extract<
+  WorkflowScheduleTarget,
+  { type: "new-workspace" }
+>;
+
+type ProjectScheduleTarget = ProjectWorkflowSchedule["target"];
+type ProjectScheduleNewWorkspaceTarget = Extract<ProjectScheduleTarget, { type: "new-workspace" }>;
 
 export interface WorkflowScheduleStartInput {
   workspaceId: string;
+  sourceWorkspaceId: string;
+  sourceProjectPath?: string;
+  projectScheduleId?: string;
   name: string;
   args: Record<string, unknown>;
+  /** When true, return after the workflow is safely backgrounded instead of waiting for terminal status. */
+  backgroundOnMessageQueued?: boolean;
+  /** Called when a backgrounded scheduled run reaches a terminal status. */
+  onTerminal?: (event: WorkflowBackgroundRunTerminalEvent) => void | Promise<void>;
+}
+
+export interface WorkflowScheduleCreateWorkspaceInput {
+  sourceWorkspaceId: string;
+  sourceProjectPath: string;
+  sourceWorkspace: Workspace;
+  target: WorkflowScheduleNewWorkspaceTarget;
+  workflowName: string;
+  startedAt: string;
+}
+
+export interface WorkflowProjectScheduleCreateWorkspaceInput {
+  sourceProjectPath: string;
+  sourceProject: ProjectConfig;
+  target: ProjectScheduleNewWorkspaceTarget;
+  workflowName: string;
+  scheduleId: string;
+  startedAt: string;
+}
+
+export interface WorkflowSchedulePrepareContextInput {
+  workspaceId: string;
+  sourceWorkspaceId: string;
+  contextMode: WorkflowScheduleContextMode;
+}
+
+export interface WorkflowScheduleCleanupWorkspaceInput {
+  workspaceId: string;
+  sourceWorkspaceId: string;
+  sourceProjectPath?: string;
+  projectScheduleId?: string;
+  workflowName: string;
+  startedAt: string;
+  error: string;
+}
+
+export type WorkflowScheduleStampedInput =
+  | {
+      type: "workspace";
+      workspaceId: string;
+      workflowName: string;
+      startedAt: string;
+    }
+  | {
+      type: "project";
+      projectPath: string;
+      scheduleId: string;
+      workflowName: string;
+      startedAt: string;
+    };
+
+interface ProjectScheduleDispatchOptions {
+  backgroundOnMessageQueued?: boolean;
+  rethrowErrors?: boolean;
+  onTerminal?: (event: WorkflowBackgroundRunTerminalEvent) => void | Promise<void>;
 }
 
 export interface WorkflowSchedulerOptions {
   config: Pick<Config, "loadConfigOrDefault" | "editConfig">;
   /** Gate (dynamic-workflows experiment); schedules are skipped while false. */
   isEnabled: () => boolean;
+  /** Create a fresh run workspace for schedules that target a new workspace. */
+  createWorkspaceForSchedule?: (
+    input: WorkflowScheduleCreateWorkspaceInput
+  ) => Promise<{ workspaceId: string }>;
+  /** Create a fresh run workspace for project automations that target a new workspace. */
+  createWorkspaceForProjectSchedule?: (
+    input: WorkflowProjectScheduleCreateWorkspaceInput
+  ) => Promise<{ workspaceId: string }>;
+  /** Prepare target workspace context before starting the workflow. */
+  prepareContext?: (input: WorkflowSchedulePrepareContextInput) => Promise<void>;
+  /** Best-effort cleanup for a fresh target workspace when pre-start work throws. */
+  cleanupWorkspaceForSchedule?: (input: WorkflowScheduleCleanupWorkspaceInput) => Promise<void>;
+  /** Best-effort notification after scheduler-owned lastRunStartedAt is persisted. */
+  onScheduleStamped?: (input: WorkflowScheduleStampedInput) => Promise<void>;
   /** Start a named workflow run; resolves when the run reaches a terminal status. */
   startWorkflow: (input: WorkflowScheduleStartInput) => Promise<{ runId: string; status: string }>;
   /** Test hook: scan cadence (default 30s). */
@@ -52,7 +148,7 @@ export class WorkflowSchedulerService {
   private readonly checkIntervalMs: number;
   private checkInterval: NodeJS.Timeout | null = null;
   private stopped = false;
-  /** workspaceId → in-flight dispatch (skip-if-running + test synchronization). */
+  /** dispatch key → in-flight dispatch (skip-if-running + test synchronization). */
   private readonly activeDispatches = new Map<string, Promise<void>>();
 
   constructor(options: WorkflowSchedulerOptions) {
@@ -93,28 +189,55 @@ export class WorkflowSchedulerService {
       }
       const config = this.options.config.loadConfigOrDefault();
       const now = Date.now();
-      for (const projectConfig of config.projects.values()) {
+      for (const [sourceProjectPath, projectConfig] of config.projects) {
+        for (const rawSchedule of projectConfig.workflowSchedules ?? []) {
+          const schedule = parsePersistedProjectWorkflowSchedule(rawSchedule);
+          if (rawSchedule != null && schedule == null) {
+            log.warn("Skipping malformed persisted project workflow schedule", {
+              sourceProjectPath,
+            });
+          }
+          if (schedule?.enabled !== true) {
+            continue;
+          }
+          const dispatchKey = getProjectScheduleDispatchKey(sourceProjectPath, schedule.id);
+          if (this.activeDispatches.has(dispatchKey)) {
+            continue; // skip-if-running
+          }
+          if (!isWorkflowScheduleDue(schedule, now)) {
+            continue; // not due yet
+          }
+          const dispatch = this.dispatchProjectSchedule(sourceProjectPath, projectConfig, schedule)
+            .then(() => undefined)
+            .finally(() => {
+              this.activeDispatches.delete(dispatchKey);
+            });
+          this.activeDispatches.set(dispatchKey, dispatch);
+        }
+
         for (const workspace of projectConfig.workspaces) {
-          const schedule = workspace.workflowSchedule;
           const workspaceId = workspace.id;
+          const schedule = parsePersistedWorkflowSchedule(workspace.workflowSchedule);
+          if (workspace.workflowSchedule != null && schedule == null) {
+            log.warn("Skipping malformed persisted workflow schedule", { workspaceId });
+          }
           if (schedule?.enabled !== true || workspaceId == null) {
             continue;
           }
           if (isWorkspaceArchived(workspace.archivedAt, workspace.unarchivedAt)) {
             continue;
           }
-          if (this.activeDispatches.has(workspaceId)) {
+          const dispatchKey = getWorkspaceScheduleDispatchKey(workspaceId);
+          if (this.activeDispatches.has(dispatchKey)) {
             continue; // skip-if-running
           }
-          const lastStarted =
-            schedule.lastRunStartedAt != null ? Date.parse(schedule.lastRunStartedAt) : Number.NaN;
-          if (Number.isFinite(lastStarted) && now - lastStarted < schedule.intervalMs) {
+          if (!isWorkflowScheduleDue(schedule, now)) {
             continue; // not due yet
           }
-          const dispatch = this.dispatch(workspaceId, schedule).finally(() => {
-            this.activeDispatches.delete(workspaceId);
+          const dispatch = this.dispatch(sourceProjectPath, workspace, schedule).finally(() => {
+            this.activeDispatches.delete(dispatchKey);
           });
-          this.activeDispatches.set(workspaceId, dispatch);
+          this.activeDispatches.set(dispatchKey, dispatch);
         }
       }
     } catch (error) {
@@ -122,35 +245,431 @@ export class WorkflowSchedulerService {
     }
   }
 
+  async runProjectScheduleNow(input: {
+    projectPath: string;
+    scheduleId: string;
+  }): Promise<{ runId: string; status: string }> {
+    const projectPath = input.projectPath.trim();
+    const scheduleId = input.scheduleId.trim();
+    assert(
+      projectPath.length > 0,
+      "WorkflowSchedulerService.runProjectScheduleNow requires projectPath"
+    );
+    assert(
+      scheduleId.length > 0,
+      "WorkflowSchedulerService.runProjectScheduleNow requires scheduleId"
+    );
+    if (!this.options.isEnabled()) {
+      throw new Error("Dynamic workflows are disabled");
+    }
+
+    const config = this.options.config.loadConfigOrDefault();
+    const sourceProject = config.projects.get(projectPath);
+    if (sourceProject == null) {
+      throw new Error(`Project not found: ${projectPath}`);
+    }
+
+    const rawSchedule = (sourceProject.workflowSchedules ?? []).find(
+      (schedule) => schedule.id === scheduleId
+    );
+    const schedule = parsePersistedProjectWorkflowSchedule(rawSchedule);
+    if (rawSchedule != null && schedule == null) {
+      throw new Error("Project automation schedule is malformed");
+    }
+    if (schedule == null) {
+      throw new Error("Project automation schedule not found");
+    }
+    if (!schedule.enabled) {
+      throw new Error("Project automation is disabled");
+    }
+
+    const dispatchKey = getProjectScheduleDispatchKey(projectPath, schedule.id);
+    if (this.activeDispatches.has(dispatchKey)) {
+      throw new Error("Project automation is already starting or running");
+    }
+
+    let resolveTerminalRun: (() => void) | null = null;
+    const terminalRun = new Promise<void>((resolve) => {
+      resolveTerminalRun = resolve;
+    });
+    const dispatch = this.dispatchProjectSchedule(projectPath, sourceProject, schedule, {
+      backgroundOnMessageQueued: true,
+      rethrowErrors: true,
+      onTerminal: () => {
+        assert(resolveTerminalRun != null, "Manual project automation terminal resolver missing");
+        resolveTerminalRun();
+      },
+    });
+    const trackedDispatch = (async () => {
+      try {
+        const result = await dispatch;
+        if (result?.status === "backgrounded") {
+          await terminalRun;
+        }
+      } catch {
+        // The caller receives the original dispatch error; this tracked promise only owns cleanup.
+      } finally {
+        this.activeDispatches.delete(dispatchKey);
+      }
+    })();
+    this.activeDispatches.set(dispatchKey, trackedDispatch);
+
+    const result = await dispatch;
+    assert(result != null, "Manual project automation dispatch must return a workflow run result");
+    return result;
+  }
+
   /** Test hook: resolves when all currently in-flight dispatches settle. */
   async awaitActiveDispatches(): Promise<void> {
     await Promise.all(this.activeDispatches.values());
   }
 
-  private async dispatch(workspaceId: string, schedule: WorkspaceWorkflowSchedule): Promise<void> {
+  private async dispatch(
+    sourceProjectPath: string,
+    sourceWorkspace: Workspace,
+    schedule: WorkspaceWorkflowSchedule
+  ): Promise<void> {
+    const sourceWorkspaceId = sourceWorkspace.id;
+    assert(sourceWorkspaceId != null, "Scheduled workflow dispatch requires a source workspace id");
+    let startedAt = "";
+    let targetWorkspaceId = sourceWorkspaceId;
+    let createdFreshTarget = false;
+
     try {
-      // Persist the dispatch time BEFORE starting: if the process crashes
-      // mid-run, the next startup waits a full interval instead of re-running
-      // immediately (the orphaned run may still be resumable).
-      await this.persistLastRunStartedAt(workspaceId, schedule, new Date().toISOString());
+      // Persist the dispatch time BEFORE target creation/start: if the process
+      // crashes mid-run (or after creating a fresh target workspace), the next
+      // startup waits a full interval instead of hot-looping duplicate work.
+      startedAt = new Date().toISOString();
+      const didStamp = await this.persistLastRunStartedAt(sourceWorkspaceId, schedule, startedAt);
+      if (didStamp) {
+        await this.emitScheduleStampedMetadata({
+          type: "workspace",
+          workspaceId: sourceWorkspaceId,
+          workflowName: schedule.workflowName,
+          startedAt,
+        });
+      }
+      if (!didStamp) {
+        log.info("Skipping stale automation dispatch after workspace schedule changed", {
+          sourceWorkspaceId,
+          workflowName: schedule.workflowName,
+        });
+        return;
+      }
+      const targetResolution = await this.resolveTargetWorkspaceId({
+        sourceProjectPath,
+        sourceWorkspace,
+        schedule,
+        startedAt,
+      });
+      targetWorkspaceId = targetResolution.workspaceId;
+      createdFreshTarget = targetResolution.createdFreshTarget;
+      const contextMode = getWorkflowScheduleContextMode(schedule);
+      if (contextMode !== WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE) {
+        if (this.options.prepareContext == null) {
+          throw new Error("Scheduled workflow context preparation is unavailable");
+        }
+        await this.options.prepareContext({
+          workspaceId: targetWorkspaceId,
+          sourceWorkspaceId,
+          contextMode,
+        });
+      }
       const result = await this.options.startWorkflow({
-        workspaceId,
+        workspaceId: targetWorkspaceId,
+        sourceWorkspaceId,
         name: schedule.workflowName,
         args: schedule.args ?? {},
       });
       log.info("Scheduled workflow run finished", {
-        workspaceId,
+        sourceWorkspaceId,
+        targetWorkspaceId,
         workflowName: schedule.workflowName,
         runId: result.runId,
         status: result.status,
       });
     } catch (error) {
+      const errorMessage = getErrorMessage(error);
+      if (createdFreshTarget) {
+        await this.cleanupFreshTargetAfterFailure({
+          workspaceId: targetWorkspaceId,
+          sourceWorkspaceId,
+          workflowName: schedule.workflowName,
+          startedAt,
+          error: errorMessage,
+        });
+      }
       // Failures are logged, never thrown: the schedule retries on the next
       // due tick (lastRunStartedAt was already advanced).
       log.error("Scheduled workflow run failed", {
-        workspaceId,
+        sourceWorkspaceId,
+        targetWorkspaceId,
         workflowName: schedule.workflowName,
+        error: errorMessage,
+      });
+    }
+  }
+
+  private async dispatchProjectSchedule(
+    sourceProjectPath: string,
+    sourceProject: ProjectConfig,
+    schedule: ProjectWorkflowSchedule,
+    options: ProjectScheduleDispatchOptions = {}
+  ): Promise<{ runId: string; status: string } | void> {
+    let startedAt = "";
+    let targetWorkspaceId = "";
+    let createdFreshTarget = false;
+
+    try {
+      const unavailableTargetReason = this.getExistingProjectTargetUnavailableReason(
+        sourceProjectPath,
+        sourceProject,
+        schedule
+      );
+      if (unavailableTargetReason != null) {
+        log.warn("Skipping unavailable project automation target", {
+          sourceProjectPath,
+          scheduleId: schedule.id,
+          workflowName: schedule.workflowName,
+          reason: unavailableTargetReason,
+        });
+        if (options.rethrowErrors === true) {
+          throw new Error(unavailableTargetReason);
+        }
+        return;
+      }
+      // Project automations own the schedule; workspaces are resolved only when a run is due.
+      startedAt = new Date().toISOString();
+      const didStamp = await this.persistProjectLastRunStartedAt(
+        sourceProjectPath,
+        schedule,
+        startedAt
+      );
+      if (didStamp) {
+        await this.emitScheduleStampedMetadata({
+          type: "project",
+          projectPath: sourceProjectPath,
+          scheduleId: schedule.id,
+          workflowName: schedule.workflowName,
+          startedAt,
+        });
+      }
+      if (!didStamp) {
+        log.info("Skipping stale automation dispatch after project schedule changed", {
+          sourceProjectPath,
+          scheduleId: schedule.id,
+          workflowName: schedule.workflowName,
+        });
+        return;
+      }
+      const targetResolution = await this.resolveProjectTargetWorkspaceId({
+        sourceProjectPath,
+        sourceProject,
+        schedule,
+        startedAt,
+      });
+      targetWorkspaceId = targetResolution.workspaceId;
+      createdFreshTarget = targetResolution.createdFreshTarget;
+      const contextMode = getProjectWorkflowScheduleContextMode(schedule);
+      if (contextMode !== WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE) {
+        if (this.options.prepareContext == null) {
+          throw new Error("Scheduled workflow context preparation is unavailable");
+        }
+        await this.options.prepareContext({
+          workspaceId: targetWorkspaceId,
+          sourceWorkspaceId: targetWorkspaceId,
+          contextMode,
+        });
+      }
+      const result = await this.options.startWorkflow({
+        workspaceId: targetWorkspaceId,
+        sourceWorkspaceId: targetWorkspaceId,
+        sourceProjectPath,
+        projectScheduleId: schedule.id,
+        name: schedule.workflowName,
+        args: schedule.args ?? {},
+        ...(options.backgroundOnMessageQueued === true ? { backgroundOnMessageQueued: true } : {}),
+        ...(options.onTerminal != null ? { onTerminal: options.onTerminal } : {}),
+      });
+      log.info("Project scheduled workflow run finished", {
+        sourceProjectPath,
+        targetWorkspaceId,
+        workflowName: schedule.workflowName,
+        scheduleId: schedule.id,
+        runId: result.runId,
+        status: result.status,
+      });
+      return result;
+    } catch (error) {
+      const errorMessage = getErrorMessage(error);
+      if (createdFreshTarget) {
+        await this.cleanupFreshTargetAfterFailure({
+          workspaceId: targetWorkspaceId,
+          sourceWorkspaceId: targetWorkspaceId,
+          sourceProjectPath,
+          projectScheduleId: schedule.id,
+          workflowName: schedule.workflowName,
+          startedAt,
+          error: errorMessage,
+        });
+      }
+      log.error("Project scheduled workflow run failed", {
+        sourceProjectPath,
+        targetWorkspaceId,
+        workflowName: schedule.workflowName,
+        scheduleId: schedule.id,
+        error: errorMessage,
+      });
+      if (options.rethrowErrors === true) {
+        throw error;
+      }
+    }
+  }
+
+  private getProjectWorkspaceOwner(
+    sourceProjectPath: string,
+    sourceProject: ProjectConfig
+  ): ProjectConfig | null {
+    const ownerProjectPath = sourceProject.parentProjectPath ?? sourceProjectPath;
+    if (ownerProjectPath === sourceProjectPath) {
+      return sourceProject;
+    }
+    return this.options.config.loadConfigOrDefault().projects.get(ownerProjectPath) ?? null;
+  }
+
+  private getExistingProjectTargetUnavailableReason(
+    sourceProjectPath: string,
+    sourceProject: ProjectConfig,
+    schedule: ProjectWorkflowSchedule
+  ): string | null {
+    const target = schedule.target;
+    if (target.type !== "existing-workspace") {
+      return null;
+    }
+
+    const ownerProject = this.getProjectWorkspaceOwner(sourceProjectPath, sourceProject);
+    if (ownerProject == null) {
+      return "Project scheduled workflow owner project was not found";
+    }
+    const workspace = ownerProject.workspaces.find((entry) => entry.id === target.workspaceId);
+    if (workspace == null) {
+      return "Project scheduled workflow target workspace was not found";
+    }
+    if (isWorkspaceArchived(workspace.archivedAt, workspace.unarchivedAt)) {
+      return "Project scheduled workflow target workspace is archived";
+    }
+    return null;
+  }
+
+  private async resolveProjectTargetWorkspaceId(input: {
+    sourceProjectPath: string;
+    sourceProject: ProjectConfig;
+    schedule: ProjectWorkflowSchedule;
+    startedAt: string;
+  }): Promise<{ workspaceId: string; createdFreshTarget: boolean }> {
+    const target = input.schedule.target;
+    if (target.type === "existing-workspace") {
+      const ownerProject = this.getProjectWorkspaceOwner(
+        input.sourceProjectPath,
+        input.sourceProject
+      );
+      if (ownerProject == null) {
+        throw new Error("Project scheduled workflow owner project was not found");
+      }
+      const workspace = ownerProject.workspaces.find((entry) => entry.id === target.workspaceId);
+      if (workspace == null) {
+        throw new Error("Project scheduled workflow target workspace was not found");
+      }
+      if (isWorkspaceArchived(workspace.archivedAt, workspace.unarchivedAt)) {
+        throw new Error("Project scheduled workflow target workspace is archived");
+      }
+      return { workspaceId: target.workspaceId, createdFreshTarget: false };
+    }
+
+    if (this.options.createWorkspaceForProjectSchedule == null) {
+      throw new Error("Project scheduled workflow new-workspace target is unavailable");
+    }
+
+    const created = await this.options.createWorkspaceForProjectSchedule({
+      sourceProjectPath: input.sourceProjectPath,
+      sourceProject: input.sourceProject,
+      target,
+      workflowName: input.schedule.workflowName,
+      scheduleId: input.schedule.id,
+      startedAt: input.startedAt,
+    });
+    assert(
+      created.workspaceId.trim().length > 0,
+      "Project scheduled workflow target creation must return a workspaceId"
+    );
+    return { workspaceId: created.workspaceId, createdFreshTarget: true };
+  }
+
+  private async resolveTargetWorkspaceId(input: {
+    sourceProjectPath: string;
+    sourceWorkspace: Workspace;
+    schedule: WorkspaceWorkflowSchedule;
+    startedAt: string;
+  }): Promise<{ workspaceId: string; createdFreshTarget: boolean }> {
+    const sourceWorkspaceId = input.sourceWorkspace.id;
+    assert(sourceWorkspaceId != null, "Scheduled workflow target resolution requires a source id");
+
+    const target = getWorkflowScheduleTarget(input.schedule);
+    if (target.type === "current-workspace") {
+      return { workspaceId: sourceWorkspaceId, createdFreshTarget: false };
+    }
+
+    if (this.options.createWorkspaceForSchedule == null) {
+      throw new Error("Scheduled workflow new-workspace target is unavailable");
+    }
+
+    const created = await this.options.createWorkspaceForSchedule({
+      sourceWorkspaceId,
+      sourceProjectPath: input.sourceProjectPath,
+      sourceWorkspace: input.sourceWorkspace,
+      target,
+      workflowName: input.schedule.workflowName,
+      startedAt: input.startedAt,
+    });
+    assert(
+      created.workspaceId.trim().length > 0,
+      "Scheduled workflow target creation must return a workspaceId"
+    );
+    return { workspaceId: created.workspaceId, createdFreshTarget: true };
+  }
+
+  private async emitScheduleStampedMetadata(input: WorkflowScheduleStampedInput): Promise<void> {
+    if (this.options.onScheduleStamped == null) {
+      return;
+    }
+    try {
+      await this.options.onScheduleStamped(input);
+    } catch (error) {
+      log.debug("Failed to emit scheduled workflow metadata update", {
+        ...(input.type === "workspace"
+          ? { workspaceId: input.workspaceId }
+          : { projectPath: input.projectPath, scheduleId: input.scheduleId }),
+        workflowName: input.workflowName,
         error: getErrorMessage(error),
+      });
+    }
+  }
+
+  private async cleanupFreshTargetAfterFailure(
+    input: WorkflowScheduleCleanupWorkspaceInput
+  ): Promise<void> {
+    if (this.options.cleanupWorkspaceForSchedule == null) {
+      return;
+    }
+    try {
+      await this.options.cleanupWorkspaceForSchedule(input);
+    } catch (cleanupError) {
+      log.error("Failed to cleanup scheduled workflow target workspace", {
+        workspaceId: input.workspaceId,
+        sourceWorkspaceId: input.sourceWorkspaceId,
+        workflowName: input.workflowName,
+        error: getErrorMessage(cleanupError),
+        originalError: input.error,
       });
     }
   }
@@ -159,7 +678,8 @@ export class WorkflowSchedulerService {
     workspaceId: string,
     dispatched: WorkspaceWorkflowSchedule,
     timestamp: string
-  ): Promise<void> {
+  ): Promise<boolean> {
+    let didStamp = false;
     await this.options.config.editConfig((config) => {
       for (const projectConfig of config.projects.values()) {
         const entry = projectConfig.workspaces.find((workspace) => workspace.id === workspaceId);
@@ -172,23 +692,96 @@ export class WorkflowSchedulerService {
         // schedule by a full interval). Only stamp the exact schedule this
         // dispatch observed; on mismatch the stale run still proceeds but the
         // new schedule keeps its due-now state.
-        if (entry.workflowSchedule != null && schedulesEqual(entry.workflowSchedule, dispatched)) {
-          entry.workflowSchedule = { ...entry.workflowSchedule, lastRunStartedAt: timestamp };
+        const persistedSchedule = parsePersistedWorkflowSchedule(entry.workflowSchedule);
+        if (persistedSchedule != null && schedulesEqual(persistedSchedule, dispatched)) {
+          entry.workflowSchedule = { ...persistedSchedule, lastRunStartedAt: timestamp };
+          didStamp = true;
         }
         break;
       }
       return config;
     });
+    return didStamp;
+  }
+
+  private async persistProjectLastRunStartedAt(
+    projectPath: string,
+    dispatched: ProjectWorkflowSchedule,
+    timestamp: string
+  ): Promise<boolean> {
+    let didStamp = false;
+    await this.options.config.editConfig((config) => {
+      const project = config.projects.get(projectPath);
+      if (project == null) {
+        return config;
+      }
+      const schedules = project.workflowSchedules ?? [];
+      const scheduleIndex = schedules.findIndex((schedule) => schedule.id === dispatched.id);
+      if (scheduleIndex < 0) {
+        return config;
+      }
+      const persistedSchedule = parsePersistedProjectWorkflowSchedule(schedules[scheduleIndex]);
+      if (persistedSchedule != null && projectSchedulesEqual(persistedSchedule, dispatched)) {
+        const nextSchedules = [...schedules];
+        nextSchedules[scheduleIndex] = { ...persistedSchedule, lastRunStartedAt: timestamp };
+        project.workflowSchedules = nextSchedules;
+        didStamp = true;
+      }
+      return config;
+    });
+    return didStamp;
   }
 }
 
+function getWorkflowScheduleContextMode(
+  schedule: WorkspaceWorkflowSchedule
+): WorkflowScheduleContextMode {
+  return schedule.contextMode ?? WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE;
+}
+
+function getWorkflowScheduleTarget(schedule: WorkspaceWorkflowSchedule): WorkflowScheduleTarget {
+  return schedule.target ?? { type: "current-workspace" };
+}
+
+function getProjectWorkflowScheduleContextMode(
+  schedule: ProjectWorkflowSchedule
+): WorkflowScheduleContextMode {
+  return schedule.target.type === "existing-workspace"
+    ? (schedule.contextMode ?? WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE)
+    : WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE;
+}
+
+function getWorkspaceScheduleDispatchKey(workspaceId: string): string {
+  return `workspace:${workspaceId}`;
+}
+
+function getProjectScheduleDispatchKey(projectPath: string, scheduleId: string): string {
+  return `project:${projectPath}:${scheduleId}`;
+}
+
 /** Field-wise schedule identity (config objects are re-parsed per load, so reference equality is meaningless). */
+function projectSchedulesEqual(a: ProjectWorkflowSchedule, b: ProjectWorkflowSchedule): boolean {
+  return (
+    a.id === b.id &&
+    a.title === b.title &&
+    a.enabled === b.enabled &&
+    a.workflowName === b.workflowName &&
+    a.intervalMs === b.intervalMs &&
+    a.lastRunStartedAt === b.lastRunStartedAt &&
+    getProjectWorkflowScheduleContextMode(a) === getProjectWorkflowScheduleContextMode(b) &&
+    JSON.stringify(a.target) === JSON.stringify(b.target) &&
+    JSON.stringify(a.args ?? null) === JSON.stringify(b.args ?? null)
+  );
+}
+
 function schedulesEqual(a: WorkspaceWorkflowSchedule, b: WorkspaceWorkflowSchedule): boolean {
   return (
     a.enabled === b.enabled &&
     a.workflowName === b.workflowName &&
     a.intervalMs === b.intervalMs &&
     a.lastRunStartedAt === b.lastRunStartedAt &&
+    getWorkflowScheduleContextMode(a) === getWorkflowScheduleContextMode(b) &&
+    JSON.stringify(getWorkflowScheduleTarget(a)) === JSON.stringify(getWorkflowScheduleTarget(b)) &&
     JSON.stringify(a.args ?? null) === JSON.stringify(b.args ?? null)
   );
 }

--- a/src/node/services/workflows/WorkflowService.test.ts
+++ b/src/node/services/workflows/WorkflowService.test.ts
@@ -609,6 +609,74 @@ export default function workflow({ action }) {
     expect(parentRun.steps.find((step) => step.stepId === "child-project")?.status).toBe("failed");
   });
 
+  test("notifies foreground run creation before the first workflow step blocks", async () => {
+    using tmp = new DisposableTempDir("workflow-service-created-callback");
+    const projectRoot = path.join(tmp.path, "project", ".mux", "workflows");
+    const globalRoot = path.join(tmp.path, "mux-home", "workflows");
+    await writeWorkflow(
+      globalRoot,
+      "scheduled-scan",
+      "// description: Scheduled scan\nexport default function workflow({ agent }) { return agent({ id: 'scope', prompt: 'scope security surface' }); }\n"
+    );
+
+    let releaseAgent: ((value: { taskId: string; reportMarkdown: string }) => void) | undefined;
+    const lifecycleEvents: string[] = [];
+    const runStore = new WorkflowRunStore({ sessionDir: tmp.path });
+    const service = new WorkflowService({
+      definitionStore: new WorkflowDefinitionStore({ projectRoot, globalRoot, builtIns: [] }),
+      runStore,
+      runtimeFactory: new QuickJSRuntimeFactory(),
+      taskAdapter: {
+        async runAgent() {
+          lifecycleEvents.push("agent-started");
+          return await new Promise<{ taskId: string; reportMarkdown: string }>((resolve) => {
+            releaseAgent = resolve;
+          });
+        },
+      },
+      generateRunId: () => "wfr_scheduled_scan",
+      runnerId: "runner-a",
+    });
+
+    const resultPromise = service.startNamedWorkflow({
+      name: "scheduled-scan",
+      workspaceId: "workspace-1",
+      projectTrusted: true,
+      args: { severity: "high" },
+      onRunCreated(event) {
+        lifecycleEvents.push("run-created");
+        expect(event).toMatchObject({
+          runId: "wfr_scheduled_scan",
+          status: "pending",
+          result: null,
+          run: {
+            id: "wfr_scheduled_scan",
+            workspaceId: "workspace-1",
+            status: "pending",
+            args: { severity: "high" },
+          },
+        });
+      },
+    });
+
+    await waitForCondition("foreground run creation callback", () =>
+      lifecycleEvents.includes("run-created")
+    );
+    expect(lifecycleEvents).toEqual(["run-created"]);
+    await waitForCondition("foreground agent to start", () => releaseAgent != null);
+    expect(lifecycleEvents).toEqual(["run-created", "agent-started"]);
+
+    releaseAgent?.({ taskId: "task_scope", reportMarkdown: "scoped" });
+    await expect(resultPromise).resolves.toEqual({
+      runId: "wfr_scheduled_scan",
+      status: "completed",
+      result: { reportMarkdown: "scoped", structuredOutput: undefined },
+    });
+    await expect(runStore.getRun("wfr_scheduled_scan")).resolves.toMatchObject({
+      status: "completed",
+    });
+  });
+
   test("runs workspace scratch workflow definitions authored as files", async () => {
     using tmp = new DisposableTempDir("workflow-service");
     const workspaceRoot = path.join(tmp.path, "project");

--- a/src/node/services/workflows/WorkflowService.ts
+++ b/src/node/services/workflows/WorkflowService.ts
@@ -47,12 +47,21 @@ export interface WorkflowServiceOptions {
   /** workflowName is the human-readable definition name, used to label spawned tasks. */
   taskAdapterFactory?: (runId: string, workflowName?: string) => WorkflowTaskAdapter;
   onBackgroundRunTerminal?: (event: WorkflowBackgroundRunTerminalEvent) => Promise<void> | void;
+  /** When true, background terminal notifications also fire for interrupted runs. */
+  notifyInterruptedBackgroundRunTerminal?: boolean;
   generateRunId?: () => string;
   // Delayed crash-recovery retries must use current trust, not the value captured when scheduled.
   getCurrentProjectTrusted?: () => boolean | Promise<boolean>;
   /** Stable prefix; WorkflowService appends run identity and a nonce for each lease owner. */
   runnerId: string;
   clock?: WorkflowRunnerClock;
+}
+
+export interface WorkflowRunCreatedEvent {
+  runId: string;
+  status: "pending";
+  result: null;
+  run: WorkflowRunRecord;
 }
 
 export interface WorkflowBackgroundRunCreatedEvent {
@@ -67,6 +76,8 @@ export interface StartNamedWorkflowInput {
   workspaceId: string;
   projectTrusted: boolean;
   args: unknown;
+  /** Called after the durable run record exists but before the foreground runner can block. */
+  onRunCreated?: (event: WorkflowRunCreatedEvent) => Promise<void> | void;
   onBackgroundRunCreated?: (event: WorkflowBackgroundRunCreatedEvent) => Promise<void> | void;
   abortSignal?: AbortSignal;
   backgroundOnMessageQueued?: boolean;
@@ -124,6 +135,7 @@ export class WorkflowService {
   private readonly onBackgroundRunTerminal?: (
     event: WorkflowBackgroundRunTerminalEvent
   ) => Promise<void> | void;
+  private readonly notifyInterruptedBackgroundRunTerminal: boolean;
   private readonly generateRunId: () => string;
   private readonly getCurrentProjectTrusted?: () => boolean | Promise<boolean>;
   private readonly runnerId: string;
@@ -146,6 +158,8 @@ export class WorkflowService {
     this.taskAdapter = options.taskAdapter;
     this.taskAdapterFactory = options.taskAdapterFactory;
     this.onBackgroundRunTerminal = options.onBackgroundRunTerminal;
+    this.notifyInterruptedBackgroundRunTerminal =
+      options.notifyInterruptedBackgroundRunTerminal === true;
     this.generateRunId = options.generateRunId ?? generateWorkflowRunId;
     this.getCurrentProjectTrusted = options.getCurrentProjectTrusted;
     this.runnerId = options.runnerId;
@@ -450,7 +464,9 @@ export class WorkflowService {
   async startNamedWorkflowInBackground(
     input: StartNamedWorkflowInput
   ): Promise<StartNamedWorkflowResult> {
-    const runId = await this.createNamedWorkflowRun(input);
+    const createdRun = await this.createNamedWorkflowRun(input);
+    const runId = createdRun.id;
+    await input.onRunCreated?.({ runId, status: "pending", result: null, run: createdRun });
     const run = await this.runStore.appendStatus(
       runId,
       "running",
@@ -464,7 +480,9 @@ export class WorkflowService {
   }
 
   async startNamedWorkflow(input: StartNamedWorkflowInput): Promise<StartNamedWorkflowResult> {
-    const runId = await this.createNamedWorkflowRun(input);
+    const createdRun = await this.createNamedWorkflowRun(input);
+    const runId = createdRun.id;
+    await input.onRunCreated?.({ runId, status: "pending", result: null, run: createdRun });
     if (isAbortSignalAborted(input.abortSignal)) {
       await this.interruptRun({ workspaceId: input.workspaceId, runId });
       throw new Error(`Workflow run interrupted: ${runId}`);
@@ -651,7 +669,7 @@ export class WorkflowService {
     };
   }
 
-  private async createNamedWorkflowRun(input: StartNamedWorkflowInput): Promise<string> {
+  private async createNamedWorkflowRun(input: StartNamedWorkflowInput): Promise<WorkflowRunRecord> {
     assert(
       input.workspaceId.length > 0,
       "WorkflowService.createNamedWorkflowRun: workspaceId is required"
@@ -665,7 +683,7 @@ export class WorkflowService {
       "WorkflowService.createNamedWorkflowRun: generated run id is required"
     );
 
-    await this.runStore.createRun({
+    return await this.runStore.createRun({
       id: runId,
       workspaceId: input.workspaceId,
       definition: definition.descriptor,
@@ -674,7 +692,6 @@ export class WorkflowService {
       ...(this.defaultActionCwd != null ? { defaultActionCwd: this.defaultActionCwd } : {}),
       now: this.clock?.nowIso() ?? new Date().toISOString(),
     });
-    return runId;
   }
 
   private async runInBackground(
@@ -759,7 +776,10 @@ export class WorkflowService {
       return;
     }
 
-    if (!WORKFLOW_BACKGROUND_CONTINUATION_STATUSES.has(run.status)) {
+    if (
+      !WORKFLOW_BACKGROUND_CONTINUATION_STATUSES.has(run.status) &&
+      !(this.notifyInterruptedBackgroundRunTerminal && run.status === "interrupted")
+    ) {
       return;
     }
 

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -8,6 +8,7 @@ import { isWorkspaceArchived } from "@/common/utils/archive";
 import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
 import type { CompactionCompletionMetadata } from "@/common/types/compaction";
 import type { Config } from "@/node/config";
+import type { Workspace } from "@/common/types/project";
 import type { Result } from "@/common/types/result";
 import { Ok, Err } from "@/common/types/result";
 import { normalizeTaskSettings } from "@/common/types/tasks";
@@ -107,6 +108,7 @@ import type {
   ProjectRef,
   WorkspaceActivitySnapshot,
   WorkspaceMetadata,
+  WorkspaceWorkflowSchedule,
 } from "@/common/types/workspace";
 import { isDynamicToolPart } from "@/common/types/toolParts";
 import { buildAskUserQuestionSummary } from "@/common/utils/tools/askUserQuestionSummary";
@@ -161,6 +163,12 @@ import {
   HEARTBEAT_RESET_BOUNDARY_MESSAGE,
   type HeartbeatContextMode,
 } from "@/constants/heartbeat";
+import {
+  WORKFLOW_SCHEDULE_CONTEXT_PREPARATION_TIMEOUT_MS,
+  WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE,
+  type WorkflowScheduleContextMode,
+} from "@/constants/workflowSchedule";
+import { getWorkflowScheduleNewWorkspaceTargetUnavailableReason } from "@/common/utils/workflowScheduleTarget";
 import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 import {
   GOAL_BUDGET_LIMIT_KIND,
@@ -800,6 +808,20 @@ interface WorkspaceHistoryLoadMoreResult {
 
 function isCompactedSummaryMessage(message: MuxMessage): boolean {
   return isDurableCompactedMarker(message.metadata?.compacted);
+}
+
+function getLatestCompactionBoundaryEpoch(messages: MuxMessage[]): number {
+  let latestEpoch = 0;
+  for (const message of messages) {
+    if (
+      isDurableCompactedMarker(message.metadata?.compacted) &&
+      message.metadata?.compactionBoundary === true &&
+      isPositiveInteger(message.metadata.compactionEpoch)
+    ) {
+      latestEpoch = Math.max(latestEpoch, message.metadata.compactionEpoch);
+    }
+  }
+  return latestEpoch;
 }
 
 function getNextCompactionEpochForAppendBoundary(
@@ -3885,6 +3907,67 @@ export class WorkspaceService extends EventEmitter {
     }
   }
 
+  private normalizeWorkflowScheduleForPersist(
+    schedule: Omit<WorkspaceWorkflowSchedule, "lastRunStartedAt">,
+    source: { sourceProjectPath: string; sourceWorkspace: Workspace }
+  ): Omit<WorkspaceWorkflowSchedule, "lastRunStartedAt"> {
+    const workflowName = schedule.workflowName.trim();
+    assert(workflowName.length > 0, "Workflow schedule requires a non-empty workflowName");
+
+    const contextMode = schedule.contextMode ?? WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE;
+    assert(
+      contextMode === "normal" || contextMode === "compact" || contextMode === "reset",
+      `Unsupported workflow schedule context mode: ${String(contextMode)}`
+    );
+
+    const target = schedule.target;
+    let normalizedTarget: WorkspaceWorkflowSchedule["target"] | undefined;
+    if (target?.type === "new-workspace") {
+      const unsupportedReason = getWorkflowScheduleNewWorkspaceTargetUnavailableReason({
+        sourceProjectPath: source.sourceProjectPath,
+        projects: source.sourceWorkspace.projects,
+        runtimeConfig: source.sourceWorkspace.runtimeConfig,
+      });
+      assert(
+        unsupportedReason == null,
+        unsupportedReason ?? "Unsupported workflow schedule target"
+      );
+      const trunkBranch = target.trunkBranch.trim();
+      assert(
+        trunkBranch.length > 0,
+        "New-workspace workflow schedules require a non-empty trunkBranch"
+      );
+      const branchName = target.branchName?.trim();
+      if (branchName) {
+        const branchNameValidation = validateWorkspaceName(branchName);
+        assert(
+          branchNameValidation.valid,
+          branchNameValidation.error ?? "Invalid scheduled workflow target branch name"
+        );
+      }
+      const title = target.title?.trim();
+      normalizedTarget = {
+        type: "new-workspace",
+        trunkBranch,
+        ...(branchName ? { branchName } : {}),
+        ...(title ? { title } : {}),
+      };
+    } else if (target?.type === "current-workspace") {
+      normalizedTarget = undefined;
+    } else {
+      assert(target == null, "Unsupported workflow schedule target");
+    }
+
+    return {
+      enabled: schedule.enabled,
+      workflowName,
+      ...(schedule.args != null ? { args: schedule.args } : {}),
+      intervalMs: schedule.intervalMs,
+      ...(contextMode !== WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE ? { contextMode } : {}),
+      ...(normalizedTarget != null ? { target: normalizedTarget } : {}),
+    };
+  }
+
   /**
    * Set (or clear, with null) the workspace's scheduled workflow run.
    * Input shape/bounds are enforced at the oRPC schema boundary
@@ -3894,12 +3977,7 @@ export class WorkspaceService extends EventEmitter {
    */
   async setWorkflowSchedule(
     workspaceId: string,
-    schedule: {
-      enabled: boolean;
-      workflowName: string;
-      args?: Record<string, unknown>;
-      intervalMs: number;
-    } | null
+    schedule: Omit<WorkspaceWorkflowSchedule, "lastRunStartedAt"> | null
   ): Promise<Result<void, string>> {
     try {
       const normalizedWorkspaceId = workspaceId.trim();
@@ -3910,7 +3988,7 @@ export class WorkspaceService extends EventEmitter {
 
       let applied = false;
       await this.config.editConfig((config) => {
-        for (const projectConfig of config.projects.values()) {
+        for (const [sourceProjectPath, projectConfig] of config.projects) {
           const workspaceEntry = projectConfig.workspaces.find(
             (entry) => entry.id === normalizedWorkspaceId
           );
@@ -3920,12 +3998,10 @@ export class WorkspaceService extends EventEmitter {
           if (schedule == null) {
             delete workspaceEntry.workflowSchedule;
           } else {
-            workspaceEntry.workflowSchedule = {
-              enabled: schedule.enabled,
-              workflowName: schedule.workflowName,
-              ...(schedule.args != null ? { args: schedule.args } : {}),
-              intervalMs: schedule.intervalMs,
-            };
+            workspaceEntry.workflowSchedule = this.normalizeWorkflowScheduleForPersist(schedule, {
+              sourceProjectPath,
+              sourceWorkspace: workspaceEntry,
+            });
           }
           applied = true;
           break;
@@ -3941,6 +4017,10 @@ export class WorkspaceService extends EventEmitter {
     } catch (error) {
       return Err(`Failed to set workflow schedule: ${getErrorMessage(error)}`);
     }
+  }
+
+  async emitCurrentWorkflowScheduleMetadata(workspaceId: string): Promise<void> {
+    await this.emitCurrentWorkspaceMetadata(workspaceId);
   }
 
   /**
@@ -6228,6 +6308,7 @@ export class WorkspaceService extends EventEmitter {
     runId: string;
     status: string;
     result: unknown;
+    synthetic?: boolean;
     run?: WorkflowRunRecord;
   }): Promise<boolean> {
     assert(input.workspaceId.length > 0, "appendWorkflowRunInvocation requires workspaceId");
@@ -6244,6 +6325,7 @@ export class WorkspaceService extends EventEmitter {
       input.rawCommand,
       {
         timestamp: now,
+        ...(input.synthetic === true ? { synthetic: true, uiVisible: true } : {}),
         muxMetadata: {
           type: WORKFLOW_TRIGGER_DISPLAY_METADATA_TYPE,
           rawCommand: input.rawCommand,
@@ -7354,6 +7436,56 @@ export class WorkspaceService extends EventEmitter {
       return Ok("reset");
     } finally {
       this.resettingContextWorkspaces.delete(workspaceId);
+    }
+  }
+
+  async prepareScheduledWorkflowContext(
+    workspaceId: string,
+    contextMode: WorkflowScheduleContextMode
+  ): Promise<Result<"normal" | "reset" | "noop" | "compact", string>> {
+    switch (contextMode) {
+      case "normal":
+        return Ok("normal");
+      case "reset":
+        return this.resetContext(workspaceId);
+      case "compact": {
+        const historyResult = await this.historyService.getHistoryFromLatestBoundary(workspaceId);
+        if (!historyResult.success) {
+          return Err(`Failed to read active context before compaction: ${historyResult.error}`);
+        }
+
+        const activeContextMessages = sliceMessagesForProviderFromLatestContextBoundary(
+          historyResult.data
+        );
+        if (!hasProviderEligibleMessages(activeContextMessages)) {
+          return Ok("noop");
+        }
+
+        const previousCompactionEpoch = getLatestCompactionBoundaryEpoch(historyResult.data);
+
+        try {
+          await this.executeIdleCompaction(workspaceId);
+          await this.waitForWorkspaceIdle(workspaceId, {
+            signal: AbortSignal.timeout(WORKFLOW_SCHEDULE_CONTEXT_PREPARATION_TIMEOUT_MS),
+          });
+          const compactedHistoryResult =
+            await this.historyService.getHistoryFromLatestBoundary(workspaceId);
+          if (!compactedHistoryResult.success) {
+            return Err(`Failed to verify compaction boundary: ${compactedHistoryResult.error}`);
+          }
+          const nextCompactionEpoch = getLatestCompactionBoundaryEpoch(compactedHistoryResult.data);
+          if (nextCompactionEpoch <= previousCompactionEpoch) {
+            return Err("Compaction finished without writing a new context boundary");
+          }
+          return Ok("compact");
+        } catch (error) {
+          return Err(getErrorMessage(error));
+        }
+      }
+      default: {
+        const exhaustiveContextMode: never = contextMode;
+        return Err(`Unsupported workflow schedule context mode: ${String(exhaustiveContextMode)}`);
+      }
     }
   }
 

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -3998,6 +3998,24 @@ export class WorkspaceService extends EventEmitter {
           if (schedule == null) {
             delete workspaceEntry.workflowSchedule;
           } else {
+            const conflictingProjectSchedule = Array.from(config.projects.entries()).find(
+              ([candidateProjectPath, candidateProject]) => {
+                const candidateOwnerPath =
+                  candidateProject.parentProjectPath ?? candidateProjectPath;
+                if (candidateOwnerPath !== sourceProjectPath) {
+                  return false;
+                }
+                return (candidateProject.workflowSchedules ?? []).some(
+                  (projectSchedule) =>
+                    projectSchedule.target.type === "existing-workspace" &&
+                    projectSchedule.target.workspaceId === normalizedWorkspaceId
+                );
+              }
+            );
+            assert(
+              conflictingProjectSchedule == null,
+              "Workspace already has a project automation"
+            );
             workspaceEntry.workflowSchedule = this.normalizeWorkflowScheduleForPersist(schedule, {
               sourceProjectPath,
               sourceWorkspace: workspaceEntry,

--- a/src/node/services/workspaceService.workflowSchedule.test.ts
+++ b/src/node/services/workspaceService.workflowSchedule.test.ts
@@ -7,6 +7,7 @@ import type { BackgroundProcessManager } from "./backgroundProcessManager";
 import type { ExtensionMetadataService } from "./ExtensionMetadataService";
 import type { HistoryService } from "./historyService";
 import type { InitStateManager } from "./initStateManager";
+import { createMuxMessage } from "@/common/types/message";
 import { WorkspaceService } from "./workspaceService";
 
 // setWorkflowSchedule persistence semantics (modeled on workspaceService.tags.test.ts):
@@ -19,6 +20,7 @@ const TEST_PROJECT_PATH = "/test/project";
 
 describe("WorkspaceService.setWorkflowSchedule", () => {
   let currentProjectsConfig: ProjectsConfig;
+  let historyServiceMock: { getHistoryFromLatestBoundary: ReturnType<typeof mock> };
   let service: WorkspaceService;
 
   beforeEach(() => {
@@ -34,9 +36,12 @@ describe("WorkspaceService.setWorkflowSchedule", () => {
       }),
     } as unknown as Config;
 
+    historyServiceMock = {
+      getHistoryFromLatestBoundary: mock(() => Promise.resolve({ success: true, data: [] })),
+    };
     service = new WorkspaceService(
       mockConfig,
-      {} as HistoryService,
+      historyServiceMock as unknown as HistoryService,
       new EventEmitter() as unknown as AIService,
       new EventEmitter() as unknown as InitStateManager,
       {} as ExtensionMetadataService,
@@ -76,6 +81,103 @@ describe("WorkspaceService.setWorkflowSchedule", () => {
     expect(storedSchedule()).toBeUndefined();
   });
 
+  test("persists new-workspace target and context mode while trimming optional fields", async () => {
+    const result = await service.setWorkflowSchedule(TEST_WORKSPACE_ID, {
+      enabled: true,
+      workflowName: " reconcile ",
+      intervalMs: 60_000,
+      contextMode: "compact",
+      target: {
+        type: "new-workspace",
+        branchName: " scheduled-triage ",
+        trunkBranch: " main ",
+        title: " Scheduled triage ",
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(storedSchedule()).toEqual({
+      enabled: true,
+      workflowName: "reconcile",
+      intervalMs: 60_000,
+      contextMode: "compact",
+      target: {
+        type: "new-workspace",
+        branchName: "scheduled-triage",
+        trunkBranch: "main",
+        title: "Scheduled triage",
+      },
+    });
+  });
+
+  test("rejects invalid new-workspace branch names at save time", async () => {
+    const result = await service.setWorkflowSchedule(TEST_WORKSPACE_ID, {
+      enabled: true,
+      workflowName: "reconcile",
+      intervalMs: 60_000,
+      target: {
+        type: "new-workspace",
+        branchName: "Invalid Branch",
+        trunkBranch: "main",
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error("expected invalid branch name to be rejected");
+    expect(result.error).toContain(
+      "Workspace names can only contain lowercase letters, numbers, hyphens, and underscores"
+    );
+    expect(storedSchedule()).toBeUndefined();
+  });
+
+  test("rejects unsupported fresh target source workspaces", async () => {
+    const workspace = currentProjectsConfig.projects.get(TEST_PROJECT_PATH)?.workspaces.at(0);
+    if (workspace == null) throw new Error("workspace missing");
+
+    workspace.projects = [
+      { projectPath: "/test/project-a", projectName: "project-a" },
+      { projectPath: "/test/project-b", projectName: "project-b" },
+    ];
+    const multiProject = await service.setWorkflowSchedule(TEST_WORKSPACE_ID, {
+      enabled: true,
+      workflowName: "reconcile",
+      intervalMs: 60_000,
+      target: { type: "new-workspace", trunkBranch: "main" },
+    });
+    expect(multiProject.success).toBe(false);
+    if (multiProject.success) throw new Error("expected multi-project schedule to be rejected");
+    expect(multiProject.error).toContain("multi-project workspaces");
+
+    delete workspace.projects;
+    workspace.runtimeConfig = { type: "local" };
+    const localProjectDir = await service.setWorkflowSchedule(TEST_WORKSPACE_ID, {
+      enabled: true,
+      workflowName: "reconcile",
+      intervalMs: 60_000,
+      target: { type: "new-workspace", trunkBranch: "main" },
+    });
+    expect(localProjectDir.success).toBe(false);
+    if (localProjectDir.success) throw new Error("expected local schedule to be rejected");
+    expect(localProjectDir.error).toContain("project-dir local workspaces");
+
+    workspace.runtimeConfig = {
+      type: "ssh",
+      host: "coder://",
+      srcBaseDir: "/home/coder/.mux/src",
+      coder: { workspaceName: "existing-vm", existingWorkspace: true },
+    };
+    const existingCoder = await service.setWorkflowSchedule(TEST_WORKSPACE_ID, {
+      enabled: true,
+      workflowName: "reconcile",
+      intervalMs: 60_000,
+      target: { type: "new-workspace", trunkBranch: "main" },
+    });
+    expect(existingCoder.success).toBe(false);
+    if (existingCoder.success) throw new Error("expected existing Coder schedule to be rejected");
+    expect(existingCoder.error).toContain("existing Coder workspaces");
+    expect(storedSchedule()).toBeUndefined();
+  });
+
   test("re-setting drops scheduler-owned lastRunStartedAt so the schedule is due", async () => {
     await service.setWorkflowSchedule(TEST_WORKSPACE_ID, {
       enabled: true,
@@ -93,6 +195,62 @@ describe("WorkspaceService.setWorkflowSchedule", () => {
     });
     expect(storedSchedule()?.lastRunStartedAt).toBeUndefined();
     expect(storedSchedule()?.intervalMs).toBe(120_000);
+  });
+
+  test("compact context preparation waits for a new durable boundary", async () => {
+    const beforeMessages = [createMuxMessage("u1", "user", "before compaction")];
+    const afterMessages = [
+      createMuxMessage("summary", "assistant", "compacted summary", {
+        compacted: "user",
+        compactionBoundary: true,
+        compactionEpoch: 1,
+      }),
+    ];
+    historyServiceMock.getHistoryFromLatestBoundary
+      .mockResolvedValueOnce({ success: true, data: beforeMessages })
+      .mockResolvedValueOnce({ success: true, data: afterMessages });
+    const serviceInternals = service as unknown as {
+      executeIdleCompaction: (workspaceId: string) => Promise<void>;
+      waitForWorkspaceIdle: (
+        workspaceId: string,
+        options: { signal?: AbortSignal }
+      ) => Promise<void>;
+    };
+    const executeIdleCompaction = mock((_workspaceId: string) => Promise.resolve());
+    const waitForWorkspaceIdle = mock((_workspaceId: string, _options: { signal?: AbortSignal }) =>
+      Promise.resolve()
+    );
+    serviceInternals.executeIdleCompaction = executeIdleCompaction;
+    serviceInternals.waitForWorkspaceIdle = waitForWorkspaceIdle;
+
+    const result = await service.prepareScheduledWorkflowContext(TEST_WORKSPACE_ID, "compact");
+
+    expect(result).toEqual({ success: true, data: "compact" });
+    expect(executeIdleCompaction).toHaveBeenCalledWith(TEST_WORKSPACE_ID);
+    expect(waitForWorkspaceIdle.mock.calls[0]?.[0]).toBe(TEST_WORKSPACE_ID);
+    expect(waitForWorkspaceIdle.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test("compact context preparation fails when compaction writes no new boundary", async () => {
+    const activeMessages = [createMuxMessage("u1", "user", "before compaction")];
+    historyServiceMock.getHistoryFromLatestBoundary
+      .mockResolvedValueOnce({ success: true, data: activeMessages })
+      .mockResolvedValueOnce({ success: true, data: activeMessages });
+    const serviceInternals = service as unknown as {
+      executeIdleCompaction: (workspaceId: string) => Promise<void>;
+      waitForWorkspaceIdle: (
+        workspaceId: string,
+        options: { signal?: AbortSignal }
+      ) => Promise<void>;
+    };
+    serviceInternals.executeIdleCompaction = mock(() => Promise.resolve());
+    serviceInternals.waitForWorkspaceIdle = mock(() => Promise.resolve());
+
+    const result = await service.prepareScheduledWorkflowContext(TEST_WORKSPACE_ID, "compact");
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error("expected compact preparation to fail");
+    expect(result.error).toContain("without writing a new context boundary");
   });
 
   test("fails for unknown workspaces without persisting", async () => {

--- a/src/node/services/workspaceService.workflowSchedule.test.ts
+++ b/src/node/services/workspaceService.workflowSchedule.test.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { EventEmitter } from "events";
 import type { ProjectConfig, ProjectsConfig, Workspace } from "@/common/types/project";
@@ -195,6 +196,33 @@ describe("WorkspaceService.setWorkflowSchedule", () => {
     });
     expect(storedSchedule()?.lastRunStartedAt).toBeUndefined();
     expect(storedSchedule()?.intervalMs).toBe(120_000);
+  });
+
+  test("rejects legacy schedules when a project automation already targets the workspace", async () => {
+    currentProjectsConfig.projects.set(path.join(TEST_PROJECT_PATH, "packages", "api"), {
+      parentProjectPath: TEST_PROJECT_PATH,
+      workspaces: [],
+      workflowSchedules: [
+        {
+          id: "sub-project-automation",
+          enabled: true,
+          workflowName: "reconcile",
+          intervalMs: 60_000,
+          target: { type: "existing-workspace", workspaceId: TEST_WORKSPACE_ID },
+        },
+      ],
+    });
+
+    const result = await service.setWorkflowSchedule(TEST_WORKSPACE_ID, {
+      enabled: true,
+      workflowName: "legacy-reconcile",
+      intervalMs: 60_000,
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error("expected project automation conflict to be rejected");
+    expect(result.error).toContain("already has a project automation");
+    expect(storedSchedule()).toBeUndefined();
   });
 
   test("compact context preparation waits for a new durable boundary", async () => {

--- a/src/node/utils/projectTrust.ts
+++ b/src/node/utils/projectTrust.ts
@@ -10,7 +10,9 @@ export function isProjectTrusted(config: Config, projectPath?: string | null): b
     return false;
   }
 
-  return (
-    config.loadConfigOrDefault().projects.get(stripTrailingSlashes(projectPath))?.trusted ?? false
-  );
+  const projects = config.loadConfigOrDefault().projects;
+  const normalizedProjectPath = stripTrailingSlashes(projectPath);
+  const project = projects.get(normalizedProjectPath);
+  const trustOwnerPath = project?.parentProjectPath ?? normalizedProjectPath;
+  return projects.get(trustOwnerPath)?.trusted ?? false;
 }


### PR DESCRIPTION
## Summary

Centralizes scheduled workflow automations at the project level so automations survive workspace archive/delete lifecycles, while still supporting existing-workspace targets and fresh-workspace-per-run targets.

## Background

Workspace-local scheduled workflows were tied to a specific workspace record. This made recurring automations fragile: removing the workspace could remove the automation too. Project-level schedules make recurring workflows a first-class project setting.

## Implementation

- Adds project workflow schedule schemas and oRPC endpoints for set/run/remove flows.
- Extends the scheduler to dispatch project-owned automations, including dynamic workspace creation and terminal cleanup for fresh-workspace targets.
- Adds UI for per-workspace automation setup and project-wide automation management.
- Validates executable workflow availability, target conflicts, and unsupported fresh-workspace templates before enabling/running schedules.
- Skips archived existing-workspace project targets before stamping `lastRunStartedAt`, so unarchiving keeps overdue automations due immediately.
- Releases manual Run now locks when backgrounded project automation runs are interrupted, without sending a workflow-result continuation for the interruption.
- Removes unshipped legacy workspace-to-project automation migration plumbing.
- Simplifies shared schedule helpers for interval validation, args parsing, due checks, and fresh-workspace template detection.
- Ensures project automation workflow discovery scans the requested host project root, and refreshes untouched fresh-workspace base-branch drafts after async branch discovery.

## Validation

- `make typecheck`
- `bun test src/browser/components/AutomationModal/AutomationModal.test.tsx src/browser/components/ProjectAutomationsModal/ProjectAutomationsModal.test.tsx src/common/utils/workflowScheduleTarget.test.ts`
- `bun test src/node/services/workflows/WorkflowSchedulerService.test.ts src/node/orpc/router.test.ts src/node/services/serviceContainer.test.ts`
- `bun test src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.test.tsx src/browser/components/AutomationModal/AutomationModal.test.tsx src/browser/components/ProjectAutomationsModal/ProjectAutomationsModal.test.tsx`
- `bun test src/node/orpc/router.test.ts src/node/services/workflows/WorkflowSchedulerService.test.ts`
- `bun test src/node/services/workflows/WorkflowSchedulerService.test.ts src/node/services/workflows/WorkflowService.test.ts`
- `bun test src/node/services/serviceContainer.test.ts`
- `make storybook-run CMD="make test-storybook"`
- `make test`
- `make static-check`
- `MUX_ESLINT_CONCURRENCY=1 make static-check`
- Storybook dogfood covered desktop and narrow/mobile automation modal layouts during implementation.

## Risks

Moderate regression risk in workflow scheduling and workspace creation paths. The change touches scheduler dispatch semantics, workflow run status propagation, and project config persistence. Risk is mitigated by targeted scheduler/router/service tests, full unit tests, Storybook interaction tests, and static checks.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$649.23`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=649.23 -->
