### PR TITLE
🤖 tests: stabilize settings experiment stories

### DIFF
--- a/src/browser/features/Settings/Sections/ExperimentsSection.stories.tsx
+++ b/src/browser/features/Settings/Sections/ExperimentsSection.stories.tsx
@@ -20,9 +20,8 @@ export const Experiments: Story = {
     <SettingsSectionStory
       setup={() =>
         setupSettingsStory({
-          // Explicit off-override: experiment localStorage keys leak between
-          // stories in the same browser session, so seed the parent off to keep
-          // the "sub-experiments hidden" assertion order-independent.
+          // Seed the parent off explicitly so the "sub-experiments hidden"
+          // assertion does not rely on the experiment's default value.
           experiments: { [EXPERIMENT_IDS.MEMORY]: false },
         })
       }

--- a/src/browser/features/Settings/Sections/settingsStoryUtils.test.tsx
+++ b/src/browser/features/Settings/Sections/settingsStoryUtils.test.tsx
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { installDom } from "../../../../../tests/ui/dom";
+import { EXPERIMENT_IDS, getExperimentKey } from "@/common/constants/experiments";
+import { resetStorybookPersistedStateForStory, setupSettingsStory } from "./settingsStoryUtils";
+
+describe("SettingsSectionStory", () => {
+  let restoreDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    restoreDom = installDom();
+  });
+
+  afterEach(() => {
+    restoreDom?.();
+    restoreDom = null;
+  });
+
+  test("clears unseeded experiment overrides before story setup", () => {
+    const key = getExperimentKey(EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING);
+    window.localStorage.setItem(key, JSON.stringify(true));
+
+    resetStorybookPersistedStateForStory();
+
+    expect(window.localStorage.getItem(key)).toBeNull();
+
+    setupSettingsStory({
+      experiments: { [EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING]: true },
+    });
+    expect(window.localStorage.getItem(key)).toBe(JSON.stringify(true));
+  });
+});

--- a/src/browser/features/Settings/Sections/settingsStoryUtils.tsx
+++ b/src/browser/features/Settings/Sections/settingsStoryUtils.tsx
@@ -14,7 +14,11 @@ import { selectWorkspace } from "@/browser/stories/helpers/uiState";
 import { createWorkspace, groupWorkspacesByProject } from "@/browser/stories/mocks/workspaces";
 import { createMockORPCClient } from "@/browser/stories/mocks/orpc";
 import { getProvidersConfigStore } from "@/browser/stores/ProvidersConfigStore";
-import { getExperimentKey, type ExperimentId } from "@/common/constants/experiments";
+import {
+  getExperimentKey,
+  getExperimentList,
+  type ExperimentId,
+} from "@/common/constants/experiments";
 import { SELECTED_WORKSPACE_KEY, UI_THEME_KEY } from "@/common/constants/storage";
 import type { ServerAuthSession } from "@/common/orpc/types";
 import type { AgentAiDefaults } from "@/common/types/agentAiDefaults";
@@ -29,10 +33,17 @@ interface SettingsSectionStoryProps {
   children: ReactNode;
 }
 
-function resetStorybookPersistedStateForStory(): void {
+export function resetStorybookPersistedStateForStory(): void {
   if (typeof localStorage !== "undefined") {
     localStorage.removeItem(SELECTED_WORKSPACE_KEY);
     localStorage.setItem(UI_THEME_KEY, JSON.stringify("dark"));
+
+    // Chromatic reuses one browser origin across stories, so experiment
+    // localStorage overrides from one story must not decide another story's
+    // switch positions. Each story can opt back in through setupSettingsStory().
+    for (const experiment of getExperimentList()) {
+      localStorage.removeItem(getExperimentKey(experiment.id));
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Stabilizes the Settings → Experiments Storybook snapshots by clearing experiment localStorage overrides before each settings section story setup, while still allowing individual stories to seed the experiments they need.

## Background

The PTC toggle in the Heartbeat Settings Enabled Chromatic snapshot could inherit `experiment:programmatic-tool-calling` from the `ExperimentsToggleOn` story because Storybook/Chromatic reuse the same browser origin across story renders.

## Implementation

- Clear every registered experiment localStorage key in the shared settings story reset helper.
- Keep story-specific experiment seeding in `setupSettingsStory()` so stories can opt back into required toggle states.
- Add regression coverage proving a pre-existing PTC localStorage override is cleared before story setup and that explicit story seeding still restores the requested value.

## Validation

- `bun test src/browser/features/Settings/Sections/settingsStoryUtils.test.tsx`
- `bun test src/browser/features/Settings/Sections/*.test.tsx`
- `MUX_ESLINT_CONCURRENCY=1 make static-check`
- `bun x test-storybook --url http://localhost:6006 --testTimeout 30000 --maxWorkers=2`
- Dogfooded in Storybook by visiting the PTC-on story, then the heartbeat story, and confirming PTC was reset off while Workspace Heartbeats remained on.

## Risks

Low. This only affects the shared Storybook wrapper for settings section stories. Production experiment persistence remains unchanged, and stories can still seed explicit experiment values through `setupSettingsStory()`.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$8.46`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=8.46 -->
